### PR TITLE
Refactor graph tests

### DIFF
--- a/software/tests/test_graphs.py
+++ b/software/tests/test_graphs.py
@@ -1,22 +1,19 @@
 #!/usr/bin/env python3
 # -*- coding: utf-8 -*-
-import sys
-import os
-import logging
 import glob
-import sys
-import unittest
+import logging
+import os
 import rdflib
+import sys
+import typing
+import unittest
 
 # Import schema.org libraries
 if not os.getcwd() in sys.path:
     sys.path.insert(1, os.getcwd())
 
 import software
-
 import software.SchemaTerms.sdotermsource as sdotermsource
-
-warnings = []
 
 TYPECOUNT_UPPERBOUND = 1000
 TYPECOUNT_LOWERBOUND = 500
@@ -44,189 +41,170 @@ class SDOGraphSetupTestCase(unittest.TestCase):
             "Graph rdflib_data should have some triples in it.",
         )
 
+    # Supporting functions to streamline tests and make their error
+    # messages as informative as possible.
+    def getResults(self, query: str, varnames: tuple[str] = ()) -> list[dict]:
+        """Runs the SparQL query and returns the results as an array of dict,
+           with keys limited to the 'varname' set if provided.
+        """
+        results = self.rdflib_data.query(query.strip())
+        return [dict([(key, row[key])
+                      for key in varnames or row.asdict().keys()])
+                for row in results]
+
+    @classmethod
+    def formatResults(cls, results, pattern: str = "", varnames: tuple[str] = (),
+                      sep: str = " => ", rowsep: str = "\n\t") -> str:
+        """Formatting results to make a human-readable list in one step."""
+        lines = []
+        if pattern:
+            lines = [pattern % row for row in results]
+        else:
+            lines = [sep.join([row[key]
+                            for key in varnames or row.keys()])
+                     for row in results]
+
+        return rowsep + rowsep.join(lines)
+
+
+    def assertNoMatch(self, results: typing.Union[str, list[dict]],
+                      error_message: str = "List should be empty", row_pattern: str = None):
+        if isinstance(results, str):
+            # Resolve the SPARQL query into results
+            results = self.getResults(results)
+        self.assertEqual(
+            len(results), 0,
+            f"{error_message}! Found {len(results)}: {self.formatResults(results, pattern=row_pattern)}")
+
+
     # SPARQLResult http://rdflib.readthedocs.org/en/latest/apidocs/rdflib.plugins.sparql.html
     # "A list of dicts (solution mappings) is returned"
 
