### PR TITLE
Fix imports and breakage

### DIFF
--- a/software/SchemaExamples/schemaexamples.py
+++ b/software/SchemaExamples/schemaexamples.py
@@ -9,30 +9,39 @@ import re
 import threading
 
 IDPREFIX = "eg-"
-DEFTEXAMPLESFILESGLOB = ("data/*examples.txt","data/ext/*/*examples.txt")
+DEFTEXAMPLESFILESGLOB = ("data/*examples.txt", "data/ext/*/*examples.txt")
 NO_JSON_REGEXPS = (
-    re.compile('No JSON-?LD',re.I),
-    re.compile('This example is in microdata only',re.I),
-    re.compile('No Json example available',re.I),
-    re.compile('microdata only', re.I))
+    re.compile("No JSON-?LD", re.I),
+    re.compile("This example is in microdata only", re.I),
+    re.compile("No Json example available", re.I),
+    re.compile("microdata only", re.I),
+)
 
 
-ldscript_match = re.compile('[\s\S]*<\s*script\s+type="application\/ld\+json"\s*>(.*)<\s*\/script\s*>[\s\S]*',re.S)
+ldscript_match = re.compile(
+    '[\s\S]*<\s*script\s+type="application\/ld\+json"\s*>(.*)<\s*\/script\s*>[\s\S]*',
+    re.S,
+)
 
 
 log = logging.getLogger(__name__)
 
 
-class Example():
+class Example:
     """Representation of an example file, with accessors for the various parts."""
+
     ExamplesCount = 0
     MaxId = 0
 
-    def __init__ (self, terms, original_html, microdata, rdfa, jsonld, exmeta, jsonld_offset=None):
+    def __init__(
+        self, terms, original_html, microdata, rdfa, jsonld, exmeta, jsonld_offset=None
+    ):
         self.terms = terms
         if not len(terms):
-            log.info("No terms for ex: %s in file %s" % (exmeta["filepos"],exmeta["file"]) )
-            first_term = 'Empty'
+            log.info(
+                "No terms for ex: %s in file %s" % (exmeta["filepos"], exmeta["file"])
+            )
+            first_term = "Empty"
         else:
             first_term = terms[0]
         self.original_html = original_html
@@ -41,14 +50,14 @@ class Example():
         self.jsonld = jsonld
         self.jsonld_offset = jsonld_offset
         self.exmeta = exmeta
-        self.keyvalue = self.exmeta.get('id',None)
+        self.keyvalue = self.exmeta.get("id", None)
         if not self.keyvalue:
-            self.keyvalue = "%s-temp-%s"% (first_term,Example.ExamplesCount)
-            self.exmeta['id'] = self.keyvalue
+            self.keyvalue = "%s-temp-%s" % (first_term, Example.ExamplesCount)
+            self.exmeta["id"] = self.keyvalue
         else:
             idnum = self.getIdNum()
             if idnum > -1:
-                Example.MaxId = max(Example.MaxId,idnum)
+                Example.MaxId = max(Example.MaxId, idnum)
                 self.keyvalue = Example.formatId(idnum)
         Example.ExamplesCount += 1
 
@@ -60,33 +69,46 @@ class Example():
         else:
             buf.append("%s" % self.terms)
         buf.append("\nKeyvalue: %s" % self.keyvalue)
-        buf.append("\nOrigLen: %s MicroLen: %s RdfaLen: %s JsonLen: %s" % (len(self.original_html),len(self.microdata),len(self.rdfa),len(self.jsonld)))
+        buf.append(
+            "\nOrigLen: %s MicroLen: %s RdfaLen: %s JsonLen: %s"
+            % (
+                len(self.original_html),
+                len(self.microdata),
+                len(self.rdfa),
+                len(self.jsonld),
+            )
+        )
         buf.append("\nexmeta: %s" % self.exmeta)
-        return ''.join(buf)
+        return "".join(buf)
 
     def getKey(self):
         return self.keyvalue
-    def setKey(self,key):
+
+    def setKey(self, key):
         self.keyvalue = key
 
     def terms(self):
         return self.terms
-    def setTerms(self,terms):
+
+    def setTerms(self, terms):
         self.terms = terms
 
     def getHtml(self):
         return self.original_html
-    def setHtml(self,content):
+
+    def setHtml(self, content):
         self.original_html = content
 
     def getMicrodata(self):
         return self.microdata
-    def setMicrodata(self,content):
+
+    def setMicrodata(self, content):
         self.microdata = content
 
     def getRdfa(self):
         return self.rdfa
-    def setRdfa(self,content):
+
+    def setRdfa(self, content):
         self.rdfa = content
 
     def getJsonld(self):
@@ -98,11 +120,11 @@ class Example():
         if len(jsondata):
             jsonmatch = ldscript_match.match(jsondata)
             if jsonmatch:
-                #extract json from within script tag
+                # extract json from within script tag
                 jsondata = jsonmatch.group(1).strip()
         return jsondata
 
-    def setJsonld(self,content):
+    def setJsonld(self, content):
         self.jsonld = content
 
     def hasHtml(self):
@@ -114,6 +136,7 @@ class Example():
             if "itemtype" in content and "itemprop" in content:
                 return True
         return False
+
     def hasRdfa(self):
         content = self.rdfa.strip()
         if len(content) > 0:
@@ -134,16 +157,17 @@ class Example():
                 return True
         return False
 
-    def setMeta(self,name,val):
+    def setMeta(self, name, val):
         self.exmeta[name] = val
-    def getMeta(self,name):
-        return self.exmeta.get(name,None)
+
+    def getMeta(self, name):
+        return self.exmeta.get(name, None)
 
     def getIdNum(self):
         idnum = -1
         if self.keyvalue.startswith(IDPREFIX):
             try:
-                idnum = int(self.keyvalue[len(IDPREFIX):])
+                idnum = int(self.keyvalue[len(IDPREFIX) :])
             except:
                 pass
         return idnum
@@ -151,21 +175,24 @@ class Example():
     def hasValidId(self):
         return self.getIdNum() > -1
 
-
     def serialize(self):
-       termnames = ', '.join(self.terms)
-       idd = "#%s" % self.keyvalue
-       if "-temp-" in idd:
-           idd = ""
+        termnames = ", ".join(self.terms)
+        idd = "#%s" % self.keyvalue
+        if "-temp-" in idd:
+            idd = ""
 
-       sections = [
-         "TYPES: %s %s\n" % (idd, termnames),
-         "PRE-MARKUP:", self.getHtml(),
-         "MICRODATA:", self.getMicrodata(),
-         "RDFA:", self.getRdfa(),
-         "JSON:", self.getJsonld(),
-       ]
-       return "\n".join(sections)
+        sections = [
+            "TYPES: %s %s\n" % (idd, termnames),
+            "PRE-MARKUP:",
+            self.getHtml(),
+            "MICRODATA:",
+            self.getMicrodata(),
+            "RDFA:",
+            self.getRdfa(),
+            "JSON:",
+            self.getJsonld(),
+        ]
+        return "\n".join(sections)
 
     @staticmethod
     def nextId():
@@ -174,7 +201,7 @@ class Example():
 
     @staticmethod
     def formatId(val):
-        return 'eg-{0:04d}'.format(val)
+        return "eg-{0:04d}".format(val)
 
     @staticmethod
     def nextIdReset(val=None):
@@ -182,19 +209,18 @@ class Example():
             val = 0
         Example.MaxId = val
 
-class SchemaExamples():
 
-    EXAMPLESLOADED=False
+class SchemaExamples:
+    EXAMPLESLOADED = False
     EXAMPLESMAP = {}
     EXAMPLES = {}
     exlock = threading.RLock()
 
-
     @staticmethod
-    def loadExamplesFiles(exfiles,init=False):
+    def loadExamplesFiles(exfiles, init=False):
         global DEFTEXAMPLESFILESGLOB
         if init:
-            EXAMPLESLOADED=False
+            EXAMPLESLOADED = False
             EXAMPLESMAP = {}
             EXAMPLES = {}
 
@@ -203,32 +229,38 @@ class SchemaExamples():
             return
 
         if not exfiles or exfiles == "default":
-            log.info("SchemaExamples.loadExamplesFiles() loading from default files found in globs: %s" % ','.join(DEFTEXAMPLESFILESGLOB))
+            log.info(
+                "SchemaExamples.loadExamplesFiles() loading from default files found in globs: %s"
+                % ",".join(DEFTEXAMPLESFILESGLOB)
+            )
             exfiles = []
             for g in DEFTEXAMPLESFILESGLOB:
                 exfiles.extend(glob.glob(g))
         elif isinstance(exfiles, str):
-            log.info("SchemaExamples.loadExamplesFiles() loading from file: %s" % exfiles)
+            log.info(
+                "SchemaExamples.loadExamplesFiles() loading from file: %s" % exfiles
+            )
             exfiles = [exfiles]
         else:
-             log.info("SchemaExamples.loadExamplesFiles() loading from %d" % len(exfiles))
+            log.info(
+                "SchemaExamples.loadExamplesFiles() loading from %d" % len(exfiles)
+            )
 
         if not len(exfiles):
             raise Exception("No examples file(s) to load")
 
-
         parser = ExampleFileParser()
         for f in exfiles:
             for example in parser.parse(f):
-                #log.info("Ex: %s %s" % (example.keyvalue,example.terms))
+                # log.info("Ex: %s %s" % (example.keyvalue,example.terms))
                 keyvalue = example.keyvalue
-                example.setMeta("source",f)
+                example.setMeta("source", f)
                 with SchemaExamples.exlock:
-                    if not SchemaExamples.EXAMPLES.get(keyvalue,None):
+                    if not SchemaExamples.EXAMPLES.get(keyvalue, None):
                         SchemaExamples.EXAMPLES[keyvalue] = example
 
                     for term in example.terms:
-                        if(not SchemaExamples.EXAMPLESMAP.get(term, None)):
+                        if not SchemaExamples.EXAMPLESMAP.get(term, None):
                             SchemaExamples.EXAMPLESMAP[term] = []
 
                         if not keyvalue in SchemaExamples.EXAMPLESMAP.get(term):
@@ -242,7 +274,6 @@ class SchemaExamples():
             SchemaExamples.loadExamplesFiles("default")
             log.info("Loaded %d examples", SchemaExamples.count())
 
-
     @staticmethod
     def examplesForTerm(term):
         SchemaExamples.loaded()
@@ -253,14 +284,14 @@ class SchemaExamples():
                 ex = SchemaExamples.EXAMPLES.get(e)
                 if ex:
                     examples.append(ex)
-        return sorted(examples,key=lambda x: x.keyvalue)
+        return sorted(examples, key=lambda x: x.keyvalue)
 
     @staticmethod
     def allExamples(sort=False):
         SchemaExamples.loaded()
         ret = SchemaExamples.EXAMPLES.values()
         if sort:
-            return sorted(ret, key=lambda x: (x.exmeta['file'],x.exmeta['filepos']))
+            return sorted(ret, key=lambda x: (x.exmeta["file"], x.exmeta["filepos"]))
         return ret
 
     @staticmethod
@@ -279,11 +310,10 @@ class SchemaExamples():
         return len(SchemaExamples.EXAMPLES)
 
 
-class ExampleFileParser():
-
-    def __init__ (self):
-        logging.basicConfig(level=logging.INFO) # dev_appserver.py --log_level debug .
-        self.file = ""    # File being parsed.
+class ExampleFileParser:
+    def __init__(self):
+        logging.basicConfig(level=logging.INFO)  # dev_appserver.py --log_level debug .
+        self.file = ""  # File being parsed.
         self.filepos = 0  # Part index.
         self.initFields()
         self.idcache = []
@@ -297,24 +327,24 @@ class ExampleFileParser():
         self.rdfaStr = ""
         self.jsonStr = ""
         self.jsonld_offset = None
-        self.state= ""
+        self.state = ""
 
     def nextPart(self, next):
         self.trimCurrentStr()
-        if (self.state == 'PRE-MARKUP:'):
+        if self.state == "PRE-MARKUP:":
             self.preMarkupStr = "".join(self.currentStr)
-        elif (self.state ==  'MICRODATA:'):
+        elif self.state == "MICRODATA:":
             self.microdataStr = "".join(self.currentStr)
-        elif (self.state == 'RDFA:'):
+        elif self.state == "RDFA:":
             self.rdfaStr = "".join(self.currentStr)
-        elif (self.state == 'JSON:'):
+        elif self.state == "JSON:":
             self.jsonStr = "".join(self.currentStr)
 
         self.state = next
         self.currentStr = []
 
     def trimCurrentStr(self):
-        #strip: leading blank lines, strip multi blank lines (replace with 1) end with blank line
+        # strip: leading blank lines, strip multi blank lines (replace with 1) end with blank line
         temp = []
         begin = True
         inwhitespace = False
@@ -333,7 +363,7 @@ class ExampleFileParser():
                 if inwhitespace:
                     temp.append("\n")
                     inwhitespace = False
-                temp.append(line+"\n")
+                temp.append(line + "\n")
 
         if not inwhitespace:
             temp.append("\n")
@@ -344,19 +374,29 @@ class ExampleFileParser():
         if ident not in self.idcache:
             self.idcache.append(ident)
         else:
-            raise Exception("Example %s in file %s has duplicate identifier: '%s'" % (self.filepos,self.file,ident))
+            raise Exception(
+                "Example %s in file %s has duplicate identifier: '%s'"
+                % (self.filepos, self.file, ident)
+            )
         self.exmeta["id"] = ident
-        return ''
+        return ""
 
     def makeExample(self):
         """Build an example out of the current state"""
         return Example(
-            terms=self.terms, original_html=self.preMarkupStr, microdata=self.microdataStr, rdfa=self.rdfaStr,
-            jsonld=self.jsonStr, exmeta=self.exmeta, jsonld_offset=self.jsonld_offset)
+            terms=self.terms,
+            original_html=self.preMarkupStr,
+            microdata=self.microdataStr,
+            rdfa=self.rdfaStr,
+            jsonld=self.jsonStr,
+            exmeta=self.exmeta,
+            jsonld_offset=self.jsonld_offset,
+        )
 
-    def parse (self, filen):
+    def parse(self, filen):
         import codecs
         import requests
+
         self.file = filen
         self.filepos = 0
         examples = []
@@ -369,11 +409,11 @@ class ExampleFileParser():
             r = requests.get(self.file)
             content = r.text
         else:
-            fd = codecs.open(self.file, 'r', encoding="utf8")
+            fd = codecs.open(self.file, "r", encoding="utf8")
             content = fd.read()
             fd.close()
 
-        lines = re.split('\n|\r', content)
+        lines = re.split("\n|\r", content)
         first = True
         boilerplate = False
         for lineno, line in enumerate(lines):
@@ -382,8 +422,8 @@ class ExampleFileParser():
 
             if line.startswith("TYPES:"):
                 self.filepos += 1
-                self.nextPart('TYPES:')
-                #Create example from what has been previously collected
+                self.nextPart("TYPES:")
+                # Create example from what has been previously collected
                 if first:
                     first = False
                 else:
@@ -391,11 +431,13 @@ class ExampleFileParser():
                         examples.append(self.makeExample())
                     boilerplate = False
                     self.initFields()
-                self.exmeta['file'] = self.file
-                self.exmeta['filepos'] = self.filepos
-                typelist = re.split(':', line)
-                tdata = egid.sub(self.process_example_id, typelist[1]) # strips IDs, records them in exmeta["id"]
-                ttl = tdata.split(',')
+                self.exmeta["file"] = self.file
+                self.exmeta["filepos"] = self.filepos
+                typelist = re.split(":", line)
+                tdata = egid.sub(
+                    self.process_example_id, typelist[1]
+                )  # strips IDs, records them in exmeta["id"]
+                ttl = tdata.split(",")
                 for ttli in ttl:
                     ttli = ttli.strip()
                     if len(ttli):
@@ -414,14 +456,11 @@ class ExampleFileParser():
                         self.nextPart(tk)
                         line = line[ltk:]
                 self.currentStr.append(line)
-        self.nextPart('TYPES:') # should flush on each block of examples
+        self.nextPart("TYPES:")  # should flush on each block of examples
         self.filepos += 1
         if not boilerplate:
-            self.exmeta['file'] = self.file
-            self.exmeta['filepos'] = self.filepos
-            examples.append(self.makeExample()) # should flush last one
+            self.exmeta["file"] = self.file
+            self.exmeta["filepos"] = self.filepos
+            examples.append(self.makeExample())  # should flush last one
         self.initFields()
         return examples
-
-
-

--- a/software/SchemaTerms/localmarkdown.py
+++ b/software/SchemaTerms/localmarkdown.py
@@ -9,7 +9,7 @@ import threading
 WIKILINKPATTERN = r'\[\[([\w0-9_ -]+)\]\]'
 
 class MarkdownTool():
-        
+
     WCLASS = "localLink"
     WPRE = "/"
     WPOST = ""
@@ -18,14 +18,14 @@ class MarkdownTool():
         #from markdown.extensions.wikilinks import WikiLinkExtension
         #self._md = markdown2.Markdown(extensions=[WikiLinkExtension(base_url='/', end_url='', html_class='localLink')])
         self._md = markdown2.Markdown()
-        self.parselock = threading.Lock() 
-    
+        self.parselock = threading.Lock()
+
     def setPre(self,pre="./"):
         self.wpre = pre
-        
+
     def setPost(self,post=""):
         self.wpost = post
-        
+
     def parse(self,source,preservePara=False,wpre=None):
         if not source or len(source) == 0:
             return ""
@@ -36,39 +36,39 @@ class MarkdownTool():
             ret = self._md.convert(source)
         finally:
             self.parselock.release()
-        
+
         if not preservePara:
             #Remove wrapping <p> </p>\n that Markdown2 adds by default
             if len(ret) > 7 and ret.startswith("<p>") and ret.endswith("</p>\n"):
                 ret = ret[3:len(ret)-5]
-            
+
             ret = ret.replace("<p>","")
             ret = ret.replace("</p>","<br/><br/>")
             if ret.endswith("<br/><br/>"):
                 ret = ret[:len(ret)-10]
-        
+
         return self.parseWiklinks(ret,wpre=wpre)
-    
+
     def parseWiklinks(self,source,wpre=None):
         self.wpre = wpre
         return re.sub(WIKILINKPATTERN, self.wikilinksReplace, source)
-        
+
     def wikilinksReplace(self,match):
         wpre = self.wpre
         t = match.group(1)
         return '<a class="%s" href="%s%s%s">%s</a>' % (MarkdownTool.WCLASS,MarkdownTool.WPRE,t,MarkdownTool.WPOST,t)
-        
-    @staticmethod
-    def setWikilinkCssClass(c):
-        MarkdownTool.WCLASS = c
-        
-    @staticmethod
-    def setWikilinkPrePath(p):
+
+    @classmethod
+    def setWikilinkCssClass(cls, c):
+        cls.WCLASS = c
+
+    @classmethod
+    def setWikilinkPrePath(cls, p):
         MarkdownTool.WPRE = p
-        
-    @staticmethod
-    def setWikilinkPostPath(p):
-        MarkdownTool.WPOST = p
-    
+
+    @classmethod
+    def setWikilinkPostPath(cls, p):
+        cls.WPOST = p
+
 
 Markdown = MarkdownTool()

--- a/software/SchemaTerms/localmarkdown.py
+++ b/software/SchemaTerms/localmarkdown.py
@@ -1,36 +1,39 @@
 import logging
-logging.basicConfig(level=logging.INFO) # dev_appserver.py --log_level debug .
+
+logging.basicConfig(level=logging.INFO)  # dev_appserver.py --log_level debug .
 log = logging.getLogger(__name__)
 
 import markdown2
-#from markdown2 import Markdown
+
+# from markdown2 import Markdown
 import re
 import threading
-WIKILINKPATTERN = r'\[\[([\w0-9_ -]+)\]\]'
 
-class MarkdownTool():
+WIKILINKPATTERN = r"\[\[([\w0-9_ -]+)\]\]"
 
+
+class MarkdownTool:
     WCLASS = "localLink"
     WPRE = "/"
     WPOST = ""
 
-    def __init__ (self):
-        #from markdown.extensions.wikilinks import WikiLinkExtension
-        #self._md = markdown2.Markdown(extensions=[WikiLinkExtension(base_url='/', end_url='', html_class='localLink')])
+    def __init__(self):
+        # from markdown.extensions.wikilinks import WikiLinkExtension
+        # self._md = markdown2.Markdown(extensions=[WikiLinkExtension(base_url='/', end_url='', html_class='localLink')])
         self._md = markdown2.Markdown()
         self.parselock = threading.Lock()
 
-    def setPre(self,pre="./"):
+    def setPre(self, pre="./"):
         self.wpre = pre
 
-    def setPost(self,post=""):
+    def setPost(self, post=""):
         self.wpost = post
 
-    def parse(self,source,preservePara=False,wpre=None):
+    def parse(self, source, preservePara=False, wpre=None):
         if not source or len(source) == 0:
             return ""
         source = source.strip()
-        source = source.replace("\\n","\n")
+        source = source.replace("\\n", "\n")
         try:
             self.parselock.acquire()
             ret = self._md.convert(source)
@@ -38,25 +41,31 @@ class MarkdownTool():
             self.parselock.release()
 
         if not preservePara:
-            #Remove wrapping <p> </p>\n that Markdown2 adds by default
+            # Remove wrapping <p> </p>\n that Markdown2 adds by default
             if len(ret) > 7 and ret.startswith("<p>") and ret.endswith("</p>\n"):
-                ret = ret[3:len(ret)-5]
+                ret = ret[3 : len(ret) - 5]
 
-            ret = ret.replace("<p>","")
-            ret = ret.replace("</p>","<br/><br/>")
+            ret = ret.replace("<p>", "")
+            ret = ret.replace("</p>", "<br/><br/>")
             if ret.endswith("<br/><br/>"):
-                ret = ret[:len(ret)-10]
+                ret = ret[: len(ret) - 10]
 
-        return self.parseWiklinks(ret,wpre=wpre)
+        return self.parseWiklinks(ret, wpre=wpre)
 
-    def parseWiklinks(self,source,wpre=None):
+    def parseWiklinks(self, source, wpre=None):
         self.wpre = wpre
         return re.sub(WIKILINKPATTERN, self.wikilinksReplace, source)
 
-    def wikilinksReplace(self,match):
+    def wikilinksReplace(self, match):
         wpre = self.wpre
         t = match.group(1)
-        return '<a class="%s" href="%s%s%s">%s</a>' % (MarkdownTool.WCLASS,MarkdownTool.WPRE,t,MarkdownTool.WPOST,t)
+        return '<a class="%s" href="%s%s%s">%s</a>' % (
+            MarkdownTool.WCLASS,
+            MarkdownTool.WPRE,
+            t,
+            MarkdownTool.WPOST,
+            t,
+        )
 
     @classmethod
     def setWikilinkCssClass(cls, c):

--- a/software/SchemaTerms/sdocollaborators.py
+++ b/software/SchemaTerms/sdocollaborators.py
@@ -22,10 +22,11 @@ import software.SchemaTerms.localmarkdown as localmarkdown
 log = logging.getLogger(__name__)
 
 
-class collaborator():
+class collaborator:
     COLLABORATORS = {}
     CONTRIBUTORS = {}
-    def __init__(self,ref,desc=None):
+
+    def __init__(self, ref, desc=None):
         self.ref = ref
         self.urirel = "/docs/collab/" + ref
         self.uri = "https://schema.org" + self.urirel
@@ -37,12 +38,15 @@ class collaborator():
         self.acknowledgement = ""
         self.parseDesc(desc)
 
-        collaborator.COLLABORATORS[self.ref]=self
+        collaborator.COLLABORATORS[self.ref] = self
 
     def __str__(self):
-        return "<collaborator ref: %s uri: %s contributor: %s img: '%s' title: '%s' url: '%s'>" % (self.ref,self.uri,self.contributor,self.img,self.title,self.url)
+        return (
+            "<collaborator ref: %s uri: %s contributor: %s img: '%s' title: '%s' url: '%s'>"
+            % (self.ref, self.uri, self.contributor, self.img, self.title, self.url)
+        )
 
-    def parseDesc(self,desc):
+    def parseDesc(self, desc):
         state = 0
         dt = []
         at = []
@@ -53,48 +57,47 @@ class collaborator():
             if state == 1:
                 if line.startswith("---"):
                     continue
-                match = self.matchval('url',line)
+                match = self.matchval("url", line)
                 if match:
                     self.url = match
                     continue
-                match = self.matchval('title',line)
+                match = self.matchval("title", line)
                 if match:
                     self.title = match
                     continue
-                match = self.matchval('img',line)
+                match = self.matchval("img", line)
                 if match:
                     self.img = match
                     continue
-            elif (state > 1):
-                if self.matchsep('--- DescriptionText.md',line):
-                    target = 'd'
+            elif state > 1:
+                if self.matchsep("--- DescriptionText.md", line):
+                    target = "d"
                     continue
-                if self.matchsep('--- AcknowledgementText.md',line):
-                    target = 'a'
+                if self.matchsep("--- AcknowledgementText.md", line):
+                    target = "a"
                     continue
                 if target:
-                    if target == 'a':
+                    if target == "a":
                         at.append(line)
-                    elif target == 'd':
+                    elif target == "d":
                         dt.append(line)
-        self.description = ''.join(dt)
-        self.acknowledgement = ''.join(at)
+        self.description = "".join(dt)
+        self.acknowledgement = "".join(at)
         self.description = localmarkdown.Markdown.parse(self.description)
         self.acknowledgement = localmarkdown.Markdown.parse(self.acknowledgement)
 
-
-    def matchval(self,val,line):
+    def matchval(self, val, line):
         ret = None
         matchstr = "(?i)%s:" % val
-        o = re.search(matchstr,line)
+        o = re.search(matchstr, line)
         if o:
-            ret = line[len(val)+1:]
+            ret = line[len(val) + 1 :]
             ret = ret.strip()
         return ret
 
-    def matchsep(self,val,line):
-        line = re.sub(' ', '', line).lower()
-        val = re.sub(' ', '', val).lower()
+    def matchsep(self, val, line):
+        line = re.sub(" ", "", line).lower()
+        val = re.sub(" ", "", val).lower()
         return line.startswith(val)
 
     def isContributor(self):
@@ -107,11 +110,10 @@ class collaborator():
             self.terms = sdotermsource.SdoTermSource.getAcknowledgedTerms(self.uri)
         return self.terms
 
-
     @classmethod
     def getCollaborator(cls, ref):
         cls.loadCollaborators()
-        coll = cls.COLLABORATORS.get(ref,None)
+        coll = cls.COLLABORATORS.get(ref, None)
         if not coll:
             log.warning("No such collaborator: %s" % ref)
         return coll
@@ -120,7 +122,7 @@ class collaborator():
     def getContributor(cls, ref):
         ref = os.path.basename(ref)
         cls.loadContributors()
-        cont = cls.CONTRIBUTORS.get(ref,None)
+        cont = cls.CONTRIBUTORS.get(ref, None)
         if not cont:
             log.warning("No such contributor: %s" % ref)
         return cont
@@ -131,11 +133,11 @@ class collaborator():
         ref = os.path.splitext(code)[0]
         coll = None
         try:
-            with open(filename,'r') as f:
+            with open(filename, "r") as f:
                 desc = f.read()
-            coll = cls(ref,desc=desc)
+            coll = cls(ref, desc=desc)
         except Exception as e:
-            log.error("Error loading colaborator source %s: %s" % (filename,e))
+            log.error("Error loading colaborator source %s: %s" % (filename, e))
         return coll
 
     @classmethod
@@ -151,7 +153,7 @@ class collaborator():
         coll = cls.getCollaborator(ref)
         if coll:
             coll.contributor = True
-            cls.CONTRIBUTORS[ref]=coll
+            cls.CONTRIBUTORS[ref] = coll
 
     @classmethod
     def loadContributors(cls):

--- a/software/__init__.py
+++ b/software/__init__.py
@@ -6,8 +6,9 @@ import os
 import sys
 
 LIB_PATHS = ()
-DATA_PATHS = ('docs', 'software/gcloud','data')
+DATA_PATHS = ("docs", "software/gcloud", "data")
 _INITIALIZED = None
+
 
 def Setup():
     """Setup the import path for the project and check the validity of the runtime."""
@@ -16,13 +17,18 @@ def Setup():
         return
 
     if not (sys.version_info.major == 3 and sys.version_info.minor > 5):
-        sys.stderr.write("Python version %s.%s not supported version 3.6 or above required - Exiting" % (sys.version_info.major,sys.version_info.minor))
+        sys.stderr.write(
+            "Python version %s.%s not supported version 3.6 or above required - Exiting"
+            % (sys.version_info.major, sys.version_info.minor)
+        )
         sys.exit(os.EX_CONFIG)
 
     for path in LIB_PATHS:
         absolute_path = os.path.join(os.getcwd(), path)
         if not os.path.isdir(absolute_path):
-            sys.stderr.write('Required directory "%s" not found - Exiting\n' % absolute_path)
+            sys.stderr.write(
+                'Required directory "%s" not found - Exiting\n' % absolute_path
+            )
             sys.exit(os.EX_CONFIG)
         sys.path.insert(1, absolute_path)
 
@@ -31,14 +37,18 @@ def Setup():
 
 def CheckWorkingDirectory():
     """Check that the working directory is correct and contains the right directories."""
-    if os.path.basename(os.getcwd()) != 'schemaorg':
-        sys.stderr.write('Script should be run from within the "schemaorg" directory! - Exiting\n')
+    if os.path.basename(os.getcwd()) != "schemaorg":
+        sys.stderr.write(
+            'Script should be run from within the "schemaorg" directory! - Exiting\n'
+        )
         sys.exit(os.EX_USAGE)
 
     for directory_name in DATA_PATHS:
         if not os.path.isdir(directory_name):
-            sys.stderr.write('Required directory "%s" not found - Exiting\n' % directory_name)
+            sys.stderr.write(
+                'Required directory "%s" not found - Exiting\n' % directory_name
+            )
             sys.exit(os.EX_CONFIG)
 
-Setup()
 
+Setup()

--- a/software/__init__.py
+++ b/software/__init__.py
@@ -5,7 +5,7 @@
 import os
 import sys
 
-LIB_PATHS = ('software/util', 'software/scripts', 'software/SchemaTerms', 'software/SchemaExamples')
+LIB_PATHS = ()
 DATA_PATHS = ('docs', 'software/gcloud','data')
 _INITIALIZED = None
 

--- a/software/scripts/buildtermlist.py
+++ b/software/scripts/buildtermlist.py
@@ -3,11 +3,11 @@
 
 # Import standard python libraries
 
-import sys
-import os
+import argparse
 import io
 import logging
-import argparse
+import os
+import sys
 
 # Import schema.org libraries
 if not os.getcwd() in sys.path:
@@ -16,12 +16,7 @@ if not os.getcwd() in sys.path:
 import software
 
 import software.SchemaTerms.sdotermsource as sdotermsource
-import software.SchemaTerms.sdoterm
-
-from sdotermsource import SdoTermSource
-
-from sdotermsource import SdoTermSource, VOCABURI
-from sdoterm import SdoTerm
+import software.SchemaTerms.sdoterm as sdoterm
 
 log = logging.getLogger(__name__)
 

--- a/software/scripts/buildtermlist.py
+++ b/software/scripts/buildtermlist.py
@@ -20,6 +20,7 @@ import software.SchemaTerms.sdoterm as sdoterm
 
 log = logging.getLogger(__name__)
 
+
 def generateTerms(tags=False):
     for term in sdotermsource.SdoTermSource.getAllTerms(expanded=True):
         label = ""
@@ -37,17 +38,20 @@ def generateTerms(tags=False):
         yield term.id + label + "\n"
 
 
-
-if __name__ == '__main__':
+if __name__ == "__main__":
     parser = argparse.ArgumentParser()
-    parser.add_argument("-t","--tagtype", default=False, action='store_true', help="Add a termtype to name")
-    parser.add_argument("-o","--output", required=True, help="output file")
+    parser.add_argument(
+        "-t",
+        "--tagtype",
+        default=False,
+        action="store_true",
+        help="Add a termtype to name",
+    )
+    parser.add_argument("-o", "--output", required=True, help="output file")
     args = parser.parse_args()
     filename = args.output
-    log.info('Writing term list to file %s', filename)
-    with open(filename, 'w', encoding='utf-8') as handle:
-      for term in generateTerms(tags=args.tagtype):
-        handle.write(term)
-    log.info('Done')
-
-
+    log.info("Writing term list to file %s", filename)
+    with open(filename, "w", encoding="utf-8") as handle:
+        for term in generateTerms(tags=args.tagtype):
+            handle.write(term)
+    log.info("Done")

--- a/software/scripts/compare_health.py
+++ b/software/scripts/compare_health.py
@@ -9,60 +9,59 @@ from rdflib import RDF, RDFS
 # into health-lifesci hosted extension (v2.3 anticipated). Specifically,
 # we want to check which terms in the extension existed previously.
 
+
 def typesInGraph(g):
-   """terms that are defined as types, stringified."""
-   _types = []
-   for s,p,o in g.triples( (None,  RDF.type, RDFS.Class) ):
-       if s not in _types:
-           _types.append(str(s))
-   return _types
+    """terms that are defined as types, stringified."""
+    _types = []
+    for s, p, o in g.triples((None, RDF.type, RDFS.Class)):
+        if s not in _types:
+            _types.append(str(s))
+    return _types
 
 
 def propertiesInGraph(g):
-   """terms that are defined as properties, stringified."""
-   _terms = []
-   for s,p,o in g.triples( (None,  RDF.type, RDF.Property) ):
-       if s not in _terms:
-           _terms.append(str(s))
-   return _terms
+    """terms that are defined as properties, stringified."""
+    _terms = []
+    for s, p, o in g.triples((None, RDF.type, RDF.Property)):
+        if s not in _terms:
+            _terms.append(str(s))
+    return _terms
+
 
 def enumeratedValuesInGraph(g):
-   """terms that are defined as enumerated values, stringified."""
-   med_enumeration = URIRef("http://schema.org/MedicalEnumeration")
-   _enums = []
-   _terms = []
-   for s,p,o in g.triples( (None,  RDFS.subClassOf, med_enumeration) ):
-       if s not in _enums:
-           _enums.append(s)
-   # print "Enumeration types are:"
-   for e in _enums:
-       # print "EnumType: ", e
-       for s,p,o in g.triples( (None,  RDF.type, e) ):
-           # print "instance: ", s
-           _terms.append(str(s))
-   return _terms
+    """terms that are defined as enumerated values, stringified."""
+    med_enumeration = URIRef("http://schema.org/MedicalEnumeration")
+    _enums = []
+    _terms = []
+    for s, p, o in g.triples((None, RDFS.subClassOf, med_enumeration)):
+        if s not in _enums:
+            _enums.append(s)
+    # print "Enumeration types are:"
+    for e in _enums:
+        # print "EnumType: ", e
+        for s, p, o in g.triples((None, RDF.type, e)):
+            # print "instance: ", s
+            _terms.append(str(s))
+    return _terms
 
 
-
-
-
-if __name__ == '__main__':
-
-
+if __name__ == "__main__":
     # we'll work with simple string URIs to keep a clear notion of identity.
 
     # relative to scripts/ directory.
