### PR TITLE
Add a new expected type of TextObject

### DIFF
--- a/data/schema.ttl
+++ b/data/schema.ttl
@@ -1774,7 +1774,7 @@ See also the <a href="/docs/hotels.html">dedicated document on the use of schema
 
 :MediaObject a rdfs:Class ;
     rdfs:label "MediaObject" ;
-    rdfs:comment "A media object, such as an image, video, or audio object embedded in a web page or a downloadable dataset i.e. DataDownload. Note that a creative work may have many media objects associated with it on the same web page. For example, a page about a single song (MusicRecording) may have a music video (VideoObject), and a high and low bandwidth audio stream (2 AudioObject's)." ;
+    rdfs:comment "A media object, such as an image, video, audio, or text object embedded in a web page or a downloadable dataset i.e. DataDownload. Note that a creative work may have many media objects associated with it on the same web page. For example, a page about a single song (MusicRecording) may have a music video (VideoObject), and a high and low bandwidth audio stream (2 AudioObject's)." ;
     rdfs:subClassOf :CreativeWork .
 
 :MediaSubscription a rdfs:Class ;
@@ -2997,6 +2997,12 @@ See also the <a href="/docs/hotels.html">dedicated document on the use of schema
     rdfs:label "TextDigitalDocument" ;
     rdfs:comment "A file composed primarily of text." ;
     rdfs:subClassOf :DigitalDocument .
+
+:TextObject a rdfs:Class ;
+    rdfs:label "TextObject" ;
+    rdfs:comment "An text file." ;
+    rdfs:subClassOf :MediaObject ;
+    owl:equivalentClass <http://purl.org/dc/dcmitype/Text> .
 
 :TheaterEvent a rdfs:Class ;
     rdfs:label "TheaterEvent" ;
@@ -9688,7 +9694,8 @@ we define a supporting type, [[SpeakableSpecification]]  which is defined to be 
 :description a rdf:Property ;
     rdfs:label "description" ;
     :domainIncludes :Thing ;
-    :rangeIncludes :Text ;
+    :rangeIncludes :Text,
+        :TextObject ;
     rdfs:comment "A description of the item." ;
     owl:equivalentProperty dc:description .
 


### PR DESCRIPTION
Add a new [MediaObject ](https://schema.org/MediaObject)subtype of TextObject. Add TextObject as a new expected type of the property [description](https://schema.org/description). For more see the issue #2942