### PR TITLE
Fix Typo and Document Footer

### DIFF
--- a/docs/data-and-datasets.html
+++ b/docs/data-and-datasets.html
@@ -20,7 +20,7 @@
 <p>This note provides some background on various notions of "data" and "dataset" related to Schema.org.</p>
 
 <p>Schema.org as a project, and as a collection of terms, is entirely devoted to data. In other words, it <em>always</em> provides, characterises, describes, or encodes some form of data. Schema.org defines particular types
-such as <a href="/Event">Event</a>, <a href="/NewsArticle">NewsArticle</a>, <a href="/Review">Review</a>, <a href="/Person">Person</a>, as well as properties that characterize and interlink instances of these types. For example, the <a href="/alumni">alumni</a> property links <a href="/Person">people</a> with <a href="/EducationalOrganization">educational organizations</a>. The <a href="/alumni">alumni</a> property exists to provide information about people being alumni of organizations; <a href="/Volcano">Volcano</a> exists to provide information about volcanoes, and so on. However, there can sometimees be confusion when the thing we are providing information about, is itself thought of as (typically a bundle of) data.
+such as <a href="/Event">Event</a>, <a href="/NewsArticle">NewsArticle</a>, <a href="/Review">Review</a>, <a href="/Person">Person</a>, as well as properties that characterize and interlink instances of these types. For example, the <a href="/alumni">alumni</a> property links <a href="/Person">people</a> with <a href="/EducationalOrganization">educational organizations</a>. The <a href="/alumni">alumni</a> property exists to provide information about people being alumni of organizations; <a href="/Volcano">Volcano</a> exists to provide information about volcanoes, and so on. However, there can sometimes be confusion when the thing we are providing information about, is itself thought of as (typically a bundle of) data.
 </p>
 
 <p>Schema.org itself also contains some dedicated vocabulary that can be used in applications which publish,
@@ -65,11 +65,7 @@ While http://schema.org/Volcano can be used to directly provide information abou
 
 </div>
 
+<!-- #### Static Doc Insert Footer here -->
 
-<div id="footer"><p>
-  <a href="../docs/terms.html">Terms and conditions</a></p>
-</div>
-
-</body><!-- #### Static Doc Insert Footer here -->
-
+</body>
 </html>


### PR DESCRIPTION
The document footer fix is to remove the duplicate display of the terms and conditions.