### PR TITLE
Improvement in term generation logic

### DIFF
--- a/software/tests/test_buildtermpages.py
+++ b/software/tests/test_buildtermpages.py
@@ -1,0 +1,56 @@
+#!/usr/bin/env python3
+# -*- coding: UTF-8 -*-
+
+import os
+import sys
+import unittest
+
+for path in (os.getcwd(), "software/util", "software/SchemaTerms"):
+  sys.path.insert(1, path) #Pickup libs from local directories
+
+import buildtermpages
+import schemaexamples
+import sdoterm
+
+
+class TestTermFileName(unittest.TestCase):
+  """Test the utility function that creates paths for terms."""
+  def testEmpty(self):
+    with self.assertRaises(ValueError):
+      buildtermpages.termFileName("")
+
+  def testUnicode(self):
+    with self.assertRaises(ValueError):
+      buildtermpages.termFileName("🟪")
+
+  def testUpper(self):
+    self.assertEqual(
+        buildtermpages.termFileName("Thingamabob"),
+        "software/site/terms/types/T/Thingamabob.html")
+  def testLower(self):
+    self.assertEqual(
+        buildtermpages.termFileName("thingamabob"),
+        "software/site/terms/properties/t/thingamabob.html"
+    )
+
+  def testDigit(self):
+    self.assertEqual(
+        buildtermpages.termFileName("4DStatue"),
+        "software/site/terms/types/4/4DStatue.html"
+    )
+
+
+class TestBuildTermPages(unittest.TestCase):
+
+  def testTemplateRender(self):
+    """Test rendering of one term page."""
+    examples = [
+      schemaexamples.Example(
+          terms=["Thingamabob"], original_html="<b>Thingamabob</b>", microdata="", rdfa="", jsonld="",
+          exmeta={"file": __file__, "filepos": 0 })
+    ]
+    json = "[42]"
+    term = sdoterm.SdoTerm(termType=sdoterm.SdoTerm.TYPE, Id=42, uri="http://example.com/thingamabob", label="Thingamabob")
+    output = buildtermpages.termtemplateRender(term=term, examples=examples, json=json)
+    self.assertRegex(output, ".*Thingamabob.*")
+    self.assertRegex(output, ".*http://example\.com/thingamabob.*")

--- a/software/tests/test_buildtermpages.py
+++ b/software/tests/test_buildtermpages.py
@@ -41,12 +41,19 @@ class TestTermFileName(unittest.TestCase):
 
 
 class TestBuildTermPages(unittest.TestCase):
+  """Test the term page rendering logic."""
 
-  def testTemplateRender(self):
+  def testTemplateRenderNoExample(self):
+    term = sdoterm.SdoTerm(termType=sdoterm.SdoTerm.TYPE, Id=42, uri="http://example.com/whatchicallit", label="whatchicallit")
+    output = buildtermpages.termtemplateRender(term=term, examples=[], json='')
+    self.assertRegex(output, ".*whatchicallit.*")
+    self.assertRegex(output, ".*http://example\.com/whatchicallit.*")
+
+  def testTemplateRenderOneExample(self):
     """Test rendering of one term page."""
     examples = [
       schemaexamples.Example(
-          terms=["Thingamabob"], original_html="<b>Thingamabob</b>", microdata="", rdfa="", jsonld="",
+          terms=["Thingamabob"], original_html="Awesome & Thingamabob", microdata="", rdfa="", jsonld="",
           exmeta={"file": __file__, "filepos": 0 })
     ]
     json = "[42]"
@@ -54,3 +61,7 @@ class TestBuildTermPages(unittest.TestCase):
     output = buildtermpages.termtemplateRender(term=term, examples=examples, json=json)
     self.assertRegex(output, ".*Thingamabob.*")
     self.assertRegex(output, ".*http://example\.com/thingamabob.*")
+    self.assertRegex(output, ".Awesome &amp; Thingamabob.*")
+
+
+

--- a/software/util/buildsite.py
+++ b/software/util/buildsite.py
@@ -10,7 +10,7 @@ import time
 import shutil
 for path in [os.getcwd(),"./software","./software/SchemaTerms","./software/SchemaExamples"]:
   sys.path.insert( 1, path ) #Pickup libs from local  directories
-  
+
 if os.path.basename(os.getcwd()) != "schemaorg":
     print("\nScript should be run from within the 'schemaorg' directory! - Exiting\n")
     sys.exit(1)
@@ -25,7 +25,7 @@ import glob
 import re
 import argparse
 import rdflib
-import jinja2 
+import jinja2
 
 from sdotermsource import SdoTermSource
 from sdoterm import *
@@ -97,11 +97,11 @@ def runtests():
 
 DOCSDOCSDIR = "/docs"
 TERMDOCSDIR = "/docs"
-DOCSHREFSUFFIX="" 
+DOCSHREFSUFFIX=""
 DOCSHREFPREFIX="/"
-TERMHREFSUFFIX="" 
+TERMHREFSUFFIX=""
 TERMHREFPREFIX="/"
-    
+
 ###################################################
 #INITIALISE Directory
 ###################################################
