### PR TITLE
Make generated files determinism

### DIFF
--- a/software/SchemaExamples/schemaexamples.py
+++ b/software/SchemaExamples/schemaexamples.py
@@ -235,7 +235,8 @@ class SchemaExamples:
             )
             exfiles = []
             for g in DEFTEXAMPLESFILESGLOB:
-                exfiles.extend(glob.glob(g))
+                exfiles.extend(sorted(glob.glob(g)))
+
         elif isinstance(exfiles, str):
             log.info(
                 "SchemaExamples.loadExamplesFiles() loading from file: %s" % exfiles

--- a/software/SchemaTerms/sdotermsource.py
+++ b/software/SchemaTerms/sdotermsource.py
@@ -5,13 +5,16 @@
 import collections
 import copy
 import glob
+import json
 import logging
 import os
 import rdflib
+from rdflib.compare import to_canonical_graph
 import re
 import sys
 import threading
 import typing
+from typing import Any
 
 
 # Import schema.org libraries
@@ -24,6 +27,7 @@ import software.SchemaTerms.sdocollaborators as sdocollaborators
 import software.SchemaTerms.localmarkdown as localmarkdown
 
 import software.util.pretty_logger as pretty_logger
+from software.util.sort_dict import sort_dict
 
 log = logging.getLogger(__name__)
 
@@ -446,12 +450,13 @@ class SdoTermSource:
             subs = self.loadSubjects("schema:supersededBy")
             for sub in subs:
                 self.supersedes.append(uri2id(str(sub)))
+            self.supersedes.sort()
         return self.supersedes
 
     def getSources(self):
         if not self.sources:
             objs = self.loadObjects("schema:source")  # To accept later ttl versions.
-            self.sources = list(objs)
+            self.sources = sorted(list(objs))
         return self.sources
 
     def getAcknowledgements(self) -> typing.Sequence[str]:
@@ -531,7 +536,7 @@ class SdoTermSource:
                         break
                     if term.termType in sdoterm.SdoTerm.TYPE_LIKE_TYPES:
                         allprop_ids.update(term.properties.ids)
-            ret = sorted(allprop_ids)
+            ret = sorted(list(allprop_ids))
         return ret
 
     def getPropUsedOn(self):
@@ -562,12 +567,13 @@ class SdoTermSource:
             subs = self.loadSubjects("schema:rangeIncludes")
             for sub in subs:
                 self.targetOf.append(uri2id(str(sub)))
+            self.targetOf.sort()
         ret = self.targetOf
         if not (len(self.targetOf) and stopontarget):
             if plusparents:
-                targets = self.targetOf
+                targets = list(self.targetOf)
                 for s in self.getSupers():
-                    sup = cls._getTerm(s, createReference=True)
+                    sup = self.__class__._getTerm(s, createReference=True)
                     if sup.uri() == ENUMERATIONURI or sup.uri == THINGURI:
                         break
                     ptargets = sup.expectedTypeFor
@@ -575,8 +581,7 @@ class SdoTermSource:
                         targets.append(t)
                     if len(targets) and stopontarget:
                         break
-                ret = targets
-        ret.sort()
+                ret = sorted(list(set(targets)))
         return ret
 
     def getEquivalents(self):
@@ -586,6 +591,7 @@ class SdoTermSource:
             equivalents.extend(self.loadObjects("owl:equivalentProperty"))
             for e in equivalents:
                 self.equivalents.append(str(e))
+            self.equivalents.sort(key=prefixedIdFromUri)
         return self.equivalents
 
     def inLayers(self, layers):
@@ -671,7 +677,7 @@ class SdoTermSource:
          ORDER BY ?sup""" % (uriWrap(fullId), uriWrap(fullId))
 
         res = self.__class__.query(query)
-        self.supers = [uri2id(str(row.sup)) for row in res]
+        self.supers = sorted([uri2id(str(row.sup)) for row in res])
 
     def loadsubs(self):
         fullId = toFullId(self.id)
@@ -691,6 +697,7 @@ class SdoTermSource:
                 "a"
             )  # Enumerationvalues have an Enumeration as a type
             self.subs.extend([uri2id(str(child)) for child in subjects])
+        self.subs.sort()
 
     def getEnumerationMembers(self):
         if not self.members and self.ttype == sdoterm.SdoTermType.ENUMERATION:
@@ -912,6 +919,8 @@ class SdoTermSource:
             tmp.type = DATATYPEURI
         elif ENUMERATIONURI in tmp.sups:
             tmp.type = ENUMERATIONURI
+        elif len(tmp.types) > 1:
+            tmp.type = sorted(tmp.types)[0]
 
         term = cls.TERMS.get(tmp.id, None)
         if not term:  # Already created this term ?
@@ -938,7 +947,7 @@ class SdoTermSource:
         g.bind("schema", VOCABURI)
 
         if not full:  # Only the term definition
-            triples = cls.triples4Term(term)
+            triples = cls.triples4Term(term.id)
             for trip in triples:
                 g.add(trip)
         else:  # full - Include all related terms
@@ -957,19 +966,32 @@ class SdoTermSource:
                     elif t == stack[0]:
                         props.extend(cls.termsFromIds(t.allproperties.ids))
 
-            for t in types:
+            for t in sorted(types):
                 triples = cls.triples4Term(t.id)
                 for trip in triples:
                     g.add(trip)
 
-            for p in props:
+            for p in sorted(props):
                 triples = cls.triples4Term(p.id)
                 for trip in triples:
                     g.add(trip)
 
         if output_format == "rdf":
             output_format = "pretty-xml"
-        ret = g.serialize(format=output_format, auto_compact=True, sort_keys=True)
+
+        ret = g.serialize(format=output_format, auto_compact=True, sort_keys=True, max_depth=1)
+
+        if output_format == "json-ld":
+            # Explicitly sort JSON keys to ensure predictability, as rdflib's
+            # json-ld serializer might not be fully deterministic in all cases.
+            # We avoid to_canonical_graph() here as it is extremely slow when
+            # called thousands of times.
+            try:
+                data = json.loads(ret)
+                return json.dumps(sort_dict(data), indent=2)
+            except Exception:
+                pass
+
         return ret
 
     @classmethod
@@ -1147,7 +1169,7 @@ class SdoTermSource:
                 )
                 files = []
                 for g in DEFTRIPLESFILESGLOB:
-                    files.extend(glob.glob(g))
+                    files.extend(sorted(glob.glob(g)))
         elif isinstance(files, str):
             cls.LOADEDDEFAULT = False
             log.info("SdoTermSource.loadSourceGraph() loading from file: %s", files)
@@ -1408,7 +1430,7 @@ def layerFromUri(uri: str) -> str:
             if voc.endswith("/") or voc.endswith("#"):
                 voc = voc[: len(voc) - 1]
             prto, root = getProtoAndRoot(voc)
-            LAYERPATTERN = "^%s([\w]*)\.%s" % (prto, root)
+            LAYERPATTERN = r"^%s([\w]*)\.%s" % (prto, root)
 
         if LAYERPATTERN:
             m = re.search(LAYERPATTERN, str(uri))
@@ -1432,7 +1454,7 @@ ProtoAndRoot = collections.namedtuple("ProtoAndRoot", ["proto", "root"])
 
 
 def getProtoAndRoot(uri: str) -> ProtoAndRoot:
-    m = re.search("^(http[s]?:\/\/)(.*)", uri)
+    m = re.search(r"^(http[s]?:\/\/)(.*)", uri)
     if m:
         prto = m.group(1)
         root = m.group(2)

--- a/software/scripts/shex_shacl_shapes_exporter.py
+++ b/software/scripts/shex_shacl_shapes_exporter.py
@@ -6,12 +6,19 @@
 import argparse
 import json
 import logging
+import os
+import sys
 from pathlib import Path
-from typing import Any, Generator, Optional, Set, Union
+
+if os.getcwd() not in sys.path:
+    sys.path.insert(1, os.getcwd())
 
 from rdflib import RDF, RDFS, BNode, Graph, Namespace, URIRef
+from rdflib.compare import to_canonical_graph
 from rdflib.collection import Collection
 from rdflib.term import Node
+
+from software.util.sort_dict import sort_dict
 
 BASE = Namespace("http://schema.org/validation#")
 SCHEMA = Namespace("http://schema.org/")
@@ -23,7 +30,7 @@ FILE_ENCODING = "utf-8"
 log = logging.getLogger(__name__)
 
 
-def replace_prefix(data: URIRef) -> URIRef:
+def replace_prefix(data):
     """
     Replaces schema.org prefix with schema.org validation prefix
     """
@@ -31,8 +38,38 @@ def replace_prefix(data: URIRef) -> URIRef:
 
 
 class ShExJParser:
-    @staticmethod
-    def parse_shape(source: Graph, shape: URIRef, is_datatype: bool) -> dict[str, Any]:
+    _ancestor_cache = {}
+    _domain_includes = {}
+    _range_includes = {}
+    _subclass_of = {}
+
+    @classmethod
+    def clear_caches(cls):
+        cls._ancestor_cache = {}
+        cls._domain_includes = {}
+        cls._range_includes = {}
+        cls._subclass_of = {}
+
+    @classmethod
+    def index_graph(cls, source):
+        cls.clear_caches()
+        for s, o in source.subject_objects(SCHEMA.domainIncludes):
+            cls._domain_includes.setdefault(o, []).append(s)
+        for s, o in source.subject_objects(SCHEMA.rangeIncludes):
+            cls._range_includes.setdefault(s, []).append(o)
+        for s, o in source.subject_objects(RDFS.subClassOf):
+            cls._subclass_of.setdefault(s, []).append(o)
+
+        # Pre-sort indexed lists for predictability
+        for k in cls._domain_includes:
+            cls._domain_includes[k].sort(key=str)
+        for k in cls._range_includes:
+            cls._range_includes[k].sort(key=str)
+        for k in cls._subclass_of:
+            cls._subclass_of[k].sort(key=str)
+
+    @classmethod
+    def parse_shape(cls, source, shape, is_datatype):
         """
         Creates shape ShExJ shape for schema.org entity
 
@@ -43,7 +80,7 @@ class ShExJParser:
         """
 
         shape_id = replace_prefix(shape)
-        node: Optional[dict[str, Any]] = None
+        node = None
         if is_datatype:
             node = {
                 "type": "NodeConstraint",
@@ -51,32 +88,34 @@ class ShExJParser:
             }
         else:
             node = {"type": "Shape"}
-            properties = list(source.subjects(SCHEMA.domainIncludes, shape))
+            properties = cls._domain_includes.get(shape, [])
+
             # find all subclasses
-            ancestors = list(set(ShExJParser.find_parent_classes(source, shape)))
+            ancestors = sorted(list(set(cls.find_parent_classes(source, shape))), key=str)
             if properties:
                 expression = {
                     "type": "EachOf",
-                    "expressions": [ShExJParser.type_constraint(ancestors + [shape])],
+                    "expressions": [cls.type_constraint(sorted(ancestors + [shape], key=str))],
                 }
-                for prop in properties:
+                for prop in sorted(properties, key=str):
                     expression["expressions"].append(
-                        ShExJParser.parse_property(source, prop)
+                        cls.parse_property(source, prop)
                     )
                 node["expression"] = expression
             else:
-                node["expression"] = ShExJParser.type_constraint(ancestors + [shape_id])
+                node["expression"] = cls.type_constraint(sorted(ancestors + [shape], key=str))
             node["extra"] = [RDF.type]
-            parents = [
-                replace_prefix(URIRef(x)) for x in source.objects(shape, RDFS.subClassOf)
-            ]
+
+            parents = sorted([
+                replace_prefix(URIRef(x)) for x in cls._subclass_of.get(shape, [])
+            ], key=str)
             if parents:
                 node["extends"] = parents
 
         return {"type": "ShapeDecl", "id": shape_id, "shapeExpr": node}
 
     @staticmethod
-    def type_constraint(types: list[URIRef]) -> dict[str, Any]:
+    def type_constraint(types):
         """
         Creates rdf:type constraints
 
@@ -89,8 +128,8 @@ class ShExJParser:
             "valueExpr": {"type": "NodeConstraint", "values": types},
         }
 
