### PR TITLE
Cleanup in the fileutils library

### DIFF
--- a/software/scripts/buildtermlist.py
+++ b/software/scripts/buildtermlist.py
@@ -17,6 +17,8 @@ import software
 
 import software.SchemaTerms.sdotermsource as sdotermsource
 import software.SchemaTerms.sdoterm as sdoterm
+import software.util.pretty_logger as pretty_logger
+
 
 log = logging.getLogger(__name__)
 
@@ -50,8 +52,8 @@ if __name__ == "__main__":
     parser.add_argument("-o", "--output", required=True, help="output file")
     args = parser.parse_args()
     filename = args.output
-    log.info("Writing term list to file %s", filename)
-    with open(filename, "w", encoding="utf-8") as handle:
-        for term in generateTerms(tags=args.tagtype):
-            handle.write(term)
-    log.info("Done")
+    with pretty_logger.BlockLog(
+        logger=log, message=f'Writing term list to file {filename}'):
+        with open(filename, "w", encoding="utf-8") as handle:
+            for term in generateTerms(tags=args.tagtype):
+                handle.write(term)

--- a/software/scripts/buildtermlist.py
+++ b/software/scripts/buildtermlist.py
@@ -53,7 +53,8 @@ if __name__ == "__main__":
     args = parser.parse_args()
     filename = args.output
     with pretty_logger.BlockLog(
-        logger=log, message=f'Writing term list to file {filename}'):
+        logger=log, message=f"Writing term list to file {filename}"
+    ):
         with open(filename, "w", encoding="utf-8") as handle:
             for term in generateTerms(tags=args.tagtype):
                 handle.write(term)

--- a/software/tests/test_buildfiles.py
+++ b/software/tests/test_buildfiles.py
@@ -4,12 +4,17 @@
 import os
 import sys
 import unittest
+import unittest.mock
+import tempfile
+import logging
 
 if not os.getcwd() in sys.path:
     sys.path.insert(1, os.getcwd())
 
 import software
 import software.util.buildfiles as buildfiles
+import software.util.fileutils as fileutils
+import software.util.schemaglobals as schemaglobals
 
 
 class TestBuildFiles(unittest.TestCase):
@@ -42,7 +47,18 @@ class TestBuildFiles(unittest.TestCase):
             buildfiles.uriwrap(['Person', 'Thing']),
             'https://schema.org/Person, https://schema.org/Thing')
 
+    @unittest.mock.patch('software.util.schemaglobals.getOutputDir')
+    def testWriteCsvOut(self, mock_output_dir):
+        with tempfile.TemporaryDirectory() as temp_dir:
+            mock_output_dir.return_value = temp_dir
+            buildfiles.writecsvout(
+                ftype='properties',
+                data=({'id': '123', 'value': 'Fnuble'}, {'id': '456', 'value': 'Blubrl'}),
+                fields=('id', 'value'),
+                selector=fileutils.FileSelector.CURRENT,
+                protocol='http', altprotocol='https')
 
 
 if __name__ == '__main__':
+    logging.basicConfig(level=logging.INFO)
     unittest.main()

--- a/software/tests/test_buildfiles.py
+++ b/software/tests/test_buildfiles.py
@@ -18,47 +18,59 @@ import software.util.schemaglobals as schemaglobals
 
 
 class TestBuildFiles(unittest.TestCase):
-
     def testProtocolSwapEmpty(self):
-        self.assertEqual(buildfiles.protocolSwap(
-            content='', protocol='http', altprotocol='https'),
-            '')
-        self.assertEqual(buildfiles.protocolSwap(
-            content='Defined in http://schema.org and http://bib.schema.org',
-            protocol='http', altprotocol='ftp'),
-            'Defined in ftp://schema.org and ftp://bib.schema.org')
+        self.assertEqual(
+            buildfiles.protocolSwap(content="", protocol="http", altprotocol="https"),
+            "",
+        )
+        self.assertEqual(
+            buildfiles.protocolSwap(
+                content="Defined in http://schema.org and http://bib.schema.org",
+                protocol="http",
+                altprotocol="ftp",
+            ),
+            "Defined in ftp://schema.org and ftp://bib.schema.org",
+        )
 
     def testProtocols(self):
