### PR TITLE
Move Python files that are *scripts* into /scripts/ and adjust.

### DIFF
--- a/.github/workflows/ci_tests.yml
+++ b/.github/workflows/ci_tests.yml
@@ -42,10 +42,10 @@ jobs:
       # Local tests prepare
       - name: Local Tests prepare
         run: |
-          software/util/buildsite.py -e -f RDFExport.nquads Context Examples
+          software/scripts/buildsite.py -e -f RDFExport.nquads Context Examples
           mkdir software/site/releases/LATEST
           (cd software/site/releases/`software/util/schemaversion.py`; cp -r * ../LATEST)
       
       # Run local tests
       - name: Run local tests
-        run: software/util/buildsite.py -r --shacltests
+        run: software/scripts/buildsite.py -r --shacltests

--- a/software/CONTRIBUTING.md
+++ b/software/CONTRIBUTING.md
@@ -23,7 +23,7 @@ The build system will pull in and merge all the files.
 ### Turtle files
 
 The `.ttl` files are in the [Turtle Syntax](https://en.wikipedia.org/wiki/Turtle_(syntax)).
-You can lint the files using the `software/util/reorg.py lint <file>` command.
+You can lint the files using the `software/scripts/reorg.py lint <file>` command.
 
 ### Example files
 

--- a/software/RELEASING.md
+++ b/software/RELEASING.md
@@ -72,7 +72,7 @@ Before building a release, confirm your Python environment is using the correct 
 
 In a checked out version of the _main_ branch:
 
-* Successfully run the `./software/util/buildsite.py --release` command.  This will:
+* Successfully run the `./software/scripts/buildsite.py --release` command.  This will:
   * assign missing example ids
   * complete a full build of the site, proceeded by tests.
   * copy working copies of release files into data/releases directory
@@ -122,7 +122,7 @@ configured as the current default github branch for /schemaorg/ project).
 It is best to test against a fresh checkout to avoid depending on uncommitted
 files. 
 
-To run tests: `./software/util/runtests.py`
+To run tests: `./software/scripts/runtests.py`
 
  Example transcript:
 
@@ -132,7 +132,7 @@ To run tests: `./software/util/runtests.py`
 
   ....
   $ cd schemaorg/
-  $ ./software/util/runtests.py
+  $ ./software/scripts/runtests.py
   [...]
 
   Ran 70 tests in 21.168s

--- a/software/SOFTWARE_README.md
+++ b/software/SOFTWARE_README.md
@@ -51,7 +51,7 @@ There are two common causes. Either your Python environment is not correctly set
 **Initial Build**
 Once a local version of the repository has been cloned, in to an appropriate python environment, initially run the following command:
 
-    ./software/util/buildsite.py -a
+    ./software/scripts/buildsite.py -a
 
 This will create a local working copy of the schema.org website in the local `site` directory. Dependent on the configuration of your system, this will take between 5-20 minutes. Note, this full build is only needed initially, or when significant changes have been made and prior to deploying a new version.  See below for details on how to build individual files and pages.
 
@@ -66,7 +66,7 @@ Running Locally
 
 To locally serve as a website, run:
 
-    ./software/devserv.py
+    ./software/scripts/devserv.py
 
 This will serve the site from the `localhost:8080` address. Use options `--host` and `--port` to change this.
 
@@ -78,7 +78,7 @@ Testing Locally
 
 Locally one can run tests that assert that the schema is self-consistent, and that examples actually satisfy the schema defined in RDF:
 
-    software/util/buildsite.py -a -r --shacltests
+    software/scripts/buildsite.py -a -r --shacltests
 
 This will auto-build the entire site (`-a`), run the tests (`-r`) as well as
 validate the examples (`--shacltests`).
@@ -109,7 +109,7 @@ The build scripts use a single configuration file `versions.json` to control the
 
 If the version number or date has been changed, a full build of the site is required, to reflect that change:
 
-    ./software/util/buildsite.py -a
+    ./software/scripts/buildsite.py -a
 
 Vocabulary Definition and Examples Files
 ========================================
@@ -122,22 +122,22 @@ Building Individual Files Documents and Term Pages
 ==================================================
 
 During development, it is possible to select individual term pages, dynamic docs pages, static docs pages, or output files (vocabulary definition RDF files, sitemap, jsonldcontext, etc.) for rebuilding in the local `site` directory.
-For details see the output of the command `./software/util/buildsite.py -h`.  Examples include:
+For details see the output of the command `./software/scripts/buildsite.py -h`.  Examples include:
 
-* `./software/util/buildsite.py -t Book sameAs`  Would rebuild the *Book* and *sameAs* term pages.
-* `./software/util/buildsite.py -t All`  Would rebuild all term pages.
-* `./software/util/buildsite.py -f Owl` Would rebuild the file `docs/schemaorg.owl` file.
-* `./software/util/buildsite.py -f RDFExport.turtle` Would rebuild the Turtle format vocabulary definition files.
-* `./software/util/buildsite.py -f All` Would rebuild all output and definition files.
-* `./software/util/buildsite.py -s` Would copy any static docs pages, css files etc. into the `site`.
-* `./software/util/buildsite.py -d PendingHome` Would rebuild the home page for the pending section (`docs/pending.home.html`).
-* `./software/util/buildsite.py -d All` Would rebuild all dynamically created docs files.
+* `./software/scripts/buildsite.py -t Book sameAs`  Would rebuild the *Book* and *sameAs* term pages.
+* `./software/scripts/buildsite.py -t All`  Would rebuild all term pages.
+* `./software/scripts/buildsite.py -f Owl` Would rebuild the file `docs/schemaorg.owl` file.
+* `./software/scripts/buildsite.py -f RDFExport.turtle` Would rebuild the Turtle format vocabulary definition files.
+* `./software/scripts/buildsite.py -f All` Would rebuild all output and definition files.
+* `./software/scripts/buildsite.py -s` Would copy any static docs pages, css files etc. into the `site`.
+* `./software/scripts/buildsite.py -d PendingHome` Would rebuild the home page for the pending section (`docs/pending.home.html`).
+* `./software/scripts/buildsite.py -d All` Would rebuild all dynamically created docs files.
 
-Changes to created pages are immediately reflected in the output of the local `./software/devserv.py` server, without the need for a restart. You may need to do a full refresh of a page to see changes, because of browser caching.
+Changes to created pages are immediately reflected in the output of the local `./software/scripts/devserv.py` server, without the need for a restart. You may need to do a full refresh of a page to see changes, because of browser caching.
 
 Whenever any changes or additions are made to .ttl files, examples files, documents or other files in the docs directory, these will need to be reflected into the `site` directory using `buildsite.py`.
 
-In a local development process, defining new types, properties, or changing wording for instance, it would only be necessary to build/rebuild the relevant term pages to see the effects via the website locally served by`./software/devserv.py`.
+In a local development process, defining new types, properties, or changing wording for instance, it would only be necessary to build/rebuild the relevant term pages to see the effects via the website locally served by`./software/scripts/devserv.py`.
 
 _Note:_ **Remember** to run the `buildsite.py` with the `-a` option prior to a deployment or release, to reflect all potential changes (including those pulled from the repository) in the local system into the `site` website image.
 
@@ -181,10 +181,10 @@ Command line commands:
  * `git clone https://github.com/schemaorg/schemaorg.git`
  * `cd schemaorg`
  * `pip3 install -r software/requirements.txt`
- * `./software/util/buildsite.py -a`
+ * `./software/scripts/buildsite.py -a`
 
  To serve local version of Schema.org site for web access:
- * `./software/devserv.py --port 8080 --host 0.0.0.0`
+ * `./software/scripts/devserv.py --port 8080 --host 0.0.0.0`
 
 Site should be accessible via:
 

--- a/software/SchemaExamples/README.md
+++ b/software/SchemaExamples/README.md
@@ -29,5 +29,9 @@ The ```schemaexamples.py``` module contains two significant classes:
  
 Checkout the example-code directory for usage, and the util directory for functionality implemented within schemorg.
 
+To run the examples, you can execute them either from the project root or from their own directory.
+Example from project root: `python3 software/SchemaExamples/example-code/examples4terms.py`
+Example from example directory: `cd software/SchemaExamples/example-code && python3 examples4terms.py`
+
 
 

--- a/software/SchemaExamples/example-code/batch-process.py
+++ b/software/SchemaExamples/example-code/batch-process.py
@@ -1,24 +1,28 @@
 #!/usr/bin/env python3
 # -*- coding: utf-8 -*-
 
-import sys
-import os
-for path in [os.getcwd()]:
-    sys.path.insert(1, path)  # Pickup libs from shipped lib directory
-
+import glob
 import logging
+import os
+import sys
+
+if os.getcwd() not in sys.path:
+    sys.path.insert(1, os.getcwd())
+import software
+
+from SchemaExamples.schemaexamples import SchemaExamples
+
+
 logging.basicConfig(level=logging.INFO)  # dev_appserver.py --log_level debug .
 log = logging.getLogger(__name__)
 
-from schemaexamples import schemaExamples
 
 
 exfiles = []
-import glob
 # globpatterns =
 # ["/Users/wallisr/Development/Schema/main/schemaorg/data/*examples.txt",
 # "/Users/wallisr/Development/Schema/main/schemaorg/data/ext/*/*examples.txt" ]
-globpatterns = ["example-code/examples.txt"]
+globpatterns = [os.path.join(os.path.dirname(__file__), "examples.txt")]
 
 files = []
 for g in globpatterns:
@@ -27,25 +31,25 @@ for g in globpatterns:
 log.info("Loading %d files" % len(files))
 for f in files:
     # log.info("Loading: %s" % f)
-    schemaExamples.loadExamplesFile(f)
+    SchemaExamples.loadExamplesFiles(f)
 
-log.info("Loaded %s examples" % schemaExamples.count())
+log.info("Loaded %s examples" % SchemaExamples.count())
 
 log.info("Process!")
-for e in schemaExamples.allExamples():
+for e in SchemaExamples.allExamples():
     if not e.hasHtml():
-        log.info("Example %s has no html" % e.key())
+        log.info("Example %s has no html" % e.getKey())
     if not e.hasMicrodata():
-        log.info("Example %s has no html" % e.key())
+        log.info("Example %s has no html" % e.getKey())
     if not e.hasRdfa():
-        log.info("Example %s has no html" % e.key())
+        log.info("Example %s has no html" % e.getKey())
     if not e.hasJsonld():
-        log.info("Example %s has no html" % e.key())
+        log.info("Example %s has no html" % e.getKey())
 
 filename = ""
 f = None
 
-examples = schemaExamples.allExamples(sort=True)
+examples = SchemaExamples.allExamples(sort=True)
 log.info("Writing %s examples" % len(examples))
 for ex in examples:
     source = ex.exmeta['file']

--- a/software/SchemaExamples/example-code/examples.txt.new
+++ b/software/SchemaExamples/example-code/examples.txt.new
@@ -1,4 +1,4 @@
-TYPES: #eg-1 Person,PostalAddress,addressRegion,postalCode,address,streetAddress,telephone,email,url,addressLocality
+TYPES: #eg-0001 Person, PostalAddress, addressRegion, postalCode, address, streetAddress, telephone, email, url, addressLocality
 
 PRE-MARKUP:
 
@@ -7,8 +7,8 @@ Jane Doe
 
 Professor
 20341 Whitworth Institute
-Suite 123
 405 Whitworth
+Suite 123
 Seattle WA 98052
 (425) 123-4567
 <a href="mailto:jane-doe@xyz.edu">jane-doe@illinois.edu</a>
@@ -30,12 +30,13 @@ MICRODATA:
   <div itemprop="address" itemscope itemtype="http://schema.org/PostalAddress">
     <span itemprop="streetAddress">
       20341 Whitworth Institute
-      Suite 123
       405 N. Whitworth
+      Suite 123
     </span>
-    <span itemprop="addressLocality">Seattle</span>,
+    <span itemprop="addressLocality">Seattle</span>
     <span itemprop="addressRegion">WA</span>
     <span itemprop="postalCode">98052</span>
+    <span itemprop="extendedAddress">Suite 123</span>
   </div>
   <span itemprop="telephone">(425) 123-4567</span>
   <a href="mailto:jane-doe@xyz.edu" itemprop="email">
@@ -81,7 +82,7 @@ JSON:
 }
 </script>
 
-TYPES: #eg2 Place,LocalBusiness,address,streetAddress,addressLocality,PostalAddress,telephone
+TYPES: #eg2 Place, LocalBusiness, address, streetAddress, addressLocality, PostalAddress, telephone
 
 PRE-MARKUP:
 
@@ -137,7 +138,7 @@ JSON:
 }
 </script>
 
-TYPES: #eg-3 Painting,genre
+TYPES: #eg-0003 Painting, genre
 
 PRE-MARKUP:
 
@@ -171,7 +172,7 @@ JSON:
 }
 </script>
 
-TYPES: #eg-4 Restaurant,AggregateRating,FoodEstablishment,LocalBusiness,aggregateRating,ratingValue,reviewCount
+TYPES: #eg-0004 Restaurant, AggregateRating, FoodEstablishment, LocalBusiness, aggregateRating, ratingValue, reviewCount
 
 PRE-MARKUP:
 
@@ -295,7 +296,7 @@ JSON:
 }
 </script>
 
-TYPES: #eg-5 Place,GeoCoordinates,latitude,longitude,geo
+TYPES: #eg-0005 Place, GeoCoordinates, latitude, longitude, geo
 
 PRE-MARKUP:
 
@@ -345,7 +346,7 @@ JSON:
 }
 </script>
 
-TYPES: #eg-6 MediaObject,AudioObject,encodingFormat,contentUrl,description,duration
+TYPES: #eg-0006 MediaObject, AudioObject, encodingFormat, contentUrl, description, duration
 
 PRE-MARKUP:
 
@@ -409,7 +410,7 @@ JSON:
 }
 </script>
 
-TYPES: #eg-7 Organization,PostalAddress,address,streetAddress,postalCode,addressLocality,faxNumber,telephone
+TYPES: #eg-0007 Organization, PostalAddress, address, streetAddress, postalCode, addressLocality, faxNumber, telephone
 
 PRE-MARKUP:
 
@@ -525,7 +526,7 @@ JSON:
 }
 </script>
 
-TYPES: #eg-8 NGO
+TYPES: #eg-0008 NGO
 
 PRE-MARKUP:
 
@@ -630,7 +631,7 @@ JSON:
 }
 </script>
 
-TYPES: #eg-9 Event,Place,PostalAddress,AggregateOffer,location,startDate,address,offers,offerCount
+TYPES: #eg-0009 Event, Place, PostalAddress, AggregateOffer, location, startDate, address, offers, offerCount
 
 PRE-MARKUP:
 
