### PR TITLE
Propose expanding range and domain of sponsor property.

### DIFF
--- a/data/schema.rdfa
+++ b/data/schema.rdfa
@@ -9284,10 +9284,16 @@ Note that Event uses startDate/endDate instead of startTime/endTime, even when d
     </div>
     <div typeof="rdf:Property" resource="http://schema.org/sponsor">
       <span class="h" property="rdfs:label">sponsor</span>
-      <span property="rdfs:comment">Sponsor of the study.</span>
+      <span property="rdfs:comment">A person or organization that supports a thing through a pledge, promise, or financial contribution. e.g. A sponsor of a Medical Study.</span>
       <span>Domain: <a property="http://schema.org/domainIncludes" href="http://schema.org/MedicalStudy">MedicalStudy</a></span>
+	  <span>Domain: <a property="http://schema.org/domainIncludes" href="http://schema.org/Person">Person</a></span> 
+	  <span>Domain: <a property="http://schema.org/domainIncludes" href="http://schema.org/Organization">Organization</a></span> 
+	  <span>Domain: <a property="http://schema.org/domainIncludes" href="http://schema.org/Event">Event</a></span> 
       <span>Range: <a property="http://schema.org/rangeIncludes" href="http://schema.org/Organization">Organization</a></span>
+	  <span>Range: <a property="http://schema.org/rangeIncludes" href="http://schema.org/Person">Person</a></span> 
     </div>
+
+	
     <div typeof="rdf:Property" resource="http://schema.org/sportsActivityLocation">
       <span class="h" property="rdfs:label">sportsActivityLocation</span>
       <span property="rdfs:comment">A sub property of location. The sports activity location where this action occurred.</span>
@@ -12646,15 +12652,6 @@ Typical unit code(s): C62 for persons </span>
   <span>Range: <a property="http://schema.org/rangeIncludes" href="http://schema.org/BlogPosting">BlogPosting</a></span>
 </div>
 
-<div typeof="rdf:property" resource="http://schema.org/sponsor">
-  <span class="h"  property="rdfs:label">sponsor</span>
-  <span property="rdfs:comment">A person or organization that supports a thing through a pledge, promise, or financial contribution.</span>
-  <span>Domain: <a property="http://schema.org/domainIncludes" href="http://schema.org/Person">Person</a></span> 
-  <span>Domain: <a property="http://schema.org/domainIncludes" href="http://schema.org/Organization">Organization</a></span> 
-  <span>Domain: <a property="http://schema.org/domainIncludes" href="http://schema.org/Event">Event</a></span> 
-  <span>Range: <a property="http://schema.org/rangeIncludes" href="http://schema.org/Person">Person</a></span> 
-  <span>Range: <a property="http://schema.org/rangeIncludes" href="http://schema.org/Organization">Organization</a></span> 
-</div>
 
 <h1>DataFeed</h1>
 

--- a/data/schema.rdfa
+++ b/data/schema.rdfa
@@ -12579,6 +12579,16 @@ Typical unit code(s): C62 for persons </span>
   <span>Range: <a property="http://schema.org/rangeIncludes" href="http://schema.org/BlogPosting">BlogPosting</a></span>
 </div>
 
+<div typeof="rdf:property" resource="http://schema.org/sponsor">
+	<span class="h"  property="rdfs:label">sponsor</span>
+	<span property="rdfs:comment">A person or organization that supports a thing through a pledge, promise, or financial contribution.</span>
+	<span>Domain: <a property="http://schema.org/domainIncludes" href="http://schema.org/Person">Person</a></span> 
+	<span>Domain: <a property="http://schema.org/domainIncludes" href="http://schema.org/Organization">Organization</a></span> 
+	<span>Domain: <a property="http://schema.org/domainIncludes" href="http://schema.org/Event">Event</a></span> 
+	<span>Range: <a property="http://schema.org/rangeIncludes" href="http://schema.org/Person">Person</a></span> 
+	<span>Range: <a property="http://schema.org/rangeIncludes" href="http://schema.org/Organization">Organization</a></span> 
+</div>
+
 <h1>DataFeed</h1>
 
 <div typeof="rdfs:Class" resource="http://schema.org/DataFeed">

--- a/data/schema.rdfa
+++ b/data/schema.rdfa
@@ -12580,13 +12580,13 @@ Typical unit code(s): C62 for persons </span>
 </div>
 
 <div typeof="rdf:property" resource="http://schema.org/sponsor">
-	<span class="h"  property="rdfs:label">sponsor</span>
-	<span property="rdfs:comment">A person or organization that supports a thing through a pledge, promise, or financial contribution.</span>
-	<span>Domain: <a property="http://schema.org/domainIncludes" href="http://schema.org/Person">Person</a></span> 
-	<span>Domain: <a property="http://schema.org/domainIncludes" href="http://schema.org/Organization">Organization</a></span> 
-	<span>Domain: <a property="http://schema.org/domainIncludes" href="http://schema.org/Event">Event</a></span> 
-	<span>Range: <a property="http://schema.org/rangeIncludes" href="http://schema.org/Person">Person</a></span> 
-	<span>Range: <a property="http://schema.org/rangeIncludes" href="http://schema.org/Organization">Organization</a></span> 
+  <span class="h"  property="rdfs:label">sponsor</span>
+  <span property="rdfs:comment">A person or organization that supports a thing through a pledge, promise, or financial contribution.</span>
+  <span>Domain: <a property="http://schema.org/domainIncludes" href="http://schema.org/Person">Person</a></span> 
+  <span>Domain: <a property="http://schema.org/domainIncludes" href="http://schema.org/Organization">Organization</a></span> 
+  <span>Domain: <a property="http://schema.org/domainIncludes" href="http://schema.org/Event">Event</a></span> 
+  <span>Range: <a property="http://schema.org/rangeIncludes" href="http://schema.org/Person">Person</a></span> 
+  <span>Range: <a property="http://schema.org/rangeIncludes" href="http://schema.org/Organization">Organization</a></span> 
 </div>
 
 <h1>DataFeed</h1>

--- a/data/schema.rdfa
+++ b/data/schema.rdfa
@@ -9284,7 +9284,7 @@ Note that Event uses startDate/endDate instead of startTime/endTime, even when d
     </div>
     <div typeof="rdf:Property" resource="http://schema.org/sponsor">
       <span class="h" property="rdfs:label">sponsor</span>
-      <span property="rdfs:comment">A person or organization that supports a thing through a pledge, promise, or financial contribution. e.g. A sponsor of a Medical Study.</span>
+      <span property="rdfs:comment">A person or organization that supports a thing through a pledge, promise, or financial contribution. e.g. A sponsor of a Medical Study or a corporate sponsor of an event.</span>
       <span>Domain: <a property="http://schema.org/domainIncludes" href="http://schema.org/MedicalStudy">MedicalStudy</a></span>
 	  <span>Domain: <a property="http://schema.org/domainIncludes" href="http://schema.org/Person">Person</a></span> 
 	  <span>Domain: <a property="http://schema.org/domainIncludes" href="http://schema.org/Organization">Organization</a></span> 

