### PR TITLE
Apply fixes to pass HTML validation

### DIFF
--- a/apimarkdown.py
+++ b/apimarkdown.py
@@ -1,3 +1,7 @@
+import logging
+logging.basicConfig(level=logging.INFO) # dev_appserver.py --log_level debug .
+log = logging.getLogger(__name__)
+
 import markdown2
 from markdown2 import Markdown
 import re
@@ -26,8 +30,8 @@ class MarkdownTool():
         source = source.strip()
         source = source.replace("\\n","\n")
     	try:
-    		self.parselock.acquire()
-    		ret = self._md.convert(source)
+            self.parselock.acquire()
+            ret = self._md.convert(source)
     	finally:
     		self.parselock.release()
         
@@ -35,6 +39,11 @@ class MarkdownTool():
             #Remove wrapping <p> </p>\n that Markdown2 adds by default
             if len(ret) > 7 and ret.startswith("<p>") and ret.endswith("</p>\n"):
                 ret = ret[3:len(ret)-5]
+            
+            ret = ret.replace("<p>","")
+            ret = ret.replace("</p>","<br/><br/>")
+            if ret.endswith("<br/><br/>"):
+                ret = ret[:len(ret)-10]
         
         return self.parseWiklinks(ret)
     

--- a/docs/about.html
+++ b/docs/about.html
@@ -29,7 +29,7 @@
 				</h1>
 				</div>
 
-				<div id="cse-search-form" style="width: 400px;"><gcse:searchbox-only resultsUrl="/docs/search_results.html"></gcse:searchbox-only></div>
+				<div id="cse-search-form" style="width: 400px;"><div class="gcse-searchbox-only" data-resultsUrl="/docs/search_results.html"></div></div>
 
               </div>
             </div>
@@ -72,11 +72,12 @@ and through <a href="http://github.com/schemaorg/schemaorg">GitHub</a>. See the 
     are public.
  </p>
 
-<h3>The People</h3>
+<h2>The People</h2>
 <br/>
 
 <p>
     A number of people have made substantial contributions to Schema.org over the years. These include:
+</p>
 
     <ul>
       <li> <a href="http://twitter.com/danbri">Dan Brickley</a> runs the daily operations for schema.org. He is on the steering group and Google's representative.</li>
@@ -132,9 +133,8 @@ and through <a href="http://github.com/schemaorg/schemaorg">GitHub</a>. See the 
       </li>
 
      </ul>
-</p>
 
-<h3 id="cgsg">Community Group and Steering Group</h3>
+<h2 id="cgsg">Community Group and Steering Group</h2>
 
 <br/>
 
@@ -180,8 +180,6 @@ It is Github-based in the sense that its GitHub repository - <a href="https://gi
 
 <p>Note also that other W3C Community Groups exist that are focussed partially or entirely on schema.org improvements, e.g. <a href="https://www.w3.org/community/schemed/">health and medicine</a>,  <a href="https://www.w3.org/community/sport-schema/">sports</a>,  <a href="https://www.w3.org/community/architypes/">archives</a>,
 <a href="https://www.w3.org/community/schemabibex/">libraries and bibliography</a>, <a href="https://www.w3.org/community/gao/">autos</a>... ...these groups have their own ways of working, and coordinate via the main Schema.org Community Group and its Github repository.
-</p>
-
 </p>
 
 <br/><br/>

--- a/docs/actions.html
+++ b/docs/actions.html
@@ -2,7 +2,6 @@
 <html xmlns="http://www.w3.org/1999/xhtml" xml:lang="en" lang="en">
 <head>
     <meta http-equiv="Content-Type" content="text/html; charset=UTF-8" />
-    <meta charset="UTF-8" />
     <title>Schema.org Actions - schema.org</title>
     <meta name="description" content="Schema.org is a set of extensible schemas that enables webmasters to embed
     structured data on their web pages for use by search engines and other applications." />
@@ -72,7 +71,7 @@
 				</h1>
 				</div>
 
-                    <div id="cse-search-form" style="width: 400px;"><gcse:searchbox-only resultsUrl="/docs/search_results.html"></gcse:searchbox-only></div>
+                    <div id="cse-search-form" style="width: 400px;"><div class="gcse-searchbox-only" data-resultsUrl="/docs/search_results.html"></div></div>
 
               </div>
             </div>

--- a/docs/automotive.html
+++ b/docs/automotive.html
@@ -57,7 +57,7 @@
                 </h1>
                 </div>
 
-                    <div id="cse-search-form" style="width: 400px;"><gcse:searchbox-only resultsUrl="/docs/search_results.html"></gcse:searchbox-only></div>
+                    <div id="cse-search-form" style="width: 400px;"><div class="gcse-searchbox-only" data-resultsUrl="/docs/search_results.html"></div></div>
 
               </div>
             </div>

--- a/docs/datamodel.html
+++ b/docs/datamodel.html
@@ -54,7 +54,7 @@
 				</h1>
 				</div>
 
-				<div id="cse-search-form" style="width: 400px;"><gcse:searchbox-only resultsUrl="/docs/search_results.html"></gcse:searchbox-only></div>
+				<div id="cse-search-form" style="width: 400px;"><div class="gcse-searchbox-only" data-resultsUrl="/docs/search_results.html"></div></div>
 
               </div>
             </div>

--- a/docs/documents.html
+++ b/docs/documents.html
@@ -28,7 +28,7 @@
 				</h1>
 				</div>
 
-                    <div id="cse-search-form" style="width: 400px;"><gcse:searchbox-only resultsUrl="/docs/search_results.html"></gcse:searchbox-only></div>
+                    <div id="cse-search-form" style="width: 400px;"><div class="gcse-searchbox-only" data-resultsUrl="/docs/search_results.html"></div></div>
 
               </div>
             </div>

--- a/docs/extension.html
+++ b/docs/extension.html
@@ -28,7 +28,7 @@
 				</h1>
 				</div>
 
-                    <div id="cse-search-form" style="width: 400px;"><gcse:searchbox-only resultsUrl="/docs/search_results.html"></gcse:searchbox-only></div>
+                    <div id="cse-search-form" style="width: 400px;"><div class="gcse-searchbox-only" data-resultsUrl="/docs/search_results.html"></div></div>
 
               </div>
             </div>
@@ -118,8 +118,9 @@ go through, but can be hosted on the third party's site.
 <p>
  All of Schema.org core and all of the reviewed extensions are available from the schema.org website. Each extension is linked to from each of the touch points it has with the core. So, if an extension (say, having to do with Legal stuff) creates <em>LegalPerson</em> which is a subclass of <em>Person</em>, the Person will link to LegalPerson.</p>
 
