### PR TITLE
Update sdo-tv-listing-examples.txt

### DIFF
--- a/data/sdo-tv-listing-examples.txt
+++ b/data/sdo-tv-listing-examples.txt
@@ -160,7 +160,7 @@ JSON:
   "endDate":"2014-10-12T21:30",
   "publishedOn":{
     "@type":"BroadcastService",
-    "name: "WAAY-TV"
+    "name": "WAAY-TV"
   },
   "workPerformed":{
     "@type":"CreativeWork",


### PR DESCRIPTION
typo: missing end quote for "name" of broadcast service in example