### PR TITLE
VisualArtwork - added URL as type for 3 properties

### DIFF
--- a/data/schema.rdfa
+++ b/data/schema.rdfa
@@ -11235,6 +11235,7 @@ postponing for 1.6.
     <span property="rdfs:comment">e.g. Painting, Drawing, Sculpture, Print, Photograph, Assemblage, Collage, etc.</span>
     <span>Domain: <a property="http://schema.org/domainIncludes" href="http://schema.org/VisualArtwork">VisualArtwork</a></span>
     <span>Range: <a property="http://schema.org/rangeIncludes" href="http://schema.org/Text">Text</a></span>
+    <span>Range: <a property="http://schema.org/rangeIncludes" href="http://schema.org/URL">URL</a></span>
 </div>
 
 <div typeof="rdf:Property" resource="http://schema.org/material">
@@ -11242,6 +11243,7 @@ postponing for 1.6.
     <span property="rdfs:comment">e.g. Oil, Watercolour, Acrylic, Linoprint, Marble, Cyanotype, Digital, Lithograph, DryPoint, Intaglio, Pastel, Woodcut, Pencil, Mixed Media, etc.</span>
     <span>Domain: <a property="http://schema.org/domainIncludes" href="http://schema.org/VisualArtwork">VisualArtwork</a></span>
     <span>Range: <a property="http://schema.org/rangeIncludes" href="http://schema.org/Text">Text</a></span>
+    <span>Range: <a property="http://schema.org/rangeIncludes" href="http://schema.org/URL">URL</a></span>
 </div>
 
 <div typeof="rdf:Property" resource="http://schema.org/surface">
@@ -11249,6 +11251,7 @@ postponing for 1.6.
     <span property="rdfs:comment">e.g. Canvas, Paper, Wood, Board, etc.</span>
     <span>Domain: <a property="http://schema.org/domainIncludes" href="http://schema.org/VisualArtwork">VisualArtwork</a></span>
     <span>Range: <a property="http://schema.org/rangeIncludes" href="http://schema.org/Text">Text</a></span>
+    <span>Range: <a property="http://schema.org/rangeIncludes" href="http://schema.org/URL">URL</a></span>
 </div>
 
 <div typeof="rdf:Property" resource="http://schema.org/width"> <!-- exists, see http://schema.org/docs/schema_org_rdfa.html existing domains MediaObject, Product. -->


### PR DESCRIPTION
Added URL as an expected type (in addition to Text) to the VisualArtwork properties of "artform", "surface", and "material" to allow use of linked data, as suggested by Niklas Lindström at https://lists.w3.org/Archives/Public/public-vocabs/2014Dec/0115.html