### PR TITLE
Wrapped header <h1> in a sitename div to fix (#679)

### DIFF
--- a/docs/about.html
+++ b/docs/about.html
@@ -13,7 +13,11 @@
         <div id="intro">
             <div id="pageHeader">
               <div class="wrapper">
-                <h1>schema.org</h1>
+				<div id="sitename">
+				<h1>
+					<a href="/">schema.org</a>
+				</h1>
+				</div>
 
 <div id="cse-search-form" style="width: 400px;"></div>
 

--- a/docs/actions.html
+++ b/docs/actions.html
@@ -55,7 +55,11 @@
         <div id="intro">
             <div id="pageHeader">
               <div class="wrapper">
-                <h1>schema.org</h1>
+				<div id="sitename">
+				<h1>
+					<a href="/">schema.org</a>
+				</h1>
+				</div>
 
 <div id="cse-search-form" style="width: 400px;"></div>
 

--- a/docs/datamodel.html
+++ b/docs/datamodel.html
@@ -39,7 +39,11 @@
         <div id="intro">
             <div id="pageHeader">
               <div class="wrapper">
-                <h1>schema.org</h1>
+				<div id="sitename">
+				<h1>
+					<a href="/">schema.org</a>
+				</h1>
+				</div>
 
 <div id="cse-search-form" style="width: 400px;"></div>
 

--- a/docs/documentation.html
+++ b/docs/documentation.html
@@ -13,7 +13,11 @@
         <div id="intro">
             <div id="pageHeader">
               <div class="wrapper">
-                <h1>schema.org</h1>
+				<div id="sitename">
+				<h1>
+					<a href="/">schema.org</a>
+				</h1>
+				</div>
 
 <div id="cse-search-form" style="width: 400px;"></div>
 

--- a/docs/documents.html
+++ b/docs/documents.html
@@ -13,7 +13,11 @@
         <div id="intro">
             <div id="pageHeader">
               <div class="wrapper">
-                <h1>schema.org</h1>
+				<div id="sitename">
+				<h1>
+					<a href="/">schema.org</a>
+				</h1>
+				</div>
 
 <div id="cse-search-form" style="width: 400px;"></div>
 

--- a/docs/extension.html
+++ b/docs/extension.html
@@ -14,7 +14,11 @@
         <div id="intro">
             <div id="pageHeader">
               <div class="wrapper">
-                <h1>schema.org</h1>
+				<div id="sitename">
+				<h1>
+					<a href="/">schema.org</a>
+				</h1>
+				</div>
 
 <div id="cse-search-form" style="width: 400px;"></div>
 

--- a/docs/faq.html
+++ b/docs/faq.html
@@ -14,7 +14,11 @@
         <div id="intro">
             <div id="pageHeader">
               <div class="wrapper">
-                <h1>schema.org</h1>
+				<div id="sitename">
+				<h1>
+					<a href="/">schema.org</a>
+				</h1>
+				</div>
 
 <div id="cse-search-form" style="width: 400px;"></div>
 

--- a/docs/feedback.html
+++ b/docs/feedback.html
@@ -12,7 +12,11 @@
         <div id="intro">
             <div id="pageHeader">
               <div class="wrapper">
-                <h1>schema.org</h1>
+				<div id="sitename">
+				<h1>
+					<a href="/">schema.org</a>
+				</h1>
+				</div>
 
 <div id="cse-search-form" style="width: 400px;"></div>
 

--- a/docs/gs.html
+++ b/docs/gs.html
@@ -12,7 +12,11 @@
         <div id="intro">
             <div id="pageHeader">
               <div class="wrapper">
-                <h1>schema.org</h1>
+				<div id="sitename">
+				<h1>
+					<a href="/">schema.org</a>
+				</h1>
+				</div>
 
 <div id="cse-search-form" style="width: 400px;"></div>
 

--- a/docs/meddocs.html
+++ b/docs/meddocs.html
@@ -40,7 +40,11 @@
         <div id="intro">
             <div id="pageHeader">
               <div class="wrapper">
-                <h1>schema.org</h1>
+				<div id="sitename">
+				<h1>
+					<a href="/">schema.org</a>
+				</h1>
+				</div>
 
 <div id="cse-search-form" style="width: 400px;"></div>
 

--- a/docs/old_extension.html
+++ b/docs/old_extension.html
@@ -13,7 +13,11 @@
         <div id="intro">
             <div id="pageHeader">
               <div class="wrapper">
-                <h1>schema.org</h1>
+				<div id="sitename">
+				<h1>
+					<a href="/">schema.org</a>
+				</h1>
+				</div>
 
 <div id="cse-search-form" style="width: 400px;"></div>
 

--- a/docs/releases.html
+++ b/docs/releases.html
@@ -38,7 +38,11 @@
         <div id="intro">
             <div id="pageHeader">
               <div class="wrapper">
-                <h1>schema.org</h1>
+				<div id="sitename">
+				<h1>
+					<a href="/">schema.org</a>
+				</h1>
+				</div>
 
 <div id="cse-search-form" style="width: 400px;"></div>
 

--- a/docs/schemaorg.css
+++ b/docs/schemaorg.css
@@ -130,7 +130,7 @@ text-decoration: none;
 
 #cse-search-form {
   float: right;
-  margin-top:-35px;
+  margin-top:20px;
   width: 248px !important;
 }
 @media all and (max-width: 720px) {
@@ -344,18 +344,19 @@ padding-top: 1em;
 float: right;
 padding: 10px 0;
 }
