### PR TITLE
Schema changes for #3617 on Shipping Details representation.

### DIFF
--- a/data/ext/pending/issue-3617.ttl
+++ b/data/ext/pending/issue-3617.ttl
@@ -1,0 +1,193 @@
+@prefix : <https://schema.org/> .
+@prefix rdf: <http://www.w3.org/1999/02/22-rdf-syntax-ns#> .
+@prefix rdfs: <http://www.w3.org/2000/01/rdf-schema#> .
+@prefix xml: <http://www.w3.org/XML/1998/namespace> .
+@prefix xsd: <http://www.w3.org/2001/XMLSchema#> .
+@prefix dct: <http://purl.org/dc/terms/> .
+
+# ╔════════════════════════════════════════════════════════╗
+# ║  Amend OfferShippingDetails                            ║
+# ╚════════════════════════════════════════════════════════╝
+:weight a rdf:Property ;
+    :domainIncludes :OfferShippingDetails ;
+    :rangeIncludes :Mass .
+
+:shippingService a rdf::Property ;
+    :domainIncludes :OfferShippingDetails ;
+    :rangeIncludes :ShippingService .
+
+:shippingSettingsLink a rdf:Property ;
+    :isPartOf <https://attic.schema.org> .
+
+:shippingLabel a rdf:Property ;
+    :isPartOf <https://attic.schema.org> .
+
+:transitTimeLabel a rdf:Property ;
+    :isPartOf <https://attic.schema.org> .
+
+# ╔════════════════════════════════════════════════════════╗
+# ║  Amending Organization                                 ║
+# ╚════════════════════════════════════════════════════════╝
+:shippingService a rdf:Property ;
+    rdfs:label "shippingService" ;
+    :domainIncludes :Organization ;
+    :rangeIncludes :ShippingService ;
+    :isPartOf <https://pending.schema.org> ;
+    :source <https://github.com/schemaorg/schemaorg/issues/3617> ;
+    rdfs:comment "Specification of a shipping services offered by the organization." .
+
+# ╔════════════════════════════════════════════════════════╗
+# ║  Delete DeliveryTimeSettings                           ║
+# ╚════════════════════════════════════════════════════════╝
+:DeliveryTimeSettings a rdfs:Class ;
+    :supersededBy :ShippingService .
+
+# ╔════════════════════════════════════════════════════════╗
+# ║  Amend ShippingDeliveryTime                            ║
+# ╚════════════════════════════════════════════════════════╝
+:transitDays a rdf:Property ;
+    rdfs:label "transitDays" ;
+    :domainIncludes :ShippingDeliveryTime ;
+    :isPartOf <https://pending.schema.org> ;
+    :rangeIncludes :OpeningHoursSpecification ;
+    :source <https://github.com/schemaorg/schemaorg/issues/3617> ;
+    rdfs:comment "Days of the week when transporters typically operate, indicated via opening hours markup." .
+
+# ╔════════════════════════════════════════════════════════╗
+# ║  Amending ShippingRateSettings                         ║
+# ╚════════════════════════════════════════════════════════╝
+:orderPercentage a rdf:Property ;
+    rdfs:label "orderPercentage" ;
+    :domainIncludes :ShippingRateSettings ;
+    :rangeIncludes :Number ;
+    :source <https://github.com/schemaorg/schemaorg/issues/3617> ;
+    :isPartOf <https://pending.schema.org> ;
+    rdfs:comment "Fraction of the value of the order that is charged as shipping cost." .
+
+:weightPercentage a rdf:Property ;
+    rdfs:label "weightPercentage" ;
+    :domainIncludes :ShippingRateSettings ;
+    :rangeIncludes :Number ;
+    :source <https://github.com/schemaorg/schemaorg/issues/3617> ;
+    :isPartOf <https://pending.schema.org> ;
+    rdfs:comment "Fraction of the weight that is used to compute the shipping price." .
+
+:orderValue a rdf:Property ;
+    rdfs:label "orderValue" ;
+    :domainIncludes :ShippingRateSettings ;
+    :rangeIncludes :MonetaryAmount ;
+    :source <https://github.com/schemaorg/schemaorg/issues/3617> ;
+    :isPartOf <https://pending.schema.org> ;
+    rdfs:comment "Minimum and maximum order value for which these shipping rates are valid." .
+
+# ╔════════════════════════════════════════════════════════╗
+# ║  Adding ValidityPeriod                                 ║
+# ╚════════════════════════════════════════════════════════╝
+:ValidityPeriod a rdfs:Class ;
+    rdfs:label "ValidityPeriod" ;
+    rdfs:subClassOf :StructuredValue ;
+    :isPartOf <https://pending.schema.org> ;
+    :source <https://github.com/schemaorg/schemaorg/issues/3617> ;
+    rdfs:comment "A ValidityPeriod represents a date-specified duration during which the valididty holds." .
+
+:periodStart a rdf:Property ;
+    rdfs:label "periodStart" ;
+    :domainIncludes :ValidityPeriod ;
+    :rangeIncludes :Date, :DateTime ;
+    :isPartOf <https://pending.schema.org> ;
+    :source <https://github.com/schemaorg/schemaorg/issues/3617> ;
+    rdfs:comment "Start point in time of the validity period." .
+
+:periodEnd a rdf:Property ;
+    rdfs:label "periodEnd" ;
+    :domainIncludes :ValidityPeriod ;
+    :rangeIncludes :Date, :DateTime ;
+    :isPartOf <https://pending.schema.org> ;
+    :source <https://github.com/schemaorg/schemaorg/issues/3617> ;
+    rdfs:comment "End point in time of the validity period." .
+
+# ╔════════════════════════════════════════════════════════╗
+# ║  Adding ShippingService                                ║
+# ╚════════════════════════════════════════════════════════╝
+:ShippingService a rdfs:Class ;
+    rdfs:label "ShippingService" ;
+    rdfs:subClassOf :StructuredValue ;
+    :isPartOf <https://pending.schema.org> ;
+    :source <https://github.com/schemaorg/schemaorg/issues/3617> ;
+    rdfs:comment "A ShippingService represents a set of contraints and information about the conditions of shipping a product. Such a service may apply to only a subset of the products being shipped, depending on aspects of the product like weight, size, price, destination, and others." .
+
+:shippingOrigin a rdf:Property ;
+    rdfs:label "shippingOrigin" ;
+    :domainIncludes :ShippingService;
+    :rangeIncludes :DefinedRegion ;
+    :source <htps://github.com/schemaorg/schemaorg/issues/3617> .
+
+:shippingDestination a rdf:Property ;
+    rdfs:label "shippingDestination" ;
+    :domainIncludes :ShippingService;
+    :rangeIncludes :DefinedRegion ;
+    :source <htps://github.com/schemaorg/schemaorg/issues/3617> .
+
+:deliveryTime a rdf:Property ;
+    rdfs:label "deliveryTime" ;
+    :domainIncludes :ShippingService;
+    :rangeIncludes :ShippingDeliveryTime ;
+    :source <htps://github.com/schemaorg/schemaorg/issues/3617> .
+
+:height a rdf:Property ;
+    rdfs:label "height" ;
+    :domainIncludes :ShippingService;
+    :rangeIncludes :QuantitativeValue ;
+    :isPartOf <https://pending.schema.org> ;
+    :source <htps://github.com/schemaorg/schemaorg/issues/3617> .
+
+:width a rdf:Property ;
+    rdfs:label "width" ;
+    :domainIncludes :ShippingService;
+    :rangeIncludes :QuantitativeValue ;
+    :isPartOf <https://pending.schema.org> ;
+    :source <htps://github.com/schemaorg/schemaorg/issues/3617> .
+
+:depth a rdf:Property ;
+    rdfs:label "depth" ;
+    :domainIncludes :ShippingService;
+    :rangeIncludes :QuantitativeValue ;
+    :isPartOf <https://pending.schema.org> ;
+    :source <htps://github.com/schemaorg/schemaorg/issues/3617> .
+
+:weight a rdf:Property ;
+    rdfs:label "weight" ;
+    :domainIncludes :ShippingService ;
+    :rangeIncludes :QuantitativeValue ;
+    :isPartOf <https://pending.schema.org> ;
+    :source <htps://github.com/schemaorg/schemaorg/issues/3617> .
+
+:numItems a rdf:Property ;
+    rdfs:label "numItems" ;
+    :domainIncludes :ShippingService ;
+    :rangeIncludes :QuantitativeValue ;
+    :isPartOf <https://pending.schema.org> ;
+    :source <htps://github.com/schemaorg/schemaorg/issues/3617> ;
+    rdfs:comment "Limits in the number of items being shipped for which this service is applicable." .
+
+:doesNotShip a rdf:Property ;
+    rdfs:label "doesNotShip" ;
+    :domainIncludes :ShippingService ;
+    :rangeIncludes :Boolean ;
+    :source <htps://github.com/schemaorg/schemaorg/issues/3617> .
+
+:shippingRate a rdf:Property ;
+    rdfs:label "shippingRate" ;
+    :domainIncludes :ShippingService,
+        :OfferShippingDetails,
+        :ShippingRateSettings ;
+    :rangeIncludes :MonetaryAmount, :ShippingRateSettings ;
+    :source <htps://github.com/schemaorg/schemaorg/issues/3617> .
+
+:seasonalOverride a rdf:Property ;
+    rdfs:label "seasonalOverride" ;
+    :domainIncludes :ShippingService ;
+    :rangeIncludes :ValidityPeriod ;
+    :isPartOf <https://pending.schema.org> ;
+    :source <htps://github.com/schemaorg/schemaorg/issues/3617> ;
+    rdfs:comment "Limited period during which this shipping service is valid." .


### PR DESCRIPTION
This changes the representation of shipping information according to issue #3617, with some properties moved to the attic.

See details in the [design doc](https://docs.google.com/document/d/1kTJJKnnWtnoJuUK0cmtDdPH3JLZILyfN6IXICXti4wQ/edit?resourcekey=0-BernNphrZhVov9lX7u2aNg&tab=t.0#heading=h.i4jlrvwq4to9).

The new structure can be navigated at: https://1-dot-schemadotorg1.ew.r.appspot.com/ShippingService
