### PR TITLE
changed property names for configuration, damages, doors, engine, gears, transmission

### DIFF
--- a/data/schema.rdfa
+++ b/data/schema.rdfa
@@ -11671,8 +11671,8 @@ postponing for 1.6.
         <span>Range: <a property="http://schema.org/rangeIncludes" href="http://schema.org/QuantitativeValue">QuantitativeValue</a></span>
         <span>Source:  <a property="dc:source" href="http://www.w3.org/wiki/WebSchemas/SchemaDotOrgSources#Automotive_Ontology_Working_Group">GAO</a></span>
     </div>
-    <div typeof="rdf:Property" resource="http://schema.org/transmission">
-        <span class="h" property="rdfs:label">transmission</span>
+    <div typeof="rdf:Property" resource="http://schema.org/vehicleTransmission">
+        <span class="h" property="rdfs:label">vehicleTransmission</span>
         <span property="rdfs:comment">The type of component used for transmitting the power from a rotating power source to the wheels or other relevant component(s) ("gearbox" for cars).</span>
         <span>Domain: <a property="http://schema.org/domainIncludes" href="http://schema.org/Vehicle">Vehicle</a></span>
         <span>Range: <a property="http://schema.org/rangeIncludes" href="http://schema.org/Text">Text</a></span>
@@ -11730,8 +11730,8 @@ postponing for 1.6.
         <span>Range: <a property="http://schema.org/rangeIncludes" href="http://schema.org/QuantitativeValue">QuantitativeValue</a></span>
         <span>Source:  <a property="dc:source" href="http://www.w3.org/wiki/WebSchemas/SchemaDotOrgSources#Automotive_Ontology_Working_Group">GAO</a></span>
     </div>
-    <div typeof="rdf:Property" resource="http://schema.org/doors">
-        <span class="h" property="rdfs:label">doors</span>
+    <div typeof="rdf:Property" resource="http://schema.org/numberOfDoors">
+        <span class="h" property="rdfs:label">numberOfDoors</span>
         <span property="rdfs:comment">The number of doors.&lt;br /&gt;
     Typical unit code(s): C62</span>
         <span>Domain: <a property="http://schema.org/domainIncludes" href="http://schema.org/Vehicle">Vehicle</a></span>
@@ -11770,8 +11770,8 @@ postponing for 1.6.
         <span>Range: <a property="http://schema.org/rangeIncludes" href="http://schema.org/QuantitativeValue">QuantitativeValue</a></span>
         <span>Source:  <a property="dc:source" href="http://www.w3.org/wiki/WebSchemas/SchemaDotOrgSources#Automotive_Ontology_Working_Group">GAO</a></span>
     </div>
-    <div typeof="rdf:Property" resource="http://schema.org/gears">
-        <span class="h" property="rdfs:label">gears</span>
+    <div typeof="rdf:Property" resource="http://schema.org/numberOfForwardGears">
+        <span class="h" property="rdfs:label">numberOfForwardGears</span>
         <span property="rdfs:comment">The total number of forward gears available for the transmission system of the vehicle.&lt;br /&gt;
     Typical unit code(s): C62</span>
         <span>Domain: <a property="http://schema.org/domainIncludes" href="http://schema.org/Vehicle">Vehicle</a></span>
@@ -11863,8 +11863,8 @@ postponing for 1.6.
         <span>Range: <a property="http://schema.org/rangeIncludes" href="http://schema.org/CarUsageType">CarUsageType</a></span>
         <span>Source:  <a property="dc:source" href="http://www.w3.org/wiki/WebSchemas/SchemaDotOrgSources#Automotive_Ontology_Working_Group">GAO</a></span>
     </div>
-    <div typeof="rdf:Property" resource="http://schema.org/damages">
-        <span class="h" property="rdfs:label">damages</span>
+    <div typeof="rdf:Property" resource="http://schema.org/knownVehicleDamages">
+        <span class="h" property="rdfs:label">knownVehicleDamages</span>
         <span property="rdfs:comment">A textual description of known damages, both repaired and unrepaired.</span>
         <span>Domain: <a property="http://schema.org/domainIncludes" href="http://schema.org/Vehicle">Vehicle</a></span>
         <span>Range: <a property="http://schema.org/rangeIncludes" href="http://schema.org/Text">Text</a></span>
@@ -11877,15 +11877,15 @@ postponing for 1.6.
         <span>Range: <a property="http://schema.org/rangeIncludes" href="http://schema.org/Date">Date</a></span>
         <span>Source:  <a property="dc:source" href="http://www.w3.org/wiki/WebSchemas/SchemaDotOrgSources#Automotive_Ontology_Working_Group">GAO</a></span>
     </div>
-    <div typeof="rdf:Property" resource="http://schema.org/engine">
-        <span class="h" property="rdfs:label">engine</span>
+    <div typeof="rdf:Property" resource="http://schema.org/vehicleEngine">
+        <span class="h" property="rdfs:label">vehicleEngine</span>
         <span property="rdfs:comment">Information about the engine or engines of the vehicle.</span>
         <span>Domain: <a property="http://schema.org/domainIncludes" href="http://schema.org/Vehicle">Vehicle</a></span>
         <span>Range: <a property="http://schema.org/rangeIncludes" href="http://schema.org/EngineSpecification">EngineSpecification</a></span>
         <span>Source:  <a property="dc:source" href="http://www.w3.org/wiki/WebSchemas/SchemaDotOrgSources#Automotive_Ontology_Working_Group">GAO</a></span>
     </div>
