### PR TITLE
Fixed all inheritance warnings in schema.org

### DIFF
--- a/data/ext/health-lifesci/med-health-core.ttl
+++ b/data/ext/health-lifesci/med-health-core.ttl
@@ -1203,8 +1203,7 @@
 
 :activeIngredient a rdf:Property ;
     rdfs:label "activeIngredient" ;
-    :domainIncludes :DietarySupplement,
-        :Drug,
+    :domainIncludes
         :DrugStrength,
         :Substance ;
     :isPartOf <https://health-lifesci.schema.org> ;
@@ -1382,7 +1381,7 @@
 
 :codeValue a rdf:Property ;
     rdfs:label "codeValue" ;
-    :domainIncludes :MedicalCode .
+    :domainIncludes :CategoryCode .
 
 :codingSystem a rdf:Property ;
     rdfs:label "codingSystem" ;
@@ -1788,9 +1787,7 @@
 
 :maximumIntake a rdf:Property ;
     rdfs:label "maximumIntake" ;
-    :domainIncludes :DietarySupplement,
-        :Drug,
-        :DrugStrength,
+    :domainIncludes :DrugStrength,
         :Substance ;
     :isPartOf <https://health-lifesci.schema.org> ;
     :rangeIncludes :MaximumDoseSchedule ;
@@ -1814,10 +1811,7 @@
 
 :medicalSpecialty a rdf:Property ;
     rdfs:label "medicalSpecialty" ;
-    :domainIncludes :Hospital,
-        :MedicalClinic,
-        :MedicalOrganization,
-        :Physician ;
+    :domainIncludes :MedicalOrganization;
     :isPartOf <https://health-lifesci.schema.org> ;
     :rangeIncludes :MedicalSpecialty ;
     rdfs:comment "A medical specialty of the provider." .
@@ -1918,8 +1912,7 @@
 
 :possibleTreatment a rdf:Property ;
     rdfs:label "possibleTreatment" ;
-    :domainIncludes :MedicalCondition,
-        :MedicalSignOrSymptom ;
+    :domainIncludes :MedicalCondition;
     :isPartOf <https://health-lifesci.schema.org> ;
     :rangeIncludes :MedicalTherapy ;
     rdfs:comment "A possible treatment to address this condition, sign or symptom." .

--- a/data/ext/pending/issue-1401.ttl
+++ b/data/ext/pending/issue-1401.ttl
@@ -19,17 +19,17 @@
     rdfs:subClassOf :CreativeWork .
 
 :assesses a rdf:Property ;
-    :domainIncludes :LearningResource .
+    :domainIncludes :CreativeWork .
 
 :educationalAlignment a rdf:Property ;
-    :domainIncludes :LearningResource .
+    :domainIncludes :CreativeWork .
 
 :educationalLevel a rdf:Property ;
-    :domainIncludes :LearningResource .
+    :domainIncludes :CreativeWork .
 
 :educationalUse a rdf:Property ;
-    :domainIncludes :LearningResource .
+    :domainIncludes :CreativeWork .
 
 :teaches a rdf:Property ;
-    :domainIncludes :LearningResource .
+    :domainIncludes :CreativeWork .
 

--- a/data/ext/pending/issue-1525.ttl
+++ b/data/ext/pending/issue-1525.ttl
@@ -87,8 +87,7 @@ A [[ReportageNewsArticle]] which goes deeper into analysis can also be marked wi
 
 :actionableFeedbackPolicy a rdf:Property ;
     rdfs:label "actionableFeedbackPolicy" ;
-    :domainIncludes :NewsMediaOrganization,
-        :Organization ;
+    :domainIncludes :Organization ;
     :isPartOf <https://pending.schema.org> ;
     :rangeIncludes :CreativeWork,
         :URL ;
@@ -99,8 +98,7 @@ A [[ReportageNewsArticle]] which goes deeper into analysis can also be marked wi
 
 :correctionsPolicy a rdf:Property ;
     rdfs:label "correctionsPolicy" ;
