### PR TITLE
Fix the pending status of the 'duration' property.

### DIFF
--- a/data/ext/pending/issue-3617.ttl
+++ b/data/ext/pending/issue-3617.ttl
@@ -71,7 +71,6 @@
     rdfs:label "duration" ;
     :domainIncludes :ServicePeriod ;
     :rangeIncludes :QuantitativeValue ;
-    :isPartOf <https://pending.schema.org> ;
     :source <https://github.com/schemaorg/schemaorg/issues/3617> .
 
 :cutoffTime a rdf:Property ;


### PR DESCRIPTION
In the addition of shipping conditions (which uses the 'duration' property as well), it was mislabeled as being in the pending section, wheras it was already a public attribute before.

This should solve issue #4438