### PR TITLE
Clarify the value range for percentages

### DIFF
--- a/data/ext/pending/issue-3617.ttl
+++ b/data/ext/pending/issue-3617.ttl
@@ -47,7 +47,7 @@
     :rangeIncludes :Number ;
     :source <https://github.com/schemaorg/schemaorg/issues/3617> ;
     :isPartOf <https://pending.schema.org> ;
-    rdfs:comment "Fraction of the value of the order that is charged as shipping cost." .
+    rdfs:comment "Value in the range [0.0 ; 1.0] representing the fraction of the value of the order that is charged as shipping cost." .
 
 :weightPercentage a rdf:Property ;
     rdfs:label "weightPercentage" ;
@@ -55,7 +55,7 @@
     :rangeIncludes :Number ;
     :source <https://github.com/schemaorg/schemaorg/issues/3617> ;
     :isPartOf <https://pending.schema.org> ;
-    rdfs:comment "Fraction of the weight that is used to compute the shipping price." .
+    rdfs:comment "Value in the range [0.0 ; 1.0] representing the fraction of the weight that is used to compute the shipping price." .
 
 # ╔════════════════════════════════════════════════════════╗
 # ║ Adding ServicePeriod                                   ║


### PR DESCRIPTION
Make the accepted values in the `orderPercentage` and `weightPercentage` from the shipping schema explicit.