### PR TITLE
updated version checking to match the actual requirements

### DIFF
--- a/software/__init__.py
+++ b/software/__init__.py
@@ -16,18 +16,18 @@ def Setup():
     if _INITIALIZED:
         return
 
-    if not (sys.version_info.major == 3 and sys.version_info.minor > 5):
+    if sys.version_info < (3, 10):
         sys.stderr.write(
-            "Python version %s.%s not supported version 3.6 or above required - Exiting"
-            % (sys.version_info.major, sys.version_info.minor)
-        )
+            f"Python version {sys.version_info.major}.{sys.version_info.minor}"
+            " not supported version 3.10 or above required - Exiting\n"
+            )
         sys.exit(os.EX_CONFIG)
 
     for path in LIB_PATHS:
         absolute_path = os.path.join(os.getcwd(), path)
         if not os.path.isdir(absolute_path):
             sys.stderr.write(
-                'Required directory "%s" not found - Exiting\n' % absolute_path
+                f'Required directory "{absolute_path}" not found - Exiting\n'
             )
             sys.exit(os.EX_CONFIG)
         sys.path.insert(1, absolute_path)
@@ -39,14 +39,15 @@ def CheckWorkingDirectory():
     """Check that the working directory is correct and contains the right directories."""
     if os.path.basename(os.getcwd()) != "schemaorg":
         sys.stderr.write(
-            'Script should be run from within the "schemaorg" directory! - Exiting\n'
+            'Script should be run from within the "schemaorg" '
+            'directory! - Exiting\n'
         )
         sys.exit(os.EX_USAGE)
 
     for directory_name in DATA_PATHS:
         if not os.path.isdir(directory_name):
             sys.stderr.write(
-                'Required directory "%s" not found - Exiting\n' % directory_name
+                'Required directory {directory_name} not found - Exiting\n'
             )
             sys.exit(os.EX_CONFIG)
 


### PR DESCRIPTION
The code now relies on Python 3.10 features, so the checking code needs to be updated.
If you try to build the site with python 3.9, you get the following error message:

```
TypeError: unsupported operand type(s) for |: 'type' and 'NoneType'
```

Update the relevant code to use f strings and a less brittle version checking code.
