### PR TITLE
Adds support for Italian and German non profit type (#3629)

### DIFF
--- a/data/ext/pending/issue-3629.ttl
+++ b/data/ext/pending/issue-3629.ttl
@@ -51,7 +51,7 @@
     rdfs:label "DEPublicCharity" ;
     :isPartOf <https://pending.schema.org> ;
     :source <https://github.com/schemaorg/schemaorg/issues/3629> ;
-    rdfs:comment "DEPublicCharity: Non-profit type referring to a charitable government owned juridical person (German Köperschaft öffentlichen Rechts) that has been recognized by the tax authorities as a charitable non-profit." .
+    rdfs:comment "DEPublicCharity: Non-profit type referring to a charitable government owned juridical person (German Körperschaft öffentlichen Rechts) that has been recognized by the tax authorities as a charitable non-profit." .
 
 :ITNonprofitType a rdfs:Class ;
     rdfs:label "ITNonprofitType" ;


### PR DESCRIPTION
Includes references to applicable laws inside the comments of the Class (DENonprofitType) or the specific ITNonprofitType.

Some notes: 
- Germany defines all charitable causes inside the German tax code referenced inside the Class comment; 
- Italy defines the admissible legal forms of charitable entities in specific laws referenced inside the comments of the subclasses. 
Closes #3629 