### PR TITLE
Remove redundant attributes in SdoTermSource

### DIFF
--- a/software/SchemaTerms/sdoterm.py
+++ b/software/SchemaTerms/sdoterm.py
@@ -231,8 +231,8 @@ class SdoTerm(object):
 class SdoType(SdoTerm):
     """Term that defines a schema.org type"""
 
-    def __init__(self, Id: str, uri: str, label: str):
-        SdoTerm.__init__(self, SdoTermType.TYPE, Id, uri, label)
+    def __init__(self, term_id: str, uri: str, label: str):
+        SdoTerm.__init__(self, SdoTermType.TYPE, term_id, uri, label)
 
         self._properties = SdoTermSequence()
         self._allproperties = SdoTermSequence()
@@ -254,8 +254,8 @@ class SdoType(SdoTerm):
 class SdoProperty(SdoTerm):
     """Term that defines a propery of another type."""
 
-    def __init__(self, Id: str, uri: str, label: str):
-        SdoTerm.__init__(self, SdoTermType.PROPERTY, Id, uri, label)
+    def __init__(self, term_id: str, uri: str, label: str):
+        SdoTerm.__init__(self, SdoTermType.PROPERTY, term_id, uri, label)
         self._domainIncludes = SdoTermSequence()
         self._rangeIncludes = SdoTermSequence()
         self._inverse = SdoTermOrId()
@@ -277,8 +277,8 @@ class SdoProperty(SdoTerm):
 class SdoDataType(SdoTerm):
     """Term that defines one of the basic data-types: Boolean, Date, Text, Number etc."""
 
-    def __init__(self, Id: str, uri: str, label: str):
-        SdoTerm.__init__(self, SdoTermType.DATATYPE, Id, uri, label)
+    def __init__(self, term_id: str, uri: str, label: str):
+        SdoTerm.__init__(self, SdoTermType.DATATYPE, term_id, uri, label)
 
         self._properties = SdoTermSequence()
         self._allproperties = SdoTermSequence()
@@ -300,8 +300,8 @@ class SdoDataType(SdoTerm):
 class SdoEnumeration(SdoTerm):
     """Term that defines a schema.org enumeration."""
 
-    def __init__(self, Id: str, uri: str, label: str):
-        SdoTerm.__init__(self, SdoTermType.ENUMERATION, Id, uri, label)
+    def __init__(self, term_id: str, uri: str, label: str):
+        SdoTerm.__init__(self, SdoTermType.ENUMERATION, term_id, uri, label)
         self._properties = SdoTermSequence()
         self._allproperties = SdoTermSequence()
         self._expectedTypeFor = SdoTermSequence()
@@ -327,8 +327,8 @@ class SdoEnumeration(SdoTerm):
 class SdoEnumerationvalue(SdoTerm):
     """Term that defines a value within a schema.org enumeration."""
 
-    def __init__(self, Id: str, uri: str, label: str):
-        SdoTerm.__init__(self, SdoTermType.ENUMERATIONVALUE, Id, uri, label)
+    def __init__(self, term_id: str, uri: str, label: str):
+        SdoTerm.__init__(self, SdoTermType.ENUMERATIONVALUE, term_id, uri, label)
         self._enumerationParent = SdoTermOrId()
 
     @property
@@ -337,5 +337,5 @@ class SdoEnumerationvalue(SdoTerm):
 
 
 class SdoReference(SdoTerm):
-    def __init__(self, Id: str, uri: str, label: str):
-        SdoTerm.__init__(self, SdoTermType.REFERENCE, Id, uri, label)
+    def __init__(self, term_id: str, uri: str, label: str):
+        SdoTerm.__init__(self, SdoTermType.REFERENCE, term_id, uri, label)

--- a/software/tests/test_buildtermpages.py
+++ b/software/tests/test_buildtermpages.py
@@ -50,7 +50,7 @@ class TestBuildTermPages(unittest.TestCase):
 
     def testTemplateRenderNoExample(self):
         term = sdoterm.SdoType(
-            Id="42",
+            term_id="42",
             uri="http://example.com/whatchicallit",
             label="whatchicallit",
         )
@@ -72,7 +72,7 @@ class TestBuildTermPages(unittest.TestCase):
         ]
         json = "[42]"
         term = sdoterm.SdoType(
-            Id="42",
+            term_id="42",
             uri="http://example.com/thingamabob",
             label="Thingamabob",
         )

--- a/software/tests/test_sdojsonldcontext.py
+++ b/software/tests/test_sdojsonldcontext.py
@@ -42,7 +42,7 @@ class SdoJsonLdContextTest(unittest.TestCase):
         self.maxDiff = None
         mock_id = "1234"
         mock_property = sdoterm.SdoProperty(
-            Id=mock_id, uri="http://schema.org/thang", label="thang"
+            term_id=mock_id, uri="http://schema.org/thang", label="thang"
         )
         mock_property.domainIncludes.setIds(["Thing"])
         mock_property.rangeIncludes.setIds(["Date", "URL", "Thing"])
