### PR TITLE
Fixed "VideoGame" example + minor formatting

### DIFF
--- a/data/sdo-videogame-examples.txt
+++ b/data/sdo-videogame-examples.txt
@@ -279,7 +279,7 @@ MICRODATA:
 
 RDFA:
 
-<body  vocab="http://schema.org/" typeof="VideoGame">
+<body vocab="http://schema.org/" typeof="VideoGame">
 <h1 property="name"><a property="url" href="http://www.elderscrolls.com/skyrim">The Elder Scrolls V: Skyrim</a></h1>
 <p>Play mode: <span property="playMode">SinglePlayer</span></p>
 <div ><h2>Items</h2>
@@ -612,7 +612,7 @@ by <span>Electronic Arts</span>
 
 MICRODATA:
 
-<body vocab="http://schema.org/" itemscope itemtype="http://schema.org/VideoGame http://schema.org/MobileApplication">
+<body itemscope itemtype="http://schema.org/VideoGame http://schema.org/MobileApplication">
 ...
 <span itemprop="gamePlatform">iOS</span>
 
@@ -621,17 +621,17 @@ MICRODATA:
 by <span itemprop="author">Electronic Arts</span>
 <span itemprop="description">
 **YOU VOTED & THE CAT’S OUT OF THE BAG** Thanks to the votes from YOU and thousands of loyal MONOPOLY Facebook fans from 185 different countries, the CAT mover is now available to play with in this latest update as well as in the classic board game version of MONOPOLY!</span>
-<div itemprop="aggregateRating"  itemscope itemtype="http://schema.org/AggregateRating">
+<div itemprop="aggregateRating" itemscope itemtype="http://schema.org/AggregateRating">
   <span itemprop="ratingValue">4</span> stars -
   <span itemprop="reviewCount">33</span> reviews
 </div>
-<div itemprop="offers"  itemscope itemtype="http://schema.org/Offer">
+<div itemprop="offers" itemscope itemtype="http://schema.org/Offer">
   Price: <span itemprop="price">1</span>
   <meta itemprop="priceCurrency" content="USD" />
   <link itemprop="availability" href="http://schema.org/InStock">In Stock
  </div>
   Version:<span itemprop="softwareVersion">1.2.50</span>
-  Updated:<meta  itemprop="dateModified" content="2013-11-09"> 09.11.2013
+  Updated:<meta itemprop="dateModified" content="2013-11-09"> 09.11.2013
 <div itemprop="audience" itemscope itemtype="http://schema.org/PeopleAudience">
   Age<span itemprop="requiredMinAge">4</span>+
 </div>
@@ -648,17 +648,17 @@ RDFA:
 by <span property="author">Electronic Arts</span>
 <span property="description">
 **YOU VOTED & THE CAT’S OUT OF THE BAG** Thanks to the votes from YOU and thousands of loyal MONOPOLY Facebook fans from 185 different countries, the CAT mover is now available to play with in this latest update as well as in the classic board game version of MONOPOLY!</span>
-<div property="aggregateRating"  typeof="AggregateRating">
+<div property="aggregateRating" typeof="AggregateRating">
   <span property="ratingValue">4</span> stars -
   <span property="reviewCount">33</span> reviews
 </div>
-<div property="offers"  typeof="Offer">
+<div property="offers" typeof="Offer">
   Price: <span property="price">1</span>
   <meta property="priceCurrency" content="USD" />
   <link property="availability" href="http://schema.org/InStock">In Stock
  </div>
   Version:<span property="softwareVersion">1.2.50</span>
-  Updated:<meta  property="dateModified" content="2013-11-09"> 09.11.2013
+  Updated:<meta property="dateModified" content="2013-11-09"> 09.11.2013
 <div property="audience" typeof="PeopleAudience">
   Age<span property="requiredMinAge">4</span>+
 </div>
@@ -733,48 +733,48 @@ PRE-MARKUP:
 
 <section>
     <section>
-        <span>Approx. Retail:</span>
-        <span>$17.99</span>
-        <a href="/monopoly-2/en_US/shop/where-to-buy.cfm?brand_guid=DAD28866-1C43-11DD-BD0B-0800200C9A66&prodName=Monopoly%20Game">Where To Buy</a>
+      <span>Approx. Retail:</span>
+      <span>$17.99</span>
+      <a href="/monopoly-2/en_US/shop/where-to-buy.cfm?brand_guid=DAD28866-1C43-11DD-BD0B-0800200C9A66&prodName=Monopoly%20Game">Where To Buy</a>
     </section>
     <span>
       Ages: <span>8</span> YEARS & UP
     </span>
