### PR TITLE
Attribution for Car

### DIFF
--- a/data/schema.rdfa
+++ b/data/schema.rdfa
@@ -9681,7 +9681,8 @@ Note that Event uses startDate/endDate instead of startTime/endTime, even when d
     </div>
     <div typeof="rdfs:Class" resource="http://schema.org/Car">
       <span class="h" property="rdfs:label">Car</span>
-      <span property="rdfs:comment">A car is a wheeled, self-powered motor vehicle used for transportation.</span>
+      <span>Source:  <a property="dc:source" href="http://www.w3.org/wiki/WebSchemas/SchemaDotOrgSources#Automotive_Ontology_Working_Group">GAO</a></span>
+      <span property="rdfs:comment">A car is a wheeled, self-powered motor vehicle used for transportation.</span>      
       <span>Subclass of: <a property="rdfs:subClassOf" href="http://schema.org/Vehicle">Vehicle</a></span>
     </div>
     <div typeof="rdf:Property" resource="http://schema.org/reservationId">


### PR DESCRIPTION
I had forgotten to add the attribution markup to the Car type, because it previously existed. But given that the majority of the new features are from the automotive extension and that it was just a skeleton before, I think that is justified.