### PR TITLE
Add functionality to annotate schema files

### DIFF
--- a/software/util/reorg.py
+++ b/software/util/reorg.py
@@ -1,4 +1,5 @@
 #!/usr/bin/env python
+# -*- coding: utf-8; python-indent-offset: 4 -*-
 """A Tool to help maintain the set of ttl files in schema.org.
 
 This helps reformatting, merging and splitting ttl files along
@@ -15,127 +16,135 @@ import sys
 SCHEMAORG = rdflib.Namespace("https://schema.org/")
 
 class SchemaOrgGraph(object):
-  def __init__(self, filename: str = None, format: str = "turtle"):
-    self.g = rdflib.Graph()
-    # Binding it here, as by default it would bind the /elements/1.1/ instead
-    # of the dc terms. this way, the elements get assigned 'dc1' or such
-    # as a prefix, and we do not use that.
-    self.g.bind("dc", rdflib.Namespace("http://purl.org/dc/terms/"), replace=True)
-    if filename:
-      self.g.parse(filename, format=format)
+    def __init__(self, filename: str = None, format: str = "turtle"):
+        self.g = rdflib.Graph()
+        # Binding it here, as by default it would bind the /elements/1.1/ instead
+        # of the dc terms. this way, the elements get assigned "dc1" or such
+        # as a prefix, and we do not use that.
+        self.g.bind("dc", rdflib.Namespace("http://purl.org/dc/terms/"), replace=True)
+        if filename:
+            self.g.parse(filename, format=format)
 
-  def __getattr__(self, *args, **kwargs):
-    return getattr(self.g, *args, **kwargs);
+    def __getattr__(self, *args, **kwargs):
+        return getattr(self.g, *args, **kwargs);
 
-  def IdenticalTo(self, other: "SchemaOrgGraph"):
-    only_in_other = other.g - self.g
-    only_in_self = self.g - other.g
-    if only_in_other or only_in_self:
-      raise ValueError(f"Graphs differ: {only_in_other + only_in_self}")
-    return True
+    def IdenticalTo(self, other: "SchemaOrgGraph"):
+        only_in_other = other.g - self.g
+        only_in_self = self.g - other.g
+        if only_in_other or only_in_self:
+            raise ValueError(f"Graphs differ: {only_in_other + only_in_self}")
+        return True
 
-  def FullyContains(self, graph: "SchemaOrgGraph"):
-    only_in_subset = graph.g - self.g
-    if only_in_subset:
-      raise ValueError(f"Graph does not contain it all: {only_in_subset}")
-    return True
+    def FullyContains(self, graph: "SchemaOrgGraph"):
+        only_in_subset = graph.g - self.g
+        if only_in_subset:
+            raise ValueError(f"Graph does not contain it all: {only_in_subset}")
+        return True
 
-  def ListSubjects(self, subject_type: rdflib.term.URIRef):
-    return set([s for s, p, o in self.g.triples((None, rdflib.RDF.type, subject_type))])
+    def ListSubjects(self, subject_type: rdflib.term.URIRef):
+        return set([s for s, p, o in self.g.triples((None, rdflib.RDF.type, subject_type))])
 
-  def Types(self):
-    return self.ListSubjects(rdflib.RDFS.Class)
+    def Types(self):
+        return self.ListSubjects(rdflib.RDFS.Class)
 
-  def Properties(self):
-    return self.ListSubjects(rdflib.RDF.Property)
+    def Properties(self):
+        return self.ListSubjects(rdflib.RDF.Property)
 
 
 def Lint(args):
-  """Reformats the file(s) properly."""
-  def LintOne(filename, output_filename, format):
-    logging.info(" - reading file ...")
-    g = SchemaOrgGraph(filename, format=format)
-    logging.info(f" - writing back {output_filename if output_filename != filename else ''} ...")
-    g.serialize(output_filename, format=format)
-    if not g.IdenticalTo(SchemaOrgGraph(output_filename, format=format)):
-      logging.fatal(f"Linting file {filename} lost some information.")
+    """Reformats the file(s) properly."""
+    def LintOne(filename, output_filename, format):
+        logging.info(" - reading file ...")
+        g = SchemaOrgGraph(filename, format=format)
+        logging.info(f" - writing back {output_filename if output_filename != filename else ""} ...")
+        g.serialize(output_filename, format=format)
+        if not g.IdenticalTo(SchemaOrgGraph(output_filename, format=format)):
+            logging.fatal(f"Linting file {filename} lost some information.")
 
-  if args.output is not None and len(args.files) > 1:
-    logging.fatal(f"Cannot use --output with multiple files!")
-  for index, filename in enumerate(args.files):
-    logging.info(f"Handling file {index} of {len(args.files)} ({filename})")
-    LintOne(filename, args.output or filename, format="turtle")
-    logging.info(" - validated.")
+        if args.output is not None and len(args.files) > 1:
+            logging.fatal(f"Cannot use --output with multiple files!")
+        for index, filename in enumerate(args.files):
+            logging.info(f"Handling file {index} of {len(args.files)} ({filename})")
+            LintOne(filename, args.output or filename, format="turtle")
+            logging.info(" - validated.")
 
 
 def MergeFiles(args):
-  """Merges a set of files into one."""
-  logging.info(f"Merging files {len(args.files)} into {args.output}")
-  merged = SchemaOrgGraph()
-  for filename in args.files:
-    logging.info(f" - reading {filename} ...")
-    merged.parse(filename, format="turtle")
-  logging.info(f"Writing {args.output} ...")
-  merged.serialize(args.output, format="turtle")
+    """Merges a set of files into one."""
+    logging.info(f"Merging files {len(args.files)} into {args.output}")
+    merged = SchemaOrgGraph()
+    for filename in args.files:
+        logging.info(f" - reading {filename} ...")
+        merged.parse(filename, format="turtle")
+    logging.info(f"Writing {args.output} ...")
+    merged.serialize(args.output, format="turtle")
 
-  for filename in args.files:
-    if not merged.FullyContains(SchemaOrgGraph(filename, format="turtle")):
-      logging.fatal(f"Merging files into {args.output} lost some information.")
+    for filename in args.files:
+        if not merged.FullyContains(SchemaOrgGraph(filename, format="turtle")):
+            logging.fatal(f"Merging files into {args.output} lost some information.")
 
 
 def Annotate(args):
-  """Adds some annotations to properties and types."""
-  if args.output is not None and len(args.files) > 1:
-    logging.fatal(f"Cannot use --output with multiple files!")
+    """Adds some annotations to properties and types."""
+    if args.output is not None and len(args.files) > 1:
+        logging.fatal(f"Cannot use --output with multiple files!")
 
-  valid_parts = ["pending", "attic", "meta", "GA"]
-  if args.ispartof not in valid_parts:
-    logging.fatal(f"PartOf annotation '{args.ispartof}' is not valid: select one of {valid_parts}")
-  new_part = rdflib.URIRef(f"https://{args.ispartof}.schema.org/")
+    valid_parts = ["pending", "attic", "meta", "GA"]
+    if args.ispartof not in valid_parts:
+        logging.fatal(f"PartOf annotation "{args.ispartof}" is not valid: select one of {valid_parts}")
+    new_part = rdflib.URIRef(f"https://{args.ispartof}.schema.org/")
 
-  for filename in args.files:
-    logging.info(f"Annotating {filename} ...")
-    g = SchemaOrgGraph(filename, format="turtle")
-    # Clean the existing parts
-    g.remove((None, SCHEMAORG.isPartOf, None))
-    # GA is special as it is the unannotated state.
-    if args.ispartof != "GA":
-      for sub in itertools.chain(g.Types(), g.Properties()):
-        g.add((sub, SCHEMAORG.isPartOf, new_part))
+    for filename in args.files:
+        logging.info(f"Annotating {filename} ...")
+        g = SchemaOrgGraph(filename, format="turtle")
+        # Clean the existing parts
+        g.remove((None, SCHEMAORG.isPartOf, None))
+        # GA is special as it is the unannotated state.
+        if args.ispartof != "GA":
+            for sub in itertools.chain(g.Types(), g.Properties()):
+                g.add((sub, SCHEMAORG.isPartOf, new_part))
 
-    g.serialize(args.output or filename, format="turtle")
-    logging.info(f" ... done, written to {args.output or filename}")
+        g.serialize(args.output or filename, format="turtle")
+        logging.info(f" ... done, written to {args.output or filename}")
 
 def main():
-  """
-  Parses command line arguments and dispatches to the appropriate
-  command.
-  """
-  logging.basicConfig(level=logging.INFO)
+    """
+    Parses command line arguments and dispatches to the appropriate
+    command.
+    """
+    logging.basicConfig(level=logging.INFO)
 
-  parser = argparse.ArgumentParser(description="Re-organize Turtle files")
-  subparsers = parser.add_subparsers(dest='command')
+    parser = argparse.ArgumentParser(description="Re-organize Turtle files")
+    subparsers = parser.add_subparsers(dest="command")
 
-  lint_parser = subparsers.add_parser('lint',
-                                      help='Reformat files (aka linting)')
-  lint_parser.add_argument('-o', '--output',
-                           help='Output file (default: overwrites)')
-  lint_parser.add_argument("files", action="extend", nargs="+", type=str)
+    lint_parser = subparsers.add_parser("lint",
+                                        help="Reformat files (aka linting)")
+    lint_parser.add_argument("-o", "--output",
+                             help="Output file (default: overwrites)")
+    lint_parser.add_argument("files", action="extend", nargs="+", type=str)
 
-  merge_parser = subparsers.add_parser('merge', help='Merging several files')
-  merge_parser.add_argument('-o', '--output', help='Output file')
-  merge_parser.add_argument("files", action="extend", nargs="+", type=str)
+    merge_parser = subparsers.add_parser("merge", help="Merging several files")
+    merge_parser.add_argument("-o", "--output", help="Output file")
+    merge_parser.add_argument("files", action="extend", nargs="+", type=str)
 
-  # Parse and dispatch
-  args = parser.parse_args()
-  if args.command == 'lint':
-    Lint(args)
-  elif args.command == 'merge':
-    MergeFiles(args)
-  elif args.command == 'annotate':
-    Annotate(args)
-  else:
-    parser.print_help()
+    annotate_parser = subparsers.add_parser("annotate",
+                                            help="Add annotations to types and properties.")
+    annotate_parser.add_argument("-o", "--output", help="Output file")
+    annotate_parser.add_argument(
+        "--ispartof",
+        help="Which state classes and properties are in schema.org (eg. pending, attic)")
+    annotate_parser.add_argument("files", action="extend", nargs="+", type=str)
+
+    # Parse and dispatch
+    args = parser.parse_args()
+    if args.command == 'lint':
+        Lint(args)
+    elif args.command == 'merge':
+        MergeFiles(args)
+    elif args.command == 'annotate':
+        Annotate(args)
+    else:
+        parser.print_help()
 
 
 if __name__ == "__main__":

--- a/software/util/reorg.py
+++ b/software/util/reorg.py
@@ -137,11 +137,11 @@ def main():
 
     # Parse and dispatch
     args = parser.parse_args()
-    if args.command == 'lint':
+    if args.command == "lint":
         Lint(args)
     elif args.command == 'merge':
         MergeFiles(args)
-    elif args.command == 'annotate':
+    elif args.command == "annotate":
         Annotate(args)
     else:
         parser.print_help()

--- a/software/util/reorg.py
+++ b/software/util/reorg.py
@@ -6,64 +6,80 @@ semantic axis.
 """
 
 from collections.abc import Sequence
