### PR TITLE
Fix to invalid date format in JSON-LD example for Event, EventCancelled, & SoldOut

### DIFF
--- a/data/examples.txt
+++ b/data/examples.txt
@@ -9333,7 +9333,7 @@ JSON:
     "priceCurrency": "USD",
     "url": "http://www.ticketfly.com/purchase/309433"
   },
-  "startDate": "Sat Sep 14"
+  "startDate": "2013-09-14T21:30"
 }
 </script>
 
@@ -9440,7 +9440,7 @@ JSON:
     "priceCurrency": "USD",
     "url": "http://www.ticketfly.com/purchase/309433"
   },
-  "startDate": "Sat Sep 14"
+  "startDate": "2013-09-14T21:30"
 }
 </script>
 
@@ -9648,7 +9648,7 @@ JSON:
     "priceCurrency": "USD",
     "url": "http://www.ticketfly.com/purchase/309433"
   },
-  "startDate": "Sat Sep 14"
+  "startDate": "2013-09-14T21:30"
 }
 </script>
 


### PR DESCRIPTION
Fix to invalid date format in JSON-LD example for Event, EventCancelled, & SoldOut includes fix for #636