### PR TITLE
supersededBy: <link> instead of <span>

### DIFF
--- a/data/schema.rdfa
+++ b/data/schema.rdfa
@@ -4582,7 +4582,7 @@
     <div typeof="rdf:Property" resource="http://schema.org/action">
       <span class="h" property="rdfs:label">action</span>
       <span property="rdfs:comment">The movement the muscle generates.</span>
-      <span property="http://schema.org/supersededBy" href="http://schema.org/muscleAction"/>
+      <link property="http://schema.org/supersededBy" href="http://schema.org/muscleAction"/>
       <span>Domain: <a property="http://schema.org/domainIncludes" href="http://schema.org/Muscle">Muscle</a></span>
       <span>Range: <a property="http://schema.org/rangeIncludes" href="http://schema.org/Text">Text</a></span>
     </div>
@@ -4631,7 +4631,7 @@
     </div>
     <div typeof="rdf:Property" resource="http://schema.org/actors">
       <span class="h" property="rdfs:label">actors</span>
-      <span property="http://schema.org/supersededBy" href="http://schema.org/actor"/>
+      <link property="http://schema.org/supersededBy" href="http://schema.org/actor"/>
       <span property="rdfs:comment">An actor, e.g. in tv, radio, movie, video games etc. Actors can be associated with individual items or with a series, episode, clip.</span>
       <span>Domain: <a property="http://schema.org/domainIncludes" href="http://schema.org/Movie">Movie</a></span>
       <span>Domain: <a property="http://schema.org/domainIncludes" href="http://schema.org/VideoObject">VideoObject</a></span>
@@ -4755,7 +4755,7 @@
     </div>
     <div typeof="rdf:Property" resource="http://schema.org/albums">
       <span class="h" property="rdfs:label">albums</span>
-      <span property="http://schema.org/supersededBy" href="http://schema.org/album"/>
+      <link property="http://schema.org/supersededBy" href="http://schema.org/album"/>
       <span property="rdfs:comment">A collection of music albums.</span>
       <span>Domain: <a property="http://schema.org/domainIncludes" href="http://schema.org/MusicGroup">MusicGroup</a></span>
       <span>Range: <a property="http://schema.org/rangeIncludes" href="http://schema.org/MusicAlbum">MusicAlbum</a></span>
@@ -4949,7 +4949,7 @@
     </div>
     <div typeof="rdf:Property" resource="http://schema.org/attendees">
       <span class="h" property="rdfs:label">attendees</span>
-      <span property="http://schema.org/supersededBy" href="http://schema.org/attendee"/>
+      <link property="http://schema.org/supersededBy" href="http://schema.org/attendee"/>
       <span property="rdfs:comment">A person attending the event.</span>
       <span>Domain: <a property="http://schema.org/domainIncludes" href="http://schema.org/Event">Event</a></span>
       <span>Range: <a property="http://schema.org/rangeIncludes" href="http://schema.org/Organization">Organization</a></span>
@@ -5081,7 +5081,7 @@
     </div>
     <div typeof="rdf:Property" resource="http://schema.org/awards">
       <span class="h" property="rdfs:label">awards</span>
-      <span property="http://schema.org/supersededBy" href="http://schema.org/award"/>
+      <link property="http://schema.org/supersededBy" href="http://schema.org/award"/>
       <span property="rdfs:comment">Awards won by or for this item.</span>
       <span>Domain: <a property="http://schema.org/domainIncludes" href="http://schema.org/CreativeWork">CreativeWork</a></span>
       <span>Domain: <a property="http://schema.org/domainIncludes" href="http://schema.org/Organization">Organization</a></span>
@@ -5154,7 +5154,7 @@
     </div>
     <div typeof="rdf:Property" resource="http://schema.org/blogPosts">
       <span class="h" property="rdfs:label">blogPosts</span>
-      <span property="http://schema.org/supersededBy" href="http://schema.org/blogPost"/>
+      <link property="http://schema.org/supersededBy" href="http://schema.org/blogPost"/>
       <span property="rdfs:comment">The postings that are part of this blog.</span>
       <span>Domain: <a property="http://schema.org/domainIncludes" href="http://schema.org/Blog">Blog</a></span>
       <span>Range: <a property="http://schema.org/rangeIncludes" href="http://schema.org/BlogPosting">BlogPosting</a></span>
