### PR TITLE
Fix typo: s/died/diet/

### DIFF
--- a/data/schema.rdfa
+++ b/data/schema.rdfa
@@ -5531,7 +5531,7 @@
     </div>
     <div typeof="rdf:Property" resource="http://schema.org/diet">
       <span class="h" property="rdfs:label">diet</span>
-      <span property="rdfs:comment">A sub property of instrument. The died used in this action.</span>
+      <span property="rdfs:comment">A sub property of instrument. The diet used in this action.</span>
       <link property="rdfs:subPropertyOf" href="http://schema.org/instrument" />
       <span>Domain: <a property="http://schema.org/domainIncludes" href="http://schema.org/ExerciseAction">ExerciseAction</a></span>
       <span>Range: <a property="http://schema.org/rangeIncludes" href="http://schema.org/Diet">Diet</a></span>


### PR DESCRIPTION
Depending on the diet, however, the former might be correct in extreme cases.

Signed-off-by: Dan Scott dan@coffeecode.net
