### PR TITLE
Refined flightNumber and Flight descriptions.

### DIFF
--- a/data/schema.rdfa
+++ b/data/schema.rdfa
@@ -9270,7 +9270,7 @@ Note that Event uses startDate/endDate instead of startTime/endTime, even when d
     </div>
     <div typeof="rdfs:Class" resource="http://schema.org/Flight">
       <span class="h" property="rdfs:label">Flight</span>
-      <span property="rdfs:comment">An airline flight. Use 'provider' to represent carrier.</span>
+      <span property="rdfs:comment">An airline flight.</span>
       <span>Subclass of: <a property="rdfs:subClassOf" href="http://schema.org/Intangible">Intangible</a></span>
     </div>
     <div typeof="rdfs:Class" resource="http://schema.org/Airline">
@@ -9486,7 +9486,7 @@ Note that Event uses startDate/endDate instead of startTime/endTime, even when d
     </div>
     <div typeof="rdf:Property" resource="http://schema.org/flightNumber">
       <span class="h" property="rdfs:label">flightNumber</span>
-      <span property="rdfs:comment">The unique identifier for a flight, not including the airline IATA code. For example, if describing United flight 110, the flightNumber is '110'. The IATA code can be set on the Airline.</span>
+      <span property="rdfs:comment">The unique identifier for a flight including the airline IATA code. For example, if describing United flight 110, where the IATA code for United is 'UA', the flightNumber is 'UA110'.</span>
       <span>domain: <a property="http://schema.org/domainIncludes" href="http://schema.org/Flight">Flight</a></span>
       <span>Range: <a property="http://schema.org/rangeIncludes" href="http://schema.org/Text">Text</a></span>
     </div>


### PR DESCRIPTION
1.
Backed out suggested addition of "Use 'provider' to represent carrier" to Flight description.

2.
2.
Updated the description of 'flightNumber' to
"The unique identifier for a flight including the airline IATA code.
For example, if describing United flight 110, where the IATA code for United is 'UA',
the flightNumber is 'UA110'."

old: The unique identifier for a flight, not including the airline IATA code. For example, if describing United flight 110, the flightNumber is '110'. The IATA code can be set on the Airline.
new: The unique identifier for a flight including the airline IATA code. For example, if describing United flight 110, where the IATA code for United is 'UA', the flightNumber is 'UA110'.

This is a change in recommended use, see
https://www.w3.org/wiki/WebSchemas/SellerVendorCleanup
https://github.com/rvguha/schemaorg/pull/89
https://github.com/rvguha/schemaorg/pull/91 for background.
