### PR TITLE
Travis enhancements to run against latest release status.

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -18,7 +18,7 @@ before_script:
   - bundle install --gemfile=scripts/Gemfile
 script:
   - xmllint --noout data/*.rdfa data/ext/*/*.rdfa
-  - scripts/buildreleasefiles.sh -y -l "nquads nt" LATEST
+  - scripts/buildreleasefiles.sh -y -e -l "nquads nt" LATEST
   - python scripts/run_tests.py
   - (cd scripts; bundle exec rake)
 sudo: false

--- a/.travis.yml
+++ b/.travis.yml
@@ -18,8 +18,8 @@ before_script:
   - bundle install --gemfile=scripts/Gemfile
 script:
   - xmllint --noout data/*.rdfa data/ext/*/*.rdfa
-  - python scripts/run_tests.py
   - scripts/buildreleasefiles.sh "LATEST" "yes"
+  - python scripts/run_tests.py
   - (cd scripts; bundle exec rake)
 sudo: false
 cache: bundler

--- a/.travis.yml
+++ b/.travis.yml
@@ -19,7 +19,7 @@ before_script:
 script:
   - xmllint --noout data/*.rdfa data/ext/*/*.rdfa
   - python scripts/run_tests.py
-  - scripts/buildreleasefiles.sh LATEST yes
+  - scripts/buildreleasefiles.sh "LATEST" "yes"
   - (cd scripts; bundle exec rake)
 sudo: false
 cache: bundler

--- a/.travis.yml
+++ b/.travis.yml
@@ -18,7 +18,7 @@ before_script:
   - bundle install --gemfile=scripts/Gemfile
 script:
   - xmllint --noout data/*.rdfa data/ext/*/*.rdfa
-  - scripts/buildreleasefiles.sh -y -l "nq nt" LATEST
+  - scripts/buildreleasefiles.sh -y -l "nquads nt" LATEST
   - python scripts/run_tests.py
   - (cd scripts; bundle exec rake)
 sudo: false

--- a/.travis.yml
+++ b/.travis.yml
@@ -18,7 +18,7 @@ before_script:
   - bundle install --gemfile=scripts/Gemfile
 script:
   - xmllint --noout data/*.rdfa data/ext/*/*.rdfa
-  - scripts/buildreleasefiles.sh "LATEST" "yes"
+  - scripts/buildreleasefiles.sh LATEST yes
   - python scripts/run_tests.py
   - (cd scripts; bundle exec rake)
 sudo: false

--- a/.travis.yml
+++ b/.travis.yml
@@ -6,6 +6,8 @@ env:
   global:
     - SOFT_LINT=true
     - NOKOGIRI_USE_SYSTEM_LIBRARIES=true
+before_install:
+  - sudo apt-get install -y libxml2-utils
 before_script:
   - SDK_URL=https://storage.googleapis.com/appengine-sdks/featured/google_appengine_1.9.49.zip
   - wget $SDK_URL -nv -O google_appengine.zip
@@ -14,11 +16,9 @@ before_script:
   - export PYTHONPATH=$PYTHONPATH:$TRAVIS_BUILD_DIR/google_appengine/
   - rvm install 2.4.0
   - bundle install --gemfile=scripts/Gemfile
-  - wget https://github.com/validator/validator/releases/download/17.9.0/vnu.jar_17.9.0.zip
-  - unzip -q vnu.jar_17.9.0.zip
 script:
+  - xmllint --noout data/*.rdfa data/ext/*/*.rdfa
   - python scripts/run_tests.py
   - (cd scripts; bundle exec rake)
-  - java -jar dist/vnu.jar data/schema.rdfa
 sudo: false
 cache: bundler

--- a/.travis.yml
+++ b/.travis.yml
@@ -19,6 +19,7 @@ before_script:
 script:
   - xmllint --noout data/*.rdfa data/ext/*/*.rdfa
   - python scripts/run_tests.py
+  - scripts/buildreleasefiles.sh LATEST yes
   - (cd scripts; bundle exec rake)
 sudo: false
 cache: bundler

--- a/.travis.yml
+++ b/.travis.yml
@@ -18,7 +18,7 @@ before_script:
   - bundle install --gemfile=scripts/Gemfile
 script:
   - xmllint --noout data/*.rdfa data/ext/*/*.rdfa
-  - scripts/buildreleasefiles.sh LATEST yes
+  - scripts/buildreleasefiles.sh -y -l "nq nt" LATEST
   - python scripts/run_tests.py
   - (cd scripts; bundle exec rake)
 sudo: false

--- a/scripts/Rakefile
+++ b/scripts/Rakefile
@@ -87,7 +87,7 @@ task vocab: "spec/schema.rb"
 
 file "spec/schema.rb" => :do_build do
   #rel = Dir.glob(File.expand_path("../../data/releases/*", __FILE__)).last
