### PR TITLE
Allow an Organization to be a buyer

### DIFF
--- a/data/schema.ttl
+++ b/data/schema.ttl
@@ -4748,7 +4748,8 @@ See also the <a href="/docs/hotels.html">dedicated document on the use of schema
 :buyer a rdf:Property ;
     rdfs:label "buyer" ;
     :domainIncludes :SellAction ;
-    :rangeIncludes :Person ;
+    :rangeIncludes :Organization,
+        :Person ;
     rdfs:comment "A sub property of participant. The participant/person/organization that bought the object." ;
     rdfs:subPropertyOf :participant .
 


### PR DESCRIPTION
An "organization" is even included in the comment.

This is a fix to address https://github.com/schemaorg/schemaorg/issues/2882
