### PR TITLE
InteractionCounter: HTML fixes

### DIFF
--- a/data/schema.rdfa
+++ b/data/schema.rdfa
@@ -3151,8 +3151,8 @@
       <span property="rdfs:comment">UserInteraction and its subtypes is an old way of talking about users interacting with pages. It is generally better to use
           &lt;a href="/Action"&gt;Action&lt;/a&gt;-based vocabulary, alongside types such as &lt;a href="/Comment"&gt;Comment&lt;/a&gt;.
       </span>
-       <span>Subclass of: <a property="rdfs:subClassOf" href="http://schema.org/Event">Event</a></span>
-      <span property="http://schema.org/supersededBy" href="http://schema.org/InteractionCounter"/>
+      <span>Subclass of: <a property="rdfs:subClassOf" href="http://schema.org/Event">Event</a></span>
+      <link property="http://schema.org/supersededBy" href="http://schema.org/InteractionCounter"/>
    </div>
 
     <div typeof="rdfs:Class" resource="http://schema.org/UserBlocks">
@@ -3161,7 +3161,7 @@
           &lt;a href="/Action"&gt;Action&lt;/a&gt;-based vocabulary, alongside types such as &lt;a href="/Comment"&gt;Comment&lt;/a&gt;.
       </span>
        <span>Subclass of: <a property="rdfs:subClassOf" href="http://schema.org/UserInteraction">UserInteraction</a></span>
-      <span property="http://schema.org/supersededBy" href="http://schema.org/InteractionCounter"/>
+      <link property="http://schema.org/supersededBy" href="http://schema.org/InteractionCounter"/>
     </div>
 
     <div typeof="rdfs:Class" resource="http://schema.org/UserCheckins">
@@ -3170,7 +3170,7 @@
           &lt;a href="/Action"&gt;Action&lt;/a&gt;-based vocabulary, alongside types such as &lt;a href="/Comment"&gt;Comment&lt;/a&gt;.
       </span>
        <span>Subclass of: <a property="rdfs:subClassOf" href="http://schema.org/UserInteraction">UserInteraction</a></span>
-      <span property="http://schema.org/supersededBy" href="http://schema.org/InteractionCounter"/>
+      <link property="http://schema.org/supersededBy" href="http://schema.org/InteractionCounter"/>
     </div>
 
     <div typeof="rdfs:Class" resource="http://schema.org/UserComments">
@@ -3181,7 +3181,7 @@
       </span>
 
        <span>Subclass of: <a property="rdfs:subClassOf" href="http://schema.org/UserInteraction">UserInteraction</a></span>
-      <span property="http://schema.org/supersededBy" href="http://schema.org/InteractionCounter"/>
+       <link property="http://schema.org/supersededBy" href="http://schema.org/InteractionCounter"/>
        <span>Source:  <a property="dc:source" href="http://www.w3.org/wiki/WebSchemas/SchemaDotOrgSources#source_rNews">rNews</a></span></div>
 
     <div typeof="rdfs:Class" resource="http://schema.org/UserDownloads">
@@ -3191,8 +3191,8 @@
           &lt;a href="/Action"&gt;Action&lt;/a&gt;-based vocabulary, alongside types such as &lt;a href="/Comment"&gt;Comment&lt;/a&gt;.
       </span>
 
-      <span property="http://schema.org/supersededBy" href="http://schema.org/InteractionCounter"/>
-     <span>Subclass of: <a property="rdfs:subClassOf" href="http://schema.org/UserInteraction">UserInteraction</a></span>
+      <link property="http://schema.org/supersededBy" href="http://schema.org/InteractionCounter"/>
+      <span>Subclass of: <a property="rdfs:subClassOf" href="http://schema.org/UserInteraction">UserInteraction</a></span>
     </div>
 
     <div typeof="rdfs:Class" resource="http://schema.org/UserLikes">
@@ -3202,7 +3202,7 @@
           &lt;a href="/Action"&gt;Action&lt;/a&gt;-based vocabulary, alongside types such as &lt;a href="/Comment"&gt;Comment&lt;/a&gt;.
       </span>
 
-      <span property="http://schema.org/supersededBy" href="http://schema.org/InteractionCounter"/>
+      <link property="http://schema.org/supersededBy" href="http://schema.org/InteractionCounter"/>
       <span>Subclass of: <a property="rdfs:subClassOf" href="http://schema.org/UserInteraction">UserInteraction</a></span>
     </div>
 
@@ -3213,7 +3213,7 @@
           &lt;a href="/Action"&gt;Action&lt;/a&gt;-based vocabulary, alongside types such as &lt;a href="/Comment"&gt;Comment&lt;/a&gt;.
       </span>
 
