### PR TITLE
Fix JSON-LD example where context is broken.

### DIFF
--- a/data/examples.txt
+++ b/data/examples.txt
@@ -9020,7 +9020,7 @@ JSON:
 
 <script type='application/ld+json'>
 {
-  "@context": "schema.org",
+  "@context": "http://schema.org",
   "@type": "GovernmentService",
   "name": "Veterans Affairs Emergency Mental Health",
   "serviceType": "Psychiatric Emergency Services",


### PR DESCRIPTION
I've parsed all examples, and this is the only real error I've found. FYI, all examples are extracted [here](https://github.com/structured-data/linter/tree/master/schema.org) for future reference.
