### PR TITLE
RDFa data model: remove duplicated 'recordedAt' definition in HTML comment

### DIFF
--- a/data/schema.rdfa
+++ b/data/schema.rdfa
@@ -11763,14 +11763,6 @@ postponing for 1.6.
 </div>
 -->
 
-<!--
-<div typeof="rdf:Property" resource="http://schema.org/recordedAt">
-  <span class="h" property="rdfs:label">recordedAt</span>
-  <span property="rdfs:comment">The event where the work was recorded. Used primarily with video, audio, and photography.</span>
-  <span>Domain: <a property="http://schema.org/domainIncludes" href="http://schema.org/CreativeWork">CreativeWork</a></span>
-  <span>Range: <a property="http://schema.org/rangeIncludes" href="http://schema.org/Event">Event</a></span>
-</div> -->
-
 <div typeof="rdf:Property" resource="http://schema.org/releasedEvent">
   <span class="h" property="rdfs:label">releasedEvent</span>
   <span property="rdfs:comment">The place and time the release was issued, expressed as a PublicationEvent.</span>


### PR DESCRIPTION
The RDFa data model file contains a definition of `recordedAt` in an HTML comment:

```
<!--
<div typeof="rdf:Property" resource="http://schema.org/recordedAt">
  <span class="h" property="rdfs:label">recordedAt</span>
  <span property="rdfs:comment">The event where the work was recorded. Used primarily with video, audio, and photography.</span>
  <span>Domain: <a property="http://schema.org/domainIncludes" href="http://schema.org/CreativeWork">CreativeWork</a></span>
  <span>Range: <a property="http://schema.org/rangeIncludes" href="http://schema.org/Event">Event</a></span>
</div> -->
```

And this is the current/real definition:

```
    <div typeof="rdf:Property" resource="http://schema.org/recordedAt">
      <span class="h" property="rdfs:label">recordedAt</span>
      <span property="rdfs:comment">The Event where the CreativeWork was recorded. The CreativeWork may capture all or part of the event.</span>
      <span>Domain: <a property="http://schema.org/domainIncludes" href="http://schema.org/CreativeWork">CreativeWork</a></span>
      <span>Range: <a property="http://schema.org/rangeIncludes" href="http://schema.org/Event">Event</a></span>
      <link property="http://schema.org/inverseOf" href="http://schema.org/recordedIn"/>
    </div>
```

As these are essentially the same (only difference in the second sentence of the description, i.e., no todo hidden here), I think the comment can be removed.