### PR TITLE
examples: Minor fixes for syntax and typos

### DIFF
--- a/data/examples.txt
+++ b/data/examples.txt
@@ -468,7 +468,7 @@ Contact Details:
   </div>
     Tel:<span itemprop="telephone">( 33 1) 42 68 53 00 </span>,
     Fax:<span itemprop="faxNumber">( 33 1) 42 68 53 01 </span>,
-    E-mail: <span itemprop="email">secretariat(at)google.org</span>
+    E-mail: <span itemprop="email">secretariat@example.com</span>
     SIRET Code: 443 061 841 00039<meta itemprop="iso6523Code" content="0009:44306184100039" />
     VAT Number: FR64443061841<meta itemprop="iso6523Code" content="9957:FR64443061841" />
 
@@ -501,7 +501,7 @@ Contact Details:
   </div>
     Tel:<span property="telephone">( 33 1) 42 68 53 00 </span>,
     Fax:<span property="faxNumber">( 33 1) 42 68 53 01 </span>,
-    E-mail: <span property="email">secretariat(at)google.org</span>
+    E-mail: <span property="email">secretariat@example.com</span>
     SIRET Code: 443 061 841 00039<meta itemprop="iso6523Code" content="0009:44306184100039" />
     VAT Number: FR64443061841<meta itemprop="iso6523Code" content="9957:FR64443061841" />
 
@@ -530,7 +530,7 @@ JSON:
     "postalCode": "F-75002",
     "streetAddress": "38 avenue de l'Opéra"
   },
-  "email": "secretariat(at)google.org",
+  "email": "secretariat@example.com",
   "faxNumber": "+33142685301",
   "iso6523Code": "0009:44306184100039",
   "iso6523Code": "9957:FR64443061841",
@@ -590,7 +590,7 @@ Contact Details:
   </div>
     Tel:<span itemprop="telephone">( 33 1) 42 68 53 00 </span>,
     Fax:<span itemprop="faxNumber">( 33 1) 42 68 53 01 </span>,
-    E-mail: <span itemprop="email">secretariat(at)google.org</span>
+    E-mail: <span itemprop="email">secretariat@example.com</span>
 
 Members:
 - National Scientific Members in 100 countries and territories: Country1, Country2, ...
@@ -620,7 +620,7 @@ Contact Details:
   </div>
     Tel:<span property="telephone">( 33 1) 42 68 53 00 </span>,
     Fax:<span property="faxNumber">( 33 1) 42 68 53 01 </span>,
-    E-mail: <span property="email">secretariat(at)google.org</span>
+    E-mail: <span property="email">secretariat@example.com</span>
 
 Members:
 - National Scientific Members in 100 countries and territories: Country1, Country2, ...
@@ -647,7 +647,7 @@ JSON:
     "postalCode": "F-75002",
     "streetAddress": "38 avenue de l'Opera"
   },