-        self.assertEqual(sorted(buildfiles.protocols()), ['http', 'https'])
+        self.assertEqual(sorted(buildfiles.protocols()), ["http", "https"])
 
     def testArrayToStr(self):
-        self.assertEqual(buildfiles.array2str([]), '')
-        self.assertEqual(buildfiles.array2str(['one']), 'one')
-        self.assertEqual(buildfiles.array2str(['one', 'two', 'three']), 'one, two, three')
+        self.assertEqual(buildfiles.array2str([]), "")
+        self.assertEqual(buildfiles.array2str(["one"]), "one")
+        self.assertEqual(
+            buildfiles.array2str(["one", "two", "three"]), "one, two, three"
+        )
 
     def testUriWrap(self):
         self.assertEqual(
-            buildfiles.uriwrap('Credential'),
-            'https://schema.org/Credential')
+            buildfiles.uriwrap("Credential"), "https://schema.org/Credential"
+        )
         self.assertEqual(
-            buildfiles.uriwrap('https://example.com/Bogus'),
-            'https://example.com/Bogus')
+            buildfiles.uriwrap("https://example.com/Bogus"), "https://example.com/Bogus"
+        )
         self.assertEqual(
-            buildfiles.uriwrap(['Person', 'Thing']),
-            'https://schema.org/Person, https://schema.org/Thing')
+            buildfiles.uriwrap(["Person", "Thing"]),
+            "https://schema.org/Person, https://schema.org/Thing",
+        )
 
-    @unittest.mock.patch('software.util.schemaglobals.getOutputDir')
+    @unittest.mock.patch("software.util.schemaglobals.getOutputDir")
     def testWriteCsvOut(self, mock_output_dir):
         with tempfile.TemporaryDirectory() as temp_dir:
             mock_output_dir.return_value = temp_dir
             buildfiles.writecsvout(
-                ftype='properties',
-                data=({'id': '123', 'value': 'Fnuble'}, {'id': '456', 'value': 'Blubrl'}),
-                fields=('id', 'value'),
+                ftype="properties",
+                data=(
+                    {"id": "123", "value": "Fnuble"},
+                    {"id": "456", "value": "Blubrl"},
+                ),
+                fields=("id", "value"),
                 selector=fileutils.FileSelector.CURRENT,
-                protocol='http', altprotocol='https')
+                protocol="http",
+                altprotocol="https",
+            )
 
 
-if __name__ == '__main__':
+if __name__ == "__main__":
     logging.basicConfig(level=logging.INFO)
     unittest.main()

--- a/software/tests/test_fileutils.py
+++ b/software/tests/test_fileutils.py
@@ -13,24 +13,31 @@ if not os.getcwd() in sys.path:
 import software
 import software.util.fileutils as fileutils
 
+
 class FileUtilsTest(unittest.TestCase):
-
-
     def test_checkFilePath(self):
         with tempfile.TemporaryDirectory() as tmp_dir:
             fileutils.checkFilePath(tmp_dir)
 
     def test_ensureAbsolutePath(self):
         with tempfile.TemporaryDirectory() as tmp_dir:
-            path = fileutils.ensureAbsolutePath(output_dir=tmp_dir, relative_path='fnord/fnuble')
-            self.assertEqual(os.path.basename(path), 'fnuble')
-            self.assertEqual(os.path.split(os.path.dirname(path))[-1], 'fnord')
+            path = fileutils.ensureAbsolutePath(
+                output_dir=tmp_dir, relative_path="fnord/fnuble"
+            )
+            self.assertEqual(os.path.basename(path), "fnuble")
+            self.assertEqual(os.path.split(os.path.dirname(path))[-1], "fnord")
 
     def test_releaseFilePath(self):
         with tempfile.TemporaryDirectory() as tmp_dir:
-            path = fileutils.releaseFilePath(output_dir=tmp_dir, version='42', selector='all', protocol='http', output_format='json-ld')
-            self.assertEqual(os.path.basename(path), 'schemaorg-all-http.jsonld')
-            self.assertEqual(os.path.split(os.path.dirname(path))[-1], '42')
+            path = fileutils.releaseFilePath(
+                output_dir=tmp_dir,
+                version="42",
+                selector="all",
+                protocol="http",
+                output_format="json-ld",
+            )
+            self.assertEqual(os.path.basename(path), "schemaorg-all-http.jsonld")
+            self.assertEqual(os.path.split(os.path.dirname(path))[-1], "42")
 
 
 if __name__ == "__main__":