--- a/data/sdo-sponsor-examples.txt
+++ b/data/sdo-sponsor-examples.txt
@@ -1,7 +1,5 @@
 TYPES: #sponsor-1 Event
 
-An Event with tiered pricing and a corprate sponsor.
-
 PRE-MARKUP:
 
 <div class="event-wrapper">
@@ -174,8 +172,6 @@ JSON-LD:
 
 TYPES: #sponsor-2 Person
 
-A person sponsored by an organization.
-
 PRE-MARKUP:
 <p>Christopher Froome was sponsored by Sky in the Tour de France.</p>
 
@@ -212,8 +208,6 @@ JSON-LD:
 </script>
 
 TYPES: #sponsor-3 Person
-
-One person sponsored by another person.
 
 PRE-MARKUP:
 <p>Rose Tyler was sponsored by Sarah Jane Smith in the membership process.</p>
@@ -252,8 +246,6 @@ JSON-LD:
 </script>
 
 TYPES: #sponsor-4 Organization
-
-One organization sponsored by another.
 
 PRE-MARKUP:
 <p>

--- a/data/sdo-sponsor-examples.txt
+++ b/data/sdo-sponsor-examples.txt
@@ -1,0 +1,223 @@
+TYPES: #sponsor-1 Event
+
+An Event with tiered pricing and a corprate sponsor.
+
+PRE-MARKUP:
+
+<div class="event-wrapper">
+	<h1>The 2016 Missoula Marathon</h1>
+	<p>The 2016 <a href="http://www.missoulamarathon.org/events/marathon/">Missoula Marathon</a> is sponsored by <a href="http://www.runwildmissoula.org/">Run Wild Missoula</a>.</p>
+	<div class="event-date">Date/Time:  Sunday, July 10th, 2016, 6:00am</div>
+	<div class="event-fees">
+		<p>Cost:</p>
+		<ul>
+			<li>Oct 1, 2015 – Jan 31, 2016 – $85</li>
+			<li>Feb 1, 2016 – June 14, 2016 – $95</li>
+			<li>Jun 15, 2016 – July 9, 2016 – $125</li>
+		</ul>
+	</div>
+	<div class="description">
+		<p>The Missoula Marathon course is flat, fast, USATF certified, and a Boston Qualifier! The marathon course does have a significant hill at the halfway point. The course is a point-to-point, beginning with a scenic route through the countryside and finishing in historic downtown Missoula. The marathon course is well marked with both cones and arrows on the road. You will notice every mile is marked on the road and with 8ft tall mile markers.</p>
+		<p>Wheelchair and Handcycle: We are pleased to offer wheelchair and handcycle divisions in the 2016 Full and Half Marathon.</p>
+	</div>
+	<div class="location">
+		<h2><a href="http://www.ci.missoula.mt.us/">About Missoula, MT</a></h2>
+		<h2><a href="http://www.missoulamarathon.org/wp-content/uploads/2015/06/2015-MM-Course-Map-V1-6-2-15.png">View Course Map</a></h2>
+	</div>
+</div>
+
+MICRODATA:
+
+<div class="event-wrapper" itemscope itemtype="http://schema.org/Event">
+	<h1 itemprop="name">The 2016 Missoula Marathon</h1>
+	<p>The 2016 <a itemprop="url" href="http://www.missoulamarathon.org/events/marathon/">Missoula Marathon</a> is sponsored by <span itemprop="sponsor" itemtype="http://schema.org/Organization"><a itemprop="url" href="http://www.runwildmissoula.org/"><span itemprop="name">Run Wild Missoula</span></a></span>.</p>
+	<div class="event-date" itemprop="startDate" content="2016-07-10T06:00">Date/Time:  Sunday, July 10th, 2016, 6:00am</div>
+	<div class="event-fees">
+		<p>Cost:</p>
+		<ul>
+			<li itemprop="offers" itemscope itemtype="http://schema.org/Offer"><a itemprop="url" href="http://www.runwildmissoula.org/runwild/index.php/ID/mmar2016/fuseaction/register.main.htm"><span itemprop="validFrom" content="2015-10-01T00:01">Oct 1, 2015</span> – <span itemprop="validThrough" content="2016-01-31T23:59">Jan 31, 2016</span> – <span itemprop="price" content="85.00"><span itemprop="priceCurrency" content="USD">$85</span></span></a></li>
+			<li itemprop="offers" itemscope itemtype="http://schema.org/Offer"><a itemprop="url" href="http://www.runwildmissoula.org/runwild/index.php/ID/mmar2016/fuseaction/register.main.htm"><span itemprop="validFrom" content="2016-02-01T00:01">Feb 1, 2016</span> – <span itemprop="validThrough" content="2016-06-14T23:59">June 14, 2016</span> – <span itemprop="price" content="95.00"><span itemprop="priceCurrency" content="USD">$95</span></span></a></li>
+			<li itemprop="offers" itemscope itemtype="http://schema.org/Offer"><a itemprop="url" href="http://www.runwildmissoula.org/runwild/index.php/ID/mmar2016/fuseaction/register.main.htm"><span itemprop="validFrom" content="2016-06-15T00:01">Jun 15, 2016</span> – <span itemprop="validThrough" content="2016-07-09T23:59">July 9, 2016</span> – <span itemprop="price" content="125.00"><span itemprop="priceCurrency" content="USD">$125</span></span></a></li>
+		</ul>
+	</div>
+	<div class="description" itemprop="description">
+		<p>The Missoula Marathon course is flat, fast, USATF certified, and a Boston Qualifier! The marathon course does have a significant hill at the halfway point. The course is a point-to-point, beginning with a scenic route through the countryside and finishing in historic downtown Missoula. The marathon course is well marked with both cones and arrows on the road. You will notice every mile is marked on the road and with 8ft tall mile markers.</p>
+		<p>Wheelchair and Handcycle: We are pleased to offer wheelchair and handcycle divisions in the 2016 Full and Half Marathon.</p>
+	</div>
+	<div class="location" itemprop="location" itemscope itemtype="http://schema.org/Place">
+		<h2 itemprop="address" itemscope itemtype="http://schema.org/PostalAddress"><a href="http://www.ci.missoula.mt.us/">About <span itemprop="addressLocality">Missoula</span>,  <span itemprop="addressRegion">MT</span></a></h2>
+		<h2><span itemprop="hasMap"><a itemprop="map" itemtype="https://schema.org/Map" href="http://www.missoulamarathon.org/wp-content/uploads/2015/06/2015-MM-Course-Map-V1-6-2-15.png">View Course Map</a></span></h2>
+	</div>
+</div>
+
+
+
+RDFA: 
+
+<div class="event-wrapper" vocab="http://schema.org/" typeof="Event">
+	<h1 property="name">The 2016 Missoula Marathon</h1>
+	<p>The 2016 <a property="url" href="http://www.missoulamarathon.org/events/marathon/">Missoula Marathon</a> is sponsored by <span property="sponsor" typeof="Organization"><a property="url" href="http://www.runwildmissoula.org/"><span property="name">Run Wild Missoula</span></a></span>.</p>
+	<div class="event-date" property="startDate" content="2016-07-10T06:00">Date/Time:  Sunday, July 10th, 2016, 6:00am</div>
+	<div class="event-fees">
+		<ul>
+			<li property="offers" typeof="http://schema.org/Offer"><a property="url" href="http://www.runwildmissoula.org/runwild/index.php/ID/mmar2016/fuseaction/register.main.htm"><span property="validFrom" content="2015-10-01T00:01">Oct 1, 2015</span> – <span property="validThrough" content="2016-01-31T23:59">Jan 31, 2016</span> – <span property="price" content="85.00"><span property="priceCurrency" content="USD">$85</span></span></a></li>
+			<li property="offers" typeof="http://schema.org/Offer"><a property="url" href="http://www.runwildmissoula.org/runwild/index.php/ID/mmar2016/fuseaction/register.main.htm"><span property="validFrom" content="2016-02-01T00:01">Feb 1, 2016</span> – <span property="validThrough" content="2016-06-14T23:59">June 14, 2016</span> – <span property="price" content="95.00"><span property="priceCurrency" content="USD">$95</span></span></a></li>
+			<li property="offers" typeof="http://schema.org/Offer"><a property="url" href="http://www.runwildmissoula.org/runwild/index.php/ID/mmar2016/fuseaction/register.main.htm"><span property="validFrom" content="2016-06-15T00:01">Jun 15, 2016</span> – <span property="validThrough" content="2016-07-09T23:59">July 9, 2016</span> – <span property="price" content="125.00"><span property="priceCurrency" content="USD">$125</span></span></a></li>
+		</ul>
+	</div>
+	<div class="description" property="description">
+		<p>The Missoula Marathon course is flat, fast, USATF certified, and a Boston Qualifier! The marathon course does have a significant hill at the halfway point. The course is a point-to-point, beginning with a scenic route through the countryside and finishing in historic downtown Missoula. The marathon course is well marked with both cones and arrows on the road. You will notice every mile is marked on the road and with 8ft tall mile markers.</p>
+		<p>Wheelchair and Handcycle: We are pleased to offer wheelchair and handcycle divisions in the 2016 Full and Half Marathon.</p>
+	</div>
+	<div class="location" property="location" typeof="http://schema.org/Place">
+		<a property="url" href="http://www.ci.missoula.mt.us/"><h2 property="address" typeof="http://schema.org/PostalAddress">About <span property="addressLocality">Missoula</span>,  <span property="addressRegion">MT</span></h2></a>
+		<h2><span property="hasMap"><a property="map" href="http://www.missoulamarathon.org/wp-content/uploads/2015/06/2015-MM-Course-Map-V1-6-2-15.png">View Course Map</a></span></h2>
+	</div>
+</div>
+
+JSON-LD: 
+
+<script type="application/ld+json">
+{
+  "@context": "http://schema.org/",
+  "@type": "Event",
+  "name": "The Missoula Marathon",
+  "sponsor": {
+	"@type": "Organization",
+	"name": "Run Wild Missoula",
+	"url": "http://www.runwildmissoula.org/"
+	},
+  "startDate": "2016-07-10T06:00",
+  "offers": [
+	{
+	 "@type": "Offer",
+	 "url": "http://www.runwildmissoula.org/runwild/index.php/ID/mmar2016/fuseaction/register.main.htm",
+	 "validFrom": "2015-10-01T00:01",
+	 "validThrough": "2016-01-31T23:59",
+	 "price": "85.00",
+	 "priceCurrency": "USD"
+	 },{
+	 "@type": "Offer",
+	 "url": "http://www.runwildmissoula.org/runwild/index.php/ID/mmar2016/fuseaction/register.main.htm",
+	 "validFrom": "2016-02-01T00:01",
+	 "validThrough": "2016-06-14T23:59",
+	 "price": "95.00",
+	 "priceCurrency": "USD"
+	 },{
+	 "@type": "Offer",
+	 "url": "http://www.runwildmissoula.org/runwild/index.php/ID/mmar2016/fuseaction/register.main.htm",
+	 "validFrom": "2016-06-15T00:01",
+	 "validThrough": "2016-07-09T23:59",
+	 "price": "125.00",
+	 "priceCurrency": "USD"
+	 }
+	],
+  "description": "The Missoula Marathon course is flat, fast, USATF certified, and a Boston Qualifier! The marathon course does have a significant hill at the halfway point. The course is a point-to-point, beginning with a scenic route through the countryside and finishing in historic downtown Missoula. The marathon course is well marked with both cones and arrows on the road. You will notice every mile is marked on the road and with 8ft tall mile markers. Wheelchair and Handcycle: We are pleased to offer wheelchair and handcycle divisions in the 2016 Full and Half Marathon.",
+  "location": {
+	"@type": "Place",
+	"name": "Missoula, MT",
+	"url": "http://www.ci.missoula.mt.us/",
+	"address": {
+		"@type": "PostalAddress",
+		"addressLocality": "Missoula",
+		"addressRegion": "MT"
+	},
+	"hasMap": "http://www.missoulamarathon.org/wp-content/uploads/2015/06/2015-MM-Course-Map-V1-6-2-15.png"
+	}
+}
+</script>
+
+TYPES: #sponsor-2 Person
+
+A person sponsored by an organization.
+
+PRE-MARKUP:
+<p>Christopher Froome was sponsored by Sky in the Tour de France.</p>
+
+MICRODATA:
+
+<p itemscope itemprop="Person" itemtype="http://schema.org/Person"><span itemprop="name">Christopher Froome</span> was sponsored by <span itemprop="sponsor" itemtype="http://schema.org/Organization"><a itemprop="url" href="http://www.skysports.com/">Sky</a></span> in the Tour de France.</p>
+
+RDFA:
+
+<p vocab="http://schema.org/" typeof="Person"><span property="name">Christopher Froome</span> was sponsored by <span property="sponsor" typeof="http://schema.org/Organization"><a property="url" href="http://www.skysports.com/">Sky</a></span> in the Tour de France.</p>
+
+JSON-LD:
+
+<script type="application/ld+json">
+{
+    "@context": "http://schema.org/",
+    "@type": "Person",
+	"name": "Christopher Froome",
+	"sponsor": 
+		{
+		"@type": "Organization",
+		"name": "Sky",
+		"url": "http://www.skysports.com/"
+		}
+}
+</script>
+
+
+
+
+TYPES: #sponsor-3 Person
+
+One person sponsored by another person.
+
+PRE-MARKUP:
+<p>Rose Tyler was sponsored by Sarah Jane Smith in the membership process.</p>
+
+MICRODATA:
+
+<p itemscope itemprop="Person" itemtype="http://schema.org/Person"><span itemprop="name">Rose Tyler</span> was sponsored by <span itemscope itemprop="sponsor" itemtype="http://schema.org/Person"><span itemprop="name">Sarah Jane Smith</span></span> in the membership process.</p>
+
+RDFA:
+
+<p vocab="http://schema.org/" typeof="Person"><span property="name">Rose Tyler</span> was sponsored by <span property="sponsor" typeof="http://schema.org/Person"><span property="name">Sarah Jane Smith</span></span> in the membership process.</p>
+
+JSON-LD:
+
+<script type="application/ld+json">
+{
+    "@context": "http://schema.org/",
+    "@type": "Person",
+	"name": "Rose Tyler",
+	"sponsor": 
+		{
+		"@type": "Person",
+		"name": "Sarah Jane Smith"
+		}
+}
+</script>
+
+TYPES: #sponsor-4 Organization
+
+One organization sponsored by another.
+
+PRE-MARKUP:
+<p><a href="http://npr.org">National Public Radio</a> has a sponsor: <a href="http://www.example.com/GloboCorp">GloboCorp</a>.</p>
+
+MICRODATA:
+<p itemscope itemprop="organization" itemtype="http://schema.org/Organization"><a href="http://npr.org" itemprop="url"><span itemprop="name">National Public Radio</span></a> has a sponsor: <span itemprop="sponsor" itemscope itemtype="http://schema.org/Organization"><a itemprop="url" href="http://www.example.com/GloboCorp"><span itemprop="name">GloboCorp</span></a></span>.</p>
+
+RDFA:
+
+<p vocab="http://schema.org/" typeof="Organization"><a href="http://npr.org" property="url"><span property="name">National Public Radio</span></a> has a sponsor, <span property="sponsor" typeof="http://schema.org/Organization"><a property="url" href="http://www.example.com/GloboCorp"><span property="name">GloboCorp</span></a></span>.</p>
+
+JSON-LD:
+
+<script type="application/ld+json">
+{
+    "@context": "http://schema.org/",
+    "@type": "Organization",
+	"name": "National Public Radio",
+    "url": "http://npr.org",
+	"sponsor": 
+		{
+		"@type": "Organization",
+		"name": "GloboCorp",
+		"url": "http://www.example.com/"
+		}
+}
+</script>