-    @staticmethod
-    def parse_property(source: Graph, prop: URIRef) -> dict[str, Any]:
+    @classmethod
+    def parse_property(cls, source, prop):
         """
         Creates property constraints
 
@@ -99,17 +138,17 @@ class ShExJParser:
         :return: JSON(dict) with ShExJ representation of property constraints
         """
         node = {"type": "TripleConstraint", "predicate": prop, "min": 0, "max": -1}
-        prop_range = [
-            replace_prefix(URIRef(x)) for x in source.objects(prop, SCHEMA.rangeIncludes)
-        ]
+        prop_range = sorted([
+            replace_prefix(URIRef(x)) for x in cls._range_includes.get(prop, [])
+        ], key=str)
         if len(prop_range) == 1:
             node["valueExpr"] = prop_range[0]
         elif prop_range:
             node["valueExpr"] = {"type": "ShapeOr", "shapeExprs": prop_range}
         return node
 
-    @staticmethod
-    def find_parent_classes(source: Graph, shape: URIRef) -> list[URIRef]:
+    @classmethod
+    def find_parent_classes(cls, source, shape):
         """
         Finds all ancestors of the shape in the subclasses tree using transitive closure.
 
@@ -117,24 +156,30 @@ class ShExJParser:
         :param shape: child shape IRI
         :return: list of all ancestor IRIs
         """
