### PR TITLE
Fix for issue 3075

### DIFF
--- a/software/SchemaExamples/schemaexamples.py
+++ b/software/SchemaExamples/schemaexamples.py
@@ -25,7 +25,10 @@ class Example ():
     def __init__ (self, terms, original_html, microdata, rdfa, jsonld, exmeta):
         self.terms = terms
         if not len(terms):
-            log.info("No terms for ex: %s in file %s" % (exmeta["filepos"],emeta["file"]) )
+            log.info("No terms for ex: %s in file %s" % (exmeta["filepos"],exmeta["file"]) )
+            first_term = 'Empty'
+        else:
+            first_term = terms[0]
         self.original_html = original_html
         self.microdata = microdata
         self.rdfa = rdfa
@@ -33,7 +36,7 @@ class Example ():
         self.exmeta = exmeta
         self.keyvalue = self.exmeta.get('id',None)
         if not self.keyvalue:
-            self.keyvalue = "%s-temp-%s"% (terms[0],Example.ExamplesCount)
+            self.keyvalue = "%s-temp-%s"% (first_term,Example.ExamplesCount)
             self.exmeta['id'] = self.keyvalue
         else:
             idnum = self.getIdNum()
@@ -53,35 +56,35 @@ class Example ():
         buf.append("\nOrigLen: %s MicroLen: %s RdfaLen: %s JsonLen: %s" % (len(self.original_html),len(self.microdata),len(self.rdfa),len(self.jsonld)))
         buf.append("\nexmeta: %s" % self.exmeta)
         return ''.join(buf)
-    
+
     def getKey(self):
         return self.keyvalue
     def setKey(self,key):
         self.keyvalue = key
-        
+
     def terms(self):
         return self.terms
     def setTerms(self,terms):
         self.terms = terms
-        
+
     def getHtml(self):
         return self.original_html
     def setHtml(self,content):
         self.original_html = content
-        
+
     def getMicrodata(self):
         return self.microdata
     def setMicrodata(self,content):
         self.microdata = content
-        
+
     def getRdfa(self):
         return self.rdfa
     def setRdfa(self,content):
         self.rdfa = content
-        
+
     def getJsonld(self):
-        return self.jsonld 
-    
+        return self.jsonld
+
     def getJsonldRaw(self):
         jsondata = self.getJsonld()
         jsondata = jsondata.strip()
@@ -103,12 +106,12 @@ class Example ():
         return len(self.rdfa.strip()) > 0
     def hasJsonld(self):
         return len(self.jsonld.strip()) > 0
-        
+
     def setMeta(self,name,val):
         self.exmeta[name] = val
     def getMeta(self,name):
         return self.exmeta.get(name,None)
-        
+
     def getIdNum(self):
         idnum = -1
         if self.keyvalue.startswith(IDPREFIX):
@@ -120,7 +123,7 @@ class Example ():
 
     def hasValidId(self):
         return self.getIdNum() > -1
-        
+
 
     def serialize(self):
         buff = []
@@ -135,19 +138,19 @@ class Example ():
             else:
                 termnames += ", "
             termnames += t
-            
+
         buff.append("TYPES: %s %s\n" % (idd,termnames))
         buff.append("PRE-MARKUP:\n%s" % self.getHtml())
         buff.append("MICRODATA:\n%s" % self.getMicrodata())
         buff.append("RDFA:\n%s" % self.getRdfa())
         buff.append("JSON:\n%s" % self.getJsonld())
         return "\n".join(buff)
-        
+
     @staticmethod
     def nextId():
         Example.MaxId += 1
         return Example.formatId(Example.MaxId)
-        
+
     @staticmethod
     def formatId(val):
         return 'eg-{0:04d}'.format(val)
@@ -159,13 +162,13 @@ class Example ():
         Example.MaxId = val
 
 class SchemaExamples():
-    
+
     EXAMPLESLOADED=False
     EXAMPLESMAP = {}
-    EXAMPLES = {}    
+    EXAMPLES = {}
     exlock = threading.RLock()
-    
-    
+
+
     @staticmethod
     def loadExamplesFiles(exfiles,init=False):
         import glob
@@ -173,12 +176,12 @@ class SchemaExamples():
         if init:
             EXAMPLESLOADED=False
             EXAMPLESMAP = {}
-            EXAMPLES = {}  
+            EXAMPLES = {}
 
         if SchemaExamples.EXAMPLESLOADED:
             print("Examples files already loaded")
             return
-            
+
         if not exfiles or exfiles == "default":
             print("SchemaExamples.loadExamplesFiles() loading from default files found in globs: %s" %  DEFTEXAMPLESFILESGLOB)
             exfiles = []
@@ -189,7 +192,7 @@ class SchemaExamples():
             exfiles = [exfiles]
         else:
             print("SchemaExamples.loadExamplesFiles() loading from %d" % len(exfiles))
-        
+
         if not len(exfiles):
             raise Exception("No examples file(s) to load")
 