@@ -732,7 +733,7 @@ JSON:
 }
 </script>
 
-TYPES: #eg-10 Product,AggregateRating,Offer,Review,Rating,price,aggregateRating,ratingValue,reviewCount,availability,InStock
+TYPES: #eg-0010 Product, AggregateRating, Offer, Review, Rating, price, aggregateRating, ratingValue, reviewCount, availability, InStock
 
 PRE-MARKUP:
 
@@ -921,7 +922,7 @@ JSON:
 }
 </script>
 
-TYPES: #eg-11 Product,AggregateRating,AggregateOffer,Offer,aggregateRating,image,offers
+TYPES: #eg-0011 Product, AggregateRating, AggregateOffer, Offer, aggregateRating, image, offers
 
 PRE-MARKUP:
 
@@ -1026,7 +1027,7 @@ JSON:
 }
 </script>
 
-TYPES: #eg-12 WebPage,Book,AggregateRating,Offer,Review,CreativeWork,mainEntity
+TYPES: #eg-0012 WebPage, Book, AggregateRating, Offer, Review, CreativeWork, mainEntity
 
 PRE-MARKUP:
 
@@ -1232,7 +1233,7 @@ JSON:
 }
 </script>
 
-TYPES: #eg-13 Recipe,NutritionInformation,image,datePublished,prepTime,cookTime,recipeYield,recipeIngredient,calories,fatContent,suitableForDiet,LowFatDiet,RestrictedDiet
+TYPES: #eg-0013 Recipe, NutritionInformation, image, datePublished, prepTime, cookTime, recipeYield, recipeIngredient, calories, fatContent, suitableForDiet, LowFatDiet, RestrictedDiet
 
 PRE-MARKUP:
 
@@ -1390,7 +1391,7 @@ JSON:
 }
 </script>
 
-TYPES: #eg-14 VideoObject,MusicGroup,MusicRecording,Event,video,interactionStatistic,InteractionCounter,duration,interactionStatistic,interactionType
+TYPES: #eg-0014 VideoObject, MusicGroup, MusicRecording, Event, video, interactionStatistic, InteractionCounter, duration, interactionStatistic, interactionType
 
 PRE-MARKUP:
 
@@ -1931,7 +1932,7 @@ JSON:
 }
 </script>
 
-TYPES:  CreativeWork,ContentRating
+TYPES:  CreativeWork, ContentRating
 
 PRE-MARKUP:
 
@@ -2198,7 +2199,7 @@ JSON:
 }
 </script>
 
-TYPES:  InteractionCounter,Article
+TYPES:  InteractionCounter, Article
 
 PRE-MARKUP:
 
@@ -2273,7 +2274,7 @@ JSON:
 }
 </script>
 
-TYPES:  CivicStructure,Place
+TYPES:  CivicStructure, Place
 
 PRE-MARKUP:
 
@@ -2392,7 +2393,7 @@ JSON:
 }
 </script>
 
-TYPES:  TVSeries,TVSeason,TVEpisode
+TYPES:  TVSeries, TVSeason, TVEpisode
 
 PRE-MARKUP:
 
@@ -4932,7 +4933,7 @@ JSON:
 }
 </script>
 
-TYPES:  AskAction,Question
+TYPES:  AskAction, Question
 
 PRE-MARKUP:
 
@@ -5299,7 +5300,7 @@ JSON:
 }
 </script>
 
-TYPES:  ReplyAction,Question,Answer
+TYPES:  ReplyAction, Question, Answer
 
 PRE-MARKUP:
 
@@ -7635,7 +7636,7 @@ JSON:
 }
 </script>
 
-TYPES:  TVSeries,TVSeason,TVEpisode,OnDemandEvent,BroadcastEvent,BroadcastService
+TYPES:  TVSeries, TVSeason, TVEpisode, OnDemandEvent, BroadcastEvent, BroadcastService
 
 PRE-MARKUP:
 
@@ -7750,7 +7751,7 @@ JSON:
 }
 </script>
 
-TYPES:  RadioSeries,RadioSeason,RadioEpisode,OnDemandEvent,BroadcastEvent,BroadcastService
+TYPES:  RadioSeries, RadioSeason, RadioEpisode, OnDemandEvent, BroadcastEvent, BroadcastService
 
 PRE-MARKUP:
 
@@ -7837,7 +7838,7 @@ JSON:
 }
 </script>
 
-TYPES:  GovernmentPermit,GovernmentOrganization,GovernmentService,AdministrativeArea
+TYPES:  GovernmentPermit, GovernmentOrganization, GovernmentService, AdministrativeArea
 
 PRE-MARKUP:
 
@@ -7901,7 +7902,7 @@ JSON:
 }
 </script>
 
-TYPES:  GovernmentService,GovernmentOrganization,AdministrativeArea,CivicAudience,ContactPoint,Language,Hospital
+TYPES:  GovernmentService, GovernmentOrganization, AdministrativeArea, CivicAudience, ContactPoint, Language, Hospital
 
 PRE-MARKUP:
 
@@ -7961,7 +7962,7 @@ JSON:
 }
 </script>
 
-TYPES:  Event,Place,PostalAddress,Offer
+TYPES:  Event, Place, PostalAddress, Offer
 
 PRE-MARKUP:
 
@@ -8064,7 +8065,7 @@ JSON:
 }
 </script>
 
-TYPES:  Event,Place,PostalAddress,Offer,EventCancelled
+TYPES:  Event, Place, PostalAddress, Offer, EventCancelled
 
 PRE-MARKUP:
 
@@ -8167,7 +8168,7 @@ JSON:
 }
 </script>
 
-TYPES:  Event,Place,PostalAddress,Offer
+TYPES:  Event, Place, PostalAddress, Offer
 
 PRE-MARKUP:
 
@@ -8269,7 +8270,7 @@ JSON:
 }
 </script>
 
-TYPES:  Event,Place,PostalAddress,Offer,SoldOut
+TYPES:  Event, Place, PostalAddress, Offer, SoldOut
 
 PRE-MARKUP:
 
@@ -8372,7 +8373,7 @@ JSON:
 }
 </script>
 
-TYPES:  Event,Place,PostalAddress,MusicGroup,Offer,LimitedAvailability
+TYPES:  Event, Place, PostalAddress, MusicGroup, Offer, LimitedAvailability
 
 PRE-MARKUP:
 
@@ -8421,7 +8422,7 @@ JSON:
 }
 </script>
 
-TYPES:  Book,CreativeWork,accessibilityFeature,accessibilityHazard,accessibilityControl,accessibilityAPI
+TYPES:  Book, CreativeWork, accessibilityFeature, accessibilityHazard, accessibilityControl, accessibilityAPI
 
 PRE-MARKUP:
 
@@ -8670,7 +8671,7 @@ JSON:
 }
 </script>
 
-TYPES:  accessibilityFeature,accessibilityHazard,encodingFormat
+TYPES:  accessibilityFeature, accessibilityHazard, encodingFormat
 
 PRE-MARKUP:
 
@@ -8705,7 +8706,7 @@ JSON:
 
 No Json example available
 
-TYPES:  encodingFormat,accessibilityHazard,accessibilityFeature,accessibilityControl,accessibilityAPI
+TYPES:  encodingFormat, accessibilityHazard, accessibilityFeature, accessibilityControl, accessibilityAPI
 
 PRE-MARKUP:
 
@@ -8776,7 +8777,7 @@ JSON:
         "fullVoiceControl" , "fullMouseControl" ]
 } </script>
 
-TYPES:  TrainReservation,TrainTrip
+TYPES:  TrainReservation, TrainTrip
 
 PRE-MARKUP:
 
@@ -8835,7 +8836,7 @@ JSON:
 }
 </script>
 
-TYPES:  BusReservation,BusTrip
+TYPES:  BusReservation, BusTrip
 
 PRE-MARKUP:
 
@@ -8885,7 +8886,7 @@ JSON:
 }
 </script>
 
-TYPES:  EventReservation,Ticket,Seat
+TYPES:  EventReservation, Ticket, Seat
 
 PRE-MARKUP:
 
@@ -8955,7 +8956,7 @@ JSON:
 }
 </script>
 
-TYPES:  Flight,FlightReservation
+TYPES:  Flight, FlightReservation
 
 PRE-MARKUP:
 
@@ -9266,7 +9267,7 @@ JSON:
 }
 </script>
 
-TYPES:  Question,Answer
+TYPES:  Question, Answer
 
 PRE-MARKUP:
 
@@ -9389,7 +9390,7 @@ JSON:
 }
 </script>
 
-TYPES:  WatchAction,Movie
+TYPES:  WatchAction, Movie
 
 PRE-MARKUP:
 
@@ -9432,7 +9433,7 @@ JSON:
 }
 </script>
 
-TYPES:  Restaurant,ViewAction,EntryPoint,SoftwareApplication
+TYPES:  Restaurant, ViewAction, EntryPoint, SoftwareApplication
 
 PRE-MARKUP:
 
@@ -9493,7 +9494,7 @@ JSON:
 }
 </script>
 
-TYPES:  MusicEvent,Event,CreativeWork,MusicGroup,Person
+TYPES:  MusicEvent, Event, CreativeWork, MusicGroup, Person
 
 PRE-MARKUP:
 
@@ -9726,7 +9727,7 @@ JSON:
 }
 </script>
 
-TYPES:  Event,TheaterEvent,PerformingArtsTheater,CreativeWork
+TYPES:  Event, TheaterEvent, PerformingArtsTheater, CreativeWork
 
 PRE-MARKUP:
 
@@ -9888,7 +9889,7 @@ JSON:
 }
 </script>
 
-TYPES:  Store,OpeningHoursSpecification
+TYPES:  Store, OpeningHoursSpecification
 
 PRE-MARKUP:
 
@@ -9977,7 +9978,7 @@ JSON:
 }
 </script>
 
-TYPES:  Pharmacy,openingHours,telephone
+TYPES:  Pharmacy, openingHours, telephone
 
 PRE-MARKUP:
 
@@ -10022,7 +10023,7 @@ JSON:
 }
 </script>
 
-TYPES:  Store,Pharmacy
+TYPES:  Store, Pharmacy
 
 PRE-MARKUP:
 
@@ -10107,7 +10108,7 @@ JSON:
 }
 </script>
 
-TYPES:  Store,DryCleaningOrLaundry,Corporation,Pharmacy
+TYPES:  Store, DryCleaningOrLaundry, Corporation, Pharmacy
 
 PRE-MARKUP:
 
@@ -10236,7 +10237,7 @@ JSON:
 }
 </script>
 
-TYPES:  Store,PostalAddress,Pharmacy
+TYPES:  Store, PostalAddress, Pharmacy
 
 PRE-MARKUP:
 
@@ -10343,7 +10344,7 @@ JSON:
 }
 </script>
 
-TYPES:  PostalAddress,Pharmacy,Store
+TYPES:  PostalAddress, Pharmacy, Store
 
 PRE-MARKUP:
 
@@ -10473,7 +10474,7 @@ JSON:
 }
 </script>
 
-TYPES:  Organization,ContactPoint
+TYPES:  Organization, ContactPoint
 
 PRE-MARKUP:
 
@@ -10500,7 +10501,7 @@ JSON:
     } ] }
 </script>
 
-TYPES:  HearingImpairedSupported,TollFree,ContactPoint,Organization
+TYPES:  HearingImpairedSupported, TollFree, ContactPoint, Organization
 
 PRE-MARKUP:
 
@@ -10553,7 +10554,7 @@ JSON:
     } ] }
 </script>
 
-TYPES:  MusicEvent,Place,Offer
+TYPES:  MusicEvent, Place, Offer
 
 PRE-MARKUP:
 
@@ -10602,7 +10603,7 @@ JSON:
 }]
 </script>
 
-TYPES:  MusicEvent,Place,PostalAddress,Offer,MusicGroup,EventRescheduled
+TYPES:  MusicEvent, Place, PostalAddress, Offer, MusicGroup, EventRescheduled
 
 PRE-MARKUP:
 
@@ -10671,7 +10672,7 @@ JSON:
 }]
 </script>
 
-TYPES:  Role,OrganizationRole
+TYPES:  Role, OrganizationRole
 
 PRE-MARKUP:
 
@@ -10723,7 +10724,7 @@ JSON:
 }
 </script>
 
-TYPES:  Role,OrganizationRole,CollegeOrUniversity,EducationalOrganization
+TYPES:  Role, OrganizationRole, CollegeOrUniversity, EducationalOrganization
 
 PRE-MARKUP:
 
@@ -10781,7 +10782,7 @@ JSON:
 }
 </script>
 
-TYPES:  Role,PerformanceRole
+TYPES:  Role, PerformanceRole
 
 PRE-MARKUP:
 
@@ -10838,7 +10839,7 @@ JSON:
 }
 </script>
 
-TYPES:  Role,OrganizationRole,Person,SportsTeam,Organization
+TYPES:  Role, OrganizationRole, Person, SportsTeam, Organization
 
 PRE-MARKUP:
 
@@ -10898,7 +10899,7 @@ JSON:
 }
 </script>
 
-TYPES:  WebPage,CollegeOrUniversity
+TYPES:  WebPage, CollegeOrUniversity
 
 PRE-MARKUP:
 
@@ -10960,7 +10961,7 @@ JSON:
 }
 </script>
 
-TYPES:  ItemList,Product,Offer
+TYPES:  ItemList, Product, Offer
 
 PRE-MARKUP:
 
@@ -11040,7 +11041,7 @@ JSON:
 }
 </script>
 
-TYPES:  ItemList,CreativeWork
+TYPES:  ItemList, CreativeWork
 
 PRE-MARKUP:
 
@@ -11395,7 +11396,7 @@ JSON:
 }
 </script>
 
-TYPES:  ItemList,MusicAlbum
+TYPES:  ItemList, MusicAlbum
 
 PRE-MARKUP:
 
@@ -11504,7 +11505,7 @@ JSON:
 }
 </script>
 
-TYPES:  Person,disambiguatingDescription
+TYPES:  Person, disambiguatingDescription
 
 PRE-MARKUP:
 

--- a/software/SchemaExamples/example-code/examples4terms.py
+++ b/software/SchemaExamples/example-code/examples4terms.py
@@ -1,27 +1,33 @@
 #!/usr/bin/env python3
 # -*- coding: utf-8 -*-
 
-import sys
-import os
-for path in [os.getcwd(), "SchemaExamples"]:
-    sys.path.insert(1, path)  # Pickup libs from shipped lib directory
-
+import glob
 import logging
