### PR TITLE
More load tuning

### DIFF
--- a/api.py
+++ b/api.py
@@ -1,11 +1,15 @@
 #!/usr/bin/env python
 # -*- coding: UTF-8 -*-
 
+import logging
+logging.basicConfig(level=logging.INFO) # dev_appserver.py --log_level debug .
+log = logging.getLogger(__name__)
+
+
 import os
 import os.path
 import glob
 import re
-import logging
 import threading
 import parsers
 import datetime, time
@@ -14,6 +18,7 @@ from google.appengine.ext import ndb
 loader_instance = False
 
 import apirdflib
+
 #from apirdflib import rdfGetTargets, rdfGetSources
 from apimarkdown import Markdown
 
@@ -26,8 +31,6 @@ def getInstanceId(short=False):
     return ret
 
 
-logging.basicConfig(level=logging.INFO) # dev_appserver.py --log_level debug .
-log = logging.getLogger(__name__)
 
 schemasInitialized = False
 extensionsLoaded = False
@@ -288,7 +291,9 @@ def enablePageStore(state):
     if state:
         log.info("[%s] Enabling NDB" % getInstanceId(short=True))
         PageStore = PageStoreTool()
+        log.info("[%s] Created PageStore" % getInstanceId(short=True))
         HeaderStore = HeaderStoreTool()
+        log.info("[%s] Created HeaderStore" % getInstanceId(short=True))
     else:
         log.info("[%s] Disabling NDB" % getInstanceId(short=True))
         PageStore = DataCacheTool()
@@ -1314,4 +1319,5 @@ def ShortenOnSentence(source,lengthHint=250):
         source = com
     return source
 
+log.info("[%s]api loaded" % (getInstanceId(short=True)))
 

--- a/app.yaml
+++ b/app.yaml
@@ -1,6 +1,5 @@
 #application: schemaorgae
-#application: webschemas
-application: sdo-rjwtest1
+application: webschemas
 
 version: 1
 runtime: python27

--- a/app.yaml
+++ b/app.yaml
@@ -1,5 +1,6 @@
 #application: schemaorgae
-application: webschemas
+#application: webschemas
+application: sdo-rjwtest1
 
 version: 1
 runtime: python27


### PR DESCRIPTION
Stopped preloading schemas definitions and example files for each newly spawned instance.  This was taking up to half a minute!  

After a period of time most popular pages will already be cached so new instances will most likely not need to create pages (requiring definitions to be loaded) only serving from NDB cache. 

Current status:
- First instance clears NDB stored data - other instances wait until complete
- The first instance called with _ah/warmup attempts to build "docs/schemas.html","docs/full.html","docs/tree.jsonld" to get the big hitters loaded.
  - These may fail with DeadlineExceededError but will have preloaded enough to speed page construction for real requests.
- Call for a page not cached in NDB causes in an instance to:
  - Load Examples into NDB if not already loaded by another instance
  - Load schema definitions if not already loaded into instance
- All major pages cached in NDB when created