### PR TITLE
Modernize python (functional no-op)

### DIFF
--- a/software/SchemaExamples/schemaexamples.py
+++ b/software/SchemaExamples/schemaexamples.py
@@ -41,7 +41,7 @@ class Example:
         self.terms: List[str] = terms
         if not len(terms):
             log.info(
-                "No terms for ex: %s in file %s" % (exmeta.get("filepos"), exmeta.get("file"))
+                f"No terms for ex: {exmeta.get('filepos')} in file {exmeta.get('file')}"
             )
             first_term: str = "Empty"
         else:
@@ -54,7 +54,7 @@ class Example:
         self.exmeta: Dict[str, Any] = exmeta
         self.keyvalue: Optional[str] = self.exmeta.get("id", None)
         if not self.keyvalue:
-            self.keyvalue = "%s-temp-%s" % (first_term, Example.ExamplesCount)
+            self.keyvalue = f"{first_term}-temp-{Example.ExamplesCount}"
             self.exmeta["id"] = self.keyvalue
         else:
             idnum: int = self.getIdNum()
@@ -70,18 +70,12 @@ class Example:
         if not len(self.terms):
             buf.append("No Terms!")
         else:
-            buf.append("%s" % self.terms)
-        buf.append("\nKeyvalue: %s" % self.keyvalue)
+            buf.append(f"{self.terms}")
+        buf.append(f"\nKeyvalue: {self.keyvalue}")
         buf.append(
-            "\nOrigLen: %s MicroLen: %s RdfaLen: %s JsonLen: %s"
-            % (
-                len(self.original_html),
-                len(self.microdata),
-                len(self.rdfa),
-                len(self.jsonld),
-            )
+            f"\nOrigLen: {len(self.original_html)} MicroLen: {len(self.microdata)} RdfaLen: {len(self.rdfa)} JsonLen: {len(self.jsonld)}"
         )
-        buf.append("\nexmeta: %s" % self.exmeta)
+        buf.append(f"\nexmeta: {self.exmeta}")
         return "".join(buf)
 
     def getKey(self) -> Optional[str]:
@@ -180,12 +174,12 @@ class Example:
 
     def serialize(self) -> str:
         termnames: str = ", ".join(self.terms)
-        idd: str = "#%s" % self.keyvalue
+        idd: str = f"#{self.keyvalue}"
         if "-temp-" in idd:
             idd = ""
 
         sections: List[str] = [
-            "TYPES: %s %s\n" % (idd, termnames),
+            f"TYPES: {idd} {termnames}\n",
             "PRE-MARKUP:",
             self.getHtml(),
             "MICRODATA:",
@@ -204,7 +198,7 @@ class Example:
 
     @staticmethod
     def formatId(val: int) -> str:
-        return "eg-{0:04d}".format(val)
+        return f"eg-{val:04d}"
 
     @staticmethod
     def nextIdReset(val: Optional[int] = None) -> None:
@@ -234,20 +228,19 @@ class SchemaExamples:
         load_files: List[str] = []
         if not exfiles or exfiles == "default":
             log.info(
-                "SchemaExamples.loadExamplesFiles() loading from default files found in globs: %s"
-                % ",".join(DEFTEXAMPLESFILESGLOB)
+                f"SchemaExamples.loadExamplesFiles() loading from default files found in globs: {','.join(DEFTEXAMPLESFILESGLOB)}"
             )
             for g in DEFTEXAMPLESFILESGLOB:
                 load_files.extend(sorted(glob.glob(g)))
 
         elif isinstance(exfiles, str):
             log.info(
-                "SchemaExamples.loadExamplesFiles() loading from file: %s" % exfiles
+                f"SchemaExamples.loadExamplesFiles() loading from file: {exfiles}"
             )
             load_files = [exfiles]
         else:
             log.info(
-                "SchemaExamples.loadExamplesFiles() loading from %d" % len(list(exfiles))
+                f"SchemaExamples.loadExamplesFiles() loading from {len(list(exfiles))}"
             )
             load_files = list(exfiles)
 
@@ -278,7 +271,7 @@ class SchemaExamples:
         if not SchemaExamples.EXAMPLESLOADED:
             log.info("Loading examples files")
             SchemaExamples.loadExamplesFiles("default")
-            log.info("Loaded %d examples", SchemaExamples.count())
+            log.info(f"Loaded {SchemaExamples.count()} examples")
 
     @staticmethod
     def examplesForTerm(term: str) -> List[Example]:
@@ -369,7 +362,7 @@ class ExampleFileParser:
                 if inwhitespace:
                     temp.append("\n")
                     inwhitespace = False
-                temp.append(line + "\n")
+                temp.append(f"{line}\n")
 
         if not inwhitespace:
             temp.append("\n")
@@ -381,8 +374,7 @@ class ExampleFileParser:
             self.idcache.append(ident)
         else:
             raise Exception(
-                "Example %s in file %s has duplicate identifier: '%s'"
-                % (self.filepos, self.file, ident)
+                f"Example {self.filepos} in file {self.file} has duplicate identifier: '{ident}'"
             )
         self.exmeta["id"] = ident
         return ""
@@ -447,7 +439,7 @@ class ExampleFileParser:
                 for ttli in ttl:
                     ttli = ttli.strip()
                     if len(ttli):
-                        if "@@" not in ttli and not "FakeEntryNeeded" in ttli:
+                        if "@@" not in ttli and "FakeEntryNeeded" not in ttli:
                             self.terms.append(ttli)
                         else:
                             boilerplate = True

--- a/software/SchemaExamples/schemaexamples.py
+++ b/software/SchemaExamples/schemaexamples.py
@@ -7,10 +7,12 @@ import io
 import glob
 import re
 import threading
+import typing
+from typing import Any, Dict, List, Optional, Tuple, Union, Iterable, Sequence, Set, Collection
 
-IDPREFIX = "eg-"
-DEFTEXAMPLESFILESGLOB = ("data/*examples.txt", "data/ext/*/*examples.txt")
-NO_JSON_REGEXPS = (
+IDPREFIX: str = "eg-"
+DEFTEXAMPLESFILESGLOB: Tuple[str, str] = ("data/*examples.txt", "data/ext/*/*examples.txt")
+NO_JSON_REGEXPS: Tuple[re.Pattern, ...] = (
     re.compile("No JSON-?LD", re.I),
     re.compile("This example is in microdata only", re.I),
     re.compile("No Json example available", re.I),
@@ -18,51 +20,52 @@ NO_JSON_REGEXPS = (
 )
 
 
-ldscript_match = re.compile(
+ldscript_match: re.Pattern = re.compile(
     r'[\s\S]*<\s*script\s+type="application\/ld\+json"\s*>(.*)<\s*\/script\s*>[\s\S]*',
     re.S,
 )
 
 
-log = logging.getLogger(__name__)
+log: logging.Logger = logging.getLogger(__name__)
 
 
 class Example:
     """Representation of an example file, with accessors for the various parts."""
 
-    ExamplesCount = 0
-    MaxId = 0
+    ExamplesCount: int = 0
+    MaxId: int = 0
 
     def __init__(
-        self, terms, original_html, microdata, rdfa, jsonld, exmeta, jsonld_offset=None
-    ):
-        self.terms = terms
+        self, terms: List[str], original_html: str, microdata: str, rdfa: str, jsonld: str, exmeta: Dict[str, Any], jsonld_offset: Optional[int] = None
+    ) -> None:
+        self.terms: List[str] = terms
         if not len(terms):
             log.info(
-                "No terms for ex: %s in file %s" % (exmeta["filepos"], exmeta["file"])
+                "No terms for ex: %s in file %s" % (exmeta.get("filepos"), exmeta.get("file"))
             )
-            first_term = "Empty"
+            first_term: str = "Empty"
         else:
             first_term = terms[0]
-        self.original_html = original_html
-        self.microdata = microdata
-        self.rdfa = rdfa
-        self.jsonld = jsonld
-        self.jsonld_offset = jsonld_offset
-        self.exmeta = exmeta
-        self.keyvalue = self.exmeta.get("id", None)
+        self.original_html: str = original_html
+        self.microdata: str = microdata
+        self.rdfa: str = rdfa
+        self.jsonld: str = jsonld
+        self.jsonld_offset: Optional[int] = jsonld_offset
+        self.exmeta: Dict[str, Any] = exmeta
+        self.keyvalue: Optional[str] = self.exmeta.get("id", None)
         if not self.keyvalue:
             self.keyvalue = "%s-temp-%s" % (first_term, Example.ExamplesCount)
             self.exmeta["id"] = self.keyvalue
         else:
-            idnum = self.getIdNum()
+            idnum: int = self.getIdNum()
             if idnum > -1:
                 Example.MaxId = max(Example.MaxId, idnum)
                 self.keyvalue = Example.formatId(idnum)
         Example.ExamplesCount += 1
+        self.exselect: List[str] = []
 
-    def __str__(self):
-        buf = []
+    def __str__(self) -> str:
+        buf: List[str] = []
         buf.append("Example: \nTerms: ")
         if not len(self.terms):
             buf.append("No Terms!")
@@ -81,41 +84,41 @@ class Example:
         buf.append("\nexmeta: %s" % self.exmeta)
         return "".join(buf)
 
-    def getKey(self):
+    def getKey(self) -> Optional[str]:
         return self.keyvalue
 
-    def setKey(self, key):
+    def setKey(self, key: str) -> None:
         self.keyvalue = key
 
-    def terms(self):
+    def getTerms(self) -> List[str]:
         return self.terms
 
-    def setTerms(self, terms):
+    def setTerms(self, terms: List[str]) -> None:
         self.terms = terms
 
-    def getHtml(self):
+    def getHtml(self) -> str:
         return self.original_html
 
-    def setHtml(self, content):
+    def setHtml(self, content: str) -> None:
         self.original_html = content
 
-    def getMicrodata(self):
+    def getMicrodata(self) -> str:
         return self.microdata
 
-    def setMicrodata(self, content):
+    def setMicrodata(self, content: str) -> None:
         self.microdata = content
 
-    def getRdfa(self):
+    def getRdfa(self) -> str:
         return self.rdfa
 
-    def setRdfa(self, content):
+    def setRdfa(self, content: str) -> None:
         self.rdfa = content
 
-    def getJsonld(self):
+    def getJsonld(self) -> str:
         return self.jsonld
 
-    def getJsonldRaw(self):
-        jsondata = self.getJsonld()
+    def getJsonldRaw(self) -> str:
+        jsondata: str = self.getJsonld()
         jsondata = jsondata.strip()
         if len(jsondata):
             jsonmatch = ldscript_match.match(jsondata)
@@ -124,29 +127,29 @@ class Example:
                 jsondata = jsonmatch.group(1).strip()
         return jsondata
 
-    def setJsonld(self, content):
+    def setJsonld(self, content: str) -> None:
         self.jsonld = content
 
-    def hasHtml(self):
+    def hasHtml(self) -> bool:
         return len(self.original_html.strip()) > 0
 
-    def hasMicrodata(self):
-        content = self.microdata.strip()
+    def hasMicrodata(self) -> bool:
+        content: str = self.microdata.strip()
         if len(content) > 0:
             if "itemtype" in content and "itemprop" in content:
                 return True
         return False
 
-    def hasRdfa(self):
-        content = self.rdfa.strip()
+    def hasRdfa(self) -> bool:
+        content: str = self.rdfa.strip()
         if len(content) > 0:
             if "typeof" in content and "property" in content:
                 return True
         return False
 
-    def hasJsonld(self):
+    def hasJsonld(self) -> bool:
         """Return True if there is real JSON, and not a placehold comment in the JSON section."""
-        json_content = self.getJsonldRaw()
+        json_content: str = self.getJsonldRaw()
         if not json_content:
             return False
         for reg in NO_JSON_REGEXPS:
@@ -157,31 +160,31 @@ class Example:
                 return True
         return False
 
-    def setMeta(self, name, val):
+    def setMeta(self, name: str, val: Any) -> None:
         self.exmeta[name] = val
 
-    def getMeta(self, name):
+    def getMeta(self, name: str) -> Any:
         return self.exmeta.get(name, None)
 
-    def getIdNum(self):
-        idnum = -1
-        if self.keyvalue.startswith(IDPREFIX):
+    def getIdNum(self) -> int:
+        idnum: int = -1
+        if self.keyvalue and self.keyvalue.startswith(IDPREFIX):
             try:
                 idnum = int(self.keyvalue[len(IDPREFIX) :])
-            except:
+            except (ValueError, TypeError):
                 pass
         return idnum
 
-    def hasValidId(self):
+    def hasValidId(self) -> bool:
         return self.getIdNum() > -1
 
-    def serialize(self):
-        termnames = ", ".join(self.terms)
-        idd = "#%s" % self.keyvalue
+    def serialize(self) -> str:
+        termnames: str = ", ".join(self.terms)
+        idd: str = "#%s" % self.keyvalue
         if "-temp-" in idd:
             idd = ""
 
-        sections = [
+        sections: List[str] = [
             "TYPES: %s %s\n" % (idd, termnames),
             "PRE-MARKUP:",
             self.getHtml(),
@@ -195,66 +198,67 @@ class Example:
         return "\n".join(sections)
 
     @staticmethod
-    def nextId():
+    def nextId() -> str:
         Example.MaxId += 1
         return Example.formatId(Example.MaxId)
 
     @staticmethod
-    def formatId(val):
+    def formatId(val: int) -> str:
         return "eg-{0:04d}".format(val)
 
     @staticmethod
-    def nextIdReset(val=None):
-        if not val:
+    def nextIdReset(val: Optional[int] = None) -> None:
+        if val is None:
             val = 0
         Example.MaxId = val
 
 
 class SchemaExamples:
-    EXAMPLESLOADED = False
-    EXAMPLESMAP = {}
-    EXAMPLES = {}
-    exlock = threading.RLock()
+    EXAMPLESLOADED: bool = False
+    EXAMPLESMAP: Dict[str, List[str]] = {}
+    EXAMPLES: Dict[str, Example] = {}
+    exlock: threading.RLock = threading.RLock()
 
     @staticmethod
-    def loadExamplesFiles(exfiles, init=False):
+    def loadExamplesFiles(exfiles: Optional[Union[str, Iterable[str]]], init: bool = False) -> None:
         global DEFTEXAMPLESFILESGLOB
         if init:
-            EXAMPLESLOADED = False
-            EXAMPLESMAP = {}
-            EXAMPLES = {}
+            SchemaExamples.EXAMPLESLOADED = False
+            SchemaExamples.EXAMPLESMAP = {}
+            SchemaExamples.EXAMPLES = {}
 
         if SchemaExamples.EXAMPLESLOADED:
             log.info("Examples files already loaded")
             return
 
+        load_files: List[str] = []
         if not exfiles or exfiles == "default":
             log.info(
                 "SchemaExamples.loadExamplesFiles() loading from default files found in globs: %s"
                 % ",".join(DEFTEXAMPLESFILESGLOB)
             )
-            exfiles = []
             for g in DEFTEXAMPLESFILESGLOB:
-                exfiles.extend(sorted(glob.glob(g)))
+                load_files.extend(sorted(glob.glob(g)))
 
         elif isinstance(exfiles, str):
             log.info(
                 "SchemaExamples.loadExamplesFiles() loading from file: %s" % exfiles
             )
-            exfiles = [exfiles]
+            load_files = [exfiles]
         else:
             log.info(
-                "SchemaExamples.loadExamplesFiles() loading from %d" % len(exfiles)
+                "SchemaExamples.loadExamplesFiles() loading from %d" % len(list(exfiles))
             )
+            load_files = list(exfiles)
 
-        if not len(exfiles):
+        if not len(load_files):
             raise Exception("No examples file(s) to load")
 
-        parser = ExampleFileParser()
-        for f in exfiles:
+        parser: ExampleFileParser = ExampleFileParser()
+        for f in load_files:
             for example in parser.parse(f):
                 # log.info("Ex: %s %s" % (example.keyvalue,example.terms))
-                keyvalue = example.keyvalue
+                keyvalue: str = str(example.keyvalue)
                 example.setMeta("source", f)
                 with SchemaExamples.exlock:
                     if not SchemaExamples.EXAMPLES.get(keyvalue, None):
@@ -264,73 +268,74 @@ class SchemaExamples:
                         if not SchemaExamples.EXAMPLESMAP.get(term, None):
                             SchemaExamples.EXAMPLESMAP[term] = []
 
-                        if not keyvalue in SchemaExamples.EXAMPLESMAP.get(term):
-                            SchemaExamples.EXAMPLESMAP.get(term).append(keyvalue)
+                        mapped_ids = SchemaExamples.EXAMPLESMAP.get(term)
+                        if mapped_ids is not None and keyvalue not in mapped_ids:
+                            mapped_ids.append(keyvalue)
         SchemaExamples.EXAMPLESLOADED = True
 
     @staticmethod
-    def loaded():
+    def loaded() -> None:
         if not SchemaExamples.EXAMPLESLOADED:
             log.info("Loading examples files")
             SchemaExamples.loadExamplesFiles("default")
             log.info("Loaded %d examples", SchemaExamples.count())
 
     @staticmethod
-    def examplesForTerm(term):
+    def examplesForTerm(term: str) -> List[Example]:
         SchemaExamples.loaded()
-        examples = []
-        examps = SchemaExamples.EXAMPLESMAP.get(term)
+        examples: List[Example] = []
+        examps: Optional[List[str]] = SchemaExamples.EXAMPLESMAP.get(term)
         if examps:
             for e in examps:
-                ex = SchemaExamples.EXAMPLES.get(e)
+                ex: Optional[Example] = SchemaExamples.EXAMPLES.get(e)
                 if ex:
                     examples.append(ex)
-        return sorted(examples, key=lambda x: x.keyvalue)
+        return sorted(examples, key=lambda x: str(x.keyvalue))
 
     @staticmethod
-    def allExamples(sort=False):
+    def allExamples(sort: bool = False) -> Collection[Example]:
         SchemaExamples.loaded()
-        ret = SchemaExamples.EXAMPLES.values()
+        ret: Collection[Example] = SchemaExamples.EXAMPLES.values()
         if sort:
-            return sorted(ret, key=lambda x: (x.exmeta["file"], x.exmeta["filepos"]))
+            return sorted(ret, key=lambda x: (str(x.exmeta.get("file", "")), x.exmeta.get("filepos", 0)))
         return ret
 
     @staticmethod
-    def allExamplesSerialised(sort=False):
+    def allExamplesSerialised(sort: bool = False) -> str:
         SchemaExamples.loaded()
-        examples = SchemaExamples.allExamples(sort=sort)
-        f = io.StringIO()
+        examples: Collection[Example] = SchemaExamples.allExamples(sort=sort)
+        f: io.StringIO = io.StringIO()
         for ex in examples:
             f.write(ex.serialize())
             f.write("\n")
         return f.getvalue()
 
     @staticmethod
-    def count():
+    def count() -> int:
         SchemaExamples.loaded()
         return len(SchemaExamples.EXAMPLES)
 
 
 class ExampleFileParser:
-    def __init__(self):
+    def __init__(self) -> None:
         logging.basicConfig(level=logging.INFO)  # dev_appserver.py --log_level debug .
-        self.file = ""  # File being parsed.
-        self.filepos = 0  # Part index.
+        self.file: str = ""  # File being parsed.
+        self.filepos: int = 0  # Part index.
         self.initFields()
-        self.idcache = []
+        self.idcache: List[str] = []
 
-    def initFields(self):
-        self.currentStr = []
-        self.terms = []
-        self.exmeta = {}
-        self.preMarkupStr = ""
-        self.microdataStr = ""
-        self.rdfaStr = ""
-        self.jsonStr = ""
-        self.jsonld_offset = None
-        self.state = ""
+    def initFields(self) -> None:
+        self.currentStr: List[str] = []
+        self.terms: List[str] = []
+        self.exmeta: Dict[str, Any] = {}
+        self.preMarkupStr: str = ""
+        self.microdataStr: str = ""
+        self.rdfaStr: str = ""
+        self.jsonStr: str = ""
+        self.jsonld_offset: Optional[int] = None
+        self.state: str = ""
 
-    def nextPart(self, next):
+    def nextPart(self, next_state: str) -> None:
         self.trimCurrentStr()
         if self.state == "PRE-MARKUP:":
             self.preMarkupStr = "".join(self.currentStr)
@@ -341,17 +346,17 @@ class ExampleFileParser:
         elif self.state == "JSON:":
             self.jsonStr = "".join(self.currentStr)
 
-        self.state = next
+        self.state = next_state
         self.currentStr = []
 
-    def trimCurrentStr(self):
+    def trimCurrentStr(self) -> None:
         # strip: leading blank lines, strip multi blank lines (replace with 1) end with blank line
-        temp = []
-        begin = True
-        inwhitespace = False
+        temp: List[str] = []
+        begin: bool = True
+        inwhitespace: bool = False
 
         for line in self.currentStr:
-            linelen = len(line.strip())
+            linelen: int = len(line.strip())
             if not linelen:
                 if begin:
                     continue
@@ -370,8 +375,8 @@ class ExampleFileParser:
             temp.append("\n")
         self.currentStr = temp
 
-    def process_example_id(self, m):
-        ident = m.group(1)
+    def process_example_id(self, m: re.Match) -> str:
+        ident: str = m.group(1)
         if ident not in self.idcache:
             self.idcache.append(ident)
         else:
@@ -382,7 +387,7 @@ class ExampleFileParser:
         self.exmeta["id"] = ident
         return ""
 
-    def makeExample(self):
+    def makeExample(self) -> Example:
         """Build an example out of the current state"""
         return Example(
             terms=self.terms,
@@ -394,29 +399,29 @@ class ExampleFileParser:
             jsonld_offset=self.jsonld_offset,
         )
 
-    def parse(self, filen):
+    def parse(self, filen: str) -> List[Example]:
         import codecs
         import requests
 
         self.file = filen
         self.filepos = 0
-        examples = []
-        egid = re.compile(r"""#(\S+)\s+""")
+        examples: List[Example] = []
+        egid: re.Pattern = re.compile(r"""#(\S+)\s+""")
 
         if self.file.startswith("file://"):
             self.file = self.file[7:]
 
+        content: str
         if "://" in self.file:
-            r = requests.get(self.file)
+            r: requests.Response = requests.get(self.file)
             content = r.text
         else:
-            fd = codecs.open(self.file, "r", encoding="utf8")
-            content = fd.read()
-            fd.close()
+            with codecs.open(self.file, "r", encoding="utf8") as fd:
+                content = fd.read()
 
-        lines = re.split("\n|\r", content)
-        first = True
-        boilerplate = False
+        lines: List[str] = re.split("\n|\r", content)
+        first: bool = True
+        boilerplate: bool = False
         for lineno, line in enumerate(lines):
             # Per-example sections begin with e.g.: 'TYPES: #music-2 Person, MusicComposition, Organization'
             line = line.rstrip()
@@ -434,11 +439,11 @@ class ExampleFileParser:
                     self.initFields()
                 self.exmeta["file"] = self.file
                 self.exmeta["filepos"] = self.filepos
-                typelist = re.split(":", line)
-                tdata = egid.sub(
+                typelist: List[str] = re.split(":", line)
+                tdata: str = egid.sub(
                     self.process_example_id, typelist[1]
                 )  # strips IDs, records them in exmeta["id"]
-                ttl = tdata.split(",")
+                ttl: List[str] = tdata.split(",")
                 for ttli in ttl:
                     ttli = ttli.strip()
                     if len(ttli):
@@ -450,9 +455,9 @@ class ExampleFileParser:
                 # Heuristic to find the start line that will be used by `getJsonldRaw`.
                 if '<script type="application/ld+json">' in line:
                     self.jsonld_offset = lineno + 1
-                tokens = ("PRE-MARKUP:", "MICRODATA:", "RDFA:", "JSON:")
+                tokens: Tuple[str, ...] = ("PRE-MARKUP:", "MICRODATA:", "RDFA:", "JSON:")
                 for tk in tokens:
-                    ltk = len(tk)
+                    ltk: int = len(tk)
                     if line.startswith(tk):
                         self.nextPart(tk)
                         line = line[ltk:]

--- a/software/SchemaTerms/localmarkdown.py
+++ b/software/SchemaTerms/localmarkdown.py
@@ -5,38 +5,42 @@ import logging
 import markdown2
 import re
 import threading
+import typing
+from typing import Any, Dict, List, Optional, Tuple, Union, Iterable, Sequence
 
 
-WIKILINKPATTERN = r"\[\[([\w0-9_ -]+)\]\]"
+WIKILINKPATTERN: str = r"\[\[([\w0-9_ -]+)\]\]"
 
-log = logging.getLogger(__name__)
+log: logging.Logger = logging.getLogger(__name__)
 
 
 class MarkdownTool(object):
-    WCLASS = "localLink"
-    WPRE = "/"
-    WPOST = ""
+    WCLASS: str = "localLink"
+    WPRE: str = "/"
+    WPOST: str = ""
 
-    def __init__(self):
+    def __init__(self) -> None:
         # from markdown.extensions.wikilinks import WikiLinkExtension
         # self._md = markdown2.Markdown(extensions=[WikiLinkExtension(base_url='/', end_url='', html_class='localLink')])
-        self._md = markdown2.Markdown()
-        self._parselock = threading.Lock()
+        self._md: markdown2.Markdown = markdown2.Markdown()
+        self._parselock: threading.Lock = threading.Lock()
+        self.wpre: Optional[str] = None
+        self.wpost: Optional[str] = None
 
-    def setPre(self, pre="./"):
+    def setPre(self, pre: str = "./") -> None:
         self.wpre = pre
 
-    def setPost(self, post=""):
+    def setPost(self, post: str = "") -> None:
         self.wpost = post
 
-    def parse(self, source, preservePara=False, wpre=None):
+    def parse(self, source: str, preservePara: bool = False, wpre: Optional[str] = None) -> str:
         source = source.strip()
         if not source:
             return ""
 
         source = source.replace("\\n", "\n")
         with self._parselock:
-            ret = self._md.convert(source)
+            ret: str = self._md.convert(source)
 
         if not preservePara:
             # Remove wrapping <p> </p>\n that Markdown2 adds by default
@@ -50,16 +54,16 @@ class MarkdownTool(object):
 
         return self.parseWiklinks(ret, wpre=wpre)
 
-    def parseLines(self, lines):
+    def parseLines(self, lines: Iterable[str]) -> str:
         return self.parse("".join(lines))
 
-    def parseWiklinks(self, source, wpre=None):
+    def parseWiklinks(self, source: str, wpre: Optional[str] = None) -> str:
         self.wpre = wpre
         return re.sub(WIKILINKPATTERN, self.wikilinksReplace, source)
 
-    def wikilinksReplace(self, match):
-        wpre = self.wpre
-        t = match.group(1)
+    def wikilinksReplace(self, match: re.Match) -> str:
+        # wpre = self.wpre # Assigned but unused in original code
+        t: str = match.group(1)
         return '<a class="%s" href="%s%s%s">%s</a>' % (
             MarkdownTool.WCLASS,
             MarkdownTool.WPRE,
@@ -69,16 +73,16 @@ class MarkdownTool(object):
         )
 
     @classmethod
-    def setWikilinkCssClass(cls, c):
+    def setWikilinkCssClass(cls, c: str) -> None:
         cls.WCLASS = c
 
     @classmethod
-    def setWikilinkPrePath(cls, p):
+    def setWikilinkPrePath(cls, p: str) -> None:
         MarkdownTool.WPRE = p
 
     @classmethod
-    def setWikilinkPostPath(cls, p):
+    def setWikilinkPostPath(cls, p: str) -> None:
         cls.WPOST = p
 
 
-Markdown = MarkdownTool()
+Markdown: MarkdownTool = MarkdownTool()

--- a/software/SchemaTerms/localmarkdown.py
+++ b/software/SchemaTerms/localmarkdown.py
@@ -5,23 +5,19 @@ import logging
 import markdown2
 import re
 import threading
-import typing
-from typing import Any, Dict, List, Optional, Tuple, Union, Iterable, Sequence
-
+from typing import Optional, Iterable
 
 WIKILINKPATTERN: str = r"\[\[([\w0-9_ -]+)\]\]"
 
 log: logging.Logger = logging.getLogger(__name__)
 
 
-class MarkdownTool(object):
+class MarkdownTool:
     WCLASS: str = "localLink"
     WPRE: str = "/"
     WPOST: str = ""
 
     def __init__(self) -> None:
-        # from markdown.extensions.wikilinks import WikiLinkExtension
-        # self._md = markdown2.Markdown(extensions=[WikiLinkExtension(base_url='/', end_url='', html_class='localLink')])
         self._md: markdown2.Markdown = markdown2.Markdown()
         self._parselock: threading.Lock = threading.Lock()
         self.wpre: Optional[str] = None
@@ -40,17 +36,15 @@ class MarkdownTool(object):
 
         source = source.replace("\\n", "\n")
         with self._parselock:
-            ret: str = self._md.convert(source)
+            ret: str = str(self._md.convert(source))
 
         if not preservePara:
-            # Remove wrapping <p> </p>\n that Markdown2 adds by default
             if len(ret) > 7 and ret.startswith("<p>") and ret.endswith("</p>\n"):
-                ret = ret[3 : len(ret) - 5]
+                ret = ret[3:-5]
 
-            ret = ret.replace("<p>", "")
-            ret = ret.replace("</p>", "<br/><br/>")
+            ret = ret.replace("<p>", "").replace("</p>", "<br/><br/>")
             if ret.endswith("<br/><br/>"):
-                ret = ret[: len(ret) - 10]
+                ret = ret[:-10]
 
         return self.parseWiklinks(ret, wpre=wpre)
 
@@ -62,9 +56,8 @@ class MarkdownTool(object):
         return re.sub(WIKILINKPATTERN, self.wikilinksReplace, source)
 
     def wikilinksReplace(self, match: re.Match) -> str:
-        # wpre = self.wpre # Assigned but unused in original code
         t: str = match.group(1)
-        return f'<a class="{MarkdownTool.WCLASS}" href="{MarkdownTool.WPRE}{t}{MarkdownTool.WPOST}">{t}</a>'
+        return f'<a class="{self.WCLASS}" href="{self.WPRE}{t}{self.WPOST}">{t}</a>'
 
     @classmethod
     def setWikilinkCssClass(cls, c: str) -> None:
@@ -72,7 +65,7 @@ class MarkdownTool(object):
 
     @classmethod
     def setWikilinkPrePath(cls, p: str) -> None:
-        MarkdownTool.WPRE = p
+        cls.WPRE = p
 
     @classmethod
     def setWikilinkPostPath(cls, p: str) -> None:

--- a/software/SchemaTerms/localmarkdown.py
+++ b/software/SchemaTerms/localmarkdown.py
@@ -64,13 +64,7 @@ class MarkdownTool(object):
     def wikilinksReplace(self, match: re.Match) -> str:
         # wpre = self.wpre # Assigned but unused in original code
         t: str = match.group(1)
-        return '<a class="%s" href="%s%s%s">%s</a>' % (
-            MarkdownTool.WCLASS,
-            MarkdownTool.WPRE,
-            t,
-            MarkdownTool.WPOST,
-            t,
-        )
+        return f'<a class="{MarkdownTool.WCLASS}" href="{MarkdownTool.WPRE}{t}{MarkdownTool.WPOST}">{t}</a>'
 
     @classmethod
     def setWikilinkCssClass(cls, c: str) -> None:

--- a/software/SchemaTerms/sdocollaborators.py
+++ b/software/SchemaTerms/sdocollaborators.py
@@ -10,6 +10,8 @@ import os
 import traceback
 import re
 import sys
+import typing
+from typing import Any, Dict, List, Optional, Tuple, Union, Iterable, Sequence
 
 
 # Import schema.org libraries
@@ -22,48 +24,52 @@ import software.SchemaTerms.sdoterm as sdoterm
 import software.SchemaTerms.sdotermsource as sdotermsource
 import software.SchemaTerms.localmarkdown as localmarkdown
 
-log = logging.getLogger(__name__)
+log: logging.Logger = logging.getLogger(__name__)
 
-INCLUDE_RE = re.compile(R"---\s+([^.]+)\.md")
-SECTION_SEPARATOR = "---"
+INCLUDE_RE: re.Pattern = re.compile(R"---\s+([^.]+)\.md")
+SECTION_SEPARATOR: str = "---"
 
 
 class collaborator(object):
     """Wrapper for the collaboration meta-data."""
 
-    COLLABORATORS = {}
-    CONTRIBUTORS = {}
+    COLLABORATORS: Dict[str, "collaborator"] = {}
+    CONTRIBUTORS: Dict[str, "collaborator"] = {}
 
-    def __init__(self, ref, desc=None):
-        self.ref = ref
-        self.urirel = os.path.join("/docs", "collab", ref)
-        self.uri = schemaglobals.HOMEPAGE + self.urirel
-        self.docurl = self.urirel
-        self.terms = None
-        self.contributor = False
-        self.img = self.code = self.title = self.url = None
-        self.description = ""
-        self.acknowledgement = ""
-        self._parseDesc(desc)
+    def __init__(self, ref: str, desc: Optional[str] = None) -> None:
+        self.ref: str = ref
+        self.urirel: str = os.path.join("/docs", "collab", ref)
+        self.uri: str = schemaglobals.HOMEPAGE + self.urirel
+        self.docurl: str = self.urirel
+        self.terms: Optional[Sequence[sdoterm.SdoTerm]] = None
+        self.contributor: bool = False
+        self.img: Optional[str] = None
+        self.code: Optional[str] = None
+        self.title: Optional[str] = None
+        self.url: Optional[str] = None
+        self.description: str = ""
+        self.acknowledgement: str = ""
+        if desc:
+            self._parseDesc(desc)
 
         collaborator.COLLABORATORS[self.ref] = self
         log.debug(f"Created collaborator for '{ref}'")
 
-    def __str__(self):
+    def __str__(self) -> str:
         return (
-            f"<collaborator ref: {self.ref} uri: {self.uri} contributor: {self.contributor} img: '{self.img}' title: '{self.title}' url: 'self.url'>"
+            f"<collaborator ref: {self.ref} uri: {self.uri} contributor: {self.contributor} img: '{self.img}' title: '{self.title}' url: '{self.url}'>"
         )
 
-    def _parseDesc(self, desc):
+    def _parseDesc(self, desc: str) -> None:
         """Parses data from the pseudo-markdown format.
 
         Args:
           desc: content of the file, typically found at the path data/collab/*.md
         """
-        section = 0
-        attributes = {}
-        lines_by_section = collections.defaultdict(list)
-        section_selector = ""
+        section: int = 0
+        attributes: Dict[str, str] = {}
+        lines_by_section: Dict[str, List[str]] = collections.defaultdict(list)
+        section_selector: str = ""
 
         for line in desc.splitlines():
             if line.startswith(SECTION_SEPARATOR):
@@ -71,44 +77,45 @@ class collaborator(object):
             if section == 1:
                 if line.startswith(SECTION_SEPARATOR):
                     continue
-                key, value = line.split(":", maxsplit=1)
-                attributes[key.strip()] = value.strip()
+                if ":" in line:
+                    key, value = line.split(":", maxsplit=1)
+                    attributes[key.strip()] = value.strip()
                 continue
             if section > 1:
                 include_match = re.search(INCLUDE_RE, line)
                 if include_match:
-                    section_selector = include_match.groups(0)[0]
+                    section_selector = include_match.groups()[0]
                     continue
                 lines_by_section[section_selector].append(line)
 
         self.url = attributes.get("url")
         self.title = attributes.get("title")
         self.img = attributes.get("img")
-        attributes.pop("url")
-        attributes.pop("title")
-        attributes.pop("img")
+        attributes.pop("url", None)
+        attributes.pop("title", None)
+        attributes.pop("img", None)
         if attributes:
             log.warning(
                 f"Unknown attributes found in collaborator file {self.urirel}: {attributes}"
             )
 
-        description_lines = lines_by_section["DescriptionText"]
-        acknowledgement_lines = lines_by_section["AcknowledgementText"]
-        lines_by_section.pop("DescriptionText")
-        lines_by_section.pop("AcknowledgementText")
+        description_lines: List[str] = lines_by_section["DescriptionText"]
+        acknowledgement_lines: List[str] = lines_by_section["AcknowledgementText"]
+        lines_by_section.pop("DescriptionText", None)
+        lines_by_section.pop("AcknowledgementText", None)
 
         if lines_by_section:
             log.warning(
-                f"Unknown sections found in collaborator file {self.urirel}: {lines_by_section}"
+                f"Unknown sections found in collaborator file {self.urirel}: {list(lines_by_section.keys())}"
             )
 
         self.description = localmarkdown.Markdown.parseLines(description_lines)
         self.acknowledgement = localmarkdown.Markdown.parseLines(acknowledgement_lines)
 
-    def isContributor(self):
+    def isContributor(self) -> bool:
         return self.contributor
 
-    def getTerms(self):
+    def getTerms(self) -> Sequence[sdoterm.SdoTerm]:
         if not self.contributor:
             return []
         if not self.terms:
@@ -116,26 +123,26 @@ class collaborator(object):
         return self.terms
 
     @classmethod
-    def getCollaborator(cls, ref):
+    def getCollaborator(cls, ref: str) -> Optional["collaborator"]:
         cls.loadCollaborators()
-        key = os.path.basename(ref)
-        coll = cls.COLLABORATORS.get(key, None)
+        key: str = os.path.basename(ref)
+        coll: Optional[collaborator] = cls.COLLABORATORS.get(key, None)
         if not coll:
             log.warning(f"No collaborator for '{ref}'")
         return coll
 
     @classmethod
-    def getContributor(cls, ref):
-        key = os.path.basename(ref)
+    def getContributor(cls, ref: str) -> Optional["collaborator"]:
+        key: str = os.path.basename(ref)
         cls.loadContributors()
-        cont = cls.CONTRIBUTORS.get(key, None)
+        cont: Optional[collaborator] = cls.CONTRIBUTORS.get(key, None)
         if not cont:
             log.warning(f"No contributor for '{ref}'")
         return cont
 
     @classmethod
-    def createCollaborator(cls, file_path):
-        code = os.path.basename(file_path)
+    def createCollaborator(cls, file_path: str) -> Optional["collaborator"]:
+        code: str = os.path.basename(file_path)
         ref, _ = os.path.splitext(code)
         try:
             with open(file_path, "r", encoding="utf-8") as file_handle:
@@ -146,39 +153,39 @@ class collaborator(object):
             return None
 
     @classmethod
-    def loadCollaborators(cls):
+    def loadCollaborators(cls) -> None:
         if not len(cls.COLLABORATORS):
             for file_path in glob.glob("data/collab/*.md"):
                 cls.createCollaborator(file_path)
             log.info(f"Loaded {len(cls.COLLABORATORS)} collaborators")
 
     @classmethod
-    def createContributor(cls, ref):
-        key = os.path.basename(ref)
-        coll = cls.getCollaborator(key)
+    def createContributor(cls, ref: str) -> None:
+        key: str = os.path.basename(ref)
+        coll: Optional[collaborator] = cls.getCollaborator(key)
         if coll:
             coll.contributor = True
             cls.CONTRIBUTORS[key] = coll
 
     @classmethod
-    def loadContributors(cls):
+    def loadContributors(cls) -> None:
         if not len(cls.CONTRIBUTORS):
             cls.loadCollaborators()
-            query = """
+            query: str = """
             SELECT distinct ?val WHERE {
                     [] schema:contributor ?val.
             }"""
             res = sdotermsource.SdoTermSource.query(query)
             for row in res:
-                cls.createContributor(row.val)
+                cls.createContributor(str(row.val))
             log.info(f"Loaded {len(cls.CONTRIBUTORS)} contributors")
 
     @classmethod
-    def collaborators(cls):
+    def collaborators(cls) -> List["collaborator"]:
         cls.loadCollaborators()
         return list(cls.COLLABORATORS.values())
 
     @classmethod
-    def contributors(cls):
+    def contributors(cls) -> List["collaborator"]:
         cls.loadContributors()
         return list(cls.CONTRIBUTORS.values())

--- a/software/SchemaTerms/sdoterm.py
+++ b/software/SchemaTerms/sdoterm.py
@@ -141,7 +141,7 @@ class SdoTermSequence(object):
         return iter(self.ids)
 
     def __str__(self) -> str:
-        return '[' + ','.join(map(str, self.ids)) + ']'
+        return f'[{" ,".join(map(str, self.ids))}]'
 
 
 class SdoTerm(object):
@@ -195,11 +195,7 @@ class SdoTerm(object):
 
 
     def __str__(self) -> str:
-        return ("<%s: '%s' expansion depth: %s >") % (
-            self.__class__.__name__.upper(),
-            self.id,
-            self._expansion_depth,
-        )
+        return f"<{self.__class__.__name__.upper()}: '{self.id}' expansion depth: {self._expansion_depth} >"
 
     def __eq__(self, other: Any) -> bool:
         if not isinstance(other, SdoTerm):

--- a/software/SchemaTerms/sdoterm.py
+++ b/software/SchemaTerms/sdoterm.py
@@ -1,10 +1,11 @@
 #!/usr/bin/env python3
 # -*- coding: utf-8 -*-
 
+# Import standard python libraries
 import enum
 import logging
-import collections
-from typing import Any, Dict, List, Optional, Tuple, Type, TypeVar, Union, Iterable, Set
+from abc import ABC, abstractmethod
+from typing import Any, Dict, List, Optional, Tuple, Type, Union, Iterable, Set, Sequence, FrozenSet
 
 log: logging.Logger = logging.getLogger(__name__)
 
@@ -25,18 +26,13 @@ class UnexpandedTermError(LookupError):
     """Term is not expanded."""
 
 
-class SdoTermOrId(object):
+class SdoTermOrId:
     """Wrapper that holds a term-id or a term, or nothing."""
 
     def __init__(self, term_id: Optional[str] = None, term: Optional["SdoTerm"] = None) -> None:
-        # Empty instance is fine.
         assert not (term_id and term), f"{term_id} {term}"
-        self._term_id: Optional[str] = None
-        if term:
-            self._term_id = term.id
-        else:
-            self._term_id = term_id
-        self._term: Optional["SdoTerm"] = term
+        self._term_id = term.id if term else term_id
+        self._term = term
 
     @property
     def expanded(self) -> bool:
@@ -57,27 +53,21 @@ class SdoTermOrId(object):
 
     def setTerm(self, term: Optional["SdoTerm"]) -> None:
         self._term = term
-        if self._term:
+        if term:
             self._term_id = term.id
 
     def __str__(self) -> str:
-        if not self._term:
-            return f'{self._term_id}'
-        return str(self._term)
+        return str(self._term or self._term_id)
 
     def __bool__(self) -> bool:
         return bool(self._term_id)
 
 
-class SdoTermSequence(object):
-    """Sequence that holds either a sequence of term-ids, or a sequence of terms.
-
-    If it holds a sequence of terms, the sequence is said to be expanded.
-    It can only be changed by replacing all the values, either with ids, or term instances.
-
-    """
+class SdoTermSequence:
+    """Sequence that holds either a sequence of term-ids, or a sequence of terms."""
+    
     def __init__(self) -> None:
-        self._term_dict: collections.OrderedDict[str, Optional["SdoTerm"]] = collections.OrderedDict()
+        self._term_dict: Dict[str, Optional["SdoTerm"]] = {}
 
     @classmethod
     def forElements(cls, elements: Iterable[Any]) -> "SdoTermSequence":
@@ -85,19 +75,18 @@ class SdoTermSequence(object):
         if isinstance(elements, cls):
             return elements
 
-        sequence: SdoTermSequence = cls()
+        sequence = cls()
         elements_list = list(elements)
-        if all(map(lambda e : isinstance(e, SdoTerm), elements_list)):
+        if all(isinstance(e, SdoTerm) for e in elements_list):
             sequence.setTerms(elements_list)
             return sequence
-        term_ids: List[str] = []
+            
+        term_ids = []
         for element in elements_list:
-            try:
-                # This will work for both SdoTerm instances, and SdoTermOrId
-                term_id: str = element.id
-            except AttributeError:
-                term_id = str(element)
-            term_ids.append(term_id)
+            if hasattr(element, "id"):
+                term_ids.append(element.id)
+            else:
+                term_ids.append(str(element))
         sequence.setIds(term_ids)
         return sequence
 
@@ -116,14 +105,10 @@ class SdoTermSequence(object):
         return tuple(self._term_dict.values()) # type: ignore
 
     def setIds(self, term_ids: Iterable[str]) -> None:
-        self._term_dict.clear()
-        for term_id in term_ids:
-            self._term_dict[term_id] = None
+        self._term_dict = {tid: None for tid in term_ids}
 
     def setTerms(self, terms: Iterable["SdoTerm"]) -> None:
-        self._term_dict.clear()
-        for term in terms:
-            self._term_dict[term.id] = term
+        self._term_dict = {t.id: t for t in terms}
 
     def clear(self) -> None:
         self._term_dict.clear()
@@ -141,61 +126,44 @@ class SdoTermSequence(object):
         return iter(self.ids)
 
     def __str__(self) -> str:
-        return f'[{" ,".join(map(str, self.ids))}]'
+        return f'[{", ".join(self.ids)}]'
 
 
-class SdoTerm(object):
-    """Abstract superclass for various schema.org types.
+class SdoTerm(ABC):
+    """Abstract superclass for various schema.org types."""
 
-    Note that the semantics of the relational fields depends on the expansion_depth.
-
-    0: Nothing is expanded
-    1: Non recursive fields are expanded
-    2: All recursive fields are expanded (and are at least at level 1)
-
-    """
-
-
-    TYPE_LIKE_TYPES: Set[SdoTermType] = frozenset(
-        [SdoTermType.TYPE, SdoTermType.DATATYPE, SdoTermType.ENUMERATION]
+    TYPE_LIKE_TYPES: FrozenSet[SdoTermType] = frozenset(
+        {SdoTermType.TYPE, SdoTermType.DATATYPE, SdoTermType.ENUMERATION}
     )
 
     def __init__(self, termType: SdoTermType, term_id: str, uri: str, label: str) -> None:
-        if type(self) == SdoTerm:
-            raise Exception("<SdoTerm> must be subclassed.")
-
         assert isinstance(term_id, str)
-        self._expansion_depth: int = 0
-        self.termType: SdoTermType = termType
-        self.uri: str = uri
-        self._term_id: str = term_id
-        self.label: str = label
+        self._expansion_depth = 0
+        self.termType = termType
+        self.uri = uri
+        self._term_id = term_id
+        self.label = label
 
         self.acknowledgements: List[Any] = []
-
-        self.comment: str = ""
+        self.comment = ""
         self.comments: List[str] = []
-
         self.examples: List[Any] = []
-        self.pending: bool = False
-        self.retired: bool = False
-        self.extLayer: str = ""
+        self.pending = False
+        self.retired = False
+        self.extLayer = ""
         self.sources: List[str] = []
-
-
-        self.supersededBy: str = ""
+        self.supersededBy = ""
         self.supersedes: List[str] = []
-        self.superseded: bool = False
+        self.superseded = False
         self.superPaths: List[Any] = []
 
-        self._termStack: SdoTermSequence = SdoTermSequence()
-        self._supers: SdoTermSequence = SdoTermSequence()
-        self._subs: SdoTermSequence = SdoTermSequence()
-        self._equivalents: SdoTermSequence = SdoTermSequence()
-
+        self._termStack = SdoTermSequence()
+        self._supers = SdoTermSequence()
+        self._subs = SdoTermSequence()
+        self._equivalents = SdoTermSequence()
 
     def __str__(self) -> str:
-        return f"<{self.__class__.__name__.upper()}: '{self.id}' expansion depth: {self._expansion_depth} >"
+        return f"<{self.__class__.__name__.upper()}: '{self.id}' expansion depth: {self._expansion_depth}>"
 
     def __eq__(self, other: Any) -> bool:
         if not isinstance(other, SdoTerm):
@@ -231,15 +199,13 @@ class SdoTerm(object):
     def id(self) -> str:
         return self._term_id
 
-class SdoType(SdoTerm):
-    """Term that defines a schema.org type"""
 
-    def __init__(self, term_id: str, uri: str, label: str) -> None:
-        SdoTerm.__init__(self, SdoTermType.TYPE, term_id, uri, label)
-
-        self._properties: SdoTermSequence = SdoTermSequence()
-        self._allproperties: SdoTermSequence = SdoTermSequence()
-        self._expectedTypeFor: SdoTermSequence = SdoTermSequence()
+class _SdoTypeLike(SdoTerm):
+    def __init__(self, termType: SdoTermType, term_id: str, uri: str, label: str) -> None:
+        super().__init__(termType, term_id, uri, label)
+        self._properties = SdoTermSequence()
+        self._allproperties = SdoTermSequence()
+        self._expectedTypeFor = SdoTermSequence()
 
     @property
     def properties(self) -> SdoTermSequence:
@@ -254,14 +220,19 @@ class SdoType(SdoTerm):
         return self._expectedTypeFor
 
 
-class SdoProperty(SdoTerm):
-    """Term that defines a propery of another type."""
-
+class SdoType(_SdoTypeLike):
+    """Term that defines a schema.org type"""
     def __init__(self, term_id: str, uri: str, label: str) -> None:
-        SdoTerm.__init__(self, SdoTermType.PROPERTY, term_id, uri, label)
-        self._domainIncludes: SdoTermSequence = SdoTermSequence()
-        self._rangeIncludes: SdoTermSequence = SdoTermSequence()
-        self._inverse: SdoTermOrId = SdoTermOrId()
+        super().__init__(SdoTermType.TYPE, term_id, uri, label)
+
+
+class SdoProperty(SdoTerm):
+    """Term that defines a property of another type."""
+    def __init__(self, term_id: str, uri: str, label: str) -> None:
+        super().__init__(SdoTermType.PROPERTY, term_id, uri, label)
+        self._domainIncludes = SdoTermSequence()
+        self._rangeIncludes = SdoTermSequence()
+        self._inverse = SdoTermOrId()
 
     @property
     def domainIncludes(self) -> SdoTermSequence:
@@ -276,51 +247,17 @@ class SdoProperty(SdoTerm):
         return self._inverse
 
 
-
-class SdoDataType(SdoTerm):
+class SdoDataType(_SdoTypeLike):
     """Term that defines one of the basic data-types: Boolean, Date, Text, Number etc."""
-
     def __init__(self, term_id: str, uri: str, label: str) -> None:
-        SdoTerm.__init__(self, SdoTermType.DATATYPE, term_id, uri, label)
-
-        self._properties: SdoTermSequence = SdoTermSequence()
-        self._allproperties: SdoTermSequence = SdoTermSequence()
-        self._expectedTypeFor: SdoTermSequence = SdoTermSequence()
-
-    @property
-    def properties(self) -> SdoTermSequence:
-        return self._properties
-
-    @property
-    def allproperties(self) -> SdoTermSequence:
-        return self._allproperties
-
-    @property
-    def expectedTypeFor(self) -> SdoTermSequence:
-        return self._expectedTypeFor
+        super().__init__(SdoTermType.DATATYPE, term_id, uri, label)
 
 
-class SdoEnumeration(SdoTerm):
+class SdoEnumeration(_SdoTypeLike):
     """Term that defines a schema.org enumeration."""
-
     def __init__(self, term_id: str, uri: str, label: str) -> None:
-        SdoTerm.__init__(self, SdoTermType.ENUMERATION, term_id, uri, label)
-        self._properties: SdoTermSequence = SdoTermSequence()
-        self._allproperties: SdoTermSequence = SdoTermSequence()
-        self._expectedTypeFor: SdoTermSequence = SdoTermSequence()
-        self._enumerationMembers: SdoTermSequence = SdoTermSequence()
-
-    @property
-    def properties(self) -> SdoTermSequence:
-        return self._properties
-
-    @property
-    def allproperties(self) -> SdoTermSequence:
-        return self._allproperties
-
-    @property
-    def expectedTypeFor(self) -> SdoTermSequence:
-        return self._expectedTypeFor
+        super().__init__(SdoTermType.ENUMERATION, term_id, uri, label)
+        self._enumerationMembers = SdoTermSequence()
 
     @property
     def enumerationMembers(self) -> SdoTermSequence:
@@ -329,10 +266,9 @@ class SdoEnumeration(SdoTerm):
 
 class SdoEnumerationvalue(SdoTerm):
     """Term that defines a value within a schema.org enumeration."""
-
     def __init__(self, term_id: str, uri: str, label: str) -> None:
-        SdoTerm.__init__(self, SdoTermType.ENUMERATIONVALUE, term_id, uri, label)
-        self._enumerationParent: SdoTermOrId = SdoTermOrId()
+        super().__init__(SdoTermType.ENUMERATIONVALUE, term_id, uri, label)
+        self._enumerationParent = SdoTermOrId()
 
     @property
     def enumerationParent(self) -> SdoTermOrId:
@@ -341,7 +277,7 @@ class SdoEnumerationvalue(SdoTerm):
 
 class SdoReference(SdoTerm):
     def __init__(self, term_id: str, uri: str, label: str) -> None:
-        SdoTerm.__init__(self, SdoTermType.REFERENCE, term_id, uri, label)
+        super().__init__(SdoTermType.REFERENCE, term_id, uri, label)
 
 
 _TYPES_FOR_TYPES: Dict[SdoTermType, Type[SdoTerm]] = {

--- a/software/SchemaTerms/sdoterm.py
+++ b/software/SchemaTerms/sdoterm.py
@@ -4,8 +4,9 @@
 import enum
 import logging
 import collections
+from typing import Any, Dict, List, Optional, Tuple, Type, TypeVar, Union, Iterable, Set
 
-log = logging.getLogger(__name__)
+log: logging.Logger = logging.getLogger(__name__)
 
 class SdoTermType(str, enum.Enum):
     """Enumeration describing the type of an SdoTerm."""
@@ -17,7 +18,7 @@ class SdoTermType(str, enum.Enum):
     ENUMERATIONVALUE = "Enumerationvalue"
     REFERENCE = "Reference"
 
-    def __str__(self):
+    def __str__(self) -> str:
         return self.value
 
 class UnexpandedTermError(LookupError):
@@ -27,43 +28,44 @@ class UnexpandedTermError(LookupError):
 class SdoTermOrId(object):
     """Wrapper that holds a term-id or a term, or nothing."""
 
-    def __init__(self, term_id : str = None, term = None):
+    def __init__(self, term_id: Optional[str] = None, term: Optional["SdoTerm"] = None) -> None:
         # Empty instance is fine.
         assert not (term_id and term), f"{term_id} {term}"
+        self._term_id: Optional[str] = None
         if term:
             self._term_id = term.id
         else:
             self._term_id = term_id
-        self._term = term
+        self._term: Optional["SdoTerm"] = term
 
     @property
     def expanded(self) -> bool:
         return not self._term_id or bool(self._term)
 
     @property
-    def id(self) -> str:
+    def id(self) -> Optional[str]:
         return self._term_id
 
     @property
-    def term(self):
+    def term(self) -> "SdoTerm":
         if not self._term:
              raise UnexpandedTermError()
         return self._term
 
-    def setId(self, term_id):
+    def setId(self, term_id: Optional[str]) -> None:
         self._term_id = term_id
 
-    def setTerm(self, term):
+    def setTerm(self, term: Optional["SdoTerm"]) -> None:
         self._term = term
         if self._term:
             self._term_id = term.id
 
-    def __str__(self):
+    def __str__(self) -> str:
         if not self._term:
             return f'{self._term_id}'
         return str(self._term)
 
-    def __bool__(self):
+    def __bool__(self) -> bool:
         return bool(self._term_id)
 
 
@@ -74,67 +76,71 @@ class SdoTermSequence(object):
     It can only be changed by replacing all the values, either with ids, or term instances.
 
     """
-    def __init__(self):
-        self._term_dict = collections.OrderedDict()
+    def __init__(self) -> None:
+        self._term_dict: collections.OrderedDict[str, Optional["SdoTerm"]] = collections.OrderedDict()
 
     @classmethod
-    def forElements(cls, elements):
+    def forElements(cls, elements: Iterable[Any]) -> "SdoTermSequence":
         """Convert an arbitrary sequence into a SdoTermSequence."""
         if isinstance(elements, cls):
             return elements
 
-        sequence = cls()
-        if all(map(lambda e : isinstance(e, SdoTerm), elements)):
-            sequence.setTerms(elements)
+        sequence: SdoTermSequence = cls()
+        elements_list = list(elements)
+        if all(map(lambda e : isinstance(e, SdoTerm), elements_list)):
+            sequence.setTerms(elements_list)
             return sequence
-        term_ids = []
-        for element in elements:
+        term_ids: List[str] = []
+        for element in elements_list:
             try:
                 # This will work for both SdoTerm instances, and SdoTermOrId
-                term_id = element.id
+                term_id: str = element.id
             except AttributeError:
-                term_id = element
+                term_id = str(element)
             term_ids.append(term_id)
         sequence.setIds(term_ids)
         return sequence
 
     @property
-    def expanded(self):
+    def expanded(self) -> bool:
         return all(self._term_dict.values())
 
     @property
-    def ids(self):
+    def ids(self) -> Tuple[str, ...]:
         return tuple(self._term_dict.keys())
 
     @property
-    def terms(self):
+    def terms(self) -> Tuple["SdoTerm", ...]:
         if not self.expanded:
           raise UnexpandedTermError()
-        return tuple(self._term_dict.values())
+        return tuple(self._term_dict.values()) # type: ignore
 
-    def setIds(self, term_ids):
+    def setIds(self, term_ids: Iterable[str]) -> None:
         self._term_dict.clear()
         for term_id in term_ids:
             self._term_dict[term_id] = None
 
-    def setTerms(self, terms):
+    def setTerms(self, terms: Iterable["SdoTerm"]) -> None:
         self._term_dict.clear()
         for term in terms:
             self._term_dict[term.id] = term
 
-    def clear(self):
+    def clear(self) -> None:
         self._term_dict.clear()
 
-    def __bool__(self):
+    def __bool__(self) -> bool:
         return bool(self._term_dict)
 
-    def __len__(self):
+    def __len__(self) -> int:
         return len(self._term_dict)
 
-    def __contains__(self, value):
-        return value in self._term_dict.keys()
+    def __contains__(self, value: str) -> bool:
+        return value in self._term_dict
 
-    def __str__(self):
+    def __iter__(self) -> Iterable[str]:
+        return iter(self.ids)
+
+    def __str__(self) -> str:
         return '[' + ','.join(map(str, self.ids)) + ']'
 
 
@@ -150,77 +156,79 @@ class SdoTerm(object):
     """
 
 
-    TYPE_LIKE_TYPES = frozenset(
+    TYPE_LIKE_TYPES: Set[SdoTermType] = frozenset(
         [SdoTermType.TYPE, SdoTermType.DATATYPE, SdoTermType.ENUMERATION]
     )
 
-    def __init__(self, termType: SdoTermType, term_id: str, uri: str, label: str):
+    def __init__(self, termType: SdoTermType, term_id: str, uri: str, label: str) -> None:
         if type(self) == SdoTerm:
             raise Exception("<SdoTerm> must be subclassed.")
 
         assert isinstance(term_id, str)
-        self._expansion_depth = 0
-        self.termType = termType
-        self.uri = uri
-        self._term_id = term_id
-        self.label = label
+        self._expansion_depth: int = 0
+        self.termType: SdoTermType = termType
+        self.uri: str = uri
+        self._term_id: str = term_id
+        self.label: str = label
 
-        self.acknowledgements = []
+        self.acknowledgements: List[Any] = []
 
-        self.comment = ""
-        self.comments = []
+        self.comment: str = ""
+        self.comments: List[str] = []
 
-        self.examples = []
-        self.pending = False
-        self.retired = False
-        self.extLayer = ""
-        self.sources = []
-
-
-        self.supersededBy = ""
-        self.supersedes = ""
-        self.superseded = False
-        self.superPaths = []
-
-        self._termStack = SdoTermSequence()
-        self._supers = SdoTermSequence()
-        self._subs = SdoTermSequence()
-        self._equivalents = SdoTermSequence()
+        self.examples: List[Any] = []
+        self.pending: bool = False
+        self.retired: bool = False
+        self.extLayer: str = ""
+        self.sources: List[str] = []
 
 
-    def __str__(self):
+        self.supersededBy: str = ""
+        self.supersedes: List[str] = []
+        self.superseded: bool = False
+        self.superPaths: List[Any] = []
+
+        self._termStack: SdoTermSequence = SdoTermSequence()
+        self._supers: SdoTermSequence = SdoTermSequence()
+        self._subs: SdoTermSequence = SdoTermSequence()
+        self._equivalents: SdoTermSequence = SdoTermSequence()
+
+
+    def __str__(self) -> str:
         return ("<%s: '%s' expansion depth: %s >") % (
             self.__class__.__name__.upper(),
             self.id,
             self._expansion_depth,
         )
 
-    def __eq__(self, other):
+    def __eq__(self, other: Any) -> bool:
+        if not isinstance(other, SdoTerm):
+             return False
         return self.id == other.id
 
-    def __lt__(self, other):
+    def __lt__(self, other: "SdoTerm") -> bool:
         return self.id < other.id
 
-    def markExpanded(self, depth : int):
+    def markExpanded(self, depth: int) -> None:
         self._expansion_depth = depth
 
-    def expanded(self):
+    def expanded(self) -> bool:
         return self._expansion_depth > 1
 
     @property
-    def supers(self):
-        return self._supers;
+    def supers(self) -> SdoTermSequence:
+        return self._supers
 
     @property
-    def subs(self):
-        return self._subs;
+    def subs(self) -> SdoTermSequence:
+        return self._subs
 
     @property
-    def equivalents(self):
+    def equivalents(self) -> SdoTermSequence:
         return self._equivalents
 
     @property
-    def termStack(self):
+    def termStack(self) -> SdoTermSequence:
         return self._termStack
 
     @property
@@ -230,45 +238,45 @@ class SdoTerm(object):
 class SdoType(SdoTerm):
     """Term that defines a schema.org type"""
 
-    def __init__(self, term_id: str, uri: str, label: str):
+    def __init__(self, term_id: str, uri: str, label: str) -> None:
         SdoTerm.__init__(self, SdoTermType.TYPE, term_id, uri, label)
 
-        self._properties = SdoTermSequence()
-        self._allproperties = SdoTermSequence()
-        self._expectedTypeFor = SdoTermSequence()
+        self._properties: SdoTermSequence = SdoTermSequence()
+        self._allproperties: SdoTermSequence = SdoTermSequence()
+        self._expectedTypeFor: SdoTermSequence = SdoTermSequence()
 
     @property
-    def properties(self):
+    def properties(self) -> SdoTermSequence:
         return self._properties
 
     @property
-    def allproperties(self):
+    def allproperties(self) -> SdoTermSequence:
         return self._allproperties
 
     @property
-    def expectedTypeFor(self):
+    def expectedTypeFor(self) -> SdoTermSequence:
         return self._expectedTypeFor
 
 
 class SdoProperty(SdoTerm):
     """Term that defines a propery of another type."""
 
-    def __init__(self, term_id: str, uri: str, label: str):
+    def __init__(self, term_id: str, uri: str, label: str) -> None:
         SdoTerm.__init__(self, SdoTermType.PROPERTY, term_id, uri, label)
-        self._domainIncludes = SdoTermSequence()
-        self._rangeIncludes = SdoTermSequence()
-        self._inverse = SdoTermOrId()
+        self._domainIncludes: SdoTermSequence = SdoTermSequence()
+        self._rangeIncludes: SdoTermSequence = SdoTermSequence()
+        self._inverse: SdoTermOrId = SdoTermOrId()
 
     @property
-    def domainIncludes(self):
+    def domainIncludes(self) -> SdoTermSequence:
         return self._domainIncludes
 
     @property
-    def rangeIncludes(self):
+    def rangeIncludes(self) -> SdoTermSequence:
         return self._rangeIncludes
 
     @property
-    def inverse(self):
+    def inverse(self) -> SdoTermOrId:
         return self._inverse
 
 
@@ -276,82 +284,80 @@ class SdoProperty(SdoTerm):
 class SdoDataType(SdoTerm):
     """Term that defines one of the basic data-types: Boolean, Date, Text, Number etc."""
 
-    def __init__(self, term_id: str, uri: str, label: str):
+    def __init__(self, term_id: str, uri: str, label: str) -> None:
         SdoTerm.__init__(self, SdoTermType.DATATYPE, term_id, uri, label)
 
-        self._properties = SdoTermSequence()
-        self._allproperties = SdoTermSequence()
-        self._expectedTypeFor = SdoTermSequence()
+        self._properties: SdoTermSequence = SdoTermSequence()
+        self._allproperties: SdoTermSequence = SdoTermSequence()
+        self._expectedTypeFor: SdoTermSequence = SdoTermSequence()
 
     @property
-    def properties(self):
+    def properties(self) -> SdoTermSequence:
         return self._properties
 
     @property
-    def allproperties(self):
+    def allproperties(self) -> SdoTermSequence:
         return self._allproperties
 
     @property
-    def expectedTypeFor(self):
+    def expectedTypeFor(self) -> SdoTermSequence:
         return self._expectedTypeFor
 
 
 class SdoEnumeration(SdoTerm):
     """Term that defines a schema.org enumeration."""
 
-    def __init__(self, term_id: str, uri: str, label: str):
+    def __init__(self, term_id: str, uri: str, label: str) -> None:
         SdoTerm.__init__(self, SdoTermType.ENUMERATION, term_id, uri, label)
-        self._properties = SdoTermSequence()
-        self._allproperties = SdoTermSequence()
-        self._expectedTypeFor = SdoTermSequence()
-        self._enumerationMembers = SdoTermSequence()
+        self._properties: SdoTermSequence = SdoTermSequence()
+        self._allproperties: SdoTermSequence = SdoTermSequence()
+        self._expectedTypeFor: SdoTermSequence = SdoTermSequence()
+        self._enumerationMembers: SdoTermSequence = SdoTermSequence()
 
     @property
-    def properties(self):
+    def properties(self) -> SdoTermSequence:
         return self._properties
 
     @property
-    def allproperties(self):
+    def allproperties(self) -> SdoTermSequence:
         return self._allproperties
 
     @property
-    def expectedTypeFor(self):
+    def expectedTypeFor(self) -> SdoTermSequence:
         return self._expectedTypeFor
 
     @property
-    def enumerationMembers(self):
+    def enumerationMembers(self) -> SdoTermSequence:
         return self._enumerationMembers
 
 
 class SdoEnumerationvalue(SdoTerm):
     """Term that defines a value within a schema.org enumeration."""
 
-    def __init__(self, term_id: str, uri: str, label: str):
+    def __init__(self, term_id: str, uri: str, label: str) -> None:
         SdoTerm.__init__(self, SdoTermType.ENUMERATIONVALUE, term_id, uri, label)
-        self._enumerationParent = SdoTermOrId()
+        self._enumerationParent: SdoTermOrId = SdoTermOrId()
 
     @property
-    def enumerationParent(self):
+    def enumerationParent(self) -> SdoTermOrId:
         return self._enumerationParent
 
 
 class SdoReference(SdoTerm):
-    def __init__(self, term_id: str, uri: str, label: str):
+    def __init__(self, term_id: str, uri: str, label: str) -> None:
         SdoTerm.__init__(self, SdoTermType.REFERENCE, term_id, uri, label)
 
 
-_TYPES_FOR_TYPES = {
-    SdoTermType.TYPE : SdoType,
-    SdoTermType.DATATYPE : SdoDataType,
-    SdoTermType.PROPERTY : SdoProperty,
-    SdoTermType.ENUMERATION : SdoEnumeration,
-    SdoTermType.ENUMERATIONVALUE : SdoEnumerationvalue,
-    SdoTermType.REFERENCE : SdoReference
+_TYPES_FOR_TYPES: Dict[SdoTermType, Type[SdoTerm]] = {
+    SdoTermType.TYPE: SdoType,
+    SdoTermType.DATATYPE: SdoDataType,
+    SdoTermType.PROPERTY: SdoProperty,
+    SdoTermType.ENUMERATION: SdoEnumeration,
+    SdoTermType.ENUMERATIONVALUE: SdoEnumerationvalue,
+    SdoTermType.REFERENCE: SdoReference
 }
 
 
-def SdoTermforType(term_type : SdoTermType, **kwargs) -> SdoTerm:
-    t = _TYPES_FOR_TYPES[term_type]
+def SdoTermforType(term_type: SdoTermType, **kwargs: Any) -> SdoTerm:
+    t: Type[SdoTerm] = _TYPES_FOR_TYPES[term_type]
     return t(**kwargs)
-
-

--- a/software/SchemaTerms/sdotermsource.py
+++ b/software/SchemaTerms/sdotermsource.py
@@ -1,25 +1,20 @@
 #!/usr/bin/env python3
 # -*- coding: utf-8 -*-
 
-# Import standard python libraries
 import collections
 import copy
 import glob
 import json
 import logging
-import os
 import rdflib
-from rdflib.compare import to_canonical_graph
 import re
 import sys
 import threading
-import typing
-from typing import Any, Dict, List, Optional, Tuple, Union, Iterable, Sequence, Set
+from pathlib import Path
+from typing import Any, Dict, List, Optional, Tuple, Union, Iterable, Sequence, Set, Type, cast
 
-
-# Import schema.org libraries
-if not os.getcwd() in sys.path:
-    sys.path.insert(1, os.getcwd())
+if Path.cwd() not in [Path(p).resolve() for p in sys.path]:
+    sys.path.insert(1, str(Path.cwd()))
 
 import software
 import software.SchemaTerms.sdoterm as sdoterm
@@ -43,152 +38,68 @@ LOADEDDEFAULT: bool = False
 
 
 def bindNameSpaces(graph: rdflib.Graph) -> None:
-    # --- Standard / W3C / Dublin Core ---
-    graph.bind("dc", "http://purl.org/dc/elements/1.1/")
-    graph.bind("dcat", "http://www.w3.org/ns/dcat#")
-    graph.bind("dct", "http://purl.org/dc/terms/")
-    graph.bind("dctype", "http://purl.org/dc/dcmitype/")
-    graph.bind("foaf", "http://xmlns.com/foaf/0.1/")
-    graph.bind("owl", "http://www.w3.org/2002/07/owl#")
-    graph.bind("rdf", "http://www.w3.org/1999/02/22-rdf-syntax-ns#")
-    graph.bind("rdfs", "http://www.w3.org/2000/01/rdf-schema#")
-    graph.bind("skos", "http://www.w3.org/2004/02/skos/core#")
-    graph.bind("void", "http://rdfs.org/ns/void#")
-
-    # --- OMG Commons ---
-    graph.bind("cmns-cls", "https://www.omg.org/spec/Commons/Classifiers/")
-    graph.bind("cmns-col", "https://www.omg.org/spec/Commons/Collections/")
-    graph.bind("cmns-dt", "https://www.omg.org/spec/Commons/DatesAndTimes/")
-    graph.bind("cmns-ge", "https://www.omg.org/spec/Commons/GeopoliticalEntities/")
-    graph.bind("cmns-id", "https://www.omg.org/spec/Commons/Identifiers/")
-    graph.bind("cmns-loc", "https://www.omg.org/spec/Commons/Locations/")
-    graph.bind("cmns-q", "https://www.omg.org/spec/Commons/Quantities/")
-    graph.bind("cmns-txt", "https://www.omg.org/spec/Commons/Text/")
-
-    # --- OMG LCC (ISO Codes) ---
-    graph.bind(
-        "lcc-3166-1", "https://www.omg.org/spec/LCC/Countries/ISO3166-1-CountryCodes/"
-    )
-    graph.bind(
-        "lcc-4217", "https://www.omg.org/spec/LCC/Countries/ISO4217-CurrencyCodes/"
-    )
-    graph.bind(
-        "lcc-lr", "https://www.omg.org/spec/LCC/Languages/LanguageRepresentation/"
-    )
-
-    # --- FIBO (Financial Industry Business Ontology) ---
-    graph.bind(
-        "fibo-be-corp-corp",
-        "https://spec.edmcouncil.org/fibo/ontology/BE/Corporations/Corporations/",
-    )
-    graph.bind(
-        "fibo-be-ge-ge",
-        "https://spec.edmcouncil.org/fibo/ontology/BE/GovernmentEntities/GovernmentEntities/",
-    )
-    graph.bind(
-        "fibo-be-le-cb",
-        "https://spec.edmcouncil.org/fibo/ontology/BE/LegalEntities/CorporateBodies/",
-    )
-    graph.bind(
-        "fibo-be-le-lp",
-        "https://spec.edmcouncil.org/fibo/ontology/BE/LegalEntities/LegalPersons/",
-    )
-    graph.bind(
-        "fibo-be-nfp-nfp",
-        "https://spec.edmcouncil.org/fibo/ontology/BE/NotForProfitOrganizations/NotForProfitOrganizations/",
-    )
-    graph.bind(
-        "fibo-be-oac-cctl",
-        "https://spec.edmcouncil.org/fibo/ontology/BE/OwnershipAndControl/CorporateControl/",
-    )
-    graph.bind(
-        "fibo-fbc-dae-dbt",
-        "https://spec.edmcouncil.org/fibo/ontology/FBC/DebtAndEquities/Debt/",
-    )
-    graph.bind(
-        "fibo-fbc-pas-fpas",
-        "https://spec.edmcouncil.org/fibo/ontology/FBC/ProductsAndServices/FinancialProductsAndServices/",
-    )
-    graph.bind(
-        "fibo-fnd-acc-cur",
-        "https://spec.edmcouncil.org/fibo/ontology/FND/Accounting/CurrencyAmount/",
-    )
-    graph.bind(
-        "fibo-fnd-agr-ctr",
-        "https://spec.edmcouncil.org/fibo/ontology/FND/Agreements/Contracts/",
-    )
-    graph.bind(
-        "fibo-fnd-arr-doc",
-        "https://spec.edmcouncil.org/fibo/ontology/FND/Arrangements/Documents/",
-    )
-    graph.bind(
-        "fibo-fnd-arr-lif",
-        "https://spec.edmcouncil.org/fibo/ontology/FND/Arrangements/Lifecycles/",
-    )
-    graph.bind(
-        "fibo-fnd-dt-oc",
-        "https://spec.edmcouncil.org/fibo/ontology/FND/DatesAndTimes/Occurrences/",
-    )
-    graph.bind(
-        "fibo-fnd-org-org",
-        "https://spec.edmcouncil.org/fibo/ontology/FND/Organizations/Organizations/",
-    )
-    graph.bind(
-        "fibo-fnd-pas-pas",
-        "https://spec.edmcouncil.org/fibo/ontology/FND/ProductsAndServices/ProductsAndServices/",
-    )
-    graph.bind(
-        "fibo-fnd-plc-adr",
-        "https://spec.edmcouncil.org/fibo/ontology/FND/Places/Addresses/",
-    )
-    graph.bind(
-        "fibo-fnd-plc-fac",
-        "https://spec.edmcouncil.org/fibo/ontology/FND/Places/Facilities/",
-    )
-    graph.bind(
-        "fibo-fnd-plc-loc",
-        "https://spec.edmcouncil.org/fibo/ontology/FND/Places/Locations/",
-    )
-    graph.bind(
-        "fibo-fnd-pty-pty",
-        "https://spec.edmcouncil.org/fibo/ontology/FND/Parties/Parties/",
-    )
-    graph.bind(
-        "fibo-fnd-rel-rel",
-        "https://spec.edmcouncil.org/fibo/ontology/FND/Relations/Relations/",
-    )
-    graph.bind(
-        "fibo-pay-ps-ps",
-        "https://spec.edmcouncil.org/fibo/ontology/PAY/PaymentServices/PaymentServices/",
-    )
-
-    # --- Other External Vocabularies ---
-    graph.bind("gleif-L1", "https://www.gleif.org/ontology/L1/")
-    graph.bind("gs1", "https://ref.gs1.org/voc/")
-    graph.bind(
-        "lcc-cr", "https://www.omg.org/spec/LCC/Countries/CountryRepresentation/"
-    )
-    graph.bind("unece", "http://unece.org/vocab#")
-    graph.bind("vcard", "http://www.w3.org/2006/vcard/ns#")
-    graph.bind("bibo", "http://purl.org/ontology/bibo/")
-    graph.bind("sarif", "http://sarif.info/")
-
-    # --- Libraries and Health ---
-    graph.bind("lrmoo", "http://iflastandards.info/ns/lrm/lrmoo/")
-    graph.bind("snomed", "http://purl.bioontology.org/ontology/SNOMEDCT/")
-
-    # --- European Legislation Identifier (ELI) ---
-    graph.bind("eli", "http://data.europa.eu/eli/ontology#")
-
-    # --- W3C Standard extensions ---
-    graph.bind("prov", "http://www.w3.org/ns/prov#")
-    graph.bind("hydra", "http://www.w3.org/ns/hydra/core#")
-
-    # --- Music Ontology ---
-    graph.bind("mo", "http://purl.org/ontology/mo/")
-
-    # --- Open-Graph ---
-    graph.bind("og", "http://ogp.me/ns#")
+    namespaces: Dict[str, str] = {
+        "dc": "http://purl.org/dc/elements/1.1/",
+        "dcat": "http://www.w3.org/ns/dcat#",
+        "dct": "http://purl.org/dc/terms/",
+        "dctype": "http://purl.org/dc/dcmitype/",
+        "foaf": "http://xmlns.com/foaf/0.1/",
+        "owl": "http://www.w3.org/2002/07/owl#",
+        "rdf": "http://www.w3.org/1999/02/22-rdf-syntax-ns#",
+        "rdfs": "http://www.w3.org/2000/01/rdf-schema#",
+        "skos": "http://www.w3.org/2004/02/skos/core#",
+        "void": "http://rdfs.org/ns/void#",
+        "cmns-cls": "https://www.omg.org/spec/Commons/Classifiers/",
+        "cmns-col": "https://www.omg.org/spec/Commons/Collections/",
+        "cmns-dt": "https://www.omg.org/spec/Commons/DatesAndTimes/",
+        "cmns-ge": "https://www.omg.org/spec/Commons/GeopoliticalEntities/",
+        "cmns-id": "https://www.omg.org/spec/Commons/Identifiers/",
+        "cmns-loc": "https://www.omg.org/spec/Commons/Locations/",
+        "cmns-q": "https://www.omg.org/spec/Commons/Quantities/",
+        "cmns-txt": "https://www.omg.org/spec/Commons/Text/",
+        "lcc-3166-1": "https://www.omg.org/spec/LCC/Countries/ISO3166-1-CountryCodes/",
+        "lcc-4217": "https://www.omg.org/spec/LCC/Countries/ISO4217-CurrencyCodes/",
+        "lcc-lr": "https://www.omg.org/spec/LCC/Languages/LanguageRepresentation/",
+        "fibo-be-corp-corp": "https://spec.edmcouncil.org/fibo/ontology/BE/Corporations/Corporations/",
+        "fibo-be-ge-ge": "https://spec.edmcouncil.org/fibo/ontology/BE/GovernmentEntities/GovernmentEntities/",
+        "fibo-be-le-cb": "https://spec.edmcouncil.org/fibo/ontology/BE/LegalEntities/CorporateBodies/",
+        "fibo-be-le-lp": "https://spec.edmcouncil.org/fibo/ontology/BE/LegalEntities/LegalPersons/",
+        "fibo-be-nfp-nfp": "https://spec.edmcouncil.org/fibo/ontology/BE/NotForProfitOrganizations/NotForProfitOrganizations/",
+        "fibo-be-oac-cctl": "https://spec.edmcouncil.org/fibo/ontology/BE/OwnershipAndControl/CorporateControl/",
+        "fibo-fbc-dae-dbt": "https://spec.edmcouncil.org/fibo/ontology/FBC/DebtAndEquities/Debt/",
+        "fibo-fbc-pas-fpas": "https://spec.edmcouncil.org/fibo/ontology/FBC/ProductsAndServices/FinancialProductsAndServices/",
+        "fibo-fnd-acc-cur": "https://spec.edmcouncil.org/fibo/ontology/FND/Accounting/CurrencyAmount/",
+        "fibo-fnd-agr-ctr": "https://spec.edmcouncil.org/fibo/ontology/FND/Agreements/Contracts/",
+        "fibo-fnd-arr-doc": "https://spec.edmcouncil.org/fibo/ontology/FND/Arrangements/Documents/",
+        "fibo-fnd-arr-lif": "https://spec.edmcouncil.org/fibo/ontology/FND/Arrangements/Lifecycles/",
+        "fibo-fnd-dt-oc": "https://spec.edmcouncil.org/fibo/ontology/FND/DatesAndTimes/Occurrences/",
+        "fibo-fnd-org-org": "https://spec.edmcouncil.org/fibo/ontology/FND/Organizations/Organizations/",
+        "fibo-fnd-pas-pas": "https://spec.edmcouncil.org/fibo/ontology/FND/ProductsAndServices/ProductsAndServices/",
+        "fibo-fnd-plc-adr": "https://spec.edmcouncil.org/fibo/ontology/FND/Places/Addresses/",
+        "fibo-fnd-plc-fac": "https://spec.edmcouncil.org/fibo/ontology/FND/Places/Facilities/",
+        "fibo-fnd-plc-loc": "https://spec.edmcouncil.org/fibo/ontology/FND/Places/Locations/",
+        "fibo-fnd-pty-pty": "https://spec.edmcouncil.org/fibo/ontology/FND/Parties/Parties/",
+        "fibo-fnd-rel-rel": "https://spec.edmcouncil.org/fibo/ontology/FND/Relations/Relations/",
+        "fibo-pay-ps-ps": "https://spec.edmcouncil.org/fibo/ontology/PAY/PaymentServices/PaymentServices/",
+        "gleif-L1": "https://www.gleif.org/ontology/L1/",
+        "gs1": "https://ref.gs1.org/voc/",
+        "lcc-cr": "https://www.omg.org/spec/LCC/Countries/CountryRepresentation/",
+        "unece": "http://unece.org/vocab#",
+        "vcard": "http://www.w3.org/2006/vcard/ns#",
+        "bibo": "http://purl.org/ontology/bibo/",
+        "sarif": "http://sarif.info/",
+        "lrmoo": "http://iflastandards.info/ns/lrm/lrmoo/",
+        "snomed": "http://purl.bioontology.org/ontology/SNOMEDCT/",
+        "eli": "http://data.europa.eu/eli/ontology#",
+        "prov": "http://www.w3.org/ns/prov#",
+        "hydra": "http://www.w3.org/ns/hydra/core#",
+        "mo": "http://purl.org/ontology/mo/",
+        "og": "http://ogp.me/ns#",
+    }
+    prefix: str
+    uri: str
+    for prefix, uri in namespaces.items():
+        graph.bind(prefix, uri)
 
 
 class _TermAccumulator:
@@ -210,41 +121,33 @@ class _TermAccumulator:
         self.layer = layerFromUri(str(row.layer))
 
 
-def _loadOneSourceGraph(file_path: str) -> rdflib.Graph:
+def _loadOneSourceGraph(file_path: Union[str, Path]) -> rdflib.Graph:
     """Load the content of one source file."""
-    name, extension = os.path.splitext(file_path)
-    if extension == ".nt":
-        file_format = "nt"
-    elif extension == ".ttl":
-        file_format = "turtle"
-    else:
-        raise NotImplementedError(f"Unsupported file format: {extension}")
+    path: Path = Path(file_path)
+    formats: Dict[str, str] = {".nt": "nt", ".ttl": "turtle"}
+    file_format: Optional[str] = formats.get(path.suffix)
+    if not file_format:
+        raise NotImplementedError(f"Unsupported file format: {path.suffix}")
     try:
-        graph = rdflib.Graph()
-        graph.parse(source=file_path, format=file_format)
+        graph: rdflib.Graph = rdflib.Graph()
+        graph.parse(source=str(path), format=file_format)
         return graph
     except Exception as e:
-        message = f"Error parsing source file '{file_path}': {e}"
+        message: str = f"Error parsing source file '{file_path}': {e}"
         log.warning(message)
-        raise IOError(message)
+        raise IOError(message) from e
 
 
 class SdoTermSource:
-    """This class acts as the source of information for terms.
-
-
-    The class acts as a cache of terms keyed by id.
-    Instances are kind of factory for terms.
-
-    """
+    """This class acts as the source of information for terms."""
 
     TYPE: str = "Class"
     TERMCOUNTS: Optional[Dict[Union[sdoterm.SdoTermType, str], int]] = None
 
     SOURCEGRAPH: Optional[rdflib.Graph] = None
     MARKDOWNPROCESS: bool = True
-    EXPANDEDTERMS: Dict[str, sdoterm.SdoTerm] = {}
-    TERMS: Dict[str, sdoterm.SdoTerm] = {}
+    EXPANDEDTERMS: Dict[str, Any] = {}
+    TERMS: Dict[str, Any] = {}
 
     TERMSLOCK: threading.Lock = threading.Lock()
     RDFLIBLOCK: threading.Lock = threading.Lock()
@@ -252,10 +155,8 @@ class SdoTermSource:
 
     def __init__(self, uri: str, ttype: Optional[Union[rdflib.URIRef, str]] = None, label: str = "", layer: Optional[str] = None) -> None:
         term_id: str = uri2id(uri)
-        self.layer: str = CORE
-        if layer:
-            self.layer = layer
-        self.termdesc: Optional[sdoterm.SdoTerm] = None
+        self.layer: str = layer or CORE
+        self.termdesc: Any = None
 
         self.parent: Optional[sdoterm.SdoTerm] = None
         self.checkedDataTypeParents: bool = False
@@ -280,15 +181,13 @@ class SdoTermSource:
         self.acks: Optional[Sequence[sdocollaborators.collaborator]] = None
         self.examples: Optional[List[Any]] = None
         global DATATYPEURI, ENUMERATIONURI
-        cls = self.__class__
+        cls: Type[SdoTermSource] = self.__class__
         self.ttype: sdoterm.SdoTermType
         if ttype == rdflib.RDFS.Class:
             self.ttype = sdoterm.SdoTermType.TYPE
-            if uri == str(DATATYPEURI):  # The base DataType is defined as a Class
+            if uri == str(DATATYPEURI):
                 self.ttype = sdoterm.SdoTermType.DATATYPE
-            elif uri == str(
-                ENUMERATIONURI
-            ):  # The base Enumeration Type is defined as a Class
+            elif uri == str(ENUMERATIONURI):
                 self.ttype = sdoterm.SdoTermType.ENUMERATION
             elif self._isEnumeration(term_id=term_id):
                 self.ttype = sdoterm.SdoTermType.ENUMERATION
@@ -304,10 +203,13 @@ class SdoTermSource:
         else:
             self.parent = cls._getTerm(str(ttype), createReference=True)
 
-            if self.parent and self.parent.termType == sdoterm.SdoTermType.ENUMERATION:
-                self.ttype = sdoterm.SdoTermType.ENUMERATIONVALUE
-            elif self.parent and self.parent.termType == sdoterm.SdoTermType.DATATYPE:
-                self.ttype = sdoterm.SdoTermType.DATATYPE
+            if self.parent:
+                if self.parent.termType == sdoterm.SdoTermType.ENUMERATION:
+                    self.ttype = sdoterm.SdoTermType.ENUMERATIONVALUE
+                elif self.parent.termType == sdoterm.SdoTermType.DATATYPE:
+                    self.ttype = sdoterm.SdoTermType.DATATYPE
+                else:
+                    self.ttype = sdoterm.SdoTermType.REFERENCE
             else:
                 self.ttype = sdoterm.SdoTermType.REFERENCE
 
@@ -331,25 +233,20 @@ class SdoTermSource:
         self.termdesc.supersedes = self.getSupersedes()
         self.termdesc.superseded = self.superseded()
         self.termdesc.termStack.setTerms(self.getTermStack())
-        self.termdesc.superPaths = (
-            self.getParentPaths()
-        )  # MUST be called after supers has been added to self.termdesc
+        self.termdesc.superPaths = self.getParentPaths()
 
-        # Class (Type) Building
         if self.ttype in sdoterm.SdoTerm.TYPE_LIKE_TYPES:
             self.termdesc.properties.setIds(self.getProperties(getall=False))
             self.termdesc.allproperties.setIds(self.getProperties(getall=True))
             self.termdesc.expectedTypeFor.setIds(self.getTargetOf())
             if self.ttype == sdoterm.SdoTermType.ENUMERATION:
-                if not len(self.termdesc.properties):
+                if not self.termdesc.properties:
                     self.termdesc.termStack.clear()
                 self.termdesc._enumerationMembers.setIds(self.getEnumerationMembers())
         elif self.ttype == sdoterm.SdoTermType.PROPERTY:
             self.termdesc.domainIncludes.setIds(self.getDomains())
             self.termdesc.rangeIncludes.setIds(self.getRanges())
             self.termdesc.inverse.setId(self.getInverseOf())
-        elif self.ttype == sdoterm.SdoTermType.ENUMERATIONVALUE:
-            pass
         elif self.ttype == sdoterm.SdoTermType.REFERENCE:
             self.termdesc.label = prefixedIdFromUri(uri)
             self.termdesc.comment = self.getComment()
@@ -361,13 +258,16 @@ class SdoTermSource:
 
     @property
     def id(self) -> str:
+        assert self.termdesc is not None
         return self.termdesc.id
 
     @property
     def uri(self) -> str:
+        assert self.termdesc is not None
         return self.termdesc.uri
 
     def getTermdesc(self) -> sdoterm.SdoTerm:
+        assert self.termdesc is not None
         return self.termdesc
 
     def getType(self) -> sdoterm.SdoTermType:
@@ -384,8 +284,9 @@ class SdoTermSource:
             return True
         if self.isClass() and not self.checkedDataTypeParents:
             self.checkedDataTypeParents = True
+            sup_id: str
             for sup_id in self.getSupers():
-                sup = self.__class__.getTerm(sup_id)
+                sup: Optional[sdoterm.SdoTerm] = self.__class__.getTerm(sup_id)
                 if sup and sup.termType == sdoterm.SdoTermType.DATATYPE:
                     self.ttype = sdoterm.SdoTermType.DATATYPE
                     return True
@@ -394,13 +295,13 @@ class SdoTermSource:
     @classmethod
     def _isEnumeration(cls, term_id: str) -> bool:
         global ENUMERATIONURI
-        query = """
+        query: str = """
           ASK  {
                     %s rdfs:subClassOf* %s.
             }""" % (uriWrap(toFullId(term_id)), uriWrap(str(ENUMERATIONURI)))
 
-        result = cls.query(query)
-        return result[-1]
+        result: Sequence[rdflib.query.ResultRow] = cls.query(query)
+        return bool(result[-1])
 
     def _isEnumerationValue(self) -> bool:
         return self.ttype == sdoterm.SdoTermType.ENUMERATIONVALUE
@@ -422,57 +323,47 @@ class SdoTermSource:
     def getComment(self) -> str:
         if not self.comment:
             self.loadComment()
+        assert self.comment is not None
         return self.comment
 
     def getSupersededBy(self) -> str:
         if not self.supersededBy:
-            tmp = []
-            ss = self.loadObjects("schema:supersededBy")
-            for s in ss:
-                t = uri2id(str(s))
-                if t:
-                    tmp.append(t)
+            ss: List[rdflib.term.Node] = self.loadObjects("schema:supersededBy")
+            tmp: List[str] = [t for s in ss if (t := uri2id(str(s)))]
 
             if len(tmp) > 1:
                 log.debug(
                     f"Warning '{self.id}' supersededBy more than 1 term ({len(tmp)})"
                 )
-            if len(tmp):
-                self.supersededBy = tmp[0]
-            else:
-                self.supersededBy = ""
+            self.supersededBy = tmp[0] if tmp else ""
         return self.supersededBy
 
     def superseded(self) -> bool:
-        return len(self.getSupersededBy()) > 0
+        return bool(self.getSupersededBy())
 
     def getSupersedes(self) -> List[str]:
         if not self.supersedes:
-            self.supersedes = []
-            subs = self.loadSubjects("schema:supersededBy")
-            for sub in subs:
-                self.supersedes.append(uri2id(str(sub)))
-            self.supersedes.sort()
+            subs: List[rdflib.term.Node] = self.loadSubjects("schema:supersededBy")
+            self.supersedes = sorted(uri2id(str(sub)) for sub in subs)
         return self.supersedes
 
     def getSources(self) -> List[str]:
         if not self.sources:
-            objs = self.loadObjects("schema:source")  # To accept later ttl versions.
-            self.sources = sorted([str(o) for o in objs])
+            objs: List[rdflib.term.Node] = self.loadObjects("schema:source")
+            self.sources = sorted(str(o) for o in objs)
         return self.sources
 
     def getAcknowledgements(self) -> Sequence[sdocollaborators.collaborator]:
         if not self.acks:
-            acks = []
-            objs = self.loadObjects(
-                "schema:contributor"
-            )  # To accept later ttl versions.
+            acks: List[sdocollaborators.collaborator] = []
+            objs: List[rdflib.term.Node] = self.loadObjects("schema:contributor")
+            obj: rdflib.term.Node
             for obj in objs:
                 if obj:
-                    cont = sdocollaborators.collaborator.getContributor(str(obj))
+                    cont: Optional[sdocollaborators.collaborator] = sdocollaborators.collaborator.getContributor(str(obj))
                     if cont:
                         acks.append(cont)
-            self.acks = sorted(acks, key=lambda t: t.title)
+            self.acks = sorted(acks, key=lambda t: t.title or "")
         return self.acks
 
     def getLayer(self) -> str:
@@ -481,7 +372,7 @@ class SdoTermSource:
     def getInverseOf(self) -> Optional[str]:
         if not self.gotinverseOf:
             self.gotinverseOf = True
-            inverse = self.loadValue("schema:inverseOf")
+            inverse: Optional[Any] = self.loadValue("schema:inverseOf")
             if inverse:
                 self.inverseOf = uri2id(str(inverse))
         return self.inverseOf
@@ -489,23 +380,27 @@ class SdoTermSource:
     def getSupers(self) -> List[str]:
         if not self.supers:
             self.loadsupers()
+        assert self.supers is not None
         return self.supers
 
     def getTermStack(self) -> List[sdoterm.SdoTerm]:
         if not self.termStack:
             self.termStack = []
+            sup_id: str
             for sup_id in self.getSupers():
                 try:
-                    s = self.__class__._getTerm(sup_id, createReference=True)
-                    if s.termType == sdoterm.SdoTermType.REFERENCE:
+                    s: Optional[sdoterm.SdoTerm] = self.__class__._getTerm(sup_id, createReference=True)
+                    if not s or s.termType == sdoterm.SdoTermType.REFERENCE:
                         continue
                     self.termStack.append(s)
                     if s.termStack:
                         self.termStack.extend(s.termStack.terms)
                 except RecursionError as e:
+                    assert self.termdesc is not None
                     e.add_note(f"Circular references with {self.termdesc}")
                     raise
-            stack = []
+            stack: List[sdoterm.SdoTerm] = []
+            t: sdoterm.SdoTerm
             for t in reversed(self.termStack):
                 if t not in stack:
                     stack.append(t)
@@ -515,85 +410,68 @@ class SdoTermSource:
     def getSubs(self) -> List[str]:
         if not self.subs:
             self.loadsubs()
+        assert self.subs is not None
         return self.subs
 
     def getProperties(self, getall: bool = False) -> List[str]:
         if not self.props:
-            self.props = []
-            subs = self.loadSubjects("schema:domainIncludes")
-            for sub in subs:
-                self.props.append(uri2id(str(sub)))
-            self.props.sort()
-        ret = self.props
+            subs: List[rdflib.term.Node] = self.loadSubjects("schema:domainIncludes")
+            self.props = sorted(uri2id(str(sub)) for sub in subs)
+        ret: List[str] = self.props
 
         if getall:
-            allprop_ids = set(self.props)
+            allprop_ids: Set[str] = set(self.props)
+            t: sdoterm.SdoTerm
             for t in self.getTermStack():
-                if not isinstance(t, sdoterm.SdoTerm):
-                    term = self.__class__._getTerm(t, createReference=True)
-                else:
-                    term = t
+                term: sdoterm.SdoTerm = t if isinstance(t, sdoterm.SdoTerm) else self.__class__._getTerm(t, createReference=True)
                 if term.id != self.id:
                     if term.id == "ENUMERATION":
                         break
                     if term.termType in sdoterm.SdoTerm.TYPE_LIKE_TYPES:
                         allprop_ids.update(term.properties.ids)
-            ret = sorted(list(allprop_ids))
+            ret = sorted(allprop_ids)
         return ret
 
     def getPropUsedOn(self) -> List[str]:
-        raise Exception("Not implemented yet")
+        raise NotImplementedError("Not implemented yet")
 
     def getRanges(self) -> List[str]:
         if not self.ranges:
-            self.ranges = []
-            objs = self.loadObjects("schema:rangeIncludes")
-            for obj in objs:
-                self.ranges.append(uri2id(str(obj)))
-            self.ranges.sort()
+            objs: List[rdflib.term.Node] = self.loadObjects("schema:rangeIncludes")
+            self.ranges = sorted(uri2id(str(obj)) for obj in objs)
         return self.ranges
 
     def getDomains(self) -> List[str]:
         if not self.domains:
-            self.domains = []
-            objs = self.loadObjects("schema:domainIncludes")
-            for obj in objs:
-                self.domains.append(uri2id(str(obj)))
-            self.domains.sort()
+            objs: List[rdflib.term.Node] = self.loadObjects("schema:domainIncludes")
+            self.domains = sorted(uri2id(str(obj)) for obj in objs)
         return self.domains
 
     def getTargetOf(self, plusparents: bool = False, stopontarget: bool = False) -> List[str]:
         global ENUMERATIONURI, THINGURI
         if not self.targetOf:
-            self.targetOf = []
-            subs = self.loadSubjects("schema:rangeIncludes")
-            for sub in subs:
-                self.targetOf.append(uri2id(str(sub)))
-            self.targetOf.sort()
-        ret = self.targetOf
-        if not (len(self.targetOf) and stopontarget):
+            subs: List[rdflib.term.Node] = self.loadSubjects("schema:rangeIncludes")
+            self.targetOf = sorted(uri2id(str(sub)) for sub in subs)
+        ret: List[str] = self.targetOf
+        if not (self.targetOf and stopontarget):
             if plusparents:
-                targets = list(self.targetOf)
+                targets: Set[str] = set(self.targetOf)
+                s: str
                 for s in self.getSupers():
-                    sup = self.__class__._getTerm(s, createReference=True)
-                    if sup.uri == str(ENUMERATIONURI) or sup.uri == str(THINGURI):
+                    sup: Optional[sdoterm.SdoTerm] = self.__class__._getTerm(s, createReference=True)
+                    if not sup or sup.uri in (str(ENUMERATIONURI), str(THINGURI)):
                         break
-                    ptargets = sup.expectedTypeFor.ids
-                    for t in ptargets:
-                        targets.append(t)
-                    if len(targets) and stopontarget:
+                    targets.update(sup.expectedTypeFor.ids)
+                    if targets and stopontarget:
                         break
-                ret = sorted(list(set(targets)))
+                ret = sorted(targets)
         return ret
 
     def getEquivalents(self) -> List[str]:
         if not self.equivalents:
-            self.equivalents = []
-            equivalents = self.loadObjects("owl:equivalentClass")
+            equivalents: List[rdflib.term.Node] = self.loadObjects("owl:equivalentClass")
             equivalents.extend(self.loadObjects("owl:equivalentProperty"))
-            for e in equivalents:
-                self.equivalents.append(str(e))
-            self.equivalents.sort(key=prefixedIdFromUri)
+            self.equivalents = sorted((str(e) for e in equivalents), key=prefixedIdFromUri)
         return self.equivalents
 
     def inLayers(self, layers: Union[str, Iterable[str]]) -> bool:
@@ -602,83 +480,65 @@ class SdoTermSource:
         return self.layer in layers
 
     def getExtLayer(self) -> str:
-        ret = ""
-        lay = self.layer
-        if len(lay) and lay != CORE:
-            ret = lay
-        return ret
+        return self.layer if self.layer and self.layer != CORE else ""
 
     @classmethod
     def subClassOf(cls, child: Union[str, sdoterm.SdoTerm], parent: Union[str, sdoterm.SdoTerm]) -> bool:
-        if isinstance(child, str):
-            child_obj = cls.getTerm(child)
-        else:
-            child_obj = child
-
-        if isinstance(parent, str):
-            parent_obj = cls.getTerm(parent)
-        else:
-            parent_obj = parent
+        child_obj: Optional[sdoterm.SdoTerm] = cls.getTerm(child) if isinstance(child, str) else child
+        parent_obj: Optional[sdoterm.SdoTerm] = cls.getTerm(parent) if isinstance(parent, str) else parent
 
         if child_obj == parent_obj:
             return True
-
         if not child_obj:
             return False
 
-        parents = child_obj.supers.ids
+        parents: Tuple[str, ...] = child_obj.supers.ids
         if parent_obj and parent_obj.id in parents:
             return True
 
-        for p in parents:
-            if cls.subClassOf(p, parent_obj):
-                return True
-        return False
+        return any(cls.subClassOf(p, parent_obj) for p in parents) if parent_obj else False
 
     def loadComment(self) -> None:
-        comments = self.getComments()
-        wpre = None
-        name = self.termdesc.id
-        if name.startswith(
-            "http:"
-        ):  # Wikilinks in markdown default to current site - extermals need overriding
-            val = os.path.basename(name)
-            wpre = name[: len(name) - len(val)]
+        comments: Sequence[str] = self.getComments()
+        wpre: Optional[str] = None
+        assert self.termdesc is not None
+        name: str = self.termdesc.id
+        if name.startswith("http:"):
+            val: str = Path(name).name
+            wpre = name[: -len(val)]
 
+        comment_buffer: List[str]
         if self.__class__.MARKDOWNPROCESS:
             comment_buffer = [
                 localmarkdown.Markdown.parse(comment, wpre=wpre) for comment in comments
             ]
         else:
             comment_buffer = list(comments)
-        result = " ".join(comment_buffer)
-        self.comment = result.strip()
+        self.comment = " ".join(comment_buffer).strip()
 
     def loadValue(self, valType: str) -> Optional[Any]:
-        ret = self.loadObjects(valType)
-        if not ret or len(ret) == 0:
-            return None
-        return ret[0]
+        ret: List[rdflib.term.Node] = self.loadObjects(valType)
+        return ret[0] if ret else None
 
     def loadObjects(self, pred: Union[rdflib.URIRef, str]) -> List[rdflib.term.Node]:
-        query = """
+        query: str = """
         SELECT ?val WHERE {
                 %s %s ?val.
          }""" % (uriWrap(toFullId(self.id)), uriWrap(str(pred)))
-        res = self.__class__.query(query)
+        res: Sequence[rdflib.query.ResultRow] = self.__class__.query(query)
         return [row.val for row in res]
 
     def loadSubjects(self, pred: Union[rdflib.URIRef, str]) -> List[rdflib.term.Node]:
-        query = """
+        query: str = """
         SELECT ?sub WHERE {
                 ?sub %s %s.
          }""" % (uriWrap(str(pred)), uriWrap(toFullId(self.id)))
-        res = self.__class__.query(query)
+        res: Sequence[rdflib.query.ResultRow] = self.__class__.query(query)
         return [row.sub for row in res]
 
     def loadsupers(self) -> None:
-        fullId = toFullId(self.id)
-        query = """
+        fullId: str = toFullId(self.id)
+        query: str = """
         SELECT ?sup WHERE {
              {
                  %s rdfs:subClassOf ?sup .
@@ -688,58 +548,50 @@ class SdoTermSource:
          }
          ORDER BY ?sup""" % (uriWrap(fullId), uriWrap(fullId))
 
-        res = self.__class__.query(query)
-        self.supers = sorted([uri2id(str(row.sup)) for row in res])
+        res: Sequence[rdflib.query.ResultRow] = self.__class__.query(query)
+        self.supers = sorted(uri2id(str(row.sup)) for row in res)
 
     def loadsubs(self) -> None:
-        fullId = toFullId(self.id)
-        if self.ttype in sdoterm.SdoTerm.TYPE_LIKE_TYPES:
-            sel = "rdfs:subClassOf"
-        else:
-            sel = "rdfs:subPropertyOf"
-        query = """
+        fullId: str = toFullId(self.id)
+        sel: str = "rdfs:subClassOf" if self.ttype in sdoterm.SdoTerm.TYPE_LIKE_TYPES else "rdfs:subPropertyOf"
+        query: str = """
         SELECT ?sub WHERE {
                 ?sub %s %s.
          }ORDER BY ?sub""" % (uriWrap(sel), uriWrap(fullId))
-        res = self.__class__.query(query)
+        res: Sequence[rdflib.query.ResultRow] = self.__class__.query(query)
         self.subs = [uri2id(str(row.sub)) for row in res]
 
         if self.ttype == sdoterm.SdoTermType.DATATYPE:
-            subjects = self.loadSubjects(
-                "a"
-            )  # Enumerationvalues have an Enumeration as a type
-            self.subs.extend([uri2id(str(child)) for child in subjects])
+            subjects: List[rdflib.term.Node] = self.loadSubjects("a")
+            self.subs.extend(uri2id(str(child)) for child in subjects)
         self.subs.sort()
 
     def getEnumerationMembers(self) -> Optional[List[str]]:
         if not self.members and self.ttype == sdoterm.SdoTermType.ENUMERATION:
-            subjects = self.loadSubjects(
-                "a"
-            )  # Enumerationvalues have an Enumeration as a type
-            self.members = [uri2id(str(child)) for child in subjects]
-            self.members.sort()
+            subjects: List[rdflib.term.Node] = self.loadSubjects("a")
+            self.members = sorted(uri2id(str(child)) for child in subjects)
         return self.members
 
     def getParentPaths(self, cstack: Optional[List[str]] = None) -> List[List[str]]:
         self._pstacks: List[List[str]] = []
-        cstack = cstack or []
-        self._pstacks.append(cstack)
-        self._getParentPaths(self.termdesc, cstack)
+        cstack_list: List[str] = cstack or []
+        self._pstacks.append(cstack_list)
+        assert self.termdesc is not None
+        self._getParentPaths(self.termdesc, cstack_list)
 
-        inserts = []
+        inserts: List[str] = []
         if self.ttype == sdoterm.SdoTermType.PROPERTY:
             inserts = ["Property", "Thing"]
         elif self.ttype == sdoterm.SdoTermType.DATATYPE and self.id != "DataType":
             inserts = ["DataType"]
         elif self.ttype == sdoterm.SdoTermType.TYPE:
-            base = self._pstacks[0][0]
-            if base != self.id:
-                basetype = self.__class__._getTerm(base)
-            else:
-                basetype = self.termdesc
+            base: str = self._pstacks[0][0]
+            basetype: Optional[sdoterm.SdoTerm] = self.termdesc if base == self.id else self.__class__._getTerm(base)
             if basetype and basetype.termType == sdoterm.SdoTermType.DATATYPE:
                 inserts = ["DataType"]
 
+        ins: str
+        s: List[str]
         for ins in inserts:
             for s in self._pstacks:
                 s.insert(0, ins)
@@ -748,55 +600,49 @@ class SdoTermSource:
 
     def _getParentPaths(self, term: sdoterm.SdoTerm, cstack: List[str]) -> None:
         cstack.insert(0, term.id)
-        tmpStacks = []
-        tmpStacks.append(cstack)
-        super_ids = list(term.supers.ids)
+        tmpStacks: List[List[str]] = [cstack]
+        super_ids: List[str] = list(term.supers.ids)
 
         if (
             term.termType == sdoterm.SdoTermType.ENUMERATIONVALUE
             and term.enumerationParent
             and term.enumerationParent.id not in super_ids
         ):
+            assert term.enumerationParent.id is not None
             super_ids.append(term.enumerationParent.id)
 
         if super_ids:
-            for i in range(len(super_ids)):
-                if i > 0:
-                    t = cstack[:]
-                    tmpStacks.append(t)
-                    self._pstacks.append(t)
+            i: int
+            for i in range(1, len(super_ids)):
+                t: List[str] = cstack[:]
+                tmpStacks.append(t)
+                self._pstacks.append(t)
 
-            x = 0
-            for parent_id in super_ids:
-                if not (
-                    parent_id.startswith("http:") or parent_id.startswith("https:")
-                ):
-                    sup = self.__class__._getTerm(parent_id)
+            x: int
+            parent_id: str
+            for x, parent_id in enumerate(super_ids):
+                if not (parent_id.startswith("http:") or parent_id.startswith("https:")):
+                    sup: Optional[sdoterm.SdoTerm] = self.__class__._getTerm(parent_id)
                     if sup:
                         self._getParentPaths(sup, tmpStacks[x])
-                    x += 1
 
     @classmethod
-    def getParentPathTo(cls, start_term_id: str, end_term_id: str = None) -> List[List[str]]:
-        # Output paths from start_term to only if end_term in path
+    def getParentPathTo(cls, start_term_id: str, end_term_id: Optional[str] = None) -> List[List[str]]:
         end_term_id = end_term_id or "Thing"
-        start_term = cls.getTerm(start_term_id, expanded=True)
-        outList = []
-        if start_term:
-            for path in start_term.superPaths:
-                if end_term_id in path:
-                    outList.append(list(path))
-        return outList
+        start_term: Optional[sdoterm.SdoTerm] = cls.getTerm(start_term_id, expanded=True)
+        if not start_term:
+            return []
+        return [list(path) for path in start_term.superPaths if end_term_id in path]
 
     def checkForEnumVal(self) -> bool:
         if self.ttype == sdoterm.SdoTermType.ENUMERATION:
             return True
 
-        for super_id in self.getSupers():
-            super_term = self.__class__.getTerm(super_id)
-            if super_term and super_term.checkForEnumVal():
-                return True
-        return False
+        sup_id: str
+        return any(
+            (sup_term := self.__class__.getTerm(sup_id)) and sup_term.checkForEnumVal()
+            for sup_id in self.getSupers()
+        )
 
     @classmethod
     def expandTerms(cls, terms: Iterable[sdoterm.SdoTerm], depth: int = 2) -> List[sdoterm.SdoTerm]:
@@ -811,8 +657,6 @@ class SdoTermSource:
 
         termdesc.markExpanded(depth)
 
-        # TODO: optimise expansion.
-
         termdesc.superPaths = [
             sdoterm.SdoTermSequence.forElements(paths) for paths in termdesc.superPaths
         ]
@@ -822,7 +666,7 @@ class SdoTermSource:
         termdesc.equivalents.setTerms(cls.termsFromIds(termdesc.equivalents.ids))
 
         if termdesc.termType in sdoterm.SdoTerm.TYPE_LIKE_TYPES:
-            if depth > 1:  # Expand the properties but prevent recursion further
+            if depth > 1:
                 termdesc.properties.setTerms(
                     cls.expandTerms(
                         cls.termsFromIds(termdesc.properties.ids), depth=depth - 1
@@ -850,15 +694,15 @@ class SdoTermSource:
             termdesc.rangeIncludes.setTerms(
                 cls.termsFromIds(termdesc.rangeIncludes.ids)
             )
-            termdesc.inverse.setTerm(cls.termFromId(termdesc.inverse.id))
+            if termdesc.inverse.id:
+                termdesc.inverse.setTerm(cls.termFromId(termdesc.inverse.id))
         elif termdesc.termType == sdoterm.SdoTermType.ENUMERATIONVALUE:
-            termdesc.enumerationParent.setTerm(
-                cls.termFromId(termdesc.enumerationParent.id)
-            )
+            if termdesc.enumerationParent.id:
+                termdesc.enumerationParent.setTerm(
+                    cls.termFromId(termdesc.enumerationParent.id)
+                )
 
-        if (
-            depth > 0
-        ):  # Expand the individual termdescs in the terms' termstack but prevent recursion further.
+        if depth > 0:
             termdesc.termStack.setTerms(
                 cls.expandTerms(
                     cls.termsFromIds(termdesc.termStack.ids), depth=depth - 1
@@ -868,60 +712,56 @@ class SdoTermSource:
         return termdesc
 
     @classmethod
-    def termFromId(cls, id: Optional[str] = "") -> Optional[sdoterm.SdoTerm]:
+    def termFromId(cls, id: str = "") -> Optional[sdoterm.SdoTerm]:
         if not id:
             return None
-        ids = cls.termsFromIds([id])
-        if len(ids):
-            return ids[0]
-        return None
+        ids: Sequence[sdoterm.SdoTerm] = cls.termsFromIds([id])
+        return ids[0] if ids else None
 
     @classmethod
     def termsFromIds(
-        cls, ids: typing.Sequence[Union[str, sdoterm.SdoTerm]] = None
+        cls, ids: Optional[Sequence[Union[str, sdoterm.SdoTerm]]] = None
     ) -> Sequence[sdoterm.SdoTerm]:
         """Convert a sequence of term-identities into a sequence of SdoTerms."""
-        ids = ids or []
-        ret = []
-        for tid in ids:
+        id_list: Sequence[Union[str, sdoterm.SdoTerm]] = ids or []
+        ret: List[sdoterm.SdoTerm] = []
+        tid: Union[str, sdoterm.SdoTerm]
+        for tid in id_list:
             if tid:
                 if isinstance(tid, str):
-                    ret.append(cls._getTerm(tid, createReference=True))
+                    term: Optional[sdoterm.SdoTerm] = cls._getTerm(tid, createReference=True)
+                    if term:
+                        ret.append(term)
                 else:
                     ret.append(tid)
         return ret
 
     @classmethod
     def _singleTermFromResult(
-        cls, res: typing.Sequence[rdflib.query.ResultRow], termId: str
+        cls, res: Sequence[rdflib.query.ResultRow], termId: str
     ) -> Optional[sdoterm.SdoTerm]:
         """Return a single term matching `termId` from res."""
-        tmp = _TermAccumulator(termId)
-        for row in res:  # Assumes termdefinition rows are ordered by termId
-            if tmp.id != termId:  # New term definition starts on this row
-                # This should not happen given the way we call this
-                pass
+        tmp: _TermAccumulator = _TermAccumulator(termId)
+        row: rdflib.query.ResultRow
+        for row in res:
             tmp.appendRow(row)
 
         return cls._createTerm(tmp)
 
     @classmethod
     def termsFromResults(
-        cls, res: typing.Sequence[rdflib.query.ResultRow]
+        cls, res: Sequence[rdflib.query.ResultRow]
     ) -> Sequence[sdoterm.SdoTerm]:
         rows_by_term_id: Dict[str, _TermAccumulator] = {}
+        row: rdflib.query.ResultRow
         for row in res:
-            key = str(row.term)
-            if not key in rows_by_term_id:
+            key: str = str(row.term)
+            if key not in rows_by_term_id:
                 rows_by_term_id[key] = _TermAccumulator(key)
             rows_by_term_id[key].appendRow(row)
 
-        return list(
-            filter(
-                None,
-                [cls._createTerm(acc) for acc in rows_by_term_id.values()],
-            )
-        )
+        acc: _TermAccumulator
+        return [t for acc in rows_by_term_id.values() if (t := cls._createTerm(acc))]
 
     @classmethod
     def _createTerm(cls, tmp: _TermAccumulator) -> Optional[sdoterm.SdoTerm]:
@@ -936,76 +776,72 @@ class SdoTermSource:
         elif tmp.types and len(tmp.types) > 1:
             tmp.type = sorted(tmp.types)[0]
 
-        term = cls.TERMS.get(tmp.id, None)
-        if not term:  # Already created this term ?
-            t = cls(tmp.id, ttype=tmp.type, label=tmp.label, layer=tmp.layer)
+        term: Optional[sdoterm.SdoTerm] = cls.TERMS.get(tmp.id)
+        if not term:
+            t: SdoTermSource = cls(tmp.id, ttype=tmp.type, label=tmp.label or "", layer=tmp.layer)
             term = t.termdesc
         return term
 
     @classmethod
     def triples4Term(cls, termId: str) -> Iterable[Tuple[rdflib.term.Node, rdflib.term.Node, rdflib.term.Node]]:
-        term = cls.getTerm(termId)
-        g = cls.SOURCEGRAPH
+        term: Optional[sdoterm.SdoTerm] = cls.getTerm(termId)
+        g: Optional[rdflib.Graph] = cls.SOURCEGRAPH
         if not term or not g:
             return []
-        triples = g.triples((rdflib.URIRef(term.uri), None, None))
-        return triples
+        return g.triples((rdflib.URIRef(term.uri), None, None))
 
     @classmethod
     def getTermAsRdfString(cls, termId: str, output_format: str, full: bool = False) -> str:
         global VOCABURI
-        term = cls.getTerm(termId)
+        term: Optional[sdoterm.SdoTerm] = cls.getTerm(termId)
         if not term or term.termType == sdoterm.SdoTermType.REFERENCE:
             return ""
-        g = rdflib.Graph()
-
-        schema = rdflib.Namespace(VOCABURI)
+        g: rdflib.Graph = rdflib.Graph()
+        assert VOCABURI is not None
         g.bind("schema", VOCABURI)
 
-        if not full:  # Only the term definition
-            triples = cls.triples4Term(term.id)
-            for trip in triples:
+        trip: Tuple[rdflib.term.Node, rdflib.term.Node, rdflib.term.Node]
+        if not full:
+            for trip in cls.triples4Term(term.id):
                 g.add(trip)
-        else:  # full - Include all related terms
-            types = []
-            props = []
-            stack = [term]
+        else:
+            types: List[sdoterm.SdoTerm] = []
+            props: List[sdoterm.SdoTerm] = []
+            stack: List[sdoterm.SdoTerm] = [term]
 
             stack.extend(cls.termsFromIds(term.termStack.ids))
+            t: sdoterm.SdoTerm
             for t in stack:
                 if t.termType == sdoterm.SdoTermType.PROPERTY:
                     props.append(t)
                 else:
                     types.append(t)
                     if t.termType == sdoterm.SdoTermType.ENUMERATIONVALUE:
-                        types.append(cls.termFromId(t.enumerationParent.id))
+                        e_parent: Optional[sdoterm.SdoTerm] = cls.termFromId(t.enumerationParent.id or "")
+                        if e_parent:
+                            types.append(e_parent)
                     elif t == stack[0]:
                         props.extend(cls.termsFromIds(t.allproperties.ids))
 
             for t in sorted(types):
                 if t:
-                    triples = cls.triples4Term(t.id)
-                    for trip in triples:
+                    for trip in cls.triples4Term(t.id):
                         g.add(trip)
 
+            p: sdoterm.SdoTerm
             for p in sorted(props):
                 if p:
-                    triples = cls.triples4Term(p.id)
-                    for trip in triples:
+                    for trip in cls.triples4Term(p.id):
                         g.add(trip)
 
         if output_format == "rdf":
             output_format = "pretty-xml"
 
-        ret = g.serialize(format=output_format, auto_compact=True, sort_keys=True, max_depth=1)
+        ret: Union[str, bytes] = g.serialize(format=output_format, auto_compact=True, sort_keys=True, max_depth=1)
 
         if output_format == "json-ld":
-            # Explicitly sort JSON keys to ensure predictability, as rdflib's
-            # json-ld serializer might not be fully deterministic in all cases.
-            # We avoid to_canonical_graph() here as it is extremely slow when
-            # called thousands of times.
             try:
-                data = json.loads(ret)
+                data: Any = json.loads(ret)
                 return json.dumps(sort_dict(data), indent=2)
             except Exception:
                 pass
@@ -1043,8 +879,8 @@ class SdoTermSource:
             logger=log, message="GetAllTerms", timing=True
         ) as block:
             global DATATYPEURI, ENUMERATIONURI
-            typsel = ""
-            extra = ""
+            typsel: str = ""
+            extra: str = ""
             if ttype == sdoterm.SdoTermType.TYPE:
                 typsel = f"a <{rdflib.RDFS.Class}>;"
             elif ttype == sdoterm.SdoTermType.PROPERTY:
@@ -1060,19 +896,19 @@ class SdoTermSource:
             else:
                 log.debug(f"Invalid type value '{ttype}'")
 
-            laysel = ""
-            fil = ""
-            suppress = ""
+            laysel: str = ""
+            fil: str = ""
+            suppress: str = ""
             if layer:
                 if layer == "core":
                     fil = "FILTER NOT EXISTS { ?term schema:isPartOf ?x. }"
                 else:
-                    laysel = f"schema:isPartOf <{uriFromLayer(layer)}>;"
+                    laysel = f"schema:isPartOf <{uriFromLayer(layer)}>; "
 
             if suppressSourceLinks:
                 suppress = "FILTER NOT EXISTS { ?s dc:source ?term. }"
 
-            query = f"""SELECT DISTINCT ?term ?type ?label ?layer ?sup WHERE {{
+            query: str = f"""SELECT DISTINCT ?term ?type ?label ?layer ?sup WHERE {{
                  ?term a ?type;
                     {typsel}
                     {laysel}
@@ -1094,7 +930,7 @@ class SdoTermSource:
             """
 
             log.debug(f"query {query}")
-            res = cls.query(query)
+            res: Sequence[rdflib.query.ResultRow] = cls.query(query)
             log.debug(f"res {len(res)}")
 
             terms: List[Union[str, sdoterm.SdoTerm]] = []
@@ -1103,18 +939,20 @@ class SdoTermSource:
                     logger=log, message=f"Expanding {len(res)} terms", timing=True
                 ):
                     terms = list(cls.termsFromResults(res))
-
             else:
+                seen: Set[str] = set()
+                row: rdflib.query.ResultRow
                 for row in res:
-                    term_id = uri2id(str(row.term))
-                    if not term_id in terms:
+                    term_id: str = uri2id(str(row.term))
+                    if term_id not in seen:
                         terms.append(term_id)
+                        seen.add(term_id)
             block.message = f"GetAllTerms: {len(terms)} terms, total: {len(cls.TERMS)}"
             return terms
 
     @classmethod
     def getAcknowledgedTerms(cls, ack: str) -> Sequence[sdoterm.SdoTerm]:
-        query = f"""SELECT DISTINCT ?term ?type ?label ?layer ?sup WHERE {{
+        query: str = f"""SELECT DISTINCT ?term ?type ?label ?layer ?sup WHERE {{
              ?term a ?type;
                 schema:contributor <{ack}>;
                 rdfs:label ?label.
@@ -1130,9 +968,8 @@ class SdoTermSource:
             }}
             ORDER BY ?term
             """
-        res = cls.query(query)
-        terms = cls.termsFromResults(res)
-        return terms
+        res: Sequence[rdflib.query.ResultRow] = cls.query(query)
+        return cls.termsFromResults(res)
 
     @classmethod
     def setSourceGraph(cls, g: rdflib.graph.Graph) -> None:
@@ -1142,23 +979,13 @@ class SdoTermSource:
             g.bind("schema", VOCABURI)
         bindNameSpaces(g)
 
-        cls.TERMS = {}  # Clear cache
+        cls.TERMS = {}
         cls.EXPANDEDTERMS = {}
 
     @classmethod
     def loadSourceGraph(
         cls, files: Optional[Union[str, Iterable[str]]] = None, init: bool = False, vocaburi: Optional[str] = None
     ) -> None:
-        """Load the source graph.
-
-        Args:
-          files: this can be either a string or a sequence of strings.
-                 The special file 'default' loads the default set of files.
-                 A single string is interpreted as a file-path to load from.
-                 A sequence of string is interpreted as a set of file-paths to load from.
-          init: if true, reset the `SOURCEGRAPH` class variable.
-          vocaburi: the vocabulary to use.
-        """
         global VOCABURI, DEFTRIPLESFILESGLOB
         if init:
             cls.SOURCEGRAPH = None
@@ -1171,36 +998,33 @@ class SdoTermSource:
         if not files or files == "default":
             if cls.SOURCEGRAPH:
                 if not cls.LOADEDDEFAULT:
-                    raise Exception(
-                        "Sourcegraph already loaded - cannot overwrite with defaults"
-                    )
+                    raise Exception("Sourcegraph already loaded - cannot overwrite with defaults")
                 log.info("Default files already loaded")
                 return
 
-            else:
-                cls.LOADEDDEFAULT = True
-                log.info(
-                    f"SdoTermSource.loadSourceGraph() loading from default files found in globs: {','.join(DEFTRIPLESFILESGLOB)}",
-                )
-                for g in DEFTRIPLESFILESGLOB:
-                    load_files.extend(sorted(glob.glob(g)))
+            cls.LOADEDDEFAULT = True
+            log.info(
+                f"SdoTermSource.loadSourceGraph() loading from default files found in globs: {','.join(DEFTRIPLESFILESGLOB)}",
+            )
+            g: str
+            for g in DEFTRIPLESFILESGLOB:
+                load_files.extend(sorted(glob.glob(g)))
         elif isinstance(files, str):
             cls.LOADEDDEFAULT = False
             log.info(f"SdoTermSource.loadSourceGraph() loading from file: {files}")
             load_files = [files]
         else:
             cls.LOADEDDEFAULT = False
-            log.info(
-                f"SdoTermSource.loadSourceGraph() loading from {len(files)} files"
-            )
+            log.info(f"SdoTermSource.loadSourceGraph() loading from {len(files)} files")
             load_files = list(files)
 
-        if not len(load_files):
+        if not load_files:
             raise Exception("No triples file(s) to load")
 
         cls.setSourceGraph(rdflib.Graph())
-
+        file_path: str
         for file_path in load_files:
+            assert cls.SOURCEGRAPH is not None
             cls.SOURCEGRAPH += _loadOneSourceGraph(file_path)
         log.info(
             f"Done: Loaded {len(cls.sourceGraph())} triples - {len(cls.getAllTerms())} terms",
@@ -1208,7 +1032,7 @@ class SdoTermSource:
 
     @classmethod
     def sourceGraph(cls) -> rdflib.Graph:
-        if cls.SOURCEGRAPH == None:
+        if cls.SOURCEGRAPH is None:
             cls.loadSourceGraph()
         assert cls.SOURCEGRAPH is not None
         return cls.SOURCEGRAPH
@@ -1230,88 +1054,39 @@ class SdoTermSource:
         return VOCABURI
 
     @classmethod
-    def query(cls, query_string: str) -> typing.Sequence[rdflib.query.ResultRow]:
-        graph = cls.sourceGraph()
+    def query(cls, query_string: str) -> Sequence[rdflib.query.ResultRow]:
+        graph: rdflib.Graph = cls.sourceGraph()
         with cls.RDFLIBLOCK:
-            result = tuple(graph.query(query_string))
+            result: Sequence[rdflib.query.ResultRow] = tuple(graph.query(query_string))
         return result
 
     @classmethod
     def termCounts(cls) -> Dict[Union[sdoterm.SdoTermType, str], int]:
         global VOCABURI
         if not cls.TERMCOUNTS:
-            count_query = f"""SELECT (COUNT(DISTINCT ?s) as ?count) WHERE {{
-                ?s a ?type .
-                FILTER (strStarts(str(?s),"{VOCABURI}"))
-            }} """
-            res = cls.query(count_query)
-            allterms = int(res[0][0])
+            def run_count_query(q: str) -> int:
+                res: Sequence[rdflib.query.ResultRow] = cls.query(q)
+                return int(res[0][0])
 
-            count_query = f"""SELECT (COUNT(DISTINCT ?s) as ?count) WHERE {{
-                ?s a rdfs:Class .
-                FILTER (strStarts(str(?s),"{VOCABURI}"))
-            }} """
-            res = cls.query(count_query)
-            classes = int(res[0][0])
+            allterms: int = run_count_query(f'SELECT (COUNT(DISTINCT ?s) as ?count) WHERE {{ ?s a ?type . FILTER (strStarts(str(?s),"{VOCABURI}")) }}')
+            classes: int = run_count_query(f'SELECT (COUNT(DISTINCT ?s) as ?count) WHERE {{ ?s a rdfs:Class . FILTER (strStarts(str(?s),"{VOCABURI}")) }}')
+            properties: int = run_count_query(f'SELECT (COUNT(DISTINCT ?s) as ?count) WHERE {{ ?s a rdf:Property . FILTER (strStarts(str(?s),"{VOCABURI}")) }}')
+            enums: int = run_count_query(f'SELECT (COUNT(DISTINCT ?s) as ?count) WHERE {{ ?s rdfs:subClassOf* schema:Enumeration . FILTER (strStarts(str(?s),"{VOCABURI}")) }}')
+            enumvals: int = run_count_query(f'SELECT (COUNT(DISTINCT ?s) as ?count) WHERE {{ ?s a ?type . ?type rdfs:subClassOf* schema:Enumeration . FILTER (strStarts(str(?s),"{VOCABURI}")) }}')
+            datatypes: int = run_count_query(f'SELECT (COUNT(DISTINCT ?s) as ?count) WHERE {{ {{ ?s a schema:DataType . }}UNION{{ ?s rdf:type* schema:DataType . }}UNION{{ ?s rdfs:subClassOf* ?x . ?x a schema:DataType . }} FILTER (strStarts(str(?s),"{VOCABURI}")) }}')
+            datatypeclasses: int = run_count_query(f'SELECT (COUNT(DISTINCT ?s) as ?count) WHERE {{ ?s rdfs:subClassOf* ?x . ?x a schema:DataType . FILTER (strStarts(str(?s),"{VOCABURI}")) }}')
 
-            count_query = f"""SELECT (COUNT(DISTINCT ?s) as ?count) WHERE {{
-                ?s a rdf:Property .
-                FILTER (strStarts(str(?s),"{VOCABURI}"))
-            }} """
-            res = cls.query(count_query)
-            properties = int(res[0][0])
+            types: int = classes - 1 - enums - datatypeclasses
+            datatypes -= 1
 
-            count_query = f"""SELECT (COUNT(DISTINCT ?s) as ?count) WHERE {{
-                ?s rdfs:subClassOf* schema:Enumeration .
-                FILTER (strStarts(str(?s),"{VOCABURI}"))
-            }} """
-            res = cls.query(count_query)
-            enums = int(res[0][0])
-
-            count_query = f"""SELECT (COUNT(DISTINCT ?s) as ?count) WHERE {{
-                ?s a ?type .
-                ?type rdfs:subClassOf* schema:Enumeration .
-                FILTER (strStarts(str(?s),"{VOCABURI}"))
-            }} """
-            res = cls.query(count_query)
-            enumvals = int(res[0][0])
-
-            count_query = f"""SELECT (COUNT(DISTINCT ?s) as ?count) WHERE {{
-                {{
-                    ?s a schema:DataType .
-                }}UNION{{
-                    ?s rdf:type* schema:DataType .
-                }}UNION{{
-                    ?s rdfs:subClassOf* ?x .
-                    ?x a schema:DataType .
-                }}
-                FILTER (strStarts(str(?s),"{VOCABURI}"))
-           }} """
-            res = cls.query(count_query)
-            datatypes = int(res[0][0])
-
-            count_query = f"""SELECT (COUNT(DISTINCT ?s) as ?count) WHERE {{
-                ?s rdfs:subClassOf* ?x .
-                ?x a schema:DataType .
-                FILTER (strStarts(str(?s),"{VOCABURI}"))
-           }} """
-            res = cls.query(count_query)
-            datatypeclasses = int(res[0][0])
-
-            types = classes
-            types -= 1  # DataType not counted
-            types -= enums
-            types -= datatypeclasses
-            datatypes -= 1  # Datatype not counted
-
-            counts: Dict[Union[sdoterm.SdoTermType, str], int] = {}
-            counts[sdoterm.SdoTermType.TYPE] = types
-            counts[sdoterm.SdoTermType.PROPERTY] = properties
-            counts[sdoterm.SdoTermType.DATATYPE] = datatypes
-            counts[sdoterm.SdoTermType.ENUMERATION] = enums
-            counts[sdoterm.SdoTermType.ENUMERATIONVALUE] = enumvals
-            counts["All"] = types + properties + datatypes + enums + enumvals
-            cls.TERMCOUNTS = counts
+            cls.TERMCOUNTS = {
+                sdoterm.SdoTermType.TYPE: types,
+                sdoterm.SdoTermType.PROPERTY: properties,
+                sdoterm.SdoTermType.DATATYPE: datatypes,
+                sdoterm.SdoTermType.ENUMERATION: enums,
+                sdoterm.SdoTermType.ENUMERATIONVALUE: enumvals,
+                "All": types + properties + datatypes + enums + enumvals
+            }
         return cls.TERMCOUNTS
 
     @classmethod
@@ -1350,46 +1125,35 @@ class SdoTermSource:
             return None
         assert isinstance(termId, str), termId
         termId = termId.strip()
-        fullId = toFullId(termId)
-        term = cls.TERMS.get(fullId, None)
+        fullId: str = toFullId(termId)
+        term: Optional[sdoterm.SdoTerm] = cls.TERMS.get(fullId)
 
         if term and refresh:
             del cls.TERMS[fullId]
             log.info(f"Term '{termId}' found and removed")
             term = None
 
-        query = f"""
-        SELECT ?term ?type ?label ?layer ?sup WHERE {{
-             {uriWrap(fullId)} a ?type;
-                rdfs:label ?label.
-            OPTIONAL {{
-                {uriWrap(fullId)} schema:isPartOf ?layer.
-            }}
-            OPTIONAL {{
-                {uriWrap(fullId)} rdfs:subClassOf ?sup.
-            }}
-            OPTIONAL {{
-                {uriWrap(fullId)} rdfs:subPropertyOf ?sup.
-            }}
-
-        }}"""
-
         if not term:
-            res = cls.query(query)
-            if len(res):
+            query: str = f"""
+            SELECT ?term ?type ?label ?layer ?sup WHERE {{
+                 {uriWrap(fullId)} a ?type;
+                    rdfs:label ?label.
+                OPTIONAL {{ {uriWrap(fullId)} schema:isPartOf ?layer. }}
+                OPTIONAL {{ {uriWrap(fullId)} rdfs:subClassOf ?sup. }}
+                OPTIONAL {{ {uriWrap(fullId)} rdfs:subPropertyOf ?sup. }}
+            }}"""
+            res: Sequence[rdflib.query.ResultRow] = cls.query(query)
+            if res:
                 term = cls._singleTermFromResult(res, termId=fullId)
             elif createReference:
-                # Create a new TermSource
                 term = cls(fullId).getTermdesc()
             else:
                 log.warning(f"No definition of term {fullId}")
 
         if term and expanded and not term.expanded():
-            exterm = cls.EXPANDEDTERMS.get(fullId, None)
-            if not exterm:
-                exterm = cls.expandTerm(term)
-                cls.EXPANDEDTERMS[fullId] = exterm
-            term = exterm
+            if fullId not in cls.EXPANDEDTERMS:
+                cls.EXPANDEDTERMS[fullId] = cls.expandTerm(term)
+            term = cls.EXPANDEDTERMS[fullId]
 
         return term
 
@@ -1397,17 +1161,19 @@ class SdoTermSource:
 def toFullId(termId: str) -> str:
     global VOCABURI
     assert VOCABURI
-    if not ":" in termId:  # Includes full path or namespaces
+    if ":" not in termId:
         return f"{VOCABURI}{termId}"
 
     if termId.startswith("http"):
         return termId
-    prefix, id_component = termId.split(":")
+    prefix: str
+    id_component: str
+    prefix, id_component = termId.split(":", 1)
     return f"{uriForPrefix(prefix)}{id_component}"
 
 
 def uriWrap(identity_str: str) -> str:
-    if identity_str.startswith("http://") or identity_str.startswith("https://"):
+    if identity_str.startswith(("http://", "https://")):
         return f"<{identity_str}>"
     return identity_str
 
@@ -1416,32 +1182,30 @@ LAYERPATTERN: Optional[str] = None
 
 
 def layerFromUri(uri: str) -> Optional[str]:
-    global VOCABURI
-    global LAYERPATTERN
+    global VOCABURI, LAYERPATTERN
     assert VOCABURI
-    if uri:
-        if not LAYERPATTERN:
-            voc = VOCABURI
-            if voc.endswith("/") or voc.endswith("#"):
-                voc = voc[: len(voc) - 1]
-            prto, root = getProtoAndRoot(voc)
-            LAYERPATTERN = rf"^{prto}([\w]*)\.{root}"
+    if not uri:
+        return None
+    if not LAYERPATTERN:
+        voc: str = VOCABURI.rstrip("/#")
+        prto: Optional[str]
+        root: Optional[str]
+        prto, root = getProtoAndRoot(voc)
+        LAYERPATTERN = rf"^{prto}([\w]*)\.{root}"
 
-        if LAYERPATTERN:
-            m = re.search(LAYERPATTERN, str(uri))
-            if m:
-                return m.group(1)
+    if m := re.search(LAYERPATTERN, str(uri)):
+        return m.group(1)
     return None
 
 
 def uriFromLayer(layer: Optional[str] = None) -> str:
     global VOCABURI
     assert VOCABURI is not None
-    voc = VOCABURI
-    if voc.endswith("/") or voc.endswith("#"):
-        voc = voc[: len(voc) - 1]
+    voc: str = VOCABURI.rstrip("/#")
     if not layer:
         return voc
+    prto: Optional[str]
+    root: Optional[str]
     prto, root = getProtoAndRoot(voc)
     return f"{prto}{layer}.{root}"
 
@@ -1450,11 +1214,9 @@ ProtoAndRoot = collections.namedtuple("ProtoAndRoot", ["proto", "root"])
 
 
 def getProtoAndRoot(uri: str) -> ProtoAndRoot:
-    m = re.search(r"^(http[s]?:\/\/)(.*)", uri)
+    m: Optional[re.Match] = re.search(r"^(http[s]?:\/\/)(.*)", uri)
     if m:
-        prto = m.group(1)
-        root = m.group(2)
-        return ProtoAndRoot(prto, root)
+        return ProtoAndRoot(m.group(1), m.group(2))
     return ProtoAndRoot(None, None)
 
 
@@ -1466,18 +1228,22 @@ def uri2id(uri: str) -> str:
     return uri
 
 
-def prefixFromUri(uri: str) -> Optional[rdflib.term.URIRef]:
+def prefixFromUri(uri: str) -> Optional[str]:
     if SdoTermSource.SOURCEGRAPH is None:
         return None
+    pref: rdflib.term.Node
+    pth: rdflib.term.Node
     for pref, pth in SdoTermSource.SOURCEGRAPH.namespaces():
         if uri.startswith(str(pth)):
-            return pref
+            return str(pref)
     return None
 
 
 def uriForPrefix(pre: str) -> Optional[rdflib.term.URIRef]:
     if SdoTermSource.SOURCEGRAPH is None:
         return None
+    pref: rdflib.term.Node
+    pth: rdflib.term.URIRef
     for pref, pth in SdoTermSource.SOURCEGRAPH.namespaces():
         if pre == str(pref):
             return pth
@@ -1486,10 +1252,10 @@ def uriForPrefix(pre: str) -> Optional[rdflib.term.URIRef]:
 
 def prefixedIdFromUri(uri: str) -> str:
     """Converts a URI into a string of the form namespace:term."""
-    prefix = prefixFromUri(uri)
+    prefix: Optional[str] = prefixFromUri(uri)
     if prefix:
-        base = os.path.basename(uri)
+        base: str = Path(uri).name
         if "#" in base:
-            base = base.split("#")[1]
+            base = base.split("#", 1)[1]
         return f"{prefix}:{base}"
     return uri

--- a/software/SchemaTerms/sdotermsource.py
+++ b/software/SchemaTerms/sdotermsource.py
@@ -218,13 +218,13 @@ def _loadOneSourceGraph(file_path: str) -> rdflib.Graph:
     elif extension == ".ttl":
         file_format = "turtle"
     else:
-        raise NotImplementedError("Unsupported file format: %s" % extension)
+        raise NotImplementedError(f"Unsupported file format: {extension}")
     try:
         graph = rdflib.Graph()
         graph.parse(source=file_path, format=file_format)
         return graph
     except Exception as e:
-        message = "Error parsing source file '%s': %s" % (file_path, e)
+        message = f"Error parsing source file '{file_path}': {e}"
         log.warning(message)
         raise IOError(message)
 
@@ -357,7 +357,7 @@ class SdoTermSource:
         cls.TERMS[uri] = self.termdesc
 
     def __str__(self) -> str:
-        return ("<SdoTermSource: %s '%s'>") % (self.ttype, self.id)
+        return f"<SdoTermSource: {self.ttype} '{self.id}'>"
 
     @property
     def id(self) -> str:
@@ -435,8 +435,7 @@ class SdoTermSource:
 
             if len(tmp) > 1:
                 log.debug(
-                    "Warning '%s' supersededBy more than 1 term (%d)"
-                    % (self.id, len(tmp))
+                    f"Warning '{self.id}' supersededBy more than 1 term ({len(tmp)})"
                 )
             if len(tmp):
                 self.supersededBy = tmp[0]
@@ -1047,19 +1046,19 @@ class SdoTermSource:
             typsel = ""
             extra = ""
             if ttype == sdoterm.SdoTermType.TYPE:
-                typsel = "a <%s>;" % rdflib.RDFS.Class
+                typsel = f"a <{rdflib.RDFS.Class}>;"
             elif ttype == sdoterm.SdoTermType.PROPERTY:
-                typsel = "a <%s>;" % rdflib.RDF.Property
+                typsel = f"a <{rdflib.RDF.Property}>;"
             elif ttype == sdoterm.SdoTermType.DATATYPE:
-                typsel = "a <%s>;" % DATATYPEURI
+                typsel = f"a <{DATATYPEURI}>;"
             elif ttype == sdoterm.SdoTermType.ENUMERATION:
-                typsel = "rdfs:subClassOf* <%s>;" % ENUMERATIONURI
+                typsel = f"rdfs:subClassOf* <{ENUMERATIONURI}>;"
             elif ttype == sdoterm.SdoTermType.ENUMERATIONVALUE:
-                extra = "?type rdfs:subClassOf*  <%s>." % ENUMERATIONURI
+                extra = f"?type rdfs:subClassOf*  <{ENUMERATIONURI}>."
             elif not ttype:
                 typsel = ""
             else:
-                log.debug("Invalid type value '%s'" % ttype)
+                log.debug(f"Invalid type value '{ttype}'")
 
             laysel = ""
             fil = ""
@@ -1068,35 +1067,35 @@ class SdoTermSource:
                 if layer == "core":
                     fil = "FILTER NOT EXISTS { ?term schema:isPartOf ?x. }"
                 else:
-                    laysel = "schema:isPartOf <%s>;" % uriFromLayer(layer)
+                    laysel = f"schema:isPartOf <{uriFromLayer(layer)}>;"
 
             if suppressSourceLinks:
                 suppress = "FILTER NOT EXISTS { ?s dc:source ?term. }"
 
-            query = """SELECT DISTINCT ?term ?type ?label ?layer ?sup WHERE {
+            query = f"""SELECT DISTINCT ?term ?type ?label ?layer ?sup WHERE {{
                  ?term a ?type;
-                    %s
-                    %s
+                    {typsel}
+                    {laysel}
                     rdfs:label ?label.
-                %s
-                OPTIONAL {
+                {extra}
+                OPTIONAL {{
                     ?term schema:isPartOf ?layer.
-                }
-                OPTIONAL {
+                }}
+                OPTIONAL {{
                     ?term rdfs:subClassOf ?sup.
-                }
-                OPTIONAL {
+                }}
+                OPTIONAL {{
                     ?term rdfs:subPropertyOf ?sup.
-                }
-                %s
-                %s
-            }
+                }}
+                {fil}
+                {suppress}
+            }}
             ORDER BY ?term
-            """ % (typsel, laysel, extra, fil, suppress)
+            """
 
-            log.debug("query %s", query)
+            log.debug(f"query {query}")
             res = cls.query(query)
-            log.debug("res %d", len(res))
+            log.debug(f"res {len(res)}")
 
             terms: List[Union[str, sdoterm.SdoTerm]] = []
             if expanded:
@@ -1115,25 +1114,22 @@ class SdoTermSource:
 
     @classmethod
     def getAcknowledgedTerms(cls, ack: str) -> Sequence[sdoterm.SdoTerm]:
-        query = (
-            """SELECT DISTINCT ?term ?type ?label ?layer ?sup WHERE {
+        query = f"""SELECT DISTINCT ?term ?type ?label ?layer ?sup WHERE {{
              ?term a ?type;
-                schema:contributor <%s>;
+                schema:contributor <{ack}>;
                 rdfs:label ?label.
-                OPTIONAL {
+                OPTIONAL {{
                     ?term schema:isPartOf ?layer.
-                }
-                OPTIONAL {
+                }}
+                OPTIONAL {{
                     ?term rdfs:subClassOf ?sup.
-                }
-                OPTIONAL {
+                }}
+                OPTIONAL {{
                     ?term rdfs:subPropertyOf ?sup.
-                }
-            }
+                }}
+            }}
             ORDER BY ?term
             """
-            % ack
-        )
         res = cls.query(query)
         terms = cls.termsFromResults(res)
         return terms
@@ -1184,19 +1180,18 @@ class SdoTermSource:
             else:
                 cls.LOADEDDEFAULT = True
                 log.info(
-                    "SdoTermSource.loadSourceGraph() loading from default files found in globs: %s",
-                    ",".join(DEFTRIPLESFILESGLOB),
+                    f"SdoTermSource.loadSourceGraph() loading from default files found in globs: {','.join(DEFTRIPLESFILESGLOB)}",
                 )
                 for g in DEFTRIPLESFILESGLOB:
                     load_files.extend(sorted(glob.glob(g)))
         elif isinstance(files, str):
             cls.LOADEDDEFAULT = False
-            log.info("SdoTermSource.loadSourceGraph() loading from file: %s", files)
+            log.info(f"SdoTermSource.loadSourceGraph() loading from file: {files}")
             load_files = [files]
         else:
             cls.LOADEDDEFAULT = False
             log.info(
-                "SdoTermSource.loadSourceGraph() loading from %d files", len(files)
+                f"SdoTermSource.loadSourceGraph() loading from {len(files)} files"
             )
             load_files = list(files)
 
@@ -1208,9 +1203,7 @@ class SdoTermSource:
         for file_path in load_files:
             cls.SOURCEGRAPH += _loadOneSourceGraph(file_path)
         log.info(
-            "Done: Loaded %s triples - %s terms",
-            len(cls.sourceGraph()),
-            len(cls.getAllTerms()),
+            f"Done: Loaded {len(cls.sourceGraph())} triples - {len(cls.getAllTerms())} terms",
         )
 
     @classmethod
@@ -1224,9 +1217,9 @@ class SdoTermSource:
     def setVocabUri(uri: Optional[str] = None) -> None:
         global VOCABURI, DATATYPEURI, ENUMERATIONURI, THINGURI
         VOCABURI = uri or DEFVOCABURI
-        DATATYPEURI = rdflib.URIRef(VOCABURI + "DataType")
-        ENUMERATIONURI = rdflib.URIRef(VOCABURI + "Enumeration")
-        THINGURI = rdflib.URIRef(VOCABURI + "Thing")
+        DATATYPEURI = rdflib.URIRef(f"{VOCABURI}DataType")
+        ENUMERATIONURI = rdflib.URIRef(f"{VOCABURI}Enumeration")
+        THINGURI = rdflib.URIRef(f"{VOCABURI}Thing")
 
     @classmethod
     def vocabUri(cls) -> str:
@@ -1247,82 +1240,61 @@ class SdoTermSource:
     def termCounts(cls) -> Dict[Union[sdoterm.SdoTermType, str], int]:
         global VOCABURI
         if not cls.TERMCOUNTS:
-            count_query = (
-                """SELECT (COUNT(DISTINCT ?s) as ?count) WHERE {
+            count_query = f"""SELECT (COUNT(DISTINCT ?s) as ?count) WHERE {{
                 ?s a ?type .
-                FILTER (strStarts(str(?s),"%s"))
-            } """
-                % VOCABURI
-            )
+                FILTER (strStarts(str(?s),"{VOCABURI}"))
+            }} """
             res = cls.query(count_query)
             allterms = int(res[0][0])
 
-            count_query = (
-                """SELECT (COUNT(DISTINCT ?s) as ?count) WHERE {
+            count_query = f"""SELECT (COUNT(DISTINCT ?s) as ?count) WHERE {{
                 ?s a rdfs:Class .
-                FILTER (strStarts(str(?s),"%s"))
-            } """
-                % VOCABURI
-            )
+                FILTER (strStarts(str(?s),"{VOCABURI}"))
+            }} """
             res = cls.query(count_query)
             classes = int(res[0][0])
 
-            count_query = (
-                """SELECT (COUNT(DISTINCT ?s) as ?count) WHERE {
+            count_query = f"""SELECT (COUNT(DISTINCT ?s) as ?count) WHERE {{
                 ?s a rdf:Property .
-                FILTER (strStarts(str(?s),"%s"))
-            } """
-                % VOCABURI
-            )
+                FILTER (strStarts(str(?s),"{VOCABURI}"))
+            }} """
             res = cls.query(count_query)
             properties = int(res[0][0])
 
-            count_query = (
-                """SELECT (COUNT(DISTINCT ?s) as ?count) WHERE {
+            count_query = f"""SELECT (COUNT(DISTINCT ?s) as ?count) WHERE {{
                 ?s rdfs:subClassOf* schema:Enumeration .
-                FILTER (strStarts(str(?s),"%s"))
-            } """
-                % VOCABURI
-            )
+                FILTER (strStarts(str(?s),"{VOCABURI}"))
+            }} """
             res = cls.query(count_query)
             enums = int(res[0][0])
 
-            count_query = (
-                """SELECT (COUNT(DISTINCT ?s) as ?count) WHERE {
+            count_query = f"""SELECT (COUNT(DISTINCT ?s) as ?count) WHERE {{
                 ?s a ?type .
                 ?type rdfs:subClassOf* schema:Enumeration .
-                FILTER (strStarts(str(?s),"%s"))
-            } """
-                % VOCABURI
-            )
+                FILTER (strStarts(str(?s),"{VOCABURI}"))
+            }} """
             res = cls.query(count_query)
             enumvals = int(res[0][0])
 
-            count_query = (
-                """SELECT (COUNT(DISTINCT ?s) as ?count) WHERE {
-                {
+            count_query = f"""SELECT (COUNT(DISTINCT ?s) as ?count) WHERE {{
+                {{
                     ?s a schema:DataType .
-                }UNION{
+                }}UNION{{
                     ?s rdf:type* schema:DataType .
-                }UNION{
+                }}UNION{{
                     ?s rdfs:subClassOf* ?x .
                     ?x a schema:DataType .
-                }
-                FILTER (strStarts(str(?s),"%s"))
-           } """
-                % VOCABURI
-            )
+                }}
+                FILTER (strStarts(str(?s),"{VOCABURI}"))
+           }} """
             res = cls.query(count_query)
             datatypes = int(res[0][0])
 
-            count_query = (
-                """SELECT (COUNT(DISTINCT ?s) as ?count) WHERE {
+            count_query = f"""SELECT (COUNT(DISTINCT ?s) as ?count) WHERE {{
                 ?s rdfs:subClassOf* ?x .
                 ?x a schema:DataType .
-                FILTER (strStarts(str(?s),"%s"))
-           } """
-                % VOCABURI
-            )
+                FILTER (strStarts(str(?s),"{VOCABURI}"))
+           }} """
             res = cls.query(count_query)
             datatypeclasses = int(res[0][0])
 
@@ -1383,24 +1355,24 @@ class SdoTermSource:
 
         if term and refresh:
             del cls.TERMS[fullId]
-            log.info("Term '%s' found and removed" % termId)
+            log.info(f"Term '{termId}' found and removed")
             term = None
 
-        query = """
-        SELECT ?term ?type ?label ?layer ?sup WHERE {
-             %s a ?type;
+        query = f"""
+        SELECT ?term ?type ?label ?layer ?sup WHERE {{
+             {uriWrap(fullId)} a ?type;
                 rdfs:label ?label.
-            OPTIONAL {
-                %s schema:isPartOf ?layer.
-            }
-            OPTIONAL {
-                %s rdfs:subClassOf ?sup.
-            }
-            OPTIONAL {
-                %s rdfs:subPropertyOf ?sup.
-            }
+            OPTIONAL {{
+                {uriWrap(fullId)} schema:isPartOf ?layer.
+            }}
+            OPTIONAL {{
+                {uriWrap(fullId)} rdfs:subClassOf ?sup.
+            }}
+            OPTIONAL {{
+                {uriWrap(fullId)} rdfs:subPropertyOf ?sup.
+            }}
 
-        }""" % (uriWrap(fullId), uriWrap(fullId), uriWrap(fullId), uriWrap(fullId))
+        }}"""
 
         if not term:
             res = cls.query(query)
@@ -1410,7 +1382,7 @@ class SdoTermSource:
                 # Create a new TermSource
                 term = cls(fullId).getTermdesc()
             else:
-                log.warning("No definition of term %s" % fullId)
+                log.warning(f"No definition of term {fullId}")
 
         if term and expanded and not term.expanded():
             exterm = cls.EXPANDEDTERMS.get(fullId, None)
@@ -1426,17 +1398,17 @@ def toFullId(termId: str) -> str:
     global VOCABURI
     assert VOCABURI
     if not ":" in termId:  # Includes full path or namespaces
-        return VOCABURI + termId
+        return f"{VOCABURI}{termId}"
 
     if termId.startswith("http"):
         return termId
     prefix, id_component = termId.split(":")
-    return "%s%s" % (uriForPrefix(prefix), id_component)
+    return f"{uriForPrefix(prefix)}{id_component}"
 
 
 def uriWrap(identity_str: str) -> str:
     if identity_str.startswith("http://") or identity_str.startswith("https://"):
-        return "<%s>" % identity_str
+        return f"<{identity_str}>"
     return identity_str
 
 
@@ -1453,7 +1425,7 @@ def layerFromUri(uri: str) -> Optional[str]:
             if voc.endswith("/") or voc.endswith("#"):
                 voc = voc[: len(voc) - 1]
             prto, root = getProtoAndRoot(voc)
-            LAYERPATTERN = r"^%s([\w]*)\.%s" % (prto, root)
+            LAYERPATTERN = rf"^{prto}([\w]*)\.{root}"
 
         if LAYERPATTERN:
             m = re.search(LAYERPATTERN, str(uri))
@@ -1471,7 +1443,7 @@ def uriFromLayer(layer: Optional[str] = None) -> str:
     if not layer:
         return voc
     prto, root = getProtoAndRoot(voc)
-    return "%s%s.%s" % (prto, layer, root)
+    return f"{prto}{layer}.{root}"
 
 
 ProtoAndRoot = collections.namedtuple("ProtoAndRoot", ["proto", "root"])
@@ -1519,5 +1491,5 @@ def prefixedIdFromUri(uri: str) -> str:
         base = os.path.basename(uri)
         if "#" in base:
             base = base.split("#")[1]
-        return "%s:%s" % (prefix, base)
+        return f"{prefix}:{base}"
     return uri

--- a/software/SchemaTerms/sdotermsource.py
+++ b/software/SchemaTerms/sdotermsource.py
@@ -14,7 +14,7 @@ import re
 import sys
 import threading
 import typing
-from typing import Any
+from typing import Any, Dict, List, Optional, Tuple, Union, Iterable, Sequence, Set
 
 
 # Import schema.org libraries
@@ -29,20 +29,20 @@ import software.SchemaTerms.localmarkdown as localmarkdown
 import software.util.pretty_logger as pretty_logger
 from software.util.sort_dict import sort_dict
 
-log = logging.getLogger(__name__)
+log: logging.Logger = logging.getLogger(__name__)
 
-DEFVOCABURI = "https://schema.org/"
-VOCABURI = None
-DATATYPEURI = None
-ENUMERATIONURI = None
-THINGURI = None
+DEFVOCABURI: str = "https://schema.org/"
+VOCABURI: Optional[str] = None
+DATATYPEURI: Optional[rdflib.URIRef] = None
+ENUMERATIONURI: Optional[rdflib.URIRef] = None
+THINGURI: Optional[rdflib.URIRef] = None
 
-CORE = "core"
-DEFTRIPLESFILESGLOB = ("data/*.ttl", "data/ext/*/*.ttl")
-LOADEDDEFAULT = False
+CORE: str = "core"
+DEFTRIPLESFILESGLOB: Tuple[str, str] = ("data/*.ttl", "data/ext/*/*.ttl")
+LOADEDDEFAULT: bool = False
 
 
-def bindNameSpaces(graph):
+def bindNameSpaces(graph: rdflib.Graph) -> None:
     # --- Standard / W3C / Dublin Core ---
     graph.bind("dc", "http://purl.org/dc/elements/1.1/")
     graph.bind("dcat", "http://www.w3.org/ns/dcat#")
@@ -194,20 +194,20 @@ def bindNameSpaces(graph):
 class _TermAccumulator:
     """Temporary holder to accumulate term information."""
 
-    def __init__(self, term_id):
-        self.id = term_id
-        self.types = []
-        self.sups = []
-        self.label = None
-        self.layer = None
-        self.type = ""
+    def __init__(self, term_id: str) -> None:
+        self.id: str = term_id
+        self.types: List[rdflib.URIRef] = []
+        self.sups: List[rdflib.URIRef] = []
+        self.label: Optional[str] = None
+        self.layer: Optional[str] = None
+        self.type: Optional[rdflib.URIRef] = None
 
-    def appendRow(self, row):
+    def appendRow(self, row: rdflib.query.ResultRow) -> None:
         self.types.append(row.type)
         self.sups.append(row.sup)
         self.type = row.type
-        self.label = row.label
-        self.layer = layerFromUri(row.layer)
+        self.label = str(row.label)
+        self.layer = layerFromUri(str(row.layer))
 
 
 def _loadOneSourceGraph(file_path: str) -> rdflib.Graph:
@@ -238,48 +238,50 @@ class SdoTermSource:
 
     """
 
-    TYPE = "Class"
-    TERMCOUNTS = None
+    TYPE: str = "Class"
+    TERMCOUNTS: Optional[Dict[Union[sdoterm.SdoTermType, str], int]] = None
 
-    SOURCEGRAPH = None
-    MARKDOWNPROCESS = True
-    EXPANDEDTERMS = {}
-    TERMS = {}
+    SOURCEGRAPH: Optional[rdflib.Graph] = None
+    MARKDOWNPROCESS: bool = True
+    EXPANDEDTERMS: Dict[str, sdoterm.SdoTerm] = {}
+    TERMS: Dict[str, sdoterm.SdoTerm] = {}
 
-    TERMSLOCK = threading.Lock()
-    RDFLIBLOCK = threading.Lock()
+    TERMSLOCK: threading.Lock = threading.Lock()
+    RDFLIBLOCK: threading.Lock = threading.Lock()
+    LOADEDDEFAULT: bool = False
 
-    def __init__(self, uri: str, ttype=None, label: str = "", layer=None):
-        term_id = uri2id(uri)
-        self.layer = CORE
+    def __init__(self, uri: str, ttype: Optional[Union[rdflib.URIRef, str]] = None, label: str = "", layer: Optional[str] = None) -> None:
+        term_id: str = uri2id(uri)
+        self.layer: str = CORE
         if layer:
             self.layer = layer
-        self.termdesc = None
+        self.termdesc: Optional[sdoterm.SdoTerm] = None
 
-        self.parent = None
-        self.checkedDataTypeParents = False
-        self.supersededBy = None
-        self.supersedes = None
-        self.supers = None
-        self.termStack = None
-        self.subs = None
-        self.members = None
-        self.props = None
-        self.propUsedOn = None
-        self.ranges = None
-        self.domains = None
-        self.targetOf = None
-        self.equivalents = None
-        self.gotinverseOf = False
-        self.inverseOf = None
-        self.comments = None
-        self.comment = None
-        self.srcacks = None
-        self.sources = None
-        self.acks = None
-        self.examples = None
+        self.parent: Optional[sdoterm.SdoTerm] = None
+        self.checkedDataTypeParents: bool = False
+        self.supersededBy: Optional[str] = None
+        self.supersedes: Optional[List[str]] = None
+        self.supers: Optional[List[str]] = None
+        self.termStack: Optional[List[sdoterm.SdoTerm]] = None
+        self.subs: Optional[List[str]] = None
+        self.members: Optional[List[str]] = None
+        self.props: Optional[List[str]] = None
+        self.propUsedOn: Optional[List[str]] = None
+        self.ranges: Optional[List[str]] = None
+        self.domains: Optional[List[str]] = None
+        self.targetOf: Optional[List[str]] = None
+        self.equivalents: Optional[List[str]] = None
+        self.gotinverseOf: bool = False
+        self.inverseOf: Optional[str] = None
+        self.comments: Optional[Sequence[str]] = None
+        self.comment: Optional[str] = None
+        self.srcacks: Optional[List[Any]] = None
+        self.sources: Optional[List[str]] = None
+        self.acks: Optional[Sequence[sdocollaborators.collaborator]] = None
+        self.examples: Optional[List[Any]] = None
         global DATATYPEURI, ENUMERATIONURI
         cls = self.__class__
+        self.ttype: sdoterm.SdoTermType
         if ttype == rdflib.RDFS.Class:
             self.ttype = sdoterm.SdoTermType.TYPE
             if uri == str(DATATYPEURI):  # The base DataType is defined as a Class
@@ -302,9 +304,9 @@ class SdoTermSource:
         else:
             self.parent = cls._getTerm(str(ttype), createReference=True)
 
-            if self.parent.termType == sdoterm.SdoTermType.ENUMERATION:
+            if self.parent and self.parent.termType == sdoterm.SdoTermType.ENUMERATION:
                 self.ttype = sdoterm.SdoTermType.ENUMERATIONVALUE
-            elif self.parent.termType == sdoterm.SdoTermType.DATATYPE:
+            elif self.parent and self.parent.termType == sdoterm.SdoTermType.DATATYPE:
                 self.ttype = sdoterm.SdoTermType.DATATYPE
             else:
                 self.ttype = sdoterm.SdoTermType.REFERENCE
@@ -354,18 +356,18 @@ class SdoTermSource:
 
         cls.TERMS[uri] = self.termdesc
 
-    def __str__(self):
+    def __str__(self) -> str:
         return ("<SdoTermSource: %s '%s'>") % (self.ttype, self.id)
 
     @property
-    def id(self):
+    def id(self) -> str:
         return self.termdesc.id
 
     @property
-    def uri(self):
+    def uri(self) -> str:
         return self.termdesc.uri
 
-    def getTermdesc(self) -> sdoterm.SdoType:
+    def getTermdesc(self) -> sdoterm.SdoTerm:
         return self.termdesc
 
     def getType(self) -> sdoterm.SdoTermType:
@@ -382,8 +384,9 @@ class SdoTermSource:
             return True
         if self.isClass() and not self.checkedDataTypeParents:
             self.checkedDataTypeParents = True
-            for super in self.getSupers():
-                if super.isDataType():
+            for sup_id in self.getSupers():
+                sup = self.__class__.getTerm(sup_id)
+                if sup and sup.termType == sdoterm.SdoTermType.DATATYPE:
                     self.ttype = sdoterm.SdoTermType.DATATYPE
                     return True
         return False
@@ -394,7 +397,7 @@ class SdoTermSource:
         query = """
           ASK  {
                     %s rdfs:subClassOf* %s.
-            }""" % (uriWrap(toFullId(term_id)), uriWrap(ENUMERATIONURI))
+            }""" % (uriWrap(toFullId(term_id)), uriWrap(str(ENUMERATIONURI)))
 
         result = cls.query(query)
         return result[-1]
@@ -405,13 +408,13 @@ class SdoTermSource:
     def isReference(self) -> bool:
         return self.ttype == sdoterm.SdoTermType.REFERENCE
 
-    def getParent(self):
+    def getParent(self) -> Optional[sdoterm.SdoTerm]:
         return self.parent
 
     def getPrefixedId(self) -> str:
         return prefixedIdFromUri(self.uri)
 
-    def getComments(self) -> typing.Sequence[str]:
+    def getComments(self) -> Sequence[str]:
         if not self.comments:
             self.comments = tuple(map(str, self.loadObjects(rdflib.RDFS.comment)))
         return self.comments
@@ -421,7 +424,7 @@ class SdoTermSource:
             self.loadComment()
         return self.comment
 
-    def getSupersededBy(self):
+    def getSupersededBy(self) -> str:
         if not self.supersededBy:
             tmp = []
             ss = self.loadObjects("schema:supersededBy")
@@ -444,7 +447,7 @@ class SdoTermSource:
     def superseded(self) -> bool:
         return len(self.getSupersededBy()) > 0
 
-    def getSupersedes(self) -> typing.Sequence[str]:
+    def getSupersedes(self) -> List[str]:
         if not self.supersedes:
             self.supersedes = []
             subs = self.loadSubjects("schema:supersededBy")
@@ -453,13 +456,13 @@ class SdoTermSource:
             self.supersedes.sort()
         return self.supersedes
 
-    def getSources(self):
+    def getSources(self) -> List[str]:
         if not self.sources:
             objs = self.loadObjects("schema:source")  # To accept later ttl versions.
-            self.sources = sorted(list(objs))
+            self.sources = sorted([str(o) for o in objs])
         return self.sources
 
-    def getAcknowledgements(self) -> typing.Sequence[str]:
+    def getAcknowledgements(self) -> Sequence[sdocollaborators.collaborator]:
         if not self.acks:
             acks = []
             objs = self.loadObjects(
@@ -467,16 +470,16 @@ class SdoTermSource:
             )  # To accept later ttl versions.
             for obj in objs:
                 if obj:
-                    cont = sdocollaborators.collaborator.getContributor(obj)
+                    cont = sdocollaborators.collaborator.getContributor(str(obj))
                     if cont:
                         acks.append(cont)
             self.acks = sorted(acks, key=lambda t: t.title)
         return self.acks
 
-    def getLayer(self):
+    def getLayer(self) -> str:
         return self.layer
 
-    def getInverseOf(self):
+    def getInverseOf(self) -> Optional[str]:
         if not self.gotinverseOf:
             self.gotinverseOf = True
             inverse = self.loadValue("schema:inverseOf")
@@ -484,17 +487,17 @@ class SdoTermSource:
                 self.inverseOf = uri2id(str(inverse))
         return self.inverseOf
 
-    def getSupers(self):
+    def getSupers(self) -> List[str]:
         if not self.supers:
             self.loadsupers()
         return self.supers
 
-    def getTermStack(self):
+    def getTermStack(self) -> List[sdoterm.SdoTerm]:
         if not self.termStack:
             self.termStack = []
-            for sup in self.getSupers():
+            for sup_id in self.getSupers():
                 try:
-                    s = self.__class__._getTerm(sup, createReference=True)
+                    s = self.__class__._getTerm(sup_id, createReference=True)
                     if s.termType == sdoterm.SdoTermType.REFERENCE:
                         continue
                     self.termStack.append(s)
@@ -510,12 +513,12 @@ class SdoTermSource:
             self.termStack = list(reversed(stack))
         return self.termStack
 
-    def getSubs(self):
+    def getSubs(self) -> List[str]:
         if not self.subs:
             self.loadsubs()
         return self.subs
 
-    def getProperties(self, getall=False):
+    def getProperties(self, getall: bool = False) -> List[str]:
         if not self.props:
             self.props = []
             subs = self.loadSubjects("schema:domainIncludes")
@@ -526,7 +529,7 @@ class SdoTermSource:
 
         if getall:
             allprop_ids = set(self.props)
-            for t in self.termStack:
+            for t in self.getTermStack():
                 if not isinstance(t, sdoterm.SdoTerm):
                     term = self.__class__._getTerm(t, createReference=True)
                 else:
@@ -539,10 +542,10 @@ class SdoTermSource:
             ret = sorted(list(allprop_ids))
         return ret
 
-    def getPropUsedOn(self):
+    def getPropUsedOn(self) -> List[str]:
         raise Exception("Not implemented yet")
 
-    def getRanges(self):
+    def getRanges(self) -> List[str]:
         if not self.ranges:
             self.ranges = []
             objs = self.loadObjects("schema:rangeIncludes")
@@ -551,7 +554,7 @@ class SdoTermSource:
             self.ranges.sort()
         return self.ranges
 
-    def getDomains(self):
+    def getDomains(self) -> List[str]:
         if not self.domains:
             self.domains = []
             objs = self.loadObjects("schema:domainIncludes")
@@ -560,7 +563,7 @@ class SdoTermSource:
             self.domains.sort()
         return self.domains
 
-    def getTargetOf(self, plusparents=False, stopontarget=False):
+    def getTargetOf(self, plusparents: bool = False, stopontarget: bool = False) -> List[str]:
         global ENUMERATIONURI, THINGURI
         if not self.targetOf:
             self.targetOf = []
@@ -574,9 +577,9 @@ class SdoTermSource:
                 targets = list(self.targetOf)
                 for s in self.getSupers():
                     sup = self.__class__._getTerm(s, createReference=True)
-                    if sup.uri() == ENUMERATIONURI or sup.uri == THINGURI:
+                    if sup.uri == str(ENUMERATIONURI) or sup.uri == str(THINGURI):
                         break
-                    ptargets = sup.expectedTypeFor
+                    ptargets = sup.expectedTypeFor.ids
                     for t in ptargets:
                         targets.append(t)
                     if len(targets) and stopontarget:
@@ -584,7 +587,7 @@ class SdoTermSource:
                 ret = sorted(list(set(targets)))
         return ret
 
-    def getEquivalents(self):
+    def getEquivalents(self) -> List[str]:
         if not self.equivalents:
             self.equivalents = []
             equivalents = self.loadObjects("owl:equivalentClass")
@@ -594,10 +597,12 @@ class SdoTermSource:
             self.equivalents.sort(key=prefixedIdFromUri)
         return self.equivalents
 
-    def inLayers(self, layers):
+    def inLayers(self, layers: Union[str, Iterable[str]]) -> bool:
+        if isinstance(layers, str):
+            return self.layer == layers
         return self.layer in layers
 
-    def getExtLayer(self):
+    def getExtLayer(self) -> str:
         ret = ""
         lay = self.layer
         if len(lay) and lay != CORE:
@@ -605,25 +610,33 @@ class SdoTermSource:
         return ret
 
     @classmethod
-    def subClassOf(cls, child, parent):
+    def subClassOf(cls, child: Union[str, sdoterm.SdoTerm], parent: Union[str, sdoterm.SdoTerm]) -> bool:
         if isinstance(child, str):
-            child = cls.getTerm(child)
-        if isinstance(parent, str):
-            parent = cls.getTerm(parent)
+            child_obj = cls.getTerm(child)
+        else:
+            child_obj = child
 
-        if child == parent:
+        if isinstance(parent, str):
+            parent_obj = cls.getTerm(parent)
+        else:
+            parent_obj = parent
+
+        if child_obj == parent_obj:
             return True
 
-        parents = child.supers.ids
-        if parent.id in parents:
+        if not child_obj:
+            return False
+
+        parents = child_obj.supers.ids
+        if parent_obj and parent_obj.id in parents:
             return True
 
         for p in parents:
-            if cls.subClassOf(p, parent):
+            if cls.subClassOf(p, parent_obj):
                 return True
         return False
 
-    def loadComment(self):
+    def loadComment(self) -> None:
         comments = self.getComments()
         wpre = None
         name = self.termdesc.id
@@ -638,33 +651,33 @@ class SdoTermSource:
                 localmarkdown.Markdown.parse(comment, wpre=wpre) for comment in comments
             ]
         else:
-            comment_buffer = comments
+            comment_buffer = list(comments)
         result = " ".join(comment_buffer)
         self.comment = result.strip()
 
-    def loadValue(self, valType):
+    def loadValue(self, valType: str) -> Optional[Any]:
         ret = self.loadObjects(valType)
         if not ret or len(ret) == 0:
             return None
         return ret[0]
 
-    def loadObjects(self, pred):
+    def loadObjects(self, pred: Union[rdflib.URIRef, str]) -> List[rdflib.term.Node]:
         query = """
         SELECT ?val WHERE {
                 %s %s ?val.
-         }""" % (uriWrap(toFullId(self.id)), uriWrap(pred))
+         }""" % (uriWrap(toFullId(self.id)), uriWrap(str(pred)))
         res = self.__class__.query(query)
         return [row.val for row in res]
 
-    def loadSubjects(self, pred):
+    def loadSubjects(self, pred: Union[rdflib.URIRef, str]) -> List[rdflib.term.Node]:
         query = """
         SELECT ?sub WHERE {
                 ?sub %s %s.
-         }""" % (uriWrap(pred), uriWrap(toFullId(self.id)))
+         }""" % (uriWrap(str(pred)), uriWrap(toFullId(self.id)))
         res = self.__class__.query(query)
         return [row.sub for row in res]
 
-    def loadsupers(self):
+    def loadsupers(self) -> None:
         fullId = toFullId(self.id)
         query = """
         SELECT ?sup WHERE {
@@ -679,7 +692,7 @@ class SdoTermSource:
         res = self.__class__.query(query)
         self.supers = sorted([uri2id(str(row.sup)) for row in res])
 
-    def loadsubs(self):
+    def loadsubs(self) -> None:
         fullId = toFullId(self.id)
         if self.ttype in sdoterm.SdoTerm.TYPE_LIKE_TYPES:
             sel = "rdfs:subClassOf"
@@ -699,7 +712,7 @@ class SdoTermSource:
             self.subs.extend([uri2id(str(child)) for child in subjects])
         self.subs.sort()
 
-    def getEnumerationMembers(self):
+    def getEnumerationMembers(self) -> Optional[List[str]]:
         if not self.members and self.ttype == sdoterm.SdoTermType.ENUMERATION:
             subjects = self.loadSubjects(
                 "a"
@@ -708,8 +721,8 @@ class SdoTermSource:
             self.members.sort()
         return self.members
 
-    def getParentPaths(self, cstack: typing.Sequence[str] = None):
-        self._pstacks = []
+    def getParentPaths(self, cstack: Optional[List[str]] = None) -> List[List[str]]:
+        self._pstacks: List[List[str]] = []
         cstack = cstack or []
         self._pstacks.append(cstack)
         self._getParentPaths(self.termdesc, cstack)
@@ -725,7 +738,7 @@ class SdoTermSource:
                 basetype = self.__class__._getTerm(base)
             else:
                 basetype = self.termdesc
-            if basetype.termType == sdoterm.SdoTermType.DATATYPE:
+            if basetype and basetype.termType == sdoterm.SdoTermType.DATATYPE:
                 inserts = ["DataType"]
 
         for ins in inserts:
@@ -734,7 +747,7 @@ class SdoTermSource:
 
         return self._pstacks
 
-    def _getParentPaths(self, term: sdoterm.SdoTerm, cstack):
+    def _getParentPaths(self, term: sdoterm.SdoTerm, cstack: List[str]) -> None:
         cstack.insert(0, term.id)
         tmpStacks = []
         tmpStacks.append(cstack)
@@ -760,31 +773,34 @@ class SdoTermSource:
                     parent_id.startswith("http:") or parent_id.startswith("https:")
                 ):
                     sup = self.__class__._getTerm(parent_id)
-                    self._getParentPaths(sup, tmpStacks[x])
+                    if sup:
+                        self._getParentPaths(sup, tmpStacks[x])
                     x += 1
 
     @classmethod
-    def getParentPathTo(cls, start_term_id: str, end_term_id: str = None):
+    def getParentPathTo(cls, start_term_id: str, end_term_id: str = None) -> List[List[str]]:
         # Output paths from start_term to only if end_term in path
         end_term_id = end_term_id or "Thing"
         start_term = cls.getTerm(start_term_id, expanded=True)
         outList = []
-        for path in start_term.superPaths:
-            if end_term_id in path:
-                outList.append(path)
+        if start_term:
+            for path in start_term.superPaths:
+                if end_term_id in path:
+                    outList.append(list(path))
         return outList
 
     def checkForEnumVal(self) -> bool:
         if self.ttype == sdoterm.SdoTermType.ENUMERATION:
             return True
 
-        for super_terms in self.supers:
-            if super_terms.checkForEnumVal():
+        for super_id in self.getSupers():
+            super_term = self.__class__.getTerm(super_id)
+            if super_term and super_term.checkForEnumVal():
                 return True
         return False
 
     @classmethod
-    def expandTerms(cls, terms, depth: int = 2):
+    def expandTerms(cls, terms: Iterable[sdoterm.SdoTerm], depth: int = 2) -> List[sdoterm.SdoTerm]:
         return [cls.expandTerm(t, depth=depth) for t in terms]
 
     @classmethod
@@ -853,7 +869,9 @@ class SdoTermSource:
         return termdesc
 
     @classmethod
-    def termFromId(cls, id: str = "") -> sdoterm.SdoTerm:
+    def termFromId(cls, id: Optional[str] = "") -> Optional[sdoterm.SdoTerm]:
+        if not id:
+            return None
         ids = cls.termsFromIds([id])
         if len(ids):
             return ids[0]
@@ -861,14 +879,14 @@ class SdoTermSource:
 
     @classmethod
     def termsFromIds(
-        cls, ids: typing.Sequence[str] = None
-    ) -> typing.Sequence[sdoterm.SdoTerm]:
+        cls, ids: typing.Sequence[Union[str, sdoterm.SdoTerm]] = None
+    ) -> Sequence[sdoterm.SdoTerm]:
         """Convert a sequence of term-identities into a sequence of SdoTerms."""
         ids = ids or []
         ret = []
         for tid in ids:
-            if tid and len(tid):
-                if type(tid) is str:
+            if tid:
+                if isinstance(tid, str):
                     ret.append(cls._getTerm(tid, createReference=True))
                 else:
                     ret.append(tid)
@@ -877,16 +895,13 @@ class SdoTermSource:
     @classmethod
     def _singleTermFromResult(
         cls, res: typing.Sequence[rdflib.query.ResultRow], termId: str
-    ) -> sdoterm.SdoTerm:
+    ) -> Optional[sdoterm.SdoTerm]:
         """Return a single term matching `termId` from res."""
         tmp = _TermAccumulator(termId)
         for row in res:  # Assumes termdefinition rows are ordered by termId
             if tmp.id != termId:  # New term definition starts on this row
-                if tmp.id:
-                    term = cls._createTerm(tmp.id)
-                    if term:
-                        ret.append(term)
-                tmp = _TermAccumulator(termId)
+                # This should not happen given the way we call this
+                pass
             tmp.appendRow(row)
 
         return cls._createTerm(tmp)
@@ -894,8 +909,8 @@ class SdoTermSource:
     @classmethod
     def termsFromResults(
         cls, res: typing.Sequence[rdflib.query.ResultRow]
-    ) -> typing.Sequence[sdoterm.SdoTerm]:
-        rows_by_term_id = {}
+    ) -> Sequence[sdoterm.SdoTerm]:
+        rows_by_term_id: Dict[str, _TermAccumulator] = {}
         for row in res:
             key = str(row.term)
             if not key in rows_by_term_id:
@@ -904,13 +919,13 @@ class SdoTermSource:
 
         return list(
             filter(
-                bool,
+                None,
                 [cls._createTerm(acc) for acc in rows_by_term_id.values()],
             )
         )
 
     @classmethod
-    def _createTerm(cls, tmp: _TermAccumulator) -> sdoterm.SdoTerm:
+    def _createTerm(cls, tmp: _TermAccumulator) -> Optional[sdoterm.SdoTerm]:
         global DATATYPEURI, ENUMERATIONURI
         if not tmp or not tmp.id:
             return None
@@ -919,7 +934,7 @@ class SdoTermSource:
             tmp.type = DATATYPEURI
         elif ENUMERATIONURI in tmp.sups:
             tmp.type = ENUMERATIONURI
-        elif len(tmp.types) > 1:
+        elif tmp.types and len(tmp.types) > 1:
             tmp.type = sorted(tmp.types)[0]
 
         term = cls.TERMS.get(tmp.id, None)
@@ -929,14 +944,16 @@ class SdoTermSource:
         return term
 
     @classmethod
-    def triples4Term(cls, termId: str):
+    def triples4Term(cls, termId: str) -> Iterable[Tuple[rdflib.term.Node, rdflib.term.Node, rdflib.term.Node]]:
         term = cls.getTerm(termId)
         g = cls.SOURCEGRAPH
+        if not term or not g:
+            return []
         triples = g.triples((rdflib.URIRef(term.uri), None, None))
         return triples
 
     @classmethod
-    def getTermAsRdfString(cls, termId: str, output_format: str, full=False):
+    def getTermAsRdfString(cls, termId: str, output_format: str, full: bool = False) -> str:
         global VOCABURI
         term = cls.getTerm(termId)
         if not term or term.termType == sdoterm.SdoTermType.REFERENCE:
@@ -967,14 +984,16 @@ class SdoTermSource:
                         props.extend(cls.termsFromIds(t.allproperties.ids))
 
             for t in sorted(types):
-                triples = cls.triples4Term(t.id)
-                for trip in triples:
-                    g.add(trip)
+                if t:
+                    triples = cls.triples4Term(t.id)
+                    for trip in triples:
+                        g.add(trip)
 
             for p in sorted(props):
-                triples = cls.triples4Term(p.id)
-                for trip in triples:
-                    g.add(trip)
+                if p:
+                    triples = cls.triples4Term(p.id)
+                    for trip in triples:
+                        g.add(trip)
 
         if output_format == "rdf":
             output_format = "pretty-xml"
@@ -991,37 +1010,36 @@ class SdoTermSource:
                 return json.dumps(sort_dict(data), indent=2)
             except Exception:
                 pass
-
-        return ret
+        return str(ret)
 
     @classmethod
-    def getAllTypes(cls, layer=None, expanded=False):
+    def getAllTypes(cls, layer: Optional[str] = None, expanded: bool = False) -> Sequence[Union[str, sdoterm.SdoTerm]]:
         return cls.getAllTerms(
             ttype=sdoterm.SdoTermType.TYPE, layer=layer, expanded=expanded
         )
 
     @classmethod
-    def getAllProperties(cls, layer=None, expanded=False):
+    def getAllProperties(cls, layer: Optional[str] = None, expanded: bool = False) -> Sequence[Union[str, sdoterm.SdoTerm]]:
         return cls.getAllTerms(
             ttype=sdoterm.SdoTermType.PROPERTY, layer=layer, expanded=expanded
         )
 
     @classmethod
-    def getAllEnumerations(cls, layer=None, expanded=False):
+    def getAllEnumerations(cls, layer: Optional[str] = None, expanded: bool = False) -> Sequence[Union[str, sdoterm.SdoTerm]]:
         return cls.getAllTerms(
             ttype=sdoterm.SdoTermType.ENUMERATION, layer=layer, expanded=expanded
         )
 
     @classmethod
-    def getAllEnumerationvalues(cls, layer=None, expanded=False):
+    def getAllEnumerationvalues(cls, layer: Optional[str] = None, expanded: bool = False) -> Sequence[Union[str, sdoterm.SdoTerm]]:
         return cls.getAllTerms(
             ttype=sdoterm.SdoTermType.ENUMERATIONVALUE, layer=layer, expanded=expanded
         )
 
     @classmethod
     def getAllTerms(
-        cls, ttype=None, layer=None, suppressSourceLinks=False, expanded=False
-    ):
+        cls, ttype: Optional[sdoterm.SdoTermType] = None, layer: Optional[str] = None, suppressSourceLinks: bool = False, expanded: bool = False
+    ) -> Sequence[Union[str, sdoterm.SdoTerm]]:
         with pretty_logger.BlockLog(
             logger=log, message="GetAllTerms", timing=True
         ) as block:
@@ -1039,7 +1057,7 @@ class SdoTermSource:
             elif ttype == sdoterm.SdoTermType.ENUMERATIONVALUE:
                 extra = "?type rdfs:subClassOf*  <%s>." % ENUMERATIONURI
             elif not ttype:
-                typesel = ""
+                typsel = ""
             else:
                 log.debug("Invalid type value '%s'" % ttype)
 
@@ -1080,23 +1098,23 @@ class SdoTermSource:
             res = cls.query(query)
             log.debug("res %d", len(res))
 
-            terms = []
+            terms: List[Union[str, sdoterm.SdoTerm]] = []
             if expanded:
                 with pretty_logger.BlockLog(
                     logger=log, message=f"Expanding {len(res)} terms", timing=True
                 ):
-                    terms = cls.termsFromResults(res)
+                    terms = list(cls.termsFromResults(res))
 
             else:
                 for row in res:
-                    term = uri2id(str(row.term))
-                    if not term in terms:
-                        terms.append(term)
+                    term_id = uri2id(str(row.term))
+                    if not term_id in terms:
+                        terms.append(term_id)
             block.message = f"GetAllTerms: {len(terms)} terms, total: {len(cls.TERMS)}"
             return terms
 
     @classmethod
-    def getAcknowledgedTerms(cls, ack):
+    def getAcknowledgedTerms(cls, ack: str) -> Sequence[sdoterm.SdoTerm]:
         query = (
             """SELECT DISTINCT ?term ?type ?label ?layer ?sup WHERE {
              ?term a ?type;
@@ -1121,10 +1139,11 @@ class SdoTermSource:
         return terms
 
     @classmethod
-    def setSourceGraph(cls, g: rdflib.graph.Graph):
+    def setSourceGraph(cls, g: rdflib.graph.Graph) -> None:
         global VOCABURI
         cls.SOURCEGRAPH = g
-        g.bind("schema", VOCABURI)
+        if VOCABURI:
+            g.bind("schema", VOCABURI)
         bindNameSpaces(g)
 
         cls.TERMS = {}  # Clear cache
@@ -1132,7 +1151,7 @@ class SdoTermSource:
 
     @classmethod
     def loadSourceGraph(
-        cls, files=None, init: bool = False, vocaburi: str = None
+        cls, files: Optional[Union[str, Iterable[str]]] = None, init: bool = False, vocaburi: Optional[str] = None
     ) -> None:
         """Load the source graph.
 
@@ -1152,6 +1171,7 @@ class SdoTermSource:
         elif vocaburi:
             cls.setVocabUri(vocaburi)
 
+        load_files: List[str] = []
         if not files or files == "default":
             if cls.SOURCEGRAPH:
                 if not cls.LOADEDDEFAULT:
@@ -1167,25 +1187,25 @@ class SdoTermSource:
                     "SdoTermSource.loadSourceGraph() loading from default files found in globs: %s",
                     ",".join(DEFTRIPLESFILESGLOB),
                 )
-                files = []
                 for g in DEFTRIPLESFILESGLOB:
-                    files.extend(sorted(glob.glob(g)))
+                    load_files.extend(sorted(glob.glob(g)))
         elif isinstance(files, str):
             cls.LOADEDDEFAULT = False
             log.info("SdoTermSource.loadSourceGraph() loading from file: %s", files)
-            files = [files]
+            load_files = [files]
         else:
             cls.LOADEDDEFAULT = False
             log.info(
                 "SdoTermSource.loadSourceGraph() loading from %d files", len(files)
             )
+            load_files = list(files)
 
-        if not len(files):
+        if not len(load_files):
             raise Exception("No triples file(s) to load")
 
         cls.setSourceGraph(rdflib.Graph())
 
-        for file_path in files:
+        for file_path in load_files:
             cls.SOURCEGRAPH += _loadOneSourceGraph(file_path)
         log.info(
             "Done: Loaded %s triples - %s terms",
@@ -1197,10 +1217,11 @@ class SdoTermSource:
     def sourceGraph(cls) -> rdflib.Graph:
         if cls.SOURCEGRAPH == None:
             cls.loadSourceGraph()
+        assert cls.SOURCEGRAPH is not None
         return cls.SOURCEGRAPH
 
     @staticmethod
-    def setVocabUri(uri: str = None):
+    def setVocabUri(uri: Optional[str] = None) -> None:
         global VOCABURI, DATATYPEURI, ENUMERATIONURI, THINGURI
         VOCABURI = uri or DEFVOCABURI
         DATATYPEURI = rdflib.URIRef(VOCABURI + "DataType")
@@ -1208,10 +1229,11 @@ class SdoTermSource:
         THINGURI = rdflib.URIRef(VOCABURI + "Thing")
 
     @classmethod
-    def vocabUri(cls):
+    def vocabUri(cls) -> str:
         global VOCABURI
         if not VOCABURI:
             cls.setVocabUri()
+        assert VOCABURI is not None
         return VOCABURI
 
     @classmethod
@@ -1222,50 +1244,50 @@ class SdoTermSource:
         return result
 
     @classmethod
-    def termCounts(cls) -> int:
+    def termCounts(cls) -> Dict[Union[sdoterm.SdoTermType, str], int]:
         global VOCABURI
         if not cls.TERMCOUNTS:
-            count = (
+            count_query = (
                 """SELECT (COUNT(DISTINCT ?s) as ?count) WHERE {
                 ?s a ?type .
                 FILTER (strStarts(str(?s),"%s"))
             } """
                 % VOCABURI
             )
-            res = cls.query(count)
+            res = cls.query(count_query)
             allterms = int(res[0][0])
 
-            count = (
+            count_query = (
                 """SELECT (COUNT(DISTINCT ?s) as ?count) WHERE {
                 ?s a rdfs:Class .
                 FILTER (strStarts(str(?s),"%s"))
             } """
                 % VOCABURI
             )
-            res = cls.query(count)
+            res = cls.query(count_query)
             classes = int(res[0][0])
 
-            count = (
+            count_query = (
                 """SELECT (COUNT(DISTINCT ?s) as ?count) WHERE {
                 ?s a rdf:Property .
                 FILTER (strStarts(str(?s),"%s"))
             } """
                 % VOCABURI
             )
-            res = cls.query(count)
+            res = cls.query(count_query)
             properties = int(res[0][0])
 
-            count = (
+            count_query = (
                 """SELECT (COUNT(DISTINCT ?s) as ?count) WHERE {
                 ?s rdfs:subClassOf* schema:Enumeration .
                 FILTER (strStarts(str(?s),"%s"))
             } """
                 % VOCABURI
             )
-            res = cls.query(count)
+            res = cls.query(count_query)
             enums = int(res[0][0])
 
-            count = (
+            count_query = (
                 """SELECT (COUNT(DISTINCT ?s) as ?count) WHERE {
                 ?s a ?type .
                 ?type rdfs:subClassOf* schema:Enumeration .
@@ -1273,10 +1295,10 @@ class SdoTermSource:
             } """
                 % VOCABURI
             )
-            res = cls.query(count)
+            res = cls.query(count_query)
             enumvals = int(res[0][0])
 
-            count = (
+            count_query = (
                 """SELECT (COUNT(DISTINCT ?s) as ?count) WHERE {
                 {
                     ?s a schema:DataType .
@@ -1290,10 +1312,10 @@ class SdoTermSource:
            } """
                 % VOCABURI
             )
-            res = cls.query(count)
+            res = cls.query(count_query)
             datatypes = int(res[0][0])
 
-            count = (
+            count_query = (
                 """SELECT (COUNT(DISTINCT ?s) as ?count) WHERE {
                 ?s rdfs:subClassOf* ?x .
                 ?x a schema:DataType .
@@ -1301,7 +1323,7 @@ class SdoTermSource:
            } """
                 % VOCABURI
             )
-            res = cls.query(count)
+            res = cls.query(count_query)
             datatypeclasses = int(res[0][0])
 
             types = classes
@@ -1310,21 +1332,22 @@ class SdoTermSource:
             types -= datatypeclasses
             datatypes -= 1  # Datatype not counted
 
-            cls.TERMCOUNTS = {}
-            cls.TERMCOUNTS[sdoterm.SdoTermType.TYPE] = types
-            cls.TERMCOUNTS[sdoterm.SdoTermType.PROPERTY] = properties
-            cls.TERMCOUNTS[sdoterm.SdoTermType.DATATYPE] = datatypes
-            cls.TERMCOUNTS[sdoterm.SdoTermType.ENUMERATION] = enums
-            cls.TERMCOUNTS[sdoterm.SdoTermType.ENUMERATIONVALUE] = enumvals
-            cls.TERMCOUNTS["All"] = types + properties + datatypes + enums + enumvals
+            counts: Dict[Union[sdoterm.SdoTermType, str], int] = {}
+            counts[sdoterm.SdoTermType.TYPE] = types
+            counts[sdoterm.SdoTermType.PROPERTY] = properties
+            counts[sdoterm.SdoTermType.DATATYPE] = datatypes
+            counts[sdoterm.SdoTermType.ENUMERATION] = enums
+            counts[sdoterm.SdoTermType.ENUMERATIONVALUE] = enumvals
+            counts["All"] = types + properties + datatypes + enums + enumvals
+            cls.TERMCOUNTS = counts
         return cls.TERMCOUNTS
 
     @classmethod
-    def setMarkdownProcess(cls, process: bool):
+    def setMarkdownProcess(cls, process: bool) -> None:
         cls.MARKDOWNPROCESS = process
 
     @classmethod
-    def termCache(cls):
+    def termCache(cls) -> Dict[str, sdoterm.SdoTerm]:
         return cls.TERMS
 
     @classmethod
@@ -1334,7 +1357,7 @@ class SdoTermSource:
         expanded: bool = False,
         refresh: bool = False,
         createReference: bool = False,
-    ):
+    ) -> Optional[sdoterm.SdoTerm]:
         with cls.TERMSLOCK:
             return cls._getTerm(
                 termId,
@@ -1350,7 +1373,7 @@ class SdoTermSource:
         expanded: bool = False,
         refresh: bool = False,
         createReference: bool = False,
-    ):
+    ) -> Optional[sdoterm.SdoTerm]:
         if not termId:
             return None
         assert isinstance(termId, str), termId
@@ -1359,7 +1382,7 @@ class SdoTermSource:
         term = cls.TERMS.get(fullId, None)
 
         if term and refresh:
-            del cls.TERMS[termId]
+            del cls.TERMS[fullId]
             log.info("Term '%s' found and removed" % termId)
             term = None
 
@@ -1417,10 +1440,10 @@ def uriWrap(identity_str: str) -> str:
     return identity_str
 
 
-LAYERPATTERN = None
+LAYERPATTERN: Optional[str] = None
 
 
-def layerFromUri(uri: str) -> str:
+def layerFromUri(uri: str) -> Optional[str]:
     global VOCABURI
     global LAYERPATTERN
     assert VOCABURI
@@ -1439,8 +1462,9 @@ def layerFromUri(uri: str) -> str:
     return None
 
 
-def uriFromLayer(layer: str = None) -> str:
+def uriFromLayer(layer: Optional[str] = None) -> str:
     global VOCABURI
+    assert VOCABURI is not None
     voc = VOCABURI
     if voc.endswith("/") or voc.endswith("#"):
         voc = voc[: len(voc) - 1]
@@ -1464,21 +1488,26 @@ def getProtoAndRoot(uri: str) -> ProtoAndRoot:
 
 def uri2id(uri: str) -> str:
     global VOCABURI
+    assert VOCABURI is not None
     if uri.startswith(VOCABURI):
         return uri[len(VOCABURI) :]
     return uri
 
 
-def prefixFromUri(uri: str) -> rdflib.term.URIRef:
+def prefixFromUri(uri: str) -> Optional[rdflib.term.URIRef]:
+    if SdoTermSource.SOURCEGRAPH is None:
+        return None
     for pref, pth in SdoTermSource.SOURCEGRAPH.namespaces():
         if uri.startswith(str(pth)):
             return pref
     return None
 
 
-def uriForPrefix(pre: str) -> str:
+def uriForPrefix(pre: str) -> Optional[rdflib.term.URIRef]:
+    if SdoTermSource.SOURCEGRAPH is None:
+        return None
     for pref, pth in SdoTermSource.SOURCEGRAPH.namespaces():
-        if pre == pref:
+        if pre == str(pref):
             return pth
     return None
 

--- a/software/devserv.py
+++ b/software/devserv.py
@@ -2,37 +2,25 @@
 # -*- coding: utf-8 -*-
 
 import argparse
-import os
-import re
 import sys
-import typing
-from typing import Any, Dict, List, Optional, Tuple, Union, Iterable, Sequence, Set, Callable
+from pathlib import Path
+from typing import Any, Dict, Optional, List
 
 from colorama import Fore, Style
 from flask import Flask, after_this_request, Response
 
-if not (sys.version_info.major == 3 and sys.version_info.minor > 5):
-    print(
-        "Python version %s.%s not supported version 3.6 or above required - exiting"
-        % (sys.version_info.major, sys.version_info.minor)
-    )
-    sys.exit(1)
-
-for path in [os.getcwd(), "software/util"]:
-    sys.path.insert(1, path)  # Pickup libs from local  directories
+for path in [Path.cwd(), Path("software/util")]:
+    if str(path) not in sys.path:
+        sys.path.insert(1, str(path))
 
 from software.util.schemaversion import getVersion
 
-
 parser: argparse.ArgumentParser = argparse.ArgumentParser()
 parser.add_argument("--host", default="localhost", help="Host (default: localhost)")
-parser.add_argument("--port", type=int, default=8080, help="Port (default: 8080")
-parser.add_argument(
-    "--production", default=False, action="store_true", help="Production settings"
-)
+parser.add_argument("--port", type=int, default=8080, help="Port (default: 8080)")
+parser.add_argument("--production", default=False, action="store_true", help="Production settings")
 args_parsed: argparse.Namespace = parser.parse_args()
 
-# create the application object
 app: Flask = Flask(__name__, static_folder="site", static_url_path="")
 
 
@@ -45,99 +33,80 @@ def serve_home() -> Response:
         response.headers["Access-Control-Allow-Origin"] = '"*"'
         response.headers["Access-Control-Allow-Methods"] = "GET"
         response.headers["Access-Control-Expose-Headers"] = "Link"
-        response.headers["link"] = (
-            '</docs/jsonldcontext.jsonld>; rel="alternate"; type="application/ld+json"'
-        )
+        response.headers["link"] = '</docs/jsonldcontext.jsonld>; rel="alternate"; type="application/ld+json"'
         return response
 
     path: str = "docs/home.html"
-    print("Serving file: " + path)
+    print(f"Serving file: {path}")
     return app.send_static_file(path)
 
 
 @app.route("/favicon.ico")
 def serve_favicon() -> Response:
     path: str = "docs/favicon.ico"
-    print("Serving file: " + path)
+    print(f"Serving file: {path}")
     return app.send_static_file(path)
 
 
 @app.route("/robots.txt")
 def serve_robots() -> Response:
     path: str = "docs/robots-blockall.txt"
-    print("Serving file: " + path)
+    print(f"Serving file: {path}")
     return app.send_static_file(path)
 
 
 @app.route("/docs/devnote.css")
 def serve_devnote() -> Response:
-    path: str
-    if args_parsed.production:
-        path = "docs/devnotehide.css"
-    else:
-        path = "docs/devnoteshow.css"
-    print("Serving file: " + path)
+    path: str = "docs/devnotehide.css" if args_parsed.production else "docs/devnoteshow.css"
+    print(f"Serving file: {path}")
     return app.send_static_file(path)
 
 
 @app.route("/sitemap.xml")
 @app.route("/docs/sitemap.xml")
 def serve_sitemap() -> Response:
-    path: str
-    if args_parsed.production:
-        path = "docs/sitemap.xml"
-    else:
-        path = "docs/sitemap.xml_no_serve"
-    print("Serving file: " + path)
+    path: str = "docs/sitemap.xml" if args_parsed.production else "docs/sitemap.xml_no_serve"
+    print(f"Serving file: {path}")
     return app.send_static_file(path)
 
 
-@app.route("/docs/collab/<path>")
+@app.route("/docs/collab/<path:path>")
 def serve_colls(path: str) -> Response:
     if not path.endswith(".html"):
-        path = "docs/collab/" + path + ".html"
+        path = f"docs/collab/{path}.html"
 
-    print("Serving file: " + path)
-
+    print(f"Serving file: {path}")
     return app.send_static_file(path)
 
 
-@app.route("/<path>")
+@app.route("/<path:path>")
 def serve_terms(path: str) -> Response:
     if not path.endswith(".html"):
-        m = re.match("^([a-z])(.*)$", path)
-        if m:
-            path = "terms/properties/%s/%s%s.html" % (
-                m.group(1),
-                m.group(1),
-                m.group(2),
-            )
-        else:
-            m = re.match("^([0-9A-Z])(.*)$", path)
-            if m:
-                path = "terms/types/%s/%s%s.html" % (m.group(1), m.group(1), m.group(2))
+        if path[0].islower():
+            path = f"terms/properties/{path[0]}/{path}.html"
+        elif path[0].isupper() or path[0].isdigit():
+            path = f"terms/types/{path[0]}/{path}.html"
 
-    print("Serving file: " + path)
-
+    print(f"Serving file: {path}")
     return app.send_static_file(path)
 
 
 @app.route("/version/<ver>")
 @app.route("/version/<ver>/")
-@app.route("/version/<ver>/<path>")
+@app.route("/version/<ver>/<path:path>")
 def serve_downloads(ver: str, path: str = "") -> Response:
     if ver == "latest":
         ver = getVersion()
-    if not len(path):
+    if not path:
         path = "schema-all.html"
-    path = "releases/%s/%s" % (ver, path)
-    print("Serving file: " + path)
-    return app.send_static_file(path)
+    
+    full_path: str = f"releases/{ver}/{path}"
+    print(f"Serving file: {full_path}")
+    return app.send_static_file(full_path)
 
 
-# start the server with the 'run()' method
 if __name__ == "__main__":
-    print("Local dev server for Schema.org version: %s" % getVersion())
+    print(f"Local dev server for Schema.org version: {getVersion()}")
     if args_parsed.production:
         print(Fore.RED + "Running with Production settings" + Style.RESET_ALL)
     else:

--- a/software/devserv.py
+++ b/software/devserv.py
@@ -5,9 +5,11 @@ import argparse
 import os
 import re
 import sys
+import typing
+from typing import Any, Dict, List, Optional, Tuple, Union, Iterable, Sequence, Set, Callable
 
 from colorama import Fore, Style
-from flask import Flask, after_this_request
+from flask import Flask, after_this_request, Response
 
 if not (sys.version_info.major == 3 and sys.version_info.minor > 5):
     print(
@@ -19,25 +21,25 @@ if not (sys.version_info.major == 3 and sys.version_info.minor > 5):
 for path in [os.getcwd(), "software/util"]:
     sys.path.insert(1, path)  # Pickup libs from local  directories
 
-from schemaversion import getVersion
+from software.util.schemaversion import getVersion
 
 
-parser = argparse.ArgumentParser()
+parser: argparse.ArgumentParser = argparse.ArgumentParser()
 parser.add_argument("--host", default="localhost", help="Host (default: localhost)")
-parser.add_argument("--port", default=8080, help="Port (default: 8080")
+parser.add_argument("--port", type=int, default=8080, help="Port (default: 8080")
 parser.add_argument(
     "--production", default=False, action="store_true", help="Production settings"
 )
-args = parser.parse_args()
+args_parsed: argparse.Namespace = parser.parse_args()
 
 # create the application object
-app = Flask(__name__, static_folder="site", static_url_path="")
+app: Flask = Flask(__name__, static_folder="site", static_url_path="")
 
 
 @app.route("/")
-def serve_home():
+def serve_home() -> Response:
     @after_this_request
-    def add_headers(response):
+    def add_headers(response: Response) -> Response:
         response.headers["Access-Control-Allow-Credentials"] = "true"
         response.headers["Access-Control-Allow-Headers"] = "Accept"
         response.headers["Access-Control-Allow-Origin"] = '"*"'
@@ -48,28 +50,29 @@ def serve_home():
         )
         return response
 
-    path = "docs/home.html"
+    path: str = "docs/home.html"
     print("Serving file: " + path)
     return app.send_static_file(path)
 
 
 @app.route("/favicon.ico")
-def serve_favicon():
-    path = "docs/favicon.ico"
+def serve_favicon() -> Response:
+    path: str = "docs/favicon.ico"
     print("Serving file: " + path)
     return app.send_static_file(path)
 
 
 @app.route("/robots.txt")
-def serve_robots():
-    path = "docs/robots-blockall.txt"
+def serve_robots() -> Response:
+    path: str = "docs/robots-blockall.txt"
     print("Serving file: " + path)
     return app.send_static_file(path)
 
 
 @app.route("/docs/devnote.css")
-def serve_devnote():
-    if args.production:
+def serve_devnote() -> Response:
+    path: str
+    if args_parsed.production:
         path = "docs/devnotehide.css"
     else:
         path = "docs/devnoteshow.css"
@@ -79,8 +82,9 @@ def serve_devnote():
 
 @app.route("/sitemap.xml")
 @app.route("/docs/sitemap.xml")
-def serve_sitemap():
-    if args.production:
+def serve_sitemap() -> Response:
+    path: str
+    if args_parsed.production:
         path = "docs/sitemap.xml"
     else:
         path = "docs/sitemap.xml_no_serve"
@@ -89,7 +93,7 @@ def serve_sitemap():
 
 
 @app.route("/docs/collab/<path>")
-def serve_colls(path):
+def serve_colls(path: str) -> Response:
     if not path.endswith(".html"):
         path = "docs/collab/" + path + ".html"
 
@@ -99,7 +103,7 @@ def serve_colls(path):
 
 
 @app.route("/<path>")
-def serve_terms(path):
+def serve_terms(path: str) -> Response:
     if not path.endswith(".html"):
         m = re.match("^([a-z])(.*)$", path)
         if m:
@@ -121,7 +125,7 @@ def serve_terms(path):
 @app.route("/version/<ver>")
 @app.route("/version/<ver>/")
 @app.route("/version/<ver>/<path>")
-def serve_downloads(ver, path=""):
+def serve_downloads(ver: str, path: str = "") -> Response:
     if ver == "latest":
         ver = getVersion()
     if not len(path):
@@ -134,9 +138,9 @@ def serve_downloads(ver, path=""):
 # start the server with the 'run()' method
 if __name__ == "__main__":
     print("Local dev server for Schema.org version: %s" % getVersion())
-    if args.production:
+    if args_parsed.production:
         print(Fore.RED + "Running with Production settings" + Style.RESET_ALL)
     else:
         print(Fore.GREEN + "Running with Development settings" + Style.RESET_ALL)
 
-    app.run(host=args.host, port=args.port, debug=True)
+    app.run(host=args_parsed.host, port=args_parsed.port, debug=True)

--- a/software/scripts/buildtermlist.py
+++ b/software/scripts/buildtermlist.py
@@ -7,6 +7,8 @@ import argparse
 import logging
 import os
 import sys
+import typing
+from typing import Any, Dict, List, Optional, Tuple, Union, Iterable, Sequence, Set, Callable, Generator
 
 # Import schema.org libraries
 if os.getcwd() not in sys.path:
@@ -18,12 +20,14 @@ import software.SchemaTerms.sdoterm as sdoterm
 import software.util.pretty_logger as pretty_logger
 
 
-log = logging.getLogger(__name__)
+log: logging.Logger = logging.getLogger(__name__)
 
 
-def generateTerms(tags=False):
+def generateTerms(tags: bool = False) -> Generator[str, None, None]:
     for term in sdotermsource.SdoTermSource.getAllTerms(expanded=True):
-        label = ""
+        if not isinstance(term, sdoterm.SdoTerm):
+            continue
+        label: str = ""
         if tags:
             if term.termType == sdoterm.SdoTermType.PROPERTY:
                 label = " p"
@@ -39,7 +43,7 @@ def generateTerms(tags=False):
 
 
 if __name__ == "__main__":
-    parser = argparse.ArgumentParser()
+    parser: argparse.ArgumentParser = argparse.ArgumentParser()
     parser.add_argument(
         "-t",
         "--tagtype",
@@ -48,11 +52,11 @@ if __name__ == "__main__":
         help="Add a termtype to name",
     )
     parser.add_argument("-o", "--output", required=True, help="output file")
-    args = parser.parse_args()
-    filename = args.output
+    args_parsed: argparse.Namespace = parser.parse_args()
+    filename: str = args_parsed.output
     with pretty_logger.BlockLog(
         logger=log, message=f"Writing term list to file {filename}"
     ):
         with open(filename, "w", encoding="utf-8") as handle:
-            for term in generateTerms(tags=args.tagtype):
-                handle.write(term)
+            for term_line in generateTerms(tags=args_parsed.tagtype):
+                handle.write(term_line)

--- a/software/scripts/shex_shacl_shapes_exporter.py
+++ b/software/scripts/shex_shacl_shapes_exporter.py
@@ -9,6 +9,7 @@ import logging
 import os
 import sys
 from pathlib import Path
+from typing import Any, Dict, List, Optional, Tuple, Union, Set, Generator
 
 if os.getcwd() not in sys.path:
     sys.path.insert(1, os.getcwd())
@@ -20,17 +21,17 @@ from rdflib.term import Node
 
 from software.util.sort_dict import sort_dict
 
-BASE = Namespace("http://schema.org/validation#")
-SCHEMA = Namespace("http://schema.org/")
-SHACL = Namespace("http://www.w3.org/ns/shacl#")
+BASE: Namespace = Namespace("http://schema.org/validation#")
+SCHEMA: Namespace = Namespace("http://schema.org/")
+SHACL: Namespace = Namespace("http://www.w3.org/ns/shacl#")
 
-PREFIX = "ValidSchema"
-FILE_ENCODING = "utf-8"
+PREFIX: str = "ValidSchema"
+FILE_ENCODING: str = "utf-8"
 
-log = logging.getLogger(__name__)
+log: logging.Logger = logging.getLogger(__name__)
 
 
-def replace_prefix(data):
+def replace_prefix(data: URIRef) -> URIRef:
     """
     Replaces schema.org prefix with schema.org validation prefix
     """
@@ -38,20 +39,20 @@ def replace_prefix(data):
 
 
 class ShExJParser:
-    _ancestor_cache = {}
-    _domain_includes = {}
-    _range_includes = {}
-    _subclass_of = {}
+    _ancestor_cache: Dict[URIRef, List[URIRef]] = {}
+    _domain_includes: Dict[URIRef, List[URIRef]] = {}
+    _range_includes: Dict[URIRef, List[URIRef]] = {}
+    _subclass_of: Dict[URIRef, List[URIRef]] = {}
 
     @classmethod
-    def clear_caches(cls):
+    def clear_caches(cls) -> None:
         cls._ancestor_cache = {}
         cls._domain_includes = {}
         cls._range_includes = {}
         cls._subclass_of = {}
 
     @classmethod
-    def index_graph(cls, source):
+    def index_graph(cls, source: Graph) -> None:
         cls.clear_caches()
         for s, o in source.subject_objects(SCHEMA.domainIncludes):
             cls._domain_includes.setdefault(o, []).append(s)
@@ -69,7 +70,7 @@ class ShExJParser:
             cls._subclass_of[k].sort(key=str)
 
     @classmethod
-    def parse_shape(cls, source, shape, is_datatype):
+    def parse_shape(cls, source: Graph, shape: URIRef, is_datatype: bool) -> Dict[str, Any]:
         """
         Creates shape ShExJ shape for schema.org entity
 
@@ -79,8 +80,8 @@ class ShExJParser:
         :return: JSON(dict) with ShEx constraints
         """
 
-        shape_id = replace_prefix(shape)
-        node = None
+        shape_id: URIRef = replace_prefix(shape)
+        node: Optional[Dict[str, Any]] = None
         if is_datatype:
             node = {
                 "type": "NodeConstraint",
@@ -88,12 +89,12 @@ class ShExJParser:
             }
         else:
             node = {"type": "Shape"}
-            properties = cls._domain_includes.get(shape, [])
+            properties: List[URIRef] = cls._domain_includes.get(shape, [])
 
             # find all subclasses
-            ancestors = sorted(list(set(cls.find_parent_classes(source, shape))), key=str)
+            ancestors: List[URIRef] = sorted(list(set(cls.find_parent_classes(source, shape))), key=str)
             if properties:
-                expression = {
+                expression: Dict[str, Any] = {
                     "type": "EachOf",
                     "expressions": [cls.type_constraint(sorted(ancestors + [shape], key=str))],
                 }
@@ -106,7 +107,7 @@ class ShExJParser:
                 node["expression"] = cls.type_constraint(sorted(ancestors + [shape], key=str))
             node["extra"] = [RDF.type]
 
-            parents = sorted([
+            parents: List[URIRef] = sorted([
                 replace_prefix(URIRef(x)) for x in cls._subclass_of.get(shape, [])
             ], key=str)
             if parents:
@@ -115,7 +116,7 @@ class ShExJParser:
         return {"type": "ShapeDecl", "id": shape_id, "shapeExpr": node}
 
     @staticmethod
-    def type_constraint(types):
+    def type_constraint(types: List[URIRef]) -> Dict[str, Any]:
         """
         Creates rdf:type constraints
 
@@ -129,7 +130,7 @@ class ShExJParser:
         }
 
     @classmethod
-    def parse_property(cls, source, prop):
+    def parse_property(cls, source: Graph, prop: URIRef) -> Dict[str, Any]:
         """
         Creates property constraints
 
@@ -137,8 +138,8 @@ class ShExJParser:
         :param prop: property IRI
         :return: JSON(dict) with ShExJ representation of property constraints
         """
-        node = {"type": "TripleConstraint", "predicate": prop, "min": 0, "max": -1}
-        prop_range = sorted([
+        node: Dict[str, Any] = {"type": "TripleConstraint", "predicate": prop, "min": 0, "max": -1}
+        prop_range: List[URIRef] = sorted([
             replace_prefix(URIRef(x)) for x in cls._range_includes.get(prop, [])
         ], key=str)
         if len(prop_range) == 1:
@@ -148,7 +149,7 @@ class ShExJParser:
         return node
 
     @classmethod
-    def find_parent_classes(cls, source, shape):
+    def find_parent_classes(cls, source: Graph, shape: URIRef) -> List[URIRef]:
         """
         Finds all ancestors of the shape in the subclasses tree using transitive closure.
 
@@ -161,15 +162,15 @@ class ShExJParser:
 
         # transitive_objects(shape, RDFS.subClassOf) returns an iterator including shape
         # itself, but we want ancestors, so we remove it from the result.
-        ancestors = list(source.transitive_objects(shape, RDFS.subClassOf))
+        ancestors: List[Node] = list(source.transitive_objects(shape, RDFS.subClassOf))
         if shape in ancestors:
             ancestors.remove(shape)
-        res = [URIRef(c) for c in ancestors if isinstance(c, URIRef)]
+        res: List[URIRef] = [URIRef(c) for c in ancestors if isinstance(c, URIRef)]
         cls._ancestor_cache[shape] = res
         return res
 
     @classmethod
-    def to_shex(cls, source):
+    def to_shex(cls, source: Graph) -> str:
         """
         Creates ShExJ constraints for schema.org terms definition
 
@@ -177,15 +178,15 @@ class ShExJParser:
         :return: string representation of ShExJ constraints
         """
         cls.index_graph(source)
-        shapes = sorted(source.subjects(RDF.type, RDFS.Class), key=str)
+        shapes: List[Node] = sorted(source.subjects(RDF.type, RDFS.Class), key=str)
 
-        all_datatypes = {URIRef(SCHEMA.DataType)}
+        all_datatypes: Set[URIRef] = {URIRef(SCHEMA.DataType)}
         # Use transitive_subjects to find all subclasses of DataType
         for dt_sub in source.transitive_subjects(RDFS.subClassOf, SCHEMA.DataType):
             if isinstance(dt_sub, URIRef):
                 all_datatypes.add(dt_sub)
 
-        shex = {
+        shex: Dict[str, Any] = {
             "type": "Schema",
             "shapes": [
                 cls.parse_shape(
@@ -196,12 +197,12 @@ class ShExJParser:
             ],
         }
 
-        return json.dumps(sort_dict(shex))
+        return str(json.dumps(sort_dict(shex)))
 
 
 class ShaclParser:
     @staticmethod
-    def parse_shape(source, shape, dest):
+    def parse_shape(source: Graph, shape: URIRef, dest: Graph) -> None:
         """
         Creates SHACL shape for schema.org entity
 
@@ -209,11 +210,11 @@ class ShaclParser:
         :param shape: target shape IRI
         :param dest: output SHACL constraints graph
         """
-        node = replace_prefix(shape)
+        node: URIRef = replace_prefix(shape)
         dest.add((node, RDF.type, SHACL.NodeShape))
         dest.add((node, SHACL.targetClass, shape))
         dest.add((node, SHACL.nodeKind, SHACL.BlankNodeOrIRI))
-        properties = sorted(ShExJParser._domain_includes.get(shape, []), key=str)
+        properties: List[URIRef] = sorted(ShExJParser._domain_includes.get(shape, []), key=str)
         for prop in properties:
             if isinstance(prop, URIRef):
                 dest.add(
@@ -225,7 +226,7 @@ class ShaclParser:
                 )
 
     @staticmethod
-    def parse_property(source, prop, dest):
+    def parse_property(source: Graph, prop: URIRef, dest: Graph) -> BNode:
         """
         Creates property constraints
 
@@ -234,17 +235,17 @@ class ShaclParser:
         :param dest: output SHACL constraints graph
         :return: property blank node
         """
-        node = BNode()
+        node: BNode = BNode()
         dest.add((node, SHACL.path, prop))
-        property_range = sorted([
+        property_range: List[URIRef] = sorted([
             replace_prefix(URIRef(x)) for x in ShExJParser._range_includes.get(prop, [])
         ], key=str)
         if len(property_range) > 1:
-            or_node = BNode()
-            or_collection = Collection(dest, or_node)
+            or_node: BNode = BNode()
+            or_collection: Collection = Collection(dest, or_node)
             dest.add((node, SHACL["or"], or_node))
             for shape in property_range:
-                t = BNode()
+                t: BNode = BNode()
                 dest.add((t, SHACL.node, shape))
                 or_collection.append(t)
         elif property_range:
@@ -252,14 +253,14 @@ class ShaclParser:
         return node
 
     @staticmethod
-    def get_subclasses(source):
+    def get_subclasses(source: Graph) -> str:
         """
         Creates subclasses tree
 
         :param source: source rdflib graph
         :return: subclasses tree rdflib graph
         """
-        subclasses = Graph()
+        subclasses: Graph = Graph()
         subclasses.bind("sh", SHACL)
         subclasses.bind("schema", SCHEMA)
         subclasses.bind("rdfs", RDFS)
@@ -272,21 +273,21 @@ class ShaclParser:
         subclasses = to_canonical_graph(subclasses)
         subclasses.namespace_manager = nsMgr
 
-        return subclasses.serialize(format="turtle", sort_keys=True)
+        return str(subclasses.serialize(format="turtle", sort_keys=True))
 
     @staticmethod
-    def to_shacl(source):
+    def to_shacl(source: Graph) -> str:
         """
         Creates SHACL constraints from schema.org terms definitions
 
         :param source: source rdflib graph
         :return: string representation of SHACL constraints
         """
-        dest = Graph()
+        dest: Graph = Graph()
         dest.bind("sh", SHACL)
         dest.bind("schema", SCHEMA)
         dest.bind("", BASE)
-        shapes = sorted(source.subjects(RDF.type, RDFS.Class), key=str)
+        shapes: List[Node] = sorted(source.subjects(RDF.type, RDFS.Class), key=str)
         for shape in shapes:
             if isinstance(shape, URIRef):
                 ShaclParser.parse_shape(source, shape, dest)
@@ -298,40 +299,40 @@ class ShaclParser:
         # dest = to_canonical_graph(dest)
         # dest.namespace_manager = nsMgr
 
-        return dest.serialize(format="turtle", sort_keys=True)
+        return str(dest.serialize(format="turtle", sort_keys=True))
 
 
 def generate_files(
-    term_defs_path,
-    outputdir,
-    outputfileprefix="",
-    input_format="nt",
-):
+    term_defs_path: Union[str, Path],
+    outputdir: Union[str, Path],
+    outputfileprefix: str = "",
+    input_format: str = "nt",
+) -> None:
     term_defs_path = Path(term_defs_path)
     outputdir = Path(outputdir)
     outputdir.mkdir(parents=True, exist_ok=True)
 
     with term_defs_path.open(encoding=FILE_ENCODING) as f:
-        term_defs = f.read()
+        term_defs: str = f.read()
 
-    graph = Graph().parse(data=term_defs, format=input_format)
+    graph: Graph = Graph().parse(data=term_defs, format=input_format)
     graph.bind("schema", SCHEMA)
 
-    shexj_path = outputdir / f"{outputfileprefix}shapes.shexj"
+    shexj_path: Path = outputdir / f"{outputfileprefix}shapes.shexj"
     shexj_path.write_text(ShExJParser.to_shex(graph), encoding=FILE_ENCODING)
     log.info(f"Created {shexj_path}")
 
-    shacl_path = outputdir / f"{outputfileprefix}shapes.shacl"
+    shacl_path: Path = outputdir / f"{outputfileprefix}shapes.shacl"
     shacl_path.write_text(ShaclParser.to_shacl(graph), encoding=FILE_ENCODING)
     log.info(f"Created {shacl_path}")
 
-    subclasses_path = outputdir / f"{outputfileprefix}subclasses.shacl"
+    subclasses_path: Path = outputdir / f"{outputfileprefix}subclasses.shacl"
     subclasses_path.write_text(ShaclParser.get_subclasses(graph), encoding=FILE_ENCODING)
     log.info(f"Created {subclasses_path}")
 
 
 if __name__ == "__main__":
-    parser = argparse.ArgumentParser(description=__doc__)
+    parser: argparse.ArgumentParser = argparse.ArgumentParser(description=__doc__)
     parser.add_argument("-s", "--sourcefile", help="rdf format source file")
     parser.add_argument(
         "-f", "--format", default="nt", help="source file format (default: .nt)"
@@ -340,8 +341,9 @@ if __name__ == "__main__":
     parser.add_argument(
         "-p", "--outputfileprefix", default="", help="output files prefix"
     )
-    args = parser.parse_args()
+    args: argparse.Namespace = parser.parse_args()
 
+    term_defs_path: Union[str, Path]
     if args.sourcefile:
         term_defs_path = args.sourcefile
     else:

--- a/software/scripts/shex_shacl_shapes_exporter.py
+++ b/software/scripts/shex_shacl_shapes_exporter.py
@@ -35,7 +35,7 @@ def replace_prefix(data: URIRef) -> URIRef:
     """
     Replaces schema.org prefix with schema.org validation prefix
     """
-    return BASE[PREFIX + str(data).replace("http://schema.org/", "")]
+    return BASE[f"{PREFIX}{str(data).replace('http://schema.org/', '')}"]
 
 
 class ShExJParser:

--- a/software/util/buildfiles.py
+++ b/software/util/buildfiles.py
@@ -1,25 +1,22 @@
 #!/usr/bin/env python3
 # -*- coding: utf-8 -*-
 
-# Import standard python libraries
 import csv
 import io
 import json
 import logging
-import os
+import sys
 from pathlib import Path
-from typing import Any, Dict, List, Optional, Tuple, Union, Set
+from typing import Any, Dict, List, Optional, Tuple, Union, Set, Callable, Iterable, Sequence
+
 import rdflib
 import rdflib.namespace
-import sys
 from rdflib.compare import to_canonical_graph
 
-# Import schema.org libraries
-if not os.getcwd() in sys.path:
-    sys.path.insert(1, os.getcwd())
+if Path.cwd() not in [Path(p).resolve() for p in sys.path]:
+    sys.path.insert(1, str(Path.cwd()))
 
 import software
-
 import software.scripts.shex_shacl_shapes_exporter as shex_shacl_shapes_exporter
 import software.util.fileutils as fileutils
 import software.util.pretty_logger as pretty_logger
@@ -30,17 +27,16 @@ import software.util.textutils as textutils
 
 import software.SchemaTerms.sdotermsource as sdotermsource
 import software.SchemaTerms.sdoterm as sdoterm
+import software.SchemaTerms.localmarkdown as localmarkdown
 import software.SchemaExamples.schemaexamples as schemaexamples
 from software.util.sort_dict import sort_dict, sort_xml
 
 VOCABURI: str = sdotermsource.SdoTermSource.vocabUri()
-
 log: logging.Logger = logging.getLogger(__name__)
 
-VISITLIST: List[str] = []
 
 def buildTurtleEquivs() -> str:
-    """Build equivalences to"""
+    """Build equivalences between http and https versions of schema.org terms."""
     s_p: str = "http://schema.org/"
     s_s: str = "https://schema.org/"
     outGraph: rdflib.Graph = rdflib.Graph()
@@ -48,26 +44,26 @@ def buildTurtleEquivs() -> str:
     outGraph.bind("schema_s", s_s)
     outGraph.bind("owl", rdflib.namespace.OWL)
 
-    all_terms: List[sdoterm.SdoTerm] = sdotermsource.SdoTermSource.getAllTerms(expanded=True)
+    all_terms: Sequence[Union[str, sdoterm.SdoTerm]] = sdotermsource.SdoTermSource.getAllTerms(expanded=True)
+    t: Union[str, sdoterm.SdoTerm]
     for t in all_terms:
-        if not t.retired:  # drops non-schema terms and those in attic
-            eqiv: rdflib.term.URIRef = rdflib.namespace.OWL.equivalentClass
+        if isinstance(t, sdoterm.SdoTerm) and not t.retired:
+            eqiv: rdflib.URIRef = rdflib.namespace.OWL.equivalentClass
             if t.termType == sdoterm.SdoTermType.PROPERTY:
                 eqiv = rdflib.namespace.OWL.equivalentProperty
 
-            p: rdflib.URIRef = rdflib.URIRef(f"{s_p}{t.id}")
-            s: rdflib.URIRef = rdflib.URIRef(f"{s_s}{t.id}")
-            outGraph.add((p, eqiv, s))
-            outGraph.add((s, eqiv, p))
-            log.debug(f"{t.uri} ")
+            p_uri: rdflib.URIRef = rdflib.URIRef(f"{s_p}{t.id}")
+            s_uri: rdflib.URIRef = rdflib.URIRef(f"{s_s}{t.id}")
+            outGraph.add((p_uri, eqiv, s_uri))
+            outGraph.add((s_uri, eqiv, p_uri))
 
     return str(outGraph.serialize(format="turtle", auto_compact=True, sort_keys=True))
 
 
 def absoluteFilePath(fn: str) -> str:
-    name: str = os.path.join(schemaglobals.OUTPUTDIR, fn)
-    fileutils.checkFilePath(os.path.dirname(name))
-    return name
+    path: Path = Path(schemaglobals.OUTPUTDIR) / fn
+    fileutils.checkFilePath(path.parent)
+    return str(path)
 
 
 def jsonldcontext(page: str) -> str:
@@ -75,53 +71,44 @@ def jsonldcontext(page: str) -> str:
 
 
 def jsonldtree(page: str) -> str:
-    global VISITLIST
-    VISITLIST = []
-
-    term: Dict[str, Any] = {}
-    context: Dict[str, Any] = {}
-    context["rdfs"] = "http://www.w3.org/2000/01/rdf-schema#"
-    context["schema"] = "https://schema.org"
-    context["rdfs:subClassOf"] = {"@type": "@id"}
-    context["description"] = "rdfs:comment"
-    context["children"] = {"@reverse": "rdfs:subClassOf"}
-    term["@context"] = context
-    data: Dict[str, Any] = _jsonldtree("Thing", term)
+    context: Dict[str, Any] = {
+        "rdfs": "http://www.w3.org/2000/01/rdf-schema#",
+        "schema": "https://schema.org",
+        "rdfs:subClassOf": {"@type": "@id"},
+        "description": "rdfs:comment",
+        "children": {"@reverse": "rdfs:subClassOf"}
+    }
+    data: Dict[str, Any] = _jsonldtree("Thing", visitset=set(), term={"@context": context})
     return json.dumps(sort_dict(data), indent=3)
 
 
-def _jsonldtree(tid: str, term: Optional[Dict[str, Any]] = None) -> Dict[str, Any]:
+def _jsonldtree(tid: str, visitset: Set[str], term: Optional[Dict[str, Any]] = None) -> Dict[str, Any]:
     termdesc: Optional[sdoterm.SdoTerm] = sdotermsource.SdoTermSource.getTerm(tid)
     if not termdesc:
         return term or {}
-    if term is None:
-        term = {}
-    term["@type"] = "rdfs:Class"
-    term["@id"] = f"schema:{termdesc.id}"
-    term["name"] = termdesc.label
+
+    term_dict: Dict[str, Any] = term if term is not None else {}
+    term_dict.update({
+        "@type": "rdfs:Class",
+        "@id": f"schema:{termdesc.id}",
+        "name": termdesc.label,
+        "description": textutils.ShortenOnSentence(textutils.StripHtmlTags(termdesc.comment))
+    })
+
     if termdesc.supers:
-        sups: List[str] = []
-        for sup in termdesc.supers.ids:
-            sups.append(f"schema:{sup}")
-        if len(sups) == 1:
-            term["rdfs:subClassOf"] = sups[0]
-        else:
-            term["rdfs:subClassOf"] = sups
-    term["description"] = textutils.ShortenOnSentence(
-        textutils.StripHtmlTags(termdesc.comment)
-    )
+        sups: List[str] = [f"schema:{sup}" for sup in termdesc.supers.ids]
+        term_dict["rdfs:subClassOf"] = sups[0] if len(sups) == 1 else sups
+
     if termdesc.pending:
-        term["pending"] = True
+        term_dict["pending"] = True
     if termdesc.retired:
-        term["attic"] = True
-    if tid not in VISITLIST:
-        VISITLIST.append(tid)
+        term_dict["attic"] = True
+
+    if tid not in visitset:
+        visitset.add(tid)
         if termdesc.subs:
-            subs: List[Dict[str, Any]] = []
-            for sub in termdesc.subs.ids:
-                subs.append(_jsonldtree(sub))
-            term["children"] = subs
-    return term
+            term_dict["children"] = [_jsonldtree(sub, visitset) for sub in termdesc.subs.ids]
+    return term_dict
 
 
 def httpequivs(page: str) -> str:
@@ -130,12 +117,11 @@ def httpequivs(page: str) -> str:
 
 def owl(page: str) -> str:
     from software.util.sdoowl import OwlBuild
-
     return str(OwlBuild().getContent())
 
 
 def sitemap(page: str) -> str:
-    version_date: str = schemaversion.getCurrentVersionDate()
+    version_date: str = str(schemaversion.getCurrentVersionDate() or "")
     def node(t: str) -> str:
         return f""" <url>
    <loc>https://schema.org/{t}</loc>
@@ -143,176 +129,124 @@ def sitemap(page: str) -> str:
  </url>
 """
     STATICPAGES: List[str] = [
-        "docs/schemas.html",
-        "docs/full.html",
-        "docs/gs.html",
-        "docs/about.html",
-        "docs/howwework.html",
-        "docs/releases.html",
-        "docs/faq.html",
-        "docs/datamodel.html",
-        "docs/developers.html",
-        "docs/extension.html",
-        "docs/meddocs.html",
-        "docs/hotels.html",
+        "docs/schemas.html", "docs/full.html", "docs/gs.html", "docs/about.html",
+        "docs/howwework.html", "docs/releases.html", "docs/faq.html",
+        "docs/datamodel.html", "docs/developers.html", "docs/extension.html",
+        "docs/meddocs.html", "docs/hotels.html",
     ]
 
-    output: List[str] = []
-    output.append("""<?xml version="1.0" encoding="utf-8"?>
-<urlset xmlns="http://www.sitemaps.org/schemas/sitemap/0.9">
-""")
-    terms: List[str] = sdotermsource.SdoTermSource.getAllTerms(suppressSourceLinks=True)
-    for term in sorted(terms):
-        if not (str(term).startswith("http://") or str(term).startswith("https://")):
+    output: List[str] = ['<?xml version="1.0" encoding="utf-8"?>\n<urlset xmlns="http://www.sitemaps.org/schemas/sitemap/0.9">\n']
+    terms: Sequence[Union[str, sdoterm.SdoTerm]] = sdotermsource.SdoTermSource.getAllTerms(suppressSourceLinks=True)
+    term: Union[str, sdoterm.SdoTerm]
+    for term in sorted(map(str, terms)):
+        if not term.startswith(("http://", "https://")):
             output.append(node(term))
-    for term in STATICPAGES:
-        output.append(node(term))
+    p: str
+    for p in STATICPAGES:
+        output.append(node(p))
     output.append("</urlset>\n")
     return "".join(output)
 
 
 def protocolSwap(content: str, protocol: str, altprotocol: str) -> str:
     ret: str = content.replace(f"{protocol}://schema.org", f"{altprotocol}://schema.org")
-    for ext in ["attic", "auto", "bib", "health-lifesci", "meta", "pending"]:
-        ret = ret.replace(
-            f"{protocol}://{ext}.schema.org",
-            f"{altprotocol}://{ext}.schema.org",
-        )
+    extensions: List[str] = ["attic", "auto", "bib", "health-lifesci", "meta", "pending"]
+    ext: str
+    for ext in extensions:
+        ret = ret.replace(f"{protocol}://{ext}.schema.org", f"{altprotocol}://{ext}.schema.org")
     return ret
 
 
 def protocols() -> Tuple[str, str]:
     """Return the protocols (http, https) in order of priority."""
-    vocaburi: str = sdotermsource.SdoTermSource.vocabUri()
-    if vocaburi.startswith("https"):
-        return "https", "http"
-    return "http", "https"
+    return ("https", "http") if sdotermsource.SdoTermSource.vocabUri().startswith("https") else ("http", "https")
 
 
-allGraph: Optional[rdflib.Graph] = None
-currentGraph: Optional[rdflib.Graph] = None
+ALL_GRAPH: Optional[rdflib.Graph] = None
+CURRENT_GRAPH: Optional[rdflib.Graph] = None
 
 
 def exportrdf(exportType: str, subdirectory_path: Optional[str] = None) -> None:
-    global allGraph, currentGraph
+    global ALL_GRAPH, CURRENT_GRAPH
 
-    if not allGraph:
-        # The bindings need to be done for each graph
-        # as they are not copied over.
-        allGraph = rdflib.Graph()
-        allGraph.bind("schema", VOCABURI)
-        sdotermsource.bindNameSpaces(allGraph)
-        currentGraph = rdflib.Graph()
-        sdotermsource.bindNameSpaces(currentGraph)
-        currentGraph.bind("schema", VOCABURI)
+    if not ALL_GRAPH:
+        ALL_GRAPH = rdflib.Graph()
+        ALL_GRAPH.bind("schema", VOCABURI)
+        sdotermsource.bindNameSpaces(ALL_GRAPH)
 
-        # Loads triples AND the bindings you added to sourceGraph()
-        allGraph += sdotermsource.SdoTermSource.sourceGraph()
+        CURRENT_GRAPH = rdflib.Graph()
+        sdotermsource.bindNameSpaces(CURRENT_GRAPH)
+        CURRENT_GRAPH.bind("schema", VOCABURI)
 
-        protocol, altprotocol = protocols()
+        ALL_GRAPH += sdotermsource.SdoTermSource.sourceGraph()
+        protocol: str
+        protocol, _ = protocols()
 
         log.debug("Cleanup non schema org things.")
-        # We delete everything where Subject is not schema.org.
-        # Since we haven't created the new types yet, they are safe.
-        deloddtriples: str = """DELETE {?s ?p ?o}
-           WHERE {
-               ?s ?p ?o.
-               FILTER (! strstarts(str(?s), "%s://schema.org") ).
-           }""" % (protocol)
-        allGraph.update(deloddtriples)
+        ALL_GRAPH.update(f'DELETE {{?s ?p ?o}} WHERE {{ ?s ?p ?o. FILTER (! strstarts(str(?s), "{protocol}://schema.org") ). }}')
 
         log.debug("Generate Foreign types – SPARQL INSERT")
-        # Insert all the types and properties that are equivalent or inherited from.
-        insert_foreign_types: str = """
+        insert_foreign_types: str = f"""
         PREFIX rdf: <http://www.w3.org/1999/02/22-rdf-syntax-ns#>
         PREFIX rdfs: <http://www.w3.org/2000/01/rdf-schema#>
         PREFIX owl: <http://www.w3.org/2002/07/owl#>
-
-        INSERT {
-            ?classNode a rdfs:Class .
-            ?propNode a rdf:Property .
-        }
-        WHERE {
-            { # Find Foreign Classes
-                { ?s rdfs:subClassOf ?classNode } UNION { ?s owl:equivalentClass ?classNode }
-
-                FILTER (isURI(?classNode))
-                FILTER (?classNode != rdfs:Class)
-                FILTER (?classNode != owl:Class)
-                FILTER (?classNode != rdf:Property)
-                FILTER (!strstarts(str(?classNode), "%s://schema.org"))
-            }
-            UNION
-            { # Find Foreign Properties
-                { ?s rdfs:subPropertyOf ?propNode } UNION { ?s owl:equivalentProperty ?propNode }
-
-                FILTER (isURI(?propNode))
-                FILTER (?propNode != rdf:Property)
-                FILTER (?propNode != owl:ObjectProperty)
-                FILTER (?propNode != owl:DatatypeProperty)
-                FILTER (!strstarts(str(?propNode), "%s://schema.org"))
-            }
-        }
-        """ % (protocol, protocol)
-
-        allGraph.update(insert_foreign_types)
+        INSERT {{ ?classNode a rdfs:Class . ?propNode a rdf:Property . }}
+        WHERE {{
+            {{ {{ ?s rdfs:subClassOf ?classNode }} UNION {{ ?s owl:equivalentClass ?classNode }}
+                FILTER (isURI(?classNode) && ?classNode != rdfs:Class && ?classNode != owl:Class && ?classNode != rdf:Property && !strstarts(str(?classNode), "{protocol}://schema.org"))
+            }} UNION
+            {{ {{ ?s rdfs:subPropertyOf ?propNode }} UNION {{ ?s owl:equivalentProperty ?propNode }}
+                FILTER (isURI(?propNode) && ?propNode != rdf:Property && ?propNode != owl:ObjectProperty && ?propNode != owl:DatatypeProperty && !strstarts(str(?propNode), "{protocol}://schema.org"))
+            }}
+        }}"""
+        ALL_GRAPH.update(insert_foreign_types)
 
         log.debug("Merge")
-        currentGraph += allGraph
+        assert CURRENT_GRAPH is not None
+        CURRENT_GRAPH += ALL_GRAPH
 
         log.debug("Delete items from the attic")
-        delattic: str = """PREFIX schema: <%s://schema.org/>
-        DELETE {?s ?p ?o}
-        WHERE{
-          ?s ?p ?o;
-              schema:isPartOf <%s://attic.schema.org>.
-        }""" % (protocol, protocol)
-
-        currentGraph.update(delattic)
+        CURRENT_GRAPH.update(f'PREFIX schema: <{protocol}://schema.org/> DELETE {{?s ?p ?o}} WHERE{{ ?s ?p ?o; schema:isPartOf <{protocol}://attic.schema.org>. }}')
 
     formats: List[str] = ["json-ld", "turtle", "nt", "nquads", "rdf"]
-    extype: str = exportType[len("RDFExport.") :]
     if exportType == "RDFExports":
-        for output_format in sorted(formats):
-            _exportrdf(output_format, allGraph, currentGraph, subdirectory_path)
-    elif extype in formats:
-        _exportrdf(extype, allGraph, currentGraph, subdirectory_path)
+        fmt: str
+        for fmt in sorted(formats):
+            assert ALL_GRAPH is not None
+            assert CURRENT_GRAPH is not None
+            _exportrdf(fmt, ALL_GRAPH, CURRENT_GRAPH, subdirectory_path)
+    elif (extype := exportType[len("RDFExport."):]) in formats:
+        assert ALL_GRAPH is not None
+        assert CURRENT_GRAPH is not None
+        _exportrdf(extype, ALL_GRAPH, CURRENT_GRAPH, subdirectory_path)
     else:
-        raise Exception(f"Unknown export format: {exportType}")
-
-
-# Set of completed EDF exports.
-completed_rdf_exports: Set[str] = set()
+        raise ValueError(f"Unknown export format: {exportType}")
 
 
 def _exportrdf(output_format: str, all_graph: rdflib.Graph, current_graph: rdflib.Graph, subdirectory_path: Optional[str] = None) -> None:
+    protocol: str
+    altprotocol: str
     protocol, altprotocol = protocols()
-
-    if output_format in completed_rdf_exports:
-        return
-    else:
-        completed_rdf_exports.add(output_format)
-
     version: str = schemaversion.getVersion()
 
+    selector: str
     for selector in fileutils.FILESET_SELECTORS:
-        g: Union[rdflib.Graph, rdflib.Dataset]
-        if fileutils.isAll(selector):
-            g = all_graph
-        else:
-            g = current_graph
+        g: rdflib.Graph = all_graph if fileutils.isAll(selector) else current_graph
+        ns_mgr: rdflib.namespace.NamespaceManager = g.namespace_manager
+        g_can: rdflib.Graph = to_canonical_graph(g)
+        g_can.namespace_manager = ns_mgr
 
-        nsMgr = g.namespace_manager
-        g = to_canonical_graph(g)
-        g.namespace_manager = nsMgr
-
-        if output_format == "nquads":
-            gr: rdflib.Dataset = rdflib.Dataset()
-            qg: rdflib.Graph = gr.graph(rdflib.URIRef(f"{protocol}://schema.org/{version}"))
-            qg += g
-            g = gr
-
+        p: str
         for p in fileutils.FILESET_PROTOCOLS:
+            final_g: Union[rdflib.Graph, rdflib.Dataset] = g_can
+            if output_format == "nquads":
+                ds: rdflib.Dataset = rdflib.Dataset()
+                qg: rdflib.Graph = ds.graph(rdflib.URIRef(f"{p}://schema.org/{version}"))
+                trip: Tuple[rdflib.term.Node, rdflib.term.Node, rdflib.term.Node]
+                for trip in g_can:
+                    qg.add(trip)
+                final_g = ds
+
             fn: str = fileutils.releaseFilePath(
                 output_dir=schemaglobals.getOutputDir(),
                 version=version,
@@ -322,36 +256,31 @@ def _exportrdf(output_format: str, all_graph: rdflib.Graph, current_graph: rdfli
                 subdirectory_path=subdirectory_path,
             )
             with pretty_logger.BlockLog(logger=log, message=f"Exporting {fn}"):
-                fmt: str
-                if output_format == "rdf":
-                    fmt = "pretty-xml"
-                else:
-                    fmt = output_format
-                out: str = str(g.serialize(format=fmt, auto_compact=True, sort_keys=True, max_depth=1))
+                fmt: str = "pretty-xml" if output_format == "rdf" else output_format
+                out: str = str(final_g.serialize(format=fmt, auto_compact=True, sort_keys=True, max_depth=1))
+
                 if output_format in ("nt", "nquads"):
-                    out = f'{"\n".join(sorted(line.rstrip() for line in out.splitlines() if line.strip()))}\n'
-                if output_format == "rdf":
+                    out = "\n".join(sorted(line.rstrip() for line in out.splitlines() if line.strip())) + "\n"
+                elif output_format == "rdf":
                     try:
                         out = sort_xml(out)
                     except Exception as e:
                         log.warning(f"Failed to sort RDF XML: {e}")
-                if output_format == "json-ld":
+                elif output_format == "json-ld":
                     try:
-                        data: Any = json.loads(out)
-                        out = json.dumps(sort_dict(data), indent=2)
+                        out = json.dumps(sort_dict(json.loads(out)), indent=2)
                     except Exception as e:
                         log.warning(f"Failed to sort JSON-LD: {e}")
 
-                with open(fn, "w", encoding="utf8") as f:
-                    if p == altprotocol:
-                        out = protocolSwap(out, protocol, altprotocol)
-                    f.write(out)
+                content: str = out
+                if p != protocol:
+                    content = protocolSwap(out, protocol, altprotocol)
+
+                Path(fn).write_text(content, encoding="utf8")
 
 
 def array2str(values: List[str]) -> str:
-    if not values:
-        return ""
-    return ", ".join(values)
+    return ", ".join(values) if values else ""
 
 
 def uriwrap(thing: Any) -> str:
@@ -359,177 +288,80 @@ def uriwrap(thing: Any) -> str:
     if not thing:
         return ""
     if isinstance(thing, str):
-        if thing.startswith("http:") or thing.startswith("https:"):
-            return thing
-        return f"{VOCABURI}{thing}"
-    if isinstance(thing, sdoterm.SdoTermSequence):
-        return uriwrap(thing.ids)
-    if isinstance(thing, sdoterm.SdoTermOrId):
-        return uriwrap(thing.id)
-    if isinstance(thing, sdoterm.SdoTerm):
-        return uriwrap(thing.id)
+        return thing if thing.startswith(("http:", "https:")) else f"{VOCABURI}{thing}"
+    if isinstance(thing, (sdoterm.SdoTermSequence, sdoterm.SdoTermOrId, sdoterm.SdoTerm)):
+        return uriwrap(getattr(thing, "ids", getattr(thing, "id", None)))
     try:
         return array2str(sorted(map(uriwrap, thing)))
-    except TypeError as e:
+    except (TypeError, ValueError) as e:
         log.fatal(f"Cannot uriwrap {thing}:{e}")
         return ""
 
 
 def exportcsv(page: str) -> None:
+    protocol: str
+    altprotocol: str
     protocol, altprotocol = protocols()
+    type_fields: List[str] = ["id", "label", "comment", "subTypeOf", "enumerationtype", "equivalentClass", "properties", "subTypes", "supersedes", "supersededBy", "isPartOf"]
+    prop_fields: List[str] = ["id", "label", "comment", "subPropertyOf", "equivalentProperty", "subproperties", "domainIncludes", "rangeIncludes", "inverseOf", "supersedes", "supersededBy", "isPartOf"]
 
-    typeFields: List[str] = [
-        "id",
-        "label",
-        "comment",
-        "subTypeOf",
-        "enumerationtype",
-        "equivalentClass",
-        "properties",
-        "subTypes",
-        "supersedes",
-        "supersededBy",
-        "isPartOf",
-    ]
-    propFields: List[str] = [
-        "id",
-        "label",
-        "comment",
-        "subPropertyOf",
-        "equivalentProperty",
-        "subproperties",
-        "domainIncludes",
-        "rangeIncludes",
-        "inverseOf",
-        "supersedes",
-        "supersededBy",
-        "isPartOf",
-    ]
     typedata: List[Dict[str, str]] = []
-    typedataAll: List[Dict[str, str]] = []
+    typedata_all: List[Dict[str, str]] = []
     propdata: List[Dict[str, str]] = []
-    propdataAll: List[Dict[str, str]] = []
-    terms: List[sdoterm.SdoTerm] = sdotermsource.SdoTermSource.getAllTerms(
-        expanded=True, suppressSourceLinks=True
-    )
+    propdata_all: List[Dict[str, str]] = []
+    terms: Sequence[Union[str, sdoterm.SdoTerm]] = sdotermsource.SdoTermSource.getAllTerms(expanded=True, suppressSourceLinks=True)
+
+    term: Union[str, sdoterm.SdoTerm]
     for term in terms:
-        if not isinstance(term, sdoterm.SdoTerm):
+        if not isinstance(term, sdoterm.SdoTerm) or term.termType == sdoterm.SdoTermType.REFERENCE or term.id.startswith(("http://", "https://")):
             continue
-        if (
-            term.termType == sdoterm.SdoTermType.REFERENCE
-            or term.id.startswith("http://")
-            or term.id.startswith("https://")
-        ):
-            continue
-        row: Dict[str, str] = {}
-        row["id"] = term.uri
-        row["label"] = term.label
-        row["comment"] = term.comment
-        row["supersedes"] = uriwrap(term.supersedes)
-        row["supersededBy"] = uriwrap(term.supersededBy)
-        ext: str = term.extLayer
-        if len(ext):
-            ext = f"{protocol}://{ext}.schema.org"
-        row["isPartOf"] = ext
+
+        row: Dict[str, str] = {
+            "id": term.uri, "label": term.label, "comment": term.comment,
+            "supersedes": uriwrap(term.supersedes), "supersededBy": uriwrap(term.supersededBy),
+            "isPartOf": f"{protocol}://{term.extLayer}.schema.org" if term.extLayer else ""
+        }
+
         if term.termType == sdoterm.SdoTermType.PROPERTY:
-            row["subPropertyOf"] = uriwrap(term.supers)
-            row["equivalentProperty"] = uriwrap(term.equivalents.ids)
-            row["subproperties"] = uriwrap(term.subs.ids)
-            row["domainIncludes"] = uriwrap(term.domainIncludes.ids)
-            row["rangeIncludes"] = uriwrap(term.rangeIncludes.ids)
-            row["inverseOf"] = uriwrap(term.inverse.id)
-            propdataAll.append(row)
-            if not term.retired:
-                propdata.append(row)
+            row.update({
+                "subPropertyOf": uriwrap(term.supers), "equivalentProperty": uriwrap(term.equivalents.ids),
+                "subproperties": uriwrap(term.subs.ids), "domainIncludes": uriwrap(term.domainIncludes.ids),
+                "rangeIncludes": uriwrap(term.rangeIncludes.ids), "inverseOf": uriwrap(term.inverse.id)
+            })
+            propdata_all.append(row)
+            if not term.retired: propdata.append(row)
         else:
-            row["subTypeOf"] = uriwrap(term.supers.ids)
+            row.update({
+                "subTypeOf": uriwrap(term.supers.ids), "equivalentClass": uriwrap(term.equivalents.ids),
+                "subTypes": uriwrap(term.subs.ids)
+            })
             if term.termType == sdoterm.SdoTermType.ENUMERATIONVALUE:
                 row["enumerationtype"] = uriwrap(term.enumerationParent.id)
             else:
                 row["properties"] = uriwrap(term.allproperties.ids)
-            row["equivalentClass"] = uriwrap(term.equivalents.ids)
-            row["subTypes"] = uriwrap(term.subs.ids)
-            typedataAll.append(row)
-            if not term.retired:
-                typedata.append(row)
+            typedata_all.append(row)
+            if not term.retired: typedata.append(row)
 
-    writecsvout(
-        "properties",
-        propdata,
-        propFields,
-        fileutils.FileSelector.CURRENT,
-        protocol,
-        altprotocol,
-    )
-    writecsvout(
-        "properties",
-        propdataAll,
-        propFields,
-        fileutils.FileSelector.ALL,
-        protocol,
-        altprotocol,
-    )
-    writecsvout(
-        "types",
-        typedata,
-        typeFields,
-        fileutils.FileSelector.CURRENT,
-        protocol,
-        altprotocol,
-    )
-    writecsvout(
-        "types",
-        typedataAll,
-        typeFields,
-        fileutils.FileSelector.ALL,
-        protocol,
-        altprotocol,
-    )
+    writecsvout("properties", propdata, prop_fields, fileutils.FileSelector.CURRENT, protocol, altprotocol)
+    writecsvout("properties", propdata_all, prop_fields, fileutils.FileSelector.ALL, protocol, altprotocol)
+    writecsvout("types", typedata, type_fields, fileutils.FileSelector.CURRENT, protocol, altprotocol)
+    writecsvout("types", typedata_all, type_fields, fileutils.FileSelector.ALL, protocol, altprotocol)
 
 
 def writecsvout(ftype: str, data: List[Dict[str, str]], fields: List[str], selector: Union[fileutils.FileSelector, str], protocol: str, altprotocol: str) -> None:
     version: str = schemaversion.getVersion()
-    fn: str = fileutils.releaseFilePath(
-        output_dir=schemaglobals.getOutputDir(),
-        version=version,
-        selector=selector,
-        protocol=protocol,
-        suffix=ftype,
-        output_format="csv",
-    )
-    afn: str = fileutils.releaseFilePath(
-        output_dir=schemaglobals.getOutputDir(),
-        version=version,
-        selector=selector,
-        protocol=altprotocol,
-        suffix=ftype,
-        output_format="csv",
-    )
+    paths: List[str] = [fileutils.releaseFilePath(output_dir=schemaglobals.getOutputDir(), version=version, selector=selector, protocol=p, suffix=ftype, output_format="csv") for p in (protocol, altprotocol)]
 
-    with pretty_logger.BlockLog(
-        message=f"Preparing files {ftype}: {fn} and {afn}.", logger=log
-    ):
-        # Create the original version in memory.
+    with pretty_logger.BlockLog(message=f"Preparing files {ftype}: {paths[0]} and {paths[1]}.", logger=log):
         csv_data: str
-        with io.StringIO() as csv_buffer:
-            writer: csv.DictWriter = csv.DictWriter(
-                csv_buffer,
-                fieldnames=fields,
-                quoting=csv.QUOTE_ALL,
-                lineterminator="\n",
-            )
+        with io.StringIO() as buffer:
+            writer: csv.DictWriter = csv.DictWriter(buffer, fieldnames=fields, quoting=csv.QUOTE_ALL, lineterminator="\n")
             writer.writeheader()
-            for row in data:
-                writer.writerow(row)
-            csv_data = csv_buffer.getvalue()
+            writer.writerows(data)
+            csv_data = buffer.getvalue()
 
-        with open(fn, "w", encoding="utf8") as file_handle:
-            file_handle.write(csv_data)
-
-        with open(afn, "w", encoding="utf8") as file_handle:
-            file_handle.write(
-                protocolSwap(csv_data, protocol=protocol, altprotocol=altprotocol)
-            )
+        Path(paths[0]).write_text(csv_data, encoding="utf8")
+        Path(paths[1]).write_text(protocolSwap(csv_data, protocol, altprotocol), encoding="utf8")
 
 
 def jsoncounts(page: str) -> str:
@@ -539,18 +371,21 @@ def jsoncounts(page: str) -> str:
 
 
 def jsonpcounts(page: str) -> str:
-    content: str = f"""
-    COUNTS = '{jsoncounts(page)}';
-
-    insertschemacounts ( COUNTS );
-    """
-    return content
+    return f"\n    COUNTS = '{jsoncounts(page)}';\n\n    insertschemacounts ( COUNTS );\n    "
 
 
 def exportshex_shacl(page: str) -> None:
-    release_dir: Path = Path.cwd() / schemaglobals.RELEASE_DIR / schemaversion.getVersion()
+    version: str = schemaversion.getVersion()
+    release_dir: Path = Path.cwd() / schemaglobals.RELEASE_DIR / version
+    nt_path: Path = release_dir / "schemaorg-all-http.nt"
+
+    if not nt_path.exists():
+        log.info(f"Generating missing {nt_path} for Shex_Shacl")
+        assert ALL_GRAPH is not None
+        _exportrdf("nt", ALL_GRAPH, CURRENT_GRAPH or ALL_GRAPH)
+
     shex_shacl_shapes_exporter.generate_files(
-        term_defs_path=release_dir / "schemaorg-all-http.nt",
+        term_defs_path=nt_path,
         outputdir=release_dir,
         outputfileprefix="schemaorg-",
     )
@@ -560,30 +395,13 @@ def examples(page: str) -> str:
     return str(schemaexamples.SchemaExamples.allExamplesSerialised())
 
 
-FILELIST: Dict[str, Tuple[Any, List[str]]] = {
-    "Context": (
-        jsonldcontext,
-        [
-            "docs/jsonldcontext.jsonld",
-            "docs/jsonldcontext.json",
-            "docs/jsonldcontext.json.txt",
-            f"releases/{schemaversion.getVersion()}/schemaorgcontext.jsonld",
-        ],
-    ),
+FILELIST: Dict[str, Tuple[Callable[[str], Any], List[str]]] = {
+    "Context": (jsonldcontext, ["docs/jsonldcontext.jsonld", "docs/jsonldcontext.json", "docs/jsonldcontext.json.txt", f"releases/{schemaversion.getVersion()}/schemaorgcontext.jsonld"]),
     "Tree": (jsonldtree, ["docs/tree.jsonld"]),
     "jsoncounts": (jsoncounts, ["docs/jsoncounts.json"]),
     "jsonpcounts": (jsonpcounts, ["docs/jsonpcounts.js"]),
-    "Owl": (
-        owl,
-        [
-            "docs/schemaorg.owl",
-            f"releases/{schemaversion.getVersion()}/schemaorg.owl",
-        ],
-    ),
-    "Httpequivs": (
-        httpequivs,
-        [f"releases/{schemaversion.getVersion()}/httpequivs.ttl"],
-    ),
+    "Owl": (owl, ["docs/schemaorg.owl", f"releases/{schemaversion.getVersion()}/schemaorg.owl"]),
+    "Httpequivs": (httpequivs, [f"releases/{schemaversion.getVersion()}/httpequivs.ttl"]),
     "Sitemap": (sitemap, ["docs/sitemap.xml"]),
     "RDFExports": (exportrdf, [""]),
     "RDFExport.turtle": (exportrdf, [""]),
@@ -593,41 +411,52 @@ FILELIST: Dict[str, Tuple[Any, List[str]]] = {
     "RDFExport.json-ld": (exportrdf, [""]),
     "Shex_Shacl": (exportshex_shacl, [""]),
     "CSVExports": (exportcsv, [""]),
-    "Examples": (
-        examples,
-        [f"releases/{schemaversion.getVersion()}/schemaorg-all-examples.txt"],
-    ),
+    "Examples": (examples, [f"releases/{schemaversion.getVersion()}/schemaorg-all-examples.txt"]),
 }
 
 
-def buildFiles(files: List[str]) -> None:
-    log.debug("Initalizing Mardown")
+def buildFiles(files: Iterable[str]) -> None:
     software.SchemaTerms.localmarkdown.MarkdownTool.setWikilinkCssClass("localLink")
-    software.SchemaTerms.localmarkdown.MarkdownTool.setWikilinkPrePath(
-        "https://schema.org/"
-    )
-    # Production site uses no suffix in link - mapping to file done in server config
+    software.SchemaTerms.localmarkdown.MarkdownTool.setWikilinkPrePath("https://schema.org/")
     software.SchemaTerms.localmarkdown.MarkdownTool.setWikilinkPostPath("")
 
-    if any(filter(fileutils.isAll, files)):
-        files = sorted(FILELIST.keys())
+    targets: List[str] = sorted(FILELIST.keys()) if any(fileutils.isAll(f) for f in files) else list(files)
 
-    for p in files:
-        with pretty_logger.BlockLog(message=f"Preparing file {p}.", logger=log):
-            if p in sorted(FILELIST.keys()):
-                entry: Optional[Tuple[Any, List[str]]] = FILELIST.get(p, None)
-                if entry:
-                    func, filenames = entry
-                    content: Any = func(p)
-                    if content:
-                        for filename in filenames:
-                            if not filename:
-                                continue
-                            fn: str = absoluteFilePath(filename)
-                            with open(fn, "w", encoding="utf8") as handle:
-                                handle.write(str(content))
-            else:
-                log.warning(f"Unknown files name: {p}")
+    process_files: List[str] = []
+    seen: Set[str] = set()
+    t: str
+    for t in targets:
+        if t not in seen:
+            process_files.append(t)
+            seen.add(t)
+
+    if "Shex_Shacl" in seen:
+        if "RDFExport.nt" not in seen and "RDFExports" not in seen:
+            process_files.insert(0, "RDFExport.nt")
+
+    if "Shex_Shacl" in seen:
+        process_files.remove("Shex_Shacl")
+        process_files.append("Shex_Shacl")
+
+    if "RDFExports" in seen and "RDFExport.nt" in seen:
+         process_files.remove("RDFExport.nt")
+         process_files.insert(0, "RDFExport.nt")
+
+    p: str
+    for p in process_files:
+        if entry := FILELIST.get(p):
+            func: Callable[[str], Any]
+            filenames: List[str]
+            func, filenames = entry
+            with pretty_logger.BlockLog(message=f"Preparing file {p}.", logger=log):
+                content: Any = func(p)
+                if content:
+                    fn: str
+                    for fn in filenames:
+                        if fn:
+                            Path(absoluteFilePath(fn)).write_text(str(content), encoding="utf8")
+        else:
+            log.warning(f"Unknown files name: {p}")
 
 
 if __name__ == "__main__":

--- a/software/util/buildfiles.py
+++ b/software/util/buildfiles.py
@@ -8,6 +8,7 @@ import json
 import logging
 import os
 from pathlib import Path
+from typing import Any, Dict, List, Optional, Tuple, Union, Set
 import rdflib
 import rdflib.namespace
 import sys
@@ -32,70 +33,74 @@ import software.SchemaTerms.sdoterm as sdoterm
 import software.SchemaExamples.schemaexamples as schemaexamples
 from software.util.sort_dict import sort_dict, sort_xml
 
-VOCABURI = sdotermsource.SdoTermSource.vocabUri()
+VOCABURI: str = sdotermsource.SdoTermSource.vocabUri()
 
-log = logging.getLogger(__name__)
+log: logging.Logger = logging.getLogger(__name__)
 
+VISITLIST: List[str] = []
 
-def buildTurtleEquivs():
+def buildTurtleEquivs() -> str:
     """Build equivalences to"""
-    s_p = "http://schema.org/"
-    s_s = "https://schema.org/"
-    outGraph = rdflib.Graph()
+    s_p: str = "http://schema.org/"
+    s_s: str = "https://schema.org/"
+    outGraph: rdflib.Graph = rdflib.Graph()
     outGraph.bind("schema_p", s_p)
     outGraph.bind("schema_s", s_s)
     outGraph.bind("owl", rdflib.namespace.OWL)
 
-    for t in sdotermsource.SdoTermSource.getAllTerms(expanded=True):
+    all_terms: List[sdoterm.SdoTerm] = sdotermsource.SdoTermSource.getAllTerms(expanded=True)
+    for t in all_terms:
         if not t.retired:  # drops non-schema terms and those in attic
-            eqiv = rdflib.namespace.OWL.equivalentClass
+            eqiv: rdflib.term.URIRef = rdflib.namespace.OWL.equivalentClass
             if t.termType == sdoterm.SdoTermType.PROPERTY:
                 eqiv = rdflib.namespace.OWL.equivalentProperty
 
-            p = rdflib.URIRef(s_p + t.id)
-            s = rdflib.URIRef(s_s + t.id)
+            p: rdflib.URIRef = rdflib.URIRef(s_p + t.id)
+            s: rdflib.URIRef = rdflib.URIRef(s_s + t.id)
             outGraph.add((p, eqiv, s))
             outGraph.add((s, eqiv, p))
             log.debug("%s ", t.uri)
 
-    return outGraph.serialize(format="turtle", auto_compact=True, sort_keys=True)
+    return str(outGraph.serialize(format="turtle", auto_compact=True, sort_keys=True))
 
 
-def absoluteFilePath(fn):
-    name = os.path.join(schemaglobals.OUTPUTDIR, fn)
+def absoluteFilePath(fn: str) -> str:
+    name: str = os.path.join(schemaglobals.OUTPUTDIR, fn)
     fileutils.checkFilePath(os.path.dirname(name))
     return name
 
 
-def jsonldcontext(page):
-    return sdojsonldcontext.getContext()
+def jsonldcontext(page: str) -> str:
+    return str(sdojsonldcontext.getContext())
 
 
-def jsonldtree(page):
+def jsonldtree(page: str) -> str:
     global VISITLIST
     VISITLIST = []
 
-    term = {}
-    context = {}
+    term: Dict[str, Any] = {}
+    context: Dict[str, Any] = {}
     context["rdfs"] = "http://www.w3.org/2000/01/rdf-schema#"
     context["schema"] = "https://schema.org"
     context["rdfs:subClassOf"] = {"@type": "@id"}
     context["description"] = "rdfs:comment"
     context["children"] = {"@reverse": "rdfs:subClassOf"}
     term["@context"] = context
-    data = _jsonldtree("Thing", term)
+    data: Dict[str, Any] = _jsonldtree("Thing", term)
     return json.dumps(sort_dict(data), indent=3)
 
 
-def _jsonldtree(tid, term=None):
-    termdesc = sdotermsource.SdoTermSource.getTerm(tid)
-    if not term:
+def _jsonldtree(tid: str, term: Optional[Dict[str, Any]] = None) -> Dict[str, Any]:
+    termdesc: Optional[sdoterm.SdoTerm] = sdotermsource.SdoTermSource.getTerm(tid)
+    if not termdesc:
+        return term or {}
+    if term is None:
         term = {}
     term["@type"] = "rdfs:Class"
     term["@id"] = "schema:" + termdesc.id
     term["name"] = termdesc.label
     if termdesc.supers:
-        sups = []
+        sups: List[str] = []
         for sup in termdesc.supers.ids:
             sups.append("schema:" + sup)
         if len(sups) == 1:
@@ -112,30 +117,30 @@ def _jsonldtree(tid, term=None):
     if tid not in VISITLIST:
         VISITLIST.append(tid)
         if termdesc.subs:
-            subs = []
+            subs: List[Dict[str, Any]] = []
             for sub in termdesc.subs.ids:
                 subs.append(_jsonldtree(sub))
             term["children"] = subs
     return term
 
 
-def httpequivs(page):
+def httpequivs(page: str) -> str:
     return buildTurtleEquivs()
 
 
-def owl(page):
-    from sdoowl import OwlBuild
+def owl(page: str) -> str:
+    from software.util.sdoowl import OwlBuild
 
-    return OwlBuild().getContent()
+    return str(OwlBuild().getContent())
 
 
-def sitemap(page):
-    node = """ <url>
+def sitemap(page: str) -> str:
+    node: str = """ <url>
    <loc>https://schema.org/%s</loc>
    <lastmod>%s</lastmod>
  </url>
 """
-    STATICPAGES = [
+    STATICPAGES: List[str] = [
         "docs/schemas.html",
         "docs/full.html",
         "docs/gs.html",
@@ -150,14 +155,14 @@ def sitemap(page):
         "docs/hotels.html",
     ]
 
-    output = []
+    output: List[str] = []
     output.append("""<?xml version="1.0" encoding="utf-8"?>
 <urlset xmlns="http://www.sitemaps.org/schemas/sitemap/0.9">
 """)
-    terms = sdotermsource.SdoTermSource.getAllTerms(suppressSourceLinks=True)
-    version_date = schemaversion.getCurrentVersionDate()
+    terms: List[str] = sdotermsource.SdoTermSource.getAllTerms(suppressSourceLinks=True)
+    version_date: str = schemaversion.getCurrentVersionDate()
     for term in sorted(terms):
-        if not (term.startswith("http://") or term.startswith("https://")):
+        if not (str(term).startswith("http://") or str(term).startswith("https://")):
             output.append(node % (term, version_date))
     for term in STATICPAGES:
         output.append(node % (term, version_date))
@@ -165,8 +170,8 @@ def sitemap(page):
     return "".join(output)
 
 
-def protocolSwap(content, protocol, altprotocol):
-    ret = content.replace("%s://schema.org" % protocol, "%s://schema.org" % altprotocol)
+def protocolSwap(content: str, protocol: str, altprotocol: str) -> str:
+    ret: str = content.replace("%s://schema.org" % protocol, "%s://schema.org" % altprotocol)
     for ext in ["attic", "auto", "bib", "health-lifesci", "meta", "pending"]:
         ret = ret.replace(
             "%s://%s.schema.org" % (protocol, ext),
@@ -175,19 +180,19 @@ def protocolSwap(content, protocol, altprotocol):
     return ret
 
 
-def protocols():
+def protocols() -> Tuple[str, str]:
     """Return the protocols (http, https) in order of priority."""
-    vocaburi = sdotermsource.SdoTermSource.vocabUri()
+    vocaburi: str = sdotermsource.SdoTermSource.vocabUri()
     if vocaburi.startswith("https"):
         return "https", "http"
     return "http", "https"
 
 
-allGraph = None
-currentGraph = None
+allGraph: Optional[rdflib.Graph] = None
+currentGraph: Optional[rdflib.Graph] = None
 
 
-def exportrdf(exportType, subdirectory_path=None):
+def exportrdf(exportType: str, subdirectory_path: Optional[str] = None) -> None:
     global allGraph, currentGraph
 
     if not allGraph:
@@ -208,7 +213,7 @@ def exportrdf(exportType, subdirectory_path=None):
         log.debug("Cleanup non schema org things.")
         # We delete everything where Subject is not schema.org.
         # Since we haven't created the new types yet, they are safe.
-        deloddtriples = """DELETE {?s ?p ?o}
+        deloddtriples: str = """DELETE {?s ?p ?o}
            WHERE {
                ?s ?p ?o.
                FILTER (! strstarts(str(?s), "%s://schema.org") ).
@@ -217,7 +222,7 @@ def exportrdf(exportType, subdirectory_path=None):
 
         log.debug("Generate Foreign types – SPARQL INSERT")
         # Insert all the types and properties that are equivalent or inherited from.
-        insert_foreign_types = """
+        insert_foreign_types: str = """
         PREFIX rdf: <http://www.w3.org/1999/02/22-rdf-syntax-ns#>
         PREFIX rdfs: <http://www.w3.org/2000/01/rdf-schema#>
         PREFIX owl: <http://www.w3.org/2002/07/owl#>
@@ -255,7 +260,7 @@ def exportrdf(exportType, subdirectory_path=None):
         currentGraph += allGraph
 
         log.debug("Delete items from the attic")
-        delattic = """PREFIX schema: <%s://schema.org/>
+        delattic: str = """PREFIX schema: <%s://schema.org/>
         DELETE {?s ?p ?o}
         WHERE{
           ?s ?p ?o;
@@ -264,8 +269,8 @@ def exportrdf(exportType, subdirectory_path=None):
 
         currentGraph.update(delattic)
 
-    formats = ["json-ld", "turtle", "nt", "nquads", "rdf"]
-    extype = exportType[len("RDFExport.") :]
+    formats: List[str] = ["json-ld", "turtle", "nt", "nquads", "rdf"]
+    extype: str = exportType[len("RDFExport.") :]
     if exportType == "RDFExports":
         for output_format in sorted(formats):
             _exportrdf(output_format, allGraph, currentGraph, subdirectory_path)
@@ -276,10 +281,10 @@ def exportrdf(exportType, subdirectory_path=None):
 
 
 # Set of completed EDF exports.
-completed_rdf_exports = set()
+completed_rdf_exports: Set[str] = set()
 
 
-def _exportrdf(output_format, all_graph, current_graph, subdirectory_path=None):
+def _exportrdf(output_format: str, all_graph: rdflib.Graph, current_graph: rdflib.Graph, subdirectory_path: Optional[str] = None) -> None:
     protocol, altprotocol = protocols()
 
     if output_format in completed_rdf_exports:
@@ -287,9 +292,10 @@ def _exportrdf(output_format, all_graph, current_graph, subdirectory_path=None):
     else:
         completed_rdf_exports.add(output_format)
 
-    version = schemaversion.getVersion()
+    version: str = schemaversion.getVersion()
 
     for selector in fileutils.FILESET_SELECTORS:
+        g: Union[rdflib.Graph, rdflib.Dataset]
         if fileutils.isAll(selector):
             g = all_graph
         else:
@@ -300,13 +306,13 @@ def _exportrdf(output_format, all_graph, current_graph, subdirectory_path=None):
         g.namespace_manager = nsMgr
 
         if output_format == "nquads":
-            gr = rdflib.Dataset()
-            qg = gr.graph(rdflib.URIRef("%s://schema.org/%s" % (protocol, version)))
+            gr: rdflib.Dataset = rdflib.Dataset()
+            qg: rdflib.Graph = gr.graph(rdflib.URIRef("%s://schema.org/%s" % (protocol, version)))
             qg += g
             g = gr
 
         for p in fileutils.FILESET_PROTOCOLS:
-            fn = fileutils.releaseFilePath(
+            fn: str = fileutils.releaseFilePath(
                 output_dir=schemaglobals.getOutputDir(),
                 version=version,
                 selector=selector,
@@ -315,11 +321,12 @@ def _exportrdf(output_format, all_graph, current_graph, subdirectory_path=None):
                 subdirectory_path=subdirectory_path,
             )
             with pretty_logger.BlockLog(logger=log, message=f"Exporting {fn}"):
+                fmt: str
                 if output_format == "rdf":
                     fmt = "pretty-xml"
                 else:
                     fmt = output_format
-                out = g.serialize(format=fmt, auto_compact=True, sort_keys=True, max_depth=1)
+                out: str = str(g.serialize(format=fmt, auto_compact=True, sort_keys=True, max_depth=1))
                 if output_format in ("nt", "nquads"):
                     out = "\n".join(sorted(line.rstrip() for line in out.splitlines() if line.strip())) + "\n"
                 if output_format == "rdf":
@@ -329,7 +336,7 @@ def _exportrdf(output_format, all_graph, current_graph, subdirectory_path=None):
                         log.warning(f"Failed to sort RDF XML: {e}")
                 if output_format == "json-ld":
                     try:
-                        data = json.loads(out)
+                        data: Any = json.loads(out)
                         out = json.dumps(sort_dict(data), indent=2)
                     except Exception as e:
                         log.warning(f"Failed to sort JSON-LD: {e}")
@@ -340,13 +347,13 @@ def _exportrdf(output_format, all_graph, current_graph, subdirectory_path=None):
                     f.write(out)
 
 
-def array2str(values):
+def array2str(values: List[str]) -> str:
     if not values:
         return ""
     return ", ".join(values)
 
 
-def uriwrap(thing):
+def uriwrap(thing: Any) -> str:
     """Convert various types into uris. Sorts items if they are a list."""
     if not thing:
         return ""
@@ -364,12 +371,13 @@ def uriwrap(thing):
         return array2str(sorted(map(uriwrap, thing)))
     except TypeError as e:
         log.fatal("Cannot uriwrap %s:%s", thing, e)
+        return ""
 
 
-def exportcsv(page):
+def exportcsv(page: str) -> None:
     protocol, altprotocol = protocols()
 
-    typeFields = [
+    typeFields: List[str] = [
         "id",
         "label",
         "comment",
@@ -382,7 +390,7 @@ def exportcsv(page):
         "supersededBy",
         "isPartOf",
     ]
-    propFields = [
+    propFields: List[str] = [
         "id",
         "label",
         "comment",
@@ -396,27 +404,29 @@ def exportcsv(page):
         "supersededBy",
         "isPartOf",
     ]
-    typedata = []
-    typedataAll = []
-    propdata = []
-    propdataAll = []
-    terms = sdotermsource.SdoTermSource.getAllTerms(
+    typedata: List[Dict[str, str]] = []
+    typedataAll: List[Dict[str, str]] = []
+    propdata: List[Dict[str, str]] = []
+    propdataAll: List[Dict[str, str]] = []
+    terms: List[sdoterm.SdoTerm] = sdotermsource.SdoTermSource.getAllTerms(
         expanded=True, suppressSourceLinks=True
     )
     for term in terms:
+        if not isinstance(term, sdoterm.SdoTerm):
+            continue
         if (
             term.termType == sdoterm.SdoTermType.REFERENCE
             or term.id.startswith("http://")
             or term.id.startswith("https://")
         ):
             continue
-        row = {}
+        row: Dict[str, str] = {}
         row["id"] = term.uri
         row["label"] = term.label
         row["comment"] = term.comment
         row["supersedes"] = uriwrap(term.supersedes)
         row["supersededBy"] = uriwrap(term.supersededBy)
-        ext = term.extLayer
+        ext: str = term.extLayer
         if len(ext):
             ext = "%s://%s.schema.org" % (protocol, ext)
         row["isPartOf"] = ext
@@ -476,9 +486,9 @@ def exportcsv(page):
     )
 
 
-def writecsvout(ftype, data, fields, selector, protocol, altprotocol):
-    version = schemaversion.getVersion()
-    fn = fileutils.releaseFilePath(
+def writecsvout(ftype: str, data: List[Dict[str, str]], fields: List[str], selector: Union[fileutils.FileSelector, str], protocol: str, altprotocol: str) -> None:
+    version: str = schemaversion.getVersion()
+    fn: str = fileutils.releaseFilePath(
         output_dir=schemaglobals.getOutputDir(),
         version=version,
         selector=selector,
@@ -486,7 +496,7 @@ def writecsvout(ftype, data, fields, selector, protocol, altprotocol):
         suffix=ftype,
         output_format="csv",
     )
-    afn = fileutils.releaseFilePath(
+    afn: str = fileutils.releaseFilePath(
         output_dir=schemaglobals.getOutputDir(),
         version=version,
         selector=selector,
@@ -499,8 +509,9 @@ def writecsvout(ftype, data, fields, selector, protocol, altprotocol):
         message=f"Preparing files {ftype}: {fn} and {afn}.", logger=log
     ):
         # Create the original version in memory.
+        csv_data: str
         with io.StringIO() as csv_buffer:
-            writer = csv.DictWriter(
+            writer: csv.DictWriter = csv.DictWriter(
                 csv_buffer,
                 fieldnames=fields,
                 quoting=csv.QUOTE_ALL,
@@ -509,25 +520,25 @@ def writecsvout(ftype, data, fields, selector, protocol, altprotocol):
             writer.writeheader()
             for row in data:
                 writer.writerow(row)
-            data = csv_buffer.getvalue()
+            csv_data = csv_buffer.getvalue()
 
         with open(fn, "w", encoding="utf8") as file_handle:
-            file_handle.write(data)
+            file_handle.write(csv_data)
 
         with open(afn, "w", encoding="utf8") as file_handle:
             file_handle.write(
-                protocolSwap(data, protocol=protocol, altprotocol=altprotocol)
+                protocolSwap(csv_data, protocol=protocol, altprotocol=altprotocol)
             )
 
 
-def jsoncounts(page):
-    counts = sdotermsource.SdoTermSource.termCounts()
+def jsoncounts(page: str) -> str:
+    counts: Dict[str, Any] = sdotermsource.SdoTermSource.termCounts()
     counts["schemaorgversion"] = schemaversion.getVersion()
     return json.dumps(sort_dict(counts))
 
 
-def jsonpcounts(page):
-    content = """
+def jsonpcounts(page: str) -> str:
+    content: str = """
     COUNTS = '%s';
 
     insertschemacounts ( COUNTS );
@@ -535,8 +546,8 @@ def jsonpcounts(page):
     return content
 
 
-def exportshex_shacl(page):
-    release_dir = Path.cwd() / schemaglobals.RELEASE_DIR / schemaversion.getVersion()
+def exportshex_shacl(page: str) -> None:
+    release_dir: Path = Path.cwd() / schemaglobals.RELEASE_DIR / schemaversion.getVersion()
     shex_shacl_shapes_exporter.generate_files(
         term_defs_path=release_dir / "schemaorg-all-http.nt",
         outputdir=release_dir,
@@ -544,11 +555,11 @@ def exportshex_shacl(page):
     )
 
 
-def examples(page):
-    return schemaexamples.SchemaExamples.allExamplesSerialised()
+def examples(page: str) -> str:
+    return str(schemaexamples.SchemaExamples.allExamplesSerialised())
 
 
-FILELIST = {
+FILELIST: Dict[str, Tuple[Any, List[str]]] = {
     "Context": (
         jsonldcontext,
         [
@@ -588,7 +599,7 @@ FILELIST = {
 }
 
 
-def buildFiles(files):
+def buildFiles(files: List[str]) -> None:
     log.debug("Initalizing Mardown")
     software.SchemaTerms.localmarkdown.MarkdownTool.setWikilinkCssClass("localLink")
     software.SchemaTerms.localmarkdown.MarkdownTool.setWikilinkPrePath(
@@ -603,14 +614,17 @@ def buildFiles(files):
     for p in files:
         with pretty_logger.BlockLog(message=f"Preparing file {p}.", logger=log):
             if p in sorted(FILELIST.keys()):
-                func, filenames = FILELIST.get(p, None)
-                if func:
-                    content = func(p)
+                entry: Optional[Tuple[Any, List[str]]] = FILELIST.get(p, None)
+                if entry:
+                    func, filenames = entry
+                    content: Any = func(p)
                     if content:
                         for filename in filenames:
-                            fn = absoluteFilePath(filename)
+                            if not filename:
+                                continue
+                            fn: str = absoluteFilePath(filename)
                             with open(fn, "w", encoding="utf8") as handle:
-                                handle.write(content)
+                                handle.write(str(content))
             else:
                 log.warning("Unknown files name: %s" % p)
 

--- a/software/util/buildfiles.py
+++ b/software/util/buildfiles.py
@@ -55,11 +55,11 @@ def buildTurtleEquivs() -> str:
             if t.termType == sdoterm.SdoTermType.PROPERTY:
                 eqiv = rdflib.namespace.OWL.equivalentProperty
 
-            p: rdflib.URIRef = rdflib.URIRef(s_p + t.id)
-            s: rdflib.URIRef = rdflib.URIRef(s_s + t.id)
+            p: rdflib.URIRef = rdflib.URIRef(f"{s_p}{t.id}")
+            s: rdflib.URIRef = rdflib.URIRef(f"{s_s}{t.id}")
             outGraph.add((p, eqiv, s))
             outGraph.add((s, eqiv, p))
-            log.debug("%s ", t.uri)
+            log.debug(f"{t.uri} ")
 
     return str(outGraph.serialize(format="turtle", auto_compact=True, sort_keys=True))
 
@@ -97,12 +97,12 @@ def _jsonldtree(tid: str, term: Optional[Dict[str, Any]] = None) -> Dict[str, An
     if term is None:
         term = {}
     term["@type"] = "rdfs:Class"
-    term["@id"] = "schema:" + termdesc.id
+    term["@id"] = f"schema:{termdesc.id}"
     term["name"] = termdesc.label
     if termdesc.supers:
         sups: List[str] = []
         for sup in termdesc.supers.ids:
-            sups.append("schema:" + sup)
+            sups.append(f"schema:{sup}")
         if len(sups) == 1:
             term["rdfs:subClassOf"] = sups[0]
         else:
@@ -135,9 +135,11 @@ def owl(page: str) -> str:
 
 
 def sitemap(page: str) -> str:
-    node: str = """ <url>
-   <loc>https://schema.org/%s</loc>
-   <lastmod>%s</lastmod>
+    version_date: str = schemaversion.getCurrentVersionDate()
+    def node(t: str) -> str:
+        return f""" <url>
+   <loc>https://schema.org/{t}</loc>
+   <lastmod>{version_date}</lastmod>
  </url>
 """
     STATICPAGES: List[str] = [
@@ -160,22 +162,21 @@ def sitemap(page: str) -> str:
 <urlset xmlns="http://www.sitemaps.org/schemas/sitemap/0.9">
 """)
     terms: List[str] = sdotermsource.SdoTermSource.getAllTerms(suppressSourceLinks=True)
-    version_date: str = schemaversion.getCurrentVersionDate()
     for term in sorted(terms):
         if not (str(term).startswith("http://") or str(term).startswith("https://")):
-            output.append(node % (term, version_date))
+            output.append(node(term))
     for term in STATICPAGES:
-        output.append(node % (term, version_date))
+        output.append(node(term))
     output.append("</urlset>\n")
     return "".join(output)
 
 
 def protocolSwap(content: str, protocol: str, altprotocol: str) -> str:
-    ret: str = content.replace("%s://schema.org" % protocol, "%s://schema.org" % altprotocol)
+    ret: str = content.replace(f"{protocol}://schema.org", f"{altprotocol}://schema.org")
     for ext in ["attic", "auto", "bib", "health-lifesci", "meta", "pending"]:
         ret = ret.replace(
-            "%s://%s.schema.org" % (protocol, ext),
-            "%s://%s.schema.org" % (altprotocol, ext),
+            f"{protocol}://{ext}.schema.org",
+            f"{altprotocol}://{ext}.schema.org",
         )
     return ret
 
@@ -277,7 +278,7 @@ def exportrdf(exportType: str, subdirectory_path: Optional[str] = None) -> None:
     elif extype in formats:
         _exportrdf(extype, allGraph, currentGraph, subdirectory_path)
     else:
-        raise Exception("Unknown export format: %s" % exportType)
+        raise Exception(f"Unknown export format: {exportType}")
 
 
 # Set of completed EDF exports.
@@ -307,7 +308,7 @@ def _exportrdf(output_format: str, all_graph: rdflib.Graph, current_graph: rdfli
 
         if output_format == "nquads":
             gr: rdflib.Dataset = rdflib.Dataset()
-            qg: rdflib.Graph = gr.graph(rdflib.URIRef("%s://schema.org/%s" % (protocol, version)))
+            qg: rdflib.Graph = gr.graph(rdflib.URIRef(f"{protocol}://schema.org/{version}"))
             qg += g
             g = gr
 
@@ -328,7 +329,7 @@ def _exportrdf(output_format: str, all_graph: rdflib.Graph, current_graph: rdfli
                     fmt = output_format
                 out: str = str(g.serialize(format=fmt, auto_compact=True, sort_keys=True, max_depth=1))
                 if output_format in ("nt", "nquads"):
-                    out = "\n".join(sorted(line.rstrip() for line in out.splitlines() if line.strip())) + "\n"
+                    out = f'{"\n".join(sorted(line.rstrip() for line in out.splitlines() if line.strip()))}\n'
                 if output_format == "rdf":
                     try:
                         out = sort_xml(out)
@@ -360,7 +361,7 @@ def uriwrap(thing: Any) -> str:
     if isinstance(thing, str):
         if thing.startswith("http:") or thing.startswith("https:"):
             return thing
-        return VOCABURI + thing
+        return f"{VOCABURI}{thing}"
     if isinstance(thing, sdoterm.SdoTermSequence):
         return uriwrap(thing.ids)
     if isinstance(thing, sdoterm.SdoTermOrId):
@@ -370,7 +371,7 @@ def uriwrap(thing: Any) -> str:
     try:
         return array2str(sorted(map(uriwrap, thing)))
     except TypeError as e:
-        log.fatal("Cannot uriwrap %s:%s", thing, e)
+        log.fatal(f"Cannot uriwrap {thing}:{e}")
         return ""
 
 
@@ -428,7 +429,7 @@ def exportcsv(page: str) -> None:
         row["supersededBy"] = uriwrap(term.supersededBy)
         ext: str = term.extLayer
         if len(ext):
-            ext = "%s://%s.schema.org" % (protocol, ext)
+            ext = f"{protocol}://{ext}.schema.org"
         row["isPartOf"] = ext
         if term.termType == sdoterm.SdoTermType.PROPERTY:
             row["subPropertyOf"] = uriwrap(term.supers)
@@ -538,11 +539,11 @@ def jsoncounts(page: str) -> str:
 
 
 def jsonpcounts(page: str) -> str:
-    content: str = """
-    COUNTS = '%s';
+    content: str = f"""
+    COUNTS = '{jsoncounts(page)}';
 
     insertschemacounts ( COUNTS );
-    """ % jsoncounts(page)
+    """
     return content
 
 
@@ -566,7 +567,7 @@ FILELIST: Dict[str, Tuple[Any, List[str]]] = {
             "docs/jsonldcontext.jsonld",
             "docs/jsonldcontext.json",
             "docs/jsonldcontext.json.txt",
-            "releases/%s/schemaorgcontext.jsonld" % schemaversion.getVersion(),
+            f"releases/{schemaversion.getVersion()}/schemaorgcontext.jsonld",
         ],
     ),
     "Tree": (jsonldtree, ["docs/tree.jsonld"]),
@@ -576,12 +577,12 @@ FILELIST: Dict[str, Tuple[Any, List[str]]] = {
         owl,
         [
             "docs/schemaorg.owl",
-            "releases/%s/schemaorg.owl" % schemaversion.getVersion(),
+            f"releases/{schemaversion.getVersion()}/schemaorg.owl",
         ],
     ),
     "Httpequivs": (
         httpequivs,
-        ["releases/%s/httpequivs.ttl" % schemaversion.getVersion()],
+        [f"releases/{schemaversion.getVersion()}/httpequivs.ttl"],
     ),
     "Sitemap": (sitemap, ["docs/sitemap.xml"]),
     "RDFExports": (exportrdf, [""]),
@@ -594,7 +595,7 @@ FILELIST: Dict[str, Tuple[Any, List[str]]] = {
     "CSVExports": (exportcsv, [""]),
     "Examples": (
         examples,
-        ["releases/%s/schemaorg-all-examples.txt" % schemaversion.getVersion()],
+        [f"releases/{schemaversion.getVersion()}/schemaorg-all-examples.txt"],
     ),
 }
 
@@ -626,7 +627,7 @@ def buildFiles(files: List[str]) -> None:
                             with open(fn, "w", encoding="utf8") as handle:
                                 handle.write(str(content))
             else:
-                log.warning("Unknown files name: %s" % p)
+                log.warning(f"Unknown files name: {p}")
 
 
 if __name__ == "__main__":

--- a/software/util/buildocspages.py
+++ b/software/util/buildocspages.py
@@ -7,6 +7,8 @@ import json
 import logging
 import os
 import sys
+import typing
+from typing import Any, Dict, List, Optional, Tuple, Union, Iterable, Sequence, Set, Callable
 
 # Import schema.org libraries
 if os.getcwd() not in sys.path:
@@ -25,18 +27,19 @@ import software.SchemaTerms.sdotermsource as sdotermsource
 import software.SchemaTerms.sdocollaborators as sdocollaborators
 import software.SchemaTerms.sdoterm as sdoterm
 
-log = logging.getLogger(__name__)
+log: logging.Logger = logging.getLogger(__name__)
 
+STRCLASSVAL: Optional[str] = None
 
-def docsTemplateRender(template, extra_vars=None):
-    tvars = {"BUILDOPTS": schemaglobals.BUILDOPTS, "docsdir": schemaglobals.DOCSDOCSDIR}
+def docsTemplateRender(template: str, extra_vars: Optional[Dict[str, Any]] = None) -> str:
+    tvars: Dict[str, Any] = {"BUILDOPTS": schemaglobals.BUILDOPTS, "docsdir": schemaglobals.DOCSDOCSDIR}
     if extra_vars:
         tvars.update(extra_vars)
     return jinga_render.templateRender(template, tvars)
 
 
-def schemasPage(page):
-    extra_vars = {
+def schemasPage(page: str) -> str:
+    extra_vars: Dict[str, Any] = {
         "home_page": "False",
         "title": "Schemas",
         "termcounts": sdotermsource.SdoTermSource.termCounts(),
@@ -44,12 +47,12 @@ def schemasPage(page):
     return docsTemplateRender("docs/Schemas.j2", extra_vars)
 
 
-def homePage(page):
+def homePage(page: str) -> str:
     global STRCLASSVAL
-    title = schemaglobals.SITENAME
-    template = "docs/Home.j2"
-    filt = None
-    overrideclassval = None
+    title: str = schemaglobals.SITENAME
+    template: str = "docs/Home.j2"
+    filt: Optional[str] = None
+    overrideclassval: Optional[str] = None
     if page == "PendingHome":
         title = "Pending"
         template = "docs/PendingHome.j2"
@@ -80,40 +83,45 @@ def homePage(page):
         template = "docs/MetaHome.j2"
         filt = "meta"
         overrideclassval = 'class="ext"'
-    sectionterms = {}
-    termcount = 0
+    
+    sectionterms: Dict[str, Dict[sdoterm.SdoTermType, List[sdoterm.SdoTerm]]] = {}
+    termcount: int = 0
     if filt:
-        terms = sdotermsource.SdoTermSource.getAllTerms(layer=filt, expanded=True)
-        for t in terms:
-            t.cat = ""
-            if filt == "pending":
-                for s in t.sources:
-                    if "schemaorg/issue" in s:
-                        t.cat = "issue-" + os.path.basename(s)
-                        break
-        terms.sort(key=lambda u: (u.cat, u.id))
+        all_terms = sdotermsource.SdoTermSource.getAllTerms(layer=filt, expanded=True)
+        terms: List[sdoterm.SdoTerm] = []
+        for t in all_terms:
+            if isinstance(t, sdoterm.SdoTerm):
+                t.cat = ""
+                if filt == "pending":
+                    for s in t.sources:
+                        if "schemaorg/issue" in s:
+                            t.cat = "issue-" + os.path.basename(s)
+                            break
+                terms.append(t)
+        terms.sort(key=lambda u: (getattr(u, 'cat', ''), u.id))
         sectionterms, termcount = buildTermCatList(terms, checkCat=True)
 
-    extra_vars = {
+    extra_vars: Dict[str, Any] = {
         "home_page": "True",
         "title": title,
         "termcount": termcount,
         "sectionterms": sectionterms,
     }
     STRCLASSVAL = overrideclassval
-    ret = docsTemplateRender(template, extra_vars)
+    ret: str = docsTemplateRender(template, extra_vars)
     STRCLASSVAL = None
     return ret
 
 
-def buildTermCatList(terms, checkCat=False):
-    first = True
-    cat = None
-    termcat = {}
-    termcount = 0
+def buildTermCatList(terms: Iterable[sdoterm.SdoTerm], checkCat: bool = False) -> Tuple[Dict[str, Dict[sdoterm.SdoTermType, List[sdoterm.SdoTerm]]], int]:
+    first: bool = True
+    cat: Optional[str] = None
+    termcat: Dict[str, Dict[sdoterm.SdoTermType, List[sdoterm.SdoTerm]]] = {}
+    termcount: int = 0
+    ttypes: Dict[sdoterm.SdoTermType, List[sdoterm.SdoTerm]] = {}
     for t in terms:
         if checkCat:
-            tcat = t.cat
+            tcat: str = getattr(t, 'cat', '')
         else:
             tcat = ""
         if first or tcat != cat:
@@ -131,8 +139,8 @@ def buildTermCatList(terms, checkCat=False):
         ttypes[t.termType].append(t)
         termcount += 1
 
-    termcat = dict(sorted(termcat.items()))
-    return termcat, termcount
+    sorted_termcat: Dict[str, Dict[sdoterm.SdoTermType, List[sdoterm.SdoTerm]]] = dict(sorted(termcat.items()))
+    return sorted_termcat, termcount
 
 
 class UnknownTermError(LookupError):
@@ -140,20 +148,20 @@ class UnknownTermError(LookupError):
 
 
 class listingNode:
-    def __init__(self, term, depth=0, title="", parent=None, visit_set=None):
+    def __init__(self, term: str, depth: int = 0, title: str = "", parent: Optional["listingNode"] = None, visit_set: Optional[Set[str]] = None) -> None:
         termdesc = sdotermsource.SdoTermSource.getTerm(term)
         if not termdesc:
             raise UnknownTermError(f"No description for term {term}")
         visit_set = visit_set or set()
-        self.repeat = False
-        self.subs = []
-        self.parent = parent
-        self.title = title
-        self.id = termdesc.label
-        self.termType = termdesc.termType
-        self.depth = depth
-        self.retired = termdesc.retired
-        self.pending = termdesc.pending
+        self.repeat: bool = False
+        self.subs: List[listingNode] = []
+        self.parent: Optional[listingNode] = parent
+        self.title: str = title
+        self.id: str = termdesc.label
+        self.termType: sdoterm.SdoTermType = termdesc.termType
+        self.depth: int = depth
+        self.retired: bool = termdesc.retired
+        self.pending: bool = termdesc.pending
         if self.id not in visit_set:
             visit_set.add(self.id)
             if termdesc.termType == sdoterm.SdoTermType.ENUMERATION:
@@ -183,31 +191,31 @@ class listingNode:
             self.repeat = True
 
 
-def jsonldtree(page) -> str:
-    term = {}
-    context = {}
+def jsonldtree(page: str) -> str:
+    term: Dict[str, Any] = {}
+    context: Dict[str, Any] = {}
     context["rdfs"] = "http://www.w3.org/2000/01/rdf-schema#"
     context["schema"] = "https://schema.org"
     context["rdfs:subClassOf"] = {"@type": "@id"}
     context["description"] = "rdfs:comment"
     context["children"] = {"@reverse": "rdfs:subClassOf"}
     term["@context"] = context
-    data = _jsonldtree("Thing", visitset=set(), term=term)
+    data: Dict[str, Any] = _jsonldtree("Thing", visitset=set(), term=term)
     return json.dumps(sort_dict(data), indent=2)
 
 
-def _jsonldtree(tid: str, visitset: set, term: dict | None = None) -> dict:
+def _jsonldtree(tid: str, visitset: Set[str], term: Optional[Dict[str, Any]] = None) -> Dict[str, Any]:
     try:
         termdesc = sdotermsource.SdoTermSource.getTerm(tid)
         if not termdesc:
-            raise UnknownTermError(f"No description for term {term}")
-        if not term:
+            raise UnknownTermError(f"No description for term {tid}")
+        if term is None:
             term = {}
         term["@type"] = "rdfs:Class"
         term["@id"] = "schema:" + termdesc.id
         term["name"] = termdesc.label
         if termdesc.supers:
-            sups = ["schema:" + sup for sup in termdesc.supers.ids]
+            sups: List[str] = ["schema:" + sup for sup in termdesc.supers.ids]
             if len(sups) == 1:
                 term["rdfs:subClassOf"] = sups[0]
             else:
@@ -222,13 +230,13 @@ def _jsonldtree(tid: str, visitset: set, term: dict | None = None) -> dict:
         if tid not in visitset:
             visitset.add(tid)
             if termdesc.subs:
-                subs = []
+                subs: List[Dict[str, Any]] = []
                 for sub in termdesc.subs.ids:
                     try:
                         subs.append(_jsonldtree(tid=sub, visitset=visitset))
                     except UnknownTermError as e:
                         log.warning(
-                            f"Error while building listing node for {term}: {e}"
+                            f"Error while building listing node for {sub}: {e}"
                         )
                 term["children"] = subs
         return term
@@ -237,16 +245,16 @@ def _jsonldtree(tid: str, visitset: set, term: dict | None = None) -> dict:
         raise
 
 
-listings = None
+listings: Optional[List[listingNode]] = None
 
 
-def fullPage(page):
+def fullPage(page: str) -> str:
     global listings
     if not listings:
         listings = []
         listings.append(listingNode("Thing", title="Types:"))
         listings.append(listingNode("DataType", title="DataTypes:"))
-    extra_vars = {
+    extra_vars: Dict[str, Any] = {
         "home_page": "False",
         "title": "Full schema hierarchy",
         "listings": listings,
@@ -255,48 +263,62 @@ def fullPage(page):
     return docsTemplateRender("docs/%s.j2" % page, extra_vars)
 
 
-def fullReleasePage(page):
-    listings = []
-    listings.append(listingNode("Thing", title="Type hierarchy"))
-    types = sdotermsource.SdoTermSource.getAllEnumerationvalues(expanded=True)
-    types.extend(sdotermsource.SdoTermSource.getAllTypes(expanded=True))
+def fullReleasePage(page: str) -> str:
+    node_listings: List[listingNode] = []
+    node_listings.append(listingNode("Thing", title="Type hierarchy"))
+    
+    all_enum_vals = sdotermsource.SdoTermSource.getAllEnumerationvalues(expanded=True)
+    all_types = sdotermsource.SdoTermSource.getAllTypes(expanded=True)
+    
+    types: List[sdoterm.SdoTerm] = []
+    for t in all_enum_vals + all_types:
+        if isinstance(t, sdoterm.SdoTerm):
+            types.append(t)
+            
     types = sdotermsource.SdoTermSource.expandTerms(types)
     types = sorted(types, key=lambda t: t.id)
-    extra_vars = {
+    
+    all_props = sdotermsource.SdoTermSource.getAllProperties(expanded=True)
+    properties: List[sdoterm.SdoTerm] = []
+    for p in all_props:
+        if isinstance(p, sdoterm.SdoTerm):
+            properties.append(p)
+
+    extra_vars: Dict[str, Any] = {
         "home_page": "False",
         "title": "Full Release Summary",
         "version": schemaversion.getVersion(),
         "date": schemaversion.getCurrentVersionDate(),
-        "listings": listings,
+        "listings": node_listings,
         "types": types,
-        "properties": sorted(sdotermsource.SdoTermSource.getAllProperties(expanded=True), key=lambda t: t.id),
+        "properties": sorted(properties, key=lambda t: t.id),
     }
     return docsTemplateRender("docs/FullRelease.j2", extra_vars)
 
 
-def collabs(page):
-    colls = sdocollaborators.collaborator.collaborators()
+def collabs(page: str) -> str:
+    colls: List[sdocollaborators.collaborator] = sdocollaborators.collaborator.collaborators()
 
     # TODO Handle collaborators that are not contributors
 
-    colls = sorted(colls, key=lambda t: t.title)
+    colls = sorted(colls, key=lambda t: t.title or "")
 
     for coll in colls:
         createCollab(coll)
 
-    extra_vars = {"collaborators": colls, "title": "Collaborators"}
+    extra_vars: Dict[str, Any] = {"collaborators": colls, "title": "Collaborators"}
     return docsTemplateRender("docs/Collabs.j2", extra_vars)
 
 
-def createCollab(coll):
-    terms = []
-    termcount = 0
-    contributor = coll.contributor
+def createCollab(coll: sdocollaborators.collaborator) -> None:
+    terms: Dict[str, Dict[sdoterm.SdoTermType, List[sdoterm.SdoTerm]]] = {}
+    termcount: int = 0
+    contributor: bool = coll.contributor
 
     if contributor:
         terms, termcount = buildTermCatList(coll.getTerms())
 
-    extra_vars = {
+    extra_vars: Dict[str, Any] = {
         "coll": coll,
         "title": coll.title,
         "contributor": contributor,
@@ -304,8 +326,8 @@ def createCollab(coll):
         "termcount": termcount,
     }
 
-    content = docsTemplateRender("docs/Collab.j2", extra_vars)
-    filename = fileutils.ensureAbsolutePath(
+    content: str = docsTemplateRender("docs/Collab.j2", extra_vars)
+    filename: str = fileutils.ensureAbsolutePath(
         output_dir=schemaglobals.OUTPUTDIR,
         relative_path=os.path.join("docs/collab/", coll.ref + ".html"),
     )
@@ -314,14 +336,14 @@ def createCollab(coll):
     log.info("Created %s" % filename)
 
 
-def termfind(file):
+def termfind(file: str) -> str:
     if not schemaglobals.hasOpt("notermfinder"):
         log.info("Building term list")
         return "".join(buildtermlist.generateTerms(tags=True))
     return ""
 
 
-PAGELIST = {
+PAGELIST: Dict[str, Tuple[Callable[[str], str], List[str]]] = {
     "Home": (homePage, ["docs/home.html"]),
     "PendingHome": (homePage, ["docs/pending.home.html"]),
     "AtticHome": (homePage, ["docs/attic.home.html"]),
@@ -345,22 +367,29 @@ PAGELIST = {
 }
 
 
-def buildDocs(pages):
+def buildDocs(pages: Iterable[str]) -> None:
+    process_pages: List[str]
     if any(filter(fileutils.isAll, pages)):
-        pages = sorted(PAGELIST.keys())
+        process_pages = sorted(PAGELIST.keys())
+    else:
+        process_pages = list(pages)
 
-    for page in pages:
+    for page in process_pages:
         if page not in PAGELIST.keys():
             log.warning(f"Unknown page name: {page}")
             continue
-        func, filenames = PAGELIST.get(page, None)
+        entry = PAGELIST.get(page)
+        if not entry:
+            log.warning(f"Missing entry for page {page}")
+            continue
+        func, filenames = entry
         if not func:
             log.warning(f"Missing function for page {page}")
             continue
         with pretty_logger.BlockLog(logger=log, message=f"Generating page {page}"):
-            content = func(page)
+            content: str = func(page)
             for relative_path in filenames:
-                filename = fileutils.ensureAbsolutePath(
+                filename: str = fileutils.ensureAbsolutePath(
                     output_dir=schemaglobals.OUTPUTDIR, relative_path=relative_path
                 )
                 with open(filename, "w", encoding="utf8") as handle:

--- a/software/util/buildocspages.py
+++ b/software/util/buildocspages.py
@@ -5,14 +5,13 @@
 
 import json
 import logging
-import os
 import sys
-import typing
-from typing import Any, Dict, List, Optional, Tuple, Union, Iterable, Sequence, Set, Callable
+from pathlib import Path
+from collections import defaultdict
+from typing import Any, Dict, List, Optional, Tuple, Union, Iterable, Set, Callable, Sequence
 
-# Import schema.org libraries
-if os.getcwd() not in sys.path:
-    sys.path.insert(1, os.getcwd())
+if Path.cwd() not in [Path(p).resolve() for p in sys.path]:
+    sys.path.insert(1, str(Path.cwd()))
 
 import software.scripts.buildtermlist as buildtermlist
 import software.util.fileutils as fileutils
@@ -47,55 +46,40 @@ def schemasPage(page: str) -> str:
     return docsTemplateRender("docs/Schemas.j2", extra_vars)
 
 
+PAGE_CONFIGS: Dict[str, Tuple[str, str, str, str]] = {
+    "PendingHome": ("Pending", "docs/PendingHome.j2", "pending", 'class="ext ext-pending"'),
+    "AtticHome": ("Retired", "docs/AtticHome.j2", "attic", 'class="ext ext-attic"'),
+    "AutoHome": ("Autotomotives", "docs/AutoHome.j2", "auto", 'class="ext"'),
+    "BibHome": ("Bib", "docs/BibHome.j2", "bib", 'class="ext"'),
+    "Health-lifesciHome": ("Health-lifesci", "docs/Health-lifesciHome.j2", "health-lifesci", 'class="ext"'),
+    "MetaHome": ("Meta", "docs/MetaHome.j2", "meta", 'class="ext"'),
+}
+
 def homePage(page: str) -> str:
     global STRCLASSVAL
     title: str = schemaglobals.SITENAME
     template: str = "docs/Home.j2"
     filt: Optional[str] = None
     overrideclassval: Optional[str] = None
-    if page == "PendingHome":
-        title = "Pending"
-        template = "docs/PendingHome.j2"
-        filt = "pending"
-        overrideclassval = 'class="ext ext-pending"'
-    elif page == "AtticHome":
-        title = "Retired"
-        template = "docs/AtticHome.j2"
-        filt = "attic"
-        overrideclassval = 'class="ext ext-attic"'
-    elif page == "AutoHome":
-        title = "Autotomotives"
-        template = "docs/AutoHome.j2"
-        filt = "auto"
-        overrideclassval = 'class="ext"'
-    elif page == "BibHome":
-        title = "Bib"
-        template = "docs/BibHome.j2"
-        filt = "bib"
-        overrideclassval = 'class="ext"'
-    elif page == "Health-lifesciHome":
-        title = "Health-lifesci"
-        template = "docs/Health-lifesciHome.j2"
-        filt = "health-lifesci"
-        overrideclassval = 'class="ext"'
-    elif page == "MetaHome":
-        title = "Meta"
-        template = "docs/MetaHome.j2"
-        filt = "meta"
-        overrideclassval = 'class="ext"'
+    
+    config: Optional[Tuple[str, str, str, str]] = PAGE_CONFIGS.get(page)
+    if config:
+        title, template, filt, overrideclassval = config
     
     sectionterms: Dict[str, Dict[sdoterm.SdoTermType, List[sdoterm.SdoTerm]]] = {}
     termcount: int = 0
     if filt:
-        all_terms = sdotermsource.SdoTermSource.getAllTerms(layer=filt, expanded=True)
+        all_terms: Sequence[Union[str, sdoterm.SdoTerm]] = sdotermsource.SdoTermSource.getAllTerms(layer=filt, expanded=True)
         terms: List[sdoterm.SdoTerm] = []
+        t: Union[str, sdoterm.SdoTerm]
         for t in all_terms:
             if isinstance(t, sdoterm.SdoTerm):
-                t.cat = ""
+                t.cat = "" # type: ignore
                 if filt == "pending":
+                    s: str
                     for s in t.sources:
                         if "schemaorg/issue" in s:
-                            t.cat = "issue-" + os.path.basename(s)
+                            t.cat = f"issue-{Path(s).name}" # type: ignore
                             break
                 terms.append(t)
         terms.sort(key=lambda u: (getattr(u, 'cat', ''), u.id))
@@ -114,33 +98,17 @@ def homePage(page: str) -> str:
 
 
 def buildTermCatList(terms: Iterable[sdoterm.SdoTerm], checkCat: bool = False) -> Tuple[Dict[str, Dict[sdoterm.SdoTermType, List[sdoterm.SdoTerm]]], int]:
-    first: bool = True
-    cat: Optional[str] = None
-    termcat: Dict[str, Dict[sdoterm.SdoTermType, List[sdoterm.SdoTerm]]] = {}
+    termcat: Dict[str, Dict[sdoterm.SdoTermType, List[sdoterm.SdoTerm]]] = defaultdict(lambda: defaultdict(list))
     termcount: int = 0
-    ttypes: Dict[sdoterm.SdoTermType, List[sdoterm.SdoTerm]] = {}
+    t: sdoterm.SdoTerm
     for t in terms:
-        if checkCat:
-            tcat: str = getattr(t, 'cat', '')
-        else:
-            tcat = ""
-        if first or tcat != cat:
-            first = False
-            cat = tcat
-            ttypes = {}
-            termcat[cat] = ttypes
-            ttypes[sdoterm.SdoTermType.TYPE] = []
-            ttypes[sdoterm.SdoTermType.PROPERTY] = []
-            ttypes[sdoterm.SdoTermType.DATATYPE] = []
-            ttypes[sdoterm.SdoTermType.ENUMERATION] = []
-            ttypes[sdoterm.SdoTermType.ENUMERATIONVALUE] = []
         if t.termType == sdoterm.SdoTermType.REFERENCE:
             continue
-        ttypes[t.termType].append(t)
+        cat: str = getattr(t, 'cat', '') if checkCat else ""
+        termcat[cat][t.termType].append(t)
         termcount += 1
 
-    sorted_termcat: Dict[str, Dict[sdoterm.SdoTermType, List[sdoterm.SdoTerm]]] = dict(sorted(termcat.items()))
-    return sorted_termcat, termcount
+    return dict(sorted(termcat.items())), termcount
 
 
 class UnknownTermError(LookupError):
@@ -149,10 +117,10 @@ class UnknownTermError(LookupError):
 
 class listingNode:
     def __init__(self, term: str, depth: int = 0, title: str = "", parent: Optional["listingNode"] = None, visit_set: Optional[Set[str]] = None) -> None:
-        termdesc = sdotermsource.SdoTermSource.getTerm(term)
+        termdesc: Optional[sdoterm.SdoTerm] = sdotermsource.SdoTermSource.getTerm(term)
         if not termdesc:
             raise UnknownTermError(f"No description for term {term}")
-        visit_set = visit_set or set()
+        visit_set = visit_set if visit_set is not None else set()
         self.repeat: bool = False
         self.subs: List[listingNode] = []
         self.parent: Optional[listingNode] = parent
@@ -162,84 +130,71 @@ class listingNode:
         self.depth: int = depth
         self.retired: bool = termdesc.retired
         self.pending: bool = termdesc.pending
+        
         if self.id not in visit_set:
             visit_set.add(self.id)
+            child_ids: List[str] = []
             if termdesc.termType == sdoterm.SdoTermType.ENUMERATION:
-                for enum in sorted(termdesc.enumerationMembers.ids):
-                    try:
-                        self.subs.append(
-                            listingNode(
-                                enum, depth=depth + 1, parent=self, visit_set=visit_set
-                            )
-                        )
-                    except UnknownTermError as e:
-                        log.warning(
-                            f"Error while building enumeration node {enum} for {term}: {e}"
-                        )
-            for sub in sorted(termdesc.subs.ids):
+                child_ids.extend(sorted(termdesc.enumerationMembers.ids))
+            child_ids.extend(sorted(termdesc.subs.ids))
+            
+            child_id: str
+            for child_id in child_ids:
                 try:
-                    self.subs.append(
-                        listingNode(
-                            sub, depth=depth + 1, parent=self, visit_set=visit_set
-                        )
-                    )
+                    self.subs.append(listingNode(child_id, depth=depth + 1, parent=self, visit_set=visit_set))
                 except UnknownTermError as e:
-                    log.warning(
-                        f"Error while building child node {sub} for {term}: {e}"
-                    )
-        else:  # Visited this node before so don't parse children
+                    log.warning(f"Error while building node {child_id} for {term}: {e}")
+        else:
             self.repeat = True
 
 
 def jsonldtree(page: str) -> str:
-    term: Dict[str, Any] = {}
-    context: Dict[str, Any] = {}
-    context["rdfs"] = "http://www.w3.org/2000/01/rdf-schema#"
-    context["schema"] = "https://schema.org"
-    context["rdfs:subClassOf"] = {"@type": "@id"}
-    context["description"] = "rdfs:comment"
-    context["children"] = {"@reverse": "rdfs:subClassOf"}
-    term["@context"] = context
-    data: Dict[str, Any] = _jsonldtree("Thing", visitset=set(), term=term)
+    context: Dict[str, Any] = {
+        "rdfs": "http://www.w3.org/2000/01/rdf-schema#",
+        "schema": "https://schema.org",
+        "rdfs:subClassOf": {"@type": "@id"},
+        "description": "rdfs:comment",
+        "children": {"@reverse": "rdfs:subClassOf"}
+    }
+    data: Dict[str, Any] = _jsonldtree("Thing", visitset=set(), term={"@context": context})
     return json.dumps(sort_dict(data), indent=2)
 
 
 def _jsonldtree(tid: str, visitset: Set[str], term: Optional[Dict[str, Any]] = None) -> Dict[str, Any]:
     try:
-        termdesc = sdotermsource.SdoTermSource.getTerm(tid)
+        termdesc: Optional[sdoterm.SdoTerm] = sdotermsource.SdoTermSource.getTerm(tid)
         if not termdesc:
             raise UnknownTermError(f"No description for term {tid}")
-        if term is None:
-            term = {}
-        term["@type"] = "rdfs:Class"
-        term["@id"] = "schema:" + termdesc.id
-        term["name"] = termdesc.label
+        
+        term_dict: Dict[str, Any] = term if term is not None else {}
+        term_dict.update({
+            "@type": "rdfs:Class",
+            "@id": f"schema:{termdesc.id}",
+            "name": termdesc.label,
+            "description": textutils.ShortenOnSentence(textutils.StripHtmlTags(termdesc.comment))
+        })
+        
         if termdesc.supers:
-            sups: List[str] = ["schema:" + sup for sup in termdesc.supers.ids]
-            if len(sups) == 1:
-                term["rdfs:subClassOf"] = sups[0]
-            else:
-                term["rdfs:subClassOf"] = sups
-        term["description"] = textutils.ShortenOnSentence(
-            textutils.StripHtmlTags(termdesc.comment)
-        )
+            sups: List[str] = [f"schema:{sup}" for sup in termdesc.supers.ids]
+            term_dict["rdfs:subClassOf"] = sups[0] if len(sups) == 1 else sups
+        
         if termdesc.pending:
-            term["pending"] = True
+            term_dict["pending"] = True
         if termdesc.retired:
-            term["attic"] = True
+            term_dict["attic"] = True
+            
         if tid not in visitset:
             visitset.add(tid)
             if termdesc.subs:
                 subs: List[Dict[str, Any]] = []
+                sub: str
                 for sub in termdesc.subs.ids:
                     try:
                         subs.append(_jsonldtree(tid=sub, visitset=visitset))
                     except UnknownTermError as e:
-                        log.warning(
-                            f"Error while building listing node for {sub}: {e}"
-                        )
-                term["children"] = subs
-        return term
+                        log.warning(f"Error while building listing node for {sub}: {e}")
+                term_dict["children"] = subs
+        return term_dict
     except Exception as e:
         e.add_note(f"while building JSON tree for id:{tid}-{term}")
         raise
@@ -251,38 +206,30 @@ listings: Optional[List[listingNode]] = None
 def fullPage(page: str) -> str:
     global listings
     if not listings:
-        listings = []
-        listings.append(listingNode("Thing", title="Types:"))
-        listings.append(listingNode("DataType", title="DataTypes:"))
+        listings = [
+            listingNode("Thing", title="Types:"),
+            listingNode("DataType", title="DataTypes:")
+        ]
     extra_vars: Dict[str, Any] = {
         "home_page": "False",
         "title": "Full schema hierarchy",
         "listings": listings,
     }
 
-    return docsTemplateRender("docs/%s.j2" % page, extra_vars)
+    return docsTemplateRender(f"docs/{page}.j2", extra_vars)
 
 
 def fullReleasePage(page: str) -> str:
-    node_listings: List[listingNode] = []
-    node_listings.append(listingNode("Thing", title="Type hierarchy"))
+    node_listings: List[listingNode] = [listingNode("Thing", title="Type hierarchy")]
     
-    all_enum_vals = sdotermsource.SdoTermSource.getAllEnumerationvalues(expanded=True)
-    all_types = sdotermsource.SdoTermSource.getAllTypes(expanded=True)
+    all_enum_vals: Sequence[Union[str, sdoterm.SdoTerm]] = sdotermsource.SdoTermSource.getAllEnumerationvalues(expanded=True)
+    all_types: Sequence[Union[str, sdoterm.SdoTerm]] = sdotermsource.SdoTermSource.getAllTypes(expanded=True)
     
-    types: List[sdoterm.SdoTerm] = []
-    for t in all_enum_vals + all_types:
-        if isinstance(t, sdoterm.SdoTerm):
-            types.append(t)
-            
-    types = sdotermsource.SdoTermSource.expandTerms(types)
-    types = sorted(types, key=lambda t: t.id)
+    types: List[sdoterm.SdoTerm] = [t for t in list(all_enum_vals) + list(all_types) if isinstance(t, sdoterm.SdoTerm)]
+    types = sorted(sdotermsource.SdoTermSource.expandTerms(types), key=lambda t: t.id)
     
-    all_props = sdotermsource.SdoTermSource.getAllProperties(expanded=True)
-    properties: List[sdoterm.SdoTerm] = []
-    for p in all_props:
-        if isinstance(p, sdoterm.SdoTerm):
-            properties.append(p)
+    all_props: Sequence[Union[str, sdoterm.SdoTerm]] = sdotermsource.SdoTermSource.getAllProperties(expanded=True)
+    properties: List[sdoterm.SdoTerm] = [p for p in all_props if isinstance(p, sdoterm.SdoTerm)]
 
     extra_vars: Dict[str, Any] = {
         "home_page": "False",
@@ -297,12 +244,9 @@ def fullReleasePage(page: str) -> str:
 
 
 def collabs(page: str) -> str:
-    colls: List[sdocollaborators.collaborator] = sdocollaborators.collaborator.collaborators()
+    colls: List[sdocollaborators.collaborator] = sorted(sdocollaborators.collaborator.collaborators(), key=lambda t: t.title or "")
 
-    # TODO Handle collaborators that are not contributors
-
-    colls = sorted(colls, key=lambda t: t.title or "")
-
+    coll: sdocollaborators.collaborator
     for coll in colls:
         createCollab(coll)
 
@@ -313,15 +257,13 @@ def collabs(page: str) -> str:
 def createCollab(coll: sdocollaborators.collaborator) -> None:
     terms: Dict[str, Dict[sdoterm.SdoTermType, List[sdoterm.SdoTerm]]] = {}
     termcount: int = 0
-    contributor: bool = coll.contributor
-
-    if contributor:
+    if coll.contributor:
         terms, termcount = buildTermCatList(coll.getTerms())
 
     extra_vars: Dict[str, Any] = {
         "coll": coll,
         "title": coll.title,
-        "contributor": contributor,
+        "contributor": coll.contributor,
         "terms": terms,
         "termcount": termcount,
     }
@@ -329,11 +271,10 @@ def createCollab(coll: sdocollaborators.collaborator) -> None:
     content: str = docsTemplateRender("docs/Collab.j2", extra_vars)
     filename: str = fileutils.ensureAbsolutePath(
         output_dir=schemaglobals.OUTPUTDIR,
-        relative_path=os.path.join("docs/collab/", coll.ref + ".html"),
+        relative_path=str(Path("docs/collab") / f"{coll.ref}.html"),
     )
-    with open(filename, "w", encoding="utf8") as handle:
-        handle.write(content)
-    log.info("Created %s" % filename)
+    Path(filename).write_text(content, encoding="utf8")
+    log.info(f"Created {filename}")
 
 
 def termfind(file: str) -> str:
@@ -358,39 +299,30 @@ PAGELIST: Dict[str, Tuple[Callable[[str], str], List[str]]] = {
         fullReleasePage,
         [
             "docs/fullrelease.html",
-            "releases/%s/schema-all.html" % schemaversion.getVersion(),
+            f"releases/{schemaversion.getVersion()}/schema-all.html",
         ],
     ),
-    # "Collabs": (collabs,["docs/collaborators.html"]),
     "TermFind": (termfind, ["docs/termfind/termlist.txt"]),
     "Tree": (jsonldtree, ["docs/tree.jsonld"]),
 }
 
 
 def buildDocs(pages: Iterable[str]) -> None:
-    process_pages: List[str]
-    if any(filter(fileutils.isAll, pages)):
-        process_pages = sorted(PAGELIST.keys())
-    else:
-        process_pages = list(pages)
+    process_pages: List[str] = sorted(PAGELIST.keys()) if any(fileutils.isAll(p) for p in pages) else list(pages)
 
+    page: str
     for page in process_pages:
-        if page not in PAGELIST.keys():
-            log.warning(f"Unknown page name: {page}")
-            continue
-        entry = PAGELIST.get(page)
-        if not entry:
-            log.warning(f"Missing entry for page {page}")
-            continue
-        func, filenames = entry
-        if not func:
-            log.warning(f"Missing function for page {page}")
-            continue
-        with pretty_logger.BlockLog(logger=log, message=f"Generating page {page}"):
-            content: str = func(page)
-            for relative_path in filenames:
-                filename: str = fileutils.ensureAbsolutePath(
-                    output_dir=schemaglobals.OUTPUTDIR, relative_path=relative_path
-                )
-                with open(filename, "w", encoding="utf8") as handle:
-                    handle.write(content)
+        if entry := PAGELIST.get(page):
+            func: Callable[[str], str]
+            filenames: List[str]
+            func, filenames = entry
+            with pretty_logger.BlockLog(logger=log, message=f"Generating page {page}"):
+                content: str = func(page)
+                relative_path: str
+                for relative_path in filenames:
+                    filename: str = fileutils.ensureAbsolutePath(
+                        output_dir=schemaglobals.OUTPUTDIR, relative_path=relative_path
+                    )
+                    Path(filename).write_text(content, encoding="utf8")
+        else:
+            log.warning(f"Unknown or missing page name: {page}")

--- a/software/util/buildsite.py
+++ b/software/util/buildsite.py
@@ -13,6 +13,8 @@ import shutil
 import subprocess
 import sys
 import logging
+import typing
+from typing import Any, Dict, List, Optional, Tuple, Union, Iterable, Sequence, Generator
 
 # Import schema.org libraries
 if not os.getcwd() in sys.path:
@@ -36,11 +38,12 @@ import software.SchemaTerms.localmarkdown
 import software.SchemaTerms.sdocollaborators as sdocollaborators
 import software.SchemaTerms.sdotermsource as sdotermsource
 
-log = logging.getLogger(__name__)
+log: logging.Logger = logging.getLogger(__name__)
 logging.basicConfig(level=logging.INFO)
 
+args: argparse.Namespace
 
-def initialize():
+def initialize() -> argparse.Namespace:
     """Initialize various systems, returns the args object"""
     parser = argparse.ArgumentParser(description=__doc__)
     parser.add_argument(
@@ -160,7 +163,7 @@ def initialize():
     return args
 
 
-def clear():
+def clear() -> None:
     if args.clearfirst or args.autobuild:
         log.info(f"Clearing {schemaglobals.OUTPUTDIR} directory")
         if os.path.isdir(schemaglobals.OUTPUTDIR):
@@ -175,12 +178,12 @@ def clear():
 ###################################################
 # RUN TESTS
 ###################################################
-def runtests():
+def runtests() -> None:
     if args.runtests or args.autobuild:
         with pretty_logger.BlockLog(
             logger=log, message="Running test scripts before proceeding…"
         ):
-            errorcount = runtests_lib.main("./software/tests/")
+            errorcount: int = runtests_lib.main("./software/tests/")
             if errorcount:
                 log.error(f"Errors returned: {errorcount}")
                 sys.exit(errorcount)
@@ -191,7 +194,7 @@ def runtests():
 ###################################################
 
 
-def initdir(output_dir, handler_path):
+def initdir(output_dir: str, handler_path: str) -> None:
     log.info(f'Building site in "{output_dir}" directory')
     fileutils.createMissingDir(output_dir)
     clear()
@@ -204,27 +207,27 @@ def initdir(output_dir, handler_path):
         os.path.join(output_dir, "releases", schemaversion.getVersion())
     )
 
-    gdir = os.path.join(output_dir, "gcloud")
+    gdir: str = os.path.join(output_dir, "gcloud")
     fileutils.createMissingDir(gdir)
 
     with pretty_logger.BlockLog(logger=log, message="Copying docs static files"):
         copystaticdocsplusinsert.copyFiles("./docs", "./software/site/docs")
 
     with pretty_logger.BlockLog(logger=log, message="Preparing GCloud files") as block:
-        gcloud_files = sorted(glob.glob("software/gcloud/*.yaml"))
+        gcloud_files: List[str] = sorted(glob.glob("software/gcloud/*.yaml"))
         for path in gcloud_files:
             shutil.copy(path, gdir)
         block.append("copied %d files" % len(gcloud_files))
 
-    message = "Creating %s from %s for version: %s" % (
+    message: str = "Creating %s from %s for version: %s" % (
         handler_path,
         schemaglobals.HANDLER_TEMPLATE,
         schemaversion.getVersion(),
     )
     with pretty_logger.BlockLog(logger=log, message=message):
         with open(os.path.join(gdir, schemaglobals.HANDLER_TEMPLATE)) as template_file:
-            template_data = template_file.read()
-        handler_data = template_data.replace("{{ver}}", schemaversion.getVersion())
+            template_data: str = template_file.read()
+        handler_data: str = template_data.replace("{{ver}}", schemaversion.getVersion())
         with open(os.path.join(gdir, handler_path), mode="w") as yaml_file:
             yaml_file.write(handler_data)
 
@@ -232,10 +235,10 @@ def initdir(output_dir, handler_path):
 ###################################################
 # TERMS SOURCE LOAD
 ###################################################
-LOADEDTERMS = False
+LOADEDTERMS: bool = False
 
 
-def loadTerms():
+def loadTerms() -> None:
     global LOADEDTERMS
     if LOADEDTERMS:
         return
@@ -251,8 +254,8 @@ def loadTerms():
 ###################################################
 # BUILD INDIVIDUAL TERM PAGES
 ###################################################
-def processTerms(terms):
-    if len(terms):
+def processTerms(terms: Iterable[str]) -> None:
+    if any(True for _ in terms):
         with pretty_logger.BlockLog(
             logger=log, message="Building term definition pages", timing=True
         ):
@@ -264,8 +267,8 @@ def processTerms(terms):
 ###################################################
 # BUILD DYNAMIC DOCS PAGES
 ###################################################
-def processDocs(pages):
-    if len(pages):
+def processDocs(pages: Iterable[str]) -> None:
+    if any(True for _ in pages):
         with pretty_logger.BlockLog(
             logger=log, message="Building dynamic documentation pages", timing=True
         ):
@@ -276,8 +279,8 @@ def processDocs(pages):
 ###################################################
 # BUILD FILES
 ###################################################
-def processFiles(files):
-    if len(files):
+def processFiles(files: Iterable[str]) -> None:
+    if any(True for _ in files):
         with pretty_logger.BlockLog(logger=log, message="Building supporting files"):
             loadTerms()
             schemaexamples.SchemaExamples.loaded()
@@ -290,7 +293,7 @@ def processFiles(files):
 
 
 @contextlib.contextmanager
-def tempory_symlink(src_dir, dst_dir):
+def tempory_symlink(src_dir: str, dst_dir: str) -> Generator[None, None, None]:
     """Context manager to create a temporary directory symlink and clean it up on exit."""
     try:
         log.info(f"Setting up {dst_dir} from {src_dir}")
@@ -303,7 +306,7 @@ def tempory_symlink(src_dir, dst_dir):
         os.unlink(dst_dir)
 
 
-RUBY_INSTALLATION_MESSAGE = """
+RUBY_INSTALLATION_MESSAGE: str = """
 Please check if your Ruby installation is correct and all dependencies installed.
 
 bundle install --gemfile=software/scripts/Gemfile --jobs 4 --retry 3
@@ -311,7 +314,7 @@ bundle install --gemfile=software/scripts/Gemfile --jobs 4 --retry 3
 """
 
 
-def runRubyTests(release_dir):
+def runRubyTests(release_dir: str) -> None:
     """The ruby tests are designed to run in a release sub-directory.
 
     Now generally, this script does not build a full release,
@@ -321,33 +324,33 @@ def runRubyTests(release_dir):
     :param release_dir: the root release directory.
     """
     with pretty_logger.BlockLog(logger=log, message="Running ruby tests"):
-        cmd = ("bundle", "check", "--gemfile=software/scripts/Gemfile")
-        status = subprocess.call(cmd)
+        cmd: Tuple[str, ...] = ("bundle", "check", "--gemfile=software/scripts/Gemfile")
+        status: int = subprocess.call(cmd)
         if status:
             log.error(RUBY_INSTALLATION_MESSAGE)
             exit(status)
-        version = schemaversion.getVersion()
-        src_dir = os.path.join(os.getcwd(), release_dir, version)
+        version: str = schemaversion.getVersion()
+        src_dir: str = os.path.join(os.getcwd(), release_dir, version)
         # Check there is something in the source directory.
         # This always be the case, as the rubytest flag triggers the autobuild flag.
-        root_json_path = os.path.join(src_dir, "schemaorgcontext.jsonld")
+        root_json_path: str = os.path.join(src_dir, "schemaorgcontext.jsonld")
         if not os.path.exists(root_json_path):
             log.error(
                 f"File {root_json_path} not found. Ruby tests require a fully built release."
             )
             exit(os.EX_NOINPUT)
         # Display modification time to the user.
-        timestamp = os.path.getmtime(root_json_path)
-        timestamp_str = datetime.datetime.fromtimestamp(timestamp).strftime(
+        timestamp: float = os.path.getmtime(root_json_path)
+        timestamp_str: str = datetime.datetime.fromtimestamp(timestamp).strftime(
             "%Y-%m-%d %H:%M:%S"
         )
         log.info(f"LATEST Release Build time: {timestamp_str}")
-        dst_dir = os.path.join(os.getcwd(), release_dir, "LATEST")
+        dst_dir: str = os.path.join(os.getcwd(), release_dir, "LATEST")
         with tempory_symlink(src_dir=src_dir, dst_dir=dst_dir):
-            cmd = ["bundle", "exec", "rake"]
-            cwd = os.path.join(os.getcwd(), "software/scripts")
+            cmd_list: List[str] = ["bundle", "exec", "rake"]
+            cwd: str = os.path.join(os.getcwd(), "software/scripts")
             log.info("Running ruby tests")
-            status = subprocess.call(cmd, cwd=cwd)
+            status = subprocess.call(cmd_list, cwd=cwd)
             if status:
                 log.error("Ruby tests failed")
                 sys.exit(status)
@@ -358,16 +361,16 @@ def runRubyTests(release_dir):
 ###################################################
 
 
-def copyReleaseFiles(release_dir):
-    version = schemaversion.getVersion()
-    srcdir = os.path.join(os.getcwd(), "data/releases/", version)
-    destdir = os.path.join(os.getcwd(), release_dir, version)
+def copyReleaseFiles(release_dir: str) -> None:
+    version: str = schemaversion.getVersion()
+    srcdir: str = os.path.join(os.getcwd(), "data/releases/", version)
+    destdir: str = os.path.join(os.getcwd(), release_dir, version)
     with pretty_logger.BlockLog(
         message=f"Copying release files from {srcdir} to {destdir}",
         logger=log,
     ):
         fileutils.mycopytree(srcdir, destdir)
-        cmd = ["git", "add", destdir]
+        cmd: List[str] = ["git", "add", destdir]
         subprocess.check_call(cmd)
 
 

--- a/software/util/buildsite.py
+++ b/software/util/buildsite.py
@@ -217,13 +217,9 @@ def initdir(output_dir: str, handler_path: str) -> None:
         gcloud_files: List[str] = sorted(glob.glob("software/gcloud/*.yaml"))
         for path in gcloud_files:
             shutil.copy(path, gdir)
-        block.append("copied %d files" % len(gcloud_files))
+        block.append(f"copied {len(gcloud_files)} files")
 
-    message: str = "Creating %s from %s for version: %s" % (
-        handler_path,
-        schemaglobals.HANDLER_TEMPLATE,
-        schemaversion.getVersion(),
-    )
+    message: str = f"Creating {handler_path} from {schemaglobals.HANDLER_TEMPLATE} for version: {schemaversion.getVersion()}"
     with pretty_logger.BlockLog(logger=log, message=message):
         with open(os.path.join(gdir, schemaglobals.HANDLER_TEMPLATE)) as template_file:
             template_data: str = template_file.read()

--- a/software/util/buildsite.py
+++ b/software/util/buildsite.py
@@ -3,7 +3,6 @@
 
 """Program that builds the whole schema.org website."""
 
-# Import standard python libraries
 import argparse
 import contextlib
 import datetime
@@ -13,15 +12,13 @@ import shutil
 import subprocess
 import sys
 import logging
-import typing
-from typing import Any, Dict, List, Optional, Tuple, Union, Iterable, Sequence, Generator
+from pathlib import Path
+from typing import Any, Dict, List, Optional, Tuple, Union, Iterable, Sequence, Generator, Type
 
-# Import schema.org libraries
-if not os.getcwd() in sys.path:
+if os.getcwd() not in sys.path:
     sys.path.insert(1, os.getcwd())
 
 import software
-
 import software.util.buildfiles as buildfiles
 import software.util.buildocspages as buildocspages
 import software.util.buildtermpages as buildtermpages
@@ -31,7 +28,6 @@ import software.util.runtests as runtests_lib
 import software.util.schemaglobals as schemaglobals
 import software.util.schemaversion as schemaversion
 import software.util.pretty_logger as pretty_logger
-
 import software.SchemaExamples.schemaexamples as schemaexamples
 import software.SchemaExamples.utils.assign_example_ids
 import software.SchemaTerms.localmarkdown
@@ -45,7 +41,7 @@ args: argparse.Namespace
 
 def initialize() -> argparse.Namespace:
     """Initialize various systems, returns the args object"""
-    parser = argparse.ArgumentParser(description=__doc__)
+    parser: argparse.ArgumentParser = argparse.ArgumentParser(description=__doc__)
     parser.add_argument(
         "-a",
         "--autobuild",
@@ -123,23 +119,28 @@ def initialize() -> argparse.Namespace:
         help="run the post generation ruby tests",
     )
     parser.add_argument(
+        "-release",
         "--release",
         default=False,
         action="store_true",
         help="create page for term (repeatable) - ALL = all terms",
     )
 
-    args = parser.parse_args()
+    args: argparse.Namespace = parser.parse_args()
 
+    op: List[str]
     for op in args.buildoption:
         schemaglobals.BUILDOPTS.extend(op)
 
+    ter: List[str]
     for ter in args.terms:
         schemaglobals.TERMS.extend(ter)
 
+    pgs: List[str]
     for pgs in args.docspages:
         schemaglobals.PAGES.extend(pgs)
 
+    fls: List[str]
     for fls in args.files:
         schemaglobals.FILES.extend(fls)
 
@@ -151,9 +152,6 @@ def initialize() -> argparse.Namespace:
         schemaglobals.PAGES = ["ALL"]
         schemaglobals.FILES = ["ALL"]
 
-    ###################################################
-    # MARKDOWN INITIALISE
-    ###################################################
     software.SchemaTerms.localmarkdown.Markdown.setWikilinkCssClass("localLink")
     software.SchemaTerms.localmarkdown.Markdown.setWikilinkPrePath("/")
     software.SchemaTerms.localmarkdown.Markdown.setWikilinkPostPath("")
@@ -165,19 +163,19 @@ def initialize() -> argparse.Namespace:
 
 def clear() -> None:
     if args.clearfirst or args.autobuild:
-        log.info(f"Clearing {schemaglobals.OUTPUTDIR} directory")
-        if os.path.isdir(schemaglobals.OUTPUTDIR):
-            for root, dirs, files in os.walk(schemaglobals.OUTPUTDIR):
-                for f in files:
-                    if f != ".gitkeep":
-                        os.unlink(os.path.join(root, f))
-                for d in dirs:
-                    shutil.rmtree(os.path.join(root, d))
+        output_dir: Path = Path(schemaglobals.OUTPUTDIR)
+        log.info(f"Clearing {output_dir} directory")
+        if output_dir.is_dir():
+            item: Path
+            for item in output_dir.iterdir():
+                if item.name == ".gitkeep":
+                    continue
+                if item.is_dir():
+                    shutil.rmtree(item)
+                else:
+                    item.unlink()
 
 
-###################################################
-# RUN TESTS
-###################################################
 def runtests() -> None:
     if args.runtests or args.autobuild:
         with pretty_logger.BlockLog(
@@ -189,48 +187,38 @@ def runtests() -> None:
                 sys.exit(errorcount)
 
 
-###################################################
-# INITIALISE Directory
-###################################################
-
-
-def initdir(output_dir: str, handler_path: str) -> None:
+def initdir(output_dir_str: str, handler_path: str) -> None:
+    output_dir: Path = Path(output_dir_str)
     log.info(f'Building site in "{output_dir}" directory')
-    fileutils.createMissingDir(output_dir)
+    output_dir.mkdir(parents=True, exist_ok=True)
     clear()
-    fileutils.createMissingDir(os.path.join(output_dir, "docs"))
-    fileutils.createMissingDir(os.path.join(output_dir, "docs/contributors"))
-    fileutils.createMissingDir(
-        os.path.join(output_dir, "empty")
-    )  # For apppengine 404 handler
-    fileutils.createMissingDir(
-        os.path.join(output_dir, "releases", schemaversion.getVersion())
-    )
+    
+    (output_dir / "docs" / "contributors").mkdir(parents=True, exist_ok=True)
+    (output_dir / "empty").mkdir(parents=True, exist_ok=True)
+    (output_dir / "releases" / schemaversion.getVersion()).mkdir(parents=True, exist_ok=True)
 
-    gdir: str = os.path.join(output_dir, "gcloud")
-    fileutils.createMissingDir(gdir)
+    gdir: Path = output_dir / "gcloud"
+    gdir.mkdir(parents=True, exist_ok=True)
 
     with pretty_logger.BlockLog(logger=log, message="Copying docs static files"):
-        copystaticdocsplusinsert.copyFiles("./docs", "./software/site/docs")
+        copystaticdocsplusinsert.copyFiles("./docs", str(output_dir / "docs"))
 
     with pretty_logger.BlockLog(logger=log, message="Preparing GCloud files") as block:
-        gcloud_files: List[str] = sorted(glob.glob("software/gcloud/*.yaml"))
+        gcloud_files: List[Path] = sorted(Path("software/gcloud").glob("*.yaml"))
+        path: Path
         for path in gcloud_files:
             shutil.copy(path, gdir)
         block.append(f"copied {len(gcloud_files)} files")
 
-    message: str = f"Creating {handler_path} from {schemaglobals.HANDLER_TEMPLATE} for version: {schemaversion.getVersion()}"
+    version: str = schemaversion.getVersion()
+    message: str = f"Creating {handler_path} from {schemaglobals.HANDLER_TEMPLATE} for version: {version}"
     with pretty_logger.BlockLog(logger=log, message=message):
-        with open(os.path.join(gdir, schemaglobals.HANDLER_TEMPLATE)) as template_file:
-            template_data: str = template_file.read()
-        handler_data: str = template_data.replace("{{ver}}", schemaversion.getVersion())
-        with open(os.path.join(gdir, handler_path), mode="w") as yaml_file:
-            yaml_file.write(handler_data)
+        template_file: Path = gdir / schemaglobals.HANDLER_TEMPLATE
+        template_data: str = template_file.read_text()
+        handler_data: str = template_data.replace("{{ver}}", version)
+        (gdir / handler_path).write_text(handler_data)
 
 
-###################################################
-# TERMS SOURCE LOAD
-###################################################
 LOADEDTERMS: bool = False
 
 
@@ -247,11 +235,8 @@ def loadTerms() -> None:
             sdocollaborators.collaborator.loadContributors()
 
 
-###################################################
-# BUILD INDIVIDUAL TERM PAGES
-###################################################
 def processTerms(terms: Iterable[str]) -> None:
-    if any(True for _ in terms):
+    if any(terms):
         with pretty_logger.BlockLog(
             logger=log, message="Building term definition pages", timing=True
         ):
@@ -260,11 +245,8 @@ def processTerms(terms: Iterable[str]) -> None:
             buildtermpages.buildTerms(terms)
 
 
-###################################################
-# BUILD DYNAMIC DOCS PAGES
-###################################################
 def processDocs(pages: Iterable[str]) -> None:
-    if any(True for _ in pages):
+    if any(pages):
         with pretty_logger.BlockLog(
             logger=log, message="Building dynamic documentation pages", timing=True
         ):
@@ -272,34 +254,26 @@ def processDocs(pages: Iterable[str]) -> None:
             buildocspages.buildDocs(pages)
 
 
-###################################################
-# BUILD FILES
-###################################################
 def processFiles(files: Iterable[str]) -> None:
-    if any(True for _ in files):
+    if any(files):
         with pretty_logger.BlockLog(logger=log, message="Building supporting files"):
             loadTerms()
             schemaexamples.SchemaExamples.loaded()
             buildfiles.buildFiles(files)
 
 
-###################################################
-# Run ruby tests
-###################################################
-
-
 @contextlib.contextmanager
-def tempory_symlink(src_dir: str, dst_dir: str) -> Generator[None, None, None]:
+def tempory_symlink(src_dir: Path, dst_dir: Path) -> Generator[None, None, None]:
     """Context manager to create a temporary directory symlink and clean it up on exit."""
     try:
         log.info(f"Setting up {dst_dir} from {src_dir}")
-        if os.path.islink(dst_dir):
-            os.unlink(dst_dir)
-        os.symlink(src_dir, dst_dir, target_is_directory=True)
+        if dst_dir.is_symlink():
+            dst_dir.unlink()
+        dst_dir.symlink_to(src_dir, target_is_directory=True)
         yield
     finally:
         log.info(f"Cleaning up {dst_dir}")
-        os.unlink(dst_dir)
+        dst_dir.unlink()
 
 
 RUBY_INSTALLATION_MESSAGE: str = """
@@ -310,7 +284,7 @@ bundle install --gemfile=software/scripts/Gemfile --jobs 4 --retry 3
 """
 
 
-def runRubyTests(release_dir: str) -> None:
+def runRubyTests(release_dir_str: str) -> None:
     """The ruby tests are designed to run in a release sub-directory.
 
     Now generally, this script does not build a full release,
@@ -320,54 +294,77 @@ def runRubyTests(release_dir: str) -> None:
     :param release_dir: the root release directory.
     """
     with pretty_logger.BlockLog(logger=log, message="Running ruby tests"):
-        cmd: Tuple[str, ...] = ("bundle", "check", "--gemfile=software/scripts/Gemfile")
+        cmd: List[str] = ["bundle", "check", "--gemfile=software/scripts/Gemfile"]
         status: int = subprocess.call(cmd)
         if status:
             log.error(RUBY_INSTALLATION_MESSAGE)
-            exit(status)
+            sys.exit(status)
+        
         version: str = schemaversion.getVersion()
-        src_dir: str = os.path.join(os.getcwd(), release_dir, version)
-        # Check there is something in the source directory.
-        # This always be the case, as the rubytest flag triggers the autobuild flag.
-        root_json_path: str = os.path.join(src_dir, "schemaorgcontext.jsonld")
-        if not os.path.exists(root_json_path):
+        src_dir: Path = Path.cwd() / release_dir_str / version
+        root_json_path: Path = src_dir / "schemaorgcontext.jsonld"
+        if not root_json_path.exists():
             log.error(
                 f"File {root_json_path} not found. Ruby tests require a fully built release."
             )
-            exit(os.EX_NOINPUT)
-        # Display modification time to the user.
-        timestamp: float = os.path.getmtime(root_json_path)
+            sys.exit(os.EX_NOINPUT)
+            
+        timestamp: float = root_json_path.stat().st_mtime
         timestamp_str: str = datetime.datetime.fromtimestamp(timestamp).strftime(
             "%Y-%m-%d %H:%M:%S"
         )
         log.info(f"LATEST Release Build time: {timestamp_str}")
-        dst_dir: str = os.path.join(os.getcwd(), release_dir, "LATEST")
+        dst_dir: Path = Path.cwd() / release_dir_str / "LATEST"
         with tempory_symlink(src_dir=src_dir, dst_dir=dst_dir):
             cmd_list: List[str] = ["bundle", "exec", "rake"]
-            cwd: str = os.path.join(os.getcwd(), "software/scripts")
+            cwd: Path = Path.cwd() / "software/scripts"
             log.info("Running ruby tests")
-            status = subprocess.call(cmd_list, cwd=cwd)
+            status = subprocess.call(cmd_list, cwd=str(cwd))
             if status:
                 log.error("Ruby tests failed")
                 sys.exit(status)
 
 
-###################################################
-# COPY CREATED RELEASE FILES into Data area
-###################################################
-
-
 def copyReleaseFiles(release_dir: str) -> None:
     version: str = schemaversion.getVersion()
-    srcdir: str = os.path.join(os.getcwd(), "data/releases/", version)
-    destdir: str = os.path.join(os.getcwd(), release_dir, version)
+    srcdir: Path = Path.cwd() / "data" / "releases" / version
+    destdir: Path = Path.cwd() / release_dir / version
     with pretty_logger.BlockLog(
         message=f"Copying release files from {srcdir} to {destdir}",
         logger=log,
     ):
-        fileutils.mycopytree(srcdir, destdir)
-        cmd: List[str] = ["git", "add", destdir]
+        fileutils.mycopytree(str(srcdir), str(destdir))
+        cmd: List[str] = ["git", "add", str(destdir)]
         subprocess.check_call(cmd)
+
+
+if __name__ == "__main__":
+    args = initialize()
+
+    software.CheckWorkingDirectory()
+    log.info(
+        f"Version: {schemaversion.getVersion()} Released: {schemaversion.getCurrentVersionDate()}"
+    )
+    if args.rubytests:
+        args.autobuild = True
+    if args.release:
+        args.autobuild = True
+        log.info("BUILDING RELEASE VERSION")
+    if args.examplesnum or args.release or args.autobuild:
+        with pretty_logger.BlockLog(
+            message="Checking Examples for assigned identifiers", logger=log
+        ):
+            software.SchemaExamples.utils.assign_example_ids.AssignExampleIds()
+    initdir(output_dir_str=schemaglobals.OUTPUTDIR, handler_path=schemaglobals.HANDLER_FILE)
+    runtests()
+    processTerms(terms=schemaglobals.TERMS)
+    processDocs(pages=schemaglobals.PAGES)
+    processFiles(files=schemaglobals.FILES)
+
+    if args.release:
+        copyReleaseFiles(release_dir=schemaglobals.RELEASE_DIR)
+    if args.rubytests:
+        runRubyTests(release_dir=schemaglobals.RELEASE_DIR)
 
 
 ###################################################
@@ -392,7 +389,7 @@ if __name__ == "__main__":
             message="Checking Examples for assigned identifiers", logger=log
         ):
             software.SchemaExamples.utils.assign_example_ids.AssignExampleIds()
-    initdir(output_dir=schemaglobals.OUTPUTDIR, handler_path=schemaglobals.HANDLER_FILE)
+    initdir(output_dir_str=schemaglobals.OUTPUTDIR, handler_path=schemaglobals.HANDLER_FILE)
     runtests()
     processTerms(terms=schemaglobals.TERMS)
     processDocs(pages=schemaglobals.PAGES)

--- a/software/util/buildtermpages.py
+++ b/software/util/buildtermpages.py
@@ -1,24 +1,19 @@
 #!/usr/bin/env python3
 # -*- coding: utf-8 -*-
-
-# Import standard python libraries
-
 import collections
 import datetime
 import logging
 import multiprocessing
-import os
 import re
 import sys
 import time
-import typing
-from typing import List, Optional, Tuple, Dict, Any, Iterable
+from pathlib import Path
+from typing import List, Optional, Tuple, Dict, Any, Iterable, Sequence, Type
 
 import jinja2
 
-# Import schema.org libraries
-if not os.getcwd() in sys.path:
-    sys.path.insert(1, os.getcwd())
+if Path.cwd() not in [Path(p).resolve() for p in sys.path]:
+    sys.path.insert(1, str(Path.cwd()))
 
 import software
 import software.util.schemaglobals as schemaglobals
@@ -26,53 +21,38 @@ import software.util.fileutils as fileutils
 import software.util.pretty_logger as pretty_logger
 import software.util.jinga_render as jinga_render
 
-
 import software.SchemaTerms.sdotermsource as sdotermsource
 import software.SchemaTerms.sdoterm as sdoterm
 import software.SchemaExamples.schemaexamples as schemaexamples
-
 
 log: logging.Logger = logging.getLogger(__name__)
 
 
 def termFileName(termid: str) -> str:
-    """Generate filename for term page.
-
-    Parameters:
-      termid (str): term identifier.
-    Returns:
-      File path the term page should be generated at.
-    """
-    path_components: List[str] = [schemaglobals.getOutputDir(), "terms"]
-    if re.match("^[a-z].*", termid):
-        path_components.append("properties")
-    elif re.match("^[0-9A-Z].*", termid):
-        path_components.append("types")
+    """Generate filename for term page."""
+    if not termid:
+        raise ValueError("Empty termid")
+    base_dir: Path = Path(schemaglobals.getOutputDir()) / "terms"
+    sub_dir: str
+    if termid[0].islower():
+        sub_dir = "properties"
+    elif termid[0].isupper() or termid[0].isdigit():
+        sub_dir = "types"
     else:
-        raise ValueError("Invalid terminid: '" + termid + "'")
-    path_components.append(termid[0])
-    directory: str = os.path.join(*path_components)
-    fileutils.checkFilePath(directory)
-    filename: str = termid + ".html"
-    return os.path.join(directory, filename)
+        raise ValueError(f"Invalid termid: '{termid}'")
+        
+    return str(base_dir / sub_dir / termid[0] / f"{termid}.html")
 
 
-# This template will be used ~2800 times, so we reuse it.
 TEMPLATE: jinja2.Template = jinga_render.GetJinga().get_template("terms/TermPage.j2")
 
 
 def termtemplateRender(term: sdoterm.SdoTerm, examples: List[schemaexamples.Example], json: str) -> str:
-    """Render the term with examples and associated JSON.
-
-    Parameters:
-      term (sdoterm.SdoTerm): term to generate the page for
-      examples (schemaexamples.Example): collection of examples for the term.
-    Returns:
-      string with the generate web-page.
-    """
+    """Render the term with examples and associated JSON."""
     assert isinstance(term, sdoterm.SdoTerm)
+    ex: schemaexamples.Example
     for ex in examples:
-        exselect: List[str] = ["", "", "", ""]
+        exselect: List[str] = [""] * 4
         if ex.hasHtml():
             exselect[0] = "selected"
         elif ex.hasMicrodata():
@@ -81,7 +61,7 @@ def termtemplateRender(term: sdoterm.SdoTerm, examples: List[schemaexamples.Exam
             exselect[2] = "selected"
         elif ex.hasJsonld():
             exselect[3] = "selected"
-        ex.exselect = exselect
+        ex.exselect = exselect # type: ignore
 
     extra_vars: Dict[str, Any] = {
         "title": term.label,
@@ -99,40 +79,37 @@ def termtemplateRender(term: sdoterm.SdoTerm, examples: List[schemaexamples.Exam
 
 
 def RenderAndWriteSingleTerm(term_key: str) -> float:
-    """Renders a single term and write the result into a file.
+    """Renders a single term and write the result into a file."""
 
-    Parameters:
-      term_key (str): key for the term.
-    """
-
+    block: pretty_logger.BlockLog
     with pretty_logger.BlockLog(
         logger=log, message=f"Generate term {term_key}", timing=True, displayStart=False
     ) as block:
         term: Optional[sdoterm.SdoTerm] = sdotermsource.SdoTermSource.getTerm(term_key, expanded=True)
         if not term:
             log.error(f"No such term: {term_key}")
-            return 0
-        if (
-            term.termType == sdoterm.SdoTermType.REFERENCE
-        ):  # Don't create pages for reference types
-            return 0
+            return 0.0
+        if term.termType == sdoterm.SdoTermType.REFERENCE:
+            return 0.0
         try:
           examples: List[schemaexamples.Example] = schemaexamples.SchemaExamples.examplesForTerm(term.id)
-          json_str: str = sdotermsource.SdoTermSource.getTermAsRdfString(
-              term.id, "json-ld", full=True
-          )
+          json_str: str = sdotermsource.SdoTermSource.getTermAsRdfString(term.id, "json-ld", full=True)
           pageout: str = termtemplateRender(term, examples, json_str)
-          with open(termFileName(term.id), "w", encoding="utf8") as outfile:
-              outfile.write(pageout)
+          outfile: Path = Path(termFileName(term.id))
+          fileutils.checkFilePath(outfile.parent)
+          outfile.write_text(pageout, encoding="utf8")
         except Exception as e:
             e.add_note(f"Term definition: {term}")
             raise
-    return block.elapsed
+    return float(block.elapsed or 0.0)
 
 
 def _buildTermIds(pair: Tuple[int, List[str]]) -> None:
+    shard: int
+    term_ids: List[str]
     shard, term_ids = pair
     pretty_logger.MakeRootLogPretty(shard=shard)
+    term_id: str
     for term_id in term_ids:
         try:
             RenderAndWriteSingleTerm(term_id)
@@ -142,30 +119,28 @@ def _buildTermIds(pair: Tuple[int, List[str]]) -> None:
 
 
 def buildTerms(term_ids: Iterable[str]) -> None:
-    """Build the rendered version for a collection of terms.
-
-    As this is rather CPU intensive, we shard the work into as many processes
-    as there are CPUs.
-    """
-
+    """Build the rendered version for a collection of terms."""
     tic: float = time.perf_counter()
-    if any(filter(fileutils.isAll, term_ids)):
+    if any(fileutils.isAll(tid) for tid in term_ids):
         log.info("Loading all term identifiers")
-        term_ids = sdotermsource.SdoTermSource.getAllTerms(suppressSourceLinks=True)
+        term_ids = sdotermsource.SdoTermSource.getAllTerms(suppressSourceLinks=True) # type: ignore
 
-    if not term_ids:
+    term_list: List[str] = list(term_ids)
+    if not term_list:
         return
 
     shard_numbers: int = multiprocessing.cpu_count()
     with pretty_logger.BlockLog(
         logger=log,
-        message=f"Building {len(list(term_ids))} term pages with {shard_numbers} shards.",
+        message=f"Building {len(term_list)} term pages with {shard_numbers} shards.",
     ):
         sharded_terms: Dict[int, List[str]] = collections.defaultdict(list)
-        for n, term_id in enumerate(term_ids):
+        n: int
+        term_id: str
+        for n, term_id in enumerate(term_list):
             sharded_terms[n % shard_numbers].append(term_id)
 
         with multiprocessing.Pool() as pool:
             pool.map(_buildTermIds, sharded_terms.items())
     elapsed: datetime.timedelta = datetime.timedelta(seconds=time.perf_counter() - tic)
-    log.info(f"{len(list(term_ids))} Terms generated in {elapsed} seconds")
+    log.info(f"{len(term_list)} Terms generated in {elapsed} seconds")

--- a/software/util/buildtermpages.py
+++ b/software/util/buildtermpages.py
@@ -11,7 +11,10 @@ import os
 import re
 import sys
 import time
+import typing
+from typing import List, Optional, Tuple, Dict, Any, Iterable
 
+import jinja2
 
 # Import schema.org libraries
 if not os.getcwd() in sys.path:
@@ -22,7 +25,6 @@ import software.util.schemaglobals as schemaglobals
 import software.util.fileutils as fileutils
 import software.util.pretty_logger as pretty_logger
 import software.util.jinga_render as jinga_render
-import software.util.pretty_logger as pretty_logger
 
 
 import software.SchemaTerms.sdotermsource as sdotermsource
@@ -30,10 +32,10 @@ import software.SchemaTerms.sdoterm as sdoterm
 import software.SchemaExamples.schemaexamples as schemaexamples
 
 
-log = logging.getLogger(__name__)
+log: logging.Logger = logging.getLogger(__name__)
 
 
-def termFileName(termid):
+def termFileName(termid: str) -> str:
     """Generate filename for term page.
 
     Parameters:
@@ -41,7 +43,7 @@ def termFileName(termid):
     Returns:
       File path the term page should be generated at.
     """
-    path_components = [schemaglobals.getOutputDir(), "terms"]
+    path_components: List[str] = [schemaglobals.getOutputDir(), "terms"]
     if re.match("^[a-z].*", termid):
         path_components.append("properties")
     elif re.match("^[0-9A-Z].*", termid):
@@ -49,17 +51,17 @@ def termFileName(termid):
     else:
         raise ValueError("Invalid terminid: '" + termid + "'")
     path_components.append(termid[0])
-    directory = os.path.join(*path_components)
+    directory: str = os.path.join(*path_components)
     fileutils.checkFilePath(directory)
-    filename = termid + ".html"
+    filename: str = termid + ".html"
     return os.path.join(directory, filename)
 
 
 # This template will be used ~2800 times, so we reuse it.
-TEMPLATE = jinga_render.GetJinga().get_template("terms/TermPage.j2")
+TEMPLATE: jinja2.Template = jinga_render.GetJinga().get_template("terms/TermPage.j2")
 
 
-def termtemplateRender(term, examples, json):
+def termtemplateRender(term: sdoterm.SdoTerm, examples: List[schemaexamples.Example], json: str) -> str:
     """Render the term with examples and associated JSON.
 
     Parameters:
@@ -70,7 +72,7 @@ def termtemplateRender(term, examples, json):
     """
     assert isinstance(term, sdoterm.SdoTerm)
     for ex in examples:
-        exselect = ["", "", "", ""]
+        exselect: List[str] = ["", "", "", ""]
         if ex.hasHtml():
             exselect[0] = "selected"
         elif ex.hasMicrodata():
@@ -81,7 +83,7 @@ def termtemplateRender(term, examples, json):
             exselect[3] = "selected"
         ex.exselect = exselect
 
-    extra_vars = {
+    extra_vars: Dict[str, Any] = {
         "title": term.label,
         "menu_sel": "Schemas",
         "home_page": "False",
@@ -96,7 +98,7 @@ def termtemplateRender(term, examples, json):
     )
 
 
-def RenderAndWriteSingleTerm(term_key):
+def RenderAndWriteSingleTerm(term_key: str) -> float:
     """Renders a single term and write the result into a file.
 
     Parameters:
@@ -106,7 +108,7 @@ def RenderAndWriteSingleTerm(term_key):
     with pretty_logger.BlockLog(
         logger=log, message=f"Generate term {term_key}", timing=True, displayStart=False
     ) as block:
-        term = sdotermsource.SdoTermSource.getTerm(term_key, expanded=True)
+        term: Optional[sdoterm.SdoTerm] = sdotermsource.SdoTermSource.getTerm(term_key, expanded=True)
         if not term:
             log.error(f"No such term: {term_key}")
             return 0
@@ -115,11 +117,11 @@ def RenderAndWriteSingleTerm(term_key):
         ):  # Don't create pages for reference types
             return 0
         try:
-          examples = schemaexamples.SchemaExamples.examplesForTerm(term.id)
-          json = sdotermsource.SdoTermSource.getTermAsRdfString(
+          examples: List[schemaexamples.Example] = schemaexamples.SchemaExamples.examplesForTerm(term.id)
+          json_str: str = sdotermsource.SdoTermSource.getTermAsRdfString(
               term.id, "json-ld", full=True
           )
-          pageout = termtemplateRender(term, examples, json)
+          pageout: str = termtemplateRender(term, examples, json_str)
           with open(termFileName(term.id), "w", encoding="utf8") as outfile:
               outfile.write(pageout)
         except Exception as e:
@@ -128,7 +130,7 @@ def RenderAndWriteSingleTerm(term_key):
     return block.elapsed
 
 
-def _buildTermIds(pair):
+def _buildTermIds(pair: Tuple[int, List[str]]) -> None:
     shard, term_ids = pair
     pretty_logger.MakeRootLogPretty(shard=shard)
     for term_id in term_ids:
@@ -139,14 +141,14 @@ def _buildTermIds(pair):
             raise
 
 
-def buildTerms(term_ids):
+def buildTerms(term_ids: Iterable[str]) -> None:
     """Build the rendered version for a collection of terms.
 
     As this is rather CPU intensive, we shard the work into as many processes
     as there are CPUs.
     """
 
-    tic = time.perf_counter()
+    tic: float = time.perf_counter()
     if any(filter(fileutils.isAll, term_ids)):
         log.info("Loading all term identifiers")
         term_ids = sdotermsource.SdoTermSource.getAllTerms(suppressSourceLinks=True)
@@ -154,16 +156,16 @@ def buildTerms(term_ids):
     if not term_ids:
         return
 
-    shard_numbers = multiprocessing.cpu_count()
+    shard_numbers: int = multiprocessing.cpu_count()
     with pretty_logger.BlockLog(
         logger=log,
-        message=f"Building {len(term_ids)} term pages with {shard_numbers} shards.",
+        message=f"Building {len(list(term_ids))} term pages with {shard_numbers} shards.",
     ):
-        sharded_terms = collections.defaultdict(list)
+        sharded_terms: Dict[int, List[str]] = collections.defaultdict(list)
         for n, term_id in enumerate(term_ids):
             sharded_terms[n % shard_numbers].append(term_id)
 
         with multiprocessing.Pool() as pool:
             pool.map(_buildTermIds, sharded_terms.items())
-    elapsed = datetime.timedelta(seconds=time.perf_counter() - tic)
-    log.info(f"{len(term_ids)} Terms generated in {elapsed} seconds")
+    elapsed: datetime.timedelta = datetime.timedelta(seconds=time.perf_counter() - tic)
+    log.info(f"{len(list(term_ids))} Terms generated in {elapsed} seconds")

--- a/software/util/convertmd2htmldocs.py
+++ b/software/util/convertmd2htmldocs.py
@@ -7,6 +7,8 @@ import sys
 import os
 import glob
 import markdown2 as markdown
+import typing
+from typing import Any, Dict, List, Optional, Tuple, Union, Iterable, Sequence, Set, Callable
 
 # Import schema.org libraries
 if not os.getcwd() in sys.path:
@@ -15,7 +17,7 @@ if not os.getcwd() in sys.path:
 import software
 
 
-begin = """<!DOCTYPE html>
+begin: str = """<!DOCTYPE html>
 <html xmlns="http://www.w3.org/1999/xhtml" xml:lang="en" lang="en">
 <head>
 <meta http-equiv="Content-Type" content="text/html; charset=UTF-8" />
@@ -26,23 +28,25 @@ begin = """<!DOCTYPE html>
 <!-- #### Static Doc Insert PageHead goes here -->
 <div id="mainContent" class="faq">"""
 
-end = """</div>\n<!-- #### Static Doc Insert Footer goes here -->\n </html>"""
+end: str = """</div>\n<!-- #### Static Doc Insert Footer goes here -->\n </html>"""
 
 
-def mddocs(sourceDir, destDir):
-    docs = glob.glob(sourceDir + "/*.md")
+def mddocs(sourceDir: str, destDir: str) -> None:
+    docs: List[str] = glob.glob(sourceDir + "/*.md")
     for d in docs:
         convert2html(d, destDir)
 
 
-def convert2html(input_path, destdir):
-    filename = os.path.basename(input_path)
+def convert2html(input_path: str, destdir: str) -> None:
+    filename: str = os.path.basename(input_path)
+    name: str
+    extension: str
     name, extension = os.path.splitext(filename)
     with open(input_path, "r") as in_handle:
-        text = in_handle.read()
-        md_html = markdown.markdown(text)
+        text: str = in_handle.read()
+        md_html: str = markdown.markdown(text)
 
-    output_path = os.path.join(destdir, name + ".html")
+    output_path: str = os.path.join(destdir, name + ".html")
     with open(output_path, "w") as output_handle:
         output_handle.write(begin.format(title=name.title()))
         output_handle.write(md_html)

--- a/software/util/copystaticdocsplusinsert.py
+++ b/software/util/copystaticdocsplusinsert.py
@@ -10,6 +10,7 @@ import os
 import glob
 import re
 import logging
+from typing import Dict, Generator, Tuple, Optional
 
 
 # Import schema.org libraries
@@ -21,30 +22,30 @@ import software.util.schemaversion as schemaversion
 import software.util.fileutils as fileutils
 import software.util.convertmd2htmldocs as convertmd2htmldocs
 
-log = logging.getLogger(__name__)
+log: logging.Logger = logging.getLogger(__name__)
 
 
-def _getInserts():
+def _getInserts() -> Generator[Tuple[str, str], None, None]:
     for f_path in glob.glob("./templates/static-doc-inserts/*.html"):
-        fn = os.path.basename(f_path).lower()
+        fn: str = os.path.basename(f_path).lower()
         fn, _ = os.path.splitext(fn)
         with open(f_path) as input_file:
-            indata = input_file.read()
+            indata: str = input_file.read()
         fn = fn[4:]  # drop sdi- from file name
         indata = indata.replace("{{version}}", schemaversion.getVersion())
         indata = indata.replace(
-            "{{versiondate}}", schemaversion.getCurrentVersionDate()
+            "{{versiondate}}", str(schemaversion.getCurrentVersionDate())
         )
         indata = indata.replace("{{docsdir}}", "/docs")
         yield (fn, indata)
 
 
 class Replacer:
-    def __init__(self, destdir):
-        self.inserts = dict(_getInserts())
-        self.destdir = destdir
+    def __init__(self, destdir: str) -> None:
+        self.inserts: Dict[str, str] = dict(_getInserts())
+        self.destdir: str = destdir
 
-    def insertcopy(self, doc, docdata=None):
+    def insertcopy(self, doc: str, docdata: Optional[str] = None) -> None:
         """Apply all substitutions defined in self.inserts to a file.
 
         The resulting output is written to a path in `destdir` based on the path `doc`.
@@ -58,32 +59,32 @@ class Replacer:
                 docdata = docfile.read()
 
         if re.search("<!-- #### Static Doc Insert", docdata, re.IGNORECASE):
-            for sub in self.inserts:
-                subpattern = re.compile(
+            for sub, insert_content in self.inserts.items():
+                subpattern: re.Pattern = re.compile(
                     "<!-- #### Static Doc Insert %s .* -->" % sub, re.IGNORECASE
                 )
-                docdata = subpattern.sub(self.inserts.get(sub), docdata, re.IGNORECASE)
+                docdata = subpattern.sub(insert_content, docdata)
 
-            targetfile = os.path.join(self.destdir, os.path.basename(doc))
+            targetfile: str = os.path.join(self.destdir, os.path.basename(doc))
             with open(targetfile, "w") as outfile:
                 outfile.write(docdata)
 
 
-SRCDIR = "./docs"
-DESTDIR = "./software/site/docs"
+SRCDIR: str = "./docs"
+DESTDIR: str = "./software/site/docs"
 
 
-def htmlinserts(destdir):
+def htmlinserts(destdir: str) -> None:
     """Perform susbstitions on all HTML files in DESTDIR."""
     log.info("Adding header/footer templates to all html files")
-    docs = sorted(glob.glob(os.path.join(destdir, "*.html")))
-    replacer = Replacer(destdir=destdir)
+    docs: List[str] = sorted(glob.glob(os.path.join(destdir, "*.html")))
+    replacer: Replacer = Replacer(destdir=destdir)
     for doc in docs:
         replacer.insertcopy(doc)
     log.info("Added to %d files" % len(docs))
 
 
-def copyFiles(srcdir, destdir):
+def copyFiles(srcdir: str, destdir: str) -> None:
     """Copy and complete all the static document pages."""
     fileutils.mycopytree(srcdir, destdir)
     log.info("Converting .md docs to html")

--- a/software/util/copystaticdocsplusinsert.py
+++ b/software/util/copystaticdocsplusinsert.py
@@ -10,7 +10,7 @@ import os
 import glob
 import re
 import logging
-from typing import Dict, Generator, Tuple, Optional
+from typing import Dict, Generator, Tuple, Optional, List
 
 
 # Import schema.org libraries
@@ -61,7 +61,7 @@ class Replacer:
         if re.search("<!-- #### Static Doc Insert", docdata, re.IGNORECASE):
             for sub, insert_content in self.inserts.items():
                 subpattern: re.Pattern = re.compile(
-                    "<!-- #### Static Doc Insert %s .* -->" % sub, re.IGNORECASE
+                    f"<!-- #### Static Doc Insert {sub} .* -->", re.IGNORECASE
                 )
                 docdata = subpattern.sub(insert_content, docdata)
 
@@ -81,7 +81,7 @@ def htmlinserts(destdir: str) -> None:
     replacer: Replacer = Replacer(destdir=destdir)
     for doc in docs:
         replacer.insertcopy(doc)
-    log.info("Added to %d files" % len(docs))
+    log.info(f"Added to {len(docs)} files")
 
 
 def copyFiles(srcdir: str, destdir: str) -> None:

--- a/software/util/copystaticdocsplusinsert.py
+++ b/software/util/copystaticdocsplusinsert.py
@@ -3,21 +3,15 @@
 
 """Tool that handles includes in static html files."""
 
-# Import standard python libraries
-
-import sys
-import os
-import glob
-import re
 import logging
-from typing import Dict, Generator, Tuple, Optional, List
+import re
+import sys
+from pathlib import Path
+from typing import Dict, Generator, Tuple, Optional, List, Iterable, Union
 
+if Path.cwd() not in [Path(p).resolve() for p in sys.path]:
+    sys.path.insert(1, str(Path.cwd()))
 
-# Import schema.org libraries
-if not os.getcwd() in sys.path:
-    sys.path.insert(1, os.getcwd())
-
-import software
 import software.util.schemaversion as schemaversion
 import software.util.fileutils as fileutils
 import software.util.convertmd2htmldocs as convertmd2htmldocs
@@ -26,59 +20,48 @@ log: logging.Logger = logging.getLogger(__name__)
 
 
 def _getInserts() -> Generator[Tuple[str, str], None, None]:
-    for f_path in glob.glob("./templates/static-doc-inserts/*.html"):
-        fn: str = os.path.basename(f_path).lower()
-        fn, _ = os.path.splitext(fn)
-        with open(f_path) as input_file:
-            indata: str = input_file.read()
-        fn = fn[4:]  # drop sdi- from file name
+    template_dir: Path = Path("./templates/static-doc-inserts")
+    f_path: Path
+    for f_path in template_dir.glob("*.html"):
+        fn: str = f_path.stem.lower()
+        if fn.startswith("sdi-"):
+            fn = fn[4:]
+            
+        indata: str = f_path.read_text()
         indata = indata.replace("{{version}}", schemaversion.getVersion())
-        indata = indata.replace(
-            "{{versiondate}}", str(schemaversion.getCurrentVersionDate())
-        )
+        indata = indata.replace("{{versiondate}}", str(schemaversion.getCurrentVersionDate()))
         indata = indata.replace("{{docsdir}}", "/docs")
         yield (fn, indata)
 
 
 class Replacer:
-    def __init__(self, destdir: str) -> None:
+    def __init__(self, destdir: Union[str, Path]) -> None:
         self.inserts: Dict[str, str] = dict(_getInserts())
-        self.destdir: str = destdir
+        self.destdir: Path = Path(destdir)
 
-    def insertcopy(self, doc: str, docdata: Optional[str] = None) -> None:
-        """Apply all substitutions defined in self.inserts to a file.
+    def insertcopy(self, doc: Union[str, Path], docdata: Optional[str] = None) -> None:
+        """Apply all substitutions defined in self.inserts to a file."""
+        doc_path: Path = Path(doc)
+        data: str = docdata if docdata is not None else doc_path.read_text()
 
-        The resulting output is written to a path in `destdir` based on the path `doc`.
-
-        Parameters:
-            doc (str): path to the file to load, only used if docdata is None.
-            docdata (str): data to apply the replacement, if empty, data is loaded from doc.
-        """
-        if not docdata:
-            with open(doc) as docfile:
-                docdata = docfile.read()
-
-        if re.search("<!-- #### Static Doc Insert", docdata, re.IGNORECASE):
+        if re.search(r"<!-- #### Static Doc Insert", data, re.IGNORECASE):
+            sub: str
+            insert_content: str
             for sub, insert_content in self.inserts.items():
-                subpattern: re.Pattern = re.compile(
-                    f"<!-- #### Static Doc Insert {sub} .* -->", re.IGNORECASE
-                )
-                docdata = subpattern.sub(insert_content, docdata)
+                subpattern: re.Pattern = re.compile(f"<!-- #### Static Doc Insert {sub} .* -->", re.IGNORECASE)
+                data = subpattern.sub(insert_content, data)
 
-            targetfile: str = os.path.join(self.destdir, os.path.basename(doc))
-            with open(targetfile, "w") as outfile:
-                outfile.write(docdata)
+            targetfile: Path = self.destdir / doc_path.name
+            targetfile.write_text(data)
 
 
-SRCDIR: str = "./docs"
-DESTDIR: str = "./software/site/docs"
-
-
-def htmlinserts(destdir: str) -> None:
-    """Perform susbstitions on all HTML files in DESTDIR."""
+def htmlinserts(destdir: Union[str, Path]) -> None:
+    """Perform substitutions on all HTML files in destdir."""
     log.info("Adding header/footer templates to all html files")
-    docs: List[str] = sorted(glob.glob(os.path.join(destdir, "*.html")))
-    replacer: Replacer = Replacer(destdir=destdir)
+    dest_path: Path = Path(destdir)
+    docs: List[Path] = sorted(dest_path.glob("*.html"))
+    replacer: Replacer = Replacer(destdir=dest_path)
+    doc: Path
     for doc in docs:
         replacer.insertcopy(doc)
     log.info(f"Added to {len(docs)} files")
@@ -88,10 +71,10 @@ def copyFiles(srcdir: str, destdir: str) -> None:
     """Copy and complete all the static document pages."""
     fileutils.mycopytree(srcdir, destdir)
     log.info("Converting .md docs to html")
-    convertmd2htmldocs.mddocs(DESTDIR, DESTDIR)
+    convertmd2htmldocs.mddocs(destdir, destdir)
     htmlinserts(destdir=destdir)
     log.info("Done")
 
 
 if __name__ == "__main__":
-    copyFiles(SRCDIR, DESTDIR)
+    copyFiles("./docs", "./software/site/docs")

--- a/software/util/fileutils.py
+++ b/software/util/fileutils.py
@@ -1,11 +1,10 @@
 #!/usr/bin/env python3
 # -*- coding: utf-8 -*-
 
-import os
-import shutil
 import enum
-from typing import Dict, Set, Union, Optional, List, Callable, Iterable, Any
-
+import shutil
+from pathlib import Path
+from typing import Dict, Set, Union, Optional, List, Callable, Iterable, Any, FrozenSet
 
 EXTENSIONS_FOR_FORMAT: Dict[str, str] = {
     "xml": "xml",
@@ -25,18 +24,17 @@ class FileSelector(str, enum.Enum):
     CURRENT = "current"
 
     def __str__(self) -> str:
-        return self.value
+        return str(self.value)
 
 
-CHECKEDPATHS: Set[str] = set()
-FILESET_SELECTORS: Set[str] = frozenset([s.value for s in FileSelector])
-FILESET_PROTOCOLS: Set[str] = frozenset(["http", "https"])
+CHECKEDPATHS: Set[Path] = set()
+FILESET_SELECTORS: FrozenSet[str] = frozenset([s.value for s in FileSelector])
+FILESET_PROTOCOLS: FrozenSet[str] = frozenset(["http", "https"])
 
 
-def createMissingDir(dir_path: str) -> None:
+def createMissingDir(dir_path: Union[str, Path]) -> None:
     """Create a directory if it does not exist"""
-    if not os.path.exists(dir_path):
-        os.makedirs(dir_path)
+    Path(dir_path).mkdir(parents=True, exist_ok=True)
 
 
 def isAll(selector: Union[str, FileSelector]) -> bool:
@@ -44,23 +42,18 @@ def isAll(selector: Union[str, FileSelector]) -> bool:
     return str(selector).lower() == FileSelector.ALL
 
 
-def checkFilePath(path: str) -> None:
-    if not path in CHECKEDPATHS:
-        CHECKEDPATHS.add(path)
-        # os.path.join ignores the first argument if `path` is absolute.
-        full_path: str = os.path.join(os.getcwd(), path)
-        try:
-            os.makedirs(full_path)
-        except OSError as e:
-            if not os.path.isdir(full_path):
-                raise e
+def checkFilePath(path: Union[str, Path]) -> None:
+    full_path: Path = Path(path).resolve()
+    if full_path not in CHECKEDPATHS:
+        full_path.mkdir(parents=True, exist_ok=True)
+        CHECKEDPATHS.add(full_path)
 
 
-def ensureAbsolutePath(output_dir: str, relative_path: str) -> str:
+def ensureAbsolutePath(output_dir: Union[str, Path], relative_path: str) -> str:
     """Convert into an absolute path and ensure the directory exists."""
-    filepath: str = os.path.join(output_dir, relative_path)
-    checkFilePath(os.path.dirname(filepath))
-    return filepath
+    filepath: Path = Path(output_dir) / relative_path
+    checkFilePath(filepath.parent)
+    return str(filepath.absolute())
 
 
 def releaseFilePath(
@@ -72,24 +65,13 @@ def releaseFilePath(
     suffix: Optional[str] = None,
     subdirectory_path: Optional[str] = None,
 ) -> str:
-    """Create a path for a release file
-
-    Args:
-        output_directory: typically schemaglobals.OUTPUTDIR
-        version: version number
-        selector: either FileSelector.ALL or FileSelector.CURRENT
-        protocol: either 'http' or 'https'
-        output_format: one of the keys present in `EXTENSIONS_FOR_FORMAT`
-        suffix: optional suffix that is ended at the end of the file.
-        subdirectory_path: optional subdirectory path. If None, defaults to "releases/{version}". An empty string means the root of output_dir.
-    Returns:
-        an absolute path with the necessary directories created.
-    """
+    """Create a path for a release file"""
     extension: str = EXTENSIONS_FOR_FORMAT[output_format.lower()]
     selector_str: str = str(selector).lower()
     assert selector_str in FILESET_SELECTORS, selector_str
     protocol = protocol.lower()
     assert protocol in FILESET_PROTOCOLS, protocol
+    
     parts: List[str] = [selector_str, protocol]
     if suffix:
         parts.append(suffix)
@@ -99,54 +81,15 @@ def releaseFilePath(
     if subdirectory_path is None:
         subdirectory_path = f"releases/{version}"
 
-    relative_path: str = os.path.join(subdirectory_path, filename)
     return ensureAbsolutePath(
         output_dir=output_dir,
-        relative_path=relative_path,
+        relative_path=str(Path(subdirectory_path) / filename),
     )
 
 
 def mycopytree(src: str, dst: str, symlinks: bool = False, ignore: Optional[Callable[[str, List[str]], Iterable[str]]] = None) -> None:
     """Copy a file-system tree, copes with already existing directories."""
-    names: List[str] = os.listdir(src)
-    ignored_names: Set[str]
-    if ignore is not None:
-        ignored_names = set(ignore(src, names))
-    else:
-        ignored_names = set()
-
-    if not os.path.isdir(dst):
-        os.makedirs(dst)
-    errors: List[Any] = []
-    for name in names:
-        if name in ignored_names:
-            continue
-        srcname: str = os.path.join(src, name)
-        dstname: str = os.path.join(dst, name)
-        try:
-            if symlinks and os.path.islink(srcname):
-                linkto: str = os.readlink(srcname)
-                os.symlink(linkto, dstname)
-            elif os.path.isdir(srcname):
-                mycopytree(srcname, dstname, symlinks, ignore)
-            else:
-                # Will raise a SpecialFileError for unsupported file types
-                shutil.copy2(srcname, dstname)
-        # catch the Error from the recursive copytree so that we can
-        # continue with other files
-        except OSError as err:
-            errors.extend(err.args[0])
-        except EnvironmentError as why:
-            errors.append((srcname, dstname, str(why)))
     try:
-        shutil.copystat(src, dst)
-    except OSError as why:
-        # WindowsError might not be available on all systems
-        win_err = getattr(__builtins__, 'WindowsError', None)
-        if win_err and isinstance(why, win_err):
-            # Copying file access times may fail on Windows
-            pass
-        else:
-            errors.append((src, dst, str(why)))
-    if errors:
-        raise Exception(errors)
+        shutil.copytree(src, dst, symlinks=symlinks, ignore=ignore, dirs_exist_ok=True)
+    except shutil.Error as err:
+        raise Exception(err.args[0])

--- a/software/util/fileutils.py
+++ b/software/util/fileutils.py
@@ -4,9 +4,10 @@
 import os
 import shutil
 import enum
+from typing import Dict, Set, Union, Optional, List, Callable, Iterable, Any
 
 
-EXTENSIONS_FOR_FORMAT = {
+EXTENSIONS_FOR_FORMAT: Dict[str, str] = {
     "xml": "xml",
     "rdf": "rdf",
     "nquads": "nq",
@@ -23,54 +24,54 @@ class FileSelector(str, enum.Enum):
     ALL = "all"
     CURRENT = "current"
 
-    def __str__(self):
+    def __str__(self) -> str:
         return self.value
 
 
-CHECKEDPATHS = set()
-FILESET_SELECTORS = frozenset([s.value for s in FileSelector])
-FILESET_PROTOCOLS = frozenset(["http", "https"])
+CHECKEDPATHS: Set[str] = set()
+FILESET_SELECTORS: Set[str] = frozenset([s.value for s in FileSelector])
+FILESET_PROTOCOLS: Set[str] = frozenset(["http", "https"])
 
 
-def createMissingDir(dir_path):
+def createMissingDir(dir_path: str) -> None:
     """Create a directory if it does not exist"""
     if not os.path.exists(dir_path):
         os.makedirs(dir_path)
 
 
-def isAll(selector):
+def isAll(selector: Union[str, FileSelector]) -> bool:
     """Check if a selector string is a variation of the 'All' token."""
     return str(selector).lower() == FileSelector.ALL
 
 
-def checkFilePath(path):
+def checkFilePath(path: str) -> None:
     if not path in CHECKEDPATHS:
         CHECKEDPATHS.add(path)
         # os.path.join ignores the first argument if `path` is absolute.
-        path = os.path.join(os.getcwd(), path)
+        full_path: str = os.path.join(os.getcwd(), path)
         try:
-            os.makedirs(path)
+            os.makedirs(full_path)
         except OSError as e:
-            if not os.path.isdir(path):
+            if not os.path.isdir(full_path):
                 raise e
 
 
-def ensureAbsolutePath(output_dir, relative_path):
+def ensureAbsolutePath(output_dir: str, relative_path: str) -> str:
     """Convert into an absolute path and ensure the directory exists."""
-    filepath = os.path.join(output_dir, relative_path)
+    filepath: str = os.path.join(output_dir, relative_path)
     checkFilePath(os.path.dirname(filepath))
     return filepath
 
 
 def releaseFilePath(
-    output_dir,
-    version,
-    selector,
-    protocol,
-    output_format,
-    suffix=None,
-    subdirectory_path=None,
-):
+    output_dir: str,
+    version: str,
+    selector: Union[str, FileSelector],
+    protocol: str,
+    output_format: str,
+    suffix: Optional[str] = None,
+    subdirectory_path: Optional[str] = None,
+) -> str:
     """Create a path for a release file
 
     Args:
@@ -84,46 +85,47 @@ def releaseFilePath(
     Returns:
         an absolute path with the necessary directories created.
     """
-    extension = EXTENSIONS_FOR_FORMAT[output_format.lower()]
-    selector = selector.lower()
-    assert selector in FILESET_SELECTORS, selector
+    extension: str = EXTENSIONS_FOR_FORMAT[output_format.lower()]
+    selector_str: str = str(selector).lower()
+    assert selector_str in FILESET_SELECTORS, selector_str
     protocol = protocol.lower()
     assert protocol in FILESET_PROTOCOLS, protocol
-    parts = [selector, protocol]
+    parts: List[str] = [selector_str, protocol]
     if suffix:
         parts.append(suffix)
-    merged = "-".join(parts)
-    filename = f"schemaorg-{merged}.{extension}"
+    merged: str = "-".join(parts)
+    filename: str = f"schemaorg-{merged}.{extension}"
 
     if subdirectory_path is None:
         subdirectory_path = f"releases/{version}"
 
-    relative_path = os.path.join(subdirectory_path, filename)
+    relative_path: str = os.path.join(subdirectory_path, filename)
     return ensureAbsolutePath(
         output_dir=output_dir,
         relative_path=relative_path,
     )
 
 
-def mycopytree(src, dst, symlinks=False, ignore=None):
+def mycopytree(src: str, dst: str, symlinks: bool = False, ignore: Optional[Callable[[str, List[str]], Iterable[str]]] = None) -> None:
     """Copy a file-system tree, copes with already existing directories."""
-    names = os.listdir(src)
+    names: List[str] = os.listdir(src)
+    ignored_names: Set[str]
     if ignore is not None:
-        ignored_names = ignore(src, names)
+        ignored_names = set(ignore(src, names))
     else:
-        ignored_names = frozenset()
+        ignored_names = set()
 
     if not os.path.isdir(dst):
         os.makedirs(dst)
-    errors = []
+    errors: List[Any] = []
     for name in names:
         if name in ignored_names:
             continue
-        srcname = os.path.join(src, name)
-        dstname = os.path.join(dst, name)
+        srcname: str = os.path.join(src, name)
+        dstname: str = os.path.join(dst, name)
         try:
             if symlinks and os.path.islink(srcname):
-                linkto = os.readlink(srcname)
+                linkto: str = os.readlink(srcname)
                 os.symlink(linkto, dstname)
             elif os.path.isdir(srcname):
                 mycopytree(srcname, dstname, symlinks, ignore)
@@ -139,10 +141,12 @@ def mycopytree(src, dst, symlinks=False, ignore=None):
     try:
         shutil.copystat(src, dst)
     except OSError as why:
-        if WindowsError is not None and isinstance(why, WindowsError):
+        # WindowsError might not be available on all systems
+        win_err = getattr(__builtins__, 'WindowsError', None)
+        if win_err and isinstance(why, win_err):
             # Copying file access times may fail on Windows
             pass
         else:
-            errors.extend((src, dst, str(why)))
+            errors.append((src, dst, str(why)))
     if errors:
-        raise Error(errors)
+        raise Exception(errors)

--- a/software/util/jinga_render.py
+++ b/software/util/jinga_render.py
@@ -2,55 +2,47 @@
 # -*- coding: utf-8 -*-
 
 # Import standard python libraries
-
-import os
-import sys
-import jinja2
 import logging
-import typing
-from typing import Any, Dict, List, Optional, Tuple, Union, Iterable, Sequence, Callable
+import sys
+from pathlib import Path
+from typing import Any, Dict, Optional, Union
+
+import jinja2
 
 # Import schema.org libraries
-if not os.getcwd() in sys.path:
-    sys.path.insert(1, os.getcwd())
+if Path.cwd() not in [Path(p).resolve() for p in sys.path]:
+    sys.path.insert(1, str(Path.cwd()))
 
-import software
 import software.util.schemaversion as schemaversion
 
-SITENAME: str = "Schema.org"
-TEMPLATESDIR: str = "templates"
-DOCSHREFSUFFIX: str = ""
-DOCSHREFPREFIX: str = "/"
-TERMHREFSUFFIX: str = ""
-TERMHREFPREFIX: str = "/"
-
-###################################################
-# JINJA INITIALISATION
-###################################################
-
+SITENAME = "Schema.org"
+TEMPLATESDIR = "templates"
+DOCSHREFSUFFIX = ""
+DOCSHREFPREFIX = "/"
+TERMHREFSUFFIX = ""
+TERMHREFPREFIX = "/"
 
 def _jinjaDebug(text: str) -> str:
     logging.debug(text)
     return ""
 
-
 local_vars: Dict[str, Any] = {}
-
 
 def _set_local_var(local_vars_dict: Dict[str, Any], name: str, value: Any) -> str:
     local_vars_dict[name] = value
     return ""
 
-
 JENV: Optional[jinja2.Environment] = None
-
 
 def GetJinga() -> jinja2.Environment:
     global JENV
-    if JENV:
+    if JENV is not None:
         return JENV
-    jenv: jinja2.Environment = jinja2.Environment(
-        loader=jinja2.FileSystemLoader(TEMPLATESDIR), autoescape=True, cache_size=0
+    
+    jenv = jinja2.Environment(
+        loader=jinja2.FileSystemLoader(TEMPLATESDIR),
+        autoescape=True,
+        cache_size=0
     )
     jenv.filters["debug"] = _jinjaDebug
     jenv.globals["set_local_var"] = _set_local_var
@@ -58,16 +50,14 @@ def GetJinga() -> jinja2.Environment:
     return JENV
 
 
-### Template rendering
-
-
-def templateRender(template_path: Optional[str], extra_vars: Optional[Dict[str, Any]] = None, template_instance: Optional[jinja2.Template] = None) -> str:
-    """Render a page template.
-
-    Returns: the generated page.
-    """
+def templateRender(
+    template_path: Optional[str], 
+    extra_vars: Optional[Dict[str, Any]] = None, 
+    template_instance: Optional[jinja2.Template] = None
+) -> str:
+    """Render a page template."""
     # Basic variables configuring UI
-    tvars: Dict[str, Any] = {
+    tvars = {
         "local_vars": local_vars,
         "version": schemaversion.getVersion(),
         "versiondate": schemaversion.getCurrentVersionDate(),
@@ -81,7 +71,6 @@ def templateRender(template_path: Optional[str], extra_vars: Optional[Dict[str, 
     if extra_vars:
         tvars.update(extra_vars)
 
-    template: jinja2.Template
     if template_instance:
         template = template_instance
     elif template_path:
@@ -90,8 +79,3 @@ def templateRender(template_path: Optional[str], extra_vars: Optional[Dict[str, 
         raise ValueError("Either template_path or template_instance must be provided")
         
     return str(template.render(tvars))
-
-
-###################################################
-# JINJA INITIALISATION - End
-###################################################

--- a/software/util/jinga_render.py
+++ b/software/util/jinga_render.py
@@ -7,6 +7,8 @@ import os
 import sys
 import jinja2
 import logging
+import typing
+from typing import Any, Dict, List, Optional, Tuple, Union, Iterable, Sequence, Callable
 
 # Import schema.org libraries
 if not os.getcwd() in sys.path:
@@ -15,39 +17,39 @@ if not os.getcwd() in sys.path:
 import software
 import software.util.schemaversion as schemaversion
 
-SITENAME = "Schema.org"
-TEMPLATESDIR = "templates"
-DOCSHREFSUFFIX = ""
-DOCSHREFPREFIX = "/"
-TERMHREFSUFFIX = ""
-TERMHREFPREFIX = "/"
+SITENAME: str = "Schema.org"
+TEMPLATESDIR: str = "templates"
+DOCSHREFSUFFIX: str = ""
+DOCSHREFPREFIX: str = "/"
+TERMHREFSUFFIX: str = ""
+TERMHREFPREFIX: str = "/"
 
 ###################################################
 # JINJA INITIALISATION
 ###################################################
 
 
-def _jinjaDebug(text):
+def _jinjaDebug(text: str) -> str:
     logging.debug(text)
     return ""
 
 
-local_vars = {}
+local_vars: Dict[str, Any] = {}
 
 
-def _set_local_var(local_vars, name, value):
-    local_vars[name] = value
+def _set_local_var(local_vars_dict: Dict[str, Any], name: str, value: Any) -> str:
+    local_vars_dict[name] = value
     return ""
 
 
-JENV = None
+JENV: Optional[jinja2.Environment] = None
 
 
-def GetJinga():
+def GetJinga() -> jinja2.Environment:
     global JENV
     if JENV:
         return JENV
-    jenv = jinja2.Environment(
+    jenv: jinja2.Environment = jinja2.Environment(
         loader=jinja2.FileSystemLoader(TEMPLATESDIR), autoescape=True, cache_size=0
     )
     jenv.filters["debug"] = _jinjaDebug
@@ -59,13 +61,13 @@ def GetJinga():
 ### Template rendering
 
 
-def templateRender(template_path, extra_vars=None, template_instance=None):
+def templateRender(template_path: Optional[str], extra_vars: Optional[Dict[str, Any]] = None, template_instance: Optional[jinja2.Template] = None) -> str:
     """Render a page template.
 
     Returns: the generated page.
     """
     # Basic variables configuring UI
-    tvars = {
+    tvars: Dict[str, Any] = {
         "local_vars": local_vars,
         "version": schemaversion.getVersion(),
         "versiondate": schemaversion.getCurrentVersionDate(),
@@ -79,8 +81,15 @@ def templateRender(template_path, extra_vars=None, template_instance=None):
     if extra_vars:
         tvars.update(extra_vars)
 
-    template = template_instance or GetJinga().get_template(template_path)
-    return template.render(tvars)
+    template: jinja2.Template
+    if template_instance:
+        template = template_instance
+    elif template_path:
+        template = GetJinga().get_template(template_path)
+    else:
+        raise ValueError("Either template_path or template_instance must be provided")
+        
+    return str(template.render(tvars))
 
 
 ###################################################

--- a/software/util/pretty_logger.py
+++ b/software/util/pretty_logger.py
@@ -6,8 +6,7 @@ import logging
 import os
 import sys
 import time
-import typing
-from typing import Any, Dict, List, Optional, Tuple, Union, Iterable, Sequence, Set, Callable, Type
+from typing import Any, Dict, Optional, List, Type
 
 
 class PrettyLogFormatter(logging.Formatter):
@@ -25,28 +24,29 @@ class PrettyLogFormatter(logging.Formatter):
         fmt: str = "%(levelname)s %(name)s: %(message)s"
         if shard is not None:
             fmt = f"%(levelname)s ({shard}) %(name)s: %(message)s"
-        logging.Formatter.__init__(self, fmt=fmt)
+        super().__init__(fmt=fmt)
         self.use_color: bool = use_color
 
     @classmethod
     def _computeLevelName(cls, record: logging.LogRecord) -> str:
-        lower_msg: str = record.getMessage().casefold()
-        if lower_msg == "done" or lower_msg[:5] == "done:":
+        msg: str = record.getMessage().casefold()
+        if msg == "done" or msg.startswith("done:"):
             return f"{colorama.Fore.LIGHTGREEN_EX}{record.levelname}{colorama.Fore.RESET}"
-        if record.levelname in cls.COLORS:
-            return f"{cls.COLORS[record.levelname]}{record.levelname}{colorama.Fore.RESET}"
+        color: Optional[str] = cls.COLORS.get(record.levelname)
+        if color:
+            return f"{color}{record.levelname}{colorama.Fore.RESET}"
         return record.levelname
 
     @classmethod
     def _computeName(cls, record: logging.LogRecord) -> str:
-        components: List[str] = record.name.split(".")
-        return f"{colorama.Style.DIM}{components[-1]}{colorama.Style.RESET_ALL}"
+        name: str = record.name.split(".")[-1]
+        return f"{colorama.Style.DIM}{name}{colorama.Style.RESET_ALL}"
 
     def format(self, record: logging.LogRecord) -> str:
         if self.use_color:
             record.levelname = self._computeLevelName(record)
             record.name = self._computeName(record)
-        return str(logging.Formatter.format(self, record))
+        return super().format(record)
 
 
 class BlockLog:
@@ -69,10 +69,10 @@ class BlockLog:
         if self.timing and self.start_time is not None:
             self.elapsed = time.perf_counter() - self.start_time
 
-        if isinstance(exc_value, Exception):
+        if exc_value:
             self.logger.error(f"Failed: {self.message}")
         else:
-            if self.elapsed:
+            if self.elapsed is not None:
                 self.logger.info(
                     f"Done: {self.message} in {self.elapsed:.2f} seconds",
                 )
@@ -84,10 +84,10 @@ class BlockLog:
 
 
 def MakeRootLogPretty(shard: Optional[int] = None) -> None:
-    """Makes the root log pretty if stdandard output is a terminal."""
+    """Makes the root log pretty if standard output is a terminal."""
     handler: logging.StreamHandler = logging.StreamHandler(sys.stdout)
     formatter: PrettyLogFormatter = PrettyLogFormatter(
-        use_color=os.isatty(sys.stdout.fileno()), shard=shard
+        use_color=sys.stdout.isatty(), shard=shard
     )
     handler.setFormatter(formatter)
 

--- a/software/util/pretty_logger.py
+++ b/software/util/pretty_logger.py
@@ -24,7 +24,7 @@ class PrettyLogFormatter(logging.Formatter):
     def __init__(self, use_color: bool = True, shard: Optional[int] = None) -> None:
         fmt: str = "%(levelname)s %(name)s: %(message)s"
         if shard is not None:
-            fmt = "%(levelname)s (" + str(shard) + ") %(name)s: %(message)s"
+            fmt = f"%(levelname)s ({shard}) %(name)s: %(message)s"
         logging.Formatter.__init__(self, fmt=fmt)
         self.use_color: bool = use_color
 
@@ -32,15 +32,15 @@ class PrettyLogFormatter(logging.Formatter):
     def _computeLevelName(cls, record: logging.LogRecord) -> str:
         lower_msg: str = record.getMessage().casefold()
         if lower_msg == "done" or lower_msg[:5] == "done:":
-            return colorama.Fore.LIGHTGREEN_EX + record.levelname + colorama.Fore.RESET
+            return f"{colorama.Fore.LIGHTGREEN_EX}{record.levelname}{colorama.Fore.RESET}"
         if record.levelname in cls.COLORS:
-            return cls.COLORS[record.levelname] + record.levelname + colorama.Fore.RESET
+            return f"{cls.COLORS[record.levelname]}{record.levelname}{colorama.Fore.RESET}"
         return record.levelname
 
     @classmethod
     def _computeName(cls, record: logging.LogRecord) -> str:
         components: List[str] = record.name.split(".")
-        return colorama.Style.DIM + components[-1] + colorama.Style.RESET_ALL
+        return f"{colorama.Style.DIM}{components[-1]}{colorama.Style.RESET_ALL}"
 
     def format(self, record: logging.LogRecord) -> str:
         if self.use_color:
@@ -80,7 +80,7 @@ class BlockLog:
                 self.logger.info(f"Done: {self.message}")
 
     def append(self, message: str) -> None:
-        self.message = self.message + " " + message
+        self.message = f"{self.message} {message}"
 
 
 def MakeRootLogPretty(shard: Optional[int] = None) -> None:

--- a/software/util/pretty_logger.py
+++ b/software/util/pretty_logger.py
@@ -6,12 +6,14 @@ import logging
 import os
 import sys
 import time
+import typing
+from typing import Any, Dict, List, Optional, Tuple, Union, Iterable, Sequence, Set, Callable, Type
 
 
 class PrettyLogFormatter(logging.Formatter):
     """Helper class to format the log messages from the various parts of the project."""
 
-    COLORS = {
+    COLORS: Dict[str, str] = {
         "WARNING": colorama.Fore.YELLOW,
         "INFO": colorama.Fore.CYAN,
         "DEBUG": colorama.Fore.BLUE,
@@ -19,16 +21,16 @@ class PrettyLogFormatter(logging.Formatter):
         "ERROR": colorama.Fore.RED,
     }
 
-    def __init__(self, use_color=True, shard=None):
-        fmt = "%(levelname)s %(name)s: %(message)s"
+    def __init__(self, use_color: bool = True, shard: Optional[int] = None) -> None:
+        fmt: str = "%(levelname)s %(name)s: %(message)s"
         if shard is not None:
             fmt = "%(levelname)s (" + str(shard) + ") %(name)s: %(message)s"
         logging.Formatter.__init__(self, fmt=fmt)
-        self.use_color = use_color
+        self.use_color: bool = use_color
 
     @classmethod
-    def _computeLevelName(cls, record):
-        lower_msg = record.getMessage().casefold()
+    def _computeLevelName(cls, record: logging.LogRecord) -> str:
+        lower_msg: str = record.getMessage().casefold()
         if lower_msg == "done" or lower_msg[:5] == "done:":
             return colorama.Fore.LIGHTGREEN_EX + record.levelname + colorama.Fore.RESET
         if record.levelname in cls.COLORS:
@@ -36,35 +38,35 @@ class PrettyLogFormatter(logging.Formatter):
         return record.levelname
 
     @classmethod
-    def _computeName(cls, record):
-        components = record.name.split(".")
+    def _computeName(cls, record: logging.LogRecord) -> str:
+        components: List[str] = record.name.split(".")
         return colorama.Style.DIM + components[-1] + colorama.Style.RESET_ALL
 
-    def format(self, record):
+    def format(self, record: logging.LogRecord) -> str:
         if self.use_color:
             record.levelname = self._computeLevelName(record)
             record.name = self._computeName(record)
-        return logging.Formatter.format(self, record)
+        return str(logging.Formatter.format(self, record))
 
 
 class BlockLog:
-    def __init__(self, logger, message, timing=False, displayStart=True):
-        self.logger = logger
-        self.message = message
-        self.timing = timing
-        self.displayStart = displayStart
-        self.start_time = None
-        self.elapsed = None
+    def __init__(self, logger: logging.Logger, message: str, timing: bool = False, displayStart: bool = True) -> None:
+        self.logger: logging.Logger = logger
+        self.message: str = message
+        self.timing: bool = timing
+        self.displayStart: bool = displayStart
+        self.start_time: Optional[float] = None
+        self.elapsed: Optional[float] = None
 
-    def __enter__(self):
+    def __enter__(self) -> "BlockLog":
         if self.displayStart:
             self.logger.info(f"Start: {self.message}")
         if self.timing:
             self.start_time = time.perf_counter()
         return self
 
-    def __exit__(self, exc_type, exc_value, traceback):
-        if self.timing:
+    def __exit__(self, exc_type: Optional[Type[BaseException]], exc_value: Optional[BaseException], traceback: Any) -> None:
+        if self.timing and self.start_time is not None:
             self.elapsed = time.perf_counter() - self.start_time
 
         if isinstance(exc_value, Exception):
@@ -77,17 +79,17 @@ class BlockLog:
             else:
                 self.logger.info(f"Done: {self.message}")
 
-    def append(self, message):
+    def append(self, message: str) -> None:
         self.message = self.message + " " + message
 
 
-def MakeRootLogPretty(shard=None):
+def MakeRootLogPretty(shard: Optional[int] = None) -> None:
     """Makes the root log pretty if stdandard output is a terminal."""
-    handler = logging.StreamHandler(sys.stdout)
-    formatter = PrettyLogFormatter(
+    handler: logging.StreamHandler = logging.StreamHandler(sys.stdout)
+    formatter: PrettyLogFormatter = PrettyLogFormatter(
         use_color=os.isatty(sys.stdout.fileno()), shard=shard
     )
     handler.setFormatter(formatter)
 
-    root_log = logging.getLogger()
+    root_log: logging.Logger = logging.getLogger()
     root_log.handlers = [handler]

--- a/software/util/reorg.py
+++ b/software/util/reorg.py
@@ -12,6 +12,8 @@ import logging
 import os
 import rdflib
 import sys
+import typing
+from typing import Any, Dict, List, Optional, Tuple, Union, Iterable, Sequence, Set, Callable
 
 # Import schema.org libraries
 if not os.getcwd() in sys.path:
@@ -20,12 +22,12 @@ if not os.getcwd() in sys.path:
 import software.util.schema_graph as graph
 
 
-def Lint(args):
+def Lint(args: argparse.Namespace) -> None:
     """Reformats the file(s) properly."""
 
-    def LintOne(filename, output_filename, format):
+    def LintOne(filename: str, output_filename: str, format: str) -> None:
         logging.info(" - reading file ...")
-        g = graph.SchemaOrgGraph(filename, format=format)
+        g: graph.SchemaOrgGraph = graph.SchemaOrgGraph(filename, format=format)
         logging.info(
             f" - writing back {output_filename if output_filename != filename else ''} ..."
         )
@@ -41,10 +43,10 @@ def Lint(args):
         logging.info(" - validated.")
 
 
-def MergeFiles(args):
+def MergeFiles(args: argparse.Namespace) -> None:
     """Merges a set of files into one."""
     logging.info(f"Merging files {len(args.files)} into {args.output}")
-    merged = graph.SchemaOrgGraph()
+    merged: graph.SchemaOrgGraph = graph.SchemaOrgGraph()
     for filename in args.files:
         logging.info(f" - reading {filename} ...")
         merged.parse(filename, format="turtle")
@@ -56,21 +58,21 @@ def MergeFiles(args):
             logging.fatal(f"Merging files into {args.output} lost some information.")
 
 
-def Annotate(args):
+def Annotate(args: argparse.Namespace) -> None:
     """Adds some annotations to properties and types."""
     if args.output is not None and len(args.files) > 1:
         logging.fatal(f"Cannot use --output with multiple files!")
 
-    valid_parts = ["pending", "attic", "meta", "GA"]
+    valid_parts: List[str] = ["pending", "attic", "meta", "GA"]
     if args.ispartof not in valid_parts:
         logging.fatal(
             f"PartOf annotation '{args.ispartof}' is not valid: select one of {valid_parts}"
         )
-    new_part = rdflib.URIRef(f"https://{args.ispartof}.schema.org/")
+    new_part: rdflib.URIRef = rdflib.URIRef(f"https://{args.ispartof}.schema.org/")
 
     for filename in args.files:
         logging.info(f"Annotating {filename} ...")
-        g = graph.SchemaOrgGraph(filename, format="turtle")
+        g: graph.SchemaOrgGraph = graph.SchemaOrgGraph(filename, format="turtle")
         # Clean the existing parts
         g.remove((None, graph.SCHEMAORG.isPartOf, None))
         # GA is special as it is the unannotated state.
@@ -82,14 +84,14 @@ def Annotate(args):
         logging.info(f" ... done, written to {args.output or filename}")
 
 
-def main():
+def main() -> None:
     """
     Parses command line arguments and dispatches to the appropriate
     command.
     """
     logging.basicConfig(level=logging.INFO)
 
-    parser = argparse.ArgumentParser(description="Re-organize Turtle files")
+    parser: argparse.ArgumentParser = argparse.ArgumentParser(description="Re-organize Turtle files")
     subparsers = parser.add_subparsers(dest="command")
 
     lint_parser = subparsers.add_parser("lint", help="Reformat files (aka linting)")
@@ -111,7 +113,7 @@ def main():
     annotate_parser.add_argument("files", action="extend", nargs="+", type=str)
 
     # Parse and dispatch
-    args = parser.parse_args()
+    args: argparse.Namespace = parser.parse_args()
     if args.command == "lint":
         Lint(args)
     elif args.command == "merge":

--- a/software/util/runtests.py
+++ b/software/util/runtests.py
@@ -55,29 +55,35 @@ import sys
 import colorama
 import os
 import unittest
+import typing
+from typing import Any, Dict, List, Optional, Tuple, Union, Iterable, Sequence, Set, Callable, Type, IO
 
-SITEDIR = "software/site"
-STANDALONE = False
+
+SITEDIR: str = "software/site"
+STANDALONE: bool = False
 
 
 class ColoredTestResult(unittest.TextTestResult):
     """Color the test results."""
 
-    def __init__(self, stream, descriptions, verbosity):
+    def __init__(self, stream: IO[Any], descriptions: bool, verbosity: int) -> None:
         super().__init__(stream, descriptions, verbosity)
+        self.is_tty: bool
         try:
             self.is_tty = os.isatty(stream.fileno())
-        except:
+        except Exception:
             self.is_tty = False
+        self.separator1: str = ""
+        self.separator2: str = ""
         if self.is_tty:
             try:
-                columns = os.get_terminal_size().columns
-            except:
+                columns: int = os.get_terminal_size().columns
+            except Exception:
                 columns = 80
             self.separator1 = "▼" * columns
             self.separator2 = "▲" * columns
 
-    def _colorPrint(self, message, color=None, short=None, newline=True):
+    def _colorPrint(self, message: str, color: Optional[str] = None, short: Optional[str] = None, newline: bool = True) -> None:
         if not self.showAll and short:
             message = short
         if self.is_tty and color:
@@ -88,48 +94,48 @@ class ColoredTestResult(unittest.TextTestResult):
             self.stream.write(message)
             self.stream.flush()
 
-    def addError(self, test, err):
+    def addError(self, test: unittest.TestCase, err: Any) -> None:
         super(ColoredTestResult, self).addError(test, err)  # Include the 'err' argument
         self._colorPrint("Error", color=colorama.Fore.YELLOW, short="E")
 
-    def startTest(self, test):
+    def startTest(self, test: unittest.TestCase) -> None:
         super(unittest.TextTestResult, self).startTest(test)
-        lines = self.getDescription(test).split("\n")
+        lines: List[str] = self.getDescription(test).split("\n")
         for index, line in enumerate(lines):
-            color = None
+            color: Optional[str] = None
             if index > 0:
                 color = colorama.Fore.LIGHTWHITE_EX
-            lastline = index == len(lines) - 1
+            lastline: bool = index == len(lines) - 1
             if lastline:
                 self._colorPrint(line + " … ", color=color, newline=False)
             else:
                 self._colorPrint(line, color=color, newline=True)
 
-    def addSuccess(self, test):
+    def addSuccess(self, test: unittest.TestCase) -> None:
         super(unittest.TextTestResult, self).addSuccess(test)
         self._colorPrint("OK", color=colorama.Fore.GREEN, short=".")
 
-    def addFailure(self, test, err):
+    def addFailure(self, test: unittest.TestCase, err: Any) -> None:
         super(unittest.TextTestResult, self).addFailure(test, err)
         self._colorPrint("FAIL", color=colorama.Fore.RED, short="F")
 
-    def addExpectedFailure(self, test, err):
+    def addExpectedFailure(self, test: unittest.TestCase, err: Any) -> None:
         super(unittest.TextTestResult, self).addExpectedFailure(test, err)
         self._colorPrint("Expected failure", color=colorama.Fore.GREEN, short="x")
 
-    def addUnexpectedSuccess(self, test):
+    def addUnexpectedSuccess(self, test: unittest.TestCase) -> None:
         super(unittest.TextTestResult, self).addUnexpectedSuccess(test)
         self._colorPrint("Unexpected success", color=colorama.Fore.RED, short="U")
 
-    def addSkip(self, test, reason):
+    def addSkip(self, test: unittest.TestCase, reason: str) -> None:
         super(unittest.TextTestResult, self).addSkip(test, reason)
         self._colorPrint("Skipped", color=colorama.Fore.CYAN, short="S")
         if reason:
             self._colorPrint(reason, color=colorama.Fore.LIGHTCYAN_EX)
 
-    def printErrorList(self, flavour, errors):
-        super(unittest.TextTestResult, self).addSkip(flavour, errors)
-        color = None
+    def printErrorList(self, flavour: str, errors: List[Tuple[unittest.TestCase, str]]) -> None:
+        # super(unittest.TextTestResult, self).addSkip(flavour, errors)
+        color: Optional[str] = None
         if flavour == "ERROR":
             color = colorama.Fore.YELLOW
         elif flavour == "FAIL":
@@ -141,7 +147,8 @@ class ColoredTestResult(unittest.TextTestResult):
             self._colorPrint("%s" % err, color=color)
 
 
-def GetSuite(test_path, args):
+def GetSuite(test_path: str, args: Optional[argparse.Namespace]) -> unittest.TestSuite:
+    suite: unittest.TestSuite
     if args and vars(args)["skipbasics"]:
         suite = unittest.loader.TestLoader().discover(test_path, pattern="*graphs*.py")
     else:
@@ -152,22 +159,22 @@ def GetSuite(test_path, args):
 # TODO:
 # Ensure that the google.appengine.* packages are available
 # in tests as well as all bundled third-party packages.
-def main(test_path, args=None):
-    runner = unittest.TextTestRunner(
+def main(test_path: str, args: Optional[argparse.Namespace] = None) -> int:
+    runner: unittest.TextTestRunner = unittest.TextTestRunner(
         verbosity=2, descriptions=True, resultclass=ColoredTestResult
     )
-    suite = GetSuite(test_path, args)
-    res = runner.run(suite)
-    count = len(res.failures) + len(res.errors)
+    suite: unittest.TestSuite = GetSuite(test_path, args)
+    res: unittest.TestResult = runner.run(suite)
+    count: int = len(res.failures) + len(res.errors)
     return count
 
 
 if __name__ == "__main__":
     colorama.init()
-    parser = argparse.ArgumentParser(description="Configurable testing of schema.org.")
+    parser: argparse.ArgumentParser = argparse.ArgumentParser(description="Configurable testing of schema.org.")
     parser.add_argument("--skipbasics", action="store_true", help="Skip basic tests.")
-    args = parser.parse_args()
-    sys.exit(main("./software/tests/", args))
+    args_parsed: argparse.Namespace = parser.parse_args()
+    sys.exit(main("./software/tests/", args_parsed))
 
 # alternative, try
 # PYTHONPATH=/usr/local/google_appengine ./scripts/run_tests.py

--- a/software/util/schema_graph.py
+++ b/software/util/schema_graph.py
@@ -5,16 +5,18 @@
 """
 
 import rdflib
+import typing
+from typing import Any, Dict, List, Optional, Tuple, Union, Iterable, Sequence, Set, Callable
 
 import software.util.schemaglobals as schemaglobals
 
 
-SCHEMAORG = rdflib.Namespace(schemaglobals.HOMEPAGE)
+SCHEMAORG: rdflib.Namespace = rdflib.Namespace(schemaglobals.HOMEPAGE)
 
 
 class SchemaOrgGraph(object):
-    def __init__(self, filename: str = None, format: str = "turtle"):
-        self.g = rdflib.Graph()
+    def __init__(self, filename: Optional[str] = None, format: str = "turtle") -> None:
+        self.g: rdflib.Graph = rdflib.Graph()
         # Binding it here, as by default it would bind the /elements/1.1/ instead
         # of the dc terms. this way, the elements get assigned "dc1" or such
         # as a prefix, and we do not use that.
@@ -22,27 +24,27 @@ class SchemaOrgGraph(object):
         if filename:
             self.g.parse(filename, format=format)
 
-    def __getattr__(self, *args, **kwargs):
-        return getattr(self.g, *args, **kwargs)
+    def __getattr__(self, name: str) -> Any:
+        return getattr(self.g, name)
 
-    def IdenticalTo(self, other: "SchemaOrgGraph"):
-        only_in_other = other.g - self.g
-        only_in_self = self.g - other.g
+    def IdenticalTo(self, other: "SchemaOrgGraph") -> bool:
+        only_in_other: rdflib.Graph = other.g - self.g
+        only_in_self: rdflib.Graph = self.g - other.g
         if only_in_other or only_in_self:
             raise ValueError(f"Graphs differ: {only_in_other + only_in_self}")
         return True
 
-    def FullyContains(self, graph: "SchemaOrgGraph"):
-        only_in_subset = graph.g - self.g
+    def FullyContains(self, graph: "SchemaOrgGraph") -> bool:
+        only_in_subset: rdflib.Graph = graph.g - self.g
         if only_in_subset:
             raise ValueError(f"Graph does not contain it all: {only_in_subset}")
         return True
 
-    def ListSubjects(self, subject_type: rdflib.term.URIRef):
+    def ListSubjects(self, subject_type: rdflib.term.URIRef) -> Set[rdflib.term.Node]:
         return set([s for s, p, o in self.g.triples((None, rdflib.RDF.type, subject_type))])
 
-    def Types(self):
+    def Types(self) -> Set[rdflib.term.Node]:
         return self.ListSubjects(rdflib.RDFS.Class)
 
-    def Properties(self):
+    def Properties(self) -> Set[rdflib.term.Node]:
         return self.ListSubjects(rdflib.RDF.Property)

--- a/software/util/schemaglobals.py
+++ b/software/util/schemaglobals.py
@@ -1,11 +1,8 @@
 #!/usr/bin/env python3
 # -*- coding: utf-8 -*-
 
-import os
-import typing
-from typing import Any, Dict, List, Optional, Tuple, Union, Iterable, Sequence, Set, Callable
-
-"""Common place for all globals to avoid circular dependencies."""
+from pathlib import Path
+from typing import List
 
 SITENAME: str = "Schema.org"
 BUILDOPTS: List[str] = []
@@ -31,4 +28,4 @@ def getOutputDir() -> str:
 
 
 def getDocsOutputDir() -> str:
-    return os.path.join(OUTPUTDIR, "docs")
+    return str(Path(OUTPUTDIR) / "docs")

--- a/software/util/schemaglobals.py
+++ b/software/util/schemaglobals.py
@@ -2,31 +2,33 @@
 # -*- coding: utf-8 -*-
 
 import os
+import typing
+from typing import Any, Dict, List, Optional, Tuple, Union, Iterable, Sequence, Set, Callable
 
 """Common place for all globals to avoid circular dependencies."""
 
-SITENAME = "Schema.org"
-BUILDOPTS = []
-TERMS = []
-PAGES = []
-FILES = []
-OUTPUTDIR = "software/site"
-DOCSDOCSDIR = "/docs"
-TERMDOCSDIR = "/docs"
-HANDLER_TEMPLATE = "handlers-template.yaml"
-HANDLER_FILE = "handlers.yaml"
-RELEASE_DIR = "software/site/releases"
-HOMEPAGE = "https://schema.org"
+SITENAME: str = "Schema.org"
+BUILDOPTS: List[str] = []
+TERMS: List[str] = []
+PAGES: List[str] = []
+FILES: List[str] = []
+OUTPUTDIR: str = "software/site"
+DOCSDOCSDIR: str = "/docs"
+TERMDOCSDIR: str = "/docs"
+HANDLER_TEMPLATE: str = "handlers-template.yaml"
+HANDLER_FILE: str = "handlers.yaml"
+RELEASE_DIR: str = "software/site/releases"
+HOMEPAGE: str = "https://schema.org"
 
 
-def hasOpt(opt):
+def hasOpt(opt: str) -> bool:
     """Return true if `opt` is among the build options"""
     return opt in BUILDOPTS
 
 
-def getOutputDir():
+def getOutputDir() -> str:
     return OUTPUTDIR
 
 
-def getDocsOutputDir():
-    os.path.join(OUTPUTDIR, "docs")
+def getDocsOutputDir() -> str:
+    return os.path.join(OUTPUTDIR, "docs")

--- a/software/util/schemaversion.py
+++ b/software/util/schemaversion.py
@@ -4,27 +4,21 @@
 """Module that handles the schema.org version information."""
 
 import json
-import os
 import sys
-from typing import Dict, Any, Optional
+from pathlib import Path
+from typing import Dict, Any, Optional, List, Tuple
 
-if os.getcwd() not in sys.path:
-    sys.path.insert(1, os.getcwd())
+if Path.cwd() not in [Path(p).resolve() for p in sys.path]:
+    sys.path.insert(1, str(Path.cwd()))
 
 from software.util.sort_dict import sort_dict
 
-###################################################
-# VERSION INFO LOAD
-###################################################
-
 VERSION_DATA: Optional[Dict[str, Any]] = None
-
 
 def getVersionData() -> Dict[str, Any]:
     global VERSION_DATA
-    if not VERSION_DATA:
-        with open("versions.json") as json_file:
-            VERSION_DATA = json.load(json_file)
+    if VERSION_DATA is None:
+        VERSION_DATA = json.loads(Path("versions.json").read_text())
     assert VERSION_DATA is not None
     return VERSION_DATA
 
@@ -34,7 +28,8 @@ def getVersion() -> str:
 
 
 def getVersionDate(ver: str) -> Optional[str]:
-    return getVersionData()["releaseLog"].get(ver, None)
+    ret: Optional[str] = getVersionData()["releaseLog"].get(ver)
+    return ret
 
 
 def getCurrentVersionDate() -> Optional[str]:
@@ -45,11 +40,11 @@ def setVersion(ver: str, date: str) -> None:
     versiondata: Dict[str, Any] = getVersionData()
     versiondata["schemaversion"] = ver
     versiondata["releaseLog"][ver] = date
-    vers: Dict[str, str] = versiondata["releaseLog"]
-    sorted_vers: Dict[str, str] = dict(sorted(vers.items(), key=lambda x: float(x[0]), reverse=True))
-    versiondata["releaseLog"] = sorted_vers
-    with open("versions.json", "w") as json_file:
-        json_file.write(json.dumps(sort_dict(versiondata), indent=4))
+    
+    logs: Dict[str, str] = versiondata["releaseLog"]
+    versiondata["releaseLog"] = dict(sorted(logs.items(), key=lambda x: float(x[0]), reverse=True))
+    
+    Path("versions.json").write_text(json.dumps(sort_dict(versiondata), indent=4))
 
 
 if __name__ == "__main__":

--- a/software/util/schemaversion.py
+++ b/software/util/schemaversion.py
@@ -6,6 +6,7 @@
 import json
 import os
 import sys
+from typing import Dict, Any, Optional
 
 if os.getcwd() not in sys.path:
     sys.path.insert(1, os.getcwd())
@@ -16,36 +17,37 @@ from software.util.sort_dict import sort_dict
 # VERSION INFO LOAD
 ###################################################
 
-VERSION_DATA = None
+VERSION_DATA: Optional[Dict[str, Any]] = None
 
 
-def getVersionData():
+def getVersionData() -> Dict[str, Any]:
     global VERSION_DATA
     if not VERSION_DATA:
         with open("versions.json") as json_file:
             VERSION_DATA = json.load(json_file)
+    assert VERSION_DATA is not None
     return VERSION_DATA
 
 
-def getVersion():
-    return getVersionData()["schemaversion"]
+def getVersion() -> str:
+    return str(getVersionData()["schemaversion"])
 
 
-def getVersionDate(ver):
+def getVersionDate(ver: str) -> Optional[str]:
     return getVersionData()["releaseLog"].get(ver, None)
 
 
-def getCurrentVersionDate():
+def getCurrentVersionDate() -> Optional[str]:
     return getVersionDate(getVersion())
 
 
-def setVersion(ver, date):
-    versiondata = getVersionData()
+def setVersion(ver: str, date: str) -> None:
+    versiondata: Dict[str, Any] = getVersionData()
     versiondata["schemaversion"] = ver
     versiondata["releaseLog"][ver] = date
-    vers = versiondata["releaseLog"]
-    vers = dict(sorted(vers.items(), key=lambda x: float(x[0]), reverse=True))
-    versiondata["releaseLog"] = vers
+    vers: Dict[str, str] = versiondata["releaseLog"]
+    sorted_vers: Dict[str, str] = dict(sorted(vers.items(), key=lambda x: float(x[0]), reverse=True))
+    versiondata["releaseLog"] = sorted_vers
     with open("versions.json", "w") as json_file:
         json_file.write(json.dumps(sort_dict(versiondata), indent=4))
 

--- a/software/util/sdojsonldcontext.py
+++ b/software/util/sdojsonldcontext.py
@@ -5,6 +5,8 @@ import json
 import logging
 import os
 import sys
+import typing
+from typing import Any, Dict, Optional, Set, List
 
 # Import schema.org libraries
 if not os.getcwd() in sys.path:
@@ -16,24 +18,22 @@ import software.SchemaTerms.sdoterm as sdoterm
 import software.util.pretty_logger as pretty_logger
 from software.util.sort_dict import sort_dict
 
-log = logging.getLogger(__name__)
+log: logging.Logger = logging.getLogger(__name__)
 
 
-CONTEXT = None
+CONTEXT: Optional[str] = None
+SCHEMAURI: str = "http://schema.org/"
 
 
-def getContext():
+def getContext() -> str:
     global CONTEXT
     if not CONTEXT:
         CONTEXT = createcontext()
     return CONTEXT
 
 
-SCHEMAURI = "http://schema.org/"
-
-
-def _convertTypes(type_range: list[str]) -> set[str]:
-    types = set()
+def _convertTypes(type_range: typing.Collection[str]) -> typing.Set[str]:
+    types: Set[str] = set()
     if "Text" in type_range:
         return types
     if "URL" in type_range:
@@ -45,39 +45,42 @@ def _convertTypes(type_range: list[str]) -> set[str]:
     return types
 
 
-def createcontext():
+def createcontext() -> str:
     """Generates a basic JSON-LD context file for schema.org."""
     with pretty_logger.BlockLog(message="Creating JSON-LD context", logger=log):
-        json_context = {
+        json_context: Dict[str, Any] = {
             "type": "@type",
             "id": "@id",
             "HTML": {"@id": "rdf:HTML"},
             "@vocab": SCHEMAURI,
         }
 
-        done_namespaces = set()
+        done_namespaces: Set[str] = set()
         for pref, path in sdotermsource.SdoTermSource.sourceGraph().namespaces():
-            pref = str(pref)
-            if not pref in done_namespaces:
-                done_namespaces.add(pref)
-                if pref == "schema":
+            pref_str: str = str(pref)
+            if pref_str not in done_namespaces:
+                done_namespaces.add(pref_str)
+                if pref_str == "schema":
                     path = SCHEMAURI  # Override vocab setting to maintain http compatibility
-                if pref == "geo":
+                if pref_str == "geo":
                     continue
-                json_context[pref] = str(path)
+                json_context[pref_str] = path
 
-        for term in sdotermsource.SdoTermSource.getAllTerms(
+        all_terms: List[sdoterm.SdoTerm] = sdotermsource.SdoTermSource.getAllTerms(
             expanded=True, suppressSourceLinks=True
-        ):
+        )
+        for term in all_terms:
+            if not isinstance(term, sdoterm.SdoTerm):
+                 continue
             if term.termType == sdoterm.SdoTermType.REFERENCE:
                 continue
-            term_json = {"@id": sdotermsource.prefixedIdFromUri(term.uri)}
+            term_json: Dict[str, Any] = {"@id": sdotermsource.prefixedIdFromUri(term.uri)}
             if term.termType == sdoterm.SdoTermType.PROPERTY:
-                types = _convertTypes(term.rangeIncludes)
+                types: Set[str] = _convertTypes(term.rangeIncludes.ids)
                 if len(types) == 1:
                     term_json["@type"] = types.pop()
                 elif len(types) > 1:
-                    term_json["@type"] = sorted(types)
+                    term_json["@type"] = sorted(list(types))
             json_context[term.id] = term_json
-        json_object = {"@context": json_context}
+        json_object: Dict[str, Any] = {"@context": json_context}
         return json.dumps(sort_dict(json_object), indent=2)

--- a/software/util/sdoowl.py
+++ b/software/util/sdoowl.py
@@ -12,6 +12,7 @@ if not (sys.version_info.major == 3 and sys.version_info.minor > 5):
 
 import glob
 import re
+from typing import Any, Dict, List, Optional, Tuple, Union, Set
 
 for path in [
     os.getcwd(),
@@ -24,7 +25,7 @@ for path in [
 
 import rdflib
 from rdflib import Graph
-from rdflib.term import URIRef, Literal
+from rdflib.term import URIRef, Literal, Node
 from rdflib.parser import Parser
 from rdflib.serializer import Serializer
 from rdflib.plugins.sparql import prepareQuery
@@ -34,15 +35,15 @@ from rdflib.namespace import RDFS, RDF
 from xml.etree import ElementTree
 from xml.dom import minidom
 
-from sdotermsource import SdoTermSource
-from sdoterm import *
-from localmarkdown import Markdown
+from software.SchemaTerms.sdotermsource import SdoTermSource
+from software.SchemaTerms.sdoterm import *
+from software.SchemaTerms.localmarkdown import Markdown
 
-import schemaversion
+import software.util.schemaversion as schemaversion
 
-VOCABURI = SdoTermSource.vocabUri()
+VOCABURI: str = SdoTermSource.vocabUri()
 
-NAMESPACES = {
+NAMESPACES: Dict[str, str] = {
     "xml:base": VOCABURI,
     "xmlns": VOCABURI,
     "xmlns:schema": VOCABURI,
@@ -53,14 +54,13 @@ NAMESPACES = {
     "xmlns:xsd": "http://www.w3.org/2001/XMLSchema#",
 }
 
-from rdflib.term import URIRef
 
-DOMAININC = URIRef(VOCABURI + "domainIncludes")
-RANGEINC = URIRef(VOCABURI + "rangeIncludes")
-INVERSEOF = URIRef(VOCABURI + "inverseOf")
-SUPERSEDEDBY = URIRef(VOCABURI + "supersededBy")
-DEFAULTRANGES = frozenset([VOCABURI + "Text", VOCABURI + "URL", VOCABURI + "Role"])
-DATATYPES = frozenset(
+DOMAININC: URIRef = URIRef(VOCABURI + "domainIncludes")
+RANGEINC: URIRef = URIRef(VOCABURI + "rangeIncludes")
+INVERSEOF: URIRef = URIRef(VOCABURI + "inverseOf")
+SUPERSEDEDBY: URIRef = URIRef(VOCABURI + "supersededBy")
+DEFAULTRANGES: Set[str] = frozenset([VOCABURI + "Text", VOCABURI + "URL", VOCABURI + "Role"])
+DATATYPES: Set[str] = frozenset(
     [
         VOCABURI + "Boolean",
         VOCABURI + "Date",
@@ -73,78 +73,81 @@ DATATYPES = frozenset(
 )
 
 
-def _MakePrettyComment(text):
+def _MakePrettyComment(text: str) -> ElementTree.Comment:
     """Make a pretty comment with a box of slashes before and after."""
-    inner_text = "/ " + text
-    bar = "/" * len(inner_text)
-    comment = "\n\t" + bar + "\n\t" + inner_text + "\n\t" + bar + "\n\n\t"
+    inner_text: str = "/ " + text
+    bar: str = "/" * len(inner_text)
+    comment: str = "\n\t" + bar + "\n\t" + inner_text + "\n\t" + bar + "\n\n\t"
     return ElementTree.Comment(comment)
 
 
 class OwlBuild:
-    def __init__(self):
-        from localmarkdown import MarkdownTool
-        self.typesCount = self.propsCount = self.namedCount = 0
-        old_pre = MarkdownTool.WPRE
+    def __init__(self) -> None:
+        from software.SchemaTerms.localmarkdown import MarkdownTool
+        self.typesCount: int = 0
+        self.propsCount: int = 0
+        self.namedCount: int = 0
+        self.dom: ElementTree.Element
+        self.ont: ElementTree.Element
+        old_pre: str = MarkdownTool.WPRE
         MarkdownTool.setWikilinkPrePath("/")
         self._createDom()
         self._loadGraph()
         MarkdownTool.setWikilinkPrePath(old_pre)
 
-    def _createDom(self):
+    def _createDom(self) -> None:
         self.dom = ElementTree.Element("rdf:RDF")
         for k, v in sorted(NAMESPACES.items()):
             self.dom.set(k, v)
 
-        version = schemaversion.getVersion()
-        version_date = schemaversion.getCurrentVersionDate()
-        comment_text = "Generated from Schema.org version: %s released: %s" % (
+        version: str = schemaversion.getVersion()
+        version_date: str = schemaversion.getCurrentVersionDate()
+        comment_text: str = "Generated from Schema.org version: %s released: %s" % (
             version,
             version_date,
         )
         self.dom.append(_MakePrettyComment(text=comment_text))
         self.ont = ElementTree.SubElement(self.dom, "owl:Ontology")
         self.ont.set("rdf:about", VOCABURI)
-        info = ElementTree.SubElement(self.ont, "owl:versionInfo")
+        info: ElementTree.Element = ElementTree.SubElement(self.ont, "owl:versionInfo")
         info.set("rdf:datatype", "http://www.w3.org/2001/XMLSchema#string")
         info.text = version
-        x = ElementTree.SubElement(self.ont, "rdfs:label")
+        x: ElementTree.Element = ElementTree.SubElement(self.ont, "rdfs:label")
         x.text = "Schema.org Vocabulary"
         x = ElementTree.SubElement(self.ont, "dcterms:modified")
         x.set("rdf:datatype", "http://www.w3.org/2001/XMLSchema#date")
         x.text = version_date
         self.dom.append(_MakePrettyComment(text="Definitions"))
 
-    def _loadGraph(self):
+    def _loadGraph(self) -> None:
         self.list(SdoTermSource.sourceGraph())
 
-    def getContent(self):
-        return self.prettify(self.dom).decode()
+    def getContent(self) -> str:
+        return self.prettify(self.dom)
 
-    def prettify(self, elem):
-        doc = minidom.parseString(ElementTree.tostring(elem))
-        return doc.toprettyxml(encoding="UTF-8")
+    def prettify(self, elem: ElementTree.Element) -> str:
+        doc: minidom.Document = minidom.parseString(ElementTree.tostring(elem))
+        return doc.toprettyxml(encoding="UTF-8").decode("utf-8")
 
-    def list(self, graph):
-        types = {}
-        props = {}
-        exts = []
+    def list(self, graph: rdflib.Graph) -> None:
+        types: Dict[rdflib.term.Node, rdflib.term.Node] = {}
+        props: Dict[rdflib.term.Node, rdflib.term.Node] = {}
         self.dom.append(_MakePrettyComment(text="Class Definitions"))
 
         for s, p, o in graph.triples((None, RDF.type, RDFS.Class)):
-            if s.startswith("https://schema.org"):
+            if str(s).startswith("https://schema.org"):
                 types.update({s: graph.identifier})
 
-        for t in sorted(types.keys()):
-            self.outputType(t, graph)
+        for t in sorted(types.keys(), key=str):
+            self.outputType(str(t), graph)
 
         self.dom.append(_MakePrettyComment(text="Property Definitions"))
         for s, p, o in graph.triples((None, RDF.type, RDF.Property)):
-            if s.startswith("https://schema.org"):
+            if str(s).startswith("https://schema.org"):
                 props.update({s: graph.identifier})
 
-        for p in sorted(props.keys()):
-            self.outputProp(p, graph)
+        for p in sorted(props.keys(), key=str):
+            self.outputProp(str(p), graph)
 
         self.dom.append(_MakePrettyComment(text="Named Individuals Definitions"))
 
@@ -152,24 +155,24 @@ class OwlBuild:
         self.outputNamedIndividuals(VOCABURI + "True", graph)
         self.outputNamedIndividuals(VOCABURI + "False", graph)
 
-    def outputType(self, uri, graph):
+    def outputType(self, uri: str, graph: rdflib.Graph) -> None:
         self.typesCount += 1
 
-        typ = ElementTree.SubElement(self.dom, "owl:Class")
+        typ: ElementTree.Element = ElementTree.SubElement(self.dom, "owl:Class")
         typ.set("rdf:about", uri)
-        ext = None
-        for p, o in sorted(graph.predicate_objects(uri)):
+        ext: Optional[str] = None
+        for p, o in sorted(graph.predicate_objects(URIRef(uri)), key=lambda x: (str(x[0]), str(x[1]))):
             if p == RDFS.label:
-                l = ElementTree.SubElement(typ, "rdfs:label")
+                l: ElementTree.Element = ElementTree.SubElement(typ, "rdfs:label")
                 l.set("xml:lang", "en")
-                l.text = o
+                l.text = str(o)
             elif p == RDFS.comment:
-                c = ElementTree.SubElement(typ, "rdfs:comment")
+                c: ElementTree.Element = ElementTree.SubElement(typ, "rdfs:comment")
                 c.set("xml:lang", "en")
-                c.text = Markdown.parse(o)
+                c.text = Markdown.parse(str(o))
             elif p == RDFS.subClassOf:
-                s = ElementTree.SubElement(typ, "rdfs:subClassOf")
-                s.set("rdf:resource", o)
+                s: ElementTree.Element = ElementTree.SubElement(typ, "rdfs:subClassOf")
+                s.set("rdf:resource", str(o))
             elif p == URIRef(VOCABURI + "isPartOf"):  # Defined in an extension
                 ext = str(o)
             elif p == RDF.type and o == URIRef(VOCABURI + "DataType"):  # A datatype
@@ -178,27 +181,27 @@ class OwlBuild:
 
         typ.append(self.addDefined(uri, ext))
 
-    def outputProp(self, uri, graph):
+    def outputProp(self, uri: str, graph: rdflib.Graph) -> None:
         self.propsCount += 1
-        children = []
-        domains = {}
-        ranges = []
-        datatypeonly = True
-        ext = None
-        for p, o in sorted(graph.predicate_objects(uri)):
+        children: List[ElementTree.Element] = []
+        domains: Dict[rdflib.term.Node, bool] = {}
+        ranges: List[str] = []
+        datatypeonly: bool = True
+        ext: Optional[str] = None
+        for p, o in sorted(graph.predicate_objects(URIRef(uri)), key=lambda x: (str(x[0]), str(x[1]))):
             if p == RDFS.label:
-                l = ElementTree.Element("rdfs:label")
+                l: ElementTree.Element = ElementTree.Element("rdfs:label")
                 l.set("xml:lang", "en")
-                l.text = o
+                l.text = str(o)
                 children.append(l)
             elif p == RDFS.comment:
-                c = ElementTree.Element("rdfs:comment")
+                c: ElementTree.Element = ElementTree.Element("rdfs:comment")
                 c.set("xml:lang", "en")
-                c.text = Markdown.parse(o)
+                c.text = Markdown.parse(str(o))
                 children.append(c)
             elif p == RDFS.subPropertyOf:
-                sub = ElementTree.Element("rdfs:subPropertyOf")
-                subval = str(o)
+                sub: ElementTree.Element = ElementTree.Element("rdfs:subPropertyOf")
+                subval: str = str(o)
                 if (
                     subval == "rdf:type"
                 ):  # Fixes a special case with schema:additionalType
@@ -208,11 +211,11 @@ class OwlBuild:
                 children.append(sub)
             elif p == INVERSEOF:
                 sub = ElementTree.Element("owl:inverseOf")
-                sub.set("rdf:resource", o)
+                sub.set("rdf:resource", str(o))
                 children.append(sub)
             elif p == SUPERSEDEDBY:
                 sub = ElementTree.Element("schema:supersededBy")
-                sub.set("rdf:resource", o)
+                sub.set("rdf:resource", str(o))
                 children.append(sub)
             elif p == DOMAININC:
                 domains[o] = True
@@ -231,73 +234,74 @@ class OwlBuild:
                     ranges.append(r)
 
         if len(domains):
-            d = ElementTree.Element("rdfs:domain")
+            d: ElementTree.Element = ElementTree.Element("rdfs:domain")
             children.append(d)
-            cl = ElementTree.SubElement(d, "owl:Class")
-            u = ElementTree.SubElement(cl, "owl:unionOf")
+            cl: ElementTree.Element = ElementTree.SubElement(d, "owl:Class")
+            u: ElementTree.Element = ElementTree.SubElement(cl, "owl:unionOf")
             u.set("rdf:parseType", "Collection")
             for target in sorted(domains.keys(), key=str):
-                targ = ElementTree.SubElement(u, "owl:Class")
-                targ.set("rdf:about", target)
+                targ: ElementTree.Element = ElementTree.SubElement(u, "owl:Class")
+                targ.set("rdf:about", str(target))
 
         if len(ranges):
-            r = ElementTree.Element("rdfs:range")
-            children.append(r)
-            cl = ElementTree.SubElement(r, "owl:Class")
-            u = ElementTree.SubElement(cl, "owl:unionOf")
-            u.set("rdf:parseType", "Collection")
-            for target in sorted(ranges, key=str):
-                targ = ElementTree.SubElement(u, "owl:Class")
-                targ.set("rdf:about", target)
+            r_elem: ElementTree.Element = ElementTree.Element("rdfs:range")
+            children.append(r_elem)
+            cl_elem: ElementTree.Element = ElementTree.SubElement(r_elem, "owl:Class")
+            u_elem: ElementTree.Element = ElementTree.SubElement(cl_elem, "owl:unionOf")
+            u_elem.set("rdf:parseType", "Collection")
+            for target_range in sorted(ranges):
+                targ_elem: ElementTree.Element = ElementTree.SubElement(u_elem, "owl:Class")
+                targ_elem.set("rdf:about", target_range)
 
+        prop: ElementTree.Element
         if datatypeonly:
             prop = ElementTree.SubElement(self.dom, "owl:DatatypeProperty")
         else:
             prop = ElementTree.SubElement(self.dom, "owl:ObjectProperty")
         prop.set("rdf:about", uri)
-        for sub in children:
-            prop.append(sub)
+        for sub_elem in children:
+            prop.append(sub_elem)
 
-    def addDefined(self, uri, ext=None):
+    def addDefined(self, uri: str, ext: Optional[str] = None) -> ElementTree.Element:
         if not ext:
             ext = "https://schema.org"
         ext = ext.replace("http://", "https://")
-        defn = ElementTree.Element("rdfs:isDefinedBy")
-        path = os.path.join(ext, os.path.basename(uri))
+        defn: ElementTree.Element = ElementTree.Element("rdfs:isDefinedBy")
+        path: str = os.path.join(ext, os.path.basename(uri))
         defn.set("rdf:resource", path)
         return defn
 
-    def outputEnums(self, graph):
-        q = """ prefix schema: <https://schema.org/>
+    def outputEnums(self, graph: rdflib.Graph) -> None:
+        q: str = """ prefix schema: <https://schema.org/>
         select Distinct ?enum ?parent where{
         ?parent rdfs:subClassOf schema:Enumeration.
             ?enum rdfs:subClassOf ?parent.
         }
         """
-        enums = list(graph.query(q))
-        for row in sorted(enums):
-            self.outputNamedIndividuals(row.enum, graph, parent=row.parent)
+        enums: List[rdflib.query.ResultRow] = list(graph.query(q))
+        for row in sorted(enums, key=lambda r: (str(r.enum), str(r.parent))):
+            self.outputNamedIndividuals(str(row.enum), graph, parent=str(row.parent))
 
-    def outputNamedIndividuals(self, individual, graph, parent=None):
+    def outputNamedIndividuals(self, individual: str, graph: rdflib.Graph, parent: Optional[str] = None) -> None:
         self.namedCount += 1
 
-        typ = ElementTree.SubElement(self.dom, "owl:NamedIndividual")
+        typ: ElementTree.Element = ElementTree.SubElement(self.dom, "owl:NamedIndividual")
         typ.set("rdf:about", individual)
-        ext = None
-        for p, o in sorted(graph.predicate_objects(URIRef(individual))):
+        ext: Optional[str] = None
+        for p, o in sorted(graph.predicate_objects(URIRef(individual)), key=lambda x: (str(x[0]), str(x[1]))):
             if p == RDFS.label:
-                l = ElementTree.SubElement(typ, "rdfs:label")
+                l: ElementTree.Element = ElementTree.SubElement(typ, "rdfs:label")
                 l.set("xml:lang", "en")
-                l.text = o
+                l.text = str(o)
             elif p == RDFS.comment:
-                c = ElementTree.SubElement(typ, "rdfs:comment")
+                c: ElementTree.Element = ElementTree.SubElement(typ, "rdfs:comment")
                 c.set("xml:lang", "en")
-                c.text = Markdown.parse(o)
+                c.text = Markdown.parse(str(o))
             elif p == URIRef(VOCABURI + "isPartOf"):
                 ext = str(o)
 
         typ.append(self.addDefined(individual, ext))
 
         if parent:
-            s = ElementTree.SubElement(typ, "rdfs:subClassOf")
+            s: ElementTree.Element = ElementTree.SubElement(typ, "rdfs:subClassOf")
             s.set("rdf:resource", parent)

--- a/software/util/sdoowl.py
+++ b/software/util/sdoowl.py
@@ -11,7 +11,7 @@ if not (sys.version_info.major == 3 and sys.version_info.minor > 5):
 
 import glob
 import re
-from typing import Any, Dict, List, Optional, Tuple, Union, Set
+from typing import Any, Dict, List, Optional, Tuple, Union, Set, FrozenSet
 
 for path in [
     os.getcwd(),
@@ -58,8 +58,8 @@ DOMAININC: URIRef = URIRef(f"{VOCABURI}domainIncludes")
 RANGEINC: URIRef = URIRef(f"{VOCABURI}rangeIncludes")
 INVERSEOF: URIRef = URIRef(f"{VOCABURI}inverseOf")
 SUPERSEDEDBY: URIRef = URIRef(f"{VOCABURI}supersededBy")
-DEFAULTRANGES: Set[str] = frozenset([f"{VOCABURI}Text", f"{VOCABURI}URL", f"{VOCABURI}Role"])
-DATATYPES: Set[str] = frozenset(
+DEFAULTRANGES: FrozenSet[str] = frozenset([f"{VOCABURI}Text", f"{VOCABURI}URL", f"{VOCABURI}Role"])
+DATATYPES: FrozenSet[str] = frozenset(
     [
         f"{VOCABURI}Boolean",
         f"{VOCABURI}Date",
@@ -100,7 +100,7 @@ class OwlBuild:
             self.dom.set(k, v)
 
         version: str = schemaversion.getVersion()
-        version_date: str = schemaversion.getCurrentVersionDate()
+        version_date: Optional[str] = schemaversion.getCurrentVersionDate()
         comment_text: str = f"Generated from Schema.org version: {version} released: {version_date}"
         self.dom.append(_MakePrettyComment(text=comment_text))
         self.ont = ElementTree.SubElement(self.dom, "owl:Ontology")

--- a/software/util/sdoowl.py
+++ b/software/util/sdoowl.py
@@ -5,8 +5,7 @@ import os
 
 if not (sys.version_info.major == 3 and sys.version_info.minor > 5):
     print(
-        "Python version %s.%s not supported version 3.6 or above required - exiting"
-        % (sys.version_info.major, sys.version_info.minor)
+        f"Python version {sys.version_info.major}.{sys.version_info.minor} not supported version 3.6 or above required - exiting"
     )
     sys.exit(os.EX_CONFIG)
 
@@ -55,29 +54,29 @@ NAMESPACES: Dict[str, str] = {
 }
 
 
-DOMAININC: URIRef = URIRef(VOCABURI + "domainIncludes")
-RANGEINC: URIRef = URIRef(VOCABURI + "rangeIncludes")
-INVERSEOF: URIRef = URIRef(VOCABURI + "inverseOf")
-SUPERSEDEDBY: URIRef = URIRef(VOCABURI + "supersededBy")
-DEFAULTRANGES: Set[str] = frozenset([VOCABURI + "Text", VOCABURI + "URL", VOCABURI + "Role"])
+DOMAININC: URIRef = URIRef(f"{VOCABURI}domainIncludes")
+RANGEINC: URIRef = URIRef(f"{VOCABURI}rangeIncludes")
+INVERSEOF: URIRef = URIRef(f"{VOCABURI}inverseOf")
+SUPERSEDEDBY: URIRef = URIRef(f"{VOCABURI}supersededBy")
+DEFAULTRANGES: Set[str] = frozenset([f"{VOCABURI}Text", f"{VOCABURI}URL", f"{VOCABURI}Role"])
 DATATYPES: Set[str] = frozenset(
     [
-        VOCABURI + "Boolean",
-        VOCABURI + "Date",
-        VOCABURI + "DateTime",
-        VOCABURI + "Number",
-        VOCABURI + "Float",
-        VOCABURI + "Integer",
-        VOCABURI + "Time",
+        f"{VOCABURI}Boolean",
+        f"{VOCABURI}Date",
+        f"{VOCABURI}DateTime",
+        f"{VOCABURI}Number",
+        f"{VOCABURI}Float",
+        f"{VOCABURI}Integer",
+        f"{VOCABURI}Time",
     ]
 )
 
 
 def _MakePrettyComment(text: str) -> ElementTree.Comment:
     """Make a pretty comment with a box of slashes before and after."""
-    inner_text: str = "/ " + text
+    inner_text: str = f"/ {text}"
     bar: str = "/" * len(inner_text)
-    comment: str = "\n\t" + bar + "\n\t" + inner_text + "\n\t" + bar + "\n\n\t"
+    comment: str = f"\n\t{bar}\n\t{inner_text}\n\t{bar}\n\n\t"
     return ElementTree.Comment(comment)
 
 
@@ -102,10 +101,7 @@ class OwlBuild:
 
         version: str = schemaversion.getVersion()
         version_date: str = schemaversion.getCurrentVersionDate()
-        comment_text: str = "Generated from Schema.org version: %s released: %s" % (
-            version,
-            version_date,
-        )
+        comment_text: str = f"Generated from Schema.org version: {version} released: {version_date}"
         self.dom.append(_MakePrettyComment(text=comment_text))
         self.ont = ElementTree.SubElement(self.dom, "owl:Ontology")
         self.ont.set("rdf:about", VOCABURI)
@@ -152,8 +148,8 @@ class OwlBuild:
         self.dom.append(_MakePrettyComment(text="Named Individuals Definitions"))
 
         self.outputEnums(graph)
-        self.outputNamedIndividuals(VOCABURI + "True", graph)
-        self.outputNamedIndividuals(VOCABURI + "False", graph)
+        self.outputNamedIndividuals(f"{VOCABURI}True", graph)
+        self.outputNamedIndividuals(f"{VOCABURI}False", graph)
 
     def outputType(self, uri: str, graph: rdflib.Graph) -> None:
         self.typesCount += 1
@@ -173,11 +169,11 @@ class OwlBuild:
             elif p == RDFS.subClassOf:
                 s: ElementTree.Element = ElementTree.SubElement(typ, "rdfs:subClassOf")
                 s.set("rdf:resource", str(o))
-            elif p == URIRef(VOCABURI + "isPartOf"):  # Defined in an extension
+            elif p == URIRef(f"{VOCABURI}isPartOf"):  # Defined in an extension
                 ext = str(o)
-            elif p == RDF.type and o == URIRef(VOCABURI + "DataType"):  # A datatype
+            elif p == RDF.type and o == URIRef(f"{VOCABURI}DataType"):  # A datatype
                 s = ElementTree.SubElement(typ, "rdfs:subClassOf")
-                s.set("rdf:resource", VOCABURI + "DataType")
+                s.set("rdf:resource", f"{VOCABURI}DataType")
 
         typ.append(self.addDefined(uri, ext))
 
@@ -223,7 +219,7 @@ class OwlBuild:
                 ranges.append(str(o))
                 if str(o) not in DATATYPES:
                     datatypeonly = False
-            elif p == URIRef(VOCABURI + "isPartOf"):
+            elif p == URIRef(f"{VOCABURI}isPartOf"):
                 ext = str(o)
 
         children.append(self.addDefined(uri, ext))
@@ -297,7 +293,7 @@ class OwlBuild:
                 c: ElementTree.Element = ElementTree.SubElement(typ, "rdfs:comment")
                 c.set("xml:lang", "en")
                 c.text = Markdown.parse(str(o))
-            elif p == URIRef(VOCABURI + "isPartOf"):
+            elif p == URIRef(f"{VOCABURI}isPartOf"):
                 ext = str(o)
 
         typ.append(self.addDefined(individual, ext))

--- a/software/util/snapshot_schema.py
+++ b/software/util/snapshot_schema.py
@@ -2,6 +2,8 @@ import os
 import shutil
 import logging
 import sys
+import typing
+from typing import Any, Dict, List, Optional, Tuple, Union, Iterable, Sequence, Set, Callable
 
 # Import schema.org libraries
 if not os.getcwd() in sys.path:
@@ -14,18 +16,18 @@ import software.SchemaTerms.sdotermsource as sdotermsource
 import software.util.buildfiles as buildfiles
 import software.util.pretty_logger as pretty_logger
 
-log = logging.getLogger(__name__)
+log: logging.Logger = logging.getLogger(__name__)
 
 
-def snapshot_ttl(output_dir: str = "software/tests/snapshot"):
+def snapshot_ttl(output_dir: str = "software/tests/snapshot") -> None:
     # Take some copies of globals we need to manipulate.
     # TODO: these globals should be arguments or similar
-    outputdir_copy = schemaglobals.OUTPUTDIR
-    selectors_copy = fileutils.FILESET_SELECTORS
-    protocols_copy = fileutils.FILESET_PROTOCOLS
+    outputdir_copy: str = schemaglobals.OUTPUTDIR
+    selectors_copy: Set[str] = fileutils.FILESET_SELECTORS
+    protocols_copy: Set[str] = fileutils.FILESET_PROTOCOLS
     schemaglobals.OUTPUTDIR = ""
-    fileutils.FILESET_SELECTORS = ("all",)
-    fileutils.FILESET_PROTOCOLS = ("https",)
+    fileutils.FILESET_SELECTORS = {"all"}
+    fileutils.FILESET_PROTOCOLS = {"https"}
 
     log.info("Building snapshot file...")
     sdotermsource.SdoTermSource.loadSourceGraph("default")

--- a/software/util/sort_dict.py
+++ b/software/util/sort_dict.py
@@ -1,7 +1,7 @@
 #!/usr/bin/env python3
 # -*- coding: utf-8 -*-
 
-from typing import Any, Tuple, List, Union, Dict
+from typing import Any, Tuple, List, Union, Dict, Optional
 from xml.dom import minidom
 from xml.etree import ElementTree
 
@@ -23,12 +23,12 @@ def sort_xml(xml_input: Union[str, ElementTree.Element]) -> str:
 
     def get_key(elem: ElementTree.Element) -> Tuple[str, str, str]:
         # We look for rdf:about or about attribute
-        about: str = elem.get("{http://www.w3.org/1999/02/22-rdf-syntax-ns#}about") or elem.get("about")
+        about: Optional[str] = elem.get("{http://www.w3.org/1999/02/22-rdf-syntax-ns#}about") or elem.get("about")
         if about:
             return (about, "", "")
         # Fallback to tag name (primary) and resource or string representation (secondary)
         tag: str = elem.tag
-        resource: str = elem.get("{http://www.w3.org/1999/02/22-rdf-syntax-ns#}resource") or elem.get("resource")
+        resource: Optional[str] = elem.get("{http://www.w3.org/1999/02/22-rdf-syntax-ns#}resource") or elem.get("resource")
         if resource:
             return (tag, resource, "")
         return (tag, "", ElementTree.tostring(elem, encoding="unicode"))

--- a/software/util/sort_dict.py
+++ b/software/util/sort_dict.py
@@ -55,7 +55,7 @@ def sort_xml(xml_input: Union[str, ElementTree.Element]) -> str:
     # Filter out empty lines and strip trailing whitespace from each line
     lines: List[str] = [line.rstrip() for line in pretty_xml.splitlines() if line.strip()]
 
-    return "\n".join(lines) + "\n"
+    return f'{"\n".join(lines)}\n'
 
 
 def universal_sort_key(item: Tuple[str, Any]) -> Tuple[int, str]:

--- a/software/util/sort_dict.py
+++ b/software/util/sort_dict.py
@@ -1,13 +1,14 @@
 #!/usr/bin/env python3
 # -*- coding: utf-8 -*-
 
+from typing import Any, Tuple, List, Union, Dict
 from xml.dom import minidom
 from xml.etree import ElementTree
 
-KEY_ORDER = ["@context", "@id", "@type"]
+KEY_ORDER: List[str] = ["@context", "@id", "@type"]
 
 
-def sort_xml(xml_input):
+def sort_xml(xml_input: Union[str, ElementTree.Element]) -> str:
     """Sorts children of an XML element for deterministic output.
 
     If the input is a string, it will be parsed as an XML Element.
@@ -20,20 +21,20 @@ def sort_xml(xml_input):
     else:
         raise TypeError(f"Expected str or ElementTree.Element, got {type(xml_input)}")
 
-    def get_key(elem):
+    def get_key(elem: ElementTree.Element) -> Tuple[str, str, str]:
         # We look for rdf:about or about attribute
-        about = elem.get("{http://www.w3.org/1999/02/22-rdf-syntax-ns#}about") or elem.get("about")
+        about: str = elem.get("{http://www.w3.org/1999/02/22-rdf-syntax-ns#}about") or elem.get("about")
         if about:
             return (about, "", "")
         # Fallback to tag name (primary) and resource or string representation (secondary)
-        tag = elem.tag
-        resource = elem.get("{http://www.w3.org/1999/02/22-rdf-syntax-ns#}resource") or elem.get("resource")
+        tag: str = elem.tag
+        resource: str = elem.get("{http://www.w3.org/1999/02/22-rdf-syntax-ns#}resource") or elem.get("resource")
         if resource:
             return (tag, resource, "")
         return (tag, "", ElementTree.tostring(elem, encoding="unicode"))
 
-    def recursive_sort(element):
-        children = list(element)
+    def recursive_sort(element: ElementTree.Element) -> None:
+        children: List[ElementTree.Element] = list(element)
         if not children:
             return
         children.sort(key=get_key)
@@ -45,19 +46,19 @@ def sort_xml(xml_input):
 
     recursive_sort(root)
 
-    pretty_xml = (
+    pretty_xml: str = (
         minidom.parseString(ElementTree.tostring(root))
         .toprettyxml(encoding="UTF-8")
         .decode()
     )
 
     # Filter out empty lines and strip trailing whitespace from each line
-    lines = [line.rstrip() for line in pretty_xml.splitlines() if line.strip()]
+    lines: List[str] = [line.rstrip() for line in pretty_xml.splitlines() if line.strip()]
 
     return "\n".join(lines) + "\n"
 
 
-def universal_sort_key(item):
+def universal_sort_key(item: Tuple[str, Any]) -> Tuple[int, str]:
 
     """Sort key for dictionary items (k, v).
 
@@ -73,7 +74,7 @@ def universal_sort_key(item):
     return (len(KEY_ORDER) + 2, k)
 
 
-def list_sort_key(item):
+def list_sort_key(item: Any) -> str:
     """Sort key for list items."""
     if isinstance(item, dict):
         # Prefer sorting by @id, then @type, then string representation
@@ -81,7 +82,7 @@ def list_sort_key(item):
     return str(item)
 
 
-def sort_dict(data):
+def sort_dict(data: Any) -> Any:
     """Recursively sort dictionary keys and list elements for predictability.
 
     Uses universal_sort_key for dictionaries. 

--- a/software/util/textutils.py
+++ b/software/util/textutils.py
@@ -2,47 +2,25 @@
 # -*- coding: utf-8 -*-
 
 import re
-import typing
-from typing import Any, Dict, List, Optional, Tuple, Union, Iterable, Sequence, Set, Callable
-
+from typing import Optional, Match, Iterable
 
 def StripHtmlTags(source: str) -> str:
     """Strip all HTML tags from source."""
-    if source and len(source) > 0:
-        return re.sub("<[^<]+?>", "", source)
-    return ""
+    return re.sub(r"<[^<]+?>", "", source) if source else ""
 
 
 def ShortenOnSentence(source: str, lengthHint: int = 250) -> str:
-    """Shorten source at a sentence boundary.
-
-    Args:
-      source: input text to shorten.
-      lengthHint: length at which the input should be shortened.
-    Returns:
-      shortened text
-    """
-    if source and len(source) > lengthHint:
-        source = source.strip()
-        sentEnd: re.Pattern = re.compile("[.!?]")
-        sentList: List[str] = sentEnd.split(source)
-        com: str = ""
-        count: int = 0
-        while count < len(sentList):
-            if count > 0:
-                if len(com) < len(source):
-                    com += source[len(com)]
-            com += sentList[count]
-            count += 1
-            if count == len(sentList):
-                if len(com) < len(source):
-                    com += source[len(source) - 1]
-            if len(com) > lengthHint:
-                if len(com) < len(source):
-                    com += source[len(com)]
-                break
-
-        if len(source) > len(com) + 1:
-            com += ".."
-        source = com
-    return source
+    """Shorten source at a sentence boundary near the lengthHint."""
+    if not source or len(source) <= lengthHint:
+        return source or ""
+        
+    source: str = source.strip()
+    pattern: re.Pattern = re.compile(r"[.!?](\s|$)")
+    
+    match: Match[str]
+    for match in pattern.finditer(source):
+        end_pos: int = match.start() + 1
+        if end_pos > lengthHint:
+            return source[:end_pos] + ".."
+            
+    return source[:lengthHint] + ".."

--- a/software/util/textutils.py
+++ b/software/util/textutils.py
@@ -2,16 +2,18 @@
 # -*- coding: utf-8 -*-
 
 import re
+import typing
+from typing import Any, Dict, List, Optional, Tuple, Union, Iterable, Sequence, Set, Callable
 
 
-def StripHtmlTags(source):
+def StripHtmlTags(source: str) -> str:
     """Strip all HTML tags from source."""
     if source and len(source) > 0:
         return re.sub("<[^<]+?>", "", source)
     return ""
 
 
-def ShortenOnSentence(source, lengthHint=250):
+def ShortenOnSentence(source: str, lengthHint: int = 250) -> str:
     """Shorten source at a sentence boundary.
 
     Args:
@@ -22,10 +24,10 @@ def ShortenOnSentence(source, lengthHint=250):
     """
     if source and len(source) > lengthHint:
         source = source.strip()
-        sentEnd = re.compile("[.!?]")
-        sentList = sentEnd.split(source)
-        com = ""
-        count = 0
+        sentEnd: re.Pattern = re.compile("[.!?]")
+        sentList: List[str] = sentEnd.split(source)
+        com: str = ""
+        count: int = 0
         while count < len(sentList):
             if count > 0:
                 if len(com) < len(source):


### PR DESCRIPTION
This make the following changes, each in a separate commit for easier reviewing:
 - add type annotations everywhere
 -  replace most strings with f-strings, except the SparQL expressions as they heavily use '{' and '}' and they would need to be all escaped
 - modernize the used Python by using more idiomatic constructs, and use existing standard library facilities when they exist.

This has been validated by comparing the resulting output, given it is now close to deterministic.