### PR TITLE
Remove additional itemprop/property attribute on 'Book' example

### DIFF
--- a/data/sdo-periodical-examples.txt
+++ b/data/sdo-periodical-examples.txt
@@ -306,7 +306,7 @@ MICRODATA:
   <link itemprop="about" href="http://id.worldcat.org/fast/1020337">
     The <strong itemprop="name">Lord of the Rings</strong> is an 
     <span itemprop="inLanguage" content="en">English-language</span> 
-    <span itemprop="genre" itemprop="Fiction">fictional</span> trilogy by
+    <span itemprop="genre">fictional</span> trilogy by
   <span itemprop="author" itemscope itemtype="http://schema.org/Person" itemid="#author">
     <link itemprop="sameAs" href="http://viaf.org/viaf/95218067">
     <span itemprop="name" content="Tolkien, J. R. R. (John Ronald Reuel)">J. R. R. Tolkien</span>
@@ -355,7 +355,7 @@ RDFA:
   <link property="about" href="http://id.worldcat.org/fast/1020337">
     The <strong property="name">Lord of the Rings</strong> is an 
     <span property="inLanguage" content="en">English-language</span> 
-    <span property="genre" property="Fiction">fictional</span> trilogy by
+    <span property="genre">fictional</span> trilogy by
   <span property="author" typeof="Person" resource="#author">
     <link property="sameAs" href="http://viaf.org/viaf/95218067">
     <span property="name" content="Tolkien, J. R. R. (John Ronald Reuel)">J. R. R. Tolkien</span>


### PR DESCRIPTION
A Microdata/RDFa example had two `itemprop`/`property` elements on the same element, one of which contained an invalid property value (`Fiction`).

I guess it was intended to use `content="Fiction"` instead, but note that Microdata doesn’t allow this on `span` (see https://github.com/rvguha/schemaorg/issues/184) and the JSON-LD example uses "fictional" instead of "Fiction", too.