### PR TITLE
Fix minor typo in extension.html

### DIFF
--- a/docs/extension.html
+++ b/docs/extension.html
@@ -61,7 +61,7 @@
 
 
 <p>We have two kinds of named extension to schema.org: 'hosted' and 'external'.  This is in addition to the ongoing practice of extending
-  schema.org via the changes and improvements included in every <a href="/docs/release.html">release</a>.
+  schema.org via the changes and improvements included in all <a href="/docs/releases.html">releases</a>.
 
 <p>Hosted extensions are managed and reviewed as part of the schema.org project itself.
 External extensions are managed and reviewed by other groups. See the <a href="/docs/schemas.html">schemas page</a> for a listing.</p>


### PR DESCRIPTION
`release.html` was apparently renamed to `releases.html`.

I wasn't sure if use of "our" was appropriate, but that would make this read more nicely.