--- a/software/tests/test_fileutils.py
+++ b/software/tests/test_fileutils.py
@@ -1,0 +1,37 @@
+#!/usr/bin/env python3
+# -*- coding: utf-8 -*-
+
+import unittest
+import os
+import sys
+import tempfile
+
+# Import schema.org libraries
+if not os.getcwd() in sys.path:
+    sys.path.insert(1, os.getcwd())
+
+import software
+import software.util.fileutils as fileutils
+
+class FileUtilsTest(unittest.TestCase):
+
+
+    def test_checkFilePath(self):
+        with tempfile.TemporaryDirectory() as tmp_dir:
+            fileutils.checkFilePath(tmp_dir)
+
+    def test_ensureAbsolutePath(self):
+        with tempfile.TemporaryDirectory() as tmp_dir:
+            path = fileutils.ensureAbsolutePath(output_dir=tmp_dir, relative_path='fnord/fnuble')
+            self.assertEqual(os.path.basename(path), 'fnuble')
+            self.assertEqual(os.path.split(os.path.dirname(path))[-1], 'fnord')
+
+    def test_releaseFilePath(self):
+        with tempfile.TemporaryDirectory() as tmp_dir:
+            path = fileutils.releaseFilePath(output_dir=tmp_dir, version='42', selector='all', protocol='http', output_format='json-ld')
+            self.assertEqual(os.path.basename(path), 'schemaorg-all-http.jsonld')
+            self.assertEqual(os.path.split(os.path.dirname(path))[-1], '42')
+
+
+if __name__ == "__main__":
+    unittest.main()

--- a/software/util/buildfiles.py
+++ b/software/util/buildfiles.py
@@ -227,60 +227,57 @@ def exportrdf(exportType):
     formats = ["json-ld", "turtle", "nt", "nquads", "rdf"]
     extype = exportType[len("RDFExport.") :]
     if exportType == "RDFExports":
-        for format in sorted(formats):
-            _exportrdf(format, allGraph, currentGraph)
+        for output_format in sorted(formats):
+            _exportrdf(output_format, allGraph, currentGraph)
     elif extype in formats:
         _exportrdf(extype, allGraph, currentGraph)
     else:
         raise Exception("Unknown export format: %s" % exportType)
 
-
-EXTENSIONS_FOR_FORMAT = {
-    "xml": ".xml",
-    "rdf": ".rdf",
-    "nquads": ".nq",
-    "nt": ".nt",
-    "json-ld": ".jsonld",
-    "turtle": ".ttl",
-}
-
 completed = []
 
 
-def _exportrdf(format, all, current):
+def _exportrdf(output_format, all, current):
     global completed
 
     protocol, altprotocol = protocols()
 
-    if format in completed:
+    if output_format in completed:
         return
     else:
-        completed.append(format)
+        completed.append(output_format)
 
     version = schemaversion.getVersion()
 
-    for ver in ["current", "all"]:
-        if ver == "all":
+    for selector in fileutils.FILESET_SELECTORS:
+        if fileutils.isAll(selector):
             g = all
         else:
             g = current
-        if format == "nquads":
+        if output_format == "nquads":
             gr = rdflib.Dataset()
             qg = gr.graph(rdflib.URIRef("%s://schema.org/%s" % (protocol, version)))
             qg += g
             g = gr
-        fn = absoluteFilePath(
-            "releases/%s/schemaorg-%s-%s%s"
-            % (version, ver, protocol, EXTENSIONS_FOR_FORMAT[format])
-        )
-        afn = absoluteFilePath(
-            "releases/%s/schemaorg-%s-%s%s"
-            % (version, ver, altprotocol, EXTENSIONS_FOR_FORMAT[format])
-        )
+        fn = fileutils.releaseFilePath(
+            output_dir=schemaglobals.getOutputDir(),
+            version=version,
+            selector=selector,
+            protocol=protocol,
+            output_format=output_format)
+
+        afn = fileutils.releaseFilePath(
+            output_dir=schemaglobals.getOutputDir(),
+            version=version,
+            selector=selector,
+            protocol=altprotocol,
+            output_format=output_format)
+
         with pretty_logger.BlockLog(logger=log, message="Exporting {fn} and {afn}"):