@@ -5296,7 +5296,7 @@
       <span>Domain: <a property="http://schema.org/domainIncludes" href="http://schema.org/ParcelDelivery">ParcelDelivery</a></span>
       <span>domain: <a property="http://schema.org/domainIncludes" href="http://schema.org/Flight">Flight</a></span>
       <span>Range: <a property="http://schema.org/rangeIncludes" href="http://schema.org/Organization">Organization</a></span>
-      <span property="http://schema.org/supersededBy" href="http://schema.org/provider"/>
+      <link property="http://schema.org/supersededBy" href="http://schema.org/provider"/>
     </div>
     <div typeof="rdf:Property" resource="http://schema.org/carrierRequirements">
       <span class="h" property="rdfs:label">carrierRequirements</span>
@@ -5431,7 +5431,7 @@
     </div>
     <div typeof="rdf:Property" resource="http://schema.org/colleagues">
       <span class="h" property="rdfs:label">colleagues</span>
-      <span property="http://schema.org/supersededBy" href="http://schema.org/colleague"/>
+      <link property="http://schema.org/supersededBy" href="http://schema.org/colleague"/>
       <span property="rdfs:comment">A colleague of the person.</span>
       <span>Domain: <a property="http://schema.org/domainIncludes" href="http://schema.org/Person">Person</a></span>
       <span>Range: <a property="http://schema.org/rangeIncludes" href="http://schema.org/Person">Person</a></span>
@@ -5504,7 +5504,7 @@
     </div>
     <div typeof="rdf:Property" resource="http://schema.org/contactPoints">
       <span class="h" property="rdfs:label">contactPoints</span>
-      <span property="http://schema.org/supersededBy" href="http://schema.org/contactPoint"/>
+      <link property="http://schema.org/supersededBy" href="http://schema.org/contactPoint"/>
       <span property="rdfs:comment">A contact point for a person or organization.</span>
       <span>Domain: <a property="http://schema.org/domainIncludes" href="http://schema.org/Organization">Organization</a></span>
       <span>Domain: <a property="http://schema.org/domainIncludes" href="http://schema.org/Person">Person</a></span>
@@ -5822,7 +5822,7 @@
     </div>
     <div typeof="rdf:Property" resource="http://schema.org/directors">
       <span class="h" property="rdfs:label">directors</span>
-      <span property="http://schema.org/supersededBy" href="http://schema.org/director"/>
+      <link property="http://schema.org/supersededBy" href="http://schema.org/director"/>
       <span property="rdfs:comment">A director of e.g. tv, radio, movie, video games etc. content. Directors can be associated with individual items or with a series, episode, clip.</span>
       <span>Domain: <a property="http://schema.org/domainIncludes" href="http://schema.org/Movie">Movie</a></span>
       <span>Domain: <a property="http://schema.org/domainIncludes" href="http://schema.org/VideoObject">VideoObject</a></span>
@@ -6114,7 +6114,7 @@
     </div>
     <div typeof="rdf:Property" resource="http://schema.org/employees">
       <span class="h" property="rdfs:label">employees</span>
-      <span property="http://schema.org/supersededBy" href="http://schema.org/employee"/>
+      <link property="http://schema.org/supersededBy" href="http://schema.org/employee"/>
       <span property="rdfs:comment">People working for this organization.</span>
       <span>Domain: <a property="http://schema.org/domainIncludes" href="http://schema.org/Organization">Organization</a></span>
       <span>Range: <a property="http://schema.org/rangeIncludes" href="http://schema.org/Person">Person</a></span>
@@ -6145,7 +6145,7 @@
     </div>
     <div typeof="rdf:Property" resource="http://schema.org/encodings">
       <span class="h" property="rdfs:label">encodings</span>
-      <span property="http://schema.org/supersededBy" href="http://schema.org/encoding"/>
+      <link property="http://schema.org/supersededBy" href="http://schema.org/encoding"/>
       <span property="rdfs:comment">A media object that encodes this CreativeWork.</span>
       <span>Domain: <a property="http://schema.org/domainIncludes" href="http://schema.org/CreativeWork">CreativeWork</a></span>
       <span>Range: <a property="http://schema.org/rangeIncludes" href="http://schema.org/MediaObject">MediaObject</a></span>
@@ -6217,7 +6217,7 @@ Note that Event uses startDate/endDate instead of startTime/endTime, even when d
     </div>
     <div typeof="rdf:Property" resource="http://schema.org/episodes">
       <span class="h" property="rdfs:label">episodes</span>
