### PR TITLE
bug fixes for bib.schema.org/Chapter example

### DIFF
--- a/data/ext/bib/bsdo-chapter-examples.txt
+++ b/data/ext/bib/bsdo-chapter-examples.txt
@@ -27,7 +27,7 @@ MICRODATA:
 <div itemscope itemtype="http://schema.org/Chapter" >
   <h2 itemprop="name">Chapter 16: Gates AND JOBS</h2>
   <h3 itemprop="alternateName">When Orbits Intersect</h3>
-  <div>Pages: <span itemprop="startPage">171</span>-<span itemprop="endPage">179</span></div>
+  <div>Pages: <span itemprop="pageStart">171</span>-<span itemprop="pageEnd">179</span></div>
   <link itemprop="isPartOf" itemscope itemtype="http://schema.org/Book" itemid="http://www.worldcat.org/oclc/751835184" />
 </div>
 </div>
@@ -43,7 +43,7 @@ RDFA:
 <div typeof="Chapter" >
   <h2 property="name">Chapter 16: Gates AND JOBS</h2>
   <h3 property="alternateName">When Orbits Intersect</h3>
-  <div>Pages: <span property="startPage">171</span>-<span property="endPage">179</span></div>
+  <div>Pages: <span property="pageStart">171</span>-<span property="pageEnd">179</span></div>
   <span property="isPartOf" typeof="Book" resource="http://www.worldcat.org/oclc/751835184"></span>
 </div>
 </div>
@@ -54,7 +54,7 @@ JSON:
 {
   "@context": {
     "rdfa": "http://www.w3.org/ns/rdfa#",
-    "schema": "http://schema.org/",
+    "schema": "http://schema.org/"
   },
   "@graph": [
     {
@@ -74,12 +74,12 @@ JSON:
       "@id": "_:",
       "@type": "schema:Chapter",
       "schema:alternateName": "When Orbits Intersect",
-      "schema:endPage": "179",
+      "schema:pageEnd": "179",
       "schema:isPartOf": {
         "@id": "http://www.worldcat.org/oclc/751835184"
       },
       "schema:name": "Chapter 16: Gates AND JOBS",
-      "schema:startPage": "171"
+      "schema:pageStart": "171"
     }
   ]
 }


### PR DESCRIPTION
The JSON example wouldn't parse due to a stray comma, and all examples used startPage/endPage instead of the correct pageStart/pageEnd.