### PR TITLE
PropertyValue example fixes (pre-markup ex. had Microdata; alt attributes were missing)

### DIFF
--- a/data/sdo-property-value-examples.txt
+++ b/data/sdo-property-value-examples.txt
@@ -3,7 +3,7 @@ TYPES: #exif ImageObject, PropertyValue
 PRE-MARKUP:
 
 <h2>Beach in Mexico</h2>
-<img src="mexico-beach.jpg" />
+<img src="mexico-beach.jpg" alt="" />
 By Jane Doe
 Photographed in Puerto Vallarta, Mexico
 Date uploaded: Jan 25, 2008
@@ -21,7 +21,7 @@ MICRODATA:
 
 <div itemscope itemtype="http://schema.org/ImageObject">
   <h2 itemprop="name">Beach in Mexico</h2>
-  <img src="mexico-beach.jpg" itemprop="contentUrl" />
+  <img src="mexico-beach.jpg" alt="" itemprop="contentUrl" />
   By <span itemprop="author">Jane Doe</span>
   Photographed in
     <span itemprop="contentLocation">Puerto Vallarta, Mexico</span>
@@ -55,7 +55,7 @@ RDFA:
 
 <div vocab="http://schema.org/" typeof="ImageObject">
   <h2 property="name">Beach in Mexico</h2>
-  <img src="mexico-beach.jpg" property="contentUrl" />
+  <img src="mexico-beach.jpg" alt="" property="contentUrl" />
   By <span property="author">Jane Doe</span>
   Photographed in
     <span property="contentLocation">Puerto Vallarta, Mexico</span>
@@ -132,7 +132,7 @@ PRE-MARKUP:
 
 <!-- Product: Point Value, with unit as text -->
 <div>
-  <img src="camera123.jpg" />
+  <img src="camera123.jpg" alt="" />
   <span>Digital Camera 123</span>
   <div>
       <span>Approx. Weight</span>
@@ -145,7 +145,7 @@ MICRODATA:
 
 <!-- Product: Point Value, with unit as text -->
 <div itemscope itemtype="http://schema.org/Product">
-  <img itemprop="image" src="camera123.jpg" />
+  <img itemprop="image" src="camera123.jpg" alt="" />
   <span itemprop="name">Digital Camera 123</span>
   <div itemprop="additionalProperty" itemscope itemtype="http://schema.org/PropertyValue">
       <span itemprop="name">Approx. Weight</span>
@@ -172,7 +172,7 @@ PRE-MARKUP:
 
 <!-- Product: Point Value, with unit as symbol -->
 <div>
-  <img src="camera123.jpg" />
+  <img src="camera123.jpg" alt="" />
   <span>Digital Camera 123</span>
   <div>
       <span>Approx. Weight</span>
@@ -185,7 +185,7 @@ MICRODATA:
 
 <!-- Product: Point Value, with unit as symbol -->
 <div itemscope itemtype="http://schema.org/Product">
-  <img itemprop="image" src="camera123.jpg" />
+  <img itemprop="image" src="camera123.jpg" alt="" />
   <span itemprop="name">Digital Camera 123</span>
   <div itemprop="additionalProperty" itemscope itemtype="http://schema.org/PropertyValue">
       <span itemprop="name">Approx. Weight</span>
@@ -212,7 +212,7 @@ PRE-MARKUP:
 
 <!-- Product: Point Value, with unit as UN/CEFACT Common Code to be added to the template -->
 <div>
-  <img src="camera123.jpg" />
+  <img src="camera123.jpg" alt="" />
   <span>Digital Camera 123</span>
   <div>
       <span>Approx. Weight</span>
@@ -224,7 +224,7 @@ MICRODATA:
 
 <!-- Product: Point Value, with unit as UN/CEFACT Common Code -->
 <div itemscope itemtype="http://schema.org/Product">