-    def test_found_sixplus_inverseOf(self):
-        inverseOf_results = self.rdflib_data.query(
+    def test_foundSixPlusInverseOf(self):
+        results = self.getResults(
             "select ?x ?y where { ?x <https://schema.org/inverseOf> ?y }"
         )
-        log.info("inverseOf result count: %s" % len(inverseOf_results))
-        self.assertTrue(
-            len(inverseOf_results) >= 6,
-            "Six or more inverseOf expected. Found: %s " % len(inverseOf_results),
-        )
+        self.assertGreaterEqual(len(results), 6,
+                                f"Six or more inverseOf expected. Found: {len(results)}")
 
-    def test_even_number_inverseOf(self):
-        inverseOf_results = self.rdflib_data.query(
+    def test_evenNumberOfInverseOf(self):
+        results = self.getResults(
             "select ?x ?y where { ?x <https://schema.org/inverseOf> ?y }"
         )
         self.assertTrue(
-            len(inverseOf_results) % 2 == 0,
-            "Even number of inverseOf triples expected. Found: %s "
-            % len(inverseOf_results),
-        )
+            len(results) % 2 == 0,
+            f"Even number of inverseOf triples expected. Found: {len(results)}")
 
-    def test_non_equal_inverseOf(self):
-        results = self.rdflib_data.query(
-            "select ?x ?y where { ?x <https://schema.org/inverseOf> ?y }"
-        )
-        for result in results:
-            self.assertTrue(
-                result[0] != result[1],
-                "%s should not be equal to %s" % (result[0], result[1]),
-            )
+    def test_noSelfInverseOf(self):
+        self.assertNoMatch("""
+            select ?x ?y where {
+                ?x <https://schema.org/inverseOf> ?y .
+                filter (?x = ?y) .
+            }
+        """,
+        error_message="inverseOf same property as itself")
 
-    def test_non_equal_supercededBy(self):
-        results = self.rdflib_data.query(
-            "select ?x ?y where { ?x <https://schema.org/supercededBy> ?y }"
-        )
-        for result in results:
-            self.assertTrue(
-                result[0] != result[1],
-                "%s should not be equal to %s" % (result[0], result[1]),
-            )
+    def test_noSelfSupercededBy(self):
+        self.assertNoMatch("""
+            select ?x ?y where {
+                ?x <https://schema.org/supercededBy> ?y .
+                filter (?x = ?y) .
+            }
+        """,
+        error_message="Type should not be supercededBy itself")
 
     @unittest.expectedFailure  # autos
     def test_needlessDomainIncludes(self):
-        global warnings
         # check immediate subtypes don't declare same domainIncludes
         # TODO: could we use property paths here to be more thorough?
         # rdfs:subClassOf+ should work but seems not to.
-        ndi1 = """SELECT ?prop ?c1 ?c2
-           WHERE {
-           ?prop <https://schema.org/domainIncludes> ?c1 .
-           ?prop <https://schema.org/domainIncludes> ?c2 .
-           ?c1 rdfs:subClassOf ?c2 .
-           FILTER (?c1 != ?c2) .
-           FILTER NOT EXISTS { ?prop <https://schema.org/isPartOf> <http://attic.schema.org> .}
-           FILTER NOT EXISTS { ?c1 <https://schema.org/isPartOf> <http://attic.schema.org> .}
-           FILTER NOT EXISTS { ?c2 <https://schema.org/isPartOf> <http://attic.schema.org> .}
-           }
-           ORDER BY ?prop """
-        ndi1_results = self.rdflib_data.query(ndi1)
-        if len(ndi1_results) > 0:
-            for row in ndi1_results:
-                warn = (
-                    "Property %s defining domain, %s, [which is subclassOf] %s unnecessarily"
-                    % (row["prop"], row["c1"], row["c2"])
-                )
-                # warnings.append(warn)
-                log.warning(warn)
-        self.assertEqual(
-            len(ndi1_results),
-            0,
-            "No subtype need redeclare a domainIncludes of its parents. Found: %s "
-            % len(ndi1_results),
-        )
+        self.assertNoMatch("""
+             SELECT ?prop ?c1 ?c2
+             WHERE {
+                 ?prop <https://schema.org/domainIncludes> ?c1 .
+                 ?prop <https://schema.org/domainIncludes> ?c2 .
+                 ?c1 rdfs:subClassOf ?c2 .
+                 FILTER (?c1 != ?c2) .
+                 FILTER NOT EXISTS { ?prop <https://schema.org/isPartOf> <http://attic.schema.org> .}
+                 FILTER NOT EXISTS { ?c1 <https://schema.org/isPartOf> <http://attic.schema.org> .}
+                 FILTER NOT EXISTS { ?c2 <https://schema.org/isPartOf> <http://attic.schema.org> .}
+             }
+             ORDER BY ?prop
+        """,
+        error_message="Subtype should not redeclare a domainIncludes of its parents",
+        row_pattern="Property %(prop)s defining domain, %(c1)s, [which is subClassOf] %(c2)s unnecessarily")
 
     @unittest.expectedFailure
     def test_needlessRangeIncludes(self):
-        global warnings
         # as above, but for range. We excuse URL as it is special, not best seen as a Text subtype.
         # check immediate subtypes don't declare same domainIncludes
         # TODO: could we use property paths here to be more thorough?
-        nri1 = """SELECT ?prop ?c1 ?c2
-         WHERE {
-         ?prop <https://schema.org/rangeIncludes> ?c1 .
-         ?prop <https://schema.org/rangeIncludes> ?c2 .
-         ?c1 rdfs:subClassOf ?c2 .
-         FILTER (?c1 != ?c2) .
-         FILTER (?c1 != <https://schema.org/URL>) .
-         FILTER NOT EXISTS { ?prop <https://schema.org/isPartOf> <http://attic.schema.org> .}
-         FILTER NOT EXISTS { ?c1 <https://schema.org/isPartOf> <http://attic.schema.org> .}
-         FILTER NOT EXISTS { ?c2 <https://schema.org/isPartOf> <http://attic.schema.org> .}
-             }
-             ORDER BY ?prop """
-        nri1_results = self.rdflib_data.query(nri1)
-        if len(nri1_results) > 0:
-            for row in nri1_results:
-                warn = (
-                    "Property %s defining range, %s, [which is subclassOf] %s unnecessarily"
-                    % (row["prop"], row["c1"], row["c2"])
-                )
-                log.warning(warn)
-        self.assertEqual(
-            len(nri1_results),
-            0,
-            "No subtype need redeclare a rangeIncludes of its parents. Found: %s"
-            % len(nri1_results),
-        )
+        self.assertNoMatch("""
+            SELECT ?prop ?c1 ?c2
+            WHERE {
+                ?prop <https://schema.org/rangeIncludes> ?c1 .
+                ?prop <https://schema.org/rangeIncludes> ?c2 .
+                ?c1 rdfs:subClassOf ?c2 .
+                FILTER (?c1 != ?c2) .
+                FILTER (?c1 != <https://schema.org/URL>) .
+                FILTER NOT EXISTS { ?prop <https://schema.org/isPartOf> <http://attic.schema.org> .}
+                FILTER NOT EXISTS { ?c1 <https://schema.org/isPartOf> <http://attic.schema.org> .}
+                FILTER NOT EXISTS { ?c2 <https://schema.org/isPartOf> <http://attic.schema.org> .}
+            }
+            ORDER BY ?prop
+        """,
+        error_message="No subtype need redeclare a rangeIncludes of its parents",
+        row_pattern="Property %(prop)s defining range, %(c1)s, [which is subclassOf] %(c2)s unnecessarily")
 
     #  def test_supersededByAreLabelled(self):
     #    supersededByAreLabelled_results = self.rdflib_data.query("select ?x ?y ?z where { ?x <https://schema.org/supersededBy> ?y . ?y <https://schema.org/name> ?z }")
     #    self.assertEqual(len(inverseOf_results ) % 2 == 0, True, "Even number of inverseOf triples expected. Found: %s " % len(inverseOf_results ) )
 
     def test_validRangeIncludes(self):
-        nri1 = """SELECT ?prop ?c1
-     WHERE {
-         ?prop <https://schema.org/rangeIncludes> ?c1 .
-         OPTIONAL{
-            ?c1 rdf:type ?c2 .
-            ?c1 rdf:type rdfs:Class .
-         }.
-         FILTER (!BOUND(?c2))
-        FILTER NOT EXISTS { ?prop <https://schema.org/isPartOf> <http://attic.schema.org> .}
-                 }
-                 ORDER BY ?prop """
-        nri1_results = self.rdflib_data.query(nri1)
-        for row in nri1_results:
-            log.info(
-                "Property %s invalid rangeIncludes value: %s\n"
-                % (row["prop"], row["c1"])
-            )
-        self.assertEqual(
-            len(nri1_results),
-            0,
-            "RangeIncludes should define valid type. Found: %s" % len(nri1_results),
-        )
+        self.assertNoMatch("""
+            SELECT ?prop ?c1
+            WHERE {
+                ?prop <https://schema.org/rangeIncludes> ?c1 .
+                OPTIONAL{
+                    ?c1 rdf:type ?c2 .
+                    ?c1 rdf:type rdfs:Class .
+                } .
+                FILTER (!BOUND(?c2))
+                FILTER NOT EXISTS { ?prop <https://schema.org/isPartOf> <http://attic.schema.org> .}
+            }
+            ORDER BY ?prop
+        """,
+        error_message="RangeIncludes should define valid type",
+        row_pattern="Property %(prop)s invalid rangeIncludes value: %(c1)s")
 
     def test_validDomainIncludes(self):
-        nri1 = """SELECT ?prop ?c1
-     WHERE {
-         ?prop <https://schema.org/domainIncludes> ?c1 .
-         OPTIONAL{
-            ?c1 rdf:type ?c2 .
-            ?c1 rdf:type rdfs:Class .
-         }.
-         FILTER (!BOUND(?c2))
-        FILTER NOT EXISTS { ?prop <https://schema.org/isPartOf> <http://attic.schema.org> .}
-                 }
-                 ORDER BY ?prop """
-        nri1_results = self.rdflib_data.query(nri1)
-        for row in nri1_results:
-            log.info(
-                "Property %s invalid domainIncludes value: %s\n"
-                % (row["prop"], row["c1"])
-            )
-        self.assertEqual(
-            len(nri1_results),
-            0,
-            "DomainIncludes should define valid type. Found: %s" % len(nri1_results),
-        )
+        self.assertNoMatch("""
+            SELECT ?prop ?c1
+            WHERE {
+                ?prop <https://schema.org/domainIncludes> ?c1 .
+                OPTIONAL {
+                    ?c1 rdf:type ?c2 .
+                    ?c1 rdf:type rdfs:Class .
+                }.
+                FILTER (!BOUND(?c2))
+                FILTER NOT EXISTS { ?prop <https://schema.org/isPartOf> <http://attic.schema.org> .}
+            }
+            ORDER BY ?prop
+        """,
+        error_message="DomainIncludes should define valid type",
+        row_pattern="Property %(prop)s invalid domainIncludes value: %(c1)s")
 
-    # These are place-holders for more sophisticated SPARQL-expressed checks.
-    @unittest.expectedFailure
-    def test_readSchemaFromRDFa(self):
-        self.assertTrue(
-            True,
-            False,
-            "We should know how to locally get /docs/schema_org_rdfa.html but this requires fixes to api.py.",
-        )
 
     # @unittest.expectedFailure
     def test_simpleLabels(self):
-        s = ""
-        complexLabels = self.rdflib_data.query(
-            "select distinct ?term ?label where { ?term rdfs:label ?label  FILTER regex(?label,'[^a-zA-Z0-9_ ]','i'). } "
-        )
-        for row in complexLabels:
-            s += " term %s has complex label: %s\n" % (row["term"], row["label"])
-        self.assertTrue(
-            len(complexLabels) == 0,
-            "No complex term labels expected; alphanumeric only please. Found: %s Details: %s\n"
-            % (len(complexLabels), s),
-        )
+        self.assertNoMatch("""
+            select distinct ?term ?label where {
+                ?term rdfs:label ?label
+                FILTER regex(?label,'[^a-zA-Z0-9_ ]','i') .
+            }
+        """,
+        error_message="Some terms have complex labels (alphanumeric only please!)",
+        row_pattern="term %(term)s has complex label: %(label)s")
         # Whitespace is tolerated, for now.
         # we don't deal well with non definitional uses of rdfs:label yet - non terms are flagged up.
         # https://github.com/schemaorg/schemaorg/issues/1136
@@ -237,434 +215,289 @@ class SDOGraphSetupTestCase(unittest.TestCase):
     # self.assertEqual(len(ndi1_results), 0, "No domainIncludes or rangeIncludes value should lack a type. Found: %s " % len(ndi1_results ) )
 
     def test_labelMatchesTermId(self):
-        nri1 = """select ?term ?label where {
-       ?term rdfs:label ?label.
-       BIND(STR(?term) AS ?strVal)
-       FILTER(STRLEN(?strVal) >= 19 && SUBSTR(?strVal, 1, 19) = "https://schema.org/")
-       FILTER(SUBSTR(?strVal, 20) != STR(?label))
-    }
-    ORDER BY ?term  """
-        nri1_results = self.rdflib_data.query(nri1)
-        if len(nri1_results):
-            log.info("Label matching errors:")
-            for row in nri1_results:
-                log.info(
-                    "Term '%s' has none-matching label: '%s'"
-                    % (row["term"], row["label"])
-                )
-        self.assertEqual(
-            len(nri1_results),
-            0,
-            "Term should have matching rdfs:label. Found: %s" % len(nri1_results),
-        )
+        self.assertNoMatch("""
+            select ?term ?label where {
+                ?term rdfs:label ?label.
+                BIND(STR(?term) AS ?strVal)
+                FILTER(STRLEN(?strVal) >= 19 && SUBSTR(?strVal, 1, 19) = "https://schema.org/")
+                FILTER(SUBSTR(?strVal, 20) != STR(?label))
+            }
+            ORDER BY ?term
+        """,
+        error_message="Term should have matching rdfs:label",
+        row_pattern="Term '%(term)s' has none-matching label: '%(label)s'")
 
     def test_superTypesExist(self):
-        nri1 = """select ?term ?super where {
-       ?term rdfs:subClassOf ?super.
-       ?term rdf:type rdfs:Class.
-       FILTER NOT EXISTS { ?super rdf:type rdfs:Class }
+        self.assertNoMatch("""
+            select ?term ?super where {
+                ?term rdfs:subClassOf ?super.
+                ?term rdf:type rdfs:Class.
+                FILTER NOT EXISTS { ?super rdf:type rdfs:Class }
 
-       BIND(STR(?term) AS ?strVal)
-       FILTER(STRLEN(?strVal) >= 19 && SUBSTR(?strVal, 1, 19) = "https://schema.org/")
+                BIND(STR(?term) AS ?strVal)
+                FILTER(STRLEN(?strVal) >= 19 && SUBSTR(?strVal, 1, 19) = "https://schema.org/")
 
-       BIND(STR(?super) AS ?superStrVal)
-       FILTER(STRLEN(?superStrVal) >= 19 && SUBSTR(?superStrVal, 1, 19) = "https://schema.org/")
-        FILTER NOT EXISTS { ?term <https://schema.org/isPartOf> <http://attic.schema.org> .}
-    }
-    ORDER BY ?term  """
-        nri1_results = self.rdflib_data.query(nri1)
-        if len(nri1_results):
-            log.info("Invalid SuperType errors!!!\n")
-            for row in nri1_results:
-                log.info(
-                    "Term '%s' has nonexistent supertype: '%s'"
-                    % (row["term"], row["super"])
-                )
-        self.assertEqual(
-            len(nri1_results),
-            0,
-            "Types with nonexistent SuperTypes. Found: %s" % len(nri1_results),
-        )
+                BIND(STR(?super) AS ?superStrVal)
+                FILTER(STRLEN(?superStrVal) >= 19 && SUBSTR(?superStrVal, 1, 19) = "https://schema.org/")
+                FILTER NOT EXISTS { ?term <https://schema.org/isPartOf> <http://attic.schema.org> .}
+            }
+            ORDER BY ?term
+            """,
+            error_message="Types with nonexistent SuperTypes",
+            row_pattern="Term '%(term)s' has nonexistent supertype: '%(super)s'")
 
-        def test_propswitoutdomain(self):
-            nri1 = """ select ?term where {
-            ?term a rdf:Property.
-            FILTER NOT EXISTS { ?term <https://schema.org/domainIncludes> ?o .}
-        }
-         """
-            nri1_results = self.rdflib_data.query(nri1)
-            if len(nri1_results):
-                log.info("Property without domain errors!!!\n")
-                for row in nri1_results:
-                    log.info("Term '%s' has no domainIncludes value(s)" % (row["term"]))
-            self.assertEqual(
-                len(nri1_results),
-                0,
-                "Property without domain extensions  Found: %s" % len(nri1_results),
-            )
+    @unittest.expectedFailure
+    def test_propsWithoutDomain(self):
+        self.assertNoMatch("""
+            select ?term where {
+                ?term a rdf:Property.
+                FILTER NOT EXISTS { ?term <https://schema.org/domainIncludes> ?o .}
+            }
+        """,
+        error_message="Property without domain extensions",
+        row_pattern="Term '%(term)s' has no domainIncludes values")
 
-        def test_propswitoutrange(self):
-            nri1 = """ select ?term where {
-            ?term a rdf:Property.
-            FILTER NOT EXISTS { ?term <https://schema.org/rangeIncludes> ?o .}
-        }
-         """
-            nri1_results = self.rdflib_data.query(nri1)
-            if len(nri1_results):
-                log.info("Property without domain errors!!!\n")
-                for row in nri1_results:
-                    log.info("Term '%s' has no rangeIncludes value(s)" % (row["term"]))
-            self.assertEqual(
-                len(nri1_results),
-                0,
-                "Property without range extensions  Found: %s" % len(nri1_results),
-            )
+    @unittest.expectedFailure
+    def test_propsWithoutRange(self):
+        self.assertNoMatch("""
+           select ?term where {
+             ?term a rdf:Property.
+             FILTER NOT EXISTS { ?term <https://schema.org/rangeIncludes> ?o .}
+           }
+        """,
+        error_message="Property without range extensions",
+        row_pattern="Term '%(term)s' has no rangeIncludes values")
 
     def test_superPropertiesExist(self):
-        nri1 = """select ?term ?super where {
-       ?term rdf:type rdf:Property.
-       ?term rdfs:subPropertyOf ?super.
-       FILTER NOT EXISTS { ?super rdf:type rdf:Property }
+        self.assertNoMatch("""
+          select ?term ?super where {
+            ?term rdf:type rdf:Property.
+            ?term rdfs:subPropertyOf ?super.
+            FILTER NOT EXISTS { ?super rdf:type rdf:Property }
 
-       BIND(STR(?term) AS ?strVal)
-       FILTER(STRLEN(?strVal) >= 19 && SUBSTR(?strVal, 1, 19) = "https://schema.org/")
+            BIND(STR(?term) AS ?strVal)
+            FILTER(STRLEN(?strVal) >= 19 && SUBSTR(?strVal, 1, 19) = "https://schema.org/")
 
-       BIND(STR(?super) AS ?superStrVal)
-       FILTER(STRLEN(?superStrVal) >= 19 && SUBSTR(?superStrVal, 1, 19) = "https://schema.org/")
-        FILTER NOT EXISTS { ?term <https://schema.org/isPartOf> <http://attic.schema.org> .}
-    }
-    ORDER BY ?term  """
-        nri1_results = self.rdflib_data.query(nri1)
-        if len(nri1_results):
-            log.info("Invalid Super-Property errors!!!\n")
-            for row in nri1_results:
-                log.info(
-                    "Term '%s' has nonexistent super-property: '%s'"
-                    % (row["term"], row["super"])
-                )
-        self.assertEqual(
-            len(nri1_results),
-            0,
-            "Properties with nonexistent SuperProperties. Found: %s"
-            % len(nri1_results),
-        )
+            BIND(STR(?super) AS ?superStrVal)
+            FILTER(STRLEN(?superStrVal) >= 19 && SUBSTR(?superStrVal, 1, 19) = "https://schema.org/")
+            FILTER NOT EXISTS { ?term <https://schema.org/isPartOf> <http://attic.schema.org> .}
+          }
+          ORDER BY ?term
+        """,
+        error_message="Property with non-existent SuperProperties",
+        row_pattern="Term '%(term)s' has nonexistent super-property: '%(super)s'")
 
     def test_selfReferencingInverse(self):
-        nri1 = """select ?term ?inverse where {
-       ?term rdf:type rdf:Property.
-       ?term <https://schema.org/inverseOf> ?inverse.
+        self.assertNoMatch("""
+          select ?term ?inverse where {
+            ?term rdf:type rdf:Property.
+            ?term <https://schema.org/inverseOf> ?inverse.
 
-       BIND(STR(?term) AS ?strVal)
-       FILTER(STRLEN(?strVal) >= 19 && SUBSTR(?strVal, 1, 19) = "https://schema.org/")
+            BIND(STR(?term) AS ?strVal)
+            FILTER(STRLEN(?strVal) >= 19 && SUBSTR(?strVal, 1, 19) = "https://schema.org/")
 
-       FILTER(str(?term) = str(?inverse))
-        FILTER NOT EXISTS { ?term <https://schema.org/isPartOf> <http://attic.schema.org> .}
-
-    }
-    ORDER BY ?term  """
-        nri1_results = self.rdflib_data.query(nri1)
-        if len(nri1_results):
-            log.info("Self referencing inverseOf errors!!!\n")
-            for row in nri1_results:
-                log.info("Term '%s' is defined as inverseOf self" % (row["term"]))
-        self.assertEqual(
-            len(nri1_results),
-            0,
-            "Types with self referencing inverseOf Found: %s" % len(nri1_results),
-        )
+            FILTER(str(?term) = str(?inverse))
+            FILTER NOT EXISTS { ?term <https://schema.org/isPartOf> <http://attic.schema.org> .}
+          }
+          ORDER BY ?term
+        """,
+        error_message="Types with self-referencing inverseOf",
+        row_pattern="Term '%(term)s' is defined as inverseOf self")
 
     def test_sameInverseAndSupercededByTarget(self):
-        nri1 = """select ?term ?inverse ?super where {
-       ?term rdf:type rdf:Property.
-       ?term <https://schema.org/inverseOf> ?inverse.
-       ?term <https://schema.org/supercededBy> ?super.
+        self.assertNoMatch("""
+          select ?term ?inverse ?super where {
+            ?term rdf:type rdf:Property.
+            ?term <https://schema.org/inverseOf> ?inverse.
+            ?term <https://schema.org/supercededBy> ?super.
 
-       BIND(STR(?term) AS ?strVal)
-       FILTER(STRLEN(?strVal) >= 18 && SUBSTR(?strVal, 1, 18) = "https://schema.org/")
+            BIND(STR(?term) AS ?strVal)
+            FILTER(STRLEN(?strVal) >= 18 && SUBSTR(?strVal, 1, 18) = "https://schema.org/")
 
-       FILTER(str(?inverse) = str(?super))
-        FILTER NOT EXISTS { ?term <https://schema.org/isPartOf> <http://attic.schema.org> .}
-
-    }
-    ORDER BY ?term  """
-        nri1_results = self.rdflib_data.query(nri1)
-        if len(nri1_results):
-            log.info("InverseOf supercededBy shared target errors!!!\n")
-            for row in nri1_results:
-                log.info(
-                    "Term '%s' defined ase inverseOf AND supercededBy %s"
-                    % (row["term"], row["inverse"])
-                )
-        self.assertEqual(
-            len(nri1_results),
-            0,
-            "Types with inverseOf supercededBy shared target Found: %s"
-            % len(nri1_results),
-        )
+            FILTER(str(?inverse) = str(?super))
+            FILTER NOT EXISTS { ?term <https://schema.org/isPartOf> <http://attic.schema.org> .}
+          }
+          ORDER BY ?term
+        """,
+        error_message="Types with inverseOf supercededBy shared target",
+        row_pattern="Term '%(term)s' defined ase inverseOf AND supercededBy %(inverse)s")
 
     def test_commentEndWithPeriod(self):
         """Validate that class and property RDF comments end with a punctuation."""
-        nri1 = """select ?term ?com where {
-       ?term rdfs:comment ?com.
+        self.assertNoMatch("""
+          select ?term ?com where {
+            ?term rdfs:comment ?com.
 
-       BIND(STR(?term) AS ?strVal)
-       FILTER(STRLEN(?strVal) >= 19 && SUBSTR(?strVal, 1, 19) = "https://schema.org/")
+            BIND(STR(?term) AS ?strVal)
+            FILTER(STRLEN(?strVal) >= 19 && SUBSTR(?strVal, 1, 19) = "https://schema.org/")
 
-       FILTER (!(regex(str(?com), '[\\\\.\\\\)\\\\?]\\\\s*$') || regex(str(?com), 'n\\\\* .*')))
-    }
-    ORDER BY ?term  """
-        nri1_results = tuple(map(str, self.rdflib_data.query(nri1)))
-        self.assertFalse(
-            nri1_results,
-            "Comment without ending '.', ')' or '?' Found: %s"
-            % "\n".join(nri1_results),
-        )
+            FILTER (!(regex(str(?com), '[\\\\.\\\\)\\\\?]\\\\s*$') || regex(str(?com), 'n\\\\* .*')))
+          }
+          ORDER BY ?term
+        """,
+        error_message="Comment without ending '.', ')' or '?' ")
 
     def test_typeLabelCase(self):
