### PR TITLE
Added Event to the domain of audience

### DIFF
--- a/data/schema.rdfa
+++ b/data/schema.rdfa
@@ -3760,6 +3760,7 @@ The place is __open__ if the [[opens]] property is specified, and __closed__ oth
       <span class="h" property="rdfs:label">audience</span>
       <span property="rdfs:comment">An intended audience, i.e. a group for whom something was created.</span>
       <span>Domain: <a property="http://schema.org/domainIncludes" href="http://schema.org/CreativeWork">CreativeWork</a></span>
+      <span>Domain: <a property="http://schema.org/domainIncludes" href="http://schema.org/Event">Event</a></span>
       <span>Domain: <a property="http://schema.org/domainIncludes" href="http://schema.org/Product">Product</a></span>
       <span>Domain: <a property="http://schema.org/domainIncludes" href="http://schema.org/Service">Service</a></span>
       <span>Domain: <a property="http://schema.org/domainIncludes" href="http://schema.org/PlayAction">PlayAction</a></span>


### PR DESCRIPTION
As identified in the discussion about PR (#1459) _Event_ does not have _audience_ as a property, although some of the descriptions of Event subtypes assume audiences.

This PR corrects that omission.