### PR TITLE
Fix for Issue: supercedes spelling: supersedes is more mainstream #101

### DIFF
--- a/api.py
+++ b/api.py
@@ -112,36 +112,36 @@ class Unit ():
         # Currently defined just to let the tests pass
         pass
 
-    def superceded(self):
-        """Has this property been superceded? (i.e. deprecated/archaic)"""
+    def superseded(self):
+        """Has this property been superseded? (i.e. deprecated/archaic)"""
         for triple in self.arcsOut:
-            if (triple.target != None and triple.arc.id == "supercededBy"):
+            if (triple.target != None and triple.arc.id == "supersededBy"):
                 return True
         return False
 
-    def supercedes(self):
-        """Returns a property (assume max 1) that is supercededBy this one, or nothing."""
+    def supersedes(self):
+        """Returns a property (assume max 1) that is supersededBy this one, or nothing."""
         for triple in self.arcsIn:
-            if (triple.source != None and triple.arc.id == "supercededBy"):
+            if (triple.source != None and triple.arc.id == "supersededBy"):
                 return triple.source
         return None
-        # TODO: supercedes is a list, e.g. 'seller' supercedes 'vendor', 'merchant'
+        # TODO: supersedes is a list, e.g. 'seller' supersedes 'vendor', 'merchant'
 
-    def supercedes_all(self):
-        """Returns a property (assume max 1) that is supercededBy this one, or nothing."""
+    def supersedes_all(self):
+        """Returns a property (assume max 1) that is supersededBy this one, or nothing."""
         newer = []
         for triple in self.arcsIn:
-            if (triple.source != None and triple.arc.id == "supercededBy"):
+            if (triple.source != None and triple.arc.id == "supersededBy"):
                 newer.append(triple.source)
         return newer
 
-    def supercededBy(self):
-        """Returns a property (assume max 1) that supercededs this one, or nothing."""
+    def supersededBy(self):
+        """Returns a property (assume max 1) that supersededs this one, or nothing."""
         for p in sorted(GetSources(Unit.GetUnit("typeOf"), Unit.GetUnit("rdf:Property")), key=lambda u: u.id):
-            allnewers = GetTargets(Unit.GetUnit("supercededBy"), p)
+            allnewers = GetTargets(Unit.GetUnit("supersededBy"), p)
             for newerprop in allnewers:
-                if self in newerprop.supercedes_all():
-                    return newerprop # this is one of possibly many properties that supercedes self.
+                if self in newerprop.supersedes_all():
+                    return newerprop # this is one of possibly many properties that supersedes self.
         return None
 
     def superproperties(self):
@@ -521,10 +521,10 @@ class ShowUnit (webapp2.RequestHandler):
         di = Unit.GetUnit("domainIncludes")
         ri = Unit.GetUnit("rangeIncludes")
         for prop in sorted(GetSources(di, cl), key=lambda u: u.id):
-            if (prop.superceded()):
+            if (prop.superseded()):
                 continue
-            supercedes = prop.supercedes()
-            olderprops = prop.supercedes_all()
+            supersedes = prop.supersedes()
+            olderprops = prop.supersedes_all()
             inverseprop = prop.inverseproperty()
             subprops = prop.subproperties()
             superprops = prop.superproperties()
@@ -550,7 +550,7 @@ class ShowUnit (webapp2.RequestHandler):
             self.write("<td class=\"prop-desc\" property=\"rdfs:comment\">%s" % (comment))
             if (len(olderprops) > 0):
                 olderlinks = ", ".join([self.ml(o) for o in olderprops])
-                self.write(" Supercedes %s." % olderlinks )
+                self.write(" Supersedes %s." % olderlinks )
             if (inverseprop != None):
                 self.write("<br/> Inverse property: %s." % (self.ml(inverseprop)))
 
@@ -566,9 +566,9 @@ class ShowUnit (webapp2.RequestHandler):
         di = Unit.GetUnit("domainIncludes")
         ri = Unit.GetUnit("rangeIncludes")
         for prop in sorted(GetSources(ri, cl), key=lambda u: u.id):
-            if (prop.superceded()):
+            if (prop.superseded()):
                 continue
-            supercedes = prop.supercedes()
+            supersedes = prop.supersedes()
             inverseprop = prop.inverseproperty()
             subprops = prop.subproperties()
             superprops = prop.superproperties()
@@ -592,8 +592,8 @@ class ShowUnit (webapp2.RequestHandler):
                 self.write("&nbsp;")
             self.write("</td>")
             self.write("<td class=\"prop-desc\">%s " % (comment))
-            if (supercedes != None):
-                self.write(" Supercedes %s." % (self.ml(supercedes)))
+            if (supersedes != None):
+                self.write(" Supersedes %s." % (self.ml(supersedes)))
             if (inverseprop != None):
                 self.write("<br/> inverse property: %s." % (self.ml(inverseprop)) )
 
@@ -610,9 +610,9 @@ class ShowUnit (webapp2.RequestHandler):
         domains = sorted(GetTargets(di, node), key=lambda u: u.id)
         first_range = True
 