-      <span property="http://schema.org/supersededBy" href="http://schema.org/InteractionCounter"/>
+      <link property="http://schema.org/supersededBy" href="http://schema.org/InteractionCounter"/>
       <span>Subclass of: <a property="rdfs:subClassOf" href="http://schema.org/UserInteraction">UserInteraction</a></span>
     </div>
 
@@ -3224,7 +3224,7 @@
           &lt;a href="/Action"&gt;Action&lt;/a&gt;-based vocabulary, alongside types such as &lt;a href="/Comment"&gt;Comment&lt;/a&gt;.
       </span>
 
-      <span property="http://schema.org/supersededBy" href="http://schema.org/InteractionCounter"/>
+      <link property="http://schema.org/supersededBy" href="http://schema.org/InteractionCounter"/>
       <span>Subclass of: <a property="rdfs:subClassOf" href="http://schema.org/UserInteraction">UserInteraction</a></span>
     </div>
 
@@ -3235,7 +3235,7 @@
           &lt;a href="/Action"&gt;Action&lt;/a&gt;-based vocabulary, alongside types such as &lt;a href="/Comment"&gt;Comment&lt;/a&gt;.
       </span>
 
-      <span property="http://schema.org/supersededBy" href="http://schema.org/InteractionCounter"/>
+      <link property="http://schema.org/supersededBy" href="http://schema.org/InteractionCounter"/>
       <span>Subclass of: <a property="rdfs:subClassOf" href="http://schema.org/UserInteraction">UserInteraction</a></span>
     </div>
 
@@ -3246,7 +3246,7 @@
           &lt;a href="/Action"&gt;Action&lt;/a&gt;-based vocabulary, alongside types such as &lt;a href="/Comment"&gt;Comment&lt;/a&gt;.
       </span>
 
-      <span property="http://schema.org/supersededBy" href="http://schema.org/InteractionCounter"/>
+      <link property="http://schema.org/supersededBy" href="http://schema.org/InteractionCounter"/>
       <span>Subclass of: <a property="rdfs:subClassOf" href="http://schema.org/UserInteraction">UserInteraction</a></span>
     </div>
 
@@ -6958,7 +6958,7 @@ Note that Event uses startDate/endDate instead of startTime/endTime, even when d
     <div typeof="rdf:Property" resource="http://schema.org/interactionCount">
       <span class="h" property="rdfs:label">interactionCount</span>
       <span property="rdfs:comment">This property is deprecated, alongside the UserInteraction types on which it depended.</span>
-      <span property="http://schema.org/supersededBy" href="http://schema.org/interactionStatistic"/>
+      <link property="http://schema.org/supersededBy" href="http://schema.org/interactionStatistic"/>
       <!-- <span>Domain: <a property="http://schema.org/domainIncludes" href="http://schema.org/CreativeWork">CreativeWork</a></span>
       <span>Domain: <a property="http://schema.org/domainIncludes" href="http://schema.org/Organization">Organization</a></span>
       <span>Domain: <a property="http://schema.org/domainIncludes" href="http://schema.org/Place">Place</a></span>

--- a/data/sdo-userinteraction-examples.txt
+++ b/data/sdo-userinteraction-examples.txt
@@ -2,7 +2,7 @@ TYPES: #interaction-counter-1 InteractionCounter,VideoObject
 
 PRE-MARKUP:
 A video has the following interactions:
-Youtube: 512 up votes
+YouTube: 512 up votes
 Twitter: 1,024 up votes
 Twitter: 2,345 tweets
 Facebook: 1,024 likes
@@ -15,18 +15,18 @@ MICRODATA:
   <h1 itemprop="name">Light at the End of the Tunnel</h1>
   <p>Author: 
     <div itemprop="author" itemscope itemtype="http://schema.org/Person">
-      <span itemprop="name"> Ramanathan V. Guha</span>
+      <span itemprop="name">Ramanathan V. Guha</span>
     </div>
   </p>
   <video controls>
     <source src="http://videolectures.net/iswc2013_guha_tunnel/" />
   </video>
-  <p>Youtube Like Count:
+  <p>YouTube Like Count:
     <div itemprop="interactionStatistic" itemscope itemtype="http://schema.org/InteractionCounter">
-      <div itemprop="interactionService" itemscope itemid="http://www.youtube.com" itemtype="http://schema.org/Website">
-        <meta itemprop="name" content="Youtube" />
+      <div itemprop="interactionService" itemscope itemid="https://www.youtube.com" itemtype="http://schema.org/Website">
+        <meta itemprop="name" content="YouTube" />
       </div>