-#    med_rdfa = '../data/ext/health-lifesci/health_core-0.3.rdfa'
-    med_rdfa = '../data/ext/health-lifesci/med-health-core.rdfa' # ignores activities .rdfa file in same dir
-    sdo_core_rdfa = '../data/releases/2.2/schema.rdfa'
+    #    med_rdfa = '../data/ext/health-lifesci/health_core-0.3.rdfa'
+    med_rdfa = "../data/ext/health-lifesci/med-health-core.rdfa"  # ignores activities .rdfa file in same dir
+    sdo_core_rdfa = "../data/releases/2.2/schema.rdfa"
 
     newhealth_g = Graph()
     sdo_corev22_g = Graph()
-    parse_errors = Graph() # re-used for all files now
+    parse_errors = Graph()  # re-used for all files now
 
-    # load RDFa/RDFS from disk.
-    newhealth_g.parse(med_rdfa, format='rdfa', pgraph=parse_errors)	#, charset="utf8")
-    sdo_corev22_g.parse(sdo_core_rdfa, format='rdfa', pgraph=parse_errors)	#, charset="utf8")
+    # load RDFa/RDFS from disk.
+    newhealth_g.parse(med_rdfa, format="rdfa", pgraph=parse_errors)  # , charset="utf8")
+    sdo_corev22_g.parse(
+        sdo_core_rdfa, format="rdfa", pgraph=parse_errors
+    )  # , charset="utf8")
 
     # get term lists from loaded data
     new_health_types = set(typesInGraph(newhealth_g))
@@ -73,20 +72,28 @@ if __name__ == '__main__':
     core_enumvals = set(enumeratedValuesInGraph(sdo_corev22_g))
 
     print("Comparing ext/health-lifesci and v2.2 core.\n\n")
-#    print "Type terms that are in 2.2 core and 2.3 ext/health-lifesci: %s \n\n" % core_types.intersection(new_health_types)
-#    print "Type terms in the ext/health-lifesci but not 2.2 core: %s \n\n" % new_health_types.difference(core_types)
+    #    print "Type terms that are in 2.2 core and 2.3 ext/health-lifesci: %s \n\n" % core_types.intersection(new_health_types)
+    #    print "Type terms in the ext/health-lifesci but not 2.2 core: %s \n\n" % new_health_types.difference(core_types)
     print("\n\n")
 
-    print("Property terms that are in 2.2 core and 2.3 ext/health-lifesci: %s \n\n" % core_props.intersection(new_health_props))
-    print("Property terms in the ext/health-lifesci but not 2.2 core: %s \n\n" % new_health_props.difference(core_props))
-    print("Property terms in 2.2 core but not in ext/health-lifesci: %s \n\n" %  core_props.difference( new_health_props)) 
+    print(
+        "Property terms that are in 2.2 core and 2.3 ext/health-lifesci: %s \n\n"
+        % core_props.intersection(new_health_props)
+    )
+    print(
+        "Property terms in the ext/health-lifesci but not 2.2 core: %s \n\n"
+        % new_health_props.difference(core_props)
+    )
+    print(
+        "Property terms in 2.2 core but not in ext/health-lifesci: %s \n\n"
+        % core_props.difference(new_health_props)
+    )
     print("\n\n")
 
-#    print "Enumuerated Value terms that are in 2.2 core and 2.3 ext/health-lifesci: %s \n\n" % core_enumvals.intersection(new_health_enumvals)
-#    print "Enumerated Value in the ext/health-lifesci but not 2.2 core: %s \n\n" % new_health_enumvals.difference(new_health_enumvals)
+    #    print "Enumuerated Value terms that are in 2.2 core and 2.3 ext/health-lifesci: %s \n\n" % core_enumvals.intersection(new_health_enumvals)
+    #    print "Enumerated Value in the ext/health-lifesci but not 2.2 core: %s \n\n" % new_health_enumvals.difference(new_health_enumvals)
     print("\n\n")
 
+    # print sdo_corev22_g.serialize(format="nt", encoding="utf-8")
 
-    #print sdo_corev22_g.serialize(format="nt", encoding="utf-8")
-
-# note: breastfeedingWarning was dropped between 2.2 and 3.0 ext
+# note: breastfeedingWarning was dropped between 2.2 and 3.0 ext

--- a/software/scripts/compareterms.py
+++ b/software/scripts/compareterms.py
@@ -3,24 +3,29 @@ import unittest
 import os
 from os import path, getenv
 from os.path import expanduser
-import logging # https://docs.python.org/2/library/logging.html#logging-levels
+import logging  # https://docs.python.org/2/library/logging.html#logging-levels
 import glob
 import argparse
 import StringIO
 import sys
-sys.path.append( os.getcwd() ) 
-sys.path.insert( 1, 'lib' ) #Pickup libs, rdflib etc., from shipped lib directory
+
+sys.path.append(os.getcwd())
+sys.path.insert(1, "lib")  # Pickup libs, rdflib etc., from shipped lib directory
 # Ensure that the google.appengine.* packages are available
 # in tests as well as all bundled third-party packages.
 
-sdk_path = getenv('APP_ENGINE',  expanduser("~") + '/google-cloud-sdk/platform/google_appengine/')
-sys.path.insert(0, sdk_path) # add AppEngine SDK to path
+sdk_path = getenv(
+    "APP_ENGINE", expanduser("~") + "/google-cloud-sdk/platform/google_appengine/"
+)
+sys.path.insert(0, sdk_path)  # add AppEngine SDK to path
 
 import dev_appserver
+
 dev_appserver.fix_sys_path()
 
 from testharness import *
-#Setup testharness state BEFORE importing sdo libraries
+
+# Setup testharness state BEFORE importing sdo libraries
 setInTestHarness(True)
 
 from api import *
@@ -34,24 +39,54 @@ from rdflib.plugins.sparql import prepareQuery
 from rdflib.compare import graph_diff
 import threading
 
-from api import inLayer, read_file, full_path, read_schemas, read_extensions, read_examples, namespaces, DataCache, getMasterStore
+from api import (
+    inLayer,
+    read_file,
+    full_path,
+    read_schemas,
+    read_extensions,
+    read_examples,
+    namespaces,
+    DataCache,
+    getMasterStore,
+)
 from apirdflib import getNss
 
 
 # Ensure that the google.appengine.* packages are available
 # in tests as well as all bundled third-party packages.
 import dev_appserver
+
 dev_appserver.fix_sys_path()
 
 import sdoapp
+
 logging.basicConfig(level=logging.INFO)
 log = logging.getLogger(__name__)
 
 parser = argparse.ArgumentParser()
-parser.add_argument("-e","--exclude", default= [[]],action='append',nargs='*', help="Exclude graph(s) [core|extensions|bib|auto|meta|{etc} (Repeatable)")
-parser.add_argument("-i","--include", default= [[]],action='append',nargs='*', help="Include graph(s) [core|extensions|bib|auto|meta|{etc} (Repeatable) overrides exclude")
-parser.add_argument("-t","--triples", default="No",help="Show triple differences Yes|No. Default No")
-parser.add_argument("-n","--names", default="No",help="List term names Yes|No. Default No")
+parser.add_argument(
+    "-e",
+    "--exclude",
+    default=[[]],
+    action="append",
+    nargs="*",
+    help="Exclude graph(s) [core|extensions|bib|auto|meta|{etc} (Repeatable)",
+)
+parser.add_argument(
+    "-i",
+    "--include",
+    default=[[]],
+    action="append",
+    nargs="*",
+    help="Include graph(s) [core|extensions|bib|auto|meta|{etc} (Repeatable) overrides exclude",
+)
+parser.add_argument(
+    "-t", "--triples", default="No", help="Show triple differences Yes|No. Default No"
+)
+parser.add_argument(
+    "-n", "--names", default="No", help="List term names Yes|No. Default No"
+)
 args = parser.parse_args()
 showDiffs = False
 if args.triples.lower() == "yes":
@@ -90,96 +125,109 @@ def getCurrentGraph():
     read_extensions(sdoapp.ENABLED_EXTENSIONS)
     graphs = list(store.graphs())
 
-    gs = sorted(list(store.graphs()),key=lambda u: u.identifier)
+    gs = sorted(list(store.graphs()), key=lambda u: u.identifier)
 
-    for g in gs: #Put core first
+    for g in gs:  # Put core first
         if str(g.identifier) == "http://schema.org/":
             gs.remove(g)
-            gs.insert(0,g)
+            gs.insert(0, g)
             break
 
     for g in gs:
         id = str(g.identifier)
-        if not id.startswith("http://"):#skip some internal graphs
+        if not id.startswith("http://"):  # skip some internal graphs
             continue
-        if id in skiplist: #Skip because we have been asked to
+        if id in skiplist:  # Skip because we have been asked to
             continue
-        
+
         currentGraph += g
     return currentGraph
+
 
 def getPreviousGraph(sources):
     graph = Graph()
     parse_errors = rdflib.Graph()
     for s in sources:
-        graph.parse(s, format='rdfa', pgraph=parse_errors)
-    
+        graph.parse(s, format="rdfa", pgraph=parse_errors)
+
     return graph
-        
+
+
 def termsInGraph(g):
-   """terms that are not defined as properties or types, stringified."""
-   _terms = []
-   #g.bind("rdf",RDF)
-   #g.bind("rdfs",RDFS)
-   for s,p,o in g.triples( (None,  RDF.type, None) ):
-       if s not in _terms:
-           _terms.append(str(s))
-   return _terms
-   
-def compareCommonTerms(terms,buff):
+    """terms that are not defined as properties or types, stringified."""
+    _terms = []
+    # g.bind("rdf",RDF)
+    # g.bind("rdfs",RDFS)
+    for s, p, o in g.triples((None, RDF.type, None)):
+        if s not in _terms:
+            _terms.append(str(s))
+    return _terms
+
+
+def compareCommonTerms(terms, buff):
     global currentGraph, previousGraph, showDiffs
-    currentGraph.bind("schema","http://schema.org/")
-    currentGraph.bind("dc","http://purl.org/dc/terms/")
-    currentGraph.bind("rdf",RDF)
-    currentGraph.bind("rdfs",RDFS)
+    currentGraph.bind("schema", "http://schema.org/")
+    currentGraph.bind("dc", "http://purl.org/dc/terms/")
+    currentGraph.bind("rdf", RDF)
+    currentGraph.bind("rdfs", RDFS)
     changedCount = 0
     for t in sorted(terms):
         c = Graph()
         p = Graph()
-        for trip in currentGraph.triples((URIRef(t),None,None)):
+        for trip in currentGraph.triples((URIRef(t), None, None)):
             c.add(trip)
-        for trip in previousGraph.triples((URIRef(t),None,None)):
+        for trip in previousGraph.triples((URIRef(t), None, None)):
             p.add(trip)
-        newg = c -  p
+        newg = c - p
         dropg = p - c
         if len(newg) > 0 or len(dropg) > 0:
-            changedCount += 1 
-            buff.write( "   Changed term: %s\n" % t)
+            changedCount += 1
+            buff.write("   Changed term: %s\n" % t)
             if showDiffs:
-                for s,p,o in newg.triples((None,None,None)):
-                    buff.write( "       New:     %s %s %s\n" % (str(s),currentGraph.qname(p),o))
-                for s,p,o in dropg.triples((None,None,None)):
-                    buff.write( "       Dropped: %s %s %s\n" % (str(s),currentGraph.qname(p),o))
+                for s, p, o in newg.triples((None, None, None)):
+                    buff.write(
+                        "       New:     %s %s %s\n"
+                        % (str(s), currentGraph.qname(p), o)
+                    )
+                for s, p, o in dropg.triples((None, None, None)):
+                    buff.write(
+                        "       Dropped: %s %s %s\n"
+                        % (str(s), currentGraph.qname(p), o)
+                    )
     return changedCount
-            
-        
+
+
 currentGraph = None
 previousGraph = None
 
 import codecs
 import sys
-UTF8Writer = codecs.getwriter('utf8')
+
+UTF8Writer = codecs.getwriter("utf8")
 sys.stdout = UTF8Writer(sys.stdout)
 
-    
-if __name__ == '__main__':
+
+if __name__ == "__main__":
     currentGraph = getCurrentGraph()
-    previousGraph = getPreviousGraph(["https://raw.github.com/schemaorg/schemaorg/sdo-phobos/data/schema.rdfa",
-                                        "https://raw.github.com/schemaorg/schemaorg/sdo-phobos/data/ext/auto/auto.rdfa",
-                                        "https://raw.github.com/schemaorg/schemaorg/sdo-phobos/data/ext/bib/bsdo-1.0.rdfa",
-                                        "https://raw.github.com/schemaorg/schemaorg/sdo-phobos/data/ext/bib/comics.rdfa"])
+    previousGraph = getPreviousGraph(
+        [
+            "https://raw.github.com/schemaorg/schemaorg/sdo-phobos/data/schema.rdfa",
+            "https://raw.github.com/schemaorg/schemaorg/sdo-phobos/data/ext/auto/auto.rdfa",
+            "https://raw.github.com/schemaorg/schemaorg/sdo-phobos/data/ext/bib/bsdo-1.0.rdfa",
+            "https://raw.github.com/schemaorg/schemaorg/sdo-phobos/data/ext/bib/comics.rdfa",
+        ]
+    )
 
     curTypes = set(termsInGraph(currentGraph))
     prevTypes = set(termsInGraph(previousGraph))
 
-    print( "Current terms count %s" % len(curTypes))
+    print("Current terms count %s" % len(curTypes))
     print("Previous terms Count %s" % len(prevTypes))
-    
-    
+
     new = curTypes.difference(prevTypes)
     dropped = prevTypes.difference(curTypes)
     common = curTypes.intersection(prevTypes)
-    
+
     print("==========   Terms  ================")
     print("Dropped terms %s" % len(dropped))
     if showNames:
@@ -189,15 +237,8 @@ if __name__ == '__main__':
     if showNames:
         for i in sorted(new):
             print("   New term %s" % i)
-    
+
     buff = StringIO.StringIO()
-    print("Changed terms %s" % compareCommonTerms(common,buff))
+    print("Changed terms %s" % compareCommonTerms(common, buff))
     if showNames:
         print(buff.getvalue())
-    
-
-    
-
-
-
-

--- a/software/scripts/examples4term.py
+++ b/software/scripts/examples4term.py
@@ -1,16 +1,26 @@
 #!/usr/bin/env python3
 # -*- coding: UTF-8 -*-
 import sys
+
 if not (sys.version_info.major == 3 and sys.version_info.minor > 5):
-    print("Python version %s.%s not supported version 3.6 or above required - exiting" % (sys.version_info.major,sys.version_info.minor))
+    print(
+        "Python version %s.%s not supported version 3.6 or above required - exiting"
+        % (sys.version_info.major, sys.version_info.minor)
+    )
     sys.exit(1)
 
 
 import os
 import io
 import argparse
-for path in [os.getcwd(),"software/Util","software/SchemaTerms","software/SchemaExamples"]:
-  sys.path.insert( 1, path ) #Pickup libs from local  directories
+
+for path in [
+    os.getcwd(),
+    "software/Util",
+    "software/SchemaTerms",
+    "software/SchemaExamples",
+]:
+    sys.path.insert(1, path)  # Pickup libs from local  directories
 
 from sdotermsource import SdoTermSource, VOCABURI
 from sdoterm import SdoTerm
@@ -20,17 +30,21 @@ from schemaexamples import SchemaExamples
 if not SdoTermSource.SOURCEGRAPH:
     print("Loading triples files")
     SdoTermSource.loadSourceGraph("default")
-    print ("loaded %s triples - %s terms" % (len(SdoTermSource.sourceGraph()),len(SdoTermSource.getAllTerms())) )
+    print(
+        "loaded %s triples - %s terms"
+        % (len(SdoTermSource.sourceGraph()), len(SdoTermSource.getAllTerms()))
+    )
 
-workingterms =[]
+workingterms = []
 
-def getterms(term,recursive):
+
+def getterms(term, recursive):
     global workingterms
 
-    termlist =[]
+    termlist = []
     for ts in term:
         termlist.extend(ts)
-    
+
     for t in termlist:
         term = SdoTermSource.getTerm(t)
         if not term:
@@ -40,41 +54,49 @@ def getterms(term,recursive):
 
         if recursive:
             addrecursive(term)
-    
+
+
 def addtoworking(term):
     global workingterms
     if not term in workingterms:
         workingterms.append(term)
+
 
 def addrecursive(term):
     for t in term.subs:
         addtoworking(t)
         addrecursive(SdoTermSource.getTerm(t))
 
+
 def getexamples(terms):
     for t in terms:
         examples = SchemaExamples.examplesForTerm(t)
         addtoworkingex(examples)
-        
+
 
 workingex = []
+
+
 def addtoworkingex(examples):
     for e in examples:
         if not e in workingex:
             workingex.append(e)
 
-def buildoutput(workingex,fname):
+
+def buildoutput(workingex, fname):
     workingex = sorted(workingex, key=lambda x: (x.keyvalue))
 
-    buildcsvoutput(workingex,fname)
+    buildcsvoutput(workingex, fname)
 
-def buildcsvoutput(workingex,fname):
+
+def buildcsvoutput(workingex, fname):
     import csv
+
     if not fname.endswith(".csv"):
         fname = fname + ".csv"
 
     data = []
-    fields = ["Example Id","Source File","Linked to Terms"]
+    fields = ["Example Id", "Source File", "Linked to Terms"]
     for e in workingex:
         row = {}
         row["Example Id"] = e.keyvalue
@@ -85,8 +107,10 @@ def buildcsvoutput(workingex,fname):
     csvout = io.StringIO()
     print("examples4term: Writing to: %s" % fname)
 
-    csvfile = open(fname,'w', encoding='utf8')
-    writer = csv.DictWriter(csvout, fieldnames=fields, quoting=csv.QUOTE_ALL,lineterminator='\n')
+    csvfile = open(fname, "w", encoding="utf8")
+    writer = csv.DictWriter(
+        csvout, fieldnames=fields, quoting=csv.QUOTE_ALL, lineterminator="\n"
+    )
     writer.writeheader()
     for row in data:
         writer.writerow(row)
@@ -103,25 +127,33 @@ def array2str(ar):
         if first:
             first = False
         else:
-            buf.append(', ')
+            buf.append(", ")
         buf.append(i)
     return "".join(buf)
 
 
-
-if __name__ == '__main__':
+if __name__ == "__main__":
     parser = argparse.ArgumentParser()
-    parser.add_argument("-t","--term", required=True, default= [],action='append',nargs='*',  help="Term to use(repeatable)")
-    parser.add_argument("-r","--recursive", default=False, action='store_true', help="Use tern=m and subtypes")
-    parser.add_argument("-o","--output", required=True, help="csv output file")
+    parser.add_argument(
+        "-t",
+        "--term",
+        required=True,
+        default=[],
+        action="append",
+        nargs="*",
+        help="Term to use(repeatable)",
+    )
+    parser.add_argument(
+        "-r",
+        "--recursive",
+        default=False,
+        action="store_true",
+        help="Use tern=m and subtypes",
+    )
+    parser.add_argument("-o", "--output", required=True, help="csv output file")
     args = parser.parse_args()
 
-
-
-    getterms(args.term,args.recursive)
+    getterms(args.term, args.recursive)
     getexamples(workingterms)
     fname = args.output
-    buildoutput(workingex,fname)
-
-
-
+    buildoutput(workingex, fname)

--- a/software/scripts/inputconvert.py
+++ b/software/scripts/inputconvert.py
@@ -3,22 +3,26 @@ import unittest
 import os
 from os import path, getenv
 from os.path import expanduser
-import logging # https://docs.python.org/2/library/logging.html#logging-levels
+import logging  # https://docs.python.org/2/library/logging.html#logging-levels
 import glob
 import argparse
 import sys
 import csv
 
-sys.path.append( os.getcwd() )
-sys.path.insert( 1, 'lib' ) #Pickup libs, rdflib etc., from shipped lib directory
-sys.path.insert( 1, 'sdopythonapp' ) #Pickup sdopythonapp functionality
-sys.path.insert( 1, 'sdopythonapp/lib' ) #Pickup sdopythonapp libs, rdflib etc., from shipped lib directory
-sys.path.insert( 1, 'sdopythonapp/site' ) #Pickup sdopythonapp from shipped site
+sys.path.append(os.getcwd())
+sys.path.insert(1, "lib")  # Pickup libs, rdflib etc., from shipped lib directory
+sys.path.insert(1, "sdopythonapp")  # Pickup sdopythonapp functionality
+sys.path.insert(
+    1, "sdopythonapp/lib"
+)  # Pickup sdopythonapp libs, rdflib etc., from shipped lib directory
+sys.path.insert(1, "sdopythonapp/site")  # Pickup sdopythonapp from shipped site
 # Ensure that the google.appengine.* packages are available
 # in tests as well as all bundled third-party packages.
 
-sdk_path = getenv('APP_ENGINE',  expanduser("~") + '/google-cloud-sdk/platform/google_appengine/')
-sys.path.insert(0, sdk_path) # add AppEngine SDK to path
+sdk_path = getenv(
+    "APP_ENGINE", expanduser("~") + "/google-cloud-sdk/platform/google_appengine/"
+)
+sys.path.insert(0, sdk_path)  # add AppEngine SDK to path
 
 import rdflib
 from rdflib.term import URIRef, Literal
@@ -31,16 +35,29 @@ from rdflib.namespace import RDFS, RDF
 
 rdflib.plugin.register("rdfa", Parser, "pyRdfa.rdflibparsers", "RDFaParser")
 
-OUTTYPES = {'jsonld': 'jsonld','xml':'xml','nq':'nquads','rdf':'xml','ttl':'turtle'}
+OUTTYPES = {
+    "jsonld": "jsonld",
+    "xml": "xml",
+    "nq": "nquads",
+    "rdf": "xml",
+    "ttl": "turtle",
+}
 
 parser = argparse.ArgumentParser()
-parser.add_argument("-i","--input" , action='append',nargs='*', help="Input file(s)")
-parser.add_argument("-o","--outputdir", help="Output directory (Default = .)")
-parser.add_argument("-f","--format", default='ttl', help="Output format ['xml', 'rdf', 'nquads','nt','jsonld','ttl']")
-parser.add_argument("-c","--combinefile", default=None, help="Combine outputs into file")
-parser.add_argument("-d","--defaultns", help="Default output namespace")
+parser.add_argument("-i", "--input", action="append", nargs="*", help="Input file(s)")
+parser.add_argument("-o", "--outputdir", help="Output directory (Default = .)")
+parser.add_argument(
+    "-f",
+    "--format",
+    default="ttl",
+    help="Output format ['xml', 'rdf', 'nquads','nt','jsonld','ttl']",
+)
+parser.add_argument(
+    "-c", "--combinefile", default=None, help="Combine outputs into file"
+)
+parser.add_argument("-d", "--defaultns", help="Default output namespace")
 args = parser.parse_args()
-print("%s: Arguments: %s" % (sys.argv[0],args))
+print("%s: Arguments: %s" % (sys.argv[0], args))
 if args.format not in OUTTYPES:
     parser.print_help()
     sys.exit(1)
@@ -56,16 +73,18 @@ WHERE {
 }
 """
 
+
 def out(filename):
     graph.update(SPARQL1)
-    graph.bind('',URIRef('http://schema.org/'),override=True)
+    graph.bind("", URIRef("http://schema.org/"), override=True)
     if args.outputdir:
-        outfile = "%s/%s" % (args.outputdir,filename)
+        outfile = "%s/%s" % (args.outputdir, filename)
     else:
         outfile = filename
-    print("Writing %s triples to  %s" % (len(graph),outfile))
-    f = open(outfile,'w')
-    f.write(graph.serialize(format=OUTTYPES.get(format),auto_compact=True))
+    print("Writing %s triples to  %s" % (len(graph), outfile))
+    f = open(outfile, "w")
+    f.write(graph.serialize(format=OUTTYPES.get(format), auto_compact=True))
+
 
 files = args.input[0]
 graph = rdflib.ConjunctiveGraph()
@@ -73,28 +92,20 @@ graph = rdflib.ConjunctiveGraph()
 for fullfilename in files:
     if not combine:
         graph = rdflib.ConjunctiveGraph()
-        
-        
-    if  args.outputdir:
+
+    if args.outputdir:
         filename = os.path.basename(fullfilename)
     else:
         filename = fullfilename
     filestub, ext = os.path.splitext(filename)
     ext = ext[1:]
 
-    graph.parse(fullfilename,format = ext)
+    graph.parse(fullfilename, format=ext)
     print("Loaded %s triples from %s" % (len(graph), filename))
-    
+
     if not combine:
-        out(filename="%s.%s" % (filestub,format))
+        out(filename="%s.%s" % (filestub, format))
 
 if combine:
     print("Outputting ")
     out(filename=combine)
-    
-    
-
-
-
-
-

--- a/software/scripts/scanissues.py
+++ b/software/scripts/scanissues.py
@@ -6,44 +6,49 @@
 
 # Beginning of script to scan github for issue/term associations.
 
-# Note: https://developer.github.com/v3/#rate-limiting 
+# Note: https://developer.github.com/v3/#rate-limiting
 # 60 requests per hour per IP address.
 
-import requests # http://www.python-requests.org/en/latest/
+import requests  # http://www.python-requests.org/en/latest/
 import json
 import re
 import os
 
 myre = re.compile(r"^\s*http://schema.org/(\w+)", re.MULTILINE)
 
+
 def getPagedAPI(u):
-    r = requests.get(u) 
-    if (r.ok):
-        if (len(r.json())==0):
-            return("000") 
+    r = requests.get(u)
+    if r.ok:
+        if len(r.json()) == 0:
+            return "000"
         for i in r.json():
             if "body" in i:
                 body = i["body"]
                 hits = myre.findall(body)
                 for h in hits:
-                    print("http://schema.org/"+h)
+                    print("http://schema.org/" + h)
                     print(i["url"])
                     if "title" in i:
                         print(i["title"])
                         print("\n")
             print
-        return None   
+        return None
     else:
-            print("# Issue API error.")
-            return("500") 
+        print("# Issue API error.")
+        return "500"
+
 
 # Auth - to avoid rate limits, create an OAuth application and put details in GH_AUTH env var.
 # See https://developer.github.com/v3/#rate-limiting
 
-gh_auth = os.environ['GH_AUTH']
+gh_auth = os.environ["GH_AUTH"]
 for i in range(10):
-  u = "https://api.github.com/repos/schemaorg/schemaorg/issues?milestone=*;page=%i;%s" % ( i, gh_auth ) 
-  print("# Fetching page %i " % i)
-  x = getPagedAPI(u) # bogus return codes
-  if x != None:
-      break
+    u = (
+        "https://api.github.com/repos/schemaorg/schemaorg/issues?milestone=*;page=%i;%s"
+        % (i, gh_auth)
+    )
+    print("# Fetching page %i " % i)
+    x = getPagedAPI(u)  # bogus return codes
+    if x != None:
+        break

--- a/software/scripts/scansite.py
+++ b/software/scripts/scansite.py
@@ -3,25 +3,25 @@
 import json
 from pprint import pprint
 import urllib2
-from google.appengine.api import urlfetch  
+from google.appengine.api import urlfetch
 
 # Work in progress attempt to fetch all term URLs
 # from our data dumps (and sanity check them), then
-# fetch pages via WWW e.g. for 
+# fetch pages via WWW e.g. for
 # https://github.com/schemaorg/schemaorg/issues/1285
 # (We could also generate a sitemap.xml file maybe?)
 
-# params		 TODO: pass this in
-v = '3.1' 
+# params		 TODO: pass this in
+v = "3.1"
 verbose = False
 SEARCH_TERM = "klzzwxh"
 host = "schema.org"
-#host = "staging.schema.org"
-#host = "localhost:8080"
+# host = "staging.schema.org"
+# host = "localhost:8080"
 
-#verbose = True
+# verbose = True
 
-fn = 'data/releases/%s/schemaorg-current.jsonld' % v # Per-release JSON-LD dumps.
+fn = "data/releases/%s/schemaorg-current.jsonld" % v  # Per-release JSON-LD dumps.
 found = []
 checked = 0
 
@@ -30,20 +30,22 @@ print("Searching for: %s" % SEARCH_TERM)
 print("Searching target: %s\n" % host)
 
 with open(fn) as data_file:
-  data = json.load(data_file)
+    data = json.load(data_file)
 if verbose:
-  pprint(data) 
+    pprint(data)
 
 # Core is      "@id": "http://schema.org/#3.1"
 
-# TODO: Not robust. Fix w/ regex to handle versions, cases etc.
+
+# TODO: Not robust. Fix w/ regex to handle versions, cases etc.
 #
 def subdomain(gurl):
-  tid = gurl.replace('http://','')
-  tid = tid.replace('#' + str(v),'') # this version
-  tid = tid.replace('.schema.org/','') # ext
-  tid = tid.replace('schema.org/','') # core
-  return( tid )
+    tid = gurl.replace("http://", "")
+    tid = tid.replace("#" + str(v), "")  # this version
+    tid = tid.replace(".schema.org/", "")  # ext
+    tid = tid.replace("schema.org/", "")  # core
+    return tid
+
 
 def checkurl(url):
     global checked
@@ -57,54 +59,51 @@ def checkurl(url):
     else:
         count = thepage.count(SEARCH_TERM)
         if count:
-            msg = "%s - Found %s instances" % (url,count)
+            msg = "%s - Found %s instances" % (url, count)
             found.append(msg)
             print(msg)
         else:
             print("%s clear" % url)
- 
+
+
 extensions = []
 
 for g in sorted(data["@graph"], key=lambda u: u["@id"]):
-  #pprint("GRAPH: %s" % g["@id"])
-  for t in sorted(g["@graph"], key=lambda u: u["@id"]):    
-    url = t["@id"]
-    targeturl = url
+    # pprint("GRAPH: %s" % g["@id"])
+    for t in sorted(g["@graph"], key=lambda u: u["@id"]):
+        url = t["@id"]
+        targeturl = url
 
-    if 'schema.org' not in str(url):
-      continue # cases like file:// and wikipedia links show up.
+        if "schema.org" not in str(url):
+            continue  # cases like file:// and wikipedia links show up.
 
-    if g['@id'] != "http://schema.org/#%s" % v: # extension
-      ext = subdomain(g['@id'])
-      if ext not in extensions:
-          extensions.append(ext)
-          print("Extension: %s" % ext)
-      exturl = url.replace('schema.org', ext + '.schema.org')
-      targeturl = exturl
-    else:
-      exturl = '' # core 
+        if g["@id"] != "http://schema.org/#%s" % v:  # extension
+            ext = subdomain(g["@id"])
+            if ext not in extensions:
+                extensions.append(ext)
+                print("Extension: %s" % ext)
+            exturl = url.replace("schema.org", ext + ".schema.org")
+            targeturl = exturl
+        else:
+            exturl = ""  # core
 
-    if host != "schema.org":
-        targeturl = targeturl.replace('schema.org', host)
+        if host != "schema.org":
+            targeturl = targeturl.replace("schema.org", host)
 
-    #print "%s, %s,\t%s" % (targeturl, url, exturl)
-    checkurl(targeturl)
+        # print "%s, %s,\t%s" % (targeturl, url, exturl)
+        checkurl(targeturl)
 
-#Check extension home pages
+# Check extension home pages
 
 for e in extensions:
-    e = "http://%s.%s" % (e,host)
-    #print e
-    checkurl(e) 
+    e = "http://%s.%s" % (e, host)
+    # print e
+    checkurl(e)
 
 print("\nChecked %s pages" % checked)
 if len(found):
-    print("Found '%s' in %s pages" % (SEARCH_TERM,len(found)))
+    print("Found '%s' in %s pages" % (SEARCH_TERM, len(found)))
     for f in found:
         print(f)
 else:
     print("Found 0 instances of %s" % SEARCH_TERM())
-
-
-
-    

--- a/software/scripts/shex_shacl_shapes_exporter.py
+++ b/software/scripts/shex_shacl_shapes_exporter.py
@@ -1,6 +1,8 @@
 #!/usr/bin/env python3
 # -*- coding: utf-8 -*-
 
+"""Generate the `shexj` and `shacl` files."""
+
 import argparse
 import json
 import os
@@ -247,7 +249,7 @@ def generate_files(term_defs_path, outputdir, outputfileprefix='', input_format=
 
 
 if __name__ == '__main__':
-    parser = argparse.ArgumentParser()
+    parser = argparse.ArgumentParser(description=__doc__)
     parser.add_argument("-s","--sourcefile", help="rdf format source file")
     parser.add_argument("-f","--format", default="nt", help="source file format (default: .nt)")
     parser.add_argument("-o","--outputdir", help="output directory (default: ./)")

--- a/software/scripts/shex_shacl_shapes_exporter.py
+++ b/software/scripts/shex_shacl_shapes_exporter.py
@@ -17,24 +17,24 @@ from rdflib import RDFS, RDF
 from rdflib.collection import Collection
 from rdflib.term import Node
 
-BASE = Namespace('http://schema.org/validation#')
-SCHEMA = Namespace('http://schema.org/')
-SHACL = Namespace('http://www.w3.org/ns/shacl#')
+BASE = Namespace("http://schema.org/validation#")
+SCHEMA = Namespace("http://schema.org/")
+SHACL = Namespace("http://www.w3.org/ns/shacl#")
 
-PREFIX = 'ValidSchema'
-FILE_ENCODING = 'utf-8'
+PREFIX = "ValidSchema"
+FILE_ENCODING = "utf-8"
 
 log = logging.getLogger(__name__)
+
 
 def replace_prefix(data):
     """
     Replaces schema.org prefix with schema.org validation prefix
     """
-    return BASE[PREFIX + data.replace('http://schema.org/', '')]
+    return BASE[PREFIX + data.replace("http://schema.org/", "")]
 
 
 class ShExJParser:
-
     @staticmethod
     def parse_shape(source: Graph, shape: URIRef, is_datatype: bool) -> dict:
         """
@@ -49,31 +49,34 @@ class ShExJParser:
         node: Union[dict[Any], None] = None
         if is_datatype:
             node = {
-                'type': 'NodeConstraint',
-                'nodeKind': 'literal'  # There are no more constraints on datatypes.
+                "type": "NodeConstraint",
+                "nodeKind": "literal",  # There are no more constraints on datatypes.
             }
         else:
-            node = {'type': 'Shape'}
-            properties = list(source.subjects(SCHEMA['domainIncludes'], shape))
+            node = {"type": "Shape"}
+            properties = list(source.subjects(SCHEMA["domainIncludes"], shape))
             # find all subclasses
             ancestors = list(set(ShExJParser.find_parent_classes(source, shape)))
             if len(properties) > 0:
-                expression = {'type': 'EachOf', 'expressions': [ShExJParser.type_constraint(ancestors + [shape])]}
+                expression = {
+                    "type": "EachOf",
+                    "expressions": [ShExJParser.type_constraint(ancestors + [shape])],
+                }
                 for prop in properties:
-                    expression['expressions'].append(ShExJParser.parse_property(source, prop))
-                node['expression'] = expression
+                    expression["expressions"].append(
+                        ShExJParser.parse_property(source, prop)
+                    )
+                node["expression"] = expression
             else:
-                node['expression'] = ShExJParser.type_constraint(ancestors + [id])
-            node['extra'] = [RDF.type]
-            parents = [replace_prefix(x) for x in source.objects(shape, RDFS.subClassOf)]
+                node["expression"] = ShExJParser.type_constraint(ancestors + [id])
+            node["extra"] = [RDF.type]
+            parents = [
+                replace_prefix(x) for x in source.objects(shape, RDFS.subClassOf)
+            ]
             if len(parents) > 0:
-                node['extends'] = parents
+                node["extends"] = parents
 
-        return {
-            'type': 'ShapeDecl',
-            'id': id,
-            'shapeExpr': node
-        }
+        return {"type": "ShapeDecl", "id": id, "shapeExpr": node}
 
     @staticmethod
     def type_constraint(types):
@@ -83,8 +86,11 @@ class ShExJParser:
         :param types: list of possible rdf:type values
         :return: JSON(dict) with ShExJ representation of rdf:type constraints
         """
-        node = {'type': 'TripleConstraint', 'predicate': RDF.type,
-                'valueExpr': {'type': 'NodeConstraint', 'values': types}}
+        node = {
+            "type": "TripleConstraint",
+            "predicate": RDF.type,
+            "valueExpr": {"type": "NodeConstraint", "values": types},
+        }
         return node
 
     @staticmethod
@@ -96,12 +102,14 @@ class ShExJParser:
         :param prop: property IRI
         :return: JSON(dict) with ShExJ representation of property constraints
         """
-        node = {'type': 'TripleConstraint', 'predicate': prop, 'min': 0, 'max': -1}
-        prop_range = list([replace_prefix(x) for x in source.objects(prop, SCHEMA['rangeIncludes'])])
+        node = {"type": "TripleConstraint", "predicate": prop, "min": 0, "max": -1}
+        prop_range = list(
+            [replace_prefix(x) for x in source.objects(prop, SCHEMA["rangeIncludes"])]
+        )
         if len(prop_range) == 1:
-            node['valueExpr'] = prop_range[0]
+            node["valueExpr"] = prop_range[0]
         elif len(prop_range) > 0:
-            node['valueExpr'] = {'type': 'ShapeOr', 'shapeExprs': prop_range}
+            node["valueExpr"] = {"type": "ShapeOr", "shapeExprs": prop_range}
         return node
 
     @staticmethod
@@ -126,29 +134,37 @@ class ShExJParser:
         :param source: source rdflib graph
         :return: string representation of ShExJ constraints
         """
-        shapes: list[URIRef] = list(source.subjects(RDF['type'], RDFS['Class']))
+        shapes: list[URIRef] = list(source.subjects(RDF["type"], RDFS["Class"]))
         shapes.sort(key=lambda u: str(u))
-        top_level_datatypes: Generator[Node, None, None] = source.subjects(RDF.type, SCHEMA.DataType)
+        top_level_datatypes: Generator[Node, None, None] = source.subjects(
+            RDF.type, SCHEMA.DataType
+        )
         all_datatypes: set[URIRef] = {URIRef(SCHEMA.DataType)}
         all_datatypes.update(ShExJParser.chase_subclasses(source, top_level_datatypes))
 
-        shex = {'type': 'Schema'}
-        shex['shapes'] = [ShExJParser.parse_shape(source, shape, is_datatype = shape in all_datatypes) for shape in shapes]
+        shex = {"type": "Schema"}
+        shex["shapes"] = [
+            ShExJParser.parse_shape(source, shape, is_datatype=shape in all_datatypes)
+            for shape in shapes
+        ]
 
         return json.dumps(shex)
 
     @staticmethod
-    def chase_subclasses(source: Graph, terms: Generator[Node, None, None]) -> Set[URIRef]:
+    def chase_subclasses(
+        source: Graph, terms: Generator[Node, None, None]
+    ) -> Set[URIRef]:
         ret: set[URIRef] = set()
         for term in terms:
             ret.add(term)
-            subclass_terms: Generator[Node, None, None] = source.subjects(RDFS.subClassOf, term)
+            subclass_terms: Generator[Node, None, None] = source.subjects(
+                RDFS.subClassOf, term
+            )
             ret.update(ShExJParser.chase_subclasses(source, subclass_terms))
         return ret
 
 
 class ShaclParser:
-
     @staticmethod
     def parse_shape(source, shape, dest):
         """
@@ -159,12 +175,18 @@ class ShaclParser:
         :param dest: output SHACL constraints graph
         """
         node = URIRef(replace_prefix(shape))
-        dest.add((node, RDF.type, SHACL['NodeShape']))
-        dest.add((node, SHACL['targetClass'], shape))
-        dest.add((node, SHACL['nodeKind'], SHACL['BlankNodeOrIRI']))
-        properties = list(source.subjects(SCHEMA['domainIncludes'], shape))
+        dest.add((node, RDF.type, SHACL["NodeShape"]))
+        dest.add((node, SHACL["targetClass"], shape))
+        dest.add((node, SHACL["nodeKind"], SHACL["BlankNodeOrIRI"]))
+        properties = list(source.subjects(SCHEMA["domainIncludes"], shape))
         for prop in properties:
-            dest.add((node, SHACL['property'], ShaclParser.parse_property(source, prop, dest)))
+            dest.add(
+                (
+                    node,
+                    SHACL["property"],
+                    ShaclParser.parse_property(source, prop, dest),
+                )
+            )
 
     @staticmethod
     def parse_property(source, prop, dest):
@@ -177,18 +199,20 @@ class ShaclParser:
         :return: property blank node
         """
         node = BNode()
-        dest.add((node, SHACL['path'], prop))
-        property_range = list([replace_prefix(x) for x in source.objects(prop, SCHEMA['rangeIncludes'])])
+        dest.add((node, SHACL["path"], prop))
+        property_range = list(
+            [replace_prefix(x) for x in source.objects(prop, SCHEMA["rangeIncludes"])]
+        )
         if len(property_range) > 1:
             or_node = BNode()
             or_collection = Collection(dest, or_node)
-            dest.add((node, SHACL['or'], or_node))
+            dest.add((node, SHACL["or"], or_node))
             for shape in property_range:
                 t = BNode()
-                dest.add((t, SHACL['node'], shape))
+                dest.add((t, SHACL["node"], shape))
                 or_collection.append(t)
         else:
-            dest.add((node, SHACL['node'], property_range[0]))
+            dest.add((node, SHACL["node"], property_range[0]))
         return node
 
     @staticmethod
@@ -200,12 +224,12 @@ class ShaclParser:
         :return: subclasses tree rdflib graph
         """
         subclasses = Graph()
-        subclasses.namespace_manager.bind('sh', SHACL)
-        subclasses.namespace_manager.bind('schema', SCHEMA)
-        subclasses.namespace_manager.bind('rdfs', RDFS)
-        for quad in list(source[None:RDFS['subClassOf']:None]):
-            subclasses.add([quad[0], RDFS['subClassOf'], quad[1]])
-        return subclasses.serialize(format='turtle')
+        subclasses.namespace_manager.bind("sh", SHACL)
+        subclasses.namespace_manager.bind("schema", SCHEMA)
+        subclasses.namespace_manager.bind("rdfs", RDFS)
+        for quad in list(source[None : RDFS["subClassOf"] : None]):
+            subclasses.add([quad[0], RDFS["subClassOf"], quad[1]])
+        return subclasses.serialize(format="turtle")
 
     @staticmethod
     def to_shacl(source):
@@ -216,54 +240,57 @@ class ShaclParser:
         :return: string representation of SHACL constraints
         """
         dest = Graph()
-        dest.namespace_manager.bind('sh', SHACL)
-        dest.namespace_manager.bind('schema', SCHEMA)
-        dest.namespace_manager.bind('', BASE)
-        shapes = set(list(source.subjects(RDF['type'], RDFS['Class'])))
+        dest.namespace_manager.bind("sh", SHACL)
+        dest.namespace_manager.bind("schema", SCHEMA)
+        dest.namespace_manager.bind("", BASE)
+        shapes = set(list(source.subjects(RDF["type"], RDFS["Class"])))
         for shape in shapes:
             ShaclParser.parse_shape(source, shape, dest)
-        return dest.serialize(format='turtle')
+        return dest.serialize(format="turtle")
 
 
-def generate_files(term_defs_path, outputdir, outputfileprefix='', input_format='nt'):
+def generate_files(term_defs_path, outputdir, outputfileprefix="", input_format="nt"):
     with open(term_defs_path) as term_def_file:
         term_defs = term_def_file.read()
     graph = Graph().parse(data=term_defs, format=input_format)
-    graph.bind('schema', SCHEMA)
+    graph.bind("schema", SCHEMA)
 
-    shexj_path = os.path.join(outputdir, outputfileprefix + 'shapes.shexj')
-    with open(shexj_path, 'w', encoding=FILE_ENCODING) as shexj_file:
+    shexj_path = os.path.join(outputdir, outputfileprefix + "shapes.shexj")
+    with open(shexj_path, "w", encoding=FILE_ENCODING) as shexj_file:
         shexj_file.write(ShExJParser.to_shex(graph))
     log.info("Created %s" % shexj_path)
 
-    shacl_path = os.path.join(outputdir, outputfileprefix + 'shapes.shacl')
-    with open(shexj_path, 'w', encoding=FILE_ENCODING) as shacl_file:
+    shacl_path = os.path.join(outputdir, outputfileprefix + "shapes.shacl")
+    with open(shexj_path, "w", encoding=FILE_ENCODING) as shacl_file:
         shacl_file.write(ShaclParser.to_shacl(graph))
     log.info("Created %s" % shacl_path)
 
     subclasses_tree = ShaclParser().get_subclasses(graph)
-    subclasses_path = os.path.join(outputdir, outputfileprefix + 'subclasses.shacl')
-    with open(subclasses_path, 'w', encoding=FILE_ENCODING) as subclasses_file:
+    subclasses_path = os.path.join(outputdir, outputfileprefix + "subclasses.shacl")
+    with open(subclasses_path, "w", encoding=FILE_ENCODING) as subclasses_file:
         subclasses_file.write(ShaclParser.get_subclasses(graph))
     log.info("Created %s" % subclasses_path)
 
 
-if __name__ == '__main__':
+if __name__ == "__main__":
     parser = argparse.ArgumentParser(description=__doc__)
-    parser.add_argument("-s","--sourcefile", help="rdf format source file")
-    parser.add_argument("-f","--format", default="nt", help="source file format (default: .nt)")
-    parser.add_argument("-o","--outputdir", help="output directory (default: ./)")
-    parser.add_argument("-p","--outputfileprefix", default="", help="output files prefix")
+    parser.add_argument("-s", "--sourcefile", help="rdf format source file")
+    parser.add_argument(
+        "-f", "--format", default="nt", help="source file format (default: .nt)"
+    )
+    parser.add_argument("-o", "--outputdir", help="output directory (default: ./)")
+    parser.add_argument(
+        "-p", "--outputfileprefix", default="", help="output files prefix"
+    )
     args = parser.parse_args()
 
     if args.sourcefile:
         term_defs_path = args.sourcefile
     else:
-        term_defs_path = input('.nt terms definitions path: ')
+        term_defs_path = input(".nt terms definitions path: ")
     generate_files(
-        term_defs_path = term_defs_path,
-        outputdir = args.outputdir,
-        outputfileprefix = args.outputfileprefix,
-        input_format = args.format)
-
-
+        term_defs_path=term_defs_path,
+        outputdir=args.outputdir,
+        outputfileprefix=args.outputfileprefix,
+        input_format=args.format,
+    )

--- a/software/scripts/vocab_counts.py
+++ b/software/scripts/vocab_counts.py
@@ -3,65 +3,71 @@
 
 import sys
 
-def vocab_term (term) :
-    parts = term.split('/', 4)
-    if (len(parts) < 4) :
-        return None 
-    domain = parts[2]
-    if (not (domain == "schema.org")) :
+
+def vocab_term(term):
+    parts = term.split("/", 4)
+    if len(parts) < 4:
         return None
-    else :
+    domain = parts[2]
+    if not (domain == "schema.org"):
+        return None
+    else:
         return parts[3]
 
+
 counts = {}
-def addCount (term, count) :
-    if (term in counts) :
+
+
+def addCount(term, count):
+    if term in counts:
         counts[term] = counts[term] + count
     else:
         counts[term] = count
-        
-def bucket (vt, count) :
-    if (vt != None):
-        if (count < 10) :
+
+
+def bucket(vt, count):
+    if vt != None:
+        if count < 10:
             return None
-        elif (count < 100) :
+        elif count < 100:
             return "%s\t%i" % (vt, 1)
-        elif (count < 1000) :
+        elif count < 1000:
             return "%s\t%i" % (vt, 2)
-        elif (count < 10000) :
+        elif count < 10000:
             return "%s\t%i" % (vt, 3)
-        elif (count < 50000) :
+        elif count < 50000:
             return "%s\t%i" % (vt, 4)
-        elif (count < 100000) :
+        elif count < 100000:
             return "%s\t%i" % (vt, 5)
-        elif (count < 250000) :
+        elif count < 250000:
             return "%s\t%i" % (vt, 7)
-        elif (count < 500000) :
+        elif count < 500000:
             return "%s\t%i" % (vt, 8)
-        elif (count < 1000000) :
+        elif count < 1000000:
             return "%s\t%i" % (vt, 9)
         else:
             return "%s\t%i" % (vt, 10)
 
+
 input_file = sys.argv[1]
 
 
-if (input_file != None):
+if input_file != None:
     f = open(input_file)
-    if (f != None):
-        for line in f:            
-            parts = line.strip().split(',')
-            if (len(parts) > 1):
+    if f != None:
+        for line in f:
+            parts = line.strip().split(",")
+            if len(parts) > 1:
                 term = parts[0]
                 count = 0
-                count_string = parts[1].replace(' ', '')
+                count_string = parts[1].replace(" ", "")
                 try:
                     count = int(parts[1])
                 except:
                     count = 0
                 term = vocab_term(term)
                 addCount(term, count)
-        for term in sorted(counts.keys(), key= lambda term: counts[term], reverse=True):
+        for term in sorted(counts.keys(), key=lambda term: counts[term], reverse=True):
             print(bucket(term, counts[term]))
     else:
         print("Cannot open file " + input_file)

--- a/software/tests/test_basics.py
+++ b/software/tests/test_basics.py
@@ -17,6 +17,7 @@ import software
 
 import software.SchemaTerms.sdotermsource as sdotermsource
 import software.SchemaTerms.sdoterm as sdoterm
+import software.SchemaTerms.localmarkdown as localmarkdown
 import software.SchemaExamples.schemaexamples as schemaexamples
 
 VOCABURI = sdotermsource.SdoTermSource.vocabUri()
@@ -30,7 +31,6 @@ examples_path = "./data/examples.txt"
 TYPECOUNT_UPPERBOUND = 1500
 TYPECOUNT_LOWERBOUND = 500
 CURRENT_CONTEXT_FILE = os.path.join(os.getcwd(), 'software', 'site', 'docs', 'jsonldcontext.jsonld')
-
 
 log = logging.getLogger(__name__)
 
@@ -401,10 +401,9 @@ class DataTypeTests(unittest.TestCase):
 
 class MarkDownTest(unittest.TestCase):
     def test_emph(self):
-        from localmarkdown import Markdown
 
         markstring = "This is _em_, __strong__, ___strong em___"