-        newerprop = node.supercededBy() # None of one. e.g. we're on 'seller'(new) page, we get 'vendor'(old)
-        olderprop = node.supercedes() # None or one
-        olderprops = node.supercedes_all() # list, e.g. 'seller' has 'vendor', 'merchant'.
+        newerprop = node.supersededBy() # None of one. e.g. we're on 'seller'(new) page, we get 'vendor'(old)
+        olderprop = node.supersedes() # None or one
+        olderprops = node.supersedes_all() # list, e.g. 'seller' has 'vendor', 'merchant'.
 
         inverseprop = node.inverseproperty()
         subprops = node.subproperties()
@@ -664,10 +664,10 @@ class ShowUnit (webapp2.RequestHandler):
                 self.write("\n    <tr><td><code>%s</code></td></tr>\n" % (self.ml(spp, spp.id, tt)))
             self.write("\n</table>\n\n")
 
-        # Supercedes
+        # Supersedes
         if (len(olderprops) > 0):
             self.write("<table class=\"definition-table\">\n")
-            self.write("  <thead>\n    <tr>\n      <th>Supercedes</th>\n    </tr>\n</thead>\n")
+            self.write("  <thead>\n    <tr>\n      <th>Supersedes</th>\n    </tr>\n</thead>\n")
 
             for o in olderprops:
                 c = GetComment(o)
@@ -675,10 +675,10 @@ class ShowUnit (webapp2.RequestHandler):
                 self.write("\n    <tr><td><code>%s</code></td></tr>\n" % (self.ml(o, o.id, tt)))
             self.write("\n</table>\n\n")
 
-        # supercededBy (at most one direct successor)
+        # supersededBy (at most one direct successor)
         if (newerprop != None):
             self.write("<table class=\"definition-table\">\n")
-            self.write("  <thead>\n    <tr>\n      <th><a href=\"/supercededBy\">supercededBy</a></th>\n    </tr>\n</thead>\n")
+            self.write("  <thead>\n    <tr>\n      <th><a href=\"/supersededBy\">supersededBy</a></th>\n    </tr>\n</thead>\n")
             self.write("\n    <tr><td><code>%s</code></td></tr>\n" % (self.ml(newerprop, newerprop.id, tt)))
             self.write("\n</table>\n\n")
 

--- a/data/schema.rdfa
+++ b/data/schema.rdfa
@@ -4426,7 +4426,7 @@
     <div typeof="rdf:Property" resource="http://schema.org/action">
       <span class="h" property="rdfs:label">action</span>
       <span property="rdfs:comment">The movement the muscle generates.</span>
-      <span property="http://schema.org/supercededBy" href="http://schema.org/muscleAction"/>
+      <span property="http://schema.org/supersededBy" href="http://schema.org/muscleAction"/>
       <span>Domain: <a property="http://schema.org/domainIncludes" href="http://schema.org/Muscle">Muscle</a></span>
       <span>Range: <a property="http://schema.org/rangeIncludes" href="http://schema.org/Text">Text</a></span>
     </div>
@@ -4472,7 +4472,7 @@
     </div>
     <div typeof="rdf:Property" resource="http://schema.org/actors">
       <span class="h" property="rdfs:label">actors</span>
-      <span property="http://schema.org/supercededBy" href="http://schema.org/actor"/>
+      <span property="http://schema.org/supersededBy" href="http://schema.org/actor"/>
       <span property="rdfs:comment">A cast member of the movie, tv/radio series, season, episode, or video. (legacy spelling; see singular form, actor)</span>
       <span>Domain: <a property="http://schema.org/domainIncludes" href="http://schema.org/Movie">Movie</a></span>
       <span>Domain: <a property="http://schema.org/domainIncludes" href="http://schema.org/Episode">Episode</a></span>
@@ -4590,7 +4590,7 @@
     </div>
     <div typeof="rdf:Property" resource="http://schema.org/albums">
       <span class="h" property="rdfs:label">albums</span>
-      <span property="http://schema.org/supercededBy" href="http://schema.org/album"/>
+      <span property="http://schema.org/supersededBy" href="http://schema.org/album"/>
       <span property="rdfs:comment">A collection of music albums (legacy spelling; see singular form, album).</span>
       <span>Domain: <a property="http://schema.org/domainIncludes" href="http://schema.org/MusicGroup">MusicGroup</a></span>
       <span>Range: <a property="http://schema.org/rangeIncludes" href="http://schema.org/MusicAlbum">MusicAlbum</a></span>
@@ -4785,7 +4785,7 @@
     </div>
     <div typeof="rdf:Property" resource="http://schema.org/attendees">
       <span class="h" property="rdfs:label">attendees</span>
-      <span property="http://schema.org/supercededBy" href="http://schema.org/attendees"/>
+      <span property="http://schema.org/supersededBy" href="http://schema.org/attendees"/>
       <span property="rdfs:comment">A person attending the event (legacy spelling; see singular form, attendee).</span>
       <span>Domain: <a property="http://schema.org/domainIncludes" href="http://schema.org/Event">Event</a></span>
       <span>Range: <a property="http://schema.org/rangeIncludes" href="http://schema.org/Organization">Organization</a></span>
