### PR TITLE
examples: Minor fixes for syntax and typos.

### DIFF
--- a/data/examples.txt
+++ b/data/examples.txt
@@ -399,7 +399,7 @@ MICRODATA:
  <meta itemprop="contentUrl" content="http://media.freesound.org/data/0/previews/719__elmomo__12oclock_girona_preview.mp3" />
 
 <span class="description">
-      <meta itemprop="duration" content="T0M15S" />
+      <meta itemprop="duration" content="PT0M15S" />
       <span itemprop="description">Recorded on a terrace of Girona a sunday morning</span>
 </span>
 </div>
@@ -418,7 +418,7 @@ RDFA:
  <meta property="contentUrl" content="http://media.freesound.org/data/0/previews/719__elmomo__12oclock_girona_preview.mp3" />
 
 <span class="description">
-      <meta property="duration" content="T0M15S" />
+      <meta property="duration" content="PT0M15S" />
       <span property="description">Recorded on a terrace of Girona a sunday morning</span>
 </span>
 </div>
@@ -431,7 +431,7 @@ JSON:
   "@type": "AudioObject",
   "contentUrl": "http://media.freesound.org/data/0/previews/719__elmomo__12oclock_girona_preview.mp3",
   "description": "Recorded on a terrace of Girona a sunday morning",
-  "duration": "T0M15S",
+  "duration": "PT0M15S",
   "encodingFormat": "audio/mpeg",
   "name": "12oclock_girona.mp3"
 }
@@ -2888,7 +2888,7 @@ RDFA:
 We use the IndividualProduct type when we are concerned with the specific item,
 rather than a set of indistinguishably similar items.
 
-<div  typeof="IndividualProduct" resource="#product">
+<div vocab="https://schema.org/" typeof="IndividualProduct" resource="#product">
  <link property="additionalType" href="http://www.productontology.org/id/Racing_bicycle" />
  <span property="name">ACME Racing Bike in black (2008)</span>
  <span property="description">ACME Racing Bike, bought 8/2008, almost new, with a signature of
@@ -2938,7 +2938,7 @@ RDFA:
 The SomeProducts type is used when the product is an item drawn from a
 collection of interchangeably similar items.
 
-<div  typeof="SomeProducts" resource="#product">
+<div vocab="https://schema.org/" typeof="SomeProducts" resource="#product">
  We have the Brother HL-2230 on sale!
  <span property="name">Brother HL-2230 Compact Laser Printer</span>
  <link property="additionalType"
@@ -3003,7 +3003,7 @@ product, e.g. if you are the manufacturer of the product and want to
 mark up your product specification pages. For example: The ACME
 Colorvision 123 specifiation on the ACME Corp. site for that model.
 
-<div  typeof="ProductModel" resource="#model">
+<div vocab="https://schema.org/" typeof="ProductModel" resource="#model">
  <link property="additionalType"
        href="http://www.productontology.org/id/Television_set" />
  <span property="name">ACME Colorvision 123</span>