@@ -143,7 +143,7 @@ def mycopytree(src, dst, symlinks=False, ignore=None):
     else:
         ignored_names = set()
 
-    if not os.path.isdir(dst): 
+    if not os.path.isdir(dst):
         os.makedirs(dst)
     errors = []
     for name in names:
@@ -177,7 +177,7 @@ def mycopytree(src, dst, symlinks=False, ignore=None):
     if errors:
         raise Error (errors)
 
-    
+
 ###################################################
 #MARKDOWN INITIALISE
 ###################################################
@@ -214,7 +214,7 @@ def loadExamples():
 ###################################################
 jenv = jinja2.Environment(loader=jinja2.FileSystemLoader(TEMPLATESDIR),
         extensions=['jinja2.ext.autoescape'], autoescape=True, cache_size=0)
-    
+
 def jinjaDebug(text):
     print("Jinja: %s" % text)
     return ''
@@ -228,26 +228,30 @@ def set_local_var(local_vars, name, value):
 jenv.globals['set_local_var'] = set_local_var
 
 
-### Template rendering 
+### Template rendering
 
-def templateRender(template,extra_vars=None):
-    #Basic varibles configuring UI
-    tvars = {
-        'local_vars': local_vars,
-        'version': getVersion(),
-        'versiondate': getCurrentVersionDate(),
-        'sitename': SITENAME,
-        'TERMHREFPREFIX': TERMHREFPREFIX,
-        'TERMHREFSUFFIX': TERMHREFSUFFIX,
-        'DOCSHREFPREFIX': DOCSHREFPREFIX,
-        'DOCSHREFSUFFIX': DOCSHREFSUFFIX,
-        'home_page': "False"
-    }
-    if extra_vars:
-        tvars.update(extra_vars)
-    
-    template = jenv.get_template(template)
-    return template.render(tvars)
+def templateRender(template_path, extra_vars=None, template_instance=None):
+  """Render a page template.
+
+  Returns: the generated page.
+  """
+  #Basic varibles configuring UI
+  tvars = {
+      'local_vars': local_vars,
+      'version': getVersion(),
+      'versiondate': getCurrentVersionDate(),
+      'sitename': SITENAME,
+      'TERMHREFPREFIX': TERMHREFPREFIX,
+      'TERMHREFSUFFIX': TERMHREFSUFFIX,
+      'DOCSHREFPREFIX': DOCSHREFPREFIX,
+      'DOCSHREFSUFFIX': DOCSHREFSUFFIX,
+      'home_page': "False"
+  }
+  if extra_vars:
+      tvars.update(extra_vars)
+
+  template = template_instance or jenv.get_template(template_path)
+  return template.render(tvars)
 
 
 ###################################################
@@ -282,7 +286,7 @@ def ShortenOnSentence(source,lengthHint=250):
                 if len(com) < len(source):
                     com += source[len(com)]
                 break
-                
+
         if len(source) > len(com) + 1:
             com += ".."
         source = com

--- a/software/util/buildtermpages.py
+++ b/software/util/buildtermpages.py
@@ -1,11 +1,15 @@
 #!/usr/bin/env python3
 # -*- coding: UTF-8 -*-
+
+import multiprocessing
+import os
 import sys
+import time
+
 if not (sys.version_info.major == 3 and sys.version_info.minor > 5):
     print("Python version %s.%s not supported version 3.6 or above required - exiting" % (sys.version_info.major,sys.version_info.minor))
     sys.exit(1)
 
-import os
 for path in [os.getcwd(),"software/Util","software/SchemaTerms","software/SchemaExamples"]:
   sys.path.insert( 1, path ) #Pickup libs from local  directories
 
@@ -14,74 +18,90 @@ from sdotermsource import SdoTermSource
 from sdoterm import *
 from schemaexamples import SchemaExamples
 
-#Calculate filename for term page
-def termFileName(termid):
-    pth = [OUTPUTDIR]
-    if re.match('^[a-z].*',termid):
-        pth.append("/terms/properties/")
-    elif re.match('^[0-9A-Z].*',termid):
-        pth.append("/terms/types/")
-    pth.append(termid[0])
-    path = "".join(pth)
-    
-    checkFilePath(path)    
 