-<p>Reviewed extensions are identified in the website with an appropriate URL prefix.  For example <em>bib.schema.org</em> for bibliographic terms, <em>auto.schema.org</em> for automotive terms.  These URL prefixes are only applicable to the documentation of terms within an extention.  The Schema.org vocabulary and its reviewed extensions are defined in a flat namespace.  ie. All terms, in the core vocabulary and extensions, within the vocabulary have a <em>http://schema.org</em> based cannonical URI.  For example the <a href="http://auto.schema.org/MotorizedBicycle">MotorizedBicycle<a> type defined in the <a href="http://auto.schema.org">auto.schema.org</a> extension and documented on the <em>http://auto.schema.org/MotorizedBicycle</em> page, has a cannonical URI of <em>http://schema.org/MotorizedBicycle</em>.  The cannonical URI is the value that is used when applying Schema.org markup. <pre>&lt;div itemscope itemtype="http://schema.org/MotorizedBicycle"&gt;</pre>
-</p>
+<p>Reviewed extensions are identified in the website with an appropriate URL prefix.  For example <em>bib.schema.org</em> for bibliographic terms, <em>auto.schema.org</em> for automotive terms.  These URL prefixes are only applicable to the documentation of terms within an extention.  The Schema.org vocabulary and its reviewed extensions are defined in a flat namespace.  ie. All terms, in the core vocabulary and extensions, within the vocabulary have a <em>http://schema.org</em> based cannonical URI.  For example the <a href="http://auto.schema.org/MotorizedBicycle">MotorizedBicycle</a> type defined in the <a href="http://auto.schema.org">auto.schema.org</a> extension and documented on the <em>http://auto.schema.org/MotorizedBicycle</em> page, has a cannonical URI of <em>http://schema.org/MotorizedBicycle</em>.  The cannonical URI is the value that is used when applying Schema.org markup.</p>
+   <pre>&lt;div itemscope itemtype="http://schema.org/MotorizedBicycle"&gt;</pre>
+
 
 <h3>What does someone creating an extension need to do</h3>
 <p>

--- a/docs/feedback.html
+++ b/docs/feedback.html
@@ -28,7 +28,7 @@
 				</h1>
 				</div>
 
-                    <div id="cse-search-form" style="width: 400px;"><gcse:searchbox-only resultsUrl="/docs/search_results.html"></gcse:searchbox-only></div>
+                    <div id="cse-search-form" style="width: 400px;"><div class="gcse-searchbox-only" data-resultsUrl="/docs/search_results.html"></div></div>
 
               </div>
             </div>
@@ -56,6 +56,8 @@
 <p></p>
 <div class="ss-form-desc ss-no-ignore-whitespace">Schema.org is an <a href="/docs/releases.html">evolving</a> specification.
     Use <a href="https://docs.google.com/a/google.com/forms/d/1krxHlWJAO3JgvHRZV9Rugkr9VYnMdrI10xbGsWt733c/viewform?entry.1174568178&entry.882602760=docs&entry.41124795=feedback.html">this form</a> to report bugs or provide general feedback about the site.</div>
+</div>
+</div>
                                                                                                             <!--       ?entry.1174568178&entry.41124795=http://schema.org/Person&entry.882602760=Misc -->
 <p></p>
 
@@ -136,7 +138,7 @@ return;
   </div>
 
 -->
-
+</div>
 
 </body>
 </html>

--- a/docs/financial.html
+++ b/docs/financial.html
@@ -52,7 +52,7 @@
                                 <a href="/">schema.org</a>
                             </h1>
                         </div>
-                    <div id="cse-search-form" style="width: 400px;"><gcse:searchbox-only resultsUrl="/docs/search_results.html"></gcse:searchbox-only></div>
+                    <div id="cse-search-form" style="width: 400px;"><div class="gcse-searchbox-only" data-resultsUrl="/docs/search_results.html"></div></div>
                     </div>
                 </div>
             </div>
@@ -130,9 +130,9 @@
                 The following diagrams present the conceptual map of the extension. As it was explained before, the map contains elements from both the schema.org "core" and the actual financial extension (at the moment of writing this was placed in pending.schema.org):
             </p>
             
-            <img alt="Mind Map for schema.org financial extension" src="financial-img/1.png" title="Mind Map for schema.org financial extension" border="0" onload="this.width *= 0.55;" />
+            <img alt="Mind Map for schema.org financial extension" src="financial-img/1.png" title="Mind Map for schema.org financial extension" style="border: 0;" onload="this.width *= 0.55;" />
 
-            <img alt="Mind Map for schema.org financial extension" src="financial-img/2.png" title="Mind Map for schema.org financial extension" border="0" onload="this.width *= 0.55;" />
+            <img alt="Mind Map for schema.org financial extension" src="financial-img/2.png" title="Mind Map for schema.org financial extension" style="border: 0;" onload="this.width *= 0.55;" />
             
             <p>
                 The banks are identified by their LEI (Legal Entity Identifier) code: <a href="http://schema.org/leiCode">leiCode</a> (upper diagram above) and terms that were already present in schema.org (see "Basic Models" below). 
@@ -150,7 +150,7 @@
             <h2>The complete hierarchy of all terms in the financial extension</h2>
             
             <p>
-                All of the extension terms are depicted in <span style="color:red">red</span>. The branches already defined in the schema.org are depicted in <span style="color:gray">gray</a>.
+                All of the extension terms are depicted in <span style="color:red">red</span>. The branches already defined in the schema.org are depicted in <span style="color:gray">gray</span>.
             </p>
             
             <h3>Types:</h3>
@@ -177,8 +177,7 @@
                             <ul>
                                 <li>
                                     <a style="color:gray" href="http://pending.schema.org/Service">Service</a>
-                                </li>
-                                <ul>
+                                    <ul>
                                     <li>
                                         <a href="http://pending.schema.org/FinancialProduct">FinancialProduct</a>
                                         <ul>
@@ -222,7 +221,7 @@
                                                 <a href="http://pending.schema.org/PaymentCard">PaymentCard</a> 
                                                 <ul>
                                                     <li>
-                                                        <a href="http://pending.schema.org/CreditCard">CreditCard</a
+                                                        <a href="http://pending.schema.org/CreditCard">CreditCard</a>
                                                     </li>
                                                 </ul>
                                             </li>
@@ -379,7 +378,7 @@
             
             <h3>A bank</h3>
             
-            <img alt="The pattern for the description of the ‘BankOrCreditUnion’ object by the financial extension to schema.org" src="financial-img/3.png" title="The pattern for the description of the ‘BankOrCreditUnion’ object by the financial extension to schema.org" border="0" width="100%" />
+            <img alt="The pattern for the description of the ‘BankOrCreditUnion’ object by the financial extension to schema.org" src="financial-img/3.png" title="The pattern for the description of the ‘BankOrCreditUnion’ object by the financial extension to schema.org" style="border:0; width:100%;" />
 
             <p>
                 The main type for the description of Banks and Credit Unions, <a href="http://schema.org/BankOrCreditUnion">BankOrCreditUnion</a> is a subclass of the following sequence of schema.org classes: <a href="http://schema.org/FinancialService">FinancialService</a> -> <a href="http://schema.org/LocalBusiness">LocalBusiness</a> -> (<a href="http://schema.org/Organization">Organization</a> and <a href="http://schema.org/Place">Place</a>). The institution can be identified by the following schema.org properties: <a href="http://schema.org/name">name</a>, <a href="http://schema.org/contactPoint">contactPoint</a>, <a href="http://schema.org/address">address</a> and the website <a href="http://schema.org/url">url</a>. The extension adds the fundamental global identifier of the financial institution: <a href="http://schema.org/leiCode">leiCode</a>: Legal Entity Identifier (the alphanumeric code or LEI URI) .
@@ -388,7 +387,7 @@
             
             <h3>A financial product</h3>
             
-            <img alt="The pattern for the description of the ‘Financial product’ by the financial extension to schema.org" src="financial-img/4.png" title="The pattern for the description of the ‘Financial product’ by the financial extension to schema.org" border="0" width="100%" />
+            <img alt="The pattern for the description of the ‘Financial product’ by the financial extension to schema.org" src="financial-img/4.png" title="The pattern for the description of the ‘Financial product’ by the financial extension to schema.org" style="border:0; width:100%;" />
             
             <p>
                 The top ‘type’ for the description of the financial products, <a href="http://schema.org/FinancialProduct">FinancialProduct</a>, (which is a subclass of schema.org <a href="http://schema.org/Service">Service</a> type) is sub-classed by the most important specific products: <a href="http://schema.org/BankAccount">BankAccount</a>, <a href="http://schema.org/PaymentCard">PaymentCard</a>, <a href="http://schema.org/LoanOrCredit">LoanOrCredit</a>, <a href="http://schema.org/InvestmentOrDeposit">InvestmentOrDeposit</a>, <a href="http://schema.org/PaymentService">PaymentService</a> and <a href="http://schema.org/CurrencyConversionService">CurrencyConversionService</a>.
