### PR TITLE
1457 adding schedules

### DIFF
--- a/data/ext/pending/issue-1457-examples.txt
+++ b/data/ext/pending/issue-1457-examples.txt
@@ -91,7 +91,7 @@ JSON:
       "@type": "Schedule",
       "startDate": "2016-12-24",
       "repeatFrequency": "P1D",
-      "occurenceCount": 10,
+      "repeatCount": 10,
       “startTime": "09:00",
       “endTime": "10:00"
     }

--- a/data/ext/pending/issue-1457-examples.txt
+++ b/data/ext/pending/issue-1457-examples.txt
@@ -1,0 +1,140 @@
+TYPES: Event, Schedule, eventSchedule
+
+PRE-MARKUP:
+
+A Tai-Chi class runs throughout 2017. The class occurs weekly, every Wednesday at 7pm.
+
+MICRODATA:
+
+Example is JSON-LD only.
+
+RDFA:
+
+Example is JSON-LD only.
+
+JSON:
+
+<script type="application/ld+json">
+{
+  "@context": "http://schema.org/",
+  "@type": "Event",
+  "url": "http://www.example.org/events/1",
+  "name": "Tai chi Class",
+  "description": "A weekly Tai-Chi class",
+  "duration": "PT60M",
+  "eventSchedule": {
+     "@type": "Schedule",
+     "startDate": "2017-01-01",
+     "endDate": "2017-12-31",
+     "repeatFrequency": "P1W",
+     "byDay": "http://schema.org/Wednesday",
+     "startTime": "19:00",
+     "endTime": "20:00"
+  }
+}
+</script>
+
+TYPES: Event, Schedule, eventSchedule
+
+PRE-MARKUP:
+
+A Meetup takes place on the 1st and 15th of every month between 9-10am
+
+MICRODATA:
+
+Example is JSON-LD only.
+
+RDFA:
+
+Example is JSON-LD only.
+
+JSON:
+
+<script type="application/ld+json">
+{
+  "@context": "http://schema.org/",
+  "@type": "Event",
+  "name": "Example Meetup",
+  "eventSchedule": {
+     "@type": "Schedule",
+     "repeatFrequency": "P1M",
+     "byMonthDay": [1,15],
+     "startTime": "09:00",
+     "endTime": "10:00"
+  }
+}
+</script>
+
+TYPES: Event, Schedule, eventSchedule
+
+PRE-MARKUP:
+
+Starting from 2th December an Event will run daily between 9-10am for 10 occurences.
+
+MICRODATA:
+
+Example is JSON-LD only.
+
+RDFA:
+
+Example is JSON-LD only.
+
+JSON:
+
+<script type="application/ld+json">
+{
+  "@context": "http://schema.org",
+  "@type": "Event",
+  "name": "Count Example",
+  "eventSchedule":
+    {
+      "@type": "Schedule",
+      "startDate": "2016-12-24",
+      "repeatFrequency": "P1D",
+      "occurenceCount": 10,
+      “startTime": "09:00",
+      “endTime": "10:00"
+    }
+}
+</script>
+
+TYPES: Event, Schedule, eventSchedule
+
+PRE-MARKUP:
+
+An Event runs twice a day, at 9am-10am and 2pm-3pm but only Monday to Friday
+
+MICRODATA:
+
+Example is JSON-LD only.
+
+RDFA:
+
+Example is JSON-LD only.
+
+JSON:
+
+<script type="application/ld+json">
+{
+  "@context": "http://schema.org",
+  "@type": "Event",
+  "name": "Example",
+  "eventSchedule":
+    [
+     {
+      "@type": "Schedule",
+      "repeatFrequency": "P1D",
+      "byDay": ["http://schema.org/Monday","http://schema.org/Tuesday","http://schema.org/Wednesday","http://schema.org/Thursday","http://schema.org/Friday"]
+      “startTime": "09:00",
+      “endTime": "10:00"
+     },
+     {
+      "@type": "Schedule",
+      "repeatFrequency": "P1D",
+      "byDay": ["http://schema.org/Monday","http://schema.org/Tuesday","http://schema.org/Wednesday","http://schema.org/Thursday","http://schema.org/Friday"]
+      "startTime": "14:00",
+      "endTime": "15:00"
+     }
+    ]
+}
+</script>

