### PR TITLE
Issue 851: a parentItem of a Comment should be Comment, not Question

### DIFF
--- a/data/releases/9.0/schema.ttl
+++ b/data/releases/9.0/schema.ttl
@@ -7465,7 +7465,7 @@ Note: for historical reasons, any textual label and formal code provided as a li
 :parentItem a rdf:Property ;
     rdfs:label "parentItem" ;
     :domainIncludes :Comment ;
-    :rangeIncludes :Comment ;
+    :rangeIncludes :Question ;
     rdfs:comment "The parent of a question, answer or item in general." .
 
 :parentService a rdf:Property ;

--- a/data/releases/9.0/schema.ttl
+++ b/data/releases/9.0/schema.ttl
@@ -7465,7 +7465,7 @@ Note: for historical reasons, any textual label and formal code provided as a li
 :parentItem a rdf:Property ;
     rdfs:label "parentItem" ;
     :domainIncludes :Comment ;
-    :rangeIncludes :Question ;
+    :rangeIncludes :Comment ;
     rdfs:comment "The parent of a question, answer or item in general." .
 
 :parentService a rdf:Property ;

--- a/data/schema.ttl
+++ b/data/schema.ttl
@@ -7465,7 +7465,7 @@ Note: for historical reasons, any textual label and formal code provided as a li
 :parentItem a rdf:Property ;
     rdfs:label "parentItem" ;
     :domainIncludes :Comment ;
-    :rangeIncludes :Question ;
+    :rangeIncludes :Comment ;
     rdfs:comment "The parent of a question, answer or item in general." .
 
 :parentService a rdf:Property ;


### PR DESCRIPTION
a parentItem of a Comment should be Comment, not Question. planned for v10 release (see issue #2648)

(edited to write " issue 2648" with a # in it so it gets automatically linked to the issue by github --danbri)