### PR TITLE
Adding legal information to organization (concerning #4366)

### DIFF
--- a/data/schema.ttl
+++ b/data/schema.ttl
@@ -658,6 +658,12 @@ See also the dedicated [document on the use of schema.org for marking up hotels 
     rdfs:comment "The act of conveying information to another person via a communication medium (instrument) such as speech, email, or telephone conversation." ;
     rdfs:subClassOf :InteractAction .
 
+:CompanyRegistration a rdfs:Class ;
+     rdfs:label "CompanyRegistration" ;
+     rdfs:comment "The official registration number of a business including the organization that issued it such as Company House or Chamber of Commerce." ;
+     :domainIncludes :Organization ;
+     :rangeIncludes :Certification .
+ 
 :CompoundPriceSpecification a rdfs:Class ;
     rdfs:label "CompoundPriceSpecification" ;
     rdfs:comment "A compound price specification is one that bundles multiple prices that all apply in combination for different dimensions of consumption. Use the name property of the attached unit price specification for indicating the dimension of a price component (e.g. \"electricity\" or \"final cleaning\")." ;
@@ -6883,11 +6889,23 @@ In the context of [[ShippingService]], use the [[ServicePeriod]] format, that co
     :rangeIncludes :DefinedTerm,
         :Text .
 
+:legalAddress a rdf:Property ;
+     rdfs:label "legalAddress" ;
+     rdfs:comment "The legal address of an organization which acts as the officially registered address used for legal and tax purposes. The legal address can be different from the place of operations of a business and other addresses can be part of an organization." ;
+     :domainIncludes :Organization ;
+     :rangeIncludes :PostalAddress .
+ 
 :legalName a rdf:Property ;
     rdfs:label "legalName" ;
     rdfs:comment "The official name of the organization, e.g. the registered company name." ;
     :domainIncludes :Organization ;
     :rangeIncludes :Text .
+
+:legalRepresentative a rdf:Property ;
+    rdfs:label "legalRepresentative" ;
+    rdfs:comment "One or multiple persons who represent this organization legally such as CEO or sole administrator." ;
+    :domainIncludes :Organization ;
+    :rangeIncludes :Person .
 
 :leiCode a rdf:Property ;
     rdfs:label "leiCode" ;


### PR DESCRIPTION
# Background regarding the legal information required on company run websites in Europe
Germany, Austria and other jurisdiction require companies (organizations) to publish all legal information of a company on their website. Also Google does that for example here:
[Google Germany Imprint](https://www.google.de/contact/impressum.html)

In fact for example to be eligible to run Google Ads [you are required to ad the information to your own website](https://support.google.com/merchants/answer/14675634?hl=en).

It is advised by many search engines to use this page (or any other about us page) to contain the structured data about the website publishing organization. Facebook for example also allows to add the information to pages:
[Add an Impressum to your Facebook Page](https://www.facebook.com/help/342430852516247)

We seemingly have everything in there inside organization, but not the basic legal fields that are even required by Google to do certain things.

Fixes: #4366 

# Addition of new properties to Organization

To allow standardisation of the information set I have tried with this PR to align the organization structured data with the legal requirements of the imprint by allowing more values. 

- legalRepresentative (Person): the legal representative of a company such as CEO or managing director.
- company registration (certification): the company registry number and the issuer of the number. 

Upon close inspection following values are not mandatory but can be contained in the Imprint:
- Common Stock Capital of your LLC or unlisted company (eg. 10.000 EUR of which 2.500 EUR Paid up);
legal representative

# Example Implementation

The example below contains also a proposal for stock capital, if desired. 

```
{
  "@context": "https://schema.org",
  "@type": "Organization",
  "url": "https://www.google.com",
  "sameAs": [
    "https://example.net/profile/example1234",
    "https://example.org/example1234"
  ],
  "logo": "https://www.google.com/images/logo.png",
  "name": "Google",
  "legalName": "Alphabet LLC",
  "legalRepresentative": {
    "@type": "Person",
    "name": "Larry Page"
  },
  "hasCompanyRegistration": {
    "@type": "Certification",
    "issuedBy": {
      "@type": "Organization",
      "name": "Chamber of Commerce of Wondertown"
    },
    "name": "Company Registration",
    "certificationIdentification": "WT-123456"
  },
  "description": "The example corporation is well-known for producing high-quality widgets",
  "email": "contact@example.com",
  "telephone": "+47-99-999-9999",
  "address": {
    "@type": "PostalAddress",
    "streetAddress": "Rue Improbable 99",
    "addressLocality": "Paris",
    "addressCountry": "FR",
    "addressRegion": "Ile-de-France",
    "postalCode": "75001"
  },
  "legalAddress": {
    "@type": "PostalAddress",
    "streetAddress": "Rue Improbable 99",
    "addressLocality": "Paris",
    "addressCountry": "FR",
    "addressRegion": "Ile-de-France",
    "postalCode": "75001"
  },
  "vatID": "FR12345678901",
  "iso6523Code": "0199:724500PMK2A2M1SQQ228"
}
```