### PR TITLE
Cleanup of the PaymentMethod structure

### DIFF
--- a/data/ext/pending/issue-3537-examples.txt
+++ b/data/ext/pending/issue-3537-examples.txt
@@ -1,0 +1,43 @@
+TYPES: #eg-3537 PaymentMethod,OnlineStore,PaymentService
+
+PRE-MARKUP:
+
+Possible Payment: Cash On Delivery, SplashPay 🌊, SEPA bank transfer and prepayment in all Splash stores 🌊.
+
+MICRODATA:
+
+
+RDFA:
+
+
+JSON:
+
+<script type="application/ld+json">
+{
+  "@context": "https://schema.org",
+  "@type": "OnlineStore",
+  "name": "Example Online Store",
+  "acceptedPaymentMethod": {
+    "@type": "PaymentMethod",
+    "paymentMethodType": "https://schema.org/COD",
+    "name": "Cash on Delivery"
+  },
+  "acceptedPaymentMethod": {
+    "@type": "PaymentService",
+    "name": "SplashPay"
+  },
+  "acceptedPaymentMethod": {
+    "@type": "PaymentMethod",
+    "paymentMethodType": "https://schema.org/ByBankTransferInAdvance",
+    "name": "SEPA bank transfer"
+  },
+  "acceptedPaymentMethod": {
+    "@type": "PaymentService",
+    "paymentMethodType": "https://schema.org/InStorePrepay",
+    "provider": {
+      "@type": "Organization",
+      "name": "Splash Store"
+    }
+  }
+}
+</script>

--- a/data/ext/pending/issue-3537-examples.txt
+++ b/data/ext/pending/issue-3537-examples.txt
@@ -17,27 +17,29 @@ JSON:
   "@context": "https://schema.org",
   "@type": "OnlineStore",
   "name": "Example Online Store",
-  "acceptedPaymentMethod": {
+  "acceptedPaymentMethod": [
+  {
     "@type": "PaymentMethod",
     "paymentMethodType": "https://schema.org/COD",
     "name": "Cash on Delivery"
-  },
-  "acceptedPaymentMethod": {
+  }, {
     "@type": "PaymentService",
-    "name": "SplashPay"
-  },
-  "acceptedPaymentMethod": {
+    "name": "SplashPay",
+    "description": "Pay using the SplashPay app."
+  }, {
     "@type": "PaymentMethod",
     "paymentMethodType": "https://schema.org/ByBankTransferInAdvance",
-    "name": "SEPA bank transfer"
-  },
-  "acceptedPaymentMethod": {
+    "name": "SEPA bank transfer",
+    "description": "Bank transfer within the Single Euro Payments Area (SEPA)."
+  }, {
     "@type": "PaymentService",
     "paymentMethodType": "https://schema.org/InStorePrepay",
     "provider": {
       "@type": "Organization",
-      "name": "Splash Store"
+      "name": "Splash Store",
+      "description": "Pay your online purchases conveniently in any Splash Store."
     }
   }
+  ]
 }
 </script>

--- a/data/ext/pending/issue-3537.ttl
+++ b/data/ext/pending/issue-3537.ttl
@@ -1,0 +1,56 @@
+@prefix : <https://schema.org/> .
+@prefix rdf: <http://www.w3.org/1999/02/22-rdf-syntax-ns#> .
+@prefix rdfs: <http://www.w3.org/2000/01/rdf-schema#> .
+@prefix xml: <http://www.w3.org/XML/1998/namespace> .
+@prefix xsd: <http://www.w3.org/2001/XMLSchema#> .
+
+:PaymentMethodType
+    a rdfs:Class ;
+    :isPartOf <https://pending.schema.org> ;
+    rdfs:label "PaymentMethodType" ;
+    :source <https://github.com/schemaorg/schemaorg/issues/3537> ;
+    rdfs:comment """The type of payment method, only for generic payment types, specific forms of payments, like card payment should be expressed using subclasses of PaymentMethod.""" ;
+    rdfs:subClassOf :Enumeration .
+
+:Cash a :PaymentMethodType ;
+    rdfs:label "Cash" ;
+    rdfs:comment "Payment using cash, on premises, equivalent to <code>http://purl.org/goodrelations/v1#Cash</code>." .
+
+:ByBankTransferInAdvance a :PaymentMethodType ;
+    rdfs:label "ByBankTransferInAdvance" ;
+    rdfs:comment "Payment in advance by bank transfer, equivalent to <code>http://purl.org/goodrelations/v1#ByBankTransferInAdvance</code>." .
+
+:ByInvoice a :PaymentMethodType ;
+    rdfs:label "ByInvoice" ;
+    rdfs:comment "Payment by invoice, typically after the goods were delivered, equivalent to <code>http://purl.org/goodrelations/v1#ByInvoice</code>." .
+
+:CheckInAdvance  a :PaymentMethodType ;
+    rdfs:label "CheckInAdvance" ;
+    rdfs:comment "Payment in advance by sending a check, equivalent to <code>http://purl.org/goodrelations/v1#CheckInAdvance</code>." .
+
+:COD a :PaymentMethodType ;
+    rdfs:label "COD" ;
+    rdfs:comment "Cash on Delivery (COD) payment, equivalent to <code>http://purl.org/goodrelations/v1#COD</code>." .
+
+:DirectDebit a :PaymentMethodType ;
+    rdfs:label "DirectDebit" ;
+    rdfs:comment "Payment in advance by direct debit from the bank, equivalent to <code>http://purl.org/goodrelations/v1#DirectDebit</code>." .
+
+:InStorePrepay a :PaymentMethodType ;
+    rdfs:label "InStorePrepay" ;
+    rdfs:comment "Payment in advance in some form of shop or kiosk for goods purchased online." .
+
+:PhoneCarrierPayment a :PaymentMethodType ;
+    rdfs:label "PhoneCarrierPayment" ;
+    rdfs:comment "Payment by billing via the phone carrier." .
+
+:paymentMethodType a rdf:Property ;
+    rdfs:label "paymentMethodType" ;
+    :domainIncludes :PaymentMethod ;
+    :isPartOf <https://pending.schema.org> ;
+    :rangeIncludes :PaymentMethodType ;
+    :source <https://github.com/schemaorg/schemaorg/issues/3537> ;
+    rdfs:comment "The type of a payment method." .
+
+
+

