### PR TITLE
Cleanup bib extension (bdso-1.0.rdfa)

### DIFF
--- a/data/ext/bib/bsdo-1.0.rdfa
+++ b/data/ext/bib/bsdo-1.0.rdfa
@@ -130,14 +130,6 @@
 	<link property="http://schema.org/inverseOf" href="http://schema.org/workTranslation"/>
 </div>
 
-<div typeof="rdf:Property" resource="http://schema.org/translator">
-	<span class="h" property="rdfs:label">translator</span>
-	<span property="rdfs:comment">An agent responsible for rendering a translated work from a source work</span>
-	<span>Domain:<a property="http://schema.org/domainIncludes" href="http://schema.org/CreativeWork">schema:CreativeWork</a></span>
-	<span>Range:<a property="http://schema.org/rangeIncludes" href="http://schema.org/Person">Person</a></span>
-	<span>Range:<a property="http://schema.org/rangeIncludes" href="http://schema.org/Organization">Organization</a></span>
-</div>
-
 <div typeof="rdf:Property" resource="http://schema.org/pageStart">
 	<span>Domain:<a property="http://schema.org/domainIncludes" href="http://schema.org/Chapter">Chapter</a></span>
 </div>


### PR DESCRIPTION
Removed duplicate definition of schema:translator from bib extension - already being overridden by core definition in schema.rdfa.

Fixes issue(#1368)