### PR TITLE
Adds employmentUnit to JobPosting with example.

### DIFF
--- a/data/ext/pending/issue-2296-examples.txt
+++ b/data/ext/pending/issue-2296-examples.txt
@@ -1,0 +1,38 @@
+TYPES: employmentUnit
+
+PRE-MARKUP:
+
+JobPosting for Junior Software Developer in ITS Division C
+of ACME Corp
+
+
+MICRODATA:
+
+<!-- JSONLD only example -->
+
+RDFA:
+
+<!-- JSONLD only example -->
+
+JSON:
+
+<script type="application/ld+json">
+{
+    "@context": "http://schema.org",
+    "@type": "JobPosting",
+    "title": "Junior software developer",
+    "hiringOrganization" : {
+        "@type": "Organization",
+        "@id": "http://www.example.com/acme#Organization",
+        "name": "ACME Corp.",
+        "url": "www.example.com"
+    },
+    "employmentUnit" : {
+        "@type": "Organization",
+        "name": "ITS - Division C",
+        "parentOrganization" : {
+            "@id": "http://www.example.com/acme#Organization"
+        }
+    }
+}
+</script>

--- a/data/ext/pending/issue-2296.rdfa
+++ b/data/ext/pending/issue-2296.rdfa
@@ -1,0 +1,13 @@
+<div>
+<!-- Adds employmentUnit to JobPosting for specific sub-department/facility/business unit at which job is based, issue 2296 -->
+
+  <div typeof="rdf:Property" resource="http://schema.org/employmentUnit">
+    <span>Category: <span property="schema:category">issue-2296</span></span>
+    <span class="h" property="rdfs:label">employmentUnit</span>
+    <span property="rdfs:comment">Indicates the department, unit and/or facility where the employee reports and/or in which the job is to be performed.</span>
+    <span>domainIncludes: <a property="http://schema.org/domainIncludes" href="http://schema.org/JobPosting">JobPosting</a></span>
+    <span>rangeIncludes: <a property="http://schema.org/rangeIncludes" href="http://schema.org/Organization">Organization</a></span>
+    <link property="http://schema.org/isPartOf" href="http://pending.schema.org" />
+    <span>Source:  <a property="dc:source" href="https://github.com/schemaorg/schemaorg/issues/2296">#2296</a></span>
+  </div>
+</div>


### PR DESCRIPTION
Adds employmentUnit to JobPosting for specific sub-department/facility/business unit at which job is based, closes issue #2296 (this is one of the missing properties mentioned in issue #1829 )