### PR TITLE
Hotels doc: 'amenityFeature' instead of 'feature'

### DIFF
--- a/docs/hotels.html
+++ b/docs/hotels.html
@@ -472,7 +472,7 @@ enjoying your morning coffee.&lt;/span&gt;
 &lt;/div&gt;</pre>
 
 <h3>Features and Services</h3>
-<p>Room features, like &quot;mini-bar&quot;, &quot;wifi&quot; or &quot;air conditioning&quot; can be expressed using the <a href="/amenityFeature">amenityFeature</a> property and an <a href="/LocationFeatureSpecification">LocationFeatureSpecification</a> entity, which is a special form of a <a href="../PropertyValue">property-value</a>. The <a href="../feature">feature</a> property does not make a statement on whether the room feature is free or for an additional charge.</p>
+<p>Room features, like &quot;mini-bar&quot;, &quot;wifi&quot; or &quot;air conditioning&quot; can be expressed using the <a href="/amenityFeature">amenityFeature</a> property and an <a href="/LocationFeatureSpecification">LocationFeatureSpecification</a> entity, which is a special form of a <a href="../PropertyValue">property-value</a>. The <a href="../amenityFeature">amenityFeature</a> property does not make a statement on whether the room feature is free or for an additional charge.</p>
 
 <h4>Room Features</h4>
 <p><strong>Example:</strong> The rooms have a mini-bar and wifi. Charges may or may not apply for those.</p>


### PR DESCRIPTION
I think it was intended to reference the [`amenityFeature` property](http://schema.org/amenityFeature) here, instead of the `feature` property (which doesn’t exist).

(Related issue about the renaming: #1262)