-        nri1 = """select ?term ?label where {
-       ?term rdf:type rdfs:Class.
-       ?term rdfs:label ?label.
+        self.assertNoMatch("""
+          select ?term ?label where {
+            ?term rdf:type rdfs:Class.
+            ?term rdfs:label ?label.
 
-       BIND(STR(?term) AS ?strVal)
-       FILTER(STRLEN(?strVal) >= 19 && SUBSTR(?strVal, 1, 19) = "https://schema.org/")
+            BIND(STR(?term) AS ?strVal)
+            FILTER(STRLEN(?strVal) >= 19 && SUBSTR(?strVal, 1, 19) = "https://schema.org/")
 
-       FILTER (!regex(str(?label), '^[0-9]*[A-Z].*'))
-    }
-    ORDER BY ?term  """
-        nri1_results = self.rdflib_data.query(nri1)
-        if len(nri1_results):
-            log.info("Type label [A-Z] errors!!!\n")
-            for row in nri1_results:
-                log.info(
-                    "Type '%s' has a label without upper case 1st character"
-                    % (row["term"])
-                )
-        self.assertEqual(
-            len(nri1_results),
-            0,
-            "Type label not [A-Z] 1st non-numeric char Found: %s" % len(nri1_results),
-        )
+            FILTER (!regex(str(?label), '^[0-9]*[A-Z].*'))
+          }
+          ORDER BY ?term
+        """,
+        error_message="Type label does not start with [A-Z] char")
 
     def test_propertyLabelCase(self):
