### PR TITLE
Book examples: fixes

### DIFF
--- a/data/examples.txt
+++ b/data/examples.txt
@@ -1048,7 +1048,7 @@ Catcher in the Rye is a fun book. It's a good book to read.
 MICRODATA:
 
 <body itemscope itemtype="http://schema.org/WebPage">
-...
+<!-- … -->
 <div itemprop="breadcrumb">
   <a href="category/books.html">Books</a> >
   <a href="category/books-literature.html">Literature & Fiction</a> >
@@ -1085,7 +1085,7 @@ Reviews:
 
 <div itemprop="review" itemscope itemtype="http://schema.org/Review">
   <span itemprop="reviewRating">5</span> stars -
-  <b>"<span itemprop="name">A masterpiece of literature</span>" </b>
+  <b>"<span itemprop="name">A masterpiece of literature</span>"</b> 
   by <span itemprop="author">John Doe</span>,
   Written on <meta itemprop="datePublished" content="2006-05-04">May 4, 2006
   <span itemprop="reviewBody">I really enjoyed this book. It captures the essential
@@ -1094,20 +1094,20 @@ Reviews:
 
 <div itemprop="review" itemscope itemtype="http://schema.org/Review">
   <span itemprop="reviewRating">4</span> stars -
-  <b>"<span itemprop="name">A good read.</span>" </b>
+  <b>"<span itemprop="name">A good read.</span>"</b> 
   by <span itemprop="author">Bob Smith</span>,
   Written on <meta itemprop="datePublished" content="2006-06-15">June 15, 2006
   <span itemprop="reviewBody">Catcher in the Rye is a fun book. It's a good book to read.</span>
 </div>
 
 </div>
-...
+<!-- … -->
 </body>
 
 RDFA:
 
 <body vocab="http://schema.org/" typeof="WebPage">
-...
+<!-- … -->
 <div property="breadcrumb">
   <a href="category/books.html">Books</a> >
   <a href="category/books-literature.html">Literature & Fiction</a> >
@@ -1127,7 +1127,7 @@ by <a property="author" href="/author/jd_salinger.html">J.D. Salinger</a>
   <span property="reviewCount">3077</span> reviews
 </div>
 
-<div property="offers"  typeof="Offer">
+<div property="offers" typeof="Offer">
   Price: $<span property="price">6.99</span>
   <meta property="priceCurrency" content="USD">
   <link property="availability" href="http://schema.org/InStock">In Stock
@@ -1144,7 +1144,7 @@ Reviews:
 
 <div property="review" typeof="Review">
   <span property="reviewRating">5</span> stars -
-  <b>"<span property="name">A masterpiece of literature</span>" </b>
+  <b>"<span property="name">A masterpiece of literature</span>"</b> 
   by <span property="author">John Doe</span>,
   Written on <meta property="datePublished" content="2006-05-04">May 4, 2006
   <span property="reviewBody">I really enjoyed this book. It captures the essential
@@ -1153,14 +1153,14 @@ Reviews:
 
 <div property="review" typeof="Review">
   <span property="reviewRating">4</span> stars -
-  <b>"<span property="name">A good read.</span>" </b>
+  <b>"<span property="name">A good read.</span>"</b> 
   by <span property="author">Bob Smith</span>,
   Written on <meta property="datePublished" content="2006-06-15">June 15, 2006
   <span property="reviewBody">Catcher in the Rye is a fun book. It's a good book to read.</span>
 </div>
 
 </div>
-...
+<!-- … -->
 </body>
 
 JSON:

--- a/data/examples.txt
+++ b/data/examples.txt
@@ -1020,7 +1020,7 @@ PRE-MARKUP:
  <a href="category/books-classics">Classics</a>
 
 <img src="catcher-in-the-rye-book-cover.jpg"
-  alt="cover art: red horse, city in background"/>
+  alt="cover art: red horse, city in background">
 The Catcher in the Rye - Mass Market Paperback
 by <a href="/author/jd_salinger.html">J.D. Salinger</a>
 4 stars - 3077 reviews
@@ -1036,12 +1036,12 @@ ISBN-10: 0316769487
 
 Reviews:
 
-5 stars - <b>"A masterpiece of literature" </b>
+5 stars - <b>"A masterpiece of literature"</b> 
 by John Doe. Written on May 4, 2006
 I really enjoyed this book. It captures the essential challenge people face
 as they try make sense of their lives and grow to adulthood.
 
-4 stars - <b>"love it LOLOL111!" </b>
+4 stars - <b>"love it LOLOL111!"</b> 
 by Bob Smith, Written on June 15, 2006
 Catcher in the Rye is a fun book. It's a good book to read.
 
@@ -1058,7 +1058,7 @@ MICRODATA:
 <div itemscope itemtype="http://schema.org/Book">
 
 <img itemprop="image" src="catcher-in-the-rye-book-cover.jpg"
-     alt="cover art: red horse, city in background" />
+     alt="cover art: red horse, city in background">
 <span itemprop="name">The Catcher in the Rye</span> -
  <link itemprop="bookFormat" href="http://schema.org/Paperback">Mass Market Paperback
 by <a itemprop="author" href="/author/jd_salinger.html">J.D. Salinger</a>
@@ -1069,8 +1069,8 @@ by <a itemprop="author" href="/author/jd_salinger.html">J.D. Salinger</a>
 </div>
 
 <div itemprop="offers" itemscope itemtype="http://schema.org/Offer">
-  Price: <span itemprop="price" content="6.99">$6.99</span>
-  <meta itemprop="priceCurrency" content="USD" />
+  Price: $<span itemprop="price">6.99</span>
+  <meta itemprop="priceCurrency" content="USD">
   <link itemprop="availability" href="http://schema.org/InStock">In Stock
 </div>
 