-from rdflib import Graph, Namespace
+import rdflib
+import argparse
+import itertools
 import logging
 import sys
-import argparse
 
-def SchemaOrgGraph():
-  """Creates a graph with usual namespaces set as we want in schemaorg."""
-  g = Graph()
-  g.bind("dc", Namespace("http://purl.org/dc/terms/"), replace=True)
-  return g
+SCHEMAORG = rdflib.Namespace("https://schema.org/")
 
-def GraphsAreIdentical(g1, g2):
-  only_in_g1 = g1 - g2
-  only_in_g2 = g2 - g1
-  # TODO: print sampled diffs if any.
-  return len(only_in_g1) == 0 and len(only_in_g2) == 0
+class SchemaOrgGraph(object):
+  def __init__(self, filename: str = None, format: str = "turtle"):
+    self.g = rdflib.Graph()
+    # Binding it here, as by default it would bind the /elements/1.1/ instead
+    # of the dc terms. this way, the elements get assigned 'dc1' or such
+    # as a prefix, and we do not use that.
+    self.g.bind("dc", rdflib.Namespace("http://purl.org/dc/terms/"), replace=True)
+    if filename:
+      self.g.parse(filename, format=format)
 
-def GraphIsIncludedIn(g_subset, g_universe):
-  only_in_subset = g_subset - g_universe
-  # TODO: print sampled diffs if any.
-  return len(only_in_subset) == 0
+  def __getattr__(self, *args, **kwargs):
+    return getattr(self.g, *args, **kwargs);
+
+  def IdenticalTo(self, other: "SchemaOrgGraph"):
+    only_in_other = other.g - self.g
+    only_in_self = self.g - other.g
+    if len(only_in_other) or len(only_in_self):
+      raise ValueError(f"Graphs differ: {only_in_other + only_in_self}")
+    return True
+
+  def FullyContains(self, graph: "SchemaOrgGraph"):
+    only_in_subset = graph.g - self.g
+    if len(only_in_subset):
+      raise ValueError(f"Graph does not contain it all: {only_in_subset}")
+    return True
+
+  def ListSubjects(self, subject_type: rdflib.term.URIRef):
+    return set([s for s, p, o in self.g.triples((None, rdflib.RDF.type, subject_type))])
+
+  def Types(self):
+    return self.ListSubjects(rdflib.RDFS.Class)
+
+  def Properties(self):
+    return self.ListSubjects(rdflib.RDF.Property)
+
 
 def Lint(args):
   """Reformats the file(s) properly."""
