### PR TITLE
alias value to @value

### DIFF
--- a/api.py
+++ b/api.py
@@ -999,6 +999,7 @@ def GetJsonLdContext(layers='core'):
         jsonldcontext = "{\n  \"@context\": {\n"
         jsonldcontext += "        \"type\": \"@type\",\n"
         jsonldcontext += "        \"id\": \"@id\",\n"
+        jsonldcontext += "        \"value\": \"@value\",\n"
         jsonldcontext += "        \"@vocab\": \"http://schema.org/\",\n"
         jsonldcontext += namespaces
 


### PR DESCRIPTION
This sort of goes with #1634 but should probably be considered independently (hence the separate PRs).

The JSON-LD context aliases `id` and `type` to their @ variants, but not `value` to `@value`. If one adopts these aliases (which are nice) this leads to strange cases for parsed literals in which you get `{ "id": "rdf:HTML", "@value": "<p>…</p>" }`.

Optics, ergonomics, etc. matter, so this little bit would surely help clean that up and make it look neat to newcomers.