### PR TITLE
Issue 1457 extending temporal props [for Schedule type]

### DIFF
--- a/data/ext/pending/issue-1457-examples.txt
+++ b/data/ext/pending/issue-1457-examples.txt
@@ -29,7 +29,8 @@ JSON:
      "repeatFrequency": "P1W",
      "byDay": "http://schema.org/Wednesday",
      "startTime": "19:00",
-     "endTime": "20:00"
+     "endTime": "20:00",
+     "scheduleTimezone": "Europe/London"
   }
 }
 </script>
@@ -60,7 +61,8 @@ JSON:
      "repeatFrequency": "P1M",
      "byMonthDay": [1,15],
      "startTime": "09:00",
-     "endTime": "10:00"
+     "endTime": "10:00",
+     "scheduleTimezone": "America/Glace_Bay"
   }
 }
 </script>
@@ -93,7 +95,8 @@ JSON:
           "repeatFrequency": "P1D",
           "repeatCount": 10,
           "startTime": "09:00",
-          "endTime": "10:00"
+          "endTime": "10:00",
+          "scheduleTimezone": "Europe/London"
         }
     }
 </script>
@@ -131,7 +134,8 @@ JSON:
         "http://schema.org/Friday"
       ],
       "startTime": "09:00",
-      "endTime": "10:00"
+      "endTime": "10:00",
+      "scheduleTimezone": "America/Glace_Bay"
     },
     {
       "@type": "Schedule",
@@ -144,7 +148,8 @@ JSON:
         "http://schema.org/Friday"
       ],
       "startTime": "14:00",
-      "endTime": "15:00"
+      "endTime": "15:00",
+      "scheduleTimezone": "America/Glace_Bay"
     }
   ]
 }
@@ -177,7 +182,8 @@ JSON:
       "repeatFrequency": "P1M",
       "byDay": "2MO",
       "startTime": "18:00",
-      "endTime": "19:30"
+      "endTime": "19:30",
+      "scheduleTimezone": "Asia/Shanghai"
     }
   ]
 }

--- a/data/ext/pending/issue-1457-examples.txt
+++ b/data/ext/pending/issue-1457-examples.txt
@@ -149,3 +149,36 @@ JSON:
   ]
 }
 </script>
+
+TYPES: Event, Schedule, eventSchedule
+
+PRE-MARKUP:
+
+An Event runs on the second Monday of every month, from 6pm-7:30pm. Because this kind of recurrence goes beyond that expressible using <a href="http://schema.org/DayOfWeek">http://schema.org/DayOfWeek</a>, it is specified instead using iCal's <a href="https://icalendar.org/iCalendar-RFC-5545/3-8-5-3-recurrence-rule.html">syntax for byDay recurrence rules</a>.
+
+MICRODATA:
+
+Example is JSON-LD only.
+
+RDFA:
+
+Example is JSON-LD only.
+
+JSON:
+
+<script type="application/ld+json">
+{
+  "@context": "http://schema.org",
+  "@type": "Event",
+  "name": "Example",
+  "eventSchedule": [
+    {
+      "@type": "Schedule",
+      "repeatFrequency": "P1M",
+      "byDay": "2MO",
+      "startTime": "18:00",
+      "endTime": "19:30"
+    }
+  ]
+}
+</script>

--- a/data/ext/pending/issue-1457.rdfa
+++ b/data/ext/pending/issue-1457.rdfa
@@ -98,6 +98,16 @@
         <span>Category: <span property="schema:category">issue-1457</span></span>
     </div>
 
+    <div typeof="rdf:Property" resource="http://schema.org/scheduleTimezone">
+      <span>Category: <span property="schema:category">issue-1457</span></span>
+      <span class="h" property="rdfs:label">scheduleTimezone</span>
+      <span property="rdfs:comment">Indicates the timezone for which the time(s) indicated in the [[Schedule]] are given.</span>
+      <span>domainIncludes: <a property="http://schema.org/domainIncludes" href="http://schema.org/Schedule">Schedule</a></span>
+      <span>Range: <a property="http://schema.org/rangeIncludes" href="http://schema.org/Text">Text</a></span>
+      <link property="http://schema.org/isPartOf" href="http://pending.schema.org" />
+      <span>Source:  <a property="dc:source" href="https://github.com/schemaorg/schemaorg/issues/1457">#1457</a></span>
+    </div>
+
     <div typeof="rdf:Property" resource="http://schema.org/eventSchedule">
       <span>Category: <span property="schema:category">issue-1457</span></span>
       <span class="h" property="rdfs:label">eventSchedule</span>

