### PR TITLE
Refine vatID comment for clarity and standards

### DIFF
--- a/data/schema.ttl
+++ b/data/schema.ttl
@@ -9811,7 +9811,7 @@ we define a supporting type, [[SpeakableSpecification]]  which is defined to be 
 
 :vatID a rdf:Property ;
     rdfs:label "vatID" ;
-    rdfs:comment "The value-added Tax ID of the organization or person with national prefix (such as IT123456789), can also be described as [[iso6523Code]] with proper prefix." ;
+    rdfs:comment "The value-added Tax ID of the organization or person with national prefix (for example IT123456789). Can also be described as [[iso6523Code]] with proper prefix." ;
     :domainIncludes :Organization,
         :Person ;
     :rangeIncludes :Text .


### PR DESCRIPTION
Updated the comment for vatID property to include ISO 6523 and PEPOL prefix as described here:
> European VAT ids should be expressed as ISO 6523 with the correct PEPOL prefix, this gives you a globally valid identifier.