### PR TITLE
Make DonateAction a TransferAction instead of a TradeAction

### DIFF
--- a/data/schema.ttl
+++ b/data/schema.ttl
@@ -986,7 +986,7 @@ Originally, URLs from [GoodRelations](http://purl.org/goodrelations/v1) were use
 :DonateAction a rdfs:Class ;
     rdfs:label "DonateAction" ;
     rdfs:comment "The act of providing goods, services, or money without compensation, often for philanthropic reasons." ;
-    rdfs:subClassOf :TradeAction .
+    rdfs:subClassOf :TransferAction .
 
 :DownloadAction a rdfs:Class ;
     rdfs:label "DownloadAction" ;

--- a/data/schema.ttl
+++ b/data/schema.ttl
@@ -7761,7 +7761,8 @@ Note: for historical reasons, any textual label and formal code provided as a li
 
 :price a rdf:Property ;
     rdfs:label "price" ;
-    :domainIncludes :Offer,
+    :domainIncludes :DonateAction,
+        :Offer,
         :PriceSpecification,
         :TradeAction ;
     :rangeIncludes :Number,
@@ -7778,7 +7779,8 @@ Note: for historical reasons, any textual label and formal code provided as a li
 
 :priceCurrency a rdf:Property ;
     rdfs:label "priceCurrency" ;
-    :domainIncludes :Offer,
+    :domainIncludes  :DonateAction,
+        :Offer,
         :PriceSpecification,
         :Reservation,
         :Ticket,
@@ -7795,6 +7797,7 @@ Note: for historical reasons, any textual label and formal code provided as a li
 :priceSpecification a rdf:Property ;
     rdfs:label "priceSpecification" ;
     :domainIncludes :Demand,
+        :DonateAction,
         :Offer,
         :TradeAction ;
     :rangeIncludes :PriceSpecification ;


### PR DESCRIPTION
DonateAction is explicitly "without compensation", so I propose to make it a subclass of TransferAction instead.

All the other TradeActions involve a swap of items or an intention of each party both giving something and receiving something in return. (In fact, in broader contexts, the concept of trade is intentionally separated from gifts and donations.)

~~There are 3 properties of TradeAction that would be lost: price, priceCurrency, and priceSpecification. To include price, one might make the `object` property be a MonetaryValue or TypeAndQuantityNode -- and if there's already an `object` then that might be turned into an array. (I posit that it does not need priceSpecification.)~~ (EDIT: added these as properties in a later commit.)