-            fmt = format
-            if format == "rdf":
+            if output_format == "rdf":
                 fmt = "pretty-xml"
+            else:
+                fmt = output_format
             out = g.serialize(format=fmt, auto_compact=True, sort_keys=True)
             with open(fn, "w", encoding="utf8") as f:
                 f.write(out)
@@ -391,37 +388,47 @@ def exportcsv(page):
             if not term.retired:
                 typedata.append(row)
 
-    writecsvout("properties", propdata, propFields, "current", protocol, altprotocol)
-    writecsvout("properties", propdataAll, propFields, "all", protocol, altprotocol)
-    writecsvout("types", typedata, typeFields, "current", protocol, altprotocol)
-    writecsvout("types", typedataAll, typeFields, "all", protocol, altprotocol)
+    writecsvout("properties", propdata, propFields, fileutils.FileSelector.CURRENT, protocol, altprotocol)
+    writecsvout("properties", propdataAll, propFields, fileutils.FileSelector.ALL, protocol, altprotocol)
+    writecsvout("types", typedata, typeFields, fileutils.FileSelector.CURRENT, protocol, altprotocol)
+    writecsvout("types", typedataAll, typeFields, fileutils.FileSelector.ALL, protocol, altprotocol)
 
 
-def writecsvout(ftype, data, fields, ver, protocol, altprotocol):
+def writecsvout(ftype, data, fields, selector, protocol, altprotocol):
     version = schemaversion.getVersion()
-    fn = absoluteFilePath(
-        "releases/%s/schemaorg-%s-%s-%s.csv" % (version, ver, protocol, ftype)
-    )
-    afn = absoluteFilePath(
-        "releases/%s/schemaorg-%s-%s-%s.csv" % (version, ver, altprotocol, ftype)
-    )
-    log.debug("Writing files %s and %s" % (fn, afn))
-    csvout = io.StringIO()
-    csvfile = open(fn, "w", encoding="utf8")
-    acsvfile = open(afn, "w", encoding="utf8")
-    writer = csv.DictWriter(
-        csvout, fieldnames=fields, quoting=csv.QUOTE_ALL, lineterminator="\n"
-    )
-    writer.writeheader()
-    for row in data:
-        writer.writerow(row)
-    csvfile.write(csvout.getvalue())
-    csvfile.close()
-    acsvfile.write(
-        protocolSwap(csvout.getvalue(), protocol=protocol, altprotocol=altprotocol)
-    )
-    acsvfile.close()
-    csvout.close()
+    fn = fileutils.releaseFilePath(
+        output_dir=schemaglobals.getOutputDir(),
+        version=version,
+        selector=selector,
+        protocol=protocol,
+        suffix=ftype,
+        output_format='csv')
+    afn = fileutils.releaseFilePath(
+        output_dir=schemaglobals.getOutputDir(),
+        version=version,
+        selector=selector,
+        protocol=altprotocol,
+        suffix=ftype,
+        output_format='csv')
+
+    with pretty_logger.BlockLog(message=f"Preparing files {ftype}: {fn} and {afn}.", logger=log):
+        # Create the original version in memory.
+        with io.StringIO() as csv_buffer:
+            writer = csv.DictWriter(
+              csv_buffer, fieldnames=fields, quoting=csv.QUOTE_ALL, lineterminator="\n"
+              )
+            writer.writeheader()
+            for row in data:
+                writer.writerow(row)
+            data = csv_buffer.getvalue()
+
+        with open(fn, "w", encoding="utf8") as file_handle:
+            file_handle.write(data)
+
+        with open(afn, "w", encoding="utf8") as file_handle:
+            file_handle.write(
+                protocolSwap(data, protocol=protocol, altprotocol=altprotocol))
+
 
 
 def jsoncounts(page):
@@ -503,11 +510,8 @@ def buildFiles(files):
     # Production site uses no suffix in link - mapping to file done in server config
     software.SchemaTerms.localmarkdown.MarkdownTool.setWikilinkPostPath("")
 
-    all = ["ALL", "All", "all"]
-    for a in all:
-        if a in files:
-            files = sorted(FILELIST.keys())
-            break
+    if any(filter(fileutils.isAll, files)):
+        files = sorted(FILELIST.keys())
 
     for p in files:
         with pretty_logger.BlockLog(message=f"Preparing file {p}.", logger=log):

