### PR TITLE
Stop recursion down hierarchy when node not in current layer(s)

### DIFF
--- a/sdoapp.py
+++ b/sdoapp.py
@@ -241,9 +241,10 @@ class TypeHierarchyTree:
 
         urlprefix = ""
         home = node.getHomeLayer()
-        gotOutput = False
-        if home in layers:
-            gotOutput = True
+        gotOutput = True
+        if home not in layers:
+            gotOutput = False
+            return gotOutput
 
         if home in ENABLED_EXTENSIONS and home != getHostExt():
             urlprefix = makeUrl(home)


### PR DESCRIPTION
Stops leaking of non-core terms into full display when they have subtypes that are in core.

Fix for issue #1284