### PR TITLE
NDB Pagestore implementation

### DIFF
--- a/api.py
+++ b/api.py
@@ -191,14 +191,20 @@ class PageStoreTool():
         self.tlocal.CurrentStoreSet = current
         log.info("Setting CurrentStoreSet: %s",current)
         
-    def put(self, key, val):
-        fullKey = self.getCurrent() + ":" + key
+    def put(self, key, val,cache=None):
+        ca = self.getCurrent()
+        if cache != None:
+            ca = cache
+        fullKey = ca + ":" + key
         #log.info("[%s]PageStore storing %s" % (os.environ["INSTANCE_ID"],fullKey))
         ent = PageEntity(id = fullKey, content = val)
         ent.put()
         
-    def get(self, key):
-        fullKey = self.getCurrent() + ":" + key
+    def get(self, key,cache=None):
+        ca = self.getCurrent()
+        if cache != None:
+            ca = cache
+        fullKey = ca + ":" + key
         ent = PageEntity.get_by_id(fullKey)
         if(ent):
             #log.info("[%s]PageStore returning %s" % (os.environ["INSTANCE_ID"],fullKey))

--- a/api.py
+++ b/api.py
@@ -6,6 +6,8 @@ import re
 import logging
 import threading
 import parsers
+from google.appengine.ext import ndb
+
 
 import apirdflib
 #from apirdflib import rdfGetTargets, rdfGetSources
@@ -49,6 +51,7 @@ DYNALOAD = True # permits read_schemas to be re-invoked live.
 #   loader=jinja2.FileSystemLoader(os.path.join(os.path.dirname(__file__), 'templates')),
 #    extensions=['jinja2.ext.autoescape'], autoescape=True)
 
+NDBPAGESTORE = True #True - uses NDB shared (accross instances) store for page cache - False uses in memory local cache
 debugging = False
 
 def getMasterStore():