-  <img itemprop="image" src="camera123.jpg" />
+  <img itemprop="image" src="camera123.jpg" alt="" />
   <span itemprop="name">Digital Camera 123</span>
   <div itemprop="additionalProperty" itemscope itemtype="http://schema.org/PropertyValue">
       <span itemprop="name">Approx. Weight</span>
@@ -251,7 +251,7 @@ PRE-MARKUP:
 
 <!-- Product: Range, with unit as UN/CEFACT Common Code to be added to the template -->
 <div>
-  <img src="camera123.jpg" />
+  <img src="camera123.jpg" alt="" />
   <span>Digital Camera 123</span>
   <div>
       <span>Operating Voltage</span>
@@ -265,7 +265,7 @@ MICRODATA:
 
 <!-- Product: Range, with unit as UN/CEFACT Common Code -->
 <div itemscope itemtype="http://schema.org/Product">
-  <img itemprop="image" src="camera123.jpg" />
+  <img itemprop="image" src="camera123.jpg" alt="" />
   <span itemprop="name">Digital Camera 123</span>
   <div itemprop="additionalProperty" itemscope itemtype="http://schema.org/PropertyValue">
       <span itemprop="name">Operating Voltage</span>
@@ -293,7 +293,7 @@ PRE-MARKUP:
 
 <!-- Product: Open Interval, with unit as UN/CEFACT Common Code to be added to the template -->
 <div>
-  <img src="camera123.jpg" />
+  <img src="camera123.jpg" alt="" />
   <span>Digital Camera 123</span>
   <div>
       <span>Wifi range</span>: up to 
@@ -306,7 +306,7 @@ MICRODATA:
 
 <!-- Product: Open Interval, with unit as UN/CEFACT Common Code -->
 <div itemscope itemtype="http://schema.org/Product">
-  <img itemprop="image" src="camera123.jpg" />
+  <img itemprop="image" src="camera123.jpg" alt="" />
   <span itemprop="name">Digital Camera 123</span>
   <div itemprop="additionalProperty" itemscope itemtype="http://schema.org/PropertyValue">
       <span itemprop="name">Wifi range</span>: up to 
@@ -334,7 +334,7 @@ PRE-MARKUP:
 
 <!-- Product: Multiple Intervals -->
 <div>
-  <img src="camera123.jpg" />
+  <img src="camera123.jpg" alt="" />
   <span>Digital Camera 123</span>
   <div>
       <span>Operating voltage</span>: 
@@ -348,7 +348,7 @@ MICRODATA:
 
 <!-- Product: Multiple Intervals -->
 <div itemscope itemtype="http://schema.org/Product">
-  <img itemprop="image" src="camera123.jpg" />
+  <img itemprop="image" src="camera123.jpg" alt="" />
   <span itemprop="name">Digital Camera 123</span>
   <div itemprop="additionalProperty" itemscope itemtype="http://schema.org/PropertyValue">
       <span itemprop="name">Operating voltage</span>: 
@@ -376,7 +376,7 @@ PRE-MARKUP:
 
 <!-- Product: Range and Enumerated Values -->
 <div>
-  <img src="camera123.jpg" />
+  <img src="camera123.jpg" alt="" />
   <span>Digital Camera 123</span>
   <div>
       <span>ISO Sensitivity</span>: 
@@ -390,7 +390,7 @@ MICRODATA:
 
 <!-- Product: Range and Enumerated Values -->
 <div itemscope itemtype="http://schema.org/Product">
-  <img itemprop="image" src="camera123.jpg" />
+  <img itemprop="image" src="camera123.jpg" alt="" />
   <span itemprop="name">Digital Camera 123</span>
   <div itemprop="additionalProperty" itemscope itemtype="http://schema.org/PropertyValue">
       <span itemprop="name">ISO Sensitivity</span>: 
@@ -418,7 +418,7 @@ PRE-MARKUP:
 
 <!-- Product: Boolean Value -->
 <div>
-  <img src="camera123.jpg" />
+  <img src="camera123.jpg" alt="" />
   <span>Digital Camera 123</span>
   <div>
       <span>USB interface</span>: Yes
