### PR TITLE
Remove `@type` keyword from JSON-LD context file

### DIFF
--- a/software/tests/test_basics.py
+++ b/software/tests/test_basics.py
@@ -518,10 +518,6 @@ class BasicJSONLDTests(unittest.TestCase):
         self.assertTrue(
             "dateModified" in self.ctx["@context"], "dateModified should be defined."
         )
-        self.assertTrue(
-            self.ctx["@context"]["dateModified"]["@type"] == "Date",
-            "dateModified should have Date type.",
-        )
 
     def test_sameas_jsonld(self):
         if not self.ctx:

--- a/software/tests/test_sdojsonldcontext.py
+++ b/software/tests/test_sdojsonldcontext.py
@@ -48,8 +48,13 @@ class SdoJsonLdContextTest(unittest.TestCase):
         self.assertIn("type", context)
         self.assertIn("id", context)
         self.assertIn("@vocab", context)
+
+        # Historically, @type=Date (or @type=id) was included for non-Text-related properties. Since we support multiple
+        # datatypes/things for properties, this led to inaccurate datatype results and inconsistent usage of
+        # datatypes/IRIs for property values (post-JSON-LD processing). This test helps ensure it is not unintentionally
+        # re-introduced and to document a bit more of the background.
         self.assertEqual(
-            context[mock_id], {"@id": "http://schema.org/thang", "@type": "Date"}
+            context[mock_id], {"@id": "http://schema.org/thang"}
         )
 
     @unittest.mock.patch("SchemaTerms.sdotermsource.SdoTermSource.getAllTerms")
@@ -122,43 +127,6 @@ class SdoJsonLdContextTest(unittest.TestCase):
         self.assertIn("id", context)
         self.assertIn("@vocab", context)
         self.assertNotIn(mock_id, context)
-
-    @unittest.mock.patch("SchemaTerms.sdotermsource.SdoTermSource.getAllTerms")
-    def test_createcontextMultiple(self, mock_getAllTerms):
-        self.maxDiff = None
-        mock_property = sdoterm.SdoProperty(
-            term_id="aa", uri="http://schema.org/a", label="a"
-        )
-        mock_property.domainIncludes.setIds(["Thing"])
-        mock_property.rangeIncludes.setIds(["Date", "URL", "Thing"])
-        mock_enumeration = sdoterm.SdoEnumeration(
-            term_id="bb", uri="http://schema.org/b", label="b"
-        )
-        mock_enumeration_value = sdoterm.SdoEnumerationvalue(
-            term_id="cc", uri="http://schema.org/c", label="c"
-        )
-        mock_getAllTerms.return_value = [
-            mock_property,
-            mock_enumeration,
-            mock_enumeration_value,
-        ]
-        json_data = sdojsonldcontext.createcontext()
-        parsed = json.loads(json_data)
-        self.assertIn("@context", parsed)
-        self.assertEqual(
-            dict(
-                [
-                    (k, v)
-                    for k, v in parsed["@context"].items()
-                    if k in ["aa", "bb", "cc"]
-                ]
-            ),
-            {
-                "aa": {"@id": "http://schema.org/a", "@type": ["@id", "Date"]},
-                "bb": {"@id": "http://schema.org/b"},
-                "cc": {"@id": "http://schema.org/c"},
-            },
-        )
 
 
 if __name__ == "__main__":

--- a/software/util/sdojsonldcontext.py
+++ b/software/util/sdojsonldcontext.py
@@ -29,20 +29,6 @@ def getContext() -> str:
         CONTEXT = createcontext()
     return CONTEXT
 
-
-def _convertTypes(type_range: typing.Collection[str]) -> typing.Set[str]:
-    types: Set[str] = set()
-    if "Text" in type_range:
-        return types
-    if "URL" in type_range:
-        types.add("@id")
-    if "Date" in type_range:
-        types.add("Date")
-    if "Datetime" in type_range:
-        types.add("DateTime")
-    return types
-
-
 def createcontext() -> str:
     """Generates a basic JSON-LD context file for schema.org."""
     with pretty_logger.BlockLog(message="Creating JSON-LD context", logger=log):
