### PR TITLE
Added a RuntimePlatform subclass of SoftwareApplication

### DIFF
--- a/data/ext/pending/issue-4575-examples.txt
+++ b/data/ext/pending/issue-4575-examples.txt
@@ -1,0 +1,31 @@
+TYPES: #eg-4575 SoftwareApplication
+
+PRE-MARKUP:
+
+The amazing <strong>Whale Rider</string> games runs on the <em>Door 44</em> operating system and requires the <em>Passive Y 31</em> library.
+
+MICRODATA:
+
+
+RDFA:
+
+
+JSON:
+
+<script type="application/ld+json">
+{
+  "@context": "https://schema.org/",
+  "@type": "VideoGame",
+  "name": "Whale Rider",
+  "operatingSystem": {
+    "@type": "OperatingSystem",
+    "name": "Door",
+    "softwareVersion": "44"
+  },
+  "softwareRequirements": {
+    "@type": "RuntimePlatform",
+    "name": "Passive Y",
+    "softwareVersion": "31"
+  }
+}
+</script>

--- a/data/ext/pending/issue-4575.ttl
+++ b/data/ext/pending/issue-4575.ttl
@@ -10,3 +10,10 @@
     :source <https://github.com/schemaorg/schemaorg/issues/4575> ;
     rdfs:comment "System software that manages computer hardware and software resources, and provides common services for computer programs." ;
     rdfs:subClassOf :SoftwareApplication .
+
+:RuntimePlatform a rdfs:Class ;
+    rdfs:label "RuntimePlatform" ;
+    :isPartOf <https://pending.schema.org> ;
+    :source <https://github.com/schemaorg/schemaorg/issues/4575> ;
+    rdfs:comment "Specialized software environment that provides the essential infrastructure, libraries, and services required to execute a program." ;
+    rdfs:subClassOf :SoftwareApplication .

--- a/data/schema.ttl
+++ b/data/schema.ttl
@@ -10423,8 +10423,8 @@ Unregistered or niche encoding and file formats can be indicated instead via the
 :runtimePlatform a rdf:Property ;
     rdfs:label "runtimePlatform" ;
     rdfs:comment "Runtime platform or script interpreter dependencies (example: Java v1, Python 2.3, .NET Framework 3.0)." ;
-    :domainIncludes :SoftwareSourceCode ;
-    :rangeIncludes :Text .
+    :domainIncludes :SoftwareSourceCode , :SoftwareApplication ;
+    :rangeIncludes :Text , :RuntimePlatform .
 
 :season a rdf:Property ;
     rdfs:label "season" ;
@@ -10480,7 +10480,7 @@ Unregistered or niche encoding and file formats can be indicated instead via the
     rdfs:comment "Component dependency requirements for application. This includes runtime environments and shared libraries that are not included in the application distribution package, but required to run the application (examples: DirectX, Java or .NET runtime)." ;
     :domainIncludes :SoftwareApplication ;
     :rangeIncludes :Text,
-        :URL .
+        :URL, :SoftwareApplication .
 
 :sponsor a rdf:Property ;
     rdfs:label "sponsor" ;


### PR DESCRIPTION
Added a RuntimePlatform subclass of SoftwareApplication
* `runtimePlatform` now accepts SoftwareApplication content.
* Added some example of Software with  `operatingSystem` and `softwareRequirements` fields. 