### PR TITLE
Adding an add-on property to MenuItem (#1288)

### DIFF
--- a/data/schema.rdfa
+++ b/data/schema.rdfa
@@ -11221,7 +11221,7 @@ Typical unit code(s): C62 for person</span>
     </div>
     
     <div typeof="rdf:Property" resource="http://schema.org/menuAddOn">
-      <span class="h" property="rdfs:label">hasMenuSection</span>
+      <span class="h" property="rdfs:label">menuAddOn</span>
       <span property="rdfs:comment">Additional menu item(s) such as a side dish of salad or side order of fries that can be added to this menu item. Additionally it can be a menu section containing allowed add-on menu items for this menu item.</span>
       <span>Domain: <a property="http://schema.org/domainIncludes" href="http://schema.org/MenuItem">Menu</a></span>
       <span>Range: <a property="http://schema.org/rangeIncludes" href="http://schema.org/MenuSection">MenuItem</a></span>

--- a/data/schema.rdfa
+++ b/data/schema.rdfa
@@ -11219,6 +11219,14 @@ Typical unit code(s): C62 for person</span>
       <span>Domain: <a property="http://schema.org/domainIncludes" href="http://schema.org/MenuSection">MenuSection</a></span>
       <span>Range: <a property="http://schema.org/rangeIncludes" href="http://schema.org/MenuSection">MenuSection</a></span>
     </div>
+    
+    <div typeof="rdf:Property" resource="http://schema.org/menuAddOn">
+      <span class="h" property="rdfs:label">hasMenuSection</span>
+      <span property="rdfs:comment">Additional menu item(s) such as a side dish of salad or side order of fries that can be added to this menu item. Additionally it can be a menu section containing allowed add-on menu items for this menu item.</span>
+      <span>Domain: <a property="http://schema.org/domainIncludes" href="http://schema.org/MenuItem">Menu</a></span>
+      <span>Range: <a property="http://schema.org/rangeIncludes" href="http://schema.org/MenuSection">MenuItem</a></span>
+      <span>Range: <a property="http://schema.org/rangeIncludes" href="http://schema.org/MenuSection">MenuSection</a></span>
+    </div>
 
 </div>
 


### PR DESCRIPTION
We need to directly connect add-ons such as side dishes for MenuItems, It can link to MenuItem or to MenuSection that contains allowable add-on MenuItems. Issue is #1288

Proposal doc: https://docs.google.com/document/d/1q0M8jdJrYZJHvD_sQXvhkGtG07XmzyPgmjnUad3lGD0/edit#heading=h.l6sgyrdwxqp6