### PR TITLE
Add coverage for non-profit organizations

### DIFF
--- a/data/ext/pending/issue-2543-examples.txt
+++ b/data/ext/pending/issue-2543-examples.txt
@@ -1,0 +1,34 @@
+TYPES: NonprofitType, nonprofitStatus
+
+PRE-MARKUP:
+
+Nonprofit organization coverage with internationally applicable nonprofit types.
+
+
+MICRODATA:
+
+<!-- JSONLD only example -->
+
+RDFA:
+
+<!-- JSONLD only example -->
+
+JSON:
+
+<script type="application/ld+json">
+
+{
+"@context": "https://schema.org",
+"@type": "LegalService",
+"name": "Example Legal Aid Nonprofit",
+"text": "A nonprofit statewide law firm dedicated to providing equal access to justice for low income people through quality advocacy and education.",
+"nonprofitStatus" : "Nonprofit501c20",
+"url":  "https://www.example.org/nonprofit/info"
+"areaServed": {
+    "@type": "AdministrativeArea",
+    "name": "Idaho"
+    }
+
+}
+
+</script>

--- a/data/ext/pending/issue-2543.rdfa
+++ b/data/ext/pending/issue-2543.rdfa
@@ -1,0 +1,342 @@
+<div>
+
+<div typeof="rdf:Property" resource="http://schema.org/nonprofitStatus">
+  <span>Category: <span property="schema:category">issue-2543</span></span>
+  <span class="h" property="rdfs:label">nonprofitStatus</span>
+  <span property="rdfs:comment">nonprofit Status indicates the legal status of a non-profit organization in its primary place of business.</span>
+  <span>domainIncludes: <a property="http://schema.org/domainIncludes" href="http://schema.org/Organization">Organization</a></span>
+  <span>rangeIncludes: <a property="http://schema.org/rangeIncludes" href="http://schema.org/NonprofitType">NonprofitType</a></span>
+  <link property="http://schema.org/isPartOf" href="http://pending.schema.org" />
+  <span>Source:  <a property="dc:source" href="https://github.com/schemaorg/schemaorg/issues/2543">#2543</a></span>
+</div>
+
+<div typeof="rdfs:Class" resource="http://schema.org/NonprofitType">
+  <span>Category: <span property="schema:category">issue-2543</span></span>
+  <span class="h" property="rdfs:label">NonprofitType</span>
+  <span>Subclass of: <a property="rdfs:subClassOf" href="http://schema.org/Enumeration">Enumeration</a></span>
+  <span property="rdfs:comment">NonprofitType enumerates several kinds of official non-profit types of which a non-profit organization can be.</span>
+  <link property="http://schema.org/isPartOf" href="http://pending.schema.org" />
+  <span>Source:  <a property="dc:source" href="https://github.com/schemaorg/schemaorg/issues/2543">#2543</a></span>
+</div>
+
+<div typeof="http://schema.org/NonprofitType" resource="http://schema.org/Nonprofit501c1">
+  <span>Category: <span property="schema:category">issue-2543</span></span>
+  <span class="h" property="rdfs:label">Nonprofit501c1</span>
+  <span property="rdfs:comment">Nonprofit501c1: Non-profit type referring to Corporations Organized Under Act of Congress, including Federal Credit Unions and National Farm Loan Associations.</span>
+  <link property="http://schema.org/isPartOf" href="http://pending.schema.org" />
+  <span>Source:  <a property="dc:source" href="https://github.com/schemaorg/schemaorg/issues/2543">#2543</a></span>
+</div>
+
+<div typeof="http://schema.org/NonprofitType" resource="http://schema.org/Nonprofit501c2">
+  <span>Category: <span property="schema:category">issue-2543</span></span>
+  <span class="h" property="rdfs:label">Nonprofit501c2</span>
+  <span property="rdfs:comment">Nonprofit501c2: Non-profit type referring to Title-holding Corporations for Exempt Organizations.</span>
+  <link property="http://schema.org/isPartOf" href="http://pending.schema.org" />
+  <span>Source:  <a property="dc:source" href="https://github.com/schemaorg/schemaorg/issues/2543">#2543</a></span>
+</div>
+
+<div typeof="http://schema.org/NonprofitType" resource="http://schema.org/Nonprofit501c3">
+  <span>Category: <span property="schema:category">issue-2543</span></span>
+  <span class="h" property="rdfs:label">Nonprofit501c3</span>
+  <span property="rdfs:comment">Nonprofit501c3: Non-profit type referring to Religious, Educational, Charitable, Scientific, Literary, Testing for Public Safety, to Foster National or International Amateur Sports Competition, or Prevention of Cruelty to Children or Animals Organizations.</span>
+  <link property="http://schema.org/isPartOf" href="http://pending.schema.org" />
+  <span>Source:  <a property="dc:source" href="https://github.com/schemaorg/schemaorg/issues/2543">#2543</a></span>
+</div>
+
+<div typeof="http://schema.org/NonprofitType" resource="http://schema.org/Nonprofit501c4">
+  <span>Category: <span property="schema:category">issue-2543</span></span>
+  <span class="h" property="rdfs:label">Nonprofit501c4</span>
+  <span property="rdfs:comment">Nonprofit501c4: Non-profit type referring to Civic Leagues, Social Welfare Organizations, and Local Associations of Employees.</span>
+  <link property="http://schema.org/isPartOf" href="http://pending.schema.org" />
+  <span>Source:  <a property="dc:source" href="https://github.com/schemaorg/schemaorg/issues/2543">#2543</a></span>
+</div>
+
+<div typeof="http://schema.org/NonprofitType" resource="http://schema.org/Nonprofit501c5">
+  <span>Category: <span property="schema:category">issue-2543</span></span>
+  <span class="h" property="rdfs:label">Nonprofit501c5</span>
+  <span property="rdfs:comment">Nonprofit501c5: Non-profit type referring to Labor, Agricultural and Horticultural Organizations.</span>
+  <link property="http://schema.org/isPartOf" href="http://pending.schema.org" />
+  <span>Source:  <a property="dc:source" href="https://github.com/schemaorg/schemaorg/issues/2543">#2543</a></span>
+</div>
+
+<div typeof="http://schema.org/NonprofitType" resource="http://schema.org/Nonprofit501c6">
+  <span>Category: <span property="schema:category">issue-2543</span></span>
+  <span class="h" property="rdfs:label">Nonprofit501c6</span>
+  <span property="rdfs:comment">Nonprofit501c6: Non-profit type referring to Business Leagues, Chambers of Commerce, Real Estate Boards.</span>
+  <link property="http://schema.org/isPartOf" href="http://pending.schema.org" />
+  <span>Source:  <a property="dc:source" href="https://github.com/schemaorg/schemaorg/issues/2543">#2543</a></span>
+</div>
+
+<div typeof="http://schema.org/NonprofitType" resource="http://schema.org/Nonprofit501c7">
+  <span>Category: <span property="schema:category">issue-2543</span></span>
+  <span class="h" property="rdfs:label">Nonprofit501c7</span>
+  <span property="rdfs:comment">Nonprofit501c7: Non-profit type referring to Social and Recreational Clubs.</span>
+  <link property="http://schema.org/isPartOf" href="http://pending.schema.org" />
+  <span>Source:  <a property="dc:source" href="https://github.com/schemaorg/schemaorg/issues/2543">#2543</a></span>
+</div>
+
+<div typeof="http://schema.org/NonprofitType" resource="http://schema.org/Nonprofit501c8">
+  <span>Category: <span property="schema:category">issue-2543</span></span>
+  <span class="h" property="rdfs:label">Nonprofit501c8</span>
+  <span property="rdfs:comment">Nonprofit501c8: Non-profit type referring to Fraternal Beneficiary Societies and Associations.</span>
+  <link property="http://schema.org/isPartOf" href="http://pending.schema.org" />
+  <span>Source:  <a property="dc:source" href="https://github.com/schemaorg/schemaorg/issues/2543">#2543</a></span>
+</div>
+
+<div typeof="http://schema.org/NonprofitType" resource="http://schema.org/Nonprofit501c9">
+  <span>Category: <span property="schema:category">issue-2543</span></span>
+  <span class="h" property="rdfs:label">Nonprofit501c9</span>
+  <span property="rdfs:comment">Nonprofit501c9: Non-profit type referring to Voluntary Employee Beneficiary Associations.</span>
+  <link property="http://schema.org/isPartOf" href="http://pending.schema.org" />
+  <span>Source:  <a property="dc:source" href="https://github.com/schemaorg/schemaorg/issues/2543">#2543</a></span>
+</div>
+
+<div typeof="http://schema.org/NonprofitType" resource="http://schema.org/Nonprofit501c10">
+  <span>Category: <span property="schema:category">issue-2543</span></span>
+  <span class="h" property="rdfs:label">Nonprofit501c10</span>
+  <span property="rdfs:comment">Nonprofit501c10: Non-profit type referring to Domestic Fraternal Societies and Associations.</span>
+  <link property="http://schema.org/isPartOf" href="http://pending.schema.org" />
+  <span>Source:  <a property="dc:source" href="https://github.com/schemaorg/schemaorg/issues/2543">#2543</a></span>
+</div>
+
+<div typeof="http://schema.org/NonprofitType" resource="http://schema.org/Nonprofit501c11">
+  <span>Category: <span property="schema:category">issue-2543</span></span>
+  <span class="h" property="rdfs:label">Nonprofit501c11</span>
+  <span property="rdfs:comment">Nonprofit501c11: Non-profit type referring to Teachers' Retirement Fund Associations.</span>
+  <link property="http://schema.org/isPartOf" href="http://pending.schema.org" />
+  <span>Source:  <a property="dc:source" href="https://github.com/schemaorg/schemaorg/issues/2543">#2543</a></span>
+</div>
+
+<div typeof="http://schema.org/NonprofitType" resource="http://schema.org/Nonprofit501c12">
+  <span>Category: <span property="schema:category">issue-2543</span></span>
+  <span class="h" property="rdfs:label">Nonprofit501c12</span>
+  <span property="rdfs:comment">Nonprofit501c12: Non-profit type referring to Benevolent Life Insurance Associations, Mutual Ditch or Irrigation Companies, Mutual or Cooperative Telephone Companies.</span>
+  <link property="http://schema.org/isPartOf" href="http://pending.schema.org" />
+  <span>Source:  <a property="dc:source" href="https://github.com/schemaorg/schemaorg/issues/2543">#2543</a></span>
+</div>
+
+<div typeof="http://schema.org/NonprofitType" resource="http://schema.org/Nonprofit501c13">
+  <span>Category: <span property="schema:category">issue-2543</span></span>
+  <span class="h" property="rdfs:label">Nonprofit501c13</span>
+  <span property="rdfs:comment">Nonprofit501c13: Non-profit type referring to Cemetery Companies.</span>
+  <link property="http://schema.org/isPartOf" href="http://pending.schema.org" />
+  <span>Source:  <a property="dc:source" href="https://github.com/schemaorg/schemaorg/issues/2543">#2543</a></span>
+</div>
+
+<div typeof="http://schema.org/NonprofitType" resource="http://schema.org/Nonprofit501c14">
+  <span>Category: <span property="schema:category">issue-2543</span></span>
+  <span class="h" property="rdfs:label">Nonprofit501c14</span>
+  <span property="rdfs:comment">Nonprofit501c14: Non-profit type referring to State-Chartered Credit Unions, Mutual Reserve Funds.</span>
+  <link property="http://schema.org/isPartOf" href="http://pending.schema.org" />
+  <span>Source:  <a property="dc:source" href="https://github.com/schemaorg/schemaorg/issues/2543">#2543</a></span>
+</div>
+
+<div typeof="http://schema.org/NonprofitType" resource="http://schema.org/Nonprofit501c15">
+  <span>Category: <span property="schema:category">issue-2543</span></span>
+  <span class="h" property="rdfs:label">Nonprofit501c15</span>
+  <span property="rdfs:comment">Nonprofit501c15: Non-profit type referring to Mutual Insurance Companies or Associations.</span>
+  <link property="http://schema.org/isPartOf" href="http://pending.schema.org" />
+  <span>Source:  <a property="dc:source" href="https://github.com/schemaorg/schemaorg/issues/2543">#2543</a></span>
+</div>
+
+<div typeof="http://schema.org/NonprofitType" resource="http://schema.org/Nonprofit501c16">
+  <span>Category: <span property="schema:category">issue-2543</span></span>
+  <span class="h" property="rdfs:label">Nonprofit501c16</span>
+  <span property="rdfs:comment">Nonprofit501c16: Non-profit type referring to Cooperative Organizations to Finance Crop Operations.</span>
+  <link property="http://schema.org/isPartOf" href="http://pending.schema.org" />
+  <span>Source:  <a property="dc:source" href="https://github.com/schemaorg/schemaorg/issues/2543">#2543</a></span>
+</div>
+
+<div typeof="http://schema.org/NonprofitType" resource="http://schema.org/Nonprofit01c17">
+  <span>Category: <span property="schema:category">issue-2543</span></span>
+  <span class="h" property="rdfs:label">Nonprofit501c17</span>
+  <span property="rdfs:comment">Nonprofit501c17: Non-profit type referring to Supplemental Unemployment Benefit Trusts.</span>
+  <link property="http://schema.org/isPartOf" href="http://pending.schema.org" />
+  <span>Source:  <a property="dc:source" href="https://github.com/schemaorg/schemaorg/issues/2543">#2543</a></span>
+</div>
+
+<div typeof="http://schema.org/NonprofitType" resource="http://schema.org/Nonprofit501c18">
+  <span>Category: <span property="schema:category">issue-2543</span></span>
+  <span class="h" property="rdfs:label">Nonprofit501c18</span>
+  <span property="rdfs:comment">Nonprofit501c18: Non-profit type referring to Employee Funded Pension Trust (created before 25 June 1959).</span>
+  <link property="http://schema.org/isPartOf" href="http://pending.schema.org" />
+  <span>Source:  <a property="dc:source" href="https://github.com/schemaorg/schemaorg/issues/2543">#2543</a></span>
+</div>
+
+<div typeof="http://schema.org/NonprofitType" resource="http://schema.org/Nonprofit501c19">
+  <span>Category: <span property="schema:category">issue-2543</span></span>
+  <span class="h" property="rdfs:label">Nonprofit501c19</span>
+  <span property="rdfs:comment">Nonprofit501c19: Non-profit type referring to Post or Organization of Past or Present Members of the Armed Forces.</span>
+  <link property="http://schema.org/isPartOf" href="http://pending.schema.org" />
+  <span>Source:  <a property="dc:source" href="https://github.com/schemaorg/schemaorg/issues/2543">#2543</a></span>
+</div>
+
+<div typeof="http://schema.org/NonprofitType" resource="http://schema.org/Nonprofit501c20">
+  <span>Category: <span property="schema:category">issue-2543</span></span>
+  <span class="h" property="rdfs:label">Nonprofit501c20</span>
+  <span property="rdfs:comment">Nonprofit501c20: Non-profit type referring to Group Legal Services Plan Organizations.</span>
+  <link property="http://schema.org/isPartOf" href="http://pending.schema.org" />
+  <span>Source:  <a property="dc:source" href="https://github.com/schemaorg/schemaorg/issues/2543">#2543</a></span>
+</div>
+
+<div typeof="http://schema.org/NonprofitType" resource="http://schema.org/Nonprofit501c21">
+  <span>Category: <span property="schema:category">issue-2543</span></span>
+  <span class="h" property="rdfs:label">Nonprofit501c21</span>
+  <span property="rdfs:comment">Nonprofit501c21: Non-profit type referring to Black Lung Benefit Trusts.</span>
+  <link property="http://schema.org/isPartOf" href="http://pending.schema.org" />
+  <span>Source:  <a property="dc:source" href="https://github.com/schemaorg/schemaorg/issues/2543">#2543</a></span>
+</div>
+
+<div typeof="http://schema.org/NonprofitType" resource="http://schema.org/Nonprofit501c22">
+  <span>Category: <span property="schema:category">issue-2543</span></span>
+  <span class="h" property="rdfs:label">Nonprofit501c22</span>
+  <span property="rdfs:comment">Nonprofit501c22: Non-profit type referring to Withdrawal Liability Payment Funds.</span>
+  <link property="http://schema.org/isPartOf" href="http://pending.schema.org" />
+  <span>Source:  <a property="dc:source" href="https://github.com/schemaorg/schemaorg/issues/2543">#2543</a></span>
+</div>
+
+<div typeof="http://schema.org/NonprofitType" resource="http://schema.org/Nonprofit501c23">
+  <span>Category: <span property="schema:category">issue-2543</span></span>
+  <span class="h" property="rdfs:label">Nonprofit501c23</span>
+  <span property="rdfs:comment">Nonprofit501c23: Non-profit type referring to Veterans Organizations.</span>
+  <link property="http://schema.org/isPartOf" href="http://pending.schema.org" />
+  <span>Source:  <a property="dc:source" href="https://github.com/schemaorg/schemaorg/issues/2543">#2543</a></span>
+</div>
+
+<div typeof="http://schema.org/NonprofitType" resource="http://schema.org/Nonprofit501c24">
+  <span>Category: <span property="schema:category">issue-2543</span></span>
+  <span class="h" property="rdfs:label">Nonprofit501c24</span>
+  <span property="rdfs:comment">Nonprofit501c24: Non-profit type referring to Section 4049 ERISA Trusts.</span>
+  <link property="http://schema.org/isPartOf" href="http://pending.schema.org" />
+  <span>Source:  <a property="dc:source" href="https://github.com/schemaorg/schemaorg/issues/2543">#2543</a></span>
+</div>
+
+<div typeof="http://schema.org/NonprofitType" resource="http://schema.orgNonprofit501c25">
+  <span>Category: <span property="schema:category">issue-2543</span></span>
+  <span class="h" property="rdfs:label">Nonprofit501c25</span>
+  <span property="rdfs:comment">Nonprofit501c25: Non-profit type referring to Real Property Title-Holding Corporations or Trusts with Multiple Parents.</span>
+  <link property="http://schema.org/isPartOf" href="http://pending.schema.org" />
+  <span>Source:  <a property="dc:source" href="https://github.com/schemaorg/schemaorg/issues/2543">#2543</a></span>
+</div>
+
+<div typeof="http://schema.org/NonprofitType" resource="http://schema.org/Nonprofit501c26">
+  <span>Category: <span property="schema:category">issue-2543</span></span>
+  <span class="h" property="rdfs:label">Nonprofit501c26</span>
+  <span property="rdfs:comment">Nonprofit501c26: Non-profit type referring to State-Sponsored Organizations Providing Health Coverage for High-Risk Individuals.</span>
+  <link property="http://schema.org/isPartOf" href="http://pending.schema.org" />
+  <span>Source:  <a property="dc:source" href="https://github.com/schemaorg/schemaorg/issues/2543">#2543</a></span>
+</div>
+
+<div typeof="http://schema.org/NonprofitType" resource="http://schema.org/Nonprofit501c27">
+  <span>Category: <span property="schema:category">issue-2543</span></span>
+  <span class="h" property="rdfs:label">Nonprofit501c27</span>
+  <span property="rdfs:comment">Nonprofit501c27: Non-profit type referring to State-Sponsored Workers' Compensation Reinsurance Organizations.</span>
+  <link property="http://schema.org/isPartOf" href="http://pending.schema.org" />
+  <span>Source:  <a property="dc:source" href="https://github.com/schemaorg/schemaorg/issues/2543">#2543</a></span>
+</div>
+
+<div typeof="http://schema.org/NonprofitType" resource="http://schema.org/Nonprofit501c28">
+  <span>Category: <span property="schema:category">issue-2543</span></span>
+  <span class="h" property="rdfs:label">Nonprofit501c28</span>
+  <span property="rdfs:comment">Nonprofit501c28: Non-profit type referring to National Railroad Retirement Investment Trusts.</span>
+  <link property="http://schema.org/isPartOf" href="http://pending.schema.org" />
+  <span>Source:  <a property="dc:source" href="https://github.com/schemaorg/schemaorg/issues/2543">#2543</a></span>
+</div>
+
+<div typeof="http://schema.org/NonprofitType" resource="http://schema.org/Nonprofit501d">
+  <span>Category: <span property="schema:category">issue-2543</span></span>
+  <span class="h" property="rdfs:label">Nonprofit501d</span>
+  <span property="rdfs:comment">Nonprofit501d: Non-profit type referring to Religious and Apostolic Associations.</span>
+  <link property="http://schema.org/isPartOf" href="http://pending.schema.org" />
+  <span>Source:  <a property="dc:source" href="https://github.com/schemaorg/schemaorg/issues/2543">#2543</a></span>
+</div>
+
+<div typeof="http://schema.org/NonprofitType" resource="http://schema.org/Nonprofit501e">
+  <span>Category: <span property="schema:category">issue-2543</span></span>
+  <span class="h" property="rdfs:label">Nonprofit501e</span>
+  <span property="rdfs:comment">Nonprofit501e: Non-profit type referring to Cooperative Hospital Service Organizations.</span>
+  <link property="http://schema.org/isPartOf" href="http://pending.schema.org" />
+  <span>Source:  <a property="dc:source" href="https://github.com/schemaorg/schemaorg/issues/2543">#2543</a></span>
+</div>
+
+<div typeof="http://schema.org/NonprofitType" resource="http://schema.org/Nonprofit501f">
+  <span>Category: <span property="schema:category">issue-2543</span></span>
+  <span class="h" property="rdfs:label">Nonprofit501f</span>
+  <span property="rdfs:comment">Nonprofit501f: Non-profit type referring to Cooperative Service Organizations.</span>
+  <link property="http://schema.org/isPartOf" href="http://pending.schema.org" />
+  <span>Source:  <a property="dc:source" href="https://github.com/schemaorg/schemaorg/issues/2543">#2543</a></span>
+</div>
+
+<div typeof="http://schema.org/NonprofitType" resource="http://schema.org/Nonprofit501k">
+  <span>Category: <span property="schema:category">issue-2543</span></span>
+  <span class="h" property="rdfs:label">Nonprofit501k</span>
+  <span property="rdfs:comment">Nonprofit501k: Non-profit type referring to Child Care Organizations.</span>
+  <link property="http://schema.org/isPartOf" href="http://pending.schema.org" />
+  <span>Source:  <a property="dc:source" href="https://github.com/schemaorg/schemaorg/issues/2543">#2543</a></span>
+</div>
+
+<div typeof="http://schema.org/NonprofitType" resource="http://schema.org/Nonprofit501n">
+  <span>Category: <span property="schema:category">issue-2543</span></span>
+  <span class="h" property="rdfs:label">Nonprofit501n</span>
+  <span property="rdfs:comment">Nonprofit501n: Non-profit type referring to Charitable Risk Pools.</span>
+  <link property="http://schema.org/isPartOf" href="http://pending.schema.org" />
+  <span>Source:  <a property="dc:source" href="https://github.com/schemaorg/schemaorg/issues/2543">#2543</a></span>
+</div>
+
+<div typeof="http://schema.org/NonprofitType" resource="http://schema.org/Nonprofit501q">
+  <span>Category: <span property="schema:category">issue-2543</span></span>
+  <span class="h" property="rdfs:label">Nonprofit501q</span>
+  <span property="rdfs:comment">Nonprofit501q: Non-profit type referring to Credit Counseling Organizations.</span>
+  <link property="http://schema.org/isPartOf" href="http://pending.schema.org" />
+  <span>Source:  <a property="dc:source" href="https://github.com/schemaorg/schemaorg/issues/2543">#2543</a></span>
+</div>
+
+<div typeof="http://schema.org/NonprofitType" resource="http://schema.org/Nonprofit501a">
+  <span>Category: <span property="schema:category">issue-2543</span></span>
+  <span class="h" property="rdfs:label">Nonprofit501a</span>
+  <span property="rdfs:comment">Nonprofit501a: Non-profit type referring to Farmers’ Cooperative Associations.</span>
+  <link property="http://schema.org/isPartOf" href="http://pending.schema.org" />
+  <span>Source:  <a property="dc:source" href="https://github.com/schemaorg/schemaorg/issues/2543">#2543</a></span>
+</div>
+
+<div typeof="http://schema.org/NonprofitType" resource="http://schema.org/Nonprofit527">
+  <span>Category: <span property="schema:category">issue-2543</span></span>
+  <span class="h" property="rdfs:label">Nonprofit527</span>
+  <span property="rdfs:comment">Nonprofit527: Non-profit type referring to Political organizations.</span>
+  <link property="http://schema.org/isPartOf" href="http://pending.schema.org" />
+  <span>Source:  <a property="dc:source" href="https://github.com/schemaorg/schemaorg/issues/2543">#2543</a></span>
+</div>
+
+<div typeof="http://schema.org/NonprofitType" resource="http://schema.org/CharitableIncorporatedOrganization">
+  <span>Category: <span property="schema:category">issue-2543</span></span>
+  <span class="h" property="rdfs:label">CharitableIncorporatedOrganization</span>
+  <span property="rdfs:comment">CharitableIncorporatedOrganization: Non-profit type referring to a Charitable Incorporated Organization (UK).</span>
+  <link property="http://schema.org/isPartOf" href="http://pending.schema.org" />
+  <span>Source:  <a property="dc:source" href="https://github.com/schemaorg/schemaorg/issues/2543">#2543</a></span>
+</div>
+
+<div typeof="http://schema.org/NonprofitType" resource="http://schema.org/LimitedByGuaranteeCharity">
+  <span>Category: <span property="schema:category">issue-2543</span></span>
+  <span class="h" property="rdfs:label">LimitedByGuarantee</span>
+  <span property="rdfs:comment">LimitedByGuarantee: Non-profit type referring to a charitable company that is limited by guarantee (UK).</span>
+  <link property="http://schema.org/isPartOf" href="http://pending.schema.org" />
+  <span>Source:  <a property="dc:source" href="https://github.com/schemaorg/schemaorg/issues/2543">#2543</a></span>
+</div>
+
+<div typeof="http://schema.org/NonprofitType" resource="http://schema.org/UnincorporatedAssociationCharity">
+  <span>Category: <span property="schema:category">issue-2543</span></span>
+  <span class="h" property="rdfs:label">UnincorporatedAssociation</span>
+  <span property="rdfs:comment">UnincorporatedAssociation: Non-profit type referring to a charitable company that is not incorporated (UK).</span>
+  <link property="http://schema.org/isPartOf" href="http://pending.schema.org" />
+  <span>Source:  <a property="dc:source" href="https://github.com/schemaorg/schemaorg/issues/2543">#2543</a></span>
+</div>
+
+<div typeof="http://schema.org/NonprofitType" resource="http://schema.org/UKTrust">
+  <span>Category: <span property="schema:category">issue-2543</span></span>
+  <span class="h" property="rdfs:label">UKTrust</span>
+  <span property="rdfs:comment">501c: Non-profit type referring to a UK trust.</span>
+  <link property="http://schema.org/isPartOf" href="http://pending.schema.org" />
+  <span>Source:  <a property="dc:source" href="https://github.com/schemaorg/schemaorg/issues/2543">#2543</a></span>
+</div>
+
+</div>

