### PR TITLE
Fix a bug with Hospital, Dentist definitions.

### DIFF
--- a/data/ext/health-lifesci/med-health-core.rdfa
+++ b/data/ext/health-lifesci/med-health-core.rdfa
@@ -2861,11 +2861,22 @@
   <link property="http://schema.org/isPartOf" href="http://health-lifesci.schema.org" />
 </div>
 
-<!-- TODO: CLINICAL TRIALS VOCAB -->
+<h3>Core Annotations</h3>
 
-<!-- TODO: US HEALTH INSURANCE VOCAB -->
+<p>Here we add in more facts about core vocabulary that use terms from the extension.</p>
 
-<!-- TODO: GENETIC VOCAB -->
+<div typeof="rdfs:Class" resource="http://schema.org/Dentist">
+  <span>Subclass of: <a property="rdfs:subClassOf" href="http://schema.org/MedicalBusiness"> MedicalBusiness</a></span>
+</div>
+
+<div typeof="rdfs:Class" resource="http://schema.org/Physician">
+  <span>Subclass of: <a property="rdfs:subClassOf" href="http://schema.org/MedicalBusiness"> health:MedicalBusiness</a></span>
+</div>
+
+<div typeof="rdfs:Class" resource="http://schema.org/Pharmacy">
+  <span>Subclass of: <a property="rdfs:subClassOf" href="http://schema.org/MedicalBusiness">MedicalBusiness</a></span>
+</div>
+
 
 </body>
 </html>

--- a/data/schema.rdfa
+++ b/data/schema.rdfa
@@ -76,10 +76,17 @@
        <span>Subclass of: <a property="rdfs:subClassOf" href="http://schema.org/Place">Place</a></span>
     </div>
 
+    <div typeof="rdfs:Class" resource="http://schema.org/MedicalOrganization">
+      <span class="h" property="rdfs:label">MedicalOrganization</span>
+      <span property="rdfs:comment">A medical organization (physical or not), such as hospital, institution or clinic.</span>
+      <span>Subclass of: <a property="rdfs:subClassOf" href="http://schema.org/Organization">Organization</a></span>
+    </div>
+
+
     <div typeof="rdfs:Class" resource="http://schema.org/Dentist">
       <span class="h" property="rdfs:label"> Dentist</span>
       <span property="rdfs:comment">A dentist.</span>
-      <span>Subclass of: <a property="rdfs:subClassOf" href="http://schema.org/MedicalBusiness"> MedicalBusiness</a></span>
+      <span>Subclass of: <a property="rdfs:subClassOf" href="http://schema.org/MedicalOrganization">MedicalOrganization</a></span>
       <span>Subclass of: <a property="rdfs:subClassOf" href="http://schema.org/ProfessionalService"> schema:ProfessionalService</a></span>
     </div>
 
@@ -89,20 +96,17 @@
       <span>Subclass of: <a property="rdfs:subClassOf" href="http://schema.org/CivicStructure">CivicStructure</a></span>
       <span>Subclass of: <a property="rdfs:subClassOf" href="http://schema.org/EmergencyService">EmergencyService</a></span>
       <span>Subclass of: <a property="rdfs:subClassOf" href="http://schema.org/MedicalOrganization">MedicalOrganization</a></span>
-      <span>Subclass of: <a property="rdfs:subClassOf" href="http://schema.org/MedicalBusiness">MedicalBusiness</a></span>
     </div>
 
     <div typeof="rdfs:Class" resource="http://schema.org/Physician">
       <span class="h" property="rdfs:label">Physician</span>
       <span property="rdfs:comment">A doctor's office.</span>
       <span>Subclass of: <a property="rdfs:subClassOf" href="http://schema.org/MedicalOrganization"> health:MedicalOrganization</a></span>
-      <span>Subclass of: <a property="rdfs:subClassOf" href="http://schema.org/MedicalBusiness"> health:MedicalBusiness</a></span>
     </div>
-        <div typeof="rdfs:Class" resource="http://schema.org/Pharmacy">
+    <div typeof="rdfs:Class" resource="http://schema.org/Pharmacy">
       <span class="h" property="rdfs:label">Pharmacy</span>
       <span property="rdfs:comment">A pharmacy or drugstore.</span>
       <span>Subclass of: <a property="rdfs:subClassOf" href="http://schema.org/MedicalOrganization">MedicalOrganization</a></span>
-      <span>Subclass of: <a property="rdfs:subClassOf" href="http://schema.org/MedicalBusiness">MedicalBusiness</a></span>
     </div>
 
     <div typeof="rdfs:Class" resource="http://schema.org/FinancialService">


### PR DESCRIPTION
MedicalBusiness is in extension and shouldn't have been used in core definitions.
MedicalOrganization is now back in the core where is belongs. This fixes
site navigation issues since core terms can't use extension terms in their definitions.

In future we will need a more considered distinction between these two types.