### PR TITLE
headline/alternativeHeadline domain of NewsArticle

### DIFF
--- a/data/schema.rdfa
+++ b/data/schema.rdfa
@@ -4776,8 +4776,8 @@
     </div>
     <div typeof="rdf:Property" resource="http://schema.org/alternativeHeadline">
       <span class="h" property="rdfs:label">alternativeHeadline</span>
-      <span property="rdfs:comment">A secondary title of the CreativeWork.</span>
-      <span>Domain: <a property="http://schema.org/domainIncludes" href="http://schema.org/CreativeWork">CreativeWork</a></span>
+      <span property="rdfs:comment">A secondary headline of the news article.</span>
+      <span>Domain: <a property="http://schema.org/domainIncludes" href="http://schema.org/NewsArticle">NewsArticle</a></span>
       <span>Range: <a property="http://schema.org/rangeIncludes" href="http://schema.org/Text">Text</a></span>
     </div>
     <div typeof="rdf:Property" resource="http://schema.org/alumni">
@@ -6568,8 +6568,8 @@ Note that Event uses startDate/endDate instead of startTime/endTime, even when d
     </div>
     <div typeof="rdf:Property" resource="http://schema.org/headline">
       <span class="h" property="rdfs:label">headline</span>
-      <span property="rdfs:comment">Headline of the article.</span>
-      <span>Domain: <a property="http://schema.org/domainIncludes" href="http://schema.org/CreativeWork">CreativeWork</a></span>
+      <span property="rdfs:comment">The headline of the news article.</span>
+      <span>Domain: <a property="http://schema.org/domainIncludes" href="http://schema.org/NewsArticle">NewsArticle</a></span>
       <span>Range: <a property="http://schema.org/rangeIncludes" href="http://schema.org/Text">Text</a></span>
     </div>
     <div typeof="rdf:Property" resource="http://schema.org/healthCondition">

--- a/docs/full.html
+++ b/docs/full.html
@@ -1803,7 +1803,7 @@ For a complete list of recent additions see the <a href="/docs/releases.html">Re
       <td class="space"></td>
       <td>
             <table class=h>
-  <tr><td class="tc" colspan=4><a href="../CreativeWork">CreativeWork</a>: about, accessibilityAPI, accessibilityControl, accessibilityFeature, accessibilityHazard, accountablePerson, aggregateRating, alternativeHeadline, associatedMedia, audience, audio, author, award, awards, citation, comment, commentCount, contentLocation, contentRating, contributor, copyrightHolder, copyrightYear, creator, dateCreated, dateModified, datePublished, discussionUrl, editor, educationalAlignment, educationalUse, encoding, encodings, genre, hasPart, headline, inLanguage, interactionCount, interactivityType, isBasedOnUrl, isFamilyFriendly, isPartOf, keywords, learningResourceType, mentions, offers, provider, publisher, publishingPrinciples, review, reviews, sourceOrganization, text, thumbnailUrl, timeRequired, typicalAgeRange, version, video
+  <tr><td class="tc" colspan=4><a href="../CreativeWork">CreativeWork</a>: about, accessibilityAPI, accessibilityControl, accessibilityFeature, accessibilityHazard, accountablePerson, aggregateRating, associatedMedia, audience, audio, author, award, awards, citation, comment, commentCount, contentLocation, contentRating, contributor, copyrightHolder, copyrightYear, creator, dateCreated, dateModified, datePublished, discussionUrl, editor, educationalAlignment, educationalUse, encoding, encodings, genre, hasPart, inLanguage, interactionCount, interactivityType, isBasedOnUrl, isFamilyFriendly, isPartOf, keywords, learningResourceType, mentions, offers, provider, publisher, publishingPrinciples, review, reviews, sourceOrganization, text, thumbnailUrl, timeRequired, typicalAgeRange, version, video
       </td></tr>
 
     <tr>
@@ -1850,7 +1850,7 @@ For a complete list of recent additions see the <a href="/docs/releases.html">Re
       <td class="space"></td>
       <td>
             <table class=h>
-  <tr><td class="tc" colspan=4><a href="../NewsArticle">NewsArticle</a>: dateline, printColumn, printEdition, printPage, printSection
+  <tr><td class="tc" colspan=4><a href="../NewsArticle">NewsArticle</a>: alternativeHeadline, dateline, headline, printColumn, printEdition, printPage, printSection
       </td></tr>
 
 </table>


### PR DESCRIPTION
Rather than continuing the tradition of keeping both name/alternateName and
headline/alternativeHeadline attached to the domain of CreativeWork, move
the latter to the domain of NewsArticle, as was indicated was the intention
in metabug #418.

Closes #205.

Signed-off-by: Dan Scott dan@coffeecode.net
