### PR TITLE
formatting and lint fixes

### DIFF
--- a/software/util/buildfiles.py
+++ b/software/util/buildfiles.py
@@ -28,7 +28,6 @@ import software.util.textutils as textutils
 import software.SchemaTerms.sdotermsource as sdotermsource
 import software.SchemaTerms.sdoterm as sdoterm
 import software.SchemaExamples.schemaexamples as schemaexamples
-import software.SchemaTerms.localmarkdown as localmarkdown
 
 VOCABURI = sdotermsource.SdoTermSource.vocabUri()
 
@@ -206,16 +205,6 @@ def exportrdf(exportType):
         allGraph.update(deloddtriples)
         currentGraph += allGraph
 
-        desuperseded = """PREFIX schema: <%s://schema.org/>
-        DELETE {?s ?p ?o}
-        WHERE{
-            ?s ?p ?o;
-                schema:supersededBy ?sup.
-        }""" % (protocol)
-        # Currently superseded terms are not suppressed from 'current' file dumps
-        # Whereas they are suppressed from the UI
-        # currentGraph.update(desuperseded)
-
         delattic = """PREFIX schema: <%s://schema.org/>
         DELETE {?s ?p ?o}
         WHERE{
@@ -225,7 +214,7 @@ def exportrdf(exportType):
         currentGraph.update(delattic)
 
     formats = ["json-ld", "turtle", "nt", "nquads", "rdf"]
-    extype = exportType[len("RDFExport.") :]
+    extype = exportType[len("RDFExport."):]
     if exportType == "RDFExports":
         for output_format in sorted(formats):
             _exportrdf(output_format, allGraph, currentGraph)
@@ -235,18 +224,18 @@ def exportrdf(exportType):
         raise Exception("Unknown export format: %s" % exportType)
 
 
-completed = []
+# Set of completed EDF exports.
+completed_rdf_exports = set()
 
 
 def _exportrdf(output_format, all, current):
-    global completed
 
     protocol, altprotocol = protocols()
 
-    if output_format in completed:
+    if output_format in completed_rdf_exports:
         return
     else:
-        completed.append(output_format)
+        completed_rdf_exports.add(output_format)
 
     version = schemaversion.getVersion()
 
@@ -308,11 +297,10 @@ def uriwrap(thing):
         return uriwrap(thing.id)
     if isinstance(thing, sdoterm.SdoTerm):
         return uriwrap(thing.id)
-        pars = map()
     try:
         return array2str(map(uriwrap, thing))
     except TypeError as e:
-        log.fatal("Cannot uriwrap %s", thing)
+        log.fatal("Cannot uriwrap %s:%s", thing, e)
 
 
 def exportcsv(page):

--- a/software/util/buildocspages.py
+++ b/software/util/buildocspages.py
@@ -3,29 +3,26 @@
 
 # Import standard python libraries
 
-import sys
-import os
+import json
 import logging
+import os
+import sys
 
 # Import schema.org libraries
 if not os.getcwd() in sys.path:
     sys.path.insert(1, os.getcwd())
 
-import software
 import software.scripts.buildtermlist as buildtermlist
 import software.util.fileutils as fileutils
 import software.util.jinga_render as jinga_render
+import software.util.pretty_logger as pretty_logger
 import software.util.schemaglobals as schemaglobals
 import software.util.schemaversion as schemaversion
 import software.util.textutils as textutils
-import software.scripts.buildtermlist as buildtermlist
-import software.util.pretty_logger as pretty_logger
 
 import software.SchemaTerms.sdotermsource as sdotermsource
 import software.SchemaTerms.sdocollaborators as sdocollaborators
 import software.SchemaTerms.sdoterm as sdoterm
-import software.SchemaExamples.schemaexamples as schemaexamples
-
 
 log = logging.getLogger(__name__)
 
@@ -144,7 +141,7 @@ class listingNode:
     def __init__(self, term, depth=0, title="", parent=None):
         global VISITLIST
         termdesc = sdotermsource.SdoTermSource.getTerm(term)
-        if parent == None:
+        if parent is None:
             VISITLIST = []
         self.repeat = False
         self.subs = []
@@ -155,7 +152,7 @@ class listingNode:
         self.depth = depth
         self.retired = termdesc.retired
         self.pending = termdesc.pending
-        if not self.id in VISITLIST:
+        if self.id not in VISITLIST:
             VISITLIST.append(self.id)
             if termdesc.termType == sdoterm.SdoTermType.ENUMERATION:
                 for enum in sorted(termdesc.enumerationMembers.ids):
@@ -165,10 +162,6 @@ class listingNode:
 
         else:  # Visited this node before so don't parse children
             self.repeat = True
-        # log.info("%s %s %s"%("  "*depth,term,len(self.subs)))
-
-
-import json
 
 
 def jsonldtree(page):
@@ -330,7 +323,7 @@ def buildDocs(pages):
         pages = sorted(PAGELIST.keys())
 
     for page in pages:
-        if not page in PAGELIST.keys():
+        if page not in PAGELIST.keys():
             log.warning(f"Unknown page name: {page}")
             continue
         func, filenames = PAGELIST.get(page, None)

--- a/software/util/buildsite.py
+++ b/software/util/buildsite.py
@@ -28,7 +28,6 @@ import software.util.fileutils as fileutils
 import software.util.runtests as runtests_lib
 import software.util.schemaglobals as schemaglobals
 import software.util.schemaversion as schemaversion
-import software.util.textutils as textutils
 import software.util.pretty_logger as pretty_logger
 
 import software.SchemaExamples.schemaexamples as schemaexamples
@@ -129,7 +128,7 @@ def initialize():
     args = parser.parse_args()
 
     for op in args.buildoption:
-        schemaglobals - BUILDOPTS.extend(op)
+        schemaglobals.BUILDOPTS.extend(op)
 
     for ter in args.terms:
         schemaglobals.TERMS.extend(ter)
@@ -242,7 +241,7 @@ def loadTerms():
     LOADEDTERMS = True
     if not sdotermsource.SdoTermSource.SOURCEGRAPH:
         with pretty_logger.BlockLog(logger=log, message="Loading triples files"):
-            graph = sdotermsource.SdoTermSource.loadSourceGraph("default")
+            sdotermsource.SdoTermSource.loadSourceGraph("default")
 
         with pretty_logger.BlockLog(logger=log, message="Loading contributors"):
             sdocollaborators.collaborator.loadContributors()

--- a/software/util/pretty_logger.py
+++ b/software/util/pretty_logger.py
@@ -21,7 +21,7 @@ class PrettyLogFormatter(logging.Formatter):
 
     def __init__(self, use_color=True, shard=None):
         fmt = "%(levelname)s %(name)s: %(message)s"
-        if not shard is None:
+        if shard is not None:
             fmt = "%(levelname)s (" + str(shard) + ") %(name)s: %(message)s"
         logging.Formatter.__init__(self, fmt=fmt)
         self.use_color = use_color

--- a/software/util/reorg.py
+++ b/software/util/reorg.py
@@ -6,7 +6,6 @@ This helps reformatting, merging and splitting ttl files along
 semantic axis.
 """
 