--- a/data/sdo-sponsor-examples.txt
+++ b/data/sdo-sponsor-examples.txt
@@ -80,9 +80,28 @@ RDFA:
   <div class="event-date" property="startDate" content="2016-07-10T06:00">Date/Time:  Sunday, July 10th, 2016, 6:00am</div>
   <div class="event-fees">
     <ul>
-      <li property="offers" typeof="http://schema.org/Offer"><a property="url" href="http://www.runwildmissoula.org/runwild/index.php/ID/mmar2016/fuseaction/register.main.htm"><span property="validFrom" content="2015-10-01T00:01">Oct 1, 2015</span> – <span property="validThrough" content="2016-01-31T23:59">Jan 31, 2016</span> – <span property="price" content="85.00"><span property="priceCurrency" content="USD">$85</span></span></a></li>
-      <li property="offers" typeof="http://schema.org/Offer"><a property="url" href="http://www.runwildmissoula.org/runwild/index.php/ID/mmar2016/fuseaction/register.main.htm"><span property="validFrom" content="2016-02-01T00:01">Feb 1, 2016</span> – <span property="validThrough" content="2016-06-14T23:59">June 14, 2016</span> – <span property="price" content="95.00"><span property="priceCurrency" content="USD">$95</span></span></a></li>
-      <li property="offers" typeof="http://schema.org/Offer"><a property="url" href="http://www.runwildmissoula.org/runwild/index.php/ID/mmar2016/fuseaction/register.main.htm"><span property="validFrom" content="2016-06-15T00:01">Jun 15, 2016</span> – <span property="validThrough" content="2016-07-09T23:59">July 9, 2016</span> – <span property="price" content="125.00"><span property="priceCurrency" content="USD">$125</span></span></a></li>
+      <li property="offers" typeof="http://schema.org/Offer">
+        <a property="url" href="http://www.runwildmissoula.org/runwild/index.php/ID/mmar2016/fuseaction/register.main.htm">
+		<span property="validFrom" content="2015-10-01T00:01">Oct 1, 2015</span> – 
+		<span property="validThrough" content="2016-01-31T23:59">Jan 31, 2016</span> – 
+		<span property="price" content="85.00">
+		  <span property="priceCurrency" content="USD">$85</span>
+		</span></a>
+      </li>
+      <li property="offers" typeof="http://schema.org/Offer">
+	    <a property="url" href="http://www.runwildmissoula.org/runwild/index.php/ID/mmar2016/fuseaction/register.main.htm">
+		<span property="validFrom" content="2016-02-01T00:01">Feb 1, 2016</span> – 
+		<span property="validThrough" content="2016-06-14T23:59">June 14, 2016</span> – 
+		<span property="price" content="95.00">
+		  <span property="priceCurrency" content="USD">$95</span>
+		</span></a>
+      </li>
+      <li property="offers" typeof="http://schema.org/Offer">
+        <a property="url" href="http://www.runwildmissoula.org/runwild/index.php/ID/mmar2016/fuseaction/register.main.htm">
+        <span property="validFrom" content="2016-06-15T00:01">Jun 15, 2016</span> – 
+        <span property="validThrough" content="2016-07-09T23:59">July 9, 2016</span> – 
+        <span property="price" content="125.00"><span property="priceCurrency" content="USD">$125</span></span></a>
+      </li>
     </ul>
   </div>
   <div class="description" property="description">
