### PR TITLE
fixed iso-6523 examples

### DIFF
--- a/data/examples.txt
+++ b/data/examples.txt
@@ -532,8 +532,9 @@ JSON:
   },
   "email": "secretariat@example.com",
   "faxNumber": "+33142685301",
-  "iso6523Code": "0009:44306184100039",
-  "iso6523Code": "9957:FR64443061841",
+  "iso6523Code": [
+      "0009:44306184100039", "9957:FR64443061841"
+  ],
   "member": [
     {
       "@type": "Organization"
@@ -1224,49 +1225,49 @@ JSON:
   "@type": "WebPage",
   "breadcrumb": "Books > Literature & Fiction > Classics",
   "mainEntity":{
-	  "@type": "Book",
-	  "author": "/author/jd_salinger.html",
-	  "bookFormat": "https://schema.org/Paperback",
-	  "datePublished": "1991-05-01",
-	  "image": "catcher-in-the-rye-book-cover.jpg",
-	  "inLanguage": "English",
-	  "isbn": "0316769487",
-	  "name": "The Catcher in the Rye",
-	  "numberOfPages": "224",
-	  "offers": {
-	    "@type": "Offer",
-	    "availability": "https://schema.org/InStock",
-	    "price": "6.99",
-	    "priceCurrency": "USD"
-	  },
-	  "publisher": "Little, Brown, and Company",
-	  "aggregateRating": {
-	    "@type": "AggregateRating",
-	    "ratingValue": "4",
-	    "reviewCount": "3077"
-	  },
-	  "review": [
-	    {
-	      "@type": "Review",
-	      "author": "John Doe",
-	      "datePublished": "2006-05-04",
-	      "name": "A masterpiece of literature",
-	      "reviewBody": "I really enjoyed this book. It captures the essential challenge people face as they try make sense of their lives and grow to adulthood.",
-	      "reviewRating": {
+    "@type": "Book",
+    "author": "/author/jd_salinger.html",
+    "bookFormat": "https://schema.org/Paperback",
+    "datePublished": "1991-05-01",
+    "image": "catcher-in-the-rye-book-cover.jpg",
+    "inLanguage": "English",
+    "isbn": "0316769487",
+    "name": "The Catcher in the Rye",
+    "numberOfPages": "224",
+    "offers": {
+      "@type": "Offer",
+      "availability": "https://schema.org/InStock",
+      "price": "6.99",
+      "priceCurrency": "USD"
+    },
+    "publisher": "Little, Brown, and Company",
+    "aggregateRating": {
+      "@type": "AggregateRating",
+      "ratingValue": "4",
+      "reviewCount": "3077"
+    },
+    "review": [
+      {
+        "@type": "Review",
+        "author": "John Doe",
+        "datePublished": "2006-05-04",
+        "name": "A masterpiece of literature",
+        "reviewBody": "I really enjoyed this book. It captures the essential challenge people face as they try make sense of their lives and grow to adulthood.",
+        "reviewRating": {
             "@type": "Rating",
             "ratingValue": "5"
            }
-	    },
-	    {
-	      "@type": "Review",
-	      "author": "Bob Smith",
-	      "datePublished": "2006-06-15",
-	      "name": "A good read.",
-	      "reviewBody": "Catcher in the Rye is a fun book. It's a good book to read.",
-	      "reviewRating": "4"
-	    }
-	  ]
-  	}
+      },
+      {
+        "@type": "Review",
+        "author": "Bob Smith",
+        "datePublished": "2006-06-15",
+        "name": "A good read.",
+        "reviewBody": "Catcher in the Rye is a fun book. It's a good book to read.",
+        "reviewRating": "4"
+      }
+    ]
+    }
 }
 </script>
 


### PR DESCRIPTION
The examples used a repeated field, when JSON-LD requires an array.