### PR TITLE
Automotive

### DIFF
--- a/data/schema.rdfa
+++ b/data/schema.rdfa
@@ -11332,7 +11332,6 @@ postponing for 1.6.
 </div>
 
 <!-- Vehicles extension proposal, as per https://www.w3.org/wiki/WebSchemas/Vehicles -->
-<div>
     <h1>Vehicles</h1>
     <div typeof="rdfs:Class" resource="http://schema.org/MotorizedRoadVehicle">
         <span class="h" property="rdfs:label">MotorizedRoadVehicle</span>

--- a/data/schema.rdfa
+++ b/data/schema.rdfa
@@ -11686,8 +11686,8 @@ postponing for 1.6.
         <span>Range: <a property="http://schema.org/rangeIncludes" href="http://schema.org/Text">Text</a></span>
         <span>Source:  <a property="dc:source" href="http://www.w3.org/wiki/WebSchemas/SchemaDotOrgSources#Automotive_Ontology_Working_Group">GAO</a></span>
     </div>
-    <div typeof="rdf:Property" resource="http://schema.org/configurationName">
-        <span class="h" property="rdfs:label">configurationName</span>
+    <div typeof="rdf:Property" resource="http://schema.org/configuration">
+        <span class="h" property="rdfs:label">configuration</span>
         <span property="rdfs:comment">A short text indicating the configuration of the vehicle, e.g. &apos;5dr hatchback ST 2.5 MT 225 hp&apos; or &apos;limited edition&apos;.</span>
         <span>Domain: <a property="http://schema.org/domainIncludes" href="http://schema.org/MotorizedRoadVehicle">MotorizedRoadVehicle</a></span>
         <span>Range: <a property="http://schema.org/rangeIncludes" href="http://schema.org/Text">Text</a></span>

--- a/data/schema.rdfa
+++ b/data/schema.rdfa
@@ -9369,11 +9369,12 @@ Note that Event uses startDate/endDate instead of startTime/endTime, even when d
       <span property="rdfs:label">BibExTerm</span>
       <span property="rdfs:comment">The W3C &lt;a href="http://www.w3.org/community/schemabibex/"&gt;Schema Bib Extend&lt;/a&gt; (BibEx) group led the work to improve schema.org for bibliographic information, including terms for periodicals, articles and multi-volume works. The design was inspired in places (e.g. pageStart, pageEnd, pagination) by the &lt;a href="http://bibliontology.com/"&gt;Bibliographic Ontology&lt;/a&gt;, 'bibo'.</span>
     </div>
-
+	
+	<div typeof="http://schema.org/Organization" resource="http://www.w3.org/wiki/WebSchemas/SchemaDotOrgSources#Automotive_Ontology_Working_Group">
+	  <span property="rdfs:label">AutomotiveOntologyWGClass</span>
+	  <span property="rdfs:comment">This class is based on the work of the Automotive Ontology Working Group, see &lt;a href=&quot;http://www.automotive-ontology.org&quot;&gt;http://www.automotive-ontology.org&lt;/a&gt; for details.</span>
+	</div>
     <hr />
-
-
-
 
     <h1>Reservations</h1>
 
@@ -9494,13 +9495,13 @@ Note that Event uses startDate/endDate instead of startTime/endTime, even when d
     </div>
     <div typeof="rdfs:Class" resource="http://schema.org/Vehicle">
       <span class="h" property="rdfs:label">Vehicle</span>
-      <span property="rdfs:comment">A vehicle.</span>
+      <span property="rdfs:comment">A vehicle is a device that is designed or used to transport people or cargo over land, water, air, or through space.</span>
       <span>Subclass of: <a property="rdfs:subClassOf" href="http://schema.org/Product">Product</a></span>
     </div>
     <div typeof="rdfs:Class" resource="http://schema.org/Car">
       <span class="h" property="rdfs:label">Car</span>
-      <span property="rdfs:comment">An automobile.</span>
-      <span>Subclass of: <a property="rdfs:subClassOf" href="http://schema.org/Vehicle">Vehicle</a></span>
+      <span property="rdfs:comment">An automobile, motor car, or car is a wheeled motor vehicle used for transporting passengers, which also carries its own engine or motor.</span>      
+      <span>Subclass of: <a property="rdfs:subClassOf" href="http://schema.org/MotorizedRoadVehicle">MotorizedRoadVehicle</a></span>
     </div>
     <div typeof="rdf:Property" resource="http://schema.org/reservationId">
       <span class="h" property="rdfs:label">reservationId</span>
@@ -11329,6 +11330,566 @@ postponing for 1.6.
   <span>Domain: <a property="http://schema.org/domainIncludes" href="http://schema.org/Invoice">Invoice</a></span>
   <span>Domain: <a property="http://schema.org/rangeIncludes" href="http://schema.org/Order">Order</a></span>
 </div>
