### PR TITLE
Fix AggregateOffer lossage

### DIFF
--- a/data/examples.txt
+++ b/data/examples.txt
@@ -935,14 +935,15 @@ MICRODATA:
     to <span itemprop="highPrice">$1495</span>
     from <span itemprop="offerCount">8</span> sellers
 
-  Sellers:
-  <div itemprop="offers" itemscope itemtype="http://schema.org/Offer">
-    <a itemprop="url" href="save-a-lot-monitors.com/dell-30.html">
-     Save A Lot Monitors - $1250</a>
-  </div>
-  <div itemprop="offers" itemscope itemtype="http://schema.org/Offer">
-    <a itemprop="url" href="jondoe-gadgets.com/dell-30.html">
-     Jon Doe's Gadgets - $1350</a>
+    Sellers:
+    <div itemprop="offers" itemscope itemtype="http://schema.org/Offer">
+        <a itemprop="url" href="save-a-lot-monitors.com/dell-30.html">
+        Save A Lot Monitors - $1250</a>
+    </div>
+    <div itemprop="offers" itemscope itemtype="http://schema.org/Offer">
+        <a itemprop="url" href="jondoe-gadgets.com/dell-30.html">
+        Jon Doe's Gadgets - $1350</a>
+    </div>
   </div>
   ...
 </div>

--- a/data/schema.rdfa
+++ b/data/schema.rdfa
@@ -7358,6 +7358,7 @@ Note that Event uses startDate/endDate instead of startTime/endTime, even when d
       <span>Domain: <a property="http://schema.org/domainIncludes" href="http://schema.org/CreativeWork">CreativeWork</a></span>
       <span>Domain: <a property="http://schema.org/domainIncludes" href="http://schema.org/Event">Event</a></span>
       <span>Domain: <a property="http://schema.org/domainIncludes" href="http://schema.org/Product">Product</a></span>
+      <span>Domain: <a property="http://schema.org/domainIncludes" href="http://schema.org/AggregateOffer">AggregateOffer</a></span>
       <span>Range: <a property="http://schema.org/rangeIncludes" href="http://schema.org/Offer">Offer</a></span>
     </div>
     <div typeof="rdf:Property" resource="http://schema.org/openingHours">


### PR DESCRIPTION
The example microdata is missing a </div> tag.

The domain of schema:offers is missing AggregateOffer (contra the examples); the rich snippets testing tool follows the rdfa and not the examples.   
