### PR TITLE
Add PerformingGroup as an expected type for the property actor

### DIFF
--- a/data/schema.ttl
+++ b/data/schema.ttl
@@ -9570,8 +9570,9 @@ we define a supporting type, [[SpeakableSpecification]]  which is defined to be 
         :VideoGame,
         :VideoGameSeries,
         :VideoObject ;
-    :rangeIncludes :Person ;
-    rdfs:comment "An actor, e.g. in TV, radio, movie, video games etc., or in an event. Actors can be associated with individual items or with a series, episode, clip." .
+    :rangeIncludes :Person,
+        :PerformingGroup ;
+    rdfs:comment "An actor (individual or a group), e.g. in TV, radio, movie, video games etc., or in an event. Actors can be associated with individual items or with a series, episode, clip." .
 
 :album a rdf:Property ;
     rdfs:label "album" ;


### PR DESCRIPTION
As discussed in #3185 cast information can contain groups (comedy, musical, etc.) as well as individual people.