-        nri1 = """select ?term ?label where {
-       ?term rdf:type rdf:Property.
-       ?term rdfs:label ?label.
+        self.assertNoMatch("""
+          select ?term ?label where {
+            ?term rdf:type rdf:Property.
+            ?term rdfs:label ?label.
 
-       BIND(STR(?term) AS ?strVal)
-       FILTER(STRLEN(?strVal) >= 19 && SUBSTR(?strVal, 1, 19) = "https://schema.org/")
+            BIND(STR(?term) AS ?strVal)
+            FILTER(STRLEN(?strVal) >= 19 && SUBSTR(?strVal, 1, 19) = "https://schema.org/")
 
-       FILTER (!regex(str(?label), '^[0-9]*[a-z].*'))
-    }
-    ORDER BY ?term  """
-        nri1_results = self.rdflib_data.query(nri1)
-        if len(nri1_results):
-            log.info("Property label [a-z] errors!!!\n")
-            for row in nri1_results:
-                log.info(
-                    "Property '%s' has a label without lower case 1st non-numeric character"
-                    % (row["term"])
-                )
-        self.assertEqual(
-            len(nri1_results),
-            0,
-            "Property label not [a-z] 1st char Found: %s" % len(nri1_results),
-        )
+            FILTER (!regex(str(?label), '^[0-9]*[a-z].*'))
+          }
+          ORDER BY ?term
+        """,
+        error_message="Property label not starting with [a-z] char")
 
     def test_superTypeInAttic(self):
