### PR TITLE
boolean to indicate sales tax exemption support for offers

### DIFF
--- a/data/schema.ttl
+++ b/data/schema.ttl
@@ -3998,6 +3998,18 @@ See also the <a href="/docs/hotels.html">dedicated document on the use of schema
         :Text,
         :URL .
 
+:acceptsTaxExemptionsDisability a rdf:Property ;
+    rdfs:label "acceptsTaxExemptionsDisability" ;
+    rdfs:comment "Indicates whether the seller processes orders with disabilty related tax exemptions." ;
+    :domainIncludes :Offer ;
+    :rangeIncludes :Boolean .
+
+:acceptsTaxExemptionsBusiness a rdf:Property ;
+    rdfs:label "acceptsTaxExemptionsBusiness" ;
+    rdfs:comment "Indicates whether the seller processes orders with business tax exemptions." ;
+    :domainIncludes :Offer ;
+    :rangeIncludes :Boolean .
+
 :accessCode a rdf:Property ;
     rdfs:label "accessCode" ;
     rdfs:comment "Password, PIN, or access code needed for delivery (e.g. from a locker)." ;


### PR DESCRIPTION
This is a first step to incorporate taxes into offers laying the ground work to define acceptance of sales tax reductions. 

In many jurisdictions there are several reasons to be exempted from sales tax. Below some examples: 
- in many countries people with disability receive sales tax / vat discount (eg Italy blind people 4% instead of 22%);
- the entire European union supports VAT exemption for businesses dealing directly (eg one company selling a service to another); 
- in the US sales tax can be exempted in many cases between businesses.

This is achieved through two booleans on offers: 

1. `acceptsTaxExemptionsDisability` allows businesses to markup disability sales tax reductions; 
2. `acceptsTaxExemptionsBusiness` allows businesses to markup B2B sales tax reductions; 

This PR introduces the ability to markup sales tax exemption support for merchants.

Concerns (but does not solve):  #380 