@@ -398,16 +397,16 @@
                 Examples of the specific products are illustrated in the following diagrams: 
             </p>
             
-            <img alt="The pattern for the description of the ‘Deposit Account’ by the financial extension to schema.org" src="financial-img/5.png" title="The pattern for the description of the ‘Deposit Account’ by the financial extension to schema.org" border="0" width="100%" />
+            <img alt="The pattern for the description of the ‘Deposit Account’ by the financial extension to schema.org" src="financial-img/5.png" title="The pattern for the description of the ‘Deposit Account’ by the financial extension to schema.org" style="border:0; width:100%;" />
 
             <p>
-                In this example, the <a href="http://schema.org/DepositAccount">DepositAccount</a> (sub-class of the sequence of <a href="http://schema.org/InvestmentOrDeposit">InvestmentOrDeposit</a> -> <a href="http://schema.org/FinancialProduct">FinancialProduct<a>) is described through the following properties: <a href="http://schema.org/amount">amount</a>, <a href="http://schema.org/interestRate">interestRate</a>, <a href="http://schema.org/provider">provider</a> and <a href="http://schema.org/availableChannel">availableChannel</a>. 
+                In this example, the <a href="http://schema.org/DepositAccount">DepositAccount</a> (sub-class of the sequence of <a href="http://schema.org/InvestmentOrDeposit">InvestmentOrDeposit</a> -> <a href="http://schema.org/FinancialProduct">FinancialProduct</a>) is described through the following properties: <a href="http://schema.org/amount">amount</a>, <a href="http://schema.org/interestRate">interestRate</a>, <a href="http://schema.org/provider">provider</a> and <a href="http://schema.org/availableChannel">availableChannel</a>. 
             </p>
             
-            <img alt="The pattern for the description of the ‘Mortgage Loan’ by the financial extension to schema.org" src="financial-img/6.png" title="The pattern for the description of the ‘Mortgage Loan’ by the financial extension to schema.org" border="0" width="100%" />
+            <img alt="The pattern for the description of the ‘Mortgage Loan’ by the financial extension to schema.org" src="financial-img/6.png" title="The pattern for the description of the ‘Mortgage Loan’ by the financial extension to schema.org" style="border:0; width:100%;" />
 
             <p>             
-                In this example, the <a href="http://schema.org/MortgageLoan">MortgageLoan</a> (sub-class of the sequence of <a href="http://schema.org/LoanOrCredit">LoanOrCredit</a> -> <a href="http://schema.org/FinancialProduct">FinancialProduct</a>) is described through the following properties: <a href="http://schema.org/amount">amount</a>, <a href="http://schema.org/interestRate">interestRate</a>, <a href="http://schema.org/annualPercentageRate">annualPercentageRate</a (representing APR), <a href="http://schema.org/loanTerm">loanTerm</a> and <a href="http://schema.org/loanRepaymentForm">loanRepaymentForm</a>. 
+                In this example, the <a href="http://schema.org/MortgageLoan">MortgageLoan</a> (sub-class of the sequence of <a href="http://schema.org/LoanOrCredit">LoanOrCredit</a> -> <a href="http://schema.org/FinancialProduct">FinancialProduct</a>) is described through the following properties: <a href="http://schema.org/amount">amount</a>, <a href="http://schema.org/interestRate">interestRate</a>, <a href="http://schema.org/annualPercentageRate">annualPercentageRate</a> (representing APR), <a href="http://schema.org/loanTerm">loanTerm</a> and <a href="http://schema.org/loanRepaymentForm">loanRepaymentForm</a>. 
             </p>
             
             
@@ -417,7 +416,7 @@
                 For the majority of the financial products, we enter into an area of schema.org relevant to commercial offers and other related terms coming from the GoodRelations Vocabulary for e-commerce:
             </p>
             
-            <img alt="The pattern for the description of the ‘Payment Service’ by the financial extension to schema.org" src="financial-img/7.png" title="The pattern for the description of the ‘Payment Service’ by the financial extension to schema.org" border="0" width="100%" />
+            <img alt="The pattern for the description of the ‘Payment Service’ by the financial extension to schema.org" src="financial-img/7.png" title="The pattern for the description of the ‘Payment Service’ by the financial extension to schema.org" style="border:0; width:100%;" />
             
             <p>
                 In this example, the type <a href="http://schema.org/Offer">Offer</a> is used to describe <a href="http://schema.org/PaymentService">PaymentService</a> (a sub-class of <a href="http://schema.org/FinancialProduct">FinancialProduct</a>) as a service offered to the client. The service can be properly named (<a href="http://schema.org/name">name</a>) and the offered price is expressed through <a href="http://schema.org/PriceSpecification">PriceSpecification</a> allowing for the specification of the price (<a href="http://schema.org/price">price</a>) itself, the currency (<a href="http://schema.org/priceCurrency">priceCurrency</a>) and the quantity (<a href="http://schema.org/eligibleQuantity">eligibleQuantity</a>).
@@ -427,7 +426,7 @@
                 In another popular example, a payment card (<a href="http://schema.org/PaymentCard">PaymentCard</a>) (sub-classed from both <a href="http://schema.org/PaymentMethod">PaymentMethod</a> and <a href="http://schema.org/FinancialProduct">FinancialProduct</a>) can be properly named (<a href="http://schema.org/name">name</a>) and offered to the client using an element of the type <a href="http://schema.org/Offer">Offer</a>, allowing for expression of the offeror (<a href="http://schema.org/offeredBy">offeredBy</a>) and its actual function (<a href="http://schema.org/BusinessFunction">BusinessFunction</a>). 
             </p>
             
-            <img alt="The pattern for the description of the ‘Payment Card’ by the financial extension to schema.org" src="financial-img/8.png" title="The pattern for the description of the ‘Payment Card’ by the financial extension to schema.org" border="0" width="100%" />
+            <img alt="The pattern for the description of the ‘Payment Card’ by the financial extension to schema.org" src="financial-img/8.png" title="The pattern for the description of the ‘Payment Card’ by the financial extension to schema.org" style="border:0; width:100%;" />
             
             
             <h2>Usage Examples</h2>
@@ -449,7 +448,7 @@
             
             <p>
                 PRE-MARKUP:
-                 
+            </p>
 <pre class="">
 &lt;div&gt;
   &lt;h1&gt;ExampleBank&reg; 1st Brokerage Account&lt;/h1&gt;
@@ -459,10 +458,11 @@
   &lt;p&gt;No fees to open or maintain an account. Other account fees, fund expenses, and brokerage commissions may apply. Commissions: $8.95 per online equity trade; commission-free ExampleBank&reg; ETF online trades in your ExampleBank&reg; account&lt;/p&gt;
 &lt;/div&gt;
 </pre>
-            </p>
+        
              
             <p>
                 MICRODATA:
+             </p>
                 
 <pre class="">
 &lt;div itemscope itemtype=&quot;http://schema.org/BrokerageAccount&quot;&gt;
