### PR TITLE
Defining external classes as RDFs Classes in the schema.

### DIFF
--- a/data/ext/pending/issue-1797.ttl
+++ b/data/ext/pending/issue-1797.ttl
@@ -8,6 +8,10 @@
 @prefix cmns-cls: <https://www.omg.org/spec/Commons/Classifiers/> .
 @prefix cmns-col: <https://www.omg.org/spec/Commons/Collections/> .
 
+# External classes
+cmns-cls:Classifier a rdfs:Class .
+cmns-col:Collection a rdfs:Class .
+
 :ProductGroup a rdfs:Class ;
     rdfs:label "ProductGroup" ;
     :isPartOf <https://pending.schema.org> ;
@@ -81,4 +85,3 @@ While a ProductGroup itself is not directly offered for sale, the various varyin
     :domainIncludes :Product ;
     :inverseOf :hasVariant ;
     :rangeIncludes :ProductGroup .
-

--- a/data/ext/pending/issue-3230.ttl
+++ b/data/ext/pending/issue-3230.ttl
@@ -10,6 +10,8 @@
 @prefix xml: <http://www.w3.org/XML/1998/namespace> .
 @prefix xsd: <http://www.w3.org/2001/XMLSchema#> .
 
+# External classes
+fibo-fnd-arr-reg:Certificate a rdfs:Class .
 
 :Certification a rdfs:Class ;
   rdfs:label "Certification" ;
@@ -88,7 +90,3 @@
   rdfs:subPropertyOf cmns-cls:isClassifiedBy ;
   rdfs:subPropertyOf fibo-fnd-arr-doc:isReferencedIn ;
   rdfs:comment "Certification information about a product, organization, service, place, or person." .
-
-
-
-

--- a/data/schema.ttl
+++ b/data/schema.ttl
@@ -43,6 +43,11 @@
 @prefix unece: <http://unece.org/vocab#> .
 @prefix void: <http://rdfs.org/ns/void#> .
 
+# External classes
+cmns-ge:GeopoliticalEntity a rdfs:Class .
+fibo-fnd-arr-doc:Document a rdfs:Class .
+fibo-fnd-arr-doc:LegalDocument a rdfs:Class .
+fibo-fnd-agr-ctr:MutualContractualAgreement a rdfs:Class .
 
 :AMRadioChannel a rdfs:Class ;
     rdfs:label "AMRadioChannel" ;


### PR DESCRIPTION
Some tool choke on an externally defined class that is not marked as such in the schema. This PR adds these as classes.

This is a mitigation of #4621.