@@ -9826,9 +9826,11 @@ JSON:
   "workPerformed": {
     "@type": "CreativeWork",
     "name": "Julius Caesar",
-    "sameAs": "http://en.wikipedia.org/wiki/Julius_Caesar_(play)",
-    "sameAs": "http://worldcat.org/entity/work/id/1807288036",
-        "creator": {
+    "sameAs": [
+      "http://en.wikipedia.org/wiki/Julius_Caesar_(play)",
+      "http://worldcat.org/entity/work/id/1807288036"
+    ],
+    "creator": {
       "@type": "Person",
       "name": "William Shakespeare",
       "sameAs": "http://en.wikipedia.org/wiki/William_Shakespeare"
@@ -11014,7 +11016,7 @@ MICRODATA:
             <span itemprop="price" content="4399.00">4399 р.</span>
         </div>...
     </div>
-    <div itemprop="itemListElement" itemtype="https://schema.org/Product">
+    <div itemprop="itemListElement" itemscope itemtype="https://schema.org/Product">
         ...
     </div>
 </div>

--- a/data/ext/bib/bsdo-atlas-examples.txt
+++ b/data/ext/bib/bsdo-atlas-examples.txt
@@ -37,16 +37,9 @@ JSON:
 <script type="application/ld+json">
 {
   "@context": {
-    "rdf": "http://www.w3.org/1999/02/22-rdf-syntax-ns#",
-    "rdfa": "http://www.w3.org/ns/rdfa#",
-    "rdfs": "http://www.w3.org/2000/01/rdf-schema#",
-    "schema": "https://schema.org/",
-    "xsd": "http://www.w3.org/2001/XMLSchema#"
+    "schema": "https://schema.org/"
   },
   "@id": "http://www.worldcat.org/oclc/41310554",
-  "rdfa:usesVocabulary": {
-    "@id": "schema:"
-  },
   "@type": "schema:Atlas",
   "schema:name": "Atlas of the World",
   "schema:alternateName": "National Geographic atlas of the world",

--- a/data/ext/bib/bsdo-chapter-examples.txt
+++ b/data/ext/bib/bsdo-chapter-examples.txt
@@ -20,7 +20,7 @@ MICRODATA:
 <div>
 <div itemscope itemtype="https://schema.org/Book" itemid="http://www.worldcat.org/oclc/751835184">
   <h1 itemprop="name">Steve Jobs</h1>
-  <div>Author: <span itemprop="author" itemid="http://viaf.org/viaf/46911882">Walter Isaacson</span></div>
+  <div>Author: <span itemprop="author" itemscope itemid="http://viaf.org/viaf/46911882">Walter Isaacson</span></div>
   <div>ISBN: <span itemprop="isbn">9781408703748</span></div>
 </div>
 <div itemscope itemtype="https://schema.org/Chapter" >
@@ -52,16 +52,9 @@ JSON:
 <script type="application/ld+json">
 {
   "@context": {
-    "rdfa": "http://www.w3.org/ns/rdfa#",
     "schema": "https://schema.org/"
   },
   "@graph": [
-    {
-      "@id": "",
-      "rdfa:usesVocabulary": {
-        "@id": "schema:"
-      }
-    },
     {
       "@id": "http://www.worldcat.org/oclc/751835184",
       "@type": "schema:Book",

--- a/data/ext/bib/bsdo-collection-examples.txt
+++ b/data/ext/bib/bsdo-collection-examples.txt
@@ -36,14 +36,14 @@ MICRODATA:
 </div>
 <div itemscope itemtype="https://schema.org/Book" itemid="http://www.worldcat.org/oclc/68043906">
   <h1 itemprop="name">The Hitchhiker's guide to the galaxy. The quandry phase</h1>
-  <div>Author: <span itemprop="author" itemid="http://viaf.org/viaf/113230702">Douglas Adams</span></div>
+  <div>Author: <span itemprop="author" itemscope itemid="http://viaf.org/viaf/113230702">Douglas Adams</span></div>
   <div>ISBN: <span itemprop="isbn">9781405699532</span></div>
-  <div>Format: <span itemprop="bookFormat" itemid="https://schema.org/AudioBook">AudioBook</span></div>
+  <div>Format: <span itemprop="bookFormat" itemscope itemid="https://schema.org/AudiobookFormat">AudioBook</span></div>
   <link itemprop="isPartOf" itemscope itemtype="https://schema.org/Collection" itemid="http://example.org/colls/68" />
 </div>
 <div itemscope itemtype="https://schema.org/Book" itemid="http://www.worldcat.org/oclc/17105155">
   <h1 itemprop="name">A brief history of time : from the big bang to black holes</h1>
-  <div>Author: <span itemprop="author" itemid="http://viaf.org/viaf/102304634">Stephen Hawking</span></div>
+  <div>Author: <span itemprop="author" itemscope itemid="http://viaf.org/viaf/102304634">Stephen Hawking</span></div>
   <link itemprop="isPartOf" itemscope itemtype="https://schema.org/Collection" itemid="http://example.org/colls/68" />
   <div>ISBN: <span itemprop="isbn">055305340X</span></div>
 </div>
@@ -68,9 +68,9 @@ RDFA:
 </div>
 <div typeof="Book" resource="http://www.worldcat.org/oclc/68043906">
   <h1 property="name">The Hitchhiker's guide to the galaxy. The quandry phase</h1>
-  <div>Author: <span property="author" itemid="http://viaf.org/viaf/113230702">Douglas Adams</span></div>
+  <div>Author: <span property="author" resource="http://viaf.org/viaf/113230702">Douglas Adams</span></div>
   <div>ISBN: <span property="isbn">9781405699532</span></div>
-  <div>Format: <span property="bookFormat" itemid="https://schema.org/AudioBook">AudioBook</span></div>
+  <div>Format: <span property="bookFormat" resource="https://schema.org/AudiobookFormat">AudioBook</span></div>
   <link property="isPartOf" resource="http://example.org/colls/68" />
 </div>
 <div typeof="Book" resource="http://www.worldcat.org/oclc/17105155">
@@ -93,11 +93,7 @@ JSON:
 <script type="application/ld+json">
 {
   "@context": {
-    "rdf": "http://www.w3.org/1999/02/22-rdf-syntax-ns#",
-    "rdfa": "http://www.w3.org/ns/rdfa#",
-    "rdfs": "http://www.w3.org/2000/01/rdf-schema#",
-    "schema": "https://schema.org/",
-    "xsd": "http://www.w3.org/2001/XMLSchema#"
+    "schema": "https://schema.org/"
   },
   "@graph": [
     {
@@ -133,18 +129,12 @@ JSON:
       "@id": "http://www.worldcat.org/oclc/68043906",
       "@type": "schema:Book",
       "schema:author": "Douglas Adams",
-      "schema:bookFormat": "AudioBook",
+      "schema:bookFormat": "AudiobookFormat",
       "schema:isPartOf": {
         "@id": "http://example.org/colls/68"
       },
       "schema:isbn": "9781405699532",
       "schema:name": "The Hitchhiker's guide to the galaxy. The quandry phase"
-    },
-    {
-      "@id": "",
-      "rdfa:usesVocabulary": {
-        "@id": "schema:"
-      }
     },
     {
       "@id": "http://www.worldcat.org/oclc/297618476",

--- a/data/ext/bib/bsdo-newspaper-examples.txt
+++ b/data/ext/bib/bsdo-newspaper-examples.txt
@@ -34,15 +34,7 @@ JSON:
 <script type="application/ld+json">
 {
   "@context": {
-    "rdf": "http://www.w3.org/1999/02/22-rdf-syntax-ns#",
-    "rdfa": "http://www.w3.org/ns/rdfa#",
-    "rdfs": "http://www.w3.org/2000/01/rdf-schema#",
-    "schema": "https://schema.org/",
-    "xsd": "http://www.w3.org/2001/XMLSchema#"
-  },
-  "@id": "",
-  "rdfa:usesVocabulary": {
-    "@id": "schema:"
+    "schema": "https://schema.org/"
   },
    "@type": "schema:Newspaper",
    "schema:editor": {

--- a/data/ext/bib/bsdo-thesis-examples.txt
+++ b/data/ext/bib/bsdo-thesis-examples.txt
@@ -37,15 +37,7 @@ JSON:
 <script type="application/ld+json">
 {
   "@context": {
-    "rdf": "http://www.w3.org/1999/02/22-rdf-syntax-ns#",
-    "rdfa": "http://www.w3.org/ns/rdfa#",
-    "rdfs": "http://www.w3.org/2000/01/rdf-schema#",
-    "schema": "https://schema.org/",
-    "xsd": "http://www.w3.org/2001/XMLSchema#"
-  },
-  "@id": "",
-  "rdfa:usesVocabulary": {
-    "@id": "schema:"
+    "schema": "https://schema.org/"
   },
   "@type": "schema:Thesis",
   "schema:author": "Sekar, Nitin, Ph.D.",

--- a/data/ext/health-lifesci/medicalGuideline-examples.txt
+++ b/data/ext/health-lifesci/medicalGuideline-examples.txt
@@ -48,7 +48,7 @@ RDFA:
 <h1>Guidelines</h1>
 <ul>
   <li>Recommendation:
-  <span  typeof="MedicalGuidelineRecommendation">
+  <span vocab="https://schema.org/" typeof="MedicalGuidelineRecommendation">
     <span property="guidelineSubject"  typeof="Drug">
       <span property="name">NewvoDrug</span>
     </span>
@@ -65,7 +65,7 @@ RDFA:
   </span>
   </li>
   <li>Contraindication:
-  <span  typeof="MedicalGuidelineContraindication">
+  <span vocab="https://schema.org/" typeof="MedicalGuidelineContraindication">
     <span property="guidelineSubject"  typeof="MedicalCondition">
       <span property="name">cardiac failure</span></span> should never
     be treated with

--- a/data/ext/health-lifesci/medicalWebpage-examples.txt
+++ b/data/ext/health-lifesci/medicalWebpage-examples.txt
@@ -30,7 +30,7 @@ MICRODATA:
   <h2><span itemprop="mainContentOfPage">Treatment</span></h2>
   There are many common treatments for high blood pressure,
   including
-  <span itemscope itemtype="https://schema.org/DrugClass">
+  <span itemprop="mentions" itemscope itemtype="https://schema.org/DrugClass">
     <span itemprop="name">beta-blocker</span> drugs such as
     <span itemprop="drug" itemscope itemtype="https://schema.org/Drug">
       <span itemprop="nonProprietaryName">propanaolol</span>
@@ -62,7 +62,7 @@ RDFA:
   <h2><span property="mainContentOfPage">Treatment</span></h2>
   There are many common treatments for high blood pressure,
   including
-  <span  typeof="DrugClass">
+  <span property="mentions" typeof="DrugClass">
     <span property="name">beta-blocker</span> drugs such as
     <span property="drug"  typeof="Drug">
       <span property="nonProprietaryName">propanaolol</span>
@@ -95,20 +95,23 @@ JSON:
     "Treatment"
   ],
   "audience": "https://schema.org/Patient",
-  "about": [
-    {
-      "@type": "Drug",
-      "nonProprietaryName": "propanaolol",
-      "alternateName": "Innopran"
-    },
-    {
-      "@type": "Drug",
-      "nonProprietaryName": "atenolol",
-      "alternateName": "Tenormin"
-    }
-  ],
+  "mentions": {
+    "@type": "DrugClass",
+    "name": "beta-blocker",
+    "drug": [
+      {
+        "@type": "Drug",
+        "nonProprietaryName": "propanaolol",
+        "alternateName": "Innopran"
+      },
+      {
+        "@type": "Drug",
+        "nonProprietaryName": "atenolol",
+        "alternateName": "Tenormin"
+      }
+    ]
+  },
   "lastReviewed": "2011-09-14",
-  "name": "beta-blocker",
   "specialty": "https://schema.org/Cardiovascular"
 }
 </script>

--- a/data/ext/pending/issue-1698-examples.txt
+++ b/data/ext/pending/issue-1698-examples.txt
@@ -145,7 +145,7 @@ JSON:
   "skills": ["Active listening", "Critical thinking", "Social awareness"],
   "estimatedSalary": {
     "@type": "MonetaryAmountDistribution",
-    "duration": "1Y",
+    "duration": "P1Y",
     "currency": "USD",
     "percentile10": 72000,
     "percentile25": 86000,

--- a/data/ext/pending/issue-1810-examples.txt
+++ b/data/ext/pending/issue-1810-examples.txt
@@ -105,8 +105,8 @@ The Ribera del Duero wine route offers visitors charming villages where they can
       <link itemprop="sameAs" href="http://www.bodegasprotos.com/" />
       <link itemprop="image" href="https://commons.wikimedia.org/wiki/File%3AFoto_Bodega_Rogers2.jpg" />
     </div>
-    <div itemprop="includesAttraction" itemtype="https://schema.org/Winery" itemscope>
-      <link itemprop="additionalType" href="https://schema.org/TouristAttraction" />
+    <div itemprop="includesAttraction" itemtype="https://schema.org/TouristAttraction" itemscope>
+      <link itemprop="additionalType" href="https://schema.org/Winery" />
       <meta itemprop="name" content="Bodega Alejandro F. Tinto Pesquera" />
       <link itemprop="sameAs" href="http://www.grupopesquera.com/" />
       <link itemprop="image" href="https://commons.wikimedia.org/wiki/File%3ARibera_Del_Duero_Pesquera.JPG" />

--- a/data/ext/pending/issue-4505-examples.txt
+++ b/data/ext/pending/issue-4505-examples.txt
@@ -41,7 +41,7 @@ JSON:
       "@id": "http://example.com/lechateausnottyaddress",
       "addressCountry": "FR",
       "addressLocality": "L'Introuvable",
-      "addressRegion": "Charentes"
+      "addressRegion": "Charente"
     },
     {
       "@type": ["QuantitativeValue", "gs1:QuantitativeValue", "unece:MeasureType"],

--- a/data/issue-1156-examples.txt
+++ b/data/issue-1156-examples.txt
@@ -84,13 +84,13 @@ MICRODATA:
   <div>
     Repeals :
     <ul>
-      <li><a itemprop="https://schema.org/legislationRepeals" itemtype="https://schema.org/Legislation" href="31971L0354.html">31971L0354</a></li>
+      <li><a itemprop="https://schema.org/legislationRepeals" itemscope itemtype="https://schema.org/Legislation" href="31971L0354.html">31971L0354</a></li>
     </ul>
   </div>
   <div>
     Amends :
     <ul>
-      <li><a itemprop="https://schema.org/legislationAmends" itemtype="https://schema.org/Legislation"  href="51980FC0181.html">51980FC0181</a></li>
+      <li><a itemprop="https://schema.org/legislationAmends" itemscope itemtype="https://schema.org/Legislation"  href="51980FC0181.html">51980FC0181</a></li>
     </ul>
   </div>
   <div>
@@ -103,7 +103,7 @@ MICRODATA:
   <div>
     Legal basis :
     <ul>
-      <li><a itemprop="https://schema.org/isBasedOn" itemtype="https://schema.org/Legislation" href="11957E100.html">11957E100</a></li>
+      <li><a itemprop="https://schema.org/isBasedOn" itemscope itemtype="https://schema.org/Legislation" href="11957E100.html">11957E100</a></li>
     </ul>
   </div>
   <div>

--- a/data/issue-1253-examples.txt
+++ b/data/issue-1253-examples.txt
@@ -141,7 +141,7 @@ MICRODATA:
     <meta itemprop="unitCode" content="ANN"/>
   </div>
   <p itemprop="description">Experience easier budgeting with predictable monthly payments. Relax knowing you’ll never have to worry about rising interest rates for the life of your loan.</p>
-  <div itemprop="loanRepaymentForm" itemscope itemtype="https://schema.org/RepaymentSpecification" itemref="estPay payNum">
+  <div itemprop="loanRepaymentForm" itemscope itemtype="https://schema.org/RepaymentSpecification">
     <meta itemprop="downPayment" content="20"/>
     <meta itemprop="loanPaymentFrequency" content="1"/>
       <span>Estimated payment</span>
@@ -175,7 +175,7 @@ RDFA:
     <meta property="unitCode" content="ANN"/>
   </div>
   <p property="description">Experience easier budgeting with predictable monthly payments. Relax knowing you’ll never have to worry about rising interest rates for the life of your loan.</p>
-  <div property="loanRepaymentForm" typeof="RepaymentSpecification" itemref="estPay payNum">
+  <div property="loanRepaymentForm" typeof="RepaymentSpecification">
     <meta property="downPayment" content="20"/>
     <meta property="loanPaymentFrequency" content="1"/>
       <span>Estimated payment</span>

--- a/data/issue-1758-examples.txt
+++ b/data/issue-1758-examples.txt
@@ -94,7 +94,7 @@ MICRODATA:
 	<span class="label">Reference</span>
 	<span class="val" itemprop="identifier">GB 71 THM/407/8</span><br/>
 	<span class="label">Dates of Creation</span>
-	<span class="val" itemprop="temporalCoverage">1929-2005</span><br/>
+	<span class="val" itemprop="temporalCoverage">1929/2005</span><br/>
 	<span class="label">Name of Creator</span>
 	<span class="val" itemprop="creator">Ronnie Barker</span><br/>
 	<span class="label">Language of Material</span>
@@ -120,7 +120,7 @@ RDFA:
 	<span class="label">Reference</span>
 	<span class="val" property="identifier">GB 71 THM/407/8</span><br/>
 	<span class="label">Dates of Creation</span>
-	<span class="val" property="temporalCoverage">1929-2005</span><br/>
+	<span class="val" property="temporalCoverage">1929/2005</span><br/>
 	<span class="label">Name of Creator</span>
 	<span class="val" property="creator">Ronnie Barker</span><br/>
 	<span class="label">Language of Material</span>
@@ -156,7 +156,7 @@ JSON:
   },
   "description": "The collection consists of memorabilia material collected by Ronnie Barker to document his career. Materials include scrapbooks compiled by Ronnie Barker with press cuttings, reviews, memorabilia and photographs of his theatre, television and film work, photographs, manuscript material, scripts, correspondence, certificates and awards, press and marketing materials, audio recordings, audio visual recordings and material relating to special events and honours in his career.",
   "inLanguage": "EN",
-  "temporalCoverage": "1929-2005",
+  "temporalCoverage": "1929/2005",
 
   "itemLocation": "https://archiveshub.jisc.ac.uk/search/locations/eae30daa-1bf9-33d9-bf1c-7aeb220d2e76",
   "holdingArchive": "https://archiveshub.jisc.ac.uk/search/locations/eae30daa-1bf9-33d9-bf1c-7aeb220d2e76",

--- a/data/issue-2811-examples.txt
+++ b/data/issue-2811-examples.txt
@@ -26,7 +26,7 @@ JSON:
   "@type": "Product",
   "sku": "44E01-M11000",
   "inProductGroupWithID": "44E01",
-  "gtin14": "98766051104218",
+  "gtin14": "12345678901231",
   "image": "https://www.example.com/jacket_large_green.jpg",
   "name": "Large green jacket",
   "description": "Large wool green jacket for the winter months",

--- a/data/issue-3475-examples.txt
+++ b/data/issue-3475-examples.txt
@@ -10,8 +10,8 @@ ensuring comfort, a refined mélange texture adds sporty appeal.</p>
 
 MICRODATA:
 
-<div class="itemscope" itemtype="https://schema.org/Product">
-<h1 itemprop="title">Crew neck white t-shirt</h1>
+<div itemscope itemtype="https://schema.org/Product">
+<h1 itemprop="name">Crew neck white t-shirt</h1>
 
 <p itemprop="description">White t-shirt  made of soft and lightweight cotton jersey,
 ensuring comfort, a refined mélange texture adds sporty appeal.</p>

--- a/data/issue-3572-examples.txt
+++ b/data/issue-3572-examples.txt
@@ -24,23 +24,23 @@ JSON:
     "@type": "Country",
     "name": "United States"
   },
-  "validFrom": "2023-01-01", 
-  "validThrough": "2032-12-31", 
-  "incentiveType": "TaxCredit",
-  "purchaseType": "NewPurchase",
+  "validFrom": "2023-01-01",
+  "validThrough": "2032-12-31",
+  "incentiveType": "IncentiveTypeTaxCredit",
+  "purchaseType": "PurchaseTypeNewPurchase",
   "incentiveAmount": {
     "@type": "QuantitativeValue",
     "minValue": "2500",
     "maxValue": "7500",
     "unitCode": "USD"
   },
-  "incentiveStatus": "Active",
+  "incentiveStatus": "IncentiveStatusActive",
   "incentivizedItem": {
     "@type": "DefinedTerm",
     "inDefinedTermSet": "https://www.unspsc.org/",
     "termCode": "25101509",
     "name": "Electrically powered vehicle"
-  }, 
+  },
   "incomeLimit": {
     "@type": "MonetaryAmount",
     "maxValue": "114000",
@@ -62,10 +62,10 @@ JSON:
   "@context": "https://schema.org/",
   "@type": "FinancialIncentive",
   "name": "ACT Sustainable Household Scheme",
-  "url": "https://www.climatechoices.act.gov.au/policy-programs/sustainable-household-scheme", 
+  "url": "https://www.climatechoices.act.gov.au/policy-programs/sustainable-household-scheme",
   "publisher": {
     "@type": "Organization",
-    "name": "ACT Government" 
+    "name": "ACT Government"
   },
   "provider": {
     "@type": "Organization",
@@ -75,16 +75,16 @@ JSON:
     "@type": "State",
     "name": "Australian Capital Territory"
   },
-  "validFrom": "2021-05-01", 
-  "validThrough": "2026-06-30", 
-  "incentiveType": "Loan", 
-  "purchaseType": "NewPurchase",
+  "validFrom": "2021-05-01",
+  "validThrough": "2026-06-30",
+  "incentiveType": "IncentiveTypeLoan",
+  "purchaseType": "PurchaseTypeNewPurchase",
   "incentiveAmount": {
     "@type": "LoanOrCredit",
     "loanTerm": {
       "@type": "QuantitativeValue",
       "value": "10",
-      "unitCode": "ANN" 
+      "unitCode": "ANN"
     },
     "annualPercentageRate": [
       {
@@ -104,31 +104,33 @@ JSON:
       }
     ]
   },
-  "incentiveStatus": "Active",
-  "incentivizedItem": {
-    "@type": "DefinedTerm",
-    "inDefinedTermSet": "https://www.unspsc.org/",
-    "termCode": "30141500",
-    "name": "Thermal insulation"
-  },
-  "incentivizedItem": {
-    "@type": "DefinedTerm",
-    "inDefinedTermSet": "https://www.unspsc.org/",
-    "termCode": "40101806",
-    "name": "Heat Pumps"
-  },
-  "incentivizedItem": {
-    "@type": "DefinedTerm",
-    "inDefinedTermSet": "https://www.unspsc.org/",
-    "termCode": "261315XX",
-    "name": "Photovoltaic module"
-  },
-  "incentivizedItem": {
-    "@type": "DefinedTerm",
-    "inDefinedTermSet": "https://www.unspsc.org/",
-    "termCode": "251018XX",
-    "name": "Electric two-wheel vehicle"
-  }
+  "incentiveStatus": "IncentiveStatusActive",
+  "incentivizedItem": [
+    {
+      "@type": "DefinedTerm",
+      "inDefinedTermSet": "https://www.unspsc.org/",
+      "termCode": "30141500",
+      "name": "Thermal insulation"
+    },
+    {
+      "@type": "DefinedTerm",
+      "inDefinedTermSet": "https://www.unspsc.org/",
+      "termCode": "40101806",
+      "name": "Heat Pumps"
+    },
+    {
+      "@type": "DefinedTerm",
+      "inDefinedTermSet": "https://www.unspsc.org/",
+      "termCode": "261315XX",
+      "name": "Photovoltaic module"
+    },
+    {
+      "@type": "DefinedTerm",
+      "inDefinedTermSet": "https://www.unspsc.org/",
+      "termCode": "251018XX",
+      "name": "Electric two-wheel vehicle"
+    }
+  ]
 }
 </script>
 
@@ -145,24 +147,24 @@ JSON:
   "@context": "https://schema.org/",
   "@type": "FinancialIncentive",
   "name": "Electric Vehicle Chargepoint Grant",
-  "url": "https://www.gov.uk/electric-vehicle-chargepoint-grant-household", 
+  "url": "https://www.gov.uk/electric-vehicle-chargepoint-grant-household",
   "publisher": {
     "@type": "Organization",
-    "name": "UK Government" 
+    "name": "UK Government"
   },
   "provider": {
     "@type": "Organization",
-    "name": "Office for Zero Emission Vehicles (OZEV)" 
+    "name": "Office for Zero Emission Vehicles (OZEV)"
   },
   "areaServed": {
     "@type": "Country",
     "name": "United Kingdom"
   },
-  "validFrom": "2020-04-01", 
-  "validThrough": "2025-03-31", 
-  "incentiveType": "RebateOrSubsidy",
-  "purchaseType": "NewPurchase",
-  "incentiveStatus": "Active", 
+  "validFrom": "2020-04-01",
+  "validThrough": "2025-03-31",
+  "incentiveType": "IncentiveTypeRebateOrSubsidy",
+  "purchaseType": "PurchaseTypeNewPurchase",
+  "incentiveStatus": "IncentiveStatusActive",
   "incentivizedItem": {
     "@type": "DefinedTerm",
     "inDefinedTermSet": "https://www.unspsc.org/",
@@ -208,20 +210,20 @@ JSON:
     "@type": "City",
     "name": "Banff"
   },
-  "validFrom": "2018-01-01", 
-  "validThrough": "2024-12-31", 
-  "incentiveType": "RebateOrSubsidy",
-  "purchaseType": "NewPurchase",
+  "validFrom": "2018-01-01",
+  "validThrough": "2024-12-31",
+  "incentiveType": "IncentiveTypeRebateOrSubsidy",
+  "purchaseType": "PurchaseTypeNewPurchase",
   "incentiveAmount": {
     "@type": "UnitPriceSpecification",
     "price": "750",
     "priceCurrency": "USD",
     "referenceQuantity": "1",
-    "unitCode": "KWT", 
+    "unitCode": "KWT",
     "unitText": "kW",
-    "maxPrice": "15000" 
+    "maxPrice": "15000"
   },
-  "incentiveStatus": "Active", 
+  "incentiveStatus": "IncentiveStatusActive",
   "incentivizedItem": {
     "@type": "DefinedTerm",
     "inDefinedTermSet": "https://www.unspsc.org/",

--- a/data/issue-447-examples.txt
+++ b/data/issue-447-examples.txt
@@ -20,8 +20,10 @@ JSON:
   "@type" : "EventSeries",
   "@id" : "http://www.olympic.org/olympic-games",
   "name" : "Olympic Games",
-  "subEvent" : "http://www.olympic.org/rio-2016-summer-olympics",
-  "subEvent" : "http://www.olympic.org/london-2012-summer-olympics"
+  "subEvent" : [
+    "http://www.olympic.org/rio-2016-summer-olympics",
+    "http://www.olympic.org/london-2012-summer-olympics"
+  ]
 },
 {
   "@context" : "https://schema.org",

--- a/data/issue-894-examples.txt
+++ b/data/issue-894-examples.txt
@@ -246,7 +246,7 @@ MICRODATA:
 	<h2>Listing of codes:</h2>
 	<ul>
 		<li>...</li>
-		<li><span itemprop="hasCategoryCode" itemid="http://id.loc.gov/vocabulary/iso639-2/cze">cze</span></li>
+		<li><a itemprop="hasCategoryCode" href="http://id.loc.gov/vocabulary/iso639-2/cze">cze</a></li>
 		<li>...</li>
 	</ul>
 </div>

--- a/data/sdo-creativework-examples.txt
+++ b/data/sdo-creativework-examples.txt
@@ -333,7 +333,7 @@ JSON:
     "name": "Bill Lumbergh",
     "email": "blumbergh@example.com"
   },
-  "ccRecipient": {
+  "bccRecipient": {
     "@type": "ContactPoint",
     "email": "tps-consulting@example.com"
   },

--- a/data/sdo-soso-dataset-examples.txt
+++ b/data/sdo-soso-dataset-examples.txt
@@ -206,7 +206,7 @@ See https://github.com/ESIPFed/science-on-schema.org/blob/master/guides/DataRepo
     "@type": "PostalAddress",
     "streetAddress": "123 Main St.",
     "addressLocality": "Anytown",
-    "addressRegion": "ST",
+    "addressRegion": "NY",
     "postalCode": "12345",
     "addressCountry": "USA"
   },
@@ -220,7 +220,7 @@ See https://github.com/ESIPFed/science-on-schema.org/blob/master/guides/DataRepo
       "@type": "PostalAddress",
       "streetAddress": "234 Main St.",
       "addressLocality": "Anytown",
-      "addressRegion": "ST",
+      "addressRegion": "NY",
       "postalCode": "12345",
       "addressCountry": "USA"
     }

--- a/data/sdo-sponsor-examples.txt
+++ b/data/sdo-sponsor-examples.txt
@@ -29,7 +29,7 @@ MICRODATA:
 <div class="event-wrapper" itemscope itemtype="https://schema.org/Event">
   <h1 itemprop="name">The 2016 Missoula Marathon</h1>
   <p>The 2016 <a itemprop="url" href="http://www.missoulamarathon.org/events/marathon/">Missoula Marathon</a> is sponsored by
-    <span itemprop="sponsor" itemtype="https://schema.org/Organization"><a itemprop="url" href="http://www.runwildmissoula.org/">
+    <span itemprop="sponsor" itemscope itemtype="https://schema.org/Organization"><a itemprop="url" href="http://www.runwildmissoula.org/">
     <span itemprop="name">Run Wild Missoula</span></a></span>.</p>
   <div class="event-date" itemprop="startDate" content="2016-07-10T06:00:00">Date/Time:  Sunday, July 10th, 2016, 6:00am</div>
   <div class="event-fees">
@@ -63,7 +63,7 @@ MICRODATA:
     <h2 itemprop="address" itemscope itemtype="https://schema.org/PostalAddress">
 	  <a href="http://www.ci.missoula.mt.us/">About <span itemprop="addressLocality">Missoula</span>,  <span itemprop="addressRegion">MT</span></a>
 	</h2>
-    <h2><a itemprop="hasMap"  itemtype="https://schema.org/Map" href="http://www.missoulamarathon.org/wp-content/uploads/2015/06/2015-MM-Course-Map-V1-6-2-15.png">View Course Map</a>
+    <h2><a itemprop="hasMap" href="http://www.missoulamarathon.org/wp-content/uploads/2015/06/2015-MM-Course-Map-V1-6-2-15.png">View Course Map</a>
 	</h2>
   </div>
 </div>
@@ -180,7 +180,7 @@ MICRODATA:
 
 <p itemscope itemprop="Person" itemtype="https://schema.org/Person">
   <span itemprop="name">Christopher Froome</span> was sponsored by
-  <span itemprop="sponsor" itemtype="https://schema.org/Organization">
+  <span itemprop="sponsor" itemscope itemtype="https://schema.org/Organization">
     <a itemprop="url" href="http://www.skysports.com/">Sky</a></span> in the Tour de France.
 </p>
 

--- a/data/sdo-tourism-examples.txt
+++ b/data/sdo-tourism-examples.txt
@@ -467,27 +467,26 @@ JSON:
     "Event",
     "TouristAttraction"
   ],
-  "name": "The Falles 2017",
   "name": [
     {
-    "@language": "es",
-    "@value": "Las Fallas 2017"
+      "@language": "es",
+      "@value": "Las Fallas 2017"
     },
     {
-    "@language": "en",
-    "@value": "The Falles 2017"
+      "@language": "en",
+      "@value": "The Falles 2017"
     }
   ],
   "alternateName":"Les Falles 2017",
-  "description":"The Falles is a traditional celebration held in commemoration of Saint Joseph in the city of Valencia, Spain. The term Falles refers to both the celebration and the monuments burnt during the celebration. Added to UNESCO's intangible cultural heritage of humanity list on 30 November 2016.",
   "description":[
+    "The Falles is a traditional celebration held in commemoration of Saint Joseph in the city of Valencia, Spain. The term Falles refers to both the celebration and the monuments burnt during the celebration. Added to UNESCO's intangible cultural heritage of humanity list on 30 November 2016.",
     {
-    "@language": "es",
-    "@value": "Las Fallas son unas fiestas con una tradición arraigada en la ciudad de Valencia y diferentes poblaciones de la Comunidad Valenciana, y que se celebran en honor de San José. El término Falla se refiere a las propia fiestas y a los monumentos quemados en las calles de Valencia el día 19 de marzo. En noviembre de 2016 la Unesco las inscribió en su Lista Representativa del Patrimonio Cultural Inmaterial de la Humanidad."
+      "@language": "es",
+      "@value": "Las Fallas son unas fiestas con una tradición arraigada en la ciudad de Valencia y diferentes poblaciones de la Comunidad Valenciana, y que se celebran en honor de San José. El término Falla se refiere a las propia fiestas y a los monumentos quemados en las calles de Valencia el día 19 de marzo. En noviembre de 2016 la Unesco las inscribió en su Lista Representativa del Patrimonio Cultural Inmaterial de la Humanidad."
     },
     {
-    "@language": "en",
-    "@value": "The Falles is a traditional celebration held in commemoration of Saint Joseph in the city of Valencia, Spain. The term Falles refers to both the celebration and the monuments burnt during the celebration. Added to UNESCO's intangible cultural heritage of humanity list on 30 November 2016."
+      "@language": "en",
+      "@value": "The Falles is a traditional celebration held in commemoration of Saint Joseph in the city of Valencia, Spain. The term Falles refers to both the celebration and the monuments burnt during the celebration. Added to UNESCO's intangible cultural heritage of humanity list on 30 November 2016."
     }
   ],
   "startDate":"2017-03-15T09:00",
@@ -732,4 +731,3 @@ JSON:
   "image": "https://commons.wikimedia.org/wiki/File%3AFoto_Bodega_Rogers2.jpg"
 }
 </script>
-

--- a/data/sdo-visualartwork-examples.txt
+++ b/data/sdo-visualartwork-examples.txt
@@ -302,11 +302,13 @@ JSON:
           "sameAs": "https://www.freebase.com/m/015sxw"
         }
       ],
-      "artMedium": "bedsheets",
-      "artMedium": "condoms",
-      "artMedium": "a pair of knickers",
-      "artMedium": "pair of slippers",
-      "artMedium": "bed"
+      "artMedium": [
+        "bedsheets",
+        "condoms",
+        "a pair of knickers",
+        "pair of slippers",
+        "bed"
+      ]
     }
     </script>
 


### PR DESCRIPTION
(originally from @dpb587)

Data-related value changes:

Duration: use P prefix for valid ISO 8601 syntax.
temporalCoverage: use correct / delimiter for valid ISO 8601 ranges.
Enumeration: fix outdated/incorrect references.
Encoding-related syntax changes:

Microdata: add missing itemscope attributes.
RDFa: add missing vocab attributes; fix incorrect attributes; drop rdfa:usesVocabulary conversion artifact from JSON-LD.
JSON-LD: fix duplicate object keys for valid syntax; drop unused @context entry conversion artifacts.
And a couple other corrections to match sibling examples and to use more-valid stub values.