### PR TITLE
Fixed inconsistencies in expected types for Date & Time expecting properties

### DIFF
--- a/data/schema.rdfa
+++ b/data/schema.rdfa
@@ -3819,6 +3819,7 @@ The place is __open__ if the [[opens]] property is specified, and __closed__ oth
       <span>Domain: <a property="http://schema.org/domainIncludes" href="http://schema.org/Offer">Offer</a></span>
       <span>Domain: <a property="http://schema.org/domainIncludes" href="http://schema.org/Demand">Demand</a></span>
       <span>Range: <a property="http://schema.org/rangeIncludes" href="http://schema.org/DateTime">DateTime</a></span>
+      <span>Range: <a property="http://schema.org/rangeIncludes" href="http://schema.org/Date">Date</a></span>
     </div>
     <div typeof="rdf:Property" resource="http://schema.org/availabilityStarts">
       <span class="h" property="rdfs:label">availabilityStarts</span>
@@ -3826,6 +3827,7 @@ The place is __open__ if the [[opens]] property is specified, and __closed__ oth
       <span>Domain: <a property="http://schema.org/domainIncludes" href="http://schema.org/Offer">Offer</a></span>
       <span>Domain: <a property="http://schema.org/domainIncludes" href="http://schema.org/Demand">Demand</a></span>
       <span>Range: <a property="http://schema.org/rangeIncludes" href="http://schema.org/DateTime">DateTime</a></span>
+      <span>Range: <a property="http://schema.org/rangeIncludes" href="http://schema.org/Date">Date</a></span>
     </div>
     <div typeof="rdf:Property" resource="http://schema.org/availableAtOrFrom">
       <span class="h" property="rdfs:label">availableAtOrFrom</span>
@@ -4463,6 +4465,7 @@ Dateline summaries are oriented more towards human readers than towards automate
       <span property="rdfs:comment">The datetime the item was removed from the DataFeed.</span>
       <span>Domain: <a property="http://schema.org/domainIncludes" href="http://schema.org/DataFeedItem">DataFeedItem</a></span>
       <span>Range: <a property="http://schema.org/rangeIncludes" href="http://schema.org/DateTime">DateTime</a></span>
+      <span>Range: <a property="http://schema.org/rangeIncludes" href="http://schema.org/Date">Date</a></span>
     </div>
     <div typeof="rdf:Property" resource="http://schema.org/dateModified">
       <span class="h" property="rdfs:label">dateModified</span>
@@ -4658,6 +4661,7 @@ Dateline summaries are oriented more towards human readers than towards automate
       <span property="rdfs:comment">The time admission will commence.</span>
       <span>Domain: <a property="http://schema.org/domainIncludes" href="http://schema.org/Event">Event</a></span>
       <span>Range: <a property="http://schema.org/rangeIncludes" href="http://schema.org/DateTime">DateTime</a></span>
+      <span>Range: <a property="http://schema.org/rangeIncludes" href="http://schema.org/Time">Time</a></span>
     </div>
 
     <div typeof="rdf:Property" resource="http://schema.org/downloadUrl">
@@ -4870,6 +4874,7 @@ Unregistered or niche encoding and file formats can be indicated instead via the
       <span>Domain: <a property="http://schema.org/domainIncludes" href="http://schema.org/FoodEstablishmentReservation">FoodEstablishmentReservation</a></span>
       <span>Domain: <a property="http://schema.org/domainIncludes" href="http://schema.org/MediaObject">MediaObject</a></span>
       <span>Range: <a property="http://schema.org/rangeIncludes" href="http://schema.org/DateTime">DateTime</a></span>
+      <span>Range: <a property="http://schema.org/rangeIncludes" href="http://schema.org/Time">Time</a></span>
     </div>
    <div typeof="rdf:Property" resource="http://schema.org/entertainmentBusiness">
       <span class="h" property="rdfs:label">entertainmentBusiness</span>
@@ -4951,12 +4956,14 @@ Unregistered or niche encoding and file formats can be indicated instead via the
       <span property="rdfs:comment">The earliest date the package may arrive.</span>
       <span>Domain: <a property="http://schema.org/domainIncludes" href="http://schema.org/ParcelDelivery">ParcelDelivery</a></span>
       <span>Range: <a property="http://schema.org/rangeIncludes" href="http://schema.org/DateTime">DateTime</a></span>
+      <span>Range: <a property="http://schema.org/rangeIncludes" href="http://schema.org/Date">Date</a></span>
     </div>
     <div typeof="rdf:Property" resource="http://schema.org/expectedArrivalUntil">
       <span class="h" property="rdfs:label">expectedArrivalUntil</span>
       <span property="rdfs:comment">The latest date the package may arrive.</span>
       <span>Domain: <a property="http://schema.org/domainIncludes" href="http://schema.org/ParcelDelivery">ParcelDelivery</a></span>
       <span>Range: <a property="http://schema.org/rangeIncludes" href="http://schema.org/DateTime">DateTime</a></span>
+      <span>Range: <a property="http://schema.org/rangeIncludes" href="http://schema.org/Date">Date</a></span>
     </div>
 
     <div typeof="rdf:Property" resource="http://schema.org/expires">
