### PR TITLE
Move namedPosition to Role and rename to roleName

### DIFF
--- a/data/examples.txt
+++ b/data/examples.txt
@@ -11956,7 +11956,7 @@ MICRODATA:
     </div>
     <span itemprop="startDate">1979</span>
     <span itemprop="endDate">1992</span>
-    <span itemprop="namedPosition">Quarterback</span>
+    <span itemprop="roleName">Quarterback</span>
 </div>
 
 RDFA:
@@ -11969,7 +11969,7 @@ RDFA:
     </div>
     <span property="startDate">1979</span>
     <span property="endDate">1992</span>
-    <span property="namedPosition">Quarterback</span>
+    <span property="roleName">Quarterback</span>
 </div>
 
 JSON:
@@ -11987,7 +11987,7 @@ JSON:
     },
     "startDate": "1979",
     "endDate": "1992",
-    "namedPosition": "Quarterback"
+    "roleName": "Quarterback"
   }
 }
 </script>

--- a/data/schema.rdfa
+++ b/data/schema.rdfa
@@ -10124,7 +10124,16 @@ postponing for 1.6.
 
     <div typeof="rdf:Property" resource="http://schema.org/namedPosition">
       <span class="h" property="rdfs:label">namedPosition</span>
+      <span property="http://schema.org/supersededBy" href="http://schema.org/roleName"/>
       <span property="rdfs:comment">A position played, performed or filled by a person or organization, as part of an organization. For example, an athlete in a SportsTeam might play in the position named 'Quarterback'.</span>
+      <span>domainIncludes: <a property="http://schema.org/domainIncludes" href="http://schema.org/Role">Role</a></span>
+      <span>rangeIncludes: <a property="http://schema.org/rangeIncludes" href="http://schema.org/Text">Text</a></span>
+      <span>rangeIncludes: <a property="http://schema.org/rangeIncludes" href="http://schema.org/URL">URL</a></span>
+    </div>
+
+    <div typeof="rdf:Property" resource="http://schema.org/roleName">
+      <span class="h" property="rdfs:label">roleName</span>
+      <span property="rdfs:comment">A role played, performed or filled by a person or organization. For example, the team of creators for a comic book might fill the roles named 'inker', 'penciller', and 'letterer'; or an athlete in a SportsTeam might play in the position named 'Quarterback'.</span>
       <span>domainIncludes: <a property="http://schema.org/domainIncludes" href="http://schema.org/Role">Role</a></span>
       <span>rangeIncludes: <a property="http://schema.org/rangeIncludes" href="http://schema.org/Text">Text</a></span>
       <span>rangeIncludes: <a property="http://schema.org/rangeIncludes" href="http://schema.org/URL">URL</a></span>


### PR DESCRIPTION
Per http://lists.w3.org/Archives/Public/public-vocabs/2014Sep/0331.html, offer a generic property on Role that can be used by sub-types of role to identify the role being played, rather than propagating more properties.