@@ -90,8 +109,16 @@ RDFA:
     <p>Wheelchair and Handcycle: We are pleased to offer wheelchair and handcycle divisions in the 2016 Full and Half Marathon.</p>
   </div>
   <div class="location" property="location" typeof="http://schema.org/Place">
-    <a property="url" href="http://www.ci.missoula.mt.us/"><h2 property="address" typeof="http://schema.org/PostalAddress">About <span property="addressLocality">Missoula</span>,  <span property="addressRegion">MT</span></h2></a>
-    <h2><span property="hasMap"><a property="map" href="http://www.missoulamarathon.org/wp-content/uploads/2015/06/2015-MM-Course-Map-V1-6-2-15.png">View Course Map</a></span></h2>
+    <a property="url" href="http://www.ci.missoula.mt.us/">
+	  <h2 property="address" typeof="http://schema.org/PostalAddress">About 
+	  <span property="addressLocality">Missoula</span>, <span property="addressRegion">MT</span>
+	</h2>
+	</a>
+    <h2>
+	  <span property="hasMap">
+	  <a property="map" href="http://www.missoulamarathon.org/wp-content/uploads/2015/06/2015-MM-Course-Map-V1-6-2-15.png">View Course Map</a>
+	  </span>
+    </h2>
   </div>
 </div>
 

--- a/data/sdo-sponsor-examples.txt
+++ b/data/sdo-sponsor-examples.txt
@@ -5,49 +5,69 @@ An Event with tiered pricing and a corprate sponsor.
 PRE-MARKUP:
 
 <div class="event-wrapper">
