### PR TITLE
Urlfixes2

### DIFF
--- a/sdoapp.py
+++ b/sdoapp.py
@@ -39,6 +39,12 @@ myhost = ""
 myport = ""
 mybasehost = ""
 
+host_ext2 = ""
+myhost2 = ""
+myport2 = ""
+mybasehost2 = ""
+debugging2 = False
+
 silent_skip_list =  [ "favicon.ico" ] # Do nothing for now
 
 all_layers = {}
@@ -1351,36 +1357,56 @@ class ShowUnit (webapp2.RequestHandler):
             DataCache.put("FullReleasePage",page)
             return True
 
-
-    def setupHostinfo(self, node):
+    
+    def setupHostinfo(self, node, test=""):
         global debugging, host_ext, myhost, myport, mybasehost
+        
+        hostString = test
+        if test == "":
+            hostString = self.request.host 
 
-        host_ext = re.match( r'([\w\-_]+)[\.:]?', self.request.host).group(1)
-        log.debug("setupHostinfo: srh=%s host_ext=%s" % (self.request.host, str(host_ext) ))        
+        host_ext = re.match( r'([\w\-_]+)[\.:]?', hostString).group(1)
+        log.debug("setupHostinfo: srh=%s host_ext2=%s" % (hostString, str(host_ext) ))        
+
+        split = hostString.rsplit(':')
+        myhost = split[0]
+        mybasehost = myhost
+        myport = "80"
+        if len(split) > 1:
+            myport = split[1]   
 
         if host_ext != None:
             # e.g. "bib"
-            log.debug("HOST: Found %s in %s" % ( host_ext, self.request.host ))
-            DataCache.setCurrent(host_ext)
-            split = self.request.host.rsplit(':')
-            myhost = split[0]
-            myport = "80"
-            if len(split) > 1:
-                myport = split[1]                
-            mybasehost = myhost
-            mybasehost = mybasehost.replace(host_ext + ".","")
-            # mybasehost = mybasehost.replace(":8080", "")
-
-
-        if "localhost" in self.request.host or "sdo-gozer.appspot.com" in self.request.host:
+            log.debug("HOST: Found %s in %s" % ( host_ext, hostString ))
+            if not host_ext in ENABLED_EXTENSIONS:
+                host_ext = ""
+            else:
+                mybasehost = mybasehost[len(host_ext) + 1:]            
+            
+        dcn = host_ext
+        if dcn == None or dcn == "":
+            dcn = "core"
+        DataCache.setCurrent(dcn)
+                        
+        debugging = False
+        if "localhost" in hostString or "sdo-ganymede.appspot.com" in hostString:
             debugging = True
-    
+            
+    def getHostExt(self):
+        return host_ext
+
+    def getBaseHost(self):
+        return mybasehost
+
+    def getHostPort(self):
+        return myport
+        
     def makeUrl(self,ext="",path=""):
         port = ""
         sub = ""
         p = ""
-        if(myport != "80"):
-            port = ":%s" % myport
+        if(self.getHostPort() != "80"):
+            port = ":%s" % self.getHostPort()
         if ext != "core" and ext != "":
             sub = "%s." % ext
         if path != "":
@@ -1389,7 +1415,7 @@ class ShowUnit (webapp2.RequestHandler):
             else:
                 p = "/%s" % path
             
-        url = "http://%s%s%s%s" % (sub,mybasehost,port,p)
+        url = "http://%s%s%s%s" % (sub,self.getBaseHost(),port,p)
         return url
 
 

--- a/sdoapp.py
+++ b/sdoapp.py
@@ -39,12 +39,6 @@ myhost = ""
 myport = ""
 mybasehost = ""
 
-host_ext2 = ""
-myhost2 = ""
-myport2 = ""
-mybasehost2 = ""
-debugging2 = False
-
 silent_skip_list =  [ "favicon.ico" ] # Do nothing for now
 
 all_layers = {}

--- a/tests/test_basics.py
+++ b/tests/test_basics.py
@@ -158,7 +158,7 @@ class SchemaBasicAPITestCase(unittest.TestCase):
          log.info("Extension load errors:\n%s" % extensionLoadErrors)
 
      self.assertEqual(len(extensionLoadErrors),0, "Extension schemas reporting errors.")
-
+     
   def test_gotThing(self):
 
      thing = Unit.GetUnit("Thing")
@@ -168,6 +168,90 @@ class SchemaBasicAPITestCase(unittest.TestCase):
        gotThing = True
 
      self.assertEqual( gotThing, True, "Thing node should be accessible via GetUnit('Thing').")