--- a/data/ext/pending/issue-1457.rdfa
+++ b/data/ext/pending/issue-1457.rdfa
@@ -37,10 +37,10 @@
       <span>Source:  <a property="dc:source" href="https://github.com/schemaorg/schemaorg/issues/1457">#1457</a></span>
     </div>
 
-    <div typeof="rdf:Property" resource="http://schema.org/occurenceCount">
+    <div typeof="rdf:Property" resource="http://schema.org/repeatCount">
       <span>Category: <span property="schema:category">issue-1457</span></span>
-      <span class="h" property="rdfs:label">occurenceCount</span>
-      <span property="rdfs:comment">Defines the number of occurences of a recurring [[Event]] in a [[Schedule]]</span>
+      <span class="h" property="rdfs:label">repeatCount</span>
+      <span property="rdfs:comment">Defines the number of times a recurring [[Event]] will take place</span>
       <span>domainIncludes: <a property="http://schema.org/domainIncludes" href="http://schema.org/Schedule">Schedule</a></span>
       <span>rangeIncludes: <a property="http://schema.org/rangeIncludes" href="http://schema.org/Integer">Integer</a></span>
       <link property="http://schema.org/isPartOf" href="http://pending.schema.org" />

--- a/data/ext/pending/issue-1457.rdfa
+++ b/data/ext/pending/issue-1457.rdfa
@@ -32,6 +32,7 @@
       <span>domainIncludes: <a property="http://schema.org/domainIncludes" href="http://schema.org/Schedule">Schedule</a></span>
       <span>rangeIncludes: <a property="http://schema.org/rangeIncludes" href="http://schema.org/Duration">Duration</a></span>
       <span>Range: <a property="http://schema.org/rangeIncludes" href="http://schema.org/Text">Text</a></span>
+      <link property="rdfs:subPropertyOf" href="http://health-lifesci.schema.org/frequency" />
       <link property="http://schema.org/isPartOf" href="http://pending.schema.org" />
       <span>Source:  <a property="dc:source" href="https://github.com/schemaorg/schemaorg/issues/1457">#1457</a></span>
     </div>