-      <h4>Game  Description:</h4>
-    <p >Own it all as a high-flying trader in the fast-paced world of real estate. Tour the city for the hottest properties: sites, stations and utilities are all up for grabs. Invest in houses and hotels, then watch the rent come pouring in! Make deals with other players and look out for bargains at auction. There are many ways to get what you want. For really speedy dealers, use the speed die for a quick and intense game of Monopoly. So get on Go and trade your way to success!<br/><br/>Includes <span>gameboard</span>, <span>8 tokens</span>, <span>28 Title Deed cards</span>, <span>16 Chance cards</span>, <span>16 Community Chest cards</span>, <span>money pack</span>,<span> 32 houses</span>, <span>12 hotels</span>, 2 dice and instructions<br/><br/>•Features a speed die for a faster, more intense game<br/>•Includes the new token that was voted No. 1: the cat<br/><br/>For <div>
-3 to 5  players </div>.<br/><br/>Ages 8 and up.<br/><br/>Monopoly and all related characters are trademarks of Hasbro. <P></p>
+    <h4>Game Description:</h4>
+    <p>Own it all as a high-flying trader in the fast-paced world of real estate. Tour the city for the hottest properties: sites, stations and utilities are all up for grabs. Invest in houses and hotels, then watch the rent come pouring in! Make deals with other players and look out for bargains at auction. There are many ways to get what you want. For really speedy dealers, use the speed die for a quick and intense game of Monopoly. So get on Go and trade your way to success!<br/><br/>Includes <span>gameboard</span>, <span>8 tokens</span>, <span>28 Title Deed cards</span>, <span>16 Chance cards</span>, <span>16 Community Chest cards</span>, <span>money pack</span>,<span> 32 houses</span>, <span>12 hotels</span>, 2 dice and instructions<br/><br/>•Features a speed die for a faster, more intense game<br/>•Includes the new token that was voted No. 1: the cat<br/><br/>
+    <div>For 3 to 5 players.</div><br/><br/>Ages 8 and up.<br/><br/>Monopoly and all related characters are trademarks of Hasbro.
     </section>
 
 MICRODATA:
 
 <section itemscope itemtype="http://schema.org/Game">
     <section itemprop="offers" itemscope itemtype="http://schema.org/Offer">
-        <span>Approx. Retail:</span>
-        <span itemprop="priceCurrency">$</span><span itemprop="price">17.99</span>
-        <a href="/monopoly-2/en_US/shop/where-to-buy.cfm?brand_guid=DAD28866-1C43-11DD-BD0B-0800200C9A66&prodName=Monopoly%20Game" itemprop="availableAtOrFrom">Where To Buy</a>
+      <span>Approx. Retail:</span>
+      <span itemprop="priceCurrency">$</span><span itemprop="price">17.99</span>
+      <a href="/monopoly-2/en_US/shop/where-to-buy.cfm?brand_guid=DAD28866-1C43-11DD-BD0B-0800200C9A66&prodName=Monopoly%20Game" itemprop="availableAtOrFrom">Where To Buy</a>
     </section>
     <span itemprop="audience" itemscope itemtype="http://schema.org/PeopleAudience">
       Ages: <span itemprop="suggestedMinAge">8</span> YEARS & UP
     </span>
-      <h4>Game  Description:</h4>
-    <p itemprop="description">Own it all as a high-flying trader in the fast-paced world of real estate. Tour the city for the hottest properties: sites, stations and utilities are all up for grabs. Invest in houses and hotels, then watch the rent come pouring in! Make deals with other players and look out for bargains at auction. There are many ways to get what you want. For really speedy dealers, use the speed die for a quick and intense game of Monopoly. So get on Go and trade your way to success!<br/><br/>Includes <span itemprop="gameItem">gameboard</span>, <span itemprop="gameItem">8 tokens</span>, <span itemprop="gameItem">28 Title Deed cards</span>, <span itemprop="gameItem">16 Chance cards</span>, <span itemprop="gameItem">16 Community Chest cards</span>, <span itemprop="gameItem">money pack</span>,<span itemprop="gameItem"> 32 houses</span>, <span itemprop="gameItem">12 hotels</span>, 2 dice and instructions<br/><br/>•Features a speed die for a faster, more intense game<br/>•Includes the new token that was voted No. 1: the cat<br/><br/>For <div itemprop="numberOfPlayers" itemscope itemtype="http://schema.org/QuantitativeValue">
-<span itemprop="minValue">3</span> to <span itemprop="maxValue">5</span>  players </div>.<br/><br/>Ages 8 and up.<br/><br/>Monopoly and all related characters are trademarks of <span itemprop="copyrightHolder">Hasbro</span>. <P></p>
+    <h4>Game Description:</h4>
+    <p itemprop="description">Own it all as a high-flying trader in the fast-paced world of real estate. Tour the city for the hottest properties: sites, stations and utilities are all up for grabs. Invest in houses and hotels, then watch the rent come pouring in! Make deals with other players and look out for bargains at auction. There are many ways to get what you want. For really speedy dealers, use the speed die for a quick and intense game of Monopoly. So get on Go and trade your way to success!<br/><br/>Includes <span itemprop="gameItem">gameboard</span>, <span itemprop="gameItem">8 tokens</span>, <span itemprop="gameItem">28 Title Deed cards</span>, <span itemprop="gameItem">16 Chance cards</span>, <span itemprop="gameItem">16 Community Chest cards</span>, <span itemprop="gameItem">money pack</span>,<span itemprop="gameItem"> 32 houses</span>, <span itemprop="gameItem">12 hotels</span>, 2 dice and instructions<br/><br/>•Features a speed die for a faster, more intense game<br/>•Includes the new token that was voted No. 1: the cat<br/><br/>
+    <div itemprop="numberOfPlayers" itemscope itemtype="http://schema.org/QuantitativeValue">For <span itemprop="minValue">3</span> to <span itemprop="maxValue">5</span> players.</div><br/><br/>Ages 8 and up.<br/><br/>Monopoly and all related characters are trademarks of <span itemprop="copyrightHolder">Hasbro</span>.
     </section>
 
 RDFA:
 
 <section vocab="http://schema.org/" typeof="Game">
     <section property="offers" typeof="Offer">