+
+<!-- Vehicles extension proposal, as per https://www.w3.org/wiki/WebSchemas/Vehicles -->
+<div>
+    <h1>Vehicles</h1>
+    <div typeof="rdfs:Class" resource="http://schema.org/MotorizedRoadVehicle">
+        <span class="h" property="rdfs:label">MotorizedRoadVehicle</span>
+        <span property="rdfs:comment">A motorized road vehicle is a wheeled land vehicle whose main propulsion is provided by an engine or motor.</span>
+        <span>Subclass of: <a property="rdfs:subClassOf" href="http://schema.org/Vehicle">Vehicle</a></span>
+        <span>Source:  <a property="dc:source" href="http://www.w3.org/wiki/WebSchemas/SchemaDotOrgSources#Automotive_Ontology_Working_Group">GAO</a></span>
+    </div>
+    <div typeof="rdfs:Class" resource="http://schema.org/Truck">
+        <span class="h" property="rdfs:label">Truck</span>
+        <span property="rdfs:comment">A lorry (British English) or truck (American English) is a motor vehicle designed to transport cargo.</span>
+        <span>Subclass of: <a property="rdfs:subClassOf" href="http://schema.org/MotorizedRoadVehicle">MotorizedRoadVehicle</a></span>
+        <span>Source:  <a property="dc:source" href="http://www.w3.org/wiki/WebSchemas/SchemaDotOrgSources#Automotive_Ontology_Working_Group">GAO</a></span>
+    </div>
+    <div typeof="rdfs:Class" resource="http://schema.org/Van">
+        <span class="h" property="rdfs:label">Van</span>
+        <span property="rdfs:comment">A van is a kind of vehicle used for transporting  goods or groups of people. It is usually a box-shaped vehicle on four wheels, about the same width and length as a large automobile, but taller and usually higher off the ground, also referred to as a light commercial vehicle or LCV.</span>
+        <span>Subclass of: <a property="rdfs:subClassOf" href="http://schema.org/MotorizedRoadVehicle">MotorizedRoadVehicle</a></span>
+        <span>Source:  <a property="dc:source" href="http://www.w3.org/wiki/WebSchemas/SchemaDotOrgSources#Automotive_Ontology_Working_Group">GAO</a></span>
+    </div>
+    <div typeof="rdfs:Class" resource="http://schema.org/MotorizedBicycle">
+        <span class="h" property="rdfs:label">MotorizedBicycle</span>
+        <span property="rdfs:comment">A motorized bicycle is a bicycle with an attached motor used to power the vehicle, or to assist with pedaling.</span>
+        <span>Subclass of: <a property="rdfs:subClassOf" href="http://schema.org/MotorizedRoadVehicle">MotorizedRoadVehicle</a></span>
+        <span>Source:  <a property="dc:source" href="http://www.w3.org/wiki/WebSchemas/SchemaDotOrgSources#Automotive_Ontology_Working_Group">GAO</a></span>
+    </div>
+    <div typeof="rdfs:Class" resource="http://schema.org/BusOrCoach">
+        <span class="h" property="rdfs:label">BusOrCoach</span>
+        <span property="rdfs:comment">A bus (also omnibus or autobus) is a road vehicle designed to carry passengers. Buses have a capacity as high as 300 passengers and are widely used for public transportation. 
+    Coaches are luxury busses, usually in service for long distance travel.</span>
+        <span>Subclass of: <a property="rdfs:subClassOf" href="http://schema.org/MotorizedRoadVehicle">MotorizedRoadVehicle</a></span>
+        <span>Source:  <a property="dc:source" href="http://www.w3.org/wiki/WebSchemas/SchemaDotOrgSources#Automotive_Ontology_Working_Group">GAO</a></span>
+    </div>
+    <div typeof="rdfs:Class" resource="http://schema.org/Motorcycle">
+        <span class="h" property="rdfs:label">Motorcycle</span>
+        <span property="rdfs:comment">A motorcycle or motorbike is a single-track, two-wheeled motor vehicle.</span>
+        <span>Subclass of: <a property="rdfs:subClassOf" href="http://schema.org/MotorizedRoadVehicle">MotorizedRoadVehicle</a></span>
+        <span>Source:  <a property="dc:source" href="http://www.w3.org/wiki/WebSchemas/SchemaDotOrgSources#Automotive_Ontology_Working_Group">GAO</a></span>
+    </div>
+    <div typeof="rdfs:Class" resource="http://schema.org/Bicycle">
+        <span class="h" property="rdfs:label">Bicycle</span>
+        <span property="rdfs:comment">A bicycle or bike is a pedal-driven, human-powered, single-track vehicle, having two wheels attached to a frame, one behind the other. Some bicycles have a small combustion or electric engine that assists with the pedaling.</span>
+        <span>Subclass of: <a property="rdfs:subClassOf" href="http://schema.org/Vehicle">Vehicle</a></span>
+        <span>Source:  <a property="dc:source" href="http://www.w3.org/wiki/WebSchemas/SchemaDotOrgSources#Automotive_Ontology_Working_Group">GAO</a></span>
+    </div>
+    <div typeof="rdfs:Class" resource="http://schema.org/Watercraft">
+        <span class="h" property="rdfs:label">Watercraft</span>
+        <span property="rdfs:comment">A watercraft is a vehicle, vessel or craft designed to move across or through water.</span>
+        <span>Subclass of: <a property="rdfs:subClassOf" href="http://schema.org/Vehicle">Vehicle</a></span>
+        <span>Source:  <a property="dc:source" href="http://www.w3.org/wiki/WebSchemas/SchemaDotOrgSources#Automotive_Ontology_Working_Group">GAO</a></span>
+    </div>
+    <div typeof="rdfs:Class" resource="http://schema.org/Boat">
+        <span class="h" property="rdfs:label">Boat</span>
+        <span property="rdfs:comment">A boat is a watercraft of modest size designed to float or plane, to provide passage across water.</span>
+        <span>Subclass of: <a property="rdfs:subClassOf" href="http://schema.org/Watercraft">Watercraft</a></span>
+        <span>Source:  <a property="dc:source" href="http://www.w3.org/wiki/WebSchemas/SchemaDotOrgSources#Automotive_Ontology_Working_Group">GAO</a></span>
+    </div>
+    <div typeof="rdfs:Class" resource="http://schema.org/MotorBoat">
+        <span class="h" property="rdfs:label">MotorBoat</span>
+        <span property="rdfs:comment">A motorboat is a boat which is powered by an engine.</span>
+        <span>Subclass of: <a property="rdfs:subClassOf" href="http://schema.org/Boat">Boat</a></span>
+        <span>Source:  <a property="dc:source" href="http://www.w3.org/wiki/WebSchemas/SchemaDotOrgSources#Automotive_Ontology_Working_Group">GAO</a></span>
+    </div>
+    <div typeof="rdfs:Class" resource="http://schema.org/SailingBoat">
+        <span class="h" property="rdfs:label">SailingBoat</span>
+        <span property="rdfs:comment">A sailboat or sailing boat is a boat propelled partly or entirely by sails.</span>
+        <span>Subclass of: <a property="rdfs:subClassOf" href="http://schema.org/Boat">Boat</a></span>
+        <span>Source:  <a property="dc:source" href="http://www.w3.org/wiki/WebSchemas/SchemaDotOrgSources#Automotive_Ontology_Working_Group">GAO</a></span>
+    </div>
+    <div typeof="rdfs:Class" resource="http://schema.org/SteeringPositionValue">
+        <span class="h" property="rdfs:label">SteeringPositionValue</span>
+        <span property="rdfs:comment">A value indicating a steering position.</span>
+        <span>Subclass of: <a property="rdfs:subClassOf" href="http://schema.org/QualitativeValue">QualitativeValue</a></span>
+        <span>Source:  <a property="dc:source" href="http://www.w3.org/wiki/WebSchemas/SchemaDotOrgSources#Automotive_Ontology_Working_Group">GAO</a></span>
+    </div>
+    <div typeof="rdfs:Class" resource="http://schema.org/EmissionStandardValue">
+        <span class="h" property="rdfs:label">EmissionStandardValue</span>
+        <span property="rdfs:comment">A value indicating the an emission standard.</span>
+        <span>Subclass of: <a property="rdfs:subClassOf" href="http://schema.org/QualitativeValue">QualitativeValue</a></span>
+        <span>Source:  <a property="dc:source" href="http://www.w3.org/wiki/WebSchemas/SchemaDotOrgSources#Automotive_Ontology_Working_Group">GAO</a></span>
+    </div>
+    <div typeof="rdfs:Class" resource="http://schema.org/TransmissionTypeValue">
+        <span class="h" property="rdfs:label">TransmissionTypeValue</span>
+        <span property="rdfs:comment">A value indicating a type of transmission.</span>
+        <span>Subclass of: <a property="rdfs:subClassOf" href="http://schema.org/QualitativeValue">QualitativeValue</a></span>
+        <span>Source:  <a property="dc:source" href="http://www.w3.org/wiki/WebSchemas/SchemaDotOrgSources#Automotive_Ontology_Working_Group">GAO</a></span>
+    </div>
+    <div typeof="rdfs:Class" resource="http://schema.org/DriveWheelConfigurationValue">
+        <span class="h" property="rdfs:label">DriveWheelConfigurationValue</span>
+        <span property="rdfs:comment">A value indicating which roadwheels will receive torque.</span>
+        <span>Subclass of: <a property="rdfs:subClassOf" href="http://schema.org/QualitativeValue">QualitativeValue</a></span>
+        <span>Source:  <a property="dc:source" href="http://www.w3.org/wiki/WebSchemas/SchemaDotOrgSources#Automotive_Ontology_Working_Group">GAO</a></span>
+    </div>
+    <div typeof="rdfs:Class" resource="http://schema.org/EngineTypeValue">
+        <span class="h" property="rdfs:label">EngineTypeValue</span>
+        <span property="rdfs:comment">A value indicating an engine type.</span>
+        <span>Subclass of: <a property="rdfs:subClassOf" href="http://schema.org/QualitativeValue">QualitativeValue</a></span>
+        <span>Source:  <a property="dc:source" href="http://www.w3.org/wiki/WebSchemas/SchemaDotOrgSources#Automotive_Ontology_Working_Group">GAO</a></span>
+    </div>
+    <div typeof="rdfs:Class" resource="http://schema.org/FuelTypeValue">
+        <span class="h" property="rdfs:label">FuelTypeValue</span>
+        <span property="rdfs:comment">A value indicating a type of fuel.</span>
+        <span>Subclass of: <a property="rdfs:subClassOf" href="http://schema.org/QualitativeValue">QualitativeValue</a></span>
+        <span>Source:  <a property="dc:source" href="http://www.w3.org/wiki/WebSchemas/SchemaDotOrgSources#Automotive_Ontology_Working_Group">GAO</a></span>
+    </div>
+    <div typeof="rdfs:Class" resource="http://schema.org/BodyTypeValue">
+        <span class="h" property="rdfs:label">BodyTypeValue</span>
+        <span property="rdfs:comment">A value indicating the body type or style of a vehicle.</span>
+        <span>Subclass of: <a property="rdfs:subClassOf" href="http://schema.org/QualitativeValue">QualitativeValue</a></span>
+        <span>Source:  <a property="dc:source" href="http://www.w3.org/wiki/WebSchemas/SchemaDotOrgSources#Automotive_Ontology_Working_Group">GAO</a></span>
+    </div>
+    <div typeof="rdfs:Class" resource="http://schema.org/CarUsageType">
+        <span class="h" property="rdfs:label">CarUsageType</span>
+        <span property="rdfs:comment">A value indicating a special usage of a car, e.g. commercial rental, driving school, or as a taxi.</span>
+        <span>Subclass of: <a property="rdfs:subClassOf" href="http://schema.org/QualitativeValue">QualitativeValue</a></span>
+        <span>Source:  <a property="dc:source" href="http://www.w3.org/wiki/WebSchemas/SchemaDotOrgSources#Automotive_Ontology_Working_Group">GAO</a></span>
+    </div>
+    <div typeof="rdf:Property" resource="http://schema.org/steeringPosition">
+        <span class="h" property="rdfs:label">steeringPosition</span>
+        <span property="rdfs:comment">The position of the steering wheel or similar device (mostly for cars).</span>
+        <span>Domain: <a property="http://schema.org/domainIncludes" href="http://schema.org/MotorizedRoadVehicle">MotorizedRoadVehicle</a></span>
+        <span>Range: <a property="http://schema.org/rangeIncludes" href="http://schema.org/SteeringPositionValue">SteeringPositionValue</a></span>
+        <span>Source:  <a property="dc:source" href="http://www.w3.org/wiki/WebSchemas/SchemaDotOrgSources#Automotive_Ontology_Working_Group">GAO</a></span>
+    </div>
+    <div typeof="rdf:Property" resource="http://schema.org/fuelCapacity">
+        <span class="h" property="rdfs:label">fuelCapacity</span>
+        <span property="rdfs:comment">The capacity of the fuel tank or in the case electric cars, the battery. If there are multiple components for storage, this should indicate the total of all storage of the same type.&lt;br /&gt;
+    Typical unit code(s): LTR for liters, GLL of US gallons, GLI for UK / imperial gallons, AMH for ampere-hours (for electrical vehicles)
+    </span>
+        <span>Domain: <a property="http://schema.org/domainIncludes" href="http://schema.org/MotorizedRoadVehicle">MotorizedRoadVehicle</a></span>
+        <span>Domain: <a property="http://schema.org/domainIncludes" href="http://schema.org/MotorBoat">MotorBoat</a></span>
+        <span>Range: <a property="http://schema.org/rangeIncludes" href="http://schema.org/QuantitativeValue">QuantitativeValue</a></span>
+        <span>Source:  <a property="dc:source" href="http://www.w3.org/wiki/WebSchemas/SchemaDotOrgSources#Automotive_Ontology_Working_Group">GAO</a></span>
+    </div>
+    <div typeof="rdf:Property" resource="http://schema.org/previousOwners">
+        <span class="h" property="rdfs:label">numberOfOwners</span>
+        <span property="rdfs:comment">The number of owners of the vehicle, including the current one.&lt;br /&gt;
+    Typical unit code(s): C62</span>
+        <span>Domain: <a property="http://schema.org/domainIncludes" href="http://schema.org/Vehicle">Vehicle</a></span>
+        <span>Range: <a property="http://schema.org/rangeIncludes" href="http://schema.org/QuantitativeValue">QuantitativeValue</a></span>
+        <span>Range: <a property="http://schema.org/rangeIncludes" href="http://schema.org/Number">Number</a></span>
+        <span>Source:  <a property="dc:source" href="http://www.w3.org/wiki/WebSchemas/SchemaDotOrgSources#Automotive_Ontology_Working_Group">GAO</a></span>
+    </div>
+    <div typeof="rdf:Property" resource="http://schema.org/roofLoad">
+        <span class="h" property="rdfs:label">roofLoad</span>
+        <span property="rdfs:comment">The permited total weight of cargo and installations (e.g. a roof rack) on top of the vehicle.&lt;br /&gt;
+    Typical unit code(s): KGM for kilogram, LBR for pound&lt;br /&gt;
+    
+    Note 1: You can indicate additional information in the rdfs:label of the &lt;a href=&quot;QuantitativeValue&quot;&gt;QuantitativeValue&lt;/a&gt; node.&lt;br /&gt;
+    Note 2: You may also link to a &lt;a href=&quot;QualitativeValue&quot;&gt;QualitativeValue&lt;/a&gt; node that provides additional information using &lt;a href=&quot;valueReference&quot;&gt;valueReference&lt;/a&gt;.&lt;br /&gt;
+    Note 3: Note that you can use &lt;a href=&quot;minValue&quot;&gt;minValue&lt;/a&gt; and &lt;a href=&quot;maxValue&quot;&gt;maxValue&lt;/a&gt; to indicate ranges.</span>
+        <span>Domain: <a property="http://schema.org/domainIncludes" href="http://schema.org/MotorizedRoadVehicle">MotorizedRoadVehicle</a></span>
+        <span>Range: <a property="http://schema.org/rangeIncludes" href="http://schema.org/QuantitativeValue">QuantitativeValue</a></span>
+        <span>Source:  <a property="dc:source" href="http://www.w3.org/wiki/WebSchemas/SchemaDotOrgSources#Automotive_Ontology_Working_Group">GAO</a></span>
+    </div>
+    <div typeof="rdf:Property" resource="http://schema.org/fuelConsumption">
+        <span class="h" property="rdfs:label">fuelConsumption</span>
+        <span property="rdfs:comment">The amount of fuel consumed for traveling a particular distance or temporal duration with the given vehicle (e.g. liters per 100 km).&lt;br /&gt;
+    Typical unit code(s): LTR for liters, GLL of US Gallons, GLI for UK / Imperial Gallons&lt;br /&gt;
+        
+    Note 1: There are unfortunately no standard unit codes for "liters per 100 km". Simply use "LTR" for liters, "GLL" of US Gallons, or "GLI" for UK / Imperial Gallons, and indicate the distance in the rdfs:label of the &lt;a href=&quot;QuantitativeValue&quot;&gt;QuantitativeValue&lt;/a&gt; or use &lt;a href=&quot;valueReference&quot;&gt;valueReference&lt;/a&gt; to model the reference distance (e.g. 100 km). &lt;br /&gt;
+    Note 2: There are two ways of indicating the fuel consumption, &lt;a href=&quot;fuelConsumption&quot;&gt;fuelConsumption&lt;/a&gt; (e.g. 8 liters per 100 km) and &lt;a href=&quot;fuelEfficiency&quot;&gt;fuelEfficiency&lt;/a&gt; (e.g. 30 miles per gallon). They are reciprocal.&lt;br /&gt;
+    Note 3: Often, the absolute value is useful only when related to driving speed ("at 80 km/h") or usage pattern ("city traffic"). You can use &lt;a href=&quot;valueReference&quot;&gt;valueReference&lt;/a&gt; to link the value for the fuel consumption to another value.</span>
+        <span>Domain: <a property="http://schema.org/domainIncludes" href="http://schema.org/MotorizedRoadVehicle">MotorizedRoadVehicle</a></span>
+        <span>Domain: <a property="http://schema.org/domainIncludes" href="http://schema.org/MotorBoat">MotorBoat</a></span>    
+        <span>Range: <a property="http://schema.org/rangeIncludes" href="http://schema.org/QuantitativeValue">QuantitativeValue</a></span>
+        <span>Source:  <a property="dc:source" href="http://www.w3.org/wiki/WebSchemas/SchemaDotOrgSources#Automotive_Ontology_Working_Group">GAO</a></span>
+    </div>
+    <div typeof="rdf:Property" resource="http://schema.org/cargoVolume">
+        <span class="h" property="rdfs:label">cargoVolume</span>
+        <span property="rdfs:comment">The available volume for cargo or luggage. For automobiles, this is usually the trunk space.&lt;br /&gt;
+    Typical unit code(s): LTR for liters, FTQ for cubic foot/feet&lt;br /&gt;
+    
+    Note: You can use &lt;a href=&quot;minValue&quot;&gt;minValue&lt;/a&gt; and &lt;a href=&quot;maxValue&quot;&gt;maxValue&lt;/a&gt; to indicate ranges.</span>
+        <span>Domain: <a property="http://schema.org/domainIncludes" href="http://schema.org/MotorizedRoadVehicle">MotorizedRoadVehicle</a></span>
+        <span>Domain: <a property="http://schema.org/domainIncludes" href="http://schema.org/Watercraft">Watercraft</a></span>  
+        <span>Range: <a property="http://schema.org/rangeIncludes" href="http://schema.org/QuantitativeValue">QuantitativeValue</a></span>
+        <span>Source:  <a property="dc:source" href="http://www.w3.org/wiki/WebSchemas/SchemaDotOrgSources#Automotive_Ontology_Working_Group">GAO</a></span>
+    </div>
+    <div typeof="rdf:Property" resource="http://schema.org/driveWheelConfiguration">
+        <span class="h" property="rdfs:label">driveWheelConfiguration</span>
+        <span property="rdfs:comment">The drive wheel configuration, i.e. which roadwheels will receive torque from the vehicle's engine via the drivetrain.</span>
+        <span>Domain: <a property="http://schema.org/domainIncludes" href="http://schema.org/MotorizedRoadVehicle">MotorizedRoadVehicle</a></span>
+        <span>Range: <a property="http://schema.org/rangeIncludes" href="http://schema.org/DriveWheelConfigurationValue">DriveWheelConfigurationValue</a></span>
+        <span>Range: <a property="http://schema.org/rangeIncludes" href="http://schema.org/Text">Text</a></span>
+        <span>Source:  <a property="dc:source" href="http://www.w3.org/wiki/WebSchemas/SchemaDotOrgSources#Automotive_Ontology_Working_Group">GAO</a></span>
+    </div>
+    <div typeof="rdf:Property" resource="http://schema.org/wheelbase">
+        <span class="h" property="rdfs:label">wheelbase</span>
+        <span property="rdfs:comment">The distance between the centers of the front and rear wheels. &lt;br /&gt;
+    Typical unit code(s): CMT for centimeters, MTR for meters, INH for inches, FOT for foot/feet</span>
+        <span>Domain: <a property="http://schema.org/domainIncludes" href="http://schema.org/MotorizedRoadVehicle">MotorizedRoadVehicle</a></span>
+        <span>Range: <a property="http://schema.org/rangeIncludes" href="http://schema.org/QuantitativeValue">QuantitativeValue</a></span>
+        <span>Source:  <a property="dc:source" href="http://www.w3.org/wiki/WebSchemas/SchemaDotOrgSources#Automotive_Ontology_Working_Group">GAO</a></span>
+    </div>
+    <div typeof="rdf:Property" resource="http://schema.org/payload">
+        <span class="h" property="rdfs:label">payload</span>
+        <span property="rdfs:comment">The permited weight of passengers and cargo, EXCLUDING the weight of the empty vehicle. &lt;br /&gt;
+    Typical unit code(s): KGM for kilogram, LBR for pound&lt;br /&gt;
+    
+    Note 1: Many databases specify the permitted TOTAL weight instead, which is the sum of &lt;a href=&quot;weight&quot;&gt;weight&lt;/a&gt; and &lt;a href=&quot;payload&quot;&gt;payload&lt;/a&gt;.&lt;br /&gt;
+    Note 2: You can indicate additional information in the &lt;a href=&quot;name&quot;&gt;name&lt;/a&gt; of the &lt;a href=&quot;QuantitativeValue&quot;&gt;QuantitativeValue&lt;/a&gt; node.&lt;br /&gt;
+    Note 3: You may also link to a &lt;a href=&quot;QualitativeValue&quot;&gt;QualitativeValue&lt;/a&gt; node that provides additional information using &lt;a href=&quot;valueReference&quot;&gt;valueReference&lt;/a&gt;.&lt;br /&gt;
+    Note 4: Note that you can use &lt;a href=&quot;minValue&quot;&gt;minValue&lt;/a&gt; and &lt;a href=&quot;maxValue&quot;&gt;maxValue&lt;/a&gt; to indicate ranges.</span>
+        <span>Domain: <a property="http://schema.org/domainIncludes" href="http://schema.org/Vehicle">Vehicle</a></span>
+        <span>Range: <a property="http://schema.org/rangeIncludes" href="http://schema.org/QuantitativeValue">QuantitativeValue</a></span>
+        <span>Source:  <a property="dc:source" href="http://www.w3.org/wiki/WebSchemas/SchemaDotOrgSources#Automotive_Ontology_Working_Group">GAO</a></span>
+    </div>
+    <div typeof="rdf:Property" resource="http://schema.org/weightTotal">
+        <span class="h" property="rdfs:label">weightTotal</span>
+        <span property="rdfs:comment">The permited total weight of the loaded vehicle, including passengers and cargo and the weight of the empty vehicle.&lt;br /&gt;
+    Typical unit code(s): KGM for kilogram, LBR for pound&lt;br /&gt;
+    
+    Note 1: You can indicate additional information in the &lt;a href=&quot;name&quot;&gt;name&lt;/a&gt; of the &lt;a href=&quot;QuantitativeValue&quot;&gt;QuantitativeValue&lt;/a&gt; node.&lt;br /&gt;
+    Note 2: You may also link to a &lt;a href=&quot;QualitativeValue&quot;&gt;QualitativeValue&lt;/a&gt; node that provides additional information using &lt;a href=&quot;valueReference&quot;&gt;valueReference&lt;/a&gt;.&lt;br /&gt;
+    Note 3: Note that you can use &lt;a href=&quot;minValue&quot;&gt;minValue&lt;/a&gt; and &lt;a href=&quot;maxValue&quot;&gt;maxValue&lt;/a&gt; to indicate ranges.</span>
+        <span>Domain: <a property="http://schema.org/domainIncludes" href="http://schema.org/Vehicle">Vehicle</a></span>
+        <span>Range: <a property="http://schema.org/rangeIncludes" href="http://schema.org/QuantitativeValue">QuantitativeValue</a></span>
+        <span>Source:  <a property="dc:source" href="http://www.w3.org/wiki/WebSchemas/SchemaDotOrgSources#Automotive_Ontology_Working_Group">GAO</a></span>
+    </div>
+    <div typeof="rdf:Property" resource="http://schema.org/transmission">
+        <span class="h" property="rdfs:label">transmission</span>
+        <span property="rdfs:comment">The type of component used for transmitting the power from a rotating power source to the wheels or propeller(s) ("gearbox" for cars).</span>
+        <span>Domain: <a property="http://schema.org/domainIncludes" href="http://schema.org/MotorizedRoadVehicle">MotorizedRoadVehicle</a></span>
+        <span>Range: <a property="http://schema.org/rangeIncludes" href="http://schema.org/TransmissionTypeValue">TransmissionTypeValue</a></span>
+        <span>Range: <a property="http://schema.org/rangeIncludes" href="http://schema.org/Text">Text</a></span>
+        <span>Source:  <a property="dc:source" href="http://www.w3.org/wiki/WebSchemas/SchemaDotOrgSources#Automotive_Ontology_Working_Group">GAO</a></span>
+    </div>
+    <div typeof="rdf:Property" resource="http://schema.org/fuelType">
+        <span class="h" property="rdfs:label">fuelType</span>
+        <span property="rdfs:comment">The type of fuel suitable for the engine or engines of the vehicle. </span>
+        <span>Domain: <a property="http://schema.org/domainIncludes" href="http://schema.org/Vehicle">Vehicle</a></span>
+        <span>Range: <a property="http://schema.org/rangeIncludes" href="http://schema.org/FuelTypeValue">FuelTypeValue</a></span>
+        <span>Range: <a property="http://schema.org/rangeIncludes" href="http://schema.org/Text">Text</a></span>
+        <span>Source:  <a property="dc:source" href="http://www.w3.org/wiki/WebSchemas/SchemaDotOrgSources#Automotive_Ontology_Working_Group">GAO</a></span>
+    </div>
+    <div typeof="rdf:Property" resource="http://schema.org/engineDisplacement">
+        <span class="h" property="rdfs:label">engineDisplacement</span>
+        <span property="rdfs:comment">The volume swept by all of the pistons inside the cylinders of an internal combustion engine in a single movement. If there are multiple engines, simply attach this property multiple times.&lt;br /&gt;
+    Typical unit code(s): CMQ for cubic centimeter, LTR for liters, INQ for cubic inches&lt;br /&gt;
+    
+    Note 1: You can link to information about how the given value has been determined using the &lt;a href=&quot;valueReference&quot;&gt;valueReference&lt;/a&gt; property.&lt;br /&gt;
+    Note 2: You can use &lt;a href=&quot;minValue&quot;&gt;minValue&lt;/a&gt; and &lt;a href=&quot;maxValue&quot;&gt;maxValue&lt;/a&gt; to indicate ranges.</span>
+        <span>Domain: <a property="http://schema.org/domainIncludes" href="http://schema.org/MotorizedRoadVehicle">MotorizedRoadVehicle</a></span>
+        <span>Domain: <a property="http://schema.org/domainIncludes" href="http://schema.org/MotorBoat">MotorBoat</a></span>    
+        <span>Range: <a property="http://schema.org/rangeIncludes" href="http://schema.org/QuantitativeValue">QuantitativeValue</a></span>
+        <span>Source:  <a property="dc:source" href="http://www.w3.org/wiki/WebSchemas/SchemaDotOrgSources#Automotive_Ontology_Working_Group">GAO</a></span>
+    </div>
+    <div typeof="rdf:Property" resource="http://schema.org/mileageFromOdometer">
+        <span class="h" property="rdfs:label">mileageFromOdometer</span>
+        <span property="rdfs:comment">The total distance travelled by the particular vehicle since its initial production, as read from its odometer.&lt;br /&gt;
+    Typical unit code(s): KMT for kilometers, SMI for statute miles</span>
+        <span>Domain: <a property="http://schema.org/domainIncludes" href="http://schema.org/MotorizedRoadVehicle">MotorizedRoadVehicle</a></span>
+        <span>Range: <a property="http://schema.org/rangeIncludes" href="http://schema.org/QuantitativeValue">QuantitativeValue</a></span>
+        <span>Source:  <a property="dc:source" href="http://www.w3.org/wiki/WebSchemas/SchemaDotOrgSources#Automotive_Ontology_Working_Group">GAO</a></span>
+    </div>
+    <div typeof="rdf:Property" resource="http://schema.org/bodyType">
+        <span class="h" property="rdfs:label">bodyType</span>
+        <span property="rdfs:comment">Indicates the design and body style of the vehicle (e.g. station wagon, hatchback, etc.).</span>
+        <span>Domain: <a property="http://schema.org/domainIncludes" href="http://schema.org/Vehicle">Vehicle</a></span>
+        <span>Range: <a property="http://schema.org/rangeIncludes" href="http://schema.org/BodyTypeValue">BodyTypeValue</a></span>
+        <span>Range: <a property="http://schema.org/rangeIncludes" href="http://schema.org/Text">Text</a></span>
+        <span>Source:  <a property="dc:source" href="http://www.w3.org/wiki/WebSchemas/SchemaDotOrgSources#Automotive_Ontology_Working_Group">GAO</a></span>
+    </div>
+    <div typeof="rdf:Property" resource="http://schema.org/tongueWeight">
+        <span class="h" property="rdfs:label">tongueWeight</span>
+        <span property="rdfs:comment">The permited vertical load (TWR) of a trailer attached to the vehicle. Also referred to as Tongue Load Rating (TLR) or Vertical Load Rating (VLR).&lt;br /&gt;
+        Typical unit code(s): KGM for kilogram, LBR for pound&lt;br /&gt;
+
+    Note 1: You can indicate additional information in the &lt;a href=&quot;name&quot;&gt;name&lt;/a&gt; of the &lt;a href=&quot;QuantitativeValue&quot;&gt;QuantitativeValue&lt;/a&gt; node.&lt;br /&gt;
+    Note 2: You may also link to a &lt;a href=&quot;QualitativeValue&quot;&gt;QualitativeValue&lt;/a&gt; node that provides additional information using &lt;a href=&quot;valueReference&quot;&gt;valueReference&lt;/a&gt;.&lt;br /&gt;
+    Note 3: Note that you can use &lt;a href=&quot;minValue&quot;&gt;minValue&lt;/a&gt; and &lt;a href=&quot;maxValue&quot;&gt;maxValue&lt;/a&gt; to indicate ranges.</span>
+        <span>Domain: <a property="http://schema.org/domainIncludes" href="http://schema.org/MotorizedRoadVehicle">MotorizedRoadVehicle</a></span>
+        <span>Range: <a property="http://schema.org/rangeIncludes" href="http://schema.org/QuantitativeValue">QuantitativeValue</a></span>
+        <span>Source:  <a property="dc:source" href="http://www.w3.org/wiki/WebSchemas/SchemaDotOrgSources#Automotive_Ontology_Working_Group">GAO</a></span>
+    </div>
+    <div typeof="rdf:Property" resource="http://schema.org/doors">
+        <span class="h" property="rdfs:label">doors</span>
+        <span property="rdfs:comment">The number of doors.&lt;br /&gt;
+    Typical unit code(s): C62</span>
+        <span>Domain: <a property="http://schema.org/domainIncludes" href="http://schema.org/MotorizedRoadVehicle">MotorizedRoadVehicle</a></span>
+        <span>Range: <a property="http://schema.org/rangeIncludes" href="http://schema.org/QuantitativeValue">QuantitativeValue</a></span>
+        <span>Range: <a property="http://schema.org/rangeIncludes" href="http://schema.org/Number">Number</a></span>
+        <span>Source:  <a property="dc:source" href="http://www.w3.org/wiki/WebSchemas/SchemaDotOrgSources#Automotive_Ontology_Working_Group">GAO</a></span>
+    </div>
+    <div typeof="rdf:Property" resource="http://schema.org/speed">
+        <span class="h" property="rdfs:label">speed</span>
+        <span property="rdfs:comment">The speed range of the vehicle. If the vehicle is powered by an engine, the upper limit of the speed range (indicated by &lt;a href=&quot;maxValue&quot;&gt;maxValue&lt;/a&gt;) should be the maximum speed achievable under regular conditions.&lt;br /&gt;
+    Typical unit code(s): KMH for km/h, HM for mile per hour (0.447 04 m/s), KNT for knot&lt;br /&gt;
+    
+    Note 1: Use &lt;a href=&quot;minValue&quot;&gt;minValue&lt;/a&gt; and &lt;a href=&quot;maxValue&quot;&gt;maxValue&lt;/a&gt; to indicate the range. Typically, the minimal value is zero.&lt;br /&gt;
+    Note 2: There are many different ways of measuring the speed range. You can link to information about how the given value has been determined using the &lt;a href=&quot;valueReference&quot;&gt;valueReference&lt;/a&gt; property.</span>
+        <span>Domain: <a property="http://schema.org/domainIncludes" href="http://schema.org/Vehicle">Vehicle</a></span>
+        <span>Range: <a property="http://schema.org/rangeIncludes" href="http://schema.org/QuantitativeValue">QuantitativeValue</a></span>
+        <span>Source:  <a property="dc:source" href="http://www.w3.org/wiki/WebSchemas/SchemaDotOrgSources#Automotive_Ontology_Working_Group">GAO</a></span>
+    </div>
+    <div typeof="rdf:Property" resource="http://schema.org/meetsEmissionStandard">
+        <span class="h" property="rdfs:label">meetsEmissionStandard</span>
+        <span property="rdfs:comment">Indicates that the vehicle meets the respective emission standard.</span>
+        <span>Domain: <a property="http://schema.org/domainIncludes" href="http://schema.org/Vehicle">Vehicle</a></span>
+        <span>Range: <a property="http://schema.org/rangeIncludes" href="http://schema.org/EmissionStandardValue">EmissionStandardValue</a></span>
+        <span>Range: <a property="http://schema.org/rangeIncludes" href="http://schema.org/Text">Text</a></span>
+        <span>Source:  <a property="dc:source" href="http://www.w3.org/wiki/WebSchemas/SchemaDotOrgSources#Automotive_Ontology_Working_Group">GAO</a></span>
+    </div>
+    <div typeof="rdf:Property" resource="http://schema.org/fuelEfficiency">
+        <span class="h" property="rdfs:label">fuelEfficiency</span>
+        <span property="rdfs:comment">The distance traveled per unit of fuel used; most commonly miles per gallon (mpg) or kilometers per liter (km/L).&lt;br /&gt;
+    Typical unit code(s): KMT for kilometers, SMI for statute miles&lt;br /&gt;
+    
+    Note 1: There are unfortunately no standard unit codes for miles per gallon or kilometers per liter.&lt;br /&gt;
+    Simply use "SMI" for statute miles (common miles in the US and UK) or "KMT" for kilometers, and indicate 
+    the fuel amount of reference in the &lt;a href=&quot;name&quot;&gt;name&lt;/a&gt; of the &lt;a href=&quot;QuantitativeValue&quot;&gt;QuantitativeValue&lt;/a&gt;, or use &lt;a href=&quot;valueReference&quot;&gt;valueReference&lt;/a&gt; to point to the reference fuel quantity, e.g. one liter, one US Gallon, or one British Gallon.&lt;br /&gt;
+    Note 2: In the absence of a a reference fuel quantity one may assume that the quantity of reference is one gallon for distances given in miles and one liter for distances given in kilometers. However, note that the original unit may be obscured by unit conversion services, so this heuristic is far from perfect.
+    Note 3: There are two ways of indicating the fuel consumption, &lt;a href=&quot;fuelConsumption&quot;&gt;fuelConsumption&lt;/a&gt; (e.g. 8 liters per 100 km) and &lt;a href=&quot;fuelEfficiency&quot;&gt;fuelEfficiency&lt;/a&gt; (e.g. 30 miles per gallon). They are reciprocal.&lt;br /&gt;
+    Note 4: Often, the absolute value is useful only when related to driving speed ("at 80 km/h") or usage pattern ("city traffic"). You can use &lt;a href=&quot;valueReference&quot;&gt;valueReference&lt;/a&gt; to link the value for the fuel economy to another value.</span>
+        <span>Domain: <a property="http://schema.org/domainIncludes" href="http://schema.org/MotorizedRoadVehicle">MotorizedRoadVehicle</a></span>
+        <span>Domain: <a property="http://schema.org/domainIncludes" href="http://schema.org/MotorBoat">MotorBoat</a></span>
+        <span>Range: <a property="http://schema.org/rangeIncludes" href="http://schema.org/QuantitativeValue">QuantitativeValue</a></span>
+        <span>Source:  <a property="dc:source" href="http://www.w3.org/wiki/WebSchemas/SchemaDotOrgSources#Automotive_Ontology_Working_Group">GAO</a></span>
+    </div>
+    <div typeof="rdf:Property" resource="http://schema.org/gears">
+        <span class="h" property="rdfs:label">gears</span>
+        <span property="rdfs:comment">The total number of forward and reverse gears available for the transmission system of the vehicle.&lt;br /&gt;
+    Typical unit code(s): C62</span>
+        <span>Domain: <a property="http://schema.org/domainIncludes" href="http://schema.org/Vehicle">Vehicle</a></span>
+        <span>Range: <a property="http://schema.org/rangeIncludes" href="http://schema.org/QuantitativeValue">QuantitativeValue</a></span>
+        <span>Range: <a property="http://schema.org/rangeIncludes" href="http://schema.org/Number">Number</a></span>
+        <span>Source:  <a property="dc:source" href="http://www.w3.org/wiki/WebSchemas/SchemaDotOrgSources#Automotive_Ontology_Working_Group">GAO</a></span>
+    </div>
+    <div typeof="rdf:Property" resource="http://schema.org/axles">
+        <span class="h" property="rdfs:label">axles</span>
+        <span property="rdfs:comment">The number of axles.&lt;br /&gt;
+    Typical unit code(s): C62</span>
+        <span>Domain: <a property="http://schema.org/domainIncludes" href="http://schema.org/MotorizedRoadVehicle">MotorizedRoadVehicle</a></span>
+        <span>Range: <a property="http://schema.org/rangeIncludes" href="http://schema.org/QuantitativeValue">QuantitativeValue</a></span>
+        <span>Range: <a property="http://schema.org/rangeIncludes" href="http://schema.org/Number">Number</a></span>
+        <span>Source:  <a property="dc:source" href="http://www.w3.org/wiki/WebSchemas/SchemaDotOrgSources#Automotive_Ontology_Working_Group">GAO</a></span>
+    </div>
+    <div typeof="rdf:Property" resource="http://schema.org/engineType">
+        <span class="h" property="rdfs:label">engineType</span>
+        <span property="rdfs:comment">The type of engine or engines powering the vehicle. If there are multiple engines, simply attach this property multiple times.</span>
+        <span>Domain: <a property="http://schema.org/domainIncludes" href="http://schema.org/MotorizedRoadVehicle">MotorizedRoadVehicle</a></span>
+        <span>Domain: <a property="http://schema.org/domainIncludes" href="http://schema.org/MotorBoat">MotorBoat</a></span>
+        <span>Range: <a property="http://schema.org/rangeIncludes" href="http://schema.org/EngineTypeValue">EngineTypeValue</a></span>
+        <span>Range: <a property="http://schema.org/rangeIncludes" href="http://schema.org/Text">Text</a></span>
+        <span>Source:  <a property="dc:source" href="http://www.w3.org/wiki/WebSchemas/SchemaDotOrgSources#Automotive_Ontology_Working_Group">GAO</a></span>
+    </div>
+    <div typeof="rdf:Property" resource="http://schema.org/seatingCapacity">
+        <span class="h" property="rdfs:label">seatingCapacity</span>
+        <span property="rdfs:comment">The number of passengers that can be seated in the vehicle, both in terms of the physical space available, and in terms of limitations set by law.&lt;br /&gt;
+    Typical unit code(s): C62 for persons </span>
+        <span>Domain: <a property="http://schema.org/domainIncludes" href="http://schema.org/Vehicle">Vehicle</a></span>
+        <span>Range: <a property="http://schema.org/rangeIncludes" href="http://schema.org/QuantitativeValue">QuantitativeValue</a></span>
+        <span>Range: <a property="http://schema.org/rangeIncludes" href="http://schema.org/Number">Number</a></span>
+        <span>Source:  <a property="dc:source" href="http://www.w3.org/wiki/WebSchemas/SchemaDotOrgSources#Automotive_Ontology_Working_Group">GAO</a></span>
+    </div>
+    <div typeof="rdf:Property" resource="http://schema.org/trailerWeight">
+        <span class="h" property="rdfs:label">trailerWeight</span>
+        <span property="rdfs:comment">The permited weight of a trailer attached to the vehicle.&lt;br /&gt;
+    Typical unit code(s): KGM for kilogram, LBR for pound&lt;br /&gt;
+
+    Note 1: You can indicate additional information in the &lt;a href=&quot;name&quot;&gt;name&lt;/a&gt; of the &lt;a href=&quot;QuantitativeValue&quot;&gt;QuantitativeValue&lt;/a&gt; node.&lt;br /&gt;
+    Note 2: You may also link to a &lt;a href=&quot;QualitativeValue&quot;&gt;QualitativeValue&lt;/a&gt; node that provides additional information using &lt;a href=&quot;valueReference&quot;&gt;valueReference&lt;/a&gt;.&lt;br /&gt;
+    Note 3: Note that you can use &lt;a href=&quot;minValue&quot;&gt;minValue&lt;/a&gt; and &lt;a href=&quot;maxValue&quot;&gt;maxValue&lt;/a&gt; to indicate ranges.</span>
+        <span>Domain: <a property="http://schema.org/domainIncludes" href="http://schema.org/MotorizedRoadVehicle">MotorizedRoadVehicle</a></span>
+        <span>Range: <a property="http://schema.org/rangeIncludes" href="http://schema.org/QuantitativeValue">QuantitativeValue</a></span>
+        <span>Source:  <a property="dc:source" href="http://www.w3.org/wiki/WebSchemas/SchemaDotOrgSources#Automotive_Ontology_Working_Group">GAO</a></span>
+    </div>
+    <div typeof="rdf:Property" resource="http://schema.org/acceleration">
+        <span class="h" property="rdfs:label">acceleration</span>
+        <span property="rdfs:comment">The time needed to accelerate the vehicle from a given start velocity to a given target velocity.&lt;br /&gt;
+    Typical unit code(s): SEC for seconds&lt;br /&gt;
+
+    Note: There are unfortunately no standard unit codes for seconds/0..100 km/h or seconds/0..60 mph. Simply use "SEC" for seconds and indicate the velocities in the &lt;a href=&quot;name&quot;&gt;name&lt;/a&gt; of the &lt;a href=&quot;QuantitativeValue&quot;&gt;QuantitativeValue&lt;/a&gt;, or use &lt;a href=&quot;valueReference&quot;&gt;valueReference&lt;/a&gt; with a &lt;a href=&quot;QuantitativeValue&quot;&gt;QuantitativeValue&lt;/a&gt; of 0..60 mph or 0..100 km/h to specify the reference speeds.</span>
+        <span>Domain: <a property="http://schema.org/domainIncludes" href="http://schema.org/MotorizedRoadVehicle">MotorizedRoadVehicle</a></span>
+        <span>Domain: <a property="http://schema.org/domainIncludes" href="http://schema.org/MotorBoat">MotorBoat</a></span>    
+        <span>Range: <a property="http://schema.org/rangeIncludes" href="http://schema.org/QuantitativeValue">QuantitativeValue</a></span>
+        <span>Source:  <a property="dc:source" href="http://www.w3.org/wiki/WebSchemas/SchemaDotOrgSources#Automotive_Ontology_Working_Group">GAO</a></span>
+    </div>
+    <div typeof="rdf:Property" resource="http://schema.org/enginePower">
+        <span class="h" property="rdfs:label">enginePower</span>
+        <span property="rdfs:comment">The power of the vehicle's engine. If there are multiple engines, simply attach this property multiple times.&lt;br /&gt;
+    Typical unit code(s): KWT for kilowatt&lt;br /&gt;
+    
+    Note 1: There are many different ways of measuring an engine's power. For an overview, see  http://en.wikipedia.org/wiki/Horsepower#Engine_power_test_codes. &lt;br /&gt;
+    Note 2: You can link to information about how the given value has been determined using the &lt;a href=&quot;valueReference&quot;&gt;valueReference&lt;/a&gt; property.&lt;br /&gt;
+    Note 3: You can use &lt;a href=&quot;minValue&quot;&gt;minValue&lt;/a&gt; and &lt;a href=&quot;maxValue&quot;&gt;maxValue&lt;/a&gt; to indicate ranges.</span>
+        <span>Domain: <a property="http://schema.org/domainIncludes" href="http://schema.org/MotorizedRoadVehicle">MotorizedRoadVehicle</a></span>
+        <span>Domain: <a property="http://schema.org/domainIncludes" href="http://schema.org/MotorBoat">MotorBoat</a></span>    
+        <span>Range: <a property="http://schema.org/rangeIncludes" href="http://schema.org/QuantitativeValue">QuantitativeValue</a></span>
+        <span>Source:  <a property="dc:source" href="http://www.w3.org/wiki/WebSchemas/SchemaDotOrgSources#Automotive_Ontology_Working_Group">GAO</a></span>
+    </div>
+    <div typeof="rdf:Property" resource="http://schema.org/productionDate">
+        <span class="h" property="rdfs:label">productionDate</span>
+        <span property="rdfs:comment">The date of production of the vehicle.</span>
+        <span>Domain: <a property="http://schema.org/domainIncludes" href="http://schema.org/Vehicle">Vehicle</a></span>
+        <span>Range: <a property="http://schema.org/rangeIncludes" href="http://schema.org/Date">Date</a></span>
+        <span>Source:  <a property="dc:source" href="http://www.w3.org/wiki/WebSchemas/SchemaDotOrgSources#Automotive_Ontology_Working_Group">GAO</a></span>
+    </div>
+    <div typeof="rdf:Property" resource="http://schema.org/purchasingDate">
+        <span class="h" property="rdfs:label">purchasingDate</span>
+        <span property="rdfs:comment">The date the vehicle was purchased by the current owner.</span>
+        <span>Domain: <a property="http://schema.org/domainIncludes" href="http://schema.org/Vehicle">Vehicle</a></span>
+        <span>Range: <a property="http://schema.org/rangeIncludes" href="http://schema.org/Date">Date</a></span>
+        <span>Source:  <a property="dc:source" href="http://www.w3.org/wiki/WebSchemas/SchemaDotOrgSources#Automotive_Ontology_Working_Group">GAO</a></span>
+    </div>
+    <div typeof="rdf:Property" resource="http://schema.org/specialUsage">
+        <span class="h" property="rdfs:label">specialUsage</span>
+        <span property="rdfs:comment">Indicates whether the vehicle has been used for special purposes, like commercial rental, driving school, or as a taxi. The legislation in many countries requires this information to be revealed when offering a car for sale. 
+    </span>
+        <span>Domain: <a property="http://schema.org/domainIncludes" href="http://schema.org/Vehicle">Vehicle</a></span>
+        <span>Range: <a property="http://schema.org/rangeIncludes" href="http://schema.org/Text">Text</a></span>
+        <span>Range: <a property="http://schema.org/rangeIncludes" href="http://schema.org/CarUsageType">CarUsageType</a></span>
+        <span>Source:  <a property="dc:source" href="http://www.w3.org/wiki/WebSchemas/SchemaDotOrgSources#Automotive_Ontology_Working_Group">GAO</a></span>
+    </div>
+    <div typeof="rdf:Property" resource="http://schema.org/damages">
+        <span class="h" property="rdfs:label">damages</span>
+        <span property="rdfs:comment">A textual description of known damages, both repaired and unrepaired.</span>
+        <span>Domain: <a property="http://schema.org/domainIncludes" href="http://schema.org/Vehicle">Vehicle</a></span>
+        <span>Range: <a property="http://schema.org/rangeIncludes" href="http://schema.org/Text">Text</a></span>
+        <span>Source:  <a property="dc:source" href="http://www.w3.org/wiki/WebSchemas/SchemaDotOrgSources#Automotive_Ontology_Working_Group">GAO</a></span>
+    </div>
+    <div typeof="rdf:Property" resource="http://schema.org/firstRegistration">
+        <span class="h" property="rdfs:label">firstRegistration</span>
+        <span property="rdfs:comment">The date of the first registration of the vehicle with the respective public authorities.</span>
+        <span>Domain: <a property="http://schema.org/domainIncludes" href="http://schema.org/Vehicle">Vehicle</a></span>
+        <span>Range: <a property="http://schema.org/rangeIncludes" href="http://schema.org/Date">Date</a></span>
+        <span>Source:  <a property="dc:source" href="http://www.w3.org/wiki/WebSchemas/SchemaDotOrgSources#Automotive_Ontology_Working_Group">GAO</a></span>
+    </div>
+    <div typeof="rdf:Property" resource="http://schema.org/engineName">
+        <span class="h" property="rdfs:label">engineName</span>
+        <span property="rdfs:comment">A short text indicating the engine(s) of the vehicle.</span>
+        <span>Domain: <a property="http://schema.org/domainIncludes" href="http://schema.org/MotorizedRoadVehicle">MotorizedRoadVehicle</a></span>
+        <span>Domain: <a property="http://schema.org/domainIncludes" href="http://schema.org/MotorBoat">MotorBoat</a></span>    
+        <span>Range: <a property="http://schema.org/rangeIncludes" href="http://schema.org/Text">Text</a></span>
+        <span>Source:  <a property="dc:source" href="http://www.w3.org/wiki/WebSchemas/SchemaDotOrgSources#Automotive_Ontology_Working_Group">GAO</a></span>
+    </div>
+    <div typeof="rdf:Property" resource="http://schema.org/configurationName">
+        <span class="h" property="rdfs:label">configurationName</span>
+        <span property="rdfs:comment">A short text indicating the configuration of the vehicle, e.g. &apos;5dr hatchback ST 2.5 MT 225 hp&apos; or &apos;limited edition&apos;.</span>
+        <span>Domain: <a property="http://schema.org/domainIncludes" href="http://schema.org/MotorizedRoadVehicle">MotorizedRoadVehicle</a></span>
+        <span>Domain: <a property="http://schema.org/domainIncludes" href="http://schema.org/MotorBoat">MotorBoat</a></span>    
+        <span>Range: <a property="http://schema.org/rangeIncludes" href="http://schema.org/Text">Text</a></span>
+        <span>Source:  <a property="dc:source" href="http://www.w3.org/wiki/WebSchemas/SchemaDotOrgSources#Automotive_Ontology_Working_Group">GAO</a></span>
+    </div>
+    <div typeof="rdf:Property" resource="http://schema.org/ACRISSCode">
+        <span class="h" property="rdfs:label">ACRISSCode</span>
+        <span property="rdfs:comment">The ACRISS Car Classification Code is a code used by many car rental companies, for classifying vehicles. ACRISS stands for Association of Car Rental Industry Systems and Standards.</span>
+        <span>Domain: <a property="http://schema.org/domainIncludes" href="http://schema.org/MotorizedRoadVehicle">MotorizedRoadVehicle</a></span>
+        <span>Range: <a property="http://schema.org/rangeIncludes" href="http://schema.org/Text">Text</a></span>
+        <span>Source:  <a property="dc:source" href="http://www.w3.org/wiki/WebSchemas/SchemaDotOrgSources#Automotive_Ontology_Working_Group">GAO</a></span>
+    </div>
+    <div typeof="rdf:Property" resource="http://schema.org/VIN">
+        <span class="h" property="rdfs:label">VIN</span>
+        <span property="rdfs:comment">The Vehicle Identification Number (VIN) is a unique serial number used by the automotive industry to identify individual motor vehicles.</span>
+         <link property="rdfs:subPropertyOf" href="http://schema.org/serialNumber" />
+        <span>Domain: <a property="http://schema.org/domainIncludes" href="http://schema.org/MotorizedRoadVehicle">MotorizedRoadVehicle</a></span>
+        <span>Range: <a property="http://schema.org/rangeIncludes" href="http://schema.org/Text">Text</a></span>
+        <span>Source:  <a property="dc:source" href="http://www.w3.org/wiki/WebSchemas/SchemaDotOrgSources#Automotive_Ontology_Working_Group">GAO</a></span>
+    </div>
+    <div typeof="rdf:Property" resource="http://schema.org/modelDate">
+        <span class="h" property="rdfs:label">modelDate</span>
+        <span property="rdfs:comment">The release date of a vehicle model (often used to differentiate versions of the same make and model).</span>
+        <span>Domain: <a property="http://schema.org/domainIncludes" href="http://schema.org/Vehicle">Vehicle</a></span>
+        <span>Range: <a property="http://schema.org/rangeIncludes" href="http://schema.org/Date">Date</a></span>
+        <span>Source:  <a property="dc:source" href="http://www.w3.org/wiki/WebSchemas/SchemaDotOrgSources#Automotive_Ontology_Working_Group">GAO</a></span>
+    </div>
+    <div typeof="rdf:Property" resource="http://schema.org/colorInterior">
+        <span class="h" property="rdfs:label">colorInterior</span>
+        <span property="rdfs:comment">The color or color combination of the interior of the vehicle.</span>
+        <span>Domain: <a property="http://schema.org/domainIncludes" href="http://schema.org/Vehicle">Vehicle</a></span>
+        <span>Range: <a property="http://schema.org/rangeIncludes" href="http://schema.org/Text">Text</a></span>
+        <span>Source:  <a property="dc:source" href="http://www.w3.org/wiki/WebSchemas/SchemaDotOrgSources#Automotive_Ontology_Working_Group">GAO</a></span>
+    </div>
+    <div typeof="rdf:Property" resource="http://schema.org/interiorType">
+        <span class="h" property="rdfs:label">interiorType</span>
+        <span property="rdfs:comment">The type or material of the interior of the vehicle (e.g. synthetic fabric, leather, wood, etc.)</span>
+        <span>Domain: <a property="http://schema.org/domainIncludes" href="http://schema.org/Vehicle">Vehicle</a></span>
+        <span>Range: <a property="http://schema.org/rangeIncludes" href="http://schema.org/Text">Text</a></span>
+        <span>Source:  <a property="dc:source" href="http://www.w3.org/wiki/WebSchemas/SchemaDotOrgSources#Automotive_Ontology_Working_Group">GAO</a></span>
+    </div>
+    <div typeof="rdf:Property" resource="http://schema.org/airbags">
+        <span class="h" property="rdfs:label">airbags</span>
+        <span property="rdfs:comment">The number or type of airbags in the vehicle.</span>
+        <span>Domain: <a property="http://schema.org/domainIncludes" href="http://schema.org/MotorizedRoadVehicle">MotorizedRoadVehicle</a></span>
+        <span>Range: <a property="http://schema.org/rangeIncludes" href="http://schema.org/Number">Number</a></span>
+        <span>Range: <a property="http://schema.org/rangeIncludes" href="http://schema.org/Text">Text</a></span>
+        <span>Source:  <a property="dc:source" href="http://www.w3.org/wiki/WebSchemas/SchemaDotOrgSources#Automotive_Ontology_Working_Group">GAO</a></span>
+    </div>
+    <div typeof="rdf:Property" resource="http://schema.org/torque">
+        <span class="h" property="rdfs:label">torque</span>
+        <span property="rdfs:comment">The torque (turning force) of the vehicle's engine.&lt;br /&gt;
+        Typical unit code(s): NU for newton metre (N m), F17 for pound-force per foot, or F48 for pound-force per inch&lt;br /&gt;
+    
+    Note 1: You can link to information about how the given value has been determined (e.g. reference RPM) using the &lt;a href=&quot;valueReference&quot;&gt;valueReference&lt;/a&gt; property.&lt;br /&gt;
+    Note 2: You can use &lt;a href=&quot;minValue&quot;&gt;minValue&lt;/a&gt; and &lt;a href=&quot;maxValue&quot;&gt;maxValue&lt;/a&gt; to indicate ranges.</span>
+        <span>Domain: <a property="http://schema.org/domainIncludes" href="http://schema.org/MotorizedRoadVehicle">MotorizedRoadVehicle</a></span>
+        <span>Domain: <a property="http://schema.org/domainIncludes" href="http://schema.org/MotorBoat">MotorBoat</a></span>    
+        <span>Range: <a property="http://schema.org/rangeIncludes" href="http://schema.org/QuantitativeValue">QuantitativeValue</a></span>
+        <span>Source:  <a property="dc:source" href="http://www.w3.org/wiki/WebSchemas/SchemaDotOrgSources#Automotive_Ontology_Working_Group">GAO</a></span>
+    </div>
+    <div typeof="rdf:Property" resource="http://schema.org/emissionsCO2">
+        <span class="h" property="rdfs:label">emissionsCO2</span>
+        <span property="rdfs:comment">The CO2 emissions in g/km. The property uses a number instead of a QuantitativeValue, since g/km is the dominant unit of measurement, and there is no UNCEFACT Common Code for g/km.</span>
+        <span>Domain: <a property="http://schema.org/domainIncludes" href="http://schema.org/MotorizedRoadVehicle">MotorizedRoadVehicle</a></span>
+        <span>Range: <a property="http://schema.org/rangeIncludes" href="http://schema.org/Number">Number</a></span>
+        <span>Source:  <a property="dc:source" href="http://www.w3.org/wiki/WebSchemas/SchemaDotOrgSources#Automotive_Ontology_Working_Group">GAO</a></span>
+    </div>
+    <div typeof="http://schema.org/SteeringPositionValue" resource="http://schema.org/RightHandDriving">
+      <span class="h" property="rdfs:label">RightHandDriving</span>
+      <span property="rdfs:comment">The steering position is on the right side of the vehicle (viewed from the main direction of driving).</span>
+      <span>Source:  <a property="dc:source" href="http://www.w3.org/wiki/WebSchemas/SchemaDotOrgSources#Automotive_Ontology_Working_Group">GAO</a></span>
+    </div>
+    <div typeof="http://schema.org/SteeringPositionValue" resource="http://schema.org/LeftHandDriving">
+      <span class="h" property="rdfs:label">LeftHandDriving</span>
+      <span property="rdfs:comment">The steering position is on the left side of the vehicle (viewed from the main direction of driving).</span>
+      <span>Source:  <a property="dc:source" href="http://www.w3.org/wiki/WebSchemas/SchemaDotOrgSources#Automotive_Ontology_Working_Group">GAO</a></span>
+    </div>
+    <div typeof="http://schema.org/DriveWheelConfigurationValue" resource="http://schema.org/4WD">
+      <span class="h" property="rdfs:label">4WD</span>
+      <span property="rdfs:comment">Four-wheel drive is a transmission layout where the engine primarily drives two wheels with a part-time four-wheel drive capability.</span>
+      <span>Source:  <a property="dc:source" href="http://www.w3.org/wiki/WebSchemas/SchemaDotOrgSources#Automotive_Ontology_Working_Group">GAO</a></span>
+    </div>
+    <div typeof="http://schema.org/DriveWheelConfigurationValue" resource="http://schema.org/AWD">
+      <span class="h" property="rdfs:label">AWD</span>
+      <span property="rdfs:comment">All-wheel Drive is a transmission layout where the engine drives all four wheels.</span>
+      <span>Source:  <a property="dc:source" href="http://www.w3.org/wiki/WebSchemas/SchemaDotOrgSources#Automotive_Ontology_Working_Group">GAO</a></span>
+    </div>
+    <div typeof="http://schema.org/DriveWheelConfigurationValue" resource="http://schema.org/FWD">
+      <span class="h" property="rdfs:label">FWD</span>
+      <span property="rdfs:comment">Front-wheel drive is a transmission layout where the engine drives the front wheels.</span>
+      <span>Source:  <a property="dc:source" href="http://www.w3.org/wiki/WebSchemas/SchemaDotOrgSources#Automotive_Ontology_Working_Group">GAO</a></span>
+    </div>
+    <div typeof="http://schema.org/DriveWheelConfigurationValue" resource="http://schema.org/RWD">
+      <span class="h" property="rdfs:label">RWD</span>
+      <span property="rdfs:comment">Real-wheel drive is a transmission layout where the engine drives the rear wheels.</span>
+      <span>Source:  <a property="dc:source" href="http://www.w3.org/wiki/WebSchemas/SchemaDotOrgSources#Automotive_Ontology_Working_Group">GAO</a></span>
+    </div>
+    <div typeof="http://schema.org/CarUsageType" resource="http://schema.org/RentalUsage">
+      <span class="h" property="rdfs:label">RentalUsage</span>
+      <span property="rdfs:comment">Indicates that the vehicle has been used as a rental car.</span>
+      <span>Source:  <a property="dc:source" href="http://www.w3.org/wiki/WebSchemas/SchemaDotOrgSources#Automotive_Ontology_Working_Group">GAO</a></span>
+    </div>
+    <div typeof="http://schema.org/CarUsageType" resource="http://schema.org/DrivingSchoolUsage">
+      <span class="h" property="rdfs:label">DrivingSchoolUsage</span>
+      <span property="rdfs:comment">Indicates that the vehicle has been used for driving school.</span>
+      <span>Source:  <a property="dc:source" href="http://www.w3.org/wiki/WebSchemas/SchemaDotOrgSources#Automotive_Ontology_Working_Group">GAO</a></span>
+    </div>
+    <div typeof="http://schema.org/CarUsageType" resource="http://schema.org/TaxiUsage">
+      <span class="h" property="rdfs:label">TaxiUsage</span>
+      <span property="rdfs:comment">Indicates that the vehicle has been used as taxi.</span>
+      <span>Source:  <a property="dc:source" href="http://www.w3.org/wiki/WebSchemas/SchemaDotOrgSources#Automotive_Ontology_Working_Group">GAO</a></span>
+    </div>  
+    <div typeof="http://schema.org/FuelTypeValue" resource="http://schema.org/TwoStrokeMixture">
+      <span class="h" property="rdfs:label">TwoStrokeMixture</span>
+      <span property="rdfs:comment">A pre-mixed fuel-oil mixture.</span>
+      <span>Source:  <a property="dc:source" href="http://www.w3.org/wiki/WebSchemas/SchemaDotOrgSources#Automotive_Ontology_Working_Group">GAO</a></span>
+    </div>
 
 </body>
 

