### PR TITLE
Updated comments to remove xml escapes in favour of markdown

### DIFF
--- a/data/ext/auto/auto.rdfa
+++ b/data/ext/auto/auto.rdfa
@@ -33,9 +33,7 @@
     <div typeof="rdf:Property" resource="http://schema.org/fuelCapacity">
         <link property="http://schema.org/isPartOf" href="http://auto.schema.org" />
         <span class="h" property="rdfs:label">fuelCapacity</span>
-        <span property="rdfs:comment">The capacity of the fuel tank or in the case of electric cars, the battery. If there are multiple components for storage, this should indicate the total of all storage of the same type.&lt;br /&gt;
-    Typical unit code(s): LTR for liters, GLL of US gallons, GLI for UK / imperial gallons, AMH for ampere-hours (for electrical vehicles)
-    </span>
+        <span property="rdfs:comment">The capacity of the fuel tank or in the case of electric cars, the battery. If there are multiple components for storage, this should indicate the total of all storage of the same type.\n\nTypical unit code(s): LTR for liters, GLL of US gallons, GLI for UK / imperial gallons, AMH for ampere-hours (for electrical vehicles).</span>
         <span>Domain: <a property="http://schema.org/domainIncludes" href="http://schema.org/Vehicle">Vehicle</a></span>
         <span>Range: <a property="http://schema.org/rangeIncludes" href="http://schema.org/QuantitativeValue">QuantitativeValue</a></span>
         <span>Source:  <a property="dc:source" href="http://www.w3.org/wiki/WebSchemas/SchemaDotOrgSources#Automotive_Ontology_Working_Group">GAO</a></span>
@@ -43,12 +41,7 @@
     <div typeof="rdf:Property" resource="http://schema.org/roofLoad">
         <link property="http://schema.org/isPartOf" href="http://auto.schema.org" />
         <span class="h" property="rdfs:label">roofLoad</span>
-        <span property="rdfs:comment">The permitted total weight of cargo and installations (e.g. a roof rack) on top of the vehicle.&lt;br /&gt;
-    Typical unit code(s): KGM for kilogram, LBR for pound&lt;br /&gt;
-
-    Note 1: You can indicate additional information in the &lt;a href=&quot;name&quot;&gt;name&lt;/a&gt; of the &lt;a href=&quot;QuantitativeValue&quot;&gt;QuantitativeValue&lt;/a&gt; node.&lt;br /&gt;
-    Note 2: You may also link to a &lt;a href=&quot;QualitativeValue&quot;&gt;QualitativeValue&lt;/a&gt; node that provides additional information using &lt;a href=&quot;valueReference&quot;&gt;valueReference&lt;/a&gt;.&lt;br /&gt;
-    Note 3: Note that you can use &lt;a href=&quot;minValue&quot;&gt;minValue&lt;/a&gt; and &lt;a href=&quot;maxValue&quot;&gt;maxValue&lt;/a&gt; to indicate ranges.</span>
+        <span property="rdfs:comment">The permitted total weight of cargo and installations (e.g. a roof rack) on top of the vehicle.\n\nTypical unit code(s): KGM for kilogram, LBR for pound\n\n* Note 1: You can indicate additional information in the [[name]] of the [[QuantitativeValue]] node.\n* Note 2: You may also link to a [[QualitativeValue]] node that provides additional information using [[valueReference]]\n* Note 3: Note that you can use [[minValue]] and [[maxValue]] to indicate ranges.</span>
         <span>Domain: <a property="http://schema.org/domainIncludes" href="http://schema.org/Car">Car</a></span>
         <span>Domain: <a property="http://schema.org/domainIncludes" href="http://schema.org/BusOrCoach">BusOrCoach</a></span>
         <span>Range: <a property="http://schema.org/rangeIncludes" href="http://schema.org/QuantitativeValue">QuantitativeValue</a></span>
@@ -58,8 +51,7 @@
     <div typeof="rdf:Property" resource="http://schema.org/wheelbase">
         <link property="http://schema.org/isPartOf" href="http://auto.schema.org" />
         <span class="h" property="rdfs:label">wheelbase</span>
-        <span property="rdfs:comment">The distance between the centers of the front and rear wheels. &lt;br /&gt;
-    Typical unit code(s): CMT for centimeters, MTR for meters, INH for inches, FOT for foot/feet</span>
+        <span property="rdfs:comment">The distance between the centers of the front and rear wheels.\n\nTypical unit code(s): CMT for centimeters, MTR for meters, INH for inches, FOT for foot/feet</span>
         <span>Domain: <a property="http://schema.org/domainIncludes" href="http://schema.org/Vehicle">Vehicle</a></span>
         <span>Range: <a property="http://schema.org/rangeIncludes" href="http://schema.org/QuantitativeValue">QuantitativeValue</a></span>
         <span>Source:  <a property="dc:source" href="http://www.w3.org/wiki/WebSchemas/SchemaDotOrgSources#Automotive_Ontology_Working_Group">GAO</a></span>
@@ -67,13 +59,7 @@
     <div typeof="rdf:Property" resource="http://schema.org/payload">
         <link property="http://schema.org/isPartOf" href="http://auto.schema.org" />
         <span class="h" property="rdfs:label">payload</span>
-        <span property="rdfs:comment">The permitted weight of passengers and cargo, EXCLUDING the weight of the empty vehicle. &lt;br /&gt;
-    Typical unit code(s): KGM for kilogram, LBR for pound&lt;br /&gt;
-
-    Note 1: Many databases specify the permitted TOTAL weight instead, which is the sum of &lt;a href=&quot;weight&quot;&gt;weight&lt;/a&gt; and &lt;a href=&quot;payload&quot;&gt;payload&lt;/a&gt;.&lt;br /&gt;
-    Note 2: You can indicate additional information in the &lt;a href=&quot;name&quot;&gt;name&lt;/a&gt; of the &lt;a href=&quot;QuantitativeValue&quot;&gt;QuantitativeValue&lt;/a&gt; node.&lt;br /&gt;
-    Note 3: You may also link to a &lt;a href=&quot;QualitativeValue&quot;&gt;QualitativeValue&lt;/a&gt; node that provides additional information using &lt;a href=&quot;valueReference&quot;&gt;valueReference&lt;/a&gt;.&lt;br /&gt;
-    Note 4: Note that you can use &lt;a href=&quot;minValue&quot;&gt;minValue&lt;/a&gt; and &lt;a href=&quot;maxValue&quot;&gt;maxValue&lt;/a&gt; to indicate ranges.</span>
+        <span property="rdfs:comment">The permitted weight of passengers and cargo, EXCLUDING the weight of the empty vehicle.\n\nTypical unit code(s): KGM for kilogram, LBR for pound\n\n* Note 1: Many databases specify the permitted TOTAL weight instead, which is the sum of [[weight]] and [[payload]]\n* Note 2: You can indicate additional information in the [[name]] of the [[QuantitativeValue]] node.\n* Note 3: You may also link to a [[QualitativeValue]] node that provides additional information using [[valueReference]].\n* Note 4: Note that you can use [[minValue]] and [[maxValue]] to indicate ranges.</span>
         <span>Domain: <a property="http://schema.org/domainIncludes" href="http://schema.org/Vehicle">Vehicle</a></span>
         <span>Range: <a property="http://schema.org/rangeIncludes" href="http://schema.org/QuantitativeValue">QuantitativeValue</a></span>
         <span>Source:  <a property="dc:source" href="http://www.w3.org/wiki/WebSchemas/SchemaDotOrgSources#Automotive_Ontology_Working_Group">GAO</a></span>
@@ -81,12 +67,7 @@
     <div typeof="rdf:Property" resource="http://schema.org/weightTotal">
         <link property="http://schema.org/isPartOf" href="http://auto.schema.org" />
         <span class="h" property="rdfs:label">weightTotal</span>
-        <span property="rdfs:comment">The permitted total weight of the loaded vehicle, including passengers and cargo and the weight of the empty vehicle.&lt;br /&gt;
-    Typical unit code(s): KGM for kilogram, LBR for pound&lt;br /&gt;
-
-    Note 1: You can indicate additional information in the &lt;a href=&quot;name&quot;&gt;name&lt;/a&gt; of the &lt;a href=&quot;QuantitativeValue&quot;&gt;QuantitativeValue&lt;/a&gt; node.&lt;br /&gt;
-    Note 2: You may also link to a &lt;a href=&quot;QualitativeValue&quot;&gt;QualitativeValue&lt;/a&gt; node that provides additional information using &lt;a href=&quot;valueReference&quot;&gt;valueReference&lt;/a&gt;.&lt;br /&gt;
-    Note 3: Note that you can use &lt;a href=&quot;minValue&quot;&gt;minValue&lt;/a&gt; and &lt;a href=&quot;maxValue&quot;&gt;maxValue&lt;/a&gt; to indicate ranges.</span>
+        <span property="rdfs:comment">The permitted total weight of the loaded vehicle, including passengers and cargo and the weight of the empty vehicle.\n\nTypical unit code(s): KGM for kilogram, LBR for pound\n\n* Note 1: You can indicate additional information in the [[name]] of the [[QuantitativeValue]] node.\n* Note 2: You may also link to a [[QualitativeValue]] node that provides additional information using [[valueReference]].\n* Note 3: Note that you can use [[minValue]] and [[maxValue]] to indicate ranges.</span>
         <span>Domain: <a property="http://schema.org/domainIncludes" href="http://schema.org/Vehicle">Vehicle</a></span>
         <span>Range: <a property="http://schema.org/rangeIncludes" href="http://schema.org/QuantitativeValue">QuantitativeValue</a></span>
         <span>Source:  <a property="dc:source" href="http://www.w3.org/wiki/WebSchemas/SchemaDotOrgSources#Automotive_Ontology_Working_Group">GAO</a></span>
@@ -94,11 +75,7 @@
     <div typeof="rdf:Property" resource="http://schema.org/engineDisplacement">
         <link property="http://schema.org/isPartOf" href="http://auto.schema.org" />
         <span class="h" property="rdfs:label">engineDisplacement</span>
-        <span property="rdfs:comment">The volume swept by all of the pistons inside the cylinders of an internal combustion engine in a single movement. &lt;br /&gt;
-    Typical unit code(s): CMQ for cubic centimeter, LTR for liters, INQ for cubic inches&lt;br /&gt;
-
-    Note 1: You can link to information about how the given value has been determined using the &lt;a href=&quot;valueReference&quot;&gt;valueReference&lt;/a&gt; property.&lt;br /&gt;
-    Note 2: You can use &lt;a href=&quot;minValue&quot;&gt;minValue&lt;/a&gt; and &lt;a href=&quot;maxValue&quot;&gt;maxValue&lt;/a&gt; to indicate ranges.</span>
+        <span property="rdfs:comment">The volume swept by all of the pistons inside the cylinders of an internal combustion engine in a single movement. \n\nTypical unit code(s): CMQ for cubic centimeter, LTR for liters, INQ for cubic inches\n* Note 1: You can link to information about how the given value has been determined using the [[valueReference]] property.\n* Note 2: You can use [[minValue]] and [[maxValue]] to indicate ranges.</span>
         <span>Domain: <a property="http://schema.org/domainIncludes" href="http://schema.org/EngineSpecification">EngineSpecification</a></span>
         <span>Range: <a property="http://schema.org/rangeIncludes" href="http://schema.org/QuantitativeValue">QuantitativeValue</a></span>
         <span>Source:  <a property="dc:source" href="http://www.w3.org/wiki/WebSchemas/SchemaDotOrgSources#Automotive_Ontology_Working_Group">GAO</a></span>
@@ -116,12 +93,7 @@
     <div typeof="rdf:Property" resource="http://schema.org/tongueWeight">
         <link property="http://schema.org/isPartOf" href="http://auto.schema.org" />
         <span class="h" property="rdfs:label">tongueWeight</span>
-        <span property="rdfs:comment">The permitted vertical load (TWR) of a trailer attached to the vehicle. Also referred to as Tongue Load Rating (TLR) or Vertical Load Rating (VLR).&lt;br /&gt;
-        Typical unit code(s): KGM for kilogram, LBR for pound&lt;br /&gt;
-
-    Note 1: You can indicate additional information in the &lt;a href=&quot;name&quot;&gt;name&lt;/a&gt; of the &lt;a href=&quot;QuantitativeValue&quot;&gt;QuantitativeValue&lt;/a&gt; node.&lt;br /&gt;
-    Note 2: You may also link to a &lt;a href=&quot;QualitativeValue&quot;&gt;QualitativeValue&lt;/a&gt; node that provides additional information using &lt;a href=&quot;valueReference&quot;&gt;valueReference&lt;/a&gt;.&lt;br /&gt;
-    Note 3: Note that you can use &lt;a href=&quot;minValue&quot;&gt;minValue&lt;/a&gt; and &lt;a href=&quot;maxValue&quot;&gt;maxValue&lt;/a&gt; to indicate ranges.</span>
+        <span property="rdfs:comment">The permitted vertical load (TWR) of a trailer attached to the vehicle. Also referred to as Tongue Load Rating (TLR) or Vertical Load Rating (VLR)\n\nTypical unit code(s): KGM for kilogram, LBR for pound\n\n* Note 1: You can indicate additional information in the [[name]] of the [[QuantitativeValue]] node.\n* Note 2: You may also link to a [[QualitativeValue]] node that provides additional information using [[valueReference]].\n* Note 3: Note that you can use [[minValue]] and [[maxValue]] to indicate ranges.</span>
         <span>Domain: <a property="http://schema.org/domainIncludes" href="http://schema.org/Vehicle">Vehicle</a></span>
         <span>Range: <a property="http://schema.org/rangeIncludes" href="http://schema.org/QuantitativeValue">QuantitativeValue</a></span>
         <span>Source:  <a property="dc:source" href="http://www.w3.org/wiki/WebSchemas/SchemaDotOrgSources#Automotive_Ontology_Working_Group">GAO</a></span>
@@ -129,11 +101,7 @@
     <div typeof="rdf:Property" resource="http://schema.org/speed">
         <link property="http://schema.org/isPartOf" href="http://auto.schema.org" />
         <span class="h" property="rdfs:label">speed</span>
