### PR TITLE
Added a theme-color header to the website 

### DIFF
--- a/templates/docs/DocsHead.j2
+++ b/templates/docs/DocsHead.j2
@@ -9,10 +9,11 @@
     <link rel="stylesheet" type="text/css" href="{{docsdir}}/devnote.css" />
     <link rel="stylesheet" type="text/css" href="{{docsdir}}/prettify.css" />
     <link rel="stylesheet" type="text/css" href="{{docsdir}}/devnote.css" />
+    <meta name="theme-color" content="#990000" />
     <script src="https://ajax.googleapis.com/ajax/libs/jquery/3.5.1/jquery.min.js"></script>
     <script src="{{docsdir}}/schemaorg.js"></script>
     {% if head_insert_available %}
         {{ head_insert() }}
     {% endif %}
-    
+
 </head>


### PR DESCRIPTION
The new color matches the red used everywhere. 
On browsers like Safari, the page top header will be colored with this red.
See https://theme-color-dot-schemadotorg1.ew.r.appspot.com for a demo. 