+        if shape in cls._ancestor_cache:
+            return cls._ancestor_cache[shape]
+
         # transitive_objects(shape, RDFS.subClassOf) returns an iterator including shape
         # itself, but we want ancestors, so we remove it from the result.
         ancestors = list(source.transitive_objects(shape, RDFS.subClassOf))
         if shape in ancestors:
             ancestors.remove(shape)
-        return [URIRef(c) for c in ancestors if isinstance(c, URIRef)]
+        res = [URIRef(c) for c in ancestors if isinstance(c, URIRef)]
+        cls._ancestor_cache[shape] = res
+        return res
 
-    @staticmethod
-    def to_shex(source: Graph) -> str:
+    @classmethod
+    def to_shex(cls, source):
         """
         Creates ShExJ constraints for schema.org terms definition
 
         :param source: source rdflib graph
         :return: string representation of ShExJ constraints
         """
+        cls.index_graph(source)
         shapes = sorted(source.subjects(RDF.type, RDFS.Class), key=str)
 
-        all_datatypes: set[URIRef] = {URIRef(SCHEMA.DataType)}
+        all_datatypes = {URIRef(SCHEMA.DataType)}
         # Use transitive_subjects to find all subclasses of DataType
         for dt_sub in source.transitive_subjects(RDFS.subClassOf, SCHEMA.DataType):
             if isinstance(dt_sub, URIRef):