-        <span>Approx. Retail:</span>
-        <span property="priceCurrency">$</span><span property="price">17.99</span>
-        <a href="/monopoly-2/en_US/shop/where-to-buy.cfm?brand_guid=DAD28866-1C43-11DD-BD0B-0800200C9A66&prodName=Monopoly%20Game" property="availableAtOrFrom">Where To Buy</a>
+      <span>Approx. Retail:</span>
+      <span property="priceCurrency">$</span><span property="price">17.99</span>
+      <a href="/monopoly-2/en_US/shop/where-to-buy.cfm?brand_guid=DAD28866-1C43-11DD-BD0B-0800200C9A66&prodName=Monopoly%20Game" property="availableAtOrFrom">Where To Buy</a>
     </section>
     <span property="audience" typeof="PeopleAudience">
       Ages: <span property="suggestedMinAge">8</span> YEARS & UP
     </span>
-      <h4>Game  Description:</h4>
-    <p property="description">Own it all as a high-flying trader in the fast-paced world of real estate. Tour the city for the hottest properties: sites, stations and utilities are all up for grabs. Invest in houses and hotels, then watch the rent come pouring in! Make deals with other players and look out for bargains at auction. There are many ways to get what you want. For really speedy dealers, use the speed die for a quick and intense game of Monopoly. So get on Go and trade your way to success!<br/><br/>Includes <span property="gameItem">gameboard</span>, <span property="gameItem">8 tokens</span>, <span property="gameItem">28 Title Deed cards</span>, <span property="gameItem">16 Chance cards</span>, <span property="gameItem">16 Community Chest cards</span>, <span property="gameItem">money pack</span>,<span property="gameItem"> 32 houses</span>, <span property="gameItem">12 hotels</span>, 2 dice and instructions<br/><br/>•Features a speed die for a faster, more intense game<br/>•Includes the new token that was voted No. 1: the cat<br/><br/>For <div property="numberOfPlayers" typeof="QuantitativeValue">
-<span property="minValue">3</span> to <span property="maxValue">5</span>  players </div>.<br/><br/>Ages 8 and up.<br/><br/>Monopoly and all related characters are trademarks of <span property="copyrightHolder">Hasbro</span>. <P></p>
+    <h4>Game Description:</h4>
+    <p property="description">Own it all as a high-flying trader in the fast-paced world of real estate. Tour the city for the hottest properties: sites, stations and utilities are all up for grabs. Invest in houses and hotels, then watch the rent come pouring in! Make deals with other players and look out for bargains at auction. There are many ways to get what you want. For really speedy dealers, use the speed die for a quick and intense game of Monopoly. So get on Go and trade your way to success!<br/><br/>Includes <span property="gameItem">gameboard</span>, <span property="gameItem">8 tokens</span>, <span property="gameItem">28 Title Deed cards</span>, <span property="gameItem">16 Chance cards</span>, <span property="gameItem">16 Community Chest cards</span>, <span property="gameItem">money pack</span>,<span property="gameItem"> 32 houses</span>, <span property="gameItem">12 hotels</span>, 2 dice and instructions<br/><br/>•Features a speed die for a faster, more intense game<br/>•Includes the new token that was voted No. 1: the cat<br/><br/>
+    <div property="numberOfPlayers" typeof="QuantitativeValue">For <span property="minValue">3</span> to <span property="maxValue">5</span> players.</div><br/><br/>Ages 8 and up.<br/><br/>Monopoly and all related characters are trademarks of <span property="copyrightHolder">Hasbro</span>.
     </section>
 
 JSON:


### PR DESCRIPTION
VideoGame: Microdata example had an RDFa attribute (`vocab`);

Game: formatted and restructured example, removed empty "`<P></p>`";

removed several superfluous spaces.