### PR TITLE
Moved RDFa properties for links to other terms from <a> to a separate <link>…

### DIFF
--- a/sdoapp.py
+++ b/sdoapp.py
@@ -415,7 +415,13 @@ class ShowUnit (webapp2.RequestHandler):
             extflag = EXTENSION_SUFFIX
             tooltip = "title=\"Extended schema: %s.schema.org\" " % home
 
-        return "<a %s %s href=\"%s%s%s\"%s%s>%s</a>%s" % (tooltip, extclass, urlprefix, hashorslash, node.id, prop, title, label, extflag)
+        rdfalink = ''
+        if prop:
+            rdfalink = '<link %s href="http://schema.org/%s" />' % (prop,label)
+            
+
+        return "%s<a %s %s href=\"%s%s%s\"%s>%s</a>%s" % (rdfalink,tooltip, extclass, urlprefix, hashorslash, node.id, title, label, extflag)
+        #return "<a %s %s href=\"%s%s%s\"%s%s>%s</a>%s" % (tooltip, extclass, urlprefix, hashorslash, node.id, prop, title, label, extflag)
 
     def makeLinksFromArray(self, nodearray, tooltip=''):
         """Make a comma separate list of links via ml() function.


### PR DESCRIPTION
On fulltermpage - Moved RDFa properties for links to other terms from <a> to a separate <link> to preserve on site navigation, in extensions and on test sites, whilst still using http://schema.org domain. (#708)