### PR TITLE
Changed mis-abbreviation of Friday as "Fri" to "Fr"

### DIFF
--- a/data/sdo-tourism-examples.txt
+++ b/data/sdo-tourism-examples.txt
@@ -4,7 +4,7 @@ PRE-MARKUP:
 
 <h1>Hyde Park</h1>
 <div>It's one of the nine royal parks of London.</div>
-<div>Website: 
+<div>Website:
 	<a href="http://www.royalparks.org.uk/parks/hyde-park">www.royalparks.org.uk/parks/hyde-park</a>
 </div>
 <div>Ticket: access for free.</div>
@@ -17,7 +17,7 @@ MICRODATA:
 	<div>
 		<span itemprop="description">It's one of nine royal parks of London.</span>
 	</div>
-	<div>Website: 
+	<div>Website:
 		<a href="http://www.royalparks.org.uk/parks/hyde-park" itemprop="url">www.royalparks.org.uk/parks/hyde-park</a>
 	</div>
 	<div>
@@ -32,7 +32,7 @@ RDFA:
 	<div>
 		<span property="description">It's one of nine royal parks of London.</span>
 	</div>
-	<div>Website: 
+	<div>Website:
 		<a href="http://www.royalparks.org.uk/parks/hyde-park" property="url">www.royalparks.org.uk/parks/hyde-park</a>
 	</div>
 	<div>
@@ -59,11 +59,11 @@ PRE-MARKUP:
 
 <h1>Disneyland Paris</h1>
 <div>It's an amusement park in Marne-la-Vallée, near Paris, in France.</div>
-<div>Hours: Mo-Fri 10am-7pm Sa 10am-22pm Su 10am-21pm</div>
+<div>Hours: Mo-Fr 10am-7pm Sa 10am-22pm Su 10am-21pm</div>
 <div>Entrance: with ticket</div>
 <div>Currency accepted: Euro</div>
 <div>Payment accepted: Cash, Credit Card</div>
-<div>Website: 
+<div>Website:
 	<a href="http://www.disneylandparis.it/">www.disneylandparis.it</a>
 </div>
 
@@ -74,8 +74,8 @@ MICRODATA:
 	<div>
 		<span itemprop="description">It's an amusement park in Marne-la-Vallée, near Paris, in France and is the most visited theme park in all of France and Europe.</span>
 	</div>
-	<div>Hours: Mo-Fri 10am-7pm Sa 10am-22pm Su 10am-21pm
-		<meta itemprop="openingHours" content="Mo-Fri 10:00-19:00"/>
+	<div>Hours: Mo-Fr 10am-7pm Sa 10am-22pm Su 10am-21pm
+		<meta itemprop="openingHours" content="Mo-Fr 10:00-19:00"/>
 		<meta itemprop="openingHours" content="Sa 10:00-22:00"/>
 		<meta itemprop="openingHours" content="Su 10:00-21:00"/>
 	</div>
@@ -88,7 +88,7 @@ MICRODATA:
 	<div>
 		<meta itemprop="paymentAccepted" content="Cash, Credit Card"/>Payment accepted: Cash, Credit Card
 	</div>
-	<div>Website: 
+	<div>Website:
 		<a href="http://www.disneylandparis.it/" itemprop="url">www.disneylandparis.it</a>
 	</div>
 </div>
@@ -100,8 +100,8 @@ RDFA:
 	<div>
 		<span property="description">It's an amusement park in Marne-la-Vallée, near Paris, in France and is the most visited theme park in all of France and Europe.</span>
 	</div>
-	<div>Hours: Mo-Fri 10am-7pm Sa 10am-22pm Su 10am-21pm
-		<meta property="openingHours" content="Mo-Fri 10:00-19:00"/>
+	<div>Hours: Mo-Fr 10am-7pm Sa 10am-22pm Su 10am-21pm
+		<meta property="openingHours" content="Mo-Fr 10:00-19:00"/>
 		<meta property="openingHours" content="Sa 10:00-22:00"/>
 		<meta property="openingHours" content="Su 10:00-21:00"/>
 	</div>
@@ -114,7 +114,7 @@ RDFA:
 	<div>
 		<meta property="paymentAccepted" content="Cash, Credit Card"/>Payment accepted: Cash, Credit Card
 	</div>
-	<div>Website: 
+	<div>Website:
 		<a href="http://www.disneylandparis.it/" property="url">www.disneylandparis.it</a>
 	</div>
 </div>