@@ -143,7 +188,7 @@ class ShExJParser:
         shex = {
             "type": "Schema",
             "shapes": [
-                ShExJParser.parse_shape(
+                cls.parse_shape(
                     source, URIRef(shape), is_datatype=shape in all_datatypes
                 )
                 for shape in shapes
@@ -151,12 +196,12 @@ class ShExJParser:
             ],
         }
 
-        return json.dumps(shex)
+        return json.dumps(sort_dict(shex))
 
 
 class ShaclParser:
     @staticmethod
-    def parse_shape(source: Graph, shape: URIRef, dest: Graph) -> None:
+    def parse_shape(source, shape, dest):
         """
         Creates SHACL shape for schema.org entity
 
@@ -168,7 +213,7 @@ class ShaclParser:
         dest.add((node, RDF.type, SHACL.NodeShape))
         dest.add((node, SHACL.targetClass, shape))
         dest.add((node, SHACL.nodeKind, SHACL.BlankNodeOrIRI))
-        properties = list(source.subjects(SCHEMA.domainIncludes, shape))
+        properties = sorted(ShExJParser._domain_includes.get(shape, []), key=str)
         for prop in properties:
             if isinstance(prop, URIRef):
                 dest.add(
@@ -180,7 +225,7 @@ class ShaclParser:
                 )
 
     @staticmethod
-    def parse_property(source: Graph, prop: URIRef, dest: Graph) -> BNode:
+    def parse_property(source, prop, dest):
         """
         Creates property constraints
 
@@ -191,9 +236,9 @@ class ShaclParser:
         """
         node = BNode()
         dest.add((node, SHACL.path, prop))
-        property_range = [
-            replace_prefix(URIRef(x)) for x in source.objects(prop, SCHEMA.rangeIncludes)
-        ]
+        property_range = sorted([
+            replace_prefix(URIRef(x)) for x in ShExJParser._range_includes.get(prop, [])
+        ], key=str)
         if len(property_range) > 1:
             or_node = BNode()
             or_collection = Collection(dest, or_node)
@@ -207,7 +252,7 @@ class ShaclParser:
         return node
 
     @staticmethod
-    def get_subclasses(source: Graph) -> str:
+    def get_subclasses(source):
         """
         Creates subclasses tree
 
@@ -218,12 +263,19 @@ class ShaclParser:
         subclasses.bind("sh", SHACL)
         subclasses.bind("schema", SCHEMA)
         subclasses.bind("rdfs", RDFS)
-        for s, p, o in source.triples((None, RDFS.subClassOf, None)):
+        # Use str() for sorting to be deterministic and fast enough
+        for s, p, o in sorted(source.triples((None, RDFS.subClassOf, None)), key=lambda t: (str(t[0]), str(t[1]), str(t[2]))):
             subclasses.add((s, p, o))
-        return subclasses.serialize(format="turtle")
+
+        log.info(f"Canonicalizing subclasses graph ({len(subclasses)})")
+        nsMgr = subclasses.namespace_manager
+        subclasses = to_canonical_graph(subclasses)
+        subclasses.namespace_manager = nsMgr
+
+        return subclasses.serialize(format="turtle", sort_keys=True)
 
     @staticmethod
-    def to_shacl(source: Graph) -> str:
+    def to_shacl(source):
         """
         Creates SHACL constraints from schema.org terms definitions
 
@@ -234,19 +286,27 @@ class ShaclParser:
         dest.bind("sh", SHACL)
         dest.bind("schema", SCHEMA)
         dest.bind("", BASE)
-        shapes = source.subjects(RDF.type, RDFS.Class)
+        shapes = sorted(source.subjects(RDF.type, RDFS.Class), key=str)
         for shape in shapes:
             if isinstance(shape, URIRef):
                 ShaclParser.parse_shape(source, shape, dest)
-        return dest.serialize(format="turtle")
+
+        # Use to_canonical_graph to ensure deterministic blank node naming and sorting
+        # This takes about 25 minutes to compute, so we leave it out for the moment.
+        # log.info(f"Canonicalizing ShAcl shapes graph ({len(dest)})")
+        # nsMgr = dest.namespace_manager
+        # dest = to_canonical_graph(dest)
+        # dest.namespace_manager = nsMgr
+
+        return dest.serialize(format="turtle", sort_keys=True)
 
 
 def generate_files(
-    term_defs_path: Union[str, Path],
-    outputdir: Union[str, Path],
-    outputfileprefix: str = "",
-    input_format: str = "nt",
-) -> None:
+    term_defs_path,
+    outputdir,
+    outputfileprefix="",
+    input_format="nt",
+):
     term_defs_path = Path(term_defs_path)
     outputdir = Path(outputdir)
     outputdir.mkdir(parents=True, exist_ok=True)

--- a/software/util/buildfiles.py
+++ b/software/util/buildfiles.py
@@ -12,6 +12,7 @@ from typing import Any
 import rdflib
 import rdflib.namespace
 import sys
+from rdflib.compare import to_canonical_graph
 
 # Import schema.org libraries
 if not os.getcwd() in sys.path:
@@ -293,6 +294,11 @@ def _exportrdf(output_format, all, current, subdirectory_path: str | None = None
             g = all
         else:
             g = current
+
+        nsMgr = g.namespace_manager
+        canonical_g = to_canonical_graph(g)
+        g.namespace_manager = nsMgr
+
         if output_format == "nquads":
             gr = rdflib.Dataset()
             qg = gr.graph(rdflib.URIRef("%s://schema.org/%s" % (protocol, version)))
@@ -327,7 +333,7 @@ def array2str(values):
 
 
 def uriwrap(thing):
-    """Convert various types into uris."""
+    """Convert various types into uris. Sorts items if they are a list."""
     if not thing:
         return ""
     if isinstance(thing, str):
@@ -341,7 +347,7 @@ def uriwrap(thing):
     if isinstance(thing, sdoterm.SdoTerm):
         return uriwrap(thing.id)
     try:
-        return array2str(map(uriwrap, thing))
+        return array2str(sorted(map(uriwrap, thing)))
     except TypeError as e:
         log.fatal("Cannot uriwrap %s:%s", thing, e)
 

--- a/software/util/buildfiles.py
+++ b/software/util/buildfiles.py
@@ -8,7 +8,6 @@ import json
 import logging
 import os
 from pathlib import Path
-from typing import Any
 import rdflib
 import rdflib.namespace
 import sys
@@ -31,6 +30,7 @@ import software.util.textutils as textutils
 import software.SchemaTerms.sdotermsource as sdotermsource
 import software.SchemaTerms.sdoterm as sdoterm
 import software.SchemaExamples.schemaexamples as schemaexamples
+from software.util.sort_dict import sort_dict, sort_xml
 
 VOCABURI = sdotermsource.SdoTermSource.vocabUri()
 
@@ -84,7 +84,7 @@ def jsonldtree(page):
     context["children"] = {"@reverse": "rdfs:subClassOf"}
     term["@context"] = context
     data = _jsonldtree("Thing", term)
-    return json.dumps(data, indent=3)
+    return json.dumps(sort_dict(data), indent=3)
 
 
 def _jsonldtree(tid, term=None):
@@ -156,7 +156,7 @@ def sitemap(page):
 """)
     terms = sdotermsource.SdoTermSource.getAllTerms(suppressSourceLinks=True)
     version_date = schemaversion.getCurrentVersionDate()
