### PR TITLE
RFC Broken link Checker

### DIFF
--- a/.github/workflows/broken-links.yml
+++ b/.github/workflows/broken-links.yml
@@ -1,0 +1,10 @@
+name: Check Markdown links
+
+on: push
+
+jobs:
+  markdown-link-check:
+    runs-on: ubuntu-latest
+    steps:
+    - uses: actions/checkout@master
+    - uses: gaurav-nelson/github-action-markdown-link-check@v1

--- a/.github/workflows/broken-links.yml
+++ b/.github/workflows/broken-links.yml
@@ -6,5 +6,5 @@ jobs:
   markdown-link-check:
     runs-on: ubuntu-latest
     steps:
-    - uses: actions/checkout@master
+    - uses: actions/checkout@main
     - uses: gaurav-nelson/github-action-markdown-link-check@v1


### PR DESCRIPTION
After a discussion in #4392 I hereby propose a broken link checker based on the work of @gaurav-nelson (Redhat). 

Gaurav has developed a broken link checker that works via Github actions and allows us to exclude: 
- folders like [release](https://github.com/schemaorg/schemaorg/tree/main/data/releases) given the frequently outdated links there;
- localhost for automated testing. 

Given that his work is licensed under MIT License, I'd like to
1. open up a repo in the Github organization of schmema.org;
2. configure the system properly with a config.json to exclude irrelevant folders and files;
3. add the workflow to schemaorg/schemaorg/