### PR TITLE
prefer http over https (see PR comment)

### DIFF
--- a/docs/faq.html
+++ b/docs/faq.html
@@ -228,7 +228,7 @@
     There is a general trend towards using <code>'https'</code> more widely, and you can already write <code>'https://schema.org'</code> in your structured data.
     Over time we will migrate the schema.org site itself towards using <code>https:</code> as the default version of the site and our preferred form in examples.
     However 'http://schema.org' -based URLs in structured data markup will remain widely understood for the forseeable future and there should
-    be no urgency about migrating existing data. This is a lengthy way of saying that both <code>'https://schema.org'</code> and <code>'http://schema.org'</code> are fine.
+    be no urgency about migrating existing data. This is a lengthy way of saying that you should use <code>'http://schema.org'</code> until we have moved everything over to <code>'https://schema.org'</code>.
   </p>
 
 


### PR DESCRIPTION
We noticed Bing does not properly markup schema when you refer to the `https` version of schema.org for healthcare related microdata. I created a test site where you can use the Bing Markup Validator to see what I'm talking about:

https://bing-schemaorg-test-vhtvoulwqx.now.sh/

In order to prevent this from happening to other folks, I suggest we change the language to prefer the `http` version until we get full `https` support. Thanks!

