### PR TITLE
Render the search box greyed out when in development mode.

### DIFF
--- a/docs/devnotehide.css
+++ b/docs/devnotehide.css
@@ -1,5 +1,6 @@
+/* shown in production mode */
 .devnote {
   display: none;
 }
-
-
+.live-only {
+}

--- a/docs/devnoteshow.css
+++ b/docs/devnoteshow.css
@@ -1,3 +1,11 @@
+/* shown in development mode */
 .devnote {
   display: block;
+}
+.live-only {
+  pointer-events: none;
+  opacity: 0.2;
+}
+.live-only svg {
+  display: none;
 }

--- a/docs/schemaorg.css
+++ b/docs/schemaorg.css
@@ -435,7 +435,7 @@ a.ext.ext-attic:hover {
 .devnote {
   padding: 1rem 2rem;
   font-size: 0.9rem;
-  background-color:#E5EEFD;
+  background-color:#EEE500;
   color: #000;
   text-align: center;
 }
@@ -508,7 +508,7 @@ a.ext.ext-attic:hover {
     display: flex;
     align-items: center;
   }
-  
+
   .header-block {
     height: 6rem;
   }
@@ -628,9 +628,6 @@ a.ext.ext-attic:hover {
   fill: #212529;
 }
 
-.devnote2 {
-  display: none;
-}
 #navicon2 {
     display: none;
 }

--- a/docs/schemaorg.css
+++ b/docs/schemaorg.css
@@ -435,9 +435,13 @@ a.ext.ext-attic:hover {
 .devnote {
   padding: 1rem 2rem;
   font-size: 0.9rem;
-  background-color:#EEE500;
+  background-color: yellow;
   color: #000;
   text-align: center;
+
+  border: 10px solid;
+  border-image: repeating-linear-gradient(45deg, yellow 0px, yellow 10px, black 10px, black 20px) 15;
+
 }
 
 .pendnote {

--- a/templates/static-doc-inserts/sdi-pagehead.html
+++ b/templates/static-doc-inserts/sdi-pagehead.html
@@ -31,7 +31,7 @@
         </div> <!-- selectionbar -->
       </div>
       <div  class="header-block header-block-right mobnav" id="pagehead-right">
-        <div id="cse-search-form2">
+        <div id="cse-search-form2" class="live-only">
             <div class="gcse-searchbox-only" data-resultsUrl="/docs/search_results.html"></div>
         </div>
       </div>
@@ -56,5 +56,3 @@
   </div>
   <div class="header-bottom"></div>
 </div>
-  
- 


### PR DESCRIPTION
Otherwise, using it will simply get the user to the live schema.org site, which is confusing when trying to debug the schema in development.