-	<h1>The 2016 Missoula Marathon</h1>
-	<p>The 2016 <a href="http://www.missoulamarathon.org/events/marathon/">Missoula Marathon</a> is sponsored by <a href="http://www.runwildmissoula.org/">Run Wild Missoula</a>.</p>
-	<div class="event-date">Date/Time:  Sunday, July 10th, 2016, 6:00am</div>
-	<div class="event-fees">
-		<p>Cost:</p>
-		<ul>
-			<li>Oct 1, 2015 – Jan 31, 2016 – $85</li>
-			<li>Feb 1, 2016 – June 14, 2016 – $95</li>
-			<li>Jun 15, 2016 – July 9, 2016 – $125</li>
-		</ul>
-	</div>
-	<div class="description">
-		<p>The Missoula Marathon course is flat, fast, USATF certified, and a Boston Qualifier! The marathon course does have a significant hill at the halfway point. The course is a point-to-point, beginning with a scenic route through the countryside and finishing in historic downtown Missoula. The marathon course is well marked with both cones and arrows on the road. You will notice every mile is marked on the road and with 8ft tall mile markers.</p>
-		<p>Wheelchair and Handcycle: We are pleased to offer wheelchair and handcycle divisions in the 2016 Full and Half Marathon.</p>
-	</div>
-	<div class="location">
-		<h2><a href="http://www.ci.missoula.mt.us/">About Missoula, MT</a></h2>
-		<h2><a href="http://www.missoulamarathon.org/wp-content/uploads/2015/06/2015-MM-Course-Map-V1-6-2-15.png">View Course Map</a></h2>
-	</div>
+  <h1>The 2016 Missoula Marathon</h1>
+  <p>The 2016 <a href="http://www.missoulamarathon.org/events/marathon/">Missoula Marathon</a> is sponsored by <a href="http://www.runwildmissoula.org/">Run Wild Missoula</a>.</p>
+  <div class="event-date">Date/Time:  Sunday, July 10th, 2016, 6:00am</div>
+  <div class="event-fees">
+    <p>Cost:</p>
+    <ul>
+      <li>Oct 1, 2015 – Jan 31, 2016 – $85</li>
+      <li>Feb 1, 2016 – June 14, 2016 – $95</li>
+      <li>Jun 15, 2016 – July 9, 2016 – $125</li>
+    </ul>
+  </div>
+  <div class="description">
+    <p>The Missoula Marathon course is flat, fast, USATF certified, and a Boston Qualifier! The marathon course does have a significant hill at the halfway point. The course is a point-to-point, beginning with a scenic route through the countryside and finishing in historic downtown Missoula. The marathon course is well marked with both cones and arrows on the road. You will notice every mile is marked on the road and with 8ft tall mile markers.</p>
+    <p>Wheelchair and Handcycle: We are pleased to offer wheelchair and handcycle divisions in the 2016 Full and Half Marathon.</p>
+  </div>
+  <div class="location">
+    <h2><a href="http://www.ci.missoula.mt.us/">About Missoula, MT</a></h2>
+    <h2><a href="http://www.missoulamarathon.org/wp-content/uploads/2015/06/2015-MM-Course-Map-V1-6-2-15.png">View Course Map</a></h2>
+  </div>
 </div>
 
 MICRODATA:
 
 <div class="event-wrapper" itemscope itemtype="http://schema.org/Event">
-	<h1 itemprop="name">The 2016 Missoula Marathon</h1>
-	<p>The 2016 <a itemprop="url" href="http://www.missoulamarathon.org/events/marathon/">Missoula Marathon</a> is sponsored by <span itemprop="sponsor" itemtype="http://schema.org/Organization"><a itemprop="url" href="http://www.runwildmissoula.org/"><span itemprop="name">Run Wild Missoula</span></a></span>.</p>
-	<div class="event-date" itemprop="startDate" content="2016-07-10T06:00">Date/Time:  Sunday, July 10th, 2016, 6:00am</div>
-	<div class="event-fees">
-		<p>Cost:</p>
-		<ul>
-			<li itemprop="offers" itemscope itemtype="http://schema.org/Offer"><a itemprop="url" href="http://www.runwildmissoula.org/runwild/index.php/ID/mmar2016/fuseaction/register.main.htm"><span itemprop="validFrom" content="2015-10-01T00:01">Oct 1, 2015</span> – <span itemprop="validThrough" content="2016-01-31T23:59">Jan 31, 2016</span> – <span itemprop="price" content="85.00"><span itemprop="priceCurrency" content="USD">$85</span></span></a></li>
-			<li itemprop="offers" itemscope itemtype="http://schema.org/Offer"><a itemprop="url" href="http://www.runwildmissoula.org/runwild/index.php/ID/mmar2016/fuseaction/register.main.htm"><span itemprop="validFrom" content="2016-02-01T00:01">Feb 1, 2016</span> – <span itemprop="validThrough" content="2016-06-14T23:59">June 14, 2016</span> – <span itemprop="price" content="95.00"><span itemprop="priceCurrency" content="USD">$95</span></span></a></li>
-			<li itemprop="offers" itemscope itemtype="http://schema.org/Offer"><a itemprop="url" href="http://www.runwildmissoula.org/runwild/index.php/ID/mmar2016/fuseaction/register.main.htm"><span itemprop="validFrom" content="2016-06-15T00:01">Jun 15, 2016</span> – <span itemprop="validThrough" content="2016-07-09T23:59">July 9, 2016</span> – <span itemprop="price" content="125.00"><span itemprop="priceCurrency" content="USD">$125</span></span></a></li>
-		</ul>
-	</div>
-	<div class="description" itemprop="description">
-		<p>The Missoula Marathon course is flat, fast, USATF certified, and a Boston Qualifier! The marathon course does have a significant hill at the halfway point. The course is a point-to-point, beginning with a scenic route through the countryside and finishing in historic downtown Missoula. The marathon course is well marked with both cones and arrows on the road. You will notice every mile is marked on the road and with 8ft tall mile markers.</p>
-		<p>Wheelchair and Handcycle: We are pleased to offer wheelchair and handcycle divisions in the 2016 Full and Half Marathon.</p>
-	</div>
-	<div class="location" itemprop="location" itemscope itemtype="http://schema.org/Place">
-		<h2 itemprop="address" itemscope itemtype="http://schema.org/PostalAddress"><a href="http://www.ci.missoula.mt.us/">About <span itemprop="addressLocality">Missoula</span>,  <span itemprop="addressRegion">MT</span></a></h2>
-		<h2><span itemprop="hasMap"><a itemprop="map" itemtype="https://schema.org/Map" href="http://www.missoulamarathon.org/wp-content/uploads/2015/06/2015-MM-Course-Map-V1-6-2-15.png">View Course Map</a></span></h2>
-	</div>
+  <h1 itemprop="name">The 2016 Missoula Marathon</h1>
+  <p>The 2016 <a itemprop="url" href="http://www.missoulamarathon.org/events/marathon/">Missoula Marathon</a> is sponsored by 
+    <span itemprop="sponsor" itemtype="http://schema.org/Organization"><a itemprop="url" href="http://www.runwildmissoula.org/">
+    <span itemprop="name">Run Wild Missoula</span></a></span>.</p>
+  <div class="event-date" itemprop="startDate" content="2016-07-10T06:00">Date/Time:  Sunday, July 10th, 2016, 6:00am</div>
+  <div class="event-fees">
+    <p>Cost:</p>
+      <ul>
+        <li itemprop="offers" itemscope itemtype="http://schema.org/Offer">
+		  <a itemprop="url" href="http://www.runwildmissoula.org/runwild/index.php/ID/mmar2016/fuseaction/register.main.htm">
+		  <span itemprop="validFrom" content="2015-10-01T00:01">Oct 1, 2015</span> – 
+		  <span itemprop="validThrough" content="2016-01-31T23:59">Jan 31, 2016</span> – 
+		  <span itemprop="price" content="85.00"><span itemprop="priceCurrency" content="USD">$85</span></span></a>
+		</li>
+        <li itemprop="offers" itemscope itemtype="http://schema.org/Offer">
+		  <a itemprop="url" href="http://www.runwildmissoula.org/runwild/index.php/ID/mmar2016/fuseaction/register.main.htm">
+		  <span itemprop="validFrom" content="2016-02-01T00:01">Feb 1, 2016</span> – 
+		  <span itemprop="validThrough" content="2016-06-14T23:59">June 14, 2016</span> – 
+		  <span itemprop="price" content="95.00"><span itemprop="priceCurrency" content="USD">$95</span></span></a>
+		</li>
+        <li itemprop="offers" itemscope itemtype="http://schema.org/Offer">
+		  <a itemprop="url" href="http://www.runwildmissoula.org/runwild/index.php/ID/mmar2016/fuseaction/register.main.htm">
+		  <span itemprop="validFrom" content="2016-06-15T00:01">Jun 15, 2016</span> – 
+		  <span itemprop="validThrough" content="2016-07-09T23:59">July 9, 2016</span> – 
+		  <span itemprop="price" content="125.00"><span itemprop="priceCurrency" content="USD">$125</span></span></a>
+		</li>
+      </ul>
+  </div>
+  <div class="description" itemprop="description">
+    <p>The Missoula Marathon course is flat, fast, USATF certified, and a Boston Qualifier! The marathon course does have a significant hill at the halfway point. The course is a point-to-point, beginning with a scenic route through the countryside and finishing in historic downtown Missoula. The marathon course is well marked with both cones and arrows on the road. You will notice every mile is marked on the road and with 8ft tall mile markers.</p>
+    <p>Wheelchair and Handcycle: We are pleased to offer wheelchair and handcycle divisions in the 2016 Full and Half Marathon.</p>
+  </div>
+  <div class="location" itemprop="location" itemscope itemtype="http://schema.org/Place">
+    <h2 itemprop="address" itemscope itemtype="http://schema.org/PostalAddress">
+	  <a href="http://www.ci.missoula.mt.us/">About <span itemprop="addressLocality">Missoula</span>,  <span itemprop="addressRegion">MT</span></a>
+	</h2>
+    <h2 itemprop="hasMap"><a itemprop="map" itemtype="https://schema.org/Map" href="http://www.missoulamarathon.org/wp-content/uploads/2015/06/2015-MM-Course-Map-V1-6-2-15.png">View Course Map</a>
+	</h2>
+  </div>
 </div>
 
 
