### PR TITLE
Clarify that RDFa and JSON-LD are supported formats

### DIFF
--- a/docs/gs.html
+++ b/docs/gs.html
@@ -59,9 +59,8 @@
 
 <p>Schema.org provides a collection of shared vocabularies webmasters can use to mark up their pages in ways that can be understood by the major search engines: Google, Microsoft, Yandex and Yahoo!</p>
 
-<p>You use the <a href="../">schema.org</a> vocabulary, along with the <a href="http://dev.w3.org/html5/md-LC/" target="new">microdata format</a>, to add information to your HTML content. While the long term goal is to support a wider range of formats,
-	      the initial focus is on  Microdata.
-This guide will help get you up to speed with microdata and schema.org, so that you can start adding markup to your web pages.</p>
+<p>You use the <a href="../">schema.org</a> vocabulary along with the <a href="http://dev.w3.org/html5/md-LC/" target="new">microdata</a>, <a href="http://rdfa.info" target="new">RDFa</a>, or <a href="http://json-ld.org" target="new">JSON-LD</a> formats to add information to your HTML content.
+This guide will help get you up to speed with microdata and schema.org so that you can start adding markup to your web pages.</p>
 
 
 <span id="top"></span>


### PR DESCRIPTION
The getting started documentation referred to a long-term plan to
support a broader variety of formats, but RDFa and JSON-LD are
pretty tightly integrated into the rest of the schema.org documentation,
so we might as well mention them explicitly in the getting started (but
continue documenting with microdata as the default approach).

Signed-off-by: Dan Scott dan@coffeecode.net
