### PR TITLE
CODE: Add RDFS for type and attribute pages

### DIFF
--- a/headers.py
+++ b/headers.py
@@ -13,7 +13,7 @@ headers = '''<!DOCTYPE html>
 <html xmlns="http://www.w3.org/1999/xhtml" xml:lang="en" lang="en">
 <head>
     <meta http-equiv="Content-Type" content="text/html; charset=UTF-8" />
-    <title>schema.org</title>
+    <title>%s - schema.org</title>
     <meta name="description" content="Schema.org is a set of extensible schemas that enables webmasters to embed
     structured data on their web pages for use by search engines and other applications." />
     <link rel="stylesheet" type="text/css"
@@ -113,11 +113,19 @@ headers = '''<!DOCTYPE html>
 
 
 
-  <div id="mainContent">
+  <div id="mainContent" vocab="http://schema.org/" typeof="%s" resource="http://schema.org/%s">
 
 '''
 
-def OutputSchemaorgHeaders(webapp, entry='') :
-    out = headers
-    out = out.replace("<title>", "<title>" + str(entry) + " - ")
+def OutputSchemaorgHeaders(webapp, entry='', is_class=False):
+    """
+    Generates the headers for class and property pages
+
+    * entry = name of the class or property
+    """
+
+    rdfs_type = 'rdfs:Property'
+    if is_class:
+        rdfs_type = 'rdfs:Class'
+    out = headers % (str(entry), rdfs_type, str(entry))
     webapp.response.write(out)


### PR DESCRIPTION
Includes properties such as:
- rdfs:comment
- rdfs:label
- rdfs:subClassOf

With this patch, individual type and attribute pages will now express basic
RDFS; classes will express their immediate subclass relationship and all
of the properties that can be applied to them, while attributes express
their domainIncludes values.

Addresses #24

Signed-off-by: Dan Scott dan@coffeecode.net
