### PR TITLE
Resolve logger warnings

### DIFF
--- a/software/SchemaTerms/sdocollaborators.py
+++ b/software/SchemaTerms/sdocollaborators.py
@@ -119,7 +119,7 @@ class collaborator(object):
         cls.loadCollaborators()
         coll = cls.COLLABORATORS.get(ref, None)
         if not coll:
-            log.warn("No such collaborator: %s" % ref)
+            log.warning("No such collaborator: %s" % ref)
         return coll
 
     @classmethod
@@ -128,7 +128,7 @@ class collaborator(object):
         cls.loadContributors()
         cont = cls.CONTRIBUTORS.get(ref, None)
         if not cont:
-            log.warn("No such contributor: %s" % ref)
+            log.warning("No such contributor: %s" % ref)
         return cont
 
     @classmethod

--- a/software/SchemaTerms/sdotermsource.py
+++ b/software/SchemaTerms/sdotermsource.py
@@ -72,7 +72,7 @@ def _loadOneSourceGraph(file_path: str) -> rdflib.Graph:
         return graph
     except Exception as e:
         message = "Error parsing source file '%s': %s" % (file_path, e)
-        log.warn(message)
+        log.warning(message)
         raise IOError(message)
 
 
@@ -702,7 +702,7 @@ class SdoTermSource:
     def termsFromIds(
         cls, ids: typing.Sequence[str] = None
     ) -> typing.Sequence[sdoterm.SdoTerm]:
-        """Convert a sequence of term-identities into a sequnece of SdoTerms."""
+        """Convert a sequence of term-identities into a sequence of SdoTerms."""
         ids = ids or []
         ret = []
         for tid in ids:


### PR DESCRIPTION
# PR Summary
This small PR resolves the annoying deprecation warnings of the `logger` library:
```python
DeprecationWarning: The 'warn' method is deprecated, use 'warning' instead
```
