### PR TITLE
Fixing the example assigner.

### DIFF
--- a/software/SchemaExamples/utils/assign_example_ids.py
+++ b/software/SchemaExamples/utils/assign_example_ids.py
@@ -28,8 +28,6 @@ def AssignExampleIds():
             filename = example.getMeta('file')
             if filename in changedFiles.keys():
                 log.error('Two examples with the same filename %s: %s and %s' % (filename, changedFiles[filename], example))
-                continue
-            filename[filename] = example
 
     if not changedFiles:
         log.info('No new identifiers assigned')


### PR DESCRIPTION
the line `filename[filename] = example` has very little chance of doing something useful to start with.
Removing it makes nothing fail, and it seems to not be used afterwards in the function anyway.