### PR TITLE
Rationalisation of dump files

### DIFF
--- a/scripts/Rakefile
+++ b/scripts/Rakefile
@@ -95,7 +95,7 @@ file "spec/schema.rb" => :do_build do
   cmd += " --class-name SCHEMA"
   cmd += " --strict"
   cmd += " -o spec/schema.rb_t"
-  cmd += " #{rel}/schemaorg-current.nq"
+  cmd += " #{rel}/schemaorg-current-http.nq"
   puts "  #{cmd}"
   begin
     %x{#{cmd} && mv spec/schema.rb_t spec/schema.rb}

--- a/scripts/Rakefile
+++ b/scripts/Rakefile
@@ -95,7 +95,7 @@ file "spec/schema.rb" => :do_build do
   cmd += " --class-name SCHEMA"
   cmd += " --strict"
   cmd += " -o spec/schema.rb_t"
-  cmd += " #{rel}/all-layers.nq"
+  cmd += " #{rel}/schemaorg-current.nq"
   puts "  #{cmd}"
   begin
     %x{#{cmd} && mv spec/schema.rb_t spec/schema.rb}

--- a/scripts/buildreleasefiles.sh
+++ b/scripts/buildreleasefiles.sh
@@ -157,7 +157,7 @@ sleep 2
 
 
 echo -n "Copying README.md, SOFTWARE_README.md into release directory... "
-#cp ./data/schema.ttl $DIR - will be overwritten by dump creation
+cp ./data/schema.ttl $DIR 
 cp ./README.md $DIR
 cp ./SOFTWARE_README.md $DIR
 echo " copied"
@@ -198,24 +198,13 @@ echo
 echo "Creating dump files - this takes a while......."
 sleep 2
 echo
-echo "Creating full dump files: "
+echo "Creating full dump files (schemaorg-current): "
 #dump core extensions schema "$LIMIT"
-dump "" "" schema "$LIMIT"
+dump "" "attic" schemaorg-current "$LIMIT"
 
 echo
-echo "Creating all-layers copies (for backwards compatibility): "
-#dump "" "" all-layers "$LIMIT"
-(
-cd $DIR
-for i in .jsonld .ttl .nt .nq .rdf -properties.csv -types.csv
-do
-    if [ -f "schema$i" ]
-    then
-        echo "schema$i ->  all-layers$i"
-        cp schema$i all-layers$i
-    fi
-done
-)
+echo "Creating full + attic dump files (schemaorg-all): "
+dump "attic" "" schemaorg-all "$LIMIT"
 
 if [ $EXTS -eq 1 ]
 then

--- a/scripts/buildreleasefiles.sh
+++ b/scripts/buildreleasefiles.sh
@@ -200,11 +200,29 @@ sleep 2
 echo
 echo "Creating full dump files (schemaorg-current): "
 #dump core extensions schema "$LIMIT"
-dump "" "attic" schemaorg-current "$LIMIT"
+dump "" "attic" schemaorg-current-http "$LIMIT"
 
 echo
 echo "Creating full + attic dump files (schemaorg-all): "
-dump "attic" "" schemaorg-all "$LIMIT"
+dump "attic" "" schemaorg-all-http "$LIMIT"
+
+echo "Creating https versions:"
+(
+    cd $DIR
+    for file in schemaorg-current schemaorg-all 
+    do
+        for ext in .ttl .rdf .jsonld .nq .nt -properties.csv -types.csv
+        do
+            SOURCE="${file}-http${ext}" 
+            TARGET="${file}-https${ext}"
+            if [ -r $SOURCE ]
+            then
+                echo "$SOURCE -> $TARGET"
+                sed 's|http://schema.org|https://schema.org|g' $SOURCE > $TARGET
+            fi
+        done
+    done
+)
 
 if [ $EXTS -eq 1 ]
 then

--- a/scripts/buildreleasefiles.sh
+++ b/scripts/buildreleasefiles.sh
@@ -14,7 +14,7 @@ fi
 function usage {
     echo "usage: $(basename $0) [-y] [-e] [-c] [-o] [-s] [-m] [-t] [-limit somevalue] VERSION"
     echo "    -y   Assume yes to continue"
-    echo "    -e   No extentstions (only produce core and all-layers)"
+#    echo "    -e   No extentstions (only produce core and all-layers)"
     echo "    -c   No context file"
     echo "    -o   No owl file"
     echo "    -s   No schema-all.htmlfile"
@@ -35,7 +35,7 @@ CONTEXT=1
 RELS=1
 OWL=1
 MAP=1
-EXTS=1
+EXTS=0
 TESTS=1
 while getopts 'yecstoml:' OPTION; do
   case "$OPTION" in
@@ -156,9 +156,10 @@ echo " cleaned."
 sleep 2
 
 
-echo -n "Copying schema.ttl and README.md into release directory... "
-cp ./data/schema.ttl $DIR
+echo -n "Copying README.md, SOFTWARE_README.md into release directory... "
+#cp ./data/schema.ttl $DIR - will be overwritten by dump creation
 cp ./README.md $DIR
+cp ./SOFTWARE_README.md $DIR
 echo " copied"
 sleep 2
 
@@ -197,12 +198,21 @@ echo
 echo "Creating dump files - this takes a while......."
 sleep 2
 echo
-echo "Creating core: "
-dump core extensions schema "$LIMIT"
+echo "Creating full dump files: "
+#dump core extensions schema "$LIMIT"
+dump "" "" schema "$LIMIT"
 
 echo
-echo "Creating all-layers: "
-dump "" "" all-layers "$LIMIT"
+echo "Creating all-layers copies (for backwards compatibility): "
+#dump "" "" all-layers "$LIMIT"
+(
+cd $DIR
+for i in .jsonld .ttl .nt .nq .rdf -properties.csv -types.csv
+do
+    echo "schema$i ->  all-layers$i"
+    cp schema$i all-layers$i
+done
+)
 
 if [ $EXTS -eq 1 ]
 then

--- a/scripts/buildreleasefiles.sh
+++ b/scripts/buildreleasefiles.sh
@@ -209,8 +209,11 @@ echo "Creating all-layers copies (for backwards compatibility): "
 cd $DIR
 for i in .jsonld .ttl .nt .nq .rdf -properties.csv -types.csv
 do
-    echo "schema$i ->  all-layers$i"
-    cp schema$i all-layers$i
+    if [ -f "schema$i" ]
+    then
+        echo "schema$i ->  all-layers$i"
+        cp schema$i all-layers$i
+    fi
 done
 )
 

--- a/scripts/scansite.py
+++ b/scripts/scansite.py
@@ -21,7 +21,7 @@ host = "schema.org"
 
 #verbose = True
 
-fn = 'data/releases/%s/all-layers.jsonld' % v # Per-release JSON-LD dumps.
+fn = 'data/releases/%s/schemaorg-current.jsonld' % v # Per-release JSON-LD dumps.
 found = []
 checked = 0
 

--- a/templates/developers.tpl
+++ b/templates/developers.tpl
@@ -28,12 +28,13 @@ This is a placeholder page for developer-oriented information about schema.org. 
 
 <h2 id="defs">Vocabulary Definition Files</h2>
 
-<p>To assist developers, files containing the definition of the core Schema.org vocabulary and its extensions are available for download in common RDF formats.</p>
+<p>To assist developers, files containing the definition of the current version of the Schema.org vocabulary is available for download in common RDF formats.</p>
 
-<p>Older releases can be found (under data/releases/) at <a href="https://github.com/schemaorg/schemaorg">GitHub</a>.
+<p>Older release versions can be found (under <code>data/releases/</code>) in <a href="https://github.com/schemaorg/schemaorg">GitHub</a>.
 
 <p>Select the file and format required and click Download.  The CSV format downloads are split accross two files: <em>Types</em> includes definitions of Types and Enumeration Values, including lists of associated properties; <em>Properties</em> contains property definitions.<br/>
-<br/><strong>Note:</strong> File <em>schema</em> contains the definition of the core vocabulary; <em>bib</em> contains only the definitions for the bib.schema.org extension; <strong><em>all-layers</em></strong> contains definitions for <strong><em>all terms</em></strong> (core plus all extensions).</p>
+<br/>
+<strong>Note:</strong> [From V9.0 onwards] File <em>schema</em> contains the definition of all terms in, all sections of, the vocabulary.  For backwards compatiility, <em>all-layers</em> also contains definitions for all terms.</p>
 
 
 	<table style="padding: 2px; width:600px">
@@ -41,9 +42,11 @@ This is a placeholder page for developer-oriented information about schema.org. 
 			File: <select id="filename"  onchange="updatetext()">
 				<option value="/version/latest/schema">schema</option>
 				<option value="/version/latest/all-layers">all-layers</option>
+                <!--  Remove from V9.0 as only schema & all0-layers versions built
 				{% for ext in extensions %}
 					<option value="/version/latest/ext-{{ ext | safe }}">{{ ext | safe }}</option>
 				{% endfor %}
+                -->
 			</select>
 	</td>
 	<td style="width: 30%;">

--- a/templates/developers.tpl
+++ b/templates/developers.tpl
@@ -34,14 +34,14 @@ This is a placeholder page for developer-oriented information about schema.org. 
 
 <p>Select the file and format required and click Download.  The CSV format downloads are split accross two files: <em>Types</em> includes definitions of Types and Enumeration Values, including lists of associated properties; <em>Properties</em> contains property definitions.<br/>
 <br/>
-<strong>Note:</strong> [From V9.0 onwards] File <em>schema</em> contains the definition of all terms in, all sections of, the vocabulary.  For backwards compatiility, <em>all-layers</em> also contains definitions for all terms.</p>
-
+File <em>schemaorg-current</em> contains the definition of all terms in, all sections of, the vocabulary.  The file <em>schemaorg-all</em> contains the definition of all terms in, all sections of, the vocabulary, <strong>plus</strong> terms retired from the vocabulary (<em>See the <a href="/docs/attic.home.html">attic section</a> for details</em>).</p>
+<br/>
 
 	<table style="padding: 2px; width:600px">
 	<tr><td style="width: 30%;">
 			File: <select id="filename"  onchange="updatetext()">
-				<option value="/version/latest/schema">schema</option>
-				<option value="/version/latest/all-layers">all-layers</option>
+				<option value="/version/latest/schemaorg-current">schemaorg-current</option>
+				<option value="/version/latest/schemaorg-all">schemaorg-all</option>
                 <!--  Remove from V9.0 as only schema & all0-layers versions built
 				{% for ext in extensions %}
 					<option value="/version/latest/ext-{{ ext | safe }}">{{ ext | safe }}</option>
@@ -51,11 +51,11 @@ This is a placeholder page for developer-oriented information about schema.org. 
 	</td>
 	<td style="width: 30%;">
 		Format:  <select id="fileext" onchange="updatetext()">
+				<option value=".jsonld">JSON-LD</option>
+				<option value=".ttl">Turtle</option>
 				<option value=".nt">Triples</option>
 				<option value=".nq">Quads</option>
-				<option value=".jsonld">JSON-LD</option>
 				<option value=".rdf">RDF/XML</option>
-				<option value=".ttl">Turtle</option>
 				<option value=".csv">CSV</option>
 		</select>
 	</td>
@@ -70,7 +70,7 @@ This is a placeholder page for developer-oriented information about schema.org. 
 	</td>
 	</tr>
 	<tr><td colspan="3">
-		<div id="label"></div>
+		<div id="label"  style="padding: 5px;"></div>
 	<tr><td colspan="3" style="text-align: center;">
 		<input type="button" onclick="dowloadfunc();" value="Download"/>
 	</td></tr>

--- a/templates/developers.tpl
+++ b/templates/developers.tpl
@@ -24,7 +24,7 @@ This is a placeholder page for developer-oriented information about schema.org. 
 
 <h2 id="conneg">Machine Readable Term Definitions</h2>
 
-<p>Machine-readable definitions of individual terms are availble as RDFa, embeded into the term page html. </p>
+<p>Machine-readable definitions of individual terms are available as RDFa, embedded into the term page html. </p>
 
 <h2 id="defs">Vocabulary Definition Files</h2>
 
@@ -32,16 +32,21 @@ This is a placeholder page for developer-oriented information about schema.org. 
 
 <p>Older release versions can be found (under <code>data/releases/</code>) in <a href="https://github.com/schemaorg/schemaorg">GitHub</a>.
 
-<p>Select the file and format required and click Download.  The CSV format downloads are split accross two files: <em>Types</em> includes definitions of Types and Enumeration Values, including lists of associated properties; <em>Properties</em> contains property definitions.<br/>
+<p>Select the file and format required and click Download.  The CSV format downloads are split across two files: <em>Types</em> includes definitions of Types and Enumeration Values, including lists of associated properties; <em>Properties</em> contains property definitions.<br/>
 <br/>
-File <em>schemaorg-current</em> contains the definition of all terms in, all sections of, the vocabulary.  The file <em>schemaorg-all</em> contains the definition of all terms in, all sections of, the vocabulary, <strong>plus</strong> terms retired from the vocabulary (<em>See the <a href="/docs/attic.home.html">attic section</a> for details</em>).</p>
+File <em>schemaorg-current-http</em> contains the definition of all terms in, all sections of, the vocabulary.  The file <em>schemaorg-all-https</em> contains the definition of all terms in, all sections of, the vocabulary, <strong>plus</strong> terms retired from the vocabulary (<em>See the <a href="/docs/attic.home.html">attic section</a> for details</em>).</p>
+
+<p>For those preferring to use https based definitions of Schema.org terms, these equivalent definitions are available in the <em>schemaorg-current-https<em> and <em>schemaorg-all-https<em> files. For more information on using http or https based terms see the <a href="https://schema.org/docs/faq.html#19">FAQ</a> for details.</p>
 <br/>
 
 	<table style="padding: 2px; width:600px">
-	<tr><td style="width: 30%;">
-			File: <select id="filename"  onchange="updatetext()">
-				<option value="/version/latest/schemaorg-current">schemaorg-current</option>
-				<option value="/version/latest/schemaorg-all">schemaorg-all</option>
+	<tr><td style="width: 40%;">
+			File: <br/>
+            <select id="filename"  onchange="updatetext()">
+				<option value="/version/latest/schemaorg-current-http">schemaorg-current-http</option>
+				<option value="/version/latest/schemaorg-all-http">schemaorg-all-http</option>
+				<option value="/version/latest/schemaorg-current-https">schemaorg-current-https</option>
+				<option value="/version/latest/schemaorg-all-https">schemaorg-all-https</option>
                 <!--  Remove from V9.0 as only schema & all0-layers versions built
 				{% for ext in extensions %}
 					<option value="/version/latest/ext-{{ ext | safe }}">{{ ext | safe }}</option>
@@ -50,7 +55,8 @@ File <em>schemaorg-current</em> contains the definition of all terms in, all sec
 			</select>
 	</td>
 	<td style="width: 30%;">
-		Format:  <select id="fileext" onchange="updatetext()">
+		Format: <br/> 
+        <select id="fileext" onchange="updatetext()">
 				<option value=".jsonld">JSON-LD</option>
 				<option value=".ttl">Turtle</option>
 				<option value=".nt">Triples</option>
@@ -61,7 +67,7 @@ File <em>schemaorg-current</em> contains the definition of all terms in, all sec
 	</td>
 	<td style="width: 30%;">
 		<div id ="csvsel">
-			For: <select id="csvfmt" onchange="updatetext()">
+			For: <br/><select id="csvfmt" onchange="updatetext()">
 				<option value="-types">Types</option>
 				<option value="-properties">Properties</option>
 				<!-- <option value="-enumvalues">Enumeration Values</option> -->


### PR DESCRIPTION
Simplified and expanded dump files and updated associated documentation.

Results in:  
- _schema_.* files now contain all terms.
- _all-layers._* are duplicates of these updated _schema_.* files
- updates to _docs/developers.html_ to reflect these changes

Implements issue #2304

**Note:** The associated tweaks to the documentation assumes this PR will be merged and shipped in V9.0.  If it does not make it into V9.0, there will be a need for a very minor tweak to the wording.