### PR TITLE
Improvements to TouristAttraction

### DIFF
--- a/data/schema.rdfa
+++ b/data/schema.rdfa
@@ -10511,7 +10511,7 @@ Standards bodies should promote a standard prefix for the identifiers of propert
 
 <div typeof="http://schema.org/Organization" resource="http://www.w3.org/wiki/WebSchemas/SchemaDotOrgSources#Tourism">
     <span property="rdfs:label">Tourism</span>
-    <span property="rdfs:comment">This element is based on the work of the [Tourisum Structured Web Data Community Group](https://www.w3.org/community/tourismdata).</span>
+    <span property="rdfs:comment">This element is based on the work of the [Tourism Structured Web Data Community Group](https://www.w3.org/community/tourismdata).</span>
   </div>
 <div typeof="http://schema.org/Organization" resource="http://www.w3.org/wiki/WebSchemas/SchemaDotOrgSources#IIT-CNR.it">
     <span property="rdfs:label">IIT-CNR.it</span>

--- a/data/schema.rdfa
+++ b/data/schema.rdfa
@@ -2022,8 +2022,21 @@ See also the &lt;a href=&quot;/docs/hotels.html&quot;&gt;dedicated document on t
 
     <div typeof="rdfs:Class" resource="http://schema.org/TouristAttraction">
       <span class="h" property="rdfs:label">TouristAttraction</span>
-      <span property="rdfs:comment">A tourist attraction.</span>
-       <span>Subclass of: <a property="rdfs:subClassOf" href="http://schema.org/Place">Place</a></span>
+      <span property="rdfs:comment">A tourist attraction.  In principle any Thing can be a [[TouristAttraction]], from a [[Mountain]] and [[LandmarksOrHistoricalBuildings]] to a [[LocalBusiness]].  This Type can be used on its own to describe a general [[TourstAttraction]], or be used as an [[additionalType]] to add tourist attraction properties to any other type.  (See examples below)</span>
+      <span>Subclass of: <a property="rdfs:subClassOf" href="http://schema.org/Place">Place</a></span>
+      <span>Source:  <a property="dc:source" href="http://www.w3.org/wiki/WebSchemas/SchemaDotOrgSources#Tourism">Tourism</a></span>
+      <span>Source:  <a property="dc:source" href="http://www.w3.org/wiki/WebSchemas/SchemaDotOrgSources#IIT-CNR.it">IIT-CNR.it</a></span>
+    </div>
+
+    <div typeof="rdf:Property" resource="http://schema.org/touristType">
+      <span class="h" property="rdfs:label">touristType</span>
+      <span property="rdfs:comment">Attraction suitable for type(s) of tourist. eg. Children, visitors from a particular country, etc. </span>
+      <link property="rdfs:subPropertyOf" href="http://schema.org/audience" />
+      <span>Domain: <a property="http://schema.org/domainIncludes" href="http://schema.org/TouristAttraction">TouristAttraction</a></span>
+      <span>rangeIncludes: <a property="http://schema.org/rangeIncludes" href="http://schema.org/Audience">Audience</a></span>
+      <span>rangeIncludes: <a property="http://schema.org/rangeIncludes" href="http://schema.org/Text">Text</a></span>
+      <span>Source:  <a property="dc:source" href="http://www.w3.org/wiki/WebSchemas/SchemaDotOrgSources#Tourism">Tourism</a></span>
+      <span>Source:  <a property="dc:source" href="http://www.w3.org/wiki/WebSchemas/SchemaDotOrgSources#IIT-CNR.it">IIT-CNR.it</a></span>
     </div>
 
     <div typeof="rdfs:Class" resource="http://schema.org/TouristInformationCenter">
@@ -3837,10 +3850,11 @@ The place is __open__ if the [[opens]] property is specified, and __closed__ oth
 
     <div typeof="rdf:Property" resource="http://schema.org/availableLanguage">
       <span class="h" property="rdfs:label">availableLanguage</span>
-      <span property="rdfs:comment">A language someone may use with the item. Please use one of the language codes from the [IETF BCP 47 standard](http://tools.ietf.org/html/bcp47). See also [[inLanguage]]</span>
+      <span property="rdfs:comment">A language someone may use with or at the item, service or place. Please use one of the language codes from the [IETF BCP 47 standard](http://tools.ietf.org/html/bcp47). See also [[inLanguage]]</span>
       <span>Domain: <a property="http://schema.org/domainIncludes" href="http://schema.org/ContactPoint">ContactPoint</a></span>
       <span>Domain: <a property="http://schema.org/domainIncludes" href="http://schema.org/ServiceChannel">ServiceChannel</a></span>
       <span>Domain: <a property="http://schema.org/domainIncludes" href="http://schema.org/LodgingBusiness">LodgingBusiness</a></span>
+      <span>Domain: <a property="http://schema.org/domainIncludes" href="http://schema.org/TouristAttraction">TouristAttraction</a></span>
       <span>Range: <a property="http://schema.org/rangeIncludes" href="http://schema.org/Language">Language</a></span>
       <span>Range: <a property="http://schema.org/rangeIncludes" href="http://schema.org/Text">Text</a></span>
     </div>
@@ -5005,10 +5019,17 @@ The place is __open__ if the [[opens]] property is specified, and __closed__ oth
     </div>
     <div typeof="rdf:Property" resource="http://schema.org/isAccessibleForFree">
       <span class="h" property="rdfs:label">isAccessibleForFree</span>
-      <span property="rdfs:comment">A flag to signal that the publication is accessible for free.</span>
+      <span property="rdfs:comment">A flag to signal that the item, event, place is accessible for free.</span>
       <span>Domain: <a property="http://schema.org/domainIncludes" href="http://schema.org/CreativeWork">CreativeWork</a></span>
       <span>Domain: <a property="http://schema.org/domainIncludes" href="http://schema.org/Event">Event</a></span>
       <span>Domain: <a property="http://schema.org/domainIncludes" href="http://schema.org/PublicationEvent">PublicationEvent</a></span>
+      <span>Domain: <a property="http://schema.org/domainIncludes" href="http://schema.org/Place">Place</a></span>
+      <span>Range: <a property="http://schema.org/rangeIncludes" href="http://schema.org/Boolean">Boolean</a></span>
+    </div>
+    <div typeof="rdf:Property" resource="http://schema.org/publicAccess">
+      <span class="h" property="rdfs:label">publicAccess</span>
+      <span property="rdfs:comment">A flag to signal that the [[Place]] is accessible by public visitors.</span>
+      <span>Domain: <a property="http://schema.org/domainIncludes" href="http://schema.org/Place">Place</a></span>
       <span>Range: <a property="http://schema.org/rangeIncludes" href="http://schema.org/Boolean">Boolean</a></span>
     </div>
 
@@ -10485,6 +10506,19 @@ Standards bodies should promote a standard prefix for the identifiers of propert
     <span>Range: <a property="http://schema.org/rangeIncludes" href="http://schema.org/QuantitativeValue">QuantitativeValue</a></span>
     <span>Source:  <a property="dc:source" href="http://www.w3.org/wiki/WebSchemas/SchemaDotOrgSources#source_GoodRelationsProperties">GoodRelationsProperty</a></span>
 </div>
+      <span>Source:  <a property="dc:source" href="http://www.w3.org/wiki/WebSchemas/SchemaDotOrgSources#Tourism">Tourism</a></span>
+      <span>Source:  <a property="dc:source" href="http://www.w3.org/wiki/WebSchemas/SchemaDotOrgSources#IIT-CNR.it">IIT-CNR.it</a></span>
+
+<div typeof="http://schema.org/Organization" resource="http://www.w3.org/wiki/WebSchemas/SchemaDotOrgSources#Tourism">
+    <span property="rdfs:label">Tourism</span>
+    <span property="rdfs:comment">This element is based on the work of the [Tourisum Structured Web Data Community Group](https://www.w3.org/community/tourismdata).</span>
+  </div>
+<div typeof="http://schema.org/Organization" resource="http://www.w3.org/wiki/WebSchemas/SchemaDotOrgSources#IIT-CNR.it">
+    <span property="rdfs:label">IIT-CNR.it</span>
+    <span property="rdfs:comment">This element is based on work by the Web Applications for the Future Internet Lab, Institute of Informatics and Telematics, Pisa, Italy.</span>
+  </div>
+
+
 <h1>FIBO - Finance inspired</h1>
 
 <div typeof="http://schema.org/Organization" resource="http://www.w3.org/wiki/WebSchemas/SchemaDotOrgSources#FIBO">

--- a/data/schema.rdfa
+++ b/data/schema.rdfa
@@ -2031,7 +2031,6 @@ See also the &lt;a href=&quot;/docs/hotels.html&quot;&gt;dedicated document on t
     <div typeof="rdf:Property" resource="http://schema.org/touristType">
       <span class="h" property="rdfs:label">touristType</span>
       <span property="rdfs:comment">Attraction suitable for type(s) of tourist. eg. Children, visitors from a particular country, etc. </span>
-      <link property="rdfs:subPropertyOf" href="http://schema.org/audience" />
       <span>Domain: <a property="http://schema.org/domainIncludes" href="http://schema.org/TouristAttraction">TouristAttraction</a></span>
       <span>rangeIncludes: <a property="http://schema.org/rangeIncludes" href="http://schema.org/Audience">Audience</a></span>
       <span>rangeIncludes: <a property="http://schema.org/rangeIncludes" href="http://schema.org/Text">Text</a></span>

--- a/data/sdo-tourism-examples.txt
+++ b/data/sdo-tourism-examples.txt
@@ -202,7 +202,7 @@ JSON:
 }
 </script>
 
-TYPES: #tourism-4 TouristAttraction, touristType
+TYPES: #tourism-4 TouristAttraction, touristType, Museum
 
 PRE-MARKUP:
 
@@ -213,6 +213,7 @@ PRE-MARKUP:
 MICRODATA:
 
 <div itemscope itemtype="http://schema.org/TouristAttraction">
+    <link itemprop="additionalType" href="http://schema.org/Museum" />
 	<h1><span itemprop="name">Please Touch Museum</span></h1>
 	<div>It is a 
 		<div itemprop="touristType" itemscope itemtype="http://schema.org/Audience">
@@ -229,7 +230,7 @@ MICRODATA:
 
 RDFA:
 
-<div vocab="http://schema.org/" typeof="TouristAttraction">
+<div vocab="http://schema.org/" typeof="TouristAttraction Museum">
 	<h1><span property="name">Please Touch Museum</span></h1>
 	<div>It is a 
 		<div property="touristType" typeof="Audience">
@@ -249,7 +250,7 @@ JSON:
 <script type="application/ld+json">
 {
 	"@context": "http://schema.org",
-	"@type": "TouristAttraction",
+	"@type": ["TouristAttraction","Museum"],
 	"name": "Please Touch Museum",
 	"address": {
 		"@type": "PostalAddress",
@@ -368,6 +369,383 @@ JSON:
 		"startDate": "2016-09-15",
 		"endDate": "2017-01-22"
 	}
+}
+</script>
+
+TYPES: #tourism-7 TouristAttraction, isAccessibleForFree
+
+PRE-MARKUP:
+
+Name: The Falles 2017
+Description: The Falles is a traditional celebration held in commemoration of Saint Joseph in the city of Valencia, Spain. The term Falles refers to both the celebration and the monuments burnt during the celebration. Added to UNESCO's intangible cultural heritage of humanity list on 30 November 2016.
+From: March 3, 2017
+To: March 3, 2017
+Location: Valencia, ES
+Public Access: yes
+Is Accessible For Free: yes
+Tourist Audience: Cultural tourism
+Image 1: https://commons.wikimedia.org/wiki/File%3AFalla_Plaza_del_Ayuntamiento_2016_(1).jpg
+Image 2: https://commons.wikimedia.org/wiki/File:La_fallera_y_su_crem%C3%A1.jpg
+Same As: http://www.wikidata.org/entity/Q1143768
+
+MICRODATA:
+
+<div>
+  <div itemtype="http://schema.org/TouristAttraction" itemscope>
+    <link itemprop="additionalType" href="http://schema.org/Event" />
+    <meta itemprop="name" content="Las Fallas 2017" />
+    <meta itemprop="name" content="The Falles 2017" />
+    <meta itemprop="alternateName" content="Les Falles 2017" />
+    <meta itemprop="touristType" content="Cultural tourism" />
+    <meta itemprop="description" content="Las Fallas son unas fiestas con una tradición arraigada en la ciudad de Valencia y diferentes poblaciones de la Comunidad Valenciana, y que se celebran en honor de San José. El término Falla se refiere a las propia fiestas y a los monumentos quemados en las calles de Valencia el día 19 de marzo. En noviembre de 2016 la Unesco las inscribió en su Lista Representativa del Patrimonio Cultural Inmaterial de la Humanidad." />
+    <meta itemprop="description" content="The Falles is a traditional celebration held in commemoration of Saint Joseph in the city of Valencia, Spain. The term Falles refers to both the celebration and the monuments burnt during the celebration. Added to UNESCO's intangible cultural heritage of humanity list on 30 November 2016." />
+    <meta itemprop="startDate" content="2017-03-15T09:00" />
+    <meta itemprop="endDate" content="2017-03-19T23:59" />
+    <div itemprop="location" itemtype="http://schema.org/PostalAddress" itemscope>
+      <meta itemprop="addressLocality" content="Valencia" />
+      <meta itemprop="addressRegion" content="Valencia" />
+      <meta itemprop="addressCountry" content="ES" />
+    </div>
+    <meta itemprop="publicAccess" content="true" />
+    <meta itemprop="isAccessibleForFree" content="true" />
+    <link itemprop="image" href="https://commons.wikimedia.org/wiki/File%3AFalla_Plaza_del_Ayuntamiento_2016_(1).jpg" />
+    <link itemprop="image" href="https://commons.wikimedia.org/wiki/File:La_fallera_y_su_crem%C3%A1.jpg" />
+    <link itemprop="sameAs" href="http://www.wikidata.org/entity/Q1143768" />
+  </div>
+</div>
+
+RDFA:
+
+<div xmlns="http://www.w3.org/1999/xhtml"
+  prefix="
+    schema: http://schema.org/
+    rdf: http://www.w3.org/1999/02/22-rdf-syntax-ns#
+    xsd: http://www.w3.org/2001/XMLSchema#
+    rdfs: http://www.w3.org/2000/01/rdf-schema#"
+  >
+  <div typeof="schema:TouristAttraction">
+    <div rel="rdf:type" resource="http://schema.org/Event"></div>
+    <div property="schema:name" xml:lang="es" content="Las Fallas 2017"></div>
+    <div property="schema:name" xml:lang="en" content="The Falles 2017"></div>
+    <div property="schema:alternateName" content="Les Falles 2017"></div>
+    <div property="schema:description" xml:lang="es" content="Las Fallas son unas fiestas con una tradición arraigada en la ciudad de Valencia y diferentes poblaciones de la Comunidad Valenciana, y que se celebran en honor de San José. El término Falla se refiere a las propia fiestas y a los monumentos quemados en las calles de Valencia el día 19 de marzo. En noviembre de 2016 la Unesco las inscribió en su Lista Representativa del Patrimonio Cultural Inmaterial de la Humanidad."></div>
+    <div property="schema:description" xml:lang="en" content="The Falles is a traditional celebration held in commemoration of Saint Joseph in the city of Valencia, Spain. The term Falles refers to both the celebration and the monuments burnt during the celebration. Added to UNESCO's intangible cultural heritage of humanity list on 30 November 2016."></div>
+    <div property="schema:startDate" datatype="schema:Date" content="2017-03-15T09:00"></div>
+    <div property="schema:endDate" datatype="schema:Date" content="2017-03-19T23:59"></div>
+    <div rel="schema:location">
+      <div typeof="schema:PostalAddress">
+        <div property="schema:addressLocality" content="Valencia"></div>
+        <div property="schema:addressCountry" content="ES"></div>
+        <div property="schema:addressRegion" content="Valencia"></div>
+      </div>
+    </div>
+    <div property="schema:publicAccess" datatype="xsd:boolean" content="true"></div>
+    <div property="schema:isAccessibleForFree" datatype="xsd:boolean" content="true"></div>
+    <div property="schema:touristType" content="Cultural tourism"></div>
+    <div rel="schema:image" resource="https://commons.wikimedia.org/wiki/File%3AFalla_Plaza_del_Ayuntamiento_2016_(1).jpg"></div>
+    <div rel="schema:image" resource="https://commons.wikimedia.org/wiki/File:La_fallera_y_su_crem%C3%A1.jpg"></div>
+    <div rel="schema:sameAs" resource="http://www.wikidata.org/entity/Q1143768"></div>
+  </div>
+</div>
+
+JSON:
+
+<script type="application/ld+json">
+{
+  "@context": "http://schema.org",
+  "@type": [
+    "Event",
+    "TouristAttraction"
+  ],
+  "name": "The Falles 2017",
+  "name": [
+    {
+    "@language": "es",
+    "@value": "Las Fallas 2017"
+    },
+    {
+    "@language": "en",
+    "@value": "The Falles 2017"
+    }
+  ],
+  "alternateName":"Les Falles 2017",
+  "description":"The Falles is a traditional celebration held in commemoration of Saint Joseph in the city of Valencia, Spain. The term Falles refers to both the celebration and the monuments burnt during the celebration. Added to UNESCO's intangible cultural heritage of humanity list on 30 November 2016.",
+  "description":[
+    {
+    "@language": "es",
+    "@value": "Las Fallas son unas fiestas con una tradición arraigada en la ciudad de Valencia y diferentes poblaciones de la Comunidad Valenciana, y que se celebran en honor de San José. El término Falla se refiere a las propia fiestas y a los monumentos quemados en las calles de Valencia el día 19 de marzo. En noviembre de 2016 la Unesco las inscribió en su Lista Representativa del Patrimonio Cultural Inmaterial de la Humanidad."
+    },
+    {
+    "@language": "en",
+    "@value": "The Falles is a traditional celebration held in commemoration of Saint Joseph in the city of Valencia, Spain. The term Falles refers to both the celebration and the monuments burnt during the celebration. Added to UNESCO's intangible cultural heritage of humanity list on 30 November 2016."
+    }
+  ],
+  "startDate":"2017-03-15T09:00",
+  "endDate": "2017-03-19T23:59",
+  "location": {
+    "@type": "PostalAddress",
+    "addressLocality": "Valencia",
+    "addressRegion": "Valencia",
+    "addressCountry": "ES"
+  },
+  "publicAccess": true,
+  "isAccessibleForFree": true,
+  "touristType": [
+    "Cultural tourism"
+  ],
+  "image": [
+    "https://commons.wikimedia.org/wiki/File%3AFalla_Plaza_del_Ayuntamiento_2016_(1).jpg",
+    "https://commons.wikimedia.org/wiki/File:La_fallera_y_su_crem%C3%A1.jpg"
+  ],
+  "sameAs": "http://www.wikidata.org/entity/Q1143768"
+}
+</script>
+
+TYPES: #tourism-8 TouristAttraction, touristType, isAccessibleForFree, Cemetery
+
+PRE-MARKUP:
+
+Name: Villers–Bretonneux Australian National Memorial
+Description: The Australian National Memorial, Villers–Bretonneux is the main memorial to Australian military personnel killed on the Western Front during World War I.
+Address: Fouilloy, FR
+Geocoordinates: lat 49.8852515, lon 2.5106436
+Public Access: yes
+Is Accessible For Free: yes
+Tourist Audience: Memorial Tourism from Australia and New Zealand
+Image: https://commons.wikimedia.org/wiki/File%3AVillers-Bretonneux_m%C3%A9morial_australien_(tour_et_croix)_1.jpg
+Same As: https://www.wikidata.org/wiki/Q2544355
+
+MICRODATA:
+
+<div>
+  <div itemtype="http://schema.org/TouristAttraction" itemscope>
+    <link itemprop="additionalType" href="http://schema.org/Cemetery" />
+    <meta itemprop="name" content="Villers–Bretonneux Australian National Memorial" />
+    <meta itemprop="description" content="The Australian National Memorial, Villers–Bretonneux is the main memorial to Australian military personnel killed on the Western Front during World War I." />
+    <div itemprop="touristType" itemtype="http://schema.org/Audience" itemscope>
+      <meta itemprop="audienceType" content="Memorial Tourism" />
+      <div itemprop="geographicArea" itemtype="http://schema.org/AdministrativeArea" itemscope>
+        <meta itemprop="name" content="New Zealand" />
+      </div>
+      <div itemprop="geographicArea" itemtype="http://schema.org/AdministrativeArea" itemscope>
+        <meta itemprop="name" content="Australia" />
+      </div>
+    </div>
+    <div itemprop="address" itemtype="http://schema.org/PostalAddress" itemscope>
+      <meta itemprop="addressLocality" content="Fouilloy" />
+      <meta itemprop="addressCountry" content="FR" />
+    </div>
+    <div itemprop="geo" itemtype="http://schema.org/GeoCoordinates" itemscope>
+      <meta itemprop="latitude" content="49.8852515" />
+      <meta itemprop="longitude" content="2.5106436" />
+    </div>
+    <meta itemprop="publicAccess" content="true" />
+    <meta itemprop="isAccessibleForFree" content="true" />
+    <link itemprop="sameAs" href="https://www.wikidata.org/wiki/Q2544355" />
+    <link itemprop="image" href="https://commons.wikimedia.org/wiki/File%3AVillers-Bretonneux_m%C3%A9morial_australien_(tour_et_croix)_1.jpg" />
+  </div>
+</div>
+
+RDFA:
+
+<div xmlns="http://www.w3.org/1999/xhtml"
+  prefix="
+    schema: http://schema.org/
+    rdf: http://www.w3.org/1999/02/22-rdf-syntax-ns#
+    xsd: http://www.w3.org/2001/XMLSchema#
+    rdfs: http://www.w3.org/2000/01/rdf-schema#"
+  >
+  <div typeof="schema:Cemetery">
+    <div rel="rdf:type" resource="http://schema.org/TouristAttraction"></div>
+    <div property="schema:name" content="Villers–Bretonneux Australian National Memorial"></div>
+    <div property="schema:description" content="The Australian National Memorial, Villers–Bretonneux is the main memorial to Australian military personnel killed on the Western Front during World War I."></div>
+    <div rel="schema:touristType">
+      <div typeof="schema:Audience">
+        <div property="schema:audienceType" content="Memorial Tourism"></div>
+        <div rel="schema:geographicArea">
+          <div typeof="schema:AdministrativeArea">
+            <div property="schema:name" content="New Zealand"></div>
+          </div>
+        </div>
+        <div rel="schema:geographicArea">
+          <div typeof="schema:AdministrativeArea">
+            <div property="schema:name" content="Australia"></div>
+          </div>
+        </div>
+      </div>
+    </div>
+    <div rel="schema:address">
+      <div typeof="schema:PostalAddress">
+        <div property="schema:addressCountry" content="FR"></div>
+        <div property="schema:addressLocality" content="Fouilloy"></div>
+      </div>
+    </div>
+    <div rel="schema:geo">
+      <div typeof="schema:GeoCoordinates">
+        <div property="schema:latitude" content="49.8852515"></div>
+        <div property="schema:longitude" content="2.5106436"></div>
+      </div>
+    </div>
+    <div property="schema:publicAccess" datatype="xsd:boolean" content="true"></div>
+    <div property="schema:isAccessibleForFree" datatype="xsd:boolean" content="true"></div>
+    <div rel="schema:sameAs" resource="https://www.wikidata.org/wiki/Q2544355"></div>
+    <div rel="schema:image" resource="https://commons.wikimedia.org/wiki/File%3AVillers-Bretonneux_m%C3%A9morial_australien_(tour_et_croix)_1.jpg"></div>
+  </div>
+</div>
+
+JSON:
+
+<script type="application/ld+json">
+{
+ "@context": "http://schema.org/",
+ "@type": [
+  "Cemetery",
+  "TouristAttraction"
+  ],
+ "name": "Villers–Bretonneux Australian National Memorial",
+ "description": "The Australian National Memorial, Villers–Bretonneux is the main memorial to Australian military personnel killed on the Western Front during World War I.",
+  "touristType": {
+    "@type": "Audience",
+    "audienceType" : "Memorial Tourism",
+    "geographicArea": [{
+      "@type": "AdministrativeArea",
+      "name": "Australia"
+    },{
+      "@type": "AdministrativeArea",
+      "name": "New Zealand"
+    }]
+  },
+  "address": {
+    "@type": "PostalAddress",
+    "addressCountry": "FR",
+    "addressLocality":"Fouilloy"
+  },
+  "geo": {
+    "@type": "GeoCoordinates",
+    "latitude": "49.8852515",
+    "longitude": "2.5106436"
+  },
+  "publicAccess": true,
+  "isAccessibleForFree": true,
+  "sameAs":"https://www.wikidata.org/wiki/Q2544355",
+  "image":"https://commons.wikimedia.org/wiki/File%3AVillers-Bretonneux_m%C3%A9morial_australien_(tour_et_croix)_1.jpg"
+}
+</script>
+
+TYPES: #tourism-9 TouristAttraction, touristType, Winery
+
+PRE-MARKUP:
+
+Name: Bodegas Protos
+Description: Protos means “first” in Greek, and since 1927 this centenary winery has embarked on the mission to be number one. This attitude has driven their search for constant improvement.The new facilities designed by prestigious architect and winner of the Priztker Award, Sir Richard Rogers, once again took the winery to the forefront of wine tourism. A tour around Protos includes a detailed visit to both the underground cellar dug into the hillside of Peñafiel Castle and to the winery designed by celebrated architect Sir Richard Rogers.After completing the itinerary, visitors can taste 2 excellent Protos wines and will receive a gift. The visit lasts 1.5 hours (including the sampling).
+Opening Hours: Monday to Friday, 10:00-13:00 and 16:30-18:00
+Address: C/ Bodegas Protos, 24-28, 47300 - Peñafiel, Spain
+Public Access: yes
+Tourist Audience: Wine tourism, Cultural tourism
+Available Languages: English, Spanish
+Telephone: +34983878011, +34659843463
+Same As: http://www.bodegasprotos.com
+Email: enoturismo@bodegasprotos.com
+Image: https://commons.wikimedia.org/wiki/File%3AFoto_Bodega_Rogers2.jpg
+
+MICRODATA:
+
+<div>
+  <div itemtype="http://schema.org/TouristAttraction" itemscope>
+    <link itemprop="additionalType" href="http://schema.org/Winery" />
+    <meta itemprop="name" content="Bodegas Protos" />
+    <meta itemprop="description" content="Protos means “first” in Greek, and since 1927 this centenary winery has embarked on the mission to be number one. This attitude has driven their search for constant improvement.The new facilities designed by prestigious architect and winner of the Priztker Award, Sir Richard Rogers, once again took the winery to the forefront of wine tourism. A tour around Protos includes a detailed visit to both the underground cellar dug into the hillside of Peñafiel Castle and to the winery designed by celebrated architect Sir Richard Rogers.After completing the itinerary, visitors can taste 2 excellent Protos wines and will receive a gift. The visit lasts 1.5 hours (including the sampling)." />
+    <div itemprop="address" itemtype="http://schema.org/PostalAddress" itemscope>
+      <meta itemprop="addressLocality" content="Peñafiel" />
+      <meta itemprop="streetAddress" content="C/ Bodegas Protos, 24-28" />
+      <meta itemprop="postalCode" content="47300" />
+      <meta itemprop="addressCountry" content="ES" />
+    </div>
+    <meta itemprop="publicAccess" content="true" />
+    <meta itemprop="availableLanguage" content="English" />
+    <meta itemprop="availableLanguage" content="Spanish" />
+    <meta itemprop="openingHours" content="Mo-Fr 10:00-13:00" />
+    <meta itemprop="openingHours" content="Mo-Fr 16:30-18:00" />
+    <meta itemprop="touristType" content="Wine tourism" />
+    <meta itemprop="touristType" content="Cultural tourism" />
+    <meta itemprop="telephone" content="+34983878011" />
+    <meta itemprop="telephone" content="+34659843463" />
+    <link itemprop="sameAs" href="http://www.bodegasprotos.com/" />
+    <meta itemprop="email" content="enoturismo@bodegasprotos.com" />
+    <link itemprop="image" href="https://commons.wikimedia.org/wiki/File%3AFoto_Bodega_Rogers2.jpg" />
+  </div>
+</div>
+
+RDFA:
+
+<div xmlns="http://www.w3.org/1999/xhtml"
+  prefix="
+    schema: http://schema.org/
+    rdf: http://www.w3.org/1999/02/22-rdf-syntax-ns#
+    xsd: http://www.w3.org/2001/XMLSchema#
+    rdfs: http://www.w3.org/2000/01/rdf-schema#"
+  >
+  <div typeof="schema:TouristAttraction">
+    <div rel="rdf:type" resource="http://schema.org/Winery"></div>
+    <div property="schema:name" content="Bodegas Protos"></div>
+    <div property="schema:description" content="Protos means “first” in Greek, and since 1927 this centenary winery has embarked on the mission to be number one. This attitude has driven their search for constant improvement.The new facilities designed by prestigious architect and winner of the Priztker Award, Sir Richard Rogers, once again took the winery to the forefront of wine tourism. A tour around Protos includes a detailed visit to both the underground cellar dug into the hillside of Peñafiel Castle and to the winery designed by celebrated architect Sir Richard Rogers.After completing the itinerary, visitors can taste 2 excellent Protos wines and will receive a gift. The visit lasts 1.5 hours (including the sampling)."></div>
+    <div rel="schema:address">
+      <div typeof="schema:PostalAddress">
+        <div property="schema:addressCountry" content="ES"></div>
+        <div property="schema:addressLocality" content="Peñafiel"></div>
+        <div property="schema:postalCode" content="47300"></div>
+        <div property="schema:streetAddress" content="C/ Bodegas Protos, 24-28"></div>
+      </div>
+    </div>
+    <div property="schema:publicAccess" datatype="xsd:boolean" content="true"></div>
+    <div property="schema:availableLanguage" content="English"></div>
+    <div property="schema:availableLanguage" content="Spanish"></div>
+    <div property="schema:openingHours" content="Mo-Fr 10:00-13:00"></div>
+    <div property="schema:openingHours" content="Mo-Fr 16:30-18:00"></div>
+    <div property="schema:touristType" content="Wine tourism"></div>
+    <div property="schema:touristType" content="Cultural tourism"></div>
+    <div property="schema:telephone" content="+34983878011"></div>
+    <div property="schema:telephone" content="+34659843463"></div>
+    <div rel="schema:sameAs" resource="http://www.bodegasprotos.com/"></div>
+    <div property="schema:email" content="enoturismo@bodegasprotos.com"></div>
+    <div rel="schema:image" resource="https://commons.wikimedia.org/wiki/File%3AFoto_Bodega_Rogers2.jpg"></div>
+  </div>
+</div>
+
+JSON:
+
+<script type="application/ld+json">
+{
+  "@context": "http://schema.org",
+  "@type": [
+    "Winery",
+    "TouristAttraction"],
+  "name": "Bodegas Protos",
+  "description": "Protos means “first” in Greek, and since 1927 this centenary winery has embarked on the mission to be number one. This attitude has driven their search for constant improvement.The new facilities designed by prestigious architect and winner of the Priztker Award, Sir Richard Rogers, once again took the winery to the forefront of wine tourism. A tour around Protos includes a detailed visit to both the underground cellar dug into the hillside of Peñafiel Castle and to the winery designed by celebrated architect Sir Richard Rogers.After completing the itinerary, visitors can taste 2 excellent Protos wines and will receive a gift. The visit lasts 1.5 hours (including the sampling).",
+  "address": {
+    "@type": "PostalAddress",
+    "addressLocality": "Peñafiel",
+    "addressCountry": "ES",
+    "postalCode": "47300",
+    "streetAddress": "C/ Bodegas Protos, 24-28"
+  },
+  "publicAccess": true,
+  "availableLanguage":[
+    "English",
+    "Spanish"
+  ],
+  "openingHours": [
+    "Mo-Fr 10:00-13:00",
+    "Mo-Fr 16:30-18:00"
+  ],
+  "touristType": [
+    "Wine tourism",
+    "Cultural tourism"
+  ],
+  "telephone": ["+34983878011","+34659843463"],
+  "sameAs": "http://www.bodegasprotos.com",
+  "email": "enoturismo@bodegasprotos.com",
+  "image": "https://commons.wikimedia.org/wiki/File%3AFoto_Bodega_Rogers2.jpg"
 }
 </script>
 

--- a/data/sdo-tourism-examples.txt
+++ b/data/sdo-tourism-examples.txt
@@ -1,27 +1,376 @@
-TYPES: #tourism-1 TouristAttraction
+TYPES: #tourism-1 TouristAttraction, isAccessibleForFree
 
 PRE-MARKUP:
 
-<p>
-Example Mark up here
-</p>
+<h1>Hyde Park</h1>
+<div>It's one of the nine royal parks of London.</div>
+<div>Website: 
+	<a href="http://www.royalparks.org.uk/parks/hyde-park">www.royalparks.org.uk/parks/hyde-park</a>
+</div>
+<div>Ticket: access for free.</div>
+
 
 MICRODATA:
 
-<p itemscope itemtype="http://schema.org/TouristAttraction">
-Example Mark up here
-</p>
+<div itemscope itemtype="http://schema.org/TouristAttraction">
+	<h1><span itemprop="name">Hyde Park</span></h1>
+	<div>
+		<span itemprop="description">It's one of nine royal parks of London.</span>
+	</div>
+	<div>Website: 
+		<a href="http://www.royalparks.org.uk/parks/hyde-park" itemprop="url">www.royalparks.org.uk/parks/hyde-park</a>
+	</div>
+	<div>
+		<meta itemprop="isAccessibleForFree" content="true"/>Ticket: access for free.
+	</div>
+</div>
 
 RDFA:
 
-<p vocab="http://schema.org/" typeof="TouristAttraction">
-Example Mark up here
-</p>
+<div vocab="http://schema.org/" typeof="TouristAttraction">
+	<h1><span property="name">Hyde Park</span></h1>
+	<div>
+		<span property="description">It's one of nine royal parks of London.</span>
+	</div>
+	<div>Website: 
+		<a href="http://www.royalparks.org.uk/parks/hyde-park" property="url">www.royalparks.org.uk/parks/hyde-park</a>
+	</div>
+	<div>
+		<meta property="isAccessibleForFree" content="true"/>Ticket: access for free.
+	</div>
+</div>
 
 JSON:
 
+<script type="application/ld+json">
 {
- "@context": "http://schema.org/",
- "@type": "TouristAttraction"
+	"@context": "http://schema.org",
+	"@type": "TouristAttraction",
+	"name": "Hyde Park",
+	"description": "It's one of nine royal parks of London.",
+	"url": "http://www.royalparks.org.uk/parks/hyde-park",
+	"isAccessibleForFree": true
 }
+</script>
+
+TYPES: #tourism-2 AmusementPark, TouristAttraction, isAccessibleForFree, currenciesAccepted, openingHours, paymentAccepted
+
+PRE-MARKUP:
+
+<h1>Disneyland Paris</h1>
+<div>It's an amusement park in Marne-la-Vallée, near Paris, in France.</div>
+<div>Hours: Mo-Fri 10am-7pm Sa 10am-22pm Su 10am-21pm</div>
+<div>Entrance: with ticket</div>
+<div>Currency accepted: Euro</div>
+<div>Payment accepted: Cash, Credit Card</div>
+<div>Website: 
+	<a href="http://www.disneylandparis.it/">www.disneylandparis.it</a>
+</div>
+
+MICRODATA:
+
+<div itemscope itemtype="http://schema.org/AmusementPark http://schema.org/TouristAttraction">
+	<h1><span itemprop="name">Disneyland Paris</span></h1>
+	<div>
+		<span itemprop="description">It's an amusement park in Marne-la-Vallée, near Paris, in France and is the most visited theme park in all of France and Europe.</span>
+	</div>
+	<div>Hours: Mo-Fri 10am-7pm Sa 10am-22pm Su 10am-21pm
+		<meta itemprop="openingHours" content="Mo-Fri 10:00-19:00"/>
+		<meta itemprop="openingHours" content="Sa 10:00-22:00"/>
+		<meta itemprop="openingHours" content="Su 10:00-21:00"/>
+	</div>
+	<div>
+		<meta itemprop="isAccessibleForFree" content="false"/>Entrance: with ticket
+	</div>
+	<div>
+		<meta itemprop="currenciesAccepted" content="EUR"/>Currency accepted: Euro
+	</div>
+	<div>
+		<meta itemprop="paymentAccepted" content="Cash, Credit Card"/>Payment accepted: Cash, Credit Card
+	</div>
+	<div>Website: 
+		<a href="http://www.disneylandparis.it/" itemprop="url">www.disneylandparis.it</a>
+	</div>
+</div>
+
+RDFA:
+
+<div vocab="http://schema.org/" typeof="TouristAttraction AmusementPark">
+	<h1><span property="name">Disneyland Paris</span></h1>
+	<div>
+		<span property="description">It's an amusement park in Marne-la-Vallée, near Paris, in France and is the most visited theme park in all of France and Europe.</span>
+	</div>
+	<div>Hours: Mo-Fri 10am-7pm Sa 10am-22pm Su 10am-21pm
+		<meta property="openingHours" content="Mo-Fri 10:00-19:00"/>
+		<meta property="openingHours" content="Sa 10:00-22:00"/>
+		<meta property="openingHours" content="Su 10:00-21:00"/>
+	</div>
+	<div>
+		<meta property="isAccessibleForFree" content="false"/>Entrance: with ticket
+	</div>
+	<div>
+		<meta property="currenciesAccepted" content="EUR"/>Currency accepted: Euro
+	</div>
+	<div>
+		<meta property="paymentAccepted" content="Cash, Credit Card"/>Payment accepted: Cash, Credit Card
+	</div>
+	<div>Website: 
+		<a href="http://www.disneylandparis.it/" property="url">www.disneylandparis.it</a>
+	</div>
+</div>
+
+JSON:
+
+<script type="application/ld+json">
+{
+	"@context": "http://schema.org",
+	"@type": ["TouristAttraction", "AmusementPark"],
+	"name": "Disneyland Paris",
+	"description": "It's an amusement park in Marne-la-Vallée, near Paris, in France and is the most visited theme park in all of France and Europe.",
+	"openingHours":["Mo-Fri 10:00-19:00", "Sa 10:00-22:00", "Su 10:00-21:00"],
+	"isAccessibleForFree": false,
+	"currenciesAccepted": "EUR",
+	"paymentAccepted":"Cash, Credit Card",
+	"url":"http://www.disneylandparis.it/"
+}
+</script>
+
+TYPES: #tourism-3 TouristAttraction, availableLanguage
+
+PRE-MARKUP:
+
+<h1>Neuschwanstein Castle</h1>
+<div>Neuschwanstein Castle is a nineteenth-century Romanesque Revival palace in Schwangau, in southwest Bavaria, Germany.</div>
+<div>Guided tours in German and English.</div>
+
+MICRODATA:
+
+<div itemscope itemtype="http://schema.org/TouristAttraction">
+	<h1><span itemprop="name">Neuschwanstein Castle</span></h1>
+	<div>It is a nineteenth-century Romanesque Revival palace in 
+		<div itemprop="address" itemscope itemtype="http://schema.org/PostalAddress">
+			<span itemprop="addressLocality">Schwangau</span>, in 
+			<span itemprop="addressCountry">Germany</span>.
+		</div>
+	</div>
+	<div>Guided tours in 
+		<div itemprop="availableLanguage" itemscope itemtype="http://schema.org/Language">
+			<span itemprop="name">German</span>
+		</div> and 
+		<div itemprop="availableLanguage" itemscope itemtype="http://schema.org/Language">
+			<span itemprop="name">English</span>.
+		</div>
+	</div>
+</div>
+
+RDFA:
+
+<div vocab="http://schema.org" typeof="TouristAttraction">
+	<h1><span property="name">Neuschwanstein Castle</span></h1>
+	<div>It is a nineteenth-century Romanesque Revival palace in 
+		<div property="address" typeof="PostalAddress">
+			<span property="addressLocality">Schwangau</span>, in 
+			<span property="addressCountry">Germany</span>.
+		</div>
+	</div>
+	<div>Guided tours in 
+		<div property="availableLanguage" typeof="Language">
+			<span property="name">German</span>
+		</div> and 
+		<div property="availableLanguage" typeof="Language">
+			<span property="name">English</span>.
+		</div>
+	</div>
+</div>
+
+JSON:
+
+<script type="application/ld+json">
+{
+	"@context": "http://schema.org",
+	"@type": "TouristAttraction",
+	"name": "Neuschwanstein Castle",
+	"address": {
+		"@type": "PostalAddress",
+		"addressLocality": "Schwangau",
+		"addressCountry": "Germany"
+	},
+	"availableLanguage": {
+		"@type": "Language",
+		"name": ["German","English"]
+	}
+}
+</script>
+
+TYPES: #tourism-4 TouristAttraction, touristType
+
+PRE-MARKUP:
+
+<h1>Please Touch Museum</h1>
+<div>It is a children's museum located in Philadelphia, Pennsylvania, USA.</div>
+<div>The museum focuses on teaching children through interactive exhibits and special events.</div>
+
+MICRODATA:
+
+<div itemscope itemtype="http://schema.org/TouristAttraction">
+	<h1><span itemprop="name">Please Touch Museum</span></h1>
+	<div>It is a 
+		<div itemprop="touristType" itemscope itemtype="http://schema.org/Audience">
+			<span itemprop="audienceType">children</span>
+		</div>'s museum located in 
+		<div itemprop="address" itemscope itemtype="http://schema.org/PostalAddress">
+			<div itemprop="addressLocality">Philadelphia</div>, 
+			<div itemprop="addressCountry">USA</div>.
+		</div>
+	<div>
+		<span itemprop="description">The museum focuses on teaching children through interactive exhibits and special events.</span>
+	</div>
+</div>
+
+RDFA:
+
+<div vocab="http://schema.org/" typeof="TouristAttraction">
+	<h1><span property="name">Please Touch Museum</span></h1>
+	<div>It is a 
+		<div property="touristType" typeof="Audience">
+			<span property="audienceType">children</span>
+		</div>'s museum located in 
+		<div property="address" typeof="PostalAddress">
+			<div property="addressLocality">Philadelphia</div>, 
+			<div property="addressCountry">USA</div>.
+		</div>
+	<div>
+		<span property="description">The museum focuses on teaching children through interactive exhibits and special events.</span>
+	</div>
+</div>
+
+JSON:
+
+<script type="application/ld+json">
+{
+	"@context": "http://schema.org",
+	"@type": "TouristAttraction",
+	"name": "Please Touch Museum",
+	"address": {
+		"@type": "PostalAddress",
+		"addressLocality": "Philadelphia",
+		"addressCountry": "USA"
+	},
+	"touristType": {
+		"@type": "Audience",
+		"audienceType": "children"
+	},
+	"description": "The museum focuses on teaching children through interactive exhibits and special events."
+}
+</script>
+
+TYPES: #tourism-5 TouristAttraction, publicAccess
+
+PRE-MARKUP:
+
+<h1>Leaning Tower of Pisa</h1>
+<div>It is a twelfth-thirteenth century Romanesque tower started building by Bonanno Pisano.</div>
+<div>Public access: yes</div>
+
+MICRODATA:
+
+<div itemscope itemtype="http://schema.org/TouristAttraction">
+	<h1><span itemprop="name">Leaning Tower of Pisa</span></h1>
+	<div>
+		<span itemprop="description">It is a twelfth-thirteenth century Romanesque tower started building by Bonanno Pisano.</span> 
+	</div>
+	<div>
+		<meta itemprop="publicAccess" content="true"/>Public access: yes
+	</div>
+</div>
+
+RDFA:
+
+<div vocab="http://schema.org/" typeof="TouristAttraction">
+	<h1><span property="name">Leaning Tower of Pisa</span></h1>
+	<div>
+		<span property="description">It is a twelfth-thirteenth century Romanesque tower started building by Bonanno Pisano.</span> 
+	</div>
+	<div>
+		<meta property="publicAccess" content="true"/>Public access: yes
+	</div>
+</div>
+
+JSON:
+
+<script type="application/ld+json">
+{
+	"@context": "http://schema.org",
+	"@type": "TouristAttraction",
+	"name": "Leaning Tower of Pisa",
+	"publicAccess": true,
+	"description": "It is a twelfth-thirteenth century Romanesque tower started building by Bonanno Pisano."
+}
+</script>
+
+TYPES: #tourism-6 TouristAttraction, event, Event
+
+PRE-MARKUP:
+
+<h1>Musée Marmottan Monet</h1>
+<div>It's a museum of Impressionism and french ninenteeth art.</div>
+<div>It is hosting the Hodler's, Monet's and Munch's exibit: "Peindre l'impossible".
+Start date: September 15 2016
+End date: Genuary 22 2017
+</div>
+
+MICRODATA:
+
+<div itemscope itemtype="http://schema.org/TouristAttraction">
+	<h1><span itemprop="name">Musée Marmottan Monet</span></h1>
+	<div>
+		<span itemprop="description">It's a museum of Impressionism and french ninenteeth art.</span>
+	</div>
+	<div itemprop="event" itemscope itemtype="http://schema.org/Event">It is hosting the 
+		<span itemprop="about">Hodler</span>'s
+		<span itemprop="about">Monet</span>'s
+		<span itemprop="about">Munch</span>'s exibit: 
+		<span itemprop="name">"Peindre l'impossible"</span>.
+		<meta itemprop="startDate" content="2016-09-15" />Start date: September 15 2016
+		<meta itemprop="endDate" content="2017-01-22" />End date: Genuary 22 2017
+	</div>
+</div>
+
+RDFA:
+
+<div vocab="http://schema.org/" typeof="TouristAttraction">
+	<h1><span property="name">Musée Marmottan Monet</span></h1>
+	<div>
+		<span property="description">It's a museum of Impressionism and french ninenteeth art.</span>
+	</div>
+	<div property="event" typeof="Event">It is hosting the 
+		<span property="about">Hodler</span>'s
+		<span property="about">Monet</span>'s
+		<span property="about">Munch</span>'s exibit:
+		<span property="name">"Peindre l'impossible"</span>.
+		<meta property="startDate" content="2016-10-01" />Start date: September 15 2016
+		<meta property="endDate" content="2017-02-05" />End date: Genuary 22 2017
+	</div>
+</div>
+
+JSON:
+
+<script type="application/ld+json">
+{
+	"@context": "http://schema.org",
+	"@type": "TouristAttraction",
+	"name": "Musée Marmottan Monet",
+	"description": "It's a museum of Impressionism and french ninenteeth art.",
+	"event": {
+		"@type": "Event",
+		"about": ["Hodler","Monet","Munch"],  
+		"name": "Peindre l'impossible",
+		"startDate": "2016-09-15",
+		"endDate": "2017-01-22"
+	}
+}
+</script>
+
+
+
 

--- a/data/sdo-tourism-examples.txt
+++ b/data/sdo-tourism-examples.txt
@@ -1,0 +1,27 @@
+TYPES: #tourism-1 TouristAttraction
+
+PRE-MARKUP:
+
+<p>
+Example Mark up here
+</p>
+
+MICRODATA:
+
+<p itemscope itemtype="http://schema.org/TouristAttraction">
+Example Mark up here
+</p>
+
+RDFA:
+
+<p vocab="http://schema.org/" typeof="TouristAttraction">
+Example Mark up here
+</p>
+
+JSON:
+
+{
+ "@context": "http://schema.org/",
+ "@type": "TouristAttraction"
+}
+


### PR DESCRIPTION
Following previous discussions on mailing lists over the last couple of months this is a proposal from the [W3C Tourism Structured Web Data Community Group](https://www.w3.org/community/tourismdata/), working with Angelica Lo Duca and Elisabetta Triolo, to increase the utility and usefulness of the TouristAttraction Type.

A working example, with many examples for several use-cases, can be found here: [TouristAttraction](http://sdo-tourism.appspot.com/TouristAttraction).

By making use of Multi Type Entity (MTE) capabilities, it should be possible to identify any 'Thing' as a TouristAttraction, in addition to its default properties as a museum, mountain, dance festival, or whatever.

To aid that utility, this proposal makes the following additions: 

- Add new property [touristType](http://sdo-tourism.appspot.com/touristType) to TouristAttraction  "_Attraction suitable for type(s) of tourist. eg. Children, visitors from a particular country, etc._"

- Extend the domain of [availableLanguage](http://sdo-tourism.appspot.com/availableLanguage) to TouristAttraction.  "_A language someone may use with or at the item, service or place...._"

- Extend the domain of [isAccessibleForFree](http://sdo-tourism.appspot.com/isAccessibleForFree) to Place  "_A flag to signal that the item, event, place is accessible for free._"

- Add new  property [publicAccess](http://sdo-tourism.appspot.com/publicAccess) to Place.  "_A flag to signal that the Place is accessible by public visitors._"

Although the target type for this proposal is TouristAttraction, it was felt that applying _isAccessibleForFree_ & _publicAccess_ to _Place_ would deliver further utility.

This proposal does not attempt to address individual enhancements to types that could be a TouristAttraction, for example a _touristAuthority_ property, or a _typeOfSand_ property being added to the _Beach_ type.   These may well be approached in later proposals after more thought and discussion.
