### PR TITLE
Add jobDuration property to JobPosting (#4475)

### DIFF
--- a/data/ext/pending/issue-4475.ttl
+++ b/data/ext/pending/issue-4475.ttl
@@ -8,7 +8,7 @@
     rdfs:label "jobDuration" ;
     :domainIncludes :JobPosting ;
     :isPartOf <https://pending.schema.org> ;
-    :rangeIncludes :Duration ,
+    :rangeIncludes :Duration,
         :QuantitativeValue;
     :source <https://github.com/schemaorg/schemaorg/issues/4475> ;
     rdfs:comment "The expected duration of an employment offer as advertised by the employer. Relevant for job postings that have a clearly defined period in mind such as seasonal work, substitutes for maternal leave or any other temporary employment." .


### PR DESCRIPTION
As requested in #4475 this new property allows to add durations to a jobPosting to indicate temporary employments.

Closes #4475