### PR TITLE
CreativeWork/ItemList example: byArtist expects MusicGroup, not Person

### DIFF
--- a/data/examples.txt
+++ b/data/examples.txt
@@ -2532,7 +2532,7 @@ RDFA:
   <meta content="8" property="numTracks" />
   <meta content="Alt/Punk" property="genre" />
 
-  <h2 property="byArtist"  typeof="MusicGroup">
+  <h2 property="byArtist" typeof="MusicGroup">
     <span property="name">Radiohead</span>
   </h2>
 
@@ -12209,7 +12209,7 @@ MICRODATA:
     <span itemprop="name" content="John Doe">by John Doe</span>
   </div>
   <div itemprop="about" itemscope itemtype="http://schema.org/MusicRecording">
-    <div itemprop="byArtist" itemscope itemtype="http://schema.org/Person">
+    <div itemprop="byArtist" itemscope itemtype="http://schema.org/MusicGroup">
       <meta itemprop="name" content="Bob Dylan" />
     </div>
   </div>
@@ -12219,7 +12219,7 @@ MICRODATA:
     <span itemprop="position">5</span>
     <div itemprop="item" itemscope itemtype="http://schema.org/MusicRecording">
       <span itemprop="name">If Not For You</span>
-      <div itemprop="byArtist" itemscope itemtype="http://schema.org/Person">
+      <div itemprop="byArtist" itemscope itemtype="http://schema.org/MusicGroup">
         <span itemprop="name">George Harrison</span>
       </div>
     </div>
@@ -12228,7 +12228,7 @@ MICRODATA:
     <span itemprop="position">4</span>
     <div itemprop="item" itemscope itemtype="http://schema.org/MusicRecording">
       <span itemprop="name">The Times They Are A-Changin'</span>
-      <div itemprop="byArtist" itemscope itemtype="http://schema.org/Person">
+      <div itemprop="byArtist" itemscope itemtype="http://schema.org/MusicGroup">
         <span itemprop="name">Tracy Chapman</span>
       </div>
     </div>
@@ -12237,10 +12237,10 @@ MICRODATA:
     <span itemprop="position">3</span>
     <div itemprop="item" itemscope itemtype="http://schema.org/MusicRecording">
       <span itemprop="name">It Ain't Me Babe</span>
-      <div itemprop="byArtist" itemscope itemtype="http://schema.org/Person">
+      <div itemprop="byArtist" itemscope itemtype="http://schema.org/MusicGroup">
         <span itemprop="name">Johnny Cash</span>
       </div>
-      <div itemprop="byArtist" itemscope itemtype="http://schema.org/Person">
+      <div itemprop="byArtist" itemscope itemtype="http://schema.org/MusicGroup">
         <span itemprop="name">June Carter Cash</span>
       </div>
     </div>
@@ -12249,7 +12249,7 @@ MICRODATA:
     <span itemprop="position">2</span>
     <div itemprop="item" itemscope itemtype="http://schema.org/MusicRecording">
       <span itemprop="name">Don't Think Twice It's Alright</span>
-      <div itemprop="byArtist" itemscope itemtype="http://schema.org/Person">
+      <div itemprop="byArtist" itemscope itemtype="http://schema.org/MusicGroup">
         <span itemprop="name">Waylon Jennings</span>
       </div>
     </div>
@@ -12258,7 +12258,7 @@ MICRODATA:
     <span itemprop="position">1</span>
     <div itemprop="item" itemscope itemtype="http://schema.org/MusicRecording">
       <span itemprop="name">All Along the Watchtower</span>
-      <div itemprop="byArtist" itemscope itemtype="http://schema.org/Person">
+      <div itemprop="byArtist" itemscope itemtype="http://schema.org/MusicGroup">
         <span itemprop="name">Jimi Hendrix</span>
       </div>
     </div>
@@ -12273,7 +12273,7 @@ RDFA:
     <span property="name" content="John Doe">by John Doe</span>
   </div>
   <div property="about" typeof="MusicRecording">
-    <div property="byArtist" typeof="Person">
+    <div property="byArtist" typeof="MusicGroup">
       <meta property="name" content="Bob Dylan" />
     </div>
   </div>