-#mainContent, #footer, #pageHeader h1, .wrapper {
+#mainContent, #footer, .wrapper {
  max-width: 960px;
  min-width: 350px;
  margin: 0 auto !important;
  padding: 0 40px;
 }
-#pageHeader h1 {
- /* display: inline-block; */
- position: relative;
- top: 25px; left: -40px;
- text-shadow: 0 2px 0 #510000;
- /*pointer-events: none; */  /* old wasn't commented out. TODO check this. */
+#sitename {
+    max-width: 500px;
+    min-width: auto;
+	display: inline-block;
+    text-shadow: 0 2px 0 #510000;
+    padding: 0;
+    top: 25px; left: -40px;	
 }
 #selectionbar ul {
   margin: 0 auto;

--- a/docs/schemas.html
+++ b/docs/schemas.html
@@ -12,7 +12,11 @@
         <div id="intro">
             <div id="pageHeader">
               <div class="wrapper">
-                <h1>schema.org</h1>
+				<div id="sitename">
+				<h1>
+					<a href="/">schema.org</a>
+				</h1>
+				</div>
 
 <div id="cse-search-form" style="width: 400px;"></div>
 

--- a/docs/search_results.html
+++ b/docs/search_results.html
@@ -12,7 +12,11 @@
         <div id="intro">
             <div id="pageHeader">
               <div class="wrapper">
-                <h1>schema.org</h1>
+				<div id="sitename">
+				<h1>
+					<a href="/">schema.org</a>
+				</h1>
+				</div>
 
 <div id="cse-search-form" style="width: 400px;"></div>
 <script src="//www.google.com/jsapi" type="text/javascript"></script>

--- a/docs/terms.html
+++ b/docs/terms.html
@@ -12,7 +12,11 @@
         <div id="intro">
             <div id="pageHeader">
               <div class="wrapper">
-                <h1>schema.org</h1>
+				<div id="sitename">
+				<h1>
+					<a href="/">schema.org</a>
+				</h1>
+				</div>
 
 <div id="cse-search-form" style="width: 400px;"></div>
 

