### PR TITLE
Skip snapshot testing for now

### DIFF
--- a/software/tests/test_snapshot.py
+++ b/software/tests/test_snapshot.py
@@ -19,6 +19,7 @@ import software.util.snapshot_schema as snapshot_schema
 FAIL_HELP = "\n [See fix here] Re-generate the snapshot file by running the 'software/util/snapshot_schema.py'-file."
 
 class SnapshotTest(unittest.TestCase):
+    @unittest.skip("skip snapshot tests until branch updates / pr actions are correctly set up")
     def test_snapshot_matches(self):
         # loads the software/tests/snapshot/schemaorg-all-https.ttl file
         snapshot_file = os.path.join(


### PR DESCRIPTION
Need some branch updating rules to make sure the snapshot test is ran against the most recent main. Disable the test for now until that is properly set up.