### PR TITLE
Fix physician subclass

### DIFF
--- a/data/schema.rdfa
+++ b/data/schema.rdfa
@@ -103,7 +103,7 @@
     <div typeof="rdfs:Class" resource="http://schema.org/Physician">
       <span class="h" property="rdfs:label">Physician</span>
       <span property="rdfs:comment">A doctor's office.</span>
-      <span>Subclass of: <a property="rdfs:subClassOf" href="http://schema.org/MedicalOrganization"> health:MedicalOrganization</a></span>
+      <span>Subclass of: <a property="rdfs:subClassOf" href="http://schema.org/MedicalOrganization">MedicalOrganization</a></span>
     </div>
     <div typeof="rdfs:Class" resource="http://schema.org/Pharmacy">
       <span class="h" property="rdfs:label">Pharmacy</span>


### PR DESCRIPTION
`Physician` is an official subclass of `MedicalOrganization` (see http://schema.org/Physician) and should be reflected as such in the rdfa.
