### PR TITLE
Correct and expand Italian nonprofit type definitions

### DIFF
--- a/data/ext/pending/issue-3629.ttl
+++ b/data/ext/pending/issue-3629.ttl
@@ -57,41 +57,59 @@
     rdfs:label "ITNonprofitType" ;
     :isPartOf <https://pending.schema.org> ;
     :source <https://github.com/schemaorg/schemaorg/issues/3629> ;
-    rdfs:comment "ITNonprofitType: Non-profit organization type originating from Italy." ;
+    rdfs:comment "ITNonprofitType: Non-profit organization type originating from Italy. Most categories are drawn from the Italian Third Sector Code (Legislative Decree No. 117 of 3 July 2017), although some Italian non-profit entities, such as amateur sports entities, are primarily governed by other legislation." ;
     rdfs:subClassOf :NonprofitType .
 
 :ITVolunteerAssociationCharity a :ITNonprofitType ;
     rdfs:label "ITVolunteerAssociationCharity" ;
     :isPartOf <https://pending.schema.org> ;
     :source <https://github.com/schemaorg/schemaorg/issues/3629> ;
-    rdfs:comment "ITVolunteerAssociationCharity: Non-profit type referring to associations organising charitable volunteer activities (Ital. Organizzazioni di volontariato or ODV) according to Italian Law 266 of 1991." .
+    rdfs:comment "ITVolunteerAssociationCharity: Non-profit type referring to Italian volunteer organizations (Ital. organizzazione di volontariato or ODV), governed primarily by Articles 32 and following of Legislative Decree No. 117 of 3 July 2017, the Italian Third Sector Code, which superseded Law 266 of 1991." .
 
 :ITSocialPromotionCharity a :ITNonprofitType ;
     rdfs:label "ITSocialPromotionCharity" ;
     :isPartOf <https://pending.schema.org> ;
     :source <https://github.com/schemaorg/schemaorg/issues/3629> ;
-    rdfs:comment "ITSocialPromotionCharity: Non-profit type referring to associations promoting charitable causes (Ital. Associazioni di promozione sociale or APS) according to Italian Law 383 of 2000." .
+    rdfs:comment "ITSocialPromotionCharity: Non-profit type referring to Italian social promotion associations (Ital. associazione di promozione sociale or APS), governed primarily by Articles 35 and following of Legislative Decree No. 117 of 3 July 2017, the Italian Third Sector Code, which superseded Law 383 of 2000." .
 
 :ITMutualAidCharity a :ITNonprofitType ;
     rdfs:label "ITMutualAidCharity" ;
     :isPartOf <https://pending.schema.org> ;
     :source <https://github.com/schemaorg/schemaorg/issues/3629> ;
-    rdfs:comment "ITMutualAidCharity: Non-profit type referring to associations providing financial aid to people need (Ital. Società di mutuo soccorso or SOMS) according to Italian Law 3818 of 1886." .
+    rdfs:comment "ITMutualAidCharity: Non-profit type referring to Italian mutual aid societies (Ital. società di mutuo soccorso or SOMS), governed by Law 3818 of 15 April 1886, in coordination with Articles 42 and following of Legislative Decree No. 117 of 3 July 2017, the Italian Third Sector Code." .
 
 :ITSocialCompanyCharity a :ITNonprofitType ;
     rdfs:label "ITSocialCompanyCharity" ;
     :isPartOf <https://pending.schema.org> ;
     :source <https://github.com/schemaorg/schemaorg/issues/3629> ;
-    rdfs:comment "ITSocialCompanyCharity: Non-profit type referring to companies with charitable missions (Ital. Imprese Sociali or IS) according to Italian Law 112 of 2017." .
+    rdfs:comment "ITSocialCompanyCharity: Non-profit type referring to Italian social enterprises (Ital. impresa sociale), a status governed by Legislative Decree No. 112 of 3 July 2017, as amended. The status may be acquired by different types of private entities and is not limited to companies." .
 
 :ITCooperativeCharity a :ITNonprofitType ;
     rdfs:label "ITCooperativeCharity" ;
     :isPartOf <https://pending.schema.org> ;
     :source <https://github.com/schemaorg/schemaorg/issues/3629> ;
-    rdfs:comment "ITCooperativeCharity: Non-profit type referring to Cooperatives with charitable missions (Ital. Cooperativa Sociale) according to Italian Law 112 of 2017." .
+    rdfs:comment "ITCooperativeCharity: Non-profit type referring to Italian social cooperatives (Ital. cooperativa sociale), governed primarily by Law 381 of 8 November 1991. Social cooperatives and their consortia qualify as social enterprises by operation of law under Article 1(4) of Legislative Decree No. 112 of 3 July 2017." .
 
 :ITSportCompanyCharity a :ITNonprofitType ;
     rdfs:label "ITSportCompanyCharity" ;
     :isPartOf <https://pending.schema.org> ;
     :source <https://github.com/schemaorg/schemaorg/issues/3629> ;
