### PR TITLE
Example fixes: no 'content' attribute for 'span' in Microdata; wrong attribute in Microdata; following recommendation for 'price' content

### DIFF
--- a/data/examples.txt
+++ b/data/examples.txt
@@ -1113,7 +1113,7 @@ by <a itemprop="author" href="/author/jd_salinger.html">J.D. Salinger</a>
 </div>
 
 <div itemprop="offers" itemscope itemtype="http://schema.org/Offer">
-  Price: <span itemprop="price" content="6.99">$6.99</span>
+  Price: $<span itemprop="price">6.99</span>
   <meta itemprop="priceCurrency" content="USD" />
   <link itemprop="availability" href="http://schema.org/InStock">In Stock
 </div>
@@ -1172,7 +1172,8 @@ by <a property="author" href="/author/jd_salinger.html">J.D. Salinger</a>
 </div>
 
 <div property="offers" typeof="Offer">
-  Price: <meta property="priceCurrency" content="USD" />$<meta property="price" content="6.99" />6.99  
+  Price: $<span property="price">6.99</span>
+  <meta property="priceCurrency" content="USD" />
   <link property="availability" href="http://schema.org/InStock">In Stock
 </div>
 

--- a/data/ext/bib/bsdo-translation-examples.txt
+++ b/data/ext/bib/bsdo-translation-examples.txt
@@ -29,13 +29,13 @@ MICRODATA:
 <div itemscope itemtype="http://schema.org/Book" itemid="http://worldcat.org/entity/work/id/2292573321">
 	<h1><span itemprop="name">Rouge et le noir</span></h1>
     <div>Author: <span itemprop="author" itemscope itemtype="http://schema.org/Person" itemid="http://viaf.org/viaf/17823">Stendhal</span></div>
-	<div>Language: <meta itemprop="inLanguage" content="fr" />French</span></div>
+	<div>Language: <meta itemprop="inLanguage" content="fr" />French</div>
 	<div>Has Translation: <span itemprop="workTranslation" itemscope itemtype="http://schema.org/CreativeWork" itemid="http://worldcat.org/entity/work/id/460647">Red and Black : A New Translation, Backgrounds and Sources, Criticism</span></div>
 </div>
 <div itemscope itemtype="http://schema.org/Book" itemid="http://worldcat.org/entity/work/id/460647">
     <h1><span itemprop="name">Red and Black : A New Translation, Backgrounds and Sources, Criticism</span></h1>
     <div>Author: <span itemprop="author" itemscope itemtype="http://schema.org/Person" itemid="http://viaf.org/viaf/17823">Stendhal</span></div>
-	<div>Language: <meta itemprop="inLanguage" content="en" />English</span></div>
+	<div>Language: <meta itemprop="inLanguage" content="en" />English</div>
 	<div>Subject: <span itemprop="about">Psychological fiction, French</span></div>
 	<div>Translation of: <span itemprop="translationOfWork" itemscope itemtype="http://schema.org/CreativeWork" itemid="http://worldcat.org/entity/work/id/2292573321">Rouge et le noir</span></div>
 	<div>Translator: <span itemprop="translator" itemscope itemtype="http://schema.org/Person" itemid="http://viaf.org/viaf/8453420">Robert Martin Adams</span></div>

--- a/data/ext/bib/bsdo-translation-examples.txt
+++ b/data/ext/bib/bsdo-translation-examples.txt
@@ -48,17 +48,17 @@ RDFA:
 <div vocab="http://schema.org/">
 <div typeof="Book" resource="http://worldcat.org/entity/work/id/2292573321">
 	<h1><span property="name">Rouge et le noir</span></h1>
-    <div>Author: <span property="author" typeOf="Person" resource="http://viaf.org/viaf/17823">Stendhal</span></div>
+    <div>Author: <span property="author" typeof="Person" resource="http://viaf.org/viaf/17823">Stendhal</span></div>
 	<div>Language: <span property="inLanguage" content="fr">French</span></div>