-      <meta itemprop="interactionType" content="http://schema.org/LikeAction"/>
+      <link itemprop="interactionType" href="http://schema.org/LikeAction"/>
       <span itemprop="userInteractionCount">512</span>
     </div>
   </p>
@@ -35,7 +35,7 @@ MICRODATA:
       <div itemprop="interactionService" itemscope itemid="http://www.twitter.com" itemtype="http://schema.org/SoftwareApplication">
         <meta itemprop="name" content="Twitter" />
       </div>
-      <meta itemprop="interactionType" content="http://schema.org/LikeAction"/>
+      <link itemprop="interactionType" href="http://schema.org/LikeAction"/>
       <span itemprop="userInteractionCount" content="1024">1,024</span>
     </div>
   </p>
@@ -44,7 +44,7 @@ MICRODATA:
       <div itemprop="interactionService" itemscope itemid="http://www.twitter.com" itemtype="http://schema.org/SoftwareApplication">
         <meta itemprop="name" content="Twitter" />
       </div>
-      <meta itemprop="interactionType" content="http://schema.org/ShareAction"/>
+      <link itemprop="interactionType" href="http://schema.org/ShareAction"/>
       <span itemprop="userInteractionCount" content="2345">2,345</span>
     </div>
   </p>
@@ -53,13 +53,13 @@ MICRODATA:
       <div itemprop="interactionService" itemscope itemid="http://www.facebook.com" itemtype="http://schema.org/Website">
         <meta itemprop="name" content="Facebook" />
       </div>
-      <meta itemprop="interactionType" content="http://schema.org/LikeAction"/>
+      <link itemprop="interactionType" href="http://schema.org/LikeAction"/>
       <span itemprop="userInteractionCount" content="1024">1,024</span>
     </div>
   </p>
   <p>View Count:
     <div itemprop="interactionStatistic" itemscope itemtype="http://schema.org/InteractionCounter">
-      <meta itemprop="interactionType" content="http://schema.org/WatchAction"/>
+      <link itemprop="interactionType" href="http://schema.org/WatchAction"/>
       <span itemprop="userInteractionCount" content="4356">4,356</span>
     </div>
   </p>
@@ -71,18 +71,18 @@ RDFA:
   <h1 property="name">Light at the End of the Tunnel</h1>
   <p>Author: 
     <div property="author" typeof="Person">
-      <span property="name"> Ramanathan V. Guha</span>
+      <span property="name">Ramanathan V. Guha</span>
     </div>
   </p>
   <video controls>
     <source src="http://videolectures.net/iswc2013_guha_tunnel/" />
   </video>
-  <p>Youtube Like Count:
+  <p>YouTube Like Count:
     <div property="interactionStatistic" typeof="InteractionCounter">
-      <div property="interactionService" itemscope itemid="http://www.youtube.com" itemtype="http://schema.org/Website">
-        <meta property="name" content="Youtube" />
+      <div property="interactionService" itemscope itemid="https://www.youtube.com" itemtype="http://schema.org/Website">
+        <meta property="name" content="YouTube" />
       </div>
-      <meta property="interactionType" content="http://schema.org/LikeAction"/>
+      <link property="interactionType" href="http://schema.org/LikeAction"/>
       <span property="userInteractionCount">512</span>
     </div>
   </p>
@@ -91,7 +91,7 @@ RDFA:
       <div property="interactionService" itemscope itemid="http://www.twitter.com" itemtype="http://schema.org/SoftwareApplication">
         <meta property="name" content="Twitter" />
       </div>
-      <meta property="interactionType" content="http://schema.org/LikeAction"/>
+      <link property="interactionType" href="http://schema.org/LikeAction"/>
       <span property="userInteractionCount" content="1024">1,024</span>
     </div>
   </p>
@@ -100,7 +100,7 @@ RDFA:
       <div property="interactionService" itemscope itemid="http://www.twitter.com" itemtype="http://schema.org/SoftwareApplication">
         <meta property="name" content="Twitter" />
       </div>
-      <meta property="interactionType" content="http://schema.org/ShareAction"/>
+      <link property="interactionType" href="http://schema.org/ShareAction"/>
       <span property="userInteractionCount" content="2345">2,345</span>
     </div>
   </p>
@@ -109,13 +109,13 @@ RDFA:
       <div property="interactionService" itemscope itemid="http://www.facebook.com" itemtype="http://schema.org/Website">
         <meta property="name" content="Facebook" />
       </div>
-      <meta property="interactionType" content="http://schema.org/LikeAction"/>
+      <link property="interactionType" href="http://schema.org/LikeAction"/>
       <span property="userInteractionCount" content="1024">1,024</span>
     </div>
   </p>
   <p>View Count:
     <div property="interactionStatistic" typeof="InteractionCounter">
