### PR TITLE
Introduced special extension 'attic' 

### DIFF
--- a/RELEASING.TXT
+++ b/RELEASING.TXT
@@ -69,6 +69,7 @@ First copy snapshot into place:
  * curl http://localhost:8080/version/latest/> data/releases/2.2/schema-all.html
 
 Then generate N-Triples etc. versions:
+* Ensure that the EXTENTIONS variable at the top of the script 'scripts/buildreleasefiles.sh' contains all the extensions for this release.
 * scripts/buildreleasefiles.sh 3.1 - Check listed extensions is correct update if not
 
 * Inspect snapshot, add to git and push to repo.

--- a/api.py
+++ b/api.py
@@ -266,13 +266,24 @@ class HeaderStoreTool():
 
 PageStore = None
 HeaderStore = None
-log.info("NDB PageStore & HeaderStore enabled: %s" % NDBPAGESTORE)
+log.info("NDB PageStore & HeaderStore available: %s" % NDBPAGESTORE)
+
+def enablePageStore(state):
+    global PageStore,HeaderStore
+    if state:
+        log.info("Enabling NDB")
+        PageStore = PageStoreTool()
+        HeaderStore = HeaderStoreTool()
+    else:
+        log.info("Disabling NDB")
+        PageStore = DataCacheTool()
+        HeaderStore = DataCacheTool()
+
 if  NDBPAGESTORE:
-    PageStore = PageStoreTool()
-    HeaderStore = HeaderStoreTool()
+    enablePageStore(True)
 else:
-    PageStore = DataCacheTool()
-    HeaderStore = DataCacheTool()
+    enablePageStore(False)
+    
     
 
 

--- a/apirdflib.py
+++ b/apirdflib.py
@@ -37,8 +37,10 @@ def loadNss():
     global revNss
     if not NSSLoaded:
         NSSLoaded = True
+        log.info("allLayersList: %s"% allLayersList)
         for i in allLayersList:
             if i != "core":
+                log.info("Setting %s to %s" % (i, "http://%s.schema.org/" % i))
                 nss.update({i:"http://%s.schema.org/" % i})
         revNss = {v: k for k, v in nss.items()}
                

--- a/app.yaml
+++ b/app.yaml
@@ -1,5 +1,6 @@
 #application: schemaorgae
-application: webschemas
+#application: webschemas
+application: sdo-rjwtest1
 
 version: 1
 runtime: python27

--- a/data/ext/attic/attic.rdfa
+++ b/data/ext/attic/attic.rdfa
@@ -1,0 +1,24 @@
+<div>
+<!-- Attic area  -->
+
+<!-- Terms removed from coore or extentions - usual reason being deprication or unsuccesful in pending -->
+
+
+    <div resource="http://attic.schema.org/">
+    </div>
+
+    <div typeof="rdfs:Class" resource="http://schema.org/StupidType">
+        <link property="http://schema.org/isPartOf" href="http://attic.schema.org" />
+        <span class="h" property="rdfs:label">StupidType</span>
+        <span property="rdfs:comment">A StupidType for testing.</span>
+        <span>Subclass of: <a property="rdfs:subClassOf" href="http://schema.org/Thing">Thing</a></span>
+    </div>
+    <div typeof="rdf:Property" resource="http://schema.org/StupidProperty">
+        <link property="http://schema.org/isPartOf" href="http://attic.schema.org" />
+        <span class="h" property="rdfs:label">StupidProperty</span>
+        <span property="rdfs:comment">This is a StupidProperty! - for testing only</span>
+        <span>Domain: <a property="http://schema.org/domainIncludes" href="http://schema.org/StupidType">StupidType</a></span>
+        <span>Domain: <a property="http://schema.org/domainIncludes" href="http://schema.org/Vehicle">Vehicle</a></span>
+        <span>Range: <a property="http://schema.org/rangeIncludes" href="http://schema.org/QuantitativeValue">QuantitativeValue</a></span>
+    </div>
+</div>

--- a/data/ext/attic/attic.rdfa
+++ b/data/ext/attic/attic.rdfa
@@ -13,9 +13,9 @@
         <span property="rdfs:comment">A StupidType for testing.</span>
         <span>Subclass of: <a property="rdfs:subClassOf" href="http://schema.org/Thing">Thing</a></span>
     </div>
-    <div typeof="rdf:Property" resource="http://schema.org/StupidProperty">
+    <div typeof="rdf:Property" resource="http://schema.org/stupidProperty">
         <link property="http://schema.org/isPartOf" href="http://attic.schema.org" />
-        <span class="h" property="rdfs:label">StupidProperty</span>
+        <span class="h" property="rdfs:label">tupidProperty</span>
         <span property="rdfs:comment">This is a StupidProperty! - for testing only</span>
         <span>Domain: <a property="http://schema.org/domainIncludes" href="http://schema.org/StupidType">StupidType</a></span>
         <span>Domain: <a property="http://schema.org/domainIncludes" href="http://schema.org/Vehicle">Vehicle</a></span>