--- a/data/ext/pending/issue-1457.rdfa
+++ b/data/ext/pending/issue-1457.rdfa
@@ -3,7 +3,7 @@
   Schema.org Recurring Events Proposal
   Issue #1457, https://github.com/schemaorg/schemaorg/issues/1457
 
-  Defines a new type: Schedule which can be associated with an Event
+  Defines a new type: Schedule which can be associated with an Event.
   A Schedule defines a recurring time period similar to an iCal rrule.
 
 -->
@@ -13,7 +13,7 @@
     <div typeof="rdfs:Class" resource="http://schema.org/Schedule">
       <span>Category: <span property="schema:category">issue-1457</span></span>
       <span class="h" property="rdfs:label">Schedule</span>
-      <span property="rdfs:comment">A schedule defines a repeating time period used to describe a regularly occurring [[Event]]. At a minimum a schedule will specify [[repeatFrequency]] which describes the interval between occurences of the event. Additional information can be provided to specify the schedule more precisely. 
+      <span property="rdfs:comment">A schedule defines a repeating time period used to describe a regularly occurring [[Event]]. At a minimum a schedule will specify [[repeatFrequency]] which describes the interval between occurences of the event. Additional information can be provided to specify the schedule more precisely.
       This includes identifying the day(s) of the week or month when the recurring event will take place, in addition to its start and end time. Schedules may also
       have start and end dates to indicate when they are active, e.g. to define a limited calendar of events.</span>
       <span>Subclass of: <a property="rdfs:subClassOf" href="http://schema.org/Intangible">Intangible</a></span>
@@ -98,10 +98,10 @@
       repeating events rather than data on the individual events themselves. For example, a website or application might prefer to publish a schedule for a weekly
       gym class rather than provide data on every event. A schedule could be processed by applications to add forthcoming events to a calendar. An [[Event]] that
       is associated with a [[Schedule]] using this property should not have [[startDate]] or [[endDate]] properties. These are instead defined within the associated
-      [[Schedule]], this avoids any ambiguity for clients using the data. The propery might have repeated values to specify different schedules, e.g. for different months
+      [[Schedule]], this avoids any ambiguity for clients using the data. The property might have repeated values to specify different schedules, e.g. for different months
       or seasons.</span>
-      <span>domainIncludes: <a property="http://schema.org/domainIncludes" href="http://schema.org/Schedule">Event</a></span>
-      <span>rangeIncludes: <a property="http://schema.org/rangeIncludes" href="http://schema.org/Duration">Schedule</a></span>
+      <span>domainIncludes: <a property="http://schema.org/domainIncludes" href="http://schema.org/Event">Event</a></span>
+      <span>rangeIncludes: <a property="http://schema.org/rangeIncludes" href="http://schema.org/Schedule">Schedule</a></span>
       <link property="http://schema.org/isPartOf" href="http://pending.schema.org" />
       <span>Source:  <a property="dc:source" href="https://github.com/schemaorg/schemaorg/issues/1457">#1457</a></span>
     </div>

--- a/data/ext/pending/issue-1457.rdfa
+++ b/data/ext/pending/issue-1457.rdfa
@@ -101,7 +101,7 @@
     <div typeof="rdf:Property" resource="http://schema.org/scheduleTimezone">
       <span>Category: <span property="schema:category">issue-1457</span></span>
       <span class="h" property="rdfs:label">scheduleTimezone</span>
-      <span property="rdfs:comment">Indicates the timezone for which the time(s) indicated in the [[Schedule]] are given.</span>
+      <span property="rdfs:comment">Indicates the timezone for which the time(s) indicated in the [[Schedule]] are given. The value provided should be among those listed in the <a href="https://www.iana.org/time-zones">IANA Time Zone Database</a>.</span>
       <span>domainIncludes: <a property="http://schema.org/domainIncludes" href="http://schema.org/Schedule">Schedule</a></span>
       <span>Range: <a property="http://schema.org/rangeIncludes" href="http://schema.org/Text">Text</a></span>
       <link property="http://schema.org/isPartOf" href="http://pending.schema.org" />

