### PR TITLE
Sdo datasets2

### DIFF
--- a/data/ext/pending/issue-1083.rdfa
+++ b/data/ext/pending/issue-1083.rdfa
@@ -1,0 +1,10 @@
+<div typeof="rdf:Property" resource="http://schema.org/variablesMeasured">
+  <span>Category: <span property="schema:category">issue-1083</span></span>
+  <span class="h" property="rdfs:label">variablesMeasured</span>
+  <span property="rdfs:comment">The variables that are measured in some dataset, either described as text or as pairs of identifier and description using PropertyValue.</span>
+  <span>domainIncludes: <a property="http://schema.org/domainIncludes" href="http://schema.org/Dataset">Dataset</a></span>
+  <span>rangeIncludes: <a property="http://schema.org/rangeIncludes" href="http://schema.org/Text">Text</a></span>
+  <span>rangeIncludes: <a property="http://schema.org/rangeIncludes" href="http://schema.org/Text">Text</a></span>
+  <link property="http://schema.org/isPartOf" href="http://pending.schema.org" />
+  <span>Source:  <a property="dc:source" href="https://github.com/schemaorg/schemaorg/issues/1083">#1083</a></span>
+</div>

--- a/data/schema.rdfa
+++ b/data/schema.rdfa
@@ -7070,9 +7070,21 @@ Use this to explicitly override general opening hours brought in scope by &lt;a 
     <div typeof="rdf:Property" resource="http://schema.org/spatial">
       <span class="h" property="rdfs:label">spatial</span>
       <span property="rdfs:comment">The range of spatial applicability of a dataset, e.g. for a dataset of New York weather, the state of New York.</span>
+      <link property="http://schema.org/supersededBy" href="http://schema.org/spatialCoverage"/>
       <span>Domain: <a property="http://schema.org/domainIncludes" href="http://schema.org/Dataset">Dataset</a></span>
       <span>Range: <a property="http://schema.org/rangeIncludes" href="http://schema.org/Place">Place</a></span>
     </div>
+
+    <div typeof="rdf:Property" resource="http://schema.org/spatialCoverage">
+      <span class="h" property="rdfs:label">spatialCoverage</span>
+      <span property="rdfs:comment">The spatialCoverage of a CreativeWork indicates the place(s) which are the focus of the content. It is a subproperty of
+      contentLocation intended primarily for more technical and detailed materials. For example with a Dataset, it indicates
+      areas that the dataset describes: a dataset of New York weather would have spatialCoverage which was the place: the state of New York.</span>
+      <link property="rdfs:subPropertyOf" href="http://schema.org/contentLocation" />
+      <span>Domain: <a property="http://schema.org/domainIncludes" href="http://schema.org/CreativeWork">CreativeWork</a></span>
+      <span>Range: <a property="http://schema.org/rangeIncludes" href="http://schema.org/Place">Place</a></span>
+    </div>
+
     <div typeof="rdf:Property" resource="http://schema.org/specialCommitments">
       <span class="h" property="rdfs:label">specialCommitments</span>
       <span property="rdfs:comment">Any special commitments associated with this job posting. Valid entries include VeteranCommit, MilitarySpouseCommit, etc.</span>
@@ -7289,9 +7301,19 @@ Note that Event uses startDate/endDate instead of startTime/endTime, even when d
       <span>Domain: <a property="http://schema.org/domainIncludes" href="http://schema.org/Person">Person</a></span>
       <span>Range: <a property="http://schema.org/rangeIncludes" href="http://schema.org/Text">Text</a></span>
     </div>