@@ -63,7 +63,7 @@ class SdoJsonLdContextTest(unittest.TestCase):
         self.maxDiff = None
         mock_id = "1234"
         mock_type = sdoterm.SdoDataType(
-            Id=mock_id, uri="http://schema.org/Fnubl", label="fnubl"
+            term_id=mock_id, uri="http://schema.org/Fnubl", label="fnubl"
         )
         mock_type.properties.setIds(["thang"])
         mock_type.expectedTypeFor.setIds(["Thing"])
@@ -82,7 +82,7 @@ class SdoJsonLdContextTest(unittest.TestCase):
         self.maxDiff = None
         mock_id = "1234"
         mock_enumeration = sdoterm.SdoEnumeration(
-            Id=mock_id, uri="http://schema.org/Grabl", label="grabl"
+            term_id=mock_id, uri="http://schema.org/Grabl", label="grabl"
         )
         mock_enumeration.expectedTypeFor.setIds(["Thing"])
         mock_getAllTerms.return_value = [mock_enumeration]
@@ -100,7 +100,7 @@ class SdoJsonLdContextTest(unittest.TestCase):
         self.maxDiff = None
         mock_id = "1234"
         mock_enumeration = sdoterm.SdoEnumerationvalue(
-            Id=mock_id, uri="http://schema.org/Bobl", label="bobl"
+            term_id=mock_id, uri="http://schema.org/Bobl", label="bobl"
         )
         mock_getAllTerms.return_value = [mock_enumeration]
         json_data = sdojsonldcontext.createcontext()
@@ -120,7 +120,7 @@ class SdoJsonLdContextTest(unittest.TestCase):
         self.maxDiff = None
         mock_id = "1234"
         mock_reference = sdoterm.SdoReference(
-            Id=mock_id, uri="http://schema.org/Bobl", label="bobl"
+            term_id=mock_id, uri="http://schema.org/Bobl", label="bobl"
         )
         mock_getAllTerms.return_value = [mock_reference]
         json_data = sdojsonldcontext.createcontext()
@@ -136,15 +136,15 @@ class SdoJsonLdContextTest(unittest.TestCase):
     def test_createcontextMultiple(self, mock_getAllTerms):
         self.maxDiff = None
         mock_property = sdoterm.SdoProperty(
-            Id="aa", uri="http://schema.org/a", label="a"
+            term_id="aa", uri="http://schema.org/a", label="a"
         )
         mock_property.domainIncludes.setIds(["Thing"])
         mock_property.rangeIncludes.setIds(["Date", "URL", "Thing"])
         mock_enumeration = sdoterm.SdoEnumeration(
-            Id="bb", uri="http://schema.org/b", label="b"
+            term_id="bb", uri="http://schema.org/b", label="b"
         )
         mock_enumeration_value = sdoterm.SdoEnumerationvalue(
-            Id="cc", uri="http://schema.org/c", label="c"
+            term_id="cc", uri="http://schema.org/c", label="c"
         )
         mock_getAllTerms.return_value = [
             mock_property,

--- a/software/tests/test_sdoterm.py
+++ b/software/tests/test_sdoterm.py
@@ -32,7 +32,7 @@ class SdoTermOrIdTest(unittest.TestCase):
         self.assertRaises(sdoterm.UnexpandedTermError, lambda : id_only.term)
 
     def testTerm(self):
-        term = sdoterm.SdoReference(Id='testing2', uri='http://example.com/testing2', label='')
+        term = sdoterm.SdoReference(term_id='testing2', uri='http://example.com/testing2', label='')
         with_term = sdoterm.SdoTermOrId(term=term)
         self.assertTrue(with_term)
         self.assertTrue(with_term.expanded)
@@ -60,7 +60,7 @@ class SdoTermSequenceTest(unittest.TestCase):
 
     def testExpanded(self):
         expanded = sdoterm.SdoTermSequence()
-        term = sdoterm.SdoReference(Id='testing4', uri='http://example.com/testing4', label='test')
+        term = sdoterm.SdoReference(term_id='testing4', uri='http://example.com/testing4', label='test')
         expanded.setTerms([term])
         self.assertTrue(expanded)
         self.assertTrue(expanded.expanded)


### PR DESCRIPTION
Removed the `id`, `uri` and `enum` fields of the SdoTermSource objects as these are not needed.
The `id` and `uri` fields are copies of what is present in the relevant fields of the `termdesc` field. 
The `enum` field was used to cache a value that is only used once, in the constructor. 
Change the `isEnumeration`  to be a class method that takes the `term_id` as parameter, and marked it protected. 