### PR TITLE
BreadcrumbList example: HTML fix

### DIFF
--- a/data/sdo-itemlist-examples.txt
+++ b/data/sdo-itemlist-examples.txt
@@ -6,7 +6,7 @@ PRE-MARKUP:
   <li>
     <a href="https://example.com/dresses">Dresses</a>
   </li>
-› <li>
+  <li>
     <a href="https://example.com/dresses/real">Real Dresses</a>
   </li>
 </ol>
@@ -20,7 +20,7 @@ MICRODATA:
     <span itemprop="name">Dresses</span></a>
     <meta itemprop="position" content="1" />
   </li>
-› <li itemprop="itemListElement" itemscope
+  <li itemprop="itemListElement" itemscope
       itemtype="http://schema.org/ListItem">
     <a itemprop="item" href="https://example.com/dresses/real">
     <span itemprop="name">Real Dresses</span></a>
@@ -36,7 +36,7 @@ RDFA:
      <span property="name">Dresses</span></a>
      <meta property="position" content="1">
   </li>
-› <li property="itemListElement" typeof="ListItem">
+  <li property="itemListElement" typeof="ListItem">
     <a property="item" typeof="WebPage" href="https://example.com/dresses/real">
     <span property="name">Real Dresses</span></a>
     <meta property="position" content="2">


### PR DESCRIPTION
The `ol` element can’t have text (like `›`) as content, only `li` elements. (If a list is used, authors should use CSS to insert visual separators.)