-from collections.abc import Sequence
 import argparse
 import itertools
 import logging
@@ -23,10 +22,13 @@ import software.util.schema_graph as graph
 
 def Lint(args):
     """Reformats the file(s) properly."""
+
     def LintOne(filename, output_filename, format):
         logging.info(" - reading file ...")
         g = graph.SchemaOrgGraph(filename, format=format)
-        logging.info(f" - writing back {output_filename if output_filename != filename else ''} ...")
+        logging.info(
+            f" - writing back {output_filename if output_filename != filename else ''} ..."
+        )
         g.serialize(output_filename, format=format)
         if not g.IdenticalTo(graph.SchemaOrgGraph(output_filename, format=format)):
             logging.fatal(f"Linting file {filename} lost some information.")
@@ -61,7 +63,9 @@ def Annotate(args):
 
     valid_parts = ["pending", "attic", "meta", "GA"]
     if args.ispartof not in valid_parts:
-        logging.fatal(f"PartOf annotation '{args.ispartof}' is not valid: select one of {valid_parts}")
+        logging.fatal(
+            f"PartOf annotation '{args.ispartof}' is not valid: select one of {valid_parts}"
+        )
     new_part = rdflib.URIRef(f"https://{args.ispartof}.schema.org/")
 
     for filename in args.files:
@@ -77,6 +81,7 @@ def Annotate(args):
         g.serialize(args.output or filename, format="turtle")
         logging.info(f" ... done, written to {args.output or filename}")
 
+
 def main():
     """
     Parses command line arguments and dispatches to the appropriate
@@ -87,29 +92,29 @@ def main():
     parser = argparse.ArgumentParser(description="Re-organize Turtle files")
     subparsers = parser.add_subparsers(dest="command")
 
-    lint_parser = subparsers.add_parser("lint",
-                                        help="Reformat files (aka linting)")
-    lint_parser.add_argument("-o", "--output",
-                             help="Output file (default: overwrites)")
+    lint_parser = subparsers.add_parser("lint", help="Reformat files (aka linting)")
+    lint_parser.add_argument("-o", "--output", help="Output file (default: overwrites)")
     lint_parser.add_argument("files", action="extend", nargs="+", type=str)
 
     merge_parser = subparsers.add_parser("merge", help="Merging several files")
     merge_parser.add_argument("-o", "--output", help="Output file")
     merge_parser.add_argument("files", action="extend", nargs="+", type=str)
 
-    annotate_parser = subparsers.add_parser("annotate",
-                                            help="Add annotations to types and properties.")
+    annotate_parser = subparsers.add_parser(
+        "annotate", help="Add annotations to types and properties."
+    )
     annotate_parser.add_argument("-o", "--output", help="Output file")
     annotate_parser.add_argument(
         "--ispartof",
-        help="Which state classes and properties are in schema.org (eg. pending, attic)")
+        help="Which state classes and properties are in schema.org (eg. pending, attic)",
+    )
     annotate_parser.add_argument("files", action="extend", nargs="+", type=str)
 
     # Parse and dispatch
     args = parser.parse_args()
     if args.command == "lint":
         Lint(args)
-    elif args.command == 'merge':
+    elif args.command == "merge":
         MergeFiles(args)
     elif args.command == "annotate":
         Annotate(args)
@@ -118,4 +123,4 @@ def main():
 
 
 if __name__ == "__main__":
-  main()
+    main()

--- a/software/util/runtests.py
+++ b/software/util/runtests.py
@@ -51,12 +51,10 @@
 #    limitations under the License.
 
 import argparse
-import optparse
 import sys
 import colorama
 import os
 import unittest
-import io
 
 SITEDIR = "software/site"
 STANDALONE = False

--- a/software/util/schema_graph.py
+++ b/software/util/schema_graph.py
@@ -4,12 +4,7 @@
 """A class that holds the schema graph and presents some operations on it.
 """
 
-from collections.abc import Sequence
 import rdflib
-import argparse
-import itertools
-import logging
-import sys
 
 import software.util.schemaglobals as schemaglobals
 
@@ -28,7 +23,7 @@ class SchemaOrgGraph(object):
             self.g.parse(filename, format=format)
 
     def __getattr__(self, *args, **kwargs):
-        return getattr(self.g, *args, **kwargs);
+        return getattr(self.g, *args, **kwargs)
 
     def IdenticalTo(self, other: "SchemaOrgGraph"):
         only_in_other = other.g - self.g

--- a/software/util/schemaglobals.py
+++ b/software/util/schemaglobals.py
@@ -1,6 +1,8 @@
 #!/usr/bin/env python3
 # -*- coding: utf-8 -*-
 
+import os
+
 """Common place for all globals to avoid circular dependencies."""
 
 SITENAME = "Schema.org"

--- a/software/util/schemaversion.py
+++ b/software/util/schemaversion.py
@@ -3,8 +3,6 @@
 
 """Module that handles the schema.org version information."""
 
-import sys
-import os
 import json
 
 ###################################################


### PR DESCRIPTION
Fixed formatting and lint errors in `software/util/` directory.

* Formatting: black version 25.9.0
* Lint: flake8 version 7.3.0 (mccabe: 0.7.0, pycodestyle: 2.14.0, pyflakes: 3.4.0)

The main changes are removal from unused packages and some dead code.
