### PR TITLE
CompoundPriceSpecification can have any PriceSpecification as child

### DIFF
--- a/data/ext/pending/issue-2712.ttl
+++ b/data/ext/pending/issue-2712.ttl
@@ -59,12 +59,6 @@
     :source <https://github.com/schemaorg/schemaorg/issues/2712> ;
     rdfs:comment "Represents a sale price (usually active for a limited period) of an offered product." .
 
-:SubtotalPrice a :PriceTypeEnumeration ;
-    rdfs:label "SubtotalPrice" ;
-    :isPartOf <https://pending.schema.org> ;
-    :source <https://github.com/schemaorg/schemaorg/issues/4618> ;
-    rdfs:comment "Represents sub-total price, for instance, a product and its accessories." .
-
 :priceType :domainIncludes :CompoundPriceSpecification ;
     :rangeIncludes :PriceTypeEnumeration .
 


### PR DESCRIPTION
* CompoundPriceSpecification can have any PriceSpecification as child
* Added SubtotalPrice [PriceTypeEnumeration](https://schema.org/PriceTypeEnumeration) value to be able to represent sub-totals. 

This is work for https://github.com/schemaorg/schemaorg/issues/4572 in order to allow the modelling of a Shopping-Cart.
