### PR TITLE
CODE: Change from href to resource where CURIEs are used

### DIFF
--- a/data/schema.rdfa
+++ b/data/schema.rdfa
@@ -539,7 +539,7 @@
       <span class="h" property="rdfs:label">Event</span>
       <span property="rdfs:comment">An event happening at a certain time and location, such as a concert, lecture, or festival. Ticketing information may be added via the &#39;offers&#39; property. Repeated events may be structured as separate Event objects.</span>
        <span>Subclass of: <a property="rdfs:subClassOf" href="http://schema.org/Thing">Thing</a></span>
-       <link property="owl:equivalentClass" href="dc:Event"/>
+       <link property="owl:equivalentClass" resource="dc:Event"/>
     </div>
 
     <div typeof="rdfs:Class" resource="http://schema.org/BusinessEvent">
@@ -1270,7 +1270,7 @@
       <span class="h" property="rdfs:label">ImageObject</span>
       <span property="rdfs:comment">An image file.</span>
        <span>Subclass of: <a property="rdfs:subClassOf" href="http://schema.org/MediaObject">MediaObject</a></span>
-       <link property="owl:equivalentClass" href="dc:Image"/>
+       <link property="owl:equivalentClass" resource="dc:Image"/>
     </div>
 
     <div typeof="rdfs:Class" resource="http://schema.org/ImagingTest">
@@ -2454,7 +2454,7 @@
       <span class="h" property="rdfs:label">Person</span>
       <span property="rdfs:comment">A person (alive, dead, undead, or fictional).</span>
        <span>Subclass of: <a property="rdfs:subClassOf" href="http://schema.org/Thing">Thing</a></span>
-       <link property="owl:equivalentClass" href="foaf:Person" />
+       <link property="owl:equivalentClass" resource="foaf:Person" />
        <span>Source:  <a property="dc:source" href="http://www.w3.org/wiki/WebSchemas/SchemaDotOrgSources#source_rNews">rNews</a></span></div>
 
     <div typeof="rdfs:Class" resource="http://schema.org/PetStore">
@@ -3456,7 +3456,7 @@
       <span property="rdfs:comment">A collection of datasets.</span>
        <span>Subclass of: <a property="rdfs:subClassOf" href="http://schema.org/CreativeWork">CreativeWork</a></span>
        <span>Source:  <a property="dc:source" href="http://www.w3.org/wiki/WebSchemas/SchemaDotOrgSources#source_DatasetClass">DatasetClass</a></span>
-       <link property="owl:equivalentClass" href="dcat:DataCatalog"/>
+       <link property="owl:equivalentClass" resource="dcat:DataCatalog"/>
     </div>
 
     <div typeof="rdfs:Class" resource="http://schema.org/DataDownload">
@@ -3464,7 +3464,7 @@
       <span property="rdfs:comment">A dataset in downloadable form.</span>
        <span>Subclass of: <a property="rdfs:subClassOf" href="http://schema.org/MediaObject">MediaObject</a></span>
        <span>Source:  <a property="dc:source" href="http://www.w3.org/wiki/WebSchemas/SchemaDotOrgSources#source_DatasetClass">DatasetClass</a></span>
-       <link property="owl:equivalentClass" href="dcat:Distribution"/>
+       <link property="owl:equivalentClass" resource="dcat:Distribution"/>
     </div>
 
     <div typeof="rdfs:Class" resource="http://schema.org/Dataset">
@@ -3472,9 +3472,9 @@
       <span property="rdfs:comment">A body of structured information describing some topic(s) of interest.</span>
        <span>Subclass of: <a property="rdfs:subClassOf" href="http://schema.org/CreativeWork">CreativeWork</a></span>
        <span>Source:  <a property="dc:source" href="http://www.w3.org/wiki/WebSchemas/SchemaDotOrgSources#source_DatasetClass">DatasetClass</a></span>
-       <link property="owl:equivalentClass" href="dcat:Dataset"/>
-       <link property="owl:equivalentClass" href="void:Dataset"/>
-       <link property="owl:equivalentClass" href="dc:Dataset"/>
+       <link property="owl:equivalentClass" resource="dcat:Dataset"/>
+       <link property="owl:equivalentClass" resource="void:Dataset"/>
+       <link property="owl:equivalentClass" resource="dc:Dataset"/>
        </div>
 
     <div typeof="rdfs:Class" resource="http://schema.org/Class">


### PR DESCRIPTION
Plain `href` attributes only work with regular URIs. To get prefix expansion within CURIEs, `resource` (and other RDFa specific attributes) are required.
