### PR TITLE
Fixed typos in JSON-LD example in extensions.html

### DIFF
--- a/docs/extension.html
+++ b/docs/extension.html
@@ -225,23 +225,23 @@ Here is that last approach written in JSON-LD (it works today, but would be even
   "name": "The Fellowship of the Rings",
   "author": "J.R.R Tolkien",
   "publisher": {
-     "@type": "Organization",
+       "@type": "Organization"
   },
   "location": "United Kingdom",
-  "name": "George Allen &amp; Unwin",
+  "name": "George Allen &amp; Unwin"
  },
   "datePublished": "1954",
   "workExample": {
-    "@type": "Book",
-    "name": "Harper Collins",
-    "datePublished": "1974",
-    "isbn": "0007149212"
+      "@type": "Book",
+      "name": "Harper Collins",
+      "datePublished": "1974",
+      "isbn": "0007149212"
   },
   "workExample": {
-    "@type": ["Book", "bib:Microform"],
-    "name": "Microfiche Press",
-    "datePublished": "2016",
-    "isbn": "12341234"
+      "@type": ["Book", "bib:Microform"],
+      "name": "Microfiche Press",
+      "datePublished": "2016",
+      "isbn": "12341234"
   }
 }
 &lt;/script&gt;


### PR DESCRIPTION
@danbri @RichardWallis The JSON-LD context file is updated now with bib from what I saw .... I wonder if this JSON-LD example in extension.html should be cleaned up even more than these typo fixes I did ?