-  def LintOne(filename, output_filename):
+  def LintOne(filename, output_filename, format):
     logging.info(" - reading file ...")
-    g = SchemaOrgGraph()
-    g.parse(filename, format="turtle")
+    g = SchemaOrgGraph(filename, format=format)
     logging.info(f" - writing back {output_filename if output_filename != filename else ''} ...")
-    g.serialize(output_filename, format="turtle")
-
-    v = SchemaOrgGraph()
-    v.parse(output_filename, format="turtle")
-    if not GraphsAreIdentical(v, g):
+    g.serialize(output_filename, format=format)
+    if not g.IdenticalTo(SchemaOrgGraph(output_filename, format=format)):
       logging.fatal(f"Linting file {filename} lost some information.")
-    logging.info(" - validated.")
 
   if args.output is not None and len(args.files) > 1:
     logging.fatal(f"Cannot use --output with multiple files!")
   for index, filename in enumerate(args.files):
     logging.info(f"Handling file {index} of {len(args.files)} ({filename})")
-    LintOne(filename, args.output or filename)
+    LintOne(filename, args.output or filename, format="turtle")
+    logging.info(" - validated.")
 
 
 def MergeFiles(args):
   """Merges a set of files into one."""
-  merged = SchemaOrgGraph()
   logging.info(f"Merging files {len(args.files)} into {args.output}")
