### PR TITLE
Invoice examples: HTML fixes

### DIFF
--- a/data/sdo-invoice-examples.txt
+++ b/data/sdo-invoice-examples.txt
@@ -276,7 +276,7 @@ MICRODATA:
     <div itemprop="orderedItem" itemscope itemtype="http://schema.org/Product">
       <span itemprop="name">Widget</span>
     </div>
-    <span itemprop="orderItemStatus" content="http://schema.org/OrderDelivered">Delivered</span>
+    <link itemprop="orderItemStatus" href="http://schema.org/OrderDelivered">Delivered
     <div itemprop="orderDelivery" itemscope itemtype="http://schema.org/ParcelDelivery">
       <span itemprop="expectedArrivalFrom">2015-03-10</span>
     </div>
@@ -287,7 +287,7 @@ MICRODATA:
     <div itemprop="orderedItem" itemscope itemtype="http://schema.org/Product">
       <span itemprop="name">Widget accessories</span>
     </div>
-    <span itemprop="orderItemStatus" content="http://schema.org/OrderInTransit">Shipped</span>
+    <link itemprop="orderItemStatus" href="http://schema.org/OrderInTransit" />Shipped
     <div itemprop="orderDelivery" itemscope itemtype="http://schema.org/ParcelDelivery">
       <span itemprop="expectedArrivalFrom">2015-03-15</span>
       <span itemprop="expectedArrivalUntil">2015-03-18</span>
@@ -311,7 +311,7 @@ RDFA:
     <div property="orderedItem" typeof="Product">
       <span property="name">Widget</span>
     </div>
-    <span property="orderItemStatus" content="http://schema.org/OrderDelivered">Delivered</span>
+    <link property="orderItemStatus" href="http://schema.org/OrderDelivered" />Delivered
     <div property="orderDelivery" typeof="ParcelDelivery">
       <span property="expectedArrivalFrom">2015-03-10</span>
     </div>
@@ -322,7 +322,7 @@ RDFA:
     <div property="orderedItem" typeof="Product">
       <span property="name">Widget accessories</span>
     </div>
-    <span property="orderItemStatus" content="http://schema.org/OrderInTransit">Shipped</span>
+    <link property="orderItemStatus" href="http://schema.org/OrderInTransit" />Shipped
     <div property="orderDelivery" typeof="ParcelDelivery">
       <span property="expectedArrivalFrom">2015-03-15</span>
       <span property="expectedArrivalUntil">2015-03-18</span>

--- a/data/sdo-invoice-examples.txt
+++ b/data/sdo-invoice-examples.txt
@@ -37,7 +37,7 @@ MICRODATA:
     <span itemprop="priceCurrency">USD</span>
   </div>
   <meta itemprop="billingPeriod" content="2014-12-21/P30D" />starts:2014-12-21 30 days
-  <meta itemprop="paymentStatus" content="http://schema.org/PaymentDue" />
+  <link itemprop="paymentStatus" href="http://schema.org/PaymentDue" />
 </div>
 
  
@@ -63,7 +63,7 @@ RDFA:
     <span property="priceCurrency">USD</span>
   </div>
   <meta property="billingPeriod" content="2014-12-21/P30D" />starts:2014-12-21 30 days
-  <meta property="paymentStatus" content="http://schema.org/PaymentDue" />
+  <link property="paymentStatus" href="http://schema.org/PaymentDue" />
 </div>
 
 
@@ -135,7 +135,7 @@ MICRODATA:
     <span itemprop="price">0.00</span>
     <span itemprop="priceCurrency">USD</span>
   </div>
-  <meta itemprop="paymentStatus" content="http://schema.org/PaymentComplete" />
+  <link itemprop="paymentStatus" href="http://schema.org/PaymentComplete" />
   <div itemprop="referencesOrder" itemscope itemtype="http://schema.org/Order">
     <span itemprop="description">furnace</span>
     <span itemprop="orderDate">2014-12-01</span>
@@ -175,7 +175,7 @@ RDFA:
     <span property="priceCurrency">USD</span>
   </div>
   <meta property="billingPeriod" content="2014-12-21/P30D" />starts:2014-12-21 30 days
-  <meta itemprop="paymentStatus" content="http://schema.org/PaymentComplete" />
+  <link itemprop="paymentStatus" href="http://schema.org/PaymentComplete" />
   <div property="referencesOrder" typeof="Order">
     <span property="description">furnace</span>
     <span property="orderDate">2014-12-01</span>