-        nri1 = """select ?term ?super where {
-       {
-           ?term rdfs:subClassOf ?super.
-       }
-       UNION
-       {
-           ?term rdfs:subPropertyOf ?super.
-       }
-       ?super <https://schema.org/isPartOf> <http://attic.schema.org> .
-       FILTER NOT EXISTS { ?term <https://schema.org/isPartOf> <http://attic.schema.org> .}
-    }
-    ORDER BY ?term  """
-        nri1_results = self.rdflib_data.query(nri1)
-        if len(nri1_results):
-            log.info("Super-term in attic errors!!!\n")
-            for row in nri1_results:
-                log.info(
-                    "Term '%s' is sub-term of %s a term in attic"
-                    % (row["term"], row["super"])
-                )
-        self.assertEqual(
-            len(nri1_results), 0, "Super-term in attic  Found: %s" % len(nri1_results)
-        )
+        self.assertNoMatch("""
+          select ?term ?super where {
+            {
+              ?term rdfs:subClassOf ?super.
+            }
+            UNION
+            {
+              ?term rdfs:subPropertyOf ?super.
+            }
+            ?super <https://schema.org/isPartOf> <http://attic.schema.org> .
+            FILTER NOT EXISTS { ?term <https://schema.org/isPartOf> <http://attic.schema.org> .}
+          }
+          ORDER BY ?term
+        """,
+        error_message="Super-term in attic!",
+        row_pattern="Term '%(term)s' is sub-term of %(super)s a term in attic")
 
     def test_referenceTermInAttic(self):
