### PR TITLE
Fix equivalentClass typo

### DIFF
--- a/data/schema.ttl
+++ b/data/schema.ttl
@@ -2450,10 +2450,10 @@ The place is __open__ if the [[opens]] property is specified, and __closed__ oth
 :PostalAddress a rdfs:Class ;
     rdfs:label "PostalAddress" ;
     rdfs:comment "The mailing address." ;
-    owl:EquivalentClass cmns-loc:Address ;
+    owl:equivalentClass cmns-loc:Address ;
     owl:equivalentClass fibo-fnd-plc-adr:PostalAddress ;
-    owl:EquivalentClass gs1:PostalAddress ;
-    owl:EquivalentClass unece:TradeAddress ;
+    owl:equivalentClass gs1:PostalAddress ;
+    owl:equivalentClass unece:TradeAddress ;
     rdfs:subClassOf :ContactPoint .
 
 :PostalCodeRangeSpecification a rdfs:Class ;


### PR DESCRIPTION
Hello - I noticed a case mismatch with `owl:equivalentClass` and assume it is unintentional.

For what it's worth, I appreciate the recent efforts to document more related ontologies here - thanks.