### PR TITLE
Extend 'MerchantReturnPolicySeasonalOverride' with additional attribu…

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -11,3 +11,12 @@
 /rspec-failures.txt
 software/site/*
 /tmp
+
+# Environments (from https://github.com/github/gitignore/blob/main/Python.gitignore)
+.env
+.venv
+env/
+venv/
+ENV/
+env.bak/
+venv.bak/

--- a/data/ext/pending/issue-2381.ttl
+++ b/data/ext/pending/issue-2381.ttl
@@ -131,7 +131,7 @@
 
 :refundType a rdf:Property ;
     rdfs:label "refundType" ;
-    :domainIncludes :MerchantReturnPolicy ;
+    :domainIncludes :MerchantReturnPolicy, :MerchantReturnPolicySeasonalOverride ;
     :isPartOf <https://pending.schema.org> ;
     :rangeIncludes :RefundTypeEnumeration ;
     :source <https://github.com/schemaorg/schemaorg/issues/2288> ;
@@ -139,7 +139,7 @@
 
 :returnFees a rdf:Property ;
     rdfs:label "returnFees" ;
-    :domainIncludes :MerchantReturnPolicy ;
+    :domainIncludes :MerchantReturnPolicy, :MerchantReturnPolicySeasonalOverride ;
     :isPartOf <https://pending.schema.org> ;
     :rangeIncludes :ReturnFeesEnumeration ;
     :source <https://github.com/schemaorg/schemaorg/issues/2288> ;
@@ -224,7 +224,7 @@
 	
 :returnMethod a rdf:Property ;
     rdfs:label "returnMethod" ;
-    :domainIncludes :MerchantReturnPolicy ;
+    :domainIncludes :MerchantReturnPolicy, :MerchantReturnPolicySeasonalOverride ;
     :isPartOf <https://pending.schema.org> ;
     :rangeIncludes :ReturnMethodEnumeration ;
     :source <https://github.com/schemaorg/schemaorg/issues/2880> ;
@@ -257,7 +257,7 @@
 
 :returnShippingFeesAmount a rdf:Property ;
     rdfs:label "returnShippingFeesAmount" ;
-    :domainIncludes :MerchantReturnPolicy ;
+    :domainIncludes :MerchantReturnPolicy, :MerchantReturnPolicySeasonalOverride ;
     :isPartOf <https://pending.schema.org> ;
     :rangeIncludes :MonetaryAmount ;
     :source <https://github.com/schemaorg/schemaorg/issues/2880> ;
@@ -281,7 +281,7 @@
 
 :restockingFee a rdf:Property ;
     rdfs:label "restockingFee" ;
-    :domainIncludes :MerchantReturnPolicy ;
+    :domainIncludes :MerchantReturnPolicy, :MerchantReturnPolicySeasonalOverride ;
     :isPartOf <https://pending.schema.org> ;
     :rangeIncludes :MonetaryAmount,
 	    :Number ;


### PR DESCRIPTION
…tes.

Closes #3542 

This adds:

* `/refundType`
* `/restockingFee`
* `/returnFees`
* `/returnMethod`
* `/returnShippingFeesAmount`

to properties which can be overridden by the seasonal override.

Also update .gitignore with common python enviroment ignores from https://github.com/github/gitignore/blob/main/Python.gitignore