@@ -473,11 +473,10 @@
   &lt;p itemprop=&quot;feesAndCommissionsSpecification&quot;&gt;No fees to open or maintain an account. Other account fees, fund expenses, and brokerage commissions may apply. Commissions: $8.95 per online equity trade; commission-free ExampleBank&reg; ETF online trades in your ExampleBank&reg; account&lt;/p&gt;
 &lt;/div&gt;
 </pre>                
-            </p>
             
             <p>
                 RDFA:
-                
+             </p>    
 <pre class="">
 &lt;div vocab=&quot;http://schema.org/&quot; typeof=&quot;BrokerageAccount&quot;&gt;
   &lt;h1 property=&quot;name&quot;&gt;ExampleBank&reg; 1st Brokerage Account&lt;/h1&gt;
@@ -487,11 +486,11 @@
   &lt;p property=&quot;feesAndCommissionsSpecification&quot;&gt;No fees to open or maintain an account. Other account fees, fund expenses, and brokerage commissions may apply. Commissions: $8.95 per online equity trade; commission-free ExampleBank&reg; ETF online trades in your ExampleBank&reg; account&lt;/p&gt;
 &lt;/div&gt;
 </pre>
-            </p>
+           
             
             <p>
                 JSON-LD:
-         
+             </p>
 <pre class="">
 &lt;script type=&quot;application/ld+json&quot;&gt;
   {
@@ -512,8 +511,6 @@
   }
 &lt;/script&gt;  
 </pre>              
-            </p>
-
             <h3>InvestmentFund</h3>
             
             <p>
@@ -522,7 +519,7 @@
             
             <p>
                 JSON-LD:
-         
+             </p>
 <pre class="">
 &lt;script type=&quot;application/ld+json&quot;&gt;
 {
@@ -540,7 +537,7 @@
 }
 &lt;/script&gt;
 </pre>              
-            </p>
+           
             
             
             <h3>MortgageLoan, RepaymentSpecification</h3>
@@ -555,7 +552,7 @@
             
             <p>
                 JSON-LD:
-                
+             </p>   
 <pre class="">
 &lt;script type=&quot;application/ld+json&quot;&gt;
   {
@@ -589,17 +586,18 @@
   }
 &lt;/script&gt;
 </pre>
-            </p>
+            
             
             
             <h3>CreditCard</h3>
             
             <p>
-                This example illustrates the use of a JSON-LD code snippet to supplement the description of credit cards. The specific card being described is identified by its name (<a href="http://schema.org/name">name</a>). The details of the offer presented by the card are expressed through: <a href="http://schema.org/annualPercentageRate">annualPercentageRate</a>, <a href="http://schema.org/interestRate">interestRate</a>, a percentage of "<a href="http://pending.schema.org/cashBack">cashback</a>" (if applicable), the card grace period (<a href="http://pending.schema.org/gracePeriod">gracePeriod<a/>) and the flag for the contactless payments (<a href="http://schema.org/contactlessPayment">contactlessPayment</a>). The additional properties, like <a href="http://schema.org/offeredBy">offeredBy</a> allow to indicate the issuer of the card and annual cardholder’s cost of the card (<a href="http://schema.org/price">price</a>) – further detailed by its currency (<a href="http://schema.org/currency">currency</a>) and type ("@type").	
+                This example illustrates the use of a JSON-LD code snippet to supplement the description of credit cards. The specific card being described is identified by its name (<a href="http://schema.org/name">name</a>). The details of the offer presented by the card are expressed through: <a href="http://schema.org/annualPercentageRate">annualPercentageRate</a>, <a href="http://schema.org/interestRate">interestRate</a>, a percentage of "<a href="http://pending.schema.org/cashBack">cashback</a>" (if applicable), the card grace period (<a href="http://pending.schema.org/gracePeriod">gracePeriod</a>) and the flag for the contactless payments (<a href="http://schema.org/contactlessPayment">contactlessPayment</a>). The additional properties, like <a href="http://schema.org/offeredBy">offeredBy</a> allow to indicate the issuer of the card and annual cardholder’s cost of the card (<a href="http://schema.org/price">price</a>) – further detailed by its currency (<a href="http://schema.org/currency">currency</a>) and type ("@type").	
             </p>
 
             <p>
             JSON-LD:
+            </p>
             
 <pre class="">
 &lt;script type=&quot;application/ld+json&quot;&gt;
@@ -637,7 +635,7 @@
 }
 &lt;/script&gt;
 </pre>
-            </p>
+            
             
             
             <h3>BankTransfer</h3>
@@ -648,7 +646,7 @@
             
             <p>
                 JSON-LD:
-                
+             </p>   
 <pre class="">
 &lt;script type=&quot;application/ld+json&quot;&gt;
 {
@@ -664,7 +662,7 @@
 }
 &lt;/script&gt;
 </pre>
-            </p>
+            
             
             
             <h2 id="acks">Acknowledgments</h2>
@@ -688,6 +686,6 @@
             </p>
         </div>
 
-        <table style="width: 180px; display: none; top: 51px; left: 1186px; position: absolute;" class="gstl_50 gssb_c" cellspacing="0" cellpadding="0"><tbody><tr><td class="gssb_f"></td><td class="gssb_e" style="width: 100%;"></td></tr></tbody></table>
+        <table style="width: 180px; display: none; top: 51px; left: 1186px; position: absolute; border-spacing: 0;" class="gstl_50 gssb_c"><tbody><tr><td class="gssb_f"></td><td class="gssb_e" style="width: 100%;"></td></tr></tbody></table>
     </body>
 </html>

--- a/docs/gs.html
+++ b/docs/gs.html
@@ -28,7 +28,7 @@
 				</h1>
 				</div>
 
-                    <div id="cse-search-form" style="width: 400px;"><gcse:searchbox-only resultsUrl="/docs/search_results.html"></gcse:searchbox-only></div>
+                    <div id="cse-search-form" style="width: 400px;"><div class="gcse-searchbox-only" data-resultsUrl="/docs/search_results.html"></div></div>
 
               </div>
             </div>
@@ -153,7 +153,7 @@ examples to see how the details compare.</p>
 
 <p>This specifies that the item contained in the div is in fact a Movie, as defined in the schema.org type hierarchy. Item types are provided as URLs, in this case <code>http://schema.org/Movie</code>.
 
-<p class="backtotop" align="right"><a href="#top">Back to top</a></p>
+<p class="backtotop" style="text-align:right;"><a href="#top">Back to top</a></p>
 
 <h3 id="microdata_itemprop">1c. itemprop</h3>
 <p>What additional information can we give search engines about the movie Avatar? Movies have interesting properties such as actors, director, ratings. To label properties of an item, use the <code>itemprop</code> attribute. For example, to identify the director of a movie, add <code>itemprop="director"</code> to the element enclosing the director's name. (There's a full list of all the properties you can associate with a movie at http://schema.org/Movie.)</p>
@@ -216,7 +216,7 @@ examples to see how the details compare.</p>
 
   <li><strong>Expected types vs text.</strong> When browsing the schema.org types, you will notice that many properties have "expected types". This means that the value of the property can itself be an embedded item (see section 1d: embedded items). But this is not a requirement&mdash;it's fine to include just regular text or a URL. In addition, whenever an expected type is specified, it is also fine to embed an item that is a child type of the expected type. For example, if the expected type is Place, it's also OK to embed a LocalBusiness.</li>
 
