### PR TITLE
Add more schema.org annotations to the schema.org Website.

### DIFF
--- a/templates/docs/Home.j2
+++ b/templates/docs/Home.j2
@@ -24,7 +24,25 @@
           "description": "Schema.org is a collaborative, community activity with a mission to create, maintain, and promote schemas for structured data on the Internet, on web pages, in email messages, and beyond.",
           "logo": "https://schema.org/docs/schemaicon.png",
           "sameAs": "https://github.com/schemaorg/schemaorg/",
-          "foundingDate": "2011-06-2"
+          "foundingDate": "2011-06-2",
+          "founder": [{
+            "@type": "Corporation",
+            "name": "Google",
+            "url": "https://google.com"
+          }, {
+            "@type": "Corporation",
+            "name": "Microsoft",
+            "url": "https://microsoft.com"
+          }, {
+            "@type": "Corporation",
+            "name": "Yahoo",
+            "url": "https://yahoo.com"
+          }, {
+            "@type": "Corporation",
+            "name": "Yandex",
+            "url": "https://yandex.com"
+          }],
+          "publishingPrinciples": "https://www.w3.org/community/about/process/cla/"
         },
         "author": {
           "@type": "Organization",

--- a/templates/docs/Home.j2
+++ b/templates/docs/Home.j2
@@ -24,25 +24,7 @@
           "description": "Schema.org is a collaborative, community activity with a mission to create, maintain, and promote schemas for structured data on the Internet, on web pages, in email messages, and beyond.",
           "logo": "https://schema.org/docs/schemaicon.png",
           "sameAs": "https://github.com/schemaorg/schemaorg/",
-          "foundingDate": "2011-06-2",
-          "founder": [{
-            "@type": "Corporation",
-            "name": "Google",
-            "url": "https://google.com"
-          }, {
-            "@type": "Corporation",
-            "name": "Microsoft",
-            "url": "https://microsoft.com"
-          }, {
-            "@type": "Corporation",
-            "name": "Yahoo",
-            "url": "https://yahoo.com"
-          }, {
-            "@type": "Corporation",
-            "name": "Yandex",
-            "url": "https://yandex.com"
-          }],
-          "publishingPrinciples": "https://www.w3.org/community/about/process/cla/"
+          "foundingDate": "2011-06-2"
         },
         "author": {
           "@type": "Organization",


### PR DESCRIPTION
The schema.org WebSite annotations now describes the list of founding organizations, now that Organizations can be founders, also added a link to the publishing principle of the project.