### PR TITLE
Fix unclear error message regarding the citation of issues in example…

### DIFF
--- a/software/scripts/Rakefile
+++ b/software/scripts/Rakefile
@@ -65,7 +65,7 @@ describe "Examples" do
       body = body[0..-(s.matched.to_s.length+1)].gsub("\r", '').strip + "\n"
       case format
       when :microdata, :rdfa, :jsonld
-        raise "One or more TYPES do not declare an issue in the example (see #{contributionGuidelines}): #{types}" unless types.to_s.start_with?('#')
+        raise "One or more TYPES do not declare an issue in the example (see #{contributionGuidelines} ): #{types}" unless types.to_s.start_with?('#')
         name, _ = types.split(/\s+/, 2)
         name = name[1..-1]  # Remove initial '#'
 


### PR DESCRIPTION
… files (#4687)

The previous error message (`TYPES does not start with example frag: #{types}`) was unclear regarding the requirements of an example file. This commit: 
- references the contribution guidelines
- raises a more defined error message in github actions

Closes #4687

Error now looks like this: 
```
One or more TYPES do not declare an issue in the example (see https://github.com/schemaorg/schemaorg/blob/main/software/CONTRIBUTING.md): ReserveAction, LinkRole
```

**Example:** 
[Job with failure due to missing issue number on example](https://github.com/fthobe/schemaorg/actions/runs/21006614057/job/60390502893)

**Screenshot:** 
<img width="1020" height="848" alt="Screenshot 2026-01-15 at 08 30 38" src="https://github.com/user-attachments/assets/e338a79d-b1a8-4a28-88be-e7c71726b49b" />
