### PR TITLE
fixes typo for word background in Documentation-Extensions-Auto

### DIFF
--- a/docs/documents.html
+++ b/docs/documents.html
@@ -96,7 +96,7 @@
                               </li>
                               <li>
                                     <h4><a href="automotive.html">Autos</a></h4>
-                                    Bckground information on marking up automobiles.
+                                    Background information on marking up automobiles.
                               </li>
                               <li>
                                     <h4><a href="financial.html">Banks and financial institutions</a></h4>


### PR DESCRIPTION
On the documentation page at https://schema.org/docs/documents.html there is a small typo of "Bckground" under Extensions Autos