### PR TITLE
UTF-8 support fix for RDFa files

### DIFF
--- a/api.py
+++ b/api.py
@@ -883,16 +883,22 @@ class ShowUnit (webapp2.RequestHandler):
 
 def read_file (filename):
     """Read a file from disk, return it as a single string."""
-    import os.path
-    folder = os.path.dirname(os.path.realpath(__file__))
-    file_path = os.path.join(folder, filename)
     strs = []
+
+    file_path = full_path(filename)
 
     import codecs
     log.info("READING FILE: filename=%s file_path=%s " % (filename, file_path ) )
     for line in codecs.open(file_path, 'r', encoding="utf8").readlines():
         strs.append(line)
     return "".join(strs)
+
+def full_path(filename):
+    """convert local file name to full path."""
+    import os.path
+    folder = os.path.dirname(os.path.realpath(__file__))
+    return os.path.join(folder, filename)
+
 
 schemasInitialized = False
 
@@ -902,14 +908,14 @@ def read_schemas():
     import glob
     global schemasInitialized
     if (not schemasInitialized):
-        files = glob.glob("data/*schema.rdfa")
-        schema_contents = []
+        files = glob.glob("data/*.rdfa")
+        file_paths = []
         for f in files:
-            schema_content = read_file(f)
-            schema_contents.append(schema_content)
+            file_paths.append(full_path(f))
 
         parser = parsers.MakeParserOfType('rdfa', None)
-        items = parser.parse(schema_contents)
+        items = parser.parse(file_paths)
+
         files = glob.glob("data/*examples.txt")
         example_contents = []
         for f in files:

--- a/parsers.py
+++ b/parsers.py
@@ -83,16 +83,19 @@ class RDFAParser :
     def __init__ (self, webapp):
         self.webapp = webapp
 
-    def parse (self, contents):
+    def parse (self, files):
         self.items = {}
         root = []
-        for i in range(len(contents)):
-            root.append(ET.fromstring(contents[i]))
+        for i in range(len(files)):
+            parser = ET.XMLParser(encoding="utf-8")
+            tree = ET.parse(files[i], parser=parser)
+            root.append(tree.getroot())
+
             pre = root[i].findall(".//*[@prefix]")
             for e in range(len(pre)):
                 api.Unit.storePrefix(pre[e].get('prefix'))
 
-        for i in range(len(contents)):
+        for i in range(len(root)):
               self.extractTriples(root[i], None)
 
 


### PR DESCRIPTION
Error when reading non-ascii characters from .rdfa files.

Fix:

parsers.py
RDFa files list passed directly to RDFAParser. 
Change from using ET.fromString() which expects ascii, to an ET.parse which is passed an UTF8 parser

api.py
read_schemas adjusted to send file list instead of list of strings to parser.
