### PR TITLE
Change redundant 'text' entry to 'name' in ld+json example for Question

### DIFF
--- a/data/examples.txt
+++ b/data/examples.txt
@@ -9540,7 +9540,7 @@ JSON:
 {
     "@context": "http://schema.org",
     "@type": "Question",
-    "text": "What is attr_accessor in Ruby?",
+    "name": "What is attr_accessor in Ruby?",
     "upvoteCount": "196",
     "text": "I am having difficulty understanding Ruby attr_accessors, can someone explain them?",
     "dateCreated": "2010-11-04T20:07Z",


### PR DESCRIPTION
Hello!  I did a quick look around for contribution guidelines, and hopefully this is simple enough not to be too much trouble, regardless.

The example for `Question` had the field `text` twice.  I believe the first entry is supposed to be `name`, based on the other examples for the same item.