### PR TITLE
ExhibitionEvent example: fixes and cleanup

### DIFF
--- a/data/sdo-exhibitionevent-examples.txt
+++ b/data/sdo-exhibitionevent-examples.txt
@@ -4,8 +4,8 @@ PRE-MARKUP:
 <div>
   <h2><a href="http://www.vam.ac.uk/whatson/event/5150/shoes-pleasure-and-pain-696789408/">
     Shoes: Pleasure and Pain</a></h2>
-  <p><time  class="nowrap" datetime="2015-06-13">Sat 13 June 2015</time>–<time datetime="2016-01-31">Sun 31 January 2016</time></p>
-    <p>Explore the transformative power of footwear from around the world as we present over 200 pairs of the most extreme shoes from the last 2000 years. </p>
+  <p><time datetime="2015-06-13">Sat 13 June 2015</time>–<time datetime="2016-01-31">Sun 31 January 2016</time></p>
+    <p>Explore the transformative power of footwear from around the world as we present over 200 pairs of the most extreme shoes from the last 2000 years.</p>
   <a href="http://www.vam.ac.uk/whatson/event/5150/date/20151007/">Book tickets</a>
 </div>
 
@@ -16,8 +16,8 @@ MICRODATA:
   <h2><a itemprop="url" href="http://www.vam.ac.uk/whatson/event/5150/shoes-pleasure-and-pain-696789408/">
     <span itemprop="name">Shoes: Pleasure and Pain</span>
   </a></h2>
-  <p><time class="nowrap" itemprop="startDate" datetime="2015-06-13">Sat 13 June 2015</time>–<time itemprop="endDate" datetime="2016-01-31">Sun 31 January 2016</time></p>
-    <p itemprop="description">Explore the transformative power of footwear from around the world as we present over 200 pairs of the most extreme shoes from the last 2000 years. </p>
+  <p><time itemprop="startDate" datetime="2015-06-13">Sat 13 June 2015</time>–<time itemprop="endDate" datetime="2016-01-31">Sun 31 January 2016</time></p>
+    <p itemprop="description">Explore the transformative power of footwear from around the world as we present over 200 pairs of the most extreme shoes from the last 2000 years.</p>
   <a itemprop="offers" href="http://www.vam.ac.uk/whatson/event/5150/date/20151007/">Book tickets</a>
 </div>
 
@@ -28,8 +28,8 @@ RDFA:
   <h2><a property="url" href="http://www.vam.ac.uk/whatson/event/5150/shoes-pleasure-and-pain-696789408/">
     <span property="name">Shoes: Pleasure and Pain</span>
   </a></h2>
-  <p><time class="nowrap" property="startDate" datetime="2015-06-13">Sat 13 June 2015</time>–<time property="endDate" datetime="2016-01-31">Sun 31 January 2016</time></p>
-    <p property="description">Explore the transformative power of footwear from around the world as we present over 200 pairs of the most extreme shoes from the last 2000 years. </p>
+  <p><time property="startDate" datetime="2015-06-13">Sat 13 June 2015</time>–<time property="endDate" datetime="2016-01-31">Sun 31 January 2016</time></p>
+    <p property="description">Explore the transformative power of footwear from around the world as we present over 200 pairs of the most extreme shoes from the last 2000 years.</p>
   <a property="offers" href="http://www.vam.ac.uk/whatson/event/5150/date/20151007/">Book tickets</a>
 </div>
 
@@ -39,9 +39,9 @@ JSON:
 {
   "@context": "http://schema.org",
   "@type": "ExhibitionEvent",
-  "location":  "Victoria and Albert Museum",
-  "url":  "http://www.vam.ac.uk/whatson/event/5150/shoes-pleasure-and-pain-696789408/",
-  "name":  "Shoes: Pleasure and Pain",
+  "location": "Victoria and Albert Museum",
+  "url": "http://www.vam.ac.uk/whatson/event/5150/shoes-pleasure-and-pain-696789408/",
+  "name": "Shoes: Pleasure and Pain",
   "startDate": "2015-06-13",
   "endDate": "2016-01-31",
   "description": "Explore the transformative power of footwear from around the world as we present over 200 pairs of the most extreme shoes from the last 2000 years.",

--- a/data/sdo-exhibitionevent-examples.txt
+++ b/data/sdo-exhibitionevent-examples.txt
@@ -4,7 +4,7 @@ PRE-MARKUP:
 <div>
   <h2><a href="http://www.vam.ac.uk/whatson/event/5150/shoes-pleasure-and-pain-696789408/">
     Shoes: Pleasure and Pain</a></h2>
-  <p><time  class="nowrap">Sat 13 June 2015</time>–<time>Sun 31 January 2016</time></p>
+  <p><time  class="nowrap" datetime="2015-06-13">Sat 13 June 2015</time>–<time datetime="2016-01-31">Sun 31 January 2016</time></p>
     <p>Explore the transformative power of footwear from around the world as we present over 200 pairs of the most extreme shoes from the last 2000 years. </p>
   <a href="http://www.vam.ac.uk/whatson/event/5150/date/20151007/">Book tickets</a>
 </div>
@@ -28,7 +28,7 @@ RDFA:
   <h2><a property="url" href="http://www.vam.ac.uk/whatson/event/5150/shoes-pleasure-and-pain-696789408/">
     <span property="name">Shoes: Pleasure and Pain</span>
   </a></h2>
-  <p><time class="nowrap" property="startDate" datetime="2015-06-13">Sat 13 June 2015</time>–<time property="endDate" datetime="">Sun 31 January 2016</time></p>
+  <p><time class="nowrap" property="startDate" datetime="2015-06-13">Sat 13 June 2015</time>–<time property="endDate" datetime="2016-01-31">Sun 31 January 2016</time></p>
     <p property="description">Explore the transformative power of footwear from around the world as we present over 200 pairs of the most extreme shoes from the last 2000 years. </p>
   <a property="offers" href="http://www.vam.ac.uk/whatson/event/5150/date/20151007/">Book tickets</a>
 </div>

--- a/data/sdo-exhibitionevent-examples.txt
+++ b/data/sdo-exhibitionevent-examples.txt
@@ -24,7 +24,7 @@ MICRODATA:
 RDFA:
 <div vocab="http://schema.org/" typeof="ExhibitionEvent">
   <meta property="location" content="Victoria and Albert Museum">
-  <meta itempropertyprop="inLanguage" content="en">
+  <meta property="inLanguage" content="en">
   <h2><a property="url" href="http://www.vam.ac.uk/whatson/event/5150/shoes-pleasure-and-pain-696789408/">
     <span property="name">Shoes: Pleasure and Pain</span>
   </a></h2>


### PR DESCRIPTION
* `property` instead of `itempropertyprop`
* RDFa missed `datetime` value in the `time` element with the `endDate` property

* added `datetime` attributes to `time` elements in PRE-MARKUP (invalid otherwise)
* removed `class` attributes (the class `nowrap` doesn’t seem to add anything needed for understanding the markup) 