### PR TITLE
#4327 corrected inverse definition of sdo:netWorth

### DIFF
--- a/data/schema.ttl
+++ b/data/schema.ttl
@@ -7272,7 +7272,7 @@ Typical unit code(s): MTK for square meter, FTK for square foot, or YDK for squa
 
 :netWorth a rdf:Property ;
     rdfs:label "netWorth" ;
-    rdfs:comment "The total financial value of the person as calculated by subtracting assets from liabilities." ;
+    rdfs:comment "The total financial value of the person as calculated by subtracting the total value of liabilities from the total value of assets." ;
     :domainIncludes :Person ;
     :rangeIncludes :MonetaryAmount,
         :PriceSpecification .


### PR DESCRIPTION
This pull request deals with issue #4327  where the terms assets and liabilities were reversed.