-      <meta property="interactionType" content="http://schema.org/WatchAction"/>
+      <link property="interactionType" href="http://schema.org/WatchAction"/>
       <span property="userInteractionCount" content="4356">4,356</span>
     </div>
   </p>
@@ -138,8 +138,8 @@ JSON:
       "@type": "InteractionCounter",
       "interactionService": {
         "@type": "Website",
-        "name": "Youtube",
-        "@id": "http://www.youtube.com"
+        "name": "YouTube",
+        "@id": "https://www.youtube.com"
       },
       "interactionType": "http://schema.org/LikeAction",
       "userInteractionCount": "512"

--- a/data/sdo-userinteraction-examples.txt
+++ b/data/sdo-userinteraction-examples.txt
@@ -32,7 +32,7 @@ MICRODATA:
   </p>
   <p>Twitter Like Count:
     <div itemprop="interactionStatistic" itemscope itemtype="http://schema.org/InteractionCounter">
-      <div itemprop="interactionService" itemscope itemid="http://www.twitter.com" itemtype="http://schema.org/SoftwareApplication">
+      <div itemprop="interactionService" itemscope itemid="https://twitter.com" itemtype="http://schema.org/SoftwareApplication">
         <meta itemprop="name" content="Twitter" />
       </div>
       <link itemprop="interactionType" href="http://schema.org/LikeAction"/>
@@ -41,7 +41,7 @@ MICRODATA:
   </p>
   <p>Twitter Share Count:
     <div itemprop="interactionStatistic" itemscope itemtype="http://schema.org/InteractionCounter">
-      <div itemprop="interactionService" itemscope itemid="http://www.twitter.com" itemtype="http://schema.org/SoftwareApplication">
+      <div itemprop="interactionService" itemscope itemid="https://twitter.com" itemtype="http://schema.org/SoftwareApplication">
         <meta itemprop="name" content="Twitter" />
       </div>
       <link itemprop="interactionType" href="http://schema.org/ShareAction"/>
@@ -50,7 +50,7 @@ MICRODATA:
   </p>
   <p>Facebook Like Count:
     <div itemprop="interactionStatistic" itemscope itemtype="http://schema.org/InteractionCounter">
-      <div itemprop="interactionService" itemscope itemid="http://www.facebook.com" itemtype="http://schema.org/Website">
+      <div itemprop="interactionService" itemscope itemid="https://www.facebook.com" itemtype="http://schema.org/Website">
         <meta itemprop="name" content="Facebook" />
       </div>
       <link itemprop="interactionType" href="http://schema.org/LikeAction"/>
@@ -88,7 +88,7 @@ RDFA:
   </p>
   <p>Twitter Like Count:
     <div property="interactionStatistic" typeof="InteractionCounter">
-      <div property="interactionService" itemscope itemid="http://www.twitter.com" itemtype="http://schema.org/SoftwareApplication">
+      <div property="interactionService" itemscope itemid="https://twitter.com" itemtype="http://schema.org/SoftwareApplication">
         <meta property="name" content="Twitter" />
       </div>
       <link property="interactionType" href="http://schema.org/LikeAction"/>
@@ -97,7 +97,7 @@ RDFA:
   </p>
   <p>Twitter Share Count:
     <div property="interactionStatistic" typeof="InteractionCounter">
-      <div property="interactionService" itemscope itemid="http://www.twitter.com" itemtype="http://schema.org/SoftwareApplication">
+      <div property="interactionService" itemscope itemid="https://twitter.com" itemtype="http://schema.org/SoftwareApplication">
         <meta property="name" content="Twitter" />
       </div>
       <link property="interactionType" href="http://schema.org/ShareAction"/>
@@ -106,7 +106,7 @@ RDFA:
   </p>
   <p>Facebook Like Count:
     <div property="interactionStatistic" typeof="InteractionCounter">
-      <div property="interactionService" itemscope itemid="http://www.facebook.com" itemtype="http://schema.org/Website">
+      <div property="interactionService" itemscope itemid="https://www.facebook.com" itemtype="http://schema.org/Website">
         <meta property="name" content="Facebook" />
       </div>
       <link property="interactionType" href="http://schema.org/LikeAction"/>
@@ -149,7 +149,7 @@ JSON:
       "interactionService": {
         "@type": "SoftwareApplication",
         "name": "Twitter",
-        "url": "http://www.twitter.com"
+        "url": "https://twitter.com"
       },
       "interactionType": "http://schema.org/LikeAction",
       "userInteractionCount": "1024"