-  rel = Dir.glob(File.expand_path("../../data/releases/LATES", __FILE__)).last
+  rel = Dir.glob(File.expand_path("../../data/releases/LATEST", __FILE__)).last
   puts "Generate spec/schema.rb"
   cmd = "bundle exec rdf"
   cmd += " serialize --uri http://schema.org/ --output-format vocabulary"

--- a/scripts/Rakefile
+++ b/scripts/Rakefile
@@ -86,7 +86,8 @@ desc "Create custom pre-compiled vocabulary"
 task vocab: "spec/schema.rb"
 
 file "spec/schema.rb" => :do_build do
-  rel = Dir.glob(File.expand_path("../../data/releases/*", __FILE__)).last
+  #rel = Dir.glob(File.expand_path("../../data/releases/*", __FILE__)).last
+  rel = Dir.glob(File.expand_path("../../data/releases/LATES", __FILE__)).last
   puts "Generate spec/schema.rb"
   cmd = "bundle exec rdf"
   cmd += " serialize --uri http://schema.org/ --output-format vocabulary"

--- a/scripts/buildreleasefiles.sh
+++ b/scripts/buildreleasefiles.sh
@@ -19,9 +19,12 @@ pre=$2
 echo "PRE: $pre"
 response=""
 
-if [ "$#" -eq 2 ] && [ "$pre" == "yes" ]
+if [ "$#" -eq 2 ] 
 then
-    response="Y"
+    if [ "$pre" == "yes" ]
+    then
+        response="Y"
+    fi
 fi
 
 if [ -z "$response" ]

--- a/scripts/buildreleasefiles.sh
+++ b/scripts/buildreleasefiles.sh
@@ -1,4 +1,7 @@
 #!/bin/bash
+set -e
+set -u
+
 EXTENSIONS="attic auto bib health-lifesci pending meta"
 PWD=`pwd`
 PROG="`basename $0`"
@@ -7,39 +10,78 @@ then
 	echo "Not in the schemaorg directory! Aborting"
 	exit 1
 fi
+
+function usage {
+    echo "usage: $(basename $0) [-y] [-e] [-c] [-o] [-limit somevalue] VERSION"
+    echo "    -y   Assume yes to continue"
+    echo "    -e   No extentstions (only produce core and all-layers)"
+    echo "    -c   No context file"
+    echo "    -o   No owl file"
+    echo "    -l   \"Output types\" (json-ld|turtle|nt|nquads|rdf|csv)" 
+}
+
 if [ "$#" -lt 1 ]
 then
-  echo "Usage: $0 VERSION [yes]" 
+usage
   exit 1
 fi
+
+LIMIT=""
+AUTORUN=0
+CONTEXT=1
+OWL=1
+EXTS=1
+while getopts 'yecol:' OPTION; do
+  case "$OPTION" in
+    y)
+        AUTORUN=1
+        echo "Run unchallenged"
+    ;;
+
+    c)
+        CONTEXT=0
+    ;;
+
+    o)
+        OWL=0
+    ;;
+    
+    e)
+        EXTS=0
+    ;;
+
+
+    l)
+        LIMIT="$OPTARG"
+        echo "The limit value provided is $OPTARG"
+    ;;
+    ?)
+        usage 
+        exit 1
+    ;;
+  esac
+done
+shift "$(($OPTIND -1))"
+VER="$*"
+
+
 VER=$1
 DIR="./data/releases/$1"
 
-pre=$2
-echo "PRE: $pre"
-response=""
 
-if [ "$#" -eq 2 ] 
-then
-    if [ "$pre" == 'yes' ]
-    then
-        response="Y"
-    fi
-fi
-
-if [ -z "$response" ]
+if [ $AUTORUN -eq 0 ]
 then
     echo "$PROG:\n\tAbout to build release files for version $VER  \n\tIncluding extensions: $EXTENSIONS"
     read -r -p  "Continue? y/n: " response
+    case $response in
+    	[yY])
+    		AUTORUN=1
+    	;;
+    	*)
+    		echo "Aborting!"
+    	exit 0
+    esac
 fi
-case $response in
-	[yY])
-		echo
-	;;
-	*)
-		echo "Aborting!"
-	exit 0
-esac
 
 if [ ! -d  $DIR ]
 then
@@ -72,34 +114,52 @@ function dump {
 		ex2="extensions"
 	fi
 	file=$3
+    LIMIT=$4
 	forms=""
-    for form in json-ld turtle nt nquads rdf csv
-	do
-        forms="$forms -f $form"
+    if [ -z "$LIMIT" ]
+    then
+        for form in json-ld turtle nt nquads rdf csv
+    	do
+            forms="$forms -f $form"
         
-    done
+        done
+    else
+        forms=$LIMIT
+    fi
+    
 	./scripts/exportgraphs.py -i "$in" -e "$ex1" -e "$ex2" -g "#$VER" $forms -o $DIR/$file 2>&1 > /dev/null
 }
 
 echo
 echo "Creating core: "
