### PR TITLE
Add VisualArtwork to Comic contributor properties

### DIFF
--- a/data/ext/bib/comics.rdfa
+++ b/data/ext/bib/comics.rdfa
@@ -89,6 +89,7 @@
   primary artwork is done in watercolors or digital paints.</span>
   <span>Domain: <a property="http://schema.org/domainIncludes" href="http://schema.org/ComicIssue">bib:ComicIssue</a></span>
   <span>Domain: <a property="http://schema.org/domainIncludes" href="http://schema.org/ComicStory">bib:ComicStory</a></span>
+  <span>Domain: <a property="http://schema.org/domainIncludes" href="http://schema.org/VisualArtwork">schema:VisualArtwork</a></span>
   <span>Range: <a property="http://schema.org/rangeIncludes" href="http://schema.org/Person">schema:Person</a></span>
 </div>
 
@@ -97,6 +98,7 @@
   <span class="h" property="rdfs:comment">The individual who adds color to inked drawings.</span>
   <span>Domain: <a property="http://schema.org/domainIncludes" href="http://schema.org/ComicIssue">bib:ComicIssue</a></span>
   <span>Domain: <a property="http://schema.org/domainIncludes" href="http://schema.org/ComicStory">bib:ComicStory</a></span>
+  <span>Domain: <a property="http://schema.org/domainIncludes" href="http://schema.org/VisualArtwork">schema:VisualArtwork</a></span>
   <span>Range: <a property="http://schema.org/rangeIncludes" href="http://schema.org/Person">schema:Person</a></span>
 </div>
 
@@ -105,6 +107,7 @@
   <span class="h" property="rdfs:comment">The individual who traces over the pencil drawings in ink after pencils are complete.</span>
   <span>Domain: <a property="http://schema.org/domainIncludes" href="http://schema.org/ComicIssue">bib:ComicIssue</a></span>
   <span>Domain: <a property="http://schema.org/domainIncludes" href="http://schema.org/ComicStory">bib:ComicStory</a></span>
+  <span>Domain: <a property="http://schema.org/domainIncludes" href="http://schema.org/VisualArtwork">schema:VisualArtwork</a></span>
   <span>Range: <a property="http://schema.org/rangeIncludes" href="http://schema.org/Person">schema:Person</a></span>
 </div>
 
@@ -113,6 +116,7 @@
   <span class="h" property="rdfs:comment">The individual who adds lettering, including speech balloons and sound effects, to artwork.</span>
   <span>Domain: <a property="http://schema.org/domainIncludes" href="http://schema.org/ComicIssue">bib:ComicIssue</a></span>
   <span>Domain: <a property="http://schema.org/domainIncludes" href="http://schema.org/ComicStory">bib:ComicStory</a></span>
+  <span>Domain: <a property="http://schema.org/domainIncludes" href="http://schema.org/VisualArtwork">schema:VisualArtwork</a></span>
   <span>Range: <a property="http://schema.org/rangeIncludes" href="http://schema.org/Person">schema:Person</a></span>
 </div>
 
@@ -121,6 +125,7 @@
   <span class="h" property="rdfs:comment">The individual who draws the primary narrative artwork.</span>
   <span>Domain: <a property="http://schema.org/domainIncludes" href="http://schema.org/ComicIssue">bib:ComicIssue</a></span>
   <span>Domain: <a property="http://schema.org/domainIncludes" href="http://schema.org/ComicStory">bib:ComicStory</a></span>
+  <span>Domain: <a property="http://schema.org/domainIncludes" href="http://schema.org/VisualArtwork">schema:VisualArtwork</a></span>
   <span>Range: <a property="http://schema.org/rangeIncludes" href="http://schema.org/Person">schema:Person</a></span>
 </div>
 


### PR DESCRIPTION
artist, colorist, inker, letterer, and penciler are desired to describe Comics
in a way that supports the Grand Comics Database (comics.org) description of
comics in a straightforward manner (that is, without requiring Role
reification). These properties are also useful for VisualArtwork.

Fixes #455.

Signed-off-by: Dan Scott <dan@coffeecode.net>