@@ -118,12 +121,15 @@ namespaces = """        "schema": "http://schema.org/",
 class DataCacheTool():
 
     def __init__ (self):
-        self._DataCache = {}
         self.tlocal = threading.local()
         self.tlocal.CurrentDataCache = "core"
+        self.initialise()
+
+    def initialise(self):
+        self._DataCache = {}
         self._DataCache[self.tlocal.CurrentDataCache] = {}
-
-
+        return
+        
     def getCache(self,cache=None):
         if cache == None:
             cache = self.getCurrent()
@@ -152,6 +158,62 @@ class DataCacheTool():
         return self._DataCache.keys()
 
 DataCache = DataCacheTool()
+
+class PageEntity(ndb.Model):
+    content = ndb.TextProperty()
+    
+class PageStoreTool():
+    def __init__ (self):
+        self.tlocal = threading.local()
+        self.tlocal.CurrentStoreSet = "core"
+
+    def initialise(self):
+        import time
+        log.info("[%s]PageStore initialising Data Store" % (os.environ["INSTANCE_ID"]))
+        loops = 0
+        ret = 0
+        while loops < 5:
+            keys = PageEntity.query().fetch(keys_only=True)
+            count = len(keys)
+            log.info("[%s]PageStore deleting %s keys" % (os.environ["INSTANCE_ID"], count))
+            if count == 0:
+                break
+            ndb.delete_multi(keys) 
+            ret += count
+            loops += 1
+            time.sleep(1)
+        return str(ret)
+            
+    def getCurrent(self):
+        return self.tlocal.CurrentStoreSet
+        
+    def setCurrent(self,current):
+        self.tlocal.CurrentStoreSet = current
+        log.info("Setting CurrentStoreSet: %s",current)
+        
+    def put(self, key, val):
+        fullKey = self.getCurrent() + ":" + key
+        #log.info("[%s]PageStore storing %s" % (os.environ["INSTANCE_ID"],fullKey))
+        ent = PageEntity(id = fullKey, content = val)
+        ent.put()
+        
+    def get(self, key):
+        fullKey = self.getCurrent() + ":" + key
+        ent = PageEntity.get_by_id(fullKey)
+        if(ent):
+            #log.info("[%s]PageStore returning %s" % (os.environ["INSTANCE_ID"],fullKey))
+            return ent.content
+        else:
+            #log.info("PageStore '%s' not found" % fullKey)
+            return None
+
+PageStore = None
+log.info("NDB PageStore enabled: %s" % NDBPAGESTORE)
+if  NDBPAGESTORE:
+    PageStore = PageStoreTool()
+else:
+    PageStore = DataCacheTool()
+    
 
 
 class Unit ():

--- a/sdoapp.py
+++ b/sdoapp.py
@@ -25,7 +25,7 @@ from google.appengine.ext.webapp import blobstore_handlers
 from google.appengine.api import modules
 from google.appengine.api import runtime
 
-from api import inLayer, read_file, full_path, read_schemas, read_extensions, read_examples, namespaces, DataCache
+from api import inLayer, read_file, full_path, read_schemas, read_extensions, read_examples, namespaces, DataCache, PageStore
 from api import Unit, GetTargets, GetSources, GetComments, GetsoftwareVersions
 from api import GetComment, all_terms, GetAllTypes, GetAllProperties, GetAllEnumerationValues, GetAllTerms, LoadExamples
 from api import GetParentList, GetImmediateSubtypes, HasMultipleBaseTypes
@@ -50,7 +50,6 @@ silent_skip_list =  [ "favicon.ico" ] # Do nothing for now
 
 all_layers = {}
 ext_re = re.compile(r'([^\w,])+')
-PageCache = {}
 
 #TODO: Modes:
 # mainsite
@@ -96,6 +95,19 @@ elif "SERVER_NAME" in os.environ and ("localhost" in os.environ['SERVER_NAME'] a
     WarmedUp = True
 ######################################
 
+def cleanCaches():
+    ret = ""
+    r = DataCache.initialise()
+    if r:
+        ret += str(r)
+    r = PageStore.initialise()
+    if r:
+        if len(ret):
+            ret += " - "
+        ret += str(r)
+    log.info("cleanCaches returning %s", ret)
+    return ret
+
 ############# Shared values and times ############
 #### Memcache functions dissabled in test mode ###
 appver = "TestHarness Version"
@@ -126,6 +138,8 @@ if not getInTestHarness():
         memcache.add(key="SysStart", value=systarttime)
         instance_first = True
         log.info("Detected new code version - resetting memory values")
+        cleanmsg = cleanCaches()
+        log.info("Clean count(s): %s" % cleanmsg)
     else:
        systarttime = memcache.get("SysStart")
        tick()
@@ -133,7 +147,6 @@ if not getInTestHarness():
 modtime = systarttime.replace(microsecond=0)
 etagSlug = "24751%s" % modtime.strftime("%y%m%d%H%M%Sa")
 #################################################
-
 
 def cleanPath(node):
     """Return the substring of a string matching chars approved for use in our URL paths."""
@@ -348,27 +361,6 @@ class ShowUnit (webapp2.RequestHandler):
         self.response.headers['Cache-Control'] = "public, max-age=600" # 10m
         #self.response.headers['Cache-Control'] = "public, max-age=43200" # 12h
         self.response.headers['Vary'] = "Accept, Accept-Encoding"
-
-    def GetCachedText(self, node, layers='core'):
-        """Return page text from node.id cache (if found, otherwise None)."""
-        global PageCache
-        cachekey = "%s:%s" % ( layers, node.id ) # was node.id
-        if (cachekey in PageCache):
-            return PageCache[cachekey]
-        else:
-            return None
-
-    def AddCachedText(self, node, textStrings, layers='core'):
-        """Cache text of our page for this node via its node.id.
-
-        We can be passed a text string or an array of text strings.
-        """
-        global PageCache
-        cachekey = "%s:%s" % ( layers, node.id ) # was node.id
-        outputText = "".join(textStrings)
-        log.debug("CACHING: %s" % node.id)
-        PageCache[cachekey] = outputText
-        return outputText
 
     def write(self, str):
         """Write some text to Web server's output stream."""
