### PR TITLE
adding hasCourse for parts of an Ed/Occ Program, issue #2483

### DIFF
--- a/data/ext/pending/issue-2438.rdfa
+++ b/data/ext/pending/issue-2438.rdfa
@@ -1,0 +1,14 @@
+<div>
+<!-- Provides a property hasCourse to specify courses that are part of an EducationalOccupationalProgram, issue 2483 -->
+
+    <div typeof="rdf:Property" resource="http://schema.org/hasCourse">
+      <span>Category: <span property="schema:category">issue-2483</span></span>
+      <span class="h" property="rdfs:label">hasCourse</span>
+      <span property="rdfs:comment">A course or class that is one of the learning opportunities that constitute an educational/occupational program. No information is implied about whether the course is mandatory or optional; no guarantee is implied about whether the course will be available to everyone on the program.</span>
+      <span>domainIncludes: <a property="http://schema.org/domainIncludes" href="http://schema.org/EducationalOccupationalProgram">EducationalOccupationalProgram</a></span>
+      <span>rangeIncludes: <a property="http://schema.org/rangeIncludes" href="http://schema.org/Course">Course</a></span>
+      <link property="http://schema.org/isPartOf" href="http://pending.schema.org" />
+      <span>Source:  <a property="dc:source" href="https://github.com/schemaorg/schemaorg/issues/2483">#2483</a></span>
+    </div>
+
+</div>


### PR DESCRIPTION
Text for release notes (pending section)
<li id="g2483"><a href="https://github.com/schemaorg/schemaorg/issues/2483">Issue 2483</a>: Add <a href="/hasCourse">hasCourse</a>  property to <a href="/EducationalOccupationalProgram">EducationalOccupationalProgram</a> to specify which courses are components of a program.</li>

closes #2483