@@ -4918,7 +4918,7 @@
     </div>
     <div typeof="rdf:Property" resource="http://schema.org/awards">
       <span class="h" property="rdfs:label">awards</span
->      <span property="http://schema.org/supercededBy" href="http://schema.org/award"/>
+>      <span property="http://schema.org/supersededBy" href="http://schema.org/award"/>
       <span property="rdfs:comment">Awards won by this person or for this creative work. (legacy spelling; see singular form, award)</span>
       <span>Domain: <a property="http://schema.org/domainIncludes" href="http://schema.org/CreativeWork">CreativeWork</a></span>
       <span>Domain: <a property="http://schema.org/domainIncludes" href="http://schema.org/Person">Person</a></span>
@@ -4987,7 +4987,7 @@
     </div>
     <div typeof="rdf:Property" resource="http://schema.org/blogPosts">
       <span class="h" property="rdfs:label">blogPosts</span>
-      <span property="http://schema.org/supercededBy" href="http://schema.org/blogPost"/>
+      <span property="http://schema.org/supersededBy" href="http://schema.org/blogPost"/>
       <span property="rdfs:comment">The postings that are part of this blog (legacy spelling; see singular form, blogPost).</span>
       <span>Domain: <a property="http://schema.org/domainIncludes" href="http://schema.org/Blog">Blog</a></span>
       <span>Range: <a property="http://schema.org/rangeIncludes" href="http://schema.org/BlogPosting">BlogPosting</a></span>
@@ -5129,7 +5129,7 @@
       <span>Domain: <a property="http://schema.org/domainIncludes" href="http://schema.org/ParcelDelivery">ParcelDelivery</a></span>
       <span>domain: <a property="http://schema.org/domainIncludes" href="http://schema.org/Flight">Flight</a></span>
       <span>Range: <a property="http://schema.org/rangeIncludes" href="http://schema.org/Organization">Organization</a></span>
-      <span property="http://schema.org/supercededBy" href="http://schema.org/provider"/>
+      <span property="http://schema.org/supersededBy" href="http://schema.org/provider"/>
     </div>
     <div typeof="rdf:Property" resource="http://schema.org/carrierRequirements">
       <span class="h" property="rdfs:label">carrierRequirements</span>
@@ -5254,7 +5254,7 @@
     </div>
     <div typeof="rdf:Property" resource="http://schema.org/colleagues">
       <span class="h" property="rdfs:label">colleagues</span>
-      <span property="http://schema.org/supercededBy" href="http://schema.org/colleague"/>
+      <span property="http://schema.org/supersededBy" href="http://schema.org/colleague"/>
       <span property="rdfs:comment">A colleague of the person (legacy spelling; see singular form, colleague).</span>
       <span>Domain: <a property="http://schema.org/domainIncludes" href="http://schema.org/Person">Person</a></span>
       <span>Range: <a property="http://schema.org/rangeIncludes" href="http://schema.org/Person">Person</a></span>
@@ -5324,7 +5324,7 @@
     </div>
     <div typeof="rdf:Property" resource="http://schema.org/contactPoints">
       <span class="h" property="rdfs:label">contactPoints</span>
-      <span property="http://schema.org/supercededBy" href="http://schema.org/contactPoint"/>
+      <span property="http://schema.org/supersededBy" href="http://schema.org/contactPoint"/>
       <span property="rdfs:comment">A contact point for a person or organization (legacy spelling; see singular form, contactPoint).</span>
       <span>Domain: <a property="http://schema.org/domainIncludes" href="http://schema.org/Organization">Organization</a></span>
       <span>Domain: <a property="http://schema.org/domainIncludes" href="http://schema.org/Person">Person</a></span>
@@ -5629,7 +5629,7 @@
     </div>
     <div typeof="rdf:Property" resource="http://schema.org/directors">
       <span class="h" property="rdfs:label">directors</span>
-      <span property="http://schema.org/supercededBy" href="http://schema.org/director"/>
+      <span property="http://schema.org/supersededBy" href="http://schema.org/director"/>
       <span property="rdfs:comment">The director of the movie, tv/radio episode or series. (legacy spelling; see singular form, director)</span>
       <span>Domain: <a property="http://schema.org/domainIncludes" href="http://schema.org/Movie">Movie</a></span>
       <span>Domain: <a property="http://schema.org/domainIncludes" href="http://schema.org/Episode">Episode</a></span>
@@ -5702,9 +5702,9 @@
       <span>Domain: <a property="http://schema.org/domainIncludes" href="http://schema.org/Property">Property</a></span>
       <span>Range: <a property="http://schema.org/rangeIncludes" href="http://schema.org/Property">Property</a></span>
     </div>
