### PR TITLE
Display of Equivalent Property/Class links

### DIFF
--- a/apirdflib.py
+++ b/apirdflib.py
@@ -31,6 +31,22 @@ VOCABLEN = 0
 ALTVOCAB = "https://schema.org"
 STORE = rdflib.Dataset()
 #Namespace mapping#############
+EXTERNALNAMESPACES = {
+            'xsd':      'hhttp://www.w3.org/2001/XMLSchema#',
+            'skos':     'http://www.w3.org/2004/02/skos/core#',
+            'owl':      'http://www.w3.org/2002/07/owl#',
+            'rdfa':     'http://www.w3.org/ns/rdfa#',
+            'dct':      'http://purl.org/dc/terms/',
+            'foaf':     'http://xmlns.com/foaf/0.1/',
+            'bibo':     'http://purl.org/ontology/bibo/',
+            'dc':       'http://purl.org/dc/elements/1.1/',
+            'dcterms':  'http://purl.org/dc/terms/',
+            'dctype':   'http://purl.org/dc/dcmitype/',
+            'dcat':     'http://www.w3.org/ns/dcat#',
+            'void':     'http://rdfs.org/ns/void#',
+            'snomed':   'http://purl.bioontology.org/ontology/SNOMEDCT/',
+            'eli':      'http://data.europa.eu/eli/ontology#'
+}
 nss = {'core': 'http://schema.org/'}
 revNss = {}
 NSSLoaded = False
@@ -56,10 +72,10 @@ def queryGraph():
                     if not id.startswith("http://") and not id.startswith("https://"):#skip some internal graphs
                         continue
                     QUERYGRAPH += g 
-                QUERYGRAPH.bind('owl', 'http://www.w3.org/2002/07/owl#')
-                QUERYGRAPH.bind('rdfa', 'http://www.w3.org/ns/rdfa#')
-                QUERYGRAPH.bind('dc', 'http://purl.org/dc/terms/')
-                QUERYGRAPH.bind('schema', 'http://schema.org/')
+                    QUERYGRAPH.bind('schema', 'http://schema.org/')
+                    for prefix in EXTERNALNAMESPACES:
+                        QUERYGRAPH.bind(prefix, EXTERNALNAMESPACES[prefix])
+
                 pre = api.SdoConfig.prefix()
                 path = api.SdoConfig.vocabUri()
                 if pre and path:
@@ -135,6 +151,9 @@ def load_graph(context, files,prefix=None,vocab=None):
             
     namespaceAdd(STORE,prefix=prefix,path=vocab)
     namespaceAdd(STORE,prefix=api.SdoConfig.prefix(),path=api.SdoConfig.vocabUri())
+    for prefix in EXTERNALNAMESPACES:
+        namespaceAdd(STORE,prefix=prefix, path=EXTERNALNAMESPACES[prefix])
+    
         
     nss = STORE.namespaces()
 

--- a/apirdfterm.py
+++ b/apirdfterm.py
@@ -37,7 +37,7 @@ class VTerm():
     REFERENCE = "Reference"
     
     
-    def __init__(self,uri,ttype=None,label=None,layer=None,cat=None):
+    def __init__(self,uri,ttype=None,label='',layer=None,cat=None):
         #log.info('%s %s "%s" %s %s' % (uri,ttype,label, layer, cat))
         uri = str(uri)
         self.uri = uri
@@ -724,7 +724,7 @@ def prefixFromUri(uri):
         pref, pth = n
         if uri.startswith(str(pth)):
             return pref
-    log.debug("Requested unknown namespace uri %s" % uri)
+    log.error("Requested unknown namespace uri %s" % uri)
     return None
     
 def uriForPrefix(pre):
@@ -734,7 +734,7 @@ def uriForPrefix(pre):
         pref, pth = n
         if pre == pref:
             return pth
-    log.debug("Requested unknown prefix %s:" % pre)
+    log.error("Requested unknown prefix %s:" % pre)
     return None
     
     

--- a/data/ext/meta/meta.rdfa
+++ b/data/ext/meta/meta.rdfa
@@ -14,6 +14,7 @@
   <span class="h" property="rdfs:label">Property</span>
   <span property="rdfs:comment">A property, used to indicate attributes and relationships of some Thing; equivalent to rdf:Property.</span>
    <span>Subclass of: <a property="rdfs:subClassOf" href="http://schema.org/Intangible">Intangible</a></span>
