### PR TITLE
Fixed alumni/alumniOf mistake in http://schema.org/Role 

### DIFF
--- a/data/examples.txt
+++ b/data/examples.txt
@@ -11808,9 +11808,9 @@ MICRODATA:
 <div itemscope itemtype="http://schema.org/Person">
   <span itemprop="name">Delia Derbyshire</span>
   <link itemprop="sameAs" href="http://en.wikipedia.org/wiki/Delia_Derbyshire"/>
-  <div itemprop="alumni" itemscope
+  <div itemprop="alumniOf" itemscope
         itemtype="http://schema.org/OrganizationRole">
-    <div itemprop="alumni" itemscope
+    <div itemprop="alumniOf" itemscope
             itemtype="http://schema.org/CollegeOrUniversity">
       <span itemprop="name">University of Cambridge</span>
       <link itemprop="sameAs" href="http://en.wikipedia.org/wiki/University_of_Cambridge"/>
@@ -11823,8 +11823,8 @@ RDFA:
 <div vocab="http://schema.org/" typeof="Person">
   <span property="name">Delia Derbyshire</span>
   <link property="sameAs" href="http://en.wikipedia.org/wiki/Delia_Derbyshire"/>
-  <div property="alumni" typeof="OrganizationRole">
-    <div property="alumni" typeof="CollegeOrUniversity">
+  <div property="alumniOf" typeof="OrganizationRole">
+    <div property="alumniOf" typeof="CollegeOrUniversity">
       <span property="name">University of Cambridge</span>
       <link property="sameAs" href="http://en.wikipedia.org/wiki/University_of_Cambridge"/>
     </div>


### PR DESCRIPTION
example, reported by Mark Harrison.
http://lists.w3.org/Archives/Public/public-vocabs/2014Jun/0229.html
