### PR TITLE
Avoid conflating enum and types.

### DIFF
--- a/data/ext/pending/issue-3057.ttl
+++ b/data/ext/pending/issue-3057.ttl
@@ -9,7 +9,7 @@
     :isPartOf <https://pending.schema.org> ;
     :source <https://github.com/schemaorg/schemaorg/issues/3057> ;
     rdfs:comment "Enumerates some common technology platforms, for use with properties such as [[actionPlatform]]. It is not supposed to be comprehensive - when a suitable code is not enumerated here, textual or URL values can be used instead. These codes are at a fairly high level and do not deal with versioning and other nuance. Additional codes can be suggested [in github](https://github.com/schemaorg/schemaorg/issues/3057). " ;
-    rdfs:subClassOf :Enumeration, :OperatingSystem .
+    rdfs:subClassOf :Enumeration .
 
 :DesktopWebPlatform a :DigitalPlatformEnumeration ;
     rdfs:label "DesktopWebPlatform" ;
@@ -40,4 +40,3 @@
     :isPartOf <https://pending.schema.org> ;
     :source <https://github.com/schemaorg/schemaorg/issues/3057> ;
     rdfs:comment "Represents the broad notion of iOS-based operating systems." .
-


### PR DESCRIPTION
Issue #4599 did conflate a type and an enumeration, which is not handled well by several systems downstream.

This removes this conflation. See comment trail in #4575 too.