### PR TITLE
DefinedTerm and DefinedTermSet have the `about` property

### DIFF
--- a/data/ext/pending/issue-894.ttl
+++ b/data/ext/pending/issue-894.ttl
@@ -22,14 +22,14 @@
     rdfs:label "DefinedTerm" ;
     :isPartOf <https://pending.schema.org> ;
     :source <https://github.com/schemaorg/schemaorg/issues/894> ;
-    rdfs:comment "A word, name, acronym, phrase, etc. with a formal definition. Often used in the context of category or subject classification, glossaries or dictionaries, product or creative work types, etc. Use the name property for the term being defined, use termCode if the term has an alpha-numeric code allocated, use description to provide the definition of the term." ;
+    rdfs:comment "A word, name, acronym, phrase, etc. with a formal definition. Often used in the context of category or subject classification, glossaries or dictionaries, product or creative work types, etc. Use the name property for the term being defined, use termCode if the term has an alpha-numeric code allocated, use description to provide the definition of the term. Use the about property to specify what the term is about." ;
     rdfs:subClassOf :Intangible .
 
 :DefinedTermSet a rdfs:Class ;
     rdfs:label "DefinedTermSet" ;
     :isPartOf <https://pending.schema.org> ;
     :source <https://github.com/schemaorg/schemaorg/issues/894> ;
-    rdfs:comment "A set of defined terms, for example a set of categories or a classification scheme, a glossary, dictionary or enumeration." ;
+    rdfs:comment "A set of defined terms, for example a set of categories or a classification scheme, a glossary, dictionary or enumeration. Use the about property to specify what the term set is about." ;
     rdfs:subClassOf :CreativeWork .
 
 :codeValue a rdf:Property ;

--- a/data/schema.ttl
+++ b/data/schema.ttl
@@ -10575,14 +10575,17 @@ Open-ended date ranges can be written with ".." in place of the end date. For ex
 
 :about a rdf:Property ;
     rdfs:label "about" ;
-    rdfs:comment "The subject matter of the content." ;
+    rdfs:comment "The subject matter of an object." ;
     :domainIncludes :Certification,
         :CommunicateAction,
         :CreativeWork,
+        :DefinedTerm,
+        :DefinedTermSet,
         :Event ;
     :inverseOf :subjectOf ;
     :rangeIncludes :Thing ;
-    :source <https://github.com/schemaorg/schemaorg/issues/1670> .
+    :source <https://github.com/schemaorg/schemaorg/issues/1670> ,
+    <https://github.com/schemaorg/schemaorg/issues/4588> .
 
 :competitor a rdf:Property ;
     rdfs:label "competitor" ;


### PR DESCRIPTION
See https://github.com/schemaorg/schemaorg/issues/4588, [DefinedTermSet](https://schema.org/DefinedTermSet) and [DefinedTerm](https://schema.org/DefinedTerm) now have the [about](https://schema.org/about) property to specify what a DefinedTerm or the DefinedTermSet is about.  