### PR TITLE
Literal type doesn't exist in schema.org, it should be Text.

### DIFF
--- a/data/schema.rdfa
+++ b/data/schema.rdfa
@@ -9831,7 +9831,7 @@ on public-vocabs@w3.org.</p>
       <span property="rdfs:comment">The default value of the input.  For properties that expect a literal, the default is a literal value, for properties that expect an object, it's an ID reference to one of the current values.</span>
       <span>Domain: <a property="http://schema.org/domainIncludes" href="http://schema.org/PropertyValueSpecification">PropertyValueSpecification</a></span>
       <span>Range: <a property="http://schema.org/rangeIncludes" href="http://schema.org/Thing">Thing</a></span>
-      <span>Range: <a property="http://schema.org/rangeIncludes" href="http://schema.org/Literal">Literal</a></span>
+      <span>Range: <a property="http://schema.org/rangeIncludes" href="http://schema.org/Text">Text</a></span>
     </div>
 
     <div typeof="rdf:Property" resource="http://schema.org/readonlyValue">


### PR DESCRIPTION
Reported by Simon Spero at http://lists.w3.org/Archives/Public/public-vocabs/2014May/0193.html
