### PR TITLE
Added structured value to range of reviewAspect

### DIFF
--- a/data/schema.ttl
+++ b/data/schema.ttl
@@ -8529,7 +8529,7 @@ While such policies are most typically expressed in natural language, sometimes 
     rdfs:comment "This Review or Rating is relevant to this part or facet of the itemReviewed." ;
     :domainIncludes :Rating,
         :Review ;
-    :rangeIncludes :Text ;
+    :rangeIncludes :Text, :StructuredValue;
     :source <https://github.com/schemaorg/schemaorg/issues/1689> .
 
 :reviewBody a rdf:Property ;


### PR DESCRIPTION
See [bug 4533](https://github.com/schemaorg/schemaorg/issues/4533), this allows [reviewAspect](https://schema.org/reviewAspect) to contain both text and [StructuredValue](https://schema.org/StructuredValue). 

Given the fact this has been present in example for years, we can consider this is de-facto accepted. 
