### PR TITLE
Added owl equivalences for FIBO and OMG

### DIFF
--- a/data/ext/pending/issue-1797.ttl
+++ b/data/ext/pending/issue-1797.ttl
@@ -5,6 +5,8 @@
 @prefix unece: <http://unece.org/vocab#> .
 @prefix xml: <http://www.w3.org/XML/1998/namespace> .
 @prefix xsd: <http://www.w3.org/2001/XMLSchema#> .
+@prefix cmns-cls: <https://www.omg.org/spec/Commons/Classifiers/> .
+@prefix cmns-col: <https://www.omg.org/spec/Commons/Collections/> .
 
 :ProductGroup a rdfs:Class ;
     rdfs:label "ProductGroup" ;
@@ -13,6 +15,8 @@
     rdfs:comment """A ProductGroup represents a group of [[Product]]s that vary only in certain well-described ways, such as by [[size]], [[color]], [[material]] etc.
 
 While a ProductGroup itself is not directly offered for sale, the various varying products that it represents can be. The ProductGroup serves as a prototype or template, standing in for all of the products who have an [[isVariantOf]] relationship to it. As such, properties (including additional types) can be applied to the ProductGroup to represent characteristics shared by each of the (possibly very many) variants. Properties that reference a ProductGroup are not included in this mechanism; neither are the following specific properties [[variesBy]], [[hasVariant]], [[url]]. """ ;
+    rdfs:subClassOf cmns-cls:Classifier ;
+    rdfs:subClassOf cmns-col:Collection ;
     rdfs:subClassOf :Product .
 
 :inProductGroupWithID a rdf:Property ;

--- a/data/ext/pending/issue-2126.ttl
+++ b/data/ext/pending/issue-2126.ttl
@@ -5,6 +5,7 @@
 @prefix unece: <http://unece.org/vocab#> .
 @prefix xml: <http://www.w3.org/XML/1998/namespace> .
 @prefix xsd: <http://www.w3.org/2001/XMLSchema#> .
+@prefix cmns-id: <https://www.omg.org/spec/Commons/Identifiers/> .
 
 :nsn a rdf:Property ;
     rdfs:label "nsn" ;
@@ -13,6 +14,7 @@
     :rangeIncludes :Text ;
     :source <https://github.com/schemaorg/schemaorg/issues/2126> ;
     owl:equivalentProperty unece:nSNId ;
+    rdfs:subPropertyOf cmns-id:identifiedBy ;
     rdfs:comment "Indicates the [NATO stock number](https://en.wikipedia.org/wiki/NATO_Stock_Number) (nsn) of a [[Product]]. " ;
     rdfs:subPropertyOf :identifier .
 

--- a/data/ext/pending/issue-3230.ttl
+++ b/data/ext/pending/issue-3230.ttl
@@ -1,15 +1,19 @@
 @prefix : <https://schema.org/> .
+@prefix cmns-cls: <https://www.omg.org/spec/Commons/Classifiers/> .
 @prefix owl: <http://www.w3.org/2002/07/owl#> .
 @prefix rdf: <http://www.w3.org/1999/02/22-rdf-syntax-ns#> .
 @prefix rdfs: <http://www.w3.org/2000/01/rdf-schema#> .
+@prefix unece: <http://unece.org/vocab#> .
 @prefix xml: <http://www.w3.org/XML/1998/namespace> .
 @prefix xsd: <http://www.w3.org/2001/XMLSchema#> .
-@prefix unece: <http://unece.org/vocab#> .
+@prefix fibo-fnd-arr-doc: <https://spec.edmcouncil.org/fibo/ontology/FND/Arrangements/Documents/> .
+@prefix fibo-fnd-arr-reg: <https://spec.edmcouncil.org/fibo/ontology/FND/Arrangements/Registration/> .
 
 :Certification a rdfs:Class ;
   rdfs:label "Certification" ;
     :isPartOf <https://pending.schema.org> ;
     :source <https://github.com/schemaorg/schemaorg/issues/3230> ;
+    rdfs:subClassOf fibo-fnd-arr-doc:Certificate ;
     owl:equivalentClass unece:SpecifiedCertificate ;
     rdfs:comment """A Certification is an official and authoritative statement about a subject, for example a product, service, person, or organization. A certification is typically issued by an indendent certification body, for example a professional organization or government. It formally attests certain characteristics about the subject, for example Organizations can be ISO certified, Food products can be certified Organic or Vegan, a Person can be a certified professional, a Place can be certified for food processing. There are certifications for many domains: regulatory, organizational, recycling, food, efficiency, educational, ecological, etc. A certification is a form of credential, as are accreditations and licenses. Mapped from the [gs1:CertificationDetails](https://www.gs1.org/voc/CertificationDetails) class in the GS1 Web Vocabulary.""" ;
     rdfs:subClassOf :CreativeWork .
@@ -20,6 +24,7 @@
     :rangeIncludes :Date,
         :DateTime ;
     :source <https://github.com/schemaorg/schemaorg/issues/3230> ;
+    owl:equivalentProperty unece:InspectionDateTime ;
     rdfs:comment "Date when a certification was last audited. See also  [gs1:certificationAuditDate](https://www.gs1.org/voc/certificationAuditDate)." .
 
 :certificationIdentification a rdf:Property ;
@@ -29,6 +34,8 @@
     :rangeIncludes :DefinedTerm,
         :Text ;
     :source <https://github.com/schemaorg/schemaorg/issues/3230> ;
+    owl:equivalentProperty unece:CertificateIdentifier ;
+    rdfs:subPropertyOf fibo-fnd-arr-reg:hasRegistrationIdentifier ;
     rdfs:comment "Identifier of a certification instance (as registered with an independent certification body). Typically this identifier can be used to consult and verify the certification instance. See also [gs1:certificationIdentification](https://www.gs1.org/voc/certificationIdentification)." .
 
 :certificationRating a rdf:Property ;
@@ -74,6 +81,9 @@
      :Place;
   :rangeIncludes :Certification;
   :source <https://github.com/schemaorg/schemaorg/issues/3230> ;
+  owl:equivalentProperty unece:ApplicableCertificate ;
+  rdfs:subPropertyOf cmns-cls:isClassifiedBy ;
+  rdfs:subPropertyOf fibo-fnd-arr-doc:isReferencedIn ;
   rdfs:comment "Certification information about a product, organization, service, place, or person." .
 
 

--- a/data/ext/pending/issue-991.ttl
+++ b/data/ext/pending/issue-991.ttl
@@ -6,9 +6,9 @@
 @prefix xml: <http://www.w3.org/XML/1998/namespace> .
 @prefix xsd: <http://www.w3.org/2001/XMLSchema#> .
 
-
 :countryOfLastProcessing a rdf:Property ;
     rdfs:label "countryOfLastProcessing" ;
+    owl:equivalentProperty unece:ProcessingCountry ;
     :domainIncludes :Product ;
     :isPartOf <https://pending.schema.org> ;
     :rangeIncludes :CountryCode ;
@@ -18,6 +18,7 @@
 
 :countryOfAssembly a rdf:Property ;
     rdfs:label "countryOfAssembly" ;
+    owl:equivalentProperty unece:finalAssemblyCountry ;
     :domainIncludes :Product ;
     :isPartOf <https://pending.schema.org> ;
     :rangeIncludes :CountryCode ;

--- a/data/schema.ttl
+++ b/data/schema.ttl
@@ -1,13 +1,47 @@
 @prefix : <https://schema.org/> .
+@prefix cmns-cls: <https://www.omg.org/spec/Commons/Classifiers/> .
+@prefix cmns-col: <https://www.omg.org/spec/Commons/Collections/> .
+@prefix cmns-dt: <https://www.omg.org/spec/Commons/DatesAndTimes/> .
+@prefix cmns-ge: <https://www.omg.org/spec/Commons/GeopoliticalEntities/> .
+@prefix cmns-id: <https://www.omg.org/spec/Commons/Identifiers/> .
+@prefix cmns-loc: <https://www.omg.org/spec/Commons/Locations/> .
+@prefix cmns-q: <https://www.omg.org/spec/Commons/Quantities/> .
+@prefix cmns-txt: <https://www.omg.org/spec/Commons/Text/> .
 @prefix dc: <http://purl.org/dc/terms/> .
 @prefix dcat: <http://www.w3.org/ns/dcat#> .
 @prefix dcmitype: <http://purl.org/dc/dcmitype/> .
