### PR TITLE
DateTime in jsonldcontext

### DIFF
--- a/software/tests/test_basics.py
+++ b/software/tests/test_basics.py
@@ -513,8 +513,18 @@ class BasicJSONLDTests(unittest.TestCase):
             "dateModified" in self.ctx["@context"], "dateModified should be defined."
         )
         self.assertTrue(
-            self.ctx["@context"]["dateModified"]["@type"] == "Date",
-            "dateModified should have Date type.",
+            len(self.ctx["@context"]["dateModified"]["@type"]) == 2,
+            "dateModified should have two types.",
+        )
+        self.assertIn(
+            "Date",
+            self.ctx["@context"]["dateModified"]["@type"],
+            msg="dateModified should have Date type.",
+        )
+        self.assertIn(
+            "DateTime",
+            self.ctx["@context"]["dateModified"]["@type"],
+            msg="dateModified should have DateTime type.",
         )
 
     def test_sameas_jsonld(self):

--- a/software/util/sdojsonldcontext.py
+++ b/software/util/sdojsonldcontext.py
@@ -40,7 +40,7 @@ def _convertTypes(type_range: typing.Collection[str]) -> typing.Set[str]:
         types.add("@id")
     if "Date" in type_range:
         types.add("Date")
-    if "Datetime" in type_range:
+    if "DateTime" in type_range:
         types.add("DateTime")
     return types
 


### PR DESCRIPTION
File at https://schema.org/docs/jsonldcontext.jsonld misses all "DateTime" types for every property, mostly due a mispelled case in the building script.