### PR TITLE
Issue #647: Add new classes for how-to/diy/instructionSet schema

### DIFF
--- a/data/schema.rdfa
+++ b/data/schema.rdfa
@@ -10603,5 +10603,104 @@ Typical unit code(s): C62 for persons.</span>
     <span>Source:  <a property="dc:source" href="http://www.w3.org/wiki/WebSchemas/SchemaDotOrgSources#source_GoodRelationsTerms">GoodRelationsProperty</a></span>
 </div>
 
+<h1>InstructionSet</h1>
+
+<p>(TODO) any reference?</p>
+
+<div typeof="rdfs:Class" resource="http://schema.org/InstructionSet">
+    <span class="h" property="rdfs:label">InstructionSet</span>
+    <span property="rdfs:comment">A set of instructions that teaches how to do something.</span>
+    <span>Subclass of: <a property="rdfs:subClassOf" href="http://schema.org/CreativeWork">CreativeWork</a></span>
+    <span>(TODO) any source?</span>
+</div>
+
+<div typeof="rdf:Property" resource="http://schema.org/estimatedCost">
+    <span class="h" property="rdfs:label">estimatedCost</span>
+    <span property="rdfs:comment">Estimated supply cost to complete the instructions.</span>
+    <span>Domain: <a property="http://schema.org/domainIncludes" href="http://schema.org/InstructionSet">InstructionSet</a></span>
+    <span>Range: <a property="http://schema.org/rangeIncludes" href="http://schema.org/Text">Text</a></span>
+    <span>Range: <a property="http://schema.org/rangeIncludes" href="http://schema.org/PriceSpecification">PriceSpecification</a></span>
+</div>
+
+<div typeof="rdf:Property" resource="http://schema.org/outcome">
+    <span class="h" property="rdfs:label">outcome</span>
+    <span property="rdfs:comment">Outcome from the instructions. For example, 20 cakes, a meal for 10 people</span>
+    <span>Domain: <a property="http://schema.org/domainIncludes" href="http://schema.org/InstructionSet">InstructionSet</a></span>
+    <span>Range: <a property="http://schema.org/rangeIncludes" href="http://schema.org/Text">Text</a></span>
+    <span>Range: <a property="http://schema.org/rangeIncludes" href="http://schema.org/QuantitativeValue">QuantitativeValue</a></span>
+</div>
+
+<div typeof="rdf:Property" resource="http://schema.org/instructions">
+    <span class="h" property="rdfs:label">instructions</span>
+    <span property="rdfs:comment">A list of instructions either in a single form (document, video, etc.) or an ordered list of InstructionStep items.</span>
+    <span>Domain: <a property="http://schema.org/domainIncludes" href="http://schema.org/InstructionSet">InstructionSet</a></span>
+    <span>Range: <a property="http://schema.org/rangeIncludes" href="http://schema.org/ItemList">ItemList</a></span>
+</div>
+
+<div typeof="rdf:Property" resource="http://schema.org/supplies">
+    <span class="h" property="rdfs:label">supplies</span>
+    <span property="rdfs:comment">A related list of supplies. The list should contain items of type InstructionSupply.</span>
+    <span>Domain: <a property="http://schema.org/domainIncludes" href="http://schema.org/InstructionSet">InstructionSet</a></span>
+    <span>Range: <a property="http://schema.org/rangeIncludes" href="http://schema.org/ItemList">ItemList</a></span>
+    <span>Range: <a property="http://schema.org/rangeIncludes" href="http://schema.org/Text">Text</a></span>
+</div>
+
+<h1>InstructionSupply</h1>
+
+<div typeof="rdfs:Class" resource="http://schema.org/InstructionSupply">
+    <span class="h" property="rdfs:label">InstructionSupply</span>
+    <span property="rdfs:comment">Supply item for an instruction set.</span>
+    <span>Subclass of: <a property="rdfs:subClassOf" href="http://schema.org/ListItem">ListItem</a></span>
+</div>
+
+<div typeof="rdf:Property" resource="http://schema.org/estimatedSupplyCost">
+    <span class="h" property="rdfs:label">estimatedSupplyCost</span>
+    <span property="rdfs:comment">Estimated cost of the supply item(s).</span>
+    <span>Domain: <a property="http://schema.org/domainIncludes" href="http://schema.org/InstructionSupply">InstructionSupply</a></span>
+    <span>Range: <a property="http://schema.org/rangeIncludes" href="http://schema.org/Text">Text</a></span>
+    <span>Range: <a property="http://schema.org/rangeIncludes" href="http://schema.org/PriceSpecification">PriceSpecification</a></span>
+</div>
+
+<div typeof="rdf:Property" resource="http://schema.org/requiredQuantity">
+    <span class="h" property="rdfs:label">requiredQuantity</span>
+    <span property="rdfs:comment">Required quantity of the item(s).</span>
+    <span>Domain: <a property="http://schema.org/domainIncludes" href="http://schema.org/InstructionSupply">InstructionSupply</a></span>
+    <span>Range: <a property="http://schema.org/rangeIncludes" href="http://schema.org/Text">Text</a></span>
+    <span>Range: <a property="http://schema.org/rangeIncludes" href="http://schema.org/Number">Number</a></span>
+    <span>Range: <a property="http://schema.org/rangeIncludes" href="http://schema.org/QuantitativeValue">QuantitativeValue</a></span>
+</div>
+
+<div typeof="rdf:Property" resource="http://schema.org/supplyItem">
+    <span class="h" property="rdfs:label">supplyItem</span>
+    <span property="rdfs:comment">Required. The supply item product.</span>
+    <span>Domain: <a property="http://schema.org/domainIncludes" href="http://schema.org/InstructionSupply">InstructionSupply</a></span>
+    <span>Range: <a property="http://schema.org/rangeIncludes" href="http://schema.org/Text">Text</a></span>
+    <span>Range: <a property="http://schema.org/rangeIncludes" href="http://schema.org/Product">Product</a></span>
+</div>
+
+<h1>InstructionStep</h1>
+
+<div typeof="rdfs:Class" resource="http://schema.org/InstructionStep">
+    <span class="h" property="rdfs:label">InstructionStep</span>
+    <span property="rdfs:comment">A step in a set of instructions.</span>
+    <span>Subclass of: <a property="rdfs:subClassOf" href="http://schema.org/ListItem">ListItem</a></span>
+</div>
+
+<div typeof="rdf:Property" resource="http://schema.org/instructionDetail">
+    <span class="h" property="rdfs:label">instructionDetail</span>
+    <span property="rdfs:comment">Estimated cost of the item(s).</span>
+    <span>Domain: <a property="http://schema.org/domainIncludes" href="http://schema.org/InstructionStep">InstructionStep</a></span>
+    <span>Range: <a property="http://schema.org/rangeIncludes" href="http://schema.org/Text">Text</a></span>
+    <span>Range: <a property="http://schema.org/rangeIncludes" href="http://schema.org/CreativeWork">CreativeWork</a></span>
+</div>
+
+<div typeof="rdf:Property" resource="http://schema.org/instructionSupplies">
+    <span class="h" property="rdfs:label">instructionSupplies</span>
+    <span property="rdfs:comment">A related list of supplies of this step. The list should contain items of type InstructionSupply.</span>
+    <span>Domain: <a property="http://schema.org/domainIncludes" href="http://schema.org/InstructionStep">InstructionStep</a></span>
+    <span>Range: <a property="http://schema.org/rangeIncludes" href="http://schema.org/ItemList">ItemList</a></span>
+    <span>Range: <a property="http://schema.org/rangeIncludes" href="http://schema.org/Text">Text</a></span>
+</div>
+
 </body>
 </html>