--- a/data/ext/pending/issue-1457.rdfa
+++ b/data/ext/pending/issue-1457.rdfa
@@ -1,0 +1,108 @@
+<div>
+<!-- 
+  Schema.org Recurring Events Proposal
+  Issue #1457, https://github.com/schemaorg/schemaorg/issues/1457 
+  
+  Defines a new type: Schedule which can be associated with an Event
+  A Schedule defines a recurring time period similar to an iCal rrule.
+  
+-->
+
+<!-- Classes -->
+
+    <div typeof="rdfs:Class" resource="http://schema.org/Schedule">
+      <span>Category: <span property="schema:category">issue-1457</span></span>
+      <span class="h" property="rdfs:label">Schedule</span>
+      <span property="rdfs:comment">A schedule defines a repeating time period used to describe a regularly occuring [[Event]]. At a minimum a schedule will specify [[repeatFrequency]] which describes the interval between occurences of the event. Additional information can be provided to specify the schedule more precisely. 
+      This includes identifying the day(s) of the week or month when the recurring event will take place, in addition to its start and end time. Schedules may also 
+      have start and end dates to indicate when they are active, e.g. to define a limited calendar of events.</span>
+      <span>Subclass of: <a property="rdfs:subClassOf" href="http://schema.org/Intangible">Intangible</a></span>
+      <link property="http://schema.org/isPartOf" href="http://pending.schema.org" />
+      <span>Source:  <a property="dc:source" href="https://github.com/schemaorg/schemaorg/issues/1457">#1457</a></span>
+    </div>
+
+<!-- Properties -->
+
+
+    <div typeof="rdf:Property" resource="http://schema.org/repeatFrequency">
+      <span>Category: <span property="schema:category">issue-1457</span></span>
+      <span class="h" property="rdfs:label">repeatFrequency</span>
+      <span property="rdfs:comment">Defines the frequency at which [[Events]] will occur according to a schedule [[Schedule]]. The intervals between 
+      events should be defined as a [[Duration]] of time.</span>
+      <span>domainIncludes: <a property="http://schema.org/domainIncludes" href="http://schema.org/Schedule">Schedule</a></span>
+      <span>rangeIncludes: <a property="http://schema.org/rangeIncludes" href="http://schema.org/Duration">Duration</a></span>
+      <span>Range: <a property="http://schema.org/rangeIncludes" href="http://schema.org/Text">Text</a></span>
+      <link property="http://schema.org/isPartOf" href="http://pending.schema.org" />
+      <span>Source:  <a property="dc:source" href="https://github.com/schemaorg/schemaorg/issues/1457">#1457</a></span>
+    </div>
+
+    <div typeof="rdf:Property" resource="http://schema.org/occurenceCount">
+      <span>Category: <span property="schema:category">issue-1457</span></span>
+      <span class="h" property="rdfs:label">occurenceCount</span>
+      <span property="rdfs:comment">Defines the number of occurences of a recurring [[Event]] in a [[Schedule]]</span>
+      <span>domainIncludes: <a property="http://schema.org/domainIncludes" href="http://schema.org/Schedule">Schedule</a></span>
+      <span>rangeIncludes: <a property="http://schema.org/rangeIncludes" href="http://schema.org/Integer">Integer</a></span>
+      <link property="http://schema.org/isPartOf" href="http://pending.schema.org" />
+      <span>Source:  <a property="dc:source" href="https://github.com/schemaorg/schemaorg/issues/1457">#1457</a></span>
+    </div>
+
+    <div typeof="rdf:Property" resource="http://schema.org/byDay">
+      <span>Category: <span property="schema:category">issue-1457</span></span>
+      <span class="h" property="rdfs:label">byDay</span>
+      <span property="rdfs:comment">Defines the day(s) of the week on which a recurring [[Event]] takes place</span>
+      <span>domainIncludes: <a property="http://schema.org/domainIncludes" href="http://schema.org/Schedule">Schedule</a></span>
+      <span>rangeIncludes: <a property="http://schema.org/rangeIncludes" href="http://schema.org/DayOfWeek">DayOfWeek</a></span>
+      <link property="http://schema.org/isPartOf" href="http://pending.schema.org" />
+      <span>Source:  <a property="dc:source" href="https://github.com/schemaorg/schemaorg/issues/1457">#1457</a></span>
+    </div>
+
+    <div typeof="rdf:Property" resource="http://schema.org/byMonth">
+      <span>Category: <span property="schema:category">issue-1457</span></span>
+      <span class="h" property="rdfs:label">byMonth</span>
+      <span property="rdfs:comment">Defines the month(s) of the year on which a recurring [[Event]] takes place. Specified as an [[Integer]] between 1-12. January is 1.</span>
+      <span>domainIncludes: <a property="http://schema.org/domainIncludes" href="http://schema.org/Schedule">Schedule</a></span>
+      <span>rangeIncludes: <a property="http://schema.org/rangeIncludes" href="http://schema.org/Integer">Integer</a></span>
+      <link property="http://schema.org/isPartOf" href="http://pending.schema.org" />
+      <span>Source:  <a property="dc:source" href="https://github.com/schemaorg/schemaorg/issues/1457">#1457</a></span>
+    </div>
+
+    <div typeof="rdf:Property" resource="http://schema.org/byMonthDay">
+      <span>Category: <span property="schema:category">issue-1457</span></span>
+      <span class="h" property="rdfs:label">byMonthDay</span>
+      <span property="rdfs:comment">Defines the day(s) of the month on which a recurring [[Event]] takes place. Specified as an [[Integer]] between 1-31.</span>
+      <span>domainIncludes: <a property="http://schema.org/domainIncludes" href="http://schema.org/Schedule">Schedule</a></span>
+      <span>rangeIncludes: <a property="http://schema.org/rangeIncludes" href="http://schema.org/Integer">Integer</a></span>
+      <link property="http://schema.org/isPartOf" href="http://pending.schema.org" />
+      <span>Source:  <a property="dc:source" href="https://github.com/schemaorg/schemaorg/issues/1457">#1457</a></span>
+    </div>
+
+    <div typeof="rdf:Property" resource="http://schema.org/exceptDate">
+      <span>Category: <span property="schema:category">issue-1457</span></span>
+      <span class="h" property="rdfs:label">exceptDate</span>
+      <span property="rdfs:comment">Defines a [[Date]] or [[DateTime]] during which a scheduled [[Event]] will not take place. The property allows exceptions to 
+      a [[Schedule]] to be specified. If an exception is specified as a [[DateTime]] then only the event that would have started at that specific date and time 
+      should be excluded from the schedule. If an exception is specified as a [[Date]] then any event that is scheduled for that 24 hour period should be 
+      excluded from the schedule. This allows a whole day to be excluded from the schedule without having to itemise every scheduled event.</span>
+      <span>domainIncludes: <a property="http://schema.org/domainIncludes" href="http://schema.org/Schedule">Schedule</a></span>
+      <span>rangeIncludes: <a property="http://schema.org/rangeIncludes" href="http://schema.org/Date">Date</a></span>
+      <span>rangeIncludes: <a property="http://schema.org/rangeIncludes" href="http://schema.org/DateTime">DateTime</a></span>
+      <link property="http://schema.org/isPartOf" href="http://pending.schema.org" />
+      <span>Source:  <a property="dc:source" href="https://github.com/schemaorg/schemaorg/issues/1457">#1457</a></span>
+    </div>
+
+    <div typeof="rdf:Property" resource="http://schema.org/eventSchedule">
+      <span>Category: <span property="schema:category">issue-1457</span></span>
+      <span class="h" property="rdfs:label">eventSchedule</span>
+      <span property="rdfs:comment">Associates an [[Event]] with a [[Schedule]]. There are circumstances where it is preferable to share a schedule for a series of 
+      repeating events rather than data on the individual events themselves. For example, a website or application might prefer to publish a schedule for a weekly 
+      gym class rather than provide data on every event. A schedule could be processed by applications to add forthcoming events to a calendar. An [[Event]] that 
+      is associated with a [[Schedule]] using this property should not have [[startDate]] or [[endDate]] properties. These are instead defined within the associated 
+      [[Schedule]], this avoids any ambiguity for clients using the data. The propery might have repeated values to specify different schedules, e.g. for different months 
+      or seasons.</span>
+      <span>domainIncludes: <a property="http://schema.org/domainIncludes" href="http://schema.org/Schedule">Event</a></span>
+      <span>rangeIncludes: <a property="http://schema.org/rangeIncludes" href="http://schema.org/Duration">Schedule</a></span>
+      <link property="http://schema.org/isPartOf" href="http://pending.schema.org" />
+      <span>Source:  <a property="dc:source" href="https://github.com/schemaorg/schemaorg/issues/1457">#1457</a></span>
+    </div>
+
+</div>


### PR DESCRIPTION
Specifies the new terms proposed in #1457.

New Classes: 

* `Schedule`

New Properties:

* `repeatFrequency`
* `repeatCount`
* `byDay`
* `byMonth`
* `byMonthDay`
* `exceptDate`
* `eventSchedule`

Changes from latest proposal in #1457:

* `count` has been renamed as `occurencyCount` to match similar properties elsewhere in Schema.org
* `frequency` has been renamed as `repeatFrequency` to clarify its role, also avoid clashes with term in life-sciences.
* `frequency` can be text, but recommended to refer to a `Duration`
* Removed `interval` as this is now covered by `frequency`

Added some examples of different schedules