@@ -55,24 +75,24 @@ MICRODATA:
 RDFA: 
 
 <div class="event-wrapper" vocab="http://schema.org/" typeof="Event">
-	<h1 property="name">The 2016 Missoula Marathon</h1>
-	<p>The 2016 <a property="url" href="http://www.missoulamarathon.org/events/marathon/">Missoula Marathon</a> is sponsored by <span property="sponsor" typeof="Organization"><a property="url" href="http://www.runwildmissoula.org/"><span property="name">Run Wild Missoula</span></a></span>.</p>
-	<div class="event-date" property="startDate" content="2016-07-10T06:00">Date/Time:  Sunday, July 10th, 2016, 6:00am</div>
-	<div class="event-fees">
-		<ul>
-			<li property="offers" typeof="http://schema.org/Offer"><a property="url" href="http://www.runwildmissoula.org/runwild/index.php/ID/mmar2016/fuseaction/register.main.htm"><span property="validFrom" content="2015-10-01T00:01">Oct 1, 2015</span> – <span property="validThrough" content="2016-01-31T23:59">Jan 31, 2016</span> – <span property="price" content="85.00"><span property="priceCurrency" content="USD">$85</span></span></a></li>
-			<li property="offers" typeof="http://schema.org/Offer"><a property="url" href="http://www.runwildmissoula.org/runwild/index.php/ID/mmar2016/fuseaction/register.main.htm"><span property="validFrom" content="2016-02-01T00:01">Feb 1, 2016</span> – <span property="validThrough" content="2016-06-14T23:59">June 14, 2016</span> – <span property="price" content="95.00"><span property="priceCurrency" content="USD">$95</span></span></a></li>
-			<li property="offers" typeof="http://schema.org/Offer"><a property="url" href="http://www.runwildmissoula.org/runwild/index.php/ID/mmar2016/fuseaction/register.main.htm"><span property="validFrom" content="2016-06-15T00:01">Jun 15, 2016</span> – <span property="validThrough" content="2016-07-09T23:59">July 9, 2016</span> – <span property="price" content="125.00"><span property="priceCurrency" content="USD">$125</span></span></a></li>
-		</ul>
-	</div>
-	<div class="description" property="description">
-		<p>The Missoula Marathon course is flat, fast, USATF certified, and a Boston Qualifier! The marathon course does have a significant hill at the halfway point. The course is a point-to-point, beginning with a scenic route through the countryside and finishing in historic downtown Missoula. The marathon course is well marked with both cones and arrows on the road. You will notice every mile is marked on the road and with 8ft tall mile markers.</p>
-		<p>Wheelchair and Handcycle: We are pleased to offer wheelchair and handcycle divisions in the 2016 Full and Half Marathon.</p>
-	</div>
-	<div class="location" property="location" typeof="http://schema.org/Place">
-		<a property="url" href="http://www.ci.missoula.mt.us/"><h2 property="address" typeof="http://schema.org/PostalAddress">About <span property="addressLocality">Missoula</span>,  <span property="addressRegion">MT</span></h2></a>
-		<h2><span property="hasMap"><a property="map" href="http://www.missoulamarathon.org/wp-content/uploads/2015/06/2015-MM-Course-Map-V1-6-2-15.png">View Course Map</a></span></h2>
-	</div>
+  <h1 property="name">The 2016 Missoula Marathon</h1>
+  <p>The 2016 <a property="url" href="http://www.missoulamarathon.org/events/marathon/">Missoula Marathon</a> is sponsored by <span property="sponsor" typeof="Organization"><a property="url" href="http://www.runwildmissoula.org/"><span property="name">Run Wild Missoula</span></a></span>.</p>
+  <div class="event-date" property="startDate" content="2016-07-10T06:00">Date/Time:  Sunday, July 10th, 2016, 6:00am</div>
+  <div class="event-fees">
+    <ul>
+      <li property="offers" typeof="http://schema.org/Offer"><a property="url" href="http://www.runwildmissoula.org/runwild/index.php/ID/mmar2016/fuseaction/register.main.htm"><span property="validFrom" content="2015-10-01T00:01">Oct 1, 2015</span> – <span property="validThrough" content="2016-01-31T23:59">Jan 31, 2016</span> – <span property="price" content="85.00"><span property="priceCurrency" content="USD">$85</span></span></a></li>
+      <li property="offers" typeof="http://schema.org/Offer"><a property="url" href="http://www.runwildmissoula.org/runwild/index.php/ID/mmar2016/fuseaction/register.main.htm"><span property="validFrom" content="2016-02-01T00:01">Feb 1, 2016</span> – <span property="validThrough" content="2016-06-14T23:59">June 14, 2016</span> – <span property="price" content="95.00"><span property="priceCurrency" content="USD">$95</span></span></a></li>
+      <li property="offers" typeof="http://schema.org/Offer"><a property="url" href="http://www.runwildmissoula.org/runwild/index.php/ID/mmar2016/fuseaction/register.main.htm"><span property="validFrom" content="2016-06-15T00:01">Jun 15, 2016</span> – <span property="validThrough" content="2016-07-09T23:59">July 9, 2016</span> – <span property="price" content="125.00"><span property="priceCurrency" content="USD">$125</span></span></a></li>
+    </ul>
+  </div>
+  <div class="description" property="description">
+    <p>The Missoula Marathon course is flat, fast, USATF certified, and a Boston Qualifier! The marathon course does have a significant hill at the halfway point. The course is a point-to-point, beginning with a scenic route through the countryside and finishing in historic downtown Missoula. The marathon course is well marked with both cones and arrows on the road. You will notice every mile is marked on the road and with 8ft tall mile markers.</p>
+    <p>Wheelchair and Handcycle: We are pleased to offer wheelchair and handcycle divisions in the 2016 Full and Half Marathon.</p>
+  </div>
+  <div class="location" property="location" typeof="http://schema.org/Place">
+    <a property="url" href="http://www.ci.missoula.mt.us/"><h2 property="address" typeof="http://schema.org/PostalAddress">About <span property="addressLocality">Missoula</span>,  <span property="addressRegion">MT</span></h2></a>
+    <h2><span property="hasMap"><a property="map" href="http://www.missoulamarathon.org/wp-content/uploads/2015/06/2015-MM-Course-Map-V1-6-2-15.png">View Course Map</a></span></h2>
+  </div>
 </div>
 
 JSON-LD: 
