### PR TITLE
Add previousStartDate rangeIncludes DateTime

### DIFF
--- a/data/schema.ttl
+++ b/data/schema.ttl
@@ -8158,7 +8158,8 @@ Note: for historical reasons, any textual label and formal code provided as a li
     rdfs:label "previousStartDate" ;
     rdfs:comment "Used in conjunction with eventStatus for rescheduled or cancelled events. This property contains the previously scheduled start date. For rescheduled events, the startDate property should be used for the newly scheduled start date. In the (rare) case of an event that has been postponed and rescheduled multiple times, this field may be repeated." ;
     :domainIncludes :Event ;
-    :rangeIncludes :Date .
+    :rangeIncludes :Date,
+        :DateTime .
 
 :price a rdf:Property ;
     rdfs:label "price" ;


### PR DESCRIPTION
This would bring it inline with conventional usage, existing repository examples, and seeming-intended usage. Without this DateTime inclusion, schema-based validation of previousStartDate assume that only a Date is valid and emit an error.

Since this is an amendment of an existing property, I updated `schema.ttl` directly rather than a dedicated `data/ext/pending/*` file that seem to be for new definitions, but let me know if I should change it.

This is a follow-up to my original issue about this in #4490, although there was not further discussion on it.