-      <span property="http://schema.org/supersededBy" href="http://schema.org/episode"/>
+      <link property="http://schema.org/supersededBy" href="http://schema.org/episode"/>
       <span property="rdfs:comment">An episode of a TV/radio series or season.</span>
       <span>Domain: <a property="http://schema.org/domainIncludes" href="http://schema.org/Season">Season</a></span>
       <span>Domain: <a property="http://schema.org/domainIncludes" href="http://schema.org/RadioSeries">RadioSeries</a></span>
@@ -6251,7 +6251,7 @@ Note that Event uses startDate/endDate instead of startTime/endTime, even when d
     </div>
     <div typeof="rdf:Property" resource="http://schema.org/events">
       <span class="h" property="rdfs:label">events</span>
-      <span property="http://schema.org/supersededBy" href="http://schema.org/event"/>
+      <link property="http://schema.org/supersededBy" href="http://schema.org/event"/>
       <span property="rdfs:comment">Upcoming or past events associated with this place or organization.</span>
       <span>Domain: <a property="http://schema.org/domainIncludes" href="http://schema.org/Organization">Organization</a></span>
       <span>Domain: <a property="http://schema.org/domainIncludes" href="http://schema.org/Place">Place</a></span>
@@ -6427,7 +6427,7 @@ Note that Event uses startDate/endDate instead of startTime/endTime, even when d
     </div>
     <div typeof="rdf:Property" resource="http://schema.org/founders">
       <span class="h" property="rdfs:label">founders</span>
-      <span property="http://schema.org/supersededBy" href="http://schema.org/founder"/>
+      <link property="http://schema.org/supersededBy" href="http://schema.org/founder"/>
       <span property="rdfs:comment">A person who founded this organization.</span>
       <span>Domain: <a property="http://schema.org/domainIncludes" href="http://schema.org/Organization">Organization</a></span>
       <span>Range: <a property="http://schema.org/rangeIncludes" href="http://schema.org/Person">Person</a></span>
@@ -7174,13 +7174,13 @@ Note that Event uses startDate/endDate instead of startTime/endTime, even when d
     <div typeof="rdf:Property" resource="http://schema.org/map">
       <span class="h" property="rdfs:label">map</span>
       <span property="rdfs:comment">A URL to a map of the place.</span>
-      <span property="http://schema.org/supersededBy" href="http://schema.org/hasMap"/>
+      <link property="http://schema.org/supersededBy" href="http://schema.org/hasMap"/>
       <span>Domain: <a property="http://schema.org/domainIncludes" href="http://schema.org/Place">Place</a></span>
       <span>Range: <a property="http://schema.org/rangeIncludes" href="http://schema.org/URL">URL</a></span>
     </div>
     <div typeof="rdf:Property" resource="http://schema.org/maps">
       <span class="h" property="rdfs:label">maps</span>
-      <span property="http://schema.org/supersededBy" href="http://schema.org/hasMap"/>
+      <link property="http://schema.org/supersededBy" href="http://schema.org/hasMap"/>
       <span property="rdfs:comment">A URL to a map of the place.</span>
       <span>Domain: <a property="http://schema.org/domainIncludes" href="http://schema.org/Place">Place</a></span>
       <span>Range: <a property="http://schema.org/rangeIncludes" href="http://schema.org/URL">URL</a></span>
@@ -7247,7 +7247,7 @@ Note that Event uses startDate/endDate instead of startTime/endTime, even when d
     </div>
     <div typeof="rdf:Property" resource="http://schema.org/members">
       <span class="h" property="rdfs:label">members</span>
-      <span property="http://schema.org/supersededBy" href="http://schema.org/member"/>
+      <link property="http://schema.org/supersededBy" href="http://schema.org/member"/>
       <span property="rdfs:comment">A member of this organization.</span>
       <span>Domain: <a property="http://schema.org/domainIncludes" href="http://schema.org/Organization">Organization</a></span>
       <span>domain: <a property="http://schema.org/domainIncludes" href="http://schema.org/ProgramMembership">ProgramMembership</a></span>
@@ -7280,7 +7280,7 @@ Note that Event uses startDate/endDate instead of startTime/endTime, even when d
       <span>Domain: <a property="http://schema.org/domainIncludes" href="http://schema.org/Order">Order</a></span>
       <span>Range: <a property="http://schema.org/rangeIncludes" href="http://schema.org/Organization">Organization</a></span>
       <span>Range: <a property="http://schema.org/rangeIncludes" href="http://schema.org/Person">Person</a></span>