+@prefix fibo-be-corp-corp: <https://spec.edmcouncil.org/fibo/ontology/BE/Corporations/Corporations/> .
+@prefix fibo-be-ge-ge: <https://spec.edmcouncil.org/fibo/ontology/BE/GovernmentEntities/GovernmentEntities/> .
+@prefix fibo-be-le-lp: <https://spec.edmcouncil.org/fibo/ontology/BE/LegalEntities/LegalPersons/> .
+@prefix fibo-be-le-cb: <https://spec.edmcouncil.org/fibo/ontology/BE/LegalEntities/CorporateBodies/> .
+@prefix fibo-be-nfp-nfp: <https://spec.edmcouncil.org/fibo/ontology/BE/NotForProfitOrganizations/NotForProfitOrganizations/> .
+@prefix fibo-be-oac-cctl: <https://spec.edmcouncil.org/fibo/ontology/BE/OwnershipAndControl/CorporateControl/> .
+@prefix fibo-fbc-dae-dbt: <https://spec.edmcouncil.org/fibo/ontology/FBC/DebtAndEquities/Debt/> .
+@prefix fibo-fbc-pas-fpas: <https://spec.edmcouncil.org/fibo/ontology/FBC/ProductsAndServices/FinancialProductsAndServices/> .
+@prefix fibo-fnd-acc-cur: <https://spec.edmcouncil.org/fibo/ontology/FND/Accounting/CurrencyAmount/> .
+@prefix fibo-fnd-agr-ctr: <https://spec.edmcouncil.org/fibo/ontology/FND/Agreements/Contracts/> .
+@prefix fibo-fnd-dt-oc: <https://spec.edmcouncil.org/fibo/ontology/FND/DatesAndTimes/Occurrences/> .
+@prefix fibo-fnd-arr-doc: <https://spec.edmcouncil.org/fibo/ontology/FND/Arrangements/Documents/> .
+@prefix fibo-fnd-arr-lif: <https://spec.edmcouncil.org/fibo/ontology/FND/Arrangements/Lifecycles/> .
+@prefix fibo-fnd-org-org: <https://spec.edmcouncil.org/fibo/ontology/FND/Organizations/Organizations/> .
+@prefix fibo-fnd-org-org: <https://spec.edmcouncil.org/fibo/ontology/FND/Organizations/Organizations/> .
+@prefix fibo-fnd-pas-pas: <https://spec.edmcouncil.org/fibo/ontology/FND/ProductsAndServices/ProductsAndServices/> .
+@prefix fibo-fnd-plc-adr: <https://spec.edmcouncil.org/fibo/ontology/FND/Places/Addresses/> .
+@prefix fibo-fnd-plc-fac: <https://spec.edmcouncil.org/fibo/ontology/FND/Places/Facilities/> .
+@prefix fibo-fnd-plc-loc: <https://spec.edmcouncil.org/fibo/ontology/FND/Places/Locations/> .
+@prefix fibo-fnd-pty-pty: <https://spec.edmcouncil.org/fibo/ontology/FND/Parties/Parties/> .
+@prefix fibo-fnd-rel-rel: <https://spec.edmcouncil.org/fibo/ontology/FND/Relations/Relations/> .
+@prefix fibo-pay-ps-ps: <https://spec.edmcouncil.org/fibo/ontology/PAY/PaymentServices/PaymentServices/> .
 @prefix foaf: <http://xmlns.com/foaf/0.1/> .
+@prefix gleif-L1: <https://www.gleif.org/ontology/L1/> .
+@prefix lcc-cr: <https://www.omg.org/spec/LCC/Countries/CountryRepresentation/> .
 @prefix owl: <http://www.w3.org/2002/07/owl#> .
 @prefix rdf: <http://www.w3.org/1999/02/22-rdf-syntax-ns#> .
 @prefix rdfs: <http://www.w3.org/2000/01/rdf-schema#> .
-@prefix void: <http://rdfs.org/ns/void#> .
+@prefix skos: <http://www.w3.org/2004/02/skos/core#> .
 @prefix unece: <http://unece.org/vocab#> .
+@prefix void: <http://rdfs.org/ns/void#> .
+
 
 :AMRadioChannel a rdfs:Class ;
     rdfs:label "AMRadioChannel" ;
@@ -81,6 +115,7 @@ See also the <a href="/docs/hotels.html">dedicated document on the use of schema
 :AdministrativeArea a rdfs:Class ;
     rdfs:label "AdministrativeArea" ;
     rdfs:comment "A geographical region, typically under the jurisdiction of a particular government." ;
+    owl:equivalentClass cmns-ge:Subdivision ;
     rdfs:subClassOf :Place .
 
 :AdultEntertainment a rdfs:Class ;
@@ -116,7 +151,6 @@ See also the <a href="/docs/hotels.html">dedicated document on the use of schema
 :AlignmentObject a rdfs:Class ;
     rdfs:label "AlignmentObject" ;
     rdfs:comment """An intangible item that describes an alignment between a learning resource and a node in an educational framework.
-
 Should not be used where the nature of the alignment can be described using a simple property, for example to express that a resource [[teaches]] or [[assesses]] a competency.""" ;
     rdfs:subClassOf :Intangible ;
     :contributor <https://schema.org/docs/collab/LRMIClass> .
@@ -269,6 +303,7 @@ Should not be used where the nature of the alignment can be described using a si
 :BankAccount a rdfs:Class ;
     rdfs:label "BankAccount" ;
     rdfs:comment "A product or service offered by a bank whereby one may deposit, withdraw or transfer money and in some cases be paid interest." ;
+    owl:equivalentClass fibo-fbc-pas-fpas:BankAccount ;
     rdfs:subClassOf :FinancialProduct ;
     :contributor <https://schema.org/docs/collab/FIBO> .
 
@@ -392,6 +427,8 @@ See also the <a href="/docs/hotels.html">dedicated document on the use of schema
     rdfs:label "Brand" ;
     rdfs:comment "A brand is a name used by an organization or business person for labeling a product, product group, or similar." ;
     rdfs:subClassOf :Intangible ;
+    rdfs:subClassOf cmns-cls:Classifier ;
+    owl:equivalentClass unece:BrandName ;
     :contributor <https://blog.schema.org/2012/11/08/good-relations-and-schema-org/> .
 
 :BreadcrumbList a rdfs:Class ;