--- a/software/util/buildfiles.py
+++ b/software/util/buildfiles.py
@@ -234,6 +234,7 @@ def exportrdf(exportType):
     else:
         raise Exception("Unknown export format: %s" % exportType)
 
+
 completed = []
 
 
@@ -264,14 +265,16 @@ def _exportrdf(output_format, all, current):
             version=version,
             selector=selector,
             protocol=protocol,
-            output_format=output_format)
+            output_format=output_format,
+        )
 
         afn = fileutils.releaseFilePath(
             output_dir=schemaglobals.getOutputDir(),
             version=version,
             selector=selector,
             protocol=altprotocol,
-            output_format=output_format)
+            output_format=output_format,
+        )
 
         with pretty_logger.BlockLog(logger=log, message="Exporting {fn} and {afn}"):
             if output_format == "rdf":
@@ -388,10 +391,38 @@ def exportcsv(page):
             if not term.retired:
                 typedata.append(row)
 
-    writecsvout("properties", propdata, propFields, fileutils.FileSelector.CURRENT, protocol, altprotocol)
-    writecsvout("properties", propdataAll, propFields, fileutils.FileSelector.ALL, protocol, altprotocol)
-    writecsvout("types", typedata, typeFields, fileutils.FileSelector.CURRENT, protocol, altprotocol)
-    writecsvout("types", typedataAll, typeFields, fileutils.FileSelector.ALL, protocol, altprotocol)
+    writecsvout(
+        "properties",
+        propdata,
+        propFields,
+        fileutils.FileSelector.CURRENT,
+        protocol,
+        altprotocol,
+    )
+    writecsvout(
+        "properties",
+        propdataAll,
+        propFields,
+        fileutils.FileSelector.ALL,
+        protocol,
+        altprotocol,
+    )
+    writecsvout(
+        "types",
+        typedata,
+        typeFields,
+        fileutils.FileSelector.CURRENT,
+        protocol,
+        altprotocol,
+    )
+    writecsvout(
+        "types",
+        typedataAll,
+        typeFields,
+        fileutils.FileSelector.ALL,
+        protocol,
+        altprotocol,
+    )
 
 
 def writecsvout(ftype, data, fields, selector, protocol, altprotocol):
@@ -402,21 +433,28 @@ def writecsvout(ftype, data, fields, selector, protocol, altprotocol):
         selector=selector,
         protocol=protocol,
         suffix=ftype,
-        output_format='csv')
+        output_format="csv",
+    )
     afn = fileutils.releaseFilePath(
         output_dir=schemaglobals.getOutputDir(),
         version=version,
         selector=selector,
         protocol=altprotocol,
         suffix=ftype,
-        output_format='csv')
+        output_format="csv",
+    )
 
-    with pretty_logger.BlockLog(message=f"Preparing files {ftype}: {fn} and {afn}.", logger=log):
+    with pretty_logger.BlockLog(
+        message=f"Preparing files {ftype}: {fn} and {afn}.", logger=log
+    ):
         # Create the original version in memory.
         with io.StringIO() as csv_buffer:
             writer = csv.DictWriter(
-              csv_buffer, fieldnames=fields, quoting=csv.QUOTE_ALL, lineterminator="\n"
-              )
+                csv_buffer,
+                fieldnames=fields,
+                quoting=csv.QUOTE_ALL,
+                lineterminator="\n",
+            )
             writer.writeheader()
             for row in data:
                 writer.writerow(row)
@@ -427,8 +465,8 @@ def writecsvout(ftype, data, fields, selector, protocol, altprotocol):
 
         with open(afn, "w", encoding="utf8") as file_handle:
             file_handle.write(
-                protocolSwap(data, protocol=protocol, altprotocol=altprotocol))
-
+                protocolSwap(data, protocol=protocol, altprotocol=altprotocol)
+            )
 
 
 def jsoncounts(page):

--- a/software/util/buildocspages.py
+++ b/software/util/buildocspages.py
@@ -287,7 +287,8 @@ def createCollab(coll):
     content = docsTemplateRender("docs/Collab.j2", extra_vars)
     filename = fileutils.ensureAbsolutePath(
         output_dir=schemaglobals.OUTPUTDIR,
-        relative_path=os.path.join("docs/collab/", coll.ref + ".html"))
+        relative_path=os.path.join("docs/collab/", coll.ref + ".html"),
+    )
     with open(filename, "w", encoding="utf8") as handle:
         handle.write(content)
     log.info("Created %s" % filename)