-      <span property="http://schema.org/supersededBy" href="http://schema.org/seller"/>
+      <link property="http://schema.org/supersededBy" href="http://schema.org/seller"/>
     </div>
     <div typeof="rdf:Property" resource="http://schema.org/minPrice">
       <span class="h" property="rdfs:label">minPrice</span>
@@ -7329,7 +7329,7 @@ Note that Event uses startDate/endDate instead of startTime/endTime, even when d
     <div typeof="rdf:Property" resource="http://schema.org/musicGroupMember">
       <span class="h" property="rdfs:label">musicGroupMember</span>
       <span property="rdfs:comment">A member of a music group&amp;#x2014;for example, John, Paul, George, or Ringo.</span>
-      <span property="http://schema.org/supersededBy" href="http://schema.org/member"/>
+      <link property="http://schema.org/supersededBy" href="http://schema.org/member"/>
       <span>Domain: <a property="http://schema.org/domainIncludes" href="http://schema.org/MusicGroup">MusicGroup</a></span>
       <span>Range: <a property="http://schema.org/rangeIncludes" href="http://schema.org/Person">Person</a></span>
     </div>
@@ -7593,7 +7593,7 @@ Note that Event uses startDate/endDate instead of startTime/endTime, even when d
     </div>
     <div typeof="rdf:Property" resource="http://schema.org/parents">
       <span class="h" property="rdfs:label">parents</span>
-      <span property="http://schema.org/supersededBy" href="http://schema.org/parent"/>
+      <link property="http://schema.org/supersededBy" href="http://schema.org/parent"/>
       <span property="rdfs:comment">A parents of the person.</span>
       <span>Domain: <a property="http://schema.org/domainIncludes" href="http://schema.org/Person">Person</a></span>
       <span>Range: <a property="http://schema.org/rangeIncludes" href="http://schema.org/Person">Person</a></span>
@@ -7657,7 +7657,7 @@ Note that Event uses startDate/endDate instead of startTime/endTime, even when d
     </div>
     <div typeof="rdf:Property" resource="http://schema.org/partOfTVSeries">
       <span class="h" property="rdfs:label">partOfTVSeries</span>
-      <span property="http://schema.org/supersededBy" href="http://schema.org/partOfSeries"/>
+      <link property="http://schema.org/supersededBy" href="http://schema.org/partOfSeries"/>
       <span property="rdfs:comment">The TV series to which this episode or season belongs.</span>
       <span>Domain: <a property="http://schema.org/domainIncludes" href="http://schema.org/TVEpisode">TVEpisode</a></span>
       <span>Domain: <a property="http://schema.org/domainIncludes" href="http://schema.org/TVSeason">TVSeason</a></span>
@@ -7720,7 +7720,7 @@ Note that Event uses startDate/endDate instead of startTime/endTime, even when d
     </div>
     <div typeof="rdf:Property" resource="http://schema.org/performers">
       <span class="h" property="rdfs:label">performers</span>
-      <span property="http://schema.org/supersededBy" href="http://schema.org/performer"/>
+      <link property="http://schema.org/supersededBy" href="http://schema.org/performer"/>
       <span property="rdfs:comment">The main performer or performers of the event&amp;#x2014;for example, a presenter, musician, or actor.</span>
       <span>Domain: <a property="http://schema.org/domainIncludes" href="http://schema.org/Event">Event</a></span>
       <span>Range: <a property="http://schema.org/rangeIncludes" href="http://schema.org/Organization">Organization</a></span>
@@ -7754,7 +7754,7 @@ Note that Event uses startDate/endDate instead of startTime/endTime, even when d
     </div>
     <div typeof="rdf:Property" resource="http://schema.org/photos">
       <span class="h" property="rdfs:label">photos</span>
-      <span property="http://schema.org/supersededBy" href="http://schema.org/photo"/>
+      <link property="http://schema.org/supersededBy" href="http://schema.org/photo"/>
       <span property="rdfs:comment">Photographs of this place.</span>
       <span>Domain: <a property="http://schema.org/domainIncludes" href="http://schema.org/Place">Place</a></span>
       <span>Range: <a property="http://schema.org/rangeIncludes" href="http://schema.org/ImageObject">ImageObject</a></span>
