### PR TITLE
Clean unused category values from term definitions.

### DIFF
--- a/SchemaTerms/sdotermsource.py
+++ b/SchemaTerms/sdotermsource.py
@@ -48,8 +48,8 @@ class SdoTermSource():
     SOURCEGRAPH=None
     MARKDOWNPROCESS=True
     
-    def __init__(self,uri,ttype=None,label='',layer=None,cat=None):
-        #log.info('%s %s "%s" %s %s' % (uri,ttype,label, layer, cat))
+    def __init__(self,uri,ttype=None,label='',layer=None):
+        #log.info('%s %s "%s" %s %s' % (uri,ttype,label, layer))
         uri = str(uri)
         self.uri = uri
         self.id = uri2id(uri)
@@ -57,9 +57,6 @@ class SdoTermSource():
         self.layer = CORE
         if  layer:
             self.layer = layer
-        self.category = cat
-        if not cat:
-              self.category = ""
         self.termdesc = None
         
         self.parent = None
@@ -133,7 +130,6 @@ class SdoTermSource():
         elif self.ttype == SdoTerm.REFERENCE:
             self.termdesc = SdoReference(self.id,self.uri,self.label)
 
-        self.termdesc.category = self.category
         self.termdesc.acknowledgements = self.getAcknowledgements()
         self.termdesc.comment = self.getComment()
         self.termdesc.comments = self.getComments()
@@ -292,8 +288,6 @@ class SdoTermSource():
         if not self.aks:
             self.getSourcesAndAcks()
         return self.aks
-    def getCategory(self):
-        return self.category
     def getLayer(self):
         return self.layer
     def getInverseOf(self):
@@ -722,7 +716,6 @@ class SdoTermSource():
             tmp.sups.append(row.sup)
             tmp.tt = row.type
             tmp.lab = row.label
-            tmp.cat = row.cat
             tmp.layer = layerFromUri(row.layer)
             
         term = SdoTermSource.createTerm(tmp)
@@ -747,7 +740,7 @@ class SdoTermSource():
             
         term = TERMS.get(tmp.id,None) 
         if not term:  #Already created this term ?     
-            t =  SdoTermSource(tmp.id,ttype=tmp.tt,label=tmp.lab,layer=tmp.layer,cat=tmp.cat)
+            t =  SdoTermSource(tmp.id,ttype=tmp.tt,label=tmp.lab,layer=tmp.layer)
             term = t.termdesc
         return term
 
@@ -758,7 +751,6 @@ class SdoTermSource():
             self.sups = []
             self.lab = None
             self.layer = None
-            self.cat = None
             self.tt = ""
 
     @staticmethod
@@ -872,7 +864,7 @@ class SdoTermSource():
             supress = "FILTER NOT EXISTS { ?s dc:source ?term. }"
             
             
-        query = """SELECT DISTINCT ?term ?type ?label ?layer ?sup ?cat WHERE {
+        query = """SELECT DISTINCT ?term ?type ?label ?layer ?sup WHERE {
              ?term a ?type;
                 %s
                 %s
@@ -886,9 +878,6 @@ class SdoTermSource():
             }
             OPTIONAL {
                 ?term rdfs:subPropertyOf ?sup.
-            }
-            OPTIONAL {
-                ?term schema:category ?cat.
             }
             %s
             %s
@@ -1126,7 +1115,7 @@ class SdoTermSource():
             term = None
 
         query = """ 
-        SELECT ?term ?type ?label ?layer ?sup ?cat WHERE {
+        SELECT ?term ?type ?label ?layer ?sup WHERE {
              %s a ?type;
                 rdfs:label ?label.
             OPTIONAL {
@@ -1138,11 +1127,8 @@ class SdoTermSource():
             OPTIONAL {
                 %s rdfs:subPropertyOf ?sup.
             }
-            OPTIONAL {
-                %s schema:category ?cat.
-            }
         
-        }""" % (uriWrap(fullId),uriWrap(fullId),uriWrap(fullId),uriWrap(fullId),uriWrap(fullId))
+        }""" % (uriWrap(fullId),uriWrap(fullId),uriWrap(fullId),uriWrap(fullId))
         
         #log.info("QUERY %s" % query)
         if not term:

--- a/data/ext/attic/attic.ttl
+++ b/data/ext/attic/attic.ttl
@@ -1,6 +1,8 @@
 @prefix : <http://schema.org/> .
 @prefix rdf: <http://www.w3.org/1999/02/22-rdf-syntax-ns#> .
 @prefix rdfs: <http://www.w3.org/2000/01/rdf-schema#> .
+@prefix xml: <http://www.w3.org/XML/1998/namespace> .
+@prefix xsd: <http://www.w3.org/2001/XMLSchema#> .
 
 :StupidType a rdfs:Class ;
     rdfs:label "StupidType" ;

--- a/data/ext/auto/auto.ttl
+++ b/data/ext/auto/auto.ttl
@@ -1,6 +1,8 @@
 @prefix : <http://schema.org/> .
 @prefix rdf: <http://www.w3.org/1999/02/22-rdf-syntax-ns#> .
 @prefix rdfs: <http://www.w3.org/2000/01/rdf-schema#> .
+@prefix xml: <http://www.w3.org/XML/1998/namespace> .
+@prefix xsd: <http://www.w3.org/2001/XMLSchema#> .
 
 :BusOrCoach a rdfs:Class ;
     rdfs:label "BusOrCoach" ;

--- a/data/ext/bib/bsdo-1.0.ttl
+++ b/data/ext/bib/bsdo-1.0.ttl
@@ -1,6 +1,8 @@
 @prefix : <http://schema.org/> .
 @prefix rdf: <http://www.w3.org/1999/02/22-rdf-syntax-ns#> .
 @prefix rdfs: <http://www.w3.org/2000/01/rdf-schema#> .
+@prefix xml: <http://www.w3.org/XML/1998/namespace> .
+@prefix xsd: <http://www.w3.org/2001/XMLSchema#> .
 
 :Atlas a rdfs:Class ;
     rdfs:label "Atlas" ;
@@ -28,6 +30,46 @@
     rdfs:comment "A collection of items e.g. creative works or products." ;
     rdfs:subClassOf :CreativeWork .
 
+:ComicCoverArt a rdfs:Class ;
+    rdfs:label "ComicCoverArt" ;
+    :isPartOf <http://bib.schema.org> ;
+    rdfs:comment "The artwork on the cover of a comic." ;
+    rdfs:subClassOf :ComicStory,
+        :CoverArt .
+
+:ComicIssue a rdfs:Class ;
+    rdfs:label "ComicIssue" ;
+    :isPartOf <http://bib.schema.org> ;
+    rdfs:comment """Individual comic issues are serially published as
+    	part of a larger series. For the sake of consistency, even one-shot issues
+    	belong to a series comprised of a single issue. All comic issues can be
+    	uniquely identified by: the combination of the name and volume number of the
+    	series to which the issue belongs; the issue number; and the variant
+    	description of the issue (if any).""" ;
+    rdfs:subClassOf :PublicationIssue .
+
+:ComicSeries a rdfs:Class ;
+    rdfs:label "ComicSeries" ;
+    :isPartOf <http://bib.schema.org> ;
+    rdfs:comment """A sequential publication of comic stories under a
+    	unifying title, for example "The Amazing Spider-Man" or "Groo the
+    	Wanderer".""" ;
+    rdfs:subClassOf :Periodical .
+
+:ComicStory a rdfs:Class ;
+    rdfs:label "ComicStory" ;
+    :isPartOf <http://bib.schema.org> ;
+    rdfs:comment """The term "story" is any indivisible, re-printable
+    	unit of a comic, including the interior stories, covers, and backmatter. Most
+    	comics have at least two stories: a cover (ComicCoverArt) and an interior story.""" ;
+    rdfs:subClassOf :CreativeWork .
+
+:CoverArt a rdfs:Class ;
+    rdfs:label "CoverArt" ;
+    :isPartOf <http://bib.schema.org> ;
+    rdfs:comment "The artwork on the outer surface of a CreativeWork." ;
+    rdfs:subClassOf :VisualArtwork .
+
 :Newspaper a rdfs:Class ;
     rdfs:label "Newspaper" ;
     :isPartOf <http://bib.schema.org> ;
@@ -42,12 +84,39 @@
     rdfs:comment "A thesis or dissertation document submitted in support of candidature for an academic degree or professional qualification." ;
     rdfs:subClassOf :CreativeWork .
 
+<file:///Users/wallisr/Development/Schema/ttl/schemaorg/data/ext/bib/comics.rdfa> :softwareVersion "bib extension - version 0.1" .
+
+:GraphicNovel a :BookFormatType ;
+    rdfs:label "GraphicNovel" ;
+    :isPartOf <http://bib.schema.org> ;
+    rdfs:comment "Book format: GraphicNovel. May represent a bound collection of ComicIssue instances." .
+
 :abridged a rdf:Property ;
     rdfs:label "abridged" ;
     :domainIncludes :Book ;
     :isPartOf <http://bib.schema.org> ;
     :rangeIncludes :Boolean ;
     rdfs:comment "Indicates whether the book is an abridged edition." .
+
+:artist a rdf:Property ;
+    rdfs:label "artist" ;
+    :domainIncludes :ComicIssue,
+        :ComicStory,
+        :VisualArtwork ;
+    :isPartOf <http://bib.schema.org> ;
+    :rangeIncludes :Person ;
+    rdfs:comment """The primary artist for a work
+    	in a medium other than pencils or digital line art--for example, if the
+    	primary artwork is done in watercolors or digital paints.""" .
+
+:colorist a rdf:Property ;
+    rdfs:label "colorist" ;
+    :domainIncludes :ComicIssue,
+        :ComicStory,
+        :VisualArtwork ;
+    :isPartOf <http://bib.schema.org> ;
+    :rangeIncludes :Person ;
+    rdfs:comment "The individual who adds color to inked drawings." .
 
 :duration a rdf:Property ;
     :domainIncludes :Audiobook .
@@ -59,6 +128,24 @@
     :rangeIncludes :Text ;
     rdfs:comment "Qualification, candidature, degree, application that Thesis supports." .
 
+:inker a rdf:Property ;
+    rdfs:label "inker" ;
+    :domainIncludes :ComicIssue,
+        :ComicStory,
+        :VisualArtwork ;
+    :isPartOf <http://bib.schema.org> ;
+    :rangeIncludes :Person ;
+    rdfs:comment "The individual who traces over the pencil drawings in ink after pencils are complete." .
+
+:letterer a rdf:Property ;
+    rdfs:label "letterer" ;
+    :domainIncludes :ComicIssue,
+        :ComicStory,
+        :VisualArtwork ;
+    :isPartOf <http://bib.schema.org> ;
+    :rangeIncludes :Person ;
+    rdfs:comment "The individual who adds lettering, including speech balloons and sound effects, to artwork." .
+
 :pageEnd a rdf:Property ;
     :domainIncludes :Chapter .
 
@@ -68,6 +155,15 @@
 :pagination a rdf:Property ;
     :domainIncludes :Chapter .
 
+:penciler a rdf:Property ;
+    rdfs:label "penciler" ;
+    :domainIncludes :ComicIssue,
+        :ComicStory,
+        :VisualArtwork ;
+    :isPartOf <http://bib.schema.org> ;
+    :rangeIncludes :Person ;
+    rdfs:comment "The individual who draws the primary narrative artwork." .
+
 :publishedBy a rdf:Property ;
     rdfs:label "publishedBy" ;
     :domainIncludes :PublicationEvent ;
@@ -76,6 +172,13 @@
         :Person ;
     rdfs:comment "An agent associated with the publication event." .
 
+:publisherImprint a rdf:Property ;
+    rdfs:label "publisherImprint" ;
+    :domainIncludes :CreativeWork ;
+    :isPartOf <http://bib.schema.org> ;
+    :rangeIncludes :Organization ;
+    rdfs:comment "The publishing division which published the comic." .
+
 :readBy a rdf:Property ;
     rdfs:label "readBy" ;
     :domainIncludes :Audiobook ;
@@ -83,6 +186,15 @@
     :rangeIncludes :Person ;
     rdfs:comment "A person who reads (performs) the audiobook." ;
     rdfs:subPropertyOf :actor .
+
+:variantCover a rdf:Property ;
+    rdfs:label "variantCover" ;
+    :domainIncludes :ComicIssue ;
+    :isPartOf <http://bib.schema.org> ;
+    :rangeIncludes :Text ;
+    rdfs:comment """A description of the variant cover
+    	for the issue, if the issue is a variant printing. For example, "Bryan Hitch
+    	Variant Cover" or "2nd Printing Variant".""" .
 
 :translationOfWork a rdf:Property ;
     rdfs:label "translationOfWork" ;
@@ -100,131 +212,3 @@
     :rangeIncludes :CreativeWork ;
     rdfs:comment "A work that is a translation of the content of this work. e.g. 西遊記 has an English workTranslation “Journey to the West”,a German workTranslation “Monkeys Pilgerfahrt” and a Vietnamese  translation Tây du ký bình khảo." .
 
-
-
-    @prefix : <http://schema.org/> .
-    @prefix rdf: <http://www.w3.org/1999/02/22-rdf-syntax-ns#> .
-    @prefix rdfs: <http://www.w3.org/2000/01/rdf-schema#> .
-
-    :ComicCoverArt a rdfs:Class ;
-        rdfs:label "ComicCoverArt" ;
-        :category "Comics" ;
-        :isPartOf <http://bib.schema.org> ;
-        rdfs:comment "The artwork on the cover of a comic." ;
-        rdfs:subClassOf :ComicStory,
-            :CoverArt .
-
-    :ComicIssue a rdfs:Class ;
-        rdfs:label "ComicIssue" ;
-        :category "Comics" ;
-        :isPartOf <http://bib.schema.org> ;
-        rdfs:comment """Individual comic issues are serially published as
-    	part of a larger series. For the sake of consistency, even one-shot issues
-    	belong to a series comprised of a single issue. All comic issues can be
-    	uniquely identified by: the combination of the name and volume number of the
-    	series to which the issue belongs; the issue number; and the variant
-    	description of the issue (if any).""" ;
-        rdfs:subClassOf :PublicationIssue .
-
-    :ComicSeries a rdfs:Class ;
-        rdfs:label "ComicSeries" ;
-        :category "Comics" ;
-        :isPartOf <http://bib.schema.org> ;
-        rdfs:comment """A sequential publication of comic stories under a
-    	unifying title, for example "The Amazing Spider-Man" or "Groo the
-    	Wanderer".""" ;
-        rdfs:subClassOf :Periodical .
-
-    :ComicStory a rdfs:Class ;
-        rdfs:label "ComicStory" ;
-        :category "Comics" ;
-        :isPartOf <http://bib.schema.org> ;
-        rdfs:comment """The term "story" is any indivisible, re-printable
-    	unit of a comic, including the interior stories, covers, and backmatter. Most
-    	comics have at least two stories: a cover (ComicCoverArt) and an interior story.""" ;
-        rdfs:subClassOf :CreativeWork .
-
-    :CoverArt a rdfs:Class ;
-        rdfs:label "CoverArt" ;
-        :category "Comics" ;
-        :isPartOf <http://bib.schema.org> ;
-        rdfs:comment "The artwork on the outer surface of a CreativeWork." ;
-        rdfs:subClassOf :VisualArtwork .
-
-    <file:///Users/wallisr/Development/Schema/ttl/schemaorg/data/ext/bib/comics.rdfa> :softwareVersion "bib extension - version 0.1" .
-
-    :GraphicNovel a :BookFormatType ;
-        rdfs:label "GraphicNovel" ;
-        :category "Comics" ;
-        :isPartOf <http://bib.schema.org> ;
-        rdfs:comment "Book format: GraphicNovel. May represent a bound collection of ComicIssue instances." .
-
-    :artist a rdf:Property ;
-        rdfs:label "artist" ;
-        :category "Comics" ;
-        :domainIncludes :ComicIssue,
-            :ComicStory,
-            :VisualArtwork ;
-        :isPartOf <http://bib.schema.org> ;
-        :rangeIncludes :Person ;
-        rdfs:comment """The primary artist for a work
-    	in a medium other than pencils or digital line art--for example, if the
-    	primary artwork is done in watercolors or digital paints.""" .
-
-    :colorist a rdf:Property ;
-        rdfs:label "colorist" ;
-        :category "Comics" ;
-        :domainIncludes :ComicIssue,
-            :ComicStory,
-            :VisualArtwork ;
-        :isPartOf <http://bib.schema.org> ;
-        :rangeIncludes :Person ;
-        rdfs:comment "The individual who adds color to inked drawings." .
-
-    :inker a rdf:Property ;
-        rdfs:label "inker" ;
-        :category "Comics" ;
-        :domainIncludes :ComicIssue,
-            :ComicStory,
-            :VisualArtwork ;
-        :isPartOf <http://bib.schema.org> ;
-        :rangeIncludes :Person ;
-        rdfs:comment "The individual who traces over the pencil drawings in ink after pencils are complete." .
-
-    :letterer a rdf:Property ;
-        rdfs:label "letterer" ;
-        :category "Comics" ;
-        :domainIncludes :ComicIssue,
-            :ComicStory,
-            :VisualArtwork ;
-        :isPartOf <http://bib.schema.org> ;
-        :rangeIncludes :Person ;
-        rdfs:comment "The individual who adds lettering, including speech balloons and sound effects, to artwork." .
-
-    :penciler a rdf:Property ;
-        rdfs:label "penciler" ;
-        :category "Comics" ;
-        :domainIncludes :ComicIssue,
-            :ComicStory,
-            :VisualArtwork ;
-        :isPartOf <http://bib.schema.org> ;
-        :rangeIncludes :Person ;
-        rdfs:comment "The individual who draws the primary narrative artwork." .
-
-    :publisherImprint a rdf:Property ;
-        rdfs:label "publisherImprint" ;
-        :category "Comics" ;
-        :domainIncludes :CreativeWork ;
-        :isPartOf <http://bib.schema.org> ;
-        :rangeIncludes :Organization ;
-        rdfs:comment "The publishing division which published the comic." .
-
-    :variantCover a rdf:Property ;
-        rdfs:label "variantCover" ;
-        :category "Comics" ;
-        :domainIncludes :ComicIssue ;
-        :isPartOf <http://bib.schema.org> ;
-        :rangeIncludes :Text ;
-        rdfs:comment """A description of the variant cover
-    	for the issue, if the issue is a variant printing. For example, "Bryan Hitch
-    	Variant Cover" or "2nd Printing Variant".""" .

--- a/data/ext/health-lifesci/med-health-core.ttl
+++ b/data/ext/health-lifesci/med-health-core.ttl
@@ -2,6 +2,8 @@
 @prefix owl: <http://www.w3.org/2002/07/owl#> .
 @prefix rdf: <http://www.w3.org/1999/02/22-rdf-syntax-ns#> .
 @prefix rdfs: <http://www.w3.org/2000/01/rdf-schema#> .
+@prefix xml: <http://www.w3.org/XML/1998/namespace> .
+@prefix xsd: <http://www.w3.org/2001/XMLSchema#> .
 
 :AnatomicalStructure a rdfs:Class ;
     rdfs:label "AnatomicalStructure" ;
@@ -494,8 +496,8 @@
     rdfs:label "PhysicalExam" ;
     :isPartOf <http://health-lifesci.schema.org> ;
     rdfs:comment "A type of physical examination of a patient performed by a physician. " ;
-    rdfs:subClassOf :MedicalProcedure,
-         :MedicalEnumeration .
+    rdfs:subClassOf :MedicalEnumeration,
+        :MedicalProcedure .
 
 :PhysicalTherapy a rdfs:Class ;
     rdfs:label "PhysicalTherapy" ;
@@ -1808,6 +1810,14 @@
     :rangeIncludes :Text ;
     rdfs:comment "The specific biochemical interaction through which this drug or supplement produces its pharmacological effect." .
 
+:medicalAudience a rdf:Property ;
+    rdfs:label "medicalAudience" ;
+    :domainIncludes :MedicalWebPage ;
+    :isPartOf <http://health-lifesci.schema.org> ;
+    :rangeIncludes :MedicalAudience,
+        :MedicalAudienceType ;
+    rdfs:comment "Medical audience for page." .
+
 :medicalSpecialty a rdf:Property ;
     rdfs:label "medicalSpecialty" ;
     :domainIncludes :Hospital,
@@ -1817,14 +1827,6 @@
     :isPartOf <http://health-lifesci.schema.org> ;
     :rangeIncludes :MedicalSpecialty ;
     rdfs:comment "A medical specialty of the provider." .
-
-:medicalAudience a rdf:Property ;
-    rdfs:label "medicalAudience" ;
-    :domainIncludes :MedicalWebPage;
-    :isPartOf <http://health-lifesci.schema.org> ;
-    :rangeIncludes :MedicalAudience,
-      :MedicalAudienceType ;
-    rdfs:comment "Medical audience for page." .
 
 :medicineSystem a rdf:Property ;
     rdfs:label "medicineSystem" ;

--- a/data/ext/health-lifesci/physical-activity-and-exercise.ttl
+++ b/data/ext/health-lifesci/physical-activity-and-exercise.ttl
@@ -2,6 +2,8 @@
 @prefix ns1: <http://www.w3.org/ns/rdfa#> .
 @prefix rdf: <http://www.w3.org/1999/02/22-rdf-syntax-ns#> .
 @prefix rdfs: <http://www.w3.org/2000/01/rdf-schema#> .
+@prefix xml: <http://www.w3.org/XML/1998/namespace> .
+@prefix xsd: <http://www.w3.org/2001/XMLSchema#> .
 
 :ExercisePlan a rdfs:Class ;
     rdfs:label "ExercisePlan" ;
@@ -131,3 +133,4 @@
     :rangeIncludes :Energy,
         :QuantitativeValue ;
     rdfs:comment "Quantitative measure of the physiologic output of the exercise; also referred to as energy expenditure." .
+

--- a/data/ext/meta/meta.ttl
+++ b/data/ext/meta/meta.ttl
@@ -2,6 +2,8 @@
 @prefix owl: <http://www.w3.org/2002/07/owl#> .
 @prefix rdf: <http://www.w3.org/1999/02/22-rdf-syntax-ns#> .
 @prefix rdfs: <http://www.w3.org/2000/01/rdf-schema#> .
+@prefix xml: <http://www.w3.org/XML/1998/namespace> .
+@prefix xsd: <http://www.w3.org/2001/XMLSchema#> .
 
 :Class a rdfs:Class ;
     rdfs:label "Class" ;

--- a/data/ext/pending/issue-1045.ttl
+++ b/data/ext/pending/issue-1045.ttl
@@ -1,10 +1,11 @@
 @prefix : <http://schema.org/> .
 @prefix rdf: <http://www.w3.org/1999/02/22-rdf-syntax-ns#> .
 @prefix rdfs: <http://www.w3.org/2000/01/rdf-schema#> .
+@prefix xml: <http://www.w3.org/XML/1998/namespace> .
+@prefix xsd: <http://www.w3.org/2001/XMLSchema#> .
 
 :LinkRole a rdfs:Class ;
     rdfs:label "LinkRole" ;
-    :category "issue-1045" ;
     :isPartOf <http://pending.schema.org> ;
     :source <https://github.com/schemaorg/schemaorg/issues/1045> ;
     rdfs:comment "A Role that represents a Web link e.g. as expressed via the 'url' property. Its linkRelationship property can indicate URL-based and plain textual link types e.g. those in IANA link registry or others such as 'amphtml'. This structure provides a placeholder where details from HTML's link element can be represented outside of HTML, e.g. in JSON-LD feeds." ;
@@ -15,7 +16,6 @@
 
 :linkRelationship a rdf:Property ;
     rdfs:label "linkRelationship" ;
-    :category "issue-1045" ;
     :domainIncludes :LinkRole ;
     :isPartOf <http://pending.schema.org> ;
     :rangeIncludes :Text ;

--- a/data/ext/pending/issue-1050.ttl
+++ b/data/ext/pending/issue-1050.ttl
@@ -1,10 +1,11 @@
 @prefix : <http://schema.org/> .
 @prefix rdf: <http://www.w3.org/1999/02/22-rdf-syntax-ns#> .
 @prefix rdfs: <http://www.w3.org/2000/01/rdf-schema#> .
+@prefix xml: <http://www.w3.org/XML/1998/namespace> .
+@prefix xsd: <http://www.w3.org/2001/XMLSchema#> .
 
 :contentReferenceTime a rdf:Property ;
     rdfs:label "contentReferenceTime" ;
-    :category "issue-1050" ;
     :domainIncludes :CreativeWork ;
     :isPartOf <http://pending.schema.org> ;
     :rangeIncludes :DateTime ;

--- a/data/ext/pending/issue-1062.ttl
+++ b/data/ext/pending/issue-1062.ttl
@@ -1,10 +1,11 @@
 @prefix : <http://schema.org/> .
 @prefix rdf: <http://www.w3.org/1999/02/22-rdf-syntax-ns#> .
 @prefix rdfs: <http://www.w3.org/2000/01/rdf-schema#> .
+@prefix xml: <http://www.w3.org/XML/1998/namespace> .
+@prefix xsd: <http://www.w3.org/2001/XMLSchema#> .
 
 :HealthInsurancePlan a rdfs:Class ;
     rdfs:label "HealthInsurancePlan" ;
-    :category "issue-1062" ;
     :isPartOf <http://pending.schema.org> ;
     :source <https://github.com/schemaorg/schemaorg/issues/1062> ;
     rdfs:comment "A US-style health insurance plan, including PPOs, EPOs, and HMOs. " ;
@@ -12,7 +13,6 @@
 
 :HealthPlanCostSharingSpecification a rdfs:Class ;
     rdfs:label "HealthPlanCostSharingSpecification" ;
-    :category "issue-1062" ;
     :isPartOf <http://pending.schema.org> ;
     :source <https://github.com/schemaorg/schemaorg/issues/1062> ;
     rdfs:comment "A description of costs to the patient under a given network or formulary." ;
@@ -20,7 +20,6 @@
 
 :HealthPlanFormulary a rdfs:Class ;
     rdfs:label "HealthPlanFormulary" ;
-    :category "issue-1062" ;
     :isPartOf <http://pending.schema.org> ;
     :source <https://github.com/schemaorg/schemaorg/issues/1062> ;
     rdfs:comment "For a given health insurance plan, the specification for costs and coverage of prescription drugs. " ;
@@ -28,7 +27,6 @@
 
 :HealthPlanNetwork a rdfs:Class ;
     rdfs:label "HealthPlanNetwork" ;
-    :category "issue-1062" ;
     :isPartOf <http://pending.schema.org> ;
     :source <https://github.com/schemaorg/schemaorg/issues/1062> ;
     rdfs:comment "A US-style health insurance plan network. " ;
@@ -36,7 +34,6 @@
 
 :benefitsSummaryUrl a rdf:Property ;
     rdfs:label "benefitsSummaryUrl" ;
-    :category "issue-1062" ;
     :domainIncludes :HealthInsurancePlan ;
     :isPartOf <http://pending.schema.org> ;
     :rangeIncludes :URL ;
@@ -49,7 +46,6 @@
 
 :healthPlanCoinsuranceOption a rdf:Property ;
     rdfs:label "healthPlanCoinsuranceOption" ;
-    :category "issue-1062" ;
     :domainIncludes :HealthPlanCostSharingSpecification ;
     :isPartOf <http://pending.schema.org> ;
     :rangeIncludes :Text ;
@@ -58,7 +54,6 @@
 
 :healthPlanCoinsuranceRate a rdf:Property ;
     rdfs:label "healthPlanCoinsuranceRate" ;
-    :category "issue-1062" ;
     :domainIncludes :HealthPlanCostSharingSpecification ;
     :isPartOf <http://pending.schema.org> ;
     :rangeIncludes :Number ;
@@ -67,7 +62,6 @@
 
 :healthPlanCopay a rdf:Property ;
     rdfs:label "healthPlanCopay" ;
-    :category "issue-1062" ;
     :domainIncludes :HealthPlanCostSharingSpecification ;
     :isPartOf <http://pending.schema.org> ;
     :rangeIncludes :PriceSpecification ;
@@ -76,7 +70,6 @@
 
 :healthPlanCopayOption a rdf:Property ;
     rdfs:label "healthPlanCopayOption" ;
-    :category "issue-1062" ;
     :domainIncludes :HealthPlanCostSharingSpecification ;
     :isPartOf <http://pending.schema.org> ;
     :rangeIncludes :Text ;
@@ -85,7 +78,6 @@
 
 :healthPlanCostSharing a rdf:Property ;
     rdfs:label "healthPlanCostSharing" ;
-    :category "issue-1062" ;
     :domainIncludes :HealthPlanFormulary,
         :HealthPlanNetwork ;
     :isPartOf <http://pending.schema.org> ;
@@ -95,7 +87,6 @@
 
 :healthPlanDrugOption a rdf:Property ;
     rdfs:label "healthPlanDrugOption" ;
-    :category "issue-1062" ;
     :domainIncludes :HealthInsurancePlan ;
     :isPartOf <http://pending.schema.org> ;
     :rangeIncludes :Text ;
@@ -104,7 +95,6 @@
 
 :healthPlanDrugTier a rdf:Property ;
     rdfs:label "healthPlanDrugTier" ;
-    :category "issue-1062" ;
     :domainIncludes :HealthInsurancePlan,
         :HealthPlanFormulary ;
     :isPartOf <http://pending.schema.org> ;
@@ -114,7 +104,6 @@
 
 :healthPlanId a rdf:Property ;
     rdfs:label "healthPlanId" ;
-    :category "issue-1062" ;
     :domainIncludes :HealthInsurancePlan ;
     :isPartOf <http://pending.schema.org> ;
     :rangeIncludes :Text ;
@@ -123,7 +112,6 @@
 
 :healthPlanMarketingUrl a rdf:Property ;
     rdfs:label "healthPlanMarketingUrl" ;
-    :category "issue-1062" ;
     :domainIncludes :HealthInsurancePlan ;
     :isPartOf <http://pending.schema.org> ;
     :rangeIncludes :URL ;
@@ -132,7 +120,6 @@
 
 :healthPlanNetworkId a rdf:Property ;
     rdfs:label "healthPlanNetworkId" ;
-    :category "issue-1062" ;
     :domainIncludes :HealthPlanNetwork,
         :MedicalOrganization ;
     :isPartOf <http://pending.schema.org> ;
@@ -142,7 +129,6 @@
 
 :healthPlanNetworkTier a rdf:Property ;
     rdfs:label "healthPlanNetworkTier" ;
-    :category "issue-1062" ;
     :domainIncludes :HealthPlanNetwork ;
     :isPartOf <http://pending.schema.org> ;
     :rangeIncludes :Text ;
@@ -151,7 +137,6 @@
 
 :healthPlanPharmacyCategory a rdf:Property ;
     rdfs:label "healthPlanPharmacyCategory" ;
-    :category "issue-1062" ;
     :domainIncludes :HealthPlanCostSharingSpecification ;
     :isPartOf <http://pending.schema.org> ;
     :rangeIncludes :Text ;
@@ -160,7 +145,6 @@
 
 :includedInHealthInsurancePlan a rdf:Property ;
     rdfs:label "includedInHealthInsurancePlan" ;
-    :category "issue-1062" ;
     :domainIncludes :Drug ;
     :isPartOf <http://pending.schema.org> ;
     :rangeIncludes :HealthInsurancePlan ;
@@ -169,7 +153,6 @@
 
 :includesHealthPlanFormulary a rdf:Property ;
     rdfs:label "includesHealthPlanFormulary" ;
-    :category "issue-1062" ;
     :domainIncludes :HealthInsurancePlan ;
     :isPartOf <http://pending.schema.org> ;
     :rangeIncludes :HealthPlanFormulary ;
@@ -178,7 +161,6 @@
 
 :includesHealthPlanNetwork a rdf:Property ;
     rdfs:label "includesHealthPlanNetwork" ;
-    :category "issue-1062" ;
     :domainIncludes :HealthInsurancePlan ;
     :isPartOf <http://pending.schema.org> ;
     :rangeIncludes :HealthPlanNetwork ;
@@ -187,7 +169,6 @@
 
 :isAcceptingNewPatients a rdf:Property ;
     rdfs:label "isAcceptingNewPatients" ;
-    :category "issue-1062" ;
     :domainIncludes :MedicalOrganization ;
     :isPartOf <http://pending.schema.org> ;
     :rangeIncludes :Boolean ;
@@ -196,7 +177,6 @@
 
 :offersPrescriptionByMail a rdf:Property ;
     rdfs:label "offersPrescriptionByMail" ;
-    :category "issue-1062" ;
     :domainIncludes :HealthPlanFormulary ;
     :isPartOf <http://pending.schema.org> ;
     :rangeIncludes :Boolean ;
@@ -205,7 +185,6 @@
 
 :rxcui a rdf:Property ;
     rdfs:label "rxcui" ;
-    :category "issue-1062" ;
     :domainIncludes :Drug ;
     :isPartOf <http://pending.schema.org> ;
     :rangeIncludes :Text ;
@@ -214,7 +193,6 @@
 
 :usesHealthPlanIdStandard a rdf:Property ;
     rdfs:label "usesHealthPlanIdStandard" ;
-    :category "issue-1062" ;
     :domainIncludes :HealthInsurancePlan ;
     :isPartOf <http://pending.schema.org> ;
     :rangeIncludes :Text,

--- a/data/ext/pending/issue-1083.ttl
+++ b/data/ext/pending/issue-1083.ttl
@@ -1,10 +1,11 @@
 @prefix : <http://schema.org/> .
 @prefix rdf: <http://www.w3.org/1999/02/22-rdf-syntax-ns#> .
 @prefix rdfs: <http://www.w3.org/2000/01/rdf-schema#> .
+@prefix xml: <http://www.w3.org/XML/1998/namespace> .
+@prefix xsd: <http://www.w3.org/2001/XMLSchema#> .
 
 :variableMeasured a rdf:Property ;
     rdfs:label "variableMeasured" ;
-    :category "issue-1083" ;
     :domainIncludes :Dataset ;
     :isPartOf <http://pending.schema.org> ;
     :rangeIncludes :PropertyValue,

--- a/data/ext/pending/issue-1156.ttl
+++ b/data/ext/pending/issue-1156.ttl
@@ -3,10 +3,11 @@
 @prefix rdf: <http://www.w3.org/1999/02/22-rdf-syntax-ns#> .
 @prefix rdfs: <http://www.w3.org/2000/01/rdf-schema#> .
 @prefix skos: <http://www.w3.org/2004/02/skos/core#> .
+@prefix xml: <http://www.w3.org/XML/1998/namespace> .
+@prefix xsd: <http://www.w3.org/2001/XMLSchema#> .
 
 :LegalForceStatus a rdfs:Class ;
     rdfs:label "LegalForceStatus" ;
-    :category "issue-1156" ;
     :isPartOf <http://pending.schema.org> ;
     :source <http://publications.europa.eu/mdr/eli/index.html>,
         <https://github.com/schemaorg/schemaorg/issues/1156> ;
@@ -16,7 +17,6 @@
 
 :LegalValueLevel a rdfs:Class ;
     rdfs:label "LegalValueLevel" ;
-    :category "issue-1156" ;
     :isPartOf <http://pending.schema.org> ;
     :source <http://publications.europa.eu/mdr/eli/index.html>,
         <https://github.com/schemaorg/schemaorg/issues/1156> ;
@@ -26,7 +26,6 @@
 
 :Legislation a rdfs:Class ;
     rdfs:label "Legislation" ;
-    :category "issue-1156" ;
     :isPartOf <http://pending.schema.org> ;
     :source <http://publications.europa.eu/mdr/eli/index.html>,
         <https://github.com/schemaorg/schemaorg/issues/1156> ;
@@ -37,7 +36,6 @@
 
 :LegislationObject a rdfs:Class ;
     rdfs:label "LegislationObject" ;
-    :category "issue-1156" ;
     :isPartOf <http://pending.schema.org> ;
     :source <http://publications.europa.eu/mdr/eli/index.html>,
         <https://github.com/schemaorg/schemaorg/issues/1156> ;
@@ -48,7 +46,6 @@
 
 :AuthoritativeLegalValue a :LegalValueLevel ;
     rdfs:label "AuthoritativeLegalValue" ;
-    :category "issue-1156" ;
     :isPartOf <http://pending.schema.org> ;
     :source <http://publications.europa.eu/mdr/eli/index.html>,
         <https://github.com/schemaorg/schemaorg/issues/1156> ;
@@ -57,7 +54,6 @@
 
 :DefinitiveLegalValue a :LegalValueLevel ;
     rdfs:label "DefinitiveLegalValue" ;
-    :category "issue-1156" ;
     :isPartOf <http://pending.schema.org> ;
     :source <http://publications.europa.eu/mdr/eli/index.html>,
         <https://github.com/schemaorg/schemaorg/issues/1156> ;
@@ -67,7 +63,6 @@
 
 :InForce a :LegalForceStatus ;
     rdfs:label "InForce" ;
-    :category "issue-1156" ;
     :isPartOf <http://pending.schema.org> ;
     :source <http://publications.europa.eu/mdr/eli/index.html>,
         <https://github.com/schemaorg/schemaorg/issues/1156> ;
@@ -76,7 +71,6 @@
 
 :NotInForce a :LegalForceStatus ;
     rdfs:label "NotInForce" ;
-    :category "issue-1156" ;
     :isPartOf <http://pending.schema.org> ;
     :source <http://publications.europa.eu/mdr/eli/index.html>,
         <https://github.com/schemaorg/schemaorg/issues/1156> ;
@@ -85,7 +79,6 @@
 
 :OfficialLegalValue a :LegalValueLevel ;
     rdfs:label "OfficialLegalValue" ;
-    :category "issue-1156" ;
     :isPartOf <http://pending.schema.org> ;
     :source <http://publications.europa.eu/mdr/eli/index.html>,
         <https://github.com/schemaorg/schemaorg/issues/1156> ;
@@ -94,7 +87,6 @@
 
 :PartiallyInForce a :LegalForceStatus ;
     rdfs:label "PartiallyInForce" ;
-    :category "issue-1156" ;
     :isPartOf <http://pending.schema.org> ;
     :source <http://publications.europa.eu/mdr/eli/index.html>,
         <https://github.com/schemaorg/schemaorg/issues/1156> ;
@@ -103,7 +95,6 @@
 
 :UnofficialLegalValue a :LegalValueLevel ;
     rdfs:label "UnofficialLegalValue" ;
-    :category "issue-1156" ;
     :isPartOf <http://pending.schema.org> ;
     :source <http://publications.europa.eu/mdr/eli/index.html>,
         <https://github.com/schemaorg/schemaorg/issues/1156> ;
@@ -112,7 +103,6 @@
 
 :legislationChanges a rdf:Property ;
     rdfs:label "legislationChanges" ;
-    :category "issue-1156" ;
     :domainIncludes :Legislation ;
     :isPartOf <http://pending.schema.org> ;
     :rangeIncludes :Legislation ;
@@ -124,7 +114,6 @@
 
 :legislationConsolidates a rdf:Property ;
     rdfs:label "legislationConsolidates" ;
-    :category "issue-1156" ;
     :domainIncludes :Legislation ;
     :isPartOf <http://pending.schema.org> ;
     :rangeIncludes :Legislation ;
@@ -136,7 +125,6 @@
 
 :legislationDate a rdf:Property ;
     rdfs:label "legislationDate" ;
-    :category "issue-1156" ;
     :domainIncludes :Legislation ;
     :isPartOf <http://pending.schema.org> ;
     :rangeIncludes :Date ;
@@ -149,7 +137,6 @@
 
 :legislationDateVersion a rdf:Property ;
     rdfs:label "legislationDateVersion" ;
-    :category "issue-1156" ;
     :domainIncludes :Legislation ;
     :isPartOf <http://pending.schema.org> ;
     :rangeIncludes :Date ;
@@ -161,7 +148,6 @@
 
 :legislationIdentifier a rdf:Property ;
     rdfs:label "legislationIdentifier" ;
-    :category "issue-1156" ;
     :domainIncludes :Legislation ;
     :isPartOf <http://pending.schema.org> ;
     :rangeIncludes :Text,
@@ -174,7 +160,6 @@
 
 :legislationJurisdiction a rdf:Property ;
     rdfs:label "legislationJurisdiction" ;
-    :category "issue-1156" ;
     :domainIncludes :Legislation ;
     :isPartOf <http://pending.schema.org> ;
     :rangeIncludes :AdministrativeArea,
@@ -188,7 +173,6 @@
 
 :legislationLegalForce a rdf:Property ;
     rdfs:label "legislationLegalForce" ;
-    :category "issue-1156" ;
     :domainIncludes :Legislation ;
     :isPartOf <http://pending.schema.org> ;
     :rangeIncludes :LegalForceStatus ;
@@ -200,7 +184,6 @@
 
 :legislationLegalValue a rdf:Property ;
     rdfs:label "legislationLegalValue" ;
-    :category "issue-1156" ;
     :domainIncludes :LegislationObject ;
     :isPartOf <http://pending.schema.org> ;
     :rangeIncludes :LegalValueLevel ;
@@ -212,7 +195,6 @@
 
 :legislationPassedBy a rdf:Property ;
     rdfs:label "legislationPassedBy" ;
-    :category "issue-1156" ;
     :domainIncludes :Legislation ;
     :isPartOf <http://pending.schema.org> ;
     :rangeIncludes :Organization,
@@ -226,7 +208,6 @@
 
 :legislationResponsible a rdf:Property ;
     rdfs:label "legislationResponsible" ;
-    :category "issue-1156" ;
     :domainIncludes :Legislation ;
     :isPartOf <http://pending.schema.org> ;
     :rangeIncludes :Organization,
@@ -239,7 +220,6 @@
 
 :legislationTransposes a rdf:Property ;
     rdfs:label "legislationTransposes" ;
-    :category "issue-1156" ;
     :domainIncludes :Legislation ;
     :isPartOf <http://pending.schema.org> ;
     :rangeIncludes :Legislation ;
@@ -252,7 +232,6 @@
 
 :legislationType a rdf:Property ;
     rdfs:label "legislationType" ;
-    :category "issue-1156" ;
     :domainIncludes :Legislation ;
     :isPartOf <http://pending.schema.org> ;
     :rangeIncludes :CategoryCode,
@@ -266,7 +245,6 @@
 
 :legislationApplies a rdf:Property ;
     rdfs:label "legislationApplies" ;
-    :category "issue-1156" ;
     :domainIncludes :Legislation ;
     :isPartOf <http://pending.schema.org> ;
     :rangeIncludes :Legislation ;
@@ -280,3 +258,4 @@
     rdfs:label "ELI" ;
     :isPartOf <http://pending.schema.org> ;
     rdfs:comment "This entry is derived from the [ELI ontology](http://publications.europa.eu/mdr/eli/index.html) (European Legislation Identifier). ELI is an initiative of some national legislation publishers endorsed by EU countries and Institutions, to identify, describe and link legislation on the web, and is led by the [ELI taskforce](http://eur-lex.europa.eu/eli-register/about.html)." .
+

--- a/data/ext/pending/issue-1244.ttl
+++ b/data/ext/pending/issue-1244.ttl
@@ -1,6 +1,8 @@
 @prefix : <http://schema.org/> .
 @prefix rdf: <http://www.w3.org/1999/02/22-rdf-syntax-ns#> .
 @prefix rdfs: <http://www.w3.org/2000/01/rdf-schema#> .
+@prefix xml: <http://www.w3.org/XML/1998/namespace> .
+@prefix xsd: <http://www.w3.org/2001/XMLSchema#> .
 
 :gtin12 a rdf:Property ;
     rdfs:subPropertyOf :gtin .
@@ -16,7 +18,6 @@
 
 :gtin a rdf:Property ;
     rdfs:label "gtin" ;
-    :category "issue-1244" ;
     :domainIncludes :Demand,
         :Offer,
         :Product ;

--- a/data/ext/pending/issue-1253.ttl
+++ b/data/ext/pending/issue-1253.ttl
@@ -1,10 +1,11 @@
 @prefix : <http://schema.org/> .
 @prefix rdf: <http://www.w3.org/1999/02/22-rdf-syntax-ns#> .
 @prefix rdfs: <http://www.w3.org/2000/01/rdf-schema#> .
+@prefix xml: <http://www.w3.org/XML/1998/namespace> .
+@prefix xsd: <http://www.w3.org/2001/XMLSchema#> .
 
 :BrokerageAccount a rdfs:Class ;
     rdfs:label "BrokerageAccount" ;
-    :category "issue-1253" ;
     :isPartOf <http://pending.schema.org> ;
     :source <http://www.w3.org/wiki/WebSchemas/SchemaDotOrgSources#FIBO>,
         <https://github.com/schemaorg/schemaorg/issues/1253> ;
@@ -13,7 +14,6 @@
 
 :ExchangeRateSpecification a rdfs:Class ;
     rdfs:label "ExchangeRateSpecification" ;
-    :category "issue-1253" ;
     :isPartOf <http://pending.schema.org> ;
     :source <http://www.w3.org/wiki/WebSchemas/SchemaDotOrgSources#FIBO>,
         <https://github.com/schemaorg/schemaorg/issues/1253> ;
@@ -22,7 +22,6 @@
 
 :InvestmentFund a rdfs:Class ;
     rdfs:label "InvestmentFund" ;
-    :category "issue-1253" ;
     :isPartOf <http://pending.schema.org> ;
     :source <http://www.w3.org/wiki/WebSchemas/SchemaDotOrgSources#FIBO>,
         <https://github.com/schemaorg/schemaorg/issues/1253> ;
@@ -31,7 +30,6 @@
 
 :MoneyTransfer a rdfs:Class ;
     rdfs:label "MoneyTransfer" ;
-    :category "issue-1253" ;
     :isPartOf <http://pending.schema.org> ;
     :source <http://www.w3.org/wiki/WebSchemas/SchemaDotOrgSources#FIBO>,
         <https://github.com/schemaorg/schemaorg/issues/1253> ;
@@ -40,7 +38,6 @@
 
 :MortgageLoan a rdfs:Class ;
     rdfs:label "MortgageLoan" ;
-    :category "issue-1253" ;
     :isPartOf <http://pending.schema.org> ;
     :source <http://www.w3.org/wiki/WebSchemas/SchemaDotOrgSources#FIBO>,
         <https://github.com/schemaorg/schemaorg/issues/1253> ;
@@ -49,7 +46,6 @@
 
 :RepaymentSpecification a rdfs:Class ;
     rdfs:label "RepaymentSpecification" ;
-    :category "issue-1253" ;
     :isPartOf <http://pending.schema.org> ;
     :source <http://www.w3.org/wiki/WebSchemas/SchemaDotOrgSources#FIBO>,
         <https://github.com/schemaorg/schemaorg/issues/1253> ;
@@ -58,7 +54,6 @@
 
 :accountMinimumInflow a rdf:Property ;
     rdfs:label "accountMinimumInflow" ;
-    :category "issue-1253" ;
     :domainIncludes :BankAccount ;
     :isPartOf <http://pending.schema.org> ;
     :rangeIncludes :MonetaryAmount ;
@@ -68,7 +63,6 @@
 
 :accountOverdraftLimit a rdf:Property ;
     rdfs:label "accountOverdraftLimit" ;
-    :category "issue-1253" ;
     :domainIncludes :BankAccount ;
     :isPartOf <http://pending.schema.org> ;
     :rangeIncludes :MonetaryAmount ;
@@ -77,13 +71,11 @@
     rdfs:comment "An overdraft is an extension of credit from a lending institution when an account reaches zero. An overdraft allows the individual to continue withdrawing money even if the account has no funds in it. Basically the bank allows people to borrow a set amount of money." .
 
 :amount a rdf:Property ;
-    :category "issue-1253" ;
     :domainIncludes :MoneyTransfer ;
     :source <https://github.com/schemaorg/schemaorg/issues/1253> .
 
 :bankAccountType a rdf:Property ;
     rdfs:label "bankAccountType" ;
-    :category "issue-1253" ;
     :domainIncludes :BankAccount ;
     :isPartOf <http://pending.schema.org> ;
     :rangeIncludes :Text,
@@ -94,7 +86,6 @@
 
 :beneficiaryBank a rdf:Property ;
     rdfs:label "beneficiaryBank" ;
-    :category "issue-1253" ;
     :domainIncludes :MoneyTransfer ;
     :isPartOf <http://pending.schema.org> ;
     :rangeIncludes :BankOrCreditUnion,
@@ -105,7 +96,6 @@
 
 :cashBack a rdf:Property ;
     rdfs:label "cashBack" ;
-    :category "issue-1253" ;
     :domainIncludes :PaymentCard ;
     :isPartOf <http://pending.schema.org> ;
     :rangeIncludes :Boolean,
@@ -116,7 +106,6 @@
 
 :contactlessPayment a rdf:Property ;
     rdfs:label "contactlessPayment" ;
-    :category "issue-1253" ;
     :domainIncludes :PaymentCard ;
     :isPartOf <http://pending.schema.org> ;
     :rangeIncludes :Boolean ;
@@ -125,14 +114,12 @@
     rdfs:comment "A secure method for consumers to purchase products or services via debit, credit or smartcards by using RFID or NFC technology." .
 
 :currency a rdf:Property ;
-    :category "issue-1253" ;
     :domainIncludes :ExchangeRateSpecification,
         :LoanOrCredit ;
     :source <https://github.com/schemaorg/schemaorg/issues/1253> .
 
 :currentExchangeRate a rdf:Property ;
     rdfs:label "currentExchangeRate" ;
-    :category "issue-1253" ;
     :domainIncludes :ExchangeRateSpecification ;
     :isPartOf <http://pending.schema.org> ;
     :rangeIncludes :UnitPriceSpecification ;
@@ -142,7 +129,6 @@
 
 :domiciledMortgage a rdf:Property ;
     rdfs:label "domiciledMortgage" ;
-    :category "issue-1253" ;
     :domainIncludes :MortgageLoan ;
     :isPartOf <http://pending.schema.org> ;
     :rangeIncludes :Boolean ;
@@ -152,7 +138,6 @@
 
 :downPayment a rdf:Property ;
     rdfs:label "downPayment" ;
-    :category "issue-1253" ;
     :domainIncludes :RepaymentSpecification ;
     :isPartOf <http://pending.schema.org> ;
     :rangeIncludes :MonetaryAmount,
@@ -163,7 +148,6 @@
 
 :earlyPrepaymentPenalty a rdf:Property ;
     rdfs:label "earlyPrepaymentPenalty" ;
-    :category "issue-1253" ;
     :domainIncludes :RepaymentSpecification ;
     :isPartOf <http://pending.schema.org> ;
     :rangeIncludes :MonetaryAmount ;
@@ -173,7 +157,6 @@
 
 :exchangeRateSpread a rdf:Property ;
     rdfs:label "exchangeRateSpread" ;
-    :category "issue-1253" ;
     :domainIncludes :ExchangeRateSpecification ;
     :isPartOf <http://pending.schema.org> ;
     :rangeIncludes :MonetaryAmount,
@@ -184,7 +167,6 @@
 
 :floorLimit a rdf:Property ;
     rdfs:label "floorLimit" ;
-    :category "issue-1253" ;
     :domainIncludes :PaymentCard ;
     :isPartOf <http://pending.schema.org> ;
     :rangeIncludes :MonetaryAmount ;
@@ -194,7 +176,6 @@
 
 :gracePeriod a rdf:Property ;
     rdfs:label "gracePeriod" ;
-    :category "issue-1253" ;
     :domainIncludes :LoanOrCredit ;
     :isPartOf <http://pending.schema.org> ;
     :rangeIncludes :Duration ;
@@ -204,7 +185,6 @@
 
 :loanMortgageMandateAmount a rdf:Property ;
     rdfs:label "loanMortgageMandateAmount" ;
-    :category "issue-1253" ;
     :domainIncludes :MortgageLoan ;
     :isPartOf <http://pending.schema.org> ;
     :rangeIncludes :MonetaryAmount ;
@@ -214,7 +194,6 @@
 
 :loanPaymentAmount a rdf:Property ;
     rdfs:label "loanPaymentAmount" ;
-    :category "issue-1253" ;
     :domainIncludes :RepaymentSpecification ;
     :isPartOf <http://pending.schema.org> ;
     :rangeIncludes :MonetaryAmount ;
@@ -224,7 +203,6 @@
 
 :loanPaymentFrequency a rdf:Property ;
     rdfs:label "loanPaymentFrequency" ;
-    :category "issue-1253" ;
     :domainIncludes :RepaymentSpecification ;
     :isPartOf <http://pending.schema.org> ;
     :rangeIncludes :Number ;
@@ -234,7 +212,6 @@
 
 :loanRepaymentForm a rdf:Property ;
     rdfs:label "loanRepaymentForm" ;
-    :category "issue-1253" ;
     :domainIncludes :LoanOrCredit ;
     :isPartOf <http://pending.schema.org> ;
     :rangeIncludes :RepaymentSpecification ;
@@ -244,7 +221,6 @@
 
 :loanType a rdf:Property ;
     rdfs:label "loanType" ;
-    :category "issue-1253" ;
     :domainIncludes :LoanOrCredit ;
     :isPartOf <http://pending.schema.org> ;
     :rangeIncludes :Text,
@@ -255,7 +231,6 @@
 
 :monthlyMinimumRepaymentAmount a rdf:Property ;
     rdfs:label "monthlyMinimumRepaymentAmount" ;
-    :category "issue-1253" ;
     :domainIncludes :PaymentCard ;
     :isPartOf <http://pending.schema.org> ;
     :rangeIncludes :MonetaryAmount,
@@ -266,7 +241,6 @@
 
 :numberOfLoanPayments a rdf:Property ;
     rdfs:label "numberOfLoanPayments" ;
-    :category "issue-1253" ;
     :domainIncludes :RepaymentSpecification ;
     :isPartOf <http://pending.schema.org> ;
     :rangeIncludes :Number ;
@@ -276,7 +250,6 @@
 
 :recourseLoan a rdf:Property ;
     rdfs:label "recourseLoan" ;
-    :category "issue-1253" ;
     :domainIncludes :LoanOrCredit ;
     :isPartOf <http://pending.schema.org> ;
     :rangeIncludes :Boolean ;
@@ -286,7 +259,6 @@
 
 :renegotiableLoan a rdf:Property ;
     rdfs:label "renegotiableLoan" ;
-    :category "issue-1253" ;
     :domainIncludes :LoanOrCredit ;
     :isPartOf <http://pending.schema.org> ;
     :rangeIncludes :Boolean ;

--- a/data/ext/pending/issue-1375.ttl
+++ b/data/ext/pending/issue-1375.ttl
@@ -1,10 +1,11 @@
 @prefix : <http://schema.org/> .
 @prefix rdf: <http://www.w3.org/1999/02/22-rdf-syntax-ns#> .
 @prefix rdfs: <http://www.w3.org/2000/01/rdf-schema#> .
+@prefix xml: <http://www.w3.org/XML/1998/namespace> .
+@prefix xsd: <http://www.w3.org/2001/XMLSchema#> .
 
 :GeospatialGeometry a rdfs:Class ;
     rdfs:label "GeospatialGeometry" ;
-    :category "issue-1375" ;
     :isPartOf <http://pending.schema.org> ;
     :source <https://github.com/schemaorg/schemaorg/issues/1375> ;
     rdfs:comment "(Eventually to be defined as) a supertype of GeoShape designed to accommodate definitions from Geo-Spatial best practices." ;

--- a/data/ext/pending/issue-1397.ttl
+++ b/data/ext/pending/issue-1397.ttl
@@ -1,9 +1,11 @@
 @prefix : <http://schema.org/> .
+@prefix rdf: <http://www.w3.org/1999/02/22-rdf-syntax-ns#> .
 @prefix rdfs: <http://www.w3.org/2000/01/rdf-schema#> .
+@prefix xml: <http://www.w3.org/XML/1998/namespace> .
+@prefix xsd: <http://www.w3.org/2001/XMLSchema#> .
 
 :CompleteDataFeed a rdfs:Class ;
     rdfs:label "CompleteDataFeed" ;
-    :category "issue-1397" ;
     :isPartOf <http://pending.schema.org> ;
     :source <https://github.com/schemaorg/schemaorg/issues/1397> ;
     rdfs:comment """A [[CompleteDataFeed]] is a [[DataFeed]] whose standard representation includes content for every item currently in the feed.

--- a/data/ext/pending/issue-1401.ttl
+++ b/data/ext/pending/issue-1401.ttl
@@ -1,30 +1,22 @@
 @prefix : <http://schema.org/> .
 @prefix rdf: <http://www.w3.org/1999/02/22-rdf-syntax-ns#> .
 @prefix rdfs: <http://www.w3.org/2000/01/rdf-schema#> .
+@prefix xml: <http://www.w3.org/XML/1998/namespace> .
+@prefix xsd: <http://www.w3.org/2001/XMLSchema#> .
 
 :Course a rdfs:Class ;
-    rdfs:subClassOf :LearningResource.
+    rdfs:subClassOf :LearningResource .
 
 :LearningResource a rdfs:Class ;
     rdfs:label "LearningResource" ;
-    :source <https://github.com/schemaorg/schemaorg/issues/1401> ;
-    :category "issue-1401" ;
     :isPartOf <http://pending.schema.org> ;
-
-    rdfs:subClassOf :CreativeWork ;
-
+    :source <https://github.com/schemaorg/schemaorg/issues/1401> ;
     rdfs:comment """The LearningResource type can be used to indicate [[CreativeWork]]s (whether physical or digital) that have a particular and explicit orientation towards learning, education, skill acquisition, and other educational purposes.
 
 [[LearningResource]] is expected to be used as an addition to a primary type such as [[Book]], [[Video]], [[Product]] etc.
 
-[[EducationEvent]] serves a similar purpose for event-like things (e.g. a [[Trip]]). A [[LearningResource]] may be created as a result of an [[EducationEvent]], for example by recording one.""" .
-
-
-:educationalLevel a rdf:Property ;
-    :domainIncludes :LearningResource .
-
-:teaches a rdf:Property ;
-       :domainIncludes :LearningResource .
+[[EducationEvent]] serves a similar purpose for event-like things (e.g. a [[Trip]]). A [[LearningResource]] may be created as a result of an [[EducationEvent]], for example by recording one.""" ;
+    rdfs:subClassOf :CreativeWork .
 
 :assesses a rdf:Property ;
     :domainIncludes :LearningResource .
@@ -32,5 +24,12 @@
 :educationalAlignment a rdf:Property ;
     :domainIncludes :LearningResource .
 
+:educationalLevel a rdf:Property ;
+    :domainIncludes :LearningResource .
+
 :educationalUse a rdf:Property ;
     :domainIncludes :LearningResource .
+
+:teaches a rdf:Property ;
+    :domainIncludes :LearningResource .
+

--- a/data/ext/pending/issue-1423.ttl
+++ b/data/ext/pending/issue-1423.ttl
@@ -1,10 +1,11 @@
 @prefix : <http://schema.org/> .
 @prefix rdf: <http://www.w3.org/1999/02/22-rdf-syntax-ns#> .
 @prefix rdfs: <http://www.w3.org/2000/01/rdf-schema#> .
+@prefix xml: <http://www.w3.org/XML/1998/namespace> .
+@prefix xsd: <http://www.w3.org/2001/XMLSchema#> .
 
 :WebAPI a rdfs:Class ;
     rdfs:label "WebAPI" ;
-    :category "issue-1423" ;
     :isPartOf <http://pending.schema.org> ;
     :source <https://github.com/schemaorg/schemaorg/issues/1423> ;
     rdfs:comment "An application programming interface accessible over Web/Internet technologies." ;
@@ -12,7 +13,6 @@
 
 :documentation a rdf:Property ;
     rdfs:label "documentation" ;
-    :category "issue-1423" ;
     :domainIncludes :WebAPI ;
     :isPartOf <http://pending.schema.org> ;
     :rangeIncludes :CreativeWork,
@@ -22,7 +22,6 @@
 
 :termsOfService a rdf:Property ;
     rdfs:label "termsOfService" ;
-    :category "issue-1423" ;
     :domainIncludes :Service ;
     :isPartOf <http://pending.schema.org> ;
     :rangeIncludes :Text,

--- a/data/ext/pending/issue-1425.ttl
+++ b/data/ext/pending/issue-1425.ttl
@@ -1,10 +1,11 @@
 @prefix : <http://schema.org/> .
 @prefix rdf: <http://www.w3.org/1999/02/22-rdf-syntax-ns#> .
 @prefix rdfs: <http://www.w3.org/2000/01/rdf-schema#> .
+@prefix xml: <http://www.w3.org/XML/1998/namespace> .
+@prefix xsd: <http://www.w3.org/2001/XMLSchema#> .
 
 :measurementTechnique a rdf:Property ;
     rdfs:label "measurementTechnique" ;
-    :category "issue-1425" ;
     :domainIncludes :DataCatalog,
         :DataDownload,
         :Dataset,

--- a/data/ext/pending/issue-1448.ttl
+++ b/data/ext/pending/issue-1448.ttl
@@ -1,9 +1,11 @@
 @prefix : <http://schema.org/> .
+@prefix rdf: <http://www.w3.org/1999/02/22-rdf-syntax-ns#> .
 @prefix rdfs: <http://www.w3.org/2000/01/rdf-schema#> .
+@prefix xml: <http://www.w3.org/XML/1998/namespace> .
+@prefix xsd: <http://www.w3.org/2001/XMLSchema#> .
 
 :Drawing a rdfs:Class ;
     rdfs:label "Drawing" ;
-    :category "issue-1448" ;
     :isPartOf <http://pending.schema.org> ;
     :source <https://github.com/schemaorg/schemaorg/issues/1448> ;
     rdfs:comment "A picture or diagram made with a pencil, pen, or crayon rather than paint." ;
@@ -11,7 +13,6 @@
 
 :Manuscript a rdfs:Class ;
     rdfs:label "Manuscript" ;
-    :category "issue-1448" ;
     :isPartOf <http://pending.schema.org> ;
     :source <https://github.com/schemaorg/schemaorg/issues/1448> ;
     rdfs:comment "A book, document, or piece of music written by hand rather than typed or printed." ;
@@ -19,7 +20,6 @@
 
 :Poster a rdfs:Class ;
     rdfs:label "Poster" ;
-    :category "issue-1448" ;
     :isPartOf <http://pending.schema.org> ;
     :source <https://github.com/schemaorg/schemaorg/issues/1448> ;
     rdfs:comment "A large, usually printed placard, bill, or announcement, often illustrated, that is posted to advertise or publicize something." ;
@@ -27,7 +27,6 @@
 
 :SheetMusic a rdfs:Class ;
     rdfs:label "SheetMusic" ;
-    :category "issue-1448" ;
     :isPartOf <http://pending.schema.org> ;
     :source <https://github.com/schemaorg/schemaorg/issues/1448> ;
     rdfs:comment "Printed music, as opposed to performed or recorded music." ;

--- a/data/ext/pending/issue-1457.ttl
+++ b/data/ext/pending/issue-1457.ttl
@@ -1,10 +1,11 @@
 @prefix : <http://schema.org/> .
 @prefix rdf: <http://www.w3.org/1999/02/22-rdf-syntax-ns#> .
 @prefix rdfs: <http://www.w3.org/2000/01/rdf-schema#> .
+@prefix xml: <http://www.w3.org/XML/1998/namespace> .
+@prefix xsd: <http://www.w3.org/2001/XMLSchema#> .
 
 :Schedule a rdfs:Class ;
     rdfs:label "Schedule" ;
-    :category "issue-1457" ;
     :isPartOf <http://pending.schema.org> ;
     :source <https://github.com/schemaorg/schemaorg/issues/1457> ;
     rdfs:comment """A schedule defines a repeating time period used to describe a regularly occurring [[Event]]. At a minimum a schedule will specify [[repeatFrequency]] which describes the interval between occurences of the event. Additional information can be provided to specify the schedule more precisely.
@@ -14,7 +15,6 @@
 
 :byDay a rdf:Property ;
     rdfs:label "byDay" ;
-    :category "issue-1457" ;
     :domainIncludes :Schedule ;
     :isPartOf <http://pending.schema.org> ;
     :rangeIncludes :DayOfWeek,
@@ -24,7 +24,6 @@
 
 :byMonth a rdf:Property ;
     rdfs:label "byMonth" ;
-    :category "issue-1457" ;
     :domainIncludes :Schedule ;
     :isPartOf <http://pending.schema.org> ;
     :rangeIncludes :Integer ;
@@ -33,7 +32,6 @@
 
 :byMonthDay a rdf:Property ;
     rdfs:label "byMonthDay" ;
-    :category "issue-1457" ;
     :domainIncludes :Schedule ;
     :isPartOf <http://pending.schema.org> ;
     :rangeIncludes :Integer ;
@@ -41,13 +39,11 @@
     rdfs:comment "Defines the day(s) of the month on which a recurring [[Event]] takes place. Specified as an [[Integer]] between 1-31." .
 
 :duration a rdf:Property ;
-    :category "issue-1457" ;
     :domainIncludes :Schedule ;
     :source <https://github.com/schemaorg/schemaorg/issues/1457> .
 
 :eventSchedule a rdf:Property ;
     rdfs:label "eventSchedule" ;
-    :category "issue-1457" ;
     :domainIncludes :Event ;
     :isPartOf <http://pending.schema.org> ;
     :rangeIncludes :Schedule ;
@@ -61,7 +57,6 @@
 
 :exceptDate a rdf:Property ;
     rdfs:label "exceptDate" ;
-    :category "issue-1457" ;
     :domainIncludes :Schedule ;
     :isPartOf <http://pending.schema.org> ;
     :rangeIncludes :Date,
@@ -74,7 +69,6 @@
 
 :repeatCount a rdf:Property ;
     rdfs:label "repeatCount" ;
-    :category "issue-1457" ;
     :domainIncludes :Schedule ;
     :isPartOf <http://pending.schema.org> ;
     :rangeIncludes :Integer ;
@@ -83,7 +77,6 @@
 
 :repeatFrequency a rdf:Property ;
     rdfs:label "repeatFrequency" ;
-    :category "issue-1457" ;
     :domainIncludes :Schedule ;
     :isPartOf <http://pending.schema.org> ;
     :rangeIncludes :Duration,
@@ -95,7 +88,6 @@
 
 :scheduleTimezone a rdf:Property ;
     rdfs:label "scheduleTimezone" ;
-    :category "issue-1457" ;
     :domainIncludes :Schedule ;
     :isPartOf <http://pending.schema.org> ;
     :rangeIncludes :Text ;

--- a/data/ext/pending/issue-1495.ttl
+++ b/data/ext/pending/issue-1495.ttl
@@ -1,9 +1,11 @@
 @prefix : <http://schema.org/> .
+@prefix rdf: <http://www.w3.org/1999/02/22-rdf-syntax-ns#> .
 @prefix rdfs: <http://www.w3.org/2000/01/rdf-schema#> .
+@prefix xml: <http://www.w3.org/XML/1998/namespace> .
+@prefix xsd: <http://www.w3.org/2001/XMLSchema#> .
 
 :LibrarySystem a rdfs:Class ;
     rdfs:label "LibrarySystem" ;
-    :category "issue-1495" ;
     :isPartOf <http://pending.schema.org> ;
     :source <https://github.com/schemaorg/schemaorg/issues/1495> ;
     rdfs:comment "A [[LibrarySystem]] is a collaborative system amongst several libraries." ;

--- a/data/ext/pending/issue-1525.ttl
+++ b/data/ext/pending/issue-1525.ttl
@@ -1,10 +1,11 @@
 @prefix : <http://schema.org/> .
 @prefix rdf: <http://www.w3.org/1999/02/22-rdf-syntax-ns#> .
 @prefix rdfs: <http://www.w3.org/2000/01/rdf-schema#> .
+@prefix xml: <http://www.w3.org/XML/1998/namespace> .
+@prefix xsd: <http://www.w3.org/2001/XMLSchema#> .
 
 :AdvertiserContentArticle a rdfs:Class ;
     rdfs:label "AdvertiserContentArticle" ;
-    :category "issue-1525" ;
     :isPartOf <http://pending.schema.org> ;
     :source <https://github.com/schemaorg/schemaorg/issues/1525>,
         <https://www.w3.org/wiki/WebSchemas/SchemaDotOrgSources#TP> ;
@@ -13,7 +14,6 @@
 
 :AnalysisNewsArticle a rdfs:Class ;
     rdfs:label "AnalysisNewsArticle" ;
-    :category "issue-1525" ;
     :isPartOf <http://pending.schema.org> ;
     :source <https://github.com/schemaorg/schemaorg/issues/1525>,
         <https://www.w3.org/wiki/WebSchemas/SchemaDotOrgSources#TP> ;
@@ -22,7 +22,6 @@
 
 :AskPublicNewsArticle a rdfs:Class ;
     rdfs:label "AskPublicNewsArticle" ;
-    :category "issue-1525" ;
     :isPartOf <http://pending.schema.org> ;
     :source <https://github.com/schemaorg/schemaorg/issues/1525>,
         <https://www.w3.org/wiki/WebSchemas/SchemaDotOrgSources#TP> ;
@@ -31,7 +30,6 @@
 
 :BackgroundNewsArticle a rdfs:Class ;
     rdfs:label "BackgroundNewsArticle" ;
-    :category "issue-1525" ;
     :isPartOf <http://pending.schema.org> ;
     :source <https://github.com/schemaorg/schemaorg/issues/1525>,
         <https://www.w3.org/wiki/WebSchemas/SchemaDotOrgSources#TP> ;
@@ -40,7 +38,6 @@
 
 :NewsMediaOrganization a rdfs:Class ;
     rdfs:label "NewsMediaOrganization" ;
-    :category "issue-1525" ;
     :isPartOf <http://pending.schema.org> ;
     :source <https://github.com/schemaorg/schemaorg/issues/1525>,
         <https://www.w3.org/wiki/WebSchemas/SchemaDotOrgSources#TP> ;
@@ -49,7 +46,6 @@
 
 :OpinionNewsArticle a rdfs:Class ;
     rdfs:label "OpinionNewsArticle" ;
-    :category "issue-1525" ;
     :isPartOf <http://pending.schema.org> ;
     :source <https://github.com/schemaorg/schemaorg/issues/1525>,
         <https://www.w3.org/wiki/WebSchemas/SchemaDotOrgSources#TP> ;
@@ -58,7 +54,6 @@
 
 :ReportageNewsArticle a rdfs:Class ;
     rdfs:label "ReportageNewsArticle" ;
-    :category "issue-1525" ;
     :isPartOf <http://pending.schema.org> ;
     :source <https://github.com/schemaorg/schemaorg/issues/1525>,
         <https://www.w3.org/wiki/WebSchemas/SchemaDotOrgSources#TP> ;
@@ -75,7 +70,6 @@ A [[ReportageNewsArticle]] which goes deeper into analysis can also be marked wi
 
 :ReviewNewsArticle a rdfs:Class ;
     rdfs:label "ReviewNewsArticle" ;
-    :category "issue-1525" ;
     :isPartOf <http://pending.schema.org> ;
     :source <https://github.com/schemaorg/schemaorg/issues/1525>,
         <https://www.w3.org/wiki/WebSchemas/SchemaDotOrgSources#TP> ;
@@ -85,7 +79,6 @@ A [[ReportageNewsArticle]] which goes deeper into analysis can also be marked wi
 
 :SatiricalArticle a rdfs:Class ;
     rdfs:label "SatiricalArticle" ;
-    :category "issue-1525" ;
     :isPartOf <http://pending.schema.org> ;
     :source <https://github.com/schemaorg/schemaorg/issues/1525>,
         <https://www.w3.org/wiki/WebSchemas/SchemaDotOrgSources#TP> ;
@@ -94,7 +87,6 @@ A [[ReportageNewsArticle]] which goes deeper into analysis can also be marked wi
 
 :actionableFeedbackPolicy a rdf:Property ;
     rdfs:label "actionableFeedbackPolicy" ;
-    :category "issue-1525" ;
     :domainIncludes :NewsMediaOrganization,
         :Organization ;
     :isPartOf <http://pending.schema.org> ;
@@ -107,7 +99,6 @@ A [[ReportageNewsArticle]] which goes deeper into analysis can also be marked wi
 
 :correctionsPolicy a rdf:Property ;
     rdfs:label "correctionsPolicy" ;
-    :category "issue-1525" ;
     :domainIncludes :NewsMediaOrganization,
         :Organization ;
     :isPartOf <http://pending.schema.org> ;
@@ -120,7 +111,6 @@ A [[ReportageNewsArticle]] which goes deeper into analysis can also be marked wi
 
 :diversityPolicy a rdf:Property ;
     rdfs:label "diversityPolicy" ;
-    :category "issue-1525" ;
     :domainIncludes :NewsMediaOrganization,
         :Organization ;
     :isPartOf <http://pending.schema.org> ;
@@ -132,7 +122,6 @@ A [[ReportageNewsArticle]] which goes deeper into analysis can also be marked wi
 
 :diversityStaffingReport a rdf:Property ;
     rdfs:label "diversityStaffingReport" ;
-    :category "issue-1525" ;
     :domainIncludes :NewsMediaOrganization,
         :Organization ;
     :isPartOf <http://pending.schema.org> ;
@@ -145,7 +134,6 @@ A [[ReportageNewsArticle]] which goes deeper into analysis can also be marked wi
 
 :ethicsPolicy a rdf:Property ;
     rdfs:label "ethicsPolicy" ;
-    :category "issue-1525" ;
     :domainIncludes :NewsMediaOrganization,
         :Organization ;
     :isPartOf <http://pending.schema.org> ;
@@ -156,7 +144,6 @@ A [[ReportageNewsArticle]] which goes deeper into analysis can also be marked wi
 
 :masthead a rdf:Property ;
     rdfs:label "masthead" ;
-    :category "issue-1525" ;
     :domainIncludes :NewsMediaOrganization ;
     :isPartOf <http://pending.schema.org> ;
     :rangeIncludes :CreativeWork,
@@ -168,7 +155,6 @@ A [[ReportageNewsArticle]] which goes deeper into analysis can also be marked wi
 
 :missionCoveragePrioritiesPolicy a rdf:Property ;
     rdfs:label "missionCoveragePrioritiesPolicy" ;
-    :category "issue-1525" ;
     :domainIncludes :NewsMediaOrganization ;
     :isPartOf <http://pending.schema.org> ;
     :rangeIncludes :CreativeWork,
@@ -180,7 +166,6 @@ A [[ReportageNewsArticle]] which goes deeper into analysis can also be marked wi
 
 :ownershipFundingInfo a rdf:Property ;
     rdfs:label "ownershipFundingInfo" ;
-    :category "issue-1525" ;
     :domainIncludes :NewsMediaOrganization,
         :Organization ;
     :isPartOf <http://pending.schema.org> ;
@@ -195,7 +180,6 @@ A [[ReportageNewsArticle]] which goes deeper into analysis can also be marked wi
 
 :unnamedSourcesPolicy a rdf:Property ;
     rdfs:label "unnamedSourcesPolicy" ;
-    :category "issue-1525" ;
     :domainIncludes :NewsMediaOrganization,
         :Organization ;
     :isPartOf <http://pending.schema.org> ;
@@ -208,7 +192,6 @@ A [[ReportageNewsArticle]] which goes deeper into analysis can also be marked wi
 
 :verificationFactCheckingPolicy a rdf:Property ;
     rdfs:label "verificationFactCheckingPolicy" ;
-    :category "issue-1525" ;
     :domainIncludes :NewsMediaOrganization ;
     :isPartOf <http://pending.schema.org> ;
     :rangeIncludes :CreativeWork,

--- a/data/ext/pending/issue-1559.ttl
+++ b/data/ext/pending/issue-1559.ttl
@@ -1,9 +1,11 @@
 @prefix : <http://schema.org/> .
+@prefix rdf: <http://www.w3.org/1999/02/22-rdf-syntax-ns#> .
 @prefix rdfs: <http://www.w3.org/2000/01/rdf-schema#> .
+@prefix xml: <http://www.w3.org/XML/1998/namespace> .
+@prefix xsd: <http://www.w3.org/2001/XMLSchema#> .
 
 :Consortium a rdfs:Class ;
     rdfs:label "Consortium" ;
-    :category "issue-1559" ;
     :isPartOf <http://pending.schema.org> ;
     :source <https://github.com/schemaorg/schemaorg/issues/1559> ;
     rdfs:comment "A Consortium is a membership [[Organization]] whose members are typically Organizations." ;

--- a/data/ext/pending/issue-1576.ttl
+++ b/data/ext/pending/issue-1576.ttl
@@ -1,9 +1,11 @@
 @prefix : <http://schema.org/> .
+@prefix rdf: <http://www.w3.org/1999/02/22-rdf-syntax-ns#> .
 @prefix rdfs: <http://www.w3.org/2000/01/rdf-schema#> .
+@prefix xml: <http://www.w3.org/XML/1998/namespace> .
+@prefix xsd: <http://www.w3.org/2001/XMLSchema#> .
 
 :EmployerReview a rdfs:Class ;
     rdfs:label "EmployerReview" ;
-    :category "issue-1576" ;
     :isPartOf <http://pending.schema.org> ;
     :source <https://github.com/schemaorg/schemaorg/issues/1589> ;
     rdfs:comment "An [[EmployerReview]] is a review of an [[Organization]] regarding its role as an employer, written by a current or former employee of that organization." ;

--- a/data/ext/pending/issue-1589.ttl
+++ b/data/ext/pending/issue-1589.ttl
@@ -1,9 +1,11 @@
 @prefix : <http://schema.org/> .
+@prefix rdf: <http://www.w3.org/1999/02/22-rdf-syntax-ns#> .
 @prefix rdfs: <http://www.w3.org/2000/01/rdf-schema#> .
+@prefix xml: <http://www.w3.org/XML/1998/namespace> .
+@prefix xsd: <http://www.w3.org/2001/XMLSchema#> .
 
 :CriticReview a rdfs:Class ;
     rdfs:label "CriticReview" ;
-    :category "issue-1589" ;
     :isPartOf <http://pending.schema.org> ;
     :source <https://github.com/schemaorg/schemaorg/issues/1589> ;
     rdfs:comment "A [[CriticReview]] is a more specialized form of Review written or published by a source that is recognized for its reviewing activities. These can include online columns, travel and food guides, TV and radio shows, blogs and other independent Web sites. [[CriticReview]]s are typically more in-depth and professionally written. For simpler, casually written user/visitor/viewer/customer reviews, it is more appropriate to use the [[UserReview]] type. Review aggregator sites such as Metacritic already separate out the site's user reviews from selected critic reviews that originate from third-party sources." ;
@@ -11,7 +13,6 @@
 
 :UserReview a rdfs:Class ;
     rdfs:label "UserReview" ;
-    :category "issue-1589" ;
     :isPartOf <http://pending.schema.org> ;
     :source <https://github.com/schemaorg/schemaorg/issues/1589> ;
     rdfs:comment "A review created by an end-user (e.g. consumer, purchaser, attendee etc.), in contrast with [[CriticReview]]." ;

--- a/data/ext/pending/issue-1591.ttl
+++ b/data/ext/pending/issue-1591.ttl
@@ -1,10 +1,11 @@
 @prefix : <http://schema.org/> .
 @prefix rdf: <http://www.w3.org/1999/02/22-rdf-syntax-ns#> .
 @prefix rdfs: <http://www.w3.org/2000/01/rdf-schema#> .
+@prefix xml: <http://www.w3.org/XML/1998/namespace> .
+@prefix xsd: <http://www.w3.org/2001/XMLSchema#> .
 
 :jobLocationType a rdf:Property ;
     rdfs:label "jobLocationType" ;
-    :category "issue-1591" ;
     :domainIncludes :JobPosting ;
     :isPartOf <http://pending.schema.org> ;
     :rangeIncludes :Text ;

--- a/data/ext/pending/issue-1624.ttl
+++ b/data/ext/pending/issue-1624.ttl
@@ -1,9 +1,11 @@
 @prefix : <http://schema.org/> .
+@prefix rdf: <http://www.w3.org/1999/02/22-rdf-syntax-ns#> .
 @prefix rdfs: <http://www.w3.org/2000/01/rdf-schema#> .
+@prefix xml: <http://www.w3.org/XML/1998/namespace> .
+@prefix xsd: <http://www.w3.org/2001/XMLSchema#> .
 
 :PublicToilet a rdfs:Class ;
     rdfs:label "PublicToilet" ;
-    :category "issue-1624" ;
     :isPartOf <http://pending.schema.org> ;
     :source <https://github.com/schemaorg/schemaorg/issues/1624> ;
     rdfs:comment "A public toilet is a room or small building containing one or more toilets (and possibly also urinals) which is available for use by the general public, or by customers or employees of certain businesses." ;

--- a/data/ext/pending/issue-1672.ttl
+++ b/data/ext/pending/issue-1672.ttl
@@ -1,9 +1,11 @@
 @prefix : <http://schema.org/> .
+@prefix rdf: <http://www.w3.org/1999/02/22-rdf-syntax-ns#> .
 @prefix rdfs: <http://www.w3.org/2000/01/rdf-schema#> .
+@prefix xml: <http://www.w3.org/XML/1998/namespace> .
+@prefix xsd: <http://www.w3.org/2001/XMLSchema#> .
 
 :CssSelectorType a rdfs:Class ;
     rdfs:label "CssSelectorType" ;
-    :category "issue-1672" ;
     :isPartOf <http://pending.schema.org> ;
     :source <https://github.com/schemaorg/schemaorg/issues/1672> ;
     rdfs:comment "Text representing a CSS selector." ;
@@ -11,7 +13,6 @@
 
 :XPathType a rdfs:Class ;
     rdfs:label "XPathType" ;
-    :category "issue-1672" ;
     :isPartOf <http://pending.schema.org> ;
     :source <https://github.com/schemaorg/schemaorg/issues/1672> ;
     rdfs:comment "Text representing an XPath (typically but not necessarily version 1.0)." ;

--- a/data/ext/pending/issue-1688.ttl
+++ b/data/ext/pending/issue-1688.ttl
@@ -1,10 +1,11 @@
 @prefix : <http://schema.org/> .
 @prefix rdf: <http://www.w3.org/1999/02/22-rdf-syntax-ns#> .
 @prefix rdfs: <http://www.w3.org/2000/01/rdf-schema#> .
+@prefix xml: <http://www.w3.org/XML/1998/namespace> .
+@prefix xsd: <http://www.w3.org/2001/XMLSchema#> .
 
 :backstory a rdf:Property ;
     rdfs:label "backstory" ;
-    :category "issue-1688" ;
     :domainIncludes :Article ;
     :isPartOf <http://pending.schema.org> ;
     :rangeIncludes :CreativeWork,
@@ -15,7 +16,6 @@
 
 :knowsAbout a rdf:Property ;
     rdfs:label "knowsAbout" ;
-    :category "issue-1688" ;
     :domainIncludes :Organization,
         :Person ;
     :isPartOf <http://pending.schema.org> ;
@@ -28,7 +28,6 @@
 
 :knowsLanguage a rdf:Property ;
     rdfs:label "knowsLanguage" ;
-    :category "issue-1688" ;
     :domainIncludes :Organization,
         :Person ;
     :isPartOf <http://pending.schema.org> ;
@@ -40,7 +39,6 @@
 
 :noBylinesPolicy a rdf:Property ;
     rdfs:label "noBylinesPolicy" ;
-    :category "issue-1688" ;
     :domainIncludes :NewsMediaOrganization ;
     :isPartOf <http://pending.schema.org> ;
     :rangeIncludes :CreativeWork,

--- a/data/ext/pending/issue-1755.ttl
+++ b/data/ext/pending/issue-1755.ttl
@@ -1,48 +1,45 @@
 @prefix : <http://schema.org/> .
 @prefix rdf: <http://www.w3.org/1999/02/22-rdf-syntax-ns#> .
 @prefix rdfs: <http://www.w3.org/2000/01/rdf-schema#> .
+@prefix xml: <http://www.w3.org/XML/1998/namespace> .
+@prefix xsd: <http://www.w3.org/2001/XMLSchema#> .
 
 :BoatReservation a rdfs:Class ;
-    :category "issue-1755" ;
+    rdfs:label "BoatReservation" ;
     :isPartOf <http://pending.schema.org> ;
     :source <https://github.com/schemaorg/schemaorg/issues/1755> ;
-    rdfs:label "BoatReservation" ;
     rdfs:comment """A reservation for boat travel.
 
 Note: This type is for information about actual reservations, e.g. in confirmation emails or HTML pages with individual confirmations of reservations. For offers of tickets, use [[Offer]].""" ;
     rdfs:subClassOf :Reservation .
 
-
 :BoatTerminal a rdfs:Class ;
-    :category "issue-1755" ;
+    rdfs:label "BoatTerminal" ;
     :isPartOf <http://pending.schema.org> ;
     :source <https://github.com/schemaorg/schemaorg/issues/1755> ;
-    rdfs:label "BoatTerminal" ;
     rdfs:comment "A terminal for boats, ships, and other water vessels." ;
     rdfs:subClassOf :CivicStructure .
 
 :BoatTrip a rdfs:Class ;
-    :category "issue-1755" ;
+    rdfs:label "BoatTrip" ;
     :isPartOf <http://pending.schema.org> ;
     :source <https://github.com/schemaorg/schemaorg/issues/1755> ;
-    rdfs:label "BoatTrip" ;
     rdfs:comment "A trip on a commercial ferry line." ;
     rdfs:subClassOf :Trip .
 
 :arrivalBoatTerminal a rdf:Property ;
-    :category "issue-1755" ;
-    :isPartOf <http://pending.schema.org> ;
-    :source <https://github.com/schemaorg/schemaorg/issues/1755> ;
     rdfs:label "arrivalBoatTerminal" ;
     :domainIncludes :BoatTrip ;
+    :isPartOf <http://pending.schema.org> ;
     :rangeIncludes :BoatTerminal ;
+    :source <https://github.com/schemaorg/schemaorg/issues/1755> ;
     rdfs:comment "The terminal or port from which the boat arrives." .
 
 :departureBoatTerminal a rdf:Property ;
-    :category "issue-1755" ;
-    :isPartOf <http://pending.schema.org> ;
-    :source <https://github.com/schemaorg/schemaorg/issues/1755> ;
     rdfs:label "departureBoatTerminal" ;
     :domainIncludes :BoatTrip ;
+    :isPartOf <http://pending.schema.org> ;
     :rangeIncludes :BoatTerminal ;
+    :source <https://github.com/schemaorg/schemaorg/issues/1755> ;
     rdfs:comment "The terminal or port from which the boat departs." .
+

--- a/data/ext/pending/issue-1758.ttl
+++ b/data/ext/pending/issue-1758.ttl
@@ -1,10 +1,11 @@
 @prefix : <http://schema.org/> .
 @prefix rdf: <http://www.w3.org/1999/02/22-rdf-syntax-ns#> .
 @prefix rdfs: <http://www.w3.org/2000/01/rdf-schema#> .
+@prefix xml: <http://www.w3.org/XML/1998/namespace> .
+@prefix xsd: <http://www.w3.org/2001/XMLSchema#> .
 
 :ArchiveComponent a rdfs:Class ;
     rdfs:label "ArchiveComponent"@en ;
-    :category "issue-1758"@en ;
     :isPartOf <http://pending.schema.org> ;
     :source <https://github.com/schemaorg/schemaorg/issues/1758> ;
     rdfs:comment "An intangible type to be applied to any archive content, carrying with it a set of properties required to describe archival items and collections."@en ;
@@ -12,7 +13,6 @@
 
 :ArchiveOrganization a rdfs:Class ;
     rdfs:label "ArchiveOrganization"@en ;
-    :category "issue-1758"@en ;
     :isPartOf <http://pending.schema.org> ;
     :source <https://github.com/schemaorg/schemaorg/issues/1758> ;
     rdfs:comment "An organization with archival holdings. An organization which keeps and preserves archival material and typically makes it accessible to the public."@en ;
@@ -20,7 +20,6 @@
 
 :itemLocation a rdf:Property ;
     rdfs:label "itemLocation"@en ;
-    :category "issue-1758"@en ;
     :domainIncludes :ArchiveComponent ;
     :isPartOf <http://pending.schema.org> ;
     :rangeIncludes :Place,
@@ -32,7 +31,6 @@
 
 :archiveHeld a rdf:Property ;
     rdfs:label "archiveHeld"@en ;
-    :category "issue-1758"@en ;
     :domainIncludes :ArchiveOrganization ;
     :inverseOf :holdingArchive ;
     :isPartOf <http://pending.schema.org> ;
@@ -42,7 +40,6 @@
 
 :holdingArchive a rdf:Property ;
     rdfs:label "holdingArchive"@en ;
-    :category "issue-1758"@en ;
     :domainIncludes :ArchiveComponent ;
     :inverseOf :archiveHeld ;
     :isPartOf <http://pending.schema.org> ;

--- a/data/ext/pending/issue-1759.ttl
+++ b/data/ext/pending/issue-1759.ttl
@@ -1,10 +1,11 @@
 @prefix : <http://schema.org/> .
 @prefix rdf: <http://www.w3.org/1999/02/22-rdf-syntax-ns#> .
 @prefix rdfs: <http://www.w3.org/2000/01/rdf-schema#> .
+@prefix xml: <http://www.w3.org/XML/1998/namespace> .
+@prefix xsd: <http://www.w3.org/2001/XMLSchema#> .
 
 :collectionSize a rdf:Property ;
     rdfs:label "collectionSize"@en ;
-    :category "issue-1759"@en ;
     :domainIncludes :Collection ;
     :isPartOf <http://pending.schema.org> ;
     :rangeIncludes :Integer ;
@@ -13,7 +14,6 @@
 
 :materialExtent a rdf:Property ;
     rdfs:label "materialExtent"@en ;
-    :category "issue-1759"@en ;
     :domainIncludes :CreativeWork ;
     :isPartOf <http://pending.schema.org> ;
     :rangeIncludes :QuantitativeValue,

--- a/data/ext/pending/issue-1779.ttl
+++ b/data/ext/pending/issue-1779.ttl
@@ -1,10 +1,11 @@
 @prefix : <http://schema.org/> .
 @prefix rdf: <http://www.w3.org/1999/02/22-rdf-syntax-ns#> .
 @prefix rdfs: <http://www.w3.org/2000/01/rdf-schema#> .
+@prefix xml: <http://www.w3.org/XML/1998/namespace> .
+@prefix xsd: <http://www.w3.org/2001/XMLSchema#> .
 
 :EducationalOccupationalCredential a rdfs:Class ;
     rdfs:label "EducationalOccupationalCredential" ;
-    :category "issue-1779" ;
     :isPartOf <http://pending.schema.org> ;
     :source <https://github.com/schemaorg/schemaorg/issues/1779> ;
     rdfs:comment "An educational or occupational credential. A diploma, academic degree, certification, qualification, badge, etc., that may be awarded to a person or other entity that meets the requirements defined by the credentialer." ;
@@ -12,7 +13,6 @@
 
 :competencyRequired a rdf:Property ;
     rdfs:label "competencyRequired" ;
-    :category "issue-1779" ;
     :domainIncludes :EducationalOccupationalCredential,
         :LearningResource ;
     :isPartOf <http://pending.schema.org> ;
@@ -24,7 +24,6 @@
 
 :credentialCategory a rdf:Property ;
     rdfs:label "credentialCategory" ;
-    :category "issue-1779" ;
     :domainIncludes :EducationalOccupationalCredential ;
     :isPartOf <http://pending.schema.org> ;
     :rangeIncludes :DefinedTerm,
@@ -34,14 +33,12 @@
     rdfs:comment "The category or type of credential being described, for example \"degree”, “certificate”, “badge”, or more specific term." .
 
 :educationRequirements a rdf:Property ;
-    :category "issue-1779" ;
     :isPartOf <http://pending.schema.org> ;
     :rangeIncludes :EducationalOccupationalCredential ;
     :source <https://github.com/schemaorg/schemaorg/issues/1779> .
 
 :educationalLevel a rdf:Property ;
     rdfs:label "educationalLevel" ;
-    :category "issue-1779" ;
     :domainIncludes :CreativeWork,
         :EducationEvent,
         :EducationalOccupationalCredential ;
@@ -53,14 +50,12 @@
     rdfs:comment "The level in terms of progression through an educational or training context. Examples of educational levels include 'beginner', 'intermediate' or 'advanced', and formal sets of level indicators." .
 
 :qualifications a rdf:Property ;
-    :category "issue-1779" ;
     :isPartOf <http://pending.schema.org> ;
     :rangeIncludes :EducationalOccupationalCredential ;
     :source <https://github.com/schemaorg/schemaorg/issues/1779> .
 
 :recognizedBy a rdf:Property ;
     rdfs:label "recognizedBy" ;
-    :category "issue-1779" ;
     :domainIncludes :EducationalOccupationalCredential ;
     :isPartOf <http://pending.schema.org> ;
     :rangeIncludes :Organization ;
@@ -69,12 +64,11 @@
 
 :validFor a rdf:Property ;
     rdfs:label "validFor" ;
-    :category "issue-1779" ;
     :domainIncludes :EducationalOccupationalCredential ;
     :source <https://github.com/schemaorg/schemaorg/issues/1779> .
 
 :validIn a rdf:Property ;
     rdfs:label "validIn" ;
-    :category "issue-1779" ;
     :domainIncludes :EducationalOccupationalCredential ;
     :source <https://github.com/schemaorg/schemaorg/issues/1779> .
+

--- a/data/ext/pending/issue-1797.ttl
+++ b/data/ext/pending/issue-1797.ttl
@@ -1,113 +1,75 @@
 @prefix : <http://schema.org/> .
 @prefix rdf: <http://www.w3.org/1999/02/22-rdf-syntax-ns#> .
 @prefix rdfs: <http://www.w3.org/2000/01/rdf-schema#> .
-
-:pattern a rdf:Property ;
-        rdfs:label "pattern" ;
-
-        :isPartOf <http://pending.schema.org> ;
-        :source <https://github.com/schemaorg/schemaorg/issues/1797> ;
-        :category "issue-1797" ;
-
-        :domainIncludes :CreativeWork, :Product ;
-        :rangeIncludes :Text, :DefinedTerm ;
-
-        rdfs:comment "A pattern that something has, for example 'polka dot', 'striped', 'Canadian flag'. Values are typically expressed as text, although links to controlled value schemes are also supported." .
-
-
-:size a rdf:Property;
-    rdfs:label "size" ;
-    :isPartOf <http://pending.schema.org> ;
-    :source <https://github.com/schemaorg/schemaorg/issues/1797> ;
-    :category "issue-1797" ;
-
-    :domainIncludes :CreativeWork, :Product ;
-    :rangeIncludes :Text, :QuantitativeValue, :DefinedTerm;
-
-     rdfs:comment "A standardized size of a product or creative work, often simplifying richer information into a simple textual string, either through referring to named sizes or (in the case of product markup), by adopting conventional simplifications. Use of QuantitativeValue with a unitCode or unitText can add more structure; in other cases, the /width, /height, /depth and /weight properties may be more applicable. ".
-
-
-
-
-
-
-
-#2597 /ProductGroup
-# https://github.com/schemaorg/schemaorg/issues/2587
+@prefix xml: <http://www.w3.org/XML/1998/namespace> .
+@prefix xsd: <http://www.w3.org/2001/XMLSchema#> .
 
 :ProductGroup a rdfs:Class ;
     rdfs:label "ProductGroup" ;
-
-    :category "issue-2597" ;
     :isPartOf <http://pending.schema.org> ;
     :source <https://github.com/schemaorg/schemaorg/issues/2597> ;
-
-    rdfs:subClassOf :Product ;
     rdfs:comment """A ProductGroup represents a group of [[Product]]s that vary only in certain well-described ways, such as by [[size]], [[color]], [[material]] etc.
 
-While a ProductGroup itself is not directly offered for sale, the various varying products that it represents can be. The ProductGroup serves as a prototype or template, standing in for all of the products who have an [[isVariantOf]] relationship to it. As such, properties (including additional types) can be applied to the ProductGroup to represent characteristics shared by each of the (possibly very many) variants. Properties that reference a ProductGroup are not included in this mechanism; neither are the following specific properties [[variesBy]], [[hasVariant]], [[url]]. """ .
-
-# TODO: incoming as well as outgoing properties?
-
-:variesBy a rdf:Property ;
-        rdfs:label "variesBy" ;
-
-        :isPartOf <http://pending.schema.org> ;
-        :source <https://github.com/schemaorg/schemaorg/issues/1797> ;
-        :category "issue-1797" ;
-
-        :domainIncludes :ProductGroup;
-        :rangeIncludes :Text, :DefinedTerm;
-
-        rdfs:comment """Indicates the property or properties by which the variants in a [[ProductGroup]] vary, e.g. their size, color etc. Schema.org properties can be referenced by their short name e.g. "color"; terms defined elsewhere can be referenced with their URIs.""" .
-
-
-
-:productGroupID a rdf:Property ;
-                rdfs:label "productGroupID" ;
-                :domainIncludes :ProductGroup;
-                :rangeIncludes :Text;
-                rdfs:comment """Indicates a textual identifier for a ProductGroup.""" ;
-                :isPartOf <http://pending.schema.org> ;
-                :source <https://github.com/schemaorg/schemaorg/issues/1797> ;
-                :category "issue-1797" .
+While a ProductGroup itself is not directly offered for sale, the various varying products that it represents can be. The ProductGroup serves as a prototype or template, standing in for all of the products who have an [[isVariantOf]] relationship to it. As such, properties (including additional types) can be applied to the ProductGroup to represent characteristics shared by each of the (possibly very many) variants. Properties that reference a ProductGroup are not included in this mechanism; neither are the following specific properties [[variesBy]], [[hasVariant]], [[url]]. """ ;
+    rdfs:subClassOf :Product .
 
 :inProductGroupWithID a rdf:Property ;
-                                rdfs:label "inProductGroupWithID" ;
-                                :domainIncludes :Product;
-                                :rangeIncludes :Text;
-                                rdfs:comment """Indicates the [[productGroupID]] for a [[ProductGroup]] that this product [[isVariantOf]]. """ ;
-                                :isPartOf <http://pending.schema.org> ;
-                                :source <https://github.com/schemaorg/schemaorg/issues/1797> ;
-                                :category "issue-1797" .
-                                # we didn't re-use :productGroupID to allow groups to potentially be members of groups.
-                                #
+    rdfs:label "inProductGroupWithID" ;
+    :domainIncludes :Product ;
+    :isPartOf <http://pending.schema.org> ;
+    :rangeIncludes :Text ;
+    :source <https://github.com/schemaorg/schemaorg/issues/1797> ;
+    rdfs:comment "Indicates the [[productGroupID]] for a [[ProductGroup]] that this product [[isVariantOf]]. " .
 
+:pattern a rdf:Property ;
+    rdfs:label "pattern" ;
+    :domainIncludes :CreativeWork,
+        :Product ;
+    :isPartOf <http://pending.schema.org> ;
+    :rangeIncludes :DefinedTerm,
+        :Text ;
+    :source <https://github.com/schemaorg/schemaorg/issues/1797> ;
+    rdfs:comment "A pattern that something has, for example 'polka dot', 'striped', 'Canadian flag'. Values are typically expressed as text, although links to controlled value schemes are also supported." .
+
+:productGroupID a rdf:Property ;
+    rdfs:label "productGroupID" ;
+    :domainIncludes :ProductGroup ;
+    :isPartOf <http://pending.schema.org> ;
+    :rangeIncludes :Text ;
+    :source <https://github.com/schemaorg/schemaorg/issues/1797> ;
+    rdfs:comment "Indicates a textual identifier for a ProductGroup." .
+
+:size a rdf:Property ;
+    rdfs:label "size" ;
+    :domainIncludes :CreativeWork,
+        :Product ;
+    :isPartOf <http://pending.schema.org> ;
+    :rangeIncludes :DefinedTerm,
+        :QuantitativeValue,
+        :Text ;
+    :source <https://github.com/schemaorg/schemaorg/issues/1797> ;
+    rdfs:comment "A standardized size of a product or creative work, often simplifying richer information into a simple textual string, either through referring to named sizes or (in the case of product markup), by adopting conventional simplifications. Use of QuantitativeValue with a unitCode or unitText can add more structure; in other cases, the /width, /height, /depth and /weight properties may be more applicable. " .
+
+:variesBy a rdf:Property ;
+    rdfs:label "variesBy" ;
+    :domainIncludes :ProductGroup ;
+    :isPartOf <http://pending.schema.org> ;
+    :rangeIncludes :DefinedTerm,
+        :Text ;
+    :source <https://github.com/schemaorg/schemaorg/issues/1797> ;
+    rdfs:comment "Indicates the property or properties by which the variants in a [[ProductGroup]] vary, e.g. their size, color etc. Schema.org properties can be referenced by their short name e.g. \"color\"; terms defined elsewhere can be referenced with their URIs." .
 
 :hasVariant a rdf:Property ;
-        rdfs:label "hasVariant" ;
+    rdfs:label "hasVariant" ;
+    :domainIncludes :ProductGroup ;
+    :inverseOf :isVariantOf ;
+    :isPartOf <http://pending.schema.org> ;
+    :rangeIncludes :Product ;
+    :source <https://github.com/schemaorg/schemaorg/issues/1797> ;
+    rdfs:comment "Indicates a [[Product]] that is a member of this [[ProductGroup]] (or [[ProductModel]])." .
 
-        :isPartOf <http://pending.schema.org> ;
-        :inverseOf :isVariantOf ;
-        :source <https://github.com/schemaorg/schemaorg/issues/1797> ;
-        :category "issue-1797" ;
+:isVariantOf a rdf:Property ;
+    :domainIncludes :Product ;
+    :inverseOf :hasVariant ;
+    :rangeIncludes :ProductGroup .
 
-        :domainIncludes :ProductGroup;
-        :rangeIncludes :Product;
-
-        rdfs:comment """Indicates a [[Product]] that is a member of this [[ProductGroup]] (or [[ProductModel]]).""" .
-
-
-:isVariantOf :inverseOf :hasVariant . # Technically redundant but we expect it normally to be defined locally per term
-                                      # In this case where one side of the inverse pair is a pending proposal, we define it all here.
-
-
-# Updates to existing terms
-
-# 1) we expect isVariantOf to sometimes be a ProductGroup
-:isVariantOf a rdf:Property ; :domainIncludes :Product ; :rangeIncludes :ProductGroup .
-
-
-# 2)
-# New text defining :isVariantOf in a way that supports these new terms
-# TODO

--- a/data/ext/pending/issue-1810.ttl
+++ b/data/ext/pending/issue-1810.ttl
@@ -1,70 +1,71 @@
 @prefix : <http://schema.org/> .
 @prefix rdf: <http://www.w3.org/1999/02/22-rdf-syntax-ns#> .
 @prefix rdfs: <http://www.w3.org/2000/01/rdf-schema#> .
+@prefix xml: <http://www.w3.org/XML/1998/namespace> .
+@prefix xsd: <http://www.w3.org/2001/XMLSchema#> .
 
 :TouristDestination a rdfs:Class ;
     rdfs:label "TouristDestination" ;
-    :category "issue-1810" ;
     :isPartOf <http://pending.schema.org> ;
     :source <http://www.w3.org/wiki/WebSchemas/SchemaDotOrgSources#IIT-CNR.it>,
-        <http://www.w3.org/wiki/WebSchemas/SchemaDotOrgSources#Tourism> ;
+        <http://www.w3.org/wiki/WebSchemas/SchemaDotOrgSources#Tourism>,
+        <https://github.com/schemaorg/schemaorg/issues/1810> ;
     rdfs:comment """A tourist destination. In principle any [[Place]] can be a [[TouristDestination]] from a [[City]], [[Region]] or [[Country]] to an [[AmusementPark]] or [[Hotel]]. This Type can be used on its own to describe a general [[TouristDestination]], or be used as an [[additionalType]] to add tourist relevant properties to any other [[Place]].  A [[TouristDestination]] is defined as a [[Place]] that contains, or is colocated with, one or more [[TouristAttraction]]s, often linked by a similar theme or interest to a particular [[touristType]]. The [UNWTO](http://www2.unwto.org/) defines Destination (main destination of a tourism trip) as the place visited that is central to the decision to take the trip.
   (See examples below).""" ;
     rdfs:subClassOf :Place .
 
 :TouristTrip a rdfs:Class ;
     rdfs:label "TouristTrip" ;
-    :category "issue-1810" ;
     :isPartOf <http://pending.schema.org> ;
     :source <http://www.w3.org/wiki/WebSchemas/SchemaDotOrgSources#IIT-CNR.it>,
-        <http://www.w3.org/wiki/WebSchemas/SchemaDotOrgSources#Tourism> ;
+        <http://www.w3.org/wiki/WebSchemas/SchemaDotOrgSources#Tourism>,
+        <https://github.com/schemaorg/schemaorg/issues/1810> ;
     rdfs:comment """A tourist trip. A created itinerary of visits to one or more places of interest ([[TouristAttraction]]/[[TouristDestination]]) often linked by a similar theme, geographic area, or interest to a particular [[touristType]]. The [UNWTO](http://www2.unwto.org/) defines tourism trip as the Trip taken by visitors.
   (See examples below).""" ;
     rdfs:subClassOf :Trip .
 
 :includesAttraction a rdf:Property ;
     rdfs:label "includesAttraction" ;
-    :category "issue-1810" ;
     :domainIncludes :TouristDestination ;
     :isPartOf <http://pending.schema.org> ;
     :rangeIncludes :TouristAttraction ;
     :source <http://www.w3.org/wiki/WebSchemas/SchemaDotOrgSources#IIT-CNR.it>,
-        <http://www.w3.org/wiki/WebSchemas/SchemaDotOrgSources#Tourism> ;
+        <http://www.w3.org/wiki/WebSchemas/SchemaDotOrgSources#Tourism>,
+        <https://github.com/schemaorg/schemaorg/issues/1810> ;
     rdfs:comment "Attraction located at destination." .
 
 :itinerary a rdf:Property ;
     rdfs:label "itinerary" ;
-    :category "issue-1810" ;
     :domainIncludes :Trip ;
     :isPartOf <http://pending.schema.org> ;
     :rangeIncludes :ItemList,
         :Place ;
-    :source <http://www.w3.org/wiki/WebSchemas/SchemaDotOrgSources#Tourism> ;
+    :source <http://www.w3.org/wiki/WebSchemas/SchemaDotOrgSources#Tourism>,
+        <https://github.com/schemaorg/schemaorg/issues/1810> ;
     rdfs:comment "Destination(s) ( [[Place]] ) that make up a trip. For a trip where destination order is important use [[ItemList]] to specify that order (see examples)." .
 
 :touristType a rdf:Property ;
     rdfs:label "touristType" ;
-    :category "issue-1810" ;
     :domainIncludes :TouristDestination,
         :TouristTrip .
 
 :partOfTrip a rdf:Property ;
     rdfs:label "partOfTrip" ;
-    :category "issue-1810" ;
     :domainIncludes :Trip ;
     :inverseOf :subTrip ;
     :isPartOf <http://pending.schema.org> ;
     :rangeIncludes :Trip ;
-    :source <http://www.w3.org/wiki/WebSchemas/SchemaDotOrgSources#Tourism> ;
+    :source <http://www.w3.org/wiki/WebSchemas/SchemaDotOrgSources#Tourism>,
+        <https://github.com/schemaorg/schemaorg/issues/1810> ;
     rdfs:comment "Identifies that this [[Trip]] is a subTrip of another Trip.  For example Day 1, Day 2, etc. of a multi-day trip." .
 
 :subTrip a rdf:Property ;
     rdfs:label "subTrip" ;
-    :category "issue-1810" ;
     :domainIncludes :Trip ;
     :inverseOf :partOfTrip ;
     :isPartOf <http://pending.schema.org> ;
     :rangeIncludes :Trip ;
-    :source <http://www.w3.org/wiki/WebSchemas/SchemaDotOrgSources#Tourism> ;
+    :source <http://www.w3.org/wiki/WebSchemas/SchemaDotOrgSources#Tourism>,
+        <https://github.com/schemaorg/schemaorg/issues/1810> ;
     rdfs:comment "Identifies a [[Trip]] that is a subTrip of this Trip.  For example Day 1, Day 2, etc. of a multi-day trip." .
 

--- a/data/ext/pending/issue-1816.ttl
+++ b/data/ext/pending/issue-1816.ttl
@@ -1,9 +1,11 @@
 @prefix : <http://schema.org/> .
+@prefix rdf: <http://www.w3.org/1999/02/22-rdf-syntax-ns#> .
 @prefix rdfs: <http://www.w3.org/2000/01/rdf-schema#> .
+@prefix xml: <http://www.w3.org/XML/1998/namespace> .
+@prefix xsd: <http://www.w3.org/2001/XMLSchema#> .
 
 :Play a rdfs:Class ;
     rdfs:label "Play" ;
-    :category "issue-1816" ;
     :isPartOf <http://pending.schema.org> ;
     :source <https://github.com/schemaorg/schemaorg/issues/1816> ;
     rdfs:comment "A play is a form of literature, usually consisting of dialogue between characters, intended for theatrical performance rather than just reading. Note the peformance of a Play would be a [[TheaterEvent]] - the *Play* being the [[workPerformed]]." ;

--- a/data/ext/pending/issue-1828.ttl
+++ b/data/ext/pending/issue-1828.ttl
@@ -1,10 +1,11 @@
 @prefix : <http://schema.org/> .
 @prefix rdf: <http://www.w3.org/1999/02/22-rdf-syntax-ns#> .
 @prefix rdfs: <http://www.w3.org/2000/01/rdf-schema#> .
+@prefix xml: <http://www.w3.org/XML/1998/namespace> .
+@prefix xsd: <http://www.w3.org/2001/XMLSchema#> .
 
 :Claim a rdfs:Class ;
     rdfs:label "Claim" ;
-    :category "issue-1828" ;
     :isPartOf <http://pending.schema.org> ;
     :source <https://github.com/schemaorg/schemaorg/issues/1828> ;
     rdfs:comment """A [[Claim]] in Schema.org represents a specific, factually-oriented claim that could be the [[itemReviewed]] in a [[ClaimReview]]. The content of a claim can be summarized with the [[text]] property. Variations on well known claims can have their common identity indicated via [[sameAs]] links, and summarized with a [[name]]. Ideally, a [[Claim]] description includes enough contextual information to minimize the risk of ambiguity or inclarity. In practice, many claims are better understood in the context in which they appear or the interpretations provided by claim reviews.
@@ -17,7 +18,6 @@
 
 :appearance a rdf:Property ;
     rdfs:label "appearance" ;
-    :category "issue-1828" ;
     :domainIncludes :Claim ;
     :isPartOf <http://pending.schema.org> ;
     :rangeIncludes :CreativeWork ;
@@ -27,7 +27,6 @@
 
 :firstAppearance a rdf:Property ;
     rdfs:label "firstAppearance" ;
-    :category "issue-1828" ;
     :domainIncludes :Claim ;
     :isPartOf <http://pending.schema.org> ;
     :rangeIncludes :CreativeWork ;

--- a/data/ext/pending/issue-1842.ttl
+++ b/data/ext/pending/issue-1842.ttl
@@ -1,10 +1,11 @@
 @prefix : <http://schema.org/> .
 @prefix rdf: <http://www.w3.org/1999/02/22-rdf-syntax-ns#> .
 @prefix rdfs: <http://www.w3.org/2000/01/rdf-schema#> .
+@prefix xml: <http://www.w3.org/XML/1998/namespace> .
+@prefix xsd: <http://www.w3.org/2001/XMLSchema#> .
 
 :EventAttendanceModeEnumeration a rdfs:Class ;
     rdfs:label "EventAttendanceModeEnumeration" ;
-    :category "issue-1842" ;
     :isPartOf <http://pending.schema.org> ;
     :source <https://github.com/schemaorg/schemaorg/issues/1842> ;
     rdfs:comment "An EventAttendanceModeEnumeration value is one of potentially several modes of organising an event, relating to whether it is online or offline." ;
@@ -12,7 +13,6 @@
 
 :VirtualLocation a rdfs:Class ;
     rdfs:label "VirtualLocation" ;
-    :category "issue-1842" ;
     :isPartOf <http://pending.schema.org> ;
     :source <https://github.com/schemaorg/schemaorg/issues/1842> ;
     rdfs:comment "An online or virtual location for attending events. For example, one may attend an online seminar or educational event. While a virtual location may be used as the location of an event, virtual locations should not be confused with physical locations in the real world." ;
@@ -20,28 +20,24 @@
 
 :MixedEventAttendanceMode a :EventAttendanceModeEnumeration ;
     rdfs:label "MixedEventAttendanceMode" ;
-    :category "issue-1842" ;
     :isPartOf <http://pending.schema.org> ;
     :source <https://github.com/schemaorg/schemaorg/issues/1842> ;
     rdfs:comment "MixedEventAttendanceMode - an event that is conducted as a combination of both offline and online modes." .
 
 :OfflineEventAttendanceMode a :EventAttendanceModeEnumeration ;
     rdfs:label "OfflineEventAttendanceMode" ;
-    :category "issue-1842" ;
     :isPartOf <http://pending.schema.org> ;
     :source <https://github.com/schemaorg/schemaorg/issues/1842> ;
     rdfs:comment "OfflineEventAttendanceMode - an event that is primarily conducted offline. " .
 
 :OnlineEventAttendanceMode a :EventAttendanceModeEnumeration ;
     rdfs:label "OnlineEventAttendanceMode" ;
-    :category "issue-1842" ;
     :isPartOf <http://pending.schema.org> ;
     :source <https://github.com/schemaorg/schemaorg/issues/1842> ;
     rdfs:comment "OnlineEventAttendanceMode - an event that is primarily conducted online. " .
 
 :eventAttendanceMode a rdf:Property ;
     rdfs:label "eventAttendanceMode" ;
-    :category "issue-1842" ;
     :domainIncludes :Event ;
     :isPartOf <http://pending.schema.org> ;
     :rangeIncludes :EventAttendanceModeEnumeration ;
@@ -53,7 +49,6 @@
 
 :maximumPhysicalAttendeeCapacity a rdf:Property ;
     rdfs:label "maximumPhysicalAttendeeCapacity" ;
-    :category "issue-1842" ;
     :domainIncludes :Event ;
     :isPartOf <http://pending.schema.org> ;
     :rangeIncludes :Integer ;
@@ -62,7 +57,6 @@
 
 :maximumVirtualAttendeeCapacity a rdf:Property ;
     rdfs:label "maximumVirtualAttendeeCapacity" ;
-    :category "issue-1842" ;
     :domainIncludes :Event ;
     :isPartOf <http://pending.schema.org> ;
     :rangeIncludes :Integer ;

--- a/data/ext/pending/issue-1886.ttl
+++ b/data/ext/pending/issue-1886.ttl
@@ -1,10 +1,11 @@
 @prefix : <http://schema.org/> .
 @prefix rdf: <http://www.w3.org/1999/02/22-rdf-syntax-ns#> .
 @prefix rdfs: <http://www.w3.org/2000/01/rdf-schema#> .
+@prefix xml: <http://www.w3.org/XML/1998/namespace> .
+@prefix xsd: <http://www.w3.org/2001/XMLSchema#> .
 
 :sdDatePublished a rdf:Property ;
     rdfs:label "sdDatePublished" ;
-    :category "issue-1886" ;
     :domainIncludes :CreativeWork ;
     :isPartOf <http://pending.schema.org> ;
     :rangeIncludes :Date ;
@@ -13,7 +14,6 @@
 
 :sdLicense a rdf:Property ;
     rdfs:label "sdLicense" ;
-    :category "issue-1886" ;
     :domainIncludes :CreativeWork ;
     :isPartOf <http://pending.schema.org> ;
     :rangeIncludes :CreativeWork,
@@ -23,7 +23,6 @@
 
 :sdPublisher a rdf:Property ;
     rdfs:label "sdPublisher" ;
-    :category "issue-1886" ;
     :domainIncludes :CreativeWork ;
     :isPartOf <http://pending.schema.org> ;
     :rangeIncludes :Organization,

--- a/data/ext/pending/issue-1909.ttl
+++ b/data/ext/pending/issue-1909.ttl
@@ -1,10 +1,11 @@
 @prefix : <http://schema.org/> .
 @prefix rdf: <http://www.w3.org/1999/02/22-rdf-syntax-ns#> .
 @prefix rdfs: <http://www.w3.org/2000/01/rdf-schema#> .
+@prefix xml: <http://www.w3.org/XML/1998/namespace> .
+@prefix xsd: <http://www.w3.org/2001/XMLSchema#> .
 
 :courseWorkload a rdf:Property ;
     rdfs:label "courseWorkload" ;
-    :category "issue-1909" ;
     :domainIncludes :CourseInstance ;
     :isPartOf <http://pending.schema.org> ;
     :rangeIncludes :Text ;

--- a/data/ext/pending/issue-1950.ttl
+++ b/data/ext/pending/issue-1950.ttl
@@ -1,10 +1,11 @@
 @prefix : <http://schema.org/> .
 @prefix rdf: <http://www.w3.org/1999/02/22-rdf-syntax-ns#> .
 @prefix rdfs: <http://www.w3.org/2000/01/rdf-schema#> .
+@prefix xml: <http://www.w3.org/XML/1998/namespace> .
+@prefix xsd: <http://www.w3.org/2001/XMLSchema#> .
 
 :CorrectionComment a rdfs:Class ;
     rdfs:label "CorrectionComment" ;
-    :category "issue-1950" ;
     :isPartOf <http://pending.schema.org> ;
     :source <https://github.com/schemaorg/schemaorg/issues/1950> ;
     rdfs:comment "A [[comment]] that corrects [[CreativeWork]]." ;
@@ -12,8 +13,6 @@
 
 :correction a rdf:Property ;
     rdfs:label "correction" ;
-    :category "issue-1688",
-        "issue-1950" ;
     :domainIncludes :CreativeWork ;
     :isPartOf <http://pending.schema.org> ;
     :rangeIncludes :CorrectionComment,

--- a/data/ext/pending/issue-1951.ttl
+++ b/data/ext/pending/issue-1951.ttl
@@ -1,10 +1,11 @@
 @prefix : <http://schema.org/> .
 @prefix rdf: <http://www.w3.org/1999/02/22-rdf-syntax-ns#> .
 @prefix rdfs: <http://www.w3.org/2000/01/rdf-schema#> .
+@prefix xml: <http://www.w3.org/XML/1998/namespace> .
+@prefix xsd: <http://www.w3.org/2001/XMLSchema#> .
 
 :sport a rdf:Property ;
     rdfs:label "sport" ;
-    :category "issue-1951" ;
     :domainIncludes :SportsEvent ;
     :isPartOf <http://pending.schema.org> ;
     :source <https://github.com/schemaorg/schemaorg/issues/1951> .

--- a/data/ext/pending/issue-1976.ttl
+++ b/data/ext/pending/issue-1976.ttl
@@ -1,9 +1,11 @@
 @prefix : <http://schema.org/> .
+@prefix rdf: <http://www.w3.org/1999/02/22-rdf-syntax-ns#> .
 @prefix rdfs: <http://www.w3.org/2000/01/rdf-schema#> .
+@prefix xml: <http://www.w3.org/XML/1998/namespace> .
+@prefix xsd: <http://www.w3.org/2001/XMLSchema#> .
 
 :ShortStory a rdfs:Class ;
     rdfs:label "ShortStory" ;
-    :category "issue-1976" ;
     :isPartOf <http://pending.schema.org> ;
     :source <https://github.com/schemaorg/schemaorg/issues/1976> ;
     rdfs:comment "Short story or tale. A brief work of literature, usually written in narrative prose." ;

--- a/data/ext/pending/issue-2021.ttl
+++ b/data/ext/pending/issue-2021.ttl
@@ -1,10 +1,11 @@
 @prefix : <http://schema.org/> .
 @prefix rdf: <http://www.w3.org/1999/02/22-rdf-syntax-ns#> .
 @prefix rdfs: <http://www.w3.org/2000/01/rdf-schema#> .
+@prefix xml: <http://www.w3.org/XML/1998/namespace> .
+@prefix xsd: <http://www.w3.org/2001/XMLSchema#> .
 
 :endOffset a rdf:Property ;
     rdfs:label "endOffset" ;
-    :category "issue-2021" ;
     :domainIncludes :Clip ;
     :isPartOf <http://pending.schema.org> ;
     :rangeIncludes :Number ;
@@ -13,7 +14,6 @@
 
 :startOffset a rdf:Property ;
     rdfs:label "startOffset" ;
-    :category "issue-2021" ;
     :domainIncludes :Clip ;
     :isPartOf <http://pending.schema.org> ;
     :rangeIncludes :Number ;

--- a/data/ext/pending/issue-2083.ttl
+++ b/data/ext/pending/issue-2083.ttl
@@ -1,10 +1,11 @@
 @prefix : <http://schema.org/> .
 @prefix rdf: <http://www.w3.org/1999/02/22-rdf-syntax-ns#> .
 @prefix rdfs: <http://www.w3.org/2000/01/rdf-schema#> .
+@prefix xml: <http://www.w3.org/XML/1998/namespace> .
+@prefix xsd: <http://www.w3.org/2001/XMLSchema#> .
 
 :applicantLocationRequirements a rdf:Property ;
     rdfs:label "applicantLocationRequirements" ;
-    :category "issue-2083" ;
     :domainIncludes :JobPosting ;
     :isPartOf <http://pending.schema.org> ;
     :rangeIncludes :AdministrativeArea ;

--- a/data/ext/pending/issue-2085.ttl
+++ b/data/ext/pending/issue-2085.ttl
@@ -1,10 +1,11 @@
 @prefix : <http://schema.org/> .
 @prefix rdf: <http://www.w3.org/1999/02/22-rdf-syntax-ns#> .
 @prefix rdfs: <http://www.w3.org/2000/01/rdf-schema#> .
+@prefix xml: <http://www.w3.org/XML/1998/namespace> .
+@prefix xsd: <http://www.w3.org/2001/XMLSchema#> .
 
 :membershipPointsEarned a rdf:Property ;
     rdfs:label "membershipPointsEarned" ;
-    :category "issue-2085" ;
     :domainIncludes :ProgramMembership ;
     :isPartOf <http://pending.schema.org> ;
     :rangeIncludes :Number,

--- a/data/ext/pending/issue-2108.ttl
+++ b/data/ext/pending/issue-2108.ttl
@@ -1,10 +1,11 @@
 @prefix : <http://schema.org/> .
 @prefix rdf: <http://www.w3.org/1999/02/22-rdf-syntax-ns#> .
 @prefix rdfs: <http://www.w3.org/2000/01/rdf-schema#> .
+@prefix xml: <http://www.w3.org/XML/1998/namespace> .
+@prefix xsd: <http://www.w3.org/2001/XMLSchema#> .
 
 :PronounceableText a rdfs:Class ;
     rdfs:label "PronounceableText" ;
-    :category "issue-2108" ;
     :isPartOf <http://pending.schema.org> ;
     :source <https://github.com/schemaorg/schemaorg/issues/2108> ;
     rdfs:comment "Data type: PronounceableText." ;
@@ -16,7 +17,6 @@
 
 :phoneticText a rdf:Property ;
     rdfs:label "phoneticText" ;
-    :category "issue-2108" ;
     :domainIncludes :PronounceableText ;
     :isPartOf <http://pending.schema.org> ;
     :rangeIncludes :Text ;
@@ -25,7 +25,6 @@
 
 :speechToTextMarkup a rdf:Property ;
     rdfs:label "speechToTextMarkup" ;
-    :category "issue-2108" ;
     :domainIncludes :PronounceableText ;
     :isPartOf <http://pending.schema.org> ;
     :rangeIncludes :Text ;
@@ -34,7 +33,6 @@
 
 :textValue a rdf:Property ;
     rdfs:label "textValue" ;
-    :category "issue-2108" ;
     :domainIncludes :PronounceableText ;
     :isPartOf <http://pending.schema.org> ;
     :rangeIncludes :Text ;

--- a/data/ext/pending/issue-2109.ttl
+++ b/data/ext/pending/issue-2109.ttl
@@ -1,10 +1,11 @@
 @prefix : <http://schema.org/> .
 @prefix rdf: <http://www.w3.org/1999/02/22-rdf-syntax-ns#> .
 @prefix rdfs: <http://www.w3.org/2000/01/rdf-schema#> .
+@prefix xml: <http://www.w3.org/XML/1998/namespace> .
+@prefix xsd: <http://www.w3.org/2001/XMLSchema#> .
 
 :RadioBroadcastService a rdfs:Class ;
     rdfs:label "RadioBroadcastService" ;
-    :category "issue-2109" ;
     :isPartOf <http://pending.schema.org> ;
     :source <https://github.com/schemaorg/schemaorg/issues/2109> ;
     rdfs:comment "A delivery service through which radio content is provided via broadcast over the air or online." ;
@@ -12,7 +13,6 @@
 
 :callSign a rdf:Property ;
     rdfs:label "callSign" ;
-    :category "issue-2109" ;
     :domainIncludes :BroadcastService,
         :Person,
         :Vehicle ;

--- a/data/ext/pending/issue-2110.ttl
+++ b/data/ext/pending/issue-2110.ttl
@@ -1,10 +1,11 @@
 @prefix : <http://schema.org/> .
 @prefix rdf: <http://www.w3.org/1999/02/22-rdf-syntax-ns#> .
 @prefix rdfs: <http://www.w3.org/2000/01/rdf-schema#> .
+@prefix xml: <http://www.w3.org/XML/1998/namespace> .
+@prefix xsd: <http://www.w3.org/2001/XMLSchema#> .
 
 :subtitleLanguage a rdf:Property ;
     rdfs:label "subtitleLanguage" ;
-    :category "issue-2110" ;
     :domainIncludes :BroadcastEvent ;
     :isPartOf <http://pending.schema.org> ;
     :rangeIncludes :Language,

--- a/data/ext/pending/issue-2111.ttl
+++ b/data/ext/pending/issue-2111.ttl
@@ -1,10 +1,11 @@
 @prefix : <http://schema.org/> .
 @prefix rdf: <http://www.w3.org/1999/02/22-rdf-syntax-ns#> .
 @prefix rdfs: <http://www.w3.org/2000/01/rdf-schema#> .
+@prefix xml: <http://www.w3.org/XML/1998/namespace> .
+@prefix xsd: <http://www.w3.org/2001/XMLSchema#> .
 
 :broadcastSignalModulation a rdf:Property ;
     rdfs:label "broadcastSignalModulation" ;
-    :category "issue-2111" ;
     :domainIncludes :BroadcastFrequencySpecification ;
     :isPartOf <http://pending.schema.org> ;
     :rangeIncludes :QualitativeValue,
@@ -14,7 +15,6 @@
 
 :broadcastSubChannel a rdf:Property ;
     rdfs:label "broadcastSubChannel" ;
-    :category "issue-2111" ;
     :domainIncludes :BroadcastFrequencySpecification ;
     :isPartOf <http://pending.schema.org> ;
     :rangeIncludes :Text ;

--- a/data/ext/pending/issue-2126.ttl
+++ b/data/ext/pending/issue-2126.ttl
@@ -1,10 +1,11 @@
 @prefix : <http://schema.org/> .
 @prefix rdf: <http://www.w3.org/1999/02/22-rdf-syntax-ns#> .
 @prefix rdfs: <http://www.w3.org/2000/01/rdf-schema#> .
+@prefix xml: <http://www.w3.org/XML/1998/namespace> .
+@prefix xsd: <http://www.w3.org/2001/XMLSchema#> .
 
 :nsn a rdf:Property ;
     rdfs:label "nsn" ;
-    :category "issue-2126" ;
     :domainIncludes :Product ;
     :isPartOf <http://pending.schema.org> ;
     :rangeIncludes :Text ;

--- a/data/ext/pending/issue-2140.ttl
+++ b/data/ext/pending/issue-2140.ttl
@@ -1,9 +1,11 @@
 @prefix : <http://schema.org/> .
+@prefix rdf: <http://www.w3.org/1999/02/22-rdf-syntax-ns#> .
 @prefix rdfs: <http://www.w3.org/2000/01/rdf-schema#> .
+@prefix xml: <http://www.w3.org/XML/1998/namespace> .
+@prefix xsd: <http://www.w3.org/2001/XMLSchema#> .
 
-:3DModel a rdfs:Class ;
+<http://schema.org/3DModel> a rdfs:Class ;
     rdfs:label "3DModel" ;
-    :category "issue-2140" ;
     :isPartOf <http://pending.schema.org> ;
     :source <https://github.com/schemaorg/schemaorg/issues/2140> ;
     rdfs:comment """A 3D model represents some kind of 3D content, which may have [[encoding]]s in one or more [[MediaObject]]s. Many 3D formats are available (e.g. see [Wikipedia](https://en.wikipedia.org/wiki/Category:3D_graphics_file_formats)); specific encoding formats can be represented using the [[encodingFormat]] property applied to the relevant [[MediaObject]]. For the

--- a/data/ext/pending/issue-2173.ttl
+++ b/data/ext/pending/issue-2173.ttl
@@ -1,10 +1,11 @@
 @prefix : <http://schema.org/> .
 @prefix rdf: <http://www.w3.org/1999/02/22-rdf-syntax-ns#> .
 @prefix rdfs: <http://www.w3.org/2000/01/rdf-schema#> .
+@prefix xml: <http://www.w3.org/XML/1998/namespace> .
+@prefix xsd: <http://www.w3.org/2001/XMLSchema#> .
 
 :conditionsOfAccess a rdf:Property ;
     rdfs:label "conditionsOfAccess" ;
-    :category "issue-2173" ;
     :domainIncludes :CreativeWork ;
     :isPartOf <http://pending.schema.org> ;
     :rangeIncludes :Text ;

--- a/data/ext/pending/issue-2192.ttl
+++ b/data/ext/pending/issue-2192.ttl
@@ -1,14 +1,15 @@
 @prefix : <http://schema.org/> .
 @prefix rdf: <http://www.w3.org/1999/02/22-rdf-syntax-ns#> .
+@prefix rdfs: <http://www.w3.org/2000/01/rdf-schema#> .
+@prefix xml: <http://www.w3.org/XML/1998/namespace> .
+@prefix xsd: <http://www.w3.org/2001/XMLSchema#> .
 
 :jobTitle a rdf:Property ;
-    :category "issue-2192" ;
     :isPartOf <http://pending.schema.org> ;
     :rangeIncludes :DefinedTerm ;
     :source <https://github.com/schemaorg/schemaorg/issues/2192> .
 
 :occupationalCategory a rdf:Property ;
-    :category "issue-2192" ;
     :rangeIncludes :CategoryCode,
         :Text ;
     :source <https://github.com/schemaorg/schemaorg/issues/2192> .

--- a/data/ext/pending/issue-2242.ttl
+++ b/data/ext/pending/issue-2242.ttl
@@ -1,10 +1,11 @@
 @prefix : <http://schema.org/> .
 @prefix rdf: <http://www.w3.org/1999/02/22-rdf-syntax-ns#> .
 @prefix rdfs: <http://www.w3.org/2000/01/rdf-schema#> .
+@prefix xml: <http://www.w3.org/XML/1998/namespace> .
+@prefix xsd: <http://www.w3.org/2001/XMLSchema#> .
 
 :ineligibleRegion a rdf:Property ;
     rdfs:label "ineligibleRegion" ;
-    :category "issue-2242" ;
     :domainIncludes :ActionAccessSpecification,
         :DeliveryChargeSpecification,
         :Demand,

--- a/data/ext/pending/issue-2244.ttl
+++ b/data/ext/pending/issue-2244.ttl
@@ -1,10 +1,11 @@
 @prefix : <http://schema.org/> .
 @prefix rdf: <http://www.w3.org/1999/02/22-rdf-syntax-ns#> .
 @prefix rdfs: <http://www.w3.org/2000/01/rdf-schema#> .
+@prefix xml: <http://www.w3.org/XML/1998/namespace> .
+@prefix xsd: <http://www.w3.org/2001/XMLSchema#> .
 
 :jobImmediateStart a rdf:Property ;
     rdfs:label "jobImmediateStart" ;
-    :category "issue-2244" ;
     :domainIncludes :JobPosting ;
     :isPartOf <http://pending.schema.org> ;
     :rangeIncludes :Boolean ;
@@ -13,7 +14,6 @@
 
 :jobStartDate a rdf:Property ;
     rdfs:label "jobStartDate" ;
-    :category "issue-2244" ;
     :domainIncludes :JobPosting ;
     :isPartOf <http://pending.schema.org> ;
     :rangeIncludes :Date,

--- a/data/ext/pending/issue-2288.ttl
+++ b/data/ext/pending/issue-2288.ttl
@@ -1,10 +1,11 @@
 @prefix : <http://schema.org/> .
 @prefix rdf: <http://www.w3.org/1999/02/22-rdf-syntax-ns#> .
 @prefix rdfs: <http://www.w3.org/2000/01/rdf-schema#> .
+@prefix xml: <http://www.w3.org/XML/1998/namespace> .
+@prefix xsd: <http://www.w3.org/2001/XMLSchema#> .
 
 :ProductReturnEnumeration a rdfs:Class ;
     rdfs:label "ProductReturnEnumeration" ;
-    :category "issue-2288" ;
     :isPartOf <http://attic.schema.org> ;
     :source <https://github.com/schemaorg/schemaorg/issues/2288> ;
     :supersededBy :MerchantReturnEnumeration ;
@@ -13,7 +14,6 @@
 
 :ProductReturnPolicy a rdfs:Class ;
     rdfs:label "ProductReturnPolicy" ;
-    :category "issue-2288" ;
     :isPartOf <http://attic.schema.org> ;
     :source <https://github.com/schemaorg/schemaorg/issues/2288> ;
     :supersededBy :MerchantReturnPolicy ;
@@ -22,7 +22,6 @@
 
 :ProductReturnFiniteReturnWindow a :ProductReturnEnumeration ;
     rdfs:label "ProductReturnFiniteReturnWindow" ;
-    :category "issue-2288" ;
     :isPartOf <http://attic.schema.org> ;
     :source <https://github.com/schemaorg/schemaorg/issues/2288> ;
     :supersededBy :MerchantReturnFiniteReturnWindow ;
@@ -30,7 +29,6 @@
 
 :ProductReturnNotPermitted a :ProductReturnEnumeration ;
     rdfs:label "ProductReturnNotPermitted" ;
-    :category "issue-2288" ;
     :isPartOf <http://attic.schema.org> ;
     :source <https://github.com/schemaorg/schemaorg/issues/2288> ;
     :supersededBy :MerchantReturnNotPermitted ;
@@ -38,7 +36,6 @@
 
 :ProductReturnUnlimitedWindow a :ProductReturnEnumeration ;
     rdfs:label "ProductReturnUnlimitedWindow" ;
-    :category "issue-2288" ;
     :isPartOf <http://attic.schema.org> ;
     :source <https://github.com/schemaorg/schemaorg/issues/2288> ;
     :supersededBy :MerchantReturnUnlimitedWindow ;
@@ -46,7 +43,6 @@
 
 :ProductReturnUnspecified a :ProductReturnEnumeration ;
     rdfs:label "ProductReturnUnspecified" ;
-    :category "issue-2288" ;
     :isPartOf <http://attic.schema.org> ;
     :source <https://github.com/schemaorg/schemaorg/issues/2288> ;
     :supersededBy :MerchantReturnUnspecified ;
@@ -54,7 +50,6 @@
 
 :hasProductReturnPolicy a rdf:Property ;
     rdfs:label "hasProductReturnPolicy" ;
-    :category "issue-2288" ;
     :domainIncludes :Organization,
         :Product ;
     :isPartOf <http://attic.schema.org> ;
@@ -65,7 +60,6 @@
 
 :productReturnDays a rdf:Property ;
     rdfs:label "productReturnDays" ;
-    :category "issue-2288" ;
     :domainIncludes :ProductReturnPolicy ;
     :isPartOf <http://attic.schema.org> ;
     :rangeIncludes :Integer ;
@@ -75,7 +69,6 @@
 
 :productReturnLink a rdf:Property ;
     rdfs:label "productReturnLink" ;
-    :category "issue-2288" ;
     :domainIncludes :ProductReturnPolicy ;
     :isPartOf <http://attic.schema.org> ;
     :rangeIncludes :URL ;

--- a/data/ext/pending/issue-2289.ttl
+++ b/data/ext/pending/issue-2289.ttl
@@ -1,10 +1,11 @@
 @prefix : <http://schema.org/> .
 @prefix rdf: <http://www.w3.org/1999/02/22-rdf-syntax-ns#> .
 @prefix rdfs: <http://www.w3.org/2000/01/rdf-schema#> .
+@prefix xml: <http://www.w3.org/XML/1998/namespace> .
+@prefix xsd: <http://www.w3.org/2001/XMLSchema#> .
 
 :EducationalOccupationalProgram a rdfs:Class ;
     rdfs:label "EducationalOccupationalProgram" ;
-    :category "issue-2289" ;
     :isPartOf <http://pending.schema.org> ;
     :source <https://github.com/schemaorg/schemaorg/issues/2289> ;
     rdfs:comment "A program offered by an institution which determines the learning progress to achieve an outcome, usually a credential like a degree or certificate. This would define a discrete set of opportunities (e.g., job, courses) that together constitute a program with a clear start, end, set of requirements, and transition to a new occupational opportunity (e.g., a job), or sometimes a higher educational opportunity (e.g., an advanced degree)." ;
@@ -12,7 +13,6 @@
 
 :WorkBasedProgram a rdfs:Class ;
     rdfs:label "WorkBasedProgram" ;
-    :category "issue-2289" ;
     :isPartOf <http://pending.schema.org> ;
     :source <https://github.com/schemaorg/schemaorg/issues/2289> ;
     rdfs:comment "A program with both an educational and employment component. Typically based at a workplace and structured around work-based learning, with the aim of instilling competencies related to an occupation. WorkBasedProgram is used to distinguish programs such as apprenticeships from school, college or other classroom based educational programs." ;
@@ -20,7 +20,6 @@
 
 :educationalCredentialAwarded a rdf:Property ;
     rdfs:label "educationalCredentialAwarded" ;
-    :category "issue-2289" ;
     :domainIncludes :Course,
         :EducationalOccupationalProgram ;
     :rangeIncludes :EducationalOccupationalCredential,
@@ -31,7 +30,6 @@
 
 :hasCredential a rdf:Property ;
     rdfs:label "hasCredential" ;
-    :category "issue-2289" ;
     :domainIncludes :Organization,
         :Person ;
     :isPartOf <http://pending.schema.org> ;
@@ -41,7 +39,6 @@
 
 :occupationalCategory a rdf:Property ;
     rdfs:label "occupationalCategory" ;
-    :category "issue-2289" ;
     :domainIncludes :WorkBasedProgram ;
     :rangeIncludes :CategoryCode,
         :Text ;
@@ -49,7 +46,6 @@
 
 :occupationalCredentialAwarded a rdf:Property ;
     rdfs:label "occupationalCredentialAwarded" ;
-    :category "issue-2289" ;
     :domainIncludes :Course,
         :EducationalOccupationalProgram ;
     :isPartOf <http://pending.schema.org> ;
@@ -61,14 +57,12 @@
 
 :offers a rdf:Property ;
     rdfs:label "offers" ;
-    :category "issue-2289" ;
     :domainIncludes :EducationalOccupationalProgram ;
     :rangeIncludes :Offer ;
     :source <https://github.com/schemaorg/schemaorg/issues/2289> .
 
 :programPrerequisites a rdf:Property ;
     rdfs:label "programPrerequisites" ;
-    :category "issue-2289" ;
     :domainIncludes :EducationalOccupationalProgram ;
     :isPartOf <http://pending.schema.org> ;
     :rangeIncludes :AlignmentObject,
@@ -80,7 +74,6 @@
 
 :provider a rdf:Property ;
     rdfs:label "provider" ;
-    :category "issue-2289" ;
     :domainIncludes :EducationalOccupationalProgram ;
     :rangeIncludes :Organization,
         :Person ;
@@ -88,7 +81,6 @@
 
 :salaryUponCompletion a rdf:Property ;
     rdfs:label "salaryUponCompletion" ;
-    :category "issue-2289" ;
     :domainIncludes :EducationalOccupationalProgram ;
     :isPartOf <http://pending.schema.org> ;
     :rangeIncludes :MonetaryAmountDistribution ;
@@ -97,7 +89,6 @@
 
 :timeToComplete a rdf:Property ;
     rdfs:label "timeToComplete" ;
-    :category "issue-2289" ;
     :domainIncludes :EducationalOccupationalProgram ;
     :isPartOf <http://pending.schema.org> ;
     :rangeIncludes :Duration ;
@@ -106,7 +97,6 @@
 
 :trainingSalary a rdf:Property ;
     rdfs:label "trainingSalary" ;
-    :category "issue-2289" ;
     :domainIncludes :WorkBasedProgram ;
     :isPartOf <http://pending.schema.org> ;
     :rangeIncludes :MonetaryAmountDistribution ;

--- a/data/ext/pending/issue-2291.ttl
+++ b/data/ext/pending/issue-2291.ttl
@@ -1,10 +1,11 @@
 @prefix : <http://schema.org/> .
 @prefix rdf: <http://www.w3.org/1999/02/22-rdf-syntax-ns#> .
 @prefix rdfs: <http://www.w3.org/2000/01/rdf-schema#> .
+@prefix xml: <http://www.w3.org/XML/1998/namespace> .
+@prefix xsd: <http://www.w3.org/2001/XMLSchema#> .
 
 :Observation a rdfs:Class ;
     rdfs:label "Observation" ;
-    :category "issue-2291" ;
     :isPartOf <http://pending.schema.org> ;
     :source <https://github.com/schemaorg/schemaorg/issues/2291> ;
     rdfs:comment """Instances of the class [[Observation]] are used to specify observations about an entity (which may or may not be an instance of a [[StatisticalPopulation]]), at a particular time. The principal properties of an [[Observation]] are [[observedNode]], [[measuredProperty]], [[measuredValue]] (or [[median]], etc.) and [[observationDate]] ([[measuredProperty]] properties can, but need not always, be W3C RDF Data Cube "measure properties", as in the [lifeExpectancy example](https://www.w3.org/TR/vocab-data-cube/#dsd-example)).
@@ -14,7 +15,6 @@ See also [[StatisticalPopulation]], and the [data and datasets](/docs/data-and-d
 
 :StatisticalPopulation a rdfs:Class ;
     rdfs:label "StatisticalPopulation" ;
-    :category "issue-2291" ;
     :isPartOf <http://pending.schema.org> ;
     :source <https://github.com/schemaorg/schemaorg/issues/2291> ;
     rdfs:comment """A StatisticalPopulation is a set of instances of a certain given type that satisfy some set of constraints. The property [[populationType]] is used to specify the type. Any property that can be used on instances of that type can appear on the statistical population. For example, a [[StatisticalPopulation]] representing all [[Person]]s with a [[homeLocation]] of East Podunk California, would be described by applying the appropriate [[homeLocation]] and [[populationType]] properties to a [[StatisticalPopulation]] item that stands for that set of people.
@@ -25,7 +25,6 @@ population, and does not imply that the population consists of people. For examp
 
 :constrainingProperty a rdf:Property ;
     rdfs:label "constrainingProperty" ;
-    :category "issue-2291" ;
     :domainIncludes :StatisticalPopulation ;
     :isPartOf <http://pending.schema.org> ;
     :rangeIncludes :Integer ;
@@ -35,7 +34,6 @@ population, and does not imply that the population consists of people. For examp
 
 :marginOfError a rdf:Property ;
     rdfs:label "marginOfError" ;
-    :category "issue-2291" ;
     :domainIncludes :Observation ;
     :isPartOf <http://pending.schema.org> ;
     :rangeIncludes :DateTime ;
@@ -44,7 +42,6 @@ population, and does not imply that the population consists of people. For examp
 
 :measuredProperty a rdf:Property ;
     rdfs:label "measuredProperty" ;
-    :category "issue-2291" ;
     :domainIncludes :Observation ;
     :isPartOf <http://pending.schema.org> ;
     :rangeIncludes :Property ;
@@ -53,7 +50,6 @@ population, and does not imply that the population consists of people. For examp
 
 :measuredValue a rdf:Property ;
     rdfs:label "measuredValue" ;
-    :category "issue-2291" ;
     :domainIncludes :Observation ;
     :isPartOf <http://pending.schema.org> ;
     :rangeIncludes :DataType ;
@@ -62,7 +58,6 @@ population, and does not imply that the population consists of people. For examp
 
 :numConstraints a rdf:Property ;
     rdfs:label "numConstraints" ;
-    :category "issue-2291" ;
     :domainIncludes :StatisticalPopulation ;
     :isPartOf <http://pending.schema.org> ;
     :rangeIncludes :Integer ;
@@ -71,7 +66,6 @@ population, and does not imply that the population consists of people. For examp
 
 :observationDate a rdf:Property ;
     rdfs:label "observationDate" ;
-    :category "issue-2291" ;
     :domainIncludes :Observation ;
     :isPartOf <http://pending.schema.org> ;
     :rangeIncludes :DateTime ;
@@ -80,7 +74,6 @@ population, and does not imply that the population consists of people. For examp
 
 :observedNode a rdf:Property ;
     rdfs:label "observedNode" ;
-    :category "issue-2291" ;
     :domainIncludes :Observation ;
     :isPartOf <http://pending.schema.org> ;
     :rangeIncludes :StatisticalPopulation ;
@@ -89,7 +82,6 @@ population, and does not imply that the population consists of people. For examp
 
 :populationType a rdf:Property ;
     rdfs:label "populationType" ;
-    :category "issue-2291" ;
     :domainIncludes :StatisticalPopulation ;
     :isPartOf <http://pending.schema.org> ;
     :rangeIncludes :Class ;

--- a/data/ext/pending/issue-2296.ttl
+++ b/data/ext/pending/issue-2296.ttl
@@ -1,10 +1,11 @@
 @prefix : <http://schema.org/> .
 @prefix rdf: <http://www.w3.org/1999/02/22-rdf-syntax-ns#> .
 @prefix rdfs: <http://www.w3.org/2000/01/rdf-schema#> .
+@prefix xml: <http://www.w3.org/XML/1998/namespace> .
+@prefix xsd: <http://www.w3.org/2001/XMLSchema#> .
 
 :employmentUnit a rdf:Property ;
     rdfs:label "employmentUnit" ;
-    :category "issue-2296" ;
     :domainIncludes :JobPosting ;
     :isPartOf <http://pending.schema.org> ;
     :rangeIncludes :Organization ;

--- a/data/ext/pending/issue-2300.ttl
+++ b/data/ext/pending/issue-2300.ttl
@@ -1,10 +1,11 @@
 @prefix : <http://schema.org/> .
 @prefix rdf: <http://www.w3.org/1999/02/22-rdf-syntax-ns#> .
 @prefix rdfs: <http://www.w3.org/2000/01/rdf-schema#> .
+@prefix xml: <http://www.w3.org/XML/1998/namespace> .
+@prefix xsd: <http://www.w3.org/2001/XMLSchema#> .
 
 :ratingExplanation a rdf:Property ;
     rdfs:label "ratingExplanation" ;
-    :category "issue-2300" ;
     :domainIncludes :Rating ;
     :isPartOf <http://pending.schema.org> ;
     :rangeIncludes :Text ;

--- a/data/ext/pending/issue-2311.ttl
+++ b/data/ext/pending/issue-2311.ttl
@@ -1,10 +1,11 @@
 @prefix : <http://schema.org/> .
 @prefix rdf: <http://www.w3.org/1999/02/22-rdf-syntax-ns#> .
 @prefix rdfs: <http://www.w3.org/2000/01/rdf-schema#> .
+@prefix xml: <http://www.w3.org/XML/1998/namespace> .
+@prefix xsd: <http://www.w3.org/2001/XMLSchema#> .
 
 :maintainer a rdf:Property ;
     rdfs:label "maintainer" ;
-    :category "issue-2311" ;
     :domainIncludes :CreativeWork ;
     :isPartOf <http://pending.schema.org> ;
     :rangeIncludes :Organization,

--- a/data/ext/pending/issue-2329.ttl
+++ b/data/ext/pending/issue-2329.ttl
@@ -1,10 +1,11 @@
 @prefix : <http://schema.org/> .
 @prefix rdf: <http://www.w3.org/1999/02/22-rdf-syntax-ns#> .
 @prefix rdfs: <http://www.w3.org/2000/01/rdf-schema#> .
+@prefix xml: <http://www.w3.org/XML/1998/namespace> .
+@prefix xsd: <http://www.w3.org/2001/XMLSchema#> .
 
 :totalJobOpenings a rdf:Property ;
     rdfs:label "totalJobOpenings" ;
-    :category "issue-2329" ;
     :domainIncludes :JobPosting ;
     :isPartOf <http://pending.schema.org> ;
     :rangeIncludes :Integer ;

--- a/data/ext/pending/issue-2341.ttl
+++ b/data/ext/pending/issue-2341.ttl
@@ -1,10 +1,11 @@
 @prefix : <http://schema.org/> .
 @prefix rdf: <http://www.w3.org/1999/02/22-rdf-syntax-ns#> .
 @prefix rdfs: <http://www.w3.org/2000/01/rdf-schema#> .
+@prefix xml: <http://www.w3.org/XML/1998/namespace> .
+@prefix xsd: <http://www.w3.org/2001/XMLSchema#> .
 
 :gender a rdf:Property ;
     rdfs:label "gender" ;
-    :category "issue-2341" ;
     :domainIncludes :SportsTeam ;
     :isPartOf <http://pending.schema.org> ;
     :source <https://github.com/schemaorg/schemaorg/issues/2341> .

--- a/data/ext/pending/issue-2348.ttl
+++ b/data/ext/pending/issue-2348.ttl
@@ -1,9 +1,11 @@
 @prefix : <http://schema.org/> .
+@prefix rdf: <http://www.w3.org/1999/02/22-rdf-syntax-ns#> .
 @prefix rdfs: <http://www.w3.org/2000/01/rdf-schema#> .
+@prefix xml: <http://www.w3.org/XML/1998/namespace> .
+@prefix xsd: <http://www.w3.org/2001/XMLSchema#> .
 
 :OfferForLease a rdfs:Class ;
     rdfs:label "OfferForLease" ;
-    :category "issue-2348" ;
     :isPartOf <http://pending.schema.org> ;
     :source <https://github.com/schemaorg/schemaorg/issues/2348> ;
     rdfs:comment """An [[OfferForLease]] in Schema.org represents an [[Offer]] to lease out something, i.e. an [[Offer]] whose
@@ -14,7 +16,6 @@
 
 :OfferForPurchase a rdfs:Class ;
     rdfs:label "OfferForPurchase" ;
-    :category "issue-2348" ;
     :isPartOf <http://pending.schema.org> ;
     :source <https://github.com/schemaorg/schemaorg/issues/2348> ;
     rdfs:comment """An [[OfferForPurchase]] in Schema.org represents an [[Offer]] to sell something, i.e. an [[Offer]] whose
@@ -25,7 +26,6 @@
 
 :RealEstateListing a rdfs:Class ;
     rdfs:label "RealEstateListing" ;
-    :category "issue-2348" ;
     :isPartOf <http://pending.schema.org> ;
     :source <https://github.com/schemaorg/schemaorg/issues/2348> ;
     rdfs:comment """A [[RealEstateListing]] is a listing that describes one or more real-estate [[Offer]]s (whose [[businessFunction]] is typically to lease out, or to sell).

--- a/data/ext/pending/issue-2358.ttl
+++ b/data/ext/pending/issue-2358.ttl
@@ -1,9 +1,11 @@
 @prefix : <http://schema.org/> .
+@prefix rdf: <http://www.w3.org/1999/02/22-rdf-syntax-ns#> .
 @prefix rdfs: <http://www.w3.org/2000/01/rdf-schema#> .
+@prefix xml: <http://www.w3.org/XML/1998/namespace> .
+@prefix xsd: <http://www.w3.org/2001/XMLSchema#> .
 
 :WebContent a rdfs:Class ;
     rdfs:label "WebContent" ;
-    :category "issue-2358" ;
     :isPartOf <http://pending.schema.org> ;
     :source <https://github.com/schemaorg/schemaorg/issues/2358> ;
     rdfs:comment """WebContent is a type representing all [[WebPage]], [[WebSite]] and [[WebPageElement]] content. It is sometimes the case that detailed distinctions between Web pages, sites and their parts is not always important or obvious. The  [[WebContent]] type makes it easier to describe Web-addressable content without requiring such distinctions to always be stated. (The intent is that the existing types [[WebPage]], [[WebSite]] and [[WebPageElement]] will eventually be declared as subtypes of [[WebContent]].)

--- a/data/ext/pending/issue-2373.ttl
+++ b/data/ext/pending/issue-2373.ttl
@@ -1,10 +1,11 @@
 @prefix : <http://schema.org/> .
 @prefix rdf: <http://www.w3.org/1999/02/22-rdf-syntax-ns#> .
 @prefix rdfs: <http://www.w3.org/2000/01/rdf-schema#> .
+@prefix xml: <http://www.w3.org/XML/1998/namespace> .
+@prefix xsd: <http://www.w3.org/2001/XMLSchema#> .
 
 :FloorPlan a rdfs:Class ;
     rdfs:label "FloorPlan" ;
-    :category "issue-2373" ;
     :isPartOf <http://pending.schema.org> ;
     :source <https://github.com/schemaorg/schemaorg/issues/2373> ;
     rdfs:comment "A FloorPlan is an explicit representation of a collection of similar accommodations, allowing the provision of common information (room counts, sizes, layout diagrams) and offers for rental or sale. In typical use, some [[ApartmentComplex]] has an [[accommodationFloorPlan]] which is a [[FloorPlan]].  A FloorPlan is always in the context of a particular place, either a larger [[ApartmentComplex]] or a single [[Apartment]]. The visual/spatial aspects of a floor plan (i.e. room layout, [see wikipedia](https://en.wikipedia.org/wiki/Floor_plan)) can be indicated using [[image]]. " ;
@@ -12,7 +13,6 @@
 
 :accommodationCategory a rdf:Property ;
     rdfs:label "accommodationCategory" ;
-    :category "issue-2373" ;
     :domainIncludes :Accommodation ;
     :isPartOf <http://pending.schema.org> ;
     :rangeIncludes :Text ;
@@ -22,7 +22,6 @@
 
 :accommodationFloorPlan a rdf:Property ;
     rdfs:label "accommodationFloorPlan" ;
-    :category "issue-2373" ;
     :domainIncludes :Accommodation,
         :Residence ;
     :isPartOf <http://pending.schema.org> ;
@@ -38,7 +37,6 @@
 
 :floorLevel a rdf:Property ;
     rdfs:label "floorLevel" ;
-    :category "issue-2373" ;
     :domainIncludes :Accommodation ;
     :isPartOf <http://pending.schema.org> ;
     :rangeIncludes :Text ;
@@ -51,16 +49,24 @@
 
 :isPlanForApartment a rdf:Property ;
     rdfs:label "isPlanForApartment" ;
-    :category "issue-2373" ;
     :domainIncludes :FloorPlan ;
     :isPartOf <http://pending.schema.org> ;
     :rangeIncludes :Accommodation ;
     :source <https://github.com/schemaorg/schemaorg/issues/2373> ;
     rdfs:comment "Indicates some accommodation that this floor plan describes." .
 
+:layoutImage a rdf:Property ;
+    rdfs:label "layoutImage" ;
+    :domainIncludes :FloorPlan ;
+    :isPartOf <http://pending.schema.org> ;
+    :rangeIncludes :ImageObject,
+        :URL ;
+    :source <https://github.com/schemaorg/schemaorg/issues/2690> ;
+    rdfs:comment "A schematic image showing the floorplan layout." ;
+    rdfs:subPropertyOf :image .
+
 :leaseLength a rdf:Property ;
     rdfs:label "leaseLength" ;
-    :category "issue-2373" ;
     :domainIncludes :Accommodation,
         :Offer,
         :RealEstateListing ;
@@ -72,7 +78,6 @@
 
 :numberOfAccommodationUnits a rdf:Property ;
     rdfs:label "numberOfAccommodationUnits" ;
-    :category "issue-2373" ;
     :domainIncludes :ApartmentComplex,
         :FloorPlan ;
     :isPartOf <http://pending.schema.org> ;
@@ -82,7 +87,6 @@
 
 :numberOfAvailableAccommodationUnits a rdf:Property ;
     rdfs:label "numberOfAvailableAccommodationUnits" ;
-    :category "issue-2373" ;
     :domainIncludes :ApartmentComplex,
         :FloorPlan ;
     :isPartOf <http://pending.schema.org> ;
@@ -92,7 +96,6 @@
 
 :numberOfBathroomsTotal a rdf:Property ;
     rdfs:label "numberOfBathroomsTotal" ;
-    :category "issue-2373" ;
     :domainIncludes :Accommodation,
         :FloorPlan ;
     :isPartOf <http://pending.schema.org> ;
@@ -102,7 +105,6 @@
 
 :numberOfBedrooms a rdf:Property ;
     rdfs:label "numberOfBedrooms" ;
-    :category "issue-2373" ;
     :domainIncludes :Accommodation,
         :ApartmentComplex,
         :FloorPlan ;
@@ -114,7 +116,6 @@
 
 :numberOfFullBathrooms a rdf:Property ;
     rdfs:label "numberOfFullBathrooms" ;
-    :category "issue-2373" ;
     :domainIncludes :Accommodation,
         :FloorPlan ;
     :isPartOf <http://pending.schema.org> ;
@@ -124,7 +125,6 @@
 
 :numberOfPartialBathrooms a rdf:Property ;
     rdfs:label "numberOfPartialBathrooms" ;
-    :category "issue-2373" ;
     :domainIncludes :Accommodation,
         :FloorPlan ;
     :isPartOf <http://pending.schema.org> ;
@@ -141,7 +141,6 @@
 
 :tourBookingPage a rdf:Property ;
     rdfs:label "tourBookingPage" ;
-    :category "issue-2373" ;
     :domainIncludes :Accommodation,
         :ApartmentComplex,
         :Place ;
@@ -152,23 +151,9 @@
 
 :yearBuilt a rdf:Property ;
     rdfs:label "yearBuilt" ;
-    :category "issue-2373" ;
     :domainIncludes :Accommodation ;
     :isPartOf <http://pending.schema.org> ;
     :rangeIncludes :Number ;
     :source <https://github.com/schemaorg/schemaorg/issues/2373> ;
     rdfs:comment "The year an [[Accommodation]] was constructed. This corresponds to the [YearBuilt field in RESO](https://ddwiki.reso.org/display/DDW17/YearBuilt+Field). " .
 
-
-
-    # included here but filed as a different issue as it was a followup:
-    #
-    :layoutImage a rdf:Property ;
-        rdfs:label "layoutImage" ;
-        :category "issue-2690" ;
-        :domainIncludes :FloorPlan ;
-        :isPartOf <http://pending.schema.org> ;
-        :rangeIncludes :ImageObject, :URL ;
-        :source <https://github.com/schemaorg/schemaorg/issues/2690> ;
-        rdfs:comment "A schematic image showing the floorplan layout." ;
-        rdfs:subPropertyOf :image .

--- a/data/ext/pending/issue-2374.ttl
+++ b/data/ext/pending/issue-2374.ttl
@@ -1,10 +1,11 @@
 @prefix : <http://schema.org/> .
 @prefix rdf: <http://www.w3.org/1999/02/22-rdf-syntax-ns#> .
 @prefix rdfs: <http://www.w3.org/2000/01/rdf-schema#> .
+@prefix xml: <http://www.w3.org/XML/1998/namespace> .
+@prefix xsd: <http://www.w3.org/2001/XMLSchema#> .
 
 :HealthAspectEnumeration a rdfs:Class ;
     rdfs:label "HealthAspectEnumeration" ;
-    :category "issue-2374" ;
     :isPartOf <http://pending.schema.org> ;
     :source <https://github.com/schemaorg/schemaorg/issues/2374> ;
     rdfs:comment "HealthAspectEnumeration enumerates several aspects of health content online, each of which might be described using [[hasHealthAspect]] and [[HealthTopicContent]]." ;
@@ -12,7 +13,6 @@
 
 :HealthTopicContent a rdfs:Class ;
     rdfs:label "HealthTopicContent" ;
-    :category "issue-2374" ;
     :isPartOf <http://pending.schema.org> ;
     :source <https://github.com/schemaorg/schemaorg/issues/2374> ;
     rdfs:comment """[[HealthTopicContent]] is [[WebContent]] that is about some aspect of a health topic, e.g. a condition, its symptoms or treatments. Such content may be comprised of several parts or sections and use different types of media. Multiple instances of [[WebContent]] (and hence [[HealthTopicContent]]) can be related using [[hasPart]] / [[isPartOf]] where there is some kind of content hierarchy, and their content described with [[about]] and [[mentions]] e.g. building upon the existing [[MedicalCondition]] vocabulary.
@@ -21,161 +21,138 @@
 
 :BenefitsHealthAspect a :HealthAspectEnumeration ;
     rdfs:label "BenefitsHealthAspect" ;
-    :category "issue-2374" ;
     :isPartOf <http://pending.schema.org> ;
     :source <https://github.com/schemaorg/schemaorg/issues/2374> ;
     rdfs:comment "Content about the benefits and advantages of usage or utilization of topic." .
 
 :CausesHealthAspect a :HealthAspectEnumeration ;
     rdfs:label "CausesHealthAspect" ;
-    :category "issue-2374" ;
     :isPartOf <http://pending.schema.org> ;
     :source <https://github.com/schemaorg/schemaorg/issues/2374> ;
     rdfs:comment "Information about the causes and main actions that gave rise to the topic." .
 
 :ContagiousnessHealthAspect a :HealthAspectEnumeration ;
     rdfs:label "ContagiousnessHealthAspect" ;
-    :category "issue-2374" ;
     :isPartOf <http://pending.schema.org> ;
     :source <https://github.com/schemaorg/schemaorg/issues/2374> ;
     rdfs:comment "Content about contagion mechanisms and contagiousness information over the topic." .
 
 :HowOrWhereHealthAspect a :HealthAspectEnumeration ;
     rdfs:label "HowOrWhereHealthAspect" ;
-    :category "issue-2374" ;
     :isPartOf <http://pending.schema.org> ;
     :source <https://github.com/schemaorg/schemaorg/issues/2374> ;
     rdfs:comment "Information about how or where to find a topic. Also may contain location data that can be used for where to look for help if the topic is observed." .
 
 :LivingWithHealthAspect a :HealthAspectEnumeration ;
     rdfs:label "LivingWithHealthAspect" ;
-    :category "issue-2374" ;
     :isPartOf <http://pending.schema.org> ;
     :source <https://github.com/schemaorg/schemaorg/issues/2374> ;
     rdfs:comment "Information about coping or life related to the topic." .
 
 :MayTreatHealthAspect a :HealthAspectEnumeration ;
     rdfs:label "MayTreatHealthAspect" ;
-    :category "issue-2374" ;
     :isPartOf <http://pending.schema.org> ;
     :source <https://github.com/schemaorg/schemaorg/issues/2374> ;
     rdfs:comment "Related topics may be treated by a Topic." .
 
 :MisconceptionsHealthAspect a :HealthAspectEnumeration ;
     rdfs:label "MisconceptionsHealthAspect" ;
-    :category "issue-2374" ;
     :isPartOf <http://pending.schema.org> ;
     :source <https://github.com/schemaorg/schemaorg/issues/2374> ;
     rdfs:comment "Content about common misconceptions and myths that are related to a topic." .
 
 :OverviewHealthAspect a :HealthAspectEnumeration ;
     rdfs:label "OverviewHealthAspect" ;
-    :category "issue-2374" ;
     :isPartOf <http://pending.schema.org> ;
     :source <https://github.com/schemaorg/schemaorg/issues/2374> ;
     rdfs:comment "Overview of the content. Contains a summarized view of the topic with the most relevant information for an introduction." .
 
 :PatientExperienceHealthAspect a :HealthAspectEnumeration ;
     rdfs:label "PatientExperienceHealthAspect" ;
-    :category "issue-2374" ;
     :isPartOf <http://pending.schema.org> ;
     :source <https://github.com/schemaorg/schemaorg/issues/2374> ;
     rdfs:comment "Content about the real life experience of patients or people that have lived a similar experience about the topic. May be forums, topics, Q-and-A and related material." .
 
 :PreventionHealthAspect a :HealthAspectEnumeration ;
     rdfs:label "PreventionHealthAspect" ;
-    :category "issue-2374" ;
     :isPartOf <http://pending.schema.org> ;
     :source <https://github.com/schemaorg/schemaorg/issues/2374> ;
     rdfs:comment "Information about actions or measures that can be taken to avoid getting the topic or reaching a critical situation related to the topic." .
 
 :PrognosisHealthAspect a :HealthAspectEnumeration ;
     rdfs:label "PrognosisHealthAspect" ;
-    :category "issue-2374" ;
     :isPartOf <http://pending.schema.org> ;
     :source <https://github.com/schemaorg/schemaorg/issues/2374> ;
     rdfs:comment "Typical progression and happenings of life course of the topic." .
 
 :RelatedTopicsHealthAspect a :HealthAspectEnumeration ;
     rdfs:label "RelatedTopicsHealthAspect" ;
-    :category "issue-2374" ;
     :isPartOf <http://pending.schema.org> ;
     :source <https://github.com/schemaorg/schemaorg/issues/2374> ;
     rdfs:comment "Other prominent or relevant topics tied to the main topic." .
 
 :RisksOrComplicationsHealthAspect a :HealthAspectEnumeration ;
     rdfs:label "RisksOrComplicationsHealthAspect" ;
-    :category "issue-2374" ;
     :isPartOf <http://pending.schema.org> ;
     :source <https://github.com/schemaorg/schemaorg/issues/2374> ;
     rdfs:comment "Information about the risk factors and possible complications that may follow a topic." .
 
 :ScreeningHealthAspect a :HealthAspectEnumeration ;
     rdfs:label "ScreeningHealthAspect" ;
-    :category "issue-2374" ;
     :isPartOf <http://pending.schema.org> ;
     :source <https://github.com/schemaorg/schemaorg/issues/2374> ;
     rdfs:comment "Content about how to screen or further filter a topic." .
 
 :SeeDoctorHealthAspect a :HealthAspectEnumeration ;
     rdfs:label "SeeDoctorHealthAspect" ;
-    :category "issue-2374" ;
     :isPartOf <http://pending.schema.org> ;
     :source <https://github.com/schemaorg/schemaorg/issues/2374> ;
     rdfs:comment "Information about questions that may be asked, when to see a professional, measures before seeing a doctor or content about the first consultation." .
 
 :SelfCareHealthAspect a :HealthAspectEnumeration ;
     rdfs:label "SelfCareHealthAspect" ;
-    :category "issue-2374" ;
     :isPartOf <http://pending.schema.org> ;
     :source <https://github.com/schemaorg/schemaorg/issues/2374> ;
     rdfs:comment "Self care actions or measures that can be taken to sooth, health or avoid a topic. This may be carried at home and can be carried/managed by the person itself." .
 
 :SideEffectsHealthAspect a :HealthAspectEnumeration ;
     rdfs:label "SideEffectsHealthAspect" ;
-    :category "issue-2374" ;
     :isPartOf <http://pending.schema.org> ;
     :source <https://github.com/schemaorg/schemaorg/issues/2374> ;
     rdfs:comment "Side effects that can be observed from the usage of the topic." .
 
 :StagesHealthAspect a :HealthAspectEnumeration ;
     rdfs:label "StagesHealthAspect" ;
-    :category "issue-2374" ;
     :isPartOf <http://pending.schema.org> ;
     :source <https://github.com/schemaorg/schemaorg/issues/2374> ;
     rdfs:comment "Stages that can be observed from a topic." .
 
 :SymptomsHealthAspect a :HealthAspectEnumeration ;
     rdfs:label "SymptomsHealthAspect" ;
-    :category "issue-2374" ;
     :isPartOf <http://pending.schema.org> ;
     :source <https://github.com/schemaorg/schemaorg/issues/2374> ;
     rdfs:comment "Symptoms or related symptoms of a Topic." .
 
 :TreatmentsHealthAspect a :HealthAspectEnumeration ;
     rdfs:label "TreatmentsHealthAspect" ;
-    :category "issue-2374" ;
     :isPartOf <http://pending.schema.org> ;
     :source <https://github.com/schemaorg/schemaorg/issues/2374> ;
     rdfs:comment "Treatments or related therapies for a Topic." .
 
 :TypesHealthAspect a :HealthAspectEnumeration ;
     rdfs:label "TypesHealthAspect" ;
-    :category "issue-2374" ;
     :isPartOf <http://pending.schema.org> ;
     :source <https://github.com/schemaorg/schemaorg/issues/2374> ;
     rdfs:comment "Categorization and other types related to a topic." .
 
 :UsageOrScheduleHealthAspect a :HealthAspectEnumeration ;
     rdfs:label "UsageOrScheduleHealthAspect" ;
-    :category "issue-2374" ;
     :isPartOf <http://pending.schema.org> ;
     :source <https://github.com/schemaorg/schemaorg/issues/2374> ;
     rdfs:comment "Content about how, when, frequency and dosage of a topic." .
 
 :hasHealthAspect a rdf:Property ;
     rdfs:label "hasHealthAspect" ;
-    :category "issue-2374" ;
     :domainIncludes :HealthTopicContent ;
     :isPartOf <http://pending.schema.org> ;
     :rangeIncludes :HealthAspectEnumeration ;

--- a/data/ext/pending/issue-2381.ttl
+++ b/data/ext/pending/issue-2381.ttl
@@ -1,10 +1,11 @@
 @prefix : <http://schema.org/> .
 @prefix rdf: <http://www.w3.org/1999/02/22-rdf-syntax-ns#> .
 @prefix rdfs: <http://www.w3.org/2000/01/rdf-schema#> .
+@prefix xml: <http://www.w3.org/XML/1998/namespace> .
+@prefix xsd: <http://www.w3.org/2001/XMLSchema#> .
 
 :MerchantReturnEnumeration a rdfs:Class ;
     rdfs:label "MerchantReturnEnumeration" ;
-    :category "issue-2288" ;
     :isPartOf <http://pending.schema.org> ;
     :source <https://github.com/schemaorg/schemaorg/issues/2288> ;
     rdfs:comment "MerchantReturnEnumeration enumerates several kinds of product return policy. Note that this structure may not capture all aspects of the policy." ;
@@ -12,7 +13,6 @@
 
 :MerchantReturnPolicy a rdfs:Class ;
     rdfs:label "MerchantReturnPolicy" ;
-    :category "issue-2288" ;
     :isPartOf <http://pending.schema.org> ;
     :source <https://github.com/schemaorg/schemaorg/issues/2288> ;
     rdfs:comment "A MerchantReturnPolicy provides information about product return policies associated with an [[Organization]] or [[Product]]." ;
@@ -20,7 +20,6 @@
 
 :RefundTypeEnumeration a rdfs:Class ;
     rdfs:label "RefundTypeEnumeration" ;
-    :category "issue-2288" ;
     :isPartOf <http://pending.schema.org> ;
     :source <https://github.com/schemaorg/schemaorg/issues/2288> ;
     rdfs:comment "RefundTypeEnumeration enumerates several kinds of product return refund types." ;
@@ -28,7 +27,6 @@
 
 :ReturnFeesEnumeration a rdfs:Class ;
     rdfs:label "ReturnFeesEnumeration" ;
-    :category "issue-2288" ;
     :isPartOf <http://pending.schema.org> ;
     :source <https://github.com/schemaorg/schemaorg/issues/2288> ;
     rdfs:comment "ReturnFeesEnumeration expresses policies for return fees." ;
@@ -36,77 +34,66 @@
 
 :ExchangeRefund a :RefundTypeEnumeration ;
     rdfs:label "ExchangeRefund" ;
-    :category "issue-2288" ;
     :isPartOf <http://pending.schema.org> ;
     :source <https://github.com/schemaorg/schemaorg/issues/2288> ;
     rdfs:comment "A ExchangeRefund ..." .
 
 :FullRefund a :RefundTypeEnumeration ;
     rdfs:label "FullRefund" ;
-    :category "issue-2288" ;
     :isPartOf <http://pending.schema.org> ;
     :source <https://github.com/schemaorg/schemaorg/issues/2288> ;
     rdfs:comment "A FullRefund ..." .
 
 :MerchantReturnFiniteReturnWindow a :MerchantReturnEnumeration ;
     rdfs:label "MerchantReturnFiniteReturnWindow" ;
-    :category "issue-2288" ;
     :isPartOf <http://pending.schema.org> ;
     :source <https://github.com/schemaorg/schemaorg/issues/2288> ;
     rdfs:comment "MerchantReturnFiniteReturnWindow: there is a finite window for product returns." .
 
 :MerchantReturnNotPermitted a :MerchantReturnEnumeration ;
     rdfs:label "MerchantReturnNotPermitted" ;
-    :category "issue-2288" ;
     :isPartOf <http://pending.schema.org> ;
     :source <https://github.com/schemaorg/schemaorg/issues/2288> ;
     rdfs:comment "MerchantReturnNotPermitted: product returns are not permitted." .
 
 :MerchantReturnUnlimitedWindow a :MerchantReturnEnumeration ;
     rdfs:label "MerchantReturnUnlimitedWindow" ;
-    :category "issue-2288" ;
     :isPartOf <http://pending.schema.org> ;
     :source <https://github.com/schemaorg/schemaorg/issues/2288> ;
     rdfs:comment "MerchantReturnUnlimitedWindow: there is an unlimited window for product returns." .
 
 :MerchantReturnUnspecified a :MerchantReturnEnumeration ;
     rdfs:label "MerchantReturnUnspecified" ;
-    :category "issue-2288" ;
     :isPartOf <http://pending.schema.org> ;
     :source <https://github.com/schemaorg/schemaorg/issues/2288> ;
     rdfs:comment "MerchantReturnUnspecified: a product return policy is not specified here." .
 
 :OriginalShippingFees a :ReturnFeesEnumeration ;
     rdfs:label "OriginalShippingFees" ;
-    :category "issue-2288" ;
     :isPartOf <http://pending.schema.org> ;
     :source <https://github.com/schemaorg/schemaorg/issues/2288> ;
     rdfs:comment "OriginalShippingFees ..." .
 
 :RestockingFees a :ReturnFeesEnumeration ;
     rdfs:label "RestockingFees" ;
-    :category "issue-2288" ;
     :isPartOf <http://pending.schema.org> ;
     :source <https://github.com/schemaorg/schemaorg/issues/2288> ;
     rdfs:comment "RestockingFees ..." .
 
 :ReturnShippingFees a :ReturnFeesEnumeration ;
     rdfs:label "ReturnShippingFees" ;
-    :category "issue-2288" ;
     :isPartOf <http://pending.schema.org> ;
     :source <https://github.com/schemaorg/schemaorg/issues/2288> ;
     rdfs:comment "ReturnShippingFees ..." .
 
 :StoreCreditRefund a :RefundTypeEnumeration ;
     rdfs:label "StoreCreditRefund" ;
-    :category "issue-2288" ;
     :isPartOf <http://pending.schema.org> ;
     :source <https://github.com/schemaorg/schemaorg/issues/2288> ;
     rdfs:comment "A StoreCreditRefund ..." .
 
 :hasMerchantReturnPolicy a rdf:Property ;
     rdfs:label "hasMerchantReturnPolicy" ;
-    :category "issue-2288" ;
     :domainIncludes :Organization,
         :Product ;
     :isPartOf <http://pending.schema.org> ;
@@ -116,7 +103,6 @@
 
 :inStoreReturnsOffered a rdf:Property ;
     rdfs:label "inStoreReturnsOffered" ;
-    :category "issue-2288" ;
     :domainIncludes :MerchantReturnPolicy ;
     :isPartOf <http://pending.schema.org> ;
     :rangeIncludes :Boolean ;
@@ -125,7 +111,6 @@
 
 :merchantReturnDays a rdf:Property ;
     rdfs:label "merchantReturnDays" ;
-    :category "issue-2288" ;
     :domainIncludes :MerchantReturnPolicy ;
     :isPartOf <http://pending.schema.org> ;
     :rangeIncludes :Integer ;
@@ -134,7 +119,6 @@
 
 :merchantReturnLink a rdf:Property ;
     rdfs:label "merchantReturnLink" ;
-    :category "issue-2288" ;
     :domainIncludes :MerchantReturnPolicy ;
     :isPartOf <http://pending.schema.org> ;
     :rangeIncludes :URL ;
@@ -143,7 +127,6 @@
 
 :refundType a rdf:Property ;
     rdfs:label "refundType" ;
-    :category "issue-2288" ;
     :domainIncludes :MerchantReturnPolicy ;
     :isPartOf <http://pending.schema.org> ;
     :rangeIncludes :RefundTypeEnumeration ;
@@ -152,7 +135,6 @@
 
 :returnFees a rdf:Property ;
     rdfs:label "returnFees" ;
-    :category "issue-2288" ;
     :domainIncludes :MerchantReturnPolicy ;
     :isPartOf <http://pending.schema.org> ;
     :rangeIncludes :ReturnFeesEnumeration ;
@@ -161,7 +143,6 @@
 
 :returnPolicyCategory a rdf:Property ;
     rdfs:label "returnPolicyCategory" ;
-    :category "issue-2288" ;
     :domainIncludes :MerchantReturnPolicy ;
     :isPartOf <http://pending.schema.org> ;
     :rangeIncludes :MerchantReturnEnumeration ;

--- a/data/ext/pending/issue-2382.ttl
+++ b/data/ext/pending/issue-2382.ttl
@@ -1,10 +1,11 @@
 @prefix : <http://schema.org/> .
 @prefix rdf: <http://www.w3.org/1999/02/22-rdf-syntax-ns#> .
 @prefix rdfs: <http://www.w3.org/2000/01/rdf-schema#> .
+@prefix xml: <http://www.w3.org/XML/1998/namespace> .
+@prefix xsd: <http://www.w3.org/2001/XMLSchema#> .
 
 :inLanguage a rdf:Property ;
     rdfs:label "inLanguage" ;
-    :category "issue-2382" ;
     :domainIncludes :BroadcastService ;
     :source <https://github.com/schemaorg/schemaorg/issues/2382> .
 

--- a/data/ext/pending/issue-2384.ttl
+++ b/data/ext/pending/issue-2384.ttl
@@ -1,10 +1,11 @@
 @prefix : <http://schema.org/> .
 @prefix rdf: <http://www.w3.org/1999/02/22-rdf-syntax-ns#> .
 @prefix rdfs: <http://www.w3.org/2000/01/rdf-schema#> .
+@prefix xml: <http://www.w3.org/XML/1998/namespace> .
+@prefix xsd: <http://www.w3.org/2001/XMLSchema#> .
 
 :eligibilityToWorkRequirement a rdf:Property ;
     rdfs:label "eligibilityToWorkRequirement" ;
-    :category "issue-2384" ;
     :domainIncludes :JobPosting ;
     :isPartOf <http://pending.schema.org> ;
     :rangeIncludes :Text ;
@@ -13,7 +14,6 @@
 
 :physicalRequirement a rdf:Property ;
     rdfs:label "physicalRequirement" ;
-    :category "issue-2384" ;
     :domainIncludes :JobPosting ;
     :isPartOf <http://pending.schema.org> ;
     :rangeIncludes :DefinedTerm,
@@ -24,7 +24,6 @@
 
 :securityClearanceRequirement a rdf:Property ;
     rdfs:label "securityClearanceRequirement" ;
-    :category "issue-2384" ;
     :domainIncludes :JobPosting ;
     :isPartOf <http://pending.schema.org> ;
     :rangeIncludes :Text,
@@ -34,7 +33,6 @@
 
 :sensoryRequirement a rdf:Property ;
     rdfs:label "sensoryRequirement" ;
-    :category "issue-2384" ;
     :domainIncludes :JobPosting ;
     :isPartOf <http://pending.schema.org> ;
     :rangeIncludes :DefinedTerm,

--- a/data/ext/pending/issue-2394.ttl
+++ b/data/ext/pending/issue-2394.ttl
@@ -1,11 +1,12 @@
 @prefix : <http://schema.org/> .
 @prefix rdf: <http://www.w3.org/1999/02/22-rdf-syntax-ns#> .
 @prefix rdfs: <http://www.w3.org/2000/01/rdf-schema#> .
+@prefix xml: <http://www.w3.org/XML/1998/namespace> .
+@prefix xsd: <http://www.w3.org/2001/XMLSchema#> .
 
 :isResizable a rdf:Property ;
     rdfs:label "isResizable" ;
-    :category "issue-2394" ;
-    :domainIncludes :3DModel ;
+    :domainIncludes <http://schema.org/3DModel> ;
     :isPartOf <http://pending.schema.org> ;
     :rangeIncludes :Boolean ;
     :source <https://github.com/schemaorg/schemaorg/issues/2394> ;

--- a/data/ext/pending/issue-2396.ttl
+++ b/data/ext/pending/issue-2396.ttl
@@ -1,10 +1,11 @@
 @prefix : <http://schema.org/> .
 @prefix rdf: <http://www.w3.org/1999/02/22-rdf-syntax-ns#> .
 @prefix rdfs: <http://www.w3.org/2000/01/rdf-schema#> .
+@prefix xml: <http://www.w3.org/XML/1998/namespace> .
+@prefix xsd: <http://www.w3.org/2001/XMLSchema#> .
 
 :applicationContact a rdf:Property ;
     rdfs:label "applicationContact" ;
-    :category "issue-2396" ;
     :domainIncludes :JobPosting ;
     :isPartOf <http://pending.schema.org> ;
     :rangeIncludes :ContactPoint ;
@@ -13,7 +14,6 @@
 
 :employerOverview a rdf:Property ;
     rdfs:label "employerOverview" ;
-    :category "issue-2396" ;
     :domainIncludes :JobPosting ;
     :isPartOf <http://pending.schema.org> ;
     :rangeIncludes :Text ;

--- a/data/ext/pending/issue-2405.ttl
+++ b/data/ext/pending/issue-2405.ttl
@@ -1,10 +1,11 @@
 @prefix : <http://schema.org/> .
 @prefix rdf: <http://www.w3.org/1999/02/22-rdf-syntax-ns#> .
 @prefix rdfs: <http://www.w3.org/2000/01/rdf-schema#> .
+@prefix xml: <http://www.w3.org/XML/1998/namespace> .
+@prefix xsd: <http://www.w3.org/2001/XMLSchema#> .
 
 :Guide a rdfs:Class ;
     rdfs:label "Guide" ;
-    :category "issue-2405" ;
     :isPartOf <http://pending.schema.org> ;
     :source <https://github.com/schemaorg/schemaorg/issues/2405> ;
     rdfs:comment "[[Guide]] is a page or article that recommend specific products or services, or aspects of a thing for a user to consider. A [[Guide]] may represent a Buying Guide and detail aspects of products or services for a user to consider. A [[Guide]] may represent a Product Guide and recommend specific products or services. A [[Guide]] may represent a Ranked List and recommend specific products or services with ranking." ;
@@ -12,7 +13,6 @@
 
 :Recommendation a rdfs:Class ;
     rdfs:label "Recommendation" ;
-    :category "issue-2405" ;
     :isPartOf <http://pending.schema.org> ;
     :source <https://github.com/schemaorg/schemaorg/issues/2405> ;
     rdfs:comment "[[Recommendation]] is a type of [[Review]] that suggests or proposes something as the best option or best course of action. Recommendations may be for products or services, or other concrete things, as in the case of a ranked list or product guide. A [[Guide]] may list multiple recommendations for different categories. For example, in a [[Guide]] about which TVs to buy, the author may have several [[Recommendation]]s." ;

--- a/data/ext/pending/issue-2418.ttl
+++ b/data/ext/pending/issue-2418.ttl
@@ -1,10 +1,11 @@
 @prefix : <http://schema.org/> .
 @prefix rdf: <http://www.w3.org/1999/02/22-rdf-syntax-ns#> .
 @prefix rdfs: <http://www.w3.org/2000/01/rdf-schema#> .
+@prefix xml: <http://www.w3.org/XML/1998/namespace> .
+@prefix xsd: <http://www.w3.org/2001/XMLSchema#> .
 
 :financialAidEligible a rdf:Property ;
     rdfs:label "financialAidEligible" ;
-    :category "issue-2418" ;
     :domainIncludes :EducationalOccupationalProgram ;
     :isPartOf <http://pending.schema.org> ;
     :rangeIncludes :DefinedTerm,

--- a/data/ext/pending/issue-2419.ttl
+++ b/data/ext/pending/issue-2419.ttl
@@ -1,10 +1,11 @@
 @prefix : <http://schema.org/> .
 @prefix rdf: <http://www.w3.org/1999/02/22-rdf-syntax-ns#> .
 @prefix rdfs: <http://www.w3.org/2000/01/rdf-schema#> .
+@prefix xml: <http://www.w3.org/XML/1998/namespace> .
+@prefix xsd: <http://www.w3.org/2001/XMLSchema#> .
 
 :applicationDeadline a rdf:Property ;
     rdfs:label "applicationDeadline" ;
-    :category "issue-2419" ;
     :domainIncludes :EducationalOccupationalProgram ;
     :isPartOf <http://pending.schema.org> ;
     :rangeIncludes :Date ;
@@ -13,7 +14,6 @@
 
 :applicationStartDate a rdf:Property ;
     rdfs:label "applicationStartDate" ;
-    :category "issue-2419" ;
     :domainIncludes :EducationalOccupationalProgram ;
     :isPartOf <http://pending.schema.org> ;
     :rangeIncludes :Date ;
@@ -25,7 +25,6 @@
 
 :educationalProgramMode a rdf:Property ;
     rdfs:label "educationalProgramMode" ;
-    :category "issue-2419" ;
     :domainIncludes :EducationalOccupationalProgram ;
     :isPartOf <http://pending.schema.org> ;
     :rangeIncludes :Text,
@@ -38,7 +37,6 @@
 
 :maximumEnrollment a rdf:Property ;
     rdfs:label "maximumEnrollment" ;
-    :category "issue-2419" ;
     :domainIncludes :EducationalOccupationalProgram ;
     :isPartOf <http://pending.schema.org> ;
     :rangeIncludes :Integer ;
@@ -47,7 +45,6 @@
 
 :numberOfCredits a rdf:Property ;
     rdfs:label "numberOfCredits" ;
-    :category "issue-2419" ;
     :domainIncludes :Course,
         :EducationalOccupationalProgram ;
     :isPartOf <http://pending.schema.org> ;
@@ -61,7 +58,6 @@
 
 :termDuration a rdf:Property ;
     rdfs:label "termDuration" ;
-    :category "issue-2419" ;
     :domainIncludes :EducationalOccupationalProgram ;
     :isPartOf <http://pending.schema.org> ;
     :rangeIncludes :Duration ;
@@ -70,7 +66,6 @@
 
 :termsPerYear a rdf:Property ;
     rdfs:label "termsPerYear" ;
-    :category "issue-2419" ;
     :domainIncludes :EducationalOccupationalProgram ;
     :isPartOf <http://pending.schema.org> ;
     :rangeIncludes :Number ;
@@ -79,7 +74,6 @@
 
 :timeOfDay a rdf:Property ;
     rdfs:label "timeOfDay" ;
-    :category "issue-2419" ;
     :domainIncludes :EducationalOccupationalProgram ;
     :isPartOf <http://pending.schema.org> ;
     :rangeIncludes :Text ;
@@ -88,7 +82,6 @@
 
 :typicalCreditsPerTerm a rdf:Property ;
     rdfs:label "typicalCreditsPerTerm" ;
-    :category "issue-2419" ;
     :domainIncludes :EducationalOccupationalProgram ;
     :isPartOf <http://pending.schema.org> ;
     :rangeIncludes :Integer,

--- a/data/ext/pending/issue-2420.ttl
+++ b/data/ext/pending/issue-2420.ttl
@@ -1,10 +1,11 @@
 @prefix : <http://schema.org/> .
 @prefix rdf: <http://www.w3.org/1999/02/22-rdf-syntax-ns#> .
 @prefix rdfs: <http://www.w3.org/2000/01/rdf-schema#> .
+@prefix xml: <http://www.w3.org/XML/1998/namespace> .
+@prefix xsd: <http://www.w3.org/2001/XMLSchema#> .
 
 :audio a rdf:Property ;
     rdfs:label "audio" ;
-    :category "issue-2420" ;
     :rangeIncludes :MusicRecording ;
     :source <https://github.com/schemaorg/schemaorg/issues/2420> .
 

--- a/data/ext/pending/issue-2421.ttl
+++ b/data/ext/pending/issue-2421.ttl
@@ -1,10 +1,11 @@
 @prefix : <http://schema.org/> .
 @prefix rdf: <http://www.w3.org/1999/02/22-rdf-syntax-ns#> .
 @prefix rdfs: <http://www.w3.org/2000/01/rdf-schema#> .
+@prefix xml: <http://www.w3.org/XML/1998/namespace> .
+@prefix xsd: <http://www.w3.org/2001/XMLSchema#> .
 
 :interactionStatistic a rdf:Property ;
     rdfs:label "interactionStatistic" ;
-    :category "issue-2421" ;
     :domainIncludes :Organization,
         :Person ;
     :source <https://github.com/schemaorg/schemaorg/issues/2421> .

--- a/data/ext/pending/issue-2427.ttl
+++ b/data/ext/pending/issue-2427.ttl
@@ -1,10 +1,11 @@
 @prefix : <http://schema.org/> .
 @prefix rdf: <http://www.w3.org/1999/02/22-rdf-syntax-ns#> .
 @prefix rdfs: <http://www.w3.org/2000/01/rdf-schema#> .
+@prefix xml: <http://www.w3.org/XML/1998/namespace> .
+@prefix xsd: <http://www.w3.org/2001/XMLSchema#> .
 
 :assesses a rdf:Property ;
     rdfs:label "assesses" ;
-    :category "issue-2427" ;
     :domainIncludes :CreativeWork,
         :EducationEvent ;
     :isPartOf <http://pending.schema.org> ;
@@ -15,7 +16,6 @@
 
 :teaches a rdf:Property ;
     rdfs:label "teaches" ;
-    :category "issue-2427" ;
     :domainIncludes :CreativeWork,
         :EducationEvent ;
     :isPartOf <http://pending.schema.org> ;

--- a/data/ext/pending/issue-2450.ttl
+++ b/data/ext/pending/issue-2450.ttl
@@ -1,10 +1,11 @@
 @prefix : <http://schema.org/> .
 @prefix rdf: <http://www.w3.org/1999/02/22-rdf-syntax-ns#> .
 @prefix rdfs: <http://www.w3.org/2000/01/rdf-schema#> .
+@prefix xml: <http://www.w3.org/XML/1998/namespace> .
+@prefix xsd: <http://www.w3.org/2001/XMLSchema#> .
 
 :MediaManipulationRatingEnumeration a rdfs:Class ;
     rdfs:label "MediaManipulationRatingEnumeration" ;
-    :category "issue-2450" ;
     :isPartOf <http://pending.schema.org> ;
     :source <https://github.com/schemaorg/schemaorg/issues/2450> ;
     rdfs:comment "(editorial work in progress, this definition is incomplete and unreviewed) MediaManipulationRatingEnumeration classifies a number of ways in which a media item (video, image, audio) can be manipulated, taking into account the context within which they are published or presented." ;
@@ -12,7 +13,6 @@
 
 :MediaReview a rdfs:Class ;
     rdfs:label "MediaReview" ;
-    :category "issue-2450" ;
     :isPartOf <http://pending.schema.org> ;
     :source <https://github.com/schemaorg/schemaorg/issues/2450> ;
     rdfs:comment """(editorial work in progress, this definition is incomplete and unreviewed)
@@ -22,21 +22,18 @@
 
 :AuthenticContent a :MediaManipulationRatingEnumeration ;
     rdfs:label "AuthenticContent" ;
-    :category "issue-2450" ;
     :isPartOf <http://pending.schema.org> ;
     :source <https://github.com/schemaorg/schemaorg/issues/2450> ;
     rdfs:comment "AuthenticMediaObject: An unaltered image that is presented in an accurate way." .
 
 :MissingContext a :MediaManipulationRatingEnumeration ;
     rdfs:label "MissingContext" ;
-    :category "issue-2450" ;
     :isPartOf <http://pending.schema.org> ;
     :source <https://github.com/schemaorg/schemaorg/issues/2450> ;
     rdfs:comment "MissingContext: ..." .
 
 :mediaAuthenticityCategory a rdf:Property ;
     rdfs:label "mediaAuthenticityCategory" ;
-    :category "issue-2450" ;
     :domainIncludes :MediaReview ;
     :isPartOf <http://pending.schema.org> ;
     :rangeIncludes :MediaManipulationRatingEnumeration ;

--- a/data/ext/pending/issue-2454.ttl
+++ b/data/ext/pending/issue-2454.ttl
@@ -1,10 +1,11 @@
 @prefix : <http://schema.org/> .
 @prefix rdf: <http://www.w3.org/1999/02/22-rdf-syntax-ns#> .
 @prefix rdfs: <http://www.w3.org/2000/01/rdf-schema#> .
+@prefix xml: <http://www.w3.org/XML/1998/namespace> .
+@prefix xsd: <http://www.w3.org/2001/XMLSchema#> .
 
 :acquireLicensePage a rdf:Property ;
     rdfs:label "acquireLicensePage" ;
-    :category "issue-2454" ;
     :domainIncludes :CreativeWork ;
     :isPartOf <http://pending.schema.org> ;
     :rangeIncludes :CreativeWork,
@@ -15,7 +16,6 @@
 
 :usageInfo a rdf:Property ;
     rdfs:label "usageInfo" ;
-    :category "issue-2454" ;
     :domainIncludes :CreativeWork ;
     :isPartOf <http://pending.schema.org> ;
     :rangeIncludes :CreativeWork,

--- a/data/ext/pending/issue-2460.ttl
+++ b/data/ext/pending/issue-2460.ttl
@@ -1,17 +1,17 @@
 @prefix : <http://schema.org/> .
 @prefix rdf: <http://www.w3.org/1999/02/22-rdf-syntax-ns#> .
 @prefix rdfs: <http://www.w3.org/2000/01/rdf-schema#> .
+@prefix xml: <http://www.w3.org/XML/1998/namespace> .
+@prefix xsd: <http://www.w3.org/2001/XMLSchema#> .
 
 :occupationalCategory a rdf:Property ;
     rdfs:label "occupationalCategory" ;
-    :category "issue-2460" ;
     :domainIncludes :EducationalOccupationalProgram ;
     :isPartOf <http://pending.schema.org> ;
     :source <https://github.com/schemaorg/schemaorg/issues/2460> .
 
 :programType a rdf:Property ;
     rdfs:label "programType" ;
-    :category "issue-2460" ;
     :domainIncludes :EducationalOccupationalProgram ;
     :isPartOf <http://pending.schema.org> ;
     :rangeIncludes :DefinedTerm,
@@ -21,7 +21,6 @@
 
 :trainingSalary a rdf:Property ;
     rdfs:label "trainingSalary" ;
-    :category "issue-2460" ;
     :domainIncludes :EducationalOccupationalProgram ;
     :isPartOf <http://pending.schema.org> ;
     :source <https://github.com/schemaorg/schemaorg/issues/2460> .

--- a/data/ext/pending/issue-2469.ttl
+++ b/data/ext/pending/issue-2469.ttl
@@ -1,10 +1,11 @@
 @prefix : <http://schema.org/> .
 @prefix rdf: <http://www.w3.org/1999/02/22-rdf-syntax-ns#> .
 @prefix rdfs: <http://www.w3.org/2000/01/rdf-schema#> .
+@prefix xml: <http://www.w3.org/XML/1998/namespace> .
+@prefix xsd: <http://www.w3.org/2001/XMLSchema#> .
 
 :editEIDR a rdf:Property ;
     rdfs:label "editEIDR" ;
-    :category "issue-2469" ;
     :domainIncludes :CreativeWork ;
     :isPartOf <http://pending.schema.org> ;
     :rangeIncludes :Text,
@@ -20,7 +21,6 @@ Since schema.org types like [[Movie]] and [[TVEpisode]] can be used for both wor
 
 :titleEIDR a rdf:Property ;
     rdfs:label "titleEIDR" ;
-    :category "issue-2469" ;
     :domainIncludes :Movie,
         :TVEpisode ;
     :isPartOf <http://pending.schema.org> ;

--- a/data/ext/pending/issue-2483.ttl
+++ b/data/ext/pending/issue-2483.ttl
@@ -1,12 +1,14 @@
 @prefix : <http://schema.org/> .
 @prefix rdf: <http://www.w3.org/1999/02/22-rdf-syntax-ns#> .
 @prefix rdfs: <http://www.w3.org/2000/01/rdf-schema#> .
+@prefix xml: <http://www.w3.org/XML/1998/namespace> .
+@prefix xsd: <http://www.w3.org/2001/XMLSchema#> .
 
 :hasCourse a rdf:Property ;
-    :category "issue-2483" ;
     rdfs:label "hasCourse" ;
-    rdfs:comment "A course or class that is one of the learning opportunities that constitute an educational / occupational program. No information is implied about whether the course is mandatory or optional; no guarantee is implied about whether the course will be available to everyone on the program." ;
     :domainIncludes :EducationalOccupationalProgram ;
-    :rangeIncludes :Course ;
     :isPartOf <http://pending.schema.org> ;
-    :source <https://github.com/schemaorg/schemaorg/issues/2483> .
+    :rangeIncludes :Course ;
+    :source <https://github.com/schemaorg/schemaorg/issues/2483> ;
+    rdfs:comment "A course or class that is one of the learning opportunities that constitute an educational / occupational program. No information is implied about whether the course is mandatory or optional; no guarantee is implied about whether the course will be available to everyone on the program." .
+

--- a/data/ext/pending/issue-2486.ttl
+++ b/data/ext/pending/issue-2486.ttl
@@ -1,13 +1,14 @@
 @prefix : <http://schema.org/> .
 @prefix rdf: <http://www.w3.org/1999/02/22-rdf-syntax-ns#> .
+@prefix rdfs: <http://www.w3.org/2000/01/rdf-schema#> .
+@prefix xml: <http://www.w3.org/XML/1998/namespace> .
+@prefix xsd: <http://www.w3.org/2001/XMLSchema#> .
 
 :endDate a rdf:Property ;
-    :category "issue-2486" ;
     :domainIncludes :Schedule ;
     :source <https://github.com/schemaorg/schemaorg/issues/2486> .
 
 :startDate a rdf:Property ;
-    :category "issue-2486" ;
     :domainIncludes :Schedule ;
     :source <https://github.com/schemaorg/schemaorg/issues/2486> .
 

--- a/data/ext/pending/issue-2490.ttl
+++ b/data/ext/pending/issue-2490.ttl
@@ -1,10 +1,11 @@
 @prefix : <http://schema.org/> .
 @prefix rdf: <http://www.w3.org/1999/02/22-rdf-syntax-ns#> .
 @prefix rdfs: <http://www.w3.org/2000/01/rdf-schema#> .
+@prefix xml: <http://www.w3.org/XML/1998/namespace> .
+@prefix xsd: <http://www.w3.org/2001/XMLSchema#> .
 
 :CovidTestingFacility a rdfs:Class ;
     rdfs:label "CovidTestingFacility" ;
-    :category "issue-2490" ;
     :isPartOf <http://pending.schema.org> ;
     :source <https://github.com/schemaorg/schemaorg/issues/2490> ;
     rdfs:comment """A CovidTestingFacility is a [[MedicalClinic]] where testing for the COVID-19 Coronavirus
@@ -16,7 +17,6 @@
 
 :SpecialAnnouncement a rdfs:Class ;
     rdfs:label "SpecialAnnouncement" ;
-    :category "issue-2490" ;
     :isPartOf <http://pending.schema.org> ;
     :source <https://github.com/schemaorg/schemaorg/issues/2490> ;
     rdfs:comment """A SpecialAnnouncement combines a simple date-stamped textual information update
@@ -64,7 +64,6 @@ media type information e.g. "application/rss+xml" or "application/atom+xml".
 
 :diseasePreventionInfo a rdf:Property ;
     rdfs:label "diseasePreventionInfo" ;
-    :category "issue-2490" ;
     :domainIncludes :SpecialAnnouncement ;
     :isPartOf <http://pending.schema.org> ;
     :rangeIncludes :URL,
@@ -74,7 +73,6 @@ media type information e.g. "application/rss+xml" or "application/atom+xml".
 
 :diseaseSpreadStatistics a rdf:Property ;
     rdfs:label "diseaseSpreadStatistics" ;
-    :category "issue-2490" ;
     :domainIncludes :SpecialAnnouncement ;
     :isPartOf <http://pending.schema.org> ;
     :rangeIncludes :Dataset,
@@ -88,7 +86,6 @@ media type information e.g. "application/rss+xml" or "application/atom+xml".
 
 :gettingTestedInfo a rdf:Property ;
     rdfs:label "gettingTestedInfo" ;
-    :category "issue-2490" ;
     :domainIncludes :SpecialAnnouncement ;
     :isPartOf <http://pending.schema.org> ;
     :rangeIncludes :URL,
@@ -98,7 +95,6 @@ media type information e.g. "application/rss+xml" or "application/atom+xml".
 
 :hasDriveThroughService a rdf:Property ;
     rdfs:label "hasDriveThroughService" ;
-    :category "issue-2490" ;
     :domainIncludes :Place ;
     :isPartOf <http://pending.schema.org> ;
     :rangeIncludes :Boolean ;
@@ -107,7 +103,6 @@ media type information e.g. "application/rss+xml" or "application/atom+xml".
 
 :newsUpdatesAndGuidelines a rdf:Property ;
     rdfs:label "newsUpdatesAndGuidelines" ;
-    :category "issue-2490" ;
     :domainIncludes :SpecialAnnouncement ;
     :isPartOf <http://pending.schema.org> ;
     :rangeIncludes :URL,
@@ -117,7 +112,6 @@ media type information e.g. "application/rss+xml" or "application/atom+xml".
 
 :publicTransportClosuresInfo a rdf:Property ;
     rdfs:label "publicTransportClosuresInfo" ;
-    :category "issue-2490" ;
     :domainIncludes :SpecialAnnouncement ;
     :isPartOf <http://pending.schema.org> ;
     :rangeIncludes :URL,
@@ -127,7 +121,6 @@ media type information e.g. "application/rss+xml" or "application/atom+xml".
 
 :quarantineGuidelines a rdf:Property ;
     rdfs:label "quarantineGuidelines" ;
-    :category "issue-2490" ;
     :domainIncludes :SpecialAnnouncement ;
     :isPartOf <http://pending.schema.org> ;
     :rangeIncludes :URL,
@@ -137,7 +130,6 @@ media type information e.g. "application/rss+xml" or "application/atom+xml".
 
 :schoolClosuresInfo a rdf:Property ;
     rdfs:label "schoolClosuresInfo" ;
-    :category "issue-2490" ;
     :domainIncludes :SpecialAnnouncement ;
     :isPartOf <http://pending.schema.org> ;
     :rangeIncludes :URL,
@@ -147,7 +139,6 @@ media type information e.g. "application/rss+xml" or "application/atom+xml".
 
 :travelBans a rdf:Property ;
     rdfs:label "travelBans" ;
-    :category "issue-2490" ;
     :domainIncludes :SpecialAnnouncement ;
     :isPartOf <http://pending.schema.org> ;
     :rangeIncludes :URL,

--- a/data/ext/pending/issue-2493.ttl
+++ b/data/ext/pending/issue-2493.ttl
@@ -1,13 +1,14 @@
 @prefix : <http://schema.org/> .
 @prefix rdf: <http://www.w3.org/1999/02/22-rdf-syntax-ns#> .
+@prefix rdfs: <http://www.w3.org/2000/01/rdf-schema#> .
+@prefix xml: <http://www.w3.org/XML/1998/namespace> .
+@prefix xsd: <http://www.w3.org/2001/XMLSchema#> .
 
 :endTime a rdf:Property ;
-    :category "issue-2493" ;
     :domainIncludes :Schedule ;
     :source <https://github.com/schemaorg/schemaorg/issues/2493> .
 
 :startTime a rdf:Property ;
-    :category "issue-2493" ;
     :domainIncludes :Schedule ;
     :source <https://github.com/schemaorg/schemaorg/issues/2493> .
 

--- a/data/ext/pending/issue-2496.ttl
+++ b/data/ext/pending/issue-2496.ttl
@@ -1,8 +1,10 @@
 @prefix : <http://schema.org/> .
 @prefix rdf: <http://www.w3.org/1999/02/22-rdf-syntax-ns#> .
+@prefix rdfs: <http://www.w3.org/2000/01/rdf-schema#> .
+@prefix xml: <http://www.w3.org/XML/1998/namespace> .
+@prefix xsd: <http://www.w3.org/2001/XMLSchema#> .
 
 :datePosted a rdf:Property ;
-    :category "issue-2490" ;
     :domainIncludes :SpecialAnnouncement ;
     :rangeIncludes :DateTime ;
     :source <https://github.com/schemaorg/schemaorg/issues/2490> .

--- a/data/ext/pending/issue-2500.ttl
+++ b/data/ext/pending/issue-2500.ttl
@@ -1,9 +1,11 @@
 @prefix : <http://schema.org/> .
+@prefix rdf: <http://www.w3.org/1999/02/22-rdf-syntax-ns#> .
 @prefix rdfs: <http://www.w3.org/2000/01/rdf-schema#> .
+@prefix xml: <http://www.w3.org/XML/1998/namespace> .
+@prefix xsd: <http://www.w3.org/2001/XMLSchema#> .
 
 :SchoolDistrict a rdfs:Class ;
     rdfs:label "SchoolDistrict" ;
-    :category "issue-2500" ;
     :isPartOf <http://pending.schema.org> ;
     :source <https://github.com/schemaorg/schemaorg/issues/2500> ;
     rdfs:comment "A School District is an administrative area for the administration of schools." ;

--- a/data/ext/pending/issue-2506.ttl
+++ b/data/ext/pending/issue-2506.ttl
@@ -1,10 +1,11 @@
 @prefix : <http://schema.org/> .
 @prefix rdf: <http://www.w3.org/1999/02/22-rdf-syntax-ns#> .
 @prefix rdfs: <http://www.w3.org/2000/01/rdf-schema#> .
+@prefix xml: <http://www.w3.org/XML/1998/namespace> .
+@prefix xsd: <http://www.w3.org/2001/XMLSchema#> .
 
 :DefinedRegion a rdfs:Class ;
     rdfs:label "DefinedRegion" ;
-    :category "issue-2506" ;
     :isPartOf <http://pending.schema.org> ;
     :source <https://github.com/schemaorg/schemaorg/issues/2506> ;
     rdfs:comment """A DefinedRegion is a geographic area defined by potentially arbitrary (rather than political, administrative or natural geographical) criteria. Properties are provided for defining a region by reference to sets of postal codes.
@@ -25,7 +26,6 @@ Region = state, canton, prefecture, autonomous community...
 
 :DeliveryTimeSettings a rdfs:Class ;
     rdfs:label "DeliveryTimeSettings" ;
-    :category "issue-2506" ;
     :isPartOf <http://pending.schema.org> ;
     :source <https://github.com/schemaorg/schemaorg/issues/2506> ;
     rdfs:comment "A DeliveryTimeSettings represents re-usable pieces of shipping information, relating to timing. It is designed for publication on an URL that may be referenced via the [[shippingSettingsLink]] property of a [[OfferShippingDetails]]. Several occurrences can be published, distinguished (and identified/referenced) by their different values for [[transitTimeLabel]]." ;
@@ -33,7 +33,6 @@ Region = state, canton, prefecture, autonomous community...
 
 :OfferShippingDetails a rdfs:Class ;
     rdfs:label "OfferShippingDetails" ;
-    :category "issue-2506" ;
     :isPartOf <http://pending.schema.org> ;
     :source <https://github.com/schemaorg/schemaorg/issues/2506> ;
     rdfs:comment """OfferShippingDetails represents information about shipping destinations.
@@ -53,7 +52,6 @@ or Fast and expensive: $15 in 1-2 days
 
 :PostalCodeRangeSpecification a rdfs:Class ;
     rdfs:label "PostalCodeRangeSpecification" ;
-    :category "issue-2506" ;
     :isPartOf <http://pending.schema.org> ;
     :source <https://github.com/schemaorg/schemaorg/issues/2506> ;
     rdfs:comment "Indicates a range of postalcodes, usually defined as the set of valid codes between [[postalCodeBegin]] and [[postalCodeEnd]], inclusively." ;
@@ -61,7 +59,6 @@ or Fast and expensive: $15 in 1-2 days
 
 :ShippingDeliveryTime a rdfs:Class ;
     rdfs:label "ShippingDeliveryTime" ;
-    :category "issue-2506" ;
     :isPartOf <http://pending.schema.org> ;
     :source <https://github.com/schemaorg/schemaorg/issues/2506> ;
     rdfs:comment "ShippingDeliveryTime provides various pieces of information about delivery times for shipping." ;
@@ -69,25 +66,21 @@ or Fast and expensive: $15 in 1-2 days
 
 :ShippingRateSettings a rdfs:Class ;
     rdfs:label "ShippingRateSettings" ;
-    :category "issue-2506" ;
     :isPartOf <http://pending.schema.org> ;
     :source <https://github.com/schemaorg/schemaorg/issues/2506> ;
     rdfs:comment "A ShippingRateSettings represents re-usable pieces of shipping information. It is designed for publication on an URL that may be referenced via the [[shippingSettingsLink]] property of an [[OfferShippingDetails]]. Several occurrences can be published, distinguished and matched (i.e. identified/referenced) by their different values for [[shippingLabel]]." ;
     rdfs:subClassOf :StructuredValue .
 
 :addressCountry a rdf:Property ;
-    :category "issue-2506" ;
     :domainIncludes :DefinedRegion ;
     :source <https://github.com/schemaorg/schemaorg/issues/2506> .
 
 :addressRegion a rdf:Property ;
-    :category "issue-2506" ;
     :domainIncludes :DefinedRegion ;
     :source <https://github.com/schemaorg/schemaorg/issues/2506> .
 
 :businessDays a rdf:Property ;
     rdfs:label "businessDays" ;
-    :category "issue-2506" ;
     :domainIncludes :ShippingDeliveryTime ;
     :isPartOf <http://pending.schema.org> ;
     :rangeIncludes :OpeningHoursSpecification ;
@@ -96,16 +89,14 @@ or Fast and expensive: $15 in 1-2 days
 
 :cutoffTime a rdf:Property ;
     rdfs:label "cutoffTime" ;
-    :category "issue-2506" ;
     :domainIncludes :ShippingDeliveryTime ;
     :isPartOf <http://pending.schema.org> ;
     :rangeIncludes :Time ;
     :source <https://github.com/schemaorg/schemaorg/issues/2506> ;
-    rdfs:comment """Order cutoff time allows merchants to describe the time after which they will no longer process orders received on that day. For orders processed after cutoff time, one day gets added to the delivery time estimate. This property is expected to be most typically used via the [[ShippingRateSettings]] publication pattern. The time is indicated using the ISO-8601 Time format, e.g. "23:30:00-05:00" would represent 6:30 pm Eastern Standard Time (EST) which is 5 hours behind Coordinated Universal Time (UTC).""" .
+    rdfs:comment "Order cutoff time allows merchants to describe the time after which they will no longer process orders received on that day. For orders processed after cutoff time, one day gets added to the delivery time estimate. This property is expected to be most typically used via the [[ShippingRateSettings]] publication pattern. The time is indicated using the ISO-8601 Time format, e.g. \"23:30:00-05:00\" would represent 6:30 pm Eastern Standard Time (EST) which is 5 hours behind Coordinated Universal Time (UTC)." .
 
 :deliveryTime a rdf:Property ;
     rdfs:label "deliveryTime" ;
-    :category "issue-2506" ;
     :domainIncludes :DeliveryTimeSettings,
         :OfferShippingDetails ;
     :isPartOf <http://pending.schema.org> ;
@@ -115,7 +106,6 @@ or Fast and expensive: $15 in 1-2 days
 
 :doesNotShip a rdf:Property ;
     rdfs:label "doesNotShip" ;
-    :category "issue-2506" ;
     :domainIncludes :OfferShippingDetails,
         :ShippingRateSettings ;
     :isPartOf <http://pending.schema.org> ;
@@ -125,7 +115,6 @@ or Fast and expensive: $15 in 1-2 days
 
 :freeShippingThreshold a rdf:Property ;
     rdfs:label "freeShippingThreshold" ;
-    :category "issue-2506" ;
     :domainIncludes :ShippingRateSettings ;
     :isPartOf <http://pending.schema.org> ;
     :rangeIncludes :DeliveryChargeSpecification,
@@ -135,7 +124,6 @@ or Fast and expensive: $15 in 1-2 days
 
 :handlingTime a rdf:Property ;
     rdfs:label "handlingTime" ;
-    :category "issue-2506" ;
     :domainIncludes :ShippingDeliveryTime ;
     :isPartOf <http://pending.schema.org> ;
     :rangeIncludes :QuantitativeValue ;
@@ -144,7 +132,6 @@ or Fast and expensive: $15 in 1-2 days
 
 :isUnlabelledFallback a rdf:Property ;
     rdfs:label "isUnlabelledFallback" ;
-    :category "issue-2506" ;
     :domainIncludes :DeliveryTimeSettings,
         :ShippingRateSettings ;
     :isPartOf <http://pending.schema.org> ;
@@ -153,13 +140,11 @@ or Fast and expensive: $15 in 1-2 days
     rdfs:comment "This can be marked 'true' to indicate that some published [[DeliveryTimeSettings]] or [[ShippingRateSettings]] are intended to apply to all [[OfferShippingDetails]] published by the same merchant, when referenced by a [[shippingSettingsLink]] in those settings. It is not meaningful to use a 'true' value for this property alongside a transitTimeLabel (for [[DeliveryTimeSettings]]) or shippingLabel (for [[ShippingRateSettings]]), since this property is for use with unlabelled settings." .
 
 :postalCode a rdf:Property ;
-    :category "issue-2506" ;
     :domainIncludes :DefinedRegion ;
     :source <https://github.com/schemaorg/schemaorg/issues/2506> .
 
 :postalCodeBegin a rdf:Property ;
     rdfs:label "postalCodeBegin" ;
-    :category "issue-2506" ;
     :domainIncludes :PostalCodeRangeSpecification ;
     :isPartOf <http://pending.schema.org> ;
     :rangeIncludes :Text ;
@@ -168,7 +153,6 @@ or Fast and expensive: $15 in 1-2 days
 
 :postalCodeEnd a rdf:Property ;
     rdfs:label "postalCodeEnd" ;
-    :category "issue-2506" ;
     :domainIncludes :PostalCodeRangeSpecification ;
     :isPartOf <http://pending.schema.org> ;
     :rangeIncludes :Text ;
@@ -177,7 +161,6 @@ or Fast and expensive: $15 in 1-2 days
 
 :postalCodePrefix a rdf:Property ;
     rdfs:label "postalCodePrefix" ;
-    :category "issue-2506" ;
     :domainIncludes :DefinedRegion ;
     :isPartOf <http://pending.schema.org> ;
     :rangeIncludes :Text ;
@@ -186,7 +169,6 @@ or Fast and expensive: $15 in 1-2 days
 
 :postalCodeRange a rdf:Property ;
     rdfs:label "postalCodeRange" ;
-    :category "issue-2506" ;
     :domainIncludes :DefinedRegion ;
     :isPartOf <http://pending.schema.org> ;
     :rangeIncludes :PostalCodeRangeSpecification ;
@@ -195,7 +177,6 @@ or Fast and expensive: $15 in 1-2 days
 
 :shippingDestination a rdf:Property ;
     rdfs:label "shippingDestination" ;
-    :category "issue-2506" ;
     :domainIncludes :DeliveryTimeSettings,
         :OfferShippingDetails,
         :ShippingRateSettings ;
@@ -206,7 +187,6 @@ or Fast and expensive: $15 in 1-2 days
 
 :shippingDetails a rdf:Property ;
     rdfs:label "shippingDetails" ;
-    :category "issue-2506" ;
     :domainIncludes :Offer ;
     :isPartOf <http://pending.schema.org> ;
     :rangeIncludes :OfferShippingDetails ;
@@ -215,7 +195,6 @@ or Fast and expensive: $15 in 1-2 days
 
 :shippingLabel a rdf:Property ;
     rdfs:label "shippingLabel" ;
-    :category "issue-2506" ;
     :domainIncludes :OfferShippingDetails,
         :ShippingRateSettings ;
     :isPartOf <http://pending.schema.org> ;
@@ -225,7 +204,6 @@ or Fast and expensive: $15 in 1-2 days
 
 :shippingRate a rdf:Property ;
     rdfs:label "shippingRate" ;
-    :category "issue-2506" ;
     :domainIncludes :OfferShippingDetails,
         :ShippingRateSettings ;
     :isPartOf <http://pending.schema.org> ;
@@ -235,7 +213,6 @@ or Fast and expensive: $15 in 1-2 days
 
 :shippingSettingsLink a rdf:Property ;
     rdfs:label "shippingSettingsLink" ;
-    :category "issue-2506" ;
     :domainIncludes :OfferShippingDetails ;
     :isPartOf <http://pending.schema.org> ;
     :rangeIncludes :URL ;
@@ -244,7 +221,6 @@ or Fast and expensive: $15 in 1-2 days
 
 :transitTime a rdf:Property ;
     rdfs:label "transitTime" ;
-    :category "issue-2506" ;
     :domainIncludes :ShippingDeliveryTime ;
     :isPartOf <http://pending.schema.org> ;
     :rangeIncludes :QuantitativeValue ;
@@ -253,10 +229,10 @@ or Fast and expensive: $15 in 1-2 days
 
 :transitTimeLabel a rdf:Property ;
     rdfs:label "transitTimeLabel" ;
-    :category "issue-2506" ;
     :domainIncludes :DeliveryTimeSettings,
         :OfferShippingDetails ;
     :isPartOf <http://pending.schema.org> ;
     :rangeIncludes :Text ;
     :source <https://github.com/schemaorg/schemaorg/issues/2506> ;
     rdfs:comment "Label to match an [[OfferShippingDetails]] with a [[DeliveryTimeSettings]] (within the context of a [[shippingSettingsLink]] cross-reference)." .
+

--- a/data/ext/pending/issue-2514.ttl
+++ b/data/ext/pending/issue-2514.ttl
@@ -1,10 +1,11 @@
 @prefix : <http://schema.org/> .
 @prefix rdf: <http://www.w3.org/1999/02/22-rdf-syntax-ns#> .
 @prefix rdfs: <http://www.w3.org/2000/01/rdf-schema#> .
+@prefix xml: <http://www.w3.org/XML/1998/namespace> .
+@prefix xsd: <http://www.w3.org/2001/XMLSchema#> .
 
 :announcementLocation a rdf:Property ;
     rdfs:label "announcementLocation" ;
-    :category "issue-2514" ;
     :domainIncludes :SpecialAnnouncement ;
     :isPartOf <http://pending.schema.org> ;
     :rangeIncludes :CivicStructure,

--- a/data/ext/pending/issue-2521.ttl
+++ b/data/ext/pending/issue-2521.ttl
@@ -1,10 +1,11 @@
 @prefix : <http://schema.org/> .
 @prefix rdf: <http://www.w3.org/1999/02/22-rdf-syntax-ns#> .
 @prefix rdfs: <http://www.w3.org/2000/01/rdf-schema#> .
+@prefix xml: <http://www.w3.org/XML/1998/namespace> .
+@prefix xsd: <http://www.w3.org/2001/XMLSchema#> .
 
 :CDCPMDRecord a rdfs:Class ;
     rdfs:label "CDCPMDRecord" ;
-    :category "issue-2521" ;
     :isPartOf <http://pending.schema.org> ;
     :source <https://github.com/schemaorg/schemaorg/issues/2521> ;
     rdfs:comment """A CDCPMDRecord is a data structure representing a record in a CDC tabular data format
@@ -15,7 +16,6 @@
 
 :cvdCollectionDate a rdf:Property ;
     rdfs:label "cvdCollectionDate" ;
-    :category "issue-2521" ;
     :domainIncludes :CDCPMDRecord ;
     :isPartOf <http://pending.schema.org> ;
     :rangeIncludes :DateTime,
@@ -25,7 +25,6 @@
 
 :cvdFacilityCounty a rdf:Property ;
     rdfs:label "cvdFacilityCounty" ;
-    :category "issue-2521" ;
     :domainIncludes :CDCPMDRecord ;
     :isPartOf <http://pending.schema.org> ;
     :rangeIncludes :Text ;
@@ -34,7 +33,6 @@
 
 :cvdFacilityId a rdf:Property ;
     rdfs:label "cvdFacilityId" ;
-    :category "issue-2521" ;
     :domainIncludes :CDCPMDRecord ;
     :isPartOf <http://pending.schema.org> ;
     :rangeIncludes :Text ;
@@ -43,7 +41,6 @@
 
 :cvdNumBeds a rdf:Property ;
     rdfs:label "cvdNumBeds" ;
-    :category "issue-2521" ;
     :domainIncludes :CDCPMDRecord ;
     :isPartOf <http://pending.schema.org> ;
     :rangeIncludes :Number ;
@@ -52,7 +49,6 @@
 
 :cvdNumBedsOcc a rdf:Property ;
     rdfs:label "cvdNumBedsOcc" ;
-    :category "issue-2521" ;
     :domainIncludes :CDCPMDRecord ;
     :isPartOf <http://pending.schema.org> ;
     :rangeIncludes :Number ;
@@ -61,7 +57,6 @@
 
 :cvdNumC19Died a rdf:Property ;
     rdfs:label "cvdNumC19Died" ;
-    :category "issue-2521" ;
     :domainIncludes :CDCPMDRecord ;
     :isPartOf <http://pending.schema.org> ;
     :rangeIncludes :Number ;
@@ -70,7 +65,6 @@
 
 :cvdNumC19HOPats a rdf:Property ;
     rdfs:label "cvdNumC19HOPats" ;
-    :category "issue-2521" ;
     :domainIncludes :CDCPMDRecord ;
     :isPartOf <http://pending.schema.org> ;
     :rangeIncludes :Number ;
@@ -79,7 +73,6 @@
 
 :cvdNumC19HospPats a rdf:Property ;
     rdfs:label "cvdNumC19HospPats" ;
-    :category "issue-2521" ;
     :domainIncludes :CDCPMDRecord ;
     :isPartOf <http://pending.schema.org> ;
     :rangeIncludes :Number ;
@@ -88,7 +81,6 @@
 
 :cvdNumC19MechVentPats a rdf:Property ;
     rdfs:label "cvdNumC19MechVentPats" ;
-    :category "issue-2521" ;
     :domainIncludes :CDCPMDRecord ;
     :isPartOf <http://pending.schema.org> ;
     :rangeIncludes :Number ;
@@ -97,7 +89,6 @@
 
 :cvdNumC19OFMechVentPats a rdf:Property ;
     rdfs:label "cvdNumC19OFMechVentPats" ;
-    :category "issue-2521" ;
     :domainIncludes :CDCPMDRecord ;
     :isPartOf <http://pending.schema.org> ;
     :rangeIncludes :Number ;
@@ -106,7 +97,6 @@
 
 :cvdNumC19OverflowPats a rdf:Property ;
     rdfs:label "cvdNumC19OverflowPats" ;
-    :category "issue-2521" ;
     :domainIncludes :CDCPMDRecord ;
     :isPartOf <http://pending.schema.org> ;
     :rangeIncludes :Number ;
@@ -115,7 +105,6 @@
 
 :cvdNumICUBeds a rdf:Property ;
     rdfs:label "cvdNumICUBeds" ;
-    :category "issue-2521" ;
     :domainIncludes :CDCPMDRecord ;
     :isPartOf <http://pending.schema.org> ;
     :rangeIncludes :Number ;
@@ -124,7 +113,6 @@
 
 :cvdNumICUBedsOcc a rdf:Property ;
     rdfs:label "cvdNumICUBedsOcc" ;
-    :category "issue-2521" ;
     :domainIncludes :CDCPMDRecord ;
     :isPartOf <http://pending.schema.org> ;
     :rangeIncludes :Number ;
@@ -133,7 +121,6 @@
 
 :cvdNumTotBeds a rdf:Property ;
     rdfs:label "cvdNumTotBeds" ;
-    :category "issue-2521" ;
     :domainIncludes :CDCPMDRecord ;
     :isPartOf <http://pending.schema.org> ;
     :rangeIncludes :Number ;
@@ -142,7 +129,6 @@
 
 :cvdNumVent a rdf:Property ;
     rdfs:label "cvdNumVent" ;
-    :category "issue-2521" ;
     :domainIncludes :CDCPMDRecord ;
     :isPartOf <http://pending.schema.org> ;
     :rangeIncludes :Number ;
@@ -151,7 +137,6 @@
 
 :cvdNumVentUse a rdf:Property ;
     rdfs:label "cvdNumVentUse" ;
-    :category "issue-2521" ;
     :domainIncludes :CDCPMDRecord ;
     :isPartOf <http://pending.schema.org> ;
     :rangeIncludes :Number ;
@@ -159,13 +144,11 @@
     rdfs:comment "numventuse - MECHANICAL VENTILATORS IN USE: Total number of ventilators in use." .
 
 :datePosted a rdf:Property ;
-    :category "issue-2521" ;
     :domainIncludes :CDCPMDRecord ;
     :source <https://github.com/schemaorg/schemaorg/issues/2521> .
 
 :healthcareReportingData a rdf:Property ;
     rdfs:label "healthcareReportingData" ;
-    :category "issue-2521" ;
     :domainIncludes :Hospital ;
     :isPartOf <http://pending.schema.org> ;
     :rangeIncludes :CDCPMDRecord,

--- a/data/ext/pending/issue-2526.ttl
+++ b/data/ext/pending/issue-2526.ttl
@@ -1,9 +1,11 @@
 @prefix : <http://schema.org/> .
+@prefix rdf: <http://www.w3.org/1999/02/22-rdf-syntax-ns#> .
 @prefix rdfs: <http://www.w3.org/2000/01/rdf-schema#> .
+@prefix xml: <http://www.w3.org/XML/1998/namespace> .
+@prefix xsd: <http://www.w3.org/2001/XMLSchema#> .
 
 :Hackathon a rdfs:Class ;
     rdfs:label "Hackathon" ;
-    :category "issue-2526" ;
     :isPartOf <http://pending.schema.org> ;
     :source <https://github.com/schemaorg/schemaorg/issues/2526> ;
     rdfs:comment "A [hackathon](https://en.wikipedia.org/wiki/Hackathon) event." ;

--- a/data/ext/pending/issue-2534.ttl
+++ b/data/ext/pending/issue-2534.ttl
@@ -1,10 +1,11 @@
 @prefix : <http://schema.org/> .
 @prefix rdf: <http://www.w3.org/1999/02/22-rdf-syntax-ns#> .
 @prefix rdfs: <http://www.w3.org/2000/01/rdf-schema#> .
+@prefix xml: <http://www.w3.org/XML/1998/namespace> .
+@prefix xsd: <http://www.w3.org/2001/XMLSchema#> .
 
 :GovernmentBenefitsType a rdfs:Class ;
     rdfs:label "GovernmentBenefitsType" ;
-    :category "issue-2534" ;
     :isPartOf <http://pending.schema.org> ;
     :source <https://github.com/schemaorg/schemaorg/issues/2534> ;
     rdfs:comment "GovernmentBenefitsType enumerates several kinds of government benefits to support the COVID-19 situation. Note that this structure may not capture all benefits offered." ;
@@ -12,63 +13,54 @@
 
 :BasicIncome a :GovernmentBenefitsType ;
     rdfs:label "BasicIncome" ;
-    :category "issue-2534" ;
     :isPartOf <http://pending.schema.org> ;
     :source <https://github.com/schemaorg/schemaorg/issues/2534> ;
     rdfs:comment "BasicIncome: this is a benefit for basic income." .
 
 :BusinessSupport a :GovernmentBenefitsType ;
     rdfs:label "BusinessSupport" ;
-    :category "issue-2534" ;
     :isPartOf <http://pending.schema.org> ;
     :source <https://github.com/schemaorg/schemaorg/issues/2534> ;
     rdfs:comment "BusinessSupport: this is a benefit for supporting businesses." .
 
 :DisabilitySupport a :GovernmentBenefitsType ;
     rdfs:label "DisabilitySupport" ;
-    :category "issue-2534" ;
     :isPartOf <http://pending.schema.org> ;
     :source <https://github.com/schemaorg/schemaorg/issues/2534> ;
     rdfs:comment "DisabilitySupport: this is a benefit for disability support." .
 
 :HealthCare a :GovernmentBenefitsType ;
     rdfs:label "HealthCare" ;
-    :category "issue-2534" ;
     :isPartOf <http://pending.schema.org> ;
     :source <https://github.com/schemaorg/schemaorg/issues/2534> ;
     rdfs:comment "HealthCare: this is a benefit for health care." .
 
 :OneTimePayments a :GovernmentBenefitsType ;
     rdfs:label "OneTimePayments" ;
-    :category "issue-2534" ;
     :isPartOf <http://pending.schema.org> ;
     :source <https://github.com/schemaorg/schemaorg/issues/2534> ;
     rdfs:comment "OneTimePayments: this is a benefit for one-time payments for individuals." .
 
 :PaidLeave a :GovernmentBenefitsType ;
     rdfs:label "PaidLeave" ;
-    :category "issue-2534" ;
     :isPartOf <http://pending.schema.org> ;
     :source <https://github.com/schemaorg/schemaorg/issues/2534> ;
     rdfs:comment "PaidLeave: this is a benefit for paid leave." .
 
 :ParentalSupport a :GovernmentBenefitsType ;
     rdfs:label "ParentalSupport" ;
-    :category "issue-2534" ;
     :isPartOf <http://pending.schema.org> ;
     :source <https://github.com/schemaorg/schemaorg/issues/2534> ;
     rdfs:comment "ParentalSupport: this is a benefit for parental support." .
 
 :UnemploymentSupport a :GovernmentBenefitsType ;
     rdfs:label "UnemploymentSupport" ;
-    :category "issue-2534" ;
     :isPartOf <http://pending.schema.org> ;
     :source <https://github.com/schemaorg/schemaorg/issues/2534> ;
     rdfs:comment "UnemploymentSupport: this is a benefit for unemployment support." .
 
 :governmentBenefitsInfo a rdf:Property ;
     rdfs:label "governmentBenefitsInfo" ;
-    :category "issue-2534" ;
     :domainIncludes :SpecialAnnouncement ;
     :isPartOf <http://pending.schema.org> ;
     :rangeIncludes :GovernmentService ;
@@ -83,7 +75,6 @@
 
 :jurisdiction a rdf:Property ;
     rdfs:label "jurisdiction" ;
-    :category "issue-2534" ;
     :domainIncludes :GovernmentService,
         :Legislation ;
     :isPartOf <http://pending.schema.org> ;

--- a/data/ext/pending/issue-2543.ttl
+++ b/data/ext/pending/issue-2543.ttl
@@ -1,10 +1,11 @@
 @prefix : <http://schema.org/> .
 @prefix rdf: <http://www.w3.org/1999/02/22-rdf-syntax-ns#> .
 @prefix rdfs: <http://www.w3.org/2000/01/rdf-schema#> .
+@prefix xml: <http://www.w3.org/XML/1998/namespace> .
+@prefix xsd: <http://www.w3.org/2001/XMLSchema#> .
 
 :NLNonprofitType a rdfs:Class ;
     rdfs:label "NLNonprofitType" ;
-    :category "issue-2543" ;
     :isPartOf <http://pending.schema.org> ;
     :source <https://github.com/schemaorg/schemaorg/issues/2543> ;
     rdfs:comment "NLNonprofitType: Non-profit organization type originating from the Netherlands." ;
@@ -12,7 +13,6 @@
 
 :NonprofitType a rdfs:Class ;
     rdfs:label "NonprofitType" ;
-    :category "issue-2543" ;
     :isPartOf <http://pending.schema.org> ;
     :source <https://github.com/schemaorg/schemaorg/issues/2543> ;
     rdfs:comment "NonprofitType enumerates several kinds of official non-profit types of which a non-profit organization can be." ;
@@ -20,7 +20,6 @@
 
 :UKNonprofitType a rdfs:Class ;
     rdfs:label "UKNonprofitType" ;
-    :category "issue-2543" ;
     :isPartOf <http://pending.schema.org> ;
     :source <https://github.com/schemaorg/schemaorg/issues/2543> ;
     rdfs:comment "UKNonprofitType: Non-profit organization type originating from the United Kingdom." ;
@@ -28,7 +27,6 @@
 
 :USNonprofitType a rdfs:Class ;
     rdfs:label "USNonprofitType" ;
-    :category "issue-2543" ;
     :isPartOf <http://pending.schema.org> ;
     :source <https://github.com/schemaorg/schemaorg/issues/2543> ;
     rdfs:comment "USNonprofitType: Non-profit organization type originating from the United States." ;
@@ -36,301 +34,258 @@
 
 :CharitableIncorporatedOrganization a :UKNonprofitType ;
     rdfs:label "CharitableIncorporatedOrganization" ;
-    :category "issue-2543" ;
     :isPartOf <http://pending.schema.org> ;
     :source <https://github.com/schemaorg/schemaorg/issues/2543> ;
     rdfs:comment "CharitableIncorporatedOrganization: Non-profit type referring to a Charitable Incorporated Organization (UK)." .
 
 :LimitedByGuaranteeCharity a :UKNonprofitType ;
     rdfs:label "LimitedByGuaranteeCharity" ;
-    :category "issue-2543" ;
     :isPartOf <http://pending.schema.org> ;
     :source <https://github.com/schemaorg/schemaorg/issues/2543> ;
     rdfs:comment "LimitedByGuaranteeCharity: Non-profit type referring to a charitable company that is limited by guarantee (UK)." .
 
 :Nonprofit501a a :USNonprofitType ;
     rdfs:label "Nonprofit501a" ;
-    :category "issue-2543" ;
     :isPartOf <http://pending.schema.org> ;
     :source <https://github.com/schemaorg/schemaorg/issues/2543> ;
     rdfs:comment "Nonprofit501a: Non-profit type referring to Farmers’ Cooperative Associations." .
 
 :Nonprofit501c1 a :USNonprofitType ;
     rdfs:label "Nonprofit501c1" ;
-    :category "issue-2543" ;
     :isPartOf <http://pending.schema.org> ;
     :source <https://github.com/schemaorg/schemaorg/issues/2543> ;
     rdfs:comment "Nonprofit501c1: Non-profit type referring to Corporations Organized Under Act of Congress, including Federal Credit Unions and National Farm Loan Associations." .
 
 :Nonprofit501c10 a :USNonprofitType ;
     rdfs:label "Nonprofit501c10" ;
-    :category "issue-2543" ;
     :isPartOf <http://pending.schema.org> ;
     :source <https://github.com/schemaorg/schemaorg/issues/2543> ;
     rdfs:comment "Nonprofit501c10: Non-profit type referring to Domestic Fraternal Societies and Associations." .
 
 :Nonprofit501c11 a :USNonprofitType ;
     rdfs:label "Nonprofit501c11" ;
-    :category "issue-2543" ;
     :isPartOf <http://pending.schema.org> ;
     :source <https://github.com/schemaorg/schemaorg/issues/2543> ;
     rdfs:comment "Nonprofit501c11: Non-profit type referring to Teachers' Retirement Fund Associations." .
 
 :Nonprofit501c12 a :USNonprofitType ;
     rdfs:label "Nonprofit501c12" ;
-    :category "issue-2543" ;
     :isPartOf <http://pending.schema.org> ;
     :source <https://github.com/schemaorg/schemaorg/issues/2543> ;
     rdfs:comment "Nonprofit501c12: Non-profit type referring to Benevolent Life Insurance Associations, Mutual Ditch or Irrigation Companies, Mutual or Cooperative Telephone Companies." .
 
 :Nonprofit501c13 a :USNonprofitType ;
     rdfs:label "Nonprofit501c13" ;
-    :category "issue-2543" ;
     :isPartOf <http://pending.schema.org> ;
     :source <https://github.com/schemaorg/schemaorg/issues/2543> ;
     rdfs:comment "Nonprofit501c13: Non-profit type referring to Cemetery Companies." .
 
 :Nonprofit501c14 a :USNonprofitType ;
     rdfs:label "Nonprofit501c14" ;
-    :category "issue-2543" ;
     :isPartOf <http://pending.schema.org> ;
     :source <https://github.com/schemaorg/schemaorg/issues/2543> ;
     rdfs:comment "Nonprofit501c14: Non-profit type referring to State-Chartered Credit Unions, Mutual Reserve Funds." .
 
 :Nonprofit501c15 a :USNonprofitType ;
     rdfs:label "Nonprofit501c15" ;
-    :category "issue-2543" ;
     :isPartOf <http://pending.schema.org> ;
     :source <https://github.com/schemaorg/schemaorg/issues/2543> ;
     rdfs:comment "Nonprofit501c15: Non-profit type referring to Mutual Insurance Companies or Associations." .
 
 :Nonprofit501c16 a :USNonprofitType ;
     rdfs:label "Nonprofit501c16" ;
-    :category "issue-2543" ;
     :isPartOf <http://pending.schema.org> ;
     :source <https://github.com/schemaorg/schemaorg/issues/2543> ;
     rdfs:comment "Nonprofit501c16: Non-profit type referring to Cooperative Organizations to Finance Crop Operations." .
 
 :Nonprofit501c17 a :USNonprofitType ;
     rdfs:label "Nonprofit501c17" ;
-    :category "issue-2543" ;
     :isPartOf <http://pending.schema.org> ;
     :source <https://github.com/schemaorg/schemaorg/issues/2543> ;
     rdfs:comment "Nonprofit501c17: Non-profit type referring to Supplemental Unemployment Benefit Trusts." .
 
 :Nonprofit501c18 a :USNonprofitType ;
     rdfs:label "Nonprofit501c18" ;
-    :category "issue-2543" ;
     :isPartOf <http://pending.schema.org> ;
     :source <https://github.com/schemaorg/schemaorg/issues/2543> ;
     rdfs:comment "Nonprofit501c18: Non-profit type referring to Employee Funded Pension Trust (created before 25 June 1959)." .
 
 :Nonprofit501c19 a :USNonprofitType ;
     rdfs:label "Nonprofit501c19" ;
-    :category "issue-2543" ;
     :isPartOf <http://pending.schema.org> ;
     :source <https://github.com/schemaorg/schemaorg/issues/2543> ;
     rdfs:comment "Nonprofit501c19: Non-profit type referring to Post or Organization of Past or Present Members of the Armed Forces." .
 
 :Nonprofit501c2 a :USNonprofitType ;
     rdfs:label "Nonprofit501c2" ;
-    :category "issue-2543" ;
     :isPartOf <http://pending.schema.org> ;
     :source <https://github.com/schemaorg/schemaorg/issues/2543> ;
     rdfs:comment "Nonprofit501c2: Non-profit type referring to Title-holding Corporations for Exempt Organizations." .
 
 :Nonprofit501c20 a :USNonprofitType ;
     rdfs:label "Nonprofit501c20" ;
-    :category "issue-2543" ;
     :isPartOf <http://pending.schema.org> ;
     :source <https://github.com/schemaorg/schemaorg/issues/2543> ;
     rdfs:comment "Nonprofit501c20: Non-profit type referring to Group Legal Services Plan Organizations." .
 
 :Nonprofit501c21 a :USNonprofitType ;
     rdfs:label "Nonprofit501c21" ;
-    :category "issue-2543" ;
     :isPartOf <http://pending.schema.org> ;
     :source <https://github.com/schemaorg/schemaorg/issues/2543> ;
     rdfs:comment "Nonprofit501c21: Non-profit type referring to Black Lung Benefit Trusts." .
 
 :Nonprofit501c22 a :USNonprofitType ;
     rdfs:label "Nonprofit501c22" ;
-    :category "issue-2543" ;
     :isPartOf <http://pending.schema.org> ;
     :source <https://github.com/schemaorg/schemaorg/issues/2543> ;
     rdfs:comment "Nonprofit501c22: Non-profit type referring to Withdrawal Liability Payment Funds." .
 
 :Nonprofit501c23 a :USNonprofitType ;
     rdfs:label "Nonprofit501c23" ;
-    :category "issue-2543" ;
     :isPartOf <http://pending.schema.org> ;
     :source <https://github.com/schemaorg/schemaorg/issues/2543> ;
     rdfs:comment "Nonprofit501c23: Non-profit type referring to Veterans Organizations." .
 
 :Nonprofit501c24 a :USNonprofitType ;
     rdfs:label "Nonprofit501c24" ;
-    :category "issue-2543" ;
     :isPartOf <http://pending.schema.org> ;
     :source <https://github.com/schemaorg/schemaorg/issues/2543> ;
     rdfs:comment "Nonprofit501c24: Non-profit type referring to Section 4049 ERISA Trusts." .
 
 :Nonprofit501c25 a :USNonprofitType ;
     rdfs:label "Nonprofit501c25" ;
-    :category "issue-2543" ;
     :isPartOf <http://pending.schema.org> ;
     :source <https://github.com/schemaorg/schemaorg/issues/2543> ;
     rdfs:comment "Nonprofit501c25: Non-profit type referring to Real Property Title-Holding Corporations or Trusts with Multiple Parents." .
 
 :Nonprofit501c26 a :USNonprofitType ;
     rdfs:label "Nonprofit501c26" ;
-    :category "issue-2543" ;
     :isPartOf <http://pending.schema.org> ;
     :source <https://github.com/schemaorg/schemaorg/issues/2543> ;
     rdfs:comment "Nonprofit501c26: Non-profit type referring to State-Sponsored Organizations Providing Health Coverage for High-Risk Individuals." .
 
 :Nonprofit501c27 a :USNonprofitType ;
     rdfs:label "Nonprofit501c27" ;
-    :category "issue-2543" ;
     :isPartOf <http://pending.schema.org> ;
     :source <https://github.com/schemaorg/schemaorg/issues/2543> ;
     rdfs:comment "Nonprofit501c27: Non-profit type referring to State-Sponsored Workers' Compensation Reinsurance Organizations." .
 
 :Nonprofit501c28 a :USNonprofitType ;
     rdfs:label "Nonprofit501c28" ;
-    :category "issue-2543" ;
     :isPartOf <http://pending.schema.org> ;
     :source <https://github.com/schemaorg/schemaorg/issues/2543> ;
     rdfs:comment "Nonprofit501c28: Non-profit type referring to National Railroad Retirement Investment Trusts." .
 
 :Nonprofit501c3 a :USNonprofitType ;
     rdfs:label "Nonprofit501c3" ;
-    :category "issue-2543" ;
     :isPartOf <http://pending.schema.org> ;
     :source <https://github.com/schemaorg/schemaorg/issues/2543> ;
     rdfs:comment "Nonprofit501c3: Non-profit type referring to Religious, Educational, Charitable, Scientific, Literary, Testing for Public Safety, to Foster National or International Amateur Sports Competition, or Prevention of Cruelty to Children or Animals Organizations." .
 
 :Nonprofit501c4 a :USNonprofitType ;
     rdfs:label "Nonprofit501c4" ;
-    :category "issue-2543" ;
     :isPartOf <http://pending.schema.org> ;
     :source <https://github.com/schemaorg/schemaorg/issues/2543> ;
     rdfs:comment "Nonprofit501c4: Non-profit type referring to Civic Leagues, Social Welfare Organizations, and Local Associations of Employees." .
 
 :Nonprofit501c5 a :USNonprofitType ;
     rdfs:label "Nonprofit501c5" ;
-    :category "issue-2543" ;
     :isPartOf <http://pending.schema.org> ;
     :source <https://github.com/schemaorg/schemaorg/issues/2543> ;
     rdfs:comment "Nonprofit501c5: Non-profit type referring to Labor, Agricultural and Horticultural Organizations." .
 
 :Nonprofit501c6 a :USNonprofitType ;
     rdfs:label "Nonprofit501c6" ;
-    :category "issue-2543" ;
     :isPartOf <http://pending.schema.org> ;
     :source <https://github.com/schemaorg/schemaorg/issues/2543> ;
     rdfs:comment "Nonprofit501c6: Non-profit type referring to Business Leagues, Chambers of Commerce, Real Estate Boards." .
 
 :Nonprofit501c7 a :USNonprofitType ;
     rdfs:label "Nonprofit501c7" ;
-    :category "issue-2543" ;
     :isPartOf <http://pending.schema.org> ;
     :source <https://github.com/schemaorg/schemaorg/issues/2543> ;
     rdfs:comment "Nonprofit501c7: Non-profit type referring to Social and Recreational Clubs." .
 
 :Nonprofit501c8 a :USNonprofitType ;
     rdfs:label "Nonprofit501c8" ;
-    :category "issue-2543" ;
     :isPartOf <http://pending.schema.org> ;
     :source <https://github.com/schemaorg/schemaorg/issues/2543> ;
     rdfs:comment "Nonprofit501c8: Non-profit type referring to Fraternal Beneficiary Societies and Associations." .
 
 :Nonprofit501c9 a :USNonprofitType ;
     rdfs:label "Nonprofit501c9" ;
-    :category "issue-2543" ;
     :isPartOf <http://pending.schema.org> ;
     :source <https://github.com/schemaorg/schemaorg/issues/2543> ;
     rdfs:comment "Nonprofit501c9: Non-profit type referring to Voluntary Employee Beneficiary Associations." .
 
 :Nonprofit501d a :USNonprofitType ;
     rdfs:label "Nonprofit501d" ;
-    :category "issue-2543" ;
     :isPartOf <http://pending.schema.org> ;
     :source <https://github.com/schemaorg/schemaorg/issues/2543> ;
     rdfs:comment "Nonprofit501d: Non-profit type referring to Religious and Apostolic Associations." .
 
 :Nonprofit501e a :USNonprofitType ;
     rdfs:label "Nonprofit501e" ;
-    :category "issue-2543" ;
     :isPartOf <http://pending.schema.org> ;
     :source <https://github.com/schemaorg/schemaorg/issues/2543> ;
     rdfs:comment "Nonprofit501e: Non-profit type referring to Cooperative Hospital Service Organizations." .
 
 :Nonprofit501f a :USNonprofitType ;
     rdfs:label "Nonprofit501f" ;
-    :category "issue-2543" ;
     :isPartOf <http://pending.schema.org> ;
     :source <https://github.com/schemaorg/schemaorg/issues/2543> ;
     rdfs:comment "Nonprofit501f: Non-profit type referring to Cooperative Service Organizations." .
 
 :Nonprofit501k a :USNonprofitType ;
     rdfs:label "Nonprofit501k" ;
-    :category "issue-2543" ;
     :isPartOf <http://pending.schema.org> ;
     :source <https://github.com/schemaorg/schemaorg/issues/2543> ;
     rdfs:comment "Nonprofit501k: Non-profit type referring to Child Care Organizations." .
 
 :Nonprofit501n a :USNonprofitType ;
     rdfs:label "Nonprofit501n" ;
-    :category "issue-2543" ;
     :isPartOf <http://pending.schema.org> ;
     :source <https://github.com/schemaorg/schemaorg/issues/2543> ;
     rdfs:comment "Nonprofit501n: Non-profit type referring to Charitable Risk Pools." .
 
 :Nonprofit501q a :USNonprofitType ;
     rdfs:label "Nonprofit501q" ;
-    :category "issue-2543" ;
     :isPartOf <http://pending.schema.org> ;
     :source <https://github.com/schemaorg/schemaorg/issues/2543> ;
     rdfs:comment "Nonprofit501q: Non-profit type referring to Credit Counseling Organizations." .
 
 :Nonprofit527 a :USNonprofitType ;
     rdfs:label "Nonprofit527" ;
-    :category "issue-2543" ;
     :isPartOf <http://pending.schema.org> ;
     :source <https://github.com/schemaorg/schemaorg/issues/2543> ;
     rdfs:comment "Nonprofit527: Non-profit type referring to Political organizations." .
 
 :NonprofitANBI a :NLNonprofitType ;
     rdfs:label "NonprofitANBI" ;
-    :category "issue-2543" ;
     :isPartOf <http://pending.schema.org> ;
     :source <https://github.com/schemaorg/schemaorg/issues/2543> ;
     rdfs:comment "NonprofitANBI: Non-profit type referring to a Public Benefit Organization (NL)." .
 
 :NonprofitSBBI a :NLNonprofitType ;
     rdfs:label "NonprofitSBBI" ;
-    :category "issue-2543" ;
     :isPartOf <http://pending.schema.org> ;
     :source <https://github.com/schemaorg/schemaorg/issues/2543> ;
     rdfs:comment "NonprofitSBBI: Non-profit type referring to a Social Interest Promoting Institution (NL)." .
 
 :UKTrust a :UKNonprofitType ;
     rdfs:label "UKTrust" ;
-    :category "issue-2543" ;
     :isPartOf <http://pending.schema.org> ;
     :source <https://github.com/schemaorg/schemaorg/issues/2543> ;
     rdfs:comment "UKTrust: Non-profit type referring to a UK trust." .
 
 :UnincorporatedAssociationCharity a :UKNonprofitType ;
     rdfs:label "UnincorporatedAssociationCharity" ;
-    :category "issue-2543" ;
     :isPartOf <http://pending.schema.org> ;
     :source <https://github.com/schemaorg/schemaorg/issues/2543> ;
     rdfs:comment "UnincorporatedAssociationCharity: Non-profit type referring to a charitable company that is not incorporated (UK)." .
 
 :nonprofitStatus a rdf:Property ;
     rdfs:label "nonprofitStatus" ;
-    :category "issue-2543" ;
     :domainIncludes :Organization ;
     :isPartOf <http://pending.schema.org> ;
     :rangeIncludes :NonprofitType ;

--- a/data/ext/pending/issue-2599.ttl
+++ b/data/ext/pending/issue-2599.ttl
@@ -1,13 +1,14 @@
 @prefix : <http://schema.org/> .
 @prefix rdf: <http://www.w3.org/1999/02/22-rdf-syntax-ns#> .
 @prefix rdfs: <http://www.w3.org/2000/01/rdf-schema#> .
+@prefix xml: <http://www.w3.org/XML/1998/namespace> .
+@prefix xsd: <http://www.w3.org/2001/XMLSchema#> .
 
 :byMonthWeek a rdf:Property ;
     rdfs:label "byMonthWeek" ;
-    :category "issue-2599" ;
     :domainIncludes :Schedule ;
     :isPartOf <http://pending.schema.org> ;
     :rangeIncludes :Integer ;
     :source <https://github.com/schemaorg/schemaorg/issues/2599> ;
     rdfs:comment "Defines the week(s) of the month on which a recurring Event takes place. Specified as an Integer between 1-5. For clarity, byMonthWeek is best used in conjunction with byDay to indicate concepts like the first and third Mondays of a month." .
-    
+

--- a/data/ext/pending/issue-2605.ttl
+++ b/data/ext/pending/issue-2605.ttl
@@ -1,26 +1,16 @@
 @prefix : <http://schema.org/> .
 @prefix rdf: <http://www.w3.org/1999/02/22-rdf-syntax-ns#> .
 @prefix rdfs: <http://www.w3.org/2000/01/rdf-schema#> .
+@prefix xml: <http://www.w3.org/XML/1998/namespace> .
+@prefix xsd: <http://www.w3.org/2001/XMLSchema#> .
 
 :ProductCollection a rdfs:Class ;
     rdfs:label "ProductCollection" ;
-
-    rdfs:subClassOf :Collection ;
-    rdfs:subClassOf :Product ;
-
-    rdfs:comment """A set of products (either [[ProductGroup]]s or specific variants) that are listed together e.g. in an [[Offer]].""" ;
-
-    :category "issue-2597" ;
     :isPartOf <http://pending.schema.org> ;
-    :source <https://github.com/schemaorg/schemaorg/issues/2597> .
-
-# TODO: how to say that something is in such a collection?
-# are we ok with this being a creative work vs a pure data structure i.e. intangible
+    :source <https://github.com/schemaorg/schemaorg/issues/2597> ;
+    rdfs:comment "A set of products (either [[ProductGroup]]s or specific variants) that are listed together e.g. in an [[Offer]]." ;
+    rdfs:subClassOf :Collection,
+        :Product .
 
 :includesObject :domainIncludes :ProductCollection .
 
-# For discussion later,
-# :includesObject :rangeIncludes :Product .
-
-# In ../../schema.ttl core we amended text to accomodate this new term:
-# rdfs:comment "... ... included in an [[Offer]] or [[ProductCollection]]." .

--- a/data/ext/pending/issue-2611.ttl
+++ b/data/ext/pending/issue-2611.ttl
@@ -1,11 +1,13 @@
 @prefix : <http://schema.org/> .
 @prefix rdf: <http://www.w3.org/1999/02/22-rdf-syntax-ns#> .
 @prefix rdfs: <http://www.w3.org/2000/01/rdf-schema#> .
+@prefix xml: <http://www.w3.org/XML/1998/namespace> .
+@prefix xsd: <http://www.w3.org/2001/XMLSchema#> .
 
 :Quiz a rdfs:Class ;
     rdfs:label "Quiz" ;
-    :category "issue-2611" ;
     :isPartOf <http://pending.schema.org> ;
     :source <https://github.com/schemaorg/schemaorg/issues/2611> ;
     rdfs:comment "Quiz: A test of knowledge, skills and abilities." ;
     rdfs:subClassOf :LearningResource .
+

--- a/data/ext/pending/issue-2636.ttl
+++ b/data/ext/pending/issue-2636.ttl
@@ -1,12 +1,15 @@
 @prefix : <http://schema.org/> .
 @prefix rdf: <http://www.w3.org/1999/02/22-rdf-syntax-ns#> .
 @prefix rdfs: <http://www.w3.org/2000/01/rdf-schema#> .
+@prefix xml: <http://www.w3.org/XML/1998/namespace> .
+@prefix xsd: <http://www.w3.org/2001/XMLSchema#> .
 
 :eduQuestionType a rdf:Property ;
     rdfs:label "eduQuestionType" ;
-    :category "issue-2636" ;
-    :domainIncludes :Question, :SolveMathAction ;
+    :domainIncludes :Question,
+        :SolveMathAction ;
     :isPartOf <http://pending.schema.org> ;
     :rangeIncludes :Text ;
     :source <https://github.com/schemaorg/schemaorg/issues/2636> ;
-    rdfs:comment """For questions that are part of learning resources (e.g. Quiz), eduQuestionType indicates the format of question being given. Example: "Multiple choice", "Open ended", "Flashcard".""" .
+    rdfs:comment "For questions that are part of learning resources (e.g. Quiz), eduQuestionType indicates the format of question being given. Example: \"Multiple choice\", \"Open ended\", \"Flashcard\"." .
+

--- a/data/ext/pending/issue-2646.ttl
+++ b/data/ext/pending/issue-2646.ttl
@@ -1,11 +1,13 @@
 @prefix : <http://schema.org/> .
 @prefix rdf: <http://www.w3.org/1999/02/22-rdf-syntax-ns#> .
 @prefix rdfs: <http://www.w3.org/2000/01/rdf-schema#> .
+@prefix xml: <http://www.w3.org/XML/1998/namespace> .
+@prefix xsd: <http://www.w3.org/2001/XMLSchema#> .
 
 :AmpStory a rdfs:Class ;
     rdfs:label "AmpStory" ;
-    :category "issue-2646" ;
     :isPartOf <http://pending.schema.org> ;
     :source <https://github.com/schemaorg/schemaorg/issues/2646> ;
     rdfs:comment "A creative work with a visual storytelling format intended to be viewed online, particularly on mobile devices." ;
     rdfs:subClassOf :CreativeWork .
+

--- a/data/ext/pending/issue-2659.ttl
+++ b/data/ext/pending/issue-2659.ttl
@@ -1,42 +1,22 @@
 @prefix : <http://schema.org/> .
 @prefix rdf: <http://www.w3.org/1999/02/22-rdf-syntax-ns#> .
 @prefix rdfs: <http://www.w3.org/2000/01/rdf-schema#> .
-
-#:EnergyConsumptionDetails a rdfs:Class ;
-#  rdfs:label "EnergyConsumptionDetails" ;
-#  :category "issue-2670" ;
-#  :isPartOf <http://pending.schema.org> ;
-#  rdfs:subClassOf :Intangible ;
-#  :source <https://github.com/schemaorg/schemaorg/issues/2670> ;
-#  rdfs:comment "EnergyConsumptionDetails represents information related to the energy efficiency of a product that consumes energy. The information that can be provided is based on international regulations such as for example [EU directive 2017/1369](https://eur-lex.europa.eu/eli/reg/2017/1369/oj) for energy labeling and the [Energy labeling rule](https://www.ftc.gov/enforcement/rules/rulemaking-regulatory-reform-proceedings/energy-water-use-labeling-consumer) under the Energy Policy and Conservation Act (EPCA) in the US" .
-
-#:hasEnergyConsumptionDetails a rdf:Property ;
-#  rdfs:label "hasEnergyConsumptionDetails" ;
-#  :category "issue-2670" ;
-#  :isPartOf <http://pending.schema.org> ;
-#  :domainIncludes :Product ;
-#  :rangeIncludes :EnergyConsumptionDetails ;
-#  :source <https://github.com/schemaorg/schemaorg/issues/2670> ;
-#  rdfs:comment """Defines the energy efficiency Category (also known as "class" or "rating") for a product according to an international energy efficiency standard""" .
-
-# https://github.com/schemaorg/schemaorg/issues/2659
-
+@prefix xml: <http://www.w3.org/XML/1998/namespace> .
+@prefix xsd: <http://www.w3.org/2001/XMLSchema#> .
 
 :copyrightNotice a rdf:Property ;
-  rdfs:label "copyrightNotice" ;
-  :category "issue-2659" ;
-  :isPartOf <http://pending.schema.org> ;
-  :domainIncludes :CreativeWork ;
-  :rangeIncludes :Text ;
-  :source <https://github.com/schemaorg/schemaorg/issues/2659> ;
-  rdfs:comment """Text of a notice appropriate for describing the copyright aspects of this Creative Work, ideally indicating the owner of the copyright for the Work.""" .
-
-
-  :creditText a rdf:Property ;
-    rdfs:label "creditText" ;
-    :category "issue-2659" ;
-    :isPartOf <http://pending.schema.org> ;
+    rdfs:label "copyrightNotice" ;
     :domainIncludes :CreativeWork ;
+    :isPartOf <http://pending.schema.org> ;
     :rangeIncludes :Text ;
     :source <https://github.com/schemaorg/schemaorg/issues/2659> ;
-    rdfs:comment """Text that can be used to credit person(s) and/or organization(s) associated with a published Creative Work.""" .
+    rdfs:comment "Text of a notice appropriate for describing the copyright aspects of this Creative Work, ideally indicating the owner of the copyright for the Work." .
+
+:creditText a rdf:Property ;
+    rdfs:label "creditText" ;
+    :domainIncludes :CreativeWork ;
+    :isPartOf <http://pending.schema.org> ;
+    :rangeIncludes :Text ;
+    :source <https://github.com/schemaorg/schemaorg/issues/2659> ;
+    rdfs:comment "Text that can be used to credit person(s) and/or organization(s) associated with a published Creative Work." .
+

--- a/data/ext/pending/issue-2665.ttl
+++ b/data/ext/pending/issue-2665.ttl
@@ -1,13 +1,15 @@
 @prefix : <http://schema.org/> .
 @prefix rdf: <http://www.w3.org/1999/02/22-rdf-syntax-ns#> .
 @prefix rdfs: <http://www.w3.org/2000/01/rdf-schema#> .
+@prefix xml: <http://www.w3.org/XML/1998/namespace> .
+@prefix xsd: <http://www.w3.org/2001/XMLSchema#> .
 
 :answerExplanation a rdf:Property ;
     rdfs:label "answerExplanation" ;
-    :category "issue-2636" ;
     :domainIncludes :Answer ;
     :isPartOf <http://pending.schema.org> ;
     :rangeIncludes :Comment,
-      :WebContent ;
+        :WebContent ;
     :source <https://github.com/schemaorg/schemaorg/issues/2636> ;
     rdfs:comment "A step-by-step or full explanation about Answer. Can outline how this Answer was achieved or contain more broad clarification or statement about it. " .
+

--- a/data/ext/pending/issue-2670.ttl
+++ b/data/ext/pending/issue-2670.ttl
@@ -1,154 +1,132 @@
 @prefix : <http://schema.org/> .
 @prefix rdf: <http://www.w3.org/1999/02/22-rdf-syntax-ns#> .
 @prefix rdfs: <http://www.w3.org/2000/01/rdf-schema#> .
-
-
-# TODO: EnergyEfficiencyEnumeration s/r:
-
-# EUEnergyEfficiencyCategory -> EUEnergyEfficiencyEnumeration
-# EnergyStarEnergyEfficiencyCategory -> EnergyStarEnergyEfficiencyEnumeration
-# EnergyEfficiencyCategory -> EnergyEfficiencyEnumeration
-
-:EnergyConsumptionDetails a rdfs:Class ;
-  rdfs:label "EnergyConsumptionDetails" ;
-  :category "issue-2670" ;
-  :isPartOf <http://pending.schema.org> ;
-  rdfs:subClassOf :Intangible ;
-  :source <https://github.com/schemaorg/schemaorg/issues/2670> ;
-  rdfs:comment "EnergyConsumptionDetails represents information related to the energy efficiency of a product that consumes energy. The information that can be provided is based on international regulations such as for example [EU directive 2017/1369](https://eur-lex.europa.eu/eli/reg/2017/1369/oj) for energy labeling and the [Energy labeling rule](https://www.ftc.gov/enforcement/rules/rulemaking-regulatory-reform-proceedings/energy-water-use-labeling-consumer) under the Energy Policy and Conservation Act (EPCA) in the US" .
-
-:hasEnergyConsumptionDetails a rdf:Property ;
-  rdfs:label "hasEnergyConsumptionDetails" ;
-  :category "issue-2670" ;
-  :isPartOf <http://pending.schema.org> ;
-  :domainIncludes :Product ;
-  :rangeIncludes :EnergyConsumptionDetails ;
-  :source <https://github.com/schemaorg/schemaorg/issues/2670> ;
-  rdfs:comment """Defines the energy efficiency Category (also known as "class" or "rating") for a product according to an international energy efficiency standard""" .
-
-:hasEnergyEfficiencyCategory a rdf:Property ;
-  rdfs:label "hasEnergyEfficiencyCategory" ;
-  :category "issue-2670" ;
-  :isPartOf <http://pending.schema.org> ;
-  :domainIncludes :EnergyConsumptionDetails ;
-  :rangeIncludes :EnergyEfficiencyEnumeration ;
-  :source <https://github.com/schemaorg/schemaorg/issues/2670> ;
-  rdfs:comment "Defines the energy efficiency Category (which could be either a rating out of range of values or a yes/no certification) for a product according to an international energy efficiency standard" .
-
-:EnergyEfficiencyEnumeration a rdfs:Class ;
-  rdfs:label "EnergyEfficiencyEnumeration" ;
-  rdfs:subClassOf :Enumeration ;
-  :category "issue-2670" ;
-  :isPartOf <http://pending.schema.org> ;
-  :source <https://github.com/schemaorg/schemaorg/issues/2670> ;
-  rdfs:comment """Enumerates energy efficiency levels (also known as "classes" or "ratings") and certifications that are part of several international energy efficiency standards.""" .
-
-:energyEfficiencyScaleMin a rdf:Property ;
-  rdfs:label "energyEfficiencyScaleMin" ;
-  :category "issue-2670" ;
-  :isPartOf <http://pending.schema.org> ;
-  :domainIncludes :EnergyConsumptionDetails ;
-  :rangeIncludes :EUEnergyEfficiencyEnumeration ;
-  :source <https://github.com/schemaorg/schemaorg/issues/2670> ;
-  rdfs:comment "Specifies the least energy efficient class on the regulated EU energy consumption scale for the product category a product belongs to. For example, energy consumption for televisions placed on the market after January 1, 2020 is scaled from D to A+++." .
-
-:energyEfficiencyScaleMax a rdf:Property ;
-  rdfs:label "energyEfficiencyScaleMax" ;
-  :category "issue-2670" ;
-  :isPartOf <http://pending.schema.org> ;
-  :domainIncludes :EnergyConsumptionDetails ;
-  :rangeIncludes :EUEnergyEfficiencyEnumeration ;
-  :source <https://github.com/schemaorg/schemaorg/issues/2670> ;
-  rdfs:comment "Specifies the most energy efficient class on the regulated EU energy consumption scale for the product category a product belongs to. For example, energy consumption for televisions placed on the market after January 1, 2020 is scaled from D to A+++." .
-
-:EnergyStarEnergyEfficiencyEnumeration a rdfs:Class ;
-  rdfs:label "EnergyStarEnergyEfficiencyEnumeration" ;
-  rdfs:subClassOf :EnergyEfficiencyEnumeration ;
-  :category "issue-2670" ;
-  :isPartOf <http://pending.schema.org> ;
-  :source <https://github.com/schemaorg/schemaorg/issues/2670> ;
-  rdfs:comment "Used to indicate whether a product is EnergyStar certified" .
-
-:EnergyStarCertified a :EnergyStarEnergyEfficiencyEnumeration ;
-  rdfs:label "EnergyStarCertified" ;
-  :category "issue-2670" ;
-  :isPartOf <http://pending.schema.org> ;
-  :source <https://github.com/schemaorg/schemaorg/issues/2670> ;
-  rdfs:comment "Represents EnergyStar certification" .
+@prefix xml: <http://www.w3.org/XML/1998/namespace> .
+@prefix xsd: <http://www.w3.org/2001/XMLSchema#> .
 
 :EUEnergyEfficiencyEnumeration a rdfs:Class ;
-  rdfs:label "EUEnergyEfficiencyEnumeration" ;
-  :category "issue-2670" ;
-  :isPartOf <http://pending.schema.org> ;
-  :source <https://github.com/schemaorg/schemaorg/issues/2670> ;
-  rdfs:comment "Enumerates the EU energy efficiency classes A-G as well as A+, A++, and A+++ as defined in EU directive 2017/1369" ;
-  rdfs:subClassOf :EnergyEfficiencyEnumeration .
+    rdfs:label "EUEnergyEfficiencyEnumeration" ;
+    :isPartOf <http://pending.schema.org> ;
+    :source <https://github.com/schemaorg/schemaorg/issues/2670> ;
+    rdfs:comment "Enumerates the EU energy efficiency classes A-G as well as A+, A++, and A+++ as defined in EU directive 2017/1369" ;
+    rdfs:subClassOf :EnergyEfficiencyEnumeration .
 
-:EUEnergyEfficiencyCategoryG a :EUEnergyEfficiencyEnumeration;
-  rdfs:label "EUEnergyEfficiencyCategoryG" ;
-  :category "issue-2670" ;
-  :isPartOf <http://pending.schema.org> ;
-  :source <https://github.com/schemaorg/schemaorg/issues/2670> ;
-  rdfs:comment "Represents EU Energy Efficiency Class G as defined in EU energy labeling regulations" .
+:EnergyConsumptionDetails a rdfs:Class ;
+    rdfs:label "EnergyConsumptionDetails" ;
+    :isPartOf <http://pending.schema.org> ;
+    :source <https://github.com/schemaorg/schemaorg/issues/2670> ;
+    rdfs:comment "EnergyConsumptionDetails represents information related to the energy efficiency of a product that consumes energy. The information that can be provided is based on international regulations such as for example [EU directive 2017/1369](https://eur-lex.europa.eu/eli/reg/2017/1369/oj) for energy labeling and the [Energy labeling rule](https://www.ftc.gov/enforcement/rules/rulemaking-regulatory-reform-proceedings/energy-water-use-labeling-consumer) under the Energy Policy and Conservation Act (EPCA) in the US" ;
+    rdfs:subClassOf :Intangible .
 
-:EUEnergyEfficiencyCategoryF a :EUEnergyEfficiencyEnumeration;
-  rdfs:label "EUEnergyEfficiencyCategoryF" ;
-  :category "issue-2670" ;
-  :isPartOf <http://pending.schema.org> ;
-  :source <https://github.com/schemaorg/schemaorg/issues/2670> ;
-  rdfs:comment "Represents EU Energy Efficiency Class F as defined in EU energy labeling regulations" .
+:EnergyEfficiencyEnumeration a rdfs:Class ;
+    rdfs:label "EnergyEfficiencyEnumeration" ;
+    :isPartOf <http://pending.schema.org> ;
+    :source <https://github.com/schemaorg/schemaorg/issues/2670> ;
+    rdfs:comment "Enumerates energy efficiency levels (also known as \"classes\" or \"ratings\") and certifications that are part of several international energy efficiency standards." ;
+    rdfs:subClassOf :Enumeration .
 
-:EUEnergyEfficiencyCategoryE a :EUEnergyEfficiencyEnumeration;
-  rdfs:label "EUEnergyEfficiencyCategoryE" ;
-  :category "issue-2670" ;
-  :isPartOf <http://pending.schema.org> ;
-  :source <https://github.com/schemaorg/schemaorg/issues/2670> ;
-  rdfs:comment "Represents EU Energy Efficiency Class E as defined in EU energy labeling regulations" .
+:EnergyStarEnergyEfficiencyEnumeration a rdfs:Class ;
+    rdfs:label "EnergyStarEnergyEfficiencyEnumeration" ;
+    :isPartOf <http://pending.schema.org> ;
+    :source <https://github.com/schemaorg/schemaorg/issues/2670> ;
+    rdfs:comment "Used to indicate whether a product is EnergyStar certified" ;
+    rdfs:subClassOf :EnergyEfficiencyEnumeration .
 
-:EUEnergyEfficiencyCategoryD a :EUEnergyEfficiencyEnumeration;
-  rdfs:label "EUEnergyEfficiencyCategoryD" ;
-  :category "issue-2670" ;
-  :isPartOf <http://pending.schema.org> ;
-  :source <https://github.com/schemaorg/schemaorg/issues/2670> ;
-  rdfs:comment "Represents EU Energy Efficiency Class D as defined in EU energy labeling regulations" .
+:EUEnergyEfficiencyCategoryA a :EUEnergyEfficiencyEnumeration ;
+    rdfs:label "EUEnergyEfficiencyCategoryA" ;
+    :isPartOf <http://pending.schema.org> ;
+    :source <https://github.com/schemaorg/schemaorg/issues/2670> ;
+    rdfs:comment "Represents EU Energy Efficiency Class A as defined in EU energy labeling regulations" .
 
-:EUEnergyEfficiencyCategoryC a :EUEnergyEfficiencyEnumeration;
-  rdfs:label "EUEnergyEfficiencyCategoryC" ;
-  :category "issue-2670" ;
-  :isPartOf <http://pending.schema.org> ;
-  :source <https://github.com/schemaorg/schemaorg/issues/2670> ;
-  rdfs:comment "Represents EU Energy Efficiency Class C as defined in EU energy labeling regulations" .
-  :EUEnergyEfficiencyCategoryB a :EUEnergyEfficiencyEnumeration;
-  rdfs:label "EUEnergyEfficiencyCategoryB" ;
-  :category "issue-2670" ;
-  :isPartOf <http://pending.schema.org> ;
-  :source <https://github.com/schemaorg/schemaorg/issues/2670> ;
-  rdfs:comment "Represents EU Energy Efficiency Class B as defined in EU energy labeling regulations" .
+:EUEnergyEfficiencyCategoryA1Plus a :EUEnergyEfficiencyEnumeration ;
+    rdfs:label "EUEnergyEfficiencyCategoryA1Plus" ;
+    :isPartOf <http://pending.schema.org> ;
+    :source <https://github.com/schemaorg/schemaorg/issues/2670> ;
+    rdfs:comment "Represents EU Energy Efficiency Class A+ as defined in EU energy labeling regulations" .
 
-:EUEnergyEfficiencyCategoryA a :EUEnergyEfficiencyEnumeration;
-  rdfs:label "EUEnergyEfficiencyCategoryA" ;
-  :category "issue-2670" ;
-  :isPartOf <http://pending.schema.org> ;
-  :source <https://github.com/schemaorg/schemaorg/issues/2670> ;
-  rdfs:comment "Represents EU Energy Efficiency Class A as defined in EU energy labeling regulations" .
+:EUEnergyEfficiencyCategoryA2Plus a :EUEnergyEfficiencyEnumeration ;
+    rdfs:label "EUEnergyEfficiencyCategoryA2Plus" ;
+    :isPartOf <http://pending.schema.org> ;
+    :source <https://github.com/schemaorg/schemaorg/issues/2670> ;
+    rdfs:comment "Represents EU Energy Efficiency Class A++ as defined in EU energy labeling regulations" .
 
-:EUEnergyEfficiencyCategoryA1Plus a :EUEnergyEfficiencyEnumeration;
-  rdfs:label "EUEnergyEfficiencyCategoryA1Plus" ;
-  :category "issue-2670" ;
-  :isPartOf <http://pending.schema.org> ;
-  :source <https://github.com/schemaorg/schemaorg/issues/2670> ;
-  rdfs:comment "Represents EU Energy Efficiency Class A+ as defined in EU energy labeling regulations" .
+:EUEnergyEfficiencyCategoryA3Plus a :EUEnergyEfficiencyEnumeration ;
+    rdfs:label "EUEnergyEfficiencyCategoryA3Plus" ;
+    :isPartOf <http://pending.schema.org> ;
+    :source <https://github.com/schemaorg/schemaorg/issues/2670> ;
+    rdfs:comment "Represents EU Energy Efficiency Class A+++ as defined in EU energy labeling regulations" .
 
-:EUEnergyEfficiencyCategoryA2Plus a :EUEnergyEfficiencyEnumeration;
-  rdfs:label "EUEnergyEfficiencyCategoryA2Plus" ;
-  :category "issue-2670" ;
-  :isPartOf <http://pending.schema.org> ;
-  :source <https://github.com/schemaorg/schemaorg/issues/2670> ;
-  rdfs:comment "Represents EU Energy Efficiency Class A++ as defined in EU energy labeling regulations" .
+:EUEnergyEfficiencyCategoryB a :EUEnergyEfficiencyEnumeration ;
+    rdfs:label "EUEnergyEfficiencyCategoryB" ;
+    :isPartOf <http://pending.schema.org> ;
+    :source <https://github.com/schemaorg/schemaorg/issues/2670> ;
+    rdfs:comment "Represents EU Energy Efficiency Class B as defined in EU energy labeling regulations" .
 
-:EUEnergyEfficiencyCategoryA3Plus a :EUEnergyEfficiencyEnumeration;
-  rdfs:label "EUEnergyEfficiencyCategoryA3Plus" ;
-  :category "issue-2670" ;
-  :isPartOf <http://pending.schema.org> ;
-  :source <https://github.com/schemaorg/schemaorg/issues/2670> ;
-  rdfs:comment "Represents EU Energy Efficiency Class A+++ as defined in EU energy labeling regulations" .
+:EUEnergyEfficiencyCategoryC a :EUEnergyEfficiencyEnumeration ;
+    rdfs:label "EUEnergyEfficiencyCategoryC" ;
+    :isPartOf <http://pending.schema.org> ;
+    :source <https://github.com/schemaorg/schemaorg/issues/2670> ;
+    rdfs:comment "Represents EU Energy Efficiency Class C as defined in EU energy labeling regulations" .
+
+:EUEnergyEfficiencyCategoryD a :EUEnergyEfficiencyEnumeration ;
+    rdfs:label "EUEnergyEfficiencyCategoryD" ;
+    :isPartOf <http://pending.schema.org> ;
+    :source <https://github.com/schemaorg/schemaorg/issues/2670> ;
+    rdfs:comment "Represents EU Energy Efficiency Class D as defined in EU energy labeling regulations" .
+
+:EUEnergyEfficiencyCategoryE a :EUEnergyEfficiencyEnumeration ;
+    rdfs:label "EUEnergyEfficiencyCategoryE" ;
+    :isPartOf <http://pending.schema.org> ;
+    :source <https://github.com/schemaorg/schemaorg/issues/2670> ;
+    rdfs:comment "Represents EU Energy Efficiency Class E as defined in EU energy labeling regulations" .
+
+:EUEnergyEfficiencyCategoryF a :EUEnergyEfficiencyEnumeration ;
+    rdfs:label "EUEnergyEfficiencyCategoryF" ;
+    :isPartOf <http://pending.schema.org> ;
+    :source <https://github.com/schemaorg/schemaorg/issues/2670> ;
+    rdfs:comment "Represents EU Energy Efficiency Class F as defined in EU energy labeling regulations" .
+
+:EUEnergyEfficiencyCategoryG a :EUEnergyEfficiencyEnumeration ;
+    rdfs:label "EUEnergyEfficiencyCategoryG" ;
+    :isPartOf <http://pending.schema.org> ;
+    :source <https://github.com/schemaorg/schemaorg/issues/2670> ;
+    rdfs:comment "Represents EU Energy Efficiency Class G as defined in EU energy labeling regulations" .
+
+:EnergyStarCertified a :EnergyStarEnergyEfficiencyEnumeration ;
+    rdfs:label "EnergyStarCertified" ;
+    :isPartOf <http://pending.schema.org> ;
+    :source <https://github.com/schemaorg/schemaorg/issues/2670> ;
+    rdfs:comment "Represents EnergyStar certification" .
+
+:energyEfficiencyScaleMax a rdf:Property ;
+    rdfs:label "energyEfficiencyScaleMax" ;
+    :domainIncludes :EnergyConsumptionDetails ;
+    :isPartOf <http://pending.schema.org> ;
+    :rangeIncludes :EUEnergyEfficiencyEnumeration ;
+    :source <https://github.com/schemaorg/schemaorg/issues/2670> ;
+    rdfs:comment "Specifies the most energy efficient class on the regulated EU energy consumption scale for the product category a product belongs to. For example, energy consumption for televisions placed on the market after January 1, 2020 is scaled from D to A+++." .
+
+:energyEfficiencyScaleMin a rdf:Property ;
+    rdfs:label "energyEfficiencyScaleMin" ;
+    :domainIncludes :EnergyConsumptionDetails ;
+    :isPartOf <http://pending.schema.org> ;
+    :rangeIncludes :EUEnergyEfficiencyEnumeration ;
+    :source <https://github.com/schemaorg/schemaorg/issues/2670> ;
+    rdfs:comment "Specifies the least energy efficient class on the regulated EU energy consumption scale for the product category a product belongs to. For example, energy consumption for televisions placed on the market after January 1, 2020 is scaled from D to A+++." .
+
+:hasEnergyConsumptionDetails a rdf:Property ;
+    rdfs:label "hasEnergyConsumptionDetails" ;
+    :domainIncludes :Product ;
+    :isPartOf <http://pending.schema.org> ;
+    :rangeIncludes :EnergyConsumptionDetails ;
+    :source <https://github.com/schemaorg/schemaorg/issues/2670> ;
+    rdfs:comment "Defines the energy efficiency Category (also known as \"class\" or \"rating\") for a product according to an international energy efficiency standard" .
+
+:hasEnergyEfficiencyCategory a rdf:Property ;
+    rdfs:label "hasEnergyEfficiencyCategory" ;
+    :domainIncludes :EnergyConsumptionDetails ;
+    :isPartOf <http://pending.schema.org> ;
+    :rangeIncludes :EnergyEfficiencyEnumeration ;
+    :source <https://github.com/schemaorg/schemaorg/issues/2670> ;
+    rdfs:comment "Defines the energy efficiency Category (which could be either a rating out of range of values or a yes/no certification) for a product according to an international energy efficiency standard" .
+

--- a/data/ext/pending/issue-2689.ttl
+++ b/data/ext/pending/issue-2689.ttl
@@ -1,83 +1,75 @@
 @prefix : <http://schema.org/> .
 @prefix rdf: <http://www.w3.org/1999/02/22-rdf-syntax-ns#> .
 @prefix rdfs: <http://www.w3.org/2000/01/rdf-schema#> .
-
-# Add support for price components (https://github.com/schemaorg/schemaorg/issues/2689)
-
-:priceComponentType a rdf:Property ;
-	rdfs:label "priceComponentType" ;
-	:category "issue-2689" ;
-	:isPartOf <http://pending.schema.org> ;
-	:domainIncludes :UnitPriceSpecification;
-	:rangeIncludes :PriceComponentTypeEnumeration ;
-	:source <https://github.com/schemaorg/schemaorg/issues/2689> ;
-	rdfs:comment "Identifies a price component (for example, a line item on an invoice), part of the total price for an offer." .
+@prefix xml: <http://www.w3.org/XML/1998/namespace> .
+@prefix xsd: <http://www.w3.org/2001/XMLSchema#> .
 
 :PriceComponentTypeEnumeration a rdfs:Class ;
-	rdfs:label "PriceComponentTypeEnumeration" ;
-	rdfs:subClassOf :Enumeration ;
-	:category "issue-2689" ;
-	:isPartOf <http://pending.schema.org> ;
-	:source <https://github.com/schemaorg/schemaorg/issues/2689> ;
-	rdfs:comment "Enumerates different price components that together make up the total price for an offered product." .
-
-:Installment a :PriceComponentTypeEnumeration ;
-	rdfs:label "Installment" ;
-	:category "issue-2689" ;
-	:isPartOf <http://pending.schema.org> ;
-	:source <https://github.com/schemaorg/schemaorg/issues/2689> ;
-	rdfs:comment "Represents the installment pricing component of the total price for an offered product" .
-
-:Subscription a :PriceComponentTypeEnumeration ;
-	rdfs:label "Subscription" ;
-	:category "issue-2689" ;
-	:isPartOf <http://pending.schema.org> ;
-	:source <https://github.com/schemaorg/schemaorg/issues/2689> ;
-	rdfs:comment "Represents the subscription pricing component of the total price for an offered product" .
-
-:Downpayment a :PriceComponentTypeEnumeration ;
-	rdfs:label "Downpayment" ;
-	:category "issue-2689" ;
-	:isPartOf <http://pending.schema.org> ;
-	:source <https://github.com/schemaorg/schemaorg/issues/2689> ;
-	rdfs:comment "Represents the downpayment (up-front payment) price component of the total price for an offered product that has additional installment payments" .
+    rdfs:label "PriceComponentTypeEnumeration" ;
+    :isPartOf <http://pending.schema.org> ;
+    :source <https://github.com/schemaorg/schemaorg/issues/2689> ;
+    rdfs:comment "Enumerates different price components that together make up the total price for an offered product." ;
+    rdfs:subClassOf :Enumeration .
 
 :ActivationFee a :PriceComponentTypeEnumeration ;
-	rdfs:label "ActivationFee" ;
-	:category "issue-2689" ;
-	:isPartOf <http://pending.schema.org> ;
-	:source <https://github.com/schemaorg/schemaorg/issues/2689> ;
-	rdfs:comment "Represents the activation fee part of the total price for an offered product, for example a cellphone contract" .
+    rdfs:label "ActivationFee" ;
+    :isPartOf <http://pending.schema.org> ;
+    :source <https://github.com/schemaorg/schemaorg/issues/2689> ;
+    rdfs:comment "Represents the activation fee part of the total price for an offered product, for example a cellphone contract" .
 
 :CleaningFee a :PriceComponentTypeEnumeration ;
-	rdfs:label "CleaningFee" ;
-	:category "issue-2689" ;
-	:isPartOf <http://pending.schema.org> ;
-	:source <https://github.com/schemaorg/schemaorg/issues/2689> ;
-	rdfs:comment "Represents the cleaning fee part of the total price for an offered product, for example a vacation rental" .
+    rdfs:label "CleaningFee" ;
+    :isPartOf <http://pending.schema.org> ;
+    :source <https://github.com/schemaorg/schemaorg/issues/2689> ;
+    rdfs:comment "Represents the cleaning fee part of the total price for an offered product, for example a vacation rental" .
 
 :DistanceFee a :PriceComponentTypeEnumeration ;
-	rdfs:label "DistanceFee" ;
-	:category "issue-2689" ;
-	:isPartOf <http://pending.schema.org> ;
-	:source <https://github.com/schemaorg/schemaorg/issues/2689> ;
-	rdfs:comment "Represents the distance fee (e.g., price per km or mile) part of the total price for an offered product, for example a car rental" .
+    rdfs:label "DistanceFee" ;
+    :isPartOf <http://pending.schema.org> ;
+    :source <https://github.com/schemaorg/schemaorg/issues/2689> ;
+    rdfs:comment "Represents the distance fee (e.g., price per km or mile) part of the total price for an offered product, for example a car rental" .
 
-# support price changes after a certain period of time, for example for subscriptions
-:billingStart a rdf:Property ;
-	rdfs:label "billingStart" ;
-	:category "issue-2689" ;
-	:isPartOf <http://pending.schema.org> ;
-	:domainIncludes :UnitPriceSpecification;
-	:rangeIncludes :Number ;
-	:source <https://github.com/schemaorg/schemaorg/issues/2689> ;
-	rdfs:comment "Specifies after how much time this price (or price component) becomes valid and billing starts. Can be used, for example, to model a price increase after the first year of a subscription. The unit of measurement is specified by the unitCode property" .
+:Downpayment a :PriceComponentTypeEnumeration ;
+    rdfs:label "Downpayment" ;
+    :isPartOf <http://pending.schema.org> ;
+    :source <https://github.com/schemaorg/schemaorg/issues/2689> ;
+    rdfs:comment "Represents the downpayment (up-front payment) price component of the total price for an offered product that has additional installment payments" .
+
+:Installment a :PriceComponentTypeEnumeration ;
+    rdfs:label "Installment" ;
+    :isPartOf <http://pending.schema.org> ;
+    :source <https://github.com/schemaorg/schemaorg/issues/2689> ;
+    rdfs:comment "Represents the installment pricing component of the total price for an offered product" .
+
+:Subscription a :PriceComponentTypeEnumeration ;
+    rdfs:label "Subscription" ;
+    :isPartOf <http://pending.schema.org> ;
+    :source <https://github.com/schemaorg/schemaorg/issues/2689> ;
+    rdfs:comment "Represents the subscription pricing component of the total price for an offered product" .
 
 :billingDuration a rdf:Property ;
-	rdfs:label "billingDuration" ;
-	:category "issue-2689" ;
-	:isPartOf <http://pending.schema.org> ;
-	:domainIncludes :UnitPriceSpecification ;
-	:rangeIncludes :Number, :QuantitativeValue,	:Duration ;
-	:source <https://github.com/schemaorg/schemaorg/issues/2689> ;
-	rdfs:comment "Specifies for how long this price (or price component) will be billed. Can be used, for example, to model the contractual duration of a subscription or payment plan. Type can be either a Duration or a Number (in which case the unit of measurement, for example month, is specified by the unitCode property)" .
+    rdfs:label "billingDuration" ;
+    :domainIncludes :UnitPriceSpecification ;
+    :isPartOf <http://pending.schema.org> ;
+    :rangeIncludes :Duration,
+        :Number,
+        :QuantitativeValue ;
+    :source <https://github.com/schemaorg/schemaorg/issues/2689> ;
+    rdfs:comment "Specifies for how long this price (or price component) will be billed. Can be used, for example, to model the contractual duration of a subscription or payment plan. Type can be either a Duration or a Number (in which case the unit of measurement, for example month, is specified by the unitCode property)" .
+
+:billingStart a rdf:Property ;
+    rdfs:label "billingStart" ;
+    :domainIncludes :UnitPriceSpecification ;
+    :isPartOf <http://pending.schema.org> ;
+    :rangeIncludes :Number ;
+    :source <https://github.com/schemaorg/schemaorg/issues/2689> ;
+    rdfs:comment "Specifies after how much time this price (or price component) becomes valid and billing starts. Can be used, for example, to model a price increase after the first year of a subscription. The unit of measurement is specified by the unitCode property" .
+
+:priceComponentType a rdf:Property ;
+    rdfs:label "priceComponentType" ;
+    :domainIncludes :UnitPriceSpecification ;
+    :isPartOf <http://pending.schema.org> ;
+    :rangeIncludes :PriceComponentTypeEnumeration ;
+    :source <https://github.com/schemaorg/schemaorg/issues/2689> ;
+    rdfs:comment "Identifies a price component (for example, a line item on an invoice), part of the total price for an offer." .
+

--- a/data/ext/pending/issue-271.ttl
+++ b/data/ext/pending/issue-271.ttl
@@ -1,10 +1,11 @@
 @prefix : <http://schema.org/> .
 @prefix rdf: <http://www.w3.org/1999/02/22-rdf-syntax-ns#> .
 @prefix rdfs: <http://www.w3.org/2000/01/rdf-schema#> .
+@prefix xml: <http://www.w3.org/XML/1998/namespace> .
+@prefix xsd: <http://www.w3.org/2001/XMLSchema#> .
 
 :Quotation a rdfs:Class ;
     rdfs:label "Quotation" ;
-    :category "issue-271" ;
     :isPartOf <http://pending.schema.org> ;
     :source <https://github.com/schemaorg/schemaorg/issues/271> ;
     rdfs:comment "A quotation. Often but not necessarily from some written work, attributable to a real world author and - if associated with a fictional character - to any fictional Person. Use [[isBasedOn]] to link to source/origin. The [[recordedIn]] property can be used to reference a Quotation from an [[Event]]." ;
@@ -12,7 +13,6 @@
 
 :spokenByCharacter a rdf:Property ;
     rdfs:label "spokenByCharacter" ;
-    :category "issue-271" ;
     :domainIncludes :Quotation ;
     :isPartOf <http://pending.schema.org> ;
     :rangeIncludes :Organization,

--- a/data/ext/pending/issue-2712.ttl
+++ b/data/ext/pending/issue-2712.ttl
@@ -1,62 +1,52 @@
 @prefix : <http://schema.org/> .
 @prefix rdf: <http://www.w3.org/1999/02/22-rdf-syntax-ns#> .
 @prefix rdfs: <http://www.w3.org/2000/01/rdf-schema#> .
+@prefix xml: <http://www.w3.org/XML/1998/namespace> .
+@prefix xsd: <http://www.w3.org/2001/XMLSchema#> .
 
-# Add support for structured priceType values (https://github.com/schemaorg/schemaorg/issues/2712)
-
-# extend the domain of priceType to include CompoundPriceSpecification
-# add PriceTypeEnumeration to the allowed types to support structured values for price types
-:priceType 
-	:domainIncludes :CompoundPriceSpecification ;
-	:rangeIncludes :PriceTypeEnumeration .
-	
 :PriceTypeEnumeration a rdfs:Class ;
-	rdfs:label "PriceTypeEnumeration" ;
-	rdfs:subClassOf :Enumeration ;
-	:category "issue-2712" ;
-	:isPartOf <http://pending.schema.org> ;
-	:source <https://github.com/schemaorg/schemaorg/issues/2712> ;
-	rdfs:comment "Enumerates different price types, for example list price, invoice price, and sale price." .
-
-:ListPrice a :PriceTypeEnumeration ;
-	rdfs:label "ListPrice" ;
-	:category "issue-2712" ;
-	:isPartOf <http://pending.schema.org> ;
-	:source <https://github.com/schemaorg/schemaorg/issues/2712> ;
-	rdfs:comment "Represents the list price (the price a product is actually advertised for) of an offered product." .
-
-:SalePrice a :PriceTypeEnumeration ;
-	rdfs:label "SalePrice" ;
-	:category "issue-2712" ;
-	:isPartOf <http://pending.schema.org> ;
-	:source <https://github.com/schemaorg/schemaorg/issues/2712> ;
-	rdfs:comment "Represents a sale price (usually active for a limited period) of an offered product." .
-	
-:MSRP a :PriceTypeEnumeration ;
-	rdfs:label "MSRP" ;
-	:category "issue-2712" ;
-	:isPartOf <http://pending.schema.org> ;
-	:source <https://github.com/schemaorg/schemaorg/issues/2712> ;
-	rdfs:comment """Represents the manufacturer suggested retail price ("MSRP") of an offered product.""" .
-
-:SRP a :PriceTypeEnumeration ;
-	rdfs:label "SRP" ;
-	:category "issue-2712" ;
-	:isPartOf <http://pending.schema.org> ;
-	:source <https://github.com/schemaorg/schemaorg/issues/2712> ;
-	rdfs:comment """Represents the suggested retail price ("SRP") of an offered product.""" .
+    rdfs:label "PriceTypeEnumeration" ;
+    :isPartOf <http://pending.schema.org> ;
+    :source <https://github.com/schemaorg/schemaorg/issues/2712> ;
+    rdfs:comment "Enumerates different price types, for example list price, invoice price, and sale price." ;
+    rdfs:subClassOf :Enumeration .
 
 :InvoicePrice a :PriceTypeEnumeration ;
-	rdfs:label "InvoicePrice" ;
-	:category "issue-2712" ;
-	:isPartOf <http://pending.schema.org> ;
-	:source <https://github.com/schemaorg/schemaorg/issues/2712> ;
-	rdfs:comment "Represents the invoice price of an offered product." .
-	
+    rdfs:label "InvoicePrice" ;
+    :isPartOf <http://pending.schema.org> ;
+    :source <https://github.com/schemaorg/schemaorg/issues/2712> ;
+    rdfs:comment "Represents the invoice price of an offered product." .
+
+:ListPrice a :PriceTypeEnumeration ;
+    rdfs:label "ListPrice" ;
+    :isPartOf <http://pending.schema.org> ;
+    :source <https://github.com/schemaorg/schemaorg/issues/2712> ;
+    rdfs:comment "Represents the list price (the price a product is actually advertised for) of an offered product." .
+
+:MSRP a :PriceTypeEnumeration ;
+    rdfs:label "MSRP" ;
+    :isPartOf <http://pending.schema.org> ;
+    :source <https://github.com/schemaorg/schemaorg/issues/2712> ;
+    rdfs:comment "Represents the manufacturer suggested retail price (\"MSRP\") of an offered product." .
+
 :MinimumAdvertisedPrice a :PriceTypeEnumeration ;
-	rdfs:label "MinimumAdvertisedPrice" ;
-	:category "issue-2712" ;
-	:isPartOf <http://pending.schema.org> ;
-	:source <https://github.com/schemaorg/schemaorg/issues/2712> ;
-	rdfs:comment """Represents the minimum advertised price ("MAP") (as dictated by the manufacturer) of an offered product.""" .
-		
+    rdfs:label "MinimumAdvertisedPrice" ;
+    :isPartOf <http://pending.schema.org> ;
+    :source <https://github.com/schemaorg/schemaorg/issues/2712> ;
+    rdfs:comment "Represents the minimum advertised price (\"MAP\") (as dictated by the manufacturer) of an offered product." .
+
+:SRP a :PriceTypeEnumeration ;
+    rdfs:label "SRP" ;
+    :isPartOf <http://pending.schema.org> ;
+    :source <https://github.com/schemaorg/schemaorg/issues/2712> ;
+    rdfs:comment "Represents the suggested retail price (\"SRP\") of an offered product." .
+
+:SalePrice a :PriceTypeEnumeration ;
+    rdfs:label "SalePrice" ;
+    :isPartOf <http://pending.schema.org> ;
+    :source <https://github.com/schemaorg/schemaorg/issues/2712> ;
+    rdfs:comment "Represents a sale price (usually active for a limited period) of an offered product." .
+
+:priceType :domainIncludes :CompoundPriceSpecification ;
+    :rangeIncludes :PriceTypeEnumeration .
+

--- a/data/ext/pending/issue-2722.ttl
+++ b/data/ext/pending/issue-2722.ttl
@@ -1,12 +1,13 @@
-
 @prefix : <http://schema.org/> .
 @prefix rdf: <http://www.w3.org/1999/02/22-rdf-syntax-ns#> .
 @prefix rdfs: <http://www.w3.org/2000/01/rdf-schema#> .
+@prefix xml: <http://www.w3.org/XML/1998/namespace> .
+@prefix xsd: <http://www.w3.org/2001/XMLSchema#> .
 
 :SeekToAction a rdfs:Class ;
     rdfs:label "SeekToAction" ;
-    :category "issue-2722" ;
     :isPartOf <http://pending.schema.org> ;
     :source <https://github.com/schemaorg/schemaorg/issues/2722> ;
     rdfs:comment "This is the [[Action]] of navigating to a specific [[startOffset]] timestamp within a [[VideoObject]], typically represented with a URL template structure." ;
     rdfs:subClassOf :Action .
+

--- a/data/ext/pending/issue-2740.ttl
+++ b/data/ext/pending/issue-2740.ttl
@@ -1,28 +1,29 @@
 @prefix : <http://schema.org/> .
 @prefix rdf: <http://www.w3.org/1999/02/22-rdf-syntax-ns#> .
 @prefix rdfs: <http://www.w3.org/2000/01/rdf-schema#> .
-
-:SolveMathAction a rdfs:Class ;
-    rdfs:label "SolveMathAction" ;
-    :category "issue-2740" ;
-    :isPartOf <http://pending.schema.org> ;
-    :source <https://github.com/schemaorg/schemaorg/issues/2740> ;
-    rdfs:comment "The action that takes in a math expression and directs users to a page potentially capable of solving/simplifying that expression." ;
-    rdfs:subClassOf :Action .
+@prefix xml: <http://www.w3.org/XML/1998/namespace> .
+@prefix xsd: <http://www.w3.org/2001/XMLSchema#> .
 
 :MathSolver a rdfs:Class ;
     rdfs:label "MathSolver" ;
-    :category "issue-2740" ;
     :isPartOf <http://pending.schema.org> ;
     :source <https://github.com/schemaorg/schemaorg/issues/2740> ;
     rdfs:comment "A math solver which is capable of solving a subset of mathematical problems." ;
     rdfs:subClassOf :CreativeWork .
 
+:SolveMathAction a rdfs:Class ;
+    rdfs:label "SolveMathAction" ;
+    :isPartOf <http://pending.schema.org> ;
+    :source <https://github.com/schemaorg/schemaorg/issues/2740> ;
+    rdfs:comment "The action that takes in a math expression and directs users to a page potentially capable of solving/simplifying that expression." ;
+    rdfs:subClassOf :Action .
+
 :mathExpression a rdf:Property ;
     rdfs:label "mathExpression" ;
-    :category "issue-2740" ;
     :domainIncludes :MathSolver ;
     :isPartOf <http://pending.schema.org> ;
-    :rangeIncludes :SolveMathAction, :Text ;
+    :rangeIncludes :SolveMathAction,
+        :Text ;
     :source <https://github.com/schemaorg/schemaorg/issues/2740> ;
     rdfs:comment "A mathematical expression (e.g. 'x^2-3x=0') that may be solved for a specific variable, simplified, or transformed. This can take many formats, e.g. LaTeX, Ascii-Math, or math as you would write with a keyboard." .
+

--- a/data/ext/pending/issue-276.ttl
+++ b/data/ext/pending/issue-276.ttl
@@ -1,10 +1,11 @@
 @prefix : <http://schema.org/> .
 @prefix rdf: <http://www.w3.org/1999/02/22-rdf-syntax-ns#> .
 @prefix rdfs: <http://www.w3.org/2000/01/rdf-schema#> .
+@prefix xml: <http://www.w3.org/XML/1998/namespace> .
+@prefix xsd: <http://www.w3.org/2001/XMLSchema#> .
 
 :abstract a rdf:Property ;
     rdfs:label "abstract" ;
-    :category "issue-276" ;
     :domainIncludes :CreativeWork ;
     :isPartOf <http://pending.schema.org> ;
     :rangeIncludes :Text ;

--- a/data/ext/pending/issue-2766.ttl
+++ b/data/ext/pending/issue-2766.ttl
@@ -1,10 +1,11 @@
 @prefix : <http://schema.org/> .
 @prefix rdf: <http://www.w3.org/1999/02/22-rdf-syntax-ns#> .
 @prefix rdfs: <http://www.w3.org/2000/01/rdf-schema#> .
+@prefix xml: <http://www.w3.org/XML/1998/namespace> .
+@prefix xsd: <http://www.w3.org/2001/XMLSchema#> .
 
 :HyperToc a rdfs:Class ;
     rdfs:label "HyperToc" ;
-    :category "issue-2766" ;
     :isPartOf <http://pending.schema.org> ;
     :source <https://github.com/schemaorg/schemaorg/issues/2766> ;
     rdfs:comment "A HyperToc represents a hypertext table of contents for complex media objects, such as [[VideoObject]], [[AudioObject]]. Items in the table of contents are indicated using the [[tocEntry]] property, and typed [[HyperTocEntry]]. For cases where the same larger work is split into multiple files, [[associatedMedia]] can be used on individual [[HyperTocEntry]] items." ;
@@ -12,47 +13,40 @@
 
 :HyperTocEntry a rdfs:Class ;
     rdfs:label "HyperTocEntry" ;
-    :category "issue-2766" ;
     :isPartOf <http://pending.schema.org> ;
     :source <https://github.com/schemaorg/schemaorg/issues/2766> ;
     rdfs:comment "A HyperToEntry is an item within a [[HyperToc]], which represents a hypertext table of contents for complex media objects, such as [[VideoObject]], [[AudioObject]]. The media object itself is indicated using [[associatedMedia]]. Each section of interest within that content can be described with a [[HyperTocEntry]], with associated [[startOffset]] and [[endOffset]]. When several entries are all from the same file, [[associatedMedia]] is used on the overarching [[HyperTocEntry]]; if the content has been split into multiple files, they can be referenced using [[associatedMedia]] on each [[HyperTocEntry]]." ;
     rdfs:subClassOf :CreativeWork .
 
-:tocEntry a rdf:Property ;
-    rdfs:label "tocEntry" ;
-    :category "issue-2766" ;
-    :domainIncludes :HyperToc;
-    :rangeIncludes :HyperTocEntry;
-    :isPartOf <http://pending.schema.org> ;
-    rdfs:subPropertyOf :hasPart;
-    :source <https://github.com/schemaorg/schemaorg/issues/2766> ;
-    rdfs:comment "Indicates a [[HyperTocEntry]] in a [[HyperToc]]." .
-
-:utterances a rdf:Property ;
-    rdfs:label "utterances" ;
-    :category "issue-2766" ;
-    :domainIncludes :HyperTocEntry;
-    :rangeIncludes :Text;
-    :isPartOf <http://pending.schema.org> ;
-    :source <https://github.com/schemaorg/schemaorg/issues/2766> ;
-    rdfs:comment "Text of an utterances (spoken words, lyrics etc.) that occurs at a certain section of a media object, represented as a [[HyperTocEntry]]." .
-
-
-:tocContinuation a rdf:Property ;
-    rdfs:label "tocContinuation" ;
-    :category "issue-2766" ;
-    :domainIncludes :HyperTocEntry;
-    :rangeIncludes :HyperTocEntry;
-    :isPartOf <http://pending.schema.org> ;
-    :source <https://github.com/schemaorg/schemaorg/issues/2766> ;
-    rdfs:comment "A [[HyperTocEntry]] can have a [[tocContinuation]] indicated, which is another [[HyperTocEntry]] that would be the default next item to play or render." .
-
-
-# Annotations that amend existing core properties:
-#
-
-:startOffset :rangeIncludes :HyperTocEntry .
+:associatedMedia :domainIncludes :HyperToc,
+        :HyperTocEntry .
 
 :endOffset :rangeIncludes :HyperTocEntry .
 
-:associatedMedia :domainIncludes :HyperToc, :HyperTocEntry .
+:startOffset :rangeIncludes :HyperTocEntry .
+
+:tocContinuation a rdf:Property ;
+    rdfs:label "tocContinuation" ;
+    :domainIncludes :HyperTocEntry ;
+    :isPartOf <http://pending.schema.org> ;
+    :rangeIncludes :HyperTocEntry ;
+    :source <https://github.com/schemaorg/schemaorg/issues/2766> ;
+    rdfs:comment "A [[HyperTocEntry]] can have a [[tocContinuation]] indicated, which is another [[HyperTocEntry]] that would be the default next item to play or render." .
+
+:tocEntry a rdf:Property ;
+    rdfs:label "tocEntry" ;
+    :domainIncludes :HyperToc ;
+    :isPartOf <http://pending.schema.org> ;
+    :rangeIncludes :HyperTocEntry ;
+    :source <https://github.com/schemaorg/schemaorg/issues/2766> ;
+    rdfs:comment "Indicates a [[HyperTocEntry]] in a [[HyperToc]]." ;
+    rdfs:subPropertyOf :hasPart .
+
+:utterances a rdf:Property ;
+    rdfs:label "utterances" ;
+    :domainIncludes :HyperTocEntry ;
+    :isPartOf <http://pending.schema.org> ;
+    :rangeIncludes :Text ;
+    :source <https://github.com/schemaorg/schemaorg/issues/2766> ;
+    rdfs:comment "Text of an utterances (spoken words, lyrics etc.) that occurs at a certain section of a media object, represented as a [[HyperTocEntry]]." .
+

--- a/data/ext/pending/issue-373.ttl
+++ b/data/ext/pending/issue-373.ttl
@@ -1,10 +1,11 @@
 @prefix : <http://schema.org/> .
 @prefix rdf: <http://www.w3.org/1999/02/22-rdf-syntax-ns#> .
 @prefix rdfs: <http://www.w3.org/2000/01/rdf-schema#> .
+@prefix xml: <http://www.w3.org/XML/1998/namespace> .
+@prefix xsd: <http://www.w3.org/2001/XMLSchema#> .
 
 :PodcastEpisode a rdfs:Class ;
     rdfs:label "PodcastEpisode" ;
-    :category "issue-373" ;
     :isPartOf <http://pending.schema.org> ;
     :source <https://github.com/schemaorg/schemaorg/issues/373> ;
     rdfs:comment "A single episode of a podcast series." ;
@@ -12,7 +13,6 @@
 
 :PodcastSeason a rdfs:Class ;
     rdfs:label "PodcastSeason" ;
-    :category "issue-373" ;
     :isPartOf <http://pending.schema.org> ;
     :source <https://github.com/schemaorg/schemaorg/issues/373> ;
     rdfs:comment "A single season of a podcast. Many podcasts do not break down into separate seasons. In that case, PodcastSeries should be used." ;
@@ -20,7 +20,6 @@
 
 :PodcastSeries a rdfs:Class ;
     rdfs:label "PodcastSeries" ;
-    :category "issue-373" ;
     :isPartOf <http://pending.schema.org> ;
     :source <https://github.com/schemaorg/schemaorg/issues/373> ;
     rdfs:comment "A podcast is an episodic series of digital audio or video files which a user can download and listen to." ;
@@ -28,7 +27,6 @@
 
 :webFeed a rdf:Property ;
     rdfs:label "webFeed" ;
-    :category "issue-373" ;
     :domainIncludes :PodcastSeries,
         :SpecialAnnouncement ;
     :isPartOf <http://pending.schema.org> ;

--- a/data/ext/pending/issue-383.ttl
+++ b/data/ext/pending/issue-383.ttl
@@ -1,25 +1,27 @@
 @prefix : <http://schema.org/> .
 @prefix rdf: <http://www.w3.org/1999/02/22-rdf-syntax-ns#> .
 @prefix rdfs: <http://www.w3.org/2000/01/rdf-schema#> .
+@prefix xml: <http://www.w3.org/XML/1998/namespace> .
+@prefix xsd: <http://www.w3.org/2001/XMLSchema#> .
 
 :FundingAgency a rdfs:Class ;
     rdfs:label "FundingAgency" ;
-    :category "issue-383" ;
     :isPartOf <http://pending.schema.org> ;
-    :source <https://www.w3.org/wiki/WebSchemas/SchemaDotOrgSources#FundInfoCollab> ;
+    :source <https://www.w3.org/wiki/WebSchemas/SchemaDotOrgSources#FundInfoCollab>,
+        <https://github.com/schemaorg/schemaorg/issues/383> ;
     rdfs:comment """A FundingAgency is an organization that implements one or more [[FundingScheme]]s and manages
     the granting process (via [[Grant]]s, typically [[MonetaryGrant]]s).
     A funding agency is not always required for grant funding, e.g. philanthropic giving, corporate sponsorship etc.
     
-    Examples of funding agencies include ERC, REA, NIH, Bill and Melinda Gates Foundation...
+Examples of funding agencies include ERC, REA, NIH, Bill and Melinda Gates Foundation...
     """ ;
     rdfs:subClassOf :Project .
 
 :FundingScheme a rdfs:Class ;
     rdfs:label "FundingScheme" ;
-    :category "issue-383" ;
     :isPartOf <http://pending.schema.org> ;
-    :source <https://www.w3.org/wiki/WebSchemas/SchemaDotOrgSources#FundInfoCollab> ;
+    :source <https://www.w3.org/wiki/WebSchemas/SchemaDotOrgSources#FundInfoCollab>,
+        <https://github.com/schemaorg/schemaorg/issues/383> ;
     rdfs:comment """A FundingScheme combines organizational, project and policy aspects of grant-based funding
     that sets guidelines, principles and mechanisms to support other kinds of projects and activities.
     Funding is typically organized via [[Grant]] funding. Examples of funding schemes: Swiss Priority Programmes (SPPs); EU Framework 7 (FP7); Horizon 2020; the NIH-R01 Grant Program; Wellcome institutional strategic support fund. For large scale public sector funding, the management and administration of grant awards is often handled by other, dedicated, organizations - [[FundingAgency]]s such as ERC, REA, ...""" ;
@@ -27,9 +29,9 @@
 
 :Grant a rdfs:Class ;
     rdfs:label "Grant" ;
-    :category "issue-383" ;
     :isPartOf <http://pending.schema.org> ;
-    :source <https://www.w3.org/wiki/WebSchemas/SchemaDotOrgSources#FundInfoCollab> ;
+    :source <https://www.w3.org/wiki/WebSchemas/SchemaDotOrgSources#FundInfoCollab>,
+        <https://github.com/schemaorg/schemaorg/issues/383> ;
     rdfs:comment """A grant, typically financial or otherwise quantifiable, of resources. Typically a [[funder]] sponsors some [[MonetaryAmount]] to an [[Organization]] or [[Person]],
     sometimes not necessarily via a dedicated or long-lived [[Project]], resulting in one or more outputs, or [[fundedItem]]s. For financial sponsorship, indicate the [[funder]] of a [[MonetaryGrant]]. For non-financial support, indicate [[sponsor]] of [[Grant]]s of resources (e.g. office space).
 
@@ -41,17 +43,17 @@ The amount of a [[Grant]] is represented using [[amount]] as a [[MonetaryAmount]
 
 :MonetaryGrant a rdfs:Class ;
     rdfs:label "MonetaryGrant" ;
-    :category "issue-383" ;
     :isPartOf <http://pending.schema.org> ;
-    :source <https://www.w3.org/wiki/WebSchemas/SchemaDotOrgSources#FundInfoCollab> ;
+    :source <https://www.w3.org/wiki/WebSchemas/SchemaDotOrgSources#FundInfoCollab>,
+        <https://github.com/schemaorg/schemaorg/issues/383> ;
     rdfs:comment "A monetary grant." ;
     rdfs:subClassOf :Grant .
 
 :Project a rdfs:Class ;
     rdfs:label "Project" ;
-    :category "issue-383" ;
     :isPartOf <http://pending.schema.org> ;
-    :source <https://www.w3.org/wiki/WebSchemas/SchemaDotOrgSources#FundInfoCollab> ;
+    :source <https://www.w3.org/wiki/WebSchemas/SchemaDotOrgSources#FundInfoCollab>,
+        <https://github.com/schemaorg/schemaorg/issues/383> ;
     rdfs:comment """An enterprise (potentially individual but typically collaborative), planned to achieve a particular aim.
 Use properties from [[Organization]], [[subOrganization]]/[[parentOrganization]] to indicate project sub-structures. 
    """ ;
@@ -59,9 +61,9 @@ Use properties from [[Organization]], [[subOrganization]]/[[parentOrganization]]
 
 :ResearchProject a rdfs:Class ;
     rdfs:label "ResearchProject" ;
-    :category "issue-383" ;
     :isPartOf <http://pending.schema.org> ;
-    :source <https://www.w3.org/wiki/WebSchemas/SchemaDotOrgSources#FundInfoCollab> ;
+    :source <https://www.w3.org/wiki/WebSchemas/SchemaDotOrgSources#FundInfoCollab>,
+        <https://github.com/schemaorg/schemaorg/issues/383> ;
     rdfs:comment "A Research project." ;
     rdfs:subClassOf :Project .
 
@@ -70,8 +72,6 @@ Use properties from [[Organization]], [[subOrganization]]/[[parentOrganization]]
 
 :fundedItem a rdf:Property ;
     rdfs:label "fundedItem" ;
-    :category "issue-1688",
-        "issue-383" ;
     :domainIncludes :Grant ;
     :isPartOf <http://pending.schema.org> ;
     :rangeIncludes :Thing ;

--- a/data/ext/pending/issue-447.ttl
+++ b/data/ext/pending/issue-447.ttl
@@ -1,9 +1,11 @@
 @prefix : <http://schema.org/> .
+@prefix rdf: <http://www.w3.org/1999/02/22-rdf-syntax-ns#> .
 @prefix rdfs: <http://www.w3.org/2000/01/rdf-schema#> .
+@prefix xml: <http://www.w3.org/XML/1998/namespace> .
+@prefix xsd: <http://www.w3.org/2001/XMLSchema#> .
 
 :EventSeries a rdfs:Class ;
     rdfs:label "EventSeries" ;
-    :category "issue-447" ;
     :isPartOf <http://pending.schema.org> ;
     :source <https://github.com/schemaorg/schemaorg/issues/447> ;
     rdfs:comment """A series of [[Event]]s. Included events can relate with the series using the [[superEvent]] property.

--- a/data/ext/pending/issue-894.ttl
+++ b/data/ext/pending/issue-894.ttl
@@ -1,10 +1,11 @@
 @prefix : <http://schema.org/> .
 @prefix rdf: <http://www.w3.org/1999/02/22-rdf-syntax-ns#> .
 @prefix rdfs: <http://www.w3.org/2000/01/rdf-schema#> .
+@prefix xml: <http://www.w3.org/XML/1998/namespace> .
+@prefix xsd: <http://www.w3.org/2001/XMLSchema#> .
 
 :CategoryCode a rdfs:Class ;
     rdfs:label "CategoryCode" ;
-    :category "issue-894" ;
     :isPartOf <http://pending.schema.org> ;
     :source <https://github.com/schemaorg/schemaorg/issues/894> ;
     rdfs:comment "A Category Code." ;
@@ -12,7 +13,6 @@
 
 :CategoryCodeSet a rdfs:Class ;
     rdfs:label "CategoryCodeSet" ;
-    :category "issue-894" ;
     :isPartOf <http://pending.schema.org> ;
     :source <https://github.com/schemaorg/schemaorg/issues/894> ;
     rdfs:comment "A set of Category Code values." ;
@@ -20,7 +20,6 @@
 
 :DefinedTerm a rdfs:Class ;
     rdfs:label "DefinedTerm" ;
-    :category "issue-894" ;
     :isPartOf <http://pending.schema.org> ;
     :source <https://github.com/schemaorg/schemaorg/issues/894> ;
     rdfs:comment "A word, name, acronym, phrase, etc. with a formal definition. Often used in the context of category or subject classification, glossaries or dictionaries, product or creative work types, etc. Use the name property for the term being defined, use termCode if the term has an alpha-numeric code allocated, use description to provide the definition of the term." ;
@@ -28,7 +27,6 @@
 
 :DefinedTermSet a rdfs:Class ;
     rdfs:label "DefinedTermSet" ;
-    :category "issue-894" ;
     :isPartOf <http://pending.schema.org> ;
     :source <https://github.com/schemaorg/schemaorg/issues/894> ;
     rdfs:comment "A set of defined terms for example a set of categories or a classification scheme, a glossary, dictionary or enumeration." ;
@@ -36,7 +34,6 @@
 
 :codeValue a rdf:Property ;
     rdfs:label "codeValue" ;
-    :category "issue-894" ;
     :domainIncludes :CategoryCode ;
     :isPartOf <http://pending.schema.org> ;
     :rangeIncludes :Text ;
@@ -46,7 +43,6 @@
 
 :hasCategoryCode a rdf:Property ;
     rdfs:label "hasCategoryCode" ;
-    :category "issue-894" ;
     :domainIncludes :CategoryCodeSet ;
     :isPartOf <http://pending.schema.org> ;
     :rangeIncludes :CategoryCode ;
@@ -56,7 +52,6 @@
 
 :inCodeSet a rdf:Property ;
     rdfs:label "inCodeSet" ;
-    :category "issue-894" ;
     :domainIncludes :CategoryCode ;
     :isPartOf <http://pending.schema.org> ;
     :rangeIncludes :CategoryCodeSet,
@@ -67,7 +62,6 @@
 
 :hasDefinedTerm a rdf:Property ;
     rdfs:label "hasDefinedTerm" ;
-    :category "issue-894" ;
     :domainIncludes :DefinedTermSet ;
     :isPartOf <http://pending.schema.org> ;
     :rangeIncludes :DefinedTerm ;
@@ -76,7 +70,6 @@
 
 :inDefinedTermSet a rdf:Property ;
     rdfs:label "inDefinedTermSet" ;
-    :category "issue-894" ;
     :domainIncludes :DefinedTerm ;
     :isPartOf <http://pending.schema.org> ;
     :rangeIncludes :DefinedTermSet,
@@ -87,7 +80,6 @@
 
 :termCode a rdf:Property ;
     rdfs:label "termCode" ;
-    :category "issue-894" ;
     :domainIncludes :DefinedTerm ;
     :isPartOf <http://pending.schema.org> ;
     :rangeIncludes :Text ;

--- a/data/ext/pending/issue-987.ttl
+++ b/data/ext/pending/issue-987.ttl
@@ -1,10 +1,11 @@
 @prefix : <http://schema.org/> .
 @prefix rdf: <http://www.w3.org/1999/02/22-rdf-syntax-ns#> .
 @prefix rdfs: <http://www.w3.org/2000/01/rdf-schema#> .
+@prefix xml: <http://www.w3.org/XML/1998/namespace> .
+@prefix xsd: <http://www.w3.org/2001/XMLSchema#> .
 
 :creativeWorkStatus a rdf:Property ;
     rdfs:label "creativeWorkStatus" ;
-    :category "issue-987" ;
     :domainIncludes :CreativeWork ;
     :isPartOf <http://pending.schema.org> ;
     :rangeIncludes :DefinedTerm,

--- a/data/gr-property-acks.ttl
+++ b/data/gr-property-acks.ttl
@@ -1,5 +1,8 @@
 @prefix : <http://schema.org/> .
 @prefix rdf: <http://www.w3.org/1999/02/22-rdf-syntax-ns#> .
+@prefix rdfs: <http://www.w3.org/2000/01/rdf-schema#> .
+@prefix xml: <http://www.w3.org/XML/1998/namespace> .
+@prefix xsd: <http://www.w3.org/2001/XMLSchema#> .
 
 :acceptedPaymentMethod a rdf:Property ;
     :source <http://www.w3.org/wiki/WebSchemas/SchemaDotOrgSources#source_GoodRelationsTerms> .

--- a/data/mappings.ttl
+++ b/data/mappings.ttl
@@ -1,5 +1,9 @@
 @prefix : <http://schema.org/> .
+@prefix rdf: <http://www.w3.org/1999/02/22-rdf-syntax-ns#> .
+@prefix rdfs: <http://www.w3.org/2000/01/rdf-schema#> .
 @prefix skos: <http://www.w3.org/2004/02/skos/core#> .
+@prefix xml: <http://www.w3.org/XML/1998/namespace> .
+@prefix xsd: <http://www.w3.org/2001/XMLSchema#> .
 
 :LocalBusiness skos:closeMatch <http://www.w3.org/ns/regorg#RegisteredOrganization> .
 

--- a/data/schema.ttl
+++ b/data/schema.ttl
@@ -3,10 +3,11 @@
 @prefix owl: <http://www.w3.org/2002/07/owl#> .
 @prefix rdf: <http://www.w3.org/1999/02/22-rdf-syntax-ns#> .
 @prefix rdfs: <http://www.w3.org/2000/01/rdf-schema#> .
+@prefix xml: <http://www.w3.org/XML/1998/namespace> .
+@prefix xsd: <http://www.w3.org/2001/XMLSchema#> .
 
 :AMRadioChannel a rdfs:Class ;
     rdfs:label "AMRadioChannel" ;
-    :category "issue-1004" ;
     :source <https://github.com/schemaorg/schemaorg/issues/1004> ;
     rdfs:comment "A radio channel that uses AM." ;
     rdfs:subClassOf :RadioChannel .
@@ -55,7 +56,6 @@ See also the <a href="/docs/hotels.html">dedicated document on the use of schema
 
 :ActionAccessSpecification a rdfs:Class ;
     rdfs:label "ActionAccessSpecification" ;
-    :category "issue-1741" ;
     :source <https://github.com/schemaorg/schemaorg/issues/1741> ;
     rdfs:comment "A set of requirements that a must be fulfilled in order to perform an Action." ;
     rdfs:subClassOf :Intangible .
@@ -310,7 +310,6 @@ See also the <a href="/docs/hotels.html">dedicated document on the use of schema
 
 :BedType a rdfs:Class ;
     rdfs:label "BedType" ;
-    :category "issue-1262" ;
     :source <https://github.com/schemaorg/schemaorg/issues/1262>,
         <https://www.w3.org/wiki/WebSchemas/SchemaDotOrgSources#STI_Accommodation_Ontology> ;
     rdfs:comment "A type of bed. This is used for indicating the bed or beds available in an accommodation." ;
@@ -420,7 +419,6 @@ See also the <a href="/docs/hotels.html">dedicated document on the use of schema
 
 :BroadcastFrequencySpecification a rdfs:Class ;
     rdfs:label "BroadcastFrequencySpecification" ;
-    :category "issue-1004" ;
     :source <https://github.com/schemaorg/schemaorg/issues/1004> ;
     rdfs:comment "The frequency in MHz and the modulation used for a particular BroadcastService." ;
     rdfs:subClassOf :Intangible .
@@ -603,7 +601,6 @@ See also the dedicated [document on the use of schema.org for marking up hotels 
 
 :ClaimReview a rdfs:Class ;
     rdfs:label "ClaimReview" ;
-    :category "issue-1061" ;
     :source <https://github.com/schemaorg/schemaorg/issues/1061> ;
     rdfs:comment "A fact-checking review of claims made (or reported) in some creative work (referenced via itemReviewed)." ;
     rdfs:subClassOf :Review .
@@ -976,7 +973,6 @@ Originally, URLs from [GoodRelations](http://purl.org/goodrelations/v1) were use
 
 :Distillery a rdfs:Class ;
     rdfs:label "Distillery" ;
-    :category "issue-743" ;
     :source <https://github.com/schemaorg/schemaorg/issues/743> ;
     rdfs:comment "A distillery." ;
     rdfs:subClassOf :FoodEstablishment .
@@ -1076,7 +1072,6 @@ Originally, URLs from [GoodRelations](http://purl.org/goodrelations/v1) were use
 
 :EmployerAggregateRating a rdfs:Class ;
     rdfs:label "EmployerAggregateRating" ;
-    :category "issue-1689" ;
     :source <https://github.com/schemaorg/schemaorg/issues/1689> ;
     rdfs:comment "An aggregate rating of an Organization related to its role as an employer." ;
     rdfs:subClassOf :AggregateRating .
@@ -1093,7 +1088,6 @@ Originally, URLs from [GoodRelations](http://purl.org/goodrelations/v1) were use
 
 :EndorsementRating a rdfs:Class ;
     rdfs:label "EndorsementRating" ;
-    :category "issue-1293" ;
     :source <https://github.com/schemaorg/schemaorg/issues/1293> ;
     rdfs:comment """An EndorsementRating is a rating that expresses some level of endorsement, for example inclusion in a "critic's pick" blog, a
 "Like" or "+1" on a social network. It can be considered the [[result]] of an [[EndorseAction]] in which the [[object]] of the action is rated positively by
@@ -1174,14 +1168,12 @@ endorsement rating is particularly useful in the absence of numeric scales as it
 
 :FAQPage a rdfs:Class ;
     rdfs:label "FAQPage" ;
-    :category "issue-1723" ;
     :source <https://github.com/schemaorg/schemaorg/issues/1723> ;
     rdfs:comment "A [[FAQPage]] is a [[WebPage]] presenting one or more \"[Frequently asked questions](https://en.wikipedia.org/wiki/FAQ)\" (see also [[QAPage]])." ;
     rdfs:subClassOf :WebPage .
 
 :FMRadioChannel a rdfs:Class ;
     rdfs:label "FMRadioChannel" ;
-    :category "issue-1004" ;
     :source <https://github.com/schemaorg/schemaorg/issues/1004> ;
     rdfs:comment "A radio channel that uses FM." ;
     rdfs:subClassOf :RadioChannel .
@@ -1735,10 +1727,6 @@ See also the <a href="/docs/hotels.html">dedicated document on the use of schema
     rdfs:comment "Specifies a location feature by providing a structured value representing a feature of an accommodation as a property-value pair of varying degrees of formality." ;
     rdfs:subClassOf :PropertyValue .
 
-:LockerDelivery a :DeliveryMethod ;
-    rdfs:label "LockerDelivery" ;
-    rdfs:comment "A DeliveryMethod in which an item is made available via locker." .
-
 :Locksmith a rdfs:Class ;
     rdfs:label "Locksmith" ;
     rdfs:comment "A locksmith." ;
@@ -1791,7 +1779,6 @@ See also the <a href="/docs/hotels.html">dedicated document on the use of schema
 
 :MediaSubscription a rdfs:Class ;
     rdfs:label "MediaSubscription" ;
-    :category "issue-1741" ;
     :source <https://github.com/schemaorg/schemaorg/issues/1741> ;
     rdfs:comment "A subscription which allows a user to access media including audio, video, books, etc." ;
     rdfs:subClassOf :Intangible .
@@ -1858,7 +1845,6 @@ See also the <a href="/docs/hotels.html">dedicated document on the use of schema
 
 :MonetaryAmountDistribution a rdfs:Class ;
     rdfs:label "MonetaryAmountDistribution" ;
-    :category "issue-1698" ;
     :source <https://github.com/schemaorg/schemaorg/issues/1698> ;
     rdfs:comment "A statistical distribution of monetary amounts." ;
     rdfs:subClassOf :QuantitativeValueDistribution .
@@ -2049,7 +2035,6 @@ A more detailed overview of [schema.org News markup](/docs/news.html) is also av
 
 :Occupation a rdfs:Class ;
     rdfs:label "Occupation" ;
-    :category "issue-1698" ;
     :source <https://github.com/schemaorg/schemaorg/issues/1698> ;
     rdfs:comment "A profession, may involve prolonged training and/or a formal qualification." ;
     rdfs:subClassOf :Intangible .
@@ -2153,12 +2138,6 @@ The place is __open__ if the [[opens]] property is specified, and __closed__ oth
     rdfs:label "ParcelDelivery" ;
     rdfs:comment "The delivery of a parcel either via the postal service or a commercial service." ;
     rdfs:subClassOf :Intangible .
-
-:ParcelService a :DeliveryMethod ;
-    rdfs:label "ParcelService" ;
-    :source <http://www.w3.org/wiki/WebSchemas/SchemaDotOrgSources#source_GoodRelationsClass> ;
-    rdfs:comment """A private parcel service as the delivery mode available for a certain offer.\\n\\nCommonly used values:\\n\\n* http://purl.org/goodrelations/v1#DHL\\n* http://purl.org/goodrelations/v1#FederalExpress\\n* http://purl.org/goodrelations/v1#UPS
-      """ .
 
 :ParentAudience a rdfs:Class ;
     rdfs:label "ParentAudience" ;
@@ -2338,7 +2317,6 @@ The place is __open__ if the [[opens]] property is specified, and __closed__ oth
 
 :PreOrderAction a rdfs:Class ;
     rdfs:label "PreOrderAction" ;
-    :category "issue-1125" ;
     :source <https://github.com/schemaorg/schemaorg/issues/1125> ;
     rdfs:comment "An agent orders a (not yet released) object/product/service to be delivered/sent." ;
     rdfs:subClassOf :TradeAction .
@@ -2448,7 +2426,6 @@ The place is __open__ if the [[opens]] property is specified, and __closed__ oth
 
 :QuantitativeValueDistribution a rdfs:Class ;
     rdfs:label "QuantitativeValueDistribution" ;
-    :category "issue-1698" ;
     :source <https://github.com/schemaorg/schemaorg/issues/1698> ;
     rdfs:comment "A statistical distribution of values." ;
     rdfs:subClassOf :StructuredValue .
@@ -2797,7 +2774,8 @@ See also the <a href="/docs/hotels.html">dedicated document on the use of schema
 :SkiResort a rdfs:Class ;
     rdfs:label "SkiResort" ;
     rdfs:comment "A ski resort." ;
-    rdfs:subClassOf :SportsActivityLocation, :Resort .
+    rdfs:subClassOf :Resort,
+        :SportsActivityLocation .
 
 :SocialEvent a rdfs:Class ;
     rdfs:label "SocialEvent" ;
@@ -2827,7 +2805,6 @@ See also the <a href="/docs/hotels.html">dedicated document on the use of schema
 
 :SpeakableSpecification a rdfs:Class ;
     rdfs:label "SpeakableSpecification" ;
-    :category "issue-1389" ;
     :source <https://github.com/schemaorg/schemaorg/issues/1389> ;
     rdfs:comment "A SpeakableSpecification indicates (typically via [[xpath]] or [[cssSelector]]) sections of a document that are highlighted as particularly [[speakable]]. Instances of this type are expected to be used primarily as values of the [[speakable]] property." ;
     rdfs:subClassOf :Intangible .
@@ -2882,6 +2859,12 @@ See also the <a href="/docs/hotels.html">dedicated document on the use of schema
     rdfs:label "State" ;
     rdfs:comment "A state or province of a country." ;
     rdfs:subClassOf :AdministrativeArea .
+
+:StatusEnumeration a rdfs:Class ;
+    rdfs:label "StatusEnumeration" ;
+    :source <https://github.com/schemaorg/schemaorg/issues/2604> ;
+    rdfs:comment "Lists or enumerations dealing with status types." ;
+    rdfs:subClassOf :Enumeration .
 
 :SteeringPositionValue a rdfs:Class ;
     rdfs:label "SteeringPositionValue" ;
@@ -3359,7 +3342,6 @@ See also the <a href="/docs/hotels.html">dedicated document on the use of schema
 
 :WorkersUnion a rdfs:Class ;
     rdfs:label "WorkersUnion" ;
-    :category "issue-243" ;
     :source <https://github.com/schemaorg/schemaorg/issues/243> ;
     rdfs:comment "A Workers Union (also known as a Labor Union, Labour Union, or Trade Union) is an organization that promotes the interests of its worker members by collectively bargaining with management, organizing, and political lobbying." ;
     rdfs:subClassOf :Organization .
@@ -3584,6 +3566,10 @@ See also the <a href="/docs/hotels.html">dedicated document on the use of schema
     :source <http://www.w3.org/wiki/WebSchemas/SchemaDotOrgSources#MBZ> ;
     rdfs:comment "LiveAlbum." .
 
+:LockerDelivery a :DeliveryMethod ;
+    rdfs:label "LockerDelivery" ;
+    rdfs:comment "A DeliveryMethod in which an item is made available via locker." .
+
 :LowCalorieDiet a :RestrictedDiet ;
     rdfs:label "LowCalorieDiet" ;
     rdfs:comment "A diet focused on reduced calorie intake." .
@@ -3685,6 +3671,12 @@ See also the <a href="/docs/hotels.html">dedicated document on the use of schema
 :Paperback a :BookFormatType ;
     rdfs:label "Paperback" ;
     rdfs:comment "Book format: Paperback." .
+
+:ParcelService a :DeliveryMethod ;
+    rdfs:label "ParcelService" ;
+    :source <http://www.w3.org/wiki/WebSchemas/SchemaDotOrgSources#source_GoodRelationsClass> ;
+    rdfs:comment """A private parcel service as the delivery mode available for a certain offer.\\n\\nCommonly used values:\\n\\n* http://purl.org/goodrelations/v1#DHL\\n* http://purl.org/goodrelations/v1#FederalExpress\\n* http://purl.org/goodrelations/v1#UPS
+      """ .
 
 :ParkingMap a :MapCategoryType ;
     rdfs:label "ParkingMap" ;
@@ -3914,7 +3906,6 @@ See also the <a href="/docs/hotels.html">dedicated document on the use of schema
 
 :accessMode a rdf:Property ;
     rdfs:label "accessMode" ;
-    :category "issue-1110" ;
     :domainIncludes :CreativeWork ;
     :rangeIncludes :Text ;
     :source <https://github.com/schemaorg/schemaorg/issues/1100> ;
@@ -3923,7 +3914,6 @@ See also the <a href="/docs/hotels.html">dedicated document on the use of schema
 
 :accessModeSufficient a rdf:Property ;
     rdfs:label "accessModeSufficient" ;
-    :category "issue-1110" ;
     :domainIncludes :CreativeWork ;
     :rangeIncludes :ItemList ;
     :source <https://github.com/schemaorg/schemaorg/issues/1100> ;
@@ -3956,7 +3946,6 @@ See also the <a href="/docs/hotels.html">dedicated document on the use of schema
 
 :accessibilitySummary a rdf:Property ;
     rdfs:label "accessibilitySummary" ;
-    :category "issue-1110" ;
     :domainIncludes :CreativeWork ;
     :rangeIncludes :Text ;
     :source <https://github.com/schemaorg/schemaorg/issues/1100> ;
@@ -3984,7 +3973,6 @@ See also the <a href="/docs/hotels.html">dedicated document on the use of schema
 
 :actionAccessibilityRequirement a rdf:Property ;
     rdfs:label "actionAccessibilityRequirement" ;
-    :category "issue-1741" ;
     :domainIncludes :ConsumeAction ;
     :rangeIncludes :ActionAccessSpecification ;
     :source <https://github.com/schemaorg/schemaorg/issues/1741> ;
@@ -4183,7 +4171,6 @@ See also the <a href="/docs/hotels.html">dedicated document on the use of schema
 
 :amount a rdf:Property ;
     rdfs:label "amount" ;
-    :category "issue-1698" ;
     :domainIncludes :DatedMoneySpecification,
         :InvestmentOrDeposit,
         :LoanOrCredit ;
@@ -4391,7 +4378,6 @@ See also the <a href="/docs/hotels.html">dedicated document on the use of schema
 
 :authenticator a rdf:Property ;
     rdfs:label "authenticator" ;
-    :category "issue-1741" ;
     :domainIncludes :MediaSubscription ;
     :rangeIncludes :Organization ;
     :source <https://github.com/schemaorg/schemaorg/issues/1741> ;
@@ -4414,7 +4400,6 @@ See also the <a href="/docs/hotels.html">dedicated document on the use of schema
 
 :availabilityEnds a rdf:Property ;
     rdfs:label "availabilityEnds" ;
-    :category "issue-1741" ;
     :domainIncludes :ActionAccessSpecification,
         :Demand,
         :Offer ;
@@ -4426,7 +4411,6 @@ See also the <a href="/docs/hotels.html">dedicated document on the use of schema
 
 :availabilityStarts a rdf:Property ;
     rdfs:label "availabilityStarts" ;
-    :category "issue-1741" ;
     :domainIncludes :ActionAccessSpecification,
         :Demand,
         :Offer ;
@@ -4693,7 +4677,6 @@ See also the <a href="/docs/hotels.html">dedicated document on the use of schema
 
 :broadcastFrequency a rdf:Property ;
     rdfs:label "broadcastFrequency" ;
-    :category "issue-1004" ;
     :domainIncludes :BroadcastChannel,
         :BroadcastService ;
     :rangeIncludes :BroadcastFrequencySpecification,
@@ -4703,7 +4686,6 @@ See also the <a href="/docs/hotels.html">dedicated document on the use of schema
 
 :broadcastFrequencyValue a rdf:Property ;
     rdfs:label "broadcastFrequencyValue" ;
-    :category "issue-1004" ;
     :domainIncludes :BroadcastFrequencySpecification ;
     :rangeIncludes :Number,
         :QuantitativeValue ;
@@ -4840,7 +4822,6 @@ See also the <a href="/docs/hotels.html">dedicated document on the use of schema
 
 :category a rdf:Property ;
     rdfs:label "category" ;
-    :category "issue-1741" ;
     :domainIncludes :ActionAccessSpecification,
         :Invoice,
         :Offer,
@@ -4941,7 +4922,6 @@ See also the <a href="/docs/hotels.html">dedicated document on the use of schema
 
 :claimReviewed a rdf:Property ;
     rdfs:label "claimReviewed" ;
-    :category "issue-1061" ;
     :domainIncludes :ClaimReview ;
     :rangeIncludes :Text ;
     :source <https://github.com/schemaorg/schemaorg/issues/1061> ;
@@ -5203,7 +5183,6 @@ See also the <a href="/docs/hotels.html">dedicated document on the use of schema
 
 :cssSelector a rdf:Property ;
     rdfs:label "cssSelector" ;
-    :category "issue-1389" ;
     :domainIncludes :SpeakableSpecification,
         :WebPageElement ;
     :rangeIncludes :CssSelectorType ;
@@ -5592,7 +5571,6 @@ Dateline summaries are oriented more towards human readers than towards automate
 
 :educationRequirements a rdf:Property ;
     rdfs:label "educationRequirements" ;
-    :category "issue-1698" ;
     :domainIncludes :JobPosting,
         :Occupation ;
     :rangeIncludes :Text ;
@@ -5657,7 +5635,6 @@ This property should not be used where the nature of the alignment can be descri
 
 :eligibleRegion a rdf:Property ;
     rdfs:label "eligibleRegion" ;
-    :category "issue-1741" ;
     :domainIncludes :ActionAccessSpecification,
         :DeliveryChargeSpecification,
         :Demand,
@@ -5800,7 +5777,6 @@ This property should not be used where the nature of the alignment can be descri
 
 :estimatedSalary a rdf:Property ;
     rdfs:label "estimatedSalary" ;
-    :category "issue-1698" ;
     :domainIncludes :JobPosting,
         :Occupation ;
     :rangeIncludes :MonetaryAmount,
@@ -5846,7 +5822,6 @@ This property should not be used where the nature of the alignment can be descri
 
 :expectsAcceptanceOf a rdf:Property ;
     rdfs:label "expectsAcceptanceOf" ;
-    :category "issue-1741" ;
     :domainIncludes :ActionAccessSpecification,
         :ConsumeAction,
         :MediaSubscription ;
@@ -5856,7 +5831,6 @@ This property should not be used where the nature of the alignment can be descri
 
 :experienceRequirements a rdf:Property ;
     rdfs:label "experienceRequirements" ;
-    :category "issue-1698" ;
     :domainIncludes :JobPosting,
         :Occupation ;
     :rangeIncludes :Text ;
@@ -6235,7 +6209,6 @@ Typical unit code(s): MTK for square meter, FTK for square foot, or YDK for squa
 
 :hasOccupation a rdf:Property ;
     rdfs:label "hasOccupation" ;
-    :category "issue-1698" ;
     :domainIncludes :Person ;
     :rangeIncludes :Occupation ;
     :source <https://github.com/schemaorg/schemaorg/issues/1698> ;
@@ -6541,8 +6514,6 @@ Typical unit code(s): MTK for square meter, FTK for square foot, or YDK for squa
     # The textual definition for isVariantOf has been minimally updated to accomodate ProductGroup; this could be
     # :isVariantOf a rdf:Property ; :domainIncludes :Product ; :rangeIncludes :ProductGroup .
 
-
-
 :isbn a rdf:Property ;
     rdfs:label "isbn" ;
     :domainIncludes :Book ;
@@ -6666,7 +6637,9 @@ Typical unit code(s): MTK for square meter, FTK for square foot, or YDK for squa
 :keywords a rdf:Property ;
     rdfs:label "keywords" ;
     :domainIncludes :CreativeWork ;
-    :rangeIncludes :Text, :DefinedTerm, :URL ;
+    :rangeIncludes :DefinedTerm,
+        :Text,
+        :URL ;
     rdfs:comment "Keywords or tags used to describe this content. Multiple entries in a keywords list are typically delimited by commas." .
 
 :knownVehicleDamages a rdf:Property ;
@@ -6911,7 +6884,6 @@ Typical unit code(s): MTK for square meter, FTK for square foot, or YDK for squa
 
 :median a rdf:Property ;
     rdfs:label "median" ;
-    :category "issue-1698" ;
     :domainIncludes :QuantitativeValueDistribution ;
     :rangeIncludes :Number ;
     :source <https://github.com/schemaorg/schemaorg/issues/1698> ;
@@ -6956,7 +6928,6 @@ Typical unit code(s): MTK for square meter, FTK for square foot, or YDK for squa
 
 :menuAddOn a rdf:Property ;
     rdfs:label "menuAddOn" ;
-    :category "issue-1541" ;
     :domainIncludes :MenuItem ;
     :rangeIncludes :MenuItem,
         :MenuSection ;
@@ -7281,7 +7252,6 @@ Typical unit code(s): C62 for person""" .
 
 :occupationLocation a rdf:Property ;
     rdfs:label "occupationLocation" ;
-    :category "issue-1698" ;
     :domainIncludes :Occupation ;
     :rangeIncludes :AdministrativeArea ;
     :source <https://github.com/schemaorg/schemaorg/issues/1698> ;
@@ -7289,7 +7259,6 @@ Typical unit code(s): C62 for person""" .
 
 :occupationalCategory a rdf:Property ;
     rdfs:label "occupationalCategory" ;
-    :category "issue-1698" ;
     :domainIncludes :JobPosting,
         :Occupation ;
     :rangeIncludes :Text ;
@@ -7583,7 +7552,6 @@ Note: for historical reasons, any textual label and formal code provided as a li
 
 :percentile10 a rdf:Property ;
     rdfs:label "percentile10" ;
-    :category "issue-1698" ;
     :domainIncludes :QuantitativeValueDistribution ;
     :rangeIncludes :Number ;
     :source <https://github.com/schemaorg/schemaorg/issues/1698> ;
@@ -7591,7 +7559,6 @@ Note: for historical reasons, any textual label and formal code provided as a li
 
 :percentile25 a rdf:Property ;
     rdfs:label "percentile25" ;
-    :category "issue-1698" ;
     :domainIncludes :QuantitativeValueDistribution ;
     :rangeIncludes :Number ;
     :source <https://github.com/schemaorg/schemaorg/issues/1698> ;
@@ -7599,7 +7566,6 @@ Note: for historical reasons, any textual label and formal code provided as a li
 
 :percentile75 a rdf:Property ;
     rdfs:label "percentile75" ;
-    :category "issue-1698" ;
     :domainIncludes :QuantitativeValueDistribution ;
     :rangeIncludes :Number ;
     :source <https://github.com/schemaorg/schemaorg/issues/1698> ;
@@ -7607,7 +7573,6 @@ Note: for historical reasons, any textual label and formal code provided as a li
 
 :percentile90 a rdf:Property ;
     rdfs:label "percentile90" ;
-    :category "issue-1698" ;
     :domainIncludes :QuantitativeValueDistribution ;
     :rangeIncludes :Number ;
     :source <https://github.com/schemaorg/schemaorg/issues/1698> ;
@@ -8003,7 +7968,6 @@ While such policies are most typically expressed in natural language, sometimes 
 
 :qualifications a rdf:Property ;
     rdfs:label "qualifications" ;
-    :category "issue-1698" ;
     :domainIncludes :JobPosting,
         :Occupation ;
     :rangeIncludes :Text ;
@@ -8154,7 +8118,6 @@ While such policies are most typically expressed in natural language, sometimes 
 
 :relevantOccupation a rdf:Property ;
     rdfs:label "relevantOccupation" ;
-    :category "issue-1698" ;
     :domainIncludes :JobPosting ;
     :rangeIncludes :Occupation ;
     :source <https://github.com/schemaorg/schemaorg/issues/1698> ;
@@ -8242,7 +8205,6 @@ While such policies are most typically expressed in natural language, sometimes 
 
 :requiresSubscription a rdf:Property ;
     rdfs:label "requiresSubscription" ;
-    :category "issue-1741" ;
     :domainIncludes :ActionAccessSpecification,
         :MediaObject ;
     :rangeIncludes :Boolean,
@@ -8276,7 +8238,6 @@ While such policies are most typically expressed in natural language, sometimes 
 
 :responsibilities a rdf:Property ;
     rdfs:label "responsibilities" ;
-    :category "issue-1698" ;
     :domainIncludes :JobPosting,
         :Occupation ;
     :rangeIncludes :Text ;
@@ -8300,7 +8261,6 @@ While such policies are most typically expressed in natural language, sometimes 
 
 :reviewAspect a rdf:Property ;
     rdfs:label "reviewAspect" ;
-    :category "issue-1689" ;
     :domainIncludes :Rating,
         :Review ;
     :rangeIncludes :Text ;
@@ -8568,8 +8528,6 @@ While such policies are most typically expressed in natural language, sometimes 
 
 :skills a rdf:Property ;
     rdfs:label "skills" ;
-    :category "issue-1698",
-        "issue-2322" ;
     :domainIncludes :JobPosting,
         :Occupation ;
     :rangeIncludes :DefinedTerm,
@@ -8654,7 +8612,6 @@ While such policies are most typically expressed in natural language, sometimes 
 
 :speakable a rdf:Property ;
     rdfs:label "speakable" ;
-    :category "issue-1389" ;
     :domainIncludes :Article,
         :WebPage ;
     :rangeIncludes :SpeakableSpecification,
@@ -9518,7 +9475,6 @@ we define a supporting type, [[SpeakableSpecification]]  which is defined to be 
 
 :xpath a rdf:Property ;
     rdfs:label "xpath" ;
-    :category "issue-1389" ;
     :domainIncludes :SpeakableSpecification,
         :WebPageElement ;
     :rangeIncludes :XPathType ;
@@ -9731,7 +9687,6 @@ we define a supporting type, [[SpeakableSpecification]]  which is defined to be 
 
 :duration a rdf:Property ;
     rdfs:label "duration" ;
-    :category "issue-1698" ;
     :domainIncludes :Event,
         :MediaObject,
         :Movie,
@@ -9832,7 +9787,6 @@ Unregistered or niche encoding and file formats can be indicated instead via the
 
 :hasBroadcastChannel a rdf:Property ;
     rdfs:label "hasBroadcastChannel" ;
-    :category "issue-1004" ;
     :domainIncludes :BroadcastService ;
     :inverseOf :providesBroadcastService ;
     :rangeIncludes :BroadcastChannel ;
@@ -9871,7 +9825,9 @@ Unregistered or niche encoding and file formats can be indicated instead via the
 
 :isAccessibleForFree a rdf:Property ;
     rdfs:label "isAccessibleForFree" ;
-    :domainIncludes :CreativeWork, :Event, :Place;
+    :domainIncludes :CreativeWork,
+        :Event,
+        :Place ;
     :rangeIncludes :Boolean ;
     rdfs:comment "A flag to signal that the item, event, or place is accessible for free." .
 
@@ -10160,7 +10116,6 @@ Unregistered or niche encoding and file formats can be indicated instead via the
 
 :subjectOf a rdf:Property ;
     rdfs:label "subjectOf" ;
-    :category "issue-1670" ;
     :domainIncludes :Thing ;
     :inverseOf :about ;
     :rangeIncludes :CreativeWork,
@@ -10243,7 +10198,6 @@ Open-ended date ranges can be written with ".." in place of the end date. For ex
 
 :about a rdf:Property ;
     rdfs:label "about" ;
-    :category "issue-1670" ;
     :domainIncludes :CommunicateAction,
         :CreativeWork,
         :Event ;
@@ -10362,6 +10316,10 @@ Open-ended date ranges can be written with ".." in place of the end date. For ex
     rdfs:comment """A work featured in some event, e.g. exhibited in an ExhibitionEvent.
        Specific subproperties are available for workPerformed (e.g. a play), or a workPresented (a Movie at a ScreeningEvent).""" .
 
+<http://www.w3.org/wiki/WebSchemas/SchemaDotOrgSources#IIT-CNR.it> a :Organization ;
+    rdfs:label "IITCNRit" ;
+    rdfs:comment "This element is based on work by the Web Applications for the Future Internet Lab, Institute of Informatics and Telematics, Pisa, Italy." .
+
 <http://www.w3.org/wiki/WebSchemas/SchemaDotOrgSources#source_LRMIClass> a :Organization ;
     rdfs:label "LRMIClass" ;
     rdfs:comment "This class is based on the work of the LRMI project, see lrmi.net for details." .
@@ -10418,9 +10376,9 @@ Open-ended date ranges can be written with ".." in place of the end date. For ex
     rdfs:comment "A sub property of participant. The participant who is at the receiving end of the action." ;
     rdfs:subPropertyOf :participant .
 
-<http://www.w3.org/wiki/WebSchemas/SchemaDotOrgSources#IIT-CNR.it> a :Organization ;
-    rdfs:label "IITCNRit" ;
-    rdfs:comment "This element is based on work by the Web Applications for the Future Internet Lab, Institute of Informatics and Telematics, Pisa, Italy." .
+<http://www.w3.org/wiki/WebSchemas/SchemaDotOrgSources#Tourism> a :Organization ;
+    rdfs:label "Tourism" ;
+    rdfs:comment "This element is based on the work of the [Tourism Structured Web Data Community Group](https://www.w3.org/community/tourismdata)." .
 
 <http://www.w3.org/wiki/WebSchemas/SchemaDotOrgSources#source_ActionCollabClass> a :Organization ;
     rdfs:label "ActionCollabClass" ;
@@ -10437,10 +10395,6 @@ Open-ended date ranges can be written with ".." in place of the end date. For ex
     :rangeIncludes :CreativeWork ;
     :source <http://www.w3.org/wiki/WebSchemas/SchemaDotOrgSources#source_bibex> ;
     rdfs:comment "Indicates an item or CreativeWork that is part of this item, or CreativeWork (in some sense)." .
-
-<http://www.w3.org/wiki/WebSchemas/SchemaDotOrgSources#Tourism> a :Organization ;
-    rdfs:label "Tourism" ;
-    rdfs:comment "This element is based on the work of the [Tourism Structured Web Data Community Group](https://www.w3.org/community/tourismdata)." .
 
 <http://www.w3.org/wiki/WebSchemas/SchemaDotOrgSources#source_GoodRelationsTerms> a :Organization ;
     rdfs:label "GoodRelationsTerms" ;
@@ -10532,12 +10486,3 @@ Open-ended date ranges can be written with ".." in place of the end date. For ex
     ([www.musicbrainz.org](http://www.musicbrainz.org)), and is partially inspired by the MusicBrainz and
     [Music Ontology](http://musicontology.com/docs/getting-started.html) schemas.""" .
 
-
-# Added here as it affects many core enums; otherwise it would be in pending
-
-:StatusEnumeration a rdfs:Class ;
-    rdfs:label "StatusEnumeration" ;
-    :category "issue-2604" ;
-    :source <https://github.com/schemaorg/schemaorg/issues/2604> ;
-    rdfs:comment "Lists or enumerations dealing with status types." ;
-    rdfs:subClassOf :Enumeration .

--- a/scripts/inputconvert.py
+++ b/scripts/inputconvert.py
@@ -28,7 +28,6 @@ from rdflib.plugins.sparql import prepareQuery, processUpdate
 from rdflib.compare import graph_diff
 from rdflib.namespace import RDFS, RDF
 
-import pyRdfa
 
 rdflib.plugin.register("jsonld", Parser, "rdflib_jsonld.parser", "JsonLDParser")
 rdflib.plugin.register("rdfa", Parser, "pyRdfa.rdflibparsers", "RDFaParser")
@@ -51,19 +50,17 @@ format = args.format
 combine = args.combinefile
 
 SPARQL1 = """
-PREFIX dc: <http://purl.org/dc/terms/> 
 PREFIX schema: <http://schema.org/> 
 
-DELETE { ?s dc:source ?o }
-INSERT { ?s schema:source ?o }
+DELETE { ?s schema:category ?o }
 WHERE {
-    ?s dc:source ?o .
+    ?s schema:category ?o .
 }
 """
 
 def out(filename):
     graph.update(SPARQL1)
-    graph.bind('',URIRef('http://schema.org/'),override=True, replace=True)
+    graph.bind('',URIRef('http://schema.org/'),override=True)
     if args.outputdir:
         outfile = "%s/%s" % (args.outputdir,filename)
     else:

--- a/util/buildocspages.py
+++ b/util/buildocspages.py
@@ -55,13 +55,21 @@ def homePage(page):
     termcount=0
     if filt:
         terms = SdoTermSource.getAllTerms(layer=filt,expanded=True)
-        terms.sort(key = lambda u: (u.category, u.id))
+        for t in terms:
+            t.cat = ""
+            if filt == "pending":
+                for s in t.sources:
+                    if "schemaorg/issue" in s:
+                        t.cat = "issue-" + os.path.basename(s)
+                        break           
+        terms.sort(key = lambda u: (u.cat,u.id))
+
         first = True
         cat = None
         for t in terms:
-            if first or t.category != cat:
+            if first or t.cat != cat:
                 first = False
-                cat = t.category 
+                cat = t.cat
                 ttypes = {}
                 sectionterms[cat] = ttypes
                 ttypes[SdoTerm.TYPE] = []
@@ -74,6 +82,8 @@ def homePage(page):
             ttypes[t.termType].append(t)
             termcount += 1
     
+    sectionterms = dict(sorted(sectionterms.items()))
+
     extra_vars = {
         'home_page': "True",
         'title': SITENAME,


### PR DESCRIPTION
Implements issue #2767 
Mostly in pending, or terms moved from pending. 

Previously category was used for housekeeping reasons.

Also removed code that is now also redundant.