@@ -590,6 +627,7 @@ See also the dedicated [document on the use of schema.org for marking up hotels 
 :City a rdfs:Class ;
     rdfs:label "City" ;
     rdfs:comment "A city or town." ;
+    owl:equivalentClass fibo-fnd-plc-loc:Municipality ;
     rdfs:subClassOf :AdministrativeArea .
 
 :CityHall a rdfs:Class ;
@@ -693,6 +731,8 @@ See also the dedicated [document on the use of schema.org for marking up hotels 
 :ContactPoint a rdfs:Class ;
     rdfs:label "ContactPoint" ;
     rdfs:comment "A contact point&#x2014;for example, a Customer Complaints department." ;
+    owl:equivalentClass fibo-fnd-org-org:ContactPoint ;
+    owl:equivalentClass <http://www.w3.org/2006/vcard/ns#VCard> ;
     rdfs:subClassOf :StructuredValue .
 
 :ContactPointOption a rdfs:Class ;
@@ -703,6 +743,7 @@ See also the dedicated [document on the use of schema.org for marking up hotels 
 :Continent a rdfs:Class ;
     rdfs:label "Continent" ;
     rdfs:comment "One of the continents (for example, Europe or Africa)." ;
+    owl:equivalentClass lcc-cr:Continent ;
     rdfs:subClassOf :Landform .
 
 :ControlAction a rdfs:Class ;
@@ -728,11 +769,13 @@ See also the dedicated [document on the use of schema.org for marking up hotels 
 :Cooperative a rdfs:Class ;
     rdfs:label "Cooperative" ;
     rdfs:comment "An organization that is a joint project of multiple organizations or persons." ;
+    owl:equivalentClass fibo-be-le-cb:CooperativeSociety ;
     rdfs:subClassOf :Organization .
 
 :Corporation a rdfs:Class ;
     rdfs:label "Corporation" ;
     rdfs:comment "Organization: A business corporation." ;
+    owl:equivalentClass fibo-be-corp-corp:Corporation ;
     rdfs:subClassOf :Organization ;
     :contributor <https://schema.org/docs/collab/rNews> .
 
@@ -740,6 +783,8 @@ See also the dedicated [document on the use of schema.org for marking up hotels 
     rdfs:label "Country" ;
     rdfs:comment "A country." ;
     owl:equivalentClass unece:Country ;
+    owl:equivalentClass lcc-cr:Country ;
+    rdfs:subClassOf cmns-ge:GeopoliticalEntity ;
     rdfs:subClassOf :AdministrativeArea .
 
 :Course a rdfs:Class ;
@@ -851,11 +896,13 @@ See also the dedicated [document on the use of schema.org for marking up hotels 
 :Date a rdfs:Class,
         :DataType ;
     rdfs:label "Date" ;
+    owl:equivalentClass cmns-dt:Date ;
     rdfs:comment "A date value in [ISO 8601 date format](http://en.wikipedia.org/wiki/ISO_8601)." .
 
 :DateTime a rdfs:Class,
         :DataType ;
     rdfs:label "DateTime" ;
+    owl:equivalentClass cmns-dt:DateTime ;
     rdfs:comment "A combination of date and time of day in the form [-]CCYY-MM-DDThh:mm:ss[Z|(+|-)hh:mm] (see Chapter 5.4 of ISO 8601)." .
 
 :DatedMoneySpecification a rdfs:Class ;
@@ -928,6 +975,7 @@ Region = state, canton, prefecture, autonomous community...
     rdfs:comment """A delivery method is a standardized procedure for transferring the product or service to the destination of fulfillment chosen by the customer. Delivery methods are characterized by the means of transportation used, and by the organization or group that is the contracting party for the sending organization or person.\\n\\nCommonly used values:\\n\\n* http://purl.org/goodrelations/v1#DeliveryModeDirectDownload\\n* http://purl.org/goodrelations/v1#DeliveryModeFreight\\n* http://purl.org/goodrelations/v1#DeliveryModeMail\\n* http://purl.org/goodrelations/v1#DeliveryModeOwnFleet\\n* http://purl.org/goodrelations/v1#DeliveryModePickUp\\n* http://purl.org/goodrelations/v1#DHL\\n* http://purl.org/goodrelations/v1#FederalExpress\\n* http://purl.org/goodrelations/v1#UPS
         """ ;
     rdfs:subClassOf :Enumeration ;
+    owl:equivalentClass unece:TransportMethod ;
     :contributor <https://blog.schema.org/2012/11/08/good-relations-and-schema-org/> .
 
 :DeliveryTimeSettings a rdfs:Class ;
@@ -940,6 +988,7 @@ Region = state, canton, prefecture, autonomous community...
     rdfs:label "Demand" ;
     rdfs:comment "A demand entity represents the public, not necessarily binding, not necessarily exclusive, announcement by an organization or person to seek a certain type of goods or services. For describing demand using this type, the very same properties used for Offer apply." ;
     rdfs:subClassOf :Intangible ;
+    owl:equivalentClass unece:RequestForQuotation ;
     :contributor <https://blog.schema.org/2012/11/08/good-relations-and-schema-org/> .
 
 :Dentist a rdfs:Class ;
@@ -968,6 +1017,8 @@ Region = state, canton, prefecture, autonomous community...
 :DigitalDocument a rdfs:Class ;
     rdfs:label "DigitalDocument" ;
     rdfs:comment "An electronic file or document." ;
+    rdfs:subClassOf fibo-fnd-arr-doc:Document ;
+    owl:equivalentClass unece:ElectronicDocument ;
     rdfs:subClassOf :CreativeWork .
 
 :DigitalDocumentPermission a rdfs:Class ;
@@ -1045,6 +1096,7 @@ Region = state, canton, prefecture, autonomous community...
 :Duration a rdfs:Class ;
     rdfs:label "Duration" ;
     rdfs:comment "Quantity: Duration (use [ISO 8601 duration format](http://en.wikipedia.org/wiki/ISO_8601))." ;
+    owl:equivalentClass cmns-dt:Duration ;
     rdfs:subClassOf :Quantity .
 
 :EatAction a rdfs:Class ;
@@ -1168,6 +1220,7 @@ endorsement rating is particularly useful in the absence of numeric scales as it
     rdfs:label "Event" ;
     rdfs:comment "An event happening at a certain time and location, such as a concert, lecture, or festival. Ticketing information may be added via the [[offers]] property. Repeated events may be structured as separate Event objects." ;
     rdfs:subClassOf :Thing ;
+    owl:equivalentClass fibo-fnd-dt-oc:Occurrence ;
     owl:equivalentClass dcmitype:Event .
 
 :EventReservation a rdfs:Class ;
@@ -1357,6 +1410,7 @@ endorsement rating is particularly useful in the absence of numeric scales as it
     rdfs:label "GeoCoordinates" ;
     rdfs:comment "The geographic coordinates of a place or event." ;
     owl:equivalentClass unece:GeographicalCoordinate ;
+    owl:equivalentClass cmns-loc:GeographicCoordinate ;
     rdfs:subClassOf :StructuredValue .
 
 :GeoShape a rdfs:Class ;
@@ -1571,6 +1625,8 @@ See also the <a href="/docs/hotels.html">dedicated document on the use of schema
     rdfs:label "IndividualProduct" ;
     rdfs:comment "A single, identifiable product instance (e.g. a laptop with a particular serial number)." ;
     rdfs:subClassOf :Product ;
+    owl:equivalentClass unece:SpecifiedTradeProduct ;
+    owl:disjointWith :ProductModel ;
     :contributor <https://blog.schema.org/2012/11/08/good-relations-and-schema-org/> .
 
 :InformAction a rdfs:Class ;
@@ -1632,6 +1688,8 @@ See also the <a href="/docs/hotels.html">dedicated document on the use of schema
 :Invoice a rdfs:Class ;
     rdfs:label "Invoice" ;
     rdfs:comment "A statement of the money due for goods or services; a bill." ;
+    owl:equivalentClass unece:Invoice ;
+    rdfs:subClassOf fibo-fnd-arr-doc:LegalDocument ;
     rdfs:subClassOf :Intangible .
 
 :ItemAvailability a rdfs:Class ;
@@ -2026,6 +2084,7 @@ See also the <a href="/docs/hotels.html">dedicated document on the use of schema
 :NGO a rdfs:Class ;
     rdfs:label "NGO" ;
     rdfs:comment "Organization: Non-governmental Organization." ;
+    owl:equivalentClass fibo-be-nfp-nfp:NonGovernmentalOrganization ;
     rdfs:subClassOf :Organization .
 
 :NailSalon a rdfs:Class ;
@@ -2082,6 +2141,8 @@ A more detailed overview of [schema.org News markup](/docs/news.html) is also av
 :Offer a rdfs:Class ;
     rdfs:label "Offer" ;
     rdfs:comment "An offer to transfer some rights to an item or to provide a service — for example, an offer to sell tickets to an event, to rent the DVD of a movie, to stream a TV show over the internet, to repair a motorcycle, or to loan a book.\\n\\nNote: As the [[businessFunction]] property, which identifies the form of offer (e.g. sell, lease, repair, dispose), defaults to http://purl.org/goodrelations/v1#Sell; an Offer without a defined businessFunction value can be assumed to be an offer to sell.\\n\\nFor [GTIN](http://www.gs1.org/barcodes/technical/idkeys/gtin)-related fields, see [Check Digit calculator](http://www.gs1.org/barcodes/support/check_digit_calculator) and [validation guide](http://www.gs1us.org/resources/standards/gtin-validation-guide) from [GS1](http://www.gs1.org/)." ;
+    owl:equivalentClass fibo-fnd-pas-pas:Offer ;
+    owl:equivalentClass unece:Offer ;
     rdfs:subClassOf :Intangible ;
     :contributor <https://schema.org/docs/collab/GoodRelationsTerms> .
 
@@ -2133,6 +2194,8 @@ The place is __open__ if the [[opens]] property is specified, and __closed__ oth
 :Order a rdfs:Class ;
     rdfs:label "Order" ;
     rdfs:comment "An order is a confirmation of a transaction (a receipt), which can contain multiple line items, each represented by an Offer that has been accepted by the customer." ;
+    owl:equivalentClass unece:Order ;
+    rdfs:subClassOf fibo-fnd-arr-doc:LegalDocument ;
     rdfs:subClassOf :Intangible .
 
 :OrderAction a rdfs:Class ;
@@ -2154,6 +2217,7 @@ The place is __open__ if the [[opens]] property is specified, and __closed__ oth
 :Organization a rdfs:Class ;
     rdfs:label "Organization" ;
     rdfs:comment "An organization such as a school, NGO, corporation, club, etc." ;
+    owl:equivalentClass fibo-fnd-org-org:Organization ;
     rdfs:subClassOf :Thing .
 
 :OrganizationRole a rdfs:Class ;
@@ -2236,6 +2300,7 @@ The place is __open__ if the [[opens]] property is specified, and __closed__ oth
     rdfs:comment """A payment method is a standardized procedure for transferring the monetary amount for a purchase. Payment methods are characterized by the legal and technical structures used, and by the organization or group carrying out the transaction. The following legacy values should be accepted: \\n\\n* http://purl.org/goodrelations/v1#ByBankTransferInAdvance\\n* http://purl.org/goodrelations/v1#ByInvoice\\n* http://purl.org/goodrelations/v1#Cash\\n* http://purl.org/goodrelations/v1#CheckInAdvance\\n* http://purl.org/goodrelations/v1#COD\\n* http://purl.org/goodrelations/v1#DirectDebit\\n* http://purl.org/goodrelations/v1#GoogleCheckout\\n* http://purl.org/goodrelations/v1#PayPal\\n* http://purl.org/goodrelations/v1#PaySwarm\\n\\nStructured values, or [UNCE payment means](https://vocabulary.uncefact.org/PaymentMeans) are recommended or for newer annotations.""" ;
     rdfs:subClassOf :Intangible ;
     owl:equivalentClass unece:PaymentMeans ;
+    owl:equivalentClass fibo-fbc-pas-fpas:PaymentMechanism ;
     :contributor <https://blog.schema.org/2012/11/08/good-relations-and-schema-org/> ;
     :source <https://github.com/schemaorg/schemaorg/issues/3537> .
 
@@ -2244,6 +2309,7 @@ The place is __open__ if the [[opens]] property is specified, and __closed__ oth
     rdfs:comment "A Service to transfer funds from a person or organization to a beneficiary person or organization." ;
     rdfs:subClassOf :FinancialProduct,
         :PaymentMethod ;
+    owl:equivalentClass fibo-pay-ps-ps:PaymentService ;
     :contributor <https://schema.org/docs/collab/FIBO> .
 
 :PaymentStatusType a rdfs:Class ;
@@ -2324,6 +2390,7 @@ The place is __open__ if the [[opens]] property is specified, and __closed__ oth
 :Place a rdfs:Class ;
     rdfs:label "Place" ;
     rdfs:comment "Entities that have a somewhat fixed, physical extension." ;
+    owl:equivalentClass cmns-loc:Location ;
     rdfs:subClassOf :Thing .
 
 :PlaceOfWorship a rdfs:Class ;
@@ -2377,6 +2444,8 @@ The place is __open__ if the [[opens]] property is specified, and __closed__ oth
     rdfs:label "PostalAddress" ;
     rdfs:comment "The mailing address." ;
     owl:EquivalentClass unece:TradeAddress ;
+    owl:EquivalentClass cmns-loc:Address ;
+    owl:equivalentClass fibo-fnd-plc-adr:PostalAddress ;
     rdfs:subClassOf :ContactPoint .
 
 :PostalCodeRangeSpecification a rdfs:Class ;
@@ -2410,12 +2479,14 @@ The place is __open__ if the [[opens]] property is specified, and __closed__ oth
     rdfs:label "PriceSpecification" ;
     rdfs:comment "A structured value representing a price or price range. Typically, only the subclasses of this type are used for markup. It is recommended to use [[MonetaryAmount]] to describe independent amounts of money such as a salary, credit card limits, etc." ;
     rdfs:subClassOf :StructuredValue ;
+    owl:equivalentClass fibo-fnd-pas-pas:Price ;
     :contributor <https://blog.schema.org/2012/11/08/good-relations-and-schema-org/> .
 
 :Product a rdfs:Class ;
     rdfs:label "Product" ;
     rdfs:comment "Any offered product or service. For example: a pair of shoes; a concert ticket; the rental of a car; a haircut; or an episode of a TV show streamed online." ;
     rdfs:subClassOf :Thing ;
+    owl:equivalentClass fibo-fnd-pas-pas:Product ;
     owl:equivalentClass unece:TradeProduct ;
     :contributor <https://schema.org/docs/collab/GoodRelationsTerms> .
 
@@ -3373,6 +3444,7 @@ See also the <a href="/docs/hotels.html">dedicated document on the use of schema
     rdfs:label "WarrantyPromise" ;
     rdfs:comment "A structured value representing the duration and scope of services that will be provided to a customer free of charge in case of a defect or malfunction of a product." ;
     rdfs:subClassOf :StructuredValue ;
+    rdfs:subClassOf fibo-fnd-agr-ctr:MutualContractualAgreement ;
     :contributor <https://blog.schema.org/2012/11/08/good-relations-and-schema-org/> .
 
 :WarrantyScope a rdfs:Class ;
@@ -4182,12 +4254,14 @@ See also the <a href="/docs/hotels.html">dedicated document on the use of schema
 :addressLocality a rdf:Property ;
     rdfs:label "addressLocality" ;
     rdfs:comment "The locality in which the street address is, and which is in the region. For example, Mountain View." ;
+    owl:equivalentProperty fibo-fnd-plc-adr:hasMunicipality ;
     :domainIncludes :PostalAddress ;
     :rangeIncludes :Text .
 
 :addressRegion a rdf:Property ;
     rdfs:label "addressRegion" ;
     rdfs:comment "The region in which the locality is, and which is in the country. For example, California or another appropriate first-level [Administrative division](https://en.wikipedia.org/wiki/List_of_administrative_divisions_by_country)." ;
+    owl:equivalentProperty fibo-fnd-plc-adr:hasCountrySubdivision ;
     :domainIncludes :DefinedRegion,
         :PostalAddress ;
     :rangeIncludes :Text, :AdministrativeArea ;
@@ -4649,6 +4723,7 @@ See also the <a href="/docs/hotels.html">dedicated document on the use of schema
 :billingAddress a rdf:Property ;
     rdfs:label "billingAddress" ;
     rdfs:comment "The billing address for the order." ;
+    owl:equivalentProperty unece:BillingAddress ;
     :domainIncludes :Order ;
     :rangeIncludes :PostalAddress .
 
@@ -4760,6 +4835,7 @@ See also the <a href="/docs/hotels.html">dedicated document on the use of schema
     rdfs:label "brand" ;
     rdfs:comment "The brand(s) associated with a product or service, or the brand(s) maintained by an organization or business person." ;
     owl:equivalentProperty unece:brandName ;
+    rdfs:subPropertyOf fibo-fnd-rel-rel:hasDesignation ;
     :domainIncludes :Organization,
         :Person,
         :Product,
@@ -5159,6 +5235,7 @@ See also the <a href="/docs/hotels.html">dedicated document on the use of schema
 :contactPoints a rdf:Property ;
     rdfs:label "contactPoints" ;
     rdfs:comment "A contact point for a person or organization." ;
+    owl:equivalentProperty fibo-fnd-org-org:hasContactPoint ;
     :domainIncludes :Organization,
         :Person ;
     :rangeIncludes :ContactPoint ;
@@ -5338,6 +5415,7 @@ In the case of products, the country of origin of the product. The exact interpr
 :currency a rdf:Property ;
     rdfs:label "currency" ;
     rdfs:comment "The currency in which the monetary amount is expressed.\\n\\nUse standard formats: [ISO 4217 currency format](http://en.wikipedia.org/wiki/ISO_4217), e.g. \"USD\"; [Ticker symbol](https://en.wikipedia.org/wiki/List_of_cryptocurrencies) for cryptocurrencies, e.g. \"BTC\"; well known names for [Local Exchange Trading Systems](https://en.wikipedia.org/wiki/Local_exchange_trading_system) (LETS) and other currency types, e.g. \"Ithaca HOUR\"." ;
+    owl:equivalentProperty fibo-fnd-acc-cur:hasCurrency ;
     :domainIncludes :DatedMoneySpecification,
         :MonetaryAmount,
         :MonetaryAmountDistribution ;
@@ -5482,6 +5560,7 @@ Dateline summaries are oriented more towards human readers than towards automate
 :deliveryAddress a rdf:Property ;
     rdfs:label "deliveryAddress" ;
     rdfs:comment "Destination address." ;
+    owl:equivalentProperty unece:ShipToAddress ;
     :domainIncludes :ParcelDelivery ;
     :rangeIncludes :PostalAddress .
 
@@ -5719,6 +5798,7 @@ Dateline summaries are oriented more towards human readers than towards automate
 :durationOfWarranty a rdf:Property ;
     rdfs:label "durationOfWarranty" ;
     rdfs:comment "The duration of the warranty promise. Common unitCode values are ANN for year, MON for months, or DAY for days." ;
+    rdfs:subPropertyOf :duration ;
     :domainIncludes :WarrantyPromise ;
     :rangeIncludes :QuantitativeValue .
 
@@ -5865,6 +5945,7 @@ This property should not be used where the nature of the alignment can be descri
 :endDate a rdf:Property ;
     rdfs:label "endDate" ;
     rdfs:comment "The end date and time of the item (in [ISO 8601 date format](http://en.wikipedia.org/wiki/ISO_8601))." ;
+    owl:equivalentProperty cmns-dt:hasEndDate ;
     :domainIncludes :CreativeWorkSeason,
         :CreativeWorkSeries,
         :DatedMoneySpecification,
@@ -6373,6 +6454,7 @@ Typical unit code(s): MTK for square meter, FTK for square foot, or YDK for squa
 In the context of [[ShippingDeliveryTime]], Typical properties: minValue, maxValue, unitCode (d for DAY).  This is by common convention assumed to mean business days (if a unitCode is used, coded as \"d\"), i.e. only counting days when the business normally operates.
 
 In the context of [[ShippingService]], use the [[ServicePeriod]] format, that contains the same information in a structured form, with cut-off time, business days and duration.""" ;
+    rdfs:subPropertyOf :duration ;
     :domainIncludes :ShippingDeliveryTime ;
     :rangeIncludes :QuantitativeValue ;
     :source <https://github.com/schemaorg/schemaorg/issues/2506> .
@@ -6386,6 +6468,7 @@ In the context of [[ShippingService]], use the [[ServicePeriod]] format, that co
 :hasDeliveryMethod a rdf:Property ;
     rdfs:label "hasDeliveryMethod" ;
     rdfs:comment "Method used for delivery or shipping." ;
+    owl:equivalentProperty unece:TransportMethod ;
     :domainIncludes :DeliveryEvent,
         :ParcelDelivery ;
     :rangeIncludes :DeliveryMethod .
@@ -6700,6 +6783,7 @@ In the context of [[ShippingService]], use the [[ServicePeriod]] format, that co
 :isRelatedTo a rdf:Property ;
     rdfs:label "isRelatedTo" ;
     rdfs:comment "A pointer to another, somehow related product (or multiple products)." ;
+    owl:equivalentProperty unece:RelatedProduct ;
     :domainIncludes :Product,
         :Service ;
     :rangeIncludes :Product,
@@ -6708,6 +6792,7 @@ In the context of [[ShippingService]], use the [[ServicePeriod]] format, that co
 :isSimilarTo a rdf:Property ;
     rdfs:label "isSimilarTo" ;
     rdfs:comment "A pointer to another, functionally similar product (or multiple products)." ;
+    owl:equivalentProperty unece:SubstituteProduct ;
     :domainIncludes :Product,
         :Service ;
     :rangeIncludes :Product,
@@ -6724,6 +6809,8 @@ In the context of [[ShippingService]], use the [[ServicePeriod]] format, that co
 :isVariantOf a rdf:Property ;
     rdfs:label "isVariantOf" ;
     rdfs:comment "Indicates the kind of product that this is a variant of. In the case of [[ProductModel]], this is a pointer (from a ProductModel) to a base product from which this product is a variant. It is safe to infer that the variant inherits all product features from the base model, unless defined locally. This is not transitive. In the case of a [[ProductGroup]], the group description also serves as a template, representing a set of Products that vary on explicitly defined, specific dimensions only (so it defines both a set of variants, as well as which values distinguish amongst those variants). When used with [[ProductGroup]], this property can apply to any [[Product]] included in the group." ;
+    rdfs:subPropertyOf cmns-cls:exemplifies ;
+    rdfs:subPropertyOf skos:broader ;
     :domainIncludes :ProductModel ;
     :rangeIncludes :ProductModel .
 
@@ -6834,6 +6921,8 @@ In the context of [[ShippingService]], use the [[ServicePeriod]] format, that co
 :itemShipped a rdf:Property ;
     rdfs:label "itemShipped" ;
     rdfs:comment "Item(s) being shipped." ;
+    rdfs:subPropertyOf fibo-fnd-pas-pas:hasProduct ;
+    owl:equivalentProperty unece:IncludedConsignmentItem ;
     :domainIncludes :ParcelDelivery ;
     :rangeIncludes :Product .
 
@@ -6900,6 +6989,7 @@ In the context of [[ShippingService]], use the [[ServicePeriod]] format, that co
 :latitude a rdf:Property ;
     rdfs:label "latitude" ;
     rdfs:comment "The latitude of a location. For example ```37.42242``` ([WGS 84](https://en.wikipedia.org/wiki/World_Geodetic_System))." ;
+    rdfs:subPropertyOf cmns-loc:hasLatitude ;
     :domainIncludes :GeoCoordinates,
         :Place ;
     :rangeIncludes :Number,
@@ -6916,12 +7006,16 @@ In the context of [[ShippingService]], use the [[ServicePeriod]] format, that co
 :legalAddress a rdf:Property ;
      rdfs:label "legalAddress" ;
      rdfs:comment "The legal address of an organization which acts as the officially registered address used for legal and tax purposes. The legal address can be different from the place of operations of a business and other addresses can be part of an organization." ;
+     rdfs:subPropertyOf cmns-loc:hasAddress ;
+     owl:equivalentProperty fibo-fnd-plc-adr:hasRegisteredAddress ;
      :domainIncludes :Organization ;
      :rangeIncludes :PostalAddress .
 
 :legalName a rdf:Property ;
     rdfs:label "legalName" ;
     rdfs:comment "The official name of the organization, e.g. the registered company name." ;
+    owl:equivalentProperty fibo-fnd-rel-rel:hasLegalName ;
+    rdfs:subPropertyOf cmns-txt:hasName ;
     :domainIncludes :Organization ;
     :rangeIncludes :Text .
 
@@ -6935,6 +7029,8 @@ In the context of [[ShippingService]], use the [[ServicePeriod]] format, that co
     rdfs:label "leiCode" ;
     rdfs:comment "An organization identifier that uniquely identifies a legal entity as defined in ISO 17442." ;
     rdfs:subPropertyOf :identifier ;
+    owl:equivalentProperty fibo-be-le-lp:hasLegalEntityIdentifier ;
+    owl:equivalentProperty gleif-L1:hasLEI ;
     :contributor <https://schema.org/docs/collab/FIBO>,
         <https://schema.org/docs/collab/GLEIF> ;
     :domainIncludes :Organization ;
@@ -7029,6 +7125,7 @@ In the context of [[ShippingService]], use the [[ServicePeriod]] format, that co
 :longitude a rdf:Property ;
     rdfs:label "longitude" ;
     rdfs:comment "The longitude of a location. For example ```-122.08585``` ([WGS 84](https://en.wikipedia.org/wiki/World_Geodetic_System))." ;
+    rdfs:subPropertyOf cmns-loc:hasLongitude ;
     :domainIncludes :GeoCoordinates,
         :Place ;
     :rangeIncludes :Number,
@@ -7044,6 +7141,8 @@ In the context of [[ShippingService]], use the [[ServicePeriod]] format, that co
 :lowPrice a rdf:Property ;
     rdfs:label "lowPrice" ;
     rdfs:comment "The lowest price of all offers available.\\n\\nUsage guidelines:\\n\\n* Use values from 0123456789 (Unicode 'DIGIT ZERO' (U+0030) to 'DIGIT NINE' (U+0039)) rather than superficially similar Unicode symbols.\\n* Use '.' (Unicode 'FULL STOP' (U+002E)) rather than ',' to indicate a decimal point. Avoid using these symbols as a readability separator." ;
+    rdfs:subPropertyOf cmns-q:hasLowerBound ;
+    rdfs:subPropertyOf fibo-fnd-acc-cur:hasMonetaryAmount ;
     :domainIncludes :AggregateOffer ;
     :rangeIncludes :Number,
         :Text .
@@ -7072,6 +7171,7 @@ In the context of [[ShippingService]], use the [[ServicePeriod]] format, that co
     rdfs:label "manufacturer" ;
     rdfs:comment "The manufacturer of the product." ;
     owl:equivalentProperty unece:manufacturerParty ;
+    rdfs:subPropertyOf fibo-fnd-pas-pas:isProvisionedBy ;
     :domainIncludes :Product ;
     :rangeIncludes :Organization .
 
@@ -7098,12 +7198,15 @@ In the context of [[ShippingService]], use the [[ServicePeriod]] format, that co
 :maxPrice a rdf:Property ;
     rdfs:label "maxPrice" ;
     rdfs:comment "The highest price if the price is a range." ;
+    rdfs:subPropertyOf cmns-q:hasUpperBound ;
+    rdfs:subPropertyOf fibo-fnd-acc-cur:hasMonetaryAmount ;
     :domainIncludes :PriceSpecification ;
     :rangeIncludes :Number .
 
 :maxValue a rdf:Property ;
     rdfs:label "maxValue" ;
     rdfs:comment "The upper value of some characteristic or property." ;
+    rdfs:subPropertyOf cmns-q:hasUpperBound ;
     :domainIncludes :MonetaryAmount,
         :PropertyValue,
         :PropertyValueSpecification,
@@ -7113,6 +7216,7 @@ In the context of [[ShippingService]], use the [[ServicePeriod]] format, that co
 :maximumAttendeeCapacity a rdf:Property ;
     rdfs:label "maximumAttendeeCapacity" ;
     rdfs:comment "The total number of individuals that may attend an event or venue." ;
+    rdfs:subPropertyOf cmns-q:hasUpperBound ;
     :domainIncludes :Event,
         :Place ;
     :rangeIncludes :Integer .
@@ -7199,12 +7303,15 @@ In the context of [[ShippingService]], use the [[ServicePeriod]] format, that co
 :minPrice a rdf:Property ;
     rdfs:label "minPrice" ;
     rdfs:comment "The lowest price if the price is a range." ;
+    rdfs:subPropertyOf cmns-q:hasLowerBound ;
+    rdfs:subPropertyOf fibo-fnd-acc-cur:hasMonetaryAmount ;
     :domainIncludes :PriceSpecification ;
     :rangeIncludes :Number .
 
 :minValue a rdf:Property ;
     rdfs:label "minValue" ;
     rdfs:comment "The lower value of some characteristic or property." ;
+    rdfs:subPropertyOf cmns-q:hasLowerBound ;
     :domainIncludes :MonetaryAmount,
         :PropertyValue,
         :PropertyValueSpecification,
@@ -7214,6 +7321,8 @@ In the context of [[ShippingService]], use the [[ServicePeriod]] format, that co
 :minimumPaymentDue a rdf:Property ;
     rdfs:label "minimumPaymentDue" ;
     rdfs:comment "The minimum payment required at this time." ;
+    rdfs:subPropertyOf cmns-q:hasLowerBound ;
+    rdfs:subPropertyOf fibo-fnd-acc-cur:hasMonetaryAmount ;
     :domainIncludes :Invoice ;
     :rangeIncludes :MonetaryAmount,
         :PriceSpecification .
@@ -7221,6 +7330,8 @@ In the context of [[ShippingService]], use the [[ServicePeriod]] format, that co
 :model a rdf:Property ;
     rdfs:label "model" ;
     rdfs:comment "The model of the product. Use with the URL of a ProductModel or a textual representation of the model identifier. The URL of the ProductModel can be from an external source. It is recommended to additionally provide strong product identifiers via the gtin8/gtin13/gtin14 and mpn properties." ;
+    owl:equivalentProperty unece:ModelName ;
+    rdfs:subPropertyOf cmns-cls:isClassifiedBy ;
     :domainIncludes :Product ;
     :rangeIncludes :ProductModel,
         :Text .
@@ -7299,6 +7410,7 @@ In the context of [[ShippingService]], use the [[ServicePeriod]] format, that co
 :naics a rdf:Property ;
     rdfs:label "naics" ;
     rdfs:comment "The North American Industry Classification System (NAICS) code for a particular organization or business person." ;
+    rdfs:subPropertyOf cmns-cls:isClassifiedBy ;
     :domainIncludes :Organization,
         :Person ;
     :rangeIncludes :Text .
@@ -7307,6 +7419,7 @@ In the context of [[ShippingService]], use the [[ServicePeriod]] format, that co
     rdfs:label "name" ;
     rdfs:comment "The name of the item." ;
     rdfs:subPropertyOf rdfs:label ;
+    owl:equivalentProperty cmns-txt:hasName ;
     owl:equivalentProperty dc:title ;
     :domainIncludes :Thing ;
     :rangeIncludes :Text .
@@ -7559,6 +7672,8 @@ Note: for historical reasons, any textual label and formal code provided as a li
 :orderDate a rdf:Property ;
     rdfs:label "orderDate" ;
     rdfs:comment "Date order was placed." ;
+    owl:equivalentProperty unece:OrderDate ;
+    rdfs:subPropertyOf cmns-dt:hasDate ;
     :domainIncludes :Order ;
     :rangeIncludes :Date,
         :DateTime .
@@ -7573,6 +7688,7 @@ Note: for historical reasons, any textual label and formal code provided as a li
 :orderItemNumber a rdf:Property ;
     rdfs:label "orderItemNumber" ;
     rdfs:comment "The identifier of the order item." ;
+    owl:equivalentProperty unece:LineItemIdentifier ;
     :domainIncludes :OrderItem ;
     :rangeIncludes :Text .
 
@@ -7585,6 +7701,7 @@ Note: for historical reasons, any textual label and formal code provided as a li
 :orderNumber a rdf:Property ;
     rdfs:label "orderNumber" ;
     rdfs:comment "The identifier of the transaction." ;
+    owl:equivalentProperty unece:OrderIdentifier ;
     rdfs:subPropertyOf :identifier ;
     :domainIncludes :Order ;
     :rangeIncludes :Text .
@@ -7593,6 +7710,7 @@ Note: for historical reasons, any textual label and formal code provided as a li
     rdfs:label "orderQuantity" ;
     rdfs:comment "The number of the item ordered. If the property is not set, assume the quantity is one." ;
     owl:equivalentProperty unece:orderQuantity ;
+    rdfs:subPropertyOf cmns-q:hasQuantity ;
     :domainIncludes :OrderItem ;
     :rangeIncludes :Number,
         :QuantitativeValue .
@@ -7606,6 +7724,7 @@ Note: for historical reasons, any textual label and formal code provided as a li
 :orderedItem a rdf:Property ;
     rdfs:label "orderedItem" ;
     rdfs:comment "The item ordered." ;
+    rdfs:subPropertyOf fibo-fnd-pas-pas:hasProduct ;
     :domainIncludes :Order,
         :OrderItem ;
     :rangeIncludes :OrderItem,
@@ -7719,12 +7838,16 @@ Note: for historical reasons, any textual label and formal code provided as a li
 :partOfInvoice a rdf:Property ;
     rdfs:label "partOfInvoice" ;
     rdfs:comment "The order is being paid as part of the referenced Invoice." ;
+    rdfs:subPropertyOf fibo-fnd-arr-doc:isReferencedIn ;
+    rdfs:subPropertyOf cmns-col:isPartOf ;
     :domainIncludes :Order ;
     :rangeIncludes :Invoice .
 
 :partOfOrder a rdf:Property ;
     rdfs:label "partOfOrder" ;
     rdfs:comment "The overall order the items in this delivery were included in." ;
+    owl:equivalentProperty unece:ReferencedOrder ;
+    rdfs:subPropertyOf fibo-fnd-arr-doc:refersTo ;
     :domainIncludes :ParcelDelivery ;
     :rangeIncludes :Order .
 
@@ -7776,6 +7899,8 @@ Note: for historical reasons, any textual label and formal code provided as a li
 :paymentDue a rdf:Property ;
     rdfs:label "paymentDue" ;
     rdfs:comment "The date that payment is due." ;
+    owl:equivalentProperty unece:PaymentDueDate ;
+    rdfs:subPropertyOf fibo-fbc-dae-dbt:hasPaymentDueDate ;
     :domainIncludes :Invoice,
         :Order ;
     :rangeIncludes :DateTime ;
@@ -7784,6 +7909,8 @@ Note: for historical reasons, any textual label and formal code provided as a li
 :paymentMethod a rdf:Property ;
     rdfs:label "paymentMethod" ;
     rdfs:comment "The name of the credit card or other method of payment for the order." ;
+    rdfs:subPropertyOf fibo-fbc-pas-fpas:hasPaymentMechanism ;
+    owl:equivalentProperty unece:PaymentMeans ;
     :domainIncludes :Invoice,
         :Order ;
     :rangeIncludes :PaymentMethod,
@@ -7793,6 +7920,7 @@ Note: for historical reasons, any textual label and formal code provided as a li
 :paymentMethodId a rdf:Property ;
     rdfs:label "paymentMethodId" ;
     rdfs:comment "An identifier for the method of payment used (e.g. the last 4 digits of the credit card)." ;
+    owl:equivalentProperty unece:PaymentMeansID ;
     :domainIncludes :Invoice,
         :Order ;
     :rangeIncludes :Text .
@@ -7807,6 +7935,7 @@ Note: for historical reasons, any textual label and formal code provided as a li
 :paymentUrl a rdf:Property ;
     rdfs:label "paymentUrl" ;
     rdfs:comment "The URL for sending a payment." ;
+    rdfs:subPropertyOf cmns-loc:hasAddress ;
     :domainIncludes :Order ;
     :rangeIncludes :URL .
 
@@ -7949,11 +8078,13 @@ Note: for historical reasons, any textual label and formal code provided as a li
         :PostalAddress ;
     :rangeIncludes :Text ;
     owl:equivalentProperty unece:postcodeCode ;
+    owl:equivalentProperty fibo-fnd-plc-adr:hasPostalCode ;
     :source <https://github.com/schemaorg/schemaorg/issues/2506> .
 
 :postalCodeBegin a rdf:Property ;
     rdfs:label "postalCodeBegin" ;
     rdfs:comment "First postal code in a range (included)." ;
+    rdfs:subPropertyOf cmns-q:hasLowerBound ;
     :domainIncludes :PostalCodeRangeSpecification ;
     :rangeIncludes :Text ;
     :source <https://github.com/schemaorg/schemaorg/issues/2506> .
@@ -7962,6 +8093,7 @@ Note: for historical reasons, any textual label and formal code provided as a li
     rdfs:label "postalCodeEnd" ;
     rdfs:comment "Last postal code in the range (included). Needs to be after [[postalCodeBegin]]." ;
     :domainIncludes :PostalCodeRangeSpecification ;
+    rdfs:subPropertyOf cmns-q:hasUpperBound ;
     :rangeIncludes :Text ;
     :source <https://github.com/schemaorg/schemaorg/issues/2506> .
 
@@ -8014,6 +8146,8 @@ Note: for historical reasons, any textual label and formal code provided as a li
     rdfs:label "price" ;
     rdfs:comment """The offer price of a product, or of a price component when attached to PriceSpecification and its subtypes.\\n\\nUsage guidelines:\\n\\n* Use the [[priceCurrency]] property (with standard formats: [ISO 4217 currency format](http://en.wikipedia.org/wiki/ISO_4217), e.g. "USD"; [Ticker symbol](https://en.wikipedia.org/wiki/List_of_cryptocurrencies) for cryptocurrencies, e.g. "BTC"; well known names for [Local Exchange Trading Systems](https://en.wikipedia.org/wiki/Local_exchange_trading_system) (LETS) and other currency types, e.g. "Ithaca HOUR") instead of including [ambiguous symbols](http://en.wikipedia.org/wiki/Dollar_sign#Currencies_that_use_the_dollar_or_peso_sign) such as '$' in the value.\\n* Use '.' (Unicode 'FULL STOP' (U+002E)) rather than ',' to indicate a decimal point. Avoid using these symbols as a readability separator.\\n* Note that both [RDFa](http://www.w3.org/TR/xhtml-rdfa-primer/#using-the-content-attribute) and Microdata syntax allow the use of a "content=" attribute for publishing simple machine-readable values alongside more human-friendly formatting.\\n* Use values from 0123456789 (Unicode 'DIGIT ZERO' (U+0030) to 'DIGIT NINE' (U+0039)) rather than superficially similar Unicode symbols.
       """ ;
+    rdfs:subPropertyOf fibo-fnd-acc-cur:hasAmount ;
+    rdfs:subPropertyOf cmns-q:hasNumericValue ;
     :domainIncludes :DonateAction,
         :Offer,
         :PriceSpecification,
@@ -8031,6 +8165,7 @@ Note: for historical reasons, any textual label and formal code provided as a li
 :priceCurrency a rdf:Property ;
     rdfs:label "priceCurrency" ;
     rdfs:comment "The currency of the price, or a price component when attached to [[PriceSpecification]] and its subtypes.\\n\\nUse standard formats: [ISO 4217 currency format](http://en.wikipedia.org/wiki/ISO_4217), e.g. \"USD\"; [Ticker symbol](https://en.wikipedia.org/wiki/List_of_cryptocurrencies) for cryptocurrencies, e.g. \"BTC\"; well known names for [Local Exchange Trading Systems](https://en.wikipedia.org/wiki/Local_exchange_trading_system) (LETS) and other currency types, e.g. \"Ithaca HOUR\"." ;
+    rdfs:subPropertyOf fibo-fnd-acc-cur:hasCurrency ;
     :domainIncludes :DonateAction,
         :Offer,
         :PriceSpecification,
@@ -8057,13 +8192,17 @@ Note: for historical reasons, any textual label and formal code provided as a li
 
 :priceType a rdf:Property ;
     rdfs:label "priceType" ;
-    rdfs:comment "Defines the type of a price specified for an offered product, for example a list price, a (temporary) sale price or a manufacturer suggested retail price. If multiple prices are specified for an offer the [[priceType]] property can be used to identify the type of each such specified price. The value of priceType can be specified as a value from enumeration PriceTypeEnumeration or as a free form text string for price types that are not already predefined in PriceTypeEnumeration." ;
+    rdfs:comment "Defines the type of a price specified for an offered product, for example a list price, a (temporary) sale price or a manufacturer suggested retail price. If multiple prices are specified for an offer the [[priceType]] property can be used to identify the type of each such specified price. The value of priceType can be specified as a value from enumeration PriceTypeEnumeration or, a UN/EDIFACT 5387 code, or as a free form text string for price types that are not already predefined in PriceTypeEnumeration." ;
+    owl:equivalentProperty unece:PriceTypeCode ;
+    rdfs:subPropertyOf cmns-cls:isClassifiedBy ;
     :domainIncludes :UnitPriceSpecification ;
     :rangeIncludes :Text .
 
 :priceValidUntil a rdf:Property ;
     rdfs:label "priceValidUntil" ;
     rdfs:comment "The date after which the price is no longer available." ;
+    rdfs:subPropertyOf :endDate ;
+    owl:equivalentProperty unece:EffectiveEndDateTime ;
     :domainIncludes :Offer ;
     :rangeIncludes :Date .
 
@@ -8153,6 +8292,7 @@ Note: for historical reasons, any textual label and formal code provided as a li
 :productionDate a rdf:Property ;
     rdfs:label "productionDate" ;
     rdfs:comment "The date of production of the item, e.g. vehicle." ;
+    owl:equivalentProperty unece:ProductionDate ;
     :contributor <https://schema.org/docs/collab/Automotive_Ontology_Working_Group> ;
     :domainIncludes :Product,
         :Vehicle ;
@@ -8401,6 +8541,7 @@ While such policies are most typically expressed in natural language, sometimes 
 :releaseDate a rdf:Property ;
     rdfs:label "releaseDate" ;
     rdfs:comment "The release date of a product or product model. This can be used to distinguish the exact variant of a product." ;
+    owl:equivalentProperty unece:ProductAvailabilityDate ;
     :domainIncludes :Product ;
     :rangeIncludes :Date .
 
@@ -8776,18 +8917,21 @@ While such policies are most typically expressed in natural language, sometimes 
 :servicePhone a rdf:Property ;
     rdfs:label "servicePhone" ;
     rdfs:comment "The phone number to use to access the service." ;
+    rdfs:subPropertyOf cmns-loc:hasAddress ;
     :domainIncludes :ServiceChannel ;
     :rangeIncludes :ContactPoint .
 
 :servicePostalAddress a rdf:Property ;
     rdfs:label "servicePostalAddress" ;
     rdfs:comment "The address for accessing the service by mail." ;
+    rdfs:subPropertyOf cmns-loc:hasAddress ;
     :domainIncludes :ServiceChannel ;
     :rangeIncludes :PostalAddress .
 
 :serviceSmsNumber a rdf:Property ;
     rdfs:label "serviceSmsNumber" ;
     rdfs:comment "The number to access the service by text message." ;
+    rdfs:subPropertyOf cmns-loc:hasAddress ;
     :domainIncludes :ServiceChannel ;
     :rangeIncludes :ContactPoint .
 
@@ -8843,6 +8987,8 @@ While such policies are most typically expressed in natural language, sometimes 
 :shippingOrigin a rdf:Property ;
     rdfs:label "shippingOrigin" ;
     rdfs:comment "Indicates the origin of a shipment, i.e. where it should be coming from." ;
+    owl:equivalentProperty unece:DespatchLocation ;
+    rdfs:subPropertyOf cmns-loc:hasLocation ;
     :domainIncludes :OfferShippingDetails ;
     :rangeIncludes :DefinedRegion ;
     :source <https://github.com/schemaorg/schemaorg/issues/3122> .
@@ -8890,6 +9036,7 @@ While such policies are most typically expressed in natural language, sometimes 
     rdfs:label "sku" ;
     rdfs:comment "The Stock Keeping Unit (SKU), i.e. a merchant-specific identifier for a product or service, or the product to which the offer refers." ;
     rdfs:subPropertyOf :identifier ;
+    owl:equivalentProperty unece:sellerAssignedId ;
     :domainIncludes :Demand,
         :Offer,
         :Product ;
@@ -8898,6 +9045,7 @@ While such policies are most typically expressed in natural language, sometimes 
 :slogan a rdf:Property ;
     rdfs:label "slogan" ;
     rdfs:comment "A slogan or motto associated with the item." ;
+    owl:equivalentProperty unece:PromotionalMessage ;
     :domainIncludes :Brand,
         :Organization,
         :Place,
@@ -9046,6 +9194,7 @@ we define a supporting type, [[SpeakableSpecification]]  which is defined to be 
 :startDate a rdf:Property ;
     rdfs:label "startDate" ;
     rdfs:comment "The start date and time of the item (in [ISO 8601 date format](http://en.wikipedia.org/wiki/ISO_8601))." ;
+    owl:equivalentProperty cmns-dt:hasStartDate ;
     :domainIncludes :CreativeWorkSeason,
         :CreativeWorkSeries,
         :DatedMoneySpecification,
@@ -9217,6 +9366,7 @@ we define a supporting type, [[SpeakableSpecification]]  which is defined to be 
     rdfs:label "taxID" ;
     rdfs:comment "The Tax / Fiscal ID of the organization or person, e.g. the TIN in the US or the CIF/NIF in Spain." ;
     rdfs:subPropertyOf :identifier ;
+    owl:equivalentProperty fibo-fnd-pty-pty:hasTaxIdentifier ;
     :domainIncludes :Organization,
         :Person ;
     :rangeIncludes :Text .
@@ -9543,6 +9693,7 @@ we define a supporting type, [[SpeakableSpecification]]  which is defined to be 
 :validFrom a rdf:Property ;
     rdfs:label "validFrom" ;
     rdfs:comment "The date when the item becomes valid." ;
+    owl:equivalentProperty cmns-dt:hasStartDate;
     :domainIncludes :Certification,
         :Demand,
         :LocationFeatureSpecification,
@@ -9564,6 +9715,7 @@ we define a supporting type, [[SpeakableSpecification]]  which is defined to be 
 :validThrough a rdf:Property ;
     rdfs:label "validThrough" ;
     rdfs:comment "The date after when the item is not valid. For example the end of an offer, salary period, or a period of opening hours." ;
+    owl:equivalentProperty cmns-dt:hasEndDate ;
     :domainIncludes :Demand,
         :JobPosting,
         :LocationFeatureSpecification,
@@ -10271,6 +10423,7 @@ Unregistered or niche encoding and file formats can be indicated instead via the
 :makesOffer a rdf:Property ;
     rdfs:label "makesOffer" ;
     rdfs:comment "A pointer to products or services offered by the organization or person." ;
+    owl:equivalentProperty fibo-fnd-pas-pas:offers ;
     :domainIncludes :Organization,
         :Person ;
     :inverseOf :offeredBy ;
@@ -10279,6 +10432,7 @@ Unregistered or niche encoding and file formats can be indicated instead via the
 :offeredBy a rdf:Property ;
     rdfs:label "offeredBy" ;
     rdfs:comment "A pointer to the organization or person making the offer." ;
+    owl:equivalentProperty fibo-fnd-pas-pas:isOfferedBy ;
     :domainIncludes :Offer ;
     :inverseOf :makesOffer ;
     :rangeIncludes :Organization,
@@ -10288,6 +10442,7 @@ Unregistered or niche encoding and file formats can be indicated instead via the
     rdfs:label "offers" ;
     rdfs:comment """An offer to provide this item&#x2014;for example, an offer to sell a product, rent the DVD of a movie, perform a service, or give away tickets to an event. Use [[businessFunction]] to indicate the kind of transaction offered, i.e. sell, lease, etc. This property can also be used to describe a [[Demand]]. While this property is listed as expected on a number of common types, it can be used in others. In that case, using a second type, such as Product or a subtype of Product, can clarify the nature of the offer.
       """ ;
+    owl:equivalentProperty fibo-fnd-pas-pas:isProductOf ;
     :domainIncludes :AggregateOffer,
         :CreativeWork,
         :Event,
@@ -10317,6 +10472,7 @@ Unregistered or niche encoding and file formats can be indicated instead via the
 :paymentDueDate a rdf:Property ;
     rdfs:label "paymentDueDate" ;
     rdfs:comment "The date that payment is due." ;
+    owl:equivalentProperty unece:PaymentDueDate ;
     :domainIncludes :Invoice,
         :Order ;
     :rangeIncludes :Date,
@@ -10347,6 +10503,7 @@ Unregistered or niche encoding and file formats can be indicated instead via the
 :provider a rdf:Property ;
     rdfs:label "provider" ;
     rdfs:comment "The service provider, service operator, or service performer; the goods producer. Another party (a seller) may offer those services or goods on behalf of the provider. A provider may also serve as the seller." ;
+    owl:equivalentProperty unece:ServiceProvider ;
     :domainIncludes :CreativeWork,
         :Invoice,
         :ParcelDelivery,
@@ -10451,6 +10608,7 @@ Unregistered or niche encoding and file formats can be indicated instead via the
     rdfs:label "serialNumber" ;
     rdfs:comment "The serial number or any alphanumeric identifier of a particular product. When attached to an offer, it is a shortcut for the serial number of the product included in the offer." ;
     rdfs:subPropertyOf :identifier ;
+    owl:equivalentProperty unece:SerialId ;
     :domainIncludes :Demand,
         :IndividualProduct,
         :Offer ;
@@ -10505,6 +10663,7 @@ Unregistered or niche encoding and file formats can be indicated instead via the
 :subOrganization a rdf:Property ;
     rdfs:label "subOrganization" ;
     rdfs:comment "A relationship between two organizations where the first includes the second, e.g., as a subsidiary. See also: the more specific 'department' property." ;
+    owl:equivalentProperty fibo-be-oac-cctl:hasSubsidiary ;
     :domainIncludes :Organization ;
     :inverseOf :parentOrganization ;
     :rangeIncludes :Organization .
@@ -10663,7 +10822,9 @@ Open-ended date ranges can be written with ".." in place of the end date. For ex
 :seller a rdf:Property ;
     rdfs:label "seller" ;
     rdfs:comment "An entity which offers (sells / leases / lends / loans) the services / goods.  A seller may also be a provider." ;
+    owl:equivalentProperty unece:Seller ;
     rdfs:subPropertyOf :participant ;
+    rdfs:subPropertyOf fibo-fnd-pas-pas:hasSupplier ;
     :domainIncludes :BuyAction,
         :Demand,
         :Flight,
@@ -10707,6 +10868,7 @@ Open-ended date ranges can be written with ".." in place of the end date. For ex
 :areaServed a rdf:Property ;
     rdfs:label "areaServed" ;
     rdfs:comment "The geographic area where a service or offered item is provided." ;
+    owl:equivalentProperty fibo-fnd-pas-pas:hasServiceArea ;
     :domainIncludes :ContactPoint,
         :DeliveryChargeSpecification,
         :Demand,
@@ -10728,6 +10890,7 @@ Open-ended date ranges can be written with ".." in place of the end date. For ex
 :member a rdf:Property ;
     rdfs:label "member" ;
     rdfs:comment "A member of an Organization or a ProgramMembership. Organizations can be members of organizations; ProgramMembership is typically for individuals." ;
+    owl:equivalentProperty fibo-fnd-org-org:hasMember ;
     :domainIncludes :Organization,
         :ProgramMembership ;
     :inverseOf :memberOf ;
@@ -10791,6 +10954,7 @@ Open-ended date ranges can be written with ".." in place of the end date. For ex
 :location a rdf:Property ;
     rdfs:label "location" ;
     rdfs:comment "The location of, for example, where an event is happening, where an organization is located, or where an action takes place." ;
+    owl:equivalentProperty cmns-loc:isLocatedIn ;
     :domainIncludes :Action,
         :Event,
         :InteractionCounter,
@@ -10811,6 +10975,7 @@ Open-ended date ranges can be written with ".." in place of the end date. For ex
     rdfs:comment """The identifier property represents any kind of identifier for any kind of [[Thing]], such as ISBNs, GTIN codes, UUIDs etc. Schema.org provides dedicated properties for representing many of these, either as textual strings or as URL (URI) links. See [background notes](/docs/datamodel.html#identifierBg) for more details.
         """ ;
     owl:equivalentProperty dc:identifier ;
+    owl:equivalentProperty cmns-id:identifiedBy ;
     :domainIncludes :Thing ;
     :rangeIncludes :PropertyValue,
         :Text,


### PR DESCRIPTION
Added OWL equivalences and sub-properties annotations to map schema.org to external ontologies.
These have no direct effect, but help document the relationship between schema and other ontologies.
It should also enable automatic mapping from objects from these ontologies into schema.org

The following ontologies are mapped. 

* Added FIBO equivalences
* Added OMG equivalences
* Added some additional UN Cefact equivalences
* Added the V-card equivalence for events. 