### PR TITLE
addressRegion now accepts AdministrativeArea

### DIFF
--- a/data/schema.ttl
+++ b/data/schema.ttl
@@ -4183,7 +4183,7 @@ See also the <a href="/docs/hotels.html">dedicated document on the use of schema
     rdfs:comment "The region in which the locality is, and which is in the country. For example, California or another appropriate first-level [Administrative division](https://en.wikipedia.org/wiki/List_of_administrative_divisions_by_country)." ;
     :domainIncludes :DefinedRegion,
         :PostalAddress ;
-    :rangeIncludes :Text ;
+    :rangeIncludes :Text, :AdministrativeArea ;
     :source <https://github.com/schemaorg/schemaorg/issues/2506> .
 
 :advanceBookingRequirement a rdf:Property ;


### PR DESCRIPTION
This is consistent with the documentation, which claims that 

The region in which the locality is, and which is in the country. For example, California or another appropriate first-level Administrative division.