+
+  def test_hostInfo(self):
+      global debugging, host_ext, myhost, myport, mybasehost
+
+      thing = Unit.GetUnit("Thing")
+      u = ShowUnit()
+      u.setupHostinfo(thing,"localhost")
+      self.assertEqual( u.getHostExt(), "", "host_ext should be empty for host localhost.")
+      self.assertEqual( u.getBaseHost(), "localhost", "baseHost should be 'schema.org' for host schema.org.")
+      self.assertEqual( u.getHostPort(), "80", "HostPort should be '80' for host localhost.")
+      self.assertEqual( u.makeUrl("tst"), "http://tst.localhost", "URL should be 'http://tst.localhost' for host localhost.")
+      
+      u.setupHostinfo(thing,"bib.localhost")
+      self.assertEqual( u.getHostExt(), "bib", "host_ext should be 'bib' for host bib.localhost.")
+      self.assertEqual( u.getBaseHost(), "localhost", "baseHost should be 'localhost' for host bib.localhost.")
+      self.assertEqual( u.getHostPort(), "80", "HostPort should be '80' for host localhost.")
+      self.assertEqual( u.makeUrl("tst"), "http://tst.localhost", "URL should be 'http://tst.localhost' for host bib.localhost.")
+
+      u.setupHostinfo(thing,"bib.localhost:8080")
+      self.assertEqual( u.getHostExt(), "bib", "host_ext should be 'bib' for host bib.localhost:8080.")
+      self.assertEqual( u.getBaseHost(), "localhost", "baseHost should be 'localhost' for host bib.localhost:8080.")
+      self.assertEqual( u.getHostPort(), "8080", "HostPort should be '8080' for host bib.localhost:8080.")
+      self.assertEqual( u.makeUrl("tst"), "http://tst.localhost:8080", "URL should be 'http://tst.localhost:8080' for host bib.localhost:8080.")
+
+      u.setupHostinfo(thing,"fred.localhost:8080")
+      self.assertEqual( u.getHostExt(), "", "host_ext should be empty for host fred.localhost:8080.")
+      self.assertEqual( u.getBaseHost(), "fred.localhost", "baseHost should be 'fred.localhost' for host fred.localhost:8080.")
+      self.assertEqual( u.getHostPort(), "8080", "HostPort should be '8080' for host fred.localhost:8080.")
+      self.assertEqual( u.makeUrl("tst"), "http://tst.fred.localhost:8080", "URL should be 'http://tst.fred.localhost:8080' for host fred.localhost:8080.")
+
+      u.setupHostinfo(thing,"schema.org")
+      self.assertEqual( u.getHostExt(), "", "host_ext should be empty for host schema.org.")
+      self.assertEqual( u.getBaseHost(), "schema.org", "baseHost should be 'schema.org' for host schema.org.")
+      self.assertEqual( u.getHostPort(), "80", "HostPort should be '80' for host schema.org.")
+      self.assertEqual( u.makeUrl("tst"), "http://tst.schema.org", "URL should be 'http://tst.schema.org' for host schema.org.")
+      
+      u.setupHostinfo(thing,"bib.schema.org")
+      self.assertEqual( u.getHostExt(), "bib", "host_ext should be 'bib' for host bib.schema.org.")
+      self.assertEqual( u.getBaseHost(), "schema.org", "baseHost should be 'bib.schema.org' for host schema.org.")
+      self.assertEqual( u.getHostPort(), "80", "HostPort should be '80' for host bib.schema.org.")
+      self.assertEqual( u.makeUrl("tst"), "http://tst.schema.org", "URL should be 'http://tst.schema.org' for host bib.schema.org.")
+
+      u.setupHostinfo(thing,"fred.schema.org:8080")
+      self.assertEqual( u.getHostExt(), "", "host_ext should be empty for host fred.schema.org:8080.")
+      self.assertEqual( u.getBaseHost(), "fred.schema.org", "baseHost should be 'fred.schema.org' for host fred.schema.org:8080.")
+      self.assertEqual( u.getHostPort(), "8080", "HostPort should be '8080' for host fred.schema.org:8080.")
+      self.assertEqual( u.makeUrl("tst"), "http://tst.fred.schema.org:8080", "URL should be 'http://tst.fred.schema.org:8080' for host fred.schema.org:8080.")
+
+      u.setupHostinfo(thing,"webschemas.org")
+      self.assertEqual( u.getHostExt(), "", "host_ext should be empty for host webschemas.org.")
+      self.assertEqual( u.getBaseHost(), "webschemas.org", "baseHost should be 'webschemas.org' for host webschemas.org.")
+      self.assertEqual( u.getHostPort(), "80", "HostPort should be '80' for host webschemas.org.")
+      self.assertEqual( u.makeUrl("tst"), "http://tst.webschemas.org", "URL should be 'http://tst.webschemas.org' for host webschemas.org.")
+      
+      u.setupHostinfo(thing,"bib.webschemas.org")
+      self.assertEqual( u.getHostExt(), "bib", "host_ext should be 'bib' for host bib.webschemas.org.")
+      self.assertEqual( u.getBaseHost(), "webschemas.org", "baseHost should be 'webschemas.org' for host bib.webschemas.org.")
+      self.assertEqual( u.getHostPort(), "80", "HostPort should be '80' for host bib.webschemas.org.")
+      self.assertEqual( u.makeUrl("tst"), "http://tst.webschemas.org", "URL should be 'http://tst.webschemas.org' for host bib.webschemas.org.")
+
+      u.setupHostinfo(thing,"fred.webschemas.org:8080")
+      self.assertEqual( u.getHostExt(), "", "host_ext should be empty for host fred.webschemas.org:8080.")
+      self.assertEqual( u.getBaseHost(), "fred.webschemas.org", "baseHost should be 'fred.webschemas.org' for host fred.webschemas.org:8080.")
+      self.assertEqual( u.getHostPort(), "8080", "HostPort should be '8080' for host fred.webschemas.org:8080.")
+      self.assertEqual( u.makeUrl("tst"), "http://tst.fred.webschemas.org:8080", "URL should be 'http://tst.fred.webschemas.org:8080' for host fred.webschemas.org:8080.")
+      
+      u.setupHostinfo(thing,"sdo-ganymede.appspot.com")
+      self.assertEqual( u.getHostExt(), "", "host_ext should be empty for host sdo-ganymede.appspot.com.")
+      self.assertEqual( u.getBaseHost(), "sdo-ganymede.appspot.com", "baseHost should be 'sdo-ganymede.appspot.com' for host sdo-ganymede.appspot.com.")
+      self.assertEqual( u.getHostPort(), "80", "HostPort should be '80' for host sdo-ganymede.appspot.com.")
+      self.assertEqual( u.makeUrl("tst"), "http://tst.sdo-ganymede.appspot.com", "URL should be 'http://tst.sdo-ganymede.appspot.com' for host sdo-ganymede.appspot.com.")
+      
+      u.setupHostinfo(thing,"bib.sdo-ganymede.appspot.com")
+      self.assertEqual( u.getHostExt(), "bib", "host_ext should be 'bib' for host bib.sdo-ganymede.appspot.com.")
+      self.assertEqual( u.getBaseHost(), "sdo-ganymede.appspot.com", "baseHost should be 'bib.sdo-ganymede.appspot.com' for host sdo-ganymede.appspot.com.")
+      self.assertEqual( u.getHostPort(), "80", "HostPort should be '80' for host bib.sdo-ganymede.appspot.com.")
+      self.assertEqual( u.makeUrl("tst"), "http://tst.sdo-ganymede.appspot.com", "URL should be 'http://tst.sdo-ganymede.appspot.com' for host bib.sdo-ganymede.appspot.com.")
+
+      u.setupHostinfo(thing,"fred.sdo-ganymede.appspot.com")
+      self.assertEqual( u.getHostExt(), "", "host_ext should be empty for host fred.sdo-ganymede.appspot.com.")
+      self.assertEqual( u.getBaseHost(), "fred.sdo-ganymede.appspot.com", "baseHost should be 'fred.sdo-ganymede.appspot.com' for host fred.sdo-ganymede.appspot.com.")
+      self.assertEqual( u.getHostPort(), "80", "HostPort should be '80' for host fred.sdo-ganymede.appspot.com.")
+      self.assertEqual( u.makeUrl("tst"), "http://tst.fred.sdo-ganymede.appspot.com", "URL should be 'http://tst.fred.sdo-ganymede.appspot.com' for host fred.sdo-ganymede.appspot.com.")
+      
 
   def test_gotFooBarThing(self):
 


### PR DESCRIPTION
Fixes to setupHostinfo to allow for several domains.
* Limit potential extension subdomains to those of enabled extensions
* Added test parameter to test operation with a passed hostname
* Added simple methods to return calculated values - makes test easier
* Mods to makeUrl to take account of the above
Added test for setupHostinfo() and getUrl() to check for core and extension hostname and port combinations for:
  localhost
  webschemas.org
  sdo-ganymede.appspot.com
  schem.org