-    :domainIncludes :NewsMediaOrganization,
-        :Organization ;
+    :domainIncludes :Organization ;
     :isPartOf <https://pending.schema.org> ;
     :rangeIncludes :CreativeWork,
         :URL ;
@@ -111,8 +109,7 @@ A [[ReportageNewsArticle]] which goes deeper into analysis can also be marked wi
 
 :diversityPolicy a rdf:Property ;
     rdfs:label "diversityPolicy" ;
-    :domainIncludes :NewsMediaOrganization,
-        :Organization ;
+    :domainIncludes :Organization ;
     :isPartOf <https://pending.schema.org> ;
     :rangeIncludes :CreativeWork,
         :URL ;
@@ -122,8 +119,7 @@ A [[ReportageNewsArticle]] which goes deeper into analysis can also be marked wi
 
 :diversityStaffingReport a rdf:Property ;
     rdfs:label "diversityStaffingReport" ;
-    :domainIncludes :NewsMediaOrganization,
-        :Organization ;
+    :domainIncludes :Organization ;
     :isPartOf <https://pending.schema.org> ;
     :rangeIncludes :Article,
         :URL ;
@@ -134,8 +130,7 @@ A [[ReportageNewsArticle]] which goes deeper into analysis can also be marked wi
 
 :ethicsPolicy a rdf:Property ;
     rdfs:label "ethicsPolicy" ;
-    :domainIncludes :NewsMediaOrganization,
-        :Organization ;
+    :domainIncludes :Organization ;
     :isPartOf <https://pending.schema.org> ;
     :rangeIncludes :CreativeWork,
         :URL ;
@@ -166,8 +161,7 @@ A [[ReportageNewsArticle]] which goes deeper into analysis can also be marked wi
 
 :ownershipFundingInfo a rdf:Property ;
     rdfs:label "ownershipFundingInfo" ;
-    :domainIncludes :NewsMediaOrganization,
-        :Organization ;
+    :domainIncludes :Organization ;
     :isPartOf <https://pending.schema.org> ;
     :rangeIncludes :AboutPage,
         :CreativeWork,
@@ -180,8 +174,7 @@ A [[ReportageNewsArticle]] which goes deeper into analysis can also be marked wi
 
 :unnamedSourcesPolicy a rdf:Property ;
     rdfs:label "unnamedSourcesPolicy" ;
-    :domainIncludes :NewsMediaOrganization,
-        :Organization ;
+    :domainIncludes :Organization ;
     :isPartOf <https://pending.schema.org> ;
     :rangeIncludes :CreativeWork,
         :URL ;

--- a/data/ext/pending/issue-1779.ttl
+++ b/data/ext/pending/issue-1779.ttl
@@ -40,8 +40,7 @@
 :educationalLevel a rdf:Property ;
     rdfs:label "educationalLevel" ;
     :domainIncludes :CreativeWork,
-        :EducationEvent,
-        :EducationalOccupationalCredential ;
+        :EducationEvent  ;
     :isPartOf <https://pending.schema.org> ;
     :rangeIncludes :DefinedTerm,
         :Text,

--- a/data/ext/pending/issue-2289.ttl
+++ b/data/ext/pending/issue-2289.ttl
@@ -39,7 +39,7 @@
 
 :occupationalCategory a rdf:Property ;
     rdfs:label "occupationalCategory" ;
-    :domainIncludes :WorkBasedProgram ;
+    :domainIncludes :EducationalOccupationalProgram ;
     :rangeIncludes :CategoryCode,
         :Text ;
     :source <https://github.com/schemaorg/schemaorg/issues/2289> .
@@ -97,7 +97,7 @@
 
 :trainingSalary a rdf:Property ;
     rdfs:label "trainingSalary" ;
-    :domainIncludes :WorkBasedProgram ;
+    :domainIncludes :EducationalOccupationalProgram ;
     :isPartOf <https://pending.schema.org> ;
     :rangeIncludes :MonetaryAmountDistribution ;
     :source <https://github.com/schemaorg/schemaorg/issues/2289> ;

