### PR TITLE
Fix the last Ruby test failures

### DIFF
--- a/data/ext/pending/issue-1045-examples.txt
+++ b/data/ext/pending/issue-1045-examples.txt
@@ -33,34 +33,3 @@ JSON:
 }
 </script>
 
-TYPES: #eg-0227 ReserveAction, LinkRole
-
-PRE-MARKUP:
-
-An article is available using AMP HTML.
-
-MICRODATA:
-
-Example is JSON-LD only.
-
-RDFA:
-
-Example is JSON-LD only.
-
-JSON:
-
-<script type="application/ld+json">
-{
- "@context": "https://schema.org/",
- "@type": "Article",
- "url": [
-   "http://www.example.com/article",
-   {
-     "@type": "LinkRole",
-     "url": "http://www.example.com/article-amp",
-     "linkRelationship": "amphtml"
-   }
- ]
-}
-</script>
-

--- a/data/ext/pending/issue-2564-examples.txt
+++ b/data/ext/pending/issue-2564-examples.txt
@@ -21,28 +21,34 @@ JSON:
   "@context": "https://schema.org/",
   "@graph": [
     {
-     "@context": "https://schema.org/",
-     "@type": "StatisticalVariable",
-     "@id": "Median_Height_Person_Female",
-     "name": "Median height of women",
-     "populationType": {"@id": "schema:Person"},
-     "measuredProperty": {"@id": "schema:height"},
-     "statType": {"@id": "schema:median"},
-     "gender": {"@id": "schema:Female"},
-     "numConstraints": 1,
-     "constrainingProperty": {"@id": "schema:gender"}
+      "@type": "StatisticalVariable",
+      "@id": "Median_Height_Person_Female",
+      "name": "Median height of women",
+      "description": "The median height of the female population.",
+      "populationType": {
+        "@id": "schema:Person"
+      },
+      "measuredProperty": {
+        "@id": "schema:height"
+      },
+      "statType": {
+        "@id": "schema:median"
+      }
     },
     {
-    "@context": "https://schema.org/",
-    "@id": "Observation_Median_Age_Person_Female_SanAntonio_TX_2014",
-    "@type": "Observation",
-    "name": "Median height of women in San Antonio, Texas in 2014",
-    "description": "An Observation of the StatisticalVariable Median_Height_Person_Female in location: San Antonio, Texas, for time period: 2014",
-    "variableMeasured": { "@id": "Median_Height_Person_Female" },
-    "observationAbout": { "@id": "https://www.wikidata.org/entity/Q975" },
-    "observationDate": "2014",
-    "value": 160,
-    "unitCode": "CMT"
+      "@type": "Observation",
+      "@id": "Observation_Median_Age_Person_Female_SanAntonio_TX_2014",
+      "name": "Median height of women in San Antonio, Texas in 2014",
+      "description": "An Observation of the StatisticalVariable Median_Height_Person_Female in location: San Antonio, Texas, for time period: 2014",
+      "variableMeasured": {
+        "@id": "Median_Height_Person_Female"
+      },
+      "observationAbout": {
+        "@id": "https://www.wikidata.org/entity/Q975"
+      },
+      "observationDate": "2014",
+      "value": 160,
+      "unitCode": "CMT"
     }
   ]
 }

--- a/data/ext/pending/issue-2564.ttl
+++ b/data/ext/pending/issue-2564.ttl
@@ -142,7 +142,7 @@ population, and does not imply that the population consists of people. For examp
     rdfs:label "observationDate" ;
     :domainIncludes :Observation ;
     :isPartOf <https://pending.schema.org> ;
-    :rangeIncludes :DateTime ;
+    :rangeIncludes :DateTime, :Date;
     :source <https://github.com/schemaorg/schemaorg/issues/2291> ;
     rdfs:comment "The observationDate of an [[Observation]]." .
 

--- a/data/pending-failures.txt
+++ b/data/pending-failures.txt
@@ -1,3 +1,0 @@
-rspec ./spec/examples_spec.rb:1239 # Examples schemaorg-all-examples.txt[28475] - eg-0227 (jsonld)
-rspec ./spec/examples_spec.rb:1082 # Examples schemaorg-all-examples.txt[24482] - eg-0480 (jsonld)
-


### PR DESCRIPTION
Fix the last Ruby test failures (see https://github.com/schemaorg/schemaorg/issues/4541):

* Remove the [LinkRole](https://schema.org/LinkRole) example, which never worked, and was never supported.
* Fix the [Observation](https://schema.org/Observation) and [StatisticalVariable](https://schema.org/StatisticalVariable) test to validate.
* Update the [observationDate](https://schema.org/observationDate) field to accept an actual date, and in-so, accept the reasonable assumption of the test file.
* Emptied the allow-list for failing tests.