--- a/data/sdo-invoice-examples.txt
+++ b/data/sdo-invoice-examples.txt
@@ -19,7 +19,7 @@ MICRODATA:
 
 <div itemscope itemtype="http://schema.org/Invoice">
   <h1 itemprop="description">January 2015 Visa</h1>
-  <link itemprop="url" href="http://acmebank.com/invoice.pdf" />Invoice PDF
+  <a itemprop="url" href="http://acmebank.com/invoice.pdf">Invoice PDF</a>
   <div itemprop="broker" itemscope itemtype="http://schema.org/BankOrCreditUnion">
     <b itemprop="name">ACME Bank</b>
   </div>
@@ -45,7 +45,7 @@ RDFA:
 
 <div vocab="http://schema.org/" typeof="Invoice">
   <h1 property="description">January 2015 Visa</h1>
-  <link property="url" href="http://acmebank.com/invoice.pdf" />Invoice PDF
+  <a property="url" href="http://acmebank.com/invoice.pdf">Invoice PDF</a>
   <div property="broker" typeof="http://schema.org/BankOrCreditUnion">
     <b property="name">ACME Bank</b>
   </div>

--- a/data/sdo-invoice-examples.txt
+++ b/data/sdo-invoice-examples.txt
@@ -46,7 +46,7 @@ RDFA:
 <div vocab="http://schema.org/" typeof="Invoice">
   <h1 property="description">January 2015 Visa</h1>
   <link property="url" href="http://acmebank.com/invoice.pdf" />Invoice PDF
-  <div property="broker" itemscope typeof="http://schema.org/BankOrCreditUnion">
+  <div property="broker" typeof="http://schema.org/BankOrCreditUnion">
     <b property="name">ACME Bank</b>
   </div>
   <span property="accountId">xxxx-xxxx-xxxx-1234</span>
@@ -159,7 +159,7 @@ RDFA:
 
 <div vocab="http://schema.org/" typeof="Invoice">
   <h1 property="description">New furnace and installation</h1>
-  <div property="broker" itemscope typeof="http://schema.org/LocalBusiness">
+  <div property="broker" typeof="http://schema.org/LocalBusiness">
     <b property="name">ACME Home Heating</b>
   </div>
   <div property="customer" typeof="http://schema.org/Person">

--- a/data/sdo-invoice-examples.txt
+++ b/data/sdo-invoice-examples.txt
@@ -27,7 +27,7 @@ MICRODATA:
   <div itemprop="customer" itemscope itemtype="http://schema.org/Person">
     <b itemprop="name">Jane Doe</b>
   </div>
-  <span itemprop="paymentDue">2015-01-30</span>
+  <time itemprop="paymentDue">2015-01-30</time>
   <div itemprop="minimumPaymentDue" itemscope itemtype="http://schema.org/PriceSpecification">
     <span itemprop="price">15.00</span>
     <span itemprop="priceCurrency">USD</span>
@@ -53,7 +53,7 @@ RDFA:
   <div property="customer" typeof="Person">
     <b property="name">Jane Doe</b>
   </div>
-  <span property="paymentDue">2015-01-30</span>
+  <time property="paymentDue">2015-01-30</time>
   <div property="minimumPaymentDue" typeof="PriceSpecification">
     <span property="price">15.00</span>
     <span property="priceCurrency">USD</span>
@@ -126,7 +126,7 @@ MICRODATA:
   <div itemprop="customer" itemscope itemtype="http://schema.org/Person">
     <b itemprop="name">Jane Doe</b>
   </div>
-  <span itemprop="paymentDue">2015-01-30</span>
+  <time itemprop="paymentDue">2015-01-30</time>
   <div itemprop="minimumPaymentDue" itemscope itemtype="http://schema.org/PriceSpecification">
     <span itemprop="price">0.00</span>
     <span itemprop="priceCurrency">USD</span>
@@ -138,7 +138,7 @@ MICRODATA:
   <link itemprop="paymentStatus" href="http://schema.org/PaymentComplete" />
   <div itemprop="referencesOrder" itemscope itemtype="http://schema.org/Order">
     <span itemprop="description">furnace</span>
-    <span itemprop="orderDate">2014-12-01</span>
+    <time itemprop="orderDate">2014-12-01</time>
     <span itemprop="orderNumber">123ABC</span>
     <div itemprop="orderedItem" itemscope itemtype="http://schema.org/Product">
       <span itemprop="name">ACME Furnace 3000</span>