@@ -429,7 +429,7 @@ MICRODATA:
 
 <!-- Product: Boolean Value -->
 <div itemscope itemtype="http://schema.org/Product">
-  <img itemprop="image" src="camera123.jpg" />
+  <img itemprop="image" src="camera123.jpg" alt="" />
   <span itemprop="name">Digital Camera 123</span>
   <div itemprop="additionalProperty" itemscope itemtype="http://schema.org/PropertyValue">
       <span itemprop="name">USB interface</span>:
@@ -455,7 +455,7 @@ PRE-MARKUP:
 
 <!-- Product: Qualitative Value -->
 <div>
-  <img src="camera123.jpg" />
+  <img src="camera123.jpg" alt="" />
   <span>Digital Camera 123</span>
   <div>
       <span>Interface</span>: <span>USB</span>
@@ -466,7 +466,7 @@ MICRODATA:
 
 <!-- Product: Qualitative Value -->
 <div itemscope itemtype="http://schema.org/Product">
-  <img itemprop="image" src="camera123.jpg" />
+  <img itemprop="image" src="camera123.jpg" alt="" />
   <span itemprop="name">Digital Camera 123</span>
   <div itemprop="additionalProperty" itemscope itemtype="http://schema.org/PropertyValue">
       <span itemprop="name">Interface</span>:
@@ -492,7 +492,7 @@ PRE-MARKUP:
 
 <!-- Product: Qualitative Value (multiple) -->
 <div>
-  <img src="camera123.jpg" />
+  <img src="camera123.jpg" alt="" />
   <span>Digital Camera 123</span>
   <div>
       <span>Interfaces</span>:
@@ -505,7 +505,7 @@ MICRODATA:
 
 <!-- Product: Qualitative Value (multiple) -->
 <div itemscope itemtype="http://schema.org/Product">
-  <img itemprop="image" src="camera123.jpg" />
+  <img itemprop="image" src="camera123.jpg" alt="" />
   <span itemprop="name">Digital Camera 123</span>
   <div itemprop="additionalProperty" itemscope itemtype="http://schema.org/PropertyValue">
       <span itemprop="name">Interfaces</span>:
@@ -533,7 +533,7 @@ PRE-MARKUP:
 <!-- Product: Property ID for clarifying the meaning of a property: URI from external vocabulary -->
 <!-- (see microdata example for comparison) -->
 <div itemscope itemtype="http://schema.org/Car">
-  <img src="station_waggon123.jpg" />
+  <img src="station_waggon123.jpg" alt="" />
   <span>Station Waggon 123</span>
   <div>
       <span>Luggage Capacity (seats folded)</span>:
@@ -546,7 +546,7 @@ MICRODATA:
 
 <!-- Product: Property ID for clarifying the meaning of a property: URI from external vocabulary -->
 <div itemscope itemtype="http://schema.org/Car">
-  <img itemprop="image" src="station_waggon123.jpg" />
+  <img itemprop="image" src="station_waggon123.jpg" alt="" />
   <span itemprop="name">Station Waggon 123</span>
   <div itemprop="additionalProperty" itemscope itemtype="http://schema.org/PropertyValue">
       <span itemprop="name">Luggage Capacity (seats folded)</span>:
@@ -576,7 +576,7 @@ PRE-MARKUP:
 <!-- The Property code 02-AAM226 is for "USB interface present" in eCl@ss 8.1 
 (see microdata example for comparison) -->
 <div>
-  <img src="camera123.jpg" />
+  <img src="camera123.jpg" alt="" />
   <span>Digital Camera 123</span>
   <div>
       <span>USB Interface</span>:Yes
@@ -589,7 +589,7 @@ MICRODATA:
 <!-- Product: Property ID for clarifying the meaning of a property: Code from eCl@ss Standard -->
 <!-- The Property code 02-AAM226 is for "USB interface present" in eCl@ss 8.1 -->
 <div itemscope itemtype="http://schema.org/Product">