+   <link property="owl:equivalentClass" href="http://www.w3.org/1999/02/22-rdf-syntax-ns#Property"/>
 </div>
 
 <div typeof="rdfs:Class" resource="http://schema.org/Class">
@@ -21,6 +22,7 @@
   <span class="h" property="rdfs:label">Class</span>
   <span property="rdfs:comment">A class, also often called a &#39;Type&#39;; equivalent to rdfs:Class.</span>
    <span>Subclass of: <a property="rdfs:subClassOf" href="http://schema.org/Intangible">Intangible</a></span>
+   <link property="owl:equivalentClass" href="http://www.w3.org/2000/01/rdf-schema#Class"/>
 </div>
 
 <div typeof="rdf:Property" resource="http://schema.org/domainIncludes">

--- a/data/schema.rdfa
+++ b/data/schema.rdfa
@@ -12066,8 +12066,8 @@ Typical unit code(s): C62 for person</span>
           <span property="rdfs:comment">A distillery.</span>
           <span>Subclass of: <a property="rdfs:subClassOf" href="http://schema.org/FoodEstablishment">FoodEstablishment</a></span>
           <span>Source:  <a property="dc:source" href="https://github.com/schemaorg/schemaorg/issues/743">#743</a></span>
-          <link itemprop="sameAs" href="http://www.wikidata.org/entity/Q1251750" />
-          <link itemprop="additionalType" href="http://www.productontology.org/id/Distillery" />
+          <link property="sameAs" href="http://www.wikidata.org/entity/Q1251750" />
+          <link property="additionalType" href="http://www.productontology.org/id/Distillery" />
         </div>
 
         <!-- moved in from data/ext/pending/issue-nnnn.rdfa-->

--- a/sdoapp.py
+++ b/sdoapp.py
@@ -650,7 +650,7 @@ class ShowUnit (webapp2.RequestHandler):
             return ""
 
         if ":" in term.getId():
-            return self.external_ml(term)
+            return self.external_ml(term,title=title, prop=prop)
 
         if label=='':
           label = term.getLabel()
@@ -687,7 +687,7 @@ class ShowUnit (webapp2.RequestHandler):
         return "%s<a %s %s href=\"%s%s%s\"%s>%s</a>%s" % (rdfalink,tooltip, extclass, urlprefix, hashorslash, term.getId(), title, label, extflag)
         #return "<a %s %s href=\"%s%s%s\"%s%s>%s</a>%s" % (tooltip, extclass, urlprefix, hashorslash, node.id, prop, title, label, extflag)
 
-    def external_ml(self, term):
+    def external_ml(self, term, title='', prop=''):
         #log.info("EXTERNAL!!!! %s %s " % (term.getLabel(),term.getId()))
 
         name = term.getId()
@@ -715,7 +715,15 @@ class ShowUnit (webapp2.RequestHandler):
             if path:
                 if not path.endswith("#") and not path.endswith("/"):
                     path += "/"
-        return "<a href=\"%s%s\" class=\"externlink\" target=\"_blank\">%s:%s</a>" % (path,val,voc,val)
+        if title != '':
+          title = " title=\"%s\"" % str(title)
+        if prop:
+            prop = " property=\"%s\"" % (prop)
+        rdfalink = ''
+        if prop:
+            rdfalink = '<link %s href="%s%s" />' % (prop,api.SdoConfig.vocabUri(),label)
+            
+        return "%s<a %s href=\"%s%s\" class=\"externlink\" target=\"_blank\">%s:%s</a>" % (rdfalink,title,path,val,voc,val)
 
 
 
@@ -743,6 +751,7 @@ class ShowUnit (webapp2.RequestHandler):
             else:
                 self.write("Defined in the <a href=\"%s\">%s</a> extension.<br/>" % (exthomeurl,exthome))
         self.emitCanonicalURL(term)
+        self.emitEquivalents(term)
 
         self.BreadCrumbs(term)
 