--- a/data/schema.ttl
+++ b/data/schema.ttl
@@ -2192,7 +2192,8 @@ The place is __open__ if the [[opens]] property is specified, and __closed__ oth
 :PaymentMethod a rdfs:Class ;
     rdfs:label "PaymentMethod" ;
     :contributor <https://schema.org/docs/collab/GoodRelationsClass> ;
-    rdfs:comment """A payment method is a standardized procedure for transferring the monetary amount for a purchase. Payment methods are characterized by the legal and technical structures used, and by the organization or group carrying out the transaction. The use of good relation values is discouraged.""" ;
+    rdfs:comment """A payment method is a standardized procedure for transferring the monetary amount for a purchase. Payment methods are characterized by the legal and technical structures used, and by the organization or group carrying out the transaction. The following legacy values should be accepted:
+    \\n\\n* http://purl.org/goodrelations/v1#ByBankTransferInAdvance\\n* http://purl.org/goodrelations/v1#ByInvoice\\n* http://purl.org/goodrelations/v1#Cash\\n* http://purl.org/goodrelations/v1#CheckInAdvance\\n* http://purl.org/goodrelations/v1#COD\\n* http://purl.org/goodrelations/v1#DirectDebit\\n* http://purl.org/goodrelations/v1#GoogleCheckout\\n* http://purl.org/goodrelations/v1#PayPal\\n* http://purl.org/goodrelations/v1#PaySwarm\\n\\nStructured values are recommended for newer payment methods.""" ;
     rdfs:subClassOf :Intangible .
 
 :PaymentService a rdfs:Class ;

--- a/data/schema.ttl
+++ b/data/schema.ttl
@@ -2192,15 +2192,14 @@ The place is __open__ if the [[opens]] property is specified, and __closed__ oth
 :PaymentMethod a rdfs:Class ;
     rdfs:label "PaymentMethod" ;
     :contributor <https://schema.org/docs/collab/GoodRelationsClass> ;
-    rdfs:comment """A payment method is a standardized procedure for transferring the monetary amount for a purchase. Payment methods are characterized by the legal and technical structures used, and by the organization or group carrying out the transaction.\\n\\nCommonly used values:\\n\\n* http://purl.org/goodrelations/v1#ByBankTransferInAdvance\\n* http://purl.org/goodrelations/v1#ByInvoice\\n* http://purl.org/goodrelations/v1#Cash\\n* http://purl.org/goodrelations/v1#CheckInAdvance\\n* http://purl.org/goodrelations/v1#COD\\n* http://purl.org/goodrelations/v1#DirectDebit\\n* http://purl.org/goodrelations/v1#GoogleCheckout\\n* http://purl.org/goodrelations/v1#PayPal\\n* http://purl.org/goodrelations/v1#PaySwarm
-        """ ;
-    rdfs:subClassOf :Enumeration .
+    rdfs:comment """A payment method is a standardized procedure for transferring the monetary amount for a purchase. Payment methods are characterized by the legal and technical structures used, and by the organization or group carrying out the transaction. The use of good relation values is discouraged.""" ;
+    rdfs:subClassOf :Intangible .
 
 :PaymentService a rdfs:Class ;
     rdfs:label "PaymentService" ;
     :contributor <https://schema.org/docs/collab/FIBO> ;
     rdfs:comment "A Service to transfer funds from a person or organization to a beneficiary person or organization." ;
-    rdfs:subClassOf :FinancialProduct .
+    rdfs:subClassOf :FinancialProduct, :PaymentMethod.
 
 :PaymentStatusType a rdfs:Class ;
     rdfs:label "PaymentStatusType" ;


### PR DESCRIPTION
See Issue #3537 this includes the following changes:

* PaymentMethod is now a proper class.
* Added a PaymentMethodType enumeration with the actual payment method types, including things like carrier-payment or in store payment which are common in Asia and not present in the good relation ontology. 
* Marked the old `http://purl.org/goodrelations/v1#` enumeration values as deprecated, the website behind these URLs has not been updated since 2011, it is missing many payment methods and mixes payment method _type_ and payment method _providers_. 
* Added examples of payment methods attached to an online store. 

A test instance can be viewed here: https://payment-methods-dot-schemadotorg1.ew.r.appspot.com/PaymentMethod