### PR TITLE
Added test to check that JSON-LD examples are valid. This does only checks that they can be parsed, not that they conform to the schema. Fixed examples so the test pass.

### DIFF
--- a/data/examples.txt
+++ b/data/examples.txt
@@ -8727,7 +8727,7 @@ RDFA:
 
 JSON:
 
-No Json example available
+No JSON-LD example available
 
 TYPES: #eg-0177 encodingFormat, accessibilityHazard, accessibilityFeature, accessibilityControl, accessibilityAPI
 

--- a/data/ext/pending/issue-1389-examples.txt
+++ b/data/ext/pending/issue-1389-examples.txt
@@ -15,40 +15,40 @@ TODO
 JSON:
 
 {
- "@context": "https://schema.org/",
- "@type": "WebPage",
- "name": "Jane Doe's homepage",
- "speakable":
- {
-  "@type": "SpeakableSpecification",
-  "cssSelector": ["headline", "summary"]
-  },
- "url": "http://www.janedoe.com"
- }
+"@context": "https://schema.org/",
+"@type": "WebPage",
+"name": "Jane Doe's homepage",
+"speakable":
+{
+"@type": "SpeakableSpecification",
+"cssSelector": ["headline", "summary"]
+},
+"url": "http://www.janedoe.com"
+}
 
- TYPES: speakable
+TYPES: #eg-0474 speakable
 
- PRE-MARKUP:
+PRE-MARKUP:
 
- An example of 'speakable' markup (JSON-LD only, initially).
+An example of 'speakable' markup (JSON-LD only, initially).
 
- MICRODATA:
+MICRODATA:
 
- TODO
+TODO
 
- RDFA:
+RDFA:
 
- TODO
+TODO
 
- JSON:
+JSON:
 
- {
+{
   "@context": "https://schema.org/",
   "@type": "WebPage",
   "name": "Jane Doe's homepage",
   "speakable": [ "#myhead1", "#thesummary"],
   "url": "http://www.janedoe.com"
-  }
+}
 
 TYPES: #eg-0238 speakable, cssSelector, SpeakableSpecification
 
@@ -60,15 +60,15 @@ MICRODATA:
 
 <!DOCTYPE html>
 <html>
- <head rel="home" href="/" itemid=""  itemscope itemtype="https://schema.org/SpeakableSpecification">
-  <title>Example showing complex structures in HTML head</title>
-  <meta itemprop="cssSelector" content=".title" />
-  <meta itemprop="xpath" content="/html/body/h3" />
- </head>
- <body>
-  <h1 class="title">Complex Microdata in HTML head</h1>
-  <p>...</p>
- </body>
+<head rel="home" href="/" itemid=""  itemscope itemtype="https://schema.org/SpeakableSpecification">
+<title>Example showing complex structures in HTML head</title>
+<meta itemprop="cssSelector" content=".title" />
+<meta itemprop="xpath" content="/html/body/h3" />
+</head>
+<body>
+<h1 class="title">Complex Microdata in HTML head</h1>
+<p>...</p>
+</body>
 </html>
 
 RDFA:

--- a/data/ext/pending/issue-894-examples.txt
+++ b/data/ext/pending/issue-894-examples.txt
@@ -290,7 +290,7 @@ JSON:
 	{
 		"@type": "CategoryCodeSet",
 		"@id": "http://id.loc.gov/vocabulary/iso639-2",
-		"name": "ISO 639-2: Codes for the Representation of Names of Languages"
+		"name": "ISO 639-2: Codes for the Representation of Names of Languages",
 		"hasCategoryCode": "http://id.loc.gov/vocabulary/iso639-2/cze"
 	},
 	{
@@ -304,4 +304,4 @@ JSON:
 		},
 		"inCodeSet": "http://id.loc.gov/vocabulary/iso639-2"
 	}
-
+]

--- a/data/sdo-identifier-examples.txt
+++ b/data/sdo-identifier-examples.txt
@@ -42,12 +42,12 @@ JSON:
  "@type": "Book",
  "name": "Library linked data in the cloud : OCLC's experiments with new models of resource description",
  "author": "Carol Jean Godby",
- "isbn": "9781627052191"
+ "isbn": "9781627052191",
  "identifier": {
  "@type": "PropertyValue",
    "propertyID": "OCoLC",
    "value":  "889647468"
-   },
+  },
  "sameAs": "http://www.worldcat.org/oclc/889647468"
 }
 
@@ -88,14 +88,14 @@ RDFA:
 JSON:
 
 {
- "@context": "https://schema.org/",
- "@type": "LocalBusiness",
- "name": "A UK Organization Ltd",
- "address": "1 A Street, London"
- "identifier": {
- "@type": "PropertyValue",
-   "propertyID": "Company Number",
-   "value":  "99065782"
-   },
+  "@context": "https://schema.org/",
+  "@type": "LocalBusiness",
+  "name": "A UK Organization Ltd",
+  "address": "1 A Street, London",
+  "identifier": {
+    "@type": "PropertyValue",
+    "propertyID": "Company Number",
+    "value":  "99065782"
+  }
 }
 

--- a/software/tests/test_basics.py
+++ b/software/tests/test_basics.py
@@ -3,6 +3,7 @@ if not (sys.version_info.major == 3 and sys.version_info.minor > 5):
     print("Python version %s.%s not supported version 3.6 or above required - exiting" % (sys.version_info.major,sys.version_info.minor))
     sys.exit(1)
 import os
+import json
 import unittest
 import logging # https://docs.python.org/2/library/logging.html#logging-levels
 for path in [os.getcwd(),"software/util","software/SchemaTerms","software/SchemaExamples"]:
@@ -341,7 +342,6 @@ class SimpleCommentCountTests(unittest.TestCase):
 class BasicJSONLDTests(unittest.TestCase):
 
     def setUp(self):
-      import json
       self.ctx = None
       try:
         with open('site/docs/jsonldcontext.json') as json_file:
@@ -369,6 +369,23 @@ class BasicJSONLDTests(unittest.TestCase):
 
 #      self.assertTrue( HasMultipleBaseTypes( Unit.GetUnit("LocalBusiness") ) , "LocalBusiness is subClassOf Place + Organization." )
 
+
+class JsonExampleTests(unittest.TestCase):
+
+  def testAllExamples(self):
+    for example in SchemaExamples.allExamples():
+      with self.subTest(key=example.getKey(), file=example.getMeta("file")):
+        if not example.hasJsonld():
+          continue
+        json_source = example.getJsonldRaw()
+        if 'microdata only' in json_source:
+          continue
+        if 'No JSON-LD' in json_source:
+          continue
+        try:
+          parsed = json.loads(json_source)
+        except Exception as exception:
+          self.fail("Could not parse JSON '%s' error: %s file: %s" % (json_source, exception, example.getMeta("file")))
 
 # TODO: Unwritten tests
 #


### PR DESCRIPTION
This does only checks that they can be parsed,
not that they conform to the schema.
Fixed examples so the test pass.