@@ -772,6 +781,20 @@ class ShowUnit (webapp2.RequestHandler):
 
             self.write(" <span class=\"canonicalUrl\">Canonical URL: <a href=\"%s\">%s</a></span> " % (cURL, cURL))
             self.write(sa)
+            
+    def emitEquivalents(self,term):
+            equivs = term.getEquivalents()
+            if len(equivs) > 0:
+                if (term.isClass() or term.isDataType()):
+                    label = "Equivalent Class:"
+                else:
+                    label = "Equivalent Property:"
+                for e in equivs:
+                    eq = VTerm.getTerm(e,createReference=True)
+                    log.info("EQUIVALENT %s %s" % (e,eq))
+                    title = eq.getUri()
+                    self.write("<br/><span class=\"equivalents\">%s %s</span> " % (label,self.ml(eq,title=title)))
+        
 
     # Stacks to support multiple inheritance
     crumbStacks = []

--- a/sdoapp.py
+++ b/sdoapp.py
@@ -572,7 +572,9 @@ class ShowUnit (webapp2.RequestHandler):
 
         feedback_url = FEEDBACK_FORM_BASE_URL.format(term.getUri, term.getType())
         items = [
-
+        self.emitCanonicalURL(term),
+        self.emitEquivalents(term),
+        
         "<a href='{0}'>Leave public feedback on this term &#128172;</a>".format(feedback_url),
         "<a href='https://github.com/schemaorg/schemaorg/issues?q=is%3Aissue+is%3Aopen+{0}'>Check for open issues.</a>".format(term.getId())
 
@@ -586,57 +588,16 @@ class ShowUnit (webapp2.RequestHandler):
         <ul>"""
 
         for i in items:
-            moreinfo += "<li>%s</li>" % i
+            if i and len(i):
+                moreinfo += "<li>%s</li>" % i
 
 #          <li>mappings to other terms.</li>
 #          <li>or links to open issues.</li>
 
         moreinfo += "</ul>\n</div>\n</div>\n"
         return moreinfo
-
-    def getParentNames(self, nodeName, layers):
-
-        ret = [nodeName]
-        node = Unit.GetUnit(nodeName)
-        if node and node.id:
-            sc = Unit.GetUnit("rdfs:subClassOf")
-            targs = GetTargets(sc, node, layers=layers)
-            if targs:
-                for p in targs:
-                    ret.extend(self.getParentNames(p.id, layers=layers))
-
-
-        return ret
-
-    def GetParentStack(self, node, layers='core'):
-        """Returns a hiearchical structured used for site breadcrumbs."""
-        thing = Unit.GetUnit("schema:Thing")
-        #log.info("GetParentStack for: %s",node)
-        if not node:
-            return
-
-        if (node not in self.parentStack):
-            self.parentStack.append(node)
-
-        if (Unit.isAttribute(node, layers=layers)):
-            self.parentStack.append(Unit.GetUnit("schema:Property"))
-            self.parentStack.append(thing)
-
-        sc = Unit.GetUnit("rdfs:subClassOf")
-        if GetTargets(sc, node, layers=layers):
-            for p in GetTargets(sc, node, layers=layers):
-                self.GetParentStack(p, layers=layers)
-        else:
-            # Enumerations are classes that have no declared subclasses
-            sc = Unit.GetUnit("rdf:type")
-            for p in GetTargets(sc, node, layers=layers):
-                self.GetParentStack(p, layers=layers)
-
-#Put 'Thing' to the end for multiple inheritance classes
-        if(thing in self.parentStack):
-            self.parentStack.remove(thing)
-            self.parentStack.append(thing)
-
+        
+        
 
     def ml(self, term, label='', title='', prop='', hashorslash='/'):
         """ml ('make link')
@@ -750,8 +711,11 @@ class ShowUnit (webapp2.RequestHandler):
                 self.write("Defined in the <a href=\"%s\">%s</a> archive area.<br/><strong>Use of this term is not advised</strong><br/>" % (exthomeurl,exthome))
             else:
                 self.write("Defined in the <a href=\"%s\">%s</a> extension.<br/>" % (exthomeurl,exthome))
-        self.emitCanonicalURL(term)
-        self.emitEquivalents(term)
+        if not ENABLEMOREINFO:
+            self.write(self.emitCanonicalURL(term))
+            eq = self.emitEquivalents(term)
+            if eq and len(eq):
+                self.write()
 
         self.BreadCrumbs(term)
 
@@ -766,10 +730,11 @@ class ShowUnit (webapp2.RequestHandler):
             self.write(self.moreInfoBlock(term))
 
     def emitCanonicalURL(self,term):
+        out = ""
         site = SdoConfig.vocabUri()
         if site != "http://schema.org":
             cURL = "%s%s" % (site,term.getId())
-            self.write(" <span class=\"canonicalUrl\">Canonical URL: %s</span> " % (cURL))
+            output = " <span class=\"canonicalUrl\">Canonical URL: %s</span> " % (cURL)
         else:
 
             cURL = "%s://schema.org/%s" % (CANONICALSCHEME,term.getId())
@@ -778,23 +743,27 @@ class ShowUnit (webapp2.RequestHandler):
             else:
                 other = "http"
             sa = '\n<link  property="sameAs" href="%s://schema.org/%s" />' % (other,term.getId())
-
-            self.write(" <span class=\"canonicalUrl\">Canonical URL: <a href=\"%s\">%s</a></span> " % (cURL, cURL))
             self.write(sa)
+
+            output = " <span class=\"canonicalUrl\">Canonical URL: <a href=\"%s\">%s</a></span> " % (cURL, cURL)
+        return output
             
     def emitEquivalents(self,term):
-            equivs = term.getEquivalents()
-            if len(equivs) > 0:
-                if (term.isClass() or term.isDataType()):
-                    label = "Equivalent Class:"
-                else:
-                    label = "Equivalent Property:"
-                for e in equivs:
-                    eq = VTerm.getTerm(e,createReference=True)
-                    log.info("EQUIVALENT %s %s" % (e,eq))
-                    title = eq.getUri()
-                    self.write("<br/><span class=\"equivalents\">%s %s</span> " % (label,self.ml(eq,title=title)))
-        
+        buff = StringIO.StringIO()
+        equivs = term.getEquivalents()
+        if len(equivs) > 0:
+            if (term.isClass() or term.isDataType()):
+                label = "Equivalent Class:"
+            else:
+                label = "Equivalent Property:"
+            br = ""
+            for e in equivs:
+                eq = VTerm.getTerm(e,createReference=True)
+                log.info("EQUIVALENT %s %s" % (e,eq))
+                title = eq.getUri()
+                buff.write("%s<span class=\"equivalents\">%s %s</span> " % (br,label,self.ml(eq,title=title)))
+                br = "<br/>"
+        return buff.getvalue()
 
     # Stacks to support multiple inheritance
     crumbStacks = []


### PR DESCRIPTION
Cleaned up and enabled code for the display of Equivalent Property/Class links. Displayed references are clickable taking user to the URI of the equivalent Property or Class.

**Example display formats:**
Equivalent Class: [dctype:Event](http://purl.org/dc/dcmitype/Event)
Equivalent Property: [dcterms:identifier](http://purl.org/dc/terms/identifier)

For terms without equvalent links nothing is displayed 

Most of code was already in place - we already output ```owl:equivalentClass``` & ```owl:equivalentProperty``` references in the on page rdfa, and in other dump formats.

Most terms only have only one equivalent - (Dataset has three)
### Sample output
#### identifier:
![image](https://user-images.githubusercontent.com/13315406/53243360-7f014380-369f-11e9-80a6-73da9d2e95a0.png)

#### Class
![image](https://user-images.githubusercontent.com/13315406/53243806-f1beee80-36a0-11e9-94b4-e682ef43a26d.png)

#### legislationType
![image](https://user-images.githubusercontent.com/13315406/53243859-0bf8cc80-36a1-11e9-8e95-6375cf4a7969.png)

#### Dataset
![image](https://user-images.githubusercontent.com/13315406/53244043-96d9c700-36a1-11e9-988d-dd3fc4c3ce3f.png)

#### Event
![image](https://user-images.githubusercontent.com/13315406/53243899-36e32080-36a1-11e9-9607-0ad773e264c8.png)

#### issn
![image](https://user-images.githubusercontent.com/13315406/53243935-4ebaa480-36a1-11e9-93d6-16fec141298b.png)