@@ -8442,7 +8442,7 @@ Note that Event uses startDate/endDate instead of startTime/endTime, even when d
     </div>
     <div typeof="rdf:Property" resource="http://schema.org/reviews">
       <span class="h" property="rdfs:label">reviews</span>
-      <span property="http://schema.org/supersededBy" href="http://schema.org/review"/>
+      <link property="http://schema.org/supersededBy" href="http://schema.org/review"/>
       <span property="rdfs:comment">Review of the item.</span>
       <span>Domain: <a property="http://schema.org/domainIncludes" href="http://schema.org/CreativeWork">CreativeWork</a></span>
       <span>Domain: <a property="http://schema.org/domainIncludes" href="http://schema.org/Organization">Organization</a></span>
@@ -8551,7 +8551,7 @@ Note that Event uses startDate/endDate instead of startTime/endTime, even when d
     </div>
     <div typeof="rdf:Property" resource="http://schema.org/seasons">
       <span class="h" property="rdfs:label">seasons</span>
-      <span property="http://schema.org/supersededBy" href="http://schema.org/season"/>
+      <link property="http://schema.org/supersededBy" href="http://schema.org/season"/>
       <span property="rdfs:comment">A season in a media series.</span>
       <span>Domain: <a property="http://schema.org/domainIncludes" href="http://schema.org/VideoGameSeries">VideoGameSeries</a></span>
       <span>Domain: <a property="http://schema.org/domainIncludes" href="http://schema.org/TVSeries">TVSeries</a></span>
@@ -8629,7 +8629,7 @@ Note that Event uses startDate/endDate instead of startTime/endTime, even when d
     <div typeof="rdf:Property" resource="http://schema.org/serviceAudience">
       <span class="h" property="rdfs:label">serviceAudience</span>
       <span property="rdfs:comment">The audience eligible for this service.</span>
-      <span property="http://schema.org/supersededBy" href="http://schema.org/audience"/>
+      <link property="http://schema.org/supersededBy" href="http://schema.org/audience"/>
       <span>Domain: <a property="http://schema.org/domainIncludes" href="http://schema.org/Service">Service</a></span>
       <span>Range: <a property="http://schema.org/rangeIncludes" href="http://schema.org/Audience">Audience</a></span>
     </div>
@@ -8689,7 +8689,7 @@ Note that Event uses startDate/endDate instead of startTime/endTime, even when d
     </div>
     <div typeof="rdf:Property" resource="http://schema.org/siblings">
       <span class="h" property="rdfs:label">siblings</span>
-      <span property="http://schema.org/supersededBy" href="http://schema.org/sibling"/>
+      <link property="http://schema.org/supersededBy" href="http://schema.org/sibling"/>
       <span property="rdfs:comment">A sibling of the person.</span>
       <span>Domain: <a property="http://schema.org/domainIncludes" href="http://schema.org/Person">Person</a></span>
       <span>Range: <a property="http://schema.org/rangeIncludes" href="http://schema.org/Person">Person</a></span>
@@ -8714,7 +8714,7 @@ Note that Event uses startDate/endDate instead of startTime/endTime, even when d
     </div>
     <div typeof="rdf:Property" resource="http://schema.org/significantLinks">
       <span class="h" property="rdfs:label">significantLinks</span>
-      <span property="http://schema.org/supersededBy" href="http://schema.org/significantLink"/>
+      <link property="http://schema.org/supersededBy" href="http://schema.org/significantLink"/>
       <span property="rdfs:comment">The most significant URLs on the page. Typically, these are the non-navigation links that are clicked on the most.</span>
       <span>Domain: <a property="http://schema.org/domainIncludes" href="http://schema.org/WebPage">WebPage</a></span>
       <span>Range: <a property="http://schema.org/rangeIncludes" href="http://schema.org/URL">URL</a></span>
@@ -8919,7 +8919,7 @@ Note that Event uses startDate/endDate instead of startTime/endTime, even when d
     </div>
     <div typeof="rdf:Property" resource="http://schema.org/subEvents">
       <span class="h" property="rdfs:label">subEvents</span>
-      <span property="http://schema.org/supersededBy" href="http://schema.org/subEvent"/>
+      <link property="http://schema.org/supersededBy" href="http://schema.org/subEvent"/>
       <span property="rdfs:comment">Events that are a part of this event. For example, a conference event includes many presentations, each subEvents of the conference.</span>
       <span>Domain: <a property="http://schema.org/domainIncludes" href="http://schema.org/Event">Event</a></span>
       <span>Range: <a property="http://schema.org/rangeIncludes" href="http://schema.org/Event">Event</a></span>
