### PR TITLE
docs: Fix ancient leftover "test" comment for Meta

### DIFF
--- a/data/ext/meta/meta.ttl
+++ b/data/ext/meta/meta.ttl
@@ -20,7 +20,7 @@
     owl:equivalentClass rdf:Property .
 
 <https://meta.schema.org/> rdfs:label "meta" ;
-    rdfs:comment "A test comment." .
+    rdfs:comment "Meta contains terms to support the implementation of the Schema.org vocabulary itself."
 
 :domainIncludes a rdf:Property ;
     rdfs:label "domainIncludes" ;


### PR DESCRIPTION
Text based on https://meta.schema.org/docs/meta.home.html