@@ -336,13 +337,11 @@ def buildDocs(pages):
         if not func:
             log.warning(f"Missing function for page {page}")
             continue
-        with pretty_logger.BlockLog(
-            logger=log, message=f"Generating page {page}"):
+        with pretty_logger.BlockLog(logger=log, message=f"Generating page {page}"):
             content = func(page)
             for relative_path in filenames:
                 filename = fileutils.ensureAbsolutePath(
-                    output_dir=schemaglobals.OUTPUTDIR,
-                    relative_path=relative_path)
+                    output_dir=schemaglobals.OUTPUTDIR, relative_path=relative_path
+                )
                 with open(filename, "w", encoding="utf8") as handle:
                     handle.write(content)
-

--- a/software/util/buildtermpages.py
+++ b/software/util/buildtermpages.py
@@ -41,7 +41,7 @@ def termFileName(termid):
     Returns:
       File path the term page should be generated at.
     """
-    path_components = [schemaglobals.OUTPUTDIR, "terms"]
+    path_components = [schemaglobals.getOutputDir(), "terms"]
     if re.match("^[a-z].*", termid):
         path_components.append("properties")
     elif re.match("^[0-9A-Z].*", termid):
@@ -139,7 +139,7 @@ def buildTerms(term_ids):
     """
 
     tic = time.perf_counter()
-    if any(filter(lambda term_id: term_id.lower() == "all", term_ids)):
+    if any(filter(fileutils.isAll, term_ids)):
         log.info("Loading all term identifiers")
         term_ids = sdotermsource.SdoTermSource.getAllTerms(suppressSourceLinks=True)
 

--- a/software/util/fileutils.py
+++ b/software/util/fileutils.py
@@ -45,7 +45,7 @@ def isAll(selector: str):
 
 def checkFilePath(path):
     if not path in CHECKEDPATHS:
-        CHECKEDPATHS.insert(path)
+        CHECKEDPATHS.add(path)
         # os.path.join ignores the first argument if `path` is absolute.
         path = os.path.join(os.getcwd(), path)
         try:

--- a/software/util/fileutils.py
+++ b/software/util/fileutils.py
@@ -7,13 +7,13 @@ import enum
 
 
 EXTENSIONS_FOR_FORMAT = {
-    'xml': 'xml',
-    'rdf': 'rdf',
-    'nquads': 'nq',
-    'nt': 'nt',
-    'json-ld': 'jsonld',
-    'turtle': 'ttl',
-    'csv': 'csv'
+    "xml": "xml",
+    "rdf": "rdf",
+    "nquads": "nq",
+    "nt": "nt",
+    "json-ld": "jsonld",
+    "turtle": "ttl",
+    "csv": "csv",
 }
 
 
@@ -29,7 +29,8 @@ class FileSelector(str, enum.Enum):
 
 CHECKEDPATHS = set()
 FILESET_SELECTORS = frozenset([s.value for s in FileSelector])
-FILESET_PROTOCOLS = frozenset(['http', 'https'])
+FILESET_PROTOCOLS = frozenset(["http", "https"])
+
 
 def createMissingDir(dir_path):
     """Create a directory if it does not exist"""
@@ -37,7 +38,7 @@ def createMissingDir(dir_path):
         os.makedirs(dir_path)
 
 
-def isAll(selector : str):
+def isAll(selector: str):
     """Check if a selector string is a variation of the 'All' token."""
     return str(selector).lower() == FileSelector.ALL
 
@@ -54,14 +55,21 @@ def checkFilePath(path):
                 raise e
 
 
-def ensureAbsolutePath(output_dir : str, relative_path: str) -> str:
+def ensureAbsolutePath(output_dir: str, relative_path: str) -> str:
     """Convert into an absolute path and ensure the directory exists."""
     filepath = os.path.join(output_dir, relative_path)
     checkFilePath(os.path.dirname(filepath))
     return filepath
 
 