--- a/templates/basicPageHeader.tpl
+++ b/templates/basicPageHeader.tpl
@@ -1,0 +1,56 @@
+<!-- Header start from basicPageHeader.tpl -->
+<div id="container">
+	<div id="intro">
+		<div id="pageHeader">
+			<div class="wrapper">
+				<div id="sitename">
+				<h1>
+					<a href="/">{{ sitename }}</a>
+				</h1>
+				</div>
+				<div id="cse-search-form" style="width: 400px;"></div>
+<script type="text/javascript" src="//www.google.com/jsapi"></script> 
+<script type="text/javascript">
+google.load('search', '1', {language : 'en', style : google.loader.themes.ESPRESSO});
+google.setOnLoadCallback(function() {
+var customSearchControl = new google.search.CustomSearchControl('013516846811604855281:nj5laplixaa');
+customSearchControl.setResultSetSize(google.search.Search.FILTERED_CSE_RESULTSET);
+var options = new google.search.DrawOptions();
+options.enableSearchboxOnly("/docs/search_results.html", null, false, '#');
+customSearchControl.draw('cse-search-form', options);
+}, true);
+</script>
+			</div>
+		</div>
+	</div>
+</div>
+<div id="selectionbar">
+	<div class="wrapper">
+		<ul>
+	        {% if menu_sel == "Documentation" %}
+	        <li class="activelink">
+	        {% else %}
+	        <li>
+	        {% endif %}
+				<a href="/docs/documents.html">Documentation</a>
+			</li>
+	        {% if menu_sel == "Schemas" %}
+	        <li class="activelink">
+	        {% else %}
+	        <li>
+	        {% endif %}
+				<a href="/docs/schemas.html">Schemas</a>
+			</li>
+			<li>
+	        {% if home_page == "True" %}
+				<a href="/docs/about.html">About</a>
+	        {% else %}
+				<a href="/">Home</a>
+	        {% endif %}
+			</li>
+		</ul>
+	</div>
+</div>
+<div style="padding: 14px; float: right;" id="languagebox"></div>
+<!-- Header end from basicPageHeader.tpl -->
+

