### PR TITLE
Add QuantitativeValue to orderQuantity

### DIFF
--- a/data/schema.ttl
+++ b/data/schema.ttl
@@ -7363,7 +7363,8 @@ Note: for historical reasons, any textual label and formal code provided as a li
 :orderQuantity a rdf:Property ;
     rdfs:label "orderQuantity" ;
     :domainIncludes :OrderItem ;
-    :rangeIncludes :Number ;
+    :rangeIncludes :Number,
+        :QuantitativeValue ;
     rdfs:comment "The number of the item ordered. If the property is not set, assume the quantity is one." .
 
 :orderStatus a rdf:Property ;


### PR DESCRIPTION
For ordering products by weight (e.g. 5kg apples) it's good to specify the used unit.