### PR TITLE
(#725) HTML <Meta> 

### DIFF
--- a/api.py
+++ b/api.py
@@ -788,7 +788,24 @@ def read_examples(files):
         parser = parsers.ParseExampleFile(None)
         parser.parse(example_contents)
 
-
+def StripHtmlTags(source):
+    return re.sub('<[^<]+?>', '', source)
+    
+def ShortenOnSentence(source,lengthHint=250):
+    if len(source) > lengthHint:
+        sentEnd = re.compile('[.!?]')
+        sentList = sentEnd.split(source)
+        com=""
+        for sent in sentList:
+            com += sent 
+            com += source[len(com)]
+            if len(com) > lengthHint:
+                break
+        if len(source) > len(com):
+            com += ".."
+        source = com
+    return source
+     
 
 
 

--- a/data/schema.rdfa
+++ b/data/schema.rdfa
@@ -3899,7 +3899,7 @@
     </div>
     <div typeof="rdfs:Class" resource="http://schema.org/Action">
       <span class="h" property="rdfs:label">Action</span>
-      <span property="rdfs:comment">An action performed by a direct agent and indirect     participants upon a direct object. Optionally happens at a location     with the help of an inanimate instrument. The execution of the action     may produce a result. Specific action sub-type documentation specifies     the exact expectation of each argument/role.
+      <span property="rdfs:comment">An action performed by a direct agent and indirect participants upon a direct object. Optionally happens at a location with the help of an inanimate instrument. The execution of the action may produce a result. Specific action sub-type documentation specifies the exact expectation of each argument/role.
       &lt;br/&gt;&lt;br/&gt;See also &lt;a href="http://blog.schema.org/2014/04/announcing-schemaorg-actions.html"&gt;blog post&lt;/a&gt;
       and &lt;a href="http://schema.org/docs/actions.html"&gt;Actions overview document&lt;/a&gt;.</span>
        <span>Subclass of: <a property="rdfs:subClassOf" href="http://schema.org/Thing">Thing</a></span>
@@ -3926,7 +3926,7 @@
 
     <div typeof="rdfs:Class" resource="http://schema.org/AchieveAction">
       <span class="h" property="rdfs:label">AchieveAction</span>
-      <span property="rdfs:comment">The act of accomplishing something via     previous efforts. It is an instantaneous action rather than an ongoing     process.</span>
+      <span property="rdfs:comment">The act of accomplishing something via previous efforts. It is an instantaneous action rather than an ongoing process.</span>
        <span>Subclass of: <a property="rdfs:subClassOf" href="http://schema.org/Action">Action</a></span>
     </div>
 

--- a/sdoapp.py
+++ b/sdoapp.py
@@ -950,7 +950,7 @@ class ShowUnit (webapp2.RequestHandler):
             com=""
             for sent in sentList:
                 com += sent 
-                com += "."
+                com += comment[len(com)]
                 if len(com) > lengthHint:
                     break
             comment = com

--- a/sdoapp.py
+++ b/sdoapp.py
@@ -22,7 +22,7 @@ from api import inLayer, read_file, full_path, read_schemas, read_extensions, re
 from api import Unit, GetTargets, GetSources
 from api import GetComment, all_terms, GetAllTypes, GetAllProperties
 from api import GetParentList, GetImmediateSubtypes, HasMultipleBaseTypes
-from api import GetJsonLdContext
+from api import GetJsonLdContext, ShortenOnSentence, StripHtmlTags
 
 logging.basicConfig(level=logging.INFO) # dev_appserver.py --log_level debug .
 log = logging.getLogger(__name__)
@@ -188,9 +188,9 @@ class TypeHierarchyTree:
         maybe_comma = "{}".format("," if unvisited_subtype_count > 0 else "")
         comment = GetComment(node, layers).strip()
         comment = comment.replace('"',"'")
-        comment = re.sub('<[^<]+?>', '', comment)[:60]
+        comment = ShortenOnSentence(StripHtmlTags(comment),60)
 
-        self.emit('\n%s{\n%s\n%s"@type": "rdfs:Class", %s "description": "%s...",\n%s"name": "%s",\n%s"@id": "schema:%s"%s'
+        self.emit('\n%s{\n%s\n%s"@type": "rdfs:Class", %s "description": "%s",\n%s"name": "%s",\n%s"@id": "schema:%s"%s'
                   % (p1, ctx, p1,                 supertx,            comment,     p1,   node.id, p1,        node.id,  maybe_comma))
 
         i = 1
@@ -944,18 +944,8 @@ class ShowUnit (webapp2.RequestHandler):
         lengthHint -= len(desc)
         
         comment = GetComment(node, layers)
-        if len(comment) > lengthHint:
-            sentEnd = re.compile('[.!?]')
-            sentList = sentEnd.split(comment)
-            com=""
-            for sent in sentList:
-                com += sent 
-                com += comment[len(com)]
-                if len(com) > lengthHint:
-                    break
-            comment = com
-              
-        desc += comment
+                     
+        desc += ShortenOnSentence(StripHtmlTags(comment),lengthHint) 
         
         return desc
         

--- a/templates/genericTermPageHeader.tpl
+++ b/templates/genericTermPageHeader.tpl
@@ -3,8 +3,7 @@
 <head>
     <meta http-equiv="Content-Type" content="text/html; charset=UTF-8" />
     <title>{{ entry }} - {{ sitename }}</title>
-    <meta name="description" content="Schema.org is a set of extensible schemas that enables webmasters to embed
-    structured data on their web pages for use by search engines and other applications." />
+    <meta name="description" content="{{ desc }}" />
     <link rel="stylesheet" type="text/css" href="/docs/schemaorg.css" />
     <link href="/docs/prettify.css" type="text/css" rel="stylesheet" />
     <script type="text/javascript" src="/docs/prettify.js"></script>


### PR DESCRIPTION
Fix (#725) HTML <Meta> built from term name, type, and comment (truncated on a sentence boundary to a sensible length - currently 200 chars)