@@ -765,7 +757,6 @@ class ShowUnit (webapp2.RequestHandler):
             exts[ext].append(prop)
 
         for e in sorted(exts.keys()):
-            log.info("%s EXTS %s: %s" % (cl, e,exts[e]))
             count = 0
             first = True
             for p in sorted(exts[e], key=lambda u: u.id):
@@ -862,7 +853,6 @@ class ShowUnit (webapp2.RequestHandler):
         ranges = []
         eranges = []
         for r in rges:
-            log.info("range %s - %s" % (r.id,r.getHomeLayer()))
             if inLayer(layers, r):
                 ranges.append(r)
             else:
@@ -870,7 +860,6 @@ class ShowUnit (webapp2.RequestHandler):
         domains = []
         edomains = []
         for d in doms:
-            log.info("domain %s - %s" % (d.id,d.getHomeLayer()))
             if inLayer(layers, d):
                 domains.append(d)
             else:
@@ -1029,7 +1018,7 @@ class ShowUnit (webapp2.RequestHandler):
             # the .tpl has responsibility for extension homepages
             # TODO: pass in extension, base_domain etc.
             sitekeyedhomepage = "homepage %s" % getSiteName()
-            hp = DataCache.get(sitekeyedhomepage)
+            hp = PageStore.get(sitekeyedhomepage)
             self.response.headers['Content-Type'] = "text/html"
             self.emitCacheHeaders()
             if hp != None:
@@ -1046,7 +1035,7 @@ class ShowUnit (webapp2.RequestHandler):
                 self.response.out.write( page )
                 log.debug("Served and cached fresh homepage.tpl key: %s " % sitekeyedhomepage)
                 #log.info("Served and cached fresh homepage.tpl key: %s " % sitekeyedhomepage)
-                DataCache.put(sitekeyedhomepage, page)
+                PageStore.put(sitekeyedhomepage, page)
                 #            self.response.out.write( open("static/index.html", 'r').read() )
             return True
         log.info("Warning: got here how?")
@@ -1111,7 +1100,7 @@ class ShowUnit (webapp2.RequestHandler):
                 'ext_mappings': ext_mappings
             }
             out = templateRender('genericTermPageHeader.tpl',template_values)
-            DataCache.put(generated_page_id,out)
+            DataCache.put(generated_page_id, out)
             log.debug("Served and cached fresh genericTermPageHeader.tpl for %s" % generated_page_id )
 
             self.response.write(out)
@@ -1153,8 +1142,11 @@ class ShowUnit (webapp2.RequestHandler):
         self.emitSchemaorgHeaders(node, ext_mappings, sitemode, getSiteName(), layers)
 
 
-        cached = self.GetCachedText(node, layers)
+        #cached = self.GetCachedText(node, layers)
+        #cached = DataCache.get(node.id)
+        cached = PageStore.get(node.id)
         if (cached != None):
+            log.info("GOT CACHED page for %s", node.id)
             self.response.write(cached)
             return
 
@@ -1328,7 +1320,11 @@ class ShowUnit (webapp2.RequestHandler):
 
         self.write(" \n\n</div>\n</body>\n</html>")
 
-        self.response.write(self.AddCachedText(node, self.outputStrings, layers))
+        page = "".join(self.outputStrings)
+        PageStore.put(node.id,page)
+
+#        self.response.write(self.AddCachedText(node, self.outputStrings, layers))
+        self.response.write(page)
 
     def emitHTTPHeaders(self, node):
         if ENABLE_CORS:
@@ -1390,8 +1386,8 @@ class ShowUnit (webapp2.RequestHandler):
         self.response.headers['Content-Type'] = "text/html"
         self.emitCacheHeaders()
 
-        if DataCache.get('SchemasPage'):
-            self.response.out.write( DataCache.get('SchemasPage') )
+        if PageStore.get('SchemasPage'):
+            self.response.out.write( PageStore.get('SchemasPage') )
             log.debug("Serving recycled SchemasPage.")
             return True
         else:
@@ -1405,7 +1401,7 @@ class ShowUnit (webapp2.RequestHandler):
 
             self.response.out.write( page )
             log.debug("Serving fresh SchemasPage.")
