### PR TITLE
Added OperatingSystem class

### DIFF
--- a/data/ext/pending/issue-3057.ttl
+++ b/data/ext/pending/issue-3057.ttl
@@ -9,7 +9,7 @@
     :isPartOf <https://pending.schema.org> ;
     :source <https://github.com/schemaorg/schemaorg/issues/3057> ;
     rdfs:comment "Enumerates some common technology platforms, for use with properties such as [[actionPlatform]]. It is not supposed to be comprehensive - when a suitable code is not enumerated here, textual or URL values can be used instead. These codes are at a fairly high level and do not deal with versioning and other nuance. Additional codes can be suggested [in github](https://github.com/schemaorg/schemaorg/issues/3057). " ;
-    rdfs:subClassOf :Enumeration .
+    rdfs:subClassOf :Enumeration, :OperatingSystem .
 
 :DesktopWebPlatform a :DigitalPlatformEnumeration ;
     rdfs:label "DesktopWebPlatform" ;
@@ -28,8 +28,8 @@
     :isPartOf <https://pending.schema.org> ;
     :source <https://github.com/schemaorg/schemaorg/issues/3057> ;
     rdfs:comment "Represents the generic notion of the Web Platform. More specific codes include [[MobileWebPlatform]] and [[DesktopWebPlatform]], as an incomplete list. " .
-    
-:AndroidPlatform a :DigitalPlatformEnumeration ;
+
+:AndroidPlatform a :DigitalPlatformEnumeration;
     rdfs:label "AndroidPlatform" ;
     :isPartOf <https://pending.schema.org> ;
     :source <https://github.com/schemaorg/schemaorg/issues/3057> ;

--- a/data/ext/pending/issue-4575.ttl
+++ b/data/ext/pending/issue-4575.ttl
@@ -1,0 +1,12 @@
+@prefix : <https://schema.org/> .
+@prefix rdf: <http://www.w3.org/1999/02/22-rdf-syntax-ns#> .
+@prefix rdfs: <http://www.w3.org/2000/01/rdf-schema#> .
+@prefix xml: <http://www.w3.org/XML/1998/namespace> .
+@prefix xsd: <http://www.w3.org/2001/XMLSchema#> .
+
+:OperatingSystem a rdfs:Class ;
+    rdfs:label "OperatingSystem" ;
+    :isPartOf <https://pending.schema.org> ;
+    :source <https://github.com/schemaorg/schemaorg/issues/4575> ;
+    rdfs:comment "System software that manages computer hardware and software resources, and provides common services for computer programs." ;
+    rdfs:subClassOf :SoftwareApplication .

--- a/data/schema.ttl
+++ b/data/schema.ttl
@@ -7538,7 +7538,7 @@ Note: for historical reasons, any textual label and formal code provided as a li
     rdfs:label "operatingSystem" ;
     rdfs:comment "Operating systems supported (Windows 7, OS X 10.6, Android 1.6)." ;
     :domainIncludes :SoftwareApplication ;
-    :rangeIncludes :Text .
+    :rangeIncludes :Text, :OperatingSystem .
 
 :opponent a rdf:Property ;
     rdfs:label "opponent" ;


### PR DESCRIPTION
This should address (partially) https://github.com/schemaorg/schemaorg/issues/4575 

The OperatingSystem class can now be used for the [operatingSystem](https://schema.org/operatingSystem) property. 
The [DigitalPlatformEnumeration](https://schema.org/DigitalPlatformEnumeration) now also inherits from OperatingSystem and so you should be able to write:

```
{
  "@context": "https://schema.org",
  "name": "uselessApp",
  "operatingSystem":  "https://schema.org/AndroidPlatform"
}

```