-        html = Markdown.parse(markstring, True)
+        html = localmarkdown.Markdown.parse(markstring, True)
         self.assertMultiLineEqual(
             html,
             "<p>This is <em>em</em>, <strong>strong</strong>, <strong><em>strong em</em></strong></p>\n",

--- a/software/tests/test_basics.py
+++ b/software/tests/test_basics.py
@@ -30,7 +30,9 @@ examples_path = "./data/examples.txt"
 
 TYPECOUNT_UPPERBOUND = 1500
 TYPECOUNT_LOWERBOUND = 500
-CURRENT_CONTEXT_FILE = os.path.join(os.getcwd(), 'software', 'site', 'docs', 'jsonldcontext.jsonld')
+CURRENT_CONTEXT_FILE = os.path.join(
+    os.getcwd(), "software", "site", "docs", "jsonldcontext.jsonld"
+)
 
 log = logging.getLogger(__name__)
 
@@ -401,7 +403,6 @@ class DataTypeTests(unittest.TestCase):
 
 class MarkDownTest(unittest.TestCase):
     def test_emph(self):
-
         markstring = "This is _em_, __strong__, ___strong em___"
         html = localmarkdown.Markdown.parse(markstring, True)
         self.assertMultiLineEqual(
@@ -499,15 +500,25 @@ class BasicJSONLDTests(unittest.TestCase):
 
     def test_issuedBy_jsonld(self):
         if not self.ctx:
-            raise unittest.SkipTest("%s file not loaded - bypassing tests" % CURRENT_CONTEXT_FILE)
-        self.assertTrue( "issuedBy" in self.ctx["@context"] , "issuedBy should be defined." )
-
+            raise unittest.SkipTest(
+                "%s file not loaded - bypassing tests" % CURRENT_CONTEXT_FILE
+            )
+        self.assertTrue(
+            "issuedBy" in self.ctx["@context"], "issuedBy should be defined."
+        )
 
     def test_dateModified_jsonld(self):
         if not self.ctx:
-            raise unittest.SkipTest("%s file not loaded - bypassing tests" % CURRENT_CONTEXT_FILE)
-        self.assertTrue( "dateModified" in self.ctx["@context"] , "dateModified should be defined." )
-        self.assertTrue( self.ctx["@context"]["dateModified"]["@type"] == "Date" , "dateModified should have Date type." )
+            raise unittest.SkipTest(
+                "%s file not loaded - bypassing tests" % CURRENT_CONTEXT_FILE
+            )
+        self.assertTrue(
+            "dateModified" in self.ctx["@context"], "dateModified should be defined."
+        )
+        self.assertTrue(
+            self.ctx["@context"]["dateModified"]["@type"] == "Date",
+            "dateModified should have Date type.",
+        )
 
     def test_sameas_jsonld(self):
         if not self.ctx:
@@ -518,28 +529,45 @@ class BasicJSONLDTests(unittest.TestCase):
 
 
 class JsonExampleTests(unittest.TestCase):
-  def testAllExamples(self):
-    for example in schemaexamples.SchemaExamples.allExamples():
-      source_filename = example.getMeta("file")
-      with self.subTest(key=example.getKey(), file=source_filename):
-        if not example.hasJsonld():
-          continue
-        json_source = example.getJsonldRaw()
-        try:
-          parsed = json.loads(json_source)
-        except json.decoder.JSONDecodeError as json_error:
-          # Display a helpful error message showing where the JSON error is.
-          lines = json_error.doc.split('\n')
-          snippet = lines[json_error.lineno - 1] + '\n' + '^'.rjust(json_error.colno)
-          # Show up to three lines above the error, often the problem is a missing comma above.
-          if json_error.lineno > 2:
-            for i in range(2, min(json_error.lineno, 5)):
-              snippet = lines[json_error.lineno - i] + '\n' + snippet
-          # Adjust by the offset inside the example file.
-          lineno = json_error.lineno + (example.jsonld_offset or 0)
-          self.fail("JSON parsing error: '%s' in file %s:%d:%d \n%s" % (json_error.msg, source_filename, lineno, json_error.colno, snippet))
-        except Exception as exception:
-          self.fail("Could not parse JSON '%s' error: %s file: %s" % (json_source, exception, source_filename))
+    def testAllExamples(self):
+        for example in schemaexamples.SchemaExamples.allExamples():
+            source_filename = example.getMeta("file")
+            with self.subTest(key=example.getKey(), file=source_filename):
+                if not example.hasJsonld():
+                    continue
+                json_source = example.getJsonldRaw()
+                try:
+                    parsed = json.loads(json_source)
+                except json.decoder.JSONDecodeError as json_error:
+                    # Display a helpful error message showing where the JSON error is.
+                    lines = json_error.doc.split("\n")
+                    snippet = (
+                        lines[json_error.lineno - 1]
+                        + "\n"
+                        + "^".rjust(json_error.colno)
+                    )
+                    # Show up to three lines above the error, often the problem is a missing comma above.
+                    if json_error.lineno > 2:
+                        for i in range(2, min(json_error.lineno, 5)):
+                            snippet = lines[json_error.lineno - i] + "\n" + snippet
+                    # Adjust by the offset inside the example file.
+                    lineno = json_error.lineno + (example.jsonld_offset or 0)
+                    self.fail(
+                        "JSON parsing error: '%s' in file %s:%d:%d \n%s"
+                        % (
+                            json_error.msg,
+                            source_filename,
+                            lineno,
+                            json_error.colno,
+                            snippet,
+                        )
+                    )
+                except Exception as exception:
+                    self.fail(
+                        "Could not parse JSON '%s' error: %s file: %s"
+                        % (json_source, exception, source_filename)
+                    )
+
 
 # TODO: Unwritten tests
 #

--- a/software/tests/test_graphs.py
+++ b/software/tests/test_graphs.py
@@ -25,58 +25,75 @@ log = logging.getLogger(__name__)
 
 VOCABURI = sdotermsource.SdoTermSource.vocabUri()
 
+
 # Tests to probe the health of both schemas and code using graph libraries in rdflib
 # Note that known failings can be annotated with @unittest.expectedFailure or @skip("reason...")
 class SDOGraphSetupTestCase(unittest.TestCase):
+    @classmethod
+    def loadGraphs(self):
+        sdotermsource.SdoTermSource.loadSourceGraph("default")
+        self.rdflib_data = sdotermsource.SdoTermSource.sourceGraph()
 
-  @classmethod
-  def loadGraphs(self):
-    sdotermsource.SdoTermSource.loadSourceGraph("default")
-    self.rdflib_data = sdotermsource.SdoTermSource.sourceGraph()
+    @classmethod
+    def setUpClass(self):
+        SDOGraphSetupTestCase.loadGraphs()
 
+    def test_graphsLoaded(self):
+        self.assertTrue(
+            len(self.rdflib_data) > 0,
+            "Graph rdflib_data should have some triples in it.",
+        )
 
-  @classmethod
-  def setUpClass(self):
-    SDOGraphSetupTestCase.loadGraphs()
+    # SPARQLResult http://rdflib.readthedocs.org/en/latest/apidocs/rdflib.plugins.sparql.html
+    # "A list of dicts (solution mappings) is returned"
 
-  def test_graphsLoaded(self):
-    self.assertTrue(len(self.rdflib_data) > 0,
-                     "Graph rdflib_data should have some triples in it.")
+    def test_found_sixplus_inverseOf(self):
+        inverseOf_results = self.rdflib_data.query(
+            "select ?x ?y where { ?x <https://schema.org/inverseOf> ?y }"
+        )
+        log.info("inverseOf result count: %s" % len(inverseOf_results))
+        self.assertTrue(
+            len(inverseOf_results) >= 6,
+            "Six or more inverseOf expected. Found: %s " % len(inverseOf_results),
+        )
 
-  # SPARQLResult http://rdflib.readthedocs.org/en/latest/apidocs/rdflib.plugins.sparql.html
-  # "A list of dicts (solution mappings) is returned"
+    def test_even_number_inverseOf(self):
+        inverseOf_results = self.rdflib_data.query(
+            "select ?x ?y where { ?x <https://schema.org/inverseOf> ?y }"
+        )
+        self.assertTrue(
+            len(inverseOf_results) % 2 == 0,
+            "Even number of inverseOf triples expected. Found: %s "
+            % len(inverseOf_results),
+        )
 
-  def test_found_sixplus_inverseOf(self):
-    inverseOf_results = self.rdflib_data.query("select ?x ?y where { ?x <https://schema.org/inverseOf> ?y }")
-    log.info("inverseOf result count: %s" % len(inverseOf_results ) )
-    self.assertTrue(len(inverseOf_results) >= 6,
-                    "Six or more inverseOf expected. Found: %s " % len(inverseOf_results ) )
+    def test_non_equal_inverseOf(self):
+        results = self.rdflib_data.query(
+            "select ?x ?y where { ?x <https://schema.org/inverseOf> ?y }"
+        )
+        for result in results:
+            self.assertTrue(
+                result[0] != result[1],
+                "%s should not be equal to %s" % (result[0], result[1]),
+            )
 
-  def test_even_number_inverseOf(self):
+    def test_non_equal_supercededBy(self):
+        results = self.rdflib_data.query(
+            "select ?x ?y where { ?x <https://schema.org/supercededBy> ?y }"
+        )
+        for result in results:
+            self.assertTrue(
+                result[0] != result[1],
+                "%s should not be equal to %s" % (result[0], result[1]),
+            )
 
-    inverseOf_results = self.rdflib_data.query("select ?x ?y where { ?x <https://schema.org/inverseOf> ?y }")
-    self.assertTrue(len(inverseOf_results ) % 2 == 0,
-                    "Even number of inverseOf triples expected. Found: %s " % len(inverseOf_results ) )
-
-  def test_non_equal_inverseOf(self):
-    results = self.rdflib_data.query("select ?x ?y where { ?x <https://schema.org/inverseOf> ?y }")
-    for result in results :
-      self.assertTrue(result[0] != result[1],
-                      "%s should not be equal to %s" % (result[0], result[1]) )
-
-  def test_non_equal_supercededBy(self):
-    results = self.rdflib_data.query("select ?x ?y where { ?x <https://schema.org/supercededBy> ?y }")
-    for result in results :
-      self.assertTrue(result[0] != result[1],
-                      "%s should not be equal to %s" % (result[0], result[1]) )
-
-  @unittest.expectedFailure # autos
-  def test_needlessDomainIncludes(self):
-    global warnings
-    # check immediate subtypes don't declare same domainIncludes
-    # TODO: could we use property paths here to be more thorough?
-    # rdfs:subClassOf+ should work but seems not to.
-    ndi1 = ('''SELECT ?prop ?c1 ?c2
+    @unittest.expectedFailure  # autos
+    def test_needlessDomainIncludes(self):
+        global warnings
+        # check immediate subtypes don't declare same domainIncludes
+        # TODO: could we use property paths here to be more thorough?
+        # rdfs:subClassOf+ should work but seems not to.
+        ndi1 = """SELECT ?prop ?c1 ?c2
            WHERE {
            ?prop <https://schema.org/domainIncludes> ?c1 .
            ?prop <https://schema.org/domainIncludes> ?c2 .
@@ -86,23 +103,30 @@ class SDOGraphSetupTestCase(unittest.TestCase):
            FILTER NOT EXISTS { ?c1 <https://schema.org/isPartOf> <http://attic.schema.org> .}
            FILTER NOT EXISTS { ?c2 <https://schema.org/isPartOf> <http://attic.schema.org> .}
            }
-           ORDER BY ?prop ''')
-    ndi1_results = self.rdflib_data.query(ndi1)
-    if (len(ndi1_results) > 0):
-        for row in ndi1_results:
-            warn = "Property %s defining domain, %s, [which is subclassOf] %s unnecessarily" % (row["prop"],row["c1"],row["c2"])
-            #warnings.append(warn)
-            log.warning(warn)
-    self.assertEqual(len(ndi1_results), 0,
-                     "No subtype need redeclare a domainIncludes of its parents. Found: %s " % len(ndi1_results ) )
+           ORDER BY ?prop """
+        ndi1_results = self.rdflib_data.query(ndi1)
+        if len(ndi1_results) > 0:
+            for row in ndi1_results:
+                warn = (
+                    "Property %s defining domain, %s, [which is subclassOf] %s unnecessarily"
+                    % (row["prop"], row["c1"], row["c2"])
+                )
+                # warnings.append(warn)
+                log.warning(warn)
+        self.assertEqual(
+            len(ndi1_results),
+            0,
+            "No subtype need redeclare a domainIncludes of its parents. Found: %s "
+            % len(ndi1_results),
+        )
 
-  @unittest.expectedFailure
-  def test_needlessRangeIncludes(self):
-    global warnings
-    # as above, but for range. We excuse URL as it is special, not best seen as a Text subtype.
-    # check immediate subtypes don't declare same domainIncludes
-    # TODO: could we use property paths here to be more thorough?
-    nri1= ('''SELECT ?prop ?c1 ?c2
+    @unittest.expectedFailure
+    def test_needlessRangeIncludes(self):
+        global warnings
+        # as above, but for range. We excuse URL as it is special, not best seen as a Text subtype.
+        # check immediate subtypes don't declare same domainIncludes
+        # TODO: could we use property paths here to be more thorough?
+        nri1 = """SELECT ?prop ?c1 ?c2
          WHERE {
          ?prop <https://schema.org/rangeIncludes> ?c1 .
          ?prop <https://schema.org/rangeIncludes> ?c2 .
@@ -113,21 +137,28 @@ class SDOGraphSetupTestCase(unittest.TestCase):
          FILTER NOT EXISTS { ?c1 <https://schema.org/isPartOf> <http://attic.schema.org> .}
          FILTER NOT EXISTS { ?c2 <https://schema.org/isPartOf> <http://attic.schema.org> .}
              }
-             ORDER BY ?prop ''')
-    nri1_results = self.rdflib_data.query(nri1)
-    if (len(nri1_results)>0):
-        for row in nri1_results:
-            warn = "Property %s defining range, %s, [which is subclassOf] %s unnecessarily" % (row["prop"],row["c1"],row["c2"])
-            log.warning(warn)
-    self.assertEqual(len(nri1_results), 0, "No subtype need redeclare a rangeIncludes of its parents. Found: %s" % len(nri1_results) )
+             ORDER BY ?prop """
+        nri1_results = self.rdflib_data.query(nri1)
+        if len(nri1_results) > 0:
+            for row in nri1_results:
+                warn = (
+                    "Property %s defining range, %s, [which is subclassOf] %s unnecessarily"
+                    % (row["prop"], row["c1"], row["c2"])
+                )
+                log.warning(warn)
+        self.assertEqual(
+            len(nri1_results),
+            0,
+            "No subtype need redeclare a rangeIncludes of its parents. Found: %s"
+            % len(nri1_results),
+        )
 
-#  def test_supersededByAreLabelled(self):
-#    supersededByAreLabelled_results = self.rdflib_data.query("select ?x ?y ?z where { ?x <https://schema.org/supersededBy> ?y . ?y <https://schema.org/name> ?z }")
-#    self.assertEqual(len(inverseOf_results ) % 2 == 0, True, "Even number of inverseOf triples expected. Found: %s " % len(inverseOf_results ) )
+    #  def test_supersededByAreLabelled(self):
+    #    supersededByAreLabelled_results = self.rdflib_data.query("select ?x ?y ?z where { ?x <https://schema.org/supersededBy> ?y . ?y <https://schema.org/name> ?z }")
+    #    self.assertEqual(len(inverseOf_results ) % 2 == 0, True, "Even number of inverseOf triples expected. Found: %s " % len(inverseOf_results ) )
 
-
-  def test_validRangeIncludes(self):
-    nri1= ('''SELECT ?prop ?c1
+    def test_validRangeIncludes(self):
+        nri1 = """SELECT ?prop ?c1
      WHERE {
          ?prop <https://schema.org/rangeIncludes> ?c1 .
          OPTIONAL{
@@ -137,14 +168,21 @@ class SDOGraphSetupTestCase(unittest.TestCase):
          FILTER (!BOUND(?c2))
         FILTER NOT EXISTS { ?prop <https://schema.org/isPartOf> <http://attic.schema.org> .}
                  }
-                 ORDER BY ?prop ''')
-    nri1_results = self.rdflib_data.query(nri1)
-    for row in nri1_results:
-        log.info("Property %s invalid rangeIncludes value: %s\n" % (row["prop"],row["c1"]))
-    self.assertEqual(len(nri1_results), 0, "RangeIncludes should define valid type. Found: %s" % len(nri1_results))
+                 ORDER BY ?prop """
+        nri1_results = self.rdflib_data.query(nri1)
+        for row in nri1_results:
+            log.info(
+                "Property %s invalid rangeIncludes value: %s\n"
+                % (row["prop"], row["c1"])
+            )
+        self.assertEqual(
+            len(nri1_results),
+            0,
+            "RangeIncludes should define valid type. Found: %s" % len(nri1_results),
+        )
 
-  def test_validDomainIncludes(self):
-    nri1= ('''SELECT ?prop ?c1
+    def test_validDomainIncludes(self):
+        nri1 = """SELECT ?prop ?c1
      WHERE {
          ?prop <https://schema.org/domainIncludes> ?c1 .
          OPTIONAL{
@@ -154,52 +192,74 @@ class SDOGraphSetupTestCase(unittest.TestCase):
          FILTER (!BOUND(?c2))
         FILTER NOT EXISTS { ?prop <https://schema.org/isPartOf> <http://attic.schema.org> .}
                  }
-                 ORDER BY ?prop ''')
-    nri1_results = self.rdflib_data.query(nri1)
-    for row in nri1_results:
-        log.info("Property %s invalid domainIncludes value: %s\n" % (row["prop"],row["c1"]))
-    self.assertEqual(len(nri1_results), 0, "DomainIncludes should define valid type. Found: %s" % len(nri1_results))
+                 ORDER BY ?prop """
+        nri1_results = self.rdflib_data.query(nri1)
+        for row in nri1_results:
+            log.info(
+                "Property %s invalid domainIncludes value: %s\n"
+                % (row["prop"], row["c1"])
+            )
+        self.assertEqual(
+            len(nri1_results),
+            0,
+            "DomainIncludes should define valid type. Found: %s" % len(nri1_results),
+        )
 
-  # These are place-holders for more sophisticated SPARQL-expressed checks.
-  @unittest.expectedFailure
-  def test_readSchemaFromRDFa(self):
-    self.assertTrue(True, False, "We should know how to locally get /docs/schema_org_rdfa.html but this requires fixes to api.py.")
+    # These are place-holders for more sophisticated SPARQL-expressed checks.
+    @unittest.expectedFailure
+    def test_readSchemaFromRDFa(self):
+        self.assertTrue(
+            True,
+            False,
+            "We should know how to locally get /docs/schema_org_rdfa.html but this requires fixes to api.py.",
+        )
 
-  #@unittest.expectedFailure
-  def test_simpleLabels(self):
-     s = ""
-     complexLabels = self.rdflib_data.query(
-        "select distinct ?term ?label where { ?term rdfs:label ?label  FILTER regex(?label,'[^a-zA-Z0-9_ ]','i'). } " )
-     for row in complexLabels:
-       s += (" term %s has complex label: %s\n" % (row["term"],row["label"]))
-     self.assertTrue(len(complexLabels ) == 0,
-       "No complex term labels expected; alphanumeric only please. Found: %s Details: %s\n"% (len(complexLabels), s) )
-     # Whitespace is tolerated, for now.
-     # we don't deal well with non definitional uses of rdfs:label yet - non terms are flagged up.
-     # https://github.com/schemaorg/schemaorg/issues/1136
+    # @unittest.expectedFailure
+    def test_simpleLabels(self):
+        s = ""
+        complexLabels = self.rdflib_data.query(
+            "select distinct ?term ?label where { ?term rdfs:label ?label  FILTER regex(?label,'[^a-zA-Z0-9_ ]','i'). } "
+        )
+        for row in complexLabels:
+            s += " term %s has complex label: %s\n" % (row["term"], row["label"])
+        self.assertTrue(
+            len(complexLabels) == 0,
+            "No complex term labels expected; alphanumeric only please. Found: %s Details: %s\n"
+            % (len(complexLabels), s),
+        )
+        # Whitespace is tolerated, for now.
+        # we don't deal well with non definitional uses of rdfs:label yet - non terms are flagged up.
+        # https://github.com/schemaorg/schemaorg/issues/1136
 
     #
     # TODO: https://github.com/schemaorg/schemaorg/issues/662
     #
     # self.assertEqual(len(ndi1_results), 0, "No domainIncludes or rangeIncludes value should lack a type. Found: %s " % len(ndi1_results ) )
 
-  def test_labelMatchesTermId(self):
-    nri1= ('''select ?term ?label where {
+    def test_labelMatchesTermId(self):
+        nri1 = """select ?term ?label where {
        ?term rdfs:label ?label.
        BIND(STR(?term) AS ?strVal)
        FILTER(STRLEN(?strVal) >= 19 && SUBSTR(?strVal, 1, 19) = "https://schema.org/")
        FILTER(SUBSTR(?strVal, 20) != STR(?label))
     }
-    ORDER BY ?term  ''')
-    nri1_results = self.rdflib_data.query(nri1)
-    if len(nri1_results):
-        log.info("Label matching errors:")
-        for row in nri1_results:
-            log.info("Term '%s' has none-matching label: '%s'" % (row["term"],row["label"]))
-    self.assertEqual(len(nri1_results), 0, "Term should have matching rdfs:label. Found: %s" % len(nri1_results))
+    ORDER BY ?term  """
+        nri1_results = self.rdflib_data.query(nri1)
+        if len(nri1_results):
+            log.info("Label matching errors:")
+            for row in nri1_results:
+                log.info(
+                    "Term '%s' has none-matching label: '%s'"
+                    % (row["term"], row["label"])
+                )
+        self.assertEqual(
+            len(nri1_results),
+            0,
+            "Term should have matching rdfs:label. Found: %s" % len(nri1_results),
+        )
 
-  def test_superTypesExist(self):
-    nri1= ('''select ?term ?super where {
+    def test_superTypesExist(self):
+        nri1 = """select ?term ?super where {
        ?term rdfs:subClassOf ?super.
        ?term rdf:type rdfs:Class.
        FILTER NOT EXISTS { ?super rdf:type rdfs:Class }
@@ -211,42 +271,57 @@ class SDOGraphSetupTestCase(unittest.TestCase):
        FILTER(STRLEN(?superStrVal) >= 19 && SUBSTR(?superStrVal, 1, 19) = "https://schema.org/")
         FILTER NOT EXISTS { ?term <https://schema.org/isPartOf> <http://attic.schema.org> .}
     }
-    ORDER BY ?term  ''')
-    nri1_results = self.rdflib_data.query(nri1)
-    if len(nri1_results):
-        log.info("Invalid SuperType errors!!!\n")
-        for row in nri1_results:
-            log.info("Term '%s' has nonexistent supertype: '%s'" % (row["term"],row["super"]))
-    self.assertEqual(len(nri1_results), 0, "Types with nonexistent SuperTypes. Found: %s" % len(nri1_results))
+    ORDER BY ?term  """
+        nri1_results = self.rdflib_data.query(nri1)
+        if len(nri1_results):
+            log.info("Invalid SuperType errors!!!\n")
+            for row in nri1_results:
+                log.info(
+                    "Term '%s' has nonexistent supertype: '%s'"
+                    % (row["term"], row["super"])
+                )
+        self.assertEqual(
+            len(nri1_results),
+            0,
+            "Types with nonexistent SuperTypes. Found: %s" % len(nri1_results),
+        )
 
-    def test_propswitoutdomain(self):
-        nri1= (''' select ?term where {
+        def test_propswitoutdomain(self):
+            nri1 = """ select ?term where {
             ?term a rdf:Property.
             FILTER NOT EXISTS { ?term <https://schema.org/domainIncludes> ?o .}
         }
-         ''')
-        nri1_results = self.rdflib_data.query(nri1)
-        if len(nri1_results):
-            log.info("Property without domain errors!!!\n")
-            for row in nri1_results:
-                log.info("Term '%s' has no domainIncludes value(s)" % (row["term"]))
-        self.assertEqual(len(nri1_results), 0, "Property without domain extensions  Found: %s" % len(nri1_results))
+         """
+            nri1_results = self.rdflib_data.query(nri1)
+            if len(nri1_results):
+                log.info("Property without domain errors!!!\n")
+                for row in nri1_results:
+                    log.info("Term '%s' has no domainIncludes value(s)" % (row["term"]))
+            self.assertEqual(
+                len(nri1_results),
+                0,
+                "Property without domain extensions  Found: %s" % len(nri1_results),
+            )
 
-    def test_propswitoutrange(self):
-        nri1= (''' select ?term where {
+        def test_propswitoutrange(self):
+            nri1 = """ select ?term where {
             ?term a rdf:Property.
             FILTER NOT EXISTS { ?term <https://schema.org/rangeIncludes> ?o .}
         }
-         ''')
-        nri1_results = self.rdflib_data.query(nri1)
-        if len(nri1_results):
-            log.info("Property without domain errors!!!\n")
-            for row in nri1_results:
-                log.info("Term '%s' has no rangeIncludes value(s)" % (row["term"]))
-        self.assertEqual(len(nri1_results), 0, "Property without range extensions  Found: %s" % len(nri1_results))
+         """
+            nri1_results = self.rdflib_data.query(nri1)
+            if len(nri1_results):
+                log.info("Property without domain errors!!!\n")
+                for row in nri1_results:
+                    log.info("Term '%s' has no rangeIncludes value(s)" % (row["term"]))
+            self.assertEqual(
+                len(nri1_results),
+                0,
+                "Property without range extensions  Found: %s" % len(nri1_results),
+            )
 
-  def test_superPropertiesExist(self):
-    nri1= ('''select ?term ?super where {
+    def test_superPropertiesExist(self):
+        nri1 = """select ?term ?super where {
        ?term rdf:type rdf:Property.
        ?term rdfs:subPropertyOf ?super.
        FILTER NOT EXISTS { ?super rdf:type rdf:Property }
@@ -258,16 +333,24 @@ class SDOGraphSetupTestCase(unittest.TestCase):
        FILTER(STRLEN(?superStrVal) >= 19 && SUBSTR(?superStrVal, 1, 19) = "https://schema.org/")
         FILTER NOT EXISTS { ?term <https://schema.org/isPartOf> <http://attic.schema.org> .}
     }
-    ORDER BY ?term  ''')
-    nri1_results = self.rdflib_data.query(nri1)
-    if len(nri1_results):
-        log.info("Invalid Super-Property errors!!!\n")
-        for row in nri1_results:
-            log.info("Term '%s' has nonexistent super-property: '%s'" % (row["term"],row["super"]))
-    self.assertEqual(len(nri1_results), 0, "Properties with nonexistent SuperProperties. Found: %s" % len(nri1_results))
+    ORDER BY ?term  """
+        nri1_results = self.rdflib_data.query(nri1)
+        if len(nri1_results):
+            log.info("Invalid Super-Property errors!!!\n")
+            for row in nri1_results:
+                log.info(
+                    "Term '%s' has nonexistent super-property: '%s'"
+                    % (row["term"], row["super"])
+                )
+        self.assertEqual(
+            len(nri1_results),
+            0,
+            "Properties with nonexistent SuperProperties. Found: %s"
+            % len(nri1_results),
+        )
 
-  def test_selfReferencingInverse(self):
-    nri1= ('''select ?term ?inverse where {
+    def test_selfReferencingInverse(self):
+        nri1 = """select ?term ?inverse where {
        ?term rdf:type rdf:Property.
        ?term <https://schema.org/inverseOf> ?inverse.
 
@@ -278,16 +361,20 @@ class SDOGraphSetupTestCase(unittest.TestCase):
         FILTER NOT EXISTS { ?term <https://schema.org/isPartOf> <http://attic.schema.org> .}
 
     }
-    ORDER BY ?term  ''')
-    nri1_results = self.rdflib_data.query(nri1)
-    if len(nri1_results):
-        log.info("Self referencing inverseOf errors!!!\n")
-        for row in nri1_results:
-            log.info("Term '%s' is defined as inverseOf self" % (row["term"]))
-    self.assertEqual(len(nri1_results), 0, "Types with self referencing inverseOf Found: %s" % len(nri1_results))
+    ORDER BY ?term  """
+        nri1_results = self.rdflib_data.query(nri1)
+        if len(nri1_results):
+            log.info("Self referencing inverseOf errors!!!\n")
+            for row in nri1_results:
+                log.info("Term '%s' is defined as inverseOf self" % (row["term"]))
+        self.assertEqual(
+            len(nri1_results),
+            0,
+            "Types with self referencing inverseOf Found: %s" % len(nri1_results),
+        )
 
-  def test_sameInverseAndSupercededByTarget(self):
-    nri1= ('''select ?term ?inverse ?super where {
+    def test_sameInverseAndSupercededByTarget(self):
+        nri1 = """select ?term ?inverse ?super where {
        ?term rdf:type rdf:Property.
        ?term <https://schema.org/inverseOf> ?inverse.
        ?term <https://schema.org/supercededBy> ?super.
@@ -299,17 +386,25 @@ class SDOGraphSetupTestCase(unittest.TestCase):
         FILTER NOT EXISTS { ?term <https://schema.org/isPartOf> <http://attic.schema.org> .}
 
     }
-    ORDER BY ?term  ''')
-    nri1_results = self.rdflib_data.query(nri1)
-    if len(nri1_results):
-        log.info("InverseOf supercededBy shared target errors!!!\n")
-        for row in nri1_results:
-            log.info("Term '%s' defined ase inverseOf AND supercededBy %s" % (row["term"], row["inverse"]))
-    self.assertEqual(len(nri1_results), 0, "Types with inverseOf supercededBy shared target Found: %s" % len(nri1_results))
+    ORDER BY ?term  """
+        nri1_results = self.rdflib_data.query(nri1)
+        if len(nri1_results):
+            log.info("InverseOf supercededBy shared target errors!!!\n")
+            for row in nri1_results:
+                log.info(
+                    "Term '%s' defined ase inverseOf AND supercededBy %s"
+                    % (row["term"], row["inverse"])
+                )
+        self.assertEqual(
+            len(nri1_results),
+            0,
+            "Types with inverseOf supercededBy shared target Found: %s"
+            % len(nri1_results),
+        )
 
-  def test_commentEndWithPeriod(self):
-    """Validate that class and property RDF comments end with a punctuation."""
-    nri1= ('''select ?term ?com where {
+    def test_commentEndWithPeriod(self):
+        """Validate that class and property RDF comments end with a punctuation."""
+        nri1 = """select ?term ?com where {
        ?term rdfs:comment ?com.
 
        BIND(STR(?term) AS ?strVal)
@@ -317,12 +412,16 @@ class SDOGraphSetupTestCase(unittest.TestCase):
 
        FILTER (!(regex(str(?com), '[\\\\.\\\\)\\\\?]\\\\s*$') || regex(str(?com), 'n\\\\* .*')))
     }
-    ORDER BY ?term  ''')
-    nri1_results = tuple(map(str, self.rdflib_data.query(nri1)))
-    self.assertFalse(nri1_results, "Comment without ending '.', ')' or '?' Found: %s" % '\n'.join(nri1_results))
+    ORDER BY ?term  """
+        nri1_results = tuple(map(str, self.rdflib_data.query(nri1)))
+        self.assertFalse(
+            nri1_results,
+            "Comment without ending '.', ')' or '?' Found: %s"
+            % "\n".join(nri1_results),
+        )
 
-  def test_typeLabelCase(self):
-    nri1= ('''select ?term ?label where {
+    def test_typeLabelCase(self):
+        nri1 = """select ?term ?label where {
        ?term rdf:type rdfs:Class.
        ?term rdfs:label ?label.
 
@@ -331,16 +430,23 @@ class SDOGraphSetupTestCase(unittest.TestCase):
 
        FILTER (!regex(str(?label), '^[0-9]*[A-Z].*'))
     }
-    ORDER BY ?term  ''')
-    nri1_results = self.rdflib_data.query(nri1)
-    if len(nri1_results):
-        log.info("Type label [A-Z] errors!!!\n")
-        for row in nri1_results:
-            log.info("Type '%s' has a label without upper case 1st character" % (row["term"]))
-    self.assertEqual(len(nri1_results), 0, "Type label not [A-Z] 1st non-numeric char Found: %s" % len(nri1_results))
+    ORDER BY ?term  """
+        nri1_results = self.rdflib_data.query(nri1)
+        if len(nri1_results):
+            log.info("Type label [A-Z] errors!!!\n")
+            for row in nri1_results:
+                log.info(
+                    "Type '%s' has a label without upper case 1st character"
+                    % (row["term"])
+                )
+        self.assertEqual(
+            len(nri1_results),
+            0,
+            "Type label not [A-Z] 1st non-numeric char Found: %s" % len(nri1_results),
+        )
 
-  def test_propertyLabelCase(self):
-    nri1= ('''select ?term ?label where {
+    def test_propertyLabelCase(self):
+        nri1 = """select ?term ?label where {
        ?term rdf:type rdf:Property.
        ?term rdfs:label ?label.
 
@@ -349,16 +455,23 @@ class SDOGraphSetupTestCase(unittest.TestCase):
 
        FILTER (!regex(str(?label), '^[0-9]*[a-z].*'))
     }
-    ORDER BY ?term  ''')
-    nri1_results = self.rdflib_data.query(nri1)
-    if len(nri1_results):
-        log.info("Property label [a-z] errors!!!\n")
-        for row in nri1_results:
-            log.info("Property '%s' has a label without lower case 1st non-numeric character" % (row["term"]))
-    self.assertEqual(len(nri1_results), 0, "Property label not [a-z] 1st char Found: %s" % len(nri1_results))
+    ORDER BY ?term  """
+        nri1_results = self.rdflib_data.query(nri1)
+        if len(nri1_results):
+            log.info("Property label [a-z] errors!!!\n")
+            for row in nri1_results:
+                log.info(
+                    "Property '%s' has a label without lower case 1st non-numeric character"
+                    % (row["term"])
+                )
+        self.assertEqual(
+            len(nri1_results),
+            0,
+            "Property label not [a-z] 1st char Found: %s" % len(nri1_results),
+        )
 
-  def test_superTypeInAttic(self):
-    nri1= ('''select ?term ?super where {
+    def test_superTypeInAttic(self):
+        nri1 = """select ?term ?super where {
        {
            ?term rdfs:subClassOf ?super.
        }
@@ -369,16 +482,21 @@ class SDOGraphSetupTestCase(unittest.TestCase):
        ?super <https://schema.org/isPartOf> <http://attic.schema.org> .
        FILTER NOT EXISTS { ?term <https://schema.org/isPartOf> <http://attic.schema.org> .}
     }
-    ORDER BY ?term  ''')
-    nri1_results = self.rdflib_data.query(nri1)
-    if len(nri1_results):
-        log.info("Super-term in attic errors!!!\n")
-        for row in nri1_results:
-            log.info("Term '%s' is sub-term of %s a term in attic" % (row["term"],row["super"]))
-    self.assertEqual(len(nri1_results), 0, "Super-term in attic  Found: %s" % len(nri1_results))
+    ORDER BY ?term  """
+        nri1_results = self.rdflib_data.query(nri1)
+        if len(nri1_results):
+            log.info("Super-term in attic errors!!!\n")
+            for row in nri1_results:
+                log.info(
+                    "Term '%s' is sub-term of %s a term in attic"
+                    % (row["term"], row["super"])
+                )
+        self.assertEqual(
+            len(nri1_results), 0, "Super-term in attic  Found: %s" % len(nri1_results)
+        )
 
-  def test_referenceTermInAttic(self):
-    nri1= ('''select ?term ?rel ?ref where {
+    def test_referenceTermInAttic(self):
+        nri1 = """select ?term ?rel ?ref where {
        {
            ?term <https://schema.org/domainIncludes> ?ref.
            ?term ?rel ?ref.
@@ -401,45 +519,58 @@ class SDOGraphSetupTestCase(unittest.TestCase):
        ?ref <https://schema.org/isPartOf> <http://attic.schema.org> .
        FILTER NOT EXISTS { ?term <https://schema.org/isPartOf> <http://attic.schema.org> .}
     }
-    ORDER BY ?term  ''')
-    nri1_results = self.rdflib_data.query(nri1)
-    if len(nri1_results):
-        log.info("Reference to attic term errors!!!\n")
-        for row in nri1_results:
-            log.info("Term '%s' makes a %s reference to %s a term in attic" % (row["term"],row["rel"],row["ref"]))
-    self.assertEqual(len(nri1_results), 0, "Reference to attic term  Found: %s" % len(nri1_results))
+    ORDER BY ?term  """
+        nri1_results = self.rdflib_data.query(nri1)
+        if len(nri1_results):
+            log.info("Reference to attic term errors!!!\n")
+            for row in nri1_results:
+                log.info(
+                    "Term '%s' makes a %s reference to %s a term in attic"
+                    % (row["term"], row["rel"], row["ref"])
+                )
+        self.assertEqual(
+            len(nri1_results),
+            0,
+            "Reference to attic term  Found: %s" % len(nri1_results),
+        )
 
-  def test_termIn2PlusExtensions(self):
-    nri1= ('''select ?term (count(?part) as ?count) where {
+    def test_termIn2PlusExtensions(self):
+        nri1 = """select ?term (count(?part) as ?count) where {
         ?term <https://schema.org/isPartOf> ?part.
     }
     GROUP BY ?term
     HAVING (count(?part) > 1)
     ORDER BY ?term
-     ''')
-    nri1_results = self.rdflib_data.query(nri1)
-    if len(nri1_results):
-        log.info("Term in +1 extensions errors!!!\n")
-        for row in nri1_results:
-            log.info("Term '%s' isPartOf %s extensions" % (row["term"],row["count"]))
-    self.assertEqual(len(nri1_results), 0, "Term in +1 extensions  Found: %s" % len(nri1_results))
+     """
+        nri1_results = self.rdflib_data.query(nri1)
+        if len(nri1_results):
+            log.info("Term in +1 extensions errors!!!\n")
+            for row in nri1_results:
+                log.info(
+                    "Term '%s' isPartOf %s extensions" % (row["term"], row["count"])
+                )
+        self.assertEqual(
+            len(nri1_results), 0, "Term in +1 extensions  Found: %s" % len(nri1_results)
+        )
 
-  def test_termNothttps(self):
-    nri1= ('''select distinct ?term where {
+    def test_termNothttps(self):
+        nri1 = """select distinct ?term where {
       ?term ?p ?o.
       FILTER strstarts(str(?term),"http://schema.org")
     }
     ORDER BY ?term
-     ''')
-    nri1_results = self.rdflib_data.query(nri1)
-    if len(nri1_results):
-        log.info("Term defined as http errors!!!\n")
-        for row in nri1_results:
-            log.info("Term '%s' is defined as http " % (row["term"]))
-    self.assertEqual(len(nri1_results), 0, "Term defined as http  Found: %s" % len(nri1_results))
+     """
+        nri1_results = self.rdflib_data.query(nri1)
+        if len(nri1_results):
+            log.info("Term defined as http errors!!!\n")
+            for row in nri1_results:
+                log.info("Term '%s' is defined as http " % (row["term"]))
+        self.assertEqual(
+            len(nri1_results), 0, "Term defined as http  Found: %s" % len(nri1_results)
+        )
 
-  def test_targetNothttps(self):
-    nri1= ('''prefix rdfs: <http://www.w3.org/2000/01/rdf-schema#>
+    def test_targetNothttps(self):
+        nri1 = """prefix rdfs: <http://www.w3.org/2000/01/rdf-schema#>
     prefix schema: <https://schema.org/>
     select ?term ?target where {
 
@@ -452,16 +583,21 @@ class SDOGraphSetupTestCase(unittest.TestCase):
       filter strstarts(str(?target),"http://schema.org")
     }
     ORDER BY ?term
-     ''')
-    nri1_results = self.rdflib_data.query(nri1)
-    if len(nri1_results):
-        log.info("Target defined as https errors!!!\n")
-        for row in nri1_results:
-            log.info("Term '%s' references term %s  as https " % (row["term"],row["target"]))
-    self.assertEqual(len(nri1_results), 0, "Term defined as https  Found: %s" % len(nri1_results))
+     """
+        nri1_results = self.rdflib_data.query(nri1)
+        if len(nri1_results):
+            log.info("Target defined as https errors!!!\n")
+            for row in nri1_results:
+                log.info(
+                    "Term '%s' references term %s  as https "
+                    % (row["term"], row["target"])
+                )
+        self.assertEqual(
+            len(nri1_results), 0, "Term defined as https  Found: %s" % len(nri1_results)
+        )
 
-  def test_isPartOf(self):
-    nri1= ('''prefix rdfs: <http://www.w3.org/2000/01/rdf-schema#>
+    def test_isPartOf(self):
+        nri1 = """prefix rdfs: <http://www.w3.org/2000/01/rdf-schema#>
     prefix schema: <https://schema.org/>
     select ?term  ?partof where {
       ?term schema:isPartOf ?partof .
@@ -485,30 +621,42 @@ class SDOGraphSetupTestCase(unittest.TestCase):
       }
     }
     ORDER BY ?term
-      ''')
-    nri1_results = self.rdflib_data.query(nri1)
-    if len(nri1_results):
-        log.info("Invalid isPartOf value errors!!!\n")
-        for row in nri1_results:
-            log.info("Term '%s' has invalid isPartOf value '%s'" % (row["term"],row["partof"]))
-    self.assertEqual(len(nri1_results), 0, "Invalid isPartOf value errors  Found: %s" % len(nri1_results))
+      """
+        nri1_results = self.rdflib_data.query(nri1)
+        if len(nri1_results):
+            log.info("Invalid isPartOf value errors!!!\n")
+            for row in nri1_results:
+                log.info(
+                    "Term '%s' has invalid isPartOf value '%s'"
+                    % (row["term"], row["partof"])
+                )
+        self.assertEqual(
+            len(nri1_results),
+            0,
+            "Invalid isPartOf value errors  Found: %s" % len(nri1_results),
+        )
 
-
-
-  @unittest.expectedFailure
-  def test_EnumerationWithoutEnums(self):
-    nri1= ('''select ?term where {
+    @unittest.expectedFailure
+    def test_EnumerationWithoutEnums(self):
+        nri1 = """select ?term where {
         ?term a rdfs:subClassOf+ <https://schema.org/Enumeration> .
         FILTER NOT EXISTS { ?enum a ?term. }
         FILTER NOT EXISTS { ?term <https://schema.org/isPartOf> <http://attic.schema.org> .}
     }
-    ORDER BY ?term  ''')
-    nri1_results = self.rdflib_data.query(nri1)
-    if len(nri1_results):
-        log.info("Enumeration Type without Enumeration value(s) errors!!!\n")
-        for row in nri1_results:
-            log.info("Enumeration Type '%s' has no matching enum values" % (row["term"]))
-    self.assertEqual(len(nri1_results), 0, "Enumeration Type without Enumeration value(s)    Found: %s" % len(nri1_results))
+    ORDER BY ?term  """
+        nri1_results = self.rdflib_data.query(nri1)
+        if len(nri1_results):
+            log.info("Enumeration Type without Enumeration value(s) errors!!!\n")
+            for row in nri1_results:
+                log.info(
+                    "Enumeration Type '%s' has no matching enum values" % (row["term"])
+                )
+        self.assertEqual(
+            len(nri1_results),
+            0,
+            "Enumeration Type without Enumeration value(s)    Found: %s"
+            % len(nri1_results),
+        )
 
 
 def tearDownModule():
@@ -518,6 +666,7 @@ def tearDownModule():
     for warn in warnings:
         log.info("%s" % warn)
 
+
 # TODO: Unwritten tests (from basics; easier here?)
 #
 # * different terms should not have identical comments
@@ -526,4 +675,4 @@ def tearDownModule():
 # * need a few supporting functions e.g. all terms, all types, all properties, all enum values; candidates for api later but just use here first.
 
 if __name__ == "__main__":
-  unittest.main()
+    unittest.main()

--- a/software/tests/test_graphs.py
+++ b/software/tests/test_graphs.py
@@ -1,33 +1,29 @@
 #!/usr/bin/env python3
 # -*- coding: UTF-8 -*-
 import sys
-if not (sys.version_info.major == 3 and sys.version_info.minor > 5):
-    print("Python version %s.%s not supported version 3.6 or above required - exiting" % (sys.version_info.major,sys.version_info.minor))
-    sys.exit(1)
-
 import os
-for path in [os.getcwd(),"software/Util","software/SchemaTerms","software/SchemaExamples"]:
-  sys.path.insert( 1, path ) #Pickup libs from local  directories
-
-import unittest
-import os
-from os import getenv
-from os.path import expanduser
-import logging # https://docs.python.org/2/library/logging.html#logging-levels
+import logging
 import glob
 import sys
+import unittest
+import rdflib
+
+# Import schema.org libraries
+if not os.getcwd() in sys.path:
+    sys.path.insert(1, os.getcwd())
+
+import software
+
+import software.SchemaTerms.sdotermsource as sdotermsource
 
 warnings = []
 
-andstr = "\n AND\n  "
 TYPECOUNT_UPPERBOUND = 1000
 TYPECOUNT_LOWERBOUND = 500
 
-logging.basicConfig(level=logging.INFO)
 log = logging.getLogger(__name__)
 
-from sdotermsource import SdoTermSource
-VOCABURI = SdoTermSource.vocabUri()
+VOCABURI = sdotermsource.SdoTermSource.vocabUri()
 
 # Tests to probe the health of both schemas and code using graph libraries in rdflib
 # Note that known failings can be annotated with @unittest.expectedFailure or @skip("reason...")
@@ -35,20 +31,12 @@ class SDOGraphSetupTestCase(unittest.TestCase):
 
   @classmethod
   def loadGraphs(self):
-      if not SdoTermSource.SOURCEGRAPH:
-        SdoTermSource.loadSourceGraph("default")
-      self.rdflib_data = SdoTermSource.sourceGraph()
+    sdotermsource.SdoTermSource.loadSourceGraph("default")
+    self.rdflib_data = sdotermsource.SdoTermSource.sourceGraph()
 
 
   @classmethod
   def setUpClass(self):
-    log.info("Graph tests require rdflib.")
-    try:
-      log.info("Trying to import rdflib...")
-      import rdflib
-      from rdflib import Graph
-    except Exception as e:
-      raise unittest.SkipTest("Need rdflib installed to do graph tests: %s" % e)
     SDOGraphSetupTestCase.loadGraphs()
 
   def test_graphsLoaded(self):

--- a/software/tests/test_schemaexamples.py
+++ b/software/tests/test_schemaexamples.py
@@ -31,80 +31,94 @@ JSON:
 
 """
 
+
 class TestExampleFileParser(unittest.TestCase):
-  """Test the example file parser logic."""
+    """Test the example file parser logic."""
 
-  def setUp(self):
-    self.parser = schemaexamples.ExampleFileParser()
-    self.temp_file = tempfile.NamedTemporaryFile()
+    def setUp(self):
+        self.parser = schemaexamples.ExampleFileParser()
+        self.temp_file = tempfile.NamedTemporaryFile()
 
-  def test_empty_example(self):
-    """Test parsing of an empty Example file."""
-    with self.assertLogs() as cm:
-      result = self.parser.parse(self.temp_file.name)
-    self.assertTrue(cm.output)
-    self.assertEqual(len(result), 1)
-    self.assertFalse(result[0].hasValidId())
-    self.assertFalse(result[0].terms)
-    self.assertFalse(result[0].getMicrodata())
-    self.assertFalse(result[0].getHtml())
-    self.assertFalse(result[0].getRdfa())
-    self.assertFalse(result[0].getJsonld())
+    def test_empty_example(self):
+        """Test parsing of an empty Example file."""
+        with self.assertLogs() as cm:
+            result = self.parser.parse(self.temp_file.name)
+        self.assertTrue(cm.output)
+        self.assertEqual(len(result), 1)
+        self.assertFalse(result[0].hasValidId())
+        self.assertFalse(result[0].terms)
+        self.assertFalse(result[0].getMicrodata())
+        self.assertFalse(result[0].getHtml())
+        self.assertFalse(result[0].getRdfa())
+        self.assertFalse(result[0].getJsonld())
 
-  def test_single_example(self):
-    """Test parsing of an Example file containing a single entry."""
-    self.temp_file.write(THING_EXAMPLE.encode('utf8'))
-    self.temp_file.seek(0)
-    result = self.parser.parse(self.temp_file.name)
-    self.assertEqual(len(result), 1)
-    self.assertTrue(result[0].hasValidId())
-    self.assertEqual(result[0].getIdNum(), 999)
-    self.assertEqual(result[0].getMeta('file'), self.temp_file.name)
-    self.assertCountEqual(result[0].terms, ['Thing'])
-    self.assertEqual(
-        result[0].getHtml().strip(), '<p>This is a thing</p>', result[0].serialize())
-    self.assertEqual(
-        result[0].getMicrodata().strip(),
-        '<p itemscope itemtype="https://schema.org/Thing">This is a thing</p>',
-        result[0].serialize())
-    self.assertEqual(
-        result[0].getRdfa().strip(),
-        '<p vocab="https://schema.org/" typeof="Thing">This is a thing</p>',
-        result[0].serialize())
-    self.assertEqual(
-        result[0].getJsonld().strip(),
-        '{"@context": "https://schema.org/", "@type": "Thing", }',
-        result[0].serialize())
+    def test_single_example(self):
+        """Test parsing of an Example file containing a single entry."""
+        self.temp_file.write(THING_EXAMPLE.encode("utf8"))
+        self.temp_file.seek(0)
+        result = self.parser.parse(self.temp_file.name)
+        self.assertEqual(len(result), 1)
+        self.assertTrue(result[0].hasValidId())
+        self.assertEqual(result[0].getIdNum(), 999)
+        self.assertEqual(result[0].getMeta("file"), self.temp_file.name)
+        self.assertCountEqual(result[0].terms, ["Thing"])
+        self.assertEqual(
+            result[0].getHtml().strip(), "<p>This is a thing</p>", result[0].serialize()
+        )
+        self.assertEqual(
+            result[0].getMicrodata().strip(),
+            '<p itemscope itemtype="https://schema.org/Thing">This is a thing</p>',
+            result[0].serialize(),
+        )
+        self.assertEqual(
+            result[0].getRdfa().strip(),
+            '<p vocab="https://schema.org/" typeof="Thing">This is a thing</p>',
+            result[0].serialize(),
+        )
+        self.assertEqual(
+            result[0].getJsonld().strip(),
+            '{"@context": "https://schema.org/", "@type": "Thing", }',
+            result[0].serialize(),
+        )
 
+    def test_two_examples(self):
+        """Test parsing of an Example file containing two entries, one of them synthesized."""
+        # Write one example
+        self.temp_file.write(THING_EXAMPLE.encode("utf8"))
+        self.temp_file.write("\n".encode("utf8"))
+        # Create a test example object.
+        example = schemaexamples.Example(
+            terms=["Offer"],
+            original_html="<b>Offer</b>",
+            microdata="",
+            rdfa="",
+            jsonld="",
+            exmeta={"id": "eg-777", "file": "/bogus", "filepos": -1},
+        )
+        self.assertTrue(example.hasValidId())
+        # Serialize it into second position.
+        self.temp_file.write(example.serialize().encode("utf8"))
+        self.temp_file.seek(0)
+        # Try reading both.
+        result = self.parser.parse(self.temp_file.name)
+        self.assertEqual(len(result), 2)
+        self.assertEqual(result[0].getIdNum(), 999)
+        self.assertCountEqual(result[0].terms, ["Thing"])
+        self.assertEqual(result[1].getIdNum(), 777)
+        self.assertCountEqual(result[1].terms, ["Offer"])
 
-  def test_two_examples(self):
-    """Test parsing of an Example file containing two entries, one of them synthesized."""
-    # Write one example
-    self.temp_file.write(THING_EXAMPLE.encode('utf8'))
-    self.temp_file.write('\n'.encode('utf8'))
-    # Create a test example object.
-    example = schemaexamples.Example(
-          terms=['Offer'], original_html='<b>Offer</b>', microdata='', rdfa='', jsonld='',
-          exmeta={'id': 'eg-777', 'file': '/bogus', 'filepos': -1})
-    self.assertTrue(example.hasValidId())
-    # Serialize it into second position.
-    self.temp_file.write(example.serialize().encode('utf8'))
-    self.temp_file.seek(0)
-    # Try reading both.
-    result = self.parser.parse(self.temp_file.name)
-    self.assertEqual(len(result), 2)
-    self.assertEqual(result[0].getIdNum(), 999)
-    self.assertCountEqual(result[0].terms, ['Thing'])
-    self.assertEqual(result[1].getIdNum(), 777)
-    self.assertCountEqual(result[1].terms, ['Offer'])
-
-
-  def test_serialize(self):
-    example = schemaexamples.Example(
-          terms=['Thing'], original_html='<b>Thing</b>', microdata='<b>Thing</b>', rdfa='', jsonld='<script>{}</script>',
-          exmeta={'id': 'eg-999', 'file': '/bogus', 'filepos': -1})
-    self.assertEqual(example.serialize(),
-"""TYPES: #eg-0999 Thing
+    def test_serialize(self):
+        example = schemaexamples.Example(
+            terms=["Thing"],
+            original_html="<b>Thing</b>",
+            microdata="<b>Thing</b>",
+            rdfa="",
+            jsonld="<script>{}</script>",
+            exmeta={"id": "eg-999", "file": "/bogus", "filepos": -1},
+        )
+        self.assertEqual(
+            example.serialize(),
+            """TYPES: #eg-0999 Thing
 
 PRE-MARKUP:
 <b>Thing</b>
@@ -113,8 +127,9 @@ MICRODATA:
 RDFA:
 
 JSON:
-<script>{}</script>""")
+<script>{}</script>""",
+        )
 
 
-if __name__ == '__main__':
+if __name__ == "__main__":
     unittest.main()

--- a/software/tests/test_sdojsonldcontext.py
+++ b/software/tests/test_sdojsonldcontext.py
@@ -21,8 +21,10 @@ import software.SchemaTerms.sdoterm as sdoterm
 class SdoJsonLdContextTest(unittest.TestCase):
     """Tests for the sdojsonldcontext library."""
 
-    @unittest.skip("createcontext outputs invalid JSON when getAllTerms returns an empty list.")
-    @unittest.mock.patch('software.SchemaTerms.sdotermsource.SdoTermSource.getAllTerms')
+    @unittest.skip(
+        "createcontext outputs invalid JSON when getAllTerms returns an empty list."
+    )
+    @unittest.mock.patch("software.SchemaTerms.sdotermsource.SdoTermSource.getAllTerms")
     def test_createcontextEmpty(self, mock_getAllTerms):
         """Test that createcontext outputs valid JSON data"""
         mock_getAllTerms.return_value = []
@@ -34,15 +36,16 @@ class SdoJsonLdContextTest(unittest.TestCase):
         self.assertIn("id", context)
         self.assertIn("@vocab", context)
 
-
-    @unittest.mock.patch('software.SchemaTerms.sdotermsource.SdoTermSource.getAllTerms')
+    @unittest.mock.patch("software.SchemaTerms.sdotermsource.SdoTermSource.getAllTerms")
     def test_createcontextOneProperty(self, mock_getAllTerms):
         """Test that createcontext outputs valid JSON data"""
         self.maxDiff = None
-        mock_id = '1234'
-        mock_property = sdoterm.SdoProperty(Id=mock_id, uri='http://schema.org/thang', label='thang')
-        mock_property.domainIncludes = ['Thing']
-        mock_property.rangeIncludes = ['Date', 'URL', 'Thing']
+        mock_id = "1234"
+        mock_property = sdoterm.SdoProperty(
+            Id=mock_id, uri="http://schema.org/thang", label="thang"
+        )
+        mock_property.domainIncludes = ["Thing"]
+        mock_property.rangeIncludes = ["Date", "URL", "Thing"]
         mock_getAllTerms.return_value = [mock_property]
         json_data = sdojsonldcontext.createcontext()
         parsed = json.loads(json_data)
@@ -51,15 +54,19 @@ class SdoJsonLdContextTest(unittest.TestCase):
         self.assertIn("type", context)
         self.assertIn("id", context)
         self.assertIn("@vocab", context)
-        self.assertEqual(context[mock_id], {'@id': 'http://schema.org/thang', '@type': 'Date'})
+        self.assertEqual(
+            context[mock_id], {"@id": "http://schema.org/thang", "@type": "Date"}
+        )
 
-    @unittest.mock.patch('software.SchemaTerms.sdotermsource.SdoTermSource.getAllTerms')
+    @unittest.mock.patch("software.SchemaTerms.sdotermsource.SdoTermSource.getAllTerms")
     def test_createcontextOneDataType(self, mock_getAllTerms):
         self.maxDiff = None
-        mock_id = '1234'
-        mock_type = sdoterm.SdoDataType(Id=mock_id, uri='http://schema.org/Fnubl', label='fnubl')
-        mock_type.properties = ['thang']
-        mock_type.expectedTypeFor = ['Thing']
+        mock_id = "1234"
+        mock_type = sdoterm.SdoDataType(
+            Id=mock_id, uri="http://schema.org/Fnubl", label="fnubl"
+        )
+        mock_type.properties = ["thang"]
+        mock_type.expectedTypeFor = ["Thing"]
         mock_getAllTerms.return_value = [mock_type]
         json_data = sdojsonldcontext.createcontext()
         parsed = json.loads(json_data)
@@ -68,14 +75,16 @@ class SdoJsonLdContextTest(unittest.TestCase):
         self.assertIn("type", context)
         self.assertIn("id", context)
         self.assertIn("@vocab", context)
-        self.assertEqual(context[mock_id], {'@id': 'http://schema.org/Fnubl'})
+        self.assertEqual(context[mock_id], {"@id": "http://schema.org/Fnubl"})
 
-    @unittest.mock.patch('software.SchemaTerms.sdotermsource.SdoTermSource.getAllTerms')
+    @unittest.mock.patch("software.SchemaTerms.sdotermsource.SdoTermSource.getAllTerms")
     def test_createcontextOneEnumeration(self, mock_getAllTerms):
         self.maxDiff = None
-        mock_id = '1234'
-        mock_enumeration = sdoterm.SdoEnumeration(Id=mock_id, uri='http://schema.org/Grabl', label='grabl')
-        mock_enumeration.expectedTypeFor = ['Thing']
+        mock_id = "1234"
+        mock_enumeration = sdoterm.SdoEnumeration(
+            Id=mock_id, uri="http://schema.org/Grabl", label="grabl"
+        )
+        mock_enumeration.expectedTypeFor = ["Thing"]
         mock_getAllTerms.return_value = [mock_enumeration]
         json_data = sdojsonldcontext.createcontext()
         parsed = json.loads(json_data)
@@ -84,13 +93,15 @@ class SdoJsonLdContextTest(unittest.TestCase):
         self.assertIn("type", context)
         self.assertIn("id", context)
         self.assertIn("@vocab", context)
-        self.assertEqual(context[mock_id], {'@id': 'http://schema.org/Grabl'})
+        self.assertEqual(context[mock_id], {"@id": "http://schema.org/Grabl"})
 
-    @unittest.mock.patch('software.SchemaTerms.sdotermsource.SdoTermSource.getAllTerms')
+    @unittest.mock.patch("software.SchemaTerms.sdotermsource.SdoTermSource.getAllTerms")
     def test_createcontextOneEnumerationValue(self, mock_getAllTerms):
         self.maxDiff = None
-        mock_id = '1234'
-        mock_enumeration = sdoterm.SdoEnumerationvalue(Id=mock_id, uri='http://schema.org/Bobl', label='bobl')
+        mock_id = "1234"
+        mock_enumeration = sdoterm.SdoEnumerationvalue(
+            Id=mock_id, uri="http://schema.org/Bobl", label="bobl"
+        )
         mock_getAllTerms.return_value = [mock_enumeration]
         json_data = sdojsonldcontext.createcontext()
         parsed = json.loads(json_data)
@@ -99,14 +110,18 @@ class SdoJsonLdContextTest(unittest.TestCase):
         self.assertIn("type", context)
         self.assertIn("id", context)
         self.assertIn("@vocab", context)
-        self.assertEqual(context[mock_id], {'@id': 'http://schema.org/Bobl'})
+        self.assertEqual(context[mock_id], {"@id": "http://schema.org/Bobl"})
 
-    @unittest.skip("createcontext outputs invalid JSON when getAllTerms returns an empty list.")
-    @unittest.mock.patch('software.SchemaTerms.sdotermsource.SdoTermSource.getAllTerms')
+    @unittest.skip(
+        "createcontext outputs invalid JSON when getAllTerms returns an empty list."
+    )
+    @unittest.mock.patch("software.SchemaTerms.sdotermsource.SdoTermSource.getAllTerms")
     def test_createcontextOneReference(self, mock_getAllTerms):
         self.maxDiff = None
-        mock_id = '1234'
-        mock_reference = sdoterm.SdoReference(Id=mock_id, uri='http://schema.org/Bobl', label='bobl')
+        mock_id = "1234"
+        mock_reference = sdoterm.SdoReference(
+            Id=mock_id, uri="http://schema.org/Bobl", label="bobl"
+        )
         mock_getAllTerms.return_value = [mock_reference]
         json_data = sdojsonldcontext.createcontext()
         parsed = json.loads(json_data)
@@ -115,56 +130,72 @@ class SdoJsonLdContextTest(unittest.TestCase):
         self.assertIn("type", context)
         self.assertIn("id", context)
         self.assertIn("@vocab", context)
-        self.assertEqual(context[mock_id], {'@id': 'http://schema.org/Bobl'})
+        self.assertEqual(context[mock_id], {"@id": "http://schema.org/Bobl"})
 
-    @unittest.mock.patch('software.SchemaTerms.sdotermsource.SdoTermSource.getAllTerms')
+    @unittest.mock.patch("software.SchemaTerms.sdotermsource.SdoTermSource.getAllTerms")
     def test_createcontextMultiple(self, mock_getAllTerms):
         self.maxDiff = None
-        mock_property = sdoterm.SdoProperty(Id='aa', uri='http://schema.org/a', label='a')
-        mock_property.domainIncludes = ['Thing']
-        mock_property.rangeIncludes = ['Date', 'URL', 'Thing']
-        mock_enumeration = sdoterm.SdoEnumeration(Id='bb', uri='http://schema.org/b', label='b')
-        mock_enumeration_value = sdoterm.SdoEnumerationvalue(Id='cc', uri='http://schema.org/c', label='c')
-        mock_getAllTerms.return_value = [mock_property, mock_enumeration, mock_enumeration_value]
+        mock_property = sdoterm.SdoProperty(
+            Id="aa", uri="http://schema.org/a", label="a"
+        )
+        mock_property.domainIncludes = ["Thing"]
+        mock_property.rangeIncludes = ["Date", "URL", "Thing"]
+        mock_enumeration = sdoterm.SdoEnumeration(
+            Id="bb", uri="http://schema.org/b", label="b"
+        )
+        mock_enumeration_value = sdoterm.SdoEnumerationvalue(
+            Id="cc", uri="http://schema.org/c", label="c"
+        )
+        mock_getAllTerms.return_value = [
+            mock_property,
+            mock_enumeration,
+            mock_enumeration_value,
+        ]
         json_data = sdojsonldcontext.createcontext()
         parsed = json.loads(json_data)
-        self.assertEqual(parsed,
-            {'@context': {
-                '@vocab': 'http://schema.org/',
-                'HTML': {'@id': 'rdf:HTML'},
-                'aa': {'@id': 'http://schema.org/a', '@type': 'Date'},
-                'bb': {'@id': 'http://schema.org/b'},
-                'cc': {'@id': 'http://schema.org/c'},
-                'csvw': 'http://www.w3.org/ns/csvw#',
-                'dc': 'http://purl.org/dc/elements/1.1/',
-                'dcam': 'http://purl.org/dc/dcam/',
-                'dcat': 'http://www.w3.org/ns/dcat#',
-                'dcmitype': 'http://purl.org/dc/dcmitype/',
-                'dct': 'http://purl.org/dc/terms/',
-                'dcterms': 'http://purl.org/dc/terms/',
-                'dctype': 'http://purl.org/dc/dcmitype/',
-                'doap': 'http://usefulinc.com/ns/doap#',
-                'foaf': 'http://xmlns.com/foaf/0.1/',
-                'id': '@id',
-                'odrl': 'http://www.w3.org/ns/odrl/2/',
-                'org': 'http://www.w3.org/ns/org#',
-                'owl': 'http://www.w3.org/2002/07/owl#',
-                'prof': 'http://www.w3.org/ns/dx/prof/',
-                'prov': 'http://www.w3.org/ns/prov#',
-                'qb': 'http://purl.org/linked-data/cube#',
-                'rdf': 'http://www.w3.org/1999/02/22-rdf-syntax-ns#',
-                'rdfs': 'http://www.w3.org/2000/01/rdf-schema#',
-                'schema': 'http://schema.org/',
-                'sh': 'http://www.w3.org/ns/shacl#',
-                'skos': 'http://www.w3.org/2004/02/skos/core#',
-                'sosa': 'http://www.w3.org/ns/sosa/',
-                'ssn': 'http://www.w3.org/ns/ssn/',
-                'time': 'http://www.w3.org/2006/time#',
-                'type': '@type',
-                'vann': 'http://purl.org/vocab/vann/',
-                'void': 'http://rdfs.org/ns/void#',
-                'xml': 'http://www.w3.org/XML/1998/namespace',
-                'xsd': 'http://www.w3.org/2001/XMLSchema#'}})
+        self.assertEqual(
+            parsed,
+            {
+                "@context": {
+                    "@vocab": "http://schema.org/",
+                    "HTML": {"@id": "rdf:HTML"},
+                    "aa": {"@id": "http://schema.org/a", "@type": "Date"},
+                    "bb": {"@id": "http://schema.org/b"},
+                    "cc": {"@id": "http://schema.org/c"},
+                    "csvw": "http://www.w3.org/ns/csvw#",
+                    "dc": "http://purl.org/dc/elements/1.1/",
+                    "dcam": "http://purl.org/dc/dcam/",
+                    "dcat": "http://www.w3.org/ns/dcat#",
+                    "dcmitype": "http://purl.org/dc/dcmitype/",
+                    "dct": "http://purl.org/dc/terms/",
+                    "dcterms": "http://purl.org/dc/terms/",
+                    "dctype": "http://purl.org/dc/dcmitype/",
+                    "doap": "http://usefulinc.com/ns/doap#",
+                    "foaf": "http://xmlns.com/foaf/0.1/",
+                    "id": "@id",
+                    "odrl": "http://www.w3.org/ns/odrl/2/",
+                    "org": "http://www.w3.org/ns/org#",
+                    "owl": "http://www.w3.org/2002/07/owl#",
+                    "prof": "http://www.w3.org/ns/dx/prof/",
+                    "prov": "http://www.w3.org/ns/prov#",
+                    "qb": "http://purl.org/linked-data/cube#",
+                    "rdf": "http://www.w3.org/1999/02/22-rdf-syntax-ns#",
+                    "rdfs": "http://www.w3.org/2000/01/rdf-schema#",
+                    "schema": "http://schema.org/",
+                    "sh": "http://www.w3.org/ns/shacl#",
+                    "skos": "http://www.w3.org/2004/02/skos/core#",
+                    "sosa": "http://www.w3.org/ns/sosa/",
+                    "ssn": "http://www.w3.org/ns/ssn/",
+                    "time": "http://www.w3.org/2006/time#",
+                    "type": "@type",
+                    "vann": "http://purl.org/vocab/vann/",
+                    "void": "http://rdfs.org/ns/void#",
+                    "xml": "http://www.w3.org/XML/1998/namespace",
+                    "xsd": "http://www.w3.org/2001/XMLSchema#",
+                }
+            },
+        )
+
 
 if __name__ == "__main__":
     unittest.main()

--- a/software/tests/test_textutils.py
+++ b/software/tests/test_textutils.py
@@ -14,48 +14,44 @@ if not os.getcwd() in sys.path:
 import software
 import software.util.textutils as textutils
 
+
 class TestStripHtmlTags(unittest.TestCase):
-  """Test for the `StripHtmlTags` function."""
+    """Test for the `StripHtmlTags` function."""
 
-  def testEmpty(self):
-    """Test processing empty input."""
-    self.assertEqual(
-        textutils.StripHtmlTags(''), '')
+    def testEmpty(self):
+        """Test processing empty input."""
+        self.assertEqual(textutils.StripHtmlTags(""), "")
 
-  def testTag(self):
-    """Test processing input with tags."""
-    self.assertEqual(
-        textutils.StripHtmlTags('<strong>Yay!</strong>'),
-        'Yay!')
+    def testTag(self):
+        """Test processing input with tags."""
+        self.assertEqual(textutils.StripHtmlTags("<strong>Yay!</strong>"), "Yay!")
 
-  def testNoTag(self):
-    """Test processign input with no tag."""
-    self.assertEqual(
-        textutils.StripHtmlTags('今日は'), '今日は')
+    def testNoTag(self):
+        """Test processign input with no tag."""
+        self.assertEqual(textutils.StripHtmlTags("今日は"), "今日は")
 
-SENTENCE = 'The quick brown fox jumps over the lazy dog.'
+
+SENTENCE = "The quick brown fox jumps over the lazy dog."
+
 
 class TestShortenOnSentence(unittest.TestCase):
+    def setUp(self):
+        self.text = " ".join(itertools.repeat(SENTENCE, 10))
 
-  def setUp(self):
-    self.text = ' '.join(itertools.repeat(SENTENCE, 10))
+    def testEmpty(self):
+        self.assertEqual(textutils.ShortenOnSentence(""), "")
 
-  def testEmpty(self):
-    self.assertEqual(
-      textutils.ShortenOnSentence(''),
-      '')
+    def testNoCut(self):
+        self.assertEqual(
+            textutils.ShortenOnSentence(self.text, lengthHint=1000), self.text
+        )
 
-  def testNoCut(self):
-    self.assertEqual(
-      textutils.ShortenOnSentence(self.text, lengthHint=1000),
-      self.text
-    )
+    def testCuts(self):
+        self.assertEqual(
+            textutils.ShortenOnSentence(self.text, lengthHint=10),
+            "The quick brown fox jumps over the lazy dog...",
+        )
 
-  def testCuts(self):
-    self.assertEqual(
-      textutils.ShortenOnSentence(self.text, lengthHint=10),
-      'The quick brown fox jumps over the lazy dog...'
-    )
 
-if __name__ == '__main__':
+if __name__ == "__main__":
     unittest.main()

--- a/software/util/buildfiles.py
+++ b/software/util/buildfiles.py
@@ -29,10 +29,10 @@ import software.SchemaExamples.schemaexamples as schemaexamples
 import software.SchemaTerms.localmarkdown as localmarkdown
 
 
-
 VOCABURI = sdotermsource.SdoTermSource.vocabUri()
 
 log = logging.getLogger(__name__)
+
 
 def absoluteFilePath(fn):
     name = os.path.join(schemaglobals.OUTPUTDIR, fn)
@@ -41,6 +41,8 @@ def absoluteFilePath(fn):
 
 
 CACHECONTEXT = None
+
+
 def jsonldcontext(page):
     global CACHECONTEXT
     if not CACHECONTEXT:
@@ -49,58 +51,67 @@ def jsonldcontext(page):
 
 
 import json
+
+
 def jsonldtree(page):
     global VISITLIST
-    VISITLIST=[]
+    VISITLIST = []
 
     term = {}
     context = {}
-    context['rdfs'] = "http://www.w3.org/2000/01/rdf-schema#"
-    context['schema'] = "https://schema.org"
-    context['rdfs:subClassOf'] = { "@type": "@id" }
-    context['description'] = "rdfs:comment"
-    context['children'] = { "@reverse": "rdfs:subClassOf" }
-    term['@context'] = context
-    data = _jsonldtree("Thing",term)
-    return json.dumps(data,indent=3)
+    context["rdfs"] = "http://www.w3.org/2000/01/rdf-schema#"
+    context["schema"] = "https://schema.org"
+    context["rdfs:subClassOf"] = {"@type": "@id"}
+    context["description"] = "rdfs:comment"
+    context["children"] = {"@reverse": "rdfs:subClassOf"}
+    term["@context"] = context
+    data = _jsonldtree("Thing", term)
+    return json.dumps(data, indent=3)
 
-def _jsonldtree(tid,term=None):
+
+def _jsonldtree(tid, term=None):
     termdesc = sdotermsource.SdoTermSource.getTerm(tid)
     if not term:
         term = {}
-    term['@type'] = "rdfs:Class"
-    term['@id'] = "schema:" + termdesc.id
-    term['name'] = termdesc.label
+    term["@type"] = "rdfs:Class"
+    term["@id"] = "schema:" + termdesc.id
+    term["name"] = termdesc.label
     if termdesc.supers:
         sups = []
         for sup in termdesc.supers:
             sups.append("schema:" + sup)
         if len(sups) == 1:
-            term['rdfs:subClassOf'] = sups[0]
+            term["rdfs:subClassOf"] = sups[0]
         else:
-            term['rdfs:subClassOf'] = sups
-    term['description'] = textutils.ShortenOnSentence(
-        textutils.StripHtmlTags(termdesc.comment))
+            term["rdfs:subClassOf"] = sups
+    term["description"] = textutils.ShortenOnSentence(
+        textutils.StripHtmlTags(termdesc.comment)
+    )
     if termdesc.pending:
-        term['pending'] = True
+        term["pending"] = True
     if termdesc.retired:
-        term['attic'] = True
+        term["attic"] = True
     if tid not in VISITLIST:
         VISITLIST.append(tid)
         if termdesc.subs:
             subs = []
             for sub in termdesc.subs:
                 subs.append(_jsonldtree(sub))
-            term['children'] = subs
+            term["children"] = subs
     return term
+
 
 def httpequivs(page):
     from buildhttpequivs import buildequivs
+
     return buildequivs("turtle")
+
 
 def owl(page):
     from sdoowl import OwlBuild
+
     return OwlBuild().getContent()
+
 
 def sitemap(page):
     node = """ <url>
@@ -108,18 +119,20 @@ def sitemap(page):
    <lastmod>%s</lastmod>
  </url>
 """
-    STATICPAGES = ["docs/schemas.html",
-                    "docs/full.html",
-                    "docs/gs.html",
-                    "docs/about.html",
-                    "docs/howwework.html",
-                    "docs/releases.html",
-                    "docs/faq.html",
-                    "docs/datamodel.html",
-                    "docs/developers.html",
-                    "docs/extension.html",
-                    "docs/meddocs.html",
-                    "docs/hotels.html"]
+    STATICPAGES = [
+        "docs/schemas.html",
+        "docs/full.html",
+        "docs/gs.html",
+        "docs/about.html",
+        "docs/howwework.html",
+        "docs/releases.html",
+        "docs/faq.html",
+        "docs/datamodel.html",
+        "docs/developers.html",
+        "docs/extension.html",
+        "docs/meddocs.html",
+        "docs/hotels.html",
+    ]
 
     output = []
     output.append("""<?xml version="1.0" encoding="utf-8"?>
@@ -135,32 +148,39 @@ def sitemap(page):
     output.append("</urlset>\n")
     return "".join(output)
 
-def prtocolswap(content,protocol,altprotocol):
-    ret = content.replace("%s://schema.org" % protocol,"%s://schema.org" % altprotocol)
-    for ext in ["attic","auto","bib","health-lifesci","meta","pending"]:
-        ret = ret.replace("%s://%s.schema.org" % (protocol,ext),"%s://%s.schema.org" % (altprotocol,ext))
+
+def prtocolswap(content, protocol, altprotocol):
+    ret = content.replace("%s://schema.org" % protocol, "%s://schema.org" % altprotocol)
+    for ext in ["attic", "auto", "bib", "health-lifesci", "meta", "pending"]:
+        ret = ret.replace(
+            "%s://%s.schema.org" % (protocol, ext),
+            "%s://%s.schema.org" % (altprotocol, ext),
+        )
     return ret
+
 
 def protocols():
     vocaburi = sdotermsource.SdoTermSource.vocabUri()
-    protocol="http"
-    altprotocol="https"
+    protocol = "http"
+    altprotocol = "https"
     if vocaburi.startswith("https"):
-        protocol="https"
-        altprotocol="http"
-    return protocol,altprotocol
+        protocol = "https"
+        altprotocol = "http"
+    return protocol, altprotocol
 
 
 allGraph = None
 currentGraph = None
+
+
 def exportrdf(exportType):
     global allGraph, currentGraph
 
     if not allGraph:
         allGraph = rdflib.Graph()
-        allGraph.bind("schema",VOCABURI)
+        allGraph.bind("schema", VOCABURI)
         currentGraph = rdflib.Graph()
-        currentGraph.bind("schema",VOCABURI)
+        currentGraph.bind("schema", VOCABURI)
 
         allGraph += sdotermsource.SdoTermSource.sourceGraph()
 
@@ -174,40 +194,48 @@ def exportrdf(exportType):
         allGraph.update(deloddtriples)
         currentGraph += allGraph
 
-
-        desuperseded="""PREFIX schema: <%s://schema.org/>
+        desuperseded = """PREFIX schema: <%s://schema.org/>
         DELETE {?s ?p ?o}
         WHERE{
             ?s ?p ?o;
                 schema:supersededBy ?sup.
         }""" % (protocol)
-        #Currently superseded terms are not suppressed from 'current' file dumps
-        #Whereas they are suppressed from the UI
-        #currentGraph.update(desuperseded)
+        # Currently superseded terms are not suppressed from 'current' file dumps
+        # Whereas they are suppressed from the UI
+        # currentGraph.update(desuperseded)
 
-        delattic="""PREFIX schema: <%s://schema.org/>
+        delattic = """PREFIX schema: <%s://schema.org/>
         DELETE {?s ?p ?o}
         WHERE{
             ?s ?p ?o;
                 schema:isPartOf <%s://attic.schema.org>.
-        }""" % (protocol,protocol)
+        }""" % (protocol, protocol)
         currentGraph.update(delattic)
 
-    formats =  ["json-ld", "turtle", "nt", "nquads", "rdf"]
-    extype = exportType[len("RDFExport."):]
+    formats = ["json-ld", "turtle", "nt", "nquads", "rdf"]
+    extype = exportType[len("RDFExport.") :]
     if exportType == "RDFExports":
         for format in sorted(formats):
-            _exportrdf(format,allGraph,currentGraph)
+            _exportrdf(format, allGraph, currentGraph)
     elif extype in formats:
-        _exportrdf(extype,allGraph,currentGraph)
+        _exportrdf(extype, allGraph, currentGraph)
     else:
         raise Exception("Unknown export format: %s" % exportType)
 
 
 completed = []
-def _exportrdf(format,all,current):
+
+
+def _exportrdf(format, all, current):
     global completed
-    exts = {"xml":".xml","rdf":".rdf","nquads":".nq","nt": ".nt","json-ld": ".jsonld", "turtle":".ttl"}
+    exts = {
+        "xml": ".xml",
+        "rdf": ".rdf",
+        "nquads": ".nq",
+        "nt": ".nt",
+        "json-ld": ".jsonld",
+        "turtle": ".ttl",
+    }
     protocol, altprotocol = protocols()
 
     if format in completed:
@@ -217,7 +245,7 @@ def _exportrdf(format,all,current):
 
     version = schemaversion.getVersion()
 
-    for ver in ["current","all"]:
+    for ver in ["current", "all"]:
         if ver == "all":
             g = all
         else:
@@ -227,22 +255,27 @@ def _exportrdf(format,all,current):
             qg = gr.graph(rdflib.URIRef("%s://schema.org/%s" % (protocol, version)))
             qg += g
             g = gr
-        fn = absoluteFilePath("releases/%s/schemaorg-%s-%s%s" % (version,ver,protocol,exts[format]))
-        afn = absoluteFilePath("releases/%s/schemaorg-%s-%s%s" % (version,ver,altprotocol,exts[format]))
+        fn = absoluteFilePath(
+            "releases/%s/schemaorg-%s-%s%s" % (version, ver, protocol, exts[format])
+        )
+        afn = absoluteFilePath(
+            "releases/%s/schemaorg-%s-%s%s" % (version, ver, altprotocol, exts[format])
+        )
         fmt = format
         if format == "rdf":
             fmt = "pretty-xml"
-        f = open(fn,"w", encoding='utf8')
-        af = open(afn,"w", encoding='utf8')
-        kwargs = {'sort_keys': True}
-        out = g.serialize(format=fmt,auto_compact=True,**kwargs)
+        f = open(fn, "w", encoding="utf8")
+        af = open(afn, "w", encoding="utf8")
+        kwargs = {"sort_keys": True}
+        out = g.serialize(format=fmt, auto_compact=True, **kwargs)
         f.write(out)
 
-        af.write(prtocolswap(out,protocol=protocol,altprotocol=altprotocol))
+        af.write(prtocolswap(out, protocol=protocol, altprotocol=altprotocol))
 
-        log.info('Exported %s and %s' % (fn, afn))
+        log.info("Exported %s and %s" % (fn, afn))
         f.close()
         af.close()
+
 
 def array2str(ar):
     if not ar or not len(ar):
@@ -253,9 +286,10 @@ def array2str(ar):
         if first:
             first = False
         else:
-            buf.append(', ')
+            buf.append(", ")
         buf.append(i)
     return "".join(buf)
+
 
 def uriwrap(ids):
     single = False
@@ -265,7 +299,7 @@ def uriwrap(ids):
     ret = []
     for i in ids:
         if i and len(i):
-            if(i.startswith("http:") or i.startswith("https:")):#external reference
+            if i.startswith("http:") or i.startswith("https:"):  # external reference
                 ret.append(i)
             else:
                 ret.append(VOCABURI + i)
@@ -277,18 +311,50 @@ def uriwrap(ids):
         return ""
     return array2str(ret)
 
+
 def exportcsv(page):
     protocol, altprotocol = protocols()
 
-    typeFields = ["id","label","comment","subTypeOf","enumerationtype","equivalentClass","properties","subTypes","supersedes","supersededBy","isPartOf"]
-    propFields = ["id","label","comment","subPropertyOf","equivalentProperty","subproperties","domainIncludes","rangeIncludes","inverseOf","supersedes","supersededBy","isPartOf"]
+    typeFields = [
+        "id",
+        "label",
+        "comment",
+        "subTypeOf",
+        "enumerationtype",
+        "equivalentClass",
+        "properties",
+        "subTypes",
+        "supersedes",
+        "supersededBy",
+        "isPartOf",
+    ]
+    propFields = [
+        "id",
+        "label",
+        "comment",
+        "subPropertyOf",
+        "equivalentProperty",
+        "subproperties",
+        "domainIncludes",
+        "rangeIncludes",
+        "inverseOf",
+        "supersedes",
+        "supersededBy",
+        "isPartOf",
+    ]
     typedata = []
     typedataAll = []
     propdata = []
     propdataAll = []
-    terms = sdotermsource.SdoTermSource.getAllTerms(expanded=True,suppressSourceLinks=True)
+    terms = sdotermsource.SdoTermSource.getAllTerms(
+        expanded=True, suppressSourceLinks=True
+    )
     for term in terms:
-        if term.termType == SdoTerm.REFERENCE or term.id.startswith("http://") or term.id.startswith("https://"):
+        if (
+            term.termType == SdoTerm.REFERENCE
+            or term.id.startswith("http://")
+            or term.id.startswith("https://")
+        ):
             continue
         row = {}
         row["id"] = term.uri
@@ -298,7 +364,7 @@ def exportcsv(page):
         row["supersededBy"] = uriwrap(term.supersededBy)
         ext = term.extLayer
         if len(ext):
-            ext ="%s://%s.schema.org" % (protocol,ext)
+            ext = "%s://%s.schema.org" % (protocol, ext)
         row["isPartOf"] = ext
         if term.termType == SdoTerm.PROPERTY:
             row["subPropertyOf"] = uriwrap(term.supers)
@@ -322,34 +388,44 @@ def exportcsv(page):
             if not term.retired:
                 typedata.append(row)
 
-    writecsvout("properties",propdata,propFields,"current",protocol,altprotocol)
-    writecsvout("properties",propdataAll,propFields,"all",protocol,altprotocol)
-    writecsvout("types",typedata,typeFields,"current",protocol,altprotocol)
-    writecsvout("types",typedataAll,typeFields,"all",protocol,altprotocol)
+    writecsvout("properties", propdata, propFields, "current", protocol, altprotocol)
+    writecsvout("properties", propdataAll, propFields, "all", protocol, altprotocol)
+    writecsvout("types", typedata, typeFields, "current", protocol, altprotocol)
+    writecsvout("types", typedataAll, typeFields, "all", protocol, altprotocol)
 
-def writecsvout(ftype,data,fields,ver,protocol,altprotocol):
 
+def writecsvout(ftype, data, fields, ver, protocol, altprotocol):
     version = schemaversion.getVersion()
-    fn = absoluteFilePath("releases/%s/schemaorg-%s-%s-%s.csv" % (version, ver, protocol, ftype))
-    afn = absoluteFilePath("releases/%s/schemaorg-%s-%s-%s.csv" % (version, ver, altprotocol, ftype))
-    log.debug('Writing files %s and %s' % (fn, afn))
+    fn = absoluteFilePath(
+        "releases/%s/schemaorg-%s-%s-%s.csv" % (version, ver, protocol, ftype)
+    )
+    afn = absoluteFilePath(
+        "releases/%s/schemaorg-%s-%s-%s.csv" % (version, ver, altprotocol, ftype)
+    )
+    log.debug("Writing files %s and %s" % (fn, afn))
     csvout = io.StringIO()
-    csvfile = open(fn,'w', encoding='utf8')
-    acsvfile = open(afn,'w', encoding='utf8')
-    writer = csv.DictWriter(csvout, fieldnames=fields, quoting=csv.QUOTE_ALL,lineterminator='\n')
+    csvfile = open(fn, "w", encoding="utf8")
+    acsvfile = open(afn, "w", encoding="utf8")
+    writer = csv.DictWriter(
+        csvout, fieldnames=fields, quoting=csv.QUOTE_ALL, lineterminator="\n"
+    )
     writer.writeheader()
     for row in data:
         writer.writerow(row)
     csvfile.write(csvout.getvalue())
     csvfile.close()
-    acsvfile.write(prtocolswap(csvout.getvalue(),protocol=protocol,altprotocol=altprotocol))
+    acsvfile.write(
+        prtocolswap(csvout.getvalue(), protocol=protocol, altprotocol=altprotocol)
+    )
     acsvfile.close()
     csvout.close()
 
+
 def jsoncounts(page):
     counts = sdotermsource.SdoTermSource.termCounts()
-    counts['schemaorgversion'] = schemaversion.getVersion()
+    counts["schemaorgversion"] = schemaversion.getVersion()
     return json.dumps(counts)
+
 
 def jsonpcounts(page):
     content = """
@@ -359,62 +435,87 @@ def jsonpcounts(page):
     """ % jsoncounts(page)
     return content
 
+
 def exportshex_shacl(page):
-    release_dir = os.path.join(os.cwd(), schemaglobals.RELEASE_DIR, schemaversion.getVersion())
+    release_dir = os.path.join(
+        os.cwd(), schemaglobals.RELEASE_DIR, schemaversion.getVersion()
+    )
     shex_shacl_shapes_exporter.generate_files(
-        term_defs_path = os.path.join(reldir, 'schemaorg-all-http.nt'),
-        outputdir = release_dir,
-        outputfileprefix = 'schemaorg-')
+        term_defs_path=os.path.join(reldir, "schemaorg-all-http.nt"),
+        outputdir=release_dir,
+        outputfileprefix="schemaorg-",
+    )
 
 
 def examples(page):
     return schemaexamples.SchemaExamples.allExamplesSerialised()
 
-FILELIST = { "Context": (jsonldcontext,["docs/jsonldcontext.jsonld",
-                "docs/jsonldcontext.json","docs/jsonldcontext.json.txt",
-                "releases/%s/schemaorgcontext.jsonld" % schemaversion.getVersion()]),
-            "Tree": (jsonldtree,["docs/tree.jsonld"]),
-            "jsoncounts": (jsoncounts,["docs/jsoncounts.json"]),
-            "jsonpcounts": (jsonpcounts,["docs/jsonpcounts.js"]),
-            "Owl": (owl,["docs/schemaorg.owl","releases/%s/schemaorg.owl" % schemaversion.getVersion()]),
-            "Httpequivs": (httpequivs,["releases/%s/httpequivs.ttl" % schemaversion.getVersion()]),
-            "Sitemap": (sitemap,["docs/sitemap.xml"]),
-            "RDFExports": (exportrdf,[""]),
-            "RDFExport.turtle": (exportrdf,[""]),
-            "RDFExport.rdf": (exportrdf,[""]),
-            "RDFExport.nt": (exportrdf,[""]),
-            "RDFExport.nquads": (exportrdf,[""]),
-            "RDFExport.json-ld": (exportrdf,[""]),
-            "Shex_Shacl": (exportshex_shacl,[""]),
-            "CSVExports": (exportcsv,[""]),
-            "Examples": (examples,["releases/%s/schemaorg-all-examples.txt" % schemaversion.getVersion()])
-         }
+
+FILELIST = {
+    "Context": (
+        jsonldcontext,
+        [
+            "docs/jsonldcontext.jsonld",
+            "docs/jsonldcontext.json",
+            "docs/jsonldcontext.json.txt",
+            "releases/%s/schemaorgcontext.jsonld" % schemaversion.getVersion(),
+        ],
+    ),
+    "Tree": (jsonldtree, ["docs/tree.jsonld"]),
+    "jsoncounts": (jsoncounts, ["docs/jsoncounts.json"]),
+    "jsonpcounts": (jsonpcounts, ["docs/jsonpcounts.js"]),
+    "Owl": (
+        owl,
+        [
+            "docs/schemaorg.owl",
+            "releases/%s/schemaorg.owl" % schemaversion.getVersion(),
+        ],
+    ),
+    "Httpequivs": (
+        httpequivs,
+        ["releases/%s/httpequivs.ttl" % schemaversion.getVersion()],
+    ),
+    "Sitemap": (sitemap, ["docs/sitemap.xml"]),
+    "RDFExports": (exportrdf, [""]),
+    "RDFExport.turtle": (exportrdf, [""]),
+    "RDFExport.rdf": (exportrdf, [""]),
+    "RDFExport.nt": (exportrdf, [""]),
+    "RDFExport.nquads": (exportrdf, [""]),
+    "RDFExport.json-ld": (exportrdf, [""]),
+    "Shex_Shacl": (exportshex_shacl, [""]),
+    "CSVExports": (exportcsv, [""]),
+    "Examples": (
+        examples,
+        ["releases/%s/schemaorg-all-examples.txt" % schemaversion.getVersion()],
+    ),
+}
+
 
 def buildFiles(files):
     log.debug("Initalizing Mardown")
     software.SchemaTerms.localmarkdown.MarkdownTool.setWikilinkCssClass("localLink")
-    software.SchemaTerms.localmarkdown.MarkdownTool.setWikilinkPrePath("https://schema.org/")
-        #Production site uses no suffix in link - mapping to file done in server config
+    software.SchemaTerms.localmarkdown.MarkdownTool.setWikilinkPrePath(
+        "https://schema.org/"
+    )
+    # Production site uses no suffix in link - mapping to file done in server config
     software.SchemaTerms.localmarkdown.MarkdownTool.setWikilinkPostPath("")
 
-
-    all = ["ALL","All","all"]
+    all = ["ALL", "All", "all"]
     for a in all:
         if a in files:
             files = sorted(FILELIST.keys())
             break
 
-
     for p in files:
-        log.info("Preparing file %s:"%p)
+        log.info("Preparing file %s:" % p)
         if p in FILELIST.keys():
-            func, filenames = FILELIST.get(p,None)
+            func, filenames = FILELIST.get(p, None)
             if func:
                 content = func(p)
                 if content:
                     for filename in filenames:
                         fn = absoluteFilePath(filename)
-                        with open(fn,"w", encoding='utf8') as handle:
+                        with open(fn, "w", encoding="utf8") as handle:
                             handle.write(content)
                         log.info("Created %s" % fn)
         else:

--- a/software/util/buildfiles.py
+++ b/software/util/buildfiles.py
@@ -20,12 +20,14 @@ import software.util.fileutils as fileutils
 import software.util.schemaglobals as schemaglobals
 import software.util.schemaversion as schemaversion
 import software.util.textutils as textutils
+import software.util.sdojsonldcontext as sdojsonldcontext
 import software.scripts.shex_shacl_shapes_exporter as shex_shacl_shapes_exporter
 
 import software.SchemaTerms.sdotermsource as sdotermsource
 import software.SchemaTerms.sdoterm as sdoterm
 import software.SchemaExamples.schemaexamples as schemaexamples
 import software.SchemaTerms.localmarkdown as localmarkdown
+
 
 
 VOCABURI = sdotermsource.SdoTermSource.vocabUri()
@@ -41,9 +43,8 @@ def absoluteFilePath(fn):
 CACHECONTEXT = None
 def jsonldcontext(page):
     global CACHECONTEXT
-    from sdojsonldcontext import createcontext
     if not CACHECONTEXT:
-        CACHECONTEXT = createcontext()
+        CACHECONTEXT = sdojsonldcontext.createcontext()
     return CACHECONTEXT
 
 
@@ -405,7 +406,7 @@ def buildFiles(files):
 
 
     for p in files:
-        log.debug("Preparing file %s:"%p)
+        log.info("Preparing file %s:"%p)
         if p in FILELIST.keys():
             func, filenames = FILELIST.get(p,None)
             if func:

--- a/software/util/buildocspages.py
+++ b/software/util/buildocspages.py
@@ -17,7 +17,7 @@ import software.util.jinga_render as jinga_render
 import software.util.fileutils as fileutils
 import software.util.schemaglobals as schemaglobals
 import software.util.textutils as textutils
-
+import software.scripts.buildtermlist as buildtermlist
 
 import software.SchemaTerms.sdotermsource as sdotermsource
 import software.SchemaTerms.sdocollaborators as sdocollaborators
@@ -288,12 +288,10 @@ def createCollab(coll):
     log.info("Created %s" % fn)
 
 def termfind(file):
-
     # Local import because of circular dependencies
-    from buildtermlist import buildlist
     if not schemaglobals.hasOpt("notermfinder"):
         log.info("Building term list")
-        return buildlist(True)
+        return ''.join(buildtermlist.generateTerms(tags=True))
     return ""
 
 PAGELIST = {"Home": (homePage,["docs/home.html"]),

--- a/software/util/buildocspages.py
+++ b/software/util/buildocspages.py
@@ -27,28 +27,28 @@ import software.SchemaExamples.schemaexamples as schemaexamples
 
 log = logging.getLogger(__name__)
 
+
 def absoluteFilePath(fn):
     name = os.path.join(schemaglobals.OUTPUTDIR, fn)
     fileutils.checkFilePath(os.path.dirname(name))
     return name
 
 
-def docsTemplateRender(template,extra_vars=None):
-    tvars = {
-        'BUILDOPTS': schemaglobals.BUILDOPTS,
-        'docsdir': schemaglobals.DOCSDOCSDIR
-    }
+def docsTemplateRender(template, extra_vars=None):
+    tvars = {"BUILDOPTS": schemaglobals.BUILDOPTS, "docsdir": schemaglobals.DOCSDOCSDIR}
     if extra_vars:
         tvars.update(extra_vars)
-    return jinga_render.templateRender(template,tvars)
+    return jinga_render.templateRender(template, tvars)
+
 
 def schemasPage(page):
     extra_vars = {
-        'home_page': "False",
-        'title': 'Schemas',
-        'termcounts': sdotermsource.SdoTermSource.termCounts()
+        "home_page": "False",
+        "title": "Schemas",
+        "termcounts": sdotermsource.SdoTermSource.termCounts(),
     }
-    return docsTemplateRender("docs/Schemas.j2",extra_vars)
+    return docsTemplateRender("docs/Schemas.j2", extra_vars)
+
 
 def homePage(page):
     global STRCLASSVAL
@@ -57,39 +57,39 @@ def homePage(page):
     filt = None
     overrideclassval = None
     if page == "PendingHome":
-        title =  "Pending"
+        title = "Pending"
         template = "docs/PendingHome.j2"
         filt = "pending"
         overrideclassval = 'class="ext ext-pending"'
     elif page == "AtticHome":
-        title =  "Retired"
+        title = "Retired"
         template = "docs/AtticHome.j2"
-        filt="attic"
+        filt = "attic"
         overrideclassval = 'class="ext ext-attic"'
     elif page == "AutoHome":
-        title =  "Autotomotives"
+        title = "Autotomotives"
         template = "docs/AutoHome.j2"
-        filt="auto"
+        filt = "auto"
         overrideclassval = 'class="ext"'
     elif page == "BibHome":
-        title =  "Bib"
+        title = "Bib"
         template = "docs/BibHome.j2"
-        filt="bib"
+        filt = "bib"
         overrideclassval = 'class="ext"'
     elif page == "Health-lifesciHome":
-        title =  "Health-lifesci"
+        title = "Health-lifesci"
         template = "docs/Health-lifesciHome.j2"
-        filt="health-lifesci"
+        filt = "health-lifesci"
         overrideclassval = 'class="ext"'
     elif page == "MetaHome":
-        title =  "Meta"
+        title = "Meta"
         template = "docs/MetaHome.j2"
-        filt="meta"
+        filt = "meta"
         overrideclassval = 'class="ext"'
-    sectionterms={}
-    termcount=0
+    sectionterms = {}
+    termcount = 0
     if filt:
-        terms = sdotermsource.SdoTermSource.getAllTerms(layer=filt,expanded=True)
+        terms = sdotermsource.SdoTermSource.getAllTerms(layer=filt, expanded=True)
         for t in terms:
             t.cat = ""
             if filt == "pending":
@@ -97,21 +97,22 @@ def homePage(page):
                     if "schemaorg/issue" in s:
                         t.cat = "issue-" + os.path.basename(s)
                         break
-        terms.sort(key = lambda u: (u.cat,u.id))
-        sectionterms, termcount = buildTermCatList(terms,checkCat=True)
+        terms.sort(key=lambda u: (u.cat, u.id))
+        sectionterms, termcount = buildTermCatList(terms, checkCat=True)
 
     extra_vars = {
-        'home_page': "True",
-        'title': title,
-        'termcount': termcount,
-        'sectionterms': sectionterms
+        "home_page": "True",
+        "title": title,
+        "termcount": termcount,
+        "sectionterms": sectionterms,
     }
     STRCLASSVAL = overrideclassval
-    ret =  docsTemplateRender(template,extra_vars)
+    ret = docsTemplateRender(template, extra_vars)
     STRCLASSVAL = None
     return ret
 
-def buildTermCatList(terms,checkCat=False):
+
+def buildTermCatList(terms, checkCat=False):
     first = True
     cat = None
     termcat = {}
@@ -140,14 +141,15 @@ def buildTermCatList(terms,checkCat=False):
     return termcat, termcount
 
 
-VISITLIST=[]
-class listingNode():
+VISITLIST = []
 
-    def __init__(self,term,depth=0,title="",parent=None):
+
+class listingNode:
+    def __init__(self, term, depth=0, title="", parent=None):
         global VISITLIST
         termdesc = sdotermsource.SdoTermSource.getTerm(term)
         if parent == None:
-            VISITLIST=[]
+            VISITLIST = []
         self.repeat = False
         self.subs = []
         self.parent = parent
@@ -161,109 +163,116 @@ class listingNode():
             VISITLIST.append(self.id)
             if termdesc.termType == sdoterm.SdoTerm.ENUMERATION:
                 for enum in sorted(termdesc.enumerationMembers):
-                    self.subs.append(listingNode(enum,depth=depth+1,parent=self))
+                    self.subs.append(listingNode(enum, depth=depth + 1, parent=self))
             for sub in sorted(termdesc.subs):
-                self.subs.append(listingNode(sub,depth=depth+1,parent=self))
+                self.subs.append(listingNode(sub, depth=depth + 1, parent=self))
 
-        else: #Visited this node before so don't parse children
+        else:  # Visited this node before so don't parse children
             self.repeat = True
-        #log.info("%s %s %s"%("  "*depth,term,len(self.subs)))
+        # log.info("%s %s %s"%("  "*depth,term,len(self.subs)))
 
 
 import json
+
+
 def jsonldtree(page):
     global VISITLIST
-    VISITLIST=[]
+    VISITLIST = []
 
     term = {}
     context = {}
-    context['rdfs'] = "http://www.w3.org/2000/01/rdf-schema#"
-    context['schema'] = "https://schema.org"
-    context['rdfs:subClassOf'] = { "@type": "@id" }
-    context['description'] = "rdfs:comment"
-    context['children'] = { "@reverse": "rdfs:subClassOf" }
-    term['@context'] = context
-    data = _jsonldtree("Thing",term)
-    return json.dumps(data,indent=3)
+    context["rdfs"] = "http://www.w3.org/2000/01/rdf-schema#"
+    context["schema"] = "https://schema.org"
+    context["rdfs:subClassOf"] = {"@type": "@id"}
+    context["description"] = "rdfs:comment"
+    context["children"] = {"@reverse": "rdfs:subClassOf"}
+    term["@context"] = context
+    data = _jsonldtree("Thing", term)
+    return json.dumps(data, indent=3)
 
-def _jsonldtree(tid,term=None):
+
+def _jsonldtree(tid, term=None):
     termdesc = sdotermsource.SdoTermSource.getTerm(tid)
     if not term:
         term = {}
-    term['@type'] = "rdfs:Class"
-    term['@id'] = "schema:" + termdesc.id
-    term['name'] = termdesc.label
+    term["@type"] = "rdfs:Class"
+    term["@id"] = "schema:" + termdesc.id
+    term["name"] = termdesc.label
     if termdesc.supers:
         sups = []
         for sup in termdesc.supers:
             sups.append("schema:" + sup)
         if len(sups) == 1:
-            term['rdfs:subClassOf'] = sups[0]
+            term["rdfs:subClassOf"] = sups[0]
         else:
-            term['rdfs:subClassOf'] = sups
-    term['description'] = textutils.ShortenOnSentence(
-        textutils.StripHtmlTags(termdesc.comment))
+            term["rdfs:subClassOf"] = sups
+    term["description"] = textutils.ShortenOnSentence(
+        textutils.StripHtmlTags(termdesc.comment)
+    )
     if termdesc.pending:
-        term['pending'] = True
+        term["pending"] = True
     if termdesc.retired:
-        term['attic'] = True
+        term["attic"] = True
     if tid not in VISITLIST:
         VISITLIST.append(tid)
         if termdesc.subs:
             subs = []
             for sub in termdesc.subs:
                 subs.append(_jsonldtree(sub))
-            term['children'] = subs
+            term["children"] = subs
     return term
 
+
 listings = None
+
+
 def fullPage(page):
     global listings
     if not listings:
         listings = []
-        listings.append(listingNode("Thing",title="Types:"))
-        listings.append(listingNode("DataType",title="DataTypes:"))
+        listings.append(listingNode("Thing", title="Types:"))
+        listings.append(listingNode("DataType", title="DataTypes:"))
     extra_vars = {
-        'home_page': "False",
-        'title': "Full schema hierarchy",
-        'listings': listings
+        "home_page": "False",
+        "title": "Full schema hierarchy",
+        "listings": listings,
     }
 
-    return docsTemplateRender("docs/%s.j2" % page,extra_vars)
+    return docsTemplateRender("docs/%s.j2" % page, extra_vars)
+
 
 def fullReleasePage(page):
     listings = []
-    listings.append(listingNode("Thing",title="Type hierarchy"))
+    listings.append(listingNode("Thing", title="Type hierarchy"))
     types = sdotermsource.SdoTermSource.getAllEnumerationvalues(expanded=True)
     types.extend(sdotermsource.SdoTermSource.getAllTypes(expanded=True))
     types = sdotermsource.SdoTermSource.expandTerms(types)
     types = sorted(types, key=lambda t: t.id)
     extra_vars = {
-        'home_page': "False",
-        'title': "Full Release Summary",
-        'version': schemaversion.getVersion(),
-        'date': schemaversion.getCurrentVersionDate(),
-        'listings': listings,
-        'types': types,
-        'properties': sdotermsource.SdoTermSource.getAllProperties(expanded=True)
+        "home_page": "False",
+        "title": "Full Release Summary",
+        "version": schemaversion.getVersion(),
+        "date": schemaversion.getCurrentVersionDate(),
+        "listings": listings,
+        "types": types,
+        "properties": sdotermsource.SdoTermSource.getAllProperties(expanded=True),
     }
-    return docsTemplateRender("docs/FullRelease.j2",extra_vars)
+    return docsTemplateRender("docs/FullRelease.j2", extra_vars)
+
 
 def collabs(page):
     colls = sdocollaborators.collaborator.collaborators()
 
-    #TODO Handle collaborators that are not contributors
+    # TODO Handle collaborators that are not contributors
 
     colls = sorted(colls, key=lambda t: t.title)
 
     for coll in colls:
         createCollab(coll)
 
-    extra_vars = {
-        'collaborators': colls,
-        'title': 'Collaborators'
-    }
-    return docsTemplateRender("docs/Collabs.j2",extra_vars)
+    extra_vars = {"collaborators": colls, "title": "Collaborators"}
+    return docsTemplateRender("docs/Collabs.j2", extra_vars)
+
 
 def createCollab(coll):
     terms = []
@@ -274,60 +283,69 @@ def createCollab(coll):
         terms, termcount = buildTermCatList(coll.getTerms())
 
     extra_vars = {
-        'coll': coll,
-        'title': coll.title,
-        'contributor': contributor,
-        'terms': terms,
-        'termcount': termcount
+        "coll": coll,
+        "title": coll.title,
+        "contributor": contributor,
+        "terms": terms,
+        "termcount": termcount,
     }
 
-    content = docsTemplateRender("docs/Collab.j2",extra_vars)
-    filename = absoluteFilePath(os.path.join("docs/collab/", + coll.ref + ".html"))
-    with open(filename, 'w', encoding='utf8') as handle:
-      handle.write(content)
+    content = docsTemplateRender("docs/Collab.j2", extra_vars)
+    filename = absoluteFilePath(os.path.join("docs/collab/", +coll.ref + ".html"))
+    with open(filename, "w", encoding="utf8") as handle:
+        handle.write(content)
     log.info("Created %s" % fn)
+
 
 def termfind(file):
     # Local import because of circular dependencies
     if not schemaglobals.hasOpt("notermfinder"):
         log.info("Building term list")
-        return ''.join(buildtermlist.generateTerms(tags=True))
+        return "".join(buildtermlist.generateTerms(tags=True))
     return ""
 
-PAGELIST = {"Home": (homePage,["docs/home.html"]),
-             "PendingHome": (homePage,["docs/pending.home.html"]),
-             "AtticHome": (homePage,["docs/attic.home.html"]),
-             "AutoHome": (homePage,["docs/auto.home.html"]),
-             "BibHome": (homePage,["docs/bib.home.html"]),
-             "Health-lifesciHome": (homePage,["docs/health-lifesci.home.html"]),
-             "MetaHome": (homePage,["docs/meta.home.html"]),
-             "Schemas": (schemasPage,["docs/schemas.html"]),
-             "Full": (fullPage,["docs/full.html"]),
-             "FullOrig": (fullPage,["docs/full.orig.html"]),
-             "FullRelease": (fullReleasePage,["docs/fullrelease.html","releases/%s/schema-all.html" % schemaversion.getVersion()]),
-             #"Collabs": (collabs,["docs/collaborators.html"]),
-             "TermFind": (termfind,["docs/termfind/termlist.txt"]),
-             "Tree": (jsonldtree,["docs/tree.jsonld"])
-         }
+
+PAGELIST = {
+    "Home": (homePage, ["docs/home.html"]),
+    "PendingHome": (homePage, ["docs/pending.home.html"]),
+    "AtticHome": (homePage, ["docs/attic.home.html"]),
+    "AutoHome": (homePage, ["docs/auto.home.html"]),
+    "BibHome": (homePage, ["docs/bib.home.html"]),
+    "Health-lifesciHome": (homePage, ["docs/health-lifesci.home.html"]),
+    "MetaHome": (homePage, ["docs/meta.home.html"]),
+    "Schemas": (schemasPage, ["docs/schemas.html"]),
+    "Full": (fullPage, ["docs/full.html"]),
+    "FullOrig": (fullPage, ["docs/full.orig.html"]),
+    "FullRelease": (
+        fullReleasePage,
+        [
+            "docs/fullrelease.html",
+            "releases/%s/schema-all.html" % schemaversion.getVersion(),
+        ],
+    ),
+    # "Collabs": (collabs,["docs/collaborators.html"]),
+    "TermFind": (termfind, ["docs/termfind/termlist.txt"]),
+    "Tree": (jsonldtree, ["docs/tree.jsonld"]),
+}
+
 
 def buildDocs(pages):
-    all = ["ALL","All","all"]
+    all = ["ALL", "All", "all"]
     for a in all:
         if a in pages:
             pages = sorted(PAGELIST.keys())
             break
 
-
     for p in pages:
         log.debug("Preparing page %s:" % p)
         if p in PAGELIST.keys():
-            func, filenames = PAGELIST.get(p,None)
+            func, filenames = PAGELIST.get(p, None)
             if func:
                 content = func(p)
                 for rel_path in filenames:
                     filename = absoluteFilePath(rel_path)
-                    with open(filename, 'w', encoding='utf8') as handle:
-                      handle.write(content)
+                    with open(filename, "w", encoding="utf8") as handle:
+                        handle.write(content)
                     log.info("Created page %s" % filename)
         else:
             log.warning("Unknown page name: %s" % p)

--- a/software/util/buildocspages.py
+++ b/software/util/buildocspages.py
@@ -18,9 +18,12 @@ import software.util.fileutils as fileutils
 import software.util.schemaglobals as schemaglobals
 import software.util.textutils as textutils
 
-from sdotermsource import SdoTermSource
-from sdocollaborators import collaborator
-from sdoterm import *
+
+import software.SchemaTerms.sdotermsource as sdotermsource
+import software.SchemaTerms.sdocollaborators as sdocollaborators
+import software.SchemaTerms.sdoterm as sdoterm
+import software.SchemaExamples.schemaexamples as schemaexamples
+
 
 log = logging.getLogger(__name__)
 
@@ -43,7 +46,7 @@ def schemasPage(page):
     extra_vars = {
         'home_page': "False",
         'title': 'Schemas',
-        'termcounts': SdoTermSource.termCounts()
+        'termcounts': sdotermsource.SdoTermSource.termCounts()
     }
     return docsTemplateRender("docs/Schemas.j2",extra_vars)
 
@@ -86,7 +89,7 @@ def homePage(page):
     sectionterms={}
     termcount=0
     if filt:
-        terms = SdoTermSource.getAllTerms(layer=filt,expanded=True)
+        terms = sdotermsource.SdoTermSource.getAllTerms(layer=filt,expanded=True)
         for t in terms:
             t.cat = ""
             if filt == "pending":
@@ -123,12 +126,12 @@ def buildTermCatList(terms,checkCat=False):
             cat = tcat
             ttypes = {}
             termcat[cat] = ttypes
-            ttypes[SdoTerm.TYPE] = []
-            ttypes[SdoTerm.PROPERTY] = []
-            ttypes[SdoTerm.DATATYPE] = []
-            ttypes[SdoTerm.ENUMERATION] = []
-            ttypes[SdoTerm.ENUMERATIONVALUE] = []
-        if t.termType == SdoTerm.REFERENCE:
+            ttypes[sdoterm.SdoTerm.TYPE] = []
+            ttypes[sdoterm.SdoTerm.PROPERTY] = []
+            ttypes[sdoterm.SdoTerm.DATATYPE] = []
+            ttypes[sdoterm.SdoTerm.ENUMERATION] = []
+            ttypes[sdoterm.SdoTerm.ENUMERATIONVALUE] = []
+        if t.termType == sdoterm.SdoTerm.REFERENCE:
             continue
         ttypes[t.termType].append(t)
         termcount += 1
@@ -142,7 +145,7 @@ class listingNode():
 
     def __init__(self,term,depth=0,title="",parent=None):
         global VISITLIST
-        termdesc = SdoTermSource.getTerm(term)
+        termdesc = sdotermsource.SdoTermSource.getTerm(term)
         if parent == None:
             VISITLIST=[]
         self.repeat = False
@@ -156,7 +159,7 @@ class listingNode():
         self.pending = termdesc.pending
         if not self.id in VISITLIST:
             VISITLIST.append(self.id)
-            if termdesc.termType == SdoTerm.ENUMERATION:
+            if termdesc.termType == sdoterm.SdoTerm.ENUMERATION:
                 for enum in sorted(termdesc.enumerationMembers):
                     self.subs.append(listingNode(enum,depth=depth+1,parent=self))
             for sub in sorted(termdesc.subs):
@@ -184,7 +187,7 @@ def jsonldtree(page):
     return json.dumps(data,indent=3)
 
 def _jsonldtree(tid,term=None):
-    termdesc = SdoTermSource.getTerm(tid)
+    termdesc = sdotermsource.SdoTermSource.getTerm(tid)
     if not term:
         term = {}
     term['@type'] = "rdfs:Class"
@@ -231,9 +234,9 @@ def fullPage(page):
 def fullReleasePage(page):
     listings = []
     listings.append(listingNode("Thing",title="Type hierarchy"))
-    types = SdoTermSource.getAllEnumerationvalues(expanded=True)
-    types.extend(SdoTermSource.getAllTypes(expanded=True))
-    types = SdoTermSource.expandTerms(types)
+    types = sdotermsource.SdoTermSource.getAllEnumerationvalues(expanded=True)
+    types.extend(sdotermsource.SdoTermSource.getAllTypes(expanded=True))
+    types = sdotermsource.SdoTermSource.expandTerms(types)
     types = sorted(types, key=lambda t: t.id)
     extra_vars = {
         'home_page': "False",
@@ -242,12 +245,12 @@ def fullReleasePage(page):
         'date': schemaversion.getCurrentVersionDate(),
         'listings': listings,
         'types': types,
-        'properties': SdoTermSource.getAllProperties(expanded=True)
+        'properties': sdotermsource.SdoTermSource.getAllProperties(expanded=True)
     }
     return docsTemplateRender("docs/FullRelease.j2",extra_vars)
 
 def collabs(page):
-    colls = collaborator.collaborators()
+    colls = sdocollaborators.collaborator.collaborators()
 
     #TODO Handle collaborators that are not contributors
 

--- a/software/util/buildsite.py
+++ b/software/util/buildsite.py
@@ -161,7 +161,8 @@ def loadTerms():
     LOADEDTERMS = True
     if not sdotermsource.SdoTermSource.SOURCEGRAPH:
         with pretty_logger.BlockLog(logger=log, message='Loading triples files'):
-            sdotermsource.SdoTermSource.loadSourceGraph('default')
+            graph = sdotermsource.SdoTermSource.loadSourceGraph('default')
+
         with pretty_logger.BlockLog(logger=log, message='Loading contributors'):
             sdocollaborators.collaborator.loadContributors()
 

--- a/software/util/buildsite.py
+++ b/software/util/buildsite.py
@@ -1,6 +1,8 @@
 #!/usr/bin/env python3
 # -*- coding: UTF-8 -*-
 
+"""Program that builds the whole schema.org website."""
+
 # Import standard python libraries
 import argparse
 import glob
@@ -29,6 +31,7 @@ import software.util.runtests as runtests_lib
 import software.util.schemaglobals as schemaglobals
 import software.util.schemaversion as schemaversion
 import software.util.textutils as textutils
+import software.util.pretty_logger as pretty_logger
 
 import software.SchemaExamples.schemaexamples as schemaexamples
 import software.SchemaExamples.utils.assign_example_ids
@@ -38,45 +41,9 @@ import software.SchemaTerms.sdotermsource as sdotermsource
 
 log = logging.getLogger(__name__)
 
-class PrettyLogFormatter(logging.Formatter):
-    """Helper class to format the log messages from the various parts of the project."""
-
-    COLORS = {
-        'WARNING': colorama.Fore.YELLOW,
-        'INFO': colorama.Fore.CYAN,
-        'DEBUG': colorama.Fore.BLUE,
-        'CRITICAL': colorama.Fore.MAGENTA,
-        'ERROR': colorama.Fore.RED,
-    }
-
-    def __init__(self, use_color=True):
-        logging.Formatter.__init__(self, fmt='%(levelname)s %(name)s: %(message)s')
-        self.use_color = use_color
-
-    @classmethod
-    def _computeLevelName(cls, record):
-        lower_msg = record.getMessage().casefold()
-        if lower_msg == 'done' or lower_msg[:5] == 'done:':
-            return colorama.Fore.LIGHTGREEN_EX + record.levelname + colorama.Fore.RESET
-        if record.levelname in cls.COLORS:
-            return cls.COLORS[record.levelname] + record.levelname + colorama.Fore.RESET
-        return record.levelname
-
-    @classmethod
-    def _computeName(cls, record):
-        components = record.name.split('.')
-        return colorama.Style.DIM + components[-1] + colorama.Style.RESET_ALL
-
-    def format(self, record):
-        if self.use_color:
-            record.levelname = self.__class__._computeLevelName(record)
-            record.name = self.__class__._computeName(record)
-        return logging.Formatter.format(self, record)
-
-
 def initialize():
     """Initialize various systems, returns the args object"""
-    parser = argparse.ArgumentParser()
+    parser = argparse.ArgumentParser(description=__doc__)
     parser.add_argument('-a','--autobuild', default=False, action='store_true', help='clear output directory and build all components - overrides all other settings (except -examplesnum)')
     parser.add_argument('-c','--clearfirst', default=False, action='store_true', help='clear output directory before creating contents')
     parser.add_argument('-d','--docspages', default=[],action='append',nargs='*', help='create docs page(repeatable) - ALL = all pages')
@@ -119,12 +86,7 @@ def initialize():
     software.SchemaTerms.localmarkdown.Markdown.setWikilinkPrePath('/')
     software.SchemaTerms.localmarkdown.Markdown.setWikilinkPostPath('')
 
-    handler = logging.StreamHandler(sys.stdout)
-    formatter = PrettyLogFormatter(use_color=os.isatty(sys.stdout.fileno()))
-    handler.setFormatter(formatter)
-
-    root_log = logging.getLogger()
-    root_log.handlers = [handler]
+    pretty_logger.MakeRootLogPretty()
 
     return args
 

--- a/software/util/buildsite.py
+++ b/software/util/buildsite.py
@@ -41,26 +41,96 @@ import software.SchemaTerms.sdotermsource as sdotermsource
 
 log = logging.getLogger(__name__)
 
+
 def initialize():
     """Initialize various systems, returns the args object"""
     parser = argparse.ArgumentParser(description=__doc__)
-    parser.add_argument('-a','--autobuild', default=False, action='store_true', help='clear output directory and build all components - overrides all other settings (except -examplesnum)')
-    parser.add_argument('-c','--clearfirst', default=False, action='store_true', help='clear output directory before creating contents')
-    parser.add_argument('-d','--docspages', default=[],action='append',nargs='*', help='create docs page(repeatable) - ALL = all pages')
-    parser.add_argument('-e','--examplesnum', default=False, action='store_true', help='Add missing example ids')
-    parser.add_argument('-f','--files', default=[], action='append', nargs='*', help='create files(repeatable) - ALL = all files')
-    parser.add_argument('-o','--output', help='output site directory (default: ./software/site)')
-    parser.add_argument('-r','--runtests', default=False, action='store_true', help='run test scripts before creating contents')
-    parser.add_argument('-s','--static', default=False, action='store_true', help='Refresh static docs in site image')
-    parser.add_argument('-t','--terms', default=[], action='append', nargs='*', help='create page for term (repeatable) - ALL = all terms')
-    parser.add_argument('-b','--buildoption',default= [],action='append', nargs='*', help='build option(repeatable) - flags to be passed to build code')
-    parser.add_argument('--rubytests', default=False, action='store_true', help='run the post generation ruby tests')
-    parser.add_argument('--release', default=False, action='store_true', help='create page for term (repeatable) - ALL = all terms')
+    parser.add_argument(
+        "-a",
+        "--autobuild",
+        default=False,
+        action="store_true",
+        help="clear output directory and build all components - overrides all other settings (except -examplesnum)",
+    )
+    parser.add_argument(
+        "-c",
+        "--clearfirst",
+        default=False,
+        action="store_true",
+        help="clear output directory before creating contents",
+    )
+    parser.add_argument(
+        "-d",
+        "--docspages",
+        default=[],
+        action="append",
+        nargs="*",
+        help="create docs page(repeatable) - ALL = all pages",
+    )
+    parser.add_argument(
+        "-e",
+        "--examplesnum",
+        default=False,
+        action="store_true",
+        help="Add missing example ids",
+    )
+    parser.add_argument(
+        "-f",
+        "--files",
+        default=[],
+        action="append",
+        nargs="*",
+        help="create files(repeatable) - ALL = all files",
+    )
+    parser.add_argument(
+        "-o", "--output", help="output site directory (default: ./software/site)"
+    )
+    parser.add_argument(
+        "-r",
+        "--runtests",
+        default=False,
+        action="store_true",
+        help="run test scripts before creating contents",
+    )
+    parser.add_argument(
+        "-s",
+        "--static",
+        default=False,
+        action="store_true",
+        help="Refresh static docs in site image",
+    )
+    parser.add_argument(
+        "-t",
+        "--terms",
+        default=[],
+        action="append",
+        nargs="*",
+        help="create page for term (repeatable) - ALL = all terms",
+    )
+    parser.add_argument(
+        "-b",
+        "--buildoption",
+        default=[],
+        action="append",
+        nargs="*",
+        help="build option(repeatable) - flags to be passed to build code",
+    )
+    parser.add_argument(
+        "--rubytests",
+        default=False,
+        action="store_true",
+        help="run the post generation ruby tests",
+    )
+    parser.add_argument(
+        "--release",
+        default=False,
+        action="store_true",
+        help="create page for term (repeatable) - ALL = all terms",
+    )
     args = parser.parse_args()
 
-
     for op in args.buildoption:
-        schemaglobals-BUILDOPTS.extend(op)
+        schemaglobals - BUILDOPTS.extend(op)
 
     for ter in args.terms:
         schemaglobals.TERMS.extend(ter)
@@ -75,16 +145,16 @@ def initialize():
         schemaglobals.OUTPUTDIR = args.output
 
     if args.autobuild or args.release:
-        schemaglobals.TERMS = ['ALL']
-        schemaglobals.PAGES = ['ALL']
-        schemaglobals.FILES = ['ALL']
+        schemaglobals.TERMS = ["ALL"]
+        schemaglobals.PAGES = ["ALL"]
+        schemaglobals.FILES = ["ALL"]
 
     ###################################################
-    #MARKDOWN INITIALISE
+    # MARKDOWN INITIALISE
     ###################################################
-    software.SchemaTerms.localmarkdown.Markdown.setWikilinkCssClass('localLink')
-    software.SchemaTerms.localmarkdown.Markdown.setWikilinkPrePath('/')
-    software.SchemaTerms.localmarkdown.Markdown.setWikilinkPostPath('')
+    software.SchemaTerms.localmarkdown.Markdown.setWikilinkCssClass("localLink")
+    software.SchemaTerms.localmarkdown.Markdown.setWikilinkPrePath("/")
+    software.SchemaTerms.localmarkdown.Markdown.setWikilinkPostPath("")
 
     pretty_logger.MakeRootLogPretty()
 
@@ -93,154 +163,185 @@ def initialize():
 
 def clear():
     if args.clearfirst or args.autobuild:
-        log.info('Clearing %s directory' % schemaglobals.OUTPUTDIR)
+        log.info("Clearing %s directory" % schemaglobals.OUTPUTDIR)
         if os.path.isdir(schemaglobals.OUTPUTDIR):
             for root, dirs, files in os.walk(schemaglobals.OUTPUTDIR):
                 for f in files:
-                    if f != '.gitkeep':
+                    if f != ".gitkeep":
                         os.unlink(os.path.join(root, f))
                 for d in dirs:
                     shutil.rmtree(os.path.join(root, d))
 
+
 ###################################################
-#RUN TESTS
+# RUN TESTS
 ###################################################
 def runtests():
     if args.runtests or args.autobuild:
-        log.info('Running test scripts before proceeding…')
-        errorcount = runtests_lib.main('./software/tests/')
+        log.info("Running test scripts before proceeding…")
+        errorcount = runtests_lib.main("./software/tests/")
         if errorcount:
-            log.error('Errors returned: %d' % errorcount)
+            log.error("Errors returned: %d" % errorcount)
             sys.exit(errorcount)
         else:
-            log.info('Done: Tests successful!')
+            log.info("Done: Tests successful!")
 
 
 ###################################################
-#INITIALISE Directory
+# INITIALISE Directory
 ###################################################
+
 
 def initdir(output_dir, handler_path):
     log.info('Building site in "%s" directory' % output_dir)
     fileutils.createMissingDir(output_dir)
     clear()
-    fileutils.createMissingDir(os.path.join(output_dir, 'docs'))
-    fileutils.createMissingDir(os.path.join(output_dir, 'docs/contributors'))
-    fileutils.createMissingDir(os.path.join(output_dir, 'empty')) #For apppengine 404 handler
-    fileutils.createMissingDir(os.path.join(output_dir, 'releases', schemaversion.getVersion()))
+    fileutils.createMissingDir(os.path.join(output_dir, "docs"))
+    fileutils.createMissingDir(os.path.join(output_dir, "docs/contributors"))
+    fileutils.createMissingDir(
+        os.path.join(output_dir, "empty")
+    )  # For apppengine 404 handler
+    fileutils.createMissingDir(
+        os.path.join(output_dir, "releases", schemaversion.getVersion())
+    )
 
-    gdir = os.path.join(output_dir, 'gcloud')
+    gdir = os.path.join(output_dir, "gcloud")
     fileutils.createMissingDir(gdir)
 
-    with pretty_logger.BlockLog(logger=log, message='Copying docs static files'):
-        copystaticdocsplusinsert.copyFiles('./docs', './software/site/docs')
+    with pretty_logger.BlockLog(logger=log, message="Copying docs static files"):
+        copystaticdocsplusinsert.copyFiles("./docs", "./software/site/docs")
 
-    with pretty_logger.BlockLog(logger=log, message='Preparing GCloud files') as block:
-        gcloud_files = glob.glob('software/gcloud/*.yaml')
+    with pretty_logger.BlockLog(logger=log, message="Preparing GCloud files") as block:
+        gcloud_files = glob.glob("software/gcloud/*.yaml")
         for path in gcloud_files:
             shutil.copy(path, gdir)
-        block.append('copied %d files' % len(gcloud_files))
+        block.append("copied %d files" % len(gcloud_files))
 
-    message = 'Creating %s from %s for version: %s' % (handler_path, schemaglobals.HANDLER_TEMPLATE, schemaversion.getVersion())
+    message = "Creating %s from %s for version: %s" % (
+        handler_path,
+        schemaglobals.HANDLER_TEMPLATE,
+        schemaversion.getVersion(),
+    )
     with pretty_logger.BlockLog(logger=log, message=message):
         with open(os.path.join(gdir, schemaglobals.HANDLER_TEMPLATE)) as template_file:
             template_data = template_file.read()
-        handler_data = template_data.replace('{{ver}}', schemaversion.getVersion())
-        with open(os.path.join(gdir, handler_path), mode='w') as yaml_file:
+        handler_data = template_data.replace("{{ver}}", schemaversion.getVersion())
+        with open(os.path.join(gdir, handler_path), mode="w") as yaml_file:
             yaml_file.write(handler_data)
 
 
 ###################################################
-#TERMS SOURCE LOAD
+# TERMS SOURCE LOAD
 ###################################################
 LOADEDTERMS = False
+
+
 def loadTerms():
     global LOADEDTERMS
     if LOADEDTERMS:
         return
     LOADEDTERMS = True
     if not sdotermsource.SdoTermSource.SOURCEGRAPH:
-        with pretty_logger.BlockLog(logger=log, message='Loading triples files'):
-            graph = sdotermsource.SdoTermSource.loadSourceGraph('default')
+        with pretty_logger.BlockLog(logger=log, message="Loading triples files"):
+            graph = sdotermsource.SdoTermSource.loadSourceGraph("default")
 
-        with pretty_logger.BlockLog(logger=log, message='Loading contributors'):
+        with pretty_logger.BlockLog(logger=log, message="Loading contributors"):
             sdocollaborators.collaborator.loadContributors()
 
+
 ###################################################
-#BUILD INDIVIDUAL TERM PAGES
+# BUILD INDIVIDUAL TERM PAGES
 ###################################################
 def processTerms(terms):
     if len(terms):
-        with pretty_logger.BlockLog(logger=log, message='Building term definition pages'):
+        with pretty_logger.BlockLog(
+            logger=log, message="Building term definition pages"
+        ):
             loadTerms()
             schemaexamples.SchemaExamples.loaded()
             buildtermpages.buildTerms(terms)
 
+
 ###################################################
-#BUILD DYNAMIC DOCS PAGES
+# BUILD DYNAMIC DOCS PAGES
 ###################################################
 def processDocs(pages):
     if len(pages):
-        with pretty_logger.BlockLog(logger=log, message='Building dynamic documentation pages'):
+        with pretty_logger.BlockLog(
+            logger=log, message="Building dynamic documentation pages"
+        ):
             loadTerms()
             buildocspages.buildDocs(pages)
 
+
 ###################################################
-#BUILD FILES
+# BUILD FILES
 ###################################################
 def processFiles(files):
     if len(files):
-        with pretty_logger.BlockLog(logger=log, message='Building supporting files'):
+        with pretty_logger.BlockLog(logger=log, message="Building supporting files"):
             loadTerms()
             schemaexamples.SchemaExamples.loaded()
             buildfiles.buildFiles(files)
 
+
 ###################################################
-#Run ruby tests
+# Run ruby tests
 ###################################################
+
 
 def runRubyTests(release_dir):
-    with pretty_logger.BlockLog(logger=log, message='Running ruby tests'):
-        log.info('Setting up LATEST')
+    with pretty_logger.BlockLog(logger=log, message="Running ruby tests"):
+        log.info("Setting up LATEST")
         version = schemaversion.getVersion()
         src_dir = os.path.join(os.getcwd(), release_dir, version)
-        dst_dir = os.path.join(os.getcwd(), release_dir, 'LATEST')
+        dst_dir = os.path.join(os.getcwd(), release_dir, "LATEST")
         os.symlink(src_dir, dst_dir)
-        cmd = ['bundle', 'exec', 'rake']
-        cwd = os.path.join(os.getcwd(), 'software/scripts')
-        log.info('Running tests')
+        cmd = ["bundle", "exec", "rake"]
+        cwd = os.path.join(os.getcwd(), "software/scripts")
+        log.info("Running tests")
         subprocess.check_call(cmd, cwd=cwd)
-        log.info('Cleaning up %s' % dst_dir)
+        log.info("Cleaning up %s" % dst_dir)
         os.unlink(dst_dir)
 
+
 ###################################################
-#COPY CREATED RELEASE FILES into Data area
+# COPY CREATED RELEASE FILES into Data area
 ###################################################
 
 
 def copyReleaseFiles(release_dir):
     version = schemaversion.getVersion()
-    with pretty_logger.BlockLog(message='Copying release files for version %s to data/releases' % version, logger=log):
+    with pretty_logger.BlockLog(
+        message="Copying release files for version %s to data/releases" % version,
+        logger=log,
+    ):
         srcdir = os.path.join(os.getcwd(), release_dir, version)
-        destdir = os.path.join(os.getcwd(), 'data/releases/', version)
+        destdir = os.path.join(os.getcwd(), "data/releases/", version)
         fileutils.mycopytree(srcdir, destdir)
-        cmd = ['git', 'add', destdir]
+        cmd = ["git", "add", destdir]
         subprocess.check_call(cmd)
+
 
 ###################################################
 # Main program
 ###################################################
 
-if __name__ == '__main__':
+if __name__ == "__main__":
     args = initialize()
 
     software.CheckWorkingDirectory()
-    log.info('Version: %s  Released: %s' % (schemaversion.getVersion(), schemaversion.getCurrentVersionDate()))
+    log.info(
+        "Version: %s  Released: %s"
+        % (schemaversion.getVersion(), schemaversion.getCurrentVersionDate())
+    )
     if args.release:
         args.autobuild = True
-        log.info('BUILDING RELEASE VERSION')
+        log.info("BUILDING RELEASE VERSION")
     if args.examplesnum or args.release or args.autobuild:
-        with pretty_logger.BlockLog(message='Checking Examples for assigned identifiers', logger=log):
+        with pretty_logger.BlockLog(
+            message="Checking Examples for assigned identifiers", logger=log
+        ):
             software.SchemaExamples.utils.assign_example_ids.AssignExampleIds()
     initdir(output_dir=schemaglobals.OUTPUTDIR, handler_path=schemaglobals.HANDLER_FILE)
     runtests()
@@ -251,5 +352,3 @@ if __name__ == '__main__':
         runRubyTests(release_dir=schemaglobals.RELEASE_DIR)
     if args.release:
         copyReleaseFiles(release_dir=schemaglobals.RELEASE_DIR)
-
-

--- a/software/util/buildtermpages.py
+++ b/software/util/buildtermpages.py
@@ -18,9 +18,10 @@ import software.util.schemaglobals as schemaglobals
 import software.util.fileutils as fileutils
 import software.util.jinga_render as jinga_render
 
-from sdotermsource import SdoTermSource
-from sdoterm import *
-from schemaexamples import SchemaExamples
+import software.SchemaTerms.sdotermsource as sdotermsource
+import software.SchemaTerms.sdoterm as sdoterm
+import software.SchemaExamples.schemaexamples as schemaexamples
+
 
 log = logging.getLogger(__name__)
 
@@ -93,14 +94,14 @@ def RenderAndWriteSingleTerm(term_key):
     elapsed time for the generation (seconds).
   """
   tic = time.perf_counter()
-  term = SdoTermSource.getTerm(term_key, expanded=True)
+  term = sdotermsource.SdoTermSource.getTerm(term_key, expanded=True)
   if not term:
     log.error("No such term: %s\n" % term_key)
     return 0
-  if term.termType == SdoTerm.REFERENCE: #Don't create pages for reference types
+  if term.termType == sdoterm.SdoTerm.REFERENCE: #Don't create pages for reference types
     return 0
-  examples = SchemaExamples.examplesForTerm(term.id)
-  json = SdoTermSource.getTermAsRdfString(term.id, "json-ld", full=True)
+  examples = schemaexamples.SchemaExamples.examplesForTerm(term.id)
+  json = sdotermsource.SdoTermSource.getTermAsRdfString(term.id, "json-ld", full=True)
   pageout = termtemplateRender(term, examples, json)
   with open(termFileName(term.id), 'w', encoding='utf8') as outfile:
       outfile.write(pageout)
@@ -112,7 +113,7 @@ def RenderAndWriteSingleTerm(term_key):
 def buildTerms(terms):
   """Build the rendered version for a collection of terms."""
   if any(filter(lambda term: term in ("ALL","All","all"), terms)):
-    terms = SdoTermSource.getAllTerms(suppressSourceLinks=True)
+    terms = sdotermsource.SdoTermSource.getAllTerms(suppressSourceLinks=True)
 
   if terms:
     log.info("Building %d term pages..." % len(terms))

--- a/software/util/buildtermpages.py
+++ b/software/util/buildtermpages.py
@@ -25,103 +25,107 @@ import software.SchemaExamples.schemaexamples as schemaexamples
 
 log = logging.getLogger(__name__)
 
-def termFileName(termid):
-  """Generate filename for term page.
 
-  Parameters:
-    termid (str): term identifier.
-  Returns:
-    File path the term page should be generated at.
-  """
-  path_components = [schemaglobals.OUTPUTDIR, "terms"]
-  if re.match('^[a-z].*',termid):
-    path_components.append('properties')
-  elif re.match('^[0-9A-Z].*',termid):
-    path_components.append('types')
-  else:
-    raise ValueError("Invalid terminid: '" + termid +"'")
-  path_components.append(termid[0])
-  directory = os.path.join(*path_components)
-  fileutils.checkFilePath(directory)
-  filename = termid + '.html'
-  return os.path.join(directory, filename)
+def termFileName(termid):
+    """Generate filename for term page.
+
+    Parameters:
+      termid (str): term identifier.
+    Returns:
+      File path the term page should be generated at.
+    """
+    path_components = [schemaglobals.OUTPUTDIR, "terms"]
+    if re.match("^[a-z].*", termid):
+        path_components.append("properties")
+    elif re.match("^[0-9A-Z].*", termid):
+        path_components.append("types")
+    else:
+        raise ValueError("Invalid terminid: '" + termid + "'")
+    path_components.append(termid[0])
+    directory = os.path.join(*path_components)
+    fileutils.checkFilePath(directory)
+    filename = termid + ".html"
+    return os.path.join(directory, filename)
 
 
 # This template will be used ~2800 times, so we reuse it.
 TEMPLATE = jinga_render.GetJinga().get_template("terms/TermPage.j2")
 
+
 def termtemplateRender(term, examples, json):
-  """Render the term with examples and associated JSON.
+    """Render the term with examples and associated JSON.
 
-  Parameters:
-    term (sdoterm.SdoTerm): term to generate the page for
-    examples (schemaexamples.Example): collection of examples for the term.
-  Returns:
-    string with the generate web-page.
-  """
+    Parameters:
+      term (sdoterm.SdoTerm): term to generate the page for
+      examples (schemaexamples.Example): collection of examples for the term.
+    Returns:
+      string with the generate web-page.
+    """
 
-  for ex in examples:
-    exselect = ["","","",""]
-    if ex.hasHtml():
-      exselect[0] = "selected"
-    elif ex.hasMicrodata():
-      exselect[1] = "selected"
-    elif ex.hasRdfa():
-      exselect[2] = "selected"
-    elif ex.hasJsonld():
-      exselect[3] = "selected"
-    ex.exselect = exselect
+    for ex in examples:
+        exselect = ["", "", "", ""]
+        if ex.hasHtml():
+            exselect[0] = "selected"
+        elif ex.hasMicrodata():
+            exselect[1] = "selected"
+        elif ex.hasRdfa():
+            exselect[2] = "selected"
+        elif ex.hasJsonld():
+            exselect[3] = "selected"
+        ex.exselect = exselect
 
-  extra_vars = {
-      'title': term.label,
-      'menu_sel': "Schemas",
-      'home_page': "False",
-      'BUILDOPTS': schemaglobals.BUILDOPTS,
-      'docsdir': schemaglobals.TERMDOCSDIR,
-      'term': term,
-      'jsonldPayload': json,
-      'examples': examples
-  }
-  return jinga_render.templateRender(template_path=None, extra_vars=extra_vars, template_instance=TEMPLATE)
+    extra_vars = {
+        "title": term.label,
+        "menu_sel": "Schemas",
+        "home_page": "False",
+        "BUILDOPTS": schemaglobals.BUILDOPTS,
+        "docsdir": schemaglobals.TERMDOCSDIR,
+        "term": term,
+        "jsonldPayload": json,
+        "examples": examples,
+    }
+    return jinga_render.templateRender(
+        template_path=None, extra_vars=extra_vars, template_instance=TEMPLATE
+    )
 
 
 def RenderAndWriteSingleTerm(term_key):
-  """Renders a single term and write the result into a file.
+    """Renders a single term and write the result into a file.
 
-  Parameters:
-    term_key (str): key for the term.
-  Returns:
-    elapsed time for the generation (seconds).
-  """
-  tic = time.perf_counter()
-  term = sdotermsource.SdoTermSource.getTerm(term_key, expanded=True)
-  if not term:
-    log.error("No such term: %s\n" % term_key)
-    return 0
-  if term.termType == sdoterm.SdoTerm.REFERENCE: #Don't create pages for reference types
-    return 0
-  examples = schemaexamples.SchemaExamples.examplesForTerm(term.id)
-  json = sdotermsource.SdoTermSource.getTermAsRdfString(term.id, "json-ld", full=True)
-  pageout = termtemplateRender(term, examples, json)
-  with open(termFileName(term.id), 'w', encoding='utf8') as outfile:
-      outfile.write(pageout)
-  elapsed = time.perf_counter() - tic
-  log.info("Term '%s' generated in %0.4f seconds" % (term_key, elapsed))
-  return elapsed
+    Parameters:
+      term_key (str): key for the term.
+    Returns:
+      elapsed time for the generation (seconds).
+    """
+    tic = time.perf_counter()
+    term = sdotermsource.SdoTermSource.getTerm(term_key, expanded=True)
+    if not term:
+        log.error("No such term: %s\n" % term_key)
+        return 0
+    if (
+        term.termType == sdoterm.SdoTerm.REFERENCE
+    ):  # Don't create pages for reference types
+        return 0
+    examples = schemaexamples.SchemaExamples.examplesForTerm(term.id)
+    json = sdotermsource.SdoTermSource.getTermAsRdfString(term.id, "json-ld", full=True)
+    pageout = termtemplateRender(term, examples, json)
+    with open(termFileName(term.id), "w", encoding="utf8") as outfile:
+        outfile.write(pageout)
+    elapsed = time.perf_counter() - tic
+    log.info("Term '%s' generated in %0.4f seconds" % (term_key, elapsed))
+    return elapsed
 
 
 def buildTerms(terms):
-  """Build the rendered version for a collection of terms."""
-  if any(filter(lambda term: term in ("ALL","All","all"), terms)):
-    terms = sdotermsource.SdoTermSource.getAllTerms(suppressSourceLinks=True)
+    """Build the rendered version for a collection of terms."""
+    if any(filter(lambda term: term in ("ALL", "All", "all"), terms)):
+        terms = sdotermsource.SdoTermSource.getAllTerms(suppressSourceLinks=True)
 
-  if terms:
-    log.info("Building %d term pages..." % len(terms))
+    if terms:
+        log.info("Building %d term pages..." % len(terms))
 
-  total_elapsed = 0
-  for term_key in terms:
-    total_elapsed += RenderAndWriteSingleTerm(term_key)
+    total_elapsed = 0
+    for term_key in terms:
+        total_elapsed += RenderAndWriteSingleTerm(term_key)
 
-  log.info("%s terms generated in %0.4f seconds" % (len(terms), total_elapsed))
-
-
+    log.info("%s terms generated in %0.4f seconds" % (len(terms), total_elapsed))

--- a/software/util/convertmd2htmldocs.py
+++ b/software/util/convertmd2htmldocs.py
@@ -28,20 +28,22 @@ begin = """<!DOCTYPE html>
 
 end = """</div>\n<!-- #### Static Doc Insert Footer goes here -->\n </html>"""
 
+
 def mddocs(sourceDir, destDir):
-    docs = glob.glob(sourceDir +'/*.md')
+    docs = glob.glob(sourceDir + "/*.md")
     for d in docs:
-        convert2html(d,destDir)
+        convert2html(d, destDir)
+
 
 def convert2html(input_path, destdir):
     filename = os.path.basename(input_path)
     name, extension = os.path.splitext(filename)
-    with open(input_path, 'r') as in_handle:
+    with open(input_path, "r") as in_handle:
         text = in_handle.read()
         md_html = markdown.markdown(text)
 
-    output_path = os.path.join(destdir, name + '.html')
-    with open(output_path, 'w') as output_handle:
+    output_path = os.path.join(destdir, name + ".html")
+    with open(output_path, "w") as output_handle:
         output_handle.write(begin.format(title=name.title()))
         output_handle.write(md_html)
         output_handle.write(end)
@@ -49,6 +51,5 @@ def convert2html(input_path, destdir):
     os.remove(input_path)
 
 
-if __name__ == '__main__':
-    mddocs(".",".")
-
+if __name__ == "__main__":
+    mddocs(".", ".")

--- a/software/util/copystaticdocsplusinsert.py
+++ b/software/util/copystaticdocsplusinsert.py
@@ -70,7 +70,7 @@ SRCDIR = './docs'
 DESTDIR = './software/site/docs'
 
 
-def htmlinserts(destdir):
+def htmlinserts(destdir : str):
     """Perform susbstitions on all HTML files in DESTDIR."""
     log.info("Adding header/footer templates to all html files")
     docs = glob.glob(os.path.join(destdir, '*.html'))
@@ -80,7 +80,8 @@ def htmlinserts(destdir):
     log.info("Added to %d files" % len(docs))
 
 
-def copyFiles(srcdir, destdir):
+def copyFiles(srcdir : str, destdir : str):
+    """Copy and complete all the static document pages."""
     fileutils.mycopytree(srcdir, destdir)
     log.info("Converting .md docs to html")
     convertmd2htmldocs.mddocs(DESTDIR, DESTDIR)

--- a/software/util/copystaticdocsplusinsert.py
+++ b/software/util/copystaticdocsplusinsert.py
@@ -1,7 +1,7 @@
 #!/usr/bin/env python3
 # -*- coding: UTF-8 -*-
 
-""" Tool that handles includes in static html files. """
+"""Tool that handles includes in static html files."""
 
 # Import standard python libraries
 
@@ -23,21 +23,23 @@ import software.util.convertmd2htmldocs as convertmd2htmldocs
 
 log = logging.getLogger(__name__)
 
+
 def _getInserts():
-    for f_path in glob.glob('./templates/static-doc-inserts/*.html'):
+    for f_path in glob.glob("./templates/static-doc-inserts/*.html"):
         fn = os.path.basename(f_path).lower()
         fn, _ = os.path.splitext(fn)
         with open(f_path) as input_file:
             indata = input_file.read()
-        fn = fn[4:] #drop sdi- from file name
-        indata = indata.replace('{{version}}', schemaversion.getVersion())
-        indata = indata.replace('{{versiondate}}', schemaversion.getCurrentVersionDate())
-        indata = indata.replace('{{docsdir}}', "/docs")
+        fn = fn[4:]  # drop sdi- from file name
+        indata = indata.replace("{{version}}", schemaversion.getVersion())
+        indata = indata.replace(
+            "{{versiondate}}", schemaversion.getCurrentVersionDate()
+        )
+        indata = indata.replace("{{docsdir}}", "/docs")
         yield (fn, indata)
 
 
 class Replacer:
-
     def __init__(self, destdir):
         self.inserts = dict(_getInserts())
         self.destdir = destdir
@@ -55,32 +57,33 @@ class Replacer:
             with open(doc) as docfile:
                 docdata = docfile.read()
 
-        if re.search('<!-- #### Static Doc Insert', docdata,re.IGNORECASE):
+        if re.search("<!-- #### Static Doc Insert", docdata, re.IGNORECASE):
             for sub in self.inserts:
-                subpattern = re.compile("<!-- #### Static Doc Insert %s .* -->" % sub,re.IGNORECASE)
-                docdata = subpattern.sub(self.inserts.get(sub),docdata,re.IGNORECASE)
+                subpattern = re.compile(
+                    "<!-- #### Static Doc Insert %s .* -->" % sub, re.IGNORECASE
+                )
+                docdata = subpattern.sub(self.inserts.get(sub), docdata, re.IGNORECASE)
 
             targetfile = os.path.join(self.destdir, os.path.basename(doc))
             with open(targetfile, "w") as outfile:
                 outfile.write(docdata)
 
 
+SRCDIR = "./docs"
+DESTDIR = "./software/site/docs"
 
-SRCDIR = './docs'
-DESTDIR = './software/site/docs'
 
-
-def htmlinserts(destdir : str):
+def htmlinserts(destdir: str):
     """Perform susbstitions on all HTML files in DESTDIR."""
     log.info("Adding header/footer templates to all html files")
-    docs = glob.glob(os.path.join(destdir, '*.html'))
+    docs = glob.glob(os.path.join(destdir, "*.html"))
     replacer = Replacer(destdir=destdir)
     for doc in docs:
         replacer.insertcopy(doc)
     log.info("Added to %d files" % len(docs))
 
 
-def copyFiles(srcdir : str, destdir : str):
+def copyFiles(srcdir: str, destdir: str):
     """Copy and complete all the static document pages."""
     fileutils.mycopytree(srcdir, destdir)
     log.info("Converting .md docs to html")
@@ -89,5 +92,5 @@ def copyFiles(srcdir : str, destdir : str):
     log.info("Done")
 
 
-if __name__ == '__main__':
+if __name__ == "__main__":
     copyFiles(SRCDIR, DESTDIR)

--- a/software/util/fileutils.py
+++ b/software/util/fileutils.py
@@ -4,12 +4,16 @@
 import os
 import shutil
 
+
 def createMissingDir(dir_path):
     """Create a directory if it does not exist"""
     if not os.path.exists(dir_path):
         os.makedirs(dir_path)
 
-CHECKEDPATHS =[]
+
+CHECKEDPATHS = []
+
+
 def checkFilePath(path):
     if not path in CHECKEDPATHS:
         CHECKEDPATHS.append(path)
@@ -62,4 +66,4 @@ def mycopytree(src, dst, symlinks=False, ignore=None):
         else:
             errors.extend((src, dst, str(why)))
     if errors:
-        raise Error (errors)
+        raise Error(errors)

--- a/software/util/jinga_render.py
+++ b/software/util/jinga_render.py
@@ -15,63 +15,74 @@ if not os.getcwd() in sys.path:
 import software
 import software.util.schemaversion as schemaversion
 
-SITENAME = 'Schema.org'
-TEMPLATESDIR = 'templates'
-DOCSHREFSUFFIX=''
-DOCSHREFPREFIX='/'
-TERMHREFSUFFIX=''
-TERMHREFPREFIX='/'
+SITENAME = "Schema.org"
+TEMPLATESDIR = "templates"
+DOCSHREFSUFFIX = ""
+DOCSHREFPREFIX = "/"
+TERMHREFSUFFIX = ""
+TERMHREFPREFIX = "/"
 
 ###################################################
-#JINJA INITIALISATION
+# JINJA INITIALISATION
 ###################################################
+
 
 def _jinjaDebug(text):
     logging.debug(text)
-    return ''
+    return ""
+
 
 local_vars = {}
+
+
 def _set_local_var(local_vars, name, value):
     local_vars[name] = value
-    return ''
+    return ""
 
 
 JENV = None
+
+
 def GetJinga():
     global JENV
     if JENV:
-      return JENV
-    jenv = jinja2.Environment(loader=jinja2.FileSystemLoader(TEMPLATESDIR), autoescape=True, cache_size=0)
-    jenv.filters['debug']=_jinjaDebug
-    jenv.globals['set_local_var'] = _set_local_var
+        return JENV
+    jenv = jinja2.Environment(
+        loader=jinja2.FileSystemLoader(TEMPLATESDIR), autoescape=True, cache_size=0
+    )
+    jenv.filters["debug"] = _jinjaDebug
+    jenv.globals["set_local_var"] = _set_local_var
     JENV = jenv
     return JENV
 
+
 ### Template rendering
 
+
 def templateRender(template_path, extra_vars=None, template_instance=None):
-  """Render a page template.
+    """Render a page template.
 
-  Returns: the generated page.
-  """
-  #Basic variables configuring UI
-  tvars = {
-      'local_vars': local_vars,
-      'version': schemaversion.getVersion(),
-      'versiondate': schemaversion.getCurrentVersionDate(),
-      'sitename': SITENAME,
-      'TERMHREFPREFIX': TERMHREFPREFIX,
-      'TERMHREFSUFFIX': TERMHREFSUFFIX,
-      'DOCSHREFPREFIX': DOCSHREFPREFIX,
-      'DOCSHREFSUFFIX': DOCSHREFSUFFIX,
-      'home_page': 'False'
-  }
-  if extra_vars:
-      tvars.update(extra_vars)
+    Returns: the generated page.
+    """
+    # Basic variables configuring UI
+    tvars = {
+        "local_vars": local_vars,
+        "version": schemaversion.getVersion(),
+        "versiondate": schemaversion.getCurrentVersionDate(),
+        "sitename": SITENAME,
+        "TERMHREFPREFIX": TERMHREFPREFIX,
+        "TERMHREFSUFFIX": TERMHREFSUFFIX,
+        "DOCSHREFPREFIX": DOCSHREFPREFIX,
+        "DOCSHREFSUFFIX": DOCSHREFSUFFIX,
+        "home_page": "False",
+    }
+    if extra_vars:
+        tvars.update(extra_vars)
 
-  template = template_instance or GetJinga().get_template(template_path)
-  return template.render(tvars)
+    template = template_instance or GetJinga().get_template(template_path)
+    return template.render(tvars)
+
 
 ###################################################
-#JINJA INITIALISATION - End
+# JINJA INITIALISATION - End
 ###################################################

--- a/software/util/pretty_logger.py
+++ b/software/util/pretty_logger.py
@@ -43,6 +43,25 @@ class PrettyLogFormatter(logging.Formatter):
         return logging.Formatter.format(self, record)
 
 
+class BlockLog:
+    def __init__(self, logger, message):
+        self.logger = logger
+        self.message = message
+
+    def __enter__(self):
+        self.logger.info('Start: %s', self.message)
+        return self
+
+    def __exit__(self, exc_type, exc_value, traceback):
+        if isinstance(exc_value, Exception):
+          self.logger.error('Failed: %s', self.message)
+        else:
+          self.logger.info('Done: %s', self.message)
+
+    def append(self, message):
+        self.message = self.message + ' ' + message
+
+
 def MakeRootLogPretty():
     """Makes the root log pretty if stdandard output is a terminal."""
     handler = logging.StreamHandler(sys.stdout)

--- a/software/util/pretty_logger.py
+++ b/software/util/pretty_logger.py
@@ -11,21 +11,21 @@ class PrettyLogFormatter(logging.Formatter):
     """Helper class to format the log messages from the various parts of the project."""
 
     COLORS = {
-        'WARNING': colorama.Fore.YELLOW,
-        'INFO': colorama.Fore.CYAN,
-        'DEBUG': colorama.Fore.BLUE,
-        'CRITICAL': colorama.Fore.MAGENTA,
-        'ERROR': colorama.Fore.RED,
+        "WARNING": colorama.Fore.YELLOW,
+        "INFO": colorama.Fore.CYAN,
+        "DEBUG": colorama.Fore.BLUE,
+        "CRITICAL": colorama.Fore.MAGENTA,
+        "ERROR": colorama.Fore.RED,
     }
 
     def __init__(self, use_color=True):
-        logging.Formatter.__init__(self, fmt='%(levelname)s %(name)s: %(message)s')
+        logging.Formatter.__init__(self, fmt="%(levelname)s %(name)s: %(message)s")
         self.use_color = use_color
 
     @classmethod
     def _computeLevelName(cls, record):
         lower_msg = record.getMessage().casefold()
-        if lower_msg == 'done' or lower_msg[:5] == 'done:':
+        if lower_msg == "done" or lower_msg[:5] == "done:":
             return colorama.Fore.LIGHTGREEN_EX + record.levelname + colorama.Fore.RESET
         if record.levelname in cls.COLORS:
             return cls.COLORS[record.levelname] + record.levelname + colorama.Fore.RESET
@@ -33,7 +33,7 @@ class PrettyLogFormatter(logging.Formatter):
 
     @classmethod
     def _computeName(cls, record):
-        components = record.name.split('.')
+        components = record.name.split(".")
         return colorama.Style.DIM + components[-1] + colorama.Style.RESET_ALL
 
     def format(self, record):
@@ -49,17 +49,17 @@ class BlockLog:
         self.message = message
 
     def __enter__(self):
-        self.logger.info('Start: %s', self.message)
+        self.logger.info("Start: %s", self.message)
         return self
 
     def __exit__(self, exc_type, exc_value, traceback):
         if isinstance(exc_value, Exception):
-          self.logger.error('Failed: %s', self.message)
+            self.logger.error("Failed: %s", self.message)
         else:
-          self.logger.info('Done: %s', self.message)
+            self.logger.info("Done: %s", self.message)
 
     def append(self, message):
-        self.message = self.message + ' ' + message
+        self.message = self.message + " " + message
 
 
 def MakeRootLogPretty():

--- a/software/util/pretty_logger.py
+++ b/software/util/pretty_logger.py
@@ -1,0 +1,53 @@
+#!/usr/bin/env python3
+# -*- coding: UTF-8 -*-
+
+import colorama
+import logging
+import os
+import sys
+
+
+class PrettyLogFormatter(logging.Formatter):
+    """Helper class to format the log messages from the various parts of the project."""
+
+    COLORS = {
+        'WARNING': colorama.Fore.YELLOW,
+        'INFO': colorama.Fore.CYAN,
+        'DEBUG': colorama.Fore.BLUE,
+        'CRITICAL': colorama.Fore.MAGENTA,
+        'ERROR': colorama.Fore.RED,
+    }
+
+    def __init__(self, use_color=True):
+        logging.Formatter.__init__(self, fmt='%(levelname)s %(name)s: %(message)s')
+        self.use_color = use_color
+
+    @classmethod
+    def _computeLevelName(cls, record):
+        lower_msg = record.getMessage().casefold()
+        if lower_msg == 'done' or lower_msg[:5] == 'done:':
+            return colorama.Fore.LIGHTGREEN_EX + record.levelname + colorama.Fore.RESET
+        if record.levelname in cls.COLORS:
+            return cls.COLORS[record.levelname] + record.levelname + colorama.Fore.RESET
+        return record.levelname
+
+    @classmethod
+    def _computeName(cls, record):
+        components = record.name.split('.')
+        return colorama.Style.DIM + components[-1] + colorama.Style.RESET_ALL
+
+    def format(self, record):
+        if self.use_color:
+            record.levelname = self.__class__._computeLevelName(record)
+            record.name = self.__class__._computeName(record)
+        return logging.Formatter.format(self, record)
+
+
+def MakeRootLogPretty():
+    """Makes the root log pretty if stdandard output is a terminal."""
+    handler = logging.StreamHandler(sys.stdout)
+    formatter = PrettyLogFormatter(use_color=os.isatty(sys.stdout.fileno()))
+    handler.setFormatter(formatter)
+
+    root_log = logging.getLogger()
+    root_log.handlers = [handler]

--- a/software/util/runtests.py
+++ b/software/util/runtests.py
@@ -2,9 +2,9 @@
 # -*- coding: UTF-8 -*-
 
 
-# Note: if this stops working in OSX, consider "sudo pip uninstall protobuf"
-# to remove a 2nd clashing google/ python lib. See
-# https://github.com/coto/gae-boilerplate/issues/306
+# Note: if this stops working in OSX, consider "sudo pip uninstall protobuf"
+# to remove a 2nd clashing google/ python lib. See
+# https://github.com/coto/gae-boilerplate/issues/306
 
 # This script runs the Schema.org unit tests. The basic tests are concerned
 # with our site infrastructure; loading and accessing data.  The graph tests
@@ -59,8 +59,9 @@ import subprocess
 import unittest
 import io
 
-SITEDIR="software/site"
-STANDALONE=False
+SITEDIR = "software/site"
+STANDALONE = False
+
 
 class ColoredTestResult(unittest.TextTestResult):
     """Color the test results."""
@@ -73,8 +74,8 @@ class ColoredTestResult(unittest.TextTestResult):
             self.is_tty = False
         if self.is_tty:
             term_size = os.get_terminal_size()
-            self.separator1 = '▼' * term_size.columns
-            self.separator2 = '▲' * term_size.columns
+            self.separator1 = "▼" * term_size.columns
+            self.separator2 = "▲" * term_size.columns
 
     def _colorPrint(self, message, color=None, short=None, newline=True):
         if not self.showAll and short:
@@ -93,12 +94,12 @@ class ColoredTestResult(unittest.TextTestResult):
 
     def startTest(self, test):
         super(unittest.TextTestResult, self).startTest(test)
-        lines = self.getDescription(test).split('\n')
+        lines = self.getDescription(test).split("\n")
         for index, line in enumerate(lines):
             color = None
             if index > 0:
-                color=colorama.Fore.LIGHTWHITE_EX
-            lastline =  index == len(lines) - 1
+                color = colorama.Fore.LIGHTWHITE_EX
+            lastline = index == len(lines) - 1
             if lastline:
                 self._colorPrint(line + " … ", color=color, newline=False)
             else:
@@ -122,17 +123,17 @@ class ColoredTestResult(unittest.TextTestResult):
 
     def addSkip(self, test, reason):
         super(unittest.TextTestResult, self).addSkip(test, reason)
-        self._colorPrint("Skipped", color=colorama.Fore.CYAN, short='S')
+        self._colorPrint("Skipped", color=colorama.Fore.CYAN, short="S")
         if reason:
-          self._colorPrint(reason, color=colorama.Fore.LIGHTCYAN_EX)
+            self._colorPrint(reason, color=colorama.Fore.LIGHTCYAN_EX)
 
     def printErrorList(self, flavour, errors):
         super(unittest.TextTestResult, self).addSkip(flavour, errors)
         color = None
-        if flavour=='ERROR':
-          color = colorama.Fore.YELLOW
-        elif flavour == 'FAIL':
-          color = colorama.Fore.LIGHTRED_EX
+        if flavour == "ERROR":
+            color = colorama.Fore.YELLOW
+        elif flavour == "FAIL":
+            color = colorama.Fore.LIGHTRED_EX
         for test, err in errors:
             self._colorPrint(self.separator1)
             self._colorPrint(self.getDescription(test), color=color)
@@ -145,14 +146,17 @@ class BasicFileTests(unittest.TestCase):
 
     def testNoHttpExamples(self):
         """Test that no examples contain url of the http://schema.org (they should be https)."""
-        httpexamplescheck = "grep -l 'http://schema.org' data/*examples.txt data/ext/*/*examples.txt"
+        httpexamplescheck = (
+            "grep -l 'http://schema.org' data/*examples.txt data/ext/*/*examples.txt"
+        )
         out = ""
         try:
-            out = subprocess.check_output(httpexamplescheck,shell=True)
+            out = subprocess.check_output(httpexamplescheck, shell=True)
             if out:
                 self.fail(
-                      "Examples file(s) found containing 'http://schema.org':\n%s\n"
-                      "Replace with 'https://schema.org and rerun.")
+                    "Examples file(s) found containing 'http://schema.org':\n%s\n"
+                    "Replace with 'https://schema.org and rerun."
+                )
         except:
             pass
 
@@ -160,7 +164,10 @@ class BasicFileTests(unittest.TestCase):
         """Test that there are no duplicated contexts in file docs/jsonldcontext.jsonld."""
         context_path = os.path.join(SITEDIR, "docs/jsonldcontext.jsonld")
         if not os.path.isfile(context_path):
-            self.skipTest("Bypassing jsonldcontext duplicates test: file '%s' not found" % context_path)
+            self.skipTest(
+                "Bypassing jsonldcontext duplicates test: file '%s' not found"
+                % context_path
+            )
         else:
             contextCheck = "cat %s |cut -d'\"' -f2|sort|uniq -d" % context_path
             dups = subprocess.check_output(contextCheck, shell=True)
@@ -169,31 +176,33 @@ class BasicFileTests(unittest.TestCase):
 
 
 def GetSuite(test_path, args):
-  if args and vars(args)["skipbasics"]:
-      suite = unittest.loader.TestLoader().discover(test_path, pattern="*graphs*.py")
-  else:
-      suite = unittest.loader.TestLoader().discover(test_path, pattern="test*.py")
-  suite.addTest(unittest.loader.TestLoader().loadTestsFromTestCase(BasicFileTests))
-  return suite
+    if args and vars(args)["skipbasics"]:
+        suite = unittest.loader.TestLoader().discover(test_path, pattern="*graphs*.py")
+    else:
+        suite = unittest.loader.TestLoader().discover(test_path, pattern="test*.py")
+    suite.addTest(unittest.loader.TestLoader().loadTestsFromTestCase(BasicFileTests))
+    return suite
 
 
 # TODO:
 # Ensure that the google.appengine.* packages are available
 # in tests as well as all bundled third-party packages.
 def main(test_path, args=None):
-    runner = unittest.TextTestRunner(verbosity=2, descriptions=True, resultclass=ColoredTestResult)
+    runner = unittest.TextTestRunner(
+        verbosity=2, descriptions=True, resultclass=ColoredTestResult
+    )
     suite = GetSuite(test_path, args)
     res = runner.run(suite)
     count = len(res.failures) + len(res.errors)
-    return(count)
+    return count
 
 
-if __name__ == '__main__':
+if __name__ == "__main__":
     colorama.init()
-    parser = argparse.ArgumentParser(description='Configurable testing of schema.org.')
-    parser.add_argument('--skipbasics', action='store_true', help='Skip basic tests.')
+    parser = argparse.ArgumentParser(description="Configurable testing of schema.org.")
+    parser.add_argument("--skipbasics", action="store_true", help="Skip basic tests.")
     args = parser.parse_args()
-    sys.exit(main('./software/tests/', args))
+    sys.exit(main("./software/tests/", args))
 
 # alternative, try
 # PYTHONPATH=/usr/local/google_appengine ./scripts/run_tests.py

--- a/software/util/schemaglobals.py
+++ b/software/util/schemaglobals.py
@@ -3,24 +3,27 @@
 
 """Common place for all globals to avoid circular dependencies."""
 
-SITENAME = 'Schema.org'
+SITENAME = "Schema.org"
 BUILDOPTS = []
 TERMS = []
 PAGES = []
 FILES = []
-OUTPUTDIR = 'software/site'
-DOCSDOCSDIR = '/docs'
-TERMDOCSDIR = '/docs'
-HANDLER_TEMPLATE = 'handlers-template.yaml'
-HANDLER_FILE = 'handlers.yaml'
-RELEASE_DIR = 'software/site/releases'
+OUTPUTDIR = "software/site"
+DOCSDOCSDIR = "/docs"
+TERMDOCSDIR = "/docs"
+HANDLER_TEMPLATE = "handlers-template.yaml"
+HANDLER_FILE = "handlers.yaml"
+RELEASE_DIR = "software/site/releases"
+
 
 def hasOpt(opt):
     """Return true if `opt` is among the build options"""
     return opt in BUILDOPTS
 
+
 def getOutputDir():
     return OUTPUTDIR
 
+
 def getDocsOutputDir():
-    os.path.join(OUTPUTDIR, 'docs')
+    os.path.join(OUTPUTDIR, "docs")

--- a/software/util/schemaversion.py
+++ b/software/util/schemaversion.py
@@ -3,13 +3,12 @@
 
 """Module that handles the schema.org version information."""
 
-
 import sys
 import os
 import json
 
 ###################################################
-#VERSION INFO LOAD
+# VERSION INFO LOAD
 ###################################################
 
 VERSION_DATA = None
@@ -18,17 +17,17 @@ VERSION_DATA = None
 def getVersionData():
     global VERSION_DATA
     if not VERSION_DATA:
-      with open('versions.json') as json_file:
-          VERSION_DATA = json.load(json_file)
+        with open("versions.json") as json_file:
+            VERSION_DATA = json.load(json_file)
     return VERSION_DATA
 
 
 def getVersion():
-    return getVersionData()['schemaversion']
+    return getVersionData()["schemaversion"]
 
 
 def getVersionDate(ver):
-    return getVersionData()['releaseLog'].get(ver, None)
+    return getVersionData()["releaseLog"].get(ver, None)
 
 
 def getCurrentVersionDate():
@@ -37,15 +36,14 @@ def getCurrentVersionDate():
 
 def setVersion(ver, date):
     versiondata = getVersionData()
-    versiondata['schemaversion'] = ver
-    versiondata['releaseLog'][ver] = date
-    vers = versiondata['releaseLog']
+    versiondata["schemaversion"] = ver
+    versiondata["releaseLog"][ver] = date
+    vers = versiondata["releaseLog"]
     vers = dict(sorted(vers.items(), key=lambda x: float(x[0]), reverse=True))
-    versiondata['releaseLog'] = vers
-    with open('versions.json', "w") as json_file:
+    versiondata["releaseLog"] = vers
+    with open("versions.json", "w") as json_file:
         json_file.write(json.dumps(versiondata, indent=4))
 
 
-if __name__ == '__main__':
+if __name__ == "__main__":
     print(getVersion())
-

--- a/software/util/sdojsonldcontext.py
+++ b/software/util/sdojsonldcontext.py
@@ -7,6 +7,7 @@ import sys
 import os
 import glob
 import re
+import logging
 
 # Import schema.org libraries
 if not os.getcwd() in sys.path:
@@ -15,6 +16,9 @@ if not os.getcwd() in sys.path:
 import software
 import software.SchemaTerms.sdotermsource as sdotermsource
 import software.SchemaTerms.sdoterm as sdoterm
+
+log = logging.getLogger(__name__)
+
 
 def createcontext():
     """Generates a basic JSON-LD context file for schema.org.
@@ -25,6 +29,7 @@ def createcontext():
       which is invalid JSON.
 
     """
+    log.info("Creating JSON-LD context")
 
     SCHEMAURI = "http://schema.org/"
 
@@ -89,4 +94,5 @@ def createcontext():
     ret = "".join(jsonldcontext)
     ret = ret.replace("},}}","}\n    }\n}")
     ret = ret.replace("},","},\n")
+    log.info("Done: creating JSON-LD context")
     return ret

--- a/software/util/sdojsonldcontext.py
+++ b/software/util/sdojsonldcontext.py
@@ -34,12 +34,12 @@ def createcontext():
     SCHEMAURI = "http://schema.org/"
 
     jsonldcontext = []
-    jsonldcontext.append("{\n  \"@context\": {\n")
-    jsonldcontext.append("        \"type\": \"@type\",\n")
-    jsonldcontext.append("        \"id\": \"@id\",\n")
-    jsonldcontext.append("        \"HTML\": { \"@id\": \"rdf:HTML\" },\n")
-    #jsonldcontext.append("        \"@vocab\": \"%s\",\n" % SdoTermSource.vocabUri())
-    jsonldcontext.append("        \"@vocab\": \"%s\",\n" % SCHEMAURI)
+    jsonldcontext.append('{\n  "@context": {\n')
+    jsonldcontext.append('        "type": "@type",\n')
+    jsonldcontext.append('        "id": "@id",\n')
+    jsonldcontext.append('        "HTML": { "@id": "rdf:HTML" },\n')
+    # jsonldcontext.append("        \"@vocab\": \"%s\",\n" % SdoTermSource.vocabUri())
+    jsonldcontext.append('        "@vocab": "%s",\n' % SCHEMAURI)
     ns = sdotermsource.SdoTermSource.sourceGraph().namespaces()
     done = []
     for n in ns:
@@ -49,22 +49,24 @@ def createcontext():
             if not pref in done:
                 done.append(pref)
                 if pref == "schema":
-                    pth = SCHEMAURI #Override vocab setting to maintain http compatibility
+                    pth = SCHEMAURI  # Override vocab setting to maintain http compatibility
                 if pref == "geo":
                     continue
-                jsonldcontext.append("        \"%s\": \"%s\",\n" % (pref,pth))
+                jsonldcontext.append('        "%s": "%s",\n' % (pref, pth))
 
     datatypepre = "schema:"
     vocablines = ""
     externalines = ""
     typins = ""
-    for t in sdotermsource.SdoTermSource.getAllTerms(expanded=True,suppressSourceLinks=True):
+    for t in sdotermsource.SdoTermSource.getAllTerms(
+        expanded=True, suppressSourceLinks=True
+    ):
         if t.termType == sdoterm.SdoTerm.PROPERTY:
             range = t.rangeIncludes
 
             types = []
 
-            #If Text in range don't output a @type value
+            # If Text in range don't output a @type value
             if not "Text" in range:
                 if "URL" in range:
                     types.append("@id")
@@ -75,13 +77,27 @@ def createcontext():
 
             typins = ""
             for typ in types:
-                typins += ", \"@type\": \"" + typ + "\""
+                typins += ', "@type": "' + typ + '"'
 
-            line = "        \"" + t.id + "\": { \"@id\": \"" + sdotermsource.prefixedIdFromUri(t.uri) + "\"" + typins + "},"
+            line = (
+                '        "'
+                + t.id
+                + '": { "@id": "'
+                + sdotermsource.prefixedIdFromUri(t.uri)
+                + '"'
+                + typins
+                + "},"
+            )
         elif t.termType == sdoterm.SdoTerm.REFERENCE:
             continue
         else:
-            line =  "        \"" + t.id + "\": {\"@id\": \"" + sdotermsource.prefixedIdFromUri(t.uri) + "\"},"
+            line = (
+                '        "'
+                + t.id
+                + '": {"@id": "'
+                + sdotermsource.prefixedIdFromUri(t.uri)
+                + '"},'
+            )
 
         if t.id.startswith("http:") or t.id.startswith("https:"):
             externalines += line
@@ -89,10 +105,10 @@ def createcontext():
             vocablines += line
 
     jsonldcontext.append(vocablines)
-    #jsonldcontext.append(externalines)
+    # jsonldcontext.append(externalines)
     jsonldcontext.append("}}\n")
     ret = "".join(jsonldcontext)
-    ret = ret.replace("},}}","}\n    }\n}")
-    ret = ret.replace("},","},\n")
+    ret = ret.replace("},}}", "}\n    }\n}")
+    ret = ret.replace("},", "},\n")
     log.info("Done: creating JSON-LD context")
     return ret

--- a/software/util/sdoowl.py
+++ b/software/util/sdoowl.py
@@ -4,14 +4,22 @@ import sys
 import os
 
 if not (sys.version_info.major == 3 and sys.version_info.minor > 5):
-    print("Python version %s.%s not supported version 3.6 or above required - exiting" % (sys.version_info.major,sys.version_info.minor))
+    print(
+        "Python version %s.%s not supported version 3.6 or above required - exiting"
+        % (sys.version_info.major, sys.version_info.minor)
+    )
     sys.exit(os.EX_CONFIG)
 
 import glob
 import re
 
-for path in [os.getcwd(),"software/util","software/SchemaTerms","software/SchemaExamples"]:
-  sys.path.insert( 1, path ) #Pickup libs from local  directories
+for path in [
+    os.getcwd(),
+    "software/util",
+    "software/SchemaTerms",
+    "software/SchemaExamples",
+]:
+    sys.path.insert(1, path)  # Pickup libs from local  directories
 
 
 import rdflib
@@ -42,57 +50,66 @@ NAMESPACES = {
     "xmlns:rdfs": "http://www.w3.org/2000/01/rdf-schema#",
     "xmlns:owl": "http://www.w3.org/2002/07/owl#",
     "xmlns:dcterms": "http://purl.org/dc/terms/",
-    "xmlns:xsd": "http://www.w3.org/2001/XMLSchema#"
+    "xmlns:xsd": "http://www.w3.org/2001/XMLSchema#",
 }
 
 from rdflib.term import URIRef
+
 DOMAININC = URIRef(VOCABURI + "domainIncludes")
 RANGEINC = URIRef(VOCABURI + "rangeIncludes")
 INVERSEOF = URIRef(VOCABURI + "inverseOf")
 SUPERSEDEDBY = URIRef(VOCABURI + "supersededBy")
 DEFAULTRANGES = frozenset([VOCABURI + "Text", VOCABURI + "URL", VOCABURI + "Role"])
-DATATYPES = frozenset([VOCABURI + "Boolean",
-            VOCABURI + "Date",
-            VOCABURI + "DateTime",
-            VOCABURI + "Number",
-            VOCABURI + "Float",
-            VOCABURI + "Integer",
-            VOCABURI + "Time"])
+DATATYPES = frozenset(
+    [
+        VOCABURI + "Boolean",
+        VOCABURI + "Date",
+        VOCABURI + "DateTime",
+        VOCABURI + "Number",
+        VOCABURI + "Float",
+        VOCABURI + "Integer",
+        VOCABURI + "Time",
+    ]
+)
+
 
 def _MakePrettyComment(text):
-  """Make a pretty comment with a box of slashes before and after."""
-  inner_text = '/ ' + text
-  bar = '/' * len(inner_text)
-  comment = '\n\t' + bar + '\n\t' + inner_text + '\n\t' + bar + '\n\n\t'
-  return ElementTree.Comment(comment)
+    """Make a pretty comment with a box of slashes before and after."""
+    inner_text = "/ " + text
+    bar = "/" * len(inner_text)
+    comment = "\n\t" + bar + "\n\t" + inner_text + "\n\t" + bar + "\n\n\t"
+    return ElementTree.Comment(comment)
 
 
-class OwlBuild():
+class OwlBuild:
     def __init__(self):
         self.typesCount = self.propsCount = self.namedCount = 0
         self._createDom()
         self._loadGraph()
 
     def _createDom(self):
-        self.dom = ElementTree.Element('rdf:RDF')
-        for (k,v) in NAMESPACES.items():
-            self.dom.set(k,v)
+        self.dom = ElementTree.Element("rdf:RDF")
+        for k, v in NAMESPACES.items():
+            self.dom.set(k, v)
 
         version = schemaversion.getVersion()
         version_date = schemaversion.getCurrentVersionDate()
-        comment_text = "Generated from Schema.org version: %s released: %s" % (version, version_date)
+        comment_text = "Generated from Schema.org version: %s released: %s" % (
+            version,
+            version_date,
+        )
         self.dom.append(_MakePrettyComment(text=comment_text))
-        self.ont = ElementTree.SubElement(self.dom,"owl:Ontology")
-        self.ont.set("rdf:about",VOCABURI)
-        info = ElementTree.SubElement(self.ont,"owl:versionInfo")
-        info.set("rdf:datatype","http://www.w3.org/2001/XMLSchema#string")
+        self.ont = ElementTree.SubElement(self.dom, "owl:Ontology")
+        self.ont.set("rdf:about", VOCABURI)
+        info = ElementTree.SubElement(self.ont, "owl:versionInfo")
+        info.set("rdf:datatype", "http://www.w3.org/2001/XMLSchema#string")
         info.text = version
-        x = ElementTree.SubElement(self.ont,"rdfs:label")
+        x = ElementTree.SubElement(self.ont, "rdfs:label")
         x.text = "Schema.org Vocabulary"
-        x = ElementTree.SubElement(self.ont,"dcterms:modified")
+        x = ElementTree.SubElement(self.ont, "dcterms:modified")
         x.set("rdf:datatype", "http://www.w3.org/2001/XMLSchema#date")
         x.text = version_date
-        self.dom.append(_MakePrettyComment(text='Definitions'))
+        self.dom.append(_MakePrettyComment(text="Definitions"))
 
     def _loadGraph(self):
         self.list(SdoTermSource.sourceGraph())
@@ -100,64 +117,64 @@ class OwlBuild():
     def getContent(self):
         return self.prettify(self.dom).decode()
 
-    def prettify(self,elem):
+    def prettify(self, elem):
         doc = minidom.parseString(ElementTree.tostring(elem))
-        return doc.toprettyxml(encoding='UTF-8')
+        return doc.toprettyxml(encoding="UTF-8")
 
     def list(self, graph):
         types = {}
         props = {}
         exts = []
-        self.dom.append(_MakePrettyComment(text='Class Definitions'))
+        self.dom.append(_MakePrettyComment(text="Class Definitions"))
 
-        for s, p, o in graph.triples((None,RDF.type,RDFS.Class)):
+        for s, p, o in graph.triples((None, RDF.type, RDFS.Class)):
             if s.startswith("https://schema.org"):
-                types.update({s:graph.identifier})
+                types.update({s: graph.identifier})
 
         for t in sorted(types.keys()):
-            self.outputType(t,graph)
+            self.outputType(t, graph)
 
-        self.dom.append(_MakePrettyComment(text='Property Definitions'))
-        for s, p, o in graph.triples((None,RDF.type,RDF.Property)):
+        self.dom.append(_MakePrettyComment(text="Property Definitions"))
+        for s, p, o in graph.triples((None, RDF.type, RDF.Property)):
             if s.startswith("https://schema.org"):
-                props.update({s:graph.identifier})
+                props.update({s: graph.identifier})
 
         for p in sorted(props.keys()):
-            self.outputProp(p,graph)
+            self.outputProp(p, graph)
 
-        self.dom.append(_MakePrettyComment(text='Named Individuals Definitions'))
+        self.dom.append(_MakePrettyComment(text="Named Individuals Definitions"))
 
         self.outputEnums(graph)
-        self.outputNamedIndividuals(VOCABURI + "True",graph)
-        self.outputNamedIndividuals(VOCABURI + "False",graph)
+        self.outputNamedIndividuals(VOCABURI + "True", graph)
+        self.outputNamedIndividuals(VOCABURI + "False", graph)
 
     def outputType(self, uri, graph):
         self.typesCount += 1
 
-        typ = ElementTree.SubElement(self.dom,"owl:Class")
-        typ.set("rdf:about",uri)
+        typ = ElementTree.SubElement(self.dom, "owl:Class")
+        typ.set("rdf:about", uri)
         ext = None
-        for (p,o) in graph.predicate_objects(uri):
+        for p, o in graph.predicate_objects(uri):
             if p == RDFS.label:
-                l = ElementTree.SubElement(typ,"rdfs:label")
-                l.set("xml:lang","en")
+                l = ElementTree.SubElement(typ, "rdfs:label")
+                l.set("xml:lang", "en")
                 l.text = o
             elif p == RDFS.comment:
-                c = ElementTree.SubElement(typ,"rdfs:comment")
-                c.set("xml:lang","en")
+                c = ElementTree.SubElement(typ, "rdfs:comment")
+                c.set("xml:lang", "en")
                 c.text = Markdown.parse(o)
             elif p == RDFS.subClassOf:
-                s = ElementTree.SubElement(typ,"rdfs:subClassOf")
-                s.set("rdf:resource",o)
-            elif p == URIRef(VOCABURI + "isPartOf"): #Defined in an extension
+                s = ElementTree.SubElement(typ, "rdfs:subClassOf")
+                s.set("rdf:resource", o)
+            elif p == URIRef(VOCABURI + "isPartOf"):  # Defined in an extension
                 ext = str(o)
-            elif p == RDF.type and o == URIRef(VOCABURI + "DataType"): #A datatype
-                s = ElementTree.SubElement(typ,"rdfs:subClassOf")
-                s.set("rdf:resource",VOCABURI + "DataType")
+            elif p == RDF.type and o == URIRef(VOCABURI + "DataType"):  # A datatype
+                s = ElementTree.SubElement(typ, "rdfs:subClassOf")
+                s.set("rdf:resource", VOCABURI + "DataType")
 
-        typ.append(self.addDefined(uri,ext))
+        typ.append(self.addDefined(uri, ext))
 
-    def outputProp(self,uri, graph):
+    def outputProp(self, uri, graph):
         self.propsCount += 1
         children = []
         domains = {}
@@ -167,29 +184,31 @@ class OwlBuild():
         for p, o in graph.predicate_objects(uri):
             if p == RDFS.label:
                 l = ElementTree.Element("rdfs:label")
-                l.set("xml:lang","en")
+                l.set("xml:lang", "en")
                 l.text = o
                 children.append(l)
             elif p == RDFS.comment:
                 c = ElementTree.Element("rdfs:comment")
-                c.set("xml:lang","en")
+                c.set("xml:lang", "en")
                 c.text = Markdown.parse(o)
                 children.append(c)
             elif p == RDFS.subPropertyOf:
                 sub = ElementTree.Element("rdfs:subPropertyOf")
                 subval = str(o)
-                if subval == "rdf:type":  #Fixes a special case with schema:additionalType
+                if (
+                    subval == "rdf:type"
+                ):  # Fixes a special case with schema:additionalType
                     subval = "http://www.w3.org/1999/02/22-rdf-syntax-ns#type"
 
-                sub.set("rdf:resource",subval)
+                sub.set("rdf:resource", subval)
                 children.append(sub)
             elif p == INVERSEOF:
                 sub = ElementTree.Element("owl:inverseOf")
-                sub.set("rdf:resource",o)
+                sub.set("rdf:resource", o)
                 children.append(sub)
             elif p == SUPERSEDEDBY:
                 sub = ElementTree.Element("schema:supersededBy")
-                sub.set("rdf:resource",o)
+                sub.set("rdf:resource", o)
                 children.append(sub)
             elif p == DOMAININC:
                 domains[o] = True
@@ -200,8 +219,7 @@ class OwlBuild():
             elif p == URIRef(VOCABURI + "isPartOf"):
                 ext = str(o)
 
-        children.append(self.addDefined(uri,ext))
-
+        children.append(self.addDefined(uri, ext))
 
         if not datatypeonly:
             for r in DEFAULTRANGES:
@@ -211,33 +229,32 @@ class OwlBuild():
         if len(domains):
             d = ElementTree.Element("rdfs:domain")
             children.append(d)
-            cl = ElementTree.SubElement(d,"owl:Class")
-            u = ElementTree.SubElement(cl,"owl:unionOf")
-            u.set("rdf:parseType","Collection")
+            cl = ElementTree.SubElement(d, "owl:Class")
+            u = ElementTree.SubElement(cl, "owl:unionOf")
+            u.set("rdf:parseType", "Collection")
             for target in domains.keys():
-                targ = ElementTree.SubElement(u,"owl:Class")
-                targ.set("rdf:about",target)
+                targ = ElementTree.SubElement(u, "owl:Class")
+                targ.set("rdf:about", target)
 
         if len(ranges):
             r = ElementTree.Element("rdfs:range")
             children.append(r)
-            cl = ElementTree.SubElement(r,"owl:Class")
-            u = ElementTree.SubElement(cl,"owl:unionOf")
-            u.set("rdf:parseType","Collection")
+            cl = ElementTree.SubElement(r, "owl:Class")
+            u = ElementTree.SubElement(cl, "owl:unionOf")
+            u.set("rdf:parseType", "Collection")
             for target in ranges:
-                targ = ElementTree.SubElement(u,"owl:Class")
-                targ.set("rdf:about",target)
-
+                targ = ElementTree.SubElement(u, "owl:Class")
+                targ.set("rdf:about", target)
 
         if datatypeonly:
-            prop = ElementTree.SubElement(self.dom,"owl:DatatypeProperty")
+            prop = ElementTree.SubElement(self.dom, "owl:DatatypeProperty")
         else:
-            prop = ElementTree.SubElement(self.dom,"owl:ObjectProperty")
-        prop.set("rdf:about",uri)
+            prop = ElementTree.SubElement(self.dom, "owl:ObjectProperty")
+        prop.set("rdf:about", uri)
         for sub in children:
             prop.append(sub)
 
-    def addDefined(self,uri,ext=None):
+    def addDefined(self, uri, ext=None):
         if not ext:
             ext = "https://schema.org"
         ext = ext.replace("http://", "https://")
@@ -246,7 +263,7 @@ class OwlBuild():
         defn.set("rdf:resource", path)
         return defn
 
-    def outputEnums(self,graph):
+    def outputEnums(self, graph):
         q = """ prefix schema: <https://schema.org/>
         select Distinct ?enum ?parent where{
         ?parent rdfs:subClassOf schema:Enumeration.
@@ -255,29 +272,28 @@ class OwlBuild():
         """
         enums = list(graph.query(q))
         for row in enums:
-            self.outputNamedIndividuals(row.enum,graph,parent=row.parent)
+            self.outputNamedIndividuals(row.enum, graph, parent=row.parent)
 
-    def outputNamedIndividuals(self,individual,graph,parent=None):
+    def outputNamedIndividuals(self, individual, graph, parent=None):
         self.namedCount += 1
 
-        typ = ElementTree.SubElement(self.dom,"owl:NamedIndividual")
-        typ.set("rdf:about",individual)
+        typ = ElementTree.SubElement(self.dom, "owl:NamedIndividual")
+        typ.set("rdf:about", individual)
         ext = None
-        for (p,o) in graph.predicate_objects(URIRef(individual)):
+        for p, o in graph.predicate_objects(URIRef(individual)):
             if p == RDFS.label:
-                l = ElementTree.SubElement(typ,"rdfs:label")
-                l.set("xml:lang","en")
+                l = ElementTree.SubElement(typ, "rdfs:label")
+                l.set("xml:lang", "en")
                 l.text = o
             elif p == RDFS.comment:
-                c = ElementTree.SubElement(typ,"rdfs:comment")
-                c.set("xml:lang","en")
+                c = ElementTree.SubElement(typ, "rdfs:comment")
+                c.set("xml:lang", "en")
                 c.text = Markdown.parse(o)
             elif p == URIRef(VOCABURI + "isPartOf"):
                 ext = str(o)
 
-        typ.append(self.addDefined(individual,ext))
+        typ.append(self.addDefined(individual, ext))
 
         if parent:
-            s = ElementTree.SubElement(typ,"rdfs:subClassOf")
-            s.set("rdf:resource",parent)
-
+            s = ElementTree.SubElement(typ, "rdfs:subClassOf")
+            s.set("rdf:resource", parent)

--- a/software/util/textutils.py
+++ b/software/util/textutils.py
@@ -3,42 +3,44 @@
 
 import re
 
+
 def StripHtmlTags(source):
-  """Strip all HTML tags from source."""
-  if source and len(source) > 0:
-    return re.sub('<[^<]+?>', '', source)
-  return ''
+    """Strip all HTML tags from source."""
+    if source and len(source) > 0:
+        return re.sub("<[^<]+?>", "", source)
+    return ""
+
 
 def ShortenOnSentence(source, lengthHint=250):
-  """Shorten source at a sentence boundary.
+    """Shorten source at a sentence boundary.
 
-  Args:
-    source: input text to shorten.
-    lengthHint: length at which the input should be shortened.
-  Returns:
-    shortened text
-  """
-  if source and len(source) > lengthHint:
-    source = source.strip()
-    sentEnd = re.compile('[.!?]')
-    sentList = sentEnd.split(source)
-    com=""
-    count = 0
-    while count < len(sentList):
-      if(count > 0 ):
-          if len(com) < len(source):
-              com += source[len(com)]
-      com += sentList[count]
-      count += 1
-      if count == len(sentList):
-        if len(com) < len(source):
-            com += source[len(source) - 1]
-      if len(com) > lengthHint:
-        if len(com) < len(source):
-            com += source[len(com)]
-        break
+    Args:
+      source: input text to shorten.
+      lengthHint: length at which the input should be shortened.
+    Returns:
+      shortened text
+    """
+    if source and len(source) > lengthHint:
+        source = source.strip()
+        sentEnd = re.compile("[.!?]")
+        sentList = sentEnd.split(source)
+        com = ""
+        count = 0
+        while count < len(sentList):
+            if count > 0:
+                if len(com) < len(source):
+                    com += source[len(com)]
+            com += sentList[count]
+            count += 1
+            if count == len(sentList):
+                if len(com) < len(source):
+                    com += source[len(source) - 1]
+            if len(com) > lengthHint:
+                if len(com) < len(source):
+                    com += source[len(com)]
+                break
 
-    if len(source) > len(com) + 1:
-      com += ".."
-    source = com
-  return source
+        if len(source) > len(com) + 1:
+            com += ".."
+        source = com
+    return source


### PR DESCRIPTION
Fix the various imports and the breakage introduced by the changes in the script directory.

* All imports are now done relative from the root.
* All imports are done at the start of the module, so we get errors immediately. 
* Fixed various breakage.
* Only module/libraries are imported.
* Moved pretty logging into its own file.
* Added a context managed to log entry/exit of a particular task.
* Uncommented some logging statements. 
* Ran the `ruff` formatter on all files.
* Removed superfluous log initialisation statements. 