### PR TITLE
Fix links to release pages from releases page

### DIFF
--- a/data/releases/10.0/schema-all.html
+++ b/data/releases/10.0/schema-all.html
@@ -88,8 +88,9 @@ var s = document.getElementsByTagName('script')[0]; s.parentNode.insertBefore(gc
  <dt>Version:</dt>
  <dd>10.0</dd>
 
- <dt>URL:</dt>
- <dd><a href="http://schema.org/version/10.0/">http://schema.org/version/10.0/</a></dd>
+ <dt>Archive URL:</dt>
+ <dd><a href="https://github.com/schemaorg/schemaorg/tree/main/data/releases/10.0/">
+    https://github.com/schemaorg/schemaorg/tree/main/data/releases/10.0/</a></dd>
 
  <dt>Published:</dt>
  <dd>2020-08-15</dd>

--- a/data/releases/10.0/schema-all.html
+++ b/data/releases/10.0/schema-all.html
@@ -4,6 +4,7 @@
   <!-- Generated from headtags.tpl -->
     <meta charset="utf-8" >
     <link rel="shortcut icon" type="image/png" href="/docs/favicon.ico"/>
+    <link rel="stylesheet" type="text/css" href="https://schema.org/docs/schemaorg.css" />
     <link rel="stylesheet" type="text/css" href="/docs/schemaorg.css" />
     <link rel="stylesheet" type="text/css" href="/docs/devnote.css" />
     <link rel="stylesheet" type="text/css" href="/docs/prettify.css" />

--- a/data/releases/11.0/schema-all.html
+++ b/data/releases/11.0/schema-all.html
@@ -81,8 +81,9 @@
  <dt>Version:</dt>
  <dd>11.0</dd>
 
- <dt>URL:</dt>
- <dd><a href="http://schema.org/version/11.0/">http://schema.org/version/11.0/</a></dd>
+ <dt>Archive URL:</dt>
+ <dd><a href="https://github.com/schemaorg/schemaorg/tree/main/data/releases/11.0/">
+    https://github.com/schemaorg/schemaorg/tree/main/data/releases/11.0/</a></dd>
 
  <dt>Published:</dt>
  <dd>2020-11-30</dd>

--- a/data/releases/11.0/schema-all.html
+++ b/data/releases/11.0/schema-all.html
@@ -11,6 +11,7 @@
     <meta name="description" content="Schema.org is a set of extensible schemas that enables webmasters to embed
     structured data on their web pages for use by search engines and other applications." />
     <link rel="shortcut icon" type="image/png" href="/docs/favicon.ico"/>
+    <link rel="stylesheet" type="text/css" href="https://schema.org/docs/schemaorg.css" />
     <link rel="stylesheet" type="text/css" href="/docs/schemaorg.css" />
     <link rel="stylesheet" type="text/css" href="/docs/devnote.css" />
     <link rel="stylesheet" type="text/css" href="/docs/prettify.css" />

--- a/data/releases/11.01/schema-all.html
+++ b/data/releases/11.01/schema-all.html
@@ -11,6 +11,7 @@
     <meta name="description" content="Schema.org is a set of extensible schemas that enables webmasters to embed
     structured data on their web pages for use by search engines and other applications." />
     <link rel="shortcut icon" type="image/png" href="/docs/favicon.ico"/>
+    <link rel="stylesheet" type="text/css" href="http://schema.org/docs/schemaorg.css" />
     <link rel="stylesheet" type="text/css" href="/docs/schemaorg.css" />
     <link rel="stylesheet" type="text/css" href="/docs/devnote.css" />
     <link rel="stylesheet" type="text/css" href="/docs/prettify.css" />
@@ -80,8 +81,8 @@
  <dt>Version:</dt>
  <dd>11.01</dd>
 
- <dt>URL:</dt>
- <dd><a href="http://schema.org/version/11.01/">http://schema.org/version/11.01/</a></dd>
+ <dt>Archive URL:</dt>
+ <dd>https://github.com/schemaorg/schemaorg/tree/main/data/releases/11.01</dd>
 
  <dt>Published:</dt>
  <dd>2021-12-04</dd>

--- a/data/releases/11.01/schema-all.html
+++ b/data/releases/11.01/schema-all.html
@@ -11,7 +11,7 @@
     <meta name="description" content="Schema.org is a set of extensible schemas that enables webmasters to embed
     structured data on their web pages for use by search engines and other applications." />
     <link rel="shortcut icon" type="image/png" href="/docs/favicon.ico"/>
-    <link rel="stylesheet" type="text/css" href="http://schema.org/docs/schemaorg.css" />
+    <link rel="stylesheet" type="text/css" href="https://schema.org/docs/schemaorg.css" />
     <link rel="stylesheet" type="text/css" href="/docs/schemaorg.css" />
     <link rel="stylesheet" type="text/css" href="/docs/devnote.css" />
     <link rel="stylesheet" type="text/css" href="/docs/prettify.css" />

--- a/data/releases/11.01/schema-all.html
+++ b/data/releases/11.01/schema-all.html
@@ -82,7 +82,8 @@
  <dd>11.01</dd>
 
  <dt>Archive URL:</dt>
- <dd>https://github.com/schemaorg/schemaorg/tree/main/data/releases/11.01</dd>
+ <dd><a href="https://github.com/schemaorg/schemaorg/tree/main/data/releases/11.01"></a>
+    https://github.com/schemaorg/schemaorg/tree/main/data/releases/11.01</dd>
 
  <dt>Published:</dt>
  <dd>2021-12-04</dd>

--- a/data/releases/11.01/schema-all.html
+++ b/data/releases/11.01/schema-all.html
@@ -82,8 +82,8 @@
  <dd>11.01</dd>
 
  <dt>Archive URL:</dt>
- <dd><a href="https://github.com/schemaorg/schemaorg/tree/main/data/releases/11.01"></a>
-    https://github.com/schemaorg/schemaorg/tree/main/data/releases/11.01</dd>
+ <dd><a href="https://github.com/schemaorg/schemaorg/tree/main/data/releases/11.01/">
+    https://github.com/schemaorg/schemaorg/tree/main/data/releases/11.01/</a></dd>
 
  <dt>Published:</dt>
  <dd>2021-12-04</dd>

--- a/data/releases/2.0/schema-all.html
+++ b/data/releases/2.0/schema-all.html
@@ -73,8 +73,9 @@ customSearchControl.draw('cse-search-form', options);
  <dt>Version:</dt>
  <dd>2.0</dd>
 
- <dt>URL:</dt>
- <dd><a href="http://schema.org/version/2.0/">http://schema.org/version/2.0/</a></dd>
+ <dt>Archive URL:</dt>
+ <dd><a href="https://github.com/schemaorg/schemaorg/tree/main/data/releases/2.0/">
+    https://github.com/schemaorg/schemaorg/tree/main/data/releases/2.0/</a></dd>
 
  <dt>Published:</dt>
  <dd>2015-05-13</dd>

--- a/data/releases/2.0/schema-all.html
+++ b/data/releases/2.0/schema-all.html
@@ -6,6 +6,7 @@
     <title>Full Release Summary: Schema.org - 2.0 - 2015-05-13</title>
     <meta name="description" content="Schema.org is a set of extensible schemas that enables webmasters to embed
     structured data on their web pages for use by search engines and other applications." />
+    <link rel="stylesheet" type="text/css" href="https://schema.org/docs/schemaorg.css" />
     <link rel="stylesheet" type="text/css" href="/docs/schemaorg.css" />
 
     <base href="/version/2.0/" ></base>

--- a/data/releases/2.1/schema-all.html
+++ b/data/releases/2.1/schema-all.html
@@ -72,8 +72,9 @@ customSearchControl.draw('cse-search-form', options);
  <dt>Version:</dt>
  <dd>2.1</dd>
 
- <dt>URL:</dt>
- <dd><a href="http://schema.org/version/2.1/">http://schema.org/version/2.1/</a></dd>
+ <dt>Archive URL:</dt>
+ <dd><a href="https://github.com/schemaorg/schemaorg/tree/main/data/releases/2.1/">
+    https://github.com/schemaorg/schemaorg/tree/main/data/releases/2.1/</a></dd>
 
  <dt>Published:</dt>
  <dd>2015-08-06</dd>

--- a/data/releases/2.1/schema-all.html
+++ b/data/releases/2.1/schema-all.html
@@ -5,6 +5,7 @@
     <title>Full Release Summary: Schema.org - 2.1 - 2015-08-06</title>
     <meta name="description" content="Schema.org is a set of extensible schemas that enables webmasters to embed
     structured data on their web pages for use by search engines and other applications." />
+    <link rel="stylesheet" type="text/css" href="https://schema.org/docs/schemaorg.css" />
     <link rel="stylesheet" type="text/css" href="/docs/schemaorg.css" />
 
     <base href="/version/2.1/" ></base>

--- a/data/releases/2.2/schema-all.html
+++ b/data/releases/2.2/schema-all.html
@@ -72,8 +72,9 @@ customSearchControl.draw('cse-search-form', options);
  <dt>Version:</dt>
  <dd>latest</dd>
 
- <dt>URL:</dt>
- <dd><a href="http://schema.org/version/latest/">http://schema.org/version/latest/</a></dd>
+ <dt>Archive URL:</dt>
+ <dd><a href="https://github.com/schemaorg/schemaorg/tree/main/data/releases/2.2/">
+    https://github.com/schemaorg/schemaorg/tree/main/data/releases/2.2/</a></dd>
 
  <dt>Published:</dt>
  <dd>2015-11-05</dd>

--- a/data/releases/2.2/schema-all.html
+++ b/data/releases/2.2/schema-all.html
@@ -5,6 +5,7 @@
     <title>Full Release Summary: Schema.org - latest - 2015-11-05</title>
     <meta name="description" content="Schema.org is a set of extensible schemas that enables webmasters to embed
     structured data on their web pages for use by search engines and other applications." />
+    <link rel="stylesheet" type="text/css" href="https://schema.org/docs/schemaorg.css" />
     <link rel="stylesheet" type="text/css" href="/docs/schemaorg.css" />
 
     <base href="/version/latest/" ></base>

--- a/data/releases/3.0/schema-all.html
+++ b/data/releases/3.0/schema-all.html
@@ -5,6 +5,7 @@
     <title>Full Release Summary: Schema.org - 3.0 - 2016-05-04</title>
     <meta name="description" content="Schema.org is a set of extensible schemas that enables webmasters to embed
     structured data on their web pages for use by search engines and other applications." />
+    <link rel="stylesheet" type="text/css" href="https://schema.org/docs/schemaorg.css" />
     <link rel="stylesheet" type="text/css" href="/docs/schemaorg.css" />
 
     <base href="/version/3.0/" ></base>

--- a/data/releases/3.0/schema-all.html
+++ b/data/releases/3.0/schema-all.html
@@ -74,8 +74,9 @@ customSearchControl.draw('cse-search-form', options);
  <dt>Version:</dt>
  <dd>3.0</dd>
 
- <dt>URL:</dt>
- <dd><a href="http://schema.org/version/3.0/">http://schema.org/version/3.0/</a></dd>
+ <dt>Archive URL:</dt>
+ <dd><a href="https://github.com/schemaorg/schemaorg/tree/main/data/releases/3.0/">
+    https://github.com/schemaorg/schemaorg/tree/main/data/releases/3.0/</a></dd>
 
  <dt>Published:</dt>
  <dd>2016-05-04</dd>

--- a/data/releases/3.1/schema-all.html
+++ b/data/releases/3.1/schema-all.html
@@ -76,8 +76,9 @@ customSearchControl.draw('cse-search-form', options);
  <dt>Version:</dt>
  <dd>3.1</dd>
 
- <dt>URL:</dt>
- <dd><a href="http://schema.org/version/3.1/">http://schema.org/version/3.1/</a></dd>
+ <dt>Archive URL:</dt>
+ <dd><a href="https://github.com/schemaorg/schemaorg/tree/main/data/releases/3.1/">
+    https://github.com/schemaorg/schemaorg/tree/main/data/releases/3.1/</a></dd>
 
  <dt>Published:</dt>
  <dd>2016-08-09</dd>

--- a/data/releases/3.1/schema-all.html
+++ b/data/releases/3.1/schema-all.html
@@ -5,6 +5,7 @@
     <title>Full Release Summary: Schema.org - 3.1 - 2016-08-09</title>
     <meta name="description" content="Schema.org is a set of extensible schemas that enables webmasters to embed
     structured data on their web pages for use by search engines and other applications." />
+    <link rel="stylesheet" type="text/css" href="https://schema.org/docs/schemaorg.css" />
     <link rel="stylesheet" type="text/css" href="/docs/schemaorg.css" />
 
     <base href="/version/3.1/" ></base>

--- a/data/releases/3.2/schema-all.html
+++ b/data/releases/3.2/schema-all.html
@@ -73,8 +73,9 @@ customSearchControl.draw('cse-search-form', options);
  <dt>Version:</dt>
  <dd>3.2</dd>
 
- <dt>URL:</dt>
- <dd><a href="http://schema.org/version/3.2/">http://schema.org/version/3.2/</a></dd>
+ <dt>Archive URL:</dt>
+ <dd><a href="https://github.com/schemaorg/schemaorg/tree/main/data/releases/3.2/">
+    https://github.com/schemaorg/schemaorg/tree/main/data/releases/3.2/</a></dd>
 
  <dt>Published:</dt>
  <dd>2017-03-23</dd>

--- a/data/releases/3.2/schema-all.html
+++ b/data/releases/3.2/schema-all.html
@@ -5,6 +5,7 @@
     <title>Full Release Summary: Schema.org - 3.2 - 2017-03-23</title>
     <meta name="description" content="Schema.org is a set of extensible schemas that enables webmasters to embed
     structured data on their web pages for use by search engines and other applications." />
+    <link rel="stylesheet" type="text/css" href="https://schema.org/docs/schemaorg.css" />
     <link rel="stylesheet" type="text/css" href="/docs/schemaorg.css" />
 
     <base href="/version/build-latest/" ></base>

--- a/data/releases/3.3/schema-all.html
+++ b/data/releases/3.3/schema-all.html
@@ -5,6 +5,7 @@
     <title>Full Release Summary: Schema.org - 3.3 - 2017-08-14</title>
     <meta name="description" content="Schema.org is a set of extensible schemas that enables webmasters to embed
     structured data on their web pages for use by search engines and other applications." />
+    <link rel="stylesheet" type="text/css" href="https://schema.org/docs/schemaorg.css" />
     <link rel="stylesheet" type="text/css" href="/docs/schemaorg.css" />
 
     <base href="/version/build-latest/" ></base>

--- a/data/releases/3.3/schema-all.html
+++ b/data/releases/3.3/schema-all.html
@@ -82,8 +82,9 @@ customSearchControl.draw('cse-search-form', options);
  <dt>Version:</dt>
  <dd>3.3</dd>
 
- <dt>URL:</dt>
- <dd><a href="http://schema.org/version/3.3/">http://schema.org/version/3.3/</a></dd>
+ <dt>Archive URL:</dt>
+ <dd><a href="https://github.com/schemaorg/schemaorg/tree/main/data/releases/3.3/">
+    https://github.com/schemaorg/schemaorg/tree/main/data/releases/3.3/</a></dd>
 
  <dt>Published:</dt>
  <dd>2017-08-14</dd>

--- a/data/releases/3.4/schema-all.html
+++ b/data/releases/3.4/schema-all.html
@@ -3,6 +3,7 @@
 <head>
   <!-- Generated from headtags.tpl -->
     <meta charset="utf-8" >
+    <link rel="stylesheet" type="text/css" href="https://schema.org/docs/schemaorg.css" />
     <link rel="stylesheet" type="text/css" href="/docs/schemaorg.css" />
     <link href="/docs/prettify.css" type="text/css" rel="stylesheet" />
     <script type="text/javascript" src="/docs/prettify.js"></script>

--- a/data/releases/3.4/schema-all.html
+++ b/data/releases/3.4/schema-all.html
@@ -75,8 +75,9 @@
  <dt>Version:</dt>
  <dd>3.4</dd>
 
- <dt>URL:</dt>
- <dd><a href="http://schema.org/version/3.4/">http://schema.org/version/3.4/</a></dd>
+ <dt>Archive URL:</dt>
+ <dd><a href="https://github.com/schemaorg/schemaorg/tree/main/data/releases/3.4/">
+    https://github.com/schemaorg/schemaorg/tree/main/data/releases/3.4/</a></dd>
 
  <dt>Published:</dt>
  <dd>2018-06-15</dd>

--- a/data/releases/3.5/schema-all.html
+++ b/data/releases/3.5/schema-all.html
@@ -4,6 +4,7 @@
   <!-- Generated from headtags.tpl -->
     <meta charset="utf-8" >
     <link rel="shortcut icon" type="image/png" href="/docs/favicon.ico"/>
+    <link rel="stylesheet" type="text/css" href="https://schema.org/docs/schemaorg.css" />
     <link rel="stylesheet" type="text/css" href="/docs/schemaorg.css" />
     <link rel="stylesheet" type="text/css" href="/docs/prettify.css" />
     <script type="text/javascript" src="/docs/prettify.js"></script>

--- a/data/releases/3.5/schema-all.html
+++ b/data/releases/3.5/schema-all.html
@@ -92,8 +92,9 @@ var s = document.getElementsByTagName('script')[0]; s.parentNode.insertBefore(gc
  <dt>Version:</dt>
  <dd>3.5</dd>
 
- <dt>URL:</dt>
- <dd><a href="http://schema.org/version/3.5/">http://schema.org/version/3.5/</a></dd>
+ <dt>Archive URL:</dt>
+ <dd><a href="https://github.com/schemaorg/schemaorg/tree/main/data/releases/3.5/">
+    https://github.com/schemaorg/schemaorg/tree/main/data/releases/3.5/</a></dd>
 
  <dt>Published:</dt>
  <dd>2019-04-01</dd>

--- a/data/releases/3.6/schema-all.html
+++ b/data/releases/3.6/schema-all.html
@@ -4,6 +4,7 @@
   <!-- Generated from headtags.tpl -->
     <meta charset="utf-8" >
     <link rel="shortcut icon" type="image/png" href="/docs/favicon.ico"/>
+    <link rel="stylesheet" type="text/css" href="https://schema.org/docs/schemaorg.css" />
     <link rel="stylesheet" type="text/css" href="/docs/schemaorg.css" />
     <link rel="stylesheet" type="text/css" href="/docs/prettify.css" />
     <script type="text/javascript" src="/docs/prettify.js"></script>

--- a/data/releases/3.6/schema-all.html
+++ b/data/releases/3.6/schema-all.html
@@ -87,8 +87,9 @@ var s = document.getElementsByTagName('script')[0]; s.parentNode.insertBefore(gc
  <dt>Version:</dt>
  <dd>3.6</dd>
 
- <dt>URL:</dt>
- <dd><a href="http://schema.org/version/3.6/">http://schema.org/version/3.6/</a></dd>
+ <dt>Archive URL:</dt>
+ <dd><a href="https://github.com/schemaorg/schemaorg/tree/main/data/releases/3.6/">
+    https://github.com/schemaorg/schemaorg/tree/main/data/releases/3.6/</a></dd>
 
  <dt>Published:</dt>
  <dd>2019-05-01</dd>

--- a/data/releases/3.7/schema-all.html
+++ b/data/releases/3.7/schema-all.html
@@ -87,8 +87,9 @@ var s = document.getElementsByTagName('script')[0]; s.parentNode.insertBefore(gc
  <dt>Version:</dt>
  <dd>3.7</dd>
 
- <dt>URL:</dt>
- <dd><a href="http://schema.org/version/3.7/">http://schema.org/version/3.7/</a></dd>
+ <dt>Archive URL:</dt>
+ <dd><a href="https://github.com/schemaorg/schemaorg/tree/main/data/releases/3.7/">
+    https://github.com/schemaorg/schemaorg/tree/main/data/releases/3.7/</a></dd>
 
  <dt>Published:</dt>
  <dd>2019-06-01</dd>

--- a/data/releases/3.7/schema-all.html
+++ b/data/releases/3.7/schema-all.html
@@ -4,6 +4,7 @@
   <!-- Generated from headtags.tpl -->
     <meta charset="utf-8" >
     <link rel="shortcut icon" type="image/png" href="/docs/favicon.ico"/>
+    <link rel="stylesheet" type="text/css" href="https://schema.org/docs/schemaorg.css" />
     <link rel="stylesheet" type="text/css" href="/docs/schemaorg.css" />
     <link rel="stylesheet" type="text/css" href="/docs/prettify.css" />
     <script type="text/javascript" src="/docs/prettify.js"></script>

--- a/data/releases/3.8/schema-all.html
+++ b/data/releases/3.8/schema-all.html
@@ -87,8 +87,9 @@ var s = document.getElementsByTagName('script')[0]; s.parentNode.insertBefore(gc
  <dt>Version:</dt>
  <dd>3.8</dd>
 
- <dt>URL:</dt>
- <dd><a href="http://schema.org/version/3.8/">http://schema.org/version/3.8/</a></dd>
+ <dt>Archive URL:</dt>
+ <dd><a href="https://github.com/schemaorg/schemaorg/tree/main/data/releases/3.8/">
+    https://github.com/schemaorg/schemaorg/tree/main/data/releases/3.8/</a></dd>
 
  <dt>Published:</dt>
  <dd>2019-07-01</dd>

--- a/data/releases/3.8/schema-all.html
+++ b/data/releases/3.8/schema-all.html
@@ -4,6 +4,7 @@
   <!-- Generated from headtags.tpl -->
     <meta charset="utf-8" >
     <link rel="shortcut icon" type="image/png" href="/docs/favicon.ico"/>
+    <link rel="stylesheet" type="text/css" href="https://schema.org/docs/schemaorg.css" />
     <link rel="stylesheet" type="text/css" href="/docs/schemaorg.css" />
     <link rel="stylesheet" type="text/css" href="/docs/prettify.css" />
     <script type="text/javascript" src="/docs/prettify.js"></script>

--- a/data/releases/3.9/schema-all.html
+++ b/data/releases/3.9/schema-all.html
@@ -87,8 +87,9 @@ var s = document.getElementsByTagName('script')[0]; s.parentNode.insertBefore(gc
  <dt>Version:</dt>
  <dd>3.9</dd>
 
- <dt>URL:</dt>
- <dd><a href="http://schema.org/version/3.9/">http://schema.org/version/3.9/</a></dd>
+ <dt>Archive URL:</dt>
+ <dd><a href="https://github.com/schemaorg/schemaorg/tree/main/data/releases/3.9/">
+    https://github.com/schemaorg/schemaorg/tree/main/data/releases/3.9/</a></dd>
 
  <dt>Published:</dt>
  <dd>2019-08-01</dd>

--- a/data/releases/3.9/schema-all.html
+++ b/data/releases/3.9/schema-all.html
@@ -4,6 +4,7 @@
   <!-- Generated from headtags.tpl -->
     <meta charset="utf-8" >
     <link rel="shortcut icon" type="image/png" href="/docs/favicon.ico"/>
+    <link rel="stylesheet" type="text/css" href="https://schema.org/docs/schemaorg.css" />
     <link rel="stylesheet" type="text/css" href="/docs/schemaorg.css" />
     <link rel="stylesheet" type="text/css" href="/docs/prettify.css" />
     <script type="text/javascript" src="/docs/prettify.js"></script>

--- a/data/releases/4.0/schema-all.html
+++ b/data/releases/4.0/schema-all.html
@@ -87,8 +87,9 @@ var s = document.getElementsByTagName('script')[0]; s.parentNode.insertBefore(gc
  <dt>Version:</dt>
  <dd>4.0</dd>
 
- <dt>URL:</dt>
- <dd><a href="http://schema.org/version/4.0/">http://schema.org/version/4.0/</a></dd>
+ <dt>Archive URL:</dt>
+ <dd><a href="https://github.com/schemaorg/schemaorg/tree/main/data/releases/4.0/">
+    https://github.com/schemaorg/schemaorg/tree/main/data/releases/4.0/</a></dd>
 
  <dt>Published:</dt>
  <dd>2019-10-15</dd>

--- a/data/releases/4.0/schema-all.html
+++ b/data/releases/4.0/schema-all.html
@@ -4,6 +4,7 @@
   <!-- Generated from headtags.tpl -->
     <meta charset="utf-8" >
     <link rel="shortcut icon" type="image/png" href="/docs/favicon.ico"/>
+    <link rel="stylesheet" type="text/css" href="https://schema.org/docs/schemaorg.css" />
     <link rel="stylesheet" type="text/css" href="/docs/schemaorg.css" />
     <link rel="stylesheet" type="text/css" href="/docs/prettify.css" />
     <script type="text/javascript" src="/docs/prettify.js"></script>

--- a/data/releases/5.0/schema-all.html
+++ b/data/releases/5.0/schema-all.html
@@ -87,8 +87,9 @@ var s = document.getElementsByTagName('script')[0]; s.parentNode.insertBefore(gc
  <dt>Version:</dt>
  <dd>5.0</dd>
 
- <dt>URL:</dt>
- <dd><a href="http://schema.org/version/5.0/">http://schema.org/version/5.0/</a></dd>
+ <dt>Archive URL:</dt>
+ <dd><a href="https://github.com/schemaorg/schemaorg/tree/main/data/releases/5.0/">
+    https://github.com/schemaorg/schemaorg/tree/main/data/releases/5.0/</a></dd>
 
  <dt>Published:</dt>
  <dd>2019-11-01</dd>

--- a/data/releases/5.0/schema-all.html
+++ b/data/releases/5.0/schema-all.html
@@ -4,6 +4,7 @@
   <!-- Generated from headtags.tpl -->
     <meta charset="utf-8" >
     <link rel="shortcut icon" type="image/png" href="/docs/favicon.ico"/>
+    <link rel="stylesheet" type="text/css" href="https://schema.org/docs/schemaorg.css" />
     <link rel="stylesheet" type="text/css" href="/docs/schemaorg.css" />
     <link rel="stylesheet" type="text/css" href="/docs/prettify.css" />
     <script type="text/javascript" src="/docs/prettify.js"></script>

--- a/data/releases/6.0/schema-all.html
+++ b/data/releases/6.0/schema-all.html
@@ -87,8 +87,9 @@ var s = document.getElementsByTagName('script')[0]; s.parentNode.insertBefore(gc
  <dt>Version:</dt>
  <dd>6.0</dd>
 
- <dt>URL:</dt>
- <dd><a href="http://schema.org/version/6.0/">http://schema.org/version/6.0/</a></dd>
+ <dt>Archive URL:</dt>
+ <dd><a href="https://github.com/schemaorg/schemaorg/tree/main/data/releases/6.0/">
+    https://github.com/schemaorg/schemaorg/tree/main/data/releases/6.0/</a></dd>
 
  <dt>Published:</dt>
  <dd>2020-01-15</dd>

--- a/data/releases/6.0/schema-all.html
+++ b/data/releases/6.0/schema-all.html
@@ -4,6 +4,7 @@
   <!-- Generated from headtags.tpl -->
     <meta charset="utf-8" >
     <link rel="shortcut icon" type="image/png" href="/docs/favicon.ico"/>
+    <link rel="stylesheet" type="text/css" href="https://schema.org/docs/schemaorg.css" />
     <link rel="stylesheet" type="text/css" href="/docs/schemaorg.css" />
     <link rel="stylesheet" type="text/css" href="/docs/prettify.css" />
     <script type="text/javascript" src="/docs/prettify.js"></script>

--- a/data/releases/7.0/schema-all.html
+++ b/data/releases/7.0/schema-all.html
@@ -4,6 +4,7 @@
   <!-- Generated from headtags.tpl -->
     <meta charset="utf-8" >
     <link rel="shortcut icon" type="image/png" href="/docs/favicon.ico"/>
+    <link rel="stylesheet" type="text/css" href="https://schema.org/docs/schemaorg.css" />
     <link rel="stylesheet" type="text/css" href="/docs/schemaorg.css" />
     <link rel="stylesheet" type="text/css" href="/docs/prettify.css" />
     <script type="text/javascript" src="/docs/prettify.js"></script>

--- a/data/releases/7.0/schema-all.html
+++ b/data/releases/7.0/schema-all.html
@@ -87,8 +87,9 @@ var s = document.getElementsByTagName('script')[0]; s.parentNode.insertBefore(gc
  <dt>Version:</dt>
  <dd>7.0</dd>
 
- <dt>URL:</dt>
- <dd><a href="http://schema.org/version/7.0/">http://schema.org/version/7.0/</a></dd>
+ <dt>Archive URL:</dt>
+ <dd><a href="https://github.com/schemaorg/schemaorg/tree/main/data/releases/7.0/">
+    https://github.com/schemaorg/schemaorg/tree/main/data/releases/7.0/</a></dd>
 
  <dt>Published:</dt>
  <dd>2020-03-10</dd>

--- a/data/releases/7.01/schema-all.html
+++ b/data/releases/7.01/schema-all.html
@@ -87,8 +87,9 @@ var s = document.getElementsByTagName('script')[0]; s.parentNode.insertBefore(gc
  <dt>Version:</dt>
  <dd>7.01</dd>
 
- <dt>URL:</dt>
- <dd><a href="http://schema.org/version/7.01/">http://schema.org/version/7.01/</a></dd>
+ <dt>Archive URL:</dt>
+ <dd><a href="https://github.com/schemaorg/schemaorg/tree/main/data/releases/7.01/">
+    https://github.com/schemaorg/schemaorg/tree/main/data/releases/7.01/</a></dd>
 
  <dt>Published:</dt>
  <dd>2020-03-22</dd>

--- a/data/releases/7.01/schema-all.html
+++ b/data/releases/7.01/schema-all.html
@@ -4,6 +4,7 @@
   <!-- Generated from headtags.tpl -->
     <meta charset="utf-8" >
     <link rel="shortcut icon" type="image/png" href="/docs/favicon.ico"/>
+    <link rel="stylesheet" type="text/css" href="https://schema.org/docs/schemaorg.css" />
     <link rel="stylesheet" type="text/css" href="/docs/schemaorg.css" />
     <link rel="stylesheet" type="text/css" href="/docs/prettify.css" />
     <script type="text/javascript" src="/docs/prettify.js"></script>

--- a/data/releases/7.02/schema-all.html
+++ b/data/releases/7.02/schema-all.html
@@ -87,8 +87,9 @@ var s = document.getElementsByTagName('script')[0]; s.parentNode.insertBefore(gc
  <dt>Version:</dt>
  <dd>7.02</dd>
 
- <dt>URL:</dt>
- <dd><a href="http://schema.org/version/7.02/">http://schema.org/version/7.02/</a></dd>
+ <dt>Archive URL:</dt>
+ <dd><a href="https://github.com/schemaorg/schemaorg/tree/main/data/releases/7.02/">
+    https://github.com/schemaorg/schemaorg/tree/main/data/releases/7.02/</a></dd>
 
  <dt>Published:</dt>
  <dd>2020-03-31</dd>

--- a/data/releases/7.02/schema-all.html
+++ b/data/releases/7.02/schema-all.html
@@ -4,6 +4,7 @@
   <!-- Generated from headtags.tpl -->
     <meta charset="utf-8" >
     <link rel="shortcut icon" type="image/png" href="/docs/favicon.ico"/>
+    <link rel="stylesheet" type="text/css" href="https://schema.org/docs/schemaorg.css" />
     <link rel="stylesheet" type="text/css" href="/docs/schemaorg.css" />
     <link rel="stylesheet" type="text/css" href="/docs/prettify.css" />
     <script type="text/javascript" src="/docs/prettify.js"></script>

--- a/data/releases/7.03/schema-all.html
+++ b/data/releases/7.03/schema-all.html
@@ -4,6 +4,7 @@
   <!-- Generated from headtags.tpl -->
     <meta charset="utf-8" >
     <link rel="shortcut icon" type="image/png" href="/docs/favicon.ico"/>
+    <link rel="stylesheet" type="text/css" href="https://schema.org/docs/schemaorg.css" />
     <link rel="stylesheet" type="text/css" href="/docs/schemaorg.css" />
     <link rel="stylesheet" type="text/css" href="/docs/prettify.css" />
     <script type="text/javascript" src="/docs/prettify.js"></script>

--- a/data/releases/7.03/schema-all.html
+++ b/data/releases/7.03/schema-all.html
@@ -87,8 +87,9 @@ var s = document.getElementsByTagName('script')[0]; s.parentNode.insertBefore(gc
  <dt>Version:</dt>
  <dd>7.03</dd>
 
- <dt>URL:</dt>
- <dd><a href="http://schema.org/version/7.03/">http://schema.org/version/7.03/</a></dd>
+ <dt>Archive URL:</dt>
+ <dd><a href="https://github.com/schemaorg/schemaorg/tree/main/data/releases/7.03/">
+    https://github.com/schemaorg/schemaorg/tree/main/data/releases/7.03/</a></dd>
 
  <dt>Published:</dt>
  <dd>2020-04-02</dd>

--- a/data/releases/7.04/schema-all.html
+++ b/data/releases/7.04/schema-all.html
@@ -87,8 +87,9 @@ var s = document.getElementsByTagName('script')[0]; s.parentNode.insertBefore(gc
  <dt>Version:</dt>
  <dd>7.04</dd>
 
- <dt>URL:</dt>
- <dd><a href="http://schema.org/version/7.04/">http://schema.org/version/7.04/</a></dd>
+ <dt>Archive URL:</dt>
+ <dd><a href="https://github.com/schemaorg/schemaorg/tree/main/data/releases/7.04/">
+    https://github.com/schemaorg/schemaorg/tree/main/data/releases/7.04/</a></dd>
 
  <dt>Published:</dt>
  <dd>2020-04-16</dd>

--- a/data/releases/7.04/schema-all.html
+++ b/data/releases/7.04/schema-all.html
@@ -4,6 +4,7 @@
   <!-- Generated from headtags.tpl -->
     <meta charset="utf-8" >
     <link rel="shortcut icon" type="image/png" href="/docs/favicon.ico"/>
+    <link rel="stylesheet" type="text/css" href="https://schema.org/docs/schemaorg.css" />
     <link rel="stylesheet" type="text/css" href="/docs/schemaorg.css" />
     <link rel="stylesheet" type="text/css" href="/docs/prettify.css" />
     <script type="text/javascript" src="/docs/prettify.js"></script>

--- a/data/releases/8.0/schema-all.html
+++ b/data/releases/8.0/schema-all.html
@@ -87,8 +87,9 @@ var s = document.getElementsByTagName('script')[0]; s.parentNode.insertBefore(gc
  <dt>Version:</dt>
  <dd>8.0</dd>
 
- <dt>URL:</dt>
- <dd><a href="http://schema.org/version/8.0/">http://schema.org/version/8.0/</a></dd>
+ <dt>Archive URL:</dt>
+ <dd><a href="https://github.com/schemaorg/schemaorg/tree/main/data/releases/8.0/">
+    https://github.com/schemaorg/schemaorg/tree/main/data/releases/8.0/</a></dd>
 
  <dt>Published:</dt>
  <dd>2020-04-29</dd>

--- a/data/releases/8.0/schema-all.html
+++ b/data/releases/8.0/schema-all.html
@@ -4,6 +4,7 @@
   <!-- Generated from headtags.tpl -->
     <meta charset="utf-8" >
     <link rel="shortcut icon" type="image/png" href="/docs/favicon.ico"/>
+    <link rel="stylesheet" type="text/css" href="https://schema.org/docs/schemaorg.css" />
     <link rel="stylesheet" type="text/css" href="/docs/schemaorg.css" />
     <link rel="stylesheet" type="text/css" href="/docs/prettify.css" />
     <script type="text/javascript" src="/docs/prettify.js"></script>

--- a/data/releases/9.0/schema-all.html
+++ b/data/releases/9.0/schema-all.html
@@ -88,8 +88,9 @@ var s = document.getElementsByTagName('script')[0]; s.parentNode.insertBefore(gc
  <dt>Version:</dt>
  <dd>9.0</dd>
 
- <dt>URL:</dt>
- <dd><a href="http://schema.org/version/9.0/">http://schema.org/version/9.0/</a></dd>
+ <dt>Archive URL:</dt>
+ <dd><a href="https://github.com/schemaorg/schemaorg/tree/main/data/releases/9.0/">
+    https://github.com/schemaorg/schemaorg/tree/main/data/releases/9.0/</a></dd>
 
  <dt>Published:</dt>
  <dd>2020-07-21</dd>

--- a/docs/releases.html
+++ b/docs/releases.html
@@ -62,6 +62,8 @@ ul {
 <p>This page lists schema.org releases, most recent first. New developments are <a href="https://github.com/schemaorg/schemaorg">discussed on Github</a>; editorial works-in-progress
   are publicly staged on the <a href="http://webschemas.org/">webschemas.org</a> drafting site for review and collaboration. See <a href="howwework.html">how we work</a> for more background.</p>
 <br/>
+Current Published Release: <a href="https://schema.org/version/latest">https://schema.org/version/latest</a>
+<br/>
 
 <div class="scroll-div">
 <span id="v.next"></span>

--- a/templates/docs/FullRelease.j2
+++ b/templates/docs/FullRelease.j2
@@ -10,7 +10,23 @@
 
 <!DOCTYPE html>
 <html lang="en">
-<!-- Generated from Home.j2 -->
+<!-- Generated from FullRelease.j2 -->
+<head>
+    <title>{{ title }} - {{ sitename }} {{ SUBNAME }}</title>
+    <meta charset="utf-8" >
+    <meta name="viewport" content="width=device-width, initial-scale=1">
+    <meta name="description" content="Schema.org is a set of extensible schemas that enables webmasters to embed
+    structured data on their web pages for use by search engines and other applications." />
+    <link rel="shortcut icon" type="image/png" href="{{docsdir}}/favicon.ico"/>
+    <link rel="stylesheet" type="text/css" href="https://schema.org/schemaorg.css" />
+    <link rel="stylesheet" type="text/css" href="{{docsdir}}/schemaorg.css" />
+    <link rel="stylesheet" type="text/css" href="{{docsdir}}/devnote.css" />
+    <link rel="stylesheet" type="text/css" href="{{docsdir}}/prettify.css" />
+    <link rel="stylesheet" type="text/css" href="{{docsdir}}/devnote.css" />
+    <script src="https://ajax.googleapis.com/ajax/libs/jquery/3.5.1/jquery.min.js"></script>
+    <script src="{{docsdir}}/schemaorg.js"></script>
+   
+</head>
     {% include 'docs/DocsHead.j2' with context %}
 <body>
     {% include 'PageHeader.j2' with context %}
@@ -23,8 +39,9 @@
  <dt>Version:</dt>
  <dd>{{version}}</dd>
 
- <dt>URL:</dt>
- <dd><a href="https://schema.org/version/{{version}}/">https://schema.org/version/{{version}}/</a></dd>
+ <dt>Archive URL:</dt>
+ <dd><a href="https://github.com/schemaorg/schemaorg/tree/main/data/releases/{{version}}/">
+     https://github.com/schemaorg/schemaorg/tree/main/data/releases/{{version}}/</a></dd>
 
  <dt>Published:</dt>
  <dd>{{date}}</dd>


### PR DESCRIPTION
Addresses issue #2805 

Links now reference full release documents, archived in Github, which now reference the associated version specific archive area.