### PR TITLE
Cleanup the copystaticdocsplusinsert python code.

### DIFF
--- a/software/util/copystaticdocsplusinsert.py
+++ b/software/util/copystaticdocsplusinsert.py
@@ -3,33 +3,32 @@
 import sys
 if not (sys.version_info.major == 3 and sys.version_info.minor > 5):
     print("Python version %s.%s not supported version 3.6 or above required - exiting" % (sys.version_info.major,sys.version_info.minor))
-    sys.exit(1)
+    sys.exit(os.EX_SOFTWARE)
 
 import os
 import glob
 import re
 
 for path in [os.getcwd(),"software/SchemaTerms","software/SchemaExamples","software/util"]:
-  sys.path.insert( 1, path ) #Pickup libs from local  directories
-  
+  sys.path.insert(1, path) #Pickup libs from local directories
+
 if os.path.basename(os.getcwd()) != "schemaorg":
     print("\nScript should be run from within the 'schemaorg' directory! - Exiting\n")
-    sys.exit(1)
+    sys.exit(os.EX_DATAERR)
 
 for dir in ["software/util","docs","software/site","templates/static-doc-inserts"]:
     if not os.path.isdir(dir):
         print("\nRequired directory '%s' not found - Exiting\n" % dir)
-        sys.exit(1)
+        sys.exit(os.EX_NOINPUT)
 
 from shutil import *
 from schemaversion import *
 import convertmd2htmldocs
 
 
-ins = glob.glob('./templates/static-doc-inserts/*.html')
 INSERTS = {}
-for f in ins:
-    fn = os.path.basename(f).lower()
+for f_path in glob.glob('./templates/static-doc-inserts/*.html'):
+    fn = os.path.basename(f_path).lower()
     fn = os.path.splitext(fn)[0]
     with open(f) as ind:
         indata = ind.read()
@@ -40,14 +39,25 @@ for f in ins:
     INSERTS[fn] = indata
 
 def mycopytree(src, dst, symlinks=False, ignore=None):
+    """Copy a full tree in the file-system.
+
+    This is basically a custom version of `shutils.copytree()`.
+
+    Parameters:
+        src (str): source path
+        dst (str): destination path
+        symlinks (bool): should symbolic links be followed.
+        ignore: function that takes the set of filenames and returns those to be ignored.
+
+    """
     #copes with already existing directories
     names = os.listdir(src)
     if ignore is not None:
         ignored_names = ignore(src, names)
     else:
-        ignored_names = set()
+        ignored_names = frozenset()
 
-    if not os.path.isdir(dst): 
+    if not os.path.isdir(dst):
         os.makedirs(dst)
     errors = []
     for name in names:
@@ -79,42 +89,49 @@ def mycopytree(src, dst, symlinks=False, ignore=None):
         else:
             errors.extend((src, dst, str(why)))
     if errors:
-        raise Error (errors)
+        raise Error(errors)
 
 
 SRCDIR = './docs'
 DESTDIR = './software/site/docs'
+
 def copydocs():
-    mycopytree(SRCDIR,DESTDIR)
+    mycopytree(SRCDIR, DESTDIR)
 
 def htmlinserts():
-    docs = glob.glob(DESTDIR +'/*.html')
-    for d in docs:
-        insertcopy(d)
+    """Perform susbstitions on all HTML files in DESTDIR."""
+    docs = glob.glob(os.path.join(DESTDIR, '*.html'))
+    for doc in docs:
+        insertcopy(doc)
 
 def insertcopy(doc, docdata=None):
+    """Apply all substitutions defined in INSERTS to a file.
+
+    The resulting output is written to a path in DESTDIR based on the path `doc`.
+
+    Parameters:
+      doc (str): path to the file to load, only used if docdata is None.
+      docdata (str): data to apply the replacement, if empty, data is loaded from doc.
+   """
     if not docdata:
         with open(doc) as docfile:
             docdata = docfile.read()
-    
-    if re.search('<!-- #### Static Doc Insert',docdata,re.IGNORECASE):
+
+    if re.search('<!-- #### Static Doc Insert', docdata,re.IGNORECASE):
         for sub in INSERTS:
             subpattern = re.compile("<!-- #### Static Doc Insert %s .* -->" % sub,re.IGNORECASE)
             docdata = subpattern.sub(INSERTS.get(sub),docdata,re.IGNORECASE)
 
-        targetfile = DESTDIR + '/' + os.path.basename(doc)
-        with open(targetfile,"w") as outfile:
+        targetfile = os.path.join(DESTDIR, os.path.basename(doc))
+        with open(targetfile, "w") as outfile:
             outfile.write(docdata)
-        #print("adding inserts to: " + targetfile)    
-
-
-
+        #print("adding inserts to: " + targetfile)
 
 
 
 if __name__ == '__main__':
     copydocs()
     print("Converting .md docs to html")
-    convertmd2htmldocs.mddocs(DESTDIR,DESTDIR)
+    convertmd2htmldocs.mddocs(DESTDIR, DESTDIR)
     print("Adding header/footer templates")
     htmlinserts()

--- a/software/util/copystaticdocsplusinsert.py
+++ b/software/util/copystaticdocsplusinsert.py
@@ -30,7 +30,7 @@ INSERTS = {}
 for f_path in glob.glob('./templates/static-doc-inserts/*.html'):
     fn = os.path.basename(f_path).lower()
     fn = os.path.splitext(fn)[0]
-    with open(f) as ind:
+    with open(f_path) as ind:
         indata = ind.read()
     fn = fn[4:] #drop sdi- from file name
     indata = indata.replace('{{version}}',getVersion())
@@ -47,7 +47,7 @@ def mycopytree(src, dst, symlinks=False, ignore=None):
         src (str): source path
         dst (str): destination path
         symlinks (bool): should symbolic links be followed.
-        ignore: function that takes the set of filenames and returns those to be ignored.
+        ignore (callable): function that takes the set of filenames and returns those to be ignored.
 
     """
     #copes with already existing directories


### PR DESCRIPTION
* Systematically use os.path.join for joining paths.
* Use os.EX_ exit values.
* Added some documentation for functions.
* Fixed spacing.
* Use `fronzenset` for immutable collection.
* Avoid uncessary variable in the root namespace.