--- a/data/ext/pending/issue-1457.rdfa
+++ b/data/ext/pending/issue-1457.rdfa
@@ -50,9 +50,10 @@
     <div typeof="rdf:Property" resource="http://schema.org/byDay">
       <span>Category: <span property="schema:category">issue-1457</span></span>
       <span class="h" property="rdfs:label">byDay</span>
-      <span property="rdfs:comment">Defines the day(s) of the week on which a recurring [[Event]] takes place</span>
+      <span property="rdfs:comment">Defines the day(s) of the week on which a recurring [[Event]] takes place. May be specified using either [[DayOfWeek]], or alternatively [[Text]] conforming to iCal's <a href="https://icalendar.org/iCalendar-RFC-5545/3-8-5-3-recurrence-rule.html">syntax for byDay recurrence rules</a></span>
       <span>domainIncludes: <a property="http://schema.org/domainIncludes" href="http://schema.org/Schedule">Schedule</a></span>
       <span>rangeIncludes: <a property="http://schema.org/rangeIncludes" href="http://schema.org/DayOfWeek">DayOfWeek</a></span>
+      <span>rangeIncludes: <a property="http://schema.org/rangeIncludes" href="http://schema.org/Text">Text</a></span>
       <link property="http://schema.org/isPartOf" href="http://pending.schema.org" />
       <span>Source:  <a property="dc:source" href="https://github.com/schemaorg/schemaorg/issues/1457">#1457</a></span>
     </div>

--- a/data/ext/pending/issue-1457.rdfa
+++ b/data/ext/pending/issue-1457.rdfa
@@ -3,7 +3,7 @@
   Schema.org Recurring Events Proposal
   Issue #1457, https://github.com/schemaorg/schemaorg/issues/1457
 
-  Defines a new type: Schedule which can be associated with an Event.
+  Defines a new type: Schedule which can be associated with an Event
   A Schedule defines a recurring time period similar to an iCal rrule.
 
 -->
@@ -91,6 +91,12 @@
       <span>Source:  <a property="dc:source" href="https://github.com/schemaorg/schemaorg/issues/1457">#1457</a></span>
     </div>
 
+    <div typeof="rdf:Property" resource="http://schema.org/duration">
+        <span>Domain: <a property="http://schema.org/domainIncludes" href="http://schema.org/Schedule">Schedule</a></span>
+        <span>Source:  <a property="dc:source" href="https://github.com/schemaorg/schemaorg/issues/1457">#1457</a></span>
+        <span>Category: <span property="schema:category">issue-1457</span></span>
+    </div>
+
     <div typeof="rdf:Property" resource="http://schema.org/eventSchedule">
       <span>Category: <span property="schema:category">issue-1457</span></span>
       <span class="h" property="rdfs:label">eventSchedule</span>
@@ -98,10 +104,10 @@
       repeating events rather than data on the individual events themselves. For example, a website or application might prefer to publish a schedule for a weekly
       gym class rather than provide data on every event. A schedule could be processed by applications to add forthcoming events to a calendar. An [[Event]] that
       is associated with a [[Schedule]] using this property should not have [[startDate]] or [[endDate]] properties. These are instead defined within the associated
-      [[Schedule]], this avoids any ambiguity for clients using the data. The property might have repeated values to specify different schedules, e.g. for different months
+      [[Schedule]], this avoids any ambiguity for clients using the data. The propery might have repeated values to specify different schedules, e.g. for different months
       or seasons.</span>
-      <span>domainIncludes: <a property="http://schema.org/domainIncludes" href="http://schema.org/Event">Event</a></span>
-      <span>rangeIncludes: <a property="http://schema.org/rangeIncludes" href="http://schema.org/Schedule">Schedule</a></span>
+      <span>domainIncludes: <a property="http://schema.org/domainIncludes" href="http://schema.org/Schedule">Event</a></span>
+      <span>rangeIncludes: <a property="http://schema.org/rangeIncludes" href="http://schema.org/Duration">Schedule</a></span>
       <link property="http://schema.org/isPartOf" href="http://pending.schema.org" />
       <span>Source:  <a property="dc:source" href="https://github.com/schemaorg/schemaorg/issues/1457">#1457</a></span>
     </div>


### PR DESCRIPTION
Introduces the following changes to the pending Schedule type:

* adds the 'duration' property
* extends the range of 'byDay' to allow for iCal-style rrule syntax
* adds the 'scheduleTimezone' property

These are discussed at #1457 and at https://github.com/openactive/modelling-opportunity-data/issues/197.

