### PR TITLE
Allow makesOffer for OfferCatalog

### DIFF
--- a/data/schema.rdfa
+++ b/data/schema.rdfa
@@ -1503,8 +1503,7 @@
 
     <div typeof="rdf:Property" resource="http://schema.org/hasOfferCatalog">
       <span class="h" property="rdfs:label">hasOfferCatalog</span>
-      <span property="rdfs:comment">Indicates an OfferCatalog listing for this Organization or Service.</span>
-      <span>Domain: <a property="http://schema.org/domainIncludes" href="http://schema.org/Organization">Organization</a></span>
+      <span property="rdfs:comment">Indicates an OfferCatalog listing for this Service. For linking from an Organization to an OfferCatalog, use makesOffer.</span>
       <span>Domain: <a property="http://schema.org/domainIncludes" href="http://schema.org/Service">Service</a></span>
       <span>Range: <a property="http://schema.org/rangeIncludes" href="http://schema.org/OfferCatalog">OfferCatalog</a></span>
     </div>
@@ -7507,12 +7506,14 @@ Note that Event uses startDate/endDate instead of startTime/endTime, even when d
       <span>Domain: <a property="http://schema.org/domainIncludes" href="http://schema.org/Organization">Organization</a></span>
       <span>Domain: <a property="http://schema.org/domainIncludes" href="http://schema.org/Person">Person</a></span>
       <span>Range: <a property="http://schema.org/rangeIncludes" href="http://schema.org/Offer">Offer</a></span>
+      <span>Range: <a property="http://schema.org/rangeIncludes" href="http://schema.org/OfferCatalog">OfferCatalog</a></span>
     </div>
     <div typeof="rdf:Property" resource="http://schema.org/offeredBy">
       <span class="h" property="rdfs:label">offeredBy</span>
       <span property="rdfs:comment">A pointer to the organization or person making the offer.</span>
       <link property="http://schema.org/inverseOf" href="http://schema.org/makesOffer"/>
       <span>Domain: <a property="http://schema.org/domainIncludes" href="http://schema.org/Offer">Organization</a></span>
+      <span>Domain: <a property="http://schema.org/domainIncludes" href="http://schema.org/OfferCatalog">OfferCatalog</a></span>
       <span>Range: <a property="http://schema.org/rangeIncludes" href="http://schema.org/Person">Person</a></span>
       <span>Range: <a property="http://schema.org/rangeIncludes" href="http://schema.org/Organization">Offer</a></span>
     </div>


### PR DESCRIPTION
As suggested, I think we should use makesOffer for linking an Organization to a OfferCatalog.
This pull request implements that proposal.
We would then use hasOfferCatalog only for linking from a Service to its OfferCatalog and makesOffer for Organizations and Persons linking to their offers.

Advantages:

1. We support Person and Organization.
2. makesOffer and offeredBy are then symmetrical, while in the current proposal, you can use offeredBy with OfferCatalog and Offer and makesOffer only with Offer.
3. You need only one property to link from the Organization to the OfferCatalog and implicitly add the makesOffer information,