--- a/data/schema.rdfa
+++ b/data/schema.rdfa
@@ -9501,7 +9501,7 @@ Note that Event uses startDate/endDate instead of startTime/endTime, even when d
     <div typeof="rdfs:Class" resource="http://schema.org/Car">
       <span class="h" property="rdfs:label">Car</span>
       <span property="rdfs:comment">A car is a wheeled, self-powered motor vehicle used for transportation.</span>      
-      <span>Subclass of: <a property="rdfs:subClassOf" href="http://schema.org/MotorizedRoadVehicle">MotorizedRoadVehicle</a></span>
+      <span>Subclass of: <a property="rdfs:subClassOf" href="http://schema.org/Vehicle">Vehicle</a></span>
     </div>
     <div typeof="rdf:Property" resource="http://schema.org/reservationId">
       <span class="h" property="rdfs:label">reservationId</span>
@@ -11333,28 +11333,28 @@ postponing for 1.6.
 
 <!-- Vehicles extension proposal, as per https://www.w3.org/wiki/WebSchemas/Vehicles -->
     <h1>Vehicles</h1>
-    <div typeof="rdfs:Class" resource="http://schema.org/MotorizedRoadVehicle">
-        <span class="h" property="rdfs:label">MotorizedRoadVehicle</span>
-        <span property="rdfs:comment">A motorized road vehicle is a wheeled land vehicle whose main propulsion is provided by an engine or motor.</span>
-        <span>Subclass of: <a property="rdfs:subClassOf" href="http://schema.org/Vehicle">Vehicle</a></span>
+    <div typeof="rdfs:Class" resource="http://schema.org/EngineSpecification">
+        <span class="h" property="rdfs:label">EngineSpecification</span>
+        <span property="rdfs:comment">Information about the engine of the vehicle. A vehicle can have multiple engines represented by multiple engine specification entities.</span>
+        <span>Subclass of: <a property="rdfs:subClassOf" href="http://schema.org/StructuredValue">StructuredValue</a></span>
         <span>Source:  <a property="dc:source" href="http://www.w3.org/wiki/WebSchemas/SchemaDotOrgSources#Automotive_Ontology_Working_Group">GAO</a></span>
     </div>
     <div typeof="rdfs:Class" resource="http://schema.org/MotorizedBicycle">
         <span class="h" property="rdfs:label">MotorizedBicycle</span>
         <span property="rdfs:comment">A motorized bicycle is a bicycle with an attached motor used to power the vehicle, or to assist with pedaling.</span>
