### PR TITLE
Fix continuity of URL in AggregateRating example 4

### DIFF
--- a/data/examples.txt
+++ b/data/examples.txt
@@ -230,7 +230,7 @@ MICRODATA:
     <span itemprop="addressRegion">CA</span> <span itemprop="postalCode">94086</span>
   </div>
   <span itemprop="telephone">(408) 714-1489</span>
-  <a itemprop="url" href="http://www.dishdash.com">www.greatfood.com</a>
+  <a itemprop="url" href="http://www.greatfood.com">www.greatfood.com</a>
 
   Hours:
   <meta itemprop="openingHours" content="Mo-Sa 11:00-14:30">Mon-Sat 11am - 2:30pm
@@ -265,7 +265,7 @@ RDFA:
     <span property="addressRegion">CA</span> <span property="postalCode">94086</span>
   </div>
   <span property="telephone">(408) 714-1489</span>
-  <a property="url" href="http://www.dishdash.com">www.greatfood.com</a>
+  <a property="url" href="http://www.greatfood.com">www.greatfood.com</a>
 
   Hours:
   <meta property="openingHours" content="Mo-Sa 11:00-14:30">Mon-Sat 11am - 2:30pm
@@ -314,7 +314,7 @@ JSON:
     "Mediterranean"
   ],
   "telephone": "(408) 714-1489",
-  "url": "http://www.dishdash.com"
+  "url": "http://www.greatfood.com"
 }
 </script>
 


### PR DESCRIPTION
The `url` property in example 4 of AggregateRating doesn't reflect the original "Without Markup" information