-    elements = [path]
-    elements.append('/')
-    elements.append(termid)
-    elements.append('.html')
-    return "".join(elements)
-    
-#Prep of rendering values for term pages
-def termtemplateRender(term,examples):
-    #Basic varibles configuring UI
-    extra_vars = {
-        'title': term.label,
-        'menu_sel': "Schemas",
-        'home_page': "False",
-        'docsdir': TERMDOCSDIR,
-        'term': term,
-        'jsonldPayload': SdoTermSource.getTermAsRdfString(term.id,"json-ld", full=True),
-        'examples': examples
-    }
-    
-    return templateRender("terms/TermPage.j2",extra_vars)
+def termFileName(termid):
+  """Generate filename for term page.
+
+  Parameters:
+    termid (str): term identifier.
+  Returns:
+    File path the term page should be generated at.
+  """
+  path_components = [OUTPUTDIR, "terms"]
+  if re.match('^[a-z].*',termid):
+    path_components.append('properties')
+  elif re.match('^[0-9A-Z].*',termid):
+    path_components.append('types')
+  else:
+    raise ValueError("Invalid terminid: '" + termid +"'")
+  path_components.append(termid[0])
+  directory = os.path.join(*path_components)
+  checkFilePath(directory)
+  filename = termid + '.html'
+  return os.path.join(directory, filename)
+
+
+# This template will be used ~2800 times, so we reuse it.
+TEMPLATE = jenv.get_template("terms/TermPage.j2")
+
+def termtemplateRender(term, examples, json):
+  """Render the term with examples and associated JSON.
+
+  Parameters:
+    term (sdoterm.SdoTerm): term to generate the page for
+    examples (schemaexamples.Example): collection of examples for the term.
+  Returns:
+    string with the generate web-page.
+  """
+  extra_vars = {
+      'title': term.label,
+      'menu_sel': "Schemas",
+      'home_page': "False",
+      'docsdir': TERMDOCSDIR,
+      'term': term,
+      'jsonldPayload': json,
+      'examples': examples
+  }
+  return templateRender(template_path=None, extra_vars=extra_vars, template_instance=TEMPLATE)
+
+
+def RenderAndWriteSingleTerm(term_key):
+  """Renders a single term and write the result into a file.
+
+  Parameters:
+    term_key (str): key for the term.
+  Returns:
+    elapsed time for the generation (seconds).
+  """
+  tic = time.perf_counter()
+  term = SdoTermSource.getTerm(term_key, expanded=True)
+  if not term:
+    print("No such term: %s\n" % term_key)
+    return 0
+  if term.termType == SdoTerm.REFERENCE: #Don't create pages for reference types
+    return 0
+  examples = SchemaExamples.examplesForTerm(term.id)
+  json = SdoTermSource.getTermAsRdfString(term.id, "json-ld", full=True)
+  pageout = termtemplateRender(term, examples, json)
+  with open(termFileName(term.id), 'w', encoding='utf8') as outfile:
+    outfile.write(pageout)
+  elapsed = time.perf_counter() - tic
+  print("Term '%s' generated in %0.4f seconds" % (term_key, elapsed))
+  return elapsed
 
 
 def buildTerms(terms):
-    all = ["ALL","All","all"]
-    for a in all:
-        if a in terms:
-            terms = SdoTermSource.getAllTerms(supressSourceLinks=True)
-            break
-    import time,datetime
-    start = datetime.datetime.now()
-    lastCount = 0
-    if len(terms):
-        print("\nBuilding term pages...\n")
-    for t in terms:
-        tic = datetime.datetime.now() #diagnostics
-        term = SdoTermSource.getTerm(t,expanded=True)
-        if not term:
-            print("No such term: %s\n" % t)
-            continue
+  """Build the rendered version for a collection of terms."""
+  if any(filter(lambda term: term in ("ALL","All","all"), terms)):
+    terms = SdoTermSource.getAllTerms(supressSourceLinks=True)
 
-        if term.termType == SdoTerm.REFERENCE: #Don't create pages for reference types
-            continue
-        examples = SchemaExamples.examplesForTerm(term.id)
-        pageout = termtemplateRender(term,examples)
-        f = open(termFileName(term.id),"w", encoding='utf8')
-        f.write(pageout)
-        f.close()
+  if terms:
+    print("\nBuilding %d term pages...\n" % len(terms))
 
-        #diagnostics ##########################################
-        termsofar = len(SdoTermSource.termCache()) #diagnostics
-        termscreated = termsofar - lastCount       #diagnostics
-        lastCount = termsofar                      #diagnostics
-        print("Term: %s (%d) - %s" % (t, termscreated, str(datetime.datetime.now()-tic))) #diagnostics
-        #      Note: (%d) = number of individual newly created (not cached) term definitions to
-        #            build this expanded definition. ie. All Properties associated with a Type, etc.
-    
-    if len(terms):
-        print()
-        print ("All terms took %s seconds" % str(datetime.datetime.now()-start)) #diagnostics
+  total_elapsed = 0
+  for term_key in terms:
+    total_elapsed += RenderAndWriteSingleTerm(term_key)
+
+  print("%s terms generated in %0.4f seconds" % (len(terms), total_elapsed))
+
+


### PR DESCRIPTION
This does not change the actual logic, the code should functionally the same. 
The main improvement is speeding up term page generation a bit.
On my MacBook Pro (13-inch, 2019), this saves around 20 seconds when rebuilding the full-site.

`time ./software/util/buildsite.py -c -a -r `

**Before**

    real	6m57.826s
    user	6m42.271s
    sys	0m6.289s

**After**

    real	6m38.477s
    user	6m20.592s
    sys	0m6.972s

This improvement is obtained by **not** reloading and initialising the term page template 2800 times.
I also cleaned up the code, added some basic error handling in the code that generates term paths, and added some unit-test for the `buildtermpages` library and added some function documentation. 
