### PR TITLE
Restricted diet subtypes (#3211 & #3176)

### DIFF
--- a/data/schema.ttl
+++ b/data/schema.ttl
@@ -3760,6 +3760,10 @@ See also the <a href="/docs/hotels.html">dedicated document on the use of schema
     rdfs:label "LowCalorieDiet" ;
     rdfs:comment "A diet focused on reduced calorie intake." .
 
+:LowCarbDiet a :RestrictedDiet ;
+    rdfs:label "LowCarbDiet" ;
+    rdfs:comment "A diet focused on reduced carbohydrate intake." .
+
 :LowFatDiet a :RestrictedDiet ;
     rdfs:label "LowFatDiet" ;
     rdfs:comment "A diet focused on reduced fat and cholesterol intake." .


### PR DESCRIPTION
Adds new types of restricted diets.

Diet Name | Diet Comment | Extra Note
-- | -- | --
LowCarbDiet | A diet focused on reduced carbohydrate intake. |  
LowLactoseDiet | A diet appropriate for people with lactose intolerance. |  
LowSucroseDiet | A diet appropriate for people with sucrose intolerance. | Some people with CSID only need to restrict sucrose
LowMaltoseDiet | A diet appropriate for people with maltose intolerance. | Some people with CSID must restrict sucrose & maltose
LowStarchDiet | A diet appropriate for people with starch intolerance. | Some people with CSID must restrict sucrose, maltose & starch
SIDDiet | A diet appropriate for people with sucrase-isomaltase deficiency (Also known as CSID). Restricts Sucrose, Maltose, Iso-maltose & Starch. |  
LowTrehaloseDiet | A diet appropriate for people with trehalose intolerance. | People who cant digest mushroom sugar
LowFructoseDiet | A diet appropriate for people with fructose intolerance. | People who do not digest fructose (must also restrict sorbitol)
FructoseFreeDiet | A diet appropriate for people with Hereditary Fructose Intolerance (HFI). | People who digest fructose and it damages their body (must also restrict sorbitol)
KetoDiet | A diet likely to induce or maintain nutritional ketosis. |  

Closes #3211 
Closes #3176 
