### PR TITLE
Back-tracking to nokogiri 1.18.3 -> 1.17.2

### DIFF
--- a/software/scripts/Gemfile.lock
+++ b/software/scripts/Gemfile.lock
@@ -32,7 +32,7 @@ GEM
     matrix (0.4.2)
     mini_portile2 (2.8.8)
     multi_json (1.15.0)
-    nokogiri (1.18.3)
+    nokogiri (1.17.2)
       mini_portile2 (~> 2.8.2)
       racc (~> 1.4)
     racc (1.8.1)

--- a/software/util/buildsite.py
+++ b/software/util/buildsite.py
@@ -297,6 +297,8 @@ def runRubyTests(release_dir):
         version = schemaversion.getVersion()
         src_dir = os.path.join(os.getcwd(), release_dir, version)
         dst_dir = os.path.join(os.getcwd(), release_dir, "LATEST")
+        if os.path.islink(dst_dir):
+            os.unlink(dst_dir)
         os.symlink(src_dir, dst_dir)
         cmd = ["bundle", "exec", "rake"]
         cwd = os.path.join(os.getcwd(), "software/scripts")


### PR DESCRIPTION
Done as the latest version does not download properly: we get an access denied error for the files.
also fixing ruby tests to not fail if the link exists already.