### PR TITLE
Add LearningResource to domain of learningResourceType

### DIFF
--- a/data/schema.ttl
+++ b/data/schema.ttl
@@ -6716,7 +6716,8 @@ Typical unit code(s): MTK for square meter, FTK for square foot, or YDK for squa
 
 :learningResourceType a rdf:Property ;
     rdfs:label "learningResourceType" ;
-    :domainIncludes :CreativeWork ;
+    :domainIncludes :CreativeWork,
+        :LearningResource ;
     :rangeIncludes :Text ;
     rdfs:comment "The predominant type or kind characterizing the learning resource. For example, 'presentation', 'handout'." .
 


### PR DESCRIPTION
Fixes the ommision of learningResourceType as a property of LearningResource, issue #1401 