@@ -12283,7 +12283,7 @@ RDFA:
     <span property="position">5</span>
     <div property="item" typeof="MusicRecording">
       <span property="name">If Not For You</span>
-      <div property="byArtist" typeof="Person">
+      <div property="byArtist" typeof="MusicGroup">
         <span property="name">George Harrison</span>
       </div>
     </div>
@@ -12292,7 +12292,7 @@ RDFA:
     <span property="position">4</span>
     <div property="item" typeof="MusicRecording">
       <span property="name">The Times They Are A-Changin'</span>
-      <div property="byArtist" typeof="Person">
+      <div property="byArtist" typeof="MusicGroup">
         <span property="name">Tracy Chapman</span>
       </div>
     </div>
@@ -12301,10 +12301,10 @@ RDFA:
     <span property="position">3</span>
     <div property="item" typeof="MusicRecording">
       <span property="name">It Ain't Me Babe</span>
-      <div property="byArtist" typeof="Person">
+      <div property="byArtist" typeof="MusicGroup">
         <span property="name">Johnny Cash</span>
       </div>
-      <div property="byArtist" typeof="Person">
+      <div property="byArtist" typeof="MusicGroup">
         <span property="name">June Carter Cash</span>
       </div>
     </div>
@@ -12313,7 +12313,7 @@ RDFA:
     <span property="position">2</span>
     <div property="item" typeof="MusicRecording">
       <span property="name">Don't Think Twice It's Alright</span>
-      <div property="byArtist" typeof="Person">
+      <div property="byArtist" typeof="MusicGroup">
         <span property="name">Waylon Jennings</span>
       </div>
     </div>
@@ -12322,7 +12322,7 @@ RDFA:
     <span property="position">1</span>
     <div property="item" typeof="MusicRecording">
       <span property="name">All Along the Watchtower</span>
-      <div property="byArtist" typeof="Person">
+      <div property="byArtist" typeof="MusicGroup">
         <span property="name">Jimi Hendrix</span>
       </div>
     </div>
@@ -12341,7 +12341,7 @@ JSON:
   "about: {
     "@type": "MusicRecording",
     "byArtist": {
-      "@type": "Person",
+      "@type": "MusicGroup",
       "name": "Bob Dylan"
     }
   },
@@ -12355,7 +12355,7 @@ JSON:
         "@type": "MusicRecording",
         "name": "If Not For You",
         "byArtist": {
-          "@type": "Person",
+          "@type": "MusicGroup",
           "name": "George Harrison"
         }
       }
@@ -12367,7 +12367,7 @@ JSON:
         "@type": "MusicRecording",
         "name": "The Times They Are A-Changin'",
         "byArtist": {
-          "@type": "Person",
+          "@type": "MusicGroup",
           "name": "Tracy Chapman"
         }
       }
@@ -12380,7 +12380,7 @@ JSON:
         "name": "It Ain't Me Babe",
         "byArtist": [
           {
-            "@type": "Person",
+            "@type": "MusicGroup",
             "name": "Johnny Cash"
           },
           {
@@ -12397,7 +12397,7 @@ JSON:
         "@type": "MusicRecording",
         "name": "Don't Think Twice It's Alright",
         "byArtist": {
-          "@type": "Person",
+          "@type": "MusicGroup",
           "name": "Waylon Jennings"
         }
       }
@@ -12409,7 +12409,7 @@ JSON:
         "@type": "MusicRecording",
         "name": "All Along the Watchtower",
         "byArtist": {
-          "@type": "Person",
+          "@type": "MusicGroup",
           "name": "Jimi Hendrix"
         }
       }

--- a/data/examples.txt
+++ b/data/examples.txt
@@ -12384,7 +12384,7 @@ JSON:
             "name": "Johnny Cash"
           },
           {
-            "@type": "Person",
+            "@type": "MusicGroup",
             "name": "June Carter Cash"
           }
         ]


### PR DESCRIPTION
The example for `CreativeWork` and `ItemList` used `Person` as value for the `byArtist` property, but the expected value is `MusicGroup` (even for solo musicians).