### PR TITLE
Social media examples: HTML corrections

### DIFF
--- a/data/sdo-social-media-examples.txt
+++ b/data/sdo-social-media-examples.txt
@@ -220,7 +220,7 @@ MICRODATA:
     </div>
   </p>
   <div itemprop="interactionStatistic" itemscope itemtype="http://schema.org/InteractionCounter">
-    <meta itemprop="interactionType" content="http://schema.org/CommentAction"</meta>
+    <link itemprop="interactionType" href="http://schema.org/CommentAction" />
     <p>Comment count: <span itemprop="userInteractionCount">25</span></p>
   </div>
 </div>
@@ -234,7 +234,7 @@ RDFA:
     </div>
   </p>
   <div property="interactionStatistic" typeof="InteractionCounter">
-    <meta property="interactionType" content="http://schema.org/CommentAction"</meta>
+    <link property="interactionType" href="http://schema.org/CommentAction" />
     <p>Comment count: <span property="userInteractionCount">25</span></p>
   </div>
 </div>

--- a/data/sdo-social-media-examples.txt
+++ b/data/sdo-social-media-examples.txt
@@ -4,9 +4,10 @@ PRE-MARKUP:
 <h1>Leaked new BMW 2 series (m235i)</h1>
 <p>Date posted: March 4, 2014</p>
 <p>Author: <a href="https://www.pinterest.com/ryansammy/">Ryan Sammy</a></p>
-<p><b itemprop="headline">
-   <a href="http://www.reddit.com/r/BMW/comments/1oyh6j/leaked_new_bmw_2_series_m235i_ahead_of_oct_25/">
-     Leaked new BMW 2 series (m235i) ahead of oct 25 reveal</a></b></p>
+<p>
+   <b><a href="http://www.reddit.com/r/BMW/comments/1oyh6j/leaked_new_bmw_2_series_m235i_ahead_of_oct_25/">
+     Leaked new BMW 2 series (m235i) ahead of oct 25 reveal</a></b>
+</p>
 <p>Author: threal135i</p>
 
 MICRODATA:

--- a/data/sdo-social-media-examples.txt
+++ b/data/sdo-social-media-examples.txt
@@ -16,19 +16,20 @@ MICRODATA:
   <h1 itemprop="headline">Leaked new BMW 2 series (m235i)</h1>
   <p>Date posted: March 4, 2014 <meta itemprop="datePublished" content="2014-03-04" /></p>
   <p>Author:
-    <div itemprop="author" itemscope itemtype="http://schema.org/Person">
+    <span itemprop="author" itemscope itemtype="http://schema.org/Person">
       <span itemprop="name">
         <a itemprop="url" href="https://www.pinterest.com/ryansammy/">Ryan Sammy</a></span>
-    </div>
+    </span>
   </p>
   <div itemprop="sharedContent" itemscope itemtype="http://schema.org/WebPage">
-      <p><b itemprop="headline">
-        <a itemprop="url" href="http://www.reddit.com/r/BMW/comments/1oyh6j/leaked_new_bmw_2_series_m235i_ahead_of_oct_25/">
-          Leaked new BMW 2 series (m235i) ahead of oct 25 reveal</a></b><p>
+      <p>
+        <b itemprop="headline"><a itemprop="url" href="http://www.reddit.com/r/BMW/comments/1oyh6j/leaked_new_bmw_2_series_m235i_ahead_of_oct_25/">
+          Leaked new BMW 2 series (m235i) ahead of oct 25 reveal</a></b>
+      </p>
       <p>Author: 
-        <div itemprop="author" itemscope itemtype="http://schema.org/Person">
+        <span itemprop="author" itemscope itemtype="http://schema.org/Person">
           <span itemprop="name">threal135i</span>
-        </div>
+        </span>
       </p>
   </div>
 </div>
@@ -39,19 +40,20 @@ RDFA:
   <h1 property="headline">Leaked new BMW 2 series (m235i)</h1>
   <p>Date posted: March 4, 2014 <meta property="datePublished" content="2014-03-04" /></p>
   <p>Author:
-    <div property="author" typeof="Person">
+    <span property="author" typeof="Person">
       <span property="name">
         <a property="url" href="https://www.pinterest.com/ryansammy/">Ryan Sammy</a></span>
-    </div>
+    </span>
   </p>
   <div property="sharedContent" typeof="WebPage">
-      <p><b property="headline">
-        <a property="url" href="http://www.reddit.com/r/BMW/comments/1oyh6j/leaked_new_bmw_2_series_m235i_ahead_of_oct_25/">
-          Leaked new BMW 2 series (m235i) ahead of oct 25 reveal</a></b><p>
+      <p>
+        <b property="headline"><a property="url" href="http://www.reddit.com/r/BMW/comments/1oyh6j/leaked_new_bmw_2_series_m235i_ahead_of_oct_25/">
+          Leaked new BMW 2 series (m235i) ahead of oct 25 reveal</a></b>
+      </p>
       <p>Author: 
-        <div property="author" typeof="Person">
+        <span property="author" typeof="Person">
           <span property="name">threal135i</span>
-        </div>
+        </span>
       </p>
   </div>
 </div>

--- a/data/sdo-social-media-examples.txt
+++ b/data/sdo-social-media-examples.txt
@@ -210,17 +210,17 @@ JSON:
 TYPES: #social-media-3 DiscussionForumPosting
 
 PRE-MARKUP:
-<h1 itemprop="headline">Is Schema.org still a thing?</h1>
+<h1>Is Schema.org still a thing?</h1>
 <p>Author: haecceity123</p>
-<p>Comment count: 25 </p>
+<p>Comment count: 25</p>
 
 MICRODATA:
 <div itemid="http://www.reddit.com/r/webdev/comments/2gypch/is_schemaorg_still_a_thing/" itemscope itemtype="http://schema.org/DiscussionForumPosting">
   <h1 itemprop="headline">Is Schema.org still a thing?</h1>
   <p>Author:
-    <div itemprop="author" itemscope itemtype="http://schema.org/Person">
+    <span itemprop="author" itemscope itemtype="http://schema.org/Person">
       <span itemprop="name">haecceity123</span>
-    </div>
+    </span>
   </p>
   <div itemprop="interactionStatistic" itemscope itemtype="http://schema.org/InteractionCounter">
     <link itemprop="interactionType" href="http://schema.org/CommentAction" />
@@ -232,9 +232,9 @@ RDFA:
 <div vocab="http://schema.org/" typeof="DiscussionForumPosting" resource="http://www.reddit.com/r/webdev/comments/2gypch/is_schemaorg_still_a_thing/">
   <h1 property="headline">Is Schema.org still a thing?</h1>
   <p>Author:
-    <div property="author" typeof="Person">
+    <span property="author" typeof="Person">
       <span property="name">haecceity123</span>
-    </div>
+    </span>
   </p>
   <div property="interactionStatistic" typeof="InteractionCounter">
     <link property="interactionType" href="http://schema.org/CommentAction" />


### PR DESCRIPTION
* `meta` was used for URI value (and had a closing tag): used `link` instead
* plain HTML examples had a Microdata attribute: removed it
* `p` can’t contain `div`: used `span` instead
* `p` closing tag missed a `/`