### PR TITLE
legalName subPropertyOf name

### DIFF
--- a/data/schema.ttl
+++ b/data/schema.ttl
@@ -6698,7 +6698,8 @@ Typical unit code(s): MTK for square meter, FTK for square foot, or YDK for squa
     rdfs:label "legalName" ;
     :domainIncludes :Organization ;
     :rangeIncludes :Text ;
-    rdfs:comment "The official name of the organization, e.g. the registered company name." .
+    rdfs:comment "The official name of the organization, e.g. the registered company name." ;
+    rdfs:subPropertyOf :name .
 
 :leiCode a rdf:Property ;
     rdfs:label "leiCode" ;
@@ -10486,4 +10487,3 @@ Open-ended date ranges can be written with ".." in place of the end date. For ex
     rdfs:comment """This vocabulary was improved through collaboration with the MusicBrainz project
     ([www.musicbrainz.org](http://www.musicbrainz.org)), and is partially inspired by the MusicBrainz and
     [Music Ontology](http://musicontology.com/docs/getting-started.html) schemas.""" .
-


### PR DESCRIPTION
I propose [legalName][schema:legalName] becomes a [subPropertyOf][rdfs:subPropertyOf] [name][schema:name]

```
:legalName a rdf:Property ;
    rdfs:label "legalName" ;
    :domainIncludes :Organization ;
    :rangeIncludes :Text ;
    rdfs:comment "The official name of the organization, e.g. the registered company name." ;
    rdfs:subPropertyOf :name .
```

<!-- links -->
[rdfs:subPropertyOf]: https://www.w3.org/TR/rdf-schema/#ch_subpropertyof "rdfs:subPropertyOf"

[schema:legalName]: https://schema.org/legalName "schema:legalName"
[schema:name]: https://schema.org/name "schema:name"

