### PR TITLE
schema:url equivalent to foaf:page

### DIFF
--- a/data/schema.ttl
+++ b/data/schema.ttl
@@ -9183,6 +9183,7 @@ we define a supporting type, [[SpeakableSpecification]]  which is defined to be 
     :domainIncludes :Thing ;
     :rangeIncludes :URL ;
     rdfs:comment "URL of the item." .
+    owl:equivalentProperty <http://xmlns.com/foaf/0.1/page> .
 
 :urlTemplate a rdf:Property ;
     rdfs:label "urlTemplate" ;

--- a/data/schema.ttl
+++ b/data/schema.ttl
@@ -9182,7 +9182,7 @@ we define a supporting type, [[SpeakableSpecification]]  which is defined to be 
     rdfs:label "url" ;
     :domainIncludes :Thing ;
     :rangeIncludes :URL ;
-    rdfs:comment "URL of the item." .
+    rdfs:comment "URL of the item." ;
     owl:equivalentProperty <http://xmlns.com/foaf/0.1/page> .
 
 :urlTemplate a rdf:Property ;


### PR DESCRIPTION
Adds an alignment between schema:url and foaf:page.

I use DCAT, Schema.org, and FOAF to describe my dataset products. The alignment between Schema.org and FOAF currently exists in DCAT https://github.com/w3c/dxwg/blob/c58b79313c10be2ec13c32d8296098fbc050d216/dcat/rdf/dcat-schema.ttl#L223, not in Schema.org. 

The effect is that even though I may have no usage of DCAT vocabulary, whether I include the DCAT definitions or not affects my data described using Schema.org. 

I believe the alignment between FOAF and Schema.org is better served being in Schema.org, rather than being in a third vocabulary.