--- a/data/ext/pending/issue-2373.ttl
+++ b/data/ext/pending/issue-2373.ttl
@@ -141,9 +141,7 @@
 
 :tourBookingPage a rdf:Property ;
     rdfs:label "tourBookingPage" ;
-    :domainIncludes :Accommodation,
-        :ApartmentComplex,
-        :Place ;
+    :domainIncludes :Place ;
     :isPartOf <https://pending.schema.org> ;
     :rangeIncludes :URL ;
     :source <https://github.com/schemaorg/schemaorg/issues/2373> ;

--- a/data/ext/pending/issue-2450.ttl
+++ b/data/ext/pending/issue-2450.ttl
@@ -169,7 +169,7 @@ For an [[AudioObject]] to be 'satire or parody content': Audio that was created 
 
 :interpretedAsClaim a rdf:Property ;
     rdfs:label "interpretedAsClaim" ;
-    :domainIncludes :MediaObject, :CreativeWork;
+    :domainIncludes :CreativeWork;
     rdfs:subPropertyOf :description ;
     :isPartOf <https://pending.schema.org> ;
     :rangeIncludes :Claim ;

--- a/data/ext/pending/issue-2564.ttl
+++ b/data/ext/pending/issue-2564.ttl
@@ -8,8 +8,8 @@
     rdfs:label "Observation" ;
     :isPartOf <https://pending.schema.org> ;
     :source <https://github.com/schemaorg/schemaorg/issues/2291> ;
