### PR TITLE
Add display location property

### DIFF
--- a/data/ext/pending/issue-4513-example.txt
+++ b/data/ext/pending/issue-4513-example.txt
@@ -1,0 +1,41 @@
+TYPES: #eg-4513 Product, displayLocation
+
+PRE-MARKUP:
+
+An example of a product with a displayLocation.
+
+MICRODATA:
+
+TODO
+
+RDFA:
+
+TODO
+
+JSON:
+
+<script type="application/ld+json">
+{
+  "@context":"https://schema.org",
+  "@type":"Product",
+  "sku":"12345",
+  "image":"https://example.com/fnobarizer.jpg",
+  "name":"Advanced Fnobarizer",
+  "brand":{
+      "@type":"Brand",
+      "name":"Nucleatronics Inc."
+  },
+  "displayLocation":{
+    "@type": "Place",
+    "address": {
+      "@type": "PostalAddress",
+      "addressLocality": "Denver",
+      "addressRegion": "CO",
+      "postalCode": "80209",
+      "streetAddress": "7 S. Broadway"
+    },
+    "name": "The Hi-Dive"
+  }
+}
+</script>
+

--- a/data/ext/pending/issue-4513.ttl
+++ b/data/ext/pending/issue-4513.ttl
@@ -1,0 +1,14 @@
+@prefix : <https://schema.org/> .
+@prefix rdf: <http://www.w3.org/1999/02/22-rdf-syntax-ns#> .
+@prefix rdfs: <http://www.w3.org/2000/01/rdf-schema#> .
+@prefix xml: <http://www.w3.org/XML/1998/namespace> .
+@prefix xsd: <http://www.w3.org/2001/XMLSchema#> .
+
+:displayLocation a rdf:Property ;
+    rdfs:label "displayLocation" ;
+    rdfs:comment "The location at which an item can be viewed or experienced in-person." ;
+    :isPartOf <https://pending.schema.org> ;
+    :domainIncludes :CreativeWork,
+        :Product ;
+    :rangeIncludes :Place ;
+    :source <https://github.com/schemaorg/schemaorg/issues/4513> .

--- a/data/schema.ttl
+++ b/data/schema.ttl
@@ -5631,14 +5631,6 @@ Dateline summaries are oriented more towards human readers than towards automate
     :domainIncludes :CreativeWork ;
     :rangeIncludes :URL .
 
-:displayLocation a rdf:Property ;
-    rdfs:label "displayLocation" ;
-    rdfs:comment "The location at which an item can be viewed or experienced in-person." ;
-    :domainIncludes :CreativeWork,
-        :Product ;
-    :rangeIncludes :Place ;
-    :source <https://github.com/schemaorg/schemaorg/issues/4513> .
-
 :dissolutionDate a rdf:Property ;
     rdfs:label "dissolutionDate" ;
     rdfs:comment "The date that this organization was dissolved." ;


### PR DESCRIPTION
Specifies a place at which a product or creative work can be viewed or experienced. Note that this does not imply that the item can be purchased at this location, nor that the item is purchaseable altogether.

Resolves https://github.com/schemaorg/schemaorg/issues/4513