@@ -159,7 +159,7 @@ JSON:
       "interactionService": {
         "@type": "SoftwareApplication",
         "name": "Twitter",
-        "url": "http://www.twitter.com"
+        "url": "https://twitter.com"
       },
       "interactionType": "http://schema.org/ShareAction",
       "userInteractionCount": "2345"
@@ -169,7 +169,7 @@ JSON:
       "interactionService": {
         "@type": "Website",
         "name": "Facebook",
-        "url": "http://www.facebook.com"
+        "url": "https://www.facebook.com"
       },
       "interactionType": "http://schema.org/LikeAction",
       "userInteractionCount": "1024"

--- a/data/sdo-userinteraction-examples.txt
+++ b/data/sdo-userinteraction-examples.txt
@@ -3,10 +3,10 @@ TYPES: #interaction-counter-1 InteractionCounter,VideoObject
 PRE-MARKUP:
 A video has the following interactions:
 YouTube: 512 up votes
-Twitter: 1,024 up votes
-Twitter: 2,345 tweets
-Facebook: 1,024 likes
-4,356 views
+Twitter: 1024 up votes
+Twitter: 2345 tweets
+Facebook: 1024 likes
+4356 views
 
 
 MICRODATA:
@@ -36,7 +36,7 @@ MICRODATA:
         <meta itemprop="name" content="Twitter" />
       </div>
       <link itemprop="interactionType" href="http://schema.org/LikeAction"/>
-      <span itemprop="userInteractionCount" content="1024">1,024</span>
+      <span itemprop="userInteractionCount">1024</span>
     </div>
   </p>
   <p>Twitter Share Count:
@@ -45,7 +45,7 @@ MICRODATA:
         <meta itemprop="name" content="Twitter" />
       </div>
       <link itemprop="interactionType" href="http://schema.org/ShareAction"/>
-      <span itemprop="userInteractionCount" content="2345">2,345</span>
+      <span itemprop="userInteractionCount">2345</span>
     </div>
   </p>
   <p>Facebook Like Count:
@@ -54,13 +54,13 @@ MICRODATA:
         <meta itemprop="name" content="Facebook" />
       </div>
       <link itemprop="interactionType" href="http://schema.org/LikeAction"/>
-      <span itemprop="userInteractionCount" content="1024">1,024</span>
+      <span itemprop="userInteractionCount">1024</span>
     </div>
   </p>
   <p>View Count:
     <div itemprop="interactionStatistic" itemscope itemtype="http://schema.org/InteractionCounter">
       <link itemprop="interactionType" href="http://schema.org/WatchAction"/>
-      <span itemprop="userInteractionCount" content="4356">4,356</span>
+      <span itemprop="userInteractionCount">4356</span>
     </div>
   </p>
 </div>
@@ -92,7 +92,7 @@ RDFA:
         <meta property="name" content="Twitter" />
       </div>
       <link property="interactionType" href="http://schema.org/LikeAction"/>
-      <span property="userInteractionCount" content="1024">1,024</span>
+      <span property="userInteractionCount">1024</span>
     </div>
   </p>
   <p>Twitter Share Count:
@@ -101,7 +101,7 @@ RDFA:
         <meta property="name" content="Twitter" />
       </div>
       <link property="interactionType" href="http://schema.org/ShareAction"/>
-      <span property="userInteractionCount" content="2345">2,345</span>
+      <span property="userInteractionCount">2345</span>
     </div>
   </p>
   <p>Facebook Like Count:
@@ -110,13 +110,13 @@ RDFA:
         <meta property="name" content="Facebook" />
       </div>
       <link property="interactionType" href="http://schema.org/LikeAction"/>
-      <span property="userInteractionCount" content="1024">1,024</span>
+      <span property="userInteractionCount">1024</span>
     </div>
   </p>
   <p>View Count:
     <div property="interactionStatistic" typeof="InteractionCounter">
       <link property="interactionType" href="http://schema.org/WatchAction"/>
-      <span property="userInteractionCount" content="4356">4,356</span>
+      <span property="userInteractionCount">4356</span>
     </div>
   </p>
 </div>


### PR DESCRIPTION
* `meta` can’t have a URI value: using `link` instead

* `span` can’t have a `href` attribute: using `link` instead

* canonical URLs for the mentioned third-party websites

* `span` can’t have a `content` attribute in Microdata; to keep the examples consistent, I removed the `content` attributes from both, Microdata and RDFa, and used numbers without delimiter instead 

 (if we want to keep the delimiters, we could use the `data` element instead, with `@value` in Microdata and `@value`+`@content` in RDFa; or the `meta` element for both)