@@ -127,7 +127,7 @@ JSON:
 	"@type": ["TouristAttraction", "AmusementPark"],
 	"name": "Disneyland Paris",
 	"description": "It's an amusement park in Marne-la-Vallée, near Paris, in France and is the most visited theme park in all of France and Europe.",
-	"openingHours":["Mo-Fri 10:00-19:00", "Sa 10:00-22:00", "Su 10:00-21:00"],
+	"openingHours":["Mo-Fr 10:00-19:00", "Sa 10:00-22:00", "Su 10:00-21:00"],
 	"isAccessibleForFree": false,
 	"currenciesAccepted": "EUR",
 	"paymentAccepted":"Cash, Credit Card",
@@ -147,16 +147,16 @@ MICRODATA:
 
 <div itemscope itemtype="http://schema.org/TouristAttraction">
 	<h1><span itemprop="name">Neuschwanstein Castle</span></h1>
-	<div>It is a nineteenth-century Romanesque Revival palace in 
+	<div>It is a nineteenth-century Romanesque Revival palace in
 		<div itemprop="address" itemscope itemtype="http://schema.org/PostalAddress">
-			<span itemprop="addressLocality">Schwangau</span>, in 
+			<span itemprop="addressLocality">Schwangau</span>, in
 			<span itemprop="addressCountry">Germany</span>.
 		</div>
 	</div>
-	<div>Guided tours in 
+	<div>Guided tours in
 		<div itemprop="availableLanguage" itemscope itemtype="http://schema.org/Language">
 			<span itemprop="name">German</span>
-		</div> and 
+		</div> and
 		<div itemprop="availableLanguage" itemscope itemtype="http://schema.org/Language">
 			<span itemprop="name">English</span>.
 		</div>
@@ -167,16 +167,16 @@ RDFA:
 
 <div vocab="http://schema.org" typeof="TouristAttraction">
 	<h1><span property="name">Neuschwanstein Castle</span></h1>
-	<div>It is a nineteenth-century Romanesque Revival palace in 
+	<div>It is a nineteenth-century Romanesque Revival palace in
 		<div property="address" typeof="PostalAddress">
-			<span property="addressLocality">Schwangau</span>, in 
+			<span property="addressLocality">Schwangau</span>, in
 			<span property="addressCountry">Germany</span>.
 		</div>
 	</div>
-	<div>Guided tours in 
+	<div>Guided tours in
 		<div property="availableLanguage" typeof="Language">
 			<span property="name">German</span>
-		</div> and 
+		</div> and
 		<div property="availableLanguage" typeof="Language">
 			<span property="name">English</span>.
 		</div>
@@ -215,12 +215,12 @@ MICRODATA:
 <div itemscope itemtype="http://schema.org/TouristAttraction">
     <link itemprop="additionalType" href="http://schema.org/Museum" />
 	<h1><span itemprop="name">Please Touch Museum</span></h1>
-	<div>It is a 
+	<div>It is a
 		<div itemprop="touristType" itemscope itemtype="http://schema.org/Audience">
 			<span itemprop="audienceType">children</span>
-		</div>'s museum located in 
+		</div>'s museum located in
 		<div itemprop="address" itemscope itemtype="http://schema.org/PostalAddress">
-			<div itemprop="addressLocality">Philadelphia</div>, 
+			<div itemprop="addressLocality">Philadelphia</div>,
 			<div itemprop="addressCountry">USA</div>.
 		</div>
 	<div>
@@ -232,12 +232,12 @@ RDFA:
 
 <div vocab="http://schema.org/" typeof="TouristAttraction Museum">
 	<h1><span property="name">Please Touch Museum</span></h1>
-	<div>It is a 
+	<div>It is a
 		<div property="touristType" typeof="Audience">
 			<span property="audienceType">children</span>
-		</div>'s museum located in 
+		</div>'s museum located in
 		<div property="address" typeof="PostalAddress">
-			<div property="addressLocality">Philadelphia</div>, 
+			<div property="addressLocality">Philadelphia</div>,
 			<div property="addressCountry">USA</div>.
 		</div>
 	<div>
@@ -278,7 +278,7 @@ MICRODATA:
 <div itemscope itemtype="http://schema.org/TouristAttraction">
 	<h1><span itemprop="name">Leaning Tower of Pisa</span></h1>
 	<div>
-		<span itemprop="description">It is a twelfth-thirteenth century Romanesque tower started building by Bonanno Pisano.</span> 
+		<span itemprop="description">It is a twelfth-thirteenth century Romanesque tower started building by Bonanno Pisano.</span>
 	</div>
 	<div>
 		<meta itemprop="publicAccess" content="true"/>Public access: yes
