### PR TITLE
Releases doc: HTML fixes

### DIFF
--- a/docs/releases.html
+++ b/docs/releases.html
@@ -158,7 +158,7 @@ td.release  {
 <ul>
 <li><a href="https://github.com/schemaorg/schemaorg/issues/343">Fix to #343</a>: Improved description of <a href="/sampleType">sampleType</a>.</li>
 <li><a href="https://github.com/schemaorg/schemaorg/issues/498">Fix to #498</a>: We now write "a URL" consistently, rather than sometimes also using "an URL".</li>
-<li><a href="https://github.com/schemaorg/schemaorg/issues/585">Fix to #585</a>: Fix description of <a href="/netWorth">netWorth, which erroneosly included Organization.</li>
+<li><a href="https://github.com/schemaorg/schemaorg/issues/585">Fix to #585</a>: Fix description of <a href="/netWorth">netWorth</a>, which erroneosly included Organization.</li>
 </ul>
 
 <div>See also <a href="https://github.com/schemaorg/schemaorg/issues?q=milestone%3A%22sdo-ganymede+release%22">issue list</a> for this release.</div>

--- a/docs/releases.html
+++ b/docs/releases.html
@@ -83,7 +83,7 @@
 
 <h1>Releases</h1>
 
-<p>This page lists schema.org releases, most recent first. New developments are <a href="https://github.com/schemaorg/schemaorg">discussed on github</a>.</p>
+<p>This page lists schema.org releases, most recent first. New developments are <a href="https://github.com/schemaorg/schemaorg">discussed on GitHub</a>.</p>
 
 <br/>
 
@@ -127,14 +127,14 @@ td.release  {
     <th>Description</th>
 </tr>
 
-<span id="v.next" />
+<span id="v.next"></span>
 
 
 <tr>
 
 <td class="release"><a href="/version/2.x/">2.x</a><br/>sdo-ganymede<br/>(2015-xx-xx)</td>
-<span id="sdo-ganymede" />
-<span id="v2.xx" />
+<span id="sdo-ganymede"></span>
+<span id="v2.xx"></span>
 <td>Version 2.xx (working name 'sdo-ganymede) is under development. An unstable working snapshot of the draft release is <a href="http://sdo-ganymede.appspot.com/">available at sdo-ganymede.appspot.com/</a>.</td>
 <td>
 
@@ -158,7 +158,7 @@ td.release  {
 <ul>
 <li><a href="https://github.com/schemaorg/schemaorg/issues/343">Fix to #343</a>: Improved description of <a href="/sampleType">sampleType</a>.</li>
 <li><a href="https://github.com/schemaorg/schemaorg/issues/498">Fix to #498</a>: We now write "a URL" consistently, rather than sometimes also using "an URL".</li>
-<li><a href="https://github.com/schemaorg/schemaorg/issues/585">Fix to #585</a>: Fix description of <a href="/netWorth">netWorth</a>, which erroneosly included Organization.</li>
+<li><a href="https://github.com/schemaorg/schemaorg/issues/585">Fix to #585</a>: Fix description of <a href="/netWorth">netWorth</a>, which erroneously included Organization.</li>
 </ul>
 
 <div>See also <a href="https://github.com/schemaorg/schemaorg/issues?q=milestone%3A%22sdo-ganymede+release%22">issue list</a> for this release.</div>
@@ -168,8 +168,8 @@ td.release  {
 
 <tr>
 <td class="release"><a href="/version/2.0/">2.0</a><br/>sdo-gozer<br/>(2015-05-12)</td>
-<span id="sdo-gozer" />
-<span id="v2.0" />
+<span id="sdo-gozer"></span>
+<span id="v2.0"></span>
 <td>Version 2.0 consolidates and integrates schema.org's existing vocabulary. This version features many updated definitions, type/property associations and term names that
 improve consistency and usability. It also introduces a new <a href="/docs/extension.html">extension system</a>.
 Version 2.0 adds various new terms including <a href="/mainEntityOfPage">mainEntityOfPage</a> and major contributions from the
@@ -295,8 +295,8 @@ the superseded names can still be used, although we encourage consumers and prod
 
 <tr>
 <td class="release">1.93<br/>sdo-stantz<br/>(2015-02-04)</td>
-<span id="sdo-stantz" />
-<span id="v1.93" />
+<span id="sdo-stantz"></span>
+<span id="v1.93"></span>
 <td>Lots of bugfixes and small improvements, plus new terms to describe visual artworks and invoices.</td>
 <td>
 <h3>Vocabulary</h3>
@@ -341,8 +341,8 @@ the superseded names can still be used, although we encourage consumers and prod
 
 <tr>
 <td class="release">1.92<br/>sdo-venkman<br/>(2014-12-11)</td>
-<span id="sdo-venkman" />
-<span id="v1.93" />
+<span id="sdo-venkman"></span>
+<span id="v1.93"></span>
 <td>ItemList and BreadcrumbList changes; Sports-related improvements; Added a Music vocabulary; Video games. Also weight/height on Person; Control and RSVP actions; Role names; Dated monetary values.</td>
 <td>
 


### PR DESCRIPTION
* the end tag for an `a` element was missing
* `span` elements were self-closed (which is not allowed)

(The document is still not valid, i.e., there’s a `style` element in the `body`, and the `span` elements are children of `tr` rather than `td`.)

Related PR: https://github.com/schemaorg/schemaorg/pull/586