### PR TITLE
Added number formatting advice to Number and relevant properties

### DIFF
--- a/data/schema.rdfa
+++ b/data/schema.rdfa
@@ -883,7 +883,7 @@ See also the &lt;a href=&quot;/docs/hotels.html&quot;&gt;dedicated document on t
 
     <div typeof="rdfs:Class http://schema.org/DataType" resource="http://schema.org/Number">
       <span class="h" property="rdfs:label">Number</span>
-      <span property="rdfs:comment">Data type: Number.</span>
+      <span property="rdfs:comment">Data type: Number.\n\nUsage guidelines:\n\n* Use values from 0123456789 (Unicode 'DIGIT ZERO' (U+0030) to 'DIGIT NINE' (U+0039)) rather than superficially similiar Unicode symbols.\n* Use '.' (Unicode 'FULL STOP' (U+002E)) rather than ',' to indicate a decimal point. Avoid using these symbols as a readability separator.</span>
     </div>
 
     <div typeof="rdfs:Class" resource="http://schema.org/Float">
@@ -5205,7 +5205,7 @@ Unregistered or niche encoding and file formats can be indicated instead via the
     </div>
     <div typeof="rdf:Property" resource="http://schema.org/highPrice">
       <span class="h" property="rdfs:label">highPrice</span>
-      <span property="rdfs:comment">The highest price of all offers available.</span>
+      <span property="rdfs:comment">The highest price of all offers available.\n\nUsage guidelines:\n\n* Use values from 0123456789 (Unicode 'DIGIT ZERO' (U+0030) to 'DIGIT NINE' (U+0039)) rather than superficially similiar Unicode symbols.\n* Use '.' (Unicode 'FULL STOP' (U+002E)) rather than ',' to indicate a decimal point. Avoid using these symbols as a readability separator.</span>
       <span>Domain: <a property="http://schema.org/domainIncludes" href="http://schema.org/AggregateOffer">AggregateOffer</a></span>
       <span>Range: <a property="http://schema.org/rangeIncludes" href="http://schema.org/Number">Number</a></span>
       <span>Range: <a property="http://schema.org/rangeIncludes" href="http://schema.org/Text">Text</a></span>
@@ -5659,7 +5659,7 @@ Unregistered or niche encoding and file formats can be indicated instead via the
     </div>
     <div typeof="rdf:Property" resource="http://schema.org/lowPrice">
       <span class="h" property="rdfs:label">lowPrice</span>
-      <span property="rdfs:comment">The lowest price of all offers available.</span>
+      <span property="rdfs:comment">The lowest price of all offers available.\n\nUsage guidelines:\n\n* Use values from 0123456789 (Unicode 'DIGIT ZERO' (U+0030) to 'DIGIT NINE' (U+0039)) rather than superficially similiar Unicode symbols.\n* Use '.' (Unicode 'FULL STOP' (U+002E)) rather than ',' to indicate a decimal point. Avoid using these symbols as a readability separator.</span>
       <span>Domain: <a property="http://schema.org/domainIncludes" href="http://schema.org/AggregateOffer">AggregateOffer</a></span>
       <span>Range: <a property="http://schema.org/rangeIncludes" href="http://schema.org/Number">Number</a></span>
       <span>Range: <a property="http://schema.org/rangeIncludes" href="http://schema.org/Text">Text</a></span>
@@ -6512,7 +6512,7 @@ While such policies are most typically expressed in natural language, sometimes 
     </div>
     <div typeof="rdf:Property" resource="http://schema.org/ratingValue">
       <span class="h" property="rdfs:label">ratingValue</span>
