### PR TITLE
Change range for fileSize in SoftwareApplication

### DIFF
--- a/data/schema.rdfa
+++ b/data/schema.rdfa
@@ -6132,7 +6132,7 @@ Note that Event uses startDate/endDate instead of startTime/endTime, even when d
       <span class="h" property="rdfs:label">fileSize</span>
       <span property="rdfs:comment">Size of the application / package (e.g. 18MB). In the absence of a unit (MB, KB etc.), KB will be assumed.</span>
       <span>Domain: <a property="http://schema.org/domainIncludes" href="http://schema.org/SoftwareApplication">SoftwareApplication</a></span>
-      <span>Range: <a property="http://schema.org/rangeIncludes" href="http://schema.org/Integer">Integer</a></span>
+      <span>Range: <a property="http://schema.org/rangeIncludes" href="http://schema.org/Text">Text</a></span>
     </div>
     <div typeof="rdf:Property" resource="http://schema.org/followee">
       <span class="h" property="rdfs:label">followee</span>


### PR DESCRIPTION
In http://schema.org/SoftwareApplication property fileSize has range http://schema.org/Integer but text description contains example with unit of measurement (18MB) what mean that actually range of fileSize is not integer, it's text