-    rdfs:comment "ITSportCompanyCharity: Non-profit type referring to Companies that organize sports activities for the public or inscribed members (Ital. Società Sportiva Dilettantistica or SSD) according to Italian Law 289 of 2002." .
+    rdfs:comment "ITSportCompanyCharity: Non-profit type referring to Italian amateur sports clubs organized in corporate form (Ital. società sportiva dilettantistica or SSD), as distinct from amateur sports associations (Ital. associazione sportiva dilettantistica or ASD), governed primarily by Legislative Decree No. 36 of 28 February 2021, as amended, and registered in the national register of amateur sports activities established by Legislative Decree No. 39 of 28 February 2021. These entities are generally outside the Italian Third Sector unless also registered in the RUNTS." .
+
+:ITPhilanthropicEntityCharity a :ITNonprofitType ;
+    rdfs:label "ITPhilanthropicEntityCharity" ;
+    :isPartOf <https://pending.schema.org> ;
+    :source <https://github.com/schemaorg/schemaorg/issues/3629> ;
+    rdfs:comment "ITPhilanthropicEntityCharity: Non-profit type referring to Italian philanthropic entities (Ital. ente filantropico), constituted as recognized associations or foundations and governed by Articles 37 and following of Legislative Decree No. 117 of 3 July 2017, the Italian Third Sector Code." .
+
+:ITAssociativeNetworkCharity a :ITNonprofitType ;
+    rdfs:label "ITAssociativeNetworkCharity" ;
+    :isPartOf <https://pending.schema.org> ;
+    :source <https://github.com/schemaorg/schemaorg/issues/3629> ;
+    rdfs:comment "ITAssociativeNetworkCharity: Non-profit type referring to Italian associative networks (Ital. rete associativa), associations grouping a large number of Third Sector entities, governed by Article 41 and related provisions of Legislative Decree No. 117 of 3 July 2017, the Italian Third Sector Code." .
+
+:ITOtherThirdSectorEntityCharity a :ITNonprofitType ;
+    rdfs:label "ITOtherThirdSectorEntityCharity" ;
+    :isPartOf <https://pending.schema.org> ;
+    :source <https://github.com/schemaorg/schemaorg/issues/3629> ;
+    rdfs:comment "ITOtherThirdSectorEntityCharity: Non-profit type referring to other Italian Third Sector entities (Ital. Ente del Terzo settore or ETS) registered in the Registro unico nazionale del Terzo settore (RUNTS) under Article 4 of Legislative Decree No. 117 of 3 July 2017 that do not fall within one of the specifically enumerated Third Sector categories." .


### PR DESCRIPTION
Related issue: #3629

Corrects outdated and inaccurate legal references in the Italian nonprofit type enumeration (`ITNonprofitType`) and adds missing Italian Third Sector categories. All changes are confined to `data/ext/pending/issue-3629.ttl`; only `rdfs:comment` values were changed for existing terms — no identifiers were renamed or removed.

## Corrections

- **ITVolunteerAssociationCharity** (ODV) and **ITSocialPromotionCharity** (APS): now anchored to the Third Sector Code (Legislative Decree 117/2017, Articles 32 ff. and 35 ff.); the superseded Laws 266/1991 and 383/2000 are mentioned as historical sources.
- **ITMutualAidCharity**: Law 3818/1886 kept, coordinated with Articles 42 ff. of Legislative Decree 117/2017.
- **ITSocialCompanyCharity**: fixed "Italian Law 112 of 2017" (it is a Legislative Decree); clarified that the *impresa sociale* status may be acquired by different types of private entities, not only companies.
- **ITCooperativeCharity**: correctly anchored to Law 381/1991 (social cooperatives), with the ex lege social enterprise status under Article 1(4) of Legislative Decree 112/2017.
- **ITSportCompanyCharity** (SSD): updated to Legislative Decrees 36/2021 and 39/2021; distinguished from ASD and from the Third Sector.
- **ITNonprofitType**: comment now frames the Third Sector Code as the main framework, noting exceptions such as amateur sports entities.

## New values (pending)

From Article 4 of Legislative Decree 117/2017: **ITPhilanthropicEntityCharity** (ente filantropico, Articles 37 ff.), **ITAssociativeNetworkCharity** (rete associativa, Article 41), and **ITOtherThirdSectorEntityCharity** (residual value for other RUNTS-registered Third Sector entities).

## Note on misnamed identifiers

Three identifiers are semantically imprecise: `ITSocialCompanyCharity` (an *impresa sociale* is a status open to many private entity types, not a "company" — a better name would be `ITSocialEnterpriseCharity`), `ITCooperativeCharity` (it covers only social cooperatives under Law 381/1991, not Italian cooperatives in general — better: `ITSocialCooperativeCharity`), and `ITSportCompanyCharity` (it omits the qualifying "amateur" element — better: `ITAmateurSportsClubCharity` or similar). This PR deliberately does not rename them, since they were published in v30.0: the corrected semantics live in the comments. However, as these terms are still in the pending section and presumably have little or no adoption yet, this may be the right window for the maintainers to either rename them outright or introduce the corrected names with `supersededBy` on the old ones. Happy to update this PR either way.

## Testing

Turtle syntax validated, full unit test suite and SHACL validation of examples pass. Legal references verified against Normattiva and the Ministry of Labour and Social Policies.