-  <li><strong>Using the url property.</strong> Some web pages are about a specific item. For example, you may have a web page about a single person, which you could mark up using the Person item type. Other pages have a collection of items described on them. For example, your company site could have a page listing employees, with a link to a profile page for each person. For pages like this with a collection of items, you should mark up each item separately (in this case as a series of Persons) and add the url property to the link to the corresponding page for each item, like this:</p>
+  <li><strong>Using the url property.</strong> Some web pages are about a specific item. For example, you may have a web page about a single person, which you could mark up using the Person item type. Other pages have a collection of items described on them. For example, your company site could have a page listing employees, with a link to a profile page for each person. For pages like this with a collection of items, you should mark up each item separately (in this case as a series of Persons) and add the url property to the link to the corresponding page for each item, like this:
 
 <pre>
 &lt;div itemscope itemtype="http://schema.org/Person"&gt;

--- a/docs/hotels.html
+++ b/docs/hotels.html
@@ -53,7 +53,7 @@
                 </h1>
                 </div>
 
-                    <div id="cse-search-form" style="width: 400px;"><gcse:searchbox-only resultsUrl="/docs/search_results.html"></gcse:searchbox-only></div>
+                    <div id="cse-search-form" style="width: 400px;"><div class="gcse-searchbox-only" data-resultsUrl="/docs/search_results.html"></div></div>
 
               </div>
             </div>

--- a/docs/howwework.html
+++ b/docs/howwework.html
@@ -49,7 +49,7 @@
 				</h1>
 				</div>
 
-                    <div id="cse-search-form" style="width: 400px;"><gcse:searchbox-only resultsUrl="/docs/search_results.html"></gcse:searchbox-only></div>
+                    <div id="cse-search-form" style="width: 400px;"><div class="gcse-searchbox-only" data-resultsUrl="/docs/search_results.html"></div></div>
 
               </div>
             </div>
@@ -186,7 +186,7 @@ definitions. Finally, all changes to the site and its underlying software are no
  <p>It is also important to understand what schema.org does <em>not</em> define or dictate. In particular schema.org does not define any notion of 'mandatory' property.
 Different sites and pages naturally have different amounts of information available; these details cannot be anticipated by schema designers. Similarly, the information needs of consuming services may also vary. We do not attempt to reach consensus at schema.org on what an ideal description of some type (Person, Place, TVSeries etc.) ought to contain - this makes consensus significantly easier to achieve. The schema.org site does contain many practical markup examples, which give rough hints about common and useful patterns for combining schema.org terms.</p>
 
-<p>
+
 Each release can include several kinds of change:
 <ul>
 <li>Bug fixes and minor improvements (e.g. typos, markup errors in examples).</li>
@@ -202,7 +202,6 @@ Each release can include several kinds of change:
   or exactly one extension, and terms can move in either direction. Terms can be generalized for wider use and moved into the core, or migrated from the core into a hosted extension. In both cases, textual definitions and machine-readable definitions may be adjusted.
 </li>
 </ul>
