### PR TITLE
Review example: use 'reviewBody' instead of 'description'

### DIFF
--- a/data/examples.txt
+++ b/data/examples.txt
@@ -776,10 +776,10 @@ Not a happy camper - by Ellie, April 1, 2011
 1/5 stars
 The lamp burned out and now I have to replace it.
 
- Value purchase - by Lucas, March 25, 2011
+Value purchase - by Lucas, March 25, 2011
 4/5 stars
 Great microwave for the price. It is small and fits in my apartment.
-...
+…
 
 MICRODATA:
 
@@ -819,8 +819,8 @@ MICRODATA:
       <span itemprop="ratingValue">1</span>/
       <span itemprop="bestRating">5</span>stars
     </div>
-    <span itemprop="description">The lamp burned out and now I have to replace
-    it. </span>
+    <span itemprop="reviewBody">The lamp burned out and now I have to replace
+    it.</span>
   </div>
 
   <div itemprop="review" itemscope itemtype="http://schema.org/Review">
@@ -832,7 +832,7 @@ MICRODATA:
       <span itemprop="ratingValue">4</span>/
       <span itemprop="bestRating">5</span>stars
     </div>
-    <span itemprop="description">Great microwave for the price. It is small and
+    <span itemprop="reviewBody">Great microwave for the price. It is small and
     fits in my apartment.</span>
   </div>
   ...
@@ -874,8 +874,8 @@ RDFA:
       <span property="ratingValue">1</span>/
       <span property="bestRating">5</span>stars
     </div>
-    <span property="description">The lamp burned out and now I have to replace
-    it. </span>
+    <span property="reviewBody">The lamp burned out and now I have to replace
+    it.</span>
   </div>
 
   <div property="review" typeof="Review">
@@ -887,7 +887,7 @@ RDFA:
       <span property="ratingValue">4</span>/
       <span property="bestRating">5</span>stars
     </div>
-    <span property="description">Great microwave for the price. It is small and
+    <span property="reviewBody">Great microwave for the price. It is small and
     fits in my apartment.</span>
   </div>
   ...
@@ -917,7 +917,7 @@ JSON:
       "@type": "Review",
       "author": "Ellie",
       "datePublished": "2011-04-01",
-      "description": "The lamp burned out and now I have to replace it.",
+      "reviewBody": "The lamp burned out and now I have to replace it.",
       "name": "Not a happy camper",
       "reviewRating": {
         "@type": "Rating",
@@ -930,7 +930,7 @@ JSON:
       "@type": "Review",
       "author": "Lucas",
       "datePublished": "2011-03-25",
-      "description": "Great microwave for the price. It is small and fits in my apartment.",
+      "reviewBody": "Great microwave for the price. It is small and fits in my apartment.",
       "name": "Value purchase",
       "reviewRating": {
         "@type": "Rating",

--- a/data/examples.txt
+++ b/data/examples.txt
@@ -797,8 +797,8 @@ MICRODATA:
     <!--price is 1000, a number, with locale-specific thousands separator
     and decimal mark, and the $ character is marked up with the
     machine-readable code "USD" -->
-    <span itemprop="priceCurrency" content="USD">$</span><span
-          itemprop="price" content="1000.00">1,000.00</span>
+    <meta itemprop="priceCurrency" content="USD" />$<meta
+          itemprop="price" content="1000.00" />1,000.00
 
     <link itemprop="availability" href="http://schema.org/InStock" />In stock
   </div>


### PR DESCRIPTION
Reported by @inetbiz in https://github.com/schemaorg/schemaorg/issues/881

(Also fixed two occurences of a `span` element having a `content` attribute in Microdata, which is not valid; replaced with `meta`.)