-        <span>Subclass of: <a property="rdfs:subClassOf" href="http://schema.org/MotorizedRoadVehicle">MotorizedRoadVehicle</a></span>
+        <span>Subclass of: <a property="rdfs:subClassOf" href="http://schema.org/Vehicle">Vehicle</a></span>
         <span>Source:  <a property="dc:source" href="http://www.w3.org/wiki/WebSchemas/SchemaDotOrgSources#Automotive_Ontology_Working_Group">GAO</a></span>
     </div>
     <div typeof="rdfs:Class" resource="http://schema.org/BusOrCoach">
         <span class="h" property="rdfs:label">BusOrCoach</span>
         <span property="rdfs:comment">A bus (also omnibus or autobus) is a road vehicle designed to carry passengers. Coaches are luxury busses, usually in service for long distance travel.</span>
-        <span>Subclass of: <a property="rdfs:subClassOf" href="http://schema.org/MotorizedRoadVehicle">MotorizedRoadVehicle</a></span>
+        <span>Subclass of: <a property="rdfs:subClassOf" href="http://schema.org/Vehicle">Vehicle</a></span>
         <span>Source:  <a property="dc:source" href="http://www.w3.org/wiki/WebSchemas/SchemaDotOrgSources#Automotive_Ontology_Working_Group">GAO</a></span>
     </div>
     <div typeof="rdfs:Class" resource="http://schema.org/Motorcycle">
         <span class="h" property="rdfs:label">Motorcycle</span>
         <span property="rdfs:comment">A motorcycle or motorbike is a single-track, two-wheeled motor vehicle.</span>
-        <span>Subclass of: <a property="rdfs:subClassOf" href="http://schema.org/MotorizedRoadVehicle">MotorizedRoadVehicle</a></span>
+        <span>Subclass of: <a property="rdfs:subClassOf" href="http://schema.org/Vehicle">Vehicle</a></span>
         <span>Source:  <a property="dc:source" href="http://www.w3.org/wiki/WebSchemas/SchemaDotOrgSources#Automotive_Ontology_Working_Group">GAO</a></span>
     </div>
     <div typeof="rdfs:Class" resource="http://schema.org/SteeringPositionValue">
@@ -11378,7 +11378,7 @@ postponing for 1.6.
     <div typeof="rdf:Property" resource="http://schema.org/steeringPosition">
         <span class="h" property="rdfs:label">steeringPosition</span>
         <span property="rdfs:comment">The position of the steering wheel or similar device (mostly for cars).</span>
-        <span>Domain: <a property="http://schema.org/domainIncludes" href="http://schema.org/MotorizedRoadVehicle">MotorizedRoadVehicle</a></span>
+        <span>Domain: <a property="http://schema.org/domainIncludes" href="http://schema.org/Vehicle">Vehicle</a></span>
         <span>Range: <a property="http://schema.org/rangeIncludes" href="http://schema.org/SteeringPositionValue">SteeringPositionValue</a></span>
         <span>Source:  <a property="dc:source" href="http://www.w3.org/wiki/WebSchemas/SchemaDotOrgSources#Automotive_Ontology_Working_Group">GAO</a></span>
     </div>
@@ -11387,7 +11387,7 @@ postponing for 1.6.
         <span property="rdfs:comment">The capacity of the fuel tank or in the case of electric cars, the battery. If there are multiple components for storage, this should indicate the total of all storage of the same type.&lt;br /&gt;
     Typical unit code(s): LTR for liters, GLL of US gallons, GLI for UK / imperial gallons, AMH for ampere-hours (for electrical vehicles)
     </span>
-        <span>Domain: <a property="http://schema.org/domainIncludes" href="http://schema.org/MotorizedRoadVehicle">MotorizedRoadVehicle</a></span>
+        <span>Domain: <a property="http://schema.org/domainIncludes" href="http://schema.org/Vehicle">Vehicle</a></span>
         <span>Range: <a property="http://schema.org/rangeIncludes" href="http://schema.org/QuantitativeValue">QuantitativeValue</a></span>
         <span>Source:  <a property="dc:source" href="http://www.w3.org/wiki/WebSchemas/SchemaDotOrgSources#Automotive_Ontology_Working_Group">GAO</a></span>
     </div>
@@ -11408,7 +11408,8 @@ postponing for 1.6.
     Note 1: You can indicate additional information in the &lt;a href=&quot;name&quot;&gt;name&lt;/a&gt; of the &lt;a href=&quot;QuantitativeValue&quot;&gt;QuantitativeValue&lt;/a&gt; node.&lt;br /&gt;
     Note 2: You may also link to a &lt;a href=&quot;QualitativeValue&quot;&gt;QualitativeValue&lt;/a&gt; node that provides additional information using &lt;a href=&quot;valueReference&quot;&gt;valueReference&lt;/a&gt;.&lt;br /&gt;
     Note 3: Note that you can use &lt;a href=&quot;minValue&quot;&gt;minValue&lt;/a&gt; and &lt;a href=&quot;maxValue&quot;&gt;maxValue&lt;/a&gt; to indicate ranges.</span>
-        <span>Domain: <a property="http://schema.org/domainIncludes" href="http://schema.org/MotorizedRoadVehicle">MotorizedRoadVehicle</a></span>
+        <span>Domain: <a property="http://schema.org/domainIncludes" href="http://schema.org/Car">Car</a></span>
+        <span>Domain: <a property="http://schema.org/domainIncludes" href="http://schema.org/BusOrCoach">BusOrCoach</a></span>
         <span>Range: <a property="http://schema.org/rangeIncludes" href="http://schema.org/QuantitativeValue">QuantitativeValue</a></span>
         <span>Source:  <a property="dc:source" href="http://www.w3.org/wiki/WebSchemas/SchemaDotOrgSources#Automotive_Ontology_Working_Group">GAO</a></span>
     </div>
@@ -11419,7 +11420,7 @@ postponing for 1.6.
     Use &lt;a href=&quot;unitText&quot;&gt;unitText&lt;/a&gt; to indicate the unit of measurement, e.g. L/100 km.
     Note 2: There are two ways of indicating the fuel consumption, &lt;a href=&quot;fuelConsumption&quot;&gt;fuelConsumption&lt;/a&gt; (e.g. 8 liters per 100 km) and &lt;a href=&quot;fuelEfficiency&quot;&gt;fuelEfficiency&lt;/a&gt; (e.g. 30 miles per gallon). They are reciprocal.&lt;br /&gt;
     Note 3: Often, the absolute value is useful only when related to driving speed ("at 80 km/h") or usage pattern ("city traffic"). You can use &lt;a href=&quot;valueReference&quot;&gt;valueReference&lt;/a&gt; to link the value for the fuel consumption to another value.</span>
-        <span>Domain: <a property="http://schema.org/domainIncludes" href="http://schema.org/MotorizedRoadVehicle">MotorizedRoadVehicle</a></span>
+        <span>Domain: <a property="http://schema.org/domainIncludes" href="http://schema.org/Vehicle">Vehicle</a></span>
         <span>Range: <a property="http://schema.org/rangeIncludes" href="http://schema.org/QuantitativeValue">QuantitativeValue</a></span>
         <span>Source:  <a property="dc:source" href="http://www.w3.org/wiki/WebSchemas/SchemaDotOrgSources#Automotive_Ontology_Working_Group">GAO</a></span>
     </div>
@@ -11429,14 +11430,14 @@ postponing for 1.6.
     Typical unit code(s): LTR for liters, FTQ for cubic foot/feet&lt;br /&gt;
     
     Note: You can use &lt;a href=&quot;minValue&quot;&gt;minValue&lt;/a&gt; and &lt;a href=&quot;maxValue&quot;&gt;maxValue&lt;/a&gt; to indicate ranges.</span>
-        <span>Domain: <a property="http://schema.org/domainIncludes" href="http://schema.org/MotorizedRoadVehicle">MotorizedRoadVehicle</a></span>  
+        <span>Domain: <a property="http://schema.org/domainIncludes" href="http://schema.org/Vehicle">Vehicle</a></span>  
         <span>Range: <a property="http://schema.org/rangeIncludes" href="http://schema.org/QuantitativeValue">QuantitativeValue</a></span>
         <span>Source:  <a property="dc:source" href="http://www.w3.org/wiki/WebSchemas/SchemaDotOrgSources#Automotive_Ontology_Working_Group">GAO</a></span>
     </div>
     <div typeof="rdf:Property" resource="http://schema.org/driveWheelConfiguration">
         <span class="h" property="rdfs:label">driveWheelConfiguration</span>
         <span property="rdfs:comment">The drive wheel configuration, i.e. which roadwheels will receive torque from the vehicle's engine via the drivetrain.</span>
-        <span>Domain: <a property="http://schema.org/domainIncludes" href="http://schema.org/MotorizedRoadVehicle">MotorizedRoadVehicle</a></span>
+        <span>Domain: <a property="http://schema.org/domainIncludes" href="http://schema.org/Vehicle">Vehicle</a></span>
         <span>Range: <a property="http://schema.org/rangeIncludes" href="http://schema.org/DriveWheelConfigurationValue">DriveWheelConfigurationValue</a></span>
         <span>Range: <a property="http://schema.org/rangeIncludes" href="http://schema.org/Text">Text</a></span>
         <span>Source:  <a property="dc:source" href="http://www.w3.org/wiki/WebSchemas/SchemaDotOrgSources#Automotive_Ontology_Working_Group">GAO</a></span>
@@ -11445,7 +11446,7 @@ postponing for 1.6.
         <span class="h" property="rdfs:label">wheelbase</span>
         <span property="rdfs:comment">The distance between the centers of the front and rear wheels. &lt;br /&gt;
     Typical unit code(s): CMT for centimeters, MTR for meters, INH for inches, FOT for foot/feet</span>
-        <span>Domain: <a property="http://schema.org/domainIncludes" href="http://schema.org/MotorizedRoadVehicle">MotorizedRoadVehicle</a></span>
+        <span>Domain: <a property="http://schema.org/domainIncludes" href="http://schema.org/Vehicle">Vehicle</a></span>
         <span>Range: <a property="http://schema.org/rangeIncludes" href="http://schema.org/QuantitativeValue">QuantitativeValue</a></span>
         <span>Source:  <a property="dc:source" href="http://www.w3.org/wiki/WebSchemas/SchemaDotOrgSources#Automotive_Ontology_Working_Group">GAO</a></span>
     </div>
@@ -11477,7 +11478,7 @@ postponing for 1.6.
     <div typeof="rdf:Property" resource="http://schema.org/transmission">
         <span class="h" property="rdfs:label">transmission</span>
         <span property="rdfs:comment">The type of component used for transmitting the power from a rotating power source to the wheels or other relevant component(s) ("gearbox" for cars).</span>
-        <span>Domain: <a property="http://schema.org/domainIncludes" href="http://schema.org/MotorizedRoadVehicle">MotorizedRoadVehicle</a></span>
+        <span>Domain: <a property="http://schema.org/domainIncludes" href="http://schema.org/Vehicle">Vehicle</a></span>
         <span>Range: <a property="http://schema.org/rangeIncludes" href="http://schema.org/Text">Text</a></span>
         <span>Range: <a property="http://schema.org/rangeIncludes" href="http://schema.org/QualitativeValue">QualitativeValue</a></span>
         <span>Range: <a property="http://schema.org/rangeIncludes" href="http://schema.org/URL">URL</a></span>
@@ -11485,8 +11486,9 @@ postponing for 1.6.
     </div>
     <div typeof="rdf:Property" resource="http://schema.org/fuelType">
         <span class="h" property="rdfs:label">fuelType</span>
-        <span property="rdfs:comment">The type of fuel suitable for the engine or engines of the vehicle. </span>
-        <span>Domain: <a property="http://schema.org/domainIncludes" href="http://schema.org/MotorizedRoadVehicle">MotorizedRoadVehicle</a></span>
+        <span property="rdfs:comment">The type of fuel suitable for the engine or engines of the vehicle. If the vehicle has only one engine, this property can be attached directly to the vehicle.</span>
+        <span>Domain: <a property="http://schema.org/domainIncludes" href="http://schema.org/Vehicle">Vehicle</a></span>
+        <span>Domain: <a property="http://schema.org/domainIncludes" href="http://schema.org/EngineSpecification">EngineSpecification</a></span>
         <span>Range: <a property="http://schema.org/rangeIncludes" href="http://schema.org/Text">Text</a></span>
         <span>Range: <a property="http://schema.org/rangeIncludes" href="http://schema.org/QualitativeValue">QualitativeValue</a></span>
         <span>Range: <a property="http://schema.org/rangeIncludes" href="http://schema.org/URL">URL</a></span>	
@@ -11494,12 +11496,12 @@ postponing for 1.6.
     </div>
     <div typeof="rdf:Property" resource="http://schema.org/engineDisplacement">
         <span class="h" property="rdfs:label">engineDisplacement</span>
-        <span property="rdfs:comment">The volume swept by all of the pistons inside the cylinders of an internal combustion engine in a single movement. If there are multiple engines, simply attach this property multiple times.&lt;br /&gt;
+        <span property="rdfs:comment">The volume swept by all of the pistons inside the cylinders of an internal combustion engine in a single movement. &lt;br /&gt;
     Typical unit code(s): CMQ for cubic centimeter, LTR for liters, INQ for cubic inches&lt;br /&gt;
     
     Note 1: You can link to information about how the given value has been determined using the &lt;a href=&quot;valueReference&quot;&gt;valueReference&lt;/a&gt; property.&lt;br /&gt;
     Note 2: You can use &lt;a href=&quot;minValue&quot;&gt;minValue&lt;/a&gt; and &lt;a href=&quot;maxValue&quot;&gt;maxValue&lt;/a&gt; to indicate ranges.</span>
-        <span>Domain: <a property="http://schema.org/domainIncludes" href="http://schema.org/MotorizedRoadVehicle">MotorizedRoadVehicle</a></span> 
+        <span>Domain: <a property="http://schema.org/domainIncludes" href="http://schema.org/EngineSpecification">EngineSpecification</a></span> 
         <span>Range: <a property="http://schema.org/rangeIncludes" href="http://schema.org/QuantitativeValue">QuantitativeValue</a></span>
         <span>Source:  <a property="dc:source" href="http://www.w3.org/wiki/WebSchemas/SchemaDotOrgSources#Automotive_Ontology_Working_Group">GAO</a></span>
     </div>
@@ -11507,7 +11509,7 @@ postponing for 1.6.
         <span class="h" property="rdfs:label">mileageFromOdometer</span>
         <span property="rdfs:comment">The total distance travelled by the particular vehicle since its initial production, as read from its odometer.&lt;br /&gt;
     Typical unit code(s): KMT for kilometers, SMI for statute miles</span>
-        <span>Domain: <a property="http://schema.org/domainIncludes" href="http://schema.org/MotorizedRoadVehicle">MotorizedRoadVehicle</a></span>
+        <span>Domain: <a property="http://schema.org/domainIncludes" href="http://schema.org/Vehicle">Vehicle</a></span>
         <span>Range: <a property="http://schema.org/rangeIncludes" href="http://schema.org/QuantitativeValue">QuantitativeValue</a></span>
         <span>Source:  <a property="dc:source" href="http://www.w3.org/wiki/WebSchemas/SchemaDotOrgSources#Automotive_Ontology_Working_Group">GAO</a></span>
     </div>
@@ -11528,7 +11530,7 @@ postponing for 1.6.
     Note 1: You can indicate additional information in the &lt;a href=&quot;name&quot;&gt;name&lt;/a&gt; of the &lt;a href=&quot;QuantitativeValue&quot;&gt;QuantitativeValue&lt;/a&gt; node.&lt;br /&gt;
     Note 2: You may also link to a &lt;a href=&quot;QualitativeValue&quot;&gt;QualitativeValue&lt;/a&gt; node that provides additional information using &lt;a href=&quot;valueReference&quot;&gt;valueReference&lt;/a&gt;.&lt;br /&gt;
     Note 3: Note that you can use &lt;a href=&quot;minValue&quot;&gt;minValue&lt;/a&gt; and &lt;a href=&quot;maxValue&quot;&gt;maxValue&lt;/a&gt; to indicate ranges.</span>
-        <span>Domain: <a property="http://schema.org/domainIncludes" href="http://schema.org/MotorizedRoadVehicle">MotorizedRoadVehicle</a></span>
+        <span>Domain: <a property="http://schema.org/domainIncludes" href="http://schema.org/Vehicle">Vehicle</a></span>
         <span>Range: <a property="http://schema.org/rangeIncludes" href="http://schema.org/QuantitativeValue">QuantitativeValue</a></span>
         <span>Source:  <a property="dc:source" href="http://www.w3.org/wiki/WebSchemas/SchemaDotOrgSources#Automotive_Ontology_Working_Group">GAO</a></span>
     </div>
@@ -11536,7 +11538,7 @@ postponing for 1.6.
         <span class="h" property="rdfs:label">doors</span>
         <span property="rdfs:comment">The number of doors.&lt;br /&gt;
     Typical unit code(s): C62</span>
-        <span>Domain: <a property="http://schema.org/domainIncludes" href="http://schema.org/MotorizedRoadVehicle">MotorizedRoadVehicle</a></span>
+        <span>Domain: <a property="http://schema.org/domainIncludes" href="http://schema.org/Vehicle">Vehicle</a></span>
         <span>Range: <a property="http://schema.org/rangeIncludes" href="http://schema.org/QuantitativeValue">QuantitativeValue</a></span>
         <span>Range: <a property="http://schema.org/rangeIncludes" href="http://schema.org/Number">Number</a></span>
         <span>Source:  <a property="dc:source" href="http://www.w3.org/wiki/WebSchemas/SchemaDotOrgSources#Automotive_Ontology_Working_Group">GAO</a></span>
@@ -11568,7 +11570,7 @@ postponing for 1.6.
     Use &lt;a href=&quot;unitText&quot;&gt;unitText&lt;/a&gt; to indicate the unit of measurement, e.g. mpg or km/L.
     Note 2: There are two ways of indicating the fuel consumption, &lt;a href=&quot;fuelConsumption&quot;&gt;fuelConsumption&lt;/a&gt; (e.g. 8 liters per 100 km) and &lt;a href=&quot;fuelEfficiency&quot;&gt;fuelEfficiency&lt;/a&gt; (e.g. 30 miles per gallon). They are reciprocal.&lt;br /&gt;
     Note 3: Often, the absolute value is useful only when related to driving speed ("at 80 km/h") or usage pattern ("city traffic"). You can use &lt;a href=&quot;valueReference&quot;&gt;valueReference&lt;/a&gt; to link the value for the fuel economy to another value.</span>
-        <span>Domain: <a property="http://schema.org/domainIncludes" href="http://schema.org/MotorizedRoadVehicle">MotorizedRoadVehicle</a></span>
+        <span>Domain: <a property="http://schema.org/domainIncludes" href="http://schema.org/Vehicle">Vehicle</a></span>
         <span>Range: <a property="http://schema.org/rangeIncludes" href="http://schema.org/QuantitativeValue">QuantitativeValue</a></span>
         <span>Source:  <a property="dc:source" href="http://www.w3.org/wiki/WebSchemas/SchemaDotOrgSources#Automotive_Ontology_Working_Group">GAO</a></span>
     </div>
@@ -11585,15 +11587,15 @@ postponing for 1.6.
         <span class="h" property="rdfs:label">axles</span>
         <span property="rdfs:comment">The number of axles.&lt;br /&gt;
     Typical unit code(s): C62</span>
-        <span>Domain: <a property="http://schema.org/domainIncludes" href="http://schema.org/MotorizedRoadVehicle">MotorizedRoadVehicle</a></span>
+        <span>Domain: <a property="http://schema.org/domainIncludes" href="http://schema.org/Vehicle">Vehicle</a></span>
         <span>Range: <a property="http://schema.org/rangeIncludes" href="http://schema.org/QuantitativeValue">QuantitativeValue</a></span>
         <span>Range: <a property="http://schema.org/rangeIncludes" href="http://schema.org/Number">Number</a></span>
         <span>Source:  <a property="dc:source" href="http://www.w3.org/wiki/WebSchemas/SchemaDotOrgSources#Automotive_Ontology_Working_Group">GAO</a></span>
     </div>
     <div typeof="rdf:Property" resource="http://schema.org/engineType">
         <span class="h" property="rdfs:label">engineType</span>
-        <span property="rdfs:comment">The type of engine or engines powering the vehicle. If there are multiple engines, simply attach this property multiple times.</span>
-        <span>Domain: <a property="http://schema.org/domainIncludes" href="http://schema.org/MotorizedRoadVehicle">MotorizedRoadVehicle</a></span>
+        <span property="rdfs:comment">The type of engine or engines powering the vehicle.</span>
+        <span>Domain: <a property="http://schema.org/domainIncludes" href="http://schema.org/EngineSpecification">EngineSpecification</a></span>
         <span>Range: <a property="http://schema.org/rangeIncludes" href="http://schema.org/Text">Text</a></span>
         <span>Range: <a property="http://schema.org/rangeIncludes" href="http://schema.org/QualitativeValue">QualitativeValue</a></span>
         <span>Range: <a property="http://schema.org/rangeIncludes" href="http://schema.org/URL">URL</a></span>
@@ -11616,7 +11618,7 @@ postponing for 1.6.
     Note 1: You can indicate additional information in the &lt;a href=&quot;name&quot;&gt;name&lt;/a&gt; of the &lt;a href=&quot;QuantitativeValue&quot;&gt;QuantitativeValue&lt;/a&gt; node.&lt;br /&gt;
     Note 2: You may also link to a &lt;a href=&quot;QualitativeValue&quot;&gt;QualitativeValue&lt;/a&gt; node that provides additional information using &lt;a href=&quot;valueReference&quot;&gt;valueReference&lt;/a&gt;.&lt;br /&gt;
     Note 3: Note that you can use &lt;a href=&quot;minValue&quot;&gt;minValue&lt;/a&gt; and &lt;a href=&quot;maxValue&quot;&gt;maxValue&lt;/a&gt; to indicate ranges.</span>
-        <span>Domain: <a property="http://schema.org/domainIncludes" href="http://schema.org/MotorizedRoadVehicle">MotorizedRoadVehicle</a></span>
+        <span>Domain: <a property="http://schema.org/domainIncludes" href="http://schema.org/Vehicle">Vehicle</a></span>
         <span>Range: <a property="http://schema.org/rangeIncludes" href="http://schema.org/QuantitativeValue">QuantitativeValue</a></span>
         <span>Source:  <a property="dc:source" href="http://www.w3.org/wiki/WebSchemas/SchemaDotOrgSources#Automotive_Ontology_Working_Group">GAO</a></span>
     </div>
@@ -11626,7 +11628,7 @@ postponing for 1.6.
     Typical unit code(s): SEC for seconds&lt;br /&gt;
 
     Note: There are unfortunately no standard unit codes for seconds/0..100 km/h or seconds/0..60 mph. Simply use "SEC" for seconds and indicate the velocities in the &lt;a href=&quot;name&quot;&gt;name&lt;/a&gt; of the &lt;a href=&quot;QuantitativeValue&quot;&gt;QuantitativeValue&lt;/a&gt;, or use &lt;a href=&quot;valueReference&quot;&gt;valueReference&lt;/a&gt; with a &lt;a href=&quot;QuantitativeValue&quot;&gt;QuantitativeValue&lt;/a&gt; of 0..60 mph or 0..100 km/h to specify the reference speeds.</span>
