### PR TITLE
List enumerated types for MedicalEnumeration

### DIFF
--- a/data/schema.rdfa
+++ b/data/schema.rdfa
@@ -869,6 +869,7 @@
       <span class="h" property="rdfs:label">MedicalEnumeration</span>
       <span property="rdfs:comment">Enumerations related to health and the practice of medicine.</span>
        <span>Subclass of: <a property="rdfs:subClassOf" href="http://schema.org/MedicalIntangible">MedicalIntangible</a></span>
+       <span>Subclass of: <a property="rdfs:subClassOf" href="http://schema.org/Enumeration">Enumeration</a></span>
     </div>
 
     <div typeof="rdfs:Class" resource="http://schema.org/DrugCostCategory">


### PR DESCRIPTION
As MedicalEnumeration is not currently a subclass of Enumeration, the
enumerated types are not listed. Make MedicalEnumeration a subclass of
Enumeration.

Fixes #12

Signed-off-by: Dan Scott dan@coffeecode.net
