### PR TITLE
Fix a few glitches in the file and site production

### DIFF
--- a/software/SchemaTerms/sdoterm.py
+++ b/software/SchemaTerms/sdoterm.py
@@ -42,6 +42,12 @@ class SdoTermOrId:
         self._term_id = term.id if term else term_id
         self._term = term
 
+    def _resolve(self) -> Optional["SdoTerm"]:
+        if not self._term and self._term_id:
+            from SchemaTerms.sdotermsource import SdoTermSource
+            self._term = SdoTermSource.getTerm(self._term_id)
+        return self._term
+
     @property
     def expanded(self) -> bool:
         return not self._term_id or bool(self._term)
@@ -52,15 +58,18 @@ class SdoTermOrId:
 
     @property
     def pending(self) -> bool:
-        return self._term.pending if self._term else False
+        term = self._resolve()
+        return term.pending if term else False
 
     @property
     def retired(self) -> bool:
-        return self._term.retired if self._term else False
+        term = self._resolve()
+        return term.retired if term else False
 
     @property
     def extLayer(self) -> str:
-        return self._term.extLayer if self._term else ""
+        term = self._resolve()
+        return term.extLayer if term else ""
 
     @property
     def term(self) -> "SdoTerm":

--- a/software/SchemaTerms/sdotermsource.py
+++ b/software/SchemaTerms/sdotermsource.py
@@ -603,7 +603,6 @@ class SdoTermSource:
 
     def _getParentPaths(self, term: sdoterm.SdoTerm, cstack: List[str]) -> None:
         cstack.insert(0, term.id)
-        tmpStacks: List[List[str]] = [cstack]
         super_ids: List[str] = list(term.supers.ids)
 
         if (
@@ -614,6 +613,12 @@ class SdoTermSource:
             assert term.enumerationParent.id is not None
             super_ids.append(term.enumerationParent.id)
 
+        super_ids = [
+            sid for sid in super_ids
+            if not (sid.startswith("http:") or sid.startswith("https:"))
+        ]
+
+        tmpStacks: List[List[str]] = [cstack]
         if super_ids:
             i: int
             for i in range(1, len(super_ids)):
@@ -624,10 +629,9 @@ class SdoTermSource:
             x: int
             parent_id: str
             for x, parent_id in enumerate(super_ids):
-                if not (parent_id.startswith("http:") or parent_id.startswith("https:")):
-                    sup: Optional[sdoterm.SdoTerm] = self.__class__._getTerm(parent_id)
-                    if sup:
-                        self._getParentPaths(sup, tmpStacks[x])
+                sup: Optional[sdoterm.SdoTerm] = self.__class__._getTerm(parent_id)
+                if sup:
+                    self._getParentPaths(sup, tmpStacks[x])
 
     @classmethod
     def getParentPathTo(cls, start_term_id: str, end_term_id: Optional[str] = None) -> List[List[str]]:

--- a/software/scripts/buildfiles.py
+++ b/software/scripts/buildfiles.py
@@ -254,6 +254,22 @@ def _exportrdf(output_format: str, all_graph: rdflib.Graph, current_graph: rdfli
         g_can: rdflib.Graph = to_canonical_graph(g)
         g_can.namespace_manager = ns_mgr
 
+        if output_format == "rdf":
+            g_out = rdflib.Graph()
+            g_out.namespace_manager = ns_mgr
+
+            def type_sort_key(trip: Tuple[Any, Any, Any]) -> Tuple[int, str, str]:
+                s, p, o = trip
+                if p == rdflib.RDF.type:
+                    if o == rdflib.RDFS.Class:
+                        return (0, str(s), str(o))
+                    return (1, str(s), str(o))
+                return (2, str(s), str(p))
+
+            for t in sorted(g_can, key=type_sort_key):
+                g_out.add(t)
+            g_can = g_out
+
         p: str
         for p in fileutils.FILESET_PROTOCOLS:
             final_g: Union[rdflib.Graph, rdflib.Dataset] = g_can

--- a/software/scripts/buildsite.py
+++ b/software/scripts/buildsite.py
@@ -397,7 +397,7 @@ if __name__ == "__main__":
         loadTerms(source="release")
         schema.config.OUTPUTDIR = "software/site"
 
-        if args.examplesnum or args.autobuild:
+        if args.examplesnum or args.autobuild or args.buildsite or any(args.terms) or any(args.files):
             with pretty_logger.BlockLog(
                 message="Checking Examples for assigned identifiers", logger=log
             ):

--- a/software/tests/test_sdotermsource.py
+++ b/software/tests/test_sdotermsource.py
@@ -111,6 +111,26 @@ class TestConversionFunctions(unittest.TestCase):
             "GoodRelations Vocabulary for E-Commerce", collaborator.acknowledgement
         )
 
+    def testParentPathsNoExternalDuplicates(self):
+        seller_paths = sdotermsource.SdoTermSource.getParentPathTo("seller")
+        self.assertEqual(seller_paths, [["Thing", "Property", "participant", "seller"]])
+
+        min_price_paths = sdotermsource.SdoTermSource.getParentPathTo("minPrice")
+        self.assertEqual(min_price_paths, [["Thing", "Property", "minPrice"]])
+
+    def testLazyResolution(self):
+        lazy_pending = sdoterm.SdoTermOrId(term_id="subTrip")
+        self.assertFalse(lazy_pending.expanded)
+        self.assertTrue(lazy_pending.pending)
+        self.assertFalse(lazy_pending.retired)
+        self.assertEqual(lazy_pending.extLayer, "pending")
+
+        lazy_attic = sdoterm.SdoTermOrId(term_id="variablesMeasured")
+        self.assertFalse(lazy_attic.expanded)
+        self.assertFalse(lazy_attic.pending)
+        self.assertTrue(lazy_attic.retired)
+        self.assertEqual(lazy_attic.extLayer, "attic")
+
 
 if __name__ == "__main__":
     unittest.main()


### PR DESCRIPTION
Some outputs contain minor issues, none of them changing the semantics of the schema though.

1. Inverse properties are now populated earlier (aka `resolve`d), so that they generate the needed info in pages (see `AutoRental` and its `funding` property).
2. The double breadcrumbs (see `minPrice`) is now fixed (does not produce the breadcrumb if it points outside of schema.org).
3. The ordering in XML files for certain nodes is now deterministic (by manually sorting the nodes).
4. Numbering of examples got more stability when new examples are added by checking in more modes.