### PR TITLE
Linting TTL files to reduce diffs in future mechanical edits.

### DIFF
--- a/data/ext/auto/auto.ttl
+++ b/data/ext/auto/auto.ttl
@@ -1,220 +1,218 @@
 @prefix : <https://schema.org/> .
 @prefix rdf: <http://www.w3.org/1999/02/22-rdf-syntax-ns#> .
 @prefix rdfs: <http://www.w3.org/2000/01/rdf-schema#> .
-@prefix xml: <http://www.w3.org/XML/1998/namespace> .
-@prefix xsd: <http://www.w3.org/2001/XMLSchema#> .
 
 :BusOrCoach a rdfs:Class ;
     rdfs:label "BusOrCoach" ;
-    :isPartOf <https://auto.schema.org> ;
-    :contributor <https://schema.org/docs/collab/Automotive_Ontology_Working_Group> ;
     rdfs:comment "A bus (also omnibus or autobus) is a road vehicle designed to carry passengers. Coaches are luxury buses, usually in service for long distance travel." ;
-    rdfs:subClassOf :Vehicle .
+    rdfs:subClassOf :Vehicle ;
+    :contributor <https://schema.org/docs/collab/Automotive_Ontology_Working_Group> ;
+    :isPartOf <https://auto.schema.org> .
 
 :CarUsageType a rdfs:Class ;
     rdfs:label "CarUsageType" ;
-    :isPartOf <https://auto.schema.org> ;
-    :contributor <https://schema.org/docs/collab/Automotive_Ontology_Working_Group> ;
     rdfs:comment "A value indicating a special usage of a car, e.g. commercial rental, driving school, or as a taxi." ;
-    rdfs:subClassOf :Enumeration .
+    rdfs:subClassOf :Enumeration ;
+    :contributor <https://schema.org/docs/collab/Automotive_Ontology_Working_Group> ;
+    :isPartOf <https://auto.schema.org> .
 
 :Motorcycle a rdfs:Class ;
     rdfs:label "Motorcycle" ;
-    :isPartOf <https://auto.schema.org> ;
-    :contributor <https://schema.org/docs/collab/Automotive_Ontology_Working_Group> ;
     rdfs:comment "A motorcycle or motorbike is a single-track, two-wheeled motor vehicle." ;
-    rdfs:subClassOf :Vehicle .
+    rdfs:subClassOf :Vehicle ;
+    :contributor <https://schema.org/docs/collab/Automotive_Ontology_Working_Group> ;
+    :isPartOf <https://auto.schema.org> .
 
 :MotorizedBicycle a rdfs:Class ;
     rdfs:label "MotorizedBicycle" ;
-    :isPartOf <https://auto.schema.org> ;
-    :contributor <https://schema.org/docs/collab/Automotive_Ontology_Working_Group> ;
     rdfs:comment "A motorized bicycle is a bicycle with an attached motor used to power the vehicle, or to assist with pedaling." ;
-    rdfs:subClassOf :Vehicle .
+    rdfs:subClassOf :Vehicle ;
+    :contributor <https://schema.org/docs/collab/Automotive_Ontology_Working_Group> ;
+    :isPartOf <https://auto.schema.org> .
 
 :DrivingSchoolVehicleUsage a :CarUsageType ;
     rdfs:label "DrivingSchoolVehicleUsage" ;
-    :isPartOf <https://auto.schema.org> ;
+    rdfs:comment "Indicates the usage of the vehicle for driving school." ;
     :contributor <https://schema.org/docs/collab/Automotive_Ontology_Working_Group> ;
-    rdfs:comment "Indicates the usage of the vehicle for driving school." .
+    :isPartOf <https://auto.schema.org> .
 
 :RentalVehicleUsage a :CarUsageType ;
     rdfs:label "RentalVehicleUsage" ;
-    :isPartOf <https://auto.schema.org> ;
+    rdfs:comment "Indicates the usage of the vehicle as a rental car." ;
     :contributor <https://schema.org/docs/collab/Automotive_Ontology_Working_Group> ;
-    rdfs:comment "Indicates the usage of the vehicle as a rental car." .
+    :isPartOf <https://auto.schema.org> .
 
 :TaxiVehicleUsage a :CarUsageType ;
     rdfs:label "TaxiVehicleUsage" ;
-    :isPartOf <https://auto.schema.org> ;
+    rdfs:comment "Indicates the usage of the car as a taxi." ;
     :contributor <https://schema.org/docs/collab/Automotive_Ontology_Working_Group> ;
-    rdfs:comment "Indicates the usage of the car as a taxi." .
+    :isPartOf <https://auto.schema.org> .
 
 :accelerationTime a rdf:Property ;
     rdfs:label "accelerationTime" ;
+    rdfs:comment "The time needed to accelerate the vehicle from a given start velocity to a given target velocity.\\n\\nTypical unit code(s): SEC for seconds\\n\\n* Note: There are unfortunately no standard unit codes for seconds/0..100 km/h or seconds/0..60 mph. Simply use \"SEC\" for seconds and indicate the velocities in the [[name]] of the [[QuantitativeValue]], or use [[valueReference]] with a [[QuantitativeValue]] of 0..60 mph or 0..100 km/h to specify the reference speeds." ;
+    :contributor <https://schema.org/docs/collab/Automotive_Ontology_Working_Group> ;
     :domainIncludes :Vehicle ;
     :isPartOf <https://auto.schema.org> ;
-    :rangeIncludes :QuantitativeValue ;
-    :contributor <https://schema.org/docs/collab/Automotive_Ontology_Working_Group> ;
-    rdfs:comment "The time needed to accelerate the vehicle from a given start velocity to a given target velocity.\\n\\nTypical unit code(s): SEC for seconds\\n\\n* Note: There are unfortunately no standard unit codes for seconds/0..100 km/h or seconds/0..60 mph. Simply use \"SEC\" for seconds and indicate the velocities in the [[name]] of the [[QuantitativeValue]], or use [[valueReference]] with a [[QuantitativeValue]] of 0..60 mph or 0..100 km/h to specify the reference speeds." .
+    :rangeIncludes :QuantitativeValue .
 
 :acrissCode a rdf:Property ;
     rdfs:label "acrissCode" ;
+    rdfs:comment "The ACRISS Car Classification Code is a code used by many car rental companies, for classifying vehicles. ACRISS stands for Association of Car Rental Industry Systems and Standards." ;
+    :contributor <https://schema.org/docs/collab/Automotive_Ontology_Working_Group> ;
     :domainIncludes :BusOrCoach,
         :Car ;
     :isPartOf <https://auto.schema.org> ;
-    :rangeIncludes :Text ;
-    :contributor <https://schema.org/docs/collab/Automotive_Ontology_Working_Group> ;
-    rdfs:comment "The ACRISS Car Classification Code is a code used by many car rental companies, for classifying vehicles. ACRISS stands for Association of Car Rental Industry Systems and Standards." .
+    :rangeIncludes :Text .
 
 :bodyType a rdf:Property ;
     rdfs:label "bodyType" ;
+    rdfs:comment "Indicates the design and body style of the vehicle (e.g. station wagon, hatchback, etc.)." ;
+    :contributor <https://schema.org/docs/collab/Automotive_Ontology_Working_Group> ;
     :domainIncludes :Vehicle ;
     :isPartOf <https://auto.schema.org> ;
     :rangeIncludes :QualitativeValue,
         :Text,
-        :URL ;
-    :contributor <https://schema.org/docs/collab/Automotive_Ontology_Working_Group> ;
-    rdfs:comment "Indicates the design and body style of the vehicle (e.g. station wagon, hatchback, etc.)." .
+        :URL .
 
 :emissionsCO2 a rdf:Property ;
     rdfs:label "emissionsCO2" ;
+    rdfs:comment "The CO2 emissions in g/km. When used in combination with a QuantitativeValue, put \"g/km\" into the unitText property of that value, since there is no UN/CEFACT Common Code for \"g/km\"." ;
+    :contributor <https://schema.org/docs/collab/Automotive_Ontology_Working_Group> ;
     :domainIncludes :Vehicle ;
     :isPartOf <https://auto.schema.org> ;
-    :rangeIncludes :Number ;
-    :contributor <https://schema.org/docs/collab/Automotive_Ontology_Working_Group> ;
-    rdfs:comment "The CO2 emissions in g/km. When used in combination with a QuantitativeValue, put \"g/km\" into the unitText property of that value, since there is no UN/CEFACT Common Code for \"g/km\"." .
+    :rangeIncludes :Number .
 
 :engineDisplacement a rdf:Property ;
     rdfs:label "engineDisplacement" ;
+    rdfs:comment "The volume swept by all of the pistons inside the cylinders of an internal combustion engine in a single movement. \\n\\nTypical unit code(s): CMQ for cubic centimeter, LTR for liters, INQ for cubic inches\\n* Note 1: You can link to information about how the given value has been determined using the [[valueReference]] property.\\n* Note 2: You can use [[minValue]] and [[maxValue]] to indicate ranges." ;
+    :contributor <https://schema.org/docs/collab/Automotive_Ontology_Working_Group> ;
     :domainIncludes :EngineSpecification ;
     :isPartOf <https://auto.schema.org> ;
-    :rangeIncludes :QuantitativeValue ;
-    :contributor <https://schema.org/docs/collab/Automotive_Ontology_Working_Group> ;
-    rdfs:comment "The volume swept by all of the pistons inside the cylinders of an internal combustion engine in a single movement. \\n\\nTypical unit code(s): CMQ for cubic centimeter, LTR for liters, INQ for cubic inches\\n* Note 1: You can link to information about how the given value has been determined using the [[valueReference]] property.\\n* Note 2: You can use [[minValue]] and [[maxValue]] to indicate ranges." .
+    :rangeIncludes :QuantitativeValue .
 
 :enginePower a rdf:Property ;
     rdfs:label "enginePower" ;
+    rdfs:comment """The power of the vehicle's engine.
+    Typical unit code(s): KWT for kilowatt, BHP for brake horsepower, N12 for metric horsepower (PS, with 1 PS = 735,49875 W)\\n\\n* Note 1: There are many different ways of measuring an engine's power. For an overview, see  [http://en.wikipedia.org/wiki/Horsepower#Engine\\_power\\_test\\_codes](http://en.wikipedia.org/wiki/Horsepower#Engine_power_test_codes).\\n* Note 2: You can link to information about how the given value has been determined using the [[valueReference]] property.\\n* Note 3: You can use [[minValue]] and [[maxValue]] to indicate ranges.""" ;
+    :contributor <https://schema.org/docs/collab/Automotive_Ontology_Working_Group> ;
     :domainIncludes :EngineSpecification ;
     :isPartOf <https://auto.schema.org> ;
-    :rangeIncludes :QuantitativeValue ;
-    :contributor <https://schema.org/docs/collab/Automotive_Ontology_Working_Group> ;
-    rdfs:comment """The power of the vehicle's engine.
-    Typical unit code(s): KWT for kilowatt, BHP for brake horsepower, N12 for metric horsepower (PS, with 1 PS = 735,49875 W)\\n\\n* Note 1: There are many different ways of measuring an engine's power. For an overview, see  [http://en.wikipedia.org/wiki/Horsepower#Engine\\_power\\_test\\_codes](http://en.wikipedia.org/wiki/Horsepower#Engine_power_test_codes).\\n* Note 2: You can link to information about how the given value has been determined using the [[valueReference]] property.\\n* Note 3: You can use [[minValue]] and [[maxValue]] to indicate ranges.""" .
+    :rangeIncludes :QuantitativeValue .
 
 :engineType a rdf:Property ;
     rdfs:label "engineType" ;
+    rdfs:comment "The type of engine or engines powering the vehicle." ;
+    :contributor <https://schema.org/docs/collab/Automotive_Ontology_Working_Group> ;
     :domainIncludes :EngineSpecification ;
     :isPartOf <https://auto.schema.org> ;
     :rangeIncludes :QualitativeValue,
         :Text,
-        :URL ;
-    :contributor <https://schema.org/docs/collab/Automotive_Ontology_Working_Group> ;
-    rdfs:comment "The type of engine or engines powering the vehicle." .
+        :URL .
 
 :fuelCapacity a rdf:Property ;
     rdfs:label "fuelCapacity" ;
+    rdfs:comment "The capacity of the fuel tank or in the case of electric cars, the battery. If there are multiple components for storage, this should indicate the total of all storage of the same type.\\n\\nTypical unit code(s): LTR for liters, GLL of US gallons, GLI for UK / imperial gallons, AMH for ampere-hours (for electrical vehicles)." ;
+    :contributor <https://schema.org/docs/collab/Automotive_Ontology_Working_Group> ;
     :domainIncludes :Vehicle ;
     :isPartOf <https://auto.schema.org> ;
-    :rangeIncludes :QuantitativeValue ;
-    :contributor <https://schema.org/docs/collab/Automotive_Ontology_Working_Group> ;
-    rdfs:comment "The capacity of the fuel tank or in the case of electric cars, the battery. If there are multiple components for storage, this should indicate the total of all storage of the same type.\\n\\nTypical unit code(s): LTR for liters, GLL of US gallons, GLI for UK / imperial gallons, AMH for ampere-hours (for electrical vehicles)." .
+    :rangeIncludes :QuantitativeValue .
 
 :meetsEmissionStandard a rdf:Property ;
     rdfs:label "meetsEmissionStandard" ;
+    rdfs:comment "Indicates that the vehicle meets the respective emission standard." ;
+    :contributor <https://schema.org/docs/collab/Automotive_Ontology_Working_Group> ;
     :domainIncludes :Vehicle ;
     :isPartOf <https://auto.schema.org> ;
     :rangeIncludes :QualitativeValue,
         :Text,
-        :URL ;
-    :contributor <https://schema.org/docs/collab/Automotive_Ontology_Working_Group> ;
-    rdfs:comment "Indicates that the vehicle meets the respective emission standard." .
+        :URL .
 
 :modelDate a rdf:Property ;
     rdfs:label "modelDate" ;
+    rdfs:comment "The release date of a vehicle model (often used to differentiate versions of the same make and model)." ;
+    :contributor <https://schema.org/docs/collab/Automotive_Ontology_Working_Group> ;
     :domainIncludes :Vehicle ;
     :isPartOf <https://auto.schema.org> ;
-    :rangeIncludes :Date ;
-    :contributor <https://schema.org/docs/collab/Automotive_Ontology_Working_Group> ;
-    rdfs:comment "The release date of a vehicle model (often used to differentiate versions of the same make and model)." .
+    :rangeIncludes :Date .
 
 :payload a rdf:Property ;
     rdfs:label "payload" ;
+    rdfs:comment "The permitted weight of passengers and cargo, EXCLUDING the weight of the empty vehicle.\\n\\nTypical unit code(s): KGM for kilogram, LBR for pound\\n\\n* Note 1: Many databases specify the permitted TOTAL weight instead, which is the sum of [[weight]] and [[payload]]\\n* Note 2: You can indicate additional information in the [[name]] of the [[QuantitativeValue]] node.\\n* Note 3: You may also link to a [[QualitativeValue]] node that provides additional information using [[valueReference]].\\n* Note 4: Note that you can use [[minValue]] and [[maxValue]] to indicate ranges." ;
+    :contributor <https://schema.org/docs/collab/Automotive_Ontology_Working_Group> ;
     :domainIncludes :Vehicle ;
     :isPartOf <https://auto.schema.org> ;
-    :rangeIncludes :QuantitativeValue ;
-    :contributor <https://schema.org/docs/collab/Automotive_Ontology_Working_Group> ;
-    rdfs:comment "The permitted weight of passengers and cargo, EXCLUDING the weight of the empty vehicle.\\n\\nTypical unit code(s): KGM for kilogram, LBR for pound\\n\\n* Note 1: Many databases specify the permitted TOTAL weight instead, which is the sum of [[weight]] and [[payload]]\\n* Note 2: You can indicate additional information in the [[name]] of the [[QuantitativeValue]] node.\\n* Note 3: You may also link to a [[QualitativeValue]] node that provides additional information using [[valueReference]].\\n* Note 4: Note that you can use [[minValue]] and [[maxValue]] to indicate ranges." .
+    :rangeIncludes :QuantitativeValue .
 
 :roofLoad a rdf:Property ;
     rdfs:label "roofLoad" ;
+    rdfs:comment "The permitted total weight of cargo and installations (e.g. a roof rack) on top of the vehicle.\\n\\nTypical unit code(s): KGM for kilogram, LBR for pound\\n\\n* Note 1: You can indicate additional information in the [[name]] of the [[QuantitativeValue]] node.\\n* Note 2: You may also link to a [[QualitativeValue]] node that provides additional information using [[valueReference]]\\n* Note 3: Note that you can use [[minValue]] and [[maxValue]] to indicate ranges." ;
+    :contributor <https://schema.org/docs/collab/Automotive_Ontology_Working_Group> ;
     :domainIncludes :BusOrCoach,
         :Car ;
     :isPartOf <https://auto.schema.org> ;
-    :rangeIncludes :QuantitativeValue ;
-    :contributor <https://schema.org/docs/collab/Automotive_Ontology_Working_Group> ;
-    rdfs:comment "The permitted total weight of cargo and installations (e.g. a roof rack) on top of the vehicle.\\n\\nTypical unit code(s): KGM for kilogram, LBR for pound\\n\\n* Note 1: You can indicate additional information in the [[name]] of the [[QuantitativeValue]] node.\\n* Note 2: You may also link to a [[QualitativeValue]] node that provides additional information using [[valueReference]]\\n* Note 3: Note that you can use [[minValue]] and [[maxValue]] to indicate ranges." .
+    :rangeIncludes :QuantitativeValue .
 
 :seatingCapacity a rdf:Property ;
     rdfs:label "seatingCapacity" ;
+    rdfs:comment "The number of persons that can be seated (e.g. in a vehicle), both in terms of the physical space available, and in terms of limitations set by law.\\n\\nTypical unit code(s): C62 for persons." ;
+    :contributor <https://schema.org/docs/collab/Automotive_Ontology_Working_Group> ;
     :domainIncludes :Vehicle ;
     :isPartOf <https://auto.schema.org> ;
     :rangeIncludes :Number,
-        :QuantitativeValue ;
-    :contributor <https://schema.org/docs/collab/Automotive_Ontology_Working_Group> ;
-    rdfs:comment "The number of persons that can be seated (e.g. in a vehicle), both in terms of the physical space available, and in terms of limitations set by law.\\n\\nTypical unit code(s): C62 for persons." .
+        :QuantitativeValue .
 
 :speed a rdf:Property ;
     rdfs:label "speed" ;
+    rdfs:comment "The speed range of the vehicle. If the vehicle is powered by an engine, the upper limit of the speed range (indicated by [[maxValue]]) should be the maximum speed achievable under regular conditions.\\n\\nTypical unit code(s): KMH for km/h, HM for mile per hour (0.447 04 m/s), KNT for knot\\n\\n*Note 1: Use [[minValue]] and [[maxValue]] to indicate the range. Typically, the minimal value is zero.\\n* Note 2: There are many different ways of measuring the speed range. You can link to information about how the given value has been determined using the [[valueReference]] property." ;
+    :contributor <https://schema.org/docs/collab/Automotive_Ontology_Working_Group> ;
     :domainIncludes :Vehicle ;
     :isPartOf <https://auto.schema.org> ;
-    :rangeIncludes :QuantitativeValue ;
-    :contributor <https://schema.org/docs/collab/Automotive_Ontology_Working_Group> ;
-    rdfs:comment "The speed range of the vehicle. If the vehicle is powered by an engine, the upper limit of the speed range (indicated by [[maxValue]]) should be the maximum speed achievable under regular conditions.\\n\\nTypical unit code(s): KMH for km/h, HM for mile per hour (0.447 04 m/s), KNT for knot\\n\\n*Note 1: Use [[minValue]] and [[maxValue]] to indicate the range. Typically, the minimal value is zero.\\n* Note 2: There are many different ways of measuring the speed range. You can link to information about how the given value has been determined using the [[valueReference]] property." .
+    :rangeIncludes :QuantitativeValue .
 
 :tongueWeight a rdf:Property ;
     rdfs:label "tongueWeight" ;
+    rdfs:comment "The permitted vertical load (TWR) of a trailer attached to the vehicle. Also referred to as Tongue Load Rating (TLR) or Vertical Load Rating (VLR).\\n\\nTypical unit code(s): KGM for kilogram, LBR for pound\\n\\n* Note 1: You can indicate additional information in the [[name]] of the [[QuantitativeValue]] node.\\n* Note 2: You may also link to a [[QualitativeValue]] node that provides additional information using [[valueReference]].\\n* Note 3: Note that you can use [[minValue]] and [[maxValue]] to indicate ranges." ;
+    :contributor <https://schema.org/docs/collab/Automotive_Ontology_Working_Group> ;
     :domainIncludes :Vehicle ;
     :isPartOf <https://auto.schema.org> ;
-    :rangeIncludes :QuantitativeValue ;
-    :contributor <https://schema.org/docs/collab/Automotive_Ontology_Working_Group> ;
-    rdfs:comment "The permitted vertical load (TWR) of a trailer attached to the vehicle. Also referred to as Tongue Load Rating (TLR) or Vertical Load Rating (VLR).\\n\\nTypical unit code(s): KGM for kilogram, LBR for pound\\n\\n* Note 1: You can indicate additional information in the [[name]] of the [[QuantitativeValue]] node.\\n* Note 2: You may also link to a [[QualitativeValue]] node that provides additional information using [[valueReference]].\\n* Note 3: Note that you can use [[minValue]] and [[maxValue]] to indicate ranges." .
+    :rangeIncludes :QuantitativeValue .
 
 :torque a rdf:Property ;
     rdfs:label "torque" ;
+    rdfs:comment "The torque (turning force) of the vehicle's engine.\\n\\nTypical unit code(s): NU for newton metre (N m), F17 for pound-force per foot, or F48 for pound-force per inch\\n\\n* Note 1: You can link to information about how the given value has been determined (e.g. reference RPM) using the [[valueReference]] property.\\n* Note 2: You can use [[minValue]] and [[maxValue]] to indicate ranges." ;
+    :contributor <https://schema.org/docs/collab/Automotive_Ontology_Working_Group> ;
     :domainIncludes :EngineSpecification ;
     :isPartOf <https://auto.schema.org> ;
-    :rangeIncludes :QuantitativeValue ;
-    :contributor <https://schema.org/docs/collab/Automotive_Ontology_Working_Group> ;
-    rdfs:comment "The torque (turning force) of the vehicle's engine.\\n\\nTypical unit code(s): NU for newton metre (N m), F17 for pound-force per foot, or F48 for pound-force per inch\\n\\n* Note 1: You can link to information about how the given value has been determined (e.g. reference RPM) using the [[valueReference]] property.\\n* Note 2: You can use [[minValue]] and [[maxValue]] to indicate ranges." .
+    :rangeIncludes :QuantitativeValue .
 
 :trailerWeight a rdf:Property ;
     rdfs:label "trailerWeight" ;
+    rdfs:comment "The permitted weight of a trailer attached to the vehicle.\\n\\nTypical unit code(s): KGM for kilogram, LBR for pound\\n* Note 1: You can indicate additional information in the [[name]] of the [[QuantitativeValue]] node.\\n* Note 2: You may also link to a [[QualitativeValue]] node that provides additional information using [[valueReference]].\\n* Note 3: Note that you can use [[minValue]] and [[maxValue]] to indicate ranges." ;
+    :contributor <https://schema.org/docs/collab/Automotive_Ontology_Working_Group> ;
     :domainIncludes :Vehicle ;
     :isPartOf <https://auto.schema.org> ;
-    :rangeIncludes :QuantitativeValue ;
-    :contributor <https://schema.org/docs/collab/Automotive_Ontology_Working_Group> ;
-    rdfs:comment "The permitted weight of a trailer attached to the vehicle.\\n\\nTypical unit code(s): KGM for kilogram, LBR for pound\\n* Note 1: You can indicate additional information in the [[name]] of the [[QuantitativeValue]] node.\\n* Note 2: You may also link to a [[QualitativeValue]] node that provides additional information using [[valueReference]].\\n* Note 3: Note that you can use [[minValue]] and [[maxValue]] to indicate ranges." .
+    :rangeIncludes :QuantitativeValue .
 
 :vehicleSpecialUsage a rdf:Property ;
     rdfs:label "vehicleSpecialUsage" ;
+    :contributor <https://schema.org/docs/collab/Automotive_Ontology_Working_Group> ;
     :isPartOf <https://auto.schema.org> ;
-    :rangeIncludes :CarUsageType ;
-    :contributor <https://schema.org/docs/collab/Automotive_Ontology_Working_Group> .
+    :rangeIncludes :CarUsageType .
 
 :weightTotal a rdf:Property ;
     rdfs:label "weightTotal" ;
+    rdfs:comment "The permitted total weight of the loaded vehicle, including passengers and cargo and the weight of the empty vehicle.\\n\\nTypical unit code(s): KGM for kilogram, LBR for pound\\n\\n* Note 1: You can indicate additional information in the [[name]] of the [[QuantitativeValue]] node.\\n* Note 2: You may also link to a [[QualitativeValue]] node that provides additional information using [[valueReference]].\\n* Note 3: Note that you can use [[minValue]] and [[maxValue]] to indicate ranges." ;
+    :contributor <https://schema.org/docs/collab/Automotive_Ontology_Working_Group> ;
     :domainIncludes :Vehicle ;
     :isPartOf <https://auto.schema.org> ;
-    :rangeIncludes :QuantitativeValue ;
-    :contributor <https://schema.org/docs/collab/Automotive_Ontology_Working_Group> ;
-    rdfs:comment "The permitted total weight of the loaded vehicle, including passengers and cargo and the weight of the empty vehicle.\\n\\nTypical unit code(s): KGM for kilogram, LBR for pound\\n\\n* Note 1: You can indicate additional information in the [[name]] of the [[QuantitativeValue]] node.\\n* Note 2: You may also link to a [[QualitativeValue]] node that provides additional information using [[valueReference]].\\n* Note 3: Note that you can use [[minValue]] and [[maxValue]] to indicate ranges." .
+    :rangeIncludes :QuantitativeValue .
 
 :wheelbase a rdf:Property ;
     rdfs:label "wheelbase" ;
+    rdfs:comment "The distance between the centers of the front and rear wheels.\\n\\nTypical unit code(s): CMT for centimeters, MTR for meters, INH for inches, FOT for foot/feet." ;
+    :contributor <https://schema.org/docs/collab/Automotive_Ontology_Working_Group> ;
     :domainIncludes :Vehicle ;
     :isPartOf <https://auto.schema.org> ;
-    :rangeIncludes :QuantitativeValue ;
-    :contributor <https://schema.org/docs/collab/Automotive_Ontology_Working_Group> ;
-    rdfs:comment "The distance between the centers of the front and rear wheels.\\n\\nTypical unit code(s): CMT for centimeters, MTR for meters, INH for inches, FOT for foot/feet." .
+    :rangeIncludes :QuantitativeValue .
 

--- a/data/ext/bib/bsdo-1.0.ttl
+++ b/data/ext/bib/bsdo-1.0.ttl
@@ -1,150 +1,148 @@
 @prefix : <https://schema.org/> .
 @prefix rdf: <http://www.w3.org/1999/02/22-rdf-syntax-ns#> .
 @prefix rdfs: <http://www.w3.org/2000/01/rdf-schema#> .
-@prefix xml: <http://www.w3.org/XML/1998/namespace> .
-@prefix xsd: <http://www.w3.org/2001/XMLSchema#> .
 
 :Atlas a rdfs:Class ;
     rdfs:label "Atlas" ;
-    :isPartOf <https://bib.schema.org> ;
-    :source <http://www.productontology.org/id/Atlas> ;
     rdfs:comment "A collection or bound volume of maps, charts, plates or tables, physical or in media form illustrating any subject." ;
-    rdfs:subClassOf :CreativeWork .
+    rdfs:subClassOf :CreativeWork ;
+    :isPartOf <https://bib.schema.org> ;
+    :source <http://www.productontology.org/id/Atlas> .
 
 :Audiobook a rdfs:Class ;
     rdfs:label "Audiobook" ;
-    :isPartOf <https://bib.schema.org> ;
     rdfs:comment "An audiobook." ;
     rdfs:subClassOf :AudioObject,
-        :Book .
+        :Book ;
+    :isPartOf <https://bib.schema.org> .
 
 :Chapter a rdfs:Class ;
     rdfs:label "Chapter" ;
-    :isPartOf <https://bib.schema.org> ;
     rdfs:comment "One of the sections into which a book is divided. A chapter usually has a section number or a name." ;
-    rdfs:subClassOf :CreativeWork .
+    rdfs:subClassOf :CreativeWork ;
+    :isPartOf <https://bib.schema.org> .
 
 :Collection a rdfs:Class ;
     rdfs:label "Collection" ;
-    :isPartOf <https://bib.schema.org> ;
     rdfs:comment "A collection of items, e.g. creative works or products." ;
-    rdfs:subClassOf :CreativeWork .
+    rdfs:subClassOf :CreativeWork ;
+    :isPartOf <https://bib.schema.org> .
 
 :ComicCoverArt a rdfs:Class ;
     rdfs:label "ComicCoverArt" ;
-    :isPartOf <https://bib.schema.org> ;
     rdfs:comment "The artwork on the cover of a comic." ;
     rdfs:subClassOf :ComicStory,
-        :CoverArt .
+        :CoverArt ;
+    :isPartOf <https://bib.schema.org> .
 
 :ComicIssue a rdfs:Class ;
     rdfs:label "ComicIssue" ;
-    :isPartOf <https://bib.schema.org> ;
     rdfs:comment """Individual comic issues are serially published as
     	part of a larger series. For the sake of consistency, even one-shot issues
     	belong to a series comprised of a single issue. All comic issues can be
     	uniquely identified by: the combination of the name and volume number of the
     	series to which the issue belongs; the issue number; and the variant
     	description of the issue (if any).""" ;
-    rdfs:subClassOf :PublicationIssue .
+    rdfs:subClassOf :PublicationIssue ;
+    :isPartOf <https://bib.schema.org> .
 
 :ComicSeries a rdfs:Class ;
     rdfs:label "ComicSeries" ;
-    :isPartOf <https://bib.schema.org> ;
     rdfs:comment """A sequential publication of comic stories under a
     	unifying title, for example "The Amazing Spider-Man" or "Groo the
     	Wanderer".""" ;
-    rdfs:subClassOf :Periodical .
+    rdfs:subClassOf :Periodical ;
+    :isPartOf <https://bib.schema.org> .
 
 :ComicStory a rdfs:Class ;
     rdfs:label "ComicStory" ;
-    :isPartOf <https://bib.schema.org> ;
     rdfs:comment """The term "story" is any indivisible, re-printable
     	unit of a comic, including the interior stories, covers, and backmatter. Most
     	comics have at least two stories: a cover (ComicCoverArt) and an interior story.""" ;
-    rdfs:subClassOf :CreativeWork .
+    rdfs:subClassOf :CreativeWork ;
+    :isPartOf <https://bib.schema.org> .
 
 :CoverArt a rdfs:Class ;
     rdfs:label "CoverArt" ;
-    :isPartOf <https://bib.schema.org> ;
     rdfs:comment "The artwork on the outer surface of a CreativeWork." ;
-    rdfs:subClassOf :VisualArtwork .
+    rdfs:subClassOf :VisualArtwork ;
+    :isPartOf <https://bib.schema.org> .
 
 :Newspaper a rdfs:Class ;
     rdfs:label "Newspaper" ;
-    :isPartOf <https://bib.schema.org> ;
-    :source <http://www.productontology.org/id/Newspaper> ;
     rdfs:comment "A publication containing information about varied topics that are pertinent to general information, a geographic area, or a specific subject matter (i.e. business, culture, education). Often published daily." ;
-    rdfs:subClassOf :Periodical .
+    rdfs:subClassOf :Periodical ;
+    :isPartOf <https://bib.schema.org> ;
+    :source <http://www.productontology.org/id/Newspaper> .
 
 :Thesis a rdfs:Class ;
     rdfs:label "Thesis" ;
-    :isPartOf <https://bib.schema.org> ;
-    :source <http://www.productontology.org/id/Thesis> ;
     rdfs:comment "A thesis or dissertation document submitted in support of candidature for an academic degree or professional qualification." ;
-    rdfs:subClassOf :CreativeWork .
+    rdfs:subClassOf :CreativeWork ;
+    :isPartOf <https://bib.schema.org> ;
+    :source <http://www.productontology.org/id/Thesis> .
 
 <file:///Users/wallisr/Development/Schema/ttl/schemaorg/data/ext/bib/comics.rdfa> :softwareVersion "bib extension - version 0.1" .
 
 :GraphicNovel a :BookFormatType ;
     rdfs:label "GraphicNovel" ;
-    :isPartOf <https://bib.schema.org> ;
-    rdfs:comment "Book format: GraphicNovel. May represent a bound collection of ComicIssue instances." .
+    rdfs:comment "Book format: GraphicNovel. May represent a bound collection of ComicIssue instances." ;
+    :isPartOf <https://bib.schema.org> .
 
 :abridged a rdf:Property ;
     rdfs:label "abridged" ;
+    rdfs:comment "Indicates whether the book is an abridged edition." ;
     :domainIncludes :Book ;
     :isPartOf <https://bib.schema.org> ;
-    :rangeIncludes :Boolean ;
-    rdfs:comment "Indicates whether the book is an abridged edition." .
+    :rangeIncludes :Boolean .
 
 :artist a rdf:Property ;
     rdfs:label "artist" ;
+    rdfs:comment """The primary artist for a work
+    	in a medium other than pencils or digital line art--for example, if the
+    	primary artwork is done in watercolors or digital paints.""" ;
     :domainIncludes :ComicIssue,
         :ComicStory,
         :VisualArtwork ;
     :isPartOf <https://bib.schema.org> ;
-    :rangeIncludes :Person ;
-    rdfs:comment """The primary artist for a work
-    	in a medium other than pencils or digital line art--for example, if the
-    	primary artwork is done in watercolors or digital paints.""" .
+    :rangeIncludes :Person .
 
 :colorist a rdf:Property ;
     rdfs:label "colorist" ;
+    rdfs:comment "The individual who adds color to inked drawings." ;
     :domainIncludes :ComicIssue,
         :ComicStory,
         :VisualArtwork ;
     :isPartOf <https://bib.schema.org> ;
-    :rangeIncludes :Person ;
-    rdfs:comment "The individual who adds color to inked drawings." .
+    :rangeIncludes :Person .
 
 :duration a rdf:Property ;
     :domainIncludes :Audiobook .
 
 :inSupportOf a rdf:Property ;
     rdfs:label "inSupportOf" ;
+    rdfs:comment "Qualification, candidature, degree, application that Thesis supports." ;
     :domainIncludes :Thesis ;
     :isPartOf <https://bib.schema.org> ;
-    :rangeIncludes :Text ;
-    rdfs:comment "Qualification, candidature, degree, application that Thesis supports." .
+    :rangeIncludes :Text .
 
 :inker a rdf:Property ;
     rdfs:label "inker" ;
+    rdfs:comment "The individual who traces over the pencil drawings in ink after pencils are complete." ;
     :domainIncludes :ComicIssue,
         :ComicStory,
         :VisualArtwork ;
     :isPartOf <https://bib.schema.org> ;
-    :rangeIncludes :Person ;
-    rdfs:comment "The individual who traces over the pencil drawings in ink after pencils are complete." .
+    :rangeIncludes :Person .
 
 :letterer a rdf:Property ;
     rdfs:label "letterer" ;
+    rdfs:comment "The individual who adds lettering, including speech balloons and sound effects, to artwork." ;
     :domainIncludes :ComicIssue,
         :ComicStory,
         :VisualArtwork ;
     :isPartOf <https://bib.schema.org> ;
-    :rangeIncludes :Person ;
-    rdfs:comment "The individual who adds lettering, including speech balloons and sound effects, to artwork." .
+    :rangeIncludes :Person .
 
 :pageEnd a rdf:Property ;
     :domainIncludes :Chapter .
@@ -157,58 +155,58 @@
 
 :penciler a rdf:Property ;
     rdfs:label "penciler" ;
+    rdfs:comment "The individual who draws the primary narrative artwork." ;
     :domainIncludes :ComicIssue,
         :ComicStory,
         :VisualArtwork ;
     :isPartOf <https://bib.schema.org> ;
-    :rangeIncludes :Person ;
-    rdfs:comment "The individual who draws the primary narrative artwork." .
+    :rangeIncludes :Person .
 
 :publishedBy a rdf:Property ;
     rdfs:label "publishedBy" ;
+    rdfs:comment "An agent associated with the publication event." ;
     :domainIncludes :PublicationEvent ;
     :isPartOf <https://bib.schema.org> ;
     :rangeIncludes :Organization,
-        :Person ;
-    rdfs:comment "An agent associated with the publication event." .
+        :Person .
 
 :publisherImprint a rdf:Property ;
     rdfs:label "publisherImprint" ;
+    rdfs:comment "The publishing division which published the comic." ;
     :domainIncludes :CreativeWork ;
     :isPartOf <https://bib.schema.org> ;
-    :rangeIncludes :Organization ;
-    rdfs:comment "The publishing division which published the comic." .
+    :rangeIncludes :Organization .
 
 :readBy a rdf:Property ;
     rdfs:label "readBy" ;
+    rdfs:comment "A person who reads (performs) the audiobook." ;
+    rdfs:subPropertyOf :actor ;
     :domainIncludes :Audiobook ;
     :isPartOf <https://bib.schema.org> ;
-    :rangeIncludes :Person ;
-    rdfs:comment "A person who reads (performs) the audiobook." ;
-    rdfs:subPropertyOf :actor .
+    :rangeIncludes :Person .
 
 :variantCover a rdf:Property ;
     rdfs:label "variantCover" ;
-    :domainIncludes :ComicIssue ;
-    :isPartOf <https://bib.schema.org> ;
-    :rangeIncludes :Text ;
     rdfs:comment """A description of the variant cover
     	for the issue, if the issue is a variant printing. For example, "Bryan Hitch
-    	Variant Cover" or "2nd Printing Variant".""" .
+    	Variant Cover" or "2nd Printing Variant".""" ;
+    :domainIncludes :ComicIssue ;
+    :isPartOf <https://bib.schema.org> ;
+    :rangeIncludes :Text .
 
 :translationOfWork a rdf:Property ;
     rdfs:label "translationOfWork" ;
+    rdfs:comment "The work that this work has been translated from. E.g. 物种起源 is a translationOf “On the Origin of Species”." ;
     :domainIncludes :CreativeWork ;
     :inverseOf :workTranslation ;
     :isPartOf <https://bib.schema.org> ;
-    :rangeIncludes :CreativeWork ;
-    rdfs:comment "The work that this work has been translated from. E.g. 物种起源 is a translationOf “On the Origin of Species”." .
+    :rangeIncludes :CreativeWork .
 
 :workTranslation a rdf:Property ;
     rdfs:label "workTranslation" ;
+    rdfs:comment "A work that is a translation of the content of this work. E.g. 西遊記 has an English workTranslation “Journey to the West”, a German workTranslation “Monkeys Pilgerfahrt” and a Vietnamese  translation Tây du ký bình khảo." ;
     :domainIncludes :CreativeWork ;
     :inverseOf :translationOfWork ;
     :isPartOf <https://bib.schema.org> ;
-    :rangeIncludes :CreativeWork ;
-    rdfs:comment "A work that is a translation of the content of this work. E.g. 西遊記 has an English workTranslation “Journey to the West”, a German workTranslation “Monkeys Pilgerfahrt” and a Vietnamese  translation Tây du ký bình khảo." .
+    :rangeIncludes :CreativeWork .
 

--- a/data/ext/health-lifesci/med-health-core.ttl
+++ b/data/ext/health-lifesci/med-health-core.ttl
@@ -2,1380 +2,1380 @@
 @prefix owl: <http://www.w3.org/2002/07/owl#> .
 @prefix rdf: <http://www.w3.org/1999/02/22-rdf-syntax-ns#> .
 @prefix rdfs: <http://www.w3.org/2000/01/rdf-schema#> .
-@prefix xml: <http://www.w3.org/XML/1998/namespace> .
-@prefix xsd: <http://www.w3.org/2001/XMLSchema#> .
 
 :AnatomicalStructure a rdfs:Class ;
     rdfs:label "AnatomicalStructure" ;
-    :isPartOf <https://health-lifesci.schema.org> ;
     rdfs:comment "Any part of the human body, typically a component of an anatomical system. Organs, tissues, and cells are all anatomical structures." ;
-    rdfs:subClassOf :MedicalEntity .
+    rdfs:subClassOf :MedicalEntity ;
+    :isPartOf <https://health-lifesci.schema.org> .
 
 :AnatomicalSystem a rdfs:Class ;
     rdfs:label "AnatomicalSystem" ;
-    :isPartOf <https://health-lifesci.schema.org> ;
     rdfs:comment "An anatomical system is a group of anatomical structures that work together to perform a certain task. Anatomical systems, such as organ systems, are one organizing principle of anatomy, and can include circulatory, digestive, endocrine, integumentary, immune, lymphatic, muscular, nervous, reproductive, respiratory, skeletal, urinary, vestibular, and other systems." ;
-    rdfs:subClassOf :MedicalEntity .
+    rdfs:subClassOf :MedicalEntity ;
+    :isPartOf <https://health-lifesci.schema.org> .
 
 :ApprovedIndication a rdfs:Class ;
     rdfs:label "ApprovedIndication" ;
-    :isPartOf <https://health-lifesci.schema.org> ;
     rdfs:comment "An indication for a medical therapy that has been formally specified or approved by a regulatory body that regulates use of the therapy; for example, the US FDA approves indications for most drugs in the US." ;
-    rdfs:subClassOf :MedicalIndication .
+    rdfs:subClassOf :MedicalIndication ;
+    :isPartOf <https://health-lifesci.schema.org> .
 
 :Artery a rdfs:Class ;
     rdfs:label "Artery" ;
-    :isPartOf <https://health-lifesci.schema.org> ;
     rdfs:comment "A type of blood vessel that specifically carries blood away from the heart." ;
     rdfs:subClassOf :Vessel ;
-    owl:equivalentClass <http://purl.bioontology.org/ontology/SNOMEDCT/51114001> .
+    owl:equivalentClass <http://purl.bioontology.org/ontology/SNOMEDCT/51114001> ;
+    :isPartOf <https://health-lifesci.schema.org> .
 
 :BloodTest a rdfs:Class ;
     rdfs:label "BloodTest" ;
-    :isPartOf <https://health-lifesci.schema.org> ;
     rdfs:comment "A medical test performed on a sample of a patient's blood." ;
-    rdfs:subClassOf :MedicalTest .
+    rdfs:subClassOf :MedicalTest ;
+    :isPartOf <https://health-lifesci.schema.org> .
 
 :Bone a rdfs:Class ;
     rdfs:label "Bone" ;
-    :isPartOf <https://health-lifesci.schema.org> ;
     rdfs:comment "Rigid connective tissue that comprises up the skeletal structure of the human body." ;
-    rdfs:subClassOf :AnatomicalStructure .
+    rdfs:subClassOf :AnatomicalStructure ;
+    :isPartOf <https://health-lifesci.schema.org> .
 
 :BrainStructure a rdfs:Class ;
     rdfs:label "BrainStructure" ;
-    :isPartOf <https://health-lifesci.schema.org> ;
     rdfs:comment "Any anatomical structure which pertains to the soft nervous tissue functioning as the coordinating center of sensation and intellectual and nervous activity." ;
-    rdfs:subClassOf :AnatomicalStructure .
+    rdfs:subClassOf :AnatomicalStructure ;
+    :isPartOf <https://health-lifesci.schema.org> .
 
 :DDxElement a rdfs:Class ;
     rdfs:label "DDxElement" ;
-    :isPartOf <https://health-lifesci.schema.org> ;
     rdfs:comment "An alternative, closely-related condition typically considered later in the differential diagnosis process along with the signs that are used to distinguish it." ;
-    rdfs:subClassOf :MedicalIntangible .
+    rdfs:subClassOf :MedicalIntangible ;
+    :isPartOf <https://health-lifesci.schema.org> .
 
 :Dentist a rdfs:Class ;
     rdfs:subClassOf :MedicalBusiness .
 
 :DiagnosticLab a rdfs:Class ;
     rdfs:label "DiagnosticLab" ;
-    :isPartOf <https://health-lifesci.schema.org> ;
     rdfs:comment "A medical laboratory that offers on-site or off-site diagnostic services." ;
-    rdfs:subClassOf :MedicalOrganization .
+    rdfs:subClassOf :MedicalOrganization ;
+    :isPartOf <https://health-lifesci.schema.org> .
 
 :DiagnosticProcedure a rdfs:Class ;
     rdfs:label "DiagnosticProcedure" ;
-    :isPartOf <https://health-lifesci.schema.org> ;
     rdfs:comment "A medical procedure intended primarily for diagnostic, as opposed to therapeutic, purposes." ;
-    rdfs:subClassOf :MedicalProcedure .
+    rdfs:subClassOf :MedicalProcedure ;
+    :isPartOf <https://health-lifesci.schema.org> .
 
 :Diet a rdfs:Class ;
     rdfs:label "Diet" ;
-    :isPartOf <https://health-lifesci.schema.org> ;
     rdfs:comment "A strategy of regulating the intake of food to achieve or maintain a specific health-related goal." ;
     rdfs:subClassOf :CreativeWork,
-        :LifestyleModification .
+        :LifestyleModification ;
+    :isPartOf <https://health-lifesci.schema.org> .
 
 :DietarySupplement a rdfs:Class ;
     rdfs:label "DietarySupplement" ;
-    :isPartOf <https://health-lifesci.schema.org> ;
     rdfs:comment "A product taken by mouth that contains a dietary ingredient intended to supplement the diet. Dietary ingredients may include vitamins, minerals, herbs or other botanicals, amino acids, and substances such as enzymes, organ tissues, glandulars and metabolites." ;
-    rdfs:subClassOf :Substance, :Product .
+    rdfs:subClassOf :Product,
+        :Substance ;
+    :isPartOf <https://health-lifesci.schema.org> .
 
 :DoseSchedule a rdfs:Class ;
     rdfs:label "DoseSchedule" ;
-    :isPartOf <https://health-lifesci.schema.org> ;
     rdfs:comment "A specific dosing schedule for a drug or supplement." ;
-    rdfs:subClassOf :MedicalIntangible .
+    rdfs:subClassOf :MedicalIntangible ;
+    :isPartOf <https://health-lifesci.schema.org> .
 
 :Drug a rdfs:Class ;
     rdfs:label "Drug" ;
-    :isPartOf <https://health-lifesci.schema.org> ;
     rdfs:comment "A chemical or biologic substance, used as a medical therapy, that has a physiological effect on an organism. Here the term drug is used interchangeably with the term medicine although clinical knowledge makes a clear difference between them." ;
-    rdfs:subClassOf :Substance, :Product ;
-    owl:equivalentClass <http://purl.bioontology.org/ontology/SNOMEDCT/410942007> .
+    rdfs:subClassOf :Product,
+        :Substance ;
+    owl:equivalentClass <http://purl.bioontology.org/ontology/SNOMEDCT/410942007> ;
+    :isPartOf <https://health-lifesci.schema.org> .
 
 :DrugClass a rdfs:Class ;
     rdfs:label "DrugClass" ;
-    :isPartOf <https://health-lifesci.schema.org> ;
     rdfs:comment "A class of medical drugs, e.g., statins. Classes can represent general pharmacological class, common mechanisms of action, common physiological effects, etc." ;
-    rdfs:subClassOf :MedicalEntity .
+    rdfs:subClassOf :MedicalEntity ;
+    :isPartOf <https://health-lifesci.schema.org> .
 
 :DrugCost a rdfs:Class ;
     rdfs:label "DrugCost" ;
-    :isPartOf <https://health-lifesci.schema.org> ;
     rdfs:comment "The cost per unit of a medical drug. Note that this type is not meant to represent the price in an offer of a drug for sale; see the Offer type for that. This type will typically be used to tag wholesale or average retail cost of a drug, or maximum reimbursable cost. Costs of medical drugs vary widely depending on how and where they are paid for, so while this type captures some of the variables, costs should be used with caution by consumers of this schema's markup." ;
-    rdfs:subClassOf :MedicalEntity .
+    rdfs:subClassOf :MedicalEntity ;
+    :isPartOf <https://health-lifesci.schema.org> .
 
 :DrugCostCategory a rdfs:Class ;
     rdfs:label "DrugCostCategory" ;
-    :isPartOf <https://health-lifesci.schema.org> ;
     rdfs:comment "Enumerated categories of medical drug costs." ;
-    rdfs:subClassOf :MedicalEnumeration .
+    rdfs:subClassOf :MedicalEnumeration ;
+    :isPartOf <https://health-lifesci.schema.org> .
 
 :DrugLegalStatus a rdfs:Class ;
     rdfs:label "DrugLegalStatus" ;
-    :isPartOf <https://health-lifesci.schema.org> ;
     rdfs:comment "The legal availability status of a medical drug." ;
-    rdfs:subClassOf :MedicalIntangible .
+    rdfs:subClassOf :MedicalIntangible ;
+    :isPartOf <https://health-lifesci.schema.org> .
 
 :DrugPregnancyCategory a rdfs:Class ;
     rdfs:label "DrugPregnancyCategory" ;
-    :isPartOf <https://health-lifesci.schema.org> ;
     rdfs:comment "Categories that represent an assessment of the risk of fetal injury due to a drug or pharmaceutical used as directed by the mother during pregnancy." ;
-    rdfs:subClassOf :MedicalEnumeration .
+    rdfs:subClassOf :MedicalEnumeration ;
+    :isPartOf <https://health-lifesci.schema.org> .
 
 :DrugPrescriptionStatus a rdfs:Class ;
     rdfs:label "DrugPrescriptionStatus" ;
-    :isPartOf <https://health-lifesci.schema.org> ;
     rdfs:comment "Indicates whether this drug is available by prescription or over-the-counter." ;
-    rdfs:subClassOf :MedicalEnumeration .
+    rdfs:subClassOf :MedicalEnumeration ;
+    :isPartOf <https://health-lifesci.schema.org> .
 
 :DrugStrength a rdfs:Class ;
     rdfs:label "DrugStrength" ;
-    :isPartOf <https://health-lifesci.schema.org> ;
     rdfs:comment "A specific strength in which a medical drug is available in a specific country." ;
-    rdfs:subClassOf :MedicalIntangible .
+    rdfs:subClassOf :MedicalIntangible ;
+    :isPartOf <https://health-lifesci.schema.org> .
 
 :ImagingTest a rdfs:Class ;
     rdfs:label "ImagingTest" ;
-    :isPartOf <https://health-lifesci.schema.org> ;
     rdfs:comment "Any medical imaging modality typically used for diagnostic purposes." ;
-    rdfs:subClassOf :MedicalTest .
+    rdfs:subClassOf :MedicalTest ;
+    :isPartOf <https://health-lifesci.schema.org> .
 
 :InfectiousAgentClass a rdfs:Class ;
     rdfs:label "InfectiousAgentClass" ;
-    :isPartOf <https://health-lifesci.schema.org> ;
     rdfs:comment "Classes of agents or pathogens that transmit infectious diseases. Enumerated type." ;
-    rdfs:subClassOf :MedicalEnumeration .
+    rdfs:subClassOf :MedicalEnumeration ;
+    :isPartOf <https://health-lifesci.schema.org> .
 
 :InfectiousDisease a rdfs:Class ;
     rdfs:label "InfectiousDisease" ;
-    :isPartOf <https://health-lifesci.schema.org> ;
     rdfs:comment "An infectious disease is a clinically evident human disease resulting from the presence of pathogenic microbial agents, like pathogenic viruses, pathogenic bacteria, fungi, protozoa, multicellular parasites, and prions. To be considered an infectious disease, such pathogens are known to be able to cause this disease." ;
-    rdfs:subClassOf :MedicalCondition .
+    rdfs:subClassOf :MedicalCondition ;
+    :isPartOf <https://health-lifesci.schema.org> .
 
 :Joint a rdfs:Class ;
     rdfs:label "Joint" ;
-    :isPartOf <https://health-lifesci.schema.org> ;
     rdfs:comment "The anatomical location at which two or more bones make contact." ;
-    rdfs:subClassOf :AnatomicalStructure .
+    rdfs:subClassOf :AnatomicalStructure ;
+    :isPartOf <https://health-lifesci.schema.org> .
 
 :LifestyleModification a rdfs:Class ;
     rdfs:label "LifestyleModification" ;
-    :isPartOf <https://health-lifesci.schema.org> ;
     rdfs:comment "A process of care involving exercise, changes to diet, fitness routines, and other lifestyle changes aimed at improving a health condition." ;
-    rdfs:subClassOf :MedicalEntity .
+    rdfs:subClassOf :MedicalEntity ;
+    :isPartOf <https://health-lifesci.schema.org> .
 
 :Ligament a rdfs:Class ;
     rdfs:label "Ligament" ;
-    :isPartOf <https://health-lifesci.schema.org> ;
     rdfs:comment "A short band of tough, flexible, fibrous connective tissue that functions to connect multiple bones, cartilages, and structurally support joints." ;
-    rdfs:subClassOf :AnatomicalStructure .
+    rdfs:subClassOf :AnatomicalStructure ;
+    :isPartOf <https://health-lifesci.schema.org> .
 
 :LymphaticVessel a rdfs:Class ;
     rdfs:label "LymphaticVessel" ;
-    :isPartOf <https://health-lifesci.schema.org> ;
     rdfs:comment "A type of blood vessel that specifically carries lymph fluid unidirectionally toward the heart." ;
-    rdfs:subClassOf :Vessel .
+    rdfs:subClassOf :Vessel ;
+    :isPartOf <https://health-lifesci.schema.org> .
 
 :MaximumDoseSchedule a rdfs:Class ;
     rdfs:label "MaximumDoseSchedule" ;
-    :isPartOf <https://health-lifesci.schema.org> ;
     rdfs:comment "The maximum dosing schedule considered safe for a drug or supplement as recommended by an authority or by the drug/supplement's manufacturer. Capture the recommending authority in the recognizingAuthority property of MedicalEntity." ;
-    rdfs:subClassOf :DoseSchedule .
+    rdfs:subClassOf :DoseSchedule ;
+    :isPartOf <https://health-lifesci.schema.org> .
 
 :MedicalAudience a rdfs:Class ;
     rdfs:label "MedicalAudience" ;
-    :isPartOf <https://health-lifesci.schema.org> ;
     rdfs:comment "Target audiences for medical web pages." ;
     rdfs:subClassOf :Audience,
-        :PeopleAudience .
+        :PeopleAudience ;
+    :isPartOf <https://health-lifesci.schema.org> .
 
 :MedicalAudienceType a rdfs:Class ;
     rdfs:label "MedicalAudienceType" ;
-    :isPartOf <https://health-lifesci.schema.org> ;
     rdfs:comment "Target audiences types for medical web pages. Enumerated type." ;
-    rdfs:subClassOf :MedicalEnumeration .
+    rdfs:subClassOf :MedicalEnumeration ;
+    :isPartOf <https://health-lifesci.schema.org> .
 
 :MedicalBusiness a rdfs:Class ;
     rdfs:label "MedicalBusiness" ;
-    :isPartOf <https://health-lifesci.schema.org> ;
     rdfs:comment "A particular physical or virtual business of an organization for medical purposes. Examples of MedicalBusiness include different businesses run by health professionals." ;
-    rdfs:subClassOf :LocalBusiness .
+    rdfs:subClassOf :LocalBusiness ;
+    :isPartOf <https://health-lifesci.schema.org> .
 
 :MedicalCause a rdfs:Class ;
     rdfs:label "MedicalCause" ;
-    :isPartOf <https://health-lifesci.schema.org> ;
     rdfs:comment "The causative agent(s) that are responsible for the pathophysiologic process that eventually results in a medical condition, symptom or sign. In this schema, unless otherwise specified this is meant to be the proximate cause of the medical condition, symptom or sign. The proximate cause is defined as the causative agent that most directly results in the medical condition, symptom or sign. For example, the HIV virus could be considered a cause of AIDS. Or in a diagnostic context, if a patient fell and sustained a hip fracture and two days later sustained a pulmonary embolism which eventuated in a cardiac arrest, the cause of the cardiac arrest (the proximate cause) would be the pulmonary embolism and not the fall. Medical causes can include cardiovascular, chemical, dermatologic, endocrine, environmental, gastroenterologic, genetic, hematologic, gynecologic, iatrogenic, infectious, musculoskeletal, neurologic, nutritional, obstetric, oncologic, otolaryngologic, pharmacologic, psychiatric, pulmonary, renal, rheumatologic, toxic, traumatic, or urologic causes; medical conditions can be causes as well." ;
-    rdfs:subClassOf :MedicalEntity .
+    rdfs:subClassOf :MedicalEntity ;
+    :isPartOf <https://health-lifesci.schema.org> .
 
 :MedicalClinic a rdfs:Class ;
     rdfs:label "MedicalClinic" ;
-    :isPartOf <https://health-lifesci.schema.org> ;
     rdfs:comment "A facility, often associated with a hospital or medical school, that is devoted to the specific diagnosis and/or healthcare. Previously limited to outpatients but with evolution it may be open to inpatients as well." ;
     rdfs:subClassOf :MedicalBusiness,
-        :MedicalOrganization .
+        :MedicalOrganization ;
+    :isPartOf <https://health-lifesci.schema.org> .
 
 :MedicalCode a rdfs:Class ;
     rdfs:label "MedicalCode" ;
-    :isPartOf <https://health-lifesci.schema.org> ;
     rdfs:comment "A code for a medical entity." ;
     rdfs:subClassOf :CategoryCode,
-        :MedicalIntangible .
+        :MedicalIntangible ;
+    :isPartOf <https://health-lifesci.schema.org> .
 
 :MedicalCondition a rdfs:Class ;
     rdfs:label "MedicalCondition" ;
-    :isPartOf <https://health-lifesci.schema.org> ;
     rdfs:comment "Any condition of the human body that affects the normal functioning of a person, whether physically or mentally. Includes diseases, injuries, disabilities, disorders, syndromes, etc." ;
-    rdfs:subClassOf :MedicalEntity .
+    rdfs:subClassOf :MedicalEntity ;
+    :isPartOf <https://health-lifesci.schema.org> .
 
 :MedicalConditionStage a rdfs:Class ;
     rdfs:label "MedicalConditionStage" ;
-    :isPartOf <https://health-lifesci.schema.org> ;
     rdfs:comment "A stage of a medical condition, such as 'Stage IIIa'." ;
-    rdfs:subClassOf :MedicalIntangible .
+    rdfs:subClassOf :MedicalIntangible ;
+    :isPartOf <https://health-lifesci.schema.org> .
 
 :MedicalContraindication a rdfs:Class ;
     rdfs:label "MedicalContraindication" ;
-    :isPartOf <https://health-lifesci.schema.org> ;
     rdfs:comment "A condition or factor that serves as a reason to withhold a certain medical therapy. Contraindications can be absolute (there are no reasonable circumstances for undertaking a course of action) or relative (the patient is at higher risk of complications, but these risks may be outweighed by other considerations or mitigated by other measures)." ;
-    rdfs:subClassOf :MedicalEntity .
+    rdfs:subClassOf :MedicalEntity ;
+    :isPartOf <https://health-lifesci.schema.org> .
 
 :MedicalDevice a rdfs:Class ;
     rdfs:label "MedicalDevice" ;
-    :isPartOf <https://health-lifesci.schema.org> ;
     rdfs:comment "Any object used in a medical capacity, such as to diagnose or treat a patient." ;
     rdfs:subClassOf :MedicalEntity ;
-    owl:equivalentClass <http://purl.bioontology.org/ontology/SNOMEDCT/63653004> .
+    owl:equivalentClass <http://purl.bioontology.org/ontology/SNOMEDCT/63653004> ;
+    :isPartOf <https://health-lifesci.schema.org> .
 
 :MedicalDevicePurpose a rdfs:Class ;
     rdfs:label "MedicalDevicePurpose" ;
-    :isPartOf <https://health-lifesci.schema.org> ;
     rdfs:comment "Categories of medical devices, organized by the purpose or intended use of the device." ;
-    rdfs:subClassOf :MedicalEnumeration .
+    rdfs:subClassOf :MedicalEnumeration ;
+    :isPartOf <https://health-lifesci.schema.org> .
 
 :MedicalEntity a rdfs:Class ;
     rdfs:label "MedicalEntity" ;
-    :isPartOf <https://health-lifesci.schema.org> ;
     rdfs:comment "The most generic type of entity related to health and the practice of medicine." ;
-    rdfs:subClassOf :Thing .
+    rdfs:subClassOf :Thing ;
+    :isPartOf <https://health-lifesci.schema.org> .
 
 :MedicalEnumeration a rdfs:Class ;
     rdfs:label "MedicalEnumeration" ;
-    :isPartOf <https://health-lifesci.schema.org> ;
     rdfs:comment "Enumerations related to health and the practice of medicine: A concept that is used to attribute a quality to another concept, as a qualifier, a collection of items or a listing of all of the elements of a set in medicine practice." ;
-    rdfs:subClassOf :Enumeration .
+    rdfs:subClassOf :Enumeration ;
+    :isPartOf <https://health-lifesci.schema.org> .
 
 :MedicalEvidenceLevel a rdfs:Class ;
     rdfs:label "MedicalEvidenceLevel" ;
-    :isPartOf <https://health-lifesci.schema.org> ;
     rdfs:comment "Level of evidence for a medical guideline. Enumerated type." ;
-    rdfs:subClassOf :MedicalEnumeration .
+    rdfs:subClassOf :MedicalEnumeration ;
+    :isPartOf <https://health-lifesci.schema.org> .
 
 :MedicalGuideline a rdfs:Class ;
     rdfs:label "MedicalGuideline" ;
-    :isPartOf <https://health-lifesci.schema.org> ;
     rdfs:comment "Any recommendation made by a standard society (e.g. ACC/AHA) or consensus statement that denotes how to diagnose and treat a particular condition. Note: this type should be used to tag the actual guideline recommendation; if the guideline recommendation occurs in a larger scholarly article, use MedicalScholarlyArticle to tag the overall article, not this type. Note also: the organization making the recommendation should be captured in the recognizingAuthority base property of MedicalEntity." ;
-    rdfs:subClassOf :MedicalEntity .
+    rdfs:subClassOf :MedicalEntity ;
+    :isPartOf <https://health-lifesci.schema.org> .
 
 :MedicalGuidelineContraindication a rdfs:Class ;
     rdfs:label "MedicalGuidelineContraindication" ;
-    :isPartOf <https://health-lifesci.schema.org> ;
     rdfs:comment "A guideline contraindication that designates a process as harmful and where quality of the data supporting the contraindication is sound." ;
-    rdfs:subClassOf :MedicalGuideline .
+    rdfs:subClassOf :MedicalGuideline ;
+    :isPartOf <https://health-lifesci.schema.org> .
 
 :MedicalGuidelineRecommendation a rdfs:Class ;
     rdfs:label "MedicalGuidelineRecommendation" ;
-    :isPartOf <https://health-lifesci.schema.org> ;
     rdfs:comment "A guideline recommendation that is regarded as efficacious and where quality of the data supporting the recommendation is sound." ;
-    rdfs:subClassOf :MedicalGuideline .
+    rdfs:subClassOf :MedicalGuideline ;
+    :isPartOf <https://health-lifesci.schema.org> .
 
 :MedicalImagingTechnique a rdfs:Class ;
     rdfs:label "MedicalImagingTechnique" ;
-    :isPartOf <https://health-lifesci.schema.org> ;
     rdfs:comment "Any medical imaging modality typically used for diagnostic purposes. Enumerated type." ;
-    rdfs:subClassOf :MedicalEnumeration .
+    rdfs:subClassOf :MedicalEnumeration ;
+    :isPartOf <https://health-lifesci.schema.org> .
 
 :MedicalIndication a rdfs:Class ;
     rdfs:label "MedicalIndication" ;
-    :isPartOf <https://health-lifesci.schema.org> ;
     rdfs:comment "A condition or factor that indicates use of a medical therapy, including signs, symptoms, risk factors, anatomical states, etc." ;
-    rdfs:subClassOf :MedicalEntity .
+    rdfs:subClassOf :MedicalEntity ;
+    :isPartOf <https://health-lifesci.schema.org> .
 
 :MedicalIntangible a rdfs:Class ;
     rdfs:label "MedicalIntangible" ;
-    :isPartOf <https://health-lifesci.schema.org> ;
     rdfs:comment "A utility class that serves as the umbrella for a number of 'intangible' things in the medical space." ;
-    rdfs:subClassOf :MedicalEntity .
+    rdfs:subClassOf :MedicalEntity ;
+    :isPartOf <https://health-lifesci.schema.org> .
 
 :MedicalObservationalStudy a rdfs:Class ;
     rdfs:label "MedicalObservationalStudy" ;
-    :isPartOf <https://health-lifesci.schema.org> ;
     rdfs:comment "An observational study is a type of medical study that attempts to infer the possible effect of a treatment through observation of a cohort of subjects over a period of time. In an observational study, the assignment of subjects into treatment groups versus control groups is outside the control of the investigator. This is in contrast with controlled studies, such as the randomized controlled trials represented by MedicalTrial, where each subject is randomly assigned to a treatment group or a control group before the start of the treatment." ;
-    rdfs:subClassOf :MedicalStudy .
+    rdfs:subClassOf :MedicalStudy ;
+    :isPartOf <https://health-lifesci.schema.org> .
 
 :MedicalObservationalStudyDesign a rdfs:Class ;
     rdfs:label "MedicalObservationalStudyDesign" ;
-    :isPartOf <https://health-lifesci.schema.org> ;
     rdfs:comment "Design models for observational medical studies. Enumerated type." ;
-    rdfs:subClassOf :MedicalEnumeration .
+    rdfs:subClassOf :MedicalEnumeration ;
+    :isPartOf <https://health-lifesci.schema.org> .
 
 :MedicalProcedure a rdfs:Class ;
     rdfs:label "MedicalProcedure" ;
-    :isPartOf <https://health-lifesci.schema.org> ;
     rdfs:comment "A process of care used in either a diagnostic, therapeutic, preventive or palliative capacity that relies on invasive (surgical), non-invasive, or other techniques." ;
     rdfs:subClassOf :MedicalEntity ;
-    owl:equivalentClass <http://purl.bioontology.org/ontology/SNOMEDCT/50731006> .
+    owl:equivalentClass <http://purl.bioontology.org/ontology/SNOMEDCT/50731006> ;
+    :isPartOf <https://health-lifesci.schema.org> .
 
 :MedicalProcedureType a rdfs:Class ;
     rdfs:label "MedicalProcedureType" ;
-    :isPartOf <https://health-lifesci.schema.org> ;
     rdfs:comment "An enumeration that describes different types of medical procedures." ;
-    rdfs:subClassOf :MedicalEnumeration .
+    rdfs:subClassOf :MedicalEnumeration ;
+    :isPartOf <https://health-lifesci.schema.org> .
 
 :MedicalRiskCalculator a rdfs:Class ;
     rdfs:label "MedicalRiskCalculator" ;
-    :isPartOf <https://health-lifesci.schema.org> ;
     rdfs:comment "A complex mathematical calculation requiring an online calculator, used to assess prognosis. Note: use the url property of Thing to record any URLs for online calculators." ;
-    rdfs:subClassOf :MedicalRiskEstimator .
+    rdfs:subClassOf :MedicalRiskEstimator ;
+    :isPartOf <https://health-lifesci.schema.org> .
 
 :MedicalRiskEstimator a rdfs:Class ;
     rdfs:label "MedicalRiskEstimator" ;
-    :isPartOf <https://health-lifesci.schema.org> ;
     rdfs:comment "Any rule set or interactive tool for estimating the risk of developing a complication or condition." ;
-    rdfs:subClassOf :MedicalEntity .
+    rdfs:subClassOf :MedicalEntity ;
+    :isPartOf <https://health-lifesci.schema.org> .
 
 :MedicalRiskFactor a rdfs:Class ;
     rdfs:label "MedicalRiskFactor" ;
-    :isPartOf <https://health-lifesci.schema.org> ;
     rdfs:comment "A risk factor is anything that increases a person's likelihood of developing or contracting a disease, medical condition, or complication." ;
-    rdfs:subClassOf :MedicalEntity .
+    rdfs:subClassOf :MedicalEntity ;
+    :isPartOf <https://health-lifesci.schema.org> .
 
 :MedicalRiskScore a rdfs:Class ;
     rdfs:label "MedicalRiskScore" ;
-    :isPartOf <https://health-lifesci.schema.org> ;
     rdfs:comment "A simple system that adds up the number of risk factors to yield a score that is associated with prognosis, e.g. CHAD score, TIMI risk score." ;
-    rdfs:subClassOf :MedicalRiskEstimator .
+    rdfs:subClassOf :MedicalRiskEstimator ;
+    :isPartOf <https://health-lifesci.schema.org> .
 
 :MedicalScholarlyArticle a rdfs:Class ;
     rdfs:label "MedicalScholarlyArticle" ;
-    :isPartOf <https://health-lifesci.schema.org> ;
     rdfs:comment "A scholarly article in the medical domain." ;
-    rdfs:subClassOf :ScholarlyArticle .
+    rdfs:subClassOf :ScholarlyArticle ;
+    :isPartOf <https://health-lifesci.schema.org> .
 
 :MedicalSign a rdfs:Class ;
     rdfs:label "MedicalSign" ;
-    :isPartOf <https://health-lifesci.schema.org> ;
     rdfs:comment "Any physical manifestation of a person's medical condition discoverable by objective diagnostic tests or physical examination." ;
-    rdfs:subClassOf :MedicalSignOrSymptom .
+    rdfs:subClassOf :MedicalSignOrSymptom ;
+    :isPartOf <https://health-lifesci.schema.org> .
 
 :MedicalSignOrSymptom a rdfs:Class ;
     rdfs:label "MedicalSignOrSymptom" ;
-    :isPartOf <https://health-lifesci.schema.org> ;
     rdfs:comment "Any feature associated or not with a medical condition. In medicine a symptom is generally subjective while a sign is objective." ;
-    rdfs:subClassOf :MedicalCondition .
+    rdfs:subClassOf :MedicalCondition ;
+    :isPartOf <https://health-lifesci.schema.org> .
 
 :MedicalSpecialty a rdfs:Class ;
     rdfs:label "MedicalSpecialty" ;
-    :isPartOf <https://health-lifesci.schema.org> ;
     rdfs:comment "Any specific branch of medical science or practice. Medical specialities include clinical specialties that pertain to particular organ systems and their respective disease states, as well as allied health specialties. Enumerated type." ;
     rdfs:subClassOf :MedicalEnumeration,
-        :Specialty .
+        :Specialty ;
+    :isPartOf <https://health-lifesci.schema.org> .
 
 :MedicalStudy a rdfs:Class ;
     rdfs:label "MedicalStudy" ;
-    :isPartOf <https://health-lifesci.schema.org> ;
     rdfs:comment "A medical study is an umbrella type covering all kinds of research studies relating to human medicine or health, including observational studies and interventional trials and registries, randomized, controlled or not. When the specific type of study is known, use one of the extensions of this type, such as MedicalTrial or MedicalObservationalStudy. Also, note that this type should be used to mark up data that describes the study itself; to tag an article that publishes the results of a study, use MedicalScholarlyArticle. Note: use the code property of MedicalEntity to store study IDs, e.g. clinicaltrials.gov ID." ;
-    rdfs:subClassOf :MedicalEntity .
+    rdfs:subClassOf :MedicalEntity ;
+    :isPartOf <https://health-lifesci.schema.org> .
 
 :MedicalStudyStatus a rdfs:Class ;
     rdfs:label "MedicalStudyStatus" ;
-    :isPartOf <https://health-lifesci.schema.org> ;
     rdfs:comment "The status of a medical study. Enumerated type." ;
-    rdfs:subClassOf :MedicalEnumeration .
+    rdfs:subClassOf :MedicalEnumeration ;
+    :isPartOf <https://health-lifesci.schema.org> .
 
 :MedicalSymptom a rdfs:Class ;
     rdfs:label "MedicalSymptom" ;
-    :isPartOf <https://health-lifesci.schema.org> ;
     rdfs:comment "Any complaint sensed and expressed by the patient (therefore defined as subjective)  like stomachache, lower-back pain, or fatigue." ;
-    rdfs:subClassOf :MedicalSignOrSymptom .
+    rdfs:subClassOf :MedicalSignOrSymptom ;
+    :isPartOf <https://health-lifesci.schema.org> .
 
 :MedicalTest a rdfs:Class ;
     rdfs:label "MedicalTest" ;
-    :isPartOf <https://health-lifesci.schema.org> ;
     rdfs:comment "Any medical test, typically performed for diagnostic purposes." ;
-    rdfs:subClassOf :MedicalEntity .
+    rdfs:subClassOf :MedicalEntity ;
+    :isPartOf <https://health-lifesci.schema.org> .
 
 :MedicalTestPanel a rdfs:Class ;
     rdfs:label "MedicalTestPanel" ;
-    :isPartOf <https://health-lifesci.schema.org> ;
     rdfs:comment "Any collection of tests commonly ordered together." ;
-    rdfs:subClassOf :MedicalTest .
+    rdfs:subClassOf :MedicalTest ;
+    :isPartOf <https://health-lifesci.schema.org> .
 
 :MedicalTherapy a rdfs:Class ;
     rdfs:label "MedicalTherapy" ;
-    :isPartOf <https://health-lifesci.schema.org> ;
     rdfs:comment "Any medical intervention designed to prevent, treat, and cure human diseases and medical conditions, including both curative and palliative therapies. Medical therapies are typically processes of care relying upon pharmacotherapy, behavioral therapy, supportive therapy (with fluid or nutrition for example), or detoxification (e.g. hemodialysis) aimed at improving or preventing a health condition." ;
-    rdfs:subClassOf :TherapeuticProcedure .
+    rdfs:subClassOf :TherapeuticProcedure ;
+    :isPartOf <https://health-lifesci.schema.org> .
 
 :MedicalTrial a rdfs:Class ;
     rdfs:label "MedicalTrial" ;
-    :isPartOf <https://health-lifesci.schema.org> ;
     rdfs:comment "A medical trial is a type of medical study that uses a scientific process to compare the safety and efficacy of medical therapies or medical procedures. In general, medical trials are controlled and subjects are allocated at random to the different treatment and/or control groups." ;
-    rdfs:subClassOf :MedicalStudy .
+    rdfs:subClassOf :MedicalStudy ;
+    :isPartOf <https://health-lifesci.schema.org> .
 
 :MedicalTrialDesign a rdfs:Class ;
     rdfs:label "MedicalTrialDesign" ;
-    :isPartOf <https://health-lifesci.schema.org> ;
-    :contributor <https://schema.org/docs/collab/WikiDoc> ;
     rdfs:comment "Design models for medical trials. Enumerated type." ;
-    rdfs:subClassOf :MedicalEnumeration .
+    rdfs:subClassOf :MedicalEnumeration ;
+    :contributor <https://schema.org/docs/collab/WikiDoc> ;
+    :isPartOf <https://health-lifesci.schema.org> .
 
 :MedicalWebPage a rdfs:Class ;
     rdfs:label "MedicalWebPage" ;
-    :isPartOf <https://health-lifesci.schema.org> ;
     rdfs:comment "A web page that provides medical information." ;
-    rdfs:subClassOf :WebPage .
+    rdfs:subClassOf :WebPage ;
+    :isPartOf <https://health-lifesci.schema.org> .
 
 :MedicineSystem a rdfs:Class ;
     rdfs:label "MedicineSystem" ;
-    :isPartOf <https://health-lifesci.schema.org> ;
     rdfs:comment "Systems of medical practice." ;
-    rdfs:subClassOf :MedicalEnumeration .
+    rdfs:subClassOf :MedicalEnumeration ;
+    :isPartOf <https://health-lifesci.schema.org> .
 
 :Muscle a rdfs:Class ;
     rdfs:label "Muscle" ;
-    :isPartOf <https://health-lifesci.schema.org> ;
     rdfs:comment "A muscle is an anatomical structure consisting of a contractile form of tissue that animals use to effect movement." ;
-    rdfs:subClassOf :AnatomicalStructure .
+    rdfs:subClassOf :AnatomicalStructure ;
+    :isPartOf <https://health-lifesci.schema.org> .
 
 :Nerve a rdfs:Class ;
     rdfs:label "Nerve" ;
-    :isPartOf <https://health-lifesci.schema.org> ;
     rdfs:comment "A common pathway for the electrochemical nerve impulses that are transmitted along each of the axons." ;
-    rdfs:subClassOf :AnatomicalStructure .
+    rdfs:subClassOf :AnatomicalStructure ;
+    :isPartOf <https://health-lifesci.schema.org> .
 
 :OccupationalTherapy a rdfs:Class ;
     rdfs:label "OccupationalTherapy" ;
-    :isPartOf <https://health-lifesci.schema.org> ;
     rdfs:comment "A treatment of people with physical, emotional, or social problems, using purposeful activity to help them overcome or learn to deal with their problems." ;
-    rdfs:subClassOf :MedicalTherapy .
+    rdfs:subClassOf :MedicalTherapy ;
+    :isPartOf <https://health-lifesci.schema.org> .
 
 :Optician a rdfs:Class ;
     rdfs:label "Optician" ;
-    :isPartOf <https://health-lifesci.schema.org> ;
     rdfs:comment "A store that sells reading glasses and similar devices for improving vision." ;
-    rdfs:subClassOf :MedicalBusiness .
+    rdfs:subClassOf :MedicalBusiness ;
+    :isPartOf <https://health-lifesci.schema.org> .
 
 :PalliativeProcedure a rdfs:Class ;
     rdfs:label "PalliativeProcedure" ;
-    :isPartOf <https://health-lifesci.schema.org> ;
     rdfs:comment "A medical procedure intended primarily for palliative purposes, aimed at relieving the symptoms of an underlying health condition." ;
     rdfs:subClassOf :MedicalProcedure,
-        :MedicalTherapy .
+        :MedicalTherapy ;
+    :isPartOf <https://health-lifesci.schema.org> .
 
 :PathologyTest a rdfs:Class ;
     rdfs:label "PathologyTest" ;
-    :isPartOf <https://health-lifesci.schema.org> ;
     rdfs:comment "A medical test performed by a laboratory that typically involves examination of a tissue sample by a pathologist." ;
-    rdfs:subClassOf :MedicalTest .
+    rdfs:subClassOf :MedicalTest ;
+    :isPartOf <https://health-lifesci.schema.org> .
 
 :Patient a rdfs:Class ;
     rdfs:label "Patient" ;
-    :isPartOf <https://health-lifesci.schema.org> ;
     rdfs:comment "A patient is any person recipient of health care services." ;
     rdfs:subClassOf :MedicalAudience,
         :Person ;
-    owl:equivalentClass <http://purl.bioontology.org/ontology/SNOMEDCT/116154003> .
+    owl:equivalentClass <http://purl.bioontology.org/ontology/SNOMEDCT/116154003> ;
+    :isPartOf <https://health-lifesci.schema.org> .
 
 :Pharmacy a rdfs:Class ;
     rdfs:subClassOf :MedicalBusiness .
 
 :PhysicalExam a rdfs:Class ;
     rdfs:label "PhysicalExam" ;
-    :isPartOf <https://health-lifesci.schema.org> ;
     rdfs:comment "A type of physical examination of a patient performed by a physician. " ;
     rdfs:subClassOf :MedicalEnumeration,
-        :MedicalProcedure .
+        :MedicalProcedure ;
+    :isPartOf <https://health-lifesci.schema.org> .
 
 :PhysicalTherapy a rdfs:Class ;
     rdfs:label "PhysicalTherapy" ;
-    :isPartOf <https://health-lifesci.schema.org> ;
     rdfs:comment "A process of progressive physical care and rehabilitation aimed at improving a health condition." ;
-    rdfs:subClassOf :MedicalTherapy .
+    rdfs:subClassOf :MedicalTherapy ;
+    :isPartOf <https://health-lifesci.schema.org> .
 
 :PreventionIndication a rdfs:Class ;
     rdfs:label "PreventionIndication" ;
-    :isPartOf <https://health-lifesci.schema.org> ;
     rdfs:comment "An indication for preventing an underlying condition, symptom, etc." ;
-    rdfs:subClassOf :MedicalIndication .
+    rdfs:subClassOf :MedicalIndication ;
+    :isPartOf <https://health-lifesci.schema.org> .
 
 :PsychologicalTreatment a rdfs:Class ;
     rdfs:label "PsychologicalTreatment" ;
-    :isPartOf <https://health-lifesci.schema.org> ;
     rdfs:comment "A process of care relying upon counseling, dialogue and communication  aimed at improving a mental health condition without use of drugs." ;
-    rdfs:subClassOf :TherapeuticProcedure .
+    rdfs:subClassOf :TherapeuticProcedure ;
+    :isPartOf <https://health-lifesci.schema.org> .
 
 :RadiationTherapy a rdfs:Class ;
     rdfs:label "RadiationTherapy" ;
-    :isPartOf <https://health-lifesci.schema.org> ;
     rdfs:comment "A process of care using radiation aimed at improving a health condition." ;
-    rdfs:subClassOf :MedicalTherapy .
+    rdfs:subClassOf :MedicalTherapy ;
+    :isPartOf <https://health-lifesci.schema.org> .
 
 :RecommendedDoseSchedule a rdfs:Class ;
     rdfs:label "RecommendedDoseSchedule" ;
-    :isPartOf <https://health-lifesci.schema.org> ;
     rdfs:comment "A recommended dosing schedule for a drug or supplement as prescribed or recommended by an authority or by the drug/supplement's manufacturer. Capture the recommending authority in the recognizingAuthority property of MedicalEntity." ;
-    rdfs:subClassOf :DoseSchedule .
+    rdfs:subClassOf :DoseSchedule ;
+    :isPartOf <https://health-lifesci.schema.org> .
 
 :ReportedDoseSchedule a rdfs:Class ;
     rdfs:label "ReportedDoseSchedule" ;
-    :isPartOf <https://health-lifesci.schema.org> ;
     rdfs:comment "A patient-reported or observed dosing schedule for a drug or supplement." ;
-    rdfs:subClassOf :DoseSchedule .
+    rdfs:subClassOf :DoseSchedule ;
+    :isPartOf <https://health-lifesci.schema.org> .
 
 :Substance a rdfs:Class ;
     rdfs:label "Substance" ;
-    :isPartOf <https://health-lifesci.schema.org> ;
     rdfs:comment "Any matter of defined composition that has discrete existence, whose origin may be biological, mineral or chemical." ;
     rdfs:subClassOf :MedicalEntity ;
-    owl:equivalentClass <http://purl.bioontology.org/ontology/SNOMEDCT/105590001> .
+    owl:equivalentClass <http://purl.bioontology.org/ontology/SNOMEDCT/105590001> ;
+    :isPartOf <https://health-lifesci.schema.org> .
 
 :SuperficialAnatomy a rdfs:Class ;
     rdfs:label "SuperficialAnatomy" ;
-    :isPartOf <https://health-lifesci.schema.org> ;
     rdfs:comment "Anatomical features that can be observed by sight (without dissection), including the form and proportions of the human body as well as surface landmarks that correspond to deeper subcutaneous structures. Superficial anatomy plays an important role in sports medicine, phlebotomy, and other medical specialties as underlying anatomical structures can be identified through surface palpation. For example, during back surgery, superficial anatomy can be used to palpate and count vertebrae to find the site of incision. Or in phlebotomy, superficial anatomy can be used to locate an underlying vein; for example, the median cubital vein can be located by palpating the borders of the cubital fossa (such as the epicondyles of the humerus) and then looking for the superficial signs of the vein, such as size, prominence, ability to refill after depression, and feel of surrounding tissue support. As another example, in a subluxation (dislocation) of the glenohumeral joint, the bony structure becomes pronounced with the deltoid muscle failing to cover the glenohumeral joint allowing the edges of the scapula to be superficially visible. Here, the superficial anatomy is the visible edges of the scapula, implying the underlying dislocation of the joint (the related anatomical structure)." ;
-    rdfs:subClassOf :MedicalEntity .
+    rdfs:subClassOf :MedicalEntity ;
+    :isPartOf <https://health-lifesci.schema.org> .
 
 :SurgicalProcedure a rdfs:Class ;
     rdfs:label "SurgicalProcedure" ;
-    :isPartOf <https://health-lifesci.schema.org> ;
     rdfs:comment "A medical procedure involving an incision with instruments; performed for diagnose, or therapeutic purposes." ;
     rdfs:subClassOf :MedicalProcedure ;
-    owl:equivalentClass <http://purl.bioontology.org/ontology/SNOMEDCT/387713003> .
+    owl:equivalentClass <http://purl.bioontology.org/ontology/SNOMEDCT/387713003> ;
+    :isPartOf <https://health-lifesci.schema.org> .
 
 :TherapeuticProcedure a rdfs:Class ;
     rdfs:label "TherapeuticProcedure" ;
-    :isPartOf <https://health-lifesci.schema.org> ;
     rdfs:comment "A medical procedure intended primarily for therapeutic purposes, aimed at improving a health condition." ;
     rdfs:subClassOf :MedicalProcedure ;
-    owl:equivalentClass <http://purl.bioontology.org/ontology/SNOMEDCT/277132007> .
+    owl:equivalentClass <http://purl.bioontology.org/ontology/SNOMEDCT/277132007> ;
+    :isPartOf <https://health-lifesci.schema.org> .
 
 :TreatmentIndication a rdfs:Class ;
     rdfs:label "TreatmentIndication" ;
-    :isPartOf <https://health-lifesci.schema.org> ;
     rdfs:comment "An indication for treating an underlying condition, symptom, etc." ;
-    rdfs:subClassOf :MedicalIndication .
+    rdfs:subClassOf :MedicalIndication ;
+    :isPartOf <https://health-lifesci.schema.org> .
 
 :Vein a rdfs:Class ;
     rdfs:label "Vein" ;
-    :isPartOf <https://health-lifesci.schema.org> ;
     rdfs:comment "A type of blood vessel that specifically carries blood to the heart." ;
-    rdfs:subClassOf :Vessel .
+    rdfs:subClassOf :Vessel ;
+    :isPartOf <https://health-lifesci.schema.org> .
 
 :Vessel a rdfs:Class ;
     rdfs:label "Vessel" ;
-    :isPartOf <https://health-lifesci.schema.org> ;
     rdfs:comment "A component of the human body circulatory system comprised of an intricate network of hollow tubes that transport blood throughout the entire body." ;
-    rdfs:subClassOf :AnatomicalStructure .
+    rdfs:subClassOf :AnatomicalStructure ;
+    :isPartOf <https://health-lifesci.schema.org> .
 
 :VeterinaryCare a rdfs:Class ;
     rdfs:label "VeterinaryCare" ;
-    :isPartOf <https://health-lifesci.schema.org> ;
     rdfs:comment "A vet's office." ;
-    rdfs:subClassOf :MedicalOrganization .
+    rdfs:subClassOf :MedicalOrganization ;
+    :isPartOf <https://health-lifesci.schema.org> .
 
 :VitalSign a rdfs:Class ;
     rdfs:label "VitalSign" ;
-    :isPartOf <https://health-lifesci.schema.org> ;
     rdfs:comment "Vital signs are measures of various physiological functions in order to assess the most basic body functions." ;
-    rdfs:subClassOf :MedicalSign .
+    rdfs:subClassOf :MedicalSign ;
+    :isPartOf <https://health-lifesci.schema.org> .
 
 :Abdomen a :PhysicalExam ;
     rdfs:label "Abdomen" ;
-    :isPartOf <https://health-lifesci.schema.org> ;
-    rdfs:comment "Abdomen clinical examination." .
+    rdfs:comment "Abdomen clinical examination." ;
+    :isPartOf <https://health-lifesci.schema.org> .
 
 :ActiveNotRecruiting a :MedicalStudyStatus ;
     rdfs:label "ActiveNotRecruiting" ;
-    :isPartOf <https://health-lifesci.schema.org> ;
-    rdfs:comment "Active, but not recruiting new participants." .
+    rdfs:comment "Active, but not recruiting new participants." ;
+    :isPartOf <https://health-lifesci.schema.org> .
 
 :Anesthesia a :MedicalSpecialty ;
     rdfs:label "Anesthesia" ;
-    :isPartOf <https://health-lifesci.schema.org> ;
-    rdfs:comment "A specific branch of medical science that pertains to study of anesthetics and their application." .
+    rdfs:comment "A specific branch of medical science that pertains to study of anesthetics and their application." ;
+    :isPartOf <https://health-lifesci.schema.org> .
 
 :Appearance a :PhysicalExam ;
     rdfs:label "Appearance" ;
-    :isPartOf <https://health-lifesci.schema.org> ;
-    rdfs:comment "Appearance assessment with clinical examination." .
+    rdfs:comment "Appearance assessment with clinical examination." ;
+    :isPartOf <https://health-lifesci.schema.org> .
 
 :Ayurvedic a :MedicineSystem ;
     rdfs:label "Ayurvedic" ;
-    :isPartOf <https://health-lifesci.schema.org> ;
-    rdfs:comment "A system of medicine that originated in India over thousands of years and that focuses on integrating and balancing the body, mind, and spirit." .
+    rdfs:comment "A system of medicine that originated in India over thousands of years and that focuses on integrating and balancing the body, mind, and spirit." ;
+    :isPartOf <https://health-lifesci.schema.org> .
 
 :Bacteria a :InfectiousAgentClass ;
     rdfs:label "Bacteria" ;
-    :isPartOf <https://health-lifesci.schema.org> ;
-    rdfs:comment "Pathogenic bacteria that cause bacterial infection." .
+    rdfs:comment "Pathogenic bacteria that cause bacterial infection." ;
+    :isPartOf <https://health-lifesci.schema.org> .
 
 :CT a :MedicalImagingTechnique ;
     rdfs:label "CT" ;
-    :isPartOf <https://health-lifesci.schema.org> ;
-    rdfs:comment "X-ray computed tomography imaging." .
+    rdfs:comment "X-ray computed tomography imaging." ;
+    :isPartOf <https://health-lifesci.schema.org> .
 
 :Cardiovascular a :MedicalSpecialty ;
     rdfs:label "Cardiovascular" ;
-    :isPartOf <https://health-lifesci.schema.org> ;
-    rdfs:comment "A specific branch of medical science that pertains to diagnosis and treatment of disorders of heart and vasculature." .
+    rdfs:comment "A specific branch of medical science that pertains to diagnosis and treatment of disorders of heart and vasculature." ;
+    :isPartOf <https://health-lifesci.schema.org> .
 
 :CardiovascularExam a :PhysicalExam ;
     rdfs:label "CardiovascularExam" ;
-    :isPartOf <https://health-lifesci.schema.org> ;
-    rdfs:comment "Cardiovascular system assessment with clinical examination." .
+    rdfs:comment "Cardiovascular system assessment with clinical examination." ;
+    :isPartOf <https://health-lifesci.schema.org> .
 
 :CaseSeries a :MedicalObservationalStudyDesign ;
     rdfs:label "CaseSeries" ;
-    :isPartOf <https://health-lifesci.schema.org> ;
-    rdfs:comment "A case series (also known as a clinical series) is a medical research study that tracks patients with a known exposure given similar treatment or examines their medical records for exposure and outcome. A case series can be retrospective or prospective and usually involves a smaller number of patients than the more powerful case-control studies or randomized controlled trials. Case series may be consecutive or non-consecutive, depending on whether all cases presenting to the reporting authors over a period of time were included, or only a selection." .
+    rdfs:comment "A case series (also known as a clinical series) is a medical research study that tracks patients with a known exposure given similar treatment or examines their medical records for exposure and outcome. A case series can be retrospective or prospective and usually involves a smaller number of patients than the more powerful case-control studies or randomized controlled trials. Case series may be consecutive or non-consecutive, depending on whether all cases presenting to the reporting authors over a period of time were included, or only a selection." ;
+    :isPartOf <https://health-lifesci.schema.org> .
 
 :Chiropractic a :MedicineSystem ;
     rdfs:label "Chiropractic" ;
-    :isPartOf <https://health-lifesci.schema.org> ;
-    rdfs:comment "A system of medicine focused on the relationship between the body's structure, mainly the spine, and its functioning." .
+    rdfs:comment "A system of medicine focused on the relationship between the body's structure, mainly the spine, and its functioning." ;
+    :isPartOf <https://health-lifesci.schema.org> .
 
 :Clinician a :MedicalAudienceType ;
     rdfs:label "Clinician" ;
-    :isPartOf <https://health-lifesci.schema.org> ;
-    rdfs:comment "Medical clinicians, including practicing physicians and other medical professionals involved in clinical practice." .
+    rdfs:comment "Medical clinicians, including practicing physicians and other medical professionals involved in clinical practice." ;
+    :isPartOf <https://health-lifesci.schema.org> .
 
 :CohortStudy a :MedicalObservationalStudyDesign ;
     rdfs:label "CohortStudy" ;
-    :isPartOf <https://health-lifesci.schema.org> ;
-    rdfs:comment "Also known as a panel study. A cohort study is a form of longitudinal study used in medicine and social science. It is one type of study design and should be compared with a cross-sectional study.  A cohort is a group of people who share a common characteristic or experience within a defined period (e.g., are born, leave school, lose their job, are exposed to a drug or a vaccine, etc.). The comparison group may be the general population from which the cohort is drawn, or it may be another cohort of persons thought to have had little or no exposure to the substance under investigation, but otherwise similar. Alternatively, subgroups within the cohort may be compared with each other." .
+    rdfs:comment "Also known as a panel study. A cohort study is a form of longitudinal study used in medicine and social science. It is one type of study design and should be compared with a cross-sectional study.  A cohort is a group of people who share a common characteristic or experience within a defined period (e.g., are born, leave school, lose their job, are exposed to a drug or a vaccine, etc.). The comparison group may be the general population from which the cohort is drawn, or it may be another cohort of persons thought to have had little or no exposure to the substance under investigation, but otherwise similar. Alternatively, subgroups within the cohort may be compared with each other." ;
+    :isPartOf <https://health-lifesci.schema.org> .
 
 :CommunityHealth a :MedicalSpecialty ;
     rdfs:label "CommunityHealth" ;
-    :isPartOf <https://health-lifesci.schema.org> ;
     rdfs:comment "A field of public health focusing on improving health characteristics of a defined population in relation with their geographical or environment areas." ;
-    rdfs:subClassOf :MedicalBusiness .
+    rdfs:subClassOf :MedicalBusiness ;
+    :isPartOf <https://health-lifesci.schema.org> .
 
 :Completed a :MedicalStudyStatus ;
     rdfs:label "Completed" ;
-    :isPartOf <https://health-lifesci.schema.org> ;
-    rdfs:comment "Completed." .
+    rdfs:comment "Completed." ;
+    :isPartOf <https://health-lifesci.schema.org> .
 
 :CrossSectional a :MedicalObservationalStudyDesign ;
     rdfs:label "CrossSectional" ;
-    :isPartOf <https://health-lifesci.schema.org> ;
-    rdfs:comment "Studies carried out on pre-existing data (usually from 'snapshot' surveys), such as that collected by the Census Bureau. Sometimes called Prevalence Studies." .
+    rdfs:comment "Studies carried out on pre-existing data (usually from 'snapshot' surveys), such as that collected by the Census Bureau. Sometimes called Prevalence Studies." ;
+    :isPartOf <https://health-lifesci.schema.org> .
 
 :Dentistry a :MedicalSpecialty ;
     rdfs:label "Dentistry" ;
-    :isPartOf <https://health-lifesci.schema.org> ;
-    rdfs:comment "A branch of medicine that is involved in the dental care." .
+    rdfs:comment "A branch of medicine that is involved in the dental care." ;
+    :isPartOf <https://health-lifesci.schema.org> .
 
 :Dermatologic a :MedicalSpecialty ;
     rdfs:label "Dermatologic" ;
+    rdfs:comment "Something relating to or practicing dermatology." ;
     :isPartOf <https://health-lifesci.schema.org> ;
-    :supersededBy :Dermatology ;
-    rdfs:comment "Something relating to or practicing dermatology." .
+    :supersededBy :Dermatology .
 
 :Diagnostic a :MedicalDevicePurpose ;
     rdfs:label "Diagnostic" ;
-    :isPartOf <https://health-lifesci.schema.org> ;
-    rdfs:comment "A medical device used for diagnostic purposes." .
+    rdfs:comment "A medical device used for diagnostic purposes." ;
+    :isPartOf <https://health-lifesci.schema.org> .
 
 :DietNutrition a :MedicalSpecialty ;
     rdfs:label "DietNutrition" ;
-    :isPartOf <https://health-lifesci.schema.org> ;
     rdfs:comment "Dietetics and nutrition as a medical specialty." ;
-    rdfs:subClassOf :MedicalBusiness .
+    rdfs:subClassOf :MedicalBusiness ;
+    :isPartOf <https://health-lifesci.schema.org> .
 
 :DoubleBlindedTrial a :MedicalTrialDesign ;
     rdfs:label "DoubleBlindedTrial" ;
-    :isPartOf <https://health-lifesci.schema.org> ;
-    rdfs:comment "A trial design in which neither the researcher nor the patient knows the details of the treatment the patient was randomly assigned to." .
+    rdfs:comment "A trial design in which neither the researcher nor the patient knows the details of the treatment the patient was randomly assigned to." ;
+    :isPartOf <https://health-lifesci.schema.org> .
 
 :Ear a :PhysicalExam ;
     rdfs:label "Ear" ;
-    :isPartOf <https://health-lifesci.schema.org> ;
-    rdfs:comment "Ear function assessment with clinical examination." .
+    rdfs:comment "Ear function assessment with clinical examination." ;
+    :isPartOf <https://health-lifesci.schema.org> .
 
 :Emergency a :MedicalSpecialty ;
     rdfs:label "Emergency" ;
-    :isPartOf <https://health-lifesci.schema.org> ;
     rdfs:comment "A specific branch of medical science that deals with the evaluation and initial treatment of medical conditions caused by trauma or sudden illness." ;
-    rdfs:subClassOf :MedicalBusiness .
+    rdfs:subClassOf :MedicalBusiness ;
+    :isPartOf <https://health-lifesci.schema.org> .
 
 :Endocrine a :MedicalSpecialty ;
     rdfs:label "Endocrine" ;
-    :isPartOf <https://health-lifesci.schema.org> ;
-    rdfs:comment "A specific branch of medical science that pertains to diagnosis and treatment of disorders of endocrine glands and their secretions." .
+    rdfs:comment "A specific branch of medical science that pertains to diagnosis and treatment of disorders of endocrine glands and their secretions." ;
+    :isPartOf <https://health-lifesci.schema.org> .
 
 :EnrollingByInvitation a :MedicalStudyStatus ;
     rdfs:label "EnrollingByInvitation" ;
-    :isPartOf <https://health-lifesci.schema.org> ;
-    rdfs:comment "Enrolling participants by invitation only." .
+    rdfs:comment "Enrolling participants by invitation only." ;
+    :isPartOf <https://health-lifesci.schema.org> .
 
 :EvidenceLevelA a :MedicalEvidenceLevel ;
     rdfs:label "EvidenceLevelA" ;
-    :isPartOf <https://health-lifesci.schema.org> ;
-    rdfs:comment "Data derived from multiple randomized clinical trials or meta-analyses." .
+    rdfs:comment "Data derived from multiple randomized clinical trials or meta-analyses." ;
+    :isPartOf <https://health-lifesci.schema.org> .
 
 :EvidenceLevelB a :MedicalEvidenceLevel ;
     rdfs:label "EvidenceLevelB" ;
-    :isPartOf <https://health-lifesci.schema.org> ;
-    rdfs:comment "Data derived from a single randomized trial, or nonrandomized studies." .
+    rdfs:comment "Data derived from a single randomized trial, or nonrandomized studies." ;
+    :isPartOf <https://health-lifesci.schema.org> .
 
 :EvidenceLevelC a :MedicalEvidenceLevel ;
     rdfs:label "EvidenceLevelC" ;
-    :isPartOf <https://health-lifesci.schema.org> ;
-    rdfs:comment "Only consensus opinion of experts, case studies, or standard-of-care." .
+    rdfs:comment "Only consensus opinion of experts, case studies, or standard-of-care." ;
+    :isPartOf <https://health-lifesci.schema.org> .
 
 :Eye a :PhysicalExam ;
     rdfs:label "Eye" ;
-    :isPartOf <https://health-lifesci.schema.org> ;
-    rdfs:comment "Eye or ophthalmological function assessment with clinical examination." .
+    rdfs:comment "Eye or ophthalmological function assessment with clinical examination." ;
+    :isPartOf <https://health-lifesci.schema.org> .
 
 :FDAcategoryA a :DrugPregnancyCategory ;
     rdfs:label "FDAcategoryA" ;
-    :isPartOf <https://health-lifesci.schema.org> ;
-    rdfs:comment "A designation by the US FDA signifying that adequate and well-controlled studies have failed to demonstrate a risk to the fetus in the first trimester of pregnancy (and there is no evidence of risk in later trimesters)." .
+    rdfs:comment "A designation by the US FDA signifying that adequate and well-controlled studies have failed to demonstrate a risk to the fetus in the first trimester of pregnancy (and there is no evidence of risk in later trimesters)." ;
+    :isPartOf <https://health-lifesci.schema.org> .
 
 :FDAcategoryB a :DrugPregnancyCategory ;
     rdfs:label "FDAcategoryB" ;
-    :isPartOf <https://health-lifesci.schema.org> ;
-    rdfs:comment "A designation by the US FDA signifying that animal reproduction studies have failed to demonstrate a risk to the fetus and there are no adequate and well-controlled studies in pregnant women." .
+    rdfs:comment "A designation by the US FDA signifying that animal reproduction studies have failed to demonstrate a risk to the fetus and there are no adequate and well-controlled studies in pregnant women." ;
+    :isPartOf <https://health-lifesci.schema.org> .
 
 :FDAcategoryC a :DrugPregnancyCategory ;
     rdfs:label "FDAcategoryC" ;
-    :isPartOf <https://health-lifesci.schema.org> ;
-    rdfs:comment "A designation by the US FDA signifying that animal reproduction studies have shown an adverse effect on the fetus and there are no adequate and well-controlled studies in humans, but potential benefits may warrant use of the drug in pregnant women despite potential risks." .
+    rdfs:comment "A designation by the US FDA signifying that animal reproduction studies have shown an adverse effect on the fetus and there are no adequate and well-controlled studies in humans, but potential benefits may warrant use of the drug in pregnant women despite potential risks." ;
+    :isPartOf <https://health-lifesci.schema.org> .
 
 :FDAcategoryD a :DrugPregnancyCategory ;
     rdfs:label "FDAcategoryD" ;
-    :isPartOf <https://health-lifesci.schema.org> ;
-    rdfs:comment "A designation by the US FDA signifying that there is positive evidence of human fetal risk based on adverse reaction data from investigational or marketing experience or studies in humans, but potential benefits may warrant use of the drug in pregnant women despite potential risks." .
+    rdfs:comment "A designation by the US FDA signifying that there is positive evidence of human fetal risk based on adverse reaction data from investigational or marketing experience or studies in humans, but potential benefits may warrant use of the drug in pregnant women despite potential risks." ;
+    :isPartOf <https://health-lifesci.schema.org> .
 
 :FDAcategoryX a :DrugPregnancyCategory ;
     rdfs:label "FDAcategoryX" ;
-    :isPartOf <https://health-lifesci.schema.org> ;
-    rdfs:comment "A designation by the US FDA signifying that studies in animals or humans have demonstrated fetal abnormalities and/or there is positive evidence of human fetal risk based on adverse reaction data from investigational or marketing experience, and the risks involved in use of the drug in pregnant women clearly outweigh potential benefits." .
+    rdfs:comment "A designation by the US FDA signifying that studies in animals or humans have demonstrated fetal abnormalities and/or there is positive evidence of human fetal risk based on adverse reaction data from investigational or marketing experience, and the risks involved in use of the drug in pregnant women clearly outweigh potential benefits." ;
+    :isPartOf <https://health-lifesci.schema.org> .
 
 :FDAnotEvaluated a :DrugPregnancyCategory ;
     rdfs:label "FDAnotEvaluated" ;
-    :isPartOf <https://health-lifesci.schema.org> ;
-    rdfs:comment "A designation that the drug in question has not been assigned a pregnancy category designation by the US FDA." .
+    rdfs:comment "A designation that the drug in question has not been assigned a pregnancy category designation by the US FDA." ;
+    :isPartOf <https://health-lifesci.schema.org> .
 
 :Fungus a :InfectiousAgentClass ;
     rdfs:label "Fungus" ;
-    :isPartOf <https://health-lifesci.schema.org> ;
-    rdfs:comment "Pathogenic fungus." .
+    rdfs:comment "Pathogenic fungus." ;
+    :isPartOf <https://health-lifesci.schema.org> .
 
 :Gastroenterologic a :MedicalSpecialty ;
     rdfs:label "Gastroenterologic" ;
-    :isPartOf <https://health-lifesci.schema.org> ;
-    rdfs:comment "A specific branch of medical science that pertains to diagnosis and treatment of disorders of digestive system." .
+    rdfs:comment "A specific branch of medical science that pertains to diagnosis and treatment of disorders of digestive system." ;
+    :isPartOf <https://health-lifesci.schema.org> .
 
 :Genetic a :MedicalSpecialty ;
     rdfs:label "Genetic" ;
-    :isPartOf <https://health-lifesci.schema.org> ;
-    rdfs:comment "A specific branch of medical science that pertains to hereditary transmission and the variation of inherited characteristics and disorders." .
+    rdfs:comment "A specific branch of medical science that pertains to hereditary transmission and the variation of inherited characteristics and disorders." ;
+    :isPartOf <https://health-lifesci.schema.org> .
 
 :Genitourinary a :PhysicalExam ;
     rdfs:label "Genitourinary" ;
-    :isPartOf <https://health-lifesci.schema.org> ;
-    rdfs:comment "Genitourinary system function assessment with clinical examination." .
+    rdfs:comment "Genitourinary system function assessment with clinical examination." ;
+    :isPartOf <https://health-lifesci.schema.org> .
 
 :Geriatric a :MedicalSpecialty ;
     rdfs:label "Geriatric" ;
-    :isPartOf <https://health-lifesci.schema.org> ;
     rdfs:comment "A specific branch of medical science that is concerned with the diagnosis and treatment of diseases, debilities and provision of care to the aged." ;
-    rdfs:subClassOf :MedicalBusiness .
+    rdfs:subClassOf :MedicalBusiness ;
+    :isPartOf <https://health-lifesci.schema.org> .
 
 :Gynecologic a :MedicalSpecialty ;
     rdfs:label "Gynecologic" ;
-    :isPartOf <https://health-lifesci.schema.org> ;
     rdfs:comment "A specific branch of medical science that pertains to the health care of women, particularly in the diagnosis and treatment of disorders affecting the female reproductive system." ;
-    rdfs:subClassOf :MedicalBusiness .
+    rdfs:subClassOf :MedicalBusiness ;
+    :isPartOf <https://health-lifesci.schema.org> .
 
 :Head a :PhysicalExam ;
     rdfs:label "Head" ;
-    :isPartOf <https://health-lifesci.schema.org> ;
-    rdfs:comment "Head assessment with clinical examination." .
+    rdfs:comment "Head assessment with clinical examination." ;
+    :isPartOf <https://health-lifesci.schema.org> .
 
 :Hematologic a :MedicalSpecialty ;
     rdfs:label "Hematologic" ;
-    :isPartOf <https://health-lifesci.schema.org> ;
-    rdfs:comment "A specific branch of medical science that pertains to diagnosis and treatment of disorders of blood and blood producing organs." .
+    rdfs:comment "A specific branch of medical science that pertains to diagnosis and treatment of disorders of blood and blood producing organs." ;
+    :isPartOf <https://health-lifesci.schema.org> .
 
 :Homeopathic a :MedicineSystem ;
     rdfs:label "Homeopathic" ;
-    :isPartOf <https://health-lifesci.schema.org> ;
-    rdfs:comment "A system of medicine based on the principle that a disease can be cured by a substance that produces similar symptoms in healthy people." .
+    rdfs:comment "A system of medicine based on the principle that a disease can be cured by a substance that produces similar symptoms in healthy people." ;
+    :isPartOf <https://health-lifesci.schema.org> .
 
 :Infectious a :MedicalSpecialty ;
     rdfs:label "Infectious" ;
-    :isPartOf <https://health-lifesci.schema.org> ;
-    rdfs:comment "Something in medical science that pertains to infectious diseases, i.e. caused by bacterial, viral, fungal or parasitic infections." .
+    rdfs:comment "Something in medical science that pertains to infectious diseases, i.e. caused by bacterial, viral, fungal or parasitic infections." ;
+    :isPartOf <https://health-lifesci.schema.org> .
 
 :InternationalTrial a :MedicalTrialDesign ;
     rdfs:label "InternationalTrial" ;
-    :isPartOf <https://health-lifesci.schema.org> ;
-    rdfs:comment "An international trial." .
+    rdfs:comment "An international trial." ;
+    :isPartOf <https://health-lifesci.schema.org> .
 
 :LaboratoryScience a :MedicalSpecialty ;
     rdfs:label "LaboratoryScience" ;
-    :isPartOf <https://health-lifesci.schema.org> ;
-    rdfs:comment "A medical science pertaining to chemical, hematological, immunologic, microscopic, or bacteriological diagnostic analyses or research." .
+    rdfs:comment "A medical science pertaining to chemical, hematological, immunologic, microscopic, or bacteriological diagnostic analyses or research." ;
+    :isPartOf <https://health-lifesci.schema.org> .
 
 :Longitudinal a :MedicalObservationalStudyDesign ;
     rdfs:label "Longitudinal" ;
-    :isPartOf <https://health-lifesci.schema.org> ;
-    rdfs:comment "Unlike cross-sectional studies, longitudinal studies track the same people, and therefore the differences observed in those people are less likely to be the result of cultural differences across generations. Longitudinal studies are also used in medicine to uncover predictors of certain diseases." .
+    rdfs:comment "Unlike cross-sectional studies, longitudinal studies track the same people, and therefore the differences observed in those people are less likely to be the result of cultural differences across generations. Longitudinal studies are also used in medicine to uncover predictors of certain diseases." ;
+    :isPartOf <https://health-lifesci.schema.org> .
 
 :Lung a :PhysicalExam ;
     rdfs:label "Lung" ;
-    :isPartOf <https://health-lifesci.schema.org> ;
-    rdfs:comment "Lung and respiratory system clinical examination." .
+    rdfs:comment "Lung and respiratory system clinical examination." ;
+    :isPartOf <https://health-lifesci.schema.org> .
 
 :MRI a :MedicalImagingTechnique ;
     rdfs:label "MRI" ;
-    :isPartOf <https://health-lifesci.schema.org> ;
-    rdfs:comment "Magnetic resonance imaging." .
+    rdfs:comment "Magnetic resonance imaging." ;
+    :isPartOf <https://health-lifesci.schema.org> .
 
 :MedicalResearcher a :MedicalAudienceType ;
     rdfs:label "MedicalResearcher" ;
-    :isPartOf <https://health-lifesci.schema.org> ;
-    rdfs:comment "Medical researchers." .
+    rdfs:comment "Medical researchers." ;
+    :isPartOf <https://health-lifesci.schema.org> .
 
 :Midwifery a :MedicalSpecialty ;
     rdfs:label "Midwifery" ;
-    :isPartOf <https://health-lifesci.schema.org> ;
     rdfs:comment "A nurse-like health profession that deals with pregnancy, childbirth, and the postpartum period (including care of the newborn), besides sexual and reproductive health of women throughout their lives." ;
-    rdfs:subClassOf :MedicalBusiness .
+    rdfs:subClassOf :MedicalBusiness ;
+    :isPartOf <https://health-lifesci.schema.org> .
 
 :MultiCenterTrial a :MedicalTrialDesign ;
     rdfs:label "MultiCenterTrial" ;
-    :isPartOf <https://health-lifesci.schema.org> ;
-    rdfs:comment "A trial that takes place at multiple centers." .
+    rdfs:comment "A trial that takes place at multiple centers." ;
+    :isPartOf <https://health-lifesci.schema.org> .
 
 :MulticellularParasite a :InfectiousAgentClass ;
     rdfs:label "MulticellularParasite" ;
-    :isPartOf <https://health-lifesci.schema.org> ;
-    rdfs:comment "Multicellular parasite that causes an infection." .
+    rdfs:comment "Multicellular parasite that causes an infection." ;
+    :isPartOf <https://health-lifesci.schema.org> .
 
 :Musculoskeletal a :MedicalSpecialty ;
     rdfs:label "Musculoskeletal" ;
-    :isPartOf <https://health-lifesci.schema.org> ;
-    rdfs:comment "A specific branch of medical science that pertains to diagnosis and treatment of disorders of muscles, ligaments and skeletal system." .
+    rdfs:comment "A specific branch of medical science that pertains to diagnosis and treatment of disorders of muscles, ligaments and skeletal system." ;
+    :isPartOf <https://health-lifesci.schema.org> .
 
 :MusculoskeletalExam a :PhysicalExam ;
     rdfs:label "MusculoskeletalExam" ;
-    :isPartOf <https://health-lifesci.schema.org> ;
-    rdfs:comment "Musculoskeletal system clinical examination." .
+    rdfs:comment "Musculoskeletal system clinical examination." ;
+    :isPartOf <https://health-lifesci.schema.org> .
 
 :Neck a :PhysicalExam ;
     rdfs:label "Neck" ;
-    :isPartOf <https://health-lifesci.schema.org> ;
-    rdfs:comment "Neck assessment with clinical examination." .
+    rdfs:comment "Neck assessment with clinical examination." ;
+    :isPartOf <https://health-lifesci.schema.org> .
 
 :Neuro a :PhysicalExam ;
     rdfs:label "Neuro" ;
-    :isPartOf <https://health-lifesci.schema.org> ;
-    rdfs:comment "Neurological system clinical examination." .
+    rdfs:comment "Neurological system clinical examination." ;
+    :isPartOf <https://health-lifesci.schema.org> .
 
 :Neurologic a :MedicalSpecialty ;
     rdfs:label "Neurologic" ;
-    :isPartOf <https://health-lifesci.schema.org> ;
-    rdfs:comment "A specific branch of medical science that studies the nerves and nervous system and its respective disease states." .
+    rdfs:comment "A specific branch of medical science that studies the nerves and nervous system and its respective disease states." ;
+    :isPartOf <https://health-lifesci.schema.org> .
 
 :NoninvasiveProcedure a :MedicalProcedureType ;
     rdfs:label "NoninvasiveProcedure" ;
-    :isPartOf <https://health-lifesci.schema.org> ;
-    rdfs:comment "A type of medical procedure that involves noninvasive techniques." .
+    rdfs:comment "A type of medical procedure that involves noninvasive techniques." ;
+    :isPartOf <https://health-lifesci.schema.org> .
 
 :Nose a :PhysicalExam ;
     rdfs:label "Nose" ;
-    :isPartOf <https://health-lifesci.schema.org> ;
-    rdfs:comment "Nose function assessment with clinical examination." .
+    rdfs:comment "Nose function assessment with clinical examination." ;
+    :isPartOf <https://health-lifesci.schema.org> .
 
 :NotYetRecruiting a :MedicalStudyStatus ;
     rdfs:label "NotYetRecruiting" ;
-    :isPartOf <https://health-lifesci.schema.org> ;
-    rdfs:comment "Not yet recruiting." .
+    rdfs:comment "Not yet recruiting." ;
+    :isPartOf <https://health-lifesci.schema.org> .
 
 :Nursing a :MedicalSpecialty ;
     rdfs:label "Nursing" ;
-    :isPartOf <https://health-lifesci.schema.org> ;
     rdfs:comment "A health profession of a person formally educated and trained in the care of the sick or infirm person." ;
-    rdfs:subClassOf :MedicalBusiness .
+    rdfs:subClassOf :MedicalBusiness ;
+    :isPartOf <https://health-lifesci.schema.org> .
 
 :OTC a :DrugPrescriptionStatus ;
     rdfs:label "OTC" ;
-    :isPartOf <https://health-lifesci.schema.org> ;
-    rdfs:comment "The character of a medical substance, typically a medicine, of being available over the counter or not." .
+    rdfs:comment "The character of a medical substance, typically a medicine, of being available over the counter or not." ;
+    :isPartOf <https://health-lifesci.schema.org> .
 
 :Observational a :MedicalObservationalStudyDesign ;
     rdfs:label "Observational" ;
-    :isPartOf <https://health-lifesci.schema.org> ;
-    rdfs:comment "An observational study design." .
+    rdfs:comment "An observational study design." ;
+    :isPartOf <https://health-lifesci.schema.org> .
 
 :Obstetric a :MedicalSpecialty ;
     rdfs:label "Obstetric" ;
-    :isPartOf <https://health-lifesci.schema.org> ;
     rdfs:comment "A specific branch of medical science that specializes in the care of women during the prenatal and postnatal care and with the delivery of the child." ;
-    rdfs:subClassOf :MedicalBusiness .
+    rdfs:subClassOf :MedicalBusiness ;
+    :isPartOf <https://health-lifesci.schema.org> .
 
 :Oncologic a :MedicalSpecialty ;
     rdfs:label "Oncologic" ;
-    :isPartOf <https://health-lifesci.schema.org> ;
     rdfs:comment "A specific branch of medical science that deals with benign and malignant tumors, including the study of their development, diagnosis, treatment and prevention." ;
-    rdfs:subClassOf :MedicalBusiness .
+    rdfs:subClassOf :MedicalBusiness ;
+    :isPartOf <https://health-lifesci.schema.org> .
 
 :OpenTrial a :MedicalTrialDesign ;
     rdfs:label "OpenTrial" ;
-    :isPartOf <https://health-lifesci.schema.org> ;
-    rdfs:comment "A trial design in which the researcher knows the full details of the treatment, and so does the patient." .
+    rdfs:comment "A trial design in which the researcher knows the full details of the treatment, and so does the patient." ;
+    :isPartOf <https://health-lifesci.schema.org> .
 
 :Optometric a :MedicalSpecialty ;
     rdfs:label "Optometric" ;
-    :isPartOf <https://health-lifesci.schema.org> ;
     rdfs:comment "The science or practice of testing visual acuity and prescribing corrective lenses." ;
-    rdfs:subClassOf :MedicalBusiness .
+    rdfs:subClassOf :MedicalBusiness ;
+    :isPartOf <https://health-lifesci.schema.org> .
 
 :Osteopathic a :MedicineSystem ;
     rdfs:label "Osteopathic" ;
-    :isPartOf <https://health-lifesci.schema.org> ;
-    rdfs:comment "A system of medicine focused on promoting the body's innate ability to heal itself." .
+    rdfs:comment "A system of medicine focused on promoting the body's innate ability to heal itself." ;
+    :isPartOf <https://health-lifesci.schema.org> .
 
 :Otolaryngologic a :MedicalSpecialty ;
     rdfs:label "Otolaryngologic" ;
-    :isPartOf <https://health-lifesci.schema.org> ;
     rdfs:comment "A specific branch of medical science that is concerned with the ear, nose and throat and their respective disease states." ;
-    rdfs:subClassOf :MedicalBusiness .
+    rdfs:subClassOf :MedicalBusiness ;
+    :isPartOf <https://health-lifesci.schema.org> .
 
 :PET a :MedicalImagingTechnique ;
     rdfs:label "PET" ;
-    :isPartOf <https://health-lifesci.schema.org> ;
-    rdfs:comment "Positron emission tomography imaging." .
+    rdfs:comment "Positron emission tomography imaging." ;
+    :isPartOf <https://health-lifesci.schema.org> .
 
 :Pathology a :MedicalSpecialty ;
     rdfs:label "Pathology" ;
-    :isPartOf <https://health-lifesci.schema.org> ;
-    rdfs:comment "A specific branch of medical science that is concerned with the study of the cause, origin and nature of a disease state, including its consequences as a result of manifestation of the disease. In clinical care, the term is used to designate a branch of medicine using laboratory tests to diagnose and determine the prognostic significance of illness." .
+    rdfs:comment "A specific branch of medical science that is concerned with the study of the cause, origin and nature of a disease state, including its consequences as a result of manifestation of the disease. In clinical care, the term is used to designate a branch of medicine using laboratory tests to diagnose and determine the prognostic significance of illness." ;
+    :isPartOf <https://health-lifesci.schema.org> .
 
 :Pediatric a :MedicalSpecialty ;
     rdfs:label "Pediatric" ;
-    :isPartOf <https://health-lifesci.schema.org> ;
     rdfs:comment "A specific branch of medical science that specializes in the care of infants, children and adolescents." ;
-    rdfs:subClassOf :MedicalBusiness .
+    rdfs:subClassOf :MedicalBusiness ;
+    :isPartOf <https://health-lifesci.schema.org> .
 
 :PercutaneousProcedure a :MedicalProcedureType ;
     rdfs:label "PercutaneousProcedure" ;
-    :isPartOf <https://health-lifesci.schema.org> ;
-    rdfs:comment "A type of medical procedure that involves percutaneous techniques, where access to organs or tissue is achieved via needle-puncture of the skin. For example, catheter-based procedures like stent delivery." .
+    rdfs:comment "A type of medical procedure that involves percutaneous techniques, where access to organs or tissue is achieved via needle-puncture of the skin. For example, catheter-based procedures like stent delivery." ;
+    :isPartOf <https://health-lifesci.schema.org> .
 
 :PharmacySpecialty a :MedicalSpecialty ;
     rdfs:label "PharmacySpecialty" ;
-    :isPartOf <https://health-lifesci.schema.org> ;
-    rdfs:comment "The practice or art and science of preparing and dispensing drugs and medicines." .
+    rdfs:comment "The practice or art and science of preparing and dispensing drugs and medicines." ;
+    :isPartOf <https://health-lifesci.schema.org> .
 
 :Physiotherapy a :MedicalSpecialty ;
     rdfs:label "Physiotherapy" ;
-    :isPartOf <https://health-lifesci.schema.org> ;
     rdfs:comment "The practice of treatment of disease, injury, or deformity by physical methods such as massage, heat treatment, and exercise rather than by drugs or surgery." ;
-    rdfs:subClassOf :MedicalBusiness .
+    rdfs:subClassOf :MedicalBusiness ;
+    :isPartOf <https://health-lifesci.schema.org> .
 
 :PlaceboControlledTrial a :MedicalTrialDesign ;
     rdfs:label "PlaceboControlledTrial" ;
-    :isPartOf <https://health-lifesci.schema.org> ;
-    rdfs:comment "A placebo-controlled trial design." .
+    rdfs:comment "A placebo-controlled trial design." ;
+    :isPartOf <https://health-lifesci.schema.org> .
 
 :PlasticSurgery a :MedicalSpecialty ;
     rdfs:label "PlasticSurgery" ;
-    :isPartOf <https://health-lifesci.schema.org> ;
     rdfs:comment "A specific branch of medical science that pertains to therapeutic or cosmetic repair or re-formation of missing, injured or malformed tissues or body parts by manual and instrumental means." ;
-    rdfs:subClassOf :MedicalBusiness .
+    rdfs:subClassOf :MedicalBusiness ;
+    :isPartOf <https://health-lifesci.schema.org> .
 
 :Podiatric a :MedicalSpecialty ;
     rdfs:label "Podiatric" ;
-    :isPartOf <https://health-lifesci.schema.org> ;
     rdfs:comment "Podiatry is the care of the human foot, especially the diagnosis and treatment of foot disorders." ;
-    rdfs:subClassOf :MedicalBusiness .
+    rdfs:subClassOf :MedicalBusiness ;
+    :isPartOf <https://health-lifesci.schema.org> .
 
 :PrescriptionOnly a :DrugPrescriptionStatus ;
     rdfs:label "PrescriptionOnly" ;
-    :isPartOf <https://health-lifesci.schema.org> ;
-    rdfs:comment "Available by prescription only." .
+    rdfs:comment "Available by prescription only." ;
+    :isPartOf <https://health-lifesci.schema.org> .
 
 :PrimaryCare a :MedicalSpecialty ;
     rdfs:label "PrimaryCare" ;
-    :isPartOf <https://health-lifesci.schema.org> ;
     rdfs:comment "The medical care by a physician, or other health-care professional, who is the patient's first contact with the health-care system and who may recommend a specialist if necessary." ;
-    rdfs:subClassOf :MedicalBusiness .
+    rdfs:subClassOf :MedicalBusiness ;
+    :isPartOf <https://health-lifesci.schema.org> .
 
 :Prion a :InfectiousAgentClass ;
     rdfs:label "Prion" ;
-    :isPartOf <https://health-lifesci.schema.org> ;
-    rdfs:comment "A prion is an infectious agent composed of protein in a misfolded form." .
+    rdfs:comment "A prion is an infectious agent composed of protein in a misfolded form." ;
+    :isPartOf <https://health-lifesci.schema.org> .
 
 :Protozoa a :InfectiousAgentClass ;
     rdfs:label "Protozoa" ;
-    :isPartOf <https://health-lifesci.schema.org> ;
-    rdfs:comment "Single-celled organism that causes an infection." .
+    rdfs:comment "Single-celled organism that causes an infection." ;
+    :isPartOf <https://health-lifesci.schema.org> .
 
 :Psychiatric a :MedicalSpecialty ;
     rdfs:label "Psychiatric" ;
-    :isPartOf <https://health-lifesci.schema.org> ;
     rdfs:comment "A specific branch of medical science that is concerned with the study, treatment, and prevention of mental illness, using both medical and psychological therapies." ;
-    rdfs:subClassOf :MedicalBusiness .
+    rdfs:subClassOf :MedicalBusiness ;
+    :isPartOf <https://health-lifesci.schema.org> .
 
 :PublicHealth a :MedicalSpecialty ;
     rdfs:label "PublicHealth" ;
-    :isPartOf <https://health-lifesci.schema.org> ;
     rdfs:comment "Branch of medicine that pertains to the health services to improve and protect community health, especially epidemiology, sanitation, immunization, and preventive medicine." ;
-    rdfs:subClassOf :MedicalBusiness .
+    rdfs:subClassOf :MedicalBusiness ;
+    :isPartOf <https://health-lifesci.schema.org> .
 
 :Pulmonary a :MedicalSpecialty ;
     rdfs:label "Pulmonary" ;
-    :isPartOf <https://health-lifesci.schema.org> ;
-    rdfs:comment "A specific branch of medical science that pertains to the study of the respiratory system and its respective disease states." .
+    rdfs:comment "A specific branch of medical science that pertains to the study of the respiratory system and its respective disease states." ;
+    :isPartOf <https://health-lifesci.schema.org> .
 
 :Radiography a :MedicalImagingTechnique,
         :MedicalSpecialty ;
     rdfs:label "Radiography" ;
-    :isPartOf <https://health-lifesci.schema.org> ;
-    rdfs:comment "Radiography is an imaging technique that uses electromagnetic radiation other than visible light, especially X-rays, to view the internal structure of a non-uniformly composed and opaque object such as the human body." .
+    rdfs:comment "Radiography is an imaging technique that uses electromagnetic radiation other than visible light, especially X-rays, to view the internal structure of a non-uniformly composed and opaque object such as the human body." ;
+    :isPartOf <https://health-lifesci.schema.org> .
 
 :RandomizedTrial a :MedicalTrialDesign ;
     rdfs:label "RandomizedTrial" ;
-    :isPartOf <https://health-lifesci.schema.org> ;
-    rdfs:comment "A randomized trial design." .
+    rdfs:comment "A randomized trial design." ;
+    :isPartOf <https://health-lifesci.schema.org> .
 
 :Recruiting a :MedicalStudyStatus ;
     rdfs:label "Recruiting" ;
-    :isPartOf <https://health-lifesci.schema.org> ;
-    rdfs:comment "Recruiting participants." .
+    rdfs:comment "Recruiting participants." ;
+    :isPartOf <https://health-lifesci.schema.org> .
 
 :Registry a :MedicalObservationalStudyDesign ;
     rdfs:label "Registry" ;
-    :isPartOf <https://health-lifesci.schema.org> ;
-    rdfs:comment "A registry-based study design." .
+    rdfs:comment "A registry-based study design." ;
+    :isPartOf <https://health-lifesci.schema.org> .
 
 :ReimbursementCap a :DrugCostCategory ;
     rdfs:label "ReimbursementCap" ;
-    :isPartOf <https://health-lifesci.schema.org> ;
-    rdfs:comment "The drug's cost represents the maximum reimbursement paid by an insurer for the drug." .
+    rdfs:comment "The drug's cost represents the maximum reimbursement paid by an insurer for the drug." ;
+    :isPartOf <https://health-lifesci.schema.org> .
 
 :Renal a :MedicalSpecialty ;
     rdfs:label "Renal" ;
-    :isPartOf <https://health-lifesci.schema.org> ;
-    rdfs:comment "A specific branch of medical science that pertains to the study of the kidneys and its respective disease states." .
+    rdfs:comment "A specific branch of medical science that pertains to the study of the kidneys and its respective disease states." ;
+    :isPartOf <https://health-lifesci.schema.org> .
 
 :RespiratoryTherapy a :MedicalSpecialty ;
     rdfs:label "RespiratoryTherapy" ;
-    :isPartOf <https://health-lifesci.schema.org> ;
     rdfs:comment "The therapy that is concerned with the maintenance or improvement of respiratory function (as in patients with pulmonary disease)." ;
-    rdfs:subClassOf :MedicalTherapy .
+    rdfs:subClassOf :MedicalTherapy ;
+    :isPartOf <https://health-lifesci.schema.org> .
 
 :ResultsAvailable a :MedicalStudyStatus ;
     rdfs:label "ResultsAvailable" ;
-    :isPartOf <https://health-lifesci.schema.org> ;
-    rdfs:comment "Results are available." .
+    rdfs:comment "Results are available." ;
+    :isPartOf <https://health-lifesci.schema.org> .
 
 :ResultsNotAvailable a :MedicalStudyStatus ;
     rdfs:label "ResultsNotAvailable" ;
-    :isPartOf <https://health-lifesci.schema.org> ;
-    rdfs:comment "Results are not available." .
+    rdfs:comment "Results are not available." ;
+    :isPartOf <https://health-lifesci.schema.org> .
 
 :Retail a :DrugCostCategory ;
     rdfs:label "Retail" ;
-    :isPartOf <https://health-lifesci.schema.org> ;
-    rdfs:comment "The drug's cost represents the retail cost of the drug." .
+    rdfs:comment "The drug's cost represents the retail cost of the drug." ;
+    :isPartOf <https://health-lifesci.schema.org> .
 
 :Rheumatologic a :MedicalSpecialty ;
     rdfs:label "Rheumatologic" ;
-    :isPartOf <https://health-lifesci.schema.org> ;
-    rdfs:comment "A specific branch of medical science that deals with the study and treatment of rheumatic, autoimmune or joint diseases." .
+    rdfs:comment "A specific branch of medical science that deals with the study and treatment of rheumatic, autoimmune or joint diseases." ;
+    :isPartOf <https://health-lifesci.schema.org> .
 
 :SingleBlindedTrial a :MedicalTrialDesign ;
     rdfs:label "SingleBlindedTrial" ;
-    :isPartOf <https://health-lifesci.schema.org> ;
-    rdfs:comment "A trial design in which the researcher knows which treatment the patient was randomly assigned to but the patient does not." .
+    rdfs:comment "A trial design in which the researcher knows which treatment the patient was randomly assigned to but the patient does not." ;
+    :isPartOf <https://health-lifesci.schema.org> .
 
 :SingleCenterTrial a :MedicalTrialDesign ;
     rdfs:label "SingleCenterTrial" ;
-    :isPartOf <https://health-lifesci.schema.org> ;
-    rdfs:comment "A trial that takes place at a single center." .
+    rdfs:comment "A trial that takes place at a single center." ;
+    :isPartOf <https://health-lifesci.schema.org> .
 
 :Skin a :PhysicalExam ;
     rdfs:label "Skin" ;
-    :isPartOf <https://health-lifesci.schema.org> ;
-    rdfs:comment "Skin assessment with clinical examination." .
+    rdfs:comment "Skin assessment with clinical examination." ;
+    :isPartOf <https://health-lifesci.schema.org> .
 
 :SpeechPathology a :MedicalSpecialty ;
     rdfs:label "SpeechPathology" ;
-    :isPartOf <https://health-lifesci.schema.org> ;
-    rdfs:comment "The scientific study and treatment of defects, disorders, and malfunctions of speech and voice, as stuttering, lisping, or lalling, and of language disturbances, as aphasia or delayed language acquisition." .
+    rdfs:comment "The scientific study and treatment of defects, disorders, and malfunctions of speech and voice, as stuttering, lisping, or lalling, and of language disturbances, as aphasia or delayed language acquisition." ;
+    :isPartOf <https://health-lifesci.schema.org> .
 
 :Surgical a :MedicalSpecialty ;
     rdfs:label "Surgical" ;
-    :isPartOf <https://health-lifesci.schema.org> ;
-    rdfs:comment "A specific branch of medical science that pertains to treating diseases, injuries and deformities by manual and instrumental means." .
+    rdfs:comment "A specific branch of medical science that pertains to treating diseases, injuries and deformities by manual and instrumental means." ;
+    :isPartOf <https://health-lifesci.schema.org> .
 
 :Suspended a :MedicalStudyStatus ;
     rdfs:label "Suspended" ;
-    :isPartOf <https://health-lifesci.schema.org> ;
-    rdfs:comment "Suspended." .
+    rdfs:comment "Suspended." ;
+    :isPartOf <https://health-lifesci.schema.org> .
 
 :Terminated a :MedicalStudyStatus ;
     rdfs:label "Terminated" ;
-    :isPartOf <https://health-lifesci.schema.org> ;
-    rdfs:comment "Terminated." .
+    rdfs:comment "Terminated." ;
+    :isPartOf <https://health-lifesci.schema.org> .
 
 :Therapeutic a :MedicalDevicePurpose ;
     rdfs:label "Therapeutic" ;
-    :isPartOf <https://health-lifesci.schema.org> ;
-    rdfs:comment "A medical device used for therapeutic purposes." .
+    rdfs:comment "A medical device used for therapeutic purposes." ;
+    :isPartOf <https://health-lifesci.schema.org> .
 
 :Throat a :PhysicalExam ;
     rdfs:label "Throat" ;
-    :isPartOf <https://health-lifesci.schema.org> ;
-    rdfs:comment "Throat assessment with  clinical examination." .
+    rdfs:comment "Throat assessment with  clinical examination." ;
+    :isPartOf <https://health-lifesci.schema.org> .
 
 :Toxicologic a :MedicalSpecialty ;
     rdfs:label "Toxicologic" ;
-    :isPartOf <https://health-lifesci.schema.org> ;
-    rdfs:comment "A specific branch of medical science that is concerned with poisons, their nature, effects and detection and involved in the treatment of poisoning." .
+    rdfs:comment "A specific branch of medical science that is concerned with poisons, their nature, effects and detection and involved in the treatment of poisoning." ;
+    :isPartOf <https://health-lifesci.schema.org> .
 
 :TraditionalChinese a :MedicineSystem ;
     rdfs:label "TraditionalChinese" ;
-    :isPartOf <https://health-lifesci.schema.org> ;
-    rdfs:comment "A system of medicine based on common theoretical concepts that originated in China and evolved over thousands of years, that uses herbs, acupuncture, exercise, massage, dietary therapy, and other methods to treat a wide range of conditions." .
+    rdfs:comment "A system of medicine based on common theoretical concepts that originated in China and evolved over thousands of years, that uses herbs, acupuncture, exercise, massage, dietary therapy, and other methods to treat a wide range of conditions." ;
+    :isPartOf <https://health-lifesci.schema.org> .
 
 :TripleBlindedTrial a :MedicalTrialDesign ;
     rdfs:label "TripleBlindedTrial" ;
-    :isPartOf <https://health-lifesci.schema.org> ;
-    rdfs:comment "A trial design in which neither the researcher, the person administering the therapy nor the patient knows the details of the treatment the patient was randomly assigned to." .
+    rdfs:comment "A trial design in which neither the researcher, the person administering the therapy nor the patient knows the details of the treatment the patient was randomly assigned to." ;
+    :isPartOf <https://health-lifesci.schema.org> .
 
 :Ultrasound a :MedicalImagingTechnique ;
     rdfs:label "Ultrasound" ;
-    :isPartOf <https://health-lifesci.schema.org> ;
-    rdfs:comment "Ultrasound imaging." .
+    rdfs:comment "Ultrasound imaging." ;
+    :isPartOf <https://health-lifesci.schema.org> .
 
 :Urologic a :MedicalSpecialty ;
     rdfs:label "Urologic" ;
-    :isPartOf <https://health-lifesci.schema.org> ;
-    rdfs:comment "A specific branch of medical science that is concerned with the diagnosis and treatment of diseases pertaining to the urinary tract and the urogenital system." .
+    rdfs:comment "A specific branch of medical science that is concerned with the diagnosis and treatment of diseases pertaining to the urinary tract and the urogenital system." ;
+    :isPartOf <https://health-lifesci.schema.org> .
 
 :Virus a :InfectiousAgentClass ;
     rdfs:label "Virus" ;
-    :isPartOf <https://health-lifesci.schema.org> ;
-    rdfs:comment "Pathogenic virus that causes viral infection." .
+    rdfs:comment "Pathogenic virus that causes viral infection." ;
+    :isPartOf <https://health-lifesci.schema.org> .
 
 :WesternConventional a :MedicineSystem ;
     rdfs:label "WesternConventional" ;
-    :isPartOf <https://health-lifesci.schema.org> ;
-    rdfs:comment "The conventional Western system of medicine, that aims to apply the best available evidence gained from the scientific method to clinical decision making. Also known as conventional or Western medicine." .
+    rdfs:comment "The conventional Western system of medicine, that aims to apply the best available evidence gained from the scientific method to clinical decision making. Also known as conventional or Western medicine." ;
+    :isPartOf <https://health-lifesci.schema.org> .
 
 :Wholesale a :DrugCostCategory ;
     rdfs:label "Wholesale" ;
-    :isPartOf <https://health-lifesci.schema.org> ;
-    rdfs:comment "The drug's cost represents the wholesale acquisition cost of the drug." .
+    rdfs:comment "The drug's cost represents the wholesale acquisition cost of the drug." ;
+    :isPartOf <https://health-lifesci.schema.org> .
 
 :Withdrawn a :MedicalStudyStatus ;
     rdfs:label "Withdrawn" ;
-    :isPartOf <https://health-lifesci.schema.org> ;
-    rdfs:comment "Withdrawn." .
+    rdfs:comment "Withdrawn." ;
+    :isPartOf <https://health-lifesci.schema.org> .
 
 :XRay a :MedicalImagingTechnique ;
     rdfs:label "XRay" ;
-    :isPartOf <https://health-lifesci.schema.org> ;
-    rdfs:comment "X-ray imaging." .
+    rdfs:comment "X-ray imaging." ;
+    :isPartOf <https://health-lifesci.schema.org> .
 
 :activeIngredient a rdf:Property ;
     rdfs:label "activeIngredient" ;
+    rdfs:comment "An active ingredient, typically chemical compounds and/or biologic substances." ;
     :domainIncludes :DietarySupplement,
         :Drug,
         :DrugStrength,
         :Substance ;
     :isPartOf <https://health-lifesci.schema.org> ;
-    :rangeIncludes :Text ;
-    rdfs:comment "An active ingredient, typically chemical compounds and/or biologic substances." .
+    :rangeIncludes :Text .
 
 :administrationRoute a rdf:Property ;
     rdfs:label "administrationRoute" ;
+    rdfs:comment "A route by which this drug may be administered, e.g. 'oral'." ;
     :domainIncludes :Drug ;
     :isPartOf <https://health-lifesci.schema.org> ;
-    :rangeIncludes :Text ;
-    rdfs:comment "A route by which this drug may be administered, e.g. 'oral'." .
+    :rangeIncludes :Text .
 
 :adverseOutcome a rdf:Property ;
     rdfs:label "adverseOutcome" ;
+    rdfs:comment "A possible complication and/or side effect of this therapy. If it is known that an adverse outcome is serious (resulting in death, disability, or permanent damage; requiring hospitalization; or otherwise life-threatening or requiring immediate medical attention), tag it as a seriousAdverseOutcome instead." ;
     :domainIncludes :MedicalDevice,
         :TherapeuticProcedure ;
     :isPartOf <https://health-lifesci.schema.org> ;
-    :rangeIncludes :MedicalEntity ;
-    rdfs:comment "A possible complication and/or side effect of this therapy. If it is known that an adverse outcome is serious (resulting in death, disability, or permanent damage; requiring hospitalization; or otherwise life-threatening or requiring immediate medical attention), tag it as a seriousAdverseOutcome instead." .
+    :rangeIncludes :MedicalEntity .
 
 :affectedBy a rdf:Property ;
     rdfs:label "affectedBy" ;
+    rdfs:comment "Drugs that affect the test's results." ;
     :domainIncludes :MedicalTest ;
     :isPartOf <https://health-lifesci.schema.org> ;
-    :rangeIncludes :Drug ;
-    rdfs:comment "Drugs that affect the test's results." .
+    :rangeIncludes :Drug .
 
 :alcoholWarning a rdf:Property ;
     rdfs:label "alcoholWarning" ;
+    rdfs:comment "Any precaution, guidance, contraindication, etc. related to consumption of alcohol while taking this drug." ;
     :domainIncludes :Drug ;
     :isPartOf <https://health-lifesci.schema.org> ;
-    :rangeIncludes :Text ;
-    rdfs:comment "Any precaution, guidance, contraindication, etc. related to consumption of alcohol while taking this drug." .
+    :rangeIncludes :Text .
 
 :algorithm a rdf:Property ;
     rdfs:label "algorithm" ;
+    rdfs:comment "The algorithm or rules to follow to compute the score." ;
     :domainIncludes :MedicalRiskScore ;
     :isPartOf <https://health-lifesci.schema.org> ;
-    :rangeIncludes :Text ;
-    rdfs:comment "The algorithm or rules to follow to compute the score." .
+    :rangeIncludes :Text .
 
 :antagonist a rdf:Property ;
     rdfs:label "antagonist" ;
+    rdfs:comment "The muscle whose action counteracts the specified muscle." ;
     :domainIncludes :Muscle ;
     :isPartOf <https://health-lifesci.schema.org> ;
-    :rangeIncludes :Muscle ;
-    rdfs:comment "The muscle whose action counteracts the specified muscle." .
+    :rangeIncludes :Muscle .
 
 :applicableLocation a rdf:Property ;
     rdfs:label "applicableLocation" ;
+    rdfs:comment "The location in which the status applies." ;
     :domainIncludes :DrugCost,
         :DrugLegalStatus ;
     :isPartOf <https://health-lifesci.schema.org> ;
-    :rangeIncludes :AdministrativeArea ;
-    rdfs:comment "The location in which the status applies." .
+    :rangeIncludes :AdministrativeArea .
 
 :aspect a rdf:Property ;
     rdfs:label "aspect" ;
+    rdfs:comment "An aspect of medical practice that is considered on the page, such as 'diagnosis', 'treatment', 'causes', 'prognosis', 'etiology', 'epidemiology', etc." ;
     :domainIncludes :MedicalWebPage ;
     :isPartOf <https://health-lifesci.schema.org> ;
     :rangeIncludes :Text ;
-    :supersededBy :mainContentOfPage ;
-    rdfs:comment "An aspect of medical practice that is considered on the page, such as 'diagnosis', 'treatment', 'causes', 'prognosis', 'etiology', 'epidemiology', etc." .
+    :supersededBy :mainContentOfPage .
 
 :associatedAnatomy a rdf:Property ;
     rdfs:label "associatedAnatomy" ;
+    rdfs:comment "The anatomy of the underlying organ system or structures associated with this entity." ;
     :domainIncludes :MedicalCondition,
         :PhysicalActivity ;
     :isPartOf <https://health-lifesci.schema.org> ;
     :rangeIncludes :AnatomicalStructure,
         :AnatomicalSystem,
-        :SuperficialAnatomy ;
-    rdfs:comment "The anatomy of the underlying organ system or structures associated with this entity." .
+        :SuperficialAnatomy .
 
 :associatedPathophysiology a rdf:Property ;
     rdfs:label "associatedPathophysiology" ;
+    rdfs:comment "If applicable, a description of the pathophysiology associated with the anatomical system, including potential abnormal changes in the mechanical, physical, and biochemical functions of the system." ;
     :domainIncludes :AnatomicalStructure,
         :AnatomicalSystem,
         :SuperficialAnatomy ;
     :isPartOf <https://health-lifesci.schema.org> ;
-    :rangeIncludes :Text ;
-    rdfs:comment "If applicable, a description of the pathophysiology associated with the anatomical system, including potential abnormal changes in the mechanical, physical, and biochemical functions of the system." .
+    :rangeIncludes :Text .
 
 :availableIn a rdf:Property ;
     rdfs:label "availableIn" ;
+    rdfs:comment "The location in which the strength is available." ;
     :domainIncludes :DrugStrength ;
     :isPartOf <https://health-lifesci.schema.org> ;
-    :rangeIncludes :AdministrativeArea ;
-    rdfs:comment "The location in which the strength is available." .
+    :rangeIncludes :AdministrativeArea .
 
 :availableService a rdf:Property ;
     rdfs:label "availableService" ;
+    rdfs:comment "A medical service available from this provider." ;
     :domainIncludes :Hospital,
         :MedicalClinic,
         :Physician ;
     :isPartOf <https://health-lifesci.schema.org> ;
     :rangeIncludes :MedicalProcedure,
         :MedicalTest,
-        :MedicalTherapy ;
-    rdfs:comment "A medical service available from this provider." .
+        :MedicalTherapy .
 
 :availableStrength a rdf:Property ;
     rdfs:label "availableStrength" ;
+    rdfs:comment "An available dosage strength for the drug." ;
     :domainIncludes :Drug ;
     :isPartOf <https://health-lifesci.schema.org> ;
-    :rangeIncludes :DrugStrength ;
-    rdfs:comment "An available dosage strength for the drug." .
+    :rangeIncludes :DrugStrength .
 
 :availableTest a rdf:Property ;
     rdfs:label "availableTest" ;
+    rdfs:comment "A diagnostic test or procedure offered by this lab." ;
     :domainIncludes :DiagnosticLab ;
     :isPartOf <https://health-lifesci.schema.org> ;
-    :rangeIncludes :MedicalTest ;
-    rdfs:comment "A diagnostic test or procedure offered by this lab." .
+    :rangeIncludes :MedicalTest .
 
 :biomechnicalClass a rdf:Property ;
     rdfs:label "biomechnicalClass" ;
+    rdfs:comment "The biomechanical properties of the bone." ;
     :domainIncludes :Joint ;
     :isPartOf <https://health-lifesci.schema.org> ;
-    :rangeIncludes :Text ;
-    rdfs:comment "The biomechanical properties of the bone." .
+    :rangeIncludes :Text .
 
 :bloodSupply a rdf:Property ;
     rdfs:label "bloodSupply" ;
+    rdfs:comment "The blood vessel that carries blood from the heart to the muscle." ;
     :domainIncludes :Muscle ;
     :isPartOf <https://health-lifesci.schema.org> ;
-    :rangeIncludes :Vessel ;
-    rdfs:comment "The blood vessel that carries blood from the heart to the muscle." .
+    :rangeIncludes :Vessel .
 
 :bodyLocation a rdf:Property ;
     rdfs:label "bodyLocation" ;
+    rdfs:comment "Location in the body of the anatomical structure." ;
     :domainIncludes :AnatomicalStructure,
         :MedicalProcedure ;
     :isPartOf <https://health-lifesci.schema.org> ;
-    :rangeIncludes :Text ;
-    rdfs:comment "Location in the body of the anatomical structure." .
+    :rangeIncludes :Text .
 
 :branch a rdf:Property ;
     rdfs:label "branch" ;
+    rdfs:comment "The branches that delineate from the nerve bundle. Not to be confused with [[branchOf]]." ;
     :domainIncludes :Nerve ;
     :isPartOf <https://health-lifesci.schema.org> ;
     :rangeIncludes :AnatomicalStructure ;
-    :supersededBy :arterialBranch;
-    rdfs:comment "The branches that delineate from the nerve bundle. Not to be confused with [[branchOf]]." .
+    :supersededBy :arterialBranch .
 
 :breastfeedingWarning a rdf:Property ;
     rdfs:label "breastfeedingWarning" ;
+    rdfs:comment "Any precaution, guidance, contraindication, etc. related to this drug's use by breastfeeding mothers." ;
     :domainIncludes :Drug ;
     :isPartOf <https://health-lifesci.schema.org> ;
-    :rangeIncludes :Text ;
-    rdfs:comment "Any precaution, guidance, contraindication, etc. related to this drug's use by breastfeeding mothers." .
+    :rangeIncludes :Text .
 
 :causeOf a rdf:Property ;
     rdfs:label "causeOf" ;
+    rdfs:comment "The condition, complication, symptom, sign, etc. caused." ;
     :domainIncludes :MedicalCause ;
     :isPartOf <https://health-lifesci.schema.org> ;
-    :rangeIncludes :MedicalEntity ;
-    rdfs:comment "The condition, complication, symptom, sign, etc. caused." .
+    :rangeIncludes :MedicalEntity .
 
 :clincalPharmacology a rdf:Property ;
     rdfs:label "clincalPharmacology" ;
+    rdfs:comment "Description of the absorption and elimination of drugs, including their concentration (pharmacokinetics, pK) and biological effects (pharmacodynamics, pD)." ;
     :domainIncludes :Drug ;
     :isPartOf <https://health-lifesci.schema.org> ;
     :rangeIncludes :Text ;
-    :supersededBy :clinicalPharmacology ;
-    rdfs:comment "Description of the absorption and elimination of drugs, including their concentration (pharmacokinetics, pK) and biological effects (pharmacodynamics, pD)." .
+    :supersededBy :clinicalPharmacology .
 
 :code a rdf:Property ;
     rdfs:label "code" ;
+    rdfs:comment "A medical code for the entity, taken from a controlled vocabulary or ontology such as ICD-9, DiseasesDB, MeSH, SNOMED-CT, RxNorm, etc." ;
     :domainIncludes :MedicalEntity ;
     :isPartOf <https://health-lifesci.schema.org> ;
-    :rangeIncludes :MedicalCode ;
-    rdfs:comment "A medical code for the entity, taken from a controlled vocabulary or ontology such as ICD-9, DiseasesDB, MeSH, SNOMED-CT, RxNorm, etc." .
+    :rangeIncludes :MedicalCode .
 
 :codeValue a rdf:Property ;
     rdfs:label "codeValue" ;
@@ -1383,786 +1383,786 @@
 
 :codingSystem a rdf:Property ;
     rdfs:label "codingSystem" ;
+    rdfs:comment "The coding system, e.g. 'ICD-10'." ;
     :domainIncludes :MedicalCode ;
     :isPartOf <https://health-lifesci.schema.org> ;
-    :rangeIncludes :Text ;
-    rdfs:comment "The coding system, e.g. 'ICD-10'." .
+    :rangeIncludes :Text .
 
 :comprisedOf a rdf:Property ;
     rdfs:label "comprisedOf" ;
+    rdfs:comment "Specifying something physically contained by something else. Typically used here for the underlying anatomical structures, such as organs, that comprise the anatomical system." ;
     :domainIncludes :AnatomicalSystem ;
     :isPartOf <https://health-lifesci.schema.org> ;
     :rangeIncludes :AnatomicalStructure,
-        :AnatomicalSystem ;
-    rdfs:comment "Specifying something physically contained by something else. Typically used here for the underlying anatomical structures, such as organs, that comprise the anatomical system." .
+        :AnatomicalSystem .
 
 :connectedTo a rdf:Property ;
     rdfs:label "connectedTo" ;
+    rdfs:comment "Other anatomical structures to which this structure is connected." ;
     :domainIncludes :AnatomicalStructure ;
     :isPartOf <https://health-lifesci.schema.org> ;
-    :rangeIncludes :AnatomicalStructure ;
-    rdfs:comment "Other anatomical structures to which this structure is connected." .
+    :rangeIncludes :AnatomicalStructure .
 
 :contraindication a rdf:Property ;
     rdfs:label "contraindication" ;
+    rdfs:comment "A contraindication for this therapy." ;
     :domainIncludes :MedicalDevice,
         :MedicalTherapy ;
     :isPartOf <https://health-lifesci.schema.org> ;
     :rangeIncludes :MedicalContraindication,
-        :Text ;
-    rdfs:comment "A contraindication for this therapy." .
+        :Text .
 
 :costCategory a rdf:Property ;
     rdfs:label "costCategory" ;
+    rdfs:comment "The category of cost, such as wholesale, retail, reimbursement cap, etc." ;
     :domainIncludes :DrugCost ;
     :isPartOf <https://health-lifesci.schema.org> ;
-    :rangeIncludes :DrugCostCategory ;
-    rdfs:comment "The category of cost, such as wholesale, retail, reimbursement cap, etc." .
+    :rangeIncludes :DrugCostCategory .
 
 :costCurrency a rdf:Property ;
     rdfs:label "costCurrency" ;
+    rdfs:comment "The currency (in 3-letter) of the drug cost. See: http://en.wikipedia.org/wiki/ISO_4217. " ;
     :domainIncludes :DrugCost ;
     :isPartOf <https://health-lifesci.schema.org> ;
-    :rangeIncludes :Text ;
-    rdfs:comment "The currency (in 3-letter) of the drug cost. See: http://en.wikipedia.org/wiki/ISO_4217. " .
+    :rangeIncludes :Text .
 
 :costOrigin a rdf:Property ;
     rdfs:label "costOrigin" ;
+    rdfs:comment "Additional details to capture the origin of the cost data. For example, 'Medicare Part B'." ;
     :domainIncludes :DrugCost ;
     :isPartOf <https://health-lifesci.schema.org> ;
-    :rangeIncludes :Text ;
-    rdfs:comment "Additional details to capture the origin of the cost data. For example, 'Medicare Part B'." .
+    :rangeIncludes :Text .
 
 :costPerUnit a rdf:Property ;
     rdfs:label "costPerUnit" ;
+    rdfs:comment "The cost per unit of the drug." ;
     :domainIncludes :DrugCost ;
     :isPartOf <https://health-lifesci.schema.org> ;
     :rangeIncludes :Number,
         :QualitativeValue,
-        :Text ;
-    rdfs:comment "The cost per unit of the drug." .
+        :Text .
 
 :diagnosis a rdf:Property ;
     rdfs:label "diagnosis" ;
+    rdfs:comment "One or more alternative conditions considered in the differential diagnosis process as output of a diagnosis process." ;
     :domainIncludes :DDxElement,
         :Patient ;
     :isPartOf <https://health-lifesci.schema.org> ;
-    :rangeIncludes :MedicalCondition ;
-    rdfs:comment "One or more alternative conditions considered in the differential diagnosis process as output of a diagnosis process." .
+    :rangeIncludes :MedicalCondition .
 
 :diagram a rdf:Property ;
     rdfs:label "diagram" ;
+    rdfs:comment "An image containing a diagram that illustrates the structure and/or its component substructures and/or connections with other structures." ;
     :domainIncludes :AnatomicalStructure ;
     :isPartOf <https://health-lifesci.schema.org> ;
-    :rangeIncludes :ImageObject ;
-    rdfs:comment "An image containing a diagram that illustrates the structure and/or its component substructures and/or connections with other structures." .
+    :rangeIncludes :ImageObject .
 
 :diet a rdf:Property ;
     rdfs:label "diet" ;
+    rdfs:comment "A sub property of instrument. The diet used in this action." ;
+    rdfs:subPropertyOf :instrument ;
     :domainIncludes :ExerciseAction ;
     :isPartOf <https://health-lifesci.schema.org> ;
-    :rangeIncludes :Diet ;
-    rdfs:comment "A sub property of instrument. The diet used in this action." ;
-    rdfs:subPropertyOf :instrument .
+    :rangeIncludes :Diet .
 
 :dietFeatures a rdf:Property ;
     rdfs:label "dietFeatures" ;
+    rdfs:comment "Nutritional information specific to the dietary plan. May include dietary recommendations on what foods to avoid, what foods to consume, and specific alterations/deviations from the USDA or other regulatory body's approved dietary guidelines." ;
     :domainIncludes :Diet ;
     :isPartOf <https://health-lifesci.schema.org> ;
-    :rangeIncludes :Text ;
-    rdfs:comment "Nutritional information specific to the dietary plan. May include dietary recommendations on what foods to avoid, what foods to consume, and specific alterations/deviations from the USDA or other regulatory body's approved dietary guidelines." .
+    :rangeIncludes :Text .
 
 :differentialDiagnosis a rdf:Property ;
     rdfs:label "differentialDiagnosis" ;
+    rdfs:comment "One of a set of differential diagnoses for the condition. Specifically, a closely-related or competing diagnosis typically considered later in the cognitive process whereby this medical condition is distinguished from others most likely responsible for a similar collection of signs and symptoms to reach the most parsimonious diagnosis or diagnoses in a patient." ;
     :domainIncludes :MedicalCondition ;
     :isPartOf <https://health-lifesci.schema.org> ;
-    :rangeIncludes :DDxElement ;
-    rdfs:comment "One of a set of differential diagnoses for the condition. Specifically, a closely-related or competing diagnosis typically considered later in the cognitive process whereby this medical condition is distinguished from others most likely responsible for a similar collection of signs and symptoms to reach the most parsimonious diagnosis or diagnoses in a patient." .
+    :rangeIncludes :DDxElement .
 
 :distinguishingSign a rdf:Property ;
     rdfs:label "distinguishingSign" ;
+    rdfs:comment "One of a set of signs and symptoms that can be used to distinguish this diagnosis from others in the differential diagnosis." ;
     :domainIncludes :DDxElement ;
     :isPartOf <https://health-lifesci.schema.org> ;
-    :rangeIncludes :MedicalSignOrSymptom ;
-    rdfs:comment "One of a set of signs and symptoms that can be used to distinguish this diagnosis from others in the differential diagnosis." .
+    :rangeIncludes :MedicalSignOrSymptom .
 
 :dosageForm a rdf:Property ;
     rdfs:label "dosageForm" ;
+    rdfs:comment "A dosage form in which this drug/supplement is available, e.g. 'tablet', 'suspension', 'injection'." ;
     :domainIncludes :Drug ;
     :isPartOf <https://health-lifesci.schema.org> ;
-    :rangeIncludes :Text ;
-    rdfs:comment "A dosage form in which this drug/supplement is available, e.g. 'tablet', 'suspension', 'injection'." .
+    :rangeIncludes :Text .
 
 :doseSchedule a rdf:Property ;
     rdfs:label "doseSchedule" ;
+    rdfs:comment "A dosing schedule for the drug for a given population, either observed, recommended, or maximum dose based on the type used." ;
     :domainIncludes :Drug,
         :TherapeuticProcedure ;
     :isPartOf <https://health-lifesci.schema.org> ;
-    :rangeIncludes :DoseSchedule ;
-    rdfs:comment "A dosing schedule for the drug for a given population, either observed, recommended, or maximum dose based on the type used." .
+    :rangeIncludes :DoseSchedule .
 
 :doseUnit a rdf:Property ;
     rdfs:label "doseUnit" ;
+    rdfs:comment "The unit of the dose, e.g. 'mg'." ;
     :domainIncludes :DoseSchedule ;
     :isPartOf <https://health-lifesci.schema.org> ;
-    :rangeIncludes :Text ;
-    rdfs:comment "The unit of the dose, e.g. 'mg'." .
+    :rangeIncludes :Text .
 
 :doseValue a rdf:Property ;
     rdfs:label "doseValue" ;
+    rdfs:comment "The value of the dose, e.g. 500." ;
     :domainIncludes :DoseSchedule ;
     :isPartOf <https://health-lifesci.schema.org> ;
     :rangeIncludes :Number,
-        :QualitativeValue ;
-    rdfs:comment "The value of the dose, e.g. 500." .
+        :QualitativeValue .
 
 :drainsTo a rdf:Property ;
     rdfs:label "drainsTo" ;
+    rdfs:comment "The vasculature that the vein drains into." ;
     :domainIncludes :Vein ;
     :isPartOf <https://health-lifesci.schema.org> ;
-    :rangeIncludes :Vessel ;
-    rdfs:comment "The vasculature that the vein drains into." .
+    :rangeIncludes :Vessel .
 
 :drug a rdf:Property ;
     rdfs:label "drug" ;
+    rdfs:comment "Specifying a drug or medicine used in a medication procedure." ;
     :domainIncludes :DrugClass,
         :MedicalCondition,
         :Patient,
         :TherapeuticProcedure ;
     :isPartOf <https://health-lifesci.schema.org> ;
-    :rangeIncludes :Drug ;
-    rdfs:comment "Specifying a drug or medicine used in a medication procedure." .
+    :rangeIncludes :Drug .
 
 :drugClass a rdf:Property ;
     rdfs:label "drugClass" ;
+    rdfs:comment "The class of drug this belongs to (e.g., statins)." ;
     :domainIncludes :Drug ;
     :isPartOf <https://health-lifesci.schema.org> ;
-    :rangeIncludes :DrugClass ;
-    rdfs:comment "The class of drug this belongs to (e.g., statins)." .
+    :rangeIncludes :DrugClass .
 
 :drugUnit a rdf:Property ;
     rdfs:label "drugUnit" ;
+    rdfs:comment "The unit in which the drug is measured, e.g. '5 mg tablet'." ;
     :domainIncludes :Drug,
         :DrugCost ;
     :isPartOf <https://health-lifesci.schema.org> ;
-    :rangeIncludes :Text ;
-    rdfs:comment "The unit in which the drug is measured, e.g. '5 mg tablet'." .
+    :rangeIncludes :Text .
 
 :duplicateTherapy a rdf:Property ;
     rdfs:label "duplicateTherapy" ;
+    rdfs:comment "A therapy that duplicates or overlaps this one." ;
     :domainIncludes :MedicalTherapy ;
     :isPartOf <https://health-lifesci.schema.org> ;
-    :rangeIncludes :MedicalTherapy ;
-    rdfs:comment "A therapy that duplicates or overlaps this one." .
+    :rangeIncludes :MedicalTherapy .
 
 :endorsers a rdf:Property ;
     rdfs:label "endorsers" ;
+    rdfs:comment "People or organizations that endorse the plan." ;
     :domainIncludes :Diet ;
     :isPartOf <https://health-lifesci.schema.org> ;
     :rangeIncludes :Organization,
-        :Person ;
-    rdfs:comment "People or organizations that endorse the plan." .
+        :Person .
 
 :epidemiology a rdf:Property ;
     rdfs:label "epidemiology" ;
+    rdfs:comment "The characteristics of associated patients, such as age, gender, race etc." ;
     :domainIncludes :MedicalCondition,
         :PhysicalActivity ;
     :isPartOf <https://health-lifesci.schema.org> ;
-    :rangeIncludes :Text ;
-    rdfs:comment "The characteristics of associated patients, such as age, gender, race etc." .
+    :rangeIncludes :Text .
 
 :estimatesRiskOf a rdf:Property ;
     rdfs:label "estimatesRiskOf" ;
+    rdfs:comment "The condition, complication, or symptom whose risk is being estimated." ;
     :domainIncludes :MedicalRiskEstimator ;
     :isPartOf <https://health-lifesci.schema.org> ;
-    :rangeIncludes :MedicalEntity ;
-    rdfs:comment "The condition, complication, or symptom whose risk is being estimated." .
+    :rangeIncludes :MedicalEntity .
 
 :evidenceLevel a rdf:Property ;
     rdfs:label "evidenceLevel" ;
+    rdfs:comment "Strength of evidence of the data used to formulate the guideline (enumerated)." ;
     :domainIncludes :MedicalGuideline ;
     :isPartOf <https://health-lifesci.schema.org> ;
-    :rangeIncludes :MedicalEvidenceLevel ;
-    rdfs:comment "Strength of evidence of the data used to formulate the guideline (enumerated)." .
+    :rangeIncludes :MedicalEvidenceLevel .
 
 :evidenceOrigin a rdf:Property ;
     rdfs:label "evidenceOrigin" ;
+    rdfs:comment "Source of the data used to formulate the guidance, e.g. RCT, consensus opinion, etc." ;
     :domainIncludes :MedicalGuideline ;
     :isPartOf <https://health-lifesci.schema.org> ;
-    :rangeIncludes :Text ;
-    rdfs:comment "Source of the data used to formulate the guidance, e.g. RCT, consensus opinion, etc." .
+    :rangeIncludes :Text .
 
 :exerciseRelatedDiet a rdf:Property ;
     rdfs:label "exerciseRelatedDiet" ;
+    rdfs:comment "A sub property of instrument. The diet used in this action." ;
+    rdfs:subPropertyOf :instrument ;
     :domainIncludes :ExerciseAction ;
     :isPartOf <https://health-lifesci.schema.org> ;
-    :rangeIncludes :Diet ;
-    rdfs:comment "A sub property of instrument. The diet used in this action." ;
-    rdfs:subPropertyOf :instrument .
+    :rangeIncludes :Diet .
 
 :expectedPrognosis a rdf:Property ;
     rdfs:label "expectedPrognosis" ;
+    rdfs:comment "The likely outcome in either the short term or long term of the medical condition." ;
     :domainIncludes :MedicalCondition ;
     :isPartOf <https://health-lifesci.schema.org> ;
-    :rangeIncludes :Text ;
-    rdfs:comment "The likely outcome in either the short term or long term of the medical condition." .
+    :rangeIncludes :Text .
 
 :expertConsiderations a rdf:Property ;
     rdfs:label "expertConsiderations" ;
+    rdfs:comment "Medical expert advice related to the plan." ;
     :domainIncludes :Diet ;
     :isPartOf <https://health-lifesci.schema.org> ;
-    :rangeIncludes :Text ;
-    rdfs:comment "Medical expert advice related to the plan." .
+    :rangeIncludes :Text .
 
 :followup a rdf:Property ;
     rdfs:label "followup" ;
+    rdfs:comment "Typical or recommended followup care after the procedure is performed." ;
     :domainIncludes :MedicalProcedure ;
     :isPartOf <https://health-lifesci.schema.org> ;
-    :rangeIncludes :Text ;
-    rdfs:comment "Typical or recommended followup care after the procedure is performed." .
+    :rangeIncludes :Text .
 
 :foodWarning a rdf:Property ;
     rdfs:label "foodWarning" ;
+    rdfs:comment "Any precaution, guidance, contraindication, etc. related to consumption of specific foods while taking this drug." ;
     :domainIncludes :Drug ;
     :isPartOf <https://health-lifesci.schema.org> ;
-    :rangeIncludes :Text ;
-    rdfs:comment "Any precaution, guidance, contraindication, etc. related to consumption of specific foods while taking this drug." .
+    :rangeIncludes :Text .
 
 :frequency a rdf:Property ;
     rdfs:label "frequency" ;
+    rdfs:comment "How often the dose is taken, e.g. 'daily'." ;
     :domainIncludes :DoseSchedule ;
     :isPartOf <https://health-lifesci.schema.org> ;
-    :rangeIncludes :Text ;
-    rdfs:comment "How often the dose is taken, e.g. 'daily'." .
+    :rangeIncludes :Text .
 
 :functionalClass a rdf:Property ;
     rdfs:label "functionalClass" ;
+    rdfs:comment "The degree of mobility the joint allows." ;
     :domainIncludes :Joint ;
     :isPartOf <https://health-lifesci.schema.org> ;
     :rangeIncludes :MedicalEntity,
-        :Text ;
-    rdfs:comment "The degree of mobility the joint allows." .
+        :Text .
 
 :guideline a rdf:Property ;
     rdfs:label "guideline" ;
+    rdfs:comment "A medical guideline related to this entity." ;
     :domainIncludes :MedicalEntity ;
     :isPartOf <https://health-lifesci.schema.org> ;
-    :rangeIncludes :MedicalGuideline ;
-    rdfs:comment "A medical guideline related to this entity." .
+    :rangeIncludes :MedicalGuideline .
 
 :guidelineDate a rdf:Property ;
     rdfs:label "guidelineDate" ;
+    rdfs:comment "Date on which this guideline's recommendation was made." ;
     :domainIncludes :MedicalGuideline ;
     :isPartOf <https://health-lifesci.schema.org> ;
-    :rangeIncludes :Date ;
-    rdfs:comment "Date on which this guideline's recommendation was made." .
+    :rangeIncludes :Date .
 
 :guidelineSubject a rdf:Property ;
     rdfs:label "guidelineSubject" ;
+    rdfs:comment "The medical conditions, treatments, etc. that are the subject of the guideline." ;
     :domainIncludes :MedicalGuideline ;
     :isPartOf <https://health-lifesci.schema.org> ;
-    :rangeIncludes :MedicalEntity ;
-    rdfs:comment "The medical conditions, treatments, etc. that are the subject of the guideline." .
+    :rangeIncludes :MedicalEntity .
 
 :healthCondition a rdf:Property ;
     rdfs:label "healthCondition" ;
+    rdfs:comment "Specifying the health condition(s) of a patient, medical study, or other target audience." ;
     :domainIncludes :MedicalStudy,
         :Patient,
         :PeopleAudience ;
     :isPartOf <https://health-lifesci.schema.org> ;
-    :rangeIncludes :MedicalCondition ;
-    rdfs:comment "Specifying the health condition(s) of a patient, medical study, or other target audience." .
+    :rangeIncludes :MedicalCondition .
 
 :hospitalAffiliation a rdf:Property ;
     rdfs:label "hospitalAffiliation" ;
+    rdfs:comment "A hospital with which the physician or office is affiliated." ;
     :domainIncludes :Physician ;
     :isPartOf <https://health-lifesci.schema.org> ;
-    :rangeIncludes :Hospital ;
-    rdfs:comment "A hospital with which the physician or office is affiliated." .
+    :rangeIncludes :Hospital .
 
 :howPerformed a rdf:Property ;
     rdfs:label "howPerformed" ;
+    rdfs:comment "How the procedure is performed." ;
     :domainIncludes :MedicalProcedure ;
     :isPartOf <https://health-lifesci.schema.org> ;
-    :rangeIncludes :Text ;
-    rdfs:comment "How the procedure is performed." .
+    :rangeIncludes :Text .
 
 :identifyingExam a rdf:Property ;
     rdfs:label "identifyingExam" ;
+    rdfs:comment "A physical examination that can identify this sign." ;
     :domainIncludes :MedicalSign ;
     :isPartOf <https://health-lifesci.schema.org> ;
-    :rangeIncludes :PhysicalExam ;
-    rdfs:comment "A physical examination that can identify this sign." .
+    :rangeIncludes :PhysicalExam .
 
 :identifyingTest a rdf:Property ;
     rdfs:label "identifyingTest" ;
+    rdfs:comment "A diagnostic test that can identify this sign." ;
     :domainIncludes :MedicalSign ;
     :isPartOf <https://health-lifesci.schema.org> ;
-    :rangeIncludes :MedicalTest ;
-    rdfs:comment "A diagnostic test that can identify this sign." .
+    :rangeIncludes :MedicalTest .
 
 :imagingTechnique a rdf:Property ;
     rdfs:label "imagingTechnique" ;
+    rdfs:comment "Imaging technique used." ;
     :domainIncludes :ImagingTest ;
     :isPartOf <https://health-lifesci.schema.org> ;
-    :rangeIncludes :MedicalImagingTechnique ;
-    rdfs:comment "Imaging technique used." .
+    :rangeIncludes :MedicalImagingTechnique .
 
 :includedRiskFactor a rdf:Property ;
     rdfs:label "includedRiskFactor" ;
+    rdfs:comment "A modifiable or non-modifiable risk factor included in the calculation, e.g. age, coexisting condition." ;
     :domainIncludes :MedicalRiskEstimator ;
     :isPartOf <https://health-lifesci.schema.org> ;
-    :rangeIncludes :MedicalRiskFactor ;
-    rdfs:comment "A modifiable or non-modifiable risk factor included in the calculation, e.g. age, coexisting condition." .
+    :rangeIncludes :MedicalRiskFactor .
 
 :increasesRiskOf a rdf:Property ;
     rdfs:label "increasesRiskOf" ;
+    rdfs:comment "The condition, complication, etc. influenced by this factor." ;
     :domainIncludes :MedicalRiskFactor ;
     :isPartOf <https://health-lifesci.schema.org> ;
-    :rangeIncludes :MedicalEntity ;
-    rdfs:comment "The condition, complication, etc. influenced by this factor." .
+    :rangeIncludes :MedicalEntity .
 
 :infectiousAgent a rdf:Property ;
     rdfs:label "infectiousAgent" ;
+    rdfs:comment "The actual infectious agent, such as a specific bacterium." ;
     :domainIncludes :InfectiousDisease ;
     :isPartOf <https://health-lifesci.schema.org> ;
-    :rangeIncludes :Text ;
-    rdfs:comment "The actual infectious agent, such as a specific bacterium." .
+    :rangeIncludes :Text .
 
 :infectiousAgentClass a rdf:Property ;
     rdfs:label "infectiousAgentClass" ;
+    rdfs:comment "The class of infectious agent (bacteria, prion, etc.) that causes the disease." ;
     :domainIncludes :InfectiousDisease ;
     :isPartOf <https://health-lifesci.schema.org> ;
-    :rangeIncludes :InfectiousAgentClass ;
-    rdfs:comment "The class of infectious agent (bacteria, prion, etc.) that causes the disease." .
+    :rangeIncludes :InfectiousAgentClass .
 
 :insertion a rdf:Property ;
     rdfs:label "insertion" ;
+    rdfs:comment "The place of attachment of a muscle, or what the muscle moves." ;
     :domainIncludes :Muscle ;
     :isPartOf <https://health-lifesci.schema.org> ;
-    :rangeIncludes :AnatomicalStructure ;
-    rdfs:comment "The place of attachment of a muscle, or what the muscle moves." .
+    :rangeIncludes :AnatomicalStructure .
 
 :interactingDrug a rdf:Property ;
     rdfs:label "interactingDrug" ;
+    rdfs:comment "Another drug that is known to interact with this drug in a way that impacts the effect of this drug or causes a risk to the patient. Note: disease interactions are typically captured as contraindications." ;
     :domainIncludes :Drug ;
     :isPartOf <https://health-lifesci.schema.org> ;
-    :rangeIncludes :Drug ;
-    rdfs:comment "Another drug that is known to interact with this drug in a way that impacts the effect of this drug or causes a risk to the patient. Note: disease interactions are typically captured as contraindications." .
+    :rangeIncludes :Drug .
 
 :isAvailableGenerically a rdf:Property ;
     rdfs:label "isAvailableGenerically" ;
+    rdfs:comment "True if the drug is available in a generic form (regardless of name)." ;
     :domainIncludes :Drug ;
     :isPartOf <https://health-lifesci.schema.org> ;
-    :rangeIncludes :Boolean ;
-    rdfs:comment "True if the drug is available in a generic form (regardless of name)." .
+    :rangeIncludes :Boolean .
 
 :isProprietary a rdf:Property ;
     rdfs:label "isProprietary" ;
+    rdfs:comment "True if this item's name is a proprietary/brand name (vs. generic name)." ;
     :domainIncludes :DietarySupplement,
         :Drug ;
     :isPartOf <https://health-lifesci.schema.org> ;
-    :rangeIncludes :Boolean ;
-    rdfs:comment "True if this item's name is a proprietary/brand name (vs. generic name)." .
+    :rangeIncludes :Boolean .
 
 :labelDetails a rdf:Property ;
     rdfs:label "labelDetails" ;
+    rdfs:comment "Link to the drug's label details." ;
     :domainIncludes :Drug ;
     :isPartOf <https://health-lifesci.schema.org> ;
-    :rangeIncludes :URL ;
-    rdfs:comment "Link to the drug's label details." .
+    :rangeIncludes :URL .
 
 :legalStatus a rdf:Property ;
     rdfs:label "legalStatus" ;
+    rdfs:comment "The drug or supplement's legal status, including any controlled substance schedules that apply." ;
     :domainIncludes :DietarySupplement,
         :Drug,
         :MedicalEntity ;
     :isPartOf <https://health-lifesci.schema.org> ;
     :rangeIncludes :DrugLegalStatus,
         :MedicalEnumeration,
-        :Text ;
-    rdfs:comment "The drug or supplement's legal status, including any controlled substance schedules that apply." .
+        :Text .
 
 :maximumIntake a rdf:Property ;
     rdfs:label "maximumIntake" ;
+    rdfs:comment "Recommended intake of this supplement for a given population as defined by a specific recommending authority." ;
     :domainIncludes :DietarySupplement,
         :Drug,
         :DrugStrength,
         :Substance ;
     :isPartOf <https://health-lifesci.schema.org> ;
-    :rangeIncludes :MaximumDoseSchedule ;
-    rdfs:comment "Recommended intake of this supplement for a given population as defined by a specific recommending authority." .
+    :rangeIncludes :MaximumDoseSchedule .
 
 :mechanismOfAction a rdf:Property ;
     rdfs:label "mechanismOfAction" ;
+    rdfs:comment "The specific biochemical interaction through which this drug or supplement produces its pharmacological effect." ;
     :domainIncludes :DietarySupplement,
         :Drug ;
     :isPartOf <https://health-lifesci.schema.org> ;
-    :rangeIncludes :Text ;
-    rdfs:comment "The specific biochemical interaction through which this drug or supplement produces its pharmacological effect." .
+    :rangeIncludes :Text .
 
 :medicalAudience a rdf:Property ;
     rdfs:label "medicalAudience" ;
+    rdfs:comment "Medical audience for page." ;
     :domainIncludes :MedicalWebPage ;
     :isPartOf <https://health-lifesci.schema.org> ;
     :rangeIncludes :MedicalAudience,
-        :MedicalAudienceType ;
-    rdfs:comment "Medical audience for page." .
+        :MedicalAudienceType .
 
 :medicalSpecialty a rdf:Property ;
     rdfs:label "medicalSpecialty" ;
+    rdfs:comment "A medical specialty of the provider." ;
     :domainIncludes :Hospital,
         :MedicalClinic,
         :MedicalOrganization,
         :Physician ;
     :isPartOf <https://health-lifesci.schema.org> ;
-    :rangeIncludes :MedicalSpecialty ;
-    rdfs:comment "A medical specialty of the provider." .
+    :rangeIncludes :MedicalSpecialty .
 
 :medicineSystem a rdf:Property ;
     rdfs:label "medicineSystem" ;
+    rdfs:comment "The system of medicine that includes this MedicalEntity, for example 'evidence-based', 'homeopathic', 'chiropractic', etc." ;
     :domainIncludes :MedicalEntity ;
     :isPartOf <https://health-lifesci.schema.org> ;
-    :rangeIncludes :MedicineSystem ;
-    rdfs:comment "The system of medicine that includes this MedicalEntity, for example 'evidence-based', 'homeopathic', 'chiropractic', etc." .
+    :rangeIncludes :MedicineSystem .
 
 :muscleAction a rdf:Property ;
     rdfs:label "muscleAction" ;
+    rdfs:comment "The movement the muscle generates." ;
     :domainIncludes :Muscle ;
     :isPartOf <https://health-lifesci.schema.org> ;
-    :rangeIncludes :Text ;
-    rdfs:comment "The movement the muscle generates." .
+    :rangeIncludes :Text .
 
 :naturalProgression a rdf:Property ;
     rdfs:label "naturalProgression" ;
+    rdfs:comment "The expected progression of the condition if it is not treated and allowed to progress naturally." ;
     :domainIncludes :MedicalCondition ;
     :isPartOf <https://health-lifesci.schema.org> ;
-    :rangeIncludes :Text ;
-    rdfs:comment "The expected progression of the condition if it is not treated and allowed to progress naturally." .
+    :rangeIncludes :Text .
 
 :nerve a rdf:Property ;
     rdfs:label "nerve" ;
+    rdfs:comment "The underlying innervation associated with the muscle." ;
     :domainIncludes :Muscle ;
     :isPartOf <https://health-lifesci.schema.org> ;
-    :rangeIncludes :Nerve ;
-    rdfs:comment "The underlying innervation associated with the muscle." .
+    :rangeIncludes :Nerve .
 
 :nerveMotor a rdf:Property ;
     rdfs:label "nerveMotor" ;
+    rdfs:comment "The neurological pathway extension that involves muscle control." ;
     :domainIncludes :Nerve ;
     :isPartOf <https://health-lifesci.schema.org> ;
-    :rangeIncludes :Muscle ;
-    rdfs:comment "The neurological pathway extension that involves muscle control." .
+    :rangeIncludes :Muscle .
 
 :nonProprietaryName a rdf:Property ;
     rdfs:label "nonProprietaryName" ;
+    rdfs:comment "The generic name of this drug or supplement." ;
     :domainIncludes :DietarySupplement,
         :Drug ;
     :isPartOf <https://health-lifesci.schema.org> ;
-    :rangeIncludes :Text ;
-    rdfs:comment "The generic name of this drug or supplement." .
+    :rangeIncludes :Text .
 
 :normalRange a rdf:Property ;
     rdfs:label "normalRange" ;
+    rdfs:comment "Range of acceptable values for a typical patient, when applicable." ;
     :domainIncludes :MedicalTest ;
     :isPartOf <https://health-lifesci.schema.org> ;
     :rangeIncludes :MedicalEnumeration,
-        :Text ;
-    rdfs:comment "Range of acceptable values for a typical patient, when applicable." .
+        :Text .
 
 :originatesFrom a rdf:Property ;
     rdfs:label "originatesFrom" ;
+    rdfs:comment "The vasculature the lymphatic structure originates, or afferents, from." ;
     :domainIncludes :LymphaticVessel ;
     :isPartOf <https://health-lifesci.schema.org> ;
-    :rangeIncludes :Vessel ;
-    rdfs:comment "The vasculature the lymphatic structure originates, or afferents, from." .
+    :rangeIncludes :Vessel .
 
 :overdosage a rdf:Property ;
     rdfs:label "overdosage" ;
+    rdfs:comment "Any information related to overdose on a drug, including signs or symptoms, treatments, contact information for emergency response." ;
     :domainIncludes :Drug ;
     :isPartOf <https://health-lifesci.schema.org> ;
-    :rangeIncludes :Text ;
-    rdfs:comment "Any information related to overdose on a drug, including signs or symptoms, treatments, contact information for emergency response." .
+    :rangeIncludes :Text .
 
 :partOfSystem a rdf:Property ;
     rdfs:label "partOfSystem" ;
+    rdfs:comment "The anatomical or organ system that this structure is part of." ;
     :domainIncludes :AnatomicalStructure ;
     :isPartOf <https://health-lifesci.schema.org> ;
-    :rangeIncludes :AnatomicalSystem ;
-    rdfs:comment "The anatomical or organ system that this structure is part of." .
+    :rangeIncludes :AnatomicalSystem .
 
 :pathophysiology a rdf:Property ;
     rdfs:label "pathophysiology" ;
+    rdfs:comment "Changes in the normal mechanical, physical, and biochemical functions that are associated with this activity or condition." ;
     :domainIncludes :MedicalCondition,
         :PhysicalActivity ;
     :isPartOf <https://health-lifesci.schema.org> ;
-    :rangeIncludes :Text ;
-    rdfs:comment "Changes in the normal mechanical, physical, and biochemical functions that are associated with this activity or condition." .
+    :rangeIncludes :Text .
 
 :physiologicalBenefits a rdf:Property ;
     rdfs:label "physiologicalBenefits" ;
+    rdfs:comment "Specific physiologic benefits associated to the plan." ;
     :domainIncludes :Diet ;
     :isPartOf <https://health-lifesci.schema.org> ;
-    :rangeIncludes :Text ;
-    rdfs:comment "Specific physiologic benefits associated to the plan." .
+    :rangeIncludes :Text .
 
 :possibleComplication a rdf:Property ;
     rdfs:label "possibleComplication" ;
+    rdfs:comment "A possible unexpected and unfavorable evolution of a medical condition. Complications may include worsening of the signs or symptoms of the disease, extension of the condition to other organ systems, etc." ;
     :domainIncludes :MedicalCondition ;
     :isPartOf <https://health-lifesci.schema.org> ;
-    :rangeIncludes :Text ;
-    rdfs:comment "A possible unexpected and unfavorable evolution of a medical condition. Complications may include worsening of the signs or symptoms of the disease, extension of the condition to other organ systems, etc." .
+    :rangeIncludes :Text .
 
 :possibleTreatment a rdf:Property ;
     rdfs:label "possibleTreatment" ;
+    rdfs:comment "A possible treatment to address this condition, sign or symptom." ;
     :domainIncludes :MedicalCondition,
         :MedicalSignOrSymptom ;
     :isPartOf <https://health-lifesci.schema.org> ;
-    :rangeIncludes :MedicalTherapy ;
-    rdfs:comment "A possible treatment to address this condition, sign or symptom." .
+    :rangeIncludes :MedicalTherapy .
 
 :postOp a rdf:Property ;
     rdfs:label "postOp" ;
+    rdfs:comment "A description of the postoperative procedures, care, and/or followups for this device." ;
     :domainIncludes :MedicalDevice ;
     :isPartOf <https://health-lifesci.schema.org> ;
-    :rangeIncludes :Text ;
-    rdfs:comment "A description of the postoperative procedures, care, and/or followups for this device." .
+    :rangeIncludes :Text .
 
 :preOp a rdf:Property ;
     rdfs:label "preOp" ;
+    rdfs:comment "A description of the workup, testing, and other preparations required before implanting this device." ;
     :domainIncludes :MedicalDevice ;
     :isPartOf <https://health-lifesci.schema.org> ;
-    :rangeIncludes :Text ;
-    rdfs:comment "A description of the workup, testing, and other preparations required before implanting this device." .
+    :rangeIncludes :Text .
 
 :pregnancyCategory a rdf:Property ;
     rdfs:label "pregnancyCategory" ;
+    rdfs:comment "Pregnancy category of this drug." ;
     :domainIncludes :Drug ;
     :isPartOf <https://health-lifesci.schema.org> ;
-    :rangeIncludes :DrugPregnancyCategory ;
-    rdfs:comment "Pregnancy category of this drug." .
+    :rangeIncludes :DrugPregnancyCategory .
 
 :pregnancyWarning a rdf:Property ;
     rdfs:label "pregnancyWarning" ;
+    rdfs:comment "Any precaution, guidance, contraindication, etc. related to this drug's use during pregnancy." ;
     :domainIncludes :Drug ;
     :isPartOf <https://health-lifesci.schema.org> ;
-    :rangeIncludes :Text ;
-    rdfs:comment "Any precaution, guidance, contraindication, etc. related to this drug's use during pregnancy." .
+    :rangeIncludes :Text .
 
 :preparation a rdf:Property ;
     rdfs:label "preparation" ;
+    rdfs:comment "Typical preparation that a patient must undergo before having the procedure performed." ;
     :domainIncludes :MedicalProcedure ;
     :isPartOf <https://health-lifesci.schema.org> ;
     :rangeIncludes :MedicalEntity,
-        :Text ;
-    rdfs:comment "Typical preparation that a patient must undergo before having the procedure performed." .
+        :Text .
 
 :prescribingInfo a rdf:Property ;
     rdfs:label "prescribingInfo" ;
+    rdfs:comment "Link to prescribing information for the drug." ;
     :domainIncludes :Drug ;
     :isPartOf <https://health-lifesci.schema.org> ;
-    :rangeIncludes :URL ;
-    rdfs:comment "Link to prescribing information for the drug." .
+    :rangeIncludes :URL .
 
 :prescriptionStatus a rdf:Property ;
     rdfs:label "prescriptionStatus" ;
+    rdfs:comment "Indicates the status of drug prescription, e.g. local catalogs classifications or whether the drug is available by prescription or over-the-counter, etc." ;
     :domainIncludes :Drug ;
     :isPartOf <https://health-lifesci.schema.org> ;
     :rangeIncludes :DrugPrescriptionStatus,
-        :Text ;
-    rdfs:comment "Indicates the status of drug prescription, e.g. local catalogs classifications or whether the drug is available by prescription or over-the-counter, etc." .
+        :Text .
 
 :primaryPrevention a rdf:Property ;
     rdfs:label "primaryPrevention" ;
+    rdfs:comment "A preventative therapy used to prevent an initial occurrence of the medical condition, such as vaccination." ;
     :domainIncludes :MedicalCondition ;
     :isPartOf <https://health-lifesci.schema.org> ;
-    :rangeIncludes :MedicalTherapy ;
-    rdfs:comment "A preventative therapy used to prevent an initial occurrence of the medical condition, such as vaccination." .
+    :rangeIncludes :MedicalTherapy .
 
 :procedure a rdf:Property ;
     rdfs:label "procedure" ;
+    rdfs:comment "A description of the procedure involved in setting up, using, and/or installing the device." ;
     :domainIncludes :MedicalDevice ;
     :isPartOf <https://health-lifesci.schema.org> ;
-    :rangeIncludes :Text ;
-    rdfs:comment "A description of the procedure involved in setting up, using, and/or installing the device." .
+    :rangeIncludes :Text .
 
 :procedureType a rdf:Property ;
     rdfs:label "procedureType" ;
+    rdfs:comment "The type of procedure, for example Surgical, Noninvasive, or Percutaneous." ;
     :domainIncludes :MedicalProcedure ;
     :isPartOf <https://health-lifesci.schema.org> ;
-    :rangeIncludes :MedicalProcedureType ;
-    rdfs:comment "The type of procedure, for example Surgical, Noninvasive, or Percutaneous." .
+    :rangeIncludes :MedicalProcedureType .
 
 :proprietaryName a rdf:Property ;
     rdfs:label "proprietaryName" ;
+    rdfs:comment "Proprietary name given to the diet plan, typically by its originator or creator." ;
     :domainIncludes :DietarySupplement,
         :Drug ;
     :isPartOf <https://health-lifesci.schema.org> ;
-    :rangeIncludes :Text ;
-    rdfs:comment "Proprietary name given to the diet plan, typically by its originator or creator." .
+    :rangeIncludes :Text .
 
 :publicationType a rdf:Property ;
     rdfs:label "publicationType" ;
+    rdfs:comment "The type of the medical article, taken from the US NLM MeSH publication type catalog. See also [MeSH documentation](http://www.nlm.nih.gov/mesh/pubtypes.html)." ;
     :domainIncludes :MedicalScholarlyArticle ;
     :isPartOf <https://health-lifesci.schema.org> ;
-    :rangeIncludes :Text ;
-    rdfs:comment "The type of the medical article, taken from the US NLM MeSH publication type catalog. See also [MeSH documentation](http://www.nlm.nih.gov/mesh/pubtypes.html)." .
+    :rangeIncludes :Text .
 
 :recognizingAuthority a rdf:Property ;
     rdfs:label "recognizingAuthority" ;
+    rdfs:comment "If applicable, the organization that officially recognizes this entity as part of its endorsed system of medicine." ;
     :domainIncludes :MedicalEntity ;
     :isPartOf <https://health-lifesci.schema.org> ;
-    :rangeIncludes :Organization ;
-    rdfs:comment "If applicable, the organization that officially recognizes this entity as part of its endorsed system of medicine." .
+    :rangeIncludes :Organization .
 
 :recommendationStrength a rdf:Property ;
     rdfs:label "recommendationStrength" ;
+    rdfs:comment "Strength of the guideline's recommendation (e.g. 'class I')." ;
     :domainIncludes :MedicalGuidelineRecommendation ;
     :isPartOf <https://health-lifesci.schema.org> ;
-    :rangeIncludes :Text ;
-    rdfs:comment "Strength of the guideline's recommendation (e.g. 'class I')." .
+    :rangeIncludes :Text .
 
 :recommendedIntake a rdf:Property ;
     rdfs:label "recommendedIntake" ;
+    rdfs:comment "Recommended intake of this supplement for a given population as defined by a specific recommending authority." ;
     :domainIncludes :DietarySupplement ;
     :isPartOf <https://health-lifesci.schema.org> ;
-    :rangeIncludes :RecommendedDoseSchedule ;
-    rdfs:comment "Recommended intake of this supplement for a given population as defined by a specific recommending authority." .
+    :rangeIncludes :RecommendedDoseSchedule .
 
 :regionDrained a rdf:Property ;
     rdfs:label "regionDrained" ;
+    rdfs:comment "The anatomical or organ system drained by this vessel; generally refers to a specific part of an organ." ;
     :domainIncludes :LymphaticVessel,
         :Vein ;
     :isPartOf <https://health-lifesci.schema.org> ;
     :rangeIncludes :AnatomicalStructure,
-        :AnatomicalSystem ;
-    rdfs:comment "The anatomical or organ system drained by this vessel; generally refers to a specific part of an organ." .
+        :AnatomicalSystem .
 
 :relatedAnatomy a rdf:Property ;
     rdfs:label "relatedAnatomy" ;
+    rdfs:comment "Anatomical systems or structures that relate to the superficial anatomy." ;
     :domainIncludes :SuperficialAnatomy ;
     :isPartOf <https://health-lifesci.schema.org> ;
     :rangeIncludes :AnatomicalStructure,
-        :AnatomicalSystem ;
-    rdfs:comment "Anatomical systems or structures that relate to the superficial anatomy." .
+        :AnatomicalSystem .
 
 :relatedCondition a rdf:Property ;
     rdfs:label "relatedCondition" ;
+    rdfs:comment "A medical condition associated with this anatomy." ;
     :domainIncludes :AnatomicalStructure,
         :AnatomicalSystem,
         :SuperficialAnatomy ;
     :isPartOf <https://health-lifesci.schema.org> ;
-    :rangeIncludes :MedicalCondition ;
-    rdfs:comment "A medical condition associated with this anatomy." .
+    :rangeIncludes :MedicalCondition .
 
 :relatedDrug a rdf:Property ;
     rdfs:label "relatedDrug" ;
+    rdfs:comment "Any other drug related to this one, for example commonly-prescribed alternatives." ;
     :domainIncludes :Drug ;
     :isPartOf <https://health-lifesci.schema.org> ;
-    :rangeIncludes :Drug ;
-    rdfs:comment "Any other drug related to this one, for example commonly-prescribed alternatives." .
+    :rangeIncludes :Drug .
 
 :relatedStructure a rdf:Property ;
     rdfs:label "relatedStructure" ;
+    rdfs:comment "Related anatomical structure(s) that are not part of the system but relate or connect to it, such as vascular bundles associated with an organ system." ;
     :domainIncludes :AnatomicalSystem ;
     :isPartOf <https://health-lifesci.schema.org> ;
-    :rangeIncludes :AnatomicalStructure ;
-    rdfs:comment "Related anatomical structure(s) that are not part of the system but relate or connect to it, such as vascular bundles associated with an organ system." .
+    :rangeIncludes :AnatomicalStructure .
 
 :relatedTherapy a rdf:Property ;
     rdfs:label "relatedTherapy" ;
+    rdfs:comment "A medical therapy related to this anatomy." ;
     :domainIncludes :AnatomicalStructure,
         :AnatomicalSystem,
         :SuperficialAnatomy ;
     :isPartOf <https://health-lifesci.schema.org> ;
-    :rangeIncludes :MedicalTherapy ;
-    rdfs:comment "A medical therapy related to this anatomy." .
+    :rangeIncludes :MedicalTherapy .
 
 :relevantSpecialty a rdf:Property ;
     rdfs:label "relevantSpecialty" ;
+    rdfs:comment "If applicable, a medical specialty in which this entity is relevant." ;
     :domainIncludes :MedicalEntity ;
     :isPartOf <https://health-lifesci.schema.org> ;
-    :rangeIncludes :MedicalSpecialty ;
-    rdfs:comment "If applicable, a medical specialty in which this entity is relevant." .
+    :rangeIncludes :MedicalSpecialty .
 
 :riskFactor a rdf:Property ;
     rdfs:label "riskFactor" ;
+    rdfs:comment "A modifiable or non-modifiable factor that increases the risk of a patient contracting this condition, e.g. age,  coexisting condition." ;
     :domainIncludes :MedicalCondition ;
     :isPartOf <https://health-lifesci.schema.org> ;
-    :rangeIncludes :MedicalRiskFactor ;
-    rdfs:comment "A modifiable or non-modifiable factor that increases the risk of a patient contracting this condition, e.g. age,  coexisting condition." .
+    :rangeIncludes :MedicalRiskFactor .
 
 :risks a rdf:Property ;
     rdfs:label "risks" ;
+    rdfs:comment "Specific physiologic risks associated to the diet plan." ;
     :domainIncludes :Diet ;
     :isPartOf <https://health-lifesci.schema.org> ;
-    :rangeIncludes :Text ;
-    rdfs:comment "Specific physiologic risks associated to the diet plan." .
+    :rangeIncludes :Text .
 
 :runsTo a rdf:Property ;
     rdfs:label "runsTo" ;
+    rdfs:comment "The vasculature the lymphatic structure runs, or efferents, to." ;
     :domainIncludes :LymphaticVessel ;
     :isPartOf <https://health-lifesci.schema.org> ;
-    :rangeIncludes :Vessel ;
-    rdfs:comment "The vasculature the lymphatic structure runs, or efferents, to." .
+    :rangeIncludes :Vessel .
 
 :safetyConsideration a rdf:Property ;
     rdfs:label "safetyConsideration" ;
+    rdfs:comment "Any potential safety concern associated with the supplement. May include interactions with other drugs and foods, pregnancy, breastfeeding, known adverse reactions, and documented efficacy of the supplement." ;
     :domainIncludes :DietarySupplement ;
     :isPartOf <https://health-lifesci.schema.org> ;
-    :rangeIncludes :Text ;
-    rdfs:comment "Any potential safety concern associated with the supplement. May include interactions with other drugs and foods, pregnancy, breastfeeding, known adverse reactions, and documented efficacy of the supplement." .
+    :rangeIncludes :Text .
 
 :secondaryPrevention a rdf:Property ;
     rdfs:label "secondaryPrevention" ;
+    rdfs:comment "A preventative therapy used to prevent reoccurrence of the medical condition after an initial episode of the condition." ;
     :domainIncludes :MedicalCondition ;
     :isPartOf <https://health-lifesci.schema.org> ;
-    :rangeIncludes :MedicalTherapy ;
-    rdfs:comment "A preventative therapy used to prevent reoccurrence of the medical condition after an initial episode of the condition." .
+    :rangeIncludes :MedicalTherapy .
 
 :sensoryUnit a rdf:Property ;
     rdfs:label "sensoryUnit" ;
+    rdfs:comment "The neurological pathway extension that inputs and sends information to the brain or spinal cord." ;
     :domainIncludes :Nerve ;
     :isPartOf <https://health-lifesci.schema.org> ;
     :rangeIncludes :AnatomicalStructure,
-        :SuperficialAnatomy ;
-    rdfs:comment "The neurological pathway extension that inputs and sends information to the brain or spinal cord." .
+        :SuperficialAnatomy .
 
 :seriousAdverseOutcome a rdf:Property ;
     rdfs:label "seriousAdverseOutcome" ;
+    rdfs:comment "A possible serious complication and/or serious side effect of this therapy. Serious adverse outcomes include those that are life-threatening; result in death, disability, or permanent damage; require hospitalization or prolong existing hospitalization; cause congenital anomalies or birth defects; or jeopardize the patient and may require medical or surgical intervention to prevent one of the outcomes in this definition." ;
     :domainIncludes :MedicalDevice,
         :MedicalTherapy ;
     :isPartOf <https://health-lifesci.schema.org> ;
-    :rangeIncludes :MedicalEntity ;
-    rdfs:comment "A possible serious complication and/or serious side effect of this therapy. Serious adverse outcomes include those that are life-threatening; result in death, disability, or permanent damage; require hospitalization or prolong existing hospitalization; cause congenital anomalies or birth defects; or jeopardize the patient and may require medical or surgical intervention to prevent one of the outcomes in this definition." .
+    :rangeIncludes :MedicalEntity .
 
 :signDetected a rdf:Property ;
     rdfs:label "signDetected" ;
+    rdfs:comment "A sign detected by the test." ;
     :domainIncludes :MedicalTest ;
     :isPartOf <https://health-lifesci.schema.org> ;
-    :rangeIncludes :MedicalSign ;
-    rdfs:comment "A sign detected by the test." .
+    :rangeIncludes :MedicalSign .
 
 :signOrSymptom a rdf:Property ;
     rdfs:label "signOrSymptom" ;
+    rdfs:comment "A sign or symptom of this condition. Signs are objective or physically observable manifestations of the medical condition while symptoms are the subjective experience of the medical condition." ;
     :domainIncludes :MedicalCondition ;
     :isPartOf <https://health-lifesci.schema.org> ;
-    :rangeIncludes :MedicalSignOrSymptom ;
-    rdfs:comment "A sign or symptom of this condition. Signs are objective or physically observable manifestations of the medical condition while symptoms are the subjective experience of the medical condition." .
+    :rangeIncludes :MedicalSignOrSymptom .
 
 :significance a rdf:Property ;
     rdfs:label "significance" ;
+    rdfs:comment "The significance associated with the superficial anatomy; as an example, how characteristics of the superficial anatomy can suggest underlying medical conditions or courses of treatment." ;
     :domainIncludes :SuperficialAnatomy ;
     :isPartOf <https://health-lifesci.schema.org> ;
-    :rangeIncludes :Text ;
-    rdfs:comment "The significance associated with the superficial anatomy; as an example, how characteristics of the superficial anatomy can suggest underlying medical conditions or courses of treatment." .
+    :rangeIncludes :Text .
 
 :sourcedFrom a rdf:Property ;
     rdfs:label "sourcedFrom" ;
+    rdfs:comment "The neurological pathway that originates the neurons." ;
     :domainIncludes :Nerve ;
     :isPartOf <https://health-lifesci.schema.org> ;
-    :rangeIncludes :BrainStructure ;
-    rdfs:comment "The neurological pathway that originates the neurons." .
+    :rangeIncludes :BrainStructure .
 
 :sponsor a rdf:Property ;
     :domainIncludes :MedicalStudy ;
@@ -2170,188 +2170,188 @@
 
 :stage a rdf:Property ;
     rdfs:label "stage" ;
+    rdfs:comment "The stage of the condition, if applicable." ;
     :domainIncludes :MedicalCondition ;
     :isPartOf <https://health-lifesci.schema.org> ;
-    :rangeIncludes :MedicalConditionStage ;
-    rdfs:comment "The stage of the condition, if applicable." .
+    :rangeIncludes :MedicalConditionStage .
 
 :stageAsNumber a rdf:Property ;
     rdfs:label "stageAsNumber" ;
+    rdfs:comment "The stage represented as a number, e.g. 3." ;
     :domainIncludes :MedicalConditionStage ;
     :isPartOf <https://health-lifesci.schema.org> ;
-    :rangeIncludes :Number ;
-    rdfs:comment "The stage represented as a number, e.g. 3." .
+    :rangeIncludes :Number .
 
 :status a rdf:Property ;
     rdfs:label "status" ;
+    rdfs:comment "The status of the study (enumerated)." ;
     :domainIncludes :MedicalCondition,
         :MedicalProcedure,
         :MedicalStudy ;
     :isPartOf <https://health-lifesci.schema.org> ;
     :rangeIncludes :EventStatusType,
         :MedicalStudyStatus,
-        :Text ;
-    rdfs:comment "The status of the study (enumerated)." .
+        :Text .
 
 :strengthUnit a rdf:Property ;
     rdfs:label "strengthUnit" ;
+    rdfs:comment "The units of an active ingredient's strength, e.g. mg." ;
     :domainIncludes :DrugStrength ;
     :isPartOf <https://health-lifesci.schema.org> ;
-    :rangeIncludes :Text ;
-    rdfs:comment "The units of an active ingredient's strength, e.g. mg." .
+    :rangeIncludes :Text .
 
 :strengthValue a rdf:Property ;
     rdfs:label "strengthValue" ;
+    rdfs:comment "The value of an active ingredient's strength, e.g. 325." ;
     :domainIncludes :DrugStrength ;
     :isPartOf <https://health-lifesci.schema.org> ;
-    :rangeIncludes :Number ;
-    rdfs:comment "The value of an active ingredient's strength, e.g. 325." .
+    :rangeIncludes :Number .
 
 :structuralClass a rdf:Property ;
     rdfs:label "structuralClass" ;
+    rdfs:comment "The name given to how bone physically connects to each other." ;
     :domainIncludes :Joint ;
     :isPartOf <https://health-lifesci.schema.org> ;
-    :rangeIncludes :Text ;
-    rdfs:comment "The name given to how bone physically connects to each other." .
+    :rangeIncludes :Text .
 
 :study a rdf:Property ;
     rdfs:label "study" ;
+    rdfs:comment "A medical study or trial related to this entity." ;
     :domainIncludes :MedicalEntity ;
     :isPartOf <https://health-lifesci.schema.org> ;
-    :rangeIncludes :MedicalStudy ;
-    rdfs:comment "A medical study or trial related to this entity." .
+    :rangeIncludes :MedicalStudy .
 
 :studyDesign a rdf:Property ;
     rdfs:label "studyDesign" ;
+    rdfs:comment "Specifics about the observational study design (enumerated)." ;
     :domainIncludes :MedicalObservationalStudy ;
     :isPartOf <https://health-lifesci.schema.org> ;
-    :rangeIncludes :MedicalObservationalStudyDesign ;
-    rdfs:comment "Specifics about the observational study design (enumerated)." .
+    :rangeIncludes :MedicalObservationalStudyDesign .
 
 :studyLocation a rdf:Property ;
     rdfs:label "studyLocation" ;
+    rdfs:comment "The location in which the study is taking/took place." ;
     :domainIncludes :MedicalStudy ;
     :isPartOf <https://health-lifesci.schema.org> ;
-    :rangeIncludes :AdministrativeArea ;
-    rdfs:comment "The location in which the study is taking/took place." .
+    :rangeIncludes :AdministrativeArea .
 
 :studySubject a rdf:Property ;
     rdfs:label "studySubject" ;
+    rdfs:comment "A subject of the study, i.e. one of the medical conditions, therapies, devices, drugs, etc. investigated by the study." ;
     :domainIncludes :MedicalStudy ;
     :isPartOf <https://health-lifesci.schema.org> ;
-    :rangeIncludes :MedicalEntity ;
-    rdfs:comment "A subject of the study, i.e. one of the medical conditions, therapies, devices, drugs, etc. investigated by the study." .
+    :rangeIncludes :MedicalEntity .
 
 :subStageSuffix a rdf:Property ;
     rdfs:label "subStageSuffix" ;
+    rdfs:comment "The substage, e.g. 'a' for Stage IIIa." ;
     :domainIncludes :MedicalConditionStage ;
     :isPartOf <https://health-lifesci.schema.org> ;
-    :rangeIncludes :Text ;
-    rdfs:comment "The substage, e.g. 'a' for Stage IIIa." .
+    :rangeIncludes :Text .
 
 :subStructure a rdf:Property ;
     rdfs:label "subStructure" ;
+    rdfs:comment "Component (sub-)structure(s) that comprise this anatomical structure." ;
     :domainIncludes :AnatomicalStructure ;
     :isPartOf <https://health-lifesci.schema.org> ;
-    :rangeIncludes :AnatomicalStructure ;
-    rdfs:comment "Component (sub-)structure(s) that comprise this anatomical structure." .
+    :rangeIncludes :AnatomicalStructure .
 
 :subTest a rdf:Property ;
     rdfs:label "subTest" ;
+    rdfs:comment "A component test of the panel." ;
     :domainIncludes :MedicalTestPanel ;
     :isPartOf <https://health-lifesci.schema.org> ;
-    :rangeIncludes :MedicalTest ;
-    rdfs:comment "A component test of the panel." .
+    :rangeIncludes :MedicalTest .
 
 :supplyTo a rdf:Property ;
     rdfs:label "supplyTo" ;
+    rdfs:comment "The area to which the artery supplies blood." ;
     :domainIncludes :Artery ;
     :isPartOf <https://health-lifesci.schema.org> ;
-    :rangeIncludes :AnatomicalStructure ;
-    rdfs:comment "The area to which the artery supplies blood." .
+    :rangeIncludes :AnatomicalStructure .
 
 :targetPopulation a rdf:Property ;
     rdfs:label "targetPopulation" ;
+    rdfs:comment "Characteristics of the population for which this is intended, or which typically uses it, e.g. 'adults'." ;
     :domainIncludes :DietarySupplement,
         :DoseSchedule ;
     :isPartOf <https://health-lifesci.schema.org> ;
-    :rangeIncludes :Text ;
-    rdfs:comment "Characteristics of the population for which this is intended, or which typically uses it, e.g. 'adults'." .
+    :rangeIncludes :Text .
 
 :tissueSample a rdf:Property ;
     rdfs:label "tissueSample" ;
+    rdfs:comment "The type of tissue sample required for the test." ;
     :domainIncludes :PathologyTest ;
     :isPartOf <https://health-lifesci.schema.org> ;
-    :rangeIncludes :Text ;
-    rdfs:comment "The type of tissue sample required for the test." .
+    :rangeIncludes :Text .
 
 :transmissionMethod a rdf:Property ;
     rdfs:label "transmissionMethod" ;
+    rdfs:comment "How the disease spreads, either as a route or vector, for example 'direct contact', 'Aedes aegypti', etc." ;
     :domainIncludes :InfectiousDisease ;
     :isPartOf <https://health-lifesci.schema.org> ;
-    :rangeIncludes :Text ;
-    rdfs:comment "How the disease spreads, either as a route or vector, for example 'direct contact', 'Aedes aegypti', etc." .
+    :rangeIncludes :Text .
 
 :trialDesign a rdf:Property ;
     rdfs:label "trialDesign" ;
+    rdfs:comment "Specifics about the trial design (enumerated)." ;
     :domainIncludes :MedicalTrial ;
     :isPartOf <https://health-lifesci.schema.org> ;
-    :rangeIncludes :MedicalTrialDesign ;
-    rdfs:comment "Specifics about the trial design (enumerated)." .
+    :rangeIncludes :MedicalTrialDesign .
 
 :tributary a rdf:Property ;
     rdfs:label "tributary" ;
+    rdfs:comment "The anatomical or organ system that the vein flows into; a larger structure that the vein connects to." ;
     :domainIncludes :Vein ;
     :isPartOf <https://health-lifesci.schema.org> ;
-    :rangeIncludes :AnatomicalStructure ;
-    rdfs:comment "The anatomical or organ system that the vein flows into; a larger structure that the vein connects to." .
+    :rangeIncludes :AnatomicalStructure .
 
 :typicalTest a rdf:Property ;
     rdfs:label "typicalTest" ;
+    rdfs:comment "A medical test typically performed given this condition." ;
     :domainIncludes :MedicalCondition ;
     :isPartOf <https://health-lifesci.schema.org> ;
-    :rangeIncludes :MedicalTest ;
-    rdfs:comment "A medical test typically performed given this condition." .
+    :rangeIncludes :MedicalTest .
 
 :usedToDiagnose a rdf:Property ;
     rdfs:label "usedToDiagnose" ;
+    rdfs:comment "A condition the test is used to diagnose." ;
     :domainIncludes :MedicalTest ;
     :isPartOf <https://health-lifesci.schema.org> ;
-    :rangeIncludes :MedicalCondition ;
-    rdfs:comment "A condition the test is used to diagnose." .
+    :rangeIncludes :MedicalCondition .
 
 :usesDevice a rdf:Property ;
     rdfs:label "usesDevice" ;
+    rdfs:comment "Device used to perform the test." ;
     :domainIncludes :MedicalTest ;
     :isPartOf <https://health-lifesci.schema.org> ;
-    :rangeIncludes :MedicalDevice ;
-    rdfs:comment "Device used to perform the test." .
+    :rangeIncludes :MedicalDevice .
 
 :warning a rdf:Property ;
     rdfs:label "warning" ;
+    rdfs:comment "Any FDA or other warnings about the drug (text or URL)." ;
     :domainIncludes :Drug ;
     :isPartOf <https://health-lifesci.schema.org> ;
     :rangeIncludes :Text,
-        :URL ;
-    rdfs:comment "Any FDA or other warnings about the drug (text or URL)." .
+        :URL .
 
 :Dermatology a :MedicalSpecialty ;
     rdfs:label "Dermatology" ;
-    :isPartOf <https://health-lifesci.schema.org> ;
     rdfs:comment "A specific branch of medical science that pertains to diagnosis and treatment of disorders of skin." ;
-    rdfs:subClassOf :MedicalBusiness .
+    rdfs:subClassOf :MedicalBusiness ;
+    :isPartOf <https://health-lifesci.schema.org> .
 
 :arterialBranch a rdf:Property ;
     rdfs:label "arterialBranch" ;
+    rdfs:comment "The branches that comprise the arterial structure." ;
     :domainIncludes :Artery ;
     :isPartOf <https://health-lifesci.schema.org> ;
-    :rangeIncludes :AnatomicalStructure ;
-    rdfs:comment "The branches that comprise the arterial structure." .
+    :rangeIncludes :AnatomicalStructure .
 
 :clinicalPharmacology a rdf:Property ;
     rdfs:label "clinicalPharmacology" ;
+    rdfs:comment "Description of the absorption and elimination of drugs, including their concentration (pharmacokinetics, pK) and biological effects (pharmacodynamics, pD)." ;
     :domainIncludes :Drug ;
     :isPartOf <https://health-lifesci.schema.org> ;
-    :rangeIncludes :Text ;
-    rdfs:comment "Description of the absorption and elimination of drugs, including their concentration (pharmacokinetics, pK) and biological effects (pharmacodynamics, pD)." .
+    :rangeIncludes :Text .
 

--- a/data/ext/health-lifesci/physical-activity-and-exercise.ttl
+++ b/data/ext/health-lifesci/physical-activity-and-exercise.ttl
@@ -1,86 +1,83 @@
 @prefix : <https://schema.org/> .
-@prefix ns1: <http://www.w3.org/ns/rdfa#> .
 @prefix rdf: <http://www.w3.org/1999/02/22-rdf-syntax-ns#> .
 @prefix rdfs: <http://www.w3.org/2000/01/rdf-schema#> .
-@prefix xml: <http://www.w3.org/XML/1998/namespace> .
-@prefix xsd: <http://www.w3.org/2001/XMLSchema#> .
 
 :ExercisePlan a rdfs:Class ;
     rdfs:label "ExercisePlan" ;
-    :isPartOf <https://health-lifesci.schema.org> ;
     rdfs:comment "Fitness-related activity designed for a specific health-related purpose, including defined exercise routines as well as activity prescribed by a clinician." ;
     rdfs:subClassOf :CreativeWork,
-        :PhysicalActivity .
+        :PhysicalActivity ;
+    :isPartOf <https://health-lifesci.schema.org> .
 
 :PhysicalActivity a rdfs:Class ;
     rdfs:label "PhysicalActivity" ;
-    :isPartOf <https://health-lifesci.schema.org> ;
     rdfs:comment "Any bodily activity that enhances or maintains physical fitness and overall health and wellness. Includes activity that is part of daily living and routine, structured exercise, and exercise prescribed as part of a medical treatment or recovery plan." ;
-    rdfs:subClassOf :LifestyleModification .
+    rdfs:subClassOf :LifestyleModification ;
+    :isPartOf <https://health-lifesci.schema.org> .
 
 :PhysicalActivityCategory a rdfs:Class ;
     rdfs:label "PhysicalActivityCategory" ;
-    :isPartOf <https://health-lifesci.schema.org> ;
     rdfs:comment "Categories of physical activity, organized by physiologic classification." ;
-    rdfs:subClassOf :Enumeration .
+    rdfs:subClassOf :Enumeration ;
+    :isPartOf <https://health-lifesci.schema.org> .
 
 :AerobicActivity a :PhysicalActivityCategory ;
     rdfs:label "AerobicActivity" ;
-    :isPartOf <https://health-lifesci.schema.org> ;
-    rdfs:comment "Physical activity of relatively low intensity that depends primarily on the aerobic energy-generating process; during activity, the aerobic metabolism uses oxygen to adequately meet energy demands during exercise." .
+    rdfs:comment "Physical activity of relatively low intensity that depends primarily on the aerobic energy-generating process; during activity, the aerobic metabolism uses oxygen to adequately meet energy demands during exercise." ;
+    :isPartOf <https://health-lifesci.schema.org> .
 
 :AnaerobicActivity a :PhysicalActivityCategory ;
     rdfs:label "AnaerobicActivity" ;
-    :isPartOf <https://health-lifesci.schema.org> ;
-    rdfs:comment "Physical activity that is of high-intensity which utilizes the anaerobic metabolism of the body." .
+    rdfs:comment "Physical activity that is of high-intensity which utilizes the anaerobic metabolism of the body." ;
+    :isPartOf <https://health-lifesci.schema.org> .
 
 :Balance a :PhysicalActivityCategory ;
     rdfs:label "Balance" ;
-    :isPartOf <https://health-lifesci.schema.org> ;
-    rdfs:comment "Physical activity that is engaged to help maintain posture and balance." .
+    rdfs:comment "Physical activity that is engaged to help maintain posture and balance." ;
+    :isPartOf <https://health-lifesci.schema.org> .
 
 :Flexibility a :PhysicalActivityCategory ;
     rdfs:label "Flexibility" ;
-    :isPartOf <https://health-lifesci.schema.org> ;
-    rdfs:comment "Physical activity that is engaged in to improve joint and muscle flexibility." .
+    rdfs:comment "Physical activity that is engaged in to improve joint and muscle flexibility." ;
+    :isPartOf <https://health-lifesci.schema.org> .
 
 :LeisureTimeActivity a :PhysicalActivityCategory ;
     rdfs:label "LeisureTimeActivity" ;
-    :isPartOf <https://health-lifesci.schema.org> ;
-    rdfs:comment "Any physical activity engaged in for recreational purposes. Examples may include ballroom dancing, roller skating, canoeing, fishing, etc." .
+    rdfs:comment "Any physical activity engaged in for recreational purposes. Examples may include ballroom dancing, roller skating, canoeing, fishing, etc." ;
+    :isPartOf <https://health-lifesci.schema.org> .
 
 :OccupationalActivity a :PhysicalActivityCategory ;
     rdfs:label "OccupationalActivity" ;
-    :isPartOf <https://health-lifesci.schema.org> ;
-    rdfs:comment "Any physical activity engaged in for job-related purposes. Examples may include waiting tables, maid service, carrying a mailbag, picking fruits or vegetables, construction work, etc." .
+    rdfs:comment "Any physical activity engaged in for job-related purposes. Examples may include waiting tables, maid service, carrying a mailbag, picking fruits or vegetables, construction work, etc." ;
+    :isPartOf <https://health-lifesci.schema.org> .
 
 :StrengthTraining a :PhysicalActivityCategory ;
     rdfs:label "StrengthTraining" ;
-    :isPartOf <https://health-lifesci.schema.org> ;
-    rdfs:comment "Physical activity that is engaged in to improve muscle and bone strength. Also referred to as resistance training." .
+    rdfs:comment "Physical activity that is engaged in to improve muscle and bone strength. Also referred to as resistance training." ;
+    :isPartOf <https://health-lifesci.schema.org> .
 
 :activityDuration a rdf:Property ;
     rdfs:label "activityDuration" ;
+    rdfs:comment "Length of time to engage in the activity." ;
     :domainIncludes :ExercisePlan ;
     :isPartOf <https://health-lifesci.schema.org> ;
     :rangeIncludes :Duration,
-        :QuantitativeValue ;
-    rdfs:comment "Length of time to engage in the activity." .
+        :QuantitativeValue .
 
 :activityFrequency a rdf:Property ;
     rdfs:label "activityFrequency" ;
+    rdfs:comment "How often one should engage in the activity." ;
     :domainIncludes :ExercisePlan ;
     :isPartOf <https://health-lifesci.schema.org> ;
     :rangeIncludes :QuantitativeValue,
-        :Text ;
-    rdfs:comment "How often one should engage in the activity." .
+        :Text .
 
 :additionalVariable a rdf:Property ;
     rdfs:label "additionalVariable" ;
+    rdfs:comment "Any additional component of the exercise prescription that may need to be articulated to the patient. This may include the order of exercises, the number of repetitions of movement, quantitative distance, progressions over time, etc." ;
     :domainIncludes :ExercisePlan ;
     :isPartOf <https://health-lifesci.schema.org> ;
-    :rangeIncludes :Text ;
-    rdfs:comment "Any additional component of the exercise prescription that may need to be articulated to the patient. This may include the order of exercises, the number of repetitions of movement, quantitative distance, progressions over time, etc." .
+    :rangeIncludes :Text .
 
 :category a rdf:Property ;
     :domainIncludes :PhysicalActivity ;
@@ -88,49 +85,49 @@
 
 :exercisePlan a rdf:Property ;
     rdfs:label "exercisePlan" ;
+    rdfs:comment "A sub property of instrument. The exercise plan used on this action." ;
+    rdfs:subPropertyOf :instrument ;
     :domainIncludes :ExerciseAction ;
     :isPartOf <https://health-lifesci.schema.org> ;
-    :rangeIncludes :ExercisePlan ;
-    rdfs:comment "A sub property of instrument. The exercise plan used on this action." ;
-    rdfs:subPropertyOf :instrument .
+    :rangeIncludes :ExercisePlan .
 
 :exerciseType a rdf:Property ;
     rdfs:label "exerciseType" ;
+    rdfs:comment "Type(s) of exercise or activity, such as strength training, flexibility training, aerobics, cardiac rehabilitation, etc." ;
     :domainIncludes :ExerciseAction,
         :ExercisePlan ;
     :isPartOf <https://health-lifesci.schema.org> ;
-    :rangeIncludes :Text ;
-    rdfs:comment "Type(s) of exercise or activity, such as strength training, flexibility training, aerobics, cardiac rehabilitation, etc." .
+    :rangeIncludes :Text .
 
 :intensity a rdf:Property ;
     rdfs:label "intensity" ;
+    rdfs:comment "Quantitative measure gauging the degree of force involved in the exercise, for example, heartbeats per minute. May include the velocity of the movement." ;
     :domainIncludes :ExercisePlan ;
     :isPartOf <https://health-lifesci.schema.org> ;
     :rangeIncludes :QuantitativeValue,
-        :Text ;
-    rdfs:comment "Quantitative measure gauging the degree of force involved in the exercise, for example, heartbeats per minute. May include the velocity of the movement." .
+        :Text .
 
 :repetitions a rdf:Property ;
     rdfs:label "repetitions" ;
+    rdfs:comment "Number of times one should repeat the activity." ;
     :domainIncludes :ExercisePlan ;
     :isPartOf <https://health-lifesci.schema.org> ;
     :rangeIncludes :Number,
-        :QuantitativeValue ;
-    rdfs:comment "Number of times one should repeat the activity." .
+        :QuantitativeValue .
 
 :restPeriods a rdf:Property ;
     rdfs:label "restPeriods" ;
+    rdfs:comment "How often one should break from the activity." ;
     :domainIncludes :ExercisePlan ;
     :isPartOf <https://health-lifesci.schema.org> ;
     :rangeIncludes :QuantitativeValue,
-        :Text ;
-    rdfs:comment "How often one should break from the activity." .
+        :Text .
 
 :workload a rdf:Property ;
     rdfs:label "workload" ;
+    rdfs:comment "Quantitative measure of the physiologic output of the exercise; also referred to as energy expenditure." ;
     :domainIncludes :ExercisePlan ;
     :isPartOf <https://health-lifesci.schema.org> ;
     :rangeIncludes :Energy,
-        :QuantitativeValue ;
-    rdfs:comment "Quantitative measure of the physiologic output of the exercise; also referred to as energy expenditure." .
+        :QuantitativeValue .
 

--- a/data/ext/meta/meta.ttl
+++ b/data/ext/meta/meta.ttl
@@ -2,55 +2,53 @@
 @prefix owl: <http://www.w3.org/2002/07/owl#> .
 @prefix rdf: <http://www.w3.org/1999/02/22-rdf-syntax-ns#> .
 @prefix rdfs: <http://www.w3.org/2000/01/rdf-schema#> .
-@prefix xml: <http://www.w3.org/XML/1998/namespace> .
-@prefix xsd: <http://www.w3.org/2001/XMLSchema#> .
 
 :Class a rdfs:Class ;
     rdfs:label "Class" ;
-    :isPartOf <https://meta.schema.org> ;
     rdfs:comment "A class, also often called a 'Type'; equivalent to rdfs:Class." ;
     rdfs:subClassOf :Intangible ;
-    owl:equivalentClass rdfs:Class .
+    owl:equivalentClass rdfs:Class ;
+    :isPartOf <https://meta.schema.org> .
 
 :Property a rdfs:Class ;
     rdfs:label "Property" ;
-    :isPartOf <https://meta.schema.org> ;
     rdfs:comment "A property, used to indicate attributes and relationships of some Thing; equivalent to rdf:Property." ;
     rdfs:subClassOf :Intangible ;
-    owl:equivalentClass rdf:Property .
+    owl:equivalentClass rdf:Property ;
+    :isPartOf <https://meta.schema.org> .
 
 <https://meta.schema.org/> rdfs:label "meta" ;
     rdfs:comment "Meta contains terms to support the implementation of the Schema.org vocabulary itself." .
 
 :domainIncludes a rdf:Property ;
     rdfs:label "domainIncludes" ;
+    rdfs:comment "Relates a property to a class that is (one of) the type(s) the property is expected to be used on." ;
     :domainIncludes :Property ;
     :isPartOf <https://meta.schema.org> ;
-    :rangeIncludes :Class ;
-    rdfs:comment "Relates a property to a class that is (one of) the type(s) the property is expected to be used on." .
+    :rangeIncludes :Class .
 
 :inverseOf a rdf:Property ;
     rdfs:label "inverseOf" ;
+    rdfs:comment "Relates a property to a property that is its inverse. Inverse properties relate the same pairs of items to each other, but in reversed direction. For example, the 'alumni' and 'alumniOf' properties are inverseOf each other. Some properties don't have explicit inverses; in these situations RDFa and JSON-LD syntax for reverse properties can be used." ;
     :domainIncludes :Property ;
     :isPartOf <https://meta.schema.org> ;
-    :rangeIncludes :Property ;
-    rdfs:comment "Relates a property to a property that is its inverse. Inverse properties relate the same pairs of items to each other, but in reversed direction. For example, the 'alumni' and 'alumniOf' properties are inverseOf each other. Some properties don't have explicit inverses; in these situations RDFa and JSON-LD syntax for reverse properties can be used." .
+    :rangeIncludes :Property .
 
 :rangeIncludes a rdf:Property ;
     rdfs:label "rangeIncludes" ;
+    rdfs:comment "Relates a property to a class that constitutes (one of) the expected type(s) for values of the property." ;
     :domainIncludes :Property ;
     :isPartOf <https://meta.schema.org> ;
-    :rangeIncludes :Class ;
-    rdfs:comment "Relates a property to a class that constitutes (one of) the expected type(s) for values of the property." .
+    :rangeIncludes :Class .
 
 :supersededBy a rdf:Property ;
     rdfs:label "supersededBy" ;
+    rdfs:comment "Relates a term (i.e. a property, class or enumeration) to one that supersedes it." ;
     :domainIncludes :Class,
         :Enumeration,
         :Property ;
     :isPartOf <https://meta.schema.org> ;
     :rangeIncludes :Class,
         :Enumeration,
-        :Property ;
-    rdfs:comment "Relates a term (i.e. a property, class or enumeration) to one that supersedes it." .
+        :Property .
 

--- a/data/gr-property-acks.ttl
+++ b/data/gr-property-acks.ttl
@@ -1,8 +1,5 @@
 @prefix : <https://schema.org/> .
 @prefix rdf: <http://www.w3.org/1999/02/22-rdf-syntax-ns#> .
-@prefix rdfs: <http://www.w3.org/2000/01/rdf-schema#> .
-@prefix xml: <http://www.w3.org/XML/1998/namespace> .
-@prefix xsd: <http://www.w3.org/2001/XMLSchema#> .
 
 :acceptedPaymentMethod a rdf:Property ;
     :contributor <https://schema.org/docs/collab/GoodRelationsTerms> .

--- a/data/mappings.ttl
+++ b/data/mappings.ttl
@@ -1,11 +1,7 @@
 @prefix : <https://schema.org/> .
-@prefix rdf: <http://www.w3.org/1999/02/22-rdf-syntax-ns#> .
-@prefix rdfs: <http://www.w3.org/2000/01/rdf-schema#> .
 @prefix skos: <http://www.w3.org/2004/02/skos/core#> .
-@prefix xml: <http://www.w3.org/XML/1998/namespace> .
-@prefix xsd: <http://www.w3.org/2001/XMLSchema#> .
-
-:LocalBusiness skos:closeMatch <http://www.w3.org/ns/regorg#RegisteredOrganization> .
 
 <http://www.w3.org/ns/regorg#RegisteredOrganization> skos:closeMatch :LocalBusiness .
+
+:LocalBusiness skos:closeMatch <http://www.w3.org/ns/regorg#RegisteredOrganization> .
 

--- a/data/schema.ttl
+++ b/data/schema.ttl
@@ -1,16 +1,18 @@
 @prefix : <https://schema.org/> .
 @prefix dc: <http://purl.org/dc/terms/> .
+@prefix dcat: <http://www.w3.org/ns/dcat#> .
+@prefix dcmitype: <http://purl.org/dc/dcmitype/> .
+@prefix foaf: <http://xmlns.com/foaf/0.1/> .
 @prefix owl: <http://www.w3.org/2002/07/owl#> .
 @prefix rdf: <http://www.w3.org/1999/02/22-rdf-syntax-ns#> .
 @prefix rdfs: <http://www.w3.org/2000/01/rdf-schema#> .
-@prefix xml: <http://www.w3.org/XML/1998/namespace> .
-@prefix xsd: <http://www.w3.org/2001/XMLSchema#> .
+@prefix void: <http://rdfs.org/ns/void#> .
 
 :AMRadioChannel a rdfs:Class ;
     rdfs:label "AMRadioChannel" ;
-    :source <https://github.com/schemaorg/schemaorg/issues/1004> ;
     rdfs:comment "A radio channel that uses AM." ;
-    rdfs:subClassOf :RadioChannel .
+    rdfs:subClassOf :RadioChannel ;
+    :source <https://github.com/schemaorg/schemaorg/issues/1004> .
 
 :APIReference a rdfs:Class ;
     rdfs:label "APIReference" ;
@@ -29,13 +31,13 @@
 
 :Accommodation a rdfs:Class ;
     rdfs:label "Accommodation" ;
-    :contributor <https://schema.org/docs/collab/STI_Accommodation_Ontology> ;
     rdfs:comment """An accommodation is a place that can accommodate human beings, e.g. a hotel room, a camping pitch, or a meeting room. Many accommodations are for overnight stays, but this is not a mandatory requirement.
 For more specific types of accommodations not defined in schema.org, one can use [[additionalType]] with external vocabularies.
 <br /><br />
 See also the <a href="/docs/hotels.html">dedicated document on the use of schema.org for marking up hotels and other forms of accommodations</a>.
 """ ;
-    rdfs:subClassOf :Place .
+    rdfs:subClassOf :Place ;
+    :contributor <https://schema.org/docs/collab/STI_Accommodation_Ontology> .
 
 :AccountingService a rdfs:Class ;
     rdfs:label "AccountingService" ;
@@ -50,20 +52,20 @@ See also the <a href="/docs/hotels.html">dedicated document on the use of schema
 
 :Action a rdfs:Class ;
     rdfs:label "Action" ;
-    :contributor <https://schema.org/docs/collab/ActionCollabClass> ;
     rdfs:comment "An action performed by a direct agent and indirect participants upon a direct object. Optionally happens at a location with the help of an inanimate instrument. The execution of the action may produce a result. Specific action sub-type documentation specifies the exact expectation of each argument/role.\\n\\nSee also [blog post](http://blog.schema.org/2014/04/announcing-schemaorg-actions.html) and [Actions overview document](https://schema.org/docs/actions.html)." ;
-    rdfs:subClassOf :Thing .
+    rdfs:subClassOf :Thing ;
+    :contributor <https://schema.org/docs/collab/ActionCollabClass> .
 
 :ActionAccessSpecification a rdfs:Class ;
     rdfs:label "ActionAccessSpecification" ;
-    :source <https://github.com/schemaorg/schemaorg/issues/1741> ;
     rdfs:comment "A set of requirements that must be fulfilled in order to perform an Action." ;
-    rdfs:subClassOf :Intangible .
+    rdfs:subClassOf :Intangible ;
+    :source <https://github.com/schemaorg/schemaorg/issues/1741> .
 
 :ActionStatusType a rdfs:Class ;
     rdfs:label "ActionStatusType" ;
     rdfs:comment "The status of an Action." ;
-    rdfs:subClassOf :StatusEnumeration . # Pending but...
+    rdfs:subClassOf :StatusEnumeration .
 
 :ActivateAction a rdfs:Class ;
     rdfs:label "ActivateAction" ;
@@ -112,11 +114,11 @@ See also the <a href="/docs/hotels.html">dedicated document on the use of schema
 
 :AlignmentObject a rdfs:Class ;
     rdfs:label "AlignmentObject" ;
-    :contributor <https://schema.org/docs/collab/LRMIClass> ;
     rdfs:comment """An intangible item that describes an alignment between a learning resource and a node in an educational framework.
 
 Should not be used where the nature of the alignment can be described using a simple property, for example to express that a resource [[teaches]] or [[assesses]] a competency.""" ;
-    rdfs:subClassOf :Intangible .
+    rdfs:subClassOf :Intangible ;
+    :contributor <https://schema.org/docs/collab/LRMIClass> .
 
 :AllocateAction a rdfs:Class ;
     rdfs:label "AllocateAction" ;
@@ -135,15 +137,15 @@ Should not be used where the nature of the alignment can be described using a si
 
 :Answer a rdfs:Class ;
     rdfs:label "Answer" ;
-    :contributor <https://schema.org/docs/collab/QAStackExchange> ;
     rdfs:comment "An answer offered to a question; perhaps correct, perhaps opinionated or wrong." ;
-    rdfs:subClassOf :Comment .
+    rdfs:subClassOf :Comment ;
+    :contributor <https://schema.org/docs/collab/QAStackExchange> .
 
 :Apartment a rdfs:Class ;
     rdfs:label "Apartment" ;
-    :contributor <https://schema.org/docs/collab/STI_Accommodation_Ontology> ;
     rdfs:comment "An apartment (in American English) or flat (in British English) is a self-contained housing unit (a type of residential real estate) that occupies only part of a building (source: Wikipedia, the free encyclopedia, see <a href=\"http://en.wikipedia.org/wiki/Apartment\">http://en.wikipedia.org/wiki/Apartment</a>)." ;
-    rdfs:subClassOf :Accommodation .
+    rdfs:subClassOf :Accommodation ;
+    :contributor <https://schema.org/docs/collab/STI_Accommodation_Ontology> .
 
 :ApartmentComplex a rdfs:Class ;
     rdfs:label "ApartmentComplex" ;
@@ -177,9 +179,9 @@ Should not be used where the nature of the alignment can be described using a si
 
 :Article a rdfs:Class ;
     rdfs:label "Article" ;
-    :contributor <https://schema.org/docs/collab/rNews> ;
     rdfs:comment "An article, such as a news article or piece of investigative report. Newspapers and magazines have articles of many different types and this is intended to cover them all.\\n\\nSee also [blog post](http://blog.schema.org/2014/09/schemaorg-support-for-bibliographic_2.html)." ;
-    rdfs:subClassOf :CreativeWork .
+    rdfs:subClassOf :CreativeWork ;
+    :contributor <https://schema.org/docs/collab/rNews> .
 
 :AskAction a rdfs:Class ;
     rdfs:label "AskAction" ;
@@ -208,9 +210,9 @@ Should not be used where the nature of the alignment can be described using a si
 
 :AudioObject a rdfs:Class ;
     rdfs:label "AudioObject" ;
-    :contributor <https://schema.org/docs/collab/rNews> ;
     rdfs:comment "An audio file." ;
-    rdfs:subClassOf :MediaObject .
+    rdfs:subClassOf :MediaObject ;
+    :contributor <https://schema.org/docs/collab/rNews> .
 
 :AuthorizeAction a rdfs:Class ;
     rdfs:label "AuthorizeAction" ;
@@ -265,9 +267,9 @@ Should not be used where the nature of the alignment can be described using a si
 
 :BankAccount a rdfs:Class ;
     rdfs:label "BankAccount" ;
-    :contributor <https://schema.org/docs/collab/FIBO> ;
     rdfs:comment "A product or service offered by a bank whereby one may deposit, withdraw or transfer money and in some cases be paid interest." ;
-    rdfs:subClassOf :FinancialProduct .
+    rdfs:subClassOf :FinancialProduct ;
+    :contributor <https://schema.org/docs/collab/FIBO> .
 
 :BankOrCreditUnion a rdfs:Class ;
     rdfs:label "BankOrCreditUnion" ;
@@ -302,24 +304,18 @@ See also the <a href="/docs/hotels.html">dedicated document on the use of schema
 """ ;
     rdfs:subClassOf :LodgingBusiness .
 
-
-:VacationRental a rdfs:Class ;
-    rdfs:label "VacationRental" ;
-    rdfs:comment """A kind of lodging business that focuses on renting single properties for limited time.""" ;
-    rdfs:subClassOf :LodgingBusiness .
-
 :BedDetails a rdfs:Class ;
     rdfs:label "BedDetails" ;
-    :contributor <https://schema.org/docs/collab/STI_Accommodation_Ontology> ;
     rdfs:comment "An entity holding detailed information about the available bed types, e.g. the quantity of twin beds for a hotel room. For the single case of just one bed of a certain type, you can use bed directly with a text. See also [[BedType]] (under development)." ;
-    rdfs:subClassOf :Intangible .
+    rdfs:subClassOf :Intangible ;
+    :contributor <https://schema.org/docs/collab/STI_Accommodation_Ontology> .
 
 :BedType a rdfs:Class ;
     rdfs:label "BedType" ;
-    :source <https://github.com/schemaorg/schemaorg/issues/1262>;
-    :contributor <https://schema.org/docs/collab/STI_Accommodation_Ontology> ;
     rdfs:comment "A type of bed. This is used for indicating the bed or beds available in an accommodation." ;
-    rdfs:subClassOf :QualitativeValue .
+    rdfs:subClassOf :QualitativeValue ;
+    :contributor <https://schema.org/docs/collab/STI_Accommodation_Ontology> ;
+    :source <https://github.com/schemaorg/schemaorg/issues/1262> .
 
 :BefriendAction a rdfs:Class ;
     rdfs:label "BefriendAction" ;
@@ -333,7 +329,7 @@ See also the <a href="/docs/hotels.html">dedicated document on the use of schema
 
 :Blog a rdfs:Class ;
     rdfs:label "Blog" ;
-    rdfs:comment """A [blog](https://en.wikipedia.org/wiki/Blog), sometimes known as a "weblog". Note that the individual posts ([[BlogPosting]]s) in a [[Blog]] are often colloquially referred to by the same term.""" ;
+    rdfs:comment "A [blog](https://en.wikipedia.org/wiki/Blog), sometimes known as a \"weblog\". Note that the individual posts ([[BlogPosting]]s) in a [[Blog]] are often colloquially referred to by the same term." ;
     rdfs:subClassOf :CreativeWork .
 
 :BlogPosting a rdfs:Class ;
@@ -376,8 +372,8 @@ See also the <a href="/docs/hotels.html">dedicated document on the use of schema
     rdfs:comment "An agent bookmarks/flags/labels/tags/marks an object." ;
     rdfs:subClassOf :OrganizeAction .
 
-:Boolean a :DataType,
-        rdfs:Class ;
+:Boolean a rdfs:Class,
+        :DataType ;
     rdfs:label "Boolean" ;
     rdfs:comment "Boolean: True or False." .
 
@@ -393,9 +389,9 @@ See also the <a href="/docs/hotels.html">dedicated document on the use of schema
 
 :Brand a rdfs:Class ;
     rdfs:label "Brand" ;
-    :contributor <https://schema.org/docs/collab/GoodRelationsClass> ;
     rdfs:comment "A brand is a name used by an organization or business person for labeling a product, product group, or similar." ;
-    rdfs:subClassOf :Intangible .
+    rdfs:subClassOf :Intangible ;
+    :contributor <https://schema.org/docs/collab/GoodRelationsClass> .
 
 :BreadcrumbList a rdfs:Class ;
     rdfs:label "BreadcrumbList" ;
@@ -425,9 +421,9 @@ See also the <a href="/docs/hotels.html">dedicated document on the use of schema
 
 :BroadcastFrequencySpecification a rdfs:Class ;
     rdfs:label "BroadcastFrequencySpecification" ;
-    :source <https://github.com/schemaorg/schemaorg/issues/1004> ;
     rdfs:comment "The frequency in MHz and the modulation used for a particular BroadcastService." ;
-    rdfs:subClassOf :Intangible .
+    rdfs:subClassOf :Intangible ;
+    :source <https://github.com/schemaorg/schemaorg/issues/1004> .
 
 :BroadcastService a rdfs:Class ;
     rdfs:label "BroadcastService" ;
@@ -466,10 +462,10 @@ See also the <a href="/docs/hotels.html">dedicated document on the use of schema
 
 :BusinessEntityType a rdfs:Class ;
     rdfs:label "BusinessEntityType" ;
-    :contributor <https://schema.org/docs/collab/GoodRelationsClass> ;
     rdfs:comment """A business entity type is a conceptual entity representing the legal form, the size, the main line of business, the position in the value chain, or any combination thereof, of an organization or business person.\\n\\nCommonly used values:\\n\\n* http://purl.org/goodrelations/v1#Business\\n* http://purl.org/goodrelations/v1#Enduser\\n* http://purl.org/goodrelations/v1#PublicInstitution\\n* http://purl.org/goodrelations/v1#Reseller
     """ ;
-    rdfs:subClassOf :Enumeration .
+    rdfs:subClassOf :Enumeration ;
+    :contributor <https://schema.org/docs/collab/GoodRelationsClass> .
 
 :BusinessEvent a rdfs:Class ;
     rdfs:label "BusinessEvent" ;
@@ -478,10 +474,10 @@ See also the <a href="/docs/hotels.html">dedicated document on the use of schema
 
 :BusinessFunction a rdfs:Class ;
     rdfs:label "BusinessFunction" ;
-    :contributor <https://schema.org/docs/collab/GoodRelationsClass> ;
     rdfs:comment """The business function specifies the type of activity or access (i.e., the bundle of rights) offered by the organization or business person through the offer. Typical are sell, rental or lease, maintenance or repair, manufacture / produce, recycle / dispose, engineering / construction, or installation. Proprietary specifications of access rights are also instances of this class.\\n\\nCommonly used values:\\n\\n* http://purl.org/goodrelations/v1#ConstructionInstallation\\n* http://purl.org/goodrelations/v1#Dispose\\n* http://purl.org/goodrelations/v1#LeaseOut\\n* http://purl.org/goodrelations/v1#Maintain\\n* http://purl.org/goodrelations/v1#ProvideService\\n* http://purl.org/goodrelations/v1#Repair\\n* http://purl.org/goodrelations/v1#Sell\\n* http://purl.org/goodrelations/v1#Buy
         """ ;
-    rdfs:subClassOf :Enumeration .
+    rdfs:subClassOf :Enumeration ;
+    :contributor <https://schema.org/docs/collab/GoodRelationsClass> .
 
 :BuyAction a rdfs:Class ;
     rdfs:label "BuyAction" ;
@@ -500,24 +496,24 @@ See also the <a href="/docs/hotels.html">dedicated document on the use of schema
 
 :Campground a rdfs:Class ;
     rdfs:label "Campground" ;
-    :contributor <https://schema.org/docs/collab/STI_Accommodation_Ontology> ;
     rdfs:comment """A camping site, campsite, or [[Campground]] is a place used for overnight stay in the outdoors, typically containing individual [[CampingPitch]] locations. \\n\\n
 In British English a campsite is an area, usually divided into a number of pitches, where people can camp overnight using tents or camper vans or caravans; this British English use of the word is synonymous with the American English expression campground. In American English the term campsite generally means an area where an individual, family, group, or military unit can pitch a tent or park a camper; a campground may contain many campsites (source: Wikipedia, see [https://en.wikipedia.org/wiki/Campsite](https://en.wikipedia.org/wiki/Campsite)).\\n\\n
 
 See also the dedicated [document on the use of schema.org for marking up hotels and other forms of accommodations](/docs/hotels.html).
 """ ;
     rdfs:subClassOf :CivicStructure,
-        :LodgingBusiness .
+        :LodgingBusiness ;
+    :contributor <https://schema.org/docs/collab/STI_Accommodation_Ontology> .
 
 :CampingPitch a rdfs:Class ;
     rdfs:label "CampingPitch" ;
-    :contributor <https://schema.org/docs/collab/STI_Accommodation_Ontology> ;
     rdfs:comment """A [[CampingPitch]] is an individual place for overnight stay in the outdoors, typically being part of a larger camping site, or [[Campground]].\\n\\n
 In British English a campsite, or campground, is an area, usually divided into a number of pitches, where people can camp overnight using tents or camper vans or caravans; this British English use of the word is synonymous with the American English expression campground. In American English the term campsite generally means an area where an individual, family, group, or military unit can pitch a tent or park a camper; a campground may contain many campsites.
 (Source: Wikipedia, see [https://en.wikipedia.org/wiki/Campsite](https://en.wikipedia.org/wiki/Campsite).)\\n\\n
 See also the dedicated [document on the use of schema.org for marking up hotels and other forms of accommodations](/docs/hotels.html).
 """ ;
-    rdfs:subClassOf :Accommodation .
+    rdfs:subClassOf :Accommodation ;
+    :contributor <https://schema.org/docs/collab/STI_Accommodation_Ontology> .
 
 :Canal a rdfs:Class ;
     rdfs:label "Canal" ;
@@ -531,9 +527,9 @@ See also the dedicated [document on the use of schema.org for marking up hotels 
 
 :Car a rdfs:Class ;
     rdfs:label "Car" ;
-    :contributor <https://schema.org/docs/collab/Automotive_Ontology_Working_Group> ;
     rdfs:comment "A car is a wheeled, self-powered motor vehicle used for transportation." ;
-    rdfs:subClassOf :Vehicle .
+    rdfs:subClassOf :Vehicle ;
+    :contributor <https://schema.org/docs/collab/Automotive_Ontology_Working_Group> .
 
 :Casino a rdfs:Class ;
     rdfs:label "Casino" ;
@@ -607,9 +603,9 @@ See also the dedicated [document on the use of schema.org for marking up hotels 
 
 :ClaimReview a rdfs:Class ;
     rdfs:label "ClaimReview" ;
-    :source <https://github.com/schemaorg/schemaorg/issues/1061> ;
     rdfs:comment "A fact-checking review of claims made (or reported) in some creative work (referenced via itemReviewed)." ;
-    rdfs:subClassOf :Review .
+    rdfs:subClassOf :Review ;
+    :source <https://github.com/schemaorg/schemaorg/issues/1061> .
 
 :Clip a rdfs:Class ;
     rdfs:label "Clip" ;
@@ -623,9 +619,9 @@ See also the dedicated [document on the use of schema.org for marking up hotels 
 
 :Code a rdfs:Class ;
     rdfs:label "Code" ;
-    :supersededBy :SoftwareSourceCode ;
     rdfs:comment "Computer programming source code. Example: Full (compile ready) solutions, code snippet samples, scripts, templates." ;
-    rdfs:subClassOf :CreativeWork .
+    rdfs:subClassOf :CreativeWork ;
+    :supersededBy :SoftwareSourceCode .
 
 :CollectionPage a rdfs:Class ;
     rdfs:label "CollectionPage" ;
@@ -664,9 +660,9 @@ See also the dedicated [document on the use of schema.org for marking up hotels 
 
 :CompoundPriceSpecification a rdfs:Class ;
     rdfs:label "CompoundPriceSpecification" ;
-    :contributor <https://schema.org/docs/collab/GoodRelationsClass> ;
     rdfs:comment "A compound price specification is one that bundles multiple prices that all apply in combination for different dimensions of consumption. Use the name property of the attached unit price specification for indicating the dimension of a price component (e.g. \"electricity\" or \"final cleaning\")." ;
-    rdfs:subClassOf :PriceSpecification .
+    rdfs:subClassOf :PriceSpecification ;
+    :contributor <https://schema.org/docs/collab/GoodRelationsClass> .
 
 :ComputerLanguage a rdfs:Class ;
     rdfs:label "ComputerLanguage" ;
@@ -730,9 +726,9 @@ See also the dedicated [document on the use of schema.org for marking up hotels 
 
 :Corporation a rdfs:Class ;
     rdfs:label "Corporation" ;
-    :contributor <https://schema.org/docs/collab/rNews> ;
     rdfs:comment "Organization: A business corporation." ;
-    rdfs:subClassOf :Organization .
+    rdfs:subClassOf :Organization ;
+    :contributor <https://schema.org/docs/collab/rNews> .
 
 :Country a rdfs:Class ;
     rdfs:label "Country" ;
@@ -761,9 +757,9 @@ See also the dedicated [document on the use of schema.org for marking up hotels 
 
 :CreativeWork a rdfs:Class ;
     rdfs:label "CreativeWork" ;
-    :contributor <https://schema.org/docs/collab/rNews> ;
     rdfs:comment "The most generic kind of creative work, including books, movies, photographs, software programs, etc." ;
-    rdfs:subClassOf :Thing .
+    rdfs:subClassOf :Thing ;
+    :contributor <https://schema.org/docs/collab/rNews> .
 
 :CreativeWorkSeason a rdfs:Class ;
     rdfs:label "CreativeWorkSeason" ;
@@ -779,12 +775,12 @@ See also the dedicated [document on the use of schema.org for marking up hotels 
 
 :CreditCard a rdfs:Class ;
     rdfs:label "CreditCard" ;
-    :contributor <https://schema.org/docs/collab/FIBO>,
-        <https://schema.org/docs/collab/GoodRelationsClass> ;
     rdfs:comment """A card payment method of a particular brand or name.  Used to mark up a particular payment method and/or the financial product/service that supplies the card account.\\n\\nCommonly used values:\\n\\n* http://purl.org/goodrelations/v1#AmericanExpress\\n* http://purl.org/goodrelations/v1#DinersClub\\n* http://purl.org/goodrelations/v1#Discover\\n* http://purl.org/goodrelations/v1#JCB\\n* http://purl.org/goodrelations/v1#MasterCard\\n* http://purl.org/goodrelations/v1#VISA
        """ ;
     rdfs:subClassOf :LoanOrCredit,
-        :PaymentCard .
+        :PaymentCard ;
+    :contributor <https://schema.org/docs/collab/FIBO>,
+        <https://schema.org/docs/collab/GoodRelationsClass> .
 
 :Crematorium a rdfs:Class ;
     rdfs:label "Crematorium" ;
@@ -793,9 +789,9 @@ See also the dedicated [document on the use of schema.org for marking up hotels 
 
 :CurrencyConversionService a rdfs:Class ;
     rdfs:label "CurrencyConversionService" ;
-    :contributor <https://schema.org/docs/collab/FIBO> ;
     rdfs:comment "A service to convert funds from one currency to another currency." ;
-    rdfs:subClassOf :FinancialProduct .
+    rdfs:subClassOf :FinancialProduct ;
+    :contributor <https://schema.org/docs/collab/FIBO> .
 
 :DanceEvent a rdfs:Class ;
     rdfs:label "DanceEvent" ;
@@ -809,17 +805,17 @@ See also the dedicated [document on the use of schema.org for marking up hotels 
 
 :DataCatalog a rdfs:Class ;
     rdfs:label "DataCatalog" ;
-    :contributor <https://schema.org/docs/collab/DatasetClass> ;
     rdfs:comment "A collection of datasets." ;
     rdfs:subClassOf :CreativeWork ;
-    owl:equivalentClass <http://www.w3.org/ns/dcat#Catalog> .
+    owl:equivalentClass dcat:Catalog ;
+    :contributor <https://schema.org/docs/collab/DatasetClass> .
 
 :DataDownload a rdfs:Class ;
     rdfs:label "DataDownload" ;
-    :contributor <https://schema.org/docs/collab/DatasetClass> ;
     rdfs:comment "All or part of a [[Dataset]] in downloadable form. " ;
     rdfs:subClassOf :MediaObject ;
-    owl:equivalentClass <http://www.w3.org/ns/dcat#Distribution> .
+    owl:equivalentClass dcat:Distribution ;
+    :contributor <https://schema.org/docs/collab/DatasetClass> .
 
 :DataFeed a rdfs:Class ;
     rdfs:label "DataFeed" ;
@@ -838,37 +834,37 @@ See also the dedicated [document on the use of schema.org for marking up hotels 
 
 :Dataset a rdfs:Class ;
     rdfs:label "Dataset" ;
-    :contributor <https://schema.org/docs/collab/DatasetClass> ;
     rdfs:comment "A body of structured information describing some topic(s) of interest." ;
     rdfs:subClassOf :CreativeWork ;
-    owl:equivalentClass <http://purl.org/dc/dcmitype/Dataset>,
-        <http://rdfs.org/ns/void#Dataset>,
-        <http://www.w3.org/ns/dcat#Dataset> .
+    owl:equivalentClass dcmitype:Dataset,
+        void:Dataset,
+        dcat:Dataset ;
+    :contributor <https://schema.org/docs/collab/DatasetClass> .
 
-:Date a :DataType,
-        rdfs:Class ;
+:Date a rdfs:Class,
+        :DataType ;
     rdfs:label "Date" ;
     rdfs:comment "A date value in [ISO 8601 date format](http://en.wikipedia.org/wiki/ISO_8601)." .
 
-:DateTime a :DataType,
-        rdfs:Class ;
+:DateTime a rdfs:Class,
+        :DataType ;
     rdfs:label "DateTime" ;
     rdfs:comment "A combination of date and time of day in the form [-]CCYY-MM-DDThh:mm:ss[Z|(+|-)hh:mm] (see Chapter 5.4 of ISO 8601)." .
 
 :DatedMoneySpecification a rdfs:Class ;
     rdfs:label "DatedMoneySpecification" ;
-    :supersededBy :MonetaryAmount ;
     rdfs:comment "A DatedMoneySpecification represents monetary values with optional start and end dates. For example, this could represent an employee's salary over a specific period of time. __Note:__ This type has been superseded by [[MonetaryAmount]], use of that type is recommended." ;
-    rdfs:subClassOf :StructuredValue .
+    rdfs:subClassOf :StructuredValue ;
+    :supersededBy :MonetaryAmount .
 
 :DayOfWeek a rdfs:Class ;
     rdfs:label "DayOfWeek" ;
-    :contributor <https://schema.org/docs/collab/GoodRelationsClass> ;
     rdfs:comment """The day of the week, e.g. used to specify to which day the opening hours of an OpeningHoursSpecification refer.
 
 Originally, URLs from [GoodRelations](http://purl.org/goodrelations/v1) were used (for [[Monday]], [[Tuesday]], [[Wednesday]], [[Thursday]], [[Friday]], [[Saturday]], [[Sunday]] plus a special entry for [[PublicHolidays]]); these have now been integrated directly into schema.org.
       """ ;
-    rdfs:subClassOf :Enumeration .
+    rdfs:subClassOf :Enumeration ;
+    :contributor <https://schema.org/docs/collab/GoodRelationsClass> .
 
 :DaySpa a rdfs:Class ;
     rdfs:label "DaySpa" ;
@@ -892,9 +888,9 @@ Originally, URLs from [GoodRelations](http://purl.org/goodrelations/v1) were use
 
 :DeliveryChargeSpecification a rdfs:Class ;
     rdfs:label "DeliveryChargeSpecification" ;
-    :contributor <https://schema.org/docs/collab/GoodRelationsClass> ;
     rdfs:comment "The price for the delivery of an offer using a particular delivery method." ;
-    rdfs:subClassOf :PriceSpecification .
+    rdfs:subClassOf :PriceSpecification ;
+    :contributor <https://schema.org/docs/collab/GoodRelationsClass> .
 
 :DeliveryEvent a rdfs:Class ;
     rdfs:label "DeliveryEvent" ;
@@ -903,16 +899,16 @@ Originally, URLs from [GoodRelations](http://purl.org/goodrelations/v1) were use
 
 :DeliveryMethod a rdfs:Class ;
     rdfs:label "DeliveryMethod" ;
-    :contributor <https://schema.org/docs/collab/GoodRelationsClass> ;
     rdfs:comment """A delivery method is a standardized procedure for transferring the product or service to the destination of fulfillment chosen by the customer. Delivery methods are characterized by the means of transportation used, and by the organization or group that is the contracting party for the sending organization or person.\\n\\nCommonly used values:\\n\\n* http://purl.org/goodrelations/v1#DeliveryModeDirectDownload\\n* http://purl.org/goodrelations/v1#DeliveryModeFreight\\n* http://purl.org/goodrelations/v1#DeliveryModeMail\\n* http://purl.org/goodrelations/v1#DeliveryModeOwnFleet\\n* http://purl.org/goodrelations/v1#DeliveryModePickUp\\n* http://purl.org/goodrelations/v1#DHL\\n* http://purl.org/goodrelations/v1#FederalExpress\\n* http://purl.org/goodrelations/v1#UPS
         """ ;
-    rdfs:subClassOf :Enumeration .
+    rdfs:subClassOf :Enumeration ;
+    :contributor <https://schema.org/docs/collab/GoodRelationsClass> .
 
 :Demand a rdfs:Class ;
     rdfs:label "Demand" ;
-    :contributor <https://schema.org/docs/collab/GoodRelationsClass> ;
     rdfs:comment "A demand entity represents the public, not necessarily binding, not necessarily exclusive, announcement by an organization or person to seek a certain type of goods or services. For describing demand using this type, the very same properties used for Offer apply." ;
-    rdfs:subClassOf :Intangible .
+    rdfs:subClassOf :Intangible ;
+    :contributor <https://schema.org/docs/collab/GoodRelationsClass> .
 
 :Dentist a rdfs:Class ;
     rdfs:label "Dentist" ;
@@ -932,10 +928,10 @@ Originally, URLs from [GoodRelations](http://purl.org/goodrelations/v1) were use
 
 :DepositAccount a rdfs:Class ;
     rdfs:label "DepositAccount" ;
-    :contributor <https://schema.org/docs/collab/FIBO> ;
     rdfs:comment "A type of Bank Account with a main purpose of depositing funds to gain interest or other benefits." ;
     rdfs:subClassOf :BankAccount,
-        :InvestmentOrDeposit .
+        :InvestmentOrDeposit ;
+    :contributor <https://schema.org/docs/collab/FIBO> .
 
 :DigitalDocument a rdfs:Class ;
     rdfs:label "DigitalDocument" ;
@@ -979,9 +975,9 @@ Originally, URLs from [GoodRelations](http://purl.org/goodrelations/v1) were use
 
 :Distillery a rdfs:Class ;
     rdfs:label "Distillery" ;
-    :source <https://github.com/schemaorg/schemaorg/issues/743> ;
     rdfs:comment "A distillery." ;
-    rdfs:subClassOf :FoodEstablishment .
+    rdfs:subClassOf :FoodEstablishment ;
+    :source <https://github.com/schemaorg/schemaorg/issues/743> .
 
 :DonateAction a rdfs:Class ;
     rdfs:label "DonateAction" ;
@@ -1005,9 +1001,9 @@ Originally, URLs from [GoodRelations](http://purl.org/goodrelations/v1) were use
 
 :DriveWheelConfigurationValue a rdfs:Class ;
     rdfs:label "DriveWheelConfigurationValue" ;
-    :contributor <https://schema.org/docs/collab/Automotive_Ontology_Working_Group> ;
     rdfs:comment "A value indicating which roadwheels will receive torque." ;
-    rdfs:subClassOf :QualitativeValue .
+    rdfs:subClassOf :QualitativeValue ;
+    :contributor <https://schema.org/docs/collab/Automotive_Ontology_Working_Group> .
 
 :DryCleaningOrLaundry a rdfs:Class ;
     rdfs:label "DryCleaningOrLaundry" ;
@@ -1031,9 +1027,9 @@ Originally, URLs from [GoodRelations](http://purl.org/goodrelations/v1) were use
 
 :EducationalAudience a rdfs:Class ;
     rdfs:label "EducationalAudience" ;
-    :contributor <https://schema.org/docs/collab/LRMIClass> ;
     rdfs:comment "An EducationalAudience." ;
-    rdfs:subClassOf :Audience .
+    rdfs:subClassOf :Audience ;
+    :contributor <https://schema.org/docs/collab/LRMIClass> .
 
 :EducationalOrganization a rdfs:Class ;
     rdfs:label "EducationalOrganization" ;
@@ -1078,9 +1074,9 @@ Originally, URLs from [GoodRelations](http://purl.org/goodrelations/v1) were use
 
 :EmployerAggregateRating a rdfs:Class ;
     rdfs:label "EmployerAggregateRating" ;
-    :source <https://github.com/schemaorg/schemaorg/issues/1689> ;
     rdfs:comment "An aggregate rating of an Organization related to its role as an employer." ;
-    rdfs:subClassOf :AggregateRating .
+    rdfs:subClassOf :AggregateRating ;
+    :source <https://github.com/schemaorg/schemaorg/issues/1689> .
 
 :EmploymentAgency a rdfs:Class ;
     rdfs:label "EmploymentAgency" ;
@@ -1094,7 +1090,6 @@ Originally, URLs from [GoodRelations](http://purl.org/goodrelations/v1) were use
 
 :EndorsementRating a rdfs:Class ;
     rdfs:label "EndorsementRating" ;
-    :source <https://github.com/schemaorg/schemaorg/issues/1293> ;
     rdfs:comment """An EndorsementRating is a rating that expresses some level of endorsement, for example inclusion in a "critic's pick" blog, a
 "Like" or "+1" on a social network. It can be considered the [[result]] of an [[EndorseAction]] in which the [[object]] of the action is rated positively by
 some [[agent]]. As is common elsewhere in schema.org, it is sometimes more useful to describe the results of such an action without explicitly describing the [[Action]].
@@ -1102,7 +1097,8 @@ some [[agent]]. As is common elsewhere in schema.org, it is sometimes more usefu
 An [[EndorsementRating]] may be part of a numeric scale or organized system, but this is not required: having an explicit type for indicating a positive,
 endorsement rating is particularly useful in the absence of numeric scales as it helps consumers understand that the rating is broadly positive.
 """ ;
-    rdfs:subClassOf :Rating .
+    rdfs:subClassOf :Rating ;
+    :source <https://github.com/schemaorg/schemaorg/issues/1293> .
 
 :Energy a rdfs:Class ;
     rdfs:label "Energy" ;
@@ -1111,9 +1107,9 @@ endorsement rating is particularly useful in the absence of numeric scales as it
 
 :EngineSpecification a rdfs:Class ;
     rdfs:label "EngineSpecification" ;
-    :contributor <https://schema.org/docs/collab/Automotive_Ontology_Working_Group> ;
     rdfs:comment "Information about the engine of the vehicle. A vehicle can have multiple engines represented by multiple engine specification entities." ;
-    rdfs:subClassOf :StructuredValue .
+    rdfs:subClassOf :StructuredValue ;
+    :contributor <https://schema.org/docs/collab/Automotive_Ontology_Working_Group> .
 
 :EntertainmentBusiness a rdfs:Class ;
     rdfs:label "EntertainmentBusiness" ;
@@ -1122,9 +1118,9 @@ endorsement rating is particularly useful in the absence of numeric scales as it
 
 :EntryPoint a rdfs:Class ;
     rdfs:label "EntryPoint" ;
-    :contributor <https://schema.org/docs/collab/ActionCollabClass> ;
     rdfs:comment "An entry point, within some Web-based protocol." ;
-    rdfs:subClassOf :Intangible .
+    rdfs:subClassOf :Intangible ;
+    :contributor <https://schema.org/docs/collab/ActionCollabClass> .
 
 :Enumeration a rdfs:Class ;
     rdfs:label "Enumeration" ;
@@ -1140,7 +1136,7 @@ endorsement rating is particularly useful in the absence of numeric scales as it
     rdfs:label "Event" ;
     rdfs:comment "An event happening at a certain time and location, such as a concert, lecture, or festival. Ticketing information may be added via the [[offers]] property. Repeated events may be structured as separate Event objects." ;
     rdfs:subClassOf :Thing ;
-    owl:equivalentClass <http://purl.org/dc/dcmitype/Event> .
+    owl:equivalentClass dcmitype:Event .
 
 :EventReservation a rdfs:Class ;
     rdfs:label "EventReservation" ;
@@ -1174,15 +1170,15 @@ endorsement rating is particularly useful in the absence of numeric scales as it
 
 :FAQPage a rdfs:Class ;
     rdfs:label "FAQPage" ;
-    :source <https://github.com/schemaorg/schemaorg/issues/1723> ;
     rdfs:comment "A [[FAQPage]] is a [[WebPage]] presenting one or more \"[Frequently asked questions](https://en.wikipedia.org/wiki/FAQ)\" (see also [[QAPage]])." ;
-    rdfs:subClassOf :WebPage .
+    rdfs:subClassOf :WebPage ;
+    :source <https://github.com/schemaorg/schemaorg/issues/1723> .
 
 :FMRadioChannel a rdfs:Class ;
     rdfs:label "FMRadioChannel" ;
-    :source <https://github.com/schemaorg/schemaorg/issues/1004> ;
     rdfs:comment "A radio channel that uses FM." ;
-    rdfs:subClassOf :RadioChannel .
+    rdfs:subClassOf :RadioChannel ;
+    :source <https://github.com/schemaorg/schemaorg/issues/1004> .
 
 :FastFoodRestaurant a rdfs:Class ;
     rdfs:label "FastFoodRestaurant" ;
@@ -1201,9 +1197,9 @@ endorsement rating is particularly useful in the absence of numeric scales as it
 
 :FinancialProduct a rdfs:Class ;
     rdfs:label "FinancialProduct" ;
-    :contributor <https://schema.org/docs/collab/FIBO> ;
     rdfs:comment "A product provided to consumers and businesses by financial institutions such as banks, insurance companies, brokerage firms, consumer finance companies, and investment companies which comprise the financial services industry." ;
-    rdfs:subClassOf :Service .
+    rdfs:subClassOf :Service ;
+    :contributor <https://schema.org/docs/collab/FIBO> .
 
 :FinancialService a rdfs:Class ;
     rdfs:label "FinancialService" ;
@@ -1263,9 +1259,9 @@ endorsement rating is particularly useful in the absence of numeric scales as it
 
 :FoodService a rdfs:Class ;
     rdfs:label "FoodService" ;
-    :contributor <https://schema.org/docs/collab/STI_Accommodation_Ontology> ;
     rdfs:comment "A food service, like breakfast, lunch, or dinner." ;
-    rdfs:subClassOf :Service .
+    rdfs:subClassOf :Service ;
+    :contributor <https://schema.org/docs/collab/STI_Accommodation_Ontology> .
 
 :FurnitureStore a rdfs:Class ;
     rdfs:label "FurnitureStore" ;
@@ -1332,9 +1328,9 @@ endorsement rating is particularly useful in the absence of numeric scales as it
 
 :GeoShape a rdfs:Class ;
     rdfs:label "GeoShape" ;
-    :contributor <https://schema.org/docs/collab/rNews> ;
     rdfs:comment "The geographic shape of a place. A GeoShape can be described using several properties whose values are based on latitude/longitude pairs. Either whitespace or commas can be used to separate latitude and longitude; whitespace should be used when writing a list of several such points." ;
-    rdfs:subClassOf :StructuredValue .
+    rdfs:subClassOf :StructuredValue ;
+    :contributor <https://schema.org/docs/collab/rNews> .
 
 :GiveAction a rdfs:Class ;
     rdfs:label "GiveAction" ;
@@ -1444,27 +1440,27 @@ See also the <a href="/docs/hotels.html">dedicated document on the use of schema
 
 :Hotel a rdfs:Class ;
     rdfs:label "Hotel" ;
-    :contributor <https://schema.org/docs/collab/STI_Accommodation_Ontology> ;
     rdfs:comment """A hotel is an establishment that provides lodging paid on a short-term basis (source: Wikipedia, the free encyclopedia, see http://en.wikipedia.org/wiki/Hotel).
 <br /><br />
 See also the <a href="/docs/hotels.html">dedicated document on the use of schema.org for marking up hotels and other forms of accommodations</a>.
 """ ;
-    rdfs:subClassOf :LodgingBusiness .
+    rdfs:subClassOf :LodgingBusiness ;
+    :contributor <https://schema.org/docs/collab/STI_Accommodation_Ontology> .
 
 :HotelRoom a rdfs:Class ;
     rdfs:label "HotelRoom" ;
-    :contributor <https://schema.org/docs/collab/STI_Accommodation_Ontology> ;
     rdfs:comment """A hotel room is a single room in a hotel.
 <br /><br />
 See also the <a href="/docs/hotels.html">dedicated document on the use of schema.org for marking up hotels and other forms of accommodations</a>.
 """ ;
-    rdfs:subClassOf :Room .
+    rdfs:subClassOf :Room ;
+    :contributor <https://schema.org/docs/collab/STI_Accommodation_Ontology> .
 
 :House a rdfs:Class ;
     rdfs:label "House" ;
-    :contributor <https://schema.org/docs/collab/STI_Accommodation_Ontology> ;
     rdfs:comment "A house is a building or structure that has the ability to be occupied for habitation by humans or other creatures (source: Wikipedia, the free encyclopedia, see <a href=\"http://en.wikipedia.org/wiki/House\">http://en.wikipedia.org/wiki/House</a>)." ;
-    rdfs:subClassOf :Accommodation .
+    rdfs:subClassOf :Accommodation ;
+    :contributor <https://schema.org/docs/collab/STI_Accommodation_Ontology> .
 
 :HousePainter a rdfs:Class ;
     rdfs:label "HousePainter" ;
@@ -1536,13 +1532,13 @@ See also the <a href="/docs/hotels.html">dedicated document on the use of schema
     rdfs:label "ImageObject" ;
     rdfs:comment "An image file." ;
     rdfs:subClassOf :MediaObject ;
-    owl:equivalentClass <http://purl.org/dc/dcmitype/Image> .
+    owl:equivalentClass dcmitype:Image .
 
 :IndividualProduct a rdfs:Class ;
     rdfs:label "IndividualProduct" ;
-    :contributor <https://schema.org/docs/collab/GoodRelationsClass> ;
     rdfs:comment "A single, identifiable product instance (e.g. a laptop with a particular serial number)." ;
-    rdfs:subClassOf :Product .
+    rdfs:subClassOf :Product ;
+    :contributor <https://schema.org/docs/collab/GoodRelationsClass> .
 
 :InformAction a rdfs:Class ;
     rdfs:label "InformAction" ;
@@ -1591,9 +1587,9 @@ See also the <a href="/docs/hotels.html">dedicated document on the use of schema
 
 :InvestmentOrDeposit a rdfs:Class ;
     rdfs:label "InvestmentOrDeposit" ;
-    :contributor <https://schema.org/docs/collab/FIBO> ;
     rdfs:comment "A type of financial product that typically requires the client to transfer funds to a financial service in return for potential beneficial financial return." ;
-    rdfs:subClassOf :FinancialProduct .
+    rdfs:subClassOf :FinancialProduct ;
+    :contributor <https://schema.org/docs/collab/FIBO> .
 
 :InviteAction a rdfs:Class ;
     rdfs:label "InviteAction" ;
@@ -1717,9 +1713,9 @@ See also the <a href="/docs/hotels.html">dedicated document on the use of schema
 
 :LoanOrCredit a rdfs:Class ;
     rdfs:label "LoanOrCredit" ;
-    :contributor <https://schema.org/docs/collab/FIBO> ;
     rdfs:comment "A financial product for the loaning of an amount of money, or line of credit, under agreed terms and charges." ;
-    rdfs:subClassOf :FinancialProduct .
+    rdfs:subClassOf :FinancialProduct ;
+    :contributor <https://schema.org/docs/collab/FIBO> .
 
 :LocalBusiness a rdfs:Class ;
     rdfs:label "LocalBusiness" ;
@@ -1729,9 +1725,9 @@ See also the <a href="/docs/hotels.html">dedicated document on the use of schema
 
 :LocationFeatureSpecification a rdfs:Class ;
     rdfs:label "LocationFeatureSpecification" ;
-    :contributor <https://schema.org/docs/collab/STI_Accommodation_Ontology> ;
     rdfs:comment "Specifies a location feature by providing a structured value representing a feature of an accommodation as a property-value pair of varying degrees of formality." ;
-    rdfs:subClassOf :PropertyValue .
+    rdfs:subClassOf :PropertyValue ;
+    :contributor <https://schema.org/docs/collab/STI_Accommodation_Ontology> .
 
 :Locksmith a rdfs:Class ;
     rdfs:label "Locksmith" ;
@@ -1785,9 +1781,9 @@ See also the <a href="/docs/hotels.html">dedicated document on the use of schema
 
 :MediaSubscription a rdfs:Class ;
     rdfs:label "MediaSubscription" ;
-    :source <https://github.com/schemaorg/schemaorg/issues/1741> ;
     rdfs:comment "A subscription which allows a user to access media including audio, video, books, etc." ;
-    rdfs:subClassOf :Intangible .
+    rdfs:subClassOf :Intangible ;
+    :source <https://github.com/schemaorg/schemaorg/issues/1741> .
 
 :MedicalOrganization a rdfs:Class ;
     rdfs:label "MedicalOrganization" ;
@@ -1796,12 +1792,12 @@ See also the <a href="/docs/hotels.html">dedicated document on the use of schema
 
 :MeetingRoom a rdfs:Class ;
     rdfs:label "MeetingRoom" ;
-    :contributor <https://schema.org/docs/collab/STI_Accommodation_Ontology> ;
     rdfs:comment """A meeting room, conference room, or conference hall is a room provided for singular events such as business conferences and meetings (source: Wikipedia, the free encyclopedia, see <a href="http://en.wikipedia.org/wiki/Conference_hall">http://en.wikipedia.org/wiki/Conference_hall</a>).
 <br /><br />
 See also the <a href="/docs/hotels.html">dedicated document on the use of schema.org for marking up hotels and other forms of accommodations</a>.
 """ ;
-    rdfs:subClassOf :Room .
+    rdfs:subClassOf :Room ;
+    :contributor <https://schema.org/docs/collab/STI_Accommodation_Ontology> .
 
 :MensClothingStore a rdfs:Class ;
     rdfs:label "MensClothingStore" ;
@@ -1845,15 +1841,15 @@ See also the <a href="/docs/hotels.html">dedicated document on the use of schema
 
 :MonetaryAmount a rdfs:Class ;
     rdfs:label "MonetaryAmount" ;
-    :contributor <https://schema.org/docs/collab/FIBO> ;
     rdfs:comment "A monetary value or range. This type can be used to describe an amount of money such as $50 USD, or a range as in describing a bank account being suitable for a balance between £1,000 and £1,000,000 GBP, or the value of a salary, etc. It is recommended to use [[PriceSpecification]] Types to describe the price of an Offer, Invoice, etc." ;
-    rdfs:subClassOf :StructuredValue .
+    rdfs:subClassOf :StructuredValue ;
+    :contributor <https://schema.org/docs/collab/FIBO> .
 
 :MonetaryAmountDistribution a rdfs:Class ;
     rdfs:label "MonetaryAmountDistribution" ;
-    :source <https://github.com/schemaorg/schemaorg/issues/1698> ;
     rdfs:comment "A statistical distribution of monetary amounts." ;
-    rdfs:subClassOf :QuantitativeValueDistribution .
+    rdfs:subClassOf :QuantitativeValueDistribution ;
+    :source <https://github.com/schemaorg/schemaorg/issues/1698> .
 
 :Mosque a rdfs:Class ;
     rdfs:label "Mosque" ;
@@ -1931,21 +1927,21 @@ See also the <a href="/docs/hotels.html">dedicated document on the use of schema
 
 :MusicAlbumProductionType a rdfs:Class ;
     rdfs:label "MusicAlbumProductionType" ;
-    :contributor <https://schema.org/docs/collab/MBZ> ;
     rdfs:comment "Classification of the album by its type of content: soundtrack, live album, studio album, etc." ;
-    rdfs:subClassOf :Enumeration .
+    rdfs:subClassOf :Enumeration ;
+    :contributor <https://schema.org/docs/collab/MBZ> .
 
 :MusicAlbumReleaseType a rdfs:Class ;
     rdfs:label "MusicAlbumReleaseType" ;
-    :contributor <https://schema.org/docs/collab/MBZ> ;
     rdfs:comment "The kind of release which this album is: single, EP or album." ;
-    rdfs:subClassOf :Enumeration .
+    rdfs:subClassOf :Enumeration ;
+    :contributor <https://schema.org/docs/collab/MBZ> .
 
 :MusicComposition a rdfs:Class ;
     rdfs:label "MusicComposition" ;
-    :contributor <https://schema.org/docs/collab/MBZ> ;
     rdfs:comment "A musical composition." ;
-    rdfs:subClassOf :CreativeWork .
+    rdfs:subClassOf :CreativeWork ;
+    :contributor <https://schema.org/docs/collab/MBZ> .
 
 :MusicEvent a rdfs:Class ;
     rdfs:label "MusicEvent" ;
@@ -1969,15 +1965,15 @@ See also the <a href="/docs/hotels.html">dedicated document on the use of schema
 
 :MusicRelease a rdfs:Class ;
     rdfs:label "MusicRelease" ;
-    :contributor <https://schema.org/docs/collab/MBZ> ;
     rdfs:comment "A MusicRelease is a specific release of a music album." ;
-    rdfs:subClassOf :MusicPlaylist .
+    rdfs:subClassOf :MusicPlaylist ;
+    :contributor <https://schema.org/docs/collab/MBZ> .
 
 :MusicReleaseFormatType a rdfs:Class ;
     rdfs:label "MusicReleaseFormatType" ;
-    :contributor <https://schema.org/docs/collab/MBZ> ;
     rdfs:comment "Format of this release (the type of recording media used, i.e. compact disc, digital media, LP, etc.)." ;
-    rdfs:subClassOf :Enumeration .
+    rdfs:subClassOf :Enumeration ;
+    :contributor <https://schema.org/docs/collab/MBZ> .
 
 :MusicStore a rdfs:Class ;
     rdfs:label "MusicStore" ;
@@ -1999,12 +1995,6 @@ See also the <a href="/docs/hotels.html">dedicated document on the use of schema
     rdfs:comment "Organization: Non-governmental Organization." ;
     rdfs:subClassOf :Organization .
 
-:PoliticalParty a rdfs:Class ;
-    rdfs:label "PoliticalParty" ;
-    rdfs:comment "Organization: Political Party." ;
-    :source <https://github.com/schemaorg/schemaorg/issues/3282> ;
-    rdfs:subClassOf :Organization .
-
 :NailSalon a rdfs:Class ;
     rdfs:label "NailSalon" ;
     rdfs:comment "A nail salon." ;
@@ -2012,13 +2002,13 @@ See also the <a href="/docs/hotels.html">dedicated document on the use of schema
 
 :NewsArticle a rdfs:Class ;
     rdfs:label "NewsArticle" ;
-    :contributor <https://schema.org/docs/collab/rNews>,
-        <https://schema.org/docs/collab/TP> ;
     rdfs:comment """A NewsArticle is an article whose content reports news, or provides background context and supporting materials for understanding the news.
 
 A more detailed overview of [schema.org News markup](/docs/news.html) is also available.
 """ ;
-    rdfs:subClassOf :Article .
+    rdfs:subClassOf :Article ;
+    :contributor <https://schema.org/docs/collab/TP>,
+        <https://schema.org/docs/collab/rNews> .
 
 :NightClub a rdfs:Class ;
     rdfs:label "NightClub" ;
@@ -2035,8 +2025,8 @@ A more detailed overview of [schema.org News markup](/docs/news.html) is also av
     rdfs:comment "A file containing a note, primarily for the author." ;
     rdfs:subClassOf :DigitalDocument .
 
-:Number a :DataType,
-        rdfs:Class ;
+:Number a rdfs:Class,
+        :DataType ;
     rdfs:label "Number" ;
     rdfs:comment "Data type: Number.\\n\\nUsage guidelines:\\n\\n* Use values from 0123456789 (Unicode 'DIGIT ZERO' (U+0030) to 'DIGIT NINE' (U+0039)) rather than superficially similar Unicode symbols.\\n* Use '.' (Unicode 'FULL STOP' (U+002E)) rather than ',' to indicate a decimal point. Avoid using these symbols as a readability separator." .
 
@@ -2047,9 +2037,9 @@ A more detailed overview of [schema.org News markup](/docs/news.html) is also av
 
 :Occupation a rdfs:Class ;
     rdfs:label "Occupation" ;
-    :source <https://github.com/schemaorg/schemaorg/issues/1698> ;
     rdfs:comment "A profession, may involve prolonged training and/or a formal qualification." ;
-    rdfs:subClassOf :Intangible .
+    rdfs:subClassOf :Intangible ;
+    :source <https://github.com/schemaorg/schemaorg/issues/1698> .
 
 :OceanBodyOfWater a rdfs:Class ;
     rdfs:label "OceanBodyOfWater" ;
@@ -2058,9 +2048,9 @@ A more detailed overview of [schema.org News markup](/docs/news.html) is also av
 
 :Offer a rdfs:Class ;
     rdfs:label "Offer" ;
-    :contributor <https://schema.org/docs/collab/GoodRelationsTerms> ;
     rdfs:comment "An offer to transfer some rights to an item or to provide a service — for example, an offer to sell tickets to an event, to rent the DVD of a movie, to stream a TV show over the internet, to repair a motorcycle, or to loan a book.\\n\\nNote: As the [[businessFunction]] property, which identifies the form of offer (e.g. sell, lease, repair, dispose), defaults to http://purl.org/goodrelations/v1#Sell; an Offer without a defined businessFunction value can be assumed to be an offer to sell.\\n\\nFor [GTIN](http://www.gs1.org/barcodes/technical/idkeys/gtin)-related fields, see [Check Digit calculator](http://www.gs1.org/barcodes/support/check_digit_calculator) and [validation guide](http://www.gs1us.org/resources/standards/gtin-validation-guide) from [GS1](http://www.gs1.org/)." ;
-    rdfs:subClassOf :Intangible .
+    rdfs:subClassOf :Intangible ;
+    :contributor <https://schema.org/docs/collab/GoodRelationsTerms> .
 
 :OfferCatalog a rdfs:Class ;
     rdfs:label "OfferCatalog" ;
@@ -2084,11 +2074,11 @@ A more detailed overview of [schema.org News markup](/docs/news.html) is also av
 
 :OpeningHoursSpecification a rdfs:Class ;
     rdfs:label "OpeningHoursSpecification" ;
-    :contributor <https://schema.org/docs/collab/GoodRelationsClass> ;
     rdfs:comment """A structured value providing information about the opening hours of a place or a certain service inside a place.\\n\\n
 The place is __open__ if the [[opens]] property is specified, and __closed__ otherwise.\\n\\nIf the value for the [[closes]] property is less than the value for the [[opens]] property then the hour range is assumed to span over the next day.
       """ ;
-    rdfs:subClassOf :StructuredValue .
+    rdfs:subClassOf :StructuredValue ;
+    :contributor <https://schema.org/docs/collab/GoodRelationsClass> .
 
 :Order a rdfs:Class ;
     rdfs:label "Order" ;
@@ -2132,9 +2122,9 @@ The place is __open__ if the [[opens]] property is specified, and __closed__ oth
 
 :OwnershipInfo a rdfs:Class ;
     rdfs:label "OwnershipInfo" ;
-    :contributor <https://schema.org/docs/collab/GoodRelationsClass> ;
     rdfs:comment "A structured value providing information about when a certain organization or person owned a certain product." ;
-    rdfs:subClassOf :StructuredValue .
+    rdfs:subClassOf :StructuredValue ;
+    :contributor <https://schema.org/docs/collab/GoodRelationsClass> .
 
 :PaintAction a rdfs:Class ;
     rdfs:label "PaintAction" ;
@@ -2178,30 +2168,31 @@ The place is __open__ if the [[opens]] property is specified, and __closed__ oth
 
 :PaymentCard a rdfs:Class ;
     rdfs:label "PaymentCard" ;
-    :contributor <https://schema.org/docs/collab/FIBO> ;
     rdfs:comment "A payment method using a credit, debit, store or other card to associate the payment with an account." ;
     rdfs:subClassOf :FinancialProduct,
-        :PaymentMethod .
+        :PaymentMethod ;
+    :contributor <https://schema.org/docs/collab/FIBO> .
 
 :PaymentChargeSpecification a rdfs:Class ;
     rdfs:label "PaymentChargeSpecification" ;
-    :contributor <https://schema.org/docs/collab/GoodRelationsClass> ;
     rdfs:comment "The costs of settling the payment using a particular payment method." ;
-    rdfs:subClassOf :PriceSpecification .
+    rdfs:subClassOf :PriceSpecification ;
+    :contributor <https://schema.org/docs/collab/GoodRelationsClass> .
 
 :PaymentMethod a rdfs:Class ;
     rdfs:label "PaymentMethod" ;
-    :contributor <https://schema.org/docs/collab/GoodRelationsClass> ;
-    :source <https://github.com/schemaorg/schemaorg/issues/3537> ;
     rdfs:comment """A payment method is a standardized procedure for transferring the monetary amount for a purchase. Payment methods are characterized by the legal and technical structures used, and by the organization or group carrying out the transaction. The following legacy values should be accepted:
     \\n\\n* http://purl.org/goodrelations/v1#ByBankTransferInAdvance\\n* http://purl.org/goodrelations/v1#ByInvoice\\n* http://purl.org/goodrelations/v1#Cash\\n* http://purl.org/goodrelations/v1#CheckInAdvance\\n* http://purl.org/goodrelations/v1#COD\\n* http://purl.org/goodrelations/v1#DirectDebit\\n* http://purl.org/goodrelations/v1#GoogleCheckout\\n* http://purl.org/goodrelations/v1#PayPal\\n* http://purl.org/goodrelations/v1#PaySwarm\\n\\nStructured values are recommended for newer payment methods.""" ;
-    rdfs:subClassOf :Intangible .
+    rdfs:subClassOf :Intangible ;
+    :contributor <https://schema.org/docs/collab/GoodRelationsClass> ;
+    :source <https://github.com/schemaorg/schemaorg/issues/3537> .
 
 :PaymentService a rdfs:Class ;
     rdfs:label "PaymentService" ;
-    :contributor <https://schema.org/docs/collab/FIBO> ;
     rdfs:comment "A Service to transfer funds from a person or organization to a beneficiary person or organization." ;
-    rdfs:subClassOf :FinancialProduct, :PaymentMethod.
+    rdfs:subClassOf :FinancialProduct,
+        :PaymentMethod ;
+    :contributor <https://schema.org/docs/collab/FIBO> .
 
 :PaymentStatusType a rdfs:Class ;
     rdfs:label "PaymentStatusType" ;
@@ -2235,10 +2226,10 @@ The place is __open__ if the [[opens]] property is specified, and __closed__ oth
 
 :Periodical a rdfs:Class ;
     rdfs:label "Periodical" ;
-    :contributor <https://schema.org/docs/collab/bibex> ;
     rdfs:comment "A publication in any medium issued in successive parts bearing numerical or chronological designations and intended to continue indefinitely, such as a magazine, scholarly journal, or newspaper.\\n\\nSee also [blog post](http://blog.schema.org/2014/09/schemaorg-support-for-bibliographic_2.html)." ;
     rdfs:subClassOf :CreativeWorkSeries ;
-    owl:equivalentClass <http://purl.org/ontology/bibo/Periodical> .
+    owl:equivalentClass <http://purl.org/ontology/bibo/Periodical> ;
+    :contributor <https://schema.org/docs/collab/bibex> .
 
 :Permit a rdfs:Class ;
     rdfs:label "Permit" ;
@@ -2247,10 +2238,10 @@ The place is __open__ if the [[opens]] property is specified, and __closed__ oth
 
 :Person a rdfs:Class ;
     rdfs:label "Person" ;
-    :contributor <https://schema.org/docs/collab/rNews> ;
     rdfs:comment "A person (alive, dead, undead, or fictional)." ;
     rdfs:subClassOf :Thing ;
-    owl:equivalentClass <http://xmlns.com/foaf/0.1/Person> .
+    owl:equivalentClass foaf:Person ;
+    :contributor <https://schema.org/docs/collab/rNews> .
 
 :PetStore a rdfs:Class ;
     rdfs:label "PetStore" ;
@@ -2274,8 +2265,9 @@ The place is __open__ if the [[opens]] property is specified, and __closed__ oth
 
 :Physician a rdfs:Class ;
     rdfs:label "Physician" ;
-    rdfs:comment """An individual physician or a physician's office considered as a [[MedicalOrganization]].""" ;
-    rdfs:subClassOf :MedicalOrganization, :MedicalBusiness .
+    rdfs:comment "An individual physician or a physician's office considered as a [[MedicalOrganization]]." ;
+    rdfs:subClassOf :MedicalBusiness,
+        :MedicalOrganization .
 
 :Place a rdfs:Class ;
     rdfs:label "Place" ;
@@ -2313,6 +2305,12 @@ The place is __open__ if the [[opens]] property is specified, and __closed__ oth
     rdfs:subClassOf :CivicStructure,
         :EmergencyService .
 
+:PoliticalParty a rdfs:Class ;
+    rdfs:label "PoliticalParty" ;
+    rdfs:comment "Organization: Political Party." ;
+    rdfs:subClassOf :Organization ;
+    :source <https://github.com/schemaorg/schemaorg/issues/3282> .
+
 :Pond a rdfs:Class ;
     rdfs:label "Pond" ;
     rdfs:comment "A pond." ;
@@ -2330,9 +2328,9 @@ The place is __open__ if the [[opens]] property is specified, and __closed__ oth
 
 :PreOrderAction a rdfs:Class ;
     rdfs:label "PreOrderAction" ;
-    :source <https://github.com/schemaorg/schemaorg/issues/1125> ;
     rdfs:comment "An agent orders a (not yet released) object/product/service to be delivered/sent." ;
-    rdfs:subClassOf :TradeAction .
+    rdfs:subClassOf :TradeAction ;
+    :source <https://github.com/schemaorg/schemaorg/issues/1125> .
 
 :PrependAction a rdfs:Class ;
     rdfs:label "PrependAction" ;
@@ -2351,21 +2349,21 @@ The place is __open__ if the [[opens]] property is specified, and __closed__ oth
 
 :PriceSpecification a rdfs:Class ;
     rdfs:label "PriceSpecification" ;
-    :contributor <https://schema.org/docs/collab/GoodRelationsClass> ;
     rdfs:comment "A structured value representing a price or price range. Typically, only the subclasses of this type are used for markup. It is recommended to use [[MonetaryAmount]] to describe independent amounts of money such as a salary, credit card limits, etc." ;
-    rdfs:subClassOf :StructuredValue .
+    rdfs:subClassOf :StructuredValue ;
+    :contributor <https://schema.org/docs/collab/GoodRelationsClass> .
 
 :Product a rdfs:Class ;
     rdfs:label "Product" ;
-    :contributor <https://schema.org/docs/collab/GoodRelationsTerms> ;
     rdfs:comment "Any offered product or service. For example: a pair of shoes; a concert ticket; the rental of a car; a haircut; or an episode of a TV show streamed online." ;
-    rdfs:subClassOf :Thing .
+    rdfs:subClassOf :Thing ;
+    :contributor <https://schema.org/docs/collab/GoodRelationsTerms> .
 
 :ProductModel a rdfs:Class ;
     rdfs:label "ProductModel" ;
-    :contributor <https://schema.org/docs/collab/GoodRelationsClass> ;
     rdfs:comment "A datasheet or vendor specification of a product (in the sense of a prototypical description)." ;
-    rdfs:subClassOf :Product .
+    rdfs:subClassOf :Product ;
+    :contributor <https://schema.org/docs/collab/GoodRelationsClass> .
 
 :ProfessionalService a rdfs:Class ;
     rdfs:label "ProfessionalService" ;
@@ -2386,16 +2384,16 @@ The place is __open__ if the [[opens]] property is specified, and __closed__ oth
 
 :PropertyValue a rdfs:Class ;
     rdfs:label "PropertyValue" ;
-    :contributor <https://schema.org/docs/collab/GoodRelationsClass> ;
     rdfs:comment """A property-value pair, e.g. representing a feature of a product or place. Use the 'name' property for the name of the property. If there is an additional human-readable version of the value, put that into the 'description' property.\\n\\n Always use specific schema.org properties when a) they exist and b) you can populate them. Using PropertyValue as a substitute will typically not trigger the same effect as using the original, specific property.
     """ ;
-    rdfs:subClassOf :StructuredValue .
+    rdfs:subClassOf :StructuredValue ;
+    :contributor <https://schema.org/docs/collab/GoodRelationsClass> .
 
 :PropertyValueSpecification a rdfs:Class ;
     rdfs:label "PropertyValueSpecification" ;
-    :contributor <https://schema.org/docs/collab/ActionCollabClass> ;
     rdfs:comment "A Property value specification." ;
-    rdfs:subClassOf :Intangible .
+    rdfs:subClassOf :Intangible ;
+    :contributor <https://schema.org/docs/collab/ActionCollabClass> .
 
 :PublicSwimmingPool a rdfs:Class ;
     rdfs:label "PublicSwimmingPool" ;
@@ -2409,16 +2407,16 @@ The place is __open__ if the [[opens]] property is specified, and __closed__ oth
 
 :PublicationIssue a rdfs:Class ;
     rdfs:label "PublicationIssue" ;
-    :contributor <https://schema.org/docs/collab/bibex> ;
     rdfs:comment "A part of a successively published publication such as a periodical or publication volume, often numbered, usually containing a grouping of works such as articles.\\n\\nSee also [blog post](http://blog.schema.org/2014/09/schemaorg-support-for-bibliographic_2.html)." ;
     rdfs:subClassOf :CreativeWork ;
-    owl:equivalentClass <http://purl.org/ontology/bibo/Issue> .
+    owl:equivalentClass <http://purl.org/ontology/bibo/Issue> ;
+    :contributor <https://schema.org/docs/collab/bibex> .
 
 :PublicationVolume a rdfs:Class ;
     rdfs:label "PublicationVolume" ;
-    :contributor <https://schema.org/docs/collab/bibex> ;
     rdfs:comment "A part of a successively published publication such as a periodical or multi-volume work, often numbered. It may represent a time span, such as a year.\\n\\nSee also [blog post](http://blog.schema.org/2014/09/schemaorg-support-for-bibliographic_2.html)." ;
-    rdfs:subClassOf :CreativeWork .
+    rdfs:subClassOf :CreativeWork ;
+    :contributor <https://schema.org/docs/collab/bibex> .
 
 :QAPage a rdfs:Class ;
     rdfs:label "QAPage" ;
@@ -2427,21 +2425,21 @@ The place is __open__ if the [[opens]] property is specified, and __closed__ oth
 
 :QualitativeValue a rdfs:Class ;
     rdfs:label "QualitativeValue" ;
-    :contributor <https://schema.org/docs/collab/GoodRelationsClass> ;
     rdfs:comment "A predefined value for a product characteristic, e.g. the power cord plug type 'US' or the garment sizes 'S', 'M', 'L', and 'XL'." ;
-    rdfs:subClassOf :Enumeration .
+    rdfs:subClassOf :Enumeration ;
+    :contributor <https://schema.org/docs/collab/GoodRelationsClass> .
 
 :QuantitativeValue a rdfs:Class ;
     rdfs:label "QuantitativeValue" ;
-    :contributor <https://schema.org/docs/collab/GoodRelationsClass> ;
     rdfs:comment " A point value or interval for product characteristics and other purposes." ;
-    rdfs:subClassOf :StructuredValue .
+    rdfs:subClassOf :StructuredValue ;
+    :contributor <https://schema.org/docs/collab/GoodRelationsClass> .
 
 :QuantitativeValueDistribution a rdfs:Class ;
     rdfs:label "QuantitativeValueDistribution" ;
-    :source <https://github.com/schemaorg/schemaorg/issues/1698> ;
     rdfs:comment "A statistical distribution of values." ;
-    rdfs:subClassOf :StructuredValue .
+    rdfs:subClassOf :StructuredValue ;
+    :source <https://github.com/schemaorg/schemaorg/issues/1698> .
 
 :Quantity a rdfs:Class ;
     rdfs:label "Quantity" ;
@@ -2450,9 +2448,9 @@ The place is __open__ if the [[opens]] property is specified, and __closed__ oth
 
 :Question a rdfs:Class ;
     rdfs:label "Question" ;
-    :contributor <https://schema.org/docs/collab/QAStackExchange> ;
     rdfs:comment "A specific question - e.g. from a user seeking answers online, or collected in a Frequently Asked Questions (FAQ) document." ;
-    rdfs:subClassOf :Comment .
+    rdfs:subClassOf :Comment ;
+    :contributor <https://schema.org/docs/collab/QAStackExchange> .
 
 :QuoteAction a rdfs:Class ;
     rdfs:label "QuoteAction" ;
@@ -2601,12 +2599,12 @@ The place is __open__ if the [[opens]] property is specified, and __closed__ oth
 
 :Resort a rdfs:Class ;
     rdfs:label "Resort" ;
-    :contributor <https://schema.org/docs/collab/STI_Accommodation_Ontology> ;
     rdfs:comment """A resort is a place used for relaxation or recreation, attracting visitors for holidays or vacations. Resorts are places, towns or sometimes commercial establishments operated by a single company (source: Wikipedia, the free encyclopedia, see <a href="http://en.wikipedia.org/wiki/Resort">http://en.wikipedia.org/wiki/Resort</a>).
 <br /><br />
 See also the <a href="/docs/hotels.html">dedicated document on the use of schema.org for marking up hotels and other forms of accommodations</a>.
     """ ;
-    rdfs:subClassOf :LodgingBusiness .
+    rdfs:subClassOf :LodgingBusiness ;
+    :contributor <https://schema.org/docs/collab/STI_Accommodation_Ontology> .
 
 :Restaurant a rdfs:Class ;
     rdfs:label "Restaurant" ;
@@ -2655,12 +2653,12 @@ See also the <a href="/docs/hotels.html">dedicated document on the use of schema
 
 :Room a rdfs:Class ;
     rdfs:label "Room" ;
-    :contributor <https://schema.org/docs/collab/STI_Accommodation_Ontology> ;
     rdfs:comment """A room is a distinguishable space within a structure, usually separated from other spaces by interior walls (source: Wikipedia, the free encyclopedia, see <a href="http://en.wikipedia.org/wiki/Room">http://en.wikipedia.org/wiki/Room</a>).
 <br /><br />
 See also the <a href="/docs/hotels.html">dedicated document on the use of schema.org for marking up hotels and other forms of accommodations</a>.
 """ ;
-    rdfs:subClassOf :Accommodation .
+    rdfs:subClassOf :Accommodation ;
+    :contributor <https://schema.org/docs/collab/STI_Accommodation_Ontology> .
 
 :RsvpAction a rdfs:Class ;
     rdfs:label "RsvpAction" ;
@@ -2719,9 +2717,9 @@ See also the <a href="/docs/hotels.html">dedicated document on the use of schema
 
 :Season a rdfs:Class ;
     rdfs:label "Season" ;
-    :supersededBy :CreativeWorkSeason ;
     rdfs:comment "A media season, e.g. TV, radio, video game etc." ;
-    rdfs:subClassOf :CreativeWork .
+    rdfs:subClassOf :CreativeWork ;
+    :supersededBy :CreativeWorkSeason .
 
 :Seat a rdfs:Class ;
     rdfs:label "Seat" ;
@@ -2811,15 +2809,15 @@ See also the <a href="/docs/hotels.html">dedicated document on the use of schema
 
 :SomeProducts a rdfs:Class ;
     rdfs:label "SomeProducts" ;
-    :contributor <https://schema.org/docs/collab/GoodRelationsClass> ;
     rdfs:comment "A placeholder for multiple similar products of the same kind." ;
-    rdfs:subClassOf :Product .
+    rdfs:subClassOf :Product ;
+    :contributor <https://schema.org/docs/collab/GoodRelationsClass> .
 
 :SpeakableSpecification a rdfs:Class ;
     rdfs:label "SpeakableSpecification" ;
-    :source <https://github.com/schemaorg/schemaorg/issues/1389> ;
     rdfs:comment "A SpeakableSpecification indicates (typically via [[xpath]] or [[cssSelector]]) sections of a document that are highlighted as particularly [[speakable]]. Instances of this type are expected to be used primarily as values of the [[speakable]] property." ;
-    rdfs:subClassOf :Intangible .
+    rdfs:subClassOf :Intangible ;
+    :source <https://github.com/schemaorg/schemaorg/issues/1389> .
 
 :Specialty a rdfs:Class ;
     rdfs:label "Specialty" ;
@@ -2874,15 +2872,15 @@ See also the <a href="/docs/hotels.html">dedicated document on the use of schema
 
 :StatusEnumeration a rdfs:Class ;
     rdfs:label "StatusEnumeration" ;
-    :source <https://github.com/schemaorg/schemaorg/issues/2604> ;
     rdfs:comment "Lists or enumerations dealing with status types." ;
-    rdfs:subClassOf :Enumeration .
+    rdfs:subClassOf :Enumeration ;
+    :source <https://github.com/schemaorg/schemaorg/issues/2604> .
 
 :SteeringPositionValue a rdfs:Class ;
     rdfs:label "SteeringPositionValue" ;
-    :contributor <https://schema.org/docs/collab/Automotive_Ontology_Working_Group> ;
     rdfs:comment "A value indicating a steering position." ;
-    rdfs:subClassOf :QualitativeValue .
+    rdfs:subClassOf :QualitativeValue ;
+    :contributor <https://schema.org/docs/collab/Automotive_Ontology_Working_Group> .
 
 :Store a rdfs:Class ;
     rdfs:label "Store" ;
@@ -2906,12 +2904,12 @@ See also the <a href="/docs/hotels.html">dedicated document on the use of schema
 
 :Suite a rdfs:Class ;
     rdfs:label "Suite" ;
-    :contributor <https://schema.org/docs/collab/STI_Accommodation_Ontology> ;
     rdfs:comment """A suite in a hotel or other public accommodation, denotes a class of luxury accommodations, the key feature of which is multiple rooms (source: Wikipedia, the free encyclopedia, see <a href="http://en.wikipedia.org/wiki/Suite_(hotel)">http://en.wikipedia.org/wiki/Suite_(hotel)</a>).
 <br /><br />
 See also the <a href="/docs/hotels.html">dedicated document on the use of schema.org for marking up hotels and other forms of accommodations</a>.
 """ ;
-    rdfs:subClassOf :Accommodation .
+    rdfs:subClassOf :Accommodation ;
+    :contributor <https://schema.org/docs/collab/STI_Accommodation_Ontology> .
 
 :SuspendAction a rdfs:Class ;
     rdfs:label "SuspendAction" ;
@@ -2962,9 +2960,9 @@ See also the <a href="/docs/hotels.html">dedicated document on the use of schema
 
 :Taxi a rdfs:Class ;
     rdfs:label "Taxi" ;
-    :supersededBy :TaxiService ;
     rdfs:comment "A taxi." ;
-    rdfs:subClassOf :Service .
+    rdfs:subClassOf :Service ;
+    :supersededBy :TaxiService .
 
 :TaxiReservation a rdfs:Class ;
     rdfs:label "TaxiReservation" ;
@@ -3001,8 +2999,8 @@ See also the <a href="/docs/hotels.html">dedicated document on the use of schema
     rdfs:comment "A tennis complex." ;
     rdfs:subClassOf :SportsActivityLocation .
 
-:Text a :DataType,
-        rdfs:Class ;
+:Text a rdfs:Class,
+        :DataType ;
     rdfs:label "Text" ;
     rdfs:comment "Data type: Text." .
 
@@ -3015,7 +3013,7 @@ See also the <a href="/docs/hotels.html">dedicated document on the use of schema
     rdfs:label "TextObject" ;
     rdfs:comment "A text file. The text can be unformatted or contain markup, html, etc." ;
     rdfs:subClassOf :MediaObject ;
-    owl:equivalentClass <http://purl.org/dc/dcmitype/Text> .
+    owl:equivalentClass dcmitype:Text .
 
 :TheaterEvent a rdfs:Class ;
     rdfs:label "TheaterEvent" ;
@@ -3041,8 +3039,8 @@ See also the <a href="/docs/hotels.html">dedicated document on the use of schema
     rdfs:comment "The act of reaching a draw in a competitive activity." ;
     rdfs:subClassOf :AchieveAction .
 
-:Time a :DataType,
-        rdfs:Class ;
+:Time a rdfs:Class,
+        :DataType ;
     rdfs:label "Time" ;
     rdfs:comment "A point in time recurring on multiple days in the form hh:mm:ss[Z|(+|-)hh:mm] (see [XML schema for details](http://www.w3.org/TR/xmlschema-2/#time))." .
 
@@ -3058,10 +3056,10 @@ See also the <a href="/docs/hotels.html">dedicated document on the use of schema
 
 :TouristAttraction a rdfs:Class ;
     rdfs:label "TouristAttraction" ;
-    :contributor <https://schema.org/docs/collab/IIT-CNR.it>,
-        <https://schema.org/docs/collab/Tourism> ;
     rdfs:comment "A tourist attraction.  In principle any Thing can be a [[TouristAttraction]], from a [[Mountain]] and [[LandmarksOrHistoricalBuildings]] to a [[LocalBusiness]].  This Type can be used on its own to describe a general [[TouristAttraction]], or be used as an [[additionalType]] to add tourist attraction properties to any other type.  (See examples below)" ;
-    rdfs:subClassOf :Place .
+    rdfs:subClassOf :Place ;
+    :contributor <https://schema.org/docs/collab/IIT-CNR.it>,
+        <https://schema.org/docs/collab/Tourism> .
 
 :TouristInformationCenter a rdfs:Class ;
     rdfs:label "TouristInformationCenter" ;
@@ -3115,15 +3113,15 @@ See also the <a href="/docs/hotels.html">dedicated document on the use of schema
 
 :Trip a rdfs:Class ;
     rdfs:label "Trip" ;
-    :contributor <https://schema.org/docs/collab/Tourism> ;
     rdfs:comment "A trip or journey. An itinerary of visits to one or more places." ;
-    rdfs:subClassOf :Intangible .
+    rdfs:subClassOf :Intangible ;
+    :contributor <https://schema.org/docs/collab/Tourism> .
 
 :TypeAndQuantityNode a rdfs:Class ;
     rdfs:label "TypeAndQuantityNode" ;
-    :contributor <https://schema.org/docs/collab/GoodRelationsClass> ;
     rdfs:comment "A structured value indicating the quantity, unit of measurement, and business function of goods included in a bundle offer." ;
-    rdfs:subClassOf :StructuredValue .
+    rdfs:subClassOf :StructuredValue ;
+    :contributor <https://schema.org/docs/collab/GoodRelationsClass> .
 
 :URL a rdfs:Class ;
     rdfs:label "URL" ;
@@ -3137,9 +3135,9 @@ See also the <a href="/docs/hotels.html">dedicated document on the use of schema
 
 :UnitPriceSpecification a rdfs:Class ;
     rdfs:label "UnitPriceSpecification" ;
-    :contributor <https://schema.org/docs/collab/GoodRelationsClass> ;
     rdfs:comment "The price asked for a given offer by the respective organization or person." ;
-    rdfs:subClassOf :PriceSpecification .
+    rdfs:subClassOf :PriceSpecification ;
+    :contributor <https://schema.org/docs/collab/GoodRelationsClass> .
 
 :UpdateAction a rdfs:Class ;
     rdfs:label "UpdateAction" ;
@@ -3153,64 +3151,69 @@ See also the <a href="/docs/hotels.html">dedicated document on the use of schema
 
 :UserBlocks a rdfs:Class ;
     rdfs:label "UserBlocks" ;
-    :supersededBy :InteractionCounter ;
     rdfs:comment "UserInteraction and its subtypes is an old way of talking about users interacting with pages. It is generally better to use [[Action]]-based vocabulary, alongside types such as [[Comment]]." ;
-    rdfs:subClassOf :UserInteraction .
+    rdfs:subClassOf :UserInteraction ;
+    :supersededBy :InteractionCounter .
 
 :UserCheckins a rdfs:Class ;
     rdfs:label "UserCheckins" ;
-    :supersededBy :InteractionCounter ;
     rdfs:comment "UserInteraction and its subtypes is an old way of talking about users interacting with pages. It is generally better to use [[Action]]-based vocabulary, alongside types such as [[Comment]]." ;
-    rdfs:subClassOf :UserInteraction .
+    rdfs:subClassOf :UserInteraction ;
+    :supersededBy :InteractionCounter .
 
 :UserComments a rdfs:Class ;
     rdfs:label "UserComments" ;
-    :contributor <https://schema.org/docs/collab/rNews> ;
-    :supersededBy :InteractionCounter ;
     rdfs:comment "UserInteraction and its subtypes is an old way of talking about users interacting with pages. It is generally better to use [[Action]]-based vocabulary, alongside types such as [[Comment]]." ;
-    rdfs:subClassOf :UserInteraction .
+    rdfs:subClassOf :UserInteraction ;
+    :contributor <https://schema.org/docs/collab/rNews> ;
+    :supersededBy :InteractionCounter .
 
 :UserDownloads a rdfs:Class ;
     rdfs:label "UserDownloads" ;
-    :supersededBy :InteractionCounter ;
     rdfs:comment "UserInteraction and its subtypes is an old way of talking about users interacting with pages. It is generally better to use [[Action]]-based vocabulary, alongside types such as [[Comment]]." ;
-    rdfs:subClassOf :UserInteraction .
+    rdfs:subClassOf :UserInteraction ;
+    :supersededBy :InteractionCounter .
 
 :UserInteraction a rdfs:Class ;
     rdfs:label "UserInteraction" ;
-    :supersededBy :InteractionCounter ;
     rdfs:comment "UserInteraction and its subtypes is an old way of talking about users interacting with pages. It is generally better to use [[Action]]-based vocabulary, alongside types such as [[Comment]]." ;
-    rdfs:subClassOf :Event .
+    rdfs:subClassOf :Event ;
+    :supersededBy :InteractionCounter .
 
 :UserLikes a rdfs:Class ;
     rdfs:label "UserLikes" ;
-    :supersededBy :InteractionCounter ;
     rdfs:comment "UserInteraction and its subtypes is an old way of talking about users interacting with pages. It is generally better to use [[Action]]-based vocabulary, alongside types such as [[Comment]]." ;
-    rdfs:subClassOf :UserInteraction .
+    rdfs:subClassOf :UserInteraction ;
+    :supersededBy :InteractionCounter .
 
 :UserPageVisits a rdfs:Class ;
     rdfs:label "UserPageVisits" ;
-    :supersededBy :InteractionCounter ;
     rdfs:comment "UserInteraction and its subtypes is an old way of talking about users interacting with pages. It is generally better to use [[Action]]-based vocabulary, alongside types such as [[Comment]]." ;
-    rdfs:subClassOf :UserInteraction .
+    rdfs:subClassOf :UserInteraction ;
+    :supersededBy :InteractionCounter .
 
 :UserPlays a rdfs:Class ;
     rdfs:label "UserPlays" ;
-    :supersededBy :InteractionCounter ;
     rdfs:comment "UserInteraction and its subtypes is an old way of talking about users interacting with pages. It is generally better to use [[Action]]-based vocabulary, alongside types such as [[Comment]]." ;
-    rdfs:subClassOf :UserInteraction .
+    rdfs:subClassOf :UserInteraction ;
+    :supersededBy :InteractionCounter .
 
 :UserPlusOnes a rdfs:Class ;
     rdfs:label "UserPlusOnes" ;
-    :supersededBy :InteractionCounter ;
     rdfs:comment "UserInteraction and its subtypes is an old way of talking about users interacting with pages. It is generally better to use [[Action]]-based vocabulary, alongside types such as [[Comment]]." ;
-    rdfs:subClassOf :UserInteraction .
+    rdfs:subClassOf :UserInteraction ;
+    :supersededBy :InteractionCounter .
 
 :UserTweets a rdfs:Class ;
     rdfs:label "UserTweets" ;
-    :supersededBy :InteractionCounter ;
     rdfs:comment "UserInteraction and its subtypes is an old way of talking about users interacting with pages. It is generally better to use [[Action]]-based vocabulary, alongside types such as [[Comment]]." ;
-    rdfs:subClassOf :UserInteraction .
+    rdfs:subClassOf :UserInteraction ;
+    :supersededBy :InteractionCounter .
+
+:VacationRental a rdfs:Class ;
+    rdfs:label "VacationRental" ;
+    rdfs:comment "A kind of lodging business that focuses on renting single properties for limited time." ;
+    rdfs:subClassOf :LodgingBusiness .
 
 :Vehicle a rdfs:Class ;
     rdfs:label "Vehicle" ;
@@ -3228,12 +3231,6 @@ See also the <a href="/docs/hotels.html">dedicated document on the use of schema
     rdfs:subClassOf :Game,
         :SoftwareApplication .
 
-:gameEdition a rdf:Property ;
-    rdfs:label "gameEdition" ;
-    :domainIncludes :VideoGame ;
-    :rangeIncludes :Text ;
-    rdfs:comment "The edition of a video game." .
-
 :VideoGameClip a rdfs:Class ;
     rdfs:label "VideoGameClip" ;
     rdfs:comment "A short segment/part of a video game." ;
@@ -3246,9 +3243,9 @@ See also the <a href="/docs/hotels.html">dedicated document on the use of schema
 
 :VideoObject a rdfs:Class ;
     rdfs:label "VideoObject" ;
-    :contributor <https://schema.org/docs/collab/rNews> ;
     rdfs:comment "A video file." ;
-    rdfs:subClassOf :MediaObject .
+    rdfs:subClassOf :MediaObject ;
+    :contributor <https://schema.org/docs/collab/rNews> .
 
 :ViewAction a rdfs:Class ;
     rdfs:label "ViewAction" ;
@@ -3302,16 +3299,16 @@ See also the <a href="/docs/hotels.html">dedicated document on the use of schema
 
 :WarrantyPromise a rdfs:Class ;
     rdfs:label "WarrantyPromise" ;
-    :contributor <https://schema.org/docs/collab/GoodRelationsClass> ;
     rdfs:comment "A structured value representing the duration and scope of services that will be provided to a customer free of charge in case of a defect or malfunction of a product." ;
-    rdfs:subClassOf :StructuredValue .
+    rdfs:subClassOf :StructuredValue ;
+    :contributor <https://schema.org/docs/collab/GoodRelationsClass> .
 
 :WarrantyScope a rdfs:Class ;
     rdfs:label "WarrantyScope" ;
-    :contributor <https://schema.org/docs/collab/GoodRelationsClass> ;
     rdfs:comment """A range of services that will be provided to a customer free of charge in case of a defect or malfunction of a product.\\n\\nCommonly used values:\\n\\n* http://purl.org/goodrelations/v1#Labor-BringIn\\n* http://purl.org/goodrelations/v1#PartsAndLabor-BringIn\\n* http://purl.org/goodrelations/v1#PartsAndLabor-PickUp
       """ ;
-    rdfs:subClassOf :Enumeration .
+    rdfs:subClassOf :Enumeration ;
+    :contributor <https://schema.org/docs/collab/GoodRelationsClass> .
 
 :WatchAction a rdfs:Class ;
     rdfs:label "WatchAction" ;
@@ -3365,9 +3362,9 @@ See also the <a href="/docs/hotels.html">dedicated document on the use of schema
 
 :WorkersUnion a rdfs:Class ;
     rdfs:label "WorkersUnion" ;
-    :source <https://github.com/schemaorg/schemaorg/issues/243> ;
     rdfs:comment "A Workers Union (also known as a Labor Union, Labour Union, or Trade Union) is an organization that promotes the interests of its worker members by collectively bargaining with management, organizing, and political lobbying." ;
-    rdfs:subClassOf :Organization .
+    rdfs:subClassOf :Organization ;
+    :source <https://github.com/schemaorg/schemaorg/issues/243> .
 
 :WriteAction a rdfs:Class ;
     rdfs:label "WriteAction" ;
@@ -3385,13 +3382,13 @@ See also the <a href="/docs/hotels.html">dedicated document on the use of schema
 
 :AlbumRelease a :MusicAlbumReleaseType ;
     rdfs:label "AlbumRelease" ;
-    :contributor <https://schema.org/docs/collab/MBZ> ;
-    rdfs:comment "AlbumRelease." .
+    rdfs:comment "AlbumRelease." ;
+    :contributor <https://schema.org/docs/collab/MBZ> .
 
 :AllWheelDriveConfiguration a :DriveWheelConfigurationValue ;
     rdfs:label "AllWheelDriveConfiguration" ;
-    :contributor <https://schema.org/docs/collab/Automotive_Ontology_Working_Group> ;
-    rdfs:comment "All-wheel Drive is a transmission layout where the engine drives all four wheels." .
+    rdfs:comment "All-wheel Drive is a transmission layout where the engine drives all four wheels." ;
+    :contributor <https://schema.org/docs/collab/Automotive_Ontology_Working_Group> .
 
 :AudiobookFormat a :BookFormatType ;
     rdfs:label "AudiobookFormat" ;
@@ -3403,18 +3400,18 @@ See also the <a href="/docs/hotels.html">dedicated document on the use of schema
 
 :BroadcastRelease a :MusicAlbumReleaseType ;
     rdfs:label "BroadcastRelease" ;
-    :contributor <https://schema.org/docs/collab/MBZ> ;
-    rdfs:comment "BroadcastRelease." .
+    rdfs:comment "BroadcastRelease." ;
+    :contributor <https://schema.org/docs/collab/MBZ> .
 
 :CDFormat a :MusicReleaseFormatType ;
     rdfs:label "CDFormat" ;
-    :contributor <https://schema.org/docs/collab/MBZ> ;
-    rdfs:comment "CDFormat." .
+    rdfs:comment "CDFormat." ;
+    :contributor <https://schema.org/docs/collab/MBZ> .
 
 :CassetteFormat a :MusicReleaseFormatType ;
     rdfs:label "CassetteFormat" ;
-    :contributor <https://schema.org/docs/collab/MBZ> ;
-    rdfs:comment "CassetteFormat." .
+    rdfs:comment "CassetteFormat." ;
+    :contributor <https://schema.org/docs/collab/MBZ> .
 
 :CoOp a :GamePlayMode ;
     rdfs:label "CoOp" ;
@@ -3426,8 +3423,8 @@ See also the <a href="/docs/hotels.html">dedicated document on the use of schema
 
 :CompilationAlbum a :MusicAlbumProductionType ;
     rdfs:label "CompilationAlbum" ;
-    :contributor <https://schema.org/docs/collab/MBZ> ;
-    rdfs:comment "CompilationAlbum." .
+    rdfs:comment "CompilationAlbum." ;
+    :contributor <https://schema.org/docs/collab/MBZ> .
 
 :CompletedActionStatus a :ActionStatusType ;
     rdfs:label "CompletedActionStatus" ;
@@ -3435,13 +3432,13 @@ See also the <a href="/docs/hotels.html">dedicated document on the use of schema
 
 :DJMixAlbum a :MusicAlbumProductionType ;
     rdfs:label "DJMixAlbum" ;
-    :contributor <https://schema.org/docs/collab/MBZ> ;
-    rdfs:comment "DJMixAlbum." .
+    rdfs:comment "DJMixAlbum." ;
+    :contributor <https://schema.org/docs/collab/MBZ> .
 
 :DVDFormat a :MusicReleaseFormatType ;
     rdfs:label "DVDFormat" ;
-    :contributor <https://schema.org/docs/collab/MBZ> ;
-    rdfs:comment "DVDFormat." .
+    rdfs:comment "DVDFormat." ;
+    :contributor <https://schema.org/docs/collab/MBZ> .
 
 :DamagedCondition a :OfferItemCondition ;
     rdfs:label "DamagedCondition" ;
@@ -3449,8 +3446,8 @@ See also the <a href="/docs/hotels.html">dedicated document on the use of schema
 
 :DemoAlbum a :MusicAlbumProductionType ;
     rdfs:label "DemoAlbum" ;
-    :contributor <https://schema.org/docs/collab/MBZ> ;
-    rdfs:comment "DemoAlbum." .
+    rdfs:comment "DemoAlbum." ;
+    :contributor <https://schema.org/docs/collab/MBZ> .
 
 :DiabeticDiet a :RestrictedDiet ;
     rdfs:label "DiabeticDiet" ;
@@ -3458,13 +3455,13 @@ See also the <a href="/docs/hotels.html">dedicated document on the use of schema
 
 :DigitalAudioTapeFormat a :MusicReleaseFormatType ;
     rdfs:label "DigitalAudioTapeFormat" ;
-    :contributor <https://schema.org/docs/collab/MBZ> ;
-    rdfs:comment "DigitalAudioTapeFormat." .
+    rdfs:comment "DigitalAudioTapeFormat." ;
+    :contributor <https://schema.org/docs/collab/MBZ> .
 
 :DigitalFormat a :MusicReleaseFormatType ;
     rdfs:label "DigitalFormat" ;
-    :contributor <https://schema.org/docs/collab/MBZ> ;
-    rdfs:comment "DigitalFormat." .
+    rdfs:comment "DigitalFormat." ;
+    :contributor <https://schema.org/docs/collab/MBZ> .
 
 :Discontinued a :ItemAvailability ;
     rdfs:label "Discontinued" ;
@@ -3476,8 +3473,8 @@ See also the <a href="/docs/hotels.html">dedicated document on the use of schema
 
 :EPRelease a :MusicAlbumReleaseType ;
     rdfs:label "EPRelease" ;
-    :contributor <https://schema.org/docs/collab/MBZ> ;
-    rdfs:comment "EPRelease." .
+    rdfs:comment "EPRelease." ;
+    :contributor <https://schema.org/docs/collab/MBZ> .
 
 :EventCancelled a :EventStatusType ;
     rdfs:label "EventCancelled" ;
@@ -3513,18 +3510,18 @@ See also the <a href="/docs/hotels.html">dedicated document on the use of schema
 
 :FourWheelDriveConfiguration a :DriveWheelConfigurationValue ;
     rdfs:label "FourWheelDriveConfiguration" ;
-    :contributor <https://schema.org/docs/collab/Automotive_Ontology_Working_Group> ;
-    rdfs:comment "Four-wheel drive is a transmission layout where the engine primarily drives two wheels with a part-time four-wheel drive capability." .
+    rdfs:comment "Four-wheel drive is a transmission layout where the engine primarily drives two wheels with a part-time four-wheel drive capability." ;
+    :contributor <https://schema.org/docs/collab/Automotive_Ontology_Working_Group> .
 
 :Friday a :DayOfWeek ;
     rdfs:label "Friday" ;
-    :sameAs <http://www.wikidata.org/entity/Q130> ;
-    rdfs:comment "The day of the week between Thursday and Saturday." .
+    rdfs:comment "The day of the week between Thursday and Saturday." ;
+    :sameAs <http://www.wikidata.org/entity/Q130> .
 
 :FrontWheelDriveConfiguration a :DriveWheelConfigurationValue ;
     rdfs:label "FrontWheelDriveConfiguration" ;
-    :contributor <https://schema.org/docs/collab/Automotive_Ontology_Working_Group> ;
-    rdfs:comment "Front-wheel drive is a transmission layout where the engine drives the front wheels." .
+    rdfs:comment "Front-wheel drive is a transmission layout where the engine drives the front wheels." ;
+    :contributor <https://schema.org/docs/collab/Automotive_Ontology_Working_Group> .
 
 :GlutenFreeDiet a :RestrictedDiet ;
     rdfs:label "GlutenFreeDiet" ;
@@ -3576,13 +3573,13 @@ See also the <a href="/docs/hotels.html">dedicated document on the use of schema
 
 :LaserDiscFormat a :MusicReleaseFormatType ;
     rdfs:label "LaserDiscFormat" ;
-    :contributor <https://schema.org/docs/collab/MBZ> ;
-    rdfs:comment "LaserDiscFormat." .
+    rdfs:comment "LaserDiscFormat." ;
+    :contributor <https://schema.org/docs/collab/MBZ> .
 
 :LeftHandDriving a :SteeringPositionValue ;
     rdfs:label "LeftHandDriving" ;
-    :contributor <https://schema.org/docs/collab/Automotive_Ontology_Working_Group> ;
-    rdfs:comment "The steering position is on the left side of the vehicle (viewed from the main direction of driving)." .
+    rdfs:comment "The steering position is on the left side of the vehicle (viewed from the main direction of driving)." ;
+    :contributor <https://schema.org/docs/collab/Automotive_Ontology_Working_Group> .
 
 :LimitedAvailability a :ItemAvailability ;
     rdfs:label "LimitedAvailability" ;
@@ -3590,8 +3587,8 @@ See also the <a href="/docs/hotels.html">dedicated document on the use of schema
 
 :LiveAlbum a :MusicAlbumProductionType ;
     rdfs:label "LiveAlbum" ;
-    :contributor <https://schema.org/docs/collab/MBZ> ;
-    rdfs:comment "LiveAlbum." .
+    rdfs:comment "LiveAlbum." ;
+    :contributor <https://schema.org/docs/collab/MBZ> .
 
 :LockerDelivery a :DeliveryMethod ;
     rdfs:label "LockerDelivery" ;
@@ -3623,13 +3620,13 @@ See also the <a href="/docs/hotels.html">dedicated document on the use of schema
 
 :MixtapeAlbum a :MusicAlbumProductionType ;
     rdfs:label "MixtapeAlbum" ;
-    :contributor <https://schema.org/docs/collab/MBZ> ;
-    rdfs:comment "MixtapeAlbum." .
+    rdfs:comment "MixtapeAlbum." ;
+    :contributor <https://schema.org/docs/collab/MBZ> .
 
 :Monday a :DayOfWeek ;
     rdfs:label "Monday" ;
-    :sameAs <http://www.wikidata.org/entity/Q105> ;
-    rdfs:comment "The day of the week between Sunday and Tuesday." .
+    rdfs:comment "The day of the week between Sunday and Tuesday." ;
+    :sameAs <http://www.wikidata.org/entity/Q105> .
 
 :MultiPlayer a :GamePlayMode ;
     rdfs:label "MultiPlayer" ;
@@ -3705,9 +3702,9 @@ See also the <a href="/docs/hotels.html">dedicated document on the use of schema
 
 :ParcelService a :DeliveryMethod ;
     rdfs:label "ParcelService" ;
-    :contributor <https://schema.org/docs/collab/GoodRelationsClass> ;
     rdfs:comment """A private parcel service as the delivery mode available for a certain offer.\\n\\nCommonly used values:\\n\\n* http://purl.org/goodrelations/v1#DHL\\n* http://purl.org/goodrelations/v1#FederalExpress\\n* http://purl.org/goodrelations/v1#UPS
-      """ .
+      """ ;
+    :contributor <https://schema.org/docs/collab/GoodRelationsClass> .
 
 :ParkingMap a :MapCategoryType ;
     rdfs:label "ParkingMap" ;
@@ -3747,8 +3744,8 @@ See also the <a href="/docs/hotels.html">dedicated document on the use of schema
 
 :PublicHolidays a :DayOfWeek ;
     rdfs:label "PublicHolidays" ;
-    :contributor <https://schema.org/docs/collab/GoodRelationsClass> ;
-    rdfs:comment "This stands for any day that is a public holiday; it is a placeholder for all official public holidays in some particular location. While not technically a \"day of the week\", it can be used with [[OpeningHoursSpecification]]. In the context of an opening hours specification it can be used to indicate opening hours on public holidays, overriding general opening hours for the day of the week on which a public holiday occurs." .
+    rdfs:comment "This stands for any day that is a public holiday; it is a placeholder for all official public holidays in some particular location. While not technically a \"day of the week\", it can be used with [[OpeningHoursSpecification]]. In the context of an opening hours specification it can be used to indicate opening hours on public holidays, overriding general opening hours for the day of the week on which a public holiday occurs." ;
+    :contributor <https://schema.org/docs/collab/GoodRelationsClass> .
 
 :ReadPermission a :DigitalDocumentPermissionType ;
     rdfs:label "ReadPermission" ;
@@ -3756,8 +3753,8 @@ See also the <a href="/docs/hotels.html">dedicated document on the use of schema
 
 :RearWheelDriveConfiguration a :DriveWheelConfigurationValue ;
     rdfs:label "RearWheelDriveConfiguration" ;
-    :contributor <https://schema.org/docs/collab/Automotive_Ontology_Working_Group> ;
-    rdfs:comment "Real-wheel drive is a transmission layout where the engine drives the rear wheels." .
+    rdfs:comment "Real-wheel drive is a transmission layout where the engine drives the rear wheels." ;
+    :contributor <https://schema.org/docs/collab/Automotive_Ontology_Working_Group> .
 
 :RefurbishedCondition a :OfferItemCondition ;
     rdfs:label "RefurbishedCondition" ;
@@ -3765,8 +3762,8 @@ See also the <a href="/docs/hotels.html">dedicated document on the use of schema
 
 :RemixAlbum a :MusicAlbumProductionType ;
     rdfs:label "RemixAlbum" ;
-    :contributor <https://schema.org/docs/collab/MBZ> ;
-    rdfs:comment "RemixAlbum." .
+    rdfs:comment "RemixAlbum." ;
+    :contributor <https://schema.org/docs/collab/MBZ> .
 
 :ReservationCancelled a :ReservationStatusType ;
     rdfs:label "ReservationCancelled" ;
@@ -3790,8 +3787,8 @@ See also the <a href="/docs/hotels.html">dedicated document on the use of schema
 
 :RightHandDriving a :SteeringPositionValue ;
     rdfs:label "RightHandDriving" ;
-    :contributor <https://schema.org/docs/collab/Automotive_Ontology_Working_Group> ;
-    rdfs:comment "The steering position is on the right side of the vehicle (viewed from the main direction of driving)." .
+    rdfs:comment "The steering position is on the right side of the vehicle (viewed from the main direction of driving)." ;
+    :contributor <https://schema.org/docs/collab/Automotive_Ontology_Working_Group> .
 
 :RsvpResponseMaybe a :RsvpResponseType ;
     rdfs:label "RsvpResponseMaybe" ;
@@ -3807,8 +3804,8 @@ See also the <a href="/docs/hotels.html">dedicated document on the use of schema
 
 :Saturday a :DayOfWeek ;
     rdfs:label "Saturday" ;
-    :sameAs <http://www.wikidata.org/entity/Q131> ;
-    rdfs:comment "The day of the week between Friday and Sunday." .
+    rdfs:comment "The day of the week between Friday and Sunday." ;
+    :sameAs <http://www.wikidata.org/entity/Q131> .
 
 :SeatingMap a :MapCategoryType ;
     rdfs:label "SeatingMap" ;
@@ -3820,8 +3817,8 @@ See also the <a href="/docs/hotels.html">dedicated document on the use of schema
 
 :SingleRelease a :MusicAlbumReleaseType ;
     rdfs:label "SingleRelease" ;
-    :contributor <https://schema.org/docs/collab/MBZ> ;
-    rdfs:comment "SingleRelease." .
+    rdfs:comment "SingleRelease." ;
+    :contributor <https://schema.org/docs/collab/MBZ> .
 
 :SoldOut a :ItemAvailability ;
     rdfs:label "SoldOut" ;
@@ -3829,28 +3826,28 @@ See also the <a href="/docs/hotels.html">dedicated document on the use of schema
 
 :SoundtrackAlbum a :MusicAlbumProductionType ;
     rdfs:label "SoundtrackAlbum" ;
-    :contributor <https://schema.org/docs/collab/MBZ> ;
-    rdfs:comment "SoundtrackAlbum." .
+    rdfs:comment "SoundtrackAlbum." ;
+    :contributor <https://schema.org/docs/collab/MBZ> .
 
 :SpokenWordAlbum a :MusicAlbumProductionType ;
     rdfs:label "SpokenWordAlbum" ;
-    :contributor <https://schema.org/docs/collab/MBZ> ;
-    rdfs:comment "SpokenWordAlbum." .
+    rdfs:comment "SpokenWordAlbum." ;
+    :contributor <https://schema.org/docs/collab/MBZ> .
 
 :StudioAlbum a :MusicAlbumProductionType ;
     rdfs:label "StudioAlbum" ;
-    :contributor <https://schema.org/docs/collab/MBZ> ;
-    rdfs:comment "StudioAlbum." .
+    rdfs:comment "StudioAlbum." ;
+    :contributor <https://schema.org/docs/collab/MBZ> .
 
 :Sunday a :DayOfWeek ;
     rdfs:label "Sunday" ;
-    :sameAs <http://www.wikidata.org/entity/Q132> ;
-    rdfs:comment "The day of the week between Saturday and Monday." .
+    rdfs:comment "The day of the week between Saturday and Monday." ;
+    :sameAs <http://www.wikidata.org/entity/Q132> .
 
 :Thursday a :DayOfWeek ;
     rdfs:label "Thursday" ;
-    :sameAs <http://www.wikidata.org/entity/Q129> ;
-    rdfs:comment "The day of the week between Wednesday and Friday." .
+    rdfs:comment "The day of the week between Wednesday and Friday." ;
+    :sameAs <http://www.wikidata.org/entity/Q129> .
 
 :TollFree a :ContactPointOption ;
     rdfs:label "TollFree" ;
@@ -3866,8 +3863,8 @@ See also the <a href="/docs/hotels.html">dedicated document on the use of schema
 
 :Tuesday a :DayOfWeek ;
     rdfs:label "Tuesday" ;
-    :sameAs <http://www.wikidata.org/entity/Q127> ;
-    rdfs:comment "The day of the week between Monday and Wednesday." .
+    rdfs:comment "The day of the week between Monday and Wednesday." ;
+    :sameAs <http://www.wikidata.org/entity/Q127> .
 
 :UsedCondition a :OfferItemCondition ;
     rdfs:label "UsedCondition" ;
@@ -3887,13 +3884,13 @@ See also the <a href="/docs/hotels.html">dedicated document on the use of schema
 
 :VinylFormat a :MusicReleaseFormatType ;
     rdfs:label "VinylFormat" ;
-    :contributor <https://schema.org/docs/collab/MBZ> ;
-    rdfs:comment "VinylFormat." .
+    rdfs:comment "VinylFormat." ;
+    :contributor <https://schema.org/docs/collab/MBZ> .
 
 :Wednesday a :DayOfWeek ;
     rdfs:label "Wednesday" ;
-    :sameAs <http://www.wikidata.org/entity/Q128> ;
-    rdfs:comment "The day of the week between Tuesday and Thursday." .
+    rdfs:comment "The day of the week between Tuesday and Thursday." ;
+    :sameAs <http://www.wikidata.org/entity/Q128> .
 
 :WritePermission a :DigitalDocumentPermissionType ;
     rdfs:label "WritePermission" ;
@@ -3905,128 +3902,132 @@ See also the <a href="/docs/hotels.html">dedicated document on the use of schema
 
 :acceptedAnswer a rdf:Property ;
     rdfs:label "acceptedAnswer" ;
+    rdfs:comment "The answer(s) that has been accepted as best, typically on a Question/Answer site. Sites vary in their selection mechanisms, e.g. drawing on community opinion and/or the view of the Question author." ;
+    rdfs:subPropertyOf :suggestedAnswer ;
     :domainIncludes :Question ;
     :rangeIncludes :Answer,
-        :ItemList ;
-    rdfs:comment "The answer(s) that has been accepted as best, typically on a Question/Answer site. Sites vary in their selection mechanisms, e.g. drawing on community opinion and/or the view of the Question author." ;
-    rdfs:subPropertyOf :suggestedAnswer .
+        :ItemList .
 
 :acceptedOffer a rdf:Property ;
     rdfs:label "acceptedOffer" ;
+    rdfs:comment "The offer(s) -- e.g., product, quantity and price combinations -- included in the order." ;
     :domainIncludes :Order ;
-    :rangeIncludes :Offer ;
-    rdfs:comment "The offer(s) -- e.g., product, quantity and price combinations -- included in the order." .
+    :rangeIncludes :Offer .
 
 :acceptedPaymentMethod a rdf:Property ;
     rdfs:label "acceptedPaymentMethod" ;
+    rdfs:comment "The payment method(s) that are accepted in general by an organization, or for some specific demand or offer." ;
     :domainIncludes :Demand,
-        :Offer, :Organization ;
+        :Offer,
+        :Organization ;
     :rangeIncludes :LoanOrCredit,
-        :PaymentMethod, :Text;
-    :source <https://github.com/schemaorg/schemaorg/issues/3537> ;
-    rdfs:comment "The payment method(s) that are accepted in general by an organization, or for some specific demand or offer." .
+        :PaymentMethod,
+        :Text ;
+    :source <https://github.com/schemaorg/schemaorg/issues/3537> .
 
 :acceptsReservations a rdf:Property ;
     rdfs:label "acceptsReservations" ;
+    rdfs:comment "Indicates whether a FoodEstablishment accepts reservations. Values can be Boolean, an URL at which reservations can be made or (for backwards compatibility) the strings ```Yes``` or ```No```." ;
     :domainIncludes :FoodEstablishment ;
     :rangeIncludes :Boolean,
         :Text,
-        :URL ;
-    rdfs:comment "Indicates whether a FoodEstablishment accepts reservations. Values can be Boolean, an URL at which reservations can be made or (for backwards compatibility) the strings ```Yes``` or ```No```." .
+        :URL .
 
 :accessCode a rdf:Property ;
     rdfs:label "accessCode" ;
+    rdfs:comment "Password, PIN, or access code needed for delivery (e.g. from a locker)." ;
     :domainIncludes :DeliveryEvent ;
-    :rangeIncludes :Text ;
-    rdfs:comment "Password, PIN, or access code needed for delivery (e.g. from a locker)." .
+    :rangeIncludes :Text .
 
 :accessMode a rdf:Property ;
     rdfs:label "accessMode" ;
+    rdfs:comment "The human sensory perceptual system or cognitive faculty through which a person may process or perceive information. Values should be drawn from the [approved vocabulary](https://www.w3.org/2021/a11y-discov-vocab/latest/#accessMode-vocabulary)." ;
     :domainIncludes :CreativeWork ;
     :rangeIncludes :Text ;
-    :source <https://github.com/schemaorg/schemaorg/issues/1100> ;
-    rdfs:comment "The human sensory perceptual system or cognitive faculty through which a person may process or perceive information. Values should be drawn from the [approved vocabulary](https://www.w3.org/2021/a11y-discov-vocab/latest/#accessMode-vocabulary)." .
+    :source <https://github.com/schemaorg/schemaorg/issues/1100> .
 
 :accessModeSufficient a rdf:Property ;
     rdfs:label "accessModeSufficient" ;
+    rdfs:comment "A list of single or combined accessModes that are sufficient to understand all the intellectual content of a resource. Values should be drawn from the [approved vocabulary](https://www.w3.org/2021/a11y-discov-vocab/latest/#accessModeSufficient-vocabulary)." ;
     :domainIncludes :CreativeWork ;
     :rangeIncludes :ItemList ;
-    :source <https://github.com/schemaorg/schemaorg/issues/1100> ;
-    rdfs:comment "A list of single or combined accessModes that are sufficient to understand all the intellectual content of a resource. Values should be drawn from the [approved vocabulary](https://www.w3.org/2021/a11y-discov-vocab/latest/#accessModeSufficient-vocabulary)." .
+    :source <https://github.com/schemaorg/schemaorg/issues/1100> .
 
 :accessibilityAPI a rdf:Property ;
     rdfs:label "accessibilityAPI" ;
+    rdfs:comment "Indicates that the resource is compatible with the referenced accessibility API. Values should be drawn from the [approved vocabulary](https://www.w3.org/2021/a11y-discov-vocab/latest/#accessibilityAPI-vocabulary)." ;
     :domainIncludes :CreativeWork ;
-    :rangeIncludes :Text ;
-    rdfs:comment "Indicates that the resource is compatible with the referenced accessibility API. Values should be drawn from the [approved vocabulary](https://www.w3.org/2021/a11y-discov-vocab/latest/#accessibilityAPI-vocabulary)." .
+    :rangeIncludes :Text .
 
 :accessibilityControl a rdf:Property ;
     rdfs:label "accessibilityControl" ;
+    rdfs:comment "Identifies input methods that are sufficient to fully control the described resource. Values should be drawn from the [approved vocabulary](https://www.w3.org/2021/a11y-discov-vocab/latest/#accessibilityControl-vocabulary)." ;
     :domainIncludes :CreativeWork ;
-    :rangeIncludes :Text ;
-    rdfs:comment "Identifies input methods that are sufficient to fully control the described resource. Values should be drawn from the [approved vocabulary](https://www.w3.org/2021/a11y-discov-vocab/latest/#accessibilityControl-vocabulary)." .
+    :rangeIncludes :Text .
 
 :accessibilityFeature a rdf:Property ;
     rdfs:label "accessibilityFeature" ;
+    rdfs:comment "Content features of the resource, such as accessible media, alternatives and supported enhancements for accessibility. Values should be drawn from the [approved vocabulary](https://www.w3.org/2021/a11y-discov-vocab/latest/#accessibilityFeature-vocabulary)." ;
     :domainIncludes :CreativeWork ;
-    :rangeIncludes :Text ;
-    rdfs:comment "Content features of the resource, such as accessible media, alternatives and supported enhancements for accessibility. Values should be drawn from the [approved vocabulary](https://www.w3.org/2021/a11y-discov-vocab/latest/#accessibilityFeature-vocabulary)." .
+    :rangeIncludes :Text .
 
 :accessibilityHazard a rdf:Property ;
     rdfs:label "accessibilityHazard" ;
+    rdfs:comment "A characteristic of the described resource that is physiologically dangerous to some users. Related to WCAG 2.0 guideline 2.3. Values should be drawn from the [approved vocabulary](https://www.w3.org/2021/a11y-discov-vocab/latest/#accessibilityHazard-vocabulary)." ;
     :domainIncludes :CreativeWork ;
-    :rangeIncludes :Text ;
-    rdfs:comment "A characteristic of the described resource that is physiologically dangerous to some users. Related to WCAG 2.0 guideline 2.3. Values should be drawn from the [approved vocabulary](https://www.w3.org/2021/a11y-discov-vocab/latest/#accessibilityHazard-vocabulary)." .
+    :rangeIncludes :Text .
 
 :accessibilitySummary a rdf:Property ;
     rdfs:label "accessibilitySummary" ;
+    rdfs:comment "A human-readable summary of specific accessibility features or deficiencies, consistent with the other accessibility metadata but expressing subtleties such as \"short descriptions are present but long descriptions will be needed for non-visual users\" or \"short descriptions are present and no long descriptions are needed\"." ;
     :domainIncludes :CreativeWork ;
     :rangeIncludes :Text ;
-    :source <https://github.com/schemaorg/schemaorg/issues/1100> ;
-    rdfs:comment "A human-readable summary of specific accessibility features or deficiencies, consistent with the other accessibility metadata but expressing subtleties such as \"short descriptions are present but long descriptions will be needed for non-visual users\" or \"short descriptions are present and no long descriptions are needed\"." .
+    :source <https://github.com/schemaorg/schemaorg/issues/1100> .
 
 :accountId a rdf:Property ;
     rdfs:label "accountId" ;
-    :domainIncludes :Invoice ;
-    :rangeIncludes :Text ;
     rdfs:comment "The identifier for the account the payment will be applied to." ;
-    rdfs:subPropertyOf :identifier .
+    rdfs:subPropertyOf :identifier ;
+    :domainIncludes :Invoice ;
+    :rangeIncludes :Text .
 
 :accountablePerson a rdf:Property ;
     rdfs:label "accountablePerson" ;
+    rdfs:comment "Specifies the Person that is legally accountable for the CreativeWork." ;
     :domainIncludes :CreativeWork ;
-    :rangeIncludes :Person ;
-    rdfs:comment "Specifies the Person that is legally accountable for the CreativeWork." .
+    :rangeIncludes :Person .
 
 :acquiredFrom a rdf:Property ;
     rdfs:label "acquiredFrom" ;
+    rdfs:comment "The organization or person from which the product was acquired." ;
     :domainIncludes :OwnershipInfo ;
     :rangeIncludes :Organization,
-        :Person ;
-    rdfs:comment "The organization or person from which the product was acquired." .
+        :Person .
 
 :actionAccessibilityRequirement a rdf:Property ;
     rdfs:label "actionAccessibilityRequirement" ;
+    rdfs:comment "A set of requirements that must be fulfilled in order to perform an Action. If more than one value is specified, fulfilling one set of requirements will allow the Action to be performed." ;
     :domainIncludes :ConsumeAction ;
     :rangeIncludes :ActionAccessSpecification ;
-    :source <https://github.com/schemaorg/schemaorg/issues/1741> ;
-    rdfs:comment "A set of requirements that must be fulfilled in order to perform an Action. If more than one value is specified, fulfilling one set of requirements will allow the Action to be performed." .
+    :source <https://github.com/schemaorg/schemaorg/issues/1741> .
 
 :actionPlatform a rdf:Property ;
     rdfs:label "actionPlatform" ;
+    rdfs:comment "The high level platform(s) where the Action can be performed for the given URL. To specify a specific application or operating system instance, use actionApplication." ;
     :domainIncludes :EntryPoint ;
-    :rangeIncludes :Text,
-        :URL, :DigitalPlatformEnumeration ;
-    rdfs:comment "The high level platform(s) where the Action can be performed for the given URL. To specify a specific application or operating system instance, use actionApplication." .
+    :rangeIncludes :DigitalPlatformEnumeration,
+        :Text,
+        :URL .
 
 :actionStatus a rdf:Property ;
     rdfs:label "actionStatus" ;
+    rdfs:comment "Indicates the current disposition of the Action." ;
     :domainIncludes :Action ;
-    :rangeIncludes :ActionStatusType ;
-    rdfs:comment "Indicates the current disposition of the Action." .
+    :rangeIncludes :ActionStatusType .
 
 :actors a rdf:Property ;
     rdfs:label "actors" ;
+    rdfs:comment "An actor, e.g. in TV, radio, movie, video games etc. Actors can be associated with individual items or with a series, episode, clip." ;
     :domainIncludes :Clip,
         :Episode,
         :Movie,
@@ -4037,110 +4038,111 @@ See also the <a href="/docs/hotels.html">dedicated document on the use of schema
         :VideoGameSeries,
         :VideoObject ;
     :rangeIncludes :Person ;
-    :supersededBy :actor ;
-    rdfs:comment "An actor, e.g. in TV, radio, movie, video games etc. Actors can be associated with individual items or with a series, episode, clip." .
+    :supersededBy :actor .
 
 :addOn a rdf:Property ;
     rdfs:label "addOn" ;
+    rdfs:comment "An additional offer that can only be obtained in combination with the first base offer (e.g. supplements and extensions that are available for a surcharge)." ;
     :domainIncludes :Offer ;
-    :rangeIncludes :Offer ;
-    rdfs:comment "An additional offer that can only be obtained in combination with the first base offer (e.g. supplements and extensions that are available for a surcharge)." .
+    :rangeIncludes :Offer .
 
 :additionalName a rdf:Property ;
     rdfs:label "additionalName" ;
-    :domainIncludes :Person ;
-    :rangeIncludes :Text ;
+    rdfs:comment "An additional name for a Person, can be used for a middle name." ;
     rdfs:subPropertyOf :alternateName ;
-    rdfs:comment "An additional name for a Person, can be used for a middle name." .
+    :domainIncludes :Person ;
+    :rangeIncludes :Text .
 
 :additionalNumberOfGuests a rdf:Property ;
     rdfs:label "additionalNumberOfGuests" ;
+    rdfs:comment "If responding yes, the number of guests who will attend in addition to the invitee." ;
     :domainIncludes :RsvpAction ;
-    :rangeIncludes :Number ;
-    rdfs:comment "If responding yes, the number of guests who will attend in addition to the invitee." .
+    :rangeIncludes :Number .
 
 :additionalProperty a rdf:Property ;
     rdfs:label "additionalProperty" ;
-    :domainIncludes :Place,
+    rdfs:comment """A property-value pair representing an additional characteristic of the entity, e.g. a product feature or another characteristic for which there is no matching property in schema.org.\\n\\nNote: Publishers should be aware that applications designed to use specific schema.org properties (e.g. https://schema.org/width, https://schema.org/color, https://schema.org/gtin13, ...) will typically expect such data to be provided using those properties, rather than using the generic property/value mechanism.
+""" ;
+    :domainIncludes :MerchantReturnPolicy,
         :Offer,
+        :Place,
         :Product,
-        :MerchantReturnPolicy,
         :QualitativeValue,
         :QuantitativeValue ;
-    :rangeIncludes :PropertyValue ;
-    rdfs:comment """A property-value pair representing an additional characteristic of the entity, e.g. a product feature or another characteristic for which there is no matching property in schema.org.\\n\\nNote: Publishers should be aware that applications designed to use specific schema.org properties (e.g. https://schema.org/width, https://schema.org/color, https://schema.org/gtin13, ...) will typically expect such data to be provided using those properties, rather than using the generic property/value mechanism.
-""" .
+    :rangeIncludes :PropertyValue .
 
 :additionalType a rdf:Property ;
     rdfs:label "additionalType" ;
-    :domainIncludes :Thing ;
-    :rangeIncludes :URL, :Text ;
     rdfs:comment """An additional type for the item, typically used for adding more specific types from external vocabularies in microdata syntax. This is a relationship between something and a class that the thing is in. Typically the value is a URI-identified RDF class, and in this case corresponds to the
     use of rdf:type in RDF. Text values can be used sparingly, for cases where useful information can be added without their being an appropriate schema to reference. In the case of text values, the class label should follow the schema.org <a href="https://schema.org/docs/styleguide.html">style guide</a>.""" ;
-    rdfs:subPropertyOf rdf:type . # see datamodel.html for "strings where we prefer things".
+    rdfs:subPropertyOf rdf:type ;
+    :domainIncludes :Thing ;
+    :rangeIncludes :Text,
+        :URL .
 
 :address a rdf:Property ;
     rdfs:label "address" ;
+    rdfs:comment "Physical address of the item." ;
     :domainIncludes :GeoCoordinates,
         :GeoShape,
         :Organization,
         :Person,
         :Place ;
     :rangeIncludes :PostalAddress,
-        :Text ;
-    rdfs:comment "Physical address of the item." .
+        :Text .
 
 :addressCountry a rdf:Property ;
     rdfs:label "addressCountry" ;
+    rdfs:comment "The country. For example, USA. You can also provide the two-letter [ISO 3166-1 alpha-2 country code](http://en.wikipedia.org/wiki/ISO_3166-1)." ;
     :domainIncludes :GeoCoordinates,
         :GeoShape,
         :PostalAddress ;
     :rangeIncludes :Country,
-        :Text ;
-    rdfs:comment "The country. For example, USA. You can also provide the two-letter [ISO 3166-1 alpha-2 country code](http://en.wikipedia.org/wiki/ISO_3166-1)." .
+        :Text .
 
 :addressLocality a rdf:Property ;
     rdfs:label "addressLocality" ;
+    rdfs:comment "The locality in which the street address is, and which is in the region. For example, Mountain View." ;
     :domainIncludes :PostalAddress ;
-    :rangeIncludes :Text ;
-    rdfs:comment "The locality in which the street address is, and which is in the region. For example, Mountain View." .
+    :rangeIncludes :Text .
 
 :addressRegion a rdf:Property ;
     rdfs:label "addressRegion" ;
+    rdfs:comment "The region in which the locality is, and which is in the country. For example, California or another appropriate first-level [Administrative division](https://en.wikipedia.org/wiki/List_of_administrative_divisions_by_country)." ;
     :domainIncludes :PostalAddress ;
-    :rangeIncludes :Text ;
-    rdfs:comment "The region in which the locality is, and which is in the country. For example, California or another appropriate first-level [Administrative division](https://en.wikipedia.org/wiki/List_of_administrative_divisions_by_country)." .
+    :rangeIncludes :Text .
 
 :advanceBookingRequirement a rdf:Property ;
     rdfs:label "advanceBookingRequirement" ;
+    rdfs:comment "The amount of time that is required between accepting the offer and the actual usage of the resource or service." ;
     :domainIncludes :Demand,
         :Offer ;
-    :rangeIncludes :QuantitativeValue ;
-    rdfs:comment "The amount of time that is required between accepting the offer and the actual usage of the resource or service." .
+    :rangeIncludes :QuantitativeValue .
 
 :affiliation a rdf:Property ;
     rdfs:label "affiliation" ;
-    :domainIncludes :Person ;
-    :rangeIncludes :Organization ;
     rdfs:comment "An organization that this person is affiliated with. For example, a school/university, a club, or a team." ;
-    rdfs:subPropertyOf :memberOf .
+    rdfs:subPropertyOf :memberOf ;
+    :domainIncludes :Person ;
+    :rangeIncludes :Organization .
 
 :afterMedia a rdf:Property ;
     rdfs:label "afterMedia" ;
+    rdfs:comment "A media object representing the circumstances after performing this direction." ;
     :domainIncludes :HowToDirection ;
     :rangeIncludes :MediaObject,
-        :URL ;
-    rdfs:comment "A media object representing the circumstances after performing this direction." .
+        :URL .
 
 :agent a rdf:Property ;
     rdfs:label "agent" ;
+    rdfs:comment "The direct performer or driver of the action (animate or inanimate). E.g. *John* wrote a book." ;
     :domainIncludes :Action ;
     :rangeIncludes :Organization,
-        :Person ;
-    rdfs:comment "The direct performer or driver of the action (animate or inanimate). E.g. *John* wrote a book." .
+        :Person .
 
 :aggregateRating a rdf:Property ;
     rdfs:label "aggregateRating" ;
+    rdfs:comment "The overall rating, based on a collection of reviews or ratings, of the item." ;
     :domainIncludes :Brand,
         :CreativeWork,
         :Event,
@@ -4149,718 +4151,713 @@ See also the <a href="/docs/hotels.html">dedicated document on the use of schema
         :Place,
         :Product,
         :Service ;
-    :rangeIncludes :AggregateRating ;
-    rdfs:comment "The overall rating, based on a collection of reviews or ratings, of the item." .
+    :rangeIncludes :AggregateRating .
 
 :aircraft a rdf:Property ;
     rdfs:label "aircraft" ;
+    rdfs:comment "The kind of aircraft (e.g., \"Boeing 747\")." ;
     :domainIncludes :Flight ;
     :rangeIncludes :Text,
-        :Vehicle ;
-    rdfs:comment "The kind of aircraft (e.g., \"Boeing 747\")." .
+        :Vehicle .
 
 :albumProductionType a rdf:Property ;
     rdfs:label "albumProductionType" ;
-    :domainIncludes :MusicAlbum ;
-    :rangeIncludes :MusicAlbumProductionType ;
+    rdfs:comment "Classification of the album by its type of content: soundtrack, live album, studio album, etc." ;
     :contributor <https://schema.org/docs/collab/MBZ> ;
-    rdfs:comment "Classification of the album by its type of content: soundtrack, live album, studio album, etc." .
+    :domainIncludes :MusicAlbum ;
+    :rangeIncludes :MusicAlbumProductionType .
 
 :albumReleaseType a rdf:Property ;
     rdfs:label "albumReleaseType" ;
-    :domainIncludes :MusicAlbum ;
-    :rangeIncludes :MusicAlbumReleaseType ;
+    rdfs:comment "The kind of release which this album is: single, EP or album." ;
     :contributor <https://schema.org/docs/collab/MBZ> ;
-    rdfs:comment "The kind of release which this album is: single, EP or album." .
+    :domainIncludes :MusicAlbum ;
+    :rangeIncludes :MusicAlbumReleaseType .
 
 :albums a rdf:Property ;
     rdfs:label "albums" ;
+    rdfs:comment "A collection of music albums." ;
     :domainIncludes :MusicGroup ;
     :rangeIncludes :MusicAlbum ;
-    :supersededBy :album ;
-    rdfs:comment "A collection of music albums." .
+    :supersededBy :album .
 
 :alignmentType a rdf:Property ;
     rdfs:label "alignmentType" ;
+    rdfs:comment "A category of alignment between the learning resource and the framework node. Recommended values include: 'requires', 'textComplexity', 'readingLevel', and 'educationalSubject'." ;
     :domainIncludes :AlignmentObject ;
-    :rangeIncludes :Text ;
-    rdfs:comment "A category of alignment between the learning resource and the framework node. Recommended values include: 'requires', 'textComplexity', 'readingLevel', and 'educationalSubject'." .
-
-:alternateName a rdf:Property ;
-    rdfs:label "alternateName" ;
-    :domainIncludes :Thing ;
-    :rangeIncludes :Text ;
-    rdfs:comment "An alias for the item." .
+    :rangeIncludes :Text .
 
 :alternativeHeadline a rdf:Property ;
     rdfs:label "alternativeHeadline" ;
+    rdfs:comment "A secondary title of the CreativeWork." ;
     :domainIncludes :CreativeWork ;
-    :rangeIncludes :Text ;
-    rdfs:comment "A secondary title of the CreativeWork." .
+    :rangeIncludes :Text .
 
 :amenityFeature a rdf:Property ;
     rdfs:label "amenityFeature" ;
+    rdfs:comment "An amenity feature (e.g. a characteristic or service) of the Accommodation. This generic property does not make a statement about whether the feature is included in an offer for the main accommodation or available at extra costs." ;
+    :contributor <https://schema.org/docs/collab/STI_Accommodation_Ontology> ;
     :domainIncludes :Accommodation,
         :LodgingBusiness,
         :Place ;
-    :rangeIncludes :LocationFeatureSpecification ;
-    :contributor <https://schema.org/docs/collab/STI_Accommodation_Ontology> ;
-    rdfs:comment "An amenity feature (e.g. a characteristic or service) of the Accommodation. This generic property does not make a statement about whether the feature is included in an offer for the main accommodation or available at extra costs." .
+    :rangeIncludes :LocationFeatureSpecification .
 
 :amount a rdf:Property ;
     rdfs:label "amount" ;
+    rdfs:comment "The amount of money." ;
     :domainIncludes :DatedMoneySpecification,
         :InvestmentOrDeposit,
         :LoanOrCredit ;
     :rangeIncludes :MonetaryAmount,
         :Number ;
-    :source <https://github.com/schemaorg/schemaorg/issues/1698> ;
-    rdfs:comment "The amount of money." .
+    :source <https://github.com/schemaorg/schemaorg/issues/1698> .
 
 :amountOfThisGood a rdf:Property ;
     rdfs:label "amountOfThisGood" ;
+    rdfs:comment "The quantity of the goods included in the offer." ;
     :domainIncludes :TypeAndQuantityNode ;
-    :rangeIncludes :Number ;
-    rdfs:comment "The quantity of the goods included in the offer." .
+    :rangeIncludes :Number .
 
 :annualPercentageRate a rdf:Property ;
     rdfs:label "annualPercentageRate" ;
+    rdfs:comment "The annual rate that is charged for borrowing (or made by investing), expressed as a single percentage number that represents the actual yearly cost of funds over the term of a loan. This includes any fees or additional costs associated with the transaction." ;
+    :contributor <https://schema.org/docs/collab/FIBO> ;
     :domainIncludes :FinancialProduct ;
     :rangeIncludes :Number,
-        :QuantitativeValue ;
-    :contributor <https://schema.org/docs/collab/FIBO> ;
-    rdfs:comment "The annual rate that is charged for borrowing (or made by investing), expressed as a single percentage number that represents the actual yearly cost of funds over the term of a loan. This includes any fees or additional costs associated with the transaction." .
+        :QuantitativeValue .
 
 :answerCount a rdf:Property ;
     rdfs:label "answerCount" ;
+    rdfs:comment "The number of answers this question has received." ;
     :domainIncludes :Question ;
-    :rangeIncludes :Integer ;
-    rdfs:comment "The number of answers this question has received." .
+    :rangeIncludes :Integer .
 
 :application a rdf:Property ;
     rdfs:label "application" ;
+    rdfs:comment "An application that can complete the request." ;
     :domainIncludes :EntryPoint ;
     :rangeIncludes :SoftwareApplication ;
-    :supersededBy :actionApplication ;
-    rdfs:comment "An application that can complete the request." .
+    :supersededBy :actionApplication .
 
 :applicationCategory a rdf:Property ;
     rdfs:label "applicationCategory" ;
+    rdfs:comment "Type of software application, e.g. 'Game, Multimedia'." ;
     :domainIncludes :SoftwareApplication ;
     :rangeIncludes :Text,
-        :URL ;
-    rdfs:comment "Type of software application, e.g. 'Game, Multimedia'." .
+        :URL .
 
 :applicationSubCategory a rdf:Property ;
     rdfs:label "applicationSubCategory" ;
+    rdfs:comment "Subcategory of the application, e.g. 'Arcade Game'." ;
     :domainIncludes :SoftwareApplication ;
     :rangeIncludes :Text,
-        :URL ;
-    rdfs:comment "Subcategory of the application, e.g. 'Arcade Game'." .
+        :URL .
 
 :applicationSuite a rdf:Property ;
     rdfs:label "applicationSuite" ;
+    rdfs:comment "The name of the application suite to which the application belongs (e.g. Excel belongs to Office)." ;
     :domainIncludes :SoftwareApplication ;
-    :rangeIncludes :Text ;
-    rdfs:comment "The name of the application suite to which the application belongs (e.g. Excel belongs to Office)." .
+    :rangeIncludes :Text .
 
 :appliesToDeliveryMethod a rdf:Property ;
     rdfs:label "appliesToDeliveryMethod" ;
+    rdfs:comment "The delivery method(s) to which the delivery charge or payment charge specification applies." ;
     :domainIncludes :DeliveryChargeSpecification,
         :PaymentChargeSpecification ;
-    :rangeIncludes :DeliveryMethod ;
-    rdfs:comment "The delivery method(s) to which the delivery charge or payment charge specification applies." .
+    :rangeIncludes :DeliveryMethod .
 
 :appliesToPaymentMethod a rdf:Property ;
     rdfs:label "appliesToPaymentMethod" ;
+    rdfs:comment "The payment method(s) to which the payment charge specification applies." ;
     :domainIncludes :PaymentChargeSpecification ;
-    :rangeIncludes :PaymentMethod ;
-    rdfs:comment "The payment method(s) to which the payment charge specification applies." .
+    :rangeIncludes :PaymentMethod .
 
 :area a rdf:Property ;
     rdfs:label "area" ;
+    rdfs:comment "The area within which users can expect to reach the broadcast service." ;
     :domainIncludes :BroadcastService ;
     :rangeIncludes :Place ;
-    :supersededBy :serviceArea ;
-    rdfs:comment "The area within which users can expect to reach the broadcast service." .
+    :supersededBy :serviceArea .
 
 :arrivalAirport a rdf:Property ;
     rdfs:label "arrivalAirport" ;
+    rdfs:comment "The airport where the flight terminates." ;
     :domainIncludes :Flight ;
-    :rangeIncludes :Airport ;
-    rdfs:comment "The airport where the flight terminates." .
+    :rangeIncludes :Airport .
 
 :arrivalBusStop a rdf:Property ;
     rdfs:label "arrivalBusStop" ;
+    rdfs:comment "The stop or station from which the bus arrives." ;
     :domainIncludes :BusTrip ;
     :rangeIncludes :BusStation,
-        :BusStop ;
-    rdfs:comment "The stop or station from which the bus arrives." .
+        :BusStop .
 
 :arrivalGate a rdf:Property ;
     rdfs:label "arrivalGate" ;
+    rdfs:comment "Identifier of the flight's arrival gate." ;
     :domainIncludes :Flight ;
-    :rangeIncludes :Text ;
-    rdfs:comment "Identifier of the flight's arrival gate." .
+    :rangeIncludes :Text .
 
 :arrivalPlatform a rdf:Property ;
     rdfs:label "arrivalPlatform" ;
+    rdfs:comment "The platform where the train arrives." ;
     :domainIncludes :TrainTrip ;
-    :rangeIncludes :Text ;
-    rdfs:comment "The platform where the train arrives." .
+    :rangeIncludes :Text .
 
 :arrivalStation a rdf:Property ;
     rdfs:label "arrivalStation" ;
+    rdfs:comment "The station where the train trip ends." ;
     :domainIncludes :TrainTrip ;
-    :rangeIncludes :TrainStation ;
-    rdfs:comment "The station where the train trip ends." .
+    :rangeIncludes :TrainStation .
 
 :arrivalTerminal a rdf:Property ;
     rdfs:label "arrivalTerminal" ;
+    rdfs:comment "Identifier of the flight's arrival terminal." ;
     :domainIncludes :Flight ;
-    :rangeIncludes :Text ;
-    rdfs:comment "Identifier of the flight's arrival terminal." .
+    :rangeIncludes :Text .
 
 :arrivalTime a rdf:Property ;
     rdfs:label "arrivalTime" ;
+    rdfs:comment "The expected arrival time." ;
     :domainIncludes :Trip ;
     :rangeIncludes :DateTime,
-        :Time ;
-    rdfs:comment "The expected arrival time." .
+        :Time .
 
 :artEdition a rdf:Property ;
     rdfs:label "artEdition" ;
+    rdfs:comment "The number of copies when multiple copies of a piece of artwork are produced - e.g. for a limited edition of 20 prints, 'artEdition' refers to the total number of copies (in this example \"20\")." ;
     :domainIncludes :VisualArtwork ;
     :rangeIncludes :Integer,
-        :Text ;
-    rdfs:comment "The number of copies when multiple copies of a piece of artwork are produced - e.g. for a limited edition of 20 prints, 'artEdition' refers to the total number of copies (in this example \"20\")." .
+        :Text .
 
 :artMedium a rdf:Property ;
     rdfs:label "artMedium" ;
+    rdfs:comment "The material used. (E.g. Oil, Watercolour, Acrylic, Linoprint, Marble, Cyanotype, Digital, Lithograph, DryPoint, Intaglio, Pastel, Woodcut, Pencil, Mixed Media, etc.)" ;
+    rdfs:subPropertyOf :material ;
     :domainIncludes :VisualArtwork ;
     :rangeIncludes :Text,
-        :URL ;
-    rdfs:comment "The material used. (E.g. Oil, Watercolour, Acrylic, Linoprint, Marble, Cyanotype, Digital, Lithograph, DryPoint, Intaglio, Pastel, Woodcut, Pencil, Mixed Media, etc.)" ;
-    rdfs:subPropertyOf :material .
+        :URL .
 
 :artform a rdf:Property ;
     rdfs:label "artform" ;
+    rdfs:comment "e.g. Painting, Drawing, Sculpture, Print, Photograph, Assemblage, Collage, etc." ;
     :domainIncludes :VisualArtwork ;
     :rangeIncludes :Text,
-        :URL ;
-    rdfs:comment "e.g. Painting, Drawing, Sculpture, Print, Photograph, Assemblage, Collage, etc." .
+        :URL .
 
 :articleBody a rdf:Property ;
     rdfs:label "articleBody" ;
+    rdfs:comment "The actual body of the article." ;
     :domainIncludes :Article ;
-    :rangeIncludes :Text ;
-    rdfs:comment "The actual body of the article." .
+    :rangeIncludes :Text .
 
 :articleSection a rdf:Property ;
     rdfs:label "articleSection" ;
+    rdfs:comment "Articles may belong to one or more 'sections' in a magazine or newspaper, such as Sports, Lifestyle, etc." ;
     :domainIncludes :Article ;
-    :rangeIncludes :Text ;
-    rdfs:comment "Articles may belong to one or more 'sections' in a magazine or newspaper, such as Sports, Lifestyle, etc." .
+    :rangeIncludes :Text .
 
 :assembly a rdf:Property ;
     rdfs:label "assembly" ;
+    rdfs:comment "Library file name, e.g., mscorlib.dll, system.web.dll." ;
     :domainIncludes :APIReference ;
     :rangeIncludes :Text ;
-    :supersededBy :executableLibraryName ;
-    rdfs:comment "Library file name, e.g., mscorlib.dll, system.web.dll." .
+    :supersededBy :executableLibraryName .
 
 :assemblyVersion a rdf:Property ;
     rdfs:label "assemblyVersion" ;
+    rdfs:comment "Associated product/technology version. E.g., .NET Framework 4.5." ;
     :domainIncludes :APIReference ;
-    :rangeIncludes :Text ;
-    rdfs:comment "Associated product/technology version. E.g., .NET Framework 4.5." .
+    :rangeIncludes :Text .
 
 :associatedArticle a rdf:Property ;
     rdfs:label "associatedArticle" ;
+    rdfs:comment "A NewsArticle associated with the Media Object." ;
     :domainIncludes :MediaObject ;
-    :rangeIncludes :NewsArticle ;
-    rdfs:comment "A NewsArticle associated with the Media Object." .
+    :rangeIncludes :NewsArticle .
 
 :associatedMedia a rdf:Property ;
     rdfs:label "associatedMedia" ;
+    rdfs:comment "A media object that encodes this CreativeWork. This property is a synonym for encoding." ;
     :domainIncludes :CreativeWork ;
-    :rangeIncludes :MediaObject ;
-    rdfs:comment "A media object that encodes this CreativeWork. This property is a synonym for encoding." .
+    :rangeIncludes :MediaObject .
 
 :athlete a rdf:Property ;
     rdfs:label "athlete" ;
+    rdfs:comment "A person that acts as performing member of a sports team; a player as opposed to a coach." ;
     :domainIncludes :SportsTeam ;
-    :rangeIncludes :Person ;
-    rdfs:comment "A person that acts as performing member of a sports team; a player as opposed to a coach." .
+    :rangeIncludes :Person .
 
 :attendees a rdf:Property ;
     rdfs:label "attendees" ;
+    rdfs:comment "A person attending the event." ;
     :domainIncludes :Event ;
     :rangeIncludes :Organization,
         :Person ;
-    :supersededBy :attendee ;
-    rdfs:comment "A person attending the event." .
+    :supersededBy :attendee .
 
 :audienceType a rdf:Property ;
     rdfs:label "audienceType" ;
+    rdfs:comment "The target group associated with a given audience (e.g. veterans, car owners, musicians, etc.)." ;
     :domainIncludes :Audience ;
-    :rangeIncludes :Text ;
-    rdfs:comment "The target group associated with a given audience (e.g. veterans, car owners, musicians, etc.)." .
+    :rangeIncludes :Text .
 
 :audio a rdf:Property ;
     rdfs:label "audio" ;
+    rdfs:comment "An embedded audio object." ;
     :domainIncludes :CreativeWork ;
     :rangeIncludes :AudioObject,
-        :Clip ;
-    rdfs:comment "An embedded audio object." .
+        :Clip .
 
 :authenticator a rdf:Property ;
     rdfs:label "authenticator" ;
+    rdfs:comment "The Organization responsible for authenticating the user's subscription. For example, many media apps require a cable/satellite provider to authenticate your subscription before playing media." ;
     :domainIncludes :MediaSubscription ;
     :rangeIncludes :Organization ;
-    :source <https://github.com/schemaorg/schemaorg/issues/1741> ;
-    rdfs:comment "The Organization responsible for authenticating the user's subscription. For example, many media apps require a cable/satellite provider to authenticate your subscription before playing media." .
+    :source <https://github.com/schemaorg/schemaorg/issues/1741> .
 
 :author a rdf:Property ;
     rdfs:label "author" ;
+    rdfs:comment "The author of this content or rating. Please note that author is special in that HTML 5 provides a special mechanism for indicating authorship via the rel tag. That is equivalent to this and may be used interchangeably." ;
     :domainIncludes :CreativeWork,
         :Rating ;
     :rangeIncludes :Organization,
-        :Person ;
-    rdfs:comment "The author of this content or rating. Please note that author is special in that HTML 5 provides a special mechanism for indicating authorship via the rel tag. That is equivalent to this and may be used interchangeably." .
+        :Person .
 
 :availability a rdf:Property ;
     rdfs:label "availability" ;
+    rdfs:comment "The availability of this item&#x2014;for example In stock, Out of stock, Pre-order, etc." ;
     :domainIncludes :Demand,
         :Offer ;
-    :rangeIncludes :ItemAvailability ;
-    rdfs:comment "The availability of this item&#x2014;for example In stock, Out of stock, Pre-order, etc." .
+    :rangeIncludes :ItemAvailability .
 
 :availabilityEnds a rdf:Property ;
     rdfs:label "availabilityEnds" ;
+    rdfs:comment "The end of the availability of the product or service included in the offer." ;
     :domainIncludes :ActionAccessSpecification,
         :Demand,
         :Offer ;
     :rangeIncludes :Date,
         :DateTime,
         :Time ;
-    :source <https://github.com/schemaorg/schemaorg/issues/1741> ;
-    rdfs:comment "The end of the availability of the product or service included in the offer." .
+    :source <https://github.com/schemaorg/schemaorg/issues/1741> .
 
 :availabilityStarts a rdf:Property ;
     rdfs:label "availabilityStarts" ;
+    rdfs:comment "The beginning of the availability of the product or service included in the offer." ;
     :domainIncludes :ActionAccessSpecification,
         :Demand,
         :Offer ;
     :rangeIncludes :Date,
         :DateTime,
         :Time ;
-    :source <https://github.com/schemaorg/schemaorg/issues/1741> ;
-    rdfs:comment "The beginning of the availability of the product or service included in the offer." .
+    :source <https://github.com/schemaorg/schemaorg/issues/1741> .
 
 :availableAtOrFrom a rdf:Property ;
     rdfs:label "availableAtOrFrom" ;
+    rdfs:comment "The place(s) from which the offer can be obtained (e.g. store locations)." ;
+    rdfs:subPropertyOf :areaServed ;
     :domainIncludes :Demand,
         :Offer ;
-    :rangeIncludes :Place ;
-    rdfs:comment "The place(s) from which the offer can be obtained (e.g. store locations)." ;
-    rdfs:subPropertyOf :areaServed .
+    :rangeIncludes :Place .
 
 :availableChannel a rdf:Property ;
     rdfs:label "availableChannel" ;
+    rdfs:comment "A means of accessing the service (e.g. a phone bank, a web site, a location, etc.)." ;
     :domainIncludes :Service ;
-    :rangeIncludes :ServiceChannel ;
-    rdfs:comment "A means of accessing the service (e.g. a phone bank, a web site, a location, etc.)." .
+    :rangeIncludes :ServiceChannel .
 
 :availableDeliveryMethod a rdf:Property ;
     rdfs:label "availableDeliveryMethod" ;
+    rdfs:comment "The delivery method(s) available for this offer." ;
     :domainIncludes :Demand,
         :Offer ;
-    :rangeIncludes :DeliveryMethod ;
-    rdfs:comment "The delivery method(s) available for this offer." .
+    :rangeIncludes :DeliveryMethod .
 
 :availableFrom a rdf:Property ;
     rdfs:label "availableFrom" ;
+    rdfs:comment "When the item is available for pickup from the store, locker, etc." ;
     :domainIncludes :DeliveryEvent ;
-    :rangeIncludes :DateTime ;
-    rdfs:comment "When the item is available for pickup from the store, locker, etc." .
+    :rangeIncludes :DateTime .
 
 :availableLanguage a rdf:Property ;
     rdfs:label "availableLanguage" ;
+    rdfs:comment "A language someone may use with or at the item, service or place. Please use one of the language codes from the [IETF BCP 47 standard](http://tools.ietf.org/html/bcp47). See also [[inLanguage]]." ;
     :domainIncludes :ContactPoint,
         :LodgingBusiness,
         :ServiceChannel,
         :TouristAttraction ;
     :rangeIncludes :Language,
-        :Text ;
-    rdfs:comment "A language someone may use with or at the item, service or place. Please use one of the language codes from the [IETF BCP 47 standard](http://tools.ietf.org/html/bcp47). See also [[inLanguage]]." .
+        :Text .
 
 :availableThrough a rdf:Property ;
     rdfs:label "availableThrough" ;
+    rdfs:comment "After this date, the item will no longer be available for pickup." ;
     :domainIncludes :DeliveryEvent ;
-    :rangeIncludes :DateTime ;
-    rdfs:comment "After this date, the item will no longer be available for pickup." .
+    :rangeIncludes :DateTime .
 
 :awards a rdf:Property ;
     rdfs:label "awards" ;
+    rdfs:comment "Awards won by or for this item." ;
     :domainIncludes :CreativeWork,
         :Organization,
         :Person,
         :Product ;
     :rangeIncludes :Text ;
-    :supersededBy :award ;
-    rdfs:comment "Awards won by or for this item." .
+    :supersededBy :award .
 
 :awayTeam a rdf:Property ;
     rdfs:label "awayTeam" ;
+    rdfs:comment "The away team in a sports event." ;
+    rdfs:subPropertyOf :competitor ;
     :domainIncludes :SportsEvent ;
     :rangeIncludes :Person,
-        :SportsTeam ;
-    rdfs:comment "The away team in a sports event." ;
-    rdfs:subPropertyOf :competitor .
+        :SportsTeam .
 
 :baseSalary a rdf:Property ;
     rdfs:label "baseSalary" ;
+    rdfs:comment "The base salary of the job or of an employee in an EmployeeRole." ;
     :domainIncludes :EmployeeRole,
         :JobPosting ;
     :rangeIncludes :MonetaryAmount,
         :Number,
-        :PriceSpecification ;
-    rdfs:comment "The base salary of the job or of an employee in an EmployeeRole." .
+        :PriceSpecification .
 
 :bccRecipient a rdf:Property ;
     rdfs:label "bccRecipient" ;
+    rdfs:comment "A sub property of recipient. The recipient blind copied on a message." ;
+    rdfs:subPropertyOf :recipient ;
     :domainIncludes :Message ;
     :rangeIncludes :ContactPoint,
         :Organization,
-        :Person ;
-    rdfs:comment "A sub property of recipient. The recipient blind copied on a message." ;
-    rdfs:subPropertyOf :recipient .
+        :Person .
 
 :bed a rdf:Property ;
     rdfs:label "bed" ;
-    :domainIncludes :HotelRoom,
-        :Suite, :Accommodation;
+    rdfs:comment """The type of bed or beds included in the accommodation. For the single case of just one bed of a certain type, you use bed directly with a text.
+      If you want to indicate the quantity of a certain kind of bed, use an instance of BedDetails. For more detailed information, use the amenityFeature property.""" ;
+    :contributor <https://schema.org/docs/collab/STI_Accommodation_Ontology> ;
+    :domainIncludes :Accommodation,
+        :HotelRoom,
+        :Suite ;
     :rangeIncludes :BedDetails,
         :BedType,
-        :Text ;
-    :contributor <https://schema.org/docs/collab/STI_Accommodation_Ontology> ;
-    rdfs:comment """The type of bed or beds included in the accommodation. For the single case of just one bed of a certain type, you use bed directly with a text.
-      If you want to indicate the quantity of a certain kind of bed, use an instance of BedDetails. For more detailed information, use the amenityFeature property.""" .
+        :Text .
 
 :beforeMedia a rdf:Property ;
     rdfs:label "beforeMedia" ;
+    rdfs:comment "A media object representing the circumstances before performing this direction." ;
     :domainIncludes :HowToDirection ;
     :rangeIncludes :MediaObject,
-        :URL ;
-    rdfs:comment "A media object representing the circumstances before performing this direction." .
+        :URL .
 
 :benefits a rdf:Property ;
     rdfs:label "benefits" ;
+    rdfs:comment "Description of benefits associated with the job." ;
     :domainIncludes :JobPosting ;
     :rangeIncludes :Text ;
-    :supersededBy :jobBenefits ;
-    rdfs:comment "Description of benefits associated with the job." .
+    :supersededBy :jobBenefits .
 
 :bestRating a rdf:Property ;
     rdfs:label "bestRating" ;
+    rdfs:comment "The highest value allowed in this rating system." ;
     :domainIncludes :Rating ;
     :rangeIncludes :Number,
-        :Text ;
-    rdfs:comment "The highest value allowed in this rating system." .
+        :Text .
 
 :billingAddress a rdf:Property ;
     rdfs:label "billingAddress" ;
+    rdfs:comment "The billing address for the order." ;
     :domainIncludes :Order ;
-    :rangeIncludes :PostalAddress ;
-    rdfs:comment "The billing address for the order." .
+    :rangeIncludes :PostalAddress .
 
 :billingIncrement a rdf:Property ;
     rdfs:label "billingIncrement" ;
+    rdfs:comment "This property specifies the minimal quantity and rounding increment that will be the basis for the billing. The unit of measurement is specified by the unitCode property." ;
     :domainIncludes :UnitPriceSpecification ;
-    :rangeIncludes :Number ;
-    rdfs:comment "This property specifies the minimal quantity and rounding increment that will be the basis for the billing. The unit of measurement is specified by the unitCode property." .
+    :rangeIncludes :Number .
 
 :billingPeriod a rdf:Property ;
     rdfs:label "billingPeriod" ;
+    rdfs:comment "The time interval used to compute the invoice." ;
     :domainIncludes :Invoice ;
-    :rangeIncludes :Duration ;
-    rdfs:comment "The time interval used to compute the invoice." .
+    :rangeIncludes :Duration .
 
 :birthDate a rdf:Property ;
     rdfs:label "birthDate" ;
+    rdfs:comment "Date of birth." ;
     :domainIncludes :Person ;
-    :rangeIncludes :Date ;
-    rdfs:comment "Date of birth." .
+    :rangeIncludes :Date .
 
 :birthPlace a rdf:Property ;
     rdfs:label "birthPlace" ;
+    rdfs:comment "The place where the person was born." ;
     :domainIncludes :Person ;
-    :rangeIncludes :Place ;
-    rdfs:comment "The place where the person was born." .
+    :rangeIncludes :Place .
 
 :bitrate a rdf:Property ;
     rdfs:label "bitrate" ;
+    rdfs:comment "The bitrate of the media object." ;
     :domainIncludes :MediaObject ;
-    :rangeIncludes :Text ;
-    rdfs:comment "The bitrate of the media object." .
+    :rangeIncludes :Text .
 
 :blogPosts a rdf:Property ;
     rdfs:label "blogPosts" ;
+    rdfs:comment "Indicates a post that is part of a [[Blog]]. Note that historically, what we term a \"Blog\" was once known as a \"weblog\", and that what we term a \"BlogPosting\" is now often colloquially referred to as a \"blog\"." ;
     :domainIncludes :Blog ;
     :rangeIncludes :BlogPosting ;
-    :supersededBy :blogPost ;
-    rdfs:comment """Indicates a post that is part of a [[Blog]]. Note that historically, what we term a "Blog" was once known as a "weblog", and that what we term a "BlogPosting" is now often colloquially referred to as a "blog".""" .
+    :supersededBy :blogPost .
 
 :boardingGroup a rdf:Property ;
     rdfs:label "boardingGroup" ;
+    rdfs:comment "The airline-specific indicator of boarding order / preference." ;
     :domainIncludes :FlightReservation ;
-    :rangeIncludes :Text ;
-    rdfs:comment "The airline-specific indicator of boarding order / preference." .
+    :rangeIncludes :Text .
 
 :boardingPolicy a rdf:Property ;
     rdfs:label "boardingPolicy" ;
+    rdfs:comment "The type of boarding policy used by the airline (e.g. zone-based or group-based)." ;
     :domainIncludes :Airline,
         :Flight ;
-    :rangeIncludes :BoardingPolicyType ;
-    rdfs:comment "The type of boarding policy used by the airline (e.g. zone-based or group-based)." .
+    :rangeIncludes :BoardingPolicyType .
 
 :bookEdition a rdf:Property ;
     rdfs:label "bookEdition" ;
+    rdfs:comment "The edition of the book." ;
     :domainIncludes :Book ;
-    :rangeIncludes :Text ;
-    rdfs:comment "The edition of the book." .
+    :rangeIncludes :Text .
 
 :bookFormat a rdf:Property ;
     rdfs:label "bookFormat" ;
+    rdfs:comment "The format of the book." ;
     :domainIncludes :Book ;
-    :rangeIncludes :BookFormatType ;
-    rdfs:comment "The format of the book." .
+    :rangeIncludes :BookFormatType .
 
 :bookingAgent a rdf:Property ;
     rdfs:label "bookingAgent" ;
+    rdfs:comment "'bookingAgent' is an out-dated term indicating a 'broker' that serves as a booking agent." ;
     :domainIncludes :Reservation ;
     :rangeIncludes :Organization,
         :Person ;
-    :supersededBy :broker ;
-    rdfs:comment "'bookingAgent' is an out-dated term indicating a 'broker' that serves as a booking agent." .
+    :supersededBy :broker .
 
 :bookingTime a rdf:Property ;
     rdfs:label "bookingTime" ;
+    rdfs:comment "The date and time the reservation was booked." ;
     :domainIncludes :Reservation ;
-    :rangeIncludes :DateTime ;
-    rdfs:comment "The date and time the reservation was booked." .
+    :rangeIncludes :DateTime .
 
 :borrower a rdf:Property ;
     rdfs:label "borrower" ;
-    :domainIncludes :LendAction ;
-    :rangeIncludes :Person ;
     rdfs:comment "A sub property of participant. The person that borrows the object being lent." ;
-    rdfs:subPropertyOf :participant .
+    rdfs:subPropertyOf :participant ;
+    :domainIncludes :LendAction ;
+    :rangeIncludes :Person .
 
 :box a rdf:Property ;
     rdfs:label "box" ;
+    rdfs:comment "A box is the area enclosed by the rectangle formed by two points. The first point is the lower corner, the second point is the upper corner. A box is expressed as two points separated by a space character." ;
     :domainIncludes :GeoShape ;
-    :rangeIncludes :Text ;
-    rdfs:comment "A box is the area enclosed by the rectangle formed by two points. The first point is the lower corner, the second point is the upper corner. A box is expressed as two points separated by a space character." .
+    :rangeIncludes :Text .
 
 :branchCode a rdf:Property ;
     rdfs:label "branchCode" ;
-    :domainIncludes :Place ;
-    :rangeIncludes :Text ;
     rdfs:comment """A short textual code (also called "store code") that uniquely identifies a place of business. The code is typically assigned by the parentOrganization and used in structured URLs.\\n\\nFor example, in the URL http://www.starbucks.co.uk/store-locator/etc/detail/3047 the code "3047" is a branchCode for a particular branch.
-      """ .
+      """ ;
+    :domainIncludes :Place ;
+    :rangeIncludes :Text .
 
 :branchOf a rdf:Property ;
     rdfs:label "branchOf" ;
+    rdfs:comment "The larger organization that this local business is a branch of, if any. Not to be confused with (anatomical) [[branch]]." ;
     :domainIncludes :LocalBusiness ;
     :rangeIncludes :Organization ;
-    :supersededBy :parentOrganization ;
-    rdfs:comment "The larger organization that this local business is a branch of, if any. Not to be confused with (anatomical) [[branch]]." .
+    :supersededBy :parentOrganization .
 
 :brand a rdf:Property ;
     rdfs:label "brand" ;
+    rdfs:comment "The brand(s) associated with a product or service, or the brand(s) maintained by an organization or business person." ;
     :domainIncludes :Organization,
         :Person,
         :Product,
         :Service ;
     :rangeIncludes :Brand,
-        :Organization ;
-    rdfs:comment "The brand(s) associated with a product or service, or the brand(s) maintained by an organization or business person." .
+        :Organization .
 
 :breadcrumb a rdf:Property ;
     rdfs:label "breadcrumb" ;
+    rdfs:comment "A set of links that can help a user understand and navigate a website hierarchy." ;
     :domainIncludes :WebPage ;
     :rangeIncludes :BreadcrumbList,
-        :Text ;
-    rdfs:comment "A set of links that can help a user understand and navigate a website hierarchy." .
+        :Text .
 
 :broadcastAffiliateOf a rdf:Property ;
     rdfs:label "broadcastAffiliateOf" ;
+    rdfs:comment "The media network(s) whose content is broadcast on this station." ;
     :domainIncludes :BroadcastService ;
-    :rangeIncludes :Organization ;
-    rdfs:comment "The media network(s) whose content is broadcast on this station." .
+    :rangeIncludes :Organization .
 
 :broadcastChannelId a rdf:Property ;
     rdfs:label "broadcastChannelId" ;
+    rdfs:comment "The unique address by which the BroadcastService can be identified in a provider lineup. In US, this is typically a number." ;
     :domainIncludes :BroadcastChannel ;
-    :rangeIncludes :Text ;
-    rdfs:comment "The unique address by which the BroadcastService can be identified in a provider lineup. In US, this is typically a number." .
+    :rangeIncludes :Text .
 
 :broadcastDisplayName a rdf:Property ;
     rdfs:label "broadcastDisplayName" ;
+    rdfs:comment "The name displayed in the channel guide. For many US affiliates, it is the network name." ;
     :domainIncludes :BroadcastService ;
-    :rangeIncludes :Text ;
-    rdfs:comment "The name displayed in the channel guide. For many US affiliates, it is the network name." .
+    :rangeIncludes :Text .
 
 :broadcastFrequency a rdf:Property ;
     rdfs:label "broadcastFrequency" ;
+    rdfs:comment "The frequency used for over-the-air broadcasts. Numeric values or simple ranges, e.g. 87-99. In addition a shortcut idiom is supported for frequencies of AM and FM radio channels, e.g. \"87 FM\"." ;
     :domainIncludes :BroadcastChannel,
         :BroadcastService ;
     :rangeIncludes :BroadcastFrequencySpecification,
         :Text ;
-    :source <https://github.com/schemaorg/schemaorg/issues/1004> ;
-    rdfs:comment "The frequency used for over-the-air broadcasts. Numeric values or simple ranges, e.g. 87-99. In addition a shortcut idiom is supported for frequencies of AM and FM radio channels, e.g. \"87 FM\"." .
+    :source <https://github.com/schemaorg/schemaorg/issues/1004> .
 
 :broadcastFrequencyValue a rdf:Property ;
     rdfs:label "broadcastFrequencyValue" ;
+    rdfs:comment "The frequency in MHz for a particular broadcast." ;
     :domainIncludes :BroadcastFrequencySpecification ;
     :rangeIncludes :Number,
         :QuantitativeValue ;
-    :source <https://github.com/schemaorg/schemaorg/issues/1004> ;
-    rdfs:comment "The frequency in MHz for a particular broadcast." .
+    :source <https://github.com/schemaorg/schemaorg/issues/1004> .
 
 :broadcastOfEvent a rdf:Property ;
     rdfs:label "broadcastOfEvent" ;
+    rdfs:comment "The event being broadcast such as a sporting event or awards ceremony." ;
     :domainIncludes :BroadcastEvent ;
-    :rangeIncludes :Event ;
-    rdfs:comment "The event being broadcast such as a sporting event or awards ceremony." .
+    :rangeIncludes :Event .
 
 :broadcastServiceTier a rdf:Property ;
     rdfs:label "broadcastServiceTier" ;
+    rdfs:comment "The type of service required to have access to the channel (e.g. Standard or Premium)." ;
     :domainIncludes :BroadcastChannel ;
-    :rangeIncludes :Text ;
-    rdfs:comment "The type of service required to have access to the channel (e.g. Standard or Premium)." .
+    :rangeIncludes :Text .
 
 :broadcastTimezone a rdf:Property ;
     rdfs:label "broadcastTimezone" ;
+    rdfs:comment "The timezone in [ISO 8601 format](http://en.wikipedia.org/wiki/ISO_8601) for which the service bases its broadcasts." ;
     :domainIncludes :BroadcastService ;
-    :rangeIncludes :Text ;
-    rdfs:comment "The timezone in [ISO 8601 format](http://en.wikipedia.org/wiki/ISO_8601) for which the service bases its broadcasts." .
+    :rangeIncludes :Text .
 
 :broadcaster a rdf:Property ;
     rdfs:label "broadcaster" ;
+    rdfs:comment "The organization owning or operating the broadcast service." ;
     :domainIncludes :BroadcastService ;
-    :rangeIncludes :Organization ;
-    rdfs:comment "The organization owning or operating the broadcast service." .
+    :rangeIncludes :Organization .
 
 :browserRequirements a rdf:Property ;
     rdfs:label "browserRequirements" ;
+    rdfs:comment "Specifies browser requirements in human-readable text. For example, 'requires HTML5 support'." ;
     :domainIncludes :WebApplication ;
-    :rangeIncludes :Text ;
-    rdfs:comment "Specifies browser requirements in human-readable text. For example, 'requires HTML5 support'." .
+    :rangeIncludes :Text .
 
 :busName a rdf:Property ;
     rdfs:label "busName" ;
+    rdfs:comment "The name of the bus (e.g. Bolt Express)." ;
     :domainIncludes :BusTrip ;
-    :rangeIncludes :Text ;
-    rdfs:comment "The name of the bus (e.g. Bolt Express)." .
+    :rangeIncludes :Text .
 
 :busNumber a rdf:Property ;
     rdfs:label "busNumber" ;
+    rdfs:comment "The unique identifier for the bus." ;
     :domainIncludes :BusTrip ;
-    :rangeIncludes :Text ;
-    rdfs:comment "The unique identifier for the bus." .
+    :rangeIncludes :Text .
 
 :businessFunction a rdf:Property ;
     rdfs:label "businessFunction" ;
+    rdfs:comment "The business function (e.g. sell, lease, repair, dispose) of the offer or component of a bundle (TypeAndQuantityNode). The default is http://purl.org/goodrelations/v1#Sell." ;
     :domainIncludes :Demand,
         :Offer,
         :TypeAndQuantityNode ;
-    :rangeIncludes :BusinessFunction ;
-    rdfs:comment "The business function (e.g. sell, lease, repair, dispose) of the offer or component of a bundle (TypeAndQuantityNode). The default is http://purl.org/goodrelations/v1#Sell." .
+    :rangeIncludes :BusinessFunction .
 
 :buyer a rdf:Property ;
     rdfs:label "buyer" ;
+    rdfs:comment "A sub property of participant. The participant/person/organization that bought the object." ;
+    rdfs:subPropertyOf :participant ;
     :domainIncludes :SellAction ;
     :rangeIncludes :Organization,
-        :Person ;
-    rdfs:comment "A sub property of participant. The participant/person/organization that bought the object." ;
-    rdfs:subPropertyOf :participant .
+        :Person .
 
 :byArtist a rdf:Property ;
     rdfs:label "byArtist" ;
+    rdfs:comment "The artist that performed this album or recording." ;
     :domainIncludes :MusicAlbum,
         :MusicRecording ;
     :rangeIncludes :MusicGroup,
-        :Person ;
-    rdfs:comment "The artist that performed this album or recording." .
+        :Person .
 
 :calories a rdf:Property ;
     rdfs:label "calories" ;
+    rdfs:comment "The number of calories." ;
     :domainIncludes :NutritionInformation ;
-    :rangeIncludes :Energy ;
-    rdfs:comment "The number of calories." .
+    :rangeIncludes :Energy .
 
 :candidate a rdf:Property ;
     rdfs:label "candidate" ;
-    :domainIncludes :VoteAction ;
-    :rangeIncludes :Person ;
     rdfs:comment "A sub property of object. The candidate subject of this action." ;
-    rdfs:subPropertyOf :object .
+    rdfs:subPropertyOf :object ;
+    :domainIncludes :VoteAction ;
+    :rangeIncludes :Person .
 
 :caption a rdf:Property ;
     rdfs:label "caption" ;
+    rdfs:comment "The caption for this object. For downloadable machine formats (closed caption, subtitles etc.) use MediaObject and indicate the [[encodingFormat]]." ;
     :domainIncludes :AudioObject,
         :ImageObject,
         :VideoObject ;
     :rangeIncludes :MediaObject,
-        :Text ;
-    rdfs:comment "The caption for this object. For downloadable machine formats (closed caption, subtitles etc.) use MediaObject and indicate the [[encodingFormat]]." .
+        :Text .
 
 :carbohydrateContent a rdf:Property ;
     rdfs:label "carbohydrateContent" ;
+    rdfs:comment "The number of grams of carbohydrates." ;
     :domainIncludes :NutritionInformation ;
-    :rangeIncludes :Mass ;
-    rdfs:comment "The number of grams of carbohydrates." .
+    :rangeIncludes :Mass .
 
 :cargoVolume a rdf:Property ;
     rdfs:label "cargoVolume" ;
-    :domainIncludes :Vehicle ;
-    :rangeIncludes :QuantitativeValue ;
+    rdfs:comment "The available volume for cargo or luggage. For automobiles, this is usually the trunk volume.\\n\\nTypical unit code(s): LTR for liters, FTQ for cubic foot/feet\\n\\nNote: You can use [[minValue]] and [[maxValue]] to indicate ranges." ;
     :contributor <https://schema.org/docs/collab/Automotive_Ontology_Working_Group> ;
-    rdfs:comment "The available volume for cargo or luggage. For automobiles, this is usually the trunk volume.\\n\\nTypical unit code(s): LTR for liters, FTQ for cubic foot/feet\\n\\nNote: You can use [[minValue]] and [[maxValue]] to indicate ranges." .
+    :domainIncludes :Vehicle ;
+    :rangeIncludes :QuantitativeValue .
 
 :carrier a rdf:Property ;
     rdfs:label "carrier" ;
+    rdfs:comment "'carrier' is an out-dated term indicating the 'provider' for parcel delivery and flights." ;
     :domainIncludes :Flight,
         :ParcelDelivery ;
     :rangeIncludes :Organization ;
-    :supersededBy :provider ;
-    rdfs:comment "'carrier' is an out-dated term indicating the 'provider' for parcel delivery and flights." .
+    :supersededBy :provider .
 
 :carrierRequirements a rdf:Property ;
     rdfs:label "carrierRequirements" ;
+    rdfs:comment "Specifies specific carrier(s) requirements for the application (e.g. an application may only work on a specific carrier network)." ;
     :domainIncludes :MobileApplication ;
-    :rangeIncludes :Text ;
-    rdfs:comment "Specifies specific carrier(s) requirements for the application (e.g. an application may only work on a specific carrier network)." .
+    :rangeIncludes :Text .
 
 :catalog a rdf:Property ;
     rdfs:label "catalog" ;
+    rdfs:comment "A data catalog which contains this dataset." ;
     :domainIncludes :Dataset ;
     :rangeIncludes :DataCatalog ;
-    :supersededBy :includedInDataCatalog ;
-    rdfs:comment "A data catalog which contains this dataset." .
+    :supersededBy :includedInDataCatalog .
 
 :catalogNumber a rdf:Property ;
     rdfs:label "catalogNumber" ;
-    :domainIncludes :MusicRelease ;
-    :rangeIncludes :Text ;
+    rdfs:comment "The catalog number for the release." ;
     :contributor <https://schema.org/docs/collab/MBZ> ;
-    rdfs:comment "The catalog number for the release." .
+    :domainIncludes :MusicRelease ;
+    :rangeIncludes :Text .
 
 :category a rdf:Property ;
     rdfs:label "category" ;
+    rdfs:comment "A category for the item. Greater signs or slashes can be used to informally indicate a category hierarchy." ;
     :domainIncludes :ActionAccessSpecification,
         :Invoice,
         :Offer,
@@ -4868,615 +4865,618 @@ See also the <a href="/docs/hotels.html">dedicated document on the use of schema
         :Service ;
     :rangeIncludes :Text,
         :Thing ;
-    :source <https://github.com/schemaorg/schemaorg/issues/1741> ;
-    rdfs:comment "A category for the item. Greater signs or slashes can be used to informally indicate a category hierarchy." .
+    :source <https://github.com/schemaorg/schemaorg/issues/1741> .
 
 :ccRecipient a rdf:Property ;
     rdfs:label "ccRecipient" ;
+    rdfs:comment "A sub property of recipient. The recipient copied on a message." ;
+    rdfs:subPropertyOf :recipient ;
     :domainIncludes :Message ;
     :rangeIncludes :ContactPoint,
         :Organization,
-        :Person ;
-    rdfs:comment "A sub property of recipient. The recipient copied on a message." ;
-    rdfs:subPropertyOf :recipient .
+        :Person .
 
 :character a rdf:Property ;
     rdfs:label "character" ;
+    rdfs:comment "Fictional person connected with a creative work." ;
     :domainIncludes :CreativeWork ;
-    :rangeIncludes :Person ;
-    rdfs:comment "Fictional person connected with a creative work." .
+    :rangeIncludes :Person .
 
 :characterAttribute a rdf:Property ;
     rdfs:label "characterAttribute" ;
+    rdfs:comment "A piece of data that represents a particular aspect of a fictional character (skill, power, character points, advantage, disadvantage)." ;
     :domainIncludes :Game,
         :VideoGameSeries ;
-    :rangeIncludes :Thing ;
-    rdfs:comment "A piece of data that represents a particular aspect of a fictional character (skill, power, character points, advantage, disadvantage)." .
+    :rangeIncludes :Thing .
 
 :characterName a rdf:Property ;
     rdfs:label "characterName" ;
+    rdfs:comment "The name of a character played in some acting or performing role, i.e. in a PerformanceRole." ;
     :domainIncludes :PerformanceRole ;
-    :rangeIncludes :Text ;
-    rdfs:comment "The name of a character played in some acting or performing role, i.e. in a PerformanceRole." .
+    :rangeIncludes :Text .
 
 :cheatCode a rdf:Property ;
     rdfs:label "cheatCode" ;
+    rdfs:comment "Cheat codes to the game." ;
     :domainIncludes :VideoGame,
         :VideoGameSeries ;
-    :rangeIncludes :CreativeWork ;
-    rdfs:comment "Cheat codes to the game." .
+    :rangeIncludes :CreativeWork .
 
 :checkinTime a rdf:Property ;
     rdfs:label "checkinTime" ;
+    rdfs:comment "The earliest someone may check into a lodging establishment." ;
     :domainIncludes :LodgingBusiness,
         :LodgingReservation ;
     :rangeIncludes :DateTime,
-        :Time ;
-    rdfs:comment "The earliest someone may check into a lodging establishment." .
+        :Time .
 
 :checkoutTime a rdf:Property ;
     rdfs:label "checkoutTime" ;
+    rdfs:comment "The latest someone may check out of a lodging establishment." ;
     :domainIncludes :LodgingBusiness,
         :LodgingReservation ;
     :rangeIncludes :DateTime,
-        :Time ;
-    rdfs:comment "The latest someone may check out of a lodging establishment." .
+        :Time .
 
 :childMaxAge a rdf:Property ;
     rdfs:label "childMaxAge" ;
+    rdfs:comment "Maximal age of the child." ;
     :domainIncludes :ParentAudience ;
-    :rangeIncludes :Number ;
-    rdfs:comment "Maximal age of the child." .
+    :rangeIncludes :Number .
 
 :childMinAge a rdf:Property ;
     rdfs:label "childMinAge" ;
+    rdfs:comment "Minimal age of the child." ;
     :domainIncludes :ParentAudience ;
-    :rangeIncludes :Number ;
-    rdfs:comment "Minimal age of the child." .
+    :rangeIncludes :Number .
 
 :children a rdf:Property ;
     rdfs:label "children" ;
+    rdfs:comment "A child of the person." ;
     :domainIncludes :Person ;
-    :rangeIncludes :Person ;
-    rdfs:comment "A child of the person." .
+    :rangeIncludes :Person .
 
 :cholesterolContent a rdf:Property ;
     rdfs:label "cholesterolContent" ;
+    rdfs:comment "The number of milligrams of cholesterol." ;
     :domainIncludes :NutritionInformation ;
-    :rangeIncludes :Mass ;
-    rdfs:comment "The number of milligrams of cholesterol." .
+    :rangeIncludes :Mass .
 
 :circle a rdf:Property ;
     rdfs:label "circle" ;
+    rdfs:comment "A circle is the circular region of a specified radius centered at a specified latitude and longitude. A circle is expressed as a pair followed by a radius in meters." ;
     :domainIncludes :GeoShape ;
-    :rangeIncludes :Text ;
-    rdfs:comment "A circle is the circular region of a specified radius centered at a specified latitude and longitude. A circle is expressed as a pair followed by a radius in meters." .
+    :rangeIncludes :Text .
 
 :citation a rdf:Property ;
     rdfs:label "citation" ;
+    rdfs:comment "A citation or reference to another creative work, such as another publication, web page, scholarly article, etc." ;
     :domainIncludes :CreativeWork ;
     :rangeIncludes :CreativeWork,
-        :Text ;
-    rdfs:comment "A citation or reference to another creative work, such as another publication, web page, scholarly article, etc." .
+        :Text .
 
 :claimReviewed a rdf:Property ;
     rdfs:label "claimReviewed" ;
+    rdfs:comment "A short summary of the specific claims reviewed in a ClaimReview." ;
     :domainIncludes :ClaimReview ;
     :rangeIncludes :Text ;
-    :source <https://github.com/schemaorg/schemaorg/issues/1061> ;
-    rdfs:comment "A short summary of the specific claims reviewed in a ClaimReview." .
+    :source <https://github.com/schemaorg/schemaorg/issues/1061> .
 
 :clipNumber a rdf:Property ;
     rdfs:label "clipNumber" ;
+    rdfs:comment "Position of the clip within an ordered group of clips." ;
+    rdfs:subPropertyOf :position ;
     :domainIncludes :Clip ;
     :rangeIncludes :Integer,
-        :Text ;
-    rdfs:comment "Position of the clip within an ordered group of clips." ;
-    rdfs:subPropertyOf :position .
+        :Text .
 
 :closes a rdf:Property ;
     rdfs:label "closes" ;
+    rdfs:comment "The closing hour of the place or service on the given day(s) of the week." ;
     :domainIncludes :OpeningHoursSpecification ;
-    :rangeIncludes :Time ;
-    rdfs:comment "The closing hour of the place or service on the given day(s) of the week." .
+    :rangeIncludes :Time .
 
 :coach a rdf:Property ;
     rdfs:label "coach" ;
+    rdfs:comment "A person that acts in a coaching role for a sports team." ;
     :domainIncludes :SportsTeam ;
-    :rangeIncludes :Person ;
-    rdfs:comment "A person that acts in a coaching role for a sports team." .
+    :rangeIncludes :Person .
 
 :codeRepository a rdf:Property ;
     rdfs:label "codeRepository" ;
+    rdfs:comment "Link to the repository where the un-compiled, human readable code and related code is located (SVN, GitHub, CodePlex)." ;
     :domainIncludes :SoftwareSourceCode ;
-    :rangeIncludes :URL ;
-    rdfs:comment "Link to the repository where the un-compiled, human readable code and related code is located (SVN, GitHub, CodePlex)." .
+    :rangeIncludes :URL .
 
 :colleagues a rdf:Property ;
     rdfs:label "colleagues" ;
+    rdfs:comment "A colleague of the person." ;
     :domainIncludes :Person ;
     :rangeIncludes :Person ;
-    :supersededBy :colleague ;
-    rdfs:comment "A colleague of the person." .
+    :supersededBy :colleague .
 
 :collection a rdf:Property ;
     rdfs:label "collection" ;
+    rdfs:comment "A sub property of object. The collection target of the action." ;
+    rdfs:subPropertyOf :object ;
     :domainIncludes :UpdateAction ;
     :rangeIncludes :Thing ;
-    :supersededBy :targetCollection ;
-    rdfs:comment "A sub property of object. The collection target of the action." ;
-    rdfs:subPropertyOf :object .
+    :supersededBy :targetCollection .
 
 :color a rdf:Property ;
     rdfs:label "color" ;
+    rdfs:comment "The color of the product." ;
     :domainIncludes :Product ;
-    :rangeIncludes :Text ;
-    rdfs:comment "The color of the product." .
+    :rangeIncludes :Text .
 
 :comment a rdf:Property ;
     rdfs:label "comment" ;
+    rdfs:comment "Comments, typically from users." ;
     :domainIncludes :CreativeWork,
         :RsvpAction ;
-    :rangeIncludes :Comment ;
-    rdfs:comment "Comments, typically from users." .
+    :rangeIncludes :Comment .
 
 :commentCount a rdf:Property ;
     rdfs:label "commentCount" ;
+    rdfs:comment "The number of comments this CreativeWork (e.g. Article, Question or Answer) has received. This is most applicable to works published in Web sites with commenting system; additional comments may exist elsewhere." ;
     :domainIncludes :CreativeWork ;
-    :rangeIncludes :Integer ;
-    rdfs:comment "The number of comments this CreativeWork (e.g. Article, Question or Answer) has received. This is most applicable to works published in Web sites with commenting system; additional comments may exist elsewhere." .
+    :rangeIncludes :Integer .
 
 :commentText a rdf:Property ;
     rdfs:label "commentText" ;
+    rdfs:comment "The text of the UserComment." ;
     :domainIncludes :UserComments ;
-    :rangeIncludes :Text ;
-    rdfs:comment "The text of the UserComment." .
+    :rangeIncludes :Text .
 
 :commentTime a rdf:Property ;
     rdfs:label "commentTime" ;
+    rdfs:comment "The time at which the UserComment was made." ;
     :domainIncludes :UserComments ;
     :rangeIncludes :Date,
-        :DateTime ;
-    rdfs:comment "The time at which the UserComment was made." .
+        :DateTime .
 
 :composer a rdf:Property ;
     rdfs:label "composer" ;
+    rdfs:comment "The person or organization who wrote a composition, or who is the composer of a work performed at some event." ;
+    :contributor <https://schema.org/docs/collab/MBZ> ;
     :domainIncludes :Event,
         :MusicComposition ;
     :rangeIncludes :Organization,
-        :Person ;
-    :contributor <https://schema.org/docs/collab/MBZ> ;
-    rdfs:comment "The person or organization who wrote a composition, or who is the composer of a work performed at some event." .
+        :Person .
 
 :confirmationNumber a rdf:Property ;
     rdfs:label "confirmationNumber" ;
+    rdfs:comment "A number that confirms the given order or payment has been received." ;
+    rdfs:subPropertyOf :identifier ;
     :domainIncludes :Invoice,
         :Order ;
-    :rangeIncludes :Text ;
-    rdfs:comment "A number that confirms the given order or payment has been received." ;
-    rdfs:subPropertyOf :identifier .
+    :rangeIncludes :Text .
 
 :contactOption a rdf:Property ;
     rdfs:label "contactOption" ;
+    rdfs:comment "An option available on this contact point (e.g. a toll-free number or support for hearing-impaired callers)." ;
     :domainIncludes :ContactPoint ;
-    :rangeIncludes :ContactPointOption ;
-    rdfs:comment "An option available on this contact point (e.g. a toll-free number or support for hearing-impaired callers)." .
+    :rangeIncludes :ContactPointOption .
 
 :contactPoints a rdf:Property ;
     rdfs:label "contactPoints" ;
+    rdfs:comment "A contact point for a person or organization." ;
     :domainIncludes :Organization,
         :Person ;
     :rangeIncludes :ContactPoint ;
-    :supersededBy :contactPoint ;
-    rdfs:comment "A contact point for a person or organization." .
+    :supersededBy :contactPoint .
 
 :contactType a rdf:Property ;
     rdfs:label "contactType" ;
+    rdfs:comment "A person or organization can have different contact points, for different purposes. For example, a sales contact point, a PR contact point and so on. This property is used to specify the kind of contact point." ;
     :domainIncludes :ContactPoint ;
-    :rangeIncludes :Text ;
-    rdfs:comment "A person or organization can have different contact points, for different purposes. For example, a sales contact point, a PR contact point and so on. This property is used to specify the kind of contact point." .
+    :rangeIncludes :Text .
 
 :containedIn a rdf:Property ;
     rdfs:label "containedIn" ;
+    rdfs:comment "The basic containment relation between a place and one that contains it." ;
     :domainIncludes :Place ;
     :rangeIncludes :Place ;
-    :supersededBy :containedInPlace ;
-    rdfs:comment "The basic containment relation between a place and one that contains it." .
+    :supersededBy :containedInPlace .
 
 :contentRating a rdf:Property ;
     rdfs:label "contentRating" ;
+    rdfs:comment "Official rating of a piece of content&#x2014;for example, 'MPAA PG-13'." ;
     :domainIncludes :CreativeWork ;
     :rangeIncludes :Rating,
-        :Text ;
-    rdfs:comment "Official rating of a piece of content&#x2014;for example, 'MPAA PG-13'." .
+        :Text .
 
 :contentSize a rdf:Property ;
     rdfs:label "contentSize" ;
+    rdfs:comment "File size in (mega/kilo)bytes." ;
     :domainIncludes :MediaObject ;
-    :rangeIncludes :Text ;
-    rdfs:comment "File size in (mega/kilo)bytes." .
+    :rangeIncludes :Text .
 
 :contentType a rdf:Property ;
     rdfs:label "contentType" ;
+    rdfs:comment "The supported content type(s) for an EntryPoint response." ;
     :domainIncludes :EntryPoint ;
-    :rangeIncludes :Text ;
-    rdfs:comment "The supported content type(s) for an EntryPoint response." .
+    :rangeIncludes :Text .
 
 :contentUrl a rdf:Property ;
     rdfs:label "contentUrl" ;
+    rdfs:comment "Actual bytes of the media object, for example the image file or video file." ;
     :domainIncludes :MediaObject ;
-    :rangeIncludes :URL ;
-    rdfs:comment "Actual bytes of the media object, for example the image file or video file." .
+    :rangeIncludes :URL .
 
 :contributor a rdf:Property ;
     rdfs:label "contributor" ;
+    rdfs:comment "A secondary contributor to the CreativeWork or Event." ;
     :domainIncludes :CreativeWork,
         :Event ;
     :rangeIncludes :Organization,
-        :Person ;
-    rdfs:comment "A secondary contributor to the CreativeWork or Event." .
+        :Person .
 
 :cookTime a rdf:Property ;
     rdfs:label "cookTime" ;
-    :domainIncludes :Recipe ;
-    :rangeIncludes :Duration ;
     rdfs:comment "The time it takes to actually cook the dish, in [ISO 8601 duration format](http://en.wikipedia.org/wiki/ISO_8601)." ;
-    rdfs:subPropertyOf :performTime .
+    rdfs:subPropertyOf :performTime ;
+    :domainIncludes :Recipe ;
+    :rangeIncludes :Duration .
 
 :cookingMethod a rdf:Property ;
     rdfs:label "cookingMethod" ;
+    rdfs:comment "The method of cooking, such as Frying, Steaming, ..." ;
     :domainIncludes :Recipe ;
-    :rangeIncludes :Text ;
-    rdfs:comment "The method of cooking, such as Frying, Steaming, ..." .
+    :rangeIncludes :Text .
 
 :copyrightHolder a rdf:Property ;
     rdfs:label "copyrightHolder" ;
+    rdfs:comment "The party holding the legal copyright to the CreativeWork." ;
     :domainIncludes :CreativeWork ;
     :rangeIncludes :Organization,
-        :Person ;
-    rdfs:comment "The party holding the legal copyright to the CreativeWork." .
+        :Person .
 
 :copyrightYear a rdf:Property ;
     rdfs:label "copyrightYear" ;
+    rdfs:comment "The year during which the claimed copyright for the CreativeWork was first asserted." ;
     :domainIncludes :CreativeWork ;
-    :rangeIncludes :Number ;
-    rdfs:comment "The year during which the claimed copyright for the CreativeWork was first asserted." .
+    :rangeIncludes :Number .
 
 :countriesNotSupported a rdf:Property ;
     rdfs:label "countriesNotSupported" ;
+    rdfs:comment "Countries for which the application is not supported. You can also provide the two-letter ISO 3166-1 alpha-2 country code." ;
     :domainIncludes :SoftwareApplication ;
-    :rangeIncludes :Text ;
-    rdfs:comment "Countries for which the application is not supported. You can also provide the two-letter ISO 3166-1 alpha-2 country code." .
+    :rangeIncludes :Text .
 
 :countriesSupported a rdf:Property ;
     rdfs:label "countriesSupported" ;
+    rdfs:comment "Countries for which the application is supported. You can also provide the two-letter ISO 3166-1 alpha-2 country code." ;
     :domainIncludes :SoftwareApplication ;
-    :rangeIncludes :Text ;
-    rdfs:comment "Countries for which the application is supported. You can also provide the two-letter ISO 3166-1 alpha-2 country code." .
+    :rangeIncludes :Text .
 
 :countryOfOrigin a rdf:Property ;
     rdfs:label "countryOfOrigin" ;
-    :domainIncludes :CreativeWork, :Product, :Movie,
-        :TVEpisode,
-        :TVSeason,
-        :TVSeries ;
-    :rangeIncludes :Country ;
     rdfs:comment """The country of origin of something, including products as well as creative  works such as movie and TV content.
 
 In the case of TV and movie, this would be the country of the principle offices of the production company or individual responsible for the movie. For other kinds of [[CreativeWork]] it is difficult to provide fully general guidance, and properties such as [[contentLocation]] and [[locationCreated]] may be more applicable.
 
-In the case of products, the country of origin of the product. The exact interpretation of this may vary by context and product type, and cannot be fully enumerated here.""" .
+In the case of products, the country of origin of the product. The exact interpretation of this may vary by context and product type, and cannot be fully enumerated here.""" ;
+    :domainIncludes :CreativeWork,
+        :Movie,
+        :Product,
+        :TVEpisode,
+        :TVSeason,
+        :TVSeries ;
+    :rangeIncludes :Country .
 
 :course a rdf:Property ;
     rdfs:label "course" ;
+    rdfs:comment "A sub property of location. The course where this action was taken." ;
+    rdfs:subPropertyOf :location ;
     :domainIncludes :ExerciseAction ;
     :rangeIncludes :Place ;
-    :supersededBy :exerciseCourse ;
-    rdfs:comment "A sub property of location. The course where this action was taken." ;
-    rdfs:subPropertyOf :location .
+    :supersededBy :exerciseCourse .
 
 :courseCode a rdf:Property ;
     rdfs:label "courseCode" ;
+    rdfs:comment "The identifier for the [[Course]] used by the course [[provider]] (e.g. CS101 or 6.001)." ;
     :domainIncludes :Course ;
-    :rangeIncludes :Text ;
-    rdfs:comment "The identifier for the [[Course]] used by the course [[provider]] (e.g. CS101 or 6.001)." .
+    :rangeIncludes :Text .
 
 :courseMode a rdf:Property ;
     rdfs:label "courseMode" ;
+    rdfs:comment "The medium or means of delivery of the course instance or the mode of study, either as a text label (e.g. \"online\", \"onsite\" or \"blended\"; \"synchronous\" or \"asynchronous\"; \"full-time\" or \"part-time\") or as a URL reference to a term from a controlled vocabulary (e.g. https://ceds.ed.gov/element/001311#Asynchronous)." ;
     :domainIncludes :CourseInstance ;
     :rangeIncludes :Text,
-        :URL ;
-    rdfs:comment "The medium or means of delivery of the course instance or the mode of study, either as a text label (e.g. \"online\", \"onsite\" or \"blended\"; \"synchronous\" or \"asynchronous\"; \"full-time\" or \"part-time\") or as a URL reference to a term from a controlled vocabulary (e.g. https://ceds.ed.gov/element/001311#Asynchronous)." .
+        :URL .
 
 :coursePrerequisites a rdf:Property ;
     rdfs:label "coursePrerequisites" ;
+    rdfs:comment "Requirements for taking the Course. May be completion of another [[Course]] or a textual description like \"permission of instructor\". Requirements may be a pre-requisite competency, referenced using [[AlignmentObject]]." ;
     :domainIncludes :Course ;
     :rangeIncludes :AlignmentObject,
         :Course,
-        :Text ;
-    rdfs:comment "Requirements for taking the Course. May be completion of another [[Course]] or a textual description like \"permission of instructor\". Requirements may be a pre-requisite competency, referenced using [[AlignmentObject]]." .
+        :Text .
 
 :coverageEndTime a rdf:Property ;
     rdfs:label "coverageEndTime" ;
+    rdfs:comment "The time when the live blog will stop covering the Event. Note that coverage may continue after the Event concludes." ;
     :domainIncludes :LiveBlogPosting ;
-    :rangeIncludes :DateTime ;
-    rdfs:comment "The time when the live blog will stop covering the Event. Note that coverage may continue after the Event concludes." .
+    :rangeIncludes :DateTime .
 
 :coverageStartTime a rdf:Property ;
     rdfs:label "coverageStartTime" ;
+    rdfs:comment "The time when the live blog will begin covering the Event. Note that coverage may begin before the Event's start time. The LiveBlogPosting may also be created before coverage begins." ;
     :domainIncludes :LiveBlogPosting ;
-    :rangeIncludes :DateTime ;
-    rdfs:comment "The time when the live blog will begin covering the Event. Note that coverage may begin before the Event's start time. The LiveBlogPosting may also be created before coverage begins." .
+    :rangeIncludes :DateTime .
 
 :creator a rdf:Property ;
     rdfs:label "creator" ;
+    rdfs:comment "The creator/author of this CreativeWork. This is the same as the Author property for CreativeWork." ;
     :domainIncludes :CreativeWork,
         :UserComments ;
     :rangeIncludes :Organization,
-        :Person ;
-    rdfs:comment "The creator/author of this CreativeWork. This is the same as the Author property for CreativeWork." .
+        :Person .
 
 :creditedTo a rdf:Property ;
     rdfs:label "creditedTo" ;
+    rdfs:comment "The group the release is credited to if different than the byArtist. For example, Red and Blue is credited to \"Stefani Germanotta Band\", but by Lady Gaga." ;
+    :contributor <https://schema.org/docs/collab/MBZ> ;
     :domainIncludes :MusicRelease ;
     :rangeIncludes :Organization,
-        :Person ;
-    :contributor <https://schema.org/docs/collab/MBZ> ;
-    rdfs:comment "The group the release is credited to if different than the byArtist. For example, Red and Blue is credited to \"Stefani Germanotta Band\", but by Lady Gaga." .
+        :Person .
 
 :cssSelector a rdf:Property ;
     rdfs:label "cssSelector" ;
+    rdfs:comment "A CSS selector, e.g. of a [[SpeakableSpecification]] or [[WebPageElement]]. In the latter case, multiple matches within a page can constitute a single conceptual \"Web page element\"." ;
     :domainIncludes :SpeakableSpecification,
         :WebPageElement ;
     :rangeIncludes :CssSelectorType ;
-    :source <https://github.com/schemaorg/schemaorg/issues/1389> ;
-    rdfs:comment "A CSS selector, e.g. of a [[SpeakableSpecification]] or [[WebPageElement]]. In the latter case, multiple matches within a page can constitute a single conceptual \"Web page element\"." .
+    :source <https://github.com/schemaorg/schemaorg/issues/1389> .
 
 :currenciesAccepted a rdf:Property ;
     rdfs:label "currenciesAccepted" ;
+    rdfs:comment "The currency accepted.\\n\\nUse standard formats: [ISO 4217 currency format](http://en.wikipedia.org/wiki/ISO_4217), e.g. \"USD\"; [Ticker symbol](https://en.wikipedia.org/wiki/List_of_cryptocurrencies) for cryptocurrencies, e.g. \"BTC\"; well known names for [Local Exchange Trading Systems](https://en.wikipedia.org/wiki/Local_exchange_trading_system) (LETS) and other currency types, e.g. \"Ithaca HOUR\"." ;
     :domainIncludes :LocalBusiness ;
-    :rangeIncludes :Text ;
-    rdfs:comment "The currency accepted.\\n\\nUse standard formats: [ISO 4217 currency format](http://en.wikipedia.org/wiki/ISO_4217), e.g. \"USD\"; [Ticker symbol](https://en.wikipedia.org/wiki/List_of_cryptocurrencies) for cryptocurrencies, e.g. \"BTC\"; well known names for [Local Exchange Trading Systems](https://en.wikipedia.org/wiki/Local_exchange_trading_system) (LETS) and other currency types, e.g. \"Ithaca HOUR\"." .
+    :rangeIncludes :Text .
 
 :currency a rdf:Property ;
     rdfs:label "currency" ;
+    rdfs:comment "The currency in which the monetary amount is expressed.\\n\\nUse standard formats: [ISO 4217 currency format](http://en.wikipedia.org/wiki/ISO_4217), e.g. \"USD\"; [Ticker symbol](https://en.wikipedia.org/wiki/List_of_cryptocurrencies) for cryptocurrencies, e.g. \"BTC\"; well known names for [Local Exchange Trading Systems](https://en.wikipedia.org/wiki/Local_exchange_trading_system) (LETS) and other currency types, e.g. \"Ithaca HOUR\"." ;
     :domainIncludes :DatedMoneySpecification,
         :MonetaryAmount,
         :MonetaryAmountDistribution ;
-    :rangeIncludes :Text ;
-    rdfs:comment "The currency in which the monetary amount is expressed.\\n\\nUse standard formats: [ISO 4217 currency format](http://en.wikipedia.org/wiki/ISO_4217), e.g. \"USD\"; [Ticker symbol](https://en.wikipedia.org/wiki/List_of_cryptocurrencies) for cryptocurrencies, e.g. \"BTC\"; well known names for [Local Exchange Trading Systems](https://en.wikipedia.org/wiki/Local_exchange_trading_system) (LETS) and other currency types, e.g. \"Ithaca HOUR\"." .
+    :rangeIncludes :Text .
 
 :customer a rdf:Property ;
     rdfs:label "customer" ;
+    rdfs:comment "Party placing the order or paying the invoice." ;
     :domainIncludes :Invoice,
         :Order ;
     :rangeIncludes :Organization,
-        :Person ;
-    rdfs:comment "Party placing the order or paying the invoice." .
+        :Person .
 
 :dataFeedElement a rdf:Property ;
     rdfs:label "dataFeedElement" ;
+    rdfs:comment "An item within a data feed. Data feeds may have many elements." ;
     :domainIncludes :DataFeed ;
     :rangeIncludes :DataFeedItem,
         :Text,
-        :Thing ;
-    rdfs:comment "An item within a data feed. Data feeds may have many elements." .
+        :Thing .
 
 :datasetTimeInterval a rdf:Property ;
     rdfs:label "datasetTimeInterval" ;
+    rdfs:comment "The range of temporal applicability of a dataset, e.g. for a 2011 census dataset, the year 2011 (in ISO 8601 time interval format)." ;
     :domainIncludes :Dataset ;
     :rangeIncludes :DateTime ;
-    :supersededBy :temporalCoverage ;
-    rdfs:comment "The range of temporal applicability of a dataset, e.g. for a 2011 census dataset, the year 2011 (in ISO 8601 time interval format)." .
+    :supersededBy :temporalCoverage .
 
 :dateCreated a rdf:Property ;
     rdfs:label "dateCreated" ;
+    rdfs:comment "The date on which the CreativeWork was created or the item was added to a DataFeed." ;
     :domainIncludes :CreativeWork,
         :DataFeedItem ;
     :rangeIncludes :Date,
-        :DateTime ;
-    rdfs:comment "The date on which the CreativeWork was created or the item was added to a DataFeed." .
+        :DateTime .
 
 :dateDeleted a rdf:Property ;
     rdfs:label "dateDeleted" ;
+    rdfs:comment "The datetime the item was removed from the DataFeed." ;
     :domainIncludes :DataFeedItem ;
     :rangeIncludes :Date,
-        :DateTime ;
-    rdfs:comment "The datetime the item was removed from the DataFeed." .
+        :DateTime .
 
 :dateIssued a rdf:Property ;
     rdfs:label "dateIssued" ;
+    rdfs:comment "The date the ticket was issued." ;
     :domainIncludes :Ticket ;
     :rangeIncludes :Date,
-        :DateTime ;
-    rdfs:comment "The date the ticket was issued." .
+        :DateTime .
 
 :dateModified a rdf:Property ;
     rdfs:label "dateModified" ;
+    rdfs:comment "The date on which the CreativeWork was most recently modified or when the item's entry was modified within a DataFeed." ;
     :domainIncludes :CreativeWork,
         :DataFeedItem ;
     :rangeIncludes :Date,
-        :DateTime ;
-    rdfs:comment "The date on which the CreativeWork was most recently modified or when the item's entry was modified within a DataFeed." .
+        :DateTime .
 
 :datePosted a rdf:Property ;
     rdfs:label "datePosted" ;
+    rdfs:comment "Publication date of an online listing." ;
     :domainIncludes :JobPosting ;
-    :rangeIncludes :Date ;
-    rdfs:comment "Publication date of an online listing." .
+    :rangeIncludes :Date .
 
 :datePublished a rdf:Property ;
     rdfs:label "datePublished" ;
-    :domainIncludes :CreativeWork,
-    :Certification;
+    rdfs:comment "Date of first publication or broadcast. For example the date a [[CreativeWork]] was broadcast or a [[Certification]] was issued." ;
+    :domainIncludes :Certification,
+        :CreativeWork ;
     :rangeIncludes :Date,
-        :DateTime;
-    rdfs:comment "Date of first publication or broadcast. For example the date a [[CreativeWork]] was broadcast or a [[Certification]] was issued." .
+        :DateTime .
 
 :dateRead a rdf:Property ;
     rdfs:label "dateRead" ;
+    rdfs:comment "The date/time at which the message has been read by the recipient if a single recipient exists." ;
     :domainIncludes :Message ;
     :rangeIncludes :Date,
-        :DateTime ;
-    rdfs:comment "The date/time at which the message has been read by the recipient if a single recipient exists." .
+        :DateTime .
 
 :dateReceived a rdf:Property ;
     rdfs:label "dateReceived" ;
+    rdfs:comment "The date/time the message was received if a single recipient exists." ;
     :domainIncludes :Message ;
-    :rangeIncludes :DateTime ;
-    rdfs:comment "The date/time the message was received if a single recipient exists." .
+    :rangeIncludes :DateTime .
 
 :dateSent a rdf:Property ;
     rdfs:label "dateSent" ;
+    rdfs:comment "The date/time at which the message was sent." ;
     :domainIncludes :Message ;
-    :rangeIncludes :DateTime ;
-    rdfs:comment "The date/time at which the message was sent." .
+    :rangeIncludes :DateTime .
 
 :dateVehicleFirstRegistered a rdf:Property ;
     rdfs:label "dateVehicleFirstRegistered" ;
-    :domainIncludes :Vehicle ;
-    :rangeIncludes :Date ;
+    rdfs:comment "The date of the first registration of the vehicle with the respective public authorities." ;
     :contributor <https://schema.org/docs/collab/Automotive_Ontology_Working_Group> ;
-    rdfs:comment "The date of the first registration of the vehicle with the respective public authorities." .
+    :domainIncludes :Vehicle ;
+    :rangeIncludes :Date .
 
 :dateline a rdf:Property ;
     rdfs:label "dateline" ;
-    :domainIncludes :NewsArticle ;
-    :rangeIncludes :Text ;
     rdfs:comment """A [dateline](https://en.wikipedia.org/wiki/Dateline) is a brief piece of text included in news articles that describes where and when the story was written or filed though the date is often omitted. Sometimes only a placename is provided.
 
 Structured representations of dateline-related information can also be expressed more explicitly using [[locationCreated]] (which represents where a work was created, e.g. where a news report was written).  For location depicted or described in the content, use [[contentLocation]].
 
 Dateline summaries are oriented more towards human readers than towards automated processing, and can vary substantially. Some examples: "BEIRUT, Lebanon, June 2.", "Paris, France", "December 19, 2017 11:43AM Reporting from Washington", "Beijing/Moscow", "QUEZON CITY, Philippines".
-      """ .
+      """ ;
+    :domainIncludes :NewsArticle ;
+    :rangeIncludes :Text .
 
 :dayOfWeek a rdf:Property ;
     rdfs:label "dayOfWeek" ;
+    rdfs:comment "The day of the week for which these opening hours are valid." ;
     :domainIncludes :OpeningHoursSpecification ;
-    :rangeIncludes :DayOfWeek ;
-    rdfs:comment "The day of the week for which these opening hours are valid." .
+    :rangeIncludes :DayOfWeek .
 
 :deathDate a rdf:Property ;
     rdfs:label "deathDate" ;
+    rdfs:comment "Date of death." ;
     :domainIncludes :Person ;
-    :rangeIncludes :Date ;
-    rdfs:comment "Date of death." .
+    :rangeIncludes :Date .
 
 :deathPlace a rdf:Property ;
     rdfs:label "deathPlace" ;
+    rdfs:comment "The place where the person died." ;
     :domainIncludes :Person ;
-    :rangeIncludes :Place ;
-    rdfs:comment "The place where the person died." .
+    :rangeIncludes :Place .
 
 :defaultValue a rdf:Property ;
     rdfs:label "defaultValue" ;
+    rdfs:comment "The default value of the input.  For properties that expect a literal, the default is a literal value, for properties that expect an object, it's an ID reference to one of the current values." ;
     :domainIncludes :PropertyValueSpecification ;
     :rangeIncludes :Text,
-        :Thing ;
-    rdfs:comment "The default value of the input.  For properties that expect a literal, the default is a literal value, for properties that expect an object, it's an ID reference to one of the current values." .
+        :Thing .
 
 :deliveryAddress a rdf:Property ;
     rdfs:label "deliveryAddress" ;
+    rdfs:comment "Destination address." ;
     :domainIncludes :ParcelDelivery ;
-    :rangeIncludes :PostalAddress ;
-    rdfs:comment "Destination address." .
+    :rangeIncludes :PostalAddress .
 
 :deliveryLeadTime a rdf:Property ;
     rdfs:label "deliveryLeadTime" ;
+    rdfs:comment "The typical delay between the receipt of the order and the goods either leaving the warehouse or being prepared for pickup, in case the delivery method is on site pickup." ;
     :domainIncludes :Demand,
         :Offer ;
-    :rangeIncludes :QuantitativeValue ;
-    rdfs:comment "The typical delay between the receipt of the order and the goods either leaving the warehouse or being prepared for pickup, in case the delivery method is on site pickup." .
+    :rangeIncludes :QuantitativeValue .
 
 :deliveryMethod a rdf:Property ;
     rdfs:label "deliveryMethod" ;
+    rdfs:comment "A sub property of instrument. The method of delivery." ;
+    rdfs:subPropertyOf :instrument ;
     :domainIncludes :OrderAction,
         :ReceiveAction,
         :SendAction,
         :TrackAction ;
-    :rangeIncludes :DeliveryMethod ;
-    rdfs:comment "A sub property of instrument. The method of delivery." ;
-    rdfs:subPropertyOf :instrument .
+    :rangeIncludes :DeliveryMethod .
 
 :deliveryStatus a rdf:Property ;
     rdfs:label "deliveryStatus" ;
+    rdfs:comment "New entry added as the package passes through each leg of its journey (from shipment to final delivery)." ;
     :domainIncludes :ParcelDelivery ;
-    :rangeIncludes :DeliveryEvent ;
-    rdfs:comment "New entry added as the package passes through each leg of its journey (from shipment to final delivery)." .
+    :rangeIncludes :DeliveryEvent .
 
 :department a rdf:Property ;
     rdfs:label "department" ;
+    rdfs:comment "A relationship between an organization and a department of that organization, also described as an organization (allowing different urls, logos, opening hours). For example: a store with a pharmacy, or a bakery with a cafe." ;
     :domainIncludes :Organization ;
-    :rangeIncludes :Organization ;
-    rdfs:comment "A relationship between an organization and a department of that organization, also described as an organization (allowing different urls, logos, opening hours). For example: a store with a pharmacy, or a bakery with a cafe." .
+    :rangeIncludes :Organization .
 
 :departureAirport a rdf:Property ;
     rdfs:label "departureAirport" ;
+    rdfs:comment "The airport where the flight originates." ;
     :domainIncludes :Flight ;
-    :rangeIncludes :Airport ;
-    rdfs:comment "The airport where the flight originates." .
+    :rangeIncludes :Airport .
 
 :departureBusStop a rdf:Property ;
     rdfs:label "departureBusStop" ;
+    rdfs:comment "The stop or station from which the bus departs." ;
     :domainIncludes :BusTrip ;
     :rangeIncludes :BusStation,
-        :BusStop ;
-    rdfs:comment "The stop or station from which the bus departs." .
+        :BusStop .
 
 :departureGate a rdf:Property ;
     rdfs:label "departureGate" ;
+    rdfs:comment "Identifier of the flight's departure gate." ;
     :domainIncludes :Flight ;
-    :rangeIncludes :Text ;
-    rdfs:comment "Identifier of the flight's departure gate." .
+    :rangeIncludes :Text .
 
 :departurePlatform a rdf:Property ;
     rdfs:label "departurePlatform" ;
+    rdfs:comment "The platform from which the train departs." ;
     :domainIncludes :TrainTrip ;
-    :rangeIncludes :Text ;
-    rdfs:comment "The platform from which the train departs." .
+    :rangeIncludes :Text .
 
 :departureStation a rdf:Property ;
     rdfs:label "departureStation" ;
+    rdfs:comment "The station from which the train departs." ;
     :domainIncludes :TrainTrip ;
-    :rangeIncludes :TrainStation ;
-    rdfs:comment "The station from which the train departs." .
+    :rangeIncludes :TrainStation .
 
 :departureTerminal a rdf:Property ;
     rdfs:label "departureTerminal" ;
+    rdfs:comment "Identifier of the flight's departure terminal." ;
     :domainIncludes :Flight ;
-    :rangeIncludes :Text ;
-    rdfs:comment "Identifier of the flight's departure terminal." .
+    :rangeIncludes :Text .
 
 :departureTime a rdf:Property ;
     rdfs:label "departureTime" ;
+    rdfs:comment "The expected departure time." ;
     :domainIncludes :Trip ;
     :rangeIncludes :DateTime,
-        :Time ;
-    rdfs:comment "The expected departure time." .
+        :Time .
 
 :dependencies a rdf:Property ;
     rdfs:label "dependencies" ;
+    rdfs:comment "Prerequisites needed to fulfill steps in article." ;
     :domainIncludes :TechArticle ;
-    :rangeIncludes :Text ;
-    rdfs:comment "Prerequisites needed to fulfill steps in article." .
+    :rangeIncludes :Text .
 
 :depth a rdf:Property ;
     rdfs:label "depth" ;
-    :domainIncludes :Product,
-        :VisualArtwork, :OfferShippingDetails ;
+    rdfs:comment "The depth of the item." ;
+    :domainIncludes :OfferShippingDetails,
+        :Product,
+        :VisualArtwork ;
     :rangeIncludes :Distance,
-        :QuantitativeValue ;
-    rdfs:comment "The depth of the item." .
+        :QuantitativeValue .
 
 :device a rdf:Property ;
     rdfs:label "device" ;
+    rdfs:comment "Device required to run the application. Used in cases where a specific make/model is required to run the application." ;
     :domainIncludes :SoftwareApplication ;
     :rangeIncludes :Text ;
-    :supersededBy :availableOnDevice ;
-    rdfs:comment "Device required to run the application. Used in cases where a specific make/model is required to run the application." .
+    :supersededBy :availableOnDevice .
 
 :directors a rdf:Property ;
     rdfs:label "directors" ;
+    rdfs:comment "A director of e.g. TV, radio, movie, video games etc. content. Directors can be associated with individual items or with a series, episode, clip." ;
     :domainIncludes :Clip,
         :Episode,
         :Movie,
@@ -5487,199 +5487,201 @@ Dateline summaries are oriented more towards human readers than towards automate
         :VideoGameSeries,
         :VideoObject ;
     :rangeIncludes :Person ;
-    :supersededBy :director ;
-    rdfs:comment "A director of e.g. TV, radio, movie, video games etc. content. Directors can be associated with individual items or with a series, episode, clip." .
+    :supersededBy :director .
 
 :disambiguatingDescription a rdf:Property ;
     rdfs:label "disambiguatingDescription" ;
-    :domainIncludes :Thing ;
-    :rangeIncludes :Text ;
     rdfs:comment "A sub property of description. A short description of the item used to disambiguate from other, similar items. Information from other properties (in particular, name) may be necessary for the description to be useful for disambiguation." ;
-    rdfs:subPropertyOf :description .
+    rdfs:subPropertyOf :description ;
+    :domainIncludes :Thing ;
+    :rangeIncludes :Text .
 
 :discount a rdf:Property ;
     rdfs:label "discount" ;
+    rdfs:comment "Any discount applied (to an Order)." ;
     :domainIncludes :Order ;
     :rangeIncludes :Number,
-        :Text ;
-    rdfs:comment "Any discount applied (to an Order)." .
+        :Text .
 
 :discountCode a rdf:Property ;
     rdfs:label "discountCode" ;
+    rdfs:comment "Code used to redeem a discount." ;
     :domainIncludes :Order ;
-    :rangeIncludes :Text ;
-    rdfs:comment "Code used to redeem a discount." .
+    :rangeIncludes :Text .
 
 :discountCurrency a rdf:Property ;
     rdfs:label "discountCurrency" ;
+    rdfs:comment "The currency of the discount.\\n\\nUse standard formats: [ISO 4217 currency format](http://en.wikipedia.org/wiki/ISO_4217), e.g. \"USD\"; [Ticker symbol](https://en.wikipedia.org/wiki/List_of_cryptocurrencies) for cryptocurrencies, e.g. \"BTC\"; well known names for [Local Exchange Trading Systems](https://en.wikipedia.org/wiki/Local_exchange_trading_system) (LETS) and other currency types, e.g. \"Ithaca HOUR\"." ;
     :domainIncludes :Order ;
-    :rangeIncludes :Text ;
-    rdfs:comment "The currency of the discount.\\n\\nUse standard formats: [ISO 4217 currency format](http://en.wikipedia.org/wiki/ISO_4217), e.g. \"USD\"; [Ticker symbol](https://en.wikipedia.org/wiki/List_of_cryptocurrencies) for cryptocurrencies, e.g. \"BTC\"; well known names for [Local Exchange Trading Systems](https://en.wikipedia.org/wiki/Local_exchange_trading_system) (LETS) and other currency types, e.g. \"Ithaca HOUR\"." .
+    :rangeIncludes :Text .
 
 :discusses a rdf:Property ;
     rdfs:label "discusses" ;
+    rdfs:comment "Specifies the CreativeWork associated with the UserComment." ;
     :domainIncludes :UserComments ;
-    :rangeIncludes :CreativeWork ;
-    rdfs:comment "Specifies the CreativeWork associated with the UserComment." .
+    :rangeIncludes :CreativeWork .
 
 :discussionUrl a rdf:Property ;
     rdfs:label "discussionUrl" ;
+    rdfs:comment "A link to the page containing the comments of the CreativeWork." ;
     :domainIncludes :CreativeWork ;
-    :rangeIncludes :URL ;
-    rdfs:comment "A link to the page containing the comments of the CreativeWork." .
+    :rangeIncludes :URL .
 
 :dissolutionDate a rdf:Property ;
     rdfs:label "dissolutionDate" ;
+    rdfs:comment "The date that this organization was dissolved." ;
     :domainIncludes :Organization ;
-    :rangeIncludes :Date ;
-    rdfs:comment "The date that this organization was dissolved." .
+    :rangeIncludes :Date .
 
 :distance a rdf:Property ;
     rdfs:label "distance" ;
+    rdfs:comment "The distance travelled, e.g. exercising or travelling." ;
     :domainIncludes :ExerciseAction,
         :TravelAction ;
-    :rangeIncludes :Distance ;
-    rdfs:comment "The distance travelled, e.g. exercising or travelling." .
+    :rangeIncludes :Distance .
 
 :distribution a rdf:Property ;
     rdfs:label "distribution" ;
+    rdfs:comment "A downloadable form of this dataset, at a specific location, in a specific format. This property can be repeated if different variations are available. There is no expectation that different downloadable distributions must contain exactly equivalent information (see also [DCAT](https://www.w3.org/TR/vocab-dcat-3/#Class:Distribution) on this point). Different distributions might include or exclude different subsets of the entire dataset, for example." ;
     :domainIncludes :Dataset ;
-    :rangeIncludes :DataDownload ;
-    rdfs:comment "A downloadable form of this dataset, at a specific location, in a specific format. This property can be repeated if different variations are available. There is no expectation that different downloadable distributions must contain exactly equivalent information (see also [DCAT](https://www.w3.org/TR/vocab-dcat-3/#Class:Distribution) on this point). Different distributions might include or exclude different subsets of the entire dataset, for example." .
+    :rangeIncludes :DataDownload .
 
 :doorTime a rdf:Property ;
     rdfs:label "doorTime" ;
+    rdfs:comment "The time admission will commence." ;
     :domainIncludes :Event ;
     :rangeIncludes :DateTime,
-        :Time ;
-    rdfs:comment "The time admission will commence." .
+        :Time .
 
 :downloadUrl a rdf:Property ;
     rdfs:label "downloadUrl" ;
+    rdfs:comment "If the file can be downloaded, URL to download the binary." ;
     :domainIncludes :SoftwareApplication ;
-    :rangeIncludes :URL ;
-    rdfs:comment "If the file can be downloaded, URL to download the binary." .
+    :rangeIncludes :URL .
 
 :downvoteCount a rdf:Property ;
     rdfs:label "downvoteCount" ;
+    rdfs:comment "The number of downvotes this question, answer or comment has received from the community." ;
     :domainIncludes :Comment ;
-    :rangeIncludes :Integer ;
-    rdfs:comment "The number of downvotes this question, answer or comment has received from the community." .
+    :rangeIncludes :Integer .
 
 :driveWheelConfiguration a rdf:Property ;
     rdfs:label "driveWheelConfiguration" ;
+    rdfs:comment "The drive wheel configuration, i.e. which roadwheels will receive torque from the vehicle's engine via the drivetrain." ;
+    :contributor <https://schema.org/docs/collab/Automotive_Ontology_Working_Group> ;
     :domainIncludes :Vehicle ;
     :rangeIncludes :DriveWheelConfigurationValue,
-        :Text ;
-    :contributor <https://schema.org/docs/collab/Automotive_Ontology_Working_Group> ;
-    rdfs:comment "The drive wheel configuration, i.e. which roadwheels will receive torque from the vehicle's engine via the drivetrain." .
+        :Text .
 
 :dropoffLocation a rdf:Property ;
     rdfs:label "dropoffLocation" ;
+    rdfs:comment "Where a rental car can be dropped off." ;
     :domainIncludes :RentalCarReservation ;
-    :rangeIncludes :Place ;
-    rdfs:comment "Where a rental car can be dropped off." .
+    :rangeIncludes :Place .
 
 :dropoffTime a rdf:Property ;
     rdfs:label "dropoffTime" ;
+    rdfs:comment "When a rental car can be dropped off." ;
     :domainIncludes :RentalCarReservation ;
-    :rangeIncludes :DateTime ;
-    rdfs:comment "When a rental car can be dropped off." .
+    :rangeIncludes :DateTime .
 
 :duns a rdf:Property ;
     rdfs:label "duns" ;
+    rdfs:comment "The Dun & Bradstreet DUNS number for identifying an organization or business person." ;
+    rdfs:subPropertyOf :identifier ;
     :domainIncludes :Organization,
         :Person ;
-    :rangeIncludes :Text ;
-    rdfs:comment "The Dun & Bradstreet DUNS number for identifying an organization or business person." ;
-    rdfs:subPropertyOf :identifier .
+    :rangeIncludes :Text .
 
 :durationOfWarranty a rdf:Property ;
     rdfs:label "durationOfWarranty" ;
+    rdfs:comment "The duration of the warranty promise. Common unitCode values are ANN for year, MON for months, or DAY for days." ;
     :domainIncludes :WarrantyPromise ;
-    :rangeIncludes :QuantitativeValue ;
-    rdfs:comment "The duration of the warranty promise. Common unitCode values are ANN for year, MON for months, or DAY for days." .
+    :rangeIncludes :QuantitativeValue .
 
 :duringMedia a rdf:Property ;
     rdfs:label "duringMedia" ;
+    rdfs:comment "A media object representing the circumstances while performing this direction." ;
     :domainIncludes :HowToDirection ;
     :rangeIncludes :MediaObject,
-        :URL ;
-    rdfs:comment "A media object representing the circumstances while performing this direction." .
+        :URL .
 
 :editor a rdf:Property ;
     rdfs:label "editor" ;
+    rdfs:comment "Specifies the Person who edited the CreativeWork." ;
     :domainIncludes :CreativeWork ;
-    :rangeIncludes :Person ;
-    rdfs:comment "Specifies the Person who edited the CreativeWork." .
+    :rangeIncludes :Person .
 
 :educationRequirements a rdf:Property ;
     rdfs:label "educationRequirements" ;
+    rdfs:comment "Educational background needed for the position or Occupation." ;
     :domainIncludes :JobPosting,
         :Occupation ;
     :rangeIncludes :Text ;
-    :source <https://github.com/schemaorg/schemaorg/issues/1698> ;
-    rdfs:comment "Educational background needed for the position or Occupation." .
+    :source <https://github.com/schemaorg/schemaorg/issues/1698> .
 
 :educationalAlignment a rdf:Property ;
     rdfs:label "educationalAlignment" ;
-    :domainIncludes :CreativeWork ;
-    :rangeIncludes :AlignmentObject ;
     rdfs:comment """An alignment to an established educational framework.
 
-This property should not be used where the nature of the alignment can be described using a simple property, for example to express that a resource [[teaches]] or [[assesses]] a competency.""" .
+This property should not be used where the nature of the alignment can be described using a simple property, for example to express that a resource [[teaches]] or [[assesses]] a competency.""" ;
+    :domainIncludes :CreativeWork ;
+    :rangeIncludes :AlignmentObject .
 
 :educationalFramework a rdf:Property ;
     rdfs:label "educationalFramework" ;
+    rdfs:comment "The framework to which the resource being described is aligned." ;
     :domainIncludes :AlignmentObject ;
-    :rangeIncludes :Text ;
-    rdfs:comment "The framework to which the resource being described is aligned." .
+    :rangeIncludes :Text .
 
 :educationalRole a rdf:Property ;
     rdfs:label "educationalRole" ;
+    rdfs:comment "An educationalRole of an EducationalAudience." ;
     :domainIncludes :EducationalAudience ;
-    :rangeIncludes :Text ;
-    rdfs:comment "An educationalRole of an EducationalAudience." .
+    :rangeIncludes :Text .
 
 :educationalUse a rdf:Property ;
     rdfs:label "educationalUse" ;
+    rdfs:comment "The purpose of a work in the context of education; for example, 'assignment', 'group work'." ;
     :domainIncludes :CreativeWork ;
     :rangeIncludes :DefinedTerm,
-        :Text ;
-    rdfs:comment "The purpose of a work in the context of education; for example, 'assignment', 'group work'." .
+        :Text .
 
 :elevation a rdf:Property ;
     rdfs:label "elevation" ;
+    rdfs:comment "The elevation of a location ([WGS 84](https://en.wikipedia.org/wiki/World_Geodetic_System)). Values may be of the form 'NUMBER UNIT\\_OF\\_MEASUREMENT' (e.g., '1,000 m', '3,200 ft') while numbers alone should be assumed to be a value in meters." ;
     :domainIncludes :GeoCoordinates,
         :GeoShape ;
     :rangeIncludes :Number,
-        :Text ;
-    rdfs:comment "The elevation of a location ([WGS 84](https://en.wikipedia.org/wiki/World_Geodetic_System)). Values may be of the form 'NUMBER UNIT\\_OF\\_MEASUREMENT' (e.g., '1,000 m', '3,200 ft') while numbers alone should be assumed to be a value in meters." .
+        :Text .
 
 :eligibleCustomerType a rdf:Property ;
     rdfs:label "eligibleCustomerType" ;
+    rdfs:comment "The type(s) of customers for which the given offer is valid." ;
     :domainIncludes :Demand,
         :Offer ;
-    :rangeIncludes :BusinessEntityType ;
-    rdfs:comment "The type(s) of customers for which the given offer is valid." .
+    :rangeIncludes :BusinessEntityType .
 
 :eligibleDuration a rdf:Property ;
     rdfs:label "eligibleDuration" ;
+    rdfs:comment "The duration for which the given offer is valid." ;
     :domainIncludes :Demand,
         :Offer ;
-    :rangeIncludes :QuantitativeValue ;
-    rdfs:comment "The duration for which the given offer is valid." .
+    :rangeIncludes :QuantitativeValue .
 
 :eligibleQuantity a rdf:Property ;
     rdfs:label "eligibleQuantity" ;
+    rdfs:comment "The interval and unit of measurement of ordering quantities for which the offer or price specification is valid. This allows e.g. specifying that a certain freight charge is valid only for a certain quantity." ;
     :domainIncludes :Demand,
         :Offer,
         :PriceSpecification ;
-    :rangeIncludes :QuantitativeValue ;
-    rdfs:comment "The interval and unit of measurement of ordering quantities for which the offer or price specification is valid. This allows e.g. specifying that a certain freight charge is valid only for a certain quantity." .
+    :rangeIncludes :QuantitativeValue .
 
 :eligibleRegion a rdf:Property ;
     rdfs:label "eligibleRegion" ;
+    rdfs:comment """The ISO 3166-1 (ISO 3166-1 alpha-2) or ISO 3166-2 code, the place, or the GeoShape for the geo-political region(s) for which the offer or delivery charge specification is valid.\\n\\nSee also [[ineligibleRegion]].
+    """ ;
+    rdfs:subPropertyOf :areaServed ;
     :domainIncludes :ActionAccessSpecification,
         :DeliveryChargeSpecification,
         :Demand,
@@ -5687,1389 +5689,1395 @@ This property should not be used where the nature of the alignment can be descri
     :rangeIncludes :GeoShape,
         :Place,
         :Text ;
-    :source <https://github.com/schemaorg/schemaorg/issues/1741> ;
-    rdfs:comment """The ISO 3166-1 (ISO 3166-1 alpha-2) or ISO 3166-2 code, the place, or the GeoShape for the geo-political region(s) for which the offer or delivery charge specification is valid.\\n\\nSee also [[ineligibleRegion]].
-    """ ;
-    rdfs:subPropertyOf :areaServed .
+    :source <https://github.com/schemaorg/schemaorg/issues/1741> .
 
 :eligibleTransactionVolume a rdf:Property ;
     rdfs:label "eligibleTransactionVolume" ;
+    rdfs:comment "The transaction volume, in a monetary unit, for which the offer or price specification is valid, e.g. for indicating a minimal purchasing volume, to express free shipping above a certain order volume, or to limit the acceptance of credit cards to purchases to a certain minimal amount." ;
     :domainIncludes :Demand,
         :Offer,
         :PriceSpecification ;
-    :rangeIncludes :PriceSpecification ;
-    rdfs:comment "The transaction volume, in a monetary unit, for which the offer or price specification is valid, e.g. for indicating a minimal purchasing volume, to express free shipping above a certain order volume, or to limit the acceptance of credit cards to purchases to a certain minimal amount." .
+    :rangeIncludes :PriceSpecification .
 
 :email a rdf:Property ;
     rdfs:label "email" ;
+    rdfs:comment "Email address." ;
     :domainIncludes :ContactPoint,
         :Organization,
         :Person ;
-    :rangeIncludes :Text ;
-    rdfs:comment "Email address." .
+    :rangeIncludes :Text .
 
 :embedUrl a rdf:Property ;
     rdfs:label "embedUrl" ;
+    rdfs:comment "A URL pointing to a player for a specific video. In general, this is the information in the ```src``` element of an ```embed``` tag and should not be the same as the content of the ```loc``` tag." ;
     :domainIncludes :MediaObject ;
-    :rangeIncludes :URL ;
-    rdfs:comment "A URL pointing to a player for a specific video. In general, this is the information in the ```src``` element of an ```embed``` tag and should not be the same as the content of the ```loc``` tag." .
+    :rangeIncludes :URL .
 
 :employees a rdf:Property ;
     rdfs:label "employees" ;
+    rdfs:comment "People working for this organization." ;
     :domainIncludes :Organization ;
     :rangeIncludes :Person ;
-    :supersededBy :employee ;
-    rdfs:comment "People working for this organization." .
+    :supersededBy :employee .
 
 :employmentType a rdf:Property ;
     rdfs:label "employmentType" ;
+    rdfs:comment "Type of employment (e.g. full-time, part-time, contract, temporary, seasonal, internship)." ;
     :domainIncludes :JobPosting ;
-    :rangeIncludes :Text ;
-    rdfs:comment "Type of employment (e.g. full-time, part-time, contract, temporary, seasonal, internship)." .
+    :rangeIncludes :Text .
 
 :encodingType a rdf:Property ;
     rdfs:label "encodingType" ;
+    rdfs:comment "The supported encoding type(s) for an EntryPoint request." ;
     :domainIncludes :EntryPoint ;
-    :rangeIncludes :Text ;
-    rdfs:comment "The supported encoding type(s) for an EntryPoint request." .
+    :rangeIncludes :Text .
 
 :encodings a rdf:Property ;
     rdfs:label "encodings" ;
+    rdfs:comment "A media object that encodes this CreativeWork." ;
     :domainIncludes :CreativeWork ;
     :rangeIncludes :MediaObject ;
-    :supersededBy :encoding ;
-    rdfs:comment "A media object that encodes this CreativeWork." .
+    :supersededBy :encoding .
 
 :endDate a rdf:Property ;
     rdfs:label "endDate" ;
+    rdfs:comment "The end date and time of the item (in [ISO 8601 date format](http://en.wikipedia.org/wiki/ISO_8601))." ;
     :domainIncludes :CreativeWorkSeason,
         :CreativeWorkSeries,
         :DatedMoneySpecification,
         :Event,
-        :Role,
-        :MerchantReturnPolicySeasonalOverride ;
+        :MerchantReturnPolicySeasonalOverride,
+        :Role ;
     :rangeIncludes :Date,
-        :DateTime ;
-    rdfs:comment "The end date and time of the item (in [ISO 8601 date format](http://en.wikipedia.org/wiki/ISO_8601))." .
+        :DateTime .
 
 :endTime a rdf:Property ;
     rdfs:label "endTime" ;
+    rdfs:comment "The endTime of something. For a reserved event or service (e.g. FoodEstablishmentReservation), the time that it is expected to end. For actions that span a period of time, when the action was performed. E.g. John wrote a book from January to *December*. For media, including audio and video, it's the time offset of the end of a clip within a larger file.\\n\\nNote that Event uses startDate/endDate instead of startTime/endTime, even when describing dates with times. This situation may be clarified in future revisions." ;
     :domainIncludes :Action,
         :FoodEstablishmentReservation,
-        :MediaObject, :InteractionCounter  ;
+        :InteractionCounter,
+        :MediaObject ;
     :rangeIncludes :DateTime,
-        :Time ;
-    rdfs:comment "The endTime of something. For a reserved event or service (e.g. FoodEstablishmentReservation), the time that it is expected to end. For actions that span a period of time, when the action was performed. E.g. John wrote a book from January to *December*. For media, including audio and video, it's the time offset of the end of a clip within a larger file.\\n\\nNote that Event uses startDate/endDate instead of startTime/endTime, even when describing dates with times. This situation may be clarified in future revisions." .
+        :Time .
 
 :endorsee a rdf:Property ;
     rdfs:label "endorsee" ;
+    rdfs:comment "A sub property of participant. The person/organization being supported." ;
+    rdfs:subPropertyOf :participant ;
     :domainIncludes :EndorseAction ;
     :rangeIncludes :Organization,
-        :Person ;
-    rdfs:comment "A sub property of participant. The person/organization being supported." ;
-    rdfs:subPropertyOf :participant .
+        :Person .
 
 :entertainmentBusiness a rdf:Property ;
     rdfs:label "entertainmentBusiness" ;
-    :domainIncludes :PerformAction ;
-    :rangeIncludes :EntertainmentBusiness ;
     rdfs:comment "A sub property of location. The entertainment business where the action occurred." ;
-    rdfs:subPropertyOf :location .
+    rdfs:subPropertyOf :location ;
+    :domainIncludes :PerformAction ;
+    :rangeIncludes :EntertainmentBusiness .
 
 :episodeNumber a rdf:Property ;
     rdfs:label "episodeNumber" ;
+    rdfs:comment "Position of the episode within an ordered group of episodes." ;
+    rdfs:subPropertyOf :position ;
     :domainIncludes :Episode ;
     :rangeIncludes :Integer,
-        :Text ;
-    rdfs:comment "Position of the episode within an ordered group of episodes." ;
-    rdfs:subPropertyOf :position .
+        :Text .
 
 :episodes a rdf:Property ;
     rdfs:label "episodes" ;
+    rdfs:comment "An episode of a TV/radio series or season." ;
     :domainIncludes :CreativeWorkSeason,
         :RadioSeries,
         :TVSeries,
         :VideoGameSeries ;
     :rangeIncludes :Episode ;
-    :supersededBy :episode ;
-    rdfs:comment "An episode of a TV/radio series or season." .
+    :supersededBy :episode .
 
 :equal a rdf:Property ;
     rdfs:label "equal" ;
+    rdfs:comment "This ordering relation for qualitative values indicates that the subject is equal to the object." ;
     :domainIncludes :QualitativeValue ;
-    :rangeIncludes :QualitativeValue ;
-    rdfs:comment "This ordering relation for qualitative values indicates that the subject is equal to the object." .
+    :rangeIncludes :QualitativeValue .
 
 :error a rdf:Property ;
     rdfs:label "error" ;
+    rdfs:comment "For failed actions, more information on the cause of the failure." ;
     :domainIncludes :Action ;
-    :rangeIncludes :Thing ;
-    rdfs:comment "For failed actions, more information on the cause of the failure." .
+    :rangeIncludes :Thing .
 
 :estimatedCost a rdf:Property ;
     rdfs:label "estimatedCost" ;
+    rdfs:comment "The estimated cost of the supply or supplies consumed when performing instructions." ;
     :domainIncludes :HowTo,
         :HowToSupply ;
     :rangeIncludes :MonetaryAmount,
-        :Text ;
-    rdfs:comment "The estimated cost of the supply or supplies consumed when performing instructions." .
+        :Text .
 
 :estimatedFlightDuration a rdf:Property ;
     rdfs:label "estimatedFlightDuration" ;
+    rdfs:comment "The estimated time the flight will take." ;
     :domainIncludes :Flight ;
     :rangeIncludes :Duration,
-        :Text ;
-    rdfs:comment "The estimated time the flight will take." .
+        :Text .
 
 :estimatedSalary a rdf:Property ;
     rdfs:label "estimatedSalary" ;
+    rdfs:comment "An estimated salary for a job posting or occupation, based on a variety of variables including, but not limited to industry, job title, and location. Estimated salaries  are often computed by outside organizations rather than the hiring organization, who may not have committed to the estimated value." ;
     :domainIncludes :JobPosting,
         :Occupation ;
     :rangeIncludes :MonetaryAmount,
         :MonetaryAmountDistribution,
         :Number ;
-    :source <https://github.com/schemaorg/schemaorg/issues/1698> ;
-    rdfs:comment "An estimated salary for a job posting or occupation, based on a variety of variables including, but not limited to industry, job title, and location. Estimated salaries  are often computed by outside organizations rather than the hiring organization, who may not have committed to the estimated value." .
+    :source <https://github.com/schemaorg/schemaorg/issues/1698> .
 
 :eventStatus a rdf:Property ;
     rdfs:label "eventStatus" ;
+    rdfs:comment "An eventStatus of an event represents its status; particularly useful when an event is cancelled or rescheduled." ;
     :domainIncludes :Event ;
-    :rangeIncludes :EventStatusType ;
-    rdfs:comment "An eventStatus of an event represents its status; particularly useful when an event is cancelled or rescheduled." .
+    :rangeIncludes :EventStatusType .
 
 :events a rdf:Property ;
     rdfs:label "events" ;
+    rdfs:comment "Upcoming or past events associated with this place or organization." ;
     :domainIncludes :Organization,
         :Place ;
     :rangeIncludes :Event ;
-    :supersededBy :event ;
-    rdfs:comment "Upcoming or past events associated with this place or organization." .
+    :supersededBy :event .
 
 :exifData a rdf:Property ;
     rdfs:label "exifData" ;
+    rdfs:comment "exif data for this object." ;
     :domainIncludes :ImageObject ;
     :rangeIncludes :PropertyValue,
-        :Text ;
-    rdfs:comment "exif data for this object." .
+        :Text .
 
 :expectedArrivalFrom a rdf:Property ;
     rdfs:label "expectedArrivalFrom" ;
+    rdfs:comment "The earliest date the package may arrive." ;
     :domainIncludes :ParcelDelivery ;
     :rangeIncludes :Date,
-        :DateTime ;
-    rdfs:comment "The earliest date the package may arrive." .
+        :DateTime .
 
 :expectedArrivalUntil a rdf:Property ;
     rdfs:label "expectedArrivalUntil" ;
+    rdfs:comment "The latest date the package may arrive." ;
     :domainIncludes :ParcelDelivery ;
     :rangeIncludes :Date,
-        :DateTime ;
-    rdfs:comment "The latest date the package may arrive." .
+        :DateTime .
 
 :expectsAcceptanceOf a rdf:Property ;
     rdfs:label "expectsAcceptanceOf" ;
+    rdfs:comment "An Offer which must be accepted before the user can perform the Action. For example, the user may need to buy a movie before being able to watch it." ;
     :domainIncludes :ActionAccessSpecification,
         :ConsumeAction,
         :MediaSubscription ;
     :rangeIncludes :Offer ;
-    :source <https://github.com/schemaorg/schemaorg/issues/1741> ;
-    rdfs:comment "An Offer which must be accepted before the user can perform the Action. For example, the user may need to buy a movie before being able to watch it." .
+    :source <https://github.com/schemaorg/schemaorg/issues/1741> .
 
 :experienceRequirements a rdf:Property ;
     rdfs:label "experienceRequirements" ;
+    rdfs:comment "Description of skills and experience needed for the position or Occupation." ;
     :domainIncludes :JobPosting,
         :Occupation ;
     :rangeIncludes :Text ;
-    :source <https://github.com/schemaorg/schemaorg/issues/1698> ;
-    rdfs:comment "Description of skills and experience needed for the position or Occupation." .
+    :source <https://github.com/schemaorg/schemaorg/issues/1698> .
 
 :expires a rdf:Property ;
     rdfs:label "expires" ;
-    :domainIncludes :CreativeWork,
-     :Certification;
+    rdfs:comment "Date the content expires and is no longer useful or available. For example a [[VideoObject]] or [[NewsArticle]] whose availability or relevance is time-limited, a [[ClaimReview]] fact check whose publisher wants to indicate that it may no longer be relevant (or helpful to highlight) after some date, or a [[Certification]] the validity has expired." ;
+    :domainIncludes :Certification,
+        :CreativeWork ;
     :rangeIncludes :Date,
-         :DateTime;
-    rdfs:comment "Date the content expires and is no longer useful or available. For example a [[VideoObject]] or [[NewsArticle]] whose availability or relevance is time-limited, a [[ClaimReview]] fact check whose publisher wants to indicate that it may no longer be relevant (or helpful to highlight) after some date, or a [[Certification]] the validity has expired." .
+        :DateTime .
 
 :familyName a rdf:Property ;
     rdfs:label "familyName" ;
+    rdfs:comment "Family name. In the U.S., the last name of a Person." ;
     :domainIncludes :Person ;
-    :rangeIncludes :Text ;
-    rdfs:comment "Family name. In the U.S., the last name of a Person." .
+    :rangeIncludes :Text .
 
 :fatContent a rdf:Property ;
     rdfs:label "fatContent" ;
+    rdfs:comment "The number of grams of fat." ;
     :domainIncludes :NutritionInformation ;
-    :rangeIncludes :Mass ;
-    rdfs:comment "The number of grams of fat." .
+    :rangeIncludes :Mass .
 
 :faxNumber a rdf:Property ;
     rdfs:label "faxNumber" ;
+    rdfs:comment "The fax number." ;
     :domainIncludes :ContactPoint,
         :Organization,
         :Person,
         :Place ;
-    :rangeIncludes :Text ;
-    rdfs:comment "The fax number." .
+    :rangeIncludes :Text .
 
 :featureList a rdf:Property ;
     rdfs:label "featureList" ;
+    rdfs:comment "Features or modules provided by this application (and possibly required by other applications)." ;
     :domainIncludes :SoftwareApplication ;
     :rangeIncludes :Text,
-        :URL ;
-    rdfs:comment "Features or modules provided by this application (and possibly required by other applications)." .
+        :URL .
 
 :feesAndCommissionsSpecification a rdf:Property ;
     rdfs:label "feesAndCommissionsSpecification" ;
+    rdfs:comment "Description of fees, commissions, and other terms applied either to a class of financial product, or by a financial service organization." ;
+    :contributor <https://schema.org/docs/collab/FIBO> ;
     :domainIncludes :FinancialProduct,
         :FinancialService ;
     :rangeIncludes :Text,
-        :URL ;
-    :contributor <https://schema.org/docs/collab/FIBO> ;
-    rdfs:comment "Description of fees, commissions, and other terms applied either to a class of financial product, or by a financial service organization." .
+        :URL .
 
 :fiberContent a rdf:Property ;
     rdfs:label "fiberContent" ;
+    rdfs:comment "The number of grams of fiber." ;
     :domainIncludes :NutritionInformation ;
-    :rangeIncludes :Mass ;
-    rdfs:comment "The number of grams of fiber." .
+    :rangeIncludes :Mass .
 
 :fileFormat a rdf:Property ;
     rdfs:label "fileFormat" ;
+    rdfs:comment "Media type, typically MIME format (see [IANA site](http://www.iana.org/assignments/media-types/media-types.xhtml)) of the content, e.g. application/zip of a SoftwareApplication binary. In cases where a CreativeWork has several media type representations, 'encoding' can be used to indicate each MediaObject alongside particular fileFormat information. Unregistered or niche file formats can be indicated instead via the most appropriate URL, e.g. defining Web page or a Wikipedia entry." ;
     :domainIncludes :CreativeWork ;
     :rangeIncludes :Text,
         :URL ;
-    :supersededBy :encodingFormat ;
-    rdfs:comment "Media type, typically MIME format (see [IANA site](http://www.iana.org/assignments/media-types/media-types.xhtml)) of the content, e.g. application/zip of a SoftwareApplication binary. In cases where a CreativeWork has several media type representations, 'encoding' can be used to indicate each MediaObject alongside particular fileFormat information. Unregistered or niche file formats can be indicated instead via the most appropriate URL, e.g. defining Web page or a Wikipedia entry." .
+    :supersededBy :encodingFormat .
 
 :fileSize a rdf:Property ;
     rdfs:label "fileSize" ;
+    rdfs:comment "Size of the application / package (e.g. 18MB). In the absence of a unit (MB, KB etc.), KB will be assumed." ;
     :domainIncludes :SoftwareApplication ;
-    :rangeIncludes :Text ;
-    rdfs:comment "Size of the application / package (e.g. 18MB). In the absence of a unit (MB, KB etc.), KB will be assumed." .
+    :rangeIncludes :Text .
 
 :firstPerformance a rdf:Property ;
     rdfs:label "firstPerformance" ;
-    :domainIncludes :MusicComposition ;
-    :rangeIncludes :Event ;
+    rdfs:comment "The date and place the work was first performed." ;
     :contributor <https://schema.org/docs/collab/MBZ> ;
-    rdfs:comment "The date and place the work was first performed." .
+    :domainIncludes :MusicComposition ;
+    :rangeIncludes :Event .
 
 :flightDistance a rdf:Property ;
     rdfs:label "flightDistance" ;
+    rdfs:comment "The distance of the flight." ;
     :domainIncludes :Flight ;
     :rangeIncludes :Distance,
-        :Text ;
-    rdfs:comment "The distance of the flight." .
+        :Text .
 
 :flightNumber a rdf:Property ;
     rdfs:label "flightNumber" ;
-    :domainIncludes :Flight ;
-    :rangeIncludes :Text ;
     rdfs:comment "The unique identifier for a flight including the airline IATA code. For example, if describing United flight 110, where the IATA code for United is 'UA', the flightNumber is 'UA110'." ;
-    rdfs:subPropertyOf :identifier .
+    rdfs:subPropertyOf :identifier ;
+    :domainIncludes :Flight ;
+    :rangeIncludes :Text .
 
 :floorSize a rdf:Property ;
     rdfs:label "floorSize" ;
-    :domainIncludes :Accommodation ;
-    :rangeIncludes :QuantitativeValue ;
-    :contributor <https://schema.org/docs/collab/STI_Accommodation_Ontology> ;
     rdfs:comment """The size of the accommodation, e.g. in square meter or squarefoot.
-Typical unit code(s): MTK for square meter, FTK for square foot, or YDK for square yard.""" .
+Typical unit code(s): MTK for square meter, FTK for square foot, or YDK for square yard.""" ;
+    :contributor <https://schema.org/docs/collab/STI_Accommodation_Ontology> ;
+    :domainIncludes :Accommodation ;
+    :rangeIncludes :QuantitativeValue .
 
 :followee a rdf:Property ;
     rdfs:label "followee" ;
+    rdfs:comment "A sub property of object. The person or organization being followed." ;
+    rdfs:subPropertyOf :object ;
     :domainIncludes :FollowAction ;
     :rangeIncludes :Organization,
-        :Person ;
-    rdfs:comment "A sub property of object. The person or organization being followed." ;
-    rdfs:subPropertyOf :object .
+        :Person .
 
 :follows a rdf:Property ;
     rdfs:label "follows" ;
+    rdfs:comment "The most generic uni-directional social relation." ;
     :domainIncludes :Person ;
-    :rangeIncludes :Person ;
-    rdfs:comment "The most generic uni-directional social relation." .
+    :rangeIncludes :Person .
 
 :foodEstablishment a rdf:Property ;
     rdfs:label "foodEstablishment" ;
+    rdfs:comment "A sub property of location. The specific food establishment where the action occurred." ;
+    rdfs:subPropertyOf :location ;
     :domainIncludes :CookAction ;
     :rangeIncludes :FoodEstablishment,
-        :Place ;
-    rdfs:comment "A sub property of location. The specific food establishment where the action occurred." ;
-    rdfs:subPropertyOf :location .
+        :Place .
 
 :foodEvent a rdf:Property ;
     rdfs:label "foodEvent" ;
-    :domainIncludes :CookAction ;
-    :rangeIncludes :FoodEvent ;
     rdfs:comment "A sub property of location. The specific food event where the action occurred." ;
-    rdfs:subPropertyOf :location .
+    rdfs:subPropertyOf :location ;
+    :domainIncludes :CookAction ;
+    :rangeIncludes :FoodEvent .
 
 :founders a rdf:Property ;
     rdfs:label "founders" ;
+    rdfs:comment "A person who founded this organization." ;
     :domainIncludes :Organization ;
     :rangeIncludes :Person ;
-    :supersededBy :founder ;
-    rdfs:comment "A person who founded this organization." .
+    :supersededBy :founder .
 
 :foundingDate a rdf:Property ;
     rdfs:label "foundingDate" ;
+    rdfs:comment "The date that this organization was founded." ;
     :domainIncludes :Organization ;
-    :rangeIncludes :Date ;
-    rdfs:comment "The date that this organization was founded." .
+    :rangeIncludes :Date .
 
 :foundingLocation a rdf:Property ;
     rdfs:label "foundingLocation" ;
+    rdfs:comment "The place where the Organization was founded." ;
     :domainIncludes :Organization ;
-    :rangeIncludes :Place ;
-    rdfs:comment "The place where the Organization was founded." .
+    :rangeIncludes :Place .
 
 :free a rdf:Property ;
     rdfs:label "free" ;
+    rdfs:comment "A flag to signal that the item, event, or place is accessible for free." ;
     :domainIncludes :PublicationEvent ;
     :rangeIncludes :Boolean ;
-    :supersededBy :isAccessibleForFree ;
-    rdfs:comment "A flag to signal that the item, event, or place is accessible for free." .
+    :supersededBy :isAccessibleForFree .
 
 :fromLocation a rdf:Property ;
     rdfs:label "fromLocation" ;
+    rdfs:comment "A sub property of location. The original location of the object or the agent before the action." ;
+    rdfs:subPropertyOf :location ;
     :domainIncludes :ExerciseAction,
         :MoveAction,
         :TransferAction ;
-    :rangeIncludes :Place ;
-    rdfs:comment "A sub property of location. The original location of the object or the agent before the action." ;
-    rdfs:subPropertyOf :location .
+    :rangeIncludes :Place .
 
 :fuelConsumption a rdf:Property ;
     rdfs:label "fuelConsumption" ;
-    :domainIncludes :Vehicle ;
-    :rangeIncludes :QuantitativeValue ;
+    rdfs:comment "The amount of fuel consumed for traveling a particular distance or temporal duration with the given vehicle (e.g. liters per 100 km).\\n\\n* Note 1: There are unfortunately no standard unit codes for liters per 100 km.  Use [[unitText]] to indicate the unit of measurement, e.g. L/100 km.\\n* Note 2: There are two ways of indicating the fuel consumption, [[fuelConsumption]] (e.g. 8 liters per 100 km) and [[fuelEfficiency]] (e.g. 30 miles per gallon). They are reciprocal.\\n* Note 3: Often, the absolute value is useful only when related to driving speed (\"at 80 km/h\") or usage pattern (\"city traffic\"). You can use [[valueReference]] to link the value for the fuel consumption to another value." ;
     :contributor <https://schema.org/docs/collab/Automotive_Ontology_Working_Group> ;
-    rdfs:comment "The amount of fuel consumed for traveling a particular distance or temporal duration with the given vehicle (e.g. liters per 100 km).\\n\\n* Note 1: There are unfortunately no standard unit codes for liters per 100 km.  Use [[unitText]] to indicate the unit of measurement, e.g. L/100 km.\\n* Note 2: There are two ways of indicating the fuel consumption, [[fuelConsumption]] (e.g. 8 liters per 100 km) and [[fuelEfficiency]] (e.g. 30 miles per gallon). They are reciprocal.\\n* Note 3: Often, the absolute value is useful only when related to driving speed (\"at 80 km/h\") or usage pattern (\"city traffic\"). You can use [[valueReference]] to link the value for the fuel consumption to another value." .
+    :domainIncludes :Vehicle ;
+    :rangeIncludes :QuantitativeValue .
 
 :fuelEfficiency a rdf:Property ;
     rdfs:label "fuelEfficiency" ;
-    :domainIncludes :Vehicle ;
-    :rangeIncludes :QuantitativeValue ;
+    rdfs:comment "The distance traveled per unit of fuel used; most commonly miles per gallon (mpg) or kilometers per liter (km/L).\\n\\n* Note 1: There are unfortunately no standard unit codes for miles per gallon or kilometers per liter. Use [[unitText]] to indicate the unit of measurement, e.g. mpg or km/L.\\n* Note 2: There are two ways of indicating the fuel consumption, [[fuelConsumption]] (e.g. 8 liters per 100 km) and [[fuelEfficiency]] (e.g. 30 miles per gallon). They are reciprocal.\\n* Note 3: Often, the absolute value is useful only when related to driving speed (\"at 80 km/h\") or usage pattern (\"city traffic\"). You can use [[valueReference]] to link the value for the fuel economy to another value." ;
     :contributor <https://schema.org/docs/collab/Automotive_Ontology_Working_Group> ;
-    rdfs:comment "The distance traveled per unit of fuel used; most commonly miles per gallon (mpg) or kilometers per liter (km/L).\\n\\n* Note 1: There are unfortunately no standard unit codes for miles per gallon or kilometers per liter. Use [[unitText]] to indicate the unit of measurement, e.g. mpg or km/L.\\n* Note 2: There are two ways of indicating the fuel consumption, [[fuelConsumption]] (e.g. 8 liters per 100 km) and [[fuelEfficiency]] (e.g. 30 miles per gallon). They are reciprocal.\\n* Note 3: Often, the absolute value is useful only when related to driving speed (\"at 80 km/h\") or usage pattern (\"city traffic\"). You can use [[valueReference]] to link the value for the fuel economy to another value." .
+    :domainIncludes :Vehicle ;
+    :rangeIncludes :QuantitativeValue .
 
 :fuelType a rdf:Property ;
     rdfs:label "fuelType" ;
+    rdfs:comment "The type of fuel suitable for the engine or engines of the vehicle. If the vehicle has only one engine, this property can be attached directly to the vehicle." ;
+    :contributor <https://schema.org/docs/collab/Automotive_Ontology_Working_Group> ;
     :domainIncludes :EngineSpecification,
         :Vehicle ;
     :rangeIncludes :QualitativeValue,
         :Text,
-        :URL ;
-    :contributor <https://schema.org/docs/collab/Automotive_Ontology_Working_Group> ;
-    rdfs:comment "The type of fuel suitable for the engine or engines of the vehicle. If the vehicle has only one engine, this property can be attached directly to the vehicle." .
+        :URL .
 
 :funder a rdf:Property ;
     rdfs:label "funder" ;
+    rdfs:comment "A person or organization that supports (sponsors) something through some kind of financial contribution." ;
+    rdfs:subPropertyOf :sponsor ;
     :domainIncludes :CreativeWork,
         :Event,
         :Organization,
         :Person ;
     :rangeIncludes :Organization,
-        :Person ;
-    rdfs:comment "A person or organization that supports (sponsors) something through some kind of financial contribution." ;
-    rdfs:subPropertyOf :sponsor .
+        :Person .
+
+:gameEdition a rdf:Property ;
+    rdfs:label "gameEdition" ;
+    rdfs:comment "The edition of a video game." ;
+    :domainIncludes :VideoGame ;
+    :rangeIncludes :Text .
 
 :gameItem a rdf:Property ;
     rdfs:label "gameItem" ;
+    rdfs:comment "An item is an object within the game world that can be collected by a player or, occasionally, a non-player character." ;
     :domainIncludes :Game,
         :VideoGameSeries ;
-    :rangeIncludes :Thing ;
-    rdfs:comment "An item is an object within the game world that can be collected by a player or, occasionally, a non-player character." .
+    :rangeIncludes :Thing .
 
 :gameLocation a rdf:Property ;
     rdfs:label "gameLocation" ;
+    rdfs:comment "Real or fictional location of the game (or part of game)." ;
     :domainIncludes :Game,
         :VideoGameSeries ;
     :rangeIncludes :Place,
         :PostalAddress,
-        :URL ;
-    rdfs:comment "Real or fictional location of the game (or part of game)." .
+        :URL .
 
 :gamePlatform a rdf:Property ;
     rdfs:label "gamePlatform" ;
+    rdfs:comment "The electronic systems used to play <a href=\"http://en.wikipedia.org/wiki/Category:Video_game_platforms\">video games</a>." ;
     :domainIncludes :VideoGame,
         :VideoGameSeries ;
     :rangeIncludes :Text,
         :Thing,
-        :URL ;
-    rdfs:comment "The electronic systems used to play <a href=\"http://en.wikipedia.org/wiki/Category:Video_game_platforms\">video games</a>." .
+        :URL .
 
 :gameTip a rdf:Property ;
     rdfs:label "gameTip" ;
+    rdfs:comment "Links to tips, tactics, etc." ;
     :domainIncludes :VideoGame ;
-    :rangeIncludes :CreativeWork ;
-    rdfs:comment "Links to tips, tactics, etc." .
+    :rangeIncludes :CreativeWork .
 
 :gender a rdf:Property ;
     rdfs:label "gender" ;
+    rdfs:comment "Gender of something, typically a [[Person]], but possibly also fictional characters, animals, etc. While https://schema.org/Male and https://schema.org/Female may be used, text strings are also acceptable for people who do not identify as a binary gender. The [[gender]] property can also be used in an extended sense to cover e.g. the gender of sports teams. As with the gender of individuals, we do not try to enumerate all possibilities. A mixed-gender [[SportsTeam]] can be indicated with a text value of \"Mixed\"." ;
     :domainIncludes :Person ;
     :rangeIncludes :GenderType,
-        :Text ;
-    rdfs:comment "Gender of something, typically a [[Person]], but possibly also fictional characters, animals, etc. While https://schema.org/Male and https://schema.org/Female may be used, text strings are also acceptable for people who do not identify as a binary gender. The [[gender]] property can also be used in an extended sense to cover e.g. the gender of sports teams. As with the gender of individuals, we do not try to enumerate all possibilities. A mixed-gender [[SportsTeam]] can be indicated with a text value of \"Mixed\"." .
+        :Text .
 
 :genre a rdf:Property ;
     rdfs:label "genre" ;
+    rdfs:comment "Genre of the creative work, broadcast channel or group." ;
     :domainIncludes :BroadcastChannel,
         :CreativeWork,
         :MusicGroup ;
     :rangeIncludes :Text,
-        :URL ;
-    rdfs:comment "Genre of the creative work, broadcast channel or group." .
+        :URL .
 
 :geo a rdf:Property ;
     rdfs:label "geo" ;
+    rdfs:comment "The geo coordinates of the place." ;
     :domainIncludes :Place ;
     :rangeIncludes :GeoCoordinates,
-        :GeoShape ;
-    rdfs:comment "The geo coordinates of the place." .
+        :GeoShape .
 
 :geoMidpoint a rdf:Property ;
     rdfs:label "geoMidpoint" ;
+    rdfs:comment "Indicates the GeoCoordinates at the centre of a GeoShape, e.g. GeoCircle." ;
     :domainIncludes :GeoCircle ;
-    :rangeIncludes :GeoCoordinates ;
-    rdfs:comment "Indicates the GeoCoordinates at the centre of a GeoShape, e.g. GeoCircle." .
+    :rangeIncludes :GeoCoordinates .
 
 :geoRadius a rdf:Property ;
     rdfs:label "geoRadius" ;
+    rdfs:comment "Indicates the approximate radius of a GeoCircle (metres unless indicated otherwise via Distance notation)." ;
     :domainIncludes :GeoCircle ;
     :rangeIncludes :Distance,
         :Number,
-        :Text ;
-    rdfs:comment "Indicates the approximate radius of a GeoCircle (metres unless indicated otherwise via Distance notation)." .
+        :Text .
 
 :geographicArea a rdf:Property ;
     rdfs:label "geographicArea" ;
+    rdfs:comment "The geographic area associated with the audience." ;
     :domainIncludes :Audience ;
-    :rangeIncludes :AdministrativeArea ;
-    rdfs:comment "The geographic area associated with the audience." .
+    :rangeIncludes :AdministrativeArea .
 
 :givenName a rdf:Property ;
     rdfs:label "givenName" ;
+    rdfs:comment "Given name. In the U.S., the first name of a Person." ;
     :domainIncludes :Person ;
-    :rangeIncludes :Text ;
-    rdfs:comment "Given name. In the U.S., the first name of a Person." .
+    :rangeIncludes :Text .
 
 :globalLocationNumber a rdf:Property ;
     rdfs:label "globalLocationNumber" ;
+    rdfs:comment "The [Global Location Number](http://www.gs1.org/gln) (GLN, sometimes also referred to as International Location Number or ILN) of the respective organization, person, or place. The GLN is a 13-digit number used to identify parties and physical locations." ;
+    rdfs:subPropertyOf :identifier ;
     :domainIncludes :Organization,
         :Person,
         :Place ;
-    :rangeIncludes :Text ;
-    rdfs:comment "The [Global Location Number](http://www.gs1.org/gln) (GLN, sometimes also referred to as International Location Number or ILN) of the respective organization, person, or place. The GLN is a 13-digit number used to identify parties and physical locations." ;
-    rdfs:subPropertyOf :identifier .
+    :rangeIncludes :Text .
 
 :grantee a rdf:Property ;
     rdfs:label "grantee" ;
+    rdfs:comment "The person, organization, contact point, or audience that has been granted this permission." ;
     :domainIncludes :DigitalDocumentPermission ;
     :rangeIncludes :Audience,
         :ContactPoint,
         :Organization,
-        :Person ;
-    rdfs:comment "The person, organization, contact point, or audience that has been granted this permission." .
+        :Person .
 
 :greater a rdf:Property ;
     rdfs:label "greater" ;
+    rdfs:comment "This ordering relation for qualitative values indicates that the subject is greater than the object." ;
     :domainIncludes :QualitativeValue ;
-    :rangeIncludes :QualitativeValue ;
-    rdfs:comment "This ordering relation for qualitative values indicates that the subject is greater than the object." .
+    :rangeIncludes :QualitativeValue .
 
 :greaterOrEqual a rdf:Property ;
     rdfs:label "greaterOrEqual" ;
+    rdfs:comment "This ordering relation for qualitative values indicates that the subject is greater than or equal to the object." ;
     :domainIncludes :QualitativeValue ;
-    :rangeIncludes :QualitativeValue ;
-    rdfs:comment "This ordering relation for qualitative values indicates that the subject is greater than or equal to the object." .
+    :rangeIncludes :QualitativeValue .
 
 :gtin12 a rdf:Property ;
     rdfs:label "gtin12" ;
+    rdfs:comment "The GTIN-12 code of the product, or the product to which the offer refers. The GTIN-12 is the 12-digit GS1 Identification Key composed of a U.P.C. Company Prefix, Item Reference, and Check Digit used to identify trade items. See [GS1 GTIN Summary](http://www.gs1.org/barcodes/technical/idkeys/gtin) for more details." ;
+    rdfs:subPropertyOf :identifier ;
     :domainIncludes :Demand,
         :Offer,
         :Product ;
-    :rangeIncludes :Text ;
-    rdfs:comment "The GTIN-12 code of the product, or the product to which the offer refers. The GTIN-12 is the 12-digit GS1 Identification Key composed of a U.P.C. Company Prefix, Item Reference, and Check Digit used to identify trade items. See [GS1 GTIN Summary](http://www.gs1.org/barcodes/technical/idkeys/gtin) for more details." ;
-    rdfs:subPropertyOf :identifier .
+    :rangeIncludes :Text .
 
 :gtin13 a rdf:Property ;
     rdfs:label "gtin13" ;
+    rdfs:comment "The GTIN-13 code of the product, or the product to which the offer refers. This is equivalent to 13-digit ISBN codes and EAN UCC-13. Former 12-digit UPC codes can be converted into a GTIN-13 code by simply adding a preceding zero. See [GS1 GTIN Summary](http://www.gs1.org/barcodes/technical/idkeys/gtin) for more details." ;
+    rdfs:subPropertyOf :identifier ;
     :domainIncludes :Demand,
         :Offer,
         :Product ;
-    :rangeIncludes :Text ;
-    rdfs:comment "The GTIN-13 code of the product, or the product to which the offer refers. This is equivalent to 13-digit ISBN codes and EAN UCC-13. Former 12-digit UPC codes can be converted into a GTIN-13 code by simply adding a preceding zero. See [GS1 GTIN Summary](http://www.gs1.org/barcodes/technical/idkeys/gtin) for more details." ;
-    rdfs:subPropertyOf :identifier .
+    :rangeIncludes :Text .
 
 :gtin14 a rdf:Property ;
     rdfs:label "gtin14" ;
+    rdfs:comment "The GTIN-14 code of the product, or the product to which the offer refers. See [GS1 GTIN Summary](http://www.gs1.org/barcodes/technical/idkeys/gtin) for more details." ;
+    rdfs:subPropertyOf :identifier ;
     :domainIncludes :Demand,
         :Offer,
         :Product ;
-    :rangeIncludes :Text ;
-    rdfs:comment "The GTIN-14 code of the product, or the product to which the offer refers. See [GS1 GTIN Summary](http://www.gs1.org/barcodes/technical/idkeys/gtin) for more details." ;
-    rdfs:subPropertyOf :identifier .
+    :rangeIncludes :Text .
 
 :gtin8 a rdf:Property ;
     rdfs:label "gtin8" ;
+    rdfs:comment "The GTIN-8 code of the product, or the product to which the offer refers. This code is also known as EAN/UCC-8 or 8-digit EAN. See [GS1 GTIN Summary](http://www.gs1.org/barcodes/technical/idkeys/gtin) for more details." ;
+    rdfs:subPropertyOf :identifier ;
     :domainIncludes :Demand,
         :Offer,
         :Product ;
-    :rangeIncludes :Text ;
-    rdfs:comment "The GTIN-8 code of the product, or the product to which the offer refers. This code is also known as EAN/UCC-8 or 8-digit EAN. See [GS1 GTIN Summary](http://www.gs1.org/barcodes/technical/idkeys/gtin) for more details." ;
-    rdfs:subPropertyOf :identifier .
+    :rangeIncludes :Text .
 
 :hasCourseInstance a rdf:Property ;
     rdfs:label "hasCourseInstance" ;
+    rdfs:comment "An offering of the course at a specific time and place or through specific media or mode of study or to a specific section of students." ;
     :domainIncludes :Course ;
-    :rangeIncludes :CourseInstance ;
-    rdfs:comment "An offering of the course at a specific time and place or through specific media or mode of study or to a specific section of students." .
+    :rangeIncludes :CourseInstance .
 
 :hasDeliveryMethod a rdf:Property ;
     rdfs:label "hasDeliveryMethod" ;
+    rdfs:comment "Method used for delivery or shipping." ;
     :domainIncludes :DeliveryEvent,
         :ParcelDelivery ;
-    :rangeIncludes :DeliveryMethod ;
-    rdfs:comment "Method used for delivery or shipping." .
+    :rangeIncludes :DeliveryMethod .
 
 :hasDigitalDocumentPermission a rdf:Property ;
     rdfs:label "hasDigitalDocumentPermission" ;
+    rdfs:comment "A permission related to the access to this document (e.g. permission to read or write an electronic document). For a public document, specify a grantee with an Audience with audienceType equal to \"public\"." ;
     :domainIncludes :DigitalDocument ;
-    :rangeIncludes :DigitalDocumentPermission ;
-    rdfs:comment "A permission related to the access to this document (e.g. permission to read or write an electronic document). For a public document, specify a grantee with an Audience with audienceType equal to \"public\"." .
+    :rangeIncludes :DigitalDocumentPermission .
 
 :hasMenuItem a rdf:Property ;
     rdfs:label "hasMenuItem" ;
+    rdfs:comment "A food or drink item contained in a menu or menu section." ;
     :domainIncludes :Menu,
         :MenuSection ;
-    :rangeIncludes :MenuItem ;
-    rdfs:comment "A food or drink item contained in a menu or menu section." .
+    :rangeIncludes :MenuItem .
 
 :hasMenuSection a rdf:Property ;
     rdfs:label "hasMenuSection" ;
+    rdfs:comment "A subgrouping of the menu (by dishes, course, serving time period, etc.)." ;
     :domainIncludes :Menu,
         :MenuSection ;
-    :rangeIncludes :MenuSection ;
-    rdfs:comment "A subgrouping of the menu (by dishes, course, serving time period, etc.)." .
+    :rangeIncludes :MenuSection .
 
 :hasOccupation a rdf:Property ;
     rdfs:label "hasOccupation" ;
+    rdfs:comment "The Person's occupation. For past professions, use Role for expressing dates." ;
     :domainIncludes :Person ;
     :rangeIncludes :Occupation ;
-    :source <https://github.com/schemaorg/schemaorg/issues/1698> ;
-    rdfs:comment "The Person's occupation. For past professions, use Role for expressing dates." .
+    :source <https://github.com/schemaorg/schemaorg/issues/1698> .
 
 :hasOfferCatalog a rdf:Property ;
     rdfs:label "hasOfferCatalog" ;
+    rdfs:comment "Indicates an OfferCatalog listing for this Organization, Person, or Service." ;
     :domainIncludes :Organization,
         :Person,
         :Service ;
-    :rangeIncludes :OfferCatalog ;
-    rdfs:comment "Indicates an OfferCatalog listing for this Organization, Person, or Service." .
+    :rangeIncludes :OfferCatalog .
 
 :hasPOS a rdf:Property ;
     rdfs:label "hasPOS" ;
+    rdfs:comment "Points-of-Sales operated by the organization or person." ;
     :domainIncludes :Organization,
         :Person ;
-    :rangeIncludes :Place ;
-    rdfs:comment "Points-of-Sales operated by the organization or person." .
+    :rangeIncludes :Place .
 
 :headline a rdf:Property ;
     rdfs:label "headline" ;
+    rdfs:comment "Headline of the article." ;
     :domainIncludes :CreativeWork ;
-    :rangeIncludes :Text ;
-    rdfs:comment "Headline of the article." .
+    :rangeIncludes :Text .
 
 :height a rdf:Property ;
     rdfs:label "height" ;
+    rdfs:comment "The height of the item." ;
     :domainIncludes :MediaObject,
+        :OfferShippingDetails,
         :Person,
         :Product,
-        :VisualArtwork, :OfferShippingDetails ;
+        :VisualArtwork ;
     :rangeIncludes :Distance,
-        :QuantitativeValue ;
-    rdfs:comment "The height of the item." .
+        :QuantitativeValue .
 
 :highPrice a rdf:Property ;
     rdfs:label "highPrice" ;
+    rdfs:comment "The highest price of all offers available.\\n\\nUsage guidelines:\\n\\n* Use values from 0123456789 (Unicode 'DIGIT ZERO' (U+0030) to 'DIGIT NINE' (U+0039)) rather than superficially similar Unicode symbols.\\n* Use '.' (Unicode 'FULL STOP' (U+002E)) rather than ',' to indicate a decimal point. Avoid using these symbols as a readability separator." ;
     :domainIncludes :AggregateOffer ;
     :rangeIncludes :Number,
-        :Text ;
-    rdfs:comment "The highest price of all offers available.\\n\\nUsage guidelines:\\n\\n* Use values from 0123456789 (Unicode 'DIGIT ZERO' (U+0030) to 'DIGIT NINE' (U+0039)) rather than superficially similar Unicode symbols.\\n* Use '.' (Unicode 'FULL STOP' (U+002E)) rather than ',' to indicate a decimal point. Avoid using these symbols as a readability separator." .
+        :Text .
 
 :hiringOrganization a rdf:Property ;
     rdfs:label "hiringOrganization" ;
+    rdfs:comment "Organization or Person offering the job position." ;
     :domainIncludes :JobPosting ;
     :rangeIncludes :Organization,
-         :Person;
-    rdfs:comment "Organization or Person offering the job position." .
+        :Person .
 
 :homeLocation a rdf:Property ;
     rdfs:label "homeLocation" ;
+    rdfs:comment "A contact location for a person's residence." ;
+    rdfs:subPropertyOf :location ;
     :domainIncludes :Person ;
     :rangeIncludes :ContactPoint,
-        :Place ;
-    rdfs:comment "A contact location for a person's residence." ;
-    rdfs:subPropertyOf :location .
+        :Place .
 
 :homeTeam a rdf:Property ;
     rdfs:label "homeTeam" ;
+    rdfs:comment "The home team in a sports event." ;
+    rdfs:subPropertyOf :competitor ;
     :domainIncludes :SportsEvent ;
     :rangeIncludes :Person,
-        :SportsTeam ;
-    rdfs:comment "The home team in a sports event." ;
-    rdfs:subPropertyOf :competitor .
+        :SportsTeam .
 
 :honorificPrefix a rdf:Property ;
     rdfs:label "honorificPrefix" ;
+    rdfs:comment "An honorific prefix preceding a Person's name such as Dr/Mrs/Mr." ;
     :domainIncludes :Person ;
-    :rangeIncludes :Text ;
-    rdfs:comment "An honorific prefix preceding a Person's name such as Dr/Mrs/Mr." .
+    :rangeIncludes :Text .
 
 :honorificSuffix a rdf:Property ;
     rdfs:label "honorificSuffix" ;
+    rdfs:comment "An honorific suffix following a Person's name such as M.D./PhD/MSCSW." ;
     :domainIncludes :Person ;
-    :rangeIncludes :Text ;
-    rdfs:comment "An honorific suffix following a Person's name such as M.D./PhD/MSCSW." .
+    :rangeIncludes :Text .
 
 :hostingOrganization a rdf:Property ;
     rdfs:label "hostingOrganization" ;
-    :domainIncludes :ProgramMembership,
-        :MemberProgram ;
-    :rangeIncludes :Organization ;
-    rdfs:comment "The Organization (airline, travelers' club, retailer, etc.) the membership is made with or which offers the  MemberProgram." .
+    rdfs:comment "The Organization (airline, travelers' club, retailer, etc.) the membership is made with or which offers the  MemberProgram." ;
+    :domainIncludes :MemberProgram,
+        :ProgramMembership ;
+    :rangeIncludes :Organization .
 
 :hoursAvailable a rdf:Property ;
     rdfs:label "hoursAvailable" ;
+    rdfs:comment "The hours during which this service or contact is available." ;
     :domainIncludes :ContactPoint,
         :LocationFeatureSpecification,
         :Service ;
-    :rangeIncludes :OpeningHoursSpecification ;
-    rdfs:comment "The hours during which this service or contact is available." .
+    :rangeIncludes :OpeningHoursSpecification .
 
 :httpMethod a rdf:Property ;
     rdfs:label "httpMethod" ;
+    rdfs:comment "An HTTP method that specifies the appropriate HTTP method for a request to an HTTP EntryPoint. Values are capitalized strings as used in HTTP." ;
     :domainIncludes :EntryPoint ;
-    :rangeIncludes :Text ;
-    rdfs:comment "An HTTP method that specifies the appropriate HTTP method for a request to an HTTP EntryPoint. Values are capitalized strings as used in HTTP." .
+    :rangeIncludes :Text .
 
 :iataCode a rdf:Property ;
     rdfs:label "iataCode" ;
+    rdfs:comment "IATA identifier for an airline or airport." ;
     :domainIncludes :Airline,
         :Airport ;
-    :rangeIncludes :Text ;
-    rdfs:comment "IATA identifier for an airline or airport." .
+    :rangeIncludes :Text .
 
 :icaoCode a rdf:Property ;
     rdfs:label "icaoCode" ;
+    rdfs:comment "ICAO identifier for an airport." ;
     :domainIncludes :Airport ;
-    :rangeIncludes :Text ;
-    rdfs:comment "ICAO identifier for an airport." .
+    :rangeIncludes :Text .
 
 :illustrator a rdf:Property ;
     rdfs:label "illustrator" ;
+    rdfs:comment "The illustrator of the book." ;
     :domainIncludes :Book ;
-    :rangeIncludes :Person ;
-    rdfs:comment "The illustrator of the book." .
+    :rangeIncludes :Person .
 
 :inAlbum a rdf:Property ;
     rdfs:label "inAlbum" ;
+    rdfs:comment "The album to which this recording belongs." ;
     :domainIncludes :MusicRecording ;
-    :rangeIncludes :MusicAlbum ;
-    rdfs:comment "The album to which this recording belongs." .
+    :rangeIncludes :MusicAlbum .
 
 :inBroadcastLineup a rdf:Property ;
     rdfs:label "inBroadcastLineup" ;
+    rdfs:comment "The CableOrSatelliteService offering the channel." ;
     :domainIncludes :BroadcastChannel ;
-    :rangeIncludes :CableOrSatelliteService ;
-    rdfs:comment "The CableOrSatelliteService offering the channel." .
+    :rangeIncludes :CableOrSatelliteService .
 
 :inPlaylist a rdf:Property ;
     rdfs:label "inPlaylist" ;
+    rdfs:comment "The playlist to which this recording belongs." ;
     :domainIncludes :MusicRecording ;
-    :rangeIncludes :MusicPlaylist ;
-    rdfs:comment "The playlist to which this recording belongs." .
+    :rangeIncludes :MusicPlaylist .
 
 :incentives a rdf:Property ;
     rdfs:label "incentives" ;
+    rdfs:comment "Description of bonus and commission compensation aspects of the job." ;
     :domainIncludes :JobPosting ;
     :rangeIncludes :Text ;
-    :supersededBy :incentiveCompensation ;
-    rdfs:comment "Description of bonus and commission compensation aspects of the job." .
+    :supersededBy :incentiveCompensation .
 
 :includedComposition a rdf:Property ;
     rdfs:label "includedComposition" ;
-    :domainIncludes :MusicComposition ;
-    :rangeIncludes :MusicComposition ;
+    rdfs:comment "Smaller compositions included in this work (e.g. a movement in a symphony)." ;
     :contributor <https://schema.org/docs/collab/MBZ> ;
-    rdfs:comment "Smaller compositions included in this work (e.g. a movement in a symphony)." .
+    :domainIncludes :MusicComposition ;
+    :rangeIncludes :MusicComposition .
 
 :includedDataCatalog a rdf:Property ;
     rdfs:label "includedDataCatalog" ;
+    rdfs:comment "A data catalog which contains this dataset (this property was previously 'catalog', preferred name is now 'includedInDataCatalog')." ;
     :domainIncludes :Dataset ;
     :rangeIncludes :DataCatalog ;
-    :supersededBy :includedInDataCatalog ;
-    rdfs:comment "A data catalog which contains this dataset (this property was previously 'catalog', preferred name is now 'includedInDataCatalog')." .
+    :supersededBy :includedInDataCatalog .
 
 :includesObject a rdf:Property ;
     rdfs:label "includesObject" ;
+    rdfs:comment "This links to a node or nodes indicating the exact quantity of the products included in  an [[Offer]] or [[ProductCollection]]." ;
     :domainIncludes :Demand,
         :Offer ;
-    :rangeIncludes :TypeAndQuantityNode ;
-    rdfs:comment "This links to a node or nodes indicating the exact quantity of the products included in  an [[Offer]] or [[ProductCollection]]." .
+    :rangeIncludes :TypeAndQuantityNode .
 
 :industry a rdf:Property ;
     rdfs:label "industry" ;
+    rdfs:comment "The industry associated with the job position." ;
     :domainIncludes :JobPosting ;
     :rangeIncludes :DefinedTerm,
-        :Text ;
-    rdfs:comment "The industry associated with the job position." .
+        :Text .
 
 :ineligibleRegion a rdf:Property ;
     rdfs:label "ineligibleRegion" ;
+    rdfs:comment """The ISO 3166-1 (ISO 3166-1 alpha-2) or ISO 3166-2 code, the place, or the GeoShape for the geo-political region(s) for which the offer or delivery charge specification is not valid, e.g. a region where the transaction is not allowed.\\n\\nSee also [[eligibleRegion]].
+      """ ;
     :domainIncludes :DeliveryChargeSpecification,
         :Demand,
-  :MediaObject,
+        :MediaObject,
         :Offer ;
     :rangeIncludes :GeoShape,
         :Place,
-        :Text ;
-    rdfs:comment """The ISO 3166-1 (ISO 3166-1 alpha-2) or ISO 3166-2 code, the place, or the GeoShape for the geo-political region(s) for which the offer or delivery charge specification is not valid, e.g. a region where the transaction is not allowed.\\n\\nSee also [[eligibleRegion]].
-      """ .
+        :Text .
 
 :ingredients a rdf:Property ;
     rdfs:label "ingredients" ;
+    rdfs:comment "A single ingredient used in the recipe, e.g. sugar, flour or garlic." ;
+    rdfs:subPropertyOf :supply ;
     :domainIncludes :Recipe ;
     :rangeIncludes :Text ;
-    :supersededBy :recipeIngredient ;
-    rdfs:comment "A single ingredient used in the recipe, e.g. sugar, flour or garlic." ;
-    rdfs:subPropertyOf :supply .
+    :supersededBy :recipeIngredient .
 
 :installUrl a rdf:Property ;
     rdfs:label "installUrl" ;
+    rdfs:comment "URL at which the app may be installed, if different from the URL of the item." ;
     :domainIncludes :SoftwareApplication ;
-    :rangeIncludes :URL ;
-    rdfs:comment "URL at which the app may be installed, if different from the URL of the item." .
+    :rangeIncludes :URL .
 
 :instructor a rdf:Property ;
     rdfs:label "instructor" ;
+    rdfs:comment "A person assigned to instruct or provide instructional assistance for the [[CourseInstance]]." ;
     :domainIncludes :CourseInstance ;
-    :rangeIncludes :Person ;
-    rdfs:comment "A person assigned to instruct or provide instructional assistance for the [[CourseInstance]]." .
+    :rangeIncludes :Person .
 
 :interactionCount a rdf:Property ;
     rdfs:label "interactionCount" ;
-    :supersededBy :interactionStatistic ;
-    rdfs:comment "This property is deprecated, alongside the UserInteraction types on which it depended." .
+    rdfs:comment "This property is deprecated, alongside the UserInteraction types on which it depended." ;
+    :supersededBy :interactionStatistic .
 
 :interactionService a rdf:Property ;
     rdfs:label "interactionService" ;
+    rdfs:comment "The WebSite or SoftwareApplication where the interactions took place." ;
     :domainIncludes :InteractionCounter ;
     :rangeIncludes :SoftwareApplication,
-        :WebSite ;
-    rdfs:comment "The WebSite or SoftwareApplication where the interactions took place." .
+        :WebSite .
 
 :interactionType a rdf:Property ;
     rdfs:label "interactionType" ;
+    rdfs:comment "The Action representing the type of interaction. For up votes, +1s, etc. use [[LikeAction]]. For down votes use [[DislikeAction]]. Otherwise, use the most specific Action." ;
     :domainIncludes :InteractionCounter ;
-    :rangeIncludes :Action ;
-    rdfs:comment "The Action representing the type of interaction. For up votes, +1s, etc. use [[LikeAction]]. For down votes use [[DislikeAction]]. Otherwise, use the most specific Action." .
+    :rangeIncludes :Action .
 
 :interactivityType a rdf:Property ;
     rdfs:label "interactivityType" ;
+    rdfs:comment "The predominant mode of learning supported by the learning resource. Acceptable values are 'active', 'expositive', or 'mixed'." ;
     :domainIncludes :CreativeWork ;
-    :rangeIncludes :Text ;
-    rdfs:comment "The predominant mode of learning supported by the learning resource. Acceptable values are 'active', 'expositive', or 'mixed'." .
+    :rangeIncludes :Text .
 
 :interestRate a rdf:Property ;
     rdfs:label "interestRate" ;
+    rdfs:comment "The interest rate, charged or paid, applicable to the financial product. Note: This is different from the calculated annualPercentageRate." ;
+    :contributor <https://schema.org/docs/collab/FIBO> ;
     :domainIncludes :FinancialProduct ;
     :rangeIncludes :Number,
-        :QuantitativeValue ;
-    :contributor <https://schema.org/docs/collab/FIBO> ;
-    rdfs:comment "The interest rate, charged or paid, applicable to the financial product. Note: This is different from the calculated annualPercentageRate." .
+        :QuantitativeValue .
 
 :inventoryLevel a rdf:Property ;
     rdfs:label "inventoryLevel" ;
+    rdfs:comment "The current approximate inventory level for the item or items." ;
     :domainIncludes :Demand,
         :Offer,
         :SomeProducts ;
-    :rangeIncludes :QuantitativeValue ;
-    rdfs:comment "The current approximate inventory level for the item or items." .
+    :rangeIncludes :QuantitativeValue .
 
 :isAccessoryOrSparePartFor a rdf:Property ;
     rdfs:label "isAccessoryOrSparePartFor" ;
+    rdfs:comment "A pointer to another product (or multiple products) for which this product is an accessory or spare part." ;
     :domainIncludes :Product ;
-    :rangeIncludes :Product ;
-    rdfs:comment "A pointer to another product (or multiple products) for which this product is an accessory or spare part." .
+    :rangeIncludes :Product .
 
 :isBasedOnUrl a rdf:Property ;
     rdfs:label "isBasedOnUrl" ;
+    rdfs:comment "A resource that was used in the creation of this resource. This term can be repeated for multiple sources. For example, http://example.com/great-multiplication-intro.html." ;
     :domainIncludes :CreativeWork ;
     :rangeIncludes :CreativeWork,
         :Product,
         :URL ;
-    :supersededBy :isBasedOn ;
-    rdfs:comment "A resource that was used in the creation of this resource. This term can be repeated for multiple sources. For example, http://example.com/great-multiplication-intro.html." .
+    :supersededBy :isBasedOn .
 
 :isConsumableFor a rdf:Property ;
     rdfs:label "isConsumableFor" ;
+    rdfs:comment "A pointer to another product (or multiple products) for which this product is a consumable." ;
     :domainIncludes :Product ;
-    :rangeIncludes :Product ;
-    rdfs:comment "A pointer to another product (or multiple products) for which this product is a consumable." .
+    :rangeIncludes :Product .
 
 :isFamilyFriendly a rdf:Property ;
     rdfs:label "isFamilyFriendly" ;
+    rdfs:comment "Indicates whether this content is family friendly." ;
     :domainIncludes :CreativeWork,
-        :Product,
-        :Offer ;
-    :rangeIncludes :Boolean ;
-    rdfs:comment "Indicates whether this content is family friendly." .
+        :Offer,
+        :Product ;
+    :rangeIncludes :Boolean .
 
 :isGift a rdf:Property ;
     rdfs:label "isGift" ;
+    rdfs:comment "Indicates whether the offer was accepted as a gift for someone other than the buyer." ;
     :domainIncludes :Order ;
-    :rangeIncludes :Boolean ;
-    rdfs:comment "Indicates whether the offer was accepted as a gift for someone other than the buyer." .
+    :rangeIncludes :Boolean .
 
 :isLiveBroadcast a rdf:Property ;
     rdfs:label "isLiveBroadcast" ;
+    rdfs:comment "True if the broadcast is of a live event." ;
     :domainIncludes :BroadcastEvent ;
-    :rangeIncludes :Boolean ;
-    rdfs:comment "True if the broadcast is of a live event." .
+    :rangeIncludes :Boolean .
 
 :isRelatedTo a rdf:Property ;
     rdfs:label "isRelatedTo" ;
+    rdfs:comment "A pointer to another, somehow related product (or multiple products)." ;
     :domainIncludes :Product,
         :Service ;
     :rangeIncludes :Product,
-        :Service ;
-    rdfs:comment "A pointer to another, somehow related product (or multiple products)." .
+        :Service .
 
 :isSimilarTo a rdf:Property ;
     rdfs:label "isSimilarTo" ;
+    rdfs:comment "A pointer to another, functionally similar product (or multiple products)." ;
     :domainIncludes :Product,
         :Service ;
     :rangeIncludes :Product,
-        :Service ;
-    rdfs:comment "A pointer to another, functionally similar product (or multiple products)." .
+        :Service .
 
 :isVariantOf a rdf:Property ;
     rdfs:label "isVariantOf" ;
+    rdfs:comment "Indicates the kind of product that this is a variant of. In the case of [[ProductModel]], this is a pointer (from a ProductModel) to a base product from which this product is a variant. It is safe to infer that the variant inherits all product features from the base model, unless defined locally. This is not transitive. In the case of a [[ProductGroup]], the group description also serves as a template, representing a set of Products that vary on explicitly defined, specific dimensions only (so it defines both a set of variants, as well as which values distinguish amongst those variants). When used with [[ProductGroup]], this property can apply to any [[Product]] included in the group." ;
     :domainIncludes :ProductModel ;
-    :rangeIncludes :ProductModel ;
-    rdfs:comment "Indicates the kind of product that this is a variant of. In the case of [[ProductModel]], this is a pointer (from a ProductModel) to a base product from which this product is a variant. It is safe to infer that the variant inherits all product features from the base model, unless defined locally. This is not transitive. In the case of a [[ProductGroup]], the group description also serves as a template, representing a set of Products that vary on explicitly defined, specific dimensions only (so it defines both a set of variants, as well as which values distinguish amongst those variants). When used with [[ProductGroup]], this property can apply to any [[Product]] included in the group." .
-
-    # NOTE in data/ext/pending/issue-1797.ttl we tentatively amend this by extending the property as follows:
-    # The textual definition for isVariantOf has been minimally updated to accommodate ProductGroup; this could be
-    # :isVariantOf a rdf:Property ; :domainIncludes :Product ; :rangeIncludes :ProductGroup .
+    :rangeIncludes :ProductModel .
 
 :isbn a rdf:Property ;
     rdfs:label "isbn" ;
-    :domainIncludes :Book ;
-    :rangeIncludes :Text ;
     rdfs:comment "The ISBN of the book." ;
     rdfs:subPropertyOf :identifier ;
-    owl:equivalentProperty <http://purl.org/ontology/bibo/isbn> .
+    owl:equivalentProperty <http://purl.org/ontology/bibo/isbn> ;
+    :domainIncludes :Book ;
+    :rangeIncludes :Text .
 
 :isicV4 a rdf:Property ;
     rdfs:label "isicV4" ;
+    rdfs:comment "The International Standard of Industrial Classification of All Economic Activities (ISIC), Revision 4 code for a particular organization, business person, or place." ;
     :domainIncludes :Organization,
         :Person,
         :Place ;
-    :rangeIncludes :Text ;
-    rdfs:comment "The International Standard of Industrial Classification of All Economic Activities (ISIC), Revision 4 code for a particular organization, business person, or place." .
+    :rangeIncludes :Text .
 
 :isrcCode a rdf:Property ;
     rdfs:label "isrcCode" ;
-    :domainIncludes :MusicRecording ;
-    :rangeIncludes :Text ;
+    rdfs:comment "The International Standard Recording Code for the recording." ;
     :contributor <https://schema.org/docs/collab/MBZ> ;
-    rdfs:comment "The International Standard Recording Code for the recording." .
+    :domainIncludes :MusicRecording ;
+    :rangeIncludes :Text .
 
 :issn a rdf:Property ;
     rdfs:label "issn" ;
+    rdfs:comment "The International Standard Serial Number (ISSN) that identifies this serial publication. You can repeat this property to identify different formats of, or the linking ISSN (ISSN-L) for, this serial publication." ;
+    rdfs:subPropertyOf :identifier ;
+    owl:equivalentProperty <http://purl.org/ontology/bibo/issn> ;
+    :contributor <https://schema.org/docs/collab/bibex> ;
     :domainIncludes :Blog,
         :CreativeWorkSeries,
         :Dataset,
         :WebSite ;
-    :rangeIncludes :Text ;
-    :contributor <https://schema.org/docs/collab/bibex> ;
-    rdfs:comment "The International Standard Serial Number (ISSN) that identifies this serial publication. You can repeat this property to identify different formats of, or the linking ISSN (ISSN-L) for, this serial publication." ;
-    rdfs:subPropertyOf :identifier ;
-    owl:equivalentProperty <http://purl.org/ontology/bibo/issn> .
+    :rangeIncludes :Text .
 
 :issueNumber a rdf:Property ;
     rdfs:label "issueNumber" ;
-    :domainIncludes :PublicationIssue ;
-    :rangeIncludes :Integer,
-        :Text ;
-    :contributor <https://schema.org/docs/collab/bibex> ;
     rdfs:comment "Identifies the issue of publication; for example, \"iii\" or \"2\"." ;
     rdfs:subPropertyOf :position ;
-    owl:equivalentProperty <http://purl.org/ontology/bibo/issue> .
+    owl:equivalentProperty <http://purl.org/ontology/bibo/issue> ;
+    :contributor <https://schema.org/docs/collab/bibex> ;
+    :domainIncludes :PublicationIssue ;
+    :rangeIncludes :Integer,
+        :Text .
 
 :issuedBy a rdf:Property ;
     rdfs:label "issuedBy" ;
-    :domainIncludes :Permit,
-        :Ticket,
-    :Certification ;
-    :rangeIncludes :Organization ;
-    rdfs:comment "The organization issuing the item, for example a [[Permit]], [[Ticket]], or [[Certification]]." .
+    rdfs:comment "The organization issuing the item, for example a [[Permit]], [[Ticket]], or [[Certification]]." ;
+    :domainIncludes :Certification,
+        :Permit,
+        :Ticket ;
+    :rangeIncludes :Organization .
 
 :issuedThrough a rdf:Property ;
     rdfs:label "issuedThrough" ;
+    rdfs:comment "The service through which the permit was granted." ;
     :domainIncludes :Permit ;
-    :rangeIncludes :Service ;
-    rdfs:comment "The service through which the permit was granted." .
+    :rangeIncludes :Service .
 
 :iswcCode a rdf:Property ;
     rdfs:label "iswcCode" ;
-    :domainIncludes :MusicComposition ;
-    :rangeIncludes :Text ;
+    rdfs:comment "The International Standard Musical Work Code for the composition." ;
     :contributor <https://schema.org/docs/collab/MBZ> ;
-    rdfs:comment "The International Standard Musical Work Code for the composition." .
+    :domainIncludes :MusicComposition ;
+    :rangeIncludes :Text .
 
 :item a rdf:Property ;
     rdfs:label "item" ;
+    rdfs:comment "An entity represented by an entry in a list or data feed (e.g. an 'artist' in a list of 'artists')." ;
     :domainIncludes :DataFeedItem,
         :ListItem ;
-    :rangeIncludes :Thing ;
-    rdfs:comment "An entity represented by an entry in a list or data feed (e.g. an 'artist' in a list of 'artists')." .
+    :rangeIncludes :Thing .
 
 :itemCondition a rdf:Property ;
     rdfs:label "itemCondition" ;
+    rdfs:comment "A predefined value from OfferItemCondition specifying the condition of the product or service, or the products or services included in the offer. Also used for product return policies to specify the condition of products accepted for returns." ;
     :domainIncludes :Demand,
+        :MerchantReturnPolicy,
         :Offer,
-        :Product,
-        :MerchantReturnPolicy ;
-    :rangeIncludes :OfferItemCondition ;
-    rdfs:comment "A predefined value from OfferItemCondition specifying the condition of the product or service, or the products or services included in the offer. Also used for product return policies to specify the condition of products accepted for returns." .
+        :Product ;
+    :rangeIncludes :OfferItemCondition .
 
 :itemListElement a rdf:Property ;
     rdfs:label "itemListElement" ;
+    rdfs:comment "For itemListElement values, you can use simple strings (e.g. \"Peter\", \"Paul\", \"Mary\"), existing entities, or use ListItem.\\n\\nText values are best if the elements in the list are plain strings. Existing entities are best for a simple, unordered list of existing things in your data. ListItem is used with ordered lists when you want to provide additional context about the element in that list or when the same item might be in different places in different lists.\\n\\nNote: The order of elements in your mark-up is not sufficient for indicating the order or elements.  Use ListItem with a 'position' property in such cases." ;
     :domainIncludes :ItemList ;
     :rangeIncludes :ListItem,
         :Text,
-        :Thing ;
-    rdfs:comment "For itemListElement values, you can use simple strings (e.g. \"Peter\", \"Paul\", \"Mary\"), existing entities, or use ListItem.\\n\\nText values are best if the elements in the list are plain strings. Existing entities are best for a simple, unordered list of existing things in your data. ListItem is used with ordered lists when you want to provide additional context about the element in that list or when the same item might be in different places in different lists.\\n\\nNote: The order of elements in your mark-up is not sufficient for indicating the order or elements.  Use ListItem with a 'position' property in such cases." .
+        :Thing .
 
 :itemListOrder a rdf:Property ;
     rdfs:label "itemListOrder" ;
+    rdfs:comment "Type of ordering (e.g. Ascending, Descending, Unordered)." ;
     :domainIncludes :ItemList ;
     :rangeIncludes :ItemListOrderType,
-        :Text ;
-    rdfs:comment "Type of ordering (e.g. Ascending, Descending, Unordered)." .
+        :Text .
 
 :itemReviewed a rdf:Property ;
     rdfs:label "itemReviewed" ;
+    rdfs:comment "The item that is being reviewed/rated." ;
     :domainIncludes :AggregateRating,
         :Review ;
-    :rangeIncludes :Thing ;
-    rdfs:comment "The item that is being reviewed/rated." .
+    :rangeIncludes :Thing .
 
 :itemShipped a rdf:Property ;
     rdfs:label "itemShipped" ;
+    rdfs:comment "Item(s) being shipped." ;
     :domainIncludes :ParcelDelivery ;
-    :rangeIncludes :Product ;
-    rdfs:comment "Item(s) being shipped." .
+    :rangeIncludes :Product .
 
 :jobLocation a rdf:Property ;
     rdfs:label "jobLocation" ;
+    rdfs:comment "A (typically single) geographic location associated with the job position." ;
     :domainIncludes :JobPosting ;
-    :rangeIncludes :Place ;
-    rdfs:comment "A (typically single) geographic location associated with the job position." .
+    :rangeIncludes :Place .
 
 :jobTitle a rdf:Property ;
     rdfs:label "jobTitle" ;
+    rdfs:comment "The job title of the person (for example, Financial Manager)." ;
     :domainIncludes :Person ;
-    :rangeIncludes :Text ;
-    rdfs:comment "The job title of the person (for example, Financial Manager)." .
+    :rangeIncludes :Text .
 
 :keywords a rdf:Property ;
     rdfs:label "keywords" ;
-    :domainIncludes :CreativeWork, :Organization, :Event, :Product, :Place ;
+    rdfs:comment "Keywords or tags used to describe some item. Multiple textual entries in a keywords list are typically delimited by commas, or by repeating the property." ;
+    :domainIncludes :CreativeWork,
+        :Event,
+        :Organization,
+        :Place,
+        :Product ;
     :rangeIncludes :DefinedTerm,
         :Text,
-        :URL ;
-    rdfs:comment "Keywords or tags used to describe some item. Multiple textual entries in a keywords list are typically delimited by commas, or by repeating the property." .
+        :URL .
 
 :knownVehicleDamages a rdf:Property ;
     rdfs:label "knownVehicleDamages" ;
-    :domainIncludes :Vehicle ;
-    :rangeIncludes :Text ;
+    rdfs:comment "A textual description of known damages, both repaired and unrepaired." ;
     :contributor <https://schema.org/docs/collab/Automotive_Ontology_Working_Group> ;
-    rdfs:comment "A textual description of known damages, both repaired and unrepaired." .
+    :domainIncludes :Vehicle ;
+    :rangeIncludes :Text .
 
 :knows a rdf:Property ;
     rdfs:label "knows" ;
+    rdfs:comment "The most generic bi-directional social/work relation." ;
     :domainIncludes :Person ;
-    :rangeIncludes :Person ;
-    rdfs:comment "The most generic bi-directional social/work relation." .
+    :rangeIncludes :Person .
 
 :landlord a rdf:Property ;
     rdfs:label "landlord" ;
+    rdfs:comment "A sub property of participant. The owner of the real estate property." ;
+    rdfs:subPropertyOf :participant ;
     :domainIncludes :RentAction ;
     :rangeIncludes :Organization,
-        :Person ;
-    rdfs:comment "A sub property of participant. The owner of the real estate property." ;
-    rdfs:subPropertyOf :participant .
+        :Person .
 
 :language a rdf:Property ;
     rdfs:label "language" ;
+    rdfs:comment "A sub property of instrument. The language used on this action." ;
+    rdfs:subPropertyOf :instrument ;
     :domainIncludes :CommunicateAction,
         :WriteAction ;
     :rangeIncludes :Language ;
-    :supersededBy :inLanguage ;
-    rdfs:comment "A sub property of instrument. The language used on this action." ;
-    rdfs:subPropertyOf :instrument .
+    :supersededBy :inLanguage .
 
 :lastReviewed a rdf:Property ;
     rdfs:label "lastReviewed" ;
+    rdfs:comment "Date on which the content on this web page was last reviewed for accuracy and/or completeness." ;
     :domainIncludes :WebPage ;
-    :rangeIncludes :Date ;
-    rdfs:comment "Date on which the content on this web page was last reviewed for accuracy and/or completeness." .
+    :rangeIncludes :Date .
 
 :latitude a rdf:Property ;
     rdfs:label "latitude" ;
+    rdfs:comment "The latitude of a location. For example ```37.42242``` ([WGS 84](https://en.wikipedia.org/wiki/World_Geodetic_System))." ;
     :domainIncludes :GeoCoordinates,
         :Place ;
     :rangeIncludes :Number,
-        :Text ;
-    rdfs:comment "The latitude of a location. For example ```37.42242``` ([WGS 84](https://en.wikipedia.org/wiki/World_Geodetic_System))." .
+        :Text .
 
 :learningResourceType a rdf:Property ;
     rdfs:label "learningResourceType" ;
+    rdfs:comment "The predominant type or kind characterizing the learning resource. For example, 'presentation', 'handout'." ;
     :domainIncludes :CreativeWork,
         :LearningResource ;
     :rangeIncludes :DefinedTerm,
-        :Text ;
-    rdfs:comment "The predominant type or kind characterizing the learning resource. For example, 'presentation', 'handout'." .
+        :Text .
 
 :legalName a rdf:Property ;
     rdfs:label "legalName" ;
+    rdfs:comment "The official name of the organization, e.g. the registered company name." ;
     :domainIncludes :Organization ;
-    :rangeIncludes :Text ;
-    rdfs:comment "The official name of the organization, e.g. the registered company name." .
+    :rangeIncludes :Text .
 
 :leiCode a rdf:Property ;
     rdfs:label "leiCode" ;
-    :domainIncludes :Organization ;
-    :rangeIncludes :Text ;
+    rdfs:comment "An organization identifier that uniquely identifies a legal entity as defined in ISO 17442." ;
+    rdfs:subPropertyOf :identifier ;
     :contributor <https://schema.org/docs/collab/FIBO>,
         <https://schema.org/docs/collab/GLEIF> ;
-    rdfs:comment "An organization identifier that uniquely identifies a legal entity as defined in ISO 17442." ;
-    rdfs:subPropertyOf :identifier .
+    :domainIncludes :Organization ;
+    :rangeIncludes :Text .
 
 :lender a rdf:Property ;
     rdfs:label "lender" ;
+    rdfs:comment "A sub property of participant. The person that lends the object being borrowed." ;
+    rdfs:subPropertyOf :participant ;
     :domainIncludes :BorrowAction ;
     :rangeIncludes :Organization,
-        :Person ;
-    rdfs:comment "A sub property of participant. The person that lends the object being borrowed." ;
-    rdfs:subPropertyOf :participant .
+        :Person .
 
 :lesser a rdf:Property ;
     rdfs:label "lesser" ;
+    rdfs:comment "This ordering relation for qualitative values indicates that the subject is lesser than the object." ;
     :domainIncludes :QualitativeValue ;
-    :rangeIncludes :QualitativeValue ;
-    rdfs:comment "This ordering relation for qualitative values indicates that the subject is lesser than the object." .
+    :rangeIncludes :QualitativeValue .
 
 :lesserOrEqual a rdf:Property ;
     rdfs:label "lesserOrEqual" ;
+    rdfs:comment "This ordering relation for qualitative values indicates that the subject is lesser than or equal to the object." ;
     :domainIncludes :QualitativeValue ;
-    :rangeIncludes :QualitativeValue ;
-    rdfs:comment "This ordering relation for qualitative values indicates that the subject is lesser than or equal to the object." .
+    :rangeIncludes :QualitativeValue .
 
 :license a rdf:Property ;
     rdfs:label "license" ;
+    rdfs:comment "A license document that applies to this content, typically indicated by URL." ;
     :domainIncludes :CreativeWork ;
     :rangeIncludes :CreativeWork,
-        :URL ;
-    rdfs:comment "A license document that applies to this content, typically indicated by URL." .
+        :URL .
 
 :line a rdf:Property ;
     rdfs:label "line" ;
+    rdfs:comment "A line is a point-to-point path consisting of two or more points. A line is expressed as a series of two or more point objects separated by space." ;
     :domainIncludes :GeoShape ;
-    :rangeIncludes :Text ;
-    rdfs:comment "A line is a point-to-point path consisting of two or more points. A line is expressed as a series of two or more point objects separated by space." .
+    :rangeIncludes :Text .
 
 :liveBlogUpdate a rdf:Property ;
     rdfs:label "liveBlogUpdate" ;
+    rdfs:comment "An update to the LiveBlog." ;
     :domainIncludes :LiveBlogPosting ;
-    :rangeIncludes :BlogPosting ;
-    rdfs:comment "An update to the LiveBlog." .
+    :rangeIncludes :BlogPosting .
 
 :loanTerm a rdf:Property ;
     rdfs:label "loanTerm" ;
-    :domainIncludes :LoanOrCredit ;
-    :rangeIncludes :QuantitativeValue ;
-    :contributor <https://schema.org/docs/collab/FIBO> ;
     rdfs:comment "The duration of the loan or credit agreement." ;
-    rdfs:subPropertyOf :duration .
+    rdfs:subPropertyOf :duration ;
+    :contributor <https://schema.org/docs/collab/FIBO> ;
+    :domainIncludes :LoanOrCredit ;
+    :rangeIncludes :QuantitativeValue .
 
 :locationCreated a rdf:Property ;
     rdfs:label "locationCreated" ;
+    rdfs:comment "The location where the CreativeWork was created, which may not be the same as the location depicted in the CreativeWork." ;
     :domainIncludes :CreativeWork ;
-    :rangeIncludes :Place ;
-    rdfs:comment "The location where the CreativeWork was created, which may not be the same as the location depicted in the CreativeWork." .
+    :rangeIncludes :Place .
 
 :lodgingUnitDescription a rdf:Property ;
     rdfs:label "lodgingUnitDescription" ;
+    rdfs:comment "A full description of the lodging unit." ;
     :domainIncludes :LodgingReservation ;
-    :rangeIncludes :Text ;
-    rdfs:comment "A full description of the lodging unit." .
+    :rangeIncludes :Text .
 
 :lodgingUnitType a rdf:Property ;
     rdfs:label "lodgingUnitType" ;
+    rdfs:comment "Textual description of the unit type (including suite vs. room, size of bed, etc.)." ;
     :domainIncludes :LodgingReservation ;
     :rangeIncludes :QualitativeValue,
-        :Text ;
-    rdfs:comment "Textual description of the unit type (including suite vs. room, size of bed, etc.)." .
+        :Text .
 
 :logo a rdf:Property ;
     rdfs:label "logo" ;
+    rdfs:comment "An associated logo." ;
+    rdfs:subPropertyOf :image ;
     :domainIncludes :Brand,
+        :Certification,
         :Organization,
         :Place,
         :Product,
-        :Service,
-        :Certification ;
+        :Service ;
     :rangeIncludes :ImageObject,
-        :URL ;
-    rdfs:comment "An associated logo." ;
-    rdfs:subPropertyOf :image .
+        :URL .
 
 :longitude a rdf:Property ;
     rdfs:label "longitude" ;
+    rdfs:comment "The longitude of a location. For example ```-122.08585``` ([WGS 84](https://en.wikipedia.org/wiki/World_Geodetic_System))." ;
     :domainIncludes :GeoCoordinates,
         :Place ;
     :rangeIncludes :Number,
-        :Text ;
-    rdfs:comment "The longitude of a location. For example ```-122.08585``` ([WGS 84](https://en.wikipedia.org/wiki/World_Geodetic_System))." .
+        :Text .
 
 :loser a rdf:Property ;
     rdfs:label "loser" ;
-    :domainIncludes :WinAction ;
-    :rangeIncludes :Person ;
     rdfs:comment "A sub property of participant. The loser of the action." ;
-    rdfs:subPropertyOf :participant .
+    rdfs:subPropertyOf :participant ;
+    :domainIncludes :WinAction ;
+    :rangeIncludes :Person .
 
 :lowPrice a rdf:Property ;
     rdfs:label "lowPrice" ;
+    rdfs:comment "The lowest price of all offers available.\\n\\nUsage guidelines:\\n\\n* Use values from 0123456789 (Unicode 'DIGIT ZERO' (U+0030) to 'DIGIT NINE' (U+0039)) rather than superficially similar Unicode symbols.\\n* Use '.' (Unicode 'FULL STOP' (U+002E)) rather than ',' to indicate a decimal point. Avoid using these symbols as a readability separator." ;
     :domainIncludes :AggregateOffer ;
     :rangeIncludes :Number,
-        :Text ;
-    rdfs:comment "The lowest price of all offers available.\\n\\nUsage guidelines:\\n\\n* Use values from 0123456789 (Unicode 'DIGIT ZERO' (U+0030) to 'DIGIT NINE' (U+0039)) rather than superficially similar Unicode symbols.\\n* Use '.' (Unicode 'FULL STOP' (U+002E)) rather than ',' to indicate a decimal point. Avoid using these symbols as a readability separator." .
+        :Text .
 
 :lyricist a rdf:Property ;
     rdfs:label "lyricist" ;
-    :domainIncludes :MusicComposition ;
-    :rangeIncludes :Person ;
+    rdfs:comment "The person who wrote the words." ;
     :contributor <https://schema.org/docs/collab/MBZ> ;
-    rdfs:comment "The person who wrote the words." .
+    :domainIncludes :MusicComposition ;
+    :rangeIncludes :Person .
 
 :lyrics a rdf:Property ;
     rdfs:label "lyrics" ;
-    :domainIncludes :MusicComposition ;
-    :rangeIncludes :CreativeWork ;
+    rdfs:comment "The words in the song." ;
     :contributor <https://schema.org/docs/collab/MBZ> ;
-    rdfs:comment "The words in the song." .
+    :domainIncludes :MusicComposition ;
+    :rangeIncludes :CreativeWork .
 
 :mainContentOfPage a rdf:Property ;
     rdfs:label "mainContentOfPage" ;
+    rdfs:comment "Indicates if this web page element is the main subject of the page." ;
     :domainIncludes :WebPage ;
-    :rangeIncludes :WebPageElement ;
-    rdfs:comment "Indicates if this web page element is the main subject of the page." .
+    :rangeIncludes :WebPageElement .
 
 :manufacturer a rdf:Property ;
     rdfs:label "manufacturer" ;
+    rdfs:comment "The manufacturer of the product." ;
     :domainIncludes :Product ;
-    :rangeIncludes :Organization ;
-    rdfs:comment "The manufacturer of the product." .
+    :rangeIncludes :Organization .
 
 :map a rdf:Property ;
     rdfs:label "map" ;
+    rdfs:comment "A URL to a map of the place." ;
     :domainIncludes :Place ;
     :rangeIncludes :URL ;
-    :supersededBy :hasMap ;
-    rdfs:comment "A URL to a map of the place." .
+    :supersededBy :hasMap .
 
 :mapType a rdf:Property ;
     rdfs:label "mapType" ;
+    rdfs:comment "Indicates the kind of Map, from the MapCategoryType Enumeration." ;
     :domainIncludes :Map ;
-    :rangeIncludes :MapCategoryType ;
-    rdfs:comment "Indicates the kind of Map, from the MapCategoryType Enumeration." .
+    :rangeIncludes :MapCategoryType .
 
 :maps a rdf:Property ;
     rdfs:label "maps" ;
+    rdfs:comment "A URL to a map of the place." ;
     :domainIncludes :Place ;
     :rangeIncludes :URL ;
-    :supersededBy :hasMap ;
-    rdfs:comment "A URL to a map of the place." .
+    :supersededBy :hasMap .
 
 :maxPrice a rdf:Property ;
     rdfs:label "maxPrice" ;
+    rdfs:comment "The highest price if the price is a range." ;
     :domainIncludes :PriceSpecification ;
-    :rangeIncludes :Number ;
-    rdfs:comment "The highest price if the price is a range." .
+    :rangeIncludes :Number .
 
 :maxValue a rdf:Property ;
     rdfs:label "maxValue" ;
+    rdfs:comment "The upper value of some characteristic or property." ;
     :domainIncludes :MonetaryAmount,
         :PropertyValue,
         :PropertyValueSpecification,
         :QuantitativeValue ;
-    :rangeIncludes :Number ;
-    rdfs:comment "The upper value of some characteristic or property." .
+    :rangeIncludes :Number .
 
 :maximumAttendeeCapacity a rdf:Property ;
     rdfs:label "maximumAttendeeCapacity" ;
+    rdfs:comment "The total number of individuals that may attend an event or venue." ;
     :domainIncludes :Event,
         :Place ;
-    :rangeIncludes :Integer ;
-    rdfs:comment "The total number of individuals that may attend an event or venue." .
+    :rangeIncludes :Integer .
 
 :mealService a rdf:Property ;
     rdfs:label "mealService" ;
+    rdfs:comment "Description of the meals that will be provided or available for purchase." ;
     :domainIncludes :Flight ;
-    :rangeIncludes :Text ;
-    rdfs:comment "Description of the meals that will be provided or available for purchase." .
+    :rangeIncludes :Text .
 
 :median a rdf:Property ;
     rdfs:label "median" ;
+    rdfs:comment "The median value." ;
     :domainIncludes :QuantitativeValueDistribution ;
     :rangeIncludes :Number ;
-    :source <https://github.com/schemaorg/schemaorg/issues/1698> ;
-    rdfs:comment "The median value." .
+    :source <https://github.com/schemaorg/schemaorg/issues/1698> .
 
 :members a rdf:Property ;
     rdfs:label "members" ;
+    rdfs:comment "A member of this organization." ;
     :domainIncludes :Organization,
         :ProgramMembership ;
     :rangeIncludes :Organization,
         :Person ;
-    :supersededBy :member ;
-    rdfs:comment "A member of this organization." .
+    :supersededBy :member .
 
 :membershipNumber a rdf:Property ;
     rdfs:label "membershipNumber" ;
+    rdfs:comment "A unique identifier for the membership." ;
     :domainIncludes :ProgramMembership ;
-    :rangeIncludes :Text ;
-    rdfs:comment "A unique identifier for the membership." .
+    :rangeIncludes :Text .
 
 :memoryRequirements a rdf:Property ;
     rdfs:label "memoryRequirements" ;
+    rdfs:comment "Minimum memory requirements." ;
     :domainIncludes :SoftwareApplication ;
     :rangeIncludes :Text,
-        :URL ;
-    rdfs:comment "Minimum memory requirements." .
+        :URL .
 
 :mentions a rdf:Property ;
     rdfs:label "mentions" ;
+    rdfs:comment "Indicates that the CreativeWork contains a reference to, but is not necessarily about a concept." ;
     :domainIncludes :CreativeWork ;
-    :rangeIncludes :Thing ;
-    rdfs:comment "Indicates that the CreativeWork contains a reference to, but is not necessarily about a concept." .
+    :rangeIncludes :Thing .
 
 :menu a rdf:Property ;
     rdfs:label "menu" ;
+    rdfs:comment "Either the actual menu as a structured representation, as text, or a URL of the menu." ;
     :domainIncludes :FoodEstablishment ;
     :rangeIncludes :Menu,
         :Text,
         :URL ;
-    :supersededBy :hasMenu ;
-    rdfs:comment "Either the actual menu as a structured representation, as text, or a URL of the menu." .
+    :supersededBy :hasMenu .
 
 :menuAddOn a rdf:Property ;
     rdfs:label "menuAddOn" ;
+    rdfs:comment "Additional menu item(s) such as a side dish of salad or side order of fries that can be added to this menu item. Additionally it can be a menu section containing allowed add-on menu items for this menu item." ;
     :domainIncludes :MenuItem ;
     :rangeIncludes :MenuItem,
         :MenuSection ;
-    :source <https://github.com/schemaorg/schemaorg/issues/1541> ;
-    rdfs:comment "Additional menu item(s) such as a side dish of salad or side order of fries that can be added to this menu item. Additionally it can be a menu section containing allowed add-on menu items for this menu item." .
+    :source <https://github.com/schemaorg/schemaorg/issues/1541> .
 
 :merchant a rdf:Property ;
     rdfs:label "merchant" ;
+    rdfs:comment "'merchant' is an out-dated term for 'seller'." ;
     :domainIncludes :Order ;
     :rangeIncludes :Organization,
         :Person ;
-    :supersededBy :seller ;
-    rdfs:comment "'merchant' is an out-dated term for 'seller'." .
+    :supersededBy :seller .
 
 :messageAttachment a rdf:Property ;
     rdfs:label "messageAttachment" ;
+    rdfs:comment "A CreativeWork attached to the message." ;
     :domainIncludes :Message ;
-    :rangeIncludes :CreativeWork ;
-    rdfs:comment "A CreativeWork attached to the message." .
+    :rangeIncludes :CreativeWork .
 
 :mileageFromOdometer a rdf:Property ;
     rdfs:label "mileageFromOdometer" ;
-    :domainIncludes :Vehicle ;
-    :rangeIncludes :QuantitativeValue ;
+    rdfs:comment "The total distance travelled by the particular vehicle since its initial production, as read from its odometer.\\n\\nTypical unit code(s): KMT for kilometers, SMI for statute miles." ;
     :contributor <https://schema.org/docs/collab/Automotive_Ontology_Working_Group> ;
-    rdfs:comment "The total distance travelled by the particular vehicle since its initial production, as read from its odometer.\\n\\nTypical unit code(s): KMT for kilometers, SMI for statute miles." .
+    :domainIncludes :Vehicle ;
+    :rangeIncludes :QuantitativeValue .
 
 :minPrice a rdf:Property ;
     rdfs:label "minPrice" ;
+    rdfs:comment "The lowest price if the price is a range." ;
     :domainIncludes :PriceSpecification ;
-    :rangeIncludes :Number ;
-    rdfs:comment "The lowest price if the price is a range." .
+    :rangeIncludes :Number .
 
 :minValue a rdf:Property ;
     rdfs:label "minValue" ;
+    rdfs:comment "The lower value of some characteristic or property." ;
     :domainIncludes :MonetaryAmount,
         :PropertyValue,
         :PropertyValueSpecification,
         :QuantitativeValue ;
-    :rangeIncludes :Number ;
-    rdfs:comment "The lower value of some characteristic or property." .
+    :rangeIncludes :Number .
 
 :minimumPaymentDue a rdf:Property ;
     rdfs:label "minimumPaymentDue" ;
+    rdfs:comment "The minimum payment required at this time." ;
     :domainIncludes :Invoice ;
     :rangeIncludes :MonetaryAmount,
-        :PriceSpecification ;
-    rdfs:comment "The minimum payment required at this time." .
+        :PriceSpecification .
 
 :model a rdf:Property ;
     rdfs:label "model" ;
+    rdfs:comment "The model of the product. Use with the URL of a ProductModel or a textual representation of the model identifier. The URL of the ProductModel can be from an external source. It is recommended to additionally provide strong product identifiers via the gtin8/gtin13/gtin14 and mpn properties." ;
     :domainIncludes :Product ;
     :rangeIncludes :ProductModel,
-        :Text ;
-    rdfs:comment "The model of the product. Use with the URL of a ProductModel or a textual representation of the model identifier. The URL of the ProductModel can be from an external source. It is recommended to additionally provide strong product identifiers via the gtin8/gtin13/gtin14 and mpn properties." .
+        :Text .
 
 :modifiedTime a rdf:Property ;
     rdfs:label "modifiedTime" ;
+    rdfs:comment "The date and time the reservation was modified." ;
     :domainIncludes :Reservation ;
-    :rangeIncludes :DateTime ;
-    rdfs:comment "The date and time the reservation was modified." .
+    :rangeIncludes :DateTime .
 
 :mpn a rdf:Property ;
     rdfs:label "mpn" ;
+    rdfs:comment "The Manufacturer Part Number (MPN) of the product, or the product to which the offer refers." ;
     :domainIncludes :Demand,
         :Offer,
         :Product ;
-    :rangeIncludes :Text ;
-    rdfs:comment "The Manufacturer Part Number (MPN) of the product, or the product to which the offer refers." .
+    :rangeIncludes :Text .
 
 :multipleValues a rdf:Property ;
     rdfs:label "multipleValues" ;
+    rdfs:comment "Whether multiple values are allowed for the property.  Default is false." ;
     :domainIncludes :PropertyValueSpecification ;
-    :rangeIncludes :Boolean ;
-    rdfs:comment "Whether multiple values are allowed for the property.  Default is false." .
+    :rangeIncludes :Boolean .
 
 :musicArrangement a rdf:Property ;
     rdfs:label "musicArrangement" ;
-    :domainIncludes :MusicComposition ;
-    :rangeIncludes :MusicComposition ;
+    rdfs:comment "An arrangement derived from the composition." ;
     :contributor <https://schema.org/docs/collab/MBZ> ;
-    rdfs:comment "An arrangement derived from the composition." .
+    :domainIncludes :MusicComposition ;
+    :rangeIncludes :MusicComposition .
 
 :musicBy a rdf:Property ;
     rdfs:label "musicBy" ;
+    rdfs:comment "The composer of the soundtrack." ;
     :domainIncludes :Clip,
         :Episode,
         :Movie,
@@ -7080,189 +7088,191 @@ Typical unit code(s): MTK for square meter, FTK for square foot, or YDK for squa
         :VideoGameSeries,
         :VideoObject ;
     :rangeIncludes :MusicGroup,
-        :Person ;
-    rdfs:comment "The composer of the soundtrack." .
+        :Person .
 
 :musicCompositionForm a rdf:Property ;
     rdfs:label "musicCompositionForm" ;
-    :domainIncludes :MusicComposition ;
-    :rangeIncludes :Text ;
+    rdfs:comment "The type of composition (e.g. overture, sonata, symphony, etc.)." ;
     :contributor <https://schema.org/docs/collab/MBZ> ;
-    rdfs:comment "The type of composition (e.g. overture, sonata, symphony, etc.)." .
+    :domainIncludes :MusicComposition ;
+    :rangeIncludes :Text .
 
 :musicGroupMember a rdf:Property ;
     rdfs:label "musicGroupMember" ;
+    rdfs:comment "A member of a music group&#x2014;for example, John, Paul, George, or Ringo." ;
     :domainIncludes :MusicGroup ;
     :rangeIncludes :Person ;
-    :supersededBy :member ;
-    rdfs:comment "A member of a music group&#x2014;for example, John, Paul, George, or Ringo." .
+    :supersededBy :member .
 
 :musicReleaseFormat a rdf:Property ;
     rdfs:label "musicReleaseFormat" ;
-    :domainIncludes :MusicRelease ;
-    :rangeIncludes :MusicReleaseFormatType ;
+    rdfs:comment "Format of this release (the type of recording media used, i.e. compact disc, digital media, LP, etc.)." ;
     :contributor <https://schema.org/docs/collab/MBZ> ;
-    rdfs:comment "Format of this release (the type of recording media used, i.e. compact disc, digital media, LP, etc.)." .
+    :domainIncludes :MusicRelease ;
+    :rangeIncludes :MusicReleaseFormatType .
 
 :musicalKey a rdf:Property ;
     rdfs:label "musicalKey" ;
-    :domainIncludes :MusicComposition ;
-    :rangeIncludes :Text ;
+    rdfs:comment "The key, mode, or scale this composition uses." ;
     :contributor <https://schema.org/docs/collab/MBZ> ;
-    rdfs:comment "The key, mode, or scale this composition uses." .
+    :domainIncludes :MusicComposition ;
+    :rangeIncludes :Text .
 
 :naics a rdf:Property ;
     rdfs:label "naics" ;
+    rdfs:comment "The North American Industry Classification System (NAICS) code for a particular organization or business person." ;
     :domainIncludes :Organization,
         :Person ;
-    :rangeIncludes :Text ;
-    rdfs:comment "The North American Industry Classification System (NAICS) code for a particular organization or business person." .
+    :rangeIncludes :Text .
 
 :name a rdf:Property ;
     rdfs:label "name" ;
-    :domainIncludes :Thing ;
-    :rangeIncludes :Text ;
     rdfs:comment "The name of the item." ;
     rdfs:subPropertyOf rdfs:label ;
-    owl:equivalentProperty dc:title .
+    owl:equivalentProperty dc:title ;
+    :domainIncludes :Thing ;
+    :rangeIncludes :Text .
 
 :namedPosition a rdf:Property ;
     rdfs:label "namedPosition" ;
+    rdfs:comment "A position played, performed or filled by a person or organization, as part of an organization. For example, an athlete in a SportsTeam might play in the position named 'Quarterback'." ;
     :domainIncludes :Role ;
     :rangeIncludes :Text,
         :URL ;
-    :supersededBy :roleName ;
-    rdfs:comment "A position played, performed or filled by a person or organization, as part of an organization. For example, an athlete in a SportsTeam might play in the position named 'Quarterback'." .
+    :supersededBy :roleName .
 
 :nationality a rdf:Property ;
     rdfs:label "nationality" ;
+    rdfs:comment "Nationality of the person." ;
     :domainIncludes :Person ;
-    :rangeIncludes :Country ;
-    rdfs:comment "Nationality of the person." .
+    :rangeIncludes :Country .
 
 :netWorth a rdf:Property ;
     rdfs:label "netWorth" ;
+    rdfs:comment "The total financial value of the person as calculated by subtracting assets from liabilities." ;
     :domainIncludes :Person ;
     :rangeIncludes :MonetaryAmount,
-        :PriceSpecification ;
-    rdfs:comment "The total financial value of the person as calculated by subtracting assets from liabilities." .
+        :PriceSpecification .
 
 :nextItem a rdf:Property ;
     rdfs:label "nextItem" ;
+    rdfs:comment "A link to the ListItem that follows the current one." ;
     :domainIncludes :ListItem ;
-    :rangeIncludes :ListItem ;
-    rdfs:comment "A link to the ListItem that follows the current one." .
+    :rangeIncludes :ListItem .
 
 :nonEqual a rdf:Property ;
     rdfs:label "nonEqual" ;
+    rdfs:comment "This ordering relation for qualitative values indicates that the subject is not equal to the object." ;
     :domainIncludes :QualitativeValue ;
-    :rangeIncludes :QualitativeValue ;
-    rdfs:comment "This ordering relation for qualitative values indicates that the subject is not equal to the object." .
+    :rangeIncludes :QualitativeValue .
 
 :numAdults a rdf:Property ;
     rdfs:label "numAdults" ;
+    rdfs:comment "The number of adults staying in the unit." ;
     :domainIncludes :LodgingReservation ;
     :rangeIncludes :Integer,
-        :QuantitativeValue ;
-    rdfs:comment "The number of adults staying in the unit." .
+        :QuantitativeValue .
 
 :numChildren a rdf:Property ;
     rdfs:label "numChildren" ;
+    rdfs:comment "The number of children staying in the unit." ;
     :domainIncludes :LodgingReservation ;
     :rangeIncludes :Integer,
-        :QuantitativeValue ;
-    rdfs:comment "The number of children staying in the unit." .
+        :QuantitativeValue .
 
 :numTracks a rdf:Property ;
     rdfs:label "numTracks" ;
+    rdfs:comment "The number of tracks in this album or playlist." ;
     :domainIncludes :MusicPlaylist ;
-    :rangeIncludes :Integer ;
-    rdfs:comment "The number of tracks in this album or playlist." .
+    :rangeIncludes :Integer .
 
 :numberOfAirbags a rdf:Property ;
     rdfs:label "numberOfAirbags" ;
+    rdfs:comment "The number or type of airbags in the vehicle." ;
+    :contributor <https://schema.org/docs/collab/Automotive_Ontology_Working_Group> ;
     :domainIncludes :Vehicle ;
     :rangeIncludes :Number,
-        :Text ;
-    :contributor <https://schema.org/docs/collab/Automotive_Ontology_Working_Group> ;
-    rdfs:comment "The number or type of airbags in the vehicle." .
+        :Text .
 
 :numberOfAxles a rdf:Property ;
     rdfs:label "numberOfAxles" ;
+    rdfs:comment "The number of axles.\\n\\nTypical unit code(s): C62." ;
+    :contributor <https://schema.org/docs/collab/Automotive_Ontology_Working_Group> ;
     :domainIncludes :Vehicle ;
     :rangeIncludes :Number,
-        :QuantitativeValue ;
-    :contributor <https://schema.org/docs/collab/Automotive_Ontology_Working_Group> ;
-    rdfs:comment "The number of axles.\\n\\nTypical unit code(s): C62." .
+        :QuantitativeValue .
 
 :numberOfBeds a rdf:Property ;
     rdfs:label "numberOfBeds" ;
-    :domainIncludes :BedDetails ;
-    :rangeIncludes :Number ;
+    rdfs:comment "The quantity of the given bed type available in the HotelRoom, Suite, House, or Apartment." ;
     :contributor <https://schema.org/docs/collab/STI_Accommodation_Ontology> ;
-    rdfs:comment "The quantity of the given bed type available in the HotelRoom, Suite, House, or Apartment." .
+    :domainIncludes :BedDetails ;
+    :rangeIncludes :Number .
 
 :numberOfDoors a rdf:Property ;
     rdfs:label "numberOfDoors" ;
+    rdfs:comment "The number of doors.\\n\\nTypical unit code(s): C62." ;
+    :contributor <https://schema.org/docs/collab/Automotive_Ontology_Working_Group> ;
     :domainIncludes :Vehicle ;
     :rangeIncludes :Number,
-        :QuantitativeValue ;
-    :contributor <https://schema.org/docs/collab/Automotive_Ontology_Working_Group> ;
-    rdfs:comment "The number of doors.\\n\\nTypical unit code(s): C62." .
+        :QuantitativeValue .
 
 :numberOfEmployees a rdf:Property ;
     rdfs:label "numberOfEmployees" ;
+    rdfs:comment "The number of employees in an organization, e.g. business." ;
     :domainIncludes :BusinessAudience,
         :Organization ;
-    :rangeIncludes :QuantitativeValue ;
-    rdfs:comment "The number of employees in an organization, e.g. business." .
+    :rangeIncludes :QuantitativeValue .
 
 :numberOfEpisodes a rdf:Property ;
     rdfs:label "numberOfEpisodes" ;
+    rdfs:comment "The number of episodes in this season or series." ;
     :domainIncludes :CreativeWorkSeason,
         :RadioSeries,
         :TVSeries,
         :VideoGameSeries ;
-    :rangeIncludes :Integer ;
-    rdfs:comment "The number of episodes in this season or series." .
+    :rangeIncludes :Integer .
 
 :numberOfForwardGears a rdf:Property ;
     rdfs:label "numberOfForwardGears" ;
+    rdfs:comment "The total number of forward gears available for the transmission system of the vehicle.\\n\\nTypical unit code(s): C62." ;
+    :contributor <https://schema.org/docs/collab/Automotive_Ontology_Working_Group> ;
     :domainIncludes :Vehicle ;
     :rangeIncludes :Number,
-        :QuantitativeValue ;
-    :contributor <https://schema.org/docs/collab/Automotive_Ontology_Working_Group> ;
-    rdfs:comment "The total number of forward gears available for the transmission system of the vehicle.\\n\\nTypical unit code(s): C62." .
+        :QuantitativeValue .
 
 :numberOfItems a rdf:Property ;
     rdfs:label "numberOfItems" ;
+    rdfs:comment "The number of items in an ItemList. Note that some descriptions might not fully describe all items in a list (e.g., multi-page pagination); in such cases, the numberOfItems would be for the entire list." ;
     :domainIncludes :ItemList ;
-    :rangeIncludes :Integer ;
-    rdfs:comment "The number of items in an ItemList. Note that some descriptions might not fully describe all items in a list (e.g., multi-page pagination); in such cases, the numberOfItems would be for the entire list." .
+    :rangeIncludes :Integer .
 
 :numberOfPages a rdf:Property ;
     rdfs:label "numberOfPages" ;
+    rdfs:comment "The number of pages in the book." ;
     :domainIncludes :Book ;
-    :rangeIncludes :Integer ;
-    rdfs:comment "The number of pages in the book." .
+    :rangeIncludes :Integer .
 
 :numberOfPlayers a rdf:Property ;
     rdfs:label "numberOfPlayers" ;
+    rdfs:comment "Indicate how many people can play this game (minimum, maximum, or range)." ;
     :domainIncludes :Game,
         :VideoGameSeries ;
-    :rangeIncludes :QuantitativeValue ;
-    rdfs:comment "Indicate how many people can play this game (minimum, maximum, or range)." .
+    :rangeIncludes :QuantitativeValue .
 
 :numberOfPreviousOwners a rdf:Property ;
     rdfs:label "numberOfPreviousOwners" ;
+    rdfs:comment "The number of owners of the vehicle, including the current one.\\n\\nTypical unit code(s): C62." ;
+    :contributor <https://schema.org/docs/collab/Automotive_Ontology_Working_Group> ;
     :domainIncludes :Vehicle ;
     :rangeIncludes :Number,
-        :QuantitativeValue ;
-    :contributor <https://schema.org/docs/collab/Automotive_Ontology_Working_Group> ;
-    rdfs:comment "The number of owners of the vehicle, including the current one.\\n\\nTypical unit code(s): C62." .
+        :QuantitativeValue .
 
 :numberOfRooms a rdf:Property ;
     rdfs:label "numberOfRooms" ;
+    rdfs:comment """The number of rooms (excluding bathrooms and closets) of the accommodation or lodging business.
+Typical unit code(s): ROM for room or C62 for no unit. The type of room can be put in the unitText property of the QuantitativeValue.""" ;
+    :contributor <https://schema.org/docs/collab/STI_Accommodation_Ontology> ;
     :domainIncludes :Accommodation,
         :Apartment,
         :House,
@@ -7270,641 +7280,644 @@ Typical unit code(s): MTK for square meter, FTK for square foot, or YDK for squa
         :SingleFamilyResidence,
         :Suite ;
     :rangeIncludes :Number,
-        :QuantitativeValue ;
-    :contributor <https://schema.org/docs/collab/STI_Accommodation_Ontology> ;
-    rdfs:comment """The number of rooms (excluding bathrooms and closets) of the accommodation or lodging business.
-Typical unit code(s): ROM for room or C62 for no unit. The type of room can be put in the unitText property of the QuantitativeValue.""" .
+        :QuantitativeValue .
 
 :numberOfSeasons a rdf:Property ;
     rdfs:label "numberOfSeasons" ;
+    rdfs:comment "The number of seasons in this series." ;
     :domainIncludes :RadioSeries,
         :TVSeries,
         :VideoGameSeries ;
-    :rangeIncludes :Integer ;
-    rdfs:comment "The number of seasons in this series." .
+    :rangeIncludes :Integer .
 
 :numberedPosition a rdf:Property ;
     rdfs:label "numberedPosition" ;
+    rdfs:comment "A number associated with a role in an organization, for example, the number on an athlete's jersey." ;
     :domainIncludes :OrganizationRole ;
-    :rangeIncludes :Number ;
-    rdfs:comment "A number associated with a role in an organization, for example, the number on an athlete's jersey." .
+    :rangeIncludes :Number .
 
 :nutrition a rdf:Property ;
     rdfs:label "nutrition" ;
+    rdfs:comment "Nutrition information about the recipe or menu item." ;
     :domainIncludes :MenuItem,
         :Recipe ;
-    :rangeIncludes :NutritionInformation ;
-    rdfs:comment "Nutrition information about the recipe or menu item." .
+    :rangeIncludes :NutritionInformation .
 
 :occupancy a rdf:Property ;
     rdfs:label "occupancy" ;
-    :domainIncludes :Apartment,
+    rdfs:comment """The allowed total occupancy for the accommodation in persons (including infants etc). For individual accommodations, this is not necessarily the legal maximum but defines the permitted usage as per the contractual agreement (e.g. a double room used by a single person).
+Typical unit code(s): C62 for person.""" ;
+    :contributor <https://schema.org/docs/collab/STI_Accommodation_Ontology> ;
+    :domainIncludes :Accommodation,
+        :Apartment,
         :HotelRoom,
         :SingleFamilyResidence,
-        :Suite, :Accommodation ;
-    :rangeIncludes :QuantitativeValue ;
-    :contributor <https://schema.org/docs/collab/STI_Accommodation_Ontology> ;
-    rdfs:comment """The allowed total occupancy for the accommodation in persons (including infants etc). For individual accommodations, this is not necessarily the legal maximum but defines the permitted usage as per the contractual agreement (e.g. a double room used by a single person).
-Typical unit code(s): C62 for person.""" .
+        :Suite ;
+    :rangeIncludes :QuantitativeValue .
 
 :occupationLocation a rdf:Property ;
     rdfs:label "occupationLocation" ;
+    rdfs:comment " The region/country for which this occupational description is appropriate. Note that educational requirements and qualifications can vary between jurisdictions." ;
     :domainIncludes :Occupation ;
     :rangeIncludes :AdministrativeArea ;
-    :source <https://github.com/schemaorg/schemaorg/issues/1698> ;
-    rdfs:comment " The region/country for which this occupational description is appropriate. Note that educational requirements and qualifications can vary between jurisdictions." .
+    :source <https://github.com/schemaorg/schemaorg/issues/1698> .
 
 :occupationalCategory a rdf:Property ;
     rdfs:label "occupationalCategory" ;
+    rdfs:comment """A category describing the job, preferably using a term from a taxonomy such as [BLS O*NET-SOC](http://www.onetcenter.org/taxonomy.html), [ISCO-08](https://www.ilo.org/public/english/bureau/stat/isco/isco08/) or similar, with the property repeated for each applicable value. Ideally the taxonomy should be identified, and both the textual label and formal code for the category should be provided.\\n
+Note: for historical reasons, any textual label and formal code provided as a literal may be assumed to be from O*NET-SOC.""" ;
     :domainIncludes :JobPosting,
         :Occupation ;
     :rangeIncludes :Text ;
-    :source <https://github.com/schemaorg/schemaorg/issues/1698> ;
-    rdfs:comment """A category describing the job, preferably using a term from a taxonomy such as [BLS O*NET-SOC](http://www.onetcenter.org/taxonomy.html), [ISCO-08](https://www.ilo.org/public/english/bureau/stat/isco/isco08/) or similar, with the property repeated for each applicable value. Ideally the taxonomy should be identified, and both the textual label and formal code for the category should be provided.\\n
-Note: for historical reasons, any textual label and formal code provided as a literal may be assumed to be from O*NET-SOC.""" .
+    :source <https://github.com/schemaorg/schemaorg/issues/1698> .
 
 :offerCount a rdf:Property ;
     rdfs:label "offerCount" ;
+    rdfs:comment "The number of offers for the product." ;
     :domainIncludes :AggregateOffer ;
-    :rangeIncludes :Integer ;
-    rdfs:comment "The number of offers for the product." .
+    :rangeIncludes :Integer .
 
 :openingHours a rdf:Property ;
     rdfs:label "openingHours" ;
+    rdfs:comment "The general opening hours for a business. Opening hours can be specified as a weekly time range, starting with days, then times per day. Multiple days can be listed with commas ',' separating each day. Day or time ranges are specified using a hyphen '-'.\\n\\n* Days are specified using the following two-letter combinations: ```Mo```, ```Tu```, ```We```, ```Th```, ```Fr```, ```Sa```, ```Su```.\\n* Times are specified using 24:00 format. For example, 3pm is specified as ```15:00```, 10am as ```10:00```. \\n* Here is an example: <code>&lt;time itemprop=\"openingHours\" datetime=&quot;Tu,Th 16:00-20:00&quot;&gt;Tuesdays and Thursdays 4-8pm&lt;/time&gt;</code>.\\n* If a business is open 7 days a week, then it can be specified as <code>&lt;time itemprop=&quot;openingHours&quot; datetime=&quot;Mo-Su&quot;&gt;Monday through Sunday, all day&lt;/time&gt;</code>." ;
     :domainIncludes :CivicStructure,
         :LocalBusiness ;
-    :rangeIncludes :Text ;
-    rdfs:comment "The general opening hours for a business. Opening hours can be specified as a weekly time range, starting with days, then times per day. Multiple days can be listed with commas ',' separating each day. Day or time ranges are specified using a hyphen '-'.\\n\\n* Days are specified using the following two-letter combinations: ```Mo```, ```Tu```, ```We```, ```Th```, ```Fr```, ```Sa```, ```Su```.\\n* Times are specified using 24:00 format. For example, 3pm is specified as ```15:00```, 10am as ```10:00```. \\n* Here is an example: <code>&lt;time itemprop=\"openingHours\" datetime=&quot;Tu,Th 16:00-20:00&quot;&gt;Tuesdays and Thursdays 4-8pm&lt;/time&gt;</code>.\\n* If a business is open 7 days a week, then it can be specified as <code>&lt;time itemprop=&quot;openingHours&quot; datetime=&quot;Mo-Su&quot;&gt;Monday through Sunday, all day&lt;/time&gt;</code>." .
+    :rangeIncludes :Text .
 
 :openingHoursSpecification a rdf:Property ;
     rdfs:label "openingHoursSpecification" ;
+    rdfs:comment "The opening hours of a certain place." ;
     :domainIncludes :Place ;
-    :rangeIncludes :OpeningHoursSpecification ;
-    rdfs:comment "The opening hours of a certain place." .
+    :rangeIncludes :OpeningHoursSpecification .
 
 :opens a rdf:Property ;
     rdfs:label "opens" ;
+    rdfs:comment "The opening hour of the place or service on the given day(s) of the week." ;
     :domainIncludes :OpeningHoursSpecification ;
-    :rangeIncludes :Time ;
-    rdfs:comment "The opening hour of the place or service on the given day(s) of the week." .
+    :rangeIncludes :Time .
 
 :operatingSystem a rdf:Property ;
     rdfs:label "operatingSystem" ;
+    rdfs:comment "Operating systems supported (Windows 7, OS X 10.6, Android 1.6)." ;
     :domainIncludes :SoftwareApplication ;
-    :rangeIncludes :Text ;
-    rdfs:comment "Operating systems supported (Windows 7, OS X 10.6, Android 1.6)." .
+    :rangeIncludes :Text .
 
 :opponent a rdf:Property ;
     rdfs:label "opponent" ;
-    :domainIncludes :ExerciseAction ;
-    :rangeIncludes :Person ;
     rdfs:comment "A sub property of participant. The opponent on this action." ;
-    rdfs:subPropertyOf :participant .
+    rdfs:subPropertyOf :participant ;
+    :domainIncludes :ExerciseAction ;
+    :rangeIncludes :Person .
 
 :option a rdf:Property ;
     rdfs:label "option" ;
+    rdfs:comment "A sub property of object. The options subject to this action." ;
+    rdfs:subPropertyOf :object ;
     :domainIncludes :ChooseAction ;
     :rangeIncludes :Text,
         :Thing ;
-    :supersededBy :actionOption ;
-    rdfs:comment "A sub property of object. The options subject to this action." ;
-    rdfs:subPropertyOf :object .
+    :supersededBy :actionOption .
 
 :orderDate a rdf:Property ;
     rdfs:label "orderDate" ;
+    rdfs:comment "Date order was placed." ;
     :domainIncludes :Order ;
     :rangeIncludes :Date,
-        :DateTime ;
-    rdfs:comment "Date order was placed." .
+        :DateTime .
 
 :orderDelivery a rdf:Property ;
     rdfs:label "orderDelivery" ;
+    rdfs:comment "The delivery of the parcel related to this order or order item." ;
     :domainIncludes :Order,
         :OrderItem ;
-    :rangeIncludes :ParcelDelivery ;
-    rdfs:comment "The delivery of the parcel related to this order or order item." .
+    :rangeIncludes :ParcelDelivery .
 
 :orderItemNumber a rdf:Property ;
     rdfs:label "orderItemNumber" ;
+    rdfs:comment "The identifier of the order item." ;
     :domainIncludes :OrderItem ;
-    :rangeIncludes :Text ;
-    rdfs:comment "The identifier of the order item." .
+    :rangeIncludes :Text .
 
 :orderItemStatus a rdf:Property ;
     rdfs:label "orderItemStatus" ;
+    rdfs:comment "The current status of the order item." ;
     :domainIncludes :OrderItem ;
-    :rangeIncludes :OrderStatus ;
-    rdfs:comment "The current status of the order item." .
+    :rangeIncludes :OrderStatus .
 
 :orderNumber a rdf:Property ;
     rdfs:label "orderNumber" ;
-    :domainIncludes :Order ;
-    :rangeIncludes :Text ;
     rdfs:comment "The identifier of the transaction." ;
-    rdfs:subPropertyOf :identifier .
+    rdfs:subPropertyOf :identifier ;
+    :domainIncludes :Order ;
+    :rangeIncludes :Text .
 
 :orderQuantity a rdf:Property ;
     rdfs:label "orderQuantity" ;
+    rdfs:comment "The number of the item ordered. If the property is not set, assume the quantity is one." ;
     :domainIncludes :OrderItem ;
     :rangeIncludes :Number,
-        :QuantitativeValue ;
-    rdfs:comment "The number of the item ordered. If the property is not set, assume the quantity is one." .
+        :QuantitativeValue .
 
 :orderStatus a rdf:Property ;
     rdfs:label "orderStatus" ;
+    rdfs:comment "The current status of the order." ;
     :domainIncludes :Order ;
-    :rangeIncludes :OrderStatus ;
-    rdfs:comment "The current status of the order." .
+    :rangeIncludes :OrderStatus .
 
 :orderedItem a rdf:Property ;
     rdfs:label "orderedItem" ;
+    rdfs:comment "The item ordered." ;
     :domainIncludes :Order,
         :OrderItem ;
     :rangeIncludes :OrderItem,
         :Product,
-        :Service ;
-    rdfs:comment "The item ordered." .
+        :Service .
 
 :organizer a rdf:Property ;
     rdfs:label "organizer" ;
+    rdfs:comment "An organizer of an Event." ;
     :domainIncludes :Event ;
     :rangeIncludes :Organization,
-        :Person ;
-    rdfs:comment "An organizer of an Event." .
+        :Person .
 
 :originAddress a rdf:Property ;
     rdfs:label "originAddress" ;
+    rdfs:comment "Shipper's address." ;
     :domainIncludes :ParcelDelivery ;
-    :rangeIncludes :PostalAddress ;
-    rdfs:comment "Shipper's address." .
+    :rangeIncludes :PostalAddress .
 
 :ownedFrom a rdf:Property ;
     rdfs:label "ownedFrom" ;
+    rdfs:comment "The date and time of obtaining the product." ;
     :domainIncludes :OwnershipInfo ;
-    :rangeIncludes :DateTime ;
-    rdfs:comment "The date and time of obtaining the product." .
+    :rangeIncludes :DateTime .
 
 :ownedThrough a rdf:Property ;
     rdfs:label "ownedThrough" ;
+    rdfs:comment "The date and time of giving up ownership on the product." ;
     :domainIncludes :OwnershipInfo ;
-    :rangeIncludes :DateTime ;
-    rdfs:comment "The date and time of giving up ownership on the product." .
+    :rangeIncludes :DateTime .
 
 :owns a rdf:Property ;
     rdfs:label "owns" ;
+    rdfs:comment "Products owned by the organization or person." ;
     :domainIncludes :Organization,
         :Person ;
     :rangeIncludes :OwnershipInfo,
-        :Product ;
-    rdfs:comment "Products owned by the organization or person." .
+        :Product .
 
 :pageEnd a rdf:Property ;
     rdfs:label "pageEnd" ;
+    rdfs:comment "The page on which the work ends; for example \"138\" or \"xvi\"." ;
+    owl:equivalentProperty <http://purl.org/ontology/bibo/pageEnd> ;
+    :contributor <https://schema.org/docs/collab/bibex> ;
     :domainIncludes :Article,
         :PublicationIssue,
         :PublicationVolume ;
     :rangeIncludes :Integer,
-        :Text ;
-    :contributor <https://schema.org/docs/collab/bibex> ;
-    rdfs:comment "The page on which the work ends; for example \"138\" or \"xvi\"." ;
-    owl:equivalentProperty <http://purl.org/ontology/bibo/pageEnd> .
+        :Text .
 
 :pageStart a rdf:Property ;
     rdfs:label "pageStart" ;
+    rdfs:comment "The page on which the work starts; for example \"135\" or \"xiii\"." ;
+    owl:equivalentProperty <http://purl.org/ontology/bibo/pageStart> ;
+    :contributor <https://schema.org/docs/collab/bibex> ;
     :domainIncludes :Article,
         :PublicationIssue,
         :PublicationVolume ;
     :rangeIncludes :Integer,
-        :Text ;
-    :contributor <https://schema.org/docs/collab/bibex> ;
-    rdfs:comment "The page on which the work starts; for example \"135\" or \"xiii\"." ;
-    owl:equivalentProperty <http://purl.org/ontology/bibo/pageStart> .
+        :Text .
 
 :pagination a rdf:Property ;
     rdfs:label "pagination" ;
+    rdfs:comment "Any description of pages that is not separated into pageStart and pageEnd; for example, \"1-6, 9, 55\" or \"10-12, 46-49\"." ;
+    owl:equivalentProperty <http://purl.org/ontology/bibo/pages> ;
+    :contributor <https://schema.org/docs/collab/bibex> ;
     :domainIncludes :Article,
         :PublicationIssue,
         :PublicationVolume ;
-    :rangeIncludes :Text ;
-    :contributor <https://schema.org/docs/collab/bibex> ;
-    rdfs:comment "Any description of pages that is not separated into pageStart and pageEnd; for example, \"1-6, 9, 55\" or \"10-12, 46-49\"." ;
-    owl:equivalentProperty <http://purl.org/ontology/bibo/pages> .
+    :rangeIncludes :Text .
 
 :parentItem a rdf:Property ;
     rdfs:label "parentItem" ;
-    :domainIncludes :Comment, :Question, :Answer ;
-    :rangeIncludes :CreativeWork, :Comment ;
-    rdfs:comment "The parent of a question, answer or item in general. Typically used for Q/A discussion threads e.g. a chain of comments with the first comment being an [[Article]] or other [[CreativeWork]]. See also [[comment]] which points from something to a comment about it." .
+    rdfs:comment "The parent of a question, answer or item in general. Typically used for Q/A discussion threads e.g. a chain of comments with the first comment being an [[Article]] or other [[CreativeWork]]. See also [[comment]] which points from something to a comment about it." ;
+    :domainIncludes :Answer,
+        :Comment,
+        :Question ;
+    :rangeIncludes :Comment,
+        :CreativeWork .
 
 :parentService a rdf:Property ;
     rdfs:label "parentService" ;
+    rdfs:comment "A broadcast service to which the broadcast service may belong to such as regional variations of a national channel." ;
     :domainIncludes :BroadcastService ;
-    :rangeIncludes :BroadcastService ;
-    rdfs:comment "A broadcast service to which the broadcast service may belong to such as regional variations of a national channel." .
+    :rangeIncludes :BroadcastService .
 
 :parents a rdf:Property ;
     rdfs:label "parents" ;
+    rdfs:comment "A parents of the person." ;
     :domainIncludes :Person ;
     :rangeIncludes :Person ;
-    :supersededBy :parent ;
-    rdfs:comment "A parents of the person." .
+    :supersededBy :parent .
 
 :partOfEpisode a rdf:Property ;
     rdfs:label "partOfEpisode" ;
-    :domainIncludes :Clip ;
-    :rangeIncludes :Episode ;
     rdfs:comment "The episode to which this clip belongs." ;
-    rdfs:subPropertyOf :isPartOf .
+    rdfs:subPropertyOf :isPartOf ;
+    :domainIncludes :Clip ;
+    :rangeIncludes :Episode .
 
 :partOfInvoice a rdf:Property ;
     rdfs:label "partOfInvoice" ;
+    rdfs:comment "The order is being paid as part of the referenced Invoice." ;
     :domainIncludes :Order ;
-    :rangeIncludes :Invoice ;
-    rdfs:comment "The order is being paid as part of the referenced Invoice." .
+    :rangeIncludes :Invoice .
 
 :partOfOrder a rdf:Property ;
     rdfs:label "partOfOrder" ;
+    rdfs:comment "The overall order the items in this delivery were included in." ;
     :domainIncludes :ParcelDelivery ;
-    :rangeIncludes :Order ;
-    rdfs:comment "The overall order the items in this delivery were included in." .
+    :rangeIncludes :Order .
 
 :partOfSeason a rdf:Property ;
     rdfs:label "partOfSeason" ;
+    rdfs:comment "The season to which this episode belongs." ;
+    rdfs:subPropertyOf :isPartOf ;
     :domainIncludes :Clip,
         :Episode ;
-    :rangeIncludes :CreativeWorkSeason ;
-    rdfs:comment "The season to which this episode belongs." ;
-    rdfs:subPropertyOf :isPartOf .
+    :rangeIncludes :CreativeWorkSeason .
 
 :partOfTVSeries a rdf:Property ;
     rdfs:label "partOfTVSeries" ;
+    rdfs:comment "The TV series to which this episode or season belongs." ;
+    rdfs:subPropertyOf :isPartOf ;
     :domainIncludes :TVClip,
         :TVEpisode,
         :TVSeason ;
     :rangeIncludes :TVSeries ;
-    :supersededBy :partOfSeries ;
-    rdfs:comment "The TV series to which this episode or season belongs." ;
-    rdfs:subPropertyOf :isPartOf .
+    :supersededBy :partOfSeries .
 
 :partySize a rdf:Property ;
     rdfs:label "partySize" ;
+    rdfs:comment "Number of people the reservation should accommodate." ;
     :domainIncludes :FoodEstablishmentReservation,
         :TaxiReservation ;
     :rangeIncludes :Integer,
-        :QuantitativeValue ;
-    rdfs:comment "Number of people the reservation should accommodate." .
+        :QuantitativeValue .
 
 :passengerPriorityStatus a rdf:Property ;
     rdfs:label "passengerPriorityStatus" ;
+    rdfs:comment "The priority status assigned to a passenger for security or boarding (e.g. FastTrack or Priority)." ;
     :domainIncludes :FlightReservation ;
     :rangeIncludes :QualitativeValue,
-        :Text ;
-    rdfs:comment "The priority status assigned to a passenger for security or boarding (e.g. FastTrack or Priority)." .
+        :Text .
 
 :passengerSequenceNumber a rdf:Property ;
     rdfs:label "passengerSequenceNumber" ;
+    rdfs:comment "The passenger's sequence number as assigned by the airline." ;
     :domainIncludes :FlightReservation ;
-    :rangeIncludes :Text ;
-    rdfs:comment "The passenger's sequence number as assigned by the airline." .
+    :rangeIncludes :Text .
 
 :paymentAccepted a rdf:Property ;
     rdfs:label "paymentAccepted" ;
+    rdfs:comment "Cash, Credit Card, Cryptocurrency, Local Exchange Tradings System, etc." ;
     :domainIncludes :LocalBusiness ;
-    :rangeIncludes :Text ;
-    rdfs:comment "Cash, Credit Card, Cryptocurrency, Local Exchange Tradings System, etc." .
+    :rangeIncludes :Text .
 
 :paymentDue a rdf:Property ;
     rdfs:label "paymentDue" ;
+    rdfs:comment "The date that payment is due." ;
     :domainIncludes :Invoice,
         :Order ;
     :rangeIncludes :DateTime ;
-    :supersededBy :paymentDueDate ;
-    rdfs:comment "The date that payment is due." .
+    :supersededBy :paymentDueDate .
 
 :paymentMethod a rdf:Property ;
     rdfs:label "paymentMethod" ;
+    rdfs:comment "The name of the credit card or other method of payment for the order." ;
     :domainIncludes :Invoice,
         :Order ;
-    :rangeIncludes :PaymentMethod, :Text ;
-    :source <https://github.com/schemaorg/schemaorg/issues/3537> ;
-    rdfs:comment "The name of the credit card or other method of payment for the order." .
+    :rangeIncludes :PaymentMethod,
+        :Text ;
+    :source <https://github.com/schemaorg/schemaorg/issues/3537> .
 
 :paymentMethodId a rdf:Property ;
     rdfs:label "paymentMethodId" ;
+    rdfs:comment "An identifier for the method of payment used (e.g. the last 4 digits of the credit card)." ;
     :domainIncludes :Invoice,
         :Order ;
-    :rangeIncludes :Text ;
-    rdfs:comment "An identifier for the method of payment used (e.g. the last 4 digits of the credit card)." .
+    :rangeIncludes :Text .
 
 :paymentStatus a rdf:Property ;
     rdfs:label "paymentStatus" ;
+    rdfs:comment "The status of payment; whether the invoice has been paid or not." ;
     :domainIncludes :Invoice ;
     :rangeIncludes :PaymentStatusType,
-        :Text ;
-    rdfs:comment "The status of payment; whether the invoice has been paid or not." .
+        :Text .
 
 :paymentUrl a rdf:Property ;
     rdfs:label "paymentUrl" ;
+    rdfs:comment "The URL for sending a payment." ;
     :domainIncludes :Order ;
-    :rangeIncludes :URL ;
-    rdfs:comment "The URL for sending a payment." .
+    :rangeIncludes :URL .
 
 :percentile10 a rdf:Property ;
     rdfs:label "percentile10" ;
+    rdfs:comment "The 10th percentile value." ;
     :domainIncludes :QuantitativeValueDistribution ;
     :rangeIncludes :Number ;
-    :source <https://github.com/schemaorg/schemaorg/issues/1698> ;
-    rdfs:comment "The 10th percentile value." .
+    :source <https://github.com/schemaorg/schemaorg/issues/1698> .
 
 :percentile25 a rdf:Property ;
     rdfs:label "percentile25" ;
+    rdfs:comment "The 25th percentile value." ;
     :domainIncludes :QuantitativeValueDistribution ;
     :rangeIncludes :Number ;
-    :source <https://github.com/schemaorg/schemaorg/issues/1698> ;
-    rdfs:comment "The 25th percentile value." .
+    :source <https://github.com/schemaorg/schemaorg/issues/1698> .
 
 :percentile75 a rdf:Property ;
     rdfs:label "percentile75" ;
+    rdfs:comment "The 75th percentile value." ;
     :domainIncludes :QuantitativeValueDistribution ;
     :rangeIncludes :Number ;
-    :source <https://github.com/schemaorg/schemaorg/issues/1698> ;
-    rdfs:comment "The 75th percentile value." .
+    :source <https://github.com/schemaorg/schemaorg/issues/1698> .
 
 :percentile90 a rdf:Property ;
     rdfs:label "percentile90" ;
+    rdfs:comment "The 90th percentile value." ;
     :domainIncludes :QuantitativeValueDistribution ;
     :rangeIncludes :Number ;
-    :source <https://github.com/schemaorg/schemaorg/issues/1698> ;
-    rdfs:comment "The 90th percentile value." .
+    :source <https://github.com/schemaorg/schemaorg/issues/1698> .
 
 :performerIn a rdf:Property ;
     rdfs:label "performerIn" ;
+    rdfs:comment "Event that this person is a performer or participant in." ;
     :domainIncludes :Person ;
-    :rangeIncludes :Event ;
-    rdfs:comment "Event that this person is a performer or participant in." .
+    :rangeIncludes :Event .
 
 :performers a rdf:Property ;
     rdfs:label "performers" ;
+    rdfs:comment "The main performer or performers of the event&#x2014;for example, a presenter, musician, or actor." ;
     :domainIncludes :Event ;
     :rangeIncludes :Organization,
         :Person ;
-    :supersededBy :performer ;
-    rdfs:comment "The main performer or performers of the event&#x2014;for example, a presenter, musician, or actor." .
+    :supersededBy :performer .
 
 :permissionType a rdf:Property ;
     rdfs:label "permissionType" ;
+    rdfs:comment "The type of permission granted the person, organization, or audience." ;
     :domainIncludes :DigitalDocumentPermission ;
-    :rangeIncludes :DigitalDocumentPermissionType ;
-    rdfs:comment "The type of permission granted the person, organization, or audience." .
+    :rangeIncludes :DigitalDocumentPermissionType .
 
 :permissions a rdf:Property ;
     rdfs:label "permissions" ;
+    rdfs:comment "Permission(s) required to run the app (for example, a mobile app may require full internet access or may run only on wifi)." ;
     :domainIncludes :SoftwareApplication ;
-    :rangeIncludes :Text ;
-    rdfs:comment "Permission(s) required to run the app (for example, a mobile app may require full internet access or may run only on wifi)." .
+    :rangeIncludes :Text .
 
 :permitAudience a rdf:Property ;
     rdfs:label "permitAudience" ;
+    rdfs:comment "The target audience for this permit." ;
     :domainIncludes :Permit ;
-    :rangeIncludes :Audience ;
-    rdfs:comment "The target audience for this permit." .
+    :rangeIncludes :Audience .
 
 :permittedUsage a rdf:Property ;
     rdfs:label "permittedUsage" ;
-    :domainIncludes :Accommodation ;
-    :rangeIncludes :Text ;
+    rdfs:comment "Indications regarding the permitted usage of the accommodation." ;
     :contributor <https://schema.org/docs/collab/STI_Accommodation_Ontology> ;
-    rdfs:comment "Indications regarding the permitted usage of the accommodation." .
+    :domainIncludes :Accommodation ;
+    :rangeIncludes :Text .
 
 :petsAllowed a rdf:Property ;
     rdfs:label "petsAllowed" ;
+    rdfs:comment "Indicates whether pets are allowed to enter the accommodation or lodging business. More detailed information can be put in a text value." ;
+    :contributor <https://schema.org/docs/collab/STI_Accommodation_Ontology> ;
     :domainIncludes :Accommodation,
         :LodgingBusiness ;
     :rangeIncludes :Boolean,
-        :Text ;
-    :contributor <https://schema.org/docs/collab/STI_Accommodation_Ontology> ;
-    rdfs:comment "Indicates whether pets are allowed to enter the accommodation or lodging business. More detailed information can be put in a text value." .
+        :Text .
 
 :photos a rdf:Property ;
     rdfs:label "photos" ;
+    rdfs:comment "Photographs of this place." ;
     :domainIncludes :Place ;
     :rangeIncludes :ImageObject,
         :Photograph ;
-    :supersededBy :photo ;
-    rdfs:comment "Photographs of this place." .
+    :supersededBy :photo .
 
 :pickupLocation a rdf:Property ;
     rdfs:label "pickupLocation" ;
+    rdfs:comment "Where a taxi will pick up a passenger or a rental car can be picked up." ;
     :domainIncludes :RentalCarReservation,
         :TaxiReservation ;
-    :rangeIncludes :Place ;
-    rdfs:comment "Where a taxi will pick up a passenger or a rental car can be picked up." .
+    :rangeIncludes :Place .
 
 :pickupTime a rdf:Property ;
     rdfs:label "pickupTime" ;
+    rdfs:comment "When a taxi will pick up a passenger or a rental car can be picked up." ;
     :domainIncludes :RentalCarReservation,
         :TaxiReservation ;
-    :rangeIncludes :DateTime ;
-    rdfs:comment "When a taxi will pick up a passenger or a rental car can be picked up." .
+    :rangeIncludes :DateTime .
 
 :playMode a rdf:Property ;
     rdfs:label "playMode" ;
+    rdfs:comment "Indicates whether this game is multi-player, co-op or single-player.  The game can be marked as multi-player, co-op and single-player at the same time." ;
     :domainIncludes :VideoGame,
         :VideoGameSeries ;
-    :rangeIncludes :GamePlayMode ;
-    rdfs:comment "Indicates whether this game is multi-player, co-op or single-player.  The game can be marked as multi-player, co-op and single-player at the same time." .
+    :rangeIncludes :GamePlayMode .
 
 :playerType a rdf:Property ;
     rdfs:label "playerType" ;
+    rdfs:comment "Player type required&#x2014;for example, Flash or Silverlight." ;
     :domainIncludes :MediaObject ;
-    :rangeIncludes :Text ;
-    rdfs:comment "Player type required&#x2014;for example, Flash or Silverlight." .
+    :rangeIncludes :Text .
 
 :playersOnline a rdf:Property ;
     rdfs:label "playersOnline" ;
+    rdfs:comment "Number of players on the server." ;
     :domainIncludes :GameServer ;
-    :rangeIncludes :Integer ;
-    rdfs:comment "Number of players on the server." .
+    :rangeIncludes :Integer .
 
 :polygon a rdf:Property ;
     rdfs:label "polygon" ;
+    rdfs:comment "A polygon is the area enclosed by a point-to-point path for which the starting and ending points are the same. A polygon is expressed as a series of four or more space delimited points where the first and final points are identical." ;
     :domainIncludes :GeoShape ;
-    :rangeIncludes :Text ;
-    rdfs:comment "A polygon is the area enclosed by a point-to-point path for which the starting and ending points are the same. A polygon is expressed as a series of four or more space delimited points where the first and final points are identical." .
+    :rangeIncludes :Text .
 
 :postOfficeBoxNumber a rdf:Property ;
     rdfs:label "postOfficeBoxNumber" ;
+    rdfs:comment "The post office box number for PO box addresses." ;
     :domainIncludes :PostalAddress ;
-    :rangeIncludes :Text ;
-    rdfs:comment "The post office box number for PO box addresses." .
+    :rangeIncludes :Text .
 
 :postalCode a rdf:Property ;
     rdfs:label "postalCode" ;
+    rdfs:comment "The postal code. For example, 94043." ;
     :domainIncludes :GeoCoordinates,
         :GeoShape,
         :PostalAddress ;
-    :rangeIncludes :Text ;
-    rdfs:comment "The postal code. For example, 94043." .
+    :rangeIncludes :Text .
 
 :potentialAction a rdf:Property ;
     rdfs:label "potentialAction" ;
+    rdfs:comment "Indicates a potential Action, which describes an idealized action in which this thing would play an 'object' role." ;
     :domainIncludes :Thing ;
-    :rangeIncludes :Action ;
-    rdfs:comment "Indicates a potential Action, which describes an idealized action in which this thing would play an 'object' role." .
+    :rangeIncludes :Action .
 
 :predecessorOf a rdf:Property ;
     rdfs:label "predecessorOf" ;
+    rdfs:comment "A pointer from a previous, often discontinued variant of the product to its newer variant." ;
     :domainIncludes :ProductModel ;
-    :rangeIncludes :ProductModel ;
-    rdfs:comment "A pointer from a previous, often discontinued variant of the product to its newer variant." .
+    :rangeIncludes :ProductModel .
 
 :prepTime a rdf:Property ;
     rdfs:label "prepTime" ;
+    rdfs:comment "The length of time it takes to prepare the items to be used in instructions or a direction, in [ISO 8601 duration format](http://en.wikipedia.org/wiki/ISO_8601)." ;
     :domainIncludes :HowTo,
         :HowToDirection ;
-    :rangeIncludes :Duration ;
-    rdfs:comment "The length of time it takes to prepare the items to be used in instructions or a direction, in [ISO 8601 duration format](http://en.wikipedia.org/wiki/ISO_8601)." .
+    :rangeIncludes :Duration .
 
 :previousItem a rdf:Property ;
     rdfs:label "previousItem" ;
+    rdfs:comment "A link to the ListItem that precedes the current one." ;
     :domainIncludes :ListItem ;
-    :rangeIncludes :ListItem ;
-    rdfs:comment "A link to the ListItem that precedes the current one." .
+    :rangeIncludes :ListItem .
 
 :previousStartDate a rdf:Property ;
     rdfs:label "previousStartDate" ;
+    rdfs:comment "Used in conjunction with eventStatus for rescheduled or cancelled events. This property contains the previously scheduled start date. For rescheduled events, the startDate property should be used for the newly scheduled start date. In the (rare) case of an event that has been postponed and rescheduled multiple times, this field may be repeated." ;
     :domainIncludes :Event ;
-    :rangeIncludes :Date ;
-    rdfs:comment "Used in conjunction with eventStatus for rescheduled or cancelled events. This property contains the previously scheduled start date. For rescheduled events, the startDate property should be used for the newly scheduled start date. In the (rare) case of an event that has been postponed and rescheduled multiple times, this field may be repeated." .
+    :rangeIncludes :Date .
 
 :price a rdf:Property ;
     rdfs:label "price" ;
+    rdfs:comment """The offer price of a product, or of a price component when attached to PriceSpecification and its subtypes.\\n\\nUsage guidelines:\\n\\n* Use the [[priceCurrency]] property (with standard formats: [ISO 4217 currency format](http://en.wikipedia.org/wiki/ISO_4217), e.g. "USD"; [Ticker symbol](https://en.wikipedia.org/wiki/List_of_cryptocurrencies) for cryptocurrencies, e.g. "BTC"; well known names for [Local Exchange Trading Systems](https://en.wikipedia.org/wiki/Local_exchange_trading_system) (LETS) and other currency types, e.g. "Ithaca HOUR") instead of including [ambiguous symbols](http://en.wikipedia.org/wiki/Dollar_sign#Currencies_that_use_the_dollar_or_peso_sign) such as '$' in the value.\\n* Use '.' (Unicode 'FULL STOP' (U+002E)) rather than ',' to indicate a decimal point. Avoid using these symbols as a readability separator.\\n* Note that both [RDFa](http://www.w3.org/TR/xhtml-rdfa-primer/#using-the-content-attribute) and Microdata syntax allow the use of a "content=" attribute for publishing simple machine-readable values alongside more human-friendly formatting.\\n* Use values from 0123456789 (Unicode 'DIGIT ZERO' (U+0030) to 'DIGIT NINE' (U+0039)) rather than superficially similar Unicode symbols.
+      """ ;
     :domainIncludes :DonateAction,
         :Offer,
         :PriceSpecification,
         :TradeAction ;
     :rangeIncludes :Number,
-        :Text ;
-    rdfs:comment """The offer price of a product, or of a price component when attached to PriceSpecification and its subtypes.\\n\\nUsage guidelines:\\n\\n* Use the [[priceCurrency]] property (with standard formats: [ISO 4217 currency format](http://en.wikipedia.org/wiki/ISO_4217), e.g. "USD"; [Ticker symbol](https://en.wikipedia.org/wiki/List_of_cryptocurrencies) for cryptocurrencies, e.g. "BTC"; well known names for [Local Exchange Trading Systems](https://en.wikipedia.org/wiki/Local_exchange_trading_system) (LETS) and other currency types, e.g. "Ithaca HOUR") instead of including [ambiguous symbols](http://en.wikipedia.org/wiki/Dollar_sign#Currencies_that_use_the_dollar_or_peso_sign) such as '$' in the value.\\n* Use '.' (Unicode 'FULL STOP' (U+002E)) rather than ',' to indicate a decimal point. Avoid using these symbols as a readability separator.\\n* Note that both [RDFa](http://www.w3.org/TR/xhtml-rdfa-primer/#using-the-content-attribute) and Microdata syntax allow the use of a "content=" attribute for publishing simple machine-readable values alongside more human-friendly formatting.\\n* Use values from 0123456789 (Unicode 'DIGIT ZERO' (U+0030) to 'DIGIT NINE' (U+0039)) rather than superficially similar Unicode symbols.
-      """ .
+        :Text .
 
 :priceComponent a rdf:Property ;
     rdfs:label "priceComponent" ;
-    :domainIncludes :CompoundPriceSpecification ;
-    :rangeIncludes :UnitPriceSpecification ;
+    rdfs:comment "This property links to all [[UnitPriceSpecification]] nodes that apply in parallel for the [[CompoundPriceSpecification]] node." ;
     :contributor <https://schema.org/docs/collab/GoodRelationsTerms> ;
-    rdfs:comment "This property links to all [[UnitPriceSpecification]] nodes that apply in parallel for the [[CompoundPriceSpecification]] node." .
+    :domainIncludes :CompoundPriceSpecification ;
+    :rangeIncludes :UnitPriceSpecification .
 
 :priceCurrency a rdf:Property ;
     rdfs:label "priceCurrency" ;
-    :domainIncludes  :DonateAction,
+    rdfs:comment "The currency of the price, or a price component when attached to [[PriceSpecification]] and its subtypes.\\n\\nUse standard formats: [ISO 4217 currency format](http://en.wikipedia.org/wiki/ISO_4217), e.g. \"USD\"; [Ticker symbol](https://en.wikipedia.org/wiki/List_of_cryptocurrencies) for cryptocurrencies, e.g. \"BTC\"; well known names for [Local Exchange Trading Systems](https://en.wikipedia.org/wiki/Local_exchange_trading_system) (LETS) and other currency types, e.g. \"Ithaca HOUR\"." ;
+    :domainIncludes :DonateAction,
         :Offer,
         :PriceSpecification,
         :Reservation,
         :Ticket,
         :TradeAction ;
-    :rangeIncludes :Text ;
-    rdfs:comment "The currency of the price, or a price component when attached to [[PriceSpecification]] and its subtypes.\\n\\nUse standard formats: [ISO 4217 currency format](http://en.wikipedia.org/wiki/ISO_4217), e.g. \"USD\"; [Ticker symbol](https://en.wikipedia.org/wiki/List_of_cryptocurrencies) for cryptocurrencies, e.g. \"BTC\"; well known names for [Local Exchange Trading Systems](https://en.wikipedia.org/wiki/Local_exchange_trading_system) (LETS) and other currency types, e.g. \"Ithaca HOUR\"." .
+    :rangeIncludes :Text .
 
 :priceRange a rdf:Property ;
     rdfs:label "priceRange" ;
+    rdfs:comment "The price range of the business, for example ```$$$```." ;
     :domainIncludes :LocalBusiness ;
-    :rangeIncludes :Text ;
-    rdfs:comment "The price range of the business, for example ```$$$```." .
+    :rangeIncludes :Text .
 
 :priceSpecification a rdf:Property ;
     rdfs:label "priceSpecification" ;
+    rdfs:comment "One or more detailed price specifications, indicating the unit price and delivery or payment charges." ;
     :domainIncludes :Demand,
         :DonateAction,
         :Offer,
         :TradeAction ;
-    :rangeIncludes :PriceSpecification ;
-    rdfs:comment "One or more detailed price specifications, indicating the unit price and delivery or payment charges." .
+    :rangeIncludes :PriceSpecification .
 
 :priceType a rdf:Property ;
     rdfs:label "priceType" ;
+    rdfs:comment "Defines the type of a price specified for an offered product, for example a list price, a (temporary) sale price or a manufacturer suggested retail price. If multiple prices are specified for an offer the [[priceType]] property can be used to identify the type of each such specified price. The value of priceType can be specified as a value from enumeration PriceTypeEnumeration or as a free form text string for price types that are not already predefined in PriceTypeEnumeration." ;
     :domainIncludes :UnitPriceSpecification ;
-    :rangeIncludes :Text ;
-    rdfs:comment "Defines the type of a price specified for an offered product, for example a list price, a (temporary) sale price or a manufacturer suggested retail price. If multiple prices are specified for an offer the [[priceType]] property can be used to identify the type of each such specified price. The value of priceType can be specified as a value from enumeration PriceTypeEnumeration or as a free form text string for price types that are not already predefined in PriceTypeEnumeration." .
+    :rangeIncludes :Text .
 
 :priceValidUntil a rdf:Property ;
     rdfs:label "priceValidUntil" ;
+    rdfs:comment "The date after which the price is no longer available." ;
     :domainIncludes :Offer ;
-    :rangeIncludes :Date ;
-    rdfs:comment "The date after which the price is no longer available." .
+    :rangeIncludes :Date .
 
 :primaryImageOfPage a rdf:Property ;
     rdfs:label "primaryImageOfPage" ;
+    rdfs:comment "Indicates the main image on the page." ;
     :domainIncludes :WebPage ;
-    :rangeIncludes :ImageObject ;
-    rdfs:comment "Indicates the main image on the page." .
+    :rangeIncludes :ImageObject .
 
 :printColumn a rdf:Property ;
     rdfs:label "printColumn" ;
+    rdfs:comment "The number of the column in which the NewsArticle appears in the print edition." ;
     :domainIncludes :NewsArticle ;
-    :rangeIncludes :Text ;
-    rdfs:comment "The number of the column in which the NewsArticle appears in the print edition." .
+    :rangeIncludes :Text .
 
 :printEdition a rdf:Property ;
     rdfs:label "printEdition" ;
+    rdfs:comment "The edition of the print product in which the NewsArticle appears." ;
     :domainIncludes :NewsArticle ;
-    :rangeIncludes :Text ;
-    rdfs:comment "The edition of the print product in which the NewsArticle appears." .
+    :rangeIncludes :Text .
 
 :printPage a rdf:Property ;
     rdfs:label "printPage" ;
+    rdfs:comment "If this NewsArticle appears in print, this field indicates the name of the page on which the article is found. Please note that this field is intended for the exact page name (e.g. A5, B18)." ;
     :domainIncludes :NewsArticle ;
-    :rangeIncludes :Text ;
-    rdfs:comment "If this NewsArticle appears in print, this field indicates the name of the page on which the article is found. Please note that this field is intended for the exact page name (e.g. A5, B18)." .
+    :rangeIncludes :Text .
 
 :printSection a rdf:Property ;
     rdfs:label "printSection" ;
+    rdfs:comment "If this NewsArticle appears in print, this field indicates the print section in which the article appeared." ;
     :domainIncludes :NewsArticle ;
-    :rangeIncludes :Text ;
-    rdfs:comment "If this NewsArticle appears in print, this field indicates the print section in which the article appeared." .
+    :rangeIncludes :Text .
 
 :processingTime a rdf:Property ;
     rdfs:label "processingTime" ;
+    rdfs:comment "Estimated processing time for the service using this channel." ;
     :domainIncludes :ServiceChannel ;
-    :rangeIncludes :Duration ;
-    rdfs:comment "Estimated processing time for the service using this channel." .
+    :rangeIncludes :Duration .
 
 :processorRequirements a rdf:Property ;
     rdfs:label "processorRequirements" ;
+    rdfs:comment "Processor architecture required to run the application (e.g. IA64)." ;
     :domainIncludes :SoftwareApplication ;
-    :rangeIncludes :Text ;
-    rdfs:comment "Processor architecture required to run the application (e.g. IA64)." .
+    :rangeIncludes :Text .
 
 :producer a rdf:Property ;
     rdfs:label "producer" ;
+    rdfs:comment "The person or organization who produced the work (e.g. music album, movie, TV/radio series etc.)." ;
     :domainIncludes :CreativeWork ;
     :rangeIncludes :Organization,
-        :Person ;
-    rdfs:comment "The person or organization who produced the work (e.g. music album, movie, TV/radio series etc.)." .
+        :Person .
 
 :produces a rdf:Property ;
     rdfs:label "produces" ;
+    rdfs:comment "The tangible thing generated by the service, e.g. a passport, permit, etc." ;
     :domainIncludes :Service ;
     :rangeIncludes :Thing ;
-    :supersededBy :serviceOutput ;
-    rdfs:comment "The tangible thing generated by the service, e.g. a passport, permit, etc." .
+    :supersededBy :serviceOutput .
 
 :productID a rdf:Property ;
     rdfs:label "productID" ;
-    :domainIncludes :Product ;
-    :rangeIncludes :Text ;
     rdfs:comment "The product identifier, such as ISBN. For example: ``` meta itemprop=\"productID\" content=\"isbn:123-456-789\" ```." ;
-    rdfs:subPropertyOf :identifier .
+    rdfs:subPropertyOf :identifier ;
+    :domainIncludes :Product ;
+    :rangeIncludes :Text .
 
 :productSupported a rdf:Property ;
     rdfs:label "productSupported" ;
+    rdfs:comment "The product or service this support contact point is related to (such as product support for a particular product line). This can be a specific product or product line (e.g. \"iPhone\") or a general category of products or services (e.g. \"smartphones\")." ;
     :domainIncludes :ContactPoint ;
     :rangeIncludes :Product,
-        :Text ;
-    rdfs:comment "The product or service this support contact point is related to (such as product support for a particular product line). This can be a specific product or product line (e.g. \"iPhone\") or a general category of products or services (e.g. \"smartphones\")." .
+        :Text .
 
 :productionCompany a rdf:Property ;
     rdfs:label "productionCompany" ;
+    rdfs:comment "The production company or studio responsible for the item, e.g. series, video game, episode etc." ;
     :domainIncludes :CreativeWorkSeason,
         :Episode,
         :MediaObject,
@@ -7913,772 +7926,768 @@ Note: for historical reasons, any textual label and formal code provided as a li
         :RadioSeries,
         :TVSeries,
         :VideoGameSeries ;
-    :rangeIncludes :Organization ;
-    rdfs:comment "The production company or studio responsible for the item, e.g. series, video game, episode etc." .
+    :rangeIncludes :Organization .
 
 :productionDate a rdf:Property ;
     rdfs:label "productionDate" ;
+    rdfs:comment "The date of production of the item, e.g. vehicle." ;
+    :contributor <https://schema.org/docs/collab/Automotive_Ontology_Working_Group> ;
     :domainIncludes :Product,
         :Vehicle ;
-    :rangeIncludes :Date ;
-    :contributor <https://schema.org/docs/collab/Automotive_Ontology_Working_Group> ;
-    rdfs:comment "The date of production of the item, e.g. vehicle." .
+    :rangeIncludes :Date .
 
 :proficiencyLevel a rdf:Property ;
     rdfs:label "proficiencyLevel" ;
+    rdfs:comment "Proficiency needed for this content; expected values: 'Beginner', 'Expert'." ;
     :domainIncludes :TechArticle ;
-    :rangeIncludes :Text ;
-    rdfs:comment "Proficiency needed for this content; expected values: 'Beginner', 'Expert'." .
+    :rangeIncludes :Text .
 
 :programMembershipUsed a rdf:Property ;
     rdfs:label "programMembershipUsed" ;
+    rdfs:comment "Any membership in a frequent flyer, hotel loyalty program, etc. being applied to the reservation." ;
     :domainIncludes :Reservation ;
-    :rangeIncludes :ProgramMembership ;
-    rdfs:comment "Any membership in a frequent flyer, hotel loyalty program, etc. being applied to the reservation." .
+    :rangeIncludes :ProgramMembership .
 
 :programName a rdf:Property ;
     rdfs:label "programName" ;
+    rdfs:comment "The program providing the membership. It is preferable to use [:program](https://schema.org/program) instead." ;
     :domainIncludes :ProgramMembership ;
-    :rangeIncludes :Text ;
-    rdfs:comment "The program providing the membership. It is preferable to use [:program](https://schema.org/program) instead." .
+    :rangeIncludes :Text .
 
 :programmingLanguage a rdf:Property ;
     rdfs:label "programmingLanguage" ;
+    rdfs:comment "The computer programming language." ;
     :domainIncludes :SoftwareSourceCode ;
     :rangeIncludes :ComputerLanguage,
-        :Text ;
-    rdfs:comment "The computer programming language." .
+        :Text .
 
 :programmingModel a rdf:Property ;
     rdfs:label "programmingModel" ;
+    rdfs:comment "Indicates whether API is managed or unmanaged." ;
     :domainIncludes :APIReference ;
-    :rangeIncludes :Text ;
-    rdfs:comment "Indicates whether API is managed or unmanaged." .
+    :rangeIncludes :Text .
 
 :propertyID a rdf:Property ;
     rdfs:label "propertyID" ;
-    :domainIncludes :PropertyValue ;
-    :rangeIncludes :Text,
-        :URL ;
     rdfs:comment """A commonly used identifier for the characteristic represented by the property, e.g. a manufacturer or a standard code for a property. propertyID can be
 (1) a prefixed string, mainly meant to be used with standards for product properties; (2) a site-specific, non-prefixed string (e.g. the primary key of the property or the vendor-specific ID of the property), or (3)
 a URL indicating the type of the property, either pointing to an external vocabulary, or a Web resource that describes the property (e.g. a glossary entry).
-Standards bodies should promote a standard prefix for the identifiers of properties from their standards.""" .
+Standards bodies should promote a standard prefix for the identifiers of properties from their standards.""" ;
+    :domainIncludes :PropertyValue ;
+    :rangeIncludes :Text,
+        :URL .
 
 :proteinContent a rdf:Property ;
     rdfs:label "proteinContent" ;
+    rdfs:comment "The number of grams of protein." ;
     :domainIncludes :NutritionInformation ;
-    :rangeIncludes :Mass ;
-    rdfs:comment "The number of grams of protein." .
+    :rangeIncludes :Mass .
 
 :providerMobility a rdf:Property ;
     rdfs:label "providerMobility" ;
+    rdfs:comment "Indicates the mobility of a provided service (e.g. 'static', 'dynamic')." ;
     :domainIncludes :Service ;
-    :rangeIncludes :Text ;
-    rdfs:comment "Indicates the mobility of a provided service (e.g. 'static', 'dynamic')." .
+    :rangeIncludes :Text .
 
 :providesService a rdf:Property ;
     rdfs:label "providesService" ;
+    rdfs:comment "The service provided by this channel." ;
     :domainIncludes :ServiceChannel ;
-    :rangeIncludes :Service ;
-    rdfs:comment "The service provided by this channel." .
+    :rangeIncludes :Service .
 
 :publicAccess a rdf:Property ;
     rdfs:label "publicAccess" ;
+    rdfs:comment "A flag to signal that the [[Place]] is open to public visitors.  If this property is omitted there is no assumed default boolean value." ;
     :domainIncludes :Place ;
-    :rangeIncludes :Boolean ;
-    rdfs:comment "A flag to signal that the [[Place]] is open to public visitors.  If this property is omitted there is no assumed default boolean value." .
+    :rangeIncludes :Boolean .
 
 :publication a rdf:Property ;
     rdfs:label "publication" ;
+    rdfs:comment "A publication event associated with the item." ;
     :domainIncludes :CreativeWork ;
-    :rangeIncludes :PublicationEvent ;
-    rdfs:comment "A publication event associated with the item." .
+    :rangeIncludes :PublicationEvent .
 
 :publishedOn a rdf:Property ;
     rdfs:label "publishedOn" ;
+    rdfs:comment "A broadcast service associated with the publication event." ;
     :domainIncludes :PublicationEvent ;
-    :rangeIncludes :BroadcastService ;
-    rdfs:comment "A broadcast service associated with the publication event." .
+    :rangeIncludes :BroadcastService .
 
 :publisher a rdf:Property ;
     rdfs:label "publisher" ;
+    rdfs:comment "The publisher of the creative work." ;
     :domainIncludes :CreativeWork ;
     :rangeIncludes :Organization,
-        :Person ;
-    rdfs:comment "The publisher of the creative work." .
+        :Person .
 
 :publishingPrinciples a rdf:Property ;
     rdfs:label "publishingPrinciples" ;
+    rdfs:comment """The publishingPrinciples property indicates (typically via [[URL]]) a document describing the editorial principles of an [[Organization]] (or individual, e.g. a [[Person]] writing a blog) that relate to their activities as a publisher, e.g. ethics or diversity policies. When applied to a [[CreativeWork]] (e.g. [[NewsArticle]]) the principles are those of the party primarily responsible for the creation of the [[CreativeWork]].
+
+While such policies are most typically expressed in natural language, sometimes related information (e.g. indicating a [[funder]]) can be expressed using schema.org terminology.
+""" ;
     :domainIncludes :CreativeWork,
         :Organization,
         :Person ;
     :rangeIncludes :CreativeWork,
-        :URL ;
-    rdfs:comment """The publishingPrinciples property indicates (typically via [[URL]]) a document describing the editorial principles of an [[Organization]] (or individual, e.g. a [[Person]] writing a blog) that relate to their activities as a publisher, e.g. ethics or diversity policies. When applied to a [[CreativeWork]] (e.g. [[NewsArticle]]) the principles are those of the party primarily responsible for the creation of the [[CreativeWork]].
-
-While such policies are most typically expressed in natural language, sometimes related information (e.g. indicating a [[funder]]) can be expressed using schema.org terminology.
-""" .
+        :URL .
 
 :purchaseDate a rdf:Property ;
     rdfs:label "purchaseDate" ;
+    rdfs:comment "The date the item, e.g. vehicle, was purchased by the current owner." ;
+    :contributor <https://schema.org/docs/collab/Automotive_Ontology_Working_Group> ;
     :domainIncludes :Product,
         :Vehicle ;
-    :rangeIncludes :Date ;
-    :contributor <https://schema.org/docs/collab/Automotive_Ontology_Working_Group> ;
-    rdfs:comment "The date the item, e.g. vehicle, was purchased by the current owner." .
+    :rangeIncludes :Date .
 
 :qualifications a rdf:Property ;
     rdfs:label "qualifications" ;
+    rdfs:comment "Specific qualifications required for this role or Occupation." ;
     :domainIncludes :JobPosting,
         :Occupation ;
     :rangeIncludes :Text ;
-    :source <https://github.com/schemaorg/schemaorg/issues/1698> ;
-    rdfs:comment "Specific qualifications required for this role or Occupation." .
+    :source <https://github.com/schemaorg/schemaorg/issues/1698> .
 
 :query a rdf:Property ;
     rdfs:label "query" ;
-    :domainIncludes :SearchAction ;
-    :rangeIncludes :Text ;
     rdfs:comment "A sub property of instrument. The query used on this action." ;
-    rdfs:subPropertyOf :instrument .
+    rdfs:subPropertyOf :instrument ;
+    :domainIncludes :SearchAction ;
+    :rangeIncludes :Text .
 
 :quest a rdf:Property ;
     rdfs:label "quest" ;
+    rdfs:comment "The task that a player-controlled character, or group of characters may complete in order to gain a reward." ;
     :domainIncludes :Game,
         :VideoGameSeries ;
-    :rangeIncludes :Thing ;
-    rdfs:comment "The task that a player-controlled character, or group of characters may complete in order to gain a reward." .
+    :rangeIncludes :Thing .
 
 :question a rdf:Property ;
     rdfs:label "question" ;
-    :domainIncludes :AskAction ;
-    :rangeIncludes :Question ;
     rdfs:comment "A sub property of object. A question." ;
-    rdfs:subPropertyOf :object .
+    rdfs:subPropertyOf :object ;
+    :domainIncludes :AskAction ;
+    :rangeIncludes :Question .
 
 :ratingCount a rdf:Property ;
     rdfs:label "ratingCount" ;
+    rdfs:comment "The count of total number of ratings." ;
     :domainIncludes :AggregateRating ;
-    :rangeIncludes :Integer ;
-    rdfs:comment "The count of total number of ratings." .
+    :rangeIncludes :Integer .
 
 :ratingValue a rdf:Property ;
     rdfs:label "ratingValue" ;
+    rdfs:comment "The rating for the content.\\n\\nUsage guidelines:\\n\\n* Use values from 0123456789 (Unicode 'DIGIT ZERO' (U+0030) to 'DIGIT NINE' (U+0039)) rather than superficially similar Unicode symbols.\\n* Use '.' (Unicode 'FULL STOP' (U+002E)) rather than ',' to indicate a decimal point. Avoid using these symbols as a readability separator." ;
     :domainIncludes :Rating ;
     :rangeIncludes :Number,
-        :Text ;
-    rdfs:comment "The rating for the content.\\n\\nUsage guidelines:\\n\\n* Use values from 0123456789 (Unicode 'DIGIT ZERO' (U+0030) to 'DIGIT NINE' (U+0039)) rather than superficially similar Unicode symbols.\\n* Use '.' (Unicode 'FULL STOP' (U+002E)) rather than ',' to indicate a decimal point. Avoid using these symbols as a readability separator." .
+        :Text .
 
 :readonlyValue a rdf:Property ;
     rdfs:label "readonlyValue" ;
+    rdfs:comment "Whether or not a property is mutable.  Default is false. Specifying this for a property that also has a value makes it act similar to a \"hidden\" input in an HTML form." ;
     :domainIncludes :PropertyValueSpecification ;
-    :rangeIncludes :Boolean ;
-    rdfs:comment "Whether or not a property is mutable.  Default is false. Specifying this for a property that also has a value makes it act similar to a \"hidden\" input in an HTML form." .
+    :rangeIncludes :Boolean .
 
 :realEstateAgent a rdf:Property ;
     rdfs:label "realEstateAgent" ;
-    :domainIncludes :RentAction ;
-    :rangeIncludes :RealEstateAgent ;
     rdfs:comment "A sub property of participant. The real estate agent involved in the action." ;
-    rdfs:subPropertyOf :participant .
+    rdfs:subPropertyOf :participant ;
+    :domainIncludes :RentAction ;
+    :rangeIncludes :RealEstateAgent .
 
 :recipe a rdf:Property ;
     rdfs:label "recipe" ;
-    :domainIncludes :CookAction ;
-    :rangeIncludes :Recipe ;
     rdfs:comment "A sub property of instrument. The recipe/instructions used to perform the action." ;
-    rdfs:subPropertyOf :instrument .
+    rdfs:subPropertyOf :instrument ;
+    :domainIncludes :CookAction ;
+    :rangeIncludes :Recipe .
 
 :recipeCategory a rdf:Property ;
     rdfs:label "recipeCategory" ;
+    rdfs:comment "The category of the recipe—for example, appetizer, entree, etc." ;
     :domainIncludes :Recipe ;
-    :rangeIncludes :Text ;
-    rdfs:comment "The category of the recipe—for example, appetizer, entree, etc." .
+    :rangeIncludes :Text .
 
 :recipeCuisine a rdf:Property ;
     rdfs:label "recipeCuisine" ;
+    rdfs:comment "The cuisine of the recipe (for example, French or Ethiopian)." ;
     :domainIncludes :Recipe ;
-    :rangeIncludes :Text ;
-    rdfs:comment "The cuisine of the recipe (for example, French or Ethiopian)." .
+    :rangeIncludes :Text .
 
 :recipeInstructions a rdf:Property ;
     rdfs:label "recipeInstructions" ;
+    rdfs:comment "A step in making the recipe, in the form of a single item (document, video, etc.) or an ordered list with HowToStep and/or HowToSection items." ;
+    rdfs:subPropertyOf :step ;
     :domainIncludes :Recipe ;
     :rangeIncludes :CreativeWork,
         :ItemList,
-        :Text ;
-    rdfs:comment "A step in making the recipe, in the form of a single item (document, video, etc.) or an ordered list with HowToStep and/or HowToSection items." ;
-    rdfs:subPropertyOf :step .
+        :Text .
 
 :recipeYield a rdf:Property ;
     rdfs:label "recipeYield" ;
+    rdfs:comment "The quantity produced by the recipe (for example, number of people served, number of servings, etc)." ;
+    rdfs:subPropertyOf :yield ;
     :domainIncludes :Recipe ;
     :rangeIncludes :QuantitativeValue,
-        :Text ;
-    rdfs:comment "The quantity produced by the recipe (for example, number of people served, number of servings, etc)." ;
-    rdfs:subPropertyOf :yield .
+        :Text .
 
 :recordLabel a rdf:Property ;
     rdfs:label "recordLabel" ;
-    :domainIncludes :MusicRelease ;
-    :rangeIncludes :Organization ;
-    :contributor <https://schema.org/docs/collab/MBZ> ;
     rdfs:comment "The label that issued the release." ;
-    owl:equivalentProperty <http://purl.org/ontology/mo/label> .
+    owl:equivalentProperty <http://purl.org/ontology/mo/label> ;
+    :contributor <https://schema.org/docs/collab/MBZ> ;
+    :domainIncludes :MusicRelease ;
+    :rangeIncludes :Organization .
 
 :referenceQuantity a rdf:Property ;
     rdfs:label "referenceQuantity" ;
-    :domainIncludes :UnitPriceSpecification ;
-    :rangeIncludes :QuantitativeValue ;
+    rdfs:comment "The reference quantity for which a certain price applies, e.g. 1 EUR per 4 kWh of electricity. This property is a replacement for unitOfMeasurement for the advanced cases where the price does not relate to a standard unit." ;
     :contributor <https://schema.org/docs/collab/GoodRelationsTerms> ;
-    rdfs:comment "The reference quantity for which a certain price applies, e.g. 1 EUR per 4 kWh of electricity. This property is a replacement for unitOfMeasurement for the advanced cases where the price does not relate to a standard unit." .
+    :domainIncludes :UnitPriceSpecification ;
+    :rangeIncludes :QuantitativeValue .
 
 :referencesOrder a rdf:Property ;
     rdfs:label "referencesOrder" ;
+    rdfs:comment "The Order(s) related to this Invoice. One or more Orders may be combined into a single Invoice." ;
     :domainIncludes :Invoice ;
-    :rangeIncludes :Order ;
-    rdfs:comment "The Order(s) related to this Invoice. One or more Orders may be combined into a single Invoice." .
+    :rangeIncludes :Order .
 
 :regionsAllowed a rdf:Property ;
     rdfs:label "regionsAllowed" ;
+    rdfs:comment "The regions where the media is allowed. If not specified, then it's assumed to be allowed everywhere. Specify the countries in [ISO 3166 format](http://en.wikipedia.org/wiki/ISO_3166)." ;
     :domainIncludes :MediaObject ;
-    :rangeIncludes :Place ;
-    rdfs:comment "The regions where the media is allowed. If not specified, then it's assumed to be allowed everywhere. Specify the countries in [ISO 3166 format](http://en.wikipedia.org/wiki/ISO_3166)." .
+    :rangeIncludes :Place .
 
 :relatedLink a rdf:Property ;
     rdfs:label "relatedLink" ;
+    rdfs:comment "A link related to this web page, for example to other related web pages." ;
     :domainIncludes :WebPage ;
-    :rangeIncludes :URL ;
-    rdfs:comment "A link related to this web page, for example to other related web pages." .
+    :rangeIncludes :URL .
 
 :relatedTo a rdf:Property ;
     rdfs:label "relatedTo" ;
+    rdfs:comment "The most generic familial relation." ;
     :domainIncludes :Person ;
-    :rangeIncludes :Person ;
-    rdfs:comment "The most generic familial relation." .
+    :rangeIncludes :Person .
 
 :releaseDate a rdf:Property ;
     rdfs:label "releaseDate" ;
+    rdfs:comment "The release date of a product or product model. This can be used to distinguish the exact variant of a product." ;
     :domainIncludes :Product ;
-    :rangeIncludes :Date ;
-    rdfs:comment "The release date of a product or product model. This can be used to distinguish the exact variant of a product." .
+    :rangeIncludes :Date .
 
 :releaseNotes a rdf:Property ;
     rdfs:label "releaseNotes" ;
+    rdfs:comment "Description of what changed in this version." ;
     :domainIncludes :SoftwareApplication ;
     :rangeIncludes :Text,
-        :URL ;
-    rdfs:comment "Description of what changed in this version." .
+        :URL .
 
 :releasedEvent a rdf:Property ;
     rdfs:label "releasedEvent" ;
+    rdfs:comment "The place and time the release was issued, expressed as a PublicationEvent." ;
     :domainIncludes :CreativeWork ;
-    :rangeIncludes :PublicationEvent ;
-    rdfs:comment "The place and time the release was issued, expressed as a PublicationEvent." .
+    :rangeIncludes :PublicationEvent .
 
 :relevantOccupation a rdf:Property ;
     rdfs:label "relevantOccupation" ;
+    rdfs:comment "The Occupation for the JobPosting." ;
     :domainIncludes :JobPosting ;
     :rangeIncludes :Occupation ;
-    :source <https://github.com/schemaorg/schemaorg/issues/1698> ;
-    rdfs:comment "The Occupation for the JobPosting." .
+    :source <https://github.com/schemaorg/schemaorg/issues/1698> .
 
 :remainingAttendeeCapacity a rdf:Property ;
     rdfs:label "remainingAttendeeCapacity" ;
+    rdfs:comment "The number of attendee places for an event that remain unallocated." ;
     :domainIncludes :Event ;
-    :rangeIncludes :Integer ;
-    rdfs:comment "The number of attendee places for an event that remain unallocated." .
+    :rangeIncludes :Integer .
 
 :replacee a rdf:Property ;
     rdfs:label "replacee" ;
-    :domainIncludes :ReplaceAction ;
-    :rangeIncludes :Thing ;
     rdfs:comment "A sub property of object. The object that is being replaced." ;
-    rdfs:subPropertyOf :object .
+    rdfs:subPropertyOf :object ;
+    :domainIncludes :ReplaceAction ;
+    :rangeIncludes :Thing .
 
 :replacer a rdf:Property ;
     rdfs:label "replacer" ;
-    :domainIncludes :ReplaceAction ;
-    :rangeIncludes :Thing ;
     rdfs:comment "A sub property of object. The object that replaces." ;
-    rdfs:subPropertyOf :object .
+    rdfs:subPropertyOf :object ;
+    :domainIncludes :ReplaceAction ;
+    :rangeIncludes :Thing .
 
 :replyToUrl a rdf:Property ;
     rdfs:label "replyToUrl" ;
+    rdfs:comment "The URL at which a reply may be posted to the specified UserComment." ;
     :domainIncludes :UserComments ;
-    :rangeIncludes :URL ;
-    rdfs:comment "The URL at which a reply may be posted to the specified UserComment." .
+    :rangeIncludes :URL .
 
 :reportNumber a rdf:Property ;
     rdfs:label "reportNumber" ;
+    rdfs:comment "The number or other unique designator assigned to a Report by the publishing organization." ;
     :domainIncludes :Report ;
-    :rangeIncludes :Text ;
-    rdfs:comment "The number or other unique designator assigned to a Report by the publishing organization." .
+    :rangeIncludes :Text .
 
 :representativeOfPage a rdf:Property ;
     rdfs:label "representativeOfPage" ;
+    rdfs:comment "Indicates whether this image is representative of the content of the page." ;
     :domainIncludes :ImageObject ;
-    :rangeIncludes :Boolean ;
-    rdfs:comment "Indicates whether this image is representative of the content of the page." .
+    :rangeIncludes :Boolean .
 
 :requiredCollateral a rdf:Property ;
     rdfs:label "requiredCollateral" ;
+    rdfs:comment "Assets required to secure loan or credit repayments. It may take form of third party pledge, goods, financial instruments (cash, securities, etc.)" ;
+    :contributor <https://schema.org/docs/collab/FIBO> ;
     :domainIncludes :LoanOrCredit ;
     :rangeIncludes :Text,
-        :Thing ;
-    :contributor <https://schema.org/docs/collab/FIBO> ;
-    rdfs:comment "Assets required to secure loan or credit repayments. It may take form of third party pledge, goods, financial instruments (cash, securities, etc.)" .
+        :Thing .
 
 :requiredGender a rdf:Property ;
     rdfs:label "requiredGender" ;
+    rdfs:comment "Audiences defined by a person's gender." ;
     :domainIncludes :PeopleAudience ;
-    :rangeIncludes :Text ;
-    rdfs:comment "Audiences defined by a person's gender." .
+    :rangeIncludes :Text .
 
 :requiredMaxAge a rdf:Property ;
     rdfs:label "requiredMaxAge" ;
+    rdfs:comment "Audiences defined by a person's maximum age." ;
     :domainIncludes :PeopleAudience ;
-    :rangeIncludes :Integer ;
-    rdfs:comment "Audiences defined by a person's maximum age." .
+    :rangeIncludes :Integer .
 
 :requiredMinAge a rdf:Property ;
     rdfs:label "requiredMinAge" ;
+    rdfs:comment "Audiences defined by a person's minimum age." ;
     :domainIncludes :PeopleAudience ;
-    :rangeIncludes :Integer ;
-    rdfs:comment "Audiences defined by a person's minimum age." .
+    :rangeIncludes :Integer .
 
 :requiredQuantity a rdf:Property ;
     rdfs:label "requiredQuantity" ;
+    rdfs:comment "The required quantity of the item(s)." ;
     :domainIncludes :HowToItem ;
     :rangeIncludes :Number,
         :QuantitativeValue,
-        :Text ;
-    rdfs:comment "The required quantity of the item(s)." .
+        :Text .
 
 :requirements a rdf:Property ;
     rdfs:label "requirements" ;
+    rdfs:comment "Component dependency requirements for application. This includes runtime environments and shared libraries that are not included in the application distribution package, but required to run the application (examples: DirectX, Java or .NET runtime)." ;
     :domainIncludes :SoftwareApplication ;
     :rangeIncludes :Text,
         :URL ;
-    :supersededBy :softwareRequirements ;
-    rdfs:comment "Component dependency requirements for application. This includes runtime environments and shared libraries that are not included in the application distribution package, but required to run the application (examples: DirectX, Java or .NET runtime)." .
+    :supersededBy :softwareRequirements .
 
 :requiresSubscription a rdf:Property ;
     rdfs:label "requiresSubscription" ;
+    rdfs:comment "Indicates if use of the media require a subscription  (either paid or free). Allowed values are ```true``` or ```false``` (note that an earlier version had 'yes', 'no')." ;
     :domainIncludes :ActionAccessSpecification,
         :MediaObject ;
     :rangeIncludes :Boolean,
         :MediaSubscription ;
-    :source <https://github.com/schemaorg/schemaorg/issues/1741> ;
-    rdfs:comment "Indicates if use of the media require a subscription  (either paid or free). Allowed values are ```true``` or ```false``` (note that an earlier version had 'yes', 'no')." .
+    :source <https://github.com/schemaorg/schemaorg/issues/1741> .
 
 :reservationFor a rdf:Property ;
     rdfs:label "reservationFor" ;
+    rdfs:comment "The thing -- flight, event, restaurant, etc. being reserved." ;
     :domainIncludes :Reservation ;
-    :rangeIncludes :Thing ;
-    rdfs:comment "The thing -- flight, event, restaurant, etc. being reserved." .
+    :rangeIncludes :Thing .
 
 :reservationId a rdf:Property ;
     rdfs:label "reservationId" ;
+    rdfs:comment "A unique identifier for the reservation." ;
     :domainIncludes :Reservation ;
-    :rangeIncludes :Text ;
-    rdfs:comment "A unique identifier for the reservation." .
+    :rangeIncludes :Text .
 
 :reservationStatus a rdf:Property ;
     rdfs:label "reservationStatus" ;
+    rdfs:comment "The current status of the reservation." ;
     :domainIncludes :Reservation ;
-    :rangeIncludes :ReservationStatusType ;
-    rdfs:comment "The current status of the reservation." .
+    :rangeIncludes :ReservationStatusType .
 
 :reservedTicket a rdf:Property ;
     rdfs:label "reservedTicket" ;
+    rdfs:comment "A ticket associated with the reservation." ;
     :domainIncludes :Reservation ;
-    :rangeIncludes :Ticket ;
-    rdfs:comment "A ticket associated with the reservation." .
+    :rangeIncludes :Ticket .
 
 :responsibilities a rdf:Property ;
     rdfs:label "responsibilities" ;
+    rdfs:comment "Responsibilities associated with this role or Occupation." ;
     :domainIncludes :JobPosting,
         :Occupation ;
     :rangeIncludes :Text ;
-    :source <https://github.com/schemaorg/schemaorg/issues/1698> ;
-    rdfs:comment "Responsibilities associated with this role or Occupation." .
+    :source <https://github.com/schemaorg/schemaorg/issues/1698> .
 
 :resultComment a rdf:Property ;
     rdfs:label "resultComment" ;
+    rdfs:comment "A sub property of result. The Comment created or sent as a result of this action." ;
+    rdfs:subPropertyOf :result ;
     :domainIncludes :CommentAction,
         :ReplyAction ;
-    :rangeIncludes :Comment ;
-    rdfs:comment "A sub property of result. The Comment created or sent as a result of this action." ;
-    rdfs:subPropertyOf :result .
+    :rangeIncludes :Comment .
 
 :resultReview a rdf:Property ;
     rdfs:label "resultReview" ;
-    :domainIncludes :ReviewAction ;
-    :rangeIncludes :Review ;
     rdfs:comment "A sub property of result. The review that resulted in the performing of the action." ;
-    rdfs:subPropertyOf :result .
+    rdfs:subPropertyOf :result ;
+    :domainIncludes :ReviewAction ;
+    :rangeIncludes :Review .
 
 :reviewAspect a rdf:Property ;
     rdfs:label "reviewAspect" ;
+    rdfs:comment "This Review or Rating is relevant to this part or facet of the itemReviewed." ;
     :domainIncludes :Rating,
         :Review ;
     :rangeIncludes :Text ;
-    :source <https://github.com/schemaorg/schemaorg/issues/1689> ;
-    rdfs:comment "This Review or Rating is relevant to this part or facet of the itemReviewed." .
+    :source <https://github.com/schemaorg/schemaorg/issues/1689> .
 
 :reviewBody a rdf:Property ;
     rdfs:label "reviewBody" ;
+    rdfs:comment "The actual body of the review." ;
     :domainIncludes :Review ;
-    :rangeIncludes :Text ;
-    rdfs:comment "The actual body of the review." .
+    :rangeIncludes :Text .
 
 :reviewCount a rdf:Property ;
     rdfs:label "reviewCount" ;
+    rdfs:comment "The count of total number of reviews." ;
     :domainIncludes :AggregateRating ;
-    :rangeIncludes :Integer ;
-    rdfs:comment "The count of total number of reviews." .
+    :rangeIncludes :Integer .
 
 :reviewRating a rdf:Property ;
     rdfs:label "reviewRating" ;
+    rdfs:comment "The rating given in this review. Note that reviews can themselves be rated. The ```reviewRating``` applies to rating given by the review. The [[aggregateRating]] property applies to the review itself, as a creative work." ;
     :domainIncludes :Review ;
-    :rangeIncludes :Rating ;
-    rdfs:comment "The rating given in this review. Note that reviews can themselves be rated. The ```reviewRating``` applies to rating given by the review. The [[aggregateRating]] property applies to the review itself, as a creative work." .
+    :rangeIncludes :Rating .
 
 :reviewedBy a rdf:Property ;
     rdfs:label "reviewedBy" ;
+    rdfs:comment "People or organizations that have reviewed the content on this web page for accuracy and/or completeness." ;
     :domainIncludes :WebPage ;
     :rangeIncludes :Organization,
-        :Person ;
-    rdfs:comment "People or organizations that have reviewed the content on this web page for accuracy and/or completeness." .
+        :Person .
 
 :reviews a rdf:Property ;
     rdfs:label "reviews" ;
+    rdfs:comment "Review of the item." ;
     :domainIncludes :CreativeWork,
         :Offer,
         :Organization,
         :Place,
         :Product ;
     :rangeIncludes :Review ;
-    :supersededBy :review ;
-    rdfs:comment "Review of the item." .
+    :supersededBy :review .
 
 :rsvpResponse a rdf:Property ;
     rdfs:label "rsvpResponse" ;
+    rdfs:comment "The response (yes, no, maybe) to the RSVP." ;
     :domainIncludes :RsvpAction ;
-    :rangeIncludes :RsvpResponseType ;
-    rdfs:comment "The response (yes, no, maybe) to the RSVP." .
+    :rangeIncludes :RsvpResponseType .
 
 :runtime a rdf:Property ;
     rdfs:label "runtime" ;
+    rdfs:comment "Runtime platform or script interpreter dependencies (example: Java v1, Python 2.3, .NET Framework 3.0)." ;
     :domainIncludes :SoftwareSourceCode ;
     :rangeIncludes :Text ;
-    :supersededBy :runtimePlatform ;
-    rdfs:comment "Runtime platform or script interpreter dependencies (example: Java v1, Python 2.3, .NET Framework 3.0)." .
+    :supersededBy :runtimePlatform .
 
 :salaryCurrency a rdf:Property ;
     rdfs:label "salaryCurrency" ;
+    rdfs:comment "The currency (coded using [ISO 4217](http://en.wikipedia.org/wiki/ISO_4217)) used for the main salary information in this job posting or for this employee." ;
     :domainIncludes :EmployeeRole,
         :JobPosting ;
-    :rangeIncludes :Text ;
-    rdfs:comment "The currency (coded using [ISO 4217](http://en.wikipedia.org/wiki/ISO_4217)) used for the main salary information in this job posting or for this employee." .
+    :rangeIncludes :Text .
 
 :sameAs a rdf:Property ;
     rdfs:label "sameAs" ;
+    rdfs:comment "URL of a reference Web page that unambiguously indicates the item's identity. E.g. the URL of the item's Wikipedia page, Wikidata entry, or official website." ;
     :domainIncludes :Thing ;
-    :rangeIncludes :URL ;
-    rdfs:comment "URL of a reference Web page that unambiguously indicates the item's identity. E.g. the URL of the item's Wikipedia page, Wikidata entry, or official website." .
+    :rangeIncludes :URL .
 
 :sampleType a rdf:Property ;
     rdfs:label "sampleType" ;
+    rdfs:comment "What type of code sample: full (compile ready) solution, code snippet, inline code, scripts, template." ;
     :domainIncludes :SoftwareSourceCode ;
     :rangeIncludes :Text ;
-    :supersededBy :codeSampleType ;
-    rdfs:comment "What type of code sample: full (compile ready) solution, code snippet, inline code, scripts, template." .
+    :supersededBy :codeSampleType .
 
 :saturatedFatContent a rdf:Property ;
     rdfs:label "saturatedFatContent" ;
+    rdfs:comment "The number of grams of saturated fat." ;
     :domainIncludes :NutritionInformation ;
-    :rangeIncludes :Mass ;
-    rdfs:comment "The number of grams of saturated fat." .
+    :rangeIncludes :Mass .
 
 :scheduledPaymentDate a rdf:Property ;
     rdfs:label "scheduledPaymentDate" ;
+    rdfs:comment "The date the invoice is scheduled to be paid." ;
     :domainIncludes :Invoice ;
-    :rangeIncludes :Date ;
-    rdfs:comment "The date the invoice is scheduled to be paid." .
+    :rangeIncludes :Date .
 
 :scheduledTime a rdf:Property ;
     rdfs:label "scheduledTime" ;
+    rdfs:comment "The time the object is scheduled to." ;
     :domainIncludes :PlanAction ;
-    :rangeIncludes :DateTime ,
-                    :Date ;
-    rdfs:comment "The time the object is scheduled to." .
+    :rangeIncludes :Date,
+        :DateTime .
 
 :schemaVersion a rdf:Property ;
     rdfs:label "schemaVersion" ;
-    :domainIncludes :CreativeWork ;
-    :rangeIncludes :Text, :URL ;
     rdfs:comment """Indicates (by URL or string) a particular version of a schema used in some CreativeWork. This property was created primarily to
-    indicate the use of a specific schema.org release, e.g. ```10.0``` as a simple string, or more explicitly via URL, ```https://schema.org/docs/releases.html#v10.0```. There may be situations in which other schemas might usefully be referenced this way, e.g. ```http://dublincore.org/specifications/dublin-core/dces/1999-07-02/``` but this has not been carefully explored in the community.""" .
+    indicate the use of a specific schema.org release, e.g. ```10.0``` as a simple string, or more explicitly via URL, ```https://schema.org/docs/releases.html#v10.0```. There may be situations in which other schemas might usefully be referenced this way, e.g. ```http://dublincore.org/specifications/dublin-core/dces/1999-07-02/``` but this has not been carefully explored in the community.""" ;
+    :domainIncludes :CreativeWork ;
+    :rangeIncludes :Text,
+        :URL .
 
 :screenCount a rdf:Property ;
     rdfs:label "screenCount" ;
+    rdfs:comment "The number of screens in the movie theater." ;
     :domainIncludes :MovieTheater ;
-    :rangeIncludes :Number ;
-    rdfs:comment "The number of screens in the movie theater." .
+    :rangeIncludes :Number .
 
 :screenshot a rdf:Property ;
     rdfs:label "screenshot" ;
+    rdfs:comment "A link to a screenshot image of the app." ;
     :domainIncludes :SoftwareApplication ;
     :rangeIncludes :ImageObject,
-        :URL ;
-    rdfs:comment "A link to a screenshot image of the app." .
+        :URL .
 
 :seasonNumber a rdf:Property ;
     rdfs:label "seasonNumber" ;
+    rdfs:comment "Position of the season within an ordered group of seasons." ;
+    rdfs:subPropertyOf :position ;
     :domainIncludes :CreativeWorkSeason ;
     :rangeIncludes :Integer,
-        :Text ;
-    rdfs:comment "Position of the season within an ordered group of seasons." ;
-    rdfs:subPropertyOf :position .
+        :Text .
 
 :seasons a rdf:Property ;
     rdfs:label "seasons" ;
+    rdfs:comment "A season in a media series." ;
     :domainIncludes :RadioSeries,
         :TVSeries,
         :VideoGameSeries ;
     :rangeIncludes :CreativeWorkSeason ;
-    :supersededBy :season ;
-    rdfs:comment "A season in a media series." .
+    :supersededBy :season .
 
 :seatNumber a rdf:Property ;
     rdfs:label "seatNumber" ;
+    rdfs:comment "The location of the reserved seat (e.g., 27)." ;
     :domainIncludes :Seat ;
-    :rangeIncludes :Text ;
-    rdfs:comment "The location of the reserved seat (e.g., 27)." .
+    :rangeIncludes :Text .
 
 :seatRow a rdf:Property ;
     rdfs:label "seatRow" ;
+    rdfs:comment "The row location of the reserved seat (e.g., B)." ;
     :domainIncludes :Seat ;
-    :rangeIncludes :Text ;
-    rdfs:comment "The row location of the reserved seat (e.g., B)." .
+    :rangeIncludes :Text .
 
 :seatSection a rdf:Property ;
     rdfs:label "seatSection" ;
+    rdfs:comment "The section location of the reserved seat (e.g. Orchestra)." ;
     :domainIncludes :Seat ;
-    :rangeIncludes :Text ;
-    rdfs:comment "The section location of the reserved seat (e.g. Orchestra)." .
+    :rangeIncludes :Text .
 
 :seatingType a rdf:Property ;
     rdfs:label "seatingType" ;
+    rdfs:comment "The type/class of the seat." ;
     :domainIncludes :Seat ;
     :rangeIncludes :QualitativeValue,
-        :Text ;
-    rdfs:comment "The type/class of the seat." .
+        :Text .
 
 :securityScreening a rdf:Property ;
     rdfs:label "securityScreening" ;
+    rdfs:comment "The type of security screening the passenger is subject to." ;
     :domainIncludes :FlightReservation ;
-    :rangeIncludes :Text ;
-    rdfs:comment "The type of security screening the passenger is subject to." .
+    :rangeIncludes :Text .
 
 :seeks a rdf:Property ;
     rdfs:label "seeks" ;
+    rdfs:comment "A pointer to products or services sought by the organization or person (demand)." ;
     :domainIncludes :Organization,
         :Person ;
-    :rangeIncludes :Demand ;
-    rdfs:comment "A pointer to products or services sought by the organization or person (demand)." .
+    :rangeIncludes :Demand .
 
 :sender a rdf:Property ;
     rdfs:label "sender" ;
+    rdfs:comment "A sub property of participant. The participant who is at the sending end of the action." ;
+    rdfs:subPropertyOf :participant ;
     :domainIncludes :Message,
         :ReceiveAction ;
     :rangeIncludes :Audience,
         :Organization,
-        :Person ;
-    rdfs:comment "A sub property of participant. The participant who is at the sending end of the action." ;
-    rdfs:subPropertyOf :participant .
+        :Person .
 
 :serverStatus a rdf:Property ;
     rdfs:label "serverStatus" ;
+    rdfs:comment "Status of a game server." ;
     :domainIncludes :GameServer ;
-    :rangeIncludes :GameServerStatus ;
-    rdfs:comment "Status of a game server." .
+    :rangeIncludes :GameServerStatus .
 
 :servesCuisine a rdf:Property ;
     rdfs:label "servesCuisine" ;
+    rdfs:comment "The cuisine of the restaurant." ;
     :domainIncludes :FoodEstablishment ;
-    :rangeIncludes :Text ;
-    rdfs:comment "The cuisine of the restaurant." .
+    :rangeIncludes :Text .
 
 :serviceAudience a rdf:Property ;
     rdfs:label "serviceAudience" ;
+    rdfs:comment "The audience eligible for this service." ;
     :domainIncludes :Service ;
     :rangeIncludes :Audience ;
-    :supersededBy :audience ;
-    rdfs:comment "The audience eligible for this service." .
+    :supersededBy :audience .
 
 :serviceLocation a rdf:Property ;
     rdfs:label "serviceLocation" ;
+    rdfs:comment "The location (e.g. civic structure, local business, etc.) where a person can go to access the service." ;
     :domainIncludes :ServiceChannel ;
-    :rangeIncludes :Place ;
-    rdfs:comment "The location (e.g. civic structure, local business, etc.) where a person can go to access the service." .
+    :rangeIncludes :Place .
 
 :serviceOperator a rdf:Property ;
     rdfs:label "serviceOperator" ;
+    rdfs:comment "The operating organization, if different from the provider.  This enables the representation of services that are provided by an organization, but operated by another organization like a subcontractor." ;
     :domainIncludes :GovernmentService ;
-    :rangeIncludes :Organization ;
-    rdfs:comment "The operating organization, if different from the provider.  This enables the representation of services that are provided by an organization, but operated by another organization like a subcontractor." .
+    :rangeIncludes :Organization .
 
 :servicePhone a rdf:Property ;
     rdfs:label "servicePhone" ;
+    rdfs:comment "The phone number to use to access the service." ;
     :domainIncludes :ServiceChannel ;
-    :rangeIncludes :ContactPoint ;
-    rdfs:comment "The phone number to use to access the service." .
+    :rangeIncludes :ContactPoint .
 
 :servicePostalAddress a rdf:Property ;
     rdfs:label "servicePostalAddress" ;
+    rdfs:comment "The address for accessing the service by mail." ;
     :domainIncludes :ServiceChannel ;
-    :rangeIncludes :PostalAddress ;
-    rdfs:comment "The address for accessing the service by mail." .
+    :rangeIncludes :PostalAddress .
 
 :serviceSmsNumber a rdf:Property ;
     rdfs:label "serviceSmsNumber" ;
+    rdfs:comment "The number to access the service by text message." ;
     :domainIncludes :ServiceChannel ;
-    :rangeIncludes :ContactPoint ;
-    rdfs:comment "The number to access the service by text message." .
+    :rangeIncludes :ContactPoint .
 
 :serviceType a rdf:Property ;
     rdfs:label "serviceType" ;
+    rdfs:comment "The type of service being offered, e.g. veterans' benefits, emergency relief, etc." ;
     :domainIncludes :Service ;
-    :rangeIncludes :Text ;
-    rdfs:comment "The type of service being offered, e.g. veterans' benefits, emergency relief, etc." .
+    :rangeIncludes :Text .
 
 :serviceUrl a rdf:Property ;
     rdfs:label "serviceUrl" ;
+    rdfs:comment "The website to access the service." ;
     :domainIncludes :ServiceChannel ;
-    :rangeIncludes :URL ;
-    rdfs:comment "The website to access the service." .
+    :rangeIncludes :URL .
 
 :servingSize a rdf:Property ;
     rdfs:label "servingSize" ;
+    rdfs:comment "The serving size, in terms of the number of volume or mass." ;
     :domainIncludes :NutritionInformation ;
-    :rangeIncludes :Text ;
-    rdfs:comment "The serving size, in terms of the number of volume or mass." .
+    :rangeIncludes :Text .
 
 :sharedContent a rdf:Property ;
     rdfs:label "sharedContent" ;
-    :domainIncludes :SocialMediaPosting, :Comment ;
-    :rangeIncludes :CreativeWork ;
-    rdfs:comment "A CreativeWork such as an image, video, or audio clip shared as part of this posting." .
+    rdfs:comment "A CreativeWork such as an image, video, or audio clip shared as part of this posting." ;
+    :domainIncludes :Comment,
+        :SocialMediaPosting ;
+    :rangeIncludes :CreativeWork .
 
 :siblings a rdf:Property ;
     rdfs:label "siblings" ;
+    rdfs:comment "A sibling of the person." ;
     :domainIncludes :Person ;
     :rangeIncludes :Person ;
-    :supersededBy :sibling ;
-    rdfs:comment "A sibling of the person." .
+    :supersededBy :sibling .
 
 :significantLinks a rdf:Property ;
     rdfs:label "significantLinks" ;
+    rdfs:comment "The most significant URLs on the page. Typically, these are the non-navigation links that are clicked on the most." ;
     :domainIncludes :WebPage ;
     :rangeIncludes :URL ;
-    :supersededBy :significantLink ;
-    rdfs:comment "The most significant URLs on the page. Typically, these are the non-navigation links that are clicked on the most." .
+    :supersededBy :significantLink .
 
 :skills a rdf:Property ;
     rdfs:label "skills" ;
+    rdfs:comment "A statement of knowledge, skill, ability, task or any other assertion expressing a competency that is desired or required to fulfill this role or to work in this occupation." ;
     :domainIncludes :JobPosting,
         :Occupation ;
     :rangeIncludes :DefinedTerm,
         :Text ;
     :source <https://github.com/schemaorg/schemaorg/issues/1698>,
-        <https://github.com/schemaorg/schemaorg/issues/2322> ;
-    rdfs:comment "A statement of knowledge, skill, ability, task or any other assertion expressing a competency that is desired or required to fulfill this role or to work in this occupation." .
+        <https://github.com/schemaorg/schemaorg/issues/2322> .
 
 :sku a rdf:Property ;
     rdfs:label "sku" ;
+    rdfs:comment "The Stock Keeping Unit (SKU), i.e. a merchant-specific identifier for a product or service, or the product to which the offer refers." ;
+    rdfs:subPropertyOf :identifier ;
     :domainIncludes :Demand,
         :Offer,
         :Product ;
-    :rangeIncludes :Text ;
-    rdfs:comment "The Stock Keeping Unit (SKU), i.e. a merchant-specific identifier for a product or service, or the product to which the offer refers." ;
-    rdfs:subPropertyOf :identifier .
+    :rangeIncludes :Text .
 
 :slogan a rdf:Property ;
     rdfs:label "slogan" ;
+    rdfs:comment "A slogan or motto associated with the item." ;
     :domainIncludes :Brand,
         :Organization,
         :Place,
         :Product,
         :Service ;
-    :rangeIncludes :Text ;
-    rdfs:comment "A slogan or motto associated with the item." .
+    :rangeIncludes :Text .
 
 :smokingAllowed a rdf:Property ;
     rdfs:label "smokingAllowed" ;
-    :domainIncludes :Place ;
-    :rangeIncludes :Boolean ;
+    rdfs:comment "Indicates whether it is allowed to smoke in the place, e.g. in the restaurant, hotel or hotel room." ;
     :contributor <https://schema.org/docs/collab/STI_Accommodation_Ontology> ;
-    rdfs:comment "Indicates whether it is allowed to smoke in the place, e.g. in the restaurant, hotel or hotel room." .
+    :domainIncludes :Place ;
+    :rangeIncludes :Boolean .
 
 :sodiumContent a rdf:Property ;
     rdfs:label "sodiumContent" ;
+    rdfs:comment "The number of milligrams of sodium." ;
     :domainIncludes :NutritionInformation ;
-    :rangeIncludes :Mass ;
-    rdfs:comment "The number of milligrams of sodium." .
+    :rangeIncludes :Mass .
 
 :softwareAddOn a rdf:Property ;
     rdfs:label "softwareAddOn" ;
+    rdfs:comment "Additional content for a software application." ;
     :domainIncludes :SoftwareApplication ;
-    :rangeIncludes :SoftwareApplication ;
-    rdfs:comment "Additional content for a software application." .
+    :rangeIncludes :SoftwareApplication .
 
 :softwareHelp a rdf:Property ;
     rdfs:label "softwareHelp" ;
+    rdfs:comment "Software application help." ;
     :domainIncludes :SoftwareApplication ;
-    :rangeIncludes :CreativeWork ;
-    rdfs:comment "Software application help." .
+    :rangeIncludes :CreativeWork .
 
 :softwareVersion a rdf:Property ;
     rdfs:label "softwareVersion" ;
+    rdfs:comment "Version of the software instance." ;
     :domainIncludes :SoftwareApplication ;
-    :rangeIncludes :Text ;
-    rdfs:comment "Version of the software instance." .
+    :rangeIncludes :Text .
 
 :sourceOrganization a rdf:Property ;
     rdfs:label "sourceOrganization" ;
+    rdfs:comment "The Organization on whose behalf the creator was working." ;
     :domainIncludes :CreativeWork ;
-    :rangeIncludes :Organization ;
-    rdfs:comment "The Organization on whose behalf the creator was working." .
+    :rangeIncludes :Organization .
 
 :spatial a rdf:Property ;
     rdfs:label "spatial" ;
-    :domainIncludes :CreativeWork ;
-    :rangeIncludes :Place ;
     rdfs:comment """The "spatial" property can be used in cases when more specific properties
 (e.g. [[locationCreated]], [[spatialCoverage]], [[contentLocation]]) are not known to be appropriate.""" ;
-    owl:equivalentProperty dc:spatial .
+    owl:equivalentProperty dc:spatial ;
+    :domainIncludes :CreativeWork ;
+    :rangeIncludes :Place .
 
 :spatialCoverage a rdf:Property ;
     rdfs:label "spatialCoverage" ;
-    :domainIncludes :CreativeWork ;
-    :rangeIncludes :Place ;
     rdfs:comment """The spatialCoverage of a CreativeWork indicates the place(s) which are the focus of the content. It is a subproperty of
       contentLocation intended primarily for more technical and detailed materials. For example with a Dataset, it indicates
       areas that the dataset describes: a dataset of New York weather would have spatialCoverage which was the place: the state of New York.""" ;
     rdfs:subPropertyOf :contentLocation ;
-    owl:equivalentProperty dc:spatial .
+    owl:equivalentProperty dc:spatial ;
+    :domainIncludes :CreativeWork ;
+    :rangeIncludes :Place .
 
 :speakable a rdf:Property ;
     rdfs:label "speakable" ;
-    :domainIncludes :Article,
-        :WebPage ;
-    :rangeIncludes :SpeakableSpecification,
-        :URL ;
-    :source <https://github.com/schemaorg/schemaorg/issues/1389> ;
     rdfs:comment """Indicates sections of a Web page that are particularly 'speakable' in the sense of being highlighted as being especially appropriate for text-to-speech conversion. Other sections of a page may also be usefully spoken in particular circumstances; the 'speakable' property serves to indicate the parts most likely to be generally useful for speech.
 
 The *speakable* property can be repeated an arbitrary number of times, with three kinds of possible 'content-locator' values:
@@ -8692,401 +8701,408 @@ The *speakable* property can be repeated an arbitrary number of times, with thre
 
 For more sophisticated markup of speakable sections beyond simple ID references, either CSS selectors or XPath expressions to pick out document section(s) as speakable. For this
 we define a supporting type, [[SpeakableSpecification]]  which is defined to be a possible value of the *speakable* property.
-         """ .
+         """ ;
+    :domainIncludes :Article,
+        :WebPage ;
+    :rangeIncludes :SpeakableSpecification,
+        :URL ;
+    :source <https://github.com/schemaorg/schemaorg/issues/1389> .
 
 :specialCommitments a rdf:Property ;
     rdfs:label "specialCommitments" ;
+    rdfs:comment "Any special commitments associated with this job posting. Valid entries include VeteranCommit, MilitarySpouseCommit, etc." ;
     :domainIncludes :JobPosting ;
-    :rangeIncludes :Text ;
-    rdfs:comment "Any special commitments associated with this job posting. Valid entries include VeteranCommit, MilitarySpouseCommit, etc." .
+    :rangeIncludes :Text .
 
 :specialOpeningHoursSpecification a rdf:Property ;
     rdfs:label "specialOpeningHoursSpecification" ;
-    :domainIncludes :Place ;
-    :rangeIncludes :OpeningHoursSpecification ;
     rdfs:comment """The special opening hours of a certain place.\\n\\nUse this to explicitly override general opening hours brought in scope by [[openingHoursSpecification]] or [[openingHours]].
-      """ .
+      """ ;
+    :domainIncludes :Place ;
+    :rangeIncludes :OpeningHoursSpecification .
 
 :specialty a rdf:Property ;
     rdfs:label "specialty" ;
+    rdfs:comment "One of the domain specialities to which this web page's content applies." ;
     :domainIncludes :WebPage ;
-    :rangeIncludes :Specialty ;
-    rdfs:comment "One of the domain specialities to which this web page's content applies." .
+    :rangeIncludes :Specialty .
 
 :sport a rdf:Property ;
     rdfs:label "sport" ;
+    rdfs:comment "A type of sport (e.g. Baseball)." ;
     :domainIncludes :SportsOrganization ;
     :rangeIncludes :Text,
-        :URL ;
-    rdfs:comment "A type of sport (e.g. Baseball)." .
+        :URL .
 
 :sportsActivityLocation a rdf:Property ;
     rdfs:label "sportsActivityLocation" ;
-    :domainIncludes :ExerciseAction ;
-    :rangeIncludes :SportsActivityLocation ;
     rdfs:comment "A sub property of location. The sports activity location where this action occurred." ;
-    rdfs:subPropertyOf :location .
+    rdfs:subPropertyOf :location ;
+    :domainIncludes :ExerciseAction ;
+    :rangeIncludes :SportsActivityLocation .
 
 :sportsEvent a rdf:Property ;
     rdfs:label "sportsEvent" ;
-    :domainIncludes :ExerciseAction ;
-    :rangeIncludes :SportsEvent ;
     rdfs:comment "A sub property of location. The sports event where this action occurred." ;
-    rdfs:subPropertyOf :location .
+    rdfs:subPropertyOf :location ;
+    :domainIncludes :ExerciseAction ;
+    :rangeIncludes :SportsEvent .
 
 :sportsTeam a rdf:Property ;
     rdfs:label "sportsTeam" ;
-    :domainIncludes :ExerciseAction ;
-    :rangeIncludes :SportsTeam ;
     rdfs:comment "A sub property of participant. The sports team that participated on this action." ;
-    rdfs:subPropertyOf :participant .
+    rdfs:subPropertyOf :participant ;
+    :domainIncludes :ExerciseAction ;
+    :rangeIncludes :SportsTeam .
 
 :spouse a rdf:Property ;
     rdfs:label "spouse" ;
+    rdfs:comment "The person's spouse." ;
     :domainIncludes :Person ;
-    :rangeIncludes :Person ;
-    rdfs:comment "The person's spouse." .
+    :rangeIncludes :Person .
 
 :starRating a rdf:Property ;
     rdfs:label "starRating" ;
+    rdfs:comment "An official rating for a lodging business or food establishment, e.g. from national associations or standards bodies. Use the author property to indicate the rating organization, e.g. as an Organization with name such as (e.g. HOTREC, DEHOGA, WHR, or Hotelstars)." ;
+    :contributor <https://schema.org/docs/collab/STI_Accommodation_Ontology> ;
     :domainIncludes :FoodEstablishment,
         :LodgingBusiness ;
-    :rangeIncludes :Rating ;
-    :contributor <https://schema.org/docs/collab/STI_Accommodation_Ontology> ;
-    rdfs:comment "An official rating for a lodging business or food establishment, e.g. from national associations or standards bodies. Use the author property to indicate the rating organization, e.g. as an Organization with name such as (e.g. HOTREC, DEHOGA, WHR, or Hotelstars)." .
+    :rangeIncludes :Rating .
 
 :startDate a rdf:Property ;
     rdfs:label "startDate" ;
+    rdfs:comment "The start date and time of the item (in [ISO 8601 date format](http://en.wikipedia.org/wiki/ISO_8601))." ;
     :domainIncludes :CreativeWorkSeason,
         :CreativeWorkSeries,
         :DatedMoneySpecification,
         :Event,
-        :Role,
-        :MerchantReturnPolicySeasonalOverride ;
+        :MerchantReturnPolicySeasonalOverride,
+        :Role ;
     :rangeIncludes :Date,
-        :DateTime ;
-    rdfs:comment "The start date and time of the item (in [ISO 8601 date format](http://en.wikipedia.org/wiki/ISO_8601))." .
+        :DateTime .
 
 :startTime a rdf:Property ;
     rdfs:label "startTime" ;
+    rdfs:comment "The startTime of something. For a reserved event or service (e.g. FoodEstablishmentReservation), the time that it is expected to start. For actions that span a period of time, when the action was performed. E.g. John wrote a book from *January* to December. For media, including audio and video, it's the time offset of the start of a clip within a larger file.\\n\\nNote that Event uses startDate/endDate instead of startTime/endTime, even when describing dates with times. This situation may be clarified in future revisions." ;
     :domainIncludes :Action,
         :FoodEstablishmentReservation,
-        :MediaObject, :InteractionCounter ;
+        :InteractionCounter,
+        :MediaObject ;
     :rangeIncludes :DateTime,
-        :Time ;
-    rdfs:comment "The startTime of something. For a reserved event or service (e.g. FoodEstablishmentReservation), the time that it is expected to start. For actions that span a period of time, when the action was performed. E.g. John wrote a book from *January* to December. For media, including audio and video, it's the time offset of the start of a clip within a larger file.\\n\\nNote that Event uses startDate/endDate instead of startTime/endTime, even when describing dates with times. This situation may be clarified in future revisions." .
+        :Time .
 
 :steeringPosition a rdf:Property ;
     rdfs:label "steeringPosition" ;
-    :domainIncludes :Vehicle ;
-    :rangeIncludes :SteeringPositionValue ;
+    rdfs:comment "The position of the steering wheel or similar device (mostly for cars)." ;
     :contributor <https://schema.org/docs/collab/Automotive_Ontology_Working_Group> ;
-    rdfs:comment "The position of the steering wheel or similar device (mostly for cars)." .
+    :domainIncludes :Vehicle ;
+    :rangeIncludes :SteeringPositionValue .
 
 :stepValue a rdf:Property ;
     rdfs:label "stepValue" ;
+    rdfs:comment "The stepValue attribute indicates the granularity that is expected (and required) of the value in a PropertyValueSpecification." ;
     :domainIncludes :PropertyValueSpecification ;
-    :rangeIncludes :Number ;
-    rdfs:comment "The stepValue attribute indicates the granularity that is expected (and required) of the value in a PropertyValueSpecification." .
+    :rangeIncludes :Number .
 
 :steps a rdf:Property ;
     rdfs:label "steps" ;
+    rdfs:comment "A single step item (as HowToStep, text, document, video, etc.) or a HowToSection (originally misnamed 'steps'; 'step' is preferred)." ;
     :domainIncludes :HowTo,
         :HowToSection ;
     :rangeIncludes :CreativeWork,
         :ItemList,
         :Text ;
-    :supersededBy :step ;
-    rdfs:comment "A single step item (as HowToStep, text, document, video, etc.) or a HowToSection (originally misnamed 'steps'; 'step' is preferred)." .
+    :supersededBy :step .
 
 :storageRequirements a rdf:Property ;
     rdfs:label "storageRequirements" ;
+    rdfs:comment "Storage requirements (free space required)." ;
     :domainIncludes :SoftwareApplication ;
     :rangeIncludes :Text,
-        :URL ;
-    rdfs:comment "Storage requirements (free space required)." .
+        :URL .
 
 :streetAddress a rdf:Property ;
     rdfs:label "streetAddress" ;
+    rdfs:comment "The street address. For example, 1600 Amphitheatre Pkwy." ;
     :domainIncludes :PostalAddress ;
-    :rangeIncludes :Text ;
-    rdfs:comment "The street address. For example, 1600 Amphitheatre Pkwy." .
+    :rangeIncludes :Text .
 
 :subEvents a rdf:Property ;
     rdfs:label "subEvents" ;
+    rdfs:comment "Events that are a part of this event. For example, a conference event includes many presentations, each subEvents of the conference." ;
     :domainIncludes :Event ;
     :rangeIncludes :Event ;
-    :supersededBy :subEvent ;
-    rdfs:comment "Events that are a part of this event. For example, a conference event includes many presentations, each subEvents of the conference." .
+    :supersededBy :subEvent .
 
 :subReservation a rdf:Property ;
     rdfs:label "subReservation" ;
+    rdfs:comment "The individual reservations included in the package. Typically a repeated property." ;
     :domainIncludes :ReservationPackage ;
-    :rangeIncludes :Reservation ;
-    rdfs:comment "The individual reservations included in the package. Typically a repeated property." .
+    :rangeIncludes :Reservation .
 
 :subtitleLanguage a rdf:Property ;
     rdfs:label "subtitleLanguage" ;
+    rdfs:comment "Languages in which subtitles/captions are available, in [IETF BCP 47 standard format](http://tools.ietf.org/html/bcp47)." ;
     :domainIncludes :Movie,
         :ScreeningEvent,
         :TVEpisode ;
     :rangeIncludes :Language,
-        :Text ;
-    rdfs:comment "Languages in which subtitles/captions are available, in [IETF BCP 47 standard format](http://tools.ietf.org/html/bcp47)." .
+        :Text .
 
 :successorOf a rdf:Property ;
     rdfs:label "successorOf" ;
+    rdfs:comment "A pointer from a newer variant of a product  to its previous, often discontinued predecessor." ;
     :domainIncludes :ProductModel ;
-    :rangeIncludes :ProductModel ;
-    rdfs:comment "A pointer from a newer variant of a product  to its previous, often discontinued predecessor." .
+    :rangeIncludes :ProductModel .
 
 :sugarContent a rdf:Property ;
     rdfs:label "sugarContent" ;
+    rdfs:comment "The number of grams of sugar." ;
     :domainIncludes :NutritionInformation ;
-    :rangeIncludes :Mass ;
-    rdfs:comment "The number of grams of sugar." .
+    :rangeIncludes :Mass .
 
 :suggestedGender a rdf:Property ;
     rdfs:label "suggestedGender" ;
+    rdfs:comment "The suggested gender of the intended person or audience, for example \"male\", \"female\", or \"unisex\"." ;
     :domainIncludes :PeopleAudience ;
-    :rangeIncludes :Text,
-        :GenderType ;
-    rdfs:comment "The suggested gender of the intended person or audience, for example \"male\", \"female\", or \"unisex\"." .
+    :rangeIncludes :GenderType,
+        :Text .
 
 :suggestedMaxAge a rdf:Property ;
     rdfs:label "suggestedMaxAge" ;
+    rdfs:comment "Maximum recommended age in years for the audience or user." ;
     :domainIncludes :PeopleAudience ;
-    :rangeIncludes :Number ;
-    rdfs:comment "Maximum recommended age in years for the audience or user." .
+    :rangeIncludes :Number .
 
 :suggestedMinAge a rdf:Property ;
     rdfs:label "suggestedMinAge" ;
+    rdfs:comment "Minimum recommended age in years for the audience or user." ;
     :domainIncludes :PeopleAudience ;
-    :rangeIncludes :Number ;
-    rdfs:comment "Minimum recommended age in years for the audience or user." .
+    :rangeIncludes :Number .
 
 :suitableForDiet a rdf:Property ;
     rdfs:label "suitableForDiet" ;
+    rdfs:comment "Indicates a dietary restriction or guideline for which this recipe or menu item is suitable, e.g. diabetic, halal etc." ;
     :domainIncludes :MenuItem,
         :Recipe ;
-    :rangeIncludes :RestrictedDiet ;
-    rdfs:comment "Indicates a dietary restriction or guideline for which this recipe or menu item is suitable, e.g. diabetic, halal etc." .
+    :rangeIncludes :RestrictedDiet .
 
 :supportingData a rdf:Property ;
     rdfs:label "supportingData" ;
+    rdfs:comment "Supporting data for a SoftwareApplication." ;
     :domainIncludes :SoftwareApplication ;
-    :rangeIncludes :DataFeed ;
-    rdfs:comment "Supporting data for a SoftwareApplication." .
+    :rangeIncludes :DataFeed .
 
 :surface a rdf:Property ;
     rdfs:label "surface" ;
+    rdfs:comment "A material used as a surface in some artwork, e.g. Canvas, Paper, Wood, Board, etc." ;
+    rdfs:subPropertyOf :material ;
     :domainIncludes :VisualArtwork ;
     :rangeIncludes :Text,
         :URL ;
-    :supersededBy :artworkSurface ;
-    rdfs:comment "A material used as a surface in some artwork, e.g. Canvas, Paper, Wood, Board, etc." ;
-    rdfs:subPropertyOf :material .
+    :supersededBy :artworkSurface .
 
 :target a rdf:Property ;
     rdfs:label "target" ;
+    rdfs:comment "Indicates a target EntryPoint, or url, for an Action." ;
     :domainIncludes :Action ;
     :rangeIncludes :EntryPoint,
-        :URL ;
-    rdfs:comment "Indicates a target EntryPoint, or url, for an Action." .
+        :URL .
 
 :targetDescription a rdf:Property ;
     rdfs:label "targetDescription" ;
+    rdfs:comment "The description of a node in an established educational framework." ;
     :domainIncludes :AlignmentObject ;
-    :rangeIncludes :Text ;
-    rdfs:comment "The description of a node in an established educational framework." .
+    :rangeIncludes :Text .
 
 :targetName a rdf:Property ;
     rdfs:label "targetName" ;
+    rdfs:comment "The name of a node in an established educational framework." ;
     :domainIncludes :AlignmentObject ;
-    :rangeIncludes :Text ;
-    rdfs:comment "The name of a node in an established educational framework." .
+    :rangeIncludes :Text .
 
 :targetPlatform a rdf:Property ;
     rdfs:label "targetPlatform" ;
+    rdfs:comment "Type of app development: phone, Metro style, desktop, XBox, etc." ;
     :domainIncludes :APIReference ;
-    :rangeIncludes :Text ;
-    rdfs:comment "Type of app development: phone, Metro style, desktop, XBox, etc." .
+    :rangeIncludes :Text .
 
 :targetProduct a rdf:Property ;
     rdfs:label "targetProduct" ;
+    rdfs:comment "Target Operating System / Product to which the code applies.  If applies to several versions, just the product name can be used." ;
     :domainIncludes :SoftwareSourceCode ;
-    :rangeIncludes :SoftwareApplication ;
-    rdfs:comment "Target Operating System / Product to which the code applies.  If applies to several versions, just the product name can be used." .
+    :rangeIncludes :SoftwareApplication .
 
 :targetUrl a rdf:Property ;
     rdfs:label "targetUrl" ;
+    rdfs:comment "The URL of a node in an established educational framework." ;
     :domainIncludes :AlignmentObject ;
-    :rangeIncludes :URL ;
-    rdfs:comment "The URL of a node in an established educational framework." .
+    :rangeIncludes :URL .
 
 :taxID a rdf:Property ;
     rdfs:label "taxID" ;
+    rdfs:comment "The Tax / Fiscal ID of the organization or person, e.g. the TIN in the US or the CIF/NIF in Spain." ;
+    rdfs:subPropertyOf :identifier ;
     :domainIncludes :Organization,
         :Person ;
-    :rangeIncludes :Text ;
-    rdfs:comment "The Tax / Fiscal ID of the organization or person, e.g. the TIN in the US or the CIF/NIF in Spain." ;
-    rdfs:subPropertyOf :identifier .
+    :rangeIncludes :Text .
 
 :telephone a rdf:Property ;
     rdfs:label "telephone" ;
+    rdfs:comment "The telephone number." ;
     :domainIncludes :ContactPoint,
         :Organization,
         :Person,
         :Place ;
-    :rangeIncludes :Text ;
-    rdfs:comment "The telephone number." .
+    :rangeIncludes :Text .
 
 :temporal a rdf:Property ;
     rdfs:label "temporal" ;
+    rdfs:comment """The "temporal" property can be used in cases where more specific properties
+(e.g. [[temporalCoverage]], [[dateCreated]], [[dateModified]], [[datePublished]]) are not known to be appropriate.""" ;
     :domainIncludes :CreativeWork ;
     :rangeIncludes :DateTime,
-        :Text ;
-    rdfs:comment """The "temporal" property can be used in cases where more specific properties
-(e.g. [[temporalCoverage]], [[dateCreated]], [[dateModified]], [[datePublished]]) are not known to be appropriate.""" .
+        :Text .
 
 :text a rdf:Property ;
     rdfs:label "text" ;
+    rdfs:comment "The textual content of this CreativeWork." ;
     :domainIncludes :CreativeWork ;
-    :rangeIncludes :Text ;
-    rdfs:comment "The textual content of this CreativeWork." .
+    :rangeIncludes :Text .
 
 :thumbnail a rdf:Property ;
     rdfs:label "thumbnail" ;
+    rdfs:comment "Thumbnail image for an image or video." ;
     :domainIncludes :CreativeWork ;
-    :rangeIncludes :ImageObject ;
-    rdfs:comment "Thumbnail image for an image or video." .
+    :rangeIncludes :ImageObject .
 
 :thumbnailUrl a rdf:Property ;
     rdfs:label "thumbnailUrl" ;
+    rdfs:comment "A thumbnail image relevant to the Thing." ;
     :domainIncludes :CreativeWork ;
-    :rangeIncludes :URL ;
-    rdfs:comment "A thumbnail image relevant to the Thing." .
+    :rangeIncludes :URL .
 
 :tickerSymbol a rdf:Property ;
     rdfs:label "tickerSymbol" ;
+    rdfs:comment "The exchange traded instrument associated with a Corporation object. The tickerSymbol is expressed as an exchange and an instrument name separated by a space character. For the exchange component of the tickerSymbol attribute, we recommend using the controlled vocabulary of Market Identifier Codes (MIC) specified in ISO 15022." ;
     :domainIncludes :Corporation ;
-    :rangeIncludes :Text ;
-    rdfs:comment "The exchange traded instrument associated with a Corporation object. The tickerSymbol is expressed as an exchange and an instrument name separated by a space character. For the exchange component of the tickerSymbol attribute, we recommend using the controlled vocabulary of Market Identifier Codes (MIC) specified in ISO 15022." .
+    :rangeIncludes :Text .
 
 :ticketNumber a rdf:Property ;
     rdfs:label "ticketNumber" ;
+    rdfs:comment "The unique identifier for the ticket." ;
     :domainIncludes :Ticket ;
-    :rangeIncludes :Text ;
-    rdfs:comment "The unique identifier for the ticket." .
+    :rangeIncludes :Text .
 
 :ticketToken a rdf:Property ;
     rdfs:label "ticketToken" ;
+    rdfs:comment "Reference to an asset (e.g., Barcode, QR code image or PDF) usable for entrance." ;
     :domainIncludes :Ticket ;
     :rangeIncludes :Text,
-        :URL ;
-    rdfs:comment "Reference to an asset (e.g., Barcode, QR code image or PDF) usable for entrance." .
+        :URL .
 
 :ticketedSeat a rdf:Property ;
     rdfs:label "ticketedSeat" ;
+    rdfs:comment "The seat associated with the ticket." ;
     :domainIncludes :Ticket ;
-    :rangeIncludes :Seat ;
-    rdfs:comment "The seat associated with the ticket." .
+    :rangeIncludes :Seat .
 
 :timeRequired a rdf:Property ;
     rdfs:label "timeRequired" ;
+    rdfs:comment "Approximate or typical time it usually takes to work with or through the content of this work for the typical or target audience." ;
     :domainIncludes :CreativeWork ;
-    :rangeIncludes :Duration ;
-    rdfs:comment "Approximate or typical time it usually takes to work with or through the content of this work for the typical or target audience." .
+    :rangeIncludes :Duration .
 
 :title a rdf:Property ;
     rdfs:label "title" ;
+    rdfs:comment "The title of the job." ;
     :domainIncludes :JobPosting ;
-    :rangeIncludes :Text ;
-    rdfs:comment "The title of the job." .
+    :rangeIncludes :Text .
 
 :toLocation a rdf:Property ;
     rdfs:label "toLocation" ;
+    rdfs:comment "A sub property of location. The final location of the object or the agent after the action." ;
+    rdfs:subPropertyOf :location ;
     :domainIncludes :ExerciseAction,
         :InsertAction,
         :MoveAction,
         :TransferAction ;
-    :rangeIncludes :Place ;
-    rdfs:comment "A sub property of location. The final location of the object or the agent after the action." ;
-    rdfs:subPropertyOf :location .
+    :rangeIncludes :Place .
 
 :toRecipient a rdf:Property ;
     rdfs:label "toRecipient" ;
+    rdfs:comment "A sub property of recipient. The recipient who was directly sent the message." ;
+    rdfs:subPropertyOf :recipient ;
     :domainIncludes :Message ;
     :rangeIncludes :Audience,
         :ContactPoint,
         :Organization,
-        :Person ;
-    rdfs:comment "A sub property of recipient. The recipient who was directly sent the message." ;
-    rdfs:subPropertyOf :recipient .
+        :Person .
 
 :tool a rdf:Property ;
     rdfs:label "tool" ;
+    rdfs:comment "A sub property of instrument. An object used (but not consumed) when performing instructions or a direction." ;
+    rdfs:subPropertyOf :instrument ;
     :domainIncludes :HowTo,
         :HowToDirection ;
     :rangeIncludes :HowToTool,
-        :Text ;
-    rdfs:comment "A sub property of instrument. An object used (but not consumed) when performing instructions or a direction." ;
-    rdfs:subPropertyOf :instrument .
+        :Text .
 
 :totalPaymentDue a rdf:Property ;
     rdfs:label "totalPaymentDue" ;
+    rdfs:comment "The total amount due." ;
     :domainIncludes :Invoice ;
     :rangeIncludes :MonetaryAmount,
-        :PriceSpecification ;
-    rdfs:comment "The total amount due." .
+        :PriceSpecification .
 
 :totalPrice a rdf:Property ;
     rdfs:label "totalPrice" ;
+    rdfs:comment "The total price for the reservation or ticket, including applicable taxes, shipping, etc.\\n\\nUsage guidelines:\\n\\n* Use values from 0123456789 (Unicode 'DIGIT ZERO' (U+0030) to 'DIGIT NINE' (U+0039)) rather than superficially similar Unicode symbols.\\n* Use '.' (Unicode 'FULL STOP' (U+002E)) rather than ',' to indicate a decimal point. Avoid using these symbols as a readability separator." ;
     :domainIncludes :Reservation,
         :Ticket ;
     :rangeIncludes :Number,
         :PriceSpecification,
-        :Text ;
-    rdfs:comment "The total price for the reservation or ticket, including applicable taxes, shipping, etc.\\n\\nUsage guidelines:\\n\\n* Use values from 0123456789 (Unicode 'DIGIT ZERO' (U+0030) to 'DIGIT NINE' (U+0039)) rather than superficially similar Unicode symbols.\\n* Use '.' (Unicode 'FULL STOP' (U+002E)) rather than ',' to indicate a decimal point. Avoid using these symbols as a readability separator." .
+        :Text .
 
 :totalTime a rdf:Property ;
     rdfs:label "totalTime" ;
+    rdfs:comment "The total time required to perform instructions or a direction (including time to prepare the supplies), in [ISO 8601 duration format](http://en.wikipedia.org/wiki/ISO_8601)." ;
     :domainIncludes :HowTo,
         :HowToDirection ;
-    :rangeIncludes :Duration ;
-    rdfs:comment "The total time required to perform instructions or a direction (including time to prepare the supplies), in [ISO 8601 duration format](http://en.wikipedia.org/wiki/ISO_8601)." .
+    :rangeIncludes :Duration .
 
 :touristType a rdf:Property ;
     rdfs:label "touristType" ;
-    :domainIncludes :TouristAttraction ;
-    :rangeIncludes :Audience,
-        :Text ;
+    rdfs:comment "Attraction suitable for type(s) of tourist. E.g. children, visitors from a particular country, etc. " ;
     :contributor <https://schema.org/docs/collab/IIT-CNR.it>,
         <https://schema.org/docs/collab/Tourism> ;
-    rdfs:comment "Attraction suitable for type(s) of tourist. E.g. children, visitors from a particular country, etc. " .
+    :domainIncludes :TouristAttraction ;
+    :rangeIncludes :Audience,
+        :Text .
 
 :trackingNumber a rdf:Property ;
     rdfs:label "trackingNumber" ;
+    rdfs:comment "Shipper tracking number." ;
     :domainIncludes :ParcelDelivery ;
-    :rangeIncludes :Text ;
-    rdfs:comment "Shipper tracking number." .
+    :rangeIncludes :Text .
 
 :trackingUrl a rdf:Property ;
     rdfs:label "trackingUrl" ;
+    rdfs:comment "Tracking url for the parcel delivery." ;
     :domainIncludes :ParcelDelivery ;
-    :rangeIncludes :URL ;
-    rdfs:comment "Tracking url for the parcel delivery." .
+    :rangeIncludes :URL .
 
 :tracks a rdf:Property ;
     rdfs:label "tracks" ;
+    rdfs:comment "A music recording (track)&#x2014;usually a single song." ;
     :domainIncludes :MusicGroup,
         :MusicPlaylist ;
     :rangeIncludes :MusicRecording ;
-    :supersededBy :track ;
-    rdfs:comment "A music recording (track)&#x2014;usually a single song." .
+    :supersededBy :track .
 
 :trailer a rdf:Property ;
     rdfs:label "trailer" ;
+    rdfs:comment "The trailer of a movie or TV/radio series, season, episode, etc." ;
     :domainIncludes :CreativeWorkSeason,
         :Episode,
         :Movie,
@@ -9095,164 +9111,165 @@ we define a supporting type, [[SpeakableSpecification]]  which is defined to be 
         :TVSeries,
         :VideoGame,
         :VideoGameSeries ;
-    :rangeIncludes :VideoObject ;
-    rdfs:comment "The trailer of a movie or TV/radio series, season, episode, etc." .
+    :rangeIncludes :VideoObject .
 
 :trainName a rdf:Property ;
     rdfs:label "trainName" ;
+    rdfs:comment "The name of the train (e.g. The Orient Express)." ;
     :domainIncludes :TrainTrip ;
-    :rangeIncludes :Text ;
-    rdfs:comment "The name of the train (e.g. The Orient Express)." .
+    :rangeIncludes :Text .
 
 :trainNumber a rdf:Property ;
     rdfs:label "trainNumber" ;
+    rdfs:comment "The unique identifier for the train." ;
     :domainIncludes :TrainTrip ;
-    :rangeIncludes :Text ;
-    rdfs:comment "The unique identifier for the train." .
+    :rangeIncludes :Text .
 
 :transFatContent a rdf:Property ;
     rdfs:label "transFatContent" ;
+    rdfs:comment "The number of grams of trans fat." ;
     :domainIncludes :NutritionInformation ;
-    :rangeIncludes :Mass ;
-    rdfs:comment "The number of grams of trans fat." .
+    :rangeIncludes :Mass .
 
 :transcript a rdf:Property ;
     rdfs:label "transcript" ;
+    rdfs:comment "If this MediaObject is an AudioObject or VideoObject, the transcript of that object." ;
     :domainIncludes :AudioObject,
         :VideoObject ;
-    :rangeIncludes :Text ;
-    rdfs:comment "If this MediaObject is an AudioObject or VideoObject, the transcript of that object." .
+    :rangeIncludes :Text .
 
 :translator a rdf:Property ;
     rdfs:label "translator" ;
+    rdfs:comment "Organization or person who adapts a creative work to different languages, regional differences and technical requirements of a target market, or that translates during some event." ;
     :domainIncludes :CreativeWork,
         :Event ;
     :rangeIncludes :Organization,
-        :Person ;
-    rdfs:comment "Organization or person who adapts a creative work to different languages, regional differences and technical requirements of a target market, or that translates during some event." .
+        :Person .
 
 :tripOrigin a rdf:Property ;
     rdfs:label "tripOrigin" ;
+    rdfs:comment "The location of origin of the trip, prior to any destination(s)." ;
     :domainIncludes :Trip ;
-    :rangeIncludes :Place ;
-    rdfs:comment "The location of origin of the trip, prior to any destination(s)." .
+    :rangeIncludes :Place .
 
 :typeOfBed a rdf:Property ;
     rdfs:label "typeOfBed" ;
+    rdfs:comment "The type of bed to which the BedDetail refers, i.e. the type of bed available in the quantity indicated by quantity." ;
+    :contributor <https://schema.org/docs/collab/STI_Accommodation_Ontology> ;
     :domainIncludes :BedDetails ;
     :rangeIncludes :BedType,
-        :Text ;
-    :contributor <https://schema.org/docs/collab/STI_Accommodation_Ontology> ;
-    rdfs:comment "The type of bed to which the BedDetail refers, i.e. the type of bed available in the quantity indicated by quantity." .
+        :Text .
 
 :typeOfGood a rdf:Property ;
     rdfs:label "typeOfGood" ;
+    rdfs:comment "The product that this structured value is referring to." ;
     :domainIncludes :OwnershipInfo,
         :TypeAndQuantityNode ;
     :rangeIncludes :Product,
-        :Service ;
-    rdfs:comment "The product that this structured value is referring to." .
+        :Service .
 
 :typicalAgeRange a rdf:Property ;
     rdfs:label "typicalAgeRange" ;
+    rdfs:comment "The typical expected age range, e.g. '7-9', '11-'." ;
     :domainIncludes :CreativeWork,
         :Event ;
-    :rangeIncludes :Text ;
-    rdfs:comment "The typical expected age range, e.g. '7-9', '11-'." .
+    :rangeIncludes :Text .
 
 :underName a rdf:Property ;
     rdfs:label "underName" ;
+    rdfs:comment "The person or organization the reservation or ticket is for." ;
     :domainIncludes :Reservation,
         :Ticket ;
     :rangeIncludes :Organization,
-        :Person ;
-    rdfs:comment "The person or organization the reservation or ticket is for." .
+        :Person .
 
 :unitCode a rdf:Property ;
     rdfs:label "unitCode" ;
+    rdfs:comment "The unit of measurement given using the UN/CEFACT Common Code (3 characters) or a URL. Other codes than the UN/CEFACT Common Code may be used with a prefix followed by a colon." ;
     :domainIncludes :PropertyValue,
         :QuantitativeValue,
         :TypeAndQuantityNode,
         :UnitPriceSpecification ;
     :rangeIncludes :Text,
-        :URL ;
-    rdfs:comment "The unit of measurement given using the UN/CEFACT Common Code (3 characters) or a URL. Other codes than the UN/CEFACT Common Code may be used with a prefix followed by a colon." .
+        :URL .
 
 :unitText a rdf:Property ;
     rdfs:label "unitText" ;
+    rdfs:comment """A string or text indicating the unit of measurement. Useful if you cannot provide a standard unit code for
+<a href='unitCode'>unitCode</a>.""" ;
     :domainIncludes :PropertyValue,
         :QuantitativeValue,
         :TypeAndQuantityNode,
         :UnitPriceSpecification ;
-    :rangeIncludes :Text ;
-    rdfs:comment """A string or text indicating the unit of measurement. Useful if you cannot provide a standard unit code for
-<a href='unitCode'>unitCode</a>.""" .
+    :rangeIncludes :Text .
 
 :unsaturatedFatContent a rdf:Property ;
     rdfs:label "unsaturatedFatContent" ;
+    rdfs:comment "The number of grams of unsaturated fat." ;
     :domainIncludes :NutritionInformation ;
-    :rangeIncludes :Mass ;
-    rdfs:comment "The number of grams of unsaturated fat." .
+    :rangeIncludes :Mass .
 
 :uploadDate a rdf:Property ;
     rdfs:label "uploadDate" ;
+    rdfs:comment "Date (including time if available) when this media object was uploaded to this site." ;
     :domainIncludes :MediaObject ;
-    :rangeIncludes :Date, :DateTime ;
-    rdfs:comment "Date (including time if available) when this media object was uploaded to this site." .
+    :rangeIncludes :Date,
+        :DateTime .
 
 :upvoteCount a rdf:Property ;
     rdfs:label "upvoteCount" ;
+    rdfs:comment "The number of upvotes this question, answer or comment has received from the community." ;
     :domainIncludes :Comment ;
-    :rangeIncludes :Integer ;
-    rdfs:comment "The number of upvotes this question, answer or comment has received from the community." .
+    :rangeIncludes :Integer .
 
 :url a rdf:Property ;
     rdfs:label "url" ;
+    rdfs:comment "URL of the item." ;
     :domainIncludes :Thing ;
-    :rangeIncludes :URL ;
-    rdfs:comment "URL of the item." .
+    :rangeIncludes :URL .
 
 :urlTemplate a rdf:Property ;
     rdfs:label "urlTemplate" ;
+    rdfs:comment "An url template (RFC6570) that will be used to construct the target of the execution of the action." ;
     :domainIncludes :EntryPoint ;
-    :rangeIncludes :Text ;
-    rdfs:comment "An url template (RFC6570) that will be used to construct the target of the execution of the action." .
+    :rangeIncludes :Text .
 
 :userInteractionCount a rdf:Property ;
     rdfs:label "userInteractionCount" ;
+    rdfs:comment "The number of interactions for the CreativeWork using the WebSite or SoftwareApplication." ;
     :domainIncludes :InteractionCounter ;
-    :rangeIncludes :Integer ;
-    rdfs:comment "The number of interactions for the CreativeWork using the WebSite or SoftwareApplication." .
+    :rangeIncludes :Integer .
 
 :validFor a rdf:Property ;
     rdfs:label "validFor" ;
+    rdfs:comment "The duration of validity of a permit or similar thing." ;
     :domainIncludes :Permit ;
-    :rangeIncludes :Duration ;
-    rdfs:comment "The duration of validity of a permit or similar thing." .
+    :rangeIncludes :Duration .
 
 :validFrom a rdf:Property ;
     rdfs:label "validFrom" ;
-    :domainIncludes :Demand,
+    rdfs:comment "The date when the item becomes valid." ;
+    :domainIncludes :Certification,
+        :Demand,
         :LocationFeatureSpecification,
         :MonetaryAmount,
         :Offer,
         :OpeningHoursSpecification,
         :Permit,
-        :PriceSpecification,
-    :Certification ;
+        :PriceSpecification ;
     :rangeIncludes :Date,
-        :DateTime ;
-    rdfs:comment "The date when the item becomes valid." .
+        :DateTime .
 
 :validIn a rdf:Property ;
     rdfs:label "validIn" ;
-    :domainIncludes :Permit,
-     :Certification;
-    :rangeIncludes :AdministrativeArea ;
-    rdfs:comment "The geographic area where the item is valid. Applies for example to a [[Permit]], a [[Certification]], or an [[EducationalOccupationalCredential]]. " .
+    rdfs:comment "The geographic area where the item is valid. Applies for example to a [[Permit]], a [[Certification]], or an [[EducationalOccupationalCredential]]. " ;
+    :domainIncludes :Certification,
+        :Permit ;
+    :rangeIncludes :AdministrativeArea .
 
 :validThrough a rdf:Property ;
     rdfs:label "validThrough" ;
+    rdfs:comment "The date after when the item is not valid. For example the end of an offer, salary period, or a period of opening hours." ;
     :domainIncludes :Demand,
         :JobPosting,
         :LocationFeatureSpecification,
@@ -9261,58 +9278,58 @@ we define a supporting type, [[SpeakableSpecification]]  which is defined to be 
         :OpeningHoursSpecification,
         :PriceSpecification ;
     :rangeIncludes :Date,
-        :DateTime ;
-    rdfs:comment "The date after when the item is not valid. For example the end of an offer, salary period, or a period of opening hours." .
+        :DateTime .
 
 :validUntil a rdf:Property ;
     rdfs:label "validUntil" ;
+    rdfs:comment "The date when the item is no longer valid." ;
     :domainIncludes :Permit ;
-    :rangeIncludes :Date ;
-    rdfs:comment "The date when the item is no longer valid." .
+    :rangeIncludes :Date .
 
 :value a rdf:Property ;
     rdfs:label "value" ;
+    rdfs:comment "The value of a [[QuantitativeValue]] (including [[Observation]]) or property value node.\\n\\n* For [[QuantitativeValue]] and [[MonetaryAmount]], the recommended type for values is 'Number'.\\n* For [[PropertyValue]], it can be 'Text', 'Number', 'Boolean', or 'StructuredValue'.\\n* Use values from 0123456789 (Unicode 'DIGIT ZERO' (U+0030) to 'DIGIT NINE' (U+0039)) rather than superficially similar Unicode symbols.\\n* Use '.' (Unicode 'FULL STOP' (U+002E)) rather than ',' to indicate a decimal point. Avoid using these symbols as a readability separator." ;
     :domainIncludes :MonetaryAmount,
         :PropertyValue,
         :QuantitativeValue ;
     :rangeIncludes :Boolean,
         :Number,
         :StructuredValue,
-        :Text ;
-    rdfs:comment "The value of a [[QuantitativeValue]] (including [[Observation]]) or property value node.\\n\\n* For [[QuantitativeValue]] and [[MonetaryAmount]], the recommended type for values is 'Number'.\\n* For [[PropertyValue]], it can be 'Text', 'Number', 'Boolean', or 'StructuredValue'.\\n* Use values from 0123456789 (Unicode 'DIGIT ZERO' (U+0030) to 'DIGIT NINE' (U+0039)) rather than superficially similar Unicode symbols.\\n* Use '.' (Unicode 'FULL STOP' (U+002E)) rather than ',' to indicate a decimal point. Avoid using these symbols as a readability separator." .
+        :Text .
 
 :valueAddedTaxIncluded a rdf:Property ;
     rdfs:label "valueAddedTaxIncluded" ;
+    rdfs:comment "Specifies whether the applicable value-added tax (VAT) is included in the price specification or not." ;
     :domainIncludes :PriceSpecification ;
-    :rangeIncludes :Boolean ;
-    rdfs:comment "Specifies whether the applicable value-added tax (VAT) is included in the price specification or not." .
+    :rangeIncludes :Boolean .
 
 :valueMaxLength a rdf:Property ;
     rdfs:label "valueMaxLength" ;
+    rdfs:comment "Specifies the allowed range for number of characters in a literal value." ;
     :domainIncludes :PropertyValueSpecification ;
-    :rangeIncludes :Number ;
-    rdfs:comment "Specifies the allowed range for number of characters in a literal value." .
+    :rangeIncludes :Number .
 
 :valueMinLength a rdf:Property ;
     rdfs:label "valueMinLength" ;
+    rdfs:comment "Specifies the minimum allowed range for number of characters in a literal value." ;
     :domainIncludes :PropertyValueSpecification ;
-    :rangeIncludes :Number ;
-    rdfs:comment "Specifies the minimum allowed range for number of characters in a literal value." .
+    :rangeIncludes :Number .
 
 :valueName a rdf:Property ;
     rdfs:label "valueName" ;
+    rdfs:comment "Indicates the name of the PropertyValueSpecification to be used in URL templates and form encoding in a manner analogous to HTML's input@name." ;
     :domainIncludes :PropertyValueSpecification ;
-    :rangeIncludes :Text ;
-    rdfs:comment "Indicates the name of the PropertyValueSpecification to be used in URL templates and form encoding in a manner analogous to HTML's input@name." .
+    :rangeIncludes :Text .
 
 :valuePattern a rdf:Property ;
     rdfs:label "valuePattern" ;
+    rdfs:comment "Specifies a regular expression for testing literal values according to the HTML spec." ;
     :domainIncludes :PropertyValueSpecification ;
-    :rangeIncludes :Text ;
-    rdfs:comment "Specifies a regular expression for testing literal values according to the HTML spec." .
+    :rangeIncludes :Text .
 
 :valueReference a rdf:Property ;
     rdfs:label "valueReference" ;
+    rdfs:comment "A secondary value that provides additional information on the original value, e.g. a reference temperature or a type of measurement." ;
     :domainIncludes :PropertyValue,
         :QualitativeValue,
         :QuantitativeValue ;
@@ -9320,267 +9337,269 @@ we define a supporting type, [[SpeakableSpecification]]  which is defined to be 
         :PropertyValue,
         :QualitativeValue,
         :QuantitativeValue,
-        :StructuredValue ;
-    rdfs:comment "A secondary value that provides additional information on the original value, e.g. a reference temperature or a type of measurement." .
+        :StructuredValue .
 
 :valueRequired a rdf:Property ;
     rdfs:label "valueRequired" ;
+    rdfs:comment "Whether the property must be filled in to complete the action.  Default is false." ;
     :domainIncludes :PropertyValueSpecification ;
-    :rangeIncludes :Boolean ;
-    rdfs:comment "Whether the property must be filled in to complete the action.  Default is false." .
+    :rangeIncludes :Boolean .
 
 :vatID a rdf:Property ;
     rdfs:label "vatID" ;
+    rdfs:comment "The Value-added Tax ID of the organization or person." ;
     :domainIncludes :Organization,
         :Person ;
-    :rangeIncludes :Text ;
-    rdfs:comment "The Value-added Tax ID of the organization or person." .
+    :rangeIncludes :Text .
 
 :vehicleConfiguration a rdf:Property ;
     rdfs:label "vehicleConfiguration" ;
-    :domainIncludes :Vehicle ;
-    :rangeIncludes :Text ;
+    rdfs:comment "A short text indicating the configuration of the vehicle, e.g. '5dr hatchback ST 2.5 MT 225 hp' or 'limited edition'." ;
     :contributor <https://schema.org/docs/collab/Automotive_Ontology_Working_Group> ;
-    rdfs:comment "A short text indicating the configuration of the vehicle, e.g. '5dr hatchback ST 2.5 MT 225 hp' or 'limited edition'." .
+    :domainIncludes :Vehicle ;
+    :rangeIncludes :Text .
 
 :vehicleEngine a rdf:Property ;
     rdfs:label "vehicleEngine" ;
-    :domainIncludes :Vehicle ;
-    :rangeIncludes :EngineSpecification ;
+    rdfs:comment "Information about the engine or engines of the vehicle." ;
     :contributor <https://schema.org/docs/collab/Automotive_Ontology_Working_Group> ;
-    rdfs:comment "Information about the engine or engines of the vehicle." .
+    :domainIncludes :Vehicle ;
+    :rangeIncludes :EngineSpecification .
 
 :vehicleIdentificationNumber a rdf:Property ;
     rdfs:label "vehicleIdentificationNumber" ;
-    :domainIncludes :Vehicle ;
-    :rangeIncludes :Text ;
-    :contributor <https://schema.org/docs/collab/Automotive_Ontology_Working_Group> ;
     rdfs:comment "The Vehicle Identification Number (VIN) is a unique serial number used by the automotive industry to identify individual motor vehicles." ;
-    rdfs:subPropertyOf :serialNumber .
+    rdfs:subPropertyOf :serialNumber ;
+    :contributor <https://schema.org/docs/collab/Automotive_Ontology_Working_Group> ;
+    :domainIncludes :Vehicle ;
+    :rangeIncludes :Text .
 
 :vehicleInteriorColor a rdf:Property ;
     rdfs:label "vehicleInteriorColor" ;
-    :domainIncludes :Vehicle ;
-    :rangeIncludes :Text ;
+    rdfs:comment "The color or color combination of the interior of the vehicle." ;
     :contributor <https://schema.org/docs/collab/Automotive_Ontology_Working_Group> ;
-    rdfs:comment "The color or color combination of the interior of the vehicle." .
+    :domainIncludes :Vehicle ;
+    :rangeIncludes :Text .
 
 :vehicleInteriorType a rdf:Property ;
     rdfs:label "vehicleInteriorType" ;
-    :domainIncludes :Vehicle ;
-    :rangeIncludes :Text ;
+    rdfs:comment "The type or material of the interior of the vehicle (e.g. synthetic fabric, leather, wood, etc.). While most interior types are characterized by the material used, an interior type can also be based on vehicle usage or target audience." ;
     :contributor <https://schema.org/docs/collab/Automotive_Ontology_Working_Group> ;
-    rdfs:comment "The type or material of the interior of the vehicle (e.g. synthetic fabric, leather, wood, etc.). While most interior types are characterized by the material used, an interior type can also be based on vehicle usage or target audience." .
+    :domainIncludes :Vehicle ;
+    :rangeIncludes :Text .
 
 :vehicleModelDate a rdf:Property ;
     rdfs:label "vehicleModelDate" ;
-    :domainIncludes :Vehicle ;
-    :rangeIncludes :Date ;
+    rdfs:comment "The release date of a vehicle model (often used to differentiate versions of the same make and model)." ;
     :contributor <https://schema.org/docs/collab/Automotive_Ontology_Working_Group> ;
-    rdfs:comment "The release date of a vehicle model (often used to differentiate versions of the same make and model)." .
+    :domainIncludes :Vehicle ;
+    :rangeIncludes :Date .
 
 :vehicleSeatingCapacity a rdf:Property ;
     rdfs:label "vehicleSeatingCapacity" ;
+    rdfs:comment "The number of passengers that can be seated in the vehicle, both in terms of the physical space available, and in terms of limitations set by law.\\n\\nTypical unit code(s): C62 for persons." ;
+    :contributor <https://schema.org/docs/collab/Automotive_Ontology_Working_Group> ;
     :domainIncludes :Vehicle ;
     :rangeIncludes :Number,
-        :QuantitativeValue ;
-    :contributor <https://schema.org/docs/collab/Automotive_Ontology_Working_Group> ;
-    rdfs:comment "The number of passengers that can be seated in the vehicle, both in terms of the physical space available, and in terms of limitations set by law.\\n\\nTypical unit code(s): C62 for persons." .
+        :QuantitativeValue .
 
 :vehicleSpecialUsage a rdf:Property ;
     rdfs:label "vehicleSpecialUsage" ;
+    rdfs:comment "Indicates whether the vehicle has been used for special purposes, like commercial rental, driving school, or as a taxi. The legislation in many countries requires this information to be revealed when offering a car for sale." ;
     :domainIncludes :Vehicle ;
-    :rangeIncludes :Text ;
-    rdfs:comment "Indicates whether the vehicle has been used for special purposes, like commercial rental, driving school, or as a taxi. The legislation in many countries requires this information to be revealed when offering a car for sale." .
+    :rangeIncludes :Text .
 
 :vehicleTransmission a rdf:Property ;
     rdfs:label "vehicleTransmission" ;
+    rdfs:comment "The type of component used for transmitting the power from a rotating power source to the wheels or other relevant component(s) (\"gearbox\" for cars)." ;
+    :contributor <https://schema.org/docs/collab/Automotive_Ontology_Working_Group> ;
     :domainIncludes :Vehicle ;
     :rangeIncludes :QualitativeValue,
         :Text,
-        :URL ;
-    :contributor <https://schema.org/docs/collab/Automotive_Ontology_Working_Group> ;
-    rdfs:comment "The type of component used for transmitting the power from a rotating power source to the wheels or other relevant component(s) (\"gearbox\" for cars)." .
+        :URL .
 
 :vendor a rdf:Property ;
     rdfs:label "vendor" ;
+    rdfs:comment "'vendor' is an earlier term for 'seller'." ;
+    rdfs:subPropertyOf :participant ;
     :domainIncludes :BuyAction ;
     :rangeIncludes :Organization,
         :Person ;
-    :supersededBy :seller ;
-    rdfs:comment "'vendor' is an earlier term for 'seller'." ;
-    rdfs:subPropertyOf :participant .
+    :supersededBy :seller .
 
 :version a rdf:Property ;
     rdfs:label "version" ;
+    rdfs:comment "The version of the CreativeWork embodied by a specified resource." ;
     :domainIncludes :CreativeWork ;
     :rangeIncludes :Number,
-        :Text ;
-    rdfs:comment "The version of the CreativeWork embodied by a specified resource." .
+        :Text .
 
 :video a rdf:Property ;
     rdfs:label "video" ;
+    rdfs:comment "An embedded video object." ;
     :domainIncludes :CreativeWork ;
     :rangeIncludes :Clip,
-        :VideoObject ;
-    rdfs:comment "An embedded video object." .
+        :VideoObject .
 
 :videoFormat a rdf:Property ;
     rdfs:label "videoFormat" ;
+    rdfs:comment "The type of screening or video broadcast used (e.g. IMAX, 3D, SD, HD, etc.)." ;
     :domainIncludes :BroadcastEvent,
         :BroadcastService,
         :ScreeningEvent ;
-    :rangeIncludes :Text ;
-    rdfs:comment "The type of screening or video broadcast used (e.g. IMAX, 3D, SD, HD, etc.)." .
+    :rangeIncludes :Text .
 
 :videoFrameSize a rdf:Property ;
     rdfs:label "videoFrameSize" ;
+    rdfs:comment "The frame size of the video." ;
     :domainIncludes :VideoObject ;
-    :rangeIncludes :Text ;
-    rdfs:comment "The frame size of the video." .
+    :rangeIncludes :Text .
 
 :videoQuality a rdf:Property ;
     rdfs:label "videoQuality" ;
+    rdfs:comment "The quality of the video." ;
     :domainIncludes :VideoObject ;
-    :rangeIncludes :Text ;
-    rdfs:comment "The quality of the video." .
+    :rangeIncludes :Text .
 
 :volumeNumber a rdf:Property ;
     rdfs:label "volumeNumber" ;
-    :domainIncludes :PublicationVolume ;
-    :rangeIncludes :Integer,
-        :Text ;
-    :contributor <https://schema.org/docs/collab/bibex> ;
     rdfs:comment "Identifies the volume of publication or multi-part work; for example, \"iii\" or \"2\"." ;
     rdfs:subPropertyOf :position ;
-    owl:equivalentProperty <http://purl.org/ontology/bibo/volume> .
+    owl:equivalentProperty <http://purl.org/ontology/bibo/volume> ;
+    :contributor <https://schema.org/docs/collab/bibex> ;
+    :domainIncludes :PublicationVolume ;
+    :rangeIncludes :Integer,
+        :Text .
 
 :warrantyPromise a rdf:Property ;
     rdfs:label "warrantyPromise" ;
+    rdfs:comment "The warranty promise(s) included in the offer." ;
     :domainIncludes :BuyAction,
         :SellAction ;
     :rangeIncludes :WarrantyPromise ;
-    :supersededBy :warranty ;
-    rdfs:comment "The warranty promise(s) included in the offer." .
+    :supersededBy :warranty .
 
 :warrantyScope a rdf:Property ;
     rdfs:label "warrantyScope" ;
+    rdfs:comment "The scope of the warranty promise." ;
     :domainIncludes :WarrantyPromise ;
-    :rangeIncludes :WarrantyScope ;
-    rdfs:comment "The scope of the warranty promise." .
+    :rangeIncludes :WarrantyScope .
 
 :webCheckinTime a rdf:Property ;
     rdfs:label "webCheckinTime" ;
+    rdfs:comment "The time when a passenger can check into the flight online." ;
     :domainIncludes :Flight ;
-    :rangeIncludes :DateTime ;
-    rdfs:comment "The time when a passenger can check into the flight online." .
+    :rangeIncludes :DateTime .
 
 :weight a rdf:Property ;
     rdfs:label "weight" ;
-    :domainIncludes :Person,
-        :Product, :OfferShippingDetails ;
-    :rangeIncludes :QuantitativeValue ;
-    rdfs:comment "The weight of the product or person." .
+    rdfs:comment "The weight of the product or person." ;
+    :domainIncludes :OfferShippingDetails,
+        :Person,
+        :Product ;
+    :rangeIncludes :QuantitativeValue .
 
 :width a rdf:Property ;
     rdfs:label "width" ;
+    rdfs:comment "The width of the item." ;
     :domainIncludes :MediaObject,
+        :OfferShippingDetails,
         :Product,
-        :VisualArtwork, :OfferShippingDetails ;
+        :VisualArtwork ;
     :rangeIncludes :Distance,
-        :QuantitativeValue ;
-    rdfs:comment "The width of the item." .
+        :QuantitativeValue .
 
 :winner a rdf:Property ;
     rdfs:label "winner" ;
-    :domainIncludes :LoseAction ;
-    :rangeIncludes :Person ;
     rdfs:comment "A sub property of participant. The winner of the action." ;
-    rdfs:subPropertyOf :participant .
+    rdfs:subPropertyOf :participant ;
+    :domainIncludes :LoseAction ;
+    :rangeIncludes :Person .
 
 :wordCount a rdf:Property ;
     rdfs:label "wordCount" ;
+    rdfs:comment "The number of words in the text of the Article." ;
     :domainIncludes :Article ;
-    :rangeIncludes :Integer ;
-    rdfs:comment "The number of words in the text of the Article." .
+    :rangeIncludes :Integer .
 
 :workHours a rdf:Property ;
     rdfs:label "workHours" ;
+    rdfs:comment "The typical working hours for this job (e.g. 1st shift, night shift, 8am-5pm)." ;
     :domainIncludes :JobPosting ;
-    :rangeIncludes :Text ;
-    rdfs:comment "The typical working hours for this job (e.g. 1st shift, night shift, 8am-5pm)." .
+    :rangeIncludes :Text .
 
 :workLocation a rdf:Property ;
     rdfs:label "workLocation" ;
+    rdfs:comment "A contact location for a person's place of work." ;
+    rdfs:subPropertyOf :location ;
     :domainIncludes :Person ;
     :rangeIncludes :ContactPoint,
-        :Place ;
-    rdfs:comment "A contact location for a person's place of work." ;
-    rdfs:subPropertyOf :location .
+        :Place .
 
 :workPerformed a rdf:Property ;
     rdfs:label "workPerformed" ;
-    :domainIncludes :Event ;
-    :rangeIncludes :CreativeWork ;
     rdfs:comment "A work performed in some event, for example a play performed in a TheaterEvent." ;
-    rdfs:subPropertyOf :workFeatured .
+    rdfs:subPropertyOf :workFeatured ;
+    :domainIncludes :Event ;
+    :rangeIncludes :CreativeWork .
 
 :workPresented a rdf:Property ;
     rdfs:label "workPresented" ;
-    :domainIncludes :ScreeningEvent ;
-    :rangeIncludes :Movie ;
     rdfs:comment "The movie presented during this event." ;
-    rdfs:subPropertyOf :workFeatured .
+    rdfs:subPropertyOf :workFeatured ;
+    :domainIncludes :ScreeningEvent ;
+    :rangeIncludes :Movie .
 
 :worksFor a rdf:Property ;
     rdfs:label "worksFor" ;
+    rdfs:comment "Organizations that the person works for." ;
     :domainIncludes :Person ;
-    :rangeIncludes :Organization ;
-    rdfs:comment "Organizations that the person works for." .
+    :rangeIncludes :Organization .
 
 :worstRating a rdf:Property ;
     rdfs:label "worstRating" ;
+    rdfs:comment "The lowest value allowed in this rating system." ;
     :domainIncludes :Rating ;
     :rangeIncludes :Number,
-        :Text ;
-    rdfs:comment "The lowest value allowed in this rating system." .
+        :Text .
 
 :xpath a rdf:Property ;
     rdfs:label "xpath" ;
+    rdfs:comment "An XPath, e.g. of a [[SpeakableSpecification]] or [[WebPageElement]]. In the latter case, multiple matches within a page can constitute a single conceptual \"Web page element\"." ;
     :domainIncludes :SpeakableSpecification,
         :WebPageElement ;
     :rangeIncludes :XPathType ;
-    :source <https://github.com/schemaorg/schemaorg/issues/1389> ;
-    rdfs:comment "An XPath, e.g. of a [[SpeakableSpecification]] or [[WebPageElement]]. In the latter case, multiple matches within a page can constitute a single conceptual \"Web page element\"." .
+    :source <https://github.com/schemaorg/schemaorg/issues/1389> .
 
 :yearlyRevenue a rdf:Property ;
     rdfs:label "yearlyRevenue" ;
+    rdfs:comment "The size of the business in annual revenue." ;
     :domainIncludes :BusinessAudience ;
-    :rangeIncludes :QuantitativeValue ;
-    rdfs:comment "The size of the business in annual revenue." .
+    :rangeIncludes :QuantitativeValue .
 
 :yearsInOperation a rdf:Property ;
     rdfs:label "yearsInOperation" ;
+    rdfs:comment "The age of the business." ;
     :domainIncludes :BusinessAudience ;
-    :rangeIncludes :QuantitativeValue ;
-    rdfs:comment "The age of the business." .
+    :rangeIncludes :QuantitativeValue .
 
 :actionApplication a rdf:Property ;
     rdfs:label "actionApplication" ;
+    rdfs:comment "An application that can complete the request." ;
     :domainIncludes :EntryPoint ;
-    :rangeIncludes :SoftwareApplication ;
-    rdfs:comment "An application that can complete the request." .
+    :rangeIncludes :SoftwareApplication .
 
 :actionOption a rdf:Property ;
     rdfs:label "actionOption" ;
+    rdfs:comment "A sub property of object. The options subject to this action." ;
+    rdfs:subPropertyOf :object ;
     :domainIncludes :ChooseAction ;
     :rangeIncludes :Text,
-        :Thing ;
-    rdfs:comment "A sub property of object. The options subject to this action." ;
-    rdfs:subPropertyOf :object .
+        :Thing .
 
 :actor a rdf:Property ;
     rdfs:label "actor" ;
+    rdfs:comment "An actor (individual or a group), e.g. in TV, radio, movie, video games etc., or in an event. Actors can be associated with individual items or with a series, episode, clip." ;
     :domainIncludes :Clip,
         :CreativeWorkSeason,
         :Episode,
@@ -9593,155 +9612,161 @@ we define a supporting type, [[SpeakableSpecification]]  which is defined to be 
         :VideoGame,
         :VideoGameSeries,
         :VideoObject ;
-    :rangeIncludes :Person,
-        :PerformingGroup ;
-    rdfs:comment "An actor (individual or a group), e.g. in TV, radio, movie, video games etc., or in an event. Actors can be associated with individual items or with a series, episode, clip." .
+    :rangeIncludes :PerformingGroup,
+        :Person .
 
 :album a rdf:Property ;
     rdfs:label "album" ;
+    rdfs:comment "A music album." ;
     :domainIncludes :MusicGroup ;
-    :rangeIncludes :MusicAlbum ;
-    rdfs:comment "A music album." .
+    :rangeIncludes :MusicAlbum .
 
 :albumRelease a rdf:Property ;
     rdfs:label "albumRelease" ;
+    rdfs:comment "A release of this album." ;
     :domainIncludes :MusicAlbum ;
     :inverseOf :releaseOf ;
-    :rangeIncludes :MusicRelease ;
-    rdfs:comment "A release of this album." .
+    :rangeIncludes :MusicRelease .
+
+:alternateName a rdf:Property ;
+    rdfs:label "alternateName" ;
+    rdfs:comment "An alias for the item." ;
+    :domainIncludes :Thing ;
+    :rangeIncludes :Text .
 
 :alumni a rdf:Property ;
     rdfs:label "alumni" ;
+    rdfs:comment "Alumni of an organization." ;
     :domainIncludes :EducationalOrganization,
         :Organization ;
     :inverseOf :alumniOf ;
-    :rangeIncludes :Person ;
-    rdfs:comment "Alumni of an organization." .
+    :rangeIncludes :Person .
 
 :alumniOf a rdf:Property ;
     rdfs:label "alumniOf" ;
+    rdfs:comment "An organization that the person is an alumni of." ;
     :domainIncludes :Person ;
     :inverseOf :alumni ;
     :rangeIncludes :EducationalOrganization,
-        :Organization ;
-    rdfs:comment "An organization that the person is an alumni of." .
+        :Organization .
 
 :artworkSurface a rdf:Property ;
     rdfs:label "artworkSurface" ;
+    rdfs:comment "The supporting materials for the artwork, e.g. Canvas, Paper, Wood, Board, etc." ;
     :domainIncludes :VisualArtwork ;
     :rangeIncludes :Text,
-        :URL ;
-    rdfs:comment "The supporting materials for the artwork, e.g. Canvas, Paper, Wood, Board, etc." .
+        :URL .
 
 :attendee a rdf:Property ;
     rdfs:label "attendee" ;
+    rdfs:comment "A person or organization attending the event." ;
     :domainIncludes :Event ;
     :rangeIncludes :Organization,
-        :Person ;
-    rdfs:comment "A person or organization attending the event." .
+        :Person .
 
 :audience a rdf:Property ;
     rdfs:label "audience" ;
+    rdfs:comment "An intended audience, i.e. a group for whom something was created." ;
     :domainIncludes :CreativeWork,
         :Event,
         :LodgingBusiness,
         :PlayAction,
         :Product,
         :Service ;
-    :rangeIncludes :Audience ;
-    rdfs:comment "An intended audience, i.e. a group for whom something was created." .
+    :rangeIncludes :Audience .
 
 :availableOnDevice a rdf:Property ;
     rdfs:label "availableOnDevice" ;
+    rdfs:comment "Device required to run the application. Used in cases where a specific make/model is required to run the application." ;
     :domainIncludes :SoftwareApplication ;
-    :rangeIncludes :Text ;
-    rdfs:comment "Device required to run the application. Used in cases where a specific make/model is required to run the application." .
+    :rangeIncludes :Text .
 
 :award a rdf:Property ;
     rdfs:label "award" ;
+    rdfs:comment "An award won by or for this item." ;
     :domainIncludes :CreativeWork,
         :Organization,
         :Person,
         :Product,
         :Service ;
-    :rangeIncludes :Text ;
-    rdfs:comment "An award won by or for this item." .
+    :rangeIncludes :Text .
 
 :blogPost a rdf:Property ;
     rdfs:label "blogPost" ;
+    rdfs:comment "A posting that is part of this blog." ;
     :domainIncludes :Blog ;
-    :rangeIncludes :BlogPosting ;
-    rdfs:comment "A posting that is part of this blog." .
+    :rangeIncludes :BlogPosting .
 
 :broker a rdf:Property ;
     rdfs:label "broker" ;
+    rdfs:comment "An entity that arranges for an exchange between a buyer and a seller.  In most cases a broker never acquires or releases ownership of a product or service involved in an exchange.  If it is not clear whether an entity is a broker, seller, or buyer, the latter two terms are preferred." ;
     :domainIncludes :Invoice,
         :Order,
         :Reservation,
         :Service ;
     :rangeIncludes :Organization,
-        :Person ;
-    rdfs:comment "An entity that arranges for an exchange between a buyer and a seller.  In most cases a broker never acquires or releases ownership of a product or service involved in an exchange.  If it is not clear whether an entity is a broker, seller, or buyer, the latter two terms are preferred." .
+        :Person .
 
 :codeSampleType a rdf:Property ;
     rdfs:label "codeSampleType" ;
+    rdfs:comment "What type of code sample: full (compile ready) solution, code snippet, inline code, scripts, template." ;
     :domainIncludes :SoftwareSourceCode ;
-    :rangeIncludes :Text ;
-    rdfs:comment "What type of code sample: full (compile ready) solution, code snippet, inline code, scripts, template." .
+    :rangeIncludes :Text .
 
 :colleague a rdf:Property ;
     rdfs:label "colleague" ;
+    rdfs:comment "A colleague of the person." ;
     :domainIncludes :Person ;
     :rangeIncludes :Person,
-        :URL ;
-    rdfs:comment "A colleague of the person." .
+        :URL .
 
 :contactPoint a rdf:Property ;
     rdfs:label "contactPoint" ;
+    rdfs:comment "A contact point for a person or organization." ;
     :domainIncludes :Organization,
         :Person ;
-    :rangeIncludes :ContactPoint ;
-    rdfs:comment "A contact point for a person or organization." .
+    :rangeIncludes :ContactPoint .
 
 :containsPlace a rdf:Property ;
     rdfs:label "containsPlace" ;
+    rdfs:comment "The basic containment relation between a place and another that it contains." ;
     :domainIncludes :Place ;
     :inverseOf :containedInPlace ;
-    :rangeIncludes :Place ;
-    rdfs:comment "The basic containment relation between a place and another that it contains." .
+    :rangeIncludes :Place .
 
 :containsSeason a rdf:Property ;
     rdfs:label "containsSeason" ;
+    rdfs:comment "A season that is part of the media series." ;
+    rdfs:subPropertyOf :hasPart ;
     :domainIncludes :RadioSeries,
         :TVSeries,
         :VideoGameSeries ;
-    :rangeIncludes :CreativeWorkSeason ;
-    rdfs:comment "A season that is part of the media series." ;
-    rdfs:subPropertyOf :hasPart .
+    :rangeIncludes :CreativeWorkSeason .
 
 :contentLocation a rdf:Property ;
     rdfs:label "contentLocation" ;
+    rdfs:comment "The location depicted or described in the content. For example, the location in a photograph or painting." ;
     :domainIncludes :CreativeWork ;
-    :rangeIncludes :Place ;
-    rdfs:comment "The location depicted or described in the content. For example, the location in a photograph or painting." .
+    :rangeIncludes :Place .
 
 :dataset a rdf:Property ;
     rdfs:label "dataset" ;
+    rdfs:comment "A dataset contained in this catalog." ;
     :domainIncludes :DataCatalog ;
     :inverseOf :includedInDataCatalog ;
-    :rangeIncludes :Dataset ;
-    rdfs:comment "A dataset contained in this catalog." .
+    :rangeIncludes :Dataset .
 
 :description a rdf:Property ;
     rdfs:label "description" ;
+    rdfs:comment "A description of the item." ;
+    owl:equivalentProperty dc:description ;
     :domainIncludes :Thing ;
     :rangeIncludes :Text,
-        :TextObject ;
-    rdfs:comment "A description of the item." ;
-    owl:equivalentProperty dc:description .
+        :TextObject .
 
 :director a rdf:Property ;
     rdfs:label "director" ;
+    rdfs:comment "A director of e.g. TV, radio, movie, video gaming etc. content, or of an event. Directors can be associated with individual items or with a series, episode, clip." ;
     :domainIncludes :Clip,
         :CreativeWorkSeason,
         :Episode,
@@ -9753,60 +9778,60 @@ we define a supporting type, [[SpeakableSpecification]]  which is defined to be 
         :VideoGame,
         :VideoGameSeries,
         :VideoObject ;
-    :rangeIncludes :Person ;
-    rdfs:comment "A director of e.g. TV, radio, movie, video gaming etc. content, or of an event. Directors can be associated with individual items or with a series, episode, clip." .
+    :rangeIncludes :Person .
 
 :duration a rdf:Property ;
     rdfs:label "duration" ;
-    :domainIncludes :Event,
+    rdfs:comment "The duration of the item (movie, audio recording, event, etc.) in [ISO 8601 duration format](http://en.wikipedia.org/wiki/ISO_8601)." ;
+    :domainIncludes :Episode,
+        :Event,
         :MediaObject,
         :Movie,
         :MusicRecording,
         :MusicRelease,
-        :QuantitativeValueDistribution,
-	      :Episode ;
+        :QuantitativeValueDistribution ;
     :rangeIncludes :Duration,
         :Text ;
-    :source <https://github.com/schemaorg/schemaorg/issues/1698> ;
-    rdfs:comment "The duration of the item (movie, audio recording, event, etc.) in [ISO 8601 duration format](http://en.wikipedia.org/wiki/ISO_8601)." .
+    :source <https://github.com/schemaorg/schemaorg/issues/1698> .
 
 :employee a rdf:Property ;
     rdfs:label "employee" ;
+    rdfs:comment "Someone working for this organization." ;
     :domainIncludes :Organization ;
-    :rangeIncludes :Person ;
-    rdfs:comment "Someone working for this organization." .
+    :rangeIncludes :Person .
 
 :encodesCreativeWork a rdf:Property ;
     rdfs:label "encodesCreativeWork" ;
+    rdfs:comment "The CreativeWork encoded by this media object." ;
     :domainIncludes :MediaObject ;
     :inverseOf :encoding ;
-    :rangeIncludes :CreativeWork ;
-    rdfs:comment "The CreativeWork encoded by this media object." .
+    :rangeIncludes :CreativeWork .
 
 :encodingFormat a rdf:Property ;
     rdfs:label "encodingFormat" ;
-    :domainIncludes :CreativeWork,
-        :MediaObject ;
-    :rangeIncludes :Text,
-        :URL ;
     rdfs:comment """Media type typically expressed using a MIME format (see [IANA site](http://www.iana.org/assignments/media-types/media-types.xhtml) and [MDN reference](https://developer.mozilla.org/en-US/docs/Web/HTTP/Basics_of_HTTP/MIME_types)), e.g. application/zip for a SoftwareApplication binary, audio/mpeg for .mp3 etc.
 
 In cases where a [[CreativeWork]] has several media type representations, [[encoding]] can be used to indicate each [[MediaObject]] alongside particular [[encodingFormat]] information.
 
-Unregistered or niche encoding and file formats can be indicated instead via the most appropriate URL, e.g. defining Web page or a Wikipedia/Wikidata entry.""" .
+Unregistered or niche encoding and file formats can be indicated instead via the most appropriate URL, e.g. defining Web page or a Wikipedia/Wikidata entry.""" ;
+    :domainIncludes :CreativeWork,
+        :MediaObject ;
+    :rangeIncludes :Text,
+        :URL .
 
 :episode a rdf:Property ;
     rdfs:label "episode" ;
+    rdfs:comment "An episode of a TV, radio or game media within a series or season." ;
+    rdfs:subPropertyOf :hasPart ;
     :domainIncludes :CreativeWorkSeason,
         :RadioSeries,
         :TVSeries,
         :VideoGameSeries ;
-    :rangeIncludes :Episode ;
-    rdfs:comment "An episode of a TV, radio or game media within a series or season." ;
-    rdfs:subPropertyOf :hasPart .
+    :rangeIncludes :Episode .
 
 :event a rdf:Property ;
     rdfs:label "event" ;
+    rdfs:comment "Upcoming or past event associated with this place, organization, or action." ;
     :domainIncludes :InformAction,
         :InviteAction,
         :JoinAction,
@@ -9814,106 +9839,107 @@ Unregistered or niche encoding and file formats can be indicated instead via the
         :Organization,
         :Place,
         :PlayAction ;
-    :rangeIncludes :Event ;
-    rdfs:comment "Upcoming or past event associated with this place, organization, or action." .
+    :rangeIncludes :Event .
 
 :exampleOfWork a rdf:Property ;
     rdfs:label "exampleOfWork" ;
+    rdfs:comment "A creative work that this work is an example/instance/realization/derivation of." ;
+    :contributor <https://schema.org/docs/collab/bibex> ;
     :domainIncludes :CreativeWork ;
     :inverseOf :workExample ;
-    :rangeIncludes :CreativeWork ;
-    :contributor <https://schema.org/docs/collab/bibex> ;
-    rdfs:comment "A creative work that this work is an example/instance/realization/derivation of." .
+    :rangeIncludes :CreativeWork .
 
 :executableLibraryName a rdf:Property ;
     rdfs:label "executableLibraryName" ;
+    rdfs:comment "Library file name, e.g., mscorlib.dll, system.web.dll." ;
     :domainIncludes :APIReference ;
-    :rangeIncludes :Text ;
-    rdfs:comment "Library file name, e.g., mscorlib.dll, system.web.dll." .
+    :rangeIncludes :Text .
 
 :exerciseCourse a rdf:Property ;
     rdfs:label "exerciseCourse" ;
-    :domainIncludes :ExerciseAction ;
-    :rangeIncludes :Place ;
     rdfs:comment "A sub property of location. The course where this action was taken." ;
-    rdfs:subPropertyOf :location .
+    rdfs:subPropertyOf :location ;
+    :domainIncludes :ExerciseAction ;
+    :rangeIncludes :Place .
 
 :founder a rdf:Property ;
     rdfs:label "founder" ;
+    rdfs:comment "A person or organization who founded this organization." ;
     :domainIncludes :Organization ;
-    :rangeIncludes :Person, :Organization; ;
-    rdfs:comment "A person or organization who founded this organization." .
+    :rangeIncludes :Organization,
+        :Person .
 
 :game a rdf:Property ;
     rdfs:label "game" ;
+    rdfs:comment "Video game which is played on this server." ;
     :domainIncludes :GameServer ;
     :inverseOf :gameServer ;
-    :rangeIncludes :VideoGame ;
-    rdfs:comment "Video game which is played on this server." .
+    :rangeIncludes :VideoGame .
 
 :gameServer a rdf:Property ;
     rdfs:label "gameServer" ;
+    rdfs:comment "The server on which  it is possible to play the game." ;
     :domainIncludes :VideoGame ;
     :inverseOf :game ;
-    :rangeIncludes :GameServer ;
-    rdfs:comment "The server on which  it is possible to play the game." .
+    :rangeIncludes :GameServer .
 
 :hasBroadcastChannel a rdf:Property ;
     rdfs:label "hasBroadcastChannel" ;
+    rdfs:comment "A broadcast channel of a broadcast service." ;
     :domainIncludes :BroadcastService ;
     :inverseOf :providesBroadcastService ;
     :rangeIncludes :BroadcastChannel ;
-    :source <https://github.com/schemaorg/schemaorg/issues/1004> ;
-    rdfs:comment "A broadcast channel of a broadcast service." .
+    :source <https://github.com/schemaorg/schemaorg/issues/1004> .
 
 :hasMenu a rdf:Property ;
     rdfs:label "hasMenu" ;
+    rdfs:comment "Either the actual menu as a structured representation, as text, or a URL of the menu." ;
     :domainIncludes :FoodEstablishment ;
     :rangeIncludes :Menu,
         :Text,
-        :URL ;
-    rdfs:comment "Either the actual menu as a structured representation, as text, or a URL of the menu." .
+        :URL .
 
 :inLanguage a rdf:Property ;
     rdfs:label "inLanguage" ;
+    rdfs:comment "The language of the content or performance or used in an action. Please use one of the language codes from the [IETF BCP 47 standard](http://tools.ietf.org/html/bcp47). See also [[availableLanguage]]." ;
     :domainIncludes :CommunicateAction,
         :CreativeWork,
         :Event,
         :WriteAction ;
     :rangeIncludes :Language,
-        :Text ;
-    rdfs:comment "The language of the content or performance or used in an action. Please use one of the language codes from the [IETF BCP 47 standard](http://tools.ietf.org/html/bcp47). See also [[availableLanguage]]." .
+        :Text .
 
 :incentiveCompensation a rdf:Property ;
     rdfs:label "incentiveCompensation" ;
+    rdfs:comment "Description of bonus and commission compensation aspects of the job." ;
     :domainIncludes :JobPosting ;
-    :rangeIncludes :Text ;
-    rdfs:comment "Description of bonus and commission compensation aspects of the job." .
+    :rangeIncludes :Text .
 
 :interactionStatistic a rdf:Property ;
     rdfs:label "interactionStatistic" ;
+    rdfs:comment "The number of interactions for the CreativeWork using the WebSite or SoftwareApplication. The most specific child type of InteractionCounter should be used." ;
     :domainIncludes :CreativeWork ;
-    :rangeIncludes :InteractionCounter ;
-    rdfs:comment "The number of interactions for the CreativeWork using the WebSite or SoftwareApplication. The most specific child type of InteractionCounter should be used." .
+    :rangeIncludes :InteractionCounter .
 
 :isAccessibleForFree a rdf:Property ;
     rdfs:label "isAccessibleForFree" ;
+    rdfs:comment "A flag to signal that the item, event, or place is accessible for free." ;
     :domainIncludes :CreativeWork,
         :Event,
         :Place ;
-    :rangeIncludes :Boolean ;
-    rdfs:comment "A flag to signal that the item, event, or place is accessible for free." .
+    :rangeIncludes :Boolean .
 
 :isBasedOn a rdf:Property ;
     rdfs:label "isBasedOn" ;
+    rdfs:comment "A resource from which this work is derived or from which it is a modification or adaptation." ;
     :domainIncludes :CreativeWork ;
     :rangeIncludes :CreativeWork,
         :Product,
-        :URL ;
-    rdfs:comment "A resource from which this work is derived or from which it is a modification or adaptation." .
+        :URL .
 
 :itemOffered a rdf:Property ;
     rdfs:label "itemOffered" ;
+    rdfs:comment "An item being offered (or demanded). The transactional nature of the offer or demand is documented using [[businessFunction]], e.g. sell, lease etc. While several common expected types are listed explicitly in this definition, others can be used. Using a second type, such as Product or a subtype of Product, can clarify the nature of the offer." ;
     :domainIncludes :Demand,
         :Offer ;
     :inverseOf :offers ;
@@ -9923,49 +9949,50 @@ Unregistered or niche encoding and file formats can be indicated instead via the
         :MenuItem,
         :Product,
         :Service,
-        :Trip ;
-    rdfs:comment "An item being offered (or demanded). The transactional nature of the offer or demand is documented using [[businessFunction]], e.g. sell, lease etc. While several common expected types are listed explicitly in this definition, others can be used. Using a second type, such as Product or a subtype of Product, can clarify the nature of the offer." .
+        :Trip .
 
 :jobBenefits a rdf:Property ;
     rdfs:label "jobBenefits" ;
+    rdfs:comment "Description of benefits associated with the job." ;
     :domainIncludes :JobPosting ;
-    :rangeIncludes :Text ;
-    rdfs:comment "Description of benefits associated with the job." .
+    :rangeIncludes :Text .
 
 :mainEntity a rdf:Property ;
     rdfs:label "mainEntity" ;
+    rdfs:comment "Indicates the primary entity described in some page or other CreativeWork." ;
+    rdfs:subPropertyOf :about ;
     :domainIncludes :CreativeWork ;
     :inverseOf :mainEntityOfPage ;
-    :rangeIncludes :Thing ;
-    rdfs:comment "Indicates the primary entity described in some page or other CreativeWork." ;
-    rdfs:subPropertyOf :about .
+    :rangeIncludes :Thing .
 
 :mainEntityOfPage a rdf:Property ;
     rdfs:label "mainEntityOfPage" ;
+    rdfs:comment "Indicates a page (or other CreativeWork) for which this thing is the main entity being described. See [background notes](/docs/datamodel.html#mainEntityBackground) for details." ;
     :domainIncludes :Thing ;
     :inverseOf :mainEntity ;
     :rangeIncludes :CreativeWork,
-        :URL ;
-    rdfs:comment "Indicates a page (or other CreativeWork) for which this thing is the main entity being described. See [background notes](/docs/datamodel.html#mainEntityBackground) for details." .
+        :URL .
 
 :makesOffer a rdf:Property ;
     rdfs:label "makesOffer" ;
+    rdfs:comment "A pointer to products or services offered by the organization or person." ;
     :domainIncludes :Organization,
         :Person ;
     :inverseOf :offeredBy ;
-    :rangeIncludes :Offer ;
-    rdfs:comment "A pointer to products or services offered by the organization or person." .
+    :rangeIncludes :Offer .
 
 :offeredBy a rdf:Property ;
     rdfs:label "offeredBy" ;
+    rdfs:comment "A pointer to the organization or person making the offer." ;
     :domainIncludes :Offer ;
     :inverseOf :makesOffer ;
     :rangeIncludes :Organization,
-        :Person ;
-    rdfs:comment "A pointer to the organization or person making the offer." .
+        :Person .
 
 :offers a rdf:Property ;
     rdfs:label "offers" ;
+    rdfs:comment """An offer to provide this item&#x2014;for example, an offer to sell a product, rent the DVD of a movie, perform a service, or give away tickets to an event. Use [[businessFunction]] to indicate the kind of transaction offered, i.e. sell, lease, etc. This property can also be used to describe a [[Demand]]. While this property is listed as expected on a number of common types, it can be used in others. In that case, using a second type, such as Product or a subtype of Product, can clarify the nature of the offer.
+      """ ;
     :domainIncludes :AggregateOffer,
         :CreativeWork,
         :Event,
@@ -9975,57 +10002,56 @@ Unregistered or niche encoding and file formats can be indicated instead via the
         :Trip ;
     :inverseOf :itemOffered ;
     :rangeIncludes :Demand,
-        :Offer ;
-    rdfs:comment """An offer to provide this item&#x2014;for example, an offer to sell a product, rent the DVD of a movie, perform a service, or give away tickets to an event. Use [[businessFunction]] to indicate the kind of transaction offered, i.e. sell, lease, etc. This property can also be used to describe a [[Demand]]. While this property is listed as expected on a number of common types, it can be used in others. In that case, using a second type, such as Product or a subtype of Product, can clarify the nature of the offer.
-      """ .
+        :Offer .
 
 :parent a rdf:Property ;
     rdfs:label "parent" ;
+    rdfs:comment "A parent of this person." ;
     :domainIncludes :Person ;
-    :rangeIncludes :Person ;
-    rdfs:comment "A parent of this person." .
+    :rangeIncludes :Person .
 
 :partOfSeries a rdf:Property ;
     rdfs:label "partOfSeries" ;
+    rdfs:comment "The series to which this episode or season belongs." ;
+    rdfs:subPropertyOf :isPartOf ;
     :domainIncludes :Clip,
         :CreativeWorkSeason,
         :Episode ;
-    :rangeIncludes :CreativeWorkSeries ;
-    rdfs:comment "The series to which this episode or season belongs." ;
-    rdfs:subPropertyOf :isPartOf .
+    :rangeIncludes :CreativeWorkSeries .
 
 :paymentDueDate a rdf:Property ;
     rdfs:label "paymentDueDate" ;
+    rdfs:comment "The date that payment is due." ;
     :domainIncludes :Invoice,
         :Order ;
     :rangeIncludes :Date,
-        :DateTime ;
-    rdfs:comment "The date that payment is due." .
+        :DateTime .
 
 :performTime a rdf:Property ;
     rdfs:label "performTime" ;
+    rdfs:comment "The length of time it takes to perform instructions or a direction (not including time to prepare the supplies), in [ISO 8601 duration format](http://en.wikipedia.org/wiki/ISO_8601)." ;
     :domainIncludes :HowTo,
         :HowToDirection ;
-    :rangeIncludes :Duration ;
-    rdfs:comment "The length of time it takes to perform instructions or a direction (not including time to prepare the supplies), in [ISO 8601 duration format](http://en.wikipedia.org/wiki/ISO_8601)." .
+    :rangeIncludes :Duration .
 
 :performer a rdf:Property ;
     rdfs:label "performer" ;
+    rdfs:comment "A performer at the event&#x2014;for example, a presenter, musician, musical group or actor." ;
     :domainIncludes :Event ;
     :rangeIncludes :Organization,
-        :Person ;
-    rdfs:comment "A performer at the event&#x2014;for example, a presenter, musician, musical group or actor." .
+        :Person .
 
 :photo a rdf:Property ;
     rdfs:label "photo" ;
+    rdfs:comment "A photograph of this place." ;
+    rdfs:subPropertyOf :image ;
     :domainIncludes :Place ;
     :rangeIncludes :ImageObject,
-        :Photograph ;
-    rdfs:comment "A photograph of this place." ;
-    rdfs:subPropertyOf :image .
+        :Photograph .
 
 :provider a rdf:Property ;
     rdfs:label "provider" ;
+    rdfs:comment "The service provider, service operator, or service performer; the goods producer. Another party (a seller) may offer those services or goods on behalf of the provider. A provider may also serve as the seller." ;
     :domainIncludes :CreativeWork,
         :Invoice,
         :ParcelDelivery,
@@ -10033,63 +10059,63 @@ Unregistered or niche encoding and file formats can be indicated instead via the
         :Service,
         :Trip ;
     :rangeIncludes :Organization,
-        :Person ;
-    rdfs:comment "The service provider, service operator, or service performer; the goods producer. Another party (a seller) may offer those services or goods on behalf of the provider. A provider may also serve as the seller." .
+        :Person .
 
 :providesBroadcastService a rdf:Property ;
     rdfs:label "providesBroadcastService" ;
+    rdfs:comment "The BroadcastService offered on this channel." ;
     :domainIncludes :BroadcastChannel ;
     :inverseOf :hasBroadcastChannel ;
-    :rangeIncludes :BroadcastService ;
-    rdfs:comment "The BroadcastService offered on this channel." .
+    :rangeIncludes :BroadcastService .
 
 :recipeIngredient a rdf:Property ;
     rdfs:label "recipeIngredient" ;
-    :domainIncludes :Recipe ;
-    :rangeIncludes :Text ;
     rdfs:comment "A single ingredient used in the recipe, e.g. sugar, flour or garlic." ;
-    rdfs:subPropertyOf :supply .
+    rdfs:subPropertyOf :supply ;
+    :domainIncludes :Recipe ;
+    :rangeIncludes :Text .
 
 :recordedAs a rdf:Property ;
     rdfs:label "recordedAs" ;
+    rdfs:comment "An audio recording of the work." ;
+    :contributor <https://schema.org/docs/collab/MBZ> ;
     :domainIncludes :MusicComposition ;
     :inverseOf :recordingOf ;
-    :rangeIncludes :MusicRecording ;
-    :contributor <https://schema.org/docs/collab/MBZ> ;
-    rdfs:comment "An audio recording of the work." .
+    :rangeIncludes :MusicRecording .
 
 :recordedAt a rdf:Property ;
     rdfs:label "recordedAt" ;
+    rdfs:comment "The Event where the CreativeWork was recorded. The CreativeWork may capture all or part of the event." ;
     :domainIncludes :CreativeWork ;
     :inverseOf :recordedIn ;
-    :rangeIncludes :Event ;
-    rdfs:comment "The Event where the CreativeWork was recorded. The CreativeWork may capture all or part of the event." .
+    :rangeIncludes :Event .
 
 :recordedIn a rdf:Property ;
     rdfs:label "recordedIn" ;
+    rdfs:comment "The CreativeWork that captured all or part of this Event." ;
     :domainIncludes :Event ;
     :inverseOf :recordedAt ;
-    :rangeIncludes :CreativeWork ;
-    rdfs:comment "The CreativeWork that captured all or part of this Event." .
+    :rangeIncludes :CreativeWork .
 
 :recordingOf a rdf:Property ;
     rdfs:label "recordingOf" ;
+    rdfs:comment "The composition this track is a recording of." ;
+    :contributor <https://schema.org/docs/collab/MBZ> ;
     :domainIncludes :MusicRecording ;
     :inverseOf :recordedAs ;
-    :rangeIncludes :MusicComposition ;
-    :contributor <https://schema.org/docs/collab/MBZ> ;
-    rdfs:comment "The composition this track is a recording of." .
+    :rangeIncludes :MusicComposition .
 
 :releaseOf a rdf:Property ;
     rdfs:label "releaseOf" ;
+    rdfs:comment "The album this is a release of." ;
+    :contributor <https://schema.org/docs/collab/MBZ> ;
     :domainIncludes :MusicRelease ;
     :inverseOf :albumRelease ;
-    :rangeIncludes :MusicAlbum ;
-    :contributor <https://schema.org/docs/collab/MBZ> ;
-    rdfs:comment "The album this is a release of." .
+    :rangeIncludes :MusicAlbum .
 
 :review a rdf:Property ;
     rdfs:label "review" ;
+    rdfs:comment "A review of the item." ;
     :domainIncludes :Brand,
         :CreativeWork,
         :Event,
@@ -10098,292 +10124,292 @@ Unregistered or niche encoding and file formats can be indicated instead via the
         :Place,
         :Product,
         :Service ;
-    :rangeIncludes :Review ;
-    rdfs:comment "A review of the item." .
+    :rangeIncludes :Review .
 
 :roleName a rdf:Property ;
     rdfs:label "roleName" ;
+    rdfs:comment "A role played, performed or filled by a person or organization. For example, the team of creators for a comic book might fill the roles named 'inker', 'penciller', and 'letterer'; or an athlete in a SportsTeam might play in the position named 'Quarterback'." ;
     :domainIncludes :Role ;
     :rangeIncludes :Text,
-        :URL ;
-    rdfs:comment "A role played, performed or filled by a person or organization. For example, the team of creators for a comic book might fill the roles named 'inker', 'penciller', and 'letterer'; or an athlete in a SportsTeam might play in the position named 'Quarterback'." .
+        :URL .
 
 :runtimePlatform a rdf:Property ;
     rdfs:label "runtimePlatform" ;
+    rdfs:comment "Runtime platform or script interpreter dependencies (example: Java v1, Python 2.3, .NET Framework 3.0)." ;
     :domainIncludes :SoftwareSourceCode ;
-    :rangeIncludes :Text ;
-    rdfs:comment "Runtime platform or script interpreter dependencies (example: Java v1, Python 2.3, .NET Framework 3.0)." .
+    :rangeIncludes :Text .
 
 :season a rdf:Property ;
     rdfs:label "season" ;
+    rdfs:comment "A season in a media series." ;
+    rdfs:subPropertyOf :hasPart ;
     :domainIncludes :RadioSeries,
         :TVSeries,
         :VideoGameSeries ;
     :rangeIncludes :CreativeWorkSeason,
         :URL ;
-    :supersededBy :containsSeason ;
-    rdfs:comment "A season in a media series." ;
-    rdfs:subPropertyOf :hasPart .
+    :supersededBy :containsSeason .
 
 :serialNumber a rdf:Property ;
     rdfs:label "serialNumber" ;
+    rdfs:comment "The serial number or any alphanumeric identifier of a particular product. When attached to an offer, it is a shortcut for the serial number of the product included in the offer." ;
+    rdfs:subPropertyOf :identifier ;
     :domainIncludes :Demand,
         :IndividualProduct,
         :Offer ;
-    :rangeIncludes :Text ;
-    rdfs:comment "The serial number or any alphanumeric identifier of a particular product. When attached to an offer, it is a shortcut for the serial number of the product included in the offer." ;
-    rdfs:subPropertyOf :identifier .
+    :rangeIncludes :Text .
 
 :serviceArea a rdf:Property ;
     rdfs:label "serviceArea" ;
+    rdfs:comment "The geographic area where the service is provided." ;
     :domainIncludes :ContactPoint,
         :Organization,
         :Service ;
     :rangeIncludes :AdministrativeArea,
         :GeoShape,
         :Place ;
-    :supersededBy :areaServed ;
-    rdfs:comment "The geographic area where the service is provided." .
+    :supersededBy :areaServed .
 
 :serviceOutput a rdf:Property ;
     rdfs:label "serviceOutput" ;
+    rdfs:comment "The tangible thing generated by the service, e.g. a passport, permit, etc." ;
     :domainIncludes :Service ;
-    :rangeIncludes :Thing ;
-    rdfs:comment "The tangible thing generated by the service, e.g. a passport, permit, etc." .
+    :rangeIncludes :Thing .
 
 :sibling a rdf:Property ;
     rdfs:label "sibling" ;
+    rdfs:comment "A sibling of the person." ;
     :domainIncludes :Person ;
-    :rangeIncludes :Person ;
-    rdfs:comment "A sibling of the person." .
+    :rangeIncludes :Person .
 
 :significantLink a rdf:Property ;
     rdfs:label "significantLink" ;
+    rdfs:comment "One of the more significant URLs on the page. Typically, these are the non-navigation links that are clicked on the most." ;
     :domainIncludes :WebPage ;
-    :rangeIncludes :URL ;
-    rdfs:comment "One of the more significant URLs on the page. Typically, these are the non-navigation links that are clicked on the most." .
+    :rangeIncludes :URL .
 
 :softwareRequirements a rdf:Property ;
     rdfs:label "softwareRequirements" ;
+    rdfs:comment "Component dependency requirements for application. This includes runtime environments and shared libraries that are not included in the application distribution package, but required to run the application (examples: DirectX, Java or .NET runtime)." ;
     :domainIncludes :SoftwareApplication ;
     :rangeIncludes :Text,
-        :URL ;
-    rdfs:comment "Component dependency requirements for application. This includes runtime environments and shared libraries that are not included in the application distribution package, but required to run the application (examples: DirectX, Java or .NET runtime)." .
+        :URL .
 
 :sponsor a rdf:Property ;
     rdfs:label "sponsor" ;
+    rdfs:comment "A person or organization that supports a thing through a pledge, promise, or financial contribution. E.g. a sponsor of a Medical Study or a corporate sponsor of an event." ;
     :domainIncludes :CreativeWork,
         :Event,
         :Organization,
         :Person ;
     :rangeIncludes :Organization,
-        :Person ;
-    rdfs:comment "A person or organization that supports a thing through a pledge, promise, or financial contribution. E.g. a sponsor of a Medical Study or a corporate sponsor of an event." .
+        :Person .
 
 :subOrganization a rdf:Property ;
     rdfs:label "subOrganization" ;
+    rdfs:comment "A relationship between two organizations where the first includes the second, e.g., as a subsidiary. See also: the more specific 'department' property." ;
     :domainIncludes :Organization ;
     :inverseOf :parentOrganization ;
-    :rangeIncludes :Organization ;
-    rdfs:comment "A relationship between two organizations where the first includes the second, e.g., as a subsidiary. See also: the more specific 'department' property." .
+    :rangeIncludes :Organization .
 
 :subjectOf a rdf:Property ;
     rdfs:label "subjectOf" ;
+    rdfs:comment "A CreativeWork or Event about this Thing." ;
     :domainIncludes :Thing ;
     :inverseOf :about ;
     :rangeIncludes :CreativeWork,
         :Event ;
-    :source <https://github.com/schemaorg/schemaorg/issues/1670> ;
-    rdfs:comment "A CreativeWork or Event about this Thing." .
+    :source <https://github.com/schemaorg/schemaorg/issues/1670> .
 
 :suggestedAnswer a rdf:Property ;
     rdfs:label "suggestedAnswer" ;
+    rdfs:comment "An answer (possibly one of several, possibly incorrect) to a Question, e.g. on a Question/Answer site." ;
     :domainIncludes :Question ;
     :rangeIncludes :Answer,
-        :ItemList ;
-    rdfs:comment "An answer (possibly one of several, possibly incorrect) to a Question, e.g. on a Question/Answer site." .
+        :ItemList .
 
 :superEvent a rdf:Property ;
     rdfs:label "superEvent" ;
+    rdfs:comment "An event that this event is a part of. For example, a collection of individual music performances might each have a music festival as their superEvent." ;
     :domainIncludes :Event ;
     :inverseOf :subEvent ;
-    :rangeIncludes :Event ;
-    rdfs:comment "An event that this event is a part of. For example, a collection of individual music performances might each have a music festival as their superEvent." .
+    :rangeIncludes :Event .
 
 :targetCollection a rdf:Property ;
     rdfs:label "targetCollection" ;
-    :domainIncludes :UpdateAction ;
-    :rangeIncludes :Thing ;
     rdfs:comment "A sub property of object. The collection target of the action." ;
-    rdfs:subPropertyOf :object .
+    rdfs:subPropertyOf :object ;
+    :domainIncludes :UpdateAction ;
+    :rangeIncludes :Thing .
 
 :temporalCoverage a rdf:Property ;
     rdfs:label "temporalCoverage" ;
-    :domainIncludes :CreativeWork ;
-    :rangeIncludes :DateTime,
-        :Text,
-        :URL ;
     rdfs:comment """The temporalCoverage of a CreativeWork indicates the period that the content applies to, i.e. that it describes, either as a DateTime or as a textual string indicating a time period in [ISO 8601 time interval format](https://en.wikipedia.org/wiki/ISO_8601#Time_intervals). In
       the case of a Dataset it will typically indicate the relevant time period in a precise notation (e.g. for a 2011 census dataset, the year 2011 would be written "2011/2012"). Other forms of content, e.g. ScholarlyArticle, Book, TVSeries or TVEpisode, may indicate their temporalCoverage in broader terms - textually or via well-known URL.
       Written works such as books may sometimes have precise temporal coverage too, e.g. a work set in 1939 - 1945 can be indicated in ISO 8601 interval format format via "1939/1945".
 
 Open-ended date ranges can be written with ".." in place of the end date. For example, "2015-11/.." indicates a range beginning in November 2015 and with no specified final date. This is tentative and might be updated in future when ISO 8601 is officially updated.""" ;
-    owl:equivalentProperty dc:temporal .
+    owl:equivalentProperty dc:temporal ;
+    :domainIncludes :CreativeWork ;
+    :rangeIncludes :DateTime,
+        :Text,
+        :URL .
 
 :track a rdf:Property ;
     rdfs:label "track" ;
+    rdfs:comment "A music recording (track)&#x2014;usually a single song. If an ItemList is given, the list should contain items of type MusicRecording." ;
+    :contributor <https://schema.org/docs/collab/MBZ> ;
     :domainIncludes :MusicGroup,
         :MusicPlaylist ;
     :rangeIncludes :ItemList,
-        :MusicRecording ;
-    :contributor <https://schema.org/docs/collab/MBZ> ;
-    rdfs:comment "A music recording (track)&#x2014;usually a single song. If an ItemList is given, the list should contain items of type MusicRecording." .
+        :MusicRecording .
 
 :warranty a rdf:Property ;
     rdfs:label "warranty" ;
+    rdfs:comment "The warranty promise(s) included in the offer." ;
     :domainIncludes :Demand,
         :Offer ;
-    :rangeIncludes :WarrantyPromise ;
-    rdfs:comment "The warranty promise(s) included in the offer." .
+    :rangeIncludes :WarrantyPromise .
 
 :workExample a rdf:Property ;
     rdfs:label "workExample" ;
+    rdfs:comment "Example/instance/realization/derivation of the concept of this creative work. E.g. the paperback edition, first edition, or e-book." ;
+    :contributor <https://schema.org/docs/collab/bibex> ;
     :domainIncludes :CreativeWork ;
     :inverseOf :exampleOfWork ;
-    :rangeIncludes :CreativeWork ;
-    :contributor <https://schema.org/docs/collab/bibex> ;
-    rdfs:comment "Example/instance/realization/derivation of the concept of this creative work. E.g. the paperback edition, first edition, or e-book." .
+    :rangeIncludes :CreativeWork .
 
 :yield a rdf:Property ;
     rdfs:label "yield" ;
+    rdfs:comment "The quantity that results by performing instructions. For example, a paper airplane, 10 personalized candles." ;
     :domainIncludes :HowTo ;
     :rangeIncludes :QuantitativeValue,
-        :Text ;
-    rdfs:comment "The quantity that results by performing instructions. For example, a paper airplane, 10 personalized candles." .
+        :Text .
 
 :about a rdf:Property ;
     rdfs:label "about" ;
-    :domainIncludes :CommunicateAction,
+    rdfs:comment "The subject matter of the content." ;
+    :domainIncludes :Certification,
+        :CommunicateAction,
         :CreativeWork,
-        :Event,
-    :Certification ;
+        :Event ;
     :inverseOf :subjectOf ;
     :rangeIncludes :Thing ;
-    :source <https://github.com/schemaorg/schemaorg/issues/1670> ;
-    rdfs:comment "The subject matter of the content." .
+    :source <https://github.com/schemaorg/schemaorg/issues/1670> .
 
 :competitor a rdf:Property ;
     rdfs:label "competitor" ;
+    rdfs:comment "A competitor in a sports event." ;
     :domainIncludes :SportsEvent ;
     :rangeIncludes :Person,
-        :SportsTeam ;
-    rdfs:comment "A competitor in a sports event." .
+        :SportsTeam .
 
 :containedInPlace a rdf:Property ;
     rdfs:label "containedInPlace" ;
+    rdfs:comment "The basic containment relation between a place and one that contains it." ;
     :domainIncludes :Place ;
     :inverseOf :containsPlace ;
-    :rangeIncludes :Place ;
-    rdfs:comment "The basic containment relation between a place and one that contains it." .
+    :rangeIncludes :Place .
 
 :encoding a rdf:Property ;
     rdfs:label "encoding" ;
+    rdfs:comment "A media object that encodes this CreativeWork. This property is a synonym for associatedMedia." ;
     :domainIncludes :CreativeWork ;
     :inverseOf :encodesCreativeWork ;
-    :rangeIncludes :MediaObject ;
-    rdfs:comment "A media object that encodes this CreativeWork. This property is a synonym for associatedMedia." .
+    :rangeIncludes :MediaObject .
 
 :hasMap a rdf:Property ;
     rdfs:label "hasMap" ;
+    rdfs:comment "A URL to a map of the place." ;
     :domainIncludes :Place ;
     :rangeIncludes :Map,
-        :URL ;
-    rdfs:comment "A URL to a map of the place." .
+        :URL .
 
 :image a rdf:Property ;
     rdfs:label "image" ;
+    rdfs:comment "An image of the item. This can be a [[URL]] or a fully described [[ImageObject]]." ;
     :domainIncludes :Thing ;
     :rangeIncludes :ImageObject,
-        :URL ;
-    rdfs:comment "An image of the item. This can be a [[URL]] or a fully described [[ImageObject]]." .
+        :URL .
 
 :material a rdf:Property ;
     rdfs:label "material" ;
+    rdfs:comment "A material that something is made from, e.g. leather, wool, cotton, paper." ;
     :domainIncludes :CreativeWork,
         :Product ;
     :rangeIncludes :Product,
         :Text,
-        :URL ;
-    rdfs:comment "A material that something is made from, e.g. leather, wool, cotton, paper." .
+        :URL .
 
 :memberOf a rdf:Property ;
     rdfs:label "memberOf" ;
+    rdfs:comment "An Organization (or ProgramMembership) to which this Person or Organization belongs." ;
     :domainIncludes :Organization,
         :Person ;
     :inverseOf :member ;
     :rangeIncludes :Organization,
-        :ProgramMembership ;
-    rdfs:comment "An Organization (or ProgramMembership) to which this Person or Organization belongs." .
+        :ProgramMembership .
 
 :parentOrganization a rdf:Property ;
     rdfs:label "parentOrganization" ;
+    rdfs:comment "The larger organization that this organization is a [[subOrganization]] of, if any." ;
     :domainIncludes :Organization ;
     :inverseOf :subOrganization ;
-    :rangeIncludes :Organization ;
-    rdfs:comment "The larger organization that this organization is a [[subOrganization]] of, if any." .
+    :rangeIncludes :Organization .
 
 :result a rdf:Property ;
     rdfs:label "result" ;
+    rdfs:comment "The result produced in the action. E.g. John wrote *a book*." ;
     :domainIncludes :Action ;
-    :rangeIncludes :Thing ;
-    rdfs:comment "The result produced in the action. E.g. John wrote *a book*." .
+    :rangeIncludes :Thing .
 
 :seller a rdf:Property ;
     rdfs:label "seller" ;
+    rdfs:comment "An entity which offers (sells / leases / lends / loans) the services / goods.  A seller may also be a provider." ;
+    rdfs:subPropertyOf :participant ;
     :domainIncludes :BuyAction,
         :Demand,
         :Flight,
         :Offer,
         :Order ;
     :rangeIncludes :Organization,
-        :Person ;
-    rdfs:comment "An entity which offers (sells / leases / lends / loans) the services / goods.  A seller may also be a provider." ;
-    rdfs:subPropertyOf :participant .
+        :Person .
 
 :step a rdf:Property ;
     rdfs:label "step" ;
+    rdfs:comment "A single step item (as HowToStep, text, document, video, etc.) or a HowToSection." ;
     :domainIncludes :HowTo ;
     :rangeIncludes :CreativeWork,
         :HowToSection,
         :HowToStep,
-        :Text ;
-    rdfs:comment "A single step item (as HowToStep, text, document, video, etc.) or a HowToSection." .
+        :Text .
 
 :subEvent a rdf:Property ;
     rdfs:label "subEvent" ;
+    rdfs:comment "An Event that is part of this event. For example, a conference event includes many presentations, each of which is a subEvent of the conference." ;
     :domainIncludes :Event ;
     :inverseOf :superEvent ;
-    :rangeIncludes :Event ;
-    rdfs:comment "An Event that is part of this event. For example, a conference event includes many presentations, each of which is a subEvent of the conference." .
+    :rangeIncludes :Event .
 
 :supply a rdf:Property ;
     rdfs:label "supply" ;
+    rdfs:comment "A sub-property of instrument. A supply consumed when performing instructions or a direction." ;
+    rdfs:subPropertyOf :instrument ;
     :domainIncludes :HowTo,
         :HowToDirection ;
     :rangeIncludes :HowToSupply,
-        :Text ;
-    rdfs:comment "A sub-property of instrument. A supply consumed when performing instructions or a direction." ;
-    rdfs:subPropertyOf :instrument .
+        :Text .
 
 :workFeatured a rdf:Property ;
     rdfs:label "workFeatured" ;
-    :domainIncludes :Event ;
-    :rangeIncludes :CreativeWork ;
     rdfs:comment """A work featured in some event, e.g. exhibited in an ExhibitionEvent.
-       Specific subproperties are available for workPerformed (e.g. a play), or a workPresented (a Movie at a ScreeningEvent).""" .
+       Specific subproperties are available for workPerformed (e.g. a play), or a workPresented (a Movie at a ScreeningEvent).""" ;
+    :domainIncludes :Event ;
+    :rangeIncludes :CreativeWork .
 
 :areaServed a rdf:Property ;
     rdfs:label "areaServed" ;
+    rdfs:comment "The geographic area where a service or offered item is provided." ;
     :domainIncludes :ContactPoint,
         :DeliveryChargeSpecification,
         :Demand,
@@ -10393,27 +10419,28 @@ Open-ended date ranges can be written with ".." in place of the end date. For ex
     :rangeIncludes :AdministrativeArea,
         :GeoShape,
         :Place,
-        :Text ;
-    rdfs:comment "The geographic area where a service or offered item is provided." .
+        :Text .
 
 :includedInDataCatalog a rdf:Property ;
     rdfs:label "includedInDataCatalog" ;
+    rdfs:comment "A data catalog which contains this dataset." ;
     :domainIncludes :Dataset ;
     :inverseOf :dataset ;
-    :rangeIncludes :DataCatalog ;
-    rdfs:comment "A data catalog which contains this dataset." .
+    :rangeIncludes :DataCatalog .
 
 :member a rdf:Property ;
     rdfs:label "member" ;
+    rdfs:comment "A member of an Organization or a ProgramMembership. Organizations can be members of organizations; ProgramMembership is typically for individuals." ;
     :domainIncludes :Organization,
         :ProgramMembership ;
     :inverseOf :memberOf ;
     :rangeIncludes :Organization,
-        :Person ;
-    rdfs:comment "A member of an Organization or a ProgramMembership. Organizations can be members of organizations; ProgramMembership is typically for individuals." .
+        :Person .
 
 :recipient a rdf:Property ;
     rdfs:label "recipient" ;
+    rdfs:comment "A sub property of participant. The participant who is at the receiving end of the action." ;
+    rdfs:subPropertyOf :participant ;
     :domainIncludes :AuthorizeAction,
         :CommunicateAction,
         :DonateAction,
@@ -10426,70 +10453,69 @@ Open-ended date ranges can be written with ".." in place of the end date. For ex
     :rangeIncludes :Audience,
         :ContactPoint,
         :Organization,
-        :Person ;
-    rdfs:comment "A sub property of participant. The participant who is at the receiving end of the action." ;
-    rdfs:subPropertyOf :participant .
+        :Person .
 
 :hasPart a rdf:Property ;
     rdfs:label "hasPart" ;
+    rdfs:comment "Indicates an item or CreativeWork that is part of this item, or CreativeWork (in some sense)." ;
+    :contributor <https://schema.org/docs/collab/bibex> ;
     :domainIncludes :CreativeWork ;
     :inverseOf :isPartOf ;
-    :rangeIncludes :CreativeWork ;
-    :contributor <https://schema.org/docs/collab/bibex> ;
-    rdfs:comment "Indicates an item or CreativeWork that is part of this item, or CreativeWork (in some sense)." .
+    :rangeIncludes :CreativeWork .
 
 :isPartOf a rdf:Property ;
     rdfs:label "isPartOf" ;
+    rdfs:comment "Indicates an item or CreativeWork that this item, or CreativeWork (in some sense), is part of." ;
     :domainIncludes :CreativeWork ;
     :inverseOf :hasPart ;
     :rangeIncludes :CreativeWork,
-        :URL ;
-    rdfs:comment "Indicates an item or CreativeWork that this item, or CreativeWork (in some sense), is part of." .
+        :URL .
 
 :position a rdf:Property ;
     rdfs:label "position" ;
+    rdfs:comment "The position of an item in a series or sequence of items." ;
     :domainIncludes :CreativeWork,
         :ListItem ;
     :rangeIncludes :Integer,
-        :Text ;
-    rdfs:comment "The position of an item in a series or sequence of items." .
+        :Text .
 
 :instrument a rdf:Property ;
     rdfs:label "instrument" ;
+    rdfs:comment "The object that helped the agent perform the action. E.g. John wrote a book with *a pen*." ;
     :domainIncludes :Action ;
-    :rangeIncludes :Thing ;
-    rdfs:comment "The object that helped the agent perform the action. E.g. John wrote a book with *a pen*." .
+    :rangeIncludes :Thing .
 
 :object a rdf:Property ;
     rdfs:label "object" ;
+    rdfs:comment "The object upon which the action is carried out, whose state is kept intact or changed. Also known as the semantic roles patient, affected or undergoer (which change their state) or theme (which doesn't). E.g. John read *a book*." ;
     :domainIncludes :Action ;
-    :rangeIncludes :Thing ;
-    rdfs:comment "The object upon which the action is carried out, whose state is kept intact or changed. Also known as the semantic roles patient, affected or undergoer (which change their state) or theme (which doesn't). E.g. John read *a book*." .
+    :rangeIncludes :Thing .
 
 :location a rdf:Property ;
     rdfs:label "location" ;
+    rdfs:comment "The location of, for example, where an event is happening, where an organization is located, or where an action takes place." ;
     :domainIncludes :Action,
         :Event,
-        :Organization, :InteractionCounter ;
+        :InteractionCounter,
+        :Organization ;
     :rangeIncludes :Place,
         :PostalAddress,
-        :Text ;
-    rdfs:comment "The location of, for example, where an event is happening, where an organization is located, or where an action takes place." .
+        :Text .
 
 :participant a rdf:Property ;
     rdfs:label "participant" ;
+    rdfs:comment "Other co-agents that participated in the action indirectly. E.g. John wrote a book with *Steve*." ;
     :domainIncludes :Action ;
     :rangeIncludes :Organization,
-        :Person ;
-    rdfs:comment "Other co-agents that participated in the action indirectly. E.g. John wrote a book with *Steve*." .
+        :Person .
 
 :identifier a rdf:Property ;
     rdfs:label "identifier" ;
+    rdfs:comment """The identifier property represents any kind of identifier for any kind of [[Thing]], such as ISBNs, GTIN codes, UUIDs etc. Schema.org provides dedicated properties for representing many of these, either as textual strings or as URL (URI) links. See [background notes](/docs/datamodel.html#identifierBg) for more details.
+        """ ;
+    owl:equivalentProperty dc:identifier ;
     :domainIncludes :Thing ;
     :rangeIncludes :PropertyValue,
         :Text,
-        :URL ;
-    rdfs:comment """The identifier property represents any kind of identifier for any kind of [[Thing]], such as ISBNs, GTIN codes, UUIDs etc. Schema.org provides dedicated properties for representing many of these, either as textual strings or as URL (URI) links. See [background notes](/docs/datamodel.html#identifierBg) for more details.
-        """ ;
-    owl:equivalentProperty dc:identifier .
+        :URL .
 


### PR DESCRIPTION
The new reorg tool puts properties and classes in a stable order. This is a no-op pass to reduce the diffs in future edits with the tool. With this change, future edits will be focused on the actual semantic change and not on random reordering of text lines.

This change has no effect on the semantics of the schema at all.