-    <div typeof="rdf:Property" resource="http://schema.org/supercededBy">
-      <span class="h" property="rdfs:label">supercededBy</span>
-      <span property="rdfs:comment">Relates a property to one that supercedes it.</span>
+    <div typeof="rdf:Property" resource="http://schema.org/supersededBy">
+      <span class="h" property="rdfs:label">supersededBy</span>
+      <span property="rdfs:comment">Relates a property to one that supersedes it.</span>
       <span>Domain: <a property="http://schema.org/domainIncludes" href="http://schema.org/Property">Property</a></span>
       <span>Range: <a property="http://schema.org/rangeIncludes" href="http://schema.org/Property">Property</a></span>
     </div>
@@ -5902,7 +5902,7 @@
     </div>
     <div typeof="rdf:Property" resource="http://schema.org/employees">
       <span class="h" property="rdfs:label">employees</span>
-      <span property="http://schema.org/supercededBy" href="http://schema.org/employee"/>
+      <span property="http://schema.org/supersededBy" href="http://schema.org/employee"/>
       <span property="rdfs:comment">People working for this organization. (legacy spelling; see singular form, employee)</span>
       <span>Domain: <a property="http://schema.org/domainIncludes" href="http://schema.org/Organization">Organization</a></span>
       <span>Range: <a property="http://schema.org/rangeIncludes" href="http://schema.org/Person">Person</a></span>
@@ -5933,7 +5933,7 @@
     </div>
     <div typeof="rdf:Property" resource="http://schema.org/encodings">
       <span class="h" property="rdfs:label">encodings</span>
-      <span property="http://schema.org/supercededBy" href="http://schema.org/encoding"/>
+      <span property="http://schema.org/supersededBy" href="http://schema.org/encoding"/>
       <span property="rdfs:comment">A media object that encodes this CreativeWork (legacy spelling; see singular form, encoding).</span>
       <span>Domain: <a property="http://schema.org/domainIncludes" href="http://schema.org/CreativeWork">CreativeWork</a></span>
       <span>Range: <a property="http://schema.org/rangeIncludes" href="http://schema.org/MediaObject">MediaObject</a></span>
@@ -6014,7 +6014,7 @@ Note that Event uses startDate/endDate instead of startTime/endTime, even when d
     </div>
     <div typeof="rdf:Property" resource="http://schema.org/episodes">
       <span class="h" property="rdfs:label">episodes</span>
-      <span property="http://schema.org/supercededBy" href="http://schema.org/episode"/>
+      <span property="http://schema.org/supersededBy" href="http://schema.org/episode"/>
       <span property="rdfs:comment">An episode of a TV/radio series or season (legacy spelling; see singular form, episode)</span>
       <span>Domain: <a property="http://schema.org/domainIncludes" href="http://schema.org/Season">Season</a></span>
       <span>Domain: <a property="http://schema.org/domainIncludes" href="http://schema.org/TVSeason">TVSeason</a></span>
@@ -6050,7 +6050,7 @@ Note that Event uses startDate/endDate instead of startTime/endTime, even when d
     </div>
     <div typeof="rdf:Property" resource="http://schema.org/events">
       <span class="h" property="rdfs:label">events</span>
-      <span property="http://schema.org/supercededBy" href="http://schema.org/event"/>
+      <span property="http://schema.org/supersededBy" href="http://schema.org/event"/>
       <span property="rdfs:comment">Upcoming or past events associated with this place or organization (legacy spelling; see singular form, event).</span>
       <span>Domain: <a property="http://schema.org/domainIncludes" href="http://schema.org/Organization">Organization</a></span>
       <span>Domain: <a property="http://schema.org/domainIncludes" href="http://schema.org/Place">Place</a></span>
@@ -6225,7 +6225,7 @@ Note that Event uses startDate/endDate instead of startTime/endTime, even when d
     </div>
     <div typeof="rdf:Property" resource="http://schema.org/founders">
       <span class="h" property="rdfs:label">founders</span>
-      <span property="http://schema.org/supercededBy" href="http://schema.org/founder"/>
+      <span property="http://schema.org/supersededBy" href="http://schema.org/founder"/>
       <span property="rdfs:comment">A person who founded this organization (legacy spelling; see singular form, founder).</span>
       <span>Domain: <a property="http://schema.org/domainIncludes" href="http://schema.org/Organization">Organization</a></span>
       <span>Range: <a property="http://schema.org/rangeIncludes" href="http://schema.org/Person">Person</a></span>
@@ -6922,13 +6922,13 @@ Note that Event uses startDate/endDate instead of startTime/endTime, even when d
     <div typeof="rdf:Property" resource="http://schema.org/map">
       <span class="h" property="rdfs:label">map</span>
       <span property="rdfs:comment">A URL to a map of the place.</span>
-      <span property="http://schema.org/supercededBy" href="http://schema.org/hasMap"/>
+      <span property="http://schema.org/supersededBy" href="http://schema.org/hasMap"/>
       <span>Domain: <a property="http://schema.org/domainIncludes" href="http://schema.org/Place">Place</a></span>
       <span>Range: <a property="http://schema.org/rangeIncludes" href="http://schema.org/URL">URL</a></span>
     </div>
     <div typeof="rdf:Property" resource="http://schema.org/maps">
       <span class="h" property="rdfs:label">maps</span>