-        <span>Domain: <a property="http://schema.org/domainIncludes" href="http://schema.org/MotorizedRoadVehicle">MotorizedRoadVehicle</a></span>
+        <span>Domain: <a property="http://schema.org/domainIncludes" href="http://schema.org/Vehicle">Vehicle</a></span>
         <span>Range: <a property="http://schema.org/rangeIncludes" href="http://schema.org/QuantitativeValue">QuantitativeValue</a></span>
         <span>Source:  <a property="dc:source" href="http://www.w3.org/wiki/WebSchemas/SchemaDotOrgSources#Automotive_Ontology_Working_Group">GAO</a></span>
     </div>
@@ -11638,7 +11640,7 @@ postponing for 1.6.
     Note 1: There are many different ways of measuring an engine's power. For an overview, see  http://en.wikipedia.org/wiki/Horsepower#Engine_power_test_codes. &lt;br /&gt;
     Note 2: You can link to information about how the given value has been determined using the &lt;a href=&quot;valueReference&quot;&gt;valueReference&lt;/a&gt; property.&lt;br /&gt;
     Note 3: You can use &lt;a href=&quot;minValue&quot;&gt;minValue&lt;/a&gt; and &lt;a href=&quot;maxValue&quot;&gt;maxValue&lt;/a&gt; to indicate ranges.</span>
-        <span>Domain: <a property="http://schema.org/domainIncludes" href="http://schema.org/MotorizedRoadVehicle">MotorizedRoadVehicle</a></span>
+        <span>Domain: <a property="http://schema.org/domainIncludes" href="http://schema.org/EngineSpecification">EngineSpecification</a></span>
         <span>Range: <a property="http://schema.org/rangeIncludes" href="http://schema.org/QuantitativeValue">QuantitativeValue</a></span>
         <span>Source:  <a property="dc:source" href="http://www.w3.org/wiki/WebSchemas/SchemaDotOrgSources#Automotive_Ontology_Working_Group">GAO</a></span>
     </div>
@@ -11679,24 +11681,25 @@ postponing for 1.6.
         <span>Range: <a property="http://schema.org/rangeIncludes" href="http://schema.org/Date">Date</a></span>
         <span>Source:  <a property="dc:source" href="http://www.w3.org/wiki/WebSchemas/SchemaDotOrgSources#Automotive_Ontology_Working_Group">GAO</a></span>
     </div>
-    <div typeof="rdf:Property" resource="http://schema.org/engineName">
-        <span class="h" property="rdfs:label">engineName</span>
-        <span property="rdfs:comment">A short text indicating the engine(s) of the vehicle.</span>
-        <span>Domain: <a property="http://schema.org/domainIncludes" href="http://schema.org/MotorizedRoadVehicle">MotorizedRoadVehicle</a></span>  
-        <span>Range: <a property="http://schema.org/rangeIncludes" href="http://schema.org/Text">Text</a></span>
+    <div typeof="rdf:Property" resource="http://schema.org/engine">
+        <span class="h" property="rdfs:label">engine</span>
+        <span property="rdfs:comment">Information about the engine or engines of the vehicle.</span>
+        <span>Domain: <a property="http://schema.org/domainIncludes" href="http://schema.org/Vehicle">Vehicle</a></span>  
+        <span>Range: <a property="http://schema.org/rangeIncludes" href="http://schema.org/EngineSpecification">EngineSpecification</a></span>
         <span>Source:  <a property="dc:source" href="http://www.w3.org/wiki/WebSchemas/SchemaDotOrgSources#Automotive_Ontology_Working_Group">GAO</a></span>
     </div>
     <div typeof="rdf:Property" resource="http://schema.org/configuration">
         <span class="h" property="rdfs:label">configuration</span>
         <span property="rdfs:comment">A short text indicating the configuration of the vehicle, e.g. &apos;5dr hatchback ST 2.5 MT 225 hp&apos; or &apos;limited edition&apos;.</span>
-        <span>Domain: <a property="http://schema.org/domainIncludes" href="http://schema.org/MotorizedRoadVehicle">MotorizedRoadVehicle</a></span>
+        <span>Domain: <a property="http://schema.org/domainIncludes" href="http://schema.org/Vehicle">Vehicle</a></span>
         <span>Range: <a property="http://schema.org/rangeIncludes" href="http://schema.org/Text">Text</a></span>
         <span>Source:  <a property="dc:source" href="http://www.w3.org/wiki/WebSchemas/SchemaDotOrgSources#Automotive_Ontology_Working_Group">GAO</a></span>
     </div>
     <div typeof="rdf:Property" resource="http://schema.org/acrissCode">
         <span class="h" property="rdfs:label">acrissCode</span>
         <span property="rdfs:comment">The ACRISS Car Classification Code is a code used by many car rental companies, for classifying vehicles. ACRISS stands for Association of Car Rental Industry Systems and Standards.</span>
-        <span>Domain: <a property="http://schema.org/domainIncludes" href="http://schema.org/MotorizedRoadVehicle">MotorizedRoadVehicle</a></span>
+        <span>Domain: <a property="http://schema.org/domainIncludes" href="http://schema.org/Car">Car</a></span>
+        <span>Domain: <a property="http://schema.org/domainIncludes" href="http://schema.org/BusOrCoach">BusOrCoach</a></span>
         <span>Range: <a property="http://schema.org/rangeIncludes" href="http://schema.org/Text">Text</a></span>
         <span>Source:  <a property="dc:source" href="http://www.w3.org/wiki/WebSchemas/SchemaDotOrgSources#Automotive_Ontology_Working_Group">GAO</a></span>
     </div>
@@ -11704,7 +11707,7 @@ postponing for 1.6.
         <span class="h" property="rdfs:label">vin</span>
         <span property="rdfs:comment">The Vehicle Identification Number (VIN) is a unique serial number used by the automotive industry to identify individual motor vehicles.</span>
          <link property="rdfs:subPropertyOf" href="http://schema.org/serialNumber" />
-        <span>Domain: <a property="http://schema.org/domainIncludes" href="http://schema.org/MotorizedRoadVehicle">MotorizedRoadVehicle</a></span>
+        <span>Domain: <a property="http://schema.org/domainIncludes" href="http://schema.org/Vehicle">Vehicle</a></span>
         <span>Range: <a property="http://schema.org/rangeIncludes" href="http://schema.org/Text">Text</a></span>
         <span>Source:  <a property="dc:source" href="http://www.w3.org/wiki/WebSchemas/SchemaDotOrgSources#Automotive_Ontology_Working_Group">GAO</a></span>
     </div>
@@ -11732,7 +11735,7 @@ postponing for 1.6.
     <div typeof="rdf:Property" resource="http://schema.org/airbags">
         <span class="h" property="rdfs:label">airbags</span>
         <span property="rdfs:comment">The number or type of airbags in the vehicle.</span>
-        <span>Domain: <a property="http://schema.org/domainIncludes" href="http://schema.org/MotorizedRoadVehicle">MotorizedRoadVehicle</a></span>
+        <span>Domain: <a property="http://schema.org/domainIncludes" href="http://schema.org/Vehicle">Vehicle</a></span>
         <span>Range: <a property="http://schema.org/rangeIncludes" href="http://schema.org/Number">Number</a></span>
         <span>Range: <a property="http://schema.org/rangeIncludes" href="http://schema.org/Text">Text</a></span>
         <span>Source:  <a property="dc:source" href="http://www.w3.org/wiki/WebSchemas/SchemaDotOrgSources#Automotive_Ontology_Working_Group">GAO</a></span>
@@ -11744,14 +11747,14 @@ postponing for 1.6.
     
     Note 1: You can link to information about how the given value has been determined (e.g. reference RPM) using the &lt;a href=&quot;valueReference&quot;&gt;valueReference&lt;/a&gt; property.&lt;br /&gt;
     Note 2: You can use &lt;a href=&quot;minValue&quot;&gt;minValue&lt;/a&gt; and &lt;a href=&quot;maxValue&quot;&gt;maxValue&lt;/a&gt; to indicate ranges.</span>
-        <span>Domain: <a property="http://schema.org/domainIncludes" href="http://schema.org/MotorizedRoadVehicle">MotorizedRoadVehicle</a></span>
+        <span>Domain: <a property="http://schema.org/domainIncludes" href="http://schema.org/EngineSpecification">EngineSpecification</a></span>
         <span>Range: <a property="http://schema.org/rangeIncludes" href="http://schema.org/QuantitativeValue">QuantitativeValue</a></span>
         <span>Source:  <a property="dc:source" href="http://www.w3.org/wiki/WebSchemas/SchemaDotOrgSources#Automotive_Ontology_Working_Group">GAO</a></span>
     </div>
     <div typeof="rdf:Property" resource="http://schema.org/emissionsCO2">
         <span class="h" property="rdfs:label">emissionsCO2</span>
         <span property="rdfs:comment">The CO2 emissions in g/km. The property uses a number instead of a QuantitativeValue, since g/km is the dominant unit of measurement, and there is no UNCEFACT Common Code for g/km.</span>
-        <span>Domain: <a property="http://schema.org/domainIncludes" href="http://schema.org/MotorizedRoadVehicle">MotorizedRoadVehicle</a></span>
+        <span>Domain: <a property="http://schema.org/domainIncludes" href="http://schema.org/Vehicle">Vehicle</a></span>
         <span>Range: <a property="http://schema.org/rangeIncludes" href="http://schema.org/Number">Number</a></span>
         <span>Source:  <a property="dc:source" href="http://www.w3.org/wiki/WebSchemas/SchemaDotOrgSources#Automotive_Ontology_Working_Group">GAO</a></span>
     </div>

--- a/data/schema.rdfa
+++ b/data/schema.rdfa
@@ -11672,8 +11672,8 @@ postponing for 1.6.
         <span>Range: <a property="http://schema.org/rangeIncludes" href="http://schema.org/Text">Text</a></span>
         <span>Source:  <a property="dc:source" href="http://www.w3.org/wiki/WebSchemas/SchemaDotOrgSources#Automotive_Ontology_Working_Group">GAO</a></span>
     </div>
-    <div typeof="rdf:Property" resource="http://schema.org/dateOfFirstRegistration">
-        <span class="h" property="rdfs:label">dateOfFirstRegistration</span>
+    <div typeof="rdf:Property" resource="http://schema.org/dateFirstRegistered">
+        <span class="h" property="rdfs:label">dateFirstRegistered</span>
         <span property="rdfs:comment">The date of the first registration of the vehicle with the respective public authorities.</span>
         <span>Domain: <a property="http://schema.org/domainIncludes" href="http://schema.org/Vehicle">Vehicle</a></span>
         <span>Range: <a property="http://schema.org/rangeIncludes" href="http://schema.org/Date">Date</a></span>

--- a/data/schema.rdfa
+++ b/data/schema.rdfa
@@ -9372,7 +9372,7 @@ Note that Event uses startDate/endDate instead of startTime/endTime, even when d
 	
 	<div typeof="http://schema.org/Organization" resource="http://www.w3.org/wiki/WebSchemas/SchemaDotOrgSources#Automotive_Ontology_Working_Group">
 	  <span property="rdfs:label">AutomotiveOntologyWGClass</span>
-	  <span property="rdfs:comment">This class is based on the work of the Automotive Ontology Working Group, see &lt;a href=&quot;http://www.automotive-ontology.org&quot;&gt;http://www.automotive-ontology.org&lt;/a&gt; for details.</span>
+	  <span property="rdfs:comment">This element is based on the work of the Automotive Ontology Working Group, see &lt;a href=&quot;http://www.automotive-ontology.org&quot;&gt;http://www.automotive-ontology.org&lt;/a&gt; for details. Many class and property definitions are inspired by or based on abstracts from Wikipedia, the free encyclopedia.</span>
 	</div>
     <hr />
 
@@ -9500,7 +9500,7 @@ Note that Event uses startDate/endDate instead of startTime/endTime, even when d
     </div>
     <div typeof="rdfs:Class" resource="http://schema.org/Car">
       <span class="h" property="rdfs:label">Car</span>
-      <span property="rdfs:comment">An automobile, motor car, or car is a wheeled motor vehicle used for transporting passengers, which also carries its own engine or motor.</span>      
+      <span property="rdfs:comment">A car is a wheeled, self-powered motor vehicle used for transportation.</span>      
       <span>Subclass of: <a property="rdfs:subClassOf" href="http://schema.org/MotorizedRoadVehicle">MotorizedRoadVehicle</a></span>
     </div>
     <div typeof="rdf:Property" resource="http://schema.org/reservationId">
@@ -11339,18 +11339,6 @@ postponing for 1.6.
         <span>Subclass of: <a property="rdfs:subClassOf" href="http://schema.org/Vehicle">Vehicle</a></span>
         <span>Source:  <a property="dc:source" href="http://www.w3.org/wiki/WebSchemas/SchemaDotOrgSources#Automotive_Ontology_Working_Group">GAO</a></span>
     </div>
-    <div typeof="rdfs:Class" resource="http://schema.org/Truck">
-        <span class="h" property="rdfs:label">Truck</span>
-        <span property="rdfs:comment">A lorry (British English) or truck (American English) is a motor vehicle designed to transport cargo.</span>
-        <span>Subclass of: <a property="rdfs:subClassOf" href="http://schema.org/MotorizedRoadVehicle">MotorizedRoadVehicle</a></span>
-        <span>Source:  <a property="dc:source" href="http://www.w3.org/wiki/WebSchemas/SchemaDotOrgSources#Automotive_Ontology_Working_Group">GAO</a></span>
-    </div>
-    <div typeof="rdfs:Class" resource="http://schema.org/Van">
-        <span class="h" property="rdfs:label">Van</span>
-        <span property="rdfs:comment">A van is a kind of vehicle used for transporting  goods or groups of people. It is usually a box-shaped vehicle on four wheels, about the same width and length as a large automobile, but taller and usually higher off the ground, also referred to as a light commercial vehicle or LCV.</span>
-        <span>Subclass of: <a property="rdfs:subClassOf" href="http://schema.org/MotorizedRoadVehicle">MotorizedRoadVehicle</a></span>
-        <span>Source:  <a property="dc:source" href="http://www.w3.org/wiki/WebSchemas/SchemaDotOrgSources#Automotive_Ontology_Working_Group">GAO</a></span>
-    </div>
     <div typeof="rdfs:Class" resource="http://schema.org/MotorizedBicycle">
         <span class="h" property="rdfs:label">MotorizedBicycle</span>
         <span property="rdfs:comment">A motorized bicycle is a bicycle with an attached motor used to power the vehicle, or to assist with pedaling.</span>
@@ -11359,8 +11347,7 @@ postponing for 1.6.
     </div>
     <div typeof="rdfs:Class" resource="http://schema.org/BusOrCoach">
         <span class="h" property="rdfs:label">BusOrCoach</span>
-        <span property="rdfs:comment">A bus (also omnibus or autobus) is a road vehicle designed to carry passengers. Buses have a capacity as high as 300 passengers and are widely used for public transportation. 
-    Coaches are luxury busses, usually in service for long distance travel.</span>
+        <span property="rdfs:comment">A bus (also omnibus or autobus) is a road vehicle designed to carry passengers. Coaches are luxury busses, usually in service for long distance travel.</span>
         <span>Subclass of: <a property="rdfs:subClassOf" href="http://schema.org/MotorizedRoadVehicle">MotorizedRoadVehicle</a></span>
         <span>Source:  <a property="dc:source" href="http://www.w3.org/wiki/WebSchemas/SchemaDotOrgSources#Automotive_Ontology_Working_Group">GAO</a></span>
     </div>
@@ -11370,75 +11357,15 @@ postponing for 1.6.
         <span>Subclass of: <a property="rdfs:subClassOf" href="http://schema.org/MotorizedRoadVehicle">MotorizedRoadVehicle</a></span>
         <span>Source:  <a property="dc:source" href="http://www.w3.org/wiki/WebSchemas/SchemaDotOrgSources#Automotive_Ontology_Working_Group">GAO</a></span>
     </div>
-    <div typeof="rdfs:Class" resource="http://schema.org/Bicycle">
-        <span class="h" property="rdfs:label">Bicycle</span>
-        <span property="rdfs:comment">A bicycle or bike is a pedal-driven, human-powered, single-track vehicle, having two wheels attached to a frame, one behind the other. Some bicycles have a small combustion or electric engine that assists with the pedaling.</span>
-        <span>Subclass of: <a property="rdfs:subClassOf" href="http://schema.org/Vehicle">Vehicle</a></span>
-        <span>Source:  <a property="dc:source" href="http://www.w3.org/wiki/WebSchemas/SchemaDotOrgSources#Automotive_Ontology_Working_Group">GAO</a></span>
-    </div>
-    <div typeof="rdfs:Class" resource="http://schema.org/Watercraft">
-        <span class="h" property="rdfs:label">Watercraft</span>
-        <span property="rdfs:comment">A watercraft is a vehicle, vessel or craft designed to move across or through water.</span>
-        <span>Subclass of: <a property="rdfs:subClassOf" href="http://schema.org/Vehicle">Vehicle</a></span>
-        <span>Source:  <a property="dc:source" href="http://www.w3.org/wiki/WebSchemas/SchemaDotOrgSources#Automotive_Ontology_Working_Group">GAO</a></span>
-    </div>
-    <div typeof="rdfs:Class" resource="http://schema.org/Boat">
-        <span class="h" property="rdfs:label">Boat</span>
-        <span property="rdfs:comment">A boat is a watercraft of modest size designed to float or plane, to provide passage across water.</span>
-        <span>Subclass of: <a property="rdfs:subClassOf" href="http://schema.org/Watercraft">Watercraft</a></span>
-        <span>Source:  <a property="dc:source" href="http://www.w3.org/wiki/WebSchemas/SchemaDotOrgSources#Automotive_Ontology_Working_Group">GAO</a></span>
-    </div>
-    <div typeof="rdfs:Class" resource="http://schema.org/MotorBoat">
-        <span class="h" property="rdfs:label">MotorBoat</span>
-        <span property="rdfs:comment">A motorboat is a boat which is powered by an engine.</span>
-        <span>Subclass of: <a property="rdfs:subClassOf" href="http://schema.org/Boat">Boat</a></span>
-        <span>Source:  <a property="dc:source" href="http://www.w3.org/wiki/WebSchemas/SchemaDotOrgSources#Automotive_Ontology_Working_Group">GAO</a></span>
-    </div>
-    <div typeof="rdfs:Class" resource="http://schema.org/SailingBoat">
-        <span class="h" property="rdfs:label">SailingBoat</span>
-        <span property="rdfs:comment">A sailboat or sailing boat is a boat propelled partly or entirely by sails.</span>
-        <span>Subclass of: <a property="rdfs:subClassOf" href="http://schema.org/Boat">Boat</a></span>
-        <span>Source:  <a property="dc:source" href="http://www.w3.org/wiki/WebSchemas/SchemaDotOrgSources#Automotive_Ontology_Working_Group">GAO</a></span>
-    </div>
     <div typeof="rdfs:Class" resource="http://schema.org/SteeringPositionValue">
         <span class="h" property="rdfs:label">SteeringPositionValue</span>
         <span property="rdfs:comment">A value indicating a steering position.</span>
         <span>Subclass of: <a property="rdfs:subClassOf" href="http://schema.org/QualitativeValue">QualitativeValue</a></span>
         <span>Source:  <a property="dc:source" href="http://www.w3.org/wiki/WebSchemas/SchemaDotOrgSources#Automotive_Ontology_Working_Group">GAO</a></span>
     </div>
-    <div typeof="rdfs:Class" resource="http://schema.org/EmissionStandardValue">
-        <span class="h" property="rdfs:label">EmissionStandardValue</span>
-        <span property="rdfs:comment">A value indicating the an emission standard.</span>
-        <span>Subclass of: <a property="rdfs:subClassOf" href="http://schema.org/QualitativeValue">QualitativeValue</a></span>
-        <span>Source:  <a property="dc:source" href="http://www.w3.org/wiki/WebSchemas/SchemaDotOrgSources#Automotive_Ontology_Working_Group">GAO</a></span>
-    </div>
-    <div typeof="rdfs:Class" resource="http://schema.org/TransmissionTypeValue">
-        <span class="h" property="rdfs:label">TransmissionTypeValue</span>
-        <span property="rdfs:comment">A value indicating a type of transmission.</span>
-        <span>Subclass of: <a property="rdfs:subClassOf" href="http://schema.org/QualitativeValue">QualitativeValue</a></span>
-        <span>Source:  <a property="dc:source" href="http://www.w3.org/wiki/WebSchemas/SchemaDotOrgSources#Automotive_Ontology_Working_Group">GAO</a></span>
-    </div>
-    <div typeof="rdfs:Class" resource="http://schema.org/DriveWheelConfigurationValue">
+     <div typeof="rdfs:Class" resource="http://schema.org/DriveWheelConfigurationValue">
         <span class="h" property="rdfs:label">DriveWheelConfigurationValue</span>
         <span property="rdfs:comment">A value indicating which roadwheels will receive torque.</span>
-        <span>Subclass of: <a property="rdfs:subClassOf" href="http://schema.org/QualitativeValue">QualitativeValue</a></span>
-        <span>Source:  <a property="dc:source" href="http://www.w3.org/wiki/WebSchemas/SchemaDotOrgSources#Automotive_Ontology_Working_Group">GAO</a></span>
-    </div>
-    <div typeof="rdfs:Class" resource="http://schema.org/EngineTypeValue">
-        <span class="h" property="rdfs:label">EngineTypeValue</span>
-        <span property="rdfs:comment">A value indicating an engine type.</span>
-        <span>Subclass of: <a property="rdfs:subClassOf" href="http://schema.org/QualitativeValue">QualitativeValue</a></span>
-        <span>Source:  <a property="dc:source" href="http://www.w3.org/wiki/WebSchemas/SchemaDotOrgSources#Automotive_Ontology_Working_Group">GAO</a></span>
-    </div>
-    <div typeof="rdfs:Class" resource="http://schema.org/FuelTypeValue">
-        <span class="h" property="rdfs:label">FuelTypeValue</span>
-        <span property="rdfs:comment">A value indicating a type of fuel.</span>
-        <span>Subclass of: <a property="rdfs:subClassOf" href="http://schema.org/QualitativeValue">QualitativeValue</a></span>
-        <span>Source:  <a property="dc:source" href="http://www.w3.org/wiki/WebSchemas/SchemaDotOrgSources#Automotive_Ontology_Working_Group">GAO</a></span>
-    </div>
-    <div typeof="rdfs:Class" resource="http://schema.org/BodyTypeValue">
-        <span class="h" property="rdfs:label">BodyTypeValue</span>
-        <span property="rdfs:comment">A value indicating the body type or style of a vehicle.</span>
         <span>Subclass of: <a property="rdfs:subClassOf" href="http://schema.org/QualitativeValue">QualitativeValue</a></span>
         <span>Source:  <a property="dc:source" href="http://www.w3.org/wiki/WebSchemas/SchemaDotOrgSources#Automotive_Ontology_Working_Group">GAO</a></span>
     </div>
@@ -11457,11 +11384,10 @@ postponing for 1.6.
     </div>
     <div typeof="rdf:Property" resource="http://schema.org/fuelCapacity">
         <span class="h" property="rdfs:label">fuelCapacity</span>
