### PR TITLE
Information about employer in JobPosting

### DIFF
--- a/data/ext/pending/issue-2396-examples.txt
+++ b/data/ext/pending/issue-2396-examples.txt
@@ -1,0 +1,92 @@
+TYPES: applicationContact
+
+PRE-MARKUP:
+
+Job title: Systems Research Engineer
+
+Questions? Email info@example.com
+
+MICRODATA:
+
+to do
+
+RDFA:
+
+to do
+
+JSON:
+
+<script type="application/ld+json">
+{
+  "@context": "http://schema.org/",
+  "@type": "JobPosting",
+  "title": "Systems Research Engineer",
+  "applicationContact": {
+    "@type": "ContactPoint",
+    "email": "info@example.com"
+  }
+}
+</script>
+
+TYPES: employerOverview
+
+PRE-MARKUP:
+
+Job Title "Systems Research Engineer" at Acme.
+
+Acme is committed to providing an environment where the most
+creative people want to work. We are committed to creating a
+diverse environment and are proud to be an equal opportunity
+employer.
+
+MICRODATA:
+
+to do
+
+RDFA:
+
+to do
+
+JSON:
+
+<script type="application/ld+json">
+{
+  "@context": "http://schema.org/",
+  "@type": "JobPosting",
+  "title": "Systems Research Engineer",
+  "employerOverview": "Acme is committed to providing an environment where the
+     most creative people want to work. We are committed to creating a diverse
+     environment and are proud to be an equal opportunity employer."
+}
+</script>
+
+TYPES: industry, DefinedTerm
+
+PRE-MARKUP:
+
+Systems Research Engineer at a Software Publishers (NAICS code 511210)
+
+MICRODATA:
+
+to do
+
+RDFA:
+
+to do
+
+JSON:
+
+<script type="application/ld+json">
+{
+  "@context": "http://schema.org/",
+  "@type": "JobPosting",
+  "title": "Systems Research Engineer",
+  "industry": {
+    "@type": "DefinedTerm",
+    "termCode": "511210",
+    "name": "Software Publishers",
+    "url": "https://www.naics.com/naics-code-description/?code=511210"
+    "inDefinedTermSet": "NAICS (North American Industry Classification System)"
+  }
+}
+</script>

--- a/data/ext/pending/issue-2396.rdfa
+++ b/data/ext/pending/issue-2396.rdfa
@@ -1,0 +1,24 @@
+<div>
+<!-- Provide information about employer in JobPostings, issue 2396 -->
+
+    <div typeof="rdf:Property" resource="http://schema.org/applicationContact">
+      <span>Category: <span property="schema:category">issue-2396</span></span>
+      <span class="h" property="rdfs:label">applicationContact</span>
+      <span property="rdfs:comment">Contact details for further information relevant to this job posting.</span>
+      <span>domainIncludes: <a property="http://schema.org/domainIncludes" href="http://schema.org/JobPosting">JobPosting</a></span>
+      <span>rangeIncludes: <a property="http://schema.org/rangeIncludes" href="http://schema.org/ContactPoint">ContactPoint</a></span>
+      <link property="http://schema.org/isPartOf" href="http://pending.schema.org" />
+      <span>Source:  <a property="dc:source" href="https://github.com/schemaorg/schemaorg/issues/2396">#2396</a></span>
+    </div>
+
+    <div typeof="rdf:Property" resource="http://schema.org/employerOverview">
+      <span>Category: <span property="schema:category">issue-2396</span></span>
+      <span class="h" property="rdfs:label">employerOverview</span>
+      <span property="rdfs:comment">A description of the employer, career opportunities and work environment for this position.</span>
+      <span>domainIncludes: <a property="http://schema.org/domainIncludes" href="http://schema.org/JobPosting">JobPosting</a></span>
+      <span>rangeIncludes: <a property="http://schema.org/rangeIncludes" href="http://schema.org/Text">Text</a></span>
+      <link property="http://schema.org/isPartOf" href="http://pending.schema.org" />
+      <span>Source:  <a property="dc:source" href="https://github.com/schemaorg/schemaorg/issues/2396">#2396</a></span>
+    </div>
+    
+</div>

--- a/data/schema.rdfa
+++ b/data/schema.rdfa
@@ -5306,6 +5306,7 @@ Unregistered or niche encoding and file formats can be indicated instead via the
       <span property="rdfs:comment">The industry associated with the job position.</span>
       <span>Domain: <a property="http://schema.org/domainIncludes" href="http://schema.org/JobPosting">JobPosting</a></span>
       <span>Range: <a property="http://schema.org/rangeIncludes" href="http://schema.org/Text">Text</a></span>
+      <span>Range: <a property="http://schema.org/rangeIncludes" href="http://schema.org/DefinedTerm">DefinedTerm</a></span>
     </div>
 
 


### PR DESCRIPTION
closes #2396
text for releases.html:
<li id="2396"><a href="https://github.com/schemaorg/schemaorg/issues/2396">Issue #2396</a>:
Provide information about employer in <a href="/JobPosting">JobPosting</a>. Adds properties for <a href="/applicationContact">applicationContact</a>, <a href="/employerOverview">employerOverview</a> and allows DefinedTerm to be used for industry property.</li>