### PR TITLE
Added sharding logic to the code that generates the term pages

### DIFF
--- a/software/util/pretty_logger.py
+++ b/software/util/pretty_logger.py
@@ -18,8 +18,11 @@ class PrettyLogFormatter(logging.Formatter):
         "ERROR": colorama.Fore.RED,
     }
 
-    def __init__(self, use_color=True):
-        logging.Formatter.__init__(self, fmt="%(levelname)s %(name)s: %(message)s")
+    def __init__(self, use_color=True, shard=None):
+        fmt = "%(levelname)s %(name)s: %(message)s"
+        if not shard is None:
+            fmt = "%(levelname)s (" + str(shard) + ") %(name)s: %(message)s"
+        logging.Formatter.__init__(self, fmt=fmt)
         self.use_color = use_color
 
     @classmethod
@@ -62,10 +65,12 @@ class BlockLog:
         self.message = self.message + " " + message
 
 
-def MakeRootLogPretty():
+def MakeRootLogPretty(shard=None):
     """Makes the root log pretty if stdandard output is a terminal."""
     handler = logging.StreamHandler(sys.stdout)
-    formatter = PrettyLogFormatter(use_color=os.isatty(sys.stdout.fileno()))
+    formatter = PrettyLogFormatter(
+        use_color=os.isatty(sys.stdout.fileno()), shard=shard
+    )
     handler.setFormatter(formatter)
 
     root_log = logging.getLogger()


### PR DESCRIPTION
The process of generating all the HTML pages is pretty CPU intensive and long (~14 minutes on my laptop).
In order to reduce this, I added logic to spawn one process per CPU.

This reduces the time to generate the pages to ~8 minutes. The increase is not linear as each process needs to load and setup the whole data-structure. 

Updated the logging classes to add the shard number to  the message, so you see which shard does what. 