### PR TITLE
Fixing typos in 'Getting Started' page

### DIFF
--- a/docs/gs.html
+++ b/docs/gs.html
@@ -177,9 +177,9 @@ examples to see how the details compare.</p>
 <p>Sometimes the value of an item property can itself be another item with its own set of properties. For example, we can specify that the director of the movie is an item of type Person and the Person has the properties <code>name</code> and <code>birthDate</code>. To specify that the value of a property is another item, you begin a new <code>itemscope</code> immediately after the corresponding <code>itemprop</code>.</p>
 
 <pre>&lt;div itemscope itemtype ="http://schema.org/Movie"&gt;
-  &lt;h1 itemprop="name"&g;Avatar&lt;/h1&gt;
+  &lt;h1 itemprop="name"&gt;Avatar&lt;/h1&gt;
   &lt;div <strong>itemprop="director" itemscope itemtype="http://schema.org/Person"</strong>&gt;
-  Director: &lt;span itemprop="name"&gt;James Cameron&lt;/span&gt; (born &lt;span <strong>itemprop="birthDate"</strong>&gt;August 16, 1954)&lt;/span&gt;
+  Director: &lt;span itemprop="name"&gt;James Cameron&lt;/span&gt; (born &lt;span <strong>itemprop="birthDate"</strong>&gt;August 16, 1954&lt;/span&gt;)
   &lt;/div&gt;
   &lt;span itemprop="genre">Science fiction&lt;/span&gt;
   &lt;a href="../movies/avatar-theatrical-trailer.html" itemprop="trailer"&gt;Trailer&lt;/a&gt;


### PR DESCRIPTION
The fixes were made inside `#microdata_embedded` section. The code related to `itemprop="name"` was generating a `&g;`, instead of displaying the `>` sign properly . The other fix was related to letting the `itemprop="birthDate"` encapsulate only the value of `August 16, 1954` instead of `August 16, 1954)`.