-        <span property="rdfs:comment">The capacity of the fuel tank or in the case electric cars, the battery. If there are multiple components for storage, this should indicate the total of all storage of the same type.&lt;br /&gt;
+        <span property="rdfs:comment">The capacity of the fuel tank or in the case of electric cars, the battery. If there are multiple components for storage, this should indicate the total of all storage of the same type.&lt;br /&gt;
     Typical unit code(s): LTR for liters, GLL of US gallons, GLI for UK / imperial gallons, AMH for ampere-hours (for electrical vehicles)
     </span>
         <span>Domain: <a property="http://schema.org/domainIncludes" href="http://schema.org/MotorizedRoadVehicle">MotorizedRoadVehicle</a></span>
-        <span>Domain: <a property="http://schema.org/domainIncludes" href="http://schema.org/MotorBoat">MotorBoat</a></span>
         <span>Range: <a property="http://schema.org/rangeIncludes" href="http://schema.org/QuantitativeValue">QuantitativeValue</a></span>
         <span>Source:  <a property="dc:source" href="http://www.w3.org/wiki/WebSchemas/SchemaDotOrgSources#Automotive_Ontology_Working_Group">GAO</a></span>
     </div>
@@ -11476,10 +11402,10 @@ postponing for 1.6.
     </div>
     <div typeof="rdf:Property" resource="http://schema.org/roofLoad">
         <span class="h" property="rdfs:label">roofLoad</span>
-        <span property="rdfs:comment">The permited total weight of cargo and installations (e.g. a roof rack) on top of the vehicle.&lt;br /&gt;
+        <span property="rdfs:comment">The permitted total weight of cargo and installations (e.g. a roof rack) on top of the vehicle.&lt;br /&gt;
     Typical unit code(s): KGM for kilogram, LBR for pound&lt;br /&gt;
     
-    Note 1: You can indicate additional information in the rdfs:label of the &lt;a href=&quot;QuantitativeValue&quot;&gt;QuantitativeValue&lt;/a&gt; node.&lt;br /&gt;
+    Note 1: You can indicate additional information in the &lt;a href=&quot;name&quot;&gt;name&lt;/a&gt; of the &lt;a href=&quot;QuantitativeValue&quot;&gt;QuantitativeValue&lt;/a&gt; node.&lt;br /&gt;
     Note 2: You may also link to a &lt;a href=&quot;QualitativeValue&quot;&gt;QualitativeValue&lt;/a&gt; node that provides additional information using &lt;a href=&quot;valueReference&quot;&gt;valueReference&lt;/a&gt;.&lt;br /&gt;
     Note 3: Note that you can use &lt;a href=&quot;minValue&quot;&gt;minValue&lt;/a&gt; and &lt;a href=&quot;maxValue&quot;&gt;maxValue&lt;/a&gt; to indicate ranges.</span>
         <span>Domain: <a property="http://schema.org/domainIncludes" href="http://schema.org/MotorizedRoadVehicle">MotorizedRoadVehicle</a></span>
@@ -11489,24 +11415,21 @@ postponing for 1.6.
     <div typeof="rdf:Property" resource="http://schema.org/fuelConsumption">
         <span class="h" property="rdfs:label">fuelConsumption</span>
         <span property="rdfs:comment">The amount of fuel consumed for traveling a particular distance or temporal duration with the given vehicle (e.g. liters per 100 km).&lt;br /&gt;
-    Typical unit code(s): LTR for liters, GLL of US Gallons, GLI for UK / Imperial Gallons&lt;br /&gt;
-        
-    Note 1: There are unfortunately no standard unit codes for "liters per 100 km". Simply use "LTR" for liters, "GLL" of US Gallons, or "GLI" for UK / Imperial Gallons, and indicate the distance in the rdfs:label of the &lt;a href=&quot;QuantitativeValue&quot;&gt;QuantitativeValue&lt;/a&gt; or use &lt;a href=&quot;valueReference&quot;&gt;valueReference&lt;/a&gt; to model the reference distance (e.g. 100 km). &lt;br /&gt;
+    Note 1: There are unfortunately no standard unit codes for liters per 100 km.&lt;br /&gt;
+    Use &lt;a href=&quot;unitText&quot;&gt;unitText&lt;/a&gt; to indicate the unit of measurement, e.g. L/100 km.
     Note 2: There are two ways of indicating the fuel consumption, &lt;a href=&quot;fuelConsumption&quot;&gt;fuelConsumption&lt;/a&gt; (e.g. 8 liters per 100 km) and &lt;a href=&quot;fuelEfficiency&quot;&gt;fuelEfficiency&lt;/a&gt; (e.g. 30 miles per gallon). They are reciprocal.&lt;br /&gt;
     Note 3: Often, the absolute value is useful only when related to driving speed ("at 80 km/h") or usage pattern ("city traffic"). You can use &lt;a href=&quot;valueReference&quot;&gt;valueReference&lt;/a&gt; to link the value for the fuel consumption to another value.</span>
         <span>Domain: <a property="http://schema.org/domainIncludes" href="http://schema.org/MotorizedRoadVehicle">MotorizedRoadVehicle</a></span>
-        <span>Domain: <a property="http://schema.org/domainIncludes" href="http://schema.org/MotorBoat">MotorBoat</a></span>    
         <span>Range: <a property="http://schema.org/rangeIncludes" href="http://schema.org/QuantitativeValue">QuantitativeValue</a></span>
         <span>Source:  <a property="dc:source" href="http://www.w3.org/wiki/WebSchemas/SchemaDotOrgSources#Automotive_Ontology_Working_Group">GAO</a></span>
     </div>
     <div typeof="rdf:Property" resource="http://schema.org/cargoVolume">
         <span class="h" property="rdfs:label">cargoVolume</span>
-        <span property="rdfs:comment">The available volume for cargo or luggage. For automobiles, this is usually the trunk space.&lt;br /&gt;
+        <span property="rdfs:comment">The available volume for cargo or luggage. For automobiles, this is usually the trunk volume.&lt;br /&gt;
     Typical unit code(s): LTR for liters, FTQ for cubic foot/feet&lt;br /&gt;
     
     Note: You can use &lt;a href=&quot;minValue&quot;&gt;minValue&lt;/a&gt; and &lt;a href=&quot;maxValue&quot;&gt;maxValue&lt;/a&gt; to indicate ranges.</span>
-        <span>Domain: <a property="http://schema.org/domainIncludes" href="http://schema.org/MotorizedRoadVehicle">MotorizedRoadVehicle</a></span>
-        <span>Domain: <a property="http://schema.org/domainIncludes" href="http://schema.org/Watercraft">Watercraft</a></span>  
+        <span>Domain: <a property="http://schema.org/domainIncludes" href="http://schema.org/MotorizedRoadVehicle">MotorizedRoadVehicle</a></span>  
         <span>Range: <a property="http://schema.org/rangeIncludes" href="http://schema.org/QuantitativeValue">QuantitativeValue</a></span>
         <span>Source:  <a property="dc:source" href="http://www.w3.org/wiki/WebSchemas/SchemaDotOrgSources#Automotive_Ontology_Working_Group">GAO</a></span>
     </div>
@@ -11528,7 +11451,7 @@ postponing for 1.6.
     </div>
     <div typeof="rdf:Property" resource="http://schema.org/payload">
         <span class="h" property="rdfs:label">payload</span>
-        <span property="rdfs:comment">The permited weight of passengers and cargo, EXCLUDING the weight of the empty vehicle. &lt;br /&gt;
+        <span property="rdfs:comment">The permitted weight of passengers and cargo, EXCLUDING the weight of the empty vehicle. &lt;br /&gt;
     Typical unit code(s): KGM for kilogram, LBR for pound&lt;br /&gt;
     
     Note 1: Many databases specify the permitted TOTAL weight instead, which is the sum of &lt;a href=&quot;weight&quot;&gt;weight&lt;/a&gt; and &lt;a href=&quot;payload&quot;&gt;payload&lt;/a&gt;.&lt;br /&gt;
@@ -11541,7 +11464,7 @@ postponing for 1.6.
     </div>
     <div typeof="rdf:Property" resource="http://schema.org/weightTotal">
         <span class="h" property="rdfs:label">weightTotal</span>
-        <span property="rdfs:comment">The permited total weight of the loaded vehicle, including passengers and cargo and the weight of the empty vehicle.&lt;br /&gt;
+        <span property="rdfs:comment">The permitted total weight of the loaded vehicle, including passengers and cargo and the weight of the empty vehicle.&lt;br /&gt;
     Typical unit code(s): KGM for kilogram, LBR for pound&lt;br /&gt;
     
     Note 1: You can indicate additional information in the &lt;a href=&quot;name&quot;&gt;name&lt;/a&gt; of the &lt;a href=&quot;QuantitativeValue&quot;&gt;QuantitativeValue&lt;/a&gt; node.&lt;br /&gt;
@@ -11553,18 +11476,20 @@ postponing for 1.6.
     </div>
     <div typeof="rdf:Property" resource="http://schema.org/transmission">
         <span class="h" property="rdfs:label">transmission</span>
-        <span property="rdfs:comment">The type of component used for transmitting the power from a rotating power source to the wheels or propeller(s) ("gearbox" for cars).</span>
+        <span property="rdfs:comment">The type of component used for transmitting the power from a rotating power source to the wheels or other relevant component(s) ("gearbox" for cars).</span>
         <span>Domain: <a property="http://schema.org/domainIncludes" href="http://schema.org/MotorizedRoadVehicle">MotorizedRoadVehicle</a></span>
-        <span>Range: <a property="http://schema.org/rangeIncludes" href="http://schema.org/TransmissionTypeValue">TransmissionTypeValue</a></span>
         <span>Range: <a property="http://schema.org/rangeIncludes" href="http://schema.org/Text">Text</a></span>
+        <span>Range: <a property="http://schema.org/rangeIncludes" href="http://schema.org/QualitativeValue">QualitativeValue</a></span>
+        <span>Range: <a property="http://schema.org/rangeIncludes" href="http://schema.org/URL">URL</a></span>
         <span>Source:  <a property="dc:source" href="http://www.w3.org/wiki/WebSchemas/SchemaDotOrgSources#Automotive_Ontology_Working_Group">GAO</a></span>
     </div>
     <div typeof="rdf:Property" resource="http://schema.org/fuelType">
         <span class="h" property="rdfs:label">fuelType</span>
         <span property="rdfs:comment">The type of fuel suitable for the engine or engines of the vehicle. </span>
-        <span>Domain: <a property="http://schema.org/domainIncludes" href="http://schema.org/Vehicle">Vehicle</a></span>
-        <span>Range: <a property="http://schema.org/rangeIncludes" href="http://schema.org/FuelTypeValue">FuelTypeValue</a></span>
+        <span>Domain: <a property="http://schema.org/domainIncludes" href="http://schema.org/MotorizedRoadVehicle">MotorizedRoadVehicle</a></span>
         <span>Range: <a property="http://schema.org/rangeIncludes" href="http://schema.org/Text">Text</a></span>
+        <span>Range: <a property="http://schema.org/rangeIncludes" href="http://schema.org/QualitativeValue">QualitativeValue</a></span>
+        <span>Range: <a property="http://schema.org/rangeIncludes" href="http://schema.org/URL">URL</a></span>	
         <span>Source:  <a property="dc:source" href="http://www.w3.org/wiki/WebSchemas/SchemaDotOrgSources#Automotive_Ontology_Working_Group">GAO</a></span>
     </div>
     <div typeof="rdf:Property" resource="http://schema.org/engineDisplacement">
@@ -11574,8 +11499,7 @@ postponing for 1.6.
     
     Note 1: You can link to information about how the given value has been determined using the &lt;a href=&quot;valueReference&quot;&gt;valueReference&lt;/a&gt; property.&lt;br /&gt;
     Note 2: You can use &lt;a href=&quot;minValue&quot;&gt;minValue&lt;/a&gt; and &lt;a href=&quot;maxValue&quot;&gt;maxValue&lt;/a&gt; to indicate ranges.</span>
-        <span>Domain: <a property="http://schema.org/domainIncludes" href="http://schema.org/MotorizedRoadVehicle">MotorizedRoadVehicle</a></span>
-        <span>Domain: <a property="http://schema.org/domainIncludes" href="http://schema.org/MotorBoat">MotorBoat</a></span>    
+        <span>Domain: <a property="http://schema.org/domainIncludes" href="http://schema.org/MotorizedRoadVehicle">MotorizedRoadVehicle</a></span> 
         <span>Range: <a property="http://schema.org/rangeIncludes" href="http://schema.org/QuantitativeValue">QuantitativeValue</a></span>
         <span>Source:  <a property="dc:source" href="http://www.w3.org/wiki/WebSchemas/SchemaDotOrgSources#Automotive_Ontology_Working_Group">GAO</a></span>
     </div>
@@ -11591,13 +11515,14 @@ postponing for 1.6.
         <span class="h" property="rdfs:label">bodyType</span>
         <span property="rdfs:comment">Indicates the design and body style of the vehicle (e.g. station wagon, hatchback, etc.).</span>
         <span>Domain: <a property="http://schema.org/domainIncludes" href="http://schema.org/Vehicle">Vehicle</a></span>
-        <span>Range: <a property="http://schema.org/rangeIncludes" href="http://schema.org/BodyTypeValue">BodyTypeValue</a></span>
         <span>Range: <a property="http://schema.org/rangeIncludes" href="http://schema.org/Text">Text</a></span>
+        <span>Range: <a property="http://schema.org/rangeIncludes" href="http://schema.org/QualitativeValue">QualitativeValue</a></span>
+        <span>Range: <a property="http://schema.org/rangeIncludes" href="http://schema.org/URL">URL</a></span>
         <span>Source:  <a property="dc:source" href="http://www.w3.org/wiki/WebSchemas/SchemaDotOrgSources#Automotive_Ontology_Working_Group">GAO</a></span>
     </div>
     <div typeof="rdf:Property" resource="http://schema.org/tongueWeight">
         <span class="h" property="rdfs:label">tongueWeight</span>
-        <span property="rdfs:comment">The permited vertical load (TWR) of a trailer attached to the vehicle. Also referred to as Tongue Load Rating (TLR) or Vertical Load Rating (VLR).&lt;br /&gt;
+        <span property="rdfs:comment">The permitted vertical load (TWR) of a trailer attached to the vehicle. Also referred to as Tongue Load Rating (TLR) or Vertical Load Rating (VLR).&lt;br /&gt;
         Typical unit code(s): KGM for kilogram, LBR for pound&lt;br /&gt;
 
     Note 1: You can indicate additional information in the &lt;a href=&quot;name&quot;&gt;name&lt;/a&gt; of the &lt;a href=&quot;QuantitativeValue&quot;&gt;QuantitativeValue&lt;/a&gt; node.&lt;br /&gt;
@@ -11631,29 +11556,25 @@ postponing for 1.6.
         <span class="h" property="rdfs:label">meetsEmissionStandard</span>
         <span property="rdfs:comment">Indicates that the vehicle meets the respective emission standard.</span>
         <span>Domain: <a property="http://schema.org/domainIncludes" href="http://schema.org/Vehicle">Vehicle</a></span>
-        <span>Range: <a property="http://schema.org/rangeIncludes" href="http://schema.org/EmissionStandardValue">EmissionStandardValue</a></span>
         <span>Range: <a property="http://schema.org/rangeIncludes" href="http://schema.org/Text">Text</a></span>
+        <span>Range: <a property="http://schema.org/rangeIncludes" href="http://schema.org/QualitativeValue">QualitativeValue</a></span>
+        <span>Range: <a property="http://schema.org/rangeIncludes" href="http://schema.org/URL">URL</a></span>
         <span>Source:  <a property="dc:source" href="http://www.w3.org/wiki/WebSchemas/SchemaDotOrgSources#Automotive_Ontology_Working_Group">GAO</a></span>
     </div>
     <div typeof="rdf:Property" resource="http://schema.org/fuelEfficiency">
         <span class="h" property="rdfs:label">fuelEfficiency</span>
         <span property="rdfs:comment">The distance traveled per unit of fuel used; most commonly miles per gallon (mpg) or kilometers per liter (km/L).&lt;br /&gt;
-    Typical unit code(s): KMT for kilometers, SMI for statute miles&lt;br /&gt;
-    
     Note 1: There are unfortunately no standard unit codes for miles per gallon or kilometers per liter.&lt;br /&gt;
-    Simply use "SMI" for statute miles (common miles in the US and UK) or "KMT" for kilometers, and indicate 
-    the fuel amount of reference in the &lt;a href=&quot;name&quot;&gt;name&lt;/a&gt; of the &lt;a href=&quot;QuantitativeValue&quot;&gt;QuantitativeValue&lt;/a&gt;, or use &lt;a href=&quot;valueReference&quot;&gt;valueReference&lt;/a&gt; to point to the reference fuel quantity, e.g. one liter, one US Gallon, or one British Gallon.&lt;br /&gt;
-    Note 2: In the absence of a a reference fuel quantity one may assume that the quantity of reference is one gallon for distances given in miles and one liter for distances given in kilometers. However, note that the original unit may be obscured by unit conversion services, so this heuristic is far from perfect.
-    Note 3: There are two ways of indicating the fuel consumption, &lt;a href=&quot;fuelConsumption&quot;&gt;fuelConsumption&lt;/a&gt; (e.g. 8 liters per 100 km) and &lt;a href=&quot;fuelEfficiency&quot;&gt;fuelEfficiency&lt;/a&gt; (e.g. 30 miles per gallon). They are reciprocal.&lt;br /&gt;
-    Note 4: Often, the absolute value is useful only when related to driving speed ("at 80 km/h") or usage pattern ("city traffic"). You can use &lt;a href=&quot;valueReference&quot;&gt;valueReference&lt;/a&gt; to link the value for the fuel economy to another value.</span>
+    Use &lt;a href=&quot;unitText&quot;&gt;unitText&lt;/a&gt; to indicate the unit of measurement, e.g. mpg or km/L.
+    Note 2: There are two ways of indicating the fuel consumption, &lt;a href=&quot;fuelConsumption&quot;&gt;fuelConsumption&lt;/a&gt; (e.g. 8 liters per 100 km) and &lt;a href=&quot;fuelEfficiency&quot;&gt;fuelEfficiency&lt;/a&gt; (e.g. 30 miles per gallon). They are reciprocal.&lt;br /&gt;
+    Note 3: Often, the absolute value is useful only when related to driving speed ("at 80 km/h") or usage pattern ("city traffic"). You can use &lt;a href=&quot;valueReference&quot;&gt;valueReference&lt;/a&gt; to link the value for the fuel economy to another value.</span>
         <span>Domain: <a property="http://schema.org/domainIncludes" href="http://schema.org/MotorizedRoadVehicle">MotorizedRoadVehicle</a></span>
-        <span>Domain: <a property="http://schema.org/domainIncludes" href="http://schema.org/MotorBoat">MotorBoat</a></span>
         <span>Range: <a property="http://schema.org/rangeIncludes" href="http://schema.org/QuantitativeValue">QuantitativeValue</a></span>
         <span>Source:  <a property="dc:source" href="http://www.w3.org/wiki/WebSchemas/SchemaDotOrgSources#Automotive_Ontology_Working_Group">GAO</a></span>
     </div>
     <div typeof="rdf:Property" resource="http://schema.org/gears">
         <span class="h" property="rdfs:label">gears</span>
-        <span property="rdfs:comment">The total number of forward and reverse gears available for the transmission system of the vehicle.&lt;br /&gt;
+        <span property="rdfs:comment">The total number of forward gears available for the transmission system of the vehicle.&lt;br /&gt;
     Typical unit code(s): C62</span>
         <span>Domain: <a property="http://schema.org/domainIncludes" href="http://schema.org/Vehicle">Vehicle</a></span>
         <span>Range: <a property="http://schema.org/rangeIncludes" href="http://schema.org/QuantitativeValue">QuantitativeValue</a></span>
@@ -11673,9 +11594,9 @@ postponing for 1.6.
         <span class="h" property="rdfs:label">engineType</span>
         <span property="rdfs:comment">The type of engine or engines powering the vehicle. If there are multiple engines, simply attach this property multiple times.</span>
         <span>Domain: <a property="http://schema.org/domainIncludes" href="http://schema.org/MotorizedRoadVehicle">MotorizedRoadVehicle</a></span>
-        <span>Domain: <a property="http://schema.org/domainIncludes" href="http://schema.org/MotorBoat">MotorBoat</a></span>
-        <span>Range: <a property="http://schema.org/rangeIncludes" href="http://schema.org/EngineTypeValue">EngineTypeValue</a></span>
         <span>Range: <a property="http://schema.org/rangeIncludes" href="http://schema.org/Text">Text</a></span>
+        <span>Range: <a property="http://schema.org/rangeIncludes" href="http://schema.org/QualitativeValue">QualitativeValue</a></span>
+        <span>Range: <a property="http://schema.org/rangeIncludes" href="http://schema.org/URL">URL</a></span>
         <span>Source:  <a property="dc:source" href="http://www.w3.org/wiki/WebSchemas/SchemaDotOrgSources#Automotive_Ontology_Working_Group">GAO</a></span>
     </div>
     <div typeof="rdf:Property" resource="http://schema.org/seatingCapacity">
@@ -11689,7 +11610,7 @@ postponing for 1.6.
     </div>
     <div typeof="rdf:Property" resource="http://schema.org/trailerWeight">
         <span class="h" property="rdfs:label">trailerWeight</span>
-        <span property="rdfs:comment">The permited weight of a trailer attached to the vehicle.&lt;br /&gt;
+        <span property="rdfs:comment">The permitted weight of a trailer attached to the vehicle.&lt;br /&gt;
     Typical unit code(s): KGM for kilogram, LBR for pound&lt;br /&gt;
 
     Note 1: You can indicate additional information in the &lt;a href=&quot;name&quot;&gt;name&lt;/a&gt; of the &lt;a href=&quot;QuantitativeValue&quot;&gt;QuantitativeValue&lt;/a&gt; node.&lt;br /&gt;
@@ -11699,27 +11620,25 @@ postponing for 1.6.
         <span>Range: <a property="http://schema.org/rangeIncludes" href="http://schema.org/QuantitativeValue">QuantitativeValue</a></span>
         <span>Source:  <a property="dc:source" href="http://www.w3.org/wiki/WebSchemas/SchemaDotOrgSources#Automotive_Ontology_Working_Group">GAO</a></span>
     </div>
-    <div typeof="rdf:Property" resource="http://schema.org/acceleration">
-        <span class="h" property="rdfs:label">acceleration</span>
+    <div typeof="rdf:Property" resource="http://schema.org/accelerationTime">
+        <span class="h" property="rdfs:label">accelerationTime</span>
         <span property="rdfs:comment">The time needed to accelerate the vehicle from a given start velocity to a given target velocity.&lt;br /&gt;
     Typical unit code(s): SEC for seconds&lt;br /&gt;
 
     Note: There are unfortunately no standard unit codes for seconds/0..100 km/h or seconds/0..60 mph. Simply use "SEC" for seconds and indicate the velocities in the &lt;a href=&quot;name&quot;&gt;name&lt;/a&gt; of the &lt;a href=&quot;QuantitativeValue&quot;&gt;QuantitativeValue&lt;/a&gt;, or use &lt;a href=&quot;valueReference&quot;&gt;valueReference&lt;/a&gt; with a &lt;a href=&quot;QuantitativeValue&quot;&gt;QuantitativeValue&lt;/a&gt; of 0..60 mph or 0..100 km/h to specify the reference speeds.</span>
         <span>Domain: <a property="http://schema.org/domainIncludes" href="http://schema.org/MotorizedRoadVehicle">MotorizedRoadVehicle</a></span>
