### PR TITLE
Re-add 'Mass' as a range type for 'weight'.

### DIFF
--- a/data/ext/pending/issue-3617.ttl
+++ b/data/ext/pending/issue-3617.ttl
@@ -8,6 +8,10 @@
 # ╔════════════════════════════════════════════════════════╗
 # ║  Amend OfferShippingDetails                            ║
 # ╚════════════════════════════════════════════════════════╝
+:weight a rdf:Property ;
+    rdfs:label "weight" ;
+    :domainIncludes :OfferShippingDetails ;
+    :rangeIncludes :Mass .
 
 # Some fields are specific to OfferShippingDetails and not used anymore.
 :shippingSettingsLink a rdf:Property ;


### PR DESCRIPTION
This was wrongly removed while fixing the pending state of the property.