--- a/data/sdo-instructionset-examples.txt
+++ b/data/sdo-instructionset-examples.txt
@@ -1,0 +1,327 @@
+TYPES:  InstructionSet
+
+PRE-MARKUP:
+
+<div>
+  <span>How to Make Healthy and Crunchy Granola</span>
+  <p>Yummy and vegan-friendly granola.</p>
+  by <span>Beate Olav</span>
+  <h1>Step one</h1>
+  <div>
+    <img src="//d1alt1wkdk73qo.cloudfront.net/images/guide/344b3648d14541698ae60bebbb3104d3/640x960.jpg" width="640" height="960">
+    <p>Ingredients: porridge oats, flax seeds, pumpkin seeds, almonds, wholefood/eco-friendly maple sirup, ground cardamom</p>
+  </div>
+
+  <h1>Step two</h1>
+  <div>
+    <img src="//d1alt1wkdk73qo.cloudfront.net/images/guide/ce22ef0f89f64c62978d31e00fae27b1/640x960.jpg" width="640" height="960">
+    <p>Mix dry and wet Ingredients in a bowl</p>
+  </div>
+
+  <h1>Ingredients</h1>
+  <ul>
+    <li>1 Cup Porridge oats</li>
+    <li>½ Cups Pumpkin seeds</li>
+  </ul>
+</div>
+
+MICRODATA:
+
+<div itemscope itemtype="http://schema.org/InstructionSet">
+  <span itemprop="name">How to Make Healthy and Crunchy Granola</span>
+  <p itemprop="description">Yummy and vegan-friendly granola.</p>
+  by <span itemprop="author">Beate Olav</span>
+  <div itemprop="instructions" itemscope>
+    <h1>Step one</h1>
+    <div itemprop="itemListElement" itemscope itemtype="http://schema.org/InstructionStep">
+      <img itemprop="image" src="//d1alt1wkdk73qo.cloudfront.net/images/guide/344b3648d14541698ae60bebbb3104d3/640x960.jpg" width="640" height="960">
+      <p itemprop="description">Ingredients: porridge oats, flax seeds, pumpkin seeds, almonds, wholefood/eco-friendly maple sirup, ground cardamom</p>
+    </div>
+
+    <h1>Step two</h1>
+    <div itemprop="itemListElement" itemscope itemtype="http://schema.org/InstructionStep">
+      <img itemprop="image" src="//d1alt1wkdk73qo.cloudfront.net/images/guide/ce22ef0f89f64c62978d31e00fae27b1/640x960.jpg" width="640" height="960">
+      <p itemprop="description">Mix dry and wet Ingredients in a bowl</p>
+    </div>
+  </div>
+
+  <h1>Ingredients</h1>
+  <ul itemprop="supplies" itemscope>
+    <li itemprop="itemListElement" itemscope itemtype="http://schema.org/InstructionSupply">
+      <span itemprop="requiredQuantity">1 Cup</span>
+      <span itemprop="supplyItem">Porridge oats</span>
+    </li>
+    <li itemprop="itemListElement" itemscope itemtype="http://schema.org/InstructionSupply">
+      <span itemprop="requiredQuantity">½ Cups</span>
+      <span itemprop="supplyItem">Pumpkin seeds</span>
+    </li>
+  </ul>
+</div>
+
+RDFA:
+There's no RDFA example.
+
+JSON:
+
+<script type="application/ld+json">
+{
+  "@context": "http://schema.org",
+  "@type": "InstructionSet",
+  "name": "How to Make Healthy and Crunchy Granola",
+  "description": "Yummy and vegan-friendly granola.",
+  "author": "Beate Olav",
+  "instructions: {
+    "@type": "ItemList",
+    "itemListElement": [
+      {
+        "@type": "CreativeWork",
+        "image": "//d1alt1wkdk73qo.cloudfront.net/images/guide/344b3648d14541698ae60bebbb3104d3/640x960.jpg",
+        “description”: “Ingredients: porridge oats, flax seeds, pumpkin seeds, almonds, wholefood/eco-friendly maple sirup, ground cardamom”
+      },
+      {
+        "@type": "CreativeWork",
+        "image": "//d1alt1wkdk73qo.cloudfront.net/images/guide/ce22ef0f89f64c62978d31e00fae27b1/640x960.jpg",
+        “description”: “Mix dry and wet Ingredients in a bowl”
+      }
+    ]
+  },
+  "supplies: {
+    "@type": "ItemList",
+    "itemListElement": [
+      {
+        "@type": "InstructionSupply",
+        "amount": "1 Cup",
+        “product”: “Porridge oats”
+      },
+      {
+        "@type": "InstructionSupply",
+        "amount": "½ Cups",
+        “product”: “Pumpkin seeds”
+      }
+    ]
+  }
+}
+</script>
+
+TYPES:  InstructionSet
+
+PRE-MARKUP:
+
+<-- content comes from http://www.popsugar.com/smart-living/Cute-DIY-Tumblers-26123676 after simplyfing.  -->
+
+<div>
+    <span>DIY Colorful Hand-Dotted Tumblers</span>
+    <span>March 23, 2016 by SARAH LIPOFF</span>
+
+    <p>Gather your friends for a fun afternoon of crafting while making these colorful and unique hand-dotted tumblers. Along with being easy to create, the finished tumblers cost around $3 each to make. Pick up tumblers from your local resale shop or dollar store for a serious deal. Use enamel acrylic paints from your local craft store for longstanding color, and you're on your way to festive gifts for everyone.</p>
+
+    <h1>What You'll Need:</h1>
+    <ul>
+        <li>Red, yellow, blue, and white enamel acrylic paint</li>
+        <li>Glass tumblers</li>
+        <li>Paper towel</li>
+        <li>Cotton swabs</li>
+        <li>Sheet pan</li>
+        <li>Parchment paper</li>
+    </ul>
+
+    <h1>Directions:</h1>
+
+    <h2>Step one</h2>
+    <p>Gather the materials for creating the dotted tumblers. Use an enamel or all-surface acrylic for long-standing results. You can purchase small containers at your local craft store for around $1 a bottle.</p>
+    <img src="https://media1.popsugar-assets.com/files/2012/11/48/4/192/1922441/07cb4bf237978a1d_P1100992.preview.jpg" width="550" height="550">
+
+    <h2>Step two</h2>
+    <p>Fold a sheet of paper towel in half and then in half again. Squeeze out a small dollop of each color of paint and then mix together to create additional colors for your tumblers. You can create different tints of colors by adding white. Or experiment with mixing the primary colors to create greens, oranges, and purples. Place a length of parchment paper on a sheet pan, and then place the glasses upside-down on the pan.</p>
+    <img src="https://media1.popsugar-assets.com/files/2012/11/48/4/192/1922441/07cb4bf237978a1d_P1100992.preview.jpg" width="550" height="550">
+
+    <h2>Step three</h2>
+    <p>Press the end of a cotton swab in one color of paint, and dot around the base of the glass. Continue dotting with other colors to create a first layer of dots, and then let dry while working on the rest of the glasses.</p>
+    <img src="https://media2.popsugar-assets.com/files/2012/11/48/4/192/1922441/4eba36d899da0bab_P1100998.preview.jpg" width="550" height="550">
+</div>
+
+MICRODATA:
+
+<div itemscope itemtype="http://schema.org/InstructionSet">
+    <span itemprop="name">DIY Colorful Hand-Dotted Tumblers</span>
+    <span itemprop="dateCreated">March 23, 2016 </span>
+    <span itemprop="author">by SARAH LIPOFF</span>
+
+    <p itemprop="description">Gather your friends for a fun afternoon of crafting while making these colorful and unique hand-dotted tumblers. Along with being easy to create, the finished tumblers cost around $3 each to make. Pick up tumblers from your local resale shop or dollar store for a serious deal. Use enamel acrylic paints from your local craft store for longstanding color, and you're on your way to festive gifts for everyone.</p>
+
+    <h1>What You'll Need:</h1>
+    <ul itemprop="supplies" itemscope>
+        <li itemprop="itemListElement">Red, yellow, blue, and white enamel acrylic paint</li>
+        <li itemprop="itemListElement">Glass tumblers</li>
+        <li itemprop="itemListElement">Paper towel</li>
+        <li itemprop="itemListElement">Cotton swabs</li>
+        <li itemprop="itemListElement">Sheet pan</li>
+        <li itemprop="itemListElement">Parchment paper</li>
+    </ul>
+
+    <h1>Directions:</h1>
+
+    <div itemprop="instructions" itemscope>
+        <div itemprop="itemListElement" itemscope itemtype="http://schema.org/InstructionStep">
+            <h2>Step one</h2>
+            <p itemprop="description">Gather the materials for creating the dotted tumblers. Use an enamel or all-surface acrylic for long-standing results. You can purchase small containers at your local craft store for around $1 a bottle.</p>
+            <img itemprop="image" src="https://media1.popsugar-assets.com/files/2012/11/48/4/192/1922441/07cb4bf237978a1d_P1100992.preview.jpg" width="550" height="550">
+        </div>
+        <div itemprop="itemListElement" itemscope itemtype="http://schema.org/InstructionStep">
+            <h2>Step two</h2>
+            <p itemprop="description">Fold a sheet of paper towel in half and then in half again. Squeeze out a small dollop of each color of paint and then mix together to create additional colors for your tumblers. You can create different tints of colors by adding white. Or experiment with mixing the primary colors to create greens, oranges, and purples. Place a length of parchment paper on a sheet pan, and then place the glasses upside-down on the pan.</p>
+            <img itemprop="image" src="https://media1.popsugar-assets.com/files/2012/11/48/4/192/1922441/07cb4bf237978a1d_P1100992.preview.jpg" width="550" height="550">
+        </div>
+        <div itemprop="itemListElement" itemscope itemtype="http://schema.org/InstructionStep">
+            <h2>Step three</h2>
+            <p itemprop="description">Press the end of a cotton swab in one color of paint, and dot around the base of the glass. Continue dotting with other colors to create a first layer of dots, and then let dry while working on the rest of the glasses.</p>
+            <img itemprop="image" src="https://media2.popsugar-assets.com/files/2012/11/48/4/192/1922441/4eba36d899da0bab_P1100998.preview.jpg" width="550" height="550">
+        </div>
+    </div>
+</div>
+
+RDFA:
+There's no RDFA example.
+
+JSON:
+There's no JSON example.
+
+
+TYPES:  InstructionSet
+
+PRE-MARKUP:
+
+<-- Content comes from https://www.ifixit.com/Guide/iPhone+4S+Display+Assembly+Replacement/7277 with simplification -->
+
+<div>
+    <h1>iPhone 4S Display Assembly Replacement</h1>
+    <span>Replace a cracked front panel or a broken screen on your iPhone 4S.</span>
+    <span>Author: Walter Galan</span>
+    <span>Time estimate: 1 hour</span>
+    <span>Difficulty: Difficult</span>
+    <p>Use this guide to replace a cracked front panel or a broken LCD. After successfully replacing the broken screen, protect your new display from scratches by installing a screen protector.</p>
+
+    <div>
+        <h2>Tools</h2>
+        <ul>
+            <li><a href="http://www.ifixit.com/Store/Tools/P2-Pentalobe-Screwdriver-iPhone/IF145-096">P2 Pentalobe Screwdriver iPhone</a></li>
+            <li><a href="http://www.ifixit.com/Tools/SIM-Card-Eject-Tool/IF145-091-1">SIM Card Eject Tool</a></li>
+        </ul>
+    </div>
+
+    <div>
+        <h2>Relevant Parts</h2>
+        <ul>
+            <li>
+                <a href="http://www.ifixit.com/iPhone-Parts/iPhone-4S-Display-Assembly/IF115-000-3">iPhone 4S LCD Screen and Digitizer</a>
+                <span>Fix Kit / Black</span>
+                <em>This kit contains the part and all tools needed.</em>
+            </li>
+            <li>
+                <a href="http://www.ifixit.com/iPhone-Parts/iPhone-4S-Display-Assembly/IF115-000-4">iPhone 4S LCD Screen and Digitizer</a>
+                <span>Fix Kit / White</span>
+                <em>This kit contains the part and all tools needed.</em>
+            </li>
+        </ul>
+    </div>
+
+    <div>
+        <div>
+            <span><b>Step 1 — Rear Panel</b></span>
+            <img src="https://d3nevzfk7ii3be.cloudfront.net/igi/diXGGSBdV3Eqd21F.medium">
+            <p>Before disassembling your iPhone, be sure it is powered off.</p>
+            <p>Remove the two 3.6 mm Pentalobe P2 screws next to the dock connector.</p>
+            <p>The 5-Point Screwdriver should only be used once, as it has the potential to strip the screws.</p>
+        </div>
+        <div>
+            <span><b>Step 2</b></span>
+            <img src="https://d3nevzfk7ii3be.cloudfront.net/igi/GHnnnMrDFAXwZtaN.medium">
+            <img src="https://d3nevzfk7ii3be.cloudfront.net/igi/1SkPGIKGX2tPwBIB.medium">
+            <p>Push the rear panel toward the top edge of the iPhone.</p>
+            <p>The panel will move about 2 mm.</p>
+        </div>
+    </div>
+</div>
+
+MICRODATA:
+
+
+<div itemscope itemtype="http://schema.org/InstructionSet">
+    <h1 itemprop="name">iPhone 4S Display Assembly Replacement</h1>
+    <span itemprop="alternativeHeadline">Replace a cracked front panel or a broken screen on your iPhone 4S.</span>
+    <span itemprop="author">Author: Walter Galan</span>
+    <span itemprop="timeRequired">Time estimate: 1 hour</span>
+    <span>Difficulty: Difficult</span>
+    <p itemprop="description">Use this guide to replace a cracked front panel or a broken LCD. After successfully replacing the broken screen, protect your new display from scratches by installing a screen protector.</p>
+
+    <div itemprop="supplies" itemscope>
+        <h2>Tools</h2>
+        <ul>
+            <li itemprop="itemListElement" itemscope itemtype="http://schema.org/InstructionSupply">
+                <span itemprop="supplyItem" itemscope itemtype="http://schema.org/Product">
+                    <a itemprop="url" href="http://www.ifixit.com/Store/Tools/P2-Pentalobe-Screwdriver-iPhone/IF145-096">
+                        <span itemprop="name">P2 Pentalobe Screwdriver iPhone</span>
+                    </a>
+                </span>
+            </li>
+            <li itemprop="itemListElement" itemscope itemtype="http://schema.org/InstructionSupply">
+                <span itemprop="supplyItem" itemscope itemtype="http://schema.org/Product">
+                    <a href="http://www.ifixit.com/Tools/SIM-Card-Eject-Tool/IF145-091-1">
+                        <span itemprop="name">SIM Card Eject Tool</span>
+                    </a>
+                </span>
+            </li>
+        </ul>
+
+        <h2>Relevant Parts</h2>
+        <ul>
+            <li itemprop="itemListElement" itemscope itemtype="http://schema.org/InstructionSupply">
+                <span itemprop="supplyItem" itemscope itemtype="http://schema.org/Product">
+                    <span itemprop="name">
+                        <a itemprop="url" href="http://www.ifixit.com/iPhone-Parts/iPhone-4S-Display-Assembly/IF115-000-3">
+                            iPhone 4S LCD Screen and Digitizer
+                        </a>
+                        Fix Kit / Black
+                    </span>
+                </span>
+                <em itemprop="description">This kit contains the part and all tools needed.</em>
+            </li>
+            <li itemprop="itemListElement" itemscope itemtype="http://schema.org/InstructionSupply">
+                <span itemprop="supplyItem" itemscope itemtype="http://schema.org/Product">
+                    <span itemprop="name">
+                        <a href="http://www.ifixit.com/iPhone-Parts/iPhone-4S-Display-Assembly/IF115-000-4">iPhone 4S LCD Screen and Digitizer</a>
+                        Fix Kit / White</span>
+                    </span>
+                    <em itemprop="description">This kit contains the part and all tools needed.</em>
+                </span>
+            </li>
+        </ul>
+    </div>
+
+    <div itemprop="instructions" itemscope>
+        <div itemprop="itemListElement" itemscope itemtype="http://schema.org/InstructionStep">
+            <span><b>Step 1 — Rear Panel</b></span>
+            <img itemprop="image" src="https://d3nevzfk7ii3be.cloudfront.net/igi/diXGGSBdV3Eqd21F.medium">
+            <div itemprop="description">
+                <p>Before disassembling your iPhone, be sure it is powered off.</p>
+                <p>Remove the two 3.6 mm Pentalobe P2 screws next to the dock connector.</p>
+                <p>The 5-Point Screwdriver should only be used once, as it has the potential to strip the screws.</p>
+            </div>
+        </div>
+        <div>
+            <span><b>Step 2</b></span>
+            <img itemprop="image" src="https://d3nevzfk7ii3be.cloudfront.net/igi/GHnnnMrDFAXwZtaN.medium">
+            <img itemprop="image" src="https://d3nevzfk7ii3be.cloudfront.net/igi/1SkPGIKGX2tPwBIB.medium">
+            <div itemprop="description">
+                <p>Push the rear panel toward the top edge of the iPhone.</p>
+                <p>The panel will move about 2 mm.</p>
+            </div>
+        </div>
+    </div>
+</div>
+
+RDFA:
+There's no RDFA example.
+
+JSON:
+There's no JSON example.


### PR DESCRIPTION
Following the discussion in https://github.com/schemaorg/schemaorg/issues/647#issuecomment-204473427, this is a demonstration of the schema type that needed by diy/how-to type of contents. 

I only added one example because a discussion is on-going on naming. Glad to add more examples after the discussion is settle down. (The commit message will be updated accordingly as well)

Live prototype:
- http://schemaorg-127321.appspot.com/InstructionSet
- http://schemaorg-127321.appspot.com/InstructionSupply

@danbri @ajax-als @chaals @mfhepp @pmika @scor @shankarnat @tmarshbing @vholland @rvguha @philbarker 

cc my coworker @j-squared
