### PR TITLE
Add properties to support standard retail and marketplace product data (#4878)

### DIFF
--- a/data/ext/pending/issue-4878-examples.txt
+++ b/data/ext/pending/issue-4878-examples.txt
@@ -1,4 +1,4 @@
-TYPES: Product, PropertyValue, Offer, OfferShippingDetails, ShippingRateSettings, WebContent, PriceSpecification, PriceTypeEnumeration
+TYPES: #eg-4878 Product, PropertyValue, Offer, OfferShippingDetails, ShippingRateSettings, TextObject, WebContent, PriceSpecification, PriceTypeEnumeration
 
 PRE-MARKUP:
 
@@ -26,7 +26,7 @@ JSON:
   },
   "image": "https://example.com/images/aeroquad-pro.jpg",
   "consumerNotice": {
-    "@type": "ConsumerNotice",
+    "@type": "TextObject",
     "name": "CHOKING_HAZARD",
     "text": "WARNING: Choking Hazard - Small parts. Not for children under 3 years. This product must be registered with the FAA before flight."
   },
@@ -99,12 +99,12 @@ JSON:
         "addressCountry": "US"
       },
       "shippingRate": {
-        "@type": "MonetaryAmount",
-        "value": "0.00",
-        "currency": "USD"
-      },
-      "shippingSettingsLink": {
         "@type": "ShippingRateSettings",
+        "shippingRate": {
+          "@type": "MonetaryAmount",
+          "value": "0.00",
+          "currency": "USD"
+        },
         "minimumOrderValue": {
           "@type": "PriceSpecification",
           "price": "50.00",

--- a/data/ext/pending/issue-4878-examples.txt
+++ b/data/ext/pending/issue-4878-examples.txt
@@ -1,0 +1,117 @@
+TYPES: Product, PropertyValue, Offer, OfferShippingDetails, ShippingRateSettings, WebContent, PriceSpecification, PriceTypeEnumeration
+
+PRE-MARKUP:
+
+This example demonstrates a comprehensive electronics product (a fictional smart drone) using the new properties introduced in Issue 4878. It showcases how to group technical specifications using `valueGroup` on `PropertyValue`, display safety information using `consumerNotice`, link related accessories using `isOftenBoughtWith`, and model pricing and shipping constraints using `MaximumRetailPrice`, `itemPopularity`, and `minimumOrderValue`.
+
+MICRODATA:
+
+Example is JSON-LD only.
+
+RDFA:
+
+Example is JSON-LD only.
+
+JSON:
+
+<script type="application/ld+json">
+{
+  "@context": "https://schema.org/",
+  "@type": "Product",
+  "name": "AeroQuad Pro Smart Drone",
+  "description": "A high-performance quadcopter drone with 4K camera and obstacle avoidance.",
+  "brand": {
+    "@type": "Brand",
+    "name": "AeroTech"
+  },
+  "image": "https://example.com/images/aeroquad-pro.jpg",
+  "consumerNotice": {
+    "@type": "ConsumerNotice",
+    "name": "CHOKING_HAZARD",
+    "text": "WARNING: Choking Hazard - Small parts. Not for children under 3 years. This product must be registered with the FAA before flight."
+  },
+  "isOftenBoughtWith": [
+    {
+      "@type": "Product",
+      "name": "AeroQuad Replacement Propellers (4-Pack)",
+      "sku": "AQ-PROP-4PK"
+    },
+    {
+      "@type": "Product",
+      "name": "AeroQuad High-Capacity Battery",
+      "sku": "AQ-BATT-HC"
+    }
+  ],
+  "specification": [
+    {
+      "@type": "PropertyValue",
+      "valueGroup": "Camera Specs",
+      "name": "Video Resolution",
+      "value": "4K at 60fps"
+    },
+    {
+      "@type": "PropertyValue",
+      "valueGroup": "Camera Specs",
+      "name": "Sensor Type",
+      "value": "1-inch CMOS"
+    },
+    {
+      "@type": "PropertyValue",
+      "valueGroup": "Flight Performance",
+      "name": "Max Flight Time",
+      "value": "35 minutes"
+    },
+    {
+      "@type": "PropertyValue",
+      "valueGroup": "Flight Performance",
+      "name": "Max Speed",
+      "value": "45 mph"
+    }
+  ],
+  "offers": {
+    "@type": "Offer",
+    "price": "799.00",
+    "priceCurrency": "USD",
+    "itemCondition": "https://schema.org/NewCondition",
+    "availability": "https://schema.org/InStock",
+    "itemPopularity": 1,
+    "priceSpecification": [
+      {
+        "@type": "UnitPriceSpecification",
+        "priceType": "https://schema.org/MaximumRetailPrice",
+        "price": "899.00",
+        "priceCurrency": "USD"
+      },
+      {
+        "@type": "UnitPriceSpecification",
+        "price": "799.00",
+        "priceCurrency": "USD"
+      }
+    ],
+    "shippingDetails": {
+      "@type": "OfferShippingDetails",
+      "provider": {
+        "@type": "Organization",
+        "name": "Acme Fast Freight"
+      },
+      "shippingDestination": {
+        "@type": "DefinedRegion",
+        "addressCountry": "US"
+      },
+      "shippingRate": {
+        "@type": "MonetaryAmount",
+        "value": "0.00",
+        "currency": "USD"
+      },
+      "shippingSettingsLink": {
+        "@type": "ShippingRateSettings",
+        "minimumOrderValue": {
+          "@type": "PriceSpecification",
+          "price": "50.00",
+          "priceCurrency": "USD"
+        }
+      }
+    }
+  }
+}
+</script>

--- a/data/ext/pending/issue-4878-examples.txt
+++ b/data/ext/pending/issue-4878-examples.txt
@@ -1,4 +1,4 @@
-TYPES: #eg-4878 Product, PropertyValue, Offer, OfferShippingDetails, ShippingRateSettings, TextObject, WebContent, PriceSpecification, PriceTypeEnumeration
+TYPES: #eg-4878 Product, PropertyValue, Offer, OfferShippingDetails, ShippingRateSettings, TextObject, WebContent, PriceSpecification, PriceTypeEnumeration, QuantitativeValue
 
 PRE-MARKUP:
 
@@ -74,7 +74,13 @@ JSON:
     "priceCurrency": "USD",
     "itemCondition": "https://schema.org/NewCondition",
     "availability": "https://schema.org/InStock",
-    "itemPopularity": 1,
+    "itemPopularity": {
+      "@type": "QuantitativeValue",
+      "value": 54,
+      "minValue": 1,
+      "maxValue": 347,
+      "name": "Category Popularity Rank"
+    },
     "priceSpecification": [
       {
         "@type": "UnitPriceSpecification",

--- a/data/ext/pending/issue-4878.ttl
+++ b/data/ext/pending/issue-4878.ttl
@@ -16,7 +16,7 @@
     rdfs:label "valueGroup" ;
     :domainIncludes :PropertyValue ;
     :rangeIncludes :Text ;
-    rdfs:comment "A header or section name for grouping related specifications or property values." ;
+    rdfs:comment "A header or section name for grouping related property values." ;
     :isPartOf <https://pending.schema.org> ;
     :source <https://github.com/schemaorg/schemaorg/issues/4878> .
 
@@ -39,7 +39,7 @@
 
 :ConsumerNotice a rdfs:Class ;
     rdfs:label "ConsumerNotice" ;
-    rdfs:subClassOf :Intangible ;
+    rdfs:subClassOf :StructuredValue ;
     rdfs:comment "A consumer notice, such as a safety warning or mandatory information, related to a product." ;
     :isPartOf <https://pending.schema.org> ;
     :source <https://github.com/schemaorg/schemaorg/issues/4878> .
@@ -68,6 +68,7 @@
     rdfs:label "minimumOrderValue" ;
     :domainIncludes :ShippingRateSettings ;
     :rangeIncludes :PriceSpecification,
+        :MonetaryAmount,
         :Number ;
     rdfs:comment "The minimum order value required for this shipping rate to apply." ;
     :isPartOf <https://pending.schema.org> ;

--- a/data/ext/pending/issue-4878.ttl
+++ b/data/ext/pending/issue-4878.ttl
@@ -55,6 +55,9 @@
     :isPartOf <https://pending.schema.org> ;
     :source <https://github.com/schemaorg/schemaorg/issues/4878> .
 
+:text :domainIncludes :ConsumerNotice ;
+    :source <https://github.com/schemaorg/schemaorg/issues/4878> .
+
 :isOftenBoughtWith a rdf:Property ;
     rdfs:label "isOftenBoughtWith" ;
     rdfs:subPropertyOf :isRelatedTo ;

--- a/data/ext/pending/issue-4878.ttl
+++ b/data/ext/pending/issue-4878.ttl
@@ -1,0 +1,74 @@
+@prefix : <https://schema.org/> .
+@prefix rdf: <http://www.w3.org/1999/02/22-rdf-syntax-ns#> .
+@prefix rdfs: <http://www.w3.org/2000/01/rdf-schema#> .
+@prefix xml: <http://www.w3.org/XML/1998/namespace> .
+@prefix xsd: <http://www.w3.org/2001/XMLSchema#> .
+
+:specification a rdf:Property ;
+    rdfs:label "specification" ;
+    :domainIncludes :Product ;
+    :rangeIncludes :PropertyValue ;
+    rdfs:comment "A specification of the product, often grouped by a section header/name. This is a cleaner alternative to additionalProperty for strict retail product specifications." ;
+    :isPartOf <https://pending.schema.org> ;
+    :source <https://github.com/schemaorg/schemaorg/issues/4878> .
+
+:valueGroup a rdf:Property ;
+    rdfs:label "valueGroup" ;
+    :domainIncludes :PropertyValue ;
+    :rangeIncludes :Text ;
+    rdfs:comment "A header or section name for grouping related specifications or property values." ;
+    :isPartOf <https://pending.schema.org> ;
+    :source <https://github.com/schemaorg/schemaorg/issues/4878> .
+
+:MaximumRetailPrice a :PriceTypeEnumeration ;
+    rdfs:label "MaximumRetailPrice" ;
+    rdfs:comment "The maximum retail price (MRP) of a product sold in India." ;
+    :isPartOf <https://pending.schema.org> ;
+    :source <https://github.com/schemaorg/schemaorg/issues/4878> .
+
+:provider :domainIncludes :OfferShippingDetails .
+
+:itemPopularity a rdf:Property ;
+    rdfs:label "itemPopularity" ;
+    :domainIncludes :Offer ;
+    :rangeIncludes :Number,
+        :QuantitativeValue ;
+    rdfs:comment "A measure of the popularity of the item, e.g. a popularity rank or sales rank." ;
+    :isPartOf <https://pending.schema.org> ;
+    :source <https://github.com/schemaorg/schemaorg/issues/4878> .
+
+:ConsumerNotice a rdfs:Class ;
+    rdfs:label "ConsumerNotice" ;
+    rdfs:subClassOf :Intangible ;
+    rdfs:comment "A consumer notice, such as a safety warning or mandatory information, related to a product." ;
+    :isPartOf <https://pending.schema.org> ;
+    :source <https://github.com/schemaorg/schemaorg/issues/4878> .
+
+:consumerNotice a rdf:Property ;
+    rdfs:label "consumerNotice" ;
+    :domainIncludes :Product ;
+    :rangeIncludes :ConsumerNotice,
+        :Text,
+        :URL,
+        :WebContent ;
+    rdfs:comment "A consumer notice, such as a safety warning or mandatory information, related to the product." ;
+    :isPartOf <https://pending.schema.org> ;
+    :source <https://github.com/schemaorg/schemaorg/issues/4878> .
+
+:isOftenBoughtWith a rdf:Property ;
+    rdfs:label "isOftenBoughtWith" ;
+    rdfs:subPropertyOf :isRelatedTo ;
+    :domainIncludes :Product ;
+    :rangeIncludes :Product ;
+    rdfs:comment "Indicates a product that is often bought with the described product." ;
+    :isPartOf <https://pending.schema.org> ;
+    :source <https://github.com/schemaorg/schemaorg/issues/4878> .
+
+:minimumOrderValue a rdf:Property ;
+    rdfs:label "minimumOrderValue" ;
+    :domainIncludes :ShippingRateSettings ;
+    :rangeIncludes :PriceSpecification,
+        :Number ;
+    rdfs:comment "The minimum order value required for this shipping rate to apply." ;
+    :isPartOf <https://pending.schema.org> ;
+    :source <https://github.com/schemaorg/schemaorg/issues/4878> .

--- a/data/ext/pending/issue-4878.ttl
+++ b/data/ext/pending/issue-4878.ttl
@@ -37,25 +37,15 @@
     :isPartOf <https://pending.schema.org> ;
     :source <https://github.com/schemaorg/schemaorg/issues/4878> .
 
-:ConsumerNotice a rdfs:Class ;
-    rdfs:label "ConsumerNotice" ;
-    rdfs:subClassOf :StructuredValue ;
-    rdfs:comment "A consumer notice, such as a safety warning or mandatory information, related to a product." ;
-    :isPartOf <https://pending.schema.org> ;
-    :source <https://github.com/schemaorg/schemaorg/issues/4878> .
-
 :consumerNotice a rdf:Property ;
     rdfs:label "consumerNotice" ;
     :domainIncludes :Product ;
-    :rangeIncludes :ConsumerNotice,
-        :Text,
+    :rangeIncludes :Text,
+        :TextObject,
         :URL,
         :WebContent ;
     rdfs:comment "A consumer notice, such as a safety warning or mandatory information, related to the product." ;
     :isPartOf <https://pending.schema.org> ;
-    :source <https://github.com/schemaorg/schemaorg/issues/4878> .
-
-:text :domainIncludes :ConsumerNotice ;
     :source <https://github.com/schemaorg/schemaorg/issues/4878> .
 
 :isOftenBoughtWith a rdf:Property ;

--- a/data/ext/pending/issue-4878.ttl
+++ b/data/ext/pending/issue-4878.ttl
@@ -33,7 +33,7 @@
     :domainIncludes :Offer ;
     :rangeIncludes :Number,
         :QuantitativeValue ;
-    rdfs:comment "A measure of the popularity of the item, e.g. a popularity rank or sales rank." ;
+    rdfs:comment "A measure of the relative popularity or sales rank of the offer within a marketplace, catalog, or platform (e.g. a platform-specific bestseller ranking or sales rank). This property is intended for platform-level or catalog-wide comparative rankings rather than self-asserted promotional claims." ;
     :isPartOf <https://pending.schema.org> ;
     :source <https://github.com/schemaorg/schemaorg/issues/4878> .
 


### PR DESCRIPTION
### **Description:**
**Closes #4878**

This PR introduces the schema changes proposed in Issue #4878 to close existing gaps when modeling standard e-commerce product data. We focused on extending existing types (like `Product`, `Offer`, and `OfferShippingDetails`) using the minimal number of novel concepts necessary.

**Changes included in this PR:**
* **Added `issue-4878.ttl` to the pending extension, which introduces:**
  * `specification` (and `valueGroup`) for structured technical product specs.
  * `ConsumerNotice` class and `consumerNotice` property for safety warnings/mandatory notices.
  * `isOftenBoughtWith` to standardise complementary product relationships.
  * `itemPopularity` to express sales rank/popularity on an `Offer`.
  * `MaximumRetailPrice` enumeration for pricing.
  * `minimumOrderValue` for conditional shipping rate settings.
  * Extended the domain of `provider` to include `OfferShippingDetails`.
* **Added `issue-4878-examples.txt`**: An example demonstrating all of the newly introduced properties in context on a standard retail product.
