### PR TITLE
Add subPropertyOf to rdf:type for additionalType.

### DIFF
--- a/data/schema.rdfa
+++ b/data/schema.rdfa
@@ -4499,6 +4499,7 @@
     <div typeof="rdf:Property" resource="http://schema.org/additionalType">
       <span class="h" property="rdfs:label">additionalType</span>
       <span property="rdfs:comment">An additional type for the item, typically used for adding more specific types from external vocabularies in microdata syntax. This is a relationship between something and a class that the thing is in. In RDFa syntax, it is better to use the native RDFa syntax - the &#39;typeof&#39; attribute - for multiple types. Schema.org tools may have only weaker understanding of extra types, in particular those defined externally.</span>
+      <link property="rdfs:subPropertyOf" href="http://www.w3.org/1999/02/22-rdf-syntax-ns#type" />
       <span>Domain: <a property="http://schema.org/domainIncludes" href="http://schema.org/Thing">Thing</a></span>
       <span>Range: <a property="http://schema.org/rangeIncludes" href="http://schema.org/URL">URL</a></span>
     </div>


### PR DESCRIPTION
The semantics of `additionalType` is that it behaves like `rdf:type`. This commit creates the necessary `rdfs:subPropertyOf` statement to allow reasoners to infer this.

This also allows custom information in a microdata registry to be removed.
