### PR TITLE
Fix899

### DIFF
--- a/api.py
+++ b/api.py
@@ -862,15 +862,27 @@ def StripHtmlTags(source):
 
 def ShortenOnSentence(source,lengthHint=250):
     if len(source) > lengthHint:
+        source = source.strip()
         sentEnd = re.compile('[.!?]')
         sentList = sentEnd.split(source)
+        log.info("source '%s'" % source)
         com=""
-        for sent in sentList:
-            com += sent
-            com += source[len(com)]
+        count = 0
+        while count < len(sentList):
+            if(count > 0 ):
+                if len(com) < len(source):
+                    com += source[len(com)]
+            com += sentList[count]
+            count += 1
+            if count == len(sentList):
+                if len(com) < len(source):
+                    com += source[len(source) - 1]
             if len(com) > lengthHint:
+                if len(com) < len(source):
+                    com += source[len(com)]
                 break
-        if len(source) > len(com):
+                
+        if len(source) > len(com) + 1:
             com += ".."
         source = com
     return source

--- a/app.yaml
+++ b/app.yaml
@@ -12,6 +12,8 @@ automatic_scaling:
 inbound_services:
 - warmup
 
+env_variables:
+  PRODSITEDEBUG: 'False'
 
 handlers:
 

--- a/data/schema.rdfa
+++ b/data/schema.rdfa
@@ -12425,7 +12425,7 @@ Typical unit code(s): C62</span>
 <div typeof="rdf:Property" resource="http://schema.org/vehicleSeatingCapacity">
     <span class="h" property="rdfs:label">vehicleSeatingCapacity</span>
     <span property="rdfs:comment">The number of passengers that can be seated in the vehicle, both in terms of the physical space available, and in terms of limitations set by law.&lt;br /&gt;
-Typical unit code(s): C62 for persons </span>
+Typical unit code(s): C62 for persons.</span>
     <span>Domain: <a property="http://schema.org/domainIncludes" href="http://schema.org/Vehicle">Vehicle</a></span>
     <span>Range: <a property="http://schema.org/rangeIncludes" href="http://schema.org/QuantitativeValue">QuantitativeValue</a></span>
     <span>Range: <a property="http://schema.org/rangeIncludes" href="http://schema.org/Number">Number</a></span>

--- a/sdoapp.py
+++ b/sdoapp.py
@@ -1852,10 +1852,11 @@ class ShowUnit (webapp2.RequestHandler):
                 else:
                     log.info("Error handling 404 under /version/")
                     return
-
+        log.info("PRODSITEDEBUG: %s" % os.environ['PRODSITEDEBUG'])
         if(node == "_siteDebug"):
-            self.siteDebug()
-            return 
+            if(getBaseHost() != "schema.org" or os.environ['PRODSITEDEBUG'] == "True"):
+                self.siteDebug()
+                return 
 
         # Pages based on request path matching a Unit in the term graph:
         if self.handleExactTermPage(node, layers=layerlist):


### PR DESCRIPTION
Fix to #899 - Fix to ShortenOnSentence() which failed on comment string over max length which did not end with '.'.  For completeness, added the missing '.' to definition of vehicleSeatingCapacity property.

Also  Disabled _siteDebug call on host schema.org unless PRODSITEDEBUG environment variable set to 'True'. Still operates as before on all other hosts.