@@ -6049,6 +6056,7 @@ Unregistered or niche encoding and file formats can be indicated instead via the
       <span property="rdfs:comment">Date order was placed.</span>
       <span>Domain: <a property="http://schema.org/domainIncludes" href="http://schema.org/Order">Order</a></span>
       <span>Range: <a property="http://schema.org/rangeIncludes" href="http://schema.org/DateTime">DateTime</a></span>
+      <span>Range: <a property="http://schema.org/rangeIncludes" href="http://schema.org/Date">Date</a></span>
     </div>
     <div typeof="rdf:Property" resource="http://schema.org/orderedItem">
       <span class="h" property="rdfs:label">orderedItem</span>
@@ -7094,6 +7102,7 @@ While such policies are most typically expressed in natural language, sometimes 
       <span>Domain: <a property="http://schema.org/domainIncludes" href="http://schema.org/FoodEstablishmentReservation">FoodEstablishmentReservation</a></span>
       <span>Domain: <a property="http://schema.org/domainIncludes" href="http://schema.org/MediaObject">MediaObject</a></span>
       <span>Range: <a property="http://schema.org/rangeIncludes" href="http://schema.org/DateTime">DateTime</a></span>
+      <span>Range: <a property="http://schema.org/rangeIncludes" href="http://schema.org/Time">Time</a></span>
     </div>
 
     <div typeof="rdf:Property" resource="http://schema.org/storageRequirements">
@@ -7422,6 +7431,7 @@ Open-ended date ranges can be written with ".." in place of the end date. For ex
       <span>Domain: <a property="http://schema.org/domainIncludes" href="http://schema.org/Permit">Permit</a></span>
       <span>Domain: <a property="http://schema.org/domainIncludes" href="http://schema.org/LocationFeatureSpecification">LocationFeatureSpecification</a></span>
       <span>Range: <a property="http://schema.org/rangeIncludes" href="http://schema.org/DateTime">DateTime</a></span>
+      <span>Range: <a property="http://schema.org/rangeIncludes" href="http://schema.org/Date">Date</a></span>
     </div>
     <div typeof="rdf:Property" resource="http://schema.org/validIn">
       <span class="h" property="rdfs:label">validIn</span>
@@ -7440,6 +7450,7 @@ Open-ended date ranges can be written with ".." in place of the end date. For ex
       <span>Domain: <a property="http://schema.org/domainIncludes" href="http://schema.org/OpeningHoursSpecification">OpeningHoursSpecification</a></span>
       <span>Domain: <a property="http://schema.org/domainIncludes" href="http://schema.org/LocationFeatureSpecification">LocationFeatureSpecification</a></span>
       <span>Range: <a property="http://schema.org/rangeIncludes" href="http://schema.org/DateTime">DateTime</a></span>
+      <span>Range: <a property="http://schema.org/rangeIncludes" href="http://schema.org/Date">Date</a></span>
     </div>
     <div typeof="rdf:Property" resource="http://schema.org/validUntil">
       <span class="h" property="rdfs:label">validUntil</span>
@@ -7542,6 +7553,7 @@ Open-ended date ranges can be written with ".." in place of the end date. For ex
       <span>Domain: <a property="http://schema.org/domainIncludes" href="http://schema.org/Order">Order</a></span>
       <span>Domain: <a property="http://schema.org/domainIncludes" href="http://schema.org/Invoice">Invoice</a></span>
       <span>Range: <a property="http://schema.org/rangeIncludes" href="http://schema.org/DateTime">DateTime</a></span>
+      <span>Range: <a property="http://schema.org/rangeIncludes" href="http://schema.org/Date">Date</a></span>
     </div>
     <div typeof="rdf:Property" resource="http://schema.org/paymentMethod">
       <span class="h" property="rdfs:label">paymentMethod</span>
@@ -7964,6 +7976,7 @@ Open-ended date ranges can be written with ".." in place of the end date. For ex
       <span property="rdfs:comment">The date the ticket was issued.</span>
       <span>domain: <a property="http://schema.org/domainIncludes" href="http://schema.org/Ticket">Ticket</a></span>
       <span>Range: <a property="http://schema.org/rangeIncludes" href="http://schema.org/DateTime">DateTime</a></span>
+      <span>Range: <a property="http://schema.org/rangeIncludes" href="http://schema.org/Date">Date</a></span>
     </div>
     <div typeof="rdf:Property" resource="http://schema.org/ticketedSeat">
       <span class="h" property="rdfs:label">ticketedSeat</span>
@@ -8061,12 +8074,14 @@ postponing for 1.6.
       <span property="rdfs:comment">The expected departure time.</span>
       <span>domain: <a property="http://schema.org/domainIncludes" href="http://schema.org/Trip">Trip</a></span>
       <span>Range: <a property="http://schema.org/rangeIncludes" href="http://schema.org/DateTime">DateTime</a></span>
