### PR TITLE
Mark up MedicalScholarlyArticle abstract as description

### DIFF
--- a/data/examples.txt
+++ b/data/examples.txt
@@ -2946,9 +2946,9 @@ MICRODATA:
   </span>
   <br><span itemprop="datePublished">2012-03-24</span></p>
   <p><b>Abstract:</b>
-  We review clinical evidence related to the use of metformin for
+  <span itemprop="description">We review clinical evidence related to the use of metformin for
   treatment of type-2 diabetes mellitus and provide new clinical guideline
-  recommendations.</p>
+  recommendations.</span></p>
   <p><b>MeSH subject headings:</b>
   <span itemprop="about" itemscope itemtype="http://schema.org/Drug">
     <span itemprop="name">Metformin</span>
@@ -2997,9 +2997,9 @@ RDFA:
   </span>
   <br><span property="datePublished">2012-03-24</span></p>
   <p><b>Abstract:</b>
-  We review clinical evidence related to the use of metformin for
+  <span property="description">We review clinical evidence related to the use of metformin for
   treatment of type-2 diabetes mellitus and provide new clinical guideline
-  recommendations.</p>
+  recommendations.</span></p>
   <p><b>MeSH subject headings:</b>
   <span property="about"  typeof="Drug">
     <span property="name">Metformin</span>
@@ -3069,6 +3069,7 @@ JSON:
     "codingSystem": "MeSH"
   },
   "datePublished": "2012-03-24",
+  "description": "We review clinical evidence related to the use of metformin for treatment of type-2 diabetes mellitus and provide new clinical guideline recommendations.",
   "evidenceLevel": "http://schema.org/EvidenceLevelA",
   "name": "New guidelines for metformin and diabetes mellitus",
   "publicationType": "Meta-Analysis",


### PR DESCRIPTION
schema:description provides "a short description of an item", while an abstract
provides a short description of an article. Rather than leaving the abstract in
the MedicalScholarlyArticle example without any structure, use
schema:description to mark up the abstract as we do in the example for Article.

Signed-off-by: Dan Scott <dan@coffeecode.net>