-        nri1 = """select ?term ?rel ?ref where {
-       {
-           ?term <https://schema.org/domainIncludes> ?ref.
-           ?term ?rel ?ref.
-       }
-       UNION
-       {
-           ?term <https://schema.org/rangeIncludes> ?ref.
-           ?term ?rel ?ref.
-       }
-       UNION
-       {
-           ?term <https://schema.org/inverseOf> ?ref.
-           ?term ?rel ?ref.
-       }
-       UNION
-       {
-           ?term <https://schema.org/supercededBy> ?ref.
-           ?term ?rel ?ref.
-       }
-       ?ref <https://schema.org/isPartOf> <http://attic.schema.org> .
-       FILTER NOT EXISTS { ?term <https://schema.org/isPartOf> <http://attic.schema.org> .}
-    }
-    ORDER BY ?term  """
-        nri1_results = self.rdflib_data.query(nri1)
-        if len(nri1_results):
-            log.info("Reference to attic term errors!!!\n")
-            for row in nri1_results:
-                log.info(
-                    "Term '%s' makes a %s reference to %s a term in attic"
-                    % (row["term"], row["rel"], row["ref"])
-                )
-        self.assertEqual(
-            len(nri1_results),
-            0,
-            "Reference to attic term  Found: %s" % len(nri1_results),
-        )
+        self.assertNoMatch("""
+          select ?term ?rel ?ref where {
+            {
+                ?term <https://schema.org/domainIncludes> ?ref.
+                ?term ?rel ?ref.
+            }
+            UNION
+            {
+                ?term <https://schema.org/rangeIncludes> ?ref.
+                ?term ?rel ?ref.
+            }
+            UNION
+            {
+                ?term <https://schema.org/inverseOf> ?ref.
+                ?term ?rel ?ref.
+            }
+            UNION
+            {
+                ?term <https://schema.org/supercededBy> ?ref.
+                ?term ?rel ?ref.
+            }
+            ?ref <https://schema.org/isPartOf> <http://attic.schema.org> .
+            FILTER NOT EXISTS { ?term <https://schema.org/isPartOf> <http://attic.schema.org> .}
+          }
+          ORDER BY ?term
+        """,
+        error_message="Reference to attic term!",
+        row_pattern="Term '%(term)s' makes a %(rel)s reference to %(ref)s, a term in attic")
 
     def test_termIn2PlusExtensions(self):
-        nri1 = """select ?term (count(?part) as ?count) where {
-        ?term <https://schema.org/isPartOf> ?part.
-    }
-    GROUP BY ?term
-    HAVING (count(?part) > 1)
-    ORDER BY ?term
-     """
-        nri1_results = self.rdflib_data.query(nri1)
-        if len(nri1_results):
-            log.info("Term in +1 extensions errors!!!\n")
-            for row in nri1_results:
-                log.info(
-                    "Term '%s' isPartOf %s extensions" % (row["term"], row["count"])
-                )
-        self.assertEqual(
-            len(nri1_results), 0, "Term in +1 extensions  Found: %s" % len(nri1_results)
-        )
+        self.assertNoMatch("""
+          select ?term (count(?part) as ?count) where {
+            ?term <https://schema.org/isPartOf> ?part.
+          }
+          GROUP BY ?term
+          HAVING (count(?part) > 1)
+          ORDER BY ?term
+        """,
+        error_message="Term partOf multiple extensions",
+        row_pattern="Term %(term)s isPartOf %(count)s extensions")
 
-    def test_termNothttps(self):
-        nri1 = """select distinct ?term where {
-      ?term ?p ?o.
-      FILTER strstarts(str(?term),"http://schema.org")
-    }
-    ORDER BY ?term
-     """
-        nri1_results = self.rdflib_data.query(nri1)
-        if len(nri1_results):
-            log.info("Term defined as http errors!!!\n")
-            for row in nri1_results:
-                log.info("Term '%s' is defined as http " % (row["term"]))
-        self.assertEqual(
-            len(nri1_results), 0, "Term defined as http  Found: %s" % len(nri1_results)
-        )
+    def test_termIsHttps(self):
+        self.assertNoMatch("""
+          select distinct ?term where {
+            ?term ?p ?o.
+            FILTER strstarts(str(?term),"http://schema.org")
+          }
+          ORDER BY ?term
+        """,
+        error_message="Term defined as http instead of https")
 
