### PR TITLE
Update schemaorg.css to fix searchbox styling issue

### DIFF
--- a/docs/schemaorg.css
+++ b/docs/schemaorg.css
@@ -591,11 +591,6 @@ a.ext.ext-attic:hover {
 #cse-search-form2 #___gcse_0 {
   border: 1px solid #212529;
   border-radius: 24px;
-  height: 46px;
-}
-
-#cse-search-form2 .gsib_a {
-  padding: 3px 9px 3px 18px;
 }
 
 #cse-search-form2 form.gsc-search-box,


### PR DESCRIPTION
Programmable Search Engine (CSE) has changed their default styling which was clashing with schema.org searchbar. When entering new text the first few characters are obscured by the search icon. I've removed the custom padding that causes this issue. Also removed the static heigh which makes the icon look off center vertically.

#### Mobile
Before:
<img width="390" height="844" alt="image" src="https://github.com/user-attachments/assets/fa439db2-9679-4fc1-9085-6b399bbded46" />
After:
<img width="386" height="836" alt="image" src="https://github.com/user-attachments/assets/5e035f34-16be-4621-9559-c4f1398f2a05" />

#### Desktop
Before:
<img width="2560" height="923" alt="image" src="https://github.com/user-attachments/assets/61c8d0e9-b493-495d-a6a4-18e5075c75c8" />
After:
<img width="2560" height="923" alt="image" src="https://github.com/user-attachments/assets/145ecd36-26b7-4147-98e4-d55dac93e13f" />
