### PR TITLE
Declare Boolean as a subclass of Enumeration

### DIFF
--- a/data/schema.rdfa
+++ b/data/schema.rdfa
@@ -460,6 +460,7 @@
       <span class="h" property="rdfs:label">Boolean</span>
       <span property="rdfs:comment">Boolean: True or False.</span>
        <span>Subclass of: <a property="rdfs:subClassOf" href="http://schema.org/DataType">DataType</a></span>
+       <span>Subclass of: <a property="rdfs:subClassOf" href="http://schema.org/Enumeration">Enumeration</a></span>
     </div>
 
     <div typeof="http://schema.org/Boolean" resource="http://schema.org/False">


### PR DESCRIPTION
This will help ensure that Boolean and its subtypes get treated as an
enumeration; currently as neither rdfs:Class nor rdfs:Property they do not
receive a breadcrumb header and Boolean does not list its enumeration members.

Fixes #26

Signed-off-by: Dan Scott dan@coffeecode.net
