### PR TITLE
feat(MedicalSpecialty): Add Audiology

### DIFF
--- a/data/ext/health-lifesci/med-health-core.ttl
+++ b/data/ext/health-lifesci/med-health-core.ttl
@@ -612,6 +612,12 @@
     rdfs:comment "Appearance assessment with clinical examination." ;
     :isPartOf <https://health-lifesci.schema.org> .
 
+:Audiology a :MedicalSpecialty ;
+    rdfs:label "Audiology" ;
+    rdfs:comment "A specific branch of medical science concerned with the diagnosis, management, and non-surgical treatment of hearing, balance, and related auditory processing disorders, including conditions such as tinnitus, hyperacusis, and misophonia." ;
+    rdfs:subClassOf :MedicalBusiness ;
+    :isPartOf <https://health-lifesci.schema.org> .
+
 :Ayurvedic a :MedicineSystem ;
     rdfs:label "Ayurvedic" ;
     rdfs:comment "A system of medicine that originated in India over thousands of years and that focuses on integrating and balancing the body, mind, and spirit." ;


### PR DESCRIPTION
Closes #4845

### Motivation

`Otolaryngologic` is currently used as a broad catch-all for ear-related conditions. However, Audiology is a distinct clinical discipline that focuses on the *perception* of sound and non-surgical management of auditory processing disorders — not on the physical anatomy of the ear.

Conditions such as Tinnitus, Hyperacusis, and Misophonia are treated primarily by Audiologists, not ENT surgeons. Adding `Audiology` as a separate `MedicalSpecialty` enables more precise markup for:
- Medical content publishers
- Healthcare provider directories
- Search engines (e.g., Google) connecting patients to the right specialists

### Proposed hierarchy

`Thing` > `MedicalEntity` > `MedicalSpecialty` > `Audiology`

### References

- WHO – Tinnitus: https://www.who.int/news-room/questions-and-answers/item/deafness-and-hearing-loss--tinnitus
- American Tinnitus Association: https://www.ata.org/about-tinnitus/why-are-my-ears-ringing/
- American Academy of Audiology: https://www.audiology.org/about-the-aaa/
- British Society of Audiology: https://thebsa.org.uk/
- Wikidata – Tinnitus: https://www.wikidata.org/wiki/Q192309
- Wikidata – Hyperacusis: https://www.wikidata.org/wiki/Q1421356
- Wikidata – Misophonia: https://www.wikidata.org/wiki/Q2054837