### PR TITLE
List enumerated types for MedicalEnumeration

### DIFF
--- a/api.py
+++ b/api.py
@@ -63,6 +63,9 @@ class Unit ():
     def isEnumeration(self):
         return self.subClassOf(Unit.GetUnit("Enumeration"))
 
+    def isMedicalEnumeration(self):
+        return self.subClassOf(Unit.GetUnit("MedicalEnumeration"))
+
     def superceded(self):
         for triple in self.arcsOut:
             if (triple.target != None and triple.arc.id == "supercededBy"):
@@ -369,7 +372,7 @@ class ShowUnit (webapp2.RequestHandler) :
                 for c in children:
                     self.write("<li> %s" % (self.ml(c)))
                         
-        if (node.isEnumeration()):
+        if (node.isEnumeration() or node.isMedicalEnumeration()):
             children = sorted(GetSources(Unit.GetUnit("typeOf"), node), key=lambda u: u.id)
             if (len(children) > 0):
                 self.write("<br/><br/>Enumeration members");


### PR DESCRIPTION
As MedicalEnumeration is not a subclass of Enumeration, the enumerated types
are not listed. In addition to checking for Enumeration, we can check to see
if a given type is a subclass of MedicalEnumeration with an additional method
and an additional or operator.

Fixes #12

Signed-off-by: Dan Scott dan@coffeecode.net
