### PR TITLE
Game description: removed link to (now closed) issue

### DIFF
--- a/data/schema.rdfa
+++ b/data/schema.rdfa
@@ -11286,7 +11286,7 @@ postponing for 1.6.
 </div>
 <div typeof="rdfs:Class" resource="http://schema.org/Game">
   <span class="h" property="rdfs:label">Game</span>
-  <span property="rdfs:comment">The Game type represents things which are games. These are typically rule-governed recreational activities, e.g. role-playing games in which players assume the role of characters in a fictional setting. See also &lt;a href="https://github.com/rvguha/schemaorg/issues/169"&gt;open issues list&lt;/a&gt;.</span>
+  <span property="rdfs:comment">The Game type represents things which are games. These are typically rule-governed recreational activities, e.g. role-playing games in which players assume the role of characters in a fictional setting.</span>
    <span>Subclass of: <a property="rdfs:subClassOf" href="http://schema.org/CreativeWork">CreativeWork</a></span>
 </div>
 


### PR DESCRIPTION
The description of http://schema.org/Game contains:

> See also [open issues list](https://github.com/rvguha/schemaorg/issues/169).

Given that the linked issue is now closed, and we have the "_Check for open issues._" link, I think this reference can be removed.