### PR TITLE
Update style of active tab in schemaorg.css

### DIFF
--- a/docs/schemaorg.css
+++ b/docs/schemaorg.css
@@ -439,7 +439,7 @@ input.gsc-search-button {
 .ds-selector-tabs .selectors a.selected {
   color: #202020 !important;
   border: 1px solid #ccc;
-  border-bottom: 1px solid #fff !important;
+  border-bottom: 1px solid #eee !important;
 }
 #mainContent .ds-selector-tabs .selectors a:hover {
   background-color: transparent;


### PR DESCRIPTION
The border-bottom should be invisible, but since it was white and presented on a grey background, it was visible. The new border-bottom-color has the same color as the background.