### PR TITLE
CODE: Improve DataType handling

### DIFF
--- a/api.py
+++ b/api.py
@@ -294,7 +294,7 @@ class ShowUnit (webapp2.RequestHandler) :
         while (ind > 0) :
             ind = ind -1
             nn = self.parentStack[ind]
-            if (nn.id == "Thing" or thing_seen):
+            if (nn.id == "Thing" or thing_seen or nn.isDataType()):
                 thing_seen = True
                 self.write(self.ml(nn) )
                 if (ind > 0):
@@ -306,7 +306,7 @@ class ShowUnit (webapp2.RequestHandler) :
         self.write("</h1>")
         comment = GetComment(node)
         self.write(" <div property=\"rdfs:comment\">%s</div>\n\n" % (comment) + "\n")
-        if (node.isClass()):
+        if (node.isClass() and not node.isDataType()):
             self.write("<table class=\"definition-table\">\n        <thead>\n  <tr><th>Property</th><th>Expected Type</th><th>Description</th>               \n  </tr>\n  </thead>\n\n")
 
     def ClassProperties (self, cl, subclass=False):

--- a/data/schema.rdfa
+++ b/data/schema.rdfa
@@ -459,17 +459,19 @@
     <div typeof="rdfs:Class" resource="http://schema.org/Boolean">
       <span class="h" property="rdfs:label">Boolean</span>
       <span property="rdfs:comment">Boolean: True or False.</span>
-       <span>Subclass of: <a property="rdfs:subClassOf" href="http://schema.org/DataType">DataType</a></span>
+      <span>Subclass of: <a property="rdfs:subClassOf" href="http://schema.org/DataType">DataType</a></span>
     </div>
 
     <div typeof="http://schema.org/Boolean" resource="http://schema.org/False">
       <span class="h" property="rdfs:label">False</span>
       <span property="rdfs:comment">The boolean value false</span>
+      <span>Subclass of: <a property="rdfs:subClassOf" href="http://schema.org/Boolean">Boolean</a></span>
     </div>
 
     <div typeof="http://schema.org/Boolean" resource="http://schema.org/True">
       <span class="h" property="rdfs:label">True</span>
       <span property="rdfs:comment">The boolean value true</span>
+      <span>Subclass of: <a property="rdfs:subClassOf" href="http://schema.org/Boolean">Boolean</a></span>
     </div>
 
     <div typeof="rdfs:Class" resource="http://schema.org/SportsActivityLocation">


### PR DESCRIPTION
DataTypes such as Integer currently do not get a header generated for them, nor
do they get their subtypes enumerated, and they also get a useless property
header generated.

Add an isDataType() method and use it throughout the page generation
accordingly.

Fixes #26

Signed-off-by: Dan Scott dan@coffeecode.net
