### PR TITLE
Enhanced specification of variant dimensions (#4885)

### DIFF
--- a/data/issue-4885-examples.txt
+++ b/data/issue-4885-examples.txt
@@ -1,0 +1,77 @@
+TYPES: #eg-4885 variesBy
+
+PRE-MARKUP:
+Markup snippet illustrating how to provide various variant dimensions (both native and non-native Schema.org properties) using PropertyValue to specify ranges of available values.
+
+MICRODATA:
+
+<!-- JSONLD only example -->
+
+RDFA: 
+
+<!-- JSONLD only example -->
+
+JSON:
+
+<script type="application/ld+json">
+
+{
+  "@context": "https://schema.org/",
+  "@type": "ProductGroup",
+  "variesBy": [
+    {
+      "@type": "PropertyValue",
+      "name": "color",
+      "value": ["black", "silver"]
+    },
+    {
+      "@type": "PropertyValue",
+      "name": "material",
+      "value": ["plastic", "aluminum"]
+    },
+    {
+      "@type": "PropertyValue",
+      "name": "Memory size",
+      "value": [16, 32, 64],
+      "unitCode": "E34",
+      "unitText": "GB"
+    },
+    {
+      "@type": "PropertyValue",
+      "name": "CPU",
+      "value": ["low_8core", "high_16core"]
+    },
+    {
+      "@type": "PropertyValue",
+      "name": "size",
+      "value": [
+        {
+          "@type": "SizeSpecification",
+          "name": ["XS", "S"],
+          "sizeSystem": "https://schema.org/WearableSizeSystemUS",
+          "sizeGroup": "https://schema.org/WearableSizeGroupPetite"
+        },
+        {
+          "@type": "SizeSpecification",
+          "name": ["M", "L"],
+          "sizeSystem": "https://schema.org/WearableSizeSystemUS",
+          "sizeGroup": "https://schema.org/WearableSizeGroupRegular"
+        },
+        {
+          "@type": "SizeSpecification",
+          "name": "XL",
+          "sizeSystem": "https://schema.org/WearableSizeSystemUS",
+          "sizeGroup": "https://schema.org/WearableSizeGroupPlus"
+        },
+        {
+          "@type": "SizeSpecification",
+          "name": ["XXL", "XXXL"],
+          "sizeSystem": "https://schema.org/WearableSizeSystemUS",
+          "sizeGroup": "https://schema.org/WearableSizeGroupBig"
+        }
+      ]
+    }
+  ]
+}
+
+ </script>

--- a/data/schema.ttl
+++ b/data/schema.ttl
@@ -13865,13 +13865,14 @@ This property can be used alongside the license property which indicates license
 
 :value a rdf:Property ;
     rdfs:label "value" ;
-    rdfs:comment "The value of a [[QuantitativeValue]] (including [[Observation]]) or property value node.\\n\\n* For [[QuantitativeValue]] and [[MonetaryAmount]], the recommended type for values is 'Number'.\\n* For [[PropertyValue]], it can be 'Text', 'Number', 'Boolean', or 'StructuredValue'.\\n* Use values from 0123456789 (Unicode 'DIGIT ZERO' (U+0030) to 'DIGIT NINE' (U+0039)) rather than superficially similar Unicode symbols.\\n* Use '.' (Unicode 'FULL STOP' (U+002E)) rather than ',' to indicate a decimal point. Avoid using these symbols as a readability separator." ;
+    rdfs:comment "The value of a [[QuantitativeValue]] (including [[Observation]]) or property value node.\\n\\n* For [[QuantitativeValue]] and [[MonetaryAmount]], the recommended type for values is 'Number'.\\n* For [[PropertyValue]], it can be 'Text', 'Number', 'Boolean', 'StructuredValue' or 'QualitativeValue'.\\n* Use values from 0123456789 (Unicode 'DIGIT ZERO' (U+0030) to 'DIGIT NINE' (U+0039)) rather than superficially similar Unicode symbols.\\n* Use '.' (Unicode 'FULL STOP' (U+002E)) rather than ',' to indicate a decimal point. Avoid using these symbols as a readability separator." ;
     :domainIncludes :MonetaryAmount,
         :PropertyValue,
         :QuantitativeValue ;
     :rangeIncludes :Boolean,
         :Number,
         :StructuredValue,
+        :QualitativeValue,
         :Text .
 
 :valueAddedTaxIncluded a rdf:Property ;
@@ -13938,11 +13939,13 @@ This property can be used alongside the license property which indicates license
 
 :variesBy a rdf:Property ;
     rdfs:label "variesBy" ;
-    rdfs:comment "Indicates the property or properties by which the variants in a [[ProductGroup]] vary, e.g. their size, color etc. Schema.org properties can be referenced by their short name e.g. \"color\"; terms defined elsewhere can be referenced with their URIs." ;
+    rdfs:comment "Indicates the property or properties by which the variants in a [[ProductGroup]] vary, e.g. their size, color etc. Schema.org properties can be referenced by their short name e.g. \"color\"; terms defined elsewhere can be referenced with their URIs. Variant properties can be provided using [[PropertyValue]] instead of plain [[Text]], to allow specification of the values available for a variant property." ;
     :domainIncludes :ProductGroup ;
     :rangeIncludes :DefinedTerm,
+        :PropertyValue,
         :Text ;
-    :source <https://github.com/schemaorg/schemaorg/issues/1797> .
+    :source <https://github.com/schemaorg/schemaorg/issues/1797>,
+        <https://github.com/schemaorg/schemaorg/issues/4885> .
 
 :vatID a rdf:Property ;
     rdfs:label "vatID" ;


### PR DESCRIPTION
Closes #4885 

Improve the modeling of variant dimensions of ```ProductGroup```:

- Add ```PropertyValue```  to the range of ```variesBy``` to allow specification of the available values for variant dimensions of a ProductGroup. 
- Add ```QualitativeValue``` to the range of ```value``` (under ```PropertyValue```) to allow ```SizeSpecification``` values (which are in the range of the ```size``` property).