-      <span property="http://schema.org/supercededBy" href="http://schema.org/hasMap"/>
+      <span property="http://schema.org/supersededBy" href="http://schema.org/hasMap"/>
       <span property="rdfs:comment">A URL to a map of the place (legacy spelling; see singular form, map).</span>
       <span>Domain: <a property="http://schema.org/domainIncludes" href="http://schema.org/Place">Place</a></span>
       <span>Range: <a property="http://schema.org/rangeIncludes" href="http://schema.org/URL">URL</a></span>
@@ -6993,7 +6993,7 @@ Note that Event uses startDate/endDate instead of startTime/endTime, even when d
     </div>
     <div typeof="rdf:Property" resource="http://schema.org/members">
       <span class="h" property="rdfs:label">members</span>
-      <span property="http://schema.org/supercededBy" href="http://schema.org/member"/>
+      <span property="http://schema.org/supersededBy" href="http://schema.org/member"/>
       <span property="rdfs:comment">A member of this organization (legacy spelling; see singular form, member).</span>
       <span>Domain: <a property="http://schema.org/domainIncludes" href="http://schema.org/Organization">Organization</a></span>
       <span>domain: <a property="http://schema.org/domainIncludes" href="http://schema.org/ProgramMembership">ProgramMembership</a></span>
@@ -7026,7 +7026,7 @@ Note that Event uses startDate/endDate instead of startTime/endTime, even when d
       <span>Domain: <a property="http://schema.org/domainIncludes" href="http://schema.org/Order">Order</a></span>
       <span>Range: <a property="http://schema.org/rangeIncludes" href="http://schema.org/Organization">Organization</a></span>
       <span>Range: <a property="http://schema.org/rangeIncludes" href="http://schema.org/Person">Person</a></span>
-      <span property="http://schema.org/supercededBy" href="http://schema.org/seller"/>
+      <span property="http://schema.org/supersededBy" href="http://schema.org/seller"/>
     </div>
     <div typeof="rdf:Property" resource="http://schema.org/minPrice">
       <span class="h" property="rdfs:label">minPrice</span>
@@ -7072,7 +7072,7 @@ Note that Event uses startDate/endDate instead of startTime/endTime, even when d
     <div typeof="rdf:Property" resource="http://schema.org/musicGroupMember">
       <span class="h" property="rdfs:label">musicGroupMember</span>
       <span property="rdfs:comment">A member of a music group&amp;#x2014;for example, John, Paul, George, or Ringo.</span>
-      <span property="http://schema.org/supercededBy" href="http://schema.org/member"/>
+      <span property="http://schema.org/supersededBy" href="http://schema.org/member"/>
       <span>Domain: <a property="http://schema.org/domainIncludes" href="http://schema.org/MusicGroup">MusicGroup</a></span>
       <span>Range: <a property="http://schema.org/rangeIncludes" href="http://schema.org/Person">Person</a></span>
     </div>
@@ -7328,7 +7328,7 @@ Note that Event uses startDate/endDate instead of startTime/endTime, even when d
     </div>
     <div typeof="rdf:Property" resource="http://schema.org/parents">
       <span class="h" property="rdfs:label">parents</span>
-      <span property="http://schema.org/supercededBy" href="http://schema.org/parent"/>
+      <span property="http://schema.org/supersededBy" href="http://schema.org/parent"/>
       <span property="rdfs:comment">A parents of the person (legacy spelling; see singular form, parent).</span>
       <span>Domain: <a property="http://schema.org/domainIncludes" href="http://schema.org/Person">Person</a></span>
       <span>Range: <a property="http://schema.org/rangeIncludes" href="http://schema.org/Person">Person</a></span>
@@ -7391,7 +7391,7 @@ Note that Event uses startDate/endDate instead of startTime/endTime, even when d
     </div>
     <div typeof="rdf:Property" resource="http://schema.org/partOfTVSeries">
       <span class="h" property="rdfs:label">partOfTVSeries</span>
-      <span property="http://schema.org/supercededBy" href="http://schema.org/partOfSeries"/>
+      <span property="http://schema.org/supersededBy" href="http://schema.org/partOfSeries"/>
       <span property="rdfs:comment">The TV series to which this episode or season belongs. (legacy form; partOfSeries is preferred)</span>
       <span>Domain: <a property="http://schema.org/domainIncludes" href="http://schema.org/TVEpisode">TVEpisode</a></span>
       <span>Domain: <a property="http://schema.org/domainIncludes" href="http://schema.org/TVSeason">TVSeason</a></span>
@@ -7450,7 +7450,7 @@ Note that Event uses startDate/endDate instead of startTime/endTime, even when d
     </div>
     <div typeof="rdf:Property" resource="http://schema.org/performers">
       <span class="h" property="rdfs:label">performers</span>
-      <span property="http://schema.org/supercededBy" href="http://schema.org/performer"/>
+      <span property="http://schema.org/supersededBy" href="http://schema.org/performer"/>
       <span property="rdfs:comment">The main performer or performers of the event&amp;#x2014;for example, a presenter, musician, or actor (legacy spelling; see singular form, performer).</span>
       <span>Domain: <a property="http://schema.org/domainIncludes" href="http://schema.org/Event">Event</a></span>
       <span>Range: <a property="http://schema.org/rangeIncludes" href="http://schema.org/Organization">Organization</a></span>
