### PR TITLE
Remove twitter from readme (closes #4388)

### DIFF
--- a/README.md
+++ b/README.md
@@ -99,4 +99,3 @@ However do note that labels, comments, and documentation should use US English (
 and schemas), if a choice between English variants is needed. Please aim for international
 English wherever possible.
 
-See also: https://twitter.com/schemaorg_dev


### PR DESCRIPTION
Due to being unused by schema.org, twitter has been removed from readme.

closes #4388