-  <img itemprop="image" src="camera123.jpg" />
+  <img itemprop="image" src="camera123.jpg" alt="" />
   <span itemprop="name">Digital Camera 123</span>
   <div itemprop="additionalProperty" itemscope itemtype="http://schema.org/PropertyValue">
       <span itemprop="name">USB Interface</span>:
@@ -616,7 +616,7 @@ PRE-MARKUP:
 
 <!-- Product: Value References -->
 <div>
-  <img src="camera123.jpg" />
+  <img src="camera123.jpg" alt="" />
   <span>Digital Camera 123</span>
   <div>
       <span>Operating Voltage</span>
@@ -635,7 +635,7 @@ MICRODATA:
 
 <!-- Product: Value References -->
 <div itemscope itemtype="http://schema.org/Product">
-  <img itemprop="image" src="camera123.jpg" />
+  <img itemprop="image" src="camera123.jpg" alt="" />
   <span itemprop="name">Digital Camera 123</span>
   <div itemprop="additionalProperty" itemscope itemtype="http://schema.org/PropertyValue">
       <span itemprop="name">Operating Voltage</span>
@@ -668,7 +668,7 @@ PRE-MARKUP:
 
 <!-- Product: Ratios -->
 <div itemscope itemtype="http://schema.org/Car">
-  <img src="station_waggon123.jpg" />
+  <img src="station_waggon123.jpg" alt="" />
   <span>Station Waggon 123</span>
   <div>
       <span>Fuel consumption</span>:
@@ -685,7 +685,7 @@ MICRODATA:
 
 <!-- Product: Ratios -->
 <div itemscope itemtype="http://schema.org/Car">
-  <img itemprop="image" src="station_waggon123.jpg" />
+  <img itemprop="image" src="station_waggon123.jpg" alt="" />
   <span itemprop="name">Station Waggon 123</span>
   <div itemprop="additionalProperty" itemscope itemtype="http://schema.org/PropertyValue">
       <span itemprop="name">Fuel consumption</span>:
@@ -715,7 +715,7 @@ PRE-MARKUP:
 
 <!-- Product: Grouping and Hierarchical Order of Properties -->
 <div>
-  <img src="camera123.jpg" />
+  <img src="camera123.jpg" alt="" />
   <span>Digital Camera 123</span>
   <div>
       <strong>Focus/Autofocus</strong>
@@ -735,7 +735,7 @@ MICRODATA:
 
 <!-- Product: Grouping and Hierarchical Order of Properties -->
 <div itemscope itemtype="http://schema.org/Product">
-  <img itemprop="image" src="camera123.jpg" />
+  <img itemprop="image" src="camera123.jpg" alt="" />
   <span itemprop="name">Digital Camera 123</span>
   <div itemprop="additionalProperty" itemscope itemtype="http://schema.org/PropertyValue">
       <strong itemprop="name">Focus/Autofocus</strong>

--- a/data/sdo-property-value-examples.txt
+++ b/data/sdo-property-value-examples.txt
@@ -532,7 +532,7 @@ PRE-MARKUP:
 
 <!-- Product: Property ID for clarifying the meaning of a property: URI from external vocabulary -->
 <!-- (see microdata example for comparison) -->
-<div itemscope itemtype="http://schema.org/Car">
+<div>
   <img src="station_waggon123.jpg" alt="" />
   <span>Station Waggon 123</span>
   <div>
@@ -667,7 +667,7 @@ TYPES:  #ratios PropertyValue
 PRE-MARKUP:
 
 <!-- Product: Ratios -->
-<div itemscope itemtype="http://schema.org/Car">
+<div>
   <img src="station_waggon123.jpg" alt="" />
   <span>Station Waggon 123</span>
   <div>


### PR DESCRIPTION
* removed Microdata from two PRE-MARKUP examples
* added empty `alt` attribute to all `img` elements

(@danbri: Should I create an issue for this? I assumed not because these are only example markup changes.)