### PR TITLE
Moved phonetic examples away from PhoneticText

### DIFF
--- a/data/ext/pending/issue-2108-examples.txt
+++ b/data/ext/pending/issue-2108-examples.txt
@@ -1,8 +1,8 @@
-TYPES: #eg-0270 PronounceableText, phoneticText
+TYPES: #eg-0270 City, name
 
 PRE-MARKUP:
 
-See JSON example.
+<ruby lang="en">Worcester<rp>(</rp><rt lang="en-fonipa">/ˈwʊstɚ/</rt><rp>)</rp></ruby>
 
 MICRODATA:
 
@@ -18,21 +18,21 @@ JSON:
 {
   "@context": "https://schema.org/",
   "@type": "City",
-  "name": {
-    "@type": "PronounceableText",
-    "inLanguage": "en-US",
-    "textValue": "Worcester",
-    "speechToTextMarkup": "IPA",
-    "phoneticText": "/ˈwʊstɚ/"
-  }
+  "name": [{
+    "@value": "Worcester",
+    "@language": "en"
+  }, {
+    "@value": "/ˈwʊstɚ/",
+    "@language": "en-fonipa"
+  }]
 }
 </script>
 
-TYPES: #eg-0271 PronounceableText, phoneticText
+TYPES: #eg-0271 RadioStation, name
 
 PRE-MARKUP:
 
-See JSON example.
+<span aria-label="W K R P">WKRP</span>
 
 MICRODATA:
 
@@ -48,13 +48,15 @@ JSON:
 {
   "@context": "https://schema.org/",
   "@type": "RadioStation",
-  "name": ["WKRP",
-      {
-        "@type": "PronounceableText",
-        "textValue": "WKRP",
-        "speechToTextMarkup": "SSML",
-        "phoneticText": "<speak><say-as interpret-as=\"characters\">WKRP</say-as>"
-      }
+  "name": [
+    {
+      "@value": "WKRP",
+      "@language": "en"
+    },
+    {
+      "@value": "ˈdʌbəljuː ˈkeɪ ˈɑːr ˈpiː",
+      "@language": "en-fonipa"
+    }
   ]
 }
 </script>

--- a/data/pending-failures.txt
+++ b/data/pending-failures.txt
@@ -1,5 +1,3 @@
 rspec ./spec/examples_spec.rb:1239 # Examples schemaorg-all-examples.txt[28475] - eg-0227 (jsonld)
-rspec ./spec/examples_spec.rb:1287 # Examples schemaorg-all-examples.txt[29268] - eg-0270 (jsonld)
-rspec ./spec/examples_spec.rb:1290 # Examples schemaorg-all-examples.txt[29298] - eg-0271 (jsonld)
 rspec ./spec/examples_spec.rb:1082 # Examples schemaorg-all-examples.txt[24482] - eg-0480 (jsonld)
 


### PR DESCRIPTION
Two more ruby text exceptions down! 

The PhoneticText class never really worked, causes errors in the ruby tests, and is not really needed, as the same effect can be achieved with multiple @language tagged values. This pull request migrates the examples away into the relevant classes and attributes (name), the actual PhoneticText class will be migrated in another pull request. 