--- a/templates/full.tpl
+++ b/templates/full.tpl
@@ -26,49 +26,7 @@ $(document).ready(function(){
 </head>
 <body style="text-align: left;">
 
-    <div id="container">
-        <div id="intro">
-            <div id="pageHeader">
-                <div class="wrapper">
-                    <h1>schema.org</h1>
-
-                    <div id="cse-search-form" style="width: 400px;"></div>
-
-                    <script type="text/javascript" src="//www.google.com/jsapi"></script>
-                    <script type="text/javascript">
-                    google.load('search', '1', {language : 'en', style : google.loader.themes.ESPRESSO});
-                    google.setOnLoadCallback(function() {
-                        var customSearchControl = new google.search.CustomSearchControl('013516846811604855281:nj5laplixaa');
-                        customSearchControl.setResultSetSize(google.search.Search.FILTERED_CSE_RESULTSET);
-                        var options = new google.search.DrawOptions();
-                        options.enableSearchboxOnly("../docs/search_results.html", null, false, '#');
-                        customSearchControl.draw('cse-search-form', options);
-                    }, true);
-                    </script>
-
-
-                </div>
-            </div>
-        </div>
-    </div>
-
-    <div id="selectionbar">
-        <div class="wrapper">
-            <ul>
-                <li >
-                    <a href="../docs/documents.html">Documentation</a></li>
-                    <li class="activelink">
-                        <a href="../docs/schemas.html">Schemas</a></li>
-                        <li >
-                            <a href="../.">Home</a></li>
-                        </ul>
-                    </div>
-
-                </div>
-                <div style="padding: 14px; float: right;" id="languagebox"></div>
-
-
-
+{% include 'basicPageHeader.tpl' with context %}
 
 <div style="margin-left: 8%; margin-right: 8%">
 

--- a/templates/fullReleasePage.tpl
+++ b/templates/fullReleasePage.tpl
@@ -11,49 +11,7 @@
 </head>
 <body style="text-align: left;">
 
-    <div id="container">
-        <div id="intro">
-            <div id="pageHeader">
-                <div class="wrapper">
-                    <h1>schema.org</h1>
-
-                    <div id="cse-search-form" style="width: 400px;"></div>
-
-                    <script type="text/javascript" src="//www.google.com/jsapi"></script>
-                    <script type="text/javascript">
-                    google.load('search', '1', {language : 'en', style : google.loader.themes.ESPRESSO});
-                    google.setOnLoadCallback(function() {
-                        var customSearchControl = new google.search.CustomSearchControl('013516846811604855281:nj5laplixaa');
-                        customSearchControl.setResultSetSize(google.search.Search.FILTERED_CSE_RESULTSET);
-                        var options = new google.search.DrawOptions();
-                        options.enableSearchboxOnly("/docs/search_results.html", null, false, '#');
-                        customSearchControl.draw('cse-search-form', options);
-                    }, true);
-                    </script>
-
-
-                </div>
-            </div>
-        </div>
-    </div>
-
-    <div id="selectionbar">
-        <div class="wrapper">
-            <ul>
-                <li >
-                    <a href="/docs/documents.html">Documentation</a></li>
-                    <li class="activelink">
-                        <a href="/docs/schemas.html">Schemas</a></li>
-                        <li >
-                            <a href="/">Home</a></li>
-                        </ul>
-                    </div>
-
-                </div>
-                <div style="padding: 14px; float: right;" id="languagebox"></div>
-
-
-
+{% include 'basicPageHeader.tpl' with context %}
 
 <div style="margin-left: 8%; margin-right: 8%">
 

--- a/templates/genericTermPageHeader.tpl
+++ b/templates/genericTermPageHeader.tpl
@@ -55,48 +55,8 @@
 
 </head>
 <body class="{{ sitemode }}">
-    <div id="container">
-        <div id="intro">
-            <div id="pageHeader">
-              <div class="wrapper">
-                <h1><a href="/">{{ sitename }}</a></h1>
 
-<div id="cse-search-form" style="width: 400px;"></div>
-
-<script type="text/javascript" src="//www.google.com/jsapi"></script>
-<script type="text/javascript">
-  google.load('search', '1', {language : 'en', style : google.loader.themes.ESPRESSO});
-  google.setOnLoadCallback(function() {
-    var customSearchControl = new google.search.CustomSearchControl('013516846811604855281:nj5laplixaa');
-    customSearchControl.setResultSetSize(google.search.Search.FILTERED_CSE_RESULTSET);
-    var options = new google.search.DrawOptions();
-    options.enableSearchboxOnly("/docs/search_results.html", null, false, '#');
-    customSearchControl.draw('cse-search-form', options);
-  }, true);
-</script>
-
-
-              </div>
-            </div>
-        </div>
-    </div>
-
-            <div id="selectionbar">
-               <div class="wrapper">
-                <ul>
-                    <li >
-                      <a href="/docs/documents.html">Documentation</a></li>
-                    <li class="activelink">
-                      <a href="/docs/schemas.html">Schemas</a></li>
-                    <li >
-                      <a href=".">Home</a></li>
-                </ul>
-                </div>
-
-            </div>
-        <div style="padding: 14px; float: right;" id="languagebox"></div>
-
-
+{% include 'basicPageHeader.tpl' with context %}
 
   <div id="mainContent" vocab="http://schema.org/" typeof="{{ rdfs_type }}" resource="http://schema.org/{{ entry }}">
   {{ ext_mappings | safe }}

--- a/templates/homepage.tpl
+++ b/templates/homepage.tpl
@@ -9,46 +9,8 @@
 
 </head>
 <body>
-    <div id="container">
-        <div id="intro">
-            <div id="pageHeader">
-              <div class="wrapper">
-                <h1>schema.org</h1>
-
-<div id="cse-search-form" style="width: 400px;"></div>
-
-<script type="text/javascript" src="//www.google.com/jsapi"></script>
-<script type="text/javascript">
-  google.load('search', '1', {language : 'en', style : google.loader.themes.ESPRESSO});
-  google.setOnLoadCallback(function() {
-    var customSearchControl = new google.search.CustomSearchControl('013516846811604855281:nj5laplixaa');
-    customSearchControl.setResultSetSize(google.search.Search.FILTERED_CSE_RESULTSET);
-    var options = new google.search.DrawOptions();
-    options.enableSearchboxOnly("docs/search_results.html", null, false, '#');
-    customSearchControl.draw('cse-search-form', options);
-  }, true);
-</script>
-
-
-              </div>
-            </div>
-        </div>
-    </div>
-
-            <div id="selectionbar">
-               <div class="wrapper">
-                <ul>
-                    <li >
-                      <a href="docs/documents.html">Documentation</a></li>
-                    <li >
-                      <a href="docs/schemas.html">Schemas</a></li>
-                    <li>
-                      <a href="docs/about.html">About</a></li>
-                </ul>
-                </div>
-
-            </div>
-        <div style="padding: 14px; float: right;" id="languagebox"></div>
+	
+{% include 'basicPageHeader.tpl' with context %}
 
   <div id="mainContent">
 

--- a/templates/tocVersionPage.tpl
+++ b/templates/tocVersionPage.tpl
@@ -10,49 +10,7 @@
 </head>
 <body style="text-align: left;">
 
-    <div id="container">
-        <div id="intro">
-            <div id="pageHeader">
-                <div class="wrapper">
-                    <h1>schema.org</h1>
-
-                    <div id="cse-search-form" style="width: 400px;"></div>
-
-                    <script type="text/javascript" src="//www.google.com/jsapi"></script>
-                    <script type="text/javascript">
-                    google.load('search', '1', {language : 'en', style : google.loader.themes.ESPRESSO});
-                    google.setOnLoadCallback(function() {
-                        var customSearchControl = new google.search.CustomSearchControl('013516846811604855281:nj5laplixaa');
-                        customSearchControl.setResultSetSize(google.search.Search.FILTERED_CSE_RESULTSET);
-                        var options = new google.search.DrawOptions();
-                        options.enableSearchboxOnly("../docs/search_results.html", null, false, '#');
-                        customSearchControl.draw('cse-search-form', options);
-                    }, true);
-                    </script>
-
-
-                </div>
-            </div>
-        </div>
-    </div>
-
-    <div id="selectionbar">
-        <div class="wrapper">
-            <ul>
-                <li >
-                    <a href="/docs/documents.html">Documentation</a></li>
-                    <li class="activelink">
-                        <a href="/docs/schemas.html">Schemas</a></li>
-                        <li >
-                            <a href="/">Home</a></li>
-                        </ul>
-                    </div>
-
-                </div>
-                <div style="padding: 14px; float: right;" id="languagebox"></div>
-
-
-
+{% include 'basicPageHeader.tpl' with context %}
 
 <div style="margin-left: 8%; margin-right: 8%">
 

--- a/templates/wrongExt.tpl
+++ b/templates/wrongExt.tpl
@@ -1,0 +1,30 @@
+<!DOCTYPE html>
+<html xmlns="http://www.w3.org/1999/xhtml" xml:lang="en" lang="en">
+<head>
+    <meta http-equiv="Content-Type" content="text/html; charset=UTF-8" />
+    <title>- schema.org</title>
+    <meta name="description" content="Schema.org is a set of extensible schemas that enables webmasters to embed
+    structured data on their web pages for use by search engines and other applications." />
+    <link rel="stylesheet" type="text/css" href="/docs/schemaorg.css">
+
+</head>
+<body>
+	
+{% include 'basicPageHeader.tpl' with context %}
+
+  <div id="mainContent">
+	<h1>Schema.org Extensions</h1>
+
+	<p>
+		The term '{{ target }}' is not in the schema.org core vocabulary, but is described by the following extension(s):
+	</p> 
+	<ul>
+	{% for ext in extensions %}
+		  <li><a href="{{ext['href']}}">{{ext['text']}}</a></li>
+	{% endfor %}
+	</ul>
+
+  </div>
+
+</body>
+</html>


### PR DESCRIPTION
Added CSS to position <div> 
Centralised header for all programaticly called templates in a new basicPageHeader.tpl template.
Created new template for page to redirect to terms in extensions (wrongExt.tpl)