### PR TITLE
Improved website annotations for schema.org website.

### DIFF
--- a/templates/docs/Home.j2
+++ b/templates/docs/Home.j2
@@ -9,13 +9,28 @@
         "@context": "https://schema.org",
         "@type": "WebSite",
         "url": "https://schema.org",
+        "name": "Schema.org",
         "potentialAction": {
           "@type": "SearchAction",
-          "target": "https://schema.org/docs/search_results.html?q={query}",
-          "query": "required"
+          "target": {
+            "@type": "EntryPoint",
+            "urlTemplate": "https://schema.org/docs/search_results.html?q={query}"
+          },
+          "query-input": "required name=query"
         },
-        "name": "Schema.org",
-        "description": "Schema.org is a collaborative, community activity with a mission to create, maintain, and promote schemas for structured data on the Internet, on web pages, in email messages, and beyond."
+        "about": {
+          "@type": "Project",
+          "name": "Schema.org Project",
+          "description": "Schema.org is a collaborative, community activity with a mission to create, maintain, and promote schemas for structured data on the Internet, on web pages, in email messages, and beyond.",
+          "logo": "https://schema.org/docs/schemaicon.png",
+          "sameAs": "https://github.com/schemaorg/schemaorg/",
+          "foundingDate": "2011-06-2"
+        },
+        "author": {
+          "@type": "Organization",
+          "name": "Schema.org Community Group",
+          "sameAs": "https://www.w3.org/community/schemaorg/"
+        }
     }
     </script>
     {%- endmacro %}
@@ -75,6 +90,6 @@
 
         <br/>
     </div> <!-- mainContent -->
-	{% include 'PageFooter.j2' with context %}
+  {% include 'PageFooter.j2' with context %}
 </body>
 </html>


### PR DESCRIPTION
Added the project as the object of the website.

* Added the schema.org `Project` as the about of the website.
* Moved the description into the project.
* Added project logo url (Project is a subclass or Organization).
* Added sameAs url to github.
* Added an Organization as the `author` field
* Describe the Schema.org Community Group in that organization.

Generally, this is just the structured representation of the information on the page.