### PR TITLE
hyperlink to new, recommended DOI resolver

### DIFF
--- a/data/sdo-periodical-examples.txt
+++ b/data/sdo-periodical-examples.txt
@@ -138,7 +138,7 @@ PRE-MARKUP:
   <strong>ISSN:</strong> 0163-9374 ;<br />
   <strong>E-ISSN:</strong> 1544-4554;<br />
   <strong>DOI:</strong>
-  <a href="http://dx.doi.org/10.1080/01639374.2012.682254">10.1080/01639374.2012.682254</a>
+  <a href="https://doi.org/10.1080/01639374.2012.682254">10.1080/01639374.2012.682254</a>
 </div>
  
 MICRODATA: 
@@ -183,7 +183,7 @@ MICRODATA:
     <strong>E-ISSN:</strong> <span itemprop="issn">1544-4554</span> ;<br />
   </span>
   <strong>DOI:</strong>
-  <a itemprop="sameAs" href="http://dx.doi.org/10.1080/01639374.2012.682254">10.1080/01639374.2012.682254</a>
+  <a itemprop="sameAs" href="https://doi.org/10.1080/01639374.2012.682254">10.1080/01639374.2012.682254</a>
 </div>
  
 RDFA:
@@ -226,7 +226,7 @@ RDFA:
     <strong>E-ISSN:</strong> <span property="issn">1544-4554</span> ;<br />
   </span>
   <strong>DOI:</strong>
-  <a property="sameAs" href="http://dx.doi.org/10.1080/01639374.2012.682254">10.1080/01639374.2012.682254</a>
+  <a property="sameAs" href="https://doi.org/10.1080/01639374.2012.682254">10.1080/01639374.2012.682254</a>
 </div>
 
 JSON:
@@ -259,7 +259,7 @@ JSON:
         "@type": "ScholarlyArticle", 
         "isPartOf": "#issue", 
         "description": "The library catalog as a catalog of works was an infectious idea, which together with research led to reconceptualization in the form of the FRBR conceptual model. Two categories of lacunae emerge--the expression entity, and gaps in the model such as aggregates and dynamic documents. Evidence needed to extend the FRBR model is available in contemporary research on instantiation. The challenge for the bibliographic community is to begin to think of FRBR as a form of knowledge organization system, adding a final dimension to classification. The articles in the present special issue offer a compendium of the promise of the FRBR model.", 
-        "sameAs": "http://dx.doi.org/10.1080/01639374.2012.682254", 
+        "sameAs": "https://doi.org/10.1080/01639374.2012.682254", 
         "about": [
             "Works", 
             "Catalog"


### PR DESCRIPTION
Hello!

The [DOI foundation started recommending `https://doi.org`](https://www.doi.org/doi_handbook/3_Resolution.html#3.8). This PR updates the few example links.

Cheers, and all the best for 2018 :-)