### PR TITLE
We don't have length/thickness under Product

### DIFF
--- a/data/schema.rdfa
+++ b/data/schema.rdfa
@@ -4490,7 +4490,7 @@ The place is __open__ if the [[opens]] property is specified, and __closed__ oth
     </div>
     <div typeof="rdf:Property" resource="http://schema.org/depth">
       <span class="h" property="rdfs:label">depth</span>
-      <span property="rdfs:comment">The depth of the item.</span>
+      <span property="rdfs:comment">The depth or thickness of the item.</span>
       <span>Domain: <a property="http://schema.org/domainIncludes" href="http://schema.org/Product">Product</a></span>
       <span>Range: <a property="http://schema.org/rangeIncludes" href="http://schema.org/Distance">Distance</a></span>
       <span>Range: <a property="http://schema.org/rangeIncludes" href="http://schema.org/QuantitativeValue">QuantitativeValue</a></span>

--- a/data/schema.rdfa
+++ b/data/schema.rdfa
@@ -4490,7 +4490,7 @@ The place is __open__ if the [[opens]] property is specified, and __closed__ oth
     </div>
     <div typeof="rdf:Property" resource="http://schema.org/depth">
       <span class="h" property="rdfs:label">depth</span>
-      <span property="rdfs:comment">The depth or thickness of the item.</span>
+      <span property="rdfs:comment">The depth or length of the item.</span>
       <span>Domain: <a property="http://schema.org/domainIncludes" href="http://schema.org/Product">Product</a></span>
       <span>Range: <a property="http://schema.org/rangeIncludes" href="http://schema.org/Distance">Distance</a></span>
       <span>Range: <a property="http://schema.org/rangeIncludes" href="http://schema.org/QuantitativeValue">QuantitativeValue</a></span>


### PR DESCRIPTION
We need to clarify that depth is also known as thickness.
In expanded form of the depth description, we could even say 'the depth or thickness or length of the item'.  But this begs the question of how not to confuse thickness with height

In general terms, its left/right, front/back, top/bottom.

In the States, we typically express those same general terms of a Products' dimensions as length/width/height  .. but for Product we currently have depth/width/height.  I think for developers, that causes more harm than good in trying to align with those general terms.

Proposal:
1. Rename depth to length instead. (or update its description to say 'the depth or length of the item'

Also found in the complaint #528 Product dimensions should be length x width x height
