### PR TITLE
Fixed more example validation failures

### DIFF
--- a/data/ext/health-lifesci/med-health-core.ttl
+++ b/data/ext/health-lifesci/med-health-core.ttl
@@ -1355,9 +1355,18 @@
     :isPartOf <https://health-lifesci.schema.org> ;
     :rangeIncludes :Text .
 
+:cause a rdf:Property ;
+    rdfs:label "cause" ;
+    rdfs:comment "The cause of a medical condition." ;
+    :inverseOf :causeOf ;
+    :domainIncludes :MedicalCondition ;
+    :isPartOf <https://health-lifesci.schema.org> ;
+    :rangeIncludes :MedicalCause .
+
 :causeOf a rdf:Property ;
     rdfs:label "causeOf" ;
     rdfs:comment "The condition, complication, symptom, sign, etc. caused." ;
+    :inverseOf :cause ;
     :domainIncludes :MedicalCause ;
     :isPartOf <https://health-lifesci.schema.org> ;
     :rangeIncludes :MedicalEntity .
@@ -1919,7 +1928,7 @@
     :domainIncludes :MedicalCondition,
         :MedicalSignOrSymptom ;
     :isPartOf <https://health-lifesci.schema.org> ;
-    :rangeIncludes :MedicalTherapy .
+    :rangeIncludes :MedicalTherapy, :Drug, :DrugClass, :LifestyleModification .
 
 :postOp a rdf:Property ;
     rdfs:label "postOp" ;
@@ -2118,7 +2127,7 @@
     rdfs:comment "A preventative therapy used to prevent reoccurrence of the medical condition after an initial episode of the condition." ;
     :domainIncludes :MedicalCondition ;
     :isPartOf <https://health-lifesci.schema.org> ;
-    :rangeIncludes :MedicalTherapy .
+    :rangeIncludes :MedicalTherapy, :Drug, :DrugClass, :LifestyleModification .
 
 :sensoryUnit a rdf:Property ;
     rdfs:label "sensoryUnit" ;

--- a/data/ext/health-lifesci/medicalWebpage-examples.txt
+++ b/data/ext/health-lifesci/medicalWebpage-examples.txt
@@ -32,17 +32,16 @@ MICRODATA:
   including
   <span itemscope itemtype="https://schema.org/DrugClass">
     <span itemprop="name">beta-blocker</span> drugs such as
-    <span itemprop="about" itemscope itemtype="https://schema.org/Drug">
+    <span itemprop="drug" itemscope itemtype="https://schema.org/Drug">
       <span itemprop="nonProprietaryName">propanaolol</span>
       (<span itemprop="alternateName">Innopran</span>)
     </span>
-  </span>
   and
-    <span itemprop="about" itemscope itemtype="https://schema.org/Drug">
+    <span itemprop="drug" itemscope itemtype="https://schema.org/Drug">
       <span itemprop="nonProprietaryName">atenolol</span>
       (<span itemprop="alternateName">Tenormin</span>)
     </span> ...
-  ...
+  </span>
 </body>
 
 RDFA:
@@ -69,13 +68,13 @@ RDFA:
       <span property="nonProprietaryName">propanaolol</span>
       (<span property="alternateName">Innopran</span>)
     </span>
-  </span>
   and
     <span property="drug"  typeof="Drug">
       <span property="nonProprietaryName">atenolol</span>
       (<span property="alternateName">Tenormin</span>)
     </span> ...
   ...
+  </span>
 </body>
 
 JSON:

--- a/data/ext/pending/issue-1062-examples.txt
+++ b/data/ext/pending/issue-1062-examples.txt
@@ -21,16 +21,15 @@ JSON:
     {
         "@context": "http://health-lifesci.schema.org/",
         "@type": "HealthInsurancePlan",
-        "usesHealthPlanIdType": "http://healthplan.schema.org/HealthPlanIdTypeHIOS",
         "healthPlanId": "12345XX9876543",
         "name": "Sample Gold Health Plan",
-        "summaryUrl": "http://url/to/summary/benefits/coverage",
-        "marketingUrl": "http://url/to/health/plan/information",
+        "benefitsSummaryUrl": "http://url/to/summary/benefits/coverage",
+        "healthPlanMarketingUrl": "http://url/to/health/plan/information",
         "contactPoint": {
             "@type": "ContactPoint",
             "email": "email@address.com"
         },
-        "healthPlanNetworkTiers": ["http://healthplan.schema.org/PreferredNetwork",
+        "healthPlanDrugTier": ["http://healthplan.schema.org/PreferredNetwork",
                                   "http://healthplan.schema.org/NonPreferredNetwork"],
         "includesHealthPlanFormulary": [
             {
@@ -40,11 +39,11 @@ JSON:
                 "healthPlanCostSharing": [
                     {
                         "@type": "HealthPlanCostSharingSpecification",
-                        "healthPlanPharmacyType": "1-MONTH-IN-RETAIL",
+                        "healthPlanPharmacyCategory": "1-MONTH-IN-RETAIL",
                         "healthPlanCopay": {
                             "@type": "PriceSpecification",
                             "price": 20,
-                            "currency": "USD"
+                            "priceCurrency": "USD"
                         },
                         "healthPlanCopayOption": "http://healthplan.schema.org/HealthPlanCopayAfterDeductable",
                         "healthPlanCoinsuranceRate": 0.1,
@@ -52,27 +51,29 @@ JSON:
                     },
                     {
                        "@type": "HealthPlanCostSharingSpecification",
-                        "healthPlanPharmacyType": "1-MONTH-IN-MAIL",
+                        "healthPlanPharmacyCategory": "1-MONTH-IN-MAIL",
                          "healthPlanCopay": {
                             "@type": "PriceSpecification",
                             "price": 0,
-                            "currency": "USD"
+                            "priceCurrency": "USD"
                         },
                         "healthPlanCopayOption": "http://healthplan.schema.org/HealthPlanCoPayNoCharge",
                         "healthPlanCoinsuranceRate": 0.2,
                         "healthPlanCoinsuranceOption": "http://healthplan.schema.org/HealthPlanCoinsuranceNone"
                     }
-                ],
+                ]
+              }, {
+                "@type": "HealthPlanFormulary",
                 "healthPlanDrugTier": "http://healthplan.schema.org/DrugTierBrand",
                 "offersPrescriptionByMail": true,
                 "healthPlanCostSharing": [
                     {
                        "@type": "HealthPlanCostSharingSpecification",
-                        "healthPlanPharmacyType": "1-MONTH-IN-RETAIL",
+                        "healthPlanPharmacyCategory": "1-MONTH-IN-RETAIL",
                         "healthPlanCopay": {
                             "@type": "PriceSpecification",
                             "price": 15,
-                            "currency": "USD"
+                            "priceCurrency": "USD"
                         },
                         "healthPlanCopayOption": "http://healthplan.schema.org/HealthPlanCopayNone",
                         "healthPlanCoinsuranceRate": 0,
@@ -80,11 +81,11 @@ JSON:
                     },
                     {
                        "@type": "HealthPlanCostSharingSpecification",
-                        "healthPlanPharmacyType": "1-MONTH-IN-MAIL",
+                        "healthPlanPharmacyCategory": "1-MONTH-IN-MAIL",
                         "healthPlanCopay": {
                             "@type": "PriceSpecification",
                             "price": 20,
-                            "currency": "USD"
+                            "priceCurrency": "USD"
                         },
                         "healthPlanCopayOption": "http://healthplan.schema.org/HealthPlanCopayAfterDeductible",
                         "healthPlanCoinsuranceRate": 0.1,

--- a/data/ext/pending/issue-1062.ttl
+++ b/data/ext/pending/issue-1062.ttl
@@ -81,7 +81,7 @@
     :domainIncludes :HealthPlanFormulary,
         :HealthPlanNetwork ;
     :isPartOf <https://pending.schema.org> ;
-    :rangeIncludes :Boolean ;
+    :rangeIncludes :Boolean, :HealthPlanCostSharingSpecification;
     :source <https://github.com/schemaorg/schemaorg/issues/1062> ;
     rdfs:comment "The costs to the patient for services under this network or formulary." .
 

--- a/data/ext/pending/issue-2564-examples.txt
+++ b/data/ext/pending/issue-2564-examples.txt
@@ -17,30 +17,33 @@ RDFA:
 JSON:
 
 <script type="application/ld+json">
-[
- {
+{
   "@context": "https://schema.org/",
-  "@type": "StatisticalVariable",
-  "@id": "Median_Height_Person_Female",
-  "name": "Median height of women",
-  "populationType": {"@id": "Person"},
-  "measuredProperty": {"@id": "height"},
-  "statType": {"@id": "median"},
-  "gender": {"@id": "Female"},
-  "numConstraints": 1,
-  "constrainingProperty": {"@id": "gender"}
- },
-  {
-  "@context": "https://schema.org/",
-  "@id": "Observation_Median_Age_Person_Female_SanAntonio_TX_2014",
-  "@type": "Observation",
-  "name": "Median height of women in San Antonio, Texas in 2014",
-  "description": "An Observation of the StatisticalVariable Median_Height_Person_Female in location: San Antonio, Texas, for time period: 2014",
-  "variableMeasured": { "@id": "Median_Height_Person_Female" },
-  "observationAbout": { "@id": "https://www.wikidata.org/entity/Q975" },
-  "observationDate": "2014",
-  "value": 160,
-  "unitCode": "CMT"
-  }
-]
+  "@graph": [
+    {
+     "@context": "https://schema.org/",
+     "@type": "StatisticalVariable",
+     "@id": "Median_Height_Person_Female",
+     "name": "Median height of women",
+     "populationType": {"@id": "Person"},
+     "measuredProperty": {"@id": "height"},
+     "statType": {"@id": "median"},
+     "gender": {"@id": "Female"},
+     "numConstraints": 1,
+     "constrainingProperty": {"@id": "gender"}
+    },
+    {
+    "@context": "https://schema.org/",
+    "@id": "Observation_Median_Age_Person_Female_SanAntonio_TX_2014",
+    "@type": "Observation",
+    "name": "Median height of women in San Antonio, Texas in 2014",
+    "description": "An Observation of the StatisticalVariable Median_Height_Person_Female in location: San Antonio, Texas, for time period: 2014",
+    "variableMeasured": { "@id": "Median_Height_Person_Female" },
+    "observationAbout": { "@id": "https://www.wikidata.org/entity/Q975" },
+    "observationDate": "2014",
+    "value": 160,
+    "unitCode": "CMT"
+    }
+  ]
+}
 </script>

--- a/data/ext/pending/issue-2740-examples.txt
+++ b/data/ext/pending/issue-2740-examples.txt
@@ -22,13 +22,11 @@ JSON:
   "potentialAction": [{
      "@type": "SolveMathAction",
      "target": "https://mathdomain.com/solve?q={math_expression_string}",
-     "mathExpression-input": "required name=math_expression_string",
      "eduQuestionType": "Polynomial Equations"
    },
    {
      "@type": "SolveMathAction",
      "target": "https://mathdomain.com/graph?q={math_expression_string}",
-     "mathExpression-input": "required name=math_expression_string",
      "eduQuestionType": "Graphing"
    }]
 }

--- a/data/pending-failures.txt
+++ b/data/pending-failures.txt
@@ -1,12 +1,5 @@
-rspec ./spec/examples_spec.rb:1120 # Examples schemaorg-all-examples.txt[25456] - eg-0463 (jsonld)
 rspec ./spec/examples_spec.rb:1239 # Examples schemaorg-all-examples.txt[28475] - eg-0227 (jsonld)
 rspec ./spec/examples_spec.rb:1287 # Examples schemaorg-all-examples.txt[29268] - eg-0270 (jsonld)
 rspec ./spec/examples_spec.rb:1290 # Examples schemaorg-all-examples.txt[29298] - eg-0271 (jsonld)
-rspec ./spec/examples_spec.rb:1305 # Examples schemaorg-all-examples.txt[29495] - eg-0229 (jsonld)
-rspec ./spec/examples_spec.rb:1062 # Examples schemaorg-all-examples.txt[23802] - eg-0223 (microdata)
-rspec ./spec/examples_spec.rb:1063 # Examples schemaorg-all-examples.txt[23904] - eg-0223 (rdfa)
-rspec ./spec/examples_spec.rb:1064 # Examples schemaorg-all-examples.txt[24006] - eg-0223 (jsonld)
-rspec ./spec/examples_spec.rb:1065 # Examples schemaorg-all-examples.txt[24139] - eg-0225 (microdata)
-rspec ./spec/examples_spec.rb:1066 # Examples schemaorg-all-examples.txt[24172] - eg-0225 (rdfa)
 rspec ./spec/examples_spec.rb:1082 # Examples schemaorg-all-examples.txt[24482] - eg-0480 (jsonld)
 


### PR DESCRIPTION
Fix more more of the failing validation failures that are currently allow-listed on the ruby test.

Most of the fixes are on the medial ontology.
* If I could fix the examples by changing an attribute I did so. 
* I added a missing reverse property 'cause' which was used extensively.
* I fixed microdata examples by changing the nesting.
* Removed some science-equation property which was literally nowhere to be found. 

The error allow-list is now down to 4 lines. 