@@ -7483,7 +7483,7 @@ Note that Event uses startDate/endDate instead of startTime/endTime, even when d
     </div>
     <div typeof="rdf:Property" resource="http://schema.org/photos">
       <span class="h" property="rdfs:label">photos</span>
-      <span property="http://schema.org/supercededBy" href="http://schema.org/photo"/>
+      <span property="http://schema.org/supersededBy" href="http://schema.org/photo"/>
       <span property="rdfs:comment">Photographs of this place (legacy spelling; see singular form, photo).</span>
       <span>Domain: <a property="http://schema.org/domainIncludes" href="http://schema.org/Place">Place</a></span>
       <span>Range: <a property="http://schema.org/rangeIncludes" href="http://schema.org/ImageObject">ImageObject</a></span>
@@ -8139,7 +8139,7 @@ Note that Event uses startDate/endDate instead of startTime/endTime, even when d
     </div>
     <div typeof="rdf:Property" resource="http://schema.org/reviews">
       <span class="h" property="rdfs:label">reviews</span>
-      <span property="http://schema.org/supercededBy" href="http://schema.org/review"/>
+      <span property="http://schema.org/supersededBy" href="http://schema.org/review"/>
       <span property="rdfs:comment">Review of the item (legacy spelling; see singular form, review).</span>
       <span>Domain: <a property="http://schema.org/domainIncludes" href="http://schema.org/CreativeWork">CreativeWork</a></span>
       <span>Domain: <a property="http://schema.org/domainIncludes" href="http://schema.org/Organization">Organization</a></span>
@@ -8235,7 +8235,7 @@ Note that Event uses startDate/endDate instead of startTime/endTime, even when d
     </div>
     <div typeof="rdf:Property" resource="http://schema.org/seasons">
       <span class="h" property="rdfs:label">seasons</span>
-      <span property="http://schema.org/supercededBy" href="http://schema.org/season"/>
+      <span property="http://schema.org/supersededBy" href="http://schema.org/season"/>
       <span property="rdfs:comment">A season in a tv/radio series. (legacy spelling; see singular form, season)</span>
       <span>Domain: <a property="http://schema.org/domainIncludes" href="http://schema.org/Series">Series</a></span>
       <span>Domain: <a property="http://schema.org/domainIncludes" href="http://schema.org/TVSeries">TVSeries</a></span>
@@ -8372,7 +8372,7 @@ Note that Event uses startDate/endDate instead of startTime/endTime, even when d
     </div>
     <div typeof="rdf:Property" resource="http://schema.org/siblings">
       <span class="h" property="rdfs:label">siblings</span>
-      <span property="http://schema.org/supercededBy" href="http://schema.org/sibling"/>
+      <span property="http://schema.org/supersededBy" href="http://schema.org/sibling"/>
       <span property="rdfs:comment">A sibling of the person (legacy spelling; see singular form, sibling).</span>
       <span>Domain: <a property="http://schema.org/domainIncludes" href="http://schema.org/Person">Person</a></span>
       <span>Range: <a property="http://schema.org/rangeIncludes" href="http://schema.org/Person">Person</a></span>
@@ -8397,7 +8397,7 @@ Note that Event uses startDate/endDate instead of startTime/endTime, even when d
     </div>
     <div typeof="rdf:Property" resource="http://schema.org/significantLinks">
       <span class="h" property="rdfs:label">significantLinks</span>
-      <span property="http://schema.org/supercededBy" href="http://schema.org/significantLink"/>
+      <span property="http://schema.org/supersededBy" href="http://schema.org/significantLink"/>
       <span property="rdfs:comment">The most significant URLs on the page. Typically, these are the non-navigation links that are clicked on the most (legacy spelling; see singular form, significantLink).</span>
       <span>Domain: <a property="http://schema.org/domainIncludes" href="http://schema.org/WebPage">WebPage</a></span>
       <span>Range: <a property="http://schema.org/rangeIncludes" href="http://schema.org/URL">URL</a></span>
@@ -8610,7 +8610,7 @@ Note that Event uses startDate/endDate instead of startTime/endTime, even when d
     </div>
     <div typeof="rdf:Property" resource="http://schema.org/subEvents">
       <span class="h" property="rdfs:label">subEvents</span>
-      <span property="http://schema.org/supercededBy" href="http://schema.org/subEvent"/>
+      <span property="http://schema.org/supersededBy" href="http://schema.org/subEvent"/>
       <span property="rdfs:comment">Events that are a part of this event. For example, a conference event includes many presentations, each subEvents of the conference (legacy spelling; see singular form, subEvent).</span>
       <span>Domain: <a property="http://schema.org/domainIncludes" href="http://schema.org/Event">Event</a></span>
       <span>Range: <a property="http://schema.org/rangeIncludes" href="http://schema.org/Event">Event</a></span>
