### PR TITLE
Add DateTime to range of datePublished

### DIFF
--- a/data/schema.rdfa
+++ b/data/schema.rdfa
@@ -4488,6 +4488,7 @@ Dateline summaries are oriented more towards human readers than towards automate
       <span property="rdfs:comment">Date of first broadcast/publication.</span>
       <span>Domain: <a property="http://schema.org/domainIncludes" href="http://schema.org/CreativeWork">CreativeWork</a></span>
       <span>Range: <a property="http://schema.org/rangeIncludes" href="http://schema.org/Date">Date</a></span>
+      <span>Range: <a property="http://schema.org/rangeIncludes" href="http://schema.org/DateTime">DateTime</a></span>
     </div>
     <div typeof="rdf:Property" resource="http://schema.org/dayOfWeek">
       <span class="h" property="rdfs:label">dayOfWeek</span>


### PR DESCRIPTION
Implements recommendation in issue (#2309) to accommodate need for some more accurate information about when a CreativeWork is published - eg. for news articles etc.  Also reflects usage by Google.