+  merged = SchemaOrgGraph()
   for filename in args.files:
     logging.info(f" - reading {filename} ...")
     merged.parse(filename, format="turtle")
   logging.info(f"Writing {args.output} ...")
-  merged.serialize(args.output)
+  merged.serialize(args.output, format="turtle")
 
   for filename in args.files:
-    v = SchemaOrgGraph()
-    v.parse(filename, format="turtle")
-    if not GraphIsIncludedIn(v, merged):
+    if not merged.FullyContains(SchemaOrgGraph(filename, format="turtle")):
       logging.fatal(f"Merging files into {args.output} lost some information.")
 
 
@@ -81,11 +97,11 @@ def main():
                                       help='Reformat files (aka linting)')
   lint_parser.add_argument('-o', '--output',
                            help='Output file (default: overwrites)')
-  lint_parser.add_argument("files", action="extend", nargs="+", type=str);
+  lint_parser.add_argument("files", action="extend", nargs="+", type=str)
 
   merge_parser = subparsers.add_parser('merge', help='Merging several files')
   merge_parser.add_argument('-o', '--output', help='Output file')
-  merge_parser.add_argument("files", action="extend", nargs="+", type=str);
+  merge_parser.add_argument("files", action="extend", nargs="+", type=str)
 
   # Parse and dispatch
   args = parser.parse_args()

--- a/software/util/reorg.py
+++ b/software/util/reorg.py
@@ -30,13 +30,13 @@ class SchemaOrgGraph(object):
   def IdenticalTo(self, other: "SchemaOrgGraph"):
     only_in_other = other.g - self.g
     only_in_self = self.g - other.g
-    if len(only_in_other) or len(only_in_self):
+    if only_in_other or only_in_self:
       raise ValueError(f"Graphs differ: {only_in_other + only_in_self}")
     return True
 
   def FullyContains(self, graph: "SchemaOrgGraph"):
     only_in_subset = graph.g - self.g
-    if len(only_in_subset):
+    if only_in_subset:
       raise ValueError(f"Graph does not contain it all: {only_in_subset}")
     return True
 
@@ -125,13 +125,6 @@ def main():
   merge_parser = subparsers.add_parser('merge', help='Merging several files')
   merge_parser.add_argument('-o', '--output', help='Output file')
   merge_parser.add_argument("files", action="extend", nargs="+", type=str)
-
-  annotate_parser = subparsers.add_parser('annotate', help='Add annotations to types and properties.')
-  annotate_parser.add_argument('-o', '--output', help='Output file')
-  annotate_parser.add_argument(
-      '--ispartof',
-      help='Which state classes and properties are in schema.org (eg. pending, attic)')
-  annotate_parser.add_argument("files", action="extend", nargs="+", type=str)
 
   # Parse and dispatch
   args = parser.parse_args()


### PR DESCRIPTION
This adds the functionality to annotate all Types and Properties of a file with `isPartOf`.

This also includes a refactoring of the graph logic into a `SchemaOrgGraph` class, which should be then reusable across several parts of the code base.
