### PR TITLE
Corrected JSON-LD for screening-1

### DIFF
--- a/data/sdo-screeningevent-examples.txt
+++ b/data/sdo-screeningevent-examples.txt
@@ -58,10 +58,10 @@ JSON:
 
 <script type="application/ld+json">
 {
-  "@context:": "http://schema.org",
+  "@context": "http://schema.org",
   "@type": "ScreeningEvent",
   "name": "Jaws 3-D",
-  "description": "Jaws 3-D shown in 3D."
+  "description": "Jaws 3-D shown in 3D.",
   "location": {
     "@type": "MovieTheater",
     "name": "ACME Cinemas 10",


### PR DESCRIPTION
Changed "@context:" to "@context" and added a comma after "Jaws 3-D shown in 3D.". JSON-LD validator now shows all the information (it didn't before) but the Google structured data testing tool complains.