### PR TITLE
Potential Actions doc: HTML fixed, IDs added

### DIFF
--- a/docs/actions.html
+++ b/docs/actions.html
@@ -108,7 +108,7 @@
     background. Earlier drafts and alternate formats are available from the <a href="https://www.w3.org/wiki/WebSchemas/ActivityActions">W3C Wiki</a>.
 </p>
 
-<h2>Part 1: Action status</h2>
+<h2 id="part-1">Part 1: Action status</h2>
 <p>First, we need a mechanism for differentiating potential actions from actions that have actually taken place or are even still in-progress. The expectation is that the status of an action will often be self-evident based on the usage context, so this property can often be elided.  However, it may still be necessary for resolving ambiguous cases when they arise. For this we introduce a new property of Action called "actionStatus.</p>
 
 <h3>Thing &gt; Action</h3>
@@ -166,7 +166,7 @@
 </tbody>
 </table>
 
-<h2>Part 2:  Connecting Actions to Things</h2>
+<h2 id="part-2">Part 2:  Connecting Actions to Things</h2>
 
 <p>Frequently actions are taken or offered in the context of an object (e.g., watch this movie, review this article, share this webpage, etc.).  We introduce a new property called potentialAction for describing the "prototype" of an action that can be taken on that Thing.</p>
 
@@ -215,7 +215,7 @@
 
 
 
-<h2>Part 3: Action EntryPoints</h2>
+<h2 id="part-3">Part 3: Action EntryPoints</h2>
 <p>Potential actions are materialized via execution against the target EntryPoint of an Action.</p>
 
 <h4>Example: Action target URL</h4>
@@ -382,7 +382,7 @@ android-app://{package_id}/{scheme}/{host_path}
 
 
 
-<h2>Part 4: Input and Output constraints</h2>
+<h2 id="part-4">Part 4: Input and Output constraints</h2>
 <p>Additional information is often required from a user or client in order to formulate a complete request.  To facilitate this process we need the ability to describe within a potential action how to construct these inputs.  Since we need this capability for filling in <i>any</i> property of an Action, we introduce a notion of property annotations using a hypen ("-") delimiter. For example, by specifying a "location-input" property on a potential action we are indicating that "location" is a supported input for completing the action.</p>
 <p>Similarly, it is also helpful to indicate to clients what will be included in the final completed version of an action, so we introduce the corresponding -output annotation for indicating which properties will be present in the completed action.</p>
 

--- a/docs/actions.html
+++ b/docs/actions.html
@@ -1,4 +1,3 @@
-<!doctype html>
 <!DOCTYPE html>
 <html xmlns="http://www.w3.org/1999/xhtml" xml:lang="en" lang="en">
 <head>
@@ -31,15 +30,31 @@
 </script>
 
 <style>
+  .tag    { color: #000; }    /* div, span, etc. */
+  .atn    { color: #000; }    /* href, datetime */
+  .custom { color: #660003; } /* itemscope, itemtype, etc. */
 
-  .tag    { color: #000; }    /* div, span, etc   */
-  .atn    { color: #000; }    /* href, datetime,  */
-  .custom { color: #660003; } /* itemscope, itemtype, etc,. */
-
+  table {
+    border-collapse:collapse;
+    border:1px solid #ccc;
+  }
+  tbody, tr, td {
+    border:inherit;
+    border-collapse:inherit;
+  }
+  td {
+    padding:5px;
+  }
+  .style0 {
+    border:1px solid #000000;
+    font-family: monospace;
+    line-height: 0.8;
+    white-space: pre;
+  }
 </style>
 
 </head>
-<body>
+<body onload="prettyPrint();">
     <div id="container">
         <div id="intro">
             <div id="pageHeader">
@@ -84,28 +99,6 @@
   <div id="mainContent">
 
 <h1>Potential Actions</h1>
-
-<style>
-table {
-  border-collapse:collapse;
-  border:1px solid #ccc;
-}
-tbody, tr, td {
-  border:inherit;
-  border-collapse:inherit;
-}
-td {
-  padding:5px;
-}
-.style0 {
-  border:1px solid #000000;
-  font-family: monospace;
-  line-height: 0.8;
-  white-space: pre;
-}
-</style>
-</head>
-<body onload="prettyPrint();">
 
 <p> What follows describes some terminology and conventions for use with
     <a href="http://schema.org/Action">http://schema.org/Action</a>.
@@ -328,9 +321,9 @@ td {
 
 <h3>Scheme-based encoding of EntryPoint</h3>
 <p>Ideally, the simple "deep link" use cases should work with just a simple URL template.  In some cases, new schemes might even be created to make that possible for some platforms, for example:</p>
-<p><pre class="prettyprint">
+<div><pre class="prettyprint">
 android-app://{package_id}/{scheme}/{host_path}
-</pre></p>
+</pre></div>
 
 
 <h4>Example: Multiple platform URLs</h4>
@@ -544,19 +537,19 @@ Equivalent to HTML's <a href="http://www.w3.org/TR/html5/forms.html#the-min-and-
 <p>The minValue, maxValue and stepValue properties specify the allowed range and intervals for literal values and are equivalent to HTML's <a href="http://www.w3.org/TR/html5/forms.html#the-min-and-max-attributes">input@min, max, step</a>. It should also be noted that if both a property and its -input annotation are present, the value of the un-annotated property should be treated as the allowed options for input (similar to &lt;select&gt;&lt;option&gt; in HTML) unless the Input indicates that the value is also readonly, in which case the value(s) should all be returned in a manner analogous to hidden inputs in forms.</p>
 <p><b>Textual representations of Input and Output</b><br/>
 For convenience, we also support a textual short-hand for both of these types that is formatted and named similarly to how they would appear in their HTML equivalent.  For example:</p>
-<p><pre class="prettyprint">
+<div><pre class="prettyprint">
 "&lt;property&gt;-input": {
   "@type": "PropertyValueSpecification",
   "valueRequired": true,
   "valueMaxlength": 100,
   "valueName": "q"
 }
-</pre></p>
+</pre></div>
 
 <p>Can also be expressed as:</p>
-<p><pre class="prettyprint">
+<div><pre class="prettyprint">
 &lt;property&gt;-input: "required maxlength=100 name=q"
-</pre></p>
+</pre></div>
 
 <p><b>URI Templates</b><br/>
 Finally, we also allow URI templating (using <a href="http://tools.ietf.org/html/rfc6570">RFC6570</a>) for inlining the resulting value of -input properties into action URLs. The allowed references in the templates for substitution are dotted schema paths to the filled-in properties (relative to the Action object).</p>


### PR DESCRIPTION
Changes to http://schema.org/docs/actions.html

The [first commit](https://github.com/schemaorg/schemaorg/commit/1499926fab54338f5e1dc8306fe2cf459057fbd5) fixes all HTML errors (I did *not* test if this commit changes the design!):

* duplicated `DOCTYPE`, `head`, and `body` (I removed the duplicates, and I moved both inline styles into one `style` element)
* `pre` inside `p` (I replaced `p` with `div`)



The [second commit](https://github.com/schemaorg/schemaorg/commit/9e9932cb9b4c3f08445810f4153ac916135d6f03) adds `id` attributes to the four parts (`h2`), so that they can be linked.