### PR TITLE
Extended estimatedSalary range to include MonetaryAmount & Number

### DIFF
--- a/data/schema.rdfa
+++ b/data/schema.rdfa
@@ -11814,6 +11814,8 @@ we define a supporting type, [[SpeakableSpecification]]  which is defined to be 
         <span property="rdfs:comment">An estimated salary for a job posting or occupation, based on a variety of variables including, but not limited to industry, job title, and location. Estimated salaries  are often computed by outside organizations rather than the hiring organization, who may not have committed to the estimated value.</span>
         <span>Domain: <a property="http://schema.org/domainIncludes" href="http://schema.org/Occupation">Occupation</a></span>
         <span>Domain: <a property="http://schema.org/domainIncludes" href="http://schema.org/JobPosting">JobPosting</a></span>
+        <span>Range: <a property="http://schema.org/rangeIncludes" href="http://schema.org/Number">Number</a></span>
+        <span>Range: <a property="http://schema.org/rangeIncludes" href="http://schema.org/MonetaryAmount">MonetaryAmount</a></span>
         <span>Range: <a property="http://schema.org/rangeIncludes" href="http://schema.org/MonetaryAmountDistribution">MonetaryAmountDistribution</a></span>
         <span property="schema:category">issue-1698</span>
         <a property="dc:source" href="https://github.com/schemaorg/schemaorg/issues/1698"></a>


### PR DESCRIPTION
Fixes Issue #2251 

Text for releases file:
```

<li id="g2251"><a href="https://github.com/schemaorg/schemaorg/issues/2251">Issue #2251</a>:
Extended rangeIncludes for property <a href="/estimatedSalary">estimatedSalary</a> to include <a href="/MonetaryAmount">MonetaryAmount</a> and <a href="/Number">Number</a>.
</li>

```