+      <span>Range: <a property="http://schema.org/rangeIncludes" href="http://schema.org/Time">Time</a></span>
     </div>
     <div typeof="rdf:Property" resource="http://schema.org/arrivalTime">
       <span class="h" property="rdfs:label">arrivalTime</span>
       <span property="rdfs:comment">The expected arrival time.</span>
       <span>domain: <a property="http://schema.org/domainIncludes" href="http://schema.org/Trip">Trip</a></span>
       <span>Range: <a property="http://schema.org/rangeIncludes" href="http://schema.org/DateTime">DateTime</a></span>
+      <span>Range: <a property="http://schema.org/rangeIncludes" href="http://schema.org/Time">Time</a></span>
     </div>
     <div typeof="rdf:Property" resource="http://schema.org/departureAirport">
       <span class="h" property="rdfs:label">departureAirport</span>
@@ -8259,6 +8274,7 @@ postponing for 1.6.
       <span>domain: <a property="http://schema.org/domainIncludes" href="http://schema.org/LodgingReservation">LodgingReservation</a></span>
       <span>domain: <a property="http://schema.org/domainIncludes" href="http://schema.org/LodgingBusiness">LodgingBusiness</a></span>
       <span>Range: <a property="http://schema.org/rangeIncludes" href="http://schema.org/DateTime">DateTime</a></span>
+      <span>Range: <a property="http://schema.org/rangeIncludes" href="http://schema.org/Time">Time</a></span>
     </div>
     <div typeof="rdf:Property" resource="http://schema.org/checkoutTime">
       <span class="h" property="rdfs:label">checkoutTime</span>
@@ -8266,6 +8282,7 @@ postponing for 1.6.
       <span>domain: <a property="http://schema.org/domainIncludes" href="http://schema.org/LodgingReservation">LodgingReservation</a></span>
       <span>domain: <a property="http://schema.org/domainIncludes" href="http://schema.org/LodgingBusiness">LodgingBusiness</a></span>
       <span>Range: <a property="http://schema.org/rangeIncludes" href="http://schema.org/DateTime">DateTime</a></span>
+      <span>Range: <a property="http://schema.org/rangeIncludes" href="http://schema.org/Time">Time</a></span>
     </div>
     <div typeof="rdf:Property" resource="http://schema.org/lodgingUnitType">
       <span class="h" property="rdfs:label">lodgingUnitType</span>
@@ -10741,6 +10758,7 @@ Standards bodies should promote a standard prefix for the identifiers of propert
   <span property="rdfs:comment">The date/time at which the message has been read by the recipient if a single recipient exists.</span>
   <span>Domain: <a property="http://schema.org/domainIncludes" href="http://schema.org/Message">Message</a></span>
   <span>Range: <a property="http://schema.org/rangeIncludes" href="http://schema.org/DateTime">DateTime</a></span>
+  <span>Range: <a property="http://schema.org/rangeIncludes" href="http://schema.org/Date">Date</a></span>
 </div>
 <div typeof="rdf:Property" resource="http://schema.org/dateReceived">
   <span class="h" property="rdfs:label">dateReceived</span>

--- a/data/schema.rdfa
+++ b/data/schema.rdfa
@@ -3819,6 +3819,7 @@ The place is __open__ if the [[opens]] property is specified, and __closed__ oth
       <span>Domain: <a property="http://schema.org/domainIncludes" href="http://schema.org/Offer">Offer</a></span>
       <span>Domain: <a property="http://schema.org/domainIncludes" href="http://schema.org/Demand">Demand</a></span>
       <span>Range: <a property="http://schema.org/rangeIncludes" href="http://schema.org/DateTime">DateTime</a></span>
+      <span>Range: <a property="http://schema.org/rangeIncludes" href="http://schema.org/Time">Time</a></span>
       <span>Range: <a property="http://schema.org/rangeIncludes" href="http://schema.org/Date">Date</a></span>
     </div>
     <div typeof="rdf:Property" resource="http://schema.org/availabilityStarts">
@@ -3827,6 +3828,7 @@ The place is __open__ if the [[opens]] property is specified, and __closed__ oth
       <span>Domain: <a property="http://schema.org/domainIncludes" href="http://schema.org/Offer">Offer</a></span>
       <span>Domain: <a property="http://schema.org/domainIncludes" href="http://schema.org/Demand">Demand</a></span>
       <span>Range: <a property="http://schema.org/rangeIncludes" href="http://schema.org/DateTime">DateTime</a></span>
+      <span>Range: <a property="http://schema.org/rangeIncludes" href="http://schema.org/Time">Time</a></span>
       <span>Range: <a property="http://schema.org/rangeIncludes" href="http://schema.org/Date">Date</a></span>
     </div>
     <div typeof="rdf:Property" resource="http://schema.org/availableAtOrFrom">


### PR DESCRIPTION
Added **Date** to rangeInclude for orderDate, validFrom, validThrough, paymentDueDate, expectedArrivalFrom, expectedArrivalUntil, dateRead, availabilityStarts, availabilityEnds, dateDeleted, dateIssued.

Added **Time** to the rangeIncludes for checkoutTime, checkinTime, checkinTime, arrivalTime,
departureTime, availabilityStarts, availabilityEnds, doorTime, endTime, startTime.
Fix for issue #(2271)

