### PR TITLE
Update the 'image' property description

### DIFF
--- a/data/schema.rdfa
+++ b/data/schema.rdfa
@@ -6473,7 +6473,7 @@ Note that Event uses startDate/endDate instead of startTime/endTime, even when d
     </div>
     <div typeof="rdf:Property" resource="http://schema.org/image">
       <span class="h" property="rdfs:label">image</span>
-      <span property="rdfs:comment">URL of an image of the item.</span>
+      <span property="rdfs:comment">An image of the item. This can be a &lt;a href=&quot;http://schema.org/URL&quot;&gt;URL&lt;/a&gt; or a fully described &lt;a href=&quot;http://schema.org/ImageObject&quot;&gt;ImageObject&lt;/a&gt;.</span>
       <span>Domain: <a property="http://schema.org/domainIncludes" href="http://schema.org/Thing">Thing</a></span>
       <span>Range: <a property="http://schema.org/rangeIncludes" href="http://schema.org/URL">URL</a></span>
       <span>Range: <a property="http://schema.org/rangeIncludes" href="http://schema.org/ImageObject">ImageObject</a></span>


### PR DESCRIPTION
We now describe that the image property has a range of both URL and
ImageObject, allowing for more flexible usage of the property.

Fixes #99.

Signed-off-by: Dan Scott dan@coffeecode.net
