### PR TITLE
`AggregateRating` example was fixed: `ratingCount` -> `reviewCount`.

### DIFF
--- a/data/examples.txt
+++ b/data/examples.txt
@@ -972,7 +972,7 @@ MICRODATA:
     itemscope itemtype="http://schema.org/AggregateRating">
     <span itemprop="ratingValue">87</span>
     out of <span itemprop="bestRating">100</span>
-    based on <span itemprop="ratingCount">24</span> user ratings
+    based on <span itemprop="reviewCount">24</span> user ratings
   </div>
 
   <div itemprop="offers" itemscope itemtype="http://schema.org/AggregateOffer">


### PR DESCRIPTION
`AggregateRating` example was fixed: `ratingCount` -> `reviewCount`.

ratingCount -- The count of total number of ratings.
reviewCount -- The count of total number of reviews.

We need to use reviewCount in this example.