### PR TITLE
Add schema:PreOrderAction

### DIFF
--- a/data/schema.rdfa
+++ b/data/schema.rdfa
@@ -3250,7 +3250,13 @@
     <div typeof="rdfs:Class" resource="http://schema.org/OrderAction">
       <span class="h" property="rdfs:label">OrderAction</span>
       <span property="rdfs:comment">An agent orders an object/product/service to be delivered/sent.</span>
-       <span>Subclass of: <a property="rdfs:subClassOf" href="http://schema.org/TradeAction">TradeAction</a></span>
+      <span>Subclass of: <a property="rdfs:subClassOf" href="http://schema.org/TradeAction">TradeAction</a></span>
+    </div>
+
+    <div typeof="rdfs:Class" resource="http://schema.org/PreOrderAction">
+      <span class="h" property="rdfs:label">PreOrderAction</span>
+      <span property="rdfs:comment">An agent orders a (not yet released) object/product/service to be delivered/sent.</span>
+      <span>Subclass of: <a property="rdfs:subClassOf" href="http://schema.org/TradeAction">TradeAction</a></span>
     </div>
 
     <div typeof="rdfs:Class" resource="http://schema.org/PaintAction">
@@ -10608,7 +10614,6 @@ Typical unit code(s): C62 for persons.</span>
   <span>Domain: <a property="http://schema.org/domainIncludes" href="http://schema.org/NutritionInformation"> NutritionInformation</a></span>
   <span>Range: <a property="http://schema.org/rangeIncludes" href="http://schema.org/Mass"> Mass</a></span>
 </div>
->>>>>>> 2aa14f0de5c921638e687d6f1a3e11c41009f8db
 
 <h1>DataFeed</h1>
 


### PR DESCRIPTION
An order suggests that the thing being ordered is available. For legal reasons, this is different from a [pre-order](https://en.wikipedia.org/wiki/Pre-order), where the item is not yet available and no promise is made re: availability.

Hence a new `schema:PreOrderAction`.