-</p>
 
 <p>
 Schema.org property names are considered "global" across the entire project (including the core and all hosted vocabularies such as "<a href="http://auto.schema.org/">auto</a>", "<a href="http://bib.schema.org/">bib</a>" etc.).
@@ -349,9 +348,8 @@ encouraging discussion amongst their contributors.
         the wider community, and implemented with the approval of the steering committee.</li>
       <li>Faciliate wide-ranging community and industry involvement during schema design discussions, e.g. via W3C, Github.</li>
     </ul>
-  </dd>
-  <p>The current schema.org webmaster is Dan Brickley, who serves in this capacity on behalf of the schema.org project rather than on behalf of his employer, Google.</p>
-</dd>
+    The current schema.org webmaster is Dan Brickley, who serves in this capacity on behalf of the schema.org project rather than on behalf of his employer, Google.
+ </dd>
  <dt id="w3rel">How is this work related to W3C? How does the steering group mechanism work in practice?</dt>
  <dd>
    <p>

--- a/docs/iot-gettingstarted.html
+++ b/docs/iot-gettingstarted.html
@@ -1,4 +1,4 @@
-<!doctype html>
+<<!doctype html>
 <html>
 <head>
 <title>IoT and Schema.org: Getting Started</title>
@@ -40,7 +40,7 @@ td {
 <h2>IoT and Schema.org: Getting Started</h2>
 <p><b>STATUS</b>: Work in progress document targetting schema.org v3.2 release.</p>
 <p>Editor: Dan Brickley &lt;<a href="mailto:danbri@google.com">danbri@google.com</a>&gt;</p>
-<p>Contributors (alphabetically):  <a href="http://www.synergylabs.org/yuvraj" >Yuvraj Agarwal</a>, <a href="https://nl.linkedin.com/in/lauradaniele">Laura Daniele</a>, <a href="http://joshuagluck.com/">Joshua Gluck</a>, R.V. Guha, <a href="http://research.google.com/pubs/TedHardie.html">Ted Hardie</a>, <a href="https://jbkoh.wordpress.com/">Jason Koh</a>, Ari Keränen, <a href="http://www.theinternetofthings.eu/michael-koster">Michael Koster</a>,<a href="http://www.theinternetofthings.eu/michael-koster">Dave Raggett</a></a>, <a href="http://maxsenges.com/">Max Senges</a></p>
+<p>Contributors (alphabetically):  <a href="http://www.synergylabs.org/yuvraj" >Yuvraj Agarwal</a>, <a href="https://nl.linkedin.com/in/lauradaniele">Laura Daniele</a>, <a href="http://joshuagluck.com/">Joshua Gluck</a>, R.V. Guha, <a href="http://research.google.com/pubs/TedHardie.html">Ted Hardie</a>, <a href="https://jbkoh.wordpress.com/">Jason Koh</a>, Ari Keränen, <a href="http://www.theinternetofthings.eu/michael-koster">Michael Koster</a>,<a href="http://www.theinternetofthings.eu/michael-koster">Dave Raggett</a>, <a href="http://maxsenges.com/">Max Senges</a></p>
 <p>This short document introduces a proposal for the schema.org community to begin work in the "Internet of Things" (IoT) area, building on schema.org's existing success to provide an approach to semantic interoperability that bridges IoT and non-IoT applications. It outlines some possible application areas where schema.org-oriented structured data vocabularies may be useful, gives some examples of related schemas and related standards efforts, before proposing some practical steps for collaborative work.</p>
 
 <h3>The case for IoT + Schema.org</h3>
@@ -78,7 +78,7 @@ td {
 <li>Schema.org has extensive existing vocabulary that covers broadcast and archived television, radio and music content. These schemas have been developed in collaboration with BBC, European Broadcasting Union (EBU), MusicBrainz and others. Many smart home devices will contain content such as personal or purchased media, or metadata relating to files, events, streams and cloud services (e.g. streaming music providers). Schema.org's descriptive vocabulary covers much of this already.</ul></li>
 <li>Sensors and the description of the physical environment.<ul>
 <li>Schema.org already contains basic and sometimes quite detailed vocabulary for describing properties and relationships of places, including businesses, events and other associated entities. It does not yet, however, have much support for the kind of data coming from IoT sensors - e.g. date/time stamped temperature measurements. It is likely that patterns based largely on existing vocabulary could be agreed relatively easily, and there is scope for an extension aligned with other work such as that <a href="https://www.w3.org/2015/spatial/wiki/Main_Page#Semantic_Sensor_Network_Ontology">at W3C</a>. There is also related work on physical accessibility of places, e.g. navigation to support vision impaired users, documentation of wheelchair ramps, availability of assistive technologies, braille menus, and related considerations.</ul></li>
-<li>Energy Efficiency:</ul></li>
+<li>Energy Efficiency:</li>
 </ul>
 <blockquote>Users can offer flexibility to the Smart Grid to manage their smart home devices by means of a Customer Energy Manager (CEM). The CEM is a logical function for optimizing energy consumption and/or production that can reside either in the home gateway or in the cloud. The interoperability of a device with other devices and with the CEM should be guaranteed regardless of their brand/manufacturer, because the user wants to be able to buy any washing machine they want and still have it communicate with the other devices that are already in their home. Some examples scenarios include the scheduling of appliances in certain modes and preferred times using power profiles to optimize energy efficiency and accommodate the user's preferences. For example, the user might want the washing done by 5:00 p.m. with least electrical power costs, or prefer to limit their own energy consumption up to a defined limit. Such scenarios suggest that there would be value in developing common schemas that can express control preferences and policies relating to energy efficiency.</blockquote>
 
@@ -142,7 +142,7 @@ This combination would simultaneously avoid fragmenting further the existing for
 <li>"This specification defines an API that provides access to the vibration mechanism of the hosting device. Vibration is a form of tactile feedback."</ul></li>
 </ul></li>
 <li>"Web of Things" (WoT) - <a href="https://www.w3.org/WoT/">https://www.w3.org/WoT/</a><br>
-This sets out to address the fragmentation of the IoT into incompatible platforms and data silos. The aim is to simplify application development and improve interoperability across different platforms through metadata that describes the interaction model exposed to applications (properties, actions and events), security and communication details for accessing platforms, an</u>d semantic models and constraints for search, validation and composition of services. The approach is based upon the core architecture of the Web with URIs <u>as addresses </u>for thing descriptions, declarative formats for these descriptions, and protocols for accessing things and their descriptions.<ul>
+This sets out to address the fragmentation of the IoT into incompatible platforms and data silos. The aim is to simplify application development and improve interoperability across different platforms through metadata that describes the interaction model exposed to applications (properties, actions and events), security and communication details for accessing platforms, and semantic models and constraints for search, validation and composition of services. The approach is based upon the core architecture of the Web with URIs <u>as addresses</u> for thing descriptions, declarative formats for these descriptions, and protocols for accessing things and their descriptions.<ul>
 <li>Interest Group - <a href="https://www.w3.org/WoT/IG/">https://www.w3.org/WoT/IG/</a> (active with frequent plugfests)</li>
 <li>Community Group - <a href="https://www.w3.org/community/wot/">https://www.w3.org/community/wot/</a> (somewhat active)</li>
 <li>Business Group, Working Group - proposals for these are planned.</ul></li>
@@ -530,8 +530,8 @@ saref-ls:SwitchOnService
 The words that constitute Tagsets are called Tags. For example, "Room Temperature Sensor" is under "Sensor" category in Fig.1. and is broken down into Tags as "Room", "Temperature" and "Sensor". In this simple way, we can achieve both ease of use and expressiveness. Building managers not familiar with the entire schema may annotate a resource such as equipment or a sensor by Tags easily. As each tag represents a meaning, meaning of a collection of tags can be inferred to the most similar Tagset. At the same time, managers or developers who have full knowledge about the schema can represent resources by Tagsets with exact meanings. Managers can define utilize predefined properties to express relationships among Tagsets as presented in Table 1. For example, we can express that a "Space Heater" "hasPoint" "Room Temperature Sensor". </p>
 <p>List 1 shows how Tagsets are defined in a formal way using Turtle syntax. "HVAC_Zone" is a Tagset, which is a subclass of "Location" and consists of Tags as "HVAC" and "Zone". The relationships between a Tagset and Tags are explicitly defined to infer the meaning of a collection of Tags easily as explained before. Usable Tags are also defined in a similar way as in List 2 with a similar taxonomy as Tagset's. We represent an example building with these subsets of the schema in List 3. From this information, we know that example_building is a Building, zone_1 is a HVAC_Zone located in the building. The zone has a vav_1, which is a Variable Air Volume Box (a type of terminal units to provide controlled air to a HVAC zone such as a room) where a one Temperature Sensor functions for both the HVAC Zone and the VAV. </p>
 <p>Actual instances of Brick for five buildings validate its completeness. Brick captures 98 % of 15,700 BMS data points and 615,000 sq-ft of floor space. Illustrative but representative queries are also successfully tested to show the coverage of relationships we need for eight canonical applications. These actual examples are available via the repository.</p>
-<p>. </p>
-<p><img src="insert_image_url_here"></p>
+
+<!-- <p><img src="insert_image_url_here"></p>-->
 
 <p>Fig. 1 A Subset of Brick Tagset Taxonomy</p>
 
@@ -668,7 +668,7 @@ ex:vav_1 a brick:VAV;<br>
 [1] Bhattacharya, Arka, Joern Ploennigs, and David Culler. "<i>Short Paper: Analyzing Metadata Schemas for Buildings: The Good, the Bad, and the Ugly</i>." In Proceedings of the 2nd ACM International Conference on Embedded Systems for Energy-Efficient Built Environments, pp. 33-34. ACM, 2015.<br>
 [2] Bharathan Balaji, Arka Bhattacharya, Gabe Fierro, Jingkun Gao, Joshua Gluck, Dezhi Hong, Aslak Johansen, Jason Koh, Yuvraj Agarwal, Mario Berges, David Culler, Rajesh Gupta, Mikkel Baun Kjærgaard, Joern Ploennigs and Kamin Whitehouse, "<i>Brick v1.0 - Towards a Unified Metadata Schema For Buildings</i>", In Proceedings of the 3rd ACM International Conference on Embedded Systems for Energy-Efficient Built Environments, 2016 (accepted, <a href="https://www.dropbox.com/s/g5ipwtkk44407ob/Brick_BuildSys2016.pdf?dl=0">provisional pdf</a>).</p>
 
-<h3></h3>
+<h3> </h3>
 
 <h3>Nest Weave (Google/Alphabet)</h3>
 <p>Documentation of the file format still Nest-internal.</p>
@@ -1050,3 +1050,4 @@ ex:vav_1 a brick:VAV;<br>
 
 </body>
 </html>
+>

--- a/docs/kickoff.html
+++ b/docs/kickoff.html
@@ -1,3 +1,4 @@
+<!DOCTYPE html>
 <html>
 <head>
 <title>Schema.org Kickoff Workshop</title>

--- a/docs/meddocs.html
+++ b/docs/meddocs.html
@@ -55,7 +55,7 @@
 				</h1>
 				</div>
 
-                    <div id="cse-search-form" style="width: 400px;"><gcse:searchbox-only resultsUrl="/docs/search_results.html"></gcse:searchbox-only></div>
+                    <div id="cse-search-form" style="width: 400px;"><div class="gcse-searchbox-only" data-resultsUrl="/docs/search_results.html"></div></div>
 
               </div>
             </div>

--- a/docs/news.html
+++ b/docs/news.html
@@ -54,7 +54,7 @@
                 </h1>
                 </div>
 
-                    <div id="cse-search-form" style="width: 400px;"><gcse:searchbox-only resultsUrl="/docs/search_results.html"></gcse:searchbox-only></div>
+                    <div id="cse-search-form" style="width: 400px;"><div class="gcse-searchbox-only" data-resultsUrl="/docs/search_results.html"></div></div>
 
               </div>
             </div>

--- a/docs/releases.html
+++ b/docs/releases.html
@@ -80,7 +80,7 @@ td.release  {
 				</h1>
 				</div>
 
-                    <div id="cse-search-form" style="width: 400px;"><gcse:searchbox-only resultsUrl="/docs/search_results.html"></gcse:searchbox-only></div>
+                    <div id="cse-search-form" style="width: 400px;"><div class="gcse-searchbox-only" data-resultsUrl="/docs/search_results.html"></div></div>
 
               </div>
             </div>
@@ -208,7 +208,7 @@ several "best practice"-oriented properties: <a href="/actionableFeedbackPolicy"
  (apart from ethicsPolicy and diversityPolicy, these are all sub-properties of <a href="/publishingPrinciples">publishingPrinciples</a>). These
 changes were based in large part upon the work of <a href="http://thetrustproject.org/">The Trust Project</a>.
 <span id="tp-news"></span></li>
-<li id="g1541"><a href="https://github.com/schemaorg/schemaorg/issues/1437">Issue #1437</a>: Add <a href="/SatiricalArticle">SatiricalArticle</a> type.</li>
+<li id="g1437"><a href="https://github.com/schemaorg/schemaorg/issues/1437">Issue #1437</a>: Add <a href="/SatiricalArticle">SatiricalArticle</a> type.</li>
 
 <!-- <li id="g@@@@"><a href=""></a></li> -->
 </ul>
@@ -225,10 +225,9 @@ changes were based in large part upon the work of <a href="http://thetrustprojec
 
 <tr>
 <td class="release"><a href="/version/3.2/">3.2</a><br/>sdo-callisto<br/>(2017-03-23)</td>
-<span id="v.next"></span>
+<td>
 <span id="sdo-callisto"></span>
 <span id="v3.2"></span>
-<td>
 <p>
 Version 3.2 (working name 'sdo-callisto'). See <a href="https://github.com/schemaorg/schemaorg/issues/1">planning pages</a>, specifically <a href="https://github.com/schemaorg/schemaorg/issues/1292">#1292</a> for details.
 </p>
@@ -256,7 +255,7 @@ with the other new menu properties, and to avoid a property and type having esse
 <li>Moved to Core from Pending:
   <ul>
 
-    <li id="g195"><a href="https://github.com/schemaorg/schemaorg/issues/195">Issue #195</a>: Added Course-description terms:
+    <li id="g195-"><a href="https://github.com/schemaorg/schemaorg/issues/195">Issue #195</a>: Added Course-description terms:
     <a href="/Course">Course</a>, <a href="/courseCode">courseCode</a>, <a href="/coursePrerequisites">coursePrerequisites</a>,
     <a href="/hasCourseInstance">hasCourseInstance</a>, <a href="/CourseInstance">CourseInstance</a>,
     <a href="/courseMode">courseMode</a>, <a href="/instructor">instructor</a>. Thanks to the
@@ -282,7 +281,7 @@ with the other new menu properties, and to avoid a property and type having esse
     <li>Types: <a href="/BrokerageAccount">BrokerageAccount</a>,
     <a href="/ExchangeRateSpecification">ExchangeRateSpecification</a>,
     <a href="/InvestmentFund">InvestmentFund</a>,
-    <a hrefw="/MoneyTransfer">MoneyTransfer</a>,
+    <a href="/MoneyTransfer">MoneyTransfer</a>,
     <a href="/MortgageLoan">MortgageLoan</a>,
     <a href="/RepaymentSpecification">RepaymentSpecification</a>.</li>
   <li>Properties: <a href="/accountMinimumInflow">accountMinimumInflow</a>,
@@ -331,7 +330,7 @@ These sections are indicated via URL/ID values, XPath and/or CSS selectors.
 <li id="g1495"><a href="https://github.com/schemaorg/schemaorg/issues/1495">Issue #1495</a>: Added a <a href="/Consortium">Consortium</a> type, as well as a <a href="/LibrarySystem">LibrarySystem</a> type to represent a particular kind of Library consortium.</li>
 <li id="g743"><a href="https://github.com/schemaorg/schemaorg/issues/743">Issue #743</a>: Added a <a href="/Distillery">Distillery</a> type.</li>
 <li id="g894"><a href="https://github.com/schemaorg/schemaorg/issues/894">Issue #894</a>: Added <a href="/CategoryCode">CategoryCode</a>, <a href="/CategoryCodeSet">CategoryCodeSet</a>, <a href="/codeValue">codeValue</a> and <a href="/inCodeSet">inCodeSet</a> to explore better description of enumerated value lists.</li>
-<li id="g1004"><a href="https://github.com/schemaorg/schemaorg/issues/1004">Issue #1004</a>: Added <a href="/broadcastFrequency">broadcastFrequency</a>, <a href="/broadcastFrequencyValue">broadcastFrequencyValue</a>
+<li id="g1004-"><a href="https://github.com/schemaorg/schemaorg/issues/1004">Issue #1004</a>: Added <a href="/broadcastFrequency">broadcastFrequency</a>, <a href="/broadcastFrequencyValue">broadcastFrequencyValue</a>
 and <a href="/BroadcastFrequencySpecification">BroadcastFrequencySpecification</a> for describing (primarily radio but also TV) frequencies. Also supporting
 types <a href="/FMRadioChannel">FMRadioChannel</a>, <a href="/AMRadioChannel">AMRadioChannel</a>,
 and property <a href="/hasBroadcastChannel">hasBroadcastChannel</a> (inverse: <a href="/providesBroadcastService">providesBroadcastService</a>).</li>
@@ -392,9 +391,9 @@ materials to be described in more detail.
 
 <tr>
 <td class="release"><a href="/version/3.1/">3.1</a><br/>sdo-makemake<br/>(2016-08-09)</td>
+<td>
 <span id="sdo-makemake"></span>
 <span id="v3.1"></span>
-<td>
 <p>
 Version 3.1 (working name 'sdo-makemake'). See <a href="https://github.com/schemaorg/schemaorg/issues/1">planning pages</a>, specifically <a href="https://github.com/schemaorg/schemaorg/issues/1212">#1212</a> for details.
 </p>
@@ -481,20 +480,21 @@ rather than <a href="/TelevisionStation">TelevisionStation</a> (per <a href="g#5
 </tr>
 
 <tr>
-<td class="release"><a href="/version/3.0/">3.0</a><br/>sdo-deimos<br/>(2016-05-04)</td>
+<td class="release"><a href="/version/3.0/">3.0</a><br/>sdo-deimos<br/>(2016-05-04)
 <span id="sdo-deimos"></span>
 <span id="v3.0"></span>
+</td>
 <td>
 <p>
 Version 3.0 (working name 'sdo-deimos'). See <a href="https://github.com/schemaorg/schemaorg/issues/1">planning pages</a>, specifically <a href="https://github.com/schemaorg/schemaorg/issues/911">#911</a> for details.
 </p>
-<p>This release introduces three new <a href="/docs/extension.html">extensions</a>.
+This release introduces three new <a href="/docs/extension.html">extensions</a>.
 <ul>
 <li>The <a href="http://meta.schema.org/">meta.schema.org</a> extension contains terms primarily designed to support the implementation of the Schema.org vocabulary itself.</li>
 <li>The <a href="http://pending.schema.org/">pending.schema.org</a> extension is a staging area for work-in-progress terms which have yet to be accepted into the core vocabulary. Pending terms are subject to change and should be used with caution.</li>
 <li>The <a href="http://health-lifesci.schema.org/">health-lifesci.schema.org</a> extension is a new home for our existing <a href="/docs/meddocs.html">Medical and healthcare</a> related terms, as well as potential future collaborative work. </li>
 </ul>
-</p>
+
 <p>The initial releases of <a href="http://bib.schema.org/">bib.schema.org</a> and <a href="http://auto.schema.org">auto.schema.org</a> have also been finalized.
 </p>
 <p>In addition to numerous vocabulary-related improvements, we have added a new "<a href="/docs/howwework.html">How we work</a>" document providing an overview of the project's approach to schema development, collaboration, versioning and change review.
@@ -562,7 +562,7 @@ The <a href="/grantee">grantee</a> property indicates in each case the person, o
 
 <h3>Site improvements</h3>
 <ul>
-<li id="g1059"><a href="https://github.com/schemaorg/schemaorg/issues/1059">Issue #1059</a>: Created hosted extensions for 'meta' vocabulary and for 'pending' vocabulary under review. Moved Class, Property, domainIncludes, rangeIncludes, inverseOf, supersededBy into meta.</li>
+<li id="g1059-"><a href="https://github.com/schemaorg/schemaorg/issues/1059">Issue #1059</a>: Created hosted extensions for 'meta' vocabulary and for 'pending' vocabulary under review. Moved Class, Property, domainIncludes, rangeIncludes, inverseOf, supersededBy into meta.</li>
 <li id="g256"><a href="https://github.com/schemaorg/schemaorg/issues/256">Issue #256</a>: Implementation of HTTP HEAD for all pages.</li>
 <li id="g1095"><a href="https://github.com/schemaorg/schemaorg/pull/1095">Issue #1095</a>: ETag and Last-Modified headers only for successful page requests.</li>
 <li id="g1098"><a href="https://github.com/schemaorg/schemaorg/pull/1098">Issue #1098</a>: Added categorization of terms listed on extension home page.</li>

--- a/docs/search_results.html
+++ b/docs/search_results.html
@@ -27,7 +27,7 @@
 				</h1>
 				</div>
 
-<div id="cse-search-form" style="width: 400px;"><gcse:searchbox></gcse:searchbox></div>
+<div id="cse-search-form" style="width: 400px;"><div class="gcse-searchbox"></div></div>
 <style type="text/css">
   input.gsc-input {
     border-color: #660000;
@@ -212,7 +212,7 @@
             </div>
 
   <div id="mainContent">
-    <gcse:searchresults></gcse:searchresults>
+    <div class="gcse-searchresults"></div>
   </div>
 
 

--- a/docs/terms.html
+++ b/docs/terms.html
@@ -28,7 +28,7 @@
 				</h1>
 				</div>
 
-                    <div id="cse-search-form" style="width: 400px;"><gcse:searchbox-only resultsUrl="/docs/search_results.html"></gcse:searchbox-only></div>
+                    <div id="cse-search-form" style="width: 400px;"><div class="gcse-searchbox-only" data-resultsUrl="/docs/search_results.html"></div></div>
 
               </div>
             </div>

--- a/templates/basicPageHeader.tpl
+++ b/templates/basicPageHeader.tpl
@@ -8,7 +8,7 @@
 					<a href="/">{{ sitename }}</a>
 				</h1>
 				</div>
-				<div id="cse-search-form" style="width: 400px;"><gcse:searchbox-only resultsUrl="/docs/search_results.html"></gcse:searchbox-only></div>
+				<div id="cse-search-form" style="width: 400px;"><div class="gcse-searchbox-only" data-resultsUrl="/docs/search_results.html"></div></div>
 			</div>
 		</div>
 	</div>

--- a/templates/developers.tpl
+++ b/templates/developers.tpl
@@ -43,9 +43,9 @@ This is a placeholder page for developer-oriented information about schema.org. 
 <p>Select the file and format required and click Download.  
 <br/>Note: File <em>schema</em> contains the definition of the core vocabulary, <em>all-layers</em> contains definitions for the core and all the extensions.</p>
 
-<p>
-	<table padding="2" width="600">
-	<tr><td width="30%">
+
+	<table style="padding: 2px; width:600px">
+	<tr><td style="width: 30%;">
 			File: <select id="filename"  onchange="updatetext()">
 				<option value="{{staticPath}}/version/latest/schema">schema</option>
 				<option value="{{staticPath}}/version/latest/all-layers">all-layers</option>
@@ -54,7 +54,7 @@ This is a placeholder page for developer-oriented information about schema.org. 
 				{% endfor %}
 			</select>
 	</td>
-	<td width="30%">
+	<td style="width: 30%;">
 		Format:  <select id="fileext" onchange="updatetext()">
 				<option value=".nt">Triples</option>
 				<option value=".nq">Quads</option>
@@ -64,7 +64,7 @@ This is a placeholder page for developer-oriented information about schema.org. 
 				<option value=".csv">CSV</option>
 		</select>
 	</td>
-	<td width="30%">
+	<td style="width: 30%;">
 		<div id ="csvsel">
 			For: <select id="csvfmt" onchange="updatetext()">
 				<option value="-types">Types</option>
@@ -76,12 +76,12 @@ This is a placeholder page for developer-oriented information about schema.org. 
 	</tr>
 	<tr><td colspan="3">
 		<div id="label"></div>
-	<tr><td colspan="3" align="centre">
-		<input type="button" onclick="dowloadfunc();" value="Download"></input>
+	<tr><td colspan="3" style="text-align: center;">
+		<input type="button" onclick="dowloadfunc();" value="Download"/>
 	</td></tr>
 		
 	</table>
-</p>
+
   </div>
 
 

--- a/templates/full.tpl
+++ b/templates/full.tpl
@@ -82,4 +82,6 @@ Schema.org is defined as two hierarchies: one for textual property values, and o
 <br/><br/>
 
 </div>
+</body>
+</html>
 

--- a/templates/schemas.tpl
+++ b/templates/schemas.tpl
@@ -63,13 +63,13 @@ For example in the <a href="http://auto.schema.org/">auto</a> extension there is
 and in the <a href="http://bib.schema.org/">bibliographic extension</a> we have a property <a href="/publisherImprint">publisherImprint</a>.
 </p>
 
-<p>Using the <a href="{{staticPath}}/docs/extension.html">extension mechanism</a> the core vocabulary is extended by the following hosted extensions:
+<p>Using the <a href="{{staticPath}}/docs/extension.html">extension mechanism</a> the core vocabulary is extended by the following hosted extensions:</p>
 <ul>
 {% for ext in extensions %}
 	<li>{{ ext | safe }}</li>
 {% endfor %}
 </ul>
-</p>
+
 
 <p><b>Note</b>: the 'pending' and 'meta' hosted extensions are part of schema.org's schema development process.</p>
 <p id="ext_pending">
@@ -82,7 +82,7 @@ and in the <a href="http://bib.schema.org/">bibliographic extension</a> we have 
 
 <p id="ext_meta">
 The 'meta' extension is primarily for vocabulary used internally within schema.org to support technical definitions and
-schema.org site functionality. These terms are not intended for general usage in the public Web.</p>
+schema.org site functionality. These terms are not intended for general usage in the public Web.
 </p>
 <p id="attic"><strong>Attic</strong> ({{attic | safe}}) is a special extension area where terms are archived when deprecated from the core and other extensions, or removed from <a href="http://pending.schema.org">pending</a> as not accepted into the full vocabulary. References to terms in the attic area are not normally displayed unless accessed via the term identifier or via the {{attic | safe}} home page. Implementors and data publishers are cautioned not to use terms in the attic area.
 </p> 


### PR DESCRIPTION
Collection of fixes to both generated and static pages to pass tests at [validator.w3.org](https://validator.w3.org).

Examples include unbalanced tags, duplicate _id_ attribute values, HTML 5 compliant version of the Google CSE feature, unclosed ```<a>``` & ```<div>``` elements, elements between instead of within table elements.
