### PR TITLE
Clarifying relative sizes of region and locality in PostalAddress

### DIFF
--- a/data/schema.rdfa
+++ b/data/schema.rdfa
@@ -3550,13 +3550,13 @@ The place is __open__ if the [[opens]] property is specified, and __closed__ oth
     </div>
     <div typeof="rdf:Property" resource="http://schema.org/addressLocality">
       <span class="h" property="rdfs:label">addressLocality</span>
-      <span property="rdfs:comment">The locality. For example, Mountain View.</span>
+      <span property="rdfs:comment">The locality in which street address is, and which is in the region. For example, Mountain View.</span>
       <span>Domain: <a property="http://schema.org/domainIncludes" href="http://schema.org/PostalAddress">PostalAddress</a></span>
       <span>Range: <a property="http://schema.org/rangeIncludes" href="http://schema.org/Text">Text</a></span>
     </div>
     <div typeof="rdf:Property" resource="http://schema.org/addressRegion">
       <span class="h" property="rdfs:label">addressRegion</span>
-      <span property="rdfs:comment">The region. For example, CA.</span>
+      <span property="rdfs:comment">The region in which locality is, and which is in the country. For example, California</span>
       <span>Domain: <a property="http://schema.org/domainIncludes" href="http://schema.org/PostalAddress">PostalAddress</a></span>
       <span>Range: <a property="http://schema.org/rangeIncludes" href="http://schema.org/Text">Text</a></span>
     </div>

--- a/data/schema.rdfa
+++ b/data/schema.rdfa
@@ -3550,13 +3550,13 @@ The place is __open__ if the [[opens]] property is specified, and __closed__ oth
     </div>
     <div typeof="rdf:Property" resource="http://schema.org/addressLocality">
       <span class="h" property="rdfs:label">addressLocality</span>
-      <span property="rdfs:comment">The locality in which street address is, and which is in the region. For example, Mountain View.</span>
+      <span property="rdfs:comment">The locality in which the street address is, and which is in the region. For example, Mountain View.</span>
       <span>Domain: <a property="http://schema.org/domainIncludes" href="http://schema.org/PostalAddress">PostalAddress</a></span>
       <span>Range: <a property="http://schema.org/rangeIncludes" href="http://schema.org/Text">Text</a></span>
     </div>
     <div typeof="rdf:Property" resource="http://schema.org/addressRegion">
       <span class="h" property="rdfs:label">addressRegion</span>
-      <span property="rdfs:comment">The region in which locality is, and which is in the country. For example, California</span>
+      <span property="rdfs:comment">The region in which the locality is, and which is in the country. For example, California</span>
       <span>Domain: <a property="http://schema.org/domainIncludes" href="http://schema.org/PostalAddress">PostalAddress</a></span>
       <span>Range: <a property="http://schema.org/rangeIncludes" href="http://schema.org/Text">Text</a></span>
     </div>


### PR DESCRIPTION
Adds to definitions of postalRegion postalLocality that a street address is in a locality and a locality is in a region. For issue #1848