### PR TITLE
Fix to RentalCarReservation Example

### DIFF
--- a/data/examples.txt
+++ b/data/examples.txt
@@ -10454,12 +10454,12 @@ JSON:
     "brand": {
       "@type": "Brand",
       "name": "Honda"
-    },
-    "operatingCompany": {
-      "@type": "Organization",
-      "name": "Hertz"
     }
   },
+  "provider": {
+        "@type": "Organization",
+        "name": "Hertz"
+      },
   "pickupLocation": {
     "@type": "Place",
     "name": "Hertz San Diego Airport",
@@ -10488,7 +10488,6 @@ JSON:
   "dropoffTime": "2017-08-06T20:00:00-07:00"
 }
 </script>
-
 TYPES: TaxiReservation
 
 PRE-MARKUP:


### PR DESCRIPTION
Fix to RentalCarReservation Example - Issue (#866)

(_The JSON-LD example for https://schema.org/RentalCarReservation uses a non-existent property operatingCompany. This should be replaced by schema:provider and attached to the schema:RentalCarReservation, not the schema:Car._)

Thanks to @mfhepp and Jimmy Phan.