-    for term in terms:
+    for term in sorted(terms):
         if not (term.startswith("http://") or term.startswith("https://")):
             output.append(node % (term, version_date))
     for term in STATICPAGES:
@@ -187,7 +187,7 @@ allGraph = None
 currentGraph = None
 
 
-def exportrdf(exportType, subdirectory_path: str | None = None):
+def exportrdf(exportType, subdirectory_path=None):
     global allGraph, currentGraph
 
     if not allGraph:
@@ -279,7 +279,7 @@ def exportrdf(exportType, subdirectory_path: str | None = None):
 completed_rdf_exports = set()
 
 
-def _exportrdf(output_format, all, current, subdirectory_path: str | None = None):
+def _exportrdf(output_format, all_graph, current_graph, subdirectory_path=None):
     protocol, altprotocol = protocols()
 
     if output_format in completed_rdf_exports:
@@ -291,12 +291,12 @@ def _exportrdf(output_format, all, current, subdirectory_path: str | None = None
 
     for selector in fileutils.FILESET_SELECTORS:
         if fileutils.isAll(selector):
-            g = all
+            g = all_graph
         else:
-            g = current
+            g = current_graph
 
         nsMgr = g.namespace_manager
-        canonical_g = to_canonical_graph(g)
+        g = to_canonical_graph(g)
         g.namespace_manager = nsMgr
 
         if output_format == "nquads":
@@ -319,7 +319,21 @@ def _exportrdf(output_format, all, current, subdirectory_path: str | None = None
                     fmt = "pretty-xml"
                 else:
                     fmt = output_format
-                out = g.serialize(format=fmt, auto_compact=True, sort_keys=True)
+                out = g.serialize(format=fmt, auto_compact=True, sort_keys=True, max_depth=1)
+                if output_format in ("nt", "nquads"):
+                    out = "\n".join(sorted(line.rstrip() for line in out.splitlines() if line.strip())) + "\n"
+                if output_format == "rdf":
+                    try:
+                        out = sort_xml(out)
+                    except Exception as e:
+                        log.warning(f"Failed to sort RDF XML: {e}")
+                if output_format == "json-ld":
+                    try:
+                        data = json.loads(out)
+                        out = json.dumps(sort_dict(data), indent=2)
+                    except Exception as e:
+                        log.warning(f"Failed to sort JSON-LD: {e}")
+
                 with open(fn, "w", encoding="utf8") as f:
                     if p == altprotocol:
                         out = protocolSwap(out, protocol, altprotocol)
@@ -509,7 +523,7 @@ def writecsvout(ftype, data, fields, selector, protocol, altprotocol):
 def jsoncounts(page):
     counts = sdotermsource.SdoTermSource.termCounts()
     counts["schemaorgversion"] = schemaversion.getVersion()
-    return json.dumps(counts)
+    return json.dumps(sort_dict(counts))
 
 
 def jsonpcounts(page):
@@ -521,7 +535,7 @@ def jsonpcounts(page):
     return content
 
 
-def exportshex_shacl(page: Any) -> None:
+def exportshex_shacl(page):
     release_dir = Path.cwd() / schemaglobals.RELEASE_DIR / schemaversion.getVersion()
     shex_shacl_shapes_exporter.generate_files(
         term_defs_path=release_dir / "schemaorg-all-http.nt",
@@ -588,7 +602,7 @@ def buildFiles(files):
 
     for p in files:
         with pretty_logger.BlockLog(message=f"Preparing file {p}.", logger=log):
-            if p in FILELIST.keys():
+            if p in sorted(FILELIST.keys()):
                 func, filenames = FILELIST.get(p, None)
                 if func:
                     content = func(p)

--- a/software/util/buildocspages.py
+++ b/software/util/buildocspages.py
@@ -19,6 +19,7 @@ import software.util.pretty_logger as pretty_logger
 import software.util.schemaglobals as schemaglobals
 import software.util.schemaversion as schemaversion
 import software.util.textutils as textutils
+from software.util.sort_dict import sort_dict
 
 import software.SchemaTerms.sdotermsource as sdotermsource
 import software.SchemaTerms.sdocollaborators as sdocollaborators
@@ -192,7 +193,7 @@ def jsonldtree(page) -> str:
     context["children"] = {"@reverse": "rdfs:subClassOf"}
     term["@context"] = context
     data = _jsonldtree("Thing", visitset=set(), term=term)
-    return json.dumps(data, indent=2)
+    return json.dumps(sort_dict(data), indent=2)
 
 
 def _jsonldtree(tid: str, visitset: set, term: dict | None = None) -> dict:
@@ -268,7 +269,7 @@ def fullReleasePage(page):
         "date": schemaversion.getCurrentVersionDate(),
         "listings": listings,
         "types": types,
-        "properties": sdotermsource.SdoTermSource.getAllProperties(expanded=True),
+        "properties": sorted(sdotermsource.SdoTermSource.getAllProperties(expanded=True), key=lambda t: t.id),
     }
     return docsTemplateRender("docs/FullRelease.j2", extra_vars)
 

--- a/software/util/buildsite.py
+++ b/software/util/buildsite.py
@@ -211,7 +211,7 @@ def initdir(output_dir, handler_path):
         copystaticdocsplusinsert.copyFiles("./docs", "./software/site/docs")
 
     with pretty_logger.BlockLog(logger=log, message="Preparing GCloud files") as block:
-        gcloud_files = glob.glob("software/gcloud/*.yaml")
+        gcloud_files = sorted(glob.glob("software/gcloud/*.yaml"))
         for path in gcloud_files:
             shutil.copy(path, gdir)
         block.append("copied %d files" % len(gcloud_files))

--- a/software/util/copystaticdocsplusinsert.py
+++ b/software/util/copystaticdocsplusinsert.py
@@ -73,17 +73,17 @@ SRCDIR = "./docs"
 DESTDIR = "./software/site/docs"
 
 
-def htmlinserts(destdir: str):
+def htmlinserts(destdir):
     """Perform susbstitions on all HTML files in DESTDIR."""
     log.info("Adding header/footer templates to all html files")
-    docs = glob.glob(os.path.join(destdir, "*.html"))
+    docs = sorted(glob.glob(os.path.join(destdir, "*.html")))
     replacer = Replacer(destdir=destdir)
     for doc in docs:
         replacer.insertcopy(doc)
     log.info("Added to %d files" % len(docs))
 
 
-def copyFiles(srcdir: str, destdir: str):
+def copyFiles(srcdir, destdir):
     """Copy and complete all the static document pages."""
     fileutils.mycopytree(srcdir, destdir)
     log.info("Converting .md docs to html")

--- a/software/util/fileutils.py
+++ b/software/util/fileutils.py
@@ -38,7 +38,7 @@ def createMissingDir(dir_path):
         os.makedirs(dir_path)
 
 
-def isAll(selector: str):
+def isAll(selector):
     """Check if a selector string is a variation of the 'All' token."""
     return str(selector).lower() == FileSelector.ALL
 
@@ -55,7 +55,7 @@ def checkFilePath(path):
                 raise e
 
 
-def ensureAbsolutePath(output_dir: str, relative_path: str) -> str:
+def ensureAbsolutePath(output_dir, relative_path):
     """Convert into an absolute path and ensure the directory exists."""
     filepath = os.path.join(output_dir, relative_path)
     checkFilePath(os.path.dirname(filepath))
@@ -63,14 +63,14 @@ def ensureAbsolutePath(output_dir: str, relative_path: str) -> str:
 
 
 def releaseFilePath(
-    output_dir: str,
-    version: str,
-    selector: FileSelector,
-    protocol: str,
-    output_format: str,
-    suffix: str | None = None,
-    subdirectory_path: str | None = None,
-) -> str:
+    output_dir,
+    version,
+    selector,
+    protocol,
+    output_format,
+    suffix=None,
+    subdirectory_path=None,
+):
     """Create a path for a release file
 
     Args:

--- a/software/util/schemaversion.py
+++ b/software/util/schemaversion.py
@@ -4,6 +4,13 @@
 """Module that handles the schema.org version information."""
 
 import json
+import os
+import sys
+
+if os.getcwd() not in sys.path:
+    sys.path.insert(1, os.getcwd())
+
+from software.util.sort_dict import sort_dict
 
 ###################################################
 # VERSION INFO LOAD
@@ -40,7 +47,7 @@ def setVersion(ver, date):
     vers = dict(sorted(vers.items(), key=lambda x: float(x[0]), reverse=True))
     versiondata["releaseLog"] = vers
     with open("versions.json", "w") as json_file:
-        json_file.write(json.dumps(versiondata, indent=4))
+        json_file.write(json.dumps(sort_dict(versiondata), indent=4))
 
 
 if __name__ == "__main__":

--- a/software/util/sdojsonldcontext.py
+++ b/software/util/sdojsonldcontext.py
@@ -1,13 +1,10 @@
 #!/usr/bin/env python3
 # -*- coding: utf-8 -*-
 
-# Import standard python libraries
-
 import json
 import logging
 import os
 import sys
-import typing
 
 # Import schema.org libraries
 if not os.getcwd() in sys.path:
@@ -17,12 +14,12 @@ import software
 import software.SchemaTerms.sdotermsource as sdotermsource
 import software.SchemaTerms.sdoterm as sdoterm
 import software.util.pretty_logger as pretty_logger
+from software.util.sort_dict import sort_dict
 
 log = logging.getLogger(__name__)
 
 
 CONTEXT = None
-SCHEMAURI = "http://schema.org/"
 
 
 def getContext():
@@ -32,7 +29,10 @@ def getContext():
     return CONTEXT
 
 
-def _convertTypes(type_range: typing.Collection[str]) -> typing.Set[str]:
+SCHEMAURI = "http://schema.org/"
+
+
+def _convertTypes(type_range: list[str]) -> set[str]:
     types = set()
     if "Text" in type_range:
         return types
@@ -64,7 +64,7 @@ def createcontext():
                     path = SCHEMAURI  # Override vocab setting to maintain http compatibility
                 if pref == "geo":
                     continue
-                json_context[pref] = path
+                json_context[pref] = str(path)
 
         for term in sdotermsource.SdoTermSource.getAllTerms(
             expanded=True, suppressSourceLinks=True
@@ -80,4 +80,4 @@ def createcontext():
                     term_json["@type"] = sorted(types)
             json_context[term.id] = term_json
         json_object = {"@context": json_context}
-        return json.dumps(json_object, indent=2)
+        return json.dumps(sort_dict(json_object), indent=2)

--- a/software/util/sdoowl.py
+++ b/software/util/sdoowl.py
@@ -83,13 +83,17 @@ def _MakePrettyComment(text):
 
 class OwlBuild:
     def __init__(self):
+        from localmarkdown import MarkdownTool
         self.typesCount = self.propsCount = self.namedCount = 0
+        old_pre = MarkdownTool.WPRE
+        MarkdownTool.setWikilinkPrePath("/")
         self._createDom()
         self._loadGraph()
+        MarkdownTool.setWikilinkPrePath(old_pre)
 
     def _createDom(self):
         self.dom = ElementTree.Element("rdf:RDF")
-        for k, v in NAMESPACES.items():
+        for k, v in sorted(NAMESPACES.items()):
             self.dom.set(k, v)
 
         version = schemaversion.getVersion()
@@ -154,7 +158,7 @@ class OwlBuild:
         typ = ElementTree.SubElement(self.dom, "owl:Class")
         typ.set("rdf:about", uri)
         ext = None
-        for p, o in graph.predicate_objects(uri):
+        for p, o in sorted(graph.predicate_objects(uri)):
             if p == RDFS.label:
                 l = ElementTree.SubElement(typ, "rdfs:label")
                 l.set("xml:lang", "en")
@@ -181,7 +185,7 @@ class OwlBuild:
         ranges = []
         datatypeonly = True
         ext = None
-        for p, o in graph.predicate_objects(uri):
+        for p, o in sorted(graph.predicate_objects(uri)):
             if p == RDFS.label:
                 l = ElementTree.Element("rdfs:label")
                 l.set("xml:lang", "en")
@@ -222,7 +226,7 @@ class OwlBuild:
         children.append(self.addDefined(uri, ext))
 
         if not datatypeonly:
-            for r in DEFAULTRANGES:
+            for r in sorted(list(DEFAULTRANGES)):
                 if r not in ranges:
                     ranges.append(r)
 
@@ -232,7 +236,7 @@ class OwlBuild:
             cl = ElementTree.SubElement(d, "owl:Class")
             u = ElementTree.SubElement(cl, "owl:unionOf")
             u.set("rdf:parseType", "Collection")
-            for target in domains.keys():
+            for target in sorted(domains.keys(), key=str):
                 targ = ElementTree.SubElement(u, "owl:Class")
                 targ.set("rdf:about", target)
 
@@ -242,7 +246,7 @@ class OwlBuild:
             cl = ElementTree.SubElement(r, "owl:Class")
             u = ElementTree.SubElement(cl, "owl:unionOf")
             u.set("rdf:parseType", "Collection")
-            for target in ranges:
+            for target in sorted(ranges, key=str):
                 targ = ElementTree.SubElement(u, "owl:Class")
                 targ.set("rdf:about", target)
 
@@ -271,7 +275,7 @@ class OwlBuild:
         }
         """
         enums = list(graph.query(q))
-        for row in enums:
+        for row in sorted(enums):
             self.outputNamedIndividuals(row.enum, graph, parent=row.parent)
 
     def outputNamedIndividuals(self, individual, graph, parent=None):
@@ -280,7 +284,7 @@ class OwlBuild:
         typ = ElementTree.SubElement(self.dom, "owl:NamedIndividual")
         typ.set("rdf:about", individual)
         ext = None
-        for p, o in graph.predicate_objects(URIRef(individual)):
+        for p, o in sorted(graph.predicate_objects(URIRef(individual))):
             if p == RDFS.label:
                 l = ElementTree.SubElement(typ, "rdfs:label")
                 l.set("xml:lang", "en")

--- a/software/util/sort_dict.py
+++ b/software/util/sort_dict.py
@@ -1,0 +1,109 @@
+#!/usr/bin/env python3
+# -*- coding: utf-8 -*-
+
+from xml.dom import minidom
+from xml.etree import ElementTree
+
+KEY_ORDER = ["@context", "@id", "@type"]
+
+
+def sort_xml(xml_input):
+    """Sorts children of an XML element for deterministic output.
+
+    If the input is a string, it will be parsed as an XML Element.
+    The function returns a formatted XML string.
+    """
+    if isinstance(xml_input, str):
+        root = ElementTree.fromstring(xml_input)
+    elif isinstance(xml_input, ElementTree.Element):
+        root = xml_input
+    else:
+        raise TypeError(f"Expected str or ElementTree.Element, got {type(xml_input)}")
+
+    def get_key(elem):
+        # We look for rdf:about or about attribute
+        about = elem.get("{http://www.w3.org/1999/02/22-rdf-syntax-ns#}about") or elem.get("about")
+        if about:
+            return (about, "", "")
+        # Fallback to tag name (primary) and resource or string representation (secondary)
+        tag = elem.tag
+        resource = elem.get("{http://www.w3.org/1999/02/22-rdf-syntax-ns#}resource") or elem.get("resource")
+        if resource:
+            return (tag, resource, "")
+        return (tag, "", ElementTree.tostring(elem, encoding="unicode"))
+
+    def recursive_sort(element):
+        children = list(element)
+        if not children:
+            return
+        children.sort(key=get_key)
+        for child in list(element):
+            element.remove(child)
+        for child in children:
+            element.append(child)
+            recursive_sort(child)
+
+    recursive_sort(root)
+
+    pretty_xml = (
+        minidom.parseString(ElementTree.tostring(root))
+        .toprettyxml(encoding="UTF-8")
+        .decode()
+    )
+
+    # Filter out empty lines and strip trailing whitespace from each line
+    lines = [line.rstrip() for line in pretty_xml.splitlines() if line.strip()]
+
+    return "\n".join(lines) + "\n"
+
+
+def universal_sort_key(item):
+
+    """Sort key for dictionary items (k, v).
+
+    Returns a priority rank and the key name itself.
+    """
+    k, v = item
+    if k in KEY_ORDER:
+        return (KEY_ORDER.index(k), k)
+    if k.startswith("@"):
+        return (len(KEY_ORDER), k)
+    if isinstance(v, (str, bytes, bool, int, float)) or v is None:
+        return (len(KEY_ORDER) + 1, k)
+    return (len(KEY_ORDER) + 2, k)
+
+
+def list_sort_key(item):
+    """Sort key for list items."""
+    if isinstance(item, dict):
+        # Prefer sorting by @id, then @type, then string representation
+        return str(item.get("@id", item.get("@type", str(item))))
+    return str(item)
+
+
+def sort_dict(data):
+    """Recursively sort dictionary keys and list elements for predictability.
+
+    Uses universal_sort_key for dictionaries. 
+    Sorts all lists for determinism, using list_sort_key for elements.
+    """
+    if isinstance(data, dict):
+        try:
+            # Sort keys based on universal priorities
+            sorted_items = sorted(data.items(), key=universal_sort_key)
+            return {k: sort_dict(v) for k, v in sorted_items}
+        except Exception:
+            # Fallback to original order if sorting fails
+            return {k: sort_dict(v) for k, v in data.items()}
+
+    elif isinstance(data, list):
+        try:
+            # Process items in the list and sort them
+            # Sorting all lists ensures 100% determinism.
+            sorted_list = sorted(data, key=list_sort_key)
+            return [sort_dict(i) for i in sorted_list]
+        except Exception:
+            # Fallback: process items without sorting if not comparable
+            return [sort_dict(i) for i in data]
+
+    return data


### PR DESCRIPTION
This expands the software to generate the diverse artifacts (schema files in many formats, Type and Properties pages, etc.) in a deterministic way. 
The goal is to be able to refactor some of the code and have an easier way to compare the outputs and check that we did indeed get the same data.

Note: the Shacl exporter would need to compute a canonical graph to be deterministic, which takes around 25 minutes. This is therefore left as-is, so there will be minimal differences.

Runtime before: 3'37"
Runtime after:  3'41"