### PR TITLE
Structure the ingredients of recipes better

### DIFF
--- a/data/ext/pending/pullrequest-2738-examples.txt
+++ b/data/ext/pending/pullrequest-2738-examples.txt
@@ -1,0 +1,170 @@
+TYPES: #eg-0458 Recipe, recipeIngredient, RecipeIngredientGroup
+
+PRE-MARKUP:
+
+Italian Pizza
+By Christian Wolf, Oct 14, 2020
+
+A very delicious pizza
+
+Ingredients for the Dough:
+- 200 g of flour
+- 1 pack of leaven
+- 1 eating spoon of olive oil
+...
+
+Ingredients for the topping:
+- 1 can of smashed tomatoes
+- 50 g of cooked jam
+...
+
+Instructions:
+ Prepare a pre-douggh using the leaven and some warm water. Mix the remaining ingredients
+ for the dough with the prepared leaven. ...
+
+MICRODATA:
+
+<div itemscope itemtype="https://schema.org/Recipe">
+  <span itemprop="name">Italian Pizza</span>
+  By <span itemprop="author">Christian Wolf</span>,
+  <meta itemprop="datePublished" content="2020-10-14">Oct 10, 2020
+
+  <span itemprop="description">A very delicious pizza</span>
+
+  <ul>
+  <li itemprop="recipeIngredient" itemscope itemtype="https://schema.org/RecipeIngredientGroup">
+    Ingredients for the <span itemprop="name">dough</span>
+    <ul>
+    <li itemprop="recipeIngredient">200 g of flour</li>
+    <li itemprop="recipeIngredient">1 pack of leaven</li>
+    <li itemprop="recipeIngredient">1 eating spoon of olive oil</li>
+    ...
+    </ul>
+  </li>
+  <li itemprop="recipeIngredient" itemscope itemtype="https://schema.org/RecipeIngredientGroup">
+    Ingredients for the <span itemprop="name">topping</span>
+    <ul>
+    <li itemprop="recipeIngredient" itemscope itemtype="https://schema.org/TypeAndQuantityNode">
+      <span itemprop="amountOfThisGood">1</span>
+      <span itemprop="unitText">can</span> of 
+      <span itemprop="typeOfGood" itemscope itemtype="https://schema.org/Product">
+        <span itemprop="name">tomatoes</span> (<span itemprop="description">smashed</span>)
+      </span>
+    </li>
+    <li itemprop="recipeIngredient" itemscope itemtype="https://schema.org/TypeAndQuantityNode">
+      <span itemprop="amountOfThisGood">50</span>
+      <span itemprop="unitText">g</span> of 
+      <span itemprop="typeOfGood" itemscope itemtype="https://schema.org/Product">
+        <span itemprop="name">jam</span> (<span itemprop="description">cooked</span>)
+      </span>
+    </li>
+    ...
+    </ul>
+  </li>
+  </ul>
+
+  Instructions:
+  <span itemprop="recipeInstructions">
+  Prepare a pre-douggh using the leaven and some warm water. Mix the remaining ingredients
+  for the dough with the prepared leaven. ...
+  </span>
+</div>
+
+RDFA:
+
+<div vocab="https://schema.org/" typeof="Recipe">
+  <span property="name">Italian Pizza</span>
+  By <span property="author">Christian Wolf</span>,
+  <meta property="datePublished" content="2020-10-14">Oct 10, 2020
+
+  <span property="description">A very delicious pizza</span>
+
+  <ul>
+  <li property="recipeIngredient" typeof="RecipeIngredientGroup">
+    Ingredients for the <span property="name">dough</span>
+    <ul>
+    <li property="recipeIngredient">200 g of flour</li>
+    <li property="recipeIngredient">1 pack of leaven</li>
+    <li property="recipeIngredient">1 eating spoon of olive oil</li>
+    ...
+    </ul>
+  </li>
+  <li property="recipeIngredient" typeof="RecipeIngredientGroup">
+    Ingredients for the <span property="name">topping</span>
+    <ul>
+    <li property="recipeIngredient" typeof="TypeAndQuantityNode">
+      <span property="amountOfThisGood">1</span>
+      <span property="unitText">can</span> of 
+      <span property="typeOfGood" typeof="Product">
+        <span property="name">tomatoes</span> (<span property="description">smashed</span>)
+      </span>
+    </li>
+    <li property="recipeIngredient" typeof="TypeAndQuantityNode">
+      <span property="amountOfThisGood">50</span>
+      <span property="unitText">g</span> of 
+      <span property="typeOfGood" typeof="Product">
+        <span property="name">jam</span> (<span property="description">cooked</span>)
+      </span>
+    </li>
+    ...
+    </ul>
+  </li>
+  </ul>
+
+  Instructions:
+  <span property="recipeInstructions">
+  Prepare a pre-douggh using the leaven and some warm water. Mix the remaining ingredients
+  for the dough with the prepared leaven. ...
+  </span>
+</div>
+
+JSON:
+
+<script type="application/ld+json">
+{
+  "@context": "https://schema.org",
+  "@type": "Recipe",
+  "author": "Christian Wolf",
+  "datePublished": "2020-10-14",
+  "description": "A very delicious pizza",
+  "recipeIngredient": [
+    {
+      "@type": "RecipeIngredientGroup",
+      "name": "dough",
+      "recipeIngredient": [
+        "200 g of flour",
+        "1 pack of leaven",
+        "1 eating spoon of olive oil"
+      ]
+    },
+    {
+      "@type": "RecipeIngredientGroup",
+      "name": "topping",
+      "recipeIngredient": [
+        {
+          "@type": "TypeAndQuantityNode",
+          "amountOfThisGood": "1",
+          "unitText": "can",
+          "typeOfGood": {
+            "@type": "Product",
+            "name": "tomatoes",
+            "description": "smashed"
+          }
+        },
+        {
+          "@type": "TypeAndQuantityNode",
+          "amountOfThisGood": "50",
+          "unitText": "g",
+          "typeOfGood": {
+            "@type": "Product",
+            "name": "jam",
+            "description": "cooked"
+          }
+        }
+      ]
+    }
+  ],
+  "name": "Italian Pizza",
+  "recipeInstructions": "Prepare a pre-douggh using the leaven and some warm water. Mix the remaining ingredients for the dough with the prepared leaven. ...",
+}
+</script>

