### PR TITLE
Fix JSON-LD example for availableLanguage

### DIFF
--- a/data/sdo-tourism-examples.txt
+++ b/data/sdo-tourism-examples.txt
@@ -195,10 +195,16 @@ JSON:
 		"addressLocality": "Schwangau",
 		"addressCountry": "Germany"
 	},
-	"availableLanguage": {
-		"@type": "Language",
-		"name": ["German","English"]
-	}
+	"availableLanguage": [
+		{
+			"@type": "Language",
+			"name": "German"
+		},
+		{
+			"@type": "Language",
+			"name": "English"
+		}
+	]
 }
 </script>
 


### PR DESCRIPTION
The intended outcome of the example of availableLanguage was to give 2 available languages. However, in the JSON-LD example currently provided, it would mean it only has 1 available language, but this language has 2 names (German and English). The RDFa example is semantically correct, and therefore I hereby pull request a fix of the JSON-LD example.