-        <span property="rdfs:comment">The speed range of the vehicle. If the vehicle is powered by an engine, the upper limit of the speed range (indicated by &lt;a href=&quot;maxValue&quot;&gt;maxValue&lt;/a&gt;) should be the maximum speed achievable under regular conditions.&lt;br /&gt;
-    Typical unit code(s): KMH for km/h, HM for mile per hour (0.447 04 m/s), KNT for knot&lt;br /&gt;
-
-    Note 1: Use &lt;a href=&quot;minValue&quot;&gt;minValue&lt;/a&gt; and &lt;a href=&quot;maxValue&quot;&gt;maxValue&lt;/a&gt; to indicate the range. Typically, the minimal value is zero.&lt;br /&gt;
-    Note 2: There are many different ways of measuring the speed range. You can link to information about how the given value has been determined using the &lt;a href=&quot;valueReference&quot;&gt;valueReference&lt;/a&gt; property.</span>
+        <span property="rdfs:comment">The speed range of the vehicle. If the vehicle is powered by an engine, the upper limit of the speed range (indicated by [[maxValue]] should be the maximum speed achievable under regular conditions.\n\nTypical unit code(s): KMH for km/h, HM for mile per hour (0.447 04 m/s), KNT for knot\n\n*Note 1: Use [[minValue]] and [[maxValue]] to indicate the range. Typically, the minimal value is zero.\n* Note 2: There are many different ways of measuring the speed range. You can link to information about how the given value has been determined using the [[valueReference]] property.</span>
         <span>Domain: <a property="http://schema.org/domainIncludes" href="http://schema.org/Vehicle">Vehicle</a></span>
         <span>Range: <a property="http://schema.org/rangeIncludes" href="http://schema.org/QuantitativeValue">QuantitativeValue</a></span>
         <span>Source:  <a property="dc:source" href="http://www.w3.org/wiki/WebSchemas/SchemaDotOrgSources#Automotive_Ontology_Working_Group">GAO</a></span>
@@ -162,8 +130,7 @@
     <div typeof="rdf:Property" resource="http://schema.org/seatingCapacity">
         <link property="http://schema.org/isPartOf" href="http://auto.schema.org" />
         <span class="h" property="rdfs:label">seatingCapacity</span>
-        <span property="rdfs:comment">The number of persons that can be seated (e.g. in a vehicle), both in terms of the physical space available, and in terms of limitations set by law.&lt;br /&gt;
-    Typical unit code(s): C62 for persons </span>
+        <span property="rdfs:comment">The number of persons that can be seated (e.g. in a vehicle), both in terms of the physical space available, and in terms of limitations set by law.\n\nTypical unit code(s): C62 for persons </span>
         <span>Domain: <a property="http://schema.org/domainIncludes" href="http://schema.org/Vehicle">Vehicle</a></span>
         <span>Range: <a property="http://schema.org/rangeIncludes" href="http://schema.org/QuantitativeValue">QuantitativeValue</a></span>
         <span>Range: <a property="http://schema.org/rangeIncludes" href="http://schema.org/Number">Number</a></span>
@@ -172,12 +139,7 @@
     <div typeof="rdf:Property" resource="http://schema.org/trailerWeight">
         <link property="http://schema.org/isPartOf" href="http://auto.schema.org" />
         <span class="h" property="rdfs:label">trailerWeight</span>
-        <span property="rdfs:comment">The permitted weight of a trailer attached to the vehicle.&lt;br /&gt;
-    Typical unit code(s): KGM for kilogram, LBR for pound&lt;br /&gt;
-
-    Note 1: You can indicate additional information in the &lt;a href=&quot;name&quot;&gt;name&lt;/a&gt; of the &lt;a href=&quot;QuantitativeValue&quot;&gt;QuantitativeValue&lt;/a&gt; node.&lt;br /&gt;
-    Note 2: You may also link to a &lt;a href=&quot;QualitativeValue&quot;&gt;QualitativeValue&lt;/a&gt; node that provides additional information using &lt;a href=&quot;valueReference&quot;&gt;valueReference&lt;/a&gt;.&lt;br /&gt;
-    Note 3: Note that you can use &lt;a href=&quot;minValue&quot;&gt;minValue&lt;/a&gt; and &lt;a href=&quot;maxValue&quot;&gt;maxValue&lt;/a&gt; to indicate ranges.</span>
+        <span property="rdfs:comment">The permitted weight of a trailer attached to the vehicle.\n\nTypical unit code(s): KGM for kilogram, LBR for pound\n* Note 1: You can indicate additional information in the [[name]] of the [[QuantitativeValue]] node.\n* Note 2: You may also link to a [[QualitativeValue]] node that provides additional information using [[valueReference]].\n* Note 3: Note that you can use [[minValue]] and [[maxValue]] to indicate ranges.</span>
         <span>Domain: <a property="http://schema.org/domainIncludes" href="http://schema.org/Vehicle">Vehicle</a></span>
         <span>Range: <a property="http://schema.org/rangeIncludes" href="http://schema.org/QuantitativeValue">QuantitativeValue</a></span>
         <span>Source:  <a property="dc:source" href="http://www.w3.org/wiki/WebSchemas/SchemaDotOrgSources#Automotive_Ontology_Working_Group">GAO</a></span>
@@ -185,10 +147,7 @@
     <div typeof="rdf:Property" resource="http://schema.org/accelerationTime">
         <link property="http://schema.org/isPartOf" href="http://auto.schema.org" />
         <span class="h" property="rdfs:label">accelerationTime</span>
-        <span property="rdfs:comment">The time needed to accelerate the vehicle from a given start velocity to a given target velocity.&lt;br /&gt;
-    Typical unit code(s): SEC for seconds&lt;br /&gt;
-
-    Note: There are unfortunately no standard unit codes for seconds/0..100 km/h or seconds/0..60 mph. Simply use "SEC" for seconds and indicate the velocities in the &lt;a href=&quot;name&quot;&gt;name&lt;/a&gt; of the &lt;a href=&quot;QuantitativeValue&quot;&gt;QuantitativeValue&lt;/a&gt;, or use &lt;a href=&quot;valueReference&quot;&gt;valueReference&lt;/a&gt; with a &lt;a href=&quot;QuantitativeValue&quot;&gt;QuantitativeValue&lt;/a&gt; of 0..60 mph or 0..100 km/h to specify the reference speeds.</span>
+        <span property="rdfs:comment">The time needed to accelerate the vehicle from a given start velocity to a given target velocity.\n\nTypical unit code(s): SEC for seconds\n\n* Note: There are unfortunately no standard unit codes for seconds/0..100 km/h or seconds/0..60 mph. Simply use "SEC" for seconds and indicate the velocities in the [[name]] of the [[QuantitativeValue]], or use [[valueReference]] with a [[QuantitativeValue]] of 0..60 mph or 0..100 km/h to specify the reference speeds.</span>
         <span>Domain: <a property="http://schema.org/domainIncludes" href="http://schema.org/Vehicle">Vehicle</a></span>
         <span>Range: <a property="http://schema.org/rangeIncludes" href="http://schema.org/QuantitativeValue">QuantitativeValue</a></span>
         <span>Source:  <a property="dc:source" href="http://www.w3.org/wiki/WebSchemas/SchemaDotOrgSources#Automotive_Ontology_Working_Group">GAO</a></span>
@@ -197,11 +156,7 @@
         <link property="http://schema.org/isPartOf" href="http://auto.schema.org" />
         <span class="h" property="rdfs:label">enginePower</span>
         <span property="rdfs:comment">The power of the vehicle's engine.
-    Typical unit code(s): KWT for kilowatt, BHP for brake horsepower, N12 for metric horsepower (PS, with 1 PS = 735,49875 W) &lt;br /&gt;
-
-    Note 1: There are many different ways of measuring an engine's power. For an overview, see  http://en.wikipedia.org/wiki/Horsepower#Engine_power_test_codes. &lt;br /&gt;
-    Note 2: You can link to information about how the given value has been determined using the &lt;a href=&quot;valueReference&quot;&gt;valueReference&lt;/a&gt; property.&lt;br /&gt;
-    Note 3: You can use &lt;a href=&quot;minValue&quot;&gt;minValue&lt;/a&gt; and &lt;a href=&quot;maxValue&quot;&gt;maxValue&lt;/a&gt; to indicate ranges.</span>
+    Typical unit code(s): KWT for kilowatt, BHP for brake horsepower, N12 for metric horsepower (PS, with 1 PS = 735,49875 W)\n\n* Note 1: There are many different ways of measuring an engine's power. For an overview, see  [http://en.wikipedia.org/wiki/Horsepower#Engine_power_test_codes](http://en.wikipedia.org/wiki/Horsepower#Engine_power_test_codes).\n* Note 2: You can link to information about how the given value has been determined using the [[valueReference]] property.\n* Note 3: You can use [[minValue]] and [[maxValue]] to indicate ranges.</span>
         <span>Domain: <a property="http://schema.org/domainIncludes" href="http://schema.org/EngineSpecification">EngineSpecification</a></span>
         <span>Range: <a property="http://schema.org/rangeIncludes" href="http://schema.org/QuantitativeValue">QuantitativeValue</a></span>
         <span>Source:  <a property="dc:source" href="http://www.w3.org/wiki/WebSchemas/SchemaDotOrgSources#Automotive_Ontology_Working_Group">GAO</a></span>
@@ -234,11 +189,7 @@
     <div typeof="rdf:Property" resource="http://schema.org/torque">
         <link property="http://schema.org/isPartOf" href="http://auto.schema.org" />
         <span class="h" property="rdfs:label">torque</span>
-        <span property="rdfs:comment">The torque (turning force) of the vehicle's engine.&lt;br /&gt;
-        Typical unit code(s): NU for newton metre (N m), F17 for pound-force per foot, or F48 for pound-force per inch&lt;br /&gt;
-
-    Note 1: You can link to information about how the given value has been determined (e.g. reference RPM) using the &lt;a href=&quot;valueReference&quot;&gt;valueReference&lt;/a&gt; property.&lt;br /&gt;
-    Note 2: You can use &lt;a href=&quot;minValue&quot;&gt;minValue&lt;/a&gt; and &lt;a href=&quot;maxValue&quot;&gt;maxValue&lt;/a&gt; to indicate ranges.</span>
+        <span property="rdfs:comment">The torque (turning force) of the vehicle's engine.\n\nTypical unit code(s): NU for newton metre (N m), F17 for pound-force per foot, or F48 for pound-force per inch\n\n* Note 1: You can link to information about how the given value has been determined (e.g. reference RPM) using the [[valueReference]] property.\n* Note 2: You can use [[minValue]] and [[maxValue]] to indicate ranges.</span>
         <span>Domain: <a property="http://schema.org/domainIncludes" href="http://schema.org/EngineSpecification">EngineSpecification</a></span>
         <span>Range: <a property="http://schema.org/rangeIncludes" href="http://schema.org/QuantitativeValue">QuantitativeValue</a></span>
         <span>Source:  <a property="dc:source" href="http://www.w3.org/wiki/WebSchemas/SchemaDotOrgSources#Automotive_Ontology_Working_Group">GAO</a></span>

--- a/data/schema.rdfa
+++ b/data/schema.rdfa
@@ -117,46 +117,21 @@
 
     <div typeof="rdfs:Class" resource="http://schema.org/ProfessionalService">
       <span class="h" property="rdfs:label">ProfessionalService</span>
-      <span property="rdfs:comment">Original definition: "provider of professional services."
-        &lt;br&gt;&lt;br&gt;
-        The general &lt;a href=&quot;/ProfessionalService&quot;&gt;ProfessionalService&lt;/a&gt; type
-        for local businesses was deprecated due to confusion with &lt;a href=&quot;/Service&quot;&gt;Service&lt;/a&gt;.
-        For reference, the types that it included were: &lt;a href=&quot;/Dentist&quot;&gt;Dentist&lt;/a&gt;,
-        &lt;a href=&quot;/AccountingService&quot;&gt;AccountingService&lt;/a&gt;,
-        &lt;a href=&quot;/Attorney&quot;&gt;Attorney&lt;/a&gt;,
-        &lt;a href=&quot;/Notary&quot;&gt;Notary&lt;/a&gt;, as well as types for several kinds of
-        &lt;a href=&quot;/HomeAndConstructionBusiness&quot;&gt;HomeAndConstructionBusiness&lt;/a&gt;:
-        &lt;a href=&quot;/Electrician&quot;&gt;Electrician&lt;/a&gt;,
-        &lt;a href=&quot;/GeneralContractor&quot;&gt;GeneralContractor&lt;/a&gt;,
-        &lt;a href=&quot;/HousePainter&quot;&gt;HousePainter&lt;/a&gt;,
-        &lt;a href=&quot;/Locksmith&quot;&gt;Locksmith&lt;/a&gt;,
-        &lt;a href=&quot;/Plumber&quot;&gt;Plumber&lt;/a&gt;,
-        &lt;a href=&quot;/Plumber&quot;&gt;RoofingContractor&lt;/a&gt;.
-        &lt;a href=&quot;/LegalService&quot;&gt;LegalService&lt;/a&gt; was introduced as a more
-        inclusive supertype of &lt;a href=&quot;/Attorney&quot;&gt;Attorney&lt;/a&gt;.
-
-      </span>
+      <span property="rdfs:comment">Original definition: "provider of professional services."\n\nThe general [[ProfessionalService]] type for local businesses was deprecated due to confusion with [[Service]]. For reference, the types that it included were: [[Dentist]],
+        [[AccountingService]], [[Attorney]], [[Notary]], as well as types for several kinds of [[HomeAndConstructionBusiness]]: [[Electrician]], [[GeneralContractor]],
+        [[HousePainter]], [[Locksmith]], [[Plumber]], [[RoofingContractor]]. [[LegalService]] was introduced as a more inclusive supertype of [[Attorney]].</span>
        <span>Subclass of: <a property="rdfs:subClassOf" href="http://schema.org/LocalBusiness">LocalBusiness</a></span>
     </div>
 
     <div typeof="rdfs:Class" resource="http://schema.org/LegalService">
       <span class="h" property="rdfs:label">LegalService</span>
-      <span property="rdfs:comment">A LegalService is a business that provides legally-oriented services, advice and representation, e.g. law firms.
-        &lt;br&gt;&lt;br&gt;
-        As a &lt;a href=&quot;/LocalBusiness&quot;&gt;LocalBusiness&lt;/a&gt; it can be
-        described as a &lt;a href=&quot;/provider&quot;&gt;provider&lt;/a&gt; of one or more
-        &lt;a href=&quot;/Service&quot;&gt;Service(s)&lt;/a&gt;.
-      </span>
+      <span property="rdfs:comment">A LegalService is a business that provides legally-oriented services, advice and representation, e.g. law firms.\n\nAs a [[LocalBusiness]] it can be described as a [[provider]] of one or more [[Service]]\(s).</span>
        <span>Subclass of: <a property="rdfs:subClassOf" href="http://schema.org/LocalBusiness">LocalBusiness</a></span>
     </div>
 
     <div typeof="rdfs:Class" resource="http://schema.org/AccountingService">
       <span class="h" property="rdfs:label">AccountingService</span>
-      <span property="rdfs:comment">Accountancy business.
-        &lt;br&gt;&lt;br&gt;
-        As a &lt;a href=&quot;/LocalBusiness&quot;&gt;LocalBusiness&lt;/a&gt; it can be
-        described as a &lt;a href=&quot;/provider&quot;&gt;provider&lt;/a&gt; of one or more
-        &lt;a href=&quot;/Service&quot;&gt;Service(s)&lt;/a&gt;.
+      <span property="rdfs:comment">Accountancy business.\n\nAs a [[LocalBusiness]] it can be described as a [[provider]] of one or more [[Service]]\(s).
       </span>
        <span>Subclass of: <a property="rdfs:subClassOf" href="http://schema.org/FinancialService">FinancialService</a></span>
     </div>
@@ -181,18 +156,13 @@
 
     <div typeof="rdfs:Class" resource="http://schema.org/Intangible">
       <span class="h" property="rdfs:label">Intangible</span>
-      <span property="rdfs:comment">A utility class that serves as the umbrella for a number of &#39;intangible&#39; things such as quantities, structured values, etc.</span>
+      <span property="rdfs:comment">A utility class that serves as the umbrella for a number of 'intangible' things such as quantities, structured values, etc.</span>
        <span>Subclass of: <a property="rdfs:subClassOf" href="http://schema.org/Thing">Thing</a></span>
     </div>
 
     <div typeof="rdfs:Class" resource="http://schema.org/Offer">
       <span class="h" property="rdfs:label">Offer</span>
-      <span property="rdfs:comment">An offer to transfer some rights to an item or to provide a service&amp;#x2014;for example, an offer to sell tickets to an event, to rent the DVD of a movie, to stream a TV show over the internet, to repair a motorcycle, or to loan a book.
-      &lt;br/&gt;&lt;br/&gt;
-      For &lt;a href="http://www.gs1.org/barcodes/technical/idkeys/gtin"&gt;GTIN&lt;/a&gt;-related fields, see
-      &lt;a href="http://www.gs1.org/barcodes/support/check_digit_calculator"&gt;Check Digit calculator&lt;/a&gt;
-      and &lt;a href="http://www.gs1us.org/resources/standards/gtin-validation-guide"&gt;validation guide&lt;/a&gt;
-      from &lt;a href="http://www.gs1.org/"&gt;GS1&lt;/a&gt;.</span>
+      <span property="rdfs:comment">An offer to transfer some rights to an item or to provide a service — for example, an offer to sell tickets to an event, to rent the DVD of a movie, to stream a TV show over the internet, to repair a motorcycle, or to loan a book.\n\nFor [GTIN](http://www.gs1.org/barcodes/technical/idkeys/gtin)-related fields, see [Check Digit calculator](http://www.gs1.org/barcodes/support/check_digit_calculator) and [validation guide](http://www.gs1us.org/resources/standards/gtin-validation-guide) from [GS1](http://www.gs1.org/).</span>
        <span>Subclass of: <a property="rdfs:subClassOf" href="http://schema.org/Intangible">Intangible</a></span>
        <span>Source:  <a property="dc:source" href="http://www.w3.org/wiki/WebSchemas/SchemaDotOrgSources#source_GoodRelationsTerms">GoodRelationsProperties</a></span>
     </div>
@@ -266,19 +236,14 @@
 
     <div typeof="rdfs:Class" resource="http://schema.org/Article">
       <span class="h" property="rdfs:label">Article</span>
-      <span property="rdfs:comment">An article, such as a news article or piece of investigative report. Newspapers and magazines have articles of many different types and this is intended to cover them all.
-
-      &lt;br/&gt;&lt;br/&gt;See also &lt;a href="http://blog.schema.org/2014/09/schemaorg-support-for-bibliographic_2.html"&gt;blog post&lt;/a&gt;.</span>
+      <span property="rdfs:comment">An article, such as a news article or piece of investigative report. Newspapers and magazines have articles of many different types and this is intended to cover them all.\n\nSee also [blog post](http://blog.schema.org/2014/09/schemaorg-support-for-bibliographic_2.html).</span>
        <span>Subclass of: <a property="rdfs:subClassOf" href="http://schema.org/CreativeWork">CreativeWork</a></span>
        <span>Source:  <a property="dc:source" href="http://www.w3.org/wiki/WebSchemas/SchemaDotOrgSources#source_rNews">rNews</a></span>
     </div>
 
     <div typeof="rdfs:Class" resource="http://schema.org/Attorney">
       <span class="h" property="rdfs:label">Attorney</span>
-      <span property="rdfs:comment">Professional service: Attorney. &lt;br&gt;&lt;br&gt;
-        This type is deprecated - &lt;a href=&quot;/LegalService&quot;&gt;LegalService&lt;/a&gt; is more inclusive and less ambiguous.
-
-      </span>
+      <span property="rdfs:comment">Professional service: Attorney. \n\nThis type is deprecated - [[LegalService]] is more inclusive and less ambiguous.</span>
        <span>Subclass of: <a property="rdfs:subClassOf" href="http://schema.org/LegalService">LegalService</a></span>
     </div>
 
@@ -558,7 +523,7 @@
 
     <div typeof="rdfs:Class" resource="http://schema.org/Event">
       <span class="h" property="rdfs:label">Event</span>
-      <span property="rdfs:comment">An event happening at a certain time and location, such as a concert, lecture, or festival. Ticketing information may be added via the &#39;offers&#39; property. Repeated events may be structured as separate Event objects.</span>
+      <span property="rdfs:comment">An event happening at a certain time and location, such as a concert, lecture, or festival. Ticketing information may be added via the [[offers]] property. Repeated events may be structured as separate Event objects.</span>
        <span>Subclass of: <a property="rdfs:subClassOf" href="http://schema.org/Thing">Thing</a></span>
        <link property="owl:equivalentClass" href="http://purl.org/dc/dcmitype/Event"/>
     </div>
@@ -685,7 +650,7 @@
 
     <div typeof="rdfs:Class" resource="http://schema.org/Comment">
       <span class="h" property="rdfs:label">Comment</span>
-      <span property="rdfs:comment">A comment on an item - for example, a comment on a blog post. The comment&#39;s content is expressed via the &quot;text&quot; property, and its topic via &quot;about&quot;, properties shared with all CreativeWorks.</span>
+      <span property="rdfs:comment">A comment on an item - for example, a comment on a blog post. The comment&#39;s content is expressed via the [[text]] property, and its topic via [[about]], properties shared with all CreativeWorks.</span>
        <span>Subclass of: <a property="rdfs:subClassOf" href="http://schema.org/CreativeWork">CreativeWork</a></span>
     </div>
 
@@ -770,7 +735,7 @@
 
     <div typeof="rdfs:Class http://schema.org/DataType" resource="http://schema.org/Date">
       <span class="h" property="rdfs:label">Date</span>
-      <span property="rdfs:comment">A date value in &lt;a href=&#39;http://en.wikipedia.org/wiki/ISO_8601&#39;&gt;ISO 8601 date format&lt;/a&gt;.</span>
+      <span property="rdfs:comment">A date value in [ISO 8601 date format](http://en.wikipedia.org/wiki/ISO_8601).</span>
     </div>
 
     <div typeof="rdfs:Class http://schema.org/DataType" resource="http://schema.org/DateTime">
@@ -817,7 +782,7 @@
 
     <div typeof="rdfs:Class" resource="http://schema.org/Duration">
       <span class="h" property="rdfs:label">Duration</span>
-      <span property="rdfs:comment">Quantity: Duration (use  &lt;a href=&#39;http://en.wikipedia.org/wiki/ISO_8601&#39;&gt;ISO 8601 duration format&lt;/a&gt;).</span>
+      <span property="rdfs:comment">Quantity: Duration (use [ISO 8601 duration format](http://en.wikipedia.org/wiki/ISO_8601)).</span>
        <span>Subclass of: <a property="rdfs:subClassOf" href="http://schema.org/Quantity">Quantity</a></span>
     </div>
 
@@ -829,14 +794,7 @@
 
     <div typeof="rdfs:Class" resource="http://schema.org/HomeAndConstructionBusiness">
       <span class="h" property="rdfs:label">HomeAndConstructionBusiness</span>
-      <span property="rdfs:comment">A construction business.
-        &lt;br&gt;&lt;br&gt;
-        A HomeAndConstructionBusiness is a LocalBusiness that provides services around homes and buildings.
-          &lt;br&gt;&lt;br&gt;
-          As a &lt;a href=&quot;/LocalBusiness&quot;&gt;LocalBusiness&lt;/a&gt; it can be
-          described as a &lt;a href=&quot;/provider&quot;&gt;provider&lt;/a&gt; of one or more
-          &lt;a href=&quot;/Service&quot;&gt;Service(s)&lt;/a&gt;.
-      </span>
+      <span property="rdfs:comment">A construction business.\n\nA HomeAndConstructionBusiness is a [[LocalBusiness]] that provides services around homes and buildings.\n\nAs a [[LocalBusiness]] it can be described as a [[provider]] of one or more [[Service]]\(s).</span>
        <span>Subclass of: <a property="rdfs:subClassOf" href="http://schema.org/LocalBusiness">LocalBusiness</a></span>
     </div>
 
@@ -1191,15 +1149,7 @@
 
     <div typeof="rdfs:Class" resource="http://schema.org/BreadcrumbList">
       <span class="h" property="rdfs:label">BreadcrumbList</span>
-      <span property="rdfs:comment">
-      A BreadcrumbList is an ItemList consisting of a chain of linked Web pages, typically described using at least their URL and their name, and typically ending with the current page.
-      &lt;br /&gt;
-      &lt;br /&gt;
-      The 'position' property is used to reconstruct the order of the items in a BreadcrumbList.
-      The convention is that a breadcrumb list has an itemListOrder of ItemListOrderAscending (lower values listed first), and that the
-      first items in this list correspond to the "top" or beginning of the breadcrumb trail, e.g. with a site or section homepage.
-      The specific values of 'position' are not assigned meaning for a BreadcrumbList, but they should be integers, e.g. beginning
-      with '1' for the first item in the list.
+      <span property="rdfs:comment">A BreadcrumbList is an ItemList consisting of a chain of linked Web pages, typically described using at least their URL and their name, and typically ending with the current page.\n\nThe [[position]] property is used to reconstruct the order of the items in a BreadcrumbList The convention is that a breadcrumb list has an [[itemListOrder]] of [[ItemListOrderAscending]] (lower values listed first), and that the first items in this list correspond to the "top" or beginning of the breadcrumb trail, e.g. with a site or section homepage. The specific values of 'position' are not assigned meaning for a BreadcrumbList, but they should be integers, e.g. beginning with '1' for the first item in the list.
       </span>
        <span>Subclass of: <a property="rdfs:subClassOf" href="http://schema.org/ItemList">ItemList</a></span>
     </div>
@@ -1974,29 +1924,8 @@
 
     <div typeof="rdfs:Class" resource="http://schema.org/CreativeWorkSeries">
       <span class="h" property="rdfs:label">CreativeWorkSeries</span>
-      <span property="rdfs:comment">
-          A CreativeWorkSeries in schema.org is a group of related items, typically but not necessarily of the same kind.
-          CreativeWorkSeries are usually organized into some order, often chronological. Unlike &lt;a href="/ItemList"&gt;ItemList&lt;/a&gt; which
-          is a general purpose data structure for lists of things, the emphasis with
-          CreativeWorkSeries is on published materials (written e.g. books and periodicals,
-          or media such as tv, radio and games).
-
-          &lt;br/&gt;&lt;br/&gt;
-
-          Specific subtypes are available for describing &lt;a href="/TVSeries"&gt;TVSeries&lt;/a&gt;, &lt;a href="/RadioSeries"&gt;RadioSeries&lt;/a&gt;,
-          &lt;a href="/MovieSeries"&gt;MovieSeries&lt;/a&gt;,
-          &lt;a href="/BookSeries"&gt;BookSeries&lt;/a&gt;,
-          &lt;a href="/Periodical"&gt;Periodical&lt;/a&gt;
-          and &lt;a href="/VideoGameSeries"&gt;VideoGameSeries&lt;/a&gt;. In each case,
-          the &lt;a href="/hasPart"&gt;hasPart&lt;/a&gt; / &lt;a href="/isPartOf"&gt;isPartOf&lt;/a&gt; properties
-          can be used to relate the CreativeWorkSeries to its parts. The general CreativeWorkSeries type serves largely
-          just to organize these more specific and practical subtypes.
-
-          &lt;br/&gt;&lt;br/&gt;
-
-          It is common for properties applicable to an item from the series to be usefully applied to the containing group.
-          Schema.org attempts to anticipate some of these cases, but publishers should be free to apply
-          properties of the series parts to the series as a whole wherever they seem appropriate.</span>
+      <span property="rdfs:comment">A CreativeWorkSeries in schema.org is a group of related items, typically but not necessarily of the same kind. CreativeWorkSeries are usually organized into some order, often chronological. Unlike [[ItemList]] which is a general purpose data structure for lists of things, the emphasis with CreativeWorkSeries is on published materials (written e.g. books and periodicals, or media such as tv, radio and games).\n\nSpecific subtypes are available for describing [[TVSeries]], [[RadioSeries]], [[MovieSeries]], [[BookSeries]], [[Periodical]] and [[VideoGameSeries]]. In each case, the [[hasPart]] / [[isPartOf]] properties can be used to relate the CreativeWorkSeries to its parts. The general CreativeWorkSeries type serves largely just to organize these more specific and practical subtypes.\n\nIt is common for properties applicable to an item from the series to be usefully applied to the containing group. Schema.org attempts to anticipate some of these cases, but publishers should be free to apply properties of the series parts to the series as a whole wherever they seem appropriate.
+	  </span>
        <span>Subclass of: <a property="rdfs:subClassOf" href="http://schema.org/CreativeWork">CreativeWork</a></span>
     </div>
 
@@ -2009,7 +1938,7 @@
 
     <div typeof="rdfs:Class" resource="http://schema.org/VideoGameSeries">
       <span class="h" property="rdfs:label">VideoGameSeries</span>
-      <span property="rdfs:comment">A &lt;a href="/VideoGame"&gt;video game&lt;/a&gt; series.</span>
+      <span property="rdfs:comment">A video game series.</span>
        <span>Subclass of: <a property="rdfs:subClassOf" href="http://schema.org/CreativeWorkSeries">CreativeWorkSeries</a></span>
     </div>
 
@@ -2062,7 +1991,7 @@
 
     <div typeof="rdfs:Class http://schema.org/DataType" resource="http://schema.org/Time">
       <span class="h" property="rdfs:label">Time</span>
-      <span property="rdfs:comment">A point in time recurring on multiple days in the form hh:mm:ss[Z|(+|-)hh:mm] (see &lt;a href=&quot;http://www.w3.org/TR/xmlschema-2/#time&quot;&gt;XML schema for details&lt;/a&gt;).</span>
+      <span property="rdfs:comment">A point in time recurring on multiple days in the form hh:mm:ss[Z|(+|-)hh:mm] (see [XML schema for details](http://www.w3.org/TR/xmlschema-2/#time)).</span>
     </div>
 
     <div typeof="rdfs:Class" resource="http://schema.org/TireShop">
@@ -2110,98 +2039,71 @@
 
     <div typeof="rdfs:Class" resource="http://schema.org/UserInteraction">
       <span class="h" property="rdfs:label">UserInteraction</span>
-      <span property="rdfs:comment">UserInteraction and its subtypes is an old way of talking about users interacting with pages. It is generally better to use
-          &lt;a href="/Action"&gt;Action&lt;/a&gt;-based vocabulary, alongside types such as &lt;a href="/Comment"&gt;Comment&lt;/a&gt;.
-      </span>
+      <span property="rdfs:comment">UserInteraction and its subtypes is an old way of talking about users interacting with pages. It is generally better to use [[Action]]-based vocabulary, alongside types such as [[Comment]].</span>
 	  <span>Subclass of: <a property="rdfs:subClassOf" href="http://schema.org/Event">Event</a></span>
       <link property="http://schema.org/supersededBy" href="http://schema.org/InteractionCounter"/>
    </div>
 
     <div typeof="rdfs:Class" resource="http://schema.org/UserBlocks">
       <span class="h" property="rdfs:label">UserBlocks</span>
-      <span property="rdfs:comment">UserInteraction and its subtypes is an old way of talking about users interacting with pages. It is generally better to use
-          &lt;a href="/Action"&gt;Action&lt;/a&gt;-based vocabulary, alongside types such as &lt;a href="/Comment"&gt;Comment&lt;/a&gt;.
-      </span>
+      <span property="rdfs:comment">UserInteraction and its subtypes is an old way of talking about users interacting with pages. It is generally better to use [[Action]]-based vocabulary, alongside types such as [[Comment]].</span>
        <span>Subclass of: <a property="rdfs:subClassOf" href="http://schema.org/UserInteraction">UserInteraction</a></span>
       <link property="http://schema.org/supersededBy" href="http://schema.org/InteractionCounter"/>
     </div>
 
     <div typeof="rdfs:Class" resource="http://schema.org/UserCheckins">
       <span class="h" property="rdfs:label">UserCheckins</span>
-      <span property="rdfs:comment">UserInteraction and its subtypes is an old way of talking about users interacting with pages. It is generally better to use
-          &lt;a href="/Action"&gt;Action&lt;/a&gt;-based vocabulary, alongside types such as &lt;a href="/Comment"&gt;Comment&lt;/a&gt;.
-      </span>
+      <span property="rdfs:comment">UserInteraction and its subtypes is an old way of talking about users interacting with pages. It is generally better to use [[Action]]-based vocabulary, alongside types such as [[Comment]].</span>
        <span>Subclass of: <a property="rdfs:subClassOf" href="http://schema.org/UserInteraction">UserInteraction</a></span>
       <link property="http://schema.org/supersededBy" href="http://schema.org/InteractionCounter"/>
     </div>
 
     <div typeof="rdfs:Class" resource="http://schema.org/UserComments">
       <span class="h" property="rdfs:label">UserComments</span>
-
-      <span property="rdfs:comment">UserInteraction and its subtypes is an old way of talking about users interacting with pages. It is generally better to use
-          &lt;a href="/Action"&gt;Action&lt;/a&gt;-based vocabulary, alongside types such as &lt;a href="/Comment"&gt;Comment&lt;/a&gt;.
-      </span>
-
+      <span property="rdfs:comment">UserInteraction and its subtypes is an old way of talking about users interacting with pages. It is generally better to use [[Action]]-based vocabulary, alongside types such as [[Comment]].</span>
        <span>Subclass of: <a property="rdfs:subClassOf" href="http://schema.org/UserInteraction">UserInteraction</a></span>
       <link property="http://schema.org/supersededBy" href="http://schema.org/InteractionCounter"/>
-       <span>Source:  <a property="dc:source" href="http://www.w3.org/wiki/WebSchemas/SchemaDotOrgSources#source_rNews">rNews</a></span></div>
+       <span>Source:  <a property="dc:source" href="http://www.w3.org/wiki/WebSchemas/SchemaDotOrgSources#source_rNews">rNews</a></span>
+   </div>
 
     <div typeof="rdfs:Class" resource="http://schema.org/UserDownloads">
       <span class="h" property="rdfs:label">UserDownloads</span>
-
-      <span property="rdfs:comment">UserInteraction and its subtypes is an old way of talking about users interacting with pages. It is generally better to use
-          &lt;a href="/Action"&gt;Action&lt;/a&gt;-based vocabulary, alongside types such as &lt;a href="/Comment"&gt;Comment&lt;/a&gt;.
-      </span>
+      <span property="rdfs:comment">UserInteraction and its subtypes is an old way of talking about users interacting with pages. It is generally better to use [[Action]]-based vocabulary, alongside types such as [[Comment]].</span>
       <link property="http://schema.org/supersededBy" href="http://schema.org/InteractionCounter"/>
      <span>Subclass of: <a property="rdfs:subClassOf" href="http://schema.org/UserInteraction">UserInteraction</a></span>
     </div>
 
     <div typeof="rdfs:Class" resource="http://schema.org/UserLikes">
       <span class="h" property="rdfs:label">UserLikes</span>
-
-      <span property="rdfs:comment">UserInteraction and its subtypes is an old way of talking about users interacting with pages. It is generally better to use
-          &lt;a href="/Action"&gt;Action&lt;/a&gt;-based vocabulary, alongside types such as &lt;a href="/Comment"&gt;Comment&lt;/a&gt;.
-      </span>
+      <span property="rdfs:comment">UserInteraction and its subtypes is an old way of talking about users interacting with pages. It is generally better to use [[Action]]-based vocabulary, alongside types such as [[Comment]].</span>
       <link property="http://schema.org/supersededBy" href="http://schema.org/InteractionCounter"/>
       <span>Subclass of: <a property="rdfs:subClassOf" href="http://schema.org/UserInteraction">UserInteraction</a></span>
     </div>
 
     <div typeof="rdfs:Class" resource="http://schema.org/UserPageVisits">
       <span class="h" property="rdfs:label">UserPageVisits</span>
-
-      <span property="rdfs:comment">UserInteraction and its subtypes is an old way of talking about users interacting with pages. It is generally better to use
-          &lt;a href="/Action"&gt;Action&lt;/a&gt;-based vocabulary, alongside types such as &lt;a href="/Comment"&gt;Comment&lt;/a&gt;.
-      </span>
+      <span property="rdfs:comment">UserInteraction and its subtypes is an old way of talking about users interacting with pages. It is generally better to use [[Action]]-based vocabulary, alongside types such as [[Comment]].</span>
       <link property="http://schema.org/supersededBy" href="http://schema.org/InteractionCounter"/>
       <span>Subclass of: <a property="rdfs:subClassOf" href="http://schema.org/UserInteraction">UserInteraction</a></span>
     </div>
 
     <div typeof="rdfs:Class" resource="http://schema.org/UserPlays">
       <span class="h" property="rdfs:label">UserPlays</span>
-
-      <span property="rdfs:comment">UserInteraction and its subtypes is an old way of talking about users interacting with pages. It is generally better to use
-          &lt;a href="/Action"&gt;Action&lt;/a&gt;-based vocabulary, alongside types such as &lt;a href="/Comment"&gt;Comment&lt;/a&gt;.
-      </span>
+      <span property="rdfs:comment">UserInteraction and its subtypes is an old way of talking about users interacting with pages. It is generally better to use [[Action]]-based vocabulary, alongside types such as [[Comment]].</span>
       <link property="http://schema.org/supersededBy" href="http://schema.org/InteractionCounter"/>
       <span>Subclass of: <a property="rdfs:subClassOf" href="http://schema.org/UserInteraction">UserInteraction</a></span>
     </div>
 
     <div typeof="rdfs:Class" resource="http://schema.org/UserPlusOnes">
       <span class="h" property="rdfs:label">UserPlusOnes</span>
-
-      <span property="rdfs:comment">UserInteraction and its subtypes is an old way of talking about users interacting with pages. It is generally better to use
-          &lt;a href="/Action"&gt;Action&lt;/a&gt;-based vocabulary, alongside types such as &lt;a href="/Comment"&gt;Comment&lt;/a&gt;.
-      </span>
+      <span property="rdfs:comment">UserInteraction and its subtypes is an old way of talking about users interacting with pages. It is generally better to use [[Action]]-based vocabulary, alongside types such as [[Comment]].</span>
       <link property="http://schema.org/supersededBy" href="http://schema.org/InteractionCounter"/>
       <span>Subclass of: <a property="rdfs:subClassOf" href="http://schema.org/UserInteraction">UserInteraction</a></span>
     </div>
 
     <div typeof="rdfs:Class" resource="http://schema.org/UserTweets">
       <span class="h" property="rdfs:label">UserTweets</span>
-
-      <span property="rdfs:comment">UserInteraction and its subtypes is an old way of talking about users interacting with pages. It is generally better to use
-          &lt;a href="/Action"&gt;Action&lt;/a&gt;-based vocabulary, alongside types such as &lt;a href="/Comment"&gt;Comment&lt;/a&gt;.
-      </span>
+      <span property="rdfs:comment">UserInteraction and its subtypes is an old way of talking about users interacting with pages. It is generally better to use [[Action]]-based vocabulary, alongside types such as [[Comment]].</span>
       <link property="http://schema.org/supersededBy" href="http://schema.org/InteractionCounter"/>
       <span>Subclass of: <a property="rdfs:subClassOf" href="http://schema.org/UserInteraction">UserInteraction</a></span>
     </div>
@@ -2301,31 +2203,15 @@
 
     <div typeof="rdfs:Class" resource="http://schema.org/BusinessEntityType">
       <span class="h" property="rdfs:label">BusinessEntityType</span>
-      <span property="rdfs:comment">A business entity type is a conceptual entity representing the legal form, the size, the main line of business, the position in the value chain, or any combination thereof, of an organization or business person.
-&lt;br /&gt;
-    Commonly used values:&lt;br /&gt;
-&lt;br /&gt;
-    http://purl.org/goodrelations/v1#Business &lt;br /&gt;
-    http://purl.org/goodrelations/v1#Enduser &lt;br /&gt;
-    http://purl.org/goodrelations/v1#PublicInstitution &lt;br /&gt;
-    http://purl.org/goodrelations/v1#Reseller &lt;br /&gt;
-
-        </span>
+      <span property="rdfs:comment">A business entity type is a conceptual entity representing the legal form, the size, the main line of business, the position in the value chain, or any combination thereof, of an organization or business person.\n\nCommonly used values:\n\n* http://purl.org/goodrelations/v1#Business\n* http://purl.org/goodrelations/v1#Enduser\n* http://purl.org/goodrelations/v1#PublicInstitution\n* http://purl.org/goodrelations/v1#Reseller
+	  </span>
        <span>Subclass of: <a property="rdfs:subClassOf" href="http://schema.org/Enumeration">Enumeration</a></span>
        <span>Source:  <a property="dc:source" href="http://www.w3.org/wiki/WebSchemas/SchemaDotOrgSources#source_GoodRelationsClass">GoodRelationsClass</a></span>
     </div>
 
     <div typeof="rdfs:Class" resource="http://schema.org/CreditCard">
       <span class="h" property="rdfs:label">CreditCard</span>
-      <span property="rdfs:comment">A card payment method of a particular brand or name.  Used to mark up a particular payment method and/or the financial product/service that supplies the card account.&lt;br /&gt;
-    Commonly used values:&lt;br /&gt;
-&lt;br /&gt;
-    http://purl.org/goodrelations/v1#AmericanExpress &lt;br /&gt;
-    http://purl.org/goodrelations/v1#DinersClub &lt;br /&gt;
-    http://purl.org/goodrelations/v1#Discover &lt;br /&gt;
-    http://purl.org/goodrelations/v1#JCB &lt;br /&gt;
-    http://purl.org/goodrelations/v1#MasterCard &lt;br /&gt;
-    http://purl.org/goodrelations/v1#VISA &lt;br /&gt;
+      <span property="rdfs:comment">A card payment method of a particular brand or name.  Used to mark up a particular payment method and/or the financial product/service that supplies the card account.\n\nCommonly used values:\n\n* http://purl.org/goodrelations/v1#AmericanExpress\n* http://purl.org/goodrelations/v1#DinersClub\n* http://purl.org/goodrelations/v1#Discover\n* http://purl.org/goodrelations/v1#JCB\n* http://purl.org/goodrelations/v1#MasterCard\n* http://purl.org/goodrelations/v1#VISA
        </span>
        <span>Subclass of: <a property="rdfs:subClassOf" href="http://schema.org/PaymentCard">PaymentCard</a></span>
        <span>Subclass of: <a property="rdfs:subClassOf" href="http://schema.org/LoanOrCredit">LoanOrCredit</a></span>
@@ -2334,18 +2220,7 @@
 
     <div typeof="rdfs:Class" resource="http://schema.org/BusinessFunction">
       <span class="h" property="rdfs:label">BusinessFunction</span>
-      <span property="rdfs:comment">The business function specifies the type of activity or access (i.e., the bundle of rights) offered by the organization or business person through the offer. Typical are sell, rental or lease, maintenance or repair, manufacture / produce, recycle / dispose, engineering / construction, or installation. Proprietary specifications of access rights are also instances of this class.
-&lt;br /&gt;
-    Commonly used values:&lt;br /&gt;
-&lt;br /&gt;
-    http://purl.org/goodrelations/v1#ConstructionInstallation &lt;br /&gt;
-    http://purl.org/goodrelations/v1#Dispose &lt;br /&gt;
-    http://purl.org/goodrelations/v1#LeaseOut &lt;br /&gt;
-    http://purl.org/goodrelations/v1#Maintain &lt;br /&gt;
-    http://purl.org/goodrelations/v1#ProvideService &lt;br /&gt;
-    http://purl.org/goodrelations/v1#Repair &lt;br /&gt;
-    http://purl.org/goodrelations/v1#Sell &lt;br /&gt;
-    http://purl.org/goodrelations/v1#Buy &lt;br /&gt;
+      <span property="rdfs:comment">The business function specifies the type of activity or access (i.e., the bundle of rights) offered by the organization or business person through the offer. Typical are sell, rental or lease, maintenance or repair, manufacture / produce, recycle / dispose, engineering / construction, or installation. Proprietary specifications of access rights are also instances of this class.\n\nCommonly used values:\n\n* http://purl.org/goodrelations/v1#ConstructionInstallation\n* http://purl.org/goodrelations/v1#Dispose\n* http://purl.org/goodrelations/v1#LeaseOut\n* http://purl.org/goodrelations/v1#Maintain\n* http://purl.org/goodrelations/v1#ProvideService\n* http://purl.org/goodrelations/v1#Repair\n* http://purl.org/goodrelations/v1#Sell\n* http://purl.org/goodrelations/v1#Buy
         </span>
        <span>Subclass of: <a property="rdfs:subClassOf" href="http://schema.org/Enumeration">Enumeration</a></span>
        <span>Source:  <a property="dc:source" href="http://www.w3.org/wiki/WebSchemas/SchemaDotOrgSources#source_GoodRelationsClass">GoodRelationsClass</a></span>
@@ -2353,19 +2228,7 @@
 
     <div typeof="rdfs:Class" resource="http://schema.org/PaymentMethod">
       <span class="h" property="rdfs:label">PaymentMethod</span>
-      <span property="rdfs:comment">A payment method is a standardized procedure for transferring the monetary amount for a purchase. Payment methods are characterized by the legal and technical structures used, and by the organization or group carrying out the transaction.
-&lt;br /&gt;
-    Commonly used values:&lt;br /&gt;
-&lt;br /&gt;
-    http://purl.org/goodrelations/v1#ByBankTransferInAdvance &lt;br /&gt;
-    http://purl.org/goodrelations/v1#ByInvoice &lt;br /&gt;
-    http://purl.org/goodrelations/v1#Cash &lt;br /&gt;
-    http://purl.org/goodrelations/v1#CheckInAdvance &lt;br /&gt;
-    http://purl.org/goodrelations/v1#COD &lt;br /&gt;
-    http://purl.org/goodrelations/v1#DirectDebit &lt;br /&gt;
-    http://purl.org/goodrelations/v1#GoogleCheckout &lt;br /&gt;
-    http://purl.org/goodrelations/v1#PayPal &lt;br /&gt;
-    http://purl.org/goodrelations/v1#PaySwarm &lt;br /&gt;
+      <span property="rdfs:comment">A payment method is a standardized procedure for transferring the monetary amount for a purchase. Payment methods are characterized by the legal and technical structures used, and by the organization or group carrying out the transaction.\n\nCommonly used values:\n\n* http://purl.org/goodrelations/v1#ByBankTransferInAdvance\n* http://purl.org/goodrelations/v1#ByInvoice\n* http://purl.org/goodrelations/v1#Cash\n* http://purl.org/goodrelations/v1#CheckInAdvance\n* http://purl.org/goodrelations/v1#COD\n* http://purl.org/goodrelations/v1#DirectDebit\n* http://purl.org/goodrelations/v1#GoogleCheckout\n* http://purl.org/goodrelations/v1#PayPal\n* http://purl.org/goodrelations/v1#PaySwarm
         </span>
        <span>Subclass of: <a property="rdfs:subClassOf" href="http://schema.org/Enumeration">Enumeration</a></span>
        <span>Source:  <a property="dc:source" href="http://www.w3.org/wiki/WebSchemas/SchemaDotOrgSources#source_GoodRelationsClass">GoodRelationsClass</a></span>
@@ -2397,18 +2260,7 @@ Originally, URLs from [GoodRelations](http://purl.org/goodrelations/v1) were use
 
     <div typeof="rdfs:Class" resource="http://schema.org/DeliveryMethod">
       <span class="h" property="rdfs:label">DeliveryMethod</span>
-      <span property="rdfs:comment">A delivery method is a standardized procedure for transferring the product or service to the destination of fulfillment chosen by the customer. Delivery methods are characterized by the means of transportation used, and by the organization or group that is the contracting party for the sending organization or person.
-&lt;br /&gt;
-    Commonly used values:&lt;br /&gt;
-&lt;br /&gt;
-    http://purl.org/goodrelations/v1#DeliveryModeDirectDownload &lt;br /&gt;
-    http://purl.org/goodrelations/v1#DeliveryModeFreight &lt;br /&gt;
-    http://purl.org/goodrelations/v1#DeliveryModeMail &lt;br /&gt;
-    http://purl.org/goodrelations/v1#DeliveryModeOwnFleet &lt;br /&gt;
-    http://purl.org/goodrelations/v1#DeliveryModePickUp &lt;br /&gt;
-    http://purl.org/goodrelations/v1#DHL &lt;br /&gt;
-    http://purl.org/goodrelations/v1#FederalExpress &lt;br /&gt;
-    http://purl.org/goodrelations/v1#UPS &lt;br /&gt;
+      <span property="rdfs:comment">A delivery method is a standardized procedure for transferring the product or service to the destination of fulfillment chosen by the customer. Delivery methods are characterized by the means of transportation used, and by the organization or group that is the contracting party for the sending organization or person.\n\nCommonly used values:\n\n* http://purl.org/goodrelations/v1#DeliveryModeDirectDownload\n* http://purl.org/goodrelations/v1#DeliveryModeFreight\n* http://purl.org/goodrelations/v1#DeliveryModeMail\n* http://purl.org/goodrelations/v1#DeliveryModeOwnFleet\n* http://purl.org/goodrelations/v1#DeliveryModePickUp\n* http://purl.org/goodrelations/v1#DHL\n* http://purl.org/goodrelations/v1#FederalExpress\n* http://purl.org/goodrelations/v1#UPS
         </span>
        <span>Subclass of: <a property="rdfs:subClassOf" href="http://schema.org/Enumeration">Enumeration</a></span>
        <span>Source:  <a property="dc:source" href="http://www.w3.org/wiki/WebSchemas/SchemaDotOrgSources#source_GoodRelationsClass">GoodRelationsClass</a></span>
@@ -2430,11 +2282,8 @@ Originally, URLs from [GoodRelations](http://purl.org/goodrelations/v1) were use
 
     <div typeof="rdfs:Class" resource="http://schema.org/OpeningHoursSpecification">
       <span class="h" property="rdfs:label">OpeningHoursSpecification</span>
-      <span property="rdfs:comment">A structured value providing information about the opening hours of a place or a certain service inside a place.
-&lt;br /&gt;
-The place is &lt;b&gt;open&lt;/b&gt; if the &lt;a href=&quot;/opens&quot;&gt;opens&lt;/a&gt; property is specified, and &lt;b&gt;closed&lt;/b&gt; otherwise.
-&lt;br /&gt;
-If the value for the &lt;a href=&quot;/closes&quot;&gt;closes&lt;/a&gt; property is less than the value for the &lt;a href=&quot;/opens&quot;&gt;opens&lt;/a&gt; property then the hour range is assumed to span over the next day.
+      <span property="rdfs:comment">A structured value providing information about the opening hours of a place or a certain service inside a place.\n\n
+The place is __open__ if the [[opens]] property is specified, and __closed__ otherwise.\n\nIf the value for the [[closes]] property is less than the value for the [[opens]] property then the hour range is assumed to span over the next day.
       </span>
       <span>Subclass of: <a property="rdfs:subClassOf" href="http://schema.org/StructuredValue">StructuredValue</a></span>
       <span>Source:  <a property="dc:source" href="http://www.w3.org/wiki/WebSchemas/SchemaDotOrgSources#source_GoodRelationsClass">GoodRelationsClass</a></span>
@@ -2449,13 +2298,7 @@ If the value for the &lt;a href=&quot;/closes&quot;&gt;closes&lt;/a&gt; property
 
     <div typeof="rdfs:Class" resource="http://schema.org/ParcelService">
       <span class="h" property="rdfs:label">ParcelService</span>
-      <span property="rdfs:comment">A private parcel service as the delivery mode available for a certain offer.
-&lt;br /&gt;
-    Commonly used values:&lt;br /&gt;
-&lt;br /&gt;
-    http://purl.org/goodrelations/v1#DHL &lt;br /&gt;
-    http://purl.org/goodrelations/v1#FederalExpress &lt;br /&gt;
-    http://purl.org/goodrelations/v1#UPS &lt;br /&gt;
+      <span property="rdfs:comment">A private parcel service as the delivery mode available for a certain offer.\n\nCommonly used values:\n\n* http://purl.org/goodrelations/v1#DHL\n* http://purl.org/goodrelations/v1#FederalExpress\n* http://purl.org/goodrelations/v1#UPS
       </span>
        <span>Subclass of: <a property="rdfs:subClassOf" href="http://schema.org/DeliveryMethod">DeliveryMethod</a></span>
        <span>Source:  <a property="dc:source" href="http://www.w3.org/wiki/WebSchemas/SchemaDotOrgSources#source_GoodRelationsClass">GoodRelationsClass</a></span>
@@ -2477,7 +2320,7 @@ If the value for the &lt;a href=&quot;/closes&quot;&gt;closes&lt;/a&gt; property
 
     <div typeof="rdfs:Class" resource="http://schema.org/QualitativeValue">
       <span class="h" property="rdfs:label">QualitativeValue</span>
-      <span property="rdfs:comment">A predefined value for a product characteristic, e.g. the power cord plug type &quot;US&quot; or the garment sizes &quot;S&quot;, &quot;M&quot;, &quot;L&quot;, and &quot;XL&quot;.</span>
+      <span property="rdfs:comment">A predefined value for a product characteristic, e.g. the power cord plug type 'US' or the garment sizes 'S', 'M', 'L', and 'XL'.</span>
        <span>Subclass of: <a property="rdfs:subClassOf" href="http://schema.org/Enumeration">Enumeration</a></span>
        <span>Source:  <a property="dc:source" href="http://www.w3.org/wiki/WebSchemas/SchemaDotOrgSources#source_GoodRelationsClass">GoodRelationsClass</a></span>
     </div>
@@ -2519,13 +2362,7 @@ If the value for the &lt;a href=&quot;/closes&quot;&gt;closes&lt;/a&gt; property
 
     <div typeof="rdfs:Class" resource="http://schema.org/WarrantyScope">
       <span class="h" property="rdfs:label">WarrantyScope</span>
-      <span property="rdfs:comment">A range of of services that will be provided to a customer free of charge in case of a defect or malfunction of a product.
-&lt;br /&gt;
-    Commonly used values:&lt;br /&gt;
-&lt;br /&gt;
-    http://purl.org/goodrelations/v1#Labor-BringIn &lt;br /&gt;
-    http://purl.org/goodrelations/v1#PartsAndLabor-BringIn &lt;br /&gt;
-    http://purl.org/goodrelations/v1#PartsAndLabor-PickUp &lt;br /&gt;
+      <span property="rdfs:comment">A range of of services that will be provided to a customer free of charge in case of a defect or malfunction of a product.\n\nCommonly used values:\n\n* http://purl.org/goodrelations/v1#Labor-BringIn\n* http://purl.org/goodrelations/v1#PartsAndLabor-BringIn\n* http://purl.org/goodrelations/v1#PartsAndLabor-PickUp
       </span>
        <span>Subclass of: <a property="rdfs:subClassOf" href="http://schema.org/Enumeration">Enumeration</a></span>
        <span>Source:  <a property="dc:source" href="http://www.w3.org/wiki/WebSchemas/SchemaDotOrgSources#source_GoodRelationsClass">GoodRelationsClass</a></span></div>
@@ -2751,7 +2588,6 @@ If the value for the &lt;a href=&quot;/closes&quot;&gt;closes&lt;/a&gt; property
     <div typeof="http://schema.org/DeliveryMethod" resource="http://schema.org/OnSitePickup">
       <span class="h" property="rdfs:label">OnSitePickup</span>
       <span property="rdfs:comment">A DeliveryMethod in which an item is collected on site, e.g. in a store or at a box office.</span>
-
     </div>
 
     <div typeof="rdfs:Class" resource="http://schema.org/Order">
@@ -2844,9 +2680,7 @@ If the value for the &lt;a href=&quot;/closes&quot;&gt;closes&lt;/a&gt; property
     </div>
     <div typeof="rdfs:Class" resource="http://schema.org/Action">
       <span class="h" property="rdfs:label">Action</span>
-      <span property="rdfs:comment">An action performed by a direct agent and indirect participants upon a direct object. Optionally happens at a location with the help of an inanimate instrument. The execution of the action may produce a result. Specific action sub-type documentation specifies the exact expectation of each argument/role.
-      &lt;br/&gt;&lt;br/&gt;See also &lt;a href="http://blog.schema.org/2014/04/announcing-schemaorg-actions.html"&gt;blog post&lt;/a&gt;
-      and &lt;a href="http://schema.org/docs/actions.html"&gt;Actions overview document&lt;/a&gt;.</span>
+      <span property="rdfs:comment">An action performed by a direct agent and indirect participants upon a direct object. Optionally happens at a location with the help of an inanimate instrument. The execution of the action may produce a result. Specific action sub-type documentation specifies the exact expectation of each argument/role.\n\nSee also [blog post](http://blog.schema.org/2014/04/announcing-schemaorg-actions.html) and [Actions overview document](http://schema.org/docs/actions.html).</span>
        <span>Subclass of: <a property="rdfs:subClassOf" href="http://schema.org/Thing">Thing</a></span>
       <span>Source:  <a property="dc:source" href="http://www.w3.org/wiki/WebSchemas/SchemaDotOrgSources#source_ActionCollabClass">Action collaborations</a></span>
     </div>
@@ -2865,7 +2699,7 @@ If the value for the &lt;a href=&quot;/closes&quot;&gt;closes&lt;/a&gt; property
 
     <div typeof="rdfs:Class" resource="http://schema.org/AcceptAction">
       <span class="h" property="rdfs:label">AcceptAction</span>
-      <span property="rdfs:comment">The act of committing to/adopting an object.&lt;p&gt;Related actions:&lt;/p&gt;&lt;ul&gt;&lt;li&gt;&lt;a href=&quot;http://schema.org/RejectAction&quot;&gt;RejectAction&lt;/a&gt;: The antonym of AcceptAction&lt;/li&gt;&lt;/ul&gt;.</span>
+      <span property="rdfs:comment">The act of committing to/adopting an object.\n\nRelated actions:\n\n* [[RejectAction]]: The antonym of AcceptAction.</span>
        <span>Subclass of: <a property="rdfs:subClassOf" href="http://schema.org/AllocateAction">AllocateAction</a></span>
     </div>
 
@@ -2919,19 +2753,19 @@ If the value for the &lt;a href=&quot;/closes&quot;&gt;closes&lt;/a&gt; property
 
     <div typeof="rdfs:Class" resource="http://schema.org/ApplyAction">
       <span class="h" property="rdfs:label">ApplyAction</span>
-      <span property="rdfs:comment">The act of registering to an organization/service without the guarantee to receive it. &lt;p&gt;Related actions:&lt;/p&gt;&lt;ul&gt;&lt;li&gt;&lt;a href=&quot;http://schema.org/RegisterAction&quot;&gt;RegisterAction&lt;/a&gt;: Unlike RegisterAction, ApplyAction has no guarantees that the application will be accepted&lt;/li&gt;&lt;/ul&gt;.</span>
+      <span property="rdfs:comment">The act of registering to an organization/service without the guarantee to receive it.\n\nRelated actions:\n\n* [[RegisterAction]]: Unlike RegisterAction, ApplyAction has no guarantees that the application will be accepted.</span>
        <span>Subclass of: <a property="rdfs:subClassOf" href="http://schema.org/OrganizeAction">OrganizeAction</a></span>
     </div>
 
     <div typeof="rdfs:Class" resource="http://schema.org/MoveAction">
       <span class="h" property="rdfs:label">MoveAction</span>
-      <span property="rdfs:comment">The act of an agent relocating to a place.&lt;p&gt;Related actions:&lt;/p&gt;&lt;ul&gt;&lt;li&gt;&lt;a href=&quot;http://schema.org/TransferAction&quot;&gt;TransferAction&lt;/a&gt;: Unlike TransferAction, the subject of the move is a living Person or Organization rather than an inanimate object&lt;/li&gt;&lt;/ul&gt;.</span>
+      <span property="rdfs:comment">The act of an agent relocating to a place.\n\nRelated actions:\n\n* [[TransferAction]]: Unlike TransferAction, the subject of the move is a living Person or Organization rather than an inanimate object.</span>
        <span>Subclass of: <a property="rdfs:subClassOf" href="http://schema.org/Action">Action</a></span>
     </div>
 
     <div typeof="rdfs:Class" resource="http://schema.org/ArriveAction">
       <span class="h" property="rdfs:label">ArriveAction</span>
-      <span property="rdfs:comment">The act of arriving at a place. An agent arrives at a destination from an fromLocation, optionally with participants.</span>
+      <span property="rdfs:comment">The act of arriving at a place. An agent arrives at a destination from a fromLocation, optionally with participants.</span>
        <span>Subclass of: <a property="rdfs:subClassOf" href="http://schema.org/MoveAction">MoveAction</a></span>
     </div>
 
@@ -2949,7 +2783,7 @@ If the value for the &lt;a href=&quot;/closes&quot;&gt;closes&lt;/a&gt; property
 
     <div typeof="rdfs:Class" resource="http://schema.org/AskAction">
       <span class="h" property="rdfs:label">AskAction</span>
-      <span property="rdfs:comment">The act of posing a question / favor to someone.&lt;p&gt;Related actions:&lt;/p&gt;&lt;ul&gt;&lt;li&gt;&lt;a href=&quot;http://schema.org/ReplyAction&quot;&gt;ReplyAction&lt;/a&gt;: Appears generally as a response to AskAction&lt;/li&gt;&lt;/ul&gt;.</span>
+      <span property="rdfs:comment">The act of posing a question / favor to someone.\n\nRelated actions:\n\n* [[ReplyAction]]: Appears generally as a response to AskAction.</span>
        <span>Subclass of: <a property="rdfs:subClassOf" href="http://schema.org/CommunicateAction">CommunicateAction</a></span>
     </div>
 
@@ -2967,7 +2801,7 @@ If the value for the &lt;a href=&quot;/closes&quot;&gt;closes&lt;/a&gt; property
 
     <div typeof="rdfs:Class" resource="http://schema.org/BefriendAction">
       <span class="h" property="rdfs:label">BefriendAction</span>
-      <span property="rdfs:comment">The act of forming a personal connection with someone (object) mutually/bidirectionally/symmetrically.&lt;p&gt;Related actions:&lt;/p&gt;&lt;ul&gt;&lt;li&gt;&lt;a href=&quot;http://schema.org/FollowAction&quot;&gt;FollowAction&lt;/a&gt;: Unlike FollowAction, BefriendAction implies that the connection is reciprocal&lt;/li&gt;&lt;/ul&gt;.</span>
+      <span property="rdfs:comment">The act of forming a personal connection with someone (object) mutually/bidirectionally/symmetrically.\n\nRelated actions:\n\n* [[FollowAction]]: Unlike FollowAction, BefriendAction implies that the connection is reciprocal.</span>
        <span>Subclass of: <a property="rdfs:subClassOf" href="http://schema.org/InteractAction">InteractAction</a></span>
     </div>
 
@@ -2985,7 +2819,7 @@ If the value for the &lt;a href=&quot;/closes&quot;&gt;closes&lt;/a&gt; property
 
     <div typeof="rdfs:Class" resource="http://schema.org/BorrowAction">
       <span class="h" property="rdfs:label">BorrowAction</span>
-      <span property="rdfs:comment">The act of obtaining an object under an agreement to return it at a later date. Reciprocal of LendAction.&lt;p&gt;Related actions:&lt;/p&gt;&lt;ul&gt;&lt;li&gt;&lt;a href=&quot;http://schema.org/LendAction&quot;&gt;LendAction&lt;/a&gt;: Reciprocal of BorrowAction&lt;/li&gt;&lt;/ul&gt;.</span>
+      <span property="rdfs:comment">The act of obtaining an object under an agreement to return it at a later date. Reciprocal of LendAction.\n\nRelated actions:\n\n* [[LendAction]]: Reciprocal of BorrowAction.</span>
        <span>Subclass of: <a property="rdfs:subClassOf" href="http://schema.org/TransferAction">TransferAction</a></span>
     </div>
 
@@ -3009,13 +2843,13 @@ If the value for the &lt;a href=&quot;/closes&quot;&gt;closes&lt;/a&gt; property
 
     <div typeof="rdfs:Class" resource="http://schema.org/CancelAction">
       <span class="h" property="rdfs:label">CancelAction</span>
-      <span property="rdfs:comment">The act of asserting that a future event/action is no longer going to happen.&lt;p&gt;Related actions:&lt;/p&gt;&lt;ul&gt;&lt;li&gt;&lt;a href=&quot;http://schema.org/ConfirmAction&quot;&gt;ConfirmAction&lt;/a&gt;: The antonym of CancelAction&lt;/li&gt;&lt;/ul&gt;.</span>
+      <span property="rdfs:comment">The act of asserting that a future event/action is no longer going to happen.\n\nRelated actions:\n\n* [[ConfirmAction]]: The antonym of CancelAction.</span>
        <span>Subclass of: <a property="rdfs:subClassOf" href="http://schema.org/PlanAction">PlanAction</a></span>
     </div>
 
     <div typeof="rdfs:Class" resource="http://schema.org/FindAction">
       <span class="h" property="rdfs:label">FindAction</span>
-      <span property="rdfs:comment">The act of finding an object.&lt;p&gt;Related actions:&lt;/p&gt;&lt;ul&gt;&lt;li&gt;&lt;a href=&quot;http://schema.org/SearchAction&quot;&gt;SearchAction&lt;/a&gt;: FindAction is generally lead by a SearchAction, but not necessarily&lt;/li&gt;&lt;/ul&gt;.</span>
+      <span property="rdfs:comment">TThe act of finding an object.\n\nRelated actions:\n\n* [[SearchAction]]: FindAction is generally lead by a SearchAction, but not necessarily.</span>
        <span>Subclass of: <a property="rdfs:subClassOf" href="http://schema.org/Action">Action</a></span>
     </div>
 
@@ -3033,7 +2867,7 @@ If the value for the &lt;a href=&quot;/closes&quot;&gt;closes&lt;/a&gt; property
 
     <div typeof="rdfs:Class" resource="http://schema.org/CheckOutAction">
       <span class="h" property="rdfs:label">CheckOutAction</span>
-      <span property="rdfs:comment">The act of an agent communicating (service provider, social media, etc) their departure of a previously reserved service (e.g. flight check in) or place (e.g. hotel).&lt;p&gt;Related actions:&lt;/p&gt;&lt;ul&gt;&lt;li&gt;&lt;a href=&quot;http://schema.org/CheckInAction&quot;&gt;CheckInAction&lt;/a&gt;: The antonym of CheckOutAction.&lt;/li&gt;&lt;li&gt;&lt;a href=&quot;http://schema.org/DepartAction&quot;&gt;DepartAction&lt;/a&gt;: Unlike DepartAction, CheckOutAction implies that the agent is informing/confirming the end of a previously reserved service.&lt;/li&gt;&lt;li&gt;&lt;a href=&quot;http://schema.org/CancelAction&quot;&gt;CancelAction&lt;/a&gt;: Unlike CancelAction, CheckOutAction implies that the agent is informing/confirming the end of a previously reserved service&lt;/li&gt;&lt;/ul&gt;.</span>
+      <span property="rdfs:comment">The act of an agent communicating (service provider, social media, etc) their departure of a previously reserved service (e.g. flight check in) or place (e.g. hotel).\n\nRelated actions:\n\n* [[CheckInAction]]: The antonym of CheckOutAction.\n* [[DepartAction]]: Unlike DepartAction, CheckOutAction implies that the agent is informing/confirming the end of a previously reserved service.\n* [[CancelAction]]: Unlike CancelAction, CheckOutAction implies that the agent is informing/confirming the end of a previously reserved service.</span>
        <span>Subclass of: <a property="rdfs:subClassOf" href="http://schema.org/CommunicateAction">CommunicateAction</a></span>
     </div>
 
@@ -3057,7 +2891,7 @@ If the value for the &lt;a href=&quot;/closes&quot;&gt;closes&lt;/a&gt; property
 
     <div typeof="rdfs:Class" resource="http://schema.org/ConfirmAction">
       <span class="h" property="rdfs:label">ConfirmAction</span>
-      <span property="rdfs:comment">The act of notifying someone that a future event/action is going to happen as expected.&lt;p&gt;Related actions:&lt;/p&gt;&lt;ul&gt;&lt;li&gt;&lt;a href=&quot;http://schema.org/CancelAction&quot;&gt;CancelAction&lt;/a&gt;: The antonym of ConfirmAction&lt;/li&gt;&lt;/ul&gt;.</span>
+      <span property="rdfs:comment">The act of notifying someone that a future event/action is going to happen as expected.\n\nRelated actions:\n\n* [[CancelAction]]: The antonym of ConfirmAction.</span>
        <span>Subclass of: <a property="rdfs:subClassOf" href="http://schema.org/InformAction">InformAction</a></span>
     </div>
 
@@ -3177,7 +3011,7 @@ If the value for the &lt;a href=&quot;/closes&quot;&gt;closes&lt;/a&gt; property
 
     <div typeof="rdfs:Class" resource="http://schema.org/PlayAction">
       <span class="h" property="rdfs:label">PlayAction</span>
-      <span property="rdfs:comment">The act of playing/exercising/training/performing for enjoyment, leisure, recreation, Competition or exercise.&lt;p&gt;Related actions:&lt;/p&gt;&lt;ul&gt;&lt;li&gt;&lt;a href=&quot;http://schema.org/ListenAction&quot;&gt;ListenAction&lt;/a&gt;: Unlike ListenAction (which is under ConsumeAction), PlayAction refers to performing for an audience or at an event, rather than consuming music.&lt;/li&gt;&lt;li&gt;&lt;a href=&quot;http://schema.org/WatchAction&quot;&gt;WatchAction&lt;/a&gt;: Unlike WatchAction (which is under ConsumeAction), PlayAction refers to showing/displaying for an audience or at an event, rather than consuming visual content&lt;/li&gt;&lt;/ul&gt;.</span>
+      <span property="rdfs:comment">The act of playing/exercising/training/performing for enjoyment, leisure, recreation, Competition or exercise.\n\nRelated actions:\n\n* [[ListenAction]]: Unlike ListenAction (which is under ConsumeAction), PlayAction refers to performing for an audience or at an event, rather than consuming music.\n* [[WatchAction]]: Unlike WatchAction (which is under ConsumeAction), PlayAction refers to showing/displaying for an audience or at an event, rather than consuming visual content.</span>
        <span>Subclass of: <a property="rdfs:subClassOf" href="http://schema.org/Action">Action</a></span>
     </div>
     <div typeof="rdfs:Class" resource="http://schema.org/ExerciseAction">
@@ -3193,13 +3027,13 @@ If the value for the &lt;a href=&quot;/closes&quot;&gt;closes&lt;/a&gt; property
 
     <div typeof="rdfs:Class" resource="http://schema.org/FollowAction">
       <span class="h" property="rdfs:label">FollowAction</span>
-      <span property="rdfs:comment">The act of forming a personal connection with someone/something (object) unidirectionally/asymmetrically to get updates polled from.&lt;p&gt;Related actions:&lt;/p&gt;&lt;ul&gt;&lt;li&gt;&lt;a href=&quot;http://schema.org/BefriendAction&quot;&gt;BefriendAction&lt;/a&gt;: Unlike BefriendAction, FollowAction implies that the connection is *not* necessarily reciprocal.&lt;/li&gt;&lt;li&gt;&lt;a href=&quot;http://schema.org/SubscribeAction&quot;&gt;SubscribeAction&lt;/a&gt;: Unlike SubscribeAction, FollowAction implies that the follower acts as an active agent constantly/actively polling for updates.&lt;/li&gt;&lt;li&gt;&lt;a href=&quot;http://schema.org/RegisterAction&quot;&gt;RegisterAction&lt;/a&gt;: Unlike RegisterAction, FollowAction implies that the agent is interested in continuing receiving updates from the object.&lt;/li&gt;&lt;li&gt;&lt;a href=&quot;http://schema.org/JoinAction&quot;&gt;JoinAction&lt;/a&gt;: Unlike JoinAction, FollowAction implies that the agent is interested in getting updates from the object.&lt;/li&gt;&lt;li&gt;&lt;a href=&quot;http://schema.org/TrackAction&quot;&gt;TrackAction&lt;/a&gt;: Unlike TrackAction, FollowAction refers to the polling of updates of all aspects of animate objects rather than the location of inanimate objects (e.g. you track a package, but you don&#39;t follow it)&lt;/li&gt;&lt;/ul&gt;.</span>
+      <span property="rdfs:comment">The act of forming a personal connection with someone/something (object) unidirectionally/asymmetrically to get updates polled from.\n\nRelated actions:\n\n* [[BefriendAction]]: Unlike BefriendAction, FollowAction implies that the connection is *not* necessarily reciprocal.\n* [[SubscribeAction]]: Unlike SubscribeAction, FollowAction implies that the follower acts as an active agent constantly/actively polling for updates.\n* [[RegisterAction]]: Unlike RegisterAction, FollowAction implies that the agent is interested in continuing receiving updates from the object.\n* [[JoinAction]]: Unlike JoinAction, FollowAction implies that the agent is interested in getting updates from the object.\n* [[TrackAction]]: Unlike TrackAction, FollowAction refers to the polling of updates of all aspects of animate objects rather than the location of inanimate objects (e.g. you track a package, but you don&#39;t follow it).</span>
        <span>Subclass of: <a property="rdfs:subClassOf" href="http://schema.org/InteractAction">InteractAction</a></span>
     </div>
 
     <div typeof="rdfs:Class" resource="http://schema.org/GiveAction">
       <span class="h" property="rdfs:label">GiveAction</span>
-      <span property="rdfs:comment">The act of transferring ownership of an object to a destination. Reciprocal of TakeAction.&lt;p&gt;Related actions:&lt;/p&gt;&lt;ul&gt;&lt;li&gt;&lt;a href=&quot;http://schema.org/TakeAction&quot;&gt;TakeAction&lt;/a&gt;: Reciprocal of GiveAction.&lt;/li&gt;&lt;li&gt;&lt;a href=&quot;http://schema.org/SendAction&quot;&gt;SendAction&lt;/a&gt;: Unlike SendAction, GiveAction implies that ownership is being transferred (e.g. I may send my laptop to you, but that doesn&#39;t mean I&#39;m giving it to you)&lt;/li&gt;&lt;/ul&gt;.</span>
+      <span property="rdfs:comment">The act of transferring ownership of an object to a destination. Reciprocal of TakeAction.\n\nRelated actions:\n\n* [[TakeAction]]: Reciprocal of GiveAction.\n* [[SendAction]]: Unlike SendAction, GiveAction implies that ownership is being transferred (e.g. I may send my laptop to you, but that doesn&#39;t mean I&#39;m giving it to you).</span>
        <span>Subclass of: <a property="rdfs:subClassOf" href="http://schema.org/TransferAction">TransferAction</a></span>
     </div>
 
@@ -3223,19 +3057,19 @@ If the value for the &lt;a href=&quot;/closes&quot;&gt;closes&lt;/a&gt; property
 
     <div typeof="rdfs:Class" resource="http://schema.org/JoinAction">
       <span class="h" property="rdfs:label">JoinAction</span>
-      <span property="rdfs:comment">An agent joins an event/group with participants/friends at a location.&lt;p&gt;Related actions:&lt;/p&gt;&lt;ul&gt;&lt;li&gt;&lt;a href=&quot;http://schema.org/RegisterAction&quot;&gt;RegisterAction&lt;/a&gt;: Unlike RegisterAction, JoinAction refers to joining a group/team of people.&lt;/li&gt;&lt;li&gt;&lt;a href=&quot;http://schema.org/SubscribeAction&quot;&gt;SubscribeAction&lt;/a&gt;: Unlike SubscribeAction, JoinAction does not imply that you&#39;ll be receiving updates.&lt;/li&gt;&lt;li&gt;&lt;a href=&quot;http://schema.org/FollowAction&quot;&gt;FollowAction&lt;/a&gt;: Unlike FollowAction, JoinAction does not imply that you&#39;ll be polling for updates&lt;/li&gt;&lt;/ul&gt;.</span>
+      <span property="rdfs:comment">An agent joins an event/group with participants/friends at a location.\n\nRelated actions:\n\n* [[RegisterAction]]: Unlike RegisterAction, JoinAction refers to joining a group/team of people.\n* [[SubscribeAction]]: Unlike SubscribeAction, JoinAction does not imply that you&#39;ll be receiving updates.\n* [[FollowAction]]: Unlike FollowAction, JoinAction does not imply that you&#39;ll be polling for updates.</span>
        <span>Subclass of: <a property="rdfs:subClassOf" href="http://schema.org/InteractAction">InteractAction</a></span>
     </div>
 
     <div typeof="rdfs:Class" resource="http://schema.org/LeaveAction">
       <span class="h" property="rdfs:label">LeaveAction</span>
-      <span property="rdfs:comment">An agent leaves an event / group with participants/friends at a location.&lt;p&gt;Related actions:&lt;/p&gt;&lt;ul&gt;&lt;li&gt;&lt;a href=&quot;http://schema.org/JoinAction&quot;&gt;JoinAction&lt;/a&gt;: The antonym of LeaveAction.&lt;/li&gt;&lt;li&gt;&lt;a href=&quot;http://schema.org/UnRegisterAction&quot;&gt;UnRegisterAction&lt;/a&gt;: Unlike UnRegisterAction, LeaveAction implies leaving a group/team of people rather than a service&lt;/li&gt;&lt;/ul&gt;.</span>
+      <span property="rdfs:comment">An agent leaves an event / group with participants/friends at a location.\n\nRelated actions:\n\n* [[JoinAction]]: The antonym of LeaveAction.\n* [[UnRegisterAction]]: Unlike UnRegisterAction, LeaveAction implies leaving a group/team of people rather than a service.</span>
        <span>Subclass of: <a property="rdfs:subClassOf" href="http://schema.org/InteractAction">InteractAction</a></span>
     </div>
 
     <div typeof="rdfs:Class" resource="http://schema.org/LendAction">
       <span class="h" property="rdfs:label">LendAction</span>
-      <span property="rdfs:comment">The act of providing an object under an agreement that it will be returned at a later date. Reciprocal of BorrowAction.&lt;p&gt;Related actions:&lt;/p&gt;&lt;ul&gt;&lt;li&gt;&lt;a href=&quot;http://schema.org/BorrowAction&quot;&gt;BorrowAction&lt;/a&gt;: Reciprocal of LendAction&lt;/li&gt;&lt;/ul&gt;.</span>
+      <span property="rdfs:comment">The act of providing an object under an agreement that it will be returned at a later date. Reciprocal of BorrowAction.\n\nRelated actions:\n\n* [[BorrowAction]]: Reciprocal of LendAction.</span>
        <span>Subclass of: <a property="rdfs:subClassOf" href="http://schema.org/TransferAction">TransferAction</a></span>
     </div>
 
@@ -3313,19 +3147,19 @@ If the value for the &lt;a href=&quot;/closes&quot;&gt;closes&lt;/a&gt; property
 
     <div typeof="rdfs:Class" resource="http://schema.org/ReceiveAction">
       <span class="h" property="rdfs:label">ReceiveAction</span>
-      <span property="rdfs:comment">The act of physically/electronically taking delivery of an object thathas been transferred from an origin to a destination. Reciprocal of SendAction.&lt;p&gt;Related actions:&lt;/p&gt;&lt;ul&gt;&lt;li&gt;&lt;a href=&quot;http://schema.org/SendAction&quot;&gt;SendAction&lt;/a&gt;: The reciprocal of ReceiveAction.&lt;/li&gt;&lt;li&gt;&lt;a href=&quot;http://schema.org/TakeAction&quot;&gt;TakeAction&lt;/a&gt;: Unlike TakeAction, ReceiveAction does not imply that the ownership has been transfered (e.g. I can receive a package, but it does not mean the package is now mine)&lt;/li&gt;&lt;/ul&gt;.</span>
+      <span property="rdfs:comment">The act of physically/electronically taking delivery of an object thathas been transferred from an origin to a destination. Reciprocal of SendAction.\n\nRelated actions:\n\n* [[SendAction]]: The reciprocal of ReceiveAction.\n* [[TakeAction]]: Unlike TakeAction, ReceiveAction does not imply that the ownership has been transfered (e.g. I can receive a package, but it does not mean the package is now mine).</span>
        <span>Subclass of: <a property="rdfs:subClassOf" href="http://schema.org/TransferAction">TransferAction</a></span>
     </div>
 
     <div typeof="rdfs:Class" resource="http://schema.org/RegisterAction">
       <span class="h" property="rdfs:label">RegisterAction</span>
-      <span property="rdfs:comment">The act of registering to be a user of a service, product or web page.&lt;p&gt;Related actions:&lt;/p&gt;&lt;ul&gt;&lt;li&gt;&lt;a href=&quot;http://schema.org/JoinAction&quot;&gt;JoinAction&lt;/a&gt;: Unlike JoinAction, RegisterAction implies you are registering to be a user of a service, *not* a group/team of people.&lt;/li&gt;&lt;li&gt;&lt;a href=&quot;http://schema.org/FollowAction&quot;&gt;FollowAction&lt;/a&gt;: Unlike FollowAction, RegisterAction doesn&#39;t imply that the agent is expecting to poll for updates from the object.&lt;/li&gt;&lt;li&gt;&lt;a href=&quot;http://schema.org/SubscribeAction&quot;&gt;SubscribeAction&lt;/a&gt;: Unlike SubscribeAction, RegisterAction doesn&#39;t imply that the agent is expecting updates from the object&lt;/li&gt;&lt;/ul&gt;.</span>
+      <span property="rdfs:comment">The act of registering to be a user of a service, product or web page.\n\nRelated actions:\n\n* [[JoinAction]]: Unlike JoinAction, RegisterAction implies you are registering to be a user of a service, *not* a group/team of people.\n* [FollowAction]]: Unlike FollowAction, RegisterAction doesn&#39;t imply that the agent is expecting to poll for updates from the object.\n* [[SubscribeAction]]: Unlike SubscribeAction, RegisterAction doesn&#39;t imply that the agent is expecting updates from the object.</span>
        <span>Subclass of: <a property="rdfs:subClassOf" href="http://schema.org/InteractAction">InteractAction</a></span>
     </div>
 
     <div typeof="rdfs:Class" resource="http://schema.org/RejectAction">
       <span class="h" property="rdfs:label">RejectAction</span>
-      <span property="rdfs:comment">The act of rejecting to/adopting an object.&lt;p&gt;Related actions:&lt;/p&gt;&lt;ul&gt;&lt;li&gt;&lt;a href=&quot;http://schema.org/AcceptAction&quot;&gt;AcceptAction&lt;/a&gt;: The antonym of RejectAction&lt;/li&gt;&lt;/ul&gt;.</span>
+      <span property="rdfs:comment">The act of rejecting to/adopting an object.\n\nRelated actions:\n\n* [[AcceptAction]]: The antonym of RejectAction.</span>
        <span>Subclass of: <a property="rdfs:subClassOf" href="http://schema.org/AllocateAction">AllocateAction</a></span>
     </div>
 
@@ -3343,13 +3177,13 @@ If the value for the &lt;a href=&quot;/closes&quot;&gt;closes&lt;/a&gt; property
 
     <div typeof="rdfs:Class" resource="http://schema.org/ReplyAction">
       <span class="h" property="rdfs:label">ReplyAction</span>
-      <span property="rdfs:comment">The act of responding to a question/message asked/sent by the object. Related to &lt;a href=&quot;AskAction&quot;&gt;AskAction&lt;/a&gt;.&lt;p&gt;Related actions:&lt;/p&gt;&lt;ul&gt;&lt;li&gt;&lt;a href=&quot;http://schema.org/AskAction&quot;&gt;AskAction&lt;/a&gt;: Appears generally as an origin of a ReplyAction&lt;/li&gt;&lt;/ul&gt;.</span>
+      <span property="rdfs:comment">The act of responding to a question/message asked/sent by the object. Related to [[AskAction]]\n\nRelated actions:\n\n* [[AskAction]]: Appears generally as an origin of a ReplyAction.</span>
        <span>Subclass of: <a property="rdfs:subClassOf" href="http://schema.org/CommunicateAction">CommunicateAction</a></span>
     </div>
 
     <div typeof="rdfs:Class" resource="http://schema.org/ReserveAction">
       <span class="h" property="rdfs:label">ReserveAction</span>
-      <span property="rdfs:comment">Reserving a concrete object.&lt;p&gt;Related actions:&lt;/p&gt;&lt;ul&gt;&lt;li&gt;&lt;a href=&quot;http://schema.org/ScheduleAction&quot;&gt;ScheduleAction&lt;/a&gt;: Unlike ScheduleAction, ReserveAction reserves concrete objects (e.g. a table, a hotel) towards a time slot / spatial allocation&lt;/li&gt;&lt;/ul&gt;.</span>
+      <span property="rdfs:comment">Reserving a concrete object.\n\nRelated actions:\n\n* [[ScheduleAction]]&lt;/a&gt;: Unlike ScheduleAction, ReserveAction reserves concrete objects (e.g. a table, a hotel) towards a time slot / spatial allocation.</span>
        <span>Subclass of: <a property="rdfs:subClassOf" href="http://schema.org/PlanAction">PlanAction</a></span>
     </div>
 
@@ -3406,13 +3240,13 @@ If the value for the &lt;a href=&quot;/closes&quot;&gt;closes&lt;/a&gt; property
 
     <div typeof="rdfs:Class" resource="http://schema.org/ScheduleAction">
       <span class="h" property="rdfs:label">ScheduleAction</span>
-      <span property="rdfs:comment">Scheduling future actions, events, or tasks.&lt;p&gt;Related actions:&lt;/p&gt;&lt;ul&gt;&lt;li&gt;&lt;a href=&quot;http://schema.org/ReserveAction&quot;&gt;ReserveAction&lt;/a&gt;: Unlike ReserveAction, ScheduleAction allocates future actions (e.g. an event, a task, etc) towards a time slot / spatial allocation&lt;/li&gt;&lt;/ul&gt;.</span>
+      <span property="rdfs:comment">Scheduling future actions, events, or tasks.\n\nRelated actions:\n\n* [[ReserveAction]]: Unlike ReserveAction, ScheduleAction allocates future actions (e.g. an event, a task, etc) towards a time slot / spatial allocation.</span>
        <span>Subclass of: <a property="rdfs:subClassOf" href="http://schema.org/PlanAction">PlanAction</a></span>
     </div>
 
     <div typeof="rdfs:Class" resource="http://schema.org/SearchAction">
       <span class="h" property="rdfs:label">SearchAction</span>
-      <span property="rdfs:comment">The act of searching for an object.&lt;p&gt;Related actions:&lt;/p&gt;&lt;ul&gt;&lt;li&gt;&lt;a href=&quot;http://schema.org/FindAction&quot;&gt;FindAction&lt;/a&gt;: SearchAction generally leads to a FindAction, but not necessarily&lt;/li&gt;&lt;/ul&gt;.</span>
+      <span property="rdfs:comment">The act of searching for an object.\n\nRelated actions:\n\n* [[FindAction]]: SearchAction generally leads to a FindAction, but not necessarily.</span>
        <span>Subclass of: <a property="rdfs:subClassOf" href="http://schema.org/Action">Action</a></span>
     </div>
 
@@ -3424,7 +3258,7 @@ If the value for the &lt;a href=&quot;/closes&quot;&gt;closes&lt;/a&gt; property
 
     <div typeof="rdfs:Class" resource="http://schema.org/SendAction">
       <span class="h" property="rdfs:label">SendAction</span>
-      <span property="rdfs:comment">The act of physically/electronically dispatching an object for transfer from an origin to a destination.&lt;p&gt;Related actions:&lt;/p&gt;&lt;ul&gt;&lt;li&gt;&lt;a href=&quot;http://schema.org/ReceiveAction&quot;&gt;ReceiveAction&lt;/a&gt;: The reciprocal of SendAction.&lt;/li&gt;&lt;li&gt;&lt;a href=&quot;http://schema.org/GiveAction&quot;&gt;GiveAction&lt;/a&gt;: Unlike GiveAction, SendAction does not imply the transfer of ownership (e.g. I can send you my laptop, but I&#39;m not necessarily giving it to you)&lt;/li&gt;&lt;/ul&gt;.</span>
+      <span property="rdfs:comment">The act of physically/electronically dispatching an object for transfer from an origin to a destination.Related actions:\n\n* [[ReceiveAction]]: The reciprocal of SendAction.\n* [[GiveAction]]: Unlike GiveAction, SendAction does not imply the transfer of ownership (e.g. I can send you my laptop, but I&#39;m not necessarily giving it to you).</span>
        <span>Subclass of: <a property="rdfs:subClassOf" href="http://schema.org/TransferAction">TransferAction</a></span>
     </div>
 
@@ -3436,13 +3270,13 @@ If the value for the &lt;a href=&quot;/closes&quot;&gt;closes&lt;/a&gt; property
 
     <div typeof="rdfs:Class" resource="http://schema.org/SubscribeAction">
       <span class="h" property="rdfs:label">SubscribeAction</span>
-      <span property="rdfs:comment">The act of forming a personal connection with someone/something (object) unidirectionally/asymmetrically to get updates pushed to.&lt;p&gt;Related actions:&lt;/p&gt;&lt;ul&gt;&lt;li&gt;&lt;a href=&quot;http://schema.org/FollowAction&quot;&gt;FollowAction&lt;/a&gt;: Unlike FollowAction, SubscribeAction implies that the subscriber acts as a passive agent being constantly/actively pushed for updates.&lt;/li&gt;&lt;li&gt;&lt;a href=&quot;http://schema.org/RegisterAction&quot;&gt;RegisterAction&lt;/a&gt;: Unlike RegisterAction, SubscribeAction implies that the agent is interested in continuing receiving updates from the object.&lt;/li&gt;&lt;li&gt;&lt;a href=&quot;http://schema.org/JoinAction&quot;&gt;JoinAction&lt;/a&gt;: Unlike JoinAction, SubscribeAction implies that the agent is interested in continuing receiving updates from the object&lt;/li&gt;&lt;/ul&gt;.</span>
+      <span property="rdfs:comment">The act of forming a personal connection with someone/something (object) unidirectionally/asymmetrically to get updates pushed to.\n\nRelated actions:\n\n* [[FollowAction]]: Unlike FollowAction, SubscribeAction implies that the subscriber acts as a passive agent being constantly/actively pushed for updates.\n* [[RegisterAction]]: Unlike RegisterAction, SubscribeAction implies that the agent is interested in continuing receiving updates from the object.\n* [[JoinAction]]: Unlike JoinAction, SubscribeAction implies that the agent is interested in continuing receiving updates from the object.</span>
        <span>Subclass of: <a property="rdfs:subClassOf" href="http://schema.org/InteractAction">InteractAction</a></span>
     </div>
 
     <div typeof="rdfs:Class" resource="http://schema.org/TakeAction">
       <span class="h" property="rdfs:label">TakeAction</span>
-      <span property="rdfs:comment">The act of gaining ownership of an object from an origin. Reciprocal of GiveAction.&lt;p&gt;Related actions:&lt;/p&gt;&lt;ul&gt;&lt;li&gt;&lt;a href=&quot;http://schema.org/GiveAction&quot;&gt;GiveAction&lt;/a&gt;: The reciprocal of TakeAction.&lt;/li&gt;&lt;li&gt;&lt;a href=&quot;http://schema.org/ReceiveAction&quot;&gt;ReceiveAction&lt;/a&gt;: Unlike ReceiveAction, TakeAction implies that ownership has been transfered&lt;/li&gt;&lt;/ul&gt;.</span>
+      <span property="rdfs:comment">The act of gaining ownership of an object from an origin. Reciprocal of GiveAction.\n\nRelated actions:\n\n* [[GiveAction]]: The reciprocal of TakeAction.\n* [[ReceiveAction]]: Unlike ReceiveAction, TakeAction implies that ownership has been transfered.</span>
        <span>Subclass of: <a property="rdfs:subClassOf" href="http://schema.org/TransferAction">TransferAction</a></span>
     </div>
 
@@ -3460,7 +3294,7 @@ If the value for the &lt;a href=&quot;/closes&quot;&gt;closes&lt;/a&gt; property
 
     <div typeof="rdfs:Class" resource="http://schema.org/TrackAction">
       <span class="h" property="rdfs:label">TrackAction</span>
-      <span property="rdfs:comment">An agent tracks an object for updates.&lt;p&gt;Related actions:&lt;/p&gt;&lt;ul&gt;&lt;li&gt;&lt;a href=&quot;http://schema.org/FollowAction&quot;&gt;FollowAction&lt;/a&gt;: Unlike FollowAction, TrackAction refers to the interest on the location of innanimates objects.&lt;/li&gt;&lt;li&gt;&lt;a href=&quot;http://schema.org/SubscribeAction&quot;&gt;SubscribeAction&lt;/a&gt;: Unlike SubscribeAction, TrackAction refers to  the interest on the location of innanimate objects&lt;/li&gt;&lt;/ul&gt;.</span>
+      <span property="rdfs:comment">An agent tracks an object for updates.\n\nRelated actions:\n\n* [[FollowAction]]: Unlike FollowAction, TrackAction refers to the interest on the location of innanimates objects.\n* [[SubscribeAction]]: Unlike SubscribeAction, TrackAction refers to  the interest on the location of innanimate objects.</span>
        <span>Subclass of: <a property="rdfs:subClassOf" href="http://schema.org/FindAction">FindAction</a></span>
     </div>
 
@@ -3472,7 +3306,7 @@ If the value for the &lt;a href=&quot;/closes&quot;&gt;closes&lt;/a&gt; property
 
     <div typeof="rdfs:Class" resource="http://schema.org/UnRegisterAction">
       <span class="h" property="rdfs:label">UnRegisterAction</span>
-      <span property="rdfs:comment">The act of un-registering from a service.&lt;p&gt;Related actions:&lt;/p&gt;&lt;ul&gt;&lt;li&gt;&lt;a href=&quot;http://schema.org/RegisterAction&quot;&gt;RegisterAction&lt;/a&gt;: antonym of UnRegisterAction.&lt;/li&gt;&lt;li&gt;&lt;a href=&quot;http://schema.org/Leave&quot;&gt;Leave&lt;/a&gt;: Unlike LeaveAction, UnRegisterAction implies that you are unregistering from a service you werer previously registered, rather than leaving a team/group of people&lt;/li&gt;&lt;/ul&gt;.</span>
+      <span property="rdfs:comment">The act of un-registering from a service.\n\nRelated actions:\n\n* [[RegisterAction]]: antonym of UnRegisterAction.\n* [[Leave]]: Unlike LeaveAction, UnRegisterAction implies that you are unregistering from a service you werer previously registered, rather than leaving a team/group of people.</span>
        <span>Subclass of: <a property="rdfs:subClassOf" href="http://schema.org/InteractAction">InteractAction</a></span>
     </div>
 
@@ -3555,7 +3389,7 @@ If the value for the &lt;a href=&quot;/closes&quot;&gt;closes&lt;/a&gt; property
     </div>
     <div typeof="rdf:Property" resource="http://schema.org/acceptsReservations">
       <span class="h" property="rdfs:label">acceptsReservations</span>
-      <span property="rdfs:comment">Indicates whether a FoodEstablishment accepts reservations. Values can be Boolean, an URL at which reservations can be made or (for backwards compatibility) the strings &lt;code&gt;Yes&lt;/code&gt; or &lt;code&gt;No&lt;/code&gt;.</span>
+      <span property="rdfs:comment">Indicates whether a FoodEstablishment accepts reservations. Values can be Boolean, an URL at which reservations can be made or (for backwards compatibility) the strings ```Yes``` or ```No```.</span>
       <span>Domain: <a property="http://schema.org/domainIncludes" href="http://schema.org/FoodEstablishment">FoodEstablishment</a></span>
       <span>Range: <a property="http://schema.org/rangeIncludes" href="http://schema.org/Text">Text</a></span>
       <span>Range: <a property="http://schema.org/rangeIncludes" href="http://schema.org/URL">URL</a></span>
@@ -3569,25 +3403,25 @@ If the value for the &lt;a href=&quot;/closes&quot;&gt;closes&lt;/a&gt; property
     </div>
     <div typeof="rdf:Property" resource="http://schema.org/accessibilityAPI">
       <span class="h" property="rdfs:label">accessibilityAPI</span>
-      <span property="rdfs:comment">Indicates that the resource is compatible with the referenced accessibility API (&lt;a href=&quot;http://www.w3.org/wiki/WebSchemas/Accessibility&quot;&gt;WebSchemas wiki lists possible values&lt;/a&gt;).</span>
+      <span property="rdfs:comment">Indicates that the resource is compatible with the referenced accessibility API ([WebSchemas wiki lists possible values](http://www.w3.org/wiki/WebSchemas/Accessibility)).</span>
       <span>Domain: <a property="http://schema.org/domainIncludes" href="http://schema.org/CreativeWork">CreativeWork</a></span>
       <span>Range: <a property="http://schema.org/rangeIncludes" href="http://schema.org/Text">Text</a></span>
     </div>
     <div typeof="rdf:Property" resource="http://schema.org/accessibilityControl">
       <span class="h" property="rdfs:label">accessibilityControl</span>
-      <span property="rdfs:comment">Identifies input methods that are sufficient to fully control the described resource (&lt;a href=&quot;http://www.w3.org/wiki/WebSchemas/Accessibility&quot;&gt;WebSchemas wiki lists possible values&lt;/a&gt;).</span>
+      <span property="rdfs:comment">Identifies input methods that are sufficient to fully control the described resource ([WebSchemas wiki lists possible values](http://www.w3.org/wiki/WebSchemas/Accessibility)).</span>
       <span>Domain: <a property="http://schema.org/domainIncludes" href="http://schema.org/CreativeWork">CreativeWork</a></span>
       <span>Range: <a property="http://schema.org/rangeIncludes" href="http://schema.org/Text">Text</a></span>
     </div>
     <div typeof="rdf:Property" resource="http://schema.org/accessibilityFeature">
       <span class="h" property="rdfs:label">accessibilityFeature</span>
-      <span property="rdfs:comment">Content features of the resource, such as accessible media, alternatives and supported enhancements for accessibility (&lt;a href=&quot;http://www.w3.org/wiki/WebSchemas/Accessibility&quot;&gt;WebSchemas wiki lists possible values&lt;/a&gt;).</span>
+      <span property="rdfs:comment">Content features of the resource, such as accessible media, alternatives and supported enhancements for accessibility ([WebSchemas wiki lists possible values](http://www.w3.org/wiki/WebSchemas/Accessibility)).</span>
       <span>Domain: <a property="http://schema.org/domainIncludes" href="http://schema.org/CreativeWork">CreativeWork</a></span>
       <span>Range: <a property="http://schema.org/rangeIncludes" href="http://schema.org/Text">Text</a></span>
     </div>
     <div typeof="rdf:Property" resource="http://schema.org/accessibilityHazard">
       <span class="h" property="rdfs:label">accessibilityHazard</span>
-      <span property="rdfs:comment">A characteristic of the described resource that is physiologically dangerous to some users. Related to WCAG 2.0 guideline 2.3 (&lt;a href=&quot;http://www.w3.org/wiki/WebSchemas/Accessibility&quot;&gt;WebSchemas wiki lists possible values&lt;/a&gt;).</span>
+      <span property="rdfs:comment">A characteristic of the described resource that is physiologically dangerous to some users. Related to WCAG 2.0 guideline 2.3 ([WebSchemas wiki lists possible values](http://www.w3.org/wiki/WebSchemas/Accessibility)).</span>
       <span>Domain: <a property="http://schema.org/domainIncludes" href="http://schema.org/CreativeWork">CreativeWork</a></span>
       <span>Range: <a property="http://schema.org/rangeIncludes" href="http://schema.org/Text">Text</a></span>
     </div>
@@ -3669,7 +3503,7 @@ If the value for the &lt;a href=&quot;/closes&quot;&gt;closes&lt;/a&gt; property
     </div>
     <div typeof="rdf:Property" resource="http://schema.org/addressCountry">
       <span class="h" property="rdfs:label">addressCountry</span>
-      <span property="rdfs:comment">The country. For example, USA. You can also provide the two-letter &lt;a href=&#39;http://en.wikipedia.org/wiki/ISO_3166-1&#39;&gt;ISO 3166-1 alpha-2 country code&lt;/a&gt;.</span>
+      <span property="rdfs:comment">The country. For example, USA. You can also provide the two-letter [ISO 3166-1 alpha-2 country code](http://en.wikipedia.org/wiki/ISO_3166-1).</span>
       <span>Domain: <a property="http://schema.org/domainIncludes" href="http://schema.org/PostalAddress">PostalAddress</a></span>
       <span>Domain: <a property="http://schema.org/domainIncludes" href="http://schema.org/GeoCoordinates">GeoCoordinates</a></span>
       <span>Domain: <a property="http://schema.org/domainIncludes" href="http://schema.org/GeoShape">GeoShape</a></span>
@@ -3739,7 +3573,7 @@ If the value for the &lt;a href=&quot;/closes&quot;&gt;closes&lt;/a&gt; property
     </div>
     <div typeof="rdf:Property" resource="http://schema.org/alignmentType">
       <span class="h" property="rdfs:label">alignmentType</span>
-      <span property="rdfs:comment">A category of alignment between the learning resource and the framework node. Recommended values include: &#39;assesses&#39;, &#39;teaches&#39;, &#39;requires&#39;, &#39;textComplexity&#39;, &#39;readingLevel&#39;, &#39;educationalSubject&#39;, and &#39;educationLevel&#39;.</span>
+      <span property="rdfs:comment">A category of alignment between the learning resource and the framework node. Recommended values include: 'assesses', 'teaches', 'requires', 'textComplexity', 'readingLevel', 'educationalSubject', and 'educationLevel'.</span>
       <span>Domain: <a property="http://schema.org/domainIncludes" href="http://schema.org/AlignmentObject">AlignmentObject</a></span>
       <span>Range: <a property="http://schema.org/rangeIncludes" href="http://schema.org/Text">Text</a></span>
     </div>
@@ -3780,14 +3614,14 @@ If the value for the &lt;a href=&quot;/closes&quot;&gt;closes&lt;/a&gt; property
 
     <div typeof="rdf:Property" resource="http://schema.org/applicationCategory">
       <span class="h" property="rdfs:label">applicationCategory</span>
-      <span property="rdfs:comment">Type of software application, e.g. &quot;Game, Multimedia&quot;.</span>
+      <span property="rdfs:comment">Type of software application, e.g. 'Game, Multimedia'.</span>
       <span>Domain: <a property="http://schema.org/domainIncludes" href="http://schema.org/SoftwareApplication">SoftwareApplication</a></span>
       <span>Range: <a property="http://schema.org/rangeIncludes" href="http://schema.org/Text">Text</a></span>
       <span>Range: <a property="http://schema.org/rangeIncludes" href="http://schema.org/URL">URL</a></span>
     </div>
     <div typeof="rdf:Property" resource="http://schema.org/applicationSubCategory">
       <span class="h" property="rdfs:label">applicationSubCategory</span>
-      <span property="rdfs:comment">Subcategory of the application, e.g. &quot;Arcade Game&quot;.</span>
+      <span property="rdfs:comment">Subcategory of the application, e.g. 'Arcade Game'.</span>
       <span>Domain: <a property="http://schema.org/domainIncludes" href="http://schema.org/SoftwareApplication">SoftwareApplication</a></span>
       <span>Range: <a property="http://schema.org/rangeIncludes" href="http://schema.org/Text">Text</a></span>
       <span>Range: <a property="http://schema.org/rangeIncludes" href="http://schema.org/URL">URL</a></span>
@@ -3841,7 +3675,7 @@ If the value for the &lt;a href=&quot;/closes&quot;&gt;closes&lt;/a&gt; property
     </div>
     <div typeof="rdf:Property" resource="http://schema.org/articleSection">
       <span class="h" property="rdfs:label">articleSection</span>
-      <span property="rdfs:comment">Articles may belong to one or more &#39;sections&#39; in a magazine or newspaper, such as Sports, Lifestyle, etc.</span>
+      <span property="rdfs:comment">Articles may belong to one or more 'sections' in a magazine or newspaper, such as Sports, Lifestyle, etc.</span>
       <span>Domain: <a property="http://schema.org/domainIncludes" href="http://schema.org/Article">Article</a></span>
       <span>Range: <a property="http://schema.org/rangeIncludes" href="http://schema.org/Text">Text</a></span>
     </div>
@@ -3980,7 +3814,7 @@ If the value for the &lt;a href=&quot;/closes&quot;&gt;closes&lt;/a&gt; property
 
     <div typeof="rdf:Property" resource="http://schema.org/availableLanguage">
       <span class="h" property="rdfs:label">availableLanguage</span>
-      <span property="rdfs:comment">A language someone may use with the item. Please use one of the language codes from the &lt;a href=&#39;http://tools.ietf.org/html/bcp47&#39;&gt;IETF BCP 47 standard&lt;/a&gt;. See also [[inLanguage]].</span>
+      <span property="rdfs:comment">A language someone may use with the item. Please use one of the language codes from the [IETF BCP 47 standard](http://tools.ietf.org/html/bcp47). See also [[inLanguage]]</span>
       <span>Domain: <a property="http://schema.org/domainIncludes" href="http://schema.org/ContactPoint">ContactPoint</a></span>
       <span>Domain: <a property="http://schema.org/domainIncludes" href="http://schema.org/ServiceChannel">ServiceChannel</a></span>
       <span>Range: <a property="http://schema.org/rangeIncludes" href="http://schema.org/Language">Language</a></span>
@@ -4125,8 +3959,7 @@ If the value for the &lt;a href=&quot;/closes&quot;&gt;closes&lt;/a&gt; property
     </div>
     <div typeof="rdf:Property" resource="http://schema.org/branchCode">
       <span class="h" property="rdfs:label">branchCode</span>
-      <span property="rdfs:comment">A short textual code (also called "store code") that uniquely identifies a place of business. The code is typically assigned by the parentOrganization and used in structured URLs.
-&lt;br /&gt;&lt;br /&gt; For example, in the URL http://www.starbucks.co.uk/store-locator/etc/detail/3047 the code "3047" is a branchCode for a particular branch.
+      <span property="rdfs:comment">A short textual code (also called "store code") that uniquely identifies a place of business. The code is typically assigned by the parentOrganization and used in structured URLs.\n\nFor example, in the URL http://www.starbucks.co.uk/store-locator/etc/detail/3047 the code "3047" is a branchCode for a particular branch.
       </span>
       <span>Domain: <a property="http://schema.org/domainIncludes" href="http://schema.org/Place">Place</a></span>
       <span>Range: <a property="http://schema.org/rangeIncludes" href="http://schema.org/Text">Text</a></span>
@@ -4157,7 +3990,7 @@ If the value for the &lt;a href=&quot;/closes&quot;&gt;closes&lt;/a&gt; property
     </div>
     <div typeof="rdf:Property" resource="http://schema.org/browserRequirements">
       <span class="h" property="rdfs:label">browserRequirements</span>
-      <span property="rdfs:comment">Specifies browser requirements in human-readable text. For example,&quot;requires HTML5 support&quot;.</span>
+      <span property="rdfs:comment">Specifies browser requirements in human-readable text. For example, 'requires HTML5 support'.</span>
       <span>Domain: <a property="http://schema.org/domainIncludes" href="http://schema.org/WebApplication">WebApplication</a></span>
       <span>Range: <a property="http://schema.org/rangeIncludes" href="http://schema.org/Text">Text</a></span>
     </div>
@@ -4519,7 +4352,7 @@ If the value for the &lt;a href=&quot;/closes&quot;&gt;closes&lt;/a&gt; property
     </div>
     <div typeof="rdf:Property" resource="http://schema.org/currenciesAccepted">
       <span class="h" property="rdfs:label">currenciesAccepted</span>
-      <span property="rdfs:comment">The currency accepted (in &lt;a href=&#39;http://en.wikipedia.org/wiki/ISO_4217&#39;&gt;ISO 4217 currency format&lt;/a&gt;).</span>
+      <span property="rdfs:comment">The currency accepted (in [ISO 4217 currency format](http://en.wikipedia.org/wiki/ISO_4217)).</span>
       <span>Domain: <a property="http://schema.org/domainIncludes" href="http://schema.org/LocalBusiness">LocalBusiness</a></span>
       <span>Range: <a property="http://schema.org/rangeIncludes" href="http://schema.org/Text">Text</a></span>
     </div>
@@ -4769,7 +4602,7 @@ If the value for the &lt;a href=&quot;/closes&quot;&gt;closes&lt;/a&gt; property
     </div>
     <div typeof="rdf:Property" resource="http://schema.org/duration">
       <span class="h" property="rdfs:label">duration</span>
-      <span property="rdfs:comment">The duration of the item (movie, audio recording, event, etc.) in &lt;a href=&#39;http://en.wikipedia.org/wiki/ISO_8601&#39;&gt;ISO 8601 date format&lt;/a&gt;.</span>
+      <span property="rdfs:comment">The duration of the item (movie, audio recording, event, etc.) in [ISO 8601 date format](http://en.wikipedia.org/wiki/ISO_8601).</span>
       <span>Domain: <a property="http://schema.org/domainIncludes" href="http://schema.org/MediaObject">MediaObject</a></span>
       <span>Domain: <a property="http://schema.org/domainIncludes" href="http://schema.org/Event">Event</a></span>
       <span>Domain: <a property="http://schema.org/domainIncludes" href="http://schema.org/Movie">Movie</a></span>
@@ -4808,7 +4641,7 @@ If the value for the &lt;a href=&quot;/closes&quot;&gt;closes&lt;/a&gt; property
     </div>
     <div typeof="rdf:Property" resource="http://schema.org/educationalUse">
       <span class="h" property="rdfs:label">educationalUse</span>
-      <span property="rdfs:comment">The purpose of a work in the context of education; for example, &#39;assignment&#39;, &#39;group work&#39;.</span>
+      <span property="rdfs:comment">The purpose of a work in the context of education; for example, 'assignment', 'group work'.</span>
       <span>Domain: <a property="http://schema.org/domainIncludes" href="http://schema.org/CreativeWork">CreativeWork</a></span>
       <span>Range: <a property="http://schema.org/rangeIncludes" href="http://schema.org/Text">Text</a></span>
     </div>
@@ -4820,7 +4653,7 @@ If the value for the &lt;a href=&quot;/closes&quot;&gt;closes&lt;/a&gt; property
     </div>
     <div typeof="rdf:Property" resource="http://schema.org/elevation">
       <span class="h" property="rdfs:label">elevation</span>
-      <span property="rdfs:comment">The elevation of a location (&lt;a href="https://en.wikipedia.org/wiki/World_Geodetic_System"&gt;WGS 84&lt;/a&gt;).</span>
+      <span property="rdfs:comment">The elevation of a location ([WGS 84](https://en.wikipedia.org/wiki/World_Geodetic_System)).</span>
       <span>Domain: <a property="http://schema.org/domainIncludes" href="http://schema.org/GeoCoordinates">GeoCoordinates</a></span>
       <span>Domain: <a property="http://schema.org/domainIncludes" href="http://schema.org/GeoShape">GeoShape</a></span>
       <span>Range: <a property="http://schema.org/rangeIncludes" href="http://schema.org/Number">Number</a></span>
@@ -4850,8 +4683,7 @@ If the value for the &lt;a href=&quot;/closes&quot;&gt;closes&lt;/a&gt; property
     </div>
     <div typeof="rdf:Property" resource="http://schema.org/eligibleRegion">
       <span class="h" property="rdfs:label">eligibleRegion</span>
-      <span property="rdfs:comment">The ISO 3166-1 (ISO 3166-1 alpha-2) or ISO 3166-2 code, the place, or the GeoShape for the geo-political region(s) for which the offer or delivery charge specification is valid.
-      &lt;br&gt;&lt;br&gt; See also &lt;a href="/ineligibleRegion"&gt;ineligibleRegion&lt;/a&gt;.
+      <span property="rdfs:comment">The ISO 3166-1 (ISO 3166-1 alpha-2) or ISO 3166-2 code, the place, or the GeoShape for the geo-political region(s) for which the offer or delivery charge specification is valid.\n\nSee also [[ineligibleRegion]].
     </span>
       <link property="rdfs:subPropertyOf" href="http://schema.org/areaServed" />
       <span>Domain: <a property="http://schema.org/domainIncludes" href="http://schema.org/Offer">Offer</a></span>
@@ -4863,8 +4695,7 @@ If the value for the &lt;a href=&quot;/closes&quot;&gt;closes&lt;/a&gt; property
     </div>
     <div typeof="rdf:Property" resource="http://schema.org/ineligibleRegion">
       <span class="h" property="rdfs:label">ineligibleRegion</span>
-      <span property="rdfs:comment">The ISO 3166-1 (ISO 3166-1 alpha-2) or ISO 3166-2 code, the place, or the GeoShape for the geo-political region(s) for which the offer or delivery charge specification is not valid, e.g. a region where the transaction is not allowed.
-      &lt;br&gt;&lt;br&gt; See also &lt;a href="/eligibleRegion"&gt;eligibleRegion&lt;/a&gt;.
+      <span property="rdfs:comment">The ISO 3166-1 (ISO 3166-1 alpha-2) or ISO 3166-2 code, the place, or the GeoShape for the geo-political region(s) for which the offer or delivery charge specification is not valid, e.g. a region where the transaction is not allowed.\n\nSee also [[eligibleRegion]].
       </span>
       <span>Domain: <a property="http://schema.org/domainIncludes" href="http://schema.org/Offer">Offer</a></span>
       <span>Domain: <a property="http://schema.org/domainIncludes" href="http://schema.org/DeliveryChargeSpecification">DeliveryChargeSpecification</a></span>
@@ -4891,7 +4722,7 @@ If the value for the &lt;a href=&quot;/closes&quot;&gt;closes&lt;/a&gt; property
     </div>
     <div typeof="rdf:Property" resource="http://schema.org/embedUrl">
       <span class="h" property="rdfs:label">embedUrl</span>
-      <span property="rdfs:comment">A URL pointing to a player for a specific video. In general, this is the information in the &lt;code&gt;src&lt;/code&gt; element of an &lt;code&gt;embed&lt;/code&gt; tag and should not be the same as the content of the &lt;code&gt;loc&lt;/code&gt; tag.</span>
+      <span property="rdfs:comment">A URL pointing to a player for a specific video. In general, this is the information in the ```src``` element of an ```embed``` tag and should not be the same as the content of the ```loc``` tag.</span>
       <span>Domain: <a property="http://schema.org/domainIncludes" href="http://schema.org/MediaObject">MediaObject</a></span>
       <span>Range: <a property="http://schema.org/rangeIncludes" href="http://schema.org/URL">URL</a></span>
     </div>
@@ -4941,7 +4772,7 @@ If the value for the &lt;a href=&quot;/closes&quot;&gt;closes&lt;/a&gt; property
     </div>
     <div typeof="rdf:Property" resource="http://schema.org/endDate">
       <span class="h" property="rdfs:label">endDate</span>
-      <span property="rdfs:comment">The end date and time of the item (in &lt;a href=&#39;http://en.wikipedia.org/wiki/ISO_8601&#39;&gt;ISO 8601 date format&lt;/a&gt;).</span>
+      <span property="rdfs:comment">The end date and time of the item (in [ISO 8601 date format](http://en.wikipedia.org/wiki/ISO_8601)).</span>
       <span>Domain: <a property="http://schema.org/domainIncludes" href="http://schema.org/Role">Role</a></span>
       <span>Domain: <a property="http://schema.org/domainIncludes" href="http://schema.org/Event">Event</a></span>
       <span>Domain: <a property="http://schema.org/domainIncludes" href="http://schema.org/CreativeWorkSeason">CreativeWorkSeason</a></span>
@@ -4959,9 +4790,7 @@ If the value for the &lt;a href=&quot;/closes&quot;&gt;closes&lt;/a&gt; property
 
     <div typeof="rdf:Property" resource="http://schema.org/endTime">
       <span class="h" property="rdfs:label">endTime</span>
-      <span property="rdfs:comment">The endTime of something. For a reserved event or service (e.g. FoodEstablishmentReservation), the time that it is expected to end. For actions that span a period of time, when the action was performed. e.g. John wrote a book from January to *December*.
-
-Note that Event uses startDate/endDate instead of startTime/endTime, even when describing dates with times. This situation may be clarified in future revisions.</span>
+      <span property="rdfs:comment">The endTime of something. For a reserved event or service (e.g. FoodEstablishmentReservation), the time that it is expected to end. For actions that span a period of time, when the action was performed. e.g. John wrote a book from January to *December*.\n\nNote that Event uses startDate/endDate instead of startTime/endTime, even when describing dates with times. This situation may be clarified in future revisions.</span>
       <span>Domain: <a property="http://schema.org/domainIncludes" href="http://schema.org/Action">Action</a></span>
       <span>Domain: <a property="http://schema.org/domainIncludes" href="http://schema.org/FoodEstablishmentReservation">FoodEstablishmentReservation</a></span>
       <span>Range: <a property="http://schema.org/rangeIncludes" href="http://schema.org/DateTime">DateTime</a></span>
@@ -5091,7 +4920,7 @@ Note that Event uses startDate/endDate instead of startTime/endTime, even when d
 
     <div typeof="rdf:Property" resource="http://schema.org/fileFormat">
       <span class="h" property="rdfs:label">fileFormat</span>
-      <span property="rdfs:comment">Media type (aka MIME format, see &lt;a href="http://www.iana.org/assignments/media-types/media-types.xhtml">IANA site&lt;/a&gt;) of the content e.g. application/zip of a SoftwareApplication binary. In cases where a CreativeWork has several media type representations, 'encoding' can be used to indicate each MediaObject alongside particular fileFormat information.</span>
+      <span property="rdfs:comment">Media type (aka MIME format, see [IANA site](http://www.iana.org/assignments/media-types/media-types.xhtml)) of the content e.g. application/zip of a SoftwareApplication binary. In cases where a CreativeWork has several media type representations, 'encoding' can be used to indicate each MediaObject alongside particular fileFormat information.</span>
       <span>Domain: <a property="http://schema.org/domainIncludes" href="http://schema.org/CreativeWork">CreativeWork</a></span>
       <span>Range: <a property="http://schema.org/rangeIncludes" href="http://schema.org/Text">Text</a></span>
     </div>
@@ -5212,7 +5041,7 @@ Note that Event uses startDate/endDate instead of startTime/endTime, even when d
     </div>
     <div typeof="rdf:Property" resource="http://schema.org/globalLocationNumber">
       <span class="h" property="rdfs:label">globalLocationNumber</span>
-      <span property="rdfs:comment">The &lt;a href="http://www.gs1.org/gln"&gt;Global Location Number&lt;/a&gt; (GLN, sometimes also referred to as International Location Number or ILN) of the respective organization, person, or place. The GLN is a 13-digit number used to identify parties and physical locations.</span>
+      <span property="rdfs:comment">The [Global Location Number](http://www.gs1.org/gln) (GLN, sometimes also referred to as International Location Number or ILN) of the respective organization, person, or place. The GLN is a 13-digit number used to identify parties and physical locations.</span>
       <span>Domain: <a property="http://schema.org/domainIncludes" href="http://schema.org/Organization">Organization</a></span>
       <span>Domain: <a property="http://schema.org/domainIncludes" href="http://schema.org/Place">Place</a></span>
       <span>Domain: <a property="http://schema.org/domainIncludes" href="http://schema.org/Person">Person</a></span>
@@ -5232,7 +5061,7 @@ Note that Event uses startDate/endDate instead of startTime/endTime, even when d
     </div>
     <div typeof="rdf:Property" resource="http://schema.org/gtin12">
       <span class="h" property="rdfs:label">gtin12</span>
-      <span property="rdfs:comment">The &lt;a href="http://ocp.gs1.org/sites/glossary/en-gb/Pages/GTIN-12.aspx"&gt;GTIN-12&lt;/a&gt; code of the product, or the product to which the offer refers. The GTIN-12 is the 12-digit GS1 Identification Key composed of a U.P.C. Company Prefix, Item Reference, and Check Digit used to identify trade items. See &lt;a href="http://www.gs1.org/barcodes/technical/idkeys/gtin"&gt;GS1 GTIN Summary&lt;/a&gt; for more details.</span>
+      <span property="rdfs:comment">The [GTIN-12](http://apps.gs1.org/GDD/glossary/Pages/GTIN-12.aspx) code of the product, or the product to which the offer refers. The GTIN-12 is the 12-digit GS1 Identification Key composed of a U.P.C. Company Prefix, Item Reference, and Check Digit used to identify trade items. See [GS1 GTIN Summary](http://www.gs1.org/barcodes/technical/idkeys/gtin) for more details.</span>
       <span>Domain: <a property="http://schema.org/domainIncludes" href="http://schema.org/Offer">Offer</a></span>
       <span>Domain: <a property="http://schema.org/domainIncludes" href="http://schema.org/Product">Product</a></span>
       <span>Domain: <a property="http://schema.org/domainIncludes" href="http://schema.org/Demand">Demand</a></span>
@@ -5240,7 +5069,7 @@ Note that Event uses startDate/endDate instead of startTime/endTime, even when d
     </div>
     <div typeof="rdf:Property" resource="http://schema.org/gtin13">
       <span class="h" property="rdfs:label">gtin13</span>
-      <span property="rdfs:comment">The &lt;a href="http://ocp.gs1.org/sites/glossary/en-gb/Pages/GTIN-13.aspx"&gt;GTIN-13&lt;/a&gt; code of the product, or the product to which the offer refers. This is equivalent to 13-digit ISBN codes and EAN UCC-13. Former 12-digit UPC codes can be converted into a GTIN-13 code by simply adding a preceeding zero. See &lt;a href="http://www.gs1.org/barcodes/technical/idkeys/gtin"&gt;GS1 GTIN Summary&lt;/a&gt; for more details.</span>
+      <span property="rdfs:comment">The [GTIN-13](http://apps.gs1.org/GDD/glossary/Pages/GTIN-13.aspx) code of the product, or the product to which the offer refers. This is equivalent to 13-digit ISBN codes and EAN UCC-13. Former 12-digit UPC codes can be converted into a GTIN-13 code by simply adding a preceeding zero. See [GS1 GTIN Summary](http://www.gs1.org/barcodes/technical/idkeys/gtin) for more details.</span>
       <span>Domain: <a property="http://schema.org/domainIncludes" href="http://schema.org/Offer">Offer</a></span>
       <span>Domain: <a property="http://schema.org/domainIncludes" href="http://schema.org/Product">Product</a></span>
       <span>Domain: <a property="http://schema.org/domainIncludes" href="http://schema.org/Demand">Demand</a></span>
@@ -5248,7 +5077,7 @@ Note that Event uses startDate/endDate instead of startTime/endTime, even when d
     </div>
     <div typeof="rdf:Property" resource="http://schema.org/gtin14">
       <span class="h" property="rdfs:label">gtin14</span>
-      <span property="rdfs:comment">The &lt;a href="http://ocp.gs1.org/sites/glossary/en-gb/Pages/GTIN-14.aspx"&gt;GTIN-14&lt;/a&gt; code of the product, or the product to which the offer refers. See &lt;a href="http://www.gs1.org/barcodes/technical/idkeys/gtin"&gt;GS1 GTIN Summary&lt;/a&gt; for more details.</span>
+      <span property="rdfs:comment">The [GTIN-14](http://apps.gs1.org/GDD/glossary/Pages/GTIN-14.aspx) code of the product, or the product to which the offer refers. See [GS1 GTIN Summary](http://www.gs1.org/barcodes/technical/idkeys/gtin) for more details.</span>
       <span>Domain: <a property="http://schema.org/domainIncludes" href="http://schema.org/Offer">Offer</a></span>
       <span>Domain: <a property="http://schema.org/domainIncludes" href="http://schema.org/Product">Product</a></span>
       <span>Domain: <a property="http://schema.org/domainIncludes" href="http://schema.org/Demand">Demand</a></span>
@@ -5256,7 +5085,7 @@ Note that Event uses startDate/endDate instead of startTime/endTime, even when d
     </div>
     <div typeof="rdf:Property" resource="http://schema.org/gtin8">
       <span class="h" property="rdfs:label">gtin8</span>
-      <span property="rdfs:comment">The &lt;a href="http://ocp.gs1.org/sites/glossary/en-gb/Pages/GTIN-8.aspx"&gt;GTIN-8&lt;/a&gt; code of the product, or the product to which the offer refers. This code is also known as EAN/UCC-8 or 8-digit EAN. See &lt;a href="http://www.gs1.org/barcodes/technical/idkeys/gtin"&gt;GS1 GTIN Summary&lt;/a&gt; for more details.</span>
+      <span property="rdfs:comment">The [GTIN-8](http://apps.gs1.org/GDD/glossary/Pages/GTIN-8.aspx) code of the product, or the product to which the offer refers. This code is also known as EAN/UCC-8 or 8-digit EAN. See [GS1 GTIN Summary](http://www.gs1.org/barcodes/technical/idkeys/gtin) for more details.</span>
       <span>Domain: <a property="http://schema.org/domainIncludes" href="http://schema.org/Offer">Offer</a></span>
       <span>Domain: <a property="http://schema.org/domainIncludes" href="http://schema.org/Product">Product</a></span>
       <span>Domain: <a property="http://schema.org/domainIncludes" href="http://schema.org/Demand">Demand</a></span>
@@ -5344,7 +5173,7 @@ Note that Event uses startDate/endDate instead of startTime/endTime, even when d
     </div>
     <div typeof="rdf:Property" resource="http://schema.org/image">
       <span class="h" property="rdfs:label">image</span>
-      <span property="rdfs:comment">An image of the item. This can be a &lt;a href=&quot;http://schema.org/URL&quot;&gt;URL&lt;/a&gt; or a fully described &lt;a href=&quot;http://schema.org/ImageObject&quot;&gt;ImageObject&lt;/a&gt;.</span>
+      <span property="rdfs:comment">An image of the item. This can be a [[URL]] or a fully described [[ImageObject]].</span>
       <span>Domain: <a property="http://schema.org/domainIncludes" href="http://schema.org/Thing">Thing</a></span>
       <span>Range: <a property="http://schema.org/rangeIncludes" href="http://schema.org/URL">URL</a></span>
       <span>Range: <a property="http://schema.org/rangeIncludes" href="http://schema.org/ImageObject">ImageObject</a></span>
@@ -5387,7 +5216,7 @@ Note that Event uses startDate/endDate instead of startTime/endTime, even when d
 
     <div typeof="rdf:Property" resource="http://schema.org/inLanguage">
       <span class="h" property="rdfs:label">inLanguage</span>
-      <span property="rdfs:comment">The language of the content or performance or used in an action. Please use one of the language codes from the &lt;a href=&#39;http://tools.ietf.org/html/bcp47&#39;&gt;IETF BCP 47 standard&lt;/a&gt;. See also [[availableLanguage]].</span>
+      <span property="rdfs:comment">The language of the content or performance or used in an action. Please use one of the language codes from the [IETF BCP 47 standard](http://tools.ietf.org/html/bcp47). See also [[availableLanguage]].</span>
       <span>Domain: <a property="http://schema.org/domainIncludes" href="http://schema.org/CreativeWork">CreativeWork</a></span>
       <span>Domain: <a property="http://schema.org/domainIncludes" href="http://schema.org/Event">Event</a></span>
       <span>Domain: <a property="http://schema.org/domainIncludes" href="http://schema.org/CommunicateAction">CommunicateAction</a></span>
@@ -5427,7 +5256,7 @@ Note that Event uses startDate/endDate instead of startTime/endTime, even when d
     </div>
     <div typeof="rdf:Property" resource="http://schema.org/interactivityType">
       <span class="h" property="rdfs:label">interactivityType</span>
-      <span property="rdfs:comment">The predominant mode of learning supported by the learning resource. Acceptable values are &#39;active&#39;, &#39;expositive&#39;, or &#39;mixed&#39;.</span>
+      <span property="rdfs:comment">The predominant mode of learning supported by the learning resource. Acceptable values are 'active', 'expositive', or 'mixed'.</span>
       <span>Domain: <a property="http://schema.org/domainIncludes" href="http://schema.org/CreativeWork">CreativeWork</a></span>
       <span>Range: <a property="http://schema.org/rangeIncludes" href="http://schema.org/Text">Text</a></span>
     </div>
@@ -5656,7 +5485,7 @@ Note that Event uses startDate/endDate instead of startTime/endTime, even when d
     </div>
     <div typeof="rdf:Property" resource="http://schema.org/latitude">
       <span class="h" property="rdfs:label">latitude</span>
-      <span property="rdfs:comment">The latitude of a location. For example &lt;code&gt;37.42242&lt;/code&gt; (&lt;a href="https://en.wikipedia.org/wiki/World_Geodetic_System"&gt;WGS 84&lt;/a&gt;).</span>
+      <span property="rdfs:comment">The latitude of a location. For example ```37.42242``` ([WGS 84](https://en.wikipedia.org/wiki/World_Geodetic_System)).</span>
       <span>Domain: <a property="http://schema.org/domainIncludes" href="http://schema.org/GeoCoordinates">GeoCoordinates</a></span>
       <span>Range: <a property="http://schema.org/rangeIncludes" href="http://schema.org/Number">Number</a></span>
       <span>Range: <a property="http://schema.org/rangeIncludes" href="http://schema.org/Text">Text</a></span>
@@ -5670,7 +5499,7 @@ Note that Event uses startDate/endDate instead of startTime/endTime, even when d
     </div>
     <div typeof="rdf:Property" resource="http://schema.org/learningResourceType">
       <span class="h" property="rdfs:label">learningResourceType</span>
-      <span property="rdfs:comment">The predominant type or kind characterizing the learning resource. For example, &#39;presentation&#39;, &#39;handout&#39;.</span>
+      <span property="rdfs:comment">The predominant type or kind characterizing the learning resource. For example, 'presentation', 'handout'.</span>
       <span>Domain: <a property="http://schema.org/domainIncludes" href="http://schema.org/CreativeWork">CreativeWork</a></span>
       <span>Range: <a property="http://schema.org/rangeIncludes" href="http://schema.org/Text">Text</a></span>
     </div>
@@ -5730,7 +5559,7 @@ Note that Event uses startDate/endDate instead of startTime/endTime, even when d
     </div>
     <div typeof="rdf:Property" resource="http://schema.org/longitude">
       <span class="h" property="rdfs:label">longitude</span>
-      <span property="rdfs:comment">The longitude of a location. For example &lt;code&gt;-122.08585&lt;/code&gt; (&lt;a href="https://en.wikipedia.org/wiki/World_Geodetic_System"&gt;WGS 84&lt;/a&gt;).</span>
+      <span property="rdfs:comment">The longitude of a location. For example ```-122.08585``` ([WGS 84](https://en.wikipedia.org/wiki/World_Geodetic_System)).</span>
       <span>Domain: <a property="http://schema.org/domainIncludes" href="http://schema.org/GeoCoordinates">GeoCoordinates</a></span>
       <span>Range: <a property="http://schema.org/rangeIncludes" href="http://schema.org/Number">Number</a></span>
       <span>Range: <a property="http://schema.org/rangeIncludes" href="http://schema.org/Text">Text</a></span>
@@ -5767,7 +5596,7 @@ Note that Event uses startDate/endDate instead of startTime/endTime, even when d
 
 <div typeof="rdf:Property" resource="http://schema.org/mainEntityOfPage">
       <span class="h" property="rdfs:label">mainEntityOfPage</span>
-      <span property="rdfs:comment">Indicates a page (or other CreativeWork) for which this thing is the main entity being described. See &lt;a href="/docs/datamodel.html#mainEntityBackground"&gt;background notes&lt;/a&gt; for details.</span>
+      <span property="rdfs:comment">Indicates a page (or other CreativeWork) for which this thing is the main entity being described. See [background notes](/docs/datamodel.html#mainEntityBackground) for details.</span>
       <span>Domain: <a property="http://schema.org/domainIncludes" href="http://schema.org/Thing">Thing</a></span>
       <span>Range: <a property="http://schema.org/rangeIncludes" href="http://schema.org/CreativeWork">CreativeWork</a></span>
       <span>Range: <a property="http://schema.org/rangeIncludes" href="http://schema.org/URL">URL</a></span>
@@ -6042,9 +5871,9 @@ Note that Event uses startDate/endDate instead of startTime/endTime, even when d
       <span>Domain: <a property="http://schema.org/domainIncludes" href="http://schema.org/AggregateOffer">AggregateOffer</a></span>
       <span>Range: <a property="http://schema.org/rangeIncludes" href="http://schema.org/Offer">Offer</a></span>
     </div>
-    <div typeof="rdf:Property" resource="http://schema.org/openingHours">
+    <div typeof="rdf:Property" resource="http://schema.org/">
       <span class="h" property="rdfs:label">openingHours</span>
-      <span property="rdfs:comment">The general opening hours for a business. Opening hours can be specified as a weekly time range, starting with days, then times per day. Multiple days can be listed with commas &#39;,&#39; separating each day. Day or time ranges are specified using a hyphen &#39;-&#39;.&lt;br /&gt;- Days are specified using the following two-letter combinations: &lt;code&gt;Mo&lt;/code&gt;, &lt;code&gt;Tu&lt;/code&gt;, &lt;code&gt;We&lt;/code&gt;, &lt;code&gt;Th&lt;/code&gt;, &lt;code&gt;Fr&lt;/code&gt;, &lt;code&gt;Sa&lt;/code&gt;, &lt;code&gt;Su&lt;/code&gt;.&lt;br /&gt;- Times are specified using 24:00 time. For example, 3pm is specified as &lt;code&gt;15:00&lt;/code&gt;. &lt;br /&gt;- Here is an example: &lt;code&gt;&amp;lt;span itemprop=&amp;quot;openingHours&amp;quot; content=&amp;quot;Tu,Th 16:00-20:00&amp;quot;&amp;gt;Tuesdays and Thursdays 4-8pm&amp;lt;/span&amp;gt;&lt;/code&gt;. &lt;br /&gt;- If a business is open 7 days a week, then it can be specified as &lt;code&gt;&amp;lt;span itemprop=&amp;quot;openingHours&amp;quot; content=&amp;quot;Mo-Su&amp;quot;&amp;gt;Monday through Sunday, all day&amp;lt;/span&amp;gt;&lt;/code&gt;.</span>
+      <span property="rdfs:comment">The general opening hours for a business. Opening hours can be specified as a weekly time range, starting with days, then times per day. Multiple days can be listed with commas ',' separating each day. Day or time ranges are specified using a hyphen '-'.\n\n* Days are specified using the following two-letter combinations: ```Mo```, ```Tu```, ```We```, ```Th```, ```Fr```, ```Sa```, ```Su```.\n* Times are specified using 24:00 time. For example, 3pm is specified as ```15:00```. \n* Here is an example: &lt;code&gt;&amp;lt;time itemprop="openingHours" datetime=&amp;quot;Tu,Th 16:00-20:00&amp;quot;&amp;gt;Tuesdays and Thursdays 4-8pm&amp;lt;/time&amp;gt;&lt;/code&gt;.\n* If a business is open 7 days a week, then it can be specified as &lt;code&gt;&amp;lt;time itemprop=&amp;quot;openingHours&amp;quot; datetime=&amp;quot;Mo-Su&amp;quot;&amp;gt;Monday through Sunday, all day&amp;lt;/time&amp;gt;&lt;/code&gt;.</span>
       <span>Domain: <a property="http://schema.org/domainIncludes" href="http://schema.org/LocalBusiness">LocalBusiness</a></span>
       <span>Domain: <a property="http://schema.org/domainIncludes" href="http://schema.org/CivicStructure">CivicStructure</a></span>
       <span>Range: <a property="http://schema.org/rangeIncludes" href="http://schema.org/Text">Text</a></span>
@@ -6057,9 +5886,7 @@ Note that Event uses startDate/endDate instead of startTime/endTime, even when d
     </div>
     <div typeof="rdf:Property" resource="http://schema.org/specialOpeningHoursSpecification">
       <span class="h" property="rdfs:label">specialOpeningHoursSpecification</span>
-      <span property="rdfs:comment">The special opening hours of a certain place.
-&lt;br /&gt;
-Use this to explicitly override general opening hours brought in scope by &lt;a href=&quot;/openingHoursSpecification&quot;&gt;openingHoursSpecification&lt;/a&gt; or &lt;a href=&quot;/openingHours&quot;&gt;openingHours&lt;/a&gt;.
+      <span property="rdfs:comment">The special opening hours of a certain place.\n\nUse this to explicitly override general opening hours brought in scope by [[openingHoursSpecification]] or [[openingHours]].
       </span>
       <span>Domain: <a property="http://schema.org/domainIncludes" href="http://schema.org/Place">Place</a></span>
       <span>Range: <a property="http://schema.org/rangeIncludes" href="http://schema.org/OpeningHoursSpecification">OpeningHoursSpecification</a></span>
@@ -6359,26 +6186,8 @@ Use this to explicitly override general opening hours brought in scope by &lt;a 
     </div>
     <div typeof="rdf:Property" resource="http://schema.org/price">
       <span class="h" property="rdfs:label">price</span>
-      <span property="rdfs:comment">The offer price of a product, or of a price component when attached to PriceSpecification and its subtypes.
-&lt;br /&gt;
-&lt;br /&gt;
-      Usage guidelines:
-&lt;br /&gt;
-&lt;ul&gt;
-&lt;li&gt;Use the &lt;a href="/priceCurrency"&gt;priceCurrency&lt;/a&gt; property (with &lt;a href="http://en.wikipedia.org/wiki/ISO_4217#Active_codes"&gt;ISO 4217 codes&lt;/a&gt; e.g. "USD") instead of
-      including &lt;a href="http://en.wikipedia.org/wiki/Dollar_sign#Currencies_that_use_the_dollar_or_peso_sign"&gt;ambiguous symbols&lt;/a&gt; such as '$' in the value.
-&lt;/li&gt;
-&lt;li&gt;
-      Use '.' (Unicode 'FULL STOP' (U+002E)) rather than ',' to indicate a decimal point. Avoid using these symbols as a readability separator.
-&lt;/li&gt;
-&lt;li&gt;
-      Note that both &lt;a href="http://www.w3.org/TR/xhtml-rdfa-primer/#using-the-content-attribute"&gt;RDFa&lt;/a&gt; and Microdata syntax allow the use of a "content=" attribute for publishing simple machine-readable values
-      alongside more human-friendly formatting.
-&lt;/li&gt;
-&lt;li&gt;
-      Use values from 0123456789 (Unicode 'DIGIT ZERO' (U+0030) to 'DIGIT NINE' (U+0039)) rather than superficially similiar Unicode symbols.
-&lt;/li&gt;
-&lt;/ul&gt;
+      <span property="rdfs:comment">The offer price of a product, or of a price component when attached to PriceSpecification and its subtypes.\n\nUsage guidelines:\n\n* Use the [[priceCurrency]] property (with [ISO 4217 codes](http://en.wikipedia.org/wiki/ISO_4217#Active_codes) e.g. "USD") instead of
+      including [ambiguous symbols](http://en.wikipedia.org/wiki/Dollar_sign#Currencies_that_use_the_dollar_or_peso_sign) such as '$' in the value.\n* Use '.' (Unicode 'FULL STOP' (U+002E)) rather than ',' to indicate a decimal point. Avoid using these symbols as a readability separator.\n* Note that both [RDFa](http://www.w3.org/TR/xhtml-rdfa-primer/#using-the-content-attribute) and Microdata syntax allow the use of a "content=" attribute for publishing simple machine-readable values alongside more human-friendly formatting.\n* Use values from 0123456789 (Unicode 'DIGIT ZERO' (U+0030) to 'DIGIT NINE' (U+0039)) rather than superficially similiar Unicode symbols.
       </span>
       <span>Domain: <a property="http://schema.org/domainIncludes" href="http://schema.org/Offer">Offer</a></span>
       <span>Domain: <a property="http://schema.org/domainIncludes" href="http://schema.org/PriceSpecification">PriceSpecification</a></span>
@@ -6388,7 +6197,7 @@ Use this to explicitly override general opening hours brought in scope by &lt;a 
     </div>
     <div typeof="rdf:Property" resource="http://schema.org/priceRange">
       <span class="h" property="rdfs:label">priceRange</span>
-      <span property="rdfs:comment">The price range of the business, for example &lt;code&gt;$$$&lt;/code&gt;.</span>
+      <span property="rdfs:comment">The price range of the business, for example ```$$$```.</span>
       <span>Domain: <a property="http://schema.org/domainIncludes" href="http://schema.org/LocalBusiness">LocalBusiness</a></span>
       <span>Range: <a property="http://schema.org/rangeIncludes" href="http://schema.org/Text">Text</a></span>
     </div>
@@ -6478,7 +6287,7 @@ Use this to explicitly override general opening hours brought in scope by &lt;a 
     </div>
     <div typeof="rdf:Property" resource="http://schema.org/productID">
       <span class="h" property="rdfs:label">productID</span>
-      <span property="rdfs:comment">The product identifier, such as ISBN. For example: &lt;code&gt;&amp;lt;meta itemprop=&#39;productID&#39; content=&#39;isbn:123-456-789&#39;/&amp;gt;&lt;/code&gt;.</span>
+      <span property="rdfs:comment">The product identifier, such as ISBN. For example: ``` meta itemprop="productID" content="isbn:123-456-789" ```.</span>
       <span>Domain: <a property="http://schema.org/domainIncludes" href="http://schema.org/Product">Product</a></span>
       <span>Range: <a property="http://schema.org/rangeIncludes" href="http://schema.org/Text">Text</a></span>
     </div>
@@ -6499,14 +6308,14 @@ Use this to explicitly override general opening hours brought in scope by &lt;a 
     </div>
     <div typeof="rdf:Property" resource="http://schema.org/productSupported">
       <span class="h" property="rdfs:label">productSupported</span>
-      <span property="rdfs:comment">The product or service this support contact point is related to (such as product support for a particular product line). This can be a specific product or product line (e.g. &quot;iPhone&quot;) or a general category of products or services (e.g. &quot;smartphones&quot;).</span>
+      <span property="rdfs:comment">The product or service this support contact point is related to (such as product support for a particular product line). This can be a specific product or product line (e.g. "iPhone") or a general category of products or services (e.g. "smartphones").</span>
       <span>Domain: <a property="http://schema.org/domainIncludes" href="http://schema.org/ContactPoint">ContactPoint</a></span>
       <span>Range: <a property="http://schema.org/rangeIncludes" href="http://schema.org/Product">Product</a></span>
       <span>Range: <a property="http://schema.org/rangeIncludes" href="http://schema.org/Text">Text</a></span>
     </div>
     <div typeof="rdf:Property" resource="http://schema.org/proficiencyLevel">
       <span class="h" property="rdfs:label">proficiencyLevel</span>
-      <span property="rdfs:comment">Proficiency needed for this content; expected values: &#39;Beginner&#39;, &#39;Expert&#39;.</span>
+      <span property="rdfs:comment">Proficiency needed for this content; expected values: 'Beginner', 'Expert'.</span>
       <span>Domain: <a property="http://schema.org/domainIncludes" href="http://schema.org/TechArticle">TechArticle</a></span>
       <span>Range: <a property="http://schema.org/rangeIncludes" href="http://schema.org/Text">Text</a></span>
     </div>
@@ -6718,7 +6527,7 @@ Use this to explicitly override general opening hours brought in scope by &lt;a 
     </div>
     <div typeof="rdf:Property" resource="http://schema.org/requiresSubscription">
       <span class="h" property="rdfs:label">requiresSubscription</span>
-      <span property="rdfs:comment">Indicates if use of the media require a subscription  (either paid or free). Allowed values are &lt;code&gt;true&lt;/code&gt; or &lt;code&gt;false&lt;/code&gt; (note that an earlier version had &#39;yes&#39;, &#39;no&#39;).</span>
+      <span property="rdfs:comment">Indicates if use of the media require a subscription  (either paid or free). Allowed values are ```true``` or ```false``` (note that an earlier version had 'yes', 'no').</span>
       <span>Domain: <a property="http://schema.org/domainIncludes" href="http://schema.org/MediaObject">MediaObject</a></span>
       <span>Range: <a property="http://schema.org/rangeIncludes" href="http://schema.org/Boolean">Boolean</a></span>
     </div>
@@ -6784,7 +6593,7 @@ Use this to explicitly override general opening hours brought in scope by &lt;a 
     </div>
     <div typeof="rdf:Property" resource="http://schema.org/reviewRating">
       <span class="h" property="rdfs:label">reviewRating</span>
-      <span property="rdfs:comment">The rating given in this review. Note that reviews can themselves be rated. The &lt;code&gt;reviewRating&lt;/code&gt; applies to rating given by the review. The &lt;code&gt;aggregateRating&lt;/code&gt; property applies to the review itself, as a creative work.</span>
+      <span property="rdfs:comment">The rating given in this review. Note that reviews can themselves be rated. The ```reviewRating``` applies to rating given by the review. The [[aggregateRating]] property applies to the review itself, as a creative work.</span>
       <span>Domain: <a property="http://schema.org/domainIncludes" href="http://schema.org/Review">Review</a></span>
       <span>Range: <a property="http://schema.org/rangeIncludes" href="http://schema.org/Rating">Rating</a></span>
     </div>
@@ -6816,7 +6625,7 @@ Use this to explicitly override general opening hours brought in scope by &lt;a 
 
     <div typeof="rdf:Property" resource="http://schema.org/salaryCurrency">
       <span class="h" property="rdfs:label">salaryCurrency</span>
-      <span property="rdfs:comment">The currency (coded using ISO 4217, http://en.wikipedia.org/wiki/ISO_4217 ) used for the main salary information in this job posting or for this employee.</span>
+      <span property="rdfs:comment">The currency (coded using [ISO 4217](http://en.wikipedia.org/wiki/ISO_4217) ) used for the main salary information in this job posting or for this employee.</span>
       <span>Domain: <a property="http://schema.org/domainIncludes" href="http://schema.org/JobPosting">JobPosting</a></span>
       <span>Domain: <a property="http://schema.org/domainIncludes" href="http://schema.org/EmployeeRole">EmployeeRole</a></span>
       <span>Range: <a property="http://schema.org/rangeIncludes" href="http://schema.org/Text">Text</a></span>
@@ -7125,7 +6934,7 @@ Use this to explicitly override general opening hours brought in scope by &lt;a 
 
     <div typeof="rdf:Property" resource="http://schema.org/startDate">
       <span class="h" property="rdfs:label">startDate</span>
-      <span property="rdfs:comment">The start date and time of the item (in &lt;a href=&#39;http://en.wikipedia.org/wiki/ISO_8601&#39;&gt;ISO 8601 date format&lt;/a&gt;).</span>
+      <span property="rdfs:comment">The start date and time of the item (in [ISO 8601 date format](http://en.wikipedia.org/wiki/ISO_8601)).</span>
       <span>Domain: <a property="http://schema.org/domainIncludes" href="http://schema.org/Role">Role</a></span>
       <span>Domain: <a property="http://schema.org/domainIncludes" href="http://schema.org/Event">Event</a></span>
       <span>Domain: <a property="http://schema.org/domainIncludes" href="http://schema.org/CreativeWorkSeason">CreativeWorkSeason</a></span>
@@ -7134,9 +6943,7 @@ Use this to explicitly override general opening hours brought in scope by &lt;a 
     </div>
     <div typeof="rdf:Property" resource="http://schema.org/startTime">
       <span class="h" property="rdfs:label">startTime</span>
-      <span property="rdfs:comment">The startTime of something. For a reserved event or service (e.g. FoodEstablishmentReservation), the time that it is expected to start. For actions that span a period of time, when the action was performed. e.g. John wrote a book from *January* to December.
-
-Note that Event uses startDate/endDate instead of startTime/endTime, even when describing dates with times. This situation may be clarified in future revisions.</span>
+      <span property="rdfs:comment">The startTime of something. For a reserved event or service (e.g. FoodEstablishmentReservation), the time that it is expected to start. For actions that span a period of time, when the action was performed. e.g. John wrote a book from *January* to December.\n\nNote that Event uses startDate/endDate instead of startTime/endTime, even when describing dates with times. This situation may be clarified in future revisions.</span>
       <span>Domain: <a property="http://schema.org/domainIncludes" href="http://schema.org/Action">Action</a></span>
       <span>Domain: <a property="http://schema.org/domainIncludes" href="http://schema.org/FoodEstablishmentReservation">FoodEstablishmentReservation</a></span>
       <span>Range: <a property="http://schema.org/rangeIncludes" href="http://schema.org/DateTime">DateTime</a></span>
@@ -7179,7 +6986,7 @@ Note that Event uses startDate/endDate instead of startTime/endTime, even when d
     </div>
     <div typeof="rdf:Property" resource="http://schema.org/subtitleLanguage">
       <span class="h" property="rdfs:label">subtitleLanguage</span>
-      <span property="rdfs:comment">Languages in which subtitles/captions are available, in &lt;a href=&#39;http://tools.ietf.org/html/bcp47&#39;&gt;IETF BCP 47 standard format.&lt;/a&gt;</span>
+      <span property="rdfs:comment">Languages in which subtitles/captions are available, in [IETF BCP 47 standard format](http://tools.ietf.org/html/bcp47).</span>
       <span>Domain: <a property="http://schema.org/domainIncludes" href="http://schema.org/Movie">Movie</a></span>
       <span>Domain: <a property="http://schema.org/domainIncludes" href="http://schema.org/ScreeningEvent">ScreeningEvent</a></span>
       <span>Domain: <a property="http://schema.org/domainIncludes" href="http://schema.org/TVEpisode">TVEpisode</a></span>
@@ -7318,7 +7125,7 @@ Note that Event uses startDate/endDate instead of startTime/endTime, even when d
     </div>
     <div typeof="rdf:Property" resource="http://schema.org/timeRequired">
       <span class="h" property="rdfs:label">timeRequired</span>
-      <span property="rdfs:comment">Approximate or typical time it takes to work with or through this learning resource for the typical intended target audience, e.g. &#39;P30M&#39;, &#39;P1H25M&#39;.</span>
+      <span property="rdfs:comment">Approximate or typical time it takes to work with or through this learning resource for the typical intended target audience, e.g. 'P30M', 'P1H25M'.</span>
       <span>Domain: <a property="http://schema.org/domainIncludes" href="http://schema.org/CreativeWork">CreativeWork</a></span>
       <span>Range: <a property="http://schema.org/rangeIncludes" href="http://schema.org/Duration">Duration</a></span>
     </div>
@@ -7399,7 +7206,6 @@ Note that Event uses startDate/endDate instead of startTime/endTime, even when d
     <div typeof="rdf:Property" resource="http://schema.org/unitCode">
       <span class="h" property="rdfs:label">unitCode</span>
       <span property="rdfs:comment">The unit of measurement given using the UN/CEFACT Common Code (3 characters) or a URL. Other codes than the UN/CEFACT Common Code may be used with a prefix followed by a colon.</span>
-
       <span>Domain: <a property="http://schema.org/domainIncludes" href="http://schema.org/QuantitativeValue">QuantitativeValue</a></span>
       <span>Domain: <a property="http://schema.org/domainIncludes" href="http://schema.org/TypeAndQuantityNode">TypeAndQuantityNode</a></span>
       <span>Domain: <a property="http://schema.org/domainIncludes" href="http://schema.org/UnitPriceSpecification">UnitPriceSpecification</a></span>
@@ -7463,9 +7269,7 @@ Note that Event uses startDate/endDate instead of startTime/endTime, even when d
     </div>
     <div typeof="rdf:Property" resource="http://schema.org/value">
       <span class="h" property="rdfs:label">value</span>
-      <span property="rdfs:comment">The value of the quantitative value or property value node.&lt;br/&gt;
-	For QuantitativeValue and MonetaryValue, the recommended type for values is &apos;Number&apos;. &lt;br/&gt;
-	For PropertyValue, it can be &apos;Text;&apos;, &apos;Number&apos;, &apos;Boolean&apos;, or &apos;StructuredValue&apos;.</span>
+      <span property="rdfs:comment">The value of the quantitative value or property value node.\n\n* For [[QuantitativeValue]] and [[MonetaryAmount]], the recommended type for values is &apos;Number&apos;.\n* For [[PropertyValue]], it can be &apos;Text;&apos;, &apos;Number&apos;, &apos;Boolean&apos;, or &apos;StructuredValue&apos;.</span>
       <span>Domain: <a property="http://schema.org/domainIncludes" href="http://schema.org/QuantitativeValue">QuantitativeValue</a></span>
 	  <span>Domain: <a property="http://schema.org/domainIncludes" href="http://schema.org/PropertyValue">PropertyValue</a></span>
       <span>Domain: <a property="http://schema.org/domainIncludes" href="http://schema.org/MonetaryAmount">MonetaryAmount</a></span>
@@ -7657,17 +7461,17 @@ Note that Event uses startDate/endDate instead of startTime/endTime, even when d
 
     <div typeof="http://schema.org/Organization" resource="http://www.w3.org/wiki/WebSchemas/SchemaDotOrgSources#source_WikiDoc">
       <span property="rdfs:label">WikiDoc</span>
-      <span property="rdfs:comment">This class contains information contributed by &lt;a href=http://wikidoc.org&gt;WikiDoc&lt;/a&gt;.</span>
+      <span property="rdfs:comment">This class contains information contributed by [http://wikidoc.org&gt;WikiDoc](http://wikidoc.org&gt;WikiDoc).</span>
     </div>
 
     <div typeof="http://schema.org/Organization" resource="http://www.w3.org/wiki/WebSchemas/SchemaDotOrgSources#source_QAStackExchange">
       <span property="rdfs:label">Stack Exchange</span>
-      <span property="rdfs:comment">The Question/Answer types were &lt;a href="https://www.w3.org/wiki/WebSchemas/QASchemaResearch"&gt;based on&lt;/a&gt; the Stack Overflow API.</span>
+      <span property="rdfs:comment">The Question/Answer types were [based on](https://www.w3.org/wiki/WebSchemas/QASchemaResearch) the Stack Overflow API.</span>
     </div>
 
     <div typeof="http://schema.org/Organization" resource="http://www.w3.org/wiki/WebSchemas/SchemaDotOrgSources#source_rNews">
       <span property="rdfs:label">rNews</span>
-      <span property="rdfs:comment">This class contains derivatives of IPTC rNews properties. rNews is a data model of publishing metadata with serializations currently available for RDFa as well as HTML5 Microdata. More information about the IPTC and rNews can be found at &lt;a href=http://rnews.org&gt;rnews.org&lt;/a&gt;.</span>
+      <span property="rdfs:comment">This class contains derivatives of IPTC rNews properties. rNews is a data model of publishing metadata with serializations currently available for RDFa as well as HTML5 Microdata. More information about the IPTC and rNews can be found at [rnews.org](http://rnews.org).</span>
     </div>
 
     <div typeof="http://schema.org/Organization" resource="http://www.w3.org/wiki/WebSchemas/SchemaDotOrgSources#source_DatasetClass">
@@ -7677,13 +7481,12 @@ Note that Event uses startDate/endDate instead of startTime/endTime, even when d
 
     <div typeof="http://schema.org/Organization" resource="http://www.w3.org/wiki/WebSchemas/SchemaDotOrgSources#source_GoodRelationsClass">
       <span property="rdfs:label">GoodRelationsClass</span>
-      <span property="rdfs:comment">This class is derived from the GoodRelations Vocabulary for E-Commerce, created by Martin Hepp. GoodRelations is a data model for sharing e-commerce data on the Web that can be expressed in a variety of syntaxes, including RDFa and HTML5 Microdata. More information about GoodRelations can be found at &lt;a href=&quot;http://purl.org/goodrelations/&quot;&gt;http://purl.org/goodrelations/&lt;/a&gt;.</span>
+      <span property="rdfs:comment">This class is derived from the GoodRelations Vocabulary for E-Commerce, created by Martin Hepp. GoodRelations is a data model for sharing e-commerce data on the Web that can be expressed in a variety of syntaxes, including RDFa and HTML5 Microdata. More information about GoodRelations can be found at [http://purl.org/goodrelations/](http://purl.org/goodrelations/).</span>
     </div>
 
     <div typeof="http://schema.org/Organization" resource="http://www.w3.org/wiki/WebSchemas/SchemaDotOrgSources#source_GoodRelationsTerms">
       <span property="rdfs:label">GoodRelationsTerms</span>
-      <span property="rdfs:comment">This term &lt;a href="http://blog.schema.org/2012/11/good-relations-and-schemaorg.html">uses&lt;/a&gt; terminology from the GoodRelations Vocabulary for E-Commerce, created by Martin Hepp. GoodRelations is a data model for sharing e-commerce data on the Web. More information about GoodRelations can be found at &lt;a href=&quot;
-        http://purl.org/goodrelations/&quot;&gt;http://purl.org/goodrelations/&lt;/a&gt;.</span>
+      <span property="rdfs:comment">This term [uses](http://blog.schema.org/2012/11/good-relations-and-schemaorg.html) terminology from the GoodRelations Vocabulary for E-Commerce, created by Martin Hepp. GoodRelations is a data model for sharing e-commerce data on the Web. More information about GoodRelations can be found at [http://purl.org/goodrelations/](http://purl.org/goodrelations/).</span>
     </div>
 
     <div typeof="http://schema.org/Organization" resource="http://www.w3.org/wiki/WebSchemas/SchemaDotOrgSources#source_LRMIClass">
@@ -7693,7 +7496,7 @@ Note that Event uses startDate/endDate instead of startTime/endTime, even when d
 
     <div typeof="http://schema.org/Organization" resource="http://www.w3.org/wiki/WebSchemas/SchemaDotOrgSources#source_ActionCollabClass">
       <span property="rdfs:label">ActionCollabClass</span>
-      <span property="rdfs:comment">The schema.org Actions mechanism benefited from extensive discussions across the Web standards community around W3C, in particular from the &lt;a href=&quot;http://purl.org/hydra/&quot;&gt; Hydra project&lt;/a&gt;'s community group.</span>
+      <span property="rdfs:comment">The schema.org Actions mechanism benefited from extensive discussions across the Web standards community around W3C, in particular from the [Hydra project](http://purl.org/hydra/)'s community group.</span>
     </div>
 
     <div typeof="http://schema.org/Organization" resource="http://www.w3.org/wiki/WebSchemas/SchemaDotOrgSources#source_bibex">
@@ -7711,22 +7514,22 @@ Note that Event uses startDate/endDate instead of startTime/endTime, even when d
 
     <div typeof="rdfs:Class" resource="http://schema.org/Reservation">
       <span class="h" property="rdfs:label">Reservation</span>
-      <span property="rdfs:comment">Describes a reservation for travel, dining or an event. Some reservations require tickets.<p>Note: This type is for information about actual reservations, e.g. in confirmation emails or HTML pages with individual confirmations of reservations. For offers of tickets, restaurant reservations, flights, or rental cars, use http://schema.org/Offer.</p></span>
+      <span property="rdfs:comment">Describes a reservation for travel, dining or an event. Some reservations require tickets. \n\nNote: This type is for information about actual reservations, e.g. in confirmation emails or HTML pages with individual confirmations of reservations. For offers of tickets, restaurant reservations, flights, or rental cars, use [[Offer]].</span>
       <span>Subclass of: <a property="rdfs:subClassOf" href="http://schema.org/Intangible">Intangible</a></span>
     </div>
     <div typeof="rdfs:Class" resource="http://schema.org/BusReservation">
       <span class="h" property="rdfs:label">BusReservation</span>
-      <span property="rdfs:comment">A reservation for bus travel.<p>Note: This type is for information about actual reservations, e.g. in confirmation emails or HTML pages with individual confirmations of reservations. For offers of tickets, use http://schema.org/Offer.</p></span>
+      <span property="rdfs:comment">A reservation for bus travel. \n\nNote: This type is for information about actual reservations, e.g. in confirmation emails or HTML pages with individual confirmations of reservations. For offers of tickets, use [[Offer]].</span>
       <span>Subclass of: <a property="rdfs:subClassOf" href="http://schema.org/Reservation">Reservation</a></span>
     </div>
     <div typeof="rdfs:Class" resource="http://schema.org/EventReservation">
       <span class="h" property="rdfs:label">EventReservation</span>
-      <span property="rdfs:comment">A reservation for an event like a concert, sporting event, or lecture.<p>Note: This type is for information about actual reservations, e.g. in confirmation emails or HTML pages with individual confirmations of reservations. For offers of tickets, use http://schema.org/Offer.</p></span>
+      <span property="rdfs:comment">A reservation for an event like a concert, sporting event, or lecture.\n\nNote: This type is for information about actual reservations, e.g. in confirmation emails or HTML pages with individual confirmations of reservations. For offers of tickets, use [[Offer]].</span>
       <span>Subclass of: <a property="rdfs:subClassOf" href="http://schema.org/Reservation">Reservation</a></span>
     </div>
     <div typeof="rdfs:Class" resource="http://schema.org/FlightReservation">
       <span class="h" property="rdfs:label">FlightReservation</span>
-      <span property="rdfs:comment">A reservation for air travel.<p>Note: This type is for information about actual reservations, e.g. in confirmation emails or HTML pages with individual confirmations of reservations. For offers of tickets, use http://schema.org/Offer.</p></span>
+      <span property="rdfs:comment">A reservation for air travel.\n\nNote: This type is for information about actual reservations, e.g. in confirmation emails or HTML pages with individual confirmations of reservations. For offers of tickets, use [[Offer]].</span>
       <span>Subclass of: <a property="rdfs:subClassOf" href="http://schema.org/Reservation">Reservation</a></span>
     </div>
     <div typeof="rdfs:Class" resource="http://schema.org/FoodEstablishmentReservation">
@@ -7736,22 +7539,22 @@ Note that Event uses startDate/endDate instead of startTime/endTime, even when d
     </div>
     <div typeof="rdfs:Class" resource="http://schema.org/LodgingReservation">
       <span class="h" property="rdfs:label">LodgingReservation</span>
-      <span property="rdfs:comment">A reservation for lodging at a hotel, motel, inn, etc.<p>Note: This type is for information about actual reservations, e.g. in confirmation emails or HTML pages with individual confirmations of reservations.</p></span>
+      <span property="rdfs:comment">A reservation for lodging at a hotel, motel, inn, etc.\n\nNote: This type is for information about actual reservations, e.g. in confirmation emails or HTML pages with individual confirmations of reservations.</span>
       <span>Subclass of: <a property="rdfs:subClassOf" href="http://schema.org/Reservation">Reservation</a></span>
     </div>
     <div typeof="rdfs:Class" resource="http://schema.org/RentalCarReservation">
       <span class="h" property="rdfs:label">RentalCarReservation</span>
-      <span property="rdfs:comment">A reservation for a rental car.<p>Note: This type is for information about actual reservations, e.g. in confirmation emails or HTML pages with individual confirmations of reservations.</p></span>
+      <span property="rdfs:comment">A reservation for a rental car.\n\nNote: This type is for information about actual reservations, e.g. in confirmation emails or HTML pages with individual confirmations of reservations.</span>
       <span>Subclass of: <a property="rdfs:subClassOf" href="http://schema.org/Reservation">Reservation</a></span>
     </div>
     <div typeof="rdfs:Class" resource="http://schema.org/TaxiReservation">
       <span class="h" property="rdfs:label">TaxiReservation</span>
-      <span property="rdfs:comment">A reservation for a taxi.<p>Note: This type is for information about actual reservations, e.g. in confirmation emails or HTML pages with individual confirmations of reservations. For offers of tickets, use http://schema.org/Offer.</p></span>
+      <span property="rdfs:comment">A reservation for a taxi.\n\nNote: This type is for information about actual reservations, e.g. in confirmation emails or HTML pages with individual confirmations of reservations. For offers of tickets, use [[Offer]].</span>
       <span>Subclass of: <a property="rdfs:subClassOf" href="http://schema.org/Reservation">Reservation</a></span>
     </div>
     <div typeof="rdfs:Class" resource="http://schema.org/TrainReservation">
       <span class="h" property="rdfs:label">TrainReservation</span>
-      <span property="rdfs:comment">A reservation for train travel.<p>Note: This type is for information about actual reservations, e.g. in confirmation emails or HTML pages with individual confirmations of reservations. For offers of tickets, use http://schema.org/Offer.</p></span>
+      <span property="rdfs:comment">A reservation for train travel.\n\nNote: This type is for information about actual reservations, e.g. in confirmation emails or HTML pages with individual confirmations of reservations. For offers of tickets, use [[Offer]].</span>
       <span>Subclass of: <a property="rdfs:subClassOf" href="http://schema.org/Reservation">Reservation</a></span>
     </div>
     <div typeof="rdfs:Class" resource="http://schema.org/ReservationPackage">
@@ -7930,7 +7733,7 @@ Note that Event uses startDate/endDate instead of startTime/endTime, even when d
     </div>
     <div typeof="rdf:Property" resource="http://schema.org/priceCurrency">
       <span class="h" property="rdfs:label">priceCurrency</span>
-      <span property="rdfs:comment">The currency (in 3-letter ISO 4217 format) of the price or a price component, when attached to PriceSpecification and its subtypes.</span>
+      <span property="rdfs:comment">The currency (in 3-letter ISO 4217 format) of the price or a price component, when attached to [[PriceSpecification]] and its subtypes.</span>
       <span>domain: <a property="http://schema.org/domainIncludes" href="http://schema.org/Reservation">Reservation</a></span>
       <span>domain: <a property="http://schema.org/domainIncludes" href="http://schema.org/Ticket">Ticket</a></span>
       <span>Domain: <a property="http://schema.org/domainIncludes" href="http://schema.org/Offer">Offer</a></span>
@@ -8649,9 +8452,7 @@ postponing for 1.6.
 
     <div typeof="rdfs:Class" resource="http://schema.org/Role">
       <span class="h" property="rdfs:label">Role</span>
-      <span property="rdfs:comment">Represents additional information about a relationship or property. For example a Role can be used to say that a 'member' role linking some SportsTeam to a player occurred during a particular time period. Or that a Person's 'actor' role in a Movie was for some particular characterName. Such properties can be attached to a Role entity, which is then associated with the main entities using ordinary properties like 'member' or 'actor'.
-
-      &lt;br/&gt;&lt;br/&gt;See also &lt;a href="http://blog.schema.org/2014/06/introducing-role.html"&gt;blog post&lt;/a&gt;.</span>
+      <span property="rdfs:comment">Represents additional information about a relationship or property. For example a Role can be used to say that a 'member' role linking some SportsTeam to a player occurred during a particular time period. Or that a Person's 'actor' role in a Movie was for some particular characterName. Such properties can be attached to a Role entity, which is then associated with the main entities using ordinary properties like 'member' or 'actor'.\n\nSee also [blog post](http://blog.schema.org/2014/06/introducing-role.html).</span>
     <span>Subclass of: <a property="rdfs:subClassOf" href="http://schema.org/Intangible">Intangible</a></span>
     </div>
 
@@ -8726,9 +8527,7 @@ postponing for 1.6.
     </div>
     <div typeof="rdfs:Class" resource="http://schema.org/PublicationIssue">
       <span class="h" property="rdfs:label">PublicationIssue</span>
-      <span property="rdfs:comment">A part of a successively published publication such as a periodical or publication volume, often numbered, usually containing a grouping of works such as articles.
-
-      &lt;br/&gt;&lt;br/&gt;See also &lt;a href="http://blog.schema.org/2014/09/schemaorg-support-for-bibliographic_2.html"&gt;blog post&lt;/a&gt;.</span>
+      <span property="rdfs:comment">A part of a successively published publication such as a periodical or publication volume, often numbered, usually containing a grouping of works such as articles.\n\n[blog post](http://blog.schema.org/2014/09/schemaorg-support-for-bibliographic_2.html).</span>
       <span>Subclass of: <a property="rdfs:subClassOf" href="http://schema.org/CreativeWork">CreativeWork</a></span>
        <link property="owl:equivalentClass" href="http://purl.org/ontology/bibo/Issue"/>
        <span>Source:  <a property="dc:source" href="http://www.w3.org/wiki/WebSchemas/SchemaDotOrgSources#source_bibex">BibEx</a></span>
@@ -8836,11 +8635,7 @@ postponing for 1.6.
 
     <div typeof="rdf:Property" resource="http://schema.org/itemListElement">
       <span class="h" property="rdfs:label">itemListElement</span>
-      <span property="rdfs:comment">For itemListElement values, you can use simple strings (e.g. "Peter", "Paul", "Mary"), existing entities, or use ListItem.
-    &lt;br/&gt;&lt;br/&gt;
-    Text values are best if the elements in the list are plain strings. Existing entities are best for a simple, unordered list of existing things in your data. ListItem is used with ordered lists when you want to provide additional context about the element in that list or when the same item might be in different places in different lists.
-    &lt;br/&gt;&lt;br/&gt;
-    Note: The order of elements in your mark-up is not sufficient for indicating the order or elements.  Use ListItem with a 'position' property in such cases.</span>
+      <span property="rdfs:comment">For itemListElement values, you can use simple strings (e.g. "Peter", "Paul", "Mary"), existing entities, or use ListItem.\n\nText values are best if the elements in the list are plain strings. Existing entities are best for a simple, unordered list of existing things in your data. ListItem is used with ordered lists when you want to provide additional context about the element in that list or when the same item might be in different places in different lists.\n\nNote: The order of elements in your mark-up is not sufficient for indicating the order or elements.  Use ListItem with a 'position' property in such cases.</span>
       <span>Domain: <a property="http://schema.org/domainIncludes" href="http://schema.org/ItemList">ItemList</a></span>
       <span>Range: <a property="http://schema.org/rangeIncludes" href="http://schema.org/Text">Text</a></span>
       <span>Range: <a property="http://schema.org/rangeIncludes" href="http://schema.org/ListItem">ListItem</a></span>
@@ -9108,8 +8903,8 @@ postponing for 1.6.
 <div typeof="http://schema.org/Organization" resource="http://www.w3.org/wiki/WebSchemas/SchemaDotOrgSources#MBZ">
   <span property="rdfs:label">MBZ</span>
   <span property="rdfs:comment">This vocabulary was improved through collaboration with the MusicBrainz project
-    (&lt;a href=&quot;http://www.musicbrainz.org&quot;&gt;www.musicbrainz.org&lt;/a&gt;), and is partially inspired by the MusicBrainz and
-    &lt;a href=&quot;http://musicontology.com/docs/getting-started.html&quot;&gt;Music Ontology&lt;/a&gt; schemas.</span>
+    ([www.musicbrainz.org](http://www.musicbrainz.org)), and is partially inspired by the MusicBrainz and
+    [Music Ontology](http://musicontology.com/docs/getting-started.html) schemas.</span>
 </div>
 
 <p>We begin by extending MusicAlbum.</p>
@@ -9397,7 +9192,7 @@ postponing for 1.6.
 
 <div typeof="rdf:Property" resource="http://schema.org/regionsAllowed">
   <span class="h" property="rdfs:label">regionsAllowed</span>
-  <span property="rdfs:comment">The regions where the media is allowed. If not specified, then it&#39;s assumed to be allowed everywhere. Specify the countries in &lt;a href=&#39;http://en.wikipedia.org/wiki/ISO_3166&#39;&gt;ISO 3166 format&lt;/a&gt;.</span>
+  <span property="rdfs:comment">The regions where the media is allowed. If not specified, then it&#39;s assumed to be allowed everywhere. Specify the countries in [ISO 3166 format](http://en.wikipedia.org/wiki/ISO_3166).</span>
   <span>Domain: <a property="http://schema.org/domainIncludes" href="http://schema.org/MediaObject">MediaObject</a></span>
   <span>Range: <a property="http://schema.org/rangeIncludes" href="http://schema.org/Place">Place</a></span>
 </div>
@@ -9608,7 +9403,7 @@ postponing for 1.6.
   </div>
   <div typeof="rdf:Property" resource="http://schema.org/currency">
     <span class="h" property="rdfs:label">currency</span>
-    <span property="rdfs:comment">The currency in which the monetary amount is expressed (in 3-letter &lt;a href=&#39;http://en.wikipedia.org/wiki/ISO_4217&#39;"&gt;ISO 4217&lt;/a&gt; format).</span>
+    <span property="rdfs:comment">The currency in which the monetary amount is expressed (in 3-letter [ISO 4217](http://en.wikipedia.org/wiki/ISO_4217) format).</span>
     <span>domain: <a property="http://schema.org/domainIncludes" href="http://schema.org/DatedMoneySpecification">DatedMoneySpecification</a></span>
     <span>Domain: <a property="http://schema.org/domainIncludes" href="http://schema.org/MonetaryAmount">MonetaryAmount</a></span>
     <span>Range: <a property="http://schema.org/rangeIncludes" href="http://schema.org/Text">Text</a></span>
@@ -9769,18 +9564,14 @@ postponing for 1.6.
 <h1>Property-Value Support</h1>
 <div typeof="rdfs:Class" resource="http://schema.org/PropertyValue">
     <span class="h" property="rdfs:label">PropertyValue</span>
-    <span property="rdfs:comment">A property-value pair, e.g. representing a feature of a product or place. Use the &apos;name&apos; property for the name of the property. If there is an additional human-readable version of the value, put that into the &apos;description&apos; property.
-        &lt;br/&gt;&lt;br/&gt;
-        Always use specific schema.org properties when a) they exist and b) you can populate them. Using PropertyValue as a substitute will typically not trigger the same effect as using the original, specific property.
+    <span property="rdfs:comment">A property-value pair, e.g. representing a feature of a product or place. Use the &apos;name&apos; property for the name of the property. If there is an additional human-readable version of the value, put that into the &apos;description&apos; property.\n\n Always use specific schema.org properties when a) they exist and b) you can populate them. Using PropertyValue as a substitute will typically not trigger the same effect as using the original, specific property.
     </span>
     <span>Subclass of: <a property="rdfs:subClassOf" href="http://schema.org/StructuredValue">StructuredValue</a></span>
     <span>Source:  <a property="dc:source" href="http://www.w3.org/wiki/WebSchemas/SchemaDotOrgSources#source_GoodRelationsClass">GoodRelationsClass</a></span>
 </div>
 <div typeof="rdf:Property" resource="http://schema.org/additionalProperty">
     <span class="h" property="rdfs:label">additionalProperty</span>
-    <span property="rdfs:comment">A property-value pair representing an additional characteristics of the entitity, e.g. a product feature or another characteristic for which there is no matching property in schema.org. &lt;br /&gt;&lt;br /&gt;
-
-Note: Publishers should be aware that applications designed to use specific schema.org properties (e.g. http://schema.org/width, http://schema.org/color, http://schema.org/gtin13, ...) will typically expect such data to be provided using those properties, rather than using the generic property/value mechanism.
+    <span property="rdfs:comment">A property-value pair representing an additional characteristics of the entitity, e.g. a product feature or another characteristic for which there is no matching property in schema.org.\n\nNote: Publishers should be aware that applications designed to use specific schema.org properties (e.g. http://schema.org/width, http://schema.org/color, http://schema.org/gtin13, ...) will typically expect such data to be provided using those properties, rather than using the generic property/value mechanism.
 </span>
     <span>Domain: <a property="http://schema.org/domainIncludes" href="http://schema.org/Product">Product</a></span>
     <span>Domain: <a property="http://schema.org/domainIncludes" href="http://schema.org/Place">Place</a></span>
@@ -9809,7 +9600,7 @@ Standards bodies should promote a standard prefix for the identifiers of propert
     <span>Range: <a property="http://schema.org/rangeIncludes" href="http://schema.org/URL">URL</a></span>
 </div>
 
-﻿<div>
+<div>
   <h1>TV Listing additions</h1>
     <div typeof="rdf:Property" resource="http://schema.org/broadcastAffiliateOf">
       <span class="h" property="rdfs:label">broadcastAffiliateOf</span>
@@ -9831,7 +9622,7 @@ Standards bodies should promote a standard prefix for the identifiers of propert
     </div>
     <div typeof="rdf:Property" resource="http://schema.org/broadcastTimezone">
       <span class="h" property="rdfs:label">timezone</span>
-      <span property="rdfs:comment">The timezone in &lt;a href=&#39;http://en.wikipedia.org/wiki/ISO_8601&#39;&gt;ISO 8601 format&lt;/a&gt; for which the service bases its broadcasts.</span>
+      <span property="rdfs:comment">The timezone in [ISO 8601 format](http://en.wikipedia.org/wiki/ISO_8601) for which the service bases its broadcasts</span>
       <span>Domain: <a property="http://schema.org/domainIncludes" href="http://schema.org/BroadcastService">BroadcastService</a></span>
       <span>Range: <a property="http://schema.org/rangeIncludes" href="http://schema.org/Text">Text</a></span>
     </div>
@@ -9901,8 +9692,7 @@ Standards bodies should promote a standard prefix for the identifiers of propert
 
 <div typeof="rdf:Property" resource="http://schema.org/numberOfDoors">
     <span class="h" property="rdfs:label">numberOfDoors</span>
-    <span property="rdfs:comment">The number of doors.&lt;br /&gt;
-Typical unit code(s): C62</span>
+    <span property="rdfs:comment">The number of doors.\n\nTypical unit code(s): C62</span>
     <span>Domain: <a property="http://schema.org/domainIncludes" href="http://schema.org/Vehicle">Vehicle</a></span>
     <span>Range: <a property="http://schema.org/rangeIncludes" href="http://schema.org/QuantitativeValue">QuantitativeValue</a></span>
     <span>Range: <a property="http://schema.org/rangeIncludes" href="http://schema.org/Number">Number</a></span>
@@ -9925,8 +9715,7 @@ Typical unit code(s): C62</span>
 
 <div typeof="rdf:Property" resource="http://schema.org/numberOfAxles">
     <span class="h" property="rdfs:label">numberOfAxles</span>
-    <span property="rdfs:comment">The number of axles.&lt;br /&gt;
-Typical unit code(s): C62</span>
+    <span property="rdfs:comment">The number of axles.\n\nTypical unit code(s): C62</span>
     <span>Domain: <a property="http://schema.org/domainIncludes" href="http://schema.org/Vehicle">Vehicle</a></span>
     <span>Range: <a property="http://schema.org/rangeIncludes" href="http://schema.org/QuantitativeValue">QuantitativeValue</a></span>
     <span>Range: <a property="http://schema.org/rangeIncludes" href="http://schema.org/Number">Number</a></span>
@@ -9943,11 +9732,7 @@ Typical unit code(s): C62</span>
 
 <div typeof="rdf:Property" resource="http://schema.org/fuelConsumption">
     <span class="h" property="rdfs:label">fuelConsumption</span>
-    <span property="rdfs:comment">The amount of fuel consumed for traveling a particular distance or temporal duration with the given vehicle (e.g. liters per 100 km).&lt;br /&gt;
-Note 1: There are unfortunately no standard unit codes for liters per 100 km.&lt;br /&gt;
-Use &lt;a href=&quot;unitText&quot;&gt;unitText&lt;/a&gt; to indicate the unit of measurement, e.g. L/100 km.
-Note 2: There are two ways of indicating the fuel consumption, &lt;a href=&quot;fuelConsumption&quot;&gt;fuelConsumption&lt;/a&gt; (e.g. 8 liters per 100 km) and &lt;a href=&quot;fuelEfficiency&quot;&gt;fuelEfficiency&lt;/a&gt; (e.g. 30 miles per gallon). They are reciprocal.&lt;br /&gt;
-Note 3: Often, the absolute value is useful only when related to driving speed ("at 80 km/h") or usage pattern ("city traffic"). You can use &lt;a href=&quot;valueReference&quot;&gt;valueReference&lt;/a&gt; to link the value for the fuel consumption to another value.</span>
+    <span property="rdfs:comment">The amount of fuel consumed for traveling a particular distance or temporal duration with the given vehicle (e.g. liters per 100 km).\n\n* Note 1: There are unfortunately no standard unit codes for liters per 100 km.  Use [[unitText]] to indicate the unit of measurement, e.g. L/100 km.\n* Note 2: There are two ways of indicating the fuel consumption, [[fuelConsumption]] (e.g. 8 liters per 100 km) and [[fuelEfficiency]] (e.g. 30 miles per gallon). They are reciprocal.\n* Note 3: Often, the absolute value is useful only when related to driving speed ("at 80 km/h") or usage pattern ("city traffic"). You can use [[valueReference]] to link the value for the fuel consumption to another value.</span>
     <span>Domain: <a property="http://schema.org/domainIncludes" href="http://schema.org/Vehicle">Vehicle</a></span>
     <span>Range: <a property="http://schema.org/rangeIncludes" href="http://schema.org/QuantitativeValue">QuantitativeValue</a></span>
     <span>Source:  <a property="dc:source" href="http://www.w3.org/wiki/WebSchemas/SchemaDotOrgSources#Automotive_Ontology_Working_Group">GAO</a></span>
@@ -9955,11 +9740,7 @@ Note 3: Often, the absolute value is useful only when related to driving speed (
 
 <div typeof="rdf:Property" resource="http://schema.org/fuelEfficiency">
     <span class="h" property="rdfs:label">fuelEfficiency</span>
-    <span property="rdfs:comment">The distance traveled per unit of fuel used; most commonly miles per gallon (mpg) or kilometers per liter (km/L).&lt;br /&gt;
-Note 1: There are unfortunately no standard unit codes for miles per gallon or kilometers per liter.&lt;br /&gt;
-Use &lt;a href=&quot;unitText&quot;&gt;unitText&lt;/a&gt; to indicate the unit of measurement, e.g. mpg or km/L.
-Note 2: There are two ways of indicating the fuel consumption, &lt;a href=&quot;fuelConsumption&quot;&gt;fuelConsumption&lt;/a&gt; (e.g. 8 liters per 100 km) and &lt;a href=&quot;fuelEfficiency&quot;&gt;fuelEfficiency&lt;/a&gt; (e.g. 30 miles per gallon). They are reciprocal.&lt;br /&gt;
-Note 3: Often, the absolute value is useful only when related to driving speed ("at 80 km/h") or usage pattern ("city traffic"). You can use &lt;a href=&quot;valueReference&quot;&gt;valueReference&lt;/a&gt; to link the value for the fuel economy to another value.</span>
+    <span property="rdfs:comment">The distance traveled per unit of fuel used; most commonly miles per gallon (mpg) or kilometers per liter (km/L).\n\n* Note 1: There are unfortunately no standard unit codes for miles per gallon or kilometers per liter. Use [[unitText]] to indicate the unit of measurement, e.g. mpg or km/L.\n* Note 2: There are two ways of indicating the fuel consumption, [[fuelConsumption]] (e.g. 8 liters per 100 km) and [[fuelEfficiency]] (e.g. 30 miles per gallon). They are reciprocal.\n* Note 3: Often, the absolute value is useful only when related to driving speed ("at 80 km/h") or usage pattern ("city traffic"). You can use [[valueReference]] to link the value for the fuel economy to another value.</span>
     <span>Domain: <a property="http://schema.org/domainIncludes" href="http://schema.org/Vehicle">Vehicle</a></span>
     <span>Range: <a property="http://schema.org/rangeIncludes" href="http://schema.org/QuantitativeValue">QuantitativeValue</a></span>
     <span>Source:  <a property="dc:source" href="http://www.w3.org/wiki/WebSchemas/SchemaDotOrgSources#Automotive_Ontology_Working_Group">GAO</a></span>
@@ -9967,8 +9748,7 @@ Note 3: Often, the absolute value is useful only when related to driving speed (
 
 <div typeof="rdf:Property" resource="http://schema.org/numberOfForwardGears">
     <span class="h" property="rdfs:label">numberOfForwardGears</span>
-    <span property="rdfs:comment">The total number of forward gears available for the transmission system of the vehicle.&lt;br /&gt;
-Typical unit code(s): C62</span>
+    <span property="rdfs:comment">The total number of forward gears available for the transmission system of the vehicle.\n\nTypical unit code(s): C62</span>
     <span>Domain: <a property="http://schema.org/domainIncludes" href="http://schema.org/Vehicle">Vehicle</a></span>
     <span>Range: <a property="http://schema.org/rangeIncludes" href="http://schema.org/QuantitativeValue">QuantitativeValue</a></span>
     <span>Range: <a property="http://schema.org/rangeIncludes" href="http://schema.org/Number">Number</a></span>
@@ -9986,10 +9766,7 @@ Typical unit code(s): C62</span>
 
 <div typeof="rdf:Property" resource="http://schema.org/cargoVolume">
     <span class="h" property="rdfs:label">cargoVolume</span>
-    <span property="rdfs:comment">The available volume for cargo or luggage. For automobiles, this is usually the trunk volume.&lt;br /&gt;
-Typical unit code(s): LTR for liters, FTQ for cubic foot/feet&lt;br /&gt;
-
-Note: You can use &lt;a href=&quot;minValue&quot;&gt;minValue&lt;/a&gt; and &lt;a href=&quot;maxValue&quot;&gt;maxValue&lt;/a&gt; to indicate ranges.</span>
+    <span property="rdfs:comment">The available volume for cargo or luggage. For automobiles, this is usually the trunk volume.\n\nTypical unit code(s): LTR for liters, FTQ for cubic foot/feet\n\nNote: You can use [[minValue]] and [[maxValue]] to indicate ranges.</span>
     <span>Domain: <a property="http://schema.org/domainIncludes" href="http://schema.org/Vehicle">Vehicle</a></span>
     <span>Range: <a property="http://schema.org/rangeIncludes" href="http://schema.org/QuantitativeValue">QuantitativeValue</a></span>
     <span>Source:  <a property="dc:source" href="http://www.w3.org/wiki/WebSchemas/SchemaDotOrgSources#Automotive_Ontology_Working_Group">GAO</a></span>
@@ -10090,8 +9867,7 @@ Note: You can use &lt;a href=&quot;minValue&quot;&gt;minValue&lt;/a&gt; and &lt;
 
 <div typeof="rdf:Property" resource="http://schema.org/mileageFromOdometer">
     <span class="h" property="rdfs:label">mileageFromOdometer</span>
-    <span property="rdfs:comment">The total distance travelled by the particular vehicle since its initial production, as read from its odometer.&lt;br /&gt;
-Typical unit code(s): KMT for kilometers, SMI for statute miles</span>
+    <span property="rdfs:comment">The total distance travelled by the particular vehicle since its initial production, as read from its odometer.\n\nTypical unit code(s): KMT for kilometers, SMI for statute miles</span>
     <span>Domain: <a property="http://schema.org/domainIncludes" href="http://schema.org/Vehicle">Vehicle</a></span>
     <span>Range: <a property="http://schema.org/rangeIncludes" href="http://schema.org/QuantitativeValue">QuantitativeValue</a></span>
     <span>Source:  <a property="dc:source" href="http://www.w3.org/wiki/WebSchemas/SchemaDotOrgSources#Automotive_Ontology_Working_Group">GAO</a></span>
@@ -10107,8 +9883,7 @@ Typical unit code(s): KMT for kilometers, SMI for statute miles</span>
 
 <div typeof="rdf:Property" resource="http://schema.org/numberOfPreviousOwners"> <!-- was previousOwners -->
     <span class="h" property="rdfs:label">numberOfPreviousOwners</span>
-    <span property="rdfs:comment">The number of owners of the vehicle, including the current one.&lt;br /&gt;
-Typical unit code(s): C62</span>
+    <span property="rdfs:comment">The number of owners of the vehicle, including the current one.\n\nTypical unit code(s): C62</span>
     <span>Domain: <a property="http://schema.org/domainIncludes" href="http://schema.org/Vehicle">Vehicle</a></span>
     <span>Range: <a property="http://schema.org/rangeIncludes" href="http://schema.org/QuantitativeValue">QuantitativeValue</a></span>
     <span>Range: <a property="http://schema.org/rangeIncludes" href="http://schema.org/Number">Number</a></span>
@@ -10135,8 +9910,7 @@ Typical unit code(s): C62</span>
 
 <div typeof="rdf:Property" resource="http://schema.org/vehicleSeatingCapacity">
     <span class="h" property="rdfs:label">vehicleSeatingCapacity</span>
-    <span property="rdfs:comment">The number of passengers that can be seated in the vehicle, both in terms of the physical space available, and in terms of limitations set by law.&lt;br /&gt;
-Typical unit code(s): C62 for persons.</span>
+    <span property="rdfs:comment">The number of passengers that can be seated in the vehicle, both in terms of the physical space available, and in terms of limitations set by law.\n\nTypical unit code(s): C62 for persons.</span>
     <span>Domain: <a property="http://schema.org/domainIncludes" href="http://schema.org/Vehicle">Vehicle</a></span>
     <span>Range: <a property="http://schema.org/rangeIncludes" href="http://schema.org/QuantitativeValue">QuantitativeValue</a></span>
     <span>Range: <a property="http://schema.org/rangeIncludes" href="http://schema.org/Number">Number</a></span>
@@ -10210,7 +9984,7 @@ Typical unit code(s): C62 for persons.</span>
 </div>
 <div typeof="rdf:Property" resource="http://schema.org/interactionType">
     <span class="h" property="rdfs:label">interactionType</span>
-    <span property="rdfs:comment">The Action representing the type of interaction. For up votes, +1s, etc. use &lt;a href="/LikeAction";&gt;LikeAction&lt;/a&gt;. For down votes use &lt;a href="/DislikeAction"&gt;DislikeAction&lt;/a&gt;. Otherwise, use the most specific Action.</span>
+    <span property="rdfs:comment">The Action representing the type of interaction. For up votes, +1s, etc. use [[LikeAction]]. For down votes use [[DislikeAction]]. Otherwise, use the most specific Action.</span>
     <span>Domain: <a property="http://schema.org/domainIncludes" href="http://schema.org/InteractionCounter">InteractionCounter</a></span>
     <span>Range: <a property="http://schema.org/rangeIncludes" href="http://schema.org/Action">Action</a></span>
 </div>
@@ -10401,9 +10175,7 @@ Typical unit code(s): C62 for persons.</span>
 
 <div typeof="rdfs:Class" resource="http://schema.org/Recipe">
   <span class="h" property="rdfs:label">Recipe</span>
-  <span property="rdfs:comment">A recipe. For dietary restrictions covered by the recipe,
-    a few common restrictions are enumerated via &lt;a href="/suitableForDiet"&gt;suitableForDiet&lt;/a&gt;.
-    The &lt;a href="/keywords"&gt;keywords&lt;/a&gt; property can also be used to add more detail.</span>
+  <span property="rdfs:comment">A recipe. For dietary restrictions covered by the recipe, a few common restrictions are enumerated via [[suitableForDiet]]. The [[keywords]] property can also be used to add more detail.</span>
    <span>Subclass of: <a property="rdfs:subClassOf" href="http://schema.org/CreativeWork">CreativeWork</a></span>
 </div>
 
@@ -10607,14 +10379,6 @@ Typical unit code(s): C62 for persons.</span>
         <span>Source:  <a property="dc:source" href="http://www.w3.org/wiki/WebSchemas/SchemaDotOrgSources#source_GoodRelationsClass">GoodRelationsClass</a></span>
 </div>
 
-<div typeof="rdf:Property" resource="http://schema.org/priceComponent">
-    <span class="h" property="rdfs:label">priceComponent</span>
-    <span property="rdfs:comment">This property links to all UnitPriceSpecification nodes that apply in parallel for the CompoundPriceSpecification node.</span>
-    <span>Domain: <a property="http://schema.org/domainIncludes" href="http://schema.org/CompoundPriceSpecification">CompoundPriceSpecification</a></span>
-    <span>Range: <a property="http://schema.org/rangeIncludes" href="http://schema.org/UnitPriceSpecification">UnitPriceSpecification</a></span>
-    <span>Source:  <a property="dc:source" href="http://www.w3.org/wiki/WebSchemas/SchemaDotOrgSources#source_GoodRelationsProperties">GoodRelationsProperty</a></span>
-</div>
-
 <div typeof="rdf:Property" resource="http://schema.org/referenceQuantity">
     <span class="h" property="rdfs:label">referenceQuantity</span>
     <span property="rdfs:comment">The reference quantity for which a certain price applies, e.g. 1 EUR per 4 kWh of electricity. This property is a replacement for unitOfMeasurement for the advanced cases where the price does not relate to a standard unit.</span>
@@ -10626,7 +10390,7 @@ Typical unit code(s): C62 for persons.</span>
 
 <div typeof="http://schema.org/Organization" resource="http://www.w3.org/wiki/WebSchemas/SchemaDotOrgSources#FIBO">
     <span property="rdfs:label">FIBO</span>
-    <span property="rdfs:comment">This element is based on the work of the Financial Industry Business Ontology project (see &lt;a href="http://www.fibo.org/schema"&gt;http://www.fibo.org/schema&lt;/a&gt; for details), in support of the W3C Financial Industry Business Ontology Community Group ( &lt;a href="http://www.fibo.org/community""&gt;http://www.fibo.org/community&lt;/a&gt;). Many class and property definitions are inspired by or based on &lt;a href="http://www.fibo.org"&gt;http://www.fibo.org&lt;/a&gt;.</span>
+    <span property="rdfs:comment">This element is based on the work of the Financial Industry Business Ontology project (see [http://www.fibo.org/schema](http://www.fibo.org/schema) for details), in support of the W3C Financial Industry Business Ontology Community Group ([http://www.fibo.org/community](http://www.fibo.org/community)). Many class and property definitions are inspired by or based on [http://www.fibo.org](http://www.fibo.org).</span>
   </div>
 
   <div typeof="rdfs:Class" resource="http://schema.org/MonetaryAmount">
@@ -10796,7 +10560,7 @@ Typical unit code(s): C62 for persons.</span>
 
 <div typeof="rdf:Property" resource="http://schema.org/priceComponent">
     <span class="h" property="rdfs:label">priceComponent</span>
-    <span property="rdfs:comment">This property links to all UnitPriceSpecification nodes that apply in parallel for the CompoundPriceSpecification node.</span>
+    <span property="rdfs:comment">This property links to all [[UnitPriceSpecification]] nodes that apply in parallel for the [[CompoundPriceSpecification]] node.</span>
     <span>Domain: <a property="http://schema.org/domainIncludes" href="http://schema.org/CompoundPriceSpecification">CompoundPriceSpecification</a></span>
     <span>Range: <a property="http://schema.org/rangeIncludes" href="http://schema.org/UnitPriceSpecification">UnitPriceSpecification</a></span>
     <span>Source:  <a property="dc:source" href="http://www.w3.org/wiki/WebSchemas/SchemaDotOrgSources#source_GoodRelationsTerms">GoodRelationsProperty</a></span>


### PR DESCRIPTION
A replacement for PR #1137 

Terms updated are listed in this Gist: https://gist.github.com/RichardWallis/4e90255c0daf052c35ea6e15670c7419

Also removed duplicate definition for http://schema.org/priceComponent