+
+    <div typeof="rdf:Property" resource="http://schema.org/temporalCoverage">
+      <span class="h" property="rdfs:label">temporalCoverage</span>
+      <span property="rdfs:comment">The temporalCoverage of a CreativeWork indicates the period that the content applies to, i.e. that it describes, either as a DateTime or as a textual string indicating a time period (in [ISO 8601 time interval format](https://en.wikipedia.org/wiki/ISO_8601#Time_intervals). In
+      the case of a Dataset it will typically indicate the relevant time period in a precise notation (e.g. for a 2011 census dataset, the year 2011 would be written "2011/2012"). Other forms of content e.g. ScholarlyArticle, Book, TVSeries or TVEpisode may indicate their temporalCoverage in broader terms - textually or via well-known URL.
+      Written works such as books may sometimes have precise temporal coverage too, e.g. a work set in 1939 - 1945 can be indicated in ISO 8601 interval format format via "1939/1945".</span>
+      <span>Domain: <a property="http://schema.org/domainIncludes" href="http://schema.org/CreativeWork">CreativeWork</a></span>
+      <span>Range: <a property="http://schema.org/rangeIncludes" href="http://schema.org/DateTime">DateTime</a></span>
+      <span>Range: <a property="http://schema.org/rangeIncludes" href="http://schema.org/URL">URL</a></span>
+    </div>
     <div typeof="rdf:Property" resource="http://schema.org/temporal">
       <span class="h" property="rdfs:label">temporal</span>
-      <link property="http://schema.org/supersededBy" href="http://schema.org/datasetTimeInterval"/>
+      <link property="http://schema.org/supersededBy" href="http://schema.org/temporalCoverage"/>
       <span property="rdfs:comment">The range of temporal applicability of a dataset, e.g. for a 2011 census dataset, the year 2011 (in ISO 8601 time interval format).</span>
       <span>Domain: <a property="http://schema.org/domainIncludes" href="http://schema.org/Dataset">Dataset</a></span>
       <span>Range: <a property="http://schema.org/rangeIncludes" href="http://schema.org/DateTime">DateTime</a></span>
@@ -7299,6 +7321,7 @@ Note that Event uses startDate/endDate instead of startTime/endTime, even when d
     <div typeof="rdf:Property" resource="http://schema.org/datasetTimeInterval">
       <span class="h" property="rdfs:label">datasetTimeInterval</span>
       <span property="rdfs:comment">The range of temporal applicability of a dataset, e.g. for a 2011 census dataset, the year 2011 (in ISO 8601 time interval format).</span>
+      <link property="http://schema.org/supersededBy" href="http://schema.org/temporalCoverage"/>
       <span>Domain: <a property="http://schema.org/domainIncludes" href="http://schema.org/Dataset">Dataset</a></span>
       <span>Range: <a property="http://schema.org/rangeIncludes" href="http://schema.org/DateTime">DateTime</a></span>
     </div>

--- a/data/schema.rdfa
+++ b/data/schema.rdfa
@@ -295,7 +295,7 @@
 
     <div typeof="rdfs:Class" resource="http://schema.org/MediaObject">
       <span class="h" property="rdfs:label">MediaObject</span>
-      <span property="rdfs:comment">An image, video, or audio object embedded in a web page. Note that a creative work may have many media objects associated with it on the same web page. For example, a page about a single song (MusicRecording) may have a music video (VideoObject), and a high and low bandwidth audio stream (2 AudioObject&#39;s).</span>
+      <span property="rdfs:comment">A media object, such as an image, video, or audio object embedded in a web page or a downloadable dataset i.e. DataDownload. Note that a creative work may have many media objects associated with it on the same web page. For example, a page about a single song (MusicRecording) may have a music video (VideoObject), and a high and low bandwidth audio stream (2 AudioObject&#39;s).</span>
        <span>Subclass of: <a property="rdfs:subClassOf" href="http://schema.org/CreativeWork">CreativeWork</a></span>
     </div>
 

--- a/data/schema.rdfa
+++ b/data/schema.rdfa
@@ -5091,9 +5091,10 @@ Note that Event uses startDate/endDate instead of startTime/endTime, even when d
 
     <div typeof="rdf:Property" resource="http://schema.org/fileFormat">
       <span class="h" property="rdfs:label">fileFormat</span>
-      <span property="rdfs:comment">Media type (aka MIME format, see &lt;a href="http://www.iana.org/assignments/media-types/media-types.xhtml">IANA site&lt;/a&gt;) of the content e.g. application/zip of a SoftwareApplication binary. In cases where a CreativeWork has several media type representations, 'encoding' can be used to indicate each MediaObject alongside particular fileFormat information.</span>
+      <span property="rdfs:comment">Media type (typically MIME format, see &lt;a href="http://www.iana.org/assignments/media-types/media-types.xhtml">IANA site&lt;/a&gt;) of the content e.g. application/zip of a SoftwareApplication binary. In cases where a CreativeWork has several media type representations, 'encoding' can be used to indicate each MediaObject alongside particular fileFormat information. Unregistered or niche file formats can be indicated instead via the most appropriate URL, e.g. defining Web page or a Wikipedia entry.</span>
       <span>Domain: <a property="http://schema.org/domainIncludes" href="http://schema.org/CreativeWork">CreativeWork</a></span>
       <span>Range: <a property="http://schema.org/rangeIncludes" href="http://schema.org/Text">Text</a></span>
+      <span>Range: <a property="http://schema.org/rangeIncludes" href="http://schema.org/URL">URL</a></span>
     </div>
     <div typeof="rdf:Property" resource="http://schema.org/fileSize">
       <span class="h" property="rdfs:label">fileSize</span>

--- a/data/schema.rdfa
+++ b/data/schema.rdfa
@@ -7084,17 +7084,27 @@ Use this to explicitly override general opening hours brought in scope by &lt;a 
       <span>Domain: <a property="http://schema.org/domainIncludes" href="http://schema.org/WebPage">WebPage</a></span>
       <span>Range: <a property="http://schema.org/rangeIncludes" href="http://schema.org/Specialty">Specialty</a></span>
     </div>
-
     <div typeof="rdf:Property" resource="http://schema.org/sponsor">
       <span class="h" property="rdfs:label">sponsor</span>
       <span property="rdfs:comment">A person or organization that supports a thing through a pledge, promise, or financial contribution. e.g. a sponsor of a Medical Study or a corporate sponsor of an event.</span>
+      <span>Domain: <a property="http://schema.org/domainIncludes" href="http://schema.org/CreativeWork">CreativeWork</a></span>
   	  <span>Domain: <a property="http://schema.org/domainIncludes" href="http://schema.org/Person">Person</a></span>
 	    <span>Domain: <a property="http://schema.org/domainIncludes" href="http://schema.org/Organization">Organization</a></span>
 	    <span>Domain: <a property="http://schema.org/domainIncludes" href="http://schema.org/Event">Event</a></span>
       <span>Range: <a property="http://schema.org/rangeIncludes" href="http://schema.org/Organization">Organization</a></span>
   	  <span>Range: <a property="http://schema.org/rangeIncludes" href="http://schema.org/Person">Person</a></span>
     </div>
-
+    <div typeof="rdf:Property" resource="http://schema.org/funder">
+      <span class="h" property="rdfs:label">funder</span>
+      <span property="rdfs:comment">A person or organization that supports (sponsors) something through some kind of financial contribution.</span>
+      <link property="rdfs:subPropertyOf" href="http://schema.org/sponsor" />
+      <span>Domain: <a property="http://schema.org/domainIncludes" href="http://schema.org/CreativeWork">CreativeWork</a></span>
+  	  <span>Domain: <a property="http://schema.org/domainIncludes" href="http://schema.org/Person">Person</a></span>
+	    <span>Domain: <a property="http://schema.org/domainIncludes" href="http://schema.org/Organization">Organization</a></span>
+	    <span>Domain: <a property="http://schema.org/domainIncludes" href="http://schema.org/Event">Event</a></span>
+      <span>Range: <a property="http://schema.org/rangeIncludes" href="http://schema.org/Organization">Organization</a></span>
+  	  <span>Range: <a property="http://schema.org/rangeIncludes" href="http://schema.org/Person">Person</a></span>
+    </div>
     <div typeof="rdf:Property" resource="http://schema.org/sportsActivityLocation">
       <span class="h" property="rdfs:label">sportsActivityLocation</span>
       <span property="rdfs:comment">A sub property of location. The sports activity location where this action occurred.</span>

--- a/docs/releases.html
+++ b/docs/releases.html
@@ -172,7 +172,8 @@ rather than <a href="/TelevisionStation">TelevisionStation</a> (per <a href="g#5
   Indicated that <a href="/spatialCoverage">spatialCoverage</a> is a subproperty of <a href="/contentLocation">contentLocation</a>.
   <a href="https://github.com/schemaorg/schemaorg/issues/383">Broadened</a> <a href="/sponsor">sponsor</a> to apply to creative works such as datasets, and added a more specific subproperty to indicate
   <a href="/funder">funder</a>. <a href="https://github.com/schemaorg/schemaorg/issues/1190">Amended</a> definition of <a href="/MediaObject">MediaObject</a> to match its use as a supertype of
-  <a href="/DataDownload">DataDownload</a>. <a href="https://github.com/schemaorg/schemaorg/issues/1191">Amended</a> <a href="/fileFormat">fileFormat</a> to allow URL as a way of indicating niche or unregistered file formats (common for scientific datasets).
+  <a href="/DataDownload">DataDownload</a>. <a href="https://github.com/schemaorg/schemaorg/issues/1191">Amended</a> <a href="/fileFormat">fileFormat</a> to allow URL as a way of indicating niche or unregistered file formats (common for scientific datasets). Added a draft <a href="http://pending.webschemas.org/variablesMeasured">variablesMeasured</a> property to the 
+  <a href="http://pending.webschemas.org/">pending extension</a>.
 </li>
 </ul>
 

--- a/docs/releases.html
+++ b/docs/releases.html
@@ -168,12 +168,11 @@ rather than <a href="/TelevisionStation">TelevisionStation</a> (per <a href="g#5
 <a href="/netWorth">netWorth</a> definition now correctly omits <a href="/Organization">Organization</a> (per <a href="#g585">#585</a>).
 </li>
 
-<li id="g1083"><a href="https://github.com/schemaorg/schemaorg/issues/1083">Issue #1083</a>: Improvements primarily around Dataset, generalized <a href="/spatial">spatial</a> to <a href="/spatialCoverage">spatialCoverage</a> of any <a href="/Dataset">Dataset</a>, similarly <a href="/temporal">temporal</a> to <a href="/temporalCoverage">temporalCoverage</a>.
-  Indicated <a href="/spatialCoverage">spatialCoverage</a> is a subproperty of <a href="/contentLocation">contentLocation</a>.
-  <a href="https://github.com/schemaorg/schemaorg/issues/383">Broadened</a> <a href="/sponsor">sponsor</a> to apply to CreativeWorks such as Dataset, and added a more specific subproperty for
+<li id="g1083"><a href="https://github.com/schemaorg/schemaorg/issues/1083">Issue #1083</a>: Improvements primarily around Dataset, generalized <a href="/spatial">spatial</a> property of <a href="/Dataset">Dataset</a> to become <a href="/spatialCoverage">spatialCoverage</a> of any <a href="/CreativeWork">CreativeWork</a>; similarly generalized <a href="/temporal">temporal</a> as <a href="/temporalCoverage">temporalCoverage</a>.
+  Indicated that <a href="/spatialCoverage">spatialCoverage</a> is a subproperty of <a href="/contentLocation">contentLocation</a>.
+  <a href="https://github.com/schemaorg/schemaorg/issues/383">Broadened</a> <a href="/sponsor">sponsor</a> to apply to creative works such as datasets, and added a more specific subproperty to indicate
   <a href="/funder">funder</a>. <a href="https://github.com/schemaorg/schemaorg/issues/1190">Amended</a> definition of <a href="/MediaObject">MediaObject</a> to match its use as a supertype of
-  <a href="/DataDownload">DataDownload</a>. <a href="https://github.com/schemaorg/schemaorg/issues/1191">Amended</a> <a href="/fileFormat">fileFormat</a> to allow URL as a way of indicating
-  niche or unregistered file formats (common for scientific datasets).
+  <a href="/DataDownload">DataDownload</a>. <a href="https://github.com/schemaorg/schemaorg/issues/1191">Amended</a> <a href="/fileFormat">fileFormat</a> to allow URL as a way of indicating niche or unregistered file formats (common for scientific datasets).
 </li>
 </ul>
 

--- a/docs/releases.html
+++ b/docs/releases.html
@@ -168,6 +168,13 @@ rather than <a href="/TelevisionStation">TelevisionStation</a> (per <a href="g#5
 <a href="/netWorth">netWorth</a> definition now correctly omits <a href="/Organization">Organization</a> (per <a href="#g585">#585</a>).
 </li>
 
+<li id="g1083"><a href="https://github.com/schemaorg/schemaorg/issues/1083">Issue #1083</a>: Improvements primarily around Dataset, generalized <a href="/spatial">spatial</a> to <a href="/spatialCoverage">spatialCoverage</a> of any <a href="/Dataset">Dataset</a>, similarly <a href="/temporal">temporal</a> to <a href="/temporalCoverage">temporalCoverage</a>.
+  Indicated <a href="/spatialCoverage">spatialCoverage</a> is a subproperty of <a href="/contentLocation">contentLocation</a>.
+  <a href="https://github.com/schemaorg/schemaorg/issues/383">Broadened</a> <a href="/sponsor">sponsor</a> to apply to CreativeWorks such as Dataset, and added a more specific subproperty for
+  <a href="/funder">funder</a>. <a href="https://github.com/schemaorg/schemaorg/issues/1190">Amended</a> definition of <a href="/MediaObject">MediaObject</a> to match its use as a supertype of
+  <a href="/DataDownload">DataDownload</a>. <a href="https://github.com/schemaorg/schemaorg/issues/1191">Amended</a> <a href="/fileFormat">fileFormat</a> to allow URL as a way of indicating
+  niche or unregistered file formats (common for scientific datasets).
+</li>
 </ul>
 
 <ul>


### PR DESCRIPTION
Changes to support datasets (but also touches CreativeWork). Main issue is #1083, releases.html entry covers sub-issues.

Additional notes copied here for context:



CHANGES

1.) for temporal and spatial coverage.

As of v3.0 we have:

Relating to Dataset specifically,

 http://schema.org/spatial (Dataset -> Place),
   "The range of spatial applicability of a dataset, e.g. for a dataset of New York weather, the state of New York."

 http://schema.org/temporal (Dataset -> Datetime),
 "The range of temporal applicability of a dataset, e.g. for a 2011 census dataset, the year 2011 (in ISO 8601 time interval format)."

The temporal property superseded by the awkwardly named http://schema.org/datasetTimeInterval -

 http://schema.org/datasetTimeInterval (Dataset -> Datetime),
 "The range of temporal applicability of a dataset, e.g. for a 2011 census dataset, the year 2011 (in ISO 8601 time interval format)."

Relating to CreativeWork,

http://schema.org/contentLocation (CreativeWork -> Place),
"The location depicted or described in the content. For example, the location in a photograph or painting"

http://schema.org/locationCreated (CreativeWork -> Place),
"The location where the CreativeWork was created, which may not be the same as the location depicted in the CreativeWork."

Note also http://schema.org/releasedEvent which structures things a little differently, grouping place/time within an Event.



PROPOSAL:

1a. a minor detail re releasedEvent, but documenting here:
For works (most typically media broadcasts but potentially e.g. datasets too) whose publication is structured in terms of documented releases, it is reasonable to expect the release information in a http://schema.org/PublicationEvent to match direct contentLocation or spatial[Coverage] properties if the latter are present. A startDate property of the event would match http://schema.org/dateCreated of the published item.

1b. 
Create spatialCoverage and temporalCoverage properties as successors to the (vaguely and/or awkwardly named) datasetTimeInterval, spatial and temporal properties.

1c. 
Broaden spatialCoverage and temporalCoverage so that they apply to CreativeWork rather than just Dataset.

1d. 
Update their textual definitions to accommodate their broader scope, and to address any confusion about related properties.
Proposed text:

spatialCoverage: "The spatialCoverage of a CreativeWork indicates the place(s) which are the focus of some work. It is a subproperty of
contentLocation intended for more technical and specific materials. For example with a Dataset, it indicates 
areas that the dataset describes: a dataset of New York weather would have spatialCoverage which was the place: the state of New York."

temporalCoverage: "The temporalCoverage of a CreativeWork indicates the period that the content applies to, i.e. that it describes. In
the case of a Dataset it will typically indicate the relevant time period in a precise notation (e.g. for a 2011 census dataset, the year 2011 (in ISO 8601 time interval format). Other forms of content e.g. ScholarlyArticle, Book, TVSeries or TVEpisode may indicate their temporalCoverage in broader terms - textually or via well-known URL."

1e. 
Update RDFS assertions.

* spatialCoverage subPropertyOf contentLocation.
* temporal supersededBy temporalCoverage. (rather than by datasetTimeInterval as now)
* datasetTimeInterval supersededBy temporalCoverage.

Add mappings,

* temporalCoverage equivalentProperty http://purl.org/dc/terms/temporal
* spatialCoverage equivalentProperty http://purl.org/dc/terms/spatial