@@ -72,13 +58,6 @@ def createcontext() -> str:
                 continue
             if term.termType == sdoterm.SdoTermType.REFERENCE:
                 continue
-            term_json: Dict[str, Any] = {"@id": sdotermsource.prefixedIdFromUri(term.uri)}
-            if term.termType == sdoterm.SdoTermType.PROPERTY:
-                types: Set[str] = _convertTypes(term.rangeIncludes.ids)
-                if len(types) == 1:
-                    term_json["@type"] = types.pop()
-                elif len(types) > 1:
-                    term_json["@type"] = sorted(list(types))
-            json_context[term.id] = term_json
+            json_context[term.id] = {"@id": sdotermsource.prefixedIdFromUri(term.uri)}
         json_object: Dict[str, Any] = {"@context": json_context}
         return json.dumps(sort_dict(json_object), indent=2)


### PR DESCRIPTION
Remove the term definition `@type` keywords from the `jsonldcontext.jsonld` generation script, delegating all value object type mapping to the data consumer. In summary, this has the following effects.

* Closes [#4384](https://github.com/schemaorg/schemaorg/pull/4384) which incorrectly tried to support multiple types via JSON-LD.
* Closes [#4852](https://github.com/schemaorg/schemaorg/issues/4852) which documents valid `Integer` values of `merchantReturnDays` being incorrectly typed as `Date`.
* Reduce scope of JSON-LD context to IRI term expansion (without the incomplete, incorrect JSON-LD type mapping).
* Avoid downstream consumers needing to patch the context file locally.

Removing the `@type` keywords via local patch is currently required for non-trivial data consumption. Based on @rrlevering's [related comment](https://github.com/schemaorg/schemaorg/pull/4384#issuecomment-4007511294), this is Google's internal approach, and it also matches my own investigations about validation methods. As a reminder, JSON-LD can only map value objects to a single datatype (see [spec](https://www.w3.org/TR/json-ld/#value-objects)) which isn't compatible with Schema.org's value ranges.

The primary risk is if consumers were relying on specific properties being a resolved IRI via JSON-LD's `@id` processing. Of course, many properties support `Text` in addition to `URL`, and those have always remained an `xsd:string` requiring consumers to resolve them anyway. That URL-like properties may or may not end up as an IRI is another reason for this change, in my opinion. Similarly, not all `Date` properties end up as `Date`, and, of those, not all correctly as seen in [#4852](https://github.com/schemaorg/schemaorg/issues/4852).

I tried to find the original requirements for the `@type` implementation, but the closest I found was in the original [code comment](https://github.com/schemaorg/schemaorg/commit/01957026c58c65c20a7eb19f25b234b62afac01b#diff-1ed02c3495a2cbdfb7310b80b4a533d180f77b750ebf1e23a86d0d93e5872178R274) saying `this needs improving; we only started with real types that are subtyped, not Text literals`. To me, that sounds more like it was a prototype that stuck around, but maybe others have more background.

Happy to discuss further, and hopefully others can help provide feedback on this change.

/cc @madbob, @rrlevering, @LuisCCFigueira, @danbri, @wiesmann from linked issues and related commits

---

<details><summary>diff schemaorgcontext.jsonld schemaorgcontext-after.jsonld</summary>

From reviewing the effective `diff` produced after this commit...

```patch
4572,4573c4571
<       "@id": "schema:acquireLicensePage",
<       "@type": "@id"
---
>       "@id": "schema:acquireLicensePage"
4600,4601c4598
<       "@id": "schema:actionableFeedbackPolicy",
<       "@type": "@id"
---
>       "@id": "schema:actionableFeedbackPolicy"
4664,4665c4661
<       "@id": "schema:afterMedia",
<       "@type": "@id"
---
>       "@id": "schema:afterMedia"
4770,4771c4766
<       "@id": "schema:applicationStartDate",
<       "@type": "Date"
---
>       "@id": "schema:applicationStartDate"
4789,4790c4784
<       "@id": "schema:archivedAt",
<       "@type": "@id"
---
>       "@id": "schema:archivedAt"
4871,4872c4865
<       "@id": "schema:associatedDisease",
<       "@type": "@id"
---
>       "@id": "schema:associatedDisease"
4905,4906c4898
<       "@id": "schema:auditDate",
<       "@type": "Date"
---
>       "@id": "schema:auditDate"
4918,4919c4910
<       "@id": "schema:availabilityEnds",
<       "@type": "Date"
---
>       "@id": "schema:availabilityEnds"
4922,4923c4913
<       "@id": "schema:availabilityStarts",
<       "@type": "Date"
---
>       "@id": "schema:availabilityStarts"
4983,4984c4973
<       "@id": "schema:beforeMedia",
<       "@type": "@id"
---
>       "@id": "schema:beforeMedia"
4993,4994c4982
<       "@id": "schema:benefitsSummaryUrl",
<       "@type": "@id"
---
>       "@id": "schema:benefitsSummaryUrl"
5027,5028c5015
<       "@id": "schema:birthDate",
<       "@type": "Date"
---
>       "@id": "schema:birthDate"
5289,5290c5276
<       "@id": "schema:codeRepository",
<       "@type": "@id"
---
>       "@id": "schema:codeRepository"
5302,5303c5288
<       "@id": "schema:colleague",
<       "@type": "@id"
---
>       "@id": "schema:colleague"
5318,5319c5303
<       "@id": "schema:colorSwatch",
<       "@type": "@id"
---
>       "@id": "schema:colorSwatch"
5334,5335c5318
<       "@id": "schema:commentTime",
<       "@type": "Date"
---
>       "@id": "schema:commentTime"
5362,5363c5345
<       "@id": "schema:constraintProperty",
<       "@type": "@id"
---
>       "@id": "schema:constraintProperty"
5408,5409c5390
<       "@id": "schema:contentUrl",
<       "@type": "@id"
---
>       "@id": "schema:contentUrl"
5436,5437c5417
<       "@id": "schema:correctionsPolicy",
<       "@type": "@id"
---
>       "@id": "schema:correctionsPolicy"
5593,5594c5573
<       "@id": "schema:dateCreated",
<       "@type": "Date"
---
>       "@id": "schema:dateCreated"
5597,5598c5576
<       "@id": "schema:dateDeleted",
<       "@type": "Date"
---
>       "@id": "schema:dateDeleted"
5601,5602c5579
<       "@id": "schema:dateIssued",
<       "@type": "Date"
---
>       "@id": "schema:dateIssued"
5605,5606c5582
<       "@id": "schema:dateModified",
<       "@type": "Date"
---
>       "@id": "schema:dateModified"
5609,5610c5585
<       "@id": "schema:datePosted",
<       "@type": "Date"
---
>       "@id": "schema:datePosted"
5613,5614c5588
<       "@id": "schema:datePublished",
<       "@type": "Date"
---
>       "@id": "schema:datePublished"
5617,5618c5591
<       "@id": "schema:dateRead",
<       "@type": "Date"
---
>       "@id": "schema:dateRead"
5627,5628c5600
<       "@id": "schema:dateVehicleFirstRegistered",
<       "@type": "Date"
---
>       "@id": "schema:dateVehicleFirstRegistered"
5637,5638c5609
<       "@id": "schema:deathDate",
<       "@type": "Date"
---
>       "@id": "schema:deathDate"
5743,5744c5714
<       "@id": "schema:discussionUrl",
<       "@type": "@id"
---
>       "@id": "schema:discussionUrl"
5747,5748c5717
<       "@id": "schema:diseasePreventionInfo",
<       "@type": "@id"
---
>       "@id": "schema:diseasePreventionInfo"
5751,5752c5720
<       "@id": "schema:diseaseSpreadStatistics",
<       "@type": "@id"
---
>       "@id": "schema:diseaseSpreadStatistics"
5758,5759c5726
<       "@id": "schema:dissolutionDate",
<       "@type": "Date"
---
>       "@id": "schema:dissolutionDate"
5771,5772c5738
<       "@id": "schema:diversityPolicy",
<       "@type": "@id"
---
>       "@id": "schema:diversityPolicy"
5775,5776c5741
<       "@id": "schema:diversityStaffingReport",
<       "@type": "@id"
---
>       "@id": "schema:diversityStaffingReport"
5779,5780c5744
<       "@id": "schema:documentation",
<       "@type": "@id"
---
>       "@id": "schema:documentation"
5810,5811c5774
<       "@id": "schema:downloadUrl",
<       "@type": "@id"
---
>       "@id": "schema:downloadUrl"
5850,5851c5813
<       "@id": "schema:duringMedia",
<       "@type": "@id"
---
>       "@id": "schema:duringMedia"
5917,5918c5879
<       "@id": "schema:embedUrl",
<       "@type": "@id"
---
>       "@id": "schema:embedUrl"
5960,5961c5921
<       "@id": "schema:endDate",
<       "@type": "Date"
---
>       "@id": "schema:endDate"
6027,6028c5987
<       "@id": "schema:ethicsPolicy",
<       "@type": "@id"
---
>       "@id": "schema:ethicsPolicy"
6055,6056c6014
<       "@id": "schema:exceptDate",
<       "@type": "Date"
---
>       "@id": "schema:exceptDate"
6080,6081c6038
<       "@id": "schema:expectedArrivalFrom",
<       "@type": "Date"
---
>       "@id": "schema:expectedArrivalFrom"
6084,6085c6041
<       "@id": "schema:expectedArrivalUntil",
<       "@type": "Date"
---
>       "@id": "schema:expectedArrivalUntil"
6103,6104c6059
<       "@id": "schema:expires",
<       "@type": "Date"
---
>       "@id": "schema:expires"
6185,6186c6140
<       "@id": "schema:foundingDate",
<       "@type": "Date"
---
>       "@id": "schema:foundingDate"
6243,6244c6197
<       "@id": "schema:gameLocation",
<       "@type": "@id"
---
>       "@id": "schema:gameLocation"
6304,6305c6257
<       "@id": "schema:gettingTestedInfo",
<       "@type": "@id"
---
>       "@id": "schema:gettingTestedInfo"
6347,6348c6299
<       "@id": "schema:guidelineDate",
<       "@type": "Date"
---
>       "@id": "schema:guidelineDate"
6402,6403c6353
<       "@id": "schema:hasGS1DigitalLink",
<       "@type": "@id"
---
>       "@id": "schema:hasGS1DigitalLink"
6409,6410c6359
<       "@id": "schema:hasMap",
<       "@type": "@id"
---
>       "@id": "schema:hasMap"
6431,6432c6380
<       "@id": "schema:hasMolecularFunction",
<       "@type": "@id"
---
>       "@id": "schema:hasMolecularFunction"
6507,6508c6455
<       "@id": "schema:healthPlanMarketingUrl",
<       "@type": "@id"
---
>       "@id": "schema:healthPlanMarketingUrl"
6580,6581c6527
<       "@id": "schema:image",
<       "@type": "@id"
---
>       "@id": "schema:image"
6599,6600c6545
<       "@id": "schema:inCodeSet",
<       "@type": "@id"
---
>       "@id": "schema:inCodeSet"
6603,6604c6548
<       "@id": "schema:inDefinedTermSet",
<       "@type": "@id"
---
>       "@id": "schema:inDefinedTermSet"
6694,6695c6638
<       "@id": "schema:installUrl",
<       "@type": "@id"
---
>       "@id": "schema:installUrl"
6749,6750c6692
<       "@id": "schema:isBasedOn",
<       "@type": "@id"
---
>       "@id": "schema:isBasedOn"
6753,6754c6695
<       "@id": "schema:isBasedOnUrl",
<       "@type": "@id"
---
>       "@id": "schema:isBasedOnUrl"
6769,6770c6710
<       "@id": "schema:isInvolvedInBiologicalProcess",
<       "@type": "@id"
---
>       "@id": "schema:isInvolvedInBiologicalProcess"
6776,6777c6716
<       "@id": "schema:isLocatedInSubcellularLocation",
<       "@type": "@id"
---
>       "@id": "schema:isLocatedInSubcellularLocation"
6780,6781c6719
<       "@id": "schema:isPartOf",
<       "@type": "@id"
---
>       "@id": "schema:isPartOf"
6919,6920c6857
<       "@id": "schema:labelDetails",
<       "@type": "@id"
---
>       "@id": "schema:labelDetails"
6929,6930c6866
<       "@id": "schema:lastReviewed",
<       "@type": "Date"
---
>       "@id": "schema:lastReviewed"
6936,6937c6872
<       "@id": "schema:layoutImage",
<       "@type": "@id"
---
>       "@id": "schema:layoutImage"
6979,6980c6914
<       "@id": "schema:legislationDate",
<       "@type": "Date"
---
>       "@id": "schema:legislationDate"
6983,6984c6917
<       "@id": "schema:legislationDateOfApplicability",
<       "@type": "Date"
---
>       "@id": "schema:legislationDateOfApplicability"
6987,6988c6920
<       "@id": "schema:legislationDateVersion",
<       "@type": "Date"
---
>       "@id": "schema:legislationDateVersion"
7036,7037c6968
<       "@id": "schema:license",
<       "@type": "@id"
---
>       "@id": "schema:license"
7082,7083c7013
<       "@id": "schema:logo",
<       "@type": "@id"
---
>       "@id": "schema:logo"
7107,7108c7037
<       "@id": "schema:mainEntityOfPage",
<       "@type": "@id"
---
>       "@id": "schema:mainEntityOfPage"
7120,7121c7049
<       "@id": "schema:map",
<       "@type": "@id"
---
>       "@id": "schema:map"
7127,7128c7055
<       "@id": "schema:maps",
<       "@type": "@id"
---
>       "@id": "schema:maps"
7134,7135c7061
<       "@id": "schema:masthead",
<       "@type": "@id"
---
>       "@id": "schema:masthead"
7240,7241c7166
<       "@id": "schema:merchantReturnDays",
<       "@type": "Date"
---
>       "@id": "schema:merchantReturnDays"
7244,7245c7169
<       "@id": "schema:merchantReturnLink",
<       "@type": "@id"
---
>       "@id": "schema:merchantReturnLink"
7263,7264c7187
<       "@id": "schema:missionCoveragePrioritiesPolicy",
<       "@type": "@id"
---
>       "@id": "schema:missionCoveragePrioritiesPolicy"
7273,7274c7196
<       "@id": "schema:modelDate",
<       "@type": "Date"
---
>       "@id": "schema:modelDate"
7349,7350c7271
<       "@id": "schema:newsUpdatesAndGuidelines",
<       "@type": "@id"
---
>       "@id": "schema:newsUpdatesAndGuidelines"
7356,7357c7277
<       "@id": "schema:noBylinesPolicy",
<       "@type": "@id"
---
>       "@id": "schema:noBylinesPolicy"
7465,7466c7385
<       "@id": "schema:observationDate",
<       "@type": "Date"
---
>       "@id": "schema:observationDate"
7514,7515c7433
<       "@id": "schema:orderDate",
<       "@type": "Date"
---
>       "@id": "schema:orderDate"
7554,7555c7472
<       "@id": "schema:originalMediaLink",
<       "@type": "@id"
---
>       "@id": "schema:originalMediaLink"
7657,7658c7574
<       "@id": "schema:paymentDueDate",
<       "@type": "Date"
---
>       "@id": "schema:paymentDueDate"
7673,7674c7589
<       "@id": "schema:paymentUrl",
<       "@type": "@id"
---
>       "@id": "schema:paymentUrl"
7815,7816c7730
<       "@id": "schema:prescribingInfo",
<       "@type": "@id"
---
>       "@id": "schema:prescribingInfo"
7825,7826c7739
<       "@id": "schema:previousStartDate",
<       "@type": "Date"
---
>       "@id": "schema:previousStartDate"
7850,7851c7763
<       "@id": "schema:priceValidUntil",
<       "@type": "Date"
---
>       "@id": "schema:priceValidUntil"
7899,7900c7811
<       "@id": "schema:productReturnLink",
<       "@type": "@id"
---
>       "@id": "schema:productReturnLink"
7909,7910c7820
<       "@id": "schema:productionDate",
<       "@type": "Date"
---
>       "@id": "schema:productionDate"
7964,7965c7874
<       "@id": "schema:publicTransportClosuresInfo",
<       "@type": "@id"
---
>       "@id": "schema:publicTransportClosuresInfo"
7986,7987c7895
<       "@id": "schema:publishingPrinciples",
<       "@type": "@id"
---
>       "@id": "schema:publishingPrinciples"
7990,7991c7898
<       "@id": "schema:purchaseDate",
<       "@type": "Date"
---
>       "@id": "schema:purchaseDate"
8006,8007c7913
<       "@id": "schema:quarantineGuidelines",
<       "@type": "@id"
---
>       "@id": "schema:quarantineGuidelines"
8118,8119c8024
<       "@id": "schema:relatedLink",
<       "@type": "@id"
---
>       "@id": "schema:relatedLink"
8131,8132c8036
<       "@id": "schema:releaseDate",
<       "@type": "Date"
---
>       "@id": "schema:releaseDate"
8171,8172c8075
<       "@id": "schema:replyToUrl",
<       "@type": "@id"
---
>       "@id": "schema:replyToUrl"
8310,8311c8213
<       "@id": "schema:sameAs",
<       "@type": "@id"
---
>       "@id": "schema:sameAs"
8323,8324c8225
<       "@id": "schema:scheduledPaymentDate",
<       "@type": "Date"
---
>       "@id": "schema:scheduledPaymentDate"
8327,8328c8228
<       "@id": "schema:scheduledTime",
<       "@type": "Date"
---
>       "@id": "schema:scheduledTime"
8334,8335c8234
<       "@id": "schema:schoolClosuresInfo",
<       "@type": "@id"
---
>       "@id": "schema:schoolClosuresInfo"
8341,8342c8240
<       "@id": "schema:screenshot",
<       "@type": "@id"
---
>       "@id": "schema:screenshot"
8345,8346c8243
<       "@id": "schema:sdDatePublished",
<       "@type": "Date"
---
>       "@id": "schema:sdDatePublished"
8349,8350c8246
<       "@id": "schema:sdLicense",
<       "@type": "@id"
---
>       "@id": "schema:sdLicense"
8356,8357c8252
<       "@id": "schema:season",
<       "@type": "@id"
---
>       "@id": "schema:season"
8447,8448c8342
<       "@id": "schema:serviceUrl",
<       "@type": "@id"
---
>       "@id": "schema:serviceUrl"
8478,8479c8372
<       "@id": "schema:shippingSettingsLink",
<       "@type": "@id"
---
>       "@id": "schema:shippingSettingsLink"
8497,8498c8390
<       "@id": "schema:significantLink",
<       "@type": "@id"
---
>       "@id": "schema:significantLink"
8501,8502c8393
<       "@id": "schema:significantLinks",
<       "@type": "@id"
---
>       "@id": "schema:significantLinks"
8559,8560c8450
<       "@id": "schema:speakable",
<       "@type": "@id"
---
>       "@id": "schema:speakable"
8608,8609c8498
<       "@id": "schema:startDate",
<       "@type": "Date"
---
>       "@id": "schema:startDate"
8744,8745c8633
<       "@id": "schema:target",
<       "@type": "@id"
---
>       "@id": "schema:target"
8766,8767c8654
<       "@id": "schema:targetUrl",
<       "@type": "@id"
---
>       "@id": "schema:targetUrl"
8812,8813c8699
<       "@id": "schema:thumbnailUrl",
<       "@type": "@id"
---
>       "@id": "schema:thumbnailUrl"
8885,8886c8771
<       "@id": "schema:tourBookingPage",
<       "@type": "@id"
---
>       "@id": "schema:tourBookingPage"
8898,8899c8783
<       "@id": "schema:trackingUrl",
<       "@type": "@id"
---
>       "@id": "schema:trackingUrl"
8941,8942c8825
<       "@id": "schema:travelBans",
<       "@type": "@id"
---
>       "@id": "schema:travelBans"
8978,8979c8861
<       "@id": "schema:unnamedSourcesPolicy",
<       "@type": "@id"
---
>       "@id": "schema:unnamedSourcesPolicy"
8985,8986c8867
<       "@id": "schema:uploadDate",
<       "@type": "Date"
---
>       "@id": "schema:uploadDate"
8992,8993c8873
<       "@id": "schema:url",
<       "@type": "@id"
---
>       "@id": "schema:url"
9002,9003c8882
<       "@id": "schema:usageInfo",
<       "@type": "@id"
---
>       "@id": "schema:usageInfo"
9027,9028c8906
<       "@id": "schema:validFrom",
<       "@type": "Date"
---
>       "@id": "schema:validFrom"
9034,9035c8912
<       "@id": "schema:validThrough",
<       "@type": "Date"
---
>       "@id": "schema:validThrough"
9038,9039c8915
<       "@id": "schema:validUntil",
<       "@type": "Date"
---
>       "@id": "schema:validUntil"
9096,9097c8972
<       "@id": "schema:vehicleModelDate",
<       "@type": "Date"
---
>       "@id": "schema:vehicleModelDate"
9112,9113c8987
<       "@id": "schema:verificationFactCheckingPolicy",
<       "@type": "@id"
---
>       "@id": "schema:verificationFactCheckingPolicy"
9149,9150c9023
<       "@id": "schema:webFeed",
<       "@type": "@id"
---
>       "@id": "schema:webFeed"
```

</details>

<details><summary>JSON-LD Context Commit Notes</summary>

From looking into the history to find more context about the `@type` functionality...

* [2014-06-14](https://github.com/schemaorg/schemaorg/commit/01957026c58c65c20a7eb19f25b234b62afac01b) (for v2.2) - JSON-LD context introduced supporting `Date` + `DateTime` datatypes; code comment of `this needs improving; we only started with real types that are subtyped, not Text literals.`; notably this uses a scalar `@type`.
* [2014-06-17](https://github.com/schemaorg/schemaorg/commit/d234d261324c33b54be9f55c225079dfee589faf) (for v2.2) - `@id` for `URL` was added to the list.
* [2020-09-10](https://github.com/schemaorg/schemaorg/commit/53ac3933b608734c1161caea3b7172f4f42464f4) (for v11.0) - new Python implementation for generating the context, mirroring the existing `@type` conventions. This is where the `Datetime` case typo appears to have been introduced. It also switched to using a local array instead of scalar (although it always outputs a JSON scalar).
* [2024-10-11](https://github.com/schemaorg/schemaorg/commit/018f5073af574daf6c3c077ab03affb698941225) (for v28.1) - seems like a proactive refactor and adding tests for the non-valid (and as-of-yet unused) case of outputting an array for `@type`.

</details>

<details><summary>SPARQL Query Notes</summary>

From investigating the definitions and enumerating collisions...
  
```
PREFIX rdf: <http://www.w3.org/1999/02/22-rdf-syntax-ns#>
PREFIX rdfs: <http://www.w3.org/2000/01/rdf-schema#>
PREFIX schema: <http://schema.org/>

SELECT
  ?property 
  (GROUP_CONCAT(STR(?rangeIncludes); separator=", ") AS ?ranges)
WHERE {
  ?property rdf:type rdf:Property .
  ?property schema:rangeIncludes ?rangeIncludes .
  FILTER EXISTS {
    ?property schema:rangeIncludes schema:URL .
  }
  {
    SELECT ?property WHERE {
      ?property rdf:type rdf:Property .
      ?property schema:rangeIncludes ?otherRange .
      ?otherRange rdfs:subClassOf*/rdf:type schema:DataType .
      FILTER NOT EXISTS {
        ?property schema:rangeIncludes schema:Text .
      }
    }
    GROUP BY ?property
    HAVING (COUNT(DISTINCT ?otherRange) > 0)
  }
}
GROUP BY ?property
ORDER BY ?property
```

</details>
