### PR TITLE
Fix regex patterns in schemaexamples.py (#4697)

### DIFF
--- a/software/SchemaExamples/schemaexamples.py
+++ b/software/SchemaExamples/schemaexamples.py
@@ -19,7 +19,7 @@ NO_JSON_REGEXPS = (
 
 
 ldscript_match = re.compile(
-    '[\s\S]*<\s*script\s+type="application\/ld\+json"\s*>(.*)<\s*\/script\s*>[\s\S]*',
+    r'[\s\S]*<\s*script\s+type="application\/ld\+json"\s*>(.*)<\s*\/script\s*>[\s\S]*',
     re.S,
 )
 
@@ -400,7 +400,7 @@ class ExampleFileParser:
         self.file = filen
         self.filepos = 0
         examples = []
-        egid = re.compile("""#(\S+)\s+""")
+        egid = re.compile(r"""#(\S+)\s+""")
 
         if self.file.startswith("file://"):
             self.file = self.file[7:]


### PR DESCRIPTION
Fixes syntax warnings thrown by python 3.12 or above as this will become a syntax error in the future.  See [cPython #71551](https://github.com/python/cpython/issues/71551)

Closes #4697