### PR TITLE
parentOrganization: broader domain (and possibly inverseOf subOrganization)

### DIFF
--- a/data/schema.rdfa
+++ b/data/schema.rdfa
@@ -5287,6 +5287,7 @@
       <span property="rdfs:comment">The larger organization that this organization is a branch of, if any.</span>
       <span>Domain: <a property="http://schema.org/domainIncludes" href="http://schema.org/Organization">Organization</a></span>
       <span>Range: <a property="http://schema.org/rangeIncludes" href="http://schema.org/Organization">Organization</a></span>
+      <link property="http://schema.org/inverseOf" href="http://schema.org/subOrganization"/>
     </div>
     <div typeof="rdf:Property" resource="http://schema.org/brand">
       <span class="h" property="rdfs:label">brand</span>
@@ -9165,6 +9166,7 @@ Note that Event uses startDate/endDate instead of startTime/endTime, even when d
       <span property="rdfs:comment">A relationship between two organizations where the first includes the second, e.g., as a subsidiary. See also: the more specific &#39;department&#39; property.</span>
       <span>Domain: <a property="http://schema.org/domainIncludes" href="http://schema.org/Organization">Organization</a></span>
       <span>Range: <a property="http://schema.org/rangeIncludes" href="http://schema.org/Organization">Organization</a></span>
+      <link property="http://schema.org/inverseOf" href="http://schema.org/parentOrganization"/>
     </div>
     <div typeof="rdf:Property" resource="http://schema.org/subStageSuffix">
       <span class="h" property="rdfs:label">subStageSuffix</span>

--- a/data/schema.rdfa
+++ b/data/schema.rdfa
@@ -5284,8 +5284,8 @@
     </div>
     <div typeof="rdf:Property" resource="http://schema.org/parentOrganization">
       <span class="h" property="rdfs:label">parentOrganization</span>
-      <span property="rdfs:comment">The larger organization that this local business is a branch of, if any.</span>
-      <span>Domain: <a property="http://schema.org/domainIncludes" href="http://schema.org/LocalBusiness">LocalBusiness</a></span>
+      <span property="rdfs:comment">The larger organization that this organization is a branch of, if any.</span>
+      <span>Domain: <a property="http://schema.org/domainIncludes" href="http://schema.org/Organization">Organization</a></span>
       <span>Range: <a property="http://schema.org/rangeIncludes" href="http://schema.org/Organization">Organization</a></span>
     </div>
     <div typeof="rdf:Property" resource="http://schema.org/brand">


### PR DESCRIPTION
Issue: https://github.com/schemaorg/schemaorg/issues/535

The [first commit](https://github.com/schemaorg/schemaorg/commit/ec7074ce3da61145386433b41bc06c5ec1da6da9) changes `parentOrganization`’s domain from `LocalBusiness` to `Organization`.

The [second commit](https://github.com/schemaorg/schemaorg/commit/a2c0492f1f9908208744f6e84d36cafb713b8a09) makes `parentOrganization` and `subOrganization` inverse properties (not sure if this is also part of the consensus in #535; if not, ignore this commit.)