### PR TITLE
Auto fix: Broaded definition of seatingCapacity and specialUsage

### DIFF
--- a/data/ext/auto/auto.rdfa
+++ b/data/ext/auto/auto.rdfa
@@ -160,7 +160,7 @@
     <div typeof="rdf:Property" resource="http://schema.org/seatingCapacity">
         <link property="http://schema.org/isPartOf" href="http://auto.schema.org" />
         <span class="h" property="rdfs:label">seatingCapacity</span>
-        <span property="rdfs:comment">The number of passengers that can be seated in the vehicle, both in terms of the physical space available, and in terms of limitations set by law.&lt;br /&gt;
+        <span property="rdfs:comment">The number of persons that can be seated (e.g. in a vehicle), both in terms of the physical space available, and in terms of limitations set by law.&lt;br /&gt;
     Typical unit code(s): C62 for persons </span>
         <span>Domain: <a property="http://schema.org/domainIncludes" href="http://schema.org/Vehicle">Vehicle</a></span>
         <span>Range: <a property="http://schema.org/rangeIncludes" href="http://schema.org/QuantitativeValue">QuantitativeValue</a></span>
@@ -207,7 +207,7 @@
     <div typeof="rdf:Property" resource="http://schema.org/specialUsage">
         <link property="http://schema.org/isPartOf" href="http://auto.schema.org" />
         <span class="h" property="rdfs:label">specialUsage</span>
-        <span property="rdfs:comment">Indicates whether the vehicle has been used for special purposes, like commercial rental, driving school, or as a taxi. The legislation in many countries requires this information to be revealed when offering a car for sale.
+        <span property="rdfs:comment">Indicates whether the object has been used for special purposes, like vehicles that have been used for commercial rental, driving school, or as a taxi. The legislation in some countries may require this information to be revealed when offering the item for sale.
     </span>
         <span>Domain: <a property="http://schema.org/domainIncludes" href="http://schema.org/Vehicle">Vehicle</a></span>
         <span>Range: <a property="http://schema.org/rangeIncludes" href="http://schema.org/Text">Text</a></span>


### PR DESCRIPTION
This solves #704.

seatingCapacity and specialUsage are now defined in a way that fits other types of objects than vehicles.
seatingCapacity may also be useful for buildings, boats, classrooms, etc.
specialUsage may also be useful for other types of products, namely real estate objects.

We may want to move the definition of these elements to schema.org core once they are added to other types. For the moment, I suggest to keep them in the auto extension and expand their range in a second step.