-    def test_targetNothttps(self):
-        nri1 = """prefix rdfs: <http://www.w3.org/2000/01/rdf-schema#>
-    prefix schema: <https://schema.org/>
-    select ?term ?target where {
+    def test_targetNotHttps(self):
+        self.assertNoMatch("""
+          prefix rdfs: <http://www.w3.org/2000/01/rdf-schema#>
+          prefix schema: <https://schema.org/>
+          select ?term ?target where {
 
-      ?term schema:domainIncludes |
-            schema:rangeIncludes |
-            rdfs:subClassOf |
-            rdfs:subPropertyOf |
-            schema:supercededBy |
-            schema:inverseOf ?target.
-      filter strstarts(str(?target),"http://schema.org")
-    }
-    ORDER BY ?term
-     """
-        nri1_results = self.rdflib_data.query(nri1)
-        if len(nri1_results):
-            log.info("Target defined as https errors!!!\n")
-            for row in nri1_results:
-                log.info(
-                    "Term '%s' references term %s  as https "
-                    % (row["term"], row["target"])
-                )
-        self.assertEqual(
-            len(nri1_results), 0, "Term defined as https  Found: %s" % len(nri1_results)
-        )
+            ?term schema:domainIncludes |
+                  schema:rangeIncludes |
+                  rdfs:subClassOf |
+                  rdfs:subPropertyOf |
+                  schema:supercededBy |
+                  schema:inverseOf ?target.
+            filter strstarts(str(?target),"http://schema.org")
+          }
+          ORDER BY ?term
+        """,
+        error_message="Term not defined as https://",
+        row_pattern="Term '%(term)s' references term %(target)s as https")
 
     def test_isPartOf(self):
-        nri1 = """prefix rdfs: <http://www.w3.org/2000/01/rdf-schema#>
-    prefix schema: <https://schema.org/>
-    select ?term  ?partof where {
-      ?term schema:isPartOf ?partof .
-      MINUS{
-        ?term schema:isPartOf <https://attic.schema.org>
-      }
-      MINUS{
-        ?term schema:isPartOf <https://auto.schema.org>
-      }
-      MINUS{
-        ?term schema:isPartOf <https://bib.schema.org>
-      }
-      MINUS{
-        ?term schema:isPartOf <https://health-lifesci.schema.org>
-      }
-      MINUS{
-        ?term schema:isPartOf <https://meta.schema.org>
-      }
-      MINUS{
-        ?term schema:isPartOf <https://pending.schema.org>
-      }
-    }
-    ORDER BY ?term
-      """
-        nri1_results = self.rdflib_data.query(nri1)
-        if len(nri1_results):
-            log.info("Invalid isPartOf value errors!!!\n")
-            for row in nri1_results:
-                log.info(
-                    "Term '%s' has invalid isPartOf value '%s'"
-                    % (row["term"], row["partof"])
-                )
-        self.assertEqual(
-            len(nri1_results),
-            0,
-            "Invalid isPartOf value errors  Found: %s" % len(nri1_results),
-        )
+        self.assertNoMatch("""
+          prefix rdfs: <http://www.w3.org/2000/01/rdf-schema#>
+          prefix schema: <https://schema.org/>
+          select ?term  ?partof where {
+            ?term schema:isPartOf ?partof .
+            MINUS{
+              ?term schema:isPartOf <https://attic.schema.org>
+            }
+            MINUS{
+              ?term schema:isPartOf <https://auto.schema.org>
+            }
+            MINUS{
+              ?term schema:isPartOf <https://bib.schema.org>
+            }
+            MINUS{
+              ?term schema:isPartOf <https://health-lifesci.schema.org>
+            }
+            MINUS{
+              ?term schema:isPartOf <https://meta.schema.org>
+            }
+            MINUS{
+              ?term schema:isPartOf <https://pending.schema.org>
+            }
+          }
+          ORDER BY ?term
+        """,
+        error_message="Invalid isPartOf value errors",
+        row_pattern="Term '%(term)s' has invalid isPartOf value '%(partof)s'")
 
     @unittest.expectedFailure
     def test_EnumerationWithoutEnums(self):
-        nri1 = """select ?term where {
-        ?term a rdfs:subClassOf+ <https://schema.org/Enumeration> .
-        FILTER NOT EXISTS { ?enum a ?term. }
-        FILTER NOT EXISTS { ?term <https://schema.org/isPartOf> <http://attic.schema.org> .}
-    }
-    ORDER BY ?term  """
-        nri1_results = self.rdflib_data.query(nri1)
-        if len(nri1_results):
-            log.info("Enumeration Type without Enumeration value(s) errors!!!\n")
-            for row in nri1_results:
-                log.info(
-                    "Enumeration Type '%s' has no matching enum values" % (row["term"])
-                )
-        self.assertEqual(
-            len(nri1_results),
-            0,
-            "Enumeration Type without Enumeration value(s)    Found: %s"
-            % len(nri1_results),
-        )
+        self.assertNoMatch("""
+          select ?term where {
+              ?term a rdfs:subClassOf+ <https://schema.org/Enumeration> .
+              FILTER NOT EXISTS { ?enum a ?term. }
+              FILTER NOT EXISTS { ?term <https://schema.org/isPartOf> <http://attic.schema.org> .}
+          }
+          ORDER BY ?term
+        """,
+        error_message="Enumeration Type without Enumeration value")
 
-
-def tearDownModule():
-    global warnings
-    if len(warnings) > 0:
-        log.info("\nWarnings (%s):\n" % len(warnings))
-    for warn in warnings:
-        log.info("%s" % warn)
 
 
 # TODO: Unwritten tests (from basics; easier here?)

--- a/software/tests/test_graphs.py
+++ b/software/tests/test_graphs.py
@@ -57,13 +57,14 @@ class SDOGraphSetupTestCase(unittest.TestCase):
                       separator: str = " => ", row_separator: str = "\n\t") -> str:
         """Formatting results to make a human-readable list in one step."""
         def formatLines():
+            yield f"Found {len(results)} item{'' if len(results)==1 else 's'}:"
             for row in results:
                 if pattern:
                     yield pattern % row
                 else:
                     yield separator.join([row[key] for key in varnames or row.keys()])
 
