### PR TITLE
Seems like a typo

### DIFF
--- a/data/sdo-library-examples.txt
+++ b/data/sdo-library-examples.txt
@@ -48,7 +48,7 @@ MICRODATA:
 <h2>Opening hours</h2>
 
 <div itemprop="openingHoursSpecification" itemtype="http://schema.org/OpeningHoursSpecification">
-<link property="itemprop" href="http://purl.org/goodrelations/v1#Monday" />Monday: 
+<link itemprop="dayOfWeek" href="http://purl.org/goodrelations/v1#Monday" />Monday: 
 <time itemprop="opens" content="09:00:00"> 9:00 AM</time> - 
 <time itemprop="closes" content="17:00:00"> 5:00 PM</time></div>
 


### PR DESCRIPTION
https://schema.org/OpeningHoursSpecification shows wrong html attribute and property name for first Microdata example