@@ -147,7 +147,7 @@ MICRODATA:
   </div>
   <div itemprop="referencesOrder" itemscope itemtype="http://schema.org/Order">
     <span itemprop="description">furnace installation</span>
-    <span itemprop="orderDate">2014-12-02</span>
+    <time itemprop="orderDate">2014-12-02</time>
     <div itemprop="orderedItem" itemscope itemtype="http://schema.org/Service">
       <span itemprop="description">furnace installation</span>
     </div>
@@ -165,7 +165,7 @@ RDFA:
   <div property="customer" typeof="Person">
     <b property="name">Jane Doe</b>
   </div>
-  <span property="paymentDue">2015-01-30</span>
+  <time property="paymentDue">2015-01-30</time>
   <div property="minimumPaymentDue" typeof="PriceSpecification">
     <span property="price">0.00</span>
     <span property="priceCurrency">USD</span>
@@ -177,7 +177,7 @@ RDFA:
   <link itemprop="paymentStatus" href="PaymentComplete" />
   <div property="referencesOrder" typeof="Order">
     <span property="description">furnace</span>
-    <span property="orderDate">2014-12-01</span>
+    <time property="orderDate">2014-12-01</time>
     <span property="orderNumber">123ABC</span>
     <div property="orderedItem" typeof="Product">
       <span property="name">ACME Furnace 3000</span>
@@ -186,7 +186,7 @@ RDFA:
   </div>
   <div property="referencesOrder" typeof="Order">
     <span property="description">furnace installation</span>
-    <span property="orderDate">2014-12-02</span>
+    <time property="orderDate">2014-12-02</time>
     <div property="orderedItem" typeof="Service">
       <span property="description">furnace installation</span>
     </div>
@@ -277,7 +277,7 @@ MICRODATA:
     </div>
     <link itemprop="orderItemStatus" href="http://schema.org/OrderDelivered">Delivered
     <div itemprop="orderDelivery" itemscope itemtype="http://schema.org/ParcelDelivery">
-      <span itemprop="expectedArrivalFrom">2015-03-10</span>
+      <time itemprop="expectedArrivalFrom">2015-03-10</time>
     </div>
   </div>
   <div itemprop="orderedItem" itemscope itemtype="http://schema.org/OrderItem">
@@ -288,8 +288,8 @@ MICRODATA:
     </div>
     <link itemprop="orderItemStatus" href="http://schema.org/OrderInTransit" />Shipped
     <div itemprop="orderDelivery" itemscope itemtype="http://schema.org/ParcelDelivery">
-      <span itemprop="expectedArrivalFrom">2015-03-15</span>
-      <span itemprop="expectedArrivalUntil">2015-03-18</span>
+      <time itemprop="expectedArrivalFrom">2015-03-15</time>
+      <time itemprop="expectedArrivalUntil">2015-03-18</time>
     </div>
   </div>
 </div>
@@ -312,7 +312,7 @@ RDFA:
     </div>
     <link property="orderItemStatus" href="http://schema.org/OrderDelivered" />Delivered
     <div property="orderDelivery" typeof="ParcelDelivery">
-      <span property="expectedArrivalFrom">2015-03-10</span>
+      <time property="expectedArrivalFrom">2015-03-10</time>
     </div>
   </div>
   <div property="orderedItem" typeof="OrderItem">
@@ -323,8 +323,8 @@ RDFA:
     </div>
     <link property="orderItemStatus" href="http://schema.org/OrderInTransit" />Shipped
     <div property="orderDelivery" typeof="ParcelDelivery">
-      <span property="expectedArrivalFrom">2015-03-15</span>
-      <span property="expectedArrivalUntil">2015-03-18</span>
+      <time property="expectedArrivalFrom">2015-03-15</time>
+      <time property="expectedArrivalUntil">2015-03-18</time>
     </div>
   </div>
 </div>

--- a/data/sdo-invoice-examples.txt
+++ b/data/sdo-invoice-examples.txt
@@ -174,7 +174,6 @@ RDFA:
     <span property="price">0.00</span>
     <span property="priceCurrency">USD</span>
   </div>
-  <meta property="billingPeriod" content="2014-12-21/P30D" />starts:2014-12-21 30 days
   <link itemprop="paymentStatus" href="PaymentComplete" />
   <div property="referencesOrder" typeof="Order">
     <span property="description">furnace</span>