-            DataCache.put("SchemasPage",page)
+            PageStore.put("SchemasPage",page)
 
             return True
 
@@ -1421,8 +1417,8 @@ class ShowUnit (webapp2.RequestHandler):
         self.response.headers['Content-Type'] = "text/html"
         self.emitCacheHeaders()
 
-        if DataCache.get('FullTreePage'):
-            self.response.out.write( DataCache.get('FullTreePage') )
+        if PageStore.get('FullTreePage'):
+            self.response.out.write( PageStore.get('FullTreePage') )
             log.debug("Serving recycled FullTreePage.")
             return True
         else:
@@ -1501,7 +1497,7 @@ class ShowUnit (webapp2.RequestHandler):
 
             self.response.out.write( page )
             log.debug("Serving fresh FullTreePage.")
-            DataCache.put("FullTreePage",page)
+            PageStore.put("FullTreePage",page)
 
             return True
 
@@ -1511,8 +1507,8 @@ class ShowUnit (webapp2.RequestHandler):
         self.response.headers['Content-Type'] = "application/ld+json"
         self.emitCacheHeaders()
 
-        if DataCache.get('JSONLDThingTree'):
-            self.response.out.write( DataCache.get('JSONLDThingTree') )
+        if PageStore.get('JSONLDThingTree'):
+            self.response.out.write( PageStore.get('JSONLDThingTree') )
             log.debug("Serving recycled JSONLDThingTree.")
             return True
         else:
@@ -1522,7 +1518,7 @@ class ShowUnit (webapp2.RequestHandler):
             thing_tree = mainroot.toJSON()
             self.response.out.write( thing_tree )
             log.debug("Serving fresh JSONLDThingTree.")
-            DataCache.put("JSONLDThingTree",thing_tree)
+            PageStore.put("JSONLDThingTree",thing_tree)
             return True
         return False
 
@@ -1567,7 +1563,7 @@ class ShowUnit (webapp2.RequestHandler):
                 return True
             return False
 
-    def handle404Failure(self, node, layers="core"):
+    def handle404Failure(self, node, layers="core", extrainfo=None):
         self.error(404)
         self.emitSchemaorgHeaders("404%20Missing")
         self.response.out.write('<h3>404 Not Found.</h3><p><br/>Page not found. Please <a href="/">try the homepage.</a><br/><br/></p>')
@@ -1584,6 +1580,9 @@ class ShowUnit (webapp2.RequestHandler):
         base_actionprop = Unit.GetUnit( node.rsplit('-')[0] )
         if base_actionprop != None :
             self.response.out.write('<div>Looking for an <a href="/Action">Action</a>-related property? Note that xyz-input and xyz-output have <a href="/docs/actions.html">special meaning</a>. See also: <a href="/%s">%s</a></div> <br/><br/> ' % ( base_actionprop.id, base_actionprop.id ))
+        
+        if extrainfo:
+            self.response.out.write("<div>%s</div>" % extrainfo)
 
         self.response.out.write("</div>\n</body>\n</html>\n")
 
@@ -1613,8 +1612,8 @@ class ShowUnit (webapp2.RequestHandler):
         log.debug("clean_node: %s requested_version: %s " %  (clean_node, requested_version))
         if (clean_node=="version/" or clean_node=="version") and requested_version=="" and requested_format=="":
             log.info("Table of contents should be sent instead, then succeed.")
-            if DataCache.get('tocVersionPage'):
-                self.response.out.write( DataCache.get('tocVersionPage'))
+            if PageStore.get('tocVersionPage'):
+                self.response.out.write( PageStore.get('tocVersionPage'))
                 return True
             else:
                 log.debug("Serving tocversionPage from cache.")
@@ -1624,7 +1623,7 @@ class ShowUnit (webapp2.RequestHandler):
 
                 self.response.out.write( page )
                 log.debug("Serving fresh tocVersionPage.")
-                DataCache.put("tocVersionPage",page)
+                PageStore.put("tocVersionPage",page)
                 return True
 
         if requested_version in releaselog:
@@ -1664,8 +1663,8 @@ class ShowUnit (webapp2.RequestHandler):
                 log.info("generating a live view of this latest release.")
 
 
-        if DataCache.get('FullReleasePage'):
-            self.response.out.write( DataCache.get('FullReleasePage') )
+        if PageStore.get('FullReleasePage'):
+            self.response.out.write( PageStore.get('FullReleasePage') )
             log.debug("Serving recycled FullReleasePage.")
             return True
         else:
@@ -1730,15 +1729,15 @@ class ShowUnit (webapp2.RequestHandler):
 
             self.response.out.write( page )
             log.debug("Serving fresh FullReleasePage.")
-            DataCache.put("FullReleasePage",page)
+            PageStore.put("FullReleasePage",page)
             return True
 
     def handleExtensionContents(self,ext):
         if not ext in ENABLED_EXTENSIONS:
             return ""
 
-        if DataCache.get('ExtensionContents',ext):
-            return DataCache.get('ExtensionContents',ext)
+        if PageStore.get('ExtensionContents',ext):
+            return PageStore.get('ExtensionContents',ext)
 
         buff = StringIO.StringIO()
 
@@ -1773,7 +1772,7 @@ class ShowUnit (webapp2.RequestHandler):
             buff.write("</div>")
 
         ret = buff.getvalue()
-        DataCache.put('ExtensionContents',ret,ext)
+        PageStore.put('ExtensionContents',ret,ext)
         buff.close()
         return ret
 
@@ -1876,6 +1875,7 @@ class ShowUnit (webapp2.RequestHandler):
 
         log.debug("sdoapp.py setting current datacache to: %s " % dcn)
         DataCache.setCurrent(dcn)
+        PageStore.setCurrent(dcn)
 
 
         debugging = False
@@ -1930,17 +1930,19 @@ class ShowUnit (webapp2.RequestHandler):
         if NotModified and DataCache.get(etag):
             retHdrs = DataCache.get(etag)   #Already cached headers for this request
         else:
-            self._get(node) #Go build the page
-            if self.response.status.startswith("200"):
-                self.response.headers.add_header("ETag", etag)
-                self.response.headers['Last-Modified'] = modtime.strftime("%a, %d %b %Y %H:%M:%S UTC")
-            retHdrs = self.response.headers.copy()
-            DataCache.put(etag,retHdrs) #Cache these headers for a future 304 return
+            enableCaching = self._get(node) #Go build the page
+            #log.info("_get result: %s" % enableCaching)
+            if enableCaching:
+                if self.response.status.startswith("200"):
+                    self.response.headers.add_header("ETag", etag)
+                    self.response.headers['Last-Modified'] = modtime.strftime("%a, %d %b %Y %H:%M:%S UTC")
+                    retHdrs = self.response.headers.copy()
+                    DataCache.put(etag,retHdrs) #Cache these headers for a future 304 return
 
-        if NotModified:
-            self.response.clear()
-            self.response.headers = retHdrs
-            self.response.set_status(304,"Not Modified")
+                if NotModified:
+                    self.response.clear()
+                    self.response.headers = retHdrs
+                    self.response.set_status(304,"Not Modified")
         return
 
 
@@ -1964,20 +1966,22 @@ class ShowUnit (webapp2.RequestHandler):
         Last resort is a 404 error if we do not exactly match a term's id.
 
         See also https://webapp-improved.appspot.com/guide/request.html#guide-request