@@ -203,18 +206,18 @@ class SchemaExamples():
                     if not SchemaExamples.EXAMPLES.get(keyvalue,None):
                         SchemaExamples.EXAMPLES[keyvalue] = example
 
-                    for term in example.terms:            
+                    for term in example.terms:
                         if(not SchemaExamples.EXAMPLESMAP.get(term, None)):
                             SchemaExamples.EXAMPLESMAP[term] = []
-                    
+
                         if not keyvalue in SchemaExamples.EXAMPLESMAP.get(term):
                             SchemaExamples.EXAMPLESMAP.get(term).append(keyvalue)
         SchemaExamples.EXAMPLESLOADED = True
-                
+
     @staticmethod
     def loaded():
-        if not SchemaExamples.EXAMPLESLOADED: 
-            SchemaExamples.loadExamplesFiles("default") 
+        if not SchemaExamples.EXAMPLESLOADED:
+            SchemaExamples.loadExamplesFiles("default")
 
     @staticmethod
     def examplesForTerm(term):
@@ -235,7 +238,7 @@ class SchemaExamples():
         if sort:
             return sorted(ret, key=lambda x: (x.exmeta['file'],x.exmeta['filepos']))
         return ret
-            
+
     @staticmethod
     def allExamplesSerialised(sort=False):
         SchemaExamples.loaded()
@@ -244,8 +247,8 @@ class SchemaExamples():
         for ex in examples:
             f.write(ex.serialize())
             f.write("\n")
-        return f.getvalue()            
-            
+        return f.getvalue()
+
     @staticmethod
     def count():
         SchemaExamples.loaded()
@@ -272,8 +275,8 @@ class ExampleFileParser():
         self.state= ""
 
     def nextPart(self, next):
-        self.trimCurrentStr() 
-        
+        self.trimCurrentStr()
+
         if (self.state == 'PRE-MARKUP:'):
             self.preMarkupStr = "".join(self.currentStr)
         elif (self.state ==  'MICRODATA:'):
@@ -284,13 +287,13 @@ class ExampleFileParser():
             self.jsonStr = "".join(self.currentStr)
         self.state = next
         self.currentStr = []
-        
+
     def trimCurrentStr(self):
         #strip: leading blank lines, strip multi blank lines (replace with 1) end with blank line
         temp = []
         begin = True
         inwhitespace = False
-        
+
         for line in self.currentStr:
             linelen = len(line.strip())
             if not linelen:
@@ -306,7 +309,7 @@ class ExampleFileParser():
                     temp.append("\n")
                     inwhitespace = False
                 temp.append(line+"\n")
-                
+
         if not inwhitespace:
             temp.append("\n")
         self.currentStr = temp
@@ -327,10 +330,10 @@ class ExampleFileParser():
         self.filepos = 0
         examples = []
         egid = re.compile("""#(\S+)\s+""")
-        
+
         if self.file.startswith("file://"):
             self.file = self.file[7:]
-        
+
         if "://" in self.file:
             r = requests.get(self.file)
             content = r.text
@@ -338,7 +341,7 @@ class ExampleFileParser():
             fd = codecs.open(self.file, 'r', encoding="utf8")
             content = fd.read()
             fd.close()
-        
+
         lines = re.split('\n|\r', content)
         first = True
         boilerplate = False
@@ -380,6 +383,8 @@ class ExampleFileParser():
         self.nextPart('TYPES:') # should flush on each block of examples
         self.filepos += 1
         if not boilerplate:
+            self.exmeta['file'] = self.file
+            self.exmeta['filepos'] = self.filepos
             examples.append(Example(self.terms, self.preMarkupStr, self.microdataStr, self.rdfaStr, self.jsonStr, self.exmeta)) # should flush last one
         self.initFields()
         return examples

--- a/software/tests/test_schemaexamples.py
+++ b/software/tests/test_schemaexamples.py
@@ -20,6 +20,7 @@ MICRODATA:
 <p itemscope itemtype="https://schema.org/Thing">This is a thing</p>
 
 RDFA:
+<p vocab="https://schema.org/" typeof="Thing">This is a thing</p>
 
 JSON:
 
@@ -34,8 +35,8 @@ class TestExampleFileParser(unittest.TestCase):
     self.parser = schemaexamples.ExampleFileParser()
     self.temp_file = tempfile.NamedTemporaryFile()
 
-  def test_empty(self):
-    """Test parsing of an empty file."""
+  def test_empty_example(self):
+    """Test parsing of an empty Example file."""
     with self.assertLogs() as cm:
       result = self.parser.parse(self.temp_file.name)
     self.assertTrue(cm.output)
@@ -47,8 +48,8 @@ class TestExampleFileParser(unittest.TestCase):
     self.assertFalse(result[0].getRdfa())
     self.assertFalse(result[0].getJsonld())
 
