### PR TITLE
Added several new sparql vocab tests

### DIFF
--- a/app.yaml
+++ b/app.yaml
@@ -1,6 +1,5 @@
 #application: schemaorgae
-#application: webschemas
-application: sdo-rjwtest1
+application: webschemas
 
 version: 1
 runtime: python27


### PR DESCRIPTION
New Tests:



- Test if a property is inverseOf itself - Issue(#1205)
- Test supercededBy & inverseOf don't point to same thing - Issue (#156)
- Test comments end on '.' - Issue (#250)
- Test for terms that are sub-type/property of an attic term - Issue (#1329) 
- Test for terms that (domainIncludes | rangeIncludes | inverseOf | supercededBy) reference an attic term
- Test for nonexistent super-types
- Test for nonexistent super-properties
- Test property name begins with lowercase
- Test type name begins with upper case
- Test Enumerations have defined enum values - Issue (#485)
- Test for terms isPartOf more than one extension 