### PR TITLE
WebSite example: HTML fix

### DIFF
--- a/data/sdo-website-examples.txt
+++ b/data/sdo-website-examples.txt
@@ -7,7 +7,7 @@ PRE-MARKUP:
 MICRODATA:
 
 <div itemscope itemtype="http://schema.org/WebSite">
-    <meta itemprop="url" content="http://www.example.com/"/>
+    <link itemprop="url" href="http://www.example.com/"/>
     <form itemprop="potentialAction" itemscope itemtype="http://schema.org/SearchAction">
       <meta itemprop="target" content="http://www.example.com/search?q={query}"/>
       <input itemprop="query-input" type="text" name="query">
@@ -18,7 +18,7 @@ MICRODATA:
 RDFA:
 
 <div vocab="http://schema.org/" typeof="WebSite">
-    <meta property="url" content="http://www.example.com/"/>
+    <link property="url" href="http://www.example.com/"/>
     <form property="potentialAction" typeof="http://schema.org/SearchAction">
       <meta property="target" content="http://www.example.com/search?q={query}"/>
       <input property="query-input" type="text" name="query">

--- a/data/sdo-website-examples.txt
+++ b/data/sdo-website-examples.txt
@@ -7,22 +7,22 @@ PRE-MARKUP:
 MICRODATA:
 
 <div itemscope itemtype="http://schema.org/WebSite">
-    <link itemprop="url" href="http://www.example.com/"/>
+    <link itemprop="url" href="http://example.com/"/>
     <form itemprop="potentialAction" itemscope itemtype="http://schema.org/SearchAction">
-      <meta itemprop="target" content="http://www.example.com/search?q={query}"/>
-      <input itemprop="query-input" type="text" name="query">
-      <input type="submit">
+      <meta itemprop="target" content="http://example.com/search?q={query}"/>
+      <input itemprop="query-input" type="text" name="query"/>
+      <input type="submit"/>
     </form>
 </div>
 
 RDFA:
 
 <div vocab="http://schema.org/" typeof="WebSite">
-    <link property="url" href="http://www.example.com/"/>
+    <link property="url" href="http://example.com/"/>
     <form property="potentialAction" typeof="SearchAction">
-      <meta property="target" content="http://www.example.com/search?q={query}"/>
-      <input property="query-input" type="text" name="query">
-      <input type="submit">
+      <meta property="target" content="http://example.com/search?q={query}"/>
+      <input property="query-input" type="text" name="query"/>
+      <input type="submit"/>
     </form>
 </div>
 
@@ -32,10 +32,10 @@ JSON:
 {
     "@context": "http://schema.org",
     "@type": "WebSite",
-    "url": "http://www.example.com/",
+    "url": "http://example.com/",
     "potentialAction": {
       "@type": "SearchAction",
-      "target": "http://www.example.com/search?&q={query}",
+      "target": "http://example.com/search?&q={query}",
       "query-input": "required"
     }
 }

--- a/data/sdo-website-examples.txt
+++ b/data/sdo-website-examples.txt
@@ -19,7 +19,7 @@ RDFA:
 
 <div vocab="http://schema.org/" typeof="WebSite">
     <link property="url" href="http://www.example.com/"/>
-    <form property="potentialAction" typeof="http://schema.org/SearchAction">
+    <form property="potentialAction" typeof="SearchAction">
       <meta property="target" content="http://www.example.com/search?q={query}"/>
       <input property="query-input" type="text" name="query">
       <input type="submit">


### PR DESCRIPTION
* using `link` instead of `meta` for `url` property
* RDFa: making use of `vocab` (i.e., `typeof="SearchAction` instead of `typeof="http://schema.org/SearchAction"`)

(I’m not sure if the value of the `target` URI should be a URL or not if no `EntryPoint` type is used, so I left it untouched.)