### PR TITLE
Fix HTML errors in schema.rdfa

### DIFF
--- a/data/schema.rdfa
+++ b/data/schema.rdfa
@@ -1,5 +1,5 @@
 <!DOCTYPE html>
-<html>
+<html lang="en">
   <head>
     <title>Schema.org master file: RDFS in RDFa</title>
     <meta charset="UTF-8" />
@@ -7711,7 +7711,7 @@ While such policies are most typically expressed in natural language, sometimes 
     </div>
     <div typeof="rdfs:Class" resource="http://schema.org/FoodEstablishmentReservation">
       <span class="h" property="rdfs:label">FoodEstablishmentReservation</span>
-      <span property="rdfs:comment">A reservation to dine at a food-related business.<p>Note: This type is for information about actual reservations, e.g. in confirmation emails or HTML pages with individual confirmations of reservations.</p></span>
+      <span property="rdfs:comment">A reservation to dine at a food-related business.\n\nNote: This type is for information about actual reservations, e.g. in confirmation emails or HTML pages with individual confirmations of reservations.</span>
       <span>Subclass of: <a property="rdfs:subClassOf" href="http://schema.org/Reservation">Reservation</a></span>
     </div>
     <div typeof="rdfs:Class" resource="http://schema.org/LodgingReservation">
@@ -10427,7 +10427,7 @@ Standards bodies should promote a standard prefix for the identifiers of propert
   <span>Subproperty of: <a property="rdfs:subPropertyOf" href="http://schema.org/supply">supply</a></span>
   <span>Domain: <a property="http://schema.org/domainIncludes" href="http://schema.org/Recipe">Recipe</a></span>
   <span>Range: <a property="http://schema.org/rangeIncludes" href="http://schema.org/Text">Text</a></span>
-  <span property="http://schema.org/supersededBy" href="http://schema.org/recipeIngredient"/>
+  <link property="http://schema.org/supersededBy" href="http://schema.org/recipeIngredient"/>
 </div>
 
 <div typeof="rdf:Property" resource="http://schema.org/recipeIngredient">


### PR DESCRIPTION
Fix HTML errors in `schema.rdfa` (see https://validator.w3.org/nu/?doc=https%3A%2F%2Fschema.org%2Fdocs%2Fschema_org_rdfa.html).

Such errors prevent our [PHP data model generator](https://github.com/api-platform/schema-generator) to work properly (the RDF library we use fail to  parse the RDFA.