-      <span property="rdfs:comment">The rating for the content.</span>
+      <span property="rdfs:comment">The rating for the content.\n\nUsage guidelines:\n\n* Use values from 0123456789 (Unicode 'DIGIT ZERO' (U+0030) to 'DIGIT NINE' (U+0039)) rather than superficially similiar Unicode symbols.\n* Use '.' (Unicode 'FULL STOP' (U+002E)) rather than ',' to indicate a decimal point. Avoid using these symbols as a readability separator.</span>
       <span>Domain: <a property="http://schema.org/domainIncludes" href="http://schema.org/Rating">Rating</a></span>
       <span>Range: <a property="http://schema.org/rangeIncludes" href="http://schema.org/Text">Text</a></span>
       <span>Range: <a property="http://schema.org/rangeIncludes" href="http://schema.org/Number">Number</a></span>
@@ -7449,7 +7449,7 @@ Open-ended date ranges can be written with ".." in place of the end date. For ex
     </div>
     <div typeof="rdf:Property" resource="http://schema.org/value">
       <span class="h" property="rdfs:label">value</span>
-      <span property="rdfs:comment">The value of the quantitative value or property value node.\n\n* For [[QuantitativeValue]] and [[MonetaryAmount]], the recommended type for values is &apos;Number&apos;.\n* For [[PropertyValue]], it can be &apos;Text;&apos;, &apos;Number&apos;, &apos;Boolean&apos;, or &apos;StructuredValue&apos;.</span>
+      <span property="rdfs:comment">The value of the quantitative value or property value node.\n\n* For [[QuantitativeValue]] and [[MonetaryAmount]], the recommended type for values is &apos;Number&apos;.\n* For [[PropertyValue]], it can be &apos;Text;&apos;, &apos;Number&apos;, &apos;Boolean&apos;, or &apos;StructuredValue&apos;.\n* Use values from 0123456789 (Unicode 'DIGIT ZERO' (U+0030) to 'DIGIT NINE' (U+0039)) rather than superficially similiar Unicode symbols.\n* Use '.' (Unicode 'FULL STOP' (U+002E)) rather than ',' to indicate a decimal point. Avoid using these symbols as a readability separator.</span>
       <span>Domain: <a property="http://schema.org/domainIncludes" href="http://schema.org/QuantitativeValue">QuantitativeValue</a></span>
 	  <span>Domain: <a property="http://schema.org/domainIncludes" href="http://schema.org/PropertyValue">PropertyValue</a></span>
       <span>Domain: <a property="http://schema.org/domainIncludes" href="http://schema.org/MonetaryAmount">MonetaryAmount</a></span>
@@ -7915,7 +7915,7 @@ Open-ended date ranges can be written with ".." in place of the end date. For ex
     </div>
     <div typeof="rdf:Property" resource="http://schema.org/totalPrice">
       <span class="h" property="rdfs:label">totalPrice</span>
-      <span property="rdfs:comment">The total price for the reservation or ticket, including applicable taxes, shipping, etc.</span>
+      <span property="rdfs:comment">The total price for the reservation or ticket, including applicable taxes, shipping, etc.\n\nUsage guidelines:\n\n* Use values from 0123456789 (Unicode 'DIGIT ZERO' (U+0030) to 'DIGIT NINE' (U+0039)) rather than superficially similiar Unicode symbols.\n* Use '.' (Unicode 'FULL STOP' (U+002E)) rather than ',' to indicate a decimal point. Avoid using these symbols as a readability separator.</span>
       <span>domain: <a property="http://schema.org/domainIncludes" href="http://schema.org/Reservation">Reservation</a></span>
       <span>domain: <a property="http://schema.org/domainIncludes" href="http://schema.org/Ticket">Ticket</a></span>
       <span>Range: <a property="http://schema.org/rangeIncludes" href="http://schema.org/Number">Number</a></span>


### PR DESCRIPTION
Added usage advice to  [Number](https://schema.org/Number) and a small number of relevant properties that expect 'Text' & 'Number' ([ratingValue](https://schema.org/ratingValue), [value](https://schema.org/value), [lowPrice](https://schema.org/lowPrice),[highPrice](https://schema.org/highPrice),[totalPrice](https://schema.org/totaPrice)).

Addresses issue #2166 