-  "email": "secretariat(at)google.org",
+  "email": "secretariat@example.com",
   "faxNumber": "( 33 1) 42 68 53 01",
   "member": [
     {
@@ -1325,13 +1325,13 @@ MICRODATA:
     itemscope itemtype="https://schema.org/NutritionInformation">
     Nutrition facts:
     <span itemprop="calories">240 calories</span>,
-    <span itemprop="fatContent">9 grams fat</span>
+    <span itemprop="fatContent">9 grams</span> fat
   </div>
 
   Ingredients:
   - <span itemprop="recipeIngredient">3 or 4 ripe bananas, smashed</span>
   - <span itemprop="recipeIngredient" itemscope itemtype="https://schema.org/PropertyValue"><span itemprop="value">1</span> <span itemprop="name">egg</span></span>
-  - <span itemprop="recipeIngredient" itemscope itemtype="https://schema.org/PropertyValue"><span itemprop="value">3/4</span> <span itemprop="unitCode">cup</span> of <span itemprop="name">sugar</span></span>
+  - <span itemprop="recipeIngredient" itemscope itemtype="https://schema.org/PropertyValue"><span itemprop="value">3/4</span> <meta itemprop="unitCode" content="G21">cup of <span itemprop="name">sugar</span></span>
   ...
 
   Instructions:
@@ -1370,13 +1370,13 @@ RDFA:
   <div property="nutrition" typeof="NutritionInformation">
     Nutrition facts:
     <span property="calories">240 calories</span>,
-    <span property="fatContent">9 grams fat</span>
+    <span property="fatContent">9 grams</span> fat
   </div>
 
   Ingredients:
   - <span property="recipeIngredient">3 or 4 ripe bananas, smashed</span>
   - <span property="recipeIngredient" typeof="PropertyValue"><span property="value">1</span> <span property="name">egg</span></span>
-  - <span property="recipeIngredient" typeof="PropertyValue"><span property="value">3/4</span> <span property="unitCode">cup</span> of <span property="name">sugar</span></span>
+  - <span property="recipeIngredient" typeof="PropertyValue"><span property="value">3/4</span> <meta property="unitCode" content="G21">cup of <span property="name">sugar</span></span>
   ...
 
   Instructions:
@@ -1408,7 +1408,7 @@ JSON:
   "recipeIngredient": [
     "3 or 4 ripe bananas, smashed",
     { "@type": "PropertyValue", "value": 1, "name": "egg" },
-    { "@type": "PropertyValue", "value": "3/4", "name": "sugar", "unitCode": "cup"}
+    { "@type": "PropertyValue", "value": "3/4", "name": "sugar", "unitCode": "G21"}
   ],
   "interactionStatistic": {
     "@type": "InteractionCounter",
@@ -1419,7 +1419,7 @@ JSON:
   "nutrition": {
     "@type": "NutritionInformation",
     "calories": "240 calories",
-    "fatContent": "9 grams fat"
+    "fatContent": "9 grams"
   },
   "prepTime": "PT15M",
   "recipeInstructions": "Preheat the oven to 350 degrees. Mix in the ingredients in a bowl. Add the flour last. Pour the mixture into a loaf pan and bake for one hour.",
@@ -2963,7 +2963,7 @@ PRE-MARKUP:
 
 <div>
 ACME Colorvision 123. The ACME Colorvision 123 is the leading-edge color TV from
-our company. EAN/UPC: 1234567890123.
+our company. EAN/UPC: 1234567890128.
 </div>
 
 MICRODATA:
@@ -2981,7 +2981,7 @@ Colorvision 123 specifiation on the ACME Corp. site for that model.
  <span itemprop="name">ACME Colorvision 123</span>
  <span itemprop="description">The ACME Colorvision 123 is
   the leading-edge color TV from our company.</span>
- EAN/UPC: <span itemprop="gtin13">1234567890123</span>
+ EAN/UPC: <span itemprop="gtin13">1234567890128</span>
 </div>
 
 Recommendation: Try to provide identifiers (gtin13, gtin14, gtin8, mpn
@@ -3004,7 +3004,7 @@ Colorvision 123 specifiation on the ACME Corp. site for that model.
  <span property="name">ACME Colorvision 123</span>
  <span property="description">The ACME Colorvision 123 is
   the leading-edge color TV from our company.</span>
- EAN/UPC: <span property="gtin13">1234567890123</span>
+ EAN/UPC: <span property="gtin13">1234567890128</span>
 </div>
 
 Recommendation: Try to provide identifiers (gtin13, gtin14, gtin8, mpn
@@ -3021,7 +3021,7 @@ JSON:
   "@type": "ProductModel",
   "additionalType": "http://www.productontology.org/id/Television_set",
   "description": "The ACME Colorvision 123 is the leading-edge color TV from our company.",
-  "gtin13": "1234567890123",
+  "gtin13": "1234567890128",
   "name": "ACME Colorvision 123"
 }
 </script>
@@ -7231,10 +7231,7 @@ JSON:
     "@type": "Person",
     "name": "Steve"
   },
-  "deliveryMethod": {
-    "@type": "DeliveryMethod",
-    "name": "http://purl.org/goodrelations/v1#UPS"
-  },
+  "deliveryMethod": "http://purl.org/goodrelations/v1#UPS",
   "fromLocation": {
     "@type": "Country",
     "name": "Brazil"
@@ -7315,10 +7312,7 @@ JSON:
     "@type": "Person",
     "name": "Steve"
   },
-  "deliveryMethod": {
-    "@type": "DeliveryMethod",
-    "name": "http://purl.org/goodrelations/v1#UPS"
-  },
+  "deliveryMethod": "http://purl.org/goodrelations/v1#UPS",
   "fromLocation": {
     "@type": "Country",
     "name": "Brazil"
@@ -8244,7 +8238,7 @@ MICRODATA:
 
 RDFA:
 
-<div vocab="https://schema.org/" class="event-wrapper">
+<div vocab="https://schema.org/" class="event-wrapper" typeof="Event">
   <div class="event-date" property="startDate" content="2013-10-12T22:00">Sat Oct 12</div>
   <div class="event-title" property="name">Typhoon with Radiation City</div>
   <meta property="eventStatus" content="https://schema.org/EventRescheduled">
@@ -8512,10 +8506,9 @@ as suggested by www.a11ymetadata.org.
 </p>
 
 <div itemscope="" itemtype="https://schema.org/Book">
-   <meta itemprop="bookFormat" content="EBook/DAISY3"/>
-   <meta itemprop="accessibilityFeature" content="largePrint/CSSEnabled"/>
-   <meta itemprop="accessibilityFeature" content="highContrast/CSSEnabled"/>
-   <meta itemprop="accessibilityFeature" content="resizeText/CSSEnabled"/>
+   <meta itemprop="bookFormat" content="EBook"/>
+   <meta itemprop="accessibilityFeature" content="largePrint"/>
+   <meta itemprop="accessibilityFeature" content="highContrastDisplay"/>
    <meta itemprop="accessibilityFeature" content="displayTransformability"/>
    <meta itemprop="accessibilityFeature" content="longDescription"/>
    <meta itemprop="accessibilityFeature" content="alternativeText"/>
@@ -8586,10 +8579,9 @@ as suggested by www.a11ymetadata.org.
 </p>
 
 <div vocab="https://schema.org/" typeof="Book">
-   <meta property="bookFormat" content="EBook/DAISY3"/>
-   <meta property="accessibilityFeature" content="largePrint/CSSEnabled"/>
-   <meta property="accessibilityFeature" content="highContrast/CSSEnabled"/>
-   <meta property="accessibilityFeature" content="resizeText/CSSEnabled"/>
+   <meta property="bookFormat" content="EBook"/>
+   <meta property="accessibilityFeature" content="largePrint"/>
+   <meta property="accessibilityFeature" content="highContrastDisplay"/>
    <meta property="accessibilityFeature" content="displayTransformability"/>
    <meta property="accessibilityFeature" content="longDescription"/>
    <meta property="accessibilityFeature" content="alternativeText"/>
@@ -8662,9 +8654,8 @@ JSON:
     "fullMouseControl"
   ],
   "accessibilityFeature": [
-    "largePrint/CSSEnabled",
-    "highContrast/CSSEnabled",
-    "resizeText/CSSEnabled",
+    "largePrint",
+    "highContrastDisplay",
     "displayTransformability",
     "longDescription",
     "alternativeText"
@@ -8678,7 +8669,7 @@ JSON:
     "@type": "AggregateRating",
     "reviewCount": "0"
   },
-  "bookFormat": "EBook/DAISY3",
+  "bookFormat": "EBook",
   "copyrightHolder": {
     "@type": "Organization",
     "name": "Holt, Rinehart and Winston"
@@ -8708,7 +8699,7 @@ PRE-MARKUP:
 MICRODATA:
 
 <figure itemscope itemtype="https://schema.org/CreativeWork">
- <meta itemprop="accessibilityFeature" content="textAlternative">
+ <meta itemprop="accessibilityFeature" content="alternativeText">
  <meta itemprop="accessibilityFeature" content="longDescription">
  <meta itemprop="accessibilityHazard" content="noFlashingHazard">
  <meta itemprop="accessibilityHazard" content="noMotionSimulationHazard">
@@ -8720,7 +8711,7 @@ MICRODATA:
 RDFA:
 
 <figure vocab="https://schema.org/" typeof="CreativeWork">
- <meta property="accessibilityFeature" content="textAlternative">
+ <meta property="accessibilityFeature" content="alternativeText">
  <meta property="accessibilityFeature" content="longDescription">
  <meta property="accessibilityHazard" content="noFlashingHazard">
  <meta property="accessibilityHazard" content="noMotionSimulationHazard">
@@ -8742,7 +8733,7 @@ PRE-MARKUP:
 MICRODATA:
 
 <main itemscope itemtype="https://schema.org/CreativeWork">
-   <meta itemprop="accessibilityHazard" content="FlashingHazard"/>
+   <meta itemprop="accessibilityHazard" content="flashing"/>
    <meta itemprop="accessibilityHazard" content="noMotionSimulationHazard"/>
    <meta itemprop="accessibilityHazard" content="noSoundHazard"/>
    <meta itemprop="accessibilityFeature" content="longDescription"/>
@@ -8752,7 +8743,7 @@ MICRODATA:
    <meta itemprop="encodingFormat" content="text/css"/>
    <meta itemprop="encodingFormat" content="text/javascript"/>
    <meta itemprop="accessibilityAPI" content="ARIA"/>
-   <meta itemprop="accessibilityAPI" content="UIA"/>
+   <meta itemprop="accessibilityAPI" content="UIAccessibility"/>
    <meta itemprop="accessibilityControl" content="fullKeyboardControl"/>
    <meta itemprop="accessibilityControl" content="fullKeyboardControl"/>
    <meta itemprop="accessibilityControl" content="fullKeyboardControl"/>
@@ -8763,7 +8754,7 @@ MICRODATA:
 RDFA:
 
 <div vocab="https://schema.org/" typeof="CreativeWork">
-   <meta property="accessibilityHazard" content="FlashingHazard"/>
+   <meta property="accessibilityHazard" content="flashing"/>
    <meta property="accessibilityHazard" content="noMotionSimulationHazard"/>
    <meta property="accessibilityHazard" content="noSoundHazard"/>
    <meta property="accessibilityFeature" content="longDescription"/>
@@ -8773,7 +8764,7 @@ RDFA:
    <meta property="encodingFormat" content="text/css"/>
    <meta property="encodingFormat" content="text/javascript"/>
    <meta property="accessibilityAPI" content="ARIA"/>
-   <meta property="accessibilityAPI" content="UIA"/>
+   <meta property="accessibilityAPI" content="UIAccessibility"/>
    <meta property="accessibilityControl" content="fullKeyboardControl"/>
    <meta property="accessibilityControl" content="fullKeyboardControl"/>
    <meta property="accessibilityControl" content="fullKeyboardControl"/>
@@ -8787,7 +8778,7 @@ JSON:
  "@context" :  "https://schema.org/" ,
  "@type" : "CreativeWork" ,
  "accessibilityHazard" :  [
-        "FlashingHazard" , "noSoundHazard" ,
+        "flashing" , "noSoundHazard" ,
         "noMotionSimulationHazard" ] ,
 
  "accessibilityFeature" : [
@@ -8798,7 +8789,7 @@ JSON:
         "text/javascript" , "text/css" ] ,
 
  "accessibilityAPI" : [
-        "ARIA" , "UIA" ],
+        "ARIA" , "UIAccessibility" ],
  "accessibilityControl" : [
         "fullKeyboardControl" , "fullTouchControl" ,
         "fullVoiceControl" , "fullMouseControl" ]
@@ -9689,13 +9680,13 @@ RDFA:
       <img src="/examples/cso_c_logo_s.jpg" alt="Chicago Symphony Orchestra"/>
       <link href="http://cso.org/" property="sameAs"/>
       <link href="http://en.wikipedia.org/wiki/Chicago_Symphony_Orchestra" property="sameAs"/>
-      <a property="name" href="examples/Performer?id=4434">Chicago Symphony Orchestra</a>
+      <span property="name"><a href="examples/Performer?id=4434">Chicago Symphony Orchestra</a></span>
     </div>
 
     <div property="performer" typeof="Person">
       <link href="http://www.jaapvanzweden.com/" property="sameAs"/>
       <img src="/examples/jvanzweden_s.jpg" alt="Jaap van Zweden" property="image"/>
-      <a property="name" href="/examples/Performer.aspx?id=11324">Jaap van Zweden</a>
+      <span property="name"><a href="/examples/Performer.aspx?id=11324">Jaap van Zweden</a></span>
       <div>conductor</div>
     </div>
   </div>

--- a/data/ext/pending/issue-1045-examples.txt
+++ b/data/ext/pending/issue-1045-examples.txt
@@ -25,7 +25,7 @@ JSON:
      {
        "@type": "LinkRole",
        "target": "http://www.example.com/Reserve-JP",
-       "inLanguage": "jp",
+       "inLanguage": "ja",
        "linkRelationship": "alternate"
      }
    ]

--- a/data/ext/pending/issue-1156-examples.txt
+++ b/data/ext/pending/issue-1156-examples.txt
@@ -335,7 +335,7 @@ RDFA:
       <ul>
         <li>
           <a property="encoding" typeof="LegislationObject" href="customs-code-en.html">
-            <link property="legislationLegalValue" href="https://schema.org/OfficiallegalValue" />
+            <link property="legislationLegalValue" href="https://schema.org/OfficialLegalValue" />
             in <span property="encodingFormat">HTML</span> (informative only)
           </a>
         </li>

--- a/data/ext/pending/issue-1810-examples.txt
+++ b/data/ext/pending/issue-1810-examples.txt
@@ -659,11 +659,11 @@ MICRODATA:
         <meta itemprop="name" content="Saturday" />
         <meta itemprop="position" content="1" />
         <meta itemprop="numberOfItems" content="3" />
-          <div itemtype="https://schema.org/ListItem" itemscope>
+          <div itemprop="itemListElement" itemtype="https://schema.org/ListItem" itemscope>
             <meta itemprop="name" content="Morning" />
             <meta itemprop="description" content="Pedestrian visit of the Golden Gate Bridge." />
             <meta itemprop="position" content="1" />
-              <div itemtype="https://schema.org/Bridge" itemscope>
+              <div itemprop="item" itemtype="https://schema.org/Bridge" itemscope>
                 <link itemprop="additionalType" href="https://schema.org/TouristAttraction" />
                 <meta itemprop="name" content="Golden Gate Bridge" />
                 <meta itemprop="description" content="Very popular suspension bridge. The bridge is one of the most internationally recognized symbols of San Francisco, California, and the United States. It has been declared one of the Wonders of the Modern World by the American Society of Civil Engineers." />
@@ -674,21 +674,21 @@ MICRODATA:
                   </div>
               </div>
           </div>
-          <div itemtype="https://schema.org/ListItem" itemscope>
+          <div itemprop="itemListElement" itemtype="https://schema.org/ListItem" itemscope>
             <meta itemprop="name" content="Afternoon" />
             <meta itemprop="description" content="Visit of the famous SF Chinatown." />
             <meta itemprop="position" content="2" />
-              <div itemtype="https://schema.org/TouristAttraction" itemscope>
+              <div itemprop="item" itemtype="https://schema.org/TouristAttraction" itemscope>
                 <meta itemprop="name" content="Chinatown" />
                 <meta itemprop="description" content="Oldest Chinatown in North America and the largest Chinese enclave outside Asia. Visit its exotic shops, food markets, restaurants, and temples." />
                 <meta itemprop="address" content="Stockton St and Clay St, San Francisco CA" />
               </div>
           </div>
-          <div itemtype="https://schema.org/ListItem" itemscope>
+          <div itemprop="itemListElement" itemtype="https://schema.org/ListItem" itemscope>
             <meta itemprop="name" content="Night" />
             <meta itemprop="description" content="Enjoy the SF nightlife" />
             <meta itemprop="position" content="3" />
-              <div itemtype="https://schema.org/TouristAttraction" itemscope>
+              <div itemprop="item" itemtype="https://schema.org/TouristAttraction" itemscope>
                 <meta itemprop="name" content="The Mission" />
                 <meta itemprop="description" content="The Mission District offers visitors an unparalleled menu of food and flavors as well as venues for fans of underground indie rock, funk, soul and jazz." />
                 <meta itemprop="address" content="Mission St and 19th St, San Francisco CA" />
@@ -700,21 +700,21 @@ MICRODATA:
         <meta itemprop="name" content="Sunday" />
         <meta itemprop="position" content="2" />
         <meta itemprop="numberOfItems" content="2" />
-          <div itemtype="https://schema.org/ListItem" itemscope>
+          <div itemprop="itemListElement" itemtype="https://schema.org/ListItem" itemscope>
             <meta itemprop="name" content="Morning" />
             <meta itemprop="description" content="Spend your morning shopping in one of the best spots in America." />
             <meta itemprop="position" content="1" />
-              <div itemtype="https://schema.org/TouristAttraction" itemscope>
+              <div itemprop="item" itemtype="https://schema.org/TouristAttraction" itemscope>
                 <meta itemprop="name" content="Union Street Area" />
                 <meta itemprop="description" content="Union Street is the major commercial hub of San Francisco. You will find most fashion labels there." />
                 <meta itemprop="address" content="Union St and Buchanan St, San Francisco CA" />
               </div>
           </div>
-          <div itemtype="https://schema.org/ListItem" itemscope>
+          <div itemprop="itemListElement" itemtype="https://schema.org/ListItem" itemscope>
             <meta itemprop="name" content="Afternoon" />
             <meta itemprop="description" content="Take your plane back home." />
             <meta itemprop="position" content="2" />
-              <div itemtype="https://schema.org/Airport" itemscope>
+              <div itemprop="item" itemtype="https://schema.org/Airport" itemscope>
                 <meta itemprop="name" content="San Francisco Airport" />
               </div>
           </div>

--- a/data/ext/pending/issue-2450-examples.txt
+++ b/data/ext/pending/issue-2450-examples.txt
@@ -25,7 +25,7 @@ JSON:
       "name":"PolitiFact",
       "url": "https://politifact.com"
    },
-   "mediaAuthenticityCategory":"DecontexualizedContent",
+   "mediaAuthenticityCategory":"DecontextualizedContent",
     "originalMediaContextDescription":"Singer Mariah Carey shared a video of herself receiving a COVID-19 vaccination.",
    "itemReviewed":{
       "@type":"MediaReviewItem",

--- a/data/ext/pending/issue-2564-examples.txt
+++ b/data/ext/pending/issue-2564-examples.txt
@@ -25,12 +25,12 @@ JSON:
      "@type": "StatisticalVariable",
      "@id": "Median_Height_Person_Female",
      "name": "Median height of women",
-     "populationType": {"@id": "Person"},
-     "measuredProperty": {"@id": "height"},
-     "statType": {"@id": "median"},
-     "gender": {"@id": "Female"},
+     "populationType": {"@id": "schema:Person"},
+     "measuredProperty": {"@id": "schema:height"},
+     "statType": {"@id": "schema:median"},
+     "gender": {"@id": "schema:Female"},
      "numConstraints": 1,
-     "constrainingProperty": {"@id": "gender"}
+     "constrainingProperty": {"@id": "schema:gender"}
     },
     {
     "@context": "https://schema.org/",

--- a/data/ext/pending/issue-3135-examples.txt
+++ b/data/ext/pending/issue-3135-examples.txt
@@ -27,7 +27,7 @@ JSON:
    },
    "offers":{
       "@type":"Offer",
-      "checkoutPageURLTemplate":"https://www.example.com/checkout?items={VARIANT_ID_1}:{Quantity-1},{VARIANT_ID_2}:{Quantity-2}&discount={DISCOUNT_CODE}&store_id={pickup_store_id}",
+      "checkoutPageURLTemplate":"https://www.example.com/checkout?items={VARIANT_ID_1}:{Quantity_1},{VARIANT_ID_2}:{Quantity_2}&discount={DISCOUNT_CODE}&store_id={pickup_store_id}",
       "priceSpecification":{
         "@type":"PriceSpecification",
         "price":"99.99",

--- a/data/ext/pending/issue-3563-examples.txt
+++ b/data/ext/pending/issue-3563-examples.txt
@@ -111,7 +111,7 @@ JSON:
         "@type": "Offer",
         "url": "https://www.example.com/coat?size=large&color=lightblue",
         "itemCondition": "https://schema.org/NewCondition",
-        "availability": "https://schema.org/Backorder",
+        "availability": "https://schema.org/BackOrder",
         "shippingDetails": {
           "@id": "https://www.example.com/shipping#shipping_policy"
         },

--- a/data/sdo-blogpost-examples.txt
+++ b/data/sdo-blogpost-examples.txt
@@ -115,7 +115,7 @@ JSON:
         {
             "@type": "Comment",
             "@id": "https://dataliberate.com/2019/05/14/library-metadata-evolution-final-mile/#Comment1",
-            "dateCreated": "2019-06-23 17:31:15",
+            "datePublished": "2019-06-23T17:31:15+01:00",
             "description": "I've been looking for a decent metadata scheme for use in a home-brew library system for the past 4 years now. I'm a big user of schema.org. I found this very interesting, especially the part about reconciliation. I assume you're referring to the process of identifying duplicate representations of works. This has also been one of my biggest struggles. I'll still be waiting for schema.org to mature...",
             "author": {
                 "@type": "Person",

--- a/data/sdo-identifier-examples.txt
+++ b/data/sdo-identifier-examples.txt
@@ -68,7 +68,7 @@ MICRODATA:
     Company Record
     <h1 itemprop="name">A UK Organization Ltd</h1>
     Registered office address: <span itemprop="address">1 A Street, London</span><br>
-    <div itemscope="" itemprop="identifier" itemptype="https://schema.org/PropertyValue">
+    <div itemscope="" itemprop="identifier" itemtype="https://schema.org/PropertyValue">
         <span itemprop="propertyID">Company Number</span>: <span itemprop="value">99065782</span>
     </div><br>
 </div>

--- a/data/sdo-invoice-examples.txt
+++ b/data/sdo-invoice-examples.txt
@@ -62,7 +62,7 @@ RDFA:
     <span property="priceCurrency">USD</span>
   </div>
   <meta property="billingPeriod" content="P30D" />starts:2014-12-21 30 days
-  <link property="paymentStatus" href="PaymentDue" />
+  <link property="paymentStatus" href="https://schema.org/PaymentDue" />
 </div>
 
 JSON:

--- a/data/sdo-offeredby-examples.txt
+++ b/data/sdo-offeredby-examples.txt
@@ -188,7 +188,7 @@ RDFA:
       <p resource="#Offer" property="offers" typeof="Offer">
         <meta property="priceCurrency" content="USD" />
         <meta property="price" content="1000.00" />
-        <link property="availability" href="InStock" />
+        <link property="availability" href="https://schema.org/InStock" />
         <link property="itemOffered" href="#Product" />
         <link property="businessFunction" href="http://purl.org/goodrelations/v1#Sell" />
         <link rev="makesOffer" href="#Organization" />

--- a/data/sdo-userinteraction-examples.txt
+++ b/data/sdo-userinteraction-examples.txt
@@ -67,7 +67,7 @@ MICRODATA:
 
 RDFA:
 
-<div vocab="http://schema./org/" resource="http://videolectures.net/iswc2013_guha_tunnel/" typeof="VideoObject">
+<div vocab="http://schema.org/" resource="http://videolectures.net/iswc2013_guha_tunnel/" typeof="VideoObject">
   <h1 property="name">Light at the End of the Tunnel</h1>
   Author:
     <div property="author" typeof="Person">

--- a/data/sdo-videogame-examples.txt
+++ b/data/sdo-videogame-examples.txt
@@ -757,7 +757,7 @@ MICRODATA:
 <section itemscope itemtype="https://schema.org/Game">
     <section itemprop="offers" itemscope itemtype="https://schema.org/Offer">
       <span>Approx. Retail:</span>
-      <span itemprop="priceCurrency">$</span><span itemprop="price">17.99</span>
+      <span><meta itemprop="priceCurrency" content="USD">$<span itemprop="price">17.99</span></span>
       <a href="/monopoly-2/en_US/shop/where-to-buy.cfm?brand_guid=DAD28866-1C43-11DD-BD0B-0800200C9A66&prodName=Monopoly%20Game" itemprop="availableAtOrFrom">Where To Buy</a>
     </section>
     <span itemprop="audience" itemscope itemtype="https://schema.org/PeopleAudience">
@@ -773,7 +773,7 @@ RDFA:
 <section vocab="https://schema.org/" typeof="Game">
     <section property="offers" typeof="Offer">
       <span>Approx. Retail:</span>
-      <span property="priceCurrency">$</span><span property="price">17.99</span>
+      <span><meta property="priceCurrency" content="USD">$<span property="price">17.99</span></span>
       <a href="/monopoly-2/en_US/shop/where-to-buy.cfm?brand_guid=DAD28866-1C43-11DD-BD0B-0800200C9A66&prodName=Monopoly%20Game" property="availableAtOrFrom">Where To Buy</a>
     </section>
     <span property="audience" typeof="PeopleAudience">
@@ -792,7 +792,7 @@ JSON:
   "@type": "Game",
   "offers":{
     "@type":"Offer",
-    "priceCurrency":"$",
+    "priceCurrency":"USD",
     "price":"17.99",
     "availableAtOrFrom":"/monopoly-2/en_US/shop/where-to-buy.cfm?brand_guid=DAD28866-1C43-11DD-BD0B-0800200C9A66&prodName=Monopoly%20Game"
   },


### PR DESCRIPTION
Hello - I was doing validation testing against the official examples and noticed some inconsistencies. These changes fix them according to my understanding of conventions.

* fix general typos in properties, types, attributes
* fix unexpected property nesting to match sibling examples
* fix encoding-specific, iri resolution-related issues
* use valid UN/CEFACT unitCode values
* migrate accessibility* properties to now-approved vocabulary terms
* drop deprecated extension-mechanism values from nearby changes
* switch to valid example email, gtin, url template values
* fix indirect enumerations syntax