### PR TITLE
Remove reference and broken link to RDFa schema

### DIFF
--- a/docs/datamodel.html
+++ b/docs/datamodel.html
@@ -49,18 +49,7 @@ and a few properties like <a href="http://meta.schema.org/domainIncludes">domain
 to allow for reflection, i.e., for the schema to be represented in terms of itself.
 </p>
 
-<p>The canonical machine representation of schema.org is in RDFa:</p>
-
-<ul>
-<li><a href="schema_org_rdfa.html">schema_org_rdfa.html</a></li>
-</ul>
-
-<p>
-Now-obsolete snapshots of <a href='https://web.archive.org/web/20150414142113/https://schema.org/docs/full_md.html'>Microdata</a> and <a href='schemaorg.owl'>OWL</a> experimental
-data dumps were previously published. See also <a href="http://datashapes.org/schema">TopQuadrant's version</a>.
-</p>
-
-<p>See the "<a href="/docs/developers.html">developers</a>" page for more information on machine-readable views of schema.org.</p>
+<p>The canonical machine representation of schema.org is in RDF/Turtle. See the "<a href="/docs/developers.html">developers</a>" page for more information on machine-readable views of schema.org.</p>
 
 <p>
 The type hierarchy presented on this site is not intended to be a 'global ontology' of the world.


### PR DESCRIPTION
...and simplify documentation on "Data model" page. The link to the [TopQuadrant page](http://datashapes.org/schema) mentions Microdata and OWL. However, on the TopQuadrant page only SHACL is mentioned so I suggest to completely remove the bit.