### PR TITLE
Clarify the definitions of accessMode and accessModeSufficient

### DIFF
--- a/data/schema.ttl
+++ b/data/schema.ttl
@@ -4095,14 +4095,14 @@ See also the <a href="/docs/hotels.html">dedicated document on the use of schema
 
 :accessMode a rdf:Property ;
     rdfs:label "accessMode" ;
-    rdfs:comment "The human sensory perceptual system or cognitive faculty through which a person may process or perceive information. Values should be drawn from the [approved vocabulary](https://www.w3.org/2021/a11y-discov-vocab/latest/#accessMode-vocabulary)." ;
+    rdfs:comment "The human sensory perceptual system or cognitive faculty through which a person may process or perceive the intellectual content of a resource, not including any adaptations of the content (e.g., text alternatives for images). Values should be drawn from the [approved vocabulary](https://www.w3.org/2021/a11y-discov-vocab/latest/#accessMode-vocabulary)." ;
     :domainIncludes :CreativeWork ;
     :rangeIncludes :Text ;
     :source <https://github.com/schemaorg/schemaorg/issues/1100> .
 
 :accessModeSufficient a rdf:Property ;
     rdfs:label "accessModeSufficient" ;
-    rdfs:comment "A list of single or combined accessModes that are sufficient to understand all the intellectual content of a resource. Values should be drawn from the [approved vocabulary](https://www.w3.org/2021/a11y-discov-vocab/latest/#accessModeSufficient-vocabulary)." ;
+    rdfs:comment "A list of single or combined access modes that are sufficient to understand all the intellectual content of a resource, including any adaptations. Values should be drawn from the [approved vocabulary](https://www.w3.org/2021/a11y-discov-vocab/latest/#accessModeSufficient-vocabulary)." ;
     :domainIncludes :CreativeWork ;
     :rangeIncludes :ItemList ;
     :source <https://github.com/schemaorg/schemaorg/issues/1100> .


### PR DESCRIPTION
It's come to our attention that our original definitions lack some clarity when it comes to adaptations of the content. We've kept the rules around setting the access modes and sufficient access modes from the original Access for All properties these were derived from in epub usage documentation, but feel it would be helpful to improve the wording of the schema.org definitions to make clearer that access modes do not take into consideration adaptations while sufficient access modes do.

The new wording has been discussed in https://github.com/w3c/a11y-discov-vocab/issues/254 as well as in the publishing community group.

/cc @clapierre @madeleinerothberg 