### PR TITLE
VOCAB: Consistency of encoding / associatedMedia description

### DIFF
--- a/data/schema.rdfa
+++ b/data/schema.rdfa
@@ -4701,7 +4701,7 @@
     </div>
     <div typeof="rdf:Property" resource="http://schema.org/associatedMedia">
       <span class="h" property="rdfs:label">associatedMedia</span>
-      <span property="rdfs:comment">The media objects that encode this creative work. This property is a synonym for encodings.</span>
+      <span property="rdfs:comment">A media object that encodes this CreativeWork. This property is a synonym for encoding.</span>
       <span>Domain: <a property="http://schema.org/domainIncludes" href="http://schema.org/CreativeWork">CreativeWork</a></span>
       <span>Range: <a property="http://schema.org/rangeIncludes" href="http://schema.org/MediaObject">MediaObject</a></span>
     </div>
@@ -5849,13 +5849,13 @@
     </div>
     <div typeof="rdf:Property" resource="http://schema.org/encodesCreativeWork">
       <span class="h" property="rdfs:label">encodesCreativeWork</span>
-      <span property="rdfs:comment">The creative work encoded by this media object</span>
+      <span property="rdfs:comment">The CreativeWork encoded by this media object.</span>
       <span>Domain: <a property="http://schema.org/domainIncludes" href="http://schema.org/MediaObject">MediaObject</a></span>
       <span>Range: <a property="http://schema.org/rangeIncludes" href="http://schema.org/CreativeWork">CreativeWork</a></span>
     </div>
     <div typeof="rdf:Property" resource="http://schema.org/encoding">
       <span class="h" property="rdfs:label">encoding</span>
-      <span property="rdfs:comment">A media object that encode this CreativeWork.</span>
+      <span property="rdfs:comment">A media object that encodes this CreativeWork. This property is a synonym for associatedMedia.</span>
       <span>Domain: <a property="http://schema.org/domainIncludes" href="http://schema.org/CreativeWork">CreativeWork</a></span>
       <span>Range: <a property="http://schema.org/rangeIncludes" href="http://schema.org/MediaObject">MediaObject</a></span>
     </div>
@@ -5868,7 +5868,7 @@
     <div typeof="rdf:Property" resource="http://schema.org/encodings">
       <span class="h" property="rdfs:label">encodings</span>
       <span property="http://schema.org/supercededBy" href="http://schema.org/encoding"/>
-      <span property="rdfs:comment">The media objects that encode this creative work (legacy spelling; see singular form, encoding).</span>
+      <span property="rdfs:comment">A media object that encodes this CreativeWork (legacy spelling; see singular form, encoding).</span>
       <span>Domain: <a property="http://schema.org/domainIncludes" href="http://schema.org/CreativeWork">CreativeWork</a></span>
       <span>Range: <a property="http://schema.org/rangeIncludes" href="http://schema.org/MediaObject">MediaObject</a></span>
     </div>


### PR DESCRIPTION
Use the same definition for encoding and associatedMedia,
as they are synonyms for one another. Also make the definition
agree grammatically with singular vs plural.

Also refer to "CreativeWork" in the description rather than
"creative work", as the former seems to be the predominant form used
for properties on CreativeWork.

Signed-off-by: Dan Scott dan@coffeecode.net