@@ -8827,7 +8827,7 @@ Note that Event uses startDate/endDate instead of startTime/endTime, even when d
     </div>
     <div typeof="rdf:Property" resource="http://schema.org/tracks">
       <span class="h" property="rdfs:label">tracks</span>
-      <span property="http://schema.org/supercededBy" href="http://schema.org/track"/>
+      <span property="http://schema.org/supersededBy" href="http://schema.org/track"/>
       <span property="rdfs:comment">A music recording (track)&amp;#x2014;usually a single song (legacy spelling; see singular form, track).</span>
       <span>Domain: <a property="http://schema.org/domainIncludes" href="http://schema.org/MusicPlaylist">MusicPlaylist</a></span>
       <span>Domain: <a property="http://schema.org/domainIncludes" href="http://schema.org/MusicGroup">MusicGroup</a></span>
@@ -9008,7 +9008,7 @@ Note that Event uses startDate/endDate instead of startTime/endTime, even when d
       <span>Domain: <a property="http://schema.org/domainIncludes" href="http://schema.org/BuyAction">BuyAction</a></span>
       <span>Range: <a property="http://schema.org/rangeIncludes" href="http://schema.org/Organization">Organization</a></span>
       <span>Range: <a property="http://schema.org/rangeIncludes" href="http://schema.org/Person">Person</a></span>
-      <span property="http://schema.org/supercededBy" href="http://schema.org/seller"/>
+      <span property="http://schema.org/supersededBy" href="http://schema.org/seller"/>
     </div>
     <div typeof="rdf:Property" resource="http://schema.org/version">
       <span class="h" property="rdfs:label">version</span>
@@ -9355,7 +9355,7 @@ Note that Event uses startDate/endDate instead of startTime/endTime, even when d
       <span>domain: <a property="http://schema.org/domainIncludes" href="http://schema.org/Reservation">Reservation</a></span>
       <span>Range: <a property="http://schema.org/rangeIncludes" href="http://schema.org/Person">Person</a></span>
       <span>Range: <a property="http://schema.org/rangeIncludes" href="http://schema.org/Organization">Organization</a></span>
-      <span property="http://schema.org/supercededBy" href="http://schema.org/broker"/>
+      <span property="http://schema.org/supersededBy" href="http://schema.org/broker"/>
     </div>
     <div typeof="rdf:Property" resource="http://schema.org/bookingTime">
       <span class="h" property="rdfs:label">bookingTime</span>

--- a/docs/qa.html
+++ b/docs/qa.html
@@ -32,9 +32,9 @@
 
 <li><a href="/DataType">DataType</a> (root of the Datatype hierarchy) </li>
 
-<li><a href="/actor">actor</a> (property page, supercedes 'actors')</li>
+<li><a href="/actor">actor</a> (property page, supersedes 'actors')</li>
 
-<li><a href="/actors">actors</a> (a superceded property page; superceded by 'actor') </li>
+<li><a href="/actors">actors</a> (a superseded property page; superseded by 'actor') </li>
 
 <li><a href="/Enumeration">Enumeration</a> (Enum type - lists enum types as subclasses)</li>
 

--- a/docs/releases.html
+++ b/docs/releases.html
@@ -152,7 +152,7 @@ The <a href="/provider">provider</a> property describes a service provider, serv
 introduce a more general <a href="/broker">broker</a> property (replacing the over-specific <a href="bookingAgent">bookingAgent</a>),
 as well as deprecating <a href="/vendor">vendor</a> and <a href="/merchant">merchant</a> in favour of <a href="/seller">seller</a>.
 Regarding <a href="/Flight">flights</a> and <a href="/ParcelDelivery">parcel delivery</a>, <a href="/carrier">carrier</a> is
-superceded by <a href="/provider">provider</a>. Please also note that <a href="/flightNumber">flightNumber</a> should now be written in full (i.e. "UA110" rather than just "110").
+superseded by <a href="/provider">provider</a>. Please also note that <a href="/flightNumber">flightNumber</a> should now be written in full (i.e. "UA110" rather than just "110").
 See the <a href="https://www.w3.org/wiki/WebSchemas/SellerVendorCleanup#Implementation_Details">supporting documents</a> for details.
 </p>
 
@@ -163,7 +163,7 @@ and <a href="/Text">Text</a> values are anticipated. A common superproperty, <a 
 reflects <a href="http://lists.w3.org/Archives/Public/public-vocabs/2014Aug/0133.html">implementation experience</a> and
 establishes a model that can be applied elsewhere, e.g. ongoing work on <a href="http://lists.w3.org/Archives/Public/public-vocabs/2014Jun/0154.html">describing</a> music.</p>
 
-<p>This update also improves the display and navigation of <a href="/supercededBy">supercededBy</a> relations between
+<p>This update also improves the display and navigation of <a href="/supersededBy">supersededBy</a> relations between
 schema.org properties (e.g. see <a href="/seller">seller</a>).</p>
 
 <p>The <a href="/docs/terms.html">Terms of service</a> document was also updated to note 