--- a/data/ext/pending/issue-2543.rdfa
+++ b/data/ext/pending/issue-2543.rdfa
@@ -334,7 +334,23 @@
 <div typeof="http://schema.org/NonprofitType" resource="http://schema.org/UKTrust">
   <span>Category: <span property="schema:category">issue-2543</span></span>
   <span class="h" property="rdfs:label">UKTrust</span>
-  <span property="rdfs:comment">501c: Non-profit type referring to a UK trust.</span>
+  <span property="rdfs:comment">UKTrust: Non-profit type referring to a UK trust.</span>
+  <link property="http://schema.org/isPartOf" href="http://pending.schema.org" />
+  <span>Source:  <a property="dc:source" href="https://github.com/schemaorg/schemaorg/issues/2543">#2543</a></span>
+</div>
+
+<div typeof="http://schema.org/NonprofitType" resource="http://schema.org/NonprofitANBI">
+  <span>Category: <span property="schema:category">issue-2543</span></span>
+  <span class="h" property="rdfs:label">NonprofitANBI</span>
+  <span property="rdfs:comment">NonprofitANBI: Non-profit type referring to a Public Benefit Organization (NL).</span>
+  <link property="http://schema.org/isPartOf" href="http://pending.schema.org" />
+  <span>Source:  <a property="dc:source" href="https://github.com/schemaorg/schemaorg/issues/2543">#2543</a></span>
+</div>
+
+<div typeof="http://schema.org/NonprofitType" resource="http://schema.org/NonprofitSBBI">
+  <span>Category: <span property="schema:category">issue-2543</span></span>
+  <span class="h" property="rdfs:label">NonprofitSBBI</span>
+  <span property="rdfs:comment">NonprofitSBBI: Non-profit type referring to a Social Interest Promoting Institution (NL).</span>
   <link property="http://schema.org/isPartOf" href="http://pending.schema.org" />
   <span>Source:  <a property="dc:source" href="https://github.com/schemaorg/schemaorg/issues/2543">#2543</a></span>
 </div>