+import os
+import sys
+
+if os.getcwd() not in sys.path:
+    sys.path.insert(1, os.getcwd())
+import software
+
+from SchemaExamples.schemaexamples import Example, SchemaExamples
+
+
 logging.basicConfig(level=logging.INFO)  # dev_appserver.py --log_level debug .
 log = logging.getLogger(__name__)
 
-from schemaexamples import Example, SchemaExamples
 
 """
 Load examples from file
 """
-import glob
-globpatterns = ["data/*examples.txt", "data/ext/*/*examples.txt"]
+root = os.path.abspath(os.path.join(os.path.dirname(__file__), "../../.."))
+globpatterns = [os.path.join(root, "data/*examples.txt"), os.path.join(root, "data/ext/*/*examples.txt")]
 
 files = []
 for g in globpatterns:
     files.extend(glob.glob(g))
 
+os.chdir(root)
 print("Loading %d files" % len(files))
 SchemaExamples.loadExamplesFiles(files)
 

--- a/software/SchemaExamples/example-code/out
+++ b/software/SchemaExamples/example-code/out
@@ -1,4 +1,4 @@
-TYPES: #eg-313 DefinedTerm, termCode
+TYPES: #eg-0314 DefinedTerm, termCode
 
 PRE-MARKUP:
 
@@ -32,7 +32,7 @@ JSON:
  "inDefinedTermSet": "http://id.loc.gov/vocabulary/resourceTypes"
 }
 
-TYPES: #eg-314 DefinedTerm, DefinedTermSet, inDefinedTermSet
+TYPES: #eg-0315 DefinedTerm, DefinedTermSet, inDefinedTermSet
 
 PRE-MARKUP:
 
@@ -58,7 +58,7 @@ MICRODATA:
 
 <div>
 	<div itemscope itemtype="https://schema.org/DefinedTermSet">
-	<meta itemprop="additionalType" content="https://schema.org/Book">
+	<link itemprop="additionalType" href="https://schema.org/Book">
 	 <h1><a itemprop="url" href="http://openjurist.org/dictionary/Ballentine"><span itemprop="name">Ballentine&apos;s Law Dictionary</span></a></h1>
 	</div>
 	<div itemscope itemtype="https://schema.org/DefinedTerm">
@@ -95,7 +95,7 @@ RDFA:
 	</div>
 	<div typeof="DefinedTerm">
 		<h2>Dictionary term</h2>
-		<link property="url" href="http://openjurist.org/dictionary/Ballentine/term/schema"/>
+		<link propery="url" href="http://openjurist.org/dictionary/Ballentine/term/schema"/>
 		Name: <span property="name">schema</span><br/>
 		Description: <span property="description">A representation of a plan or theory in the form of an outline or model.</span><br/>
 		In Dictionary: Ballentine&apos;s Law Dictionary
@@ -130,7 +130,7 @@ JSON:
 	}
 ]
 
-TYPES: #eg-315 DefinedTerm, inDefinedTermSet, termCode
+TYPES: #eg-0316 DefinedTerm, inDefinedTermSet, termCode
 
 PRE-MARKUP:
 
@@ -167,7 +167,7 @@ JSON:
  "inDefinedTermSet": "http://onetonline.org"
 }
 
-TYPES: #eg-316 CategoryCode, CategoryCodeSet, hasCategoryCode, inCodeSet
+TYPES: #eg-0317 CategoryCode, CategoryCodeSet, hasCategoryCode, inCodeSet
 
 PRE-MARKUP:
 
@@ -217,7 +217,7 @@ JSON:
 	}
 }
 
-TYPES: #eg-317 CategoryCode, CategoryCodeSet, inCodeSet, codeValue, hasCategoryCode
+TYPES: #eg-0318 CategoryCode, CategoryCodeSet, inCodeSet, codeValue, hasCategoryCode
 
 PRE-MARKUP:
 
@@ -270,7 +270,7 @@ RDFA:
 		<li>...</li>
 	</ul>
 </div>
-<div vocab="https://schema.org/" typeof="CategoryCode" resource=="http://id.loc.gov/vocabulary/iso639-2/cze">
+<div vocab="https://schema.org/" typeof="CategoryCode" resource="http://id.loc.gov/vocabulary/iso639-2/cze">
 	<meta property="codeValue" content="cze">
 	<h2>Czech; tchèque; Tschechisch</h2>
 	<link property="inCodeSet" href="http://id.loc.gov/vocabulary/iso639-2">
@@ -289,7 +289,7 @@ JSON:
 	{
 		"@type": "CategoryCodeSet",
 		"@id": "http://id.loc.gov/vocabulary/iso639-2",
-		"name": "ISO 639-2: Codes for the Representation of Names of Languages"
+		"name": "ISO 639-2: Codes for the Representation of Names of Languages",
 		"hasCategoryCode": "http://id.loc.gov/vocabulary/iso639-2/cze"
 	},
 	{
@@ -303,4 +303,5 @@ JSON:
 		},
 		"inCodeSet": "http://id.loc.gov/vocabulary/iso639-2"
 	}
+]
 

--- a/software/SchemaExamples/example-code/singleload.py
+++ b/software/SchemaExamples/example-code/singleload.py
@@ -1,28 +1,32 @@
 #!/usr/bin/env python3
 # -*- coding: utf-8 -*-
 
-import sys
-import os
-for path in [os.getcwd(), "SchemaExamples"]:
-    sys.path.insert(1, path)  # Pickup libs from shipped lib directory
-
 import logging
+import os
+import sys
+
+if os.getcwd() not in sys.path:
+    sys.path.insert(1, os.getcwd())
+import software
+
+from SchemaExamples.schemaexamples import Example, SchemaExamples
+
+
 logging.basicConfig(level=logging.INFO)  # dev_appserver.py --log_level debug .
 log = logging.getLogger(__name__)
 
-from schemaexamples import Example, SchemaExamples
 
 """
 Load examples from file
 write back to another file
 """
 
-SchemaExamples.loadExamplesFile("data/ext/pending/issue-894-examples.txt")
+SchemaExamples.loadExamplesFiles("data/ext/pending/issue-894-examples.txt")
 # print(SchemaExamples.examplesForTerm("Event"))
 
 
 # filename = "out" + term.id +".html"
-filename = "SchemaExamples/example-code/out"
+filename = os.path.join(os.path.dirname(__file__), "out")
 
 exes = sorted(SchemaExamples.allExamples(), key=lambda x: (x.exmeta['file'], x.exmeta['filepos']))
 f = open(filename, "w")

--- a/software/SchemaExamples/schemaexamples.py
+++ b/software/SchemaExamples/schemaexamples.py
@@ -1,15 +1,25 @@
 #!/usr/bin/env python3
 # -*- coding: utf-8 -*-
 
+from __future__ import annotations
+
+import codecs
+import glob
+import io
 import logging
 import os
-import io
-import glob
 import re
+import sys
 import threading
 import typing
-from typing import Any, Dict, List, Optional, Tuple, Union, Iterable, Sequence, Set, Collection
-import software.util.paths as paths
+from typing import Any, Collection, Dict, Iterable, List, Optional, Sequence, Set, Tuple, Union
+
+import requests
+
+import software
+
+import util.paths as paths
+
 
 IDPREFIX: str = "eg-"
 DEFTEXAMPLESFILESGLOB: Tuple[str, str] = ("data/*examples.txt", "data/ext/*/*examples.txt")
@@ -393,9 +403,6 @@ class ExampleFileParser:
         )
 
     def parse(self, filen: str) -> List[Example]:
-        import codecs
-        import requests
-
         self.file = filen
         self.filepos = 0
         examples: List[Example] = []

--- a/software/SchemaExamples/utils/assign_example_ids.py
+++ b/software/SchemaExamples/utils/assign_example_ids.py
@@ -1,14 +1,14 @@
 #!/usr/bin/env python3
 # -*- coding: utf-8 -*-
 
+import logging
 import os
 import sys
-import logging
 
-for path in [os.getcwd(), './SchemaExamples', './software/SchemaExamples']:
-    sys.path.insert(1, path)  # Pickup libs from shipped lib directory
+import software
 
-import schemaexamples
+from SchemaExamples import schemaexamples
+
 
 def AssignExampleIds():
     """Check if all examples are assigned an identity, if not, assign one and rewrite the file."""

--- a/software/SchemaExamples/utils/consolidate.py
+++ b/software/SchemaExamples/utils/consolidate.py
@@ -1,17 +1,19 @@
 #!/usr/bin/env python3
 # -*- coding: utf-8 -*-
 
-import sys
-import os
-for path in [os.getcwd(), "./SchemaExamples", "./software/SchemaExamples"]:
-    sys.path.insert(1, path)  # Pickup libs from shipped lib directory
-
-import logging
 import argparse
+import logging
+import os
+import sys
+
+import software
+
+from SchemaExamples.schemaexamples import Example, SchemaExamples
+
+
 logging.basicConfig(level=logging.INFO)  # dev_appserver.py --log_level debug .
 log = logging.getLogger(__name__)
 
-from schemaexamples import SchemaExamples, Example
 
 parser = argparse.ArgumentParser()
 parser.add_argument("-o", "--output", required=True, help="output file")

--- a/software/SchemaTerms/README.txt
+++ b/software/SchemaTerms/README.txt
@@ -11,5 +11,9 @@ sdoterm.py defines the structures used.
 
 See example-code for examples of how the code can be used.
 
+To run the examples, you can execute them either from the project root or from their own directory.
+Example from project root: `python3 software/SchemaTerms/example-code/simpleTermList/simpleTermList.py`
+Example from example directory: `cd software/SchemaTerms/example-code/simpleTermList && python3 simpleTermList.py`
+
 Richard Wallis
 Sept 2020

--- a/software/SchemaTerms/example-code/HttpHttpsMapping/httphttpsmap.py
+++ b/software/SchemaTerms/example-code/HttpHttpsMapping/httphttpsmap.py
@@ -1,23 +1,26 @@
 #!/usr/bin/env python3
 # -*- coding: utf-8 -*-
 
-
+import argparse
+import glob
+import os
 import sys
+
+import rdflib
+from rdflib.namespace import OWL
+
+if os.getcwd() not in sys.path:
+    sys.path.insert(1, os.getcwd())
+import software
+
+from SchemaTerms.sdoterm import *
+from SchemaTerms.sdotermsource import *
+
+
 if not (sys.version_info.major == 3 and sys.version_info.minor > 5):
     print("Python version %s.%s not supported version 3.6 or above required - exiting" % (sys.version_info.major, sys.version_info.minor))
     sys.exit(1)
 
-# To be executed in the SchemaTerms/example-code/{example} directory
-import os
-for path in [os.getcwd(), "..", "../..", "../../.."]:  # Adds in current, example-code, and SchemaTerms directory into path
-    sys.path.insert(1, path)  # Pickup libs from local  directories
-
-import rdflib
-from rdflib.namespace import OWL
-import argparse
-import glob
-from sdotermsource import *
-from sdoterm import *
 
 parser = argparse.ArgumentParser()
 parser.add_argument("-o", "--output", required=True, help="output file")
@@ -27,7 +30,7 @@ exts = {"rdf": ".rdf", "nt": ".nt", "json-ld": ".jsonld", "turtle": ".ttl"}
 
 files = []
 triplesfilesglob = ["data/*.ttl", "data/ext/*/*.ttl"]
-schemaroot = "../../../"
+schemaroot = os.path.abspath(os.path.join(os.path.dirname(__file__), "../../../..")) + "/"
 for g in triplesfilesglob:
     files.extend(glob.glob(schemaroot + g))
 SdoTermSource.loadSourceGraph(files)
@@ -48,7 +51,7 @@ for term in terms:
 
     if t.uri.startswith(VOCABURI):  # Filter out non Schema terms
         eqiv = OWL.equivalentClass
-        if t.termType == SdoTerm.PROPERTY:
+        if t.termType == SdoTermType.PROPERTY:
             eqiv = OWL.equivalentProperty
 
         p = URIRef(s_p + t.id)

--- a/software/SchemaTerms/example-code/jinjaTemplating/simpleJinjaHtml.py
+++ b/software/SchemaTerms/example-code/jinjaTemplating/simpleJinjaHtml.py
@@ -1,30 +1,37 @@
 #!/usr/bin/env python3
 # -*- coding: utf-8 -*-
 
+import datetime
+import os
 import sys
+import time
+
+import jinja2
+import rdflib
+
+if os.getcwd() not in sys.path:
+    sys.path.insert(1, os.getcwd())
+import software
+
+from SchemaTerms.localmarkdown import Markdown
+from SchemaTerms.sdoterm import *
+from SchemaTerms.sdotermsource import *
+
+
 if not (sys.version_info.major == 3 and sys.version_info.minor > 5):
     print("Python version %s.%s not supported version 3.6 or above required - exiting" % (sys.version_info.major, sys.version_info.minor))
     sys.exit(1)
 
-# To be executed in the SchemaTerms/example-code/{example} directory
-import os
-for path in [os.getcwd(), "..", "../..", "../../.."]:  # Adds in current, example-code, and SchemaTerms directory into path
-    sys.path.insert(1, path)  # Pickup libs from local  directories
 
-import rdflib
-from sdotermsource import *
-from sdoterm import *
-from localmarkdown import Markdown
-
-import jinja2
 Markdown.setWikilinkCssClass("localLink")
 Markdown.setWikilinkPrePath("/")
 
 
-if VOCABURI.startswith("https://"):
-    triplesfile = "../data/schemaorg-all-https.nt"
+DATADIR = os.path.join(os.path.dirname(__file__), "../data")
+if SdoTermSource.vocabUri().startswith("https://"):
+    triplesfile = os.path.join(DATADIR, "schemaorg-all-https.nt")
 else:
-    triplesfile = "../data/schemaorg-all-http.nt"
+    triplesfile = os.path.join(DATADIR, "schemaorg-all-http.nt")
 
 termgraph = rdflib.Graph()
 termgraph.parse(triplesfile, format="nt")
