### PR TITLE
Added breadcrumb annotations for schema.org terms.

### DIFF
--- a/templates/macros.j2
+++ b/templates/macros.j2
@@ -1,10 +1,10 @@
-{% macro term_sdotermlink(term,titlepre="",props="") -%}
+{% macro term_sdotermlink(term, titlepre="", props="") -%}
     {% if term.pending %}{% set CLASS = "ext ext-pending" %}
     {% elif term.retired %}{% set CLASS = "ext ext-attic" %}
     {% else %}{% set CLASS = "core" %}
     {% endif %}
     {% if term.id %}{% set name = term.id %}{% else %}{% set name = term %}{% endif %}
-    <a href="{{TERMHREFPREFIX}}{{name}}{{TERMHREFSUFFIX}}" {{props|safe}} 
+    <a href="{{TERMHREFPREFIX}}{{name}}{{TERMHREFSUFFIX}}" {{props|safe}}
         class="{{CLASS}}" title="{{titlepre}}{{name}}">{{name}}</a>
 {%- endmacro %}
 
@@ -15,7 +15,21 @@
     {% endif %}
     {% if term.id %}{% set name = term.id %}{% else %}{% set name = term %}{% endif %}
     {% if text|length %}{% set label = text %}{% else %}{% set label = name %}{% endif %}
-    
-    <a href="{{TERMHREFPREFIX}}{{name}}{{TERMHREFSUFFIX}}" {{props|safe}} 
+
+    <a href="{{TERMHREFPREFIX}}{{name}}{{TERMHREFSUFFIX}}" {{props|safe}}
             class="{{CLASS}}" title="{{titlepre}}{{name}}">{{label|safe}}</a>
+{%- endmacro %}
+
+{% macro term_sdotermbreadcrumlink(term, position, titlepre="", props="") -%}
+    {% if term.pending %}{% set CLASS = "ext ext-pending" %}
+    {% elif term.retired %}{% set CLASS = "ext ext-attic" %}
+    {% else %}{% set CLASS = "core" %}
+    {% endif %}
+    {% if term.id %}{% set name = term.id %}{% else %}{% set name = term %}{% endif %}
+    <span itemscope itemprop="itemListElement" itemtype="https://schema.org/ListItem">
+    <meta itemprop="name" content="{{name}}" />
+    <meta itemprop="position" content="{{position}}" />
+    <a href="{{TERMHREFPREFIX}}{{name}}{{TERMHREFSUFFIX}}" {{props|safe}} itemprop="item"
+        class="{{CLASS}}" title="{{titlepre}}{{name}}">{{name}}</a>
+    </span>
 {%- endmacro %}

--- a/templates/terms/InfoBlock.j2
+++ b/templates/terms/InfoBlock.j2
@@ -1,6 +1,7 @@
 {% from 'macros.j2' import term_sdotermlink as sdotermlink with context %}
+{% from 'macros.j2' import term_sdotermbreadcrumlink as sdotermbreadcrumblink with context %}
 <div id="infoblock" class="jumptarget" title="Details">
-	<!-- Label /  termType  / canonical URI -->
+  <!-- Label /  termType  / canonical URI -->
     <div id="infohead">
         <h1>{{ term.label }}</h1>
         <div class="infotype">A Schema.org {{ TERMTYPE }}</div>
@@ -11,21 +12,22 @@
         {% elif term.extLayer %}<em>Defined in the <a href="/docs/{{term.extLayer}}.home.html">{{term.extLayer}}</a> section.</em>
         {% endif %}
     </div>
-	<!-- Breadcrumb display of term inheritance -->
-    <div class="superPaths">
+  <!-- Breadcrumb display of term inheritance -->
+    <div class="superPaths" itemscope itemtype="https://schema.org/BreadcrumbList">
     {% for superPath in term.superPaths %}
-        {% for super in superPath %} 
+        {% for super in superPath %}
             {% if term.termType == "Property" %}
                 {% if not loop.first %}
-                    {% if loop.index == 2 %} > {% elif loop.index == 3 %} :: {% else %} : {% endif %}
+                    {% if loop.index == 2 %} &gt; {% elif loop.index == 3 %} :: {% else %} : {% endif %}
                 {% endif %}
             {% else %}
                 {% if not loop.first %}
-                        {% if not loop.last %} > {% endif %}
+                        {% if not loop.last %} &gt; {% endif %}
                     {% endif %}
-				{% if loop.index > 1 %}{% if loop.last %}{% if term.termType == "Enumerationvalue" %} :: {% else %} > {% endif %}{% endif %}{% endif %}
+        {% if loop.index > 1 %}{% if loop.last %}{% if term.termType == "Enumerationvalue" %} :: {% else %} &gt; {% endif %}{% endif %}{% endif %}
             {% endif %}
-					{{ sdotermlink(super)|safe }}{% endfor %}
+          {{ sdotermbreadcrumblink(super, position=loop.index)|safe }}{% endfor %}
+
         <br/>
     {% endfor %}
     </div>
@@ -46,8 +48,8 @@
             </ul>
     </div>
     </div>
-	
-	<!-- Description of term -->
+
+  <!-- Description of term -->
     <div class="description">{{term.comment|safe}}</div>
         {% if term.termType == "Enumerationvalue" %}
        <br/> A member value for enumeration type: {{sdotermlink(term.enumerationParent)}}
@@ -59,5 +61,5 @@
             {% if loop.last %}</ul><br/>{% endif %}
         {% endif %}
     {% endfor %}
-	
+
 </div> <!-- infoblock -->


### PR DESCRIPTION
The term page should now have breadcrumbs annotations for the object hierarchy, i.e. 

See this demo site:  https://breadcrumbs-dot-schemadotorg1.ew.r.appspot.com/SportsOrganization

```html 
<div class="superPaths" itemscope="" itemtype="https://schema.org/BreadcrumbList">
    <span itemscope="" itemprop="itemListElement" itemtype="https://schema.org/ListItem">
    <meta itemprop="name" content="Thing">
    <meta itemprop="position" content="1">
    <a href="/Thing" itemprop="item" class="core" title="Thing">Thing</a>
    </span> &gt; 
    <span itemscope="" itemprop="itemListElement" itemtype="https://schema.org/ListItem">
    <meta itemprop="name" content="Organization">
    <meta itemprop="position" content="2">
    <a href="/Organization" itemprop="item" class="core" title="Organization">Organization</a>
    </span> &gt; 
    <span itemscope="" itemprop="itemListElement" itemtype="https://schema.org/ListItem">
    <meta itemprop="name" content="SportsOrganization">
    <meta itemprop="position" content="3">
    <a href="/SportsOrganization" itemprop="item" class="core" title="SportsOrganization">SportsOrganization</a>
    </span>
     <br>
   </div>
```