### PR TITLE
add DefinedTerm to learningResourceType and educationalUse

### DIFF
--- a/data/schema.ttl
+++ b/data/schema.ttl
@@ -5622,7 +5622,8 @@ This property should not be used where the nature of the alignment can be descri
 :educationalUse a rdf:Property ;
     rdfs:label "educationalUse" ;
     :domainIncludes :CreativeWork ;
-    :rangeIncludes :Text ;
+    :rangeIncludes :DefinedTerm,
+        :Text ;
     rdfs:comment "The purpose of a work in the context of education; for example, 'assignment', 'group work'." .
 
 :elevation a rdf:Property ;
@@ -6717,7 +6718,8 @@ Typical unit code(s): MTK for square meter, FTK for square foot, or YDK for squa
     rdfs:label "learningResourceType" ;
     :domainIncludes :CreativeWork,
         :LearningResource ;
-    :rangeIncludes :Text ;
+    :rangeIncludes :DefinedTerm,
+        :Text ;
     rdfs:comment "The predominant type or kind characterizing the learning resource. For example, 'presentation', 'handout'." .
 
 :legalName a rdf:Property ;


### PR DESCRIPTION
Hello 👋
as discussed in #2764 and the positive feedvack, I add <http://schema.org/DefinedTerm> to <http://schema.org/learningResourceType> and, as demanded by @philbarker, @stuartasutton and @jmarks, to <http://schema.org/educationalUse> as an expected type.