### PR TITLE
Move spatial and temporal properties to CreativeWork and generalise descriptions

### DIFF
--- a/data/schema.rdfa
+++ b/data/schema.rdfa
@@ -6999,9 +6999,9 @@ While such policies are most typically expressed in natural language, sometimes 
     </div>
     <div typeof="rdf:Property" resource="http://schema.org/spatial">
       <span class="h" property="rdfs:label">spatial</span>
-      <span property="rdfs:comment">The range of spatial applicability of a dataset, e.g. for a dataset of New York weather, the state of New York.</span>
-      <link property="http://schema.org/supersededBy" href="http://schema.org/spatialCoverage"/>
-      <span>Domain: <a property="http://schema.org/domainIncludes" href="http://schema.org/Dataset">Dataset</a></span>
+      <span property="rdfs:comment">The "spatial" property can be used in cases when more specific properties
+(e.g. [[locationCreated]], [[spatialCoverage]], [[contentLocation]]) are not known to be appropriate.</span>
+      <span>Domain: <a property="http://schema.org/domainIncludes" href="http://schema.org/CreativeWork">CreativeWork</a></span>
       <span>Range: <a property="http://schema.org/rangeIncludes" href="http://schema.org/Place">Place</a></span>
       <link property="owl:equivalentProperty" href="http://purl.org/dc/terms/spatial"/>
     </div>
@@ -7250,10 +7250,11 @@ Open-ended date ranges can be written with ".." in place of the end date. For ex
     </div>
     <div typeof="rdf:Property" resource="http://schema.org/temporal">
       <span class="h" property="rdfs:label">temporal</span>
-      <link property="http://schema.org/supersededBy" href="http://schema.org/temporalCoverage"/>
-      <span property="rdfs:comment">The range of temporal applicability of a dataset, e.g. for a 2011 census dataset, the year 2011 (in ISO 8601 time interval format).</span>
-      <span>Domain: <a property="http://schema.org/domainIncludes" href="http://schema.org/Dataset">Dataset</a></span>
+      <span property="rdfs:comment">The "temporal" property can be used in cases where more specific properties
+(e.g. [[temporalCoverage]], [[dateCreated]], [[dateModified]], [[datePublished]]) are not known to be appropriate.</span>
+      <span>Domain: <a property="http://schema.org/domainIncludes" href="http://schema.org/CreativeWork">CreativeWork</a></span>
       <span>Range: <a property="http://schema.org/rangeIncludes" href="http://schema.org/DateTime">DateTime</a></span>
+      <span>Range: <a property="http://schema.org/rangeIncludes" href="http://schema.org/Text">Text</a></span>
     </div>
     <div typeof="rdf:Property" resource="http://schema.org/datasetTimeInterval">
       <span class="h" property="rdfs:label">datasetTimeInterval</span>

--- a/docs/releases.html
+++ b/docs/releases.html
@@ -257,6 +257,10 @@ Noted that <a href="/encodesCreativeWork">encodesCreativeWork</a> is inverseOf <
 Added <a href="/startOffset">startOffset</a> and <a href="/endOffset">endOffset</a> to <a href="/Clip">Clip</a>.
 </li>
 
+<li id="g1765"><a href="https://github.com/schemaorg/schemaorg/issues/1765">Issue #1765</a>:
+Removed superseded status from and generalised descriptions for <a href="/spatial">spatial</a> and <a href="/temporal">temporal</a> properties plus expanded range to <a href="/CreativeWork">CreativeWork</a>.
+</li>
+
 </ul>
 
 <h3>Changes in <a href="http://pending.schema.org/">Pending</a> section:</h3>


### PR DESCRIPTION
Removed superseded status from and generalised descriptions for spatial and temporal properties plus expanded their range to CreativeWork.

Implements Issue #1765.