+        
+        Return True to enable browser caching ETag/Last-Modified - False for no cache
         """
 
         global_vars.time_start = datetime.datetime.now()
         tick() #keep system fresh
 
         if not self.setupHostinfo(node):
-            return
+            return False
 
         self.callCount()
 
         self.emitHTTPHeaders(node)
 
         if (node in silent_skip_list):
-            return
+            return False
 
         if ENABLE_HOSTED_EXTENSIONS:
             layerlist = self.setupExtensionLayerlist(node) # e.g. ['core', 'bib']
@@ -1991,7 +1995,7 @@ class ShowUnit (webapp2.RequestHandler):
                 log.info("Warmup dissabled for localhost instance")
             else:
                 self.warmup()
-            return
+            return False
         else:  #Do a bit of warming on each call
             global WarmedUp
             global Warmer
@@ -2000,73 +2004,82 @@ class ShowUnit (webapp2.RequestHandler):
 
         if(node == "_ah/start"):
             log.info("Instance[%s] received Start request at %s" % (modules.get_current_instance_id(), global_vars.time_start) )
-            return
+            return False
 
         if (node in ["", "/"]):
             if self.handleHomepage(node):
-                return
+                return True
             else:
                 log.info("Error handling homepage: %s" % node)
-                return
+                return False
 
         if node in ["docs/jsonldcontext.json.txt", "docs/jsonldcontext.json"]:
             if self.handleJSONContext(node):
-                return
+                return True
             else:
                 log.info("Error handling JSON-LD context: %s" % node)
-                return
+                return False
 
         if (node == "docs/full.html"): # DataCache.getDataCache.get
             if self.handleFullHierarchyPage(node, layerlist=layerlist):
-                return
+                return True
             else:
                 log.info("Error handling full.html : %s " % node)
-                return
+                return False
 
         if (node == "docs/schemas.html"): # DataCache.getDataCache.get
             if self.handleSchemasPage(node, layerlist=layerlist):
-                return
+                return True
             else:
                 log.info("Error handling schemas.html : %s " % node)
-                return
+                return False
 
 
 
         if (node == "docs/tree.jsonld" or node == "docs/tree.json"):
             if self.handleJSONSchemaTree(node, layerlist=ALL_LAYERS):
-                return
+                return True
             else:
                 log.info("Error handling JSON-LD schema tree: %s " % node)
-                return
+                return False
 
-        if (node == "version/2.0/" or node == "version/latest/" or "version/" in node):
+        if (node == "version/3.0/" or node == "version/latest/" or "version/" in node):
             if self.handleFullReleasePage(node, layerlist=layerlist):
-                return
+                return True
             else:
                 log.info("Error handling full release page: %s " % node)
                 if self.handle404Failure(node):
-                    return
+                    return False
                 else:
                     log.info("Error handling 404 under /version/")
-                    return
+                    return False
 
         if(node == "_siteDebug"):
             if(getBaseHost() != "schema.org" or os.environ['PRODSITEDEBUG'] == "True"):
                 self.siteDebug()
-                return
+                return False #Treat as a dynamic page - suppress Etags etc.
+
+        if(node == "_cacheFlush"):
+            counts = cleanCaches()
+            inf = "<div style=\"clear: both; float: left; text-align: left; font-size: xx-small; color: #888 ; margin: 1em; line-height: 100%;\">"
+            inf +=  counts
+            inf += "</div>"
+            self.handle404Failure(node,extrainfo=inf)
+            return False
+            
 
         # Pages based on request path matching a Unit in the term graph:
         if self.handleExactTermPage(node, layers=layerlist):
-            return
+            return True
         else:
             log.info("Error handling exact term page. Assuming a 404: %s" % node)
 
             # Drop through to 404 as default exit.
             if self.handle404Failure(node):
-                return
+                return False
             else:
                 log.info("Error handling 404.")
-                return
+                return False
 
     def siteDebug(self):
         global STATS


### PR DESCRIPTION
In response to issue (#1171) 
Overview:
* Previously created pages are held in a within instance memory cache that is shared between threads.  This means that each page is recreated for each application instance.  We previously noted that the live site spawned off dozens of instances to support the load,
* This version uses the Cloud Datastore to hold cached pages.
* The single NDB store is shared between all threads of all instances.
* ​_Should_​ result in a lot less page creations, and more importantly you having to wait for a new instance to create you a page.
*  The NDB store is persistent so will keep the page store even when you reload/deploy a new version of the code/data.
* Implemented code that detects this condition and deletes all pages in the store as it starts. 
* For early supporting there is a way to  manually call this caheFlush function.

If successful a similar approach should be considered for the underlying RDF data. 