### PR TITLE
VOCAB: Adds abstract property to Article

### DIFF
--- a/data/examples.txt
+++ b/data/examples.txt
@@ -2946,9 +2946,9 @@ MICRODATA:
   </span>
   <br><span itemprop="datePublished">2012-03-24</span></p>
   <p><b>Abstract:</b>
-  We review clinical evidence related to the use of metformin for
+  <span itemprop="abstract">We review clinical evidence related to the use of metformin for
   treatment of type-2 diabetes mellitus and provide new clinical guideline
-  recommendations.</p>
+  recommendations.</span></p>
   <p><b>MeSH subject headings:</b>
   <span itemprop="about" itemscope itemtype="http://schema.org/Drug">
     <span itemprop="name">Metformin</span>
@@ -2997,9 +2997,9 @@ RDFA:
   </span>
   <br><span property="datePublished">2012-03-24</span></p>
   <p><b>Abstract:</b>
-  We review clinical evidence related to the use of metformin for
+  <span property="abstract">We review clinical evidence related to the use of metformin for
   treatment of type-2 diabetes mellitus and provide new clinical guideline
-  recommendations.</p>
+  recommendations.</span></p>
   <p><b>MeSH subject headings:</b>
   <span property="about"  typeof="Drug">
     <span property="name">Metformin</span>
@@ -3056,6 +3056,7 @@ JSON:
       "name": "Diabetes Mellitus, Type 2"
     }
   ],
+  "abstract": "We review clinical evidence related to the use of metformin for treatment of type-2 diabetes mellitus and provide new clinical guideline recommendations.",
   "audience": "http://schema.org/Clinician",
   "author": {
     "@type": "Person",

--- a/data/schema.rdfa
+++ b/data/schema.rdfa
@@ -4468,6 +4468,12 @@
       <span>Domain: <a property="http://schema.org/domainIncludes" href="http://schema.org/CommunicateAction">CommunicateAction</a></span>
       <span>Range: <a property="http://schema.org/rangeIncludes" href="http://schema.org/Thing">Thing</a></span>
     </div>
+    <div typeof="rdf:Property" resource="http://schema.org/abstract">
+      <span class="h" property="rdfs:label">abstract</span>
+      <span property="rdfs:comment">The abstract of the article.</span>
+      <span>Domain: <a property="http://schema.org/domainIncludes" href="http://schema.org/Article">Article</a></span>
+      <span>Range: <a property="http://schema.org/rangeIncludes" href="http://schema.org/Text">Text</a></span>
+    </div>
     <div typeof="rdf:Property" resource="http://schema.org/acceptedOffer">
       <span class="h" property="rdfs:label">acceptedOffer</span>
       <span property="rdfs:comment">The offer(s) -- e.g., product, quantity and price combinations -- included in the order.</span>


### PR DESCRIPTION
This property is very useful for scholar articles that are often referenced with their abstract by databases like [JSTOR](http://www.jstor.org), [arXiv](http://arxiv.org/), [HAL](https://hal.archives-ouvertes.fr/)...