-dump core extensions schema
+dump core extensions schema "$LIMIT"
+
 echo
 echo "Creating all-layers: "
-dump "" "" all-layers
-for e in $EXTENSIONS
-do
-	echo
-	echo "Creating $e"
-	dump "$e" "ALL" "ext-$e"
-done
+dump "" "" all-layers "$LIMIT"
 
-echo "Creating archive context file"
+if [ $EXTS -eq 1 ]
+then
+    for e in $EXTENSIONS
+    do
+    	echo
+    	echo "Creating $e"
+    	dump "$e" "ALL" "ext-$e" "$LIMIT"
+    done
+fi
 
-./scripts/buildarchivecontext.py -o schemaorgcontext.jsonld -d $DIR
 
-echo "creating owl file"
-./scripts/buildowlfile.py
+if [ $CONTEXT -eq 1 ]
+then
+    echo "Creating archive context file"
+    ./scripts/buildarchivecontext.py -o schemaorgcontext.jsonld -d $DIR
+fi
+
+if [ $OWL -eq 1 ]
+then
+    echo "creating owl file"
+    ./scripts/buildowlfile.py
+fi
 echo done
 
 

--- a/scripts/buildreleasefiles.sh
+++ b/scripts/buildreleasefiles.sh
@@ -21,7 +21,7 @@ response=""
 
 if [ "$#" -eq 2 ] 
 then
-    if [ "$pre" == "yes" ]
+    if [ "$pre" -eq "yes" ]
     then
         response="Y"
     fi

--- a/scripts/buildreleasefiles.sh
+++ b/scripts/buildreleasefiles.sh
@@ -21,7 +21,7 @@ response=""
 
 if [ "$#" -eq 2 ] 
 then
-    if [ "$pre" -eq "yes" ]
+    if [ "$pre" == 'yes' ]
     then
         response="Y"
     fi

--- a/scripts/buildreleasefiles.sh
+++ b/scripts/buildreleasefiles.sh
@@ -1,4 +1,4 @@
-#!/bin/sh
+#!/bin/bash
 EXTENSIONS="attic auto bib health-lifesci pending meta"
 PWD=`pwd`
 PROG="`basename $0`"

--- a/scripts/buildreleasefiles.sh
+++ b/scripts/buildreleasefiles.sh
@@ -16,7 +16,7 @@ VER=$1
 DIR="./data/releases/$1"
 
 pre=$2
-echo "$preS"
+echo "PRE: $pre"
 response=""
 
 if [ "$#" -eq 2 ] && [ "$pre" == "yes" ]

--- a/scripts/buildreleasefiles.sh
+++ b/scripts/buildreleasefiles.sh
@@ -124,7 +124,11 @@ function dump {
         
         done
     else
-        forms=$LIMIT
+        for form in $LIMIT
+    	do
+            forms="$forms -f $form"
+        
+        done
     fi
     
 	./scripts/exportgraphs.py -i "$in" -e "$ex1" -e "$ex2" -g "#$VER" $forms -o $DIR/$file 2>&1 > /dev/null

--- a/scripts/buildreleasefiles.sh
+++ b/scripts/buildreleasefiles.sh
@@ -15,9 +15,11 @@ fi
 VER=$1
 DIR="./data/releases/$1"
 
+pre=$2
+echo "$preS"
 response=""
 
-if [ "$#" -eq 2 ] && [ "$2" == "yes" ]
+if [ "$#" -eq 2 ] && [ "$pre" == "yes" ]
 then
     response="Y"
 fi

--- a/scripts/buildreleasefiles.sh
+++ b/scripts/buildreleasefiles.sh
@@ -15,7 +15,9 @@ fi
 VER=$1
 DIR="./data/releases/$1"
 
-if [ "$#" -eq 2 ] && [ $2 == "yes" ]
+response=""
+
+if [ "$#" -eq 2 ] && [ "$2" == "yes" ]
 then
     response="Y"
 fi


### PR DESCRIPTION
Travis scripts previously used dump files from previous release to validate against.  This is because the release version is not changed until release time.  This produced spurious errors around vocabulary changes in the [new] version being checked.

Updated scripts to create a temporary latest release version for Travis scripts to work with.

Results in reduced warning messages especially from examples referencing non-existent terms.

Also replaced use of html validator with xmlint to check structure of .rdfa files (validator enforces html syntax not used in many extension .rdfa files).   Expanded this syntax checking to all .rdfa files.