--- a/data/extdefs.jsonld
+++ b/data/extdefs.jsonld
@@ -12,6 +12,13 @@
 			"rdfs:comment": "The meta extension contains terms primarily designed to support the implementation of the Schema.org vocabulary itself. It includes terms such as [[Class]], [[Property]], [[domainIncludes]] and [[supersededBy]]. They are not currently advocated for widespread use across the web."
 		},
 		{
+		    "@id": "http://attic.schema.org",
+		  	"schema:name": "Attic Area",
+			"schema:disambiguatingDescription": "these terms have been either depricated from the core or extentions, or removed from [pending](/docs/howwework.html#pending) as not accepted into the full vocabulary.",
+		    "schema:softwareVersion": "0.0",
+		  	"rdfs:comment": "The attic area is an archive area for terms which are no longer part of the core vocabulary or its extensions. _Attic_ terms are preserved here to satisfy previous links to them.\n\nImplementors and publishers are cautioned not to use terms in the attic area."
+		},
+		{
 		    "@id": "http://pending.schema.org",
 		  	"schema:name": "Pending Extension",
 			"schema:disambiguatingDescription": "these terms are [pending](/docs/howwework.html#pending) wider review. Feedback is welcomed!",

--- a/docs/schemaorg.css
+++ b/docs/schemaorg.css
@@ -470,23 +470,23 @@ a.ext:hover {
    text-decoration: none;
 }
 
-/* Bib extension links overriding default 'ext' values
-a.ext.ext-bib:link{
-   color: #009900 !important;
-   border-bottom: dotted 1px #009900;
+/* Attic extension links overriding default 'ext' values */
+a.ext.ext-attic:link{
+   color: #888888 !important;
+   border-bottom: dotted 1px #888888 !important;
    text-decoration: none;
 }
-a.ext.ext-bib:visited {
-   color: #00bb00 !important;
-   border-bottom: dotted 1px #00bb00;
+a.ext.ext-attic:visited {
+   color: #888888 !important;
+   border-bottom: dotted 1px #888888 !important;
    text-decoration: none;
 }
-a.ext.ext-bib:hover {
+a.ext.ext-attic:hover {
    color: #fff !important;
-   background-color: #00bb00;
+   background-color: #bbbbbb;
    text-decoration: none;
 }
-*/
+
 
 
 

--- a/scripts/buildreleasefiles.sh
+++ b/scripts/buildreleasefiles.sh
@@ -1,5 +1,5 @@
 #!/bin/sh
-EXTENSIONS="auto bib health-lifesci pending meta"
+EXTENSIONS="attic auto bib health-lifesci pending meta"
 PWD=`pwd`
 PROG="`basename $0`"
 if [ `basename $PWD` != "schemaorg" ]

--- a/templates/basicPageHeader.tpl
+++ b/templates/basicPageHeader.tpl
@@ -63,7 +63,7 @@ customSearchControl.draw('cse-search-form', options);
 
 {% if sitename != "schema.org" %}
 <div class="pendnote">
-	<b><a href="{{staticPath}}">core</a></b> + <b>{{host_ext}}</b>
+	<b><a href="{{staticPath}}">core</a></b> + <a href="{{extensionPath}}">{{host_ext}}</a>
 	({{extName}}): {{extDD|safe}}</div>
 {% endif %}
 

--- a/templates/schemas.tpl
+++ b/templates/schemas.tpl
@@ -45,7 +45,6 @@ Or you can jump directly to a commonly used type:
 <br />
 We also have a small set of <a href="{{staticPath}}/DataType">primitive data types</a> for numbers, text, etc. More details about the data model, etc. are available <a href="{{staticPath}}/docs/datamodel.html">here</a>.
 <br />
-<br />
 
  <h2 id="ext">Extensions</h2>
 
@@ -64,12 +63,13 @@ For example in the <a href="http://auto.schema.org/">auto</a> extension there is
 and in the <a href="http://bib.schema.org/">bibliographic extension</a> we have a property <a href="/publisherImprint">publisherImprint</a>.
 </p>
 
-<br/>Using the <a href="{{staticPath}}/docs/extension.html">extension mechanism</a> the core vocabulary is extended by the following hosted extensions:
+<p>Using the <a href="{{staticPath}}/docs/extension.html">extension mechanism</a> the core vocabulary is extended by the following hosted extensions:
 <ul>
 {% for ext in extensions %}
 	<li>{{ ext | safe }}</li>
 {% endfor %}
 </ul>
+</p>
 
 <p><b>Note</b>: the 'pending' and 'meta' hosted extensions are part of schema.org's schema development process.</p>
 <p id="ext_pending">
@@ -84,6 +84,9 @@ and in the <a href="http://bib.schema.org/">bibliographic extension</a> we have 
 The 'meta' extension is primarily for vocabulary used internally within schema.org to support technical definitions and
 schema.org site functionality. These terms are not intended for general usage in the public Web.</p>
 </p>
+<p id="attic"><strong>Attic</strong> ({{attic | safe}}) is a special extension area where terms are archived when deprecated from the core and other extensions, or removed from <a href="http://pending.schema.org">pending</a> as not accepted into the full vocabulary. References to terms in the attic area are not normally displayed unless accessed via the term identifier or via the {{attic | safe}} home page. Implementors and data publishers are cautioned not to use terms in the attic area.
+</p> 
+
 <p>
 Unlike other core and extension terms, these extensions may be updated at any time without the need for a full <a href="/docs/releases.html">release</a>.
 </p>


### PR DESCRIPTION
Introduced special extension 'attic'  which by default does not appear unless explicitly addressed.

> The attic area is an archive area for terms which are no longer part of the core vocabulary or its extensions. Attic terms are preserved here to satisfy previous links to them.
> Implementors and publishers are cautioned not to use terms in the attic area.

Note: This PR contains two terms StupidType & stupidProperty, to test the functionally.  These will need to be replaced with real terms before release by real term(s)

Addresses issue(#1318)
