### PR TITLE
WIP: Attempt to run schemaorg instance through Docker

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,0 +1,9 @@
+FROM google/cloud-sdk:latest
+RUN apt-get install -y rsync git
+ADD . /schemaorg
+#RUN mkdir -p /schemaorg
+WORKDIR /schemaorg
+RUN git submodule update --init --recursive
+EXPOSE 8080
+CMD ./runpythonapp.sh
+

--- a/SOFTWARE_README.md
+++ b/SOFTWARE_README.md
@@ -48,6 +48,20 @@ Note: If you are informed of an update to the sdopythonapp submodule, use the co
 Note: To run subdomain areas of the application on a local development system eg.  `http://bib.localhost:8080/` the subdomains will need to be added to the local system's host file.  eg. `127.0.0.1 localhost bib.localhost pending.localhost` etc.
 
 
+Docker
+------
+
+If you are using [Docker](https://www.docker.com/) you can alternatively run:
+
+    docker build -t schemaorg .
+    docker run -v `pwd`:/schemaorg --net=host -it schemaorg
+
+then access <http://localhost:8080/>
+
+Note that because the sdopythonapp currently binds to `localhost` inside the
+container, the above needs `--net=host` and will probably only work on Linux.
+
+
 Internals
 =========
 


### PR DESCRIPTION
Here is my successful attempt of running the schemaorg appengine server through Docker, as I could not find any instructions on how to get the Python dependencies of `runpythonapp.sh` installed locally (requirements.txt anyone?) but loads of Devs know how to run Docker.

I mark this as `WIP` as it for now only works with `docker run --net=host` as I could not find any instructions on modifying the scripts to do equivalent of `--host=0.0.0.0`. There are also too many hardcoded instances of `localhost`. The side-effect is that this docker method only works on Linux for now, as you need to bind `0.0.0.0` to escape the container.

It would also be nice if there was a way to disable the interactive prompting and put it straight in local mode - perhaps someone more knowledgable with the `runpythonapp.sh` can suggest better command line args that the container can start?