### PR TITLE
Extract the schema graph class from reorg.py for it to be reused.

### DIFF
--- a/software/util/reorg.py
+++ b/software/util/reorg.py
@@ -7,58 +7,28 @@ semantic axis.
 """
 
 from collections.abc import Sequence
-import rdflib
 import argparse
 import itertools
 import logging
+import os
+import rdflib
 import sys
 
-SCHEMAORG = rdflib.Namespace("https://schema.org/")
+# Import schema.org libraries
+if not os.getcwd() in sys.path:
+    sys.path.insert(1, os.getcwd())
 
-class SchemaOrgGraph(object):
-    def __init__(self, filename: str = None, format: str = "turtle"):
-        self.g = rdflib.Graph()
-        # Binding it here, as by default it would bind the /elements/1.1/ instead
-        # of the dc terms. this way, the elements get assigned "dc1" or such
-        # as a prefix, and we do not use that.
-        self.g.bind("dc", rdflib.Namespace("http://purl.org/dc/terms/"), replace=True)
-        if filename:
-            self.g.parse(filename, format=format)
-
-    def __getattr__(self, *args, **kwargs):
-        return getattr(self.g, *args, **kwargs);
-
-    def IdenticalTo(self, other: "SchemaOrgGraph"):
-        only_in_other = other.g - self.g
-        only_in_self = self.g - other.g
-        if only_in_other or only_in_self:
-            raise ValueError(f"Graphs differ: {only_in_other + only_in_self}")
-        return True
-
-    def FullyContains(self, graph: "SchemaOrgGraph"):
-        only_in_subset = graph.g - self.g
-        if only_in_subset:
-            raise ValueError(f"Graph does not contain it all: {only_in_subset}")
-        return True
-
-    def ListSubjects(self, subject_type: rdflib.term.URIRef):
-        return set([s for s, p, o in self.g.triples((None, rdflib.RDF.type, subject_type))])
-
-    def Types(self):
-        return self.ListSubjects(rdflib.RDFS.Class)
-
-    def Properties(self):
-        return self.ListSubjects(rdflib.RDF.Property)
+import software.util.schema_graph as graph
 
 
 def Lint(args):
     """Reformats the file(s) properly."""
     def LintOne(filename, output_filename, format):
         logging.info(" - reading file ...")
-        g = SchemaOrgGraph(filename, format=format)
-        logging.info(f" - writing back {output_filename if output_filename != filename else ""} ...")
+        g = graph.SchemaOrgGraph(filename, format=format)
+        logging.info(f" - writing back {output_filename if output_filename != filename else ''} ...")
         g.serialize(output_filename, format=format)
-        if not g.IdenticalTo(SchemaOrgGraph(output_filename, format=format)):
+        if not g.IdenticalTo(graph.SchemaOrgGraph(output_filename, format=format)):
             logging.fatal(f"Linting file {filename} lost some information.")
 
         if args.output is not None and len(args.files) > 1:
@@ -72,7 +42,7 @@ def Lint(args):
 def MergeFiles(args):
     """Merges a set of files into one."""
     logging.info(f"Merging files {len(args.files)} into {args.output}")
-    merged = SchemaOrgGraph()
+    merged = graph.SchemaOrgGraph()
     for filename in args.files:
         logging.info(f" - reading {filename} ...")
         merged.parse(filename, format="turtle")
@@ -80,7 +50,7 @@ def MergeFiles(args):
     merged.serialize(args.output, format="turtle")
 
     for filename in args.files:
-        if not merged.FullyContains(SchemaOrgGraph(filename, format="turtle")):
+        if not merged.FullyContains(graph.SchemaOrgGraph(filename, format="turtle")):
             logging.fatal(f"Merging files into {args.output} lost some information.")
 
 
@@ -91,18 +61,18 @@ def Annotate(args):
 
     valid_parts = ["pending", "attic", "meta", "GA"]
     if args.ispartof not in valid_parts:
-        logging.fatal(f"PartOf annotation "{args.ispartof}" is not valid: select one of {valid_parts}")
+        logging.fatal(f"PartOf annotation '{args.ispartof}' is not valid: select one of {valid_parts}")
     new_part = rdflib.URIRef(f"https://{args.ispartof}.schema.org/")
 
     for filename in args.files:
         logging.info(f"Annotating {filename} ...")
-        g = SchemaOrgGraph(filename, format="turtle")
+        g = graph.SchemaOrgGraph(filename, format="turtle")
         # Clean the existing parts
-        g.remove((None, SCHEMAORG.isPartOf, None))
+        g.remove((None, graph.SCHEMAORG.isPartOf, None))
         # GA is special as it is the unannotated state.
         if args.ispartof != "GA":
             for sub in itertools.chain(g.Types(), g.Properties()):
-                g.add((sub, SCHEMAORG.isPartOf, new_part))
+                g.add((sub, graph.SCHEMAORG.isPartOf, new_part))
 
         g.serialize(args.output or filename, format="turtle")
         logging.info(f" ... done, written to {args.output or filename}")

--- a/software/util/schema_graph.py
+++ b/software/util/schema_graph.py
@@ -1,0 +1,53 @@
+#!/usr/bin/env python
+# -*- coding: utf-8; python-indent-offset: 4 -*-
+
+"""A class that holds the schema graph and presents some operations on it.
+"""
+
+from collections.abc import Sequence
+import rdflib
+import argparse
+import itertools
+import logging
+import sys
+
+import software.util.schemaglobals as schemaglobals
+
+
+SCHEMAORG = rdflib.Namespace(schemaglobals.HOMEPAGE)
+
+
+class SchemaOrgGraph(object):
+    def __init__(self, filename: str = None, format: str = "turtle"):
+        self.g = rdflib.Graph()
+        # Binding it here, as by default it would bind the /elements/1.1/ instead
+        # of the dc terms. this way, the elements get assigned "dc1" or such
+        # as a prefix, and we do not use that.
+        self.g.bind("dc", rdflib.Namespace("http://purl.org/dc/terms/"), replace=True)
+        if filename:
+            self.g.parse(filename, format=format)
+
+    def __getattr__(self, *args, **kwargs):
+        return getattr(self.g, *args, **kwargs);
+
+    def IdenticalTo(self, other: "SchemaOrgGraph"):
+        only_in_other = other.g - self.g
+        only_in_self = self.g - other.g
+        if only_in_other or only_in_self:
+            raise ValueError(f"Graphs differ: {only_in_other + only_in_self}")
+        return True
+
+    def FullyContains(self, graph: "SchemaOrgGraph"):
+        only_in_subset = graph.g - self.g
+        if only_in_subset:
+            raise ValueError(f"Graph does not contain it all: {only_in_subset}")
+        return True
+
+    def ListSubjects(self, subject_type: rdflib.term.URIRef):
+        return set([s for s, p, o in self.g.triples((None, rdflib.RDF.type, subject_type))])
+
+    def Types(self):
+        return self.ListSubjects(rdflib.RDFS.Class)
+
+    def Properties(self):
+        return self.ListSubjects(rdflib.RDF.Property)


### PR DESCRIPTION
This will be reused for other tooling as a wrapper around the RDF graph that exposes some common operations.