### PR TITLE
Versions fix

### DIFF
--- a/RELEASING.TXT
+++ b/RELEASING.TXT
@@ -50,8 +50,8 @@ Of these,
 
  * schema.rdfa is a frozen one-time copy of data/schema.rdfa
  * schema-all.html is generated from this via running the Web app and
-   capturing via curl of /version/ (no numbers),
-   e.g. http://localhost:8080/version/
+   capturing via curl of /version/build-latest,
+   e.g. http://localhost:8080/version/build-latest
    when served locally via "dev_appserver ."
    For now, you need to edit this html to remove webschemas.org from heading section.
 

--- a/app.yaml
+++ b/app.yaml
@@ -61,8 +61,21 @@ handlers:
 - url: /search_files
   static_dir: static/search_files
 
-- url: /releases/*/
+- url: /version/latest/.*
+  script: sdoapp.app
+
+- url: /(version/[^/]*/)$
+  script: sdoapp.app
+
+- url: /(version/([^/]*))$
+  script: sdoapp.app
+
+- url: /version/
+  script: sdoapp.app
+
+- url: /version/*/*
   static_dir: data/releases/
+  application_readable: True
 
 - url: /.*
   script: sdoapp.app

--- a/templates/developers.tpl
+++ b/templates/developers.tpl
@@ -7,7 +7,7 @@
     structured data on their web pages for use by search engines and other applications." />
     <link rel="stylesheet" type="text/css" href="/docs/schemaorg.css" />
 </head>
-<body>
+<body onload="updatetext()">
 
 {% include 'basicPageHeader.tpl' with context %}
 
@@ -34,22 +34,24 @@ This is a placeholder page for developer-oriented information about schema.org. 
 <p>
 	<table padding="2">
 	<tr><td>
-			File: <select id="filename">
-				<option value="{{staticPath}}/releases/{{version}}/schema">schema</option>
-				<option value="{{staticPath}}/releases/{{version}}/all-layers">all-layers</option>
+			File: <select id="filename"  onchange="updatetext()">
+				<option value="{{staticPath}}/version/latest/schema">schema</option>
+				<option value="{{staticPath}}/version/latest/all-layers">all-layers</option>
 				{% for ext in extensions %}
-					<option value="{{staticPath}}/releases/{{version}}/ext-{{ ext | safe }}">{{ ext | safe }}</option>
+					<option value="{{staticPath}}/version/latest/ext-{{ ext | safe }}">{{ ext | safe }}</option>
 				{% endfor %}
 			</select>
 	</td>
 	<td>
-		Format:  <select id="fileext">
+		Format:  <select id="fileext" onchange="updatetext()">
 				<option value=".nt">Triples</option>
 				<option value=".nq">Quads</option>
 				<option value=".jsonld">JSON-LD</option>
 				<option value=".ttl">Turtle</option>
 		</select>
 	</td></tr>
+	<tr><td colspan="2">
+		<div id="label"></div>
 	<tr><td colspan="2" align="centre">
 		<input type="button" onclick="dowloadfunc();" value="Download"></input>
 	</td></tr>
@@ -63,6 +65,11 @@ This is a placeholder page for developer-oriented information about schema.org. 
   <a href="../docs/terms.html">Terms and conditions</a></p>
 </div>
 <script>
+function updatetext(){
+	file = document.getElementById("filename").value + document.getElementById("fileext").value;
+	document.getElementById("label").innerHTML = file
+}
+
 function dowloadfunc(){
 	path = document.getElementById("filename").value;
 	ext = document.getElementById("fileext").value;

--- a/templates/fullReleasePage.tpl
+++ b/templates/fullReleasePage.tpl
@@ -11,9 +11,9 @@
 </head>
 <body style="text-align: left;">
 
-{% include 'basicPageHeader.tpl' with context %}
-
 <div style="margin-left: 8%; margin-right: 8%">
+
+{% include 'basicPageHeader.tpl' with context %}
 
 <h1>Schema.org version {{ requested_version }}</h1>
 
@@ -28,17 +28,15 @@
  <dt>Published:</dt>
  <dd>{{ releasedate }}</dd>
 
- <dt>Alternate formats:</dt>
- <dd>
-     {% if requested_version != "latest" %}
+ <dt>Alternate formats: </dt>
+  <dd>
+     {% if requested_version != liveversion %}
      This release is also available in <a href="schema.rdfa">RDFa/RDFS</a>, <a href="schema.nt">N-Triples</a>
      {% endif %}
 
-     {% if requested_version == "latest" %}
-     This release is also available in <a href="http://schema.org/docs/schema_org_rdfa.html">rdfa</a>
+     {% if requested_version == liveversion %}
+     This release is also available in <a href="http://schema.org/docs/schema_org_rdfa.html">rdfa</a>. Plus full core and extension definition files in N-Triples, Quads, JSON-LD, and Turtle formats are available for <a href="/docs/developers.html#defs">download</a>.
      {% endif %}
-
-
 </dd>
 
 <p>


### PR DESCRIPTION
 * Introduced /versions/latest mapping to current versions of download files
 * Fixed 500 error on /version/*/ pages
 * Updated method of building source page for ‘schema-all.html’:
     http://localhost:8080/version/build-latest
 * Updated text of fullReleasePage.tpl to link to definition file downloads for latest version.
 * Updated RELEASING.TXT to reflect change to curl call for ‘schema-all.html’