@@ -83,47 +103,47 @@ JSON-LD:
   "@type": "Event",
   "name": "The Missoula Marathon",
   "sponsor": {
-	"@type": "Organization",
-	"name": "Run Wild Missoula",
-	"url": "http://www.runwildmissoula.org/"
+    "@type": "Organization",
+    "name": "Run Wild Missoula",
+    "url": "http://www.runwildmissoula.org/"
 	},
   "startDate": "2016-07-10T06:00",
   "offers": [
-	{
-	 "@type": "Offer",
-	 "url": "http://www.runwildmissoula.org/runwild/index.php/ID/mmar2016/fuseaction/register.main.htm",
-	 "validFrom": "2015-10-01T00:01",
-	 "validThrough": "2016-01-31T23:59",
-	 "price": "85.00",
-	 "priceCurrency": "USD"
-	 },{
-	 "@type": "Offer",
-	 "url": "http://www.runwildmissoula.org/runwild/index.php/ID/mmar2016/fuseaction/register.main.htm",
-	 "validFrom": "2016-02-01T00:01",
-	 "validThrough": "2016-06-14T23:59",
-	 "price": "95.00",
-	 "priceCurrency": "USD"
-	 },{
-	 "@type": "Offer",
-	 "url": "http://www.runwildmissoula.org/runwild/index.php/ID/mmar2016/fuseaction/register.main.htm",
-	 "validFrom": "2016-06-15T00:01",
-	 "validThrough": "2016-07-09T23:59",
-	 "price": "125.00",
-	 "priceCurrency": "USD"
-	 }
-	],
+    {
+      "@type": "Offer",
+      "url": "http://www.runwildmissoula.org/runwild/index.php/ID/mmar2016/fuseaction/register.main.htm",
+      "validFrom": "2015-10-01T00:01",
+      "validThrough": "2016-01-31T23:59",
+      "price": "85.00",
+      "priceCurrency": "USD"
+    },{
+      "@type": "Offer",
+      "url": "http://www.runwildmissoula.org/runwild/index.php/ID/mmar2016/fuseaction/register.main.htm",
+      "validFrom": "2016-02-01T00:01",
+      "validThrough": "2016-06-14T23:59",
+      "price": "95.00",
+      "priceCurrency": "USD"
+    },{
+      "@type": "Offer",
+      "url": "http://www.runwildmissoula.org/runwild/index.php/ID/mmar2016/fuseaction/register.main.htm",
+      "validFrom": "2016-06-15T00:01",
+      "validThrough": "2016-07-09T23:59",
+      "price": "125.00",
+      "priceCurrency": "USD"
+    }
+    ],
   "description": "The Missoula Marathon course is flat, fast, USATF certified, and a Boston Qualifier! The marathon course does have a significant hill at the halfway point. The course is a point-to-point, beginning with a scenic route through the countryside and finishing in historic downtown Missoula. The marathon course is well marked with both cones and arrows on the road. You will notice every mile is marked on the road and with 8ft tall mile markers. Wheelchair and Handcycle: We are pleased to offer wheelchair and handcycle divisions in the 2016 Full and Half Marathon.",
   "location": {
-	"@type": "Place",
-	"name": "Missoula, MT",
-	"url": "http://www.ci.missoula.mt.us/",
-	"address": {
-		"@type": "PostalAddress",
-		"addressLocality": "Missoula",
-		"addressRegion": "MT"
-	},
-	"hasMap": "http://www.missoulamarathon.org/wp-content/uploads/2015/06/2015-MM-Course-Map-V1-6-2-15.png"
-	}
+    "@type": "Place",
+    "name": "Missoula, MT",
+    "url": "http://www.ci.missoula.mt.us/",
+    "address": {
+      "@type": "PostalAddress",
+      "addressLocality": "Missoula",
+      "addressRegion": "MT"
+    },
+    "hasMap": "http://www.missoulamarathon.org/wp-content/uploads/2015/06/2015-MM-Course-Map-V1-6-2-15.png"
+    }
 }
 </script>
 
@@ -136,25 +156,33 @@ PRE-MARKUP:
 
 MICRODATA:
 
-<p itemscope itemprop="Person" itemtype="http://schema.org/Person"><span itemprop="name">Christopher Froome</span> was sponsored by <span itemprop="sponsor" itemtype="http://schema.org/Organization"><a itemprop="url" href="http://www.skysports.com/">Sky</a></span> in the Tour de France.</p>
+<p itemscope itemprop="Person" itemtype="http://schema.org/Person">
+  <span itemprop="name">Christopher Froome</span> was sponsored by 
+  <span itemprop="sponsor" itemtype="http://schema.org/Organization">
+    <a itemprop="url" href="http://www.skysports.com/">Sky</a></span> in the Tour de France.
+</p>
 
 RDFA:
 