-  def test_single_thing(self):
-    """Test parsing of an example with a single thing."""
+  def test_single_example(self):
+    """Test parsing of an Example file containing a single entry."""
     self.temp_file.write(THING_EXAMPLE.encode('utf8'))
     self.temp_file.seek(0)
     result = self.parser.parse(self.temp_file.name)
@@ -64,12 +65,17 @@ class TestExampleFileParser(unittest.TestCase):
         '<p itemscope itemtype="https://schema.org/Thing">This is a thing</p>',
         result[0].serialize())
     self.assertEqual(
+        result[0].getRdfa().strip(),
+        '<p vocab="https://schema.org/" typeof="Thing">This is a thing</p>',
+        result[0].serialize())
+    self.assertEqual(
         result[0].getJsonld().strip(),
         '{"@context": "https://schema.org/", "@type": "Thing", }',
         result[0].serialize())
 
 
-  def test_parse_two_one_serialized(self):
+  def test_two_examples(self):
+    """Test parsing of an Example file containing two entries, one of them synthetized."""
     # Write one exampel
     self.temp_file.write(THING_EXAMPLE.encode('utf8'))
     self.temp_file.write('\n'.encode('utf8'))
@@ -85,7 +91,9 @@ class TestExampleFileParser(unittest.TestCase):
     result = self.parser.parse(self.temp_file.name)
     self.assertEqual(len(result), 2)
     self.assertEqual(result[0].getIdNum(), 999)
+    self.assertCountEqual(result[0].terms, ['Thing'])
     self.assertEqual(result[1].getIdNum(), 777)
+    self.assertCountEqual(result[1].terms, ['Offer'])
 
 
 if __name__ == '__main__':

--- a/software/tests/test_schemaexamples.py
+++ b/software/tests/test_schemaexamples.py
@@ -1,0 +1,70 @@
+#!/usr/bin/env python3
+# -*- coding: UTF-8 -*-
+
+import os
+import sys
+import unittest
+import tempfile
+
+for path in [os.getcwd(),"software/util","software/SchemaTerms","software/SchemaExamples"]:
+  sys.path.insert( 1, path ) #Pickup libs from local directories
+
+import schemaexamples
+
+THING_EXAMPLE = """TYPES: #eg-0999 Thing
+
+PRE-MARKUP:
+<p>This is a thing</p>
+
+MICRODATA:
+<p itemscope itemtype="https://schema.org/Thing">This is a thing</p>
+
+RDFA:
+
+JSON:
+
+{"@context": "https://schema.org/", "@type": "Thing", }
+
+"""
+
+class TestExampleFileParser(unittest.TestCase):
+  """Test the example file parser logic"""
+
+  def setUp(self):
+    self.parser = schemaexamples.ExampleFileParser()
+    self.temp_file = tempfile.NamedTemporaryFile()
+
+  def test_empty(self):
+    with self.assertLogs() as cm:
+      result = self.parser.parse(self.temp_file.name)
+    self.assertTrue(cm.output)
+    self.assertEqual(len(result), 1)
+    self.assertFalse(result[0].hasValidId())
+    self.assertFalse(result[0].terms)
+    self.assertFalse(result[0].getMicrodata())
+    self.assertFalse(result[0].getHtml())
+    self.assertFalse(result[0].getRdfa())
+    self.assertFalse(result[0].getJsonld())
+
+  def test_thing(self):
+    self.temp_file.write(THING_EXAMPLE.encode('utf8'))
+    self.temp_file.seek(0)
+    result = self.parser.parse(self.temp_file.name)
+    self.assertEqual(len(result), 1)
+    self.assertTrue(result[0].hasValidId())
+    self.assertEqual(result[0].getIdNum(), 999)
+    self.assertCountEqual(result[0].terms, ['Thing'])
+    self.assertEqual(
+        result[0].getHtml().strip(), '<p>This is a thing</p>', result[0].serialize())
+    self.assertEqual(
+        result[0].getMicrodata().strip(),
+        '<p itemscope itemtype="https://schema.org/Thing">This is a thing</p>',
+        result[0].serialize())
+    self.assertEqual(
+        result[0].getJsonld().strip(),
+        '{"@context": "https://schema.org/", "@type": "Thing", }',
+        result[0].serialize())
+
+
+if __name__ == '__main__':
+    unittest.main()


### PR DESCRIPTION
Fix issue 3075, proper handling of error while parsing empty input file.

Added unit-tests for the schemaexample library. 
- Test for empty file
- Test for file with one and two examples.
- Test accessors and serialization method.

The unit-test is automatically executed with the other tests by `./software/util/runtests.py`. 

```
test_empty_example (test_schemaexamples.TestExampleFileParser)
Test parsing of an empty Example file. ... ok
test_single_example (test_schemaexamples.TestExampleFileParser)
Test parsing of an Example file containing a single entry. ... ok
test_two_examples (test_schemaexamples.TestExampleFileParser)
Test parsing of an Example file containing two entries, one of them synthetized. ... ok
```