--- a/data/ext/pending/issue-2543.rdfa
+++ b/data/ext/pending/issue-2543.rdfa
@@ -147,7 +147,7 @@
   <span>Source:  <a property="dc:source" href="https://github.com/schemaorg/schemaorg/issues/2543">#2543</a></span>
 </div>
 
-<div typeof="http://schema.org/NonprofitType" resource="http://schema.org/Nonprofit01c17">
+<div typeof="http://schema.org/NonprofitType" resource="http://schema.org/Nonprofit501c17">
   <span>Category: <span property="schema:category">issue-2543</span></span>
   <span class="h" property="rdfs:label">Nonprofit501c17</span>
   <span property="rdfs:comment">Nonprofit501c17: Non-profit type referring to Supplemental Unemployment Benefit Trusts.</span>
@@ -317,16 +317,16 @@
 
 <div typeof="http://schema.org/NonprofitType" resource="http://schema.org/LimitedByGuaranteeCharity">
   <span>Category: <span property="schema:category">issue-2543</span></span>
-  <span class="h" property="rdfs:label">LimitedByGuarantee</span>
-  <span property="rdfs:comment">LimitedByGuarantee: Non-profit type referring to a charitable company that is limited by guarantee (UK).</span>
+  <span class="h" property="rdfs:label">LimitedByGuaranteeCharity</span>
+  <span property="rdfs:comment">LimitedByGuaranteeCharity: Non-profit type referring to a charitable company that is limited by guarantee (UK).</span>
   <link property="http://schema.org/isPartOf" href="http://pending.schema.org" />
   <span>Source:  <a property="dc:source" href="https://github.com/schemaorg/schemaorg/issues/2543">#2543</a></span>
 </div>
 
 <div typeof="http://schema.org/NonprofitType" resource="http://schema.org/UnincorporatedAssociationCharity">
   <span>Category: <span property="schema:category">issue-2543</span></span>
-  <span class="h" property="rdfs:label">UnincorporatedAssociation</span>
-  <span property="rdfs:comment">UnincorporatedAssociation: Non-profit type referring to a charitable company that is not incorporated (UK).</span>
+  <span class="h" property="rdfs:label">UnincorporatedAssociationCharity</span>
+  <span property="rdfs:comment">UnincorporatedAssociationCharity: Non-profit type referring to a charitable company that is not incorporated (UK).</span>
   <link property="http://schema.org/isPartOf" href="http://pending.schema.org" />
   <span>Source:  <a property="dc:source" href="https://github.com/schemaorg/schemaorg/issues/2543">#2543</a></span>
 </div>


### PR DESCRIPTION
This will allow coverage of non-profit organizations in schema.org. Since non-profits fall under different categories in different countries, the added property of nonprofitStatus will allow this to be an internationally applicable schema.

Addresses issue #2543