### PR TITLE
Hardened docs page building logic

### DIFF
--- a/software/SchemaTerms/example-code/jinjaTemplating/templates/simple/DataTypePage.tpl
+++ b/software/SchemaTerms/example-code/jinjaTemplating/templates/simple/DataTypePage.tpl
@@ -8,31 +8,35 @@
     <link rel="stylesheet" type="text/css" href="util/schemaorg.css" />
     <link rel="stylesheet" type="text/css" href="util/prettify.css" />
     <script type="text/javascript" src="util/prettify.js"></script>
-    
+
 </head>
 <body>
     {% set TERMTYPE = "DataType" %}
     {% include 'PageHeader.tpl' with context %}
     <div id="mainContent">
-	    {% include 'InfoBlock.tpl' with context %}
+      {% include 'InfoBlock.tpl' with context %}
 
-	    <div><h2>Specific Properties</h2>
-	        {% for prop in term.properties %}<a href="{{href_prefix}}{{prop}}.html">{{ prop }}</a>{% if not loop.last %}, {% endif %}{% endfor %}
-	    </div>
-		
-	    <div>
-	        {% for type in term.expectedTypeFor %}
-	        {% if loop.first %}<h2>Expected Type For</h2>{% endif %}<a href="{{href_prefix}}{{type}}">{{ type }}</a>{% if not loop.last %}, {% endif %}{% endfor %}
-	    </div>
+      <div><h2>Specific Properties</h2>
+          {% for prop in term.properties %}<a href="{{href_prefix}}{{prop}}.html">{{ prop }}</a>{% if not loop.last %}, {% endif %}{% endfor %}
+      </div>
 
-	    <div>
-	        {% for sub in term.subs %}
-	        {% if loop.first %}<h2>More Specific Data Types</h2>{% endif %}<a href="{{href_prefix}}{{sub}}.html">{{ sub }}</a>{% if not loop.last %}, {% endif %}{% endfor %}
-	    </div>
+      <div>
+          {% for type in term.expectedTypeFor %}
+          {% if loop.first %}<h2>Expected Type For</h2>{% endif %}<a href="{{href_prefix}}{{type}}">{{ type }}</a>{% if not loop.last %}, {% endif %}{% endfor %}
+      </div>
 
-		<!-- list source references and acknowledgements -->
-		{% include 'Ackblock.tpl' with context %}
-		
+     <div>
+         {% for sub in term.subs %}
+             {% if loop.first %}<h2>More Specific Data Types</h2>{% endif %}
+             <a href="{% if sub.startswith('http') %}{{ sub }}{% else %}{{ href_prefix }}{{ sub }}.html{% endif %}">
+                 {{ sub }}
+             </a>{% if not loop.last %}, {% endif %}
+         {% endfor %}
+     </div>
+
+    <!-- list source references and acknowledgements -->
+    {% include 'Ackblock.tpl' with context %}
+
     </div> <!-- mainContent -->
 </body>
 </html>

--- a/software/SchemaTerms/example-code/jinjaTemplating/templates/simple/TypePage.tpl
+++ b/software/SchemaTerms/example-code/jinjaTemplating/templates/simple/TypePage.tpl
@@ -8,36 +8,40 @@
     <link rel="stylesheet" type="text/css" href="util/schemaorg.css" />
     <link rel="stylesheet" type="text/css" href="util/prettify.css" />
     <script type="text/javascript" src="util/prettify.js"></script>
-    
+
 </head>
 <body>
     {% set TERMTYPE = "Type" %}
     {% include 'PageHeader.tpl' with context %}
     <div id="mainContent">
-	    {% include 'InfoBlock.tpl' with context %}
+      {% include 'InfoBlock.tpl' with context %}
 
-	    <div><h2>Properties Specific to this Type</h2>
-	        {% for prop in term.properties %}<a href="{{href_prefix}}{{prop}}.html">{{ prop }}</a>{% if not loop.last %}, {% endif %}{% endfor %}
-	    </div>
-		
-	    <div><h2>All Available Properties</h2>
-	        {% for prop in term.allproperties %}<a href="{{href_prefix}}{{prop}}.html">{{ prop }}</a>{% if not loop.last %}, {% endif %}{% endfor %}
-	    </div>
+      <div><h2>Properties Specific to this Type</h2>
+          {% for prop in term.properties %}<a href="{{href_prefix}}{{prop}}.html">{{ prop }}</a>{% if not loop.last %}, {% endif %}{% endfor %}
+      </div>
 
-		
-	    <div>
-	        {% for type in term.expectedTypeFor %}
-	        {% if loop.first %}<h2>Expected Type For</h2>{% endif %}<a href="{{href_prefix}}{{type}}">{{ type }}</a>{% if not loop.last %}, {% endif %}{% endfor %}
-	    </div>
+      <div><h2>All Available Properties</h2>
+          {% for prop in term.allproperties %}<a href="{{href_prefix}}{{prop}}.html">{{ prop }}</a>{% if not loop.last %}, {% endif %}{% endfor %}
+      </div>
 
-	    <div>
-	        {% for sub in term.subs %}
-	        {% if loop.first %}<h2>More Specific Types</h2>{% endif %}<a href="{{href_prefix}}{{sub}}.html">{{ sub }}</a>{% if not loop.last %}, {% endif %}{% endfor %}
-	    </div>
 
-		<!-- list source references and acknowledgements -->
-		{% include 'Ackblock.tpl' with context %}
-		
+      <div>
+          {% for type in term.expectedTypeFor %}
+          {% if loop.first %}<h2>Expected Type For</h2>{% endif %}<a href="{{href_prefix}}{{type}}">{{ type }}</a>{% if not loop.last %}, {% endif %}{% endfor %}
+      </div>
+
+      <div>
+          {% for sub in term.subs %}
+              {% if loop.first %}<h2>More Specific Data Types</h2>{% endif %}
+              <a href="{% if sub.startswith('http') %}{{ sub }}{% else %}{{ href_prefix }}{{ sub }}.html{% endif %}">
+                  {{ sub }}
+              </a>{% if not loop.last %}, {% endif %}
+          {% endfor %}
+      </div>
+
+    <!-- list source references and acknowledgements -->
+    {% include 'Ackblock.tpl' with context %}
+
     </div> <!-- mainContent -->
 </body>
 </html>


### PR DESCRIPTION
Hardened the doc page building logic.

- Better error reporting if a term is not found.
- Removed global variables.
- Use sets for set logic
- Templates now output full types if a non schema type is encountered.
- Added type information to functions
