### PR TITLE
Improve the doc around percentages in shipping rates.

### DIFF
--- a/data/ext/pending/issue-3617.ttl
+++ b/data/ext/pending/issue-3617.ttl
@@ -47,7 +47,7 @@
     :rangeIncludes :Number ;
     :source <https://github.com/schemaorg/schemaorg/issues/3617> ;
     :isPartOf <https://pending.schema.org> ;
-    rdfs:comment "Value in the range [0.0 ; 1.0] representing the fraction of the value of the order that is charged as shipping cost." .
+    rdfs:comment "Value representing the fraction of the value of the order that is charged as shipping cost. Example: 0.10 would mean shipping rate is 10% of the total order value." .
 
 :weightPercentage a rdf:Property ;
     rdfs:label "weightPercentage" ;
@@ -55,7 +55,7 @@
     :rangeIncludes :Number ;
     :source <https://github.com/schemaorg/schemaorg/issues/3617> ;
     :isPartOf <https://pending.schema.org> ;
-    rdfs:comment "Value in the range [0.0 ; 1.0] representing the fraction of the weight that is used to compute the shipping price." .
+    rdfs:comment "Value representing the fraction of the weight that is used to compute the shipping price. Example: 0.10 and a shipping weight of 15kg would add $1.5 to the order price, where the $ is the currency of the order." .
 
 # ╔════════════════════════════════════════════════════════╗
 # ║ Adding ServicePeriod                                   ║


### PR DESCRIPTION
The numeric limits were unnecessarily restrictive, and the documentation a bit confusing. Now there are examples.