### PR TITLE
Style guide starRating property should reference LodgingBusiness, not LocalBusiness

### DIFF
--- a/docs/styleguide.html
+++ b/docs/styleguide.html
@@ -80,7 +80,7 @@ area of the project's <a href="https://github.com/schemaorg/schemaorg/">github r
 
 <li>Properties may be used on more than one type.
       <ul>
-    <li>E.g. the property <a href="https://schema.org/starRating">starRating</a> can be used on <a href="https://schema.org/FoodEstablishment">FoodEstablishment</a> OR <a href="https://schema.org/LocalBusiness">LocalBusiness</a>.</li>
+    <li>E.g. the property <a href="https://schema.org/starRating">starRating</a> can be used on <a href="https://schema.org/FoodEstablishment">FoodEstablishment</a> OR <a href="https://schema.org/LodgingBusiness">LodgingBusiness</a>.</li>
     </ul>
  </li>
 <li>Properties must not take properties.</li>


### PR DESCRIPTION
[The Style guide](https://schema.org/docs/styleguide.html) mentions that the same properties can be on multiple types. It uses `starRating` from [FoodEstablishment](https://schema.org/FoodEstablishment) and [LocalBusiness](https://schema.org/LocalBusiness). There is no `starRating` property on [LocalBusiness](https://schema.org/LocalBusiness). The [starRating](https://schema.org/starRating) property references [LodgingBusiness](https://schema.org/LodgingBusiness), so this may just be a "Lo*Business" typo.