-def releaseFilePath(output_dir : str, version: str, selector: FileSelector, protocol: str, output_format: str, suffix : str = None) -> str:
+def releaseFilePath(
+    output_dir: str,
+    version: str,
+    selector: FileSelector,
+    protocol: str,
+    output_format: str,
+    suffix: str = None,
+) -> str:
     """Create a path for a release file
 
     Args:
@@ -82,10 +90,11 @@ def releaseFilePath(output_dir : str, version: str, selector: FileSelector, prot
     parts = [selector, protocol]
     if suffix:
         parts.append(suffix)
-    merged = '-'.join(parts)
+    merged = "-".join(parts)
     return ensureAbsolutePath(
         output_dir=output_dir,
-        relative_path=f'releases/{version}/schemaorg-{merged}.{extension}')
+        relative_path=f"releases/{version}/schemaorg-{merged}.{extension}",
+    )
 
 
 def mycopytree(src, dst, symlinks=False, ignore=None):

--- a/software/util/fileutils.py
+++ b/software/util/fileutils.py
@@ -3,7 +3,33 @@
 
 import os
 import shutil
+import enum
 
+
+EXTENSIONS_FOR_FORMAT = {
+    'xml': 'xml',
+    'rdf': 'rdf',
+    'nquads': 'nq',
+    'nt': 'nt',
+    'json-ld': 'jsonld',
+    'turtle': 'ttl',
+    'csv': 'csv'
+}
+
+
+class FileSelector(str, enum.Enum):
+    """Enumeration describing the type of an SdoTerm."""
+
+    ALL = "all"
+    CURRENT = "current"
+
+    def __str__(self):
+        return self.value
+
+
+CHECKEDPATHS = set()
+FILESET_SELECTORS = frozenset([s.value for s in FileSelector])
+FILESET_PROTOCOLS = frozenset(['http', 'https'])
 
 def createMissingDir(dir_path):
     """Create a directory if it does not exist"""
@@ -11,12 +37,14 @@ def createMissingDir(dir_path):
         os.makedirs(dir_path)
 
 
-CHECKEDPATHS = []
+def isAll(selector : str):
+    """Check if a selector string is a variation of the 'All' token."""
+    return str(selector).lower() == FileSelector.ALL
 
 
 def checkFilePath(path):
     if not path in CHECKEDPATHS:
-        CHECKEDPATHS.append(path)
+        CHECKEDPATHS.insert(path)
         # os.path.join ignores the first argument if `path` is absolute.
         path = os.path.join(os.getcwd(), path)
         try:
@@ -24,6 +52,40 @@ def checkFilePath(path):
         except OSError as e:
             if not os.path.isdir(path):
                 raise e
+
+
+def ensureAbsolutePath(output_dir : str, relative_path: str) -> str:
+    """Convert into an absolute path and ensure the directory exists."""
+    filepath = os.path.join(output_dir, relative_path)
+    checkFilePath(os.path.dirname(filepath))
+    return filepath
+
+
+def releaseFilePath(output_dir : str, version: str, selector: FileSelector, protocol: str, output_format: str, suffix : str = None) -> str:
+    """Create a path for a release file
+
+    Args:
+        output_directory: typically schemaglobals.OUTPUTDIR
+        version: version number
+        selector: either FileSelector.ALL or FileSelector.CURRENT
+        protocol: either 'http' or 'https'
+        output_format: one of the keys present in `EXTENSIONS_FOR_FORMAT`
+        suffix: optional suffix that is ended at the end of the file.
+    Returns:
+        an absolute path with the necessary directories created.
+    """
+    extension = EXTENSIONS_FOR_FORMAT[output_format.lower()]
+    selector = selector.lower()
+    assert selector in FILESET_SELECTORS, selector
+    protocol = protocol.lower()
+    assert protocol in FILESET_PROTOCOLS, protocol
+    parts = [selector, protocol]
+    if suffix:
+        parts.append(suffix)
+    merged = '-'.join(parts)
+    return ensureAbsolutePath(
+        output_dir=output_dir,
+        relative_path=f'releases/{version}/schemaorg-{merged}.{extension}')
 
 
 def mycopytree(src, dst, symlinks=False, ignore=None):


### PR DESCRIPTION
* Factored out the path building logic.
* Transformed some magic strings into a structure (Enum).
* Factored out logic to decide if the build command was for all, it was implemented in multiple places, differently.
* Added unit-tests.
* Renamed unit-test which whose name was clearly a typo.