### PR TITLE
Expand domain of video & audio to Thing

### DIFF
--- a/data/schema.rdfa
+++ b/data/schema.rdfa
@@ -3791,7 +3791,7 @@ The place is __open__ if the [[opens]] property is specified, and __closed__ oth
     </div>
     <div typeof="rdf:Property" resource="http://schema.org/audio">
       <span class="h" property="rdfs:label">audio</span>
-      <span property="rdfs:comment">An audio recording of, or audio component of, the item. This can be a URL or a fully described [[AudioObject]]</span>
+      <span property="rdfs:comment">An audio recording of, or audio component of, the item. This can be a URL or a fully described [[AudioObject]].</span>
       <span>Domain: <a property="http://schema.org/domainIncludes" href="http://schema.org/Thing">Thing</a></span>
       <span>Range: <a property="http://schema.org/rangeIncludes" href="http://schema.org/AudioObject">AudioObject</a></span>
       <span>Range: <a property="http://schema.org/rangeIncludes" href="http://schema.org/URL">URL</a></span>

--- a/data/schema.rdfa
+++ b/data/schema.rdfa
@@ -3791,9 +3791,10 @@ The place is __open__ if the [[opens]] property is specified, and __closed__ oth
     </div>
     <div typeof="rdf:Property" resource="http://schema.org/audio">
       <span class="h" property="rdfs:label">audio</span>
-      <span property="rdfs:comment">An embedded audio object.</span>
-      <span>Domain: <a property="http://schema.org/domainIncludes" href="http://schema.org/CreativeWork">CreativeWork</a></span>
+      <span property="rdfs:comment">An audio recording of, or audio component of, the item. This can be a URL or a fully described [[AudioObject]]</span>
+      <span>Domain: <a property="http://schema.org/domainIncludes" href="http://schema.org/Thing">Thing</a></span>
       <span>Range: <a property="http://schema.org/rangeIncludes" href="http://schema.org/AudioObject">AudioObject</a></span>
+      <span>Range: <a property="http://schema.org/rangeIncludes" href="http://schema.org/URL">URL</a></span>
     </div>
     <div typeof="rdf:Property" resource="http://schema.org/author">
       <span class="h" property="rdfs:label">author</span>
@@ -7496,9 +7497,10 @@ While such policies are most typically expressed in natural language, sometimes 
     </div>
     <div typeof="rdf:Property" resource="http://schema.org/video">
       <span class="h" property="rdfs:label">video</span>
-      <span property="rdfs:comment">An embedded video object.</span>
-      <span>Domain: <a property="http://schema.org/domainIncludes" href="http://schema.org/CreativeWork">CreativeWork</a></span>
+      <span property="rdfs:comment">A video of, or video component of, the item. This can be a URL or a fully described [[VideoObject]].</span>
+      <span>Domain: <a property="http://schema.org/domainIncludes" href="http://schema.org/Thing">Thing</a></span>
       <span>Range: <a property="http://schema.org/rangeIncludes" href="http://schema.org/VideoObject">VideoObject</a></span>
+      <span>Range: <a property="http://schema.org/rangeIncludes" href="http://schema.org/URL">URL</a></span>
     </div>
     <div typeof="rdf:Property" resource="http://schema.org/videoFrameSize">
       <span class="h" property="rdfs:label">videoFrameSize</span>


### PR DESCRIPTION
As per Issue #1447  
Expand domain of _video_ property to _Thing_ plus update description to clarify use and preserve its continued suitability for current usage on _CreativeWork_.

> A video of, or video component of, the item. This can be a URL or a fully described VideoObject.

Only expanding the domain of _video_ creates an anomaly where any _Thing_ can have an _image_ or a _video_, but only CreativeWorks can also have an _audio_.  To remove the anomaly the domain and description of _audio_ is also expanded.

> An audio recording of, or audio component of, the item. This can be a URL or a fully described AudioObject.