--- a/data/ext/pending/pullrequest-2738-examples.txt
+++ b/data/ext/pending/pullrequest-2738-examples.txt
@@ -143,7 +143,7 @@ JSON:
       "recipeIngredient": [
         {
           "@type": "TypeAndQuantityNode",
-          "amountOfThisGood": "1",
+          "amountOfThisGood": 1,
           "unitText": "can",
           "typeOfGood": {
             "@type": "Product",
@@ -153,7 +153,7 @@ JSON:
         },
         {
           "@type": "TypeAndQuantityNode",
-          "amountOfThisGood": "50",
+          "amountOfThisGood": 50,
           "unitText": "g",
           "typeOfGood": {
             "@type": "Product",

--- a/data/ext/pending/pullrequest-2738.ttl
+++ b/data/ext/pending/pullrequest-2738.ttl
@@ -1,0 +1,18 @@
+@prefix : <http://schema.org/> .
+@prefix rdf: <http://www.w3.org/1999/02/22-rdf-syntax-ns#> .
+@prefix rdfs: <http://www.w3.org/2000/01/rdf-schema#> .
+
+:RecipeIngredientGroup a rdfs:Class ;
+    rdfs:label "RecipeIngredientGroup" ;
+    :category "pullrequest-2738" ;
+    :isPartOf <http://pending.schema.org> ;
+    rdfs:comment "A group if ingredients of a [[Recipe]] for a certain part. For example, cream and dough of a cake can be different such groups." ;
+    rdfs:subClassOf :ListItem .
+
+:recipeIngredient a rdf:Property ;
+    rdfs:label "recipeIngredient" ;
+    :domainIncludes :RecipeIngredientGroup ;
+    :rangeIncludes :RecipeIngredientGroup,
+		:TypeAndQuantityNode ;
+    rdfs:comment "A single ingredient used in the recipe, e.g. sugar, flour or garlic or a group of ingredients used in the recipe." ;
+    rdfs:subPropertyOf :supply .

--- a/data/schema.ttl
+++ b/data/schema.ttl
@@ -2534,6 +2534,11 @@ The place is __open__ if the [[opens]] property is specified, and __closed__ oth
     rdfs:comment "A recipe. For dietary restrictions covered by the recipe, a few common restrictions are enumerated via [[suitableForDiet]]. The [[keywords]] property can also be used to add more detail." ;
     rdfs:subClassOf :HowTo .
 
+:RecipeIngredientGroup a rdfs:Class ;
+    rdfs:label "RecipeIngredientGroup" ;
+    rdfs:comment "A group if ingredients of a [[Recipe]] for a certain part. For example, cream and dough of a cake can be different such groups." ;
+    rdfs:subClassOf :ListItem .
+
 :RecyclingCenter a rdfs:Class ;
     rdfs:label "RecyclingCenter" ;
     rdfs:comment "A recycling center." ;
@@ -10016,8 +10021,10 @@ Unregistered or niche encoding and file formats can be indicated instead via the
 
 :recipeIngredient a rdf:Property ;
     rdfs:label "recipeIngredient" ;
-    :domainIncludes :Recipe ;
-    :rangeIncludes :Text ;
+    :domainIncludes :Recipe,
+        :RecipeIngredientGroup ;
+    :rangeIncludes :Text,
+        :TypeAndQuantityNode ;
     rdfs:comment "A single ingredient used in the recipe, e.g. sugar, flour or garlic." ;
     rdfs:subPropertyOf :supply .
 

--- a/data/schema.ttl
+++ b/data/schema.ttl
@@ -10028,6 +10028,13 @@ Unregistered or niche encoding and file formats can be indicated instead via the
     rdfs:comment "A single ingredient used in the recipe, e.g. sugar, flour or garlic." ;
     rdfs:subPropertyOf :supply .
 
+:recipeIngredientGroup a rdf:Property ;
+    rdfs:label "recipeIngredientGroup" ;
+    :domainIncludes :Recipe ;
+    :rangeIncludes :RecipeIngredientGroup ;
+    rdfs:comment "A group of ingredients for a recipe. This allows structuring the ingredients." ;
+    rdfs:subPropertyOf :supply .
+
 :recordedAs a rdf:Property ;
     rdfs:label "recordedAs" ;
     :domainIncludes :MusicComposition ;

--- a/data/schema.ttl
+++ b/data/schema.ttl
@@ -10018,7 +10018,6 @@ Unregistered or niche encoding and file formats can be indicated instead via the
     rdfs:label "recipeIngredient" ;
     :domainIncludes :Recipe ;
     :rangeIncludes :Text ;
-    rdfs:comment "A single ingredient used in the recipe, e.g. sugar, flour or garlic." ;
     rdfs:subPropertyOf :supply .
 
 :recordedAs a rdf:Property ;

--- a/data/schema.ttl
+++ b/data/schema.ttl
@@ -2534,11 +2534,6 @@ The place is __open__ if the [[opens]] property is specified, and __closed__ oth
     rdfs:comment "A recipe. For dietary restrictions covered by the recipe, a few common restrictions are enumerated via [[suitableForDiet]]. The [[keywords]] property can also be used to add more detail." ;
     rdfs:subClassOf :HowTo .
 
-:RecipeIngredientGroup a rdfs:Class ;
-    rdfs:label "RecipeIngredientGroup" ;
-    rdfs:comment "A group if ingredients of a [[Recipe]] for a certain part. For example, cream and dough of a cake can be different such groups." ;
-    rdfs:subClassOf :ListItem .
-
 :RecyclingCenter a rdfs:Class ;
     rdfs:label "RecyclingCenter" ;
     rdfs:comment "A recycling center." ;
@@ -10021,18 +10016,9 @@ Unregistered or niche encoding and file formats can be indicated instead via the
 
 :recipeIngredient a rdf:Property ;
     rdfs:label "recipeIngredient" ;
-    :domainIncludes :Recipe,
-        :RecipeIngredientGroup ;
-    :rangeIncludes :Text,
-        :TypeAndQuantityNode ;
-    rdfs:comment "A single ingredient used in the recipe, e.g. sugar, flour or garlic." ;
-    rdfs:subPropertyOf :supply .
-
-:recipeIngredientGroup a rdf:Property ;
-    rdfs:label "recipeIngredientGroup" ;
     :domainIncludes :Recipe ;
-    :rangeIncludes :RecipeIngredientGroup ;
-    rdfs:comment "A group of ingredients for a recipe. This allows structuring the ingredients." ;
+    :rangeIncludes :Text ;
+    rdfs:comment "A single ingredient used in the recipe, e.g. sugar, flour or garlic." ;
     rdfs:subPropertyOf :supply .
 
 :recordedAs a rdf:Property ;


### PR DESCRIPTION
The [Recipe](https://schema.org/Recipe) currently only supports unstructured text for the list of ingredients. This is unfavorable for multiple reasons:
1. Calculations based on the amount of servings is hard to accomplish (needs text parsing)
2. Grouping of ingredients is not possible. Many recipes have groups of ingredients and refer to these in the instructions (like "put all dry ingredients for the dough into a bowl").

This PR tries to accomplish this in a backward-compatible manner. It is related to #882 and #2628 and possibly other issues.

In fact, the motivation to file this PR is [this feature request](https://github.com/nextcloud/cookbook/issues/311) (and similar/duplicate ones not linked here). The [nextcloud cookbook app](https://github.com/nextcloud/cookbook) is an extension to the nextcloud server that allows to store recipes on the server to create personal, digital collections of recipes. One of the main development principles is to stick with the schema.org standard to save the recipes within the server. That way, the export/import into other applications should be kept maximally compatible. Acceptance of this PR will allow us to use the new functions while other applications can take their time for implementing this extension properly.

As this is my first contribution to schemaorg, I hope this suits your process. I was unaware how to overwrite the existing `recipeIngredient` property from within a `data/ext/pending/*.ttl` file. Thus, I changed directly on the `schema.ttl`. If there is a better way to get things done, please tell me. I will try to be conform to your requirements.