-    rdfs:comment """Instances of the class [[Observation]] are used to specify observations about an entity at a particular time. The principal properties of an [[Observation]] are [[observationAbout]], [[measuredProperty]], [[statType]], [[value] and [[observationDate]]  and [[measuredProperty]]. Some but not all Observations represent a [[QuantitativeValue]]. Quantitative observations can be about a [[StatisticalVariable]], which is an abstract specification about which we can make observations that are grounded at a particular location and time. 
-    
+    rdfs:comment """Instances of the class [[Observation]] are used to specify observations about an entity at a particular time. The principal properties of an [[Observation]] are [[observationAbout]], [[measuredProperty]], [[statType]], [[value] and [[observationDate]]  and [[measuredProperty]]. Some but not all Observations represent a [[QuantitativeValue]]. Quantitative observations can be about a [[StatisticalVariable]], which is an abstract specification about which we can make observations that are grounded at a particular location and time.
+
 Observations can also encode a subset of simple RDF-like statements (its observationAbout, a StatisticalVariable, defining the measuredPoperty; its observationAbout property indicating the entity the statement is about, and [[value]] )
 
 In the context of a quantitative knowledge graph, typical properties could include [[measuredProperty]], [[observationAbout]], [[observationDate]], [[value]], [[unitCode]], [[unitText]], [[measurementMethod]].
@@ -101,7 +101,7 @@ population, and does not imply that the population consists of people. For examp
     rdfs:label "ConstraintNode" ;
     :isPartOf <https://pending.schema.org> ;
     :source <https://github.com/schemaorg/schemaorg/issues/2564> ;
-    rdfs:comment """The ConstraintNode type is provided to support usecases in which a node in a structured data graph is described with properties which appear to describe a single entity, but are being used in a situation where they serve a more abstract purpose. A [[ConstraintNode]] can be described using [[constraintProperty]] and [[numConstraints]]. These constraint properties can serve a 
+    rdfs:comment """The ConstraintNode type is provided to support usecases in which a node in a structured data graph is described with properties which appear to describe a single entity, but are being used in a situation where they serve a more abstract purpose. A [[ConstraintNode]] can be described using [[constraintProperty]] and [[numConstraints]]. These constraint properties can serve a
     variety of purposes, and their values may sometimes be understood to indicate sets of possible values rather than single, exact and specific values.""" ;
     rdfs:subClassOf :Intangible . # there are a couple of areas around product templates (including groups), possibly Actions, where this might be applied too.
 
@@ -150,7 +150,7 @@ population, and does not imply that the population consists of people. For examp
     rdfs:label "observationAbout" ;
     :domainIncludes :Observation ;
     :isPartOf <https://pending.schema.org> ;
-    :rangeIncludes :Thing, :Place ;
+    :rangeIncludes :Thing;
     :source <https://github.com/schemaorg/schemaorg/issues/2291> ;
     rdfs:comment "The [[observationAbout]] property identifies an entity, often a [[Place]], associated with an [[Observation]]." .
 

--- a/data/ext/pending/issue-2766.ttl
+++ b/data/ext/pending/issue-2766.ttl
@@ -18,8 +18,7 @@
     rdfs:comment "A HyperToEntry is an item within a [[HyperToc]], which represents a hypertext table of contents for complex media objects, such as [[VideoObject]], [[AudioObject]]. The media object itself is indicated using [[associatedMedia]]. Each section of interest within that content can be described with a [[HyperTocEntry]], with associated [[startOffset]] and [[endOffset]]. When several entries are all from the same file, [[associatedMedia]] is used on the overarching [[HyperTocEntry]]; if the content has been split into multiple files, they can be referenced using [[associatedMedia]] on each [[HyperTocEntry]]." ;
     rdfs:subClassOf :CreativeWork .
 
-:associatedMedia :domainIncludes :HyperToc,
-        :HyperTocEntry .
+:associatedMedia :domainIncludes :CreativeWork .
 
 :endOffset :rangeIncludes :HyperTocEntry .
 

--- a/data/ext/pending/issue-2811.ttl
+++ b/data/ext/pending/issue-2811.ttl
@@ -483,7 +483,7 @@
 
 :size :rangeIncludes :SizeSpecification .
 
-:valueReference :rangeIncludes :MeasurementTypeEnumeration, :Text, :DefinedTerm .
+:valueReference :rangeIncludes :Enumeration, :Text, :DefinedTerm .
 
 
 

--- a/data/ext/pending/issue-383.ttl
+++ b/data/ext/pending/issue-383.ttl
@@ -12,7 +12,7 @@
     rdfs:comment """A FundingAgency is an organization that implements one or more [[FundingScheme]]s and manages
     the granting process (via [[Grant]]s, typically [[MonetaryGrant]]s).
     A funding agency is not always required for grant funding, e.g. philanthropic giving, corporate sponsorship etc.
-    
+
 Examples of funding agencies include ERC, REA, NIH, Bill and Melinda Gates Foundation, ...
     """ ;
     rdfs:subClassOf :Project .
@@ -56,7 +56,7 @@ The amount of a [[Grant]] is represented using [[amount]] as a [[MonetaryAmount]
         <https://github.com/schemaorg/schemaorg/issues/383> ;
 
     rdfs:comment """An enterprise (potentially individual but typically collaborative), planned to achieve a particular aim.
-Use properties from [[Organization]], [[subOrganization]]/[[parentOrganization]] to indicate project sub-structures. 
+Use properties from [[Organization]], [[subOrganization]]/[[parentOrganization]] to indicate project sub-structures.
    """ ;
     rdfs:subClassOf :Organization .
 
@@ -94,7 +94,7 @@ Use properties from [[Organization]], [[subOrganization]]/[[parentOrganization]]
     rdfs:comment "A [[Grant]] that directly or indirectly provide funding or sponsorship for this item. See also [[ownershipFundingInfo]]." .
 
 :funder a rdf:Property ;
-    :domainIncludes :Grant, :MonetaryGrant .
+    :domainIncludes :Grant .
 
 :sponsor a rdf:Property ;
     :domainIncludes :Grant .

--- a/data/schema.ttl
+++ b/data/schema.ttl
@@ -4189,7 +4189,7 @@ See also the <a href="/docs/hotels.html">dedicated document on the use of schema
 
 :amenityFeature a rdf:Property ;
     rdfs:label "amenityFeature" ;
-    :domainIncludes :Accommodation,
+    :domainIncludes
         :LodgingBusiness,
         :Place ;
     :rangeIncludes :LocationFeatureSpecification ;
@@ -4529,7 +4529,7 @@ See also the <a href="/docs/hotels.html">dedicated document on the use of schema
 :bed a rdf:Property ;
     rdfs:label "bed" ;
     :domainIncludes :HotelRoom,
-        :Suite, :Accommodation;
+        :Accommodation;
     :rangeIncludes :BedDetails,
         :BedType,
         :Text ;
@@ -5145,10 +5145,8 @@ See also the <a href="/docs/hotels.html">dedicated document on the use of schema
 
 :countryOfOrigin a rdf:Property ;
     rdfs:label "countryOfOrigin" ;
-    :domainIncludes :CreativeWork, :Product, :Movie,
-        :TVEpisode,
-        :TVSeason,
-        :TVSeries ;
+    :domainIncludes :CreativeWork, :Product,
+        :TVEpisode;
     :rangeIncludes :Country ;
     rdfs:comment """The country of origin of something, including products as well as creative  works such as movie and TV content.
 
@@ -6545,7 +6543,7 @@ Typical unit code(s): MTK for square meter, FTK for square foot, or YDK for squa
 
 :isVariantOf a rdf:Property ;
     rdfs:label "isVariantOf" ;
-    :domainIncludes :ProductModel ;
+    :domainIncludes :Product ;
     :rangeIncludes :ProductModel ;
     rdfs:comment "Indicates the kind of product that this is a variant of. In the case of [[ProductModel]], this is a pointer (from a ProductModel) to a base product from which this product is a variant. It is safe to infer that the variant inherits all product features from the base model, unless defined locally. This is not transitive. In the case of a [[ProductGroup]], the group description also serves as a template, representing a set of Products that vary on explicitly defined, specific dimensions only (so it defines both a set of variants, as well as which values distinguish amongst those variants). When used with [[ProductGroup]], this property can apply to any [[Product]] included in the group." .
 
@@ -6728,8 +6726,7 @@ Typical unit code(s): MTK for square meter, FTK for square foot, or YDK for squa
 
 :learningResourceType a rdf:Property ;
     rdfs:label "learningResourceType" ;
-    :domainIncludes :CreativeWork,
-        :LearningResource ;
+    :domainIncludes :CreativeWork;
     :rangeIncludes :DefinedTerm,
         :Text ;
     rdfs:comment "The predominant type or kind characterizing the learning resource. For example, 'presentation', 'handout'." .
@@ -7248,11 +7245,7 @@ Typical unit code(s): MTK for square meter, FTK for square foot, or YDK for squa
 :numberOfRooms a rdf:Property ;
     rdfs:label "numberOfRooms" ;
     :domainIncludes :Accommodation,
-        :Apartment,
-        :House,
-        :LodgingBusiness,
-        :SingleFamilyResidence,
-        :Suite ;
+        :LodgingBusiness;
     :rangeIncludes :Number,
         :QuantitativeValue ;
     :contributor <https://schema.org/docs/collab/STI_Accommodation_Ontology> ;
@@ -7282,10 +7275,9 @@ Typical unit code(s): ROM for room or C62 for no unit. The type of room can be p
 
 :occupancy a rdf:Property ;
     rdfs:label "occupancy" ;
-    :domainIncludes :Apartment,
-        :HotelRoom,
+    :domainIncludes :HotelRoom,
         :SingleFamilyResidence,
-        :Suite, :Accommodation ;
+        :Accommodation ;
     :rangeIncludes :QuantitativeValue ;
     :contributor <https://schema.org/docs/collab/STI_Accommodation_Ontology> ;
     rdfs:comment """The allowed total occupancy for the accommodation in persons (including infants etc). For individual accommodations, this is not necessarily the legal maximum but defines the permitted usage as per the contractual agreement (e.g. a double room used by a single person).
@@ -7897,8 +7889,7 @@ Note: for historical reasons, any textual label and formal code provided as a li
 
 :productionDate a rdf:Property ;
     rdfs:label "productionDate" ;
-    :domainIncludes :Product,
-        :Vehicle ;
+    :domainIncludes :Product;
     :rangeIncludes :Date ;
     :contributor <https://schema.org/docs/collab/Automotive_Ontology_Working_Group> ;
     rdfs:comment "The date of production of the item, e.g. vehicle." .
@@ -8001,8 +7992,7 @@ While such policies are most typically expressed in natural language, sometimes 
 
 :purchaseDate a rdf:Property ;
     rdfs:label "purchaseDate" ;
-    :domainIncludes :Product,
-        :Vehicle ;
+    :domainIncludes :Product;
     :rangeIncludes :Date ;
     :contributor <https://schema.org/docs/collab/Automotive_Ontology_Working_Group> ;
     rdfs:comment "The date the item, e.g. vehicle, was purchased by the current owner." .
@@ -9294,9 +9284,6 @@ we define a supporting type, [[SpeakableSpecification]]  which is defined to be 
         :QualitativeValue,
         :QuantitativeValue ;
     :rangeIncludes :Enumeration,
-        :PropertyValue,
-        :QualitativeValue,
-        :QuantitativeValue,
         :StructuredValue ;
     rdfs:comment "A secondary value that provides additional information on the original value, e.g. a reference temperature or a type of measurement." .
 
@@ -9588,8 +9575,7 @@ we define a supporting type, [[SpeakableSpecification]]  which is defined to be 
 
 :alumni a rdf:Property ;
     rdfs:label "alumni" ;
-    :domainIncludes :EducationalOrganization,
-        :Organization ;
+    :domainIncludes :Organization ;
     :inverseOf :alumniOf ;
     :rangeIncludes :Person ;
     rdfs:comment "Alumni of an organization." .
@@ -9598,8 +9584,7 @@ we define a supporting type, [[SpeakableSpecification]]  which is defined to be 
     rdfs:label "alumniOf" ;
     :domainIncludes :Person ;
     :inverseOf :alumni ;
-    :rangeIncludes :EducationalOrganization,
-        :Organization ;
+    :rangeIncludes :Organization ;
     rdfs:comment "An organization that the person is an alumni of." .
 
 :artworkSurface a rdf:Property ;
@@ -9760,8 +9745,7 @@ we define a supporting type, [[SpeakableSpecification]]  which is defined to be 
 
 :encodingFormat a rdf:Property ;
     rdfs:label "encodingFormat" ;
-    :domainIncludes :CreativeWork,
-        :MediaObject ;
+    :domainIncludes :CreativeWork;
     :rangeIncludes :Text,
         :URL ;
     rdfs:comment """Media type typically expressed using a MIME format (see [IANA site](http://www.iana.org/assignments/media-types/media-types.xhtml) and [MDN reference](https://developer.mozilla.org/en-US/docs/Web/HTTP/Basics_of_HTTP/MIME_types)), e.g. application/zip for a SoftwareApplication binary, audio/mpeg for .mp3 etc.
@@ -10114,8 +10098,7 @@ Unregistered or niche encoding and file formats can be indicated instead via the
     :domainIncludes :ContactPoint,
         :Organization,
         :Service ;
-    :rangeIncludes :AdministrativeArea,
-        :GeoShape,
+    :rangeIncludes :GeoShape,
         :Place ;
     :supersededBy :areaServed ;
     rdfs:comment "The geographic area where the service is provided." .
@@ -10328,8 +10311,6 @@ Open-ended date ranges can be written with ".." in place of the end date. For ex
     rdfs:label "step" ;
     :domainIncludes :HowTo ;
     :rangeIncludes :CreativeWork,
-        :HowToSection,
-        :HowToStep,
         :Text ;
     rdfs:comment "A single step item (as HowToStep, text, document, video, etc.) or a HowToSection." .
 
@@ -10364,8 +10345,7 @@ Open-ended date ranges can be written with ".." in place of the end date. For ex
         :Offer,
         :Organization,
         :Service ;
-    :rangeIncludes :AdministrativeArea,
-        :GeoShape,
+    :rangeIncludes :GeoShape,
         :Place,
         :Text ;
     rdfs:comment "The geographic area where a service or offered item is provided." .

--- a/software/tests/test_graphs.py
+++ b/software/tests/test_graphs.py
@@ -82,7 +82,6 @@ class SDOGraphSetupTestCase(unittest.TestCase):
       self.assertTrue(result[0] != result[1],
                       "%s should not be equal to %s" % (result[0], result[1]) )
 
-  @unittest.expectedFailure # autos
   def test_needlessDomainIncludes(self):
     global warnings
     # check immediate subtypes don't declare same domainIncludes
@@ -100,15 +99,12 @@ class SDOGraphSetupTestCase(unittest.TestCase):
            }
            ORDER BY ?prop ''')
     ndi1_results = self.rdflib_data.query(ndi1)
-    if (len(ndi1_results) > 0):
+    if ndi1_results:
         for row in ndi1_results:
-            warn = "WARNING property %s defining domain, %s, [which is subclassOf] %s unnecessarily" % (row["prop"],row["c1"],row["c2"])
-            #warnings.append(warn)
-            log.info(warn + "\n")
-    self.assertEqual(len(ndi1_results), 0,
-                     "No subtype need redeclare a domainIncludes of its parents. Found: %s " % len(ndi1_results ) )
+            with self.subTest(property=str(row["prop"])):
+                warn = "WARNING property %s defining domain, %s, [which is subclassOf] %s unnecessarily" % (row["prop"],row["c1"],row["c2"])
+                self.fail(warn)
 
-  @unittest.expectedFailure
   def test_needlessRangeIncludes(self):
     global warnings
     # as above, but for range. We excuse URL as it is special, not best seen as a Text subtype.
@@ -127,12 +123,11 @@ class SDOGraphSetupTestCase(unittest.TestCase):
              }
              ORDER BY ?prop ''')
     nri1_results = self.rdflib_data.query(nri1)
-    if (len(nri1_results)>0):
+    if nri1_results:
         for row in nri1_results:
-            warn = "WARNING property %s defining range, %s, [which is subclassOf] %s unnecessarily" % (row["prop"],row["c1"],row["c2"])
-            #warnings.append(warn)
-            log.info(warn + "\n")
-    self.assertEqual(len(nri1_results), 0, "No subtype need redeclare a rangeIncludes of its parents. Found: %s" % len(nri1_results) )
+            with self.subTest(property=str(row["prop"])):
+                warn = "WARNING property %s defining range, %s, [which is subclassOf] %s unnecessarily" % (row["prop"],row["c1"],row["c2"])
+                self.fail(warn)
 
 #  def test_supersededByAreLabelled(self):
 #    supersededByAreLabelled_results = self.rdflib_data.query("select ?x ?y ?z where { ?x <https://schema.org/supersededBy> ?y . ?y <https://schema.org/name> ?z }")

--- a/software/tests/test_graphs.py
+++ b/software/tests/test_graphs.py
@@ -83,7 +83,6 @@ class SDOGraphSetupTestCase(unittest.TestCase):
                       "%s should not be equal to %s" % (result[0], result[1]) )
 
   def test_needlessDomainIncludes(self):
-    global warnings
     # check immediate subtypes don't declare same domainIncludes
     # TODO: could we use property paths here to be more thorough?
     # rdfs:subClassOf+ should work but seems not to.
@@ -106,7 +105,6 @@ class SDOGraphSetupTestCase(unittest.TestCase):
                 self.fail(warn)
 
   def test_needlessRangeIncludes(self):
-    global warnings
     # as above, but for range. We excuse URL as it is special, not best seen as a Text subtype.
     # check immediate subtypes don't declare same domainIncludes
     # TODO: could we use property paths here to be more thorough?


### PR DESCRIPTION
Fixed all inheritance warnings in the repository, activated the test.

* All domain or range declaration where the target inherits from another target have been removed, or if this would have resulted in an empty declaration, replaced with the common parent. 
* All the related tests are not activated (not expected to fail). In case of failure, each failure case is its own subtest with reporting. 
* Removed some globals that are not needed anymore.