### PR TITLE
Proposal for OrderItem and parcelDelivery addition to the Orders Schema

### DIFF
--- a/data/schema.rdfa
+++ b/data/schema.rdfa
@@ -3679,6 +3679,12 @@
       <span property="rdfs:comment">An order is a confirmation of a transaction (a receipt), which can contain multiple line items, each represented by an Offer that has been accepted by the customer.</span>
        <span>Subclass of: <a property="rdfs:subClassOf" href="http://schema.org/Intangible">Intangible</a></span>
     </div>
+    
+    <div typeof="rdfs:Class" resource="http://schema.org/OrderItem">
+      <span class="h" property="rdfs:label">OrderItem</span>
+      <span property="rdfs:comment">An order item is a line of an order. It includes the quantity and details of a bought offer.</span>
+       <span>Subclass of: <a property="rdfs:subClassOf" href="http://schema.org/Intangible">Intangible</a></span>
+    </div>
 
     <div typeof="rdfs:Class" resource="http://schema.org/OrderStatus">
       <span class="h" property="rdfs:label">OrderStatus</span>
@@ -9491,6 +9497,44 @@ Note that Event uses startDate/endDate instead of startTime/endTime, even when d
       <span property="rdfs:comment">The unique identifier for a flight including the airline IATA code. For example, if describing United flight 110, where the IATA code for United is 'UA', the flightNumber is 'UA110'.</span>
       <span>domain: <a property="http://schema.org/domainIncludes" href="http://schema.org/Flight">Flight</a></span>
       <span>Range: <a property="http://schema.org/rangeIncludes" href="http://schema.org/Text">Text</a></span>
+    </div>
+    <div typeof="rdf:Property" resource="http://schema.org/orderItem">
+        <span class="h" property="rdfs:label">orderItem</span>
+        <span property="rdfs:comment">A list of associated order items (order lines).</span>
+        <span>Domain: <a property="http://schema.org/domainIncludes" href="http://schema.org/Order">Order</a></span>
+        <span>Range: <a property="http://schema.org/rangeIncludes" href="http://schema.org/OrderItem">OrderItem</a></span>
+    </div>
+    <div typeof="rdf:Property" resource="http://schema.org/quantity">
+      <span class="h" property="rdfs:label">quantity</span>
+      <span property="rdfs:comment">The quantity of offers ordered.</span>
+      <span>Domain: <a property="http://schema.org/domainIncludes" href="http://schema.org/OrderItem">OrderItem</a></span>
+      <span>Range: <a property="http://schema.org/rangeIncludes" href="http://schema.org/Number">Number</a></span>
+    </div>
+    <div typeof="rdf:Property" resource="http://schema.org/acceptedOffer">
+      <span class="h" property="rdfs:label">acceptedOffer</span>
+      <span property="rdfs:comment">The offer(s) -- e.g., product, quantity and price combinations -- included in the order.</span>
+      <span>Domain: <a property="http://schema.org/domainIncludes" href="http://schema.org/Order">Order</a></span>
+      <span>Domain: <a property="http://schema.org/domainIncludes" href="http://schema.org/OrderItem">OrderItem</a></span>
+      <span>Range: <a property="http://schema.org/rangeIncludes" href="http://schema.org/Offer">Offer</a></span>
+    </div>
+    <div typeof="rdf:Property" resource="http://schema.org/orderItemStatus">
+      <span class="h" property="rdfs:label">orderItemStatus</span>
+      <span property="rdfs:comment">The current status of the order item.</span>
+      <span>Domain: <a property="http://schema.org/domainIncludes" href="http://schema.org/OrderItem">OrderItem</a></span>
+      <span>Range: <a property="http://schema.org/rangeIncludes" href="http://schema.org/OrderStatus">OrderStatus</a></span>
+    </div>
+    <div typeof="rdf:Property" resource="http://schema.org/orderItemNumber">
+      <span class="h" property="rdfs:label">orderItemNumber</span>
+      <span property="rdfs:comment">The identifier of the order item.</span>
+      <span>Domain: <a property="http://schema.org/domainIncludes" href="http://schema.org/OrderItem">OrderItem</a></span>
+      <span>Range: <a property="http://schema.org/rangeIncludes" href="http://schema.org/Text">Text</a></span>
+    </div>
+    <div typeof="rdf:Property" resource="http://schema.org/parcelDelivery">
+      <span class="h" property="rdfs:label">parcelDelivery</span>
+      <span property="rdfs:comment">The delivery of the parcel related to this order or order item.</span>
+      <span>Domain: <a property="http://schema.org/domainIncludes" href="http://schema.org/Order">Order</a></span>
+      <span>Domain: <a property="http://schema.org/domainIncludes" href="http://schema.org/OrderItem">OrderItem</a></span>
+      <span>Range: <a property="http://schema.org/rangeIncludes" href="http://schema.org/ParcelDelivery">ParcelDelivery</a></span>
     </div>
 
 <!--


### PR DESCRIPTION
This update has been discussed first [on the public vocabs mailing list](http://lists.w3.org/Archives/Public/public-vocabs/2014Jan/0161.html).

# Overview (extracted from the mailing list)

The current Orders Schema has some drawbacks:
- Many merchants such as Amazon, CDiscount or La Redoute handle status at the order line level: one item can be "Processing" while another of the same order (ordered in the same time) is "In Transit". In the current Orders Schema, the status is stored at the Order level, not at the Order item level, so it's impossible to represent case explained above.
- In the current Orders Schema, there is no notion of quantity for an order item. However, in almost all e-commerce platforms, a customer can order several times the same "Offer". (For instance, you can buy 3 t-shirts with SKU ABCDE).
- The Orders Schema does not include shipment details. However, a ParcelDelivery type already exists and a reverse property from Order to ParcelDelivery is sufficient.

# Vocabulary

The main additions / changes are:
- The new type Thing > Intangible > OrderItem
- Two new properties on Thing > Intangible > Order
