### PR TITLE
Updated invalid comment syntax

### DIFF
--- a/data/examples.txt
+++ b/data/examples.txt
@@ -5944,8 +5944,8 @@ This example is JSON only.
 
 JSON:
 
+<!--  John travel to Brazil. -->
 <script type="application/ld+json">
-  // John travel to Brazil.
 {
   "@context": "https://schema.org",
   "@type": "TravelAction",
@@ -5976,8 +5976,8 @@ This example is JSON only.
 
 JSON:
 
+<!--  John travel from the US to Brazil with Steve.-->
 <script type="application/ld+json">
-  // John travel from the US to Brazil with Steve.
 {
   "@context": "https://schema.org",
   "@type": "TravelAction",
@@ -6016,8 +6016,8 @@ This example is JSON only.
 
 JSON:
 
+<!--  John organized his webpage.-->
 <script type="application/ld+json">
-  // John organized his webpage.
 {
   "@context": "https://schema.org",
   "@type": "OrganizeAction",
@@ -6048,8 +6048,8 @@ This example is JSON only.
 
 JSON:
 
+<!--  John organized his business.-->
 <script type="application/ld+json">
-  // John organized his business.
 {
   "@context": "https://schema.org",
   "@type": "OrganizeAction",
@@ -6080,8 +6080,8 @@ This example is JSON only.
 
 JSON:
 
+<!--  John allocated 5 hours to exercise.-->
 <script type="application/ld+json">
-  // John allocated 5 hours to exercise.
 {
   "@context": "https://schema.org",
   "@type": "AllocateAction",
@@ -6116,8 +6116,8 @@ This example is JSON only.
 
 JSON:
 
+<!--  John accepted a plan to exercise to help with his obesity-->.
 <script type="application/ld+json">
-  // John accepted a plan to exercise to help with his obesity.
 {
   "@context": "https://schema.org",
   "@type": "AcceptAction",
@@ -6152,8 +6152,8 @@ This example is JSON only.
 
 JSON:
 
+<!--  Dr. John assigned an exercise plan to Steve.-->
 <script type="application/ld+json">
-  // Dr. John assigned an exercise plan to Steve.
 {
   "@context": "https://schema.org",
   "@type": "AssignAction",
@@ -6192,8 +6192,8 @@ This example is JSON only.
 
 JSON:
 
+<!--  Dr. John authorized Steve's diet.-->
 <script type="application/ld+json">
-  // Dr. John authorized Steve's diet.
 {
   "@context": "https://schema.org",
   "@type": "AuthorizeAction",
@@ -6232,8 +6232,8 @@ This example is JSON only.
 
 JSON:
 
+<!--  John rejected a plan to exercise that helps him with his obesity.-->
 <script type="application/ld+json">
-  // John rejected a plan to exercise that helps him with his obesity.
 {
   "@context": "https://schema.org",
   "@type": "RejectAction",
@@ -6268,8 +6268,8 @@ This example is JSON only.
 
 JSON:
 
+<!--  John applied to Harvard.-->
 <script type="application/ld+json">
-  // John applied to Harvard.
 {
   "@context": "https://schema.org",
   "@type": "ApplyAction",
@@ -6300,8 +6300,8 @@ This example is JSON only.
 
 JSON:
 
+<!--  John bookmarked a photo using instagram.-->
 <script type="application/ld+json">
-  // John bookmarked a photo using instagram.
 {
   "@context": "https://schema.org",
   "@type": "BookmarkAction",
@@ -6337,8 +6337,8 @@ This example is JSON only.
 
 JSON:
 
+<!--  John planned a trip with a travel agency.-->
 <script type="application/ld+json">
-  // John planned a trip with a travel agency.
 {
   "@context": "https://schema.org",
   "@type": "PlanAction",
@@ -6373,8 +6373,8 @@ This example is JSON only.
 
 JSON:
 
+<!--  John planned an exercise plan with Steve.-->
 <script type="application/ld+json">
-  // John planned an exercise plan with Steve.
 {
   "@context": "https://schema.org",
   "@type": "PlanAction",
@@ -6409,8 +6409,8 @@ This example is JSON only.
 
 JSON:
 
+<!--  John cancelled a trip with a travel agency.-->
 <script type="application/ld+json">
-  // John cancelled a trip with a travel agency.
 {
   "@context": "https://schema.org",
   "@type": "CancelAction",
@@ -6445,8 +6445,8 @@ This example is JSON only.
 
 JSON:
 
+<!--  John reserved a table for May.-->
 <script type="application/ld+json">
-  // John reserved a table for May.
 {
   "@context": "https://schema.org",
   "@type": "ReserveAction",
@@ -6478,8 +6478,8 @@ This example is JSON only.
 
 JSON:
 
+<!--  John scheduled an event to occur in May.-->
 <script type="application/ld+json">
-  // John scheduled an event to occur in May.
 {
   "@context": "https://schema.org",
   "@type": "ScheduleAction",
@@ -6511,8 +6511,8 @@ This example is JSON only.
 
 JSON:
 
+<!--  John played angry birds with Steve.-->
 <script type="application/ld+json">
-  // John played angry birds with Steve.
 {
   "@context": "https://schema.org",
   "@type": "PlayAction",
@@ -6547,8 +6547,8 @@ This example is JSON only.
 
 JSON:
 
+<!--  John ran 100 miles with Steve.-->
 <script type="application/ld+json">
-  // John ran 100 miles with Steve.
 {
   "@context": "https://schema.org",
   "@type": "ExerciseAction",
@@ -6581,8 +6581,8 @@ This example is JSON only.
 
 JSON:
 
+<!--  John played tennis against Steve.-->
 <script type="application/ld+json">
-  // John played tennis against Steve.
 {
   "@context": "https://schema.org",
   "@type": "ExerciseAction",
@@ -6614,8 +6614,8 @@ This example is JSON only.
 
 JSON:
 
+<!--  John performed as a DJ playing Daft Punk on his turntable at Woodstock.-->
 <script type="application/ld+json">
-  // John performed as a DJ playing Daft Punk on his turntable at Woodstock.
 {
   "@context": "https://schema.org",
   "@type": "PerformAction",
@@ -6654,8 +6654,8 @@ This example is JSON only.
 
 JSON:
 
+<!--  John searched for 'What is the answer to life the universe and everything?'.-->
 <script type="application/ld+json">
-  // John searched for 'What is the answer to life the universe and everything?'.
 {
   "@context": "https://schema.org",
   "@type": "SearchAction",
@@ -6683,8 +6683,8 @@ This example is JSON only.
 
 JSON:
 
+<!--  John searched for hotels.-->
 <script type="application/ld+json">
-  // John searched for hotels.
 {
   "@context": "https://schema.org",
   "@type": "SearchAction",
@@ -6712,8 +6712,8 @@ This example is JSON only.
 
 JSON:
 
+<!--  John traded a Book for US$ 50.-->
 <script type="application/ld+json">
-  // John traded a Book for US$ 50.
 {
   "@context": "https://schema.org",
   "@type": "TradeAction",
@@ -6746,8 +6746,8 @@ This example is JSON only.
 
 JSON:
 
+<!--  John bought a Book on amazon.com.-->
 <script type="application/ld+json">
-  // John bought a Book on amazon.com.
 {
   "@context": "https://schema.org",
   "@type": "BuyAction",
@@ -6782,8 +6782,8 @@ This example is JSON only.
 
 JSON:
 
+<!--  John donated $10 to Steve.-->
 <script type="application/ld+json">
-  // John donated $10 to Steve.
 {
   "@context": "https://schema.org",
   "@type": "DonateAction",
@@ -6816,8 +6816,8 @@ This example is JSON only.
 
 JSON:
 
+<!--  John ordered a Book on amazon.com.-->
 <script type="application/ld+json">
-  // John ordered a Book on amazon.com.
 {
   "@context": "https://schema.org",
   "@type": "OrderAction",
@@ -6852,8 +6852,8 @@ This example is JSON only.
 
 JSON:
 
+<!--  John paid US$ 1,500 for a flight.-->
 <script type="application/ld+json">
-  // John paid US$ 1,500 for a flight.
 {
   "@context": "https://schema.org",
   "@type": "PayAction",
@@ -6886,8 +6886,8 @@ This example is JSON only.
 
 JSON:
 
+<!--  John quoted a flight for US$ 1,500.-->
 <script type="application/ld+json">
-  // John quoted a flight for US$ 1,500.
 {
   "@context": "https://schema.org",
   "@type": "QuoteAction",
@@ -6920,8 +6920,8 @@ This example is JSON only.
 
 JSON:
 
+<!--  John rented a house from Steve.-->
 <script type="application/ld+json">
-  // John rented a house from Steve.
 {
   "@context": "https://schema.org",
   "@type": "RentAction",
@@ -6956,8 +6956,8 @@ This example is JSON only.
 
 JSON:
 
+<!--  John sold a Book on amazon.com.-->
 <script type="application/ld+json">
-  // John sold a Book on amazon.com.
 {
   "@context": "https://schema.org",
   "@type": "SellAction",
@@ -6993,8 +6993,8 @@ This example is JSON only.
 
 JSON:
 
+<!--  John tipped $10 to Steve.-->
 <script type="application/ld+json">
-  // John tipped $10 to Steve.
 {
   "@context": "https://schema.org",
   "@type": "TipAction",
@@ -7030,8 +7030,8 @@ This example is JSON only.
 
 JSON:
 
+<!--  John transfered his store from Brazil to the USA.-->
 <script type="application/ld+json">
-  // John transfered his store from Brazil to the USA.
 {
   "@context": "https://schema.org",
   "@type": "TransferAction",
@@ -7070,8 +7070,8 @@ This example is JSON only.
 
 JSON:
 
+<!--  John borrowed Steve's book.-->
 <script type="application/ld+json">
-  // John borrowed Steve's book.
 {
   "@context": "https://schema.org",
   "@type": "BorrowAction",
@@ -7106,8 +7106,8 @@ This example is JSON only.
 
 JSON:
 
+<!--  John downloaded the java updates.-->
 <script type="application/ld+json">
-  // John downloaded the java updates.
 {
   "@context": "https://schema.org",
   "@type": "DownloadAction",
@@ -7138,8 +7138,8 @@ This example is JSON only.
 
 JSON:
 
+<!--  John gave a book to Steve.-->
 <script type="application/ld+json">
-  // John gave a book to Steve.
 {
   "@context": "https://schema.org",
   "@type": "GiveAction",
@@ -7174,8 +7174,8 @@ This example is JSON only.
 
 JSON:
 
+<!--  John lent $10 to Steve.-->
 <script type="application/ld+json">
-  // John lent $10 to Steve.
 {
   "@context": "https://schema.org",
   "@type": "LendAction",
@@ -7211,8 +7211,8 @@ This example is JSON only.
 
 JSON:
 
+<!--  John received a book from Steve via UPS from Brazil to the USA.-->
 <script type="application/ld+json">
-  // John received a book from Steve via UPS from Brazil to the USA.
 {
   "@context": "https://schema.org",
   "@type": "ReceiveAction",
@@ -7259,8 +7259,8 @@ This example is JSON only.
 
 JSON:
 
+<!--  John returned the book to Steve.-->
 <script type="application/ld+json">
-  // John returned the book to Steve.
 {
   "@context": "https://schema.org",
   "@type": "ReturnAction",
@@ -7295,8 +7295,8 @@ This example is JSON only.
 
 JSON:
 
+<!--  John sent a book to Steve via UPS from Brazil to the USA.-->
 <script type="application/ld+json">
-  // John sent a book to Steve via UPS from Brazil to the USA.
 {
   "@context": "https://schema.org",
   "@type": "SendAction",
@@ -7343,8 +7343,8 @@ This example is JSON only.
 
 JSON:
 
+<!--  John gave a book to Steve.-->
 <script type="application/ld+json">
-  // John gave a book to Steve.
 {
   "@context": "https://schema.org",
   "@type": "GiveAction",
@@ -7379,8 +7379,8 @@ This example is JSON only.
 
 JSON:
 
+<!--  John updated his movie collection.-->
 <script type="application/ld+json">
-  // John updated his movie collection.
 {
   "@context": "https://schema.org",
   "@type": "UpdateAction",
@@ -7412,8 +7412,8 @@ This example is JSON only.
 
 JSON:
 
+<!--  John add a movie to his movie queue.-->
 <script type="application/ld+json">
-  // John add a movie to his movie queue.
 {
   "@context": "https://schema.org",
   "@type": "AddAction",
@@ -7449,8 +7449,8 @@ This example is JSON only.
 
 JSON:
 
+<!--  John added SAAS to his skillset.-->
 <script type="application/ld+json">
-  // John added SAAS to his skillset.
 {
   "@context": "https://schema.org",
   "@type": "AddAction",
@@ -7486,8 +7486,8 @@ This example is JSON only.
 
 JSON:
 
+<!--  John inserted a movie to his movie queue.-->
 <script type="application/ld+json">
-  // John inserted a movie to his movie queue.
 {
   "@context": "https://schema.org",
   "@type": "InsertAction",
@@ -7523,8 +7523,8 @@ This example is JSON only.
 
 JSON:
 
+<!--  John appended a movie to his movie queue.-->
 <script type="application/ld+json">
-  // John appended a movie to his movie queue.
 {
   "@context": "https://schema.org",
   "@type": "AppendAction",
@@ -7560,8 +7560,8 @@ This example is JSON only.
 
 JSON:
 
+<!--  John prepended a movie to his movie queue.-->
 <script type="application/ld+json">
-  // John prepended a movie to his movie queue.
 {
   "@context": "https://schema.org",
   "@type": "PrependAction",
@@ -7597,8 +7597,8 @@ This example is JSON only.
 
 JSON:
 
+<!--  John deleted The Internship from his movie queue.-->
 <script type="application/ld+json">
-  // John deleted The Internship from his movie queue.
 {
   "@context": "https://schema.org",
   "@type": "DeleteAction",
@@ -7634,8 +7634,8 @@ This example is JSON only.
 
 JSON:
 
+<!--  John replaced The Internship with The Wedding Crashers from his movie queue.-->
 <script type="application/ld+json">
-  // John replaced The Internship with The Wedding Crashers from his movie queue.
 {
   "@context": "https://schema.org",
   "@type": "ReplaceAction",


### PR DESCRIPTION
Updated invalid comment syntax in JSON-LD element of examples listed below.

Replaced:
```
<script type="application/ld+json">
  //Comment text
{
```
With:
```
<!-- Comment text -->
<script type="application/ld+json">
{
```

Process completed for examples:
 #eg-0118, #eg-0119, #eg-0120, #eg-0121, #eg-0122, #eg-0123, #eg-0124, #eg-0125, #eg-0126, #eg-0127, #eg-0128, #eg-0129, #eg-0130, #eg-0131, #eg-0132, #eg-0133, #eg-0134, #eg-0135, #eg-0136, #eg-0137, #eg-0138, #eg-0139, #eg-0140, #eg-0141, #eg-0142, #eg-0143, #eg-0144, #eg-0145, #eg-0146, #eg-0147, #eg-0148, #eg-0149, #eg-0150, #eg-0151, #eg-0152, #eg-0153, #eg-0154, #eg-0155, #eg-0156, #eg-0157, #eg-0158, #eg-0159, #eg-0160, #eg-0161, #eg-0162, #eg-0163, #eg-0164, #eg-0165

Fixes issue #2747 