### PR TITLE
DC Terms for spatialCoverage using spatial not coverage?

### DIFF
--- a/data/schema.rdfa
+++ b/data/schema.rdfa
@@ -7010,7 +7010,7 @@ While such policies are most typically expressed in natural language, sometimes 
       <link property="rdfs:subPropertyOf" href="http://schema.org/contentLocation" />
       <span>Domain: <a property="http://schema.org/domainIncludes" href="http://schema.org/CreativeWork">CreativeWork</a></span>
       <span>Range: <a property="http://schema.org/rangeIncludes" href="http://schema.org/Place">Place</a></span>
-      <link property="owl:equivalentProperty" href="http://purl.org/dc/terms/spatial"/>
+      <link property="owl:equivalentProperty" href="http://purl.org/dc/terms/coverage"/>
     </div>
 
     <div typeof="rdf:Property" resource="http://schema.org/specialCommitments">


### PR DESCRIPTION
Maybe it was a previous typo by someone but I think http://dublincore.org/2012/06/14/dcterms#coverage has the intent we were after ?
The main difference being between rdfs:range dcterms:LocationPeriodOrJurisdiction and just rdfs:range dcterms:Location