### PR TITLE
Update Link

### DIFF
--- a/docs/datamodel.html
+++ b/docs/datamodel.html
@@ -57,7 +57,7 @@ to allow for reflection, i.e., for the schema to be represented in terms of itse
 
 <p>
 Now-obsolete snapshots of <a href='https://web.archive.org/web/20150414142113/http://schema.org/docs/full_md.html'>Microdata</a> and <a href='schemaorg.owl'>OWL</a> experimental
-data dumps were previously published. See also <a href="http://topbraid.org/schema/">TopBraid's version</a>.
+data dumps were previously published. See also <a href="http://datashapes.org/schema">TopQuadrant's version</a>.
 </p>
 
 <p>See the "<a href="/docs/developers.html">developers</a>" page for more information on machine-readable views of schema.org.</p>


### PR DESCRIPTION
TopBraid is now TopQuadrant. Now hosted at datashapes.org.