### PR TITLE
Adds eligibilityToWorkRequirement property to JobPosting 

### DIFF
--- a/data/ext/pending/issue-2384.rdfa
+++ b/data/ext/pending/issue-2384.rdfa
@@ -33,6 +33,15 @@
       <link property="http://schema.org/isPartOf" href="http://pending.schema.org" />
       <span>Source:  <a property="dc:source" href="https://github.com/schemaorg/schemaorg/issues/2384">#2384</a></span>
     </div>
+    <div typeof="rdf:Property" resource="http://schema.org/eligibilityToWorkRequirement">
+      <span>Category: <span property="schema:category">issue-2384</span></span>
+      <span class="h" property="rdfs:label">eligibilityToWorkRequirement</span>
+      <span property="rdfs:comment">The legal requirements such as citizenship, visa and other documentation required for an applicant to this job.</span>
+      <span>domainIncludes: <a property="http://schema.org/domainIncludes" href="http://schema.org/JobPosting">JobPosting</a></span>
+      <span>rangeIncludes: <a property="http://schema.org/rangeIncludes" href="http://schema.org/Text">Text</a></span>
+      <link property="http://schema.org/isPartOf" href="http://pending.schema.org" />
+      <span>Source:  <a property="dc:source" href="https://github.com/schemaorg/schemaorg/issues/2384">#2384</a></span>
+    </div>
 
 
 </div>


### PR DESCRIPTION
For visa and citizenship requirements of a JobPosting.  closes #2384 

Text for release notes
<li id="g2384b"><a href="https://github.com/schemaorg/schemaorg/issues/2384">Issue 2384</a>: Adds property to <a href="/JobPosting">JobPosting</a> for legal requirements relating to <a href="/eligibilityToWorkRequirement ">eligibility to work</a> such as citizenship, visa or other documentation.</li>