### PR TITLE
docs: rescue broken mcf links

### DIFF
--- a/docs/datamodel.html
+++ b/docs/datamodel.html
@@ -302,7 +302,7 @@ conventional short name for most identifier schemes (which should be used in low
 <ul>
 <li><a href="https://www.w3.org/TR/rdf-schema/">RDF Schema</a></li>
 <li><a href="https://www.w3.org/TR/NOTE-MCF-XML-970606">Meta Content Framework (MCF) Using XML</a> (and <a href="https://www.w3.org/TR/NOTE-MCF-XML/MCF-tutorial.html">Tutorial</a>).</li>
-<li><a href="http://www.guha.com/mcf/wp.html">MCF whitepaper</a>, <a href="http://www.guha.com/mcf/mcf_spec.html">spec</a> and <a href="http://www.guha.com/mcf/vocab.html">basic vocabulary</a>.</li>
+<li><a href="https://web.archive.org/web/20110609111156/http://www.guha.com/mcf/wp.html">MCF whitepaper</a>, <a href="https://web.archive.org/web/20110609111124/http://www.guha.com/mcf/mcf_spec.html">spec</a> and <a href="https://web.archive.org/web/20110609110822/http://www.guha.com/mcf/vocab.html">basic vocabulary</a>.</li>
 <li>See also <a href="https://en.wikipedia.org/wiki/Semantic_network">Semantic network</a> article on Wikipedia.</li>
 </ul>
 


### PR DESCRIPTION
Use Wayback Machine archives of these dead links