### PR TITLE
VOCAB: Change domain of associatedMedia to Thing

### DIFF
--- a/data/schema.rdfa
+++ b/data/schema.rdfa
@@ -4699,8 +4699,8 @@
     </div>
     <div typeof="rdf:Property" resource="http://schema.org/associatedMedia">
       <span class="h" property="rdfs:label">associatedMedia</span>
-      <span property="rdfs:comment">The media objects that encode this creative work. This property is a synonym for encodings.</span>
-      <span>Domain: <a property="http://schema.org/domainIncludes" href="http://schema.org/CreativeWork">CreativeWork</a></span>
+      <span property="rdfs:comment">A media object that encodes or complements the item.</span>
+      <span>Domain: <a property="http://schema.org/domainIncludes" href="http://schema.org/Thing">Thing</a></span>
       <span>Range: <a property="http://schema.org/rangeIncludes" href="http://schema.org/MediaObject">MediaObject</a></span>
     </div>
     <div typeof="rdf:Property" resource="http://schema.org/associatedPathophysiology">


### PR DESCRIPTION
Per https://www.w3.org/wiki/WebSchemas/associatedMediaToThing and discussion at
http://lists.w3.org/Archives/Public/public-vocabs/2014May/0204.html and
http://lists.w3.org/Archives/Public/public-vocabs/2014May/0224.html, change the
domain of associatedMedia to Thing to enable other children of Thing that do
not descend from CreativeWork to have a straightforward means of including
media objects that complement their content.

Signed-off-by: Dan Scott dan@coffeecode.net
