### PR TITLE
Fixes typo for rdfs:label URI in schema.rdfa

### DIFF
--- a/data/schema.rdfa
+++ b/data/schema.rdfa
@@ -5911,7 +5911,7 @@ Unregistered or niche encoding and file formats can be indicated instead via the
       <span property="rdfs:comment">The name of the item.</span>
       <span>Domain: <a property="http://schema.org/domainIncludes" href="http://schema.org/Thing">Thing</a></span>
       <span>Range: <a property="http://schema.org/rangeIncludes" href="http://schema.org/Text">Text</a></span>
-      <link property="rdfs:subPropertyOf" href="rdfs:label"/>
+      <link property="rdfs:subPropertyOf" href="http://www.w3.org/2000/01/rdf-schema#label"/>
       <link property="owl:equivalentProperty" href="http://purl.org/dc/terms/title"/>
     </div>
     <div typeof="rdf:Property" resource="http://schema.org/nationality">


### PR DESCRIPTION
The `rdfs:label` value was used for the `href` attribute.

It was leading to the generation of the triple `schema:name rdfs:subPropertyOf <rdfs:label>` instead of `schema:name rdfs:subPropertyOf rdfs:label` (the rdfa parsers do not resolve namespace prefixes in the `href` attribute value).