### PR TITLE
Rename imprecise Italian nonprofit type identifiers with supersededBy

### DIFF
--- a/data/ext/pending/issue-3629.ttl
+++ b/data/ext/pending/issue-3629.ttl
@@ -82,19 +82,40 @@
     rdfs:label "ITSocialCompanyCharity" ;
     :isPartOf <https://pending.schema.org> ;
     :source <https://github.com/schemaorg/schemaorg/issues/3629> ;
-    rdfs:comment "ITSocialCompanyCharity: Non-profit type referring to Italian social enterprises (Ital. impresa sociale), a status governed by Legislative Decree No. 112 of 3 July 2017, as amended. The status may be acquired by different types of private entities and is not limited to companies." .
+    rdfs:comment "ITSocialCompanyCharity: Non-profit type referring to Italian social enterprises (Ital. impresa sociale), a status governed by Legislative Decree No. 112 of 3 July 2017, as amended. The status may be acquired by different types of private entities and is not limited to companies." ;
+    :supersededBy :ITSocialEnterpriseCharity .
 
 :ITCooperativeCharity a :ITNonprofitType ;
     rdfs:label "ITCooperativeCharity" ;
     :isPartOf <https://pending.schema.org> ;
     :source <https://github.com/schemaorg/schemaorg/issues/3629> ;
-    rdfs:comment "ITCooperativeCharity: Non-profit type referring to Italian social cooperatives (Ital. cooperativa sociale), governed primarily by Law 381 of 8 November 1991. Social cooperatives and their consortia qualify as social enterprises by operation of law under Article 1(4) of Legislative Decree No. 112 of 3 July 2017." .
+    rdfs:comment "ITCooperativeCharity: Non-profit type referring to Italian social cooperatives (Ital. cooperativa sociale), governed primarily by Law 381 of 8 November 1991. Social cooperatives and their consortia qualify as social enterprises by operation of law under Article 1(4) of Legislative Decree No. 112 of 3 July 2017." ;
+    :supersededBy :ITSocialCooperativeCharity .
 
 :ITSportCompanyCharity a :ITNonprofitType ;
     rdfs:label "ITSportCompanyCharity" ;
     :isPartOf <https://pending.schema.org> ;
     :source <https://github.com/schemaorg/schemaorg/issues/3629> ;
-    rdfs:comment "ITSportCompanyCharity: Non-profit type referring to Italian amateur sports clubs organized in corporate form (Ital. società sportiva dilettantistica or SSD), as distinct from amateur sports associations (Ital. associazione sportiva dilettantistica or ASD), governed primarily by Legislative Decree No. 36 of 28 February 2021, as amended, and registered in the national register of amateur sports activities established by Legislative Decree No. 39 of 28 February 2021. These entities are generally outside the Italian Third Sector unless also registered in the RUNTS." .
+    rdfs:comment "ITSportCompanyCharity: Non-profit type referring to Italian amateur sports clubs organized in corporate form (Ital. società sportiva dilettantistica or SSD), as distinct from amateur sports associations (Ital. associazione sportiva dilettantistica or ASD), governed primarily by Legislative Decree No. 36 of 28 February 2021, as amended, and registered in the national register of amateur sports activities established by Legislative Decree No. 39 of 28 February 2021. These entities are generally outside the Italian Third Sector unless also registered in the RUNTS." ;
+    :supersededBy :ITAmateurSportsClubCharity .
+
+:ITSocialEnterpriseCharity a :ITNonprofitType ;
+    rdfs:label "ITSocialEnterpriseCharity" ;
+    :isPartOf <https://pending.schema.org> ;
+    :source <https://github.com/schemaorg/schemaorg/issues/3629> ;
+    rdfs:comment "ITSocialEnterpriseCharity: Non-profit type referring to Italian social enterprises (Ital. impresa sociale), a status governed by Legislative Decree No. 112 of 3 July 2017, as amended. The status may be acquired by different types of private entities and is not limited to companies." .
+
+:ITSocialCooperativeCharity a :ITNonprofitType ;
+    rdfs:label "ITSocialCooperativeCharity" ;
+    :isPartOf <https://pending.schema.org> ;
+    :source <https://github.com/schemaorg/schemaorg/issues/3629> ;
+    rdfs:comment "ITSocialCooperativeCharity: Non-profit type referring to Italian social cooperatives (Ital. cooperativa sociale), governed primarily by Law 381 of 8 November 1991. Social cooperatives and their consortia qualify as social enterprises by operation of law under Article 1(4) of Legislative Decree No. 112 of 3 July 2017." .
+
+:ITAmateurSportsClubCharity a :ITNonprofitType ;
+    rdfs:label "ITAmateurSportsClubCharity" ;
+    :isPartOf <https://pending.schema.org> ;
+    :source <https://github.com/schemaorg/schemaorg/issues/3629> ;
+    rdfs:comment "ITAmateurSportsClubCharity: Non-profit type referring to Italian amateur sports clubs organized in corporate form (Ital. società sportiva dilettantistica or SSD), as distinct from amateur sports associations (Ital. associazione sportiva dilettantistica or ASD), governed primarily by Legislative Decree No. 36 of 28 February 2021, as amended, and registered in the national register of amateur sports activities established by Legislative Decree No. 39 of 28 February 2021. These entities are generally outside the Italian Third Sector unless also registered in the RUNTS." .
 
 :ITPhilanthropicEntityCharity a :ITNonprofitType ;
     rdfs:label "ITPhilanthropicEntityCharity" ;


### PR DESCRIPTION
Related issue: #3629
Follow-up to #4862, per [this comment](https://github.com/schemaorg/schemaorg/pull/4862#issuecomment-5265876416).

As noted in the "Note on misnamed identifiers" section of #4862, three `ITNonprofitType` values are semantically imprecise. Usage statistics show no adoption yet for these leaf types, and @pascalfleury confirmed that the rename should still carry `supersededBy` since the old identifiers have been released at least once. This PR therefore renames them via `supersededBy` rather than in place:

- `ITSocialCompanyCharity` → `ITSocialEnterpriseCharity` (an *impresa sociale* is a status open to many private entity types, not a "company")
- `ITCooperativeCharity` → `ITSocialCooperativeCharity` (it covers only social cooperatives under Law 381/1991, not Italian cooperatives in general)
- `ITSportCompanyCharity` → `ITAmateurSportsClubCharity` (the previous name omitted the qualifying "amateur" element)

The old identifiers are kept (unchanged label/comment) with a new `:supersededBy` triple pointing to the new term; the new terms carry the same (already corrected) comment text introduced in #4862. All changes are confined to `data/ext/pending/issue-3629.ttl`.