--- a/data/sdo-invoice-examples.txt
+++ b/data/sdo-invoice-examples.txt
@@ -174,7 +174,7 @@ RDFA:
     <span property="price">0.00</span>
     <span property="priceCurrency">USD</span>
   </div>
-  <link itemprop="paymentStatus" href="PaymentComplete" />
+  <link property="paymentStatus" href="PaymentComplete" />
   <div property="referencesOrder" typeof="Order">
     <span property="description">furnace</span>
     <time property="orderDate">2014-12-01</time>

--- a/data/sdo-invoice-examples.txt
+++ b/data/sdo-invoice-examples.txt
@@ -46,24 +46,24 @@ RDFA:
 <div vocab="http://schema.org/" typeof="Invoice">
   <h1 property="description">January 2015 Visa</h1>
   <a property="url" href="http://acmebank.com/invoice.pdf">Invoice PDF</a>
-  <div property="broker" typeof="http://schema.org/BankOrCreditUnion">
+  <div property="broker" typeof="BankOrCreditUnion">
     <b property="name">ACME Bank</b>
   </div>
   <span property="accountId">xxxx-xxxx-xxxx-1234</span>
-  <div property="customer" typeof="http://schema.org/Person">
+  <div property="customer" typeof="Person">
     <b property="name">Jane Doe</b>
   </div>
   <span property="paymentDue">2015-01-30</span>
-  <div property="minimumPaymentDue" typeof="http://schema.org/PriceSpecification">
+  <div property="minimumPaymentDue" typeof="PriceSpecification">
     <span property="price">15.00</span>
     <span property="priceCurrency">USD</span>
   </div>
-  <div property="totalPaymentDue" typeof="http://schema.org/PriceSpecification">
+  <div property="totalPaymentDue" typeof="PriceSpecification">
     <span property="price">200.00</span>
     <span property="priceCurrency">USD</span>
   </div>
   <meta property="billingPeriod" content="2014-12-21/P30D" />starts:2014-12-21 30 days
-  <link property="paymentStatus" href="http://schema.org/PaymentDue" />
+  <link property="paymentStatus" href="PaymentDue" />
 </div>
 
 
@@ -159,23 +159,23 @@ RDFA:
 
 <div vocab="http://schema.org/" typeof="Invoice">
   <h1 property="description">New furnace and installation</h1>
-  <div property="broker" typeof="http://schema.org/LocalBusiness">
+  <div property="broker" typeof="LocalBusiness">
     <b property="name">ACME Home Heating</b>
   </div>
-  <div property="customer" typeof="http://schema.org/Person">
+  <div property="customer" typeof="Person">
     <b property="name">Jane Doe</b>
   </div>
   <span property="paymentDue">2015-01-30</span>
-  <div property="minimumPaymentDue" typeof="http://schema.org/PriceSpecification">
+  <div property="minimumPaymentDue" typeof="PriceSpecification">
     <span property="price">0.00</span>
     <span property="priceCurrency">USD</span>
   </div>
-  <div property="totalPaymentDue" typeof="http://schema.org/PriceSpecification">
+  <div property="totalPaymentDue" typeof="PriceSpecification">
     <span property="price">0.00</span>
     <span property="priceCurrency">USD</span>
   </div>
   <meta property="billingPeriod" content="2014-12-21/P30D" />starts:2014-12-21 30 days
-  <link itemprop="paymentStatus" href="http://schema.org/PaymentComplete" />
+  <link itemprop="paymentStatus" href="PaymentComplete" />
   <div property="referencesOrder" typeof="Order">
     <span property="description">furnace</span>
     <span property="orderDate">2014-12-01</span>


### PR DESCRIPTION
Using `link` instead of `meta` for example change from https://github.com/schemaorg/schemaorg/issues/523

**Update**: I made some more changes to the examples in the `sdo-invoice-examples.txt` file:

* removed Microdata attributes from RDFa examples
* it seemed that the URL for the "Invoice PDF" could be a visible `a` instead of an invisible `link`
* some RDFa examples used full Schema.org URIs for types although `vocab` was specified
* removed a property that was only specified in the RDFa example, but no in the pre-markup, Microdata, or JSON-LD
* used the `time` element for the visible dates
* an RDFa example used `itemprop` instead of `property`