### PR TITLE
Change examples of <meta ... href=""> to <link ... href="">

### DIFF
--- a/data/examples.txt
+++ b/data/examples.txt
@@ -10599,7 +10599,7 @@ MICRODATA:
     <link itemprop="url" href="/examples/ticket/12341234" />
     <meta itemprop="price" content="40"/>
     <meta itemprop="priceCurrency" content="USD" />
-    <meta itemprop="availability" href="http://schema.org/InStock"/>
+    <link itemprop="availability" href="http://schema.org/InStock"/>
   </div>
 
   <h2 itemprop="name">Shostakovich Leningrad</h2>
@@ -10667,7 +10667,7 @@ RDFA:
     <link property="url" href="/examples/ticket/12341234"/>
     <meta property="price" content="40"/>
     <meta property="priceCurrency" content="USD" />
-    <meta property="availability" href="http://schema.org/InStock"/>
+    <link property="availability" href="http://schema.org/InStock"/>
   </div>
 
   <h2 property="name">Shostakovich Leningrad</h2>

--- a/data/sdo-periodical-examples.txt
+++ b/data/sdo-periodical-examples.txt
@@ -619,14 +619,14 @@ MICRODATA:
 <p>
     The book has also been adapted for the screen several times.
     <span itemscope itemtype="http://schema.org/Movie">
-        <meta itemprop="exampleOfWork" href="http://www.freebase.com/m/0h35m">
+        <link itemprop="exampleOfWork" href="http://www.freebase.com/m/0h35m">
         <em itemprop="name">J.R.R. Tolkien's The Lord of the Rings</em>, an
         animated version directed by <span itemprop="director">Ralph Bakshi</span>
         and released in <time itemprop="datePublished">1978</time>, covered the
         events of the novel and parts of its sequel.
     </span>
     <span itemscope itemtype="http://schema.org/Movie">
-        <meta itemprop="exampleOfWork" href="http://www.freebase.com/m/0h35m">
+        <link itemprop="exampleOfWork" href="http://www.freebase.com/m/0h35m">
         The movie <em itemprop="name">The Lord of the Rings: The Fellowship of the
         Ring</em>, directed by <span itemprop="director">Peter Jackson</span> and
         released in <time itemprop="datePublished">2001</time>, ran
@@ -662,14 +662,14 @@ RDFA:
     <p>
         The book has also been adapted for the screen several times.
         <span typeof="Movie">
-            <meta property="exampleOfWork" href="http://www.freebase.com/m/0h35m">
+            <link property="exampleOfWork" href="http://www.freebase.com/m/0h35m">
             <em property="name">J.R.R. Tolkien's The Lord of the Rings</em>, an
             animated version directed by <span property="director">Ralph Bakshi</span>
             and released in <time property="datePublished">1978</time>, covered the
             events of the novel and parts of its sequel.
         </span>
         <span typeof="Movie">
-            <meta property="exampleOfWork" href="http://www.freebase.com/m/0h35m">
+            <link property="exampleOfWork" href="http://www.freebase.com/m/0h35m">
             The movie <em property="name">The Lord of the Rings: The Fellowship of the
             Ring</em>, directed by <span property="director">Peter Jackson</span> and
             released in <time property="datePublished">2001</time>, ran


### PR DESCRIPTION
A few instances of <meta property="" href=""> had crept into examples, but
<link property="" href=""> is the preferred formulation.

Related to #77, which focuses on the more worrisome <meta property=""
content="http://example.com"> usage in examples.

Signed-off-by: Dan Scott <dan@coffeecode.net>