### PR TITLE
alias HTML to rdf:HTML

### DIFF
--- a/api.py
+++ b/api.py
@@ -999,6 +999,7 @@ def GetJsonLdContext(layers='core'):
         jsonldcontext = "{\n  \"@context\": {\n"
         jsonldcontext += "        \"type\": \"@type\",\n"
         jsonldcontext += "        \"id\": \"@id\",\n"
+        jsonldcontext += "        \"HTML\": { \"@id\": \"rdf:HTML\" },\n"
         jsonldcontext += "        \"@vocab\": \"http://schema.org/\",\n"
         jsonldcontext += namespaces
 


### PR DESCRIPTION
Experience shows that when using parsed literals some people see the string "rdf" and immediately have an allergic reaction. Beyond that, the `rdf` bit is rather unrelated to the fact that this is HTML and feels like a strange magic string. This small patch aliases `HTML` to `rdf:HTML` so that one can write `"description": { "@type": "HTML", "@value": "<p>…</p>" }` and make things look pretty self-evident and obvious.

(I hope this is the right way to change this, I wasn't 100% clear exactly on the correct indirection or how to test this.)