### PR TITLE
Properly escape quotes in jsonld in old releases.

### DIFF
--- a/data/releases/10.0/schemaorg-all-http.jsonld
+++ b/data/releases/10.0/schemaorg-all-http.jsonld
@@ -10917,7 +10917,7 @@
       "http://schema.org/source": {
         "@id": "http://www.w3.org/wiki/WebSchemas/SchemaDotOrgSources#source_ActionCollabClass"
       },
-      "rdfs:comment": "An action performed by a direct agent and indirect participants upon a direct object. Optionally happens at a location with the help of an inanimate instrument. The execution of the action may produce a result. Specific action sub-type documentation specifies the exact expectation of each argument/role.<br/><br/>\n\nSee also <a href=\"https://blog.schema.org/2014/04/16/announcing-schema-org-actions/">blog post</a> and <a href=\"http://schema.org/docs/actions.html\">Actions overview document</a>.",
+      "rdfs:comment": "An action performed by a direct agent and indirect participants upon a direct object. Optionally happens at a location with the help of an inanimate instrument. The execution of the action may produce a result. Specific action sub-type documentation specifies the exact expectation of each argument/role.<br/><br/>\n\nSee also <a href=\"https://blog.schema.org/2014/04/16/announcing-schema-org-actions\">blog post</a> and <a href=\"http://schema.org/docs/actions.html\">Actions overview document</a>.",
       "rdfs:label": "Action",
       "rdfs:subClassOf": {
         "@id": "http://schema.org/Thing"
@@ -16064,7 +16064,7 @@
       "http://schema.org/source": {
         "@id": "http://www.w3.org/wiki/WebSchemas/SchemaDotOrgSources#source_bibex"
       },
-      "rdfs:comment": "A part of a successively published publication such as a periodical or multi-volume work, often numbered. It may represent a time span, such as a year.<br/><br/>\n\nSee also <a href=\"https://blog.schema.org/2014/09/02/schema-org-support-for-bibliographic-relationships-and-periodicals/">blog post</a>.",
+      "rdfs:comment": "A part of a successively published publication such as a periodical or multi-volume work, often numbered. It may represent a time span, such as a year.<br/><br/>\n\nSee also <a href=\"https://blog.schema.org/2014/09/02/schema-org-support-for-bibliographic-relationships-and-periodicals\">blog post</a>.",
       "rdfs:label": "PublicationVolume",
       "rdfs:subClassOf": {
         "@id": "http://schema.org/CreativeWork"
@@ -19151,7 +19151,7 @@
       "http://www.w3.org/2002/07/owl#equivalentClass": {
         "@id": "http://purl.org/ontology/bibo/Issue"
       },
-      "rdfs:comment": "A part of a successively published publication such as a periodical or publication volume, often numbered, usually containing a grouping of works such as articles.<br/><br/>\n\nSee also <a href=\"https://blog.schema.org/2014/09/02/schema-org-support-for-bibliographic-relationships-and-periodicals/">blog post</a>.",
+      "rdfs:comment": "A part of a successively published publication such as a periodical or publication volume, often numbered, usually containing a grouping of works such as articles.<br/><br/>\n\nSee also <a href=\"https://blog.schema.org/2014/09/02/schema-org-support-for-bibliographic-relationships-and-periodicals\">blog post</a>.",
       "rdfs:label": "PublicationIssue",
       "rdfs:subClassOf": {
         "@id": "http://schema.org/CreativeWork"
@@ -19572,7 +19572,7 @@
       "http://schema.org/source": {
         "@id": "http://www.w3.org/wiki/WebSchemas/SchemaDotOrgSources#source_rNews"
       },
-      "rdfs:comment": "An article, such as a news article or piece of investigative report. Newspapers and magazines have articles of many different types and this is intended to cover them all.<br/><br/>\n\nSee also <a href=\"https://blog.schema.org/2014/09/02/schema-org-support-for-bibliographic-relationships-and-periodicals/">blog post</a>.",
+      "rdfs:comment": "An article, such as a news article or piece of investigative report. Newspapers and magazines have articles of many different types and this is intended to cover them all.<br/><br/>\n\nSee also <a href=\"https://blog.schema.org/2014/09/02/schema-org-support-for-bibliographic-relationships-and-periodicals\">blog post</a>.",
       "rdfs:label": "Article",
       "rdfs:subClassOf": {
         "@id": "http://schema.org/CreativeWork"
@@ -33427,7 +33427,7 @@
       "http://www.w3.org/2002/07/owl#equivalentClass": {
         "@id": "http://purl.org/ontology/bibo/Periodical"
       },
-      "rdfs:comment": "A publication in any medium issued in successive parts bearing numerical or chronological designations and intended, such as a magazine, scholarly journal, or newspaper to continue indefinitely.<br/><br/>\n\nSee also <a href=\"https://blog.schema.org/2014/09/02/schema-org-support-for-bibliographic-relationships-and-periodicals/">blog post</a>.",
+      "rdfs:comment": "A publication in any medium issued in successive parts bearing numerical or chronological designations and intended, such as a magazine, scholarly journal, or newspaper to continue indefinitely.<br/><br/>\n\nSee also <a href=\"https://blog.schema.org/2014/09/02/schema-org-support-for-bibliographic-relationships-and-periodicals\">blog post</a>.",
       "rdfs:label": "Periodical",
       "rdfs:subClassOf": {
         "@id": "http://schema.org/CreativeWorkSeries"
@@ -35275,7 +35275,7 @@
     {
       "@id": "http://schema.org/Role",
       "@type": "rdfs:Class",
-      "rdfs:comment": "Represents additional information about a relationship or property. For example a Role can be used to say that a 'member' role linking some SportsTeam to a player occurred during a particular time period. Or that a Person's 'actor' role in a Movie was for some particular characterName. Such properties can be attached to a Role entity, which is then associated with the main entities using ordinary properties like 'member' or 'actor'.<br/><br/>\n\nSee also <a href=\"https://blog.schema.org/2014/06/16/introducing-role/">blog post</a>.",
+      "rdfs:comment": "Represents additional information about a relationship or property. For example a Role can be used to say that a 'member' role linking some SportsTeam to a player occurred during a particular time period. Or that a Person's 'actor' role in a Movie was for some particular characterName. Such properties can be attached to a Role entity, which is then associated with the main entities using ordinary properties like 'member' or 'actor'.<br/><br/>\n\nSee also <a href=\"https://blog.schema.org/2014/06/16/introducing-role\">blog post</a>.",
       "rdfs:label": "Role",
       "rdfs:subClassOf": {
         "@id": "http://schema.org/Intangible"

--- a/data/releases/10.0/schemaorg-all-https.jsonld
+++ b/data/releases/10.0/schemaorg-all-https.jsonld
@@ -10917,7 +10917,7 @@
       "https://schema.org/source": {
         "@id": "http://www.w3.org/wiki/WebSchemas/SchemaDotOrgSources#source_ActionCollabClass"
       },
-      "rdfs:comment": "An action performed by a direct agent and indirect participants upon a direct object. Optionally happens at a location with the help of an inanimate instrument. The execution of the action may produce a result. Specific action sub-type documentation specifies the exact expectation of each argument/role.<br/><br/>\n\nSee also <a href=\"https://blog.schema.org/2014/04/16/announcing-schema-org-actions/">blog post</a> and <a href=\"https://schema.org/docs/actions.html\">Actions overview document</a>.",
+      "rdfs:comment": "An action performed by a direct agent and indirect participants upon a direct object. Optionally happens at a location with the help of an inanimate instrument. The execution of the action may produce a result. Specific action sub-type documentation specifies the exact expectation of each argument/role.<br/><br/>\n\nSee also <a href=\"https://blog.schema.org/2014/04/16/announcing-schema-org-actions\">blog post</a> and <a href=\"https://schema.org/docs/actions.html\">Actions overview document</a>.",
       "rdfs:label": "Action",
       "rdfs:subClassOf": {
         "@id": "https://schema.org/Thing"
@@ -16064,7 +16064,7 @@
       "https://schema.org/source": {
         "@id": "http://www.w3.org/wiki/WebSchemas/SchemaDotOrgSources#source_bibex"
       },
-      "rdfs:comment": "A part of a successively published publication such as a periodical or multi-volume work, often numbered. It may represent a time span, such as a year.<br/><br/>\n\nSee also <a href=\"https://blog.schema.org/2014/09/02/schema-org-support-for-bibliographic-relationships-and-periodicals/">blog post</a>.",
+      "rdfs:comment": "A part of a successively published publication such as a periodical or multi-volume work, often numbered. It may represent a time span, such as a year.<br/><br/>\n\nSee also <a href=\"https://blog.schema.org/2014/09/02/schema-org-support-for-bibliographic-relationships-and-periodicals\">blog post</a>.",
       "rdfs:label": "PublicationVolume",
       "rdfs:subClassOf": {
         "@id": "https://schema.org/CreativeWork"
@@ -19151,7 +19151,7 @@
       "http://www.w3.org/2002/07/owl#equivalentClass": {
         "@id": "http://purl.org/ontology/bibo/Issue"
       },
-      "rdfs:comment": "A part of a successively published publication such as a periodical or publication volume, often numbered, usually containing a grouping of works such as articles.<br/><br/>\n\nSee also <a href=\"https://blog.schema.org/2014/09/02/schema-org-support-for-bibliographic-relationships-and-periodicals/">blog post</a>.",
+      "rdfs:comment": "A part of a successively published publication such as a periodical or publication volume, often numbered, usually containing a grouping of works such as articles.<br/><br/>\n\nSee also <a href=\"https://blog.schema.org/2014/09/02/schema-org-support-for-bibliographic-relationships-and-periodicals\">blog post</a>.",
       "rdfs:label": "PublicationIssue",
       "rdfs:subClassOf": {
         "@id": "https://schema.org/CreativeWork"
@@ -19572,7 +19572,7 @@
       "https://schema.org/source": {
         "@id": "http://www.w3.org/wiki/WebSchemas/SchemaDotOrgSources#source_rNews"
       },
-      "rdfs:comment": "An article, such as a news article or piece of investigative report. Newspapers and magazines have articles of many different types and this is intended to cover them all.<br/><br/>\n\nSee also <a href=\"https://blog.schema.org/2014/09/02/schema-org-support-for-bibliographic-relationships-and-periodicals/">blog post</a>.",
+      "rdfs:comment": "An article, such as a news article or piece of investigative report. Newspapers and magazines have articles of many different types and this is intended to cover them all.<br/><br/>\n\nSee also <a href=\"https://blog.schema.org/2014/09/02/schema-org-support-for-bibliographic-relationships-and-periodicals\">blog post</a>.",
       "rdfs:label": "Article",
       "rdfs:subClassOf": {
         "@id": "https://schema.org/CreativeWork"
@@ -33427,7 +33427,7 @@
       "http://www.w3.org/2002/07/owl#equivalentClass": {
         "@id": "http://purl.org/ontology/bibo/Periodical"
       },
-      "rdfs:comment": "A publication in any medium issued in successive parts bearing numerical or chronological designations and intended, such as a magazine, scholarly journal, or newspaper to continue indefinitely.<br/><br/>\n\nSee also <a href=\"https://blog.schema.org/2014/09/02/schema-org-support-for-bibliographic-relationships-and-periodicals/">blog post</a>.",
+      "rdfs:comment": "A publication in any medium issued in successive parts bearing numerical or chronological designations and intended, such as a magazine, scholarly journal, or newspaper to continue indefinitely.<br/><br/>\n\nSee also <a href=\"https://blog.schema.org/2014/09/02/schema-org-support-for-bibliographic-relationships-and-periodicals\">blog post</a>.",
       "rdfs:label": "Periodical",
       "rdfs:subClassOf": {
         "@id": "https://schema.org/CreativeWorkSeries"
@@ -35275,7 +35275,7 @@
     {
       "@id": "https://schema.org/Role",
       "@type": "rdfs:Class",
-      "rdfs:comment": "Represents additional information about a relationship or property. For example a Role can be used to say that a 'member' role linking some SportsTeam to a player occurred during a particular time period. Or that a Person's 'actor' role in a Movie was for some particular characterName. Such properties can be attached to a Role entity, which is then associated with the main entities using ordinary properties like 'member' or 'actor'.<br/><br/>\n\nSee also <a href=\"https://blog.schema.org/2014/06/16/introducing-role/">blog post</a>.",
+      "rdfs:comment": "Represents additional information about a relationship or property. For example a Role can be used to say that a 'member' role linking some SportsTeam to a player occurred during a particular time period. Or that a Person's 'actor' role in a Movie was for some particular characterName. Such properties can be attached to a Role entity, which is then associated with the main entities using ordinary properties like 'member' or 'actor'.<br/><br/>\n\nSee also <a href=\"https://blog.schema.org/2014/06/16/introducing-role\">blog post</a>.",
       "rdfs:label": "Role",
       "rdfs:subClassOf": {
         "@id": "https://schema.org/Intangible"

--- a/data/releases/10.0/schemaorg-current-http.jsonld
+++ b/data/releases/10.0/schemaorg-current-http.jsonld
@@ -10972,7 +10972,7 @@
       "http://schema.org/source": {
         "@id": "http://www.w3.org/wiki/WebSchemas/SchemaDotOrgSources#source_ActionCollabClass"
       },
-      "rdfs:comment": "An action performed by a direct agent and indirect participants upon a direct object. Optionally happens at a location with the help of an inanimate instrument. The execution of the action may produce a result. Specific action sub-type documentation specifies the exact expectation of each argument/role.<br/><br/>\n\nSee also <a href=\"https://blog.schema.org/2014/04/16/announcing-schema-org-actions/">blog post</a> and <a href=\"http://schema.org/docs/actions.html\">Actions overview document</a>.",
+      "rdfs:comment": "An action performed by a direct agent and indirect participants upon a direct object. Optionally happens at a location with the help of an inanimate instrument. The execution of the action may produce a result. Specific action sub-type documentation specifies the exact expectation of each argument/role.<br/><br/>\n\nSee also <a href=\"https://blog.schema.org/2014/04/16/announcing-schema-org-actions\">blog post</a> and <a href=\"http://schema.org/docs/actions.html\">Actions overview document</a>.",
       "rdfs:label": "Action",
       "rdfs:subClassOf": {
         "@id": "http://schema.org/Thing"
@@ -18306,7 +18306,7 @@
       "http://schema.org/source": {
         "@id": "http://www.w3.org/wiki/WebSchemas/SchemaDotOrgSources#source_bibex"
       },
-      "rdfs:comment": "A part of a successively published publication such as a periodical or multi-volume work, often numbered. It may represent a time span, such as a year.<br/><br/>\n\nSee also <a href=\"https://blog.schema.org/2014/09/02/schema-org-support-for-bibliographic-relationships-and-periodicals/">blog post</a>.",
+      "rdfs:comment": "A part of a successively published publication such as a periodical or multi-volume work, often numbered. It may represent a time span, such as a year.<br/><br/>\n\nSee also <a href=\"https://blog.schema.org/2014/09/02/schema-org-support-for-bibliographic-relationships-and-periodicals\">blog post</a>.",
       "rdfs:label": "PublicationVolume",
       "rdfs:subClassOf": {
         "@id": "http://schema.org/CreativeWork"
@@ -19141,7 +19141,7 @@
       "http://www.w3.org/2002/07/owl#equivalentClass": {
         "@id": "http://purl.org/ontology/bibo/Issue"
       },
-      "rdfs:comment": "A part of a successively published publication such as a periodical or publication volume, often numbered, usually containing a grouping of works such as articles.<br/><br/>\n\nSee also <a href=\"https://blog.schema.org/2014/09/02/schema-org-support-for-bibliographic-relationships-and-periodicals/">blog post</a>.",
+      "rdfs:comment": "A part of a successively published publication such as a periodical or publication volume, often numbered, usually containing a grouping of works such as articles.<br/><br/>\n\nSee also <a href=\"https://blog.schema.org/2014/09/02/schema-org-support-for-bibliographic-relationships-and-periodicals\">blog post</a>.",
       "rdfs:label": "PublicationIssue",
       "rdfs:subClassOf": {
         "@id": "http://schema.org/CreativeWork"
@@ -19568,7 +19568,7 @@
       "http://schema.org/source": {
         "@id": "http://www.w3.org/wiki/WebSchemas/SchemaDotOrgSources#source_rNews"
       },
-      "rdfs:comment": "An article, such as a news article or piece of investigative report. Newspapers and magazines have articles of many different types and this is intended to cover them all.<br/><br/>\n\nSee also <a href=\"https://blog.schema.org/2014/09/02/schema-org-support-for-bibliographic-relationships-and-periodicals/">blog post</a>.",
+      "rdfs:comment": "An article, such as a news article or piece of investigative report. Newspapers and magazines have articles of many different types and this is intended to cover them all.<br/><br/>\n\nSee also <a href=\"https://blog.schema.org/2014/09/02/schema-org-support-for-bibliographic-relationships-and-periodicals\">blog post</a>.",
       "rdfs:label": "Article",
       "rdfs:subClassOf": {
         "@id": "http://schema.org/CreativeWork"
@@ -33362,7 +33362,7 @@
       "http://www.w3.org/2002/07/owl#equivalentClass": {
         "@id": "http://purl.org/ontology/bibo/Periodical"
       },
-      "rdfs:comment": "A publication in any medium issued in successive parts bearing numerical or chronological designations and intended, such as a magazine, scholarly journal, or newspaper to continue indefinitely.<br/><br/>\n\nSee also <a href=\"https://blog.schema.org/2014/09/02/schema-org-support-for-bibliographic-relationships-and-periodicals/">blog post</a>.",
+      "rdfs:comment": "A publication in any medium issued in successive parts bearing numerical or chronological designations and intended, such as a magazine, scholarly journal, or newspaper to continue indefinitely.<br/><br/>\n\nSee also <a href=\"https://blog.schema.org/2014/09/02/schema-org-support-for-bibliographic-relationships-and-periodicals\">blog post</a>.",
       "rdfs:label": "Periodical",
       "rdfs:subClassOf": {
         "@id": "http://schema.org/CreativeWorkSeries"
@@ -35182,7 +35182,7 @@
     {
       "@id": "http://schema.org/Role",
       "@type": "rdfs:Class",
-      "rdfs:comment": "Represents additional information about a relationship or property. For example a Role can be used to say that a 'member' role linking some SportsTeam to a player occurred during a particular time period. Or that a Person's 'actor' role in a Movie was for some particular characterName. Such properties can be attached to a Role entity, which is then associated with the main entities using ordinary properties like 'member' or 'actor'.<br/><br/>\n\nSee also <a href=\"https://blog.schema.org/2014/06/16/introducing-role/">blog post</a>.",
+      "rdfs:comment": "Represents additional information about a relationship or property. For example a Role can be used to say that a 'member' role linking some SportsTeam to a player occurred during a particular time period. Or that a Person's 'actor' role in a Movie was for some particular characterName. Such properties can be attached to a Role entity, which is then associated with the main entities using ordinary properties like 'member' or 'actor'.<br/><br/>\n\nSee also <a href=\"https://blog.schema.org/2014/06/16/introducing-role\">blog post</a>.",
       "rdfs:label": "Role",
       "rdfs:subClassOf": {
         "@id": "http://schema.org/Intangible"

--- a/data/releases/10.0/schemaorg-current-https.jsonld
+++ b/data/releases/10.0/schemaorg-current-https.jsonld
@@ -10972,7 +10972,7 @@
       "https://schema.org/source": {
         "@id": "http://www.w3.org/wiki/WebSchemas/SchemaDotOrgSources#source_ActionCollabClass"
       },
-      "rdfs:comment": "An action performed by a direct agent and indirect participants upon a direct object. Optionally happens at a location with the help of an inanimate instrument. The execution of the action may produce a result. Specific action sub-type documentation specifies the exact expectation of each argument/role.<br/><br/>\n\nSee also <a href=\"https://blog.schema.org/2014/04/16/announcing-schema-org-actions/">blog post</a> and <a href=\"https://schema.org/docs/actions.html\">Actions overview document</a>.",
+      "rdfs:comment": "An action performed by a direct agent and indirect participants upon a direct object. Optionally happens at a location with the help of an inanimate instrument. The execution of the action may produce a result. Specific action sub-type documentation specifies the exact expectation of each argument/role.<br/><br/>\n\nSee also <a href=\"https://blog.schema.org/2014/04/16/announcing-schema-org-actions\">blog post</a> and <a href=\"https://schema.org/docs/actions.html\">Actions overview document</a>.",
       "rdfs:label": "Action",
       "rdfs:subClassOf": {
         "@id": "https://schema.org/Thing"
@@ -18306,7 +18306,7 @@
       "https://schema.org/source": {
         "@id": "http://www.w3.org/wiki/WebSchemas/SchemaDotOrgSources#source_bibex"
       },
-      "rdfs:comment": "A part of a successively published publication such as a periodical or multi-volume work, often numbered. It may represent a time span, such as a year.<br/><br/>\n\nSee also <a href=\"https://blog.schema.org/2014/09/02/schema-org-support-for-bibliographic-relationships-and-periodicals/">blog post</a>.",
+      "rdfs:comment": "A part of a successively published publication such as a periodical or multi-volume work, often numbered. It may represent a time span, such as a year.<br/><br/>\n\nSee also <a href=\"https://blog.schema.org/2014/09/02/schema-org-support-for-bibliographic-relationships-and-periodicals\">blog post</a>.",
       "rdfs:label": "PublicationVolume",
       "rdfs:subClassOf": {
         "@id": "https://schema.org/CreativeWork"
@@ -19141,7 +19141,7 @@
       "http://www.w3.org/2002/07/owl#equivalentClass": {
         "@id": "http://purl.org/ontology/bibo/Issue"
       },
-      "rdfs:comment": "A part of a successively published publication such as a periodical or publication volume, often numbered, usually containing a grouping of works such as articles.<br/><br/>\n\nSee also <a href=\"https://blog.schema.org/2014/09/02/schema-org-support-for-bibliographic-relationships-and-periodicals/">blog post</a>.",
+      "rdfs:comment": "A part of a successively published publication such as a periodical or publication volume, often numbered, usually containing a grouping of works such as articles.<br/><br/>\n\nSee also <a href=\"https://blog.schema.org/2014/09/02/schema-org-support-for-bibliographic-relationships-and-periodicals\">blog post</a>.",
       "rdfs:label": "PublicationIssue",
       "rdfs:subClassOf": {
         "@id": "https://schema.org/CreativeWork"
@@ -19568,7 +19568,7 @@
       "https://schema.org/source": {
         "@id": "http://www.w3.org/wiki/WebSchemas/SchemaDotOrgSources#source_rNews"
       },
-      "rdfs:comment": "An article, such as a news article or piece of investigative report. Newspapers and magazines have articles of many different types and this is intended to cover them all.<br/><br/>\n\nSee also <a href=\"https://blog.schema.org/2014/09/02/schema-org-support-for-bibliographic-relationships-and-periodicals/">blog post</a>.",
+      "rdfs:comment": "An article, such as a news article or piece of investigative report. Newspapers and magazines have articles of many different types and this is intended to cover them all.<br/><br/>\n\nSee also <a href=\"https://blog.schema.org/2014/09/02/schema-org-support-for-bibliographic-relationships-and-periodicals\">blog post</a>.",
       "rdfs:label": "Article",
       "rdfs:subClassOf": {
         "@id": "https://schema.org/CreativeWork"
@@ -33362,7 +33362,7 @@
       "http://www.w3.org/2002/07/owl#equivalentClass": {
         "@id": "http://purl.org/ontology/bibo/Periodical"
       },
-      "rdfs:comment": "A publication in any medium issued in successive parts bearing numerical or chronological designations and intended, such as a magazine, scholarly journal, or newspaper to continue indefinitely.<br/><br/>\n\nSee also <a href=\"https://blog.schema.org/2014/09/02/schema-org-support-for-bibliographic-relationships-and-periodicals/">blog post</a>.",
+      "rdfs:comment": "A publication in any medium issued in successive parts bearing numerical or chronological designations and intended, such as a magazine, scholarly journal, or newspaper to continue indefinitely.<br/><br/>\n\nSee also <a href=\"https://blog.schema.org/2014/09/02/schema-org-support-for-bibliographic-relationships-and-periodicals\">blog post</a>.",
       "rdfs:label": "Periodical",
       "rdfs:subClassOf": {
         "@id": "https://schema.org/CreativeWorkSeries"
@@ -35182,7 +35182,7 @@
     {
       "@id": "https://schema.org/Role",
       "@type": "rdfs:Class",
-      "rdfs:comment": "Represents additional information about a relationship or property. For example a Role can be used to say that a 'member' role linking some SportsTeam to a player occurred during a particular time period. Or that a Person's 'actor' role in a Movie was for some particular characterName. Such properties can be attached to a Role entity, which is then associated with the main entities using ordinary properties like 'member' or 'actor'.<br/><br/>\n\nSee also <a href=\"https://blog.schema.org/2014/06/16/introducing-role/">blog post</a>.",
+      "rdfs:comment": "Represents additional information about a relationship or property. For example a Role can be used to say that a 'member' role linking some SportsTeam to a player occurred during a particular time period. Or that a Person's 'actor' role in a Movie was for some particular characterName. Such properties can be attached to a Role entity, which is then associated with the main entities using ordinary properties like 'member' or 'actor'.<br/><br/>\n\nSee also <a href=\"https://blog.schema.org/2014/06/16/introducing-role\">blog post</a>.",
       "rdfs:label": "Role",
       "rdfs:subClassOf": {
         "@id": "https://schema.org/Intangible"

--- a/data/releases/3.1/all-layers.jsonld
+++ b/data/releases/3.1/all-layers.jsonld
@@ -5946,7 +5946,7 @@
           "http://purl.org/dc/terms/source": {
             "@id": "http://www.w3.org/wiki/WebSchemas/SchemaDotOrgSources#source_ActionCollabClass"
           },
-          "rdfs:comment": "An action performed by a direct agent and indirect participants upon a direct object. Optionally happens at a location with the help of an inanimate instrument. The execution of the action may produce a result. Specific action sub-type documentation specifies the exact expectation of each argument/role.</p>\n<p>See also <a href=\"https://blog.schema.org/2014/04/16/announcing-schema-org-actions/">blog post</a> and <a href=\"http://schema.org/docs/actions.html\">Actions overview document</a>.",
+          "rdfs:comment": "An action performed by a direct agent and indirect participants upon a direct object. Optionally happens at a location with the help of an inanimate instrument. The execution of the action may produce a result. Specific action sub-type documentation specifies the exact expectation of each argument/role.</p>\n<p>See also <a href=\"https://blog.schema.org/2014/04/16/announcing-schema-org-actions\">blog post</a> and <a href=\"http://schema.org/docs/actions.html\">Actions overview document</a>.",
           "rdfs:label": "Action",
           "rdfs:subClassOf": {
             "@id": "http://schema.org/Thing"
@@ -8710,7 +8710,7 @@
           "http://purl.org/dc/terms/source": {
             "@id": "http://www.w3.org/wiki/WebSchemas/SchemaDotOrgSources#source_bibex"
           },
-          "rdfs:comment": "<p>A part of a successively published publication such as a periodical or multi-volume work, often numbered. It may represent a time span, such as a year.</p>\n<pre><code>  &lt;br/&gt;&lt;br/&gt;See also &lt;a href=\"https://blog.schema.org/2014/09/02/schema-org-support-for-bibliographic-relationships-and-periodicals/"&gt;blog post&lt;/a&gt;.\n</code></pre>",
+          "rdfs:comment": "<p>A part of a successively published publication such as a periodical or multi-volume work, often numbered. It may represent a time span, such as a year.</p>\n<pre><code>  &lt;br/&gt;&lt;br/&gt;See also &lt;a href=\"https://blog.schema.org/2014/09/02/schema-org-support-for-bibliographic-relationships-and-periodicals\"&gt;blog post&lt;/a&gt;.\n</code></pre>",
           "rdfs:label": "PublicationVolume",
           "rdfs:subClassOf": {
             "@id": "http://schema.org/CreativeWork"
@@ -9199,7 +9199,7 @@
         {
           "@id": "http://www.w3.org/wiki/WebSchemas/SchemaDotOrgSources#source_GoodRelationsTerms",
           "@type": "http://schema.org/Organization",
-          "rdfs:comment": "This term <a href=\"https://blog.schema.org/2012/11/08/good-relations-and-schema-org/">uses</a> terminology from the GoodRelations Vocabulary for E-Commerce, created by Martin Hepp. GoodRelations is a data model for sharing e-commerce data on the Web. More information about GoodRelations can be found at <a href=\"http://purl.org/goodrelations/\">http://purl.org/goodrelations/</a>.",
+          "rdfs:comment": "This term <a href=\"https://blog.schema.org/2012/11/08/good-relations-and-schema-org\">uses</a> terminology from the GoodRelations Vocabulary for E-Commerce, created by Martin Hepp. GoodRelations is a data model for sharing e-commerce data on the Web. More information about GoodRelations can be found at <a href=\"http://purl.org/goodrelations/\">http://purl.org/goodrelations/</a>.",
           "rdfs:label": "GoodRelationsTerms"
         },
         {
@@ -10426,7 +10426,7 @@
           "http://www.w3.org/2002/07/owl#equivalentClass": {
             "@id": "http://purl.org/ontology/bibo/Issue"
           },
-          "rdfs:comment": "A part of a successively published publication such as a periodical or publication volume, often numbered, usually containing a grouping of works such as articles.</p>\n<p><a href=\"https://blog.schema.org/2014/09/02/schema-org-support-for-bibliographic-relationships-and-periodicals/">blog post</a>.",
+          "rdfs:comment": "A part of a successively published publication such as a periodical or publication volume, often numbered, usually containing a grouping of works such as articles.</p>\n<p><a href=\"https://blog.schema.org/2014/09/02/schema-org-support-for-bibliographic-relationships-and-periodicals\">blog post</a>.",
           "rdfs:label": "PublicationIssue",
           "rdfs:subClassOf": {
             "@id": "http://schema.org/CreativeWork"
@@ -10456,7 +10456,7 @@
           "http://purl.org/dc/terms/source": {
             "@id": "http://www.w3.org/wiki/WebSchemas/SchemaDotOrgSources#source_rNews"
           },
-          "rdfs:comment": "An article, such as a news article or piece of investigative report. Newspapers and magazines have articles of many different types and this is intended to cover them all.</p>\n<p>See also <a href=\"https://blog.schema.org/2014/09/02/schema-org-support-for-bibliographic-relationships-and-periodicals/">blog post</a>.",
+          "rdfs:comment": "An article, such as a news article or piece of investigative report. Newspapers and magazines have articles of many different types and this is intended to cover them all.</p>\n<p>See also <a href=\"https://blog.schema.org/2014/09/02/schema-org-support-for-bibliographic-relationships-and-periodicals\">blog post</a>.",
           "rdfs:label": "Article",
           "rdfs:subClassOf": {
             "@id": "http://schema.org/CreativeWork"
@@ -18041,7 +18041,7 @@
           "http://www.w3.org/2002/07/owl#equivalentClass": {
             "@id": "http://purl.org/ontology/bibo/Periodical"
           },
-          "rdfs:comment": "A publication in any medium issued in successive parts bearing numerical or chronological designations and intended, such as a magazine, scholarly journal, or newspaper to continue indefinitely.</p>\n<p>See also <a href=\"https://blog.schema.org/2014/09/02/schema-org-support-for-bibliographic-relationships-and-periodicals/">blog post</a>.",
+          "rdfs:comment": "A publication in any medium issued in successive parts bearing numerical or chronological designations and intended, such as a magazine, scholarly journal, or newspaper to continue indefinitely.</p>\n<p>See also <a href=\"https://blog.schema.org/2014/09/02/schema-org-support-for-bibliographic-relationships-and-periodicals\">blog post</a>.",
           "rdfs:label": "Periodical",
           "rdfs:subClassOf": {
             "@id": "http://schema.org/CreativeWorkSeries"
@@ -19279,7 +19279,7 @@
         {
           "@id": "http://schema.org/Role",
           "@type": "rdfs:Class",
-          "rdfs:comment": "Represents additional information about a relationship or property. For example a Role can be used to say that a 'member' role linking some SportsTeam to a player occurred during a particular time period. Or that a Person's 'actor' role in a Movie was for some particular characterName. Such properties can be attached to a Role entity, which is then associated with the main entities using ordinary properties like 'member' or 'actor'.</p>\n<p>See also <a href=\"https://blog.schema.org/2014/06/16/introducing-role/">blog post</a>.",
+          "rdfs:comment": "Represents additional information about a relationship or property. For example a Role can be used to say that a 'member' role linking some SportsTeam to a player occurred during a particular time period. Or that a Person's 'actor' role in a Movie was for some particular characterName. Such properties can be attached to a Role entity, which is then associated with the main entities using ordinary properties like 'member' or 'actor'.</p>\n<p>See also <a href=\"https://blog.schema.org/2014/06/16/introducing-role\">blog post</a>.",
           "rdfs:label": "Role",
           "rdfs:subClassOf": {
             "@id": "http://schema.org/Intangible"

--- a/data/releases/3.1/schema.jsonld
+++ b/data/releases/3.1/schema.jsonld
@@ -411,7 +411,7 @@
       "http://purl.org/dc/terms/source": {
         "@id": "http://www.w3.org/wiki/WebSchemas/SchemaDotOrgSources#source_ActionCollabClass"
       },
-      "rdfs:comment": "An action performed by a direct agent and indirect participants upon a direct object. Optionally happens at a location with the help of an inanimate instrument. The execution of the action may produce a result. Specific action sub-type documentation specifies the exact expectation of each argument/role.</p>\n<p>See also <a href=\"https://blog.schema.org/2014/04/16/announcing-schema-org-actions/">blog post</a> and <a href=\"http://schema.org/docs/actions.html\">Actions overview document</a>.",
+      "rdfs:comment": "An action performed by a direct agent and indirect participants upon a direct object. Optionally happens at a location with the help of an inanimate instrument. The execution of the action may produce a result. Specific action sub-type documentation specifies the exact expectation of each argument/role.</p>\n<p>See also <a href=\"https://blog.schema.org/2014/04/16/announcing-schema-org-actions\">blog post</a> and <a href=\"http://schema.org/docs/actions.html\">Actions overview document</a>.",
       "rdfs:label": "Action",
       "rdfs:subClassOf": {
         "@id": "http://schema.org/Thing"
@@ -3271,7 +3271,7 @@
       "http://purl.org/dc/terms/source": {
         "@id": "http://www.w3.org/wiki/WebSchemas/SchemaDotOrgSources#source_bibex"
       },
-      "rdfs:comment": "<p>A part of a successively published publication such as a periodical or multi-volume work, often numbered. It may represent a time span, such as a year.</p>\n<pre><code>  &lt;br/&gt;&lt;br/&gt;See also &lt;a href=\"https://blog.schema.org/2014/09/02/schema-org-support-for-bibliographic-relationships-and-periodicals/"&gt;blog post&lt;/a&gt;.\n</code></pre>",
+      "rdfs:comment": "<p>A part of a successively published publication such as a periodical or multi-volume work, often numbered. It may represent a time span, such as a year.</p>\n<pre><code>  &lt;br/&gt;&lt;br/&gt;See also &lt;a href=\"https://blog.schema.org/2014/09/02/schema-org-support-for-bibliographic-relationships-and-periodicals\"&gt;blog post&lt;/a&gt;.\n</code></pre>",
       "rdfs:label": "PublicationVolume",
       "rdfs:subClassOf": {
         "@id": "http://schema.org/CreativeWork"
@@ -3760,7 +3760,7 @@
     {
       "@id": "http://www.w3.org/wiki/WebSchemas/SchemaDotOrgSources#source_GoodRelationsTerms",
       "@type": "http://schema.org/Organization",
-      "rdfs:comment": "This term <a href=\"https://blog.schema.org/2012/11/08/good-relations-and-schema-org/">uses</a> terminology from the GoodRelations Vocabulary for E-Commerce, created by Martin Hepp. GoodRelations is a data model for sharing e-commerce data on the Web. More information about GoodRelations can be found at <a href=\"http://purl.org/goodrelations/\">http://purl.org/goodrelations/</a>.",
+      "rdfs:comment": "This term <a href=\"https://blog.schema.org/2012/11/08/good-relations-and-schema-org\">uses</a> terminology from the GoodRelations Vocabulary for E-Commerce, created by Martin Hepp. GoodRelations is a data model for sharing e-commerce data on the Web. More information about GoodRelations can be found at <a href=\"http://purl.org/goodrelations/\">http://purl.org/goodrelations/</a>.",
       "rdfs:label": "GoodRelationsTerms"
     },
     {
@@ -4980,7 +4980,7 @@
       "http://www.w3.org/2002/07/owl#equivalentClass": {
         "@id": "http://purl.org/ontology/bibo/Issue"
       },
-      "rdfs:comment": "A part of a successively published publication such as a periodical or publication volume, often numbered, usually containing a grouping of works such as articles.</p>\n<p><a href=\"https://blog.schema.org/2014/09/02/schema-org-support-for-bibliographic-relationships-and-periodicals/">blog post</a>.",
+      "rdfs:comment": "A part of a successively published publication such as a periodical or publication volume, often numbered, usually containing a grouping of works such as articles.</p>\n<p><a href=\"https://blog.schema.org/2014/09/02/schema-org-support-for-bibliographic-relationships-and-periodicals\">blog post</a>.",
       "rdfs:label": "PublicationIssue",
       "rdfs:subClassOf": {
         "@id": "http://schema.org/CreativeWork"
@@ -5001,7 +5001,7 @@
       "http://purl.org/dc/terms/source": {
         "@id": "http://www.w3.org/wiki/WebSchemas/SchemaDotOrgSources#source_rNews"
       },
-      "rdfs:comment": "An article, such as a news article or piece of investigative report. Newspapers and magazines have articles of many different types and this is intended to cover them all.</p>\n<p>See also <a href=\"https://blog.schema.org/2014/09/02/schema-org-support-for-bibliographic-relationships-and-periodicals/">blog post</a>.",
+      "rdfs:comment": "An article, such as a news article or piece of investigative report. Newspapers and magazines have articles of many different types and this is intended to cover them all.</p>\n<p>See also <a href=\"https://blog.schema.org/2014/09/02/schema-org-support-for-bibliographic-relationships-and-periodicals\">blog post</a>.",
       "rdfs:label": "Article",
       "rdfs:subClassOf": {
         "@id": "http://schema.org/CreativeWork"
@@ -12562,7 +12562,7 @@
       "http://www.w3.org/2002/07/owl#equivalentClass": {
         "@id": "http://purl.org/ontology/bibo/Periodical"
       },
-      "rdfs:comment": "A publication in any medium issued in successive parts bearing numerical or chronological designations and intended, such as a magazine, scholarly journal, or newspaper to continue indefinitely.</p>\n<p>See also <a href=\"https://blog.schema.org/2014/09/02/schema-org-support-for-bibliographic-relationships-and-periodicals/">blog post</a>.",
+      "rdfs:comment": "A publication in any medium issued in successive parts bearing numerical or chronological designations and intended, such as a magazine, scholarly journal, or newspaper to continue indefinitely.</p>\n<p>See also <a href=\"https://blog.schema.org/2014/09/02/schema-org-support-for-bibliographic-relationships-and-periodicals\">blog post</a>.",
       "rdfs:label": "Periodical",
       "rdfs:subClassOf": {
         "@id": "http://schema.org/CreativeWorkSeries"
@@ -13791,7 +13791,7 @@
     {
       "@id": "http://schema.org/Role",
       "@type": "rdfs:Class",
-      "rdfs:comment": "Represents additional information about a relationship or property. For example a Role can be used to say that a 'member' role linking some SportsTeam to a player occurred during a particular time period. Or that a Person's 'actor' role in a Movie was for some particular characterName. Such properties can be attached to a Role entity, which is then associated with the main entities using ordinary properties like 'member' or 'actor'.</p>\n<p>See also <a href=\"https://blog.schema.org/2014/06/16/introducing-role/">blog post</a>.",
+      "rdfs:comment": "Represents additional information about a relationship or property. For example a Role can be used to say that a 'member' role linking some SportsTeam to a player occurred during a particular time period. Or that a Person's 'actor' role in a Movie was for some particular characterName. Such properties can be attached to a Role entity, which is then associated with the main entities using ordinary properties like 'member' or 'actor'.</p>\n<p>See also <a href=\"https://blog.schema.org/2014/06/16/introducing-role\">blog post</a>.",
       "rdfs:label": "Role",
       "rdfs:subClassOf": {
         "@id": "http://schema.org/Intangible"

--- a/data/releases/3.2/all-layers.jsonld
+++ b/data/releases/3.2/all-layers.jsonld
@@ -407,7 +407,7 @@
           "http://purl.org/dc/terms/source": {
             "@id": "http://www.w3.org/wiki/WebSchemas/SchemaDotOrgSources#source_ActionCollabClass"
           },
-          "rdfs:comment": "An action performed by a direct agent and indirect participants upon a direct object. Optionally happens at a location with the help of an inanimate instrument. The execution of the action may produce a result. Specific action sub-type documentation specifies the exact expectation of each argument/role.</p>\n\n<p>See also <a href=\"https://blog.schema.org/2014/04/16/announcing-schema-org-actions/">blog post</a> and <a href=\"http://schema.org/docs/actions.html\">Actions overview document</a>.",
+          "rdfs:comment": "An action performed by a direct agent and indirect participants upon a direct object. Optionally happens at a location with the help of an inanimate instrument. The execution of the action may produce a result. Specific action sub-type documentation specifies the exact expectation of each argument/role.</p>\n\n<p>See also <a href=\"https://blog.schema.org/2014/04/16/announcing-schema-org-actions\">blog post</a> and <a href=\"http://schema.org/docs/actions.html\">Actions overview document</a>.",
           "rdfs:label": "Action",
           "rdfs:subClassOf": {
             "@id": "http://schema.org/Thing"
@@ -3295,7 +3295,7 @@
           "http://purl.org/dc/terms/source": {
             "@id": "http://www.w3.org/wiki/WebSchemas/SchemaDotOrgSources#source_bibex"
           },
-          "rdfs:comment": "<p>A part of a successively published publication such as a periodical or multi-volume work, often numbered. It may represent a time span, such as a year.</p>\n\n<pre><code>  &lt;br/&gt;&lt;br/&gt;See also &lt;a href=\"https://blog.schema.org/2014/09/02/schema-org-support-for-bibliographic-relationships-and-periodicals/"&gt;blog post&lt;/a&gt;.\n</code></pre>\n",
+          "rdfs:comment": "<p>A part of a successively published publication such as a periodical or multi-volume work, often numbered. It may represent a time span, such as a year.</p>\n\n<pre><code>  &lt;br/&gt;&lt;br/&gt;See also &lt;a href=\"https://blog.schema.org/2014/09/02/schema-org-support-for-bibliographic-relationships-and-periodicals\"&gt;blog post&lt;/a&gt;.\n</code></pre>\n",
           "rdfs:label": "PublicationVolume",
           "rdfs:subClassOf": {
             "@id": "http://schema.org/CreativeWork"
@@ -3797,7 +3797,7 @@
         {
           "@id": "http://www.w3.org/wiki/WebSchemas/SchemaDotOrgSources#source_GoodRelationsTerms",
           "@type": "http://schema.org/Organization",
-          "rdfs:comment": "This term <a href=\"https://blog.schema.org/2012/11/08/good-relations-and-schema-org/">uses</a> terminology from the GoodRelations Vocabulary for E-Commerce, created by Martin Hepp. GoodRelations is a data model for sharing e-commerce data on the Web. More information about GoodRelations can be found at <a href=\"http://purl.org/goodrelations/\">http://purl.org/goodrelations/</a>.",
+          "rdfs:comment": "This term <a href=\"https://blog.schema.org/2012/11/08/good-relations-and-schema-org\">uses</a> terminology from the GoodRelations Vocabulary for E-Commerce, created by Martin Hepp. GoodRelations is a data model for sharing e-commerce data on the Web. More information about GoodRelations can be found at <a href=\"http://purl.org/goodrelations/\">http://purl.org/goodrelations/</a>.",
           "rdfs:label": "GoodRelationsTerms"
         },
         {
@@ -5005,7 +5005,7 @@
           "http://www.w3.org/2002/07/owl#equivalentClass": {
             "@id": "http://purl.org/ontology/bibo/Issue"
           },
-          "rdfs:comment": "A part of a successively published publication such as a periodical or publication volume, often numbered, usually containing a grouping of works such as articles.</p>\n\n<p><a href=\"https://blog.schema.org/2014/09/02/schema-org-support-for-bibliographic-relationships-and-periodicals/">blog post</a>.",
+          "rdfs:comment": "A part of a successively published publication such as a periodical or publication volume, often numbered, usually containing a grouping of works such as articles.</p>\n\n<p><a href=\"https://blog.schema.org/2014/09/02/schema-org-support-for-bibliographic-relationships-and-periodicals\">blog post</a>.",
           "rdfs:label": "PublicationIssue",
           "rdfs:subClassOf": {
             "@id": "http://schema.org/CreativeWork"
@@ -5055,7 +5055,7 @@
           "http://purl.org/dc/terms/source": {
             "@id": "http://www.w3.org/wiki/WebSchemas/SchemaDotOrgSources#source_rNews"
           },
-          "rdfs:comment": "An article, such as a news article or piece of investigative report. Newspapers and magazines have articles of many different types and this is intended to cover them all.</p>\n\n<p>See also <a href=\"https://blog.schema.org/2014/09/02/schema-org-support-for-bibliographic-relationships-and-periodicals/">blog post</a>.",
+          "rdfs:comment": "An article, such as a news article or piece of investigative report. Newspapers and magazines have articles of many different types and this is intended to cover them all.</p>\n\n<p>See also <a href=\"https://blog.schema.org/2014/09/02/schema-org-support-for-bibliographic-relationships-and-periodicals\">blog post</a>.",
           "rdfs:label": "Article",
           "rdfs:subClassOf": {
             "@id": "http://schema.org/CreativeWork"
@@ -12930,7 +12930,7 @@
           "http://www.w3.org/2002/07/owl#equivalentClass": {
             "@id": "http://purl.org/ontology/bibo/Periodical"
           },
-          "rdfs:comment": "A publication in any medium issued in successive parts bearing numerical or chronological designations and intended, such as a magazine, scholarly journal, or newspaper to continue indefinitely.</p>\n\n<p>See also <a href=\"https://blog.schema.org/2014/09/02/schema-org-support-for-bibliographic-relationships-and-periodicals/">blog post</a>.",
+          "rdfs:comment": "A publication in any medium issued in successive parts bearing numerical or chronological designations and intended, such as a magazine, scholarly journal, or newspaper to continue indefinitely.</p>\n\n<p>See also <a href=\"https://blog.schema.org/2014/09/02/schema-org-support-for-bibliographic-relationships-and-periodicals\">blog post</a>.",
           "rdfs:label": "Periodical",
           "rdfs:subClassOf": {
             "@id": "http://schema.org/CreativeWorkSeries"
@@ -14167,7 +14167,7 @@
         {
           "@id": "http://schema.org/Role",
           "@type": "rdfs:Class",
-          "rdfs:comment": "Represents additional information about a relationship or property. For example a Role can be used to say that a 'member' role linking some SportsTeam to a player occurred during a particular time period. Or that a Person's 'actor' role in a Movie was for some particular characterName. Such properties can be attached to a Role entity, which is then associated with the main entities using ordinary properties like 'member' or 'actor'.</p>\n\n<p>See also <a href=\"https://blog.schema.org/2014/06/16/introducing-role/">blog post</a>.",
+          "rdfs:comment": "Represents additional information about a relationship or property. For example a Role can be used to say that a 'member' role linking some SportsTeam to a player occurred during a particular time period. Or that a Person's 'actor' role in a Movie was for some particular characterName. Such properties can be attached to a Role entity, which is then associated with the main entities using ordinary properties like 'member' or 'actor'.</p>\n\n<p>See also <a href=\"https://blog.schema.org/2014/06/16/introducing-role\">blog post</a>.",
           "rdfs:label": "Role",
           "rdfs:subClassOf": {
             "@id": "http://schema.org/Intangible"

--- a/data/releases/3.2/schema.jsonld
+++ b/data/releases/3.2/schema.jsonld
@@ -408,7 +408,7 @@
       "http://purl.org/dc/terms/source": {
         "@id": "http://www.w3.org/wiki/WebSchemas/SchemaDotOrgSources#source_ActionCollabClass"
       },
-      "rdfs:comment": "An action performed by a direct agent and indirect participants upon a direct object. Optionally happens at a location with the help of an inanimate instrument. The execution of the action may produce a result. Specific action sub-type documentation specifies the exact expectation of each argument/role.</p>\n\n<p>See also <a href=\"https://blog.schema.org/2014/04/16/announcing-schema-org-actions/">blog post</a> and <a href=\"http://schema.org/docs/actions.html\">Actions overview document</a>.",
+      "rdfs:comment": "An action performed by a direct agent and indirect participants upon a direct object. Optionally happens at a location with the help of an inanimate instrument. The execution of the action may produce a result. Specific action sub-type documentation specifies the exact expectation of each argument/role.</p>\n\n<p>See also <a href=\"https://blog.schema.org/2014/04/16/announcing-schema-org-actions\">blog post</a> and <a href=\"http://schema.org/docs/actions.html\">Actions overview document</a>.",
       "rdfs:label": "Action",
       "rdfs:subClassOf": {
         "@id": "http://schema.org/Thing"
@@ -3281,7 +3281,7 @@
       "http://purl.org/dc/terms/source": {
         "@id": "http://www.w3.org/wiki/WebSchemas/SchemaDotOrgSources#source_bibex"
       },
-      "rdfs:comment": "<p>A part of a successively published publication such as a periodical or multi-volume work, often numbered. It may represent a time span, such as a year.</p>\n\n<pre><code>  &lt;br/&gt;&lt;br/&gt;See also &lt;a href=\"https://blog.schema.org/2014/09/02/schema-org-support-for-bibliographic-relationships-and-periodicals/"&gt;blog post&lt;/a&gt;.\n</code></pre>\n",
+      "rdfs:comment": "<p>A part of a successively published publication such as a periodical or multi-volume work, often numbered. It may represent a time span, such as a year.</p>\n\n<pre><code>  &lt;br/&gt;&lt;br/&gt;See also &lt;a href=\"https://blog.schema.org/2014/09/02/schema-org-support-for-bibliographic-relationships-and-periodicals\"&gt;blog post&lt;/a&gt;.\n</code></pre>\n",
       "rdfs:label": "PublicationVolume",
       "rdfs:subClassOf": {
         "@id": "http://schema.org/CreativeWork"
@@ -3782,7 +3782,7 @@
     {
       "@id": "http://www.w3.org/wiki/WebSchemas/SchemaDotOrgSources#source_GoodRelationsTerms",
       "@type": "http://schema.org/Organization",
-      "rdfs:comment": "This term <a href=\"https://blog.schema.org/2012/11/08/good-relations-and-schema-org/">uses</a> terminology from the GoodRelations Vocabulary for E-Commerce, created by Martin Hepp. GoodRelations is a data model for sharing e-commerce data on the Web. More information about GoodRelations can be found at <a href=\"http://purl.org/goodrelations/\">http://purl.org/goodrelations/</a>.",
+      "rdfs:comment": "This term <a href=\"https://blog.schema.org/2012/11/08/good-relations-and-schema-org\">uses</a> terminology from the GoodRelations Vocabulary for E-Commerce, created by Martin Hepp. GoodRelations is a data model for sharing e-commerce data on the Web. More information about GoodRelations can be found at <a href=\"http://purl.org/goodrelations/\">http://purl.org/goodrelations/</a>.",
       "rdfs:label": "GoodRelationsTerms"
     },
     {
@@ -4974,7 +4974,7 @@
       "http://www.w3.org/2002/07/owl#equivalentClass": {
         "@id": "http://purl.org/ontology/bibo/Issue"
       },
-      "rdfs:comment": "A part of a successively published publication such as a periodical or publication volume, often numbered, usually containing a grouping of works such as articles.</p>\n\n<p><a href=\"https://blog.schema.org/2014/09/02/schema-org-support-for-bibliographic-relationships-and-periodicals/">blog post</a>.",
+      "rdfs:comment": "A part of a successively published publication such as a periodical or publication volume, often numbered, usually containing a grouping of works such as articles.</p>\n\n<p><a href=\"https://blog.schema.org/2014/09/02/schema-org-support-for-bibliographic-relationships-and-periodicals\">blog post</a>.",
       "rdfs:label": "PublicationIssue",
       "rdfs:subClassOf": {
         "@id": "http://schema.org/CreativeWork"
@@ -5015,7 +5015,7 @@
       "http://purl.org/dc/terms/source": {
         "@id": "http://www.w3.org/wiki/WebSchemas/SchemaDotOrgSources#source_rNews"
       },
-      "rdfs:comment": "An article, such as a news article or piece of investigative report. Newspapers and magazines have articles of many different types and this is intended to cover them all.</p>\n\n<p>See also <a href=\"https://blog.schema.org/2014/09/02/schema-org-support-for-bibliographic-relationships-and-periodicals/">blog post</a>.",
+      "rdfs:comment": "An article, such as a news article or piece of investigative report. Newspapers and magazines have articles of many different types and this is intended to cover them all.</p>\n\n<p>See also <a href=\"https://blog.schema.org/2014/09/02/schema-org-support-for-bibliographic-relationships-and-periodicals\">blog post</a>.",
       "rdfs:label": "Article",
       "rdfs:subClassOf": {
         "@id": "http://schema.org/CreativeWork"
@@ -12792,7 +12792,7 @@
       "http://www.w3.org/2002/07/owl#equivalentClass": {
         "@id": "http://purl.org/ontology/bibo/Periodical"
       },
-      "rdfs:comment": "A publication in any medium issued in successive parts bearing numerical or chronological designations and intended, such as a magazine, scholarly journal, or newspaper to continue indefinitely.</p>\n\n<p>See also <a href=\"https://blog.schema.org/2014/09/02/schema-org-support-for-bibliographic-relationships-and-periodicals/">blog post</a>.",
+      "rdfs:comment": "A publication in any medium issued in successive parts bearing numerical or chronological designations and intended, such as a magazine, scholarly journal, or newspaper to continue indefinitely.</p>\n\n<p>See also <a href=\"https://blog.schema.org/2014/09/02/schema-org-support-for-bibliographic-relationships-and-periodicals\">blog post</a>.",
       "rdfs:label": "Periodical",
       "rdfs:subClassOf": {
         "@id": "http://schema.org/CreativeWorkSeries"
@@ -14028,7 +14028,7 @@
     {
       "@id": "http://schema.org/Role",
       "@type": "rdfs:Class",
-      "rdfs:comment": "Represents additional information about a relationship or property. For example a Role can be used to say that a 'member' role linking some SportsTeam to a player occurred during a particular time period. Or that a Person's 'actor' role in a Movie was for some particular characterName. Such properties can be attached to a Role entity, which is then associated with the main entities using ordinary properties like 'member' or 'actor'.</p>\n\n<p>See also <a href=\"https://blog.schema.org/2014/06/16/introducing-role/">blog post</a>.",
+      "rdfs:comment": "Represents additional information about a relationship or property. For example a Role can be used to say that a 'member' role linking some SportsTeam to a player occurred during a particular time period. Or that a Person's 'actor' role in a Movie was for some particular characterName. Such properties can be attached to a Role entity, which is then associated with the main entities using ordinary properties like 'member' or 'actor'.</p>\n\n<p>See also <a href=\"https://blog.schema.org/2014/06/16/introducing-role\">blog post</a>.",
       "rdfs:label": "Role",
       "rdfs:subClassOf": {
         "@id": "http://schema.org/Intangible"

--- a/data/releases/3.3/all-layers.jsonld
+++ b/data/releases/3.3/all-layers.jsonld
@@ -5952,7 +5952,7 @@
           "http://purl.org/dc/terms/source": {
             "@id": "http://www.w3.org/wiki/WebSchemas/SchemaDotOrgSources#source_ActionCollabClass"
           },
-          "rdfs:comment": "An action performed by a direct agent and indirect participants upon a direct object. Optionally happens at a location with the help of an inanimate instrument. The execution of the action may produce a result. Specific action sub-type documentation specifies the exact expectation of each argument/role.</p>\n\n<p>See also <a href=\"https://blog.schema.org/2014/04/16/announcing-schema-org-actions/">blog post</a> and <a href=\"http://schema.org/docs/actions.html\">Actions overview document</a>.",
+          "rdfs:comment": "An action performed by a direct agent and indirect participants upon a direct object. Optionally happens at a location with the help of an inanimate instrument. The execution of the action may produce a result. Specific action sub-type documentation specifies the exact expectation of each argument/role.</p>\n\n<p>See also <a href=\"https://blog.schema.org/2014/04/16/announcing-schema-org-actions\">blog post</a> and <a href=\"http://schema.org/docs/actions.html\">Actions overview document</a>.",
           "rdfs:label": "Action",
           "rdfs:subClassOf": {
             "@id": "http://schema.org/Thing"
@@ -8909,7 +8909,7 @@
           "http://purl.org/dc/terms/source": {
             "@id": "http://www.w3.org/wiki/WebSchemas/SchemaDotOrgSources#source_bibex"
           },
-          "rdfs:comment": "<p>A part of a successively published publication such as a periodical or multi-volume work, often numbered. It may represent a time span, such as a year.</p>\n\n<pre><code>  &lt;br/&gt;&lt;br/&gt;See also &lt;a href=\"https://blog.schema.org/2014/09/02/schema-org-support-for-bibliographic-relationships-and-periodicals/"&gt;blog post&lt;/a&gt;.\n</code></pre>\n",
+          "rdfs:comment": "<p>A part of a successively published publication such as a periodical or multi-volume work, often numbered. It may represent a time span, such as a year.</p>\n\n<pre><code>  &lt;br/&gt;&lt;br/&gt;See also &lt;a href=\"https://blog.schema.org/2014/09/02/schema-org-support-for-bibliographic-relationships-and-periodicals\"&gt;blog post&lt;/a&gt;.\n</code></pre>\n",
           "rdfs:label": "PublicationVolume",
           "rdfs:subClassOf": {
             "@id": "http://schema.org/CreativeWork"
@@ -9405,7 +9405,7 @@
         {
           "@id": "http://www.w3.org/wiki/WebSchemas/SchemaDotOrgSources#source_GoodRelationsTerms",
           "@type": "http://schema.org/Organization",
-          "rdfs:comment": "This term <a href=\"https://blog.schema.org/2012/11/08/good-relations-and-schema-org/">uses</a> terminology from the GoodRelations Vocabulary for E-Commerce, created by Martin Hepp. GoodRelations is a data model for sharing e-commerce data on the Web. More information about GoodRelations can be found at <a href=\"http://purl.org/goodrelations/\">http://purl.org/goodrelations/</a>.",
+          "rdfs:comment": "This term <a href=\"https://blog.schema.org/2012/11/08/good-relations-and-schema-org\">uses</a> terminology from the GoodRelations Vocabulary for E-Commerce, created by Martin Hepp. GoodRelations is a data model for sharing e-commerce data on the Web. More information about GoodRelations can be found at <a href=\"http://purl.org/goodrelations/\">http://purl.org/goodrelations/</a>.",
           "rdfs:label": "GoodRelationsTerms"
         },
         {
@@ -10626,7 +10626,7 @@
           "http://www.w3.org/2002/07/owl#equivalentClass": {
             "@id": "http://purl.org/ontology/bibo/Issue"
           },
-          "rdfs:comment": "A part of a successively published publication such as a periodical or publication volume, often numbered, usually containing a grouping of works such as articles.</p>\n\n<p><a href=\"https://blog.schema.org/2014/09/02/schema-org-support-for-bibliographic-relationships-and-periodicals/">blog post</a>.",
+          "rdfs:comment": "A part of a successively published publication such as a periodical or publication volume, often numbered, usually containing a grouping of works such as articles.</p>\n\n<p><a href=\"https://blog.schema.org/2014/09/02/schema-org-support-for-bibliographic-relationships-and-periodicals\">blog post</a>.",
           "rdfs:label": "PublicationIssue",
           "rdfs:subClassOf": {
             "@id": "http://schema.org/CreativeWork"
@@ -10676,7 +10676,7 @@
           "http://purl.org/dc/terms/source": {
             "@id": "http://www.w3.org/wiki/WebSchemas/SchemaDotOrgSources#source_rNews"
           },
-          "rdfs:comment": "An article, such as a news article or piece of investigative report. Newspapers and magazines have articles of many different types and this is intended to cover them all.</p>\n\n<p>See also <a href=\"https://blog.schema.org/2014/09/02/schema-org-support-for-bibliographic-relationships-and-periodicals/">blog post</a>.",
+          "rdfs:comment": "An article, such as a news article or piece of investigative report. Newspapers and magazines have articles of many different types and this is intended to cover them all.</p>\n\n<p>See also <a href=\"https://blog.schema.org/2014/09/02/schema-org-support-for-bibliographic-relationships-and-periodicals\">blog post</a>.",
           "rdfs:label": "Article",
           "rdfs:subClassOf": {
             "@id": "http://schema.org/CreativeWork"
@@ -18675,7 +18675,7 @@
           "http://www.w3.org/2002/07/owl#equivalentClass": {
             "@id": "http://purl.org/ontology/bibo/Periodical"
           },
-          "rdfs:comment": "A publication in any medium issued in successive parts bearing numerical or chronological designations and intended, such as a magazine, scholarly journal, or newspaper to continue indefinitely.</p>\n\n<p>See also <a href=\"https://blog.schema.org/2014/09/02/schema-org-support-for-bibliographic-relationships-and-periodicals/">blog post</a>.",
+          "rdfs:comment": "A publication in any medium issued in successive parts bearing numerical or chronological designations and intended, such as a magazine, scholarly journal, or newspaper to continue indefinitely.</p>\n\n<p>See also <a href=\"https://blog.schema.org/2014/09/02/schema-org-support-for-bibliographic-relationships-and-periodicals\">blog post</a>.",
           "rdfs:label": "Periodical",
           "rdfs:subClassOf": {
             "@id": "http://schema.org/CreativeWorkSeries"
@@ -19973,7 +19973,7 @@
         {
           "@id": "http://schema.org/Role",
           "@type": "rdfs:Class",
-          "rdfs:comment": "Represents additional information about a relationship or property. For example a Role can be used to say that a 'member' role linking some SportsTeam to a player occurred during a particular time period. Or that a Person's 'actor' role in a Movie was for some particular characterName. Such properties can be attached to a Role entity, which is then associated with the main entities using ordinary properties like 'member' or 'actor'.</p>\n\n<p>See also <a href=\"https://blog.schema.org/2014/06/16/introducing-role/">blog post</a>.",
+          "rdfs:comment": "Represents additional information about a relationship or property. For example a Role can be used to say that a 'member' role linking some SportsTeam to a player occurred during a particular time period. Or that a Person's 'actor' role in a Movie was for some particular characterName. Such properties can be attached to a Role entity, which is then associated with the main entities using ordinary properties like 'member' or 'actor'.</p>\n\n<p>See also <a href=\"https://blog.schema.org/2014/06/16/introducing-role\">blog post</a>.",
           "rdfs:label": "Role",
           "rdfs:subClassOf": {
             "@id": "http://schema.org/Intangible"

--- a/data/releases/3.3/schema.jsonld
+++ b/data/releases/3.3/schema.jsonld
@@ -398,7 +398,7 @@
       "http://purl.org/dc/terms/source": {
         "@id": "http://www.w3.org/wiki/WebSchemas/SchemaDotOrgSources#source_ActionCollabClass"
       },
-      "rdfs:comment": "An action performed by a direct agent and indirect participants upon a direct object. Optionally happens at a location with the help of an inanimate instrument. The execution of the action may produce a result. Specific action sub-type documentation specifies the exact expectation of each argument/role.</p>\n\n<p>See also <a href=\"https://blog.schema.org/2014/04/16/announcing-schema-org-actions/">blog post</a> and <a href=\"http://schema.org/docs/actions.html\">Actions overview document</a>.",
+      "rdfs:comment": "An action performed by a direct agent and indirect participants upon a direct object. Optionally happens at a location with the help of an inanimate instrument. The execution of the action may produce a result. Specific action sub-type documentation specifies the exact expectation of each argument/role.</p>\n\n<p>See also <a href=\"https://blog.schema.org/2014/04/16/announcing-schema-org-actions\">blog post</a> and <a href=\"http://schema.org/docs/actions.html\">Actions overview document</a>.",
       "rdfs:label": "Action",
       "rdfs:subClassOf": {
         "@id": "http://schema.org/Thing"
@@ -3355,7 +3355,7 @@
       "http://purl.org/dc/terms/source": {
         "@id": "http://www.w3.org/wiki/WebSchemas/SchemaDotOrgSources#source_bibex"
       },
-      "rdfs:comment": "<p>A part of a successively published publication such as a periodical or multi-volume work, often numbered. It may represent a time span, such as a year.</p>\n\n<pre><code>  &lt;br/&gt;&lt;br/&gt;See also &lt;a href=\"https://blog.schema.org/2014/09/02/schema-org-support-for-bibliographic-relationships-and-periodicals/"&gt;blog post&lt;/a&gt;.\n</code></pre>\n",
+      "rdfs:comment": "<p>A part of a successively published publication such as a periodical or multi-volume work, often numbered. It may represent a time span, such as a year.</p>\n\n<pre><code>  &lt;br/&gt;&lt;br/&gt;See also &lt;a href=\"https://blog.schema.org/2014/09/02/schema-org-support-for-bibliographic-relationships-and-periodicals\"&gt;blog post&lt;/a&gt;.\n</code></pre>\n",
       "rdfs:label": "PublicationVolume",
       "rdfs:subClassOf": {
         "@id": "http://schema.org/CreativeWork"
@@ -3865,7 +3865,7 @@
     {
       "@id": "http://www.w3.org/wiki/WebSchemas/SchemaDotOrgSources#source_GoodRelationsTerms",
       "@type": "http://schema.org/Organization",
-      "rdfs:comment": "This term <a href=\"https://blog.schema.org/2012/11/08/good-relations-and-schema-org/">uses</a> terminology from the GoodRelations Vocabulary for E-Commerce, created by Martin Hepp. GoodRelations is a data model for sharing e-commerce data on the Web. More information about GoodRelations can be found at <a href=\"http://purl.org/goodrelations/\">http://purl.org/goodrelations/</a>.",
+      "rdfs:comment": "This term <a href=\"https://blog.schema.org/2012/11/08/good-relations-and-schema-org\">uses</a> terminology from the GoodRelations Vocabulary for E-Commerce, created by Martin Hepp. GoodRelations is a data model for sharing e-commerce data on the Web. More information about GoodRelations can be found at <a href=\"http://purl.org/goodrelations/\">http://purl.org/goodrelations/</a>.",
       "rdfs:label": "GoodRelationsTerms"
     },
     {
@@ -5085,7 +5085,7 @@
       "http://www.w3.org/2002/07/owl#equivalentClass": {
         "@id": "http://purl.org/ontology/bibo/Issue"
       },
-      "rdfs:comment": "A part of a successively published publication such as a periodical or publication volume, often numbered, usually containing a grouping of works such as articles.</p>\n\n<p><a href=\"https://blog.schema.org/2014/09/02/schema-org-support-for-bibliographic-relationships-and-periodicals/">blog post</a>.",
+      "rdfs:comment": "A part of a successively published publication such as a periodical or publication volume, often numbered, usually containing a grouping of works such as articles.</p>\n\n<p><a href=\"https://blog.schema.org/2014/09/02/schema-org-support-for-bibliographic-relationships-and-periodicals\">blog post</a>.",
       "rdfs:label": "PublicationIssue",
       "rdfs:subClassOf": {
         "@id": "http://schema.org/CreativeWork"
@@ -5135,7 +5135,7 @@
       "http://purl.org/dc/terms/source": {
         "@id": "http://www.w3.org/wiki/WebSchemas/SchemaDotOrgSources#source_rNews"
       },
-      "rdfs:comment": "An article, such as a news article or piece of investigative report. Newspapers and magazines have articles of many different types and this is intended to cover them all.</p>\n\n<p>See also <a href=\"https://blog.schema.org/2014/09/02/schema-org-support-for-bibliographic-relationships-and-periodicals/">blog post</a>.",
+      "rdfs:comment": "An article, such as a news article or piece of investigative report. Newspapers and magazines have articles of many different types and this is intended to cover them all.</p>\n\n<p>See also <a href=\"https://blog.schema.org/2014/09/02/schema-org-support-for-bibliographic-relationships-and-periodicals\">blog post</a>.",
       "rdfs:label": "Article",
       "rdfs:subClassOf": {
         "@id": "http://schema.org/CreativeWork"
@@ -13105,7 +13105,7 @@
       "http://www.w3.org/2002/07/owl#equivalentClass": {
         "@id": "http://purl.org/ontology/bibo/Periodical"
       },
-      "rdfs:comment": "A publication in any medium issued in successive parts bearing numerical or chronological designations and intended, such as a magazine, scholarly journal, or newspaper to continue indefinitely.</p>\n\n<p>See also <a href=\"https://blog.schema.org/2014/09/02/schema-org-support-for-bibliographic-relationships-and-periodicals/">blog post</a>.",
+      "rdfs:comment": "A publication in any medium issued in successive parts bearing numerical or chronological designations and intended, such as a magazine, scholarly journal, or newspaper to continue indefinitely.</p>\n\n<p>See also <a href=\"https://blog.schema.org/2014/09/02/schema-org-support-for-bibliographic-relationships-and-periodicals\">blog post</a>.",
       "rdfs:label": "Periodical",
       "rdfs:subClassOf": {
         "@id": "http://schema.org/CreativeWorkSeries"
@@ -14442,7 +14442,7 @@
     {
       "@id": "http://schema.org/Role",
       "@type": "rdfs:Class",
-      "rdfs:comment": "Represents additional information about a relationship or property. For example a Role can be used to say that a 'member' role linking some SportsTeam to a player occurred during a particular time period. Or that a Person's 'actor' role in a Movie was for some particular characterName. Such properties can be attached to a Role entity, which is then associated with the main entities using ordinary properties like 'member' or 'actor'.</p>\n\n<p>See also <a href=\"https://blog.schema.org/2014/06/16/introducing-role/">blog post</a>.",
+      "rdfs:comment": "Represents additional information about a relationship or property. For example a Role can be used to say that a 'member' role linking some SportsTeam to a player occurred during a particular time period. Or that a Person's 'actor' role in a Movie was for some particular characterName. Such properties can be attached to a Role entity, which is then associated with the main entities using ordinary properties like 'member' or 'actor'.</p>\n\n<p>See also <a href=\"https://blog.schema.org/2014/06/16/introducing-role\">blog post</a>.",
       "rdfs:label": "Role",
       "rdfs:subClassOf": {
         "@id": "http://schema.org/Intangible"

--- a/data/releases/3.4/all-layers.jsonld
+++ b/data/releases/3.4/all-layers.jsonld
@@ -448,7 +448,7 @@
           "http://purl.org/dc/terms/source": {
             "@id": "http://www.w3.org/wiki/WebSchemas/SchemaDotOrgSources#source_ActionCollabClass"
           },
-          "rdfs:comment": "An action performed by a direct agent and indirect participants upon a direct object. Optionally happens at a location with the help of an inanimate instrument. The execution of the action may produce a result. Specific action sub-type documentation specifies the exact expectation of each argument/role.<br/><br/>\n\nSee also <a href=\"https://blog.schema.org/2014/04/16/announcing-schema-org-actions/">blog post</a> and <a href=\"http://schema.org/docs/actions.html\">Actions overview document</a>.",
+          "rdfs:comment": "An action performed by a direct agent and indirect participants upon a direct object. Optionally happens at a location with the help of an inanimate instrument. The execution of the action may produce a result. Specific action sub-type documentation specifies the exact expectation of each argument/role.<br/><br/>\n\nSee also <a href=\"https://blog.schema.org/2014/04/16/announcing-schema-org-actions\">blog post</a> and <a href=\"http://schema.org/docs/actions.html\">Actions overview document</a>.",
           "rdfs:label": "Action",
           "rdfs:subClassOf": {
             "@id": "http://schema.org/Thing"
@@ -3342,7 +3342,7 @@
           "http://purl.org/dc/terms/source": {
             "@id": "http://www.w3.org/wiki/WebSchemas/SchemaDotOrgSources#source_bibex"
           },
-          "rdfs:comment": "A part of a successively published publication such as a periodical or multi-volume work, often numbered. It may represent a time span, such as a year.<br/><br/>\n\n<pre><code>  &lt;br/&gt;&lt;br/&gt;See also &lt;a href=\"https://blog.schema.org/2014/09/02/schema-org-support-for-bibliographic-relationships-and-periodicals/"&gt;blog post&lt;/a&gt;.\n</code></pre>\n",
+          "rdfs:comment": "A part of a successively published publication such as a periodical or multi-volume work, often numbered. It may represent a time span, such as a year.<br/><br/>\n\n<pre><code>  &lt;br/&gt;&lt;br/&gt;See also &lt;a href=\"https://blog.schema.org/2014/09/02/schema-org-support-for-bibliographic-relationships-and-periodicals\"&gt;blog post&lt;/a&gt;.\n</code></pre>\n",
           "rdfs:label": "PublicationVolume",
           "rdfs:subClassOf": {
             "@id": "http://schema.org/CreativeWork"
@@ -3861,7 +3861,7 @@
         {
           "@id": "http://www.w3.org/wiki/WebSchemas/SchemaDotOrgSources#source_GoodRelationsTerms",
           "@type": "http://schema.org/Organization",
-          "rdfs:comment": "This term <a href=\"https://blog.schema.org/2012/11/08/good-relations-and-schema-org/">uses</a> terminology from the GoodRelations Vocabulary for E-Commerce, created by Martin Hepp. GoodRelations is a data model for sharing e-commerce data on the Web. More information about GoodRelations can be found at <a href=\"http://purl.org/goodrelations/\">http://purl.org/goodrelations/</a>.",
+          "rdfs:comment": "This term <a href=\"https://blog.schema.org/2012/11/08/good-relations-and-schema-org\">uses</a> terminology from the GoodRelations Vocabulary for E-Commerce, created by Martin Hepp. GoodRelations is a data model for sharing e-commerce data on the Web. More information about GoodRelations can be found at <a href=\"http://purl.org/goodrelations/\">http://purl.org/goodrelations/</a>.",
           "rdfs:label": "GoodRelationsTerms"
         },
         {
@@ -5083,7 +5083,7 @@
           "http://www.w3.org/2002/07/owl#equivalentClass": {
             "@id": "http://purl.org/ontology/bibo/Issue"
           },
-          "rdfs:comment": "A part of a successively published publication such as a periodical or publication volume, often numbered, usually containing a grouping of works such as articles.<br/><br/>\n\n<a href=\"https://blog.schema.org/2014/09/02/schema-org-support-for-bibliographic-relationships-and-periodicals/">blog post</a>.",
+          "rdfs:comment": "A part of a successively published publication such as a periodical or publication volume, often numbered, usually containing a grouping of works such as articles.<br/><br/>\n\n<a href=\"https://blog.schema.org/2014/09/02/schema-org-support-for-bibliographic-relationships-and-periodicals\">blog post</a>.",
           "rdfs:label": "PublicationIssue",
           "rdfs:subClassOf": {
             "@id": "http://schema.org/CreativeWork"
@@ -5124,7 +5124,7 @@
           "http://purl.org/dc/terms/source": {
             "@id": "http://www.w3.org/wiki/WebSchemas/SchemaDotOrgSources#source_rNews"
           },
-          "rdfs:comment": "An article, such as a news article or piece of investigative report. Newspapers and magazines have articles of many different types and this is intended to cover them all.<br/><br/>\n\nSee also <a href=\"https://blog.schema.org/2014/09/02/schema-org-support-for-bibliographic-relationships-and-periodicals/">blog post</a>.",
+          "rdfs:comment": "An article, such as a news article or piece of investigative report. Newspapers and magazines have articles of many different types and this is intended to cover them all.<br/><br/>\n\nSee also <a href=\"https://blog.schema.org/2014/09/02/schema-org-support-for-bibliographic-relationships-and-periodicals\">blog post</a>.",
           "rdfs:label": "Article",
           "rdfs:subClassOf": {
             "@id": "http://schema.org/CreativeWork"
@@ -13186,7 +13186,7 @@
           "http://www.w3.org/2002/07/owl#equivalentClass": {
             "@id": "http://purl.org/ontology/bibo/Periodical"
           },
-          "rdfs:comment": "A publication in any medium issued in successive parts bearing numerical or chronological designations and intended, such as a magazine, scholarly journal, or newspaper to continue indefinitely.<br/><br/>\n\nSee also <a href=\"https://blog.schema.org/2014/09/02/schema-org-support-for-bibliographic-relationships-and-periodicals/">blog post</a>.",
+          "rdfs:comment": "A publication in any medium issued in successive parts bearing numerical or chronological designations and intended, such as a magazine, scholarly journal, or newspaper to continue indefinitely.<br/><br/>\n\nSee also <a href=\"https://blog.schema.org/2014/09/02/schema-org-support-for-bibliographic-relationships-and-periodicals\">blog post</a>.",
           "rdfs:label": "Periodical",
           "rdfs:subClassOf": {
             "@id": "http://schema.org/CreativeWorkSeries"
@@ -14472,7 +14472,7 @@
         {
           "@id": "http://schema.org/Role",
           "@type": "rdfs:Class",
-          "rdfs:comment": "Represents additional information about a relationship or property. For example a Role can be used to say that a 'member' role linking some SportsTeam to a player occurred during a particular time period. Or that a Person's 'actor' role in a Movie was for some particular characterName. Such properties can be attached to a Role entity, which is then associated with the main entities using ordinary properties like 'member' or 'actor'.<br/><br/>\n\nSee also <a href=\"https://blog.schema.org/2014/06/16/introducing-role/">blog post</a>.",
+          "rdfs:comment": "Represents additional information about a relationship or property. For example a Role can be used to say that a 'member' role linking some SportsTeam to a player occurred during a particular time period. Or that a Person's 'actor' role in a Movie was for some particular characterName. Such properties can be attached to a Role entity, which is then associated with the main entities using ordinary properties like 'member' or 'actor'.<br/><br/>\n\nSee also <a href=\"https://blog.schema.org/2014/06/16/introducing-role\">blog post</a>.",
           "rdfs:label": "Role",
           "rdfs:subClassOf": {
             "@id": "http://schema.org/Intangible"

--- a/data/releases/3.4/schema.jsonld
+++ b/data/releases/3.4/schema.jsonld
@@ -424,7 +424,7 @@
       "http://purl.org/dc/terms/source": {
         "@id": "http://www.w3.org/wiki/WebSchemas/SchemaDotOrgSources#source_ActionCollabClass"
       },
-      "rdfs:comment": "An action performed by a direct agent and indirect participants upon a direct object. Optionally happens at a location with the help of an inanimate instrument. The execution of the action may produce a result. Specific action sub-type documentation specifies the exact expectation of each argument/role.<br/><br/>\n\nSee also <a href=\"https://blog.schema.org/2014/04/16/announcing-schema-org-actions/">blog post</a> and <a href=\"http://schema.org/docs/actions.html\">Actions overview document</a>.",
+      "rdfs:comment": "An action performed by a direct agent and indirect participants upon a direct object. Optionally happens at a location with the help of an inanimate instrument. The execution of the action may produce a result. Specific action sub-type documentation specifies the exact expectation of each argument/role.<br/><br/>\n\nSee also <a href=\"https://blog.schema.org/2014/04/16/announcing-schema-org-actions\">blog post</a> and <a href=\"http://schema.org/docs/actions.html\">Actions overview document</a>.",
       "rdfs:label": "Action",
       "rdfs:subClassOf": {
         "@id": "http://schema.org/Thing"
@@ -3402,7 +3402,7 @@
       "http://purl.org/dc/terms/source": {
         "@id": "http://www.w3.org/wiki/WebSchemas/SchemaDotOrgSources#source_bibex"
       },
-      "rdfs:comment": "A part of a successively published publication such as a periodical or multi-volume work, often numbered. It may represent a time span, such as a year.<br/><br/>\n\n<pre><code>  &lt;br/&gt;&lt;br/&gt;See also &lt;a href=\"https://blog.schema.org/2014/09/02/schema-org-support-for-bibliographic-relationships-and-periodicals/"&gt;blog post&lt;/a&gt;.\n</code></pre>\n",
+      "rdfs:comment": "A part of a successively published publication such as a periodical or multi-volume work, often numbered. It may represent a time span, such as a year.<br/><br/>\n\n<pre><code>  &lt;br/&gt;&lt;br/&gt;See also &lt;a href=\"https://blog.schema.org/2014/09/02/schema-org-support-for-bibliographic-relationships-and-periodicals\"&gt;blog post&lt;/a&gt;.\n</code></pre>\n",
       "rdfs:label": "PublicationVolume",
       "rdfs:subClassOf": {
         "@id": "http://schema.org/CreativeWork"
@@ -3906,7 +3906,7 @@
     {
       "@id": "http://www.w3.org/wiki/WebSchemas/SchemaDotOrgSources#source_GoodRelationsTerms",
       "@type": "http://schema.org/Organization",
-      "rdfs:comment": "This term <a href=\"https://blog.schema.org/2012/11/08/good-relations-and-schema-org/">uses</a> terminology from the GoodRelations Vocabulary for E-Commerce, created by Martin Hepp. GoodRelations is a data model for sharing e-commerce data on the Web. More information about GoodRelations can be found at <a href=\"http://purl.org/goodrelations/\">http://purl.org/goodrelations/</a>.",
+      "rdfs:comment": "This term <a href=\"https://blog.schema.org/2012/11/08/good-relations-and-schema-org\">uses</a> terminology from the GoodRelations Vocabulary for E-Commerce, created by Martin Hepp. GoodRelations is a data model for sharing e-commerce data on the Web. More information about GoodRelations can be found at <a href=\"http://purl.org/goodrelations/\">http://purl.org/goodrelations/</a>.",
       "rdfs:label": "GoodRelationsTerms"
     },
     {
@@ -5127,7 +5127,7 @@
       "http://www.w3.org/2002/07/owl#equivalentClass": {
         "@id": "http://purl.org/ontology/bibo/Issue"
       },
-      "rdfs:comment": "A part of a successively published publication such as a periodical or publication volume, often numbered, usually containing a grouping of works such as articles.<br/><br/>\n\n<a href=\"https://blog.schema.org/2014/09/02/schema-org-support-for-bibliographic-relationships-and-periodicals/">blog post</a>.",
+      "rdfs:comment": "A part of a successively published publication such as a periodical or publication volume, often numbered, usually containing a grouping of works such as articles.<br/><br/>\n\n<a href=\"https://blog.schema.org/2014/09/02/schema-org-support-for-bibliographic-relationships-and-periodicals\">blog post</a>.",
       "rdfs:label": "PublicationIssue",
       "rdfs:subClassOf": {
         "@id": "http://schema.org/CreativeWork"
@@ -5177,7 +5177,7 @@
       "http://purl.org/dc/terms/source": {
         "@id": "http://www.w3.org/wiki/WebSchemas/SchemaDotOrgSources#source_rNews"
       },
-      "rdfs:comment": "An article, such as a news article or piece of investigative report. Newspapers and magazines have articles of many different types and this is intended to cover them all.<br/><br/>\n\nSee also <a href=\"https://blog.schema.org/2014/09/02/schema-org-support-for-bibliographic-relationships-and-periodicals/">blog post</a>.",
+      "rdfs:comment": "An article, such as a news article or piece of investigative report. Newspapers and magazines have articles of many different types and this is intended to cover them all.<br/><br/>\n\nSee also <a href=\"https://blog.schema.org/2014/09/02/schema-org-support-for-bibliographic-relationships-and-periodicals\">blog post</a>.",
       "rdfs:label": "Article",
       "rdfs:subClassOf": {
         "@id": "http://schema.org/CreativeWork"
@@ -13183,7 +13183,7 @@
       "http://www.w3.org/2002/07/owl#equivalentClass": {
         "@id": "http://purl.org/ontology/bibo/Periodical"
       },
-      "rdfs:comment": "A publication in any medium issued in successive parts bearing numerical or chronological designations and intended, such as a magazine, scholarly journal, or newspaper to continue indefinitely.<br/><br/>\n\nSee also <a href=\"https://blog.schema.org/2014/09/02/schema-org-support-for-bibliographic-relationships-and-periodicals/">blog post</a>.",
+      "rdfs:comment": "A publication in any medium issued in successive parts bearing numerical or chronological designations and intended, such as a magazine, scholarly journal, or newspaper to continue indefinitely.<br/><br/>\n\nSee also <a href=\"https://blog.schema.org/2014/09/02/schema-org-support-for-bibliographic-relationships-and-periodicals\">blog post</a>.",
       "rdfs:label": "Periodical",
       "rdfs:subClassOf": {
         "@id": "http://schema.org/CreativeWorkSeries"
@@ -14490,7 +14490,7 @@
     {
       "@id": "http://schema.org/Role",
       "@type": "rdfs:Class",
-      "rdfs:comment": "Represents additional information about a relationship or property. For example a Role can be used to say that a 'member' role linking some SportsTeam to a player occurred during a particular time period. Or that a Person's 'actor' role in a Movie was for some particular characterName. Such properties can be attached to a Role entity, which is then associated with the main entities using ordinary properties like 'member' or 'actor'.<br/><br/>\n\nSee also <a href=\"https://blog.schema.org/2014/06/16/introducing-role/">blog post</a>.",
+      "rdfs:comment": "Represents additional information about a relationship or property. For example a Role can be used to say that a 'member' role linking some SportsTeam to a player occurred during a particular time period. Or that a Person's 'actor' role in a Movie was for some particular characterName. Such properties can be attached to a Role entity, which is then associated with the main entities using ordinary properties like 'member' or 'actor'.<br/><br/>\n\nSee also <a href=\"https://blog.schema.org/2014/06/16/introducing-role\">blog post</a>.",
       "rdfs:label": "Role",
       "rdfs:subClassOf": {
         "@id": "http://schema.org/Intangible"

--- a/data/releases/3.5/all-layers.jsonld
+++ b/data/releases/3.5/all-layers.jsonld
@@ -656,7 +656,7 @@
       "http://purl.org/dc/terms/source": {
         "@id": "http://www.w3.org/wiki/WebSchemas/SchemaDotOrgSources#source_ActionCollabClass"
       },
-      "rdfs:comment": "An action performed by a direct agent and indirect participants upon a direct object. Optionally happens at a location with the help of an inanimate instrument. The execution of the action may produce a result. Specific action sub-type documentation specifies the exact expectation of each argument/role.<br/><br/>\n\nSee also <a href=\"https://blog.schema.org/2014/04/16/announcing-schema-org-actions/">blog post</a> and <a href=\"http://schema.org/docs/actions.html\">Actions overview document</a>.",
+      "rdfs:comment": "An action performed by a direct agent and indirect participants upon a direct object. Optionally happens at a location with the help of an inanimate instrument. The execution of the action may produce a result. Specific action sub-type documentation specifies the exact expectation of each argument/role.<br/><br/>\n\nSee also <a href=\"https://blog.schema.org/2014/04/16/announcing-schema-org-actions\">blog post</a> and <a href=\"http://schema.org/docs/actions.html\">Actions overview document</a>.",
       "rdfs:label": "Action",
       "rdfs:subClassOf": {
         "@id": "http://schema.org/Thing"
@@ -5152,7 +5152,7 @@
       "http://purl.org/dc/terms/source": {
         "@id": "http://www.w3.org/wiki/WebSchemas/SchemaDotOrgSources#source_bibex"
       },
-      "rdfs:comment": "A part of a successively published publication such as a periodical or multi-volume work, often numbered. It may represent a time span, such as a year.<br/><br/>\n\n<pre><code>  &lt;br/&gt;&lt;br/&gt;See also &lt;a href=\"https://blog.schema.org/2014/09/02/schema-org-support-for-bibliographic-relationships-and-periodicals/"&gt;blog post&lt;/a&gt;.\n</code></pre>\n",
+      "rdfs:comment": "A part of a successively published publication such as a periodical or multi-volume work, often numbered. It may represent a time span, such as a year.<br/><br/>\n\n<pre><code>  &lt;br/&gt;&lt;br/&gt;See also &lt;a href=\"https://blog.schema.org/2014/09/02/schema-org-support-for-bibliographic-relationships-and-periodicals\"&gt;blog post&lt;/a&gt;.\n</code></pre>\n",
       "rdfs:label": "PublicationVolume",
       "rdfs:subClassOf": {
         "@id": "http://schema.org/CreativeWork"
@@ -7908,7 +7908,7 @@
       "http://www.w3.org/2002/07/owl#equivalentClass": {
         "@id": "http://purl.org/ontology/bibo/Issue"
       },
-      "rdfs:comment": "A part of a successively published publication such as a periodical or publication volume, often numbered, usually containing a grouping of works such as articles.<br/><br/>\n\n<a href=\"https://blog.schema.org/2014/09/02/schema-org-support-for-bibliographic-relationships-and-periodicals/">blog post</a>.",
+      "rdfs:comment": "A part of a successively published publication such as a periodical or publication volume, often numbered, usually containing a grouping of works such as articles.<br/><br/>\n\n<a href=\"https://blog.schema.org/2014/09/02/schema-org-support-for-bibliographic-relationships-and-periodicals\">blog post</a>.",
       "rdfs:label": "PublicationIssue",
       "rdfs:subClassOf": {
         "@id": "http://schema.org/CreativeWork"
@@ -7988,7 +7988,7 @@
       "http://purl.org/dc/terms/source": {
         "@id": "http://www.w3.org/wiki/WebSchemas/SchemaDotOrgSources#source_rNews"
       },
-      "rdfs:comment": "An article, such as a news article or piece of investigative report. Newspapers and magazines have articles of many different types and this is intended to cover them all.<br/><br/>\n\nSee also <a href=\"https://blog.schema.org/2014/09/02/schema-org-support-for-bibliographic-relationships-and-periodicals/">blog post</a>.",
+      "rdfs:comment": "An article, such as a news article or piece of investigative report. Newspapers and magazines have articles of many different types and this is intended to cover them all.<br/><br/>\n\nSee also <a href=\"https://blog.schema.org/2014/09/02/schema-org-support-for-bibliographic-relationships-and-periodicals\">blog post</a>.",
       "rdfs:label": "Article",
       "rdfs:subClassOf": {
         "@id": "http://schema.org/CreativeWork"
@@ -19904,7 +19904,7 @@
       "http://www.w3.org/2002/07/owl#equivalentClass": {
         "@id": "http://purl.org/ontology/bibo/Periodical"
       },
-      "rdfs:comment": "A publication in any medium issued in successive parts bearing numerical or chronological designations and intended, such as a magazine, scholarly journal, or newspaper to continue indefinitely.<br/><br/>\n\nSee also <a href=\"https://blog.schema.org/2014/09/02/schema-org-support-for-bibliographic-relationships-and-periodicals/">blog post</a>.",
+      "rdfs:comment": "A publication in any medium issued in successive parts bearing numerical or chronological designations and intended, such as a magazine, scholarly journal, or newspaper to continue indefinitely.<br/><br/>\n\nSee also <a href=\"https://blog.schema.org/2014/09/02/schema-org-support-for-bibliographic-relationships-and-periodicals\">blog post</a>.",
       "rdfs:label": "Periodical",
       "rdfs:subClassOf": {
         "@id": "http://schema.org/CreativeWorkSeries"
@@ -22016,7 +22016,7 @@
     {
       "@id": "http://schema.org/Role",
       "@type": "rdfs:Class",
-      "rdfs:comment": "Represents additional information about a relationship or property. For example a Role can be used to say that a 'member' role linking some SportsTeam to a player occurred during a particular time period. Or that a Person's 'actor' role in a Movie was for some particular characterName. Such properties can be attached to a Role entity, which is then associated with the main entities using ordinary properties like 'member' or 'actor'.<br/><br/>\n\nSee also <a href=\"https://blog.schema.org/2014/06/16/introducing-role/">blog post</a>.",
+      "rdfs:comment": "Represents additional information about a relationship or property. For example a Role can be used to say that a 'member' role linking some SportsTeam to a player occurred during a particular time period. Or that a Person's 'actor' role in a Movie was for some particular characterName. Such properties can be attached to a Role entity, which is then associated with the main entities using ordinary properties like 'member' or 'actor'.<br/><br/>\n\nSee also <a href=\"https://blog.schema.org/2014/06/16/introducing-role\">blog post</a>.",
       "rdfs:label": "Role",
       "rdfs:subClassOf": {
         "@id": "http://schema.org/Intangible"

--- a/data/releases/3.5/schema.jsonld
+++ b/data/releases/3.5/schema.jsonld
@@ -437,7 +437,7 @@
       "http://purl.org/dc/terms/source": {
         "@id": "http://www.w3.org/wiki/WebSchemas/SchemaDotOrgSources#source_ActionCollabClass"
       },
-      "rdfs:comment": "An action performed by a direct agent and indirect participants upon a direct object. Optionally happens at a location with the help of an inanimate instrument. The execution of the action may produce a result. Specific action sub-type documentation specifies the exact expectation of each argument/role.<br/><br/>\n\nSee also <a href=\"https://blog.schema.org/2014/04/16/announcing-schema-org-actions/">blog post</a> and <a href=\"http://schema.org/docs/actions.html\">Actions overview document</a>.",
+      "rdfs:comment": "An action performed by a direct agent and indirect participants upon a direct object. Optionally happens at a location with the help of an inanimate instrument. The execution of the action may produce a result. Specific action sub-type documentation specifies the exact expectation of each argument/role.<br/><br/>\n\nSee also <a href=\"https://blog.schema.org/2014/04/16/announcing-schema-org-actions\">blog post</a> and <a href=\"http://schema.org/docs/actions.html\">Actions overview document</a>.",
       "rdfs:label": "Action",
       "rdfs:subClassOf": {
         "@id": "http://schema.org/Thing"
@@ -3454,7 +3454,7 @@
       "http://purl.org/dc/terms/source": {
         "@id": "http://www.w3.org/wiki/WebSchemas/SchemaDotOrgSources#source_bibex"
       },
-      "rdfs:comment": "A part of a successively published publication such as a periodical or multi-volume work, often numbered. It may represent a time span, such as a year.<br/><br/>\n\n<pre><code>  &lt;br/&gt;&lt;br/&gt;See also &lt;a href=\"https://blog.schema.org/2014/09/02/schema-org-support-for-bibliographic-relationships-and-periodicals/"&gt;blog post&lt;/a&gt;.\n</code></pre>\n",
+      "rdfs:comment": "A part of a successively published publication such as a periodical or multi-volume work, often numbered. It may represent a time span, such as a year.<br/><br/>\n\n<pre><code>  &lt;br/&gt;&lt;br/&gt;See also &lt;a href=\"https://blog.schema.org/2014/09/02/schema-org-support-for-bibliographic-relationships-and-periodicals\"&gt;blog post&lt;/a&gt;.\n</code></pre>\n",
       "rdfs:label": "PublicationVolume",
       "rdfs:subClassOf": {
         "@id": "http://schema.org/CreativeWork"
@@ -5271,7 +5271,7 @@
       "http://www.w3.org/2002/07/owl#equivalentClass": {
         "@id": "http://purl.org/ontology/bibo/Issue"
       },
-      "rdfs:comment": "A part of a successively published publication such as a periodical or publication volume, often numbered, usually containing a grouping of works such as articles.<br/><br/>\n\n<a href=\"https://blog.schema.org/2014/09/02/schema-org-support-for-bibliographic-relationships-and-periodicals/">blog post</a>.",
+      "rdfs:comment": "A part of a successively published publication such as a periodical or publication volume, often numbered, usually containing a grouping of works such as articles.<br/><br/>\n\n<a href=\"https://blog.schema.org/2014/09/02/schema-org-support-for-bibliographic-relationships-and-periodicals\">blog post</a>.",
       "rdfs:label": "PublicationIssue",
       "rdfs:subClassOf": {
         "@id": "http://schema.org/CreativeWork"
@@ -5312,7 +5312,7 @@
       "http://purl.org/dc/terms/source": {
         "@id": "http://www.w3.org/wiki/WebSchemas/SchemaDotOrgSources#source_rNews"
       },
-      "rdfs:comment": "An article, such as a news article or piece of investigative report. Newspapers and magazines have articles of many different types and this is intended to cover them all.<br/><br/>\n\nSee also <a href=\"https://blog.schema.org/2014/09/02/schema-org-support-for-bibliographic-relationships-and-periodicals/">blog post</a>.",
+      "rdfs:comment": "An article, such as a news article or piece of investigative report. Newspapers and magazines have articles of many different types and this is intended to cover them all.<br/><br/>\n\nSee also <a href=\"https://blog.schema.org/2014/09/02/schema-org-support-for-bibliographic-relationships-and-periodicals\">blog post</a>.",
       "rdfs:label": "Article",
       "rdfs:subClassOf": {
         "@id": "http://schema.org/CreativeWork"
@@ -13747,7 +13747,7 @@
       "http://www.w3.org/2002/07/owl#equivalentClass": {
         "@id": "http://purl.org/ontology/bibo/Periodical"
       },
-      "rdfs:comment": "A publication in any medium issued in successive parts bearing numerical or chronological designations and intended, such as a magazine, scholarly journal, or newspaper to continue indefinitely.<br/><br/>\n\nSee also <a href=\"https://blog.schema.org/2014/09/02/schema-org-support-for-bibliographic-relationships-and-periodicals/">blog post</a>.",
+      "rdfs:comment": "A publication in any medium issued in successive parts bearing numerical or chronological designations and intended, such as a magazine, scholarly journal, or newspaper to continue indefinitely.<br/><br/>\n\nSee also <a href=\"https://blog.schema.org/2014/09/02/schema-org-support-for-bibliographic-relationships-and-periodicals\">blog post</a>.",
       "rdfs:label": "Periodical",
       "rdfs:subClassOf": {
         "@id": "http://schema.org/CreativeWorkSeries"
@@ -15056,7 +15056,7 @@
     {
       "@id": "http://schema.org/Role",
       "@type": "rdfs:Class",
-      "rdfs:comment": "Represents additional information about a relationship or property. For example a Role can be used to say that a 'member' role linking some SportsTeam to a player occurred during a particular time period. Or that a Person's 'actor' role in a Movie was for some particular characterName. Such properties can be attached to a Role entity, which is then associated with the main entities using ordinary properties like 'member' or 'actor'.<br/><br/>\n\nSee also <a href=\"https://blog.schema.org/2014/06/16/introducing-role/">blog post</a>.",
+      "rdfs:comment": "Represents additional information about a relationship or property. For example a Role can be used to say that a 'member' role linking some SportsTeam to a player occurred during a particular time period. Or that a Person's 'actor' role in a Movie was for some particular characterName. Such properties can be attached to a Role entity, which is then associated with the main entities using ordinary properties like 'member' or 'actor'.<br/><br/>\n\nSee also <a href=\"https://blog.schema.org/2014/06/16/introducing-role\">blog post</a>.",
       "rdfs:label": "Role",
       "rdfs:subClassOf": {
         "@id": "http://schema.org/Intangible"

--- a/data/releases/3.6/all-layers.jsonld
+++ b/data/releases/3.6/all-layers.jsonld
@@ -640,7 +640,7 @@
       "http://purl.org/dc/terms/source": {
         "@id": "http://www.w3.org/wiki/WebSchemas/SchemaDotOrgSources#source_ActionCollabClass"
       },
-      "rdfs:comment": "An action performed by a direct agent and indirect participants upon a direct object. Optionally happens at a location with the help of an inanimate instrument. The execution of the action may produce a result. Specific action sub-type documentation specifies the exact expectation of each argument/role.<br/><br/>\n\nSee also <a href=\"https://blog.schema.org/2014/04/16/announcing-schema-org-actions/">blog post</a> and <a href=\"http://schema.org/docs/actions.html\">Actions overview document</a>.",
+      "rdfs:comment": "An action performed by a direct agent and indirect participants upon a direct object. Optionally happens at a location with the help of an inanimate instrument. The execution of the action may produce a result. Specific action sub-type documentation specifies the exact expectation of each argument/role.<br/><br/>\n\nSee also <a href=\"https://blog.schema.org/2014/04/16/announcing-schema-org-actions\">blog post</a> and <a href=\"http://schema.org/docs/actions.html\">Actions overview document</a>.",
       "rdfs:label": "Action",
       "rdfs:subClassOf": {
         "@id": "http://schema.org/Thing"
@@ -5109,7 +5109,7 @@
       "http://purl.org/dc/terms/source": {
         "@id": "http://www.w3.org/wiki/WebSchemas/SchemaDotOrgSources#source_bibex"
       },
-      "rdfs:comment": "A part of a successively published publication such as a periodical or multi-volume work, often numbered. It may represent a time span, such as a year.<br/><br/>\n\n<pre><code>  &lt;br/&gt;&lt;br/&gt;See also &lt;a href=\"https://blog.schema.org/2014/09/02/schema-org-support-for-bibliographic-relationships-and-periodicals/"&gt;blog post&lt;/a&gt;.\n</code></pre>\n",
+      "rdfs:comment": "A part of a successively published publication such as a periodical or multi-volume work, often numbered. It may represent a time span, such as a year.<br/><br/>\n\n<pre><code>  &lt;br/&gt;&lt;br/&gt;See also &lt;a href=\"https://blog.schema.org/2014/09/02/schema-org-support-for-bibliographic-relationships-and-periodicals\"&gt;blog post&lt;/a&gt;.\n</code></pre>\n",
       "rdfs:label": "PublicationVolume",
       "rdfs:subClassOf": {
         "@id": "http://schema.org/CreativeWork"
@@ -7760,7 +7760,7 @@
       "http://www.w3.org/2002/07/owl#equivalentClass": {
         "@id": "http://purl.org/ontology/bibo/Issue"
       },
-      "rdfs:comment": "A part of a successively published publication such as a periodical or publication volume, often numbered, usually containing a grouping of works such as articles.<br/><br/>\n\n<a href=\"https://blog.schema.org/2014/09/02/schema-org-support-for-bibliographic-relationships-and-periodicals/">blog post</a>.",
+      "rdfs:comment": "A part of a successively published publication such as a periodical or publication volume, often numbered, usually containing a grouping of works such as articles.<br/><br/>\n\n<a href=\"https://blog.schema.org/2014/09/02/schema-org-support-for-bibliographic-relationships-and-periodicals\">blog post</a>.",
       "rdfs:label": "PublicationIssue",
       "rdfs:subClassOf": {
         "@id": "http://schema.org/CreativeWork"
@@ -7840,7 +7840,7 @@
       "http://purl.org/dc/terms/source": {
         "@id": "http://www.w3.org/wiki/WebSchemas/SchemaDotOrgSources#source_rNews"
       },
-      "rdfs:comment": "An article, such as a news article or piece of investigative report. Newspapers and magazines have articles of many different types and this is intended to cover them all.<br/><br/>\n\nSee also <a href=\"https://blog.schema.org/2014/09/02/schema-org-support-for-bibliographic-relationships-and-periodicals/">blog post</a>.",
+      "rdfs:comment": "An article, such as a news article or piece of investigative report. Newspapers and magazines have articles of many different types and this is intended to cover them all.<br/><br/>\n\nSee also <a href=\"https://blog.schema.org/2014/09/02/schema-org-support-for-bibliographic-relationships-and-periodicals\">blog post</a>.",
       "rdfs:label": "Article",
       "rdfs:subClassOf": {
         "@id": "http://schema.org/CreativeWork"
@@ -19774,7 +19774,7 @@
       "http://www.w3.org/2002/07/owl#equivalentClass": {
         "@id": "http://purl.org/ontology/bibo/Periodical"
       },
-      "rdfs:comment": "A publication in any medium issued in successive parts bearing numerical or chronological designations and intended, such as a magazine, scholarly journal, or newspaper to continue indefinitely.<br/><br/>\n\nSee also <a href=\"https://blog.schema.org/2014/09/02/schema-org-support-for-bibliographic-relationships-and-periodicals/">blog post</a>.",
+      "rdfs:comment": "A publication in any medium issued in successive parts bearing numerical or chronological designations and intended, such as a magazine, scholarly journal, or newspaper to continue indefinitely.<br/><br/>\n\nSee also <a href=\"https://blog.schema.org/2014/09/02/schema-org-support-for-bibliographic-relationships-and-periodicals\">blog post</a>.",
       "rdfs:label": "Periodical",
       "rdfs:subClassOf": {
         "@id": "http://schema.org/CreativeWorkSeries"
@@ -21842,7 +21842,7 @@
     {
       "@id": "http://schema.org/Role",
       "@type": "rdfs:Class",
-      "rdfs:comment": "Represents additional information about a relationship or property. For example a Role can be used to say that a 'member' role linking some SportsTeam to a player occurred during a particular time period. Or that a Person's 'actor' role in a Movie was for some particular characterName. Such properties can be attached to a Role entity, which is then associated with the main entities using ordinary properties like 'member' or 'actor'.<br/><br/>\n\nSee also <a href=\"https://blog.schema.org/2014/06/16/introducing-role/">blog post</a>.",
+      "rdfs:comment": "Represents additional information about a relationship or property. For example a Role can be used to say that a 'member' role linking some SportsTeam to a player occurred during a particular time period. Or that a Person's 'actor' role in a Movie was for some particular characterName. Such properties can be attached to a Role entity, which is then associated with the main entities using ordinary properties like 'member' or 'actor'.<br/><br/>\n\nSee also <a href=\"https://blog.schema.org/2014/06/16/introducing-role\">blog post</a>.",
       "rdfs:label": "Role",
       "rdfs:subClassOf": {
         "@id": "http://schema.org/Intangible"

--- a/data/releases/3.6/schema.jsonld
+++ b/data/releases/3.6/schema.jsonld
@@ -432,7 +432,7 @@
       "http://purl.org/dc/terms/source": {
         "@id": "http://www.w3.org/wiki/WebSchemas/SchemaDotOrgSources#source_ActionCollabClass"
       },
-      "rdfs:comment": "An action performed by a direct agent and indirect participants upon a direct object. Optionally happens at a location with the help of an inanimate instrument. The execution of the action may produce a result. Specific action sub-type documentation specifies the exact expectation of each argument/role.<br/><br/>\n\nSee also <a href=\"https://blog.schema.org/2014/04/16/announcing-schema-org-actions/">blog post</a> and <a href=\"http://schema.org/docs/actions.html\">Actions overview document</a>.",
+      "rdfs:comment": "An action performed by a direct agent and indirect participants upon a direct object. Optionally happens at a location with the help of an inanimate instrument. The execution of the action may produce a result. Specific action sub-type documentation specifies the exact expectation of each argument/role.<br/><br/>\n\nSee also <a href=\"https://blog.schema.org/2014/04/16/announcing-schema-org-actions\">blog post</a> and <a href=\"http://schema.org/docs/actions.html\">Actions overview document</a>.",
       "rdfs:label": "Action",
       "rdfs:subClassOf": {
         "@id": "http://schema.org/Thing"
@@ -3527,7 +3527,7 @@
       "http://purl.org/dc/terms/source": {
         "@id": "http://www.w3.org/wiki/WebSchemas/SchemaDotOrgSources#source_bibex"
       },
-      "rdfs:comment": "A part of a successively published publication such as a periodical or multi-volume work, often numbered. It may represent a time span, such as a year.<br/><br/>\n\n<pre><code>  &lt;br/&gt;&lt;br/&gt;See also &lt;a href=\"https://blog.schema.org/2014/09/02/schema-org-support-for-bibliographic-relationships-and-periodicals/"&gt;blog post&lt;/a&gt;.\n</code></pre>\n",
+      "rdfs:comment": "A part of a successively published publication such as a periodical or multi-volume work, often numbered. It may represent a time span, such as a year.<br/><br/>\n\n<pre><code>  &lt;br/&gt;&lt;br/&gt;See also &lt;a href=\"https://blog.schema.org/2014/09/02/schema-org-support-for-bibliographic-relationships-and-periodicals\"&gt;blog post&lt;/a&gt;.\n</code></pre>\n",
       "rdfs:label": "PublicationVolume",
       "rdfs:subClassOf": {
         "@id": "http://schema.org/CreativeWork"
@@ -5316,7 +5316,7 @@
       "http://www.w3.org/2002/07/owl#equivalentClass": {
         "@id": "http://purl.org/ontology/bibo/Issue"
       },
-      "rdfs:comment": "A part of a successively published publication such as a periodical or publication volume, often numbered, usually containing a grouping of works such as articles.<br/><br/>\n\n<a href=\"https://blog.schema.org/2014/09/02/schema-org-support-for-bibliographic-relationships-and-periodicals/">blog post</a>.",
+      "rdfs:comment": "A part of a successively published publication such as a periodical or publication volume, often numbered, usually containing a grouping of works such as articles.<br/><br/>\n\n<a href=\"https://blog.schema.org/2014/09/02/schema-org-support-for-bibliographic-relationships-and-periodicals\">blog post</a>.",
       "rdfs:label": "PublicationIssue",
       "rdfs:subClassOf": {
         "@id": "http://schema.org/CreativeWork"
@@ -5357,7 +5357,7 @@
       "http://purl.org/dc/terms/source": {
         "@id": "http://www.w3.org/wiki/WebSchemas/SchemaDotOrgSources#source_rNews"
       },
-      "rdfs:comment": "An article, such as a news article or piece of investigative report. Newspapers and magazines have articles of many different types and this is intended to cover them all.<br/><br/>\n\nSee also <a href=\"https://blog.schema.org/2014/09/02/schema-org-support-for-bibliographic-relationships-and-periodicals/">blog post</a>.",
+      "rdfs:comment": "An article, such as a news article or piece of investigative report. Newspapers and magazines have articles of many different types and this is intended to cover them all.<br/><br/>\n\nSee also <a href=\"https://blog.schema.org/2014/09/02/schema-org-support-for-bibliographic-relationships-and-periodicals\">blog post</a>.",
       "rdfs:label": "Article",
       "rdfs:subClassOf": {
         "@id": "http://schema.org/CreativeWork"
@@ -13773,7 +13773,7 @@
       "http://www.w3.org/2002/07/owl#equivalentClass": {
         "@id": "http://purl.org/ontology/bibo/Periodical"
       },
-      "rdfs:comment": "A publication in any medium issued in successive parts bearing numerical or chronological designations and intended, such as a magazine, scholarly journal, or newspaper to continue indefinitely.<br/><br/>\n\nSee also <a href=\"https://blog.schema.org/2014/09/02/schema-org-support-for-bibliographic-relationships-and-periodicals/">blog post</a>.",
+      "rdfs:comment": "A publication in any medium issued in successive parts bearing numerical or chronological designations and intended, such as a magazine, scholarly journal, or newspaper to continue indefinitely.<br/><br/>\n\nSee also <a href=\"https://blog.schema.org/2014/09/02/schema-org-support-for-bibliographic-relationships-and-periodicals\">blog post</a>.",
       "rdfs:label": "Periodical",
       "rdfs:subClassOf": {
         "@id": "http://schema.org/CreativeWorkSeries"
@@ -15086,7 +15086,7 @@
     {
       "@id": "http://schema.org/Role",
       "@type": "rdfs:Class",
-      "rdfs:comment": "Represents additional information about a relationship or property. For example a Role can be used to say that a 'member' role linking some SportsTeam to a player occurred during a particular time period. Or that a Person's 'actor' role in a Movie was for some particular characterName. Such properties can be attached to a Role entity, which is then associated with the main entities using ordinary properties like 'member' or 'actor'.<br/><br/>\n\nSee also <a href=\"https://blog.schema.org/2014/06/16/introducing-role/">blog post</a>.",
+      "rdfs:comment": "Represents additional information about a relationship or property. For example a Role can be used to say that a 'member' role linking some SportsTeam to a player occurred during a particular time period. Or that a Person's 'actor' role in a Movie was for some particular characterName. Such properties can be attached to a Role entity, which is then associated with the main entities using ordinary properties like 'member' or 'actor'.<br/><br/>\n\nSee also <a href=\"https://blog.schema.org/2014/06/16/introducing-role\">blog post</a>.",
       "rdfs:label": "Role",
       "rdfs:subClassOf": {
         "@id": "http://schema.org/Intangible"

--- a/data/releases/3.7/all-layers.jsonld
+++ b/data/releases/3.7/all-layers.jsonld
@@ -676,7 +676,7 @@
       "http://purl.org/dc/terms/source": {
         "@id": "http://www.w3.org/wiki/WebSchemas/SchemaDotOrgSources#source_ActionCollabClass"
       },
-      "rdfs:comment": "An action performed by a direct agent and indirect participants upon a direct object. Optionally happens at a location with the help of an inanimate instrument. The execution of the action may produce a result. Specific action sub-type documentation specifies the exact expectation of each argument/role.<br/><br/>\n\nSee also <a href=\"https://blog.schema.org/2014/04/16/announcing-schema-org-actions/">blog post</a> and <a href=\"http://schema.org/docs/actions.html\">Actions overview document</a>.",
+      "rdfs:comment": "An action performed by a direct agent and indirect participants upon a direct object. Optionally happens at a location with the help of an inanimate instrument. The execution of the action may produce a result. Specific action sub-type documentation specifies the exact expectation of each argument/role.<br/><br/>\n\nSee also <a href=\"https://blog.schema.org/2014/04/16/announcing-schema-org-actions\">blog post</a> and <a href=\"http://schema.org/docs/actions.html\">Actions overview document</a>.",
       "rdfs:label": "Action",
       "rdfs:subClassOf": {
         "@id": "http://schema.org/Thing"
@@ -5200,7 +5200,7 @@
       "http://purl.org/dc/terms/source": {
         "@id": "http://www.w3.org/wiki/WebSchemas/SchemaDotOrgSources#source_bibex"
       },
-      "rdfs:comment": "A part of a successively published publication such as a periodical or multi-volume work, often numbered. It may represent a time span, such as a year.<br/><br/>\n\nSee also <a href=\"https://blog.schema.org/2014/09/02/schema-org-support-for-bibliographic-relationships-and-periodicals/">blog post</a>.",
+      "rdfs:comment": "A part of a successively published publication such as a periodical or multi-volume work, often numbered. It may represent a time span, such as a year.<br/><br/>\n\nSee also <a href=\"https://blog.schema.org/2014/09/02/schema-org-support-for-bibliographic-relationships-and-periodicals\">blog post</a>.",
       "rdfs:label": "PublicationVolume",
       "rdfs:subClassOf": {
         "@id": "http://schema.org/CreativeWork"
@@ -7884,7 +7884,7 @@
       "http://www.w3.org/2002/07/owl#equivalentClass": {
         "@id": "http://purl.org/ontology/bibo/Issue"
       },
-      "rdfs:comment": "A part of a successively published publication such as a periodical or publication volume, often numbered, usually containing a grouping of works such as articles.<br/><br/>\n\nSee also <a href=\"https://blog.schema.org/2014/09/02/schema-org-support-for-bibliographic-relationships-and-periodicals/">blog post</a>.",
+      "rdfs:comment": "A part of a successively published publication such as a periodical or publication volume, often numbered, usually containing a grouping of works such as articles.<br/><br/>\n\nSee also <a href=\"https://blog.schema.org/2014/09/02/schema-org-support-for-bibliographic-relationships-and-periodicals\">blog post</a>.",
       "rdfs:label": "PublicationIssue",
       "rdfs:subClassOf": {
         "@id": "http://schema.org/CreativeWork"
@@ -7964,7 +7964,7 @@
       "http://purl.org/dc/terms/source": {
         "@id": "http://www.w3.org/wiki/WebSchemas/SchemaDotOrgSources#source_rNews"
       },
-      "rdfs:comment": "An article, such as a news article or piece of investigative report. Newspapers and magazines have articles of many different types and this is intended to cover them all.<br/><br/>\n\nSee also <a href=\"https://blog.schema.org/2014/09/02/schema-org-support-for-bibliographic-relationships-and-periodicals/">blog post</a>.",
+      "rdfs:comment": "An article, such as a news article or piece of investigative report. Newspapers and magazines have articles of many different types and this is intended to cover them all.<br/><br/>\n\nSee also <a href=\"https://blog.schema.org/2014/09/02/schema-org-support-for-bibliographic-relationships-and-periodicals\">blog post</a>.",
       "rdfs:label": "Article",
       "rdfs:subClassOf": {
         "@id": "http://schema.org/CreativeWork"
@@ -19856,7 +19856,7 @@
       "http://www.w3.org/2002/07/owl#equivalentClass": {
         "@id": "http://purl.org/ontology/bibo/Periodical"
       },
-      "rdfs:comment": "A publication in any medium issued in successive parts bearing numerical or chronological designations and intended, such as a magazine, scholarly journal, or newspaper to continue indefinitely.<br/><br/>\n\nSee also <a href=\"https://blog.schema.org/2014/09/02/schema-org-support-for-bibliographic-relationships-and-periodicals/">blog post</a>.",
+      "rdfs:comment": "A publication in any medium issued in successive parts bearing numerical or chronological designations and intended, such as a magazine, scholarly journal, or newspaper to continue indefinitely.<br/><br/>\n\nSee also <a href=\"https://blog.schema.org/2014/09/02/schema-org-support-for-bibliographic-relationships-and-periodicals\">blog post</a>.",
       "rdfs:label": "Periodical",
       "rdfs:subClassOf": {
         "@id": "http://schema.org/CreativeWorkSeries"
@@ -21887,7 +21887,7 @@
     {
       "@id": "http://schema.org/Role",
       "@type": "rdfs:Class",
-      "rdfs:comment": "Represents additional information about a relationship or property. For example a Role can be used to say that a 'member' role linking some SportsTeam to a player occurred during a particular time period. Or that a Person's 'actor' role in a Movie was for some particular characterName. Such properties can be attached to a Role entity, which is then associated with the main entities using ordinary properties like 'member' or 'actor'.<br/><br/>\n\nSee also <a href=\"https://blog.schema.org/2014/06/16/introducing-role/">blog post</a>.",
+      "rdfs:comment": "Represents additional information about a relationship or property. For example a Role can be used to say that a 'member' role linking some SportsTeam to a player occurred during a particular time period. Or that a Person's 'actor' role in a Movie was for some particular characterName. Such properties can be attached to a Role entity, which is then associated with the main entities using ordinary properties like 'member' or 'actor'.<br/><br/>\n\nSee also <a href=\"https://blog.schema.org/2014/06/16/introducing-role\">blog post</a>.",
       "rdfs:label": "Role",
       "rdfs:subClassOf": {
         "@id": "http://schema.org/Intangible"

--- a/data/releases/3.7/schema.jsonld
+++ b/data/releases/3.7/schema.jsonld
@@ -449,7 +449,7 @@
       "http://purl.org/dc/terms/source": {
         "@id": "http://www.w3.org/wiki/WebSchemas/SchemaDotOrgSources#source_ActionCollabClass"
       },
-      "rdfs:comment": "An action performed by a direct agent and indirect participants upon a direct object. Optionally happens at a location with the help of an inanimate instrument. The execution of the action may produce a result. Specific action sub-type documentation specifies the exact expectation of each argument/role.<br/><br/>\n\nSee also <a href=\"https://blog.schema.org/2014/04/16/announcing-schema-org-actions/">blog post</a> and <a href=\"http://schema.org/docs/actions.html\">Actions overview document</a>.",
+      "rdfs:comment": "An action performed by a direct agent and indirect participants upon a direct object. Optionally happens at a location with the help of an inanimate instrument. The execution of the action may produce a result. Specific action sub-type documentation specifies the exact expectation of each argument/role.<br/><br/>\n\nSee also <a href=\"https://blog.schema.org/2014/04/16/announcing-schema-org-actions\">blog post</a> and <a href=\"http://schema.org/docs/actions.html\">Actions overview document</a>.",
       "rdfs:label": "Action",
       "rdfs:subClassOf": {
         "@id": "http://schema.org/Thing"
@@ -3440,7 +3440,7 @@
       "http://purl.org/dc/terms/source": {
         "@id": "http://www.w3.org/wiki/WebSchemas/SchemaDotOrgSources#source_bibex"
       },
-      "rdfs:comment": "A part of a successively published publication such as a periodical or multi-volume work, often numbered. It may represent a time span, such as a year.<br/><br/>\n\nSee also <a href=\"https://blog.schema.org/2014/09/02/schema-org-support-for-bibliographic-relationships-and-periodicals/">blog post</a>.",
+      "rdfs:comment": "A part of a successively published publication such as a periodical or multi-volume work, often numbered. It may represent a time span, such as a year.<br/><br/>\n\nSee also <a href=\"https://blog.schema.org/2014/09/02/schema-org-support-for-bibliographic-relationships-and-periodicals\">blog post</a>.",
       "rdfs:label": "PublicationVolume",
       "rdfs:subClassOf": {
         "@id": "http://schema.org/CreativeWork"
@@ -5269,7 +5269,7 @@
       "http://www.w3.org/2002/07/owl#equivalentClass": {
         "@id": "http://purl.org/ontology/bibo/Issue"
       },
-      "rdfs:comment": "A part of a successively published publication such as a periodical or publication volume, often numbered, usually containing a grouping of works such as articles.<br/><br/>\n\nSee also <a href=\"https://blog.schema.org/2014/09/02/schema-org-support-for-bibliographic-relationships-and-periodicals/">blog post</a>.",
+      "rdfs:comment": "A part of a successively published publication such as a periodical or publication volume, often numbered, usually containing a grouping of works such as articles.<br/><br/>\n\nSee also <a href=\"https://blog.schema.org/2014/09/02/schema-org-support-for-bibliographic-relationships-and-periodicals\">blog post</a>.",
       "rdfs:label": "PublicationIssue",
       "rdfs:subClassOf": {
         "@id": "http://schema.org/CreativeWork"
@@ -5310,7 +5310,7 @@
       "http://purl.org/dc/terms/source": {
         "@id": "http://www.w3.org/wiki/WebSchemas/SchemaDotOrgSources#source_rNews"
       },
-      "rdfs:comment": "An article, such as a news article or piece of investigative report. Newspapers and magazines have articles of many different types and this is intended to cover them all.<br/><br/>\n\nSee also <a href=\"https://blog.schema.org/2014/09/02/schema-org-support-for-bibliographic-relationships-and-periodicals/">blog post</a>.",
+      "rdfs:comment": "An article, such as a news article or piece of investigative report. Newspapers and magazines have articles of many different types and this is intended to cover them all.<br/><br/>\n\nSee also <a href=\"https://blog.schema.org/2014/09/02/schema-org-support-for-bibliographic-relationships-and-periodicals\">blog post</a>.",
       "rdfs:label": "Article",
       "rdfs:subClassOf": {
         "@id": "http://schema.org/CreativeWork"
@@ -13749,7 +13749,7 @@
       "http://www.w3.org/2002/07/owl#equivalentClass": {
         "@id": "http://purl.org/ontology/bibo/Periodical"
       },
-      "rdfs:comment": "A publication in any medium issued in successive parts bearing numerical or chronological designations and intended, such as a magazine, scholarly journal, or newspaper to continue indefinitely.<br/><br/>\n\nSee also <a href=\"https://blog.schema.org/2014/09/02/schema-org-support-for-bibliographic-relationships-and-periodicals/">blog post</a>.",
+      "rdfs:comment": "A publication in any medium issued in successive parts bearing numerical or chronological designations and intended, such as a magazine, scholarly journal, or newspaper to continue indefinitely.<br/><br/>\n\nSee also <a href=\"https://blog.schema.org/2014/09/02/schema-org-support-for-bibliographic-relationships-and-periodicals\">blog post</a>.",
       "rdfs:label": "Periodical",
       "rdfs:subClassOf": {
         "@id": "http://schema.org/CreativeWorkSeries"
@@ -15084,7 +15084,7 @@
     {
       "@id": "http://schema.org/Role",
       "@type": "rdfs:Class",
-      "rdfs:comment": "Represents additional information about a relationship or property. For example a Role can be used to say that a 'member' role linking some SportsTeam to a player occurred during a particular time period. Or that a Person's 'actor' role in a Movie was for some particular characterName. Such properties can be attached to a Role entity, which is then associated with the main entities using ordinary properties like 'member' or 'actor'.<br/><br/>\n\nSee also <a href=\"https://blog.schema.org/2014/06/16/introducing-role/">blog post</a>.",
+      "rdfs:comment": "Represents additional information about a relationship or property. For example a Role can be used to say that a 'member' role linking some SportsTeam to a player occurred during a particular time period. Or that a Person's 'actor' role in a Movie was for some particular characterName. Such properties can be attached to a Role entity, which is then associated with the main entities using ordinary properties like 'member' or 'actor'.<br/><br/>\n\nSee also <a href=\"https://blog.schema.org/2014/06/16/introducing-role\">blog post</a>.",
       "rdfs:label": "Role",
       "rdfs:subClassOf": {
         "@id": "http://schema.org/Intangible"

--- a/data/releases/3.8/all-layers.jsonld
+++ b/data/releases/3.8/all-layers.jsonld
@@ -699,7 +699,7 @@
       "http://purl.org/dc/terms/source": {
         "@id": "http://www.w3.org/wiki/WebSchemas/SchemaDotOrgSources#source_ActionCollabClass"
       },
-      "rdfs:comment": "An action performed by a direct agent and indirect participants upon a direct object. Optionally happens at a location with the help of an inanimate instrument. The execution of the action may produce a result. Specific action sub-type documentation specifies the exact expectation of each argument/role.<br/><br/>\n\nSee also <a href=\"https://blog.schema.org/2014/04/16/announcing-schema-org-actions/">blog post</a> and <a href=\"http://schema.org/docs/actions.html\">Actions overview document</a>.",
+      "rdfs:comment": "An action performed by a direct agent and indirect participants upon a direct object. Optionally happens at a location with the help of an inanimate instrument. The execution of the action may produce a result. Specific action sub-type documentation specifies the exact expectation of each argument/role.<br/><br/>\n\nSee also <a href=\"https://blog.schema.org/2014/04/16/announcing-schema-org-actions\">blog post</a> and <a href=\"http://schema.org/docs/actions.html\">Actions overview document</a>.",
       "rdfs:label": "Action",
       "rdfs:subClassOf": {
         "@id": "http://schema.org/Thing"
@@ -5234,7 +5234,7 @@
       "http://purl.org/dc/terms/source": {
         "@id": "http://www.w3.org/wiki/WebSchemas/SchemaDotOrgSources#source_bibex"
       },
-      "rdfs:comment": "A part of a successively published publication such as a periodical or multi-volume work, often numbered. It may represent a time span, such as a year.<br/><br/>\n\nSee also <a href=\"https://blog.schema.org/2014/09/02/schema-org-support-for-bibliographic-relationships-and-periodicals/">blog post</a>.",
+      "rdfs:comment": "A part of a successively published publication such as a periodical or multi-volume work, often numbered. It may represent a time span, such as a year.<br/><br/>\n\nSee also <a href=\"https://blog.schema.org/2014/09/02/schema-org-support-for-bibliographic-relationships-and-periodicals\">blog post</a>.",
       "rdfs:label": "PublicationVolume",
       "rdfs:subClassOf": {
         "@id": "http://schema.org/CreativeWork"
@@ -7957,7 +7957,7 @@
       "http://www.w3.org/2002/07/owl#equivalentClass": {
         "@id": "http://purl.org/ontology/bibo/Issue"
       },
-      "rdfs:comment": "A part of a successively published publication such as a periodical or publication volume, often numbered, usually containing a grouping of works such as articles.<br/><br/>\n\nSee also <a href=\"https://blog.schema.org/2014/09/02/schema-org-support-for-bibliographic-relationships-and-periodicals/">blog post</a>.",
+      "rdfs:comment": "A part of a successively published publication such as a periodical or publication volume, often numbered, usually containing a grouping of works such as articles.<br/><br/>\n\nSee also <a href=\"https://blog.schema.org/2014/09/02/schema-org-support-for-bibliographic-relationships-and-periodicals\">blog post</a>.",
       "rdfs:label": "PublicationIssue",
       "rdfs:subClassOf": {
         "@id": "http://schema.org/CreativeWork"
@@ -8037,7 +8037,7 @@
       "http://purl.org/dc/terms/source": {
         "@id": "http://www.w3.org/wiki/WebSchemas/SchemaDotOrgSources#source_rNews"
       },
-      "rdfs:comment": "An article, such as a news article or piece of investigative report. Newspapers and magazines have articles of many different types and this is intended to cover them all.<br/><br/>\n\nSee also <a href=\"https://blog.schema.org/2014/09/02/schema-org-support-for-bibliographic-relationships-and-periodicals/">blog post</a>.",
+      "rdfs:comment": "An article, such as a news article or piece of investigative report. Newspapers and magazines have articles of many different types and this is intended to cover them all.<br/><br/>\n\nSee also <a href=\"https://blog.schema.org/2014/09/02/schema-org-support-for-bibliographic-relationships-and-periodicals\">blog post</a>.",
       "rdfs:label": "Article",
       "rdfs:subClassOf": {
         "@id": "http://schema.org/CreativeWork"
@@ -20090,7 +20090,7 @@
       "http://www.w3.org/2002/07/owl#equivalentClass": {
         "@id": "http://purl.org/ontology/bibo/Periodical"
       },
-      "rdfs:comment": "A publication in any medium issued in successive parts bearing numerical or chronological designations and intended, such as a magazine, scholarly journal, or newspaper to continue indefinitely.<br/><br/>\n\nSee also <a href=\"https://blog.schema.org/2014/09/02/schema-org-support-for-bibliographic-relationships-and-periodicals/">blog post</a>.",
+      "rdfs:comment": "A publication in any medium issued in successive parts bearing numerical or chronological designations and intended, such as a magazine, scholarly journal, or newspaper to continue indefinitely.<br/><br/>\n\nSee also <a href=\"https://blog.schema.org/2014/09/02/schema-org-support-for-bibliographic-relationships-and-periodicals\">blog post</a>.",
       "rdfs:label": "Periodical",
       "rdfs:subClassOf": {
         "@id": "http://schema.org/CreativeWorkSeries"
@@ -22272,7 +22272,7 @@
     {
       "@id": "http://schema.org/Role",
       "@type": "rdfs:Class",
-      "rdfs:comment": "Represents additional information about a relationship or property. For example a Role can be used to say that a 'member' role linking some SportsTeam to a player occurred during a particular time period. Or that a Person's 'actor' role in a Movie was for some particular characterName. Such properties can be attached to a Role entity, which is then associated with the main entities using ordinary properties like 'member' or 'actor'.<br/><br/>\n\nSee also <a href=\"https://blog.schema.org/2014/06/16/introducing-role/">blog post</a>.",
+      "rdfs:comment": "Represents additional information about a relationship or property. For example a Role can be used to say that a 'member' role linking some SportsTeam to a player occurred during a particular time period. Or that a Person's 'actor' role in a Movie was for some particular characterName. Such properties can be attached to a Role entity, which is then associated with the main entities using ordinary properties like 'member' or 'actor'.<br/><br/>\n\nSee also <a href=\"https://blog.schema.org/2014/06/16/introducing-role\">blog post</a>.",
       "rdfs:label": "Role",
       "rdfs:subClassOf": {
         "@id": "http://schema.org/Intangible"

--- a/data/releases/3.8/schema.jsonld
+++ b/data/releases/3.8/schema.jsonld
@@ -438,7 +438,7 @@
       "http://purl.org/dc/terms/source": {
         "@id": "http://www.w3.org/wiki/WebSchemas/SchemaDotOrgSources#source_ActionCollabClass"
       },
-      "rdfs:comment": "An action performed by a direct agent and indirect participants upon a direct object. Optionally happens at a location with the help of an inanimate instrument. The execution of the action may produce a result. Specific action sub-type documentation specifies the exact expectation of each argument/role.<br/><br/>\n\nSee also <a href=\"https://blog.schema.org/2014/04/16/announcing-schema-org-actions/">blog post</a> and <a href=\"http://schema.org/docs/actions.html\">Actions overview document</a>.",
+      "rdfs:comment": "An action performed by a direct agent and indirect participants upon a direct object. Optionally happens at a location with the help of an inanimate instrument. The execution of the action may produce a result. Specific action sub-type documentation specifies the exact expectation of each argument/role.<br/><br/>\n\nSee also <a href=\"https://blog.schema.org/2014/04/16/announcing-schema-org-actions\">blog post</a> and <a href=\"http://schema.org/docs/actions.html\">Actions overview document</a>.",
       "rdfs:label": "Action",
       "rdfs:subClassOf": {
         "@id": "http://schema.org/Thing"
@@ -3525,7 +3525,7 @@
       "http://purl.org/dc/terms/source": {
         "@id": "http://www.w3.org/wiki/WebSchemas/SchemaDotOrgSources#source_bibex"
       },
-      "rdfs:comment": "A part of a successively published publication such as a periodical or multi-volume work, often numbered. It may represent a time span, such as a year.<br/><br/>\n\nSee also <a href=\"https://blog.schema.org/2014/09/02/schema-org-support-for-bibliographic-relationships-and-periodicals/">blog post</a>.",
+      "rdfs:comment": "A part of a successively published publication such as a periodical or multi-volume work, often numbered. It may represent a time span, such as a year.<br/><br/>\n\nSee also <a href=\"https://blog.schema.org/2014/09/02/schema-org-support-for-bibliographic-relationships-and-periodicals\">blog post</a>.",
       "rdfs:label": "PublicationVolume",
       "rdfs:subClassOf": {
         "@id": "http://schema.org/CreativeWork"
@@ -5300,7 +5300,7 @@
       "http://www.w3.org/2002/07/owl#equivalentClass": {
         "@id": "http://purl.org/ontology/bibo/Issue"
       },
-      "rdfs:comment": "A part of a successively published publication such as a periodical or publication volume, often numbered, usually containing a grouping of works such as articles.<br/><br/>\n\nSee also <a href=\"https://blog.schema.org/2014/09/02/schema-org-support-for-bibliographic-relationships-and-periodicals/">blog post</a>.",
+      "rdfs:comment": "A part of a successively published publication such as a periodical or publication volume, often numbered, usually containing a grouping of works such as articles.<br/><br/>\n\nSee also <a href=\"https://blog.schema.org/2014/09/02/schema-org-support-for-bibliographic-relationships-and-periodicals\">blog post</a>.",
       "rdfs:label": "PublicationIssue",
       "rdfs:subClassOf": {
         "@id": "http://schema.org/CreativeWork"
@@ -5341,7 +5341,7 @@
       "http://purl.org/dc/terms/source": {
         "@id": "http://www.w3.org/wiki/WebSchemas/SchemaDotOrgSources#source_rNews"
       },
-      "rdfs:comment": "An article, such as a news article or piece of investigative report. Newspapers and magazines have articles of many different types and this is intended to cover them all.<br/><br/>\n\nSee also <a href=\"https://blog.schema.org/2014/09/02/schema-org-support-for-bibliographic-relationships-and-periodicals/">blog post</a>.",
+      "rdfs:comment": "An article, such as a news article or piece of investigative report. Newspapers and magazines have articles of many different types and this is intended to cover them all.<br/><br/>\n\nSee also <a href=\"https://blog.schema.org/2014/09/02/schema-org-support-for-bibliographic-relationships-and-periodicals\">blog post</a>.",
       "rdfs:label": "Article",
       "rdfs:subClassOf": {
         "@id": "http://schema.org/CreativeWork"
@@ -13756,7 +13756,7 @@
       "http://www.w3.org/2002/07/owl#equivalentClass": {
         "@id": "http://purl.org/ontology/bibo/Periodical"
       },
-      "rdfs:comment": "A publication in any medium issued in successive parts bearing numerical or chronological designations and intended, such as a magazine, scholarly journal, or newspaper to continue indefinitely.<br/><br/>\n\nSee also <a href=\"https://blog.schema.org/2014/09/02/schema-org-support-for-bibliographic-relationships-and-periodicals/">blog post</a>.",
+      "rdfs:comment": "A publication in any medium issued in successive parts bearing numerical or chronological designations and intended, such as a magazine, scholarly journal, or newspaper to continue indefinitely.<br/><br/>\n\nSee also <a href=\"https://blog.schema.org/2014/09/02/schema-org-support-for-bibliographic-relationships-and-periodicals\">blog post</a>.",
       "rdfs:label": "Periodical",
       "rdfs:subClassOf": {
         "@id": "http://schema.org/CreativeWorkSeries"
@@ -15111,7 +15111,7 @@
     {
       "@id": "http://schema.org/Role",
       "@type": "rdfs:Class",
-      "rdfs:comment": "Represents additional information about a relationship or property. For example a Role can be used to say that a 'member' role linking some SportsTeam to a player occurred during a particular time period. Or that a Person's 'actor' role in a Movie was for some particular characterName. Such properties can be attached to a Role entity, which is then associated with the main entities using ordinary properties like 'member' or 'actor'.<br/><br/>\n\nSee also <a href=\"https://blog.schema.org/2014/06/16/introducing-role/">blog post</a>.",
+      "rdfs:comment": "Represents additional information about a relationship or property. For example a Role can be used to say that a 'member' role linking some SportsTeam to a player occurred during a particular time period. Or that a Person's 'actor' role in a Movie was for some particular characterName. Such properties can be attached to a Role entity, which is then associated with the main entities using ordinary properties like 'member' or 'actor'.<br/><br/>\n\nSee also <a href=\"https://blog.schema.org/2014/06/16/introducing-role\">blog post</a>.",
       "rdfs:label": "Role",
       "rdfs:subClassOf": {
         "@id": "http://schema.org/Intangible"

--- a/data/releases/3.9/all-layers.jsonld
+++ b/data/releases/3.9/all-layers.jsonld
@@ -688,7 +688,7 @@
       "http://purl.org/dc/terms/source": {
         "@id": "http://www.w3.org/wiki/WebSchemas/SchemaDotOrgSources#source_ActionCollabClass"
       },
-      "rdfs:comment": "An action performed by a direct agent and indirect participants upon a direct object. Optionally happens at a location with the help of an inanimate instrument. The execution of the action may produce a result. Specific action sub-type documentation specifies the exact expectation of each argument/role.<br/><br/>\n\nSee also <a href=\"https://blog.schema.org/2014/04/16/announcing-schema-org-actions/">blog post</a> and <a href=\"http://schema.org/docs/actions.html\">Actions overview document</a>.",
+      "rdfs:comment": "An action performed by a direct agent and indirect participants upon a direct object. Optionally happens at a location with the help of an inanimate instrument. The execution of the action may produce a result. Specific action sub-type documentation specifies the exact expectation of each argument/role.<br/><br/>\n\nSee also <a href=\"https://blog.schema.org/2014/04/16/announcing-schema-org-actions\">blog post</a> and <a href=\"http://schema.org/docs/actions.html\">Actions overview document</a>.",
       "rdfs:label": "Action",
       "rdfs:subClassOf": {
         "@id": "http://schema.org/Thing"
@@ -5305,7 +5305,7 @@
       "http://purl.org/dc/terms/source": {
         "@id": "http://www.w3.org/wiki/WebSchemas/SchemaDotOrgSources#source_bibex"
       },
-      "rdfs:comment": "A part of a successively published publication such as a periodical or multi-volume work, often numbered. It may represent a time span, such as a year.<br/><br/>\n\nSee also <a href=\"https://blog.schema.org/2014/09/02/schema-org-support-for-bibliographic-relationships-and-periodicals/">blog post</a>.",
+      "rdfs:comment": "A part of a successively published publication such as a periodical or multi-volume work, often numbered. It may represent a time span, such as a year.<br/><br/>\n\nSee also <a href=\"https://blog.schema.org/2014/09/02/schema-org-support-for-bibliographic-relationships-and-periodicals\">blog post</a>.",
       "rdfs:label": "PublicationVolume",
       "rdfs:subClassOf": {
         "@id": "http://schema.org/CreativeWork"
@@ -8033,7 +8033,7 @@
       "http://www.w3.org/2002/07/owl#equivalentClass": {
         "@id": "http://purl.org/ontology/bibo/Issue"
       },
-      "rdfs:comment": "A part of a successively published publication such as a periodical or publication volume, often numbered, usually containing a grouping of works such as articles.<br/><br/>\n\nSee also <a href=\"https://blog.schema.org/2014/09/02/schema-org-support-for-bibliographic-relationships-and-periodicals/">blog post</a>.",
+      "rdfs:comment": "A part of a successively published publication such as a periodical or publication volume, often numbered, usually containing a grouping of works such as articles.<br/><br/>\n\nSee also <a href=\"https://blog.schema.org/2014/09/02/schema-org-support-for-bibliographic-relationships-and-periodicals\">blog post</a>.",
       "rdfs:label": "PublicationIssue",
       "rdfs:subClassOf": {
         "@id": "http://schema.org/CreativeWork"
@@ -8113,7 +8113,7 @@
       "http://purl.org/dc/terms/source": {
         "@id": "http://www.w3.org/wiki/WebSchemas/SchemaDotOrgSources#source_rNews"
       },
-      "rdfs:comment": "An article, such as a news article or piece of investigative report. Newspapers and magazines have articles of many different types and this is intended to cover them all.<br/><br/>\n\nSee also <a href=\"https://blog.schema.org/2014/09/02/schema-org-support-for-bibliographic-relationships-and-periodicals/">blog post</a>.",
+      "rdfs:comment": "An article, such as a news article or piece of investigative report. Newspapers and magazines have articles of many different types and this is intended to cover them all.<br/><br/>\n\nSee also <a href=\"https://blog.schema.org/2014/09/02/schema-org-support-for-bibliographic-relationships-and-periodicals\">blog post</a>.",
       "rdfs:label": "Article",
       "rdfs:subClassOf": {
         "@id": "http://schema.org/CreativeWork"
@@ -20314,7 +20314,7 @@
       "http://www.w3.org/2002/07/owl#equivalentClass": {
         "@id": "http://purl.org/ontology/bibo/Periodical"
       },
-      "rdfs:comment": "A publication in any medium issued in successive parts bearing numerical or chronological designations and intended, such as a magazine, scholarly journal, or newspaper to continue indefinitely.<br/><br/>\n\nSee also <a href=\"https://blog.schema.org/2014/09/02/schema-org-support-for-bibliographic-relationships-and-periodicals/">blog post</a>.",
+      "rdfs:comment": "A publication in any medium issued in successive parts bearing numerical or chronological designations and intended, such as a magazine, scholarly journal, or newspaper to continue indefinitely.<br/><br/>\n\nSee also <a href=\"https://blog.schema.org/2014/09/02/schema-org-support-for-bibliographic-relationships-and-periodicals\">blog post</a>.",
       "rdfs:label": "Periodical",
       "rdfs:subClassOf": {
         "@id": "http://schema.org/CreativeWorkSeries"
@@ -22405,7 +22405,7 @@
     {
       "@id": "http://schema.org/Role",
       "@type": "rdfs:Class",
-      "rdfs:comment": "Represents additional information about a relationship or property. For example a Role can be used to say that a 'member' role linking some SportsTeam to a player occurred during a particular time period. Or that a Person's 'actor' role in a Movie was for some particular characterName. Such properties can be attached to a Role entity, which is then associated with the main entities using ordinary properties like 'member' or 'actor'.<br/><br/>\n\nSee also <a href=\"https://blog.schema.org/2014/06/16/introducing-role/">blog post</a>.",
+      "rdfs:comment": "Represents additional information about a relationship or property. For example a Role can be used to say that a 'member' role linking some SportsTeam to a player occurred during a particular time period. Or that a Person's 'actor' role in a Movie was for some particular characterName. Such properties can be attached to a Role entity, which is then associated with the main entities using ordinary properties like 'member' or 'actor'.<br/><br/>\n\nSee also <a href=\"https://blog.schema.org/2014/06/16/introducing-role\">blog post</a>.",
       "rdfs:label": "Role",
       "rdfs:subClassOf": {
         "@id": "http://schema.org/Intangible"

--- a/data/releases/3.9/schema.jsonld
+++ b/data/releases/3.9/schema.jsonld
@@ -452,7 +452,7 @@
       "http://purl.org/dc/terms/source": {
         "@id": "http://www.w3.org/wiki/WebSchemas/SchemaDotOrgSources#source_ActionCollabClass"
       },
-      "rdfs:comment": "An action performed by a direct agent and indirect participants upon a direct object. Optionally happens at a location with the help of an inanimate instrument. The execution of the action may produce a result. Specific action sub-type documentation specifies the exact expectation of each argument/role.<br/><br/>\n\nSee also <a href=\"https://blog.schema.org/2014/04/16/announcing-schema-org-actions/">blog post</a> and <a href=\"http://schema.org/docs/actions.html\">Actions overview document</a>.",
+      "rdfs:comment": "An action performed by a direct agent and indirect participants upon a direct object. Optionally happens at a location with the help of an inanimate instrument. The execution of the action may produce a result. Specific action sub-type documentation specifies the exact expectation of each argument/role.<br/><br/>\n\nSee also <a href=\"https://blog.schema.org/2014/04/16/announcing-schema-org-actions\">blog post</a> and <a href=\"http://schema.org/docs/actions.html\">Actions overview document</a>.",
       "rdfs:label": "Action",
       "rdfs:subClassOf": {
         "@id": "http://schema.org/Thing"
@@ -3571,7 +3571,7 @@
       "http://purl.org/dc/terms/source": {
         "@id": "http://www.w3.org/wiki/WebSchemas/SchemaDotOrgSources#source_bibex"
       },
-      "rdfs:comment": "A part of a successively published publication such as a periodical or multi-volume work, often numbered. It may represent a time span, such as a year.<br/><br/>\n\nSee also <a href=\"https://blog.schema.org/2014/09/02/schema-org-support-for-bibliographic-relationships-and-periodicals/">blog post</a>.",
+      "rdfs:comment": "A part of a successively published publication such as a periodical or multi-volume work, often numbered. It may represent a time span, such as a year.<br/><br/>\n\nSee also <a href=\"https://blog.schema.org/2014/09/02/schema-org-support-for-bibliographic-relationships-and-periodicals\">blog post</a>.",
       "rdfs:label": "PublicationVolume",
       "rdfs:subClassOf": {
         "@id": "http://schema.org/CreativeWork"
@@ -5398,7 +5398,7 @@
       "http://www.w3.org/2002/07/owl#equivalentClass": {
         "@id": "http://purl.org/ontology/bibo/Issue"
       },
-      "rdfs:comment": "A part of a successively published publication such as a periodical or publication volume, often numbered, usually containing a grouping of works such as articles.<br/><br/>\n\nSee also <a href=\"https://blog.schema.org/2014/09/02/schema-org-support-for-bibliographic-relationships-and-periodicals/">blog post</a>.",
+      "rdfs:comment": "A part of a successively published publication such as a periodical or publication volume, often numbered, usually containing a grouping of works such as articles.<br/><br/>\n\nSee also <a href=\"https://blog.schema.org/2014/09/02/schema-org-support-for-bibliographic-relationships-and-periodicals\">blog post</a>.",
       "rdfs:label": "PublicationIssue",
       "rdfs:subClassOf": {
         "@id": "http://schema.org/CreativeWork"
@@ -5439,7 +5439,7 @@
       "http://purl.org/dc/terms/source": {
         "@id": "http://www.w3.org/wiki/WebSchemas/SchemaDotOrgSources#source_rNews"
       },
-      "rdfs:comment": "An article, such as a news article or piece of investigative report. Newspapers and magazines have articles of many different types and this is intended to cover them all.<br/><br/>\n\nSee also <a href=\"https://blog.schema.org/2014/09/02/schema-org-support-for-bibliographic-relationships-and-periodicals/">blog post</a>.",
+      "rdfs:comment": "An article, such as a news article or piece of investigative report. Newspapers and magazines have articles of many different types and this is intended to cover them all.<br/><br/>\n\nSee also <a href=\"https://blog.schema.org/2014/09/02/schema-org-support-for-bibliographic-relationships-and-periodicals\">blog post</a>.",
       "rdfs:label": "Article",
       "rdfs:subClassOf": {
         "@id": "http://schema.org/CreativeWork"
@@ -13915,7 +13915,7 @@
       "http://www.w3.org/2002/07/owl#equivalentClass": {
         "@id": "http://purl.org/ontology/bibo/Periodical"
       },
-      "rdfs:comment": "A publication in any medium issued in successive parts bearing numerical or chronological designations and intended, such as a magazine, scholarly journal, or newspaper to continue indefinitely.<br/><br/>\n\nSee also <a href=\"https://blog.schema.org/2014/09/02/schema-org-support-for-bibliographic-relationships-and-periodicals/">blog post</a>.",
+      "rdfs:comment": "A publication in any medium issued in successive parts bearing numerical or chronological designations and intended, such as a magazine, scholarly journal, or newspaper to continue indefinitely.<br/><br/>\n\nSee also <a href=\"https://blog.schema.org/2014/09/02/schema-org-support-for-bibliographic-relationships-and-periodicals\">blog post</a>.",
       "rdfs:label": "Periodical",
       "rdfs:subClassOf": {
         "@id": "http://schema.org/CreativeWorkSeries"
@@ -15274,7 +15274,7 @@
     {
       "@id": "http://schema.org/Role",
       "@type": "rdfs:Class",
-      "rdfs:comment": "Represents additional information about a relationship or property. For example a Role can be used to say that a 'member' role linking some SportsTeam to a player occurred during a particular time period. Or that a Person's 'actor' role in a Movie was for some particular characterName. Such properties can be attached to a Role entity, which is then associated with the main entities using ordinary properties like 'member' or 'actor'.<br/><br/>\n\nSee also <a href=\"https://blog.schema.org/2014/06/16/introducing-role/">blog post</a>.",
+      "rdfs:comment": "Represents additional information about a relationship or property. For example a Role can be used to say that a 'member' role linking some SportsTeam to a player occurred during a particular time period. Or that a Person's 'actor' role in a Movie was for some particular characterName. Such properties can be attached to a Role entity, which is then associated with the main entities using ordinary properties like 'member' or 'actor'.<br/><br/>\n\nSee also <a href=\"https://blog.schema.org/2014/06/16/introducing-role\">blog post</a>.",
       "rdfs:label": "Role",
       "rdfs:subClassOf": {
         "@id": "http://schema.org/Intangible"

--- a/data/releases/4.0/all-layers.jsonld
+++ b/data/releases/4.0/all-layers.jsonld
@@ -710,7 +710,7 @@
       "http://purl.org/dc/terms/source": {
         "@id": "http://www.w3.org/wiki/WebSchemas/SchemaDotOrgSources#source_ActionCollabClass"
       },
-      "rdfs:comment": "An action performed by a direct agent and indirect participants upon a direct object. Optionally happens at a location with the help of an inanimate instrument. The execution of the action may produce a result. Specific action sub-type documentation specifies the exact expectation of each argument/role.<br/><br/>\n\nSee also <a href=\"https://blog.schema.org/2014/04/16/announcing-schema-org-actions/">blog post</a> and <a href=\"http://schema.org/docs/actions.html\">Actions overview document</a>.",
+      "rdfs:comment": "An action performed by a direct agent and indirect participants upon a direct object. Optionally happens at a location with the help of an inanimate instrument. The execution of the action may produce a result. Specific action sub-type documentation specifies the exact expectation of each argument/role.<br/><br/>\n\nSee also <a href=\"https://blog.schema.org/2014/04/16/announcing-schema-org-actions\">blog post</a> and <a href=\"http://schema.org/docs/actions.html\">Actions overview document</a>.",
       "rdfs:label": "Action",
       "rdfs:subClassOf": {
         "@id": "http://schema.org/Thing"
@@ -5395,7 +5395,7 @@
       "http://purl.org/dc/terms/source": {
         "@id": "http://www.w3.org/wiki/WebSchemas/SchemaDotOrgSources#source_bibex"
       },
-      "rdfs:comment": "A part of a successively published publication such as a periodical or multi-volume work, often numbered. It may represent a time span, such as a year.<br/><br/>\n\nSee also <a href=\"https://blog.schema.org/2014/09/02/schema-org-support-for-bibliographic-relationships-and-periodicals/">blog post</a>.",
+      "rdfs:comment": "A part of a successively published publication such as a periodical or multi-volume work, often numbered. It may represent a time span, such as a year.<br/><br/>\n\nSee also <a href=\"https://blog.schema.org/2014/09/02/schema-org-support-for-bibliographic-relationships-and-periodicals\">blog post</a>.",
       "rdfs:label": "PublicationVolume",
       "rdfs:subClassOf": {
         "@id": "http://schema.org/CreativeWork"
@@ -8105,7 +8105,7 @@
       "http://www.w3.org/2002/07/owl#equivalentClass": {
         "@id": "http://purl.org/ontology/bibo/Issue"
       },
-      "rdfs:comment": "A part of a successively published publication such as a periodical or publication volume, often numbered, usually containing a grouping of works such as articles.<br/><br/>\n\nSee also <a href=\"https://blog.schema.org/2014/09/02/schema-org-support-for-bibliographic-relationships-and-periodicals/">blog post</a>.",
+      "rdfs:comment": "A part of a successively published publication such as a periodical or publication volume, often numbered, usually containing a grouping of works such as articles.<br/><br/>\n\nSee also <a href=\"https://blog.schema.org/2014/09/02/schema-org-support-for-bibliographic-relationships-and-periodicals\">blog post</a>.",
       "rdfs:label": "PublicationIssue",
       "rdfs:subClassOf": {
         "@id": "http://schema.org/CreativeWork"
@@ -8185,7 +8185,7 @@
       "http://purl.org/dc/terms/source": {
         "@id": "http://www.w3.org/wiki/WebSchemas/SchemaDotOrgSources#source_rNews"
       },
-      "rdfs:comment": "An article, such as a news article or piece of investigative report. Newspapers and magazines have articles of many different types and this is intended to cover them all.<br/><br/>\n\nSee also <a href=\"https://blog.schema.org/2014/09/02/schema-org-support-for-bibliographic-relationships-and-periodicals/">blog post</a>.",
+      "rdfs:comment": "An article, such as a news article or piece of investigative report. Newspapers and magazines have articles of many different types and this is intended to cover them all.<br/><br/>\n\nSee also <a href=\"https://blog.schema.org/2014/09/02/schema-org-support-for-bibliographic-relationships-and-periodicals\">blog post</a>.",
       "rdfs:label": "Article",
       "rdfs:subClassOf": {
         "@id": "http://schema.org/CreativeWork"
@@ -20525,7 +20525,7 @@
       "http://www.w3.org/2002/07/owl#equivalentClass": {
         "@id": "http://purl.org/ontology/bibo/Periodical"
       },
-      "rdfs:comment": "A publication in any medium issued in successive parts bearing numerical or chronological designations and intended, such as a magazine, scholarly journal, or newspaper to continue indefinitely.<br/><br/>\n\nSee also <a href=\"https://blog.schema.org/2014/09/02/schema-org-support-for-bibliographic-relationships-and-periodicals/">blog post</a>.",
+      "rdfs:comment": "A publication in any medium issued in successive parts bearing numerical or chronological designations and intended, such as a magazine, scholarly journal, or newspaper to continue indefinitely.<br/><br/>\n\nSee also <a href=\"https://blog.schema.org/2014/09/02/schema-org-support-for-bibliographic-relationships-and-periodicals\">blog post</a>.",
       "rdfs:label": "Periodical",
       "rdfs:subClassOf": {
         "@id": "http://schema.org/CreativeWorkSeries"
@@ -22640,7 +22640,7 @@
     {
       "@id": "http://schema.org/Role",
       "@type": "rdfs:Class",
-      "rdfs:comment": "Represents additional information about a relationship or property. For example a Role can be used to say that a 'member' role linking some SportsTeam to a player occurred during a particular time period. Or that a Person's 'actor' role in a Movie was for some particular characterName. Such properties can be attached to a Role entity, which is then associated with the main entities using ordinary properties like 'member' or 'actor'.<br/><br/>\n\nSee also <a href=\"https://blog.schema.org/2014/06/16/introducing-role/">blog post</a>.",
+      "rdfs:comment": "Represents additional information about a relationship or property. For example a Role can be used to say that a 'member' role linking some SportsTeam to a player occurred during a particular time period. Or that a Person's 'actor' role in a Movie was for some particular characterName. Such properties can be attached to a Role entity, which is then associated with the main entities using ordinary properties like 'member' or 'actor'.<br/><br/>\n\nSee also <a href=\"https://blog.schema.org/2014/06/16/introducing-role\">blog post</a>.",
       "rdfs:label": "Role",
       "rdfs:subClassOf": {
         "@id": "http://schema.org/Intangible"

--- a/data/releases/4.0/schema.jsonld
+++ b/data/releases/4.0/schema.jsonld
@@ -430,7 +430,7 @@
       "http://purl.org/dc/terms/source": {
         "@id": "http://www.w3.org/wiki/WebSchemas/SchemaDotOrgSources#source_ActionCollabClass"
       },
-      "rdfs:comment": "An action performed by a direct agent and indirect participants upon a direct object. Optionally happens at a location with the help of an inanimate instrument. The execution of the action may produce a result. Specific action sub-type documentation specifies the exact expectation of each argument/role.<br/><br/>\n\nSee also <a href=\"https://blog.schema.org/2014/04/16/announcing-schema-org-actions/">blog post</a> and <a href=\"http://schema.org/docs/actions.html\">Actions overview document</a>.",
+      "rdfs:comment": "An action performed by a direct agent and indirect participants upon a direct object. Optionally happens at a location with the help of an inanimate instrument. The execution of the action may produce a result. Specific action sub-type documentation specifies the exact expectation of each argument/role.<br/><br/>\n\nSee also <a href=\"https://blog.schema.org/2014/04/16/announcing-schema-org-actions\">blog post</a> and <a href=\"http://schema.org/docs/actions.html\">Actions overview document</a>.",
       "rdfs:label": "Action",
       "rdfs:subClassOf": {
         "@id": "http://schema.org/Thing"
@@ -3530,7 +3530,7 @@
       "http://purl.org/dc/terms/source": {
         "@id": "http://www.w3.org/wiki/WebSchemas/SchemaDotOrgSources#source_bibex"
       },
-      "rdfs:comment": "A part of a successively published publication such as a periodical or multi-volume work, often numbered. It may represent a time span, such as a year.<br/><br/>\n\nSee also <a href=\"https://blog.schema.org/2014/09/02/schema-org-support-for-bibliographic-relationships-and-periodicals/">blog post</a>.",
+      "rdfs:comment": "A part of a successively published publication such as a periodical or multi-volume work, often numbered. It may represent a time span, such as a year.<br/><br/>\n\nSee also <a href=\"https://blog.schema.org/2014/09/02/schema-org-support-for-bibliographic-relationships-and-periodicals\">blog post</a>.",
       "rdfs:label": "PublicationVolume",
       "rdfs:subClassOf": {
         "@id": "http://schema.org/CreativeWork"
@@ -5315,7 +5315,7 @@
       "http://www.w3.org/2002/07/owl#equivalentClass": {
         "@id": "http://purl.org/ontology/bibo/Issue"
       },
-      "rdfs:comment": "A part of a successively published publication such as a periodical or publication volume, often numbered, usually containing a grouping of works such as articles.<br/><br/>\n\nSee also <a href=\"https://blog.schema.org/2014/09/02/schema-org-support-for-bibliographic-relationships-and-periodicals/">blog post</a>.",
+      "rdfs:comment": "A part of a successively published publication such as a periodical or publication volume, often numbered, usually containing a grouping of works such as articles.<br/><br/>\n\nSee also <a href=\"https://blog.schema.org/2014/09/02/schema-org-support-for-bibliographic-relationships-and-periodicals\">blog post</a>.",
       "rdfs:label": "PublicationIssue",
       "rdfs:subClassOf": {
         "@id": "http://schema.org/CreativeWork"
@@ -5365,7 +5365,7 @@
       "http://purl.org/dc/terms/source": {
         "@id": "http://www.w3.org/wiki/WebSchemas/SchemaDotOrgSources#source_rNews"
       },
-      "rdfs:comment": "An article, such as a news article or piece of investigative report. Newspapers and magazines have articles of many different types and this is intended to cover them all.<br/><br/>\n\nSee also <a href=\"https://blog.schema.org/2014/09/02/schema-org-support-for-bibliographic-relationships-and-periodicals/">blog post</a>.",
+      "rdfs:comment": "An article, such as a news article or piece of investigative report. Newspapers and magazines have articles of many different types and this is intended to cover them all.<br/><br/>\n\nSee also <a href=\"https://blog.schema.org/2014/09/02/schema-org-support-for-bibliographic-relationships-and-periodicals\">blog post</a>.",
       "rdfs:label": "Article",
       "rdfs:subClassOf": {
         "@id": "http://schema.org/CreativeWork"
@@ -13812,7 +13812,7 @@
       "http://www.w3.org/2002/07/owl#equivalentClass": {
         "@id": "http://purl.org/ontology/bibo/Periodical"
       },
-      "rdfs:comment": "A publication in any medium issued in successive parts bearing numerical or chronological designations and intended, such as a magazine, scholarly journal, or newspaper to continue indefinitely.<br/><br/>\n\nSee also <a href=\"https://blog.schema.org/2014/09/02/schema-org-support-for-bibliographic-relationships-and-periodicals/">blog post</a>.",
+      "rdfs:comment": "A publication in any medium issued in successive parts bearing numerical or chronological designations and intended, such as a magazine, scholarly journal, or newspaper to continue indefinitely.<br/><br/>\n\nSee also <a href=\"https://blog.schema.org/2014/09/02/schema-org-support-for-bibliographic-relationships-and-periodicals\">blog post</a>.",
       "rdfs:label": "Periodical",
       "rdfs:subClassOf": {
         "@id": "http://schema.org/CreativeWorkSeries"
@@ -15167,7 +15167,7 @@
     {
       "@id": "http://schema.org/Role",
       "@type": "rdfs:Class",
-      "rdfs:comment": "Represents additional information about a relationship or property. For example a Role can be used to say that a 'member' role linking some SportsTeam to a player occurred during a particular time period. Or that a Person's 'actor' role in a Movie was for some particular characterName. Such properties can be attached to a Role entity, which is then associated with the main entities using ordinary properties like 'member' or 'actor'.<br/><br/>\n\nSee also <a href=\"https://blog.schema.org/2014/06/16/introducing-role/">blog post</a>.",
+      "rdfs:comment": "Represents additional information about a relationship or property. For example a Role can be used to say that a 'member' role linking some SportsTeam to a player occurred during a particular time period. Or that a Person's 'actor' role in a Movie was for some particular characterName. Such properties can be attached to a Role entity, which is then associated with the main entities using ordinary properties like 'member' or 'actor'.<br/><br/>\n\nSee also <a href=\"https://blog.schema.org/2014/06/16/introducing-role\">blog post</a>.",
       "rdfs:label": "Role",
       "rdfs:subClassOf": {
         "@id": "http://schema.org/Intangible"

--- a/data/releases/5.0/all-layers.jsonld
+++ b/data/releases/5.0/all-layers.jsonld
@@ -719,7 +719,7 @@
       "http://purl.org/dc/terms/source": {
         "@id": "http://www.w3.org/wiki/WebSchemas/SchemaDotOrgSources#source_ActionCollabClass"
       },
-      "rdfs:comment": "An action performed by a direct agent and indirect participants upon a direct object. Optionally happens at a location with the help of an inanimate instrument. The execution of the action may produce a result. Specific action sub-type documentation specifies the exact expectation of each argument/role.<br/><br/>\n\nSee also <a href=\"https://blog.schema.org/2014/04/16/announcing-schema-org-actions/">blog post</a> and <a href=\"http://schema.org/docs/actions.html\">Actions overview document</a>.",
+      "rdfs:comment": "An action performed by a direct agent and indirect participants upon a direct object. Optionally happens at a location with the help of an inanimate instrument. The execution of the action may produce a result. Specific action sub-type documentation specifies the exact expectation of each argument/role.<br/><br/>\n\nSee also <a href=\"https://blog.schema.org/2014/04/16/announcing-schema-org-actions\">blog post</a> and <a href=\"http://schema.org/docs/actions.html\">Actions overview document</a>.",
       "rdfs:label": "Action",
       "rdfs:subClassOf": {
         "@id": "http://schema.org/Thing"
@@ -5550,7 +5550,7 @@
       "http://purl.org/dc/terms/source": {
         "@id": "http://www.w3.org/wiki/WebSchemas/SchemaDotOrgSources#source_bibex"
       },
-      "rdfs:comment": "A part of a successively published publication such as a periodical or multi-volume work, often numbered. It may represent a time span, such as a year.<br/><br/>\n\nSee also <a href=\"https://blog.schema.org/2014/09/02/schema-org-support-for-bibliographic-relationships-and-periodicals/">blog post</a>.",
+      "rdfs:comment": "A part of a successively published publication such as a periodical or multi-volume work, often numbered. It may represent a time span, such as a year.<br/><br/>\n\nSee also <a href=\"https://blog.schema.org/2014/09/02/schema-org-support-for-bibliographic-relationships-and-periodicals\">blog post</a>.",
       "rdfs:label": "PublicationVolume",
       "rdfs:subClassOf": {
         "@id": "http://schema.org/CreativeWork"
@@ -8364,7 +8364,7 @@
       "http://www.w3.org/2002/07/owl#equivalentClass": {
         "@id": "http://purl.org/ontology/bibo/Issue"
       },
-      "rdfs:comment": "A part of a successively published publication such as a periodical or publication volume, often numbered, usually containing a grouping of works such as articles.<br/><br/>\n\nSee also <a href=\"https://blog.schema.org/2014/09/02/schema-org-support-for-bibliographic-relationships-and-periodicals/">blog post</a>.",
+      "rdfs:comment": "A part of a successively published publication such as a periodical or publication volume, often numbered, usually containing a grouping of works such as articles.<br/><br/>\n\nSee also <a href=\"https://blog.schema.org/2014/09/02/schema-org-support-for-bibliographic-relationships-and-periodicals\">blog post</a>.",
       "rdfs:label": "PublicationIssue",
       "rdfs:subClassOf": {
         "@id": "http://schema.org/CreativeWork"
@@ -8444,7 +8444,7 @@
       "http://purl.org/dc/terms/source": {
         "@id": "http://www.w3.org/wiki/WebSchemas/SchemaDotOrgSources#source_rNews"
       },
-      "rdfs:comment": "An article, such as a news article or piece of investigative report. Newspapers and magazines have articles of many different types and this is intended to cover them all.<br/><br/>\n\nSee also <a href=\"https://blog.schema.org/2014/09/02/schema-org-support-for-bibliographic-relationships-and-periodicals/">blog post</a>.",
+      "rdfs:comment": "An article, such as a news article or piece of investigative report. Newspapers and magazines have articles of many different types and this is intended to cover them all.<br/><br/>\n\nSee also <a href=\"https://blog.schema.org/2014/09/02/schema-org-support-for-bibliographic-relationships-and-periodicals\">blog post</a>.",
       "rdfs:label": "Article",
       "rdfs:subClassOf": {
         "@id": "http://schema.org/CreativeWork"
@@ -20791,7 +20791,7 @@
       "http://www.w3.org/2002/07/owl#equivalentClass": {
         "@id": "http://purl.org/ontology/bibo/Periodical"
       },
-      "rdfs:comment": "A publication in any medium issued in successive parts bearing numerical or chronological designations and intended, such as a magazine, scholarly journal, or newspaper to continue indefinitely.<br/><br/>\n\nSee also <a href=\"https://blog.schema.org/2014/09/02/schema-org-support-for-bibliographic-relationships-and-periodicals/">blog post</a>.",
+      "rdfs:comment": "A publication in any medium issued in successive parts bearing numerical or chronological designations and intended, such as a magazine, scholarly journal, or newspaper to continue indefinitely.<br/><br/>\n\nSee also <a href=\"https://blog.schema.org/2014/09/02/schema-org-support-for-bibliographic-relationships-and-periodicals\">blog post</a>.",
       "rdfs:label": "Periodical",
       "rdfs:subClassOf": {
         "@id": "http://schema.org/CreativeWorkSeries"
@@ -22861,7 +22861,7 @@
     {
       "@id": "http://schema.org/Role",
       "@type": "rdfs:Class",
-      "rdfs:comment": "Represents additional information about a relationship or property. For example a Role can be used to say that a 'member' role linking some SportsTeam to a player occurred during a particular time period. Or that a Person's 'actor' role in a Movie was for some particular characterName. Such properties can be attached to a Role entity, which is then associated with the main entities using ordinary properties like 'member' or 'actor'.<br/><br/>\n\nSee also <a href=\"https://blog.schema.org/2014/06/16/introducing-role/">blog post</a>.",
+      "rdfs:comment": "Represents additional information about a relationship or property. For example a Role can be used to say that a 'member' role linking some SportsTeam to a player occurred during a particular time period. Or that a Person's 'actor' role in a Movie was for some particular characterName. Such properties can be attached to a Role entity, which is then associated with the main entities using ordinary properties like 'member' or 'actor'.<br/><br/>\n\nSee also <a href=\"https://blog.schema.org/2014/06/16/introducing-role\">blog post</a>.",
       "rdfs:label": "Role",
       "rdfs:subClassOf": {
         "@id": "http://schema.org/Intangible"

--- a/data/releases/5.0/schema.jsonld
+++ b/data/releases/5.0/schema.jsonld
@@ -454,7 +454,7 @@
       "http://purl.org/dc/terms/source": {
         "@id": "http://www.w3.org/wiki/WebSchemas/SchemaDotOrgSources#source_ActionCollabClass"
       },
-      "rdfs:comment": "An action performed by a direct agent and indirect participants upon a direct object. Optionally happens at a location with the help of an inanimate instrument. The execution of the action may produce a result. Specific action sub-type documentation specifies the exact expectation of each argument/role.<br/><br/>\n\nSee also <a href=\"https://blog.schema.org/2014/04/16/announcing-schema-org-actions/">blog post</a> and <a href=\"http://schema.org/docs/actions.html\">Actions overview document</a>.",
+      "rdfs:comment": "An action performed by a direct agent and indirect participants upon a direct object. Optionally happens at a location with the help of an inanimate instrument. The execution of the action may produce a result. Specific action sub-type documentation specifies the exact expectation of each argument/role.<br/><br/>\n\nSee also <a href=\"https://blog.schema.org/2014/04/16/announcing-schema-org-actions\">blog post</a> and <a href=\"http://schema.org/docs/actions.html\">Actions overview document</a>.",
       "rdfs:label": "Action",
       "rdfs:subClassOf": {
         "@id": "http://schema.org/Thing"
@@ -3516,7 +3516,7 @@
       "http://purl.org/dc/terms/source": {
         "@id": "http://www.w3.org/wiki/WebSchemas/SchemaDotOrgSources#source_bibex"
       },
-      "rdfs:comment": "A part of a successively published publication such as a periodical or multi-volume work, often numbered. It may represent a time span, such as a year.<br/><br/>\n\nSee also <a href=\"https://blog.schema.org/2014/09/02/schema-org-support-for-bibliographic-relationships-and-periodicals/">blog post</a>.",
+      "rdfs:comment": "A part of a successively published publication such as a periodical or multi-volume work, often numbered. It may represent a time span, such as a year.<br/><br/>\n\nSee also <a href=\"https://blog.schema.org/2014/09/02/schema-org-support-for-bibliographic-relationships-and-periodicals\">blog post</a>.",
       "rdfs:label": "PublicationVolume",
       "rdfs:subClassOf": {
         "@id": "http://schema.org/CreativeWork"
@@ -5319,7 +5319,7 @@
       "http://www.w3.org/2002/07/owl#equivalentClass": {
         "@id": "http://purl.org/ontology/bibo/Issue"
       },
-      "rdfs:comment": "A part of a successively published publication such as a periodical or publication volume, often numbered, usually containing a grouping of works such as articles.<br/><br/>\n\nSee also <a href=\"https://blog.schema.org/2014/09/02/schema-org-support-for-bibliographic-relationships-and-periodicals/">blog post</a>.",
+      "rdfs:comment": "A part of a successively published publication such as a periodical or publication volume, often numbered, usually containing a grouping of works such as articles.<br/><br/>\n\nSee also <a href=\"https://blog.schema.org/2014/09/02/schema-org-support-for-bibliographic-relationships-and-periodicals\">blog post</a>.",
       "rdfs:label": "PublicationIssue",
       "rdfs:subClassOf": {
         "@id": "http://schema.org/CreativeWork"
@@ -5360,7 +5360,7 @@
       "http://purl.org/dc/terms/source": {
         "@id": "http://www.w3.org/wiki/WebSchemas/SchemaDotOrgSources#source_rNews"
       },
-      "rdfs:comment": "An article, such as a news article or piece of investigative report. Newspapers and magazines have articles of many different types and this is intended to cover them all.<br/><br/>\n\nSee also <a href=\"https://blog.schema.org/2014/09/02/schema-org-support-for-bibliographic-relationships-and-periodicals/">blog post</a>.",
+      "rdfs:comment": "An article, such as a news article or piece of investigative report. Newspapers and magazines have articles of many different types and this is intended to cover them all.<br/><br/>\n\nSee also <a href=\"https://blog.schema.org/2014/09/02/schema-org-support-for-bibliographic-relationships-and-periodicals\">blog post</a>.",
       "rdfs:label": "Article",
       "rdfs:subClassOf": {
         "@id": "http://schema.org/CreativeWork"
@@ -13825,7 +13825,7 @@
       "http://www.w3.org/2002/07/owl#equivalentClass": {
         "@id": "http://purl.org/ontology/bibo/Periodical"
       },
-      "rdfs:comment": "A publication in any medium issued in successive parts bearing numerical or chronological designations and intended, such as a magazine, scholarly journal, or newspaper to continue indefinitely.<br/><br/>\n\nSee also <a href=\"https://blog.schema.org/2014/09/02/schema-org-support-for-bibliographic-relationships-and-periodicals/">blog post</a>.",
+      "rdfs:comment": "A publication in any medium issued in successive parts bearing numerical or chronological designations and intended, such as a magazine, scholarly journal, or newspaper to continue indefinitely.<br/><br/>\n\nSee also <a href=\"https://blog.schema.org/2014/09/02/schema-org-support-for-bibliographic-relationships-and-periodicals\">blog post</a>.",
       "rdfs:label": "Periodical",
       "rdfs:subClassOf": {
         "@id": "http://schema.org/CreativeWorkSeries"
@@ -15172,7 +15172,7 @@
     {
       "@id": "http://schema.org/Role",
       "@type": "rdfs:Class",
-      "rdfs:comment": "Represents additional information about a relationship or property. For example a Role can be used to say that a 'member' role linking some SportsTeam to a player occurred during a particular time period. Or that a Person's 'actor' role in a Movie was for some particular characterName. Such properties can be attached to a Role entity, which is then associated with the main entities using ordinary properties like 'member' or 'actor'.<br/><br/>\n\nSee also <a href=\"https://blog.schema.org/2014/06/16/introducing-role/">blog post</a>.",
+      "rdfs:comment": "Represents additional information about a relationship or property. For example a Role can be used to say that a 'member' role linking some SportsTeam to a player occurred during a particular time period. Or that a Person's 'actor' role in a Movie was for some particular characterName. Such properties can be attached to a Role entity, which is then associated with the main entities using ordinary properties like 'member' or 'actor'.<br/><br/>\n\nSee also <a href=\"https://blog.schema.org/2014/06/16/introducing-role\">blog post</a>.",
       "rdfs:label": "Role",
       "rdfs:subClassOf": {
         "@id": "http://schema.org/Intangible"

--- a/data/releases/6.0/all-layers.jsonld
+++ b/data/releases/6.0/all-layers.jsonld
@@ -716,7 +716,7 @@
       "http://purl.org/dc/terms/source": {
         "@id": "http://www.w3.org/wiki/WebSchemas/SchemaDotOrgSources#source_ActionCollabClass"
       },
-      "rdfs:comment": "An action performed by a direct agent and indirect participants upon a direct object. Optionally happens at a location with the help of an inanimate instrument. The execution of the action may produce a result. Specific action sub-type documentation specifies the exact expectation of each argument/role.<br/><br/>\n\nSee also <a href=\"https://blog.schema.org/2014/04/16/announcing-schema-org-actions/">blog post</a> and <a href=\"http://schema.org/docs/actions.html\">Actions overview document</a>.",
+      "rdfs:comment": "An action performed by a direct agent and indirect participants upon a direct object. Optionally happens at a location with the help of an inanimate instrument. The execution of the action may produce a result. Specific action sub-type documentation specifies the exact expectation of each argument/role.<br/><br/>\n\nSee also <a href=\"https://blog.schema.org/2014/04/16/announcing-schema-org-actions\">blog post</a> and <a href=\"http://schema.org/docs/actions.html\">Actions overview document</a>.",
       "rdfs:label": "Action",
       "rdfs:subClassOf": {
         "@id": "http://schema.org/Thing"
@@ -5662,7 +5662,7 @@
       "http://purl.org/dc/terms/source": {
         "@id": "http://www.w3.org/wiki/WebSchemas/SchemaDotOrgSources#source_bibex"
       },
-      "rdfs:comment": "A part of a successively published publication such as a periodical or multi-volume work, often numbered. It may represent a time span, such as a year.<br/><br/>\n\nSee also <a href=\"https://blog.schema.org/2014/09/02/schema-org-support-for-bibliographic-relationships-and-periodicals/">blog post</a>.",
+      "rdfs:comment": "A part of a successively published publication such as a periodical or multi-volume work, often numbered. It may represent a time span, such as a year.<br/><br/>\n\nSee also <a href=\"https://blog.schema.org/2014/09/02/schema-org-support-for-bibliographic-relationships-and-periodicals\">blog post</a>.",
       "rdfs:label": "PublicationVolume",
       "rdfs:subClassOf": {
         "@id": "http://schema.org/CreativeWork"
@@ -8497,7 +8497,7 @@
       "http://www.w3.org/2002/07/owl#equivalentClass": {
         "@id": "http://purl.org/ontology/bibo/Issue"
       },
-      "rdfs:comment": "A part of a successively published publication such as a periodical or publication volume, often numbered, usually containing a grouping of works such as articles.<br/><br/>\n\nSee also <a href=\"https://blog.schema.org/2014/09/02/schema-org-support-for-bibliographic-relationships-and-periodicals/">blog post</a>.",
+      "rdfs:comment": "A part of a successively published publication such as a periodical or publication volume, often numbered, usually containing a grouping of works such as articles.<br/><br/>\n\nSee also <a href=\"https://blog.schema.org/2014/09/02/schema-org-support-for-bibliographic-relationships-and-periodicals\">blog post</a>.",
       "rdfs:label": "PublicationIssue",
       "rdfs:subClassOf": {
         "@id": "http://schema.org/CreativeWork"
@@ -8596,7 +8596,7 @@
       "http://purl.org/dc/terms/source": {
         "@id": "http://www.w3.org/wiki/WebSchemas/SchemaDotOrgSources#source_rNews"
       },
-      "rdfs:comment": "An article, such as a news article or piece of investigative report. Newspapers and magazines have articles of many different types and this is intended to cover them all.<br/><br/>\n\nSee also <a href=\"https://blog.schema.org/2014/09/02/schema-org-support-for-bibliographic-relationships-and-periodicals/">blog post</a>.",
+      "rdfs:comment": "An article, such as a news article or piece of investigative report. Newspapers and magazines have articles of many different types and this is intended to cover them all.<br/><br/>\n\nSee also <a href=\"https://blog.schema.org/2014/09/02/schema-org-support-for-bibliographic-relationships-and-periodicals\">blog post</a>.",
       "rdfs:label": "Article",
       "rdfs:subClassOf": {
         "@id": "http://schema.org/CreativeWork"
@@ -21540,7 +21540,7 @@
       "http://www.w3.org/2002/07/owl#equivalentClass": {
         "@id": "http://purl.org/ontology/bibo/Periodical"
       },
-      "rdfs:comment": "A publication in any medium issued in successive parts bearing numerical or chronological designations and intended, such as a magazine, scholarly journal, or newspaper to continue indefinitely.<br/><br/>\n\nSee also <a href=\"https://blog.schema.org/2014/09/02/schema-org-support-for-bibliographic-relationships-and-periodicals/">blog post</a>.",
+      "rdfs:comment": "A publication in any medium issued in successive parts bearing numerical or chronological designations and intended, such as a magazine, scholarly journal, or newspaper to continue indefinitely.<br/><br/>\n\nSee also <a href=\"https://blog.schema.org/2014/09/02/schema-org-support-for-bibliographic-relationships-and-periodicals\">blog post</a>.",
       "rdfs:label": "Periodical",
       "rdfs:subClassOf": {
         "@id": "http://schema.org/CreativeWorkSeries"
@@ -23724,7 +23724,7 @@
     {
       "@id": "http://schema.org/Role",
       "@type": "rdfs:Class",
-      "rdfs:comment": "Represents additional information about a relationship or property. For example a Role can be used to say that a 'member' role linking some SportsTeam to a player occurred during a particular time period. Or that a Person's 'actor' role in a Movie was for some particular characterName. Such properties can be attached to a Role entity, which is then associated with the main entities using ordinary properties like 'member' or 'actor'.<br/><br/>\n\nSee also <a href=\"https://blog.schema.org/2014/06/16/introducing-role/">blog post</a>.",
+      "rdfs:comment": "Represents additional information about a relationship or property. For example a Role can be used to say that a 'member' role linking some SportsTeam to a player occurred during a particular time period. Or that a Person's 'actor' role in a Movie was for some particular characterName. Such properties can be attached to a Role entity, which is then associated with the main entities using ordinary properties like 'member' or 'actor'.<br/><br/>\n\nSee also <a href=\"https://blog.schema.org/2014/06/16/introducing-role\">blog post</a>.",
       "rdfs:label": "Role",
       "rdfs:subClassOf": {
         "@id": "http://schema.org/Intangible"

--- a/data/releases/6.0/schema.jsonld
+++ b/data/releases/6.0/schema.jsonld
@@ -452,7 +452,7 @@
       "http://purl.org/dc/terms/source": {
         "@id": "http://www.w3.org/wiki/WebSchemas/SchemaDotOrgSources#source_ActionCollabClass"
       },
-      "rdfs:comment": "An action performed by a direct agent and indirect participants upon a direct object. Optionally happens at a location with the help of an inanimate instrument. The execution of the action may produce a result. Specific action sub-type documentation specifies the exact expectation of each argument/role.<br/><br/>\n\nSee also <a href=\"https://blog.schema.org/2014/04/16/announcing-schema-org-actions/">blog post</a> and <a href=\"http://schema.org/docs/actions.html\">Actions overview document</a>.",
+      "rdfs:comment": "An action performed by a direct agent and indirect participants upon a direct object. Optionally happens at a location with the help of an inanimate instrument. The execution of the action may produce a result. Specific action sub-type documentation specifies the exact expectation of each argument/role.<br/><br/>\n\nSee also <a href=\"https://blog.schema.org/2014/04/16/announcing-schema-org-actions\">blog post</a> and <a href=\"http://schema.org/docs/actions.html\">Actions overview document</a>.",
       "rdfs:label": "Action",
       "rdfs:subClassOf": {
         "@id": "http://schema.org/Thing"
@@ -3548,7 +3548,7 @@
       "http://purl.org/dc/terms/source": {
         "@id": "http://www.w3.org/wiki/WebSchemas/SchemaDotOrgSources#source_bibex"
       },
-      "rdfs:comment": "A part of a successively published publication such as a periodical or multi-volume work, often numbered. It may represent a time span, such as a year.<br/><br/>\n\nSee also <a href=\"https://blog.schema.org/2014/09/02/schema-org-support-for-bibliographic-relationships-and-periodicals/">blog post</a>.",
+      "rdfs:comment": "A part of a successively published publication such as a periodical or multi-volume work, often numbered. It may represent a time span, such as a year.<br/><br/>\n\nSee also <a href=\"https://blog.schema.org/2014/09/02/schema-org-support-for-bibliographic-relationships-and-periodicals\">blog post</a>.",
       "rdfs:label": "PublicationVolume",
       "rdfs:subClassOf": {
         "@id": "http://schema.org/CreativeWork"
@@ -5353,7 +5353,7 @@
       "http://www.w3.org/2002/07/owl#equivalentClass": {
         "@id": "http://purl.org/ontology/bibo/Issue"
       },
-      "rdfs:comment": "A part of a successively published publication such as a periodical or publication volume, often numbered, usually containing a grouping of works such as articles.<br/><br/>\n\nSee also <a href=\"https://blog.schema.org/2014/09/02/schema-org-support-for-bibliographic-relationships-and-periodicals/">blog post</a>.",
+      "rdfs:comment": "A part of a successively published publication such as a periodical or publication volume, often numbered, usually containing a grouping of works such as articles.<br/><br/>\n\nSee also <a href=\"https://blog.schema.org/2014/09/02/schema-org-support-for-bibliographic-relationships-and-periodicals\">blog post</a>.",
       "rdfs:label": "PublicationIssue",
       "rdfs:subClassOf": {
         "@id": "http://schema.org/CreativeWork"
@@ -5394,7 +5394,7 @@
       "http://purl.org/dc/terms/source": {
         "@id": "http://www.w3.org/wiki/WebSchemas/SchemaDotOrgSources#source_rNews"
       },
-      "rdfs:comment": "An article, such as a news article or piece of investigative report. Newspapers and magazines have articles of many different types and this is intended to cover them all.<br/><br/>\n\nSee also <a href=\"https://blog.schema.org/2014/09/02/schema-org-support-for-bibliographic-relationships-and-periodicals/">blog post</a>.",
+      "rdfs:comment": "An article, such as a news article or piece of investigative report. Newspapers and magazines have articles of many different types and this is intended to cover them all.<br/><br/>\n\nSee also <a href=\"https://blog.schema.org/2014/09/02/schema-org-support-for-bibliographic-relationships-and-periodicals\">blog post</a>.",
       "rdfs:label": "Article",
       "rdfs:subClassOf": {
         "@id": "http://schema.org/CreativeWork"
@@ -13873,7 +13873,7 @@
       "http://www.w3.org/2002/07/owl#equivalentClass": {
         "@id": "http://purl.org/ontology/bibo/Periodical"
       },
-      "rdfs:comment": "A publication in any medium issued in successive parts bearing numerical or chronological designations and intended, such as a magazine, scholarly journal, or newspaper to continue indefinitely.<br/><br/>\n\nSee also <a href=\"https://blog.schema.org/2014/09/02/schema-org-support-for-bibliographic-relationships-and-periodicals/">blog post</a>.",
+      "rdfs:comment": "A publication in any medium issued in successive parts bearing numerical or chronological designations and intended, such as a magazine, scholarly journal, or newspaper to continue indefinitely.<br/><br/>\n\nSee also <a href=\"https://blog.schema.org/2014/09/02/schema-org-support-for-bibliographic-relationships-and-periodicals\">blog post</a>.",
       "rdfs:label": "Periodical",
       "rdfs:subClassOf": {
         "@id": "http://schema.org/CreativeWorkSeries"
@@ -15204,7 +15204,7 @@
     {
       "@id": "http://schema.org/Role",
       "@type": "rdfs:Class",
-      "rdfs:comment": "Represents additional information about a relationship or property. For example a Role can be used to say that a 'member' role linking some SportsTeam to a player occurred during a particular time period. Or that a Person's 'actor' role in a Movie was for some particular characterName. Such properties can be attached to a Role entity, which is then associated with the main entities using ordinary properties like 'member' or 'actor'.<br/><br/>\n\nSee also <a href=\"https://blog.schema.org/2014/06/16/introducing-role/">blog post</a>.",
+      "rdfs:comment": "Represents additional information about a relationship or property. For example a Role can be used to say that a 'member' role linking some SportsTeam to a player occurred during a particular time period. Or that a Person's 'actor' role in a Movie was for some particular characterName. Such properties can be attached to a Role entity, which is then associated with the main entities using ordinary properties like 'member' or 'actor'.<br/><br/>\n\nSee also <a href=\"https://blog.schema.org/2014/06/16/introducing-role\">blog post</a>.",
       "rdfs:label": "Role",
       "rdfs:subClassOf": {
         "@id": "http://schema.org/Intangible"

--- a/data/releases/7.0/all-layers.jsonld
+++ b/data/releases/7.0/all-layers.jsonld
@@ -739,7 +739,7 @@
       "http://purl.org/dc/terms/source": {
         "@id": "http://www.w3.org/wiki/WebSchemas/SchemaDotOrgSources#source_ActionCollabClass"
       },
-      "rdfs:comment": "An action performed by a direct agent and indirect participants upon a direct object. Optionally happens at a location with the help of an inanimate instrument. The execution of the action may produce a result. Specific action sub-type documentation specifies the exact expectation of each argument/role.<br/><br/>\n\nSee also <a href=\"https://blog.schema.org/2014/04/16/announcing-schema-org-actions/">blog post</a> and <a href=\"http://schema.org/docs/actions.html\">Actions overview document</a>.",
+      "rdfs:comment": "An action performed by a direct agent and indirect participants upon a direct object. Optionally happens at a location with the help of an inanimate instrument. The execution of the action may produce a result. Specific action sub-type documentation specifies the exact expectation of each argument/role.<br/><br/>\n\nSee also <a href=\"https://blog.schema.org/2014/04/16/announcing-schema-org-actions\">blog post</a> and <a href=\"http://schema.org/docs/actions.html\">Actions overview document</a>.",
       "rdfs:label": "Action",
       "rdfs:subClassOf": {
         "@id": "http://schema.org/Thing"
@@ -5673,7 +5673,7 @@
       "http://purl.org/dc/terms/source": {
         "@id": "http://www.w3.org/wiki/WebSchemas/SchemaDotOrgSources#source_bibex"
       },
-      "rdfs:comment": "A part of a successively published publication such as a periodical or multi-volume work, often numbered. It may represent a time span, such as a year.<br/><br/>\n\nSee also <a href=\"https://blog.schema.org/2014/09/02/schema-org-support-for-bibliographic-relationships-and-periodicals/">blog post</a>.",
+      "rdfs:comment": "A part of a successively published publication such as a periodical or multi-volume work, often numbered. It may represent a time span, such as a year.<br/><br/>\n\nSee also <a href=\"https://blog.schema.org/2014/09/02/schema-org-support-for-bibliographic-relationships-and-periodicals\">blog post</a>.",
       "rdfs:label": "PublicationVolume",
       "rdfs:subClassOf": {
         "@id": "http://schema.org/CreativeWork"
@@ -8475,7 +8475,7 @@
       "http://www.w3.org/2002/07/owl#equivalentClass": {
         "@id": "http://purl.org/ontology/bibo/Issue"
       },
-      "rdfs:comment": "A part of a successively published publication such as a periodical or publication volume, often numbered, usually containing a grouping of works such as articles.<br/><br/>\n\nSee also <a href=\"https://blog.schema.org/2014/09/02/schema-org-support-for-bibliographic-relationships-and-periodicals/">blog post</a>.",
+      "rdfs:comment": "A part of a successively published publication such as a periodical or publication volume, often numbered, usually containing a grouping of works such as articles.<br/><br/>\n\nSee also <a href=\"https://blog.schema.org/2014/09/02/schema-org-support-for-bibliographic-relationships-and-periodicals\">blog post</a>.",
       "rdfs:label": "PublicationIssue",
       "rdfs:subClassOf": {
         "@id": "http://schema.org/CreativeWork"
@@ -8587,7 +8587,7 @@
       "http://purl.org/dc/terms/source": {
         "@id": "http://www.w3.org/wiki/WebSchemas/SchemaDotOrgSources#source_rNews"
       },
-      "rdfs:comment": "An article, such as a news article or piece of investigative report. Newspapers and magazines have articles of many different types and this is intended to cover them all.<br/><br/>\n\nSee also <a href=\"https://blog.schema.org/2014/09/02/schema-org-support-for-bibliographic-relationships-and-periodicals/">blog post</a>.",
+      "rdfs:comment": "An article, such as a news article or piece of investigative report. Newspapers and magazines have articles of many different types and this is intended to cover them all.<br/><br/>\n\nSee also <a href=\"https://blog.schema.org/2014/09/02/schema-org-support-for-bibliographic-relationships-and-periodicals\">blog post</a>.",
       "rdfs:label": "Article",
       "rdfs:subClassOf": {
         "@id": "http://schema.org/CreativeWork"
@@ -21581,7 +21581,7 @@
       "http://www.w3.org/2002/07/owl#equivalentClass": {
         "@id": "http://purl.org/ontology/bibo/Periodical"
       },
-      "rdfs:comment": "A publication in any medium issued in successive parts bearing numerical or chronological designations and intended, such as a magazine, scholarly journal, or newspaper to continue indefinitely.<br/><br/>\n\nSee also <a href=\"https://blog.schema.org/2014/09/02/schema-org-support-for-bibliographic-relationships-and-periodicals/">blog post</a>.",
+      "rdfs:comment": "A publication in any medium issued in successive parts bearing numerical or chronological designations and intended, such as a magazine, scholarly journal, or newspaper to continue indefinitely.<br/><br/>\n\nSee also <a href=\"https://blog.schema.org/2014/09/02/schema-org-support-for-bibliographic-relationships-and-periodicals\">blog post</a>.",
       "rdfs:label": "Periodical",
       "rdfs:subClassOf": {
         "@id": "http://schema.org/CreativeWorkSeries"
@@ -23816,7 +23816,7 @@
     {
       "@id": "http://schema.org/Role",
       "@type": "rdfs:Class",
-      "rdfs:comment": "Represents additional information about a relationship or property. For example a Role can be used to say that a 'member' role linking some SportsTeam to a player occurred during a particular time period. Or that a Person's 'actor' role in a Movie was for some particular characterName. Such properties can be attached to a Role entity, which is then associated with the main entities using ordinary properties like 'member' or 'actor'.<br/><br/>\n\nSee also <a href=\"https://blog.schema.org/2014/06/16/introducing-role/">blog post</a>.",
+      "rdfs:comment": "Represents additional information about a relationship or property. For example a Role can be used to say that a 'member' role linking some SportsTeam to a player occurred during a particular time period. Or that a Person's 'actor' role in a Movie was for some particular characterName. Such properties can be attached to a Role entity, which is then associated with the main entities using ordinary properties like 'member' or 'actor'.<br/><br/>\n\nSee also <a href=\"https://blog.schema.org/2014/06/16/introducing-role\">blog post</a>.",
       "rdfs:label": "Role",
       "rdfs:subClassOf": {
         "@id": "http://schema.org/Intangible"

--- a/data/releases/7.0/schema.jsonld
+++ b/data/releases/7.0/schema.jsonld
@@ -428,7 +428,7 @@
       "http://purl.org/dc/terms/source": {
         "@id": "http://www.w3.org/wiki/WebSchemas/SchemaDotOrgSources#source_ActionCollabClass"
       },
-      "rdfs:comment": "An action performed by a direct agent and indirect participants upon a direct object. Optionally happens at a location with the help of an inanimate instrument. The execution of the action may produce a result. Specific action sub-type documentation specifies the exact expectation of each argument/role.<br/><br/>\n\nSee also <a href=\"https://blog.schema.org/2014/04/16/announcing-schema-org-actions/">blog post</a> and <a href=\"http://schema.org/docs/actions.html\">Actions overview document</a>.",
+      "rdfs:comment": "An action performed by a direct agent and indirect participants upon a direct object. Optionally happens at a location with the help of an inanimate instrument. The execution of the action may produce a result. Specific action sub-type documentation specifies the exact expectation of each argument/role.<br/><br/>\n\nSee also <a href=\"https://blog.schema.org/2014/04/16/announcing-schema-org-actions\">blog post</a> and <a href=\"http://schema.org/docs/actions.html\">Actions overview document</a>.",
       "rdfs:label": "Action",
       "rdfs:subClassOf": {
         "@id": "http://schema.org/Thing"
@@ -3497,7 +3497,7 @@
       "http://purl.org/dc/terms/source": {
         "@id": "http://www.w3.org/wiki/WebSchemas/SchemaDotOrgSources#source_bibex"
       },
-      "rdfs:comment": "A part of a successively published publication such as a periodical or multi-volume work, often numbered. It may represent a time span, such as a year.<br/><br/>\n\nSee also <a href=\"https://blog.schema.org/2014/09/02/schema-org-support-for-bibliographic-relationships-and-periodicals/">blog post</a>.",
+      "rdfs:comment": "A part of a successively published publication such as a periodical or multi-volume work, often numbered. It may represent a time span, such as a year.<br/><br/>\n\nSee also <a href=\"https://blog.schema.org/2014/09/02/schema-org-support-for-bibliographic-relationships-and-periodicals\">blog post</a>.",
       "rdfs:label": "PublicationVolume",
       "rdfs:subClassOf": {
         "@id": "http://schema.org/CreativeWork"
@@ -5306,7 +5306,7 @@
       "http://www.w3.org/2002/07/owl#equivalentClass": {
         "@id": "http://purl.org/ontology/bibo/Issue"
       },
-      "rdfs:comment": "A part of a successively published publication such as a periodical or publication volume, often numbered, usually containing a grouping of works such as articles.<br/><br/>\n\nSee also <a href=\"https://blog.schema.org/2014/09/02/schema-org-support-for-bibliographic-relationships-and-periodicals/">blog post</a>.",
+      "rdfs:comment": "A part of a successively published publication such as a periodical or publication volume, often numbered, usually containing a grouping of works such as articles.<br/><br/>\n\nSee also <a href=\"https://blog.schema.org/2014/09/02/schema-org-support-for-bibliographic-relationships-and-periodicals\">blog post</a>.",
       "rdfs:label": "PublicationIssue",
       "rdfs:subClassOf": {
         "@id": "http://schema.org/CreativeWork"
@@ -5347,7 +5347,7 @@
       "http://purl.org/dc/terms/source": {
         "@id": "http://www.w3.org/wiki/WebSchemas/SchemaDotOrgSources#source_rNews"
       },
-      "rdfs:comment": "An article, such as a news article or piece of investigative report. Newspapers and magazines have articles of many different types and this is intended to cover them all.<br/><br/>\n\nSee also <a href=\"https://blog.schema.org/2014/09/02/schema-org-support-for-bibliographic-relationships-and-periodicals/">blog post</a>.",
+      "rdfs:comment": "An article, such as a news article or piece of investigative report. Newspapers and magazines have articles of many different types and this is intended to cover them all.<br/><br/>\n\nSee also <a href=\"https://blog.schema.org/2014/09/02/schema-org-support-for-bibliographic-relationships-and-periodicals\">blog post</a>.",
       "rdfs:label": "Article",
       "rdfs:subClassOf": {
         "@id": "http://schema.org/CreativeWork"
@@ -13921,7 +13921,7 @@
       "http://www.w3.org/2002/07/owl#equivalentClass": {
         "@id": "http://purl.org/ontology/bibo/Periodical"
       },
-      "rdfs:comment": "A publication in any medium issued in successive parts bearing numerical or chronological designations and intended, such as a magazine, scholarly journal, or newspaper to continue indefinitely.<br/><br/>\n\nSee also <a href=\"https://blog.schema.org/2014/09/02/schema-org-support-for-bibliographic-relationships-and-periodicals/">blog post</a>.",
+      "rdfs:comment": "A publication in any medium issued in successive parts bearing numerical or chronological designations and intended, such as a magazine, scholarly journal, or newspaper to continue indefinitely.<br/><br/>\n\nSee also <a href=\"https://blog.schema.org/2014/09/02/schema-org-support-for-bibliographic-relationships-and-periodicals\">blog post</a>.",
       "rdfs:label": "Periodical",
       "rdfs:subClassOf": {
         "@id": "http://schema.org/CreativeWorkSeries"
@@ -15276,7 +15276,7 @@
     {
       "@id": "http://schema.org/Role",
       "@type": "rdfs:Class",
-      "rdfs:comment": "Represents additional information about a relationship or property. For example a Role can be used to say that a 'member' role linking some SportsTeam to a player occurred during a particular time period. Or that a Person's 'actor' role in a Movie was for some particular characterName. Such properties can be attached to a Role entity, which is then associated with the main entities using ordinary properties like 'member' or 'actor'.<br/><br/>\n\nSee also <a href=\"https://blog.schema.org/2014/06/16/introducing-role/">blog post</a>.",
+      "rdfs:comment": "Represents additional information about a relationship or property. For example a Role can be used to say that a 'member' role linking some SportsTeam to a player occurred during a particular time period. Or that a Person's 'actor' role in a Movie was for some particular characterName. Such properties can be attached to a Role entity, which is then associated with the main entities using ordinary properties like 'member' or 'actor'.<br/><br/>\n\nSee also <a href=\"https://blog.schema.org/2014/06/16/introducing-role\">blog post</a>.",
       "rdfs:label": "Role",
       "rdfs:subClassOf": {
         "@id": "http://schema.org/Intangible"

--- a/data/releases/7.01/all-layers.jsonld
+++ b/data/releases/7.01/all-layers.jsonld
@@ -759,7 +759,7 @@
       "http://purl.org/dc/terms/source": {
         "@id": "http://www.w3.org/wiki/WebSchemas/SchemaDotOrgSources#source_ActionCollabClass"
       },
-      "rdfs:comment": "An action performed by a direct agent and indirect participants upon a direct object. Optionally happens at a location with the help of an inanimate instrument. The execution of the action may produce a result. Specific action sub-type documentation specifies the exact expectation of each argument/role.<br/><br/>\n\nSee also <a href=\"https://blog.schema.org/2014/04/16/announcing-schema-org-actions/">blog post</a> and <a href=\"http://schema.org/docs/actions.html\">Actions overview document</a>.",
+      "rdfs:comment": "An action performed by a direct agent and indirect participants upon a direct object. Optionally happens at a location with the help of an inanimate instrument. The execution of the action may produce a result. Specific action sub-type documentation specifies the exact expectation of each argument/role.<br/><br/>\n\nSee also <a href=\"https://blog.schema.org/2014/04/16/announcing-schema-org-actions\">blog post</a> and <a href=\"http://schema.org/docs/actions.html\">Actions overview document</a>.",
       "rdfs:label": "Action",
       "rdfs:subClassOf": {
         "@id": "http://schema.org/Thing"
@@ -5623,7 +5623,7 @@
       "http://purl.org/dc/terms/source": {
         "@id": "http://www.w3.org/wiki/WebSchemas/SchemaDotOrgSources#source_bibex"
       },
-      "rdfs:comment": "A part of a successively published publication such as a periodical or multi-volume work, often numbered. It may represent a time span, such as a year.<br/><br/>\n\nSee also <a href=\"https://blog.schema.org/2014/09/02/schema-org-support-for-bibliographic-relationships-and-periodicals/">blog post</a>.",
+      "rdfs:comment": "A part of a successively published publication such as a periodical or multi-volume work, often numbered. It may represent a time span, such as a year.<br/><br/>\n\nSee also <a href=\"https://blog.schema.org/2014/09/02/schema-org-support-for-bibliographic-relationships-and-periodicals\">blog post</a>.",
       "rdfs:label": "PublicationVolume",
       "rdfs:subClassOf": {
         "@id": "http://schema.org/CreativeWork"
@@ -8444,7 +8444,7 @@
       "http://www.w3.org/2002/07/owl#equivalentClass": {
         "@id": "http://purl.org/ontology/bibo/Issue"
       },
-      "rdfs:comment": "A part of a successively published publication such as a periodical or publication volume, often numbered, usually containing a grouping of works such as articles.<br/><br/>\n\nSee also <a href=\"https://blog.schema.org/2014/09/02/schema-org-support-for-bibliographic-relationships-and-periodicals/">blog post</a>.",
+      "rdfs:comment": "A part of a successively published publication such as a periodical or publication volume, often numbered, usually containing a grouping of works such as articles.<br/><br/>\n\nSee also <a href=\"https://blog.schema.org/2014/09/02/schema-org-support-for-bibliographic-relationships-and-periodicals\">blog post</a>.",
       "rdfs:label": "PublicationIssue",
       "rdfs:subClassOf": {
         "@id": "http://schema.org/CreativeWork"
@@ -8556,7 +8556,7 @@
       "http://purl.org/dc/terms/source": {
         "@id": "http://www.w3.org/wiki/WebSchemas/SchemaDotOrgSources#source_rNews"
       },
-      "rdfs:comment": "An article, such as a news article or piece of investigative report. Newspapers and magazines have articles of many different types and this is intended to cover them all.<br/><br/>\n\nSee also <a href=\"https://blog.schema.org/2014/09/02/schema-org-support-for-bibliographic-relationships-and-periodicals/">blog post</a>.",
+      "rdfs:comment": "An article, such as a news article or piece of investigative report. Newspapers and magazines have articles of many different types and this is intended to cover them all.<br/><br/>\n\nSee also <a href=\"https://blog.schema.org/2014/09/02/schema-org-support-for-bibliographic-relationships-and-periodicals\">blog post</a>.",
       "rdfs:label": "Article",
       "rdfs:subClassOf": {
         "@id": "http://schema.org/CreativeWork"
@@ -21640,7 +21640,7 @@
       "http://www.w3.org/2002/07/owl#equivalentClass": {
         "@id": "http://purl.org/ontology/bibo/Periodical"
       },
-      "rdfs:comment": "A publication in any medium issued in successive parts bearing numerical or chronological designations and intended, such as a magazine, scholarly journal, or newspaper to continue indefinitely.<br/><br/>\n\nSee also <a href=\"https://blog.schema.org/2014/09/02/schema-org-support-for-bibliographic-relationships-and-periodicals/">blog post</a>.",
+      "rdfs:comment": "A publication in any medium issued in successive parts bearing numerical or chronological designations and intended, such as a magazine, scholarly journal, or newspaper to continue indefinitely.<br/><br/>\n\nSee also <a href=\"https://blog.schema.org/2014/09/02/schema-org-support-for-bibliographic-relationships-and-periodicals\">blog post</a>.",
       "rdfs:label": "Periodical",
       "rdfs:subClassOf": {
         "@id": "http://schema.org/CreativeWorkSeries"
@@ -23823,7 +23823,7 @@
     {
       "@id": "http://schema.org/Role",
       "@type": "rdfs:Class",
-      "rdfs:comment": "Represents additional information about a relationship or property. For example a Role can be used to say that a 'member' role linking some SportsTeam to a player occurred during a particular time period. Or that a Person's 'actor' role in a Movie was for some particular characterName. Such properties can be attached to a Role entity, which is then associated with the main entities using ordinary properties like 'member' or 'actor'.<br/><br/>\n\nSee also <a href=\"https://blog.schema.org/2014/06/16/introducing-role/">blog post</a>.",
+      "rdfs:comment": "Represents additional information about a relationship or property. For example a Role can be used to say that a 'member' role linking some SportsTeam to a player occurred during a particular time period. Or that a Person's 'actor' role in a Movie was for some particular characterName. Such properties can be attached to a Role entity, which is then associated with the main entities using ordinary properties like 'member' or 'actor'.<br/><br/>\n\nSee also <a href=\"https://blog.schema.org/2014/06/16/introducing-role\">blog post</a>.",
       "rdfs:label": "Role",
       "rdfs:subClassOf": {
         "@id": "http://schema.org/Intangible"

--- a/data/releases/7.01/schema.jsonld
+++ b/data/releases/7.01/schema.jsonld
@@ -433,7 +433,7 @@
       "http://purl.org/dc/terms/source": {
         "@id": "http://www.w3.org/wiki/WebSchemas/SchemaDotOrgSources#source_ActionCollabClass"
       },
-      "rdfs:comment": "An action performed by a direct agent and indirect participants upon a direct object. Optionally happens at a location with the help of an inanimate instrument. The execution of the action may produce a result. Specific action sub-type documentation specifies the exact expectation of each argument/role.<br/><br/>\n\nSee also <a href=\"https://blog.schema.org/2014/04/16/announcing-schema-org-actions/">blog post</a> and <a href=\"http://schema.org/docs/actions.html\">Actions overview document</a>.",
+      "rdfs:comment": "An action performed by a direct agent and indirect participants upon a direct object. Optionally happens at a location with the help of an inanimate instrument. The execution of the action may produce a result. Specific action sub-type documentation specifies the exact expectation of each argument/role.<br/><br/>\n\nSee also <a href=\"https://blog.schema.org/2014/04/16/announcing-schema-org-actions\">blog post</a> and <a href=\"http://schema.org/docs/actions.html\">Actions overview document</a>.",
       "rdfs:label": "Action",
       "rdfs:subClassOf": {
         "@id": "http://schema.org/Thing"
@@ -3550,7 +3550,7 @@
       "http://purl.org/dc/terms/source": {
         "@id": "http://www.w3.org/wiki/WebSchemas/SchemaDotOrgSources#source_bibex"
       },
-      "rdfs:comment": "A part of a successively published publication such as a periodical or multi-volume work, often numbered. It may represent a time span, such as a year.<br/><br/>\n\nSee also <a href=\"https://blog.schema.org/2014/09/02/schema-org-support-for-bibliographic-relationships-and-periodicals/">blog post</a>.",
+      "rdfs:comment": "A part of a successively published publication such as a periodical or multi-volume work, often numbered. It may represent a time span, such as a year.<br/><br/>\n\nSee also <a href=\"https://blog.schema.org/2014/09/02/schema-org-support-for-bibliographic-relationships-and-periodicals\">blog post</a>.",
       "rdfs:label": "PublicationVolume",
       "rdfs:subClassOf": {
         "@id": "http://schema.org/CreativeWork"
@@ -5340,7 +5340,7 @@
       "http://www.w3.org/2002/07/owl#equivalentClass": {
         "@id": "http://purl.org/ontology/bibo/Issue"
       },
-      "rdfs:comment": "A part of a successively published publication such as a periodical or publication volume, often numbered, usually containing a grouping of works such as articles.<br/><br/>\n\nSee also <a href=\"https://blog.schema.org/2014/09/02/schema-org-support-for-bibliographic-relationships-and-periodicals/">blog post</a>.",
+      "rdfs:comment": "A part of a successively published publication such as a periodical or publication volume, often numbered, usually containing a grouping of works such as articles.<br/><br/>\n\nSee also <a href=\"https://blog.schema.org/2014/09/02/schema-org-support-for-bibliographic-relationships-and-periodicals\">blog post</a>.",
       "rdfs:label": "PublicationIssue",
       "rdfs:subClassOf": {
         "@id": "http://schema.org/CreativeWork"
@@ -5381,7 +5381,7 @@
       "http://purl.org/dc/terms/source": {
         "@id": "http://www.w3.org/wiki/WebSchemas/SchemaDotOrgSources#source_rNews"
       },
-      "rdfs:comment": "An article, such as a news article or piece of investigative report. Newspapers and magazines have articles of many different types and this is intended to cover them all.<br/><br/>\n\nSee also <a href=\"https://blog.schema.org/2014/09/02/schema-org-support-for-bibliographic-relationships-and-periodicals/">blog post</a>.",
+      "rdfs:comment": "An article, such as a news article or piece of investigative report. Newspapers and magazines have articles of many different types and this is intended to cover them all.<br/><br/>\n\nSee also <a href=\"https://blog.schema.org/2014/09/02/schema-org-support-for-bibliographic-relationships-and-periodicals\">blog post</a>.",
       "rdfs:label": "Article",
       "rdfs:subClassOf": {
         "@id": "http://schema.org/CreativeWork"
@@ -13909,7 +13909,7 @@
       "http://www.w3.org/2002/07/owl#equivalentClass": {
         "@id": "http://purl.org/ontology/bibo/Periodical"
       },
-      "rdfs:comment": "A publication in any medium issued in successive parts bearing numerical or chronological designations and intended, such as a magazine, scholarly journal, or newspaper to continue indefinitely.<br/><br/>\n\nSee also <a href=\"https://blog.schema.org/2014/09/02/schema-org-support-for-bibliographic-relationships-and-periodicals/">blog post</a>.",
+      "rdfs:comment": "A publication in any medium issued in successive parts bearing numerical or chronological designations and intended, such as a magazine, scholarly journal, or newspaper to continue indefinitely.<br/><br/>\n\nSee also <a href=\"https://blog.schema.org/2014/09/02/schema-org-support-for-bibliographic-relationships-and-periodicals\">blog post</a>.",
       "rdfs:label": "Periodical",
       "rdfs:subClassOf": {
         "@id": "http://schema.org/CreativeWorkSeries"
@@ -15257,7 +15257,7 @@
     {
       "@id": "http://schema.org/Role",
       "@type": "rdfs:Class",
-      "rdfs:comment": "Represents additional information about a relationship or property. For example a Role can be used to say that a 'member' role linking some SportsTeam to a player occurred during a particular time period. Or that a Person's 'actor' role in a Movie was for some particular characterName. Such properties can be attached to a Role entity, which is then associated with the main entities using ordinary properties like 'member' or 'actor'.<br/><br/>\n\nSee also <a href=\"https://blog.schema.org/2014/06/16/introducing-role/">blog post</a>.",
+      "rdfs:comment": "Represents additional information about a relationship or property. For example a Role can be used to say that a 'member' role linking some SportsTeam to a player occurred during a particular time period. Or that a Person's 'actor' role in a Movie was for some particular characterName. Such properties can be attached to a Role entity, which is then associated with the main entities using ordinary properties like 'member' or 'actor'.<br/><br/>\n\nSee also <a href=\"https://blog.schema.org/2014/06/16/introducing-role\">blog post</a>.",
       "rdfs:label": "Role",
       "rdfs:subClassOf": {
         "@id": "http://schema.org/Intangible"

--- a/data/releases/7.02/all-layers.jsonld
+++ b/data/releases/7.02/all-layers.jsonld
@@ -727,7 +727,7 @@
       "http://purl.org/dc/terms/source": {
         "@id": "http://www.w3.org/wiki/WebSchemas/SchemaDotOrgSources#source_ActionCollabClass"
       },
-      "rdfs:comment": "An action performed by a direct agent and indirect participants upon a direct object. Optionally happens at a location with the help of an inanimate instrument. The execution of the action may produce a result. Specific action sub-type documentation specifies the exact expectation of each argument/role.<br/><br/>\n\nSee also <a href=\"https://blog.schema.org/2014/04/16/announcing-schema-org-actions/">blog post</a> and <a href=\"http://schema.org/docs/actions.html\">Actions overview document</a>.",
+      "rdfs:comment": "An action performed by a direct agent and indirect participants upon a direct object. Optionally happens at a location with the help of an inanimate instrument. The execution of the action may produce a result. Specific action sub-type documentation specifies the exact expectation of each argument/role.<br/><br/>\n\nSee also <a href=\"https://blog.schema.org/2014/04/16/announcing-schema-org-actions\">blog post</a> and <a href=\"http://schema.org/docs/actions.html\">Actions overview document</a>.",
       "rdfs:label": "Action",
       "rdfs:subClassOf": {
         "@id": "http://schema.org/Thing"
@@ -5622,7 +5622,7 @@
       "http://purl.org/dc/terms/source": {
         "@id": "http://www.w3.org/wiki/WebSchemas/SchemaDotOrgSources#source_bibex"
       },
-      "rdfs:comment": "A part of a successively published publication such as a periodical or multi-volume work, often numbered. It may represent a time span, such as a year.<br/><br/>\n\nSee also <a href=\"https://blog.schema.org/2014/09/02/schema-org-support-for-bibliographic-relationships-and-periodicals/">blog post</a>.",
+      "rdfs:comment": "A part of a successively published publication such as a periodical or multi-volume work, often numbered. It may represent a time span, such as a year.<br/><br/>\n\nSee also <a href=\"https://blog.schema.org/2014/09/02/schema-org-support-for-bibliographic-relationships-and-periodicals\">blog post</a>.",
       "rdfs:label": "PublicationVolume",
       "rdfs:subClassOf": {
         "@id": "http://schema.org/CreativeWork"
@@ -8500,7 +8500,7 @@
       "http://www.w3.org/2002/07/owl#equivalentClass": {
         "@id": "http://purl.org/ontology/bibo/Issue"
       },
-      "rdfs:comment": "A part of a successively published publication such as a periodical or publication volume, often numbered, usually containing a grouping of works such as articles.<br/><br/>\n\nSee also <a href=\"https://blog.schema.org/2014/09/02/schema-org-support-for-bibliographic-relationships-and-periodicals/">blog post</a>.",
+      "rdfs:comment": "A part of a successively published publication such as a periodical or publication volume, often numbered, usually containing a grouping of works such as articles.<br/><br/>\n\nSee also <a href=\"https://blog.schema.org/2014/09/02/schema-org-support-for-bibliographic-relationships-and-periodicals\">blog post</a>.",
       "rdfs:label": "PublicationIssue",
       "rdfs:subClassOf": {
         "@id": "http://schema.org/CreativeWork"
@@ -8612,7 +8612,7 @@
       "http://purl.org/dc/terms/source": {
         "@id": "http://www.w3.org/wiki/WebSchemas/SchemaDotOrgSources#source_rNews"
       },
-      "rdfs:comment": "An article, such as a news article or piece of investigative report. Newspapers and magazines have articles of many different types and this is intended to cover them all.<br/><br/>\n\nSee also <a href=\"https://blog.schema.org/2014/09/02/schema-org-support-for-bibliographic-relationships-and-periodicals/">blog post</a>.",
+      "rdfs:comment": "An article, such as a news article or piece of investigative report. Newspapers and magazines have articles of many different types and this is intended to cover them all.<br/><br/>\n\nSee also <a href=\"https://blog.schema.org/2014/09/02/schema-org-support-for-bibliographic-relationships-and-periodicals\">blog post</a>.",
       "rdfs:label": "Article",
       "rdfs:subClassOf": {
         "@id": "http://schema.org/CreativeWork"
@@ -21759,7 +21759,7 @@
       "http://www.w3.org/2002/07/owl#equivalentClass": {
         "@id": "http://purl.org/ontology/bibo/Periodical"
       },
-      "rdfs:comment": "A publication in any medium issued in successive parts bearing numerical or chronological designations and intended, such as a magazine, scholarly journal, or newspaper to continue indefinitely.<br/><br/>\n\nSee also <a href=\"https://blog.schema.org/2014/09/02/schema-org-support-for-bibliographic-relationships-and-periodicals/">blog post</a>.",
+      "rdfs:comment": "A publication in any medium issued in successive parts bearing numerical or chronological designations and intended, such as a magazine, scholarly journal, or newspaper to continue indefinitely.<br/><br/>\n\nSee also <a href=\"https://blog.schema.org/2014/09/02/schema-org-support-for-bibliographic-relationships-and-periodicals\">blog post</a>.",
       "rdfs:label": "Periodical",
       "rdfs:subClassOf": {
         "@id": "http://schema.org/CreativeWorkSeries"
@@ -23939,7 +23939,7 @@
     {
       "@id": "http://schema.org/Role",
       "@type": "rdfs:Class",
-      "rdfs:comment": "Represents additional information about a relationship or property. For example a Role can be used to say that a 'member' role linking some SportsTeam to a player occurred during a particular time period. Or that a Person's 'actor' role in a Movie was for some particular characterName. Such properties can be attached to a Role entity, which is then associated with the main entities using ordinary properties like 'member' or 'actor'.<br/><br/>\n\nSee also <a href=\"https://blog.schema.org/2014/06/16/introducing-role/">blog post</a>.",
+      "rdfs:comment": "Represents additional information about a relationship or property. For example a Role can be used to say that a 'member' role linking some SportsTeam to a player occurred during a particular time period. Or that a Person's 'actor' role in a Movie was for some particular characterName. Such properties can be attached to a Role entity, which is then associated with the main entities using ordinary properties like 'member' or 'actor'.<br/><br/>\n\nSee also <a href=\"https://blog.schema.org/2014/06/16/introducing-role\">blog post</a>.",
       "rdfs:label": "Role",
       "rdfs:subClassOf": {
         "@id": "http://schema.org/Intangible"

--- a/data/releases/7.02/schema.jsonld
+++ b/data/releases/7.02/schema.jsonld
@@ -444,7 +444,7 @@
       "http://purl.org/dc/terms/source": {
         "@id": "http://www.w3.org/wiki/WebSchemas/SchemaDotOrgSources#source_ActionCollabClass"
       },
-      "rdfs:comment": "An action performed by a direct agent and indirect participants upon a direct object. Optionally happens at a location with the help of an inanimate instrument. The execution of the action may produce a result. Specific action sub-type documentation specifies the exact expectation of each argument/role.<br/><br/>\n\nSee also <a href=\"https://blog.schema.org/2014/04/16/announcing-schema-org-actions/">blog post</a> and <a href=\"http://schema.org/docs/actions.html\">Actions overview document</a>.",
+      "rdfs:comment": "An action performed by a direct agent and indirect participants upon a direct object. Optionally happens at a location with the help of an inanimate instrument. The execution of the action may produce a result. Specific action sub-type documentation specifies the exact expectation of each argument/role.<br/><br/>\n\nSee also <a href=\"https://blog.schema.org/2014/04/16/announcing-schema-org-actions\">blog post</a> and <a href=\"http://schema.org/docs/actions.html\">Actions overview document</a>.",
       "rdfs:label": "Action",
       "rdfs:subClassOf": {
         "@id": "http://schema.org/Thing"
@@ -3543,7 +3543,7 @@
       "http://purl.org/dc/terms/source": {
         "@id": "http://www.w3.org/wiki/WebSchemas/SchemaDotOrgSources#source_bibex"
       },
-      "rdfs:comment": "A part of a successively published publication such as a periodical or multi-volume work, often numbered. It may represent a time span, such as a year.<br/><br/>\n\nSee also <a href=\"https://blog.schema.org/2014/09/02/schema-org-support-for-bibliographic-relationships-and-periodicals/">blog post</a>.",
+      "rdfs:comment": "A part of a successively published publication such as a periodical or multi-volume work, often numbered. It may represent a time span, such as a year.<br/><br/>\n\nSee also <a href=\"https://blog.schema.org/2014/09/02/schema-org-support-for-bibliographic-relationships-and-periodicals\">blog post</a>.",
       "rdfs:label": "PublicationVolume",
       "rdfs:subClassOf": {
         "@id": "http://schema.org/CreativeWork"
@@ -5367,7 +5367,7 @@
       "http://www.w3.org/2002/07/owl#equivalentClass": {
         "@id": "http://purl.org/ontology/bibo/Issue"
       },
-      "rdfs:comment": "A part of a successively published publication such as a periodical or publication volume, often numbered, usually containing a grouping of works such as articles.<br/><br/>\n\nSee also <a href=\"https://blog.schema.org/2014/09/02/schema-org-support-for-bibliographic-relationships-and-periodicals/">blog post</a>.",
+      "rdfs:comment": "A part of a successively published publication such as a periodical or publication volume, often numbered, usually containing a grouping of works such as articles.<br/><br/>\n\nSee also <a href=\"https://blog.schema.org/2014/09/02/schema-org-support-for-bibliographic-relationships-and-periodicals\">blog post</a>.",
       "rdfs:label": "PublicationIssue",
       "rdfs:subClassOf": {
         "@id": "http://schema.org/CreativeWork"
@@ -5408,7 +5408,7 @@
       "http://purl.org/dc/terms/source": {
         "@id": "http://www.w3.org/wiki/WebSchemas/SchemaDotOrgSources#source_rNews"
       },
-      "rdfs:comment": "An article, such as a news article or piece of investigative report. Newspapers and magazines have articles of many different types and this is intended to cover them all.<br/><br/>\n\nSee also <a href=\"https://blog.schema.org/2014/09/02/schema-org-support-for-bibliographic-relationships-and-periodicals/">blog post</a>.",
+      "rdfs:comment": "An article, such as a news article or piece of investigative report. Newspapers and magazines have articles of many different types and this is intended to cover them all.<br/><br/>\n\nSee also <a href=\"https://blog.schema.org/2014/09/02/schema-org-support-for-bibliographic-relationships-and-periodicals\">blog post</a>.",
       "rdfs:label": "Article",
       "rdfs:subClassOf": {
         "@id": "http://schema.org/CreativeWork"
@@ -13971,7 +13971,7 @@
       "http://www.w3.org/2002/07/owl#equivalentClass": {
         "@id": "http://purl.org/ontology/bibo/Periodical"
       },
-      "rdfs:comment": "A publication in any medium issued in successive parts bearing numerical or chronological designations and intended, such as a magazine, scholarly journal, or newspaper to continue indefinitely.<br/><br/>\n\nSee also <a href=\"https://blog.schema.org/2014/09/02/schema-org-support-for-bibliographic-relationships-and-periodicals/">blog post</a>.",
+      "rdfs:comment": "A publication in any medium issued in successive parts bearing numerical or chronological designations and intended, such as a magazine, scholarly journal, or newspaper to continue indefinitely.<br/><br/>\n\nSee also <a href=\"https://blog.schema.org/2014/09/02/schema-org-support-for-bibliographic-relationships-and-periodicals\">blog post</a>.",
       "rdfs:label": "Periodical",
       "rdfs:subClassOf": {
         "@id": "http://schema.org/CreativeWorkSeries"
@@ -15318,7 +15318,7 @@
     {
       "@id": "http://schema.org/Role",
       "@type": "rdfs:Class",
-      "rdfs:comment": "Represents additional information about a relationship or property. For example a Role can be used to say that a 'member' role linking some SportsTeam to a player occurred during a particular time period. Or that a Person's 'actor' role in a Movie was for some particular characterName. Such properties can be attached to a Role entity, which is then associated with the main entities using ordinary properties like 'member' or 'actor'.<br/><br/>\n\nSee also <a href=\"https://blog.schema.org/2014/06/16/introducing-role/">blog post</a>.",
+      "rdfs:comment": "Represents additional information about a relationship or property. For example a Role can be used to say that a 'member' role linking some SportsTeam to a player occurred during a particular time period. Or that a Person's 'actor' role in a Movie was for some particular characterName. Such properties can be attached to a Role entity, which is then associated with the main entities using ordinary properties like 'member' or 'actor'.<br/><br/>\n\nSee also <a href=\"https://blog.schema.org/2014/06/16/introducing-role\">blog post</a>.",
       "rdfs:label": "Role",
       "rdfs:subClassOf": {
         "@id": "http://schema.org/Intangible"

--- a/data/releases/7.03/all-layers.jsonld
+++ b/data/releases/7.03/all-layers.jsonld
@@ -749,7 +749,7 @@
       "http://purl.org/dc/terms/source": {
         "@id": "http://www.w3.org/wiki/WebSchemas/SchemaDotOrgSources#source_ActionCollabClass"
       },
-      "rdfs:comment": "An action performed by a direct agent and indirect participants upon a direct object. Optionally happens at a location with the help of an inanimate instrument. The execution of the action may produce a result. Specific action sub-type documentation specifies the exact expectation of each argument/role.<br/><br/>\n\nSee also <a href=\"https://blog.schema.org/2014/04/16/announcing-schema-org-actions/">blog post</a> and <a href=\"http://schema.org/docs/actions.html\">Actions overview document</a>.",
+      "rdfs:comment": "An action performed by a direct agent and indirect participants upon a direct object. Optionally happens at a location with the help of an inanimate instrument. The execution of the action may produce a result. Specific action sub-type documentation specifies the exact expectation of each argument/role.<br/><br/>\n\nSee also <a href=\"https://blog.schema.org/2014/04/16/announcing-schema-org-actions\">blog post</a> and <a href=\"http://schema.org/docs/actions.html\">Actions overview document</a>.",
       "rdfs:label": "Action",
       "rdfs:subClassOf": {
         "@id": "http://schema.org/Thing"
@@ -5600,7 +5600,7 @@
       "http://purl.org/dc/terms/source": {
         "@id": "http://www.w3.org/wiki/WebSchemas/SchemaDotOrgSources#source_bibex"
       },
-      "rdfs:comment": "A part of a successively published publication such as a periodical or multi-volume work, often numbered. It may represent a time span, such as a year.<br/><br/>\n\nSee also <a href=\"https://blog.schema.org/2014/09/02/schema-org-support-for-bibliographic-relationships-and-periodicals/">blog post</a>.",
+      "rdfs:comment": "A part of a successively published publication such as a periodical or multi-volume work, often numbered. It may represent a time span, such as a year.<br/><br/>\n\nSee also <a href=\"https://blog.schema.org/2014/09/02/schema-org-support-for-bibliographic-relationships-and-periodicals\">blog post</a>.",
       "rdfs:label": "PublicationVolume",
       "rdfs:subClassOf": {
         "@id": "http://schema.org/CreativeWork"
@@ -8491,7 +8491,7 @@
       "http://www.w3.org/2002/07/owl#equivalentClass": {
         "@id": "http://purl.org/ontology/bibo/Issue"
       },
-      "rdfs:comment": "A part of a successively published publication such as a periodical or publication volume, often numbered, usually containing a grouping of works such as articles.<br/><br/>\n\nSee also <a href=\"https://blog.schema.org/2014/09/02/schema-org-support-for-bibliographic-relationships-and-periodicals/">blog post</a>.",
+      "rdfs:comment": "A part of a successively published publication such as a periodical or publication volume, often numbered, usually containing a grouping of works such as articles.<br/><br/>\n\nSee also <a href=\"https://blog.schema.org/2014/09/02/schema-org-support-for-bibliographic-relationships-and-periodicals\">blog post</a>.",
       "rdfs:label": "PublicationIssue",
       "rdfs:subClassOf": {
         "@id": "http://schema.org/CreativeWork"
@@ -8603,7 +8603,7 @@
       "http://purl.org/dc/terms/source": {
         "@id": "http://www.w3.org/wiki/WebSchemas/SchemaDotOrgSources#source_rNews"
       },
-      "rdfs:comment": "An article, such as a news article or piece of investigative report. Newspapers and magazines have articles of many different types and this is intended to cover them all.<br/><br/>\n\nSee also <a href=\"https://blog.schema.org/2014/09/02/schema-org-support-for-bibliographic-relationships-and-periodicals/">blog post</a>.",
+      "rdfs:comment": "An article, such as a news article or piece of investigative report. Newspapers and magazines have articles of many different types and this is intended to cover them all.<br/><br/>\n\nSee also <a href=\"https://blog.schema.org/2014/09/02/schema-org-support-for-bibliographic-relationships-and-periodicals\">blog post</a>.",
       "rdfs:label": "Article",
       "rdfs:subClassOf": {
         "@id": "http://schema.org/CreativeWork"
@@ -21805,7 +21805,7 @@
       "http://www.w3.org/2002/07/owl#equivalentClass": {
         "@id": "http://purl.org/ontology/bibo/Periodical"
       },
-      "rdfs:comment": "A publication in any medium issued in successive parts bearing numerical or chronological designations and intended, such as a magazine, scholarly journal, or newspaper to continue indefinitely.<br/><br/>\n\nSee also <a href=\"https://blog.schema.org/2014/09/02/schema-org-support-for-bibliographic-relationships-and-periodicals/">blog post</a>.",
+      "rdfs:comment": "A publication in any medium issued in successive parts bearing numerical or chronological designations and intended, such as a magazine, scholarly journal, or newspaper to continue indefinitely.<br/><br/>\n\nSee also <a href=\"https://blog.schema.org/2014/09/02/schema-org-support-for-bibliographic-relationships-and-periodicals\">blog post</a>.",
       "rdfs:label": "Periodical",
       "rdfs:subClassOf": {
         "@id": "http://schema.org/CreativeWorkSeries"
@@ -24055,7 +24055,7 @@
     {
       "@id": "http://schema.org/Role",
       "@type": "rdfs:Class",
-      "rdfs:comment": "Represents additional information about a relationship or property. For example a Role can be used to say that a 'member' role linking some SportsTeam to a player occurred during a particular time period. Or that a Person's 'actor' role in a Movie was for some particular characterName. Such properties can be attached to a Role entity, which is then associated with the main entities using ordinary properties like 'member' or 'actor'.<br/><br/>\n\nSee also <a href=\"https://blog.schema.org/2014/06/16/introducing-role/">blog post</a>.",
+      "rdfs:comment": "Represents additional information about a relationship or property. For example a Role can be used to say that a 'member' role linking some SportsTeam to a player occurred during a particular time period. Or that a Person's 'actor' role in a Movie was for some particular characterName. Such properties can be attached to a Role entity, which is then associated with the main entities using ordinary properties like 'member' or 'actor'.<br/><br/>\n\nSee also <a href=\"https://blog.schema.org/2014/06/16/introducing-role\">blog post</a>.",
       "rdfs:label": "Role",
       "rdfs:subClassOf": {
         "@id": "http://schema.org/Intangible"

--- a/data/releases/7.03/schema.jsonld
+++ b/data/releases/7.03/schema.jsonld
@@ -449,7 +449,7 @@
       "http://purl.org/dc/terms/source": {
         "@id": "http://www.w3.org/wiki/WebSchemas/SchemaDotOrgSources#source_ActionCollabClass"
       },
-      "rdfs:comment": "An action performed by a direct agent and indirect participants upon a direct object. Optionally happens at a location with the help of an inanimate instrument. The execution of the action may produce a result. Specific action sub-type documentation specifies the exact expectation of each argument/role.<br/><br/>\n\nSee also <a href=\"https://blog.schema.org/2014/04/16/announcing-schema-org-actions/">blog post</a> and <a href=\"http://schema.org/docs/actions.html\">Actions overview document</a>.",
+      "rdfs:comment": "An action performed by a direct agent and indirect participants upon a direct object. Optionally happens at a location with the help of an inanimate instrument. The execution of the action may produce a result. Specific action sub-type documentation specifies the exact expectation of each argument/role.<br/><br/>\n\nSee also <a href=\"https://blog.schema.org/2014/04/16/announcing-schema-org-actions\">blog post</a> and <a href=\"http://schema.org/docs/actions.html\">Actions overview document</a>.",
       "rdfs:label": "Action",
       "rdfs:subClassOf": {
         "@id": "http://schema.org/Thing"
@@ -3587,7 +3587,7 @@
       "http://purl.org/dc/terms/source": {
         "@id": "http://www.w3.org/wiki/WebSchemas/SchemaDotOrgSources#source_bibex"
       },
-      "rdfs:comment": "A part of a successively published publication such as a periodical or multi-volume work, often numbered. It may represent a time span, such as a year.<br/><br/>\n\nSee also <a href=\"https://blog.schema.org/2014/09/02/schema-org-support-for-bibliographic-relationships-and-periodicals/">blog post</a>.",
+      "rdfs:comment": "A part of a successively published publication such as a periodical or multi-volume work, often numbered. It may represent a time span, such as a year.<br/><br/>\n\nSee also <a href=\"https://blog.schema.org/2014/09/02/schema-org-support-for-bibliographic-relationships-and-periodicals\">blog post</a>.",
       "rdfs:label": "PublicationVolume",
       "rdfs:subClassOf": {
         "@id": "http://schema.org/CreativeWork"
@@ -5382,7 +5382,7 @@
       "http://www.w3.org/2002/07/owl#equivalentClass": {
         "@id": "http://purl.org/ontology/bibo/Issue"
       },
-      "rdfs:comment": "A part of a successively published publication such as a periodical or publication volume, often numbered, usually containing a grouping of works such as articles.<br/><br/>\n\nSee also <a href=\"https://blog.schema.org/2014/09/02/schema-org-support-for-bibliographic-relationships-and-periodicals/">blog post</a>.",
+      "rdfs:comment": "A part of a successively published publication such as a periodical or publication volume, often numbered, usually containing a grouping of works such as articles.<br/><br/>\n\nSee also <a href=\"https://blog.schema.org/2014/09/02/schema-org-support-for-bibliographic-relationships-and-periodicals\">blog post</a>.",
       "rdfs:label": "PublicationIssue",
       "rdfs:subClassOf": {
         "@id": "http://schema.org/CreativeWork"
@@ -5423,7 +5423,7 @@
       "http://purl.org/dc/terms/source": {
         "@id": "http://www.w3.org/wiki/WebSchemas/SchemaDotOrgSources#source_rNews"
       },
-      "rdfs:comment": "An article, such as a news article or piece of investigative report. Newspapers and magazines have articles of many different types and this is intended to cover them all.<br/><br/>\n\nSee also <a href=\"https://blog.schema.org/2014/09/02/schema-org-support-for-bibliographic-relationships-and-periodicals/">blog post</a>.",
+      "rdfs:comment": "An article, such as a news article or piece of investigative report. Newspapers and magazines have articles of many different types and this is intended to cover them all.<br/><br/>\n\nSee also <a href=\"https://blog.schema.org/2014/09/02/schema-org-support-for-bibliographic-relationships-and-periodicals\">blog post</a>.",
       "rdfs:label": "Article",
       "rdfs:subClassOf": {
         "@id": "http://schema.org/CreativeWork"
@@ -13882,7 +13882,7 @@
       "http://www.w3.org/2002/07/owl#equivalentClass": {
         "@id": "http://purl.org/ontology/bibo/Periodical"
       },
-      "rdfs:comment": "A publication in any medium issued in successive parts bearing numerical or chronological designations and intended, such as a magazine, scholarly journal, or newspaper to continue indefinitely.<br/><br/>\n\nSee also <a href=\"https://blog.schema.org/2014/09/02/schema-org-support-for-bibliographic-relationships-and-periodicals/">blog post</a>.",
+      "rdfs:comment": "A publication in any medium issued in successive parts bearing numerical or chronological designations and intended, such as a magazine, scholarly journal, or newspaper to continue indefinitely.<br/><br/>\n\nSee also <a href=\"https://blog.schema.org/2014/09/02/schema-org-support-for-bibliographic-relationships-and-periodicals\">blog post</a>.",
       "rdfs:label": "Periodical",
       "rdfs:subClassOf": {
         "@id": "http://schema.org/CreativeWorkSeries"
@@ -15230,7 +15230,7 @@
     {
       "@id": "http://schema.org/Role",
       "@type": "rdfs:Class",
-      "rdfs:comment": "Represents additional information about a relationship or property. For example a Role can be used to say that a 'member' role linking some SportsTeam to a player occurred during a particular time period. Or that a Person's 'actor' role in a Movie was for some particular characterName. Such properties can be attached to a Role entity, which is then associated with the main entities using ordinary properties like 'member' or 'actor'.<br/><br/>\n\nSee also <a href=\"https://blog.schema.org/2014/06/16/introducing-role/">blog post</a>.",
+      "rdfs:comment": "Represents additional information about a relationship or property. For example a Role can be used to say that a 'member' role linking some SportsTeam to a player occurred during a particular time period. Or that a Person's 'actor' role in a Movie was for some particular characterName. Such properties can be attached to a Role entity, which is then associated with the main entities using ordinary properties like 'member' or 'actor'.<br/><br/>\n\nSee also <a href=\"https://blog.schema.org/2014/06/16/introducing-role\">blog post</a>.",
       "rdfs:label": "Role",
       "rdfs:subClassOf": {
         "@id": "http://schema.org/Intangible"

--- a/data/releases/7.04/all-layers.jsonld
+++ b/data/releases/7.04/all-layers.jsonld
@@ -740,7 +740,7 @@
       "http://purl.org/dc/terms/source": {
         "@id": "http://www.w3.org/wiki/WebSchemas/SchemaDotOrgSources#source_ActionCollabClass"
       },
-      "rdfs:comment": "An action performed by a direct agent and indirect participants upon a direct object. Optionally happens at a location with the help of an inanimate instrument. The execution of the action may produce a result. Specific action sub-type documentation specifies the exact expectation of each argument/role.<br/><br/>\n\nSee also <a href=\"https://blog.schema.org/2014/04/16/announcing-schema-org-actions/">blog post</a> and <a href=\"http://schema.org/docs/actions.html\">Actions overview document</a>.",
+      "rdfs:comment": "An action performed by a direct agent and indirect participants upon a direct object. Optionally happens at a location with the help of an inanimate instrument. The execution of the action may produce a result. Specific action sub-type documentation specifies the exact expectation of each argument/role.<br/><br/>\n\nSee also <a href=\"https://blog.schema.org/2014/04/16/announcing-schema-org-actions\">blog post</a> and <a href=\"http://schema.org/docs/actions.html\">Actions overview document</a>.",
       "rdfs:label": "Action",
       "rdfs:subClassOf": {
         "@id": "http://schema.org/Thing"
@@ -5761,7 +5761,7 @@
       "http://purl.org/dc/terms/source": {
         "@id": "http://www.w3.org/wiki/WebSchemas/SchemaDotOrgSources#source_bibex"
       },
-      "rdfs:comment": "A part of a successively published publication such as a periodical or multi-volume work, often numbered. It may represent a time span, such as a year.<br/><br/>\n\nSee also <a href=\"https://blog.schema.org/2014/09/02/schema-org-support-for-bibliographic-relationships-and-periodicals/">blog post</a>.",
+      "rdfs:comment": "A part of a successively published publication such as a periodical or multi-volume work, often numbered. It may represent a time span, such as a year.<br/><br/>\n\nSee also <a href=\"https://blog.schema.org/2014/09/02/schema-org-support-for-bibliographic-relationships-and-periodicals\">blog post</a>.",
       "rdfs:label": "PublicationVolume",
       "rdfs:subClassOf": {
         "@id": "http://schema.org/CreativeWork"
@@ -8631,7 +8631,7 @@
       "http://www.w3.org/2002/07/owl#equivalentClass": {
         "@id": "http://purl.org/ontology/bibo/Issue"
       },
-      "rdfs:comment": "A part of a successively published publication such as a periodical or publication volume, often numbered, usually containing a grouping of works such as articles.<br/><br/>\n\nSee also <a href=\"https://blog.schema.org/2014/09/02/schema-org-support-for-bibliographic-relationships-and-periodicals/">blog post</a>.",
+      "rdfs:comment": "A part of a successively published publication such as a periodical or publication volume, often numbered, usually containing a grouping of works such as articles.<br/><br/>\n\nSee also <a href=\"https://blog.schema.org/2014/09/02/schema-org-support-for-bibliographic-relationships-and-periodicals\">blog post</a>.",
       "rdfs:label": "PublicationIssue",
       "rdfs:subClassOf": {
         "@id": "http://schema.org/CreativeWork"
@@ -8743,7 +8743,7 @@
       "http://purl.org/dc/terms/source": {
         "@id": "http://www.w3.org/wiki/WebSchemas/SchemaDotOrgSources#source_rNews"
       },
-      "rdfs:comment": "An article, such as a news article or piece of investigative report. Newspapers and magazines have articles of many different types and this is intended to cover them all.<br/><br/>\n\nSee also <a href=\"https://blog.schema.org/2014/09/02/schema-org-support-for-bibliographic-relationships-and-periodicals/">blog post</a>.",
+      "rdfs:comment": "An article, such as a news article or piece of investigative report. Newspapers and magazines have articles of many different types and this is intended to cover them all.<br/><br/>\n\nSee also <a href=\"https://blog.schema.org/2014/09/02/schema-org-support-for-bibliographic-relationships-and-periodicals\">blog post</a>.",
       "rdfs:label": "Article",
       "rdfs:subClassOf": {
         "@id": "http://schema.org/CreativeWork"
@@ -22029,7 +22029,7 @@
       "http://www.w3.org/2002/07/owl#equivalentClass": {
         "@id": "http://purl.org/ontology/bibo/Periodical"
       },
-      "rdfs:comment": "A publication in any medium issued in successive parts bearing numerical or chronological designations and intended, such as a magazine, scholarly journal, or newspaper to continue indefinitely.<br/><br/>\n\nSee also <a href=\"https://blog.schema.org/2014/09/02/schema-org-support-for-bibliographic-relationships-and-periodicals/">blog post</a>.",
+      "rdfs:comment": "A publication in any medium issued in successive parts bearing numerical or chronological designations and intended, such as a magazine, scholarly journal, or newspaper to continue indefinitely.<br/><br/>\n\nSee also <a href=\"https://blog.schema.org/2014/09/02/schema-org-support-for-bibliographic-relationships-and-periodicals\">blog post</a>.",
       "rdfs:label": "Periodical",
       "rdfs:subClassOf": {
         "@id": "http://schema.org/CreativeWorkSeries"
@@ -24254,7 +24254,7 @@
     {
       "@id": "http://schema.org/Role",
       "@type": "rdfs:Class",
-      "rdfs:comment": "Represents additional information about a relationship or property. For example a Role can be used to say that a 'member' role linking some SportsTeam to a player occurred during a particular time period. Or that a Person's 'actor' role in a Movie was for some particular characterName. Such properties can be attached to a Role entity, which is then associated with the main entities using ordinary properties like 'member' or 'actor'.<br/><br/>\n\nSee also <a href=\"https://blog.schema.org/2014/06/16/introducing-role/">blog post</a>.",
+      "rdfs:comment": "Represents additional information about a relationship or property. For example a Role can be used to say that a 'member' role linking some SportsTeam to a player occurred during a particular time period. Or that a Person's 'actor' role in a Movie was for some particular characterName. Such properties can be attached to a Role entity, which is then associated with the main entities using ordinary properties like 'member' or 'actor'.<br/><br/>\n\nSee also <a href=\"https://blog.schema.org/2014/06/16/introducing-role\">blog post</a>.",
       "rdfs:label": "Role",
       "rdfs:subClassOf": {
         "@id": "http://schema.org/Intangible"

--- a/data/releases/7.04/schema.jsonld
+++ b/data/releases/7.04/schema.jsonld
@@ -435,7 +435,7 @@
       "http://purl.org/dc/terms/source": {
         "@id": "http://www.w3.org/wiki/WebSchemas/SchemaDotOrgSources#source_ActionCollabClass"
       },
-      "rdfs:comment": "An action performed by a direct agent and indirect participants upon a direct object. Optionally happens at a location with the help of an inanimate instrument. The execution of the action may produce a result. Specific action sub-type documentation specifies the exact expectation of each argument/role.<br/><br/>\n\nSee also <a href=\"https://blog.schema.org/2014/04/16/announcing-schema-org-actions/">blog post</a> and <a href=\"http://schema.org/docs/actions.html\">Actions overview document</a>.",
+      "rdfs:comment": "An action performed by a direct agent and indirect participants upon a direct object. Optionally happens at a location with the help of an inanimate instrument. The execution of the action may produce a result. Specific action sub-type documentation specifies the exact expectation of each argument/role.<br/><br/>\n\nSee also <a href=\"https://blog.schema.org/2014/04/16/announcing-schema-org-actions\">blog post</a> and <a href=\"http://schema.org/docs/actions.html\">Actions overview document</a>.",
       "rdfs:label": "Action",
       "rdfs:subClassOf": {
         "@id": "http://schema.org/Thing"
@@ -3596,7 +3596,7 @@
       "http://purl.org/dc/terms/source": {
         "@id": "http://www.w3.org/wiki/WebSchemas/SchemaDotOrgSources#source_bibex"
       },
-      "rdfs:comment": "A part of a successively published publication such as a periodical or multi-volume work, often numbered. It may represent a time span, such as a year.<br/><br/>\n\nSee also <a href=\"https://blog.schema.org/2014/09/02/schema-org-support-for-bibliographic-relationships-and-periodicals/">blog post</a>.",
+      "rdfs:comment": "A part of a successively published publication such as a periodical or multi-volume work, often numbered. It may represent a time span, such as a year.<br/><br/>\n\nSee also <a href=\"https://blog.schema.org/2014/09/02/schema-org-support-for-bibliographic-relationships-and-periodicals\">blog post</a>.",
       "rdfs:label": "PublicationVolume",
       "rdfs:subClassOf": {
         "@id": "http://schema.org/CreativeWork"
@@ -5404,7 +5404,7 @@
       "http://www.w3.org/2002/07/owl#equivalentClass": {
         "@id": "http://purl.org/ontology/bibo/Issue"
       },
-      "rdfs:comment": "A part of a successively published publication such as a periodical or publication volume, often numbered, usually containing a grouping of works such as articles.<br/><br/>\n\nSee also <a href=\"https://blog.schema.org/2014/09/02/schema-org-support-for-bibliographic-relationships-and-periodicals/">blog post</a>.",
+      "rdfs:comment": "A part of a successively published publication such as a periodical or publication volume, often numbered, usually containing a grouping of works such as articles.<br/><br/>\n\nSee also <a href=\"https://blog.schema.org/2014/09/02/schema-org-support-for-bibliographic-relationships-and-periodicals\">blog post</a>.",
       "rdfs:label": "PublicationIssue",
       "rdfs:subClassOf": {
         "@id": "http://schema.org/CreativeWork"
@@ -5445,7 +5445,7 @@
       "http://purl.org/dc/terms/source": {
         "@id": "http://www.w3.org/wiki/WebSchemas/SchemaDotOrgSources#source_rNews"
       },
-      "rdfs:comment": "An article, such as a news article or piece of investigative report. Newspapers and magazines have articles of many different types and this is intended to cover them all.<br/><br/>\n\nSee also <a href=\"https://blog.schema.org/2014/09/02/schema-org-support-for-bibliographic-relationships-and-periodicals/">blog post</a>.",
+      "rdfs:comment": "An article, such as a news article or piece of investigative report. Newspapers and magazines have articles of many different types and this is intended to cover them all.<br/><br/>\n\nSee also <a href=\"https://blog.schema.org/2014/09/02/schema-org-support-for-bibliographic-relationships-and-periodicals\">blog post</a>.",
       "rdfs:label": "Article",
       "rdfs:subClassOf": {
         "@id": "http://schema.org/CreativeWork"
@@ -13948,7 +13948,7 @@
       "http://www.w3.org/2002/07/owl#equivalentClass": {
         "@id": "http://purl.org/ontology/bibo/Periodical"
       },
-      "rdfs:comment": "A publication in any medium issued in successive parts bearing numerical or chronological designations and intended, such as a magazine, scholarly journal, or newspaper to continue indefinitely.<br/><br/>\n\nSee also <a href=\"https://blog.schema.org/2014/09/02/schema-org-support-for-bibliographic-relationships-and-periodicals/">blog post</a>.",
+      "rdfs:comment": "A publication in any medium issued in successive parts bearing numerical or chronological designations and intended, such as a magazine, scholarly journal, or newspaper to continue indefinitely.<br/><br/>\n\nSee also <a href=\"https://blog.schema.org/2014/09/02/schema-org-support-for-bibliographic-relationships-and-periodicals\">blog post</a>.",
       "rdfs:label": "Periodical",
       "rdfs:subClassOf": {
         "@id": "http://schema.org/CreativeWorkSeries"
@@ -15313,7 +15313,7 @@
     {
       "@id": "http://schema.org/Role",
       "@type": "rdfs:Class",
-      "rdfs:comment": "Represents additional information about a relationship or property. For example a Role can be used to say that a 'member' role linking some SportsTeam to a player occurred during a particular time period. Or that a Person's 'actor' role in a Movie was for some particular characterName. Such properties can be attached to a Role entity, which is then associated with the main entities using ordinary properties like 'member' or 'actor'.<br/><br/>\n\nSee also <a href=\"https://blog.schema.org/2014/06/16/introducing-role/">blog post</a>.",
+      "rdfs:comment": "Represents additional information about a relationship or property. For example a Role can be used to say that a 'member' role linking some SportsTeam to a player occurred during a particular time period. Or that a Person's 'actor' role in a Movie was for some particular characterName. Such properties can be attached to a Role entity, which is then associated with the main entities using ordinary properties like 'member' or 'actor'.<br/><br/>\n\nSee also <a href=\"https://blog.schema.org/2014/06/16/introducing-role\">blog post</a>.",
       "rdfs:label": "Role",
       "rdfs:subClassOf": {
         "@id": "http://schema.org/Intangible"

--- a/data/releases/8.0/all-layers.jsonld
+++ b/data/releases/8.0/all-layers.jsonld
@@ -727,7 +727,7 @@
       "http://purl.org/dc/terms/source": {
         "@id": "http://www.w3.org/wiki/WebSchemas/SchemaDotOrgSources#source_ActionCollabClass"
       },
-      "rdfs:comment": "An action performed by a direct agent and indirect participants upon a direct object. Optionally happens at a location with the help of an inanimate instrument. The execution of the action may produce a result. Specific action sub-type documentation specifies the exact expectation of each argument/role.<br/><br/>\n\nSee also <a href=\"https://blog.schema.org/2014/04/16/announcing-schema-org-actions/">blog post</a> and <a href=\"http://schema.org/docs/actions.html\">Actions overview document</a>.",
+      "rdfs:comment": "An action performed by a direct agent and indirect participants upon a direct object. Optionally happens at a location with the help of an inanimate instrument. The execution of the action may produce a result. Specific action sub-type documentation specifies the exact expectation of each argument/role.<br/><br/>\n\nSee also <a href=\"https://blog.schema.org/2014/04/16/announcing-schema-org-actions\">blog post</a> and <a href=\"http://schema.org/docs/actions.html\">Actions overview document</a>.",
       "rdfs:label": "Action",
       "rdfs:subClassOf": {
         "@id": "http://schema.org/Thing"
@@ -6021,7 +6021,7 @@
       "http://purl.org/dc/terms/source": {
         "@id": "http://www.w3.org/wiki/WebSchemas/SchemaDotOrgSources#source_bibex"
       },
-      "rdfs:comment": "A part of a successively published publication such as a periodical or multi-volume work, often numbered. It may represent a time span, such as a year.<br/><br/>\n\nSee also <a href=\"https://blog.schema.org/2014/09/02/schema-org-support-for-bibliographic-relationships-and-periodicals/">blog post</a>.",
+      "rdfs:comment": "A part of a successively published publication such as a periodical or multi-volume work, often numbered. It may represent a time span, such as a year.<br/><br/>\n\nSee also <a href=\"https://blog.schema.org/2014/09/02/schema-org-support-for-bibliographic-relationships-and-periodicals\">blog post</a>.",
       "rdfs:label": "PublicationVolume",
       "rdfs:subClassOf": {
         "@id": "http://schema.org/CreativeWork"
@@ -9073,7 +9073,7 @@
       "http://www.w3.org/2002/07/owl#equivalentClass": {
         "@id": "http://purl.org/ontology/bibo/Issue"
       },
-      "rdfs:comment": "A part of a successively published publication such as a periodical or publication volume, often numbered, usually containing a grouping of works such as articles.<br/><br/>\n\nSee also <a href=\"https://blog.schema.org/2014/09/02/schema-org-support-for-bibliographic-relationships-and-periodicals/">blog post</a>.",
+      "rdfs:comment": "A part of a successively published publication such as a periodical or publication volume, often numbered, usually containing a grouping of works such as articles.<br/><br/>\n\nSee also <a href=\"https://blog.schema.org/2014/09/02/schema-org-support-for-bibliographic-relationships-and-periodicals\">blog post</a>.",
       "rdfs:label": "PublicationIssue",
       "rdfs:subClassOf": {
         "@id": "http://schema.org/CreativeWork"
@@ -9185,7 +9185,7 @@
       "http://purl.org/dc/terms/source": {
         "@id": "http://www.w3.org/wiki/WebSchemas/SchemaDotOrgSources#source_rNews"
       },
-      "rdfs:comment": "An article, such as a news article or piece of investigative report. Newspapers and magazines have articles of many different types and this is intended to cover them all.<br/><br/>\n\nSee also <a href=\"https://blog.schema.org/2014/09/02/schema-org-support-for-bibliographic-relationships-and-periodicals/">blog post</a>.",
+      "rdfs:comment": "An article, such as a news article or piece of investigative report. Newspapers and magazines have articles of many different types and this is intended to cover them all.<br/><br/>\n\nSee also <a href=\"https://blog.schema.org/2014/09/02/schema-org-support-for-bibliographic-relationships-and-periodicals\">blog post</a>.",
       "rdfs:label": "Article",
       "rdfs:subClassOf": {
         "@id": "http://schema.org/CreativeWork"
@@ -22914,7 +22914,7 @@
       "http://www.w3.org/2002/07/owl#equivalentClass": {
         "@id": "http://purl.org/ontology/bibo/Periodical"
       },
-      "rdfs:comment": "A publication in any medium issued in successive parts bearing numerical or chronological designations and intended, such as a magazine, scholarly journal, or newspaper to continue indefinitely.<br/><br/>\n\nSee also <a href=\"https://blog.schema.org/2014/09/02/schema-org-support-for-bibliographic-relationships-and-periodicals/">blog post</a>.",
+      "rdfs:comment": "A publication in any medium issued in successive parts bearing numerical or chronological designations and intended, such as a magazine, scholarly journal, or newspaper to continue indefinitely.<br/><br/>\n\nSee also <a href=\"https://blog.schema.org/2014/09/02/schema-org-support-for-bibliographic-relationships-and-periodicals\">blog post</a>.",
       "rdfs:label": "Periodical",
       "rdfs:subClassOf": {
         "@id": "http://schema.org/CreativeWorkSeries"
@@ -25267,7 +25267,7 @@
     {
       "@id": "http://schema.org/Role",
       "@type": "rdfs:Class",
-      "rdfs:comment": "Represents additional information about a relationship or property. For example a Role can be used to say that a 'member' role linking some SportsTeam to a player occurred during a particular time period. Or that a Person's 'actor' role in a Movie was for some particular characterName. Such properties can be attached to a Role entity, which is then associated with the main entities using ordinary properties like 'member' or 'actor'.<br/><br/>\n\nSee also <a href=\"https://blog.schema.org/2014/06/16/introducing-role/">blog post</a>.",
+      "rdfs:comment": "Represents additional information about a relationship or property. For example a Role can be used to say that a 'member' role linking some SportsTeam to a player occurred during a particular time period. Or that a Person's 'actor' role in a Movie was for some particular characterName. Such properties can be attached to a Role entity, which is then associated with the main entities using ordinary properties like 'member' or 'actor'.<br/><br/>\n\nSee also <a href=\"https://blog.schema.org/2014/06/16/introducing-role\">blog post</a>.",
       "rdfs:label": "Role",
       "rdfs:subClassOf": {
         "@id": "http://schema.org/Intangible"

--- a/data/releases/8.0/schema.jsonld
+++ b/data/releases/8.0/schema.jsonld
@@ -447,7 +447,7 @@
       "http://purl.org/dc/terms/source": {
         "@id": "http://www.w3.org/wiki/WebSchemas/SchemaDotOrgSources#source_ActionCollabClass"
       },
-      "rdfs:comment": "An action performed by a direct agent and indirect participants upon a direct object. Optionally happens at a location with the help of an inanimate instrument. The execution of the action may produce a result. Specific action sub-type documentation specifies the exact expectation of each argument/role.<br/><br/>\n\nSee also <a href=\"https://blog.schema.org/2014/04/16/announcing-schema-org-actions/">blog post</a> and <a href=\"http://schema.org/docs/actions.html\">Actions overview document</a>.",
+      "rdfs:comment": "An action performed by a direct agent and indirect participants upon a direct object. Optionally happens at a location with the help of an inanimate instrument. The execution of the action may produce a result. Specific action sub-type documentation specifies the exact expectation of each argument/role.<br/><br/>\n\nSee also <a href=\"https://blog.schema.org/2014/04/16/announcing-schema-org-actions\">blog post</a> and <a href=\"http://schema.org/docs/actions.html\">Actions overview document</a>.",
       "rdfs:label": "Action",
       "rdfs:subClassOf": {
         "@id": "http://schema.org/Thing"
@@ -3526,7 +3526,7 @@
       "http://purl.org/dc/terms/source": {
         "@id": "http://www.w3.org/wiki/WebSchemas/SchemaDotOrgSources#source_bibex"
       },
-      "rdfs:comment": "A part of a successively published publication such as a periodical or multi-volume work, often numbered. It may represent a time span, such as a year.<br/><br/>\n\nSee also <a href=\"https://blog.schema.org/2014/09/02/schema-org-support-for-bibliographic-relationships-and-periodicals/">blog post</a>.",
+      "rdfs:comment": "A part of a successively published publication such as a periodical or multi-volume work, often numbered. It may represent a time span, such as a year.<br/><br/>\n\nSee also <a href=\"https://blog.schema.org/2014/09/02/schema-org-support-for-bibliographic-relationships-and-periodicals\">blog post</a>.",
       "rdfs:label": "PublicationVolume",
       "rdfs:subClassOf": {
         "@id": "http://schema.org/CreativeWork"
@@ -5363,7 +5363,7 @@
       "http://www.w3.org/2002/07/owl#equivalentClass": {
         "@id": "http://purl.org/ontology/bibo/Issue"
       },
-      "rdfs:comment": "A part of a successively published publication such as a periodical or publication volume, often numbered, usually containing a grouping of works such as articles.<br/><br/>\n\nSee also <a href=\"https://blog.schema.org/2014/09/02/schema-org-support-for-bibliographic-relationships-and-periodicals/">blog post</a>.",
+      "rdfs:comment": "A part of a successively published publication such as a periodical or publication volume, often numbered, usually containing a grouping of works such as articles.<br/><br/>\n\nSee also <a href=\"https://blog.schema.org/2014/09/02/schema-org-support-for-bibliographic-relationships-and-periodicals\">blog post</a>.",
       "rdfs:label": "PublicationIssue",
       "rdfs:subClassOf": {
         "@id": "http://schema.org/CreativeWork"
@@ -5404,7 +5404,7 @@
       "http://purl.org/dc/terms/source": {
         "@id": "http://www.w3.org/wiki/WebSchemas/SchemaDotOrgSources#source_rNews"
       },
-      "rdfs:comment": "An article, such as a news article or piece of investigative report. Newspapers and magazines have articles of many different types and this is intended to cover them all.<br/><br/>\n\nSee also <a href=\"https://blog.schema.org/2014/09/02/schema-org-support-for-bibliographic-relationships-and-periodicals/">blog post</a>.",
+      "rdfs:comment": "An article, such as a news article or piece of investigative report. Newspapers and magazines have articles of many different types and this is intended to cover them all.<br/><br/>\n\nSee also <a href=\"https://blog.schema.org/2014/09/02/schema-org-support-for-bibliographic-relationships-and-periodicals\">blog post</a>.",
       "rdfs:label": "Article",
       "rdfs:subClassOf": {
         "@id": "http://schema.org/CreativeWork"
@@ -13965,7 +13965,7 @@
       "http://www.w3.org/2002/07/owl#equivalentClass": {
         "@id": "http://purl.org/ontology/bibo/Periodical"
       },
-      "rdfs:comment": "A publication in any medium issued in successive parts bearing numerical or chronological designations and intended, such as a magazine, scholarly journal, or newspaper to continue indefinitely.<br/><br/>\n\nSee also <a href=\"https://blog.schema.org/2014/09/02/schema-org-support-for-bibliographic-relationships-and-periodicals/">blog post</a>.",
+      "rdfs:comment": "A publication in any medium issued in successive parts bearing numerical or chronological designations and intended, such as a magazine, scholarly journal, or newspaper to continue indefinitely.<br/><br/>\n\nSee also <a href=\"https://blog.schema.org/2014/09/02/schema-org-support-for-bibliographic-relationships-and-periodicals\">blog post</a>.",
       "rdfs:label": "Periodical",
       "rdfs:subClassOf": {
         "@id": "http://schema.org/CreativeWorkSeries"
@@ -15327,7 +15327,7 @@
     {
       "@id": "http://schema.org/Role",
       "@type": "rdfs:Class",
-      "rdfs:comment": "Represents additional information about a relationship or property. For example a Role can be used to say that a 'member' role linking some SportsTeam to a player occurred during a particular time period. Or that a Person's 'actor' role in a Movie was for some particular characterName. Such properties can be attached to a Role entity, which is then associated with the main entities using ordinary properties like 'member' or 'actor'.<br/><br/>\n\nSee also <a href=\"https://blog.schema.org/2014/06/16/introducing-role/">blog post</a>.",
+      "rdfs:comment": "Represents additional information about a relationship or property. For example a Role can be used to say that a 'member' role linking some SportsTeam to a player occurred during a particular time period. Or that a Person's 'actor' role in a Movie was for some particular characterName. Such properties can be attached to a Role entity, which is then associated with the main entities using ordinary properties like 'member' or 'actor'.<br/><br/>\n\nSee also <a href=\"https://blog.schema.org/2014/06/16/introducing-role\">blog post</a>.",
       "rdfs:label": "Role",
       "rdfs:subClassOf": {
         "@id": "http://schema.org/Intangible"

--- a/data/releases/9.0/schemaorg-all-http.jsonld
+++ b/data/releases/9.0/schemaorg-all-http.jsonld
@@ -10909,7 +10909,7 @@
       "http://schema.org/source": {
         "@id": "http://www.w3.org/wiki/WebSchemas/SchemaDotOrgSources#source_ActionCollabClass"
       },
-      "rdfs:comment": "An action performed by a direct agent and indirect participants upon a direct object. Optionally happens at a location with the help of an inanimate instrument. The execution of the action may produce a result. Specific action sub-type documentation specifies the exact expectation of each argument/role.<br/><br/>\n\nSee also <a href=\"https://blog.schema.org/2014/04/16/announcing-schema-org-actions/">blog post</a> and <a href=\"http://schema.org/docs/actions.html\">Actions overview document</a>.",
+      "rdfs:comment": "An action performed by a direct agent and indirect participants upon a direct object. Optionally happens at a location with the help of an inanimate instrument. The execution of the action may produce a result. Specific action sub-type documentation specifies the exact expectation of each argument/role.<br/><br/>\n\nSee also <a href=\"https://blog.schema.org/2014/04/16/announcing-schema-org-actions\">blog post</a> and <a href=\"http://schema.org/docs/actions.html\">Actions overview document</a>.",
       "rdfs:label": "Action",
       "rdfs:subClassOf": {
         "@id": "http://schema.org/Thing"
@@ -18222,7 +18222,7 @@
       "http://schema.org/source": {
         "@id": "http://www.w3.org/wiki/WebSchemas/SchemaDotOrgSources#source_bibex"
       },
-      "rdfs:comment": "A part of a successively published publication such as a periodical or multi-volume work, often numbered. It may represent a time span, such as a year.<br/><br/>\n\nSee also <a href=\"https://blog.schema.org/2014/09/02/schema-org-support-for-bibliographic-relationships-and-periodicals/">blog post</a>.",
+      "rdfs:comment": "A part of a successively published publication such as a periodical or multi-volume work, often numbered. It may represent a time span, such as a year.<br/><br/>\n\nSee also <a href=\"https://blog.schema.org/2014/09/02/schema-org-support-for-bibliographic-relationships-and-periodicals\">blog post</a>.",
       "rdfs:label": "PublicationVolume",
       "rdfs:subClassOf": {
         "@id": "http://schema.org/CreativeWork"
@@ -19047,7 +19047,7 @@
       "http://www.w3.org/2002/07/owl#equivalentClass": {
         "@id": "http://purl.org/ontology/bibo/Issue"
       },
-      "rdfs:comment": "A part of a successively published publication such as a periodical or publication volume, often numbered, usually containing a grouping of works such as articles.<br/><br/>\n\nSee also <a href=\"https://blog.schema.org/2014/09/02/schema-org-support-for-bibliographic-relationships-and-periodicals/">blog post</a>.",
+      "rdfs:comment": "A part of a successively published publication such as a periodical or publication volume, often numbered, usually containing a grouping of works such as articles.<br/><br/>\n\nSee also <a href=\"https://blog.schema.org/2014/09/02/schema-org-support-for-bibliographic-relationships-and-periodicals\">blog post</a>.",
       "rdfs:label": "PublicationIssue",
       "rdfs:subClassOf": {
         "@id": "http://schema.org/CreativeWork"
@@ -19460,7 +19460,7 @@
       "http://schema.org/source": {
         "@id": "http://www.w3.org/wiki/WebSchemas/SchemaDotOrgSources#source_rNews"
       },
-      "rdfs:comment": "An article, such as a news article or piece of investigative report. Newspapers and magazines have articles of many different types and this is intended to cover them all.<br/><br/>\n\nSee also <a href=\"https://blog.schema.org/2014/09/02/schema-org-support-for-bibliographic-relationships-and-periodicals/">blog post</a>.",
+      "rdfs:comment": "An article, such as a news article or piece of investigative report. Newspapers and magazines have articles of many different types and this is intended to cover them all.<br/><br/>\n\nSee also <a href=\"https://blog.schema.org/2014/09/02/schema-org-support-for-bibliographic-relationships-and-periodicals\">blog post</a>.",
       "rdfs:label": "Article",
       "rdfs:subClassOf": {
         "@id": "http://schema.org/CreativeWork"
@@ -33096,7 +33096,7 @@
       "http://www.w3.org/2002/07/owl#equivalentClass": {
         "@id": "http://purl.org/ontology/bibo/Periodical"
       },
-      "rdfs:comment": "A publication in any medium issued in successive parts bearing numerical or chronological designations and intended, such as a magazine, scholarly journal, or newspaper to continue indefinitely.<br/><br/>\n\nSee also <a href=\"https://blog.schema.org/2014/09/02/schema-org-support-for-bibliographic-relationships-and-periodicals/">blog post</a>.",
+      "rdfs:comment": "A publication in any medium issued in successive parts bearing numerical or chronological designations and intended, such as a magazine, scholarly journal, or newspaper to continue indefinitely.<br/><br/>\n\nSee also <a href=\"https://blog.schema.org/2014/09/02/schema-org-support-for-bibliographic-relationships-and-periodicals\">blog post</a>.",
       "rdfs:label": "Periodical",
       "rdfs:subClassOf": {
         "@id": "http://schema.org/CreativeWorkSeries"
@@ -34927,7 +34927,7 @@
     {
       "@id": "http://schema.org/Role",
       "@type": "rdfs:Class",
-      "rdfs:comment": "Represents additional information about a relationship or property. For example a Role can be used to say that a 'member' role linking some SportsTeam to a player occurred during a particular time period. Or that a Person's 'actor' role in a Movie was for some particular characterName. Such properties can be attached to a Role entity, which is then associated with the main entities using ordinary properties like 'member' or 'actor'.<br/><br/>\n\nSee also <a href=\"https://blog.schema.org/2014/06/16/introducing-role/">blog post</a>.",
+      "rdfs:comment": "Represents additional information about a relationship or property. For example a Role can be used to say that a 'member' role linking some SportsTeam to a player occurred during a particular time period. Or that a Person's 'actor' role in a Movie was for some particular characterName. Such properties can be attached to a Role entity, which is then associated with the main entities using ordinary properties like 'member' or 'actor'.<br/><br/>\n\nSee also <a href=\"https://blog.schema.org/2014/06/16/introducing-role\">blog post</a>.",
       "rdfs:label": "Role",
       "rdfs:subClassOf": {
         "@id": "http://schema.org/Intangible"

--- a/data/releases/9.0/schemaorg-all-https.jsonld
+++ b/data/releases/9.0/schemaorg-all-https.jsonld
@@ -10909,7 +10909,7 @@
       "https://schema.org/source": {
         "@id": "http://www.w3.org/wiki/WebSchemas/SchemaDotOrgSources#source_ActionCollabClass"
       },
-      "rdfs:comment": "An action performed by a direct agent and indirect participants upon a direct object. Optionally happens at a location with the help of an inanimate instrument. The execution of the action may produce a result. Specific action sub-type documentation specifies the exact expectation of each argument/role.<br/><br/>\n\nSee also <a href=\"https://blog.schema.org/2014/04/16/announcing-schema-org-actions/">blog post</a> and <a href=\"https://schema.org/docs/actions.html\">Actions overview document</a>.",
+      "rdfs:comment": "An action performed by a direct agent and indirect participants upon a direct object. Optionally happens at a location with the help of an inanimate instrument. The execution of the action may produce a result. Specific action sub-type documentation specifies the exact expectation of each argument/role.<br/><br/>\n\nSee also <a href=\"https://blog.schema.org/2014/04/16/announcing-schema-org-actions\">blog post</a> and <a href=\"https://schema.org/docs/actions.html\">Actions overview document</a>.",
       "rdfs:label": "Action",
       "rdfs:subClassOf": {
         "@id": "https://schema.org/Thing"
@@ -18222,7 +18222,7 @@
       "https://schema.org/source": {
         "@id": "http://www.w3.org/wiki/WebSchemas/SchemaDotOrgSources#source_bibex"
       },
-      "rdfs:comment": "A part of a successively published publication such as a periodical or multi-volume work, often numbered. It may represent a time span, such as a year.<br/><br/>\n\nSee also <a href=\"https://blog.schema.org/2014/09/02/schema-org-support-for-bibliographic-relationships-and-periodicals/">blog post</a>.",
+      "rdfs:comment": "A part of a successively published publication such as a periodical or multi-volume work, often numbered. It may represent a time span, such as a year.<br/><br/>\n\nSee also <a href=\"https://blog.schema.org/2014/09/02/schema-org-support-for-bibliographic-relationships-and-periodicals\">blog post</a>.",
       "rdfs:label": "PublicationVolume",
       "rdfs:subClassOf": {
         "@id": "https://schema.org/CreativeWork"
@@ -19047,7 +19047,7 @@
       "http://www.w3.org/2002/07/owl#equivalentClass": {
         "@id": "http://purl.org/ontology/bibo/Issue"
       },
-      "rdfs:comment": "A part of a successively published publication such as a periodical or publication volume, often numbered, usually containing a grouping of works such as articles.<br/><br/>\n\nSee also <a href=\"https://blog.schema.org/2014/09/02/schema-org-support-for-bibliographic-relationships-and-periodicals/">blog post</a>.",
+      "rdfs:comment": "A part of a successively published publication such as a periodical or publication volume, often numbered, usually containing a grouping of works such as articles.<br/><br/>\n\nSee also <a href=\"https://blog.schema.org/2014/09/02/schema-org-support-for-bibliographic-relationships-and-periodicals\">blog post</a>.",
       "rdfs:label": "PublicationIssue",
       "rdfs:subClassOf": {
         "@id": "https://schema.org/CreativeWork"
@@ -19460,7 +19460,7 @@
       "https://schema.org/source": {
         "@id": "http://www.w3.org/wiki/WebSchemas/SchemaDotOrgSources#source_rNews"
       },
-      "rdfs:comment": "An article, such as a news article or piece of investigative report. Newspapers and magazines have articles of many different types and this is intended to cover them all.<br/><br/>\n\nSee also <a href=\"https://blog.schema.org/2014/09/02/schema-org-support-for-bibliographic-relationships-and-periodicals/">blog post</a>.",
+      "rdfs:comment": "An article, such as a news article or piece of investigative report. Newspapers and magazines have articles of many different types and this is intended to cover them all.<br/><br/>\n\nSee also <a href=\"https://blog.schema.org/2014/09/02/schema-org-support-for-bibliographic-relationships-and-periodicals\">blog post</a>.",
       "rdfs:label": "Article",
       "rdfs:subClassOf": {
         "@id": "https://schema.org/CreativeWork"
@@ -33096,7 +33096,7 @@
       "http://www.w3.org/2002/07/owl#equivalentClass": {
         "@id": "http://purl.org/ontology/bibo/Periodical"
       },
-      "rdfs:comment": "A publication in any medium issued in successive parts bearing numerical or chronological designations and intended, such as a magazine, scholarly journal, or newspaper to continue indefinitely.<br/><br/>\n\nSee also <a href=\"https://blog.schema.org/2014/09/02/schema-org-support-for-bibliographic-relationships-and-periodicals/">blog post</a>.",
+      "rdfs:comment": "A publication in any medium issued in successive parts bearing numerical or chronological designations and intended, such as a magazine, scholarly journal, or newspaper to continue indefinitely.<br/><br/>\n\nSee also <a href=\"https://blog.schema.org/2014/09/02/schema-org-support-for-bibliographic-relationships-and-periodicals\">blog post</a>.",
       "rdfs:label": "Periodical",
       "rdfs:subClassOf": {
         "@id": "https://schema.org/CreativeWorkSeries"
@@ -34927,7 +34927,7 @@
     {
       "@id": "https://schema.org/Role",
       "@type": "rdfs:Class",
-      "rdfs:comment": "Represents additional information about a relationship or property. For example a Role can be used to say that a 'member' role linking some SportsTeam to a player occurred during a particular time period. Or that a Person's 'actor' role in a Movie was for some particular characterName. Such properties can be attached to a Role entity, which is then associated with the main entities using ordinary properties like 'member' or 'actor'.<br/><br/>\n\nSee also <a href=\"https://blog.schema.org/2014/06/16/introducing-role/">blog post</a>.",
+      "rdfs:comment": "Represents additional information about a relationship or property. For example a Role can be used to say that a 'member' role linking some SportsTeam to a player occurred during a particular time period. Or that a Person's 'actor' role in a Movie was for some particular characterName. Such properties can be attached to a Role entity, which is then associated with the main entities using ordinary properties like 'member' or 'actor'.<br/><br/>\n\nSee also <a href=\"https://blog.schema.org/2014/06/16/introducing-role\">blog post</a>.",
       "rdfs:label": "Role",
       "rdfs:subClassOf": {
         "@id": "https://schema.org/Intangible"

--- a/data/releases/9.0/schemaorg-current-http.jsonld
+++ b/data/releases/9.0/schemaorg-current-http.jsonld
@@ -10725,7 +10725,7 @@
       "http://schema.org/source": {
         "@id": "http://www.w3.org/wiki/WebSchemas/SchemaDotOrgSources#source_ActionCollabClass"
       },
-      "rdfs:comment": "An action performed by a direct agent and indirect participants upon a direct object. Optionally happens at a location with the help of an inanimate instrument. The execution of the action may produce a result. Specific action sub-type documentation specifies the exact expectation of each argument/role.<br/><br/>\n\nSee also <a href=\"https://blog.schema.org/2014/04/16/announcing-schema-org-actions/">blog post</a> and <a href=\"http://schema.org/docs/actions.html\">Actions overview document</a>.",
+      "rdfs:comment": "An action performed by a direct agent and indirect participants upon a direct object. Optionally happens at a location with the help of an inanimate instrument. The execution of the action may produce a result. Specific action sub-type documentation specifies the exact expectation of each argument/role.<br/><br/>\n\nSee also <a href=\"https://blog.schema.org/2014/04/16/announcing-schema-org-actions\">blog post</a> and <a href=\"http://schema.org/docs/actions.html\">Actions overview document</a>.",
       "rdfs:label": "Action",
       "rdfs:subClassOf": {
         "@id": "http://schema.org/Thing"
@@ -15975,7 +15975,7 @@
       "http://schema.org/source": {
         "@id": "http://www.w3.org/wiki/WebSchemas/SchemaDotOrgSources#source_bibex"
       },
-      "rdfs:comment": "A part of a successively published publication such as a periodical or multi-volume work, often numbered. It may represent a time span, such as a year.<br/><br/>\n\nSee also <a href=\"https://blog.schema.org/2014/09/02/schema-org-support-for-bibliographic-relationships-and-periodicals/">blog post</a>.",
+      "rdfs:comment": "A part of a successively published publication such as a periodical or multi-volume work, often numbered. It may represent a time span, such as a year.<br/><br/>\n\nSee also <a href=\"https://blog.schema.org/2014/09/02/schema-org-support-for-bibliographic-relationships-and-periodicals\">blog post</a>.",
       "rdfs:label": "PublicationVolume",
       "rdfs:subClassOf": {
         "@id": "http://schema.org/CreativeWork"
@@ -19012,7 +19012,7 @@
       "http://www.w3.org/2002/07/owl#equivalentClass": {
         "@id": "http://purl.org/ontology/bibo/Issue"
       },
-      "rdfs:comment": "A part of a successively published publication such as a periodical or publication volume, often numbered, usually containing a grouping of works such as articles.<br/><br/>\n\nSee also <a href=\"https://blog.schema.org/2014/09/02/schema-org-support-for-bibliographic-relationships-and-periodicals/">blog post</a>.",
+      "rdfs:comment": "A part of a successively published publication such as a periodical or publication volume, often numbered, usually containing a grouping of works such as articles.<br/><br/>\n\nSee also <a href=\"https://blog.schema.org/2014/09/02/schema-org-support-for-bibliographic-relationships-and-periodicals\">blog post</a>.",
       "rdfs:label": "PublicationIssue",
       "rdfs:subClassOf": {
         "@id": "http://schema.org/CreativeWork"
@@ -19413,7 +19413,7 @@
       "http://schema.org/source": {
         "@id": "http://www.w3.org/wiki/WebSchemas/SchemaDotOrgSources#source_rNews"
       },
-      "rdfs:comment": "An article, such as a news article or piece of investigative report. Newspapers and magazines have articles of many different types and this is intended to cover them all.<br/><br/>\n\nSee also <a href=\"https://blog.schema.org/2014/09/02/schema-org-support-for-bibliographic-relationships-and-periodicals/">blog post</a>.",
+      "rdfs:comment": "An article, such as a news article or piece of investigative report. Newspapers and magazines have articles of many different types and this is intended to cover them all.<br/><br/>\n\nSee also <a href=\"https://blog.schema.org/2014/09/02/schema-org-support-for-bibliographic-relationships-and-periodicals\">blog post</a>.",
       "rdfs:label": "Article",
       "rdfs:subClassOf": {
         "@id": "http://schema.org/CreativeWork"
@@ -32955,7 +32955,7 @@
       "http://www.w3.org/2002/07/owl#equivalentClass": {
         "@id": "http://purl.org/ontology/bibo/Periodical"
       },
-      "rdfs:comment": "A publication in any medium issued in successive parts bearing numerical or chronological designations and intended, such as a magazine, scholarly journal, or newspaper to continue indefinitely.<br/><br/>\n\nSee also <a href=\"https://blog.schema.org/2014/09/02/schema-org-support-for-bibliographic-relationships-and-periodicals/">blog post</a>.",
+      "rdfs:comment": "A publication in any medium issued in successive parts bearing numerical or chronological designations and intended, such as a magazine, scholarly journal, or newspaper to continue indefinitely.<br/><br/>\n\nSee also <a href=\"https://blog.schema.org/2014/09/02/schema-org-support-for-bibliographic-relationships-and-periodicals\">blog post</a>.",
       "rdfs:label": "Periodical",
       "rdfs:subClassOf": {
         "@id": "http://schema.org/CreativeWorkSeries"
@@ -34681,7 +34681,7 @@
     {
       "@id": "http://schema.org/Role",
       "@type": "rdfs:Class",
-      "rdfs:comment": "Represents additional information about a relationship or property. For example a Role can be used to say that a 'member' role linking some SportsTeam to a player occurred during a particular time period. Or that a Person's 'actor' role in a Movie was for some particular characterName. Such properties can be attached to a Role entity, which is then associated with the main entities using ordinary properties like 'member' or 'actor'.<br/><br/>\n\nSee also <a href=\"https://blog.schema.org/2014/06/16/introducing-role/">blog post</a>.",
+      "rdfs:comment": "Represents additional information about a relationship or property. For example a Role can be used to say that a 'member' role linking some SportsTeam to a player occurred during a particular time period. Or that a Person's 'actor' role in a Movie was for some particular characterName. Such properties can be attached to a Role entity, which is then associated with the main entities using ordinary properties like 'member' or 'actor'.<br/><br/>\n\nSee also <a href=\"https://blog.schema.org/2014/06/16/introducing-role\">blog post</a>.",
       "rdfs:label": "Role",
       "rdfs:subClassOf": {
         "@id": "http://schema.org/Intangible"

--- a/data/releases/9.0/schemaorg-current-https.jsonld
+++ b/data/releases/9.0/schemaorg-current-https.jsonld
@@ -10725,7 +10725,7 @@
       "https://schema.org/source": {
         "@id": "http://www.w3.org/wiki/WebSchemas/SchemaDotOrgSources#source_ActionCollabClass"
       },
-      "rdfs:comment": "An action performed by a direct agent and indirect participants upon a direct object. Optionally happens at a location with the help of an inanimate instrument. The execution of the action may produce a result. Specific action sub-type documentation specifies the exact expectation of each argument/role.<br/><br/>\n\nSee also <a href=\"https://blog.schema.org/2014/04/16/announcing-schema-org-actions/">blog post</a> and <a href=\"https://schema.org/docs/actions.html\">Actions overview document</a>.",
+      "rdfs:comment": "An action performed by a direct agent and indirect participants upon a direct object. Optionally happens at a location with the help of an inanimate instrument. The execution of the action may produce a result. Specific action sub-type documentation specifies the exact expectation of each argument/role.<br/><br/>\n\nSee also <a href=\"https://blog.schema.org/2014/04/16/announcing-schema-org-actions\">blog post</a> and <a href=\"https://schema.org/docs/actions.html\">Actions overview document</a>.",
       "rdfs:label": "Action",
       "rdfs:subClassOf": {
         "@id": "https://schema.org/Thing"
@@ -15975,7 +15975,7 @@
       "https://schema.org/source": {
         "@id": "http://www.w3.org/wiki/WebSchemas/SchemaDotOrgSources#source_bibex"
       },
-      "rdfs:comment": "A part of a successively published publication such as a periodical or multi-volume work, often numbered. It may represent a time span, such as a year.<br/><br/>\n\nSee also <a href=\"https://blog.schema.org/2014/09/02/schema-org-support-for-bibliographic-relationships-and-periodicals/">blog post</a>.",
+      "rdfs:comment": "A part of a successively published publication such as a periodical or multi-volume work, often numbered. It may represent a time span, such as a year.<br/><br/>\n\nSee also <a href=\"https://blog.schema.org/2014/09/02/schema-org-support-for-bibliographic-relationships-and-periodicals\">blog post</a>.",
       "rdfs:label": "PublicationVolume",
       "rdfs:subClassOf": {
         "@id": "https://schema.org/CreativeWork"
@@ -19012,7 +19012,7 @@
       "http://www.w3.org/2002/07/owl#equivalentClass": {
         "@id": "http://purl.org/ontology/bibo/Issue"
       },
-      "rdfs:comment": "A part of a successively published publication such as a periodical or publication volume, often numbered, usually containing a grouping of works such as articles.<br/><br/>\n\nSee also <a href=\"https://blog.schema.org/2014/09/02/schema-org-support-for-bibliographic-relationships-and-periodicals/">blog post</a>.",
+      "rdfs:comment": "A part of a successively published publication such as a periodical or publication volume, often numbered, usually containing a grouping of works such as articles.<br/><br/>\n\nSee also <a href=\"https://blog.schema.org/2014/09/02/schema-org-support-for-bibliographic-relationships-and-periodicals\">blog post</a>.",
       "rdfs:label": "PublicationIssue",
       "rdfs:subClassOf": {
         "@id": "https://schema.org/CreativeWork"
@@ -19413,7 +19413,7 @@
       "https://schema.org/source": {
         "@id": "http://www.w3.org/wiki/WebSchemas/SchemaDotOrgSources#source_rNews"
       },
-      "rdfs:comment": "An article, such as a news article or piece of investigative report. Newspapers and magazines have articles of many different types and this is intended to cover them all.<br/><br/>\n\nSee also <a href=\"https://blog.schema.org/2014/09/02/schema-org-support-for-bibliographic-relationships-and-periodicals/">blog post</a>.",
+      "rdfs:comment": "An article, such as a news article or piece of investigative report. Newspapers and magazines have articles of many different types and this is intended to cover them all.<br/><br/>\n\nSee also <a href=\"https://blog.schema.org/2014/09/02/schema-org-support-for-bibliographic-relationships-and-periodicals\">blog post</a>.",
       "rdfs:label": "Article",
       "rdfs:subClassOf": {
         "@id": "https://schema.org/CreativeWork"
@@ -32955,7 +32955,7 @@
       "http://www.w3.org/2002/07/owl#equivalentClass": {
         "@id": "http://purl.org/ontology/bibo/Periodical"
       },
-      "rdfs:comment": "A publication in any medium issued in successive parts bearing numerical or chronological designations and intended, such as a magazine, scholarly journal, or newspaper to continue indefinitely.<br/><br/>\n\nSee also <a href=\"https://blog.schema.org/2014/09/02/schema-org-support-for-bibliographic-relationships-and-periodicals/">blog post</a>.",
+      "rdfs:comment": "A publication in any medium issued in successive parts bearing numerical or chronological designations and intended, such as a magazine, scholarly journal, or newspaper to continue indefinitely.<br/><br/>\n\nSee also <a href=\"https://blog.schema.org/2014/09/02/schema-org-support-for-bibliographic-relationships-and-periodicals\">blog post</a>.",
       "rdfs:label": "Periodical",
       "rdfs:subClassOf": {
         "@id": "https://schema.org/CreativeWorkSeries"
@@ -34681,7 +34681,7 @@
     {
       "@id": "https://schema.org/Role",
       "@type": "rdfs:Class",
-      "rdfs:comment": "Represents additional information about a relationship or property. For example a Role can be used to say that a 'member' role linking some SportsTeam to a player occurred during a particular time period. Or that a Person's 'actor' role in a Movie was for some particular characterName. Such properties can be attached to a Role entity, which is then associated with the main entities using ordinary properties like 'member' or 'actor'.<br/><br/>\n\nSee also <a href=\"https://blog.schema.org/2014/06/16/introducing-role/">blog post</a>.",
+      "rdfs:comment": "Represents additional information about a relationship or property. For example a Role can be used to say that a 'member' role linking some SportsTeam to a player occurred during a particular time period. Or that a Person's 'actor' role in a Movie was for some particular characterName. Such properties can be attached to a Role entity, which is then associated with the main entities using ordinary properties like 'member' or 'actor'.<br/><br/>\n\nSee also <a href=\"https://blog.schema.org/2014/06/16/introducing-role\">blog post</a>.",
       "rdfs:label": "Role",
       "rdfs:subClassOf": {
         "@id": "https://schema.org/Intangible"


### PR DESCRIPTION
These URLs were 'fixed' and now points to something that exists, but the jsonld became invalid in the process.

Fixed all instances of 

`...for-bibliographic-relationships-and-periodicals/">` 
`...introducing-role/">`
`...announcing-schema-org-actions/">`

missing the quote escape, mentioned in #4497 

```bash
cd data/releases
rg "/\">" -g '*.jsonld' --count-matches | sort
10.0/schemaorg-all-http.jsonld:6
10.0/schemaorg-all-https.jsonld:6
10.0/schemaorg-current-http.jsonld:6
10.0/schemaorg-current-https.jsonld:6
3.1/all-layers.jsonld:6
3.1/schema.jsonld:6
3.2/all-layers.jsonld:6
3.2/schema.jsonld:6
3.3/all-layers.jsonld:6
3.3/schema.jsonld:6
3.4/all-layers.jsonld:6
3.4/schema.jsonld:6
3.5/all-layers.jsonld:5
3.5/schema.jsonld:5
3.6/all-layers.jsonld:5
3.6/schema.jsonld:5
3.7/all-layers.jsonld:6
3.7/schema.jsonld:6
3.8/all-layers.jsonld:6
3.8/schema.jsonld:6
3.9/all-layers.jsonld:6
3.9/schema.jsonld:6
4.0/all-layers.jsonld:6
4.0/schema.jsonld:6
5.0/all-layers.jsonld:6
5.0/schema.jsonld:6
6.0/all-layers.jsonld:6
6.0/schema.jsonld:6
7.01/all-layers.jsonld:6
7.01/schema.jsonld:6
7.02/all-layers.jsonld:6
7.02/schema.jsonld:6
7.03/all-layers.jsonld:6
7.03/schema.jsonld:6
7.04/all-layers.jsonld:6
7.04/schema.jsonld:6
7.0/all-layers.jsonld:6
7.0/schema.jsonld:6
8.0/all-layers.jsonld:6
8.0/schema.jsonld:6
9.0/schemaorg-all-http.jsonld:6
9.0/schemaorg-all-https.jsonld:6
9.0/schemaorg-current-http.jsonld:6
9.0/schemaorg-current-https.jsonld:6
```

Closes #4497 
