### PR TITLE
Create a new WebAPI class and some useful properties

### DIFF
--- a/data/ext/pending/issue-1423-examples.txt
+++ b/data/ext/pending/issue-1423-examples.txt
@@ -1,0 +1,30 @@
+TYPES: WebAPI, documentation, termsOfService
+
+PRE-MARKUP:
+
+See JSON example.
+
+MICRODATA:
+
+TODO
+
+RDFA:
+
+TODO
+
+JSON:
+
+<script type="application/ld+json">
+{
+  "@context": "http://schema.org/",
+  "@type": "WebAPI",
+  "name": "Google Knowledge Graph Search API",
+  "description": "The Knowledge Graph Search API lets you find entities in the Google Knowledge Graph. The API uses standard schema.org types and is compliant with the JSON-LD specification.",
+  "documentation": "https://developers.google.com/knowledge-graph/",
+  "termsOfService": "https://developers.google.com/knowledge-graph/terms",
+  "provider": {
+    "@type": "Organization",
+    "name": "Google Inc."
+  }
+}
+</script>

--- a/data/ext/pending/issue-1423.rdfa
+++ b/data/ext/pending/issue-1423.rdfa
@@ -1,0 +1,26 @@
+<div>
+  <!-- WebAPI, issue 1423 -->
+
+  <div typeof="rdfs:Class" resource="http://schema.org/WebAPI">
+    <span class="h" property="rdfs:label">WebAPI</span>
+    <span property="rdfs:comment">An application programming interface accessible over Web/Internet technologies.</span>
+    <span>Subclass of: <a property="rdfs:subClassOf" href="http://schema.org/Service">Service</a></span>
+  </div>
+
+  <div typeof="rdf:Property" resource="http://schema.org/documentation">
+      <span class="h" property="rdfs:label">documentation</span>
+      <span property="rdfs:comment">Further documentation describing the Web API in more detail.</span>
+      <span>Domain: <a property="http://schema.org/domainIncludes" href="http://schema.org/WebAPI">WebAPI</a></span>
+      <span>Range: <a property="http://schema.org/rangeIncludes" href="http://schema.org/URL">URL</a></span>
+      <span>Range: <a property="http://schema.org/rangeIncludes" href="http://schema.org/CreativeWork">CreativeWork</a></span>
+  </div>
+
+  <div typeof="rdf:Property" resource="http://schema.org/termsOfService">
+      <span class="h" property="rdfs:label">termsOfService</span>
+      <span property="rdfs:comment">Rules by which one must agree to abide in order to use the service</span>
+      <span>Domain: <a property="http://schema.org/domainIncludes" href="http://schema.org/Service">Service</a></span>
+      <span>Range: <a property="http://schema.org/rangeIncludes" href="http://schema.org/URL">URL</a></span>
+      <span>Range: <a property="http://schema.org/rangeIncludes" href="http://schema.org/Text">Text</a></span>
+  </div>
+
+</div>

--- a/data/schema.rdfa
+++ b/data/schema.rdfa
@@ -11219,7 +11219,7 @@ Typical unit code(s): C62 for person</span>
       <span>Domain: <a property="http://schema.org/domainIncludes" href="http://schema.org/MenuSection">MenuSection</a></span>
       <span>Range: <a property="http://schema.org/rangeIncludes" href="http://schema.org/MenuSection">MenuSection</a></span>
     </div>
-    
+
     <div typeof="rdf:Property" resource="http://schema.org/menuAddOn">
       <span class="h" property="rdfs:label">menuAddOn</span>
       <span property="rdfs:comment">Additional menu item(s) such as a side dish of salad or side order of fries that can be added to this menu item. Additionally it can be a menu section containing allowed add-on menu items for this menu item.</span>


### PR DESCRIPTION
This adds a new WebAPI class to Schema.org's core vocabulary. I decided to subclass `Intangible > Service` as a distinct feature of a Web API in contrast to normal *application* programming interfaces is that they are always offered by a `provider`.

Previous discussions in #1423 mentioned a couple of fields, most of them are addressed by this design:

- Title: `Thing > name`
- Description: `Thing > description`
- Logo: `Service > logo`
- License: I don't see how a license applies to a Web API!?
- ToS: newly added `Service > termsOfService`
- Support contacts: available through `Service > provider`
- Version: ~IMO breaking down an API by versions isn't very useful. Either describe multiple WebAPIs or push this into the API documentation~ removed again after discussions; see thread below
- list of base URLs: should be part of API documentation, not the definition of the API IMO
- Type of service: should be part of API documentation
- Link to API Description: newly added `WebAPI > documentation`

@RichardWallis, I saw you suggested to specialize `EntryPoint`. I don't think that would work well as an `EntryPoint` is supposed to be a specific resource (URL), a WebAPI on the other hand is a collection of resources.

Just as @tlrobinson I also had a few concerns about the Web in `WebAPI` but I think what it is supposed to convey here is that it is *somehow* accessible over the Web/Internet. I tried to clarify that in the description of the class.

Last but not least, things like versions, technologies (SOAP, GraphQL), REST maturity level, dependsOn etc. are beyond the scope of this IMO and should be addressed by the `documentation` of the `WebAPI`. I thus made the range of `documentation` a URL. This provides a great extension point for the future and allows people to start pointing to both human-readable and machine-readable docs.