### PR TITLE
Changes to move to https only (for UI, not for vocab URIs)

### DIFF
--- a/apirdflib.py
+++ b/apirdflib.py
@@ -23,6 +23,8 @@ rdflib.plugin.register("json-ld", Serializer, "rdflib_jsonld.serializer", "JsonL
 
 ATTIC = 'attic'
 VOCAB = "http://schema.org"
+VOCABLEN = len(VOCAB)
+ALTVOCAB = "https://schema.org"
 STORE = rdflib.Dataset()
 #Namespace mapping#############
 nss = {'core': 'http://schema.org/'}
@@ -55,10 +57,18 @@ def queryGraph():
                 QUERYGRAPH.bind('rdfa', 'http://www.w3.org/ns/rdfa#')
                 QUERYGRAPH.bind('dct', 'http://purl.org/dc/terms/')
                 QUERYGRAPH.bind('schema', 'http://schema.org/')
+                altSameAs(QUERYGRAPH)
         finally:
             RDFLIBLOCK.release()
     return QUERYGRAPH
 
+def altSameAs(graph):
+    sameAs = URIRef("%s/sameAs" % VOCAB)
+    for sub in graph.subjects(None,None):
+        if sub.startswith(VOCAB):
+            #log.info("%s >>>> %s " % (sub,"%s%s" % (ALTVOCAB,sub[VOCABLEN:])))
+            graph.add( (sub,sameAs,URIRef("%s%s" % (ALTVOCAB,sub[VOCABLEN:]))) )
+            
 def loadNss():
     global NSSLoaded
     global nss

--- a/app.yaml
+++ b/app.yaml
@@ -6,7 +6,6 @@ module: default
 runtime: python27
 api_version: 1
 threadsafe: true
-
   
 #automatic_scaling: #Only applicable for appengine accounts with billing enabled
 #  min_idle_instances: 2

--- a/schemaorg.yaml
+++ b/schemaorg.yaml
@@ -28,10 +28,14 @@ handlers:
   static_files: docs/favicon.ico
   upload: docs/favicon.ico
   mime_type: image/x-icon
+  secure: always
+  redirect_http_response_code: 301
 
 - url: /robots.txt
   static_files: docs/robots.txt
   upload: docs/robots.txt
+  secure: always
+  redirect_http_response_code: 301
   mime_type: text/plain
 
 # To avoid: "Could not guess mimetype for docs/schemaorg.owl.  Using application/octet-stream."
@@ -39,30 +43,46 @@ handlers:
   static_files: docs/schemaorg.owl
   upload: docs/schemaorg.owl
   mime_type: application/rdf+xml
+  secure: always
+  redirect_http_response_code: 301
 
 - url: /docs/schema_org_rdfa.html
   static_files: data/schema.rdfa
   upload: data/schema.rdfa
   application_readable: True
   mime_type: text/html
+  secure: always
+  redirect_http_response_code: 301
 
 - url: /docs/jsonldcontext.json.*
   script: sdoapp.app
+  secure: always
+  redirect_http_response_code: 301
 
 - url: /docs/full.*.html
   script: sdoapp.app
+  secure: always
+  redirect_http_response_code: 301
 
 - url: /docs/schemas.html
   script: sdoapp.app
+  secure: always
+  redirect_http_response_code: 301
 
 - url: /docs/developers.html
   script: sdoapp.app
+  secure: always
+  redirect_http_response_code: 301
 
 - url: /docs/tree.json.*
   script: sdoapp.app
+  secure: always
+  redirect_http_response_code: 301
 
 - url: /docs
   static_dir: docs
+  secure: always
+  redirect_http_response_code: 301
 
 #- url: /
 #  static_files: static/index.html
@@ -71,67 +91,95 @@ handlers:
 
 - url: /search_files
   static_dir: static/search_files
+  secure: always
+  redirect_http_response_code: 301
 
 - url: /version/latest/.*
   script: sdoapp.app
+  secure: always
+  redirect_http_response_code: 301
 
 - url: /(version/[^/]*/)$
   script: sdoapp.app
+  secure: always
+  redirect_http_response_code: 301
 
 - url: /(version/([^/]*))$
   script: sdoapp.app
+  secure: always
+  redirect_http_response_code: 301
 
 - url: /version/
   script: sdoapp.app
+  secure: always
+  redirect_http_response_code: 301
 
 - url: /version/(.*/.*\.rdfa)
   mime_type: text/html
   static_files: data/releases/\1
   upload: data/releases/(.*/.*\.rdfa)
   application_readable: True
+  secure: always
+  redirect_http_response_code: 301
 
 - url: /version/(.*/.*\.ttl)
   mime_type: application/x-turtle
   static_files: data/releases/\1
   upload: data/releases/(.*/.*\.ttl)
   application_readable: True
+  secure: always
+  redirect_http_response_code: 301
 
 - url: /version/(.*/.*\.jsonld)
   mime_type: application/ld+json
   static_files: data/releases/\1
   upload: data/releases/(.*/.*\.jsonld)
   application_readable: True
+  secure: always
+  redirect_http_response_code: 301
 
 - url: /version/(.*/.*\.rdf)
   mime_type: application/rdf+xml
   static_files: data/releases/\1
   upload: data/releases/(.*/.*\.rdf)
   application_readable: True
+  secure: always
+  redirect_http_response_code: 301
 
 - url: /version/(.*/.*\.nt)
   mime_type: application/n-triples
   static_files: data/releases/\1
   upload: data/releases/(.*/.*\.nt)
   application_readable: True
+  secure: always
+  redirect_http_response_code: 301
 
 - url: /version/(.*/.*\.nq)
   mime_type: application/n-quads
   static_files: data/releases/\1
   upload: data/releases/(.*/.*\.nq)
   application_readable: True
+  secure: always
+  redirect_http_response_code: 301
 
 - url: /version/(.*/.*\.csv)
   mime_type: text/csv
   static_files: data/releases/\1
   upload: data/releases/(.*/.*\.csv)
   application_readable: True
+  secure: always
+  redirect_http_response_code: 301
 
 - url: /version/*/*
   static_dir: data/releases/
   application_readable: True
+  secure: always
+  redirect_http_response_code: 301
 
 - url: /.*
   script: sdoapp.app
+  secure: always
+  redirect_http_response_code: 301
 
 
 

--- a/sdoapp.py
+++ b/sdoapp.py
@@ -611,7 +611,15 @@ class ShowUnit (webapp2.RequestHandler):
 
     def emitCanonicalURL(self,node):
         cURL = "%s://schema.org/%s" % (CANONICALSCHEME,node.id)
-        self.write(" <span class=\"canonicalUrl\">Canonical URL: <a href=\"%s\">%s</a></span>" % (cURL, cURL))
+        if CANONICALSCHEME == "http":
+            other = "https"
+        else:
+            other = "http"
+        sa = '\n<link  property="sameAs" href="%s://schema.org/%s" />' % (other,node.id)
+        
+        self.write(" <span class=\"canonicalUrl\">Canonical URL: <a href=\"%s\">%s</a></span> " % (cURL, cURL))
+        self.write(" (<a href=\"/docs/faq.html#19\" title=\"http/https help\">?</a>)")
+        self.write(sa)
 
     # Stacks to support multiple inheritance
     crumbStacks = []

--- a/templates/genericTermPageHeader.tpl
+++ b/templates/genericTermPageHeader.tpl
@@ -57,7 +57,7 @@
   
 
 </style>
-
+<link rel="canonical" href="https://schema.org/{{ entry }}" />
 </head>
 <body class="{{ sitemode }}">
 


### PR DESCRIPTION
Implements issue (#1925)
- .yaml changes for forced 301 redirect to https - for schema.org but not webschemas.org
  -  Webschema.org can be done retrospectively when Certificates have been updated. See Issue (#1739)
- In m/c readable outputs aded sameAs statements from http to https URIs
- Added help link from canonical URL on term pages to faq about http/https
- Added rel=canonical link to http://schema.org/{term} in term page header.