@@ -290,7 +290,7 @@ RDFA:
 <div vocab="http://schema.org/" typeof="TouristAttraction">
 	<h1><span property="name">Leaning Tower of Pisa</span></h1>
 	<div>
-		<span property="description">It is a twelfth-thirteenth century Romanesque tower started building by Bonanno Pisano.</span> 
+		<span property="description">It is a twelfth-thirteenth century Romanesque tower started building by Bonanno Pisano.</span>
 	</div>
 	<div>
 		<meta property="publicAccess" content="true"/>Public access: yes
@@ -327,10 +327,10 @@ MICRODATA:
 	<div>
 		<span itemprop="description">It's a museum of Impressionism and french ninenteeth art.</span>
 	</div>
-	<div itemprop="event" itemscope itemtype="http://schema.org/Event">It is hosting the 
+	<div itemprop="event" itemscope itemtype="http://schema.org/Event">It is hosting the
 		<span itemprop="about">Hodler</span>'s
 		<span itemprop="about">Monet</span>'s
-		<span itemprop="about">Munch</span>'s exibit: 
+		<span itemprop="about">Munch</span>'s exibit:
 		<span itemprop="name">"Peindre l'impossible"</span>.
 		<meta itemprop="startDate" content="2016-09-15" />Start date: September 15 2016
 		<meta itemprop="endDate" content="2017-01-22" />End date: Genuary 22 2017
@@ -344,7 +344,7 @@ RDFA:
 	<div>
 		<span property="description">It's a museum of Impressionism and french ninenteeth art.</span>
 	</div>
-	<div property="event" typeof="Event">It is hosting the 
+	<div property="event" typeof="Event">It is hosting the
 		<span property="about">Hodler</span>'s
 		<span property="about">Monet</span>'s
 		<span property="about">Munch</span>'s exibit:
@@ -364,7 +364,7 @@ JSON:
 	"description": "It's a museum of Impressionism and french ninenteeth art.",
 	"event": {
 		"@type": "Event",
-		"about": ["Hodler","Monet","Munch"],  
+		"about": ["Hodler","Monet","Munch"],
 		"name": "Peindre l'impossible",
 		"startDate": "2016-09-15",
 		"endDate": "2017-01-22"
@@ -637,7 +637,7 @@ TYPES: #tourism-9 TouristAttraction, touristType, Winery
 PRE-MARKUP:
 
 Name: Bodegas Protos
-Description: Protos means “first” in Greek, and since 1927 this centenary winery has embarked on the mission to be number one. This attitude has driven their search for constant improvement.The new facilities designed by prestigious architect and winner of the Priztker Award, Sir Richard Rogers, once again took the winery to the forefront of wine tourism. A tour around Protos includes a detailed visit to both the underground cellar dug into the hillside of Peñafiel Castle and to the winery designed by celebrated architect Sir Richard Rogers.After completing the itinerary, visitors can taste 2 excellent Protos wines and will receive a gift. The visit lasts 1.5 hours (including the sampling).
+Description: Protos means “first” in Greek, and since 1927 this centenary winery has embarked on the mission to be number one. This attitude has driven their search for constant improvement. The new facilities designed by prestigious architect and winner of the Priztker Award, Sir Richard Rogers, once again took the winery to the forefront of wine tourism. A tour around Protos includes a detailed visit to both the underground cellar dug into the hillside of Peñafiel Castle and to the winery designed by celebrated architect Sir Richard Rogers. After completing the itinerary, visitors can taste 2 excellent Protos wines and will receive a gift. The visit lasts 1.5 hours (including the sampling).
 Opening Hours: Monday to Friday, 10:00-13:00 and 16:30-18:00
 Address: C/ Bodegas Protos, 24-28, 47300 - Peñafiel, Spain
 Public Access: yes
@@ -654,7 +654,7 @@ MICRODATA:
   <div itemtype="http://schema.org/TouristAttraction" itemscope>
     <link itemprop="additionalType" href="http://schema.org/Winery" />
     <meta itemprop="name" content="Bodegas Protos" />
-    <meta itemprop="description" content="Protos means “first” in Greek, and since 1927 this centenary winery has embarked on the mission to be number one. This attitude has driven their search for constant improvement.The new facilities designed by prestigious architect and winner of the Priztker Award, Sir Richard Rogers, once again took the winery to the forefront of wine tourism. A tour around Protos includes a detailed visit to both the underground cellar dug into the hillside of Peñafiel Castle and to the winery designed by celebrated architect Sir Richard Rogers.After completing the itinerary, visitors can taste 2 excellent Protos wines and will receive a gift. The visit lasts 1.5 hours (including the sampling)." />
+    <meta itemprop="description" content="Protos means “first” in Greek, and since 1927 this centenary winery has embarked on the mission to be number one. This attitude has driven their search for constant improvement. The new facilities designed by prestigious architect and winner of the Priztker Award, Sir Richard Rogers, once again took the winery to the forefront of wine tourism. A tour around Protos includes a detailed visit to both the underground cellar dug into the hillside of Peñafiel Castle and to the winery designed by celebrated architect Sir Richard Rogers. After completing the itinerary, visitors can taste 2 excellent Protos wines and will receive a gift. The visit lasts 1.5 hours (including the sampling)." />
     <div itemprop="address" itemtype="http://schema.org/PostalAddress" itemscope>
       <meta itemprop="addressLocality" content="Peñafiel" />
       <meta itemprop="streetAddress" content="C/ Bodegas Protos, 24-28" />
@@ -688,7 +688,7 @@ RDFA:
   <div typeof="schema:TouristAttraction">
     <div rel="rdf:type" resource="http://schema.org/Winery"></div>
     <div property="schema:name" content="Bodegas Protos"></div>
-    <div property="schema:description" content="Protos means “first” in Greek, and since 1927 this centenary winery has embarked on the mission to be number one. This attitude has driven their search for constant improvement.The new facilities designed by prestigious architect and winner of the Priztker Award, Sir Richard Rogers, once again took the winery to the forefront of wine tourism. A tour around Protos includes a detailed visit to both the underground cellar dug into the hillside of Peñafiel Castle and to the winery designed by celebrated architect Sir Richard Rogers.After completing the itinerary, visitors can taste 2 excellent Protos wines and will receive a gift. The visit lasts 1.5 hours (including the sampling)."></div>
+    <div property="schema:description" content="Protos means “first” in Greek, and since 1927 this centenary winery has embarked on the mission to be number one. This attitude has driven their search for constant improvement. The new facilities designed by prestigious architect and winner of the Priztker Award, Sir Richard Rogers, once again took the winery to the forefront of wine tourism. A tour around Protos includes a detailed visit to both the underground cellar dug into the hillside of Peñafiel Castle and to the winery designed by celebrated architect Sir Richard Rogers. After completing the itinerary, visitors can taste 2 excellent Protos wines and will receive a gift. The visit lasts 1.5 hours (including the sampling)."></div>
     <div rel="schema:address">
       <div typeof="schema:PostalAddress">
         <div property="schema:addressCountry" content="ES"></div>
@@ -721,7 +721,7 @@ JSON:
     "Winery",
     "TouristAttraction"],
   "name": "Bodegas Protos",