-    <div typeof="rdf:Property" resource="http://schema.org/configuration">
-        <span class="h" property="rdfs:label">configuration</span>
+    <div typeof="rdf:Property" resource="http://schema.org/vehicleConfiguration">
+        <span class="h" property="rdfs:label">vehicleConfiguration</span>
         <span property="rdfs:comment">A short text indicating the configuration of the vehicle, e.g. &apos;5dr hatchback ST 2.5 MT 225 hp&apos; or &apos;limited edition&apos;.</span>
         <span>Domain: <a property="http://schema.org/domainIncludes" href="http://schema.org/Vehicle">Vehicle</a></span>
         <span>Range: <a property="http://schema.org/rangeIncludes" href="http://schema.org/Text">Text</a></span>

--- a/data/sdo-automobile-examples.txt
+++ b/data/sdo-automobile-examples.txt
@@ -61,20 +61,20 @@ MICRODATA:
     wood paneling</span></p>
   <p><strong>Model Year: </strong><time itemprop="modelDate">2009</time></p>    
   <p><strong>Transmission: </strong>
-    <span itemprop="transmission">6 speed Sports Automatic Dual Clutch</span>
+    <span itemprop="vehicleTransmission">6 speed Sports Automatic Dual Clutch</span>
   </p>  
   <p><strong>VIN: </strong><span itemprop="vin">WVWZZZ1KZ9U######</span></p>  
-  <p><strong>Number of gears: </strong><span itemprop="gears">6</span></p>    
+  <p><strong>Number of gears: </strong><span itemprop="numberOfForwardGears">6</span></p>    
   <p><strong>Body: </strong>
     <span itemprop="bodyType">Hatchback</span>
   </p>
-  <p><strong>Number of doors: </strong><span itemprop="doors">3</span></p>
+  <p><strong>Number of doors: </strong><span itemprop="numberOfDoors">3</span></p>
   <p><strong>Number of seats: </strong><span itemprop="seatingCapacity">5</span></p>
   <p><strong>Drive Type: </strong>
     <link itemprop="driveWheelConfiguration" href="http://schema.org/FWD" />
     Front Wheel Drive
   </p>
-  <div itemprop="engine" itemscope itemtype="http://schema.org/EngineSpecification">
+  <div itemprop="vehicleEngine" itemscope itemtype="http://schema.org/EngineSpecification">
     <p><strong>Engine: </strong>
       <span itemprop="name">4 cylinder Petrol Turbo Intercooled 2.0 L (1984 cc)</span>
     </p>
@@ -134,20 +134,20 @@ RDFA:
       <p><strong>Interior Type: </strong><span property="interiorType">Leather upholstery, wood paneling</span></p>
       <p><strong>Model Year: </strong><time property="modelDate">2009</time></p> 
       <p><strong>Transmission: </strong>
-        <span property="transmission">6 speed Sports Automatic Dual Clutch</span>
+        <span property="vehicleTransmission">6 speed Sports Automatic Dual Clutch</span>
       </p> 
       <p><strong>VIN: </strong><span property="vin">WVWZZZ1KZ9U######</span></p> 
-      <p><strong>Number of gears: </strong><span property="gears">6</span></p> 
+      <p><strong>Number of gears: </strong><span property="numberOfForwardGears">6</span></p> 
       <p><strong>Body: </strong>
         <span property="bodyType">Hatchback</span>
       </p>
-      <p><strong>Number of doors: </strong><span property="doors">3</span></p>
+      <p><strong>Number of doors: </strong><span property="numberOfDoors">3</span></p>
       <p><strong>Number of seats: </strong><span property="seatingCapacity">5</span></p>
       <p><strong>Drive Type: </strong>
         <link property="driveWheelConfiguration" href="http://schema.org/FWD" />
         Front Wheel Drive
       </p>
-      <div property="engine" typeOf="EngineSpecification">
+      <div property="vehicleEngine" typeOf="EngineSpecification">
         <p><strong>Engine: </strong>
           <span property="name">4 cylinder Petrol Turbo Intercooled 2.0 L (1984 cc)</span>
         </p>
@@ -206,14 +206,14 @@ JSON:
         "interiorColor" : "Black",
         "interiorType" : "Leather upholstery, wood paneling",
         "modelDate" : "2009",
-        "transmission" : "6 speed Sports Automatic Dual Clutch",
+        "vehicleTransmission" : "6 speed Sports Automatic Dual Clutch",
         "vin" : "WVWZZZ1KZ9U######",
-        "gears" : "6",
+        "numberOfForwardGears" : "6",
         "bodyType" : "Hatchback",
-        "doors" : "3",
+        "numberOfDoors" : "3",
         "seatingCapacity" : "5",
         "driveWheelConfiguration" : "http://schema.org/FWD",
-        "engine" : {
+        "vehicleEngine" : {
             "@type": "EngineSpecification",
             "name" : "4 cylinder Petrol Turbo Intercooled 2.0 L (1984 cc)",
             "enginePower" : { 


### PR DESCRIPTION
This pull requests implements the proposed changes to property names in the vocabulary and example for the new automotive part in order to reduce the risk of future name clashes as per @vholland's suggestion in issue #417.

configuration	NEW	vehicleConfiguration
damages	NEW	knownVehicleDamages
doors	NEW	numberOfDoors
engine	NEW	vehicleEngine
gears	NEW	numberOfForwardGears
transmission	NEW	vehicleTransmission