@@ -195,7 +195,7 @@ Several <a href="http://github.com/rvguha/schemaorg/pull/71">markup fixes</a> fr
 <td>This release amends the <a href="http://schema.org/image">image</a> property, noting that <a href="/ImageObject">ImageObject</a> is a
     reasonable value. It also adds an <a href="http://schema.org/organizer">organizer</a> property to
     <a href="/Event">Event</a>. Changes around <a href="/Map">Map</a>: we add and prefer a '<a href="/hasMap">hasMap</a>' property
-which supercedes the older 'map' property, and we add a <a href="/mapType">mapType</a> property which comes with some enumerated values:
+which supersedes the older 'map' property, and we add a <a href="/mapType">mapType</a> property which comes with some enumerated values:
 <a href="ParkingMap">ParkingMap</a>, <a href="SeatingMap">SeatingMap</a>, <a href="TransitMap">TransitMap</a>,
 <a href="VenueMap">VenueMap</a>. A Map might be (but needn't be) also an <a href="/ImageObject">ImageObject</a>.
     (<a href="http://lists.w3.org/Archives/Public/public-vocabs/2014Jul/0012.html">announcement</a>)</td>
@@ -208,7 +208,7 @@ which supercedes the older 'map' property, and we add a <a href="/mapType">mapTy
     for details. The Role mechanism applies across all of schema.org, and allows simple statements to be elaborated or
     qualified, for example with temporal information. Other changes in this release include the addition of a
     <a href="/license">license</a> property, and some documentation of properties used internally by schema.org's documentation system
-    (<a href="/Property">Property</a>, <a href="/Class">Class</a>, <a href="/supercededBy">supercededBy</a>, <a href="/inverseOf">inverseOf</a>).
+    (<a href="/Property">Property</a>, <a href="/Class">Class</a>, <a href="/supersededBy">supersededBy</a>, <a href="/inverseOf">inverseOf</a>).
     Fixed an embarrassing typo - "dead" -  in the <a href="/diet">diet</a> property - thanks, Dan Scott. Various other
     small changes - listed in the <a href="http://lists.w3.org/Archives/Public/public-vocabs/2014Jun/0106.html">preview</a> announcement.
 (<a href="http://lists.w3.org/Archives/Public/public-vocabs/2014Jun/0178.html">announcement</a> and

--- a/tests/test_basics.py
+++ b/tests/test_basics.py
@@ -216,32 +216,32 @@ class SchemaBasicAPITestCase(unittest.TestCase):
 
 class SchemaPropertyAPITestCase(unittest.TestCase):
 
-  def test_actorSupercedesActors(self):
+  def test_actorSupersedesActors(self):
     p_actor = Unit.GetUnit("actor")
     p_actors = Unit.GetUnit("actors")
-    self.assertTrue(p_actors == p_actor.supercedes(), "actor supercedes actors.")
+    self.assertTrue(p_actors == p_actor.supersedes(), "actor supersedes actors.")
 
-  def test_actorsSuperceded(self):
+  def test_actorsSuperseded(self):
     p_actors = Unit.GetUnit("actors")
-    self.assertTrue(p_actors.superceded(), "actors property has been superceded.")
+    self.assertTrue(p_actors.superseded(), "actors property has been superseded.")
 
-  def test_actorNotSuperceded(self):
+  def test_actorNotSuperseded(self):
     p_actor = Unit.GetUnit("actor")
-    self.assertFalse(p_actor.superceded(), "actor property has not been superceded.")
+    self.assertFalse(p_actor.superseded(), "actor property has not been superseded.")
 
-  def test_offersNotSuperceded(self):
+  def test_offersNotSuperseded(self):
     p_offers = Unit.GetUnit("offers")
-    self.assertFalse(p_offers.superceded(), "offers property has not been superceded.")
+    self.assertFalse(p_offers.superseded(), "offers property has not been superseded.")
 
-  def test_actorNotSupercededByOffers(self):
-    p_actor = Unit.GetUnit("actor")
-    p_offers = Unit.GetUnit("offers")
-    self.assertFalse(p_actor == p_offers.supercedes(), "actor property doesn't supercede offers property.")
-
-  def test_offersNotSupercededByActor(self):
+  def test_actorNotSupersededByOffers(self):
     p_actor = Unit.GetUnit("actor")
     p_offers = Unit.GetUnit("offers")
-    self.assertFalse(p_offers == p_actor.supercedes(), "offers property doesn't supercede actors property.")
+    self.assertFalse(p_actor == p_offers.supersedes(), "actor property doesn't supersede offers property.")
+
+  def test_offersNotSupersededByActor(self):
+    p_actor = Unit.GetUnit("actor")
+    p_offers = Unit.GetUnit("offers")
+    self.assertFalse(p_offers == p_actor.supersedes(), "offers property doesn't supersede actors property.")
 
 # acceptedAnswer subPropertyOf suggestedAnswer .
 class SchemaPropertyMetadataTestCase(unittest.TestCase):


### PR DESCRIPTION
Hi everyone,

This is a fix for Issue "supercedes" spelling: "supersedes" is more mainstream #101" created by @danbri

All occurrences of 'supercede' is replaced by 'supersede'.