-<p vocab="http://schema.org/" typeof="Person"><span property="name">Christopher Froome</span> was sponsored by <span property="sponsor" typeof="http://schema.org/Organization"><a property="url" href="http://www.skysports.com/">Sky</a></span> in the Tour de France.</p>
+<p vocab="http://schema.org/" typeof="Person">
+  <span property="name">Christopher Froome</span> was sponsored by 
+  <span property="sponsor" typeof="http://schema.org/Organization">
+    <a property="url" href="http://www.skysports.com/">Sky</a></span> in the Tour de France.
+</p>
 
 JSON-LD:
 
 <script type="application/ld+json">
 {
-    "@context": "http://schema.org/",
-    "@type": "Person",
-	"name": "Christopher Froome",
-	"sponsor": 
-		{
-		"@type": "Organization",
-		"name": "Sky",
-		"url": "http://www.skysports.com/"
-		}
+  "@context": "http://schema.org/",
+  "@type": "Person",
+  "name": "Christopher Froome",
+  "sponsor": 
+  {
+    "@type": "Organization",
+    "name": "Sky",
+    "url": "http://www.skysports.com/"
+  }
 }
 </script>
 
@@ -170,24 +198,34 @@ PRE-MARKUP:
 
 MICRODATA:
 
-<p itemscope itemprop="Person" itemtype="http://schema.org/Person"><span itemprop="name">Rose Tyler</span> was sponsored by <span itemscope itemprop="sponsor" itemtype="http://schema.org/Person"><span itemprop="name">Sarah Jane Smith</span></span> in the membership process.</p>
+<p itemscope itemprop="Person" itemtype="http://schema.org/Person">
+  <span itemprop="name">Rose Tyler</span> was sponsored by 
+  <span itemscope itemprop="sponsor" itemtype="http://schema.org/Person">
+    <span itemprop="name">Sarah Jane Smith</span>
+  </span> in the membership process.
+</p>
 
 RDFA:
 
-<p vocab="http://schema.org/" typeof="Person"><span property="name">Rose Tyler</span> was sponsored by <span property="sponsor" typeof="http://schema.org/Person"><span property="name">Sarah Jane Smith</span></span> in the membership process.</p>
+<p vocab="http://schema.org/" typeof="Person">
+  <span property="name">Rose Tyler</span> was sponsored by 
+  <span property="sponsor" typeof="http://schema.org/Person">
+    <span property="name">Sarah Jane Smith</span>
+  </span> in the membership process.
+</p>
 
 JSON-LD:
 
 <script type="application/ld+json">
 {
-    "@context": "http://schema.org/",
+  "@context": "http://schema.org/",
+  "@type": "Person",
+  "name": "Rose Tyler",
+  "sponsor": 
+    {
     "@type": "Person",
-	"name": "Rose Tyler",
-	"sponsor": 
-		{
-		"@type": "Person",
-		"name": "Sarah Jane Smith"
-		}
+    "name": "Sarah Jane Smith"
+    }
 }
 </script>
 
@@ -196,28 +234,45 @@ TYPES: #sponsor-4 Organization
 One organization sponsored by another.
 
 PRE-MARKUP:
-<p><a href="http://npr.org">National Public Radio</a> has a sponsor: <a href="http://www.example.com/GloboCorp">GloboCorp</a>.</p>
+<p>
+  <a href="http://npr.org">National Public Radio</a> has a sponsor: 
+  <a href="http://www.example.com/GloboCorp">GloboCorp</a>.
+</p>
 
 MICRODATA:
-<p itemscope itemprop="organization" itemtype="http://schema.org/Organization"><a href="http://npr.org" itemprop="url"><span itemprop="name">National Public Radio</span></a> has a sponsor: <span itemprop="sponsor" itemscope itemtype="http://schema.org/Organization"><a itemprop="url" href="http://www.example.com/GloboCorp"><span itemprop="name">GloboCorp</span></a></span>.</p>
+<p itemscope itemprop="organization" itemtype="http://schema.org/Organization">
+  <a href="http://npr.org" itemprop="url">
+    <span itemprop="name">National Public Radio</span></a> has a sponsor: 
+	<span itemprop="sponsor" itemscope itemtype="http://schema.org/Organization">
+	  <a itemprop="url" href="http://www.example.com/GloboCorp">
+	  <span itemprop="name">GloboCorp</span></a>
+	</span>.
+</p>
 
 RDFA:
 
-<p vocab="http://schema.org/" typeof="Organization"><a href="http://npr.org" property="url"><span property="name">National Public Radio</span></a> has a sponsor, <span property="sponsor" typeof="http://schema.org/Organization"><a property="url" href="http://www.example.com/GloboCorp"><span property="name">GloboCorp</span></a></span>.</p>
+<p vocab="http://schema.org/" typeof="Organization">
+  <a href="http://npr.org" property="url">
+  <span property="name">National Public Radio</span></a> has a sponsor, 
+  <span property="sponsor" typeof="http://schema.org/Organization">
+    <a property="url" href="http://www.example.com/GloboCorp">
+    <span property="name">GloboCorp</span></a>
+  </span>.
+</p>
 
 JSON-LD:
 
 <script type="application/ld+json">
 {
-    "@context": "http://schema.org/",
+  "@context": "http://schema.org/",
+  "@type": "Organization",
+  "name": "National Public Radio",
+  "url": "http://npr.org",
+  "sponsor": 
+  {
     "@type": "Organization",
-	"name": "National Public Radio",
-    "url": "http://npr.org",
-	"sponsor": 
-		{
-		"@type": "Organization",
-		"name": "GloboCorp",
-		"url": "http://www.example.com/"
-		}
+    "name": "GloboCorp",
+    "url": "http://www.example.com/"
+  }
 }
 </script>

--- a/data/sdo-sponsor-examples.txt
+++ b/data/sdo-sponsor-examples.txt
@@ -70,8 +70,6 @@ MICRODATA:
   </div>
 </div>
 
-
-
 RDFA: 
 
 <div class="event-wrapper" vocab="http://schema.org/" typeof="Event">
@@ -212,9 +210,6 @@ JSON-LD:
   }
 }
 </script>
-
-
-
 
 TYPES: #sponsor-3 Person
 


### PR DESCRIPTION
Hi,

I'm proposing to expand the range and domain of [sponsor](https://schema.org/sponsor), currently described as "Sponsor of the study." where 'study specifically refers to a [MedicalStudy](http://schema.org/MedicalStudy). In my proposal, the expanded comment defining the property is:
"A person or organization that supports a thing through a pledge, promise, or financial contribution. e.g. A sponsor of a Medical Study or a corporate sponsor of an event."

I propose that the domain be expanded from [MedicalStudy](http://schema.org/MedicalStudy) to ALSO include: [Person](http://schema.org/Person), [Event](http://schema.org/Event), and [Organization](http://schema.org/Organization). 

I propose that the range be expanded to include [Person](http://schema.org/Person), adding to [Organization](http://schema.org/Organization), which is there now.

I've created some examples in Microdata, RDFa, and JSON-LD covering the following situations:

* an Event sponsored by an Organization
* a Person sponsored by an Organization
* a Person sponsored by a Person
* an Organization sponsored by an Organization

These examples are in the file "[sdo-sponsor-examples.txt](https://github.com/EricAxel/schemaorg/blob/e08db43576a873cc7b17bacc5793a3589a88b041/data/sdo-sponsor-examples.txt)."

I can imagine there may be other uses for sponsor (CreativeWork instances -- such as an [episode](https://schema.org/Episode) of a media program), but am putting this forth as a start.

Thanks,
--Eric