-  "description": "Protos means “first” in Greek, and since 1927 this centenary winery has embarked on the mission to be number one. This attitude has driven their search for constant improvement.The new facilities designed by prestigious architect and winner of the Priztker Award, Sir Richard Rogers, once again took the winery to the forefront of wine tourism. A tour around Protos includes a detailed visit to both the underground cellar dug into the hillside of Peñafiel Castle and to the winery designed by celebrated architect Sir Richard Rogers.After completing the itinerary, visitors can taste 2 excellent Protos wines and will receive a gift. The visit lasts 1.5 hours (including the sampling).",
+  "description": "Protos means “first” in Greek, and since 1927 this centenary winery has embarked on the mission to be number one. This attitude has driven their search for constant improvement. The new facilities designed by prestigious architect and winner of the Priztker Award, Sir Richard Rogers, once again took the winery to the forefront of wine tourism. A tour around Protos includes a detailed visit to both the underground cellar dug into the hillside of Peñafiel Castle and to the winery designed by celebrated architect Sir Richard Rogers. After completing the itinerary, visitors can taste 2 excellent Protos wines and will receive a gift. The visit lasts 1.5 hours (including the sampling).",
   "address": {
     "@type": "PostalAddress",
     "addressLocality": "Peñafiel",
@@ -748,7 +748,3 @@ JSON:
   "image": "https://commons.wikimedia.org/wiki/File%3AFoto_Bodega_Rogers2.jpg"
 }
 </script>
-
-
-
-


### PR DESCRIPTION
Per the guidelines for openingHours, Friday should be abbreviated as
"Fr." In one set of examples, it was abbreviated as "Fri." This error
was corrected in each instance of the example.

Additionally, in a paragraph associated with the same example, two
sentences has no space after a period. Space was added in each instance
of the example.

(My editor appears to have stripped out some additional spaces.)