@@ -1114,22 +1114,22 @@ RDFA:
   <a href="category/books-classics">Classics</a>
 </div>
 
-<div  typeof="Book">
+<div typeof="Book">
 
 <img property="image" src="catcher-in-the-rye-book-cover.jpg"
-    alt="cover art: red horse, city in background"/>
+    alt="cover art: red horse, city in background">
 <span property="name">The Catcher in the Rye</span> -
  <link property="bookFormat" href="http://schema.org/Paperback">Mass Market Paperback
 by <a property="author" href="/author/jd_salinger.html">J.D. Salinger</a>
 
-<div property="aggregateRating"  typeof="AggregateRating">
+<div property="aggregateRating" typeof="AggregateRating">
   <span property="ratingValue">4</span> stars -
   <span property="reviewCount">3077</span> reviews
 </div>
 
 <div property="offers"  typeof="Offer">
-  Price: <span property="price" content="6.99">$6.99</span>
-  <meta property="priceCurrency" content="USD" />
+  Price: $<span property="price">6.99</span>
+  <meta property="priceCurrency" content="USD">
   <link property="availability" href="http://schema.org/InStock">In Stock
 </div>
 
@@ -1142,7 +1142,7 @@ ISBN-10: <span property="isbn">0316769487</span>
 
 Reviews:
 
-<div property="review"  typeof="Review">
+<div property="review" typeof="Review">
   <span property="reviewRating">5</span> stars -
   <b>"<span property="name">A masterpiece of literature</span>" </b>
   by <span property="author">John Doe</span>,
@@ -1151,7 +1151,7 @@ Reviews:
   challenge people face as they try make sense of their lives and grow to adulthood.</span>
 </div>
 
-<div property="review"  typeof="Review">
+<div property="review" typeof="Review">
   <span property="reviewRating">4</span> stars -
   <b>"<span property="name">A good read.</span>" </b>
   by <span property="author">Bob Smith</span>,

--- a/data/sdo-periodical-examples.txt
+++ b/data/sdo-periodical-examples.txt
@@ -303,18 +303,18 @@ MICRODATA:
 <!-- A trilogy of books with numbered volumes. -->
 <div>
   <p itemscope itemtype="http://schema.org/Book" itemid="#trilogy">
-  <link itemprop="about" href="http://id.worldcat.org/fast/1020337">
+    <link itemprop="about" href="http://id.worldcat.org/fast/1020337">
     The <strong itemprop="name">Lord of the Rings</strong> is an 
-    <span itemprop="inLanguage" content="en">English-language</span> 
+    <meta itemprop="inLanguage" content="en">English-language 
     <span itemprop="genre">fictional</span> trilogy by
-  <span itemprop="author" itemscope itemtype="http://schema.org/Person" itemid="#author">
-    <link itemprop="sameAs" href="http://viaf.org/viaf/95218067">
-    <span itemprop="name" content="Tolkien, J. R. R. (John Ronald Reuel)">J. R. R. Tolkien</span>
-    (<span itemprop="birthDate">1892</span>-<span itemprop="deathDate">1973</span>).
-  </span>
-  <link itemprop="hasPart" href="#book1">
-  <link itemprop="hasPart" href="#book2">
-  <link itemprop="hasPart" href="#book3">
+    <span itemprop="author" itemscope itemtype="http://schema.org/Person" itemid="#author">
+      <link itemprop="sameAs" href="http://viaf.org/viaf/95218067">
+      <meta itemprop="name" content="Tolkien, J. R. R. (John Ronald Reuel)">J. R. R. Tolkien
+      (<span itemprop="birthDate">1892</span>-<span itemprop="deathDate">1973</span>).
+    </span>
+    <link itemprop="hasPart" href="#book1">
+    <link itemprop="hasPart" href="#book2">
+    <link itemprop="hasPart" href="#book3">
   </p>
   <p>
     The books in the trilogy are:
@@ -352,18 +352,18 @@ RDFA:
 <!-- A trilogy of books with numbered volumes. -->
 <div vocab="http://schema.org/">
   <p typeof="Book" resource="#trilogy">
-  <link property="about" href="http://id.worldcat.org/fast/1020337">
+    <link property="about" href="http://id.worldcat.org/fast/1020337">
     The <strong property="name">Lord of the Rings</strong> is an 
     <span property="inLanguage" content="en">English-language</span> 
     <span property="genre">fictional</span> trilogy by
-  <span property="author" typeof="Person" resource="#author">
+    <span property="author" typeof="Person" resource="#author">
     <link property="sameAs" href="http://viaf.org/viaf/95218067">
     <span property="name" content="Tolkien, J. R. R. (John Ronald Reuel)">J. R. R. Tolkien</span>
-    (<span property="birthDate">1892</span>-<span property="deathDate">1973</span>).
-  </span>
-  <link property="hasPart" href="#book1">
-  <link property="hasPart" href="#book2">
-  <link property="hasPart" href="#book3">
+      (<span property="birthDate">1892</span>-<span property="deathDate">1973</span>).
+    </span>
+    <link property="hasPart" href="#book1">
+    <link property="hasPart" href="#book2">
+    <link property="hasPart" href="#book3">
   </p>
   <p>
     The books in the trilogy are:


### PR DESCRIPTION
In Microdata, only the `meta` element can have a `content` attribute (see https://github.com/schemaorg/schemaorg/issues/184):

* for `inLanguage`: using `meta` instead of `span` in Microdata (keeping `span` in RDFa)
* for `price`: omitting `content` in Microdata and RDFa, because it was not needed (moving the "$" outside of the `price` property)