### PR TITLE
CODE: Move actionStatus property after ActionStatusType definition

### DIFF
--- a/data/schema.rdfa
+++ b/data/schema.rdfa
@@ -9716,13 +9716,6 @@ on public-vocabs@w3.org.</p>
  <h1>Potential Actions</h1>
 
 
-    <div typeof="rdf:Property" resource="http://schema.org/actionStatus">
-      <span class="h" property="rdfs:label">actionStatus</span>
-      <span property="rdfs:comment">Indicates the current disposition of the Action.</span>
-      <span>Domain: <a property="http://schema.org/domainIncludes" href="http://schema.org/Action">Action</a></span>
-      <span>Range: <a property="http://schema.org/rangeIncludes" href="http://schema.org/ActionStatusType">ActionStatusType</a></span>
-    </div>
-
     <div typeof="rdfs:Class" resource="http://schema.org/ActionStatusType">
       <span class="h" property="rdfs:label">ActionStatusType</span>
       <span property="rdfs:comment">The status of an Action.</span>
@@ -9742,6 +9735,13 @@ on public-vocabs@w3.org.</p>
     <div typeof="http://schema.org/ActionStatusType" resource="http://schema.org/CompletedActionStatus">
       <span class="h" property="rdfs:label">CompletedActionStatus</span>
       <span property="rdfs:comment">An action that has already taken place.</span>
+    </div>
+
+    <div typeof="rdf:Property" resource="http://schema.org/actionStatus">
+      <span class="h" property="rdfs:label">actionStatus</span>
+      <span property="rdfs:comment">Indicates the current disposition of the Action.</span>
+      <span>Domain: <a property="http://schema.org/domainIncludes" href="http://schema.org/Action">Action</a></span>
+      <span>Range: <a property="http://schema.org/rangeIncludes" href="http://schema.org/ActionStatusType">ActionStatusType</a></span>
     </div>
 
     <div typeof="rdf:Property" resource="http://schema.org/potentialAction">


### PR DESCRIPTION
Due to a quirk in the current processing approach, the ActionStatusType
definition will not be rendered correctly as an enumeration because
the actionStatus property that refers to it is defined earlier in schema.rdfa.
We can work on a more robust processing approach, but in the short term
the easiest fix is to simply move the definition to later in schema.rdfa.

Signed-off-by: Dan Scott dan@coffeecode.net
