### PR TITLE
Deprecate GrapicNovel in BookFormatType and add a seperate LiteraryForm wich includes this.

### DIFF
--- a/data/ext/bib/bsdo-1.0.ttl
+++ b/data/ext/bib/bsdo-1.0.ttl
@@ -93,7 +93,7 @@
 
 :GraphicNovel a :BookFormatType ;
     rdfs:label "GraphicNovel" ;
-    rdfs:comment "This type is deprecated: GraphicNovel does not fit the BookFormatType enumeration, as it can appear in multiple formats (e.g., Hardcover, eBook). It is not mutually exclusive and therefore deprecated. Use standard BookFormatType values instead.\n\nBook format: GraphicNovel. May represent a bound collection of ComicIssue instances." ;
+    rdfs:comment "This type is deprecated: GraphicNovel does not fit the BookFormatType enumeration, as it can appear in multiple formats (e.g., Hardcover, eBook). It is not mutually exclusive and therefore deprecated. Use standard BookFormatType values instead in combination with the SequentialArt.\n\nBook format: GraphicNovel. May represent a bound collection of ComicIssue instances." ;
     :isPartOf <https://bib.schema.org> .
 
 :abridged a rdf:Property ;


### PR DESCRIPTION
This is a proposal in regards to #3697. Feel free to comment and edit ;)

---

Just removing (depricating) the GrapicNovel seems not to be a good idea, since someone created it because he needed it.
So instead there is now a subtype of Book, ComicBook.

This pull request has 3 changes:

- The GrapicNovel in BookFormatType was depricated. (In comment, I havn't seen any actually syntax to depricate stuff)
- A new subclass of book that is ComicBook.
- Extend Genre Attribute 

---

I have yet to check if it builds, since I currently have no python enviroment…

