### PR TITLE
Remove @value clauses from Periodical JSON-LD examples

### DIFF
--- a/data/sdo-periodical-examples.txt
+++ b/data/sdo-periodical-examples.txt
@@ -88,10 +88,7 @@ JSON:
       {
         "@id": "issue9735", 
         "@type": "PublicationIssue", 
-        "datePublished": {
-          "@value": "2010-07-03", 
-          "@type": "http://www.w3.org/2001/XMLSchema#date"
-        }, 
+        "datePublished": "2010-07-03", 
         "pageEnd": "140", 
         "pageStart": "69", 
         "issueNumber": "9735"
@@ -99,10 +96,7 @@ JSON:
       {
         "@id": "issue9734", 
         "@type": "PublicationIssue", 
-        "datePublished": {
-          "@value": "2010-07-03", 
-          "@type": "http://www.w3.org/2001/XMLSchema#date"
-        }, 
+        "datePublished": "2010-07-03", 
         "pageEnd": "68", 
         "pageStart": "1", 
         "issueNumber": "9734"
@@ -531,10 +525,7 @@ JSON:
     {
       "@id": "#issue4",
       "@type": "PublicationIssue",
-      "datePublished": {
-        "@value": "2006-10",
-        "@type": "xsd:gYearMonth"
-      },
+      "datePublished": "2006-10",
       "issueNumber": "4"
     },
     {


### PR DESCRIPTION
The JSON-LD examples for ScholarlyArticle included unnecessary @value
clauses due to a naive conversion from the RDFa source. Remove them, so
instead of:

      "datePublished": {
        "@value": "2006-10",
        "@type": "xsd:gYearMonth"
      },

we'll have the much simpler, easier to publish and consume:

      "datePublished": "2006-10",

Fixes #904.

Signed-off-by: Dan Scott <dan@coffeecode.net>