@@ -9137,7 +9137,7 @@ Note that Event uses startDate/endDate instead of startTime/endTime, even when d
     </div>
     <div typeof="rdf:Property" resource="http://schema.org/tracks">
       <span class="h" property="rdfs:label">tracks</span>
-      <span property="http://schema.org/supersededBy" href="http://schema.org/track"/>
+      <link property="http://schema.org/supersededBy" href="http://schema.org/track"/>
       <span property="rdfs:comment">A music recording (track)&amp;#x2014;usually a single song.</span>
       <span>Domain: <a property="http://schema.org/domainIncludes" href="http://schema.org/MusicPlaylist">MusicPlaylist</a></span>
       <span>Domain: <a property="http://schema.org/domainIncludes" href="http://schema.org/MusicGroup">MusicGroup</a></span>
@@ -9329,7 +9329,7 @@ Note that Event uses startDate/endDate instead of startTime/endTime, even when d
       <span>Domain: <a property="http://schema.org/domainIncludes" href="http://schema.org/BuyAction">BuyAction</a></span>
       <span>Range: <a property="http://schema.org/rangeIncludes" href="http://schema.org/Organization">Organization</a></span>
       <span>Range: <a property="http://schema.org/rangeIncludes" href="http://schema.org/Person">Person</a></span>
-      <span property="http://schema.org/supersededBy" href="http://schema.org/seller"/>
+      <link property="http://schema.org/supersededBy" href="http://schema.org/seller"/>
     </div>
     <div typeof="rdf:Property" resource="http://schema.org/version">
       <span class="h" property="rdfs:label">version</span>
@@ -9372,7 +9372,7 @@ Note that Event uses startDate/endDate instead of startTime/endTime, even when d
     <div typeof="rdf:Property" resource="http://schema.org/warrantyPromise">
       <span class="h" property="rdfs:label">warrantyPromise</span>
       <span property="rdfs:comment">The warranty promise(s) included in the offer.</span>
-      <span property="http://schema.org/supersededBy" href="http://schema.org/warranty"/>
+      <link property="http://schema.org/supersededBy" href="http://schema.org/warranty"/>
       <span>Domain: <a property="http://schema.org/domainIncludes" href="http://schema.org/BuyAction">BuyAction</a></span>
       <span>Domain: <a property="http://schema.org/domainIncludes" href="http://schema.org/SellAction">SellAction</a></span>
       <span>Range: <a property="http://schema.org/rangeIncludes" href="http://schema.org/WarrantyPromise">WarrantyPromise</a></span>
@@ -9680,7 +9680,7 @@ Note that Event uses startDate/endDate instead of startTime/endTime, even when d
       <span>domain: <a property="http://schema.org/domainIncludes" href="http://schema.org/Reservation">Reservation</a></span>
       <span>Range: <a property="http://schema.org/rangeIncludes" href="http://schema.org/Person">Person</a></span>
       <span>Range: <a property="http://schema.org/rangeIncludes" href="http://schema.org/Organization">Organization</a></span>
-      <span property="http://schema.org/supersededBy" href="http://schema.org/broker"/>
+      <link property="http://schema.org/supersededBy" href="http://schema.org/broker"/>
     </div>
     <div typeof="rdf:Property" resource="http://schema.org/bookingTime">
       <span class="h" property="rdfs:label">bookingTime</span>
@@ -10446,7 +10446,7 @@ postponing for 1.6.
 
     <div typeof="rdf:Property" resource="http://schema.org/namedPosition">
       <span class="h" property="rdfs:label">namedPosition</span>
-      <span property="http://schema.org/supersededBy" href="http://schema.org/roleName"/>
+      <link property="http://schema.org/supersededBy" href="http://schema.org/roleName"/>
       <span property="rdfs:comment">A position played, performed or filled by a person or organization, as part of an organization. For example, an athlete in a SportsTeam might play in the position named 'Quarterback'.</span>
       <span>domainIncludes: <a property="http://schema.org/domainIncludes" href="http://schema.org/Role">Role</a></span>
       <span>rangeIncludes: <a property="http://schema.org/rangeIncludes" href="http://schema.org/Text">Text</a></span>


### PR DESCRIPTION
For some `supersededBy` entries, `span` was used instead of `link`.