### PR TITLE
docs: clarify README usage

### DIFF
--- a/README.md
+++ b/README.md
@@ -68,7 +68,7 @@ Full instructions are available in [SOFTWARE_README.md](software/SOFTWARE_README
 
 Essentially you will need to have a Linux-like (inc Mac) environment loaded with Python version 3.6 or above. You can then make test builds of Schema.org running on your own machine accessible as http://localhost:8080/ or else post them on appspot.com for collaboration. See the [Appengine documentation](https://cloud.google.com/appengine/docs) for details of the relevant gcloud commands.
 
-If you work primarily on Windows, use the Windows Subsystem for Linux (WSL2) or another POSIX-like environment to follow these commands. WSL2 provides the required tooling (Python, make, git) and matches the paths referenced in SOFTWARE_README.md, avoiding discrepancies between Windows native shells and the scripts in this repository.
+If you work primarily on Windows, use the Windows Subsystem for Linux (WSL2) or another POSIX-like environment to follow these commands. WSL2 provides the required tooling (Python, make, git) and matches the paths referenced in [SOFTWARE_README.md](software/SOFTWARE_README.md), avoiding discrepancies between Windows native shells and the scripts in this repository.
 
 More detailed information about the software is available in [SOFTWARE_README.md](software/SOFTWARE_README.md).
 


### PR DESCRIPTION
This PR adds a brief clarification for contributors working on Windows, recommending WSL2 to avoid environment and path inconsistencies.

No functional or schema changes are introduced.
