### PR TITLE
Update issue-2469.ttl

### DIFF
--- a/data/ext/pending/issue-2469.ttl
+++ b/data/ext/pending/issue-2469.ttl
@@ -22,7 +22,7 @@ Since schema.org types like [[Movie]] and [[TVEpisode]] can be used for both wor
 :titleEIDR a rdf:Property ;
     rdfs:label "titleEIDR" ;
     :domainIncludes :Movie,
-        :TVEpisode ;
+        :TVEpisode, :TVSeason, :TVSeries ;
     :isPartOf <https://pending.schema.org> ;
     :rangeIncludes :Text,
         :URL ;
@@ -31,7 +31,7 @@ Since schema.org types like [[Movie]] and [[TVEpisode]] can be used for both wor
 
 For example, the motion picture known as "Ghostbusters" has a titleEIDR of  "10.5240/7EC7-228A-510A-053E-CBB8-J". This title (or work) may have several variants, which EIDR calls "edits". See [[editEIDR]].
 
-Since schema.org types like [[Movie]] and [[TVEpisode]] can be used for both works and their multiple expressions, it is possible to use [[titleEIDR]] alone (for a general description), or alongside [[editEIDR]] for a more edit-specific description.
+Since schema.org types like [[Movie]], [[TVEpisode]], [[TVSeason]], and [[TVSeries]] can be used for both works and their multiple expressions, it is possible to use [[titleEIDR]] alone (for a general description), or alongside [[editEIDR]] for a more edit-specific description.
 """ ;
     rdfs:subPropertyOf :identifier .
 


### PR DESCRIPTION
The property [[titleEIDR]] used for storing EIDR (Entertainment Identifier Registry) values is also used for [[TVSeason]] and [[TVSeries]] and should be added to those two types.

E.g.:
TVSeries for "12 Monkeys": https://ui.eidr.org/view/content?id=10.5240/354B-4B1D-02AA-068E-CDFD-3 with titleEIDR 10.5240/354B-4B1D-02AA-068E-CDFD-3 TVSeason for "12 Monkeys: Season 1": https://ui.eidr.org/view/content?id=10.5240/9450-3CB5-BB29-5430-CCDA-B with titleEIDR 10.5240/9450-3CB5-BB29-5430-CCDA-B

Google's Media Action Developer site already recommends titleEIDR for both [TVSeason](https://developers.devsite.corp.google.com/actions/media/reference/data-specification/tv-shows-specification#tvseason) and [TVSeries](https://developers.devsite.corp.google.com/actions/media/reference/data-specification/tv-shows-specification#tvseries).