### PR TITLE
Fix overlay h1 element on the search form

### DIFF
--- a/docs/schemaorg.css
+++ b/docs/schemaorg.css
@@ -327,7 +327,8 @@ padding: 10px 0;
  padding: 0 40px;
 }
 #pageHeader h1 {
- position:relative;
+ display: inline-block;
+ position: relative;
  top: 25px; left: -40px;
  text-shadow: 0 2px 0 #510000;
  /*pointer-events: none; */  /* old wasn't commented out. TODO check this. */


### PR DESCRIPTION
![cljf60eumaatawi](https://cloud.githubusercontent.com/assets/430267/8979042/230eb280-36e2-11e5-902c-f4b093d37e40.png)
https://twitter.com/kubosho_/status/626668763081891840

## I confirmed the bug on browsers:

OS: Windows 8.1 Pro 64bit

- Chrome 45.0.2454.15 dev-m (64-bit)
- Firefox Developer Edition 41.0a2 (2015-07-29)
- IE 11