-        return row_separator + row_separator.join(formatLines())
+        return row_separator.join(formatLines())
 
 
     def assertNoMatch(self, results: typing.Union[str, list[dict]],
@@ -73,7 +74,7 @@ class SDOGraphSetupTestCase(unittest.TestCase):
             results = self.getResults(results)
         self.assertEqual(
             len(results), 0,
-            f"{error_message}! Found {len(results)}: {self.formatResults(results, pattern=row_pattern)}")
+            f"{error_message}! {self.formatResults(results, pattern=row_pattern)}")
 
 
     # SPARQLResult http://rdflib.readthedocs.org/en/latest/apidocs/rdflib.plugins.sparql.html

--- a/software/tests/test_graphs.py
+++ b/software/tests/test_graphs.py
@@ -52,19 +52,18 @@ class SDOGraphSetupTestCase(unittest.TestCase):
                       for key in varnames or row.asdict().keys()])
                 for row in results]
 
-    @classmethod
-    def formatResults(cls, results, pattern: str = "", varnames: tuple[str] = (),
-                      sep: str = " => ", rowsep: str = "\n\t") -> str:
+    @staticmethod
+    def formatResults(results, pattern: str = "", varnames: tuple[str] = (),
+                      separator: str = " => ", row_separator: str = "\n\t") -> str:
         """Formatting results to make a human-readable list in one step."""
-        lines = []
-        if pattern:
-            lines = [pattern % row for row in results]
-        else:
-            lines = [sep.join([row[key]
-                            for key in varnames or row.keys()])
-                     for row in results]
+        def formatLines():
+            for row in results:
+                if pattern:
+                    yield pattern % row
+                else:
+                    yield separator.join([row[key] for key in varnames or row.keys()])
 
-        return rowsep + rowsep.join(lines)
+        return row_separator + row_separator.join(formatLines())
 
 
     def assertNoMatch(self, results: typing.Union[str, list[dict]],

--- a/software/tests/test_graphs.py
+++ b/software/tests/test_graphs.py
@@ -104,14 +104,14 @@ class SDOGraphSetupTestCase(unittest.TestCase):
         """,
         error_message="inverseOf same property as itself")
 
-    def test_noSelfSupercededBy(self):
+    def test_noSelfSupersededBy(self):
         self.assertNoMatch("""
             select ?x ?y where {
-                ?x <https://schema.org/supercededBy> ?y .
+                ?x <https://schema.org/supersededBy> ?y .
                 filter (?x = ?y) .
             }
         """,
-        error_message="Type should not be supercededBy itself")
+        error_message="Type should not be supersededBy itself")
 
     @unittest.expectedFailure  # autos
     def test_needlessDomainIncludes(self):
@@ -246,23 +246,23 @@ class SDOGraphSetupTestCase(unittest.TestCase):
             error_message="Types with nonexistent SuperTypes",
             row_pattern="Term '%(term)s' has nonexistent supertype: '%(super)s'")
 
-    @unittest.expectedFailure
     def test_propsWithoutDomain(self):
         self.assertNoMatch("""
             select ?term where {
                 ?term a rdf:Property.
                 FILTER NOT EXISTS { ?term <https://schema.org/domainIncludes> ?o .}
+                FILTER NOT EXISTS { ?term <https://schema.org/supersededBy> ?o .}
             }
         """,
         error_message="Property without domain extensions",
         row_pattern="Term '%(term)s' has no domainIncludes values")
 
-    @unittest.expectedFailure
     def test_propsWithoutRange(self):
         self.assertNoMatch("""
            select ?term where {
              ?term a rdf:Property.
              FILTER NOT EXISTS { ?term <https://schema.org/rangeIncludes> ?o .}
+             FILTER NOT EXISTS { ?term <https://schema.org/supersededBy> ?o .}
            }
         """,
         error_message="Property without range extensions",
@@ -304,12 +304,12 @@ class SDOGraphSetupTestCase(unittest.TestCase):
         error_message="Types with self-referencing inverseOf",
         row_pattern="Term '%(term)s' is defined as inverseOf self")
 
-    def test_sameInverseAndSupercededByTarget(self):
+    def test_sameInverseAndSupersededByTarget(self):
         self.assertNoMatch("""
           select ?term ?inverse ?super where {
             ?term rdf:type rdf:Property.
             ?term <https://schema.org/inverseOf> ?inverse.
-            ?term <https://schema.org/supercededBy> ?super.
+            ?term <https://schema.org/supersededBy> ?super.
 
             BIND(STR(?term) AS ?strVal)
             FILTER(STRLEN(?strVal) >= 18 && SUBSTR(?strVal, 1, 18) = "https://schema.org/")
@@ -319,8 +319,8 @@ class SDOGraphSetupTestCase(unittest.TestCase):
           }
           ORDER BY ?term
         """,
-        error_message="Types with inverseOf supercededBy shared target",
-        row_pattern="Term '%(term)s' defined ase inverseOf AND supercededBy %(inverse)s")
+        error_message="Types with inverseOf supersededBy shared target",
+        row_pattern="Term '%(term)s' defined ase inverseOf AND supersededBy %(inverse)s")
 
     def test_commentEndWithPeriod(self):
         """Validate that class and property RDF comments end with a punctuation."""
@@ -404,7 +404,7 @@ class SDOGraphSetupTestCase(unittest.TestCase):
             }
             UNION
             {
-                ?term <https://schema.org/supercededBy> ?ref.
+                ?term <https://schema.org/supersededBy> ?ref.
                 ?term ?rel ?ref.
             }
             ?ref <https://schema.org/isPartOf> <http://attic.schema.org> .
@@ -447,7 +447,7 @@ class SDOGraphSetupTestCase(unittest.TestCase):
                   schema:rangeIncludes |
                   rdfs:subClassOf |
                   rdfs:subPropertyOf |
-                  schema:supercededBy |
+                  schema:supersededBy |
                   schema:inverseOf ?target.
             filter strstarts(str(?target),"http://schema.org")
           }


### PR DESCRIPTION
This refactors and simplifies the graph unit tests and exposes mroe useful information in the failure message.
It also reformats the file, exposing two tests that were hidden because of indentation. 
The tests failed, so they were fixes too.