### PR TITLE
Added logic to annotate recursion errors

### DIFF
--- a/software/SchemaTerms/sdotermsource.py
+++ b/software/SchemaTerms/sdotermsource.py
@@ -339,12 +339,16 @@ class SdoTermSource:
         if not self.termStack:
             self.termStack = []
             for sup in self.getSupers():
-                s = self.__class__._getTerm(sup, createReference=True)
-                if s.termType == sdoterm.SdoTermType.REFERENCE:
-                    continue
-                self.termStack.append(s)
-                if s.termStack:
-                    self.termStack.extend(s.termStack.terms)
+                try:
+                    s = self.__class__._getTerm(sup, createReference=True)
+                    if s.termType == sdoterm.SdoTermType.REFERENCE:
+                        continue
+                    self.termStack.append(s)
+                    if s.termStack:
+                        self.termStack.extend(s.termStack.terms)
+                except RecursionError as e:
+                    e.add_note(f"Circular references with {self.termdesc}")
+                    raise
             stack = []
             for t in reversed(self.termStack):
                 if t not in stack:


### PR DESCRIPTION
Added logic to annotate a recursion exception with the terms that form the cycle. 
This makes it easier to debug if one were to add a cycle, for instance by making a property a sub-property of itself. 
This should address https://github.com/schemaorg/schemaorg/issues/4606