-        <span>Domain: <a property="http://schema.org/domainIncludes" href="http://schema.org/MotorBoat">MotorBoat</a></span>    
         <span>Range: <a property="http://schema.org/rangeIncludes" href="http://schema.org/QuantitativeValue">QuantitativeValue</a></span>
         <span>Source:  <a property="dc:source" href="http://www.w3.org/wiki/WebSchemas/SchemaDotOrgSources#Automotive_Ontology_Working_Group">GAO</a></span>
     </div>
     <div typeof="rdf:Property" resource="http://schema.org/enginePower">
         <span class="h" property="rdfs:label">enginePower</span>
-        <span property="rdfs:comment">The power of the vehicle's engine. If there are multiple engines, simply attach this property multiple times.&lt;br /&gt;
+        <span property="rdfs:comment">The power of the vehicle's engine.
     Typical unit code(s): KWT for kilowatt&lt;br /&gt;
     
     Note 1: There are many different ways of measuring an engine's power. For an overview, see  http://en.wikipedia.org/wiki/Horsepower#Engine_power_test_codes. &lt;br /&gt;
     Note 2: You can link to information about how the given value has been determined using the &lt;a href=&quot;valueReference&quot;&gt;valueReference&lt;/a&gt; property.&lt;br /&gt;
     Note 3: You can use &lt;a href=&quot;minValue&quot;&gt;minValue&lt;/a&gt; and &lt;a href=&quot;maxValue&quot;&gt;maxValue&lt;/a&gt; to indicate ranges.</span>
         <span>Domain: <a property="http://schema.org/domainIncludes" href="http://schema.org/MotorizedRoadVehicle">MotorizedRoadVehicle</a></span>
-        <span>Domain: <a property="http://schema.org/domainIncludes" href="http://schema.org/MotorBoat">MotorBoat</a></span>    
         <span>Range: <a property="http://schema.org/rangeIncludes" href="http://schema.org/QuantitativeValue">QuantitativeValue</a></span>
         <span>Source:  <a property="dc:source" href="http://www.w3.org/wiki/WebSchemas/SchemaDotOrgSources#Automotive_Ontology_Working_Group">GAO</a></span>
     </div>
@@ -11730,8 +11649,8 @@ postponing for 1.6.
         <span>Range: <a property="http://schema.org/rangeIncludes" href="http://schema.org/Date">Date</a></span>
         <span>Source:  <a property="dc:source" href="http://www.w3.org/wiki/WebSchemas/SchemaDotOrgSources#Automotive_Ontology_Working_Group">GAO</a></span>
     </div>
-    <div typeof="rdf:Property" resource="http://schema.org/purchasingDate">
-        <span class="h" property="rdfs:label">purchasingDate</span>
+    <div typeof="rdf:Property" resource="http://schema.org/purchaseDate">
+        <span class="h" property="rdfs:label">purchaseDate</span>
         <span property="rdfs:comment">The date the vehicle was purchased by the current owner.</span>
         <span>Domain: <a property="http://schema.org/domainIncludes" href="http://schema.org/Vehicle">Vehicle</a></span>
         <span>Range: <a property="http://schema.org/rangeIncludes" href="http://schema.org/Date">Date</a></span>
@@ -11753,8 +11672,8 @@ postponing for 1.6.
         <span>Range: <a property="http://schema.org/rangeIncludes" href="http://schema.org/Text">Text</a></span>
         <span>Source:  <a property="dc:source" href="http://www.w3.org/wiki/WebSchemas/SchemaDotOrgSources#Automotive_Ontology_Working_Group">GAO</a></span>
     </div>
-    <div typeof="rdf:Property" resource="http://schema.org/firstRegistration">
-        <span class="h" property="rdfs:label">firstRegistration</span>
+    <div typeof="rdf:Property" resource="http://schema.org/dateOfFirstRegistration">
+        <span class="h" property="rdfs:label">dateOfFirstRegistration</span>
         <span property="rdfs:comment">The date of the first registration of the vehicle with the respective public authorities.</span>
         <span>Domain: <a property="http://schema.org/domainIncludes" href="http://schema.org/Vehicle">Vehicle</a></span>
         <span>Range: <a property="http://schema.org/rangeIncludes" href="http://schema.org/Date">Date</a></span>
@@ -11763,8 +11682,7 @@ postponing for 1.6.
     <div typeof="rdf:Property" resource="http://schema.org/engineName">
         <span class="h" property="rdfs:label">engineName</span>
         <span property="rdfs:comment">A short text indicating the engine(s) of the vehicle.</span>
-        <span>Domain: <a property="http://schema.org/domainIncludes" href="http://schema.org/MotorizedRoadVehicle">MotorizedRoadVehicle</a></span>
-        <span>Domain: <a property="http://schema.org/domainIncludes" href="http://schema.org/MotorBoat">MotorBoat</a></span>    
+        <span>Domain: <a property="http://schema.org/domainIncludes" href="http://schema.org/MotorizedRoadVehicle">MotorizedRoadVehicle</a></span>  
         <span>Range: <a property="http://schema.org/rangeIncludes" href="http://schema.org/Text">Text</a></span>
         <span>Source:  <a property="dc:source" href="http://www.w3.org/wiki/WebSchemas/SchemaDotOrgSources#Automotive_Ontology_Working_Group">GAO</a></span>
     </div>
@@ -11772,19 +11690,18 @@ postponing for 1.6.
         <span class="h" property="rdfs:label">configurationName</span>
         <span property="rdfs:comment">A short text indicating the configuration of the vehicle, e.g. &apos;5dr hatchback ST 2.5 MT 225 hp&apos; or &apos;limited edition&apos;.</span>
         <span>Domain: <a property="http://schema.org/domainIncludes" href="http://schema.org/MotorizedRoadVehicle">MotorizedRoadVehicle</a></span>
-        <span>Domain: <a property="http://schema.org/domainIncludes" href="http://schema.org/MotorBoat">MotorBoat</a></span>    
         <span>Range: <a property="http://schema.org/rangeIncludes" href="http://schema.org/Text">Text</a></span>
         <span>Source:  <a property="dc:source" href="http://www.w3.org/wiki/WebSchemas/SchemaDotOrgSources#Automotive_Ontology_Working_Group">GAO</a></span>
     </div>
-    <div typeof="rdf:Property" resource="http://schema.org/ACRISSCode">
-        <span class="h" property="rdfs:label">ACRISSCode</span>
+    <div typeof="rdf:Property" resource="http://schema.org/acrissCode">
+        <span class="h" property="rdfs:label">acrissCode</span>
         <span property="rdfs:comment">The ACRISS Car Classification Code is a code used by many car rental companies, for classifying vehicles. ACRISS stands for Association of Car Rental Industry Systems and Standards.</span>
         <span>Domain: <a property="http://schema.org/domainIncludes" href="http://schema.org/MotorizedRoadVehicle">MotorizedRoadVehicle</a></span>
         <span>Range: <a property="http://schema.org/rangeIncludes" href="http://schema.org/Text">Text</a></span>
         <span>Source:  <a property="dc:source" href="http://www.w3.org/wiki/WebSchemas/SchemaDotOrgSources#Automotive_Ontology_Working_Group">GAO</a></span>
     </div>
-    <div typeof="rdf:Property" resource="http://schema.org/VIN">
-        <span class="h" property="rdfs:label">VIN</span>
+    <div typeof="rdf:Property" resource="http://schema.org/vin">
+        <span class="h" property="rdfs:label">vin</span>
         <span property="rdfs:comment">The Vehicle Identification Number (VIN) is a unique serial number used by the automotive industry to identify individual motor vehicles.</span>
          <link property="rdfs:subPropertyOf" href="http://schema.org/serialNumber" />
         <span>Domain: <a property="http://schema.org/domainIncludes" href="http://schema.org/MotorizedRoadVehicle">MotorizedRoadVehicle</a></span>
@@ -11798,8 +11715,8 @@ postponing for 1.6.
         <span>Range: <a property="http://schema.org/rangeIncludes" href="http://schema.org/Date">Date</a></span>
         <span>Source:  <a property="dc:source" href="http://www.w3.org/wiki/WebSchemas/SchemaDotOrgSources#Automotive_Ontology_Working_Group">GAO</a></span>
     </div>
-    <div typeof="rdf:Property" resource="http://schema.org/colorInterior">
-        <span class="h" property="rdfs:label">colorInterior</span>
+    <div typeof="rdf:Property" resource="http://schema.org/interiorColor">
+        <span class="h" property="rdfs:label">interiorColor</span>
         <span property="rdfs:comment">The color or color combination of the interior of the vehicle.</span>
         <span>Domain: <a property="http://schema.org/domainIncludes" href="http://schema.org/Vehicle">Vehicle</a></span>
         <span>Range: <a property="http://schema.org/rangeIncludes" href="http://schema.org/Text">Text</a></span>
@@ -11828,7 +11745,6 @@ postponing for 1.6.
     Note 1: You can link to information about how the given value has been determined (e.g. reference RPM) using the &lt;a href=&quot;valueReference&quot;&gt;valueReference&lt;/a&gt; property.&lt;br /&gt;
     Note 2: You can use &lt;a href=&quot;minValue&quot;&gt;minValue&lt;/a&gt; and &lt;a href=&quot;maxValue&quot;&gt;maxValue&lt;/a&gt; to indicate ranges.</span>
         <span>Domain: <a property="http://schema.org/domainIncludes" href="http://schema.org/MotorizedRoadVehicle">MotorizedRoadVehicle</a></span>
-        <span>Domain: <a property="http://schema.org/domainIncludes" href="http://schema.org/MotorBoat">MotorBoat</a></span>    
         <span>Range: <a property="http://schema.org/rangeIncludes" href="http://schema.org/QuantitativeValue">QuantitativeValue</a></span>
         <span>Source:  <a property="dc:source" href="http://www.w3.org/wiki/WebSchemas/SchemaDotOrgSources#Automotive_Ontology_Working_Group">GAO</a></span>
     </div>
@@ -11871,24 +11787,19 @@ postponing for 1.6.
     </div>
     <div typeof="http://schema.org/CarUsageType" resource="http://schema.org/RentalUsage">
       <span class="h" property="rdfs:label">RentalUsage</span>
-      <span property="rdfs:comment">Indicates that the vehicle has been used as a rental car.</span>
+      <span property="rdfs:comment">Indicates the usage of the vehicle as a rental car.</span>
       <span>Source:  <a property="dc:source" href="http://www.w3.org/wiki/WebSchemas/SchemaDotOrgSources#Automotive_Ontology_Working_Group">GAO</a></span>
     </div>
     <div typeof="http://schema.org/CarUsageType" resource="http://schema.org/DrivingSchoolUsage">
       <span class="h" property="rdfs:label">DrivingSchoolUsage</span>
-      <span property="rdfs:comment">Indicates that the vehicle has been used for driving school.</span>
+      <span property="rdfs:comment">Indicates the usage of the vehicle for driving school.</span>
       <span>Source:  <a property="dc:source" href="http://www.w3.org/wiki/WebSchemas/SchemaDotOrgSources#Automotive_Ontology_Working_Group">GAO</a></span>
     </div>
     <div typeof="http://schema.org/CarUsageType" resource="http://schema.org/TaxiUsage">
       <span class="h" property="rdfs:label">TaxiUsage</span>
-      <span property="rdfs:comment">Indicates that the vehicle has been used as taxi.</span>
+      <span property="rdfs:comment">Indicates the usage of the car as a taxi.</span>
       <span>Source:  <a property="dc:source" href="http://www.w3.org/wiki/WebSchemas/SchemaDotOrgSources#Automotive_Ontology_Working_Group">GAO</a></span>
     </div>  
-    <div typeof="http://schema.org/FuelTypeValue" resource="http://schema.org/TwoStrokeMixture">
-      <span class="h" property="rdfs:label">TwoStrokeMixture</span>
-      <span property="rdfs:comment">A pre-mixed fuel-oil mixture.</span>
-      <span>Source:  <a property="dc:source" href="http://www.w3.org/wiki/WebSchemas/SchemaDotOrgSources#Automotive_Ontology_Working_Group">GAO</a></span>
-    </div>
 
 </body>
 

--- a/data/schema.rdfa
+++ b/data/schema.rdfa
@@ -11633,7 +11633,7 @@ postponing for 1.6.
     <div typeof="rdf:Property" resource="http://schema.org/enginePower">
         <span class="h" property="rdfs:label">enginePower</span>
         <span property="rdfs:comment">The power of the vehicle's engine.
-    Typical unit code(s): KWT for kilowatt&lt;br /&gt;
+    Typical unit code(s): KWT for kilowatt, BHP for brake horsepower, N12 for metric horsepower (PS, with 1 PS = 735,49875 W) &lt;br /&gt;
     
     Note 1: There are many different ways of measuring an engine's power. For an overview, see  http://en.wikipedia.org/wiki/Horsepower#Engine_power_test_codes. &lt;br /&gt;
     Note 2: You can link to information about how the given value has been determined using the &lt;a href=&quot;valueReference&quot;&gt;valueReference&lt;/a&gt; property.&lt;br /&gt;

--- a/data/schema.rdfa
+++ b/data/schema.rdfa
@@ -11724,7 +11724,7 @@ postponing for 1.6.
     </div>
     <div typeof="rdf:Property" resource="http://schema.org/interiorType">
         <span class="h" property="rdfs:label">interiorType</span>
-        <span property="rdfs:comment">The type or material of the interior of the vehicle (e.g. synthetic fabric, leather, wood, etc.)</span>
+        <span property="rdfs:comment">The type or material of the interior of the vehicle (e.g. synthetic fabric, leather, wood, etc.). While most interior types are characterized by the material used, an interior type can also be based on vehicle usage or target audience.</span>
         <span>Domain: <a property="http://schema.org/domainIncludes" href="http://schema.org/Vehicle">Vehicle</a></span>
         <span>Range: <a property="http://schema.org/rangeIncludes" href="http://schema.org/Text">Text</a></span>
         <span>Source:  <a property="dc:source" href="http://www.w3.org/wiki/WebSchemas/SchemaDotOrgSources#Automotive_Ontology_Working_Group">GAO</a></span>

--- a/data/sdo-automobile-examples.txt
+++ b/data/sdo-automobile-examples.txt
@@ -1,0 +1,245 @@
+TYPES: Car
+
+PRE-MARKUP:
+
+<!-- Seller Details -->
+<div >
+  <strong>Contact Name: </strong> <span>Brent</span>
+  <div>$18,000</div>
+<!-- Car Details -->
+  <div id="product">
+    <strong>2009 Volkswagen Golf V GTI MY09 Direct-Shift Gearbox</strong>
+    <p>2009 Volkswagen Golf V GTI MY09 Direct-Shift Gearbox in perfect 
+    mechanical condition and low kilometres. It's impressive 2.0 litre turbo engine makes 
+    every drive a fun experience. Well looked after by one owner with full service history. 
+    It drives like new and has only done 50,000kms. (...)</p>
+    <img href="2009_Volkswagen_Golf_V_GTI_MY09.png" />
+    <p><strong>Color: </strong>Black</p>
+    <p><strong>Interior Color: </strong>Black</p>
+    <p><strong>Interior Type: </strong>Leather upholstery, wood paneling</p>
+    <p><strong>Model Year: </strong><time>2009</time></p>    
+    <p><strong>Transmission: </strong>6 speed Sports Automatic Dual Clutch</p>  
+    <p><strong>VIN: </strong>WVWZZZ1KZ9U######</p>  
+    <p><strong>Number of gears: </strong>6</p>    
+    <p><strong>Body: </strong>Hatchback</p>
+    <p><strong>Number of doors: </strong>3</p>
+    <p><strong>Number of seats: </strong>5</p>
+    <p><strong>Drive Type: </strong>Front Wheel Drive</p>
+    <p><strong>Engine: </strong>4 cylinder Petrol Turbo Intercooled 2.0 L (1984 cc)</p>
+    <p><strong>Engine Power: </strong>147 kw at 5100 rpm</p>
+    <p><strong>Fuel type: </strong>Petrol - Premium ULP</p>
+    <p><strong>Engine Size: </strong>1984 ccm</p>
+    <p><strong>Mileage: </strong>53100 km</p>
+    <p><strong>Number of airbags: </strong>6</p>
+    <p><strong>CO2 Emission Combined: </strong>192 g/km</p>
+</div>
+
+MICRODATA:
+
+<!-- Seller Details -->
+<div itemscope itemtype="http://schema.org/Person">
+  <strong>Contact Name: </strong> <span itemprop="name givenName">Brent</span>
+  <div itemprop="makesOffer" itemscope itemtype="http://schema.org/Offer" itemref="product">
+    <span itemprop="priceSpecification" itemscope 
+        itemtype="http://schema.org/UnitPriceSpecification">
+      <meta itemprop="priceCurrency" content="USD">$
+      <meta itemprop="price" content="18000">18,000
+     </span>
+   </div>
+</div>
+<!-- Car Details -->
+<div id="product" itemprop="itemOffered" itemscope itemtype="http://schema.org/Car">
+  <strong itemprop="name">2009 Volkswagen Golf V GTI MY09 Direct-Shift Gearbox</strong>
+  <p itemprop="description">2009 Volkswagen Golf V GTI MY09 Direct-Shift Gearbox in perfect 
+  mechanical condition and low kilometres. It's impressive 2.0 litre turbo engine makes 
+  every drive a fun experience. Well looked after by one owner with full service history. 
+  It drives like new and has only done 50,000kms. (...)</p>
+  <img itemprop="image" href="2009_Volkswagen_Golf_V_GTI_MY09.png" />
+  <p><strong>Color: </strong><span itemprop="color">Black</span></p>
+  <p><strong>Interior Color: </strong><span itemprop="colorInterior">Black</span></p>
+  <p><strong>Interior Type: </strong><span itemprop="interiorType">Leather upholstery, 
+    wood paneling</span></p>
+  <p><strong>Model Year: </strong><time itemprop="modelDate">2009</time></p>    
+  <p><strong>Transmission: </strong>
+    <span itemprop="transmission">6 speed Sports Automatic Dual Clutch</span>
+  </p>  
+  <p><strong>VIN: </strong><span itemprop="VIN">WVWZZZ1KZ9U######</span></p>  
+  <p><strong>Number of gears: </strong><span itemprop="gears">6</span></p>    
+  <p><strong>Body: </strong>
+    <span itemprop="bodyType">Hatchback</span>
+  </p>
+  <p><strong>Number of doors: </strong><span itemprop="doors">3</span></p>
+  <p><strong>Number of seats: </strong><span itemprop="seatingCapacity">5</span></p>
+  <p><strong>Drive Type: </strong>
+    <link itemprop="driveWheelConfiguration" href="http://schema.org/FWD" />
+    Front Wheel Drive
+  </p>
+  <p><strong>Engine: </strong>
+    <span itemprop="engineName">4 cylinder Petrol Turbo Intercooled 2.0 L (1984 cc)</span>
+  </p>
+  <p><strong>Engine Power: </strong>
+    <span itemprop="enginePower" itemscope itemtype="http://schema.org/QuantitativeValue">
+      <span itemprop="value">147</span> 
+      <meta itemprop="unitCode" content="KWT">kw
+      at <span itemprop="valueReference" itemscope itemtype="http://schema.org/QuantitativeValue">
+        <meta itemprop="name" content="referenceRPM"> 
+        <span itemprop="value">5100</span> 
+        <meta itemprop="unitCode" content="RPM">rpm
+      </span>
+    </span>
+  </p>
+  <p><strong>Fuel type: </strong>
+    <span itemprop="fuelType">Petrol - Premium ULP</span>     
+  </p>
+  <p><strong>Engine Size: </strong>
+    <span itemprop="engineDisplacement" itemscope itemtype="http://schema.org/QuantitativeValue">
+      <span itemprop="value">1984</span> 
+      <meta itemprop="unitCode" content="CMQ">ccm
+    </span>
+  </p>
+  <p><strong>Mileage: </strong>
+    <span itemprop="mileageFromOdometer" itemscope itemtype="http://schema.org/QuantitativeValue">
+      <span itemprop="value">53100</span> 
+      <meta itemprop="unitCode" content="KMT">km
+    </span>
+  </p>
+  <p><strong>Number of airbags: </strong><span itemprop="airbags">6</span></p>
+  <p><strong>CO2 Emission Combined: </strong><span itemprop="emissionCO2">192</span> g/km</p>
+</div>
+
+
+RDFA:
+
+<!-- Seller Details -->
+<div vocab="http://schema.org/" typeof="Person">
+<strong>Contact Name: </strong> <span property="name givenName">Brent</span>
+  <div property="makesOffer" typeof="Offer">
+    <span property="priceSpecification" typeof="UnitPriceSpecification">
+      <meta property="priceCurrency" content="USD">$
+      <meta property="price" content="18000">18,000
+    </span>
+<!-- Car Details -->
+    <div id="product" property="itemOffered" typeof="Car">
+      <strong property="name">2009 Volkswagen Golf V GTI MY09 Direct-Shift Gearbox</strong>
+      <p property="description">2009 Volkswagen Golf V GTI MY09 Direct-Shift Gearbox in perfect 
+        mechanical condition and low kilometres. It's impressive 2.0 litre turbo engine makes 
+        every drive a fun experience. Well looked after by one owner with full service history. 
+        It drives like new and has only done 50,000kms. (...)
+      </p>
+      <img property="image" href="2009_Volkswagen_Golf_V_GTI_MY09.png" />
+      <p><strong>Color: </strong><span property="color">Black</span></p>
+      <p><strong>Interior Color: </strong><span property="colorInterior">Black</span></p>
+      <p><strong>Interior Type: </strong><span property="interiorType">Leather upholstery, wood paneling</span></p>
+      <p><strong>Model Year: </strong><time property="modelDate">2009</time></p> 
+      <p><strong>Transmission: </strong>
+        <span property="transmission">6 speed Sports Automatic Dual Clutch</span>
+      </p> 
+      <p><strong>VIN: </strong><span property="VIN">WVWZZZ1KZ9U######</span></p> 
+      <p><strong>Number of gears: </strong><span property="gears">6</span></p> 
+      <p><strong>Body: </strong>
+        <span property="bodyType">Hatchback</span>
+      </p>
+      <p><strong>Number of doors: </strong><span property="doors">3</span></p>
+      <p><strong>Number of seats: </strong><span property="seatingCapacity">5</span></p>
+      <p><strong>Drive Type: </strong>
+        <link property="driveWheelConfiguration" href="http://schema.org/FWD" />
+        Front Wheel Drive
+      </p>
+      <p><strong>Engine: </strong>
+        <span property="engineName">4 cylinder Petrol Turbo Intercooled 2.0 L (1984 cc)</span>
+      </p>
+      <p><strong>Engine Power: </strong>
+        <span property="enginePower" typeof="QuantitativeValue">
+          <span property="value">147</span> 
+          <meta property="unitCode" content="KWT">kw
+          at <span property="valueReference" typeof="QuantitativeValue">
+            <meta property="name" content="referenceRPM"> 
+            <span property="value">5100</span> 
+            <meta property="unitCode" content="RPM">rpm
+          </span>
+        </span>
+      </p>
+      <p><strong>Fuel type: </strong>
+        <span property="fuelType">Petrol - Premium ULP</span>
+      </p>
+      <p><strong>Engine Size: </strong>
+        <span property="engineDisplacement" typeof="QuantitativeValue">
+          <span property="value">1984</span> 
+          <meta property="unitCode" content="CMQ">ccm
+        </span>
+      </p>
+      <p><strong>Mileage: </strong>
+        <span property="mileageFromOdometer" typeof="QuantitativeValue">
+          <span property="value">53100</span> 
+          <meta property="unitCode" content="KMT">km
+        </span>
+      </p>
+      <p><strong>Number of airbags: </strong><span property="airbags">6</span></p>
+      <p><strong>CO2 Emission Combined: </strong><span property="emissionCO2">192</span> g/km</p>
+    </div>
+  </div>
+</div>
+
+JSON:
+
+<script type="application/ld+json">
+{
+  "@context": "http://schema.org",
+  "@type": "Person",
+  "name" : "Brent",
+  "makesOffer" : { 
+        "@type" :"Offer",
+        "priceSpecification" : { 
+            "@type" : "UnitPriceSpecification", 
+            "priceCurrency" : "USD",
+            "price" : "18000" },
+        "itemOffered" : { 
+            "@type" : "Car",
+            "name" : "2009 Volkswagen Golf V GTI MY09 Direct-Shift Gearbox",
+            "description" : "2009 Volkswagen Golf V GTI MY09 Direct-Shift Gearbox in perfect mechanical condition and low kilometres. It's impressive 2.0 litre turbo engine makes every drive a fun experience. Well looked after by one owner with full service history. It drives like new and has only done 50,000kms. (...)",
+        "image" : "2009_Volkswagen_Golf_V_GTI_MY09.png",
+        "color" : "Black",
+        "colorInterior" : "Black",
+        "interiorType" : "Leather upholstery, wood paneling",
+        "modelDate" : "2009",
+        "transmission" : "6 speed Sports Automatic Dual Clutch",
+        "VIN" : "WVWZZZ1KZ9U######",
+        "gears" : "6",
+        "bodyType" : "Hatchback",
+        "doors" : "3",
+        "seatingCapacity" : "5",
+        "driveWheelConfiguration" : "http://schema.org/FWD",
+        "engineName" : "4 cylinder Petrol Turbo Intercooled 2.0 L (1984 cc)",
+        "enginePower" : { 
+            "@type" : "QuantitativeValue",
+            "value" : "147",
+            "unitCode" : "KWT",
+            "valueReference" : {
+                "@type" : "QuantitativeValue",
+                "name" : "referenceRPM", 
+                "value" : "5100",
+                "unitCode" : "RPM" }
+                        },
+        "fuelType" : "Petrol - Premium ULP",
+        "engineDisplacement" : {
+            "@type": "QuantitativeValue",
+            "value" : "1984",
+            "unitCode" : "CMQ"
+                        },
+        "mileageFromOdometer" : {
+            "@type" : "QuantitativeValue",
+            "value" : "53100",
+            "unitCode" : "KMT"
+                        },
+        "airbags" : "6",
+        "emissionCO2" : "192"
+        }
+    }
+}
+</script>
+
+TYPES:  FakeEntryNeeded, FixMeSomeDay
+PRE-MARKUP:
+MICRODATA:
+RDFA:
+JSON:

--- a/data/sdo-automobile-examples.txt
+++ b/data/sdo-automobile-examples.txt
@@ -74,29 +74,31 @@ MICRODATA:
     <link itemprop="driveWheelConfiguration" href="http://schema.org/FWD" />
     Front Wheel Drive
   </p>
-  <p><strong>Engine: </strong>
-    <span itemprop="engineName">4 cylinder Petrol Turbo Intercooled 2.0 L (1984 cc)</span>
-  </p>
-  <p><strong>Engine Power: </strong>
-    <span itemprop="enginePower" itemscope itemtype="http://schema.org/QuantitativeValue">
-      <span itemprop="value">147</span> 
-      <meta itemprop="unitCode" content="KWT">kw
-      at <span itemprop="valueReference" itemscope itemtype="http://schema.org/QuantitativeValue">
-        <meta itemprop="name" content="referenceRPM"> 
-        <span itemprop="value">5100</span> 
-        <meta itemprop="unitCode" content="RPM">rpm
+  <div itemprop="engine" itemscope itemtype="http://schema.org/EngineSpecification">
+    <p><strong>Engine: </strong>
+      <span itemprop="name">4 cylinder Petrol Turbo Intercooled 2.0 L (1984 cc)</span>
+    </p>
+    <p><strong>Engine Power: </strong>
+      <span itemprop="enginePower" itemscope itemtype="http://schema.org/QuantitativeValue">
+        <span itemprop="value">147</span> 
+        <meta itemprop="unitCode" content="KWT">kw
+        at <span itemprop="valueReference" itemscope itemtype="http://schema.org/QuantitativeValue">
+          <meta itemprop="name" content="referenceRPM"> 
+          <span itemprop="value">5100</span> 
+          <meta itemprop="unitCode" content="RPM">rpm
+        </span>
       </span>
-    </span>
-  </p>
-  <p><strong>Fuel type: </strong>
-    <span itemprop="fuelType">Petrol - Premium ULP</span>     
-  </p>
-  <p><strong>Engine Size: </strong>
-    <span itemprop="engineDisplacement" itemscope itemtype="http://schema.org/QuantitativeValue">
-      <span itemprop="value">1984</span> 
-      <meta itemprop="unitCode" content="CMQ">ccm
-    </span>
-  </p>
+    </p>
+    <p><strong>Fuel type: </strong>
+      <span itemprop="fuelType">Petrol - Premium ULP</span>     
+    </p>
+    <p><strong>Engine Size: </strong>
+      <span itemprop="engineDisplacement" itemscope itemtype="http://schema.org/QuantitativeValue">
+        <span itemprop="value">1984</span> 
+        <meta itemprop="unitCode" content="CMQ">ccm
+      </span>
+    </p>
+  </div>
   <p><strong>Mileage: </strong>
     <span itemprop="mileageFromOdometer" itemscope itemtype="http://schema.org/QuantitativeValue">
       <span itemprop="value">53100</span> 
@@ -145,29 +147,31 @@ RDFA:
         <link property="driveWheelConfiguration" href="http://schema.org/FWD" />
         Front Wheel Drive
       </p>
-      <p><strong>Engine: </strong>
-        <span property="engineName">4 cylinder Petrol Turbo Intercooled 2.0 L (1984 cc)</span>
-      </p>
-      <p><strong>Engine Power: </strong>
-        <span property="enginePower" typeof="QuantitativeValue">
-          <span property="value">147</span> 
-          <meta property="unitCode" content="KWT">kw
-          at <span property="valueReference" typeof="QuantitativeValue">
-            <meta property="name" content="referenceRPM"> 
-            <span property="value">5100</span> 
-            <meta property="unitCode" content="RPM">rpm
+      <div property="engine" typeOf="EngineSpecification">
+        <p><strong>Engine: </strong>
+          <span property="name">4 cylinder Petrol Turbo Intercooled 2.0 L (1984 cc)</span>
+        </p>
+        <p><strong>Engine Power: </strong>
+          <span property="enginePower" typeof="QuantitativeValue">
+            <span property="value">147</span> 
+            <meta property="unitCode" content="KWT">kw
+            at <span property="valueReference" typeof="QuantitativeValue">
+              <meta property="name" content="referenceRPM"> 
+              <span property="value">5100</span> 
+              <meta property="unitCode" content="RPM">rpm
+            </span>
           </span>
-        </span>
-      </p>
-      <p><strong>Fuel type: </strong>
-        <span property="fuelType">Petrol - Premium ULP</span>
-      </p>
-      <p><strong>Engine Size: </strong>
-        <span property="engineDisplacement" typeof="QuantitativeValue">
-          <span property="value">1984</span> 
-          <meta property="unitCode" content="CMQ">ccm
-        </span>
-      </p>
+        </p>
+        <p><strong>Fuel type: </strong>
+          <span property="fuelType">Petrol - Premium ULP</span>
+        </p>
+        <p><strong>Engine Size: </strong>
+          <span property="engineDisplacement" typeof="QuantitativeValue">
+            <span property="value">1984</span> 
+            <meta property="unitCode" content="CMQ">ccm
+          </span>
+        </p>
+      </div>
       <p><strong>Mileage: </strong>
         <span property="mileageFromOdometer" typeof="QuantitativeValue">
           <span property="value">53100</span> 
@@ -209,23 +213,26 @@ JSON:
         "doors" : "3",
         "seatingCapacity" : "5",
         "driveWheelConfiguration" : "http://schema.org/FWD",
-        "engineName" : "4 cylinder Petrol Turbo Intercooled 2.0 L (1984 cc)",
-        "enginePower" : { 
-            "@type" : "QuantitativeValue",
-            "value" : "147",
-            "unitCode" : "KWT",
-            "valueReference" : {
+        "engine" : {
+            "@type": "EngineSpecification",
+            "name" : "4 cylinder Petrol Turbo Intercooled 2.0 L (1984 cc)",
+            "enginePower" : { 
                 "@type" : "QuantitativeValue",
-                "name" : "referenceRPM", 
-                "value" : "5100",
-                "unitCode" : "RPM" }
+                "value" : "147",
+                "unitCode" : "KWT",
+                "valueReference" : {
+                    "@type" : "QuantitativeValue",
+                    "name" : "referenceRPM", 
+                    "value" : "5100",
+                    "unitCode" : "RPM" }
                         },
-        "fuelType" : "Petrol - Premium ULP",
-        "engineDisplacement" : {
-            "@type": "QuantitativeValue",
-            "value" : "1984",
-            "unitCode" : "CMQ"
-                        },
+            "fuelType" : "Petrol - Premium ULP",
+            "engineDisplacement" : {
+                "@type": "QuantitativeValue",
+                "value" : "1984",
+                "unitCode" : "CMQ"
+                        }
+                    },
         "mileageFromOdometer" : {
             "@type" : "QuantitativeValue",
             "value" : "53100",

--- a/data/sdo-automobile-examples.txt
+++ b/data/sdo-automobile-examples.txt
@@ -56,7 +56,7 @@ MICRODATA:
   It drives like new and has only done 50,000kms. (...)</p>
   <img itemprop="image" href="2009_Volkswagen_Golf_V_GTI_MY09.png" />
   <p><strong>Color: </strong><span itemprop="color">Black</span></p>
-  <p><strong>Interior Color: </strong><span itemprop="vin">Black</span></p>
+  <p><strong>Interior Color: </strong><span itemprop="interiorColor">Black</span></p>
   <p><strong>Interior Type: </strong><span itemprop="interiorType">Leather upholstery, 
     wood paneling</span></p>
   <p><strong>Model Year: </strong><time itemprop="modelDate">2009</time></p>    

--- a/data/sdo-automobile-examples.txt
+++ b/data/sdo-automobile-examples.txt
@@ -56,14 +56,14 @@ MICRODATA:
   It drives like new and has only done 50,000kms. (...)</p>
   <img itemprop="image" href="2009_Volkswagen_Golf_V_GTI_MY09.png" />
   <p><strong>Color: </strong><span itemprop="color">Black</span></p>
-  <p><strong>Interior Color: </strong><span itemprop="colorInterior">Black</span></p>
+  <p><strong>Interior Color: </strong><span itemprop="vin">Black</span></p>
   <p><strong>Interior Type: </strong><span itemprop="interiorType">Leather upholstery, 
     wood paneling</span></p>
   <p><strong>Model Year: </strong><time itemprop="modelDate">2009</time></p>    
   <p><strong>Transmission: </strong>
     <span itemprop="transmission">6 speed Sports Automatic Dual Clutch</span>
   </p>  
-  <p><strong>VIN: </strong><span itemprop="VIN">WVWZZZ1KZ9U######</span></p>  
+  <p><strong>VIN: </strong><span itemprop="vin">WVWZZZ1KZ9U######</span></p>  
   <p><strong>Number of gears: </strong><span itemprop="gears">6</span></p>    
   <p><strong>Body: </strong>
     <span itemprop="bodyType">Hatchback</span>
@@ -128,13 +128,13 @@ RDFA:
       </p>
       <img property="image" href="2009_Volkswagen_Golf_V_GTI_MY09.png" />
       <p><strong>Color: </strong><span property="color">Black</span></p>
-      <p><strong>Interior Color: </strong><span property="colorInterior">Black</span></p>
+      <p><strong>Interior Color: </strong><span property="interiorColor">Black</span></p>
       <p><strong>Interior Type: </strong><span property="interiorType">Leather upholstery, wood paneling</span></p>
       <p><strong>Model Year: </strong><time property="modelDate">2009</time></p> 
       <p><strong>Transmission: </strong>
         <span property="transmission">6 speed Sports Automatic Dual Clutch</span>
       </p> 
-      <p><strong>VIN: </strong><span property="VIN">WVWZZZ1KZ9U######</span></p> 
+      <p><strong>VIN: </strong><span property="vin">WVWZZZ1KZ9U######</span></p> 
       <p><strong>Number of gears: </strong><span property="gears">6</span></p> 
       <p><strong>Body: </strong>
         <span property="bodyType">Hatchback</span>
@@ -199,11 +199,11 @@ JSON:
             "description" : "2009 Volkswagen Golf V GTI MY09 Direct-Shift Gearbox in perfect mechanical condition and low kilometres. It's impressive 2.0 litre turbo engine makes every drive a fun experience. Well looked after by one owner with full service history. It drives like new and has only done 50,000kms. (...)",
         "image" : "2009_Volkswagen_Golf_V_GTI_MY09.png",
         "color" : "Black",
-        "colorInterior" : "Black",
+        "interiorColor" : "Black",
         "interiorType" : "Leather upholstery, wood paneling",
         "modelDate" : "2009",
         "transmission" : "6 speed Sports Automatic Dual Clutch",
-        "VIN" : "WVWZZZ1KZ9U######",
+        "vin" : "WVWZZZ1KZ9U######",
         "gears" : "6",
         "bodyType" : "Hatchback",
         "doors" : "3",


### PR DESCRIPTION
Dear all:

This is the new automotive extension proposal, initially based on https://www.w3.org/wiki/WebSchemas/Vehicles. This pull request addresses the requests to 

2. separate the automotive part from the property-values proposal,
3. remove the bicycles, boats, etc. elements until there will be fully-fledged proposals for those domains and
4. various detailed comments from Tom March from Jan 9, 2015.

In the following, I summarize how these comments and requests have been addressed.

"In general, I think we should review and make changes to schema.org in smaller self-contained units. In this case, that would mean splitting out the changes into:
(1) the value-prop changes, which I will send a separate mail on.
(2) the auto changes
(3) the bicycle changes
(4) the boats changes"

--> OK, done.

"For the bicycle and boat changes, I think we should defer the changes for now. In both cases, I did a quick survey of boats/bicycles for sale and manufacturer sites, and I saw little overlap between the main attributes they used to describe the boats/bicycles vs. what is present in the Bicycle, Watercraft, Boat, MotorBoat, and SailingBoat proposals. I think we should revisit this as a separate change once there are more complete and detailed proposals for these types with their own use-cases, etc. (the use cases in the current proposal are all auto-specific)."

--> OK, done: removed Bicycle, Boat, Watercraft, Motorboat, Sailing Boat and removed/updated domain/range definitions.

"One small note on Bicycle, when we add it: why does Bicycle allow for “some bicycles have a small combustion or electric engine that assists with pedaling” when there is a separate MotorizedBicycle type for that?"

--> The idea was that, at least in Europe, there are MotorizedBicycles, which are essentially very light Motorcycles (their pedals are not typically used, except for starting the engine), and bikes with a very small support engine, like e-bikes. Since we removed all bikes parts for the moment, this issue is closed.

"Car vs. Van vs. Truck – Can this be modeled as body styles (now called bodyType) instead? The three example sites seem to do this, and it strikes me as cleaner from a vocabulary point of view, especially as companies continue to blur the lines between these (SUVs, crossovers, etc.)."

--> OK, done: Van and Truck have been removed. This will also make it easier for used car listing sites that may not have proper classification information in their DBs. Also note that Wikipedia has recently changed its definition for car to to "A car is a wheeled, self-powered motor vehicle used for transportation." I copied that. I also added an acknowledgment to Wikipedia to the GAO text, to give proper credit that some class and property definitions are inspired by Wikipedia.

So we now have the following subtypes of Vehicle:

MotorizedRoadVehicle
	BusOrCoach
	Car
	Motorcycle
	MotorizedBicycle

MotorizedRoadVehicle will be handy for non-cars, like trikes, and it also allows bundling all engine-related properties nicely.

"For EmissionStandardValue, TransmissionTypeValue, EngineTypeValue, and BodyTypeValue, there doesn’t seem to be any distinction in the usage vs. using Text, so why do we need these? If we were to have enumeration values for these, then having separate types would make more sense to me."

--> The initial idea was to to use / allow the use of URIs, like Freebase, DBPedia. 
DONE - I changed the range of all respective properties to Text OR QualitativeValue or URL and removed the classes for these types. That should cover all use-cases and reduce the size of the proposal.

"For FuelTypeValue, I saw on the US version of Autotrader (one of the examples cited on the wiki) values of Alternative, Diesel, Electric, Gasoline, and Hybrid. These are missing from the enumeration, and I think they should be added. Also, I haven’t seen a reference to TwoStrokeMixture (the only current enum value for this type) from the sorts of sites in the use case list before. Is that for motorcycles? Or if the entire purpose of this type is to add TwoStrokeMixture to the lists already available on DBPedia/Freebase/etc., then I would argue people can just enter text for that, and we can remove the FuelTypeValue in favor of having people directly use QualitativeValue."

--> DONE. I removed TwoStrokeMixture an the FuelType type,  and changed of all properties to Text or QualitativeValue or URL. This will allow standardization bodies to establish canonical URLs/URIs for important fuel types and foster the use of Wikipedia, DBPedia and Freebase IDs.

"For CarUsageType, the name and description don’t imply past usage to me. Should we rename this as something like PastCarUsageType instead? Otherwise, when I first read it, I was expecting this type to be used to describe the current use (i.e., available for rental now, not available for sale to a private owner but previously used as a rental car)."

--> Note that the property name is specialUsage, which I think fits. For the enumerations, I would like to keep CarUsageType, because we may want to reuse this for terms and conditions of rental offers or insurance contracts.
DONE: I changed the description of the values RentalUsage, DrivingSchoolUsage, TaxiUsage to prepare for such future usages but kept specialUsage for the property and CarUsageType for the enumerations.

"Can we rename ACRISSCode to acriss and VIN to vin? Other similar properties (isbn, gtin13, gtin14, etc.) follow this naming convention."
--> OK, DONE: Changed ACRISSCode to acrissCode and VIN to vin.

"Can we rename acceleration to accelerationTime? This would make the usage slightly clearer and also remove the issues in the notes about there not being unit codes for acceleration."

--> OK, DONE. 

"Can we rename colorInterior to interiorColor to be consistent with things like tongueWeight, seatingCapacity, modelDate, etc.?"

--> OK, DONE.

"How should a publisher specify the condition (new/used/etc.)? It seems like we could reuse the existing itemCondition property (with updated description) for this."

--> For the general condition, it will be itemCondition. For damages, there is the damages property.

"configurationName seems to be duplicating a bunch of other properties (transmission, enginePower, bodyType, etc.). If people are going to do this, IMO, they should just use the name property. There is a concept of trim level that the US version of AutoTrader uses, which I think is missing and would be useful. That would capture probably just the “ST 2.5” part of the example. For a Subaru Legacy, on the US AutoTrader site, for example, you’ll see values such as “2.5GT Limited”, “2.5i”, “3.6R Limited”, etc. "

--> I would like to keep that, because

1. the resulting strings may be very valuable for NLP processing (links to knowledge graphs);
2. I am thinking of an extension for modeling configurable products (cars and other), and for that I would like to have a generic name already; trim is very car-specific and does not even fit for other vehicles.
3. schema:name may include the full make and model, while configurationName will just contain strings referring to the car configuration. In European cars, this may be much more detailed than just trim information, because they are very highly configurable. The configuration string in there will be too long to be used as a short name.
4. Yandex initially requested this property, if I remember correctly.

"The engine properties (displacement, name, power, and type) should probably be separated out into their own type, especially if we want to model multiple engines per vehicle (as some of the descriptions suggest). Otherwise, it will not be explicit which property sets go together."

--> While we could add a type Engine and set the domain of all these properties to MotorizedRoadVehicle OR Engine, and define a property "engine" with a domain of MotorizedRoadVehicle and a range of Engine, I would like to keep that as a future extension, because most cars have only one engine, and the proposal is already pretty substantial.

"For enginePower, should we also list the unit code for horsepower (BHP?)?"

--> I decided against listing it, because horsepower is to my knowledge an obsolete unit. As far as I can see, the proper code would be N12 ("Pferdestaerke", with 1 PS = 735,498 75 W, btw. It could still be used, but I think we should not actively promote it.

"For fuelConsumption and fuelEfficiency, it would be good to have examples of these in addition to the existing notes. Also, I am not sure it makes sense to put the “wrong” units in the unitCode property. Why not guide people to use unitText instead? I thought that unitText was introduced for just this situation; i.e., when there is no standard code to refer to."

--> I fixed the description to recommend unitText. As for examples, I will put them on my radar, but I think such can be added in a second step.

"fuelType is on Vehicle, but fuelConsumption and fuelEfficiency are only on the more specific types. I think the placement of these three properties should be consistent, and I like putting them on the more specific types."

-> OK, DONE: I changed the domain of fuelType to MotorizedRoadVehicle. 

"For gears, the description says forward and reverse gears, but I think it is customary to only list the forward gears. The example for Car also seems to list only the forward gears. Should we update the description?"

--> Agreed. OK - DONE.

"For interiorType, if this is intended to describe just the material, should we rename it to interiorMaterial?"

--> I would like to keep interiorType, because it could also be a type that is not based on a material but on a target usage or audience ("Hunter edition with gun rack" or "1970s disco interior").

"It looks like numberOfOwners was renamed to previousOwners. It would be nice to have the wiki updated if so."

--> OK, DONE - but while I tried to sync the Wiki page with the github work, it is very resource-consuming and error-prone, so we should consider the Wiki page deprecated.

"What is the use case for productionDate? I’m not sure we need this property, but if we do, can we reuse the existing dateCreated property instead? It sounds like it would have the same meaning."

--> In Europe, the production date is often an essential characteristic for new and used car, because some cars stand on stock for several months depending on factory capacities and demand. The property was also present in the older Yandex proposal. So I suggest to keep that.

"Can we rename purchasingDate to purchaseDate and firstRegistration to firstRegisteredDate? Our date property naming in schema.org isn’t very self-consistent, but I think these suggestions will be more consistent."

--> OK, DONE: Renamed purchasingDate to purchaseDate and firstRegistration to dateOfFirstRegistration, which I think is better English.

"transmission mentions sending power to propellers, but this property is on MotorizedRoadVehicle. Should it instead be on Vehicle? Or should the description be updated?" 

--> OK, DONE: I changed the description so that it remains generic without irritating typical users.

"There are some typos:
In the description for fuelCapacity: staorage => storage"

--> OK, DONE.

"In the description for unitText: “Useful if you cannot provide a standard unit code for” what?"

--> This is an issue for https://github.com/mfhepp/schemaorg/tree/property-values. I will add it there.

"In the descriptions for payload and weightTotal: permited -> permitted"

-> OK, DONE. (Also found a few more).

I also updated the examples accordingly.

Again, a huge thanks for your detailed review! I hope this is ready for inclusion now.

PS: For tracking what I changed between the two version, see

    https://github.com/mfhepp/schemaorg/commit/ed235c80edfd60000e0d1b6cb58f04284f734ec1

Best wishes

Martin