-	<div>Has Translation: <span property="workTranslation" typeOf="CreativeWork" resource="http://worldcat.org/entity/work/id/460647">Red and Black : A New Translation, Backgrounds and Sources, Criticism</span></div>
+	<div>Has Translation: <span property="workTranslation" typeof="CreativeWork" resource="http://worldcat.org/entity/work/id/460647">Red and Black : A New Translation, Backgrounds and Sources, Criticism</span></div>
 </div>
 <div typeof="Book" resource="http://worldcat.org/entity/work/id/460647">
     <h1><span property="name">Red and Black : A New Translation, Backgrounds and Sources, Criticism</span></h1>
-    <div>Author: <span property="author" typeOf="Person" resource="http://viaf.org/viaf/17823">Stendhal</span></div>
+    <div>Author: <span property="author" typeof="Person" resource="http://viaf.org/viaf/17823">Stendhal</span></div>
 	<div>Language: <span property="inLanguage" content="en">English</span></div>
 	<div>Subject: <span property="about">Psychological fiction, French</span></div>
-	<div>Translation of: <span property="translationOfWork" typeOf="CreativeWork" resource="http://worldcat.org/entity/work/id/2292573321">Rouge et le noir</span></div>
-	<div>Translator: <span property="translator" typeOf="Person" resource="http://viaf.org/viaf/8453420">Robert Martin Adams</span></div>
+	<div>Translation of: <span property="translationOfWork" typeof="CreativeWork" resource="http://worldcat.org/entity/work/id/2292573321">Rouge et le noir</span></div>
+	<div>Translator: <span property="translator" typeof="Person" resource="http://viaf.org/viaf/8453420">Robert Martin Adams</span></div>
 </div>
 </div>
 

--- a/data/ext/bib/bsdo-translation-examples.txt
+++ b/data/ext/bib/bsdo-translation-examples.txt
@@ -28,17 +28,17 @@ MICRODATA:
 <div>
 <div itemscope itemtype="http://schema.org/Book" itemid="http://worldcat.org/entity/work/id/2292573321">
 	<h1><span itemprop="name">Rouge et le noir</span></h1>
-    <div>Author: <span property="itemprop" itemscope itemtype="http://schema.org/Person" itemid="http://viaf.org/viaf/17823">Stendhal</span></div>
-	<div>Language: <span itemprop="inLanguage" content="fr">French</span></div>
+    <div>Author: <span itemprop="author" itemscope itemtype="http://schema.org/Person" itemid="http://viaf.org/viaf/17823">Stendhal</span></div>
+	<div>Language: <meta itemprop="inLanguage" content="fr" />French</span></div>
 	<div>Has Translation: <span itemprop="workTranslation" itemscope itemtype="http://schema.org/CreativeWork" itemid="http://worldcat.org/entity/work/id/460647">Red and Black : A New Translation, Backgrounds and Sources, Criticism</span></div>
 </div>
 <div itemscope itemtype="http://schema.org/Book" itemid="http://worldcat.org/entity/work/id/460647">
     <h1><span itemprop="name">Red and Black : A New Translation, Backgrounds and Sources, Criticism</span></h1>
     <div>Author: <span itemprop="author" itemscope itemtype="http://schema.org/Person" itemid="http://viaf.org/viaf/17823">Stendhal</span></div>
-	<div>Language: <span itemprop="inLanguage" content="en">English</span></div>
+	<div>Language: <meta itemprop="inLanguage" content="en" />English</span></div>
 	<div>Subject: <span itemprop="about">Psychological fiction, French</span></div>
 	<div>Translation of: <span itemprop="translationOfWork" itemscope itemtype="http://schema.org/CreativeWork" itemid="http://worldcat.org/entity/work/id/2292573321">Rouge et le noir</span></div>
-	<div>Translator: <span property="itemprop" itemscope itemtype="http://schema.org/Person" itemid="http://viaf.org/viaf/8453420">Robert Martin Adams</span></div>
+	<div>Translator: <span itemprop="translator" itemscope itemtype="http://schema.org/Person" itemid="http://viaf.org/viaf/8453420">Robert Martin Adams</span></div>
 </div>
 </div>
 


### PR DESCRIPTION
This PR only changes examples:

* in Microdata, the `span` element can’t have a `content` attribute (#184): either omitted the element (in case where the value is the same) or used the `meta` element instead
* the currency symbol should not be part of the `price` value
* Microdata: replaced `property` attribute with `itemprop`, and used the same properties from the RDFa example (`author`, `translator`)
* RDFa: used `typeof` instead of `typeOf`