@@ -41,7 +48,7 @@ print("Properties Count: %s" % len(SdoTermSource.getAllProperties(expanded=False
 
 # Setup Jinja2 environment - template(s) location etc.
 # TEMPLATESFOLDER = "SchemaTerms/templates"
-TEMPLATESDIR = "templates"
+TEMPLATESDIR = os.path.join(os.path.dirname(__file__), "templates")
 
 jenv = jinja2.Environment(loader=jinja2.FileSystemLoader(TEMPLATESDIR),
                           extensions=['jinja2.ext.autoescape'], autoescape=True, cache_size=0)
@@ -62,27 +69,27 @@ def templateRender(term):
 
     page = None
 
-    if term.expanded:
-        if term.termType == SdoTerm.TYPE:
+    if term.expanded():
+        if term.termType == SdoTermType.TYPE:
             page = "expanded/TypePageEx.tpl"
-        elif term.termType == SdoTerm.PROPERTY:
+        elif term.termType == SdoTermType.PROPERTY:
             page = "expanded/PropertyPageEx.tpl"
-        elif term.termType == SdoTerm.ENUMERATION:
+        elif term.termType == SdoTermType.ENUMERATION:
             page = "expanded/EnumerationPageEx.tpl"
-        elif term.termType == SdoTerm.ENUMERATIONVALUE:
+        elif term.termType == SdoTermType.ENUMERATIONVALUE:
             page = "expanded/EnumerationValuePageEx.tpl"
-        elif term.termType == SdoTerm.DATATYPE:
+        elif term.termType == SdoTermType.DATATYPE:
             page = "expanded/DataTypePageEx.tpl"
     else:
-        if term.termType == SdoTerm.TYPE:
+        if term.termType == SdoTermType.TYPE:
             page = "simple/TypePage.tpl"
-        elif term.termType == SdoTerm.PROPERTY:
+        elif term.termType == SdoTermType.PROPERTY:
             page = "simple/PropertyPage.tpl"
-        elif term.termType == SdoTerm.ENUMERATION:
+        elif term.termType == SdoTermType.ENUMERATION:
             page = "simple/EnumerationPage.tpl"
-        elif term.termType == SdoTerm.ENUMERATIONVALUE:
+        elif term.termType == SdoTermType.ENUMERATIONVALUE:
             page = "simple/EnumerationValuePage.tpl"
-        elif term.termType == SdoTerm.DATATYPE:
+        elif term.termType == SdoTermType.DATATYPE:
             page = "simple/DataTypePage.tpl"
     if not page:
         print("Invalid term type: %s" % term.termType)
@@ -101,7 +108,6 @@ terms = ["DataType", "about", "Action", "CreativeWork", "MonetaryAmount", "Prono
 print("Processing %s terms" % len(terms))
 
 
-import time, datetime
 start = datetime.datetime.now()
 lastCount = 0
 for t in terms:
@@ -109,7 +115,7 @@ for t in terms:
 
     term = SdoTermSource.getTerm(t, expanded=True)
     pageout = templateRender(term)
-    filename = "html/" + term.id + ".html"
+    filename = os.path.join(os.path.dirname(__file__), "html", term.id + ".html")
     f = open(filename, "w")
     f.write(pageout)
     f.close()

--- a/software/SchemaTerms/example-code/protobufs/protoexpanded.py
+++ b/software/SchemaTerms/example-code/protobufs/protoexpanded.py
@@ -2,25 +2,26 @@
 # -*- coding: utf-8 -*-
 
 
+import os
 import sys
+if os.getcwd() not in sys.path:
+    sys.path.insert(1, os.getcwd())
+import software
+
 if not (sys.version_info.major == 3 and sys.version_info.minor > 5):
     print("Python version %s.%s not supported version 3.6 or above required - exiting" % (sys.version_info.major,sys.version_info.minor))
     sys.exit(1)
 
-# To be executed in the SchemaTerms/example-code/{example} directory
-import os
-for path in [os.getcwd(),"..","../..","../../.."]: #Adds in current, example-code, and SchemaTerms directory into path
-  sys.path.insert( 1, path ) #Pickup libs from local  directories
-
-from sdotermsource import *
-from sdoterm import *
-from localmarkdown import Markdown
+from SchemaTerms.sdotermsource import *
+from SchemaTerms.sdoterm import *
+from SchemaTerms.localmarkdown import Markdown
 
 Markdown.setWikilinkCssClass("localLink")
 Markdown.setWikilinkPrePath("/")
 
 
-triplesfile = "../data/schemaorg-all-http.nt"
+DATADIR = os.path.join(os.path.dirname(__file__), "../data")
+triplesfile = os.path.join(DATADIR, "schemaorg-all-http.nt")
 SdoTermSource.VOCABURI = "https://schema.org/" #Force to https as loaded https file
 SdoTermSource.loadSourceGraph(triplesfile)
 print ("loaded %s triples" % len(SdoTermSource.sourceGraph()))
@@ -40,8 +41,8 @@ for t in terms:
     buf = sdotermToProtobuf(term)
     msg = protobufToMsg(buf)
     txt = protobufToText(buf)
-    mfilename = "out-protomsgs/" + t +".msg"
-    tfilename = "out-protomsgs/" + t +".txt"
+    mfilename = os.path.join(os.path.dirname(__file__), "out-protomsgs", t + ".msg")
+    tfilename = os.path.join(os.path.dirname(__file__), "out-protomsgs", t + ".txt")
     f = open(mfilename,"wb")
     f.write(msg)
     f.close()

--- a/software/SchemaTerms/example-code/protobufs/protosimple.py
+++ b/software/SchemaTerms/example-code/protobufs/protosimple.py
@@ -2,25 +2,26 @@
 # -*- coding: utf-8 -*-
 
 
+import os
 import sys
+if os.getcwd() not in sys.path:
+    sys.path.insert(1, os.getcwd())
+import software
+
 if not (sys.version_info.major == 3 and sys.version_info.minor > 5):
     print("Python version %s.%s not supported version 3.6 or above required - exiting" % (sys.version_info.major,sys.version_info.minor))
     sys.exit(1)
 
-# To be executed in the SchemaTerms/example-code/{example} directory
-import os
-for path in [os.getcwd(),"..","../..","../../.."]: #Adds in current, example-code, and SchemaTerms directory into path
-  sys.path.insert( 1, path ) #Pickup libs from local  directories
-
-from sdotermsource import *
-from sdoterm import *
-from localmarkdown import Markdown
+from SchemaTerms.sdotermsource import *
+from SchemaTerms.sdoterm import *
+from SchemaTerms.localmarkdown import Markdown
 
 Markdown.setWikilinkCssClass("localLink")
 Markdown.setWikilinkPrePath("/")
 
 
-triplesfile = "../data/schemaorg-all-http.nt"
+DATADIR = os.path.join(os.path.dirname(__file__), "../data")
+triplesfile = os.path.join(DATADIR, "schemaorg-all-http.nt")
 SdoTermSource.VOCABURI = "https://schema.org/" #Force to https as loaded https file
 SdoTermSource.loadSourceGraph(triplesfile)
 print ("loaded %s triples" % len(SdoTermSource.sourceGraph()))
@@ -40,8 +41,8 @@ for t in terms:
     buf = sdotermToProtobuf(term)
     msg = protobufToMsg(buf)
     txt = protobufToText(buf)
-    mfilename = "out-protomsgs/" + t +".msg"
-    tfilename = "out-protomsgs/" + t +".txt"
+    mfilename = os.path.join(os.path.dirname(__file__), "out-protomsgs", t + ".msg")
+    tfilename = os.path.join(os.path.dirname(__file__), "out-protomsgs", t + ".txt")
     f = open(mfilename,"wb")
     f.write(msg)
     f.close()

--- a/software/SchemaTerms/example-code/protobufs/schematermsprotobuf.py
+++ b/software/SchemaTerms/example-code/protobufs/schematermsprotobuf.py
@@ -2,16 +2,17 @@
 # -*- coding: utf-8 -*-
 
 
+import os
 import sys
+if os.getcwd() not in sys.path:
+    sys.path.insert(1, os.getcwd())
+import software
+
 if not (sys.version_info.major == 3 and sys.version_info.minor > 5):
     print("Python version %s.%s not supported version 3.6 or above required - exiting" % (sys.version_info.major,sys.version_info.minor))
     sys.exit(1)
 
-# To be executed in the SchemaTerms/example-code/{example} directory
-import os
-for path in [os.getcwd(),"..","../..","../../.."]: #Adds in current, example-code, and SchemaTerms directory into path
-  sys.path.insert( 1, path ) #Pickup libs from local  directories
-from sdoterm import SdoTerm
+from SchemaTerms.sdoterm import SdoTerm
 import schematerms_pb2
 
 sdotypemap = {

--- a/software/SchemaTerms/example-code/simpleTermList/simpleExpandedTermList.py
+++ b/software/SchemaTerms/example-code/simpleTermList/simpleExpandedTermList.py
@@ -1,30 +1,34 @@
 #!/usr/bin/env python3
 # -*- coding: utf-8 -*-
 
-
+import os
 import sys
+
+import rdflib
+
+if os.getcwd() not in sys.path:
+    sys.path.insert(1, os.getcwd())
+import software
+
+from SchemaTerms.localmarkdown import Markdown
+from SchemaTerms.sdoterm import *
+from SchemaTerms.sdotermsource import *
+
+
 if not (sys.version_info.major == 3 and sys.version_info.minor > 5):
     print("Python version %s.%s not supported version 3.6 or above required - exiting" % (sys.version_info.major, sys.version_info.minor))
     sys.exit(1)
 
-# To be executed in the SchemaTerms/example-code/{example} directory
-import os
-for path in [os.getcwd(), "..", "../..", "../../.."]:  # Adds in current, example-code, and SchemaTerms directory into path
-    sys.path.insert(1, path)  # Pickup libs from local  directories
 
-import rdflib
-
-from sdotermsource import *
-from sdoterm import *
-from localmarkdown import Markdown
 
 Markdown.setWikilinkCssClass("localLink")
 Markdown.setWikilinkPrePath("/")
 
-if VOCABURI.startswith("https://"):
-    triplesfile = "../data/schemaorg-all-https.nt"
+DATADIR = os.path.join(os.path.dirname(__file__), "../data")
+if SdoTermSource.vocabUri().startswith("https://"):
+    triplesfile = os.path.join(DATADIR, "schemaorg-all-https.nt")
 else:
-    triplesfile = "../data/schemaorg-all-http.nt"
+    triplesfile = os.path.join(DATADIR, "schemaorg-all-http.nt")
 
 
 termgraph = rdflib.Graph()
@@ -59,32 +63,32 @@ def showTerm(term, ind=""):
     print("%ssupersededBy: %s" % (ind, term.supersededBy))
     print("%ssupersedes: %s" % (ind, term.supersedes))
 
-    if term.termType == SdoTerm.TYPE or term.termType == SdoTerm.ENUMERATION or term.termType == SdoTerm.DATATYPE:
-        if term.expanded:
+    if term.termType == SdoTermType.TYPE or term.termType == SdoTermType.ENUMERATION or term.termType == SdoTermType.DATATYPE:
+        if term.expanded():
             print("%sProperties count %s" % (ind, len(term.properties)))
-            for p in term.properties:
+            for p in term.properties.terms:
                 showTerm(p, ind=ind + "   ")
             print("%sExpected Type for count %s" % (ind, len(term.expectedTypeFor)))
-            for t in term.expectedTypeFor:
+            for t in term.expectedTypeFor.terms:
                 showTerm(t, ind=ind + "   ")
         else:
             print("%sProperties: %s" % (ind, term.properties))
             print("%sExpected Type for: %s" % (ind, term.expectedTypeFor))
 
-    if term.termType == SdoTerm.PROPERTY:
+    if term.termType == SdoTermType.PROPERTY:
         print("%sDomain includes: %s" % (ind, term.domainIncludes))
         print("%sRange includes: %s" % (ind, term.rangeIncludes))
 
-    if term.termType == SdoTerm.ENUMERATION:
+    if term.termType == SdoTermType.ENUMERATION:
         print("%sEnumeration Members: %s" % (ind, term.enumerationMembers))
 
 
-    if term.termType == SdoTerm.ENUMERATIONVALUE:
+    if term.termType == SdoTermType.ENUMERATIONVALUE:
         print("%sParent Enumeration: %s" % (ind, term.enumerationParent))
 
-    if term.expanded:
+    if term.expanded():
         print("%stermStack count: %s " % (ind, len(term.termStack)))
-        for t in term.termStack:
+        for t in term.termStack.terms:
             showTerm(t, ind=ind + "...")
     else:
         print("%stermStack: %s " % (ind, term.termStack))

--- a/software/SchemaTerms/example-code/simpleTermList/simpleTermList.py
+++ b/software/SchemaTerms/example-code/simpleTermList/simpleTermList.py
@@ -1,30 +1,34 @@
 #!/usr/bin/env python3
 # -*- coding: utf-8 -*-
 
-
+import os
 import sys
+
+import rdflib
+
+if os.getcwd() not in sys.path:
+    sys.path.insert(1, os.getcwd())
+import software
+
+from SchemaTerms.localmarkdown import Markdown
+from SchemaTerms.sdoterm import *
+from SchemaTerms.sdotermsource import *
+
+
 if not (sys.version_info.major == 3 and sys.version_info.minor > 5):
     print("Python version %s.%s not supported version 3.6 or above required - exiting" % (sys.version_info.major, sys.version_info.minor))
     sys.exit(1)
 
-# To be executed in the SchemaTerms/example-code/{example} directory
-import os
-for path in [os.getcwd(), "..", "../..", "../../.."]:  # Adds in current, example-code, and SchemaTerms directory into path
-    sys.path.insert(1, path)  # Pickup libs from local  directories
 
-import rdflib
-
-from sdotermsource import *
-from sdoterm import *
-from localmarkdown import Markdown
 
 Markdown.setWikilinkCssClass("localLink")
 Markdown.setWikilinkPrePath("/")
 
-if VOCABURI.startswith("https://"):
-    triplesfile = "../data/schemaorg-all-https.nt"
+DATADIR = os.path.join(os.path.dirname(__file__), "../data")
+if SdoTermSource.vocabUri().startswith("https://"):
+    triplesfile = os.path.join(DATADIR, "schemaorg-all-https.nt")
 else:
-    triplesfile = "../data/schemaorg-all-http.nt"
+    triplesfile = os.path.join(DATADIR, "schemaorg-all-http.nt")
 
 
 termgraph = rdflib.Graph()
@@ -63,20 +67,20 @@ for termname in ["acceptedAnswer", "Book"]:
     for stackElement in term.termStack:
         print("Element: %s" % stackElement)
 
-    if term.termType == SdoTerm.TYPE or term.termType == SdoTerm.ENUMERATION:
+    if term.termType == SdoTermType.TYPE or term.termType == SdoTermType.ENUMERATION:
         print("Properties: %s" % term.properties)
         print("All Properties: %s" % term.allproperties)
         print("Expected Type for: %s" % term.expectedTypeFor)
 
-    if term.termType == SdoTerm.PROPERTY:
+    if term.termType == SdoTermType.PROPERTY:
         print("Domain includes: %s" % term.domainIncludes)
         print("Range includes: %s" % term.rangeIncludes)
     else:
-        if term.termType == SdoTerm.ENUMERATION:
+        if term.termType == SdoTermType.ENUMERATION:
             print("Enumeration Members: %s" % term.enumerationMembers)
 
 
-        if term.termType == SdoTerm.ENUMERATIONVALUE:
+        if term.termType == SdoTermType.ENUMERATIONVALUE:
             print("Parent Enumeration: %s" % term.enumerationParent)
 
         for p in term.properties:

--- a/software/SchemaTerms/localmarkdown.py
+++ b/software/SchemaTerms/localmarkdown.py
@@ -1,11 +1,19 @@
 #!/usr/bin/env python3
 # -*- coding: UTF-8 -*-
 
+from __future__ import annotations
+
 import logging
-import markdown2
+import os
 import re
+import sys
 import threading
-from typing import Optional, Iterable
+from typing import Iterable, Optional
+
+import markdown2
+
+import software
+
 
 WIKILINKPATTERN: str = r"\[\[([\w0-9_ -]+)\]\]"
 

--- a/software/SchemaTerms/sdocollaborators.py
+++ b/software/SchemaTerms/sdocollaborators.py
@@ -1,29 +1,28 @@
 #!/usr/bin/env python3
 # -*- coding: utf-8 -*-
 
+from __future__ import annotations
+
 # Import standard python libraries
 
 import collections
 import glob
 import logging
 import os
-import traceback
 import re
 import sys
+import traceback
 import typing
-from typing import Any, Dict, List, Optional, Tuple, Union, Iterable, Sequence
-
-
-# Import schema.org libraries
-if not os.getcwd() in sys.path:
-    sys.path.insert(1, os.getcwd())
+from typing import Any, Dict, Iterable, List, Optional, Sequence, Tuple, Union
 
 import software
-import software.util.paths as paths
-import software.util.schemaglobals as schemaglobals
-import software.SchemaTerms.sdoterm as sdoterm
-import software.SchemaTerms.sdotermsource as sdotermsource
-import software.SchemaTerms.localmarkdown as localmarkdown
+
+import SchemaTerms.localmarkdown as localmarkdown
+import SchemaTerms.sdoterm as sdoterm
+import SchemaTerms.sdotermsource as sdotermsource
+import util.paths as paths
+import util.schemaglobals as schemaglobals
+
 
 log: logging.Logger = logging.getLogger(__name__)
 

--- a/software/SchemaTerms/sdoterm.py
+++ b/software/SchemaTerms/sdoterm.py
@@ -1,11 +1,19 @@
 #!/usr/bin/env python3
 # -*- coding: utf-8 -*-
 
+from __future__ import annotations
+
 # Import standard python libraries
+
+from abc import ABC, abstractmethod
 import enum
 import logging
-from abc import ABC, abstractmethod
-from typing import Any, Dict, List, Optional, Tuple, Type, Union, Iterable, Set, Sequence, FrozenSet
+import os
+import sys
+from typing import Any, Dict, FrozenSet, Iterable, List, Optional, Sequence, Set, Tuple, Type, Union
+
+import software
+
 
 log: logging.Logger = logging.getLogger(__name__)
 

--- a/software/SchemaTerms/sdotermsource.py
+++ b/software/SchemaTerms/sdotermsource.py
@@ -1,29 +1,31 @@
 #!/usr/bin/env python3
 # -*- coding: utf-8 -*-
 
+from __future__ import annotations
+
 import collections
 import copy
 import glob
 import json
 import logging
-import rdflib
+import os
+from pathlib import Path
 import re
 import sys
 import threading
-from pathlib import Path
-from typing import Any, Dict, List, Optional, Tuple, Union, Iterable, Sequence, Set, Type, cast
+from typing import Any, Dict, Iterable, List, Optional, Sequence, Set, Tuple, Type, Union, cast
 
-if Path.cwd() not in [Path(p).resolve() for p in sys.path]:
-    sys.path.insert(1, str(Path.cwd()))
+import rdflib
 
 import software
-import software.SchemaTerms.sdoterm as sdoterm
-import software.SchemaTerms.sdocollaborators as sdocollaborators
-import software.SchemaTerms.localmarkdown as localmarkdown
-import software.util.paths as paths
 
-import software.util.pretty_logger as pretty_logger
-from software.util.sort_dict import sort_dict
+import SchemaTerms.localmarkdown as localmarkdown
+import SchemaTerms.sdocollaborators as sdocollaborators
+import SchemaTerms.sdoterm as sdoterm
+import util.paths as paths
+import util.pretty_logger as pretty_logger
+from util.sort_dict import sort_dict
+
 
 log: logging.Logger = logging.getLogger(__name__)
 

--- a/software/__init__.py
+++ b/software/__init__.py
@@ -1,9 +1,9 @@
 #!/usr/bin/env python3
 # -*- coding: utf-8 -*-
 
-
 import os
 import sys
+
 
 LIB_PATHS = ()
 DATA_PATHS = ("docs", "software/gcloud", "data")
@@ -16,6 +16,10 @@ def Setup():
     global _INITIALIZED
     if _INITIALIZED:
         return
+
+    software_dir = os.path.dirname(os.path.abspath(__file__))
+    if software_dir not in sys.path:
+        sys.path.insert(1, software_dir)
 
     if sys.version_info < REQUIRED_VERSION:
         sys.stderr.write(

--- a/software/gcloud/DEPLOYMENT_README.txt
+++ b/software/gcloud/DEPLOYMENT_README.txt
@@ -16,4 +16,4 @@ run the appropriate deploy script:
 
 † Relevant access permissions will be required to deploy to these sites.
 
-‡ To be confident that all changes are deployed, run the 'software/util/buildsite.py -a' command before deploying
+‡ To be confident that all changes are deployed, run the 'software/scripts/buildsite.py -a' command before deploying

--- a/software/scripts/bmdc2sdo/mcf2turtle.py
+++ b/software/scripts/bmdc2sdo/mcf2turtle.py
@@ -1,10 +1,15 @@
 #!/usr/bin/env python3
 
+from collections import OrderedDict
+import logging
 import os
 import sys
-import logging
 from typing import Dict, Optional, Union
-from collections import OrderedDict
+
+if os.getcwd() not in sys.path:
+    sys.path.insert(1, os.getcwd())
+import software
+
 
 DEBUG = False
 

--- a/software/scripts/bmdc2sdo/syntaxdebug.py
+++ b/software/scripts/bmdc2sdo/syntaxdebug.py
@@ -1,11 +1,15 @@
 #!/usr/bin/env python3
 
+from collections import OrderedDict
+import logging
 import os
 import sys
-import logging
-
 from typing import Dict, Optional, Union
-from collections import OrderedDict
+
+if os.getcwd() not in sys.path:
+    sys.path.insert(1, os.getcwd())
+import software
+
 
 # Ensure data/ repo is nearby (for a basic MCF parser), for example:
 # sys.path.insert(1, '/home/danbri/working/datcom/data/')

--- a/software/scripts/brokenlinkcheck.py
+++ b/software/scripts/brokenlinkcheck.py
@@ -10,12 +10,16 @@
 """Basic command line tool to find broken links in a web-site."""
 
 import argparse
+import os
+import sys
+from urllib.parse import urldefrag, urljoin, urlparse
+
 import bs4
 import requests
-import sys
 
-
-from urllib.parse import urlparse, urldefrag, urljoin
+if os.getcwd() not in sys.path:
+    sys.path.insert(1, os.getcwd())
+import software
 
 
 class BadLink:

--- a/software/scripts/buildfiles.py
+++ b/software/scripts/buildfiles.py
@@ -5,31 +5,34 @@ import csv
 import io
 import json
 import logging
-import sys
+import os
 from pathlib import Path
-from typing import Any, Dict, List, Optional, Tuple, Union, Set, Callable, Iterable, Sequence
+import sys
+from typing import Any, Callable, Dict, Iterable, List, Optional, Sequence, Set, Tuple, Union
 
 import rdflib
-import rdflib.namespace
 from rdflib.compare import to_canonical_graph
+import rdflib.namespace
 
-if Path.cwd() not in [Path(p).resolve() for p in sys.path]:
-    sys.path.insert(1, str(Path.cwd()))
-
+if os.getcwd() not in sys.path:
+    sys.path.insert(1, os.getcwd())
 import software
-import software.scripts.shex_shacl_shapes_exporter as shex_shacl_shapes_exporter
-import software.util.fileutils as fileutils
-import software.util.pretty_logger as pretty_logger
-import software.util.schemaglobals as schemaglobals
-import software.util.schemaversion as schemaversion
-import software.util.sdojsonldcontext as sdojsonldcontext
-import software.util.textutils as textutils
 
-import software.SchemaTerms.sdotermsource as sdotermsource
-import software.SchemaTerms.sdoterm as sdoterm
-import software.SchemaTerms.localmarkdown as localmarkdown
-import software.SchemaExamples.schemaexamples as schemaexamples
-from software.util.sort_dict import sort_dict, sort_xml
+import SchemaExamples.schemaexamples as schemaexamples
+import SchemaTerms.localmarkdown as localmarkdown
+import SchemaTerms.sdoterm as sdoterm
+import SchemaTerms.sdotermsource as sdotermsource
+import scripts.shex_shacl_shapes_exporter as shex_shacl_shapes_exporter
+import util.fileutils as fileutils
+import util.paths as paths
+import util.pretty_logger as pretty_logger
+import util.schemaglobals as schemaglobals
+import util.schemaversion as schemaversion
+import util.sdojsonldcontext as sdojsonldcontext
+from util.sdoowl import OwlBuild
+from util.sort_dict import sort_dict, sort_xml
+import util.textutils as textutils
+
 
 VOCABURI: str = sdotermsource.SdoTermSource.vocabUri()
 log: logging.Logger = logging.getLogger(__name__)
@@ -59,8 +62,6 @@ def buildTurtleEquivs() -> str:
 
     return str(outGraph.serialize(format="turtle", auto_compact=True, sort_keys=True))
 
-
-import software.util.paths as paths
 
 def jsonldcontext(page: str) -> str:
     return str(sdojsonldcontext.getContext())
@@ -112,7 +113,6 @@ def httpequivs(page: str) -> str:
 
 
 def owl(page: str) -> str:
-    from software.util.sdoowl import OwlBuild
     return str(OwlBuild().getContent())
 
 
@@ -437,9 +437,9 @@ FILELIST: Dict[str, Tuple[Callable[[str], Any], List[Tuple[Any, ...]]]] = {
 
 
 def buildFiles(files: Iterable[str]) -> None:
-    software.SchemaTerms.localmarkdown.MarkdownTool.setWikilinkCssClass("localLink")
-    software.SchemaTerms.localmarkdown.MarkdownTool.setWikilinkPrePath("https://schema.org/")
-    software.SchemaTerms.localmarkdown.MarkdownTool.setWikilinkPostPath("")
+    localmarkdown.MarkdownTool.setWikilinkCssClass("localLink")
+    localmarkdown.MarkdownTool.setWikilinkPrePath("https://schema.org/")
+    localmarkdown.MarkdownTool.setWikilinkPostPath("")
 
     targets: List[str] = sorted(FILELIST.keys()) if any(fileutils.isAll(f) for f in files) else list(files)
 

--- a/software/scripts/buildsite.py
+++ b/software/scripts/buildsite.py
@@ -7,33 +7,34 @@ import argparse
 import contextlib
 import datetime
 import glob
+import logging
 import os
+from pathlib import Path
 import shutil
 import subprocess
 import sys
-import logging
-from pathlib import Path
-from typing import Any, Dict, List, Optional, Tuple, Union, Iterable, Sequence, Generator, Type
+from typing import Any, Dict, Generator, Iterable, List, Optional, Sequence, Tuple, Type, Union
 
 if os.getcwd() not in sys.path:
     sys.path.insert(1, os.getcwd())
-
 import software
-import software.util.buildfiles as buildfiles
-import software.util.paths as paths
-import software.util.buildocspages as buildocspages
-import software.util.buildtermpages as buildtermpages
-import software.util.copystaticdocsplusinsert as copystaticdocsplusinsert
-import software.util.fileutils as fileutils
-import software.util.runtests as runtests_lib
-import software.util.schemaglobals as schemaglobals
-import software.util.schemaversion as schemaversion
-import software.util.pretty_logger as pretty_logger
-import software.SchemaExamples.schemaexamples as schemaexamples
-import software.SchemaExamples.utils.assign_example_ids
-import software.SchemaTerms.localmarkdown
-import software.SchemaTerms.sdocollaborators as sdocollaborators
-import software.SchemaTerms.sdotermsource as sdotermsource
+
+import SchemaExamples.schemaexamples as schemaexamples
+import SchemaExamples.utils.assign_example_ids
+import SchemaTerms.localmarkdown
+import SchemaTerms.sdocollaborators as sdocollaborators
+import SchemaTerms.sdotermsource as sdotermsource
+import scripts.buildfiles as buildfiles
+import scripts.runtests as runtests_lib
+import util.buildocspages as buildocspages
+import util.buildtermpages as buildtermpages
+import util.copystaticdocsplusinsert as copystaticdocsplusinsert
+import util.fileutils as fileutils
+import util.paths as paths
+import util.pretty_logger as pretty_logger
+import util.schemaglobals as schemaglobals
+import util.schemaversion as schemaversion
+
 
 log: logging.Logger = logging.getLogger(__name__)
 logging.basicConfig(level=logging.INFO)
@@ -153,9 +154,9 @@ def initialize() -> argparse.Namespace:
         schemaglobals.PAGES = ["ALL"]
         schemaglobals.FILES = ["ALL"]
 
-    software.SchemaTerms.localmarkdown.Markdown.setWikilinkCssClass("localLink")
-    software.SchemaTerms.localmarkdown.Markdown.setWikilinkPrePath("/")
-    software.SchemaTerms.localmarkdown.Markdown.setWikilinkPostPath("")
+    SchemaTerms.localmarkdown.Markdown.setWikilinkCssClass("localLink")
+    SchemaTerms.localmarkdown.Markdown.setWikilinkPrePath("/")
+    SchemaTerms.localmarkdown.Markdown.setWikilinkPostPath("")
 
     pretty_logger.MakeRootLogPretty()
 
@@ -308,7 +309,7 @@ if __name__ == "__main__":
         with pretty_logger.BlockLog(
             message="Checking Examples for assigned identifiers", logger=log
         ):
-            software.SchemaExamples.utils.assign_example_ids.AssignExampleIds()
+            SchemaExamples.utils.assign_example_ids.AssignExampleIds()
     initdir(output_dir_str=schemaglobals.OUTPUTDIR, handler_path=schemaglobals.HANDLER_FILE)
     runtests()
     processTerms(terms=schemaglobals.TERMS)

--- a/software/scripts/buildtermlist.py
+++ b/software/scripts/buildtermlist.py
@@ -8,16 +8,20 @@ import logging
 import os
 import sys
 import typing
-from typing import Any, Dict, List, Optional, Tuple, Union, Iterable, Sequence, Set, Callable, Generator
+from typing import Any, Callable, Dict, Generator, Iterable, List, Optional, Sequence, Set, Tuple, Union
 
-# Import schema.org libraries
 if os.getcwd() not in sys.path:
     sys.path.insert(1, os.getcwd())
+import software
+
+import SchemaTerms.sdoterm as sdoterm
+import SchemaTerms.sdotermsource as sdotermsource
+import util.pretty_logger as pretty_logger
 
 
-import software.SchemaTerms.sdotermsource as sdotermsource
-import software.SchemaTerms.sdoterm as sdoterm
-import software.util.pretty_logger as pretty_logger
+# Import schema.org libraries
+
+
 
 
 log: logging.Logger = logging.getLogger(__name__)

--- a/software/scripts/compare_health.py
+++ b/software/scripts/compare_health.py
@@ -1,8 +1,16 @@
 #!/usr/bin/env python
 # -*- coding: utf-8 -*-
 
+import os
+import sys
+
 from rdflib import Graph, URIRef
 from rdflib import RDF, RDFS
+
+if os.getcwd() not in sys.path:
+    sys.path.insert(1, os.getcwd())
+import software
+
 
 # On-off utility to help QA the migration of terms from core (v2.2)
 # into health-lifesci hosted extension (v2.3 anticipated). Specifically,

--- a/software/scripts/compareterms.py
+++ b/software/scripts/compareterms.py
@@ -1,52 +1,35 @@
 #!/usr/bin/env python
+
+import argparse
+import codecs
+import io
+import logging
 import os
+import sys
 from os import getenv
 from os.path import expanduser
-import logging  # https://docs.python.org/2/library/logging.html#logging-levels
-import argparse
-import StringIO
-import sys
-
-sys.path.append(os.getcwd())
-sys.path.insert(1, "lib")  # Pickup libs, rdflib etc., from shipped lib directory
-# Ensure that the google.appengine.* packages are available
-# in tests as well as all bundled third-party packages.
-
-sdk_path = getenv(
-    "APP_ENGINE", expanduser("~") + "/google-cloud-sdk/platform/google_appengine/"
-)
-sys.path.insert(0, sdk_path)  # add AppEngine SDK to path
 
 import dev_appserver
-
-dev_appserver.fix_sys_path()
-
-from testharness import *
-
-# Setup testharness state BEFORE importing sdo libraries
-setInTestHarness(True)
-
-from api import *
 import rdflib
-from rdflib import Graph
-from rdflib import RDF, RDFS
+import sdoapp
+from rdflib import Graph, RDF, RDFS
 from rdflib.term import URIRef
 
-from api import (
-    read_schemas,
-    read_extensions,
-    getMasterStore,
-)
-from apirdflib import getNss
-
+if os.getcwd() not in sys.path:
+    sys.path.insert(1, os.getcwd())
+import software
 
 # Ensure that the google.appengine.* packages are available
 # in tests as well as all bundled third-party packages.
-import dev_appserver
-
 dev_appserver.fix_sys_path()
 
-import sdoapp
+from api import *
+from api import (
+    getMasterStore,
+    read_extensions,
+    read_schemas,
+)
+from apirdflib import getNss
 
 logging.basicConfig(level=logging.INFO)
 log = logging.getLogger(__name__)
@@ -187,9 +170,6 @@ def compareCommonTerms(terms, buff):
 currentGraph = None
 previousGraph = None
 
-import codecs
-import sys
-
 UTF8Writer = codecs.getwriter("utf8")
 sys.stdout = UTF8Writer(sys.stdout)
 
@@ -225,7 +205,7 @@ if __name__ == "__main__":
         for i in sorted(new):
             print("   New term %s" % i)
 
-    buff = StringIO.StringIO()
+    buff = io.StringIO()
     print("Changed terms %s" % compareCommonTerms(common, buff))
     if showNames:
         print(buff.getvalue())

--- a/software/scripts/devserv.py
+++ b/software/scripts/devserv.py
@@ -2,18 +2,20 @@
 # -*- coding: utf-8 -*-
 
 import argparse
-import sys
+import os
 from pathlib import Path
-from typing import Any, Dict, Optional, List
+import sys
+from typing import Any, Dict, List, Optional
 
 from colorama import Fore, Style
-from flask import Flask, after_this_request, Response
+from flask import Flask, Response, after_this_request
 
-for path in [Path.cwd(), Path("software/util")]:
-    if str(path) not in sys.path:
-        sys.path.insert(1, str(path))
+if os.getcwd() not in sys.path:
+    sys.path.insert(1, os.getcwd())
+import software
 
-from software.util.schemaversion import getVersion
+from util.schemaversion import getVersion
+
 
 parser: argparse.ArgumentParser = argparse.ArgumentParser()
 parser.add_argument("--host", default="localhost", help="Host (default: localhost)")

--- a/software/scripts/examples4term.py
+++ b/software/scripts/examples4term.py
@@ -2,28 +2,17 @@
 # -*- coding: utf-8 -*-
 
 import argparse
+import csv
 import io
 import os
 import sys
 
-if not (sys.version_info.major == 3 and sys.version_info.minor > 5):
-    print(
-        "Python version %s.%s not supported version 3.6 or above required - exiting"
-        % (sys.version_info.major, sys.version_info.minor)
-    )
-    sys.exit(1)
+if os.getcwd() not in sys.path:
+    sys.path.insert(1, os.getcwd())
+import software
 
-
-for path in [
-    os.getcwd(),
-    "software/Util",
-    "software/SchemaTerms",
-    "software/SchemaExamples",
-]:
-    sys.path.insert(1, path)  # Pickup libs from local  directories
-
-from sdotermsource import SdoTermSource
-from schemaexamples import SchemaExamples
+from SchemaExamples.schemaexamples import SchemaExamples
+from SchemaTerms.sdotermsource import SdoTermSource
 
 
 if not SdoTermSource.SOURCEGRAPH:
@@ -89,8 +78,6 @@ def buildoutput(workingex, fname):
 
 
 def buildcsvoutput(workingex, fname):
-    import csv
-
     if not fname.endswith(".csv"):
         fname = fname + ".csv"
 

--- a/software/scripts/inputconvert.py
+++ b/software/scripts/inputconvert.py
@@ -2,21 +2,19 @@
 
 import argparse
 import os
-import rdflib
-import sys
-
 from os import getenv
 from os.path import expanduser
+import sys
+
+import rdflib
 from rdflib.parser import Parser
 from rdflib.term import URIRef
 
-sys.path.append(os.getcwd())
-sys.path.insert(1, "lib")  # Pickup libs, rdflib etc., from shipped lib directory
-sys.path.insert(1, "sdopythonapp")  # Pickup sdopythonapp functionality
-sys.path.insert(
-    1, "sdopythonapp/lib"
-)  # Pickup sdopythonapp libs, rdflib etc., from shipped lib directory
-sys.path.insert(1, "sdopythonapp/site")  # Pickup sdopythonapp from shipped site
+if os.getcwd() not in sys.path:
+    sys.path.insert(1, os.getcwd())
+import software
+
+
 # Ensure that the google.appengine.* packages are available
 # in tests as well as all bundled third-party packages.
 

--- a/software/scripts/reorg.py
+++ b/software/scripts/reorg.py
@@ -10,16 +10,21 @@ import argparse
 import itertools
 import logging
 import os
-import rdflib
 import sys
 import typing
-from typing import Any, Dict, List, Optional, Tuple, Union, Iterable, Sequence, Set, Callable
+from typing import Any, Callable, Dict, Iterable, List, Optional, Sequence, Set, Tuple, Union
+
+import rdflib
+
+if os.getcwd() not in sys.path:
+    sys.path.insert(1, os.getcwd())
+import software
+
+import util.schema_graph as graph
+
 
 # Import schema.org libraries
-if not os.getcwd() in sys.path:
-    sys.path.insert(1, os.getcwd())
 
-import software.util.schema_graph as graph
 
 
 def Lint(args: argparse.Namespace) -> None:

--- a/software/scripts/runtests.py
+++ b/software/scripts/runtests.py
@@ -52,12 +52,17 @@
 #    limitations under the License.
 
 import argparse
-import sys
-import colorama
 import os
-import unittest
+import sys
 import typing
-from typing import Any, Dict, List, Optional, Tuple, Union, Iterable, Sequence, Set, Callable, Type, IO
+from typing import Any, Callable, Dict, IO, Iterable, List, Optional, Sequence, Set, Tuple, Type, Union
+import unittest
+
+import colorama
+
+if os.getcwd() not in sys.path:
+    sys.path.insert(1, os.getcwd())
+import software
 
 
 SITEDIR: str = "software/site"

--- a/software/scripts/scansite.py
+++ b/software/scripts/scansite.py
@@ -1,8 +1,17 @@
 #!/usr/bin/python
 # -*- coding: utf-8 -*-
+
 import json
+import os
 from pprint import pprint
+import sys
+
 import urllib2
+
+if os.getcwd() not in sys.path:
+    sys.path.insert(1, os.getcwd())
+import software
+
 
 # Work in progress attempt to fetch all term URLs
 # from our data dumps (and sanity check them), then

--- a/software/scripts/shex_shacl_shapes_exporter.py
+++ b/software/scripts/shex_shacl_shapes_exporter.py
@@ -7,19 +7,23 @@ import argparse
 import json
 import logging
 import os
-import sys
 from pathlib import Path
-from typing import Any, Dict, List, Optional, Tuple, Union, Set, Generator
+import sys
+from typing import Any, Dict, Generator, List, Optional, Set, Tuple, Union
+
+from rdflib import BNode, Graph, Namespace, RDF, RDFS, URIRef
+from rdflib.collection import Collection
+from rdflib.compare import to_canonical_graph
+from rdflib.term import Node
 
 if os.getcwd() not in sys.path:
     sys.path.insert(1, os.getcwd())
+import software
 
-from rdflib import RDF, RDFS, BNode, Graph, Namespace, URIRef
-from rdflib.compare import to_canonical_graph
-from rdflib.collection import Collection
-from rdflib.term import Node
+import util.paths as paths
+import util.schemaversion as schemaversion
+from util.sort_dict import sort_dict
 
-from software.util.sort_dict import sort_dict
 
 BASE: Namespace = Namespace("http://schema.org/validation#")
 SCHEMA: Namespace = Namespace("http://schema.org/")
@@ -338,8 +342,6 @@ class ShaclParser:
         return str(dest.serialize(format="turtle", sort_keys=True))
 
 
-import software.util.paths as paths
-
 def generate_files(
     term_defs_path: Union[str, Path],
     version: str,
@@ -367,7 +369,6 @@ def generate_files(
 
 
 if __name__ == "__main__":
-    import software.util.schemaversion as schemaversion
     parser: argparse.ArgumentParser = argparse.ArgumentParser(description=__doc__)
     parser.add_argument("-s", "--sourcefile", help="rdf format source file")
     parser.add_argument(

--- a/software/scripts/snapshot_schema.py
+++ b/software/scripts/snapshot_schema.py
@@ -1,20 +1,20 @@
+import logging
 import os
 import shutil
-import logging
 import sys
 import typing
-from typing import Any, Dict, List, Optional, Tuple, Union, Iterable, Sequence, Set, Callable
+from typing import Any, Callable, Dict, Iterable, List, Optional, Sequence, Set, Tuple, Union
 
-# Import schema.org libraries
-if not os.getcwd() in sys.path:
+if os.getcwd() not in sys.path:
     sys.path.insert(1, os.getcwd())
-
 import software
-import software.util.fileutils as fileutils
-import software.util.schemaglobals as schemaglobals
-import software.SchemaTerms.sdotermsource as sdotermsource
-import software.util.buildfiles as buildfiles
-import software.util.pretty_logger as pretty_logger
+
+import SchemaTerms.sdotermsource as sdotermsource
+import scripts.buildfiles as buildfiles
+import util.fileutils as fileutils
+import util.pretty_logger as pretty_logger
+import util.schemaglobals as schemaglobals
+
 
 log: logging.Logger = logging.getLogger(__name__)
 

--- a/software/scripts/validate_examples_shacl.py
+++ b/software/scripts/validate_examples_shacl.py
@@ -9,20 +9,23 @@ This replaces the legacy Ruby validation tests.
 import argparse
 import logging
 import os
-import sys
 from pathlib import Path
-import rdflib
+import sys
+
 import pyshacl
+import rdflib
 
-if str(Path.cwd()) not in sys.path:
-    sys.path.insert(1, str(Path.cwd()))
+if os.getcwd() not in sys.path:
+    sys.path.insert(1, os.getcwd())
+import software
 
-import software.SchemaExamples.schemaexamples as schemaexamples
-import software.util.schemaversion as schemaversion
+import SchemaExamples.schemaexamples as schemaexamples
+import util.paths as paths
+import util.schemaversion as schemaversion
+
 
 log: logging.Logger = logging.getLogger(__name__)
 
-import software.util.paths as paths
 
 def load_examples() -> list:
     """Finds and loads all examples."""

--- a/software/tests/examples_validate.py
+++ b/software/tests/examples_validate.py
@@ -10,16 +10,14 @@ import argparse
 import io
 import logging
 import os
-import rdflib
 import re
 import sys
 
-# Import schema.org libraries
-if not os.getcwd() in sys.path:
-    sys.path.insert(1, os.getcwd())
+import rdflib
 
 import software
-import software.SchemaExamples.schemaexamples as schemaexamples
+
+import SchemaExamples.schemaexamples as schemaexamples
 
 
 log = logging.getLogger(__name__)

--- a/software/tests/test_basics.py
+++ b/software/tests/test_basics.py
@@ -2,22 +2,20 @@
 # -*- coding: utf-8 -*-
 
 # Import standard python libraries
-import sys
-import os
-import json
-import unittest
-import logging
 
-# Import schema.org libraries
-if not os.getcwd() in sys.path:
-    sys.path.insert(1, os.getcwd())
+import json
+import logging
+import os
+import sys
+import unittest
 
 import software
 
-import software.SchemaTerms.sdotermsource as sdotermsource
-import software.SchemaTerms.sdoterm as sdoterm
-import software.SchemaTerms.localmarkdown as localmarkdown
-import software.SchemaExamples.schemaexamples as schemaexamples
+import SchemaExamples.schemaexamples as schemaexamples
+import SchemaTerms.localmarkdown as localmarkdown
+import SchemaTerms.sdoterm as sdoterm
+import SchemaTerms.sdotermsource as sdotermsource
+
 
 VOCABURI = sdotermsource.SdoTermSource.vocabUri()
 TRIPLESFILESGLOB = ["data/*.ttl", "data/ext/*/*.ttl"]

--- a/software/tests/test_buildfiles.py
+++ b/software/tests/test_buildfiles.py
@@ -1,20 +1,18 @@
 #!/usr/bin/env python3
 # -*- coding: utf-8 -*-
 
+import logging
 import os
 import sys
+import tempfile
 import unittest
 import unittest.mock
-import tempfile
-import logging
-
-if not os.getcwd() in sys.path:
-    sys.path.insert(1, os.getcwd())
 
 import software
-import software.util.buildfiles as buildfiles
-import software.util.fileutils as fileutils
-import software.util.schemaglobals as schemaglobals
+
+import scripts.buildfiles as buildfiles
+import util.fileutils as fileutils
+import util.schemaglobals as schemaglobals
 
 
 class TestBuildFiles(unittest.TestCase):
@@ -54,7 +52,7 @@ class TestBuildFiles(unittest.TestCase):
             "https://schema.org/Person, https://schema.org/Thing",
         )
 
-    @unittest.mock.patch("software.util.schemaglobals.getOutputDir")
+    @unittest.mock.patch("util.schemaglobals.getOutputDir")
     def testWriteCsvOut(self, mock_output_dir):
         with tempfile.TemporaryDirectory() as temp_dir:
             mock_output_dir.return_value = temp_dir

--- a/software/tests/test_buildocspages.py
+++ b/software/tests/test_buildocspages.py
@@ -1,22 +1,16 @@
 #!/usr/bin/env python3
 # -*- coding: utf-8 -*-
 
-
 import os
 import sys
 import unittest
 
-
-# Import schema.org libraries
-if not os.getcwd() in sys.path:
-    sys.path.insert(1, os.getcwd())
-
 import software
-import software.SchemaExamples.schemaexamples as schemaexamples
-import software.SchemaTerms.sdoterm as sdoterm
-import software.SchemaTerms.sdotermsource as sdotermsource
 
-import software.util.buildocspages as buildocspages
+import SchemaExamples.schemaexamples as schemaexamples
+import SchemaTerms.sdoterm as sdoterm
+import SchemaTerms.sdotermsource as sdotermsource
+import util.buildocspages as buildocspages
 
 
 class TestBuildDocs(unittest.TestCase):

--- a/software/tests/test_buildtermpages.py
+++ b/software/tests/test_buildtermpages.py
@@ -5,15 +5,12 @@ import os
 import sys
 import unittest
 
-# Import schema.org libraries
-if not os.getcwd() in sys.path:
-    sys.path.insert(1, os.getcwd())
-
 import software
-import software.SchemaExamples.schemaexamples as schemaexamples
-import software.SchemaTerms.sdoterm as sdoterm
-import software.util.buildtermpages as buildtermpages
-import software.util.schemaglobals as schemaglobals
+
+import SchemaExamples.schemaexamples as schemaexamples
+import SchemaTerms.sdoterm as sdoterm
+import util.buildtermpages as buildtermpages
+import util.schemaglobals as schemaglobals
 
 
 class TestTermFileName(unittest.TestCase):

--- a/software/tests/test_fileutils.py
+++ b/software/tests/test_fileutils.py
@@ -1,17 +1,14 @@
 #!/usr/bin/env python3
 # -*- coding: utf-8 -*-
 
-import unittest
 import os
 import sys
 import tempfile
-
-# Import schema.org libraries
-if not os.getcwd() in sys.path:
-    sys.path.insert(1, os.getcwd())
+import unittest
 
 import software
-import software.util.fileutils as fileutils
+
+import util.fileutils as fileutils
 
 
 class FileUtilsTest(unittest.TestCase):

--- a/software/tests/test_generatedfiles.py
+++ b/software/tests/test_generatedfiles.py
@@ -1,8 +1,12 @@
 #!/usr/bin/env python3
 # -*- coding: utf-8 -*-
 
-import unittest
+import os
 import subprocess
+import sys
+import unittest
+
+import software
 
 
 class BasicFileTests(unittest.TestCase):

--- a/software/tests/test_graphs.py
+++ b/software/tests/test_graphs.py
@@ -1,20 +1,20 @@
 #!/usr/bin/env python3
 # -*- coding: utf-8 -*-
+
 import collections
 import glob
 import logging
 import os
-import rdflib
 import sys
 import typing
 import unittest
 
-# Import schema.org libraries
-if not os.getcwd() in sys.path:
-    sys.path.insert(1, os.getcwd())
+import rdflib
 
 import software
-import software.SchemaTerms.sdotermsource as sdotermsource
+
+import SchemaTerms.sdotermsource as sdotermsource
+
 
 TYPECOUNT_UPPERBOUND = 1000
 TYPECOUNT_LOWERBOUND = 500

--- a/software/tests/test_schemaexamples.py
+++ b/software/tests/test_schemaexamples.py
@@ -3,15 +3,14 @@
 
 import os
 import sys
-import unittest
 import tempfile
-
-# Import schema.org libraries
-if not os.getcwd() in sys.path:
-    sys.path.insert(1, os.getcwd())
+import unittest
+from unittest.mock import patch
 
 import software
-import software.SchemaExamples.schemaexamples as schemaexamples
+
+import SchemaExamples.schemaexamples as schemaexamples
+from util.paths import InputLayout
 
 
 THING_EXAMPLE = """TYPES: #eg-0999 Thing
@@ -38,9 +37,7 @@ class TestExampleFileParser(unittest.TestCase):
     def setUp(self):
         self.parser = schemaexamples.ExampleFileParser()
         self.temp_file = tempfile.NamedTemporaryFile()
-        from unittest.mock import patch
-        from software.util.paths import InputLayout
-        patcher = patch('software.SchemaExamples.schemaexamples.paths.DefaultInputLayout')
+        patcher = patch('SchemaExamples.schemaexamples.paths.DefaultInputLayout')
         mock_input_layout = patcher.start()
         mock_input_layout.return_value = InputLayout(os.path.dirname(self.temp_file.name))
         self.addCleanup(patcher.stop)

--- a/software/tests/test_sdocollaborators.py
+++ b/software/tests/test_sdocollaborators.py
@@ -5,12 +5,10 @@ import os
 import sys
 import unittest
 
+import software
 
-# Import schema.org libraries
-if not os.getcwd() in sys.path:
-    sys.path.insert(1, os.getcwd())
+import SchemaTerms.sdocollaborators as sdocollaborators
 
-import software.SchemaTerms.sdocollaborators as sdocollaborators
 
 TEST_DESCRIPTION = """---
 img: http://example.com/logo.png

--- a/software/tests/test_sdojsonldcontext.py
+++ b/software/tests/test_sdojsonldcontext.py
@@ -1,27 +1,24 @@
 #!/usr/bin/env python3
 # -*- coding: utf-8 -*-
 
+import json
+import logging
 import os
 import sys
-import json
 import unittest
 import unittest.mock
-import logging
-
-# Import schema.org libraries
-if not os.getcwd() in sys.path:
-    sys.path.insert(1, os.getcwd())
 
 import software
-import software.SchemaTerms.sdotermsource as sdotermsource
-import software.util.sdojsonldcontext as sdojsonldcontext
-import software.SchemaTerms.sdoterm as sdoterm
+
+import SchemaTerms.sdoterm as sdoterm
+import SchemaTerms.sdotermsource as sdotermsource
+import util.sdojsonldcontext as sdojsonldcontext
 
 
 class SdoJsonLdContextTest(unittest.TestCase):
     """Tests for the sdojsonldcontext library."""
 
-    @unittest.mock.patch("software.SchemaTerms.sdotermsource.SdoTermSource.getAllTerms")
+    @unittest.mock.patch("SchemaTerms.sdotermsource.SdoTermSource.getAllTerms")
     def test_createcontextEmpty(self, mock_getAllTerms):
         """Test that createcontext outputs valid JSON data"""
         mock_getAllTerms.return_value = []
@@ -33,7 +30,7 @@ class SdoJsonLdContextTest(unittest.TestCase):
         self.assertIn("id", context)
         self.assertIn("@vocab", context)
 
-    @unittest.mock.patch("software.SchemaTerms.sdotermsource.SdoTermSource.getAllTerms")
+    @unittest.mock.patch("SchemaTerms.sdotermsource.SdoTermSource.getAllTerms")
     def test_createcontextOneProperty(self, mock_getAllTerms):
         """Test that createcontext outputs valid JSON data"""
         self.maxDiff = None
@@ -55,7 +52,7 @@ class SdoJsonLdContextTest(unittest.TestCase):
             context[mock_id], {"@id": "http://schema.org/thang", "@type": "Date"}
         )
 
-    @unittest.mock.patch("software.SchemaTerms.sdotermsource.SdoTermSource.getAllTerms")
+    @unittest.mock.patch("SchemaTerms.sdotermsource.SdoTermSource.getAllTerms")
     def test_createcontextOneDataType(self, mock_getAllTerms):
         self.maxDiff = None
         mock_id = "1234"
@@ -74,7 +71,7 @@ class SdoJsonLdContextTest(unittest.TestCase):
         self.assertIn("@vocab", context)
         self.assertEqual(context[mock_id], {"@id": "http://schema.org/Fnubl"})
 
-    @unittest.mock.patch("software.SchemaTerms.sdotermsource.SdoTermSource.getAllTerms")
+    @unittest.mock.patch("SchemaTerms.sdotermsource.SdoTermSource.getAllTerms")
     def test_createcontextOneEnumeration(self, mock_getAllTerms):
         self.maxDiff = None
         mock_id = "1234"
@@ -92,7 +89,7 @@ class SdoJsonLdContextTest(unittest.TestCase):
         self.assertIn("@vocab", context)
         self.assertEqual(context[mock_id], {"@id": "http://schema.org/Grabl"})
 
-    @unittest.mock.patch("software.SchemaTerms.sdotermsource.SdoTermSource.getAllTerms")
+    @unittest.mock.patch("SchemaTerms.sdotermsource.SdoTermSource.getAllTerms")
     def test_createcontextOneEnumerationValue(self, mock_getAllTerms):
         self.maxDiff = None
         mock_id = "1234"
@@ -109,7 +106,7 @@ class SdoJsonLdContextTest(unittest.TestCase):
         self.assertIn("@vocab", context)
         self.assertEqual(context[mock_id], {"@id": "http://schema.org/Bobl"})
 
-    @unittest.mock.patch("software.SchemaTerms.sdotermsource.SdoTermSource.getAllTerms")
+    @unittest.mock.patch("SchemaTerms.sdotermsource.SdoTermSource.getAllTerms")
     def test_createcontextOneReference(self, mock_getAllTerms):
         self.maxDiff = None
         mock_id = "1234"
@@ -126,7 +123,7 @@ class SdoJsonLdContextTest(unittest.TestCase):
         self.assertIn("@vocab", context)
         self.assertNotIn(mock_id, context)
 
-    @unittest.mock.patch("software.SchemaTerms.sdotermsource.SdoTermSource.getAllTerms")
+    @unittest.mock.patch("SchemaTerms.sdotermsource.SdoTermSource.getAllTerms")
     def test_createcontextMultiple(self, mock_getAllTerms):
         self.maxDiff = None
         mock_property = sdoterm.SdoProperty(

--- a/software/tests/test_sdoterm.py
+++ b/software/tests/test_sdoterm.py
@@ -2,18 +2,16 @@
 # -*- coding: UTF-8 -*-
 
 # Import standard python libraries
-import sys
-import os
-import unittest
-import logging
 
-# Import schema.org libraries
-if not os.getcwd() in sys.path:
-    sys.path.insert(1, os.getcwd())
+import logging
+import os
+import sys
+import unittest
 
 import software
 
-import software.SchemaTerms.sdoterm as sdoterm
+import SchemaTerms.sdoterm as sdoterm
+
 
 class SdoTermOrIdTest(unittest.TestCase):
 

--- a/software/tests/test_sdotermsource.py
+++ b/software/tests/test_sdotermsource.py
@@ -1,20 +1,17 @@
 #!/usr/bin/env python3
 # -*- coding: UTF-8 -*-
 
-import sys
-import os
-import unittest
 import logging
-import rdflib
+import os
+import sys
+import unittest
 
-# Import schema.org libraries
-if not os.getcwd() in sys.path:
-    sys.path.insert(1, os.getcwd())
+import rdflib
 
 import software
 
-import software.SchemaTerms.sdotermsource as sdotermsource
-import software.SchemaTerms.sdoterm as sdoterm
+import SchemaTerms.sdoterm as sdoterm
+import SchemaTerms.sdotermsource as sdotermsource
 
 
 class TestConversionFunctions(unittest.TestCase):

--- a/software/tests/test_snapshot.py
+++ b/software/tests/test_snapshot.py
@@ -5,18 +5,15 @@ import difflib
 import logging
 import os
 import sys
-import sys
 import tempfile
 import unittest
 
-# Import schema.org libraries
-if not os.getcwd() in sys.path:
-    sys.path.insert(1, os.getcwd())
+import software
 
-import software.util.snapshot_schema as snapshot_schema
+import scripts.snapshot_schema as snapshot_schema
 
 
-FAIL_HELP = "\n [See fix here] Re-generate the snapshot file by running the 'software/util/snapshot_schema.py'-file."
+FAIL_HELP = "\n [See fix here] Re-generate the snapshot file by running the 'software/scripts/snapshot_schema.py'-file."
 
 class SnapshotTest(unittest.TestCase):
     @unittest.skip("skip snapshot tests until branch updates / pr actions are correctly set up")

--- a/software/tests/test_textutils.py
+++ b/software/tests/test_textutils.py
@@ -4,15 +4,12 @@
 import itertools
 import os
 import sys
-import unittest
 import tempfile
-
-# Import schema.org libraries
-if not os.getcwd() in sys.path:
-    sys.path.insert(1, os.getcwd())
+import unittest
 
 import software
-import software.util.textutils as textutils
+
+import util.textutils as textutils
 
 
 class TestStripHtmlTags(unittest.TestCase):

--- a/software/util/buildocspages.py
+++ b/software/util/buildocspages.py
@@ -3,34 +3,34 @@
 
 # Import standard python libraries
 
+from collections import defaultdict
 import json
 import logging
-import sys
+import os
 from pathlib import Path
-from collections import defaultdict
-from typing import Any, Dict, List, Optional, Tuple, Union, Iterable, Set, Callable, Sequence
+import sys
+from typing import Any, Callable, Dict, Iterable, List, Optional, Sequence, Set, Tuple, Union
 
-if Path.cwd() not in [Path(p).resolve() for p in sys.path]:
-    sys.path.insert(1, str(Path.cwd()))
+import software
 
-import software.scripts.buildtermlist as buildtermlist
-import software.util.fileutils as fileutils
-import software.util.jinga_render as jinga_render
-import software.util.pretty_logger as pretty_logger
-import software.util.schemaglobals as schemaglobals
-import software.util.schemaversion as schemaversion
-import software.util.textutils as textutils
-from software.util.sort_dict import sort_dict
+import SchemaTerms.sdocollaborators as sdocollaborators
+import SchemaTerms.sdoterm as sdoterm
+import SchemaTerms.sdotermsource as sdotermsource
+import scripts.buildtermlist as buildtermlist
+import util.fileutils as fileutils
+import util.jinga_render as jinga_render
+import util.paths as paths
+import util.pretty_logger as pretty_logger
+import util.schemaglobals as schemaglobals
+import util.schemaversion as schemaversion
+from util.sort_dict import sort_dict
+import util.textutils as textutils
 
-import software.SchemaTerms.sdotermsource as sdotermsource
-import software.SchemaTerms.sdocollaborators as sdocollaborators
-import software.SchemaTerms.sdoterm as sdoterm
 
 log: logging.Logger = logging.getLogger(__name__)
 
 STRCLASSVAL: Optional[str] = None
 
-import software.util.paths as paths
 
 def docsTemplateRender(template: str, extra_vars: Optional[Dict[str, Any]] = None) -> str:
     tvars: Dict[str, Any] = {"BUILDOPTS": schemaglobals.BUILDOPTS, "docsdir": schemaglobals.DOCSDOCSDIR}

--- a/software/util/buildtermpages.py
+++ b/software/util/buildtermpages.py
@@ -1,34 +1,34 @@
 #!/usr/bin/env python3
 # -*- coding: utf-8 -*-
+
 import collections
 import datetime
 import logging
 import multiprocessing
+import os
+from pathlib import Path
 import re
 import sys
 import time
-from pathlib import Path
-from typing import List, Optional, Tuple, Dict, Any, Iterable, Sequence, Type
+from typing import Any, Dict, Iterable, List, Optional, Sequence, Tuple, Type
 
 import jinja2
 
-if Path.cwd() not in [Path(p).resolve() for p in sys.path]:
-    sys.path.insert(1, str(Path.cwd()))
-
 import software
-import software.util.schemaglobals as schemaglobals
-import software.util.fileutils as fileutils
-import software.util.pretty_logger as pretty_logger
-import software.util.jinga_render as jinga_render
 
-import software.SchemaTerms.sdotermsource as sdotermsource
-import software.SchemaTerms.sdoterm as sdoterm
-import software.SchemaExamples.schemaexamples as schemaexamples
+import SchemaExamples.schemaexamples as schemaexamples
+import SchemaTerms.sdoterm as sdoterm
+import SchemaTerms.sdotermsource as sdotermsource
+import util.fileutils as fileutils
+import util.jinga_render as jinga_render
+import util.paths as paths
+import util.pretty_logger as pretty_logger
+import util.schemaglobals as schemaglobals
+
 
 log: logging.Logger = logging.getLogger(__name__)
 
 
-import software.util.paths as paths
 
 def termFileName(termid: str) -> str:
     """Generate filename for term page."""

--- a/software/util/convertmd2htmldocs.py
+++ b/software/util/convertmd2htmldocs.py
@@ -3,16 +3,13 @@
 
 # Import standard python libraries
 
-import sys
-import os
 import glob
-import markdown2 as markdown
+import os
+import sys
 import typing
-from typing import Any, Dict, List, Optional, Tuple, Union, Iterable, Sequence, Set, Callable
+from typing import Any, Callable, Dict, Iterable, List, Optional, Sequence, Set, Tuple, Union
 
-# Import schema.org libraries
-if not os.getcwd() in sys.path:
-    sys.path.insert(1, os.getcwd())
+import markdown2 as markdown
 
 import software
 

--- a/software/util/copystaticdocsplusinsert.py
+++ b/software/util/copystaticdocsplusinsert.py
@@ -4,22 +4,23 @@
 """Tool that handles includes in static html files."""
 
 import logging
+import os
+from pathlib import Path
 import re
 import sys
-from pathlib import Path
-from typing import Dict, Generator, Tuple, Optional, List, Iterable, Union
+from typing import Dict, Generator, Iterable, List, Optional, Tuple, Union
 
-if Path.cwd() not in [Path(p).resolve() for p in sys.path]:
-    sys.path.insert(1, str(Path.cwd()))
+import software
 
-import software.util.schemaversion as schemaversion
-import software.util.fileutils as fileutils
-import software.util.convertmd2htmldocs as convertmd2htmldocs
+import util.convertmd2htmldocs as convertmd2htmldocs
+import util.fileutils as fileutils
+import util.paths as paths
+import util.schemaversion as schemaversion
+
 
 log: logging.Logger = logging.getLogger(__name__)
 
 
-import software.util.paths as paths
 
 def _getInserts() -> Generator[Tuple[str, str], None, None]:
     template_dir: Path = paths.DefaultInputLayout().domain_dir(paths.Domain.STATIC_DOC_INSERTS)

--- a/software/util/fileutils.py
+++ b/software/util/fileutils.py
@@ -2,9 +2,14 @@
 # -*- coding: utf-8 -*-
 
 import enum
-import shutil
+import os
 from pathlib import Path
-from typing import Dict, Set, Union, Optional, List, Callable, Iterable, Any, FrozenSet
+import shutil
+import sys
+from typing import Any, Callable, Dict, FrozenSet, Iterable, List, Optional, Set, Union
+
+import software
+
 
 EXTENSIONS_FOR_FORMAT: Dict[str, str] = {
     "xml": "xml",

--- a/software/util/jinga_render.py
+++ b/software/util/jinga_render.py
@@ -2,18 +2,18 @@
 # -*- coding: utf-8 -*-
 
 # Import standard python libraries
+
 import logging
+import os
 import sys
-from pathlib import Path
 from typing import Any, Dict, Optional, Union
 
 import jinja2
 
-# Import schema.org libraries
-if Path.cwd() not in [Path(p).resolve() for p in sys.path]:
-    sys.path.insert(1, str(Path.cwd()))
+import software
 
-import software.util.schemaversion as schemaversion
+import util.schemaversion as schemaversion
+
 
 SITENAME = "Schema.org"
 TEMPLATESDIR = "templates"

--- a/software/util/paths.py
+++ b/software/util/paths.py
@@ -1,14 +1,20 @@
 #!/usr/bin/env python3
 # -*- coding: utf-8 -*-
 
+from enum import Enum, unique
 import glob
+import locale
+import os
+from pathlib import Path
 import string
 import sys
-import os
-import locale
-from pathlib import Path
-from typing import List, Optional, Union, Sequence
-from enum import Enum, unique
+from typing import List, Optional, Sequence, Union
+
+import software
+
+import util.schemaglobals as schemaglobals
+import util.schemaversion as schemaversion
+
 
 # Globally enforce UTF-8 as the default encoding for file reads/writes
 def _enforce_global_utf8() -> None:
@@ -19,10 +25,6 @@ def _enforce_global_utf8() -> None:
 _enforce_global_utf8()
 
 # Need to safely import schemaglobals to read OUTPUTDIR
-if Path.cwd() not in [Path(p).resolve() for p in sys.path]:
-    sys.path.insert(1, str(Path.cwd()))
-import software.util.schemaglobals as schemaglobals
-import software.util.schemaversion as schemaversion
 
 
 @unique

--- a/software/util/pretty_logger.py
+++ b/software/util/pretty_logger.py
@@ -1,12 +1,15 @@
 #!/usr/bin/env python3
 # -*- coding: utf-8 -*-
 
-import colorama
 import logging
 import os
 import sys
 import time
-from typing import Any, Dict, Optional, List, Type
+from typing import Any, Dict, List, Optional, Type
+
+import colorama
+
+import software
 
 
 class PrettyLogFormatter(logging.Formatter):

--- a/software/util/schema_graph.py
+++ b/software/util/schema_graph.py
@@ -4,11 +4,16 @@
 """A class that holds the schema graph and presents some operations on it.
 """
 
-import rdflib
+import os
+import sys
 import typing
-from typing import Any, Dict, List, Optional, Tuple, Union, Iterable, Sequence, Set, Callable
+from typing import Any, Callable, Dict, Iterable, List, Optional, Sequence, Set, Tuple, Union
 
-import software.util.schemaglobals as schemaglobals
+import rdflib
+
+import software
+
+import util.schemaglobals as schemaglobals
 
 
 SCHEMAORG: rdflib.Namespace = rdflib.Namespace(schemaglobals.HOMEPAGE)

--- a/software/util/schemaglobals.py
+++ b/software/util/schemaglobals.py
@@ -1,8 +1,13 @@
 #!/usr/bin/env python3
 # -*- coding: utf-8 -*-
 
+import os
 from pathlib import Path
+import sys
 from typing import List
+
+import software
+
 
 SITENAME: str = "Schema.org"
 BUILDOPTS: List[str] = []

--- a/software/util/schemaversion.py
+++ b/software/util/schemaversion.py
@@ -4,16 +4,17 @@
 """Module that handles the schema.org version information."""
 
 import json
+import os
 import sys
-from pathlib import Path
-from typing import Dict, Any, Optional, List, Tuple
+from typing import Any, Dict, List, Optional, Tuple
 
-if Path.cwd() not in [Path(p).resolve() for p in sys.path]:
-    sys.path.insert(1, str(Path.cwd()))
+if os.getcwd() not in sys.path:
+    sys.path.insert(1, os.getcwd())
+import software
 
-from software.util.sort_dict import sort_dict
+import util.paths as paths
+from util.sort_dict import sort_dict
 
-import software.util.paths as paths
 
 VERSION_DATA: Optional[Dict[str, Any]] = None
 

--- a/software/util/sdojsonldcontext.py
+++ b/software/util/sdojsonldcontext.py
@@ -6,17 +6,15 @@ import logging
 import os
 import sys
 import typing
-from typing import Any, Dict, Optional, Set, List
-
-# Import schema.org libraries
-if not os.getcwd() in sys.path:
-    sys.path.insert(1, os.getcwd())
+from typing import Any, Dict, List, Optional, Set
 
 import software
-import software.SchemaTerms.sdotermsource as sdotermsource
-import software.SchemaTerms.sdoterm as sdoterm
-import software.util.pretty_logger as pretty_logger
-from software.util.sort_dict import sort_dict
+
+import SchemaTerms.sdoterm as sdoterm
+import SchemaTerms.sdotermsource as sdotermsource
+import util.pretty_logger as pretty_logger
+from util.sort_dict import sort_dict
+
 
 log: logging.Logger = logging.getLogger(__name__)
 

--- a/software/util/sdoowl.py
+++ b/software/util/sdoowl.py
@@ -1,7 +1,30 @@
 #!/usr/bin/env python3
 # -*- coding: utf-8 -*-
-import sys
+
+import glob
 import os
+import re
+import sys
+from typing import Any, Dict, FrozenSet, List, Optional, Set, Tuple, Union
+from xml.dom import minidom
+from xml.etree import ElementTree
+
+import rdflib
+from rdflib import Graph
+from rdflib.compare import graph_diff
+from rdflib.namespace import RDF, RDFS
+from rdflib.parser import Parser
+from rdflib.plugins.sparql import prepareQuery
+from rdflib.serializer import Serializer
+from rdflib.term import Literal, Node, URIRef
+
+import software
+
+from SchemaTerms.localmarkdown import Markdown, MarkdownTool
+from SchemaTerms.sdoterm import *
+from SchemaTerms.sdotermsource import SdoTermSource
+import util.schemaversion as schemaversion
+
 
 if not (sys.version_info.major == 3 and sys.version_info.minor > 5):
     print(
@@ -9,36 +32,12 @@ if not (sys.version_info.major == 3 and sys.version_info.minor > 5):
     )
     sys.exit(os.EX_CONFIG)
 
-import glob
-import re
-from typing import Any, Dict, List, Optional, Tuple, Union, Set, FrozenSet
-
-for path in [
-    os.getcwd(),
-    "software/util",
-    "software/SchemaTerms",
-    "software/SchemaExamples",
-]:
-    sys.path.insert(1, path)  # Pickup libs from local  directories
 
 
-import rdflib
-from rdflib import Graph
-from rdflib.term import URIRef, Literal, Node
-from rdflib.parser import Parser
-from rdflib.serializer import Serializer
-from rdflib.plugins.sparql import prepareQuery
-from rdflib.compare import graph_diff
-from rdflib.namespace import RDFS, RDF
 
-from xml.etree import ElementTree
-from xml.dom import minidom
 
-from software.SchemaTerms.sdotermsource import SdoTermSource
-from software.SchemaTerms.sdoterm import *
-from software.SchemaTerms.localmarkdown import Markdown
 
-import software.util.schemaversion as schemaversion
+
 
 VOCABURI: str = SdoTermSource.vocabUri()
 
@@ -82,7 +81,6 @@ def _MakePrettyComment(text: str) -> ElementTree.Comment:
 
 class OwlBuild:
     def __init__(self) -> None:
-        from software.SchemaTerms.localmarkdown import MarkdownTool
         self.typesCount: int = 0
         self.propsCount: int = 0
         self.namedCount: int = 0

--- a/software/util/sort_dict.py
+++ b/software/util/sort_dict.py
@@ -1,9 +1,14 @@
 #!/usr/bin/env python3
 # -*- coding: utf-8 -*-
 
-from typing import Any, Tuple, List, Union, Dict, Optional
+import os
+import sys
+from typing import Any, Dict, List, Optional, Tuple, Union
 from xml.dom import minidom
 from xml.etree import ElementTree
+
+import software
+
 
 KEY_ORDER: List[str] = ["@context", "@id", "@type"]
 

--- a/software/util/textutils.py
+++ b/software/util/textutils.py
@@ -1,8 +1,13 @@
 #!/usr/bin/env python3
 # -*- coding: utf-8 -*-
 
+import os
 import re
-from typing import Optional, Match, Iterable
+import sys
+from typing import Iterable, Match, Optional
+
+import software
+
 
 def StripHtmlTags(source: str) -> str:
     """Strip all HTML tags from source."""


### PR DESCRIPTION
Scripts (Python files expected to be called on the command line) are moved into the script dir.

- we also adjust all other Python files, documentation;
- we remove all the import path handling from non-script files;
- we further assume the directory from which these are run is the root of the project (i.e. `schemaorg`) and therefore loading other Python files can be greatly simplified;
- we moved any import that is not at the top of the file to ... the top of the file;
- the example-code is also adjusted so it works like described in the documentation.