### PR TITLE
Code handling schema in 'software/' only deals in https

### DIFF
--- a/data/public_stats/google/2026_05.csv
+++ b/data/public_stats/google/2026_05.csv
@@ -1,5546 +1,5546 @@
 Class,Name,Domain Bucket
-Itemtype,http://schema.org/3DModel,< 1K
-Itemtype,http://schema.org/AMRadioChannel,< 1K
-Itemtype,http://schema.org/APIReference,< 1K
-Itemtype,http://schema.org/AboutPage,100K - 1M
-Itemtype,http://schema.org/AcceptAction,< 1K
-Itemtype,http://schema.org/Accommodation,10K - 100K
-Itemtype,http://schema.org/AccountingService,10K - 100K
-Itemtype,http://schema.org/AchieveAction,< 1K
-Itemtype,http://schema.org/Action,10K - 100K
-Itemtype,http://schema.org/ActionAccessSpecification,< 1K
-Itemtype,http://schema.org/ActionStatusType,< 1K
-Itemtype,http://schema.org/ActivateAction,< 1K
-Itemtype,http://schema.org/AddAction,< 1K
-Itemtype,http://schema.org/AdministrativeArea,100K - 1M
-Itemtype,http://schema.org/AdultEntertainment,1K - 10K
-Itemtype,http://schema.org/AdultOrientedEnumeration,< 1K
-Itemtype,http://schema.org/AdvertiserContentArticle,1K - 10K
-Itemtype,http://schema.org/AggregateOffer,1M - 10M
-Itemtype,http://schema.org/AggregateRating,1M - 10M
-Itemtype,http://schema.org/AgreeAction,< 1K
-Itemtype,http://schema.org/Airline,1K - 10K
-Itemtype,http://schema.org/Airport,1K - 10K
-Itemtype,http://schema.org/AlignmentObject,1K - 10K
-Itemtype,http://schema.org/AllocateAction,< 1K
-Itemtype,http://schema.org/AmpStory,< 1K
-Itemtype,http://schema.org/AmusementPark,1K - 10K
-Itemtype,http://schema.org/AnalysisNewsArticle,1K - 10K
-Itemtype,http://schema.org/AnatomicalStructure,1K - 10K
-Itemtype,http://schema.org/AnatomicalSystem,< 1K
-Itemtype,http://schema.org/AnimalShelter,1K - 10K
-Itemtype,http://schema.org/Answer,1M - 10M
-Itemtype,http://schema.org/Apartment,10K - 100K
-Itemtype,http://schema.org/ApartmentComplex,10K - 100K
-Itemtype,http://schema.org/AppendAction,< 1K
-Itemtype,http://schema.org/ApplyAction,1K - 10K
-Itemtype,http://schema.org/ApprovedIndication,< 1K
-Itemtype,http://schema.org/Aquarium,< 1K
-Itemtype,http://schema.org/ArchiveComponent,< 1K
-Itemtype,http://schema.org/ArchiveOrganization,1K - 10K
-Itemtype,http://schema.org/ArriveAction,< 1K
-Itemtype,http://schema.org/ArtGallery,1K - 10K
-Itemtype,http://schema.org/Artery,< 1K
-Itemtype,http://schema.org/Article,1M - 10M
-Itemtype,http://schema.org/AskAction,< 1K
-Itemtype,http://schema.org/AskPublicNewsArticle,< 1K
-Itemtype,http://schema.org/AssessAction,< 1K
-Itemtype,http://schema.org/AssignAction,< 1K
-Itemtype,http://schema.org/Atlas,< 1K
-Itemtype,http://schema.org/Attorney,10K - 100K
-Itemtype,http://schema.org/Audience,100K - 1M
-Itemtype,http://schema.org/AudioObject,10K - 100K
-Itemtype,http://schema.org/AudioObjectSnapshot,< 1K
-Itemtype,http://schema.org/Audiobook,< 1K
-Itemtype,http://schema.org/AuthenticateAction,< 1K
-Itemtype,http://schema.org/AuthorizeAction,< 1K
-Itemtype,http://schema.org/AutoBodyShop,1K - 10K
-Itemtype,http://schema.org/AutoDealer,10K - 100K
-Itemtype,http://schema.org/AutoPartsStore,10K - 100K
-Itemtype,http://schema.org/AutoRental,1K - 10K
-Itemtype,http://schema.org/AutoRepair,10K - 100K
-Itemtype,http://schema.org/AutoWash,1K - 10K
-Itemtype,http://schema.org/AutomatedTeller,< 1K
-Itemtype,http://schema.org/AutomotiveBusiness,10K - 100K
-Itemtype,http://schema.org/BackgroundNewsArticle,< 1K
-Itemtype,http://schema.org/Bakery,1K - 10K
-Itemtype,http://schema.org/BankAccount,< 1K
-Itemtype,http://schema.org/BankOrCreditUnion,1K - 10K
-Itemtype,http://schema.org/BarOrPub,1K - 10K
-Itemtype,http://schema.org/Barcode,< 1K
-Itemtype,http://schema.org/Beach,1K - 10K
-Itemtype,http://schema.org/BeautySalon,10K - 100K
-Itemtype,http://schema.org/BedAndBreakfast,1K - 10K
-Itemtype,http://schema.org/BedDetails,10K - 100K
-Itemtype,http://schema.org/BedType,< 1K
-Itemtype,http://schema.org/BefriendAction,< 1K
-Itemtype,http://schema.org/BikeStore,1K - 10K
-Itemtype,http://schema.org/BioChemEntity,< 1K
-Itemtype,http://schema.org/Blog,1M - 10M
-Itemtype,http://schema.org/BlogPosting,1M - 10M
-Itemtype,http://schema.org/BloodTest,< 1K
-Itemtype,http://schema.org/BoardingPolicyType,< 1K
-Itemtype,http://schema.org/BoatReservation,< 1K
-Itemtype,http://schema.org/BoatTerminal,< 1K
-Itemtype,http://schema.org/BoatTrip,< 1K
-Itemtype,http://schema.org/BodyMeasurementTypeEnumeration,< 1K
-Itemtype,http://schema.org/BodyOfWater,< 1K
-Itemtype,http://schema.org/Bone,< 1K
-Itemtype,http://schema.org/Book,10K - 100K
-Itemtype,http://schema.org/BookFormatType,< 1K
-Itemtype,http://schema.org/BookSeries,1K - 10K
-Itemtype,http://schema.org/BookStore,1K - 10K
-Itemtype,http://schema.org/BookmarkAction,< 1K
-Itemtype,http://schema.org/Boolean,< 1K
-Itemtype,http://schema.org/BorrowAction,< 1K
-Itemtype,http://schema.org/BowlingAlley,< 1K
-Itemtype,http://schema.org/BrainStructure,< 1K
-Itemtype,http://schema.org/Brand,1M - 10M
-Itemtype,http://schema.org/BreadcrumbList,10M+
-Itemtype,http://schema.org/Brewery,1K - 10K
-Itemtype,http://schema.org/Bridge,< 1K
-Itemtype,http://schema.org/BroadcastChannel,< 1K
-Itemtype,http://schema.org/BroadcastEvent,10K - 100K
-Itemtype,http://schema.org/BroadcastFrequencySpecification,< 1K
-Itemtype,http://schema.org/BroadcastService,1K - 10K
-Itemtype,http://schema.org/BrokerageAccount,< 1K
-Itemtype,http://schema.org/BuddhistTemple,< 1K
-Itemtype,http://schema.org/BusOrCoach,< 1K
-Itemtype,http://schema.org/BusReservation,< 1K
-Itemtype,http://schema.org/BusStation,< 1K
-Itemtype,http://schema.org/BusStop,< 1K
-Itemtype,http://schema.org/BusTrip,< 1K
-Itemtype,http://schema.org/BusinessAudience,10K - 100K
-Itemtype,http://schema.org/BusinessEntityType,< 1K
-Itemtype,http://schema.org/BusinessEvent,1K - 10K
-Itemtype,http://schema.org/BusinessFunction,< 1K
-Itemtype,http://schema.org/BuyAction,10K - 100K
-Itemtype,http://schema.org/CDCPMDRecord,< 1K
-Itemtype,http://schema.org/CableOrSatelliteService,< 1K
-Itemtype,http://schema.org/CafeOrCoffeeShop,1K - 10K
-Itemtype,http://schema.org/Campground,1K - 10K
-Itemtype,http://schema.org/CampingPitch,< 1K
-Itemtype,http://schema.org/Canal,< 1K
-Itemtype,http://schema.org/CancelAction,< 1K
-Itemtype,http://schema.org/Car,10K - 100K
-Itemtype,http://schema.org/CarUsageType,< 1K
-Itemtype,http://schema.org/Casino,10K - 100K
-Itemtype,http://schema.org/CategoryCode,1K - 10K
-Itemtype,http://schema.org/CategoryCodeSet,< 1K
-Itemtype,http://schema.org/CatholicChurch,< 1K
-Itemtype,http://schema.org/Cemetery,< 1K
-Itemtype,http://schema.org/Certification,1K - 10K
-Itemtype,http://schema.org/CertificationStatusEnumeration,< 1K
-Itemtype,http://schema.org/Chapter,1K - 10K
-Itemtype,http://schema.org/CheckAction,< 1K
-Itemtype,http://schema.org/CheckInAction,< 1K
-Itemtype,http://schema.org/CheckOutAction,< 1K
-Itemtype,http://schema.org/CheckoutPage,1K - 10K
-Itemtype,http://schema.org/ChemicalSubstance,< 1K
-Itemtype,http://schema.org/ChildCare,1K - 10K
-Itemtype,http://schema.org/ChildrensEvent,< 1K
-Itemtype,http://schema.org/ChooseAction,1K - 10K
-Itemtype,http://schema.org/Church,1K - 10K
-Itemtype,http://schema.org/City,100K - 1M
-Itemtype,http://schema.org/CityHall,< 1K
-Itemtype,http://schema.org/CivicStructure,1K - 10K
-Itemtype,http://schema.org/Claim,1K - 10K
-Itemtype,http://schema.org/ClaimReview,1K - 10K
-Itemtype,http://schema.org/Class,< 1K
-Itemtype,http://schema.org/Clip,10K - 100K
-Itemtype,http://schema.org/ClothingStore,10K - 100K
-Itemtype,http://schema.org/Code,< 1K
-Itemtype,http://schema.org/Collection,10K - 100K
-Itemtype,http://schema.org/CollectionPage,1M - 10M
-Itemtype,http://schema.org/CollegeOrUniversity,10K - 100K
-Itemtype,http://schema.org/ComedyClub,< 1K
-Itemtype,http://schema.org/ComedyEvent,< 1K
-Itemtype,http://schema.org/ComicCoverArt,< 1K
-Itemtype,http://schema.org/ComicIssue,< 1K
-Itemtype,http://schema.org/ComicSeries,1K - 10K
-Itemtype,http://schema.org/ComicStory,< 1K
-Itemtype,http://schema.org/Comment,100K - 1M
-Itemtype,http://schema.org/CommentAction,1M - 10M
-Itemtype,http://schema.org/CommunicateAction,10K - 100K
-Itemtype,http://schema.org/CommunityHealth,1K - 10K
-Itemtype,http://schema.org/CompleteDataFeed,< 1K
-Itemtype,http://schema.org/CompoundPriceSpecification,1K - 10K
-Itemtype,http://schema.org/ComputerLanguage,< 1K
-Itemtype,http://schema.org/ComputerStore,1K - 10K
-Itemtype,http://schema.org/ConferenceEvent,< 1K
-Itemtype,http://schema.org/ConfirmAction,< 1K
-Itemtype,http://schema.org/Consortium,< 1K
-Itemtype,http://schema.org/ConstraintNode,< 1K
-Itemtype,http://schema.org/ConsumeAction,< 1K
-Itemtype,http://schema.org/ContactPage,100K - 1M
-Itemtype,http://schema.org/ContactPoint,1M - 10M
-Itemtype,http://schema.org/ContactPointOption,< 1K
-Itemtype,http://schema.org/Continent,1K - 10K
-Itemtype,http://schema.org/ControlAction,< 1K
-Itemtype,http://schema.org/ConvenienceStore,< 1K
-Itemtype,http://schema.org/Conversation,< 1K
-Itemtype,http://schema.org/CookAction,< 1K
-Itemtype,http://schema.org/Cooperative,< 1K
-Itemtype,http://schema.org/Corporation,100K - 1M
-Itemtype,http://schema.org/CorrectionComment,< 1K
-Itemtype,http://schema.org/Country,1M - 10M
-Itemtype,http://schema.org/Course,10K - 100K
-Itemtype,http://schema.org/CourseInstance,10K - 100K
-Itemtype,http://schema.org/Courthouse,< 1K
-Itemtype,http://schema.org/CoverArt,< 1K
-Itemtype,http://schema.org/CovidTestingFacility,< 1K
-Itemtype,http://schema.org/CreateAction,1K - 10K
-Itemtype,http://schema.org/CreativeWork,1M - 10M
-Itemtype,http://schema.org/CreativeWorkSeason,1K - 10K
-Itemtype,http://schema.org/CreativeWorkSeries,10K - 100K
-Itemtype,http://schema.org/Credential,10K - 100K
-Itemtype,http://schema.org/CreditCard,1K - 10K
-Itemtype,http://schema.org/Crematorium,< 1K
-Itemtype,http://schema.org/CriticReview,< 1K
-Itemtype,http://schema.org/CssSelectorType,< 1K
-Itemtype,http://schema.org/CurrencyConversionService,< 1K
-Itemtype,http://schema.org/DDxElement,< 1K
-Itemtype,http://schema.org/DENonprofitType,< 1K
-Itemtype,http://schema.org/DanceEvent,< 1K
-Itemtype,http://schema.org/DanceGroup,< 1K
-Itemtype,http://schema.org/DataCatalog,1K - 10K
-Itemtype,http://schema.org/DataDownload,10K - 100K
-Itemtype,http://schema.org/DataFeed,1K - 10K
-Itemtype,http://schema.org/DataFeedItem,1K - 10K
-Itemtype,http://schema.org/DataType,< 1K
-Itemtype,http://schema.org/Dataset,10K - 100K
-Itemtype,http://schema.org/Date,< 1K
-Itemtype,http://schema.org/DateTime,< 1K
-Itemtype,http://schema.org/DatedMoneySpecification,< 1K
-Itemtype,http://schema.org/DayOfWeek,10K - 100K
-Itemtype,http://schema.org/DaySpa,1K - 10K
-Itemtype,http://schema.org/DeactivateAction,< 1K
-Itemtype,http://schema.org/DefenceEstablishment,< 1K
-Itemtype,http://schema.org/DefinedRegion,100K - 1M
-Itemtype,http://schema.org/DefinedTerm,10K - 100K
-Itemtype,http://schema.org/DefinedTermSet,10K - 100K
-Itemtype,http://schema.org/DeleteAction,< 1K
-Itemtype,http://schema.org/DeliveryChargeSpecification,10K - 100K
-Itemtype,http://schema.org/DeliveryEvent,< 1K
-Itemtype,http://schema.org/DeliveryMethod,< 1K
-Itemtype,http://schema.org/DeliveryTimeSettings,< 1K
-Itemtype,http://schema.org/Demand,1K - 10K
-Itemtype,http://schema.org/Dentist,10K - 100K
-Itemtype,http://schema.org/DepartAction,< 1K
-Itemtype,http://schema.org/DepartmentStore,1K - 10K
-Itemtype,http://schema.org/DepositAccount,< 1K
-Itemtype,http://schema.org/Dermatology,< 1K
-Itemtype,http://schema.org/DiagnosticLab,1K - 10K
-Itemtype,http://schema.org/DiagnosticProcedure,< 1K
-Itemtype,http://schema.org/Diet,< 1K
-Itemtype,http://schema.org/DietNutrition,1K - 10K
-Itemtype,http://schema.org/DietarySupplement,< 1K
-Itemtype,http://schema.org/DigitalDocument,10K - 100K
-Itemtype,http://schema.org/DigitalDocumentPermission,< 1K
-Itemtype,http://schema.org/DigitalDocumentPermissionType,< 1K
-Itemtype,http://schema.org/DigitalPlatformEnumeration,< 1K
-Itemtype,http://schema.org/DisagreeAction,< 1K
-Itemtype,http://schema.org/DiscoverAction,< 1K
-Itemtype,http://schema.org/DiscussionForumPosting,10K - 100K
-Itemtype,http://schema.org/DislikeAction,1K - 10K
-Itemtype,http://schema.org/Distance,1K - 10K
-Itemtype,http://schema.org/Distillery,< 1K
-Itemtype,http://schema.org/DonateAction,1K - 10K
-Itemtype,http://schema.org/DoseSchedule,< 1K
-Itemtype,http://schema.org/DownloadAction,1K - 10K
-Itemtype,http://schema.org/DrawAction,< 1K
-Itemtype,http://schema.org/Drawing,< 1K
-Itemtype,http://schema.org/DrinkAction,< 1K
-Itemtype,http://schema.org/DriveWheelConfigurationValue,< 1K
-Itemtype,http://schema.org/Drug,1K - 10K
-Itemtype,http://schema.org/DrugClass,1K - 10K
-Itemtype,http://schema.org/DrugCost,< 1K
-Itemtype,http://schema.org/DrugCostCategory,< 1K
-Itemtype,http://schema.org/DrugLegalStatus,< 1K
-Itemtype,http://schema.org/DrugPregnancyCategory,< 1K
-Itemtype,http://schema.org/DrugPrescriptionStatus,< 1K
-Itemtype,http://schema.org/DrugStrength,< 1K
-Itemtype,http://schema.org/DryCleaningOrLaundry,1K - 10K
-Itemtype,http://schema.org/Duration,1K - 10K
-Itemtype,http://schema.org/EUEnergyEfficiencyEnumeration,< 1K
-Itemtype,http://schema.org/EatAction,< 1K
-Itemtype,http://schema.org/EducationEvent,1K - 10K
-Itemtype,http://schema.org/EducationalAudience,10K - 100K
-Itemtype,http://schema.org/EducationalOccupationalCredential,10K - 100K
-Itemtype,http://schema.org/EducationalOccupationalProgram,1K - 10K
-Itemtype,http://schema.org/EducationalOrganization,100K - 1M
-Itemtype,http://schema.org/Electrician,10K - 100K
-Itemtype,http://schema.org/ElectronicsStore,1K - 10K
-Itemtype,http://schema.org/ElementarySchool,< 1K
-Itemtype,http://schema.org/EmailMessage,< 1K
-Itemtype,http://schema.org/Embassy,< 1K
-Itemtype,http://schema.org/Emergency,< 1K
-Itemtype,http://schema.org/EmergencyService,1K - 10K
-Itemtype,http://schema.org/EmployeeRole,< 1K
-Itemtype,http://schema.org/EmployerAggregateRating,1K - 10K
-Itemtype,http://schema.org/EmployerReview,< 1K
-Itemtype,http://schema.org/EmploymentAgency,1K - 10K
-Itemtype,http://schema.org/EndorseAction,< 1K
-Itemtype,http://schema.org/EndorsementRating,< 1K
-Itemtype,http://schema.org/Energy,< 1K
-Itemtype,http://schema.org/EnergyConsumptionDetails,1K - 10K
-Itemtype,http://schema.org/EnergyEfficiencyEnumeration,< 1K
-Itemtype,http://schema.org/EnergyStarEnergyEfficiencyEnumeration,< 1K
-Itemtype,http://schema.org/EngineSpecification,10K - 100K
-Itemtype,http://schema.org/EntertainmentBusiness,10K - 100K
-Itemtype,http://schema.org/EntryPoint,10M+
-Itemtype,http://schema.org/Enumeration,1K - 10K
-Itemtype,http://schema.org/Episode,1K - 10K
-Itemtype,http://schema.org/Error,< 1K
-Itemtype,http://schema.org/Event,100K - 1M
-Itemtype,http://schema.org/EventAttendanceModeEnumeration,< 1K
-Itemtype,http://schema.org/EventReservation,< 1K
-Itemtype,http://schema.org/EventSeries,1K - 10K
-Itemtype,http://schema.org/EventStatusType,< 1K
-Itemtype,http://schema.org/EventVenue,10K - 100K
-Itemtype,http://schema.org/ExchangeRateSpecification,< 1K
-Itemtype,http://schema.org/ExerciseAction,< 1K
-Itemtype,http://schema.org/ExerciseGym,1K - 10K
-Itemtype,http://schema.org/ExercisePlan,< 1K
-Itemtype,http://schema.org/ExhibitionEvent,1K - 10K
-Itemtype,http://schema.org/FAQPage,1M - 10M
-Itemtype,http://schema.org/FMRadioChannel,< 1K
-Itemtype,http://schema.org/FastFoodRestaurant,1K - 10K
-Itemtype,http://schema.org/Festival,1K - 10K
-Itemtype,http://schema.org/FilmAction,< 1K
-Itemtype,http://schema.org/FinancialIncentive,< 1K
-Itemtype,http://schema.org/FinancialProduct,10K - 100K
-Itemtype,http://schema.org/FinancialService,10K - 100K
-Itemtype,http://schema.org/FindAction,< 1K
-Itemtype,http://schema.org/FireStation,< 1K
-Itemtype,http://schema.org/Flight,1K - 10K
-Itemtype,http://schema.org/FlightReservation,< 1K
-Itemtype,http://schema.org/Float,< 1K
-Itemtype,http://schema.org/FloorPlan,10K - 100K
-Itemtype,http://schema.org/Florist,10K - 100K
-Itemtype,http://schema.org/FollowAction,10K - 100K
-Itemtype,http://schema.org/FoodEstablishment,10K - 100K
-Itemtype,http://schema.org/FoodEstablishmentReservation,1K - 10K
-Itemtype,http://schema.org/FoodEvent,1K - 10K
-Itemtype,http://schema.org/FoodService,1K - 10K
-Itemtype,http://schema.org/FulfillmentTypeEnumeration,< 1K
-Itemtype,http://schema.org/FundingAgency,< 1K
-Itemtype,http://schema.org/FundingScheme,< 1K
-Itemtype,http://schema.org/FurnitureStore,10K - 100K
-Itemtype,http://schema.org/Game,100K - 1M
-Itemtype,http://schema.org/GameAvailabilityEnumeration,< 1K
-Itemtype,http://schema.org/GamePlayMode,< 1K
-Itemtype,http://schema.org/GameServer,1K - 10K
-Itemtype,http://schema.org/GameServerStatus,< 1K
-Itemtype,http://schema.org/GardenStore,1K - 10K
-Itemtype,http://schema.org/GasStation,1K - 10K
-Itemtype,http://schema.org/GatedResidenceCommunity,< 1K
-Itemtype,http://schema.org/GenderType,< 1K
-Itemtype,http://schema.org/Gene,< 1K
-Itemtype,http://schema.org/GeneralContractor,10K - 100K
-Itemtype,http://schema.org/GeoCircle,100K - 1M
-Itemtype,http://schema.org/GeoCoordinates,1M - 10M
-Itemtype,http://schema.org/GeoShape,10K - 100K
-Itemtype,http://schema.org/GeospatialGeometry,< 1K
-Itemtype,http://schema.org/Geriatric,< 1K
-Itemtype,http://schema.org/GiveAction,< 1K
-Itemtype,http://schema.org/GolfCourse,1K - 10K
-Itemtype,http://schema.org/GovernmentBenefitsType,< 1K
-Itemtype,http://schema.org/GovernmentBuilding,< 1K
-Itemtype,http://schema.org/GovernmentOffice,1K - 10K
-Itemtype,http://schema.org/GovernmentOrganization,10K - 100K
-Itemtype,http://schema.org/GovernmentPermit,< 1K
-Itemtype,http://schema.org/GovernmentService,1K - 10K
-Itemtype,http://schema.org/Grant,1K - 10K
-Itemtype,http://schema.org/GroceryStore,1K - 10K
-Itemtype,http://schema.org/Guide,1K - 10K
-Itemtype,http://schema.org/Gynecologic,< 1K
-Itemtype,http://schema.org/HVACBusiness,10K - 100K
-Itemtype,http://schema.org/Hackathon,< 1K
-Itemtype,http://schema.org/HairSalon,10K - 100K
-Itemtype,http://schema.org/HardwareStore,1K - 10K
-Itemtype,http://schema.org/HealthAndBeautyBusiness,10K - 100K
-Itemtype,http://schema.org/HealthAspectEnumeration,< 1K
-Itemtype,http://schema.org/HealthClub,1K - 10K
-Itemtype,http://schema.org/HealthInsurancePlan,< 1K
-Itemtype,http://schema.org/HealthPlanCostSharingSpecification,< 1K
-Itemtype,http://schema.org/HealthPlanFormulary,< 1K
-Itemtype,http://schema.org/HealthPlanNetwork,< 1K
-Itemtype,http://schema.org/HealthTopicContent,< 1K
-Itemtype,http://schema.org/HighSchool,1K - 10K
-Itemtype,http://schema.org/HinduTemple,< 1K
-Itemtype,http://schema.org/HobbyShop,1K - 10K
-Itemtype,http://schema.org/HomeAndConstructionBusiness,100K - 1M
-Itemtype,http://schema.org/HomeGoodsStore,1K - 10K
-Itemtype,http://schema.org/Hospital,10K - 100K
-Itemtype,http://schema.org/Hostel,1K - 10K
-Itemtype,http://schema.org/Hotel,10K - 100K
-Itemtype,http://schema.org/HotelRoom,10K - 100K
-Itemtype,http://schema.org/House,10K - 100K
-Itemtype,http://schema.org/HousePainter,1K - 10K
-Itemtype,http://schema.org/HowTo,100K - 1M
-Itemtype,http://schema.org/HowToDirection,10K - 100K
-Itemtype,http://schema.org/HowToItem,< 1K
-Itemtype,http://schema.org/HowToSection,10K - 100K
-Itemtype,http://schema.org/HowToStep,100K - 1M
-Itemtype,http://schema.org/HowToSupply,10K - 100K
-Itemtype,http://schema.org/HowToTip,1K - 10K
-Itemtype,http://schema.org/HowToTool,10K - 100K
-Itemtype,http://schema.org/HyperToc,< 1K
-Itemtype,http://schema.org/HyperTocEntry,< 1K
-Itemtype,http://schema.org/IPTCDigitalSourceEnumeration,< 1K
-Itemtype,http://schema.org/ITNonprofitType,< 1K
-Itemtype,http://schema.org/IceCreamShop,1K - 10K
-Itemtype,http://schema.org/IgnoreAction,< 1K
-Itemtype,http://schema.org/ImageGallery,1M - 10M
-Itemtype,http://schema.org/ImageObject,10M+
-Itemtype,http://schema.org/ImageObjectSnapshot,< 1K
-Itemtype,http://schema.org/ImagingTest,< 1K
-Itemtype,http://schema.org/IncentiveQualifiedExpenseType,< 1K
-Itemtype,http://schema.org/IncentiveStatus,< 1K
-Itemtype,http://schema.org/IncentiveType,< 1K
-Itemtype,http://schema.org/IndividualPhysician,1K - 10K
-Itemtype,http://schema.org/IndividualProduct,10K - 100K
-Itemtype,http://schema.org/InfectiousAgentClass,< 1K
-Itemtype,http://schema.org/InfectiousDisease,< 1K
-Itemtype,http://schema.org/InformAction,< 1K
-Itemtype,http://schema.org/InsertAction,< 1K
-Itemtype,http://schema.org/InstallAction,< 1K
-Itemtype,http://schema.org/InstantaneousEvent,< 1K
-Itemtype,http://schema.org/InsuranceAgency,10K - 100K
-Itemtype,http://schema.org/Intangible,1K - 10K
-Itemtype,http://schema.org/Integer,< 1K
-Itemtype,http://schema.org/InteractAction,1K - 10K
-Itemtype,http://schema.org/InteractionCounter,100K - 1M
-Itemtype,http://schema.org/InternetCafe,< 1K
-Itemtype,http://schema.org/InvestmentFund,< 1K
-Itemtype,http://schema.org/InvestmentOrDeposit,< 1K
-Itemtype,http://schema.org/InviteAction,< 1K
-Itemtype,http://schema.org/Invoice,< 1K
-Itemtype,http://schema.org/ItemAvailability,1K - 10K
-Itemtype,http://schema.org/ItemList,1M - 10M
-Itemtype,http://schema.org/ItemListOrderType,< 1K
-Itemtype,http://schema.org/ItemPage,1M - 10M
-Itemtype,http://schema.org/JewelryStore,10K - 100K
-Itemtype,http://schema.org/JobPosting,100K - 1M
-Itemtype,http://schema.org/JoinAction,1K - 10K
-Itemtype,http://schema.org/Joint,< 1K
-Itemtype,http://schema.org/LakeBodyOfWater,< 1K
-Itemtype,http://schema.org/Landform,1K - 10K
-Itemtype,http://schema.org/LandmarksOrHistoricalBuildings,1K - 10K
-Itemtype,http://schema.org/Language,10K - 100K
-Itemtype,http://schema.org/LearningResource,1K - 10K
-Itemtype,http://schema.org/LeaveAction,< 1K
-Itemtype,http://schema.org/LegalForceStatus,< 1K
-Itemtype,http://schema.org/LegalService,10K - 100K
-Itemtype,http://schema.org/LegalValueLevel,< 1K
-Itemtype,http://schema.org/Legislation,1K - 10K
-Itemtype,http://schema.org/LegislationObject,1K - 10K
-Itemtype,http://schema.org/LegislativeBuilding,< 1K
-Itemtype,http://schema.org/LendAction,< 1K
-Itemtype,http://schema.org/Library,1K - 10K
-Itemtype,http://schema.org/LibrarySystem,< 1K
-Itemtype,http://schema.org/LifestyleModification,< 1K
-Itemtype,http://schema.org/Ligament,< 1K
-Itemtype,http://schema.org/LikeAction,10K - 100K
-Itemtype,http://schema.org/LinkRole,< 1K
-Itemtype,http://schema.org/LiquorStore,1K - 10K
-Itemtype,http://schema.org/ListItem,10M+
-Itemtype,http://schema.org/ListenAction,1K - 10K
-Itemtype,http://schema.org/Literal,< 1K
-Itemtype,http://schema.org/LiteraryEvent,< 1K
-Itemtype,http://schema.org/LiveBlogPosting,10K - 100K
-Itemtype,http://schema.org/LoanOrCredit,1K - 10K
-Itemtype,http://schema.org/LocalBusiness,1M - 10M
-Itemtype,http://schema.org/LocationFeatureSpecification,100K - 1M
-Itemtype,http://schema.org/Locksmith,10K - 100K
-Itemtype,http://schema.org/LodgingBusiness,10K - 100K
-Itemtype,http://schema.org/LodgingReservation,1K - 10K
-Itemtype,http://schema.org/LoginAction,1K - 10K
-Itemtype,http://schema.org/LoseAction,< 1K
-Itemtype,http://schema.org/LymphaticVessel,< 1K
-Itemtype,http://schema.org/Manuscript,< 1K
-Itemtype,http://schema.org/Map,10K - 100K
-Itemtype,http://schema.org/MapCategoryType,< 1K
-Itemtype,http://schema.org/MarryAction,< 1K
-Itemtype,http://schema.org/Mass,< 1K
-Itemtype,http://schema.org/MathSolver,< 1K
-Itemtype,http://schema.org/MaximumDoseSchedule,< 1K
-Itemtype,http://schema.org/MeasurementMethodEnum,< 1K
-Itemtype,http://schema.org/MeasurementTypeEnumeration,< 1K
-Itemtype,http://schema.org/MediaEnumeration,< 1K
-Itemtype,http://schema.org/MediaGallery,1K - 10K
-Itemtype,http://schema.org/MediaManipulationRatingEnumeration,< 1K
-Itemtype,http://schema.org/MediaObject,100K - 1M
-Itemtype,http://schema.org/MediaReview,< 1K
-Itemtype,http://schema.org/MediaReviewItem,< 1K
-Itemtype,http://schema.org/MediaSubscription,< 1K
-Itemtype,http://schema.org/MedicalAudience,1K - 10K
-Itemtype,http://schema.org/MedicalAudienceType,< 1K
-Itemtype,http://schema.org/MedicalBusiness,10K - 100K
-Itemtype,http://schema.org/MedicalCause,1K - 10K
-Itemtype,http://schema.org/MedicalClinic,10K - 100K
-Itemtype,http://schema.org/MedicalCode,1K - 10K
-Itemtype,http://schema.org/MedicalCondition,10K - 100K
-Itemtype,http://schema.org/MedicalConditionStage,< 1K
-Itemtype,http://schema.org/MedicalContraindication,< 1K
-Itemtype,http://schema.org/MedicalDevice,1K - 10K
-Itemtype,http://schema.org/MedicalDevicePurpose,< 1K
-Itemtype,http://schema.org/MedicalEntity,1K - 10K
-Itemtype,http://schema.org/MedicalEnumeration,< 1K
-Itemtype,http://schema.org/MedicalEvidenceLevel,< 1K
-Itemtype,http://schema.org/MedicalGuideline,< 1K
-Itemtype,http://schema.org/MedicalGuidelineContraindication,< 1K
-Itemtype,http://schema.org/MedicalGuidelineRecommendation,< 1K
-Itemtype,http://schema.org/MedicalImagingTechnique,< 1K
-Itemtype,http://schema.org/MedicalIndication,1K - 10K
-Itemtype,http://schema.org/MedicalIntangible,< 1K
-Itemtype,http://schema.org/MedicalObservationalStudy,< 1K
-Itemtype,http://schema.org/MedicalObservationalStudyDesign,< 1K
-Itemtype,http://schema.org/MedicalOrganization,10K - 100K
-Itemtype,http://schema.org/MedicalProcedure,10K - 100K
-Itemtype,http://schema.org/MedicalProcedureType,< 1K
-Itemtype,http://schema.org/MedicalRiskCalculator,< 1K
-Itemtype,http://schema.org/MedicalRiskEstimator,< 1K
-Itemtype,http://schema.org/MedicalRiskFactor,1K - 10K
-Itemtype,http://schema.org/MedicalRiskScore,< 1K
-Itemtype,http://schema.org/MedicalScholarlyArticle,1K - 10K
-Itemtype,http://schema.org/MedicalSign,< 1K
-Itemtype,http://schema.org/MedicalSignOrSymptom,1K - 10K
-Itemtype,http://schema.org/MedicalSpecialty,10K - 100K
-Itemtype,http://schema.org/MedicalStudy,1K - 10K
-Itemtype,http://schema.org/MedicalStudyStatus,< 1K
-Itemtype,http://schema.org/MedicalSymptom,1K - 10K
-Itemtype,http://schema.org/MedicalTest,1K - 10K
-Itemtype,http://schema.org/MedicalTestPanel,< 1K
-Itemtype,http://schema.org/MedicalTherapy,10K - 100K
-Itemtype,http://schema.org/MedicalTrial,< 1K
-Itemtype,http://schema.org/MedicalTrialDesign,< 1K
-Itemtype,http://schema.org/MedicalWebPage,10K - 100K
-Itemtype,http://schema.org/MedicineSystem,< 1K
-Itemtype,http://schema.org/MeetingRoom,1K - 10K
-Itemtype,http://schema.org/MemberProgram,1K - 10K
-Itemtype,http://schema.org/MemberProgramTier,1K - 10K
-Itemtype,http://schema.org/MensClothingStore,< 1K
-Itemtype,http://schema.org/Menu,100K - 1M
-Itemtype,http://schema.org/MenuItem,10K - 100K
-Itemtype,http://schema.org/MenuSection,10K - 100K
-Itemtype,http://schema.org/MerchantReturnEnumeration,< 1K
-Itemtype,http://schema.org/MerchantReturnPolicy,100K - 1M
-Itemtype,http://schema.org/MerchantReturnPolicySeasonalOverride,< 1K
-Itemtype,http://schema.org/Message,< 1K
-Itemtype,http://schema.org/MiddleSchool,< 1K
-Itemtype,http://schema.org/Midwifery,< 1K
-Itemtype,http://schema.org/MobileApplication,10K - 100K
-Itemtype,http://schema.org/MobilePhoneStore,1K - 10K
-Itemtype,http://schema.org/MolecularEntity,< 1K
-Itemtype,http://schema.org/MonetaryAmount,100K - 1M
-Itemtype,http://schema.org/MonetaryAmountDistribution,1K - 10K
-Itemtype,http://schema.org/MonetaryGrant,1K - 10K
-Itemtype,http://schema.org/MoneyTransfer,< 1K
-Itemtype,http://schema.org/MortgageLoan,< 1K
-Itemtype,http://schema.org/Mosque,< 1K
-Itemtype,http://schema.org/Motel,< 1K
-Itemtype,http://schema.org/Motorcycle,1K - 10K
-Itemtype,http://schema.org/MotorcycleDealer,1K - 10K
-Itemtype,http://schema.org/MotorcycleRepair,< 1K
-Itemtype,http://schema.org/MotorizedBicycle,< 1K
-Itemtype,http://schema.org/Mountain,< 1K
-Itemtype,http://schema.org/MoveAction,< 1K
-Itemtype,http://schema.org/Movie,10K - 100K
-Itemtype,http://schema.org/MovieClip,< 1K
-Itemtype,http://schema.org/MovieRentalStore,< 1K
-Itemtype,http://schema.org/MovieSeries,< 1K
-Itemtype,http://schema.org/MovieTheater,1K - 10K
-Itemtype,http://schema.org/MovingCompany,10K - 100K
-Itemtype,http://schema.org/Muscle,< 1K
-Itemtype,http://schema.org/Museum,1K - 10K
-Itemtype,http://schema.org/MusicAlbum,10K - 100K
-Itemtype,http://schema.org/MusicAlbumProductionType,< 1K
-Itemtype,http://schema.org/MusicAlbumReleaseType,< 1K
-Itemtype,http://schema.org/MusicComposition,1K - 10K
-Itemtype,http://schema.org/MusicEvent,10K - 100K
-Itemtype,http://schema.org/MusicGroup,10K - 100K
-Itemtype,http://schema.org/MusicPlaylist,1K - 10K
-Itemtype,http://schema.org/MusicRecording,10K - 100K
-Itemtype,http://schema.org/MusicRelease,1K - 10K
-Itemtype,http://schema.org/MusicReleaseFormatType,< 1K
-Itemtype,http://schema.org/MusicStore,1K - 10K
-Itemtype,http://schema.org/MusicVenue,1K - 10K
-Itemtype,http://schema.org/MusicVideoObject,< 1K
-Itemtype,http://schema.org/NGO,10K - 100K
-Itemtype,http://schema.org/NLNonprofitType,< 1K
-Itemtype,http://schema.org/NailSalon,1K - 10K
-Itemtype,http://schema.org/Nerve,< 1K
-Itemtype,http://schema.org/NewsArticle,100K - 1M
-Itemtype,http://schema.org/NewsMediaOrganization,10K - 100K
-Itemtype,http://schema.org/Newspaper,< 1K
-Itemtype,http://schema.org/NightClub,1K - 10K
-Itemtype,http://schema.org/NonprofitType,< 1K
-Itemtype,http://schema.org/Notary,1K - 10K
-Itemtype,http://schema.org/NoteDigitalDocument,< 1K
-Itemtype,http://schema.org/Number,< 1K
-Itemtype,http://schema.org/Nursing,< 1K
-Itemtype,http://schema.org/NutritionInformation,10K - 100K
-Itemtype,http://schema.org/Observation,< 1K
-Itemtype,http://schema.org/Obstetric,< 1K
-Itemtype,http://schema.org/Occupation,10K - 100K
-Itemtype,http://schema.org/OccupationalExperienceRequirements,1K - 10K
-Itemtype,http://schema.org/OccupationalTherapy,< 1K
-Itemtype,http://schema.org/OceanBodyOfWater,< 1K
-Itemtype,http://schema.org/Offer,1M - 10M
-Itemtype,http://schema.org/OfferCatalog,100K - 1M
-Itemtype,http://schema.org/OfferForLease,1K - 10K
-Itemtype,http://schema.org/OfferForPurchase,1K - 10K
-Itemtype,http://schema.org/OfferItemCondition,1K - 10K
-Itemtype,http://schema.org/OfferShippingDetails,100K - 1M
-Itemtype,http://schema.org/OfficeEquipmentStore,1K - 10K
-Itemtype,http://schema.org/OnDemandEvent,< 1K
-Itemtype,http://schema.org/Oncologic,< 1K
-Itemtype,http://schema.org/OnlineBusiness,10K - 100K
-Itemtype,http://schema.org/OnlineMarketplace,< 1K
-Itemtype,http://schema.org/OnlineStore,100K - 1M
-Itemtype,http://schema.org/OpeningHoursSpecification,1M - 10M
-Itemtype,http://schema.org/OperatingSystem,< 1K
-Itemtype,http://schema.org/OpinionNewsArticle,1K - 10K
-Itemtype,http://schema.org/Optician,1K - 10K
-Itemtype,http://schema.org/Optometric,1K - 10K
-Itemtype,http://schema.org/Order,< 1K
-Itemtype,http://schema.org/OrderAction,10K - 100K
-Itemtype,http://schema.org/OrderItem,< 1K
-Itemtype,http://schema.org/OrderStatus,< 1K
-Itemtype,http://schema.org/Organization,10M+
-Itemtype,http://schema.org/OrganizationRole,1K - 10K
-Itemtype,http://schema.org/OrganizeAction,< 1K
-Itemtype,http://schema.org/Otolaryngologic,< 1K
-Itemtype,http://schema.org/OutletStore,< 1K
-Itemtype,http://schema.org/OwnershipInfo,< 1K
-Itemtype,http://schema.org/PaintAction,< 1K
-Itemtype,http://schema.org/Painting,< 1K
-Itemtype,http://schema.org/PalliativeProcedure,< 1K
-Itemtype,http://schema.org/ParcelDelivery,< 1K
-Itemtype,http://schema.org/ParentAudience,< 1K
-Itemtype,http://schema.org/Park,1K - 10K
-Itemtype,http://schema.org/ParkingFacility,1K - 10K
-Itemtype,http://schema.org/PathologyTest,< 1K
-Itemtype,http://schema.org/Patient,1K - 10K
-Itemtype,http://schema.org/PawnShop,< 1K
-Itemtype,http://schema.org/PayAction,< 1K
-Itemtype,http://schema.org/PaymentCard,< 1K
-Itemtype,http://schema.org/PaymentChargeSpecification,< 1K
-Itemtype,http://schema.org/PaymentMethod,10K - 100K
-Itemtype,http://schema.org/PaymentMethodType,< 1K
-Itemtype,http://schema.org/PaymentService,1K - 10K
-Itemtype,http://schema.org/PaymentStatusType,< 1K
-Itemtype,http://schema.org/Pediatric,< 1K
-Itemtype,http://schema.org/PeopleAudience,10K - 100K
-Itemtype,http://schema.org/PerformAction,< 1K
-Itemtype,http://schema.org/PerformanceRole,< 1K
-Itemtype,http://schema.org/PerformingArtsEvent,< 1K
-Itemtype,http://schema.org/PerformingArtsTheater,1K - 10K
-Itemtype,http://schema.org/PerformingGroup,10K - 100K
-Itemtype,http://schema.org/Periodical,1K - 10K
-Itemtype,http://schema.org/Permit,10K - 100K
-Itemtype,http://schema.org/Person,10M+
-Itemtype,http://schema.org/PetStore,1K - 10K
-Itemtype,http://schema.org/Pharmacy,10K - 100K
-Itemtype,http://schema.org/Photograph,10K - 100K
-Itemtype,http://schema.org/PhotographAction,< 1K
-Itemtype,http://schema.org/PhysicalActivity,< 1K
-Itemtype,http://schema.org/PhysicalActivityCategory,1K - 10K
-Itemtype,http://schema.org/PhysicalExam,< 1K
-Itemtype,http://schema.org/PhysicalTherapy,< 1K
-Itemtype,http://schema.org/Physician,10K - 100K
-Itemtype,http://schema.org/PhysiciansOffice,< 1K
-Itemtype,http://schema.org/Physiotherapy,1K - 10K
-Itemtype,http://schema.org/Place,1M - 10M
-Itemtype,http://schema.org/PlaceOfWorship,1K - 10K
-Itemtype,http://schema.org/PlanAction,< 1K
-Itemtype,http://schema.org/PlasticSurgery,< 1K
-Itemtype,http://schema.org/Play,< 1K
-Itemtype,http://schema.org/PlayAction,10K - 100K
-Itemtype,http://schema.org/PlayGameAction,< 1K
-Itemtype,http://schema.org/Playground,< 1K
-Itemtype,http://schema.org/Plumber,10K - 100K
-Itemtype,http://schema.org/PodcastEpisode,10K - 100K
-Itemtype,http://schema.org/PodcastSeason,< 1K
-Itemtype,http://schema.org/PodcastSeries,10K - 100K
-Itemtype,http://schema.org/Podiatric,< 1K
-Itemtype,http://schema.org/PoliceStation,< 1K
-Itemtype,http://schema.org/PoliticalParty,< 1K
-Itemtype,http://schema.org/Pond,< 1K
-Itemtype,http://schema.org/PostOffice,< 1K
-Itemtype,http://schema.org/PostalAddress,1M - 10M
-Itemtype,http://schema.org/PostalCodeRangeSpecification,1K - 10K
-Itemtype,http://schema.org/Poster,< 1K
-Itemtype,http://schema.org/PreOrderAction,< 1K
-Itemtype,http://schema.org/PrependAction,< 1K
-Itemtype,http://schema.org/Preschool,1K - 10K
-Itemtype,http://schema.org/PresentationDigitalDocument,< 1K
-Itemtype,http://schema.org/PreventionIndication,< 1K
-Itemtype,http://schema.org/PriceComponentTypeEnumeration,< 1K
-Itemtype,http://schema.org/PriceSpecification,100K - 1M
-Itemtype,http://schema.org/PriceTypeEnumeration,< 1K
-Itemtype,http://schema.org/PrimaryCare,< 1K
-Itemtype,http://schema.org/Product,1M - 10M
-Itemtype,http://schema.org/ProductCollection,1K - 10K
-Itemtype,http://schema.org/ProductGroup,100K - 1M
-Itemtype,http://schema.org/ProductModel,1K - 10K
-Itemtype,http://schema.org/ProductReturnEnumeration,< 1K
-Itemtype,http://schema.org/ProductReturnPolicy,< 1K
-Itemtype,http://schema.org/ProfessionalService,100K - 1M
-Itemtype,http://schema.org/ProfilePage,100K - 1M
-Itemtype,http://schema.org/ProgramMembership,1K - 10K
-Itemtype,http://schema.org/Project,1K - 10K
-Itemtype,http://schema.org/PronounceableText,< 1K
-Itemtype,http://schema.org/Property,< 1K
-Itemtype,http://schema.org/PropertyValue,100K - 1M
-Itemtype,http://schema.org/PropertyValueSpecification,10M+
-Itemtype,http://schema.org/Protein,< 1K
-Itemtype,http://schema.org/Psychiatric,1K - 10K
-Itemtype,http://schema.org/PsychologicalTreatment,< 1K
-Itemtype,http://schema.org/PublicHealth,< 1K
-Itemtype,http://schema.org/PublicSwimmingPool,< 1K
-Itemtype,http://schema.org/PublicToilet,< 1K
-Itemtype,http://schema.org/PublicationEvent,1K - 10K
-Itemtype,http://schema.org/PublicationIssue,1K - 10K
-Itemtype,http://schema.org/PublicationVolume,1K - 10K
-Itemtype,http://schema.org/PurchaseType,< 1K
-Itemtype,http://schema.org/QAPage,10K - 100K
-Itemtype,http://schema.org/QualitativeValue,1K - 10K
-Itemtype,http://schema.org/QuantitativeValue,1M - 10M
-Itemtype,http://schema.org/QuantitativeValueDistribution,< 1K
-Itemtype,http://schema.org/Quantity,< 1K
-Itemtype,http://schema.org/Question,1M - 10M
-Itemtype,http://schema.org/Quiz,1K - 10K
-Itemtype,http://schema.org/Quotation,1K - 10K
-Itemtype,http://schema.org/QuoteAction,1K - 10K
-Itemtype,http://schema.org/RVPark,< 1K
-Itemtype,http://schema.org/RadiationTherapy,< 1K
-Itemtype,http://schema.org/RadioBroadcastService,< 1K
-Itemtype,http://schema.org/RadioChannel,< 1K
-Itemtype,http://schema.org/RadioClip,< 1K
-Itemtype,http://schema.org/RadioEpisode,1K - 10K
-Itemtype,http://schema.org/RadioSeason,< 1K
-Itemtype,http://schema.org/RadioSeries,1K - 10K
-Itemtype,http://schema.org/RadioStation,1K - 10K
-Itemtype,http://schema.org/Rating,1M - 10M
-Itemtype,http://schema.org/ReactAction,< 1K
-Itemtype,http://schema.org/ReadAction,10M+
-Itemtype,http://schema.org/RealEstateAgent,100K - 1M
-Itemtype,http://schema.org/RealEstateListing,10K - 100K
-Itemtype,http://schema.org/ReceiveAction,< 1K
-Itemtype,http://schema.org/Recipe,10K - 100K
-Itemtype,http://schema.org/Recommendation,< 1K
-Itemtype,http://schema.org/RecommendedDoseSchedule,< 1K
-Itemtype,http://schema.org/RecyclingCenter,1K - 10K
-Itemtype,http://schema.org/RefundTypeEnumeration,< 1K
-Itemtype,http://schema.org/RegisterAction,1K - 10K
-Itemtype,http://schema.org/RejectAction,< 1K
-Itemtype,http://schema.org/RentAction,1K - 10K
-Itemtype,http://schema.org/RentalCarReservation,< 1K
-Itemtype,http://schema.org/RepaymentSpecification,< 1K
-Itemtype,http://schema.org/ReplaceAction,< 1K
-Itemtype,http://schema.org/ReplyAction,1K - 10K
-Itemtype,http://schema.org/Report,1K - 10K
-Itemtype,http://schema.org/ReportageNewsArticle,1K - 10K
-Itemtype,http://schema.org/ReportedDoseSchedule,< 1K
-Itemtype,http://schema.org/ResearchOrganization,1K - 10K
-Itemtype,http://schema.org/ResearchProject,1K - 10K
-Itemtype,http://schema.org/Researcher,< 1K
-Itemtype,http://schema.org/Reservation,10K - 100K
-Itemtype,http://schema.org/ReservationPackage,< 1K
-Itemtype,http://schema.org/ReservationStatusType,< 1K
-Itemtype,http://schema.org/ReserveAction,10K - 100K
-Itemtype,http://schema.org/Reservoir,< 1K
-Itemtype,http://schema.org/ResetPasswordAction,< 1K
-Itemtype,http://schema.org/Residence,10K - 100K
-Itemtype,http://schema.org/Resort,1K - 10K
-Itemtype,http://schema.org/RespiratoryTherapy,< 1K
-Itemtype,http://schema.org/Restaurant,100K - 1M
-Itemtype,http://schema.org/RestrictedDiet,1K - 10K
-Itemtype,http://schema.org/ResumeAction,< 1K
-Itemtype,http://schema.org/ReturnAction,< 1K
-Itemtype,http://schema.org/ReturnFeesEnumeration,< 1K
-Itemtype,http://schema.org/ReturnLabelSourceEnumeration,< 1K
-Itemtype,http://schema.org/ReturnMethodEnumeration,< 1K
-Itemtype,http://schema.org/Review,1M - 10M
-Itemtype,http://schema.org/ReviewAction,1K - 10K
-Itemtype,http://schema.org/ReviewNewsArticle,< 1K
-Itemtype,http://schema.org/RiverBodyOfWater,< 1K
-Itemtype,http://schema.org/Role,1K - 10K
-Itemtype,http://schema.org/RoofingContractor,10K - 100K
-Itemtype,http://schema.org/Room,1K - 10K
-Itemtype,http://schema.org/RsvpAction,< 1K
-Itemtype,http://schema.org/RsvpResponseType,< 1K
-Itemtype,http://schema.org/RuntimePlatform,< 1K
-Itemtype,http://schema.org/SaleEvent,1K - 10K
-Itemtype,http://schema.org/SatiricalArticle,< 1K
-Itemtype,http://schema.org/Schedule,10K - 100K
-Itemtype,http://schema.org/ScheduleAction,1K - 10K
-Itemtype,http://schema.org/ScholarlyArticle,10K - 100K
-Itemtype,http://schema.org/School,1K - 10K
-Itemtype,http://schema.org/SchoolDistrict,< 1K
-Itemtype,http://schema.org/ScreeningEvent,< 1K
-Itemtype,http://schema.org/Sculpture,< 1K
-Itemtype,http://schema.org/SeaBodyOfWater,< 1K
-Itemtype,http://schema.org/SearchAction,10M+
-Itemtype,http://schema.org/SearchRescueOrganization,< 1K
-Itemtype,http://schema.org/SearchResultsPage,10K - 100K
-Itemtype,http://schema.org/Season,< 1K
-Itemtype,http://schema.org/Seat,< 1K
-Itemtype,http://schema.org/SeekToAction,10K - 100K
-Itemtype,http://schema.org/SelfStorage,1K - 10K
-Itemtype,http://schema.org/SellAction,1K - 10K
-Itemtype,http://schema.org/SendAction,< 1K
-Itemtype,http://schema.org/SequentialArt,< 1K
-Itemtype,http://schema.org/Series,10K - 100K
-Itemtype,http://schema.org/Service,1M - 10M
-Itemtype,http://schema.org/ServiceChannel,10K - 100K
-Itemtype,http://schema.org/ServicePeriod,1K - 10K
-Itemtype,http://schema.org/ShareAction,10K - 100K
-Itemtype,http://schema.org/SheetMusic,< 1K
-Itemtype,http://schema.org/ShippingConditions,10K - 100K
-Itemtype,http://schema.org/ShippingDeliveryTime,100K - 1M
-Itemtype,http://schema.org/ShippingRateSettings,< 1K
-Itemtype,http://schema.org/ShippingService,10K - 100K
-Itemtype,http://schema.org/ShoeStore,1K - 10K
-Itemtype,http://schema.org/ShoppingCenter,1K - 10K
-Itemtype,http://schema.org/ShortStory,< 1K
-Itemtype,http://schema.org/SingleFamilyResidence,10K - 100K
-Itemtype,http://schema.org/SiteNavigationElement,1M - 10M
-Itemtype,http://schema.org/SizeGroupEnumeration,< 1K
-Itemtype,http://schema.org/SizeSpecification,1K - 10K
-Itemtype,http://schema.org/SizeSystemEnumeration,< 1K
-Itemtype,http://schema.org/SkiResort,< 1K
-Itemtype,http://schema.org/SocialEvent,1K - 10K
-Itemtype,http://schema.org/SocialMediaPosting,10K - 100K
-Itemtype,http://schema.org/SoftwareApplication,100K - 1M
-Itemtype,http://schema.org/SoftwareSourceCode,1K - 10K
-Itemtype,http://schema.org/SolveMathAction,< 1K
-Itemtype,http://schema.org/SomeProducts,10K - 100K
-Itemtype,http://schema.org/SpeakableSpecification,100K - 1M
-Itemtype,http://schema.org/SpecialAnnouncement,1K - 10K
-Itemtype,http://schema.org/Specialty,1K - 10K
-Itemtype,http://schema.org/SportingGoodsStore,1K - 10K
-Itemtype,http://schema.org/SportsActivityLocation,10K - 100K
-Itemtype,http://schema.org/SportsClub,1K - 10K
-Itemtype,http://schema.org/SportsEvent,10K - 100K
-Itemtype,http://schema.org/SportsOrganization,10K - 100K
-Itemtype,http://schema.org/SportsTeam,10K - 100K
-Itemtype,http://schema.org/SpreadsheetDigitalDocument,< 1K
-Itemtype,http://schema.org/StadiumOrArena,1K - 10K
-Itemtype,http://schema.org/State,100K - 1M
-Itemtype,http://schema.org/Statement,< 1K
-Itemtype,http://schema.org/StatisticalPopulation,< 1K
-Itemtype,http://schema.org/StatisticalVariable,< 1K
-Itemtype,http://schema.org/StatusEnumeration,< 1K
-Itemtype,http://schema.org/SteeringPositionValue,< 1K
-Itemtype,http://schema.org/Store,100K - 1M
-Itemtype,http://schema.org/StructuredValue,1K - 10K
-Itemtype,http://schema.org/StupidType,< 1K
-Itemtype,http://schema.org/SubscribeAction,10K - 100K
-Itemtype,http://schema.org/Substance,< 1K
-Itemtype,http://schema.org/SubwayStation,< 1K
-Itemtype,http://schema.org/Suite,< 1K
-Itemtype,http://schema.org/SuperficialAnatomy,< 1K
-Itemtype,http://schema.org/SurgicalProcedure,< 1K
-Itemtype,http://schema.org/SuspendAction,< 1K
-Itemtype,http://schema.org/Syllabus,1K - 10K
-Itemtype,http://schema.org/Synagogue,< 1K
-Itemtype,http://schema.org/TVClip,< 1K
-Itemtype,http://schema.org/TVEpisode,1K - 10K
-Itemtype,http://schema.org/TVSeason,1K - 10K
-Itemtype,http://schema.org/TVSeries,10K - 100K
-Itemtype,http://schema.org/Table,10K - 100K
-Itemtype,http://schema.org/TakeAction,< 1K
-Itemtype,http://schema.org/TattooParlor,1K - 10K
-Itemtype,http://schema.org/Taxi,< 1K
-Itemtype,http://schema.org/TaxiReservation,< 1K
-Itemtype,http://schema.org/TaxiService,1K - 10K
-Itemtype,http://schema.org/TaxiStand,< 1K
-Itemtype,http://schema.org/Taxon,< 1K
-Itemtype,http://schema.org/TechArticle,10K - 100K
-Itemtype,http://schema.org/TelevisionChannel,< 1K
-Itemtype,http://schema.org/TelevisionStation,< 1K
-Itemtype,http://schema.org/TennisComplex,< 1K
-Itemtype,http://schema.org/Text,10K - 100K
-Itemtype,http://schema.org/TextDigitalDocument,< 1K
-Itemtype,http://schema.org/TextObject,1K - 10K
-Itemtype,http://schema.org/TheaterEvent,1K - 10K
-Itemtype,http://schema.org/TheaterGroup,1K - 10K
-Itemtype,http://schema.org/TherapeuticProcedure,1K - 10K
-Itemtype,http://schema.org/Thesis,< 1K
-Itemtype,http://schema.org/Thing,10M+
-Itemtype,http://schema.org/Ticket,< 1K
-Itemtype,http://schema.org/TieAction,< 1K
-Itemtype,http://schema.org/TierBenefitEnumeration,< 1K
-Itemtype,http://schema.org/Time,< 1K
-Itemtype,http://schema.org/TipAction,< 1K
-Itemtype,http://schema.org/TireShop,1K - 10K
-Itemtype,http://schema.org/TouristAttraction,10K - 100K
-Itemtype,http://schema.org/TouristDestination,10K - 100K
-Itemtype,http://schema.org/TouristInformationCenter,1K - 10K
-Itemtype,http://schema.org/TouristTrip,10K - 100K
-Itemtype,http://schema.org/ToyStore,1K - 10K
-Itemtype,http://schema.org/TrackAction,< 1K
-Itemtype,http://schema.org/TradeAction,1K - 10K
-Itemtype,http://schema.org/TrainReservation,< 1K
-Itemtype,http://schema.org/TrainStation,< 1K
-Itemtype,http://schema.org/TrainTrip,< 1K
-Itemtype,http://schema.org/TransferAction,< 1K
-Itemtype,http://schema.org/TravelAction,1K - 10K
-Itemtype,http://schema.org/TravelAgency,10K - 100K
-Itemtype,http://schema.org/TreatmentIndication,< 1K
-Itemtype,http://schema.org/Trip,10K - 100K
-Itemtype,http://schema.org/TypeAndQuantityNode,< 1K
-Itemtype,http://schema.org/UKNonprofitType,< 1K
-Itemtype,http://schema.org/URL,1K - 10K
-Itemtype,http://schema.org/USNonprofitType,< 1K
-Itemtype,http://schema.org/UnRegisterAction,< 1K
-Itemtype,http://schema.org/UnitPriceSpecification,1M - 10M
-Itemtype,http://schema.org/UpdateAction,< 1K
-Itemtype,http://schema.org/UseAction,1K - 10K
-Itemtype,http://schema.org/UserBlocks,< 1K
-Itemtype,http://schema.org/UserCheckins,1K - 10K
-Itemtype,http://schema.org/UserComments,10K - 100K
-Itemtype,http://schema.org/UserDownloads,< 1K
-Itemtype,http://schema.org/UserInteraction,< 1K
-Itemtype,http://schema.org/UserLikes,< 1K
-Itemtype,http://schema.org/UserPageVisits,< 1K
-Itemtype,http://schema.org/UserPlays,< 1K
-Itemtype,http://schema.org/UserPlusOnes,< 1K
-Itemtype,http://schema.org/UserReview,1K - 10K
-Itemtype,http://schema.org/UserTweets,< 1K
-Itemtype,http://schema.org/VacationRental,10K - 100K
-Itemtype,http://schema.org/Vehicle,10K - 100K
-Itemtype,http://schema.org/Vein,< 1K
-Itemtype,http://schema.org/Vessel,< 1K
-Itemtype,http://schema.org/VeterinaryCare,1K - 10K
-Itemtype,http://schema.org/VideoGallery,1K - 10K
-Itemtype,http://schema.org/VideoGame,10K - 100K
-Itemtype,http://schema.org/VideoGameClip,< 1K
-Itemtype,http://schema.org/VideoGameSeries,< 1K
-Itemtype,http://schema.org/VideoObject,1M - 10M
-Itemtype,http://schema.org/VideoObjectSnapshot,< 1K
-Itemtype,http://schema.org/ViewAction,10K - 100K
-Itemtype,http://schema.org/VirtualLocation,10K - 100K
-Itemtype,http://schema.org/VisualArtsEvent,< 1K
-Itemtype,http://schema.org/VisualArtwork,1K - 10K
-Itemtype,http://schema.org/VitalSign,< 1K
-Itemtype,http://schema.org/Volcano,< 1K
-Itemtype,http://schema.org/VoteAction,< 1K
-Itemtype,http://schema.org/WPAdBlock,10K - 100K
-Itemtype,http://schema.org/WPFooter,1M - 10M
-Itemtype,http://schema.org/WPHeader,1M - 10M
-Itemtype,http://schema.org/WPSideBar,1M - 10M
-Itemtype,http://schema.org/WantAction,< 1K
-Itemtype,http://schema.org/WarrantyPromise,10K - 100K
-Itemtype,http://schema.org/WarrantyScope,< 1K
-Itemtype,http://schema.org/WatchAction,10K - 100K
-Itemtype,http://schema.org/Waterfall,< 1K
-Itemtype,http://schema.org/WearAction,< 1K
-Itemtype,http://schema.org/WearableMeasurementTypeEnumeration,< 1K
-Itemtype,http://schema.org/WearableSizeGroupEnumeration,< 1K
-Itemtype,http://schema.org/WearableSizeSystemEnumeration,< 1K
-Itemtype,http://schema.org/WebAPI,1K - 10K
-Itemtype,http://schema.org/WebApplication,100K - 1M
-Itemtype,http://schema.org/WebContent,1K - 10K
-Itemtype,http://schema.org/WebPage,10M+
-Itemtype,http://schema.org/WebPageElement,1M - 10M
-Itemtype,http://schema.org/WebSite,10M+
-Itemtype,http://schema.org/WholesaleStore,1K - 10K
-Itemtype,http://schema.org/WinAction,< 1K
-Itemtype,http://schema.org/Winery,1K - 10K
-Itemtype,http://schema.org/WorkBasedProgram,< 1K
-Itemtype,http://schema.org/WorkersUnion,< 1K
-Itemtype,http://schema.org/WriteAction,10K - 100K
-Itemtype,http://schema.org/XPathType,< 1K
-Itemtype,http://schema.org/Zoo,< 1K
-Predicate,http://schema.org/about,10M+
-Predicate,http://schema.org/about-input,< 1K
-Predicate,http://schema.org/about-output,< 1K
-Predicate,http://schema.org/abridged,< 1K
-Predicate,http://schema.org/abridged-input,< 1K
-Predicate,http://schema.org/abridged-output,< 1K
-Predicate,http://schema.org/abstract,10K - 100K
-Predicate,http://schema.org/abstract-input,< 1K
-Predicate,http://schema.org/abstract-output,< 1K
-Predicate,http://schema.org/accelerationTime,1K - 10K
-Predicate,http://schema.org/accelerationTime-input,< 1K
-Predicate,http://schema.org/accelerationTime-output,< 1K
-Predicate,http://schema.org/acceptedAnswer,1M - 10M
-Predicate,http://schema.org/acceptedAnswer-input,< 1K
-Predicate,http://schema.org/acceptedAnswer-output,< 1K
-Predicate,http://schema.org/acceptedOffer,< 1K
-Predicate,http://schema.org/acceptedOffer-input,< 1K
-Predicate,http://schema.org/acceptedOffer-output,< 1K
-Predicate,http://schema.org/acceptedPaymentMethod,10K - 100K
-Predicate,http://schema.org/acceptedPaymentMethod-input,< 1K
-Predicate,http://schema.org/acceptedPaymentMethod-output,< 1K
-Predicate,http://schema.org/acceptsReservations,100K - 1M
-Predicate,http://schema.org/acceptsReservations-input,< 1K
-Predicate,http://schema.org/acceptsReservations-output,< 1K
-Predicate,http://schema.org/accessCode,< 1K
-Predicate,http://schema.org/accessCode-input,< 1K
-Predicate,http://schema.org/accessCode-output,< 1K
-Predicate,http://schema.org/accessMode,1K - 10K
-Predicate,http://schema.org/accessMode-input,< 1K
-Predicate,http://schema.org/accessMode-output,< 1K
-Predicate,http://schema.org/accessModeSufficient,1K - 10K
-Predicate,http://schema.org/accessModeSufficient-input,< 1K
-Predicate,http://schema.org/accessModeSufficient-output,< 1K
-Predicate,http://schema.org/accessibilityAPI,1K - 10K
-Predicate,http://schema.org/accessibilityAPI-input,< 1K
-Predicate,http://schema.org/accessibilityAPI-output,< 1K
-Predicate,http://schema.org/accessibilityControl,1K - 10K
-Predicate,http://schema.org/accessibilityControl-input,< 1K
-Predicate,http://schema.org/accessibilityControl-output,< 1K
-Predicate,http://schema.org/accessibilityFeature,10K - 100K
-Predicate,http://schema.org/accessibilityFeature-input,< 1K
-Predicate,http://schema.org/accessibilityFeature-output,< 1K
-Predicate,http://schema.org/accessibilityHazard,1K - 10K
-Predicate,http://schema.org/accessibilityHazard-input,< 1K
-Predicate,http://schema.org/accessibilityHazard-output,< 1K
-Predicate,http://schema.org/accessibilitySummary,10K - 100K
-Predicate,http://schema.org/accessibilitySummary-input,< 1K
-Predicate,http://schema.org/accessibilitySummary-output,< 1K
-Predicate,http://schema.org/accommodationCategory,1K - 10K
-Predicate,http://schema.org/accommodationCategory-input,< 1K
-Predicate,http://schema.org/accommodationCategory-output,< 1K
-Predicate,http://schema.org/accommodationFloorPlan,10K - 100K
-Predicate,http://schema.org/accommodationFloorPlan-input,< 1K
-Predicate,http://schema.org/accommodationFloorPlan-output,< 1K
-Predicate,http://schema.org/accountId,< 1K
-Predicate,http://schema.org/accountId-input,< 1K
-Predicate,http://schema.org/accountId-output,< 1K
-Predicate,http://schema.org/accountMinimumInflow,< 1K
-Predicate,http://schema.org/accountMinimumInflow-input,< 1K
-Predicate,http://schema.org/accountMinimumInflow-output,< 1K
-Predicate,http://schema.org/accountOverdraftLimit,< 1K
-Predicate,http://schema.org/accountOverdraftLimit-input,< 1K
-Predicate,http://schema.org/accountOverdraftLimit-output,< 1K
-Predicate,http://schema.org/accountablePerson,10K - 100K
-Predicate,http://schema.org/accountablePerson-input,< 1K
-Predicate,http://schema.org/accountablePerson-output,< 1K
-Predicate,http://schema.org/acquireLicensePage,10K - 100K
-Predicate,http://schema.org/acquireLicensePage-input,< 1K
-Predicate,http://schema.org/acquireLicensePage-output,< 1K
-Predicate,http://schema.org/acquiredFrom,< 1K
-Predicate,http://schema.org/acquiredFrom-input,< 1K
-Predicate,http://schema.org/acquiredFrom-output,< 1K
-Predicate,http://schema.org/acrissCode,< 1K
-Predicate,http://schema.org/acrissCode-input,< 1K
-Predicate,http://schema.org/acrissCode-output,< 1K
-Predicate,http://schema.org/actionAccessibilityRequirement,< 1K
-Predicate,http://schema.org/actionAccessibilityRequirement-input,< 1K
-Predicate,http://schema.org/actionAccessibilityRequirement-output,< 1K
-Predicate,http://schema.org/actionApplication,1K - 10K
-Predicate,http://schema.org/actionApplication-input,< 1K
-Predicate,http://schema.org/actionApplication-output,< 1K
-Predicate,http://schema.org/actionOption,1K - 10K
-Predicate,http://schema.org/actionOption-input,< 1K
-Predicate,http://schema.org/actionOption-output,< 1K
-Predicate,http://schema.org/actionPlatform,100K - 1M
-Predicate,http://schema.org/actionPlatform-input,< 1K
-Predicate,http://schema.org/actionPlatform-output,< 1K
-Predicate,http://schema.org/actionProcess,< 1K
-Predicate,http://schema.org/actionProcess-input,< 1K
-Predicate,http://schema.org/actionProcess-output,< 1K
-Predicate,http://schema.org/actionStatus,10K - 100K
-Predicate,http://schema.org/actionStatus-input,< 1K
-Predicate,http://schema.org/actionStatus-output,< 1K
-Predicate,http://schema.org/actionableFeedbackPolicy,10K - 100K
-Predicate,http://schema.org/actionableFeedbackPolicy-input,< 1K
-Predicate,http://schema.org/actionableFeedbackPolicy-output,< 1K
-Predicate,http://schema.org/activeIngredient,1K - 10K
-Predicate,http://schema.org/activeIngredient-input,< 1K
-Predicate,http://schema.org/activeIngredient-output,< 1K
-Predicate,http://schema.org/activityDuration,< 1K
-Predicate,http://schema.org/activityDuration-input,< 1K
-Predicate,http://schema.org/activityDuration-output,< 1K
-Predicate,http://schema.org/activityFrequency,< 1K
-Predicate,http://schema.org/activityFrequency-input,< 1K
-Predicate,http://schema.org/activityFrequency-output,< 1K
-Predicate,http://schema.org/actor,10K - 100K
-Predicate,http://schema.org/actor-input,< 1K
-Predicate,http://schema.org/actor-output,< 1K
-Predicate,http://schema.org/actors,1K - 10K
-Predicate,http://schema.org/actors-input,< 1K
-Predicate,http://schema.org/actors-output,< 1K
-Predicate,http://schema.org/addOn,1K - 10K
-Predicate,http://schema.org/addOn-input,< 1K
-Predicate,http://schema.org/addOn-output,< 1K
-Predicate,http://schema.org/additionalName,10K - 100K
-Predicate,http://schema.org/additionalName-input,< 1K
-Predicate,http://schema.org/additionalName-output,< 1K
-Predicate,http://schema.org/additionalNumberOfGuests,< 1K
-Predicate,http://schema.org/additionalNumberOfGuests-input,< 1K
-Predicate,http://schema.org/additionalNumberOfGuests-output,< 1K
-Predicate,http://schema.org/additionalProperty,100K - 1M
-Predicate,http://schema.org/additionalProperty-input,< 1K
-Predicate,http://schema.org/additionalProperty-output,< 1K
-Predicate,http://schema.org/additionalType,100K - 1M
-Predicate,http://schema.org/additionalType-input,< 1K
-Predicate,http://schema.org/additionalType-output,< 1K
-Predicate,http://schema.org/additionalVariable,< 1K
-Predicate,http://schema.org/additionalVariable-input,< 1K
-Predicate,http://schema.org/additionalVariable-output,< 1K
-Predicate,http://schema.org/address,1M - 10M
-Predicate,http://schema.org/address-input,< 1K
-Predicate,http://schema.org/address-output,< 1K
-Predicate,http://schema.org/addressCountry,1M - 10M
-Predicate,http://schema.org/addressCountry-input,< 1K
-Predicate,http://schema.org/addressCountry-output,< 1K
-Predicate,http://schema.org/addressLocality,1M - 10M
-Predicate,http://schema.org/addressLocality-input,< 1K
-Predicate,http://schema.org/addressLocality-output,< 1K
-Predicate,http://schema.org/addressRegion,1M - 10M
-Predicate,http://schema.org/addressRegion-input,< 1K
-Predicate,http://schema.org/addressRegion-output,< 1K
-Predicate,http://schema.org/administrationRoute,1K - 10K
-Predicate,http://schema.org/administrationRoute-input,< 1K
-Predicate,http://schema.org/administrationRoute-output,< 1K
-Predicate,http://schema.org/advanceBookingRequirement,< 1K
-Predicate,http://schema.org/advanceBookingRequirement-input,< 1K
-Predicate,http://schema.org/advanceBookingRequirement-output,< 1K
-Predicate,http://schema.org/adverseOutcome,< 1K
-Predicate,http://schema.org/adverseOutcome-input,< 1K
-Predicate,http://schema.org/adverseOutcome-output,< 1K
-Predicate,http://schema.org/affectedBy,< 1K
-Predicate,http://schema.org/affectedBy-input,< 1K
-Predicate,http://schema.org/affectedBy-output,< 1K
-Predicate,http://schema.org/affiliation,10K - 100K
-Predicate,http://schema.org/affiliation-input,< 1K
-Predicate,http://schema.org/affiliation-output,< 1K
-Predicate,http://schema.org/afterMedia,< 1K
-Predicate,http://schema.org/afterMedia-input,< 1K
-Predicate,http://schema.org/afterMedia-output,< 1K
-Predicate,http://schema.org/agent,10K - 100K
-Predicate,http://schema.org/agent-input,< 1K
-Predicate,http://schema.org/agent-output,< 1K
-Predicate,http://schema.org/agentInteractionStatistic,10K - 100K
-Predicate,http://schema.org/agentInteractionStatistic-input,< 1K
-Predicate,http://schema.org/agentInteractionStatistic-output,< 1K
-Predicate,http://schema.org/aggregateElement,< 1K
-Predicate,http://schema.org/aggregateElement-input,< 1K
-Predicate,http://schema.org/aggregateElement-output,< 1K
-Predicate,http://schema.org/aggregateRating,1M - 10M
-Predicate,http://schema.org/aggregateRating-input,< 1K
-Predicate,http://schema.org/aggregateRating-output,< 1K
-Predicate,http://schema.org/aircraft,< 1K
-Predicate,http://schema.org/aircraft-input,< 1K
-Predicate,http://schema.org/aircraft-output,< 1K
-Predicate,http://schema.org/album,1K - 10K
-Predicate,http://schema.org/album-input,< 1K
-Predicate,http://schema.org/album-output,< 1K
-Predicate,http://schema.org/albumProductionType,< 1K
-Predicate,http://schema.org/albumProductionType-input,< 1K
-Predicate,http://schema.org/albumProductionType-output,< 1K
-Predicate,http://schema.org/albumRelease,1K - 10K
-Predicate,http://schema.org/albumRelease-input,< 1K
-Predicate,http://schema.org/albumRelease-output,< 1K
-Predicate,http://schema.org/albumReleaseType,1K - 10K
-Predicate,http://schema.org/albumReleaseType-input,< 1K
-Predicate,http://schema.org/albumReleaseType-output,< 1K
-Predicate,http://schema.org/albums,< 1K
-Predicate,http://schema.org/albums-input,< 1K
-Predicate,http://schema.org/albums-output,< 1K
-Predicate,http://schema.org/alcoholWarning,< 1K
-Predicate,http://schema.org/alcoholWarning-input,< 1K
-Predicate,http://schema.org/alcoholWarning-output,< 1K
-Predicate,http://schema.org/algorithm,< 1K
-Predicate,http://schema.org/algorithm-input,< 1K
-Predicate,http://schema.org/algorithm-output,< 1K
-Predicate,http://schema.org/alignmentType,1K - 10K
-Predicate,http://schema.org/alignmentType-input,< 1K
-Predicate,http://schema.org/alignmentType-output,< 1K
-Predicate,http://schema.org/alternateName,1M - 10M
-Predicate,http://schema.org/alternateName-input,< 1K
-Predicate,http://schema.org/alternateName-output,< 1K
-Predicate,http://schema.org/alternativeHeadline,100K - 1M
-Predicate,http://schema.org/alternativeHeadline-input,< 1K
-Predicate,http://schema.org/alternativeHeadline-output,< 1K
-Predicate,http://schema.org/alternativeOf,< 1K
-Predicate,http://schema.org/alternativeOf-input,< 1K
-Predicate,http://schema.org/alternativeOf-output,< 1K
-Predicate,http://schema.org/alumni,1K - 10K
-Predicate,http://schema.org/alumni-input,< 1K
-Predicate,http://schema.org/alumni-output,< 1K
-Predicate,http://schema.org/alumniOf,100K - 1M
-Predicate,http://schema.org/alumniOf-input,< 1K
-Predicate,http://schema.org/alumniOf-output,< 1K
-Predicate,http://schema.org/amenityFeature,100K - 1M
-Predicate,http://schema.org/amenityFeature-input,< 1K
-Predicate,http://schema.org/amenityFeature-output,< 1K
-Predicate,http://schema.org/amount,1K - 10K
-Predicate,http://schema.org/amount-input,< 1K
-Predicate,http://schema.org/amount-output,< 1K
-Predicate,http://schema.org/amountOfThisGood,< 1K
-Predicate,http://schema.org/amountOfThisGood-input,< 1K
-Predicate,http://schema.org/amountOfThisGood-output,< 1K
-Predicate,http://schema.org/announcementLocation,1K - 10K
-Predicate,http://schema.org/announcementLocation-input,< 1K
-Predicate,http://schema.org/announcementLocation-output,< 1K
-Predicate,http://schema.org/annualPercentageRate,1K - 10K
-Predicate,http://schema.org/annualPercentageRate-input,< 1K
-Predicate,http://schema.org/annualPercentageRate-output,< 1K
-Predicate,http://schema.org/answerCount,100K - 1M
-Predicate,http://schema.org/answerCount-input,< 1K
-Predicate,http://schema.org/answerCount-output,< 1K
-Predicate,http://schema.org/answerExplanation,< 1K
-Predicate,http://schema.org/answerExplanation-input,< 1K
-Predicate,http://schema.org/answerExplanation-output,< 1K
-Predicate,http://schema.org/antagonist,< 1K
-Predicate,http://schema.org/antagonist-input,< 1K
-Predicate,http://schema.org/antagonist-output,< 1K
-Predicate,http://schema.org/appearance,1K - 10K
-Predicate,http://schema.org/appearance-input,< 1K
-Predicate,http://schema.org/appearance-output,< 1K
-Predicate,http://schema.org/applicableCountry,100K - 1M
-Predicate,http://schema.org/applicableCountry-input,< 1K
-Predicate,http://schema.org/applicableCountry-output,< 1K
-Predicate,http://schema.org/applicableLocation,< 1K
-Predicate,http://schema.org/applicableLocation-input,< 1K
-Predicate,http://schema.org/applicableLocation-output,< 1K
-Predicate,http://schema.org/applicantLocationRequirements,10K - 100K
-Predicate,http://schema.org/applicantLocationRequirements-input,< 1K
-Predicate,http://schema.org/applicantLocationRequirements-output,< 1K
-Predicate,http://schema.org/application,< 1K
-Predicate,http://schema.org/application-input,< 1K
-Predicate,http://schema.org/application-output,< 1K
-Predicate,http://schema.org/applicationCategory,100K - 1M
-Predicate,http://schema.org/applicationCategory-input,< 1K
-Predicate,http://schema.org/applicationCategory-output,< 1K
-Predicate,http://schema.org/applicationContact,1K - 10K
-Predicate,http://schema.org/applicationContact-input,< 1K
-Predicate,http://schema.org/applicationContact-output,< 1K
-Predicate,http://schema.org/applicationDeadline,< 1K
-Predicate,http://schema.org/applicationDeadline-input,< 1K
-Predicate,http://schema.org/applicationDeadline-output,< 1K
-Predicate,http://schema.org/applicationStartDate,< 1K
-Predicate,http://schema.org/applicationStartDate-input,< 1K
-Predicate,http://schema.org/applicationStartDate-output,< 1K
-Predicate,http://schema.org/applicationSubCategory,10K - 100K
-Predicate,http://schema.org/applicationSubCategory-input,< 1K
-Predicate,http://schema.org/applicationSubCategory-output,< 1K
-Predicate,http://schema.org/applicationSuite,1K - 10K
-Predicate,http://schema.org/applicationSuite-input,< 1K
-Predicate,http://schema.org/applicationSuite-output,< 1K
-Predicate,http://schema.org/appliesToDeliveryMethod,10K - 100K
-Predicate,http://schema.org/appliesToDeliveryMethod-input,< 1K
-Predicate,http://schema.org/appliesToDeliveryMethod-output,< 1K
-Predicate,http://schema.org/appliesToPaymentMethod,< 1K
-Predicate,http://schema.org/appliesToPaymentMethod-input,< 1K
-Predicate,http://schema.org/appliesToPaymentMethod-output,< 1K
-Predicate,http://schema.org/archiveHeld,< 1K
-Predicate,http://schema.org/archiveHeld-input,< 1K
-Predicate,http://schema.org/archiveHeld-output,< 1K
-Predicate,http://schema.org/archivedAt,< 1K
-Predicate,http://schema.org/archivedAt-input,< 1K
-Predicate,http://schema.org/archivedAt-output,< 1K
-Predicate,http://schema.org/area,1K - 10K
-Predicate,http://schema.org/area-input,< 1K
-Predicate,http://schema.org/area-output,< 1K
-Predicate,http://schema.org/areaServed,1M - 10M
-Predicate,http://schema.org/areaServed-input,< 1K
-Predicate,http://schema.org/areaServed-output,< 1K
-Predicate,http://schema.org/arrivalAirport,1K - 10K
-Predicate,http://schema.org/arrivalAirport-input,< 1K
-Predicate,http://schema.org/arrivalAirport-output,< 1K
-Predicate,http://schema.org/arrivalBoatTerminal,< 1K
-Predicate,http://schema.org/arrivalBoatTerminal-input,< 1K
-Predicate,http://schema.org/arrivalBoatTerminal-output,< 1K
-Predicate,http://schema.org/arrivalBusStop,< 1K
-Predicate,http://schema.org/arrivalBusStop-input,< 1K
-Predicate,http://schema.org/arrivalBusStop-output,< 1K
-Predicate,http://schema.org/arrivalGate,< 1K
-Predicate,http://schema.org/arrivalGate-input,< 1K
-Predicate,http://schema.org/arrivalGate-output,< 1K
-Predicate,http://schema.org/arrivalPlatform,< 1K
-Predicate,http://schema.org/arrivalPlatform-input,< 1K
-Predicate,http://schema.org/arrivalPlatform-output,< 1K
-Predicate,http://schema.org/arrivalStation,< 1K
-Predicate,http://schema.org/arrivalStation-input,< 1K
-Predicate,http://schema.org/arrivalStation-output,< 1K
-Predicate,http://schema.org/arrivalTerminal,< 1K
-Predicate,http://schema.org/arrivalTerminal-input,< 1K
-Predicate,http://schema.org/arrivalTerminal-output,< 1K
-Predicate,http://schema.org/arrivalTime,1K - 10K
-Predicate,http://schema.org/arrivalTime-input,< 1K
-Predicate,http://schema.org/arrivalTime-output,< 1K
-Predicate,http://schema.org/artEdition,< 1K
-Predicate,http://schema.org/artEdition-input,< 1K
-Predicate,http://schema.org/artEdition-output,< 1K
-Predicate,http://schema.org/artMedium,1K - 10K
-Predicate,http://schema.org/artMedium-input,< 1K
-Predicate,http://schema.org/artMedium-output,< 1K
-Predicate,http://schema.org/arterialBranch,< 1K
-Predicate,http://schema.org/arterialBranch-input,< 1K
-Predicate,http://schema.org/arterialBranch-output,< 1K
-Predicate,http://schema.org/artform,1K - 10K
-Predicate,http://schema.org/artform-input,< 1K
-Predicate,http://schema.org/artform-output,< 1K
-Predicate,http://schema.org/articleBody,1M - 10M
-Predicate,http://schema.org/articleBody-input,< 1K
-Predicate,http://schema.org/articleBody-output,< 1K
-Predicate,http://schema.org/articleSection,1M - 10M
-Predicate,http://schema.org/articleSection-input,< 1K
-Predicate,http://schema.org/articleSection-output,< 1K
-Predicate,http://schema.org/artist,1K - 10K
-Predicate,http://schema.org/artist-input,< 1K
-Predicate,http://schema.org/artist-output,< 1K
-Predicate,http://schema.org/artworkSurface,< 1K
-Predicate,http://schema.org/artworkSurface-input,< 1K
-Predicate,http://schema.org/artworkSurface-output,< 1K
-Predicate,http://schema.org/asin,< 1K
-Predicate,http://schema.org/asin-input,< 1K
-Predicate,http://schema.org/asin-output,< 1K
-Predicate,http://schema.org/aspect,< 1K
-Predicate,http://schema.org/aspect-input,< 1K
-Predicate,http://schema.org/aspect-output,< 1K
-Predicate,http://schema.org/assembly,< 1K
-Predicate,http://schema.org/assembly-input,< 1K
-Predicate,http://schema.org/assembly-output,< 1K
-Predicate,http://schema.org/assemblyVersion,< 1K
-Predicate,http://schema.org/assemblyVersion-input,< 1K
-Predicate,http://schema.org/assemblyVersion-output,< 1K
-Predicate,http://schema.org/assesses,1K - 10K
-Predicate,http://schema.org/assesses-input,< 1K
-Predicate,http://schema.org/assesses-output,< 1K
-Predicate,http://schema.org/associatedAnatomy,1K - 10K
-Predicate,http://schema.org/associatedAnatomy-input,< 1K
-Predicate,http://schema.org/associatedAnatomy-output,< 1K
-Predicate,http://schema.org/associatedArticle,1K - 10K
-Predicate,http://schema.org/associatedArticle-input,< 1K
-Predicate,http://schema.org/associatedArticle-output,< 1K
-Predicate,http://schema.org/associatedClaimReview,< 1K
-Predicate,http://schema.org/associatedClaimReview-input,< 1K
-Predicate,http://schema.org/associatedClaimReview-output,< 1K
-Predicate,http://schema.org/associatedDisease,< 1K
-Predicate,http://schema.org/associatedDisease-input,< 1K
-Predicate,http://schema.org/associatedDisease-output,< 1K
-Predicate,http://schema.org/associatedMedia,100K - 1M
-Predicate,http://schema.org/associatedMedia-input,< 1K
-Predicate,http://schema.org/associatedMedia-output,< 1K
-Predicate,http://schema.org/associatedMediaReview,< 1K
-Predicate,http://schema.org/associatedMediaReview-input,< 1K
-Predicate,http://schema.org/associatedMediaReview-output,< 1K
-Predicate,http://schema.org/associatedPathophysiology,< 1K
-Predicate,http://schema.org/associatedPathophysiology-input,< 1K
-Predicate,http://schema.org/associatedPathophysiology-output,< 1K
-Predicate,http://schema.org/associatedReview,< 1K
-Predicate,http://schema.org/associatedReview-input,< 1K
-Predicate,http://schema.org/associatedReview-output,< 1K
-Predicate,http://schema.org/athlete,< 1K
-Predicate,http://schema.org/athlete-input,< 1K
-Predicate,http://schema.org/athlete-output,< 1K
-Predicate,http://schema.org/attendee,1K - 10K
-Predicate,http://schema.org/attendee-input,< 1K
-Predicate,http://schema.org/attendee-output,< 1K
-Predicate,http://schema.org/attendees,< 1K
-Predicate,http://schema.org/attendees-input,< 1K
-Predicate,http://schema.org/attendees-output,< 1K
-Predicate,http://schema.org/audience,100K - 1M
-Predicate,http://schema.org/audience-input,< 1K
-Predicate,http://schema.org/audience-output,< 1K
-Predicate,http://schema.org/audienceType,100K - 1M
-Predicate,http://schema.org/audienceType-input,< 1K
-Predicate,http://schema.org/audienceType-output,< 1K
-Predicate,http://schema.org/audio,10K - 100K
-Predicate,http://schema.org/audio-input,< 1K
-Predicate,http://schema.org/audio-output,< 1K
-Predicate,http://schema.org/auditDate,< 1K
-Predicate,http://schema.org/auditDate-input,< 1K
-Predicate,http://schema.org/auditDate-output,< 1K
-Predicate,http://schema.org/authenticator,< 1K
-Predicate,http://schema.org/authenticator-input,< 1K
-Predicate,http://schema.org/authenticator-output,< 1K
-Predicate,http://schema.org/author,10M+
-Predicate,http://schema.org/author-input,< 1K
-Predicate,http://schema.org/author-output,< 1K
-Predicate,http://schema.org/availability,1M - 10M
-Predicate,http://schema.org/availability-input,< 1K
-Predicate,http://schema.org/availability-output,< 1K
-Predicate,http://schema.org/availabilityEnds,1K - 10K
-Predicate,http://schema.org/availabilityEnds-input,< 1K
-Predicate,http://schema.org/availabilityEnds-output,< 1K
-Predicate,http://schema.org/availabilityStarts,10K - 100K
-Predicate,http://schema.org/availabilityStarts-input,< 1K
-Predicate,http://schema.org/availabilityStarts-output,< 1K
-Predicate,http://schema.org/availableAtOrFrom,10K - 100K
-Predicate,http://schema.org/availableAtOrFrom-input,< 1K
-Predicate,http://schema.org/availableAtOrFrom-output,< 1K
-Predicate,http://schema.org/availableChannel,10K - 100K
-Predicate,http://schema.org/availableChannel-input,< 1K
-Predicate,http://schema.org/availableChannel-output,< 1K
-Predicate,http://schema.org/availableDeliveryMethod,10K - 100K
-Predicate,http://schema.org/availableDeliveryMethod-input,< 1K
-Predicate,http://schema.org/availableDeliveryMethod-output,< 1K
-Predicate,http://schema.org/availableFrom,< 1K
-Predicate,http://schema.org/availableFrom-input,< 1K
-Predicate,http://schema.org/availableFrom-output,< 1K
-Predicate,http://schema.org/availableIn,< 1K
-Predicate,http://schema.org/availableIn-input,< 1K
-Predicate,http://schema.org/availableIn-output,< 1K
-Predicate,http://schema.org/availableLanguage,1M - 10M
-Predicate,http://schema.org/availableLanguage-input,< 1K
-Predicate,http://schema.org/availableLanguage-output,< 1K
-Predicate,http://schema.org/availableOnDevice,1K - 10K
-Predicate,http://schema.org/availableOnDevice-input,< 1K
-Predicate,http://schema.org/availableOnDevice-output,< 1K
-Predicate,http://schema.org/availableService,10K - 100K
-Predicate,http://schema.org/availableService-input,< 1K
-Predicate,http://schema.org/availableService-output,< 1K
-Predicate,http://schema.org/availableStrength,< 1K
-Predicate,http://schema.org/availableStrength-input,< 1K
-Predicate,http://schema.org/availableStrength-output,< 1K
-Predicate,http://schema.org/availableTest,< 1K
-Predicate,http://schema.org/availableTest-input,< 1K
-Predicate,http://schema.org/availableTest-output,< 1K
-Predicate,http://schema.org/availableThrough,< 1K
-Predicate,http://schema.org/availableThrough-input,< 1K
-Predicate,http://schema.org/availableThrough-output,< 1K
-Predicate,http://schema.org/award,10K - 100K
-Predicate,http://schema.org/award-input,< 1K
-Predicate,http://schema.org/award-output,< 1K
-Predicate,http://schema.org/awards,1K - 10K
-Predicate,http://schema.org/awards-input,< 1K
-Predicate,http://schema.org/awards-output,< 1K
-Predicate,http://schema.org/awayTeam,10K - 100K
-Predicate,http://schema.org/awayTeam-input,< 1K
-Predicate,http://schema.org/awayTeam-output,< 1K
-Predicate,http://schema.org/backstory,1K - 10K
-Predicate,http://schema.org/backstory-input,< 1K
-Predicate,http://schema.org/backstory-output,< 1K
-Predicate,http://schema.org/bankAccountType,< 1K
-Predicate,http://schema.org/bankAccountType-input,< 1K
-Predicate,http://schema.org/bankAccountType-output,< 1K
-Predicate,http://schema.org/baseSalary,10K - 100K
-Predicate,http://schema.org/baseSalary-input,< 1K
-Predicate,http://schema.org/baseSalary-output,< 1K
-Predicate,http://schema.org/bccRecipient,< 1K
-Predicate,http://schema.org/bccRecipient-input,< 1K
-Predicate,http://schema.org/bccRecipient-output,< 1K
-Predicate,http://schema.org/bed,10K - 100K
-Predicate,http://schema.org/bed-input,< 1K
-Predicate,http://schema.org/bed-output,< 1K
-Predicate,http://schema.org/beforeMedia,< 1K
-Predicate,http://schema.org/beforeMedia-input,< 1K
-Predicate,http://schema.org/beforeMedia-output,< 1K
-Predicate,http://schema.org/beneficiaryBank,< 1K
-Predicate,http://schema.org/beneficiaryBank-input,< 1K
-Predicate,http://schema.org/beneficiaryBank-output,< 1K
-Predicate,http://schema.org/benefits,1K - 10K
-Predicate,http://schema.org/benefits-input,< 1K
-Predicate,http://schema.org/benefits-output,< 1K
-Predicate,http://schema.org/benefitsSummaryUrl,< 1K
-Predicate,http://schema.org/benefitsSummaryUrl-input,< 1K
-Predicate,http://schema.org/benefitsSummaryUrl-output,< 1K
-Predicate,http://schema.org/bestRating,1M - 10M
-Predicate,http://schema.org/bestRating-input,< 1K
-Predicate,http://schema.org/bestRating-output,< 1K
-Predicate,http://schema.org/billingAddress,< 1K
-Predicate,http://schema.org/billingAddress-input,< 1K
-Predicate,http://schema.org/billingAddress-output,< 1K
-Predicate,http://schema.org/billingDuration,10K - 100K
-Predicate,http://schema.org/billingDuration-input,< 1K
-Predicate,http://schema.org/billingDuration-output,< 1K
-Predicate,http://schema.org/billingIncrement,10K - 100K
-Predicate,http://schema.org/billingIncrement-input,< 1K
-Predicate,http://schema.org/billingIncrement-output,< 1K
-Predicate,http://schema.org/billingPeriod,1K - 10K
-Predicate,http://schema.org/billingPeriod-input,< 1K
-Predicate,http://schema.org/billingPeriod-output,< 1K
-Predicate,http://schema.org/billingStart,< 1K
-Predicate,http://schema.org/billingStart-input,< 1K
-Predicate,http://schema.org/billingStart-output,< 1K
-Predicate,http://schema.org/bioChemInteraction,< 1K
-Predicate,http://schema.org/bioChemInteraction-input,< 1K
-Predicate,http://schema.org/bioChemInteraction-output,< 1K
-Predicate,http://schema.org/bioChemSimilarity,< 1K
-Predicate,http://schema.org/bioChemSimilarity-input,< 1K
-Predicate,http://schema.org/bioChemSimilarity-output,< 1K
-Predicate,http://schema.org/biologicalRole,< 1K
-Predicate,http://schema.org/biologicalRole-input,< 1K
-Predicate,http://schema.org/biologicalRole-output,< 1K
-Predicate,http://schema.org/biomechnicalClass,< 1K
-Predicate,http://schema.org/biomechnicalClass-input,< 1K
-Predicate,http://schema.org/biomechnicalClass-output,< 1K
-Predicate,http://schema.org/birthDate,10K - 100K
-Predicate,http://schema.org/birthDate-input,< 1K
-Predicate,http://schema.org/birthDate-output,< 1K
-Predicate,http://schema.org/birthPlace,10K - 100K
-Predicate,http://schema.org/birthPlace-input,< 1K
-Predicate,http://schema.org/birthPlace-output,< 1K
-Predicate,http://schema.org/bitrate,1K - 10K
-Predicate,http://schema.org/bitrate-input,< 1K
-Predicate,http://schema.org/bitrate-output,< 1K
-Predicate,http://schema.org/blogPost,100K - 1M
-Predicate,http://schema.org/blogPost-input,< 1K
-Predicate,http://schema.org/blogPost-output,< 1K
-Predicate,http://schema.org/blogPosts,10K - 100K
-Predicate,http://schema.org/blogPosts-input,< 1K
-Predicate,http://schema.org/blogPosts-output,< 1K
-Predicate,http://schema.org/bloodSupply,< 1K
-Predicate,http://schema.org/bloodSupply-input,< 1K
-Predicate,http://schema.org/bloodSupply-output,< 1K
-Predicate,http://schema.org/boardingGroup,< 1K
-Predicate,http://schema.org/boardingGroup-input,< 1K
-Predicate,http://schema.org/boardingGroup-output,< 1K
-Predicate,http://schema.org/boardingPolicy,< 1K
-Predicate,http://schema.org/boardingPolicy-input,< 1K
-Predicate,http://schema.org/boardingPolicy-output,< 1K
-Predicate,http://schema.org/bodyLocation,1K - 10K
-Predicate,http://schema.org/bodyLocation-input,< 1K
-Predicate,http://schema.org/bodyLocation-output,< 1K
-Predicate,http://schema.org/bodyType,10K - 100K
-Predicate,http://schema.org/bodyType-input,< 1K
-Predicate,http://schema.org/bodyType-output,< 1K
-Predicate,http://schema.org/bookEdition,1K - 10K
-Predicate,http://schema.org/bookEdition-input,< 1K
-Predicate,http://schema.org/bookEdition-output,< 1K
-Predicate,http://schema.org/bookFormat,10K - 100K
-Predicate,http://schema.org/bookFormat-input,< 1K
-Predicate,http://schema.org/bookFormat-output,< 1K
-Predicate,http://schema.org/bookingAgent,< 1K
-Predicate,http://schema.org/bookingAgent-input,< 1K
-Predicate,http://schema.org/bookingAgent-output,< 1K
-Predicate,http://schema.org/bookingTime,< 1K
-Predicate,http://schema.org/bookingTime-input,< 1K
-Predicate,http://schema.org/bookingTime-output,< 1K
-Predicate,http://schema.org/borrower,< 1K
-Predicate,http://schema.org/borrower-input,< 1K
-Predicate,http://schema.org/borrower-output,< 1K
-Predicate,http://schema.org/box,1K - 10K
-Predicate,http://schema.org/box-input,< 1K
-Predicate,http://schema.org/box-output,< 1K
-Predicate,http://schema.org/branch,< 1K
-Predicate,http://schema.org/branch-input,< 1K
-Predicate,http://schema.org/branch-output,< 1K
-Predicate,http://schema.org/branchCode,1K - 10K
-Predicate,http://schema.org/branchCode-input,< 1K
-Predicate,http://schema.org/branchCode-output,< 1K
-Predicate,http://schema.org/branchOf,10K - 100K
-Predicate,http://schema.org/branchOf-input,< 1K
-Predicate,http://schema.org/branchOf-output,< 1K
-Predicate,http://schema.org/brand,1M - 10M
-Predicate,http://schema.org/brand-input,< 1K
-Predicate,http://schema.org/brand-output,< 1K
-Predicate,http://schema.org/breadcrumb,10M+
-Predicate,http://schema.org/breadcrumb-input,< 1K
-Predicate,http://schema.org/breadcrumb-output,< 1K
-Predicate,http://schema.org/breastfeedingWarning,< 1K
-Predicate,http://schema.org/breastfeedingWarning-input,< 1K
-Predicate,http://schema.org/breastfeedingWarning-output,< 1K
-Predicate,http://schema.org/broadcastAffiliateOf,< 1K
-Predicate,http://schema.org/broadcastAffiliateOf-input,< 1K
-Predicate,http://schema.org/broadcastAffiliateOf-output,< 1K
-Predicate,http://schema.org/broadcastChannelId,< 1K
-Predicate,http://schema.org/broadcastChannelId-input,< 1K
-Predicate,http://schema.org/broadcastChannelId-output,< 1K
-Predicate,http://schema.org/broadcastDisplayName,1K - 10K
-Predicate,http://schema.org/broadcastDisplayName-input,< 1K
-Predicate,http://schema.org/broadcastDisplayName-output,< 1K
-Predicate,http://schema.org/broadcastFrequency,1K - 10K
-Predicate,http://schema.org/broadcastFrequency-input,< 1K
-Predicate,http://schema.org/broadcastFrequency-output,< 1K
-Predicate,http://schema.org/broadcastFrequencyValue,< 1K
-Predicate,http://schema.org/broadcastFrequencyValue-input,< 1K
-Predicate,http://schema.org/broadcastFrequencyValue-output,< 1K
-Predicate,http://schema.org/broadcastOfEvent,< 1K
-Predicate,http://schema.org/broadcastOfEvent-input,< 1K
-Predicate,http://schema.org/broadcastOfEvent-output,< 1K
-Predicate,http://schema.org/broadcastServiceTier,< 1K
-Predicate,http://schema.org/broadcastServiceTier-input,< 1K
-Predicate,http://schema.org/broadcastServiceTier-output,< 1K
-Predicate,http://schema.org/broadcastSignalModulation,< 1K
-Predicate,http://schema.org/broadcastSignalModulation-input,< 1K
-Predicate,http://schema.org/broadcastSignalModulation-output,< 1K
-Predicate,http://schema.org/broadcastSubChannel,< 1K
-Predicate,http://schema.org/broadcastSubChannel-input,< 1K
-Predicate,http://schema.org/broadcastSubChannel-output,< 1K
-Predicate,http://schema.org/broadcastTimezone,< 1K
-Predicate,http://schema.org/broadcastTimezone-input,< 1K
-Predicate,http://schema.org/broadcastTimezone-output,< 1K
-Predicate,http://schema.org/broadcaster,< 1K
-Predicate,http://schema.org/broadcaster-input,< 1K
-Predicate,http://schema.org/broadcaster-output,< 1K
-Predicate,http://schema.org/broker,1K - 10K
-Predicate,http://schema.org/broker-input,< 1K
-Predicate,http://schema.org/broker-output,< 1K
-Predicate,http://schema.org/browserRequirements,10K - 100K
-Predicate,http://schema.org/browserRequirements-input,< 1K
-Predicate,http://schema.org/browserRequirements-output,< 1K
-Predicate,http://schema.org/busName,< 1K
-Predicate,http://schema.org/busName-input,< 1K
-Predicate,http://schema.org/busName-output,< 1K
-Predicate,http://schema.org/busNumber,< 1K
-Predicate,http://schema.org/busNumber-input,< 1K
-Predicate,http://schema.org/busNumber-output,< 1K
-Predicate,http://schema.org/businessDays,10K - 100K
-Predicate,http://schema.org/businessDays-input,< 1K
-Predicate,http://schema.org/businessDays-output,< 1K
-Predicate,http://schema.org/businessFunction,10K - 100K
-Predicate,http://schema.org/businessFunction-input,< 1K
-Predicate,http://schema.org/businessFunction-output,< 1K
-Predicate,http://schema.org/buyer,< 1K
-Predicate,http://schema.org/buyer-input,< 1K
-Predicate,http://schema.org/buyer-output,< 1K
-Predicate,http://schema.org/byArtist,10K - 100K
-Predicate,http://schema.org/byArtist-input,< 1K
-Predicate,http://schema.org/byArtist-output,< 1K
-Predicate,http://schema.org/byDay,1K - 10K
-Predicate,http://schema.org/byDay-input,< 1K
-Predicate,http://schema.org/byDay-output,< 1K
-Predicate,http://schema.org/byMonth,< 1K
-Predicate,http://schema.org/byMonth-input,< 1K
-Predicate,http://schema.org/byMonth-output,< 1K
-Predicate,http://schema.org/byMonthDay,< 1K
-Predicate,http://schema.org/byMonthDay-input,< 1K
-Predicate,http://schema.org/byMonthDay-output,< 1K
-Predicate,http://schema.org/byMonthWeek,< 1K
-Predicate,http://schema.org/byMonthWeek-input,< 1K
-Predicate,http://schema.org/byMonthWeek-output,< 1K
-Predicate,http://schema.org/callSign,< 1K
-Predicate,http://schema.org/callSign-input,< 1K
-Predicate,http://schema.org/callSign-output,< 1K
-Predicate,http://schema.org/calories,10K - 100K
-Predicate,http://schema.org/calories-input,< 1K
-Predicate,http://schema.org/calories-output,< 1K
-Predicate,http://schema.org/candidate,< 1K
-Predicate,http://schema.org/candidate-input,< 1K
-Predicate,http://schema.org/candidate-output,< 1K
-Predicate,http://schema.org/caption,10M+
-Predicate,http://schema.org/caption-input,< 1K
-Predicate,http://schema.org/caption-output,< 1K
-Predicate,http://schema.org/carbohydrateContent,10K - 100K
-Predicate,http://schema.org/carbohydrateContent-input,< 1K
-Predicate,http://schema.org/carbohydrateContent-output,< 1K
-Predicate,http://schema.org/cargoVolume,1K - 10K
-Predicate,http://schema.org/cargoVolume-input,< 1K
-Predicate,http://schema.org/cargoVolume-output,< 1K
-Predicate,http://schema.org/carrier,< 1K
-Predicate,http://schema.org/carrier-input,< 1K
-Predicate,http://schema.org/carrier-output,< 1K
-Predicate,http://schema.org/carrierRequirements,< 1K
-Predicate,http://schema.org/carrierRequirements-input,< 1K
-Predicate,http://schema.org/carrierRequirements-output,< 1K
-Predicate,http://schema.org/cashBack,< 1K
-Predicate,http://schema.org/cashBack-input,< 1K
-Predicate,http://schema.org/cashBack-output,< 1K
-Predicate,http://schema.org/catalog,< 1K
-Predicate,http://schema.org/catalog-input,< 1K
-Predicate,http://schema.org/catalog-output,< 1K
-Predicate,http://schema.org/catalogNumber,< 1K
-Predicate,http://schema.org/catalogNumber-input,< 1K
-Predicate,http://schema.org/catalogNumber-output,< 1K
-Predicate,http://schema.org/category,1M - 10M
-Predicate,http://schema.org/category-input,< 1K
-Predicate,http://schema.org/category-output,< 1K
-Predicate,http://schema.org/cause,1K - 10K
-Predicate,http://schema.org/cause-input,< 1K
-Predicate,http://schema.org/cause-output,< 1K
-Predicate,http://schema.org/causeOf,< 1K
-Predicate,http://schema.org/causeOf-input,< 1K
-Predicate,http://schema.org/causeOf-output,< 1K
-Predicate,http://schema.org/ccRecipient,< 1K
-Predicate,http://schema.org/ccRecipient-input,< 1K
-Predicate,http://schema.org/ccRecipient-output,< 1K
-Predicate,http://schema.org/certificationIdentification,1K - 10K
-Predicate,http://schema.org/certificationIdentification-input,< 1K
-Predicate,http://schema.org/certificationIdentification-output,< 1K
-Predicate,http://schema.org/certificationRating,< 1K
-Predicate,http://schema.org/certificationRating-input,< 1K
-Predicate,http://schema.org/certificationRating-output,< 1K
-Predicate,http://schema.org/certificationStatus,< 1K
-Predicate,http://schema.org/certificationStatus-input,< 1K
-Predicate,http://schema.org/certificationStatus-output,< 1K
-Predicate,http://schema.org/character,< 1K
-Predicate,http://schema.org/character-input,< 1K
-Predicate,http://schema.org/character-output,< 1K
-Predicate,http://schema.org/characterAttribute,< 1K
-Predicate,http://schema.org/characterAttribute-input,< 1K
-Predicate,http://schema.org/characterAttribute-output,< 1K
-Predicate,http://schema.org/characterName,< 1K
-Predicate,http://schema.org/characterName-input,< 1K
-Predicate,http://schema.org/characterName-output,< 1K
-Predicate,http://schema.org/cheatCode,< 1K
-Predicate,http://schema.org/cheatCode-input,< 1K
-Predicate,http://schema.org/cheatCode-output,< 1K
-Predicate,http://schema.org/checkinTime,10K - 100K
-Predicate,http://schema.org/checkinTime-input,< 1K
-Predicate,http://schema.org/checkinTime-output,< 1K
-Predicate,http://schema.org/checkoutPageURLTemplate,10K - 100K
-Predicate,http://schema.org/checkoutPageURLTemplate-input,< 1K
-Predicate,http://schema.org/checkoutPageURLTemplate-output,< 1K
-Predicate,http://schema.org/checkoutTime,10K - 100K
-Predicate,http://schema.org/checkoutTime-input,< 1K
-Predicate,http://schema.org/checkoutTime-output,< 1K
-Predicate,http://schema.org/chemicalComposition,< 1K
-Predicate,http://schema.org/chemicalComposition-input,< 1K
-Predicate,http://schema.org/chemicalComposition-output,< 1K
-Predicate,http://schema.org/chemicalRole,< 1K
-Predicate,http://schema.org/chemicalRole-input,< 1K
-Predicate,http://schema.org/chemicalRole-output,< 1K
-Predicate,http://schema.org/childMaxAge,< 1K
-Predicate,http://schema.org/childMaxAge-input,< 1K
-Predicate,http://schema.org/childMaxAge-output,< 1K
-Predicate,http://schema.org/childMinAge,< 1K
-Predicate,http://schema.org/childMinAge-input,< 1K
-Predicate,http://schema.org/childMinAge-output,< 1K
-Predicate,http://schema.org/childTaxon,< 1K
-Predicate,http://schema.org/childTaxon-input,< 1K
-Predicate,http://schema.org/childTaxon-output,< 1K
-Predicate,http://schema.org/children,1K - 10K
-Predicate,http://schema.org/children-input,< 1K
-Predicate,http://schema.org/children-output,< 1K
-Predicate,http://schema.org/cholesterolContent,10K - 100K
-Predicate,http://schema.org/cholesterolContent-input,< 1K
-Predicate,http://schema.org/cholesterolContent-output,< 1K
-Predicate,http://schema.org/circle,1K - 10K
-Predicate,http://schema.org/circle-input,< 1K
-Predicate,http://schema.org/circle-output,< 1K
-Predicate,http://schema.org/citation,10K - 100K
-Predicate,http://schema.org/citation-input,< 1K
-Predicate,http://schema.org/citation-output,< 1K
-Predicate,http://schema.org/claimInterpreter,< 1K
-Predicate,http://schema.org/claimInterpreter-input,< 1K
-Predicate,http://schema.org/claimInterpreter-output,< 1K
-Predicate,http://schema.org/claimReviewed,1K - 10K
-Predicate,http://schema.org/claimReviewed-input,< 1K
-Predicate,http://schema.org/claimReviewed-output,< 1K
-Predicate,http://schema.org/clincalPharmacology,< 1K
-Predicate,http://schema.org/clincalPharmacology-input,< 1K
-Predicate,http://schema.org/clincalPharmacology-output,< 1K
-Predicate,http://schema.org/clinicalPharmacology,< 1K
-Predicate,http://schema.org/clinicalPharmacology-input,< 1K
-Predicate,http://schema.org/clinicalPharmacology-output,< 1K
-Predicate,http://schema.org/clipNumber,< 1K
-Predicate,http://schema.org/clipNumber-input,< 1K
-Predicate,http://schema.org/clipNumber-output,< 1K
-Predicate,http://schema.org/closes,1M - 10M
-Predicate,http://schema.org/closes-input,< 1K
-Predicate,http://schema.org/closes-output,< 1K
-Predicate,http://schema.org/coach,< 1K
-Predicate,http://schema.org/coach-input,< 1K
-Predicate,http://schema.org/coach-output,< 1K
-Predicate,http://schema.org/code,1K - 10K
-Predicate,http://schema.org/code-input,< 1K
-Predicate,http://schema.org/code-output,< 1K
-Predicate,http://schema.org/codeRepository,1K - 10K
-Predicate,http://schema.org/codeRepository-input,< 1K
-Predicate,http://schema.org/codeRepository-output,< 1K
-Predicate,http://schema.org/codeSampleType,< 1K
-Predicate,http://schema.org/codeSampleType-input,< 1K
-Predicate,http://schema.org/codeSampleType-output,< 1K
-Predicate,http://schema.org/codeValue,1K - 10K
-Predicate,http://schema.org/codeValue-input,< 1K
-Predicate,http://schema.org/codeValue-output,< 1K
-Predicate,http://schema.org/codingSystem,1K - 10K
-Predicate,http://schema.org/codingSystem-input,< 1K
-Predicate,http://schema.org/codingSystem-output,< 1K
-Predicate,http://schema.org/colleague,1K - 10K
-Predicate,http://schema.org/colleague-input,< 1K
-Predicate,http://schema.org/colleague-output,< 1K
-Predicate,http://schema.org/colleagues,< 1K
-Predicate,http://schema.org/colleagues-input,< 1K
-Predicate,http://schema.org/colleagues-output,< 1K
-Predicate,http://schema.org/collection,< 1K
-Predicate,http://schema.org/collection-input,< 1K
-Predicate,http://schema.org/collection-output,< 1K
-Predicate,http://schema.org/collectionSize,1K - 10K
-Predicate,http://schema.org/collectionSize-input,< 1K
-Predicate,http://schema.org/collectionSize-output,< 1K
-Predicate,http://schema.org/color,100K - 1M
-Predicate,http://schema.org/color-input,< 1K
-Predicate,http://schema.org/color-output,< 1K
-Predicate,http://schema.org/colorSwatch,< 1K
-Predicate,http://schema.org/colorSwatch-input,< 1K
-Predicate,http://schema.org/colorSwatch-output,< 1K
-Predicate,http://schema.org/colorist,< 1K
-Predicate,http://schema.org/colorist-input,< 1K
-Predicate,http://schema.org/colorist-output,< 1K
-Predicate,http://schema.org/comment,10K - 100K
-Predicate,http://schema.org/comment-input,< 1K
-Predicate,http://schema.org/comment-output,< 1K
-Predicate,http://schema.org/commentCount,1M - 10M
-Predicate,http://schema.org/commentCount-input,< 1K
-Predicate,http://schema.org/commentCount-output,< 1K
-Predicate,http://schema.org/commentText,10K - 100K
-Predicate,http://schema.org/commentText-input,< 1K
-Predicate,http://schema.org/commentText-output,< 1K
-Predicate,http://schema.org/commentTime,10K - 100K
-Predicate,http://schema.org/commentTime-input,< 1K
-Predicate,http://schema.org/commentTime-output,< 1K
-Predicate,http://schema.org/companyRegistration,< 1K
-Predicate,http://schema.org/companyRegistration-input,< 1K
-Predicate,http://schema.org/companyRegistration-output,< 1K
-Predicate,http://schema.org/competencyRequired,1K - 10K
-Predicate,http://schema.org/competencyRequired-input,< 1K
-Predicate,http://schema.org/competencyRequired-output,< 1K
-Predicate,http://schema.org/competitor,1K - 10K
-Predicate,http://schema.org/competitor-input,< 1K
-Predicate,http://schema.org/competitor-output,< 1K
-Predicate,http://schema.org/composer,1K - 10K
-Predicate,http://schema.org/composer-input,< 1K
-Predicate,http://schema.org/composer-output,< 1K
-Predicate,http://schema.org/comprisedOf,< 1K
-Predicate,http://schema.org/comprisedOf-input,< 1K
-Predicate,http://schema.org/comprisedOf-output,< 1K
-Predicate,http://schema.org/conditionsOfAccess,< 1K
-Predicate,http://schema.org/conditionsOfAccess-input,< 1K
-Predicate,http://schema.org/conditionsOfAccess-output,< 1K
-Predicate,http://schema.org/confirmationNumber,< 1K
-Predicate,http://schema.org/confirmationNumber-input,< 1K
-Predicate,http://schema.org/confirmationNumber-output,< 1K
-Predicate,http://schema.org/connectedTo,< 1K
-Predicate,http://schema.org/connectedTo-input,< 1K
-Predicate,http://schema.org/connectedTo-output,< 1K
-Predicate,http://schema.org/constraintProperty,< 1K
-Predicate,http://schema.org/constraintProperty-input,< 1K
-Predicate,http://schema.org/constraintProperty-output,< 1K
-Predicate,http://schema.org/contactOption,100K - 1M
-Predicate,http://schema.org/contactOption-input,< 1K
-Predicate,http://schema.org/contactOption-output,< 1K
-Predicate,http://schema.org/contactPoint,1M - 10M
-Predicate,http://schema.org/contactPoint-input,< 1K
-Predicate,http://schema.org/contactPoint-output,< 1K
-Predicate,http://schema.org/contactPoints,< 1K
-Predicate,http://schema.org/contactPoints-input,< 1K
-Predicate,http://schema.org/contactPoints-output,< 1K
-Predicate,http://schema.org/contactType,1M - 10M
-Predicate,http://schema.org/contactType-input,< 1K
-Predicate,http://schema.org/contactType-output,< 1K
-Predicate,http://schema.org/contactlessPayment,< 1K
-Predicate,http://schema.org/contactlessPayment-input,< 1K
-Predicate,http://schema.org/contactlessPayment-output,< 1K
-Predicate,http://schema.org/containedIn,1K - 10K
-Predicate,http://schema.org/containedIn-input,< 1K
-Predicate,http://schema.org/containedIn-output,< 1K
-Predicate,http://schema.org/containedInPlace,100K - 1M
-Predicate,http://schema.org/containedInPlace-input,< 1K
-Predicate,http://schema.org/containedInPlace-output,< 1K
-Predicate,http://schema.org/containsPlace,10K - 100K
-Predicate,http://schema.org/containsPlace-input,< 1K
-Predicate,http://schema.org/containsPlace-output,< 1K
-Predicate,http://schema.org/containsSeason,1K - 10K
-Predicate,http://schema.org/containsSeason-input,< 1K
-Predicate,http://schema.org/containsSeason-output,< 1K
-Predicate,http://schema.org/contentLocation,10K - 100K
-Predicate,http://schema.org/contentLocation-input,< 1K
-Predicate,http://schema.org/contentLocation-output,< 1K
-Predicate,http://schema.org/contentRating,10K - 100K
-Predicate,http://schema.org/contentRating-input,< 1K
-Predicate,http://schema.org/contentRating-output,< 1K
-Predicate,http://schema.org/contentReferenceTime,1K - 10K
-Predicate,http://schema.org/contentReferenceTime-input,< 1K
-Predicate,http://schema.org/contentReferenceTime-output,< 1K
-Predicate,http://schema.org/contentSize,100K - 1M
-Predicate,http://schema.org/contentSize-input,< 1K
-Predicate,http://schema.org/contentSize-output,< 1K
-Predicate,http://schema.org/contentType,1K - 10K
-Predicate,http://schema.org/contentType-input,< 1K
-Predicate,http://schema.org/contentType-output,< 1K
-Predicate,http://schema.org/contentUrl,10M+
-Predicate,http://schema.org/contentUrl-input,< 1K
-Predicate,http://schema.org/contentUrl-output,< 1K
-Predicate,http://schema.org/contraindication,< 1K
-Predicate,http://schema.org/contraindication-input,< 1K
-Predicate,http://schema.org/contraindication-output,< 1K
-Predicate,http://schema.org/contributor,100K - 1M
-Predicate,http://schema.org/contributor-input,< 1K
-Predicate,http://schema.org/contributor-output,< 1K
-Predicate,http://schema.org/cookTime,10K - 100K
-Predicate,http://schema.org/cookTime-input,< 1K
-Predicate,http://schema.org/cookTime-output,< 1K
-Predicate,http://schema.org/cookingMethod,1K - 10K
-Predicate,http://schema.org/cookingMethod-input,< 1K
-Predicate,http://schema.org/cookingMethod-output,< 1K
-Predicate,http://schema.org/copyrightHolder,100K - 1M
-Predicate,http://schema.org/copyrightHolder-input,< 1K
-Predicate,http://schema.org/copyrightHolder-output,< 1K
-Predicate,http://schema.org/copyrightNotice,10K - 100K
-Predicate,http://schema.org/copyrightNotice-input,< 1K
-Predicate,http://schema.org/copyrightNotice-output,< 1K
-Predicate,http://schema.org/copyrightYear,100K - 1M
-Predicate,http://schema.org/copyrightYear-input,< 1K
-Predicate,http://schema.org/copyrightYear-output,< 1K
-Predicate,http://schema.org/correction,< 1K
-Predicate,http://schema.org/correction-input,< 1K
-Predicate,http://schema.org/correction-output,< 1K
-Predicate,http://schema.org/correctionsPolicy,10K - 100K
-Predicate,http://schema.org/correctionsPolicy-input,< 1K
-Predicate,http://schema.org/correctionsPolicy-output,< 1K
-Predicate,http://schema.org/costCategory,< 1K
-Predicate,http://schema.org/costCategory-input,< 1K
-Predicate,http://schema.org/costCategory-output,< 1K
-Predicate,http://schema.org/costCurrency,< 1K
-Predicate,http://schema.org/costCurrency-input,< 1K
-Predicate,http://schema.org/costCurrency-output,< 1K
-Predicate,http://schema.org/costOrigin,< 1K
-Predicate,http://schema.org/costOrigin-input,< 1K
-Predicate,http://schema.org/costOrigin-output,< 1K
-Predicate,http://schema.org/costPerUnit,< 1K
-Predicate,http://schema.org/costPerUnit-input,< 1K
-Predicate,http://schema.org/costPerUnit-output,< 1K
-Predicate,http://schema.org/countriesNotSupported,< 1K
-Predicate,http://schema.org/countriesNotSupported-input,< 1K
-Predicate,http://schema.org/countriesNotSupported-output,< 1K
-Predicate,http://schema.org/countriesSupported,1K - 10K
-Predicate,http://schema.org/countriesSupported-input,< 1K
-Predicate,http://schema.org/countriesSupported-output,< 1K
-Predicate,http://schema.org/countryOfAssembly,1K - 10K
-Predicate,http://schema.org/countryOfAssembly-input,< 1K
-Predicate,http://schema.org/countryOfAssembly-output,< 1K
-Predicate,http://schema.org/countryOfLastProcessing,< 1K
-Predicate,http://schema.org/countryOfLastProcessing-input,< 1K
-Predicate,http://schema.org/countryOfLastProcessing-output,< 1K
-Predicate,http://schema.org/countryOfOrigin,10K - 100K
-Predicate,http://schema.org/countryOfOrigin-input,< 1K
-Predicate,http://schema.org/countryOfOrigin-output,< 1K
-Predicate,http://schema.org/course,< 1K
-Predicate,http://schema.org/course-input,< 1K
-Predicate,http://schema.org/course-output,< 1K
-Predicate,http://schema.org/courseCode,1K - 10K
-Predicate,http://schema.org/courseCode-input,< 1K
-Predicate,http://schema.org/courseCode-output,< 1K
-Predicate,http://schema.org/courseMode,10K - 100K
-Predicate,http://schema.org/courseMode-input,< 1K
-Predicate,http://schema.org/courseMode-output,< 1K
-Predicate,http://schema.org/coursePrerequisites,1K - 10K
-Predicate,http://schema.org/coursePrerequisites-input,< 1K
-Predicate,http://schema.org/coursePrerequisites-output,< 1K
-Predicate,http://schema.org/courseSchedule,1K - 10K
-Predicate,http://schema.org/courseSchedule-input,< 1K
-Predicate,http://schema.org/courseSchedule-output,< 1K
-Predicate,http://schema.org/courseWorkload,10K - 100K
-Predicate,http://schema.org/courseWorkload-input,< 1K
-Predicate,http://schema.org/courseWorkload-output,< 1K
-Predicate,http://schema.org/coverageEndTime,1K - 10K
-Predicate,http://schema.org/coverageEndTime-input,< 1K
-Predicate,http://schema.org/coverageEndTime-output,< 1K
-Predicate,http://schema.org/coverageStartTime,1K - 10K
-Predicate,http://schema.org/coverageStartTime-input,< 1K
-Predicate,http://schema.org/coverageStartTime-output,< 1K
-Predicate,http://schema.org/creativeWorkStatus,1K - 10K
-Predicate,http://schema.org/creativeWorkStatus-input,< 1K
-Predicate,http://schema.org/creativeWorkStatus-output,< 1K
-Predicate,http://schema.org/creator,1M - 10M
-Predicate,http://schema.org/creator-input,< 1K
-Predicate,http://schema.org/creator-output,< 1K
-Predicate,http://schema.org/credentialCategory,10K - 100K
-Predicate,http://schema.org/credentialCategory-input,< 1K
-Predicate,http://schema.org/credentialCategory-output,< 1K
-Predicate,http://schema.org/creditText,10K - 100K
-Predicate,http://schema.org/creditText-input,< 1K
-Predicate,http://schema.org/creditText-output,< 1K
-Predicate,http://schema.org/creditedTo,< 1K
-Predicate,http://schema.org/creditedTo-input,< 1K
-Predicate,http://schema.org/creditedTo-output,< 1K
-Predicate,http://schema.org/cssSelector,100K - 1M
-Predicate,http://schema.org/cssSelector-input,< 1K
-Predicate,http://schema.org/cssSelector-output,< 1K
-Predicate,http://schema.org/currenciesAccepted,100K - 1M
-Predicate,http://schema.org/currenciesAccepted-input,< 1K
-Predicate,http://schema.org/currenciesAccepted-output,< 1K
-Predicate,http://schema.org/currency,100K - 1M
-Predicate,http://schema.org/currency-input,< 1K
-Predicate,http://schema.org/currency-output,< 1K
-Predicate,http://schema.org/currentExchangeRate,< 1K
-Predicate,http://schema.org/currentExchangeRate-input,< 1K
-Predicate,http://schema.org/currentExchangeRate-output,< 1K
-Predicate,http://schema.org/customer,< 1K
-Predicate,http://schema.org/customer-input,< 1K
-Predicate,http://schema.org/customer-output,< 1K
-Predicate,http://schema.org/customerRemorseReturnFees,1K - 10K
-Predicate,http://schema.org/customerRemorseReturnFees-input,< 1K
-Predicate,http://schema.org/customerRemorseReturnFees-output,< 1K
-Predicate,http://schema.org/customerRemorseReturnLabelSource,< 1K
-Predicate,http://schema.org/customerRemorseReturnLabelSource-input,< 1K
-Predicate,http://schema.org/customerRemorseReturnLabelSource-output,< 1K
-Predicate,http://schema.org/customerRemorseReturnShippingFeesAmount,< 1K
-Predicate,http://schema.org/customerRemorseReturnShippingFeesAmount-input,< 1K
-Predicate,http://schema.org/customerRemorseReturnShippingFeesAmount-output,< 1K
-Predicate,http://schema.org/cutoffTime,10K - 100K
-Predicate,http://schema.org/cutoffTime-input,< 1K
-Predicate,http://schema.org/cutoffTime-output,< 1K
-Predicate,http://schema.org/cvdCollectionDate,< 1K
-Predicate,http://schema.org/cvdCollectionDate-input,< 1K
-Predicate,http://schema.org/cvdCollectionDate-output,< 1K
-Predicate,http://schema.org/cvdFacilityCounty,< 1K
-Predicate,http://schema.org/cvdFacilityCounty-input,< 1K
-Predicate,http://schema.org/cvdFacilityCounty-output,< 1K
-Predicate,http://schema.org/cvdFacilityId,< 1K
-Predicate,http://schema.org/cvdFacilityId-input,< 1K
-Predicate,http://schema.org/cvdFacilityId-output,< 1K
-Predicate,http://schema.org/cvdNumBeds,< 1K
-Predicate,http://schema.org/cvdNumBeds-input,< 1K
-Predicate,http://schema.org/cvdNumBeds-output,< 1K
-Predicate,http://schema.org/cvdNumBedsOcc,< 1K
-Predicate,http://schema.org/cvdNumBedsOcc-input,< 1K
-Predicate,http://schema.org/cvdNumBedsOcc-output,< 1K
-Predicate,http://schema.org/cvdNumC19Died,< 1K
-Predicate,http://schema.org/cvdNumC19Died-input,< 1K
-Predicate,http://schema.org/cvdNumC19Died-output,< 1K
-Predicate,http://schema.org/cvdNumC19HOPats,< 1K
-Predicate,http://schema.org/cvdNumC19HOPats-input,< 1K
-Predicate,http://schema.org/cvdNumC19HOPats-output,< 1K
-Predicate,http://schema.org/cvdNumC19HospPats,< 1K
-Predicate,http://schema.org/cvdNumC19HospPats-input,< 1K
-Predicate,http://schema.org/cvdNumC19HospPats-output,< 1K
-Predicate,http://schema.org/cvdNumC19MechVentPats,< 1K
-Predicate,http://schema.org/cvdNumC19MechVentPats-input,< 1K
-Predicate,http://schema.org/cvdNumC19MechVentPats-output,< 1K
-Predicate,http://schema.org/cvdNumC19OFMechVentPats,< 1K
-Predicate,http://schema.org/cvdNumC19OFMechVentPats-input,< 1K
-Predicate,http://schema.org/cvdNumC19OFMechVentPats-output,< 1K
-Predicate,http://schema.org/cvdNumC19OverflowPats,< 1K
-Predicate,http://schema.org/cvdNumC19OverflowPats-input,< 1K
-Predicate,http://schema.org/cvdNumC19OverflowPats-output,< 1K
-Predicate,http://schema.org/cvdNumICUBeds,< 1K
-Predicate,http://schema.org/cvdNumICUBeds-input,< 1K
-Predicate,http://schema.org/cvdNumICUBeds-output,< 1K
-Predicate,http://schema.org/cvdNumICUBedsOcc,< 1K
-Predicate,http://schema.org/cvdNumICUBedsOcc-input,< 1K
-Predicate,http://schema.org/cvdNumICUBedsOcc-output,< 1K
-Predicate,http://schema.org/cvdNumTotBeds,< 1K
-Predicate,http://schema.org/cvdNumTotBeds-input,< 1K
-Predicate,http://schema.org/cvdNumTotBeds-output,< 1K
-Predicate,http://schema.org/cvdNumVent,< 1K
-Predicate,http://schema.org/cvdNumVent-input,< 1K
-Predicate,http://schema.org/cvdNumVent-output,< 1K
-Predicate,http://schema.org/cvdNumVentUse,< 1K
-Predicate,http://schema.org/cvdNumVentUse-input,< 1K
-Predicate,http://schema.org/cvdNumVentUse-output,< 1K
-Predicate,http://schema.org/data,1K - 10K
-Predicate,http://schema.org/data-input,< 1K
-Predicate,http://schema.org/data-output,< 1K
-Predicate,http://schema.org/dataFeedElement,1K - 10K
-Predicate,http://schema.org/dataFeedElement-input,< 1K
-Predicate,http://schema.org/dataFeedElement-output,< 1K
-Predicate,http://schema.org/dataset,< 1K
-Predicate,http://schema.org/dataset-input,< 1K
-Predicate,http://schema.org/dataset-output,< 1K
-Predicate,http://schema.org/datasetTimeInterval,< 1K
-Predicate,http://schema.org/datasetTimeInterval-input,< 1K
-Predicate,http://schema.org/datasetTimeInterval-output,< 1K
-Predicate,http://schema.org/dateCreated,100K - 1M
-Predicate,http://schema.org/dateCreated-input,< 1K
-Predicate,http://schema.org/dateCreated-output,< 1K
-Predicate,http://schema.org/dateDeleted,< 1K
-Predicate,http://schema.org/dateDeleted-input,< 1K
-Predicate,http://schema.org/dateDeleted-output,< 1K
-Predicate,http://schema.org/dateIssued,< 1K
-Predicate,http://schema.org/dateIssued-input,< 1K
-Predicate,http://schema.org/dateIssued-output,< 1K
-Predicate,http://schema.org/dateModified,10M+
-Predicate,http://schema.org/dateModified-input,< 1K
-Predicate,http://schema.org/dateModified-output,< 1K
-Predicate,http://schema.org/datePosted,100K - 1M
-Predicate,http://schema.org/datePosted-input,< 1K
-Predicate,http://schema.org/datePosted-output,< 1K
-Predicate,http://schema.org/datePublished,10M+
-Predicate,http://schema.org/datePublished-input,< 1K
-Predicate,http://schema.org/datePublished-output,< 1K
-Predicate,http://schema.org/dateRead,< 1K
-Predicate,http://schema.org/dateRead-input,< 1K
-Predicate,http://schema.org/dateRead-output,< 1K
-Predicate,http://schema.org/dateReceived,< 1K
-Predicate,http://schema.org/dateReceived-input,< 1K
-Predicate,http://schema.org/dateReceived-output,< 1K
-Predicate,http://schema.org/dateSent,< 1K
-Predicate,http://schema.org/dateSent-input,< 1K
-Predicate,http://schema.org/dateSent-output,< 1K
-Predicate,http://schema.org/dateVehicleFirstRegistered,1K - 10K
-Predicate,http://schema.org/dateVehicleFirstRegistered-input,< 1K
-Predicate,http://schema.org/dateVehicleFirstRegistered-output,< 1K
-Predicate,http://schema.org/dateline,1K - 10K
-Predicate,http://schema.org/dateline-input,< 1K
-Predicate,http://schema.org/dateline-output,< 1K
-Predicate,http://schema.org/dayOfWeek,1M - 10M
-Predicate,http://schema.org/dayOfWeek-input,< 1K
-Predicate,http://schema.org/dayOfWeek-output,< 1K
-Predicate,http://schema.org/deathDate,10K - 100K
-Predicate,http://schema.org/deathDate-input,< 1K
-Predicate,http://schema.org/deathDate-output,< 1K
-Predicate,http://schema.org/deathPlace,1K - 10K
-Predicate,http://schema.org/deathPlace-input,< 1K
-Predicate,http://schema.org/deathPlace-output,< 1K
-Predicate,http://schema.org/defaultValue,100K - 1M
-Predicate,http://schema.org/defaultValue-input,< 1K
-Predicate,http://schema.org/defaultValue-output,< 1K
-Predicate,http://schema.org/deliveryAddress,< 1K
-Predicate,http://schema.org/deliveryAddress-input,< 1K
-Predicate,http://schema.org/deliveryAddress-output,< 1K
-Predicate,http://schema.org/deliveryLeadTime,10K - 100K
-Predicate,http://schema.org/deliveryLeadTime-input,< 1K
-Predicate,http://schema.org/deliveryLeadTime-output,< 1K
-Predicate,http://schema.org/deliveryMethod,10K - 100K
-Predicate,http://schema.org/deliveryMethod-input,< 1K
-Predicate,http://schema.org/deliveryMethod-output,< 1K
-Predicate,http://schema.org/deliveryStatus,< 1K
-Predicate,http://schema.org/deliveryStatus-input,< 1K
-Predicate,http://schema.org/deliveryStatus-output,< 1K
-Predicate,http://schema.org/deliveryTime,100K - 1M
-Predicate,http://schema.org/deliveryTime-input,< 1K
-Predicate,http://schema.org/deliveryTime-output,< 1K
-Predicate,http://schema.org/department,10K - 100K
-Predicate,http://schema.org/department-input,< 1K
-Predicate,http://schema.org/department-output,< 1K
-Predicate,http://schema.org/departureAirport,1K - 10K
-Predicate,http://schema.org/departureAirport-input,< 1K
-Predicate,http://schema.org/departureAirport-output,< 1K
-Predicate,http://schema.org/departureBoatTerminal,< 1K
-Predicate,http://schema.org/departureBoatTerminal-input,< 1K
-Predicate,http://schema.org/departureBoatTerminal-output,< 1K
-Predicate,http://schema.org/departureBusStop,< 1K
-Predicate,http://schema.org/departureBusStop-input,< 1K
-Predicate,http://schema.org/departureBusStop-output,< 1K
-Predicate,http://schema.org/departureGate,< 1K
-Predicate,http://schema.org/departureGate-input,< 1K
-Predicate,http://schema.org/departureGate-output,< 1K
-Predicate,http://schema.org/departurePlatform,< 1K
-Predicate,http://schema.org/departurePlatform-input,< 1K
-Predicate,http://schema.org/departurePlatform-output,< 1K
-Predicate,http://schema.org/departureStation,< 1K
-Predicate,http://schema.org/departureStation-input,< 1K
-Predicate,http://schema.org/departureStation-output,< 1K
-Predicate,http://schema.org/departureTerminal,< 1K
-Predicate,http://schema.org/departureTerminal-input,< 1K
-Predicate,http://schema.org/departureTerminal-output,< 1K
-Predicate,http://schema.org/departureTime,1K - 10K
-Predicate,http://schema.org/departureTime-input,< 1K
-Predicate,http://schema.org/departureTime-output,< 1K
-Predicate,http://schema.org/dependencies,1K - 10K
-Predicate,http://schema.org/dependencies-input,< 1K
-Predicate,http://schema.org/dependencies-output,< 1K
-Predicate,http://schema.org/depth,10K - 100K
-Predicate,http://schema.org/depth-input,< 1K
-Predicate,http://schema.org/depth-output,< 1K
-Predicate,http://schema.org/description,10M+
-Predicate,http://schema.org/description-input,< 1K
-Predicate,http://schema.org/description-output,< 1K
-Predicate,http://schema.org/device,< 1K
-Predicate,http://schema.org/device-input,< 1K
-Predicate,http://schema.org/device-output,< 1K
-Predicate,http://schema.org/diagnosis,< 1K
-Predicate,http://schema.org/diagnosis-input,< 1K
-Predicate,http://schema.org/diagnosis-output,< 1K
-Predicate,http://schema.org/diagram,< 1K
-Predicate,http://schema.org/diagram-input,< 1K
-Predicate,http://schema.org/diagram-output,< 1K
-Predicate,http://schema.org/diet,< 1K
-Predicate,http://schema.org/diet-input,< 1K
-Predicate,http://schema.org/diet-output,< 1K
-Predicate,http://schema.org/dietFeatures,< 1K
-Predicate,http://schema.org/dietFeatures-input,< 1K
-Predicate,http://schema.org/dietFeatures-output,< 1K
-Predicate,http://schema.org/differentialDiagnosis,< 1K
-Predicate,http://schema.org/differentialDiagnosis-input,< 1K
-Predicate,http://schema.org/differentialDiagnosis-output,< 1K
-Predicate,http://schema.org/digitalSourceType,< 1K
-Predicate,http://schema.org/digitalSourceType-input,< 1K
-Predicate,http://schema.org/digitalSourceType-output,< 1K
-Predicate,http://schema.org/directApply,10K - 100K
-Predicate,http://schema.org/directApply-input,< 1K
-Predicate,http://schema.org/directApply-output,< 1K
-Predicate,http://schema.org/director,10K - 100K
-Predicate,http://schema.org/director-input,< 1K
-Predicate,http://schema.org/director-output,< 1K
-Predicate,http://schema.org/directors,< 1K
-Predicate,http://schema.org/directors-input,< 1K
-Predicate,http://schema.org/directors-output,< 1K
-Predicate,http://schema.org/disambiguatingDescription,10K - 100K
-Predicate,http://schema.org/disambiguatingDescription-input,< 1K
-Predicate,http://schema.org/disambiguatingDescription-output,< 1K
-Predicate,http://schema.org/discount,10K - 100K
-Predicate,http://schema.org/discount-input,< 1K
-Predicate,http://schema.org/discount-output,< 1K
-Predicate,http://schema.org/discountCode,< 1K
-Predicate,http://schema.org/discountCode-input,< 1K
-Predicate,http://schema.org/discountCode-output,< 1K
-Predicate,http://schema.org/discountCurrency,< 1K
-Predicate,http://schema.org/discountCurrency-input,< 1K
-Predicate,http://schema.org/discountCurrency-output,< 1K
-Predicate,http://schema.org/discusses,1K - 10K
-Predicate,http://schema.org/discusses-input,< 1K
-Predicate,http://schema.org/discusses-output,< 1K
-Predicate,http://schema.org/discussionUrl,10K - 100K
-Predicate,http://schema.org/discussionUrl-input,< 1K
-Predicate,http://schema.org/discussionUrl-output,< 1K
-Predicate,http://schema.org/diseasePreventionInfo,< 1K
-Predicate,http://schema.org/diseasePreventionInfo-input,< 1K
-Predicate,http://schema.org/diseasePreventionInfo-output,< 1K
-Predicate,http://schema.org/diseaseSpreadStatistics,< 1K
-Predicate,http://schema.org/diseaseSpreadStatistics-input,< 1K
-Predicate,http://schema.org/diseaseSpreadStatistics-output,< 1K
-Predicate,http://schema.org/displayLocation,< 1K
-Predicate,http://schema.org/displayLocation-input,< 1K
-Predicate,http://schema.org/displayLocation-output,< 1K
-Predicate,http://schema.org/dissolutionDate,< 1K
-Predicate,http://schema.org/dissolutionDate-input,< 1K
-Predicate,http://schema.org/dissolutionDate-output,< 1K
-Predicate,http://schema.org/distance,1K - 10K
-Predicate,http://schema.org/distance-input,< 1K
-Predicate,http://schema.org/distance-output,< 1K
-Predicate,http://schema.org/distinguishingSign,< 1K
-Predicate,http://schema.org/distinguishingSign-input,< 1K
-Predicate,http://schema.org/distinguishingSign-output,< 1K
-Predicate,http://schema.org/distribution,10K - 100K
-Predicate,http://schema.org/distribution-input,< 1K
-Predicate,http://schema.org/distribution-output,< 1K
-Predicate,http://schema.org/diversityPolicy,10K - 100K
-Predicate,http://schema.org/diversityPolicy-input,< 1K
-Predicate,http://schema.org/diversityPolicy-output,< 1K
-Predicate,http://schema.org/diversityStaffingReport,1K - 10K
-Predicate,http://schema.org/diversityStaffingReport-input,< 1K
-Predicate,http://schema.org/diversityStaffingReport-output,< 1K
-Predicate,http://schema.org/documentation,1K - 10K
-Predicate,http://schema.org/documentation-input,< 1K
-Predicate,http://schema.org/documentation-output,< 1K
-Predicate,http://schema.org/doesNotShip,10K - 100K
-Predicate,http://schema.org/doesNotShip-input,< 1K
-Predicate,http://schema.org/doesNotShip-output,< 1K
-Predicate,http://schema.org/domainIncludes,< 1K
-Predicate,http://schema.org/domainIncludes-input,< 1K
-Predicate,http://schema.org/domainIncludes-output,< 1K
-Predicate,http://schema.org/domiciledMortgage,< 1K
-Predicate,http://schema.org/domiciledMortgage-input,< 1K
-Predicate,http://schema.org/domiciledMortgage-output,< 1K
-Predicate,http://schema.org/doorTime,1K - 10K
-Predicate,http://schema.org/doorTime-input,< 1K
-Predicate,http://schema.org/doorTime-output,< 1K
-Predicate,http://schema.org/dosageForm,1K - 10K
-Predicate,http://schema.org/dosageForm-input,< 1K
-Predicate,http://schema.org/dosageForm-output,< 1K
-Predicate,http://schema.org/doseSchedule,< 1K
-Predicate,http://schema.org/doseSchedule-input,< 1K
-Predicate,http://schema.org/doseSchedule-output,< 1K
-Predicate,http://schema.org/doseUnit,< 1K
-Predicate,http://schema.org/doseUnit-input,< 1K
-Predicate,http://schema.org/doseUnit-output,< 1K
-Predicate,http://schema.org/doseValue,< 1K
-Predicate,http://schema.org/doseValue-input,< 1K
-Predicate,http://schema.org/doseValue-output,< 1K
-Predicate,http://schema.org/downPayment,< 1K
-Predicate,http://schema.org/downPayment-input,< 1K
-Predicate,http://schema.org/downPayment-output,< 1K
-Predicate,http://schema.org/downloadUrl,100K - 1M
-Predicate,http://schema.org/downloadUrl-input,< 1K
-Predicate,http://schema.org/downloadUrl-output,< 1K
-Predicate,http://schema.org/downvoteCount,1K - 10K
-Predicate,http://schema.org/downvoteCount-input,< 1K
-Predicate,http://schema.org/downvoteCount-output,< 1K
-Predicate,http://schema.org/drainsTo,< 1K
-Predicate,http://schema.org/drainsTo-input,< 1K
-Predicate,http://schema.org/drainsTo-output,< 1K
-Predicate,http://schema.org/driveWheelConfiguration,10K - 100K
-Predicate,http://schema.org/driveWheelConfiguration-input,< 1K
-Predicate,http://schema.org/driveWheelConfiguration-output,< 1K
-Predicate,http://schema.org/dropoffLocation,< 1K
-Predicate,http://schema.org/dropoffLocation-input,< 1K
-Predicate,http://schema.org/dropoffLocation-output,< 1K
-Predicate,http://schema.org/dropoffTime,< 1K
-Predicate,http://schema.org/dropoffTime-input,< 1K
-Predicate,http://schema.org/dropoffTime-output,< 1K
-Predicate,http://schema.org/drug,< 1K
-Predicate,http://schema.org/drug-input,< 1K
-Predicate,http://schema.org/drug-output,< 1K
-Predicate,http://schema.org/drugClass,1K - 10K
-Predicate,http://schema.org/drugClass-input,< 1K
-Predicate,http://schema.org/drugClass-output,< 1K
-Predicate,http://schema.org/drugUnit,< 1K
-Predicate,http://schema.org/drugUnit-input,< 1K
-Predicate,http://schema.org/drugUnit-output,< 1K
-Predicate,http://schema.org/duns,1K - 10K
-Predicate,http://schema.org/duns-input,< 1K
-Predicate,http://schema.org/duns-output,< 1K
-Predicate,http://schema.org/duplicateTherapy,< 1K
-Predicate,http://schema.org/duplicateTherapy-input,< 1K
-Predicate,http://schema.org/duplicateTherapy-output,< 1K
-Predicate,http://schema.org/duration,1M - 10M
-Predicate,http://schema.org/duration-input,< 1K
-Predicate,http://schema.org/duration-output,< 1K
-Predicate,http://schema.org/durationOfWarranty,1K - 10K
-Predicate,http://schema.org/durationOfWarranty-input,< 1K
-Predicate,http://schema.org/durationOfWarranty-output,< 1K
-Predicate,http://schema.org/duringMedia,< 1K
-Predicate,http://schema.org/duringMedia-input,< 1K
-Predicate,http://schema.org/duringMedia-output,< 1K
-Predicate,http://schema.org/earlyPrepaymentPenalty,< 1K
-Predicate,http://schema.org/earlyPrepaymentPenalty-input,< 1K
-Predicate,http://schema.org/earlyPrepaymentPenalty-output,< 1K
-Predicate,http://schema.org/editEIDR,< 1K
-Predicate,http://schema.org/editEIDR-input,< 1K
-Predicate,http://schema.org/editEIDR-output,< 1K
-Predicate,http://schema.org/editor,100K - 1M
-Predicate,http://schema.org/editor-input,< 1K
-Predicate,http://schema.org/editor-output,< 1K
-Predicate,http://schema.org/eduQuestionType,< 1K
-Predicate,http://schema.org/eduQuestionType-input,< 1K
-Predicate,http://schema.org/eduQuestionType-output,< 1K
-Predicate,http://schema.org/educationRequirements,10K - 100K
-Predicate,http://schema.org/educationRequirements-input,< 1K
-Predicate,http://schema.org/educationRequirements-output,< 1K
-Predicate,http://schema.org/educationalAlignment,1K - 10K
-Predicate,http://schema.org/educationalAlignment-input,< 1K
-Predicate,http://schema.org/educationalAlignment-output,< 1K
-Predicate,http://schema.org/educationalCredentialAwarded,10K - 100K
-Predicate,http://schema.org/educationalCredentialAwarded-input,< 1K
-Predicate,http://schema.org/educationalCredentialAwarded-output,< 1K
-Predicate,http://schema.org/educationalFramework,< 1K
-Predicate,http://schema.org/educationalFramework-input,< 1K
-Predicate,http://schema.org/educationalFramework-output,< 1K
-Predicate,http://schema.org/educationalLevel,10K - 100K
-Predicate,http://schema.org/educationalLevel-input,< 1K
-Predicate,http://schema.org/educationalLevel-output,< 1K
-Predicate,http://schema.org/educationalProgramMode,1K - 10K
-Predicate,http://schema.org/educationalProgramMode-input,< 1K
-Predicate,http://schema.org/educationalProgramMode-output,< 1K
-Predicate,http://schema.org/educationalRole,10K - 100K
-Predicate,http://schema.org/educationalRole-input,< 1K
-Predicate,http://schema.org/educationalRole-output,< 1K
-Predicate,http://schema.org/educationalUse,1K - 10K
-Predicate,http://schema.org/educationalUse-input,< 1K
-Predicate,http://schema.org/educationalUse-output,< 1K
-Predicate,http://schema.org/elevation,1K - 10K
-Predicate,http://schema.org/elevation-input,< 1K
-Predicate,http://schema.org/elevation-output,< 1K
-Predicate,http://schema.org/eligibilityToWorkRequirement,< 1K
-Predicate,http://schema.org/eligibilityToWorkRequirement-input,< 1K
-Predicate,http://schema.org/eligibilityToWorkRequirement-output,< 1K
-Predicate,http://schema.org/eligibleCustomerType,1K - 10K
-Predicate,http://schema.org/eligibleCustomerType-input,< 1K
-Predicate,http://schema.org/eligibleCustomerType-output,< 1K
-Predicate,http://schema.org/eligibleDuration,10K - 100K
-Predicate,http://schema.org/eligibleDuration-input,< 1K
-Predicate,http://schema.org/eligibleDuration-output,< 1K
-Predicate,http://schema.org/eligibleQuantity,10K - 100K
-Predicate,http://schema.org/eligibleQuantity-input,< 1K
-Predicate,http://schema.org/eligibleQuantity-output,< 1K
-Predicate,http://schema.org/eligibleRegion,10K - 100K
-Predicate,http://schema.org/eligibleRegion-input,< 1K
-Predicate,http://schema.org/eligibleRegion-output,< 1K
-Predicate,http://schema.org/eligibleTransactionVolume,10K - 100K
-Predicate,http://schema.org/eligibleTransactionVolume-input,< 1K
-Predicate,http://schema.org/eligibleTransactionVolume-output,< 1K
-Predicate,http://schema.org/eligibleWithSupplier,< 1K
-Predicate,http://schema.org/eligibleWithSupplier-input,< 1K
-Predicate,http://schema.org/eligibleWithSupplier-output,< 1K
-Predicate,http://schema.org/email,1M - 10M
-Predicate,http://schema.org/email-input,< 1K
-Predicate,http://schema.org/email-output,< 1K
-Predicate,http://schema.org/embedUrl,1M - 10M
-Predicate,http://schema.org/embedUrl-input,< 1K
-Predicate,http://schema.org/embedUrl-output,< 1K
-Predicate,http://schema.org/embeddedTextCaption,1K - 10K
-Predicate,http://schema.org/embeddedTextCaption-input,< 1K
-Predicate,http://schema.org/embeddedTextCaption-output,< 1K
-Predicate,http://schema.org/emissionsCO2,1K - 10K
-Predicate,http://schema.org/emissionsCO2-input,< 1K
-Predicate,http://schema.org/emissionsCO2-output,< 1K
-Predicate,http://schema.org/employee,100K - 1M
-Predicate,http://schema.org/employee-input,< 1K
-Predicate,http://schema.org/employee-output,< 1K
-Predicate,http://schema.org/employees,1K - 10K
-Predicate,http://schema.org/employees-input,< 1K
-Predicate,http://schema.org/employees-output,< 1K
-Predicate,http://schema.org/employerOverview,1K - 10K
-Predicate,http://schema.org/employerOverview-input,< 1K
-Predicate,http://schema.org/employerOverview-output,< 1K
-Predicate,http://schema.org/employmentType,100K - 1M
-Predicate,http://schema.org/employmentType-input,< 1K
-Predicate,http://schema.org/employmentType-output,< 1K
-Predicate,http://schema.org/employmentUnit,1K - 10K
-Predicate,http://schema.org/employmentUnit-input,< 1K
-Predicate,http://schema.org/employmentUnit-output,< 1K
-Predicate,http://schema.org/encodesBioChemEntity,< 1K
-Predicate,http://schema.org/encodesBioChemEntity-input,< 1K
-Predicate,http://schema.org/encodesBioChemEntity-output,< 1K
-Predicate,http://schema.org/encodesCreativeWork,< 1K
-Predicate,http://schema.org/encodesCreativeWork-input,< 1K
-Predicate,http://schema.org/encodesCreativeWork-output,< 1K
-Predicate,http://schema.org/encoding,100K - 1M
-Predicate,http://schema.org/encoding-input,< 1K
-Predicate,http://schema.org/encoding-output,< 1K
-Predicate,http://schema.org/encodingFormat,10K - 100K
-Predicate,http://schema.org/encodingFormat-input,< 1K
-Predicate,http://schema.org/encodingFormat-output,< 1K
-Predicate,http://schema.org/encodingType,< 1K
-Predicate,http://schema.org/encodingType-input,< 1K
-Predicate,http://schema.org/encodingType-output,< 1K
-Predicate,http://schema.org/encodings,< 1K
-Predicate,http://schema.org/encodings-input,< 1K
-Predicate,http://schema.org/encodings-output,< 1K
-Predicate,http://schema.org/endDate,100K - 1M
-Predicate,http://schema.org/endDate-input,< 1K
-Predicate,http://schema.org/endDate-output,< 1K
-Predicate,http://schema.org/endOffset,10K - 100K
-Predicate,http://schema.org/endOffset-input,< 1K
-Predicate,http://schema.org/endOffset-output,< 1K
-Predicate,http://schema.org/endTime,1K - 10K
-Predicate,http://schema.org/endTime-input,< 1K
-Predicate,http://schema.org/endTime-output,< 1K
-Predicate,http://schema.org/endorsee,< 1K
-Predicate,http://schema.org/endorsee-input,< 1K
-Predicate,http://schema.org/endorsee-output,< 1K
-Predicate,http://schema.org/endorsers,< 1K
-Predicate,http://schema.org/endorsers-input,< 1K
-Predicate,http://schema.org/endorsers-output,< 1K
-Predicate,http://schema.org/energyEfficiencyScaleMax,1K - 10K
-Predicate,http://schema.org/energyEfficiencyScaleMax-input,< 1K
-Predicate,http://schema.org/energyEfficiencyScaleMax-output,< 1K
-Predicate,http://schema.org/energyEfficiencyScaleMin,1K - 10K
-Predicate,http://schema.org/energyEfficiencyScaleMin-input,< 1K
-Predicate,http://schema.org/energyEfficiencyScaleMin-output,< 1K
-Predicate,http://schema.org/engineDisplacement,10K - 100K
-Predicate,http://schema.org/engineDisplacement-input,< 1K
-Predicate,http://schema.org/engineDisplacement-output,< 1K
-Predicate,http://schema.org/enginePower,10K - 100K
-Predicate,http://schema.org/enginePower-input,< 1K
-Predicate,http://schema.org/enginePower-output,< 1K
-Predicate,http://schema.org/engineType,1K - 10K
-Predicate,http://schema.org/engineType-input,< 1K
-Predicate,http://schema.org/engineType-output,< 1K
-Predicate,http://schema.org/entertainmentBusiness,< 1K
-Predicate,http://schema.org/entertainmentBusiness-input,< 1K
-Predicate,http://schema.org/entertainmentBusiness-output,< 1K
-Predicate,http://schema.org/epidemiology,< 1K
-Predicate,http://schema.org/epidemiology-input,< 1K
-Predicate,http://schema.org/epidemiology-output,< 1K
-Predicate,http://schema.org/episode,1K - 10K
-Predicate,http://schema.org/episode-input,< 1K
-Predicate,http://schema.org/episode-output,< 1K
-Predicate,http://schema.org/episodeNumber,10K - 100K
-Predicate,http://schema.org/episodeNumber-input,< 1K
-Predicate,http://schema.org/episodeNumber-output,< 1K
-Predicate,http://schema.org/episodes,< 1K
-Predicate,http://schema.org/episodes-input,< 1K
-Predicate,http://schema.org/episodes-output,< 1K
-Predicate,http://schema.org/equal,< 1K
-Predicate,http://schema.org/equal-input,< 1K
-Predicate,http://schema.org/equal-output,< 1K
-Predicate,http://schema.org/error,1K - 10K
-Predicate,http://schema.org/error-input,< 1K
-Predicate,http://schema.org/error-output,< 1K
-Predicate,http://schema.org/errorCode,< 1K
-Predicate,http://schema.org/errorCode-input,< 1K
-Predicate,http://schema.org/errorCode-output,< 1K
-Predicate,http://schema.org/estimatedCost,10K - 100K
-Predicate,http://schema.org/estimatedCost-input,< 1K
-Predicate,http://schema.org/estimatedCost-output,< 1K
-Predicate,http://schema.org/estimatedFlightDuration,< 1K
-Predicate,http://schema.org/estimatedFlightDuration-input,< 1K
-Predicate,http://schema.org/estimatedFlightDuration-output,< 1K
-Predicate,http://schema.org/estimatedSalary,1K - 10K
-Predicate,http://schema.org/estimatedSalary-input,< 1K
-Predicate,http://schema.org/estimatedSalary-output,< 1K
-Predicate,http://schema.org/estimatesRiskOf,< 1K
-Predicate,http://schema.org/estimatesRiskOf-input,< 1K
-Predicate,http://schema.org/estimatesRiskOf-output,< 1K
-Predicate,http://schema.org/ethicsPolicy,10K - 100K
-Predicate,http://schema.org/ethicsPolicy-input,< 1K
-Predicate,http://schema.org/ethicsPolicy-output,< 1K
-Predicate,http://schema.org/event,10K - 100K
-Predicate,http://schema.org/event-input,< 1K
-Predicate,http://schema.org/event-output,< 1K
-Predicate,http://schema.org/eventAttendanceMode,100K - 1M
-Predicate,http://schema.org/eventAttendanceMode-input,< 1K
-Predicate,http://schema.org/eventAttendanceMode-output,< 1K
-Predicate,http://schema.org/eventSchedule,1K - 10K
-Predicate,http://schema.org/eventSchedule-input,< 1K
-Predicate,http://schema.org/eventSchedule-output,< 1K
-Predicate,http://schema.org/eventStatus,100K - 1M
-Predicate,http://schema.org/eventStatus-input,< 1K
-Predicate,http://schema.org/eventStatus-output,< 1K
-Predicate,http://schema.org/events,1K - 10K
-Predicate,http://schema.org/events-input,< 1K
-Predicate,http://schema.org/events-output,< 1K
-Predicate,http://schema.org/evidenceLevel,< 1K
-Predicate,http://schema.org/evidenceLevel-input,< 1K
-Predicate,http://schema.org/evidenceLevel-output,< 1K
-Predicate,http://schema.org/evidenceOrigin,< 1K
-Predicate,http://schema.org/evidenceOrigin-input,< 1K
-Predicate,http://schema.org/evidenceOrigin-output,< 1K
-Predicate,http://schema.org/exampleOfWork,1K - 10K
-Predicate,http://schema.org/exampleOfWork-input,< 1K
-Predicate,http://schema.org/exampleOfWork-output,< 1K
-Predicate,http://schema.org/exceptDate,< 1K
-Predicate,http://schema.org/exceptDate-input,< 1K
-Predicate,http://schema.org/exceptDate-output,< 1K
-Predicate,http://schema.org/exchangeRateSpread,< 1K
-Predicate,http://schema.org/exchangeRateSpread-input,< 1K
-Predicate,http://schema.org/exchangeRateSpread-output,< 1K
-Predicate,http://schema.org/executableLibraryName,< 1K
-Predicate,http://schema.org/executableLibraryName-input,< 1K
-Predicate,http://schema.org/executableLibraryName-output,< 1K
-Predicate,http://schema.org/exerciseCourse,< 1K
-Predicate,http://schema.org/exerciseCourse-input,< 1K
-Predicate,http://schema.org/exerciseCourse-output,< 1K
-Predicate,http://schema.org/exercisePlan,< 1K
-Predicate,http://schema.org/exercisePlan-input,< 1K
-Predicate,http://schema.org/exercisePlan-output,< 1K
-Predicate,http://schema.org/exerciseRelatedDiet,< 1K
-Predicate,http://schema.org/exerciseRelatedDiet-input,< 1K
-Predicate,http://schema.org/exerciseRelatedDiet-output,< 1K
-Predicate,http://schema.org/exerciseType,< 1K
-Predicate,http://schema.org/exerciseType-input,< 1K
-Predicate,http://schema.org/exerciseType-output,< 1K
-Predicate,http://schema.org/exifData,1K - 10K
-Predicate,http://schema.org/exifData-input,< 1K
-Predicate,http://schema.org/exifData-output,< 1K
-Predicate,http://schema.org/expectedArrivalFrom,< 1K
-Predicate,http://schema.org/expectedArrivalFrom-input,< 1K
-Predicate,http://schema.org/expectedArrivalFrom-output,< 1K
-Predicate,http://schema.org/expectedArrivalUntil,< 1K
-Predicate,http://schema.org/expectedArrivalUntil-input,< 1K
-Predicate,http://schema.org/expectedArrivalUntil-output,< 1K
-Predicate,http://schema.org/expectedPrognosis,< 1K
-Predicate,http://schema.org/expectedPrognosis-input,< 1K
-Predicate,http://schema.org/expectedPrognosis-output,< 1K
-Predicate,http://schema.org/expectsAcceptanceOf,1K - 10K
-Predicate,http://schema.org/expectsAcceptanceOf-input,< 1K
-Predicate,http://schema.org/expectsAcceptanceOf-output,< 1K
-Predicate,http://schema.org/experienceInPlaceOfEducation,1K - 10K
-Predicate,http://schema.org/experienceInPlaceOfEducation-input,< 1K
-Predicate,http://schema.org/experienceInPlaceOfEducation-output,< 1K
-Predicate,http://schema.org/experienceRequirements,10K - 100K
-Predicate,http://schema.org/experienceRequirements-input,< 1K
-Predicate,http://schema.org/experienceRequirements-output,< 1K
-Predicate,http://schema.org/expertConsiderations,< 1K
-Predicate,http://schema.org/expertConsiderations-input,< 1K
-Predicate,http://schema.org/expertConsiderations-output,< 1K
-Predicate,http://schema.org/expires,1K - 10K
-Predicate,http://schema.org/expires-input,< 1K
-Predicate,http://schema.org/expires-output,< 1K
-Predicate,http://schema.org/expressedIn,< 1K
-Predicate,http://schema.org/expressedIn-input,< 1K
-Predicate,http://schema.org/expressedIn-output,< 1K
-Predicate,http://schema.org/extendedAddress,< 1K
-Predicate,http://schema.org/extendedAddress-input,< 1K
-Predicate,http://schema.org/extendedAddress-output,< 1K
-Predicate,http://schema.org/familyName,100K - 1M
-Predicate,http://schema.org/familyName-input,< 1K
-Predicate,http://schema.org/familyName-output,< 1K
-Predicate,http://schema.org/fatContent,10K - 100K
-Predicate,http://schema.org/fatContent-input,< 1K
-Predicate,http://schema.org/fatContent-output,< 1K
-Predicate,http://schema.org/faxNumber,100K - 1M
-Predicate,http://schema.org/faxNumber-input,< 1K
-Predicate,http://schema.org/faxNumber-output,< 1K
-Predicate,http://schema.org/featureList,100K - 1M
-Predicate,http://schema.org/featureList-input,< 1K
-Predicate,http://schema.org/featureList-output,< 1K
-Predicate,http://schema.org/feesAndCommissionsSpecification,1K - 10K
-Predicate,http://schema.org/feesAndCommissionsSpecification-input,< 1K
-Predicate,http://schema.org/feesAndCommissionsSpecification-output,< 1K
-Predicate,http://schema.org/fiberContent,10K - 100K
-Predicate,http://schema.org/fiberContent-input,< 1K
-Predicate,http://schema.org/fiberContent-output,< 1K
-Predicate,http://schema.org/fileFormat,10K - 100K
-Predicate,http://schema.org/fileFormat-input,< 1K
-Predicate,http://schema.org/fileFormat-output,< 1K
-Predicate,http://schema.org/fileSize,10K - 100K
-Predicate,http://schema.org/fileSize-input,< 1K
-Predicate,http://schema.org/fileSize-output,< 1K
-Predicate,http://schema.org/financialAidEligible,< 1K
-Predicate,http://schema.org/financialAidEligible-input,< 1K
-Predicate,http://schema.org/financialAidEligible-output,< 1K
-Predicate,http://schema.org/firstAppearance,< 1K
-Predicate,http://schema.org/firstAppearance-input,< 1K
-Predicate,http://schema.org/firstAppearance-output,< 1K
-Predicate,http://schema.org/firstPerformance,< 1K
-Predicate,http://schema.org/firstPerformance-input,< 1K
-Predicate,http://schema.org/firstPerformance-output,< 1K
-Predicate,http://schema.org/flightDistance,< 1K
-Predicate,http://schema.org/flightDistance-input,< 1K
-Predicate,http://schema.org/flightDistance-output,< 1K
-Predicate,http://schema.org/flightNumber,< 1K
-Predicate,http://schema.org/flightNumber-input,< 1K
-Predicate,http://schema.org/flightNumber-output,< 1K
-Predicate,http://schema.org/floorLevel,1K - 10K
-Predicate,http://schema.org/floorLevel-input,< 1K
-Predicate,http://schema.org/floorLevel-output,< 1K
-Predicate,http://schema.org/floorLimit,< 1K
-Predicate,http://schema.org/floorLimit-input,< 1K
-Predicate,http://schema.org/floorLimit-output,< 1K
-Predicate,http://schema.org/floorSize,100K - 1M
-Predicate,http://schema.org/floorSize-input,< 1K
-Predicate,http://schema.org/floorSize-output,< 1K
-Predicate,http://schema.org/followee,< 1K
-Predicate,http://schema.org/followee-input,< 1K
-Predicate,http://schema.org/followee-output,< 1K
-Predicate,http://schema.org/follows,< 1K
-Predicate,http://schema.org/follows-input,< 1K
-Predicate,http://schema.org/follows-output,< 1K
-Predicate,http://schema.org/followup,1K - 10K
-Predicate,http://schema.org/followup-input,< 1K
-Predicate,http://schema.org/followup-output,< 1K
-Predicate,http://schema.org/foodEstablishment,< 1K
-Predicate,http://schema.org/foodEstablishment-input,< 1K
-Predicate,http://schema.org/foodEstablishment-output,< 1K
-Predicate,http://schema.org/foodEvent,< 1K
-Predicate,http://schema.org/foodEvent-input,< 1K
-Predicate,http://schema.org/foodEvent-output,< 1K
-Predicate,http://schema.org/foodWarning,< 1K
-Predicate,http://schema.org/foodWarning-input,< 1K
-Predicate,http://schema.org/foodWarning-output,< 1K
-Predicate,http://schema.org/founder,100K - 1M
-Predicate,http://schema.org/founder-input,< 1K
-Predicate,http://schema.org/founder-output,< 1K
-Predicate,http://schema.org/founders,10K - 100K
-Predicate,http://schema.org/founders-input,< 1K
-Predicate,http://schema.org/founders-output,< 1K
-Predicate,http://schema.org/foundingDate,100K - 1M
-Predicate,http://schema.org/foundingDate-input,< 1K
-Predicate,http://schema.org/foundingDate-output,< 1K
-Predicate,http://schema.org/foundingLocation,10K - 100K
-Predicate,http://schema.org/foundingLocation-input,< 1K
-Predicate,http://schema.org/foundingLocation-output,< 1K
-Predicate,http://schema.org/free,1K - 10K
-Predicate,http://schema.org/free-input,< 1K
-Predicate,http://schema.org/free-output,< 1K
-Predicate,http://schema.org/freeShippingThreshold,10K - 100K
-Predicate,http://schema.org/freeShippingThreshold-input,< 1K
-Predicate,http://schema.org/freeShippingThreshold-output,< 1K
-Predicate,http://schema.org/frequency,< 1K
-Predicate,http://schema.org/frequency-input,< 1K
-Predicate,http://schema.org/frequency-output,< 1K
-Predicate,http://schema.org/fromLocation,1K - 10K
-Predicate,http://schema.org/fromLocation-input,< 1K
-Predicate,http://schema.org/fromLocation-output,< 1K
-Predicate,http://schema.org/fuelCapacity,1K - 10K
-Predicate,http://schema.org/fuelCapacity-input,< 1K
-Predicate,http://schema.org/fuelCapacity-output,< 1K
-Predicate,http://schema.org/fuelConsumption,1K - 10K
-Predicate,http://schema.org/fuelConsumption-input,< 1K
-Predicate,http://schema.org/fuelConsumption-output,< 1K
-Predicate,http://schema.org/fuelEfficiency,1K - 10K
-Predicate,http://schema.org/fuelEfficiency-input,< 1K
-Predicate,http://schema.org/fuelEfficiency-output,< 1K
-Predicate,http://schema.org/fuelType,10K - 100K
-Predicate,http://schema.org/fuelType-input,< 1K
-Predicate,http://schema.org/fuelType-output,< 1K
-Predicate,http://schema.org/fulfillmentType,10K - 100K
-Predicate,http://schema.org/fulfillmentType-input,< 1K
-Predicate,http://schema.org/fulfillmentType-output,< 1K
-Predicate,http://schema.org/functionalClass,< 1K
-Predicate,http://schema.org/functionalClass-input,< 1K
-Predicate,http://schema.org/functionalClass-output,< 1K
-Predicate,http://schema.org/fundedItem,< 1K
-Predicate,http://schema.org/fundedItem-input,< 1K
-Predicate,http://schema.org/fundedItem-output,< 1K
-Predicate,http://schema.org/funder,1K - 10K
-Predicate,http://schema.org/funder-input,< 1K
-Predicate,http://schema.org/funder-output,< 1K
-Predicate,http://schema.org/funding,1K - 10K
-Predicate,http://schema.org/funding-input,< 1K
-Predicate,http://schema.org/funding-output,< 1K
-Predicate,http://schema.org/game,10K - 100K
-Predicate,http://schema.org/game-input,< 1K
-Predicate,http://schema.org/game-output,< 1K
-Predicate,http://schema.org/gameAvailabilityType,< 1K
-Predicate,http://schema.org/gameAvailabilityType-input,< 1K
-Predicate,http://schema.org/gameAvailabilityType-output,< 1K
-Predicate,http://schema.org/gameEdition,< 1K
-Predicate,http://schema.org/gameEdition-input,< 1K
-Predicate,http://schema.org/gameEdition-output,< 1K
-Predicate,http://schema.org/gameItem,1K - 10K
-Predicate,http://schema.org/gameItem-input,< 1K
-Predicate,http://schema.org/gameItem-output,< 1K
-Predicate,http://schema.org/gameLocation,10K - 100K
-Predicate,http://schema.org/gameLocation-input,< 1K
-Predicate,http://schema.org/gameLocation-output,< 1K
-Predicate,http://schema.org/gamePlatform,10K - 100K
-Predicate,http://schema.org/gamePlatform-input,< 1K
-Predicate,http://schema.org/gamePlatform-output,< 1K
-Predicate,http://schema.org/gameServer,< 1K
-Predicate,http://schema.org/gameServer-input,< 1K
-Predicate,http://schema.org/gameServer-output,< 1K
-Predicate,http://schema.org/gameTip,< 1K
-Predicate,http://schema.org/gameTip-input,< 1K
-Predicate,http://schema.org/gameTip-output,< 1K
-Predicate,http://schema.org/gender,10K - 100K
-Predicate,http://schema.org/gender-input,< 1K
-Predicate,http://schema.org/gender-output,< 1K
-Predicate,http://schema.org/genre,100K - 1M
-Predicate,http://schema.org/genre-input,< 1K
-Predicate,http://schema.org/genre-output,< 1K
-Predicate,http://schema.org/geo,1M - 10M
-Predicate,http://schema.org/geo-input,< 1K
-Predicate,http://schema.org/geo-output,< 1K
-Predicate,http://schema.org/geoContains,< 1K
-Predicate,http://schema.org/geoContains-input,< 1K
-Predicate,http://schema.org/geoContains-output,< 1K
-Predicate,http://schema.org/geoCoveredBy,< 1K
-Predicate,http://schema.org/geoCoveredBy-input,< 1K
-Predicate,http://schema.org/geoCoveredBy-output,< 1K
-Predicate,http://schema.org/geoCovers,< 1K
-Predicate,http://schema.org/geoCovers-input,< 1K
-Predicate,http://schema.org/geoCovers-output,< 1K
-Predicate,http://schema.org/geoCrosses,< 1K
-Predicate,http://schema.org/geoCrosses-input,< 1K
-Predicate,http://schema.org/geoCrosses-output,< 1K
-Predicate,http://schema.org/geoDisjoint,< 1K
-Predicate,http://schema.org/geoDisjoint-input,< 1K
-Predicate,http://schema.org/geoDisjoint-output,< 1K
-Predicate,http://schema.org/geoEquals,< 1K
-Predicate,http://schema.org/geoEquals-input,< 1K
-Predicate,http://schema.org/geoEquals-output,< 1K
-Predicate,http://schema.org/geoIntersects,< 1K
-Predicate,http://schema.org/geoIntersects-input,< 1K
-Predicate,http://schema.org/geoIntersects-output,< 1K
-Predicate,http://schema.org/geoMidpoint,100K - 1M
-Predicate,http://schema.org/geoMidpoint-input,< 1K
-Predicate,http://schema.org/geoMidpoint-output,< 1K
-Predicate,http://schema.org/geoOverlaps,< 1K
-Predicate,http://schema.org/geoOverlaps-input,< 1K
-Predicate,http://schema.org/geoOverlaps-output,< 1K
-Predicate,http://schema.org/geoRadius,100K - 1M
-Predicate,http://schema.org/geoRadius-input,< 1K
-Predicate,http://schema.org/geoRadius-output,< 1K
-Predicate,http://schema.org/geoTouches,< 1K
-Predicate,http://schema.org/geoTouches-input,< 1K
-Predicate,http://schema.org/geoTouches-output,< 1K
-Predicate,http://schema.org/geoWithin,< 1K
-Predicate,http://schema.org/geoWithin-input,< 1K
-Predicate,http://schema.org/geoWithin-output,< 1K
-Predicate,http://schema.org/geographicArea,10K - 100K
-Predicate,http://schema.org/geographicArea-input,< 1K
-Predicate,http://schema.org/geographicArea-output,< 1K
-Predicate,http://schema.org/gettingTestedInfo,< 1K
-Predicate,http://schema.org/gettingTestedInfo-input,< 1K
-Predicate,http://schema.org/gettingTestedInfo-output,< 1K
-Predicate,http://schema.org/givenName,100K - 1M
-Predicate,http://schema.org/givenName-input,< 1K
-Predicate,http://schema.org/givenName-output,< 1K
-Predicate,http://schema.org/globalLocationNumber,1K - 10K
-Predicate,http://schema.org/globalLocationNumber-input,< 1K
-Predicate,http://schema.org/globalLocationNumber-output,< 1K
-Predicate,http://schema.org/governmentBenefitsInfo,< 1K
-Predicate,http://schema.org/governmentBenefitsInfo-input,< 1K
-Predicate,http://schema.org/governmentBenefitsInfo-output,< 1K
-Predicate,http://schema.org/gracePeriod,< 1K
-Predicate,http://schema.org/gracePeriod-input,< 1K
-Predicate,http://schema.org/gracePeriod-output,< 1K
-Predicate,http://schema.org/grantee,< 1K
-Predicate,http://schema.org/grantee-input,< 1K
-Predicate,http://schema.org/grantee-output,< 1K
-Predicate,http://schema.org/greater,< 1K
-Predicate,http://schema.org/greater-input,< 1K
-Predicate,http://schema.org/greater-output,< 1K
-Predicate,http://schema.org/greaterOrEqual,< 1K
-Predicate,http://schema.org/greaterOrEqual-input,< 1K
-Predicate,http://schema.org/greaterOrEqual-output,< 1K
-Predicate,http://schema.org/gtin,100K - 1M
-Predicate,http://schema.org/gtin-input,< 1K
-Predicate,http://schema.org/gtin-output,< 1K
-Predicate,http://schema.org/gtin12,100K - 1M
-Predicate,http://schema.org/gtin12-input,< 1K
-Predicate,http://schema.org/gtin12-output,< 1K
-Predicate,http://schema.org/gtin13,100K - 1M
-Predicate,http://schema.org/gtin13-input,< 1K
-Predicate,http://schema.org/gtin13-output,< 1K
-Predicate,http://schema.org/gtin14,10K - 100K
-Predicate,http://schema.org/gtin14-input,< 1K
-Predicate,http://schema.org/gtin14-output,< 1K
-Predicate,http://schema.org/gtin8,10K - 100K
-Predicate,http://schema.org/gtin8-input,< 1K
-Predicate,http://schema.org/gtin8-output,< 1K
-Predicate,http://schema.org/guideline,< 1K
-Predicate,http://schema.org/guideline-input,< 1K
-Predicate,http://schema.org/guideline-output,< 1K
-Predicate,http://schema.org/guidelineDate,< 1K
-Predicate,http://schema.org/guidelineDate-input,< 1K
-Predicate,http://schema.org/guidelineDate-output,< 1K
-Predicate,http://schema.org/guidelineSubject,< 1K
-Predicate,http://schema.org/guidelineSubject-input,< 1K
-Predicate,http://schema.org/guidelineSubject-output,< 1K
-Predicate,http://schema.org/handlingTime,100K - 1M
-Predicate,http://schema.org/handlingTime-input,< 1K
-Predicate,http://schema.org/handlingTime-output,< 1K
-Predicate,http://schema.org/hasAdultConsideration,< 1K
-Predicate,http://schema.org/hasAdultConsideration-input,< 1K
-Predicate,http://schema.org/hasAdultConsideration-output,< 1K
-Predicate,http://schema.org/hasBioChemEntityPart,< 1K
-Predicate,http://schema.org/hasBioChemEntityPart-input,< 1K
-Predicate,http://schema.org/hasBioChemEntityPart-output,< 1K
-Predicate,http://schema.org/hasBioPolymerSequence,< 1K
-Predicate,http://schema.org/hasBioPolymerSequence-input,< 1K
-Predicate,http://schema.org/hasBioPolymerSequence-output,< 1K
-Predicate,http://schema.org/hasBroadcastChannel,< 1K
-Predicate,http://schema.org/hasBroadcastChannel-input,< 1K
-Predicate,http://schema.org/hasBroadcastChannel-output,< 1K
-Predicate,http://schema.org/hasCategoryCode,< 1K
-Predicate,http://schema.org/hasCategoryCode-input,< 1K
-Predicate,http://schema.org/hasCategoryCode-output,< 1K
-Predicate,http://schema.org/hasCertification,1K - 10K
-Predicate,http://schema.org/hasCertification-input,< 1K
-Predicate,http://schema.org/hasCertification-output,< 1K
-Predicate,http://schema.org/hasCourse,1K - 10K
-Predicate,http://schema.org/hasCourse-input,< 1K
-Predicate,http://schema.org/hasCourse-output,< 1K
-Predicate,http://schema.org/hasCourseInstance,10K - 100K
-Predicate,http://schema.org/hasCourseInstance-input,< 1K
-Predicate,http://schema.org/hasCourseInstance-output,< 1K
-Predicate,http://schema.org/hasCredential,10K - 100K
-Predicate,http://schema.org/hasCredential-input,< 1K
-Predicate,http://schema.org/hasCredential-output,< 1K
-Predicate,http://schema.org/hasDefinedTerm,1K - 10K
-Predicate,http://schema.org/hasDefinedTerm-input,< 1K
-Predicate,http://schema.org/hasDefinedTerm-output,< 1K
-Predicate,http://schema.org/hasDeliveryMethod,< 1K
-Predicate,http://schema.org/hasDeliveryMethod-input,< 1K
-Predicate,http://schema.org/hasDeliveryMethod-output,< 1K
-Predicate,http://schema.org/hasDigitalDocumentPermission,< 1K
-Predicate,http://schema.org/hasDigitalDocumentPermission-input,< 1K
-Predicate,http://schema.org/hasDigitalDocumentPermission-output,< 1K
-Predicate,http://schema.org/hasDriveThroughService,< 1K
-Predicate,http://schema.org/hasDriveThroughService-input,< 1K
-Predicate,http://schema.org/hasDriveThroughService-output,< 1K
-Predicate,http://schema.org/hasEnergyConsumptionDetails,1K - 10K
-Predicate,http://schema.org/hasEnergyConsumptionDetails-input,< 1K
-Predicate,http://schema.org/hasEnergyConsumptionDetails-output,< 1K
-Predicate,http://schema.org/hasEnergyEfficiencyCategory,1K - 10K
-Predicate,http://schema.org/hasEnergyEfficiencyCategory-input,< 1K
-Predicate,http://schema.org/hasEnergyEfficiencyCategory-output,< 1K
-Predicate,http://schema.org/hasGS1DigitalLink,< 1K
-Predicate,http://schema.org/hasGS1DigitalLink-input,< 1K
-Predicate,http://schema.org/hasGS1DigitalLink-output,< 1K
-Predicate,http://schema.org/hasHealthAspect,< 1K
-Predicate,http://schema.org/hasHealthAspect-input,< 1K
-Predicate,http://schema.org/hasHealthAspect-output,< 1K
-Predicate,http://schema.org/hasMap,100K - 1M
-Predicate,http://schema.org/hasMap-input,< 1K
-Predicate,http://schema.org/hasMap-output,< 1K
-Predicate,http://schema.org/hasMeasurement,1K - 10K
-Predicate,http://schema.org/hasMeasurement-input,< 1K
-Predicate,http://schema.org/hasMeasurement-output,< 1K
-Predicate,http://schema.org/hasMemberProgram,1K - 10K
-Predicate,http://schema.org/hasMemberProgram-input,< 1K
-Predicate,http://schema.org/hasMemberProgram-output,< 1K
-Predicate,http://schema.org/hasMenu,10K - 100K
-Predicate,http://schema.org/hasMenu-input,< 1K
-Predicate,http://schema.org/hasMenu-output,< 1K
-Predicate,http://schema.org/hasMenuItem,10K - 100K
-Predicate,http://schema.org/hasMenuItem-input,< 1K
-Predicate,http://schema.org/hasMenuItem-output,< 1K
-Predicate,http://schema.org/hasMenuSection,10K - 100K
-Predicate,http://schema.org/hasMenuSection-input,< 1K
-Predicate,http://schema.org/hasMenuSection-output,< 1K
-Predicate,http://schema.org/hasMerchantReturnPolicy,100K - 1M
-Predicate,http://schema.org/hasMerchantReturnPolicy-input,< 1K
-Predicate,http://schema.org/hasMerchantReturnPolicy-output,< 1K
-Predicate,http://schema.org/hasMolecularFunction,< 1K
-Predicate,http://schema.org/hasMolecularFunction-input,< 1K
-Predicate,http://schema.org/hasMolecularFunction-output,< 1K
-Predicate,http://schema.org/hasOccupation,10K - 100K
-Predicate,http://schema.org/hasOccupation-input,< 1K
-Predicate,http://schema.org/hasOccupation-output,< 1K
-Predicate,http://schema.org/hasOfferCatalog,100K - 1M
-Predicate,http://schema.org/hasOfferCatalog-input,< 1K
-Predicate,http://schema.org/hasOfferCatalog-output,< 1K
-Predicate,http://schema.org/hasPOS,1K - 10K
-Predicate,http://schema.org/hasPOS-input,< 1K
-Predicate,http://schema.org/hasPOS-output,< 1K
-Predicate,http://schema.org/hasPart,100K - 1M
-Predicate,http://schema.org/hasPart-input,< 1K
-Predicate,http://schema.org/hasPart-output,< 1K
-Predicate,http://schema.org/hasParticipationOffer,< 1K
-Predicate,http://schema.org/hasParticipationOffer-input,< 1K
-Predicate,http://schema.org/hasParticipationOffer-output,< 1K
-Predicate,http://schema.org/hasProductReturnPolicy,< 1K
-Predicate,http://schema.org/hasProductReturnPolicy-input,< 1K
-Predicate,http://schema.org/hasProductReturnPolicy-output,< 1K
-Predicate,http://schema.org/hasRepresentation,< 1K
-Predicate,http://schema.org/hasRepresentation-input,< 1K
-Predicate,http://schema.org/hasRepresentation-output,< 1K
-Predicate,http://schema.org/hasShippingService,10K - 100K
-Predicate,http://schema.org/hasShippingService-input,< 1K
-Predicate,http://schema.org/hasShippingService-output,< 1K
-Predicate,http://schema.org/hasSponsorshipOffer,< 1K
-Predicate,http://schema.org/hasSponsorshipOffer-input,< 1K
-Predicate,http://schema.org/hasSponsorshipOffer-output,< 1K
-Predicate,http://schema.org/hasStore,< 1K
-Predicate,http://schema.org/hasStore-input,< 1K
-Predicate,http://schema.org/hasStore-output,< 1K
-Predicate,http://schema.org/hasTierBenefit,< 1K
-Predicate,http://schema.org/hasTierBenefit-input,< 1K
-Predicate,http://schema.org/hasTierBenefit-output,< 1K
-Predicate,http://schema.org/hasTierRequirement,< 1K
-Predicate,http://schema.org/hasTierRequirement-input,< 1K
-Predicate,http://schema.org/hasTierRequirement-output,< 1K
-Predicate,http://schema.org/hasTiers,< 1K
-Predicate,http://schema.org/hasTiers-input,< 1K
-Predicate,http://schema.org/hasTiers-output,< 1K
-Predicate,http://schema.org/hasVariant,100K - 1M
-Predicate,http://schema.org/hasVariant-input,< 1K
-Predicate,http://schema.org/hasVariant-output,< 1K
-Predicate,http://schema.org/headline,10M+
-Predicate,http://schema.org/headline-input,< 1K
-Predicate,http://schema.org/headline-output,< 1K
-Predicate,http://schema.org/healthCondition,1K - 10K
-Predicate,http://schema.org/healthCondition-input,< 1K
-Predicate,http://schema.org/healthCondition-output,< 1K
-Predicate,http://schema.org/healthPlanCoinsuranceOption,< 1K
-Predicate,http://schema.org/healthPlanCoinsuranceOption-input,< 1K
-Predicate,http://schema.org/healthPlanCoinsuranceOption-output,< 1K
-Predicate,http://schema.org/healthPlanCoinsuranceRate,< 1K
-Predicate,http://schema.org/healthPlanCoinsuranceRate-input,< 1K
-Predicate,http://schema.org/healthPlanCoinsuranceRate-output,< 1K
-Predicate,http://schema.org/healthPlanCopay,< 1K
-Predicate,http://schema.org/healthPlanCopay-input,< 1K
-Predicate,http://schema.org/healthPlanCopay-output,< 1K
-Predicate,http://schema.org/healthPlanCopayOption,< 1K
-Predicate,http://schema.org/healthPlanCopayOption-input,< 1K
-Predicate,http://schema.org/healthPlanCopayOption-output,< 1K
-Predicate,http://schema.org/healthPlanCostSharing,< 1K
-Predicate,http://schema.org/healthPlanCostSharing-input,< 1K
-Predicate,http://schema.org/healthPlanCostSharing-output,< 1K
-Predicate,http://schema.org/healthPlanDrugOption,< 1K
-Predicate,http://schema.org/healthPlanDrugOption-input,< 1K
-Predicate,http://schema.org/healthPlanDrugOption-output,< 1K
-Predicate,http://schema.org/healthPlanDrugTier,< 1K
-Predicate,http://schema.org/healthPlanDrugTier-input,< 1K
-Predicate,http://schema.org/healthPlanDrugTier-output,< 1K
-Predicate,http://schema.org/healthPlanId,< 1K
-Predicate,http://schema.org/healthPlanId-input,< 1K
-Predicate,http://schema.org/healthPlanId-output,< 1K
-Predicate,http://schema.org/healthPlanMarketingUrl,< 1K
-Predicate,http://schema.org/healthPlanMarketingUrl-input,< 1K
-Predicate,http://schema.org/healthPlanMarketingUrl-output,< 1K
-Predicate,http://schema.org/healthPlanNetworkId,< 1K
-Predicate,http://schema.org/healthPlanNetworkId-input,< 1K
-Predicate,http://schema.org/healthPlanNetworkId-output,< 1K
-Predicate,http://schema.org/healthPlanNetworkTier,< 1K
-Predicate,http://schema.org/healthPlanNetworkTier-input,< 1K
-Predicate,http://schema.org/healthPlanNetworkTier-output,< 1K
-Predicate,http://schema.org/healthPlanPharmacyCategory,< 1K
-Predicate,http://schema.org/healthPlanPharmacyCategory-input,< 1K
-Predicate,http://schema.org/healthPlanPharmacyCategory-output,< 1K
-Predicate,http://schema.org/healthcareReportingData,< 1K
-Predicate,http://schema.org/healthcareReportingData-input,< 1K
-Predicate,http://schema.org/healthcareReportingData-output,< 1K
-Predicate,http://schema.org/height,10M+
-Predicate,http://schema.org/height-input,< 1K
-Predicate,http://schema.org/height-output,< 1K
-Predicate,http://schema.org/highPrice,1M - 10M
-Predicate,http://schema.org/highPrice-input,< 1K
-Predicate,http://schema.org/highPrice-output,< 1K
-Predicate,http://schema.org/hiringOrganization,100K - 1M
-Predicate,http://schema.org/hiringOrganization-input,< 1K
-Predicate,http://schema.org/hiringOrganization-output,< 1K
-Predicate,http://schema.org/holdingArchive,< 1K
-Predicate,http://schema.org/holdingArchive-input,< 1K
-Predicate,http://schema.org/holdingArchive-output,< 1K
-Predicate,http://schema.org/homeLocation,10K - 100K
-Predicate,http://schema.org/homeLocation-input,< 1K
-Predicate,http://schema.org/homeLocation-output,< 1K
-Predicate,http://schema.org/homeTeam,10K - 100K
-Predicate,http://schema.org/homeTeam-input,< 1K
-Predicate,http://schema.org/homeTeam-output,< 1K
-Predicate,http://schema.org/honorificPrefix,10K - 100K
-Predicate,http://schema.org/honorificPrefix-input,< 1K
-Predicate,http://schema.org/honorificPrefix-output,< 1K
-Predicate,http://schema.org/honorificSuffix,10K - 100K
-Predicate,http://schema.org/honorificSuffix-input,< 1K
-Predicate,http://schema.org/honorificSuffix-output,< 1K
-Predicate,http://schema.org/hospitalAffiliation,1K - 10K
-Predicate,http://schema.org/hospitalAffiliation-input,< 1K
-Predicate,http://schema.org/hospitalAffiliation-output,< 1K
-Predicate,http://schema.org/hostingOrganization,1K - 10K
-Predicate,http://schema.org/hostingOrganization-input,< 1K
-Predicate,http://schema.org/hostingOrganization-output,< 1K
-Predicate,http://schema.org/hoursAvailable,100K - 1M
-Predicate,http://schema.org/hoursAvailable-input,< 1K
-Predicate,http://schema.org/hoursAvailable-output,< 1K
-Predicate,http://schema.org/howPerformed,1K - 10K
-Predicate,http://schema.org/howPerformed-input,< 1K
-Predicate,http://schema.org/howPerformed-output,< 1K
-Predicate,http://schema.org/httpMethod,1K - 10K
-Predicate,http://schema.org/httpMethod-input,< 1K
-Predicate,http://schema.org/httpMethod-output,< 1K
-Predicate,http://schema.org/iataCode,1K - 10K
-Predicate,http://schema.org/iataCode-input,< 1K
-Predicate,http://schema.org/iataCode-output,< 1K
-Predicate,http://schema.org/icaoCode,< 1K
-Predicate,http://schema.org/icaoCode-input,< 1K
-Predicate,http://schema.org/icaoCode-output,< 1K
-Predicate,http://schema.org/identifier,100K - 1M
-Predicate,http://schema.org/identifier-input,< 1K
-Predicate,http://schema.org/identifier-output,< 1K
-Predicate,http://schema.org/identifyingExam,< 1K
-Predicate,http://schema.org/identifyingExam-input,< 1K
-Predicate,http://schema.org/identifyingExam-output,< 1K
-Predicate,http://schema.org/identifyingTest,< 1K
-Predicate,http://schema.org/identifyingTest-input,< 1K
-Predicate,http://schema.org/identifyingTest-output,< 1K
-Predicate,http://schema.org/illustrator,1K - 10K
-Predicate,http://schema.org/illustrator-input,< 1K
-Predicate,http://schema.org/illustrator-output,< 1K
-Predicate,http://schema.org/image,10M+
-Predicate,http://schema.org/image-input,< 1K
-Predicate,http://schema.org/image-output,< 1K
-Predicate,http://schema.org/imagingTechnique,< 1K
-Predicate,http://schema.org/imagingTechnique-input,< 1K
-Predicate,http://schema.org/imagingTechnique-output,< 1K
-Predicate,http://schema.org/inAlbum,10K - 100K
-Predicate,http://schema.org/inAlbum-input,< 1K
-Predicate,http://schema.org/inAlbum-output,< 1K
-Predicate,http://schema.org/inBroadcastLineup,< 1K
-Predicate,http://schema.org/inBroadcastLineup-input,< 1K
-Predicate,http://schema.org/inBroadcastLineup-output,< 1K
-Predicate,http://schema.org/inChI,< 1K
-Predicate,http://schema.org/inChI-input,< 1K
-Predicate,http://schema.org/inChI-output,< 1K
-Predicate,http://schema.org/inChIKey,< 1K
-Predicate,http://schema.org/inChIKey-input,< 1K
-Predicate,http://schema.org/inChIKey-output,< 1K
-Predicate,http://schema.org/inCodeSet,1K - 10K
-Predicate,http://schema.org/inCodeSet-input,< 1K
-Predicate,http://schema.org/inCodeSet-output,< 1K
-Predicate,http://schema.org/inDefinedTermSet,10K - 100K
-Predicate,http://schema.org/inDefinedTermSet-input,< 1K
-Predicate,http://schema.org/inDefinedTermSet-output,< 1K
-Predicate,http://schema.org/inLanguage,10M+
-Predicate,http://schema.org/inLanguage-input,< 1K
-Predicate,http://schema.org/inLanguage-output,< 1K
-Predicate,http://schema.org/inPlaylist,< 1K
-Predicate,http://schema.org/inPlaylist-input,< 1K
-Predicate,http://schema.org/inPlaylist-output,< 1K
-Predicate,http://schema.org/inProductGroupWithID,1K - 10K
-Predicate,http://schema.org/inProductGroupWithID-input,< 1K
-Predicate,http://schema.org/inProductGroupWithID-output,< 1K
-Predicate,http://schema.org/inStoreReturnsOffered,1K - 10K
-Predicate,http://schema.org/inStoreReturnsOffered-input,< 1K
-Predicate,http://schema.org/inStoreReturnsOffered-output,< 1K
-Predicate,http://schema.org/inSupportOf,< 1K
-Predicate,http://schema.org/inSupportOf-input,< 1K
-Predicate,http://schema.org/inSupportOf-output,< 1K
-Predicate,http://schema.org/incentiveAmount,< 1K
-Predicate,http://schema.org/incentiveAmount-input,< 1K
-Predicate,http://schema.org/incentiveAmount-output,< 1K
-Predicate,http://schema.org/incentiveCompensation,1K - 10K
-Predicate,http://schema.org/incentiveCompensation-input,< 1K
-Predicate,http://schema.org/incentiveCompensation-output,< 1K
-Predicate,http://schema.org/incentiveStatus,< 1K
-Predicate,http://schema.org/incentiveStatus-input,< 1K
-Predicate,http://schema.org/incentiveStatus-output,< 1K
-Predicate,http://schema.org/incentiveType,< 1K
-Predicate,http://schema.org/incentiveType-input,< 1K
-Predicate,http://schema.org/incentiveType-output,< 1K
-Predicate,http://schema.org/incentives,< 1K
-Predicate,http://schema.org/incentives-input,< 1K
-Predicate,http://schema.org/incentives-output,< 1K
-Predicate,http://schema.org/incentivizedItem,< 1K
-Predicate,http://schema.org/incentivizedItem-input,< 1K
-Predicate,http://schema.org/incentivizedItem-output,< 1K
-Predicate,http://schema.org/includedComposition,< 1K
-Predicate,http://schema.org/includedComposition-input,< 1K
-Predicate,http://schema.org/includedComposition-output,< 1K
-Predicate,http://schema.org/includedDataCatalog,< 1K
-Predicate,http://schema.org/includedDataCatalog-input,< 1K
-Predicate,http://schema.org/includedDataCatalog-output,< 1K
-Predicate,http://schema.org/includedInDataCatalog,1K - 10K
-Predicate,http://schema.org/includedInDataCatalog-input,< 1K
-Predicate,http://schema.org/includedInDataCatalog-output,< 1K
-Predicate,http://schema.org/includedInHealthInsurancePlan,< 1K
-Predicate,http://schema.org/includedInHealthInsurancePlan-input,< 1K
-Predicate,http://schema.org/includedInHealthInsurancePlan-output,< 1K
-Predicate,http://schema.org/includedRiskFactor,< 1K
-Predicate,http://schema.org/includedRiskFactor-input,< 1K
-Predicate,http://schema.org/includedRiskFactor-output,< 1K
-Predicate,http://schema.org/includesAttraction,1K - 10K
-Predicate,http://schema.org/includesAttraction-input,< 1K
-Predicate,http://schema.org/includesAttraction-output,< 1K
-Predicate,http://schema.org/includesHealthPlanFormulary,< 1K
-Predicate,http://schema.org/includesHealthPlanFormulary-input,< 1K
-Predicate,http://schema.org/includesHealthPlanFormulary-output,< 1K
-Predicate,http://schema.org/includesHealthPlanNetwork,< 1K
-Predicate,http://schema.org/includesHealthPlanNetwork-input,< 1K
-Predicate,http://schema.org/includesHealthPlanNetwork-output,< 1K
-Predicate,http://schema.org/includesObject,1K - 10K
-Predicate,http://schema.org/includesObject-input,< 1K
-Predicate,http://schema.org/includesObject-output,< 1K
-Predicate,http://schema.org/incomeLimit,< 1K
-Predicate,http://schema.org/incomeLimit-input,< 1K
-Predicate,http://schema.org/incomeLimit-output,< 1K
-Predicate,http://schema.org/increasesRiskOf,< 1K
-Predicate,http://schema.org/increasesRiskOf-input,< 1K
-Predicate,http://schema.org/increasesRiskOf-output,< 1K
-Predicate,http://schema.org/industry,10K - 100K
-Predicate,http://schema.org/industry-input,< 1K
-Predicate,http://schema.org/industry-output,< 1K
-Predicate,http://schema.org/ineligibleRegion,< 1K
-Predicate,http://schema.org/ineligibleRegion-input,< 1K
-Predicate,http://schema.org/ineligibleRegion-output,< 1K
-Predicate,http://schema.org/infectiousAgent,< 1K
-Predicate,http://schema.org/infectiousAgent-input,< 1K
-Predicate,http://schema.org/infectiousAgent-output,< 1K
-Predicate,http://schema.org/infectiousAgentClass,< 1K
-Predicate,http://schema.org/infectiousAgentClass-input,< 1K
-Predicate,http://schema.org/infectiousAgentClass-output,< 1K
-Predicate,http://schema.org/ingredients,1K - 10K
-Predicate,http://schema.org/ingredients-input,< 1K
-Predicate,http://schema.org/ingredients-output,< 1K
-Predicate,http://schema.org/inker,< 1K
-Predicate,http://schema.org/inker-input,< 1K
-Predicate,http://schema.org/inker-output,< 1K
-Predicate,http://schema.org/insertion,< 1K
-Predicate,http://schema.org/insertion-input,< 1K
-Predicate,http://schema.org/insertion-output,< 1K
-Predicate,http://schema.org/installUrl,10K - 100K
-Predicate,http://schema.org/installUrl-input,< 1K
-Predicate,http://schema.org/installUrl-output,< 1K
-Predicate,http://schema.org/instructor,10K - 100K
-Predicate,http://schema.org/instructor-input,< 1K
-Predicate,http://schema.org/instructor-output,< 1K
-Predicate,http://schema.org/instrument,1K - 10K
-Predicate,http://schema.org/instrument-input,< 1K
-Predicate,http://schema.org/instrument-output,< 1K
-Predicate,http://schema.org/intensity,< 1K
-Predicate,http://schema.org/intensity-input,< 1K
-Predicate,http://schema.org/intensity-output,< 1K
-Predicate,http://schema.org/interactingDrug,< 1K
-Predicate,http://schema.org/interactingDrug-input,< 1K
-Predicate,http://schema.org/interactingDrug-output,< 1K
-Predicate,http://schema.org/interactionCount,100K - 1M
-Predicate,http://schema.org/interactionCount-input,< 1K
-Predicate,http://schema.org/interactionCount-output,< 1K
-Predicate,http://schema.org/interactionService,< 1K
-Predicate,http://schema.org/interactionService-input,< 1K
-Predicate,http://schema.org/interactionService-output,< 1K
-Predicate,http://schema.org/interactionStatistic,100K - 1M
-Predicate,http://schema.org/interactionStatistic-input,< 1K
-Predicate,http://schema.org/interactionStatistic-output,< 1K
-Predicate,http://schema.org/interactionType,100K - 1M
-Predicate,http://schema.org/interactionType-input,< 1K
-Predicate,http://schema.org/interactionType-output,< 1K
-Predicate,http://schema.org/interactivityType,1K - 10K
-Predicate,http://schema.org/interactivityType-input,< 1K
-Predicate,http://schema.org/interactivityType-output,< 1K
-Predicate,http://schema.org/interestRate,1K - 10K
-Predicate,http://schema.org/interestRate-input,< 1K
-Predicate,http://schema.org/interestRate-output,< 1K
-Predicate,http://schema.org/interpretedAsClaim,< 1K
-Predicate,http://schema.org/interpretedAsClaim-input,< 1K
-Predicate,http://schema.org/interpretedAsClaim-output,< 1K
-Predicate,http://schema.org/inventoryLevel,100K - 1M
-Predicate,http://schema.org/inventoryLevel-input,< 1K
-Predicate,http://schema.org/inventoryLevel-output,< 1K
-Predicate,http://schema.org/inverseOf,< 1K
-Predicate,http://schema.org/inverseOf-input,< 1K
-Predicate,http://schema.org/inverseOf-output,< 1K
-Predicate,http://schema.org/isAcceptingNewPatients,10K - 100K
-Predicate,http://schema.org/isAcceptingNewPatients-input,< 1K
-Predicate,http://schema.org/isAcceptingNewPatients-output,< 1K
-Predicate,http://schema.org/isAccessibleForFree,100K - 1M
-Predicate,http://schema.org/isAccessibleForFree-input,< 1K
-Predicate,http://schema.org/isAccessibleForFree-output,< 1K
-Predicate,http://schema.org/isAccessoryOrSparePartFor,1K - 10K
-Predicate,http://schema.org/isAccessoryOrSparePartFor-input,< 1K
-Predicate,http://schema.org/isAccessoryOrSparePartFor-output,< 1K
-Predicate,http://schema.org/isAvailableGenerically,< 1K
-Predicate,http://schema.org/isAvailableGenerically-input,< 1K
-Predicate,http://schema.org/isAvailableGenerically-output,< 1K
-Predicate,http://schema.org/isBasedOn,10K - 100K
-Predicate,http://schema.org/isBasedOn-input,< 1K
-Predicate,http://schema.org/isBasedOn-output,< 1K
-Predicate,http://schema.org/isBasedOnUrl,< 1K
-Predicate,http://schema.org/isBasedOnUrl-input,< 1K
-Predicate,http://schema.org/isBasedOnUrl-output,< 1K
-Predicate,http://schema.org/isConsumableFor,< 1K
-Predicate,http://schema.org/isConsumableFor-input,< 1K
-Predicate,http://schema.org/isConsumableFor-output,< 1K
-Predicate,http://schema.org/isEncodedByBioChemEntity,< 1K
-Predicate,http://schema.org/isEncodedByBioChemEntity-input,< 1K
-Predicate,http://schema.org/isEncodedByBioChemEntity-output,< 1K
-Predicate,http://schema.org/isFamilyFriendly,100K - 1M
-Predicate,http://schema.org/isFamilyFriendly-input,< 1K
-Predicate,http://schema.org/isFamilyFriendly-output,< 1K
-Predicate,http://schema.org/isGift,< 1K
-Predicate,http://schema.org/isGift-input,< 1K
-Predicate,http://schema.org/isGift-output,< 1K
-Predicate,http://schema.org/isInvolvedInBiologicalProcess,< 1K
-Predicate,http://schema.org/isInvolvedInBiologicalProcess-input,< 1K
-Predicate,http://schema.org/isInvolvedInBiologicalProcess-output,< 1K
-Predicate,http://schema.org/isLiveBroadcast,10K - 100K
-Predicate,http://schema.org/isLiveBroadcast-input,< 1K
-Predicate,http://schema.org/isLiveBroadcast-output,< 1K
-Predicate,http://schema.org/isLocatedInSubcellularLocation,< 1K
-Predicate,http://schema.org/isLocatedInSubcellularLocation-input,< 1K
-Predicate,http://schema.org/isLocatedInSubcellularLocation-output,< 1K
-Predicate,http://schema.org/isPartOf,10M+
-Predicate,http://schema.org/isPartOf-input,< 1K
-Predicate,http://schema.org/isPartOf-output,< 1K
-Predicate,http://schema.org/isPartOfBioChemEntity,< 1K
-Predicate,http://schema.org/isPartOfBioChemEntity-input,< 1K
-Predicate,http://schema.org/isPartOfBioChemEntity-output,< 1K
-Predicate,http://schema.org/isPlanForApartment,< 1K
-Predicate,http://schema.org/isPlanForApartment-input,< 1K
-Predicate,http://schema.org/isPlanForApartment-output,< 1K
-Predicate,http://schema.org/isProprietary,< 1K
-Predicate,http://schema.org/isProprietary-input,< 1K
-Predicate,http://schema.org/isProprietary-output,< 1K
-Predicate,http://schema.org/isRelatedTo,100K - 1M
-Predicate,http://schema.org/isRelatedTo-input,< 1K
-Predicate,http://schema.org/isRelatedTo-output,< 1K
-Predicate,http://schema.org/isResizable,< 1K
-Predicate,http://schema.org/isResizable-input,< 1K
-Predicate,http://schema.org/isResizable-output,< 1K
-Predicate,http://schema.org/isSimilarTo,1K - 10K
-Predicate,http://schema.org/isSimilarTo-input,< 1K
-Predicate,http://schema.org/isSimilarTo-output,< 1K
-Predicate,http://schema.org/isStoreOn,< 1K
-Predicate,http://schema.org/isStoreOn-input,< 1K
-Predicate,http://schema.org/isStoreOn-output,< 1K
-Predicate,http://schema.org/isTierOf,< 1K
-Predicate,http://schema.org/isTierOf-input,< 1K
-Predicate,http://schema.org/isTierOf-output,< 1K
-Predicate,http://schema.org/isUnlabelledFallback,< 1K
-Predicate,http://schema.org/isUnlabelledFallback-input,< 1K
-Predicate,http://schema.org/isUnlabelledFallback-output,< 1K
-Predicate,http://schema.org/isVariantOf,1K - 10K
-Predicate,http://schema.org/isVariantOf-input,< 1K
-Predicate,http://schema.org/isVariantOf-output,< 1K
-Predicate,http://schema.org/isbn,10K - 100K
-Predicate,http://schema.org/isbn-input,< 1K
-Predicate,http://schema.org/isbn-output,< 1K
-Predicate,http://schema.org/isicV4,1K - 10K
-Predicate,http://schema.org/isicV4-input,< 1K
-Predicate,http://schema.org/isicV4-output,< 1K
-Predicate,http://schema.org/iso6523Code,1K - 10K
-Predicate,http://schema.org/iso6523Code-input,< 1K
-Predicate,http://schema.org/iso6523Code-output,< 1K
-Predicate,http://schema.org/isrcCode,< 1K
-Predicate,http://schema.org/isrcCode-input,< 1K
-Predicate,http://schema.org/isrcCode-output,< 1K
-Predicate,http://schema.org/issn,1K - 10K
-Predicate,http://schema.org/issn-input,< 1K
-Predicate,http://schema.org/issn-output,< 1K
-Predicate,http://schema.org/issueNumber,1K - 10K
-Predicate,http://schema.org/issueNumber-input,< 1K
-Predicate,http://schema.org/issueNumber-output,< 1K
-Predicate,http://schema.org/issuedBy,10K - 100K
-Predicate,http://schema.org/issuedBy-input,< 1K
-Predicate,http://schema.org/issuedBy-output,< 1K
-Predicate,http://schema.org/issuedThrough,< 1K
-Predicate,http://schema.org/issuedThrough-input,< 1K
-Predicate,http://schema.org/issuedThrough-output,< 1K
-Predicate,http://schema.org/iswcCode,< 1K
-Predicate,http://schema.org/iswcCode-input,< 1K
-Predicate,http://schema.org/iswcCode-output,< 1K
-Predicate,http://schema.org/item,10M+
-Predicate,http://schema.org/item-input,< 1K
-Predicate,http://schema.org/item-output,< 1K
-Predicate,http://schema.org/itemCondition,1M - 10M
-Predicate,http://schema.org/itemCondition-input,< 1K
-Predicate,http://schema.org/itemCondition-output,< 1K
-Predicate,http://schema.org/itemDefectReturnFees,1K - 10K
-Predicate,http://schema.org/itemDefectReturnFees-input,< 1K
-Predicate,http://schema.org/itemDefectReturnFees-output,< 1K
-Predicate,http://schema.org/itemDefectReturnLabelSource,< 1K
-Predicate,http://schema.org/itemDefectReturnLabelSource-input,< 1K
-Predicate,http://schema.org/itemDefectReturnLabelSource-output,< 1K
-Predicate,http://schema.org/itemDefectReturnShippingFeesAmount,< 1K
-Predicate,http://schema.org/itemDefectReturnShippingFeesAmount-input,< 1K
-Predicate,http://schema.org/itemDefectReturnShippingFeesAmount-output,< 1K
-Predicate,http://schema.org/itemListElement,10M+
-Predicate,http://schema.org/itemListElement-input,< 1K
-Predicate,http://schema.org/itemListElement-output,< 1K
-Predicate,http://schema.org/itemListOrder,100K - 1M
-Predicate,http://schema.org/itemListOrder-input,< 1K
-Predicate,http://schema.org/itemListOrder-output,< 1K
-Predicate,http://schema.org/itemLocation,< 1K
-Predicate,http://schema.org/itemLocation-input,< 1K
-Predicate,http://schema.org/itemLocation-output,< 1K
-Predicate,http://schema.org/itemOffered,100K - 1M
-Predicate,http://schema.org/itemOffered-input,< 1K
-Predicate,http://schema.org/itemOffered-output,< 1K
-Predicate,http://schema.org/itemReviewed,100K - 1M
-Predicate,http://schema.org/itemReviewed-input,< 1K
-Predicate,http://schema.org/itemReviewed-output,< 1K
-Predicate,http://schema.org/itemShipped,< 1K
-Predicate,http://schema.org/itemShipped-input,< 1K
-Predicate,http://schema.org/itemShipped-output,< 1K
-Predicate,http://schema.org/itinerary,10K - 100K
-Predicate,http://schema.org/itinerary-input,< 1K
-Predicate,http://schema.org/itinerary-output,< 1K
-Predicate,http://schema.org/iupacName,< 1K
-Predicate,http://schema.org/iupacName-input,< 1K
-Predicate,http://schema.org/iupacName-output,< 1K
-Predicate,http://schema.org/jobBenefits,10K - 100K
-Predicate,http://schema.org/jobBenefits-input,< 1K
-Predicate,http://schema.org/jobBenefits-output,< 1K
-Predicate,http://schema.org/jobDuration,< 1K
-Predicate,http://schema.org/jobDuration-input,< 1K
-Predicate,http://schema.org/jobDuration-output,< 1K
-Predicate,http://schema.org/jobImmediateStart,1K - 10K
-Predicate,http://schema.org/jobImmediateStart-input,< 1K
-Predicate,http://schema.org/jobImmediateStart-output,< 1K
-Predicate,http://schema.org/jobLocation,100K - 1M
-Predicate,http://schema.org/jobLocation-input,< 1K
-Predicate,http://schema.org/jobLocation-output,< 1K
-Predicate,http://schema.org/jobLocationType,10K - 100K
-Predicate,http://schema.org/jobLocationType-input,< 1K
-Predicate,http://schema.org/jobLocationType-output,< 1K
-Predicate,http://schema.org/jobStartDate,1K - 10K
-Predicate,http://schema.org/jobStartDate-input,< 1K
-Predicate,http://schema.org/jobStartDate-output,< 1K
-Predicate,http://schema.org/jobTitle,100K - 1M
-Predicate,http://schema.org/jobTitle-input,< 1K
-Predicate,http://schema.org/jobTitle-output,< 1K
-Predicate,http://schema.org/jurisdiction,< 1K
-Predicate,http://schema.org/jurisdiction-input,< 1K
-Predicate,http://schema.org/jurisdiction-output,< 1K
-Predicate,http://schema.org/keywords,1M - 10M
-Predicate,http://schema.org/keywords-input,< 1K
-Predicate,http://schema.org/keywords-output,< 1K
-Predicate,http://schema.org/knownVehicleDamages,< 1K
-Predicate,http://schema.org/knownVehicleDamages-input,< 1K
-Predicate,http://schema.org/knownVehicleDamages-output,< 1K
-Predicate,http://schema.org/knows,1K - 10K
-Predicate,http://schema.org/knows-input,< 1K
-Predicate,http://schema.org/knows-output,< 1K
-Predicate,http://schema.org/knowsAbout,100K - 1M
-Predicate,http://schema.org/knowsAbout-input,< 1K
-Predicate,http://schema.org/knowsAbout-output,< 1K
-Predicate,http://schema.org/knowsLanguage,10K - 100K
-Predicate,http://schema.org/knowsLanguage-input,< 1K
-Predicate,http://schema.org/knowsLanguage-output,< 1K
-Predicate,http://schema.org/labelDetails,< 1K
-Predicate,http://schema.org/labelDetails-input,< 1K
-Predicate,http://schema.org/labelDetails-output,< 1K
-Predicate,http://schema.org/landlord,< 1K
-Predicate,http://schema.org/landlord-input,< 1K
-Predicate,http://schema.org/landlord-output,< 1K
-Predicate,http://schema.org/language,10K - 100K
-Predicate,http://schema.org/language-input,< 1K
-Predicate,http://schema.org/language-output,< 1K
-Predicate,http://schema.org/lastReviewed,10K - 100K
-Predicate,http://schema.org/lastReviewed-input,< 1K
-Predicate,http://schema.org/lastReviewed-output,< 1K
-Predicate,http://schema.org/latitude,1M - 10M
-Predicate,http://schema.org/latitude-input,< 1K
-Predicate,http://schema.org/latitude-output,< 1K
-Predicate,http://schema.org/layoutImage,1K - 10K
-Predicate,http://schema.org/layoutImage-input,< 1K
-Predicate,http://schema.org/layoutImage-output,< 1K
-Predicate,http://schema.org/learningResourceType,10K - 100K
-Predicate,http://schema.org/learningResourceType-input,< 1K
-Predicate,http://schema.org/learningResourceType-output,< 1K
-Predicate,http://schema.org/leaseLength,1K - 10K
-Predicate,http://schema.org/leaseLength-input,< 1K
-Predicate,http://schema.org/leaseLength-output,< 1K
-Predicate,http://schema.org/legalAddress,1K - 10K
-Predicate,http://schema.org/legalAddress-input,< 1K
-Predicate,http://schema.org/legalAddress-output,< 1K
-Predicate,http://schema.org/legalName,1M - 10M
-Predicate,http://schema.org/legalName-input,< 1K
-Predicate,http://schema.org/legalName-output,< 1K
-Predicate,http://schema.org/legalRepresentative,1K - 10K
-Predicate,http://schema.org/legalRepresentative-input,< 1K
-Predicate,http://schema.org/legalRepresentative-output,< 1K
-Predicate,http://schema.org/legalStatus,1K - 10K
-Predicate,http://schema.org/legalStatus-input,< 1K
-Predicate,http://schema.org/legalStatus-output,< 1K
-Predicate,http://schema.org/legislationAmends,< 1K
-Predicate,http://schema.org/legislationAmends-input,< 1K
-Predicate,http://schema.org/legislationAmends-output,< 1K
-Predicate,http://schema.org/legislationApplies,< 1K
-Predicate,http://schema.org/legislationApplies-input,< 1K
-Predicate,http://schema.org/legislationApplies-output,< 1K
-Predicate,http://schema.org/legislationChanges,< 1K
-Predicate,http://schema.org/legislationChanges-input,< 1K
-Predicate,http://schema.org/legislationChanges-output,< 1K
-Predicate,http://schema.org/legislationCommences,< 1K
-Predicate,http://schema.org/legislationCommences-input,< 1K
-Predicate,http://schema.org/legislationCommences-output,< 1K
-Predicate,http://schema.org/legislationConsolidates,< 1K
-Predicate,http://schema.org/legislationConsolidates-input,< 1K
-Predicate,http://schema.org/legislationConsolidates-output,< 1K
-Predicate,http://schema.org/legislationCorrects,< 1K
-Predicate,http://schema.org/legislationCorrects-input,< 1K
-Predicate,http://schema.org/legislationCorrects-output,< 1K
-Predicate,http://schema.org/legislationCountersignedBy,< 1K
-Predicate,http://schema.org/legislationCountersignedBy-input,< 1K
-Predicate,http://schema.org/legislationCountersignedBy-output,< 1K
-Predicate,http://schema.org/legislationDate,< 1K
-Predicate,http://schema.org/legislationDate-input,< 1K
-Predicate,http://schema.org/legislationDate-output,< 1K
-Predicate,http://schema.org/legislationDateOfApplicability,< 1K
-Predicate,http://schema.org/legislationDateOfApplicability-input,< 1K
-Predicate,http://schema.org/legislationDateOfApplicability-output,< 1K
-Predicate,http://schema.org/legislationDateVersion,< 1K
-Predicate,http://schema.org/legislationDateVersion-input,< 1K
-Predicate,http://schema.org/legislationDateVersion-output,< 1K
-Predicate,http://schema.org/legislationEnsuresImplementationOf,< 1K
-Predicate,http://schema.org/legislationEnsuresImplementationOf-input,< 1K
-Predicate,http://schema.org/legislationEnsuresImplementationOf-output,< 1K
-Predicate,http://schema.org/legislationIdentifier,< 1K
-Predicate,http://schema.org/legislationIdentifier-input,< 1K
-Predicate,http://schema.org/legislationIdentifier-output,< 1K
-Predicate,http://schema.org/legislationJurisdiction,1K - 10K
-Predicate,http://schema.org/legislationJurisdiction-input,< 1K
-Predicate,http://schema.org/legislationJurisdiction-output,< 1K
-Predicate,http://schema.org/legislationLegalForce,< 1K
-Predicate,http://schema.org/legislationLegalForce-input,< 1K
-Predicate,http://schema.org/legislationLegalForce-output,< 1K
-Predicate,http://schema.org/legislationLegalValue,< 1K
-Predicate,http://schema.org/legislationLegalValue-input,< 1K
-Predicate,http://schema.org/legislationLegalValue-output,< 1K
-Predicate,http://schema.org/legislationPassedBy,< 1K
-Predicate,http://schema.org/legislationPassedBy-input,< 1K
-Predicate,http://schema.org/legislationPassedBy-output,< 1K
-Predicate,http://schema.org/legislationRepeals,< 1K
-Predicate,http://schema.org/legislationRepeals-input,< 1K
-Predicate,http://schema.org/legislationRepeals-output,< 1K
-Predicate,http://schema.org/legislationResponsible,< 1K
-Predicate,http://schema.org/legislationResponsible-input,< 1K
-Predicate,http://schema.org/legislationResponsible-output,< 1K
-Predicate,http://schema.org/legislationTransposes,< 1K
-Predicate,http://schema.org/legislationTransposes-input,< 1K
-Predicate,http://schema.org/legislationTransposes-output,< 1K
-Predicate,http://schema.org/legislationType,< 1K
-Predicate,http://schema.org/legislationType-input,< 1K
-Predicate,http://schema.org/legislationType-output,< 1K
-Predicate,http://schema.org/leiCode,1K - 10K
-Predicate,http://schema.org/leiCode-input,< 1K
-Predicate,http://schema.org/leiCode-output,< 1K
-Predicate,http://schema.org/lender,< 1K
-Predicate,http://schema.org/lender-input,< 1K
-Predicate,http://schema.org/lender-output,< 1K
-Predicate,http://schema.org/lesser,< 1K
-Predicate,http://schema.org/lesser-input,< 1K
-Predicate,http://schema.org/lesser-output,< 1K
-Predicate,http://schema.org/lesserOrEqual,< 1K
-Predicate,http://schema.org/lesserOrEqual-input,< 1K
-Predicate,http://schema.org/lesserOrEqual-output,< 1K
-Predicate,http://schema.org/letterer,< 1K
-Predicate,http://schema.org/letterer-input,< 1K
-Predicate,http://schema.org/letterer-output,< 1K
-Predicate,http://schema.org/license,100K - 1M
-Predicate,http://schema.org/license-input,< 1K
-Predicate,http://schema.org/license-output,< 1K
-Predicate,http://schema.org/lifeEvent,< 1K
-Predicate,http://schema.org/lifeEvent-input,< 1K
-Predicate,http://schema.org/lifeEvent-output,< 1K
-Predicate,http://schema.org/line,< 1K
-Predicate,http://schema.org/line-input,< 1K
-Predicate,http://schema.org/line-output,< 1K
-Predicate,http://schema.org/linkRelationship,< 1K
-Predicate,http://schema.org/linkRelationship-input,< 1K
-Predicate,http://schema.org/linkRelationship-output,< 1K
-Predicate,http://schema.org/liveBlogUpdate,1K - 10K
-Predicate,http://schema.org/liveBlogUpdate-input,< 1K
-Predicate,http://schema.org/liveBlogUpdate-output,< 1K
-Predicate,http://schema.org/loanMortgageMandateAmount,< 1K
-Predicate,http://schema.org/loanMortgageMandateAmount-input,< 1K
-Predicate,http://schema.org/loanMortgageMandateAmount-output,< 1K
-Predicate,http://schema.org/loanPaymentAmount,< 1K
-Predicate,http://schema.org/loanPaymentAmount-input,< 1K
-Predicate,http://schema.org/loanPaymentAmount-output,< 1K
-Predicate,http://schema.org/loanPaymentFrequency,< 1K
-Predicate,http://schema.org/loanPaymentFrequency-input,< 1K
-Predicate,http://schema.org/loanPaymentFrequency-output,< 1K
-Predicate,http://schema.org/loanRepaymentForm,< 1K
-Predicate,http://schema.org/loanRepaymentForm-input,< 1K
-Predicate,http://schema.org/loanRepaymentForm-output,< 1K
-Predicate,http://schema.org/loanTerm,1K - 10K
-Predicate,http://schema.org/loanTerm-input,< 1K
-Predicate,http://schema.org/loanTerm-output,< 1K
-Predicate,http://schema.org/loanType,1K - 10K
-Predicate,http://schema.org/loanType-input,< 1K
-Predicate,http://schema.org/loanType-output,< 1K
-Predicate,http://schema.org/location,1M - 10M
-Predicate,http://schema.org/location-input,< 1K
-Predicate,http://schema.org/location-output,< 1K
-Predicate,http://schema.org/locationCreated,10K - 100K
-Predicate,http://schema.org/locationCreated-input,< 1K
-Predicate,http://schema.org/locationCreated-output,< 1K
-Predicate,http://schema.org/lodgingUnitDescription,< 1K
-Predicate,http://schema.org/lodgingUnitDescription-input,< 1K
-Predicate,http://schema.org/lodgingUnitDescription-output,< 1K
-Predicate,http://schema.org/lodgingUnitType,< 1K
-Predicate,http://schema.org/lodgingUnitType-input,< 1K
-Predicate,http://schema.org/lodgingUnitType-output,< 1K
-Predicate,http://schema.org/logo,10M+
-Predicate,http://schema.org/logo-input,< 1K
-Predicate,http://schema.org/logo-output,< 1K
-Predicate,http://schema.org/longitude,1M - 10M
-Predicate,http://schema.org/longitude-input,< 1K
-Predicate,http://schema.org/longitude-output,< 1K
-Predicate,http://schema.org/loser,< 1K
-Predicate,http://schema.org/loser-input,< 1K
-Predicate,http://schema.org/loser-output,< 1K
-Predicate,http://schema.org/lowPrice,1M - 10M
-Predicate,http://schema.org/lowPrice-input,< 1K
-Predicate,http://schema.org/lowPrice-output,< 1K
-Predicate,http://schema.org/lyricist,< 1K
-Predicate,http://schema.org/lyricist-input,< 1K
-Predicate,http://schema.org/lyricist-output,< 1K
-Predicate,http://schema.org/lyrics,1K - 10K
-Predicate,http://schema.org/lyrics-input,< 1K
-Predicate,http://schema.org/lyrics-output,< 1K
-Predicate,http://schema.org/mainContentOfPage,1M - 10M
-Predicate,http://schema.org/mainContentOfPage-input,< 1K
-Predicate,http://schema.org/mainContentOfPage-output,< 1K
-Predicate,http://schema.org/mainEntity,1M - 10M
-Predicate,http://schema.org/mainEntity-input,< 1K
-Predicate,http://schema.org/mainEntity-output,< 1K
-Predicate,http://schema.org/mainEntityOfPage,10M+
-Predicate,http://schema.org/mainEntityOfPage-input,< 1K
-Predicate,http://schema.org/mainEntityOfPage-output,< 1K
-Predicate,http://schema.org/maintainer,1K - 10K
-Predicate,http://schema.org/maintainer-input,< 1K
-Predicate,http://schema.org/maintainer-output,< 1K
-Predicate,http://schema.org/makesOffer,100K - 1M
-Predicate,http://schema.org/makesOffer-input,< 1K
-Predicate,http://schema.org/makesOffer-output,< 1K
-Predicate,http://schema.org/manufacturer,100K - 1M
-Predicate,http://schema.org/manufacturer-input,< 1K
-Predicate,http://schema.org/manufacturer-output,< 1K
-Predicate,http://schema.org/map,1K - 10K
-Predicate,http://schema.org/map-input,< 1K
-Predicate,http://schema.org/map-output,< 1K
-Predicate,http://schema.org/mapType,1K - 10K
-Predicate,http://schema.org/mapType-input,< 1K
-Predicate,http://schema.org/mapType-output,< 1K
-Predicate,http://schema.org/maps,1K - 10K
-Predicate,http://schema.org/maps-input,< 1K
-Predicate,http://schema.org/maps-output,< 1K
-Predicate,http://schema.org/marginOfError,< 1K
-Predicate,http://schema.org/marginOfError-input,< 1K
-Predicate,http://schema.org/marginOfError-output,< 1K
-Predicate,http://schema.org/masthead,10K - 100K
-Predicate,http://schema.org/masthead-input,< 1K
-Predicate,http://schema.org/masthead-output,< 1K
-Predicate,http://schema.org/material,10K - 100K
-Predicate,http://schema.org/material-input,< 1K
-Predicate,http://schema.org/material-output,< 1K
-Predicate,http://schema.org/materialExtent,< 1K
-Predicate,http://schema.org/materialExtent-input,< 1K
-Predicate,http://schema.org/materialExtent-output,< 1K
-Predicate,http://schema.org/mathExpression,< 1K
-Predicate,http://schema.org/mathExpression-input,< 1K
-Predicate,http://schema.org/mathExpression-output,< 1K
-Predicate,http://schema.org/maxPrice,10K - 100K
-Predicate,http://schema.org/maxPrice-input,< 1K
-Predicate,http://schema.org/maxPrice-output,< 1K
-Predicate,http://schema.org/maxValue,100K - 1M
-Predicate,http://schema.org/maxValue-input,< 1K
-Predicate,http://schema.org/maxValue-output,< 1K
-Predicate,http://schema.org/maximumAttendeeCapacity,10K - 100K
-Predicate,http://schema.org/maximumAttendeeCapacity-input,< 1K
-Predicate,http://schema.org/maximumAttendeeCapacity-output,< 1K
-Predicate,http://schema.org/maximumEnrollment,< 1K
-Predicate,http://schema.org/maximumEnrollment-input,< 1K
-Predicate,http://schema.org/maximumEnrollment-output,< 1K
-Predicate,http://schema.org/maximumIntake,< 1K
-Predicate,http://schema.org/maximumIntake-input,< 1K
-Predicate,http://schema.org/maximumIntake-output,< 1K
-Predicate,http://schema.org/maximumPhysicalAttendeeCapacity,< 1K
-Predicate,http://schema.org/maximumPhysicalAttendeeCapacity-input,< 1K
-Predicate,http://schema.org/maximumPhysicalAttendeeCapacity-output,< 1K
-Predicate,http://schema.org/maximumVirtualAttendeeCapacity,< 1K
-Predicate,http://schema.org/maximumVirtualAttendeeCapacity-input,< 1K
-Predicate,http://schema.org/maximumVirtualAttendeeCapacity-output,< 1K
-Predicate,http://schema.org/mealService,< 1K
-Predicate,http://schema.org/mealService-input,< 1K
-Predicate,http://schema.org/mealService-output,< 1K
-Predicate,http://schema.org/measuredProperty,< 1K
-Predicate,http://schema.org/measuredProperty-input,< 1K
-Predicate,http://schema.org/measuredProperty-output,< 1K
-Predicate,http://schema.org/measurementDenominator,< 1K
-Predicate,http://schema.org/measurementDenominator-input,< 1K
-Predicate,http://schema.org/measurementDenominator-output,< 1K
-Predicate,http://schema.org/measurementMethod,< 1K
-Predicate,http://schema.org/measurementMethod-input,< 1K
-Predicate,http://schema.org/measurementMethod-output,< 1K
-Predicate,http://schema.org/measurementQualifier,< 1K
-Predicate,http://schema.org/measurementQualifier-input,< 1K
-Predicate,http://schema.org/measurementQualifier-output,< 1K
-Predicate,http://schema.org/measurementTechnique,1K - 10K
-Predicate,http://schema.org/measurementTechnique-input,< 1K
-Predicate,http://schema.org/measurementTechnique-output,< 1K
-Predicate,http://schema.org/mechanismOfAction,< 1K
-Predicate,http://schema.org/mechanismOfAction-input,< 1K
-Predicate,http://schema.org/mechanismOfAction-output,< 1K
-Predicate,http://schema.org/mediaAuthenticityCategory,< 1K
-Predicate,http://schema.org/mediaAuthenticityCategory-input,< 1K
-Predicate,http://schema.org/mediaAuthenticityCategory-output,< 1K
-Predicate,http://schema.org/mediaItemAppearance,< 1K
-Predicate,http://schema.org/mediaItemAppearance-input,< 1K
-Predicate,http://schema.org/mediaItemAppearance-output,< 1K
-Predicate,http://schema.org/median,1K - 10K
-Predicate,http://schema.org/median-input,< 1K
-Predicate,http://schema.org/median-output,< 1K
-Predicate,http://schema.org/medicalAudience,1K - 10K
-Predicate,http://schema.org/medicalAudience-input,< 1K
-Predicate,http://schema.org/medicalAudience-output,< 1K
-Predicate,http://schema.org/medicalSpecialty,10K - 100K
-Predicate,http://schema.org/medicalSpecialty-input,< 1K
-Predicate,http://schema.org/medicalSpecialty-output,< 1K
-Predicate,http://schema.org/medicineSystem,1K - 10K
-Predicate,http://schema.org/medicineSystem-input,< 1K
-Predicate,http://schema.org/medicineSystem-output,< 1K
-Predicate,http://schema.org/meetsEmissionStandard,< 1K
-Predicate,http://schema.org/meetsEmissionStandard-input,< 1K
-Predicate,http://schema.org/meetsEmissionStandard-output,< 1K
-Predicate,http://schema.org/member,10K - 100K
-Predicate,http://schema.org/member-input,< 1K
-Predicate,http://schema.org/member-output,< 1K
-Predicate,http://schema.org/memberOf,10K - 100K
-Predicate,http://schema.org/memberOf-input,< 1K
-Predicate,http://schema.org/memberOf-output,< 1K
-Predicate,http://schema.org/members,< 1K
-Predicate,http://schema.org/members-input,< 1K
-Predicate,http://schema.org/members-output,< 1K
-Predicate,http://schema.org/membershipNumber,< 1K
-Predicate,http://schema.org/membershipNumber-input,< 1K
-Predicate,http://schema.org/membershipNumber-output,< 1K
-Predicate,http://schema.org/membershipPointsEarned,< 1K
-Predicate,http://schema.org/membershipPointsEarned-input,< 1K
-Predicate,http://schema.org/membershipPointsEarned-output,< 1K
-Predicate,http://schema.org/memoryRequirements,1K - 10K
-Predicate,http://schema.org/memoryRequirements-input,< 1K
-Predicate,http://schema.org/memoryRequirements-output,< 1K
-Predicate,http://schema.org/mentions,10K - 100K
-Predicate,http://schema.org/mentions-input,< 1K
-Predicate,http://schema.org/mentions-output,< 1K
-Predicate,http://schema.org/menu,10K - 100K
-Predicate,http://schema.org/menu-input,< 1K
-Predicate,http://schema.org/menu-output,< 1K
-Predicate,http://schema.org/menuAddOn,1K - 10K
-Predicate,http://schema.org/menuAddOn-input,< 1K
-Predicate,http://schema.org/menuAddOn-output,< 1K
-Predicate,http://schema.org/merchant,< 1K
-Predicate,http://schema.org/merchant-input,< 1K
-Predicate,http://schema.org/merchant-output,< 1K
-Predicate,http://schema.org/merchantReturnDays,100K - 1M
-Predicate,http://schema.org/merchantReturnDays-input,< 1K
-Predicate,http://schema.org/merchantReturnDays-output,< 1K
-Predicate,http://schema.org/merchantReturnLink,10K - 100K
-Predicate,http://schema.org/merchantReturnLink-input,< 1K
-Predicate,http://schema.org/merchantReturnLink-output,< 1K
-Predicate,http://schema.org/messageAttachment,< 1K
-Predicate,http://schema.org/messageAttachment-input,< 1K
-Predicate,http://schema.org/messageAttachment-output,< 1K
-Predicate,http://schema.org/mileageFromOdometer,10K - 100K
-Predicate,http://schema.org/mileageFromOdometer-input,< 1K
-Predicate,http://schema.org/mileageFromOdometer-output,< 1K
-Predicate,http://schema.org/minPrice,10K - 100K
-Predicate,http://schema.org/minPrice-input,< 1K
-Predicate,http://schema.org/minPrice-output,< 1K
-Predicate,http://schema.org/minValue,100K - 1M
-Predicate,http://schema.org/minValue-input,< 1K
-Predicate,http://schema.org/minValue-output,< 1K
-Predicate,http://schema.org/minimumPaymentDue,< 1K
-Predicate,http://schema.org/minimumPaymentDue-input,< 1K
-Predicate,http://schema.org/minimumPaymentDue-output,< 1K
-Predicate,http://schema.org/missionCoveragePrioritiesPolicy,1K - 10K
-Predicate,http://schema.org/missionCoveragePrioritiesPolicy-input,< 1K
-Predicate,http://schema.org/missionCoveragePrioritiesPolicy-output,< 1K
-Predicate,http://schema.org/mobileUrl,< 1K
-Predicate,http://schema.org/mobileUrl-input,< 1K
-Predicate,http://schema.org/mobileUrl-output,< 1K
-Predicate,http://schema.org/model,100K - 1M
-Predicate,http://schema.org/model-input,< 1K
-Predicate,http://schema.org/model-output,< 1K
-Predicate,http://schema.org/modelDate,10K - 100K
-Predicate,http://schema.org/modelDate-input,< 1K
-Predicate,http://schema.org/modelDate-output,< 1K
-Predicate,http://schema.org/modifiedTime,< 1K
-Predicate,http://schema.org/modifiedTime-input,< 1K
-Predicate,http://schema.org/modifiedTime-output,< 1K
-Predicate,http://schema.org/molecularFormula,< 1K
-Predicate,http://schema.org/molecularFormula-input,< 1K
-Predicate,http://schema.org/molecularFormula-output,< 1K
-Predicate,http://schema.org/molecularWeight,< 1K
-Predicate,http://schema.org/molecularWeight-input,< 1K
-Predicate,http://schema.org/molecularWeight-output,< 1K
-Predicate,http://schema.org/monoisotopicMolecularWeight,< 1K
-Predicate,http://schema.org/monoisotopicMolecularWeight-input,< 1K
-Predicate,http://schema.org/monoisotopicMolecularWeight-output,< 1K
-Predicate,http://schema.org/monthlyMinimumRepaymentAmount,< 1K
-Predicate,http://schema.org/monthlyMinimumRepaymentAmount-input,< 1K
-Predicate,http://schema.org/monthlyMinimumRepaymentAmount-output,< 1K
-Predicate,http://schema.org/monthsOfExperience,1K - 10K
-Predicate,http://schema.org/monthsOfExperience-input,< 1K
-Predicate,http://schema.org/monthsOfExperience-output,< 1K
-Predicate,http://schema.org/mpn,100K - 1M
-Predicate,http://schema.org/mpn-input,< 1K
-Predicate,http://schema.org/mpn-output,< 1K
-Predicate,http://schema.org/multipleValues,< 1K
-Predicate,http://schema.org/multipleValues-input,< 1K
-Predicate,http://schema.org/multipleValues-output,< 1K
-Predicate,http://schema.org/muscleAction,< 1K
-Predicate,http://schema.org/muscleAction-input,< 1K
-Predicate,http://schema.org/muscleAction-output,< 1K
-Predicate,http://schema.org/musicArrangement,< 1K
-Predicate,http://schema.org/musicArrangement-input,< 1K
-Predicate,http://schema.org/musicArrangement-output,< 1K
-Predicate,http://schema.org/musicBy,1K - 10K
-Predicate,http://schema.org/musicBy-input,< 1K
-Predicate,http://schema.org/musicBy-output,< 1K
-Predicate,http://schema.org/musicCompositionForm,< 1K
-Predicate,http://schema.org/musicCompositionForm-input,< 1K
-Predicate,http://schema.org/musicCompositionForm-output,< 1K
-Predicate,http://schema.org/musicGroupMember,< 1K
-Predicate,http://schema.org/musicGroupMember-input,< 1K
-Predicate,http://schema.org/musicGroupMember-output,< 1K
-Predicate,http://schema.org/musicReleaseFormat,1K - 10K
-Predicate,http://schema.org/musicReleaseFormat-input,< 1K
-Predicate,http://schema.org/musicReleaseFormat-output,< 1K
-Predicate,http://schema.org/musicalKey,< 1K
-Predicate,http://schema.org/musicalKey-input,< 1K
-Predicate,http://schema.org/musicalKey-output,< 1K
-Predicate,http://schema.org/naics,10K - 100K
-Predicate,http://schema.org/naics-input,< 1K
-Predicate,http://schema.org/naics-output,< 1K
-Predicate,http://schema.org/name,10M+
-Predicate,http://schema.org/name-input,< 1K
-Predicate,http://schema.org/name-output,< 1K
-Predicate,http://schema.org/namedPosition,< 1K
-Predicate,http://schema.org/namedPosition-input,< 1K
-Predicate,http://schema.org/namedPosition-output,< 1K
-Predicate,http://schema.org/nationality,10K - 100K
-Predicate,http://schema.org/nationality-input,< 1K
-Predicate,http://schema.org/nationality-output,< 1K
-Predicate,http://schema.org/naturalProgression,< 1K
-Predicate,http://schema.org/naturalProgression-input,< 1K
-Predicate,http://schema.org/naturalProgression-output,< 1K
-Predicate,http://schema.org/negativeNotes,10K - 100K
-Predicate,http://schema.org/negativeNotes-input,< 1K
-Predicate,http://schema.org/negativeNotes-output,< 1K
-Predicate,http://schema.org/nerve,< 1K
-Predicate,http://schema.org/nerve-input,< 1K
-Predicate,http://schema.org/nerve-output,< 1K
-Predicate,http://schema.org/nerveMotor,< 1K
-Predicate,http://schema.org/nerveMotor-input,< 1K
-Predicate,http://schema.org/nerveMotor-output,< 1K
-Predicate,http://schema.org/netWorth,< 1K
-Predicate,http://schema.org/netWorth-input,< 1K
-Predicate,http://schema.org/netWorth-output,< 1K
-Predicate,http://schema.org/newsUpdatesAndGuidelines,< 1K
-Predicate,http://schema.org/newsUpdatesAndGuidelines-input,< 1K
-Predicate,http://schema.org/newsUpdatesAndGuidelines-output,< 1K
-Predicate,http://schema.org/nextItem,1M - 10M
-Predicate,http://schema.org/nextItem-input,< 1K
-Predicate,http://schema.org/nextItem-output,< 1K
-Predicate,http://schema.org/noBylinesPolicy,1K - 10K
-Predicate,http://schema.org/noBylinesPolicy-input,< 1K
-Predicate,http://schema.org/noBylinesPolicy-output,< 1K
-Predicate,http://schema.org/nonEqual,< 1K
-Predicate,http://schema.org/nonEqual-input,< 1K
-Predicate,http://schema.org/nonEqual-output,< 1K
-Predicate,http://schema.org/nonProprietaryName,1K - 10K
-Predicate,http://schema.org/nonProprietaryName-input,< 1K
-Predicate,http://schema.org/nonProprietaryName-output,< 1K
-Predicate,http://schema.org/nonprofitStatus,1K - 10K
-Predicate,http://schema.org/nonprofitStatus-input,< 1K
-Predicate,http://schema.org/nonprofitStatus-output,< 1K
-Predicate,http://schema.org/normalRange,< 1K
-Predicate,http://schema.org/normalRange-input,< 1K
-Predicate,http://schema.org/normalRange-output,< 1K
-Predicate,http://schema.org/nsn,< 1K
-Predicate,http://schema.org/nsn-input,< 1K
-Predicate,http://schema.org/nsn-output,< 1K
-Predicate,http://schema.org/numAdults,< 1K
-Predicate,http://schema.org/numAdults-input,< 1K
-Predicate,http://schema.org/numAdults-output,< 1K
-Predicate,http://schema.org/numChildren,< 1K
-Predicate,http://schema.org/numChildren-input,< 1K
-Predicate,http://schema.org/numChildren-output,< 1K
-Predicate,http://schema.org/numConstraints,< 1K
-Predicate,http://schema.org/numConstraints-input,< 1K
-Predicate,http://schema.org/numConstraints-output,< 1K
-Predicate,http://schema.org/numItems,< 1K
-Predicate,http://schema.org/numItems-input,< 1K
-Predicate,http://schema.org/numItems-output,< 1K
-Predicate,http://schema.org/numTracks,10K - 100K
-Predicate,http://schema.org/numTracks-input,< 1K
-Predicate,http://schema.org/numTracks-output,< 1K
-Predicate,http://schema.org/numberOfAccommodationUnits,1K - 10K
-Predicate,http://schema.org/numberOfAccommodationUnits-input,< 1K
-Predicate,http://schema.org/numberOfAccommodationUnits-output,< 1K
-Predicate,http://schema.org/numberOfAirbags,< 1K
-Predicate,http://schema.org/numberOfAirbags-input,< 1K
-Predicate,http://schema.org/numberOfAirbags-output,< 1K
-Predicate,http://schema.org/numberOfAvailableAccommodationUnits,1K - 10K
-Predicate,http://schema.org/numberOfAvailableAccommodationUnits-input,< 1K
-Predicate,http://schema.org/numberOfAvailableAccommodationUnits-output,< 1K
-Predicate,http://schema.org/numberOfAxles,< 1K
-Predicate,http://schema.org/numberOfAxles-input,< 1K
-Predicate,http://schema.org/numberOfAxles-output,< 1K
-Predicate,http://schema.org/numberOfBathroomsTotal,10K - 100K
-Predicate,http://schema.org/numberOfBathroomsTotal-input,< 1K
-Predicate,http://schema.org/numberOfBathroomsTotal-output,< 1K
-Predicate,http://schema.org/numberOfBedrooms,10K - 100K
-Predicate,http://schema.org/numberOfBedrooms-input,< 1K
-Predicate,http://schema.org/numberOfBedrooms-output,< 1K
-Predicate,http://schema.org/numberOfBeds,10K - 100K
-Predicate,http://schema.org/numberOfBeds-input,< 1K
-Predicate,http://schema.org/numberOfBeds-output,< 1K
-Predicate,http://schema.org/numberOfCredits,1K - 10K
-Predicate,http://schema.org/numberOfCredits-input,< 1K
-Predicate,http://schema.org/numberOfCredits-output,< 1K
-Predicate,http://schema.org/numberOfDoors,10K - 100K
-Predicate,http://schema.org/numberOfDoors-input,< 1K
-Predicate,http://schema.org/numberOfDoors-output,< 1K
-Predicate,http://schema.org/numberOfEmployees,100K - 1M
-Predicate,http://schema.org/numberOfEmployees-input,< 1K
-Predicate,http://schema.org/numberOfEmployees-output,< 1K
-Predicate,http://schema.org/numberOfEpisodes,1K - 10K
-Predicate,http://schema.org/numberOfEpisodes-input,< 1K
-Predicate,http://schema.org/numberOfEpisodes-output,< 1K
-Predicate,http://schema.org/numberOfForwardGears,1K - 10K
-Predicate,http://schema.org/numberOfForwardGears-input,< 1K
-Predicate,http://schema.org/numberOfForwardGears-output,< 1K
-Predicate,http://schema.org/numberOfFullBathrooms,10K - 100K
-Predicate,http://schema.org/numberOfFullBathrooms-input,< 1K
-Predicate,http://schema.org/numberOfFullBathrooms-output,< 1K
-Predicate,http://schema.org/numberOfItems,100K - 1M
-Predicate,http://schema.org/numberOfItems-input,< 1K
-Predicate,http://schema.org/numberOfItems-output,< 1K
-Predicate,http://schema.org/numberOfLoanPayments,< 1K
-Predicate,http://schema.org/numberOfLoanPayments-input,< 1K
-Predicate,http://schema.org/numberOfLoanPayments-output,< 1K
-Predicate,http://schema.org/numberOfPages,10K - 100K
-Predicate,http://schema.org/numberOfPages-input,< 1K
-Predicate,http://schema.org/numberOfPages-output,< 1K
-Predicate,http://schema.org/numberOfPartialBathrooms,1K - 10K
-Predicate,http://schema.org/numberOfPartialBathrooms-input,< 1K
-Predicate,http://schema.org/numberOfPartialBathrooms-output,< 1K
-Predicate,http://schema.org/numberOfPlayers,10K - 100K
-Predicate,http://schema.org/numberOfPlayers-input,< 1K
-Predicate,http://schema.org/numberOfPlayers-output,< 1K
-Predicate,http://schema.org/numberOfPreviousOwners,1K - 10K
-Predicate,http://schema.org/numberOfPreviousOwners-input,< 1K
-Predicate,http://schema.org/numberOfPreviousOwners-output,< 1K
-Predicate,http://schema.org/numberOfRooms,10K - 100K
-Predicate,http://schema.org/numberOfRooms-input,< 1K
-Predicate,http://schema.org/numberOfRooms-output,< 1K
-Predicate,http://schema.org/numberOfSeasons,1K - 10K
-Predicate,http://schema.org/numberOfSeasons-input,< 1K
-Predicate,http://schema.org/numberOfSeasons-output,< 1K
-Predicate,http://schema.org/numberedPosition,< 1K
-Predicate,http://schema.org/numberedPosition-input,< 1K
-Predicate,http://schema.org/numberedPosition-output,< 1K
-Predicate,http://schema.org/nutrition,10K - 100K
-Predicate,http://schema.org/nutrition-input,< 1K
-Predicate,http://schema.org/nutrition-output,< 1K
-Predicate,http://schema.org/object,10K - 100K
-Predicate,http://schema.org/object-input,< 1K
-Predicate,http://schema.org/object-output,< 1K
-Predicate,http://schema.org/observationAbout,< 1K
-Predicate,http://schema.org/observationAbout-input,< 1K
-Predicate,http://schema.org/observationAbout-output,< 1K
-Predicate,http://schema.org/observationDate,< 1K
-Predicate,http://schema.org/observationDate-input,< 1K
-Predicate,http://schema.org/observationDate-output,< 1K
-Predicate,http://schema.org/observationPeriod,< 1K
-Predicate,http://schema.org/observationPeriod-input,< 1K
-Predicate,http://schema.org/observationPeriod-output,< 1K
-Predicate,http://schema.org/occupancy,10K - 100K
-Predicate,http://schema.org/occupancy-input,< 1K
-Predicate,http://schema.org/occupancy-output,< 1K
-Predicate,http://schema.org/occupationLocation,10K - 100K
-Predicate,http://schema.org/occupationLocation-input,< 1K
-Predicate,http://schema.org/occupationLocation-output,< 1K
-Predicate,http://schema.org/occupationalCategory,10K - 100K
-Predicate,http://schema.org/occupationalCategory-input,< 1K
-Predicate,http://schema.org/occupationalCategory-output,< 1K
-Predicate,http://schema.org/occupationalCredentialAwarded,1K - 10K
-Predicate,http://schema.org/occupationalCredentialAwarded-input,< 1K
-Predicate,http://schema.org/occupationalCredentialAwarded-output,< 1K
-Predicate,http://schema.org/offerCount,100K - 1M
-Predicate,http://schema.org/offerCount-input,< 1K
-Predicate,http://schema.org/offerCount-output,< 1K
-Predicate,http://schema.org/offeredBy,10K - 100K
-Predicate,http://schema.org/offeredBy-input,< 1K
-Predicate,http://schema.org/offeredBy-output,< 1K
-Predicate,http://schema.org/offers,1M - 10M
-Predicate,http://schema.org/offers-input,< 1K
-Predicate,http://schema.org/offers-output,< 1K
-Predicate,http://schema.org/offersPrescriptionByMail,< 1K
-Predicate,http://schema.org/offersPrescriptionByMail-input,< 1K
-Predicate,http://schema.org/offersPrescriptionByMail-output,< 1K
-Predicate,http://schema.org/openingHours,1M - 10M
-Predicate,http://schema.org/openingHours-input,< 1K
-Predicate,http://schema.org/openingHours-output,< 1K
-Predicate,http://schema.org/openingHoursSpecification,1M - 10M
-Predicate,http://schema.org/openingHoursSpecification-input,< 1K
-Predicate,http://schema.org/openingHoursSpecification-output,< 1K
-Predicate,http://schema.org/opens,1M - 10M
-Predicate,http://schema.org/opens-input,< 1K
-Predicate,http://schema.org/opens-output,< 1K
-Predicate,http://schema.org/operatingSystem,100K - 1M
-Predicate,http://schema.org/operatingSystem-input,< 1K
-Predicate,http://schema.org/operatingSystem-output,< 1K
-Predicate,http://schema.org/opponent,< 1K
-Predicate,http://schema.org/opponent-input,< 1K
-Predicate,http://schema.org/opponent-output,< 1K
-Predicate,http://schema.org/option,< 1K
-Predicate,http://schema.org/option-input,< 1K
-Predicate,http://schema.org/option-output,< 1K
-Predicate,http://schema.org/orderDate,< 1K
-Predicate,http://schema.org/orderDate-input,< 1K
-Predicate,http://schema.org/orderDate-output,< 1K
-Predicate,http://schema.org/orderDelivery,< 1K
-Predicate,http://schema.org/orderDelivery-input,< 1K
-Predicate,http://schema.org/orderDelivery-output,< 1K
-Predicate,http://schema.org/orderItemNumber,< 1K
-Predicate,http://schema.org/orderItemNumber-input,< 1K
-Predicate,http://schema.org/orderItemNumber-output,< 1K
-Predicate,http://schema.org/orderItemStatus,< 1K
-Predicate,http://schema.org/orderItemStatus-input,< 1K
-Predicate,http://schema.org/orderItemStatus-output,< 1K
-Predicate,http://schema.org/orderNumber,< 1K
-Predicate,http://schema.org/orderNumber-input,< 1K
-Predicate,http://schema.org/orderNumber-output,< 1K
-Predicate,http://schema.org/orderPercentage,< 1K
-Predicate,http://schema.org/orderPercentage-input,< 1K
-Predicate,http://schema.org/orderPercentage-output,< 1K
-Predicate,http://schema.org/orderQuantity,< 1K
-Predicate,http://schema.org/orderQuantity-input,< 1K
-Predicate,http://schema.org/orderQuantity-output,< 1K
-Predicate,http://schema.org/orderStatus,< 1K
-Predicate,http://schema.org/orderStatus-input,< 1K
-Predicate,http://schema.org/orderStatus-output,< 1K
-Predicate,http://schema.org/orderValue,< 1K
-Predicate,http://schema.org/orderValue-input,< 1K
-Predicate,http://schema.org/orderValue-output,< 1K
-Predicate,http://schema.org/orderedItem,< 1K
-Predicate,http://schema.org/orderedItem-input,< 1K
-Predicate,http://schema.org/orderedItem-output,< 1K
-Predicate,http://schema.org/organizer,100K - 1M
-Predicate,http://schema.org/organizer-input,< 1K
-Predicate,http://schema.org/organizer-output,< 1K
-Predicate,http://schema.org/originAddress,< 1K
-Predicate,http://schema.org/originAddress-input,< 1K
-Predicate,http://schema.org/originAddress-output,< 1K
-Predicate,http://schema.org/originalMediaContextDescription,< 1K
-Predicate,http://schema.org/originalMediaContextDescription-input,< 1K
-Predicate,http://schema.org/originalMediaContextDescription-output,< 1K
-Predicate,http://schema.org/originalMediaLink,< 1K
-Predicate,http://schema.org/originalMediaLink-input,< 1K
-Predicate,http://schema.org/originalMediaLink-output,< 1K
-Predicate,http://schema.org/originatesFrom,< 1K
-Predicate,http://schema.org/originatesFrom-input,< 1K
-Predicate,http://schema.org/originatesFrom-output,< 1K
-Predicate,http://schema.org/overdosage,< 1K
-Predicate,http://schema.org/overdosage-input,< 1K
-Predicate,http://schema.org/overdosage-output,< 1K
-Predicate,http://schema.org/ownedFrom,< 1K
-Predicate,http://schema.org/ownedFrom-input,< 1K
-Predicate,http://schema.org/ownedFrom-output,< 1K
-Predicate,http://schema.org/ownedThrough,< 1K
-Predicate,http://schema.org/ownedThrough-input,< 1K
-Predicate,http://schema.org/ownedThrough-output,< 1K
-Predicate,http://schema.org/owner,1K - 10K
-Predicate,http://schema.org/owner-input,< 1K
-Predicate,http://schema.org/owner-output,< 1K
-Predicate,http://schema.org/ownershipFundingInfo,10K - 100K
-Predicate,http://schema.org/ownershipFundingInfo-input,< 1K
-Predicate,http://schema.org/ownershipFundingInfo-output,< 1K
-Predicate,http://schema.org/owns,10K - 100K
-Predicate,http://schema.org/owns-input,< 1K
-Predicate,http://schema.org/owns-output,< 1K
-Predicate,http://schema.org/pageEnd,1K - 10K
-Predicate,http://schema.org/pageEnd-input,< 1K
-Predicate,http://schema.org/pageEnd-output,< 1K
-Predicate,http://schema.org/pageStart,1K - 10K
-Predicate,http://schema.org/pageStart-input,< 1K
-Predicate,http://schema.org/pageStart-output,< 1K
-Predicate,http://schema.org/pagination,1K - 10K
-Predicate,http://schema.org/pagination-input,< 1K
-Predicate,http://schema.org/pagination-output,< 1K
-Predicate,http://schema.org/parent,< 1K
-Predicate,http://schema.org/parent-input,< 1K
-Predicate,http://schema.org/parent-output,< 1K
-Predicate,http://schema.org/parentItem,1K - 10K
-Predicate,http://schema.org/parentItem-input,< 1K
-Predicate,http://schema.org/parentItem-output,< 1K
-Predicate,http://schema.org/parentOrganization,100K - 1M
-Predicate,http://schema.org/parentOrganization-input,< 1K
-Predicate,http://schema.org/parentOrganization-output,< 1K
-Predicate,http://schema.org/parentService,< 1K
-Predicate,http://schema.org/parentService-input,< 1K
-Predicate,http://schema.org/parentService-output,< 1K
-Predicate,http://schema.org/parentTaxon,< 1K
-Predicate,http://schema.org/parentTaxon-input,< 1K
-Predicate,http://schema.org/parentTaxon-output,< 1K
-Predicate,http://schema.org/parents,< 1K
-Predicate,http://schema.org/parents-input,< 1K
-Predicate,http://schema.org/parents-output,< 1K
-Predicate,http://schema.org/partOfEpisode,< 1K
-Predicate,http://schema.org/partOfEpisode-input,< 1K
-Predicate,http://schema.org/partOfEpisode-output,< 1K
-Predicate,http://schema.org/partOfInvoice,< 1K
-Predicate,http://schema.org/partOfInvoice-input,< 1K
-Predicate,http://schema.org/partOfInvoice-output,< 1K
-Predicate,http://schema.org/partOfOrder,< 1K
-Predicate,http://schema.org/partOfOrder-input,< 1K
-Predicate,http://schema.org/partOfOrder-output,< 1K
-Predicate,http://schema.org/partOfSeason,1K - 10K
-Predicate,http://schema.org/partOfSeason-input,< 1K
-Predicate,http://schema.org/partOfSeason-output,< 1K
-Predicate,http://schema.org/partOfSeries,10K - 100K
-Predicate,http://schema.org/partOfSeries-input,< 1K
-Predicate,http://schema.org/partOfSeries-output,< 1K
-Predicate,http://schema.org/partOfSystem,< 1K
-Predicate,http://schema.org/partOfSystem-input,< 1K
-Predicate,http://schema.org/partOfSystem-output,< 1K
-Predicate,http://schema.org/partOfTVSeries,< 1K
-Predicate,http://schema.org/partOfTVSeries-input,< 1K
-Predicate,http://schema.org/partOfTVSeries-output,< 1K
-Predicate,http://schema.org/partOfTrip,< 1K
-Predicate,http://schema.org/partOfTrip-input,< 1K
-Predicate,http://schema.org/partOfTrip-output,< 1K
-Predicate,http://schema.org/participant,1K - 10K
-Predicate,http://schema.org/participant-input,< 1K
-Predicate,http://schema.org/participant-output,< 1K
-Predicate,http://schema.org/partySize,< 1K
-Predicate,http://schema.org/partySize-input,< 1K
-Predicate,http://schema.org/partySize-output,< 1K
-Predicate,http://schema.org/passengerPriorityStatus,< 1K
-Predicate,http://schema.org/passengerPriorityStatus-input,< 1K
-Predicate,http://schema.org/passengerPriorityStatus-output,< 1K
-Predicate,http://schema.org/passengerSequenceNumber,< 1K
-Predicate,http://schema.org/passengerSequenceNumber-input,< 1K
-Predicate,http://schema.org/passengerSequenceNumber-output,< 1K
-Predicate,http://schema.org/pathophysiology,< 1K
-Predicate,http://schema.org/pathophysiology-input,< 1K
-Predicate,http://schema.org/pathophysiology-output,< 1K
-Predicate,http://schema.org/pattern,1K - 10K
-Predicate,http://schema.org/pattern-input,< 1K
-Predicate,http://schema.org/pattern-output,< 1K
-Predicate,http://schema.org/payload,1K - 10K
-Predicate,http://schema.org/payload-input,< 1K
-Predicate,http://schema.org/payload-output,< 1K
-Predicate,http://schema.org/paymentAccepted,100K - 1M
-Predicate,http://schema.org/paymentAccepted-input,< 1K
-Predicate,http://schema.org/paymentAccepted-output,< 1K
-Predicate,http://schema.org/paymentDue,< 1K
-Predicate,http://schema.org/paymentDue-input,< 1K
-Predicate,http://schema.org/paymentDue-output,< 1K
-Predicate,http://schema.org/paymentDueDate,< 1K
-Predicate,http://schema.org/paymentDueDate-input,< 1K
-Predicate,http://schema.org/paymentDueDate-output,< 1K
-Predicate,http://schema.org/paymentMethod,< 1K
-Predicate,http://schema.org/paymentMethod-input,< 1K
-Predicate,http://schema.org/paymentMethod-output,< 1K
-Predicate,http://schema.org/paymentMethodId,< 1K
-Predicate,http://schema.org/paymentMethodId-input,< 1K
-Predicate,http://schema.org/paymentMethodId-output,< 1K
-Predicate,http://schema.org/paymentMethodType,1K - 10K
-Predicate,http://schema.org/paymentMethodType-input,< 1K
-Predicate,http://schema.org/paymentMethodType-output,< 1K
-Predicate,http://schema.org/paymentStatus,< 1K
-Predicate,http://schema.org/paymentStatus-input,< 1K
-Predicate,http://schema.org/paymentStatus-output,< 1K
-Predicate,http://schema.org/paymentUrl,< 1K
-Predicate,http://schema.org/paymentUrl-input,< 1K
-Predicate,http://schema.org/paymentUrl-output,< 1K
-Predicate,http://schema.org/penciler,< 1K
-Predicate,http://schema.org/penciler-input,< 1K
-Predicate,http://schema.org/penciler-output,< 1K
-Predicate,http://schema.org/percentile10,1K - 10K
-Predicate,http://schema.org/percentile10-input,< 1K
-Predicate,http://schema.org/percentile10-output,< 1K
-Predicate,http://schema.org/percentile25,< 1K
-Predicate,http://schema.org/percentile25-input,< 1K
-Predicate,http://schema.org/percentile25-output,< 1K
-Predicate,http://schema.org/percentile75,< 1K
-Predicate,http://schema.org/percentile75-input,< 1K
-Predicate,http://schema.org/percentile75-output,< 1K
-Predicate,http://schema.org/percentile90,1K - 10K
-Predicate,http://schema.org/percentile90-input,< 1K
-Predicate,http://schema.org/percentile90-output,< 1K
-Predicate,http://schema.org/performTime,1K - 10K
-Predicate,http://schema.org/performTime-input,< 1K
-Predicate,http://schema.org/performTime-output,< 1K
-Predicate,http://schema.org/performer,100K - 1M
-Predicate,http://schema.org/performer-input,< 1K
-Predicate,http://schema.org/performer-output,< 1K
-Predicate,http://schema.org/performerIn,1K - 10K
-Predicate,http://schema.org/performerIn-input,< 1K
-Predicate,http://schema.org/performerIn-output,< 1K
-Predicate,http://schema.org/performers,1K - 10K
-Predicate,http://schema.org/performers-input,< 1K
-Predicate,http://schema.org/performers-output,< 1K
-Predicate,http://schema.org/permissionType,< 1K
-Predicate,http://schema.org/permissionType-input,< 1K
-Predicate,http://schema.org/permissionType-output,< 1K
-Predicate,http://schema.org/permissions,10K - 100K
-Predicate,http://schema.org/permissions-input,< 1K
-Predicate,http://schema.org/permissions-output,< 1K
-Predicate,http://schema.org/permitAudience,< 1K
-Predicate,http://schema.org/permitAudience-input,< 1K
-Predicate,http://schema.org/permitAudience-output,< 1K
-Predicate,http://schema.org/permittedUsage,< 1K
-Predicate,http://schema.org/permittedUsage-input,< 1K
-Predicate,http://schema.org/permittedUsage-output,< 1K
-Predicate,http://schema.org/petsAllowed,10K - 100K
-Predicate,http://schema.org/petsAllowed-input,< 1K
-Predicate,http://schema.org/petsAllowed-output,< 1K
-Predicate,http://schema.org/phoneticText,< 1K
-Predicate,http://schema.org/phoneticText-input,< 1K
-Predicate,http://schema.org/phoneticText-output,< 1K
-Predicate,http://schema.org/photo,10K - 100K
-Predicate,http://schema.org/photo-input,< 1K
-Predicate,http://schema.org/photo-output,< 1K
-Predicate,http://schema.org/photos,10K - 100K
-Predicate,http://schema.org/photos-input,< 1K
-Predicate,http://schema.org/photos-output,< 1K
-Predicate,http://schema.org/physicalRequirement,< 1K
-Predicate,http://schema.org/physicalRequirement-input,< 1K
-Predicate,http://schema.org/physicalRequirement-output,< 1K
-Predicate,http://schema.org/physiologicalBenefits,< 1K
-Predicate,http://schema.org/physiologicalBenefits-input,< 1K
-Predicate,http://schema.org/physiologicalBenefits-output,< 1K
-Predicate,http://schema.org/pickupLocation,< 1K
-Predicate,http://schema.org/pickupLocation-input,< 1K
-Predicate,http://schema.org/pickupLocation-output,< 1K
-Predicate,http://schema.org/pickupTime,< 1K
-Predicate,http://schema.org/pickupTime-input,< 1K
-Predicate,http://schema.org/pickupTime-output,< 1K
-Predicate,http://schema.org/playMode,10K - 100K
-Predicate,http://schema.org/playMode-input,< 1K
-Predicate,http://schema.org/playMode-output,< 1K
-Predicate,http://schema.org/playerType,1K - 10K
-Predicate,http://schema.org/playerType-input,< 1K
-Predicate,http://schema.org/playerType-output,< 1K
-Predicate,http://schema.org/playersOnline,1K - 10K
-Predicate,http://schema.org/playersOnline-input,< 1K
-Predicate,http://schema.org/playersOnline-output,< 1K
-Predicate,http://schema.org/polygon,< 1K
-Predicate,http://schema.org/polygon-input,< 1K
-Predicate,http://schema.org/polygon-output,< 1K
-Predicate,http://schema.org/populationType,< 1K
-Predicate,http://schema.org/populationType-input,< 1K
-Predicate,http://schema.org/populationType-output,< 1K
-Predicate,http://schema.org/position,10M+
-Predicate,http://schema.org/position-input,< 1K
-Predicate,http://schema.org/position-output,< 1K
-Predicate,http://schema.org/positiveNotes,10K - 100K
-Predicate,http://schema.org/positiveNotes-input,< 1K
-Predicate,http://schema.org/positiveNotes-output,< 1K
-Predicate,http://schema.org/possibleComplication,1K - 10K
-Predicate,http://schema.org/possibleComplication-input,< 1K
-Predicate,http://schema.org/possibleComplication-output,< 1K
-Predicate,http://schema.org/possibleTreatment,1K - 10K
-Predicate,http://schema.org/possibleTreatment-input,< 1K
-Predicate,http://schema.org/possibleTreatment-output,< 1K
-Predicate,http://schema.org/postOfficeBoxNumber,10K - 100K
-Predicate,http://schema.org/postOfficeBoxNumber-input,< 1K
-Predicate,http://schema.org/postOfficeBoxNumber-output,< 1K
-Predicate,http://schema.org/postOp,< 1K
-Predicate,http://schema.org/postOp-input,< 1K
-Predicate,http://schema.org/postOp-output,< 1K
-Predicate,http://schema.org/postalCode,1M - 10M
-Predicate,http://schema.org/postalCode-input,< 1K
-Predicate,http://schema.org/postalCode-output,< 1K
-Predicate,http://schema.org/postalCodeBegin,1K - 10K
-Predicate,http://schema.org/postalCodeBegin-input,< 1K
-Predicate,http://schema.org/postalCodeBegin-output,< 1K
-Predicate,http://schema.org/postalCodeEnd,1K - 10K
-Predicate,http://schema.org/postalCodeEnd-input,< 1K
-Predicate,http://schema.org/postalCodeEnd-output,< 1K
-Predicate,http://schema.org/postalCodePrefix,< 1K
-Predicate,http://schema.org/postalCodePrefix-input,< 1K
-Predicate,http://schema.org/postalCodePrefix-output,< 1K
-Predicate,http://schema.org/postalCodeRange,1K - 10K
-Predicate,http://schema.org/postalCodeRange-input,< 1K
-Predicate,http://schema.org/postalCodeRange-output,< 1K
-Predicate,http://schema.org/potentialAction,10M+
-Predicate,http://schema.org/potentialAction-input,< 1K
-Predicate,http://schema.org/potentialAction-output,< 1K
-Predicate,http://schema.org/potentialUse,< 1K
-Predicate,http://schema.org/potentialUse-input,< 1K
-Predicate,http://schema.org/potentialUse-output,< 1K
-Predicate,http://schema.org/practicesAt,< 1K
-Predicate,http://schema.org/practicesAt-input,< 1K
-Predicate,http://schema.org/practicesAt-output,< 1K
-Predicate,http://schema.org/preOp,< 1K
-Predicate,http://schema.org/preOp-input,< 1K
-Predicate,http://schema.org/preOp-output,< 1K
-Predicate,http://schema.org/predecessorOf,< 1K
-Predicate,http://schema.org/predecessorOf-input,< 1K
-Predicate,http://schema.org/predecessorOf-output,< 1K
-Predicate,http://schema.org/pregnancyCategory,< 1K
-Predicate,http://schema.org/pregnancyCategory-input,< 1K
-Predicate,http://schema.org/pregnancyCategory-output,< 1K
-Predicate,http://schema.org/pregnancyWarning,< 1K
-Predicate,http://schema.org/pregnancyWarning-input,< 1K
-Predicate,http://schema.org/pregnancyWarning-output,< 1K
-Predicate,http://schema.org/prepTime,10K - 100K
-Predicate,http://schema.org/prepTime-input,< 1K
-Predicate,http://schema.org/prepTime-output,< 1K
-Predicate,http://schema.org/preparation,1K - 10K
-Predicate,http://schema.org/preparation-input,< 1K
-Predicate,http://schema.org/preparation-output,< 1K
-Predicate,http://schema.org/prescribingInfo,< 1K
-Predicate,http://schema.org/prescribingInfo-input,< 1K
-Predicate,http://schema.org/prescribingInfo-output,< 1K
-Predicate,http://schema.org/prescriptionStatus,1K - 10K
-Predicate,http://schema.org/prescriptionStatus-input,< 1K
-Predicate,http://schema.org/prescriptionStatus-output,< 1K
-Predicate,http://schema.org/previousItem,1M - 10M
-Predicate,http://schema.org/previousItem-input,< 1K
-Predicate,http://schema.org/previousItem-output,< 1K
-Predicate,http://schema.org/previousStartDate,1K - 10K
-Predicate,http://schema.org/previousStartDate-input,< 1K
-Predicate,http://schema.org/previousStartDate-output,< 1K
-Predicate,http://schema.org/price,1M - 10M
-Predicate,http://schema.org/price-input,< 1K
-Predicate,http://schema.org/price-output,< 1K
-Predicate,http://schema.org/priceComponent,1K - 10K
-Predicate,http://schema.org/priceComponent-input,< 1K
-Predicate,http://schema.org/priceComponent-output,< 1K
-Predicate,http://schema.org/priceComponentType,< 1K
-Predicate,http://schema.org/priceComponentType-input,< 1K
-Predicate,http://schema.org/priceComponentType-output,< 1K
-Predicate,http://schema.org/priceCurrency,1M - 10M
-Predicate,http://schema.org/priceCurrency-input,< 1K
-Predicate,http://schema.org/priceCurrency-output,< 1K
-Predicate,http://schema.org/priceRange,1M - 10M
-Predicate,http://schema.org/priceRange-input,< 1K
-Predicate,http://schema.org/priceRange-output,< 1K
-Predicate,http://schema.org/priceSpecification,1M - 10M
-Predicate,http://schema.org/priceSpecification-input,< 1K
-Predicate,http://schema.org/priceSpecification-output,< 1K
-Predicate,http://schema.org/priceType,100K - 1M
-Predicate,http://schema.org/priceType-input,< 1K
-Predicate,http://schema.org/priceType-output,< 1K
-Predicate,http://schema.org/priceValidUntil,1M - 10M
-Predicate,http://schema.org/priceValidUntil-input,< 1K
-Predicate,http://schema.org/priceValidUntil-output,< 1K
-Predicate,http://schema.org/primaryImageOfPage,10M+
-Predicate,http://schema.org/primaryImageOfPage-input,< 1K
-Predicate,http://schema.org/primaryImageOfPage-output,< 1K
-Predicate,http://schema.org/primaryPrevention,< 1K
-Predicate,http://schema.org/primaryPrevention-input,< 1K
-Predicate,http://schema.org/primaryPrevention-output,< 1K
-Predicate,http://schema.org/printColumn,< 1K
-Predicate,http://schema.org/printColumn-input,< 1K
-Predicate,http://schema.org/printColumn-output,< 1K
-Predicate,http://schema.org/printEdition,< 1K
-Predicate,http://schema.org/printEdition-input,< 1K
-Predicate,http://schema.org/printEdition-output,< 1K
-Predicate,http://schema.org/printPage,< 1K
-Predicate,http://schema.org/printPage-input,< 1K
-Predicate,http://schema.org/printPage-output,< 1K
-Predicate,http://schema.org/printSection,< 1K
-Predicate,http://schema.org/printSection-input,< 1K
-Predicate,http://schema.org/printSection-output,< 1K
-Predicate,http://schema.org/procedure,< 1K
-Predicate,http://schema.org/procedure-input,< 1K
-Predicate,http://schema.org/procedure-output,< 1K
-Predicate,http://schema.org/procedureType,10K - 100K
-Predicate,http://schema.org/procedureType-input,< 1K
-Predicate,http://schema.org/procedureType-output,< 1K
-Predicate,http://schema.org/processingTime,< 1K
-Predicate,http://schema.org/processingTime-input,< 1K
-Predicate,http://schema.org/processingTime-output,< 1K
-Predicate,http://schema.org/processorRequirements,1K - 10K
-Predicate,http://schema.org/processorRequirements-input,< 1K
-Predicate,http://schema.org/processorRequirements-output,< 1K
-Predicate,http://schema.org/producer,1K - 10K
-Predicate,http://schema.org/producer-input,< 1K
-Predicate,http://schema.org/producer-output,< 1K
-Predicate,http://schema.org/produces,< 1K
-Predicate,http://schema.org/produces-input,< 1K
-Predicate,http://schema.org/produces-output,< 1K
-Predicate,http://schema.org/productGroupID,100K - 1M
-Predicate,http://schema.org/productGroupID-input,< 1K
-Predicate,http://schema.org/productGroupID-output,< 1K
-Predicate,http://schema.org/productID,100K - 1M
-Predicate,http://schema.org/productID-input,< 1K
-Predicate,http://schema.org/productID-output,< 1K
-Predicate,http://schema.org/productReturnDays,< 1K
-Predicate,http://schema.org/productReturnDays-input,< 1K
-Predicate,http://schema.org/productReturnDays-output,< 1K
-Predicate,http://schema.org/productReturnLink,< 1K
-Predicate,http://schema.org/productReturnLink-input,< 1K
-Predicate,http://schema.org/productReturnLink-output,< 1K
-Predicate,http://schema.org/productSupported,1K - 10K
-Predicate,http://schema.org/productSupported-input,< 1K
-Predicate,http://schema.org/productSupported-output,< 1K
-Predicate,http://schema.org/productionCompany,1K - 10K
-Predicate,http://schema.org/productionCompany-input,< 1K
-Predicate,http://schema.org/productionCompany-output,< 1K
-Predicate,http://schema.org/productionDate,10K - 100K
-Predicate,http://schema.org/productionDate-input,< 1K
-Predicate,http://schema.org/productionDate-output,< 1K
-Predicate,http://schema.org/proficiencyLevel,10K - 100K
-Predicate,http://schema.org/proficiencyLevel-input,< 1K
-Predicate,http://schema.org/proficiencyLevel-output,< 1K
-Predicate,http://schema.org/program,< 1K
-Predicate,http://schema.org/program-input,< 1K
-Predicate,http://schema.org/program-output,< 1K
-Predicate,http://schema.org/programMembershipUsed,< 1K
-Predicate,http://schema.org/programMembershipUsed-input,< 1K
-Predicate,http://schema.org/programMembershipUsed-output,< 1K
-Predicate,http://schema.org/programName,1K - 10K
-Predicate,http://schema.org/programName-input,< 1K
-Predicate,http://schema.org/programName-output,< 1K
-Predicate,http://schema.org/programPrerequisites,1K - 10K
-Predicate,http://schema.org/programPrerequisites-input,< 1K
-Predicate,http://schema.org/programPrerequisites-output,< 1K
-Predicate,http://schema.org/programType,1K - 10K
-Predicate,http://schema.org/programType-input,< 1K
-Predicate,http://schema.org/programType-output,< 1K
-Predicate,http://schema.org/programmingLanguage,1K - 10K
-Predicate,http://schema.org/programmingLanguage-input,< 1K
-Predicate,http://schema.org/programmingLanguage-output,< 1K
-Predicate,http://schema.org/programmingModel,< 1K
-Predicate,http://schema.org/programmingModel-input,< 1K
-Predicate,http://schema.org/programmingModel-output,< 1K
-Predicate,http://schema.org/pronouns,1K - 10K
-Predicate,http://schema.org/pronouns-input,< 1K
-Predicate,http://schema.org/pronouns-output,< 1K
-Predicate,http://schema.org/propertyID,10K - 100K
-Predicate,http://schema.org/propertyID-input,< 1K
-Predicate,http://schema.org/propertyID-output,< 1K
-Predicate,http://schema.org/proprietaryName,< 1K
-Predicate,http://schema.org/proprietaryName-input,< 1K
-Predicate,http://schema.org/proprietaryName-output,< 1K
-Predicate,http://schema.org/proteinContent,10K - 100K
-Predicate,http://schema.org/proteinContent-input,< 1K
-Predicate,http://schema.org/proteinContent-output,< 1K
-Predicate,http://schema.org/provider,100K - 1M
-Predicate,http://schema.org/provider-input,< 1K
-Predicate,http://schema.org/provider-output,< 1K
-Predicate,http://schema.org/providerMobility,1K - 10K
-Predicate,http://schema.org/providerMobility-input,< 1K
-Predicate,http://schema.org/providerMobility-output,< 1K
-Predicate,http://schema.org/providesBroadcastService,< 1K
-Predicate,http://schema.org/providesBroadcastService-input,< 1K
-Predicate,http://schema.org/providesBroadcastService-output,< 1K
-Predicate,http://schema.org/providesService,< 1K
-Predicate,http://schema.org/providesService-input,< 1K
-Predicate,http://schema.org/providesService-output,< 1K
-Predicate,http://schema.org/publicAccess,10K - 100K
-Predicate,http://schema.org/publicAccess-input,< 1K
-Predicate,http://schema.org/publicAccess-output,< 1K
-Predicate,http://schema.org/publicTransportClosuresInfo,< 1K
-Predicate,http://schema.org/publicTransportClosuresInfo-input,< 1K
-Predicate,http://schema.org/publicTransportClosuresInfo-output,< 1K
-Predicate,http://schema.org/publication,1K - 10K
-Predicate,http://schema.org/publication-input,< 1K
-Predicate,http://schema.org/publication-output,< 1K
-Predicate,http://schema.org/publicationType,< 1K
-Predicate,http://schema.org/publicationType-input,< 1K
-Predicate,http://schema.org/publicationType-output,< 1K
-Predicate,http://schema.org/publishedBy,< 1K
-Predicate,http://schema.org/publishedBy-input,< 1K
-Predicate,http://schema.org/publishedBy-output,< 1K
-Predicate,http://schema.org/publishedOn,< 1K
-Predicate,http://schema.org/publishedOn-input,< 1K
-Predicate,http://schema.org/publishedOn-output,< 1K
-Predicate,http://schema.org/publisher,10M+
-Predicate,http://schema.org/publisher-input,< 1K
-Predicate,http://schema.org/publisher-output,< 1K
-Predicate,http://schema.org/publisherImprint,< 1K
-Predicate,http://schema.org/publisherImprint-input,< 1K
-Predicate,http://schema.org/publisherImprint-output,< 1K
-Predicate,http://schema.org/publishingPrinciples,10K - 100K
-Predicate,http://schema.org/publishingPrinciples-input,< 1K
-Predicate,http://schema.org/publishingPrinciples-output,< 1K
-Predicate,http://schema.org/purchaseDate,1K - 10K
-Predicate,http://schema.org/purchaseDate-input,< 1K
-Predicate,http://schema.org/purchaseDate-output,< 1K
-Predicate,http://schema.org/purchasePriceLimit,< 1K
-Predicate,http://schema.org/purchasePriceLimit-input,< 1K
-Predicate,http://schema.org/purchasePriceLimit-output,< 1K
-Predicate,http://schema.org/purchaseType,< 1K
-Predicate,http://schema.org/purchaseType-input,< 1K
-Predicate,http://schema.org/purchaseType-output,< 1K
-Predicate,http://schema.org/qualifications,10K - 100K
-Predicate,http://schema.org/qualifications-input,< 1K
-Predicate,http://schema.org/qualifications-output,< 1K
-Predicate,http://schema.org/qualifiedExpense,< 1K
-Predicate,http://schema.org/qualifiedExpense-input,< 1K
-Predicate,http://schema.org/qualifiedExpense-output,< 1K
-Predicate,http://schema.org/quarantineGuidelines,< 1K
-Predicate,http://schema.org/quarantineGuidelines-input,< 1K
-Predicate,http://schema.org/quarantineGuidelines-output,< 1K
-Predicate,http://schema.org/query,10K - 100K
-Predicate,http://schema.org/query-input,10M+
-Predicate,http://schema.org/query-output,< 1K
-Predicate,http://schema.org/quest,< 1K
-Predicate,http://schema.org/quest-input,< 1K
-Predicate,http://schema.org/quest-output,< 1K
-Predicate,http://schema.org/question,< 1K
-Predicate,http://schema.org/question-input,< 1K
-Predicate,http://schema.org/question-output,< 1K
-Predicate,http://schema.org/rangeIncludes,< 1K
-Predicate,http://schema.org/rangeIncludes-input,< 1K
-Predicate,http://schema.org/rangeIncludes-output,< 1K
-Predicate,http://schema.org/ratingCount,1M - 10M
-Predicate,http://schema.org/ratingCount-input,< 1K
-Predicate,http://schema.org/ratingCount-output,< 1K
-Predicate,http://schema.org/ratingExplanation,1K - 10K
-Predicate,http://schema.org/ratingExplanation-input,< 1K
-Predicate,http://schema.org/ratingExplanation-output,< 1K
-Predicate,http://schema.org/ratingValue,1M - 10M
-Predicate,http://schema.org/ratingValue-input,< 1K
-Predicate,http://schema.org/ratingValue-output,< 1K
-Predicate,http://schema.org/readBy,< 1K
-Predicate,http://schema.org/readBy-input,< 1K
-Predicate,http://schema.org/readBy-output,< 1K
-Predicate,http://schema.org/readonlyValue,< 1K
-Predicate,http://schema.org/readonlyValue-input,< 1K
-Predicate,http://schema.org/readonlyValue-output,< 1K
-Predicate,http://schema.org/realEstateAgent,< 1K
-Predicate,http://schema.org/realEstateAgent-input,< 1K
-Predicate,http://schema.org/realEstateAgent-output,< 1K
-Predicate,http://schema.org/recipe,< 1K
-Predicate,http://schema.org/recipe-input,< 1K
-Predicate,http://schema.org/recipe-output,< 1K
-Predicate,http://schema.org/recipeCategory,10K - 100K
-Predicate,http://schema.org/recipeCategory-input,< 1K
-Predicate,http://schema.org/recipeCategory-output,< 1K
-Predicate,http://schema.org/recipeCuisine,10K - 100K
-Predicate,http://schema.org/recipeCuisine-input,< 1K
-Predicate,http://schema.org/recipeCuisine-output,< 1K
-Predicate,http://schema.org/recipeIngredient,10K - 100K
-Predicate,http://schema.org/recipeIngredient-input,< 1K
-Predicate,http://schema.org/recipeIngredient-output,< 1K
-Predicate,http://schema.org/recipeInstructions,10K - 100K
-Predicate,http://schema.org/recipeInstructions-input,< 1K
-Predicate,http://schema.org/recipeInstructions-output,< 1K
-Predicate,http://schema.org/recipeYield,10K - 100K
-Predicate,http://schema.org/recipeYield-input,< 1K
-Predicate,http://schema.org/recipeYield-output,< 1K
-Predicate,http://schema.org/recipient,1K - 10K
-Predicate,http://schema.org/recipient-input,< 1K
-Predicate,http://schema.org/recipient-output,< 1K
-Predicate,http://schema.org/recognizedBy,10K - 100K
-Predicate,http://schema.org/recognizedBy-input,< 1K
-Predicate,http://schema.org/recognizedBy-output,< 1K
-Predicate,http://schema.org/recognizingAuthority,1K - 10K
-Predicate,http://schema.org/recognizingAuthority-input,< 1K
-Predicate,http://schema.org/recognizingAuthority-output,< 1K
-Predicate,http://schema.org/recommendationStrength,< 1K
-Predicate,http://schema.org/recommendationStrength-input,< 1K
-Predicate,http://schema.org/recommendationStrength-output,< 1K
-Predicate,http://schema.org/recommendedIntake,< 1K
-Predicate,http://schema.org/recommendedIntake-input,< 1K
-Predicate,http://schema.org/recommendedIntake-output,< 1K
-Predicate,http://schema.org/recordLabel,1K - 10K
-Predicate,http://schema.org/recordLabel-input,< 1K
-Predicate,http://schema.org/recordLabel-output,< 1K
-Predicate,http://schema.org/recordedAs,< 1K
-Predicate,http://schema.org/recordedAs-input,< 1K
-Predicate,http://schema.org/recordedAs-output,< 1K
-Predicate,http://schema.org/recordedAt,< 1K
-Predicate,http://schema.org/recordedAt-input,< 1K
-Predicate,http://schema.org/recordedAt-output,< 1K
-Predicate,http://schema.org/recordedIn,< 1K
-Predicate,http://schema.org/recordedIn-input,< 1K
-Predicate,http://schema.org/recordedIn-output,< 1K
-Predicate,http://schema.org/recordingOf,1K - 10K
-Predicate,http://schema.org/recordingOf-input,< 1K
-Predicate,http://schema.org/recordingOf-output,< 1K
-Predicate,http://schema.org/recourseLoan,< 1K
-Predicate,http://schema.org/recourseLoan-input,< 1K
-Predicate,http://schema.org/recourseLoan-output,< 1K
-Predicate,http://schema.org/referee,< 1K
-Predicate,http://schema.org/referee-input,< 1K
-Predicate,http://schema.org/referee-output,< 1K
-Predicate,http://schema.org/referenceQuantity,10K - 100K
-Predicate,http://schema.org/referenceQuantity-input,< 1K
-Predicate,http://schema.org/referenceQuantity-output,< 1K
-Predicate,http://schema.org/referencesOrder,< 1K
-Predicate,http://schema.org/referencesOrder-input,< 1K
-Predicate,http://schema.org/referencesOrder-output,< 1K
-Predicate,http://schema.org/refundType,10K - 100K
-Predicate,http://schema.org/refundType-input,< 1K
-Predicate,http://schema.org/refundType-output,< 1K
-Predicate,http://schema.org/regionDrained,< 1K
-Predicate,http://schema.org/regionDrained-input,< 1K
-Predicate,http://schema.org/regionDrained-output,< 1K
-Predicate,http://schema.org/regionsAllowed,1K - 10K
-Predicate,http://schema.org/regionsAllowed-input,< 1K
-Predicate,http://schema.org/regionsAllowed-output,< 1K
-Predicate,http://schema.org/relatedAnatomy,< 1K
-Predicate,http://schema.org/relatedAnatomy-input,< 1K
-Predicate,http://schema.org/relatedAnatomy-output,< 1K
-Predicate,http://schema.org/relatedCondition,< 1K
-Predicate,http://schema.org/relatedCondition-input,< 1K
-Predicate,http://schema.org/relatedCondition-output,< 1K
-Predicate,http://schema.org/relatedDrug,< 1K
-Predicate,http://schema.org/relatedDrug-input,< 1K
-Predicate,http://schema.org/relatedDrug-output,< 1K
-Predicate,http://schema.org/relatedLink,10K - 100K
-Predicate,http://schema.org/relatedLink-input,< 1K
-Predicate,http://schema.org/relatedLink-output,< 1K
-Predicate,http://schema.org/relatedStructure,< 1K
-Predicate,http://schema.org/relatedStructure-input,< 1K
-Predicate,http://schema.org/relatedStructure-output,< 1K
-Predicate,http://schema.org/relatedTherapy,< 1K
-Predicate,http://schema.org/relatedTherapy-input,< 1K
-Predicate,http://schema.org/relatedTherapy-output,< 1K
-Predicate,http://schema.org/relatedTo,< 1K
-Predicate,http://schema.org/relatedTo-input,< 1K
-Predicate,http://schema.org/relatedTo-output,< 1K
-Predicate,http://schema.org/releaseDate,10K - 100K
-Predicate,http://schema.org/releaseDate-input,< 1K
-Predicate,http://schema.org/releaseDate-output,< 1K
-Predicate,http://schema.org/releaseNotes,10K - 100K
-Predicate,http://schema.org/releaseNotes-input,< 1K
-Predicate,http://schema.org/releaseNotes-output,< 1K
-Predicate,http://schema.org/releaseOf,< 1K
-Predicate,http://schema.org/releaseOf-input,< 1K
-Predicate,http://schema.org/releaseOf-output,< 1K
-Predicate,http://schema.org/releasedEvent,1K - 10K
-Predicate,http://schema.org/releasedEvent-input,< 1K
-Predicate,http://schema.org/releasedEvent-output,< 1K
-Predicate,http://schema.org/relevantOccupation,< 1K
-Predicate,http://schema.org/relevantOccupation-input,< 1K
-Predicate,http://schema.org/relevantOccupation-output,< 1K
-Predicate,http://schema.org/relevantSpecialty,1K - 10K
-Predicate,http://schema.org/relevantSpecialty-input,< 1K
-Predicate,http://schema.org/relevantSpecialty-output,< 1K
-Predicate,http://schema.org/remainingAttendeeCapacity,1K - 10K
-Predicate,http://schema.org/remainingAttendeeCapacity-input,< 1K
-Predicate,http://schema.org/remainingAttendeeCapacity-output,< 1K
-Predicate,http://schema.org/renegotiableLoan,< 1K
-Predicate,http://schema.org/renegotiableLoan-input,< 1K
-Predicate,http://schema.org/renegotiableLoan-output,< 1K
-Predicate,http://schema.org/repeatCount,1K - 10K
-Predicate,http://schema.org/repeatCount-input,< 1K
-Predicate,http://schema.org/repeatCount-output,< 1K
-Predicate,http://schema.org/repeatFrequency,10K - 100K
-Predicate,http://schema.org/repeatFrequency-input,< 1K
-Predicate,http://schema.org/repeatFrequency-output,< 1K
-Predicate,http://schema.org/repetitions,< 1K
-Predicate,http://schema.org/repetitions-input,< 1K
-Predicate,http://schema.org/repetitions-output,< 1K
-Predicate,http://schema.org/replacee,< 1K
-Predicate,http://schema.org/replacee-input,< 1K
-Predicate,http://schema.org/replacee-output,< 1K
-Predicate,http://schema.org/replacer,< 1K
-Predicate,http://schema.org/replacer-input,< 1K
-Predicate,http://schema.org/replacer-output,< 1K
-Predicate,http://schema.org/replyToUrl,1K - 10K
-Predicate,http://schema.org/replyToUrl-input,< 1K
-Predicate,http://schema.org/replyToUrl-output,< 1K
-Predicate,http://schema.org/reportNumber,< 1K
-Predicate,http://schema.org/reportNumber-input,< 1K
-Predicate,http://schema.org/reportNumber-output,< 1K
-Predicate,http://schema.org/representativeOfPage,100K - 1M
-Predicate,http://schema.org/representativeOfPage-input,< 1K
-Predicate,http://schema.org/representativeOfPage-output,< 1K
-Predicate,http://schema.org/requiredCollateral,< 1K
-Predicate,http://schema.org/requiredCollateral-input,< 1K
-Predicate,http://schema.org/requiredCollateral-output,< 1K
-Predicate,http://schema.org/requiredGender,< 1K
-Predicate,http://schema.org/requiredGender-input,< 1K
-Predicate,http://schema.org/requiredGender-output,< 1K
-Predicate,http://schema.org/requiredMaxAge,< 1K
-Predicate,http://schema.org/requiredMaxAge-input,< 1K
-Predicate,http://schema.org/requiredMaxAge-output,< 1K
-Predicate,http://schema.org/requiredMinAge,1K - 10K
-Predicate,http://schema.org/requiredMinAge-input,< 1K
-Predicate,http://schema.org/requiredMinAge-output,< 1K
-Predicate,http://schema.org/requiredQuantity,1K - 10K
-Predicate,http://schema.org/requiredQuantity-input,< 1K
-Predicate,http://schema.org/requiredQuantity-output,< 1K
-Predicate,http://schema.org/requirements,1K - 10K
-Predicate,http://schema.org/requirements-input,< 1K
-Predicate,http://schema.org/requirements-output,< 1K
-Predicate,http://schema.org/requiresSubscription,1K - 10K
-Predicate,http://schema.org/requiresSubscription-input,< 1K
-Predicate,http://schema.org/requiresSubscription-output,< 1K
-Predicate,http://schema.org/reservationFor,1K - 10K
-Predicate,http://schema.org/reservationFor-input,< 1K
-Predicate,http://schema.org/reservationFor-output,< 1K
-Predicate,http://schema.org/reservationId,< 1K
-Predicate,http://schema.org/reservationId-input,< 1K
-Predicate,http://schema.org/reservationId-output,< 1K
-Predicate,http://schema.org/reservationStatus,< 1K
-Predicate,http://schema.org/reservationStatus-input,< 1K
-Predicate,http://schema.org/reservationStatus-output,< 1K
-Predicate,http://schema.org/reservedTicket,< 1K
-Predicate,http://schema.org/reservedTicket-input,< 1K
-Predicate,http://schema.org/reservedTicket-output,< 1K
-Predicate,http://schema.org/responsibilities,10K - 100K
-Predicate,http://schema.org/responsibilities-input,< 1K
-Predicate,http://schema.org/responsibilities-output,< 1K
-Predicate,http://schema.org/restPeriods,< 1K
-Predicate,http://schema.org/restPeriods-input,< 1K
-Predicate,http://schema.org/restPeriods-output,< 1K
-Predicate,http://schema.org/restockingFee,1K - 10K
-Predicate,http://schema.org/restockingFee-input,< 1K
-Predicate,http://schema.org/restockingFee-output,< 1K
-Predicate,http://schema.org/result,10K - 100K
-Predicate,http://schema.org/result-input,< 1K
-Predicate,http://schema.org/result-output,< 1K
-Predicate,http://schema.org/resultComment,< 1K
-Predicate,http://schema.org/resultComment-input,< 1K
-Predicate,http://schema.org/resultComment-output,< 1K
-Predicate,http://schema.org/resultReview,< 1K
-Predicate,http://schema.org/resultReview-input,< 1K
-Predicate,http://schema.org/resultReview-output,< 1K
-Predicate,http://schema.org/returnFees,100K - 1M
-Predicate,http://schema.org/returnFees-input,< 1K
-Predicate,http://schema.org/returnFees-output,< 1K
-Predicate,http://schema.org/returnLabelSource,1K - 10K
-Predicate,http://schema.org/returnLabelSource-input,< 1K
-Predicate,http://schema.org/returnLabelSource-output,< 1K
-Predicate,http://schema.org/returnMethod,100K - 1M
-Predicate,http://schema.org/returnMethod-input,< 1K
-Predicate,http://schema.org/returnMethod-output,< 1K
-Predicate,http://schema.org/returnPolicyCategory,100K - 1M
-Predicate,http://schema.org/returnPolicyCategory-input,< 1K
-Predicate,http://schema.org/returnPolicyCategory-output,< 1K
-Predicate,http://schema.org/returnPolicyCountry,10K - 100K
-Predicate,http://schema.org/returnPolicyCountry-input,< 1K
-Predicate,http://schema.org/returnPolicyCountry-output,< 1K
-Predicate,http://schema.org/returnPolicySeasonalOverride,1K - 10K
-Predicate,http://schema.org/returnPolicySeasonalOverride-input,< 1K
-Predicate,http://schema.org/returnPolicySeasonalOverride-output,< 1K
-Predicate,http://schema.org/returnShippingFeesAmount,10K - 100K
-Predicate,http://schema.org/returnShippingFeesAmount-input,< 1K
-Predicate,http://schema.org/returnShippingFeesAmount-output,< 1K
-Predicate,http://schema.org/review,1M - 10M
-Predicate,http://schema.org/review-input,< 1K
-Predicate,http://schema.org/review-output,< 1K
-Predicate,http://schema.org/reviewAspect,10K - 100K
-Predicate,http://schema.org/reviewAspect-input,< 1K
-Predicate,http://schema.org/reviewAspect-output,< 1K
-Predicate,http://schema.org/reviewBody,1M - 10M
-Predicate,http://schema.org/reviewBody-input,< 1K
-Predicate,http://schema.org/reviewBody-output,< 1K
-Predicate,http://schema.org/reviewCount,1M - 10M
-Predicate,http://schema.org/reviewCount-input,< 1K
-Predicate,http://schema.org/reviewCount-output,< 1K
-Predicate,http://schema.org/reviewRating,1M - 10M
-Predicate,http://schema.org/reviewRating-input,< 1K
-Predicate,http://schema.org/reviewRating-output,< 1K
-Predicate,http://schema.org/reviewedBy,10K - 100K
-Predicate,http://schema.org/reviewedBy-input,< 1K
-Predicate,http://schema.org/reviewedBy-output,< 1K
-Predicate,http://schema.org/reviews,1K - 10K
-Predicate,http://schema.org/reviews-input,< 1K
-Predicate,http://schema.org/reviews-output,< 1K
-Predicate,http://schema.org/riskFactor,1K - 10K
-Predicate,http://schema.org/riskFactor-input,< 1K
-Predicate,http://schema.org/riskFactor-output,< 1K
-Predicate,http://schema.org/risks,< 1K
-Predicate,http://schema.org/risks-input,< 1K
-Predicate,http://schema.org/risks-output,< 1K
-Predicate,http://schema.org/roleName,1K - 10K
-Predicate,http://schema.org/roleName-input,< 1K
-Predicate,http://schema.org/roleName-output,< 1K
-Predicate,http://schema.org/roofLoad,< 1K
-Predicate,http://schema.org/roofLoad-input,< 1K
-Predicate,http://schema.org/roofLoad-output,< 1K
-Predicate,http://schema.org/rsvpResponse,< 1K
-Predicate,http://schema.org/rsvpResponse-input,< 1K
-Predicate,http://schema.org/rsvpResponse-output,< 1K
-Predicate,http://schema.org/runsTo,< 1K
-Predicate,http://schema.org/runsTo-input,< 1K
-Predicate,http://schema.org/runsTo-output,< 1K
-Predicate,http://schema.org/runtime,< 1K
-Predicate,http://schema.org/runtime-input,< 1K
-Predicate,http://schema.org/runtime-output,< 1K
-Predicate,http://schema.org/runtimePlatform,1K - 10K
-Predicate,http://schema.org/runtimePlatform-input,< 1K
-Predicate,http://schema.org/runtimePlatform-output,< 1K
-Predicate,http://schema.org/rxcui,< 1K
-Predicate,http://schema.org/rxcui-input,< 1K
-Predicate,http://schema.org/rxcui-output,< 1K
-Predicate,http://schema.org/safetyConsideration,< 1K
-Predicate,http://schema.org/safetyConsideration-input,< 1K
-Predicate,http://schema.org/safetyConsideration-output,< 1K
-Predicate,http://schema.org/salaryCurrency,1K - 10K
-Predicate,http://schema.org/salaryCurrency-input,< 1K
-Predicate,http://schema.org/salaryCurrency-output,< 1K
-Predicate,http://schema.org/salaryUponCompletion,< 1K
-Predicate,http://schema.org/salaryUponCompletion-input,< 1K
-Predicate,http://schema.org/salaryUponCompletion-output,< 1K
-Predicate,http://schema.org/sameAs,10M+
-Predicate,http://schema.org/sameAs-input,< 1K
-Predicate,http://schema.org/sameAs-output,< 1K
-Predicate,http://schema.org/sampleType,< 1K
-Predicate,http://schema.org/sampleType-input,< 1K
-Predicate,http://schema.org/sampleType-output,< 1K
-Predicate,http://schema.org/saturatedFatContent,10K - 100K
-Predicate,http://schema.org/saturatedFatContent-input,< 1K
-Predicate,http://schema.org/saturatedFatContent-output,< 1K
-Predicate,http://schema.org/scheduleTimezone,1K - 10K
-Predicate,http://schema.org/scheduleTimezone-input,< 1K
-Predicate,http://schema.org/scheduleTimezone-output,< 1K
-Predicate,http://schema.org/scheduledPaymentDate,< 1K
-Predicate,http://schema.org/scheduledPaymentDate-input,< 1K
-Predicate,http://schema.org/scheduledPaymentDate-output,< 1K
-Predicate,http://schema.org/scheduledTime,< 1K
-Predicate,http://schema.org/scheduledTime-input,< 1K
-Predicate,http://schema.org/scheduledTime-output,< 1K
-Predicate,http://schema.org/schemaVersion,< 1K
-Predicate,http://schema.org/schemaVersion-input,< 1K
-Predicate,http://schema.org/schemaVersion-output,< 1K
-Predicate,http://schema.org/schoolClosuresInfo,< 1K
-Predicate,http://schema.org/schoolClosuresInfo-input,< 1K
-Predicate,http://schema.org/schoolClosuresInfo-output,< 1K
-Predicate,http://schema.org/screenCount,< 1K
-Predicate,http://schema.org/screenCount-input,< 1K
-Predicate,http://schema.org/screenCount-output,< 1K
-Predicate,http://schema.org/screenshot,100K - 1M
-Predicate,http://schema.org/screenshot-input,< 1K
-Predicate,http://schema.org/screenshot-output,< 1K
-Predicate,http://schema.org/sdDatePublished,1K - 10K
-Predicate,http://schema.org/sdDatePublished-input,< 1K
-Predicate,http://schema.org/sdDatePublished-output,< 1K
-Predicate,http://schema.org/sdLicense,< 1K
-Predicate,http://schema.org/sdLicense-input,< 1K
-Predicate,http://schema.org/sdLicense-output,< 1K
-Predicate,http://schema.org/sdPublisher,1K - 10K
-Predicate,http://schema.org/sdPublisher-input,< 1K
-Predicate,http://schema.org/sdPublisher-output,< 1K
-Predicate,http://schema.org/season,< 1K
-Predicate,http://schema.org/season-input,< 1K
-Predicate,http://schema.org/season-output,< 1K
-Predicate,http://schema.org/seasonNumber,1K - 10K
-Predicate,http://schema.org/seasonNumber-input,< 1K
-Predicate,http://schema.org/seasonNumber-output,< 1K
-Predicate,http://schema.org/seasonalOverride,< 1K
-Predicate,http://schema.org/seasonalOverride-input,< 1K
-Predicate,http://schema.org/seasonalOverride-output,< 1K
-Predicate,http://schema.org/seasons,< 1K
-Predicate,http://schema.org/seasons-input,< 1K
-Predicate,http://schema.org/seasons-output,< 1K
-Predicate,http://schema.org/seatNumber,< 1K
-Predicate,http://schema.org/seatNumber-input,< 1K
-Predicate,http://schema.org/seatNumber-output,< 1K
-Predicate,http://schema.org/seatRow,< 1K
-Predicate,http://schema.org/seatRow-input,< 1K
-Predicate,http://schema.org/seatRow-output,< 1K
-Predicate,http://schema.org/seatSection,< 1K
-Predicate,http://schema.org/seatSection-input,< 1K
-Predicate,http://schema.org/seatSection-output,< 1K
-Predicate,http://schema.org/seatingCapacity,1K - 10K
-Predicate,http://schema.org/seatingCapacity-input,< 1K
-Predicate,http://schema.org/seatingCapacity-output,< 1K
-Predicate,http://schema.org/seatingType,< 1K
-Predicate,http://schema.org/seatingType-input,< 1K
-Predicate,http://schema.org/seatingType-output,< 1K
-Predicate,http://schema.org/secondaryPrevention,< 1K
-Predicate,http://schema.org/secondaryPrevention-input,< 1K
-Predicate,http://schema.org/secondaryPrevention-output,< 1K
-Predicate,http://schema.org/securityClearanceRequirement,< 1K
-Predicate,http://schema.org/securityClearanceRequirement-input,< 1K
-Predicate,http://schema.org/securityClearanceRequirement-output,< 1K
-Predicate,http://schema.org/securityScreening,< 1K
-Predicate,http://schema.org/securityScreening-input,< 1K
-Predicate,http://schema.org/securityScreening-output,< 1K
-Predicate,http://schema.org/seeks,1K - 10K
-Predicate,http://schema.org/seeks-input,< 1K
-Predicate,http://schema.org/seeks-output,< 1K
-Predicate,http://schema.org/seller,1M - 10M
-Predicate,http://schema.org/seller-input,< 1K
-Predicate,http://schema.org/seller-output,< 1K
-Predicate,http://schema.org/sender,< 1K
-Predicate,http://schema.org/sender-input,< 1K
-Predicate,http://schema.org/sender-output,< 1K
-Predicate,http://schema.org/sensoryRequirement,< 1K
-Predicate,http://schema.org/sensoryRequirement-input,< 1K
-Predicate,http://schema.org/sensoryRequirement-output,< 1K
-Predicate,http://schema.org/sensoryUnit,< 1K
-Predicate,http://schema.org/sensoryUnit-input,< 1K
-Predicate,http://schema.org/sensoryUnit-output,< 1K
-Predicate,http://schema.org/serialNumber,10K - 100K
-Predicate,http://schema.org/serialNumber-input,< 1K
-Predicate,http://schema.org/serialNumber-output,< 1K
-Predicate,http://schema.org/seriousAdverseOutcome,< 1K
-Predicate,http://schema.org/seriousAdverseOutcome-input,< 1K
-Predicate,http://schema.org/seriousAdverseOutcome-output,< 1K
-Predicate,http://schema.org/serverStatus,< 1K
-Predicate,http://schema.org/serverStatus-input,< 1K
-Predicate,http://schema.org/serverStatus-output,< 1K
-Predicate,http://schema.org/servesCuisine,100K - 1M
-Predicate,http://schema.org/servesCuisine-input,< 1K
-Predicate,http://schema.org/servesCuisine-output,< 1K
-Predicate,http://schema.org/serviceArea,10K - 100K
-Predicate,http://schema.org/serviceArea-input,< 1K
-Predicate,http://schema.org/serviceArea-output,< 1K
-Predicate,http://schema.org/serviceAudience,1K - 10K
-Predicate,http://schema.org/serviceAudience-input,< 1K
-Predicate,http://schema.org/serviceAudience-output,< 1K
-Predicate,http://schema.org/serviceLocation,10K - 100K
-Predicate,http://schema.org/serviceLocation-input,< 1K
-Predicate,http://schema.org/serviceLocation-output,< 1K
-Predicate,http://schema.org/serviceOperator,1K - 10K
-Predicate,http://schema.org/serviceOperator-input,< 1K
-Predicate,http://schema.org/serviceOperator-output,< 1K
-Predicate,http://schema.org/serviceOutput,10K - 100K
-Predicate,http://schema.org/serviceOutput-input,< 1K
-Predicate,http://schema.org/serviceOutput-output,< 1K
-Predicate,http://schema.org/servicePhone,10K - 100K
-Predicate,http://schema.org/servicePhone-input,< 1K
-Predicate,http://schema.org/servicePhone-output,< 1K
-Predicate,http://schema.org/servicePostalAddress,< 1K
-Predicate,http://schema.org/servicePostalAddress-input,< 1K
-Predicate,http://schema.org/servicePostalAddress-output,< 1K
-Predicate,http://schema.org/serviceSmsNumber,1K - 10K
-Predicate,http://schema.org/serviceSmsNumber-input,< 1K
-Predicate,http://schema.org/serviceSmsNumber-output,< 1K
-Predicate,http://schema.org/serviceType,100K - 1M
-Predicate,http://schema.org/serviceType-input,< 1K
-Predicate,http://schema.org/serviceType-output,< 1K
-Predicate,http://schema.org/serviceUrl,10K - 100K
-Predicate,http://schema.org/serviceUrl-input,< 1K
-Predicate,http://schema.org/serviceUrl-output,< 1K
-Predicate,http://schema.org/servingSize,10K - 100K
-Predicate,http://schema.org/servingSize-input,< 1K
-Predicate,http://schema.org/servingSize-output,< 1K
-Predicate,http://schema.org/sha256,< 1K
-Predicate,http://schema.org/sha256-input,< 1K
-Predicate,http://schema.org/sha256-output,< 1K
-Predicate,http://schema.org/sharedContent,1K - 10K
-Predicate,http://schema.org/sharedContent-input,< 1K
-Predicate,http://schema.org/sharedContent-output,< 1K
-Predicate,http://schema.org/shippingConditions,10K - 100K
-Predicate,http://schema.org/shippingConditions-input,< 1K
-Predicate,http://schema.org/shippingConditions-output,< 1K
-Predicate,http://schema.org/shippingDestination,100K - 1M
-Predicate,http://schema.org/shippingDestination-input,< 1K
-Predicate,http://schema.org/shippingDestination-output,< 1K
-Predicate,http://schema.org/shippingDetails,100K - 1M
-Predicate,http://schema.org/shippingDetails-input,< 1K
-Predicate,http://schema.org/shippingDetails-output,< 1K
-Predicate,http://schema.org/shippingLabel,1K - 10K
-Predicate,http://schema.org/shippingLabel-input,< 1K
-Predicate,http://schema.org/shippingLabel-output,< 1K
-Predicate,http://schema.org/shippingOrigin,10K - 100K
-Predicate,http://schema.org/shippingOrigin-input,< 1K
-Predicate,http://schema.org/shippingOrigin-output,< 1K
-Predicate,http://schema.org/shippingRate,100K - 1M
-Predicate,http://schema.org/shippingRate-input,< 1K
-Predicate,http://schema.org/shippingRate-output,< 1K
-Predicate,http://schema.org/shippingSettingsLink,1K - 10K
-Predicate,http://schema.org/shippingSettingsLink-input,< 1K
-Predicate,http://schema.org/shippingSettingsLink-output,< 1K
-Predicate,http://schema.org/sibling,< 1K
-Predicate,http://schema.org/sibling-input,< 1K
-Predicate,http://schema.org/sibling-output,< 1K
-Predicate,http://schema.org/siblings,< 1K
-Predicate,http://schema.org/siblings-input,< 1K
-Predicate,http://schema.org/siblings-output,< 1K
-Predicate,http://schema.org/signDetected,< 1K
-Predicate,http://schema.org/signDetected-input,< 1K
-Predicate,http://schema.org/signDetected-output,< 1K
-Predicate,http://schema.org/signOrSymptom,1K - 10K
-Predicate,http://schema.org/signOrSymptom-input,< 1K
-Predicate,http://schema.org/signOrSymptom-output,< 1K
-Predicate,http://schema.org/significance,< 1K
-Predicate,http://schema.org/significance-input,< 1K
-Predicate,http://schema.org/significance-output,< 1K
-Predicate,http://schema.org/significantLink,10K - 100K
-Predicate,http://schema.org/significantLink-input,< 1K
-Predicate,http://schema.org/significantLink-output,< 1K
-Predicate,http://schema.org/significantLinks,1K - 10K
-Predicate,http://schema.org/significantLinks-input,< 1K
-Predicate,http://schema.org/significantLinks-output,< 1K
-Predicate,http://schema.org/size,10K - 100K
-Predicate,http://schema.org/size-input,< 1K
-Predicate,http://schema.org/size-output,< 1K
-Predicate,http://schema.org/sizeGroup,< 1K
-Predicate,http://schema.org/sizeGroup-input,< 1K
-Predicate,http://schema.org/sizeGroup-output,< 1K
-Predicate,http://schema.org/sizeSystem,< 1K
-Predicate,http://schema.org/sizeSystem-input,< 1K
-Predicate,http://schema.org/sizeSystem-output,< 1K
-Predicate,http://schema.org/skills,10K - 100K
-Predicate,http://schema.org/skills-input,< 1K
-Predicate,http://schema.org/skills-output,< 1K
-Predicate,http://schema.org/sku,1M - 10M
-Predicate,http://schema.org/sku-input,< 1K
-Predicate,http://schema.org/sku-output,< 1K
-Predicate,http://schema.org/slogan,100K - 1M
-Predicate,http://schema.org/slogan-input,< 1K
-Predicate,http://schema.org/slogan-output,< 1K
-Predicate,http://schema.org/smiles,< 1K
-Predicate,http://schema.org/smiles-input,< 1K
-Predicate,http://schema.org/smiles-output,< 1K
-Predicate,http://schema.org/smokingAllowed,10K - 100K
-Predicate,http://schema.org/smokingAllowed-input,< 1K
-Predicate,http://schema.org/smokingAllowed-output,< 1K
-Predicate,http://schema.org/sodiumContent,10K - 100K
-Predicate,http://schema.org/sodiumContent-input,< 1K
-Predicate,http://schema.org/sodiumContent-output,< 1K
-Predicate,http://schema.org/softwareAddOn,< 1K
-Predicate,http://schema.org/softwareAddOn-input,< 1K
-Predicate,http://schema.org/softwareAddOn-output,< 1K
-Predicate,http://schema.org/softwareHelp,10K - 100K
-Predicate,http://schema.org/softwareHelp-input,< 1K
-Predicate,http://schema.org/softwareHelp-output,< 1K
-Predicate,http://schema.org/softwareRequirements,10K - 100K
-Predicate,http://schema.org/softwareRequirements-input,< 1K
-Predicate,http://schema.org/softwareRequirements-output,< 1K
-Predicate,http://schema.org/softwareVersion,100K - 1M
-Predicate,http://schema.org/softwareVersion-input,< 1K
-Predicate,http://schema.org/softwareVersion-output,< 1K
-Predicate,http://schema.org/source,1K - 10K
-Predicate,http://schema.org/source-input,< 1K
-Predicate,http://schema.org/source-output,< 1K
-Predicate,http://schema.org/sourceOrganization,10K - 100K
-Predicate,http://schema.org/sourceOrganization-input,< 1K
-Predicate,http://schema.org/sourceOrganization-output,< 1K
-Predicate,http://schema.org/sourcedFrom,< 1K
-Predicate,http://schema.org/sourcedFrom-input,< 1K
-Predicate,http://schema.org/sourcedFrom-output,< 1K
-Predicate,http://schema.org/spatial,1K - 10K
-Predicate,http://schema.org/spatial-input,< 1K
-Predicate,http://schema.org/spatial-output,< 1K
-Predicate,http://schema.org/spatialCoverage,10K - 100K
-Predicate,http://schema.org/spatialCoverage-input,< 1K
-Predicate,http://schema.org/spatialCoverage-output,< 1K
-Predicate,http://schema.org/speakable,100K - 1M
-Predicate,http://schema.org/speakable-input,< 1K
-Predicate,http://schema.org/speakable-output,< 1K
-Predicate,http://schema.org/specialCommitments,< 1K
-Predicate,http://schema.org/specialCommitments-input,< 1K
-Predicate,http://schema.org/specialCommitments-output,< 1K
-Predicate,http://schema.org/specialOpeningHoursSpecification,1K - 10K
-Predicate,http://schema.org/specialOpeningHoursSpecification-input,< 1K
-Predicate,http://schema.org/specialOpeningHoursSpecification-output,< 1K
-Predicate,http://schema.org/specialty,10K - 100K
-Predicate,http://schema.org/specialty-input,< 1K
-Predicate,http://schema.org/specialty-output,< 1K
-Predicate,http://schema.org/speechToTextMarkup,< 1K
-Predicate,http://schema.org/speechToTextMarkup-input,< 1K
-Predicate,http://schema.org/speechToTextMarkup-output,< 1K
-Predicate,http://schema.org/speed,1K - 10K
-Predicate,http://schema.org/speed-input,< 1K
-Predicate,http://schema.org/speed-output,< 1K
-Predicate,http://schema.org/spokenByCharacter,< 1K
-Predicate,http://schema.org/spokenByCharacter-input,< 1K
-Predicate,http://schema.org/spokenByCharacter-output,< 1K
-Predicate,http://schema.org/sponsor,10K - 100K
-Predicate,http://schema.org/sponsor-input,< 1K
-Predicate,http://schema.org/sponsor-output,< 1K
-Predicate,http://schema.org/sport,10K - 100K
-Predicate,http://schema.org/sport-input,< 1K
-Predicate,http://schema.org/sport-output,< 1K
-Predicate,http://schema.org/sportsActivityLocation,< 1K
-Predicate,http://schema.org/sportsActivityLocation-input,< 1K
-Predicate,http://schema.org/sportsActivityLocation-output,< 1K
-Predicate,http://schema.org/sportsEvent,< 1K
-Predicate,http://schema.org/sportsEvent-input,< 1K
-Predicate,http://schema.org/sportsEvent-output,< 1K
-Predicate,http://schema.org/sportsTeam,< 1K
-Predicate,http://schema.org/sportsTeam-input,< 1K
-Predicate,http://schema.org/sportsTeam-output,< 1K
-Predicate,http://schema.org/spouse,1K - 10K
-Predicate,http://schema.org/spouse-input,< 1K
-Predicate,http://schema.org/spouse-output,< 1K
-Predicate,http://schema.org/stage,< 1K
-Predicate,http://schema.org/stage-input,< 1K
-Predicate,http://schema.org/stage-output,< 1K
-Predicate,http://schema.org/stageAsNumber,< 1K
-Predicate,http://schema.org/stageAsNumber-input,< 1K
-Predicate,http://schema.org/stageAsNumber-output,< 1K
-Predicate,http://schema.org/starRating,10K - 100K
-Predicate,http://schema.org/starRating-input,< 1K
-Predicate,http://schema.org/starRating-output,< 1K
-Predicate,http://schema.org/startDate,100K - 1M
-Predicate,http://schema.org/startDate-input,< 1K
-Predicate,http://schema.org/startDate-output,< 1K
-Predicate,http://schema.org/startOffset,10K - 100K
-Predicate,http://schema.org/startOffset-input,10K - 100K
-Predicate,http://schema.org/startOffset-output,< 1K
-Predicate,http://schema.org/startTime,1K - 10K
-Predicate,http://schema.org/startTime-input,< 1K
-Predicate,http://schema.org/startTime-output,< 1K
-Predicate,http://schema.org/statType,< 1K
-Predicate,http://schema.org/statType-input,< 1K
-Predicate,http://schema.org/statType-output,< 1K
-Predicate,http://schema.org/status,1K - 10K
-Predicate,http://schema.org/status-input,< 1K
-Predicate,http://schema.org/status-output,< 1K
-Predicate,http://schema.org/steeringPosition,1K - 10K
-Predicate,http://schema.org/steeringPosition-input,< 1K
-Predicate,http://schema.org/steeringPosition-output,< 1K
-Predicate,http://schema.org/step,100K - 1M
-Predicate,http://schema.org/step-input,< 1K
-Predicate,http://schema.org/step-output,< 1K
-Predicate,http://schema.org/stepValue,< 1K
-Predicate,http://schema.org/stepValue-input,< 1K
-Predicate,http://schema.org/stepValue-output,< 1K
-Predicate,http://schema.org/steps,< 1K
-Predicate,http://schema.org/steps-input,< 1K
-Predicate,http://schema.org/steps-output,< 1K
-Predicate,http://schema.org/storageRequirements,10K - 100K
-Predicate,http://schema.org/storageRequirements-input,< 1K
-Predicate,http://schema.org/storageRequirements-output,< 1K
-Predicate,http://schema.org/streetAddress,1M - 10M
-Predicate,http://schema.org/streetAddress-input,< 1K
-Predicate,http://schema.org/streetAddress-output,< 1K
-Predicate,http://schema.org/strengthUnit,< 1K
-Predicate,http://schema.org/strengthUnit-input,< 1K
-Predicate,http://schema.org/strengthUnit-output,< 1K
-Predicate,http://schema.org/strengthValue,< 1K
-Predicate,http://schema.org/strengthValue-input,< 1K
-Predicate,http://schema.org/strengthValue-output,< 1K
-Predicate,http://schema.org/structuralClass,< 1K
-Predicate,http://schema.org/structuralClass-input,< 1K
-Predicate,http://schema.org/structuralClass-output,< 1K
-Predicate,http://schema.org/study,< 1K
-Predicate,http://schema.org/study-input,< 1K
-Predicate,http://schema.org/study-output,< 1K
-Predicate,http://schema.org/studyDesign,< 1K
-Predicate,http://schema.org/studyDesign-input,< 1K
-Predicate,http://schema.org/studyDesign-output,< 1K
-Predicate,http://schema.org/studyLocation,< 1K
-Predicate,http://schema.org/studyLocation-input,< 1K
-Predicate,http://schema.org/studyLocation-output,< 1K
-Predicate,http://schema.org/studySubject,< 1K
-Predicate,http://schema.org/studySubject-input,< 1K
-Predicate,http://schema.org/studySubject-output,< 1K
-Predicate,http://schema.org/stupidProperty,< 1K
-Predicate,http://schema.org/stupidProperty-input,< 1K
-Predicate,http://schema.org/stupidProperty-output,< 1K
-Predicate,http://schema.org/subEvent,1K - 10K
-Predicate,http://schema.org/subEvent-input,< 1K
-Predicate,http://schema.org/subEvent-output,< 1K
-Predicate,http://schema.org/subEvents,< 1K
-Predicate,http://schema.org/subEvents-input,< 1K
-Predicate,http://schema.org/subEvents-output,< 1K
-Predicate,http://schema.org/subOrganization,10K - 100K
-Predicate,http://schema.org/subOrganization-input,< 1K
-Predicate,http://schema.org/subOrganization-output,< 1K
-Predicate,http://schema.org/subReservation,< 1K
-Predicate,http://schema.org/subReservation-input,< 1K
-Predicate,http://schema.org/subReservation-output,< 1K
-Predicate,http://schema.org/subStageSuffix,< 1K
-Predicate,http://schema.org/subStageSuffix-input,< 1K
-Predicate,http://schema.org/subStageSuffix-output,< 1K
-Predicate,http://schema.org/subStructure,< 1K
-Predicate,http://schema.org/subStructure-input,< 1K
-Predicate,http://schema.org/subStructure-output,< 1K
-Predicate,http://schema.org/subTest,< 1K
-Predicate,http://schema.org/subTest-input,< 1K
-Predicate,http://schema.org/subTest-output,< 1K
-Predicate,http://schema.org/subTrip,< 1K
-Predicate,http://schema.org/subTrip-input,< 1K
-Predicate,http://schema.org/subTrip-output,< 1K
-Predicate,http://schema.org/subjectOf,100K - 1M
-Predicate,http://schema.org/subjectOf-input,< 1K
-Predicate,http://schema.org/subjectOf-output,< 1K
-Predicate,http://schema.org/subtitleLanguage,< 1K
-Predicate,http://schema.org/subtitleLanguage-input,< 1K
-Predicate,http://schema.org/subtitleLanguage-output,< 1K
-Predicate,http://schema.org/successorOf,< 1K
-Predicate,http://schema.org/successorOf-input,< 1K
-Predicate,http://schema.org/successorOf-output,< 1K
-Predicate,http://schema.org/sugarContent,10K - 100K
-Predicate,http://schema.org/sugarContent-input,< 1K
-Predicate,http://schema.org/sugarContent-output,< 1K
-Predicate,http://schema.org/suggestedAge,1K - 10K
-Predicate,http://schema.org/suggestedAge-input,< 1K
-Predicate,http://schema.org/suggestedAge-output,< 1K
-Predicate,http://schema.org/suggestedAnswer,10K - 100K
-Predicate,http://schema.org/suggestedAnswer-input,< 1K
-Predicate,http://schema.org/suggestedAnswer-output,< 1K
-Predicate,http://schema.org/suggestedGender,10K - 100K
-Predicate,http://schema.org/suggestedGender-input,< 1K
-Predicate,http://schema.org/suggestedGender-output,< 1K
-Predicate,http://schema.org/suggestedMaxAge,1K - 10K
-Predicate,http://schema.org/suggestedMaxAge-input,< 1K
-Predicate,http://schema.org/suggestedMaxAge-output,< 1K
-Predicate,http://schema.org/suggestedMeasurement,< 1K
-Predicate,http://schema.org/suggestedMeasurement-input,< 1K
-Predicate,http://schema.org/suggestedMeasurement-output,< 1K
-Predicate,http://schema.org/suggestedMinAge,10K - 100K
-Predicate,http://schema.org/suggestedMinAge-input,< 1K
-Predicate,http://schema.org/suggestedMinAge-output,< 1K
-Predicate,http://schema.org/suitableForDiet,10K - 100K
-Predicate,http://schema.org/suitableForDiet-input,< 1K
-Predicate,http://schema.org/suitableForDiet-output,< 1K
-Predicate,http://schema.org/superEvent,1K - 10K
-Predicate,http://schema.org/superEvent-input,< 1K
-Predicate,http://schema.org/superEvent-output,< 1K
-Predicate,http://schema.org/supersededBy,1K - 10K
-Predicate,http://schema.org/supersededBy-input,< 1K
-Predicate,http://schema.org/supersededBy-output,< 1K
-Predicate,http://schema.org/supply,10K - 100K
-Predicate,http://schema.org/supply-input,< 1K
-Predicate,http://schema.org/supply-output,< 1K
-Predicate,http://schema.org/supplyTo,< 1K
-Predicate,http://schema.org/supplyTo-input,< 1K
-Predicate,http://schema.org/supplyTo-output,< 1K
-Predicate,http://schema.org/supportingData,< 1K
-Predicate,http://schema.org/supportingData-input,< 1K
-Predicate,http://schema.org/supportingData-output,< 1K
-Predicate,http://schema.org/surface,< 1K
-Predicate,http://schema.org/surface-input,< 1K
-Predicate,http://schema.org/surface-output,< 1K
-Predicate,http://schema.org/syllabusSections,1K - 10K
-Predicate,http://schema.org/syllabusSections-input,< 1K
-Predicate,http://schema.org/syllabusSections-output,< 1K
-Predicate,http://schema.org/target,10M+
-Predicate,http://schema.org/target-input,< 1K
-Predicate,http://schema.org/target-output,< 1K
-Predicate,http://schema.org/targetCollection,< 1K
-Predicate,http://schema.org/targetCollection-input,< 1K
-Predicate,http://schema.org/targetCollection-output,< 1K
-Predicate,http://schema.org/targetDescription,< 1K
-Predicate,http://schema.org/targetDescription-input,< 1K
-Predicate,http://schema.org/targetDescription-output,< 1K
-Predicate,http://schema.org/targetName,1K - 10K
-Predicate,http://schema.org/targetName-input,< 1K
-Predicate,http://schema.org/targetName-output,< 1K
-Predicate,http://schema.org/targetPlatform,< 1K
-Predicate,http://schema.org/targetPlatform-input,< 1K
-Predicate,http://schema.org/targetPlatform-output,< 1K
-Predicate,http://schema.org/targetPopulation,< 1K
-Predicate,http://schema.org/targetPopulation-input,< 1K
-Predicate,http://schema.org/targetPopulation-output,< 1K
-Predicate,http://schema.org/targetProduct,< 1K
-Predicate,http://schema.org/targetProduct-input,< 1K
-Predicate,http://schema.org/targetProduct-output,< 1K
-Predicate,http://schema.org/targetUrl,< 1K
-Predicate,http://schema.org/targetUrl-input,< 1K
-Predicate,http://schema.org/targetUrl-output,< 1K
-Predicate,http://schema.org/taxID,10K - 100K
-Predicate,http://schema.org/taxID-input,< 1K
-Predicate,http://schema.org/taxID-output,< 1K
-Predicate,http://schema.org/taxonRank,< 1K
-Predicate,http://schema.org/taxonRank-input,< 1K
-Predicate,http://schema.org/taxonRank-output,< 1K
-Predicate,http://schema.org/taxonomicRange,< 1K
-Predicate,http://schema.org/taxonomicRange-input,< 1K
-Predicate,http://schema.org/taxonomicRange-output,< 1K
-Predicate,http://schema.org/teaches,10K - 100K
-Predicate,http://schema.org/teaches-input,< 1K
-Predicate,http://schema.org/teaches-output,< 1K
-Predicate,http://schema.org/telephone,1M - 10M
-Predicate,http://schema.org/telephone-input,< 1K
-Predicate,http://schema.org/telephone-output,< 1K
-Predicate,http://schema.org/temporal,< 1K
-Predicate,http://schema.org/temporal-input,< 1K
-Predicate,http://schema.org/temporal-output,< 1K
-Predicate,http://schema.org/temporalCoverage,10K - 100K
-Predicate,http://schema.org/temporalCoverage-input,< 1K
-Predicate,http://schema.org/temporalCoverage-output,< 1K
-Predicate,http://schema.org/termCode,1K - 10K
-Predicate,http://schema.org/termCode-input,< 1K
-Predicate,http://schema.org/termCode-output,< 1K
-Predicate,http://schema.org/termDuration,< 1K
-Predicate,http://schema.org/termDuration-input,< 1K
-Predicate,http://schema.org/termDuration-output,< 1K
-Predicate,http://schema.org/termsOfService,10K - 100K
-Predicate,http://schema.org/termsOfService-input,< 1K
-Predicate,http://schema.org/termsOfService-output,< 1K
-Predicate,http://schema.org/termsPerYear,< 1K
-Predicate,http://schema.org/termsPerYear-input,< 1K
-Predicate,http://schema.org/termsPerYear-output,< 1K
-Predicate,http://schema.org/text,1M - 10M
-Predicate,http://schema.org/text-input,< 1K
-Predicate,http://schema.org/text-output,< 1K
-Predicate,http://schema.org/textValue,< 1K
-Predicate,http://schema.org/textValue-input,< 1K
-Predicate,http://schema.org/textValue-output,< 1K
-Predicate,http://schema.org/thumbnail,100K - 1M
-Predicate,http://schema.org/thumbnail-input,< 1K
-Predicate,http://schema.org/thumbnail-output,< 1K
-Predicate,http://schema.org/thumbnailUrl,10M+
-Predicate,http://schema.org/thumbnailUrl-input,< 1K
-Predicate,http://schema.org/thumbnailUrl-output,< 1K
-Predicate,http://schema.org/tickerSymbol,1K - 10K
-Predicate,http://schema.org/tickerSymbol-input,< 1K
-Predicate,http://schema.org/tickerSymbol-output,< 1K
-Predicate,http://schema.org/ticketNumber,< 1K
-Predicate,http://schema.org/ticketNumber-input,< 1K
-Predicate,http://schema.org/ticketNumber-output,< 1K
-Predicate,http://schema.org/ticketToken,< 1K
-Predicate,http://schema.org/ticketToken-input,< 1K
-Predicate,http://schema.org/ticketToken-output,< 1K
-Predicate,http://schema.org/ticketedSeat,< 1K
-Predicate,http://schema.org/ticketedSeat-input,< 1K
-Predicate,http://schema.org/ticketedSeat-output,< 1K
-Predicate,http://schema.org/timeOfDay,< 1K
-Predicate,http://schema.org/timeOfDay-input,< 1K
-Predicate,http://schema.org/timeOfDay-output,< 1K
-Predicate,http://schema.org/timeRequired,100K - 1M
-Predicate,http://schema.org/timeRequired-input,< 1K
-Predicate,http://schema.org/timeRequired-output,< 1K
-Predicate,http://schema.org/timeToComplete,1K - 10K
-Predicate,http://schema.org/timeToComplete-input,< 1K
-Predicate,http://schema.org/timeToComplete-output,< 1K
-Predicate,http://schema.org/timestamp,1K - 10K
-Predicate,http://schema.org/timestamp-input,< 1K
-Predicate,http://schema.org/timestamp-output,< 1K
-Predicate,http://schema.org/tissueSample,< 1K
-Predicate,http://schema.org/tissueSample-input,< 1K
-Predicate,http://schema.org/tissueSample-output,< 1K
-Predicate,http://schema.org/title,100K - 1M
-Predicate,http://schema.org/title-input,< 1K
-Predicate,http://schema.org/title-output,< 1K
-Predicate,http://schema.org/titleEIDR,< 1K
-Predicate,http://schema.org/titleEIDR-input,< 1K
-Predicate,http://schema.org/titleEIDR-output,< 1K
-Predicate,http://schema.org/toLocation,1K - 10K
-Predicate,http://schema.org/toLocation-input,< 1K
-Predicate,http://schema.org/toLocation-output,< 1K
-Predicate,http://schema.org/toRecipient,< 1K
-Predicate,http://schema.org/toRecipient-input,< 1K
-Predicate,http://schema.org/toRecipient-output,< 1K
-Predicate,http://schema.org/tocContinuation,< 1K
-Predicate,http://schema.org/tocContinuation-input,< 1K
-Predicate,http://schema.org/tocContinuation-output,< 1K
-Predicate,http://schema.org/tocEntry,< 1K
-Predicate,http://schema.org/tocEntry-input,< 1K
-Predicate,http://schema.org/tocEntry-output,< 1K
-Predicate,http://schema.org/tongueWeight,< 1K
-Predicate,http://schema.org/tongueWeight-input,< 1K
-Predicate,http://schema.org/tongueWeight-output,< 1K
-Predicate,http://schema.org/tool,10K - 100K
-Predicate,http://schema.org/tool-input,< 1K
-Predicate,http://schema.org/tool-output,< 1K
-Predicate,http://schema.org/torque,1K - 10K
-Predicate,http://schema.org/torque-input,< 1K
-Predicate,http://schema.org/torque-output,< 1K
-Predicate,http://schema.org/totalHistoricalEnrollment,< 1K
-Predicate,http://schema.org/totalHistoricalEnrollment-input,< 1K
-Predicate,http://schema.org/totalHistoricalEnrollment-output,< 1K
-Predicate,http://schema.org/totalJobOpenings,< 1K
-Predicate,http://schema.org/totalJobOpenings-input,< 1K
-Predicate,http://schema.org/totalJobOpenings-output,< 1K
-Predicate,http://schema.org/totalPaymentDue,< 1K
-Predicate,http://schema.org/totalPaymentDue-input,< 1K
-Predicate,http://schema.org/totalPaymentDue-output,< 1K
-Predicate,http://schema.org/totalPrice,< 1K
-Predicate,http://schema.org/totalPrice-input,< 1K
-Predicate,http://schema.org/totalPrice-output,< 1K
-Predicate,http://schema.org/totalTime,100K - 1M
-Predicate,http://schema.org/totalTime-input,< 1K
-Predicate,http://schema.org/totalTime-output,< 1K
-Predicate,http://schema.org/tourBookingPage,10K - 100K
-Predicate,http://schema.org/tourBookingPage-input,< 1K
-Predicate,http://schema.org/tourBookingPage-output,< 1K
-Predicate,http://schema.org/touristType,10K - 100K
-Predicate,http://schema.org/touristType-input,< 1K
-Predicate,http://schema.org/touristType-output,< 1K
-Predicate,http://schema.org/track,10K - 100K
-Predicate,http://schema.org/track-input,< 1K
-Predicate,http://schema.org/track-output,< 1K
-Predicate,http://schema.org/trackingNumber,< 1K
-Predicate,http://schema.org/trackingNumber-input,< 1K
-Predicate,http://schema.org/trackingNumber-output,< 1K
-Predicate,http://schema.org/trackingUrl,< 1K
-Predicate,http://schema.org/trackingUrl-input,< 1K
-Predicate,http://schema.org/trackingUrl-output,< 1K
-Predicate,http://schema.org/tracks,< 1K
-Predicate,http://schema.org/tracks-input,< 1K
-Predicate,http://schema.org/tracks-output,< 1K
-Predicate,http://schema.org/trailer,1K - 10K
-Predicate,http://schema.org/trailer-input,< 1K
-Predicate,http://schema.org/trailer-output,< 1K
-Predicate,http://schema.org/trailerWeight,< 1K
-Predicate,http://schema.org/trailerWeight-input,< 1K
-Predicate,http://schema.org/trailerWeight-output,< 1K
-Predicate,http://schema.org/trainName,< 1K
-Predicate,http://schema.org/trainName-input,< 1K
-Predicate,http://schema.org/trainName-output,< 1K
-Predicate,http://schema.org/trainNumber,< 1K
-Predicate,http://schema.org/trainNumber-input,< 1K
-Predicate,http://schema.org/trainNumber-output,< 1K
-Predicate,http://schema.org/trainingSalary,< 1K
-Predicate,http://schema.org/trainingSalary-input,< 1K
-Predicate,http://schema.org/trainingSalary-output,< 1K
-Predicate,http://schema.org/transFatContent,10K - 100K
-Predicate,http://schema.org/transFatContent-input,< 1K
-Predicate,http://schema.org/transFatContent-output,< 1K
-Predicate,http://schema.org/transcript,10K - 100K
-Predicate,http://schema.org/transcript-input,< 1K
-Predicate,http://schema.org/transcript-output,< 1K
-Predicate,http://schema.org/transitTime,100K - 1M
-Predicate,http://schema.org/transitTime-input,< 1K
-Predicate,http://schema.org/transitTime-output,< 1K
-Predicate,http://schema.org/transitTimeLabel,< 1K
-Predicate,http://schema.org/transitTimeLabel-input,< 1K
-Predicate,http://schema.org/transitTimeLabel-output,< 1K
-Predicate,http://schema.org/translationOfWork,1K - 10K
-Predicate,http://schema.org/translationOfWork-input,< 1K
-Predicate,http://schema.org/translationOfWork-output,< 1K
-Predicate,http://schema.org/translator,1K - 10K
-Predicate,http://schema.org/translator-input,< 1K
-Predicate,http://schema.org/translator-output,< 1K
-Predicate,http://schema.org/transmissionMethod,< 1K
-Predicate,http://schema.org/transmissionMethod-input,< 1K
-Predicate,http://schema.org/transmissionMethod-output,< 1K
-Predicate,http://schema.org/travelBans,< 1K
-Predicate,http://schema.org/travelBans-input,< 1K
-Predicate,http://schema.org/travelBans-output,< 1K
-Predicate,http://schema.org/trialDesign,< 1K
-Predicate,http://schema.org/trialDesign-input,< 1K
-Predicate,http://schema.org/trialDesign-output,< 1K
-Predicate,http://schema.org/tributary,< 1K
-Predicate,http://schema.org/tributary-input,< 1K
-Predicate,http://schema.org/tributary-output,< 1K
-Predicate,http://schema.org/tripOrigin,< 1K
-Predicate,http://schema.org/tripOrigin-input,< 1K
-Predicate,http://schema.org/tripOrigin-output,< 1K
-Predicate,http://schema.org/typeOfBed,10K - 100K
-Predicate,http://schema.org/typeOfBed-input,< 1K
-Predicate,http://schema.org/typeOfBed-output,< 1K
-Predicate,http://schema.org/typeOfGood,< 1K
-Predicate,http://schema.org/typeOfGood-input,< 1K
-Predicate,http://schema.org/typeOfGood-output,< 1K
-Predicate,http://schema.org/typicalAgeRange,10K - 100K
-Predicate,http://schema.org/typicalAgeRange-input,< 1K
-Predicate,http://schema.org/typicalAgeRange-output,< 1K
-Predicate,http://schema.org/typicalCreditsPerTerm,< 1K
-Predicate,http://schema.org/typicalCreditsPerTerm-input,< 1K
-Predicate,http://schema.org/typicalCreditsPerTerm-output,< 1K
-Predicate,http://schema.org/typicalTest,< 1K
-Predicate,http://schema.org/typicalTest-input,< 1K
-Predicate,http://schema.org/typicalTest-output,< 1K
-Predicate,http://schema.org/underName,< 1K
-Predicate,http://schema.org/underName-input,< 1K
-Predicate,http://schema.org/underName-output,< 1K
-Predicate,http://schema.org/unitCode,100K - 1M
-Predicate,http://schema.org/unitCode-input,< 1K
-Predicate,http://schema.org/unitCode-output,< 1K
-Predicate,http://schema.org/unitText,100K - 1M
-Predicate,http://schema.org/unitText-input,< 1K
-Predicate,http://schema.org/unitText-output,< 1K
-Predicate,http://schema.org/unnamedSourcesPolicy,1K - 10K
-Predicate,http://schema.org/unnamedSourcesPolicy-input,< 1K
-Predicate,http://schema.org/unnamedSourcesPolicy-output,< 1K
-Predicate,http://schema.org/unsaturatedFatContent,10K - 100K
-Predicate,http://schema.org/unsaturatedFatContent-input,< 1K
-Predicate,http://schema.org/unsaturatedFatContent-output,< 1K
-Predicate,http://schema.org/uploadDate,1M - 10M
-Predicate,http://schema.org/uploadDate-input,< 1K
-Predicate,http://schema.org/uploadDate-output,< 1K
-Predicate,http://schema.org/upvoteCount,10K - 100K
-Predicate,http://schema.org/upvoteCount-input,< 1K
-Predicate,http://schema.org/upvoteCount-output,< 1K
-Predicate,http://schema.org/url,10M+
-Predicate,http://schema.org/url-input,< 1K
-Predicate,http://schema.org/url-output,< 1K
-Predicate,http://schema.org/urlTemplate,10M+
-Predicate,http://schema.org/urlTemplate-input,< 1K
-Predicate,http://schema.org/urlTemplate-output,< 1K
-Predicate,http://schema.org/usNPI,< 1K
-Predicate,http://schema.org/usNPI-input,< 1K
-Predicate,http://schema.org/usNPI-output,< 1K
-Predicate,http://schema.org/usageInfo,1K - 10K
-Predicate,http://schema.org/usageInfo-input,< 1K
-Predicate,http://schema.org/usageInfo-output,< 1K
-Predicate,http://schema.org/usedToDiagnose,1K - 10K
-Predicate,http://schema.org/usedToDiagnose-input,< 1K
-Predicate,http://schema.org/usedToDiagnose-output,< 1K
-Predicate,http://schema.org/userInteractionCount,100K - 1M
-Predicate,http://schema.org/userInteractionCount-input,< 1K
-Predicate,http://schema.org/userInteractionCount-output,< 1K
-Predicate,http://schema.org/usesDevice,< 1K
-Predicate,http://schema.org/usesDevice-input,< 1K
-Predicate,http://schema.org/usesDevice-output,< 1K
-Predicate,http://schema.org/usesHealthPlanIdStandard,< 1K
-Predicate,http://schema.org/usesHealthPlanIdStandard-input,< 1K
-Predicate,http://schema.org/usesHealthPlanIdStandard-output,< 1K
-Predicate,http://schema.org/utterances,< 1K
-Predicate,http://schema.org/utterances-input,< 1K
-Predicate,http://schema.org/utterances-output,< 1K
-Predicate,http://schema.org/validFor,< 1K
-Predicate,http://schema.org/validFor-input,< 1K
-Predicate,http://schema.org/validFor-output,< 1K
-Predicate,http://schema.org/validForMemberTier,< 1K
-Predicate,http://schema.org/validForMemberTier-input,< 1K
-Predicate,http://schema.org/validForMemberTier-output,< 1K
-Predicate,http://schema.org/validFrom,100K - 1M
-Predicate,http://schema.org/validFrom-input,< 1K
-Predicate,http://schema.org/validFrom-output,< 1K
-Predicate,http://schema.org/validIn,1K - 10K
-Predicate,http://schema.org/validIn-input,< 1K
-Predicate,http://schema.org/validIn-output,< 1K
-Predicate,http://schema.org/validThrough,1M - 10M
-Predicate,http://schema.org/validThrough-input,< 1K
-Predicate,http://schema.org/validThrough-output,< 1K
-Predicate,http://schema.org/validUntil,< 1K
-Predicate,http://schema.org/validUntil-input,< 1K
-Predicate,http://schema.org/validUntil-output,< 1K
-Predicate,http://schema.org/value,1M - 10M
-Predicate,http://schema.org/value-input,< 1K
-Predicate,http://schema.org/value-output,< 1K
-Predicate,http://schema.org/valueAddedTaxIncluded,1M - 10M
-Predicate,http://schema.org/valueAddedTaxIncluded-input,< 1K
-Predicate,http://schema.org/valueAddedTaxIncluded-output,< 1K
-Predicate,http://schema.org/valueMaxLength,1K - 10K
-Predicate,http://schema.org/valueMaxLength-input,< 1K
-Predicate,http://schema.org/valueMaxLength-output,< 1K
-Predicate,http://schema.org/valueMinLength,< 1K
-Predicate,http://schema.org/valueMinLength-input,< 1K
-Predicate,http://schema.org/valueMinLength-output,< 1K
-Predicate,http://schema.org/valueName,10M+
-Predicate,http://schema.org/valueName-input,< 1K
-Predicate,http://schema.org/valueName-output,< 1K
-Predicate,http://schema.org/valuePattern,< 1K
-Predicate,http://schema.org/valuePattern-input,< 1K
-Predicate,http://schema.org/valuePattern-output,< 1K
-Predicate,http://schema.org/valueReference,1K - 10K
-Predicate,http://schema.org/valueReference-input,< 1K
-Predicate,http://schema.org/valueReference-output,< 1K
-Predicate,http://schema.org/valueRequired,10M+
-Predicate,http://schema.org/valueRequired-input,< 1K
-Predicate,http://schema.org/valueRequired-output,< 1K
-Predicate,http://schema.org/variableMeasured,10K - 100K
-Predicate,http://schema.org/variableMeasured-input,< 1K
-Predicate,http://schema.org/variableMeasured-output,< 1K
-Predicate,http://schema.org/variablesMeasured,< 1K
-Predicate,http://schema.org/variablesMeasured-input,< 1K
-Predicate,http://schema.org/variablesMeasured-output,< 1K
-Predicate,http://schema.org/variantCover,< 1K
-Predicate,http://schema.org/variantCover-input,< 1K
-Predicate,http://schema.org/variantCover-output,< 1K
-Predicate,http://schema.org/variesBy,10K - 100K
-Predicate,http://schema.org/variesBy-input,< 1K
-Predicate,http://schema.org/variesBy-output,< 1K
-Predicate,http://schema.org/vatID,100K - 1M
-Predicate,http://schema.org/vatID-input,< 1K
-Predicate,http://schema.org/vatID-output,< 1K
-Predicate,http://schema.org/vehicleConfiguration,10K - 100K
-Predicate,http://schema.org/vehicleConfiguration-input,< 1K
-Predicate,http://schema.org/vehicleConfiguration-output,< 1K
-Predicate,http://schema.org/vehicleEngine,10K - 100K
-Predicate,http://schema.org/vehicleEngine-input,< 1K
-Predicate,http://schema.org/vehicleEngine-output,< 1K
-Predicate,http://schema.org/vehicleIdentificationNumber,10K - 100K
-Predicate,http://schema.org/vehicleIdentificationNumber-input,< 1K
-Predicate,http://schema.org/vehicleIdentificationNumber-output,< 1K
-Predicate,http://schema.org/vehicleInteriorColor,10K - 100K
-Predicate,http://schema.org/vehicleInteriorColor-input,< 1K
-Predicate,http://schema.org/vehicleInteriorColor-output,< 1K
-Predicate,http://schema.org/vehicleInteriorType,10K - 100K
-Predicate,http://schema.org/vehicleInteriorType-input,< 1K
-Predicate,http://schema.org/vehicleInteriorType-output,< 1K
-Predicate,http://schema.org/vehicleModelDate,10K - 100K
-Predicate,http://schema.org/vehicleModelDate-input,< 1K
-Predicate,http://schema.org/vehicleModelDate-output,< 1K
-Predicate,http://schema.org/vehicleSeatingCapacity,10K - 100K
-Predicate,http://schema.org/vehicleSeatingCapacity-input,< 1K
-Predicate,http://schema.org/vehicleSeatingCapacity-output,< 1K
-Predicate,http://schema.org/vehicleSpecialUsage,< 1K
-Predicate,http://schema.org/vehicleSpecialUsage-input,< 1K
-Predicate,http://schema.org/vehicleSpecialUsage-output,< 1K
-Predicate,http://schema.org/vehicleTransmission,10K - 100K
-Predicate,http://schema.org/vehicleTransmission-input,< 1K
-Predicate,http://schema.org/vehicleTransmission-output,< 1K
-Predicate,http://schema.org/vendor,< 1K
-Predicate,http://schema.org/vendor-input,< 1K
-Predicate,http://schema.org/vendor-output,< 1K
-Predicate,http://schema.org/verificationFactCheckingPolicy,1K - 10K
-Predicate,http://schema.org/verificationFactCheckingPolicy-input,< 1K
-Predicate,http://schema.org/verificationFactCheckingPolicy-output,< 1K
-Predicate,http://schema.org/version,1K - 10K
-Predicate,http://schema.org/version-input,< 1K
-Predicate,http://schema.org/version-output,< 1K
-Predicate,http://schema.org/video,100K - 1M
-Predicate,http://schema.org/video-input,< 1K
-Predicate,http://schema.org/video-output,< 1K
-Predicate,http://schema.org/videoFormat,1K - 10K
-Predicate,http://schema.org/videoFormat-input,< 1K
-Predicate,http://schema.org/videoFormat-output,< 1K
-Predicate,http://schema.org/videoFrameSize,< 1K
-Predicate,http://schema.org/videoFrameSize-input,< 1K
-Predicate,http://schema.org/videoFrameSize-output,< 1K
-Predicate,http://schema.org/videoQuality,10K - 100K
-Predicate,http://schema.org/videoQuality-input,< 1K
-Predicate,http://schema.org/videoQuality-output,< 1K
-Predicate,http://schema.org/volumeNumber,1K - 10K
-Predicate,http://schema.org/volumeNumber-input,< 1K
-Predicate,http://schema.org/volumeNumber-output,< 1K
-Predicate,http://schema.org/warning,< 1K
-Predicate,http://schema.org/warning-input,< 1K
-Predicate,http://schema.org/warning-output,< 1K
-Predicate,http://schema.org/warranty,10K - 100K
-Predicate,http://schema.org/warranty-input,< 1K
-Predicate,http://schema.org/warranty-output,< 1K
-Predicate,http://schema.org/warrantyPromise,< 1K
-Predicate,http://schema.org/warrantyPromise-input,< 1K
-Predicate,http://schema.org/warrantyPromise-output,< 1K
-Predicate,http://schema.org/warrantyScope,1K - 10K
-Predicate,http://schema.org/warrantyScope-input,< 1K
-Predicate,http://schema.org/warrantyScope-output,< 1K
-Predicate,http://schema.org/webCheckinTime,< 1K
-Predicate,http://schema.org/webCheckinTime-input,< 1K
-Predicate,http://schema.org/webCheckinTime-output,< 1K
-Predicate,http://schema.org/webFeed,1K - 10K
-Predicate,http://schema.org/webFeed-input,< 1K
-Predicate,http://schema.org/webFeed-output,< 1K
-Predicate,http://schema.org/weight,100K - 1M
-Predicate,http://schema.org/weight-input,< 1K
-Predicate,http://schema.org/weight-output,< 1K
-Predicate,http://schema.org/weightPercentage,< 1K
-Predicate,http://schema.org/weightPercentage-input,< 1K
-Predicate,http://schema.org/weightPercentage-output,< 1K
-Predicate,http://schema.org/weightTotal,1K - 10K
-Predicate,http://schema.org/weightTotal-input,< 1K
-Predicate,http://schema.org/weightTotal-output,< 1K
-Predicate,http://schema.org/wheelbase,1K - 10K
-Predicate,http://schema.org/wheelbase-input,< 1K
-Predicate,http://schema.org/wheelbase-output,< 1K
-Predicate,http://schema.org/width,10M+
-Predicate,http://schema.org/width-input,< 1K
-Predicate,http://schema.org/width-output,< 1K
-Predicate,http://schema.org/winner,< 1K
-Predicate,http://schema.org/winner-input,< 1K
-Predicate,http://schema.org/winner-output,< 1K
-Predicate,http://schema.org/wordCount,1M - 10M
-Predicate,http://schema.org/wordCount-input,< 1K
-Predicate,http://schema.org/wordCount-output,< 1K
-Predicate,http://schema.org/workExample,1K - 10K
-Predicate,http://schema.org/workExample-input,< 1K
-Predicate,http://schema.org/workExample-output,< 1K
-Predicate,http://schema.org/workFeatured,< 1K
-Predicate,http://schema.org/workFeatured-input,< 1K
-Predicate,http://schema.org/workFeatured-output,< 1K
-Predicate,http://schema.org/workHours,10K - 100K
-Predicate,http://schema.org/workHours-input,< 1K
-Predicate,http://schema.org/workHours-output,< 1K
-Predicate,http://schema.org/workLocation,10K - 100K
-Predicate,http://schema.org/workLocation-input,< 1K
-Predicate,http://schema.org/workLocation-output,< 1K
-Predicate,http://schema.org/workPerformed,1K - 10K
-Predicate,http://schema.org/workPerformed-input,< 1K
-Predicate,http://schema.org/workPerformed-output,< 1K
-Predicate,http://schema.org/workPresented,< 1K
-Predicate,http://schema.org/workPresented-input,< 1K
-Predicate,http://schema.org/workPresented-output,< 1K
-Predicate,http://schema.org/workTranslation,1K - 10K
-Predicate,http://schema.org/workTranslation-input,< 1K
-Predicate,http://schema.org/workTranslation-output,< 1K
-Predicate,http://schema.org/workload,< 1K
-Predicate,http://schema.org/workload-input,< 1K
-Predicate,http://schema.org/workload-output,< 1K
-Predicate,http://schema.org/worksFor,1M - 10M
-Predicate,http://schema.org/worksFor-input,< 1K
-Predicate,http://schema.org/worksFor-output,< 1K
-Predicate,http://schema.org/worstRating,1M - 10M
-Predicate,http://schema.org/worstRating-input,< 1K
-Predicate,http://schema.org/worstRating-output,< 1K
-Predicate,http://schema.org/xpath,10K - 100K
-Predicate,http://schema.org/xpath-input,< 1K
-Predicate,http://schema.org/xpath-output,< 1K
-Predicate,http://schema.org/yearBuilt,10K - 100K
-Predicate,http://schema.org/yearBuilt-input,< 1K
-Predicate,http://schema.org/yearBuilt-output,< 1K
-Predicate,http://schema.org/yearlyRevenue,< 1K
-Predicate,http://schema.org/yearlyRevenue-input,< 1K
-Predicate,http://schema.org/yearlyRevenue-output,< 1K
-Predicate,http://schema.org/yearsInOperation,< 1K
-Predicate,http://schema.org/yearsInOperation-input,< 1K
-Predicate,http://schema.org/yearsInOperation-output,< 1K
-Predicate,http://schema.org/yield,1K - 10K
-Predicate,http://schema.org/yield-input,< 1K
-Predicate,http://schema.org/yield-output,< 1K
+Itemtype,https://schema.org/3DModel,< 1K
+Itemtype,https://schema.org/AMRadioChannel,< 1K
+Itemtype,https://schema.org/APIReference,< 1K
+Itemtype,https://schema.org/AboutPage,100K - 1M
+Itemtype,https://schema.org/AcceptAction,< 1K
+Itemtype,https://schema.org/Accommodation,10K - 100K
+Itemtype,https://schema.org/AccountingService,10K - 100K
+Itemtype,https://schema.org/AchieveAction,< 1K
+Itemtype,https://schema.org/Action,10K - 100K
+Itemtype,https://schema.org/ActionAccessSpecification,< 1K
+Itemtype,https://schema.org/ActionStatusType,< 1K
+Itemtype,https://schema.org/ActivateAction,< 1K
+Itemtype,https://schema.org/AddAction,< 1K
+Itemtype,https://schema.org/AdministrativeArea,100K - 1M
+Itemtype,https://schema.org/AdultEntertainment,1K - 10K
+Itemtype,https://schema.org/AdultOrientedEnumeration,< 1K
+Itemtype,https://schema.org/AdvertiserContentArticle,1K - 10K
+Itemtype,https://schema.org/AggregateOffer,1M - 10M
+Itemtype,https://schema.org/AggregateRating,1M - 10M
+Itemtype,https://schema.org/AgreeAction,< 1K
+Itemtype,https://schema.org/Airline,1K - 10K
+Itemtype,https://schema.org/Airport,1K - 10K
+Itemtype,https://schema.org/AlignmentObject,1K - 10K
+Itemtype,https://schema.org/AllocateAction,< 1K
+Itemtype,https://schema.org/AmpStory,< 1K
+Itemtype,https://schema.org/AmusementPark,1K - 10K
+Itemtype,https://schema.org/AnalysisNewsArticle,1K - 10K
+Itemtype,https://schema.org/AnatomicalStructure,1K - 10K
+Itemtype,https://schema.org/AnatomicalSystem,< 1K
+Itemtype,https://schema.org/AnimalShelter,1K - 10K
+Itemtype,https://schema.org/Answer,1M - 10M
+Itemtype,https://schema.org/Apartment,10K - 100K
+Itemtype,https://schema.org/ApartmentComplex,10K - 100K
+Itemtype,https://schema.org/AppendAction,< 1K
+Itemtype,https://schema.org/ApplyAction,1K - 10K
+Itemtype,https://schema.org/ApprovedIndication,< 1K
+Itemtype,https://schema.org/Aquarium,< 1K
+Itemtype,https://schema.org/ArchiveComponent,< 1K
+Itemtype,https://schema.org/ArchiveOrganization,1K - 10K
+Itemtype,https://schema.org/ArriveAction,< 1K
+Itemtype,https://schema.org/ArtGallery,1K - 10K
+Itemtype,https://schema.org/Artery,< 1K
+Itemtype,https://schema.org/Article,1M - 10M
+Itemtype,https://schema.org/AskAction,< 1K
+Itemtype,https://schema.org/AskPublicNewsArticle,< 1K
+Itemtype,https://schema.org/AssessAction,< 1K
+Itemtype,https://schema.org/AssignAction,< 1K
+Itemtype,https://schema.org/Atlas,< 1K
+Itemtype,https://schema.org/Attorney,10K - 100K
+Itemtype,https://schema.org/Audience,100K - 1M
+Itemtype,https://schema.org/AudioObject,10K - 100K
+Itemtype,https://schema.org/AudioObjectSnapshot,< 1K
+Itemtype,https://schema.org/Audiobook,< 1K
+Itemtype,https://schema.org/AuthenticateAction,< 1K
+Itemtype,https://schema.org/AuthorizeAction,< 1K
+Itemtype,https://schema.org/AutoBodyShop,1K - 10K
+Itemtype,https://schema.org/AutoDealer,10K - 100K
+Itemtype,https://schema.org/AutoPartsStore,10K - 100K
+Itemtype,https://schema.org/AutoRental,1K - 10K
+Itemtype,https://schema.org/AutoRepair,10K - 100K
+Itemtype,https://schema.org/AutoWash,1K - 10K
+Itemtype,https://schema.org/AutomatedTeller,< 1K
+Itemtype,https://schema.org/AutomotiveBusiness,10K - 100K
+Itemtype,https://schema.org/BackgroundNewsArticle,< 1K
+Itemtype,https://schema.org/Bakery,1K - 10K
+Itemtype,https://schema.org/BankAccount,< 1K
+Itemtype,https://schema.org/BankOrCreditUnion,1K - 10K
+Itemtype,https://schema.org/BarOrPub,1K - 10K
+Itemtype,https://schema.org/Barcode,< 1K
+Itemtype,https://schema.org/Beach,1K - 10K
+Itemtype,https://schema.org/BeautySalon,10K - 100K
+Itemtype,https://schema.org/BedAndBreakfast,1K - 10K
+Itemtype,https://schema.org/BedDetails,10K - 100K
+Itemtype,https://schema.org/BedType,< 1K
+Itemtype,https://schema.org/BefriendAction,< 1K
+Itemtype,https://schema.org/BikeStore,1K - 10K
+Itemtype,https://schema.org/BioChemEntity,< 1K
+Itemtype,https://schema.org/Blog,1M - 10M
+Itemtype,https://schema.org/BlogPosting,1M - 10M
+Itemtype,https://schema.org/BloodTest,< 1K
+Itemtype,https://schema.org/BoardingPolicyType,< 1K
+Itemtype,https://schema.org/BoatReservation,< 1K
+Itemtype,https://schema.org/BoatTerminal,< 1K
+Itemtype,https://schema.org/BoatTrip,< 1K
+Itemtype,https://schema.org/BodyMeasurementTypeEnumeration,< 1K
+Itemtype,https://schema.org/BodyOfWater,< 1K
+Itemtype,https://schema.org/Bone,< 1K
+Itemtype,https://schema.org/Book,10K - 100K
+Itemtype,https://schema.org/BookFormatType,< 1K
+Itemtype,https://schema.org/BookSeries,1K - 10K
+Itemtype,https://schema.org/BookStore,1K - 10K
+Itemtype,https://schema.org/BookmarkAction,< 1K
+Itemtype,https://schema.org/Boolean,< 1K
+Itemtype,https://schema.org/BorrowAction,< 1K
+Itemtype,https://schema.org/BowlingAlley,< 1K
+Itemtype,https://schema.org/BrainStructure,< 1K
+Itemtype,https://schema.org/Brand,1M - 10M
+Itemtype,https://schema.org/BreadcrumbList,10M+
+Itemtype,https://schema.org/Brewery,1K - 10K
+Itemtype,https://schema.org/Bridge,< 1K
+Itemtype,https://schema.org/BroadcastChannel,< 1K
+Itemtype,https://schema.org/BroadcastEvent,10K - 100K
+Itemtype,https://schema.org/BroadcastFrequencySpecification,< 1K
+Itemtype,https://schema.org/BroadcastService,1K - 10K
+Itemtype,https://schema.org/BrokerageAccount,< 1K
+Itemtype,https://schema.org/BuddhistTemple,< 1K
+Itemtype,https://schema.org/BusOrCoach,< 1K
+Itemtype,https://schema.org/BusReservation,< 1K
+Itemtype,https://schema.org/BusStation,< 1K
+Itemtype,https://schema.org/BusStop,< 1K
+Itemtype,https://schema.org/BusTrip,< 1K
+Itemtype,https://schema.org/BusinessAudience,10K - 100K
+Itemtype,https://schema.org/BusinessEntityType,< 1K
+Itemtype,https://schema.org/BusinessEvent,1K - 10K
+Itemtype,https://schema.org/BusinessFunction,< 1K
+Itemtype,https://schema.org/BuyAction,10K - 100K
+Itemtype,https://schema.org/CDCPMDRecord,< 1K
+Itemtype,https://schema.org/CableOrSatelliteService,< 1K
+Itemtype,https://schema.org/CafeOrCoffeeShop,1K - 10K
+Itemtype,https://schema.org/Campground,1K - 10K
+Itemtype,https://schema.org/CampingPitch,< 1K
+Itemtype,https://schema.org/Canal,< 1K
+Itemtype,https://schema.org/CancelAction,< 1K
+Itemtype,https://schema.org/Car,10K - 100K
+Itemtype,https://schema.org/CarUsageType,< 1K
+Itemtype,https://schema.org/Casino,10K - 100K
+Itemtype,https://schema.org/CategoryCode,1K - 10K
+Itemtype,https://schema.org/CategoryCodeSet,< 1K
+Itemtype,https://schema.org/CatholicChurch,< 1K
+Itemtype,https://schema.org/Cemetery,< 1K
+Itemtype,https://schema.org/Certification,1K - 10K
+Itemtype,https://schema.org/CertificationStatusEnumeration,< 1K
+Itemtype,https://schema.org/Chapter,1K - 10K
+Itemtype,https://schema.org/CheckAction,< 1K
+Itemtype,https://schema.org/CheckInAction,< 1K
+Itemtype,https://schema.org/CheckOutAction,< 1K
+Itemtype,https://schema.org/CheckoutPage,1K - 10K
+Itemtype,https://schema.org/ChemicalSubstance,< 1K
+Itemtype,https://schema.org/ChildCare,1K - 10K
+Itemtype,https://schema.org/ChildrensEvent,< 1K
+Itemtype,https://schema.org/ChooseAction,1K - 10K
+Itemtype,https://schema.org/Church,1K - 10K
+Itemtype,https://schema.org/City,100K - 1M
+Itemtype,https://schema.org/CityHall,< 1K
+Itemtype,https://schema.org/CivicStructure,1K - 10K
+Itemtype,https://schema.org/Claim,1K - 10K
+Itemtype,https://schema.org/ClaimReview,1K - 10K
+Itemtype,https://schema.org/Class,< 1K
+Itemtype,https://schema.org/Clip,10K - 100K
+Itemtype,https://schema.org/ClothingStore,10K - 100K
+Itemtype,https://schema.org/Code,< 1K
+Itemtype,https://schema.org/Collection,10K - 100K
+Itemtype,https://schema.org/CollectionPage,1M - 10M
+Itemtype,https://schema.org/CollegeOrUniversity,10K - 100K
+Itemtype,https://schema.org/ComedyClub,< 1K
+Itemtype,https://schema.org/ComedyEvent,< 1K
+Itemtype,https://schema.org/ComicCoverArt,< 1K
+Itemtype,https://schema.org/ComicIssue,< 1K
+Itemtype,https://schema.org/ComicSeries,1K - 10K
+Itemtype,https://schema.org/ComicStory,< 1K
+Itemtype,https://schema.org/Comment,100K - 1M
+Itemtype,https://schema.org/CommentAction,1M - 10M
+Itemtype,https://schema.org/CommunicateAction,10K - 100K
+Itemtype,https://schema.org/CommunityHealth,1K - 10K
+Itemtype,https://schema.org/CompleteDataFeed,< 1K
+Itemtype,https://schema.org/CompoundPriceSpecification,1K - 10K
+Itemtype,https://schema.org/ComputerLanguage,< 1K
+Itemtype,https://schema.org/ComputerStore,1K - 10K
+Itemtype,https://schema.org/ConferenceEvent,< 1K
+Itemtype,https://schema.org/ConfirmAction,< 1K
+Itemtype,https://schema.org/Consortium,< 1K
+Itemtype,https://schema.org/ConstraintNode,< 1K
+Itemtype,https://schema.org/ConsumeAction,< 1K
+Itemtype,https://schema.org/ContactPage,100K - 1M
+Itemtype,https://schema.org/ContactPoint,1M - 10M
+Itemtype,https://schema.org/ContactPointOption,< 1K
+Itemtype,https://schema.org/Continent,1K - 10K
+Itemtype,https://schema.org/ControlAction,< 1K
+Itemtype,https://schema.org/ConvenienceStore,< 1K
+Itemtype,https://schema.org/Conversation,< 1K
+Itemtype,https://schema.org/CookAction,< 1K
+Itemtype,https://schema.org/Cooperative,< 1K
+Itemtype,https://schema.org/Corporation,100K - 1M
+Itemtype,https://schema.org/CorrectionComment,< 1K
+Itemtype,https://schema.org/Country,1M - 10M
+Itemtype,https://schema.org/Course,10K - 100K
+Itemtype,https://schema.org/CourseInstance,10K - 100K
+Itemtype,https://schema.org/Courthouse,< 1K
+Itemtype,https://schema.org/CoverArt,< 1K
+Itemtype,https://schema.org/CovidTestingFacility,< 1K
+Itemtype,https://schema.org/CreateAction,1K - 10K
+Itemtype,https://schema.org/CreativeWork,1M - 10M
+Itemtype,https://schema.org/CreativeWorkSeason,1K - 10K
+Itemtype,https://schema.org/CreativeWorkSeries,10K - 100K
+Itemtype,https://schema.org/Credential,10K - 100K
+Itemtype,https://schema.org/CreditCard,1K - 10K
+Itemtype,https://schema.org/Crematorium,< 1K
+Itemtype,https://schema.org/CriticReview,< 1K
+Itemtype,https://schema.org/CssSelectorType,< 1K
+Itemtype,https://schema.org/CurrencyConversionService,< 1K
+Itemtype,https://schema.org/DDxElement,< 1K
+Itemtype,https://schema.org/DENonprofitType,< 1K
+Itemtype,https://schema.org/DanceEvent,< 1K
+Itemtype,https://schema.org/DanceGroup,< 1K
+Itemtype,https://schema.org/DataCatalog,1K - 10K
+Itemtype,https://schema.org/DataDownload,10K - 100K
+Itemtype,https://schema.org/DataFeed,1K - 10K
+Itemtype,https://schema.org/DataFeedItem,1K - 10K
+Itemtype,https://schema.org/DataType,< 1K
+Itemtype,https://schema.org/Dataset,10K - 100K
+Itemtype,https://schema.org/Date,< 1K
+Itemtype,https://schema.org/DateTime,< 1K
+Itemtype,https://schema.org/DatedMoneySpecification,< 1K
+Itemtype,https://schema.org/DayOfWeek,10K - 100K
+Itemtype,https://schema.org/DaySpa,1K - 10K
+Itemtype,https://schema.org/DeactivateAction,< 1K
+Itemtype,https://schema.org/DefenceEstablishment,< 1K
+Itemtype,https://schema.org/DefinedRegion,100K - 1M
+Itemtype,https://schema.org/DefinedTerm,10K - 100K
+Itemtype,https://schema.org/DefinedTermSet,10K - 100K
+Itemtype,https://schema.org/DeleteAction,< 1K
+Itemtype,https://schema.org/DeliveryChargeSpecification,10K - 100K
+Itemtype,https://schema.org/DeliveryEvent,< 1K
+Itemtype,https://schema.org/DeliveryMethod,< 1K
+Itemtype,https://schema.org/DeliveryTimeSettings,< 1K
+Itemtype,https://schema.org/Demand,1K - 10K
+Itemtype,https://schema.org/Dentist,10K - 100K
+Itemtype,https://schema.org/DepartAction,< 1K
+Itemtype,https://schema.org/DepartmentStore,1K - 10K
+Itemtype,https://schema.org/DepositAccount,< 1K
+Itemtype,https://schema.org/Dermatology,< 1K
+Itemtype,https://schema.org/DiagnosticLab,1K - 10K
+Itemtype,https://schema.org/DiagnosticProcedure,< 1K
+Itemtype,https://schema.org/Diet,< 1K
+Itemtype,https://schema.org/DietNutrition,1K - 10K
+Itemtype,https://schema.org/DietarySupplement,< 1K
+Itemtype,https://schema.org/DigitalDocument,10K - 100K
+Itemtype,https://schema.org/DigitalDocumentPermission,< 1K
+Itemtype,https://schema.org/DigitalDocumentPermissionType,< 1K
+Itemtype,https://schema.org/DigitalPlatformEnumeration,< 1K
+Itemtype,https://schema.org/DisagreeAction,< 1K
+Itemtype,https://schema.org/DiscoverAction,< 1K
+Itemtype,https://schema.org/DiscussionForumPosting,10K - 100K
+Itemtype,https://schema.org/DislikeAction,1K - 10K
+Itemtype,https://schema.org/Distance,1K - 10K
+Itemtype,https://schema.org/Distillery,< 1K
+Itemtype,https://schema.org/DonateAction,1K - 10K
+Itemtype,https://schema.org/DoseSchedule,< 1K
+Itemtype,https://schema.org/DownloadAction,1K - 10K
+Itemtype,https://schema.org/DrawAction,< 1K
+Itemtype,https://schema.org/Drawing,< 1K
+Itemtype,https://schema.org/DrinkAction,< 1K
+Itemtype,https://schema.org/DriveWheelConfigurationValue,< 1K
+Itemtype,https://schema.org/Drug,1K - 10K
+Itemtype,https://schema.org/DrugClass,1K - 10K
+Itemtype,https://schema.org/DrugCost,< 1K
+Itemtype,https://schema.org/DrugCostCategory,< 1K
+Itemtype,https://schema.org/DrugLegalStatus,< 1K
+Itemtype,https://schema.org/DrugPregnancyCategory,< 1K
+Itemtype,https://schema.org/DrugPrescriptionStatus,< 1K
+Itemtype,https://schema.org/DrugStrength,< 1K
+Itemtype,https://schema.org/DryCleaningOrLaundry,1K - 10K
+Itemtype,https://schema.org/Duration,1K - 10K
+Itemtype,https://schema.org/EUEnergyEfficiencyEnumeration,< 1K
+Itemtype,https://schema.org/EatAction,< 1K
+Itemtype,https://schema.org/EducationEvent,1K - 10K
+Itemtype,https://schema.org/EducationalAudience,10K - 100K
+Itemtype,https://schema.org/EducationalOccupationalCredential,10K - 100K
+Itemtype,https://schema.org/EducationalOccupationalProgram,1K - 10K
+Itemtype,https://schema.org/EducationalOrganization,100K - 1M
+Itemtype,https://schema.org/Electrician,10K - 100K
+Itemtype,https://schema.org/ElectronicsStore,1K - 10K
+Itemtype,https://schema.org/ElementarySchool,< 1K
+Itemtype,https://schema.org/EmailMessage,< 1K
+Itemtype,https://schema.org/Embassy,< 1K
+Itemtype,https://schema.org/Emergency,< 1K
+Itemtype,https://schema.org/EmergencyService,1K - 10K
+Itemtype,https://schema.org/EmployeeRole,< 1K
+Itemtype,https://schema.org/EmployerAggregateRating,1K - 10K
+Itemtype,https://schema.org/EmployerReview,< 1K
+Itemtype,https://schema.org/EmploymentAgency,1K - 10K
+Itemtype,https://schema.org/EndorseAction,< 1K
+Itemtype,https://schema.org/EndorsementRating,< 1K
+Itemtype,https://schema.org/Energy,< 1K
+Itemtype,https://schema.org/EnergyConsumptionDetails,1K - 10K
+Itemtype,https://schema.org/EnergyEfficiencyEnumeration,< 1K
+Itemtype,https://schema.org/EnergyStarEnergyEfficiencyEnumeration,< 1K
+Itemtype,https://schema.org/EngineSpecification,10K - 100K
+Itemtype,https://schema.org/EntertainmentBusiness,10K - 100K
+Itemtype,https://schema.org/EntryPoint,10M+
+Itemtype,https://schema.org/Enumeration,1K - 10K
+Itemtype,https://schema.org/Episode,1K - 10K
+Itemtype,https://schema.org/Error,< 1K
+Itemtype,https://schema.org/Event,100K - 1M
+Itemtype,https://schema.org/EventAttendanceModeEnumeration,< 1K
+Itemtype,https://schema.org/EventReservation,< 1K
+Itemtype,https://schema.org/EventSeries,1K - 10K
+Itemtype,https://schema.org/EventStatusType,< 1K
+Itemtype,https://schema.org/EventVenue,10K - 100K
+Itemtype,https://schema.org/ExchangeRateSpecification,< 1K
+Itemtype,https://schema.org/ExerciseAction,< 1K
+Itemtype,https://schema.org/ExerciseGym,1K - 10K
+Itemtype,https://schema.org/ExercisePlan,< 1K
+Itemtype,https://schema.org/ExhibitionEvent,1K - 10K
+Itemtype,https://schema.org/FAQPage,1M - 10M
+Itemtype,https://schema.org/FMRadioChannel,< 1K
+Itemtype,https://schema.org/FastFoodRestaurant,1K - 10K
+Itemtype,https://schema.org/Festival,1K - 10K
+Itemtype,https://schema.org/FilmAction,< 1K
+Itemtype,https://schema.org/FinancialIncentive,< 1K
+Itemtype,https://schema.org/FinancialProduct,10K - 100K
+Itemtype,https://schema.org/FinancialService,10K - 100K
+Itemtype,https://schema.org/FindAction,< 1K
+Itemtype,https://schema.org/FireStation,< 1K
+Itemtype,https://schema.org/Flight,1K - 10K
+Itemtype,https://schema.org/FlightReservation,< 1K
+Itemtype,https://schema.org/Float,< 1K
+Itemtype,https://schema.org/FloorPlan,10K - 100K
+Itemtype,https://schema.org/Florist,10K - 100K
+Itemtype,https://schema.org/FollowAction,10K - 100K
+Itemtype,https://schema.org/FoodEstablishment,10K - 100K
+Itemtype,https://schema.org/FoodEstablishmentReservation,1K - 10K
+Itemtype,https://schema.org/FoodEvent,1K - 10K
+Itemtype,https://schema.org/FoodService,1K - 10K
+Itemtype,https://schema.org/FulfillmentTypeEnumeration,< 1K
+Itemtype,https://schema.org/FundingAgency,< 1K
+Itemtype,https://schema.org/FundingScheme,< 1K
+Itemtype,https://schema.org/FurnitureStore,10K - 100K
+Itemtype,https://schema.org/Game,100K - 1M
+Itemtype,https://schema.org/GameAvailabilityEnumeration,< 1K
+Itemtype,https://schema.org/GamePlayMode,< 1K
+Itemtype,https://schema.org/GameServer,1K - 10K
+Itemtype,https://schema.org/GameServerStatus,< 1K
+Itemtype,https://schema.org/GardenStore,1K - 10K
+Itemtype,https://schema.org/GasStation,1K - 10K
+Itemtype,https://schema.org/GatedResidenceCommunity,< 1K
+Itemtype,https://schema.org/GenderType,< 1K
+Itemtype,https://schema.org/Gene,< 1K
+Itemtype,https://schema.org/GeneralContractor,10K - 100K
+Itemtype,https://schema.org/GeoCircle,100K - 1M
+Itemtype,https://schema.org/GeoCoordinates,1M - 10M
+Itemtype,https://schema.org/GeoShape,10K - 100K
+Itemtype,https://schema.org/GeospatialGeometry,< 1K
+Itemtype,https://schema.org/Geriatric,< 1K
+Itemtype,https://schema.org/GiveAction,< 1K
+Itemtype,https://schema.org/GolfCourse,1K - 10K
+Itemtype,https://schema.org/GovernmentBenefitsType,< 1K
+Itemtype,https://schema.org/GovernmentBuilding,< 1K
+Itemtype,https://schema.org/GovernmentOffice,1K - 10K
+Itemtype,https://schema.org/GovernmentOrganization,10K - 100K
+Itemtype,https://schema.org/GovernmentPermit,< 1K
+Itemtype,https://schema.org/GovernmentService,1K - 10K
+Itemtype,https://schema.org/Grant,1K - 10K
+Itemtype,https://schema.org/GroceryStore,1K - 10K
+Itemtype,https://schema.org/Guide,1K - 10K
+Itemtype,https://schema.org/Gynecologic,< 1K
+Itemtype,https://schema.org/HVACBusiness,10K - 100K
+Itemtype,https://schema.org/Hackathon,< 1K
+Itemtype,https://schema.org/HairSalon,10K - 100K
+Itemtype,https://schema.org/HardwareStore,1K - 10K
+Itemtype,https://schema.org/HealthAndBeautyBusiness,10K - 100K
+Itemtype,https://schema.org/HealthAspectEnumeration,< 1K
+Itemtype,https://schema.org/HealthClub,1K - 10K
+Itemtype,https://schema.org/HealthInsurancePlan,< 1K
+Itemtype,https://schema.org/HealthPlanCostSharingSpecification,< 1K
+Itemtype,https://schema.org/HealthPlanFormulary,< 1K
+Itemtype,https://schema.org/HealthPlanNetwork,< 1K
+Itemtype,https://schema.org/HealthTopicContent,< 1K
+Itemtype,https://schema.org/HighSchool,1K - 10K
+Itemtype,https://schema.org/HinduTemple,< 1K
+Itemtype,https://schema.org/HobbyShop,1K - 10K
+Itemtype,https://schema.org/HomeAndConstructionBusiness,100K - 1M
+Itemtype,https://schema.org/HomeGoodsStore,1K - 10K
+Itemtype,https://schema.org/Hospital,10K - 100K
+Itemtype,https://schema.org/Hostel,1K - 10K
+Itemtype,https://schema.org/Hotel,10K - 100K
+Itemtype,https://schema.org/HotelRoom,10K - 100K
+Itemtype,https://schema.org/House,10K - 100K
+Itemtype,https://schema.org/HousePainter,1K - 10K
+Itemtype,https://schema.org/HowTo,100K - 1M
+Itemtype,https://schema.org/HowToDirection,10K - 100K
+Itemtype,https://schema.org/HowToItem,< 1K
+Itemtype,https://schema.org/HowToSection,10K - 100K
+Itemtype,https://schema.org/HowToStep,100K - 1M
+Itemtype,https://schema.org/HowToSupply,10K - 100K
+Itemtype,https://schema.org/HowToTip,1K - 10K
+Itemtype,https://schema.org/HowToTool,10K - 100K
+Itemtype,https://schema.org/HyperToc,< 1K
+Itemtype,https://schema.org/HyperTocEntry,< 1K
+Itemtype,https://schema.org/IPTCDigitalSourceEnumeration,< 1K
+Itemtype,https://schema.org/ITNonprofitType,< 1K
+Itemtype,https://schema.org/IceCreamShop,1K - 10K
+Itemtype,https://schema.org/IgnoreAction,< 1K
+Itemtype,https://schema.org/ImageGallery,1M - 10M
+Itemtype,https://schema.org/ImageObject,10M+
+Itemtype,https://schema.org/ImageObjectSnapshot,< 1K
+Itemtype,https://schema.org/ImagingTest,< 1K
+Itemtype,https://schema.org/IncentiveQualifiedExpenseType,< 1K
+Itemtype,https://schema.org/IncentiveStatus,< 1K
+Itemtype,https://schema.org/IncentiveType,< 1K
+Itemtype,https://schema.org/IndividualPhysician,1K - 10K
+Itemtype,https://schema.org/IndividualProduct,10K - 100K
+Itemtype,https://schema.org/InfectiousAgentClass,< 1K
+Itemtype,https://schema.org/InfectiousDisease,< 1K
+Itemtype,https://schema.org/InformAction,< 1K
+Itemtype,https://schema.org/InsertAction,< 1K
+Itemtype,https://schema.org/InstallAction,< 1K
+Itemtype,https://schema.org/InstantaneousEvent,< 1K
+Itemtype,https://schema.org/InsuranceAgency,10K - 100K
+Itemtype,https://schema.org/Intangible,1K - 10K
+Itemtype,https://schema.org/Integer,< 1K
+Itemtype,https://schema.org/InteractAction,1K - 10K
+Itemtype,https://schema.org/InteractionCounter,100K - 1M
+Itemtype,https://schema.org/InternetCafe,< 1K
+Itemtype,https://schema.org/InvestmentFund,< 1K
+Itemtype,https://schema.org/InvestmentOrDeposit,< 1K
+Itemtype,https://schema.org/InviteAction,< 1K
+Itemtype,https://schema.org/Invoice,< 1K
+Itemtype,https://schema.org/ItemAvailability,1K - 10K
+Itemtype,https://schema.org/ItemList,1M - 10M
+Itemtype,https://schema.org/ItemListOrderType,< 1K
+Itemtype,https://schema.org/ItemPage,1M - 10M
+Itemtype,https://schema.org/JewelryStore,10K - 100K
+Itemtype,https://schema.org/JobPosting,100K - 1M
+Itemtype,https://schema.org/JoinAction,1K - 10K
+Itemtype,https://schema.org/Joint,< 1K
+Itemtype,https://schema.org/LakeBodyOfWater,< 1K
+Itemtype,https://schema.org/Landform,1K - 10K
+Itemtype,https://schema.org/LandmarksOrHistoricalBuildings,1K - 10K
+Itemtype,https://schema.org/Language,10K - 100K
+Itemtype,https://schema.org/LearningResource,1K - 10K
+Itemtype,https://schema.org/LeaveAction,< 1K
+Itemtype,https://schema.org/LegalForceStatus,< 1K
+Itemtype,https://schema.org/LegalService,10K - 100K
+Itemtype,https://schema.org/LegalValueLevel,< 1K
+Itemtype,https://schema.org/Legislation,1K - 10K
+Itemtype,https://schema.org/LegislationObject,1K - 10K
+Itemtype,https://schema.org/LegislativeBuilding,< 1K
+Itemtype,https://schema.org/LendAction,< 1K
+Itemtype,https://schema.org/Library,1K - 10K
+Itemtype,https://schema.org/LibrarySystem,< 1K
+Itemtype,https://schema.org/LifestyleModification,< 1K
+Itemtype,https://schema.org/Ligament,< 1K
+Itemtype,https://schema.org/LikeAction,10K - 100K
+Itemtype,https://schema.org/LinkRole,< 1K
+Itemtype,https://schema.org/LiquorStore,1K - 10K
+Itemtype,https://schema.org/ListItem,10M+
+Itemtype,https://schema.org/ListenAction,1K - 10K
+Itemtype,https://schema.org/Literal,< 1K
+Itemtype,https://schema.org/LiteraryEvent,< 1K
+Itemtype,https://schema.org/LiveBlogPosting,10K - 100K
+Itemtype,https://schema.org/LoanOrCredit,1K - 10K
+Itemtype,https://schema.org/LocalBusiness,1M - 10M
+Itemtype,https://schema.org/LocationFeatureSpecification,100K - 1M
+Itemtype,https://schema.org/Locksmith,10K - 100K
+Itemtype,https://schema.org/LodgingBusiness,10K - 100K
+Itemtype,https://schema.org/LodgingReservation,1K - 10K
+Itemtype,https://schema.org/LoginAction,1K - 10K
+Itemtype,https://schema.org/LoseAction,< 1K
+Itemtype,https://schema.org/LymphaticVessel,< 1K
+Itemtype,https://schema.org/Manuscript,< 1K
+Itemtype,https://schema.org/Map,10K - 100K
+Itemtype,https://schema.org/MapCategoryType,< 1K
+Itemtype,https://schema.org/MarryAction,< 1K
+Itemtype,https://schema.org/Mass,< 1K
+Itemtype,https://schema.org/MathSolver,< 1K
+Itemtype,https://schema.org/MaximumDoseSchedule,< 1K
+Itemtype,https://schema.org/MeasurementMethodEnum,< 1K
+Itemtype,https://schema.org/MeasurementTypeEnumeration,< 1K
+Itemtype,https://schema.org/MediaEnumeration,< 1K
+Itemtype,https://schema.org/MediaGallery,1K - 10K
+Itemtype,https://schema.org/MediaManipulationRatingEnumeration,< 1K
+Itemtype,https://schema.org/MediaObject,100K - 1M
+Itemtype,https://schema.org/MediaReview,< 1K
+Itemtype,https://schema.org/MediaReviewItem,< 1K
+Itemtype,https://schema.org/MediaSubscription,< 1K
+Itemtype,https://schema.org/MedicalAudience,1K - 10K
+Itemtype,https://schema.org/MedicalAudienceType,< 1K
+Itemtype,https://schema.org/MedicalBusiness,10K - 100K
+Itemtype,https://schema.org/MedicalCause,1K - 10K
+Itemtype,https://schema.org/MedicalClinic,10K - 100K
+Itemtype,https://schema.org/MedicalCode,1K - 10K
+Itemtype,https://schema.org/MedicalCondition,10K - 100K
+Itemtype,https://schema.org/MedicalConditionStage,< 1K
+Itemtype,https://schema.org/MedicalContraindication,< 1K
+Itemtype,https://schema.org/MedicalDevice,1K - 10K
+Itemtype,https://schema.org/MedicalDevicePurpose,< 1K
+Itemtype,https://schema.org/MedicalEntity,1K - 10K
+Itemtype,https://schema.org/MedicalEnumeration,< 1K
+Itemtype,https://schema.org/MedicalEvidenceLevel,< 1K
+Itemtype,https://schema.org/MedicalGuideline,< 1K
+Itemtype,https://schema.org/MedicalGuidelineContraindication,< 1K
+Itemtype,https://schema.org/MedicalGuidelineRecommendation,< 1K
+Itemtype,https://schema.org/MedicalImagingTechnique,< 1K
+Itemtype,https://schema.org/MedicalIndication,1K - 10K
+Itemtype,https://schema.org/MedicalIntangible,< 1K
+Itemtype,https://schema.org/MedicalObservationalStudy,< 1K
+Itemtype,https://schema.org/MedicalObservationalStudyDesign,< 1K
+Itemtype,https://schema.org/MedicalOrganization,10K - 100K
+Itemtype,https://schema.org/MedicalProcedure,10K - 100K
+Itemtype,https://schema.org/MedicalProcedureType,< 1K
+Itemtype,https://schema.org/MedicalRiskCalculator,< 1K
+Itemtype,https://schema.org/MedicalRiskEstimator,< 1K
+Itemtype,https://schema.org/MedicalRiskFactor,1K - 10K
+Itemtype,https://schema.org/MedicalRiskScore,< 1K
+Itemtype,https://schema.org/MedicalScholarlyArticle,1K - 10K
+Itemtype,https://schema.org/MedicalSign,< 1K
+Itemtype,https://schema.org/MedicalSignOrSymptom,1K - 10K
+Itemtype,https://schema.org/MedicalSpecialty,10K - 100K
+Itemtype,https://schema.org/MedicalStudy,1K - 10K
+Itemtype,https://schema.org/MedicalStudyStatus,< 1K
+Itemtype,https://schema.org/MedicalSymptom,1K - 10K
+Itemtype,https://schema.org/MedicalTest,1K - 10K
+Itemtype,https://schema.org/MedicalTestPanel,< 1K
+Itemtype,https://schema.org/MedicalTherapy,10K - 100K
+Itemtype,https://schema.org/MedicalTrial,< 1K
+Itemtype,https://schema.org/MedicalTrialDesign,< 1K
+Itemtype,https://schema.org/MedicalWebPage,10K - 100K
+Itemtype,https://schema.org/MedicineSystem,< 1K
+Itemtype,https://schema.org/MeetingRoom,1K - 10K
+Itemtype,https://schema.org/MemberProgram,1K - 10K
+Itemtype,https://schema.org/MemberProgramTier,1K - 10K
+Itemtype,https://schema.org/MensClothingStore,< 1K
+Itemtype,https://schema.org/Menu,100K - 1M
+Itemtype,https://schema.org/MenuItem,10K - 100K
+Itemtype,https://schema.org/MenuSection,10K - 100K
+Itemtype,https://schema.org/MerchantReturnEnumeration,< 1K
+Itemtype,https://schema.org/MerchantReturnPolicy,100K - 1M
+Itemtype,https://schema.org/MerchantReturnPolicySeasonalOverride,< 1K
+Itemtype,https://schema.org/Message,< 1K
+Itemtype,https://schema.org/MiddleSchool,< 1K
+Itemtype,https://schema.org/Midwifery,< 1K
+Itemtype,https://schema.org/MobileApplication,10K - 100K
+Itemtype,https://schema.org/MobilePhoneStore,1K - 10K
+Itemtype,https://schema.org/MolecularEntity,< 1K
+Itemtype,https://schema.org/MonetaryAmount,100K - 1M
+Itemtype,https://schema.org/MonetaryAmountDistribution,1K - 10K
+Itemtype,https://schema.org/MonetaryGrant,1K - 10K
+Itemtype,https://schema.org/MoneyTransfer,< 1K
+Itemtype,https://schema.org/MortgageLoan,< 1K
+Itemtype,https://schema.org/Mosque,< 1K
+Itemtype,https://schema.org/Motel,< 1K
+Itemtype,https://schema.org/Motorcycle,1K - 10K
+Itemtype,https://schema.org/MotorcycleDealer,1K - 10K
+Itemtype,https://schema.org/MotorcycleRepair,< 1K
+Itemtype,https://schema.org/MotorizedBicycle,< 1K
+Itemtype,https://schema.org/Mountain,< 1K
+Itemtype,https://schema.org/MoveAction,< 1K
+Itemtype,https://schema.org/Movie,10K - 100K
+Itemtype,https://schema.org/MovieClip,< 1K
+Itemtype,https://schema.org/MovieRentalStore,< 1K
+Itemtype,https://schema.org/MovieSeries,< 1K
+Itemtype,https://schema.org/MovieTheater,1K - 10K
+Itemtype,https://schema.org/MovingCompany,10K - 100K
+Itemtype,https://schema.org/Muscle,< 1K
+Itemtype,https://schema.org/Museum,1K - 10K
+Itemtype,https://schema.org/MusicAlbum,10K - 100K
+Itemtype,https://schema.org/MusicAlbumProductionType,< 1K
+Itemtype,https://schema.org/MusicAlbumReleaseType,< 1K
+Itemtype,https://schema.org/MusicComposition,1K - 10K
+Itemtype,https://schema.org/MusicEvent,10K - 100K
+Itemtype,https://schema.org/MusicGroup,10K - 100K
+Itemtype,https://schema.org/MusicPlaylist,1K - 10K
+Itemtype,https://schema.org/MusicRecording,10K - 100K
+Itemtype,https://schema.org/MusicRelease,1K - 10K
+Itemtype,https://schema.org/MusicReleaseFormatType,< 1K
+Itemtype,https://schema.org/MusicStore,1K - 10K
+Itemtype,https://schema.org/MusicVenue,1K - 10K
+Itemtype,https://schema.org/MusicVideoObject,< 1K
+Itemtype,https://schema.org/NGO,10K - 100K
+Itemtype,https://schema.org/NLNonprofitType,< 1K
+Itemtype,https://schema.org/NailSalon,1K - 10K
+Itemtype,https://schema.org/Nerve,< 1K
+Itemtype,https://schema.org/NewsArticle,100K - 1M
+Itemtype,https://schema.org/NewsMediaOrganization,10K - 100K
+Itemtype,https://schema.org/Newspaper,< 1K
+Itemtype,https://schema.org/NightClub,1K - 10K
+Itemtype,https://schema.org/NonprofitType,< 1K
+Itemtype,https://schema.org/Notary,1K - 10K
+Itemtype,https://schema.org/NoteDigitalDocument,< 1K
+Itemtype,https://schema.org/Number,< 1K
+Itemtype,https://schema.org/Nursing,< 1K
+Itemtype,https://schema.org/NutritionInformation,10K - 100K
+Itemtype,https://schema.org/Observation,< 1K
+Itemtype,https://schema.org/Obstetric,< 1K
+Itemtype,https://schema.org/Occupation,10K - 100K
+Itemtype,https://schema.org/OccupationalExperienceRequirements,1K - 10K
+Itemtype,https://schema.org/OccupationalTherapy,< 1K
+Itemtype,https://schema.org/OceanBodyOfWater,< 1K
+Itemtype,https://schema.org/Offer,1M - 10M
+Itemtype,https://schema.org/OfferCatalog,100K - 1M
+Itemtype,https://schema.org/OfferForLease,1K - 10K
+Itemtype,https://schema.org/OfferForPurchase,1K - 10K
+Itemtype,https://schema.org/OfferItemCondition,1K - 10K
+Itemtype,https://schema.org/OfferShippingDetails,100K - 1M
+Itemtype,https://schema.org/OfficeEquipmentStore,1K - 10K
+Itemtype,https://schema.org/OnDemandEvent,< 1K
+Itemtype,https://schema.org/Oncologic,< 1K
+Itemtype,https://schema.org/OnlineBusiness,10K - 100K
+Itemtype,https://schema.org/OnlineMarketplace,< 1K
+Itemtype,https://schema.org/OnlineStore,100K - 1M
+Itemtype,https://schema.org/OpeningHoursSpecification,1M - 10M
+Itemtype,https://schema.org/OperatingSystem,< 1K
+Itemtype,https://schema.org/OpinionNewsArticle,1K - 10K
+Itemtype,https://schema.org/Optician,1K - 10K
+Itemtype,https://schema.org/Optometric,1K - 10K
+Itemtype,https://schema.org/Order,< 1K
+Itemtype,https://schema.org/OrderAction,10K - 100K
+Itemtype,https://schema.org/OrderItem,< 1K
+Itemtype,https://schema.org/OrderStatus,< 1K
+Itemtype,https://schema.org/Organization,10M+
+Itemtype,https://schema.org/OrganizationRole,1K - 10K
+Itemtype,https://schema.org/OrganizeAction,< 1K
+Itemtype,https://schema.org/Otolaryngologic,< 1K
+Itemtype,https://schema.org/OutletStore,< 1K
+Itemtype,https://schema.org/OwnershipInfo,< 1K
+Itemtype,https://schema.org/PaintAction,< 1K
+Itemtype,https://schema.org/Painting,< 1K
+Itemtype,https://schema.org/PalliativeProcedure,< 1K
+Itemtype,https://schema.org/ParcelDelivery,< 1K
+Itemtype,https://schema.org/ParentAudience,< 1K
+Itemtype,https://schema.org/Park,1K - 10K
+Itemtype,https://schema.org/ParkingFacility,1K - 10K
+Itemtype,https://schema.org/PathologyTest,< 1K
+Itemtype,https://schema.org/Patient,1K - 10K
+Itemtype,https://schema.org/PawnShop,< 1K
+Itemtype,https://schema.org/PayAction,< 1K
+Itemtype,https://schema.org/PaymentCard,< 1K
+Itemtype,https://schema.org/PaymentChargeSpecification,< 1K
+Itemtype,https://schema.org/PaymentMethod,10K - 100K
+Itemtype,https://schema.org/PaymentMethodType,< 1K
+Itemtype,https://schema.org/PaymentService,1K - 10K
+Itemtype,https://schema.org/PaymentStatusType,< 1K
+Itemtype,https://schema.org/Pediatric,< 1K
+Itemtype,https://schema.org/PeopleAudience,10K - 100K
+Itemtype,https://schema.org/PerformAction,< 1K
+Itemtype,https://schema.org/PerformanceRole,< 1K
+Itemtype,https://schema.org/PerformingArtsEvent,< 1K
+Itemtype,https://schema.org/PerformingArtsTheater,1K - 10K
+Itemtype,https://schema.org/PerformingGroup,10K - 100K
+Itemtype,https://schema.org/Periodical,1K - 10K
+Itemtype,https://schema.org/Permit,10K - 100K
+Itemtype,https://schema.org/Person,10M+
+Itemtype,https://schema.org/PetStore,1K - 10K
+Itemtype,https://schema.org/Pharmacy,10K - 100K
+Itemtype,https://schema.org/Photograph,10K - 100K
+Itemtype,https://schema.org/PhotographAction,< 1K
+Itemtype,https://schema.org/PhysicalActivity,< 1K
+Itemtype,https://schema.org/PhysicalActivityCategory,1K - 10K
+Itemtype,https://schema.org/PhysicalExam,< 1K
+Itemtype,https://schema.org/PhysicalTherapy,< 1K
+Itemtype,https://schema.org/Physician,10K - 100K
+Itemtype,https://schema.org/PhysiciansOffice,< 1K
+Itemtype,https://schema.org/Physiotherapy,1K - 10K
+Itemtype,https://schema.org/Place,1M - 10M
+Itemtype,https://schema.org/PlaceOfWorship,1K - 10K
+Itemtype,https://schema.org/PlanAction,< 1K
+Itemtype,https://schema.org/PlasticSurgery,< 1K
+Itemtype,https://schema.org/Play,< 1K
+Itemtype,https://schema.org/PlayAction,10K - 100K
+Itemtype,https://schema.org/PlayGameAction,< 1K
+Itemtype,https://schema.org/Playground,< 1K
+Itemtype,https://schema.org/Plumber,10K - 100K
+Itemtype,https://schema.org/PodcastEpisode,10K - 100K
+Itemtype,https://schema.org/PodcastSeason,< 1K
+Itemtype,https://schema.org/PodcastSeries,10K - 100K
+Itemtype,https://schema.org/Podiatric,< 1K
+Itemtype,https://schema.org/PoliceStation,< 1K
+Itemtype,https://schema.org/PoliticalParty,< 1K
+Itemtype,https://schema.org/Pond,< 1K
+Itemtype,https://schema.org/PostOffice,< 1K
+Itemtype,https://schema.org/PostalAddress,1M - 10M
+Itemtype,https://schema.org/PostalCodeRangeSpecification,1K - 10K
+Itemtype,https://schema.org/Poster,< 1K
+Itemtype,https://schema.org/PreOrderAction,< 1K
+Itemtype,https://schema.org/PrependAction,< 1K
+Itemtype,https://schema.org/Preschool,1K - 10K
+Itemtype,https://schema.org/PresentationDigitalDocument,< 1K
+Itemtype,https://schema.org/PreventionIndication,< 1K
+Itemtype,https://schema.org/PriceComponentTypeEnumeration,< 1K
+Itemtype,https://schema.org/PriceSpecification,100K - 1M
+Itemtype,https://schema.org/PriceTypeEnumeration,< 1K
+Itemtype,https://schema.org/PrimaryCare,< 1K
+Itemtype,https://schema.org/Product,1M - 10M
+Itemtype,https://schema.org/ProductCollection,1K - 10K
+Itemtype,https://schema.org/ProductGroup,100K - 1M
+Itemtype,https://schema.org/ProductModel,1K - 10K
+Itemtype,https://schema.org/ProductReturnEnumeration,< 1K
+Itemtype,https://schema.org/ProductReturnPolicy,< 1K
+Itemtype,https://schema.org/ProfessionalService,100K - 1M
+Itemtype,https://schema.org/ProfilePage,100K - 1M
+Itemtype,https://schema.org/ProgramMembership,1K - 10K
+Itemtype,https://schema.org/Project,1K - 10K
+Itemtype,https://schema.org/PronounceableText,< 1K
+Itemtype,https://schema.org/Property,< 1K
+Itemtype,https://schema.org/PropertyValue,100K - 1M
+Itemtype,https://schema.org/PropertyValueSpecification,10M+
+Itemtype,https://schema.org/Protein,< 1K
+Itemtype,https://schema.org/Psychiatric,1K - 10K
+Itemtype,https://schema.org/PsychologicalTreatment,< 1K
+Itemtype,https://schema.org/PublicHealth,< 1K
+Itemtype,https://schema.org/PublicSwimmingPool,< 1K
+Itemtype,https://schema.org/PublicToilet,< 1K
+Itemtype,https://schema.org/PublicationEvent,1K - 10K
+Itemtype,https://schema.org/PublicationIssue,1K - 10K
+Itemtype,https://schema.org/PublicationVolume,1K - 10K
+Itemtype,https://schema.org/PurchaseType,< 1K
+Itemtype,https://schema.org/QAPage,10K - 100K
+Itemtype,https://schema.org/QualitativeValue,1K - 10K
+Itemtype,https://schema.org/QuantitativeValue,1M - 10M
+Itemtype,https://schema.org/QuantitativeValueDistribution,< 1K
+Itemtype,https://schema.org/Quantity,< 1K
+Itemtype,https://schema.org/Question,1M - 10M
+Itemtype,https://schema.org/Quiz,1K - 10K
+Itemtype,https://schema.org/Quotation,1K - 10K
+Itemtype,https://schema.org/QuoteAction,1K - 10K
+Itemtype,https://schema.org/RVPark,< 1K
+Itemtype,https://schema.org/RadiationTherapy,< 1K
+Itemtype,https://schema.org/RadioBroadcastService,< 1K
+Itemtype,https://schema.org/RadioChannel,< 1K
+Itemtype,https://schema.org/RadioClip,< 1K
+Itemtype,https://schema.org/RadioEpisode,1K - 10K
+Itemtype,https://schema.org/RadioSeason,< 1K
+Itemtype,https://schema.org/RadioSeries,1K - 10K
+Itemtype,https://schema.org/RadioStation,1K - 10K
+Itemtype,https://schema.org/Rating,1M - 10M
+Itemtype,https://schema.org/ReactAction,< 1K
+Itemtype,https://schema.org/ReadAction,10M+
+Itemtype,https://schema.org/RealEstateAgent,100K - 1M
+Itemtype,https://schema.org/RealEstateListing,10K - 100K
+Itemtype,https://schema.org/ReceiveAction,< 1K
+Itemtype,https://schema.org/Recipe,10K - 100K
+Itemtype,https://schema.org/Recommendation,< 1K
+Itemtype,https://schema.org/RecommendedDoseSchedule,< 1K
+Itemtype,https://schema.org/RecyclingCenter,1K - 10K
+Itemtype,https://schema.org/RefundTypeEnumeration,< 1K
+Itemtype,https://schema.org/RegisterAction,1K - 10K
+Itemtype,https://schema.org/RejectAction,< 1K
+Itemtype,https://schema.org/RentAction,1K - 10K
+Itemtype,https://schema.org/RentalCarReservation,< 1K
+Itemtype,https://schema.org/RepaymentSpecification,< 1K
+Itemtype,https://schema.org/ReplaceAction,< 1K
+Itemtype,https://schema.org/ReplyAction,1K - 10K
+Itemtype,https://schema.org/Report,1K - 10K
+Itemtype,https://schema.org/ReportageNewsArticle,1K - 10K
+Itemtype,https://schema.org/ReportedDoseSchedule,< 1K
+Itemtype,https://schema.org/ResearchOrganization,1K - 10K
+Itemtype,https://schema.org/ResearchProject,1K - 10K
+Itemtype,https://schema.org/Researcher,< 1K
+Itemtype,https://schema.org/Reservation,10K - 100K
+Itemtype,https://schema.org/ReservationPackage,< 1K
+Itemtype,https://schema.org/ReservationStatusType,< 1K
+Itemtype,https://schema.org/ReserveAction,10K - 100K
+Itemtype,https://schema.org/Reservoir,< 1K
+Itemtype,https://schema.org/ResetPasswordAction,< 1K
+Itemtype,https://schema.org/Residence,10K - 100K
+Itemtype,https://schema.org/Resort,1K - 10K
+Itemtype,https://schema.org/RespiratoryTherapy,< 1K
+Itemtype,https://schema.org/Restaurant,100K - 1M
+Itemtype,https://schema.org/RestrictedDiet,1K - 10K
+Itemtype,https://schema.org/ResumeAction,< 1K
+Itemtype,https://schema.org/ReturnAction,< 1K
+Itemtype,https://schema.org/ReturnFeesEnumeration,< 1K
+Itemtype,https://schema.org/ReturnLabelSourceEnumeration,< 1K
+Itemtype,https://schema.org/ReturnMethodEnumeration,< 1K
+Itemtype,https://schema.org/Review,1M - 10M
+Itemtype,https://schema.org/ReviewAction,1K - 10K
+Itemtype,https://schema.org/ReviewNewsArticle,< 1K
+Itemtype,https://schema.org/RiverBodyOfWater,< 1K
+Itemtype,https://schema.org/Role,1K - 10K
+Itemtype,https://schema.org/RoofingContractor,10K - 100K
+Itemtype,https://schema.org/Room,1K - 10K
+Itemtype,https://schema.org/RsvpAction,< 1K
+Itemtype,https://schema.org/RsvpResponseType,< 1K
+Itemtype,https://schema.org/RuntimePlatform,< 1K
+Itemtype,https://schema.org/SaleEvent,1K - 10K
+Itemtype,https://schema.org/SatiricalArticle,< 1K
+Itemtype,https://schema.org/Schedule,10K - 100K
+Itemtype,https://schema.org/ScheduleAction,1K - 10K
+Itemtype,https://schema.org/ScholarlyArticle,10K - 100K
+Itemtype,https://schema.org/School,1K - 10K
+Itemtype,https://schema.org/SchoolDistrict,< 1K
+Itemtype,https://schema.org/ScreeningEvent,< 1K
+Itemtype,https://schema.org/Sculpture,< 1K
+Itemtype,https://schema.org/SeaBodyOfWater,< 1K
+Itemtype,https://schema.org/SearchAction,10M+
+Itemtype,https://schema.org/SearchRescueOrganization,< 1K
+Itemtype,https://schema.org/SearchResultsPage,10K - 100K
+Itemtype,https://schema.org/Season,< 1K
+Itemtype,https://schema.org/Seat,< 1K
+Itemtype,https://schema.org/SeekToAction,10K - 100K
+Itemtype,https://schema.org/SelfStorage,1K - 10K
+Itemtype,https://schema.org/SellAction,1K - 10K
+Itemtype,https://schema.org/SendAction,< 1K
+Itemtype,https://schema.org/SequentialArt,< 1K
+Itemtype,https://schema.org/Series,10K - 100K
+Itemtype,https://schema.org/Service,1M - 10M
+Itemtype,https://schema.org/ServiceChannel,10K - 100K
+Itemtype,https://schema.org/ServicePeriod,1K - 10K
+Itemtype,https://schema.org/ShareAction,10K - 100K
+Itemtype,https://schema.org/SheetMusic,< 1K
+Itemtype,https://schema.org/ShippingConditions,10K - 100K
+Itemtype,https://schema.org/ShippingDeliveryTime,100K - 1M
+Itemtype,https://schema.org/ShippingRateSettings,< 1K
+Itemtype,https://schema.org/ShippingService,10K - 100K
+Itemtype,https://schema.org/ShoeStore,1K - 10K
+Itemtype,https://schema.org/ShoppingCenter,1K - 10K
+Itemtype,https://schema.org/ShortStory,< 1K
+Itemtype,https://schema.org/SingleFamilyResidence,10K - 100K
+Itemtype,https://schema.org/SiteNavigationElement,1M - 10M
+Itemtype,https://schema.org/SizeGroupEnumeration,< 1K
+Itemtype,https://schema.org/SizeSpecification,1K - 10K
+Itemtype,https://schema.org/SizeSystemEnumeration,< 1K
+Itemtype,https://schema.org/SkiResort,< 1K
+Itemtype,https://schema.org/SocialEvent,1K - 10K
+Itemtype,https://schema.org/SocialMediaPosting,10K - 100K
+Itemtype,https://schema.org/SoftwareApplication,100K - 1M
+Itemtype,https://schema.org/SoftwareSourceCode,1K - 10K
+Itemtype,https://schema.org/SolveMathAction,< 1K
+Itemtype,https://schema.org/SomeProducts,10K - 100K
+Itemtype,https://schema.org/SpeakableSpecification,100K - 1M
+Itemtype,https://schema.org/SpecialAnnouncement,1K - 10K
+Itemtype,https://schema.org/Specialty,1K - 10K
+Itemtype,https://schema.org/SportingGoodsStore,1K - 10K
+Itemtype,https://schema.org/SportsActivityLocation,10K - 100K
+Itemtype,https://schema.org/SportsClub,1K - 10K
+Itemtype,https://schema.org/SportsEvent,10K - 100K
+Itemtype,https://schema.org/SportsOrganization,10K - 100K
+Itemtype,https://schema.org/SportsTeam,10K - 100K
+Itemtype,https://schema.org/SpreadsheetDigitalDocument,< 1K
+Itemtype,https://schema.org/StadiumOrArena,1K - 10K
+Itemtype,https://schema.org/State,100K - 1M
+Itemtype,https://schema.org/Statement,< 1K
+Itemtype,https://schema.org/StatisticalPopulation,< 1K
+Itemtype,https://schema.org/StatisticalVariable,< 1K
+Itemtype,https://schema.org/StatusEnumeration,< 1K
+Itemtype,https://schema.org/SteeringPositionValue,< 1K
+Itemtype,https://schema.org/Store,100K - 1M
+Itemtype,https://schema.org/StructuredValue,1K - 10K
+Itemtype,https://schema.org/StupidType,< 1K
+Itemtype,https://schema.org/SubscribeAction,10K - 100K
+Itemtype,https://schema.org/Substance,< 1K
+Itemtype,https://schema.org/SubwayStation,< 1K
+Itemtype,https://schema.org/Suite,< 1K
+Itemtype,https://schema.org/SuperficialAnatomy,< 1K
+Itemtype,https://schema.org/SurgicalProcedure,< 1K
+Itemtype,https://schema.org/SuspendAction,< 1K
+Itemtype,https://schema.org/Syllabus,1K - 10K
+Itemtype,https://schema.org/Synagogue,< 1K
+Itemtype,https://schema.org/TVClip,< 1K
+Itemtype,https://schema.org/TVEpisode,1K - 10K
+Itemtype,https://schema.org/TVSeason,1K - 10K
+Itemtype,https://schema.org/TVSeries,10K - 100K
+Itemtype,https://schema.org/Table,10K - 100K
+Itemtype,https://schema.org/TakeAction,< 1K
+Itemtype,https://schema.org/TattooParlor,1K - 10K
+Itemtype,https://schema.org/Taxi,< 1K
+Itemtype,https://schema.org/TaxiReservation,< 1K
+Itemtype,https://schema.org/TaxiService,1K - 10K
+Itemtype,https://schema.org/TaxiStand,< 1K
+Itemtype,https://schema.org/Taxon,< 1K
+Itemtype,https://schema.org/TechArticle,10K - 100K
+Itemtype,https://schema.org/TelevisionChannel,< 1K
+Itemtype,https://schema.org/TelevisionStation,< 1K
+Itemtype,https://schema.org/TennisComplex,< 1K
+Itemtype,https://schema.org/Text,10K - 100K
+Itemtype,https://schema.org/TextDigitalDocument,< 1K
+Itemtype,https://schema.org/TextObject,1K - 10K
+Itemtype,https://schema.org/TheaterEvent,1K - 10K
+Itemtype,https://schema.org/TheaterGroup,1K - 10K
+Itemtype,https://schema.org/TherapeuticProcedure,1K - 10K
+Itemtype,https://schema.org/Thesis,< 1K
+Itemtype,https://schema.org/Thing,10M+
+Itemtype,https://schema.org/Ticket,< 1K
+Itemtype,https://schema.org/TieAction,< 1K
+Itemtype,https://schema.org/TierBenefitEnumeration,< 1K
+Itemtype,https://schema.org/Time,< 1K
+Itemtype,https://schema.org/TipAction,< 1K
+Itemtype,https://schema.org/TireShop,1K - 10K
+Itemtype,https://schema.org/TouristAttraction,10K - 100K
+Itemtype,https://schema.org/TouristDestination,10K - 100K
+Itemtype,https://schema.org/TouristInformationCenter,1K - 10K
+Itemtype,https://schema.org/TouristTrip,10K - 100K
+Itemtype,https://schema.org/ToyStore,1K - 10K
+Itemtype,https://schema.org/TrackAction,< 1K
+Itemtype,https://schema.org/TradeAction,1K - 10K
+Itemtype,https://schema.org/TrainReservation,< 1K
+Itemtype,https://schema.org/TrainStation,< 1K
+Itemtype,https://schema.org/TrainTrip,< 1K
+Itemtype,https://schema.org/TransferAction,< 1K
+Itemtype,https://schema.org/TravelAction,1K - 10K
+Itemtype,https://schema.org/TravelAgency,10K - 100K
+Itemtype,https://schema.org/TreatmentIndication,< 1K
+Itemtype,https://schema.org/Trip,10K - 100K
+Itemtype,https://schema.org/TypeAndQuantityNode,< 1K
+Itemtype,https://schema.org/UKNonprofitType,< 1K
+Itemtype,https://schema.org/URL,1K - 10K
+Itemtype,https://schema.org/USNonprofitType,< 1K
+Itemtype,https://schema.org/UnRegisterAction,< 1K
+Itemtype,https://schema.org/UnitPriceSpecification,1M - 10M
+Itemtype,https://schema.org/UpdateAction,< 1K
+Itemtype,https://schema.org/UseAction,1K - 10K
+Itemtype,https://schema.org/UserBlocks,< 1K
+Itemtype,https://schema.org/UserCheckins,1K - 10K
+Itemtype,https://schema.org/UserComments,10K - 100K
+Itemtype,https://schema.org/UserDownloads,< 1K
+Itemtype,https://schema.org/UserInteraction,< 1K
+Itemtype,https://schema.org/UserLikes,< 1K
+Itemtype,https://schema.org/UserPageVisits,< 1K
+Itemtype,https://schema.org/UserPlays,< 1K
+Itemtype,https://schema.org/UserPlusOnes,< 1K
+Itemtype,https://schema.org/UserReview,1K - 10K
+Itemtype,https://schema.org/UserTweets,< 1K
+Itemtype,https://schema.org/VacationRental,10K - 100K
+Itemtype,https://schema.org/Vehicle,10K - 100K
+Itemtype,https://schema.org/Vein,< 1K
+Itemtype,https://schema.org/Vessel,< 1K
+Itemtype,https://schema.org/VeterinaryCare,1K - 10K
+Itemtype,https://schema.org/VideoGallery,1K - 10K
+Itemtype,https://schema.org/VideoGame,10K - 100K
+Itemtype,https://schema.org/VideoGameClip,< 1K
+Itemtype,https://schema.org/VideoGameSeries,< 1K
+Itemtype,https://schema.org/VideoObject,1M - 10M
+Itemtype,https://schema.org/VideoObjectSnapshot,< 1K
+Itemtype,https://schema.org/ViewAction,10K - 100K
+Itemtype,https://schema.org/VirtualLocation,10K - 100K
+Itemtype,https://schema.org/VisualArtsEvent,< 1K
+Itemtype,https://schema.org/VisualArtwork,1K - 10K
+Itemtype,https://schema.org/VitalSign,< 1K
+Itemtype,https://schema.org/Volcano,< 1K
+Itemtype,https://schema.org/VoteAction,< 1K
+Itemtype,https://schema.org/WPAdBlock,10K - 100K
+Itemtype,https://schema.org/WPFooter,1M - 10M
+Itemtype,https://schema.org/WPHeader,1M - 10M
+Itemtype,https://schema.org/WPSideBar,1M - 10M
+Itemtype,https://schema.org/WantAction,< 1K
+Itemtype,https://schema.org/WarrantyPromise,10K - 100K
+Itemtype,https://schema.org/WarrantyScope,< 1K
+Itemtype,https://schema.org/WatchAction,10K - 100K
+Itemtype,https://schema.org/Waterfall,< 1K
+Itemtype,https://schema.org/WearAction,< 1K
+Itemtype,https://schema.org/WearableMeasurementTypeEnumeration,< 1K
+Itemtype,https://schema.org/WearableSizeGroupEnumeration,< 1K
+Itemtype,https://schema.org/WearableSizeSystemEnumeration,< 1K
+Itemtype,https://schema.org/WebAPI,1K - 10K
+Itemtype,https://schema.org/WebApplication,100K - 1M
+Itemtype,https://schema.org/WebContent,1K - 10K
+Itemtype,https://schema.org/WebPage,10M+
+Itemtype,https://schema.org/WebPageElement,1M - 10M
+Itemtype,https://schema.org/WebSite,10M+
+Itemtype,https://schema.org/WholesaleStore,1K - 10K
+Itemtype,https://schema.org/WinAction,< 1K
+Itemtype,https://schema.org/Winery,1K - 10K
+Itemtype,https://schema.org/WorkBasedProgram,< 1K
+Itemtype,https://schema.org/WorkersUnion,< 1K
+Itemtype,https://schema.org/WriteAction,10K - 100K
+Itemtype,https://schema.org/XPathType,< 1K
+Itemtype,https://schema.org/Zoo,< 1K
+Predicate,https://schema.org/about,10M+
+Predicate,https://schema.org/about-input,< 1K
+Predicate,https://schema.org/about-output,< 1K
+Predicate,https://schema.org/abridged,< 1K
+Predicate,https://schema.org/abridged-input,< 1K
+Predicate,https://schema.org/abridged-output,< 1K
+Predicate,https://schema.org/abstract,10K - 100K
+Predicate,https://schema.org/abstract-input,< 1K
+Predicate,https://schema.org/abstract-output,< 1K
+Predicate,https://schema.org/accelerationTime,1K - 10K
+Predicate,https://schema.org/accelerationTime-input,< 1K
+Predicate,https://schema.org/accelerationTime-output,< 1K
+Predicate,https://schema.org/acceptedAnswer,1M - 10M
+Predicate,https://schema.org/acceptedAnswer-input,< 1K
+Predicate,https://schema.org/acceptedAnswer-output,< 1K
+Predicate,https://schema.org/acceptedOffer,< 1K
+Predicate,https://schema.org/acceptedOffer-input,< 1K
+Predicate,https://schema.org/acceptedOffer-output,< 1K
+Predicate,https://schema.org/acceptedPaymentMethod,10K - 100K
+Predicate,https://schema.org/acceptedPaymentMethod-input,< 1K
+Predicate,https://schema.org/acceptedPaymentMethod-output,< 1K
+Predicate,https://schema.org/acceptsReservations,100K - 1M
+Predicate,https://schema.org/acceptsReservations-input,< 1K
+Predicate,https://schema.org/acceptsReservations-output,< 1K
+Predicate,https://schema.org/accessCode,< 1K
+Predicate,https://schema.org/accessCode-input,< 1K
+Predicate,https://schema.org/accessCode-output,< 1K
+Predicate,https://schema.org/accessMode,1K - 10K
+Predicate,https://schema.org/accessMode-input,< 1K
+Predicate,https://schema.org/accessMode-output,< 1K
+Predicate,https://schema.org/accessModeSufficient,1K - 10K
+Predicate,https://schema.org/accessModeSufficient-input,< 1K
+Predicate,https://schema.org/accessModeSufficient-output,< 1K
+Predicate,https://schema.org/accessibilityAPI,1K - 10K
+Predicate,https://schema.org/accessibilityAPI-input,< 1K
+Predicate,https://schema.org/accessibilityAPI-output,< 1K
+Predicate,https://schema.org/accessibilityControl,1K - 10K
+Predicate,https://schema.org/accessibilityControl-input,< 1K
+Predicate,https://schema.org/accessibilityControl-output,< 1K
+Predicate,https://schema.org/accessibilityFeature,10K - 100K
+Predicate,https://schema.org/accessibilityFeature-input,< 1K
+Predicate,https://schema.org/accessibilityFeature-output,< 1K
+Predicate,https://schema.org/accessibilityHazard,1K - 10K
+Predicate,https://schema.org/accessibilityHazard-input,< 1K
+Predicate,https://schema.org/accessibilityHazard-output,< 1K
+Predicate,https://schema.org/accessibilitySummary,10K - 100K
+Predicate,https://schema.org/accessibilitySummary-input,< 1K
+Predicate,https://schema.org/accessibilitySummary-output,< 1K
+Predicate,https://schema.org/accommodationCategory,1K - 10K
+Predicate,https://schema.org/accommodationCategory-input,< 1K
+Predicate,https://schema.org/accommodationCategory-output,< 1K
+Predicate,https://schema.org/accommodationFloorPlan,10K - 100K
+Predicate,https://schema.org/accommodationFloorPlan-input,< 1K
+Predicate,https://schema.org/accommodationFloorPlan-output,< 1K
+Predicate,https://schema.org/accountId,< 1K
+Predicate,https://schema.org/accountId-input,< 1K
+Predicate,https://schema.org/accountId-output,< 1K
+Predicate,https://schema.org/accountMinimumInflow,< 1K
+Predicate,https://schema.org/accountMinimumInflow-input,< 1K
+Predicate,https://schema.org/accountMinimumInflow-output,< 1K
+Predicate,https://schema.org/accountOverdraftLimit,< 1K
+Predicate,https://schema.org/accountOverdraftLimit-input,< 1K
+Predicate,https://schema.org/accountOverdraftLimit-output,< 1K
+Predicate,https://schema.org/accountablePerson,10K - 100K
+Predicate,https://schema.org/accountablePerson-input,< 1K
+Predicate,https://schema.org/accountablePerson-output,< 1K
+Predicate,https://schema.org/acquireLicensePage,10K - 100K
+Predicate,https://schema.org/acquireLicensePage-input,< 1K
+Predicate,https://schema.org/acquireLicensePage-output,< 1K
+Predicate,https://schema.org/acquiredFrom,< 1K
+Predicate,https://schema.org/acquiredFrom-input,< 1K
+Predicate,https://schema.org/acquiredFrom-output,< 1K
+Predicate,https://schema.org/acrissCode,< 1K
+Predicate,https://schema.org/acrissCode-input,< 1K
+Predicate,https://schema.org/acrissCode-output,< 1K
+Predicate,https://schema.org/actionAccessibilityRequirement,< 1K
+Predicate,https://schema.org/actionAccessibilityRequirement-input,< 1K
+Predicate,https://schema.org/actionAccessibilityRequirement-output,< 1K
+Predicate,https://schema.org/actionApplication,1K - 10K
+Predicate,https://schema.org/actionApplication-input,< 1K
+Predicate,https://schema.org/actionApplication-output,< 1K
+Predicate,https://schema.org/actionOption,1K - 10K
+Predicate,https://schema.org/actionOption-input,< 1K
+Predicate,https://schema.org/actionOption-output,< 1K
+Predicate,https://schema.org/actionPlatform,100K - 1M
+Predicate,https://schema.org/actionPlatform-input,< 1K
+Predicate,https://schema.org/actionPlatform-output,< 1K
+Predicate,https://schema.org/actionProcess,< 1K
+Predicate,https://schema.org/actionProcess-input,< 1K
+Predicate,https://schema.org/actionProcess-output,< 1K
+Predicate,https://schema.org/actionStatus,10K - 100K
+Predicate,https://schema.org/actionStatus-input,< 1K
+Predicate,https://schema.org/actionStatus-output,< 1K
+Predicate,https://schema.org/actionableFeedbackPolicy,10K - 100K
+Predicate,https://schema.org/actionableFeedbackPolicy-input,< 1K
+Predicate,https://schema.org/actionableFeedbackPolicy-output,< 1K
+Predicate,https://schema.org/activeIngredient,1K - 10K
+Predicate,https://schema.org/activeIngredient-input,< 1K
+Predicate,https://schema.org/activeIngredient-output,< 1K
+Predicate,https://schema.org/activityDuration,< 1K
+Predicate,https://schema.org/activityDuration-input,< 1K
+Predicate,https://schema.org/activityDuration-output,< 1K
+Predicate,https://schema.org/activityFrequency,< 1K
+Predicate,https://schema.org/activityFrequency-input,< 1K
+Predicate,https://schema.org/activityFrequency-output,< 1K
+Predicate,https://schema.org/actor,10K - 100K
+Predicate,https://schema.org/actor-input,< 1K
+Predicate,https://schema.org/actor-output,< 1K
+Predicate,https://schema.org/actors,1K - 10K
+Predicate,https://schema.org/actors-input,< 1K
+Predicate,https://schema.org/actors-output,< 1K
+Predicate,https://schema.org/addOn,1K - 10K
+Predicate,https://schema.org/addOn-input,< 1K
+Predicate,https://schema.org/addOn-output,< 1K
+Predicate,https://schema.org/additionalName,10K - 100K
+Predicate,https://schema.org/additionalName-input,< 1K
+Predicate,https://schema.org/additionalName-output,< 1K
+Predicate,https://schema.org/additionalNumberOfGuests,< 1K
+Predicate,https://schema.org/additionalNumberOfGuests-input,< 1K
+Predicate,https://schema.org/additionalNumberOfGuests-output,< 1K
+Predicate,https://schema.org/additionalProperty,100K - 1M
+Predicate,https://schema.org/additionalProperty-input,< 1K
+Predicate,https://schema.org/additionalProperty-output,< 1K
+Predicate,https://schema.org/additionalType,100K - 1M
+Predicate,https://schema.org/additionalType-input,< 1K
+Predicate,https://schema.org/additionalType-output,< 1K
+Predicate,https://schema.org/additionalVariable,< 1K
+Predicate,https://schema.org/additionalVariable-input,< 1K
+Predicate,https://schema.org/additionalVariable-output,< 1K
+Predicate,https://schema.org/address,1M - 10M
+Predicate,https://schema.org/address-input,< 1K
+Predicate,https://schema.org/address-output,< 1K
+Predicate,https://schema.org/addressCountry,1M - 10M
+Predicate,https://schema.org/addressCountry-input,< 1K
+Predicate,https://schema.org/addressCountry-output,< 1K
+Predicate,https://schema.org/addressLocality,1M - 10M
+Predicate,https://schema.org/addressLocality-input,< 1K
+Predicate,https://schema.org/addressLocality-output,< 1K
+Predicate,https://schema.org/addressRegion,1M - 10M
+Predicate,https://schema.org/addressRegion-input,< 1K
+Predicate,https://schema.org/addressRegion-output,< 1K
+Predicate,https://schema.org/administrationRoute,1K - 10K
+Predicate,https://schema.org/administrationRoute-input,< 1K
+Predicate,https://schema.org/administrationRoute-output,< 1K
+Predicate,https://schema.org/advanceBookingRequirement,< 1K
+Predicate,https://schema.org/advanceBookingRequirement-input,< 1K
+Predicate,https://schema.org/advanceBookingRequirement-output,< 1K
+Predicate,https://schema.org/adverseOutcome,< 1K
+Predicate,https://schema.org/adverseOutcome-input,< 1K
+Predicate,https://schema.org/adverseOutcome-output,< 1K
+Predicate,https://schema.org/affectedBy,< 1K
+Predicate,https://schema.org/affectedBy-input,< 1K
+Predicate,https://schema.org/affectedBy-output,< 1K
+Predicate,https://schema.org/affiliation,10K - 100K
+Predicate,https://schema.org/affiliation-input,< 1K
+Predicate,https://schema.org/affiliation-output,< 1K
+Predicate,https://schema.org/afterMedia,< 1K
+Predicate,https://schema.org/afterMedia-input,< 1K
+Predicate,https://schema.org/afterMedia-output,< 1K
+Predicate,https://schema.org/agent,10K - 100K
+Predicate,https://schema.org/agent-input,< 1K
+Predicate,https://schema.org/agent-output,< 1K
+Predicate,https://schema.org/agentInteractionStatistic,10K - 100K
+Predicate,https://schema.org/agentInteractionStatistic-input,< 1K
+Predicate,https://schema.org/agentInteractionStatistic-output,< 1K
+Predicate,https://schema.org/aggregateElement,< 1K
+Predicate,https://schema.org/aggregateElement-input,< 1K
+Predicate,https://schema.org/aggregateElement-output,< 1K
+Predicate,https://schema.org/aggregateRating,1M - 10M
+Predicate,https://schema.org/aggregateRating-input,< 1K
+Predicate,https://schema.org/aggregateRating-output,< 1K
+Predicate,https://schema.org/aircraft,< 1K
+Predicate,https://schema.org/aircraft-input,< 1K
+Predicate,https://schema.org/aircraft-output,< 1K
+Predicate,https://schema.org/album,1K - 10K
+Predicate,https://schema.org/album-input,< 1K
+Predicate,https://schema.org/album-output,< 1K
+Predicate,https://schema.org/albumProductionType,< 1K
+Predicate,https://schema.org/albumProductionType-input,< 1K
+Predicate,https://schema.org/albumProductionType-output,< 1K
+Predicate,https://schema.org/albumRelease,1K - 10K
+Predicate,https://schema.org/albumRelease-input,< 1K
+Predicate,https://schema.org/albumRelease-output,< 1K
+Predicate,https://schema.org/albumReleaseType,1K - 10K
+Predicate,https://schema.org/albumReleaseType-input,< 1K
+Predicate,https://schema.org/albumReleaseType-output,< 1K
+Predicate,https://schema.org/albums,< 1K
+Predicate,https://schema.org/albums-input,< 1K
+Predicate,https://schema.org/albums-output,< 1K
+Predicate,https://schema.org/alcoholWarning,< 1K
+Predicate,https://schema.org/alcoholWarning-input,< 1K
+Predicate,https://schema.org/alcoholWarning-output,< 1K
+Predicate,https://schema.org/algorithm,< 1K
+Predicate,https://schema.org/algorithm-input,< 1K
+Predicate,https://schema.org/algorithm-output,< 1K
+Predicate,https://schema.org/alignmentType,1K - 10K
+Predicate,https://schema.org/alignmentType-input,< 1K
+Predicate,https://schema.org/alignmentType-output,< 1K
+Predicate,https://schema.org/alternateName,1M - 10M
+Predicate,https://schema.org/alternateName-input,< 1K
+Predicate,https://schema.org/alternateName-output,< 1K
+Predicate,https://schema.org/alternativeHeadline,100K - 1M
+Predicate,https://schema.org/alternativeHeadline-input,< 1K
+Predicate,https://schema.org/alternativeHeadline-output,< 1K
+Predicate,https://schema.org/alternativeOf,< 1K
+Predicate,https://schema.org/alternativeOf-input,< 1K
+Predicate,https://schema.org/alternativeOf-output,< 1K
+Predicate,https://schema.org/alumni,1K - 10K
+Predicate,https://schema.org/alumni-input,< 1K
+Predicate,https://schema.org/alumni-output,< 1K
+Predicate,https://schema.org/alumniOf,100K - 1M
+Predicate,https://schema.org/alumniOf-input,< 1K
+Predicate,https://schema.org/alumniOf-output,< 1K
+Predicate,https://schema.org/amenityFeature,100K - 1M
+Predicate,https://schema.org/amenityFeature-input,< 1K
+Predicate,https://schema.org/amenityFeature-output,< 1K
+Predicate,https://schema.org/amount,1K - 10K
+Predicate,https://schema.org/amount-input,< 1K
+Predicate,https://schema.org/amount-output,< 1K
+Predicate,https://schema.org/amountOfThisGood,< 1K
+Predicate,https://schema.org/amountOfThisGood-input,< 1K
+Predicate,https://schema.org/amountOfThisGood-output,< 1K
+Predicate,https://schema.org/announcementLocation,1K - 10K
+Predicate,https://schema.org/announcementLocation-input,< 1K
+Predicate,https://schema.org/announcementLocation-output,< 1K
+Predicate,https://schema.org/annualPercentageRate,1K - 10K
+Predicate,https://schema.org/annualPercentageRate-input,< 1K
+Predicate,https://schema.org/annualPercentageRate-output,< 1K
+Predicate,https://schema.org/answerCount,100K - 1M
+Predicate,https://schema.org/answerCount-input,< 1K
+Predicate,https://schema.org/answerCount-output,< 1K
+Predicate,https://schema.org/answerExplanation,< 1K
+Predicate,https://schema.org/answerExplanation-input,< 1K
+Predicate,https://schema.org/answerExplanation-output,< 1K
+Predicate,https://schema.org/antagonist,< 1K
+Predicate,https://schema.org/antagonist-input,< 1K
+Predicate,https://schema.org/antagonist-output,< 1K
+Predicate,https://schema.org/appearance,1K - 10K
+Predicate,https://schema.org/appearance-input,< 1K
+Predicate,https://schema.org/appearance-output,< 1K
+Predicate,https://schema.org/applicableCountry,100K - 1M
+Predicate,https://schema.org/applicableCountry-input,< 1K
+Predicate,https://schema.org/applicableCountry-output,< 1K
+Predicate,https://schema.org/applicableLocation,< 1K
+Predicate,https://schema.org/applicableLocation-input,< 1K
+Predicate,https://schema.org/applicableLocation-output,< 1K
+Predicate,https://schema.org/applicantLocationRequirements,10K - 100K
+Predicate,https://schema.org/applicantLocationRequirements-input,< 1K
+Predicate,https://schema.org/applicantLocationRequirements-output,< 1K
+Predicate,https://schema.org/application,< 1K
+Predicate,https://schema.org/application-input,< 1K
+Predicate,https://schema.org/application-output,< 1K
+Predicate,https://schema.org/applicationCategory,100K - 1M
+Predicate,https://schema.org/applicationCategory-input,< 1K
+Predicate,https://schema.org/applicationCategory-output,< 1K
+Predicate,https://schema.org/applicationContact,1K - 10K
+Predicate,https://schema.org/applicationContact-input,< 1K
+Predicate,https://schema.org/applicationContact-output,< 1K
+Predicate,https://schema.org/applicationDeadline,< 1K
+Predicate,https://schema.org/applicationDeadline-input,< 1K
+Predicate,https://schema.org/applicationDeadline-output,< 1K
+Predicate,https://schema.org/applicationStartDate,< 1K
+Predicate,https://schema.org/applicationStartDate-input,< 1K
+Predicate,https://schema.org/applicationStartDate-output,< 1K
+Predicate,https://schema.org/applicationSubCategory,10K - 100K
+Predicate,https://schema.org/applicationSubCategory-input,< 1K
+Predicate,https://schema.org/applicationSubCategory-output,< 1K
+Predicate,https://schema.org/applicationSuite,1K - 10K
+Predicate,https://schema.org/applicationSuite-input,< 1K
+Predicate,https://schema.org/applicationSuite-output,< 1K
+Predicate,https://schema.org/appliesToDeliveryMethod,10K - 100K
+Predicate,https://schema.org/appliesToDeliveryMethod-input,< 1K
+Predicate,https://schema.org/appliesToDeliveryMethod-output,< 1K
+Predicate,https://schema.org/appliesToPaymentMethod,< 1K
+Predicate,https://schema.org/appliesToPaymentMethod-input,< 1K
+Predicate,https://schema.org/appliesToPaymentMethod-output,< 1K
+Predicate,https://schema.org/archiveHeld,< 1K
+Predicate,https://schema.org/archiveHeld-input,< 1K
+Predicate,https://schema.org/archiveHeld-output,< 1K
+Predicate,https://schema.org/archivedAt,< 1K
+Predicate,https://schema.org/archivedAt-input,< 1K
+Predicate,https://schema.org/archivedAt-output,< 1K
+Predicate,https://schema.org/area,1K - 10K
+Predicate,https://schema.org/area-input,< 1K
+Predicate,https://schema.org/area-output,< 1K
+Predicate,https://schema.org/areaServed,1M - 10M
+Predicate,https://schema.org/areaServed-input,< 1K
+Predicate,https://schema.org/areaServed-output,< 1K
+Predicate,https://schema.org/arrivalAirport,1K - 10K
+Predicate,https://schema.org/arrivalAirport-input,< 1K
+Predicate,https://schema.org/arrivalAirport-output,< 1K
+Predicate,https://schema.org/arrivalBoatTerminal,< 1K
+Predicate,https://schema.org/arrivalBoatTerminal-input,< 1K
+Predicate,https://schema.org/arrivalBoatTerminal-output,< 1K
+Predicate,https://schema.org/arrivalBusStop,< 1K
+Predicate,https://schema.org/arrivalBusStop-input,< 1K
+Predicate,https://schema.org/arrivalBusStop-output,< 1K
+Predicate,https://schema.org/arrivalGate,< 1K
+Predicate,https://schema.org/arrivalGate-input,< 1K
+Predicate,https://schema.org/arrivalGate-output,< 1K
+Predicate,https://schema.org/arrivalPlatform,< 1K
+Predicate,https://schema.org/arrivalPlatform-input,< 1K
+Predicate,https://schema.org/arrivalPlatform-output,< 1K
+Predicate,https://schema.org/arrivalStation,< 1K
+Predicate,https://schema.org/arrivalStation-input,< 1K
+Predicate,https://schema.org/arrivalStation-output,< 1K
+Predicate,https://schema.org/arrivalTerminal,< 1K
+Predicate,https://schema.org/arrivalTerminal-input,< 1K
+Predicate,https://schema.org/arrivalTerminal-output,< 1K
+Predicate,https://schema.org/arrivalTime,1K - 10K
+Predicate,https://schema.org/arrivalTime-input,< 1K
+Predicate,https://schema.org/arrivalTime-output,< 1K
+Predicate,https://schema.org/artEdition,< 1K
+Predicate,https://schema.org/artEdition-input,< 1K
+Predicate,https://schema.org/artEdition-output,< 1K
+Predicate,https://schema.org/artMedium,1K - 10K
+Predicate,https://schema.org/artMedium-input,< 1K
+Predicate,https://schema.org/artMedium-output,< 1K
+Predicate,https://schema.org/arterialBranch,< 1K
+Predicate,https://schema.org/arterialBranch-input,< 1K
+Predicate,https://schema.org/arterialBranch-output,< 1K
+Predicate,https://schema.org/artform,1K - 10K
+Predicate,https://schema.org/artform-input,< 1K
+Predicate,https://schema.org/artform-output,< 1K
+Predicate,https://schema.org/articleBody,1M - 10M
+Predicate,https://schema.org/articleBody-input,< 1K
+Predicate,https://schema.org/articleBody-output,< 1K
+Predicate,https://schema.org/articleSection,1M - 10M
+Predicate,https://schema.org/articleSection-input,< 1K
+Predicate,https://schema.org/articleSection-output,< 1K
+Predicate,https://schema.org/artist,1K - 10K
+Predicate,https://schema.org/artist-input,< 1K
+Predicate,https://schema.org/artist-output,< 1K
+Predicate,https://schema.org/artworkSurface,< 1K
+Predicate,https://schema.org/artworkSurface-input,< 1K
+Predicate,https://schema.org/artworkSurface-output,< 1K
+Predicate,https://schema.org/asin,< 1K
+Predicate,https://schema.org/asin-input,< 1K
+Predicate,https://schema.org/asin-output,< 1K
+Predicate,https://schema.org/aspect,< 1K
+Predicate,https://schema.org/aspect-input,< 1K
+Predicate,https://schema.org/aspect-output,< 1K
+Predicate,https://schema.org/assembly,< 1K
+Predicate,https://schema.org/assembly-input,< 1K
+Predicate,https://schema.org/assembly-output,< 1K
+Predicate,https://schema.org/assemblyVersion,< 1K
+Predicate,https://schema.org/assemblyVersion-input,< 1K
+Predicate,https://schema.org/assemblyVersion-output,< 1K
+Predicate,https://schema.org/assesses,1K - 10K
+Predicate,https://schema.org/assesses-input,< 1K
+Predicate,https://schema.org/assesses-output,< 1K
+Predicate,https://schema.org/associatedAnatomy,1K - 10K
+Predicate,https://schema.org/associatedAnatomy-input,< 1K
+Predicate,https://schema.org/associatedAnatomy-output,< 1K
+Predicate,https://schema.org/associatedArticle,1K - 10K
+Predicate,https://schema.org/associatedArticle-input,< 1K
+Predicate,https://schema.org/associatedArticle-output,< 1K
+Predicate,https://schema.org/associatedClaimReview,< 1K
+Predicate,https://schema.org/associatedClaimReview-input,< 1K
+Predicate,https://schema.org/associatedClaimReview-output,< 1K
+Predicate,https://schema.org/associatedDisease,< 1K
+Predicate,https://schema.org/associatedDisease-input,< 1K
+Predicate,https://schema.org/associatedDisease-output,< 1K
+Predicate,https://schema.org/associatedMedia,100K - 1M
+Predicate,https://schema.org/associatedMedia-input,< 1K
+Predicate,https://schema.org/associatedMedia-output,< 1K
+Predicate,https://schema.org/associatedMediaReview,< 1K
+Predicate,https://schema.org/associatedMediaReview-input,< 1K
+Predicate,https://schema.org/associatedMediaReview-output,< 1K
+Predicate,https://schema.org/associatedPathophysiology,< 1K
+Predicate,https://schema.org/associatedPathophysiology-input,< 1K
+Predicate,https://schema.org/associatedPathophysiology-output,< 1K
+Predicate,https://schema.org/associatedReview,< 1K
+Predicate,https://schema.org/associatedReview-input,< 1K
+Predicate,https://schema.org/associatedReview-output,< 1K
+Predicate,https://schema.org/athlete,< 1K
+Predicate,https://schema.org/athlete-input,< 1K
+Predicate,https://schema.org/athlete-output,< 1K
+Predicate,https://schema.org/attendee,1K - 10K
+Predicate,https://schema.org/attendee-input,< 1K
+Predicate,https://schema.org/attendee-output,< 1K
+Predicate,https://schema.org/attendees,< 1K
+Predicate,https://schema.org/attendees-input,< 1K
+Predicate,https://schema.org/attendees-output,< 1K
+Predicate,https://schema.org/audience,100K - 1M
+Predicate,https://schema.org/audience-input,< 1K
+Predicate,https://schema.org/audience-output,< 1K
+Predicate,https://schema.org/audienceType,100K - 1M
+Predicate,https://schema.org/audienceType-input,< 1K
+Predicate,https://schema.org/audienceType-output,< 1K
+Predicate,https://schema.org/audio,10K - 100K
+Predicate,https://schema.org/audio-input,< 1K
+Predicate,https://schema.org/audio-output,< 1K
+Predicate,https://schema.org/auditDate,< 1K
+Predicate,https://schema.org/auditDate-input,< 1K
+Predicate,https://schema.org/auditDate-output,< 1K
+Predicate,https://schema.org/authenticator,< 1K
+Predicate,https://schema.org/authenticator-input,< 1K
+Predicate,https://schema.org/authenticator-output,< 1K
+Predicate,https://schema.org/author,10M+
+Predicate,https://schema.org/author-input,< 1K
+Predicate,https://schema.org/author-output,< 1K
+Predicate,https://schema.org/availability,1M - 10M
+Predicate,https://schema.org/availability-input,< 1K
+Predicate,https://schema.org/availability-output,< 1K
+Predicate,https://schema.org/availabilityEnds,1K - 10K
+Predicate,https://schema.org/availabilityEnds-input,< 1K
+Predicate,https://schema.org/availabilityEnds-output,< 1K
+Predicate,https://schema.org/availabilityStarts,10K - 100K
+Predicate,https://schema.org/availabilityStarts-input,< 1K
+Predicate,https://schema.org/availabilityStarts-output,< 1K
+Predicate,https://schema.org/availableAtOrFrom,10K - 100K
+Predicate,https://schema.org/availableAtOrFrom-input,< 1K
+Predicate,https://schema.org/availableAtOrFrom-output,< 1K
+Predicate,https://schema.org/availableChannel,10K - 100K
+Predicate,https://schema.org/availableChannel-input,< 1K
+Predicate,https://schema.org/availableChannel-output,< 1K
+Predicate,https://schema.org/availableDeliveryMethod,10K - 100K
+Predicate,https://schema.org/availableDeliveryMethod-input,< 1K
+Predicate,https://schema.org/availableDeliveryMethod-output,< 1K
+Predicate,https://schema.org/availableFrom,< 1K
+Predicate,https://schema.org/availableFrom-input,< 1K
+Predicate,https://schema.org/availableFrom-output,< 1K
+Predicate,https://schema.org/availableIn,< 1K
+Predicate,https://schema.org/availableIn-input,< 1K
+Predicate,https://schema.org/availableIn-output,< 1K
+Predicate,https://schema.org/availableLanguage,1M - 10M
+Predicate,https://schema.org/availableLanguage-input,< 1K
+Predicate,https://schema.org/availableLanguage-output,< 1K
+Predicate,https://schema.org/availableOnDevice,1K - 10K
+Predicate,https://schema.org/availableOnDevice-input,< 1K
+Predicate,https://schema.org/availableOnDevice-output,< 1K
+Predicate,https://schema.org/availableService,10K - 100K
+Predicate,https://schema.org/availableService-input,< 1K
+Predicate,https://schema.org/availableService-output,< 1K
+Predicate,https://schema.org/availableStrength,< 1K
+Predicate,https://schema.org/availableStrength-input,< 1K
+Predicate,https://schema.org/availableStrength-output,< 1K
+Predicate,https://schema.org/availableTest,< 1K
+Predicate,https://schema.org/availableTest-input,< 1K
+Predicate,https://schema.org/availableTest-output,< 1K
+Predicate,https://schema.org/availableThrough,< 1K
+Predicate,https://schema.org/availableThrough-input,< 1K
+Predicate,https://schema.org/availableThrough-output,< 1K
+Predicate,https://schema.org/award,10K - 100K
+Predicate,https://schema.org/award-input,< 1K
+Predicate,https://schema.org/award-output,< 1K
+Predicate,https://schema.org/awards,1K - 10K
+Predicate,https://schema.org/awards-input,< 1K
+Predicate,https://schema.org/awards-output,< 1K
+Predicate,https://schema.org/awayTeam,10K - 100K
+Predicate,https://schema.org/awayTeam-input,< 1K
+Predicate,https://schema.org/awayTeam-output,< 1K
+Predicate,https://schema.org/backstory,1K - 10K
+Predicate,https://schema.org/backstory-input,< 1K
+Predicate,https://schema.org/backstory-output,< 1K
+Predicate,https://schema.org/bankAccountType,< 1K
+Predicate,https://schema.org/bankAccountType-input,< 1K
+Predicate,https://schema.org/bankAccountType-output,< 1K
+Predicate,https://schema.org/baseSalary,10K - 100K
+Predicate,https://schema.org/baseSalary-input,< 1K
+Predicate,https://schema.org/baseSalary-output,< 1K
+Predicate,https://schema.org/bccRecipient,< 1K
+Predicate,https://schema.org/bccRecipient-input,< 1K
+Predicate,https://schema.org/bccRecipient-output,< 1K
+Predicate,https://schema.org/bed,10K - 100K
+Predicate,https://schema.org/bed-input,< 1K
+Predicate,https://schema.org/bed-output,< 1K
+Predicate,https://schema.org/beforeMedia,< 1K
+Predicate,https://schema.org/beforeMedia-input,< 1K
+Predicate,https://schema.org/beforeMedia-output,< 1K
+Predicate,https://schema.org/beneficiaryBank,< 1K
+Predicate,https://schema.org/beneficiaryBank-input,< 1K
+Predicate,https://schema.org/beneficiaryBank-output,< 1K
+Predicate,https://schema.org/benefits,1K - 10K
+Predicate,https://schema.org/benefits-input,< 1K
+Predicate,https://schema.org/benefits-output,< 1K
+Predicate,https://schema.org/benefitsSummaryUrl,< 1K
+Predicate,https://schema.org/benefitsSummaryUrl-input,< 1K
+Predicate,https://schema.org/benefitsSummaryUrl-output,< 1K
+Predicate,https://schema.org/bestRating,1M - 10M
+Predicate,https://schema.org/bestRating-input,< 1K
+Predicate,https://schema.org/bestRating-output,< 1K
+Predicate,https://schema.org/billingAddress,< 1K
+Predicate,https://schema.org/billingAddress-input,< 1K
+Predicate,https://schema.org/billingAddress-output,< 1K
+Predicate,https://schema.org/billingDuration,10K - 100K
+Predicate,https://schema.org/billingDuration-input,< 1K
+Predicate,https://schema.org/billingDuration-output,< 1K
+Predicate,https://schema.org/billingIncrement,10K - 100K
+Predicate,https://schema.org/billingIncrement-input,< 1K
+Predicate,https://schema.org/billingIncrement-output,< 1K
+Predicate,https://schema.org/billingPeriod,1K - 10K
+Predicate,https://schema.org/billingPeriod-input,< 1K
+Predicate,https://schema.org/billingPeriod-output,< 1K
+Predicate,https://schema.org/billingStart,< 1K
+Predicate,https://schema.org/billingStart-input,< 1K
+Predicate,https://schema.org/billingStart-output,< 1K
+Predicate,https://schema.org/bioChemInteraction,< 1K
+Predicate,https://schema.org/bioChemInteraction-input,< 1K
+Predicate,https://schema.org/bioChemInteraction-output,< 1K
+Predicate,https://schema.org/bioChemSimilarity,< 1K
+Predicate,https://schema.org/bioChemSimilarity-input,< 1K
+Predicate,https://schema.org/bioChemSimilarity-output,< 1K
+Predicate,https://schema.org/biologicalRole,< 1K
+Predicate,https://schema.org/biologicalRole-input,< 1K
+Predicate,https://schema.org/biologicalRole-output,< 1K
+Predicate,https://schema.org/biomechnicalClass,< 1K
+Predicate,https://schema.org/biomechnicalClass-input,< 1K
+Predicate,https://schema.org/biomechnicalClass-output,< 1K
+Predicate,https://schema.org/birthDate,10K - 100K
+Predicate,https://schema.org/birthDate-input,< 1K
+Predicate,https://schema.org/birthDate-output,< 1K
+Predicate,https://schema.org/birthPlace,10K - 100K
+Predicate,https://schema.org/birthPlace-input,< 1K
+Predicate,https://schema.org/birthPlace-output,< 1K
+Predicate,https://schema.org/bitrate,1K - 10K
+Predicate,https://schema.org/bitrate-input,< 1K
+Predicate,https://schema.org/bitrate-output,< 1K
+Predicate,https://schema.org/blogPost,100K - 1M
+Predicate,https://schema.org/blogPost-input,< 1K
+Predicate,https://schema.org/blogPost-output,< 1K
+Predicate,https://schema.org/blogPosts,10K - 100K
+Predicate,https://schema.org/blogPosts-input,< 1K
+Predicate,https://schema.org/blogPosts-output,< 1K
+Predicate,https://schema.org/bloodSupply,< 1K
+Predicate,https://schema.org/bloodSupply-input,< 1K
+Predicate,https://schema.org/bloodSupply-output,< 1K
+Predicate,https://schema.org/boardingGroup,< 1K
+Predicate,https://schema.org/boardingGroup-input,< 1K
+Predicate,https://schema.org/boardingGroup-output,< 1K
+Predicate,https://schema.org/boardingPolicy,< 1K
+Predicate,https://schema.org/boardingPolicy-input,< 1K
+Predicate,https://schema.org/boardingPolicy-output,< 1K
+Predicate,https://schema.org/bodyLocation,1K - 10K
+Predicate,https://schema.org/bodyLocation-input,< 1K
+Predicate,https://schema.org/bodyLocation-output,< 1K
+Predicate,https://schema.org/bodyType,10K - 100K
+Predicate,https://schema.org/bodyType-input,< 1K
+Predicate,https://schema.org/bodyType-output,< 1K
+Predicate,https://schema.org/bookEdition,1K - 10K
+Predicate,https://schema.org/bookEdition-input,< 1K
+Predicate,https://schema.org/bookEdition-output,< 1K
+Predicate,https://schema.org/bookFormat,10K - 100K
+Predicate,https://schema.org/bookFormat-input,< 1K
+Predicate,https://schema.org/bookFormat-output,< 1K
+Predicate,https://schema.org/bookingAgent,< 1K
+Predicate,https://schema.org/bookingAgent-input,< 1K
+Predicate,https://schema.org/bookingAgent-output,< 1K
+Predicate,https://schema.org/bookingTime,< 1K
+Predicate,https://schema.org/bookingTime-input,< 1K
+Predicate,https://schema.org/bookingTime-output,< 1K
+Predicate,https://schema.org/borrower,< 1K
+Predicate,https://schema.org/borrower-input,< 1K
+Predicate,https://schema.org/borrower-output,< 1K
+Predicate,https://schema.org/box,1K - 10K
+Predicate,https://schema.org/box-input,< 1K
+Predicate,https://schema.org/box-output,< 1K
+Predicate,https://schema.org/branch,< 1K
+Predicate,https://schema.org/branch-input,< 1K
+Predicate,https://schema.org/branch-output,< 1K
+Predicate,https://schema.org/branchCode,1K - 10K
+Predicate,https://schema.org/branchCode-input,< 1K
+Predicate,https://schema.org/branchCode-output,< 1K
+Predicate,https://schema.org/branchOf,10K - 100K
+Predicate,https://schema.org/branchOf-input,< 1K
+Predicate,https://schema.org/branchOf-output,< 1K
+Predicate,https://schema.org/brand,1M - 10M
+Predicate,https://schema.org/brand-input,< 1K
+Predicate,https://schema.org/brand-output,< 1K
+Predicate,https://schema.org/breadcrumb,10M+
+Predicate,https://schema.org/breadcrumb-input,< 1K
+Predicate,https://schema.org/breadcrumb-output,< 1K
+Predicate,https://schema.org/breastfeedingWarning,< 1K
+Predicate,https://schema.org/breastfeedingWarning-input,< 1K
+Predicate,https://schema.org/breastfeedingWarning-output,< 1K
+Predicate,https://schema.org/broadcastAffiliateOf,< 1K
+Predicate,https://schema.org/broadcastAffiliateOf-input,< 1K
+Predicate,https://schema.org/broadcastAffiliateOf-output,< 1K
+Predicate,https://schema.org/broadcastChannelId,< 1K
+Predicate,https://schema.org/broadcastChannelId-input,< 1K
+Predicate,https://schema.org/broadcastChannelId-output,< 1K
+Predicate,https://schema.org/broadcastDisplayName,1K - 10K
+Predicate,https://schema.org/broadcastDisplayName-input,< 1K
+Predicate,https://schema.org/broadcastDisplayName-output,< 1K
+Predicate,https://schema.org/broadcastFrequency,1K - 10K
+Predicate,https://schema.org/broadcastFrequency-input,< 1K
+Predicate,https://schema.org/broadcastFrequency-output,< 1K
+Predicate,https://schema.org/broadcastFrequencyValue,< 1K
+Predicate,https://schema.org/broadcastFrequencyValue-input,< 1K
+Predicate,https://schema.org/broadcastFrequencyValue-output,< 1K
+Predicate,https://schema.org/broadcastOfEvent,< 1K
+Predicate,https://schema.org/broadcastOfEvent-input,< 1K
+Predicate,https://schema.org/broadcastOfEvent-output,< 1K
+Predicate,https://schema.org/broadcastServiceTier,< 1K
+Predicate,https://schema.org/broadcastServiceTier-input,< 1K
+Predicate,https://schema.org/broadcastServiceTier-output,< 1K
+Predicate,https://schema.org/broadcastSignalModulation,< 1K
+Predicate,https://schema.org/broadcastSignalModulation-input,< 1K
+Predicate,https://schema.org/broadcastSignalModulation-output,< 1K
+Predicate,https://schema.org/broadcastSubChannel,< 1K
+Predicate,https://schema.org/broadcastSubChannel-input,< 1K
+Predicate,https://schema.org/broadcastSubChannel-output,< 1K
+Predicate,https://schema.org/broadcastTimezone,< 1K
+Predicate,https://schema.org/broadcastTimezone-input,< 1K
+Predicate,https://schema.org/broadcastTimezone-output,< 1K
+Predicate,https://schema.org/broadcaster,< 1K
+Predicate,https://schema.org/broadcaster-input,< 1K
+Predicate,https://schema.org/broadcaster-output,< 1K
+Predicate,https://schema.org/broker,1K - 10K
+Predicate,https://schema.org/broker-input,< 1K
+Predicate,https://schema.org/broker-output,< 1K
+Predicate,https://schema.org/browserRequirements,10K - 100K
+Predicate,https://schema.org/browserRequirements-input,< 1K
+Predicate,https://schema.org/browserRequirements-output,< 1K
+Predicate,https://schema.org/busName,< 1K
+Predicate,https://schema.org/busName-input,< 1K
+Predicate,https://schema.org/busName-output,< 1K
+Predicate,https://schema.org/busNumber,< 1K
+Predicate,https://schema.org/busNumber-input,< 1K
+Predicate,https://schema.org/busNumber-output,< 1K
+Predicate,https://schema.org/businessDays,10K - 100K
+Predicate,https://schema.org/businessDays-input,< 1K
+Predicate,https://schema.org/businessDays-output,< 1K
+Predicate,https://schema.org/businessFunction,10K - 100K
+Predicate,https://schema.org/businessFunction-input,< 1K
+Predicate,https://schema.org/businessFunction-output,< 1K
+Predicate,https://schema.org/buyer,< 1K
+Predicate,https://schema.org/buyer-input,< 1K
+Predicate,https://schema.org/buyer-output,< 1K
+Predicate,https://schema.org/byArtist,10K - 100K
+Predicate,https://schema.org/byArtist-input,< 1K
+Predicate,https://schema.org/byArtist-output,< 1K
+Predicate,https://schema.org/byDay,1K - 10K
+Predicate,https://schema.org/byDay-input,< 1K
+Predicate,https://schema.org/byDay-output,< 1K
+Predicate,https://schema.org/byMonth,< 1K
+Predicate,https://schema.org/byMonth-input,< 1K
+Predicate,https://schema.org/byMonth-output,< 1K
+Predicate,https://schema.org/byMonthDay,< 1K
+Predicate,https://schema.org/byMonthDay-input,< 1K
+Predicate,https://schema.org/byMonthDay-output,< 1K
+Predicate,https://schema.org/byMonthWeek,< 1K
+Predicate,https://schema.org/byMonthWeek-input,< 1K
+Predicate,https://schema.org/byMonthWeek-output,< 1K
+Predicate,https://schema.org/callSign,< 1K
+Predicate,https://schema.org/callSign-input,< 1K
+Predicate,https://schema.org/callSign-output,< 1K
+Predicate,https://schema.org/calories,10K - 100K
+Predicate,https://schema.org/calories-input,< 1K
+Predicate,https://schema.org/calories-output,< 1K
+Predicate,https://schema.org/candidate,< 1K
+Predicate,https://schema.org/candidate-input,< 1K
+Predicate,https://schema.org/candidate-output,< 1K
+Predicate,https://schema.org/caption,10M+
+Predicate,https://schema.org/caption-input,< 1K
+Predicate,https://schema.org/caption-output,< 1K
+Predicate,https://schema.org/carbohydrateContent,10K - 100K
+Predicate,https://schema.org/carbohydrateContent-input,< 1K
+Predicate,https://schema.org/carbohydrateContent-output,< 1K
+Predicate,https://schema.org/cargoVolume,1K - 10K
+Predicate,https://schema.org/cargoVolume-input,< 1K
+Predicate,https://schema.org/cargoVolume-output,< 1K
+Predicate,https://schema.org/carrier,< 1K
+Predicate,https://schema.org/carrier-input,< 1K
+Predicate,https://schema.org/carrier-output,< 1K
+Predicate,https://schema.org/carrierRequirements,< 1K
+Predicate,https://schema.org/carrierRequirements-input,< 1K
+Predicate,https://schema.org/carrierRequirements-output,< 1K
+Predicate,https://schema.org/cashBack,< 1K
+Predicate,https://schema.org/cashBack-input,< 1K
+Predicate,https://schema.org/cashBack-output,< 1K
+Predicate,https://schema.org/catalog,< 1K
+Predicate,https://schema.org/catalog-input,< 1K
+Predicate,https://schema.org/catalog-output,< 1K
+Predicate,https://schema.org/catalogNumber,< 1K
+Predicate,https://schema.org/catalogNumber-input,< 1K
+Predicate,https://schema.org/catalogNumber-output,< 1K
+Predicate,https://schema.org/category,1M - 10M
+Predicate,https://schema.org/category-input,< 1K
+Predicate,https://schema.org/category-output,< 1K
+Predicate,https://schema.org/cause,1K - 10K
+Predicate,https://schema.org/cause-input,< 1K
+Predicate,https://schema.org/cause-output,< 1K
+Predicate,https://schema.org/causeOf,< 1K
+Predicate,https://schema.org/causeOf-input,< 1K
+Predicate,https://schema.org/causeOf-output,< 1K
+Predicate,https://schema.org/ccRecipient,< 1K
+Predicate,https://schema.org/ccRecipient-input,< 1K
+Predicate,https://schema.org/ccRecipient-output,< 1K
+Predicate,https://schema.org/certificationIdentification,1K - 10K
+Predicate,https://schema.org/certificationIdentification-input,< 1K
+Predicate,https://schema.org/certificationIdentification-output,< 1K
+Predicate,https://schema.org/certificationRating,< 1K
+Predicate,https://schema.org/certificationRating-input,< 1K
+Predicate,https://schema.org/certificationRating-output,< 1K
+Predicate,https://schema.org/certificationStatus,< 1K
+Predicate,https://schema.org/certificationStatus-input,< 1K
+Predicate,https://schema.org/certificationStatus-output,< 1K
+Predicate,https://schema.org/character,< 1K
+Predicate,https://schema.org/character-input,< 1K
+Predicate,https://schema.org/character-output,< 1K
+Predicate,https://schema.org/characterAttribute,< 1K
+Predicate,https://schema.org/characterAttribute-input,< 1K
+Predicate,https://schema.org/characterAttribute-output,< 1K
+Predicate,https://schema.org/characterName,< 1K
+Predicate,https://schema.org/characterName-input,< 1K
+Predicate,https://schema.org/characterName-output,< 1K
+Predicate,https://schema.org/cheatCode,< 1K
+Predicate,https://schema.org/cheatCode-input,< 1K
+Predicate,https://schema.org/cheatCode-output,< 1K
+Predicate,https://schema.org/checkinTime,10K - 100K
+Predicate,https://schema.org/checkinTime-input,< 1K
+Predicate,https://schema.org/checkinTime-output,< 1K
+Predicate,https://schema.org/checkoutPageURLTemplate,10K - 100K
+Predicate,https://schema.org/checkoutPageURLTemplate-input,< 1K
+Predicate,https://schema.org/checkoutPageURLTemplate-output,< 1K
+Predicate,https://schema.org/checkoutTime,10K - 100K
+Predicate,https://schema.org/checkoutTime-input,< 1K
+Predicate,https://schema.org/checkoutTime-output,< 1K
+Predicate,https://schema.org/chemicalComposition,< 1K
+Predicate,https://schema.org/chemicalComposition-input,< 1K
+Predicate,https://schema.org/chemicalComposition-output,< 1K
+Predicate,https://schema.org/chemicalRole,< 1K
+Predicate,https://schema.org/chemicalRole-input,< 1K
+Predicate,https://schema.org/chemicalRole-output,< 1K
+Predicate,https://schema.org/childMaxAge,< 1K
+Predicate,https://schema.org/childMaxAge-input,< 1K
+Predicate,https://schema.org/childMaxAge-output,< 1K
+Predicate,https://schema.org/childMinAge,< 1K
+Predicate,https://schema.org/childMinAge-input,< 1K
+Predicate,https://schema.org/childMinAge-output,< 1K
+Predicate,https://schema.org/childTaxon,< 1K
+Predicate,https://schema.org/childTaxon-input,< 1K
+Predicate,https://schema.org/childTaxon-output,< 1K
+Predicate,https://schema.org/children,1K - 10K
+Predicate,https://schema.org/children-input,< 1K
+Predicate,https://schema.org/children-output,< 1K
+Predicate,https://schema.org/cholesterolContent,10K - 100K
+Predicate,https://schema.org/cholesterolContent-input,< 1K
+Predicate,https://schema.org/cholesterolContent-output,< 1K
+Predicate,https://schema.org/circle,1K - 10K
+Predicate,https://schema.org/circle-input,< 1K
+Predicate,https://schema.org/circle-output,< 1K
+Predicate,https://schema.org/citation,10K - 100K
+Predicate,https://schema.org/citation-input,< 1K
+Predicate,https://schema.org/citation-output,< 1K
+Predicate,https://schema.org/claimInterpreter,< 1K
+Predicate,https://schema.org/claimInterpreter-input,< 1K
+Predicate,https://schema.org/claimInterpreter-output,< 1K
+Predicate,https://schema.org/claimReviewed,1K - 10K
+Predicate,https://schema.org/claimReviewed-input,< 1K
+Predicate,https://schema.org/claimReviewed-output,< 1K
+Predicate,https://schema.org/clincalPharmacology,< 1K
+Predicate,https://schema.org/clincalPharmacology-input,< 1K
+Predicate,https://schema.org/clincalPharmacology-output,< 1K
+Predicate,https://schema.org/clinicalPharmacology,< 1K
+Predicate,https://schema.org/clinicalPharmacology-input,< 1K
+Predicate,https://schema.org/clinicalPharmacology-output,< 1K
+Predicate,https://schema.org/clipNumber,< 1K
+Predicate,https://schema.org/clipNumber-input,< 1K
+Predicate,https://schema.org/clipNumber-output,< 1K
+Predicate,https://schema.org/closes,1M - 10M
+Predicate,https://schema.org/closes-input,< 1K
+Predicate,https://schema.org/closes-output,< 1K
+Predicate,https://schema.org/coach,< 1K
+Predicate,https://schema.org/coach-input,< 1K
+Predicate,https://schema.org/coach-output,< 1K
+Predicate,https://schema.org/code,1K - 10K
+Predicate,https://schema.org/code-input,< 1K
+Predicate,https://schema.org/code-output,< 1K
+Predicate,https://schema.org/codeRepository,1K - 10K
+Predicate,https://schema.org/codeRepository-input,< 1K
+Predicate,https://schema.org/codeRepository-output,< 1K
+Predicate,https://schema.org/codeSampleType,< 1K
+Predicate,https://schema.org/codeSampleType-input,< 1K
+Predicate,https://schema.org/codeSampleType-output,< 1K
+Predicate,https://schema.org/codeValue,1K - 10K
+Predicate,https://schema.org/codeValue-input,< 1K
+Predicate,https://schema.org/codeValue-output,< 1K
+Predicate,https://schema.org/codingSystem,1K - 10K
+Predicate,https://schema.org/codingSystem-input,< 1K
+Predicate,https://schema.org/codingSystem-output,< 1K
+Predicate,https://schema.org/colleague,1K - 10K
+Predicate,https://schema.org/colleague-input,< 1K
+Predicate,https://schema.org/colleague-output,< 1K
+Predicate,https://schema.org/colleagues,< 1K
+Predicate,https://schema.org/colleagues-input,< 1K
+Predicate,https://schema.org/colleagues-output,< 1K
+Predicate,https://schema.org/collection,< 1K
+Predicate,https://schema.org/collection-input,< 1K
+Predicate,https://schema.org/collection-output,< 1K
+Predicate,https://schema.org/collectionSize,1K - 10K
+Predicate,https://schema.org/collectionSize-input,< 1K
+Predicate,https://schema.org/collectionSize-output,< 1K
+Predicate,https://schema.org/color,100K - 1M
+Predicate,https://schema.org/color-input,< 1K
+Predicate,https://schema.org/color-output,< 1K
+Predicate,https://schema.org/colorSwatch,< 1K
+Predicate,https://schema.org/colorSwatch-input,< 1K
+Predicate,https://schema.org/colorSwatch-output,< 1K
+Predicate,https://schema.org/colorist,< 1K
+Predicate,https://schema.org/colorist-input,< 1K
+Predicate,https://schema.org/colorist-output,< 1K
+Predicate,https://schema.org/comment,10K - 100K
+Predicate,https://schema.org/comment-input,< 1K
+Predicate,https://schema.org/comment-output,< 1K
+Predicate,https://schema.org/commentCount,1M - 10M
+Predicate,https://schema.org/commentCount-input,< 1K
+Predicate,https://schema.org/commentCount-output,< 1K
+Predicate,https://schema.org/commentText,10K - 100K
+Predicate,https://schema.org/commentText-input,< 1K
+Predicate,https://schema.org/commentText-output,< 1K
+Predicate,https://schema.org/commentTime,10K - 100K
+Predicate,https://schema.org/commentTime-input,< 1K
+Predicate,https://schema.org/commentTime-output,< 1K
+Predicate,https://schema.org/companyRegistration,< 1K
+Predicate,https://schema.org/companyRegistration-input,< 1K
+Predicate,https://schema.org/companyRegistration-output,< 1K
+Predicate,https://schema.org/competencyRequired,1K - 10K
+Predicate,https://schema.org/competencyRequired-input,< 1K
+Predicate,https://schema.org/competencyRequired-output,< 1K
+Predicate,https://schema.org/competitor,1K - 10K
+Predicate,https://schema.org/competitor-input,< 1K
+Predicate,https://schema.org/competitor-output,< 1K
+Predicate,https://schema.org/composer,1K - 10K
+Predicate,https://schema.org/composer-input,< 1K
+Predicate,https://schema.org/composer-output,< 1K
+Predicate,https://schema.org/comprisedOf,< 1K
+Predicate,https://schema.org/comprisedOf-input,< 1K
+Predicate,https://schema.org/comprisedOf-output,< 1K
+Predicate,https://schema.org/conditionsOfAccess,< 1K
+Predicate,https://schema.org/conditionsOfAccess-input,< 1K
+Predicate,https://schema.org/conditionsOfAccess-output,< 1K
+Predicate,https://schema.org/confirmationNumber,< 1K
+Predicate,https://schema.org/confirmationNumber-input,< 1K
+Predicate,https://schema.org/confirmationNumber-output,< 1K
+Predicate,https://schema.org/connectedTo,< 1K
+Predicate,https://schema.org/connectedTo-input,< 1K
+Predicate,https://schema.org/connectedTo-output,< 1K
+Predicate,https://schema.org/constraintProperty,< 1K
+Predicate,https://schema.org/constraintProperty-input,< 1K
+Predicate,https://schema.org/constraintProperty-output,< 1K
+Predicate,https://schema.org/contactOption,100K - 1M
+Predicate,https://schema.org/contactOption-input,< 1K
+Predicate,https://schema.org/contactOption-output,< 1K
+Predicate,https://schema.org/contactPoint,1M - 10M
+Predicate,https://schema.org/contactPoint-input,< 1K
+Predicate,https://schema.org/contactPoint-output,< 1K
+Predicate,https://schema.org/contactPoints,< 1K
+Predicate,https://schema.org/contactPoints-input,< 1K
+Predicate,https://schema.org/contactPoints-output,< 1K
+Predicate,https://schema.org/contactType,1M - 10M
+Predicate,https://schema.org/contactType-input,< 1K
+Predicate,https://schema.org/contactType-output,< 1K
+Predicate,https://schema.org/contactlessPayment,< 1K
+Predicate,https://schema.org/contactlessPayment-input,< 1K
+Predicate,https://schema.org/contactlessPayment-output,< 1K
+Predicate,https://schema.org/containedIn,1K - 10K
+Predicate,https://schema.org/containedIn-input,< 1K
+Predicate,https://schema.org/containedIn-output,< 1K
+Predicate,https://schema.org/containedInPlace,100K - 1M
+Predicate,https://schema.org/containedInPlace-input,< 1K
+Predicate,https://schema.org/containedInPlace-output,< 1K
+Predicate,https://schema.org/containsPlace,10K - 100K
+Predicate,https://schema.org/containsPlace-input,< 1K
+Predicate,https://schema.org/containsPlace-output,< 1K
+Predicate,https://schema.org/containsSeason,1K - 10K
+Predicate,https://schema.org/containsSeason-input,< 1K
+Predicate,https://schema.org/containsSeason-output,< 1K
+Predicate,https://schema.org/contentLocation,10K - 100K
+Predicate,https://schema.org/contentLocation-input,< 1K
+Predicate,https://schema.org/contentLocation-output,< 1K
+Predicate,https://schema.org/contentRating,10K - 100K
+Predicate,https://schema.org/contentRating-input,< 1K
+Predicate,https://schema.org/contentRating-output,< 1K
+Predicate,https://schema.org/contentReferenceTime,1K - 10K
+Predicate,https://schema.org/contentReferenceTime-input,< 1K
+Predicate,https://schema.org/contentReferenceTime-output,< 1K
+Predicate,https://schema.org/contentSize,100K - 1M
+Predicate,https://schema.org/contentSize-input,< 1K
+Predicate,https://schema.org/contentSize-output,< 1K
+Predicate,https://schema.org/contentType,1K - 10K
+Predicate,https://schema.org/contentType-input,< 1K
+Predicate,https://schema.org/contentType-output,< 1K
+Predicate,https://schema.org/contentUrl,10M+
+Predicate,https://schema.org/contentUrl-input,< 1K
+Predicate,https://schema.org/contentUrl-output,< 1K
+Predicate,https://schema.org/contraindication,< 1K
+Predicate,https://schema.org/contraindication-input,< 1K
+Predicate,https://schema.org/contraindication-output,< 1K
+Predicate,https://schema.org/contributor,100K - 1M
+Predicate,https://schema.org/contributor-input,< 1K
+Predicate,https://schema.org/contributor-output,< 1K
+Predicate,https://schema.org/cookTime,10K - 100K
+Predicate,https://schema.org/cookTime-input,< 1K
+Predicate,https://schema.org/cookTime-output,< 1K
+Predicate,https://schema.org/cookingMethod,1K - 10K
+Predicate,https://schema.org/cookingMethod-input,< 1K
+Predicate,https://schema.org/cookingMethod-output,< 1K
+Predicate,https://schema.org/copyrightHolder,100K - 1M
+Predicate,https://schema.org/copyrightHolder-input,< 1K
+Predicate,https://schema.org/copyrightHolder-output,< 1K
+Predicate,https://schema.org/copyrightNotice,10K - 100K
+Predicate,https://schema.org/copyrightNotice-input,< 1K
+Predicate,https://schema.org/copyrightNotice-output,< 1K
+Predicate,https://schema.org/copyrightYear,100K - 1M
+Predicate,https://schema.org/copyrightYear-input,< 1K
+Predicate,https://schema.org/copyrightYear-output,< 1K
+Predicate,https://schema.org/correction,< 1K
+Predicate,https://schema.org/correction-input,< 1K
+Predicate,https://schema.org/correction-output,< 1K
+Predicate,https://schema.org/correctionsPolicy,10K - 100K
+Predicate,https://schema.org/correctionsPolicy-input,< 1K
+Predicate,https://schema.org/correctionsPolicy-output,< 1K
+Predicate,https://schema.org/costCategory,< 1K
+Predicate,https://schema.org/costCategory-input,< 1K
+Predicate,https://schema.org/costCategory-output,< 1K
+Predicate,https://schema.org/costCurrency,< 1K
+Predicate,https://schema.org/costCurrency-input,< 1K
+Predicate,https://schema.org/costCurrency-output,< 1K
+Predicate,https://schema.org/costOrigin,< 1K
+Predicate,https://schema.org/costOrigin-input,< 1K
+Predicate,https://schema.org/costOrigin-output,< 1K
+Predicate,https://schema.org/costPerUnit,< 1K
+Predicate,https://schema.org/costPerUnit-input,< 1K
+Predicate,https://schema.org/costPerUnit-output,< 1K
+Predicate,https://schema.org/countriesNotSupported,< 1K
+Predicate,https://schema.org/countriesNotSupported-input,< 1K
+Predicate,https://schema.org/countriesNotSupported-output,< 1K
+Predicate,https://schema.org/countriesSupported,1K - 10K
+Predicate,https://schema.org/countriesSupported-input,< 1K
+Predicate,https://schema.org/countriesSupported-output,< 1K
+Predicate,https://schema.org/countryOfAssembly,1K - 10K
+Predicate,https://schema.org/countryOfAssembly-input,< 1K
+Predicate,https://schema.org/countryOfAssembly-output,< 1K
+Predicate,https://schema.org/countryOfLastProcessing,< 1K
+Predicate,https://schema.org/countryOfLastProcessing-input,< 1K
+Predicate,https://schema.org/countryOfLastProcessing-output,< 1K
+Predicate,https://schema.org/countryOfOrigin,10K - 100K
+Predicate,https://schema.org/countryOfOrigin-input,< 1K
+Predicate,https://schema.org/countryOfOrigin-output,< 1K
+Predicate,https://schema.org/course,< 1K
+Predicate,https://schema.org/course-input,< 1K
+Predicate,https://schema.org/course-output,< 1K
+Predicate,https://schema.org/courseCode,1K - 10K
+Predicate,https://schema.org/courseCode-input,< 1K
+Predicate,https://schema.org/courseCode-output,< 1K
+Predicate,https://schema.org/courseMode,10K - 100K
+Predicate,https://schema.org/courseMode-input,< 1K
+Predicate,https://schema.org/courseMode-output,< 1K
+Predicate,https://schema.org/coursePrerequisites,1K - 10K
+Predicate,https://schema.org/coursePrerequisites-input,< 1K
+Predicate,https://schema.org/coursePrerequisites-output,< 1K
+Predicate,https://schema.org/courseSchedule,1K - 10K
+Predicate,https://schema.org/courseSchedule-input,< 1K
+Predicate,https://schema.org/courseSchedule-output,< 1K
+Predicate,https://schema.org/courseWorkload,10K - 100K
+Predicate,https://schema.org/courseWorkload-input,< 1K
+Predicate,https://schema.org/courseWorkload-output,< 1K
+Predicate,https://schema.org/coverageEndTime,1K - 10K
+Predicate,https://schema.org/coverageEndTime-input,< 1K
+Predicate,https://schema.org/coverageEndTime-output,< 1K
+Predicate,https://schema.org/coverageStartTime,1K - 10K
+Predicate,https://schema.org/coverageStartTime-input,< 1K
+Predicate,https://schema.org/coverageStartTime-output,< 1K
+Predicate,https://schema.org/creativeWorkStatus,1K - 10K
+Predicate,https://schema.org/creativeWorkStatus-input,< 1K
+Predicate,https://schema.org/creativeWorkStatus-output,< 1K
+Predicate,https://schema.org/creator,1M - 10M
+Predicate,https://schema.org/creator-input,< 1K
+Predicate,https://schema.org/creator-output,< 1K
+Predicate,https://schema.org/credentialCategory,10K - 100K
+Predicate,https://schema.org/credentialCategory-input,< 1K
+Predicate,https://schema.org/credentialCategory-output,< 1K
+Predicate,https://schema.org/creditText,10K - 100K
+Predicate,https://schema.org/creditText-input,< 1K
+Predicate,https://schema.org/creditText-output,< 1K
+Predicate,https://schema.org/creditedTo,< 1K
+Predicate,https://schema.org/creditedTo-input,< 1K
+Predicate,https://schema.org/creditedTo-output,< 1K
+Predicate,https://schema.org/cssSelector,100K - 1M
+Predicate,https://schema.org/cssSelector-input,< 1K
+Predicate,https://schema.org/cssSelector-output,< 1K
+Predicate,https://schema.org/currenciesAccepted,100K - 1M
+Predicate,https://schema.org/currenciesAccepted-input,< 1K
+Predicate,https://schema.org/currenciesAccepted-output,< 1K
+Predicate,https://schema.org/currency,100K - 1M
+Predicate,https://schema.org/currency-input,< 1K
+Predicate,https://schema.org/currency-output,< 1K
+Predicate,https://schema.org/currentExchangeRate,< 1K
+Predicate,https://schema.org/currentExchangeRate-input,< 1K
+Predicate,https://schema.org/currentExchangeRate-output,< 1K
+Predicate,https://schema.org/customer,< 1K
+Predicate,https://schema.org/customer-input,< 1K
+Predicate,https://schema.org/customer-output,< 1K
+Predicate,https://schema.org/customerRemorseReturnFees,1K - 10K
+Predicate,https://schema.org/customerRemorseReturnFees-input,< 1K
+Predicate,https://schema.org/customerRemorseReturnFees-output,< 1K
+Predicate,https://schema.org/customerRemorseReturnLabelSource,< 1K
+Predicate,https://schema.org/customerRemorseReturnLabelSource-input,< 1K
+Predicate,https://schema.org/customerRemorseReturnLabelSource-output,< 1K
+Predicate,https://schema.org/customerRemorseReturnShippingFeesAmount,< 1K
+Predicate,https://schema.org/customerRemorseReturnShippingFeesAmount-input,< 1K
+Predicate,https://schema.org/customerRemorseReturnShippingFeesAmount-output,< 1K
+Predicate,https://schema.org/cutoffTime,10K - 100K
+Predicate,https://schema.org/cutoffTime-input,< 1K
+Predicate,https://schema.org/cutoffTime-output,< 1K
+Predicate,https://schema.org/cvdCollectionDate,< 1K
+Predicate,https://schema.org/cvdCollectionDate-input,< 1K
+Predicate,https://schema.org/cvdCollectionDate-output,< 1K
+Predicate,https://schema.org/cvdFacilityCounty,< 1K
+Predicate,https://schema.org/cvdFacilityCounty-input,< 1K
+Predicate,https://schema.org/cvdFacilityCounty-output,< 1K
+Predicate,https://schema.org/cvdFacilityId,< 1K
+Predicate,https://schema.org/cvdFacilityId-input,< 1K
+Predicate,https://schema.org/cvdFacilityId-output,< 1K
+Predicate,https://schema.org/cvdNumBeds,< 1K
+Predicate,https://schema.org/cvdNumBeds-input,< 1K
+Predicate,https://schema.org/cvdNumBeds-output,< 1K
+Predicate,https://schema.org/cvdNumBedsOcc,< 1K
+Predicate,https://schema.org/cvdNumBedsOcc-input,< 1K
+Predicate,https://schema.org/cvdNumBedsOcc-output,< 1K
+Predicate,https://schema.org/cvdNumC19Died,< 1K
+Predicate,https://schema.org/cvdNumC19Died-input,< 1K
+Predicate,https://schema.org/cvdNumC19Died-output,< 1K
+Predicate,https://schema.org/cvdNumC19HOPats,< 1K
+Predicate,https://schema.org/cvdNumC19HOPats-input,< 1K
+Predicate,https://schema.org/cvdNumC19HOPats-output,< 1K
+Predicate,https://schema.org/cvdNumC19HospPats,< 1K
+Predicate,https://schema.org/cvdNumC19HospPats-input,< 1K
+Predicate,https://schema.org/cvdNumC19HospPats-output,< 1K
+Predicate,https://schema.org/cvdNumC19MechVentPats,< 1K
+Predicate,https://schema.org/cvdNumC19MechVentPats-input,< 1K
+Predicate,https://schema.org/cvdNumC19MechVentPats-output,< 1K
+Predicate,https://schema.org/cvdNumC19OFMechVentPats,< 1K
+Predicate,https://schema.org/cvdNumC19OFMechVentPats-input,< 1K
+Predicate,https://schema.org/cvdNumC19OFMechVentPats-output,< 1K
+Predicate,https://schema.org/cvdNumC19OverflowPats,< 1K
+Predicate,https://schema.org/cvdNumC19OverflowPats-input,< 1K
+Predicate,https://schema.org/cvdNumC19OverflowPats-output,< 1K
+Predicate,https://schema.org/cvdNumICUBeds,< 1K
+Predicate,https://schema.org/cvdNumICUBeds-input,< 1K
+Predicate,https://schema.org/cvdNumICUBeds-output,< 1K
+Predicate,https://schema.org/cvdNumICUBedsOcc,< 1K
+Predicate,https://schema.org/cvdNumICUBedsOcc-input,< 1K
+Predicate,https://schema.org/cvdNumICUBedsOcc-output,< 1K
+Predicate,https://schema.org/cvdNumTotBeds,< 1K
+Predicate,https://schema.org/cvdNumTotBeds-input,< 1K
+Predicate,https://schema.org/cvdNumTotBeds-output,< 1K
+Predicate,https://schema.org/cvdNumVent,< 1K
+Predicate,https://schema.org/cvdNumVent-input,< 1K
+Predicate,https://schema.org/cvdNumVent-output,< 1K
+Predicate,https://schema.org/cvdNumVentUse,< 1K
+Predicate,https://schema.org/cvdNumVentUse-input,< 1K
+Predicate,https://schema.org/cvdNumVentUse-output,< 1K
+Predicate,https://schema.org/data,1K - 10K
+Predicate,https://schema.org/data-input,< 1K
+Predicate,https://schema.org/data-output,< 1K
+Predicate,https://schema.org/dataFeedElement,1K - 10K
+Predicate,https://schema.org/dataFeedElement-input,< 1K
+Predicate,https://schema.org/dataFeedElement-output,< 1K
+Predicate,https://schema.org/dataset,< 1K
+Predicate,https://schema.org/dataset-input,< 1K
+Predicate,https://schema.org/dataset-output,< 1K
+Predicate,https://schema.org/datasetTimeInterval,< 1K
+Predicate,https://schema.org/datasetTimeInterval-input,< 1K
+Predicate,https://schema.org/datasetTimeInterval-output,< 1K
+Predicate,https://schema.org/dateCreated,100K - 1M
+Predicate,https://schema.org/dateCreated-input,< 1K
+Predicate,https://schema.org/dateCreated-output,< 1K
+Predicate,https://schema.org/dateDeleted,< 1K
+Predicate,https://schema.org/dateDeleted-input,< 1K
+Predicate,https://schema.org/dateDeleted-output,< 1K
+Predicate,https://schema.org/dateIssued,< 1K
+Predicate,https://schema.org/dateIssued-input,< 1K
+Predicate,https://schema.org/dateIssued-output,< 1K
+Predicate,https://schema.org/dateModified,10M+
+Predicate,https://schema.org/dateModified-input,< 1K
+Predicate,https://schema.org/dateModified-output,< 1K
+Predicate,https://schema.org/datePosted,100K - 1M
+Predicate,https://schema.org/datePosted-input,< 1K
+Predicate,https://schema.org/datePosted-output,< 1K
+Predicate,https://schema.org/datePublished,10M+
+Predicate,https://schema.org/datePublished-input,< 1K
+Predicate,https://schema.org/datePublished-output,< 1K
+Predicate,https://schema.org/dateRead,< 1K
+Predicate,https://schema.org/dateRead-input,< 1K
+Predicate,https://schema.org/dateRead-output,< 1K
+Predicate,https://schema.org/dateReceived,< 1K
+Predicate,https://schema.org/dateReceived-input,< 1K
+Predicate,https://schema.org/dateReceived-output,< 1K
+Predicate,https://schema.org/dateSent,< 1K
+Predicate,https://schema.org/dateSent-input,< 1K
+Predicate,https://schema.org/dateSent-output,< 1K
+Predicate,https://schema.org/dateVehicleFirstRegistered,1K - 10K
+Predicate,https://schema.org/dateVehicleFirstRegistered-input,< 1K
+Predicate,https://schema.org/dateVehicleFirstRegistered-output,< 1K
+Predicate,https://schema.org/dateline,1K - 10K
+Predicate,https://schema.org/dateline-input,< 1K
+Predicate,https://schema.org/dateline-output,< 1K
+Predicate,https://schema.org/dayOfWeek,1M - 10M
+Predicate,https://schema.org/dayOfWeek-input,< 1K
+Predicate,https://schema.org/dayOfWeek-output,< 1K
+Predicate,https://schema.org/deathDate,10K - 100K
+Predicate,https://schema.org/deathDate-input,< 1K
+Predicate,https://schema.org/deathDate-output,< 1K
+Predicate,https://schema.org/deathPlace,1K - 10K
+Predicate,https://schema.org/deathPlace-input,< 1K
+Predicate,https://schema.org/deathPlace-output,< 1K
+Predicate,https://schema.org/defaultValue,100K - 1M
+Predicate,https://schema.org/defaultValue-input,< 1K
+Predicate,https://schema.org/defaultValue-output,< 1K
+Predicate,https://schema.org/deliveryAddress,< 1K
+Predicate,https://schema.org/deliveryAddress-input,< 1K
+Predicate,https://schema.org/deliveryAddress-output,< 1K
+Predicate,https://schema.org/deliveryLeadTime,10K - 100K
+Predicate,https://schema.org/deliveryLeadTime-input,< 1K
+Predicate,https://schema.org/deliveryLeadTime-output,< 1K
+Predicate,https://schema.org/deliveryMethod,10K - 100K
+Predicate,https://schema.org/deliveryMethod-input,< 1K
+Predicate,https://schema.org/deliveryMethod-output,< 1K
+Predicate,https://schema.org/deliveryStatus,< 1K
+Predicate,https://schema.org/deliveryStatus-input,< 1K
+Predicate,https://schema.org/deliveryStatus-output,< 1K
+Predicate,https://schema.org/deliveryTime,100K - 1M
+Predicate,https://schema.org/deliveryTime-input,< 1K
+Predicate,https://schema.org/deliveryTime-output,< 1K
+Predicate,https://schema.org/department,10K - 100K
+Predicate,https://schema.org/department-input,< 1K
+Predicate,https://schema.org/department-output,< 1K
+Predicate,https://schema.org/departureAirport,1K - 10K
+Predicate,https://schema.org/departureAirport-input,< 1K
+Predicate,https://schema.org/departureAirport-output,< 1K
+Predicate,https://schema.org/departureBoatTerminal,< 1K
+Predicate,https://schema.org/departureBoatTerminal-input,< 1K
+Predicate,https://schema.org/departureBoatTerminal-output,< 1K
+Predicate,https://schema.org/departureBusStop,< 1K
+Predicate,https://schema.org/departureBusStop-input,< 1K
+Predicate,https://schema.org/departureBusStop-output,< 1K
+Predicate,https://schema.org/departureGate,< 1K
+Predicate,https://schema.org/departureGate-input,< 1K
+Predicate,https://schema.org/departureGate-output,< 1K
+Predicate,https://schema.org/departurePlatform,< 1K
+Predicate,https://schema.org/departurePlatform-input,< 1K
+Predicate,https://schema.org/departurePlatform-output,< 1K
+Predicate,https://schema.org/departureStation,< 1K
+Predicate,https://schema.org/departureStation-input,< 1K
+Predicate,https://schema.org/departureStation-output,< 1K
+Predicate,https://schema.org/departureTerminal,< 1K
+Predicate,https://schema.org/departureTerminal-input,< 1K
+Predicate,https://schema.org/departureTerminal-output,< 1K
+Predicate,https://schema.org/departureTime,1K - 10K
+Predicate,https://schema.org/departureTime-input,< 1K
+Predicate,https://schema.org/departureTime-output,< 1K
+Predicate,https://schema.org/dependencies,1K - 10K
+Predicate,https://schema.org/dependencies-input,< 1K
+Predicate,https://schema.org/dependencies-output,< 1K
+Predicate,https://schema.org/depth,10K - 100K
+Predicate,https://schema.org/depth-input,< 1K
+Predicate,https://schema.org/depth-output,< 1K
+Predicate,https://schema.org/description,10M+
+Predicate,https://schema.org/description-input,< 1K
+Predicate,https://schema.org/description-output,< 1K
+Predicate,https://schema.org/device,< 1K
+Predicate,https://schema.org/device-input,< 1K
+Predicate,https://schema.org/device-output,< 1K
+Predicate,https://schema.org/diagnosis,< 1K
+Predicate,https://schema.org/diagnosis-input,< 1K
+Predicate,https://schema.org/diagnosis-output,< 1K
+Predicate,https://schema.org/diagram,< 1K
+Predicate,https://schema.org/diagram-input,< 1K
+Predicate,https://schema.org/diagram-output,< 1K
+Predicate,https://schema.org/diet,< 1K
+Predicate,https://schema.org/diet-input,< 1K
+Predicate,https://schema.org/diet-output,< 1K
+Predicate,https://schema.org/dietFeatures,< 1K
+Predicate,https://schema.org/dietFeatures-input,< 1K
+Predicate,https://schema.org/dietFeatures-output,< 1K
+Predicate,https://schema.org/differentialDiagnosis,< 1K
+Predicate,https://schema.org/differentialDiagnosis-input,< 1K
+Predicate,https://schema.org/differentialDiagnosis-output,< 1K
+Predicate,https://schema.org/digitalSourceType,< 1K
+Predicate,https://schema.org/digitalSourceType-input,< 1K
+Predicate,https://schema.org/digitalSourceType-output,< 1K
+Predicate,https://schema.org/directApply,10K - 100K
+Predicate,https://schema.org/directApply-input,< 1K
+Predicate,https://schema.org/directApply-output,< 1K
+Predicate,https://schema.org/director,10K - 100K
+Predicate,https://schema.org/director-input,< 1K
+Predicate,https://schema.org/director-output,< 1K
+Predicate,https://schema.org/directors,< 1K
+Predicate,https://schema.org/directors-input,< 1K
+Predicate,https://schema.org/directors-output,< 1K
+Predicate,https://schema.org/disambiguatingDescription,10K - 100K
+Predicate,https://schema.org/disambiguatingDescription-input,< 1K
+Predicate,https://schema.org/disambiguatingDescription-output,< 1K
+Predicate,https://schema.org/discount,10K - 100K
+Predicate,https://schema.org/discount-input,< 1K
+Predicate,https://schema.org/discount-output,< 1K
+Predicate,https://schema.org/discountCode,< 1K
+Predicate,https://schema.org/discountCode-input,< 1K
+Predicate,https://schema.org/discountCode-output,< 1K
+Predicate,https://schema.org/discountCurrency,< 1K
+Predicate,https://schema.org/discountCurrency-input,< 1K
+Predicate,https://schema.org/discountCurrency-output,< 1K
+Predicate,https://schema.org/discusses,1K - 10K
+Predicate,https://schema.org/discusses-input,< 1K
+Predicate,https://schema.org/discusses-output,< 1K
+Predicate,https://schema.org/discussionUrl,10K - 100K
+Predicate,https://schema.org/discussionUrl-input,< 1K
+Predicate,https://schema.org/discussionUrl-output,< 1K
+Predicate,https://schema.org/diseasePreventionInfo,< 1K
+Predicate,https://schema.org/diseasePreventionInfo-input,< 1K
+Predicate,https://schema.org/diseasePreventionInfo-output,< 1K
+Predicate,https://schema.org/diseaseSpreadStatistics,< 1K
+Predicate,https://schema.org/diseaseSpreadStatistics-input,< 1K
+Predicate,https://schema.org/diseaseSpreadStatistics-output,< 1K
+Predicate,https://schema.org/displayLocation,< 1K
+Predicate,https://schema.org/displayLocation-input,< 1K
+Predicate,https://schema.org/displayLocation-output,< 1K
+Predicate,https://schema.org/dissolutionDate,< 1K
+Predicate,https://schema.org/dissolutionDate-input,< 1K
+Predicate,https://schema.org/dissolutionDate-output,< 1K
+Predicate,https://schema.org/distance,1K - 10K
+Predicate,https://schema.org/distance-input,< 1K
+Predicate,https://schema.org/distance-output,< 1K
+Predicate,https://schema.org/distinguishingSign,< 1K
+Predicate,https://schema.org/distinguishingSign-input,< 1K
+Predicate,https://schema.org/distinguishingSign-output,< 1K
+Predicate,https://schema.org/distribution,10K - 100K
+Predicate,https://schema.org/distribution-input,< 1K
+Predicate,https://schema.org/distribution-output,< 1K
+Predicate,https://schema.org/diversityPolicy,10K - 100K
+Predicate,https://schema.org/diversityPolicy-input,< 1K
+Predicate,https://schema.org/diversityPolicy-output,< 1K
+Predicate,https://schema.org/diversityStaffingReport,1K - 10K
+Predicate,https://schema.org/diversityStaffingReport-input,< 1K
+Predicate,https://schema.org/diversityStaffingReport-output,< 1K
+Predicate,https://schema.org/documentation,1K - 10K
+Predicate,https://schema.org/documentation-input,< 1K
+Predicate,https://schema.org/documentation-output,< 1K
+Predicate,https://schema.org/doesNotShip,10K - 100K
+Predicate,https://schema.org/doesNotShip-input,< 1K
+Predicate,https://schema.org/doesNotShip-output,< 1K
+Predicate,https://schema.org/domainIncludes,< 1K
+Predicate,https://schema.org/domainIncludes-input,< 1K
+Predicate,https://schema.org/domainIncludes-output,< 1K
+Predicate,https://schema.org/domiciledMortgage,< 1K
+Predicate,https://schema.org/domiciledMortgage-input,< 1K
+Predicate,https://schema.org/domiciledMortgage-output,< 1K
+Predicate,https://schema.org/doorTime,1K - 10K
+Predicate,https://schema.org/doorTime-input,< 1K
+Predicate,https://schema.org/doorTime-output,< 1K
+Predicate,https://schema.org/dosageForm,1K - 10K
+Predicate,https://schema.org/dosageForm-input,< 1K
+Predicate,https://schema.org/dosageForm-output,< 1K
+Predicate,https://schema.org/doseSchedule,< 1K
+Predicate,https://schema.org/doseSchedule-input,< 1K
+Predicate,https://schema.org/doseSchedule-output,< 1K
+Predicate,https://schema.org/doseUnit,< 1K
+Predicate,https://schema.org/doseUnit-input,< 1K
+Predicate,https://schema.org/doseUnit-output,< 1K
+Predicate,https://schema.org/doseValue,< 1K
+Predicate,https://schema.org/doseValue-input,< 1K
+Predicate,https://schema.org/doseValue-output,< 1K
+Predicate,https://schema.org/downPayment,< 1K
+Predicate,https://schema.org/downPayment-input,< 1K
+Predicate,https://schema.org/downPayment-output,< 1K
+Predicate,https://schema.org/downloadUrl,100K - 1M
+Predicate,https://schema.org/downloadUrl-input,< 1K
+Predicate,https://schema.org/downloadUrl-output,< 1K
+Predicate,https://schema.org/downvoteCount,1K - 10K
+Predicate,https://schema.org/downvoteCount-input,< 1K
+Predicate,https://schema.org/downvoteCount-output,< 1K
+Predicate,https://schema.org/drainsTo,< 1K
+Predicate,https://schema.org/drainsTo-input,< 1K
+Predicate,https://schema.org/drainsTo-output,< 1K
+Predicate,https://schema.org/driveWheelConfiguration,10K - 100K
+Predicate,https://schema.org/driveWheelConfiguration-input,< 1K
+Predicate,https://schema.org/driveWheelConfiguration-output,< 1K
+Predicate,https://schema.org/dropoffLocation,< 1K
+Predicate,https://schema.org/dropoffLocation-input,< 1K
+Predicate,https://schema.org/dropoffLocation-output,< 1K
+Predicate,https://schema.org/dropoffTime,< 1K
+Predicate,https://schema.org/dropoffTime-input,< 1K
+Predicate,https://schema.org/dropoffTime-output,< 1K
+Predicate,https://schema.org/drug,< 1K
+Predicate,https://schema.org/drug-input,< 1K
+Predicate,https://schema.org/drug-output,< 1K
+Predicate,https://schema.org/drugClass,1K - 10K
+Predicate,https://schema.org/drugClass-input,< 1K
+Predicate,https://schema.org/drugClass-output,< 1K
+Predicate,https://schema.org/drugUnit,< 1K
+Predicate,https://schema.org/drugUnit-input,< 1K
+Predicate,https://schema.org/drugUnit-output,< 1K
+Predicate,https://schema.org/duns,1K - 10K
+Predicate,https://schema.org/duns-input,< 1K
+Predicate,https://schema.org/duns-output,< 1K
+Predicate,https://schema.org/duplicateTherapy,< 1K
+Predicate,https://schema.org/duplicateTherapy-input,< 1K
+Predicate,https://schema.org/duplicateTherapy-output,< 1K
+Predicate,https://schema.org/duration,1M - 10M
+Predicate,https://schema.org/duration-input,< 1K
+Predicate,https://schema.org/duration-output,< 1K
+Predicate,https://schema.org/durationOfWarranty,1K - 10K
+Predicate,https://schema.org/durationOfWarranty-input,< 1K
+Predicate,https://schema.org/durationOfWarranty-output,< 1K
+Predicate,https://schema.org/duringMedia,< 1K
+Predicate,https://schema.org/duringMedia-input,< 1K
+Predicate,https://schema.org/duringMedia-output,< 1K
+Predicate,https://schema.org/earlyPrepaymentPenalty,< 1K
+Predicate,https://schema.org/earlyPrepaymentPenalty-input,< 1K
+Predicate,https://schema.org/earlyPrepaymentPenalty-output,< 1K
+Predicate,https://schema.org/editEIDR,< 1K
+Predicate,https://schema.org/editEIDR-input,< 1K
+Predicate,https://schema.org/editEIDR-output,< 1K
+Predicate,https://schema.org/editor,100K - 1M
+Predicate,https://schema.org/editor-input,< 1K
+Predicate,https://schema.org/editor-output,< 1K
+Predicate,https://schema.org/eduQuestionType,< 1K
+Predicate,https://schema.org/eduQuestionType-input,< 1K
+Predicate,https://schema.org/eduQuestionType-output,< 1K
+Predicate,https://schema.org/educationRequirements,10K - 100K
+Predicate,https://schema.org/educationRequirements-input,< 1K
+Predicate,https://schema.org/educationRequirements-output,< 1K
+Predicate,https://schema.org/educationalAlignment,1K - 10K
+Predicate,https://schema.org/educationalAlignment-input,< 1K
+Predicate,https://schema.org/educationalAlignment-output,< 1K
+Predicate,https://schema.org/educationalCredentialAwarded,10K - 100K
+Predicate,https://schema.org/educationalCredentialAwarded-input,< 1K
+Predicate,https://schema.org/educationalCredentialAwarded-output,< 1K
+Predicate,https://schema.org/educationalFramework,< 1K
+Predicate,https://schema.org/educationalFramework-input,< 1K
+Predicate,https://schema.org/educationalFramework-output,< 1K
+Predicate,https://schema.org/educationalLevel,10K - 100K
+Predicate,https://schema.org/educationalLevel-input,< 1K
+Predicate,https://schema.org/educationalLevel-output,< 1K
+Predicate,https://schema.org/educationalProgramMode,1K - 10K
+Predicate,https://schema.org/educationalProgramMode-input,< 1K
+Predicate,https://schema.org/educationalProgramMode-output,< 1K
+Predicate,https://schema.org/educationalRole,10K - 100K
+Predicate,https://schema.org/educationalRole-input,< 1K
+Predicate,https://schema.org/educationalRole-output,< 1K
+Predicate,https://schema.org/educationalUse,1K - 10K
+Predicate,https://schema.org/educationalUse-input,< 1K
+Predicate,https://schema.org/educationalUse-output,< 1K
+Predicate,https://schema.org/elevation,1K - 10K
+Predicate,https://schema.org/elevation-input,< 1K
+Predicate,https://schema.org/elevation-output,< 1K
+Predicate,https://schema.org/eligibilityToWorkRequirement,< 1K
+Predicate,https://schema.org/eligibilityToWorkRequirement-input,< 1K
+Predicate,https://schema.org/eligibilityToWorkRequirement-output,< 1K
+Predicate,https://schema.org/eligibleCustomerType,1K - 10K
+Predicate,https://schema.org/eligibleCustomerType-input,< 1K
+Predicate,https://schema.org/eligibleCustomerType-output,< 1K
+Predicate,https://schema.org/eligibleDuration,10K - 100K
+Predicate,https://schema.org/eligibleDuration-input,< 1K
+Predicate,https://schema.org/eligibleDuration-output,< 1K
+Predicate,https://schema.org/eligibleQuantity,10K - 100K
+Predicate,https://schema.org/eligibleQuantity-input,< 1K
+Predicate,https://schema.org/eligibleQuantity-output,< 1K
+Predicate,https://schema.org/eligibleRegion,10K - 100K
+Predicate,https://schema.org/eligibleRegion-input,< 1K
+Predicate,https://schema.org/eligibleRegion-output,< 1K
+Predicate,https://schema.org/eligibleTransactionVolume,10K - 100K
+Predicate,https://schema.org/eligibleTransactionVolume-input,< 1K
+Predicate,https://schema.org/eligibleTransactionVolume-output,< 1K
+Predicate,https://schema.org/eligibleWithSupplier,< 1K
+Predicate,https://schema.org/eligibleWithSupplier-input,< 1K
+Predicate,https://schema.org/eligibleWithSupplier-output,< 1K
+Predicate,https://schema.org/email,1M - 10M
+Predicate,https://schema.org/email-input,< 1K
+Predicate,https://schema.org/email-output,< 1K
+Predicate,https://schema.org/embedUrl,1M - 10M
+Predicate,https://schema.org/embedUrl-input,< 1K
+Predicate,https://schema.org/embedUrl-output,< 1K
+Predicate,https://schema.org/embeddedTextCaption,1K - 10K
+Predicate,https://schema.org/embeddedTextCaption-input,< 1K
+Predicate,https://schema.org/embeddedTextCaption-output,< 1K
+Predicate,https://schema.org/emissionsCO2,1K - 10K
+Predicate,https://schema.org/emissionsCO2-input,< 1K
+Predicate,https://schema.org/emissionsCO2-output,< 1K
+Predicate,https://schema.org/employee,100K - 1M
+Predicate,https://schema.org/employee-input,< 1K
+Predicate,https://schema.org/employee-output,< 1K
+Predicate,https://schema.org/employees,1K - 10K
+Predicate,https://schema.org/employees-input,< 1K
+Predicate,https://schema.org/employees-output,< 1K
+Predicate,https://schema.org/employerOverview,1K - 10K
+Predicate,https://schema.org/employerOverview-input,< 1K
+Predicate,https://schema.org/employerOverview-output,< 1K
+Predicate,https://schema.org/employmentType,100K - 1M
+Predicate,https://schema.org/employmentType-input,< 1K
+Predicate,https://schema.org/employmentType-output,< 1K
+Predicate,https://schema.org/employmentUnit,1K - 10K
+Predicate,https://schema.org/employmentUnit-input,< 1K
+Predicate,https://schema.org/employmentUnit-output,< 1K
+Predicate,https://schema.org/encodesBioChemEntity,< 1K
+Predicate,https://schema.org/encodesBioChemEntity-input,< 1K
+Predicate,https://schema.org/encodesBioChemEntity-output,< 1K
+Predicate,https://schema.org/encodesCreativeWork,< 1K
+Predicate,https://schema.org/encodesCreativeWork-input,< 1K
+Predicate,https://schema.org/encodesCreativeWork-output,< 1K
+Predicate,https://schema.org/encoding,100K - 1M
+Predicate,https://schema.org/encoding-input,< 1K
+Predicate,https://schema.org/encoding-output,< 1K
+Predicate,https://schema.org/encodingFormat,10K - 100K
+Predicate,https://schema.org/encodingFormat-input,< 1K
+Predicate,https://schema.org/encodingFormat-output,< 1K
+Predicate,https://schema.org/encodingType,< 1K
+Predicate,https://schema.org/encodingType-input,< 1K
+Predicate,https://schema.org/encodingType-output,< 1K
+Predicate,https://schema.org/encodings,< 1K
+Predicate,https://schema.org/encodings-input,< 1K
+Predicate,https://schema.org/encodings-output,< 1K
+Predicate,https://schema.org/endDate,100K - 1M
+Predicate,https://schema.org/endDate-input,< 1K
+Predicate,https://schema.org/endDate-output,< 1K
+Predicate,https://schema.org/endOffset,10K - 100K
+Predicate,https://schema.org/endOffset-input,< 1K
+Predicate,https://schema.org/endOffset-output,< 1K
+Predicate,https://schema.org/endTime,1K - 10K
+Predicate,https://schema.org/endTime-input,< 1K
+Predicate,https://schema.org/endTime-output,< 1K
+Predicate,https://schema.org/endorsee,< 1K
+Predicate,https://schema.org/endorsee-input,< 1K
+Predicate,https://schema.org/endorsee-output,< 1K
+Predicate,https://schema.org/endorsers,< 1K
+Predicate,https://schema.org/endorsers-input,< 1K
+Predicate,https://schema.org/endorsers-output,< 1K
+Predicate,https://schema.org/energyEfficiencyScaleMax,1K - 10K
+Predicate,https://schema.org/energyEfficiencyScaleMax-input,< 1K
+Predicate,https://schema.org/energyEfficiencyScaleMax-output,< 1K
+Predicate,https://schema.org/energyEfficiencyScaleMin,1K - 10K
+Predicate,https://schema.org/energyEfficiencyScaleMin-input,< 1K
+Predicate,https://schema.org/energyEfficiencyScaleMin-output,< 1K
+Predicate,https://schema.org/engineDisplacement,10K - 100K
+Predicate,https://schema.org/engineDisplacement-input,< 1K
+Predicate,https://schema.org/engineDisplacement-output,< 1K
+Predicate,https://schema.org/enginePower,10K - 100K
+Predicate,https://schema.org/enginePower-input,< 1K
+Predicate,https://schema.org/enginePower-output,< 1K
+Predicate,https://schema.org/engineType,1K - 10K
+Predicate,https://schema.org/engineType-input,< 1K
+Predicate,https://schema.org/engineType-output,< 1K
+Predicate,https://schema.org/entertainmentBusiness,< 1K
+Predicate,https://schema.org/entertainmentBusiness-input,< 1K
+Predicate,https://schema.org/entertainmentBusiness-output,< 1K
+Predicate,https://schema.org/epidemiology,< 1K
+Predicate,https://schema.org/epidemiology-input,< 1K
+Predicate,https://schema.org/epidemiology-output,< 1K
+Predicate,https://schema.org/episode,1K - 10K
+Predicate,https://schema.org/episode-input,< 1K
+Predicate,https://schema.org/episode-output,< 1K
+Predicate,https://schema.org/episodeNumber,10K - 100K
+Predicate,https://schema.org/episodeNumber-input,< 1K
+Predicate,https://schema.org/episodeNumber-output,< 1K
+Predicate,https://schema.org/episodes,< 1K
+Predicate,https://schema.org/episodes-input,< 1K
+Predicate,https://schema.org/episodes-output,< 1K
+Predicate,https://schema.org/equal,< 1K
+Predicate,https://schema.org/equal-input,< 1K
+Predicate,https://schema.org/equal-output,< 1K
+Predicate,https://schema.org/error,1K - 10K
+Predicate,https://schema.org/error-input,< 1K
+Predicate,https://schema.org/error-output,< 1K
+Predicate,https://schema.org/errorCode,< 1K
+Predicate,https://schema.org/errorCode-input,< 1K
+Predicate,https://schema.org/errorCode-output,< 1K
+Predicate,https://schema.org/estimatedCost,10K - 100K
+Predicate,https://schema.org/estimatedCost-input,< 1K
+Predicate,https://schema.org/estimatedCost-output,< 1K
+Predicate,https://schema.org/estimatedFlightDuration,< 1K
+Predicate,https://schema.org/estimatedFlightDuration-input,< 1K
+Predicate,https://schema.org/estimatedFlightDuration-output,< 1K
+Predicate,https://schema.org/estimatedSalary,1K - 10K
+Predicate,https://schema.org/estimatedSalary-input,< 1K
+Predicate,https://schema.org/estimatedSalary-output,< 1K
+Predicate,https://schema.org/estimatesRiskOf,< 1K
+Predicate,https://schema.org/estimatesRiskOf-input,< 1K
+Predicate,https://schema.org/estimatesRiskOf-output,< 1K
+Predicate,https://schema.org/ethicsPolicy,10K - 100K
+Predicate,https://schema.org/ethicsPolicy-input,< 1K
+Predicate,https://schema.org/ethicsPolicy-output,< 1K
+Predicate,https://schema.org/event,10K - 100K
+Predicate,https://schema.org/event-input,< 1K
+Predicate,https://schema.org/event-output,< 1K
+Predicate,https://schema.org/eventAttendanceMode,100K - 1M
+Predicate,https://schema.org/eventAttendanceMode-input,< 1K
+Predicate,https://schema.org/eventAttendanceMode-output,< 1K
+Predicate,https://schema.org/eventSchedule,1K - 10K
+Predicate,https://schema.org/eventSchedule-input,< 1K
+Predicate,https://schema.org/eventSchedule-output,< 1K
+Predicate,https://schema.org/eventStatus,100K - 1M
+Predicate,https://schema.org/eventStatus-input,< 1K
+Predicate,https://schema.org/eventStatus-output,< 1K
+Predicate,https://schema.org/events,1K - 10K
+Predicate,https://schema.org/events-input,< 1K
+Predicate,https://schema.org/events-output,< 1K
+Predicate,https://schema.org/evidenceLevel,< 1K
+Predicate,https://schema.org/evidenceLevel-input,< 1K
+Predicate,https://schema.org/evidenceLevel-output,< 1K
+Predicate,https://schema.org/evidenceOrigin,< 1K
+Predicate,https://schema.org/evidenceOrigin-input,< 1K
+Predicate,https://schema.org/evidenceOrigin-output,< 1K
+Predicate,https://schema.org/exampleOfWork,1K - 10K
+Predicate,https://schema.org/exampleOfWork-input,< 1K
+Predicate,https://schema.org/exampleOfWork-output,< 1K
+Predicate,https://schema.org/exceptDate,< 1K
+Predicate,https://schema.org/exceptDate-input,< 1K
+Predicate,https://schema.org/exceptDate-output,< 1K
+Predicate,https://schema.org/exchangeRateSpread,< 1K
+Predicate,https://schema.org/exchangeRateSpread-input,< 1K
+Predicate,https://schema.org/exchangeRateSpread-output,< 1K
+Predicate,https://schema.org/executableLibraryName,< 1K
+Predicate,https://schema.org/executableLibraryName-input,< 1K
+Predicate,https://schema.org/executableLibraryName-output,< 1K
+Predicate,https://schema.org/exerciseCourse,< 1K
+Predicate,https://schema.org/exerciseCourse-input,< 1K
+Predicate,https://schema.org/exerciseCourse-output,< 1K
+Predicate,https://schema.org/exercisePlan,< 1K
+Predicate,https://schema.org/exercisePlan-input,< 1K
+Predicate,https://schema.org/exercisePlan-output,< 1K
+Predicate,https://schema.org/exerciseRelatedDiet,< 1K
+Predicate,https://schema.org/exerciseRelatedDiet-input,< 1K
+Predicate,https://schema.org/exerciseRelatedDiet-output,< 1K
+Predicate,https://schema.org/exerciseType,< 1K
+Predicate,https://schema.org/exerciseType-input,< 1K
+Predicate,https://schema.org/exerciseType-output,< 1K
+Predicate,https://schema.org/exifData,1K - 10K
+Predicate,https://schema.org/exifData-input,< 1K
+Predicate,https://schema.org/exifData-output,< 1K
+Predicate,https://schema.org/expectedArrivalFrom,< 1K
+Predicate,https://schema.org/expectedArrivalFrom-input,< 1K
+Predicate,https://schema.org/expectedArrivalFrom-output,< 1K
+Predicate,https://schema.org/expectedArrivalUntil,< 1K
+Predicate,https://schema.org/expectedArrivalUntil-input,< 1K
+Predicate,https://schema.org/expectedArrivalUntil-output,< 1K
+Predicate,https://schema.org/expectedPrognosis,< 1K
+Predicate,https://schema.org/expectedPrognosis-input,< 1K
+Predicate,https://schema.org/expectedPrognosis-output,< 1K
+Predicate,https://schema.org/expectsAcceptanceOf,1K - 10K
+Predicate,https://schema.org/expectsAcceptanceOf-input,< 1K
+Predicate,https://schema.org/expectsAcceptanceOf-output,< 1K
+Predicate,https://schema.org/experienceInPlaceOfEducation,1K - 10K
+Predicate,https://schema.org/experienceInPlaceOfEducation-input,< 1K
+Predicate,https://schema.org/experienceInPlaceOfEducation-output,< 1K
+Predicate,https://schema.org/experienceRequirements,10K - 100K
+Predicate,https://schema.org/experienceRequirements-input,< 1K
+Predicate,https://schema.org/experienceRequirements-output,< 1K
+Predicate,https://schema.org/expertConsiderations,< 1K
+Predicate,https://schema.org/expertConsiderations-input,< 1K
+Predicate,https://schema.org/expertConsiderations-output,< 1K
+Predicate,https://schema.org/expires,1K - 10K
+Predicate,https://schema.org/expires-input,< 1K
+Predicate,https://schema.org/expires-output,< 1K
+Predicate,https://schema.org/expressedIn,< 1K
+Predicate,https://schema.org/expressedIn-input,< 1K
+Predicate,https://schema.org/expressedIn-output,< 1K
+Predicate,https://schema.org/extendedAddress,< 1K
+Predicate,https://schema.org/extendedAddress-input,< 1K
+Predicate,https://schema.org/extendedAddress-output,< 1K
+Predicate,https://schema.org/familyName,100K - 1M
+Predicate,https://schema.org/familyName-input,< 1K
+Predicate,https://schema.org/familyName-output,< 1K
+Predicate,https://schema.org/fatContent,10K - 100K
+Predicate,https://schema.org/fatContent-input,< 1K
+Predicate,https://schema.org/fatContent-output,< 1K
+Predicate,https://schema.org/faxNumber,100K - 1M
+Predicate,https://schema.org/faxNumber-input,< 1K
+Predicate,https://schema.org/faxNumber-output,< 1K
+Predicate,https://schema.org/featureList,100K - 1M
+Predicate,https://schema.org/featureList-input,< 1K
+Predicate,https://schema.org/featureList-output,< 1K
+Predicate,https://schema.org/feesAndCommissionsSpecification,1K - 10K
+Predicate,https://schema.org/feesAndCommissionsSpecification-input,< 1K
+Predicate,https://schema.org/feesAndCommissionsSpecification-output,< 1K
+Predicate,https://schema.org/fiberContent,10K - 100K
+Predicate,https://schema.org/fiberContent-input,< 1K
+Predicate,https://schema.org/fiberContent-output,< 1K
+Predicate,https://schema.org/fileFormat,10K - 100K
+Predicate,https://schema.org/fileFormat-input,< 1K
+Predicate,https://schema.org/fileFormat-output,< 1K
+Predicate,https://schema.org/fileSize,10K - 100K
+Predicate,https://schema.org/fileSize-input,< 1K
+Predicate,https://schema.org/fileSize-output,< 1K
+Predicate,https://schema.org/financialAidEligible,< 1K
+Predicate,https://schema.org/financialAidEligible-input,< 1K
+Predicate,https://schema.org/financialAidEligible-output,< 1K
+Predicate,https://schema.org/firstAppearance,< 1K
+Predicate,https://schema.org/firstAppearance-input,< 1K
+Predicate,https://schema.org/firstAppearance-output,< 1K
+Predicate,https://schema.org/firstPerformance,< 1K
+Predicate,https://schema.org/firstPerformance-input,< 1K
+Predicate,https://schema.org/firstPerformance-output,< 1K
+Predicate,https://schema.org/flightDistance,< 1K
+Predicate,https://schema.org/flightDistance-input,< 1K
+Predicate,https://schema.org/flightDistance-output,< 1K
+Predicate,https://schema.org/flightNumber,< 1K
+Predicate,https://schema.org/flightNumber-input,< 1K
+Predicate,https://schema.org/flightNumber-output,< 1K
+Predicate,https://schema.org/floorLevel,1K - 10K
+Predicate,https://schema.org/floorLevel-input,< 1K
+Predicate,https://schema.org/floorLevel-output,< 1K
+Predicate,https://schema.org/floorLimit,< 1K
+Predicate,https://schema.org/floorLimit-input,< 1K
+Predicate,https://schema.org/floorLimit-output,< 1K
+Predicate,https://schema.org/floorSize,100K - 1M
+Predicate,https://schema.org/floorSize-input,< 1K
+Predicate,https://schema.org/floorSize-output,< 1K
+Predicate,https://schema.org/followee,< 1K
+Predicate,https://schema.org/followee-input,< 1K
+Predicate,https://schema.org/followee-output,< 1K
+Predicate,https://schema.org/follows,< 1K
+Predicate,https://schema.org/follows-input,< 1K
+Predicate,https://schema.org/follows-output,< 1K
+Predicate,https://schema.org/followup,1K - 10K
+Predicate,https://schema.org/followup-input,< 1K
+Predicate,https://schema.org/followup-output,< 1K
+Predicate,https://schema.org/foodEstablishment,< 1K
+Predicate,https://schema.org/foodEstablishment-input,< 1K
+Predicate,https://schema.org/foodEstablishment-output,< 1K
+Predicate,https://schema.org/foodEvent,< 1K
+Predicate,https://schema.org/foodEvent-input,< 1K
+Predicate,https://schema.org/foodEvent-output,< 1K
+Predicate,https://schema.org/foodWarning,< 1K
+Predicate,https://schema.org/foodWarning-input,< 1K
+Predicate,https://schema.org/foodWarning-output,< 1K
+Predicate,https://schema.org/founder,100K - 1M
+Predicate,https://schema.org/founder-input,< 1K
+Predicate,https://schema.org/founder-output,< 1K
+Predicate,https://schema.org/founders,10K - 100K
+Predicate,https://schema.org/founders-input,< 1K
+Predicate,https://schema.org/founders-output,< 1K
+Predicate,https://schema.org/foundingDate,100K - 1M
+Predicate,https://schema.org/foundingDate-input,< 1K
+Predicate,https://schema.org/foundingDate-output,< 1K
+Predicate,https://schema.org/foundingLocation,10K - 100K
+Predicate,https://schema.org/foundingLocation-input,< 1K
+Predicate,https://schema.org/foundingLocation-output,< 1K
+Predicate,https://schema.org/free,1K - 10K
+Predicate,https://schema.org/free-input,< 1K
+Predicate,https://schema.org/free-output,< 1K
+Predicate,https://schema.org/freeShippingThreshold,10K - 100K
+Predicate,https://schema.org/freeShippingThreshold-input,< 1K
+Predicate,https://schema.org/freeShippingThreshold-output,< 1K
+Predicate,https://schema.org/frequency,< 1K
+Predicate,https://schema.org/frequency-input,< 1K
+Predicate,https://schema.org/frequency-output,< 1K
+Predicate,https://schema.org/fromLocation,1K - 10K
+Predicate,https://schema.org/fromLocation-input,< 1K
+Predicate,https://schema.org/fromLocation-output,< 1K
+Predicate,https://schema.org/fuelCapacity,1K - 10K
+Predicate,https://schema.org/fuelCapacity-input,< 1K
+Predicate,https://schema.org/fuelCapacity-output,< 1K
+Predicate,https://schema.org/fuelConsumption,1K - 10K
+Predicate,https://schema.org/fuelConsumption-input,< 1K
+Predicate,https://schema.org/fuelConsumption-output,< 1K
+Predicate,https://schema.org/fuelEfficiency,1K - 10K
+Predicate,https://schema.org/fuelEfficiency-input,< 1K
+Predicate,https://schema.org/fuelEfficiency-output,< 1K
+Predicate,https://schema.org/fuelType,10K - 100K
+Predicate,https://schema.org/fuelType-input,< 1K
+Predicate,https://schema.org/fuelType-output,< 1K
+Predicate,https://schema.org/fulfillmentType,10K - 100K
+Predicate,https://schema.org/fulfillmentType-input,< 1K
+Predicate,https://schema.org/fulfillmentType-output,< 1K
+Predicate,https://schema.org/functionalClass,< 1K
+Predicate,https://schema.org/functionalClass-input,< 1K
+Predicate,https://schema.org/functionalClass-output,< 1K
+Predicate,https://schema.org/fundedItem,< 1K
+Predicate,https://schema.org/fundedItem-input,< 1K
+Predicate,https://schema.org/fundedItem-output,< 1K
+Predicate,https://schema.org/funder,1K - 10K
+Predicate,https://schema.org/funder-input,< 1K
+Predicate,https://schema.org/funder-output,< 1K
+Predicate,https://schema.org/funding,1K - 10K
+Predicate,https://schema.org/funding-input,< 1K
+Predicate,https://schema.org/funding-output,< 1K
+Predicate,https://schema.org/game,10K - 100K
+Predicate,https://schema.org/game-input,< 1K
+Predicate,https://schema.org/game-output,< 1K
+Predicate,https://schema.org/gameAvailabilityType,< 1K
+Predicate,https://schema.org/gameAvailabilityType-input,< 1K
+Predicate,https://schema.org/gameAvailabilityType-output,< 1K
+Predicate,https://schema.org/gameEdition,< 1K
+Predicate,https://schema.org/gameEdition-input,< 1K
+Predicate,https://schema.org/gameEdition-output,< 1K
+Predicate,https://schema.org/gameItem,1K - 10K
+Predicate,https://schema.org/gameItem-input,< 1K
+Predicate,https://schema.org/gameItem-output,< 1K
+Predicate,https://schema.org/gameLocation,10K - 100K
+Predicate,https://schema.org/gameLocation-input,< 1K
+Predicate,https://schema.org/gameLocation-output,< 1K
+Predicate,https://schema.org/gamePlatform,10K - 100K
+Predicate,https://schema.org/gamePlatform-input,< 1K
+Predicate,https://schema.org/gamePlatform-output,< 1K
+Predicate,https://schema.org/gameServer,< 1K
+Predicate,https://schema.org/gameServer-input,< 1K
+Predicate,https://schema.org/gameServer-output,< 1K
+Predicate,https://schema.org/gameTip,< 1K
+Predicate,https://schema.org/gameTip-input,< 1K
+Predicate,https://schema.org/gameTip-output,< 1K
+Predicate,https://schema.org/gender,10K - 100K
+Predicate,https://schema.org/gender-input,< 1K
+Predicate,https://schema.org/gender-output,< 1K
+Predicate,https://schema.org/genre,100K - 1M
+Predicate,https://schema.org/genre-input,< 1K
+Predicate,https://schema.org/genre-output,< 1K
+Predicate,https://schema.org/geo,1M - 10M
+Predicate,https://schema.org/geo-input,< 1K
+Predicate,https://schema.org/geo-output,< 1K
+Predicate,https://schema.org/geoContains,< 1K
+Predicate,https://schema.org/geoContains-input,< 1K
+Predicate,https://schema.org/geoContains-output,< 1K
+Predicate,https://schema.org/geoCoveredBy,< 1K
+Predicate,https://schema.org/geoCoveredBy-input,< 1K
+Predicate,https://schema.org/geoCoveredBy-output,< 1K
+Predicate,https://schema.org/geoCovers,< 1K
+Predicate,https://schema.org/geoCovers-input,< 1K
+Predicate,https://schema.org/geoCovers-output,< 1K
+Predicate,https://schema.org/geoCrosses,< 1K
+Predicate,https://schema.org/geoCrosses-input,< 1K
+Predicate,https://schema.org/geoCrosses-output,< 1K
+Predicate,https://schema.org/geoDisjoint,< 1K
+Predicate,https://schema.org/geoDisjoint-input,< 1K
+Predicate,https://schema.org/geoDisjoint-output,< 1K
+Predicate,https://schema.org/geoEquals,< 1K
+Predicate,https://schema.org/geoEquals-input,< 1K
+Predicate,https://schema.org/geoEquals-output,< 1K
+Predicate,https://schema.org/geoIntersects,< 1K
+Predicate,https://schema.org/geoIntersects-input,< 1K
+Predicate,https://schema.org/geoIntersects-output,< 1K
+Predicate,https://schema.org/geoMidpoint,100K - 1M
+Predicate,https://schema.org/geoMidpoint-input,< 1K
+Predicate,https://schema.org/geoMidpoint-output,< 1K
+Predicate,https://schema.org/geoOverlaps,< 1K
+Predicate,https://schema.org/geoOverlaps-input,< 1K
+Predicate,https://schema.org/geoOverlaps-output,< 1K
+Predicate,https://schema.org/geoRadius,100K - 1M
+Predicate,https://schema.org/geoRadius-input,< 1K
+Predicate,https://schema.org/geoRadius-output,< 1K
+Predicate,https://schema.org/geoTouches,< 1K
+Predicate,https://schema.org/geoTouches-input,< 1K
+Predicate,https://schema.org/geoTouches-output,< 1K
+Predicate,https://schema.org/geoWithin,< 1K
+Predicate,https://schema.org/geoWithin-input,< 1K
+Predicate,https://schema.org/geoWithin-output,< 1K
+Predicate,https://schema.org/geographicArea,10K - 100K
+Predicate,https://schema.org/geographicArea-input,< 1K
+Predicate,https://schema.org/geographicArea-output,< 1K
+Predicate,https://schema.org/gettingTestedInfo,< 1K
+Predicate,https://schema.org/gettingTestedInfo-input,< 1K
+Predicate,https://schema.org/gettingTestedInfo-output,< 1K
+Predicate,https://schema.org/givenName,100K - 1M
+Predicate,https://schema.org/givenName-input,< 1K
+Predicate,https://schema.org/givenName-output,< 1K
+Predicate,https://schema.org/globalLocationNumber,1K - 10K
+Predicate,https://schema.org/globalLocationNumber-input,< 1K
+Predicate,https://schema.org/globalLocationNumber-output,< 1K
+Predicate,https://schema.org/governmentBenefitsInfo,< 1K
+Predicate,https://schema.org/governmentBenefitsInfo-input,< 1K
+Predicate,https://schema.org/governmentBenefitsInfo-output,< 1K
+Predicate,https://schema.org/gracePeriod,< 1K
+Predicate,https://schema.org/gracePeriod-input,< 1K
+Predicate,https://schema.org/gracePeriod-output,< 1K
+Predicate,https://schema.org/grantee,< 1K
+Predicate,https://schema.org/grantee-input,< 1K
+Predicate,https://schema.org/grantee-output,< 1K
+Predicate,https://schema.org/greater,< 1K
+Predicate,https://schema.org/greater-input,< 1K
+Predicate,https://schema.org/greater-output,< 1K
+Predicate,https://schema.org/greaterOrEqual,< 1K
+Predicate,https://schema.org/greaterOrEqual-input,< 1K
+Predicate,https://schema.org/greaterOrEqual-output,< 1K
+Predicate,https://schema.org/gtin,100K - 1M
+Predicate,https://schema.org/gtin-input,< 1K
+Predicate,https://schema.org/gtin-output,< 1K
+Predicate,https://schema.org/gtin12,100K - 1M
+Predicate,https://schema.org/gtin12-input,< 1K
+Predicate,https://schema.org/gtin12-output,< 1K
+Predicate,https://schema.org/gtin13,100K - 1M
+Predicate,https://schema.org/gtin13-input,< 1K
+Predicate,https://schema.org/gtin13-output,< 1K
+Predicate,https://schema.org/gtin14,10K - 100K
+Predicate,https://schema.org/gtin14-input,< 1K
+Predicate,https://schema.org/gtin14-output,< 1K
+Predicate,https://schema.org/gtin8,10K - 100K
+Predicate,https://schema.org/gtin8-input,< 1K
+Predicate,https://schema.org/gtin8-output,< 1K
+Predicate,https://schema.org/guideline,< 1K
+Predicate,https://schema.org/guideline-input,< 1K
+Predicate,https://schema.org/guideline-output,< 1K
+Predicate,https://schema.org/guidelineDate,< 1K
+Predicate,https://schema.org/guidelineDate-input,< 1K
+Predicate,https://schema.org/guidelineDate-output,< 1K
+Predicate,https://schema.org/guidelineSubject,< 1K
+Predicate,https://schema.org/guidelineSubject-input,< 1K
+Predicate,https://schema.org/guidelineSubject-output,< 1K
+Predicate,https://schema.org/handlingTime,100K - 1M
+Predicate,https://schema.org/handlingTime-input,< 1K
+Predicate,https://schema.org/handlingTime-output,< 1K
+Predicate,https://schema.org/hasAdultConsideration,< 1K
+Predicate,https://schema.org/hasAdultConsideration-input,< 1K
+Predicate,https://schema.org/hasAdultConsideration-output,< 1K
+Predicate,https://schema.org/hasBioChemEntityPart,< 1K
+Predicate,https://schema.org/hasBioChemEntityPart-input,< 1K
+Predicate,https://schema.org/hasBioChemEntityPart-output,< 1K
+Predicate,https://schema.org/hasBioPolymerSequence,< 1K
+Predicate,https://schema.org/hasBioPolymerSequence-input,< 1K
+Predicate,https://schema.org/hasBioPolymerSequence-output,< 1K
+Predicate,https://schema.org/hasBroadcastChannel,< 1K
+Predicate,https://schema.org/hasBroadcastChannel-input,< 1K
+Predicate,https://schema.org/hasBroadcastChannel-output,< 1K
+Predicate,https://schema.org/hasCategoryCode,< 1K
+Predicate,https://schema.org/hasCategoryCode-input,< 1K
+Predicate,https://schema.org/hasCategoryCode-output,< 1K
+Predicate,https://schema.org/hasCertification,1K - 10K
+Predicate,https://schema.org/hasCertification-input,< 1K
+Predicate,https://schema.org/hasCertification-output,< 1K
+Predicate,https://schema.org/hasCourse,1K - 10K
+Predicate,https://schema.org/hasCourse-input,< 1K
+Predicate,https://schema.org/hasCourse-output,< 1K
+Predicate,https://schema.org/hasCourseInstance,10K - 100K
+Predicate,https://schema.org/hasCourseInstance-input,< 1K
+Predicate,https://schema.org/hasCourseInstance-output,< 1K
+Predicate,https://schema.org/hasCredential,10K - 100K
+Predicate,https://schema.org/hasCredential-input,< 1K
+Predicate,https://schema.org/hasCredential-output,< 1K
+Predicate,https://schema.org/hasDefinedTerm,1K - 10K
+Predicate,https://schema.org/hasDefinedTerm-input,< 1K
+Predicate,https://schema.org/hasDefinedTerm-output,< 1K
+Predicate,https://schema.org/hasDeliveryMethod,< 1K
+Predicate,https://schema.org/hasDeliveryMethod-input,< 1K
+Predicate,https://schema.org/hasDeliveryMethod-output,< 1K
+Predicate,https://schema.org/hasDigitalDocumentPermission,< 1K
+Predicate,https://schema.org/hasDigitalDocumentPermission-input,< 1K
+Predicate,https://schema.org/hasDigitalDocumentPermission-output,< 1K
+Predicate,https://schema.org/hasDriveThroughService,< 1K
+Predicate,https://schema.org/hasDriveThroughService-input,< 1K
+Predicate,https://schema.org/hasDriveThroughService-output,< 1K
+Predicate,https://schema.org/hasEnergyConsumptionDetails,1K - 10K
+Predicate,https://schema.org/hasEnergyConsumptionDetails-input,< 1K
+Predicate,https://schema.org/hasEnergyConsumptionDetails-output,< 1K
+Predicate,https://schema.org/hasEnergyEfficiencyCategory,1K - 10K
+Predicate,https://schema.org/hasEnergyEfficiencyCategory-input,< 1K
+Predicate,https://schema.org/hasEnergyEfficiencyCategory-output,< 1K
+Predicate,https://schema.org/hasGS1DigitalLink,< 1K
+Predicate,https://schema.org/hasGS1DigitalLink-input,< 1K
+Predicate,https://schema.org/hasGS1DigitalLink-output,< 1K
+Predicate,https://schema.org/hasHealthAspect,< 1K
+Predicate,https://schema.org/hasHealthAspect-input,< 1K
+Predicate,https://schema.org/hasHealthAspect-output,< 1K
+Predicate,https://schema.org/hasMap,100K - 1M
+Predicate,https://schema.org/hasMap-input,< 1K
+Predicate,https://schema.org/hasMap-output,< 1K
+Predicate,https://schema.org/hasMeasurement,1K - 10K
+Predicate,https://schema.org/hasMeasurement-input,< 1K
+Predicate,https://schema.org/hasMeasurement-output,< 1K
+Predicate,https://schema.org/hasMemberProgram,1K - 10K
+Predicate,https://schema.org/hasMemberProgram-input,< 1K
+Predicate,https://schema.org/hasMemberProgram-output,< 1K
+Predicate,https://schema.org/hasMenu,10K - 100K
+Predicate,https://schema.org/hasMenu-input,< 1K
+Predicate,https://schema.org/hasMenu-output,< 1K
+Predicate,https://schema.org/hasMenuItem,10K - 100K
+Predicate,https://schema.org/hasMenuItem-input,< 1K
+Predicate,https://schema.org/hasMenuItem-output,< 1K
+Predicate,https://schema.org/hasMenuSection,10K - 100K
+Predicate,https://schema.org/hasMenuSection-input,< 1K
+Predicate,https://schema.org/hasMenuSection-output,< 1K
+Predicate,https://schema.org/hasMerchantReturnPolicy,100K - 1M
+Predicate,https://schema.org/hasMerchantReturnPolicy-input,< 1K
+Predicate,https://schema.org/hasMerchantReturnPolicy-output,< 1K
+Predicate,https://schema.org/hasMolecularFunction,< 1K
+Predicate,https://schema.org/hasMolecularFunction-input,< 1K
+Predicate,https://schema.org/hasMolecularFunction-output,< 1K
+Predicate,https://schema.org/hasOccupation,10K - 100K
+Predicate,https://schema.org/hasOccupation-input,< 1K
+Predicate,https://schema.org/hasOccupation-output,< 1K
+Predicate,https://schema.org/hasOfferCatalog,100K - 1M
+Predicate,https://schema.org/hasOfferCatalog-input,< 1K
+Predicate,https://schema.org/hasOfferCatalog-output,< 1K
+Predicate,https://schema.org/hasPOS,1K - 10K
+Predicate,https://schema.org/hasPOS-input,< 1K
+Predicate,https://schema.org/hasPOS-output,< 1K
+Predicate,https://schema.org/hasPart,100K - 1M
+Predicate,https://schema.org/hasPart-input,< 1K
+Predicate,https://schema.org/hasPart-output,< 1K
+Predicate,https://schema.org/hasParticipationOffer,< 1K
+Predicate,https://schema.org/hasParticipationOffer-input,< 1K
+Predicate,https://schema.org/hasParticipationOffer-output,< 1K
+Predicate,https://schema.org/hasProductReturnPolicy,< 1K
+Predicate,https://schema.org/hasProductReturnPolicy-input,< 1K
+Predicate,https://schema.org/hasProductReturnPolicy-output,< 1K
+Predicate,https://schema.org/hasRepresentation,< 1K
+Predicate,https://schema.org/hasRepresentation-input,< 1K
+Predicate,https://schema.org/hasRepresentation-output,< 1K
+Predicate,https://schema.org/hasShippingService,10K - 100K
+Predicate,https://schema.org/hasShippingService-input,< 1K
+Predicate,https://schema.org/hasShippingService-output,< 1K
+Predicate,https://schema.org/hasSponsorshipOffer,< 1K
+Predicate,https://schema.org/hasSponsorshipOffer-input,< 1K
+Predicate,https://schema.org/hasSponsorshipOffer-output,< 1K
+Predicate,https://schema.org/hasStore,< 1K
+Predicate,https://schema.org/hasStore-input,< 1K
+Predicate,https://schema.org/hasStore-output,< 1K
+Predicate,https://schema.org/hasTierBenefit,< 1K
+Predicate,https://schema.org/hasTierBenefit-input,< 1K
+Predicate,https://schema.org/hasTierBenefit-output,< 1K
+Predicate,https://schema.org/hasTierRequirement,< 1K
+Predicate,https://schema.org/hasTierRequirement-input,< 1K
+Predicate,https://schema.org/hasTierRequirement-output,< 1K
+Predicate,https://schema.org/hasTiers,< 1K
+Predicate,https://schema.org/hasTiers-input,< 1K
+Predicate,https://schema.org/hasTiers-output,< 1K
+Predicate,https://schema.org/hasVariant,100K - 1M
+Predicate,https://schema.org/hasVariant-input,< 1K
+Predicate,https://schema.org/hasVariant-output,< 1K
+Predicate,https://schema.org/headline,10M+
+Predicate,https://schema.org/headline-input,< 1K
+Predicate,https://schema.org/headline-output,< 1K
+Predicate,https://schema.org/healthCondition,1K - 10K
+Predicate,https://schema.org/healthCondition-input,< 1K
+Predicate,https://schema.org/healthCondition-output,< 1K
+Predicate,https://schema.org/healthPlanCoinsuranceOption,< 1K
+Predicate,https://schema.org/healthPlanCoinsuranceOption-input,< 1K
+Predicate,https://schema.org/healthPlanCoinsuranceOption-output,< 1K
+Predicate,https://schema.org/healthPlanCoinsuranceRate,< 1K
+Predicate,https://schema.org/healthPlanCoinsuranceRate-input,< 1K
+Predicate,https://schema.org/healthPlanCoinsuranceRate-output,< 1K
+Predicate,https://schema.org/healthPlanCopay,< 1K
+Predicate,https://schema.org/healthPlanCopay-input,< 1K
+Predicate,https://schema.org/healthPlanCopay-output,< 1K
+Predicate,https://schema.org/healthPlanCopayOption,< 1K
+Predicate,https://schema.org/healthPlanCopayOption-input,< 1K
+Predicate,https://schema.org/healthPlanCopayOption-output,< 1K
+Predicate,https://schema.org/healthPlanCostSharing,< 1K
+Predicate,https://schema.org/healthPlanCostSharing-input,< 1K
+Predicate,https://schema.org/healthPlanCostSharing-output,< 1K
+Predicate,https://schema.org/healthPlanDrugOption,< 1K
+Predicate,https://schema.org/healthPlanDrugOption-input,< 1K
+Predicate,https://schema.org/healthPlanDrugOption-output,< 1K
+Predicate,https://schema.org/healthPlanDrugTier,< 1K
+Predicate,https://schema.org/healthPlanDrugTier-input,< 1K
+Predicate,https://schema.org/healthPlanDrugTier-output,< 1K
+Predicate,https://schema.org/healthPlanId,< 1K
+Predicate,https://schema.org/healthPlanId-input,< 1K
+Predicate,https://schema.org/healthPlanId-output,< 1K
+Predicate,https://schema.org/healthPlanMarketingUrl,< 1K
+Predicate,https://schema.org/healthPlanMarketingUrl-input,< 1K
+Predicate,https://schema.org/healthPlanMarketingUrl-output,< 1K
+Predicate,https://schema.org/healthPlanNetworkId,< 1K
+Predicate,https://schema.org/healthPlanNetworkId-input,< 1K
+Predicate,https://schema.org/healthPlanNetworkId-output,< 1K
+Predicate,https://schema.org/healthPlanNetworkTier,< 1K
+Predicate,https://schema.org/healthPlanNetworkTier-input,< 1K
+Predicate,https://schema.org/healthPlanNetworkTier-output,< 1K
+Predicate,https://schema.org/healthPlanPharmacyCategory,< 1K
+Predicate,https://schema.org/healthPlanPharmacyCategory-input,< 1K
+Predicate,https://schema.org/healthPlanPharmacyCategory-output,< 1K
+Predicate,https://schema.org/healthcareReportingData,< 1K
+Predicate,https://schema.org/healthcareReportingData-input,< 1K
+Predicate,https://schema.org/healthcareReportingData-output,< 1K
+Predicate,https://schema.org/height,10M+
+Predicate,https://schema.org/height-input,< 1K
+Predicate,https://schema.org/height-output,< 1K
+Predicate,https://schema.org/highPrice,1M - 10M
+Predicate,https://schema.org/highPrice-input,< 1K
+Predicate,https://schema.org/highPrice-output,< 1K
+Predicate,https://schema.org/hiringOrganization,100K - 1M
+Predicate,https://schema.org/hiringOrganization-input,< 1K
+Predicate,https://schema.org/hiringOrganization-output,< 1K
+Predicate,https://schema.org/holdingArchive,< 1K
+Predicate,https://schema.org/holdingArchive-input,< 1K
+Predicate,https://schema.org/holdingArchive-output,< 1K
+Predicate,https://schema.org/homeLocation,10K - 100K
+Predicate,https://schema.org/homeLocation-input,< 1K
+Predicate,https://schema.org/homeLocation-output,< 1K
+Predicate,https://schema.org/homeTeam,10K - 100K
+Predicate,https://schema.org/homeTeam-input,< 1K
+Predicate,https://schema.org/homeTeam-output,< 1K
+Predicate,https://schema.org/honorificPrefix,10K - 100K
+Predicate,https://schema.org/honorificPrefix-input,< 1K
+Predicate,https://schema.org/honorificPrefix-output,< 1K
+Predicate,https://schema.org/honorificSuffix,10K - 100K
+Predicate,https://schema.org/honorificSuffix-input,< 1K
+Predicate,https://schema.org/honorificSuffix-output,< 1K
+Predicate,https://schema.org/hospitalAffiliation,1K - 10K
+Predicate,https://schema.org/hospitalAffiliation-input,< 1K
+Predicate,https://schema.org/hospitalAffiliation-output,< 1K
+Predicate,https://schema.org/hostingOrganization,1K - 10K
+Predicate,https://schema.org/hostingOrganization-input,< 1K
+Predicate,https://schema.org/hostingOrganization-output,< 1K
+Predicate,https://schema.org/hoursAvailable,100K - 1M
+Predicate,https://schema.org/hoursAvailable-input,< 1K
+Predicate,https://schema.org/hoursAvailable-output,< 1K
+Predicate,https://schema.org/howPerformed,1K - 10K
+Predicate,https://schema.org/howPerformed-input,< 1K
+Predicate,https://schema.org/howPerformed-output,< 1K
+Predicate,https://schema.org/httpMethod,1K - 10K
+Predicate,https://schema.org/httpMethod-input,< 1K
+Predicate,https://schema.org/httpMethod-output,< 1K
+Predicate,https://schema.org/iataCode,1K - 10K
+Predicate,https://schema.org/iataCode-input,< 1K
+Predicate,https://schema.org/iataCode-output,< 1K
+Predicate,https://schema.org/icaoCode,< 1K
+Predicate,https://schema.org/icaoCode-input,< 1K
+Predicate,https://schema.org/icaoCode-output,< 1K
+Predicate,https://schema.org/identifier,100K - 1M
+Predicate,https://schema.org/identifier-input,< 1K
+Predicate,https://schema.org/identifier-output,< 1K
+Predicate,https://schema.org/identifyingExam,< 1K
+Predicate,https://schema.org/identifyingExam-input,< 1K
+Predicate,https://schema.org/identifyingExam-output,< 1K
+Predicate,https://schema.org/identifyingTest,< 1K
+Predicate,https://schema.org/identifyingTest-input,< 1K
+Predicate,https://schema.org/identifyingTest-output,< 1K
+Predicate,https://schema.org/illustrator,1K - 10K
+Predicate,https://schema.org/illustrator-input,< 1K
+Predicate,https://schema.org/illustrator-output,< 1K
+Predicate,https://schema.org/image,10M+
+Predicate,https://schema.org/image-input,< 1K
+Predicate,https://schema.org/image-output,< 1K
+Predicate,https://schema.org/imagingTechnique,< 1K
+Predicate,https://schema.org/imagingTechnique-input,< 1K
+Predicate,https://schema.org/imagingTechnique-output,< 1K
+Predicate,https://schema.org/inAlbum,10K - 100K
+Predicate,https://schema.org/inAlbum-input,< 1K
+Predicate,https://schema.org/inAlbum-output,< 1K
+Predicate,https://schema.org/inBroadcastLineup,< 1K
+Predicate,https://schema.org/inBroadcastLineup-input,< 1K
+Predicate,https://schema.org/inBroadcastLineup-output,< 1K
+Predicate,https://schema.org/inChI,< 1K
+Predicate,https://schema.org/inChI-input,< 1K
+Predicate,https://schema.org/inChI-output,< 1K
+Predicate,https://schema.org/inChIKey,< 1K
+Predicate,https://schema.org/inChIKey-input,< 1K
+Predicate,https://schema.org/inChIKey-output,< 1K
+Predicate,https://schema.org/inCodeSet,1K - 10K
+Predicate,https://schema.org/inCodeSet-input,< 1K
+Predicate,https://schema.org/inCodeSet-output,< 1K
+Predicate,https://schema.org/inDefinedTermSet,10K - 100K
+Predicate,https://schema.org/inDefinedTermSet-input,< 1K
+Predicate,https://schema.org/inDefinedTermSet-output,< 1K
+Predicate,https://schema.org/inLanguage,10M+
+Predicate,https://schema.org/inLanguage-input,< 1K
+Predicate,https://schema.org/inLanguage-output,< 1K
+Predicate,https://schema.org/inPlaylist,< 1K
+Predicate,https://schema.org/inPlaylist-input,< 1K
+Predicate,https://schema.org/inPlaylist-output,< 1K
+Predicate,https://schema.org/inProductGroupWithID,1K - 10K
+Predicate,https://schema.org/inProductGroupWithID-input,< 1K
+Predicate,https://schema.org/inProductGroupWithID-output,< 1K
+Predicate,https://schema.org/inStoreReturnsOffered,1K - 10K
+Predicate,https://schema.org/inStoreReturnsOffered-input,< 1K
+Predicate,https://schema.org/inStoreReturnsOffered-output,< 1K
+Predicate,https://schema.org/inSupportOf,< 1K
+Predicate,https://schema.org/inSupportOf-input,< 1K
+Predicate,https://schema.org/inSupportOf-output,< 1K
+Predicate,https://schema.org/incentiveAmount,< 1K
+Predicate,https://schema.org/incentiveAmount-input,< 1K
+Predicate,https://schema.org/incentiveAmount-output,< 1K
+Predicate,https://schema.org/incentiveCompensation,1K - 10K
+Predicate,https://schema.org/incentiveCompensation-input,< 1K
+Predicate,https://schema.org/incentiveCompensation-output,< 1K
+Predicate,https://schema.org/incentiveStatus,< 1K
+Predicate,https://schema.org/incentiveStatus-input,< 1K
+Predicate,https://schema.org/incentiveStatus-output,< 1K
+Predicate,https://schema.org/incentiveType,< 1K
+Predicate,https://schema.org/incentiveType-input,< 1K
+Predicate,https://schema.org/incentiveType-output,< 1K
+Predicate,https://schema.org/incentives,< 1K
+Predicate,https://schema.org/incentives-input,< 1K
+Predicate,https://schema.org/incentives-output,< 1K
+Predicate,https://schema.org/incentivizedItem,< 1K
+Predicate,https://schema.org/incentivizedItem-input,< 1K
+Predicate,https://schema.org/incentivizedItem-output,< 1K
+Predicate,https://schema.org/includedComposition,< 1K
+Predicate,https://schema.org/includedComposition-input,< 1K
+Predicate,https://schema.org/includedComposition-output,< 1K
+Predicate,https://schema.org/includedDataCatalog,< 1K
+Predicate,https://schema.org/includedDataCatalog-input,< 1K
+Predicate,https://schema.org/includedDataCatalog-output,< 1K
+Predicate,https://schema.org/includedInDataCatalog,1K - 10K
+Predicate,https://schema.org/includedInDataCatalog-input,< 1K
+Predicate,https://schema.org/includedInDataCatalog-output,< 1K
+Predicate,https://schema.org/includedInHealthInsurancePlan,< 1K
+Predicate,https://schema.org/includedInHealthInsurancePlan-input,< 1K
+Predicate,https://schema.org/includedInHealthInsurancePlan-output,< 1K
+Predicate,https://schema.org/includedRiskFactor,< 1K
+Predicate,https://schema.org/includedRiskFactor-input,< 1K
+Predicate,https://schema.org/includedRiskFactor-output,< 1K
+Predicate,https://schema.org/includesAttraction,1K - 10K
+Predicate,https://schema.org/includesAttraction-input,< 1K
+Predicate,https://schema.org/includesAttraction-output,< 1K
+Predicate,https://schema.org/includesHealthPlanFormulary,< 1K
+Predicate,https://schema.org/includesHealthPlanFormulary-input,< 1K
+Predicate,https://schema.org/includesHealthPlanFormulary-output,< 1K
+Predicate,https://schema.org/includesHealthPlanNetwork,< 1K
+Predicate,https://schema.org/includesHealthPlanNetwork-input,< 1K
+Predicate,https://schema.org/includesHealthPlanNetwork-output,< 1K
+Predicate,https://schema.org/includesObject,1K - 10K
+Predicate,https://schema.org/includesObject-input,< 1K
+Predicate,https://schema.org/includesObject-output,< 1K
+Predicate,https://schema.org/incomeLimit,< 1K
+Predicate,https://schema.org/incomeLimit-input,< 1K
+Predicate,https://schema.org/incomeLimit-output,< 1K
+Predicate,https://schema.org/increasesRiskOf,< 1K
+Predicate,https://schema.org/increasesRiskOf-input,< 1K
+Predicate,https://schema.org/increasesRiskOf-output,< 1K
+Predicate,https://schema.org/industry,10K - 100K
+Predicate,https://schema.org/industry-input,< 1K
+Predicate,https://schema.org/industry-output,< 1K
+Predicate,https://schema.org/ineligibleRegion,< 1K
+Predicate,https://schema.org/ineligibleRegion-input,< 1K
+Predicate,https://schema.org/ineligibleRegion-output,< 1K
+Predicate,https://schema.org/infectiousAgent,< 1K
+Predicate,https://schema.org/infectiousAgent-input,< 1K
+Predicate,https://schema.org/infectiousAgent-output,< 1K
+Predicate,https://schema.org/infectiousAgentClass,< 1K
+Predicate,https://schema.org/infectiousAgentClass-input,< 1K
+Predicate,https://schema.org/infectiousAgentClass-output,< 1K
+Predicate,https://schema.org/ingredients,1K - 10K
+Predicate,https://schema.org/ingredients-input,< 1K
+Predicate,https://schema.org/ingredients-output,< 1K
+Predicate,https://schema.org/inker,< 1K
+Predicate,https://schema.org/inker-input,< 1K
+Predicate,https://schema.org/inker-output,< 1K
+Predicate,https://schema.org/insertion,< 1K
+Predicate,https://schema.org/insertion-input,< 1K
+Predicate,https://schema.org/insertion-output,< 1K
+Predicate,https://schema.org/installUrl,10K - 100K
+Predicate,https://schema.org/installUrl-input,< 1K
+Predicate,https://schema.org/installUrl-output,< 1K
+Predicate,https://schema.org/instructor,10K - 100K
+Predicate,https://schema.org/instructor-input,< 1K
+Predicate,https://schema.org/instructor-output,< 1K
+Predicate,https://schema.org/instrument,1K - 10K
+Predicate,https://schema.org/instrument-input,< 1K
+Predicate,https://schema.org/instrument-output,< 1K
+Predicate,https://schema.org/intensity,< 1K
+Predicate,https://schema.org/intensity-input,< 1K
+Predicate,https://schema.org/intensity-output,< 1K
+Predicate,https://schema.org/interactingDrug,< 1K
+Predicate,https://schema.org/interactingDrug-input,< 1K
+Predicate,https://schema.org/interactingDrug-output,< 1K
+Predicate,https://schema.org/interactionCount,100K - 1M
+Predicate,https://schema.org/interactionCount-input,< 1K
+Predicate,https://schema.org/interactionCount-output,< 1K
+Predicate,https://schema.org/interactionService,< 1K
+Predicate,https://schema.org/interactionService-input,< 1K
+Predicate,https://schema.org/interactionService-output,< 1K
+Predicate,https://schema.org/interactionStatistic,100K - 1M
+Predicate,https://schema.org/interactionStatistic-input,< 1K
+Predicate,https://schema.org/interactionStatistic-output,< 1K
+Predicate,https://schema.org/interactionType,100K - 1M
+Predicate,https://schema.org/interactionType-input,< 1K
+Predicate,https://schema.org/interactionType-output,< 1K
+Predicate,https://schema.org/interactivityType,1K - 10K
+Predicate,https://schema.org/interactivityType-input,< 1K
+Predicate,https://schema.org/interactivityType-output,< 1K
+Predicate,https://schema.org/interestRate,1K - 10K
+Predicate,https://schema.org/interestRate-input,< 1K
+Predicate,https://schema.org/interestRate-output,< 1K
+Predicate,https://schema.org/interpretedAsClaim,< 1K
+Predicate,https://schema.org/interpretedAsClaim-input,< 1K
+Predicate,https://schema.org/interpretedAsClaim-output,< 1K
+Predicate,https://schema.org/inventoryLevel,100K - 1M
+Predicate,https://schema.org/inventoryLevel-input,< 1K
+Predicate,https://schema.org/inventoryLevel-output,< 1K
+Predicate,https://schema.org/inverseOf,< 1K
+Predicate,https://schema.org/inverseOf-input,< 1K
+Predicate,https://schema.org/inverseOf-output,< 1K
+Predicate,https://schema.org/isAcceptingNewPatients,10K - 100K
+Predicate,https://schema.org/isAcceptingNewPatients-input,< 1K
+Predicate,https://schema.org/isAcceptingNewPatients-output,< 1K
+Predicate,https://schema.org/isAccessibleForFree,100K - 1M
+Predicate,https://schema.org/isAccessibleForFree-input,< 1K
+Predicate,https://schema.org/isAccessibleForFree-output,< 1K
+Predicate,https://schema.org/isAccessoryOrSparePartFor,1K - 10K
+Predicate,https://schema.org/isAccessoryOrSparePartFor-input,< 1K
+Predicate,https://schema.org/isAccessoryOrSparePartFor-output,< 1K
+Predicate,https://schema.org/isAvailableGenerically,< 1K
+Predicate,https://schema.org/isAvailableGenerically-input,< 1K
+Predicate,https://schema.org/isAvailableGenerically-output,< 1K
+Predicate,https://schema.org/isBasedOn,10K - 100K
+Predicate,https://schema.org/isBasedOn-input,< 1K
+Predicate,https://schema.org/isBasedOn-output,< 1K
+Predicate,https://schema.org/isBasedOnUrl,< 1K
+Predicate,https://schema.org/isBasedOnUrl-input,< 1K
+Predicate,https://schema.org/isBasedOnUrl-output,< 1K
+Predicate,https://schema.org/isConsumableFor,< 1K
+Predicate,https://schema.org/isConsumableFor-input,< 1K
+Predicate,https://schema.org/isConsumableFor-output,< 1K
+Predicate,https://schema.org/isEncodedByBioChemEntity,< 1K
+Predicate,https://schema.org/isEncodedByBioChemEntity-input,< 1K
+Predicate,https://schema.org/isEncodedByBioChemEntity-output,< 1K
+Predicate,https://schema.org/isFamilyFriendly,100K - 1M
+Predicate,https://schema.org/isFamilyFriendly-input,< 1K
+Predicate,https://schema.org/isFamilyFriendly-output,< 1K
+Predicate,https://schema.org/isGift,< 1K
+Predicate,https://schema.org/isGift-input,< 1K
+Predicate,https://schema.org/isGift-output,< 1K
+Predicate,https://schema.org/isInvolvedInBiologicalProcess,< 1K
+Predicate,https://schema.org/isInvolvedInBiologicalProcess-input,< 1K
+Predicate,https://schema.org/isInvolvedInBiologicalProcess-output,< 1K
+Predicate,https://schema.org/isLiveBroadcast,10K - 100K
+Predicate,https://schema.org/isLiveBroadcast-input,< 1K
+Predicate,https://schema.org/isLiveBroadcast-output,< 1K
+Predicate,https://schema.org/isLocatedInSubcellularLocation,< 1K
+Predicate,https://schema.org/isLocatedInSubcellularLocation-input,< 1K
+Predicate,https://schema.org/isLocatedInSubcellularLocation-output,< 1K
+Predicate,https://schema.org/isPartOf,10M+
+Predicate,https://schema.org/isPartOf-input,< 1K
+Predicate,https://schema.org/isPartOf-output,< 1K
+Predicate,https://schema.org/isPartOfBioChemEntity,< 1K
+Predicate,https://schema.org/isPartOfBioChemEntity-input,< 1K
+Predicate,https://schema.org/isPartOfBioChemEntity-output,< 1K
+Predicate,https://schema.org/isPlanForApartment,< 1K
+Predicate,https://schema.org/isPlanForApartment-input,< 1K
+Predicate,https://schema.org/isPlanForApartment-output,< 1K
+Predicate,https://schema.org/isProprietary,< 1K
+Predicate,https://schema.org/isProprietary-input,< 1K
+Predicate,https://schema.org/isProprietary-output,< 1K
+Predicate,https://schema.org/isRelatedTo,100K - 1M
+Predicate,https://schema.org/isRelatedTo-input,< 1K
+Predicate,https://schema.org/isRelatedTo-output,< 1K
+Predicate,https://schema.org/isResizable,< 1K
+Predicate,https://schema.org/isResizable-input,< 1K
+Predicate,https://schema.org/isResizable-output,< 1K
+Predicate,https://schema.org/isSimilarTo,1K - 10K
+Predicate,https://schema.org/isSimilarTo-input,< 1K
+Predicate,https://schema.org/isSimilarTo-output,< 1K
+Predicate,https://schema.org/isStoreOn,< 1K
+Predicate,https://schema.org/isStoreOn-input,< 1K
+Predicate,https://schema.org/isStoreOn-output,< 1K
+Predicate,https://schema.org/isTierOf,< 1K
+Predicate,https://schema.org/isTierOf-input,< 1K
+Predicate,https://schema.org/isTierOf-output,< 1K
+Predicate,https://schema.org/isUnlabelledFallback,< 1K
+Predicate,https://schema.org/isUnlabelledFallback-input,< 1K
+Predicate,https://schema.org/isUnlabelledFallback-output,< 1K
+Predicate,https://schema.org/isVariantOf,1K - 10K
+Predicate,https://schema.org/isVariantOf-input,< 1K
+Predicate,https://schema.org/isVariantOf-output,< 1K
+Predicate,https://schema.org/isbn,10K - 100K
+Predicate,https://schema.org/isbn-input,< 1K
+Predicate,https://schema.org/isbn-output,< 1K
+Predicate,https://schema.org/isicV4,1K - 10K
+Predicate,https://schema.org/isicV4-input,< 1K
+Predicate,https://schema.org/isicV4-output,< 1K
+Predicate,https://schema.org/iso6523Code,1K - 10K
+Predicate,https://schema.org/iso6523Code-input,< 1K
+Predicate,https://schema.org/iso6523Code-output,< 1K
+Predicate,https://schema.org/isrcCode,< 1K
+Predicate,https://schema.org/isrcCode-input,< 1K
+Predicate,https://schema.org/isrcCode-output,< 1K
+Predicate,https://schema.org/issn,1K - 10K
+Predicate,https://schema.org/issn-input,< 1K
+Predicate,https://schema.org/issn-output,< 1K
+Predicate,https://schema.org/issueNumber,1K - 10K
+Predicate,https://schema.org/issueNumber-input,< 1K
+Predicate,https://schema.org/issueNumber-output,< 1K
+Predicate,https://schema.org/issuedBy,10K - 100K
+Predicate,https://schema.org/issuedBy-input,< 1K
+Predicate,https://schema.org/issuedBy-output,< 1K
+Predicate,https://schema.org/issuedThrough,< 1K
+Predicate,https://schema.org/issuedThrough-input,< 1K
+Predicate,https://schema.org/issuedThrough-output,< 1K
+Predicate,https://schema.org/iswcCode,< 1K
+Predicate,https://schema.org/iswcCode-input,< 1K
+Predicate,https://schema.org/iswcCode-output,< 1K
+Predicate,https://schema.org/item,10M+
+Predicate,https://schema.org/item-input,< 1K
+Predicate,https://schema.org/item-output,< 1K
+Predicate,https://schema.org/itemCondition,1M - 10M
+Predicate,https://schema.org/itemCondition-input,< 1K
+Predicate,https://schema.org/itemCondition-output,< 1K
+Predicate,https://schema.org/itemDefectReturnFees,1K - 10K
+Predicate,https://schema.org/itemDefectReturnFees-input,< 1K
+Predicate,https://schema.org/itemDefectReturnFees-output,< 1K
+Predicate,https://schema.org/itemDefectReturnLabelSource,< 1K
+Predicate,https://schema.org/itemDefectReturnLabelSource-input,< 1K
+Predicate,https://schema.org/itemDefectReturnLabelSource-output,< 1K
+Predicate,https://schema.org/itemDefectReturnShippingFeesAmount,< 1K
+Predicate,https://schema.org/itemDefectReturnShippingFeesAmount-input,< 1K
+Predicate,https://schema.org/itemDefectReturnShippingFeesAmount-output,< 1K
+Predicate,https://schema.org/itemListElement,10M+
+Predicate,https://schema.org/itemListElement-input,< 1K
+Predicate,https://schema.org/itemListElement-output,< 1K
+Predicate,https://schema.org/itemListOrder,100K - 1M
+Predicate,https://schema.org/itemListOrder-input,< 1K
+Predicate,https://schema.org/itemListOrder-output,< 1K
+Predicate,https://schema.org/itemLocation,< 1K
+Predicate,https://schema.org/itemLocation-input,< 1K
+Predicate,https://schema.org/itemLocation-output,< 1K
+Predicate,https://schema.org/itemOffered,100K - 1M
+Predicate,https://schema.org/itemOffered-input,< 1K
+Predicate,https://schema.org/itemOffered-output,< 1K
+Predicate,https://schema.org/itemReviewed,100K - 1M
+Predicate,https://schema.org/itemReviewed-input,< 1K
+Predicate,https://schema.org/itemReviewed-output,< 1K
+Predicate,https://schema.org/itemShipped,< 1K
+Predicate,https://schema.org/itemShipped-input,< 1K
+Predicate,https://schema.org/itemShipped-output,< 1K
+Predicate,https://schema.org/itinerary,10K - 100K
+Predicate,https://schema.org/itinerary-input,< 1K
+Predicate,https://schema.org/itinerary-output,< 1K
+Predicate,https://schema.org/iupacName,< 1K
+Predicate,https://schema.org/iupacName-input,< 1K
+Predicate,https://schema.org/iupacName-output,< 1K
+Predicate,https://schema.org/jobBenefits,10K - 100K
+Predicate,https://schema.org/jobBenefits-input,< 1K
+Predicate,https://schema.org/jobBenefits-output,< 1K
+Predicate,https://schema.org/jobDuration,< 1K
+Predicate,https://schema.org/jobDuration-input,< 1K
+Predicate,https://schema.org/jobDuration-output,< 1K
+Predicate,https://schema.org/jobImmediateStart,1K - 10K
+Predicate,https://schema.org/jobImmediateStart-input,< 1K
+Predicate,https://schema.org/jobImmediateStart-output,< 1K
+Predicate,https://schema.org/jobLocation,100K - 1M
+Predicate,https://schema.org/jobLocation-input,< 1K
+Predicate,https://schema.org/jobLocation-output,< 1K
+Predicate,https://schema.org/jobLocationType,10K - 100K
+Predicate,https://schema.org/jobLocationType-input,< 1K
+Predicate,https://schema.org/jobLocationType-output,< 1K
+Predicate,https://schema.org/jobStartDate,1K - 10K
+Predicate,https://schema.org/jobStartDate-input,< 1K
+Predicate,https://schema.org/jobStartDate-output,< 1K
+Predicate,https://schema.org/jobTitle,100K - 1M
+Predicate,https://schema.org/jobTitle-input,< 1K
+Predicate,https://schema.org/jobTitle-output,< 1K
+Predicate,https://schema.org/jurisdiction,< 1K
+Predicate,https://schema.org/jurisdiction-input,< 1K
+Predicate,https://schema.org/jurisdiction-output,< 1K
+Predicate,https://schema.org/keywords,1M - 10M
+Predicate,https://schema.org/keywords-input,< 1K
+Predicate,https://schema.org/keywords-output,< 1K
+Predicate,https://schema.org/knownVehicleDamages,< 1K
+Predicate,https://schema.org/knownVehicleDamages-input,< 1K
+Predicate,https://schema.org/knownVehicleDamages-output,< 1K
+Predicate,https://schema.org/knows,1K - 10K
+Predicate,https://schema.org/knows-input,< 1K
+Predicate,https://schema.org/knows-output,< 1K
+Predicate,https://schema.org/knowsAbout,100K - 1M
+Predicate,https://schema.org/knowsAbout-input,< 1K
+Predicate,https://schema.org/knowsAbout-output,< 1K
+Predicate,https://schema.org/knowsLanguage,10K - 100K
+Predicate,https://schema.org/knowsLanguage-input,< 1K
+Predicate,https://schema.org/knowsLanguage-output,< 1K
+Predicate,https://schema.org/labelDetails,< 1K
+Predicate,https://schema.org/labelDetails-input,< 1K
+Predicate,https://schema.org/labelDetails-output,< 1K
+Predicate,https://schema.org/landlord,< 1K
+Predicate,https://schema.org/landlord-input,< 1K
+Predicate,https://schema.org/landlord-output,< 1K
+Predicate,https://schema.org/language,10K - 100K
+Predicate,https://schema.org/language-input,< 1K
+Predicate,https://schema.org/language-output,< 1K
+Predicate,https://schema.org/lastReviewed,10K - 100K
+Predicate,https://schema.org/lastReviewed-input,< 1K
+Predicate,https://schema.org/lastReviewed-output,< 1K
+Predicate,https://schema.org/latitude,1M - 10M
+Predicate,https://schema.org/latitude-input,< 1K
+Predicate,https://schema.org/latitude-output,< 1K
+Predicate,https://schema.org/layoutImage,1K - 10K
+Predicate,https://schema.org/layoutImage-input,< 1K
+Predicate,https://schema.org/layoutImage-output,< 1K
+Predicate,https://schema.org/learningResourceType,10K - 100K
+Predicate,https://schema.org/learningResourceType-input,< 1K
+Predicate,https://schema.org/learningResourceType-output,< 1K
+Predicate,https://schema.org/leaseLength,1K - 10K
+Predicate,https://schema.org/leaseLength-input,< 1K
+Predicate,https://schema.org/leaseLength-output,< 1K
+Predicate,https://schema.org/legalAddress,1K - 10K
+Predicate,https://schema.org/legalAddress-input,< 1K
+Predicate,https://schema.org/legalAddress-output,< 1K
+Predicate,https://schema.org/legalName,1M - 10M
+Predicate,https://schema.org/legalName-input,< 1K
+Predicate,https://schema.org/legalName-output,< 1K
+Predicate,https://schema.org/legalRepresentative,1K - 10K
+Predicate,https://schema.org/legalRepresentative-input,< 1K
+Predicate,https://schema.org/legalRepresentative-output,< 1K
+Predicate,https://schema.org/legalStatus,1K - 10K
+Predicate,https://schema.org/legalStatus-input,< 1K
+Predicate,https://schema.org/legalStatus-output,< 1K
+Predicate,https://schema.org/legislationAmends,< 1K
+Predicate,https://schema.org/legislationAmends-input,< 1K
+Predicate,https://schema.org/legislationAmends-output,< 1K
+Predicate,https://schema.org/legislationApplies,< 1K
+Predicate,https://schema.org/legislationApplies-input,< 1K
+Predicate,https://schema.org/legislationApplies-output,< 1K
+Predicate,https://schema.org/legislationChanges,< 1K
+Predicate,https://schema.org/legislationChanges-input,< 1K
+Predicate,https://schema.org/legislationChanges-output,< 1K
+Predicate,https://schema.org/legislationCommences,< 1K
+Predicate,https://schema.org/legislationCommences-input,< 1K
+Predicate,https://schema.org/legislationCommences-output,< 1K
+Predicate,https://schema.org/legislationConsolidates,< 1K
+Predicate,https://schema.org/legislationConsolidates-input,< 1K
+Predicate,https://schema.org/legislationConsolidates-output,< 1K
+Predicate,https://schema.org/legislationCorrects,< 1K
+Predicate,https://schema.org/legislationCorrects-input,< 1K
+Predicate,https://schema.org/legislationCorrects-output,< 1K
+Predicate,https://schema.org/legislationCountersignedBy,< 1K
+Predicate,https://schema.org/legislationCountersignedBy-input,< 1K
+Predicate,https://schema.org/legislationCountersignedBy-output,< 1K
+Predicate,https://schema.org/legislationDate,< 1K
+Predicate,https://schema.org/legislationDate-input,< 1K
+Predicate,https://schema.org/legislationDate-output,< 1K
+Predicate,https://schema.org/legislationDateOfApplicability,< 1K
+Predicate,https://schema.org/legislationDateOfApplicability-input,< 1K
+Predicate,https://schema.org/legislationDateOfApplicability-output,< 1K
+Predicate,https://schema.org/legislationDateVersion,< 1K
+Predicate,https://schema.org/legislationDateVersion-input,< 1K
+Predicate,https://schema.org/legislationDateVersion-output,< 1K
+Predicate,https://schema.org/legislationEnsuresImplementationOf,< 1K
+Predicate,https://schema.org/legislationEnsuresImplementationOf-input,< 1K
+Predicate,https://schema.org/legislationEnsuresImplementationOf-output,< 1K
+Predicate,https://schema.org/legislationIdentifier,< 1K
+Predicate,https://schema.org/legislationIdentifier-input,< 1K
+Predicate,https://schema.org/legislationIdentifier-output,< 1K
+Predicate,https://schema.org/legislationJurisdiction,1K - 10K
+Predicate,https://schema.org/legislationJurisdiction-input,< 1K
+Predicate,https://schema.org/legislationJurisdiction-output,< 1K
+Predicate,https://schema.org/legislationLegalForce,< 1K
+Predicate,https://schema.org/legislationLegalForce-input,< 1K
+Predicate,https://schema.org/legislationLegalForce-output,< 1K
+Predicate,https://schema.org/legislationLegalValue,< 1K
+Predicate,https://schema.org/legislationLegalValue-input,< 1K
+Predicate,https://schema.org/legislationLegalValue-output,< 1K
+Predicate,https://schema.org/legislationPassedBy,< 1K
+Predicate,https://schema.org/legislationPassedBy-input,< 1K
+Predicate,https://schema.org/legislationPassedBy-output,< 1K
+Predicate,https://schema.org/legislationRepeals,< 1K
+Predicate,https://schema.org/legislationRepeals-input,< 1K
+Predicate,https://schema.org/legislationRepeals-output,< 1K
+Predicate,https://schema.org/legislationResponsible,< 1K
+Predicate,https://schema.org/legislationResponsible-input,< 1K
+Predicate,https://schema.org/legislationResponsible-output,< 1K
+Predicate,https://schema.org/legislationTransposes,< 1K
+Predicate,https://schema.org/legislationTransposes-input,< 1K
+Predicate,https://schema.org/legislationTransposes-output,< 1K
+Predicate,https://schema.org/legislationType,< 1K
+Predicate,https://schema.org/legislationType-input,< 1K
+Predicate,https://schema.org/legislationType-output,< 1K
+Predicate,https://schema.org/leiCode,1K - 10K
+Predicate,https://schema.org/leiCode-input,< 1K
+Predicate,https://schema.org/leiCode-output,< 1K
+Predicate,https://schema.org/lender,< 1K
+Predicate,https://schema.org/lender-input,< 1K
+Predicate,https://schema.org/lender-output,< 1K
+Predicate,https://schema.org/lesser,< 1K
+Predicate,https://schema.org/lesser-input,< 1K
+Predicate,https://schema.org/lesser-output,< 1K
+Predicate,https://schema.org/lesserOrEqual,< 1K
+Predicate,https://schema.org/lesserOrEqual-input,< 1K
+Predicate,https://schema.org/lesserOrEqual-output,< 1K
+Predicate,https://schema.org/letterer,< 1K
+Predicate,https://schema.org/letterer-input,< 1K
+Predicate,https://schema.org/letterer-output,< 1K
+Predicate,https://schema.org/license,100K - 1M
+Predicate,https://schema.org/license-input,< 1K
+Predicate,https://schema.org/license-output,< 1K
+Predicate,https://schema.org/lifeEvent,< 1K
+Predicate,https://schema.org/lifeEvent-input,< 1K
+Predicate,https://schema.org/lifeEvent-output,< 1K
+Predicate,https://schema.org/line,< 1K
+Predicate,https://schema.org/line-input,< 1K
+Predicate,https://schema.org/line-output,< 1K
+Predicate,https://schema.org/linkRelationship,< 1K
+Predicate,https://schema.org/linkRelationship-input,< 1K
+Predicate,https://schema.org/linkRelationship-output,< 1K
+Predicate,https://schema.org/liveBlogUpdate,1K - 10K
+Predicate,https://schema.org/liveBlogUpdate-input,< 1K
+Predicate,https://schema.org/liveBlogUpdate-output,< 1K
+Predicate,https://schema.org/loanMortgageMandateAmount,< 1K
+Predicate,https://schema.org/loanMortgageMandateAmount-input,< 1K
+Predicate,https://schema.org/loanMortgageMandateAmount-output,< 1K
+Predicate,https://schema.org/loanPaymentAmount,< 1K
+Predicate,https://schema.org/loanPaymentAmount-input,< 1K
+Predicate,https://schema.org/loanPaymentAmount-output,< 1K
+Predicate,https://schema.org/loanPaymentFrequency,< 1K
+Predicate,https://schema.org/loanPaymentFrequency-input,< 1K
+Predicate,https://schema.org/loanPaymentFrequency-output,< 1K
+Predicate,https://schema.org/loanRepaymentForm,< 1K
+Predicate,https://schema.org/loanRepaymentForm-input,< 1K
+Predicate,https://schema.org/loanRepaymentForm-output,< 1K
+Predicate,https://schema.org/loanTerm,1K - 10K
+Predicate,https://schema.org/loanTerm-input,< 1K
+Predicate,https://schema.org/loanTerm-output,< 1K
+Predicate,https://schema.org/loanType,1K - 10K
+Predicate,https://schema.org/loanType-input,< 1K
+Predicate,https://schema.org/loanType-output,< 1K
+Predicate,https://schema.org/location,1M - 10M
+Predicate,https://schema.org/location-input,< 1K
+Predicate,https://schema.org/location-output,< 1K
+Predicate,https://schema.org/locationCreated,10K - 100K
+Predicate,https://schema.org/locationCreated-input,< 1K
+Predicate,https://schema.org/locationCreated-output,< 1K
+Predicate,https://schema.org/lodgingUnitDescription,< 1K
+Predicate,https://schema.org/lodgingUnitDescription-input,< 1K
+Predicate,https://schema.org/lodgingUnitDescription-output,< 1K
+Predicate,https://schema.org/lodgingUnitType,< 1K
+Predicate,https://schema.org/lodgingUnitType-input,< 1K
+Predicate,https://schema.org/lodgingUnitType-output,< 1K
+Predicate,https://schema.org/logo,10M+
+Predicate,https://schema.org/logo-input,< 1K
+Predicate,https://schema.org/logo-output,< 1K
+Predicate,https://schema.org/longitude,1M - 10M
+Predicate,https://schema.org/longitude-input,< 1K
+Predicate,https://schema.org/longitude-output,< 1K
+Predicate,https://schema.org/loser,< 1K
+Predicate,https://schema.org/loser-input,< 1K
+Predicate,https://schema.org/loser-output,< 1K
+Predicate,https://schema.org/lowPrice,1M - 10M
+Predicate,https://schema.org/lowPrice-input,< 1K
+Predicate,https://schema.org/lowPrice-output,< 1K
+Predicate,https://schema.org/lyricist,< 1K
+Predicate,https://schema.org/lyricist-input,< 1K
+Predicate,https://schema.org/lyricist-output,< 1K
+Predicate,https://schema.org/lyrics,1K - 10K
+Predicate,https://schema.org/lyrics-input,< 1K
+Predicate,https://schema.org/lyrics-output,< 1K
+Predicate,https://schema.org/mainContentOfPage,1M - 10M
+Predicate,https://schema.org/mainContentOfPage-input,< 1K
+Predicate,https://schema.org/mainContentOfPage-output,< 1K
+Predicate,https://schema.org/mainEntity,1M - 10M
+Predicate,https://schema.org/mainEntity-input,< 1K
+Predicate,https://schema.org/mainEntity-output,< 1K
+Predicate,https://schema.org/mainEntityOfPage,10M+
+Predicate,https://schema.org/mainEntityOfPage-input,< 1K
+Predicate,https://schema.org/mainEntityOfPage-output,< 1K
+Predicate,https://schema.org/maintainer,1K - 10K
+Predicate,https://schema.org/maintainer-input,< 1K
+Predicate,https://schema.org/maintainer-output,< 1K
+Predicate,https://schema.org/makesOffer,100K - 1M
+Predicate,https://schema.org/makesOffer-input,< 1K
+Predicate,https://schema.org/makesOffer-output,< 1K
+Predicate,https://schema.org/manufacturer,100K - 1M
+Predicate,https://schema.org/manufacturer-input,< 1K
+Predicate,https://schema.org/manufacturer-output,< 1K
+Predicate,https://schema.org/map,1K - 10K
+Predicate,https://schema.org/map-input,< 1K
+Predicate,https://schema.org/map-output,< 1K
+Predicate,https://schema.org/mapType,1K - 10K
+Predicate,https://schema.org/mapType-input,< 1K
+Predicate,https://schema.org/mapType-output,< 1K
+Predicate,https://schema.org/maps,1K - 10K
+Predicate,https://schema.org/maps-input,< 1K
+Predicate,https://schema.org/maps-output,< 1K
+Predicate,https://schema.org/marginOfError,< 1K
+Predicate,https://schema.org/marginOfError-input,< 1K
+Predicate,https://schema.org/marginOfError-output,< 1K
+Predicate,https://schema.org/masthead,10K - 100K
+Predicate,https://schema.org/masthead-input,< 1K
+Predicate,https://schema.org/masthead-output,< 1K
+Predicate,https://schema.org/material,10K - 100K
+Predicate,https://schema.org/material-input,< 1K
+Predicate,https://schema.org/material-output,< 1K
+Predicate,https://schema.org/materialExtent,< 1K
+Predicate,https://schema.org/materialExtent-input,< 1K
+Predicate,https://schema.org/materialExtent-output,< 1K
+Predicate,https://schema.org/mathExpression,< 1K
+Predicate,https://schema.org/mathExpression-input,< 1K
+Predicate,https://schema.org/mathExpression-output,< 1K
+Predicate,https://schema.org/maxPrice,10K - 100K
+Predicate,https://schema.org/maxPrice-input,< 1K
+Predicate,https://schema.org/maxPrice-output,< 1K
+Predicate,https://schema.org/maxValue,100K - 1M
+Predicate,https://schema.org/maxValue-input,< 1K
+Predicate,https://schema.org/maxValue-output,< 1K
+Predicate,https://schema.org/maximumAttendeeCapacity,10K - 100K
+Predicate,https://schema.org/maximumAttendeeCapacity-input,< 1K
+Predicate,https://schema.org/maximumAttendeeCapacity-output,< 1K
+Predicate,https://schema.org/maximumEnrollment,< 1K
+Predicate,https://schema.org/maximumEnrollment-input,< 1K
+Predicate,https://schema.org/maximumEnrollment-output,< 1K
+Predicate,https://schema.org/maximumIntake,< 1K
+Predicate,https://schema.org/maximumIntake-input,< 1K
+Predicate,https://schema.org/maximumIntake-output,< 1K
+Predicate,https://schema.org/maximumPhysicalAttendeeCapacity,< 1K
+Predicate,https://schema.org/maximumPhysicalAttendeeCapacity-input,< 1K
+Predicate,https://schema.org/maximumPhysicalAttendeeCapacity-output,< 1K
+Predicate,https://schema.org/maximumVirtualAttendeeCapacity,< 1K
+Predicate,https://schema.org/maximumVirtualAttendeeCapacity-input,< 1K
+Predicate,https://schema.org/maximumVirtualAttendeeCapacity-output,< 1K
+Predicate,https://schema.org/mealService,< 1K
+Predicate,https://schema.org/mealService-input,< 1K
+Predicate,https://schema.org/mealService-output,< 1K
+Predicate,https://schema.org/measuredProperty,< 1K
+Predicate,https://schema.org/measuredProperty-input,< 1K
+Predicate,https://schema.org/measuredProperty-output,< 1K
+Predicate,https://schema.org/measurementDenominator,< 1K
+Predicate,https://schema.org/measurementDenominator-input,< 1K
+Predicate,https://schema.org/measurementDenominator-output,< 1K
+Predicate,https://schema.org/measurementMethod,< 1K
+Predicate,https://schema.org/measurementMethod-input,< 1K
+Predicate,https://schema.org/measurementMethod-output,< 1K
+Predicate,https://schema.org/measurementQualifier,< 1K
+Predicate,https://schema.org/measurementQualifier-input,< 1K
+Predicate,https://schema.org/measurementQualifier-output,< 1K
+Predicate,https://schema.org/measurementTechnique,1K - 10K
+Predicate,https://schema.org/measurementTechnique-input,< 1K
+Predicate,https://schema.org/measurementTechnique-output,< 1K
+Predicate,https://schema.org/mechanismOfAction,< 1K
+Predicate,https://schema.org/mechanismOfAction-input,< 1K
+Predicate,https://schema.org/mechanismOfAction-output,< 1K
+Predicate,https://schema.org/mediaAuthenticityCategory,< 1K
+Predicate,https://schema.org/mediaAuthenticityCategory-input,< 1K
+Predicate,https://schema.org/mediaAuthenticityCategory-output,< 1K
+Predicate,https://schema.org/mediaItemAppearance,< 1K
+Predicate,https://schema.org/mediaItemAppearance-input,< 1K
+Predicate,https://schema.org/mediaItemAppearance-output,< 1K
+Predicate,https://schema.org/median,1K - 10K
+Predicate,https://schema.org/median-input,< 1K
+Predicate,https://schema.org/median-output,< 1K
+Predicate,https://schema.org/medicalAudience,1K - 10K
+Predicate,https://schema.org/medicalAudience-input,< 1K
+Predicate,https://schema.org/medicalAudience-output,< 1K
+Predicate,https://schema.org/medicalSpecialty,10K - 100K
+Predicate,https://schema.org/medicalSpecialty-input,< 1K
+Predicate,https://schema.org/medicalSpecialty-output,< 1K
+Predicate,https://schema.org/medicineSystem,1K - 10K
+Predicate,https://schema.org/medicineSystem-input,< 1K
+Predicate,https://schema.org/medicineSystem-output,< 1K
+Predicate,https://schema.org/meetsEmissionStandard,< 1K
+Predicate,https://schema.org/meetsEmissionStandard-input,< 1K
+Predicate,https://schema.org/meetsEmissionStandard-output,< 1K
+Predicate,https://schema.org/member,10K - 100K
+Predicate,https://schema.org/member-input,< 1K
+Predicate,https://schema.org/member-output,< 1K
+Predicate,https://schema.org/memberOf,10K - 100K
+Predicate,https://schema.org/memberOf-input,< 1K
+Predicate,https://schema.org/memberOf-output,< 1K
+Predicate,https://schema.org/members,< 1K
+Predicate,https://schema.org/members-input,< 1K
+Predicate,https://schema.org/members-output,< 1K
+Predicate,https://schema.org/membershipNumber,< 1K
+Predicate,https://schema.org/membershipNumber-input,< 1K
+Predicate,https://schema.org/membershipNumber-output,< 1K
+Predicate,https://schema.org/membershipPointsEarned,< 1K
+Predicate,https://schema.org/membershipPointsEarned-input,< 1K
+Predicate,https://schema.org/membershipPointsEarned-output,< 1K
+Predicate,https://schema.org/memoryRequirements,1K - 10K
+Predicate,https://schema.org/memoryRequirements-input,< 1K
+Predicate,https://schema.org/memoryRequirements-output,< 1K
+Predicate,https://schema.org/mentions,10K - 100K
+Predicate,https://schema.org/mentions-input,< 1K
+Predicate,https://schema.org/mentions-output,< 1K
+Predicate,https://schema.org/menu,10K - 100K
+Predicate,https://schema.org/menu-input,< 1K
+Predicate,https://schema.org/menu-output,< 1K
+Predicate,https://schema.org/menuAddOn,1K - 10K
+Predicate,https://schema.org/menuAddOn-input,< 1K
+Predicate,https://schema.org/menuAddOn-output,< 1K
+Predicate,https://schema.org/merchant,< 1K
+Predicate,https://schema.org/merchant-input,< 1K
+Predicate,https://schema.org/merchant-output,< 1K
+Predicate,https://schema.org/merchantReturnDays,100K - 1M
+Predicate,https://schema.org/merchantReturnDays-input,< 1K
+Predicate,https://schema.org/merchantReturnDays-output,< 1K
+Predicate,https://schema.org/merchantReturnLink,10K - 100K
+Predicate,https://schema.org/merchantReturnLink-input,< 1K
+Predicate,https://schema.org/merchantReturnLink-output,< 1K
+Predicate,https://schema.org/messageAttachment,< 1K
+Predicate,https://schema.org/messageAttachment-input,< 1K
+Predicate,https://schema.org/messageAttachment-output,< 1K
+Predicate,https://schema.org/mileageFromOdometer,10K - 100K
+Predicate,https://schema.org/mileageFromOdometer-input,< 1K
+Predicate,https://schema.org/mileageFromOdometer-output,< 1K
+Predicate,https://schema.org/minPrice,10K - 100K
+Predicate,https://schema.org/minPrice-input,< 1K
+Predicate,https://schema.org/minPrice-output,< 1K
+Predicate,https://schema.org/minValue,100K - 1M
+Predicate,https://schema.org/minValue-input,< 1K
+Predicate,https://schema.org/minValue-output,< 1K
+Predicate,https://schema.org/minimumPaymentDue,< 1K
+Predicate,https://schema.org/minimumPaymentDue-input,< 1K
+Predicate,https://schema.org/minimumPaymentDue-output,< 1K
+Predicate,https://schema.org/missionCoveragePrioritiesPolicy,1K - 10K
+Predicate,https://schema.org/missionCoveragePrioritiesPolicy-input,< 1K
+Predicate,https://schema.org/missionCoveragePrioritiesPolicy-output,< 1K
+Predicate,https://schema.org/mobileUrl,< 1K
+Predicate,https://schema.org/mobileUrl-input,< 1K
+Predicate,https://schema.org/mobileUrl-output,< 1K
+Predicate,https://schema.org/model,100K - 1M
+Predicate,https://schema.org/model-input,< 1K
+Predicate,https://schema.org/model-output,< 1K
+Predicate,https://schema.org/modelDate,10K - 100K
+Predicate,https://schema.org/modelDate-input,< 1K
+Predicate,https://schema.org/modelDate-output,< 1K
+Predicate,https://schema.org/modifiedTime,< 1K
+Predicate,https://schema.org/modifiedTime-input,< 1K
+Predicate,https://schema.org/modifiedTime-output,< 1K
+Predicate,https://schema.org/molecularFormula,< 1K
+Predicate,https://schema.org/molecularFormula-input,< 1K
+Predicate,https://schema.org/molecularFormula-output,< 1K
+Predicate,https://schema.org/molecularWeight,< 1K
+Predicate,https://schema.org/molecularWeight-input,< 1K
+Predicate,https://schema.org/molecularWeight-output,< 1K
+Predicate,https://schema.org/monoisotopicMolecularWeight,< 1K
+Predicate,https://schema.org/monoisotopicMolecularWeight-input,< 1K
+Predicate,https://schema.org/monoisotopicMolecularWeight-output,< 1K
+Predicate,https://schema.org/monthlyMinimumRepaymentAmount,< 1K
+Predicate,https://schema.org/monthlyMinimumRepaymentAmount-input,< 1K
+Predicate,https://schema.org/monthlyMinimumRepaymentAmount-output,< 1K
+Predicate,https://schema.org/monthsOfExperience,1K - 10K
+Predicate,https://schema.org/monthsOfExperience-input,< 1K
+Predicate,https://schema.org/monthsOfExperience-output,< 1K
+Predicate,https://schema.org/mpn,100K - 1M
+Predicate,https://schema.org/mpn-input,< 1K
+Predicate,https://schema.org/mpn-output,< 1K
+Predicate,https://schema.org/multipleValues,< 1K
+Predicate,https://schema.org/multipleValues-input,< 1K
+Predicate,https://schema.org/multipleValues-output,< 1K
+Predicate,https://schema.org/muscleAction,< 1K
+Predicate,https://schema.org/muscleAction-input,< 1K
+Predicate,https://schema.org/muscleAction-output,< 1K
+Predicate,https://schema.org/musicArrangement,< 1K
+Predicate,https://schema.org/musicArrangement-input,< 1K
+Predicate,https://schema.org/musicArrangement-output,< 1K
+Predicate,https://schema.org/musicBy,1K - 10K
+Predicate,https://schema.org/musicBy-input,< 1K
+Predicate,https://schema.org/musicBy-output,< 1K
+Predicate,https://schema.org/musicCompositionForm,< 1K
+Predicate,https://schema.org/musicCompositionForm-input,< 1K
+Predicate,https://schema.org/musicCompositionForm-output,< 1K
+Predicate,https://schema.org/musicGroupMember,< 1K
+Predicate,https://schema.org/musicGroupMember-input,< 1K
+Predicate,https://schema.org/musicGroupMember-output,< 1K
+Predicate,https://schema.org/musicReleaseFormat,1K - 10K
+Predicate,https://schema.org/musicReleaseFormat-input,< 1K
+Predicate,https://schema.org/musicReleaseFormat-output,< 1K
+Predicate,https://schema.org/musicalKey,< 1K
+Predicate,https://schema.org/musicalKey-input,< 1K
+Predicate,https://schema.org/musicalKey-output,< 1K
+Predicate,https://schema.org/naics,10K - 100K
+Predicate,https://schema.org/naics-input,< 1K
+Predicate,https://schema.org/naics-output,< 1K
+Predicate,https://schema.org/name,10M+
+Predicate,https://schema.org/name-input,< 1K
+Predicate,https://schema.org/name-output,< 1K
+Predicate,https://schema.org/namedPosition,< 1K
+Predicate,https://schema.org/namedPosition-input,< 1K
+Predicate,https://schema.org/namedPosition-output,< 1K
+Predicate,https://schema.org/nationality,10K - 100K
+Predicate,https://schema.org/nationality-input,< 1K
+Predicate,https://schema.org/nationality-output,< 1K
+Predicate,https://schema.org/naturalProgression,< 1K
+Predicate,https://schema.org/naturalProgression-input,< 1K
+Predicate,https://schema.org/naturalProgression-output,< 1K
+Predicate,https://schema.org/negativeNotes,10K - 100K
+Predicate,https://schema.org/negativeNotes-input,< 1K
+Predicate,https://schema.org/negativeNotes-output,< 1K
+Predicate,https://schema.org/nerve,< 1K
+Predicate,https://schema.org/nerve-input,< 1K
+Predicate,https://schema.org/nerve-output,< 1K
+Predicate,https://schema.org/nerveMotor,< 1K
+Predicate,https://schema.org/nerveMotor-input,< 1K
+Predicate,https://schema.org/nerveMotor-output,< 1K
+Predicate,https://schema.org/netWorth,< 1K
+Predicate,https://schema.org/netWorth-input,< 1K
+Predicate,https://schema.org/netWorth-output,< 1K
+Predicate,https://schema.org/newsUpdatesAndGuidelines,< 1K
+Predicate,https://schema.org/newsUpdatesAndGuidelines-input,< 1K
+Predicate,https://schema.org/newsUpdatesAndGuidelines-output,< 1K
+Predicate,https://schema.org/nextItem,1M - 10M
+Predicate,https://schema.org/nextItem-input,< 1K
+Predicate,https://schema.org/nextItem-output,< 1K
+Predicate,https://schema.org/noBylinesPolicy,1K - 10K
+Predicate,https://schema.org/noBylinesPolicy-input,< 1K
+Predicate,https://schema.org/noBylinesPolicy-output,< 1K
+Predicate,https://schema.org/nonEqual,< 1K
+Predicate,https://schema.org/nonEqual-input,< 1K
+Predicate,https://schema.org/nonEqual-output,< 1K
+Predicate,https://schema.org/nonProprietaryName,1K - 10K
+Predicate,https://schema.org/nonProprietaryName-input,< 1K
+Predicate,https://schema.org/nonProprietaryName-output,< 1K
+Predicate,https://schema.org/nonprofitStatus,1K - 10K
+Predicate,https://schema.org/nonprofitStatus-input,< 1K
+Predicate,https://schema.org/nonprofitStatus-output,< 1K
+Predicate,https://schema.org/normalRange,< 1K
+Predicate,https://schema.org/normalRange-input,< 1K
+Predicate,https://schema.org/normalRange-output,< 1K
+Predicate,https://schema.org/nsn,< 1K
+Predicate,https://schema.org/nsn-input,< 1K
+Predicate,https://schema.org/nsn-output,< 1K
+Predicate,https://schema.org/numAdults,< 1K
+Predicate,https://schema.org/numAdults-input,< 1K
+Predicate,https://schema.org/numAdults-output,< 1K
+Predicate,https://schema.org/numChildren,< 1K
+Predicate,https://schema.org/numChildren-input,< 1K
+Predicate,https://schema.org/numChildren-output,< 1K
+Predicate,https://schema.org/numConstraints,< 1K
+Predicate,https://schema.org/numConstraints-input,< 1K
+Predicate,https://schema.org/numConstraints-output,< 1K
+Predicate,https://schema.org/numItems,< 1K
+Predicate,https://schema.org/numItems-input,< 1K
+Predicate,https://schema.org/numItems-output,< 1K
+Predicate,https://schema.org/numTracks,10K - 100K
+Predicate,https://schema.org/numTracks-input,< 1K
+Predicate,https://schema.org/numTracks-output,< 1K
+Predicate,https://schema.org/numberOfAccommodationUnits,1K - 10K
+Predicate,https://schema.org/numberOfAccommodationUnits-input,< 1K
+Predicate,https://schema.org/numberOfAccommodationUnits-output,< 1K
+Predicate,https://schema.org/numberOfAirbags,< 1K
+Predicate,https://schema.org/numberOfAirbags-input,< 1K
+Predicate,https://schema.org/numberOfAirbags-output,< 1K
+Predicate,https://schema.org/numberOfAvailableAccommodationUnits,1K - 10K
+Predicate,https://schema.org/numberOfAvailableAccommodationUnits-input,< 1K
+Predicate,https://schema.org/numberOfAvailableAccommodationUnits-output,< 1K
+Predicate,https://schema.org/numberOfAxles,< 1K
+Predicate,https://schema.org/numberOfAxles-input,< 1K
+Predicate,https://schema.org/numberOfAxles-output,< 1K
+Predicate,https://schema.org/numberOfBathroomsTotal,10K - 100K
+Predicate,https://schema.org/numberOfBathroomsTotal-input,< 1K
+Predicate,https://schema.org/numberOfBathroomsTotal-output,< 1K
+Predicate,https://schema.org/numberOfBedrooms,10K - 100K
+Predicate,https://schema.org/numberOfBedrooms-input,< 1K
+Predicate,https://schema.org/numberOfBedrooms-output,< 1K
+Predicate,https://schema.org/numberOfBeds,10K - 100K
+Predicate,https://schema.org/numberOfBeds-input,< 1K
+Predicate,https://schema.org/numberOfBeds-output,< 1K
+Predicate,https://schema.org/numberOfCredits,1K - 10K
+Predicate,https://schema.org/numberOfCredits-input,< 1K
+Predicate,https://schema.org/numberOfCredits-output,< 1K
+Predicate,https://schema.org/numberOfDoors,10K - 100K
+Predicate,https://schema.org/numberOfDoors-input,< 1K
+Predicate,https://schema.org/numberOfDoors-output,< 1K
+Predicate,https://schema.org/numberOfEmployees,100K - 1M
+Predicate,https://schema.org/numberOfEmployees-input,< 1K
+Predicate,https://schema.org/numberOfEmployees-output,< 1K
+Predicate,https://schema.org/numberOfEpisodes,1K - 10K
+Predicate,https://schema.org/numberOfEpisodes-input,< 1K
+Predicate,https://schema.org/numberOfEpisodes-output,< 1K
+Predicate,https://schema.org/numberOfForwardGears,1K - 10K
+Predicate,https://schema.org/numberOfForwardGears-input,< 1K
+Predicate,https://schema.org/numberOfForwardGears-output,< 1K
+Predicate,https://schema.org/numberOfFullBathrooms,10K - 100K
+Predicate,https://schema.org/numberOfFullBathrooms-input,< 1K
+Predicate,https://schema.org/numberOfFullBathrooms-output,< 1K
+Predicate,https://schema.org/numberOfItems,100K - 1M
+Predicate,https://schema.org/numberOfItems-input,< 1K
+Predicate,https://schema.org/numberOfItems-output,< 1K
+Predicate,https://schema.org/numberOfLoanPayments,< 1K
+Predicate,https://schema.org/numberOfLoanPayments-input,< 1K
+Predicate,https://schema.org/numberOfLoanPayments-output,< 1K
+Predicate,https://schema.org/numberOfPages,10K - 100K
+Predicate,https://schema.org/numberOfPages-input,< 1K
+Predicate,https://schema.org/numberOfPages-output,< 1K
+Predicate,https://schema.org/numberOfPartialBathrooms,1K - 10K
+Predicate,https://schema.org/numberOfPartialBathrooms-input,< 1K
+Predicate,https://schema.org/numberOfPartialBathrooms-output,< 1K
+Predicate,https://schema.org/numberOfPlayers,10K - 100K
+Predicate,https://schema.org/numberOfPlayers-input,< 1K
+Predicate,https://schema.org/numberOfPlayers-output,< 1K
+Predicate,https://schema.org/numberOfPreviousOwners,1K - 10K
+Predicate,https://schema.org/numberOfPreviousOwners-input,< 1K
+Predicate,https://schema.org/numberOfPreviousOwners-output,< 1K
+Predicate,https://schema.org/numberOfRooms,10K - 100K
+Predicate,https://schema.org/numberOfRooms-input,< 1K
+Predicate,https://schema.org/numberOfRooms-output,< 1K
+Predicate,https://schema.org/numberOfSeasons,1K - 10K
+Predicate,https://schema.org/numberOfSeasons-input,< 1K
+Predicate,https://schema.org/numberOfSeasons-output,< 1K
+Predicate,https://schema.org/numberedPosition,< 1K
+Predicate,https://schema.org/numberedPosition-input,< 1K
+Predicate,https://schema.org/numberedPosition-output,< 1K
+Predicate,https://schema.org/nutrition,10K - 100K
+Predicate,https://schema.org/nutrition-input,< 1K
+Predicate,https://schema.org/nutrition-output,< 1K
+Predicate,https://schema.org/object,10K - 100K
+Predicate,https://schema.org/object-input,< 1K
+Predicate,https://schema.org/object-output,< 1K
+Predicate,https://schema.org/observationAbout,< 1K
+Predicate,https://schema.org/observationAbout-input,< 1K
+Predicate,https://schema.org/observationAbout-output,< 1K
+Predicate,https://schema.org/observationDate,< 1K
+Predicate,https://schema.org/observationDate-input,< 1K
+Predicate,https://schema.org/observationDate-output,< 1K
+Predicate,https://schema.org/observationPeriod,< 1K
+Predicate,https://schema.org/observationPeriod-input,< 1K
+Predicate,https://schema.org/observationPeriod-output,< 1K
+Predicate,https://schema.org/occupancy,10K - 100K
+Predicate,https://schema.org/occupancy-input,< 1K
+Predicate,https://schema.org/occupancy-output,< 1K
+Predicate,https://schema.org/occupationLocation,10K - 100K
+Predicate,https://schema.org/occupationLocation-input,< 1K
+Predicate,https://schema.org/occupationLocation-output,< 1K
+Predicate,https://schema.org/occupationalCategory,10K - 100K
+Predicate,https://schema.org/occupationalCategory-input,< 1K
+Predicate,https://schema.org/occupationalCategory-output,< 1K
+Predicate,https://schema.org/occupationalCredentialAwarded,1K - 10K
+Predicate,https://schema.org/occupationalCredentialAwarded-input,< 1K
+Predicate,https://schema.org/occupationalCredentialAwarded-output,< 1K
+Predicate,https://schema.org/offerCount,100K - 1M
+Predicate,https://schema.org/offerCount-input,< 1K
+Predicate,https://schema.org/offerCount-output,< 1K
+Predicate,https://schema.org/offeredBy,10K - 100K
+Predicate,https://schema.org/offeredBy-input,< 1K
+Predicate,https://schema.org/offeredBy-output,< 1K
+Predicate,https://schema.org/offers,1M - 10M
+Predicate,https://schema.org/offers-input,< 1K
+Predicate,https://schema.org/offers-output,< 1K
+Predicate,https://schema.org/offersPrescriptionByMail,< 1K
+Predicate,https://schema.org/offersPrescriptionByMail-input,< 1K
+Predicate,https://schema.org/offersPrescriptionByMail-output,< 1K
+Predicate,https://schema.org/openingHours,1M - 10M
+Predicate,https://schema.org/openingHours-input,< 1K
+Predicate,https://schema.org/openingHours-output,< 1K
+Predicate,https://schema.org/openingHoursSpecification,1M - 10M
+Predicate,https://schema.org/openingHoursSpecification-input,< 1K
+Predicate,https://schema.org/openingHoursSpecification-output,< 1K
+Predicate,https://schema.org/opens,1M - 10M
+Predicate,https://schema.org/opens-input,< 1K
+Predicate,https://schema.org/opens-output,< 1K
+Predicate,https://schema.org/operatingSystem,100K - 1M
+Predicate,https://schema.org/operatingSystem-input,< 1K
+Predicate,https://schema.org/operatingSystem-output,< 1K
+Predicate,https://schema.org/opponent,< 1K
+Predicate,https://schema.org/opponent-input,< 1K
+Predicate,https://schema.org/opponent-output,< 1K
+Predicate,https://schema.org/option,< 1K
+Predicate,https://schema.org/option-input,< 1K
+Predicate,https://schema.org/option-output,< 1K
+Predicate,https://schema.org/orderDate,< 1K
+Predicate,https://schema.org/orderDate-input,< 1K
+Predicate,https://schema.org/orderDate-output,< 1K
+Predicate,https://schema.org/orderDelivery,< 1K
+Predicate,https://schema.org/orderDelivery-input,< 1K
+Predicate,https://schema.org/orderDelivery-output,< 1K
+Predicate,https://schema.org/orderItemNumber,< 1K
+Predicate,https://schema.org/orderItemNumber-input,< 1K
+Predicate,https://schema.org/orderItemNumber-output,< 1K
+Predicate,https://schema.org/orderItemStatus,< 1K
+Predicate,https://schema.org/orderItemStatus-input,< 1K
+Predicate,https://schema.org/orderItemStatus-output,< 1K
+Predicate,https://schema.org/orderNumber,< 1K
+Predicate,https://schema.org/orderNumber-input,< 1K
+Predicate,https://schema.org/orderNumber-output,< 1K
+Predicate,https://schema.org/orderPercentage,< 1K
+Predicate,https://schema.org/orderPercentage-input,< 1K
+Predicate,https://schema.org/orderPercentage-output,< 1K
+Predicate,https://schema.org/orderQuantity,< 1K
+Predicate,https://schema.org/orderQuantity-input,< 1K
+Predicate,https://schema.org/orderQuantity-output,< 1K
+Predicate,https://schema.org/orderStatus,< 1K
+Predicate,https://schema.org/orderStatus-input,< 1K
+Predicate,https://schema.org/orderStatus-output,< 1K
+Predicate,https://schema.org/orderValue,< 1K
+Predicate,https://schema.org/orderValue-input,< 1K
+Predicate,https://schema.org/orderValue-output,< 1K
+Predicate,https://schema.org/orderedItem,< 1K
+Predicate,https://schema.org/orderedItem-input,< 1K
+Predicate,https://schema.org/orderedItem-output,< 1K
+Predicate,https://schema.org/organizer,100K - 1M
+Predicate,https://schema.org/organizer-input,< 1K
+Predicate,https://schema.org/organizer-output,< 1K
+Predicate,https://schema.org/originAddress,< 1K
+Predicate,https://schema.org/originAddress-input,< 1K
+Predicate,https://schema.org/originAddress-output,< 1K
+Predicate,https://schema.org/originalMediaContextDescription,< 1K
+Predicate,https://schema.org/originalMediaContextDescription-input,< 1K
+Predicate,https://schema.org/originalMediaContextDescription-output,< 1K
+Predicate,https://schema.org/originalMediaLink,< 1K
+Predicate,https://schema.org/originalMediaLink-input,< 1K
+Predicate,https://schema.org/originalMediaLink-output,< 1K
+Predicate,https://schema.org/originatesFrom,< 1K
+Predicate,https://schema.org/originatesFrom-input,< 1K
+Predicate,https://schema.org/originatesFrom-output,< 1K
+Predicate,https://schema.org/overdosage,< 1K
+Predicate,https://schema.org/overdosage-input,< 1K
+Predicate,https://schema.org/overdosage-output,< 1K
+Predicate,https://schema.org/ownedFrom,< 1K
+Predicate,https://schema.org/ownedFrom-input,< 1K
+Predicate,https://schema.org/ownedFrom-output,< 1K
+Predicate,https://schema.org/ownedThrough,< 1K
+Predicate,https://schema.org/ownedThrough-input,< 1K
+Predicate,https://schema.org/ownedThrough-output,< 1K
+Predicate,https://schema.org/owner,1K - 10K
+Predicate,https://schema.org/owner-input,< 1K
+Predicate,https://schema.org/owner-output,< 1K
+Predicate,https://schema.org/ownershipFundingInfo,10K - 100K
+Predicate,https://schema.org/ownershipFundingInfo-input,< 1K
+Predicate,https://schema.org/ownershipFundingInfo-output,< 1K
+Predicate,https://schema.org/owns,10K - 100K
+Predicate,https://schema.org/owns-input,< 1K
+Predicate,https://schema.org/owns-output,< 1K
+Predicate,https://schema.org/pageEnd,1K - 10K
+Predicate,https://schema.org/pageEnd-input,< 1K
+Predicate,https://schema.org/pageEnd-output,< 1K
+Predicate,https://schema.org/pageStart,1K - 10K
+Predicate,https://schema.org/pageStart-input,< 1K
+Predicate,https://schema.org/pageStart-output,< 1K
+Predicate,https://schema.org/pagination,1K - 10K
+Predicate,https://schema.org/pagination-input,< 1K
+Predicate,https://schema.org/pagination-output,< 1K
+Predicate,https://schema.org/parent,< 1K
+Predicate,https://schema.org/parent-input,< 1K
+Predicate,https://schema.org/parent-output,< 1K
+Predicate,https://schema.org/parentItem,1K - 10K
+Predicate,https://schema.org/parentItem-input,< 1K
+Predicate,https://schema.org/parentItem-output,< 1K
+Predicate,https://schema.org/parentOrganization,100K - 1M
+Predicate,https://schema.org/parentOrganization-input,< 1K
+Predicate,https://schema.org/parentOrganization-output,< 1K
+Predicate,https://schema.org/parentService,< 1K
+Predicate,https://schema.org/parentService-input,< 1K
+Predicate,https://schema.org/parentService-output,< 1K
+Predicate,https://schema.org/parentTaxon,< 1K
+Predicate,https://schema.org/parentTaxon-input,< 1K
+Predicate,https://schema.org/parentTaxon-output,< 1K
+Predicate,https://schema.org/parents,< 1K
+Predicate,https://schema.org/parents-input,< 1K
+Predicate,https://schema.org/parents-output,< 1K
+Predicate,https://schema.org/partOfEpisode,< 1K
+Predicate,https://schema.org/partOfEpisode-input,< 1K
+Predicate,https://schema.org/partOfEpisode-output,< 1K
+Predicate,https://schema.org/partOfInvoice,< 1K
+Predicate,https://schema.org/partOfInvoice-input,< 1K
+Predicate,https://schema.org/partOfInvoice-output,< 1K
+Predicate,https://schema.org/partOfOrder,< 1K
+Predicate,https://schema.org/partOfOrder-input,< 1K
+Predicate,https://schema.org/partOfOrder-output,< 1K
+Predicate,https://schema.org/partOfSeason,1K - 10K
+Predicate,https://schema.org/partOfSeason-input,< 1K
+Predicate,https://schema.org/partOfSeason-output,< 1K
+Predicate,https://schema.org/partOfSeries,10K - 100K
+Predicate,https://schema.org/partOfSeries-input,< 1K
+Predicate,https://schema.org/partOfSeries-output,< 1K
+Predicate,https://schema.org/partOfSystem,< 1K
+Predicate,https://schema.org/partOfSystem-input,< 1K
+Predicate,https://schema.org/partOfSystem-output,< 1K
+Predicate,https://schema.org/partOfTVSeries,< 1K
+Predicate,https://schema.org/partOfTVSeries-input,< 1K
+Predicate,https://schema.org/partOfTVSeries-output,< 1K
+Predicate,https://schema.org/partOfTrip,< 1K
+Predicate,https://schema.org/partOfTrip-input,< 1K
+Predicate,https://schema.org/partOfTrip-output,< 1K
+Predicate,https://schema.org/participant,1K - 10K
+Predicate,https://schema.org/participant-input,< 1K
+Predicate,https://schema.org/participant-output,< 1K
+Predicate,https://schema.org/partySize,< 1K
+Predicate,https://schema.org/partySize-input,< 1K
+Predicate,https://schema.org/partySize-output,< 1K
+Predicate,https://schema.org/passengerPriorityStatus,< 1K
+Predicate,https://schema.org/passengerPriorityStatus-input,< 1K
+Predicate,https://schema.org/passengerPriorityStatus-output,< 1K
+Predicate,https://schema.org/passengerSequenceNumber,< 1K
+Predicate,https://schema.org/passengerSequenceNumber-input,< 1K
+Predicate,https://schema.org/passengerSequenceNumber-output,< 1K
+Predicate,https://schema.org/pathophysiology,< 1K
+Predicate,https://schema.org/pathophysiology-input,< 1K
+Predicate,https://schema.org/pathophysiology-output,< 1K
+Predicate,https://schema.org/pattern,1K - 10K
+Predicate,https://schema.org/pattern-input,< 1K
+Predicate,https://schema.org/pattern-output,< 1K
+Predicate,https://schema.org/payload,1K - 10K
+Predicate,https://schema.org/payload-input,< 1K
+Predicate,https://schema.org/payload-output,< 1K
+Predicate,https://schema.org/paymentAccepted,100K - 1M
+Predicate,https://schema.org/paymentAccepted-input,< 1K
+Predicate,https://schema.org/paymentAccepted-output,< 1K
+Predicate,https://schema.org/paymentDue,< 1K
+Predicate,https://schema.org/paymentDue-input,< 1K
+Predicate,https://schema.org/paymentDue-output,< 1K
+Predicate,https://schema.org/paymentDueDate,< 1K
+Predicate,https://schema.org/paymentDueDate-input,< 1K
+Predicate,https://schema.org/paymentDueDate-output,< 1K
+Predicate,https://schema.org/paymentMethod,< 1K
+Predicate,https://schema.org/paymentMethod-input,< 1K
+Predicate,https://schema.org/paymentMethod-output,< 1K
+Predicate,https://schema.org/paymentMethodId,< 1K
+Predicate,https://schema.org/paymentMethodId-input,< 1K
+Predicate,https://schema.org/paymentMethodId-output,< 1K
+Predicate,https://schema.org/paymentMethodType,1K - 10K
+Predicate,https://schema.org/paymentMethodType-input,< 1K
+Predicate,https://schema.org/paymentMethodType-output,< 1K
+Predicate,https://schema.org/paymentStatus,< 1K
+Predicate,https://schema.org/paymentStatus-input,< 1K
+Predicate,https://schema.org/paymentStatus-output,< 1K
+Predicate,https://schema.org/paymentUrl,< 1K
+Predicate,https://schema.org/paymentUrl-input,< 1K
+Predicate,https://schema.org/paymentUrl-output,< 1K
+Predicate,https://schema.org/penciler,< 1K
+Predicate,https://schema.org/penciler-input,< 1K
+Predicate,https://schema.org/penciler-output,< 1K
+Predicate,https://schema.org/percentile10,1K - 10K
+Predicate,https://schema.org/percentile10-input,< 1K
+Predicate,https://schema.org/percentile10-output,< 1K
+Predicate,https://schema.org/percentile25,< 1K
+Predicate,https://schema.org/percentile25-input,< 1K
+Predicate,https://schema.org/percentile25-output,< 1K
+Predicate,https://schema.org/percentile75,< 1K
+Predicate,https://schema.org/percentile75-input,< 1K
+Predicate,https://schema.org/percentile75-output,< 1K
+Predicate,https://schema.org/percentile90,1K - 10K
+Predicate,https://schema.org/percentile90-input,< 1K
+Predicate,https://schema.org/percentile90-output,< 1K
+Predicate,https://schema.org/performTime,1K - 10K
+Predicate,https://schema.org/performTime-input,< 1K
+Predicate,https://schema.org/performTime-output,< 1K
+Predicate,https://schema.org/performer,100K - 1M
+Predicate,https://schema.org/performer-input,< 1K
+Predicate,https://schema.org/performer-output,< 1K
+Predicate,https://schema.org/performerIn,1K - 10K
+Predicate,https://schema.org/performerIn-input,< 1K
+Predicate,https://schema.org/performerIn-output,< 1K
+Predicate,https://schema.org/performers,1K - 10K
+Predicate,https://schema.org/performers-input,< 1K
+Predicate,https://schema.org/performers-output,< 1K
+Predicate,https://schema.org/permissionType,< 1K
+Predicate,https://schema.org/permissionType-input,< 1K
+Predicate,https://schema.org/permissionType-output,< 1K
+Predicate,https://schema.org/permissions,10K - 100K
+Predicate,https://schema.org/permissions-input,< 1K
+Predicate,https://schema.org/permissions-output,< 1K
+Predicate,https://schema.org/permitAudience,< 1K
+Predicate,https://schema.org/permitAudience-input,< 1K
+Predicate,https://schema.org/permitAudience-output,< 1K
+Predicate,https://schema.org/permittedUsage,< 1K
+Predicate,https://schema.org/permittedUsage-input,< 1K
+Predicate,https://schema.org/permittedUsage-output,< 1K
+Predicate,https://schema.org/petsAllowed,10K - 100K
+Predicate,https://schema.org/petsAllowed-input,< 1K
+Predicate,https://schema.org/petsAllowed-output,< 1K
+Predicate,https://schema.org/phoneticText,< 1K
+Predicate,https://schema.org/phoneticText-input,< 1K
+Predicate,https://schema.org/phoneticText-output,< 1K
+Predicate,https://schema.org/photo,10K - 100K
+Predicate,https://schema.org/photo-input,< 1K
+Predicate,https://schema.org/photo-output,< 1K
+Predicate,https://schema.org/photos,10K - 100K
+Predicate,https://schema.org/photos-input,< 1K
+Predicate,https://schema.org/photos-output,< 1K
+Predicate,https://schema.org/physicalRequirement,< 1K
+Predicate,https://schema.org/physicalRequirement-input,< 1K
+Predicate,https://schema.org/physicalRequirement-output,< 1K
+Predicate,https://schema.org/physiologicalBenefits,< 1K
+Predicate,https://schema.org/physiologicalBenefits-input,< 1K
+Predicate,https://schema.org/physiologicalBenefits-output,< 1K
+Predicate,https://schema.org/pickupLocation,< 1K
+Predicate,https://schema.org/pickupLocation-input,< 1K
+Predicate,https://schema.org/pickupLocation-output,< 1K
+Predicate,https://schema.org/pickupTime,< 1K
+Predicate,https://schema.org/pickupTime-input,< 1K
+Predicate,https://schema.org/pickupTime-output,< 1K
+Predicate,https://schema.org/playMode,10K - 100K
+Predicate,https://schema.org/playMode-input,< 1K
+Predicate,https://schema.org/playMode-output,< 1K
+Predicate,https://schema.org/playerType,1K - 10K
+Predicate,https://schema.org/playerType-input,< 1K
+Predicate,https://schema.org/playerType-output,< 1K
+Predicate,https://schema.org/playersOnline,1K - 10K
+Predicate,https://schema.org/playersOnline-input,< 1K
+Predicate,https://schema.org/playersOnline-output,< 1K
+Predicate,https://schema.org/polygon,< 1K
+Predicate,https://schema.org/polygon-input,< 1K
+Predicate,https://schema.org/polygon-output,< 1K
+Predicate,https://schema.org/populationType,< 1K
+Predicate,https://schema.org/populationType-input,< 1K
+Predicate,https://schema.org/populationType-output,< 1K
+Predicate,https://schema.org/position,10M+
+Predicate,https://schema.org/position-input,< 1K
+Predicate,https://schema.org/position-output,< 1K
+Predicate,https://schema.org/positiveNotes,10K - 100K
+Predicate,https://schema.org/positiveNotes-input,< 1K
+Predicate,https://schema.org/positiveNotes-output,< 1K
+Predicate,https://schema.org/possibleComplication,1K - 10K
+Predicate,https://schema.org/possibleComplication-input,< 1K
+Predicate,https://schema.org/possibleComplication-output,< 1K
+Predicate,https://schema.org/possibleTreatment,1K - 10K
+Predicate,https://schema.org/possibleTreatment-input,< 1K
+Predicate,https://schema.org/possibleTreatment-output,< 1K
+Predicate,https://schema.org/postOfficeBoxNumber,10K - 100K
+Predicate,https://schema.org/postOfficeBoxNumber-input,< 1K
+Predicate,https://schema.org/postOfficeBoxNumber-output,< 1K
+Predicate,https://schema.org/postOp,< 1K
+Predicate,https://schema.org/postOp-input,< 1K
+Predicate,https://schema.org/postOp-output,< 1K
+Predicate,https://schema.org/postalCode,1M - 10M
+Predicate,https://schema.org/postalCode-input,< 1K
+Predicate,https://schema.org/postalCode-output,< 1K
+Predicate,https://schema.org/postalCodeBegin,1K - 10K
+Predicate,https://schema.org/postalCodeBegin-input,< 1K
+Predicate,https://schema.org/postalCodeBegin-output,< 1K
+Predicate,https://schema.org/postalCodeEnd,1K - 10K
+Predicate,https://schema.org/postalCodeEnd-input,< 1K
+Predicate,https://schema.org/postalCodeEnd-output,< 1K
+Predicate,https://schema.org/postalCodePrefix,< 1K
+Predicate,https://schema.org/postalCodePrefix-input,< 1K
+Predicate,https://schema.org/postalCodePrefix-output,< 1K
+Predicate,https://schema.org/postalCodeRange,1K - 10K
+Predicate,https://schema.org/postalCodeRange-input,< 1K
+Predicate,https://schema.org/postalCodeRange-output,< 1K
+Predicate,https://schema.org/potentialAction,10M+
+Predicate,https://schema.org/potentialAction-input,< 1K
+Predicate,https://schema.org/potentialAction-output,< 1K
+Predicate,https://schema.org/potentialUse,< 1K
+Predicate,https://schema.org/potentialUse-input,< 1K
+Predicate,https://schema.org/potentialUse-output,< 1K
+Predicate,https://schema.org/practicesAt,< 1K
+Predicate,https://schema.org/practicesAt-input,< 1K
+Predicate,https://schema.org/practicesAt-output,< 1K
+Predicate,https://schema.org/preOp,< 1K
+Predicate,https://schema.org/preOp-input,< 1K
+Predicate,https://schema.org/preOp-output,< 1K
+Predicate,https://schema.org/predecessorOf,< 1K
+Predicate,https://schema.org/predecessorOf-input,< 1K
+Predicate,https://schema.org/predecessorOf-output,< 1K
+Predicate,https://schema.org/pregnancyCategory,< 1K
+Predicate,https://schema.org/pregnancyCategory-input,< 1K
+Predicate,https://schema.org/pregnancyCategory-output,< 1K
+Predicate,https://schema.org/pregnancyWarning,< 1K
+Predicate,https://schema.org/pregnancyWarning-input,< 1K
+Predicate,https://schema.org/pregnancyWarning-output,< 1K
+Predicate,https://schema.org/prepTime,10K - 100K
+Predicate,https://schema.org/prepTime-input,< 1K
+Predicate,https://schema.org/prepTime-output,< 1K
+Predicate,https://schema.org/preparation,1K - 10K
+Predicate,https://schema.org/preparation-input,< 1K
+Predicate,https://schema.org/preparation-output,< 1K
+Predicate,https://schema.org/prescribingInfo,< 1K
+Predicate,https://schema.org/prescribingInfo-input,< 1K
+Predicate,https://schema.org/prescribingInfo-output,< 1K
+Predicate,https://schema.org/prescriptionStatus,1K - 10K
+Predicate,https://schema.org/prescriptionStatus-input,< 1K
+Predicate,https://schema.org/prescriptionStatus-output,< 1K
+Predicate,https://schema.org/previousItem,1M - 10M
+Predicate,https://schema.org/previousItem-input,< 1K
+Predicate,https://schema.org/previousItem-output,< 1K
+Predicate,https://schema.org/previousStartDate,1K - 10K
+Predicate,https://schema.org/previousStartDate-input,< 1K
+Predicate,https://schema.org/previousStartDate-output,< 1K
+Predicate,https://schema.org/price,1M - 10M
+Predicate,https://schema.org/price-input,< 1K
+Predicate,https://schema.org/price-output,< 1K
+Predicate,https://schema.org/priceComponent,1K - 10K
+Predicate,https://schema.org/priceComponent-input,< 1K
+Predicate,https://schema.org/priceComponent-output,< 1K
+Predicate,https://schema.org/priceComponentType,< 1K
+Predicate,https://schema.org/priceComponentType-input,< 1K
+Predicate,https://schema.org/priceComponentType-output,< 1K
+Predicate,https://schema.org/priceCurrency,1M - 10M
+Predicate,https://schema.org/priceCurrency-input,< 1K
+Predicate,https://schema.org/priceCurrency-output,< 1K
+Predicate,https://schema.org/priceRange,1M - 10M
+Predicate,https://schema.org/priceRange-input,< 1K
+Predicate,https://schema.org/priceRange-output,< 1K
+Predicate,https://schema.org/priceSpecification,1M - 10M
+Predicate,https://schema.org/priceSpecification-input,< 1K
+Predicate,https://schema.org/priceSpecification-output,< 1K
+Predicate,https://schema.org/priceType,100K - 1M
+Predicate,https://schema.org/priceType-input,< 1K
+Predicate,https://schema.org/priceType-output,< 1K
+Predicate,https://schema.org/priceValidUntil,1M - 10M
+Predicate,https://schema.org/priceValidUntil-input,< 1K
+Predicate,https://schema.org/priceValidUntil-output,< 1K
+Predicate,https://schema.org/primaryImageOfPage,10M+
+Predicate,https://schema.org/primaryImageOfPage-input,< 1K
+Predicate,https://schema.org/primaryImageOfPage-output,< 1K
+Predicate,https://schema.org/primaryPrevention,< 1K
+Predicate,https://schema.org/primaryPrevention-input,< 1K
+Predicate,https://schema.org/primaryPrevention-output,< 1K
+Predicate,https://schema.org/printColumn,< 1K
+Predicate,https://schema.org/printColumn-input,< 1K
+Predicate,https://schema.org/printColumn-output,< 1K
+Predicate,https://schema.org/printEdition,< 1K
+Predicate,https://schema.org/printEdition-input,< 1K
+Predicate,https://schema.org/printEdition-output,< 1K
+Predicate,https://schema.org/printPage,< 1K
+Predicate,https://schema.org/printPage-input,< 1K
+Predicate,https://schema.org/printPage-output,< 1K
+Predicate,https://schema.org/printSection,< 1K
+Predicate,https://schema.org/printSection-input,< 1K
+Predicate,https://schema.org/printSection-output,< 1K
+Predicate,https://schema.org/procedure,< 1K
+Predicate,https://schema.org/procedure-input,< 1K
+Predicate,https://schema.org/procedure-output,< 1K
+Predicate,https://schema.org/procedureType,10K - 100K
+Predicate,https://schema.org/procedureType-input,< 1K
+Predicate,https://schema.org/procedureType-output,< 1K
+Predicate,https://schema.org/processingTime,< 1K
+Predicate,https://schema.org/processingTime-input,< 1K
+Predicate,https://schema.org/processingTime-output,< 1K
+Predicate,https://schema.org/processorRequirements,1K - 10K
+Predicate,https://schema.org/processorRequirements-input,< 1K
+Predicate,https://schema.org/processorRequirements-output,< 1K
+Predicate,https://schema.org/producer,1K - 10K
+Predicate,https://schema.org/producer-input,< 1K
+Predicate,https://schema.org/producer-output,< 1K
+Predicate,https://schema.org/produces,< 1K
+Predicate,https://schema.org/produces-input,< 1K
+Predicate,https://schema.org/produces-output,< 1K
+Predicate,https://schema.org/productGroupID,100K - 1M
+Predicate,https://schema.org/productGroupID-input,< 1K
+Predicate,https://schema.org/productGroupID-output,< 1K
+Predicate,https://schema.org/productID,100K - 1M
+Predicate,https://schema.org/productID-input,< 1K
+Predicate,https://schema.org/productID-output,< 1K
+Predicate,https://schema.org/productReturnDays,< 1K
+Predicate,https://schema.org/productReturnDays-input,< 1K
+Predicate,https://schema.org/productReturnDays-output,< 1K
+Predicate,https://schema.org/productReturnLink,< 1K
+Predicate,https://schema.org/productReturnLink-input,< 1K
+Predicate,https://schema.org/productReturnLink-output,< 1K
+Predicate,https://schema.org/productSupported,1K - 10K
+Predicate,https://schema.org/productSupported-input,< 1K
+Predicate,https://schema.org/productSupported-output,< 1K
+Predicate,https://schema.org/productionCompany,1K - 10K
+Predicate,https://schema.org/productionCompany-input,< 1K
+Predicate,https://schema.org/productionCompany-output,< 1K
+Predicate,https://schema.org/productionDate,10K - 100K
+Predicate,https://schema.org/productionDate-input,< 1K
+Predicate,https://schema.org/productionDate-output,< 1K
+Predicate,https://schema.org/proficiencyLevel,10K - 100K
+Predicate,https://schema.org/proficiencyLevel-input,< 1K
+Predicate,https://schema.org/proficiencyLevel-output,< 1K
+Predicate,https://schema.org/program,< 1K
+Predicate,https://schema.org/program-input,< 1K
+Predicate,https://schema.org/program-output,< 1K
+Predicate,https://schema.org/programMembershipUsed,< 1K
+Predicate,https://schema.org/programMembershipUsed-input,< 1K
+Predicate,https://schema.org/programMembershipUsed-output,< 1K
+Predicate,https://schema.org/programName,1K - 10K
+Predicate,https://schema.org/programName-input,< 1K
+Predicate,https://schema.org/programName-output,< 1K
+Predicate,https://schema.org/programPrerequisites,1K - 10K
+Predicate,https://schema.org/programPrerequisites-input,< 1K
+Predicate,https://schema.org/programPrerequisites-output,< 1K
+Predicate,https://schema.org/programType,1K - 10K
+Predicate,https://schema.org/programType-input,< 1K
+Predicate,https://schema.org/programType-output,< 1K
+Predicate,https://schema.org/programmingLanguage,1K - 10K
+Predicate,https://schema.org/programmingLanguage-input,< 1K
+Predicate,https://schema.org/programmingLanguage-output,< 1K
+Predicate,https://schema.org/programmingModel,< 1K
+Predicate,https://schema.org/programmingModel-input,< 1K
+Predicate,https://schema.org/programmingModel-output,< 1K
+Predicate,https://schema.org/pronouns,1K - 10K
+Predicate,https://schema.org/pronouns-input,< 1K
+Predicate,https://schema.org/pronouns-output,< 1K
+Predicate,https://schema.org/propertyID,10K - 100K
+Predicate,https://schema.org/propertyID-input,< 1K
+Predicate,https://schema.org/propertyID-output,< 1K
+Predicate,https://schema.org/proprietaryName,< 1K
+Predicate,https://schema.org/proprietaryName-input,< 1K
+Predicate,https://schema.org/proprietaryName-output,< 1K
+Predicate,https://schema.org/proteinContent,10K - 100K
+Predicate,https://schema.org/proteinContent-input,< 1K
+Predicate,https://schema.org/proteinContent-output,< 1K
+Predicate,https://schema.org/provider,100K - 1M
+Predicate,https://schema.org/provider-input,< 1K
+Predicate,https://schema.org/provider-output,< 1K
+Predicate,https://schema.org/providerMobility,1K - 10K
+Predicate,https://schema.org/providerMobility-input,< 1K
+Predicate,https://schema.org/providerMobility-output,< 1K
+Predicate,https://schema.org/providesBroadcastService,< 1K
+Predicate,https://schema.org/providesBroadcastService-input,< 1K
+Predicate,https://schema.org/providesBroadcastService-output,< 1K
+Predicate,https://schema.org/providesService,< 1K
+Predicate,https://schema.org/providesService-input,< 1K
+Predicate,https://schema.org/providesService-output,< 1K
+Predicate,https://schema.org/publicAccess,10K - 100K
+Predicate,https://schema.org/publicAccess-input,< 1K
+Predicate,https://schema.org/publicAccess-output,< 1K
+Predicate,https://schema.org/publicTransportClosuresInfo,< 1K
+Predicate,https://schema.org/publicTransportClosuresInfo-input,< 1K
+Predicate,https://schema.org/publicTransportClosuresInfo-output,< 1K
+Predicate,https://schema.org/publication,1K - 10K
+Predicate,https://schema.org/publication-input,< 1K
+Predicate,https://schema.org/publication-output,< 1K
+Predicate,https://schema.org/publicationType,< 1K
+Predicate,https://schema.org/publicationType-input,< 1K
+Predicate,https://schema.org/publicationType-output,< 1K
+Predicate,https://schema.org/publishedBy,< 1K
+Predicate,https://schema.org/publishedBy-input,< 1K
+Predicate,https://schema.org/publishedBy-output,< 1K
+Predicate,https://schema.org/publishedOn,< 1K
+Predicate,https://schema.org/publishedOn-input,< 1K
+Predicate,https://schema.org/publishedOn-output,< 1K
+Predicate,https://schema.org/publisher,10M+
+Predicate,https://schema.org/publisher-input,< 1K
+Predicate,https://schema.org/publisher-output,< 1K
+Predicate,https://schema.org/publisherImprint,< 1K
+Predicate,https://schema.org/publisherImprint-input,< 1K
+Predicate,https://schema.org/publisherImprint-output,< 1K
+Predicate,https://schema.org/publishingPrinciples,10K - 100K
+Predicate,https://schema.org/publishingPrinciples-input,< 1K
+Predicate,https://schema.org/publishingPrinciples-output,< 1K
+Predicate,https://schema.org/purchaseDate,1K - 10K
+Predicate,https://schema.org/purchaseDate-input,< 1K
+Predicate,https://schema.org/purchaseDate-output,< 1K
+Predicate,https://schema.org/purchasePriceLimit,< 1K
+Predicate,https://schema.org/purchasePriceLimit-input,< 1K
+Predicate,https://schema.org/purchasePriceLimit-output,< 1K
+Predicate,https://schema.org/purchaseType,< 1K
+Predicate,https://schema.org/purchaseType-input,< 1K
+Predicate,https://schema.org/purchaseType-output,< 1K
+Predicate,https://schema.org/qualifications,10K - 100K
+Predicate,https://schema.org/qualifications-input,< 1K
+Predicate,https://schema.org/qualifications-output,< 1K
+Predicate,https://schema.org/qualifiedExpense,< 1K
+Predicate,https://schema.org/qualifiedExpense-input,< 1K
+Predicate,https://schema.org/qualifiedExpense-output,< 1K
+Predicate,https://schema.org/quarantineGuidelines,< 1K
+Predicate,https://schema.org/quarantineGuidelines-input,< 1K
+Predicate,https://schema.org/quarantineGuidelines-output,< 1K
+Predicate,https://schema.org/query,10K - 100K
+Predicate,https://schema.org/query-input,10M+
+Predicate,https://schema.org/query-output,< 1K
+Predicate,https://schema.org/quest,< 1K
+Predicate,https://schema.org/quest-input,< 1K
+Predicate,https://schema.org/quest-output,< 1K
+Predicate,https://schema.org/question,< 1K
+Predicate,https://schema.org/question-input,< 1K
+Predicate,https://schema.org/question-output,< 1K
+Predicate,https://schema.org/rangeIncludes,< 1K
+Predicate,https://schema.org/rangeIncludes-input,< 1K
+Predicate,https://schema.org/rangeIncludes-output,< 1K
+Predicate,https://schema.org/ratingCount,1M - 10M
+Predicate,https://schema.org/ratingCount-input,< 1K
+Predicate,https://schema.org/ratingCount-output,< 1K
+Predicate,https://schema.org/ratingExplanation,1K - 10K
+Predicate,https://schema.org/ratingExplanation-input,< 1K
+Predicate,https://schema.org/ratingExplanation-output,< 1K
+Predicate,https://schema.org/ratingValue,1M - 10M
+Predicate,https://schema.org/ratingValue-input,< 1K
+Predicate,https://schema.org/ratingValue-output,< 1K
+Predicate,https://schema.org/readBy,< 1K
+Predicate,https://schema.org/readBy-input,< 1K
+Predicate,https://schema.org/readBy-output,< 1K
+Predicate,https://schema.org/readonlyValue,< 1K
+Predicate,https://schema.org/readonlyValue-input,< 1K
+Predicate,https://schema.org/readonlyValue-output,< 1K
+Predicate,https://schema.org/realEstateAgent,< 1K
+Predicate,https://schema.org/realEstateAgent-input,< 1K
+Predicate,https://schema.org/realEstateAgent-output,< 1K
+Predicate,https://schema.org/recipe,< 1K
+Predicate,https://schema.org/recipe-input,< 1K
+Predicate,https://schema.org/recipe-output,< 1K
+Predicate,https://schema.org/recipeCategory,10K - 100K
+Predicate,https://schema.org/recipeCategory-input,< 1K
+Predicate,https://schema.org/recipeCategory-output,< 1K
+Predicate,https://schema.org/recipeCuisine,10K - 100K
+Predicate,https://schema.org/recipeCuisine-input,< 1K
+Predicate,https://schema.org/recipeCuisine-output,< 1K
+Predicate,https://schema.org/recipeIngredient,10K - 100K
+Predicate,https://schema.org/recipeIngredient-input,< 1K
+Predicate,https://schema.org/recipeIngredient-output,< 1K
+Predicate,https://schema.org/recipeInstructions,10K - 100K
+Predicate,https://schema.org/recipeInstructions-input,< 1K
+Predicate,https://schema.org/recipeInstructions-output,< 1K
+Predicate,https://schema.org/recipeYield,10K - 100K
+Predicate,https://schema.org/recipeYield-input,< 1K
+Predicate,https://schema.org/recipeYield-output,< 1K
+Predicate,https://schema.org/recipient,1K - 10K
+Predicate,https://schema.org/recipient-input,< 1K
+Predicate,https://schema.org/recipient-output,< 1K
+Predicate,https://schema.org/recognizedBy,10K - 100K
+Predicate,https://schema.org/recognizedBy-input,< 1K
+Predicate,https://schema.org/recognizedBy-output,< 1K
+Predicate,https://schema.org/recognizingAuthority,1K - 10K
+Predicate,https://schema.org/recognizingAuthority-input,< 1K
+Predicate,https://schema.org/recognizingAuthority-output,< 1K
+Predicate,https://schema.org/recommendationStrength,< 1K
+Predicate,https://schema.org/recommendationStrength-input,< 1K
+Predicate,https://schema.org/recommendationStrength-output,< 1K
+Predicate,https://schema.org/recommendedIntake,< 1K
+Predicate,https://schema.org/recommendedIntake-input,< 1K
+Predicate,https://schema.org/recommendedIntake-output,< 1K
+Predicate,https://schema.org/recordLabel,1K - 10K
+Predicate,https://schema.org/recordLabel-input,< 1K
+Predicate,https://schema.org/recordLabel-output,< 1K
+Predicate,https://schema.org/recordedAs,< 1K
+Predicate,https://schema.org/recordedAs-input,< 1K
+Predicate,https://schema.org/recordedAs-output,< 1K
+Predicate,https://schema.org/recordedAt,< 1K
+Predicate,https://schema.org/recordedAt-input,< 1K
+Predicate,https://schema.org/recordedAt-output,< 1K
+Predicate,https://schema.org/recordedIn,< 1K
+Predicate,https://schema.org/recordedIn-input,< 1K
+Predicate,https://schema.org/recordedIn-output,< 1K
+Predicate,https://schema.org/recordingOf,1K - 10K
+Predicate,https://schema.org/recordingOf-input,< 1K
+Predicate,https://schema.org/recordingOf-output,< 1K
+Predicate,https://schema.org/recourseLoan,< 1K
+Predicate,https://schema.org/recourseLoan-input,< 1K
+Predicate,https://schema.org/recourseLoan-output,< 1K
+Predicate,https://schema.org/referee,< 1K
+Predicate,https://schema.org/referee-input,< 1K
+Predicate,https://schema.org/referee-output,< 1K
+Predicate,https://schema.org/referenceQuantity,10K - 100K
+Predicate,https://schema.org/referenceQuantity-input,< 1K
+Predicate,https://schema.org/referenceQuantity-output,< 1K
+Predicate,https://schema.org/referencesOrder,< 1K
+Predicate,https://schema.org/referencesOrder-input,< 1K
+Predicate,https://schema.org/referencesOrder-output,< 1K
+Predicate,https://schema.org/refundType,10K - 100K
+Predicate,https://schema.org/refundType-input,< 1K
+Predicate,https://schema.org/refundType-output,< 1K
+Predicate,https://schema.org/regionDrained,< 1K
+Predicate,https://schema.org/regionDrained-input,< 1K
+Predicate,https://schema.org/regionDrained-output,< 1K
+Predicate,https://schema.org/regionsAllowed,1K - 10K
+Predicate,https://schema.org/regionsAllowed-input,< 1K
+Predicate,https://schema.org/regionsAllowed-output,< 1K
+Predicate,https://schema.org/relatedAnatomy,< 1K
+Predicate,https://schema.org/relatedAnatomy-input,< 1K
+Predicate,https://schema.org/relatedAnatomy-output,< 1K
+Predicate,https://schema.org/relatedCondition,< 1K
+Predicate,https://schema.org/relatedCondition-input,< 1K
+Predicate,https://schema.org/relatedCondition-output,< 1K
+Predicate,https://schema.org/relatedDrug,< 1K
+Predicate,https://schema.org/relatedDrug-input,< 1K
+Predicate,https://schema.org/relatedDrug-output,< 1K
+Predicate,https://schema.org/relatedLink,10K - 100K
+Predicate,https://schema.org/relatedLink-input,< 1K
+Predicate,https://schema.org/relatedLink-output,< 1K
+Predicate,https://schema.org/relatedStructure,< 1K
+Predicate,https://schema.org/relatedStructure-input,< 1K
+Predicate,https://schema.org/relatedStructure-output,< 1K
+Predicate,https://schema.org/relatedTherapy,< 1K
+Predicate,https://schema.org/relatedTherapy-input,< 1K
+Predicate,https://schema.org/relatedTherapy-output,< 1K
+Predicate,https://schema.org/relatedTo,< 1K
+Predicate,https://schema.org/relatedTo-input,< 1K
+Predicate,https://schema.org/relatedTo-output,< 1K
+Predicate,https://schema.org/releaseDate,10K - 100K
+Predicate,https://schema.org/releaseDate-input,< 1K
+Predicate,https://schema.org/releaseDate-output,< 1K
+Predicate,https://schema.org/releaseNotes,10K - 100K
+Predicate,https://schema.org/releaseNotes-input,< 1K
+Predicate,https://schema.org/releaseNotes-output,< 1K
+Predicate,https://schema.org/releaseOf,< 1K
+Predicate,https://schema.org/releaseOf-input,< 1K
+Predicate,https://schema.org/releaseOf-output,< 1K
+Predicate,https://schema.org/releasedEvent,1K - 10K
+Predicate,https://schema.org/releasedEvent-input,< 1K
+Predicate,https://schema.org/releasedEvent-output,< 1K
+Predicate,https://schema.org/relevantOccupation,< 1K
+Predicate,https://schema.org/relevantOccupation-input,< 1K
+Predicate,https://schema.org/relevantOccupation-output,< 1K
+Predicate,https://schema.org/relevantSpecialty,1K - 10K
+Predicate,https://schema.org/relevantSpecialty-input,< 1K
+Predicate,https://schema.org/relevantSpecialty-output,< 1K
+Predicate,https://schema.org/remainingAttendeeCapacity,1K - 10K
+Predicate,https://schema.org/remainingAttendeeCapacity-input,< 1K
+Predicate,https://schema.org/remainingAttendeeCapacity-output,< 1K
+Predicate,https://schema.org/renegotiableLoan,< 1K
+Predicate,https://schema.org/renegotiableLoan-input,< 1K
+Predicate,https://schema.org/renegotiableLoan-output,< 1K
+Predicate,https://schema.org/repeatCount,1K - 10K
+Predicate,https://schema.org/repeatCount-input,< 1K
+Predicate,https://schema.org/repeatCount-output,< 1K
+Predicate,https://schema.org/repeatFrequency,10K - 100K
+Predicate,https://schema.org/repeatFrequency-input,< 1K
+Predicate,https://schema.org/repeatFrequency-output,< 1K
+Predicate,https://schema.org/repetitions,< 1K
+Predicate,https://schema.org/repetitions-input,< 1K
+Predicate,https://schema.org/repetitions-output,< 1K
+Predicate,https://schema.org/replacee,< 1K
+Predicate,https://schema.org/replacee-input,< 1K
+Predicate,https://schema.org/replacee-output,< 1K
+Predicate,https://schema.org/replacer,< 1K
+Predicate,https://schema.org/replacer-input,< 1K
+Predicate,https://schema.org/replacer-output,< 1K
+Predicate,https://schema.org/replyToUrl,1K - 10K
+Predicate,https://schema.org/replyToUrl-input,< 1K
+Predicate,https://schema.org/replyToUrl-output,< 1K
+Predicate,https://schema.org/reportNumber,< 1K
+Predicate,https://schema.org/reportNumber-input,< 1K
+Predicate,https://schema.org/reportNumber-output,< 1K
+Predicate,https://schema.org/representativeOfPage,100K - 1M
+Predicate,https://schema.org/representativeOfPage-input,< 1K
+Predicate,https://schema.org/representativeOfPage-output,< 1K
+Predicate,https://schema.org/requiredCollateral,< 1K
+Predicate,https://schema.org/requiredCollateral-input,< 1K
+Predicate,https://schema.org/requiredCollateral-output,< 1K
+Predicate,https://schema.org/requiredGender,< 1K
+Predicate,https://schema.org/requiredGender-input,< 1K
+Predicate,https://schema.org/requiredGender-output,< 1K
+Predicate,https://schema.org/requiredMaxAge,< 1K
+Predicate,https://schema.org/requiredMaxAge-input,< 1K
+Predicate,https://schema.org/requiredMaxAge-output,< 1K
+Predicate,https://schema.org/requiredMinAge,1K - 10K
+Predicate,https://schema.org/requiredMinAge-input,< 1K
+Predicate,https://schema.org/requiredMinAge-output,< 1K
+Predicate,https://schema.org/requiredQuantity,1K - 10K
+Predicate,https://schema.org/requiredQuantity-input,< 1K
+Predicate,https://schema.org/requiredQuantity-output,< 1K
+Predicate,https://schema.org/requirements,1K - 10K
+Predicate,https://schema.org/requirements-input,< 1K
+Predicate,https://schema.org/requirements-output,< 1K
+Predicate,https://schema.org/requiresSubscription,1K - 10K
+Predicate,https://schema.org/requiresSubscription-input,< 1K
+Predicate,https://schema.org/requiresSubscription-output,< 1K
+Predicate,https://schema.org/reservationFor,1K - 10K
+Predicate,https://schema.org/reservationFor-input,< 1K
+Predicate,https://schema.org/reservationFor-output,< 1K
+Predicate,https://schema.org/reservationId,< 1K
+Predicate,https://schema.org/reservationId-input,< 1K
+Predicate,https://schema.org/reservationId-output,< 1K
+Predicate,https://schema.org/reservationStatus,< 1K
+Predicate,https://schema.org/reservationStatus-input,< 1K
+Predicate,https://schema.org/reservationStatus-output,< 1K
+Predicate,https://schema.org/reservedTicket,< 1K
+Predicate,https://schema.org/reservedTicket-input,< 1K
+Predicate,https://schema.org/reservedTicket-output,< 1K
+Predicate,https://schema.org/responsibilities,10K - 100K
+Predicate,https://schema.org/responsibilities-input,< 1K
+Predicate,https://schema.org/responsibilities-output,< 1K
+Predicate,https://schema.org/restPeriods,< 1K
+Predicate,https://schema.org/restPeriods-input,< 1K
+Predicate,https://schema.org/restPeriods-output,< 1K
+Predicate,https://schema.org/restockingFee,1K - 10K
+Predicate,https://schema.org/restockingFee-input,< 1K
+Predicate,https://schema.org/restockingFee-output,< 1K
+Predicate,https://schema.org/result,10K - 100K
+Predicate,https://schema.org/result-input,< 1K
+Predicate,https://schema.org/result-output,< 1K
+Predicate,https://schema.org/resultComment,< 1K
+Predicate,https://schema.org/resultComment-input,< 1K
+Predicate,https://schema.org/resultComment-output,< 1K
+Predicate,https://schema.org/resultReview,< 1K
+Predicate,https://schema.org/resultReview-input,< 1K
+Predicate,https://schema.org/resultReview-output,< 1K
+Predicate,https://schema.org/returnFees,100K - 1M
+Predicate,https://schema.org/returnFees-input,< 1K
+Predicate,https://schema.org/returnFees-output,< 1K
+Predicate,https://schema.org/returnLabelSource,1K - 10K
+Predicate,https://schema.org/returnLabelSource-input,< 1K
+Predicate,https://schema.org/returnLabelSource-output,< 1K
+Predicate,https://schema.org/returnMethod,100K - 1M
+Predicate,https://schema.org/returnMethod-input,< 1K
+Predicate,https://schema.org/returnMethod-output,< 1K
+Predicate,https://schema.org/returnPolicyCategory,100K - 1M
+Predicate,https://schema.org/returnPolicyCategory-input,< 1K
+Predicate,https://schema.org/returnPolicyCategory-output,< 1K
+Predicate,https://schema.org/returnPolicyCountry,10K - 100K
+Predicate,https://schema.org/returnPolicyCountry-input,< 1K
+Predicate,https://schema.org/returnPolicyCountry-output,< 1K
+Predicate,https://schema.org/returnPolicySeasonalOverride,1K - 10K
+Predicate,https://schema.org/returnPolicySeasonalOverride-input,< 1K
+Predicate,https://schema.org/returnPolicySeasonalOverride-output,< 1K
+Predicate,https://schema.org/returnShippingFeesAmount,10K - 100K
+Predicate,https://schema.org/returnShippingFeesAmount-input,< 1K
+Predicate,https://schema.org/returnShippingFeesAmount-output,< 1K
+Predicate,https://schema.org/review,1M - 10M
+Predicate,https://schema.org/review-input,< 1K
+Predicate,https://schema.org/review-output,< 1K
+Predicate,https://schema.org/reviewAspect,10K - 100K
+Predicate,https://schema.org/reviewAspect-input,< 1K
+Predicate,https://schema.org/reviewAspect-output,< 1K
+Predicate,https://schema.org/reviewBody,1M - 10M
+Predicate,https://schema.org/reviewBody-input,< 1K
+Predicate,https://schema.org/reviewBody-output,< 1K
+Predicate,https://schema.org/reviewCount,1M - 10M
+Predicate,https://schema.org/reviewCount-input,< 1K
+Predicate,https://schema.org/reviewCount-output,< 1K
+Predicate,https://schema.org/reviewRating,1M - 10M
+Predicate,https://schema.org/reviewRating-input,< 1K
+Predicate,https://schema.org/reviewRating-output,< 1K
+Predicate,https://schema.org/reviewedBy,10K - 100K
+Predicate,https://schema.org/reviewedBy-input,< 1K
+Predicate,https://schema.org/reviewedBy-output,< 1K
+Predicate,https://schema.org/reviews,1K - 10K
+Predicate,https://schema.org/reviews-input,< 1K
+Predicate,https://schema.org/reviews-output,< 1K
+Predicate,https://schema.org/riskFactor,1K - 10K
+Predicate,https://schema.org/riskFactor-input,< 1K
+Predicate,https://schema.org/riskFactor-output,< 1K
+Predicate,https://schema.org/risks,< 1K
+Predicate,https://schema.org/risks-input,< 1K
+Predicate,https://schema.org/risks-output,< 1K
+Predicate,https://schema.org/roleName,1K - 10K
+Predicate,https://schema.org/roleName-input,< 1K
+Predicate,https://schema.org/roleName-output,< 1K
+Predicate,https://schema.org/roofLoad,< 1K
+Predicate,https://schema.org/roofLoad-input,< 1K
+Predicate,https://schema.org/roofLoad-output,< 1K
+Predicate,https://schema.org/rsvpResponse,< 1K
+Predicate,https://schema.org/rsvpResponse-input,< 1K
+Predicate,https://schema.org/rsvpResponse-output,< 1K
+Predicate,https://schema.org/runsTo,< 1K
+Predicate,https://schema.org/runsTo-input,< 1K
+Predicate,https://schema.org/runsTo-output,< 1K
+Predicate,https://schema.org/runtime,< 1K
+Predicate,https://schema.org/runtime-input,< 1K
+Predicate,https://schema.org/runtime-output,< 1K
+Predicate,https://schema.org/runtimePlatform,1K - 10K
+Predicate,https://schema.org/runtimePlatform-input,< 1K
+Predicate,https://schema.org/runtimePlatform-output,< 1K
+Predicate,https://schema.org/rxcui,< 1K
+Predicate,https://schema.org/rxcui-input,< 1K
+Predicate,https://schema.org/rxcui-output,< 1K
+Predicate,https://schema.org/safetyConsideration,< 1K
+Predicate,https://schema.org/safetyConsideration-input,< 1K
+Predicate,https://schema.org/safetyConsideration-output,< 1K
+Predicate,https://schema.org/salaryCurrency,1K - 10K
+Predicate,https://schema.org/salaryCurrency-input,< 1K
+Predicate,https://schema.org/salaryCurrency-output,< 1K
+Predicate,https://schema.org/salaryUponCompletion,< 1K
+Predicate,https://schema.org/salaryUponCompletion-input,< 1K
+Predicate,https://schema.org/salaryUponCompletion-output,< 1K
+Predicate,https://schema.org/sameAs,10M+
+Predicate,https://schema.org/sameAs-input,< 1K
+Predicate,https://schema.org/sameAs-output,< 1K
+Predicate,https://schema.org/sampleType,< 1K
+Predicate,https://schema.org/sampleType-input,< 1K
+Predicate,https://schema.org/sampleType-output,< 1K
+Predicate,https://schema.org/saturatedFatContent,10K - 100K
+Predicate,https://schema.org/saturatedFatContent-input,< 1K
+Predicate,https://schema.org/saturatedFatContent-output,< 1K
+Predicate,https://schema.org/scheduleTimezone,1K - 10K
+Predicate,https://schema.org/scheduleTimezone-input,< 1K
+Predicate,https://schema.org/scheduleTimezone-output,< 1K
+Predicate,https://schema.org/scheduledPaymentDate,< 1K
+Predicate,https://schema.org/scheduledPaymentDate-input,< 1K
+Predicate,https://schema.org/scheduledPaymentDate-output,< 1K
+Predicate,https://schema.org/scheduledTime,< 1K
+Predicate,https://schema.org/scheduledTime-input,< 1K
+Predicate,https://schema.org/scheduledTime-output,< 1K
+Predicate,https://schema.org/schemaVersion,< 1K
+Predicate,https://schema.org/schemaVersion-input,< 1K
+Predicate,https://schema.org/schemaVersion-output,< 1K
+Predicate,https://schema.org/schoolClosuresInfo,< 1K
+Predicate,https://schema.org/schoolClosuresInfo-input,< 1K
+Predicate,https://schema.org/schoolClosuresInfo-output,< 1K
+Predicate,https://schema.org/screenCount,< 1K
+Predicate,https://schema.org/screenCount-input,< 1K
+Predicate,https://schema.org/screenCount-output,< 1K
+Predicate,https://schema.org/screenshot,100K - 1M
+Predicate,https://schema.org/screenshot-input,< 1K
+Predicate,https://schema.org/screenshot-output,< 1K
+Predicate,https://schema.org/sdDatePublished,1K - 10K
+Predicate,https://schema.org/sdDatePublished-input,< 1K
+Predicate,https://schema.org/sdDatePublished-output,< 1K
+Predicate,https://schema.org/sdLicense,< 1K
+Predicate,https://schema.org/sdLicense-input,< 1K
+Predicate,https://schema.org/sdLicense-output,< 1K
+Predicate,https://schema.org/sdPublisher,1K - 10K
+Predicate,https://schema.org/sdPublisher-input,< 1K
+Predicate,https://schema.org/sdPublisher-output,< 1K
+Predicate,https://schema.org/season,< 1K
+Predicate,https://schema.org/season-input,< 1K
+Predicate,https://schema.org/season-output,< 1K
+Predicate,https://schema.org/seasonNumber,1K - 10K
+Predicate,https://schema.org/seasonNumber-input,< 1K
+Predicate,https://schema.org/seasonNumber-output,< 1K
+Predicate,https://schema.org/seasonalOverride,< 1K
+Predicate,https://schema.org/seasonalOverride-input,< 1K
+Predicate,https://schema.org/seasonalOverride-output,< 1K
+Predicate,https://schema.org/seasons,< 1K
+Predicate,https://schema.org/seasons-input,< 1K
+Predicate,https://schema.org/seasons-output,< 1K
+Predicate,https://schema.org/seatNumber,< 1K
+Predicate,https://schema.org/seatNumber-input,< 1K
+Predicate,https://schema.org/seatNumber-output,< 1K
+Predicate,https://schema.org/seatRow,< 1K
+Predicate,https://schema.org/seatRow-input,< 1K
+Predicate,https://schema.org/seatRow-output,< 1K
+Predicate,https://schema.org/seatSection,< 1K
+Predicate,https://schema.org/seatSection-input,< 1K
+Predicate,https://schema.org/seatSection-output,< 1K
+Predicate,https://schema.org/seatingCapacity,1K - 10K
+Predicate,https://schema.org/seatingCapacity-input,< 1K
+Predicate,https://schema.org/seatingCapacity-output,< 1K
+Predicate,https://schema.org/seatingType,< 1K
+Predicate,https://schema.org/seatingType-input,< 1K
+Predicate,https://schema.org/seatingType-output,< 1K
+Predicate,https://schema.org/secondaryPrevention,< 1K
+Predicate,https://schema.org/secondaryPrevention-input,< 1K
+Predicate,https://schema.org/secondaryPrevention-output,< 1K
+Predicate,https://schema.org/securityClearanceRequirement,< 1K
+Predicate,https://schema.org/securityClearanceRequirement-input,< 1K
+Predicate,https://schema.org/securityClearanceRequirement-output,< 1K
+Predicate,https://schema.org/securityScreening,< 1K
+Predicate,https://schema.org/securityScreening-input,< 1K
+Predicate,https://schema.org/securityScreening-output,< 1K
+Predicate,https://schema.org/seeks,1K - 10K
+Predicate,https://schema.org/seeks-input,< 1K
+Predicate,https://schema.org/seeks-output,< 1K
+Predicate,https://schema.org/seller,1M - 10M
+Predicate,https://schema.org/seller-input,< 1K
+Predicate,https://schema.org/seller-output,< 1K
+Predicate,https://schema.org/sender,< 1K
+Predicate,https://schema.org/sender-input,< 1K
+Predicate,https://schema.org/sender-output,< 1K
+Predicate,https://schema.org/sensoryRequirement,< 1K
+Predicate,https://schema.org/sensoryRequirement-input,< 1K
+Predicate,https://schema.org/sensoryRequirement-output,< 1K
+Predicate,https://schema.org/sensoryUnit,< 1K
+Predicate,https://schema.org/sensoryUnit-input,< 1K
+Predicate,https://schema.org/sensoryUnit-output,< 1K
+Predicate,https://schema.org/serialNumber,10K - 100K
+Predicate,https://schema.org/serialNumber-input,< 1K
+Predicate,https://schema.org/serialNumber-output,< 1K
+Predicate,https://schema.org/seriousAdverseOutcome,< 1K
+Predicate,https://schema.org/seriousAdverseOutcome-input,< 1K
+Predicate,https://schema.org/seriousAdverseOutcome-output,< 1K
+Predicate,https://schema.org/serverStatus,< 1K
+Predicate,https://schema.org/serverStatus-input,< 1K
+Predicate,https://schema.org/serverStatus-output,< 1K
+Predicate,https://schema.org/servesCuisine,100K - 1M
+Predicate,https://schema.org/servesCuisine-input,< 1K
+Predicate,https://schema.org/servesCuisine-output,< 1K
+Predicate,https://schema.org/serviceArea,10K - 100K
+Predicate,https://schema.org/serviceArea-input,< 1K
+Predicate,https://schema.org/serviceArea-output,< 1K
+Predicate,https://schema.org/serviceAudience,1K - 10K
+Predicate,https://schema.org/serviceAudience-input,< 1K
+Predicate,https://schema.org/serviceAudience-output,< 1K
+Predicate,https://schema.org/serviceLocation,10K - 100K
+Predicate,https://schema.org/serviceLocation-input,< 1K
+Predicate,https://schema.org/serviceLocation-output,< 1K
+Predicate,https://schema.org/serviceOperator,1K - 10K
+Predicate,https://schema.org/serviceOperator-input,< 1K
+Predicate,https://schema.org/serviceOperator-output,< 1K
+Predicate,https://schema.org/serviceOutput,10K - 100K
+Predicate,https://schema.org/serviceOutput-input,< 1K
+Predicate,https://schema.org/serviceOutput-output,< 1K
+Predicate,https://schema.org/servicePhone,10K - 100K
+Predicate,https://schema.org/servicePhone-input,< 1K
+Predicate,https://schema.org/servicePhone-output,< 1K
+Predicate,https://schema.org/servicePostalAddress,< 1K
+Predicate,https://schema.org/servicePostalAddress-input,< 1K
+Predicate,https://schema.org/servicePostalAddress-output,< 1K
+Predicate,https://schema.org/serviceSmsNumber,1K - 10K
+Predicate,https://schema.org/serviceSmsNumber-input,< 1K
+Predicate,https://schema.org/serviceSmsNumber-output,< 1K
+Predicate,https://schema.org/serviceType,100K - 1M
+Predicate,https://schema.org/serviceType-input,< 1K
+Predicate,https://schema.org/serviceType-output,< 1K
+Predicate,https://schema.org/serviceUrl,10K - 100K
+Predicate,https://schema.org/serviceUrl-input,< 1K
+Predicate,https://schema.org/serviceUrl-output,< 1K
+Predicate,https://schema.org/servingSize,10K - 100K
+Predicate,https://schema.org/servingSize-input,< 1K
+Predicate,https://schema.org/servingSize-output,< 1K
+Predicate,https://schema.org/sha256,< 1K
+Predicate,https://schema.org/sha256-input,< 1K
+Predicate,https://schema.org/sha256-output,< 1K
+Predicate,https://schema.org/sharedContent,1K - 10K
+Predicate,https://schema.org/sharedContent-input,< 1K
+Predicate,https://schema.org/sharedContent-output,< 1K
+Predicate,https://schema.org/shippingConditions,10K - 100K
+Predicate,https://schema.org/shippingConditions-input,< 1K
+Predicate,https://schema.org/shippingConditions-output,< 1K
+Predicate,https://schema.org/shippingDestination,100K - 1M
+Predicate,https://schema.org/shippingDestination-input,< 1K
+Predicate,https://schema.org/shippingDestination-output,< 1K
+Predicate,https://schema.org/shippingDetails,100K - 1M
+Predicate,https://schema.org/shippingDetails-input,< 1K
+Predicate,https://schema.org/shippingDetails-output,< 1K
+Predicate,https://schema.org/shippingLabel,1K - 10K
+Predicate,https://schema.org/shippingLabel-input,< 1K
+Predicate,https://schema.org/shippingLabel-output,< 1K
+Predicate,https://schema.org/shippingOrigin,10K - 100K
+Predicate,https://schema.org/shippingOrigin-input,< 1K
+Predicate,https://schema.org/shippingOrigin-output,< 1K
+Predicate,https://schema.org/shippingRate,100K - 1M
+Predicate,https://schema.org/shippingRate-input,< 1K
+Predicate,https://schema.org/shippingRate-output,< 1K
+Predicate,https://schema.org/shippingSettingsLink,1K - 10K
+Predicate,https://schema.org/shippingSettingsLink-input,< 1K
+Predicate,https://schema.org/shippingSettingsLink-output,< 1K
+Predicate,https://schema.org/sibling,< 1K
+Predicate,https://schema.org/sibling-input,< 1K
+Predicate,https://schema.org/sibling-output,< 1K
+Predicate,https://schema.org/siblings,< 1K
+Predicate,https://schema.org/siblings-input,< 1K
+Predicate,https://schema.org/siblings-output,< 1K
+Predicate,https://schema.org/signDetected,< 1K
+Predicate,https://schema.org/signDetected-input,< 1K
+Predicate,https://schema.org/signDetected-output,< 1K
+Predicate,https://schema.org/signOrSymptom,1K - 10K
+Predicate,https://schema.org/signOrSymptom-input,< 1K
+Predicate,https://schema.org/signOrSymptom-output,< 1K
+Predicate,https://schema.org/significance,< 1K
+Predicate,https://schema.org/significance-input,< 1K
+Predicate,https://schema.org/significance-output,< 1K
+Predicate,https://schema.org/significantLink,10K - 100K
+Predicate,https://schema.org/significantLink-input,< 1K
+Predicate,https://schema.org/significantLink-output,< 1K
+Predicate,https://schema.org/significantLinks,1K - 10K
+Predicate,https://schema.org/significantLinks-input,< 1K
+Predicate,https://schema.org/significantLinks-output,< 1K
+Predicate,https://schema.org/size,10K - 100K
+Predicate,https://schema.org/size-input,< 1K
+Predicate,https://schema.org/size-output,< 1K
+Predicate,https://schema.org/sizeGroup,< 1K
+Predicate,https://schema.org/sizeGroup-input,< 1K
+Predicate,https://schema.org/sizeGroup-output,< 1K
+Predicate,https://schema.org/sizeSystem,< 1K
+Predicate,https://schema.org/sizeSystem-input,< 1K
+Predicate,https://schema.org/sizeSystem-output,< 1K
+Predicate,https://schema.org/skills,10K - 100K
+Predicate,https://schema.org/skills-input,< 1K
+Predicate,https://schema.org/skills-output,< 1K
+Predicate,https://schema.org/sku,1M - 10M
+Predicate,https://schema.org/sku-input,< 1K
+Predicate,https://schema.org/sku-output,< 1K
+Predicate,https://schema.org/slogan,100K - 1M
+Predicate,https://schema.org/slogan-input,< 1K
+Predicate,https://schema.org/slogan-output,< 1K
+Predicate,https://schema.org/smiles,< 1K
+Predicate,https://schema.org/smiles-input,< 1K
+Predicate,https://schema.org/smiles-output,< 1K
+Predicate,https://schema.org/smokingAllowed,10K - 100K
+Predicate,https://schema.org/smokingAllowed-input,< 1K
+Predicate,https://schema.org/smokingAllowed-output,< 1K
+Predicate,https://schema.org/sodiumContent,10K - 100K
+Predicate,https://schema.org/sodiumContent-input,< 1K
+Predicate,https://schema.org/sodiumContent-output,< 1K
+Predicate,https://schema.org/softwareAddOn,< 1K
+Predicate,https://schema.org/softwareAddOn-input,< 1K
+Predicate,https://schema.org/softwareAddOn-output,< 1K
+Predicate,https://schema.org/softwareHelp,10K - 100K
+Predicate,https://schema.org/softwareHelp-input,< 1K
+Predicate,https://schema.org/softwareHelp-output,< 1K
+Predicate,https://schema.org/softwareRequirements,10K - 100K
+Predicate,https://schema.org/softwareRequirements-input,< 1K
+Predicate,https://schema.org/softwareRequirements-output,< 1K
+Predicate,https://schema.org/softwareVersion,100K - 1M
+Predicate,https://schema.org/softwareVersion-input,< 1K
+Predicate,https://schema.org/softwareVersion-output,< 1K
+Predicate,https://schema.org/source,1K - 10K
+Predicate,https://schema.org/source-input,< 1K
+Predicate,https://schema.org/source-output,< 1K
+Predicate,https://schema.org/sourceOrganization,10K - 100K
+Predicate,https://schema.org/sourceOrganization-input,< 1K
+Predicate,https://schema.org/sourceOrganization-output,< 1K
+Predicate,https://schema.org/sourcedFrom,< 1K
+Predicate,https://schema.org/sourcedFrom-input,< 1K
+Predicate,https://schema.org/sourcedFrom-output,< 1K
+Predicate,https://schema.org/spatial,1K - 10K
+Predicate,https://schema.org/spatial-input,< 1K
+Predicate,https://schema.org/spatial-output,< 1K
+Predicate,https://schema.org/spatialCoverage,10K - 100K
+Predicate,https://schema.org/spatialCoverage-input,< 1K
+Predicate,https://schema.org/spatialCoverage-output,< 1K
+Predicate,https://schema.org/speakable,100K - 1M
+Predicate,https://schema.org/speakable-input,< 1K
+Predicate,https://schema.org/speakable-output,< 1K
+Predicate,https://schema.org/specialCommitments,< 1K
+Predicate,https://schema.org/specialCommitments-input,< 1K
+Predicate,https://schema.org/specialCommitments-output,< 1K
+Predicate,https://schema.org/specialOpeningHoursSpecification,1K - 10K
+Predicate,https://schema.org/specialOpeningHoursSpecification-input,< 1K
+Predicate,https://schema.org/specialOpeningHoursSpecification-output,< 1K
+Predicate,https://schema.org/specialty,10K - 100K
+Predicate,https://schema.org/specialty-input,< 1K
+Predicate,https://schema.org/specialty-output,< 1K
+Predicate,https://schema.org/speechToTextMarkup,< 1K
+Predicate,https://schema.org/speechToTextMarkup-input,< 1K
+Predicate,https://schema.org/speechToTextMarkup-output,< 1K
+Predicate,https://schema.org/speed,1K - 10K
+Predicate,https://schema.org/speed-input,< 1K
+Predicate,https://schema.org/speed-output,< 1K
+Predicate,https://schema.org/spokenByCharacter,< 1K
+Predicate,https://schema.org/spokenByCharacter-input,< 1K
+Predicate,https://schema.org/spokenByCharacter-output,< 1K
+Predicate,https://schema.org/sponsor,10K - 100K
+Predicate,https://schema.org/sponsor-input,< 1K
+Predicate,https://schema.org/sponsor-output,< 1K
+Predicate,https://schema.org/sport,10K - 100K
+Predicate,https://schema.org/sport-input,< 1K
+Predicate,https://schema.org/sport-output,< 1K
+Predicate,https://schema.org/sportsActivityLocation,< 1K
+Predicate,https://schema.org/sportsActivityLocation-input,< 1K
+Predicate,https://schema.org/sportsActivityLocation-output,< 1K
+Predicate,https://schema.org/sportsEvent,< 1K
+Predicate,https://schema.org/sportsEvent-input,< 1K
+Predicate,https://schema.org/sportsEvent-output,< 1K
+Predicate,https://schema.org/sportsTeam,< 1K
+Predicate,https://schema.org/sportsTeam-input,< 1K
+Predicate,https://schema.org/sportsTeam-output,< 1K
+Predicate,https://schema.org/spouse,1K - 10K
+Predicate,https://schema.org/spouse-input,< 1K
+Predicate,https://schema.org/spouse-output,< 1K
+Predicate,https://schema.org/stage,< 1K
+Predicate,https://schema.org/stage-input,< 1K
+Predicate,https://schema.org/stage-output,< 1K
+Predicate,https://schema.org/stageAsNumber,< 1K
+Predicate,https://schema.org/stageAsNumber-input,< 1K
+Predicate,https://schema.org/stageAsNumber-output,< 1K
+Predicate,https://schema.org/starRating,10K - 100K
+Predicate,https://schema.org/starRating-input,< 1K
+Predicate,https://schema.org/starRating-output,< 1K
+Predicate,https://schema.org/startDate,100K - 1M
+Predicate,https://schema.org/startDate-input,< 1K
+Predicate,https://schema.org/startDate-output,< 1K
+Predicate,https://schema.org/startOffset,10K - 100K
+Predicate,https://schema.org/startOffset-input,10K - 100K
+Predicate,https://schema.org/startOffset-output,< 1K
+Predicate,https://schema.org/startTime,1K - 10K
+Predicate,https://schema.org/startTime-input,< 1K
+Predicate,https://schema.org/startTime-output,< 1K
+Predicate,https://schema.org/statType,< 1K
+Predicate,https://schema.org/statType-input,< 1K
+Predicate,https://schema.org/statType-output,< 1K
+Predicate,https://schema.org/status,1K - 10K
+Predicate,https://schema.org/status-input,< 1K
+Predicate,https://schema.org/status-output,< 1K
+Predicate,https://schema.org/steeringPosition,1K - 10K
+Predicate,https://schema.org/steeringPosition-input,< 1K
+Predicate,https://schema.org/steeringPosition-output,< 1K
+Predicate,https://schema.org/step,100K - 1M
+Predicate,https://schema.org/step-input,< 1K
+Predicate,https://schema.org/step-output,< 1K
+Predicate,https://schema.org/stepValue,< 1K
+Predicate,https://schema.org/stepValue-input,< 1K
+Predicate,https://schema.org/stepValue-output,< 1K
+Predicate,https://schema.org/steps,< 1K
+Predicate,https://schema.org/steps-input,< 1K
+Predicate,https://schema.org/steps-output,< 1K
+Predicate,https://schema.org/storageRequirements,10K - 100K
+Predicate,https://schema.org/storageRequirements-input,< 1K
+Predicate,https://schema.org/storageRequirements-output,< 1K
+Predicate,https://schema.org/streetAddress,1M - 10M
+Predicate,https://schema.org/streetAddress-input,< 1K
+Predicate,https://schema.org/streetAddress-output,< 1K
+Predicate,https://schema.org/strengthUnit,< 1K
+Predicate,https://schema.org/strengthUnit-input,< 1K
+Predicate,https://schema.org/strengthUnit-output,< 1K
+Predicate,https://schema.org/strengthValue,< 1K
+Predicate,https://schema.org/strengthValue-input,< 1K
+Predicate,https://schema.org/strengthValue-output,< 1K
+Predicate,https://schema.org/structuralClass,< 1K
+Predicate,https://schema.org/structuralClass-input,< 1K
+Predicate,https://schema.org/structuralClass-output,< 1K
+Predicate,https://schema.org/study,< 1K
+Predicate,https://schema.org/study-input,< 1K
+Predicate,https://schema.org/study-output,< 1K
+Predicate,https://schema.org/studyDesign,< 1K
+Predicate,https://schema.org/studyDesign-input,< 1K
+Predicate,https://schema.org/studyDesign-output,< 1K
+Predicate,https://schema.org/studyLocation,< 1K
+Predicate,https://schema.org/studyLocation-input,< 1K
+Predicate,https://schema.org/studyLocation-output,< 1K
+Predicate,https://schema.org/studySubject,< 1K
+Predicate,https://schema.org/studySubject-input,< 1K
+Predicate,https://schema.org/studySubject-output,< 1K
+Predicate,https://schema.org/stupidProperty,< 1K
+Predicate,https://schema.org/stupidProperty-input,< 1K
+Predicate,https://schema.org/stupidProperty-output,< 1K
+Predicate,https://schema.org/subEvent,1K - 10K
+Predicate,https://schema.org/subEvent-input,< 1K
+Predicate,https://schema.org/subEvent-output,< 1K
+Predicate,https://schema.org/subEvents,< 1K
+Predicate,https://schema.org/subEvents-input,< 1K
+Predicate,https://schema.org/subEvents-output,< 1K
+Predicate,https://schema.org/subOrganization,10K - 100K
+Predicate,https://schema.org/subOrganization-input,< 1K
+Predicate,https://schema.org/subOrganization-output,< 1K
+Predicate,https://schema.org/subReservation,< 1K
+Predicate,https://schema.org/subReservation-input,< 1K
+Predicate,https://schema.org/subReservation-output,< 1K
+Predicate,https://schema.org/subStageSuffix,< 1K
+Predicate,https://schema.org/subStageSuffix-input,< 1K
+Predicate,https://schema.org/subStageSuffix-output,< 1K
+Predicate,https://schema.org/subStructure,< 1K
+Predicate,https://schema.org/subStructure-input,< 1K
+Predicate,https://schema.org/subStructure-output,< 1K
+Predicate,https://schema.org/subTest,< 1K
+Predicate,https://schema.org/subTest-input,< 1K
+Predicate,https://schema.org/subTest-output,< 1K
+Predicate,https://schema.org/subTrip,< 1K
+Predicate,https://schema.org/subTrip-input,< 1K
+Predicate,https://schema.org/subTrip-output,< 1K
+Predicate,https://schema.org/subjectOf,100K - 1M
+Predicate,https://schema.org/subjectOf-input,< 1K
+Predicate,https://schema.org/subjectOf-output,< 1K
+Predicate,https://schema.org/subtitleLanguage,< 1K
+Predicate,https://schema.org/subtitleLanguage-input,< 1K
+Predicate,https://schema.org/subtitleLanguage-output,< 1K
+Predicate,https://schema.org/successorOf,< 1K
+Predicate,https://schema.org/successorOf-input,< 1K
+Predicate,https://schema.org/successorOf-output,< 1K
+Predicate,https://schema.org/sugarContent,10K - 100K
+Predicate,https://schema.org/sugarContent-input,< 1K
+Predicate,https://schema.org/sugarContent-output,< 1K
+Predicate,https://schema.org/suggestedAge,1K - 10K
+Predicate,https://schema.org/suggestedAge-input,< 1K
+Predicate,https://schema.org/suggestedAge-output,< 1K
+Predicate,https://schema.org/suggestedAnswer,10K - 100K
+Predicate,https://schema.org/suggestedAnswer-input,< 1K
+Predicate,https://schema.org/suggestedAnswer-output,< 1K
+Predicate,https://schema.org/suggestedGender,10K - 100K
+Predicate,https://schema.org/suggestedGender-input,< 1K
+Predicate,https://schema.org/suggestedGender-output,< 1K
+Predicate,https://schema.org/suggestedMaxAge,1K - 10K
+Predicate,https://schema.org/suggestedMaxAge-input,< 1K
+Predicate,https://schema.org/suggestedMaxAge-output,< 1K
+Predicate,https://schema.org/suggestedMeasurement,< 1K
+Predicate,https://schema.org/suggestedMeasurement-input,< 1K
+Predicate,https://schema.org/suggestedMeasurement-output,< 1K
+Predicate,https://schema.org/suggestedMinAge,10K - 100K
+Predicate,https://schema.org/suggestedMinAge-input,< 1K
+Predicate,https://schema.org/suggestedMinAge-output,< 1K
+Predicate,https://schema.org/suitableForDiet,10K - 100K
+Predicate,https://schema.org/suitableForDiet-input,< 1K
+Predicate,https://schema.org/suitableForDiet-output,< 1K
+Predicate,https://schema.org/superEvent,1K - 10K
+Predicate,https://schema.org/superEvent-input,< 1K
+Predicate,https://schema.org/superEvent-output,< 1K
+Predicate,https://schema.org/supersededBy,1K - 10K
+Predicate,https://schema.org/supersededBy-input,< 1K
+Predicate,https://schema.org/supersededBy-output,< 1K
+Predicate,https://schema.org/supply,10K - 100K
+Predicate,https://schema.org/supply-input,< 1K
+Predicate,https://schema.org/supply-output,< 1K
+Predicate,https://schema.org/supplyTo,< 1K
+Predicate,https://schema.org/supplyTo-input,< 1K
+Predicate,https://schema.org/supplyTo-output,< 1K
+Predicate,https://schema.org/supportingData,< 1K
+Predicate,https://schema.org/supportingData-input,< 1K
+Predicate,https://schema.org/supportingData-output,< 1K
+Predicate,https://schema.org/surface,< 1K
+Predicate,https://schema.org/surface-input,< 1K
+Predicate,https://schema.org/surface-output,< 1K
+Predicate,https://schema.org/syllabusSections,1K - 10K
+Predicate,https://schema.org/syllabusSections-input,< 1K
+Predicate,https://schema.org/syllabusSections-output,< 1K
+Predicate,https://schema.org/target,10M+
+Predicate,https://schema.org/target-input,< 1K
+Predicate,https://schema.org/target-output,< 1K
+Predicate,https://schema.org/targetCollection,< 1K
+Predicate,https://schema.org/targetCollection-input,< 1K
+Predicate,https://schema.org/targetCollection-output,< 1K
+Predicate,https://schema.org/targetDescription,< 1K
+Predicate,https://schema.org/targetDescription-input,< 1K
+Predicate,https://schema.org/targetDescription-output,< 1K
+Predicate,https://schema.org/targetName,1K - 10K
+Predicate,https://schema.org/targetName-input,< 1K
+Predicate,https://schema.org/targetName-output,< 1K
+Predicate,https://schema.org/targetPlatform,< 1K
+Predicate,https://schema.org/targetPlatform-input,< 1K
+Predicate,https://schema.org/targetPlatform-output,< 1K
+Predicate,https://schema.org/targetPopulation,< 1K
+Predicate,https://schema.org/targetPopulation-input,< 1K
+Predicate,https://schema.org/targetPopulation-output,< 1K
+Predicate,https://schema.org/targetProduct,< 1K
+Predicate,https://schema.org/targetProduct-input,< 1K
+Predicate,https://schema.org/targetProduct-output,< 1K
+Predicate,https://schema.org/targetUrl,< 1K
+Predicate,https://schema.org/targetUrl-input,< 1K
+Predicate,https://schema.org/targetUrl-output,< 1K
+Predicate,https://schema.org/taxID,10K - 100K
+Predicate,https://schema.org/taxID-input,< 1K
+Predicate,https://schema.org/taxID-output,< 1K
+Predicate,https://schema.org/taxonRank,< 1K
+Predicate,https://schema.org/taxonRank-input,< 1K
+Predicate,https://schema.org/taxonRank-output,< 1K
+Predicate,https://schema.org/taxonomicRange,< 1K
+Predicate,https://schema.org/taxonomicRange-input,< 1K
+Predicate,https://schema.org/taxonomicRange-output,< 1K
+Predicate,https://schema.org/teaches,10K - 100K
+Predicate,https://schema.org/teaches-input,< 1K
+Predicate,https://schema.org/teaches-output,< 1K
+Predicate,https://schema.org/telephone,1M - 10M
+Predicate,https://schema.org/telephone-input,< 1K
+Predicate,https://schema.org/telephone-output,< 1K
+Predicate,https://schema.org/temporal,< 1K
+Predicate,https://schema.org/temporal-input,< 1K
+Predicate,https://schema.org/temporal-output,< 1K
+Predicate,https://schema.org/temporalCoverage,10K - 100K
+Predicate,https://schema.org/temporalCoverage-input,< 1K
+Predicate,https://schema.org/temporalCoverage-output,< 1K
+Predicate,https://schema.org/termCode,1K - 10K
+Predicate,https://schema.org/termCode-input,< 1K
+Predicate,https://schema.org/termCode-output,< 1K
+Predicate,https://schema.org/termDuration,< 1K
+Predicate,https://schema.org/termDuration-input,< 1K
+Predicate,https://schema.org/termDuration-output,< 1K
+Predicate,https://schema.org/termsOfService,10K - 100K
+Predicate,https://schema.org/termsOfService-input,< 1K
+Predicate,https://schema.org/termsOfService-output,< 1K
+Predicate,https://schema.org/termsPerYear,< 1K
+Predicate,https://schema.org/termsPerYear-input,< 1K
+Predicate,https://schema.org/termsPerYear-output,< 1K
+Predicate,https://schema.org/text,1M - 10M
+Predicate,https://schema.org/text-input,< 1K
+Predicate,https://schema.org/text-output,< 1K
+Predicate,https://schema.org/textValue,< 1K
+Predicate,https://schema.org/textValue-input,< 1K
+Predicate,https://schema.org/textValue-output,< 1K
+Predicate,https://schema.org/thumbnail,100K - 1M
+Predicate,https://schema.org/thumbnail-input,< 1K
+Predicate,https://schema.org/thumbnail-output,< 1K
+Predicate,https://schema.org/thumbnailUrl,10M+
+Predicate,https://schema.org/thumbnailUrl-input,< 1K
+Predicate,https://schema.org/thumbnailUrl-output,< 1K
+Predicate,https://schema.org/tickerSymbol,1K - 10K
+Predicate,https://schema.org/tickerSymbol-input,< 1K
+Predicate,https://schema.org/tickerSymbol-output,< 1K
+Predicate,https://schema.org/ticketNumber,< 1K
+Predicate,https://schema.org/ticketNumber-input,< 1K
+Predicate,https://schema.org/ticketNumber-output,< 1K
+Predicate,https://schema.org/ticketToken,< 1K
+Predicate,https://schema.org/ticketToken-input,< 1K
+Predicate,https://schema.org/ticketToken-output,< 1K
+Predicate,https://schema.org/ticketedSeat,< 1K
+Predicate,https://schema.org/ticketedSeat-input,< 1K
+Predicate,https://schema.org/ticketedSeat-output,< 1K
+Predicate,https://schema.org/timeOfDay,< 1K
+Predicate,https://schema.org/timeOfDay-input,< 1K
+Predicate,https://schema.org/timeOfDay-output,< 1K
+Predicate,https://schema.org/timeRequired,100K - 1M
+Predicate,https://schema.org/timeRequired-input,< 1K
+Predicate,https://schema.org/timeRequired-output,< 1K
+Predicate,https://schema.org/timeToComplete,1K - 10K
+Predicate,https://schema.org/timeToComplete-input,< 1K
+Predicate,https://schema.org/timeToComplete-output,< 1K
+Predicate,https://schema.org/timestamp,1K - 10K
+Predicate,https://schema.org/timestamp-input,< 1K
+Predicate,https://schema.org/timestamp-output,< 1K
+Predicate,https://schema.org/tissueSample,< 1K
+Predicate,https://schema.org/tissueSample-input,< 1K
+Predicate,https://schema.org/tissueSample-output,< 1K
+Predicate,https://schema.org/title,100K - 1M
+Predicate,https://schema.org/title-input,< 1K
+Predicate,https://schema.org/title-output,< 1K
+Predicate,https://schema.org/titleEIDR,< 1K
+Predicate,https://schema.org/titleEIDR-input,< 1K
+Predicate,https://schema.org/titleEIDR-output,< 1K
+Predicate,https://schema.org/toLocation,1K - 10K
+Predicate,https://schema.org/toLocation-input,< 1K
+Predicate,https://schema.org/toLocation-output,< 1K
+Predicate,https://schema.org/toRecipient,< 1K
+Predicate,https://schema.org/toRecipient-input,< 1K
+Predicate,https://schema.org/toRecipient-output,< 1K
+Predicate,https://schema.org/tocContinuation,< 1K
+Predicate,https://schema.org/tocContinuation-input,< 1K
+Predicate,https://schema.org/tocContinuation-output,< 1K
+Predicate,https://schema.org/tocEntry,< 1K
+Predicate,https://schema.org/tocEntry-input,< 1K
+Predicate,https://schema.org/tocEntry-output,< 1K
+Predicate,https://schema.org/tongueWeight,< 1K
+Predicate,https://schema.org/tongueWeight-input,< 1K
+Predicate,https://schema.org/tongueWeight-output,< 1K
+Predicate,https://schema.org/tool,10K - 100K
+Predicate,https://schema.org/tool-input,< 1K
+Predicate,https://schema.org/tool-output,< 1K
+Predicate,https://schema.org/torque,1K - 10K
+Predicate,https://schema.org/torque-input,< 1K
+Predicate,https://schema.org/torque-output,< 1K
+Predicate,https://schema.org/totalHistoricalEnrollment,< 1K
+Predicate,https://schema.org/totalHistoricalEnrollment-input,< 1K
+Predicate,https://schema.org/totalHistoricalEnrollment-output,< 1K
+Predicate,https://schema.org/totalJobOpenings,< 1K
+Predicate,https://schema.org/totalJobOpenings-input,< 1K
+Predicate,https://schema.org/totalJobOpenings-output,< 1K
+Predicate,https://schema.org/totalPaymentDue,< 1K
+Predicate,https://schema.org/totalPaymentDue-input,< 1K
+Predicate,https://schema.org/totalPaymentDue-output,< 1K
+Predicate,https://schema.org/totalPrice,< 1K
+Predicate,https://schema.org/totalPrice-input,< 1K
+Predicate,https://schema.org/totalPrice-output,< 1K
+Predicate,https://schema.org/totalTime,100K - 1M
+Predicate,https://schema.org/totalTime-input,< 1K
+Predicate,https://schema.org/totalTime-output,< 1K
+Predicate,https://schema.org/tourBookingPage,10K - 100K
+Predicate,https://schema.org/tourBookingPage-input,< 1K
+Predicate,https://schema.org/tourBookingPage-output,< 1K
+Predicate,https://schema.org/touristType,10K - 100K
+Predicate,https://schema.org/touristType-input,< 1K
+Predicate,https://schema.org/touristType-output,< 1K
+Predicate,https://schema.org/track,10K - 100K
+Predicate,https://schema.org/track-input,< 1K
+Predicate,https://schema.org/track-output,< 1K
+Predicate,https://schema.org/trackingNumber,< 1K
+Predicate,https://schema.org/trackingNumber-input,< 1K
+Predicate,https://schema.org/trackingNumber-output,< 1K
+Predicate,https://schema.org/trackingUrl,< 1K
+Predicate,https://schema.org/trackingUrl-input,< 1K
+Predicate,https://schema.org/trackingUrl-output,< 1K
+Predicate,https://schema.org/tracks,< 1K
+Predicate,https://schema.org/tracks-input,< 1K
+Predicate,https://schema.org/tracks-output,< 1K
+Predicate,https://schema.org/trailer,1K - 10K
+Predicate,https://schema.org/trailer-input,< 1K
+Predicate,https://schema.org/trailer-output,< 1K
+Predicate,https://schema.org/trailerWeight,< 1K
+Predicate,https://schema.org/trailerWeight-input,< 1K
+Predicate,https://schema.org/trailerWeight-output,< 1K
+Predicate,https://schema.org/trainName,< 1K
+Predicate,https://schema.org/trainName-input,< 1K
+Predicate,https://schema.org/trainName-output,< 1K
+Predicate,https://schema.org/trainNumber,< 1K
+Predicate,https://schema.org/trainNumber-input,< 1K
+Predicate,https://schema.org/trainNumber-output,< 1K
+Predicate,https://schema.org/trainingSalary,< 1K
+Predicate,https://schema.org/trainingSalary-input,< 1K
+Predicate,https://schema.org/trainingSalary-output,< 1K
+Predicate,https://schema.org/transFatContent,10K - 100K
+Predicate,https://schema.org/transFatContent-input,< 1K
+Predicate,https://schema.org/transFatContent-output,< 1K
+Predicate,https://schema.org/transcript,10K - 100K
+Predicate,https://schema.org/transcript-input,< 1K
+Predicate,https://schema.org/transcript-output,< 1K
+Predicate,https://schema.org/transitTime,100K - 1M
+Predicate,https://schema.org/transitTime-input,< 1K
+Predicate,https://schema.org/transitTime-output,< 1K
+Predicate,https://schema.org/transitTimeLabel,< 1K
+Predicate,https://schema.org/transitTimeLabel-input,< 1K
+Predicate,https://schema.org/transitTimeLabel-output,< 1K
+Predicate,https://schema.org/translationOfWork,1K - 10K
+Predicate,https://schema.org/translationOfWork-input,< 1K
+Predicate,https://schema.org/translationOfWork-output,< 1K
+Predicate,https://schema.org/translator,1K - 10K
+Predicate,https://schema.org/translator-input,< 1K
+Predicate,https://schema.org/translator-output,< 1K
+Predicate,https://schema.org/transmissionMethod,< 1K
+Predicate,https://schema.org/transmissionMethod-input,< 1K
+Predicate,https://schema.org/transmissionMethod-output,< 1K
+Predicate,https://schema.org/travelBans,< 1K
+Predicate,https://schema.org/travelBans-input,< 1K
+Predicate,https://schema.org/travelBans-output,< 1K
+Predicate,https://schema.org/trialDesign,< 1K
+Predicate,https://schema.org/trialDesign-input,< 1K
+Predicate,https://schema.org/trialDesign-output,< 1K
+Predicate,https://schema.org/tributary,< 1K
+Predicate,https://schema.org/tributary-input,< 1K
+Predicate,https://schema.org/tributary-output,< 1K
+Predicate,https://schema.org/tripOrigin,< 1K
+Predicate,https://schema.org/tripOrigin-input,< 1K
+Predicate,https://schema.org/tripOrigin-output,< 1K
+Predicate,https://schema.org/typeOfBed,10K - 100K
+Predicate,https://schema.org/typeOfBed-input,< 1K
+Predicate,https://schema.org/typeOfBed-output,< 1K
+Predicate,https://schema.org/typeOfGood,< 1K
+Predicate,https://schema.org/typeOfGood-input,< 1K
+Predicate,https://schema.org/typeOfGood-output,< 1K
+Predicate,https://schema.org/typicalAgeRange,10K - 100K
+Predicate,https://schema.org/typicalAgeRange-input,< 1K
+Predicate,https://schema.org/typicalAgeRange-output,< 1K
+Predicate,https://schema.org/typicalCreditsPerTerm,< 1K
+Predicate,https://schema.org/typicalCreditsPerTerm-input,< 1K
+Predicate,https://schema.org/typicalCreditsPerTerm-output,< 1K
+Predicate,https://schema.org/typicalTest,< 1K
+Predicate,https://schema.org/typicalTest-input,< 1K
+Predicate,https://schema.org/typicalTest-output,< 1K
+Predicate,https://schema.org/underName,< 1K
+Predicate,https://schema.org/underName-input,< 1K
+Predicate,https://schema.org/underName-output,< 1K
+Predicate,https://schema.org/unitCode,100K - 1M
+Predicate,https://schema.org/unitCode-input,< 1K
+Predicate,https://schema.org/unitCode-output,< 1K
+Predicate,https://schema.org/unitText,100K - 1M
+Predicate,https://schema.org/unitText-input,< 1K
+Predicate,https://schema.org/unitText-output,< 1K
+Predicate,https://schema.org/unnamedSourcesPolicy,1K - 10K
+Predicate,https://schema.org/unnamedSourcesPolicy-input,< 1K
+Predicate,https://schema.org/unnamedSourcesPolicy-output,< 1K
+Predicate,https://schema.org/unsaturatedFatContent,10K - 100K
+Predicate,https://schema.org/unsaturatedFatContent-input,< 1K
+Predicate,https://schema.org/unsaturatedFatContent-output,< 1K
+Predicate,https://schema.org/uploadDate,1M - 10M
+Predicate,https://schema.org/uploadDate-input,< 1K
+Predicate,https://schema.org/uploadDate-output,< 1K
+Predicate,https://schema.org/upvoteCount,10K - 100K
+Predicate,https://schema.org/upvoteCount-input,< 1K
+Predicate,https://schema.org/upvoteCount-output,< 1K
+Predicate,https://schema.org/url,10M+
+Predicate,https://schema.org/url-input,< 1K
+Predicate,https://schema.org/url-output,< 1K
+Predicate,https://schema.org/urlTemplate,10M+
+Predicate,https://schema.org/urlTemplate-input,< 1K
+Predicate,https://schema.org/urlTemplate-output,< 1K
+Predicate,https://schema.org/usNPI,< 1K
+Predicate,https://schema.org/usNPI-input,< 1K
+Predicate,https://schema.org/usNPI-output,< 1K
+Predicate,https://schema.org/usageInfo,1K - 10K
+Predicate,https://schema.org/usageInfo-input,< 1K
+Predicate,https://schema.org/usageInfo-output,< 1K
+Predicate,https://schema.org/usedToDiagnose,1K - 10K
+Predicate,https://schema.org/usedToDiagnose-input,< 1K
+Predicate,https://schema.org/usedToDiagnose-output,< 1K
+Predicate,https://schema.org/userInteractionCount,100K - 1M
+Predicate,https://schema.org/userInteractionCount-input,< 1K
+Predicate,https://schema.org/userInteractionCount-output,< 1K
+Predicate,https://schema.org/usesDevice,< 1K
+Predicate,https://schema.org/usesDevice-input,< 1K
+Predicate,https://schema.org/usesDevice-output,< 1K
+Predicate,https://schema.org/usesHealthPlanIdStandard,< 1K
+Predicate,https://schema.org/usesHealthPlanIdStandard-input,< 1K
+Predicate,https://schema.org/usesHealthPlanIdStandard-output,< 1K
+Predicate,https://schema.org/utterances,< 1K
+Predicate,https://schema.org/utterances-input,< 1K
+Predicate,https://schema.org/utterances-output,< 1K
+Predicate,https://schema.org/validFor,< 1K
+Predicate,https://schema.org/validFor-input,< 1K
+Predicate,https://schema.org/validFor-output,< 1K
+Predicate,https://schema.org/validForMemberTier,< 1K
+Predicate,https://schema.org/validForMemberTier-input,< 1K
+Predicate,https://schema.org/validForMemberTier-output,< 1K
+Predicate,https://schema.org/validFrom,100K - 1M
+Predicate,https://schema.org/validFrom-input,< 1K
+Predicate,https://schema.org/validFrom-output,< 1K
+Predicate,https://schema.org/validIn,1K - 10K
+Predicate,https://schema.org/validIn-input,< 1K
+Predicate,https://schema.org/validIn-output,< 1K
+Predicate,https://schema.org/validThrough,1M - 10M
+Predicate,https://schema.org/validThrough-input,< 1K
+Predicate,https://schema.org/validThrough-output,< 1K
+Predicate,https://schema.org/validUntil,< 1K
+Predicate,https://schema.org/validUntil-input,< 1K
+Predicate,https://schema.org/validUntil-output,< 1K
+Predicate,https://schema.org/value,1M - 10M
+Predicate,https://schema.org/value-input,< 1K
+Predicate,https://schema.org/value-output,< 1K
+Predicate,https://schema.org/valueAddedTaxIncluded,1M - 10M
+Predicate,https://schema.org/valueAddedTaxIncluded-input,< 1K
+Predicate,https://schema.org/valueAddedTaxIncluded-output,< 1K
+Predicate,https://schema.org/valueMaxLength,1K - 10K
+Predicate,https://schema.org/valueMaxLength-input,< 1K
+Predicate,https://schema.org/valueMaxLength-output,< 1K
+Predicate,https://schema.org/valueMinLength,< 1K
+Predicate,https://schema.org/valueMinLength-input,< 1K
+Predicate,https://schema.org/valueMinLength-output,< 1K
+Predicate,https://schema.org/valueName,10M+
+Predicate,https://schema.org/valueName-input,< 1K
+Predicate,https://schema.org/valueName-output,< 1K
+Predicate,https://schema.org/valuePattern,< 1K
+Predicate,https://schema.org/valuePattern-input,< 1K
+Predicate,https://schema.org/valuePattern-output,< 1K
+Predicate,https://schema.org/valueReference,1K - 10K
+Predicate,https://schema.org/valueReference-input,< 1K
+Predicate,https://schema.org/valueReference-output,< 1K
+Predicate,https://schema.org/valueRequired,10M+
+Predicate,https://schema.org/valueRequired-input,< 1K
+Predicate,https://schema.org/valueRequired-output,< 1K
+Predicate,https://schema.org/variableMeasured,10K - 100K
+Predicate,https://schema.org/variableMeasured-input,< 1K
+Predicate,https://schema.org/variableMeasured-output,< 1K
+Predicate,https://schema.org/variablesMeasured,< 1K
+Predicate,https://schema.org/variablesMeasured-input,< 1K
+Predicate,https://schema.org/variablesMeasured-output,< 1K
+Predicate,https://schema.org/variantCover,< 1K
+Predicate,https://schema.org/variantCover-input,< 1K
+Predicate,https://schema.org/variantCover-output,< 1K
+Predicate,https://schema.org/variesBy,10K - 100K
+Predicate,https://schema.org/variesBy-input,< 1K
+Predicate,https://schema.org/variesBy-output,< 1K
+Predicate,https://schema.org/vatID,100K - 1M
+Predicate,https://schema.org/vatID-input,< 1K
+Predicate,https://schema.org/vatID-output,< 1K
+Predicate,https://schema.org/vehicleConfiguration,10K - 100K
+Predicate,https://schema.org/vehicleConfiguration-input,< 1K
+Predicate,https://schema.org/vehicleConfiguration-output,< 1K
+Predicate,https://schema.org/vehicleEngine,10K - 100K
+Predicate,https://schema.org/vehicleEngine-input,< 1K
+Predicate,https://schema.org/vehicleEngine-output,< 1K
+Predicate,https://schema.org/vehicleIdentificationNumber,10K - 100K
+Predicate,https://schema.org/vehicleIdentificationNumber-input,< 1K
+Predicate,https://schema.org/vehicleIdentificationNumber-output,< 1K
+Predicate,https://schema.org/vehicleInteriorColor,10K - 100K
+Predicate,https://schema.org/vehicleInteriorColor-input,< 1K
+Predicate,https://schema.org/vehicleInteriorColor-output,< 1K
+Predicate,https://schema.org/vehicleInteriorType,10K - 100K
+Predicate,https://schema.org/vehicleInteriorType-input,< 1K
+Predicate,https://schema.org/vehicleInteriorType-output,< 1K
+Predicate,https://schema.org/vehicleModelDate,10K - 100K
+Predicate,https://schema.org/vehicleModelDate-input,< 1K
+Predicate,https://schema.org/vehicleModelDate-output,< 1K
+Predicate,https://schema.org/vehicleSeatingCapacity,10K - 100K
+Predicate,https://schema.org/vehicleSeatingCapacity-input,< 1K
+Predicate,https://schema.org/vehicleSeatingCapacity-output,< 1K
+Predicate,https://schema.org/vehicleSpecialUsage,< 1K
+Predicate,https://schema.org/vehicleSpecialUsage-input,< 1K
+Predicate,https://schema.org/vehicleSpecialUsage-output,< 1K
+Predicate,https://schema.org/vehicleTransmission,10K - 100K
+Predicate,https://schema.org/vehicleTransmission-input,< 1K
+Predicate,https://schema.org/vehicleTransmission-output,< 1K
+Predicate,https://schema.org/vendor,< 1K
+Predicate,https://schema.org/vendor-input,< 1K
+Predicate,https://schema.org/vendor-output,< 1K
+Predicate,https://schema.org/verificationFactCheckingPolicy,1K - 10K
+Predicate,https://schema.org/verificationFactCheckingPolicy-input,< 1K
+Predicate,https://schema.org/verificationFactCheckingPolicy-output,< 1K
+Predicate,https://schema.org/version,1K - 10K
+Predicate,https://schema.org/version-input,< 1K
+Predicate,https://schema.org/version-output,< 1K
+Predicate,https://schema.org/video,100K - 1M
+Predicate,https://schema.org/video-input,< 1K
+Predicate,https://schema.org/video-output,< 1K
+Predicate,https://schema.org/videoFormat,1K - 10K
+Predicate,https://schema.org/videoFormat-input,< 1K
+Predicate,https://schema.org/videoFormat-output,< 1K
+Predicate,https://schema.org/videoFrameSize,< 1K
+Predicate,https://schema.org/videoFrameSize-input,< 1K
+Predicate,https://schema.org/videoFrameSize-output,< 1K
+Predicate,https://schema.org/videoQuality,10K - 100K
+Predicate,https://schema.org/videoQuality-input,< 1K
+Predicate,https://schema.org/videoQuality-output,< 1K
+Predicate,https://schema.org/volumeNumber,1K - 10K
+Predicate,https://schema.org/volumeNumber-input,< 1K
+Predicate,https://schema.org/volumeNumber-output,< 1K
+Predicate,https://schema.org/warning,< 1K
+Predicate,https://schema.org/warning-input,< 1K
+Predicate,https://schema.org/warning-output,< 1K
+Predicate,https://schema.org/warranty,10K - 100K
+Predicate,https://schema.org/warranty-input,< 1K
+Predicate,https://schema.org/warranty-output,< 1K
+Predicate,https://schema.org/warrantyPromise,< 1K
+Predicate,https://schema.org/warrantyPromise-input,< 1K
+Predicate,https://schema.org/warrantyPromise-output,< 1K
+Predicate,https://schema.org/warrantyScope,1K - 10K
+Predicate,https://schema.org/warrantyScope-input,< 1K
+Predicate,https://schema.org/warrantyScope-output,< 1K
+Predicate,https://schema.org/webCheckinTime,< 1K
+Predicate,https://schema.org/webCheckinTime-input,< 1K
+Predicate,https://schema.org/webCheckinTime-output,< 1K
+Predicate,https://schema.org/webFeed,1K - 10K
+Predicate,https://schema.org/webFeed-input,< 1K
+Predicate,https://schema.org/webFeed-output,< 1K
+Predicate,https://schema.org/weight,100K - 1M
+Predicate,https://schema.org/weight-input,< 1K
+Predicate,https://schema.org/weight-output,< 1K
+Predicate,https://schema.org/weightPercentage,< 1K
+Predicate,https://schema.org/weightPercentage-input,< 1K
+Predicate,https://schema.org/weightPercentage-output,< 1K
+Predicate,https://schema.org/weightTotal,1K - 10K
+Predicate,https://schema.org/weightTotal-input,< 1K
+Predicate,https://schema.org/weightTotal-output,< 1K
+Predicate,https://schema.org/wheelbase,1K - 10K
+Predicate,https://schema.org/wheelbase-input,< 1K
+Predicate,https://schema.org/wheelbase-output,< 1K
+Predicate,https://schema.org/width,10M+
+Predicate,https://schema.org/width-input,< 1K
+Predicate,https://schema.org/width-output,< 1K
+Predicate,https://schema.org/winner,< 1K
+Predicate,https://schema.org/winner-input,< 1K
+Predicate,https://schema.org/winner-output,< 1K
+Predicate,https://schema.org/wordCount,1M - 10M
+Predicate,https://schema.org/wordCount-input,< 1K
+Predicate,https://schema.org/wordCount-output,< 1K
+Predicate,https://schema.org/workExample,1K - 10K
+Predicate,https://schema.org/workExample-input,< 1K
+Predicate,https://schema.org/workExample-output,< 1K
+Predicate,https://schema.org/workFeatured,< 1K
+Predicate,https://schema.org/workFeatured-input,< 1K
+Predicate,https://schema.org/workFeatured-output,< 1K
+Predicate,https://schema.org/workHours,10K - 100K
+Predicate,https://schema.org/workHours-input,< 1K
+Predicate,https://schema.org/workHours-output,< 1K
+Predicate,https://schema.org/workLocation,10K - 100K
+Predicate,https://schema.org/workLocation-input,< 1K
+Predicate,https://schema.org/workLocation-output,< 1K
+Predicate,https://schema.org/workPerformed,1K - 10K
+Predicate,https://schema.org/workPerformed-input,< 1K
+Predicate,https://schema.org/workPerformed-output,< 1K
+Predicate,https://schema.org/workPresented,< 1K
+Predicate,https://schema.org/workPresented-input,< 1K
+Predicate,https://schema.org/workPresented-output,< 1K
+Predicate,https://schema.org/workTranslation,1K - 10K
+Predicate,https://schema.org/workTranslation-input,< 1K
+Predicate,https://schema.org/workTranslation-output,< 1K
+Predicate,https://schema.org/workload,< 1K
+Predicate,https://schema.org/workload-input,< 1K
+Predicate,https://schema.org/workload-output,< 1K
+Predicate,https://schema.org/worksFor,1M - 10M
+Predicate,https://schema.org/worksFor-input,< 1K
+Predicate,https://schema.org/worksFor-output,< 1K
+Predicate,https://schema.org/worstRating,1M - 10M
+Predicate,https://schema.org/worstRating-input,< 1K
+Predicate,https://schema.org/worstRating-output,< 1K
+Predicate,https://schema.org/xpath,10K - 100K
+Predicate,https://schema.org/xpath-input,< 1K
+Predicate,https://schema.org/xpath-output,< 1K
+Predicate,https://schema.org/yearBuilt,10K - 100K
+Predicate,https://schema.org/yearBuilt-input,< 1K
+Predicate,https://schema.org/yearBuilt-output,< 1K
+Predicate,https://schema.org/yearlyRevenue,< 1K
+Predicate,https://schema.org/yearlyRevenue-input,< 1K
+Predicate,https://schema.org/yearlyRevenue-output,< 1K
+Predicate,https://schema.org/yearsInOperation,< 1K
+Predicate,https://schema.org/yearsInOperation-input,< 1K
+Predicate,https://schema.org/yearsInOperation-output,< 1K
+Predicate,https://schema.org/yield,1K - 10K
+Predicate,https://schema.org/yield-input,< 1K
+Predicate,https://schema.org/yield-output,< 1K

--- a/data/public_stats/google/2026_05.json
+++ b/data/public_stats/google/2026_05.json
@@ -1,27727 +1,27727 @@
 [
   {
     "Class":"Itemtype",
-    "Name":"http:\/\/schema.org\/3DModel",
+    "Name":"https://schema.org/3DModel",
     "Domain Bucket":"< 1K"
   },
   {
     "Class":"Itemtype",
-    "Name":"http:\/\/schema.org\/AMRadioChannel",
+    "Name":"https://schema.org/AMRadioChannel",
     "Domain Bucket":"< 1K"
   },
   {
     "Class":"Itemtype",
-    "Name":"http:\/\/schema.org\/APIReference",
+    "Name":"https://schema.org/APIReference",
     "Domain Bucket":"< 1K"
   },
   {
     "Class":"Itemtype",
-    "Name":"http:\/\/schema.org\/AboutPage",
+    "Name":"https://schema.org/AboutPage",
     "Domain Bucket":"100K - 1M"
   },
   {
     "Class":"Itemtype",
-    "Name":"http:\/\/schema.org\/AcceptAction",
+    "Name":"https://schema.org/AcceptAction",
     "Domain Bucket":"< 1K"
   },
   {
     "Class":"Itemtype",
-    "Name":"http:\/\/schema.org\/Accommodation",
+    "Name":"https://schema.org/Accommodation",
     "Domain Bucket":"10K - 100K"
   },
   {
     "Class":"Itemtype",
-    "Name":"http:\/\/schema.org\/AccountingService",
+    "Name":"https://schema.org/AccountingService",
     "Domain Bucket":"10K - 100K"
   },
   {
     "Class":"Itemtype",
-    "Name":"http:\/\/schema.org\/AchieveAction",
+    "Name":"https://schema.org/AchieveAction",
     "Domain Bucket":"< 1K"
   },
   {
     "Class":"Itemtype",
-    "Name":"http:\/\/schema.org\/Action",
+    "Name":"https://schema.org/Action",
     "Domain Bucket":"10K - 100K"
   },
   {
     "Class":"Itemtype",
-    "Name":"http:\/\/schema.org\/ActionAccessSpecification",
+    "Name":"https://schema.org/ActionAccessSpecification",
     "Domain Bucket":"< 1K"
   },
   {
     "Class":"Itemtype",
-    "Name":"http:\/\/schema.org\/ActionStatusType",
+    "Name":"https://schema.org/ActionStatusType",
     "Domain Bucket":"< 1K"
   },
   {
     "Class":"Itemtype",
-    "Name":"http:\/\/schema.org\/ActivateAction",
+    "Name":"https://schema.org/ActivateAction",
     "Domain Bucket":"< 1K"
   },
   {
     "Class":"Itemtype",
-    "Name":"http:\/\/schema.org\/AddAction",
+    "Name":"https://schema.org/AddAction",
     "Domain Bucket":"< 1K"
   },
   {
     "Class":"Itemtype",
-    "Name":"http:\/\/schema.org\/AdministrativeArea",
+    "Name":"https://schema.org/AdministrativeArea",
     "Domain Bucket":"100K - 1M"
   },
   {
     "Class":"Itemtype",
-    "Name":"http:\/\/schema.org\/AdultEntertainment",
+    "Name":"https://schema.org/AdultEntertainment",
     "Domain Bucket":"1K - 10K"
   },
   {
     "Class":"Itemtype",
-    "Name":"http:\/\/schema.org\/AdultOrientedEnumeration",
+    "Name":"https://schema.org/AdultOrientedEnumeration",
     "Domain Bucket":"< 1K"
   },
   {
     "Class":"Itemtype",
-    "Name":"http:\/\/schema.org\/AdvertiserContentArticle",
+    "Name":"https://schema.org/AdvertiserContentArticle",
     "Domain Bucket":"1K - 10K"
   },
   {
     "Class":"Itemtype",
-    "Name":"http:\/\/schema.org\/AggregateOffer",
+    "Name":"https://schema.org/AggregateOffer",
     "Domain Bucket":"1M - 10M"
   },
   {
     "Class":"Itemtype",
-    "Name":"http:\/\/schema.org\/AggregateRating",
+    "Name":"https://schema.org/AggregateRating",
     "Domain Bucket":"1M - 10M"
   },
   {
     "Class":"Itemtype",
-    "Name":"http:\/\/schema.org\/AgreeAction",
+    "Name":"https://schema.org/AgreeAction",
     "Domain Bucket":"< 1K"
   },
   {
     "Class":"Itemtype",
-    "Name":"http:\/\/schema.org\/Airline",
+    "Name":"https://schema.org/Airline",
     "Domain Bucket":"1K - 10K"
   },
   {
     "Class":"Itemtype",
-    "Name":"http:\/\/schema.org\/Airport",
+    "Name":"https://schema.org/Airport",
     "Domain Bucket":"1K - 10K"
   },
   {
     "Class":"Itemtype",
-    "Name":"http:\/\/schema.org\/AlignmentObject",
+    "Name":"https://schema.org/AlignmentObject",
     "Domain Bucket":"1K - 10K"
   },
   {
     "Class":"Itemtype",
-    "Name":"http:\/\/schema.org\/AllocateAction",
+    "Name":"https://schema.org/AllocateAction",
     "Domain Bucket":"< 1K"
   },
   {
     "Class":"Itemtype",
-    "Name":"http:\/\/schema.org\/AmpStory",
+    "Name":"https://schema.org/AmpStory",
     "Domain Bucket":"< 1K"
   },
   {
     "Class":"Itemtype",
-    "Name":"http:\/\/schema.org\/AmusementPark",
+    "Name":"https://schema.org/AmusementPark",
     "Domain Bucket":"1K - 10K"
   },
   {
     "Class":"Itemtype",
-    "Name":"http:\/\/schema.org\/AnalysisNewsArticle",
+    "Name":"https://schema.org/AnalysisNewsArticle",
     "Domain Bucket":"1K - 10K"
   },
   {
     "Class":"Itemtype",
-    "Name":"http:\/\/schema.org\/AnatomicalStructure",
+    "Name":"https://schema.org/AnatomicalStructure",
     "Domain Bucket":"1K - 10K"
   },
   {
     "Class":"Itemtype",
-    "Name":"http:\/\/schema.org\/AnatomicalSystem",
+    "Name":"https://schema.org/AnatomicalSystem",
     "Domain Bucket":"< 1K"
   },
   {
     "Class":"Itemtype",
-    "Name":"http:\/\/schema.org\/AnimalShelter",
+    "Name":"https://schema.org/AnimalShelter",
     "Domain Bucket":"1K - 10K"
   },
   {
     "Class":"Itemtype",
-    "Name":"http:\/\/schema.org\/Answer",
+    "Name":"https://schema.org/Answer",
     "Domain Bucket":"1M - 10M"
   },
   {
     "Class":"Itemtype",
-    "Name":"http:\/\/schema.org\/Apartment",
+    "Name":"https://schema.org/Apartment",
     "Domain Bucket":"10K - 100K"
   },
   {
     "Class":"Itemtype",
-    "Name":"http:\/\/schema.org\/ApartmentComplex",
+    "Name":"https://schema.org/ApartmentComplex",
     "Domain Bucket":"10K - 100K"
   },
   {
     "Class":"Itemtype",
-    "Name":"http:\/\/schema.org\/AppendAction",
+    "Name":"https://schema.org/AppendAction",
     "Domain Bucket":"< 1K"
   },
   {
     "Class":"Itemtype",
-    "Name":"http:\/\/schema.org\/ApplyAction",
+    "Name":"https://schema.org/ApplyAction",
     "Domain Bucket":"1K - 10K"
   },
   {
     "Class":"Itemtype",
-    "Name":"http:\/\/schema.org\/ApprovedIndication",
+    "Name":"https://schema.org/ApprovedIndication",
     "Domain Bucket":"< 1K"
   },
   {
     "Class":"Itemtype",
-    "Name":"http:\/\/schema.org\/Aquarium",
+    "Name":"https://schema.org/Aquarium",
     "Domain Bucket":"< 1K"
   },
   {
     "Class":"Itemtype",
-    "Name":"http:\/\/schema.org\/ArchiveComponent",
+    "Name":"https://schema.org/ArchiveComponent",
     "Domain Bucket":"< 1K"
   },
   {
     "Class":"Itemtype",
-    "Name":"http:\/\/schema.org\/ArchiveOrganization",
+    "Name":"https://schema.org/ArchiveOrganization",
     "Domain Bucket":"1K - 10K"
   },
   {
     "Class":"Itemtype",
-    "Name":"http:\/\/schema.org\/ArriveAction",
+    "Name":"https://schema.org/ArriveAction",
     "Domain Bucket":"< 1K"
   },
   {
     "Class":"Itemtype",
-    "Name":"http:\/\/schema.org\/ArtGallery",
+    "Name":"https://schema.org/ArtGallery",
     "Domain Bucket":"1K - 10K"
   },
   {
     "Class":"Itemtype",
-    "Name":"http:\/\/schema.org\/Artery",
+    "Name":"https://schema.org/Artery",
     "Domain Bucket":"< 1K"
   },
   {
     "Class":"Itemtype",
-    "Name":"http:\/\/schema.org\/Article",
+    "Name":"https://schema.org/Article",
     "Domain Bucket":"1M - 10M"
   },
   {
     "Class":"Itemtype",
-    "Name":"http:\/\/schema.org\/AskAction",
+    "Name":"https://schema.org/AskAction",
     "Domain Bucket":"< 1K"
   },
   {
     "Class":"Itemtype",
-    "Name":"http:\/\/schema.org\/AskPublicNewsArticle",
+    "Name":"https://schema.org/AskPublicNewsArticle",
     "Domain Bucket":"< 1K"
   },
   {
     "Class":"Itemtype",
-    "Name":"http:\/\/schema.org\/AssessAction",
+    "Name":"https://schema.org/AssessAction",
     "Domain Bucket":"< 1K"
   },
   {
     "Class":"Itemtype",
-    "Name":"http:\/\/schema.org\/AssignAction",
+    "Name":"https://schema.org/AssignAction",
     "Domain Bucket":"< 1K"
   },
   {
     "Class":"Itemtype",
-    "Name":"http:\/\/schema.org\/Atlas",
+    "Name":"https://schema.org/Atlas",
     "Domain Bucket":"< 1K"
   },
   {
     "Class":"Itemtype",
-    "Name":"http:\/\/schema.org\/Attorney",
+    "Name":"https://schema.org/Attorney",
     "Domain Bucket":"10K - 100K"
   },
   {
     "Class":"Itemtype",
-    "Name":"http:\/\/schema.org\/Audience",
+    "Name":"https://schema.org/Audience",
     "Domain Bucket":"100K - 1M"
   },
   {
     "Class":"Itemtype",
-    "Name":"http:\/\/schema.org\/AudioObject",
+    "Name":"https://schema.org/AudioObject",
     "Domain Bucket":"10K - 100K"
   },
   {
     "Class":"Itemtype",
-    "Name":"http:\/\/schema.org\/AudioObjectSnapshot",
+    "Name":"https://schema.org/AudioObjectSnapshot",
     "Domain Bucket":"< 1K"
   },
   {
     "Class":"Itemtype",
-    "Name":"http:\/\/schema.org\/Audiobook",
+    "Name":"https://schema.org/Audiobook",
     "Domain Bucket":"< 1K"
   },
   {
     "Class":"Itemtype",
-    "Name":"http:\/\/schema.org\/AuthenticateAction",
+    "Name":"https://schema.org/AuthenticateAction",
     "Domain Bucket":"< 1K"
   },
   {
     "Class":"Itemtype",
-    "Name":"http:\/\/schema.org\/AuthorizeAction",
+    "Name":"https://schema.org/AuthorizeAction",
     "Domain Bucket":"< 1K"
   },
   {
     "Class":"Itemtype",
-    "Name":"http:\/\/schema.org\/AutoBodyShop",
+    "Name":"https://schema.org/AutoBodyShop",
     "Domain Bucket":"1K - 10K"
   },
   {
     "Class":"Itemtype",
-    "Name":"http:\/\/schema.org\/AutoDealer",
+    "Name":"https://schema.org/AutoDealer",
     "Domain Bucket":"10K - 100K"
   },
   {
     "Class":"Itemtype",
-    "Name":"http:\/\/schema.org\/AutoPartsStore",
+    "Name":"https://schema.org/AutoPartsStore",
     "Domain Bucket":"10K - 100K"
   },
   {
     "Class":"Itemtype",
-    "Name":"http:\/\/schema.org\/AutoRental",
+    "Name":"https://schema.org/AutoRental",
     "Domain Bucket":"1K - 10K"
   },
   {
     "Class":"Itemtype",
-    "Name":"http:\/\/schema.org\/AutoRepair",
+    "Name":"https://schema.org/AutoRepair",
     "Domain Bucket":"10K - 100K"
   },
   {
     "Class":"Itemtype",
-    "Name":"http:\/\/schema.org\/AutoWash",
+    "Name":"https://schema.org/AutoWash",
     "Domain Bucket":"1K - 10K"
   },
   {
     "Class":"Itemtype",
-    "Name":"http:\/\/schema.org\/AutomatedTeller",
+    "Name":"https://schema.org/AutomatedTeller",
     "Domain Bucket":"< 1K"
   },
   {
     "Class":"Itemtype",
-    "Name":"http:\/\/schema.org\/AutomotiveBusiness",
+    "Name":"https://schema.org/AutomotiveBusiness",
     "Domain Bucket":"10K - 100K"
   },
   {
     "Class":"Itemtype",
-    "Name":"http:\/\/schema.org\/BackgroundNewsArticle",
+    "Name":"https://schema.org/BackgroundNewsArticle",
     "Domain Bucket":"< 1K"
   },
   {
     "Class":"Itemtype",
-    "Name":"http:\/\/schema.org\/Bakery",
+    "Name":"https://schema.org/Bakery",
     "Domain Bucket":"1K - 10K"
   },
   {
     "Class":"Itemtype",
-    "Name":"http:\/\/schema.org\/BankAccount",
+    "Name":"https://schema.org/BankAccount",
     "Domain Bucket":"< 1K"
   },
   {
     "Class":"Itemtype",
-    "Name":"http:\/\/schema.org\/BankOrCreditUnion",
+    "Name":"https://schema.org/BankOrCreditUnion",
     "Domain Bucket":"1K - 10K"
   },
   {
     "Class":"Itemtype",
-    "Name":"http:\/\/schema.org\/BarOrPub",
+    "Name":"https://schema.org/BarOrPub",
     "Domain Bucket":"1K - 10K"
   },
   {
     "Class":"Itemtype",
-    "Name":"http:\/\/schema.org\/Barcode",
+    "Name":"https://schema.org/Barcode",
     "Domain Bucket":"< 1K"
   },
   {
     "Class":"Itemtype",
-    "Name":"http:\/\/schema.org\/Beach",
+    "Name":"https://schema.org/Beach",
     "Domain Bucket":"1K - 10K"
   },
   {
     "Class":"Itemtype",
-    "Name":"http:\/\/schema.org\/BeautySalon",
+    "Name":"https://schema.org/BeautySalon",
     "Domain Bucket":"10K - 100K"
   },
   {
     "Class":"Itemtype",
-    "Name":"http:\/\/schema.org\/BedAndBreakfast",
+    "Name":"https://schema.org/BedAndBreakfast",
     "Domain Bucket":"1K - 10K"
   },
   {
     "Class":"Itemtype",
-    "Name":"http:\/\/schema.org\/BedDetails",
+    "Name":"https://schema.org/BedDetails",
     "Domain Bucket":"10K - 100K"
   },
   {
     "Class":"Itemtype",
-    "Name":"http:\/\/schema.org\/BedType",
+    "Name":"https://schema.org/BedType",
     "Domain Bucket":"< 1K"
   },
   {
     "Class":"Itemtype",
-    "Name":"http:\/\/schema.org\/BefriendAction",
+    "Name":"https://schema.org/BefriendAction",
     "Domain Bucket":"< 1K"
   },
   {
     "Class":"Itemtype",
-    "Name":"http:\/\/schema.org\/BikeStore",
+    "Name":"https://schema.org/BikeStore",
     "Domain Bucket":"1K - 10K"
   },
   {
     "Class":"Itemtype",
-    "Name":"http:\/\/schema.org\/BioChemEntity",
+    "Name":"https://schema.org/BioChemEntity",
     "Domain Bucket":"< 1K"
   },
   {
     "Class":"Itemtype",
-    "Name":"http:\/\/schema.org\/Blog",
+    "Name":"https://schema.org/Blog",
     "Domain Bucket":"1M - 10M"
   },
   {
     "Class":"Itemtype",
-    "Name":"http:\/\/schema.org\/BlogPosting",
+    "Name":"https://schema.org/BlogPosting",
     "Domain Bucket":"1M - 10M"
   },
   {
     "Class":"Itemtype",
-    "Name":"http:\/\/schema.org\/BloodTest",
+    "Name":"https://schema.org/BloodTest",
     "Domain Bucket":"< 1K"
   },
   {
     "Class":"Itemtype",
-    "Name":"http:\/\/schema.org\/BoardingPolicyType",
+    "Name":"https://schema.org/BoardingPolicyType",
     "Domain Bucket":"< 1K"
   },
   {
     "Class":"Itemtype",
-    "Name":"http:\/\/schema.org\/BoatReservation",
+    "Name":"https://schema.org/BoatReservation",
     "Domain Bucket":"< 1K"
   },
   {
     "Class":"Itemtype",
-    "Name":"http:\/\/schema.org\/BoatTerminal",
+    "Name":"https://schema.org/BoatTerminal",
     "Domain Bucket":"< 1K"
   },
   {
     "Class":"Itemtype",
-    "Name":"http:\/\/schema.org\/BoatTrip",
+    "Name":"https://schema.org/BoatTrip",
     "Domain Bucket":"< 1K"
   },
   {
     "Class":"Itemtype",
-    "Name":"http:\/\/schema.org\/BodyMeasurementTypeEnumeration",
+    "Name":"https://schema.org/BodyMeasurementTypeEnumeration",
     "Domain Bucket":"< 1K"
   },
   {
     "Class":"Itemtype",
-    "Name":"http:\/\/schema.org\/BodyOfWater",
+    "Name":"https://schema.org/BodyOfWater",
     "Domain Bucket":"< 1K"
   },
   {
     "Class":"Itemtype",
-    "Name":"http:\/\/schema.org\/Bone",
+    "Name":"https://schema.org/Bone",
     "Domain Bucket":"< 1K"
   },
   {
     "Class":"Itemtype",
-    "Name":"http:\/\/schema.org\/Book",
+    "Name":"https://schema.org/Book",
     "Domain Bucket":"10K - 100K"
   },
   {
     "Class":"Itemtype",
-    "Name":"http:\/\/schema.org\/BookFormatType",
+    "Name":"https://schema.org/BookFormatType",
     "Domain Bucket":"< 1K"
   },
   {
     "Class":"Itemtype",
-    "Name":"http:\/\/schema.org\/BookSeries",
+    "Name":"https://schema.org/BookSeries",
     "Domain Bucket":"1K - 10K"
   },
   {
     "Class":"Itemtype",
-    "Name":"http:\/\/schema.org\/BookStore",
+    "Name":"https://schema.org/BookStore",
     "Domain Bucket":"1K - 10K"
   },
   {
     "Class":"Itemtype",
-    "Name":"http:\/\/schema.org\/BookmarkAction",
+    "Name":"https://schema.org/BookmarkAction",
     "Domain Bucket":"< 1K"
   },
   {
     "Class":"Itemtype",
-    "Name":"http:\/\/schema.org\/Boolean",
+    "Name":"https://schema.org/Boolean",
     "Domain Bucket":"< 1K"
   },
   {
     "Class":"Itemtype",
-    "Name":"http:\/\/schema.org\/BorrowAction",
+    "Name":"https://schema.org/BorrowAction",
     "Domain Bucket":"< 1K"
   },
   {
     "Class":"Itemtype",
-    "Name":"http:\/\/schema.org\/BowlingAlley",
+    "Name":"https://schema.org/BowlingAlley",
     "Domain Bucket":"< 1K"
   },
   {
     "Class":"Itemtype",
-    "Name":"http:\/\/schema.org\/BrainStructure",
+    "Name":"https://schema.org/BrainStructure",
     "Domain Bucket":"< 1K"
   },
   {
     "Class":"Itemtype",
-    "Name":"http:\/\/schema.org\/Brand",
+    "Name":"https://schema.org/Brand",
     "Domain Bucket":"1M - 10M"
   },
   {
     "Class":"Itemtype",
-    "Name":"http:\/\/schema.org\/BreadcrumbList",
+    "Name":"https://schema.org/BreadcrumbList",
     "Domain Bucket":"10M+"
   },
   {
     "Class":"Itemtype",
-    "Name":"http:\/\/schema.org\/Brewery",
+    "Name":"https://schema.org/Brewery",
     "Domain Bucket":"1K - 10K"
   },
   {
     "Class":"Itemtype",
-    "Name":"http:\/\/schema.org\/Bridge",
+    "Name":"https://schema.org/Bridge",
     "Domain Bucket":"< 1K"
   },
   {
     "Class":"Itemtype",
-    "Name":"http:\/\/schema.org\/BroadcastChannel",
+    "Name":"https://schema.org/BroadcastChannel",
     "Domain Bucket":"< 1K"
   },
   {
     "Class":"Itemtype",
-    "Name":"http:\/\/schema.org\/BroadcastEvent",
+    "Name":"https://schema.org/BroadcastEvent",
     "Domain Bucket":"10K - 100K"
   },
   {
     "Class":"Itemtype",
-    "Name":"http:\/\/schema.org\/BroadcastFrequencySpecification",
+    "Name":"https://schema.org/BroadcastFrequencySpecification",
     "Domain Bucket":"< 1K"
   },
   {
     "Class":"Itemtype",
-    "Name":"http:\/\/schema.org\/BroadcastService",
+    "Name":"https://schema.org/BroadcastService",
     "Domain Bucket":"1K - 10K"
   },
   {
     "Class":"Itemtype",
-    "Name":"http:\/\/schema.org\/BrokerageAccount",
+    "Name":"https://schema.org/BrokerageAccount",
     "Domain Bucket":"< 1K"
   },
   {
     "Class":"Itemtype",
-    "Name":"http:\/\/schema.org\/BuddhistTemple",
+    "Name":"https://schema.org/BuddhistTemple",
     "Domain Bucket":"< 1K"
   },
   {
     "Class":"Itemtype",
-    "Name":"http:\/\/schema.org\/BusOrCoach",
+    "Name":"https://schema.org/BusOrCoach",
     "Domain Bucket":"< 1K"
   },
   {
     "Class":"Itemtype",
-    "Name":"http:\/\/schema.org\/BusReservation",
+    "Name":"https://schema.org/BusReservation",
     "Domain Bucket":"< 1K"
   },
   {
     "Class":"Itemtype",
-    "Name":"http:\/\/schema.org\/BusStation",
+    "Name":"https://schema.org/BusStation",
     "Domain Bucket":"< 1K"
   },
   {
     "Class":"Itemtype",
-    "Name":"http:\/\/schema.org\/BusStop",
+    "Name":"https://schema.org/BusStop",
     "Domain Bucket":"< 1K"
   },
   {
     "Class":"Itemtype",
-    "Name":"http:\/\/schema.org\/BusTrip",
+    "Name":"https://schema.org/BusTrip",
     "Domain Bucket":"< 1K"
   },
   {
     "Class":"Itemtype",
-    "Name":"http:\/\/schema.org\/BusinessAudience",
+    "Name":"https://schema.org/BusinessAudience",
     "Domain Bucket":"10K - 100K"
   },
   {
     "Class":"Itemtype",
-    "Name":"http:\/\/schema.org\/BusinessEntityType",
+    "Name":"https://schema.org/BusinessEntityType",
     "Domain Bucket":"< 1K"
   },
   {
     "Class":"Itemtype",
-    "Name":"http:\/\/schema.org\/BusinessEvent",
+    "Name":"https://schema.org/BusinessEvent",
     "Domain Bucket":"1K - 10K"
   },
   {
     "Class":"Itemtype",
-    "Name":"http:\/\/schema.org\/BusinessFunction",
+    "Name":"https://schema.org/BusinessFunction",
     "Domain Bucket":"< 1K"
   },
   {
     "Class":"Itemtype",
-    "Name":"http:\/\/schema.org\/BuyAction",
+    "Name":"https://schema.org/BuyAction",
     "Domain Bucket":"10K - 100K"
   },
   {
     "Class":"Itemtype",
-    "Name":"http:\/\/schema.org\/CDCPMDRecord",
+    "Name":"https://schema.org/CDCPMDRecord",
     "Domain Bucket":"< 1K"
   },
   {
     "Class":"Itemtype",
-    "Name":"http:\/\/schema.org\/CableOrSatelliteService",
+    "Name":"https://schema.org/CableOrSatelliteService",
     "Domain Bucket":"< 1K"
   },
   {
     "Class":"Itemtype",
-    "Name":"http:\/\/schema.org\/CafeOrCoffeeShop",
+    "Name":"https://schema.org/CafeOrCoffeeShop",
     "Domain Bucket":"1K - 10K"
   },
   {
     "Class":"Itemtype",
-    "Name":"http:\/\/schema.org\/Campground",
+    "Name":"https://schema.org/Campground",
     "Domain Bucket":"1K - 10K"
   },
   {
     "Class":"Itemtype",
-    "Name":"http:\/\/schema.org\/CampingPitch",
+    "Name":"https://schema.org/CampingPitch",
     "Domain Bucket":"< 1K"
   },
   {
     "Class":"Itemtype",
-    "Name":"http:\/\/schema.org\/Canal",
+    "Name":"https://schema.org/Canal",
     "Domain Bucket":"< 1K"
   },
   {
     "Class":"Itemtype",
-    "Name":"http:\/\/schema.org\/CancelAction",
+    "Name":"https://schema.org/CancelAction",
     "Domain Bucket":"< 1K"
   },
   {
     "Class":"Itemtype",
-    "Name":"http:\/\/schema.org\/Car",
+    "Name":"https://schema.org/Car",
     "Domain Bucket":"10K - 100K"
   },
   {
     "Class":"Itemtype",
-    "Name":"http:\/\/schema.org\/CarUsageType",
+    "Name":"https://schema.org/CarUsageType",
     "Domain Bucket":"< 1K"
   },
   {
     "Class":"Itemtype",
-    "Name":"http:\/\/schema.org\/Casino",
+    "Name":"https://schema.org/Casino",
     "Domain Bucket":"10K - 100K"
   },
   {
     "Class":"Itemtype",
-    "Name":"http:\/\/schema.org\/CategoryCode",
+    "Name":"https://schema.org/CategoryCode",
     "Domain Bucket":"1K - 10K"
   },
   {
     "Class":"Itemtype",
-    "Name":"http:\/\/schema.org\/CategoryCodeSet",
+    "Name":"https://schema.org/CategoryCodeSet",
     "Domain Bucket":"< 1K"
   },
   {
     "Class":"Itemtype",
-    "Name":"http:\/\/schema.org\/CatholicChurch",
+    "Name":"https://schema.org/CatholicChurch",
     "Domain Bucket":"< 1K"
   },
   {
     "Class":"Itemtype",
-    "Name":"http:\/\/schema.org\/Cemetery",
+    "Name":"https://schema.org/Cemetery",
     "Domain Bucket":"< 1K"
   },
   {
     "Class":"Itemtype",
-    "Name":"http:\/\/schema.org\/Certification",
+    "Name":"https://schema.org/Certification",
     "Domain Bucket":"1K - 10K"
   },
   {
     "Class":"Itemtype",
-    "Name":"http:\/\/schema.org\/CertificationStatusEnumeration",
+    "Name":"https://schema.org/CertificationStatusEnumeration",
     "Domain Bucket":"< 1K"
   },
   {
     "Class":"Itemtype",
-    "Name":"http:\/\/schema.org\/Chapter",
+    "Name":"https://schema.org/Chapter",
     "Domain Bucket":"1K - 10K"
   },
   {
     "Class":"Itemtype",
-    "Name":"http:\/\/schema.org\/CheckAction",
+    "Name":"https://schema.org/CheckAction",
     "Domain Bucket":"< 1K"
   },
   {
     "Class":"Itemtype",
-    "Name":"http:\/\/schema.org\/CheckInAction",
+    "Name":"https://schema.org/CheckInAction",
     "Domain Bucket":"< 1K"
   },
   {
     "Class":"Itemtype",
-    "Name":"http:\/\/schema.org\/CheckOutAction",
+    "Name":"https://schema.org/CheckOutAction",
     "Domain Bucket":"< 1K"
   },
   {
     "Class":"Itemtype",
-    "Name":"http:\/\/schema.org\/CheckoutPage",
+    "Name":"https://schema.org/CheckoutPage",
     "Domain Bucket":"1K - 10K"
   },
   {
     "Class":"Itemtype",
-    "Name":"http:\/\/schema.org\/ChemicalSubstance",
+    "Name":"https://schema.org/ChemicalSubstance",
     "Domain Bucket":"< 1K"
   },
   {
     "Class":"Itemtype",
-    "Name":"http:\/\/schema.org\/ChildCare",
+    "Name":"https://schema.org/ChildCare",
     "Domain Bucket":"1K - 10K"
   },
   {
     "Class":"Itemtype",
-    "Name":"http:\/\/schema.org\/ChildrensEvent",
+    "Name":"https://schema.org/ChildrensEvent",
     "Domain Bucket":"< 1K"
   },
   {
     "Class":"Itemtype",
-    "Name":"http:\/\/schema.org\/ChooseAction",
+    "Name":"https://schema.org/ChooseAction",
     "Domain Bucket":"1K - 10K"
   },
   {
     "Class":"Itemtype",
-    "Name":"http:\/\/schema.org\/Church",
+    "Name":"https://schema.org/Church",
     "Domain Bucket":"1K - 10K"
   },
   {
     "Class":"Itemtype",
-    "Name":"http:\/\/schema.org\/City",
+    "Name":"https://schema.org/City",
     "Domain Bucket":"100K - 1M"
   },
   {
     "Class":"Itemtype",
-    "Name":"http:\/\/schema.org\/CityHall",
+    "Name":"https://schema.org/CityHall",
     "Domain Bucket":"< 1K"
   },
   {
     "Class":"Itemtype",
-    "Name":"http:\/\/schema.org\/CivicStructure",
+    "Name":"https://schema.org/CivicStructure",
     "Domain Bucket":"1K - 10K"
   },
   {
     "Class":"Itemtype",
-    "Name":"http:\/\/schema.org\/Claim",
+    "Name":"https://schema.org/Claim",
     "Domain Bucket":"1K - 10K"
   },
   {
     "Class":"Itemtype",
-    "Name":"http:\/\/schema.org\/ClaimReview",
+    "Name":"https://schema.org/ClaimReview",
     "Domain Bucket":"1K - 10K"
   },
   {
     "Class":"Itemtype",
-    "Name":"http:\/\/schema.org\/Class",
+    "Name":"https://schema.org/Class",
     "Domain Bucket":"< 1K"
   },
   {
     "Class":"Itemtype",
-    "Name":"http:\/\/schema.org\/Clip",
+    "Name":"https://schema.org/Clip",
     "Domain Bucket":"10K - 100K"
   },
   {
     "Class":"Itemtype",
-    "Name":"http:\/\/schema.org\/ClothingStore",
+    "Name":"https://schema.org/ClothingStore",
     "Domain Bucket":"10K - 100K"
   },
   {
     "Class":"Itemtype",
-    "Name":"http:\/\/schema.org\/Code",
+    "Name":"https://schema.org/Code",
     "Domain Bucket":"< 1K"
   },
   {
     "Class":"Itemtype",
-    "Name":"http:\/\/schema.org\/Collection",
+    "Name":"https://schema.org/Collection",
     "Domain Bucket":"10K - 100K"
   },
   {
     "Class":"Itemtype",
-    "Name":"http:\/\/schema.org\/CollectionPage",
+    "Name":"https://schema.org/CollectionPage",
     "Domain Bucket":"1M - 10M"
   },
   {
     "Class":"Itemtype",
-    "Name":"http:\/\/schema.org\/CollegeOrUniversity",
+    "Name":"https://schema.org/CollegeOrUniversity",
     "Domain Bucket":"10K - 100K"
   },
   {
     "Class":"Itemtype",
-    "Name":"http:\/\/schema.org\/ComedyClub",
+    "Name":"https://schema.org/ComedyClub",
     "Domain Bucket":"< 1K"
   },
   {
     "Class":"Itemtype",
-    "Name":"http:\/\/schema.org\/ComedyEvent",
+    "Name":"https://schema.org/ComedyEvent",
     "Domain Bucket":"< 1K"
   },
   {
     "Class":"Itemtype",
-    "Name":"http:\/\/schema.org\/ComicCoverArt",
+    "Name":"https://schema.org/ComicCoverArt",
     "Domain Bucket":"< 1K"
   },
   {
     "Class":"Itemtype",
-    "Name":"http:\/\/schema.org\/ComicIssue",
+    "Name":"https://schema.org/ComicIssue",
     "Domain Bucket":"< 1K"
   },
   {
     "Class":"Itemtype",
-    "Name":"http:\/\/schema.org\/ComicSeries",
+    "Name":"https://schema.org/ComicSeries",
     "Domain Bucket":"1K - 10K"
   },
   {
     "Class":"Itemtype",
-    "Name":"http:\/\/schema.org\/ComicStory",
+    "Name":"https://schema.org/ComicStory",
     "Domain Bucket":"< 1K"
   },
   {
     "Class":"Itemtype",
-    "Name":"http:\/\/schema.org\/Comment",
+    "Name":"https://schema.org/Comment",
     "Domain Bucket":"100K - 1M"
   },
   {
     "Class":"Itemtype",
-    "Name":"http:\/\/schema.org\/CommentAction",
+    "Name":"https://schema.org/CommentAction",
     "Domain Bucket":"1M - 10M"
   },
   {
     "Class":"Itemtype",
-    "Name":"http:\/\/schema.org\/CommunicateAction",
+    "Name":"https://schema.org/CommunicateAction",
     "Domain Bucket":"10K - 100K"
   },
   {
     "Class":"Itemtype",
-    "Name":"http:\/\/schema.org\/CommunityHealth",
+    "Name":"https://schema.org/CommunityHealth",
     "Domain Bucket":"1K - 10K"
   },
   {
     "Class":"Itemtype",
-    "Name":"http:\/\/schema.org\/CompleteDataFeed",
+    "Name":"https://schema.org/CompleteDataFeed",
     "Domain Bucket":"< 1K"
   },
   {
     "Class":"Itemtype",
-    "Name":"http:\/\/schema.org\/CompoundPriceSpecification",
+    "Name":"https://schema.org/CompoundPriceSpecification",
     "Domain Bucket":"1K - 10K"
   },
   {
     "Class":"Itemtype",
-    "Name":"http:\/\/schema.org\/ComputerLanguage",
+    "Name":"https://schema.org/ComputerLanguage",
     "Domain Bucket":"< 1K"
   },
   {
     "Class":"Itemtype",
-    "Name":"http:\/\/schema.org\/ComputerStore",
+    "Name":"https://schema.org/ComputerStore",
     "Domain Bucket":"1K - 10K"
   },
   {
     "Class":"Itemtype",
-    "Name":"http:\/\/schema.org\/ConferenceEvent",
+    "Name":"https://schema.org/ConferenceEvent",
     "Domain Bucket":"< 1K"
   },
   {
     "Class":"Itemtype",
-    "Name":"http:\/\/schema.org\/ConfirmAction",
+    "Name":"https://schema.org/ConfirmAction",
     "Domain Bucket":"< 1K"
   },
   {
     "Class":"Itemtype",
-    "Name":"http:\/\/schema.org\/Consortium",
+    "Name":"https://schema.org/Consortium",
     "Domain Bucket":"< 1K"
   },
   {
     "Class":"Itemtype",
-    "Name":"http:\/\/schema.org\/ConstraintNode",
+    "Name":"https://schema.org/ConstraintNode",
     "Domain Bucket":"< 1K"
   },
   {
     "Class":"Itemtype",
-    "Name":"http:\/\/schema.org\/ConsumeAction",
+    "Name":"https://schema.org/ConsumeAction",
     "Domain Bucket":"< 1K"
   },
   {
     "Class":"Itemtype",
-    "Name":"http:\/\/schema.org\/ContactPage",
+    "Name":"https://schema.org/ContactPage",
     "Domain Bucket":"100K - 1M"
   },
   {
     "Class":"Itemtype",
-    "Name":"http:\/\/schema.org\/ContactPoint",
+    "Name":"https://schema.org/ContactPoint",
     "Domain Bucket":"1M - 10M"
   },
   {
     "Class":"Itemtype",
-    "Name":"http:\/\/schema.org\/ContactPointOption",
+    "Name":"https://schema.org/ContactPointOption",
     "Domain Bucket":"< 1K"
   },
   {
     "Class":"Itemtype",
-    "Name":"http:\/\/schema.org\/Continent",
+    "Name":"https://schema.org/Continent",
     "Domain Bucket":"1K - 10K"
   },
   {
     "Class":"Itemtype",
-    "Name":"http:\/\/schema.org\/ControlAction",
+    "Name":"https://schema.org/ControlAction",
     "Domain Bucket":"< 1K"
   },
   {
     "Class":"Itemtype",
-    "Name":"http:\/\/schema.org\/ConvenienceStore",
+    "Name":"https://schema.org/ConvenienceStore",
     "Domain Bucket":"< 1K"
   },
   {
     "Class":"Itemtype",
-    "Name":"http:\/\/schema.org\/Conversation",
+    "Name":"https://schema.org/Conversation",
     "Domain Bucket":"< 1K"
   },
   {
     "Class":"Itemtype",
-    "Name":"http:\/\/schema.org\/CookAction",
+    "Name":"https://schema.org/CookAction",
     "Domain Bucket":"< 1K"
   },
   {
     "Class":"Itemtype",
-    "Name":"http:\/\/schema.org\/Cooperative",
+    "Name":"https://schema.org/Cooperative",
     "Domain Bucket":"< 1K"
   },
   {
     "Class":"Itemtype",
-    "Name":"http:\/\/schema.org\/Corporation",
+    "Name":"https://schema.org/Corporation",
     "Domain Bucket":"100K - 1M"
   },
   {
     "Class":"Itemtype",
-    "Name":"http:\/\/schema.org\/CorrectionComment",
+    "Name":"https://schema.org/CorrectionComment",
     "Domain Bucket":"< 1K"
   },
   {
     "Class":"Itemtype",
-    "Name":"http:\/\/schema.org\/Country",
+    "Name":"https://schema.org/Country",
     "Domain Bucket":"1M - 10M"
   },
   {
     "Class":"Itemtype",
-    "Name":"http:\/\/schema.org\/Course",
+    "Name":"https://schema.org/Course",
     "Domain Bucket":"10K - 100K"
   },
   {
     "Class":"Itemtype",
-    "Name":"http:\/\/schema.org\/CourseInstance",
+    "Name":"https://schema.org/CourseInstance",
     "Domain Bucket":"10K - 100K"
   },
   {
     "Class":"Itemtype",
-    "Name":"http:\/\/schema.org\/Courthouse",
+    "Name":"https://schema.org/Courthouse",
     "Domain Bucket":"< 1K"
   },
   {
     "Class":"Itemtype",
-    "Name":"http:\/\/schema.org\/CoverArt",
+    "Name":"https://schema.org/CoverArt",
     "Domain Bucket":"< 1K"
   },
   {
     "Class":"Itemtype",
-    "Name":"http:\/\/schema.org\/CovidTestingFacility",
+    "Name":"https://schema.org/CovidTestingFacility",
     "Domain Bucket":"< 1K"
   },
   {
     "Class":"Itemtype",
-    "Name":"http:\/\/schema.org\/CreateAction",
+    "Name":"https://schema.org/CreateAction",
     "Domain Bucket":"1K - 10K"
   },
   {
     "Class":"Itemtype",
-    "Name":"http:\/\/schema.org\/CreativeWork",
+    "Name":"https://schema.org/CreativeWork",
     "Domain Bucket":"1M - 10M"
   },
   {
     "Class":"Itemtype",
-    "Name":"http:\/\/schema.org\/CreativeWorkSeason",
+    "Name":"https://schema.org/CreativeWorkSeason",
     "Domain Bucket":"1K - 10K"
   },
   {
     "Class":"Itemtype",
-    "Name":"http:\/\/schema.org\/CreativeWorkSeries",
+    "Name":"https://schema.org/CreativeWorkSeries",
     "Domain Bucket":"10K - 100K"
   },
   {
     "Class":"Itemtype",
-    "Name":"http:\/\/schema.org\/Credential",
+    "Name":"https://schema.org/Credential",
     "Domain Bucket":"10K - 100K"
   },
   {
     "Class":"Itemtype",
-    "Name":"http:\/\/schema.org\/CreditCard",
+    "Name":"https://schema.org/CreditCard",
     "Domain Bucket":"1K - 10K"
   },
   {
     "Class":"Itemtype",
-    "Name":"http:\/\/schema.org\/Crematorium",
+    "Name":"https://schema.org/Crematorium",
     "Domain Bucket":"< 1K"
   },
   {
     "Class":"Itemtype",
-    "Name":"http:\/\/schema.org\/CriticReview",
+    "Name":"https://schema.org/CriticReview",
     "Domain Bucket":"< 1K"
   },
   {
     "Class":"Itemtype",
-    "Name":"http:\/\/schema.org\/CssSelectorType",
+    "Name":"https://schema.org/CssSelectorType",
     "Domain Bucket":"< 1K"
   },
   {
     "Class":"Itemtype",
-    "Name":"http:\/\/schema.org\/CurrencyConversionService",
+    "Name":"https://schema.org/CurrencyConversionService",
     "Domain Bucket":"< 1K"
   },
   {
     "Class":"Itemtype",
-    "Name":"http:\/\/schema.org\/DDxElement",
+    "Name":"https://schema.org/DDxElement",
     "Domain Bucket":"< 1K"
   },
   {
     "Class":"Itemtype",
-    "Name":"http:\/\/schema.org\/DENonprofitType",
+    "Name":"https://schema.org/DENonprofitType",
     "Domain Bucket":"< 1K"
   },
   {
     "Class":"Itemtype",
-    "Name":"http:\/\/schema.org\/DanceEvent",
+    "Name":"https://schema.org/DanceEvent",
     "Domain Bucket":"< 1K"
   },
   {
     "Class":"Itemtype",
-    "Name":"http:\/\/schema.org\/DanceGroup",
+    "Name":"https://schema.org/DanceGroup",
     "Domain Bucket":"< 1K"
   },
   {
     "Class":"Itemtype",
-    "Name":"http:\/\/schema.org\/DataCatalog",
+    "Name":"https://schema.org/DataCatalog",
     "Domain Bucket":"1K - 10K"
   },
   {
     "Class":"Itemtype",
-    "Name":"http:\/\/schema.org\/DataDownload",
+    "Name":"https://schema.org/DataDownload",
     "Domain Bucket":"10K - 100K"
   },
   {
     "Class":"Itemtype",
-    "Name":"http:\/\/schema.org\/DataFeed",
+    "Name":"https://schema.org/DataFeed",
     "Domain Bucket":"1K - 10K"
   },
   {
     "Class":"Itemtype",
-    "Name":"http:\/\/schema.org\/DataFeedItem",
+    "Name":"https://schema.org/DataFeedItem",
     "Domain Bucket":"1K - 10K"
   },
   {
     "Class":"Itemtype",
-    "Name":"http:\/\/schema.org\/DataType",
+    "Name":"https://schema.org/DataType",
     "Domain Bucket":"< 1K"
   },
   {
     "Class":"Itemtype",
-    "Name":"http:\/\/schema.org\/Dataset",
+    "Name":"https://schema.org/Dataset",
     "Domain Bucket":"10K - 100K"
   },
   {
     "Class":"Itemtype",
-    "Name":"http:\/\/schema.org\/Date",
+    "Name":"https://schema.org/Date",
     "Domain Bucket":"< 1K"
   },
   {
     "Class":"Itemtype",
-    "Name":"http:\/\/schema.org\/DateTime",
+    "Name":"https://schema.org/DateTime",
     "Domain Bucket":"< 1K"
   },
   {
     "Class":"Itemtype",
-    "Name":"http:\/\/schema.org\/DatedMoneySpecification",
+    "Name":"https://schema.org/DatedMoneySpecification",
     "Domain Bucket":"< 1K"
   },
   {
     "Class":"Itemtype",
-    "Name":"http:\/\/schema.org\/DayOfWeek",
+    "Name":"https://schema.org/DayOfWeek",
     "Domain Bucket":"10K - 100K"
   },
   {
     "Class":"Itemtype",
-    "Name":"http:\/\/schema.org\/DaySpa",
+    "Name":"https://schema.org/DaySpa",
     "Domain Bucket":"1K - 10K"
   },
   {
     "Class":"Itemtype",
-    "Name":"http:\/\/schema.org\/DeactivateAction",
+    "Name":"https://schema.org/DeactivateAction",
     "Domain Bucket":"< 1K"
   },
   {
     "Class":"Itemtype",
-    "Name":"http:\/\/schema.org\/DefenceEstablishment",
+    "Name":"https://schema.org/DefenceEstablishment",
     "Domain Bucket":"< 1K"
   },
   {
     "Class":"Itemtype",
-    "Name":"http:\/\/schema.org\/DefinedRegion",
+    "Name":"https://schema.org/DefinedRegion",
     "Domain Bucket":"100K - 1M"
   },
   {
     "Class":"Itemtype",
-    "Name":"http:\/\/schema.org\/DefinedTerm",
+    "Name":"https://schema.org/DefinedTerm",
     "Domain Bucket":"10K - 100K"
   },
   {
     "Class":"Itemtype",
-    "Name":"http:\/\/schema.org\/DefinedTermSet",
+    "Name":"https://schema.org/DefinedTermSet",
     "Domain Bucket":"10K - 100K"
   },
   {
     "Class":"Itemtype",
-    "Name":"http:\/\/schema.org\/DeleteAction",
+    "Name":"https://schema.org/DeleteAction",
     "Domain Bucket":"< 1K"
   },
   {
     "Class":"Itemtype",
-    "Name":"http:\/\/schema.org\/DeliveryChargeSpecification",
+    "Name":"https://schema.org/DeliveryChargeSpecification",
     "Domain Bucket":"10K - 100K"
   },
   {
     "Class":"Itemtype",
-    "Name":"http:\/\/schema.org\/DeliveryEvent",
+    "Name":"https://schema.org/DeliveryEvent",
     "Domain Bucket":"< 1K"
   },
   {
     "Class":"Itemtype",
-    "Name":"http:\/\/schema.org\/DeliveryMethod",
+    "Name":"https://schema.org/DeliveryMethod",
     "Domain Bucket":"< 1K"
   },
   {
     "Class":"Itemtype",
-    "Name":"http:\/\/schema.org\/DeliveryTimeSettings",
+    "Name":"https://schema.org/DeliveryTimeSettings",
     "Domain Bucket":"< 1K"
   },
   {
     "Class":"Itemtype",
-    "Name":"http:\/\/schema.org\/Demand",
+    "Name":"https://schema.org/Demand",
     "Domain Bucket":"1K - 10K"
   },
   {
     "Class":"Itemtype",
-    "Name":"http:\/\/schema.org\/Dentist",
+    "Name":"https://schema.org/Dentist",
     "Domain Bucket":"10K - 100K"
   },
   {
     "Class":"Itemtype",
-    "Name":"http:\/\/schema.org\/DepartAction",
+    "Name":"https://schema.org/DepartAction",
     "Domain Bucket":"< 1K"
   },
   {
     "Class":"Itemtype",
-    "Name":"http:\/\/schema.org\/DepartmentStore",
+    "Name":"https://schema.org/DepartmentStore",
     "Domain Bucket":"1K - 10K"
   },
   {
     "Class":"Itemtype",
-    "Name":"http:\/\/schema.org\/DepositAccount",
+    "Name":"https://schema.org/DepositAccount",
     "Domain Bucket":"< 1K"
   },
   {
     "Class":"Itemtype",
-    "Name":"http:\/\/schema.org\/Dermatology",
+    "Name":"https://schema.org/Dermatology",
     "Domain Bucket":"< 1K"
   },
   {
     "Class":"Itemtype",
-    "Name":"http:\/\/schema.org\/DiagnosticLab",
+    "Name":"https://schema.org/DiagnosticLab",
     "Domain Bucket":"1K - 10K"
   },
   {
     "Class":"Itemtype",
-    "Name":"http:\/\/schema.org\/DiagnosticProcedure",
+    "Name":"https://schema.org/DiagnosticProcedure",
     "Domain Bucket":"< 1K"
   },
   {
     "Class":"Itemtype",
-    "Name":"http:\/\/schema.org\/Diet",
+    "Name":"https://schema.org/Diet",
     "Domain Bucket":"< 1K"
   },
   {
     "Class":"Itemtype",
-    "Name":"http:\/\/schema.org\/DietNutrition",
+    "Name":"https://schema.org/DietNutrition",
     "Domain Bucket":"1K - 10K"
   },
   {
     "Class":"Itemtype",
-    "Name":"http:\/\/schema.org\/DietarySupplement",
+    "Name":"https://schema.org/DietarySupplement",
     "Domain Bucket":"< 1K"
   },
   {
     "Class":"Itemtype",
-    "Name":"http:\/\/schema.org\/DigitalDocument",
+    "Name":"https://schema.org/DigitalDocument",
     "Domain Bucket":"10K - 100K"
   },
   {
     "Class":"Itemtype",
-    "Name":"http:\/\/schema.org\/DigitalDocumentPermission",
+    "Name":"https://schema.org/DigitalDocumentPermission",
     "Domain Bucket":"< 1K"
   },
   {
     "Class":"Itemtype",
-    "Name":"http:\/\/schema.org\/DigitalDocumentPermissionType",
+    "Name":"https://schema.org/DigitalDocumentPermissionType",
     "Domain Bucket":"< 1K"
   },
   {
     "Class":"Itemtype",
-    "Name":"http:\/\/schema.org\/DigitalPlatformEnumeration",
+    "Name":"https://schema.org/DigitalPlatformEnumeration",
     "Domain Bucket":"< 1K"
   },
   {
     "Class":"Itemtype",
-    "Name":"http:\/\/schema.org\/DisagreeAction",
+    "Name":"https://schema.org/DisagreeAction",
     "Domain Bucket":"< 1K"
   },
   {
     "Class":"Itemtype",
-    "Name":"http:\/\/schema.org\/DiscoverAction",
+    "Name":"https://schema.org/DiscoverAction",
     "Domain Bucket":"< 1K"
   },
   {
     "Class":"Itemtype",
-    "Name":"http:\/\/schema.org\/DiscussionForumPosting",
+    "Name":"https://schema.org/DiscussionForumPosting",
     "Domain Bucket":"10K - 100K"
   },
   {
     "Class":"Itemtype",
-    "Name":"http:\/\/schema.org\/DislikeAction",
+    "Name":"https://schema.org/DislikeAction",
     "Domain Bucket":"1K - 10K"
   },
   {
     "Class":"Itemtype",
-    "Name":"http:\/\/schema.org\/Distance",
+    "Name":"https://schema.org/Distance",
     "Domain Bucket":"1K - 10K"
   },
   {
     "Class":"Itemtype",
-    "Name":"http:\/\/schema.org\/Distillery",
+    "Name":"https://schema.org/Distillery",
     "Domain Bucket":"< 1K"
   },
   {
     "Class":"Itemtype",
-    "Name":"http:\/\/schema.org\/DonateAction",
+    "Name":"https://schema.org/DonateAction",
     "Domain Bucket":"1K - 10K"
   },
   {
     "Class":"Itemtype",
-    "Name":"http:\/\/schema.org\/DoseSchedule",
+    "Name":"https://schema.org/DoseSchedule",
     "Domain Bucket":"< 1K"
   },
   {
     "Class":"Itemtype",
-    "Name":"http:\/\/schema.org\/DownloadAction",
+    "Name":"https://schema.org/DownloadAction",
     "Domain Bucket":"1K - 10K"
   },
   {
     "Class":"Itemtype",
-    "Name":"http:\/\/schema.org\/DrawAction",
+    "Name":"https://schema.org/DrawAction",
     "Domain Bucket":"< 1K"
   },
   {
     "Class":"Itemtype",
-    "Name":"http:\/\/schema.org\/Drawing",
+    "Name":"https://schema.org/Drawing",
     "Domain Bucket":"< 1K"
   },
   {
     "Class":"Itemtype",
-    "Name":"http:\/\/schema.org\/DrinkAction",
+    "Name":"https://schema.org/DrinkAction",
     "Domain Bucket":"< 1K"
   },
   {
     "Class":"Itemtype",
-    "Name":"http:\/\/schema.org\/DriveWheelConfigurationValue",
+    "Name":"https://schema.org/DriveWheelConfigurationValue",
     "Domain Bucket":"< 1K"
   },
   {
     "Class":"Itemtype",
-    "Name":"http:\/\/schema.org\/Drug",
+    "Name":"https://schema.org/Drug",
     "Domain Bucket":"1K - 10K"
   },
   {
     "Class":"Itemtype",
-    "Name":"http:\/\/schema.org\/DrugClass",
+    "Name":"https://schema.org/DrugClass",
     "Domain Bucket":"1K - 10K"
   },
   {
     "Class":"Itemtype",
-    "Name":"http:\/\/schema.org\/DrugCost",
+    "Name":"https://schema.org/DrugCost",
     "Domain Bucket":"< 1K"
   },
   {
     "Class":"Itemtype",
-    "Name":"http:\/\/schema.org\/DrugCostCategory",
+    "Name":"https://schema.org/DrugCostCategory",
     "Domain Bucket":"< 1K"
   },
   {
     "Class":"Itemtype",
-    "Name":"http:\/\/schema.org\/DrugLegalStatus",
+    "Name":"https://schema.org/DrugLegalStatus",
     "Domain Bucket":"< 1K"
   },
   {
     "Class":"Itemtype",
-    "Name":"http:\/\/schema.org\/DrugPregnancyCategory",
+    "Name":"https://schema.org/DrugPregnancyCategory",
     "Domain Bucket":"< 1K"
   },
   {
     "Class":"Itemtype",
-    "Name":"http:\/\/schema.org\/DrugPrescriptionStatus",
+    "Name":"https://schema.org/DrugPrescriptionStatus",
     "Domain Bucket":"< 1K"
   },
   {
     "Class":"Itemtype",
-    "Name":"http:\/\/schema.org\/DrugStrength",
+    "Name":"https://schema.org/DrugStrength",
     "Domain Bucket":"< 1K"
   },
   {
     "Class":"Itemtype",
-    "Name":"http:\/\/schema.org\/DryCleaningOrLaundry",
+    "Name":"https://schema.org/DryCleaningOrLaundry",
     "Domain Bucket":"1K - 10K"
   },
   {
     "Class":"Itemtype",
-    "Name":"http:\/\/schema.org\/Duration",
+    "Name":"https://schema.org/Duration",
     "Domain Bucket":"1K - 10K"
   },
   {
     "Class":"Itemtype",
-    "Name":"http:\/\/schema.org\/EUEnergyEfficiencyEnumeration",
+    "Name":"https://schema.org/EUEnergyEfficiencyEnumeration",
     "Domain Bucket":"< 1K"
   },
   {
     "Class":"Itemtype",
-    "Name":"http:\/\/schema.org\/EatAction",
+    "Name":"https://schema.org/EatAction",
     "Domain Bucket":"< 1K"
   },
   {
     "Class":"Itemtype",
-    "Name":"http:\/\/schema.org\/EducationEvent",
+    "Name":"https://schema.org/EducationEvent",
     "Domain Bucket":"1K - 10K"
   },
   {
     "Class":"Itemtype",
-    "Name":"http:\/\/schema.org\/EducationalAudience",
+    "Name":"https://schema.org/EducationalAudience",
     "Domain Bucket":"10K - 100K"
   },
   {
     "Class":"Itemtype",
-    "Name":"http:\/\/schema.org\/EducationalOccupationalCredential",
+    "Name":"https://schema.org/EducationalOccupationalCredential",
     "Domain Bucket":"10K - 100K"
   },
   {
     "Class":"Itemtype",
-    "Name":"http:\/\/schema.org\/EducationalOccupationalProgram",
+    "Name":"https://schema.org/EducationalOccupationalProgram",
     "Domain Bucket":"1K - 10K"
   },
   {
     "Class":"Itemtype",
-    "Name":"http:\/\/schema.org\/EducationalOrganization",
+    "Name":"https://schema.org/EducationalOrganization",
     "Domain Bucket":"100K - 1M"
   },
   {
     "Class":"Itemtype",
-    "Name":"http:\/\/schema.org\/Electrician",
+    "Name":"https://schema.org/Electrician",
     "Domain Bucket":"10K - 100K"
   },
   {
     "Class":"Itemtype",
-    "Name":"http:\/\/schema.org\/ElectronicsStore",
+    "Name":"https://schema.org/ElectronicsStore",
     "Domain Bucket":"1K - 10K"
   },
   {
     "Class":"Itemtype",
-    "Name":"http:\/\/schema.org\/ElementarySchool",
+    "Name":"https://schema.org/ElementarySchool",
     "Domain Bucket":"< 1K"
   },
   {
     "Class":"Itemtype",
-    "Name":"http:\/\/schema.org\/EmailMessage",
+    "Name":"https://schema.org/EmailMessage",
     "Domain Bucket":"< 1K"
   },
   {
     "Class":"Itemtype",
-    "Name":"http:\/\/schema.org\/Embassy",
+    "Name":"https://schema.org/Embassy",
     "Domain Bucket":"< 1K"
   },
   {
     "Class":"Itemtype",
-    "Name":"http:\/\/schema.org\/Emergency",
+    "Name":"https://schema.org/Emergency",
     "Domain Bucket":"< 1K"
   },
   {
     "Class":"Itemtype",
-    "Name":"http:\/\/schema.org\/EmergencyService",
+    "Name":"https://schema.org/EmergencyService",
     "Domain Bucket":"1K - 10K"
   },
   {
     "Class":"Itemtype",
-    "Name":"http:\/\/schema.org\/EmployeeRole",
+    "Name":"https://schema.org/EmployeeRole",
     "Domain Bucket":"< 1K"
   },
   {
     "Class":"Itemtype",
-    "Name":"http:\/\/schema.org\/EmployerAggregateRating",
+    "Name":"https://schema.org/EmployerAggregateRating",
     "Domain Bucket":"1K - 10K"
   },
   {
     "Class":"Itemtype",
-    "Name":"http:\/\/schema.org\/EmployerReview",
+    "Name":"https://schema.org/EmployerReview",
     "Domain Bucket":"< 1K"
   },
   {
     "Class":"Itemtype",
-    "Name":"http:\/\/schema.org\/EmploymentAgency",
+    "Name":"https://schema.org/EmploymentAgency",
     "Domain Bucket":"1K - 10K"
   },
   {
     "Class":"Itemtype",
-    "Name":"http:\/\/schema.org\/EndorseAction",
+    "Name":"https://schema.org/EndorseAction",
     "Domain Bucket":"< 1K"
   },
   {
     "Class":"Itemtype",
-    "Name":"http:\/\/schema.org\/EndorsementRating",
+    "Name":"https://schema.org/EndorsementRating",
     "Domain Bucket":"< 1K"
   },
   {
     "Class":"Itemtype",
-    "Name":"http:\/\/schema.org\/Energy",
+    "Name":"https://schema.org/Energy",
     "Domain Bucket":"< 1K"
   },
   {
     "Class":"Itemtype",
-    "Name":"http:\/\/schema.org\/EnergyConsumptionDetails",
+    "Name":"https://schema.org/EnergyConsumptionDetails",
     "Domain Bucket":"1K - 10K"
   },
   {
     "Class":"Itemtype",
-    "Name":"http:\/\/schema.org\/EnergyEfficiencyEnumeration",
+    "Name":"https://schema.org/EnergyEfficiencyEnumeration",
     "Domain Bucket":"< 1K"
   },
   {
     "Class":"Itemtype",
-    "Name":"http:\/\/schema.org\/EnergyStarEnergyEfficiencyEnumeration",
+    "Name":"https://schema.org/EnergyStarEnergyEfficiencyEnumeration",
     "Domain Bucket":"< 1K"
   },
   {
     "Class":"Itemtype",
-    "Name":"http:\/\/schema.org\/EngineSpecification",
+    "Name":"https://schema.org/EngineSpecification",
     "Domain Bucket":"10K - 100K"
   },
   {
     "Class":"Itemtype",
-    "Name":"http:\/\/schema.org\/EntertainmentBusiness",
+    "Name":"https://schema.org/EntertainmentBusiness",
     "Domain Bucket":"10K - 100K"
   },
   {
     "Class":"Itemtype",
-    "Name":"http:\/\/schema.org\/EntryPoint",
+    "Name":"https://schema.org/EntryPoint",
     "Domain Bucket":"10M+"
   },
   {
     "Class":"Itemtype",
-    "Name":"http:\/\/schema.org\/Enumeration",
+    "Name":"https://schema.org/Enumeration",
     "Domain Bucket":"1K - 10K"
   },
   {
     "Class":"Itemtype",
-    "Name":"http:\/\/schema.org\/Episode",
+    "Name":"https://schema.org/Episode",
     "Domain Bucket":"1K - 10K"
   },
   {
     "Class":"Itemtype",
-    "Name":"http:\/\/schema.org\/Error",
+    "Name":"https://schema.org/Error",
     "Domain Bucket":"< 1K"
   },
   {
     "Class":"Itemtype",
-    "Name":"http:\/\/schema.org\/Event",
+    "Name":"https://schema.org/Event",
     "Domain Bucket":"100K - 1M"
   },
   {
     "Class":"Itemtype",
-    "Name":"http:\/\/schema.org\/EventAttendanceModeEnumeration",
+    "Name":"https://schema.org/EventAttendanceModeEnumeration",
     "Domain Bucket":"< 1K"
   },
   {
     "Class":"Itemtype",
-    "Name":"http:\/\/schema.org\/EventReservation",
+    "Name":"https://schema.org/EventReservation",
     "Domain Bucket":"< 1K"
   },
   {
     "Class":"Itemtype",
-    "Name":"http:\/\/schema.org\/EventSeries",
+    "Name":"https://schema.org/EventSeries",
     "Domain Bucket":"1K - 10K"
   },
   {
     "Class":"Itemtype",
-    "Name":"http:\/\/schema.org\/EventStatusType",
+    "Name":"https://schema.org/EventStatusType",
     "Domain Bucket":"< 1K"
   },
   {
     "Class":"Itemtype",
-    "Name":"http:\/\/schema.org\/EventVenue",
+    "Name":"https://schema.org/EventVenue",
     "Domain Bucket":"10K - 100K"
   },
   {
     "Class":"Itemtype",
-    "Name":"http:\/\/schema.org\/ExchangeRateSpecification",
+    "Name":"https://schema.org/ExchangeRateSpecification",
     "Domain Bucket":"< 1K"
   },
   {
     "Class":"Itemtype",
-    "Name":"http:\/\/schema.org\/ExerciseAction",
+    "Name":"https://schema.org/ExerciseAction",
     "Domain Bucket":"< 1K"
   },
   {
     "Class":"Itemtype",
-    "Name":"http:\/\/schema.org\/ExerciseGym",
+    "Name":"https://schema.org/ExerciseGym",
     "Domain Bucket":"1K - 10K"
   },
   {
     "Class":"Itemtype",
-    "Name":"http:\/\/schema.org\/ExercisePlan",
+    "Name":"https://schema.org/ExercisePlan",
     "Domain Bucket":"< 1K"
   },
   {
     "Class":"Itemtype",
-    "Name":"http:\/\/schema.org\/ExhibitionEvent",
+    "Name":"https://schema.org/ExhibitionEvent",
     "Domain Bucket":"1K - 10K"
   },
   {
     "Class":"Itemtype",
-    "Name":"http:\/\/schema.org\/FAQPage",
+    "Name":"https://schema.org/FAQPage",
     "Domain Bucket":"1M - 10M"
   },
   {
     "Class":"Itemtype",
-    "Name":"http:\/\/schema.org\/FMRadioChannel",
+    "Name":"https://schema.org/FMRadioChannel",
     "Domain Bucket":"< 1K"
   },
   {
     "Class":"Itemtype",
-    "Name":"http:\/\/schema.org\/FastFoodRestaurant",
+    "Name":"https://schema.org/FastFoodRestaurant",
     "Domain Bucket":"1K - 10K"
   },
   {
     "Class":"Itemtype",
-    "Name":"http:\/\/schema.org\/Festival",
+    "Name":"https://schema.org/Festival",
     "Domain Bucket":"1K - 10K"
   },
   {
     "Class":"Itemtype",
-    "Name":"http:\/\/schema.org\/FilmAction",
+    "Name":"https://schema.org/FilmAction",
     "Domain Bucket":"< 1K"
   },
   {
     "Class":"Itemtype",
-    "Name":"http:\/\/schema.org\/FinancialIncentive",
+    "Name":"https://schema.org/FinancialIncentive",
     "Domain Bucket":"< 1K"
   },
   {
     "Class":"Itemtype",
-    "Name":"http:\/\/schema.org\/FinancialProduct",
+    "Name":"https://schema.org/FinancialProduct",
     "Domain Bucket":"10K - 100K"
   },
   {
     "Class":"Itemtype",
-    "Name":"http:\/\/schema.org\/FinancialService",
+    "Name":"https://schema.org/FinancialService",
     "Domain Bucket":"10K - 100K"
   },
   {
     "Class":"Itemtype",
-    "Name":"http:\/\/schema.org\/FindAction",
+    "Name":"https://schema.org/FindAction",
     "Domain Bucket":"< 1K"
   },
   {
     "Class":"Itemtype",
-    "Name":"http:\/\/schema.org\/FireStation",
+    "Name":"https://schema.org/FireStation",
     "Domain Bucket":"< 1K"
   },
   {
     "Class":"Itemtype",
-    "Name":"http:\/\/schema.org\/Flight",
+    "Name":"https://schema.org/Flight",
     "Domain Bucket":"1K - 10K"
   },
   {
     "Class":"Itemtype",
-    "Name":"http:\/\/schema.org\/FlightReservation",
+    "Name":"https://schema.org/FlightReservation",
     "Domain Bucket":"< 1K"
   },
   {
     "Class":"Itemtype",
-    "Name":"http:\/\/schema.org\/Float",
+    "Name":"https://schema.org/Float",
     "Domain Bucket":"< 1K"
   },
   {
     "Class":"Itemtype",
-    "Name":"http:\/\/schema.org\/FloorPlan",
+    "Name":"https://schema.org/FloorPlan",
     "Domain Bucket":"10K - 100K"
   },
   {
     "Class":"Itemtype",
-    "Name":"http:\/\/schema.org\/Florist",
+    "Name":"https://schema.org/Florist",
     "Domain Bucket":"10K - 100K"
   },
   {
     "Class":"Itemtype",
-    "Name":"http:\/\/schema.org\/FollowAction",
+    "Name":"https://schema.org/FollowAction",
     "Domain Bucket":"10K - 100K"
   },
   {
     "Class":"Itemtype",
-    "Name":"http:\/\/schema.org\/FoodEstablishment",
+    "Name":"https://schema.org/FoodEstablishment",
     "Domain Bucket":"10K - 100K"
   },
   {
     "Class":"Itemtype",
-    "Name":"http:\/\/schema.org\/FoodEstablishmentReservation",
+    "Name":"https://schema.org/FoodEstablishmentReservation",
     "Domain Bucket":"1K - 10K"
   },
   {
     "Class":"Itemtype",
-    "Name":"http:\/\/schema.org\/FoodEvent",
+    "Name":"https://schema.org/FoodEvent",
     "Domain Bucket":"1K - 10K"
   },
   {
     "Class":"Itemtype",
-    "Name":"http:\/\/schema.org\/FoodService",
+    "Name":"https://schema.org/FoodService",
     "Domain Bucket":"1K - 10K"
   },
   {
     "Class":"Itemtype",
-    "Name":"http:\/\/schema.org\/FulfillmentTypeEnumeration",
+    "Name":"https://schema.org/FulfillmentTypeEnumeration",
     "Domain Bucket":"< 1K"
   },
   {
     "Class":"Itemtype",
-    "Name":"http:\/\/schema.org\/FundingAgency",
+    "Name":"https://schema.org/FundingAgency",
     "Domain Bucket":"< 1K"
   },
   {
     "Class":"Itemtype",
-    "Name":"http:\/\/schema.org\/FundingScheme",
+    "Name":"https://schema.org/FundingScheme",
     "Domain Bucket":"< 1K"
   },
   {
     "Class":"Itemtype",
-    "Name":"http:\/\/schema.org\/FurnitureStore",
+    "Name":"https://schema.org/FurnitureStore",
     "Domain Bucket":"10K - 100K"
   },
   {
     "Class":"Itemtype",
-    "Name":"http:\/\/schema.org\/Game",
+    "Name":"https://schema.org/Game",
     "Domain Bucket":"100K - 1M"
   },
   {
     "Class":"Itemtype",
-    "Name":"http:\/\/schema.org\/GameAvailabilityEnumeration",
+    "Name":"https://schema.org/GameAvailabilityEnumeration",
     "Domain Bucket":"< 1K"
   },
   {
     "Class":"Itemtype",
-    "Name":"http:\/\/schema.org\/GamePlayMode",
+    "Name":"https://schema.org/GamePlayMode",
     "Domain Bucket":"< 1K"
   },
   {
     "Class":"Itemtype",
-    "Name":"http:\/\/schema.org\/GameServer",
+    "Name":"https://schema.org/GameServer",
     "Domain Bucket":"1K - 10K"
   },
   {
     "Class":"Itemtype",
-    "Name":"http:\/\/schema.org\/GameServerStatus",
+    "Name":"https://schema.org/GameServerStatus",
     "Domain Bucket":"< 1K"
   },
   {
     "Class":"Itemtype",
-    "Name":"http:\/\/schema.org\/GardenStore",
+    "Name":"https://schema.org/GardenStore",
     "Domain Bucket":"1K - 10K"
   },
   {
     "Class":"Itemtype",
-    "Name":"http:\/\/schema.org\/GasStation",
+    "Name":"https://schema.org/GasStation",
     "Domain Bucket":"1K - 10K"
   },
   {
     "Class":"Itemtype",
-    "Name":"http:\/\/schema.org\/GatedResidenceCommunity",
+    "Name":"https://schema.org/GatedResidenceCommunity",
     "Domain Bucket":"< 1K"
   },
   {
     "Class":"Itemtype",
-    "Name":"http:\/\/schema.org\/GenderType",
+    "Name":"https://schema.org/GenderType",
     "Domain Bucket":"< 1K"
   },
   {
     "Class":"Itemtype",
-    "Name":"http:\/\/schema.org\/Gene",
+    "Name":"https://schema.org/Gene",
     "Domain Bucket":"< 1K"
   },
   {
     "Class":"Itemtype",
-    "Name":"http:\/\/schema.org\/GeneralContractor",
+    "Name":"https://schema.org/GeneralContractor",
     "Domain Bucket":"10K - 100K"
   },
   {
     "Class":"Itemtype",
-    "Name":"http:\/\/schema.org\/GeoCircle",
+    "Name":"https://schema.org/GeoCircle",
     "Domain Bucket":"100K - 1M"
   },
   {
     "Class":"Itemtype",
-    "Name":"http:\/\/schema.org\/GeoCoordinates",
+    "Name":"https://schema.org/GeoCoordinates",
     "Domain Bucket":"1M - 10M"
   },
   {
     "Class":"Itemtype",
-    "Name":"http:\/\/schema.org\/GeoShape",
+    "Name":"https://schema.org/GeoShape",
     "Domain Bucket":"10K - 100K"
   },
   {
     "Class":"Itemtype",
-    "Name":"http:\/\/schema.org\/GeospatialGeometry",
+    "Name":"https://schema.org/GeospatialGeometry",
     "Domain Bucket":"< 1K"
   },
   {
     "Class":"Itemtype",
-    "Name":"http:\/\/schema.org\/Geriatric",
+    "Name":"https://schema.org/Geriatric",
     "Domain Bucket":"< 1K"
   },
   {
     "Class":"Itemtype",
-    "Name":"http:\/\/schema.org\/GiveAction",
+    "Name":"https://schema.org/GiveAction",
     "Domain Bucket":"< 1K"
   },
   {
     "Class":"Itemtype",
-    "Name":"http:\/\/schema.org\/GolfCourse",
+    "Name":"https://schema.org/GolfCourse",
     "Domain Bucket":"1K - 10K"
   },
   {
     "Class":"Itemtype",
-    "Name":"http:\/\/schema.org\/GovernmentBenefitsType",
+    "Name":"https://schema.org/GovernmentBenefitsType",
     "Domain Bucket":"< 1K"
   },
   {
     "Class":"Itemtype",
-    "Name":"http:\/\/schema.org\/GovernmentBuilding",
+    "Name":"https://schema.org/GovernmentBuilding",
     "Domain Bucket":"< 1K"
   },
   {
     "Class":"Itemtype",
-    "Name":"http:\/\/schema.org\/GovernmentOffice",
+    "Name":"https://schema.org/GovernmentOffice",
     "Domain Bucket":"1K - 10K"
   },
   {
     "Class":"Itemtype",
-    "Name":"http:\/\/schema.org\/GovernmentOrganization",
+    "Name":"https://schema.org/GovernmentOrganization",
     "Domain Bucket":"10K - 100K"
   },
   {
     "Class":"Itemtype",
-    "Name":"http:\/\/schema.org\/GovernmentPermit",
+    "Name":"https://schema.org/GovernmentPermit",
     "Domain Bucket":"< 1K"
   },
   {
     "Class":"Itemtype",
-    "Name":"http:\/\/schema.org\/GovernmentService",
+    "Name":"https://schema.org/GovernmentService",
     "Domain Bucket":"1K - 10K"
   },
   {
     "Class":"Itemtype",
-    "Name":"http:\/\/schema.org\/Grant",
+    "Name":"https://schema.org/Grant",
     "Domain Bucket":"1K - 10K"
   },
   {
     "Class":"Itemtype",
-    "Name":"http:\/\/schema.org\/GroceryStore",
+    "Name":"https://schema.org/GroceryStore",
     "Domain Bucket":"1K - 10K"
   },
   {
     "Class":"Itemtype",
-    "Name":"http:\/\/schema.org\/Guide",
+    "Name":"https://schema.org/Guide",
     "Domain Bucket":"1K - 10K"
   },
   {
     "Class":"Itemtype",
-    "Name":"http:\/\/schema.org\/Gynecologic",
+    "Name":"https://schema.org/Gynecologic",
     "Domain Bucket":"< 1K"
   },
   {
     "Class":"Itemtype",
-    "Name":"http:\/\/schema.org\/HVACBusiness",
+    "Name":"https://schema.org/HVACBusiness",
     "Domain Bucket":"10K - 100K"
   },
   {
     "Class":"Itemtype",
-    "Name":"http:\/\/schema.org\/Hackathon",
+    "Name":"https://schema.org/Hackathon",
     "Domain Bucket":"< 1K"
   },
   {
     "Class":"Itemtype",
-    "Name":"http:\/\/schema.org\/HairSalon",
+    "Name":"https://schema.org/HairSalon",
     "Domain Bucket":"10K - 100K"
   },
   {
     "Class":"Itemtype",
-    "Name":"http:\/\/schema.org\/HardwareStore",
+    "Name":"https://schema.org/HardwareStore",
     "Domain Bucket":"1K - 10K"
   },
   {
     "Class":"Itemtype",
-    "Name":"http:\/\/schema.org\/HealthAndBeautyBusiness",
+    "Name":"https://schema.org/HealthAndBeautyBusiness",
     "Domain Bucket":"10K - 100K"
   },
   {
     "Class":"Itemtype",
-    "Name":"http:\/\/schema.org\/HealthAspectEnumeration",
+    "Name":"https://schema.org/HealthAspectEnumeration",
     "Domain Bucket":"< 1K"
   },
   {
     "Class":"Itemtype",
-    "Name":"http:\/\/schema.org\/HealthClub",
+    "Name":"https://schema.org/HealthClub",
     "Domain Bucket":"1K - 10K"
   },
   {
     "Class":"Itemtype",
-    "Name":"http:\/\/schema.org\/HealthInsurancePlan",
+    "Name":"https://schema.org/HealthInsurancePlan",
     "Domain Bucket":"< 1K"
   },
   {
     "Class":"Itemtype",
-    "Name":"http:\/\/schema.org\/HealthPlanCostSharingSpecification",
+    "Name":"https://schema.org/HealthPlanCostSharingSpecification",
     "Domain Bucket":"< 1K"
   },
   {
     "Class":"Itemtype",
-    "Name":"http:\/\/schema.org\/HealthPlanFormulary",
+    "Name":"https://schema.org/HealthPlanFormulary",
     "Domain Bucket":"< 1K"
   },
   {
     "Class":"Itemtype",
-    "Name":"http:\/\/schema.org\/HealthPlanNetwork",
+    "Name":"https://schema.org/HealthPlanNetwork",
     "Domain Bucket":"< 1K"
   },
   {
     "Class":"Itemtype",
-    "Name":"http:\/\/schema.org\/HealthTopicContent",
+    "Name":"https://schema.org/HealthTopicContent",
     "Domain Bucket":"< 1K"
   },
   {
     "Class":"Itemtype",
-    "Name":"http:\/\/schema.org\/HighSchool",
+    "Name":"https://schema.org/HighSchool",
     "Domain Bucket":"1K - 10K"
   },
   {
     "Class":"Itemtype",
-    "Name":"http:\/\/schema.org\/HinduTemple",
+    "Name":"https://schema.org/HinduTemple",
     "Domain Bucket":"< 1K"
   },
   {
     "Class":"Itemtype",
-    "Name":"http:\/\/schema.org\/HobbyShop",
+    "Name":"https://schema.org/HobbyShop",
     "Domain Bucket":"1K - 10K"
   },
   {
     "Class":"Itemtype",
-    "Name":"http:\/\/schema.org\/HomeAndConstructionBusiness",
+    "Name":"https://schema.org/HomeAndConstructionBusiness",
     "Domain Bucket":"100K - 1M"
   },
   {
     "Class":"Itemtype",
-    "Name":"http:\/\/schema.org\/HomeGoodsStore",
+    "Name":"https://schema.org/HomeGoodsStore",
     "Domain Bucket":"1K - 10K"
   },
   {
     "Class":"Itemtype",
-    "Name":"http:\/\/schema.org\/Hospital",
+    "Name":"https://schema.org/Hospital",
     "Domain Bucket":"10K - 100K"
   },
   {
     "Class":"Itemtype",
-    "Name":"http:\/\/schema.org\/Hostel",
+    "Name":"https://schema.org/Hostel",
     "Domain Bucket":"1K - 10K"
   },
   {
     "Class":"Itemtype",
-    "Name":"http:\/\/schema.org\/Hotel",
+    "Name":"https://schema.org/Hotel",
     "Domain Bucket":"10K - 100K"
   },
   {
     "Class":"Itemtype",
-    "Name":"http:\/\/schema.org\/HotelRoom",
+    "Name":"https://schema.org/HotelRoom",
     "Domain Bucket":"10K - 100K"
   },
   {
     "Class":"Itemtype",
-    "Name":"http:\/\/schema.org\/House",
+    "Name":"https://schema.org/House",
     "Domain Bucket":"10K - 100K"
   },
   {
     "Class":"Itemtype",
-    "Name":"http:\/\/schema.org\/HousePainter",
+    "Name":"https://schema.org/HousePainter",
     "Domain Bucket":"1K - 10K"
   },
   {
     "Class":"Itemtype",
-    "Name":"http:\/\/schema.org\/HowTo",
+    "Name":"https://schema.org/HowTo",
     "Domain Bucket":"100K - 1M"
   },
   {
     "Class":"Itemtype",
-    "Name":"http:\/\/schema.org\/HowToDirection",
+    "Name":"https://schema.org/HowToDirection",
     "Domain Bucket":"10K - 100K"
   },
   {
     "Class":"Itemtype",
-    "Name":"http:\/\/schema.org\/HowToItem",
+    "Name":"https://schema.org/HowToItem",
     "Domain Bucket":"< 1K"
   },
   {
     "Class":"Itemtype",
-    "Name":"http:\/\/schema.org\/HowToSection",
+    "Name":"https://schema.org/HowToSection",
     "Domain Bucket":"10K - 100K"
   },
   {
     "Class":"Itemtype",
-    "Name":"http:\/\/schema.org\/HowToStep",
+    "Name":"https://schema.org/HowToStep",
     "Domain Bucket":"100K - 1M"
   },
   {
     "Class":"Itemtype",
-    "Name":"http:\/\/schema.org\/HowToSupply",
+    "Name":"https://schema.org/HowToSupply",
     "Domain Bucket":"10K - 100K"
   },
   {
     "Class":"Itemtype",
-    "Name":"http:\/\/schema.org\/HowToTip",
+    "Name":"https://schema.org/HowToTip",
     "Domain Bucket":"1K - 10K"
   },
   {
     "Class":"Itemtype",
-    "Name":"http:\/\/schema.org\/HowToTool",
+    "Name":"https://schema.org/HowToTool",
     "Domain Bucket":"10K - 100K"
   },
   {
     "Class":"Itemtype",
-    "Name":"http:\/\/schema.org\/HyperToc",
+    "Name":"https://schema.org/HyperToc",
     "Domain Bucket":"< 1K"
   },
   {
     "Class":"Itemtype",
-    "Name":"http:\/\/schema.org\/HyperTocEntry",
+    "Name":"https://schema.org/HyperTocEntry",
     "Domain Bucket":"< 1K"
   },
   {
     "Class":"Itemtype",
-    "Name":"http:\/\/schema.org\/IPTCDigitalSourceEnumeration",
+    "Name":"https://schema.org/IPTCDigitalSourceEnumeration",
     "Domain Bucket":"< 1K"
   },
   {
     "Class":"Itemtype",
-    "Name":"http:\/\/schema.org\/ITNonprofitType",
+    "Name":"https://schema.org/ITNonprofitType",
     "Domain Bucket":"< 1K"
   },
   {
     "Class":"Itemtype",
-    "Name":"http:\/\/schema.org\/IceCreamShop",
+    "Name":"https://schema.org/IceCreamShop",
     "Domain Bucket":"1K - 10K"
   },
   {
     "Class":"Itemtype",
-    "Name":"http:\/\/schema.org\/IgnoreAction",
+    "Name":"https://schema.org/IgnoreAction",
     "Domain Bucket":"< 1K"
   },
   {
     "Class":"Itemtype",
-    "Name":"http:\/\/schema.org\/ImageGallery",
+    "Name":"https://schema.org/ImageGallery",
     "Domain Bucket":"1M - 10M"
   },
   {
     "Class":"Itemtype",
-    "Name":"http:\/\/schema.org\/ImageObject",
+    "Name":"https://schema.org/ImageObject",
     "Domain Bucket":"10M+"
   },
   {
     "Class":"Itemtype",
-    "Name":"http:\/\/schema.org\/ImageObjectSnapshot",
+    "Name":"https://schema.org/ImageObjectSnapshot",
     "Domain Bucket":"< 1K"
   },
   {
     "Class":"Itemtype",
-    "Name":"http:\/\/schema.org\/ImagingTest",
+    "Name":"https://schema.org/ImagingTest",
     "Domain Bucket":"< 1K"
   },
   {
     "Class":"Itemtype",
-    "Name":"http:\/\/schema.org\/IncentiveQualifiedExpenseType",
+    "Name":"https://schema.org/IncentiveQualifiedExpenseType",
     "Domain Bucket":"< 1K"
   },
   {
     "Class":"Itemtype",
-    "Name":"http:\/\/schema.org\/IncentiveStatus",
+    "Name":"https://schema.org/IncentiveStatus",
     "Domain Bucket":"< 1K"
   },
   {
     "Class":"Itemtype",
-    "Name":"http:\/\/schema.org\/IncentiveType",
+    "Name":"https://schema.org/IncentiveType",
     "Domain Bucket":"< 1K"
   },
   {
     "Class":"Itemtype",
-    "Name":"http:\/\/schema.org\/IndividualPhysician",
+    "Name":"https://schema.org/IndividualPhysician",
     "Domain Bucket":"1K - 10K"
   },
   {
     "Class":"Itemtype",
-    "Name":"http:\/\/schema.org\/IndividualProduct",
+    "Name":"https://schema.org/IndividualProduct",
     "Domain Bucket":"10K - 100K"
   },
   {
     "Class":"Itemtype",
-    "Name":"http:\/\/schema.org\/InfectiousAgentClass",
+    "Name":"https://schema.org/InfectiousAgentClass",
     "Domain Bucket":"< 1K"
   },
   {
     "Class":"Itemtype",
-    "Name":"http:\/\/schema.org\/InfectiousDisease",
+    "Name":"https://schema.org/InfectiousDisease",
     "Domain Bucket":"< 1K"
   },
   {
     "Class":"Itemtype",
-    "Name":"http:\/\/schema.org\/InformAction",
+    "Name":"https://schema.org/InformAction",
     "Domain Bucket":"< 1K"
   },
   {
     "Class":"Itemtype",
-    "Name":"http:\/\/schema.org\/InsertAction",
+    "Name":"https://schema.org/InsertAction",
     "Domain Bucket":"< 1K"
   },
   {
     "Class":"Itemtype",
-    "Name":"http:\/\/schema.org\/InstallAction",
+    "Name":"https://schema.org/InstallAction",
     "Domain Bucket":"< 1K"
   },
   {
     "Class":"Itemtype",
-    "Name":"http:\/\/schema.org\/InstantaneousEvent",
+    "Name":"https://schema.org/InstantaneousEvent",
     "Domain Bucket":"< 1K"
   },
   {
     "Class":"Itemtype",
-    "Name":"http:\/\/schema.org\/InsuranceAgency",
+    "Name":"https://schema.org/InsuranceAgency",
     "Domain Bucket":"10K - 100K"
   },
   {
     "Class":"Itemtype",
-    "Name":"http:\/\/schema.org\/Intangible",
+    "Name":"https://schema.org/Intangible",
     "Domain Bucket":"1K - 10K"
   },
   {
     "Class":"Itemtype",
-    "Name":"http:\/\/schema.org\/Integer",
+    "Name":"https://schema.org/Integer",
     "Domain Bucket":"< 1K"
   },
   {
     "Class":"Itemtype",
-    "Name":"http:\/\/schema.org\/InteractAction",
+    "Name":"https://schema.org/InteractAction",
     "Domain Bucket":"1K - 10K"
   },
   {
     "Class":"Itemtype",
-    "Name":"http:\/\/schema.org\/InteractionCounter",
+    "Name":"https://schema.org/InteractionCounter",
     "Domain Bucket":"100K - 1M"
   },
   {
     "Class":"Itemtype",
-    "Name":"http:\/\/schema.org\/InternetCafe",
+    "Name":"https://schema.org/InternetCafe",
     "Domain Bucket":"< 1K"
   },
   {
     "Class":"Itemtype",
-    "Name":"http:\/\/schema.org\/InvestmentFund",
+    "Name":"https://schema.org/InvestmentFund",
     "Domain Bucket":"< 1K"
   },
   {
     "Class":"Itemtype",
-    "Name":"http:\/\/schema.org\/InvestmentOrDeposit",
+    "Name":"https://schema.org/InvestmentOrDeposit",
     "Domain Bucket":"< 1K"
   },
   {
     "Class":"Itemtype",
-    "Name":"http:\/\/schema.org\/InviteAction",
+    "Name":"https://schema.org/InviteAction",
     "Domain Bucket":"< 1K"
   },
   {
     "Class":"Itemtype",
-    "Name":"http:\/\/schema.org\/Invoice",
+    "Name":"https://schema.org/Invoice",
     "Domain Bucket":"< 1K"
   },
   {
     "Class":"Itemtype",
-    "Name":"http:\/\/schema.org\/ItemAvailability",
+    "Name":"https://schema.org/ItemAvailability",
     "Domain Bucket":"1K - 10K"
   },
   {
     "Class":"Itemtype",
-    "Name":"http:\/\/schema.org\/ItemList",
+    "Name":"https://schema.org/ItemList",
     "Domain Bucket":"1M - 10M"
   },
   {
     "Class":"Itemtype",
-    "Name":"http:\/\/schema.org\/ItemListOrderType",
+    "Name":"https://schema.org/ItemListOrderType",
     "Domain Bucket":"< 1K"
   },
   {
     "Class":"Itemtype",
-    "Name":"http:\/\/schema.org\/ItemPage",
+    "Name":"https://schema.org/ItemPage",
     "Domain Bucket":"1M - 10M"
   },
   {
     "Class":"Itemtype",
-    "Name":"http:\/\/schema.org\/JewelryStore",
+    "Name":"https://schema.org/JewelryStore",
     "Domain Bucket":"10K - 100K"
   },
   {
     "Class":"Itemtype",
-    "Name":"http:\/\/schema.org\/JobPosting",
+    "Name":"https://schema.org/JobPosting",
     "Domain Bucket":"100K - 1M"
   },
   {
     "Class":"Itemtype",
-    "Name":"http:\/\/schema.org\/JoinAction",
+    "Name":"https://schema.org/JoinAction",
     "Domain Bucket":"1K - 10K"
   },
   {
     "Class":"Itemtype",
-    "Name":"http:\/\/schema.org\/Joint",
+    "Name":"https://schema.org/Joint",
     "Domain Bucket":"< 1K"
   },
   {
     "Class":"Itemtype",
-    "Name":"http:\/\/schema.org\/LakeBodyOfWater",
+    "Name":"https://schema.org/LakeBodyOfWater",
     "Domain Bucket":"< 1K"
   },
   {
     "Class":"Itemtype",
-    "Name":"http:\/\/schema.org\/Landform",
+    "Name":"https://schema.org/Landform",
     "Domain Bucket":"1K - 10K"
   },
   {
     "Class":"Itemtype",
-    "Name":"http:\/\/schema.org\/LandmarksOrHistoricalBuildings",
+    "Name":"https://schema.org/LandmarksOrHistoricalBuildings",
     "Domain Bucket":"1K - 10K"
   },
   {
     "Class":"Itemtype",
-    "Name":"http:\/\/schema.org\/Language",
+    "Name":"https://schema.org/Language",
     "Domain Bucket":"10K - 100K"
   },
   {
     "Class":"Itemtype",
-    "Name":"http:\/\/schema.org\/LearningResource",
+    "Name":"https://schema.org/LearningResource",
     "Domain Bucket":"1K - 10K"
   },
   {
     "Class":"Itemtype",
-    "Name":"http:\/\/schema.org\/LeaveAction",
+    "Name":"https://schema.org/LeaveAction",
     "Domain Bucket":"< 1K"
   },
   {
     "Class":"Itemtype",
-    "Name":"http:\/\/schema.org\/LegalForceStatus",
+    "Name":"https://schema.org/LegalForceStatus",
     "Domain Bucket":"< 1K"
   },
   {
     "Class":"Itemtype",
-    "Name":"http:\/\/schema.org\/LegalService",
+    "Name":"https://schema.org/LegalService",
     "Domain Bucket":"10K - 100K"
   },
   {
     "Class":"Itemtype",
-    "Name":"http:\/\/schema.org\/LegalValueLevel",
+    "Name":"https://schema.org/LegalValueLevel",
     "Domain Bucket":"< 1K"
   },
   {
     "Class":"Itemtype",
-    "Name":"http:\/\/schema.org\/Legislation",
+    "Name":"https://schema.org/Legislation",
     "Domain Bucket":"1K - 10K"
   },
   {
     "Class":"Itemtype",
-    "Name":"http:\/\/schema.org\/LegislationObject",
+    "Name":"https://schema.org/LegislationObject",
     "Domain Bucket":"1K - 10K"
   },
   {
     "Class":"Itemtype",
-    "Name":"http:\/\/schema.org\/LegislativeBuilding",
+    "Name":"https://schema.org/LegislativeBuilding",
     "Domain Bucket":"< 1K"
   },
   {
     "Class":"Itemtype",
-    "Name":"http:\/\/schema.org\/LendAction",
+    "Name":"https://schema.org/LendAction",
     "Domain Bucket":"< 1K"
   },
   {
     "Class":"Itemtype",
-    "Name":"http:\/\/schema.org\/Library",
+    "Name":"https://schema.org/Library",
     "Domain Bucket":"1K - 10K"
   },
   {
     "Class":"Itemtype",
-    "Name":"http:\/\/schema.org\/LibrarySystem",
+    "Name":"https://schema.org/LibrarySystem",
     "Domain Bucket":"< 1K"
   },
   {
     "Class":"Itemtype",
-    "Name":"http:\/\/schema.org\/LifestyleModification",
+    "Name":"https://schema.org/LifestyleModification",
     "Domain Bucket":"< 1K"
   },
   {
     "Class":"Itemtype",
-    "Name":"http:\/\/schema.org\/Ligament",
+    "Name":"https://schema.org/Ligament",
     "Domain Bucket":"< 1K"
   },
   {
     "Class":"Itemtype",
-    "Name":"http:\/\/schema.org\/LikeAction",
+    "Name":"https://schema.org/LikeAction",
     "Domain Bucket":"10K - 100K"
   },
   {
     "Class":"Itemtype",
-    "Name":"http:\/\/schema.org\/LinkRole",
+    "Name":"https://schema.org/LinkRole",
     "Domain Bucket":"< 1K"
   },
   {
     "Class":"Itemtype",
-    "Name":"http:\/\/schema.org\/LiquorStore",
+    "Name":"https://schema.org/LiquorStore",
     "Domain Bucket":"1K - 10K"
   },
   {
     "Class":"Itemtype",
-    "Name":"http:\/\/schema.org\/ListItem",
+    "Name":"https://schema.org/ListItem",
     "Domain Bucket":"10M+"
   },
   {
     "Class":"Itemtype",
-    "Name":"http:\/\/schema.org\/ListenAction",
+    "Name":"https://schema.org/ListenAction",
     "Domain Bucket":"1K - 10K"
   },
   {
     "Class":"Itemtype",
-    "Name":"http:\/\/schema.org\/Literal",
+    "Name":"https://schema.org/Literal",
     "Domain Bucket":"< 1K"
   },
   {
     "Class":"Itemtype",
-    "Name":"http:\/\/schema.org\/LiteraryEvent",
+    "Name":"https://schema.org/LiteraryEvent",
     "Domain Bucket":"< 1K"
   },
   {
     "Class":"Itemtype",
-    "Name":"http:\/\/schema.org\/LiveBlogPosting",
+    "Name":"https://schema.org/LiveBlogPosting",
     "Domain Bucket":"10K - 100K"
   },
   {
     "Class":"Itemtype",
-    "Name":"http:\/\/schema.org\/LoanOrCredit",
+    "Name":"https://schema.org/LoanOrCredit",
     "Domain Bucket":"1K - 10K"
   },
   {
     "Class":"Itemtype",
-    "Name":"http:\/\/schema.org\/LocalBusiness",
+    "Name":"https://schema.org/LocalBusiness",
     "Domain Bucket":"1M - 10M"
   },
   {
     "Class":"Itemtype",
-    "Name":"http:\/\/schema.org\/LocationFeatureSpecification",
+    "Name":"https://schema.org/LocationFeatureSpecification",
     "Domain Bucket":"100K - 1M"
   },
   {
     "Class":"Itemtype",
-    "Name":"http:\/\/schema.org\/Locksmith",
+    "Name":"https://schema.org/Locksmith",
     "Domain Bucket":"10K - 100K"
   },
   {
     "Class":"Itemtype",
-    "Name":"http:\/\/schema.org\/LodgingBusiness",
+    "Name":"https://schema.org/LodgingBusiness",
     "Domain Bucket":"10K - 100K"
   },
   {
     "Class":"Itemtype",
-    "Name":"http:\/\/schema.org\/LodgingReservation",
+    "Name":"https://schema.org/LodgingReservation",
     "Domain Bucket":"1K - 10K"
   },
   {
     "Class":"Itemtype",
-    "Name":"http:\/\/schema.org\/LoginAction",
+    "Name":"https://schema.org/LoginAction",
     "Domain Bucket":"1K - 10K"
   },
   {
     "Class":"Itemtype",
-    "Name":"http:\/\/schema.org\/LoseAction",
+    "Name":"https://schema.org/LoseAction",
     "Domain Bucket":"< 1K"
   },
   {
     "Class":"Itemtype",
-    "Name":"http:\/\/schema.org\/LymphaticVessel",
+    "Name":"https://schema.org/LymphaticVessel",
     "Domain Bucket":"< 1K"
   },
   {
     "Class":"Itemtype",
-    "Name":"http:\/\/schema.org\/Manuscript",
+    "Name":"https://schema.org/Manuscript",
     "Domain Bucket":"< 1K"
   },
   {
     "Class":"Itemtype",
-    "Name":"http:\/\/schema.org\/Map",
+    "Name":"https://schema.org/Map",
     "Domain Bucket":"10K - 100K"
   },
   {
     "Class":"Itemtype",
-    "Name":"http:\/\/schema.org\/MapCategoryType",
+    "Name":"https://schema.org/MapCategoryType",
     "Domain Bucket":"< 1K"
   },
   {
     "Class":"Itemtype",
-    "Name":"http:\/\/schema.org\/MarryAction",
+    "Name":"https://schema.org/MarryAction",
     "Domain Bucket":"< 1K"
   },
   {
     "Class":"Itemtype",
-    "Name":"http:\/\/schema.org\/Mass",
+    "Name":"https://schema.org/Mass",
     "Domain Bucket":"< 1K"
   },
   {
     "Class":"Itemtype",
-    "Name":"http:\/\/schema.org\/MathSolver",
+    "Name":"https://schema.org/MathSolver",
     "Domain Bucket":"< 1K"
   },
   {
     "Class":"Itemtype",
-    "Name":"http:\/\/schema.org\/MaximumDoseSchedule",
+    "Name":"https://schema.org/MaximumDoseSchedule",
     "Domain Bucket":"< 1K"
   },
   {
     "Class":"Itemtype",
-    "Name":"http:\/\/schema.org\/MeasurementMethodEnum",
+    "Name":"https://schema.org/MeasurementMethodEnum",
     "Domain Bucket":"< 1K"
   },
   {
     "Class":"Itemtype",
-    "Name":"http:\/\/schema.org\/MeasurementTypeEnumeration",
+    "Name":"https://schema.org/MeasurementTypeEnumeration",
     "Domain Bucket":"< 1K"
   },
   {
     "Class":"Itemtype",
-    "Name":"http:\/\/schema.org\/MediaEnumeration",
+    "Name":"https://schema.org/MediaEnumeration",
     "Domain Bucket":"< 1K"
   },
   {
     "Class":"Itemtype",
-    "Name":"http:\/\/schema.org\/MediaGallery",
+    "Name":"https://schema.org/MediaGallery",
     "Domain Bucket":"1K - 10K"
   },
   {
     "Class":"Itemtype",
-    "Name":"http:\/\/schema.org\/MediaManipulationRatingEnumeration",
+    "Name":"https://schema.org/MediaManipulationRatingEnumeration",
     "Domain Bucket":"< 1K"
   },
   {
     "Class":"Itemtype",
-    "Name":"http:\/\/schema.org\/MediaObject",
+    "Name":"https://schema.org/MediaObject",
     "Domain Bucket":"100K - 1M"
   },
   {
     "Class":"Itemtype",
-    "Name":"http:\/\/schema.org\/MediaReview",
+    "Name":"https://schema.org/MediaReview",
     "Domain Bucket":"< 1K"
   },
   {
     "Class":"Itemtype",
-    "Name":"http:\/\/schema.org\/MediaReviewItem",
+    "Name":"https://schema.org/MediaReviewItem",
     "Domain Bucket":"< 1K"
   },
   {
     "Class":"Itemtype",
-    "Name":"http:\/\/schema.org\/MediaSubscription",
+    "Name":"https://schema.org/MediaSubscription",
     "Domain Bucket":"< 1K"
   },
   {
     "Class":"Itemtype",
-    "Name":"http:\/\/schema.org\/MedicalAudience",
+    "Name":"https://schema.org/MedicalAudience",
     "Domain Bucket":"1K - 10K"
   },
   {
     "Class":"Itemtype",
-    "Name":"http:\/\/schema.org\/MedicalAudienceType",
+    "Name":"https://schema.org/MedicalAudienceType",
     "Domain Bucket":"< 1K"
   },
   {
     "Class":"Itemtype",
-    "Name":"http:\/\/schema.org\/MedicalBusiness",
+    "Name":"https://schema.org/MedicalBusiness",
     "Domain Bucket":"10K - 100K"
   },
   {
     "Class":"Itemtype",
-    "Name":"http:\/\/schema.org\/MedicalCause",
+    "Name":"https://schema.org/MedicalCause",
     "Domain Bucket":"1K - 10K"
   },
   {
     "Class":"Itemtype",
-    "Name":"http:\/\/schema.org\/MedicalClinic",
+    "Name":"https://schema.org/MedicalClinic",
     "Domain Bucket":"10K - 100K"
   },
   {
     "Class":"Itemtype",
-    "Name":"http:\/\/schema.org\/MedicalCode",
+    "Name":"https://schema.org/MedicalCode",
     "Domain Bucket":"1K - 10K"
   },
   {
     "Class":"Itemtype",
-    "Name":"http:\/\/schema.org\/MedicalCondition",
+    "Name":"https://schema.org/MedicalCondition",
     "Domain Bucket":"10K - 100K"
   },
   {
     "Class":"Itemtype",
-    "Name":"http:\/\/schema.org\/MedicalConditionStage",
+    "Name":"https://schema.org/MedicalConditionStage",
     "Domain Bucket":"< 1K"
   },
   {
     "Class":"Itemtype",
-    "Name":"http:\/\/schema.org\/MedicalContraindication",
+    "Name":"https://schema.org/MedicalContraindication",
     "Domain Bucket":"< 1K"
   },
   {
     "Class":"Itemtype",
-    "Name":"http:\/\/schema.org\/MedicalDevice",
+    "Name":"https://schema.org/MedicalDevice",
     "Domain Bucket":"1K - 10K"
   },
   {
     "Class":"Itemtype",
-    "Name":"http:\/\/schema.org\/MedicalDevicePurpose",
+    "Name":"https://schema.org/MedicalDevicePurpose",
     "Domain Bucket":"< 1K"
   },
   {
     "Class":"Itemtype",
-    "Name":"http:\/\/schema.org\/MedicalEntity",
+    "Name":"https://schema.org/MedicalEntity",
     "Domain Bucket":"1K - 10K"
   },
   {
     "Class":"Itemtype",
-    "Name":"http:\/\/schema.org\/MedicalEnumeration",
+    "Name":"https://schema.org/MedicalEnumeration",
     "Domain Bucket":"< 1K"
   },
   {
     "Class":"Itemtype",
-    "Name":"http:\/\/schema.org\/MedicalEvidenceLevel",
+    "Name":"https://schema.org/MedicalEvidenceLevel",
     "Domain Bucket":"< 1K"
   },
   {
     "Class":"Itemtype",
-    "Name":"http:\/\/schema.org\/MedicalGuideline",
+    "Name":"https://schema.org/MedicalGuideline",
     "Domain Bucket":"< 1K"
   },
   {
     "Class":"Itemtype",
-    "Name":"http:\/\/schema.org\/MedicalGuidelineContraindication",
+    "Name":"https://schema.org/MedicalGuidelineContraindication",
     "Domain Bucket":"< 1K"
   },
   {
     "Class":"Itemtype",
-    "Name":"http:\/\/schema.org\/MedicalGuidelineRecommendation",
+    "Name":"https://schema.org/MedicalGuidelineRecommendation",
     "Domain Bucket":"< 1K"
   },
   {
     "Class":"Itemtype",
-    "Name":"http:\/\/schema.org\/MedicalImagingTechnique",
+    "Name":"https://schema.org/MedicalImagingTechnique",
     "Domain Bucket":"< 1K"
   },
   {
     "Class":"Itemtype",
-    "Name":"http:\/\/schema.org\/MedicalIndication",
+    "Name":"https://schema.org/MedicalIndication",
     "Domain Bucket":"1K - 10K"
   },
   {
     "Class":"Itemtype",
-    "Name":"http:\/\/schema.org\/MedicalIntangible",
+    "Name":"https://schema.org/MedicalIntangible",
     "Domain Bucket":"< 1K"
   },
   {
     "Class":"Itemtype",
-    "Name":"http:\/\/schema.org\/MedicalObservationalStudy",
+    "Name":"https://schema.org/MedicalObservationalStudy",
     "Domain Bucket":"< 1K"
   },
   {
     "Class":"Itemtype",
-    "Name":"http:\/\/schema.org\/MedicalObservationalStudyDesign",
+    "Name":"https://schema.org/MedicalObservationalStudyDesign",
     "Domain Bucket":"< 1K"
   },
   {
     "Class":"Itemtype",
-    "Name":"http:\/\/schema.org\/MedicalOrganization",
+    "Name":"https://schema.org/MedicalOrganization",
     "Domain Bucket":"10K - 100K"
   },
   {
     "Class":"Itemtype",
-    "Name":"http:\/\/schema.org\/MedicalProcedure",
+    "Name":"https://schema.org/MedicalProcedure",
     "Domain Bucket":"10K - 100K"
   },
   {
     "Class":"Itemtype",
-    "Name":"http:\/\/schema.org\/MedicalProcedureType",
+    "Name":"https://schema.org/MedicalProcedureType",
     "Domain Bucket":"< 1K"
   },
   {
     "Class":"Itemtype",
-    "Name":"http:\/\/schema.org\/MedicalRiskCalculator",
+    "Name":"https://schema.org/MedicalRiskCalculator",
     "Domain Bucket":"< 1K"
   },
   {
     "Class":"Itemtype",
-    "Name":"http:\/\/schema.org\/MedicalRiskEstimator",
+    "Name":"https://schema.org/MedicalRiskEstimator",
     "Domain Bucket":"< 1K"
   },
   {
     "Class":"Itemtype",
-    "Name":"http:\/\/schema.org\/MedicalRiskFactor",
+    "Name":"https://schema.org/MedicalRiskFactor",
     "Domain Bucket":"1K - 10K"
   },
   {
     "Class":"Itemtype",
-    "Name":"http:\/\/schema.org\/MedicalRiskScore",
+    "Name":"https://schema.org/MedicalRiskScore",
     "Domain Bucket":"< 1K"
   },
   {
     "Class":"Itemtype",
-    "Name":"http:\/\/schema.org\/MedicalScholarlyArticle",
+    "Name":"https://schema.org/MedicalScholarlyArticle",
     "Domain Bucket":"1K - 10K"
   },
   {
     "Class":"Itemtype",
-    "Name":"http:\/\/schema.org\/MedicalSign",
+    "Name":"https://schema.org/MedicalSign",
     "Domain Bucket":"< 1K"
   },
   {
     "Class":"Itemtype",
-    "Name":"http:\/\/schema.org\/MedicalSignOrSymptom",
+    "Name":"https://schema.org/MedicalSignOrSymptom",
     "Domain Bucket":"1K - 10K"
   },
   {
     "Class":"Itemtype",
-    "Name":"http:\/\/schema.org\/MedicalSpecialty",
+    "Name":"https://schema.org/MedicalSpecialty",
     "Domain Bucket":"10K - 100K"
   },
   {
     "Class":"Itemtype",
-    "Name":"http:\/\/schema.org\/MedicalStudy",
+    "Name":"https://schema.org/MedicalStudy",
     "Domain Bucket":"1K - 10K"
   },
   {
     "Class":"Itemtype",
-    "Name":"http:\/\/schema.org\/MedicalStudyStatus",
+    "Name":"https://schema.org/MedicalStudyStatus",
     "Domain Bucket":"< 1K"
   },
   {
     "Class":"Itemtype",
-    "Name":"http:\/\/schema.org\/MedicalSymptom",
+    "Name":"https://schema.org/MedicalSymptom",
     "Domain Bucket":"1K - 10K"
   },
   {
     "Class":"Itemtype",
-    "Name":"http:\/\/schema.org\/MedicalTest",
+    "Name":"https://schema.org/MedicalTest",
     "Domain Bucket":"1K - 10K"
   },
   {
     "Class":"Itemtype",
-    "Name":"http:\/\/schema.org\/MedicalTestPanel",
+    "Name":"https://schema.org/MedicalTestPanel",
     "Domain Bucket":"< 1K"
   },
   {
     "Class":"Itemtype",
-    "Name":"http:\/\/schema.org\/MedicalTherapy",
+    "Name":"https://schema.org/MedicalTherapy",
     "Domain Bucket":"10K - 100K"
   },
   {
     "Class":"Itemtype",
-    "Name":"http:\/\/schema.org\/MedicalTrial",
+    "Name":"https://schema.org/MedicalTrial",
     "Domain Bucket":"< 1K"
   },
   {
     "Class":"Itemtype",
-    "Name":"http:\/\/schema.org\/MedicalTrialDesign",
+    "Name":"https://schema.org/MedicalTrialDesign",
     "Domain Bucket":"< 1K"
   },
   {
     "Class":"Itemtype",
-    "Name":"http:\/\/schema.org\/MedicalWebPage",
+    "Name":"https://schema.org/MedicalWebPage",
     "Domain Bucket":"10K - 100K"
   },
   {
     "Class":"Itemtype",
-    "Name":"http:\/\/schema.org\/MedicineSystem",
+    "Name":"https://schema.org/MedicineSystem",
     "Domain Bucket":"< 1K"
   },
   {
     "Class":"Itemtype",
-    "Name":"http:\/\/schema.org\/MeetingRoom",
+    "Name":"https://schema.org/MeetingRoom",
     "Domain Bucket":"1K - 10K"
   },
   {
     "Class":"Itemtype",
-    "Name":"http:\/\/schema.org\/MemberProgram",
+    "Name":"https://schema.org/MemberProgram",
     "Domain Bucket":"1K - 10K"
   },
   {
     "Class":"Itemtype",
-    "Name":"http:\/\/schema.org\/MemberProgramTier",
+    "Name":"https://schema.org/MemberProgramTier",
     "Domain Bucket":"1K - 10K"
   },
   {
     "Class":"Itemtype",
-    "Name":"http:\/\/schema.org\/MensClothingStore",
+    "Name":"https://schema.org/MensClothingStore",
     "Domain Bucket":"< 1K"
   },
   {
     "Class":"Itemtype",
-    "Name":"http:\/\/schema.org\/Menu",
+    "Name":"https://schema.org/Menu",
     "Domain Bucket":"100K - 1M"
   },
   {
     "Class":"Itemtype",
-    "Name":"http:\/\/schema.org\/MenuItem",
+    "Name":"https://schema.org/MenuItem",
     "Domain Bucket":"10K - 100K"
   },
   {
     "Class":"Itemtype",
-    "Name":"http:\/\/schema.org\/MenuSection",
+    "Name":"https://schema.org/MenuSection",
     "Domain Bucket":"10K - 100K"
   },
   {
     "Class":"Itemtype",
-    "Name":"http:\/\/schema.org\/MerchantReturnEnumeration",
+    "Name":"https://schema.org/MerchantReturnEnumeration",
     "Domain Bucket":"< 1K"
   },
   {
     "Class":"Itemtype",
-    "Name":"http:\/\/schema.org\/MerchantReturnPolicy",
+    "Name":"https://schema.org/MerchantReturnPolicy",
     "Domain Bucket":"100K - 1M"
   },
   {
     "Class":"Itemtype",
-    "Name":"http:\/\/schema.org\/MerchantReturnPolicySeasonalOverride",
+    "Name":"https://schema.org/MerchantReturnPolicySeasonalOverride",
     "Domain Bucket":"< 1K"
   },
   {
     "Class":"Itemtype",
-    "Name":"http:\/\/schema.org\/Message",
+    "Name":"https://schema.org/Message",
     "Domain Bucket":"< 1K"
   },
   {
     "Class":"Itemtype",
-    "Name":"http:\/\/schema.org\/MiddleSchool",
+    "Name":"https://schema.org/MiddleSchool",
     "Domain Bucket":"< 1K"
   },
   {
     "Class":"Itemtype",
-    "Name":"http:\/\/schema.org\/Midwifery",
+    "Name":"https://schema.org/Midwifery",
     "Domain Bucket":"< 1K"
   },
   {
     "Class":"Itemtype",
-    "Name":"http:\/\/schema.org\/MobileApplication",
+    "Name":"https://schema.org/MobileApplication",
     "Domain Bucket":"10K - 100K"
   },
   {
     "Class":"Itemtype",
-    "Name":"http:\/\/schema.org\/MobilePhoneStore",
+    "Name":"https://schema.org/MobilePhoneStore",
     "Domain Bucket":"1K - 10K"
   },
   {
     "Class":"Itemtype",
-    "Name":"http:\/\/schema.org\/MolecularEntity",
+    "Name":"https://schema.org/MolecularEntity",
     "Domain Bucket":"< 1K"
   },
   {
     "Class":"Itemtype",
-    "Name":"http:\/\/schema.org\/MonetaryAmount",
+    "Name":"https://schema.org/MonetaryAmount",
     "Domain Bucket":"100K - 1M"
   },
   {
     "Class":"Itemtype",
-    "Name":"http:\/\/schema.org\/MonetaryAmountDistribution",
+    "Name":"https://schema.org/MonetaryAmountDistribution",
     "Domain Bucket":"1K - 10K"
   },
   {
     "Class":"Itemtype",
-    "Name":"http:\/\/schema.org\/MonetaryGrant",
+    "Name":"https://schema.org/MonetaryGrant",
     "Domain Bucket":"1K - 10K"
   },
   {
     "Class":"Itemtype",
-    "Name":"http:\/\/schema.org\/MoneyTransfer",
+    "Name":"https://schema.org/MoneyTransfer",
     "Domain Bucket":"< 1K"
   },
   {
     "Class":"Itemtype",
-    "Name":"http:\/\/schema.org\/MortgageLoan",
+    "Name":"https://schema.org/MortgageLoan",
     "Domain Bucket":"< 1K"
   },
   {
     "Class":"Itemtype",
-    "Name":"http:\/\/schema.org\/Mosque",
+    "Name":"https://schema.org/Mosque",
     "Domain Bucket":"< 1K"
   },
   {
     "Class":"Itemtype",
-    "Name":"http:\/\/schema.org\/Motel",
+    "Name":"https://schema.org/Motel",
     "Domain Bucket":"< 1K"
   },
   {
     "Class":"Itemtype",
-    "Name":"http:\/\/schema.org\/Motorcycle",
+    "Name":"https://schema.org/Motorcycle",
     "Domain Bucket":"1K - 10K"
   },
   {
     "Class":"Itemtype",
-    "Name":"http:\/\/schema.org\/MotorcycleDealer",
+    "Name":"https://schema.org/MotorcycleDealer",
     "Domain Bucket":"1K - 10K"
   },
   {
     "Class":"Itemtype",
-    "Name":"http:\/\/schema.org\/MotorcycleRepair",
+    "Name":"https://schema.org/MotorcycleRepair",
     "Domain Bucket":"< 1K"
   },
   {
     "Class":"Itemtype",
-    "Name":"http:\/\/schema.org\/MotorizedBicycle",
+    "Name":"https://schema.org/MotorizedBicycle",
     "Domain Bucket":"< 1K"
   },
   {
     "Class":"Itemtype",
-    "Name":"http:\/\/schema.org\/Mountain",
+    "Name":"https://schema.org/Mountain",
     "Domain Bucket":"< 1K"
   },
   {
     "Class":"Itemtype",
-    "Name":"http:\/\/schema.org\/MoveAction",
+    "Name":"https://schema.org/MoveAction",
     "Domain Bucket":"< 1K"
   },
   {
     "Class":"Itemtype",
-    "Name":"http:\/\/schema.org\/Movie",
+    "Name":"https://schema.org/Movie",
     "Domain Bucket":"10K - 100K"
   },
   {
     "Class":"Itemtype",
-    "Name":"http:\/\/schema.org\/MovieClip",
+    "Name":"https://schema.org/MovieClip",
     "Domain Bucket":"< 1K"
   },
   {
     "Class":"Itemtype",
-    "Name":"http:\/\/schema.org\/MovieRentalStore",
+    "Name":"https://schema.org/MovieRentalStore",
     "Domain Bucket":"< 1K"
   },
   {
     "Class":"Itemtype",
-    "Name":"http:\/\/schema.org\/MovieSeries",
+    "Name":"https://schema.org/MovieSeries",
     "Domain Bucket":"< 1K"
   },
   {
     "Class":"Itemtype",
-    "Name":"http:\/\/schema.org\/MovieTheater",
+    "Name":"https://schema.org/MovieTheater",
     "Domain Bucket":"1K - 10K"
   },
   {
     "Class":"Itemtype",
-    "Name":"http:\/\/schema.org\/MovingCompany",
+    "Name":"https://schema.org/MovingCompany",
     "Domain Bucket":"10K - 100K"
   },
   {
     "Class":"Itemtype",
-    "Name":"http:\/\/schema.org\/Muscle",
+    "Name":"https://schema.org/Muscle",
     "Domain Bucket":"< 1K"
   },
   {
     "Class":"Itemtype",
-    "Name":"http:\/\/schema.org\/Museum",
+    "Name":"https://schema.org/Museum",
     "Domain Bucket":"1K - 10K"
   },
   {
     "Class":"Itemtype",
-    "Name":"http:\/\/schema.org\/MusicAlbum",
+    "Name":"https://schema.org/MusicAlbum",
     "Domain Bucket":"10K - 100K"
   },
   {
     "Class":"Itemtype",
-    "Name":"http:\/\/schema.org\/MusicAlbumProductionType",
+    "Name":"https://schema.org/MusicAlbumProductionType",
     "Domain Bucket":"< 1K"
   },
   {
     "Class":"Itemtype",
-    "Name":"http:\/\/schema.org\/MusicAlbumReleaseType",
+    "Name":"https://schema.org/MusicAlbumReleaseType",
     "Domain Bucket":"< 1K"
   },
   {
     "Class":"Itemtype",
-    "Name":"http:\/\/schema.org\/MusicComposition",
+    "Name":"https://schema.org/MusicComposition",
     "Domain Bucket":"1K - 10K"
   },
   {
     "Class":"Itemtype",
-    "Name":"http:\/\/schema.org\/MusicEvent",
+    "Name":"https://schema.org/MusicEvent",
     "Domain Bucket":"10K - 100K"
   },
   {
     "Class":"Itemtype",
-    "Name":"http:\/\/schema.org\/MusicGroup",
+    "Name":"https://schema.org/MusicGroup",
     "Domain Bucket":"10K - 100K"
   },
   {
     "Class":"Itemtype",
-    "Name":"http:\/\/schema.org\/MusicPlaylist",
+    "Name":"https://schema.org/MusicPlaylist",
     "Domain Bucket":"1K - 10K"
   },
   {
     "Class":"Itemtype",
-    "Name":"http:\/\/schema.org\/MusicRecording",
+    "Name":"https://schema.org/MusicRecording",
     "Domain Bucket":"10K - 100K"
   },
   {
     "Class":"Itemtype",
-    "Name":"http:\/\/schema.org\/MusicRelease",
+    "Name":"https://schema.org/MusicRelease",
     "Domain Bucket":"1K - 10K"
   },
   {
     "Class":"Itemtype",
-    "Name":"http:\/\/schema.org\/MusicReleaseFormatType",
+    "Name":"https://schema.org/MusicReleaseFormatType",
     "Domain Bucket":"< 1K"
   },
   {
     "Class":"Itemtype",
-    "Name":"http:\/\/schema.org\/MusicStore",
+    "Name":"https://schema.org/MusicStore",
     "Domain Bucket":"1K - 10K"
   },
   {
     "Class":"Itemtype",
-    "Name":"http:\/\/schema.org\/MusicVenue",
+    "Name":"https://schema.org/MusicVenue",
     "Domain Bucket":"1K - 10K"
   },
   {
     "Class":"Itemtype",
-    "Name":"http:\/\/schema.org\/MusicVideoObject",
+    "Name":"https://schema.org/MusicVideoObject",
     "Domain Bucket":"< 1K"
   },
   {
     "Class":"Itemtype",
-    "Name":"http:\/\/schema.org\/NGO",
+    "Name":"https://schema.org/NGO",
     "Domain Bucket":"10K - 100K"
   },
   {
     "Class":"Itemtype",
-    "Name":"http:\/\/schema.org\/NLNonprofitType",
+    "Name":"https://schema.org/NLNonprofitType",
     "Domain Bucket":"< 1K"
   },
   {
     "Class":"Itemtype",
-    "Name":"http:\/\/schema.org\/NailSalon",
+    "Name":"https://schema.org/NailSalon",
     "Domain Bucket":"1K - 10K"
   },
   {
     "Class":"Itemtype",
-    "Name":"http:\/\/schema.org\/Nerve",
+    "Name":"https://schema.org/Nerve",
     "Domain Bucket":"< 1K"
   },
   {
     "Class":"Itemtype",
-    "Name":"http:\/\/schema.org\/NewsArticle",
+    "Name":"https://schema.org/NewsArticle",
     "Domain Bucket":"100K - 1M"
   },
   {
     "Class":"Itemtype",
-    "Name":"http:\/\/schema.org\/NewsMediaOrganization",
+    "Name":"https://schema.org/NewsMediaOrganization",
     "Domain Bucket":"10K - 100K"
   },
   {
     "Class":"Itemtype",
-    "Name":"http:\/\/schema.org\/Newspaper",
+    "Name":"https://schema.org/Newspaper",
     "Domain Bucket":"< 1K"
   },
   {
     "Class":"Itemtype",
-    "Name":"http:\/\/schema.org\/NightClub",
+    "Name":"https://schema.org/NightClub",
     "Domain Bucket":"1K - 10K"
   },
   {
     "Class":"Itemtype",
-    "Name":"http:\/\/schema.org\/NonprofitType",
+    "Name":"https://schema.org/NonprofitType",
     "Domain Bucket":"< 1K"
   },
   {
     "Class":"Itemtype",
-    "Name":"http:\/\/schema.org\/Notary",
+    "Name":"https://schema.org/Notary",
     "Domain Bucket":"1K - 10K"
   },
   {
     "Class":"Itemtype",
-    "Name":"http:\/\/schema.org\/NoteDigitalDocument",
+    "Name":"https://schema.org/NoteDigitalDocument",
     "Domain Bucket":"< 1K"
   },
   {
     "Class":"Itemtype",
-    "Name":"http:\/\/schema.org\/Number",
+    "Name":"https://schema.org/Number",
     "Domain Bucket":"< 1K"
   },
   {
     "Class":"Itemtype",
-    "Name":"http:\/\/schema.org\/Nursing",
+    "Name":"https://schema.org/Nursing",
     "Domain Bucket":"< 1K"
   },
   {
     "Class":"Itemtype",
-    "Name":"http:\/\/schema.org\/NutritionInformation",
+    "Name":"https://schema.org/NutritionInformation",
     "Domain Bucket":"10K - 100K"
   },
   {
     "Class":"Itemtype",
-    "Name":"http:\/\/schema.org\/Observation",
+    "Name":"https://schema.org/Observation",
     "Domain Bucket":"< 1K"
   },
   {
     "Class":"Itemtype",
-    "Name":"http:\/\/schema.org\/Obstetric",
+    "Name":"https://schema.org/Obstetric",
     "Domain Bucket":"< 1K"
   },
   {
     "Class":"Itemtype",
-    "Name":"http:\/\/schema.org\/Occupation",
+    "Name":"https://schema.org/Occupation",
     "Domain Bucket":"10K - 100K"
   },
   {
     "Class":"Itemtype",
-    "Name":"http:\/\/schema.org\/OccupationalExperienceRequirements",
+    "Name":"https://schema.org/OccupationalExperienceRequirements",
     "Domain Bucket":"1K - 10K"
   },
   {
     "Class":"Itemtype",
-    "Name":"http:\/\/schema.org\/OccupationalTherapy",
+    "Name":"https://schema.org/OccupationalTherapy",
     "Domain Bucket":"< 1K"
   },
   {
     "Class":"Itemtype",
-    "Name":"http:\/\/schema.org\/OceanBodyOfWater",
+    "Name":"https://schema.org/OceanBodyOfWater",
     "Domain Bucket":"< 1K"
   },
   {
     "Class":"Itemtype",
-    "Name":"http:\/\/schema.org\/Offer",
+    "Name":"https://schema.org/Offer",
     "Domain Bucket":"1M - 10M"
   },
   {
     "Class":"Itemtype",
-    "Name":"http:\/\/schema.org\/OfferCatalog",
+    "Name":"https://schema.org/OfferCatalog",
     "Domain Bucket":"100K - 1M"
   },
   {
     "Class":"Itemtype",
-    "Name":"http:\/\/schema.org\/OfferForLease",
+    "Name":"https://schema.org/OfferForLease",
     "Domain Bucket":"1K - 10K"
   },
   {
     "Class":"Itemtype",
-    "Name":"http:\/\/schema.org\/OfferForPurchase",
+    "Name":"https://schema.org/OfferForPurchase",
     "Domain Bucket":"1K - 10K"
   },
   {
     "Class":"Itemtype",
-    "Name":"http:\/\/schema.org\/OfferItemCondition",
+    "Name":"https://schema.org/OfferItemCondition",
     "Domain Bucket":"1K - 10K"
   },
   {
     "Class":"Itemtype",
-    "Name":"http:\/\/schema.org\/OfferShippingDetails",
+    "Name":"https://schema.org/OfferShippingDetails",
     "Domain Bucket":"100K - 1M"
   },
   {
     "Class":"Itemtype",
-    "Name":"http:\/\/schema.org\/OfficeEquipmentStore",
+    "Name":"https://schema.org/OfficeEquipmentStore",
     "Domain Bucket":"1K - 10K"
   },
   {
     "Class":"Itemtype",
-    "Name":"http:\/\/schema.org\/OnDemandEvent",
+    "Name":"https://schema.org/OnDemandEvent",
     "Domain Bucket":"< 1K"
   },
   {
     "Class":"Itemtype",
-    "Name":"http:\/\/schema.org\/Oncologic",
+    "Name":"https://schema.org/Oncologic",
     "Domain Bucket":"< 1K"
   },
   {
     "Class":"Itemtype",
-    "Name":"http:\/\/schema.org\/OnlineBusiness",
+    "Name":"https://schema.org/OnlineBusiness",
     "Domain Bucket":"10K - 100K"
   },
   {
     "Class":"Itemtype",
-    "Name":"http:\/\/schema.org\/OnlineMarketplace",
+    "Name":"https://schema.org/OnlineMarketplace",
     "Domain Bucket":"< 1K"
   },
   {
     "Class":"Itemtype",
-    "Name":"http:\/\/schema.org\/OnlineStore",
+    "Name":"https://schema.org/OnlineStore",
     "Domain Bucket":"100K - 1M"
   },
   {
     "Class":"Itemtype",
-    "Name":"http:\/\/schema.org\/OpeningHoursSpecification",
+    "Name":"https://schema.org/OpeningHoursSpecification",
     "Domain Bucket":"1M - 10M"
   },
   {
     "Class":"Itemtype",
-    "Name":"http:\/\/schema.org\/OperatingSystem",
+    "Name":"https://schema.org/OperatingSystem",
     "Domain Bucket":"< 1K"
   },
   {
     "Class":"Itemtype",
-    "Name":"http:\/\/schema.org\/OpinionNewsArticle",
+    "Name":"https://schema.org/OpinionNewsArticle",
     "Domain Bucket":"1K - 10K"
   },
   {
     "Class":"Itemtype",
-    "Name":"http:\/\/schema.org\/Optician",
+    "Name":"https://schema.org/Optician",
     "Domain Bucket":"1K - 10K"
   },
   {
     "Class":"Itemtype",
-    "Name":"http:\/\/schema.org\/Optometric",
+    "Name":"https://schema.org/Optometric",
     "Domain Bucket":"1K - 10K"
   },
   {
     "Class":"Itemtype",
-    "Name":"http:\/\/schema.org\/Order",
+    "Name":"https://schema.org/Order",
     "Domain Bucket":"< 1K"
   },
   {
     "Class":"Itemtype",
-    "Name":"http:\/\/schema.org\/OrderAction",
+    "Name":"https://schema.org/OrderAction",
     "Domain Bucket":"10K - 100K"
   },
   {
     "Class":"Itemtype",
-    "Name":"http:\/\/schema.org\/OrderItem",
+    "Name":"https://schema.org/OrderItem",
     "Domain Bucket":"< 1K"
   },
   {
     "Class":"Itemtype",
-    "Name":"http:\/\/schema.org\/OrderStatus",
+    "Name":"https://schema.org/OrderStatus",
     "Domain Bucket":"< 1K"
   },
   {
     "Class":"Itemtype",
-    "Name":"http:\/\/schema.org\/Organization",
+    "Name":"https://schema.org/Organization",
     "Domain Bucket":"10M+"
   },
   {
     "Class":"Itemtype",
-    "Name":"http:\/\/schema.org\/OrganizationRole",
+    "Name":"https://schema.org/OrganizationRole",
     "Domain Bucket":"1K - 10K"
   },
   {
     "Class":"Itemtype",
-    "Name":"http:\/\/schema.org\/OrganizeAction",
+    "Name":"https://schema.org/OrganizeAction",
     "Domain Bucket":"< 1K"
   },
   {
     "Class":"Itemtype",
-    "Name":"http:\/\/schema.org\/Otolaryngologic",
+    "Name":"https://schema.org/Otolaryngologic",
     "Domain Bucket":"< 1K"
   },
   {
     "Class":"Itemtype",
-    "Name":"http:\/\/schema.org\/OutletStore",
+    "Name":"https://schema.org/OutletStore",
     "Domain Bucket":"< 1K"
   },
   {
     "Class":"Itemtype",
-    "Name":"http:\/\/schema.org\/OwnershipInfo",
+    "Name":"https://schema.org/OwnershipInfo",
     "Domain Bucket":"< 1K"
   },
   {
     "Class":"Itemtype",
-    "Name":"http:\/\/schema.org\/PaintAction",
+    "Name":"https://schema.org/PaintAction",
     "Domain Bucket":"< 1K"
   },
   {
     "Class":"Itemtype",
-    "Name":"http:\/\/schema.org\/Painting",
+    "Name":"https://schema.org/Painting",
     "Domain Bucket":"< 1K"
   },
   {
     "Class":"Itemtype",
-    "Name":"http:\/\/schema.org\/PalliativeProcedure",
+    "Name":"https://schema.org/PalliativeProcedure",
     "Domain Bucket":"< 1K"
   },
   {
     "Class":"Itemtype",
-    "Name":"http:\/\/schema.org\/ParcelDelivery",
+    "Name":"https://schema.org/ParcelDelivery",
     "Domain Bucket":"< 1K"
   },
   {
     "Class":"Itemtype",
-    "Name":"http:\/\/schema.org\/ParentAudience",
+    "Name":"https://schema.org/ParentAudience",
     "Domain Bucket":"< 1K"
   },
   {
     "Class":"Itemtype",
-    "Name":"http:\/\/schema.org\/Park",
+    "Name":"https://schema.org/Park",
     "Domain Bucket":"1K - 10K"
   },
   {
     "Class":"Itemtype",
-    "Name":"http:\/\/schema.org\/ParkingFacility",
+    "Name":"https://schema.org/ParkingFacility",
     "Domain Bucket":"1K - 10K"
   },
   {
     "Class":"Itemtype",
-    "Name":"http:\/\/schema.org\/PathologyTest",
+    "Name":"https://schema.org/PathologyTest",
     "Domain Bucket":"< 1K"
   },
   {
     "Class":"Itemtype",
-    "Name":"http:\/\/schema.org\/Patient",
+    "Name":"https://schema.org/Patient",
     "Domain Bucket":"1K - 10K"
   },
   {
     "Class":"Itemtype",
-    "Name":"http:\/\/schema.org\/PawnShop",
+    "Name":"https://schema.org/PawnShop",
     "Domain Bucket":"< 1K"
   },
   {
     "Class":"Itemtype",
-    "Name":"http:\/\/schema.org\/PayAction",
+    "Name":"https://schema.org/PayAction",
     "Domain Bucket":"< 1K"
   },
   {
     "Class":"Itemtype",
-    "Name":"http:\/\/schema.org\/PaymentCard",
+    "Name":"https://schema.org/PaymentCard",
     "Domain Bucket":"< 1K"
   },
   {
     "Class":"Itemtype",
-    "Name":"http:\/\/schema.org\/PaymentChargeSpecification",
+    "Name":"https://schema.org/PaymentChargeSpecification",
     "Domain Bucket":"< 1K"
   },
   {
     "Class":"Itemtype",
-    "Name":"http:\/\/schema.org\/PaymentMethod",
+    "Name":"https://schema.org/PaymentMethod",
     "Domain Bucket":"10K - 100K"
   },
   {
     "Class":"Itemtype",
-    "Name":"http:\/\/schema.org\/PaymentMethodType",
+    "Name":"https://schema.org/PaymentMethodType",
     "Domain Bucket":"< 1K"
   },
   {
     "Class":"Itemtype",
-    "Name":"http:\/\/schema.org\/PaymentService",
+    "Name":"https://schema.org/PaymentService",
     "Domain Bucket":"1K - 10K"
   },
   {
     "Class":"Itemtype",
-    "Name":"http:\/\/schema.org\/PaymentStatusType",
+    "Name":"https://schema.org/PaymentStatusType",
     "Domain Bucket":"< 1K"
   },
   {
     "Class":"Itemtype",
-    "Name":"http:\/\/schema.org\/Pediatric",
+    "Name":"https://schema.org/Pediatric",
     "Domain Bucket":"< 1K"
   },
   {
     "Class":"Itemtype",
-    "Name":"http:\/\/schema.org\/PeopleAudience",
+    "Name":"https://schema.org/PeopleAudience",
     "Domain Bucket":"10K - 100K"
   },
   {
     "Class":"Itemtype",
-    "Name":"http:\/\/schema.org\/PerformAction",
+    "Name":"https://schema.org/PerformAction",
     "Domain Bucket":"< 1K"
   },
   {
     "Class":"Itemtype",
-    "Name":"http:\/\/schema.org\/PerformanceRole",
+    "Name":"https://schema.org/PerformanceRole",
     "Domain Bucket":"< 1K"
   },
   {
     "Class":"Itemtype",
-    "Name":"http:\/\/schema.org\/PerformingArtsEvent",
+    "Name":"https://schema.org/PerformingArtsEvent",
     "Domain Bucket":"< 1K"
   },
   {
     "Class":"Itemtype",
-    "Name":"http:\/\/schema.org\/PerformingArtsTheater",
+    "Name":"https://schema.org/PerformingArtsTheater",
     "Domain Bucket":"1K - 10K"
   },
   {
     "Class":"Itemtype",
-    "Name":"http:\/\/schema.org\/PerformingGroup",
+    "Name":"https://schema.org/PerformingGroup",
     "Domain Bucket":"10K - 100K"
   },
   {
     "Class":"Itemtype",
-    "Name":"http:\/\/schema.org\/Periodical",
+    "Name":"https://schema.org/Periodical",
     "Domain Bucket":"1K - 10K"
   },
   {
     "Class":"Itemtype",
-    "Name":"http:\/\/schema.org\/Permit",
+    "Name":"https://schema.org/Permit",
     "Domain Bucket":"10K - 100K"
   },
   {
     "Class":"Itemtype",
-    "Name":"http:\/\/schema.org\/Person",
+    "Name":"https://schema.org/Person",
     "Domain Bucket":"10M+"
   },
   {
     "Class":"Itemtype",
-    "Name":"http:\/\/schema.org\/PetStore",
+    "Name":"https://schema.org/PetStore",
     "Domain Bucket":"1K - 10K"
   },
   {
     "Class":"Itemtype",
-    "Name":"http:\/\/schema.org\/Pharmacy",
+    "Name":"https://schema.org/Pharmacy",
     "Domain Bucket":"10K - 100K"
   },
   {
     "Class":"Itemtype",
-    "Name":"http:\/\/schema.org\/Photograph",
+    "Name":"https://schema.org/Photograph",
     "Domain Bucket":"10K - 100K"
   },
   {
     "Class":"Itemtype",
-    "Name":"http:\/\/schema.org\/PhotographAction",
+    "Name":"https://schema.org/PhotographAction",
     "Domain Bucket":"< 1K"
   },
   {
     "Class":"Itemtype",
-    "Name":"http:\/\/schema.org\/PhysicalActivity",
+    "Name":"https://schema.org/PhysicalActivity",
     "Domain Bucket":"< 1K"
   },
   {
     "Class":"Itemtype",
-    "Name":"http:\/\/schema.org\/PhysicalActivityCategory",
+    "Name":"https://schema.org/PhysicalActivityCategory",
     "Domain Bucket":"1K - 10K"
   },
   {
     "Class":"Itemtype",
-    "Name":"http:\/\/schema.org\/PhysicalExam",
+    "Name":"https://schema.org/PhysicalExam",
     "Domain Bucket":"< 1K"
   },
   {
     "Class":"Itemtype",
-    "Name":"http:\/\/schema.org\/PhysicalTherapy",
+    "Name":"https://schema.org/PhysicalTherapy",
     "Domain Bucket":"< 1K"
   },
   {
     "Class":"Itemtype",
-    "Name":"http:\/\/schema.org\/Physician",
+    "Name":"https://schema.org/Physician",
     "Domain Bucket":"10K - 100K"
   },
   {
     "Class":"Itemtype",
-    "Name":"http:\/\/schema.org\/PhysiciansOffice",
+    "Name":"https://schema.org/PhysiciansOffice",
     "Domain Bucket":"< 1K"
   },
   {
     "Class":"Itemtype",
-    "Name":"http:\/\/schema.org\/Physiotherapy",
+    "Name":"https://schema.org/Physiotherapy",
     "Domain Bucket":"1K - 10K"
   },
   {
     "Class":"Itemtype",
-    "Name":"http:\/\/schema.org\/Place",
+    "Name":"https://schema.org/Place",
     "Domain Bucket":"1M - 10M"
   },
   {
     "Class":"Itemtype",
-    "Name":"http:\/\/schema.org\/PlaceOfWorship",
+    "Name":"https://schema.org/PlaceOfWorship",
     "Domain Bucket":"1K - 10K"
   },
   {
     "Class":"Itemtype",
-    "Name":"http:\/\/schema.org\/PlanAction",
+    "Name":"https://schema.org/PlanAction",
     "Domain Bucket":"< 1K"
   },
   {
     "Class":"Itemtype",
-    "Name":"http:\/\/schema.org\/PlasticSurgery",
+    "Name":"https://schema.org/PlasticSurgery",
     "Domain Bucket":"< 1K"
   },
   {
     "Class":"Itemtype",
-    "Name":"http:\/\/schema.org\/Play",
+    "Name":"https://schema.org/Play",
     "Domain Bucket":"< 1K"
   },
   {
     "Class":"Itemtype",
-    "Name":"http:\/\/schema.org\/PlayAction",
+    "Name":"https://schema.org/PlayAction",
     "Domain Bucket":"10K - 100K"
   },
   {
     "Class":"Itemtype",
-    "Name":"http:\/\/schema.org\/PlayGameAction",
+    "Name":"https://schema.org/PlayGameAction",
     "Domain Bucket":"< 1K"
   },
   {
     "Class":"Itemtype",
-    "Name":"http:\/\/schema.org\/Playground",
+    "Name":"https://schema.org/Playground",
     "Domain Bucket":"< 1K"
   },
   {
     "Class":"Itemtype",
-    "Name":"http:\/\/schema.org\/Plumber",
+    "Name":"https://schema.org/Plumber",
     "Domain Bucket":"10K - 100K"
   },
   {
     "Class":"Itemtype",
-    "Name":"http:\/\/schema.org\/PodcastEpisode",
+    "Name":"https://schema.org/PodcastEpisode",
     "Domain Bucket":"10K - 100K"
   },
   {
     "Class":"Itemtype",
-    "Name":"http:\/\/schema.org\/PodcastSeason",
+    "Name":"https://schema.org/PodcastSeason",
     "Domain Bucket":"< 1K"
   },
   {
     "Class":"Itemtype",
-    "Name":"http:\/\/schema.org\/PodcastSeries",
+    "Name":"https://schema.org/PodcastSeries",
     "Domain Bucket":"10K - 100K"
   },
   {
     "Class":"Itemtype",
-    "Name":"http:\/\/schema.org\/Podiatric",
+    "Name":"https://schema.org/Podiatric",
     "Domain Bucket":"< 1K"
   },
   {
     "Class":"Itemtype",
-    "Name":"http:\/\/schema.org\/PoliceStation",
+    "Name":"https://schema.org/PoliceStation",
     "Domain Bucket":"< 1K"
   },
   {
     "Class":"Itemtype",
-    "Name":"http:\/\/schema.org\/PoliticalParty",
+    "Name":"https://schema.org/PoliticalParty",
     "Domain Bucket":"< 1K"
   },
   {
     "Class":"Itemtype",
-    "Name":"http:\/\/schema.org\/Pond",
+    "Name":"https://schema.org/Pond",
     "Domain Bucket":"< 1K"
   },
   {
     "Class":"Itemtype",
-    "Name":"http:\/\/schema.org\/PostOffice",
+    "Name":"https://schema.org/PostOffice",
     "Domain Bucket":"< 1K"
   },
   {
     "Class":"Itemtype",
-    "Name":"http:\/\/schema.org\/PostalAddress",
+    "Name":"https://schema.org/PostalAddress",
     "Domain Bucket":"1M - 10M"
   },
   {
     "Class":"Itemtype",
-    "Name":"http:\/\/schema.org\/PostalCodeRangeSpecification",
+    "Name":"https://schema.org/PostalCodeRangeSpecification",
     "Domain Bucket":"1K - 10K"
   },
   {
     "Class":"Itemtype",
-    "Name":"http:\/\/schema.org\/Poster",
+    "Name":"https://schema.org/Poster",
     "Domain Bucket":"< 1K"
   },
   {
     "Class":"Itemtype",
-    "Name":"http:\/\/schema.org\/PreOrderAction",
+    "Name":"https://schema.org/PreOrderAction",
     "Domain Bucket":"< 1K"
   },
   {
     "Class":"Itemtype",
-    "Name":"http:\/\/schema.org\/PrependAction",
+    "Name":"https://schema.org/PrependAction",
     "Domain Bucket":"< 1K"
   },
   {
     "Class":"Itemtype",
-    "Name":"http:\/\/schema.org\/Preschool",
+    "Name":"https://schema.org/Preschool",
     "Domain Bucket":"1K - 10K"
   },
   {
     "Class":"Itemtype",
-    "Name":"http:\/\/schema.org\/PresentationDigitalDocument",
+    "Name":"https://schema.org/PresentationDigitalDocument",
     "Domain Bucket":"< 1K"
   },
   {
     "Class":"Itemtype",
-    "Name":"http:\/\/schema.org\/PreventionIndication",
+    "Name":"https://schema.org/PreventionIndication",
     "Domain Bucket":"< 1K"
   },
   {
     "Class":"Itemtype",
-    "Name":"http:\/\/schema.org\/PriceComponentTypeEnumeration",
+    "Name":"https://schema.org/PriceComponentTypeEnumeration",
     "Domain Bucket":"< 1K"
   },
   {
     "Class":"Itemtype",
-    "Name":"http:\/\/schema.org\/PriceSpecification",
+    "Name":"https://schema.org/PriceSpecification",
     "Domain Bucket":"100K - 1M"
   },
   {
     "Class":"Itemtype",
-    "Name":"http:\/\/schema.org\/PriceTypeEnumeration",
+    "Name":"https://schema.org/PriceTypeEnumeration",
     "Domain Bucket":"< 1K"
   },
   {
     "Class":"Itemtype",
-    "Name":"http:\/\/schema.org\/PrimaryCare",
+    "Name":"https://schema.org/PrimaryCare",
     "Domain Bucket":"< 1K"
   },
   {
     "Class":"Itemtype",
-    "Name":"http:\/\/schema.org\/Product",
+    "Name":"https://schema.org/Product",
     "Domain Bucket":"1M - 10M"
   },
   {
     "Class":"Itemtype",
-    "Name":"http:\/\/schema.org\/ProductCollection",
+    "Name":"https://schema.org/ProductCollection",
     "Domain Bucket":"1K - 10K"
   },
   {
     "Class":"Itemtype",
-    "Name":"http:\/\/schema.org\/ProductGroup",
+    "Name":"https://schema.org/ProductGroup",
     "Domain Bucket":"100K - 1M"
   },
   {
     "Class":"Itemtype",
-    "Name":"http:\/\/schema.org\/ProductModel",
+    "Name":"https://schema.org/ProductModel",
     "Domain Bucket":"1K - 10K"
   },
   {
     "Class":"Itemtype",
-    "Name":"http:\/\/schema.org\/ProductReturnEnumeration",
+    "Name":"https://schema.org/ProductReturnEnumeration",
     "Domain Bucket":"< 1K"
   },
   {
     "Class":"Itemtype",
-    "Name":"http:\/\/schema.org\/ProductReturnPolicy",
+    "Name":"https://schema.org/ProductReturnPolicy",
     "Domain Bucket":"< 1K"
   },
   {
     "Class":"Itemtype",
-    "Name":"http:\/\/schema.org\/ProfessionalService",
+    "Name":"https://schema.org/ProfessionalService",
     "Domain Bucket":"100K - 1M"
   },
   {
     "Class":"Itemtype",
-    "Name":"http:\/\/schema.org\/ProfilePage",
+    "Name":"https://schema.org/ProfilePage",
     "Domain Bucket":"100K - 1M"
   },
   {
     "Class":"Itemtype",
-    "Name":"http:\/\/schema.org\/ProgramMembership",
+    "Name":"https://schema.org/ProgramMembership",
     "Domain Bucket":"1K - 10K"
   },
   {
     "Class":"Itemtype",
-    "Name":"http:\/\/schema.org\/Project",
+    "Name":"https://schema.org/Project",
     "Domain Bucket":"1K - 10K"
   },
   {
     "Class":"Itemtype",
-    "Name":"http:\/\/schema.org\/PronounceableText",
+    "Name":"https://schema.org/PronounceableText",
     "Domain Bucket":"< 1K"
   },
   {
     "Class":"Itemtype",
-    "Name":"http:\/\/schema.org\/Property",
+    "Name":"https://schema.org/Property",
     "Domain Bucket":"< 1K"
   },
   {
     "Class":"Itemtype",
-    "Name":"http:\/\/schema.org\/PropertyValue",
+    "Name":"https://schema.org/PropertyValue",
     "Domain Bucket":"100K - 1M"
   },
   {
     "Class":"Itemtype",
-    "Name":"http:\/\/schema.org\/PropertyValueSpecification",
+    "Name":"https://schema.org/PropertyValueSpecification",
     "Domain Bucket":"10M+"
   },
   {
     "Class":"Itemtype",
-    "Name":"http:\/\/schema.org\/Protein",
+    "Name":"https://schema.org/Protein",
     "Domain Bucket":"< 1K"
   },
   {
     "Class":"Itemtype",
-    "Name":"http:\/\/schema.org\/Psychiatric",
+    "Name":"https://schema.org/Psychiatric",
     "Domain Bucket":"1K - 10K"
   },
   {
     "Class":"Itemtype",
-    "Name":"http:\/\/schema.org\/PsychologicalTreatment",
+    "Name":"https://schema.org/PsychologicalTreatment",
     "Domain Bucket":"< 1K"
   },
   {
     "Class":"Itemtype",
-    "Name":"http:\/\/schema.org\/PublicHealth",
+    "Name":"https://schema.org/PublicHealth",
     "Domain Bucket":"< 1K"
   },
   {
     "Class":"Itemtype",
-    "Name":"http:\/\/schema.org\/PublicSwimmingPool",
+    "Name":"https://schema.org/PublicSwimmingPool",
     "Domain Bucket":"< 1K"
   },
   {
     "Class":"Itemtype",
-    "Name":"http:\/\/schema.org\/PublicToilet",
+    "Name":"https://schema.org/PublicToilet",
     "Domain Bucket":"< 1K"
   },
   {
     "Class":"Itemtype",
-    "Name":"http:\/\/schema.org\/PublicationEvent",
+    "Name":"https://schema.org/PublicationEvent",
     "Domain Bucket":"1K - 10K"
   },
   {
     "Class":"Itemtype",
-    "Name":"http:\/\/schema.org\/PublicationIssue",
+    "Name":"https://schema.org/PublicationIssue",
     "Domain Bucket":"1K - 10K"
   },
   {
     "Class":"Itemtype",
-    "Name":"http:\/\/schema.org\/PublicationVolume",
+    "Name":"https://schema.org/PublicationVolume",
     "Domain Bucket":"1K - 10K"
   },
   {
     "Class":"Itemtype",
-    "Name":"http:\/\/schema.org\/PurchaseType",
+    "Name":"https://schema.org/PurchaseType",
     "Domain Bucket":"< 1K"
   },
   {
     "Class":"Itemtype",
-    "Name":"http:\/\/schema.org\/QAPage",
+    "Name":"https://schema.org/QAPage",
     "Domain Bucket":"10K - 100K"
   },
   {
     "Class":"Itemtype",
-    "Name":"http:\/\/schema.org\/QualitativeValue",
+    "Name":"https://schema.org/QualitativeValue",
     "Domain Bucket":"1K - 10K"
   },
   {
     "Class":"Itemtype",
-    "Name":"http:\/\/schema.org\/QuantitativeValue",
+    "Name":"https://schema.org/QuantitativeValue",
     "Domain Bucket":"1M - 10M"
   },
   {
     "Class":"Itemtype",
-    "Name":"http:\/\/schema.org\/QuantitativeValueDistribution",
+    "Name":"https://schema.org/QuantitativeValueDistribution",
     "Domain Bucket":"< 1K"
   },
   {
     "Class":"Itemtype",
-    "Name":"http:\/\/schema.org\/Quantity",
+    "Name":"https://schema.org/Quantity",
     "Domain Bucket":"< 1K"
   },
   {
     "Class":"Itemtype",
-    "Name":"http:\/\/schema.org\/Question",
+    "Name":"https://schema.org/Question",
     "Domain Bucket":"1M - 10M"
   },
   {
     "Class":"Itemtype",
-    "Name":"http:\/\/schema.org\/Quiz",
+    "Name":"https://schema.org/Quiz",
     "Domain Bucket":"1K - 10K"
   },
   {
     "Class":"Itemtype",
-    "Name":"http:\/\/schema.org\/Quotation",
+    "Name":"https://schema.org/Quotation",
     "Domain Bucket":"1K - 10K"
   },
   {
     "Class":"Itemtype",
-    "Name":"http:\/\/schema.org\/QuoteAction",
+    "Name":"https://schema.org/QuoteAction",
     "Domain Bucket":"1K - 10K"
   },
   {
     "Class":"Itemtype",
-    "Name":"http:\/\/schema.org\/RVPark",
+    "Name":"https://schema.org/RVPark",
     "Domain Bucket":"< 1K"
   },
   {
     "Class":"Itemtype",
-    "Name":"http:\/\/schema.org\/RadiationTherapy",
+    "Name":"https://schema.org/RadiationTherapy",
     "Domain Bucket":"< 1K"
   },
   {
     "Class":"Itemtype",
-    "Name":"http:\/\/schema.org\/RadioBroadcastService",
+    "Name":"https://schema.org/RadioBroadcastService",
     "Domain Bucket":"< 1K"
   },
   {
     "Class":"Itemtype",
-    "Name":"http:\/\/schema.org\/RadioChannel",
+    "Name":"https://schema.org/RadioChannel",
     "Domain Bucket":"< 1K"
   },
   {
     "Class":"Itemtype",
-    "Name":"http:\/\/schema.org\/RadioClip",
+    "Name":"https://schema.org/RadioClip",
     "Domain Bucket":"< 1K"
   },
   {
     "Class":"Itemtype",
-    "Name":"http:\/\/schema.org\/RadioEpisode",
+    "Name":"https://schema.org/RadioEpisode",
     "Domain Bucket":"1K - 10K"
   },
   {
     "Class":"Itemtype",
-    "Name":"http:\/\/schema.org\/RadioSeason",
+    "Name":"https://schema.org/RadioSeason",
     "Domain Bucket":"< 1K"
   },
   {
     "Class":"Itemtype",
-    "Name":"http:\/\/schema.org\/RadioSeries",
+    "Name":"https://schema.org/RadioSeries",
     "Domain Bucket":"1K - 10K"
   },
   {
     "Class":"Itemtype",
-    "Name":"http:\/\/schema.org\/RadioStation",
+    "Name":"https://schema.org/RadioStation",
     "Domain Bucket":"1K - 10K"
   },
   {
     "Class":"Itemtype",
-    "Name":"http:\/\/schema.org\/Rating",
+    "Name":"https://schema.org/Rating",
     "Domain Bucket":"1M - 10M"
   },
   {
     "Class":"Itemtype",
-    "Name":"http:\/\/schema.org\/ReactAction",
+    "Name":"https://schema.org/ReactAction",
     "Domain Bucket":"< 1K"
   },
   {
     "Class":"Itemtype",
-    "Name":"http:\/\/schema.org\/ReadAction",
+    "Name":"https://schema.org/ReadAction",
     "Domain Bucket":"10M+"
   },
   {
     "Class":"Itemtype",
-    "Name":"http:\/\/schema.org\/RealEstateAgent",
+    "Name":"https://schema.org/RealEstateAgent",
     "Domain Bucket":"100K - 1M"
   },
   {
     "Class":"Itemtype",
-    "Name":"http:\/\/schema.org\/RealEstateListing",
+    "Name":"https://schema.org/RealEstateListing",
     "Domain Bucket":"10K - 100K"
   },
   {
     "Class":"Itemtype",
-    "Name":"http:\/\/schema.org\/ReceiveAction",
+    "Name":"https://schema.org/ReceiveAction",
     "Domain Bucket":"< 1K"
   },
   {
     "Class":"Itemtype",
-    "Name":"http:\/\/schema.org\/Recipe",
+    "Name":"https://schema.org/Recipe",
     "Domain Bucket":"10K - 100K"
   },
   {
     "Class":"Itemtype",
-    "Name":"http:\/\/schema.org\/Recommendation",
+    "Name":"https://schema.org/Recommendation",
     "Domain Bucket":"< 1K"
   },
   {
     "Class":"Itemtype",
-    "Name":"http:\/\/schema.org\/RecommendedDoseSchedule",
+    "Name":"https://schema.org/RecommendedDoseSchedule",
     "Domain Bucket":"< 1K"
   },
   {
     "Class":"Itemtype",
-    "Name":"http:\/\/schema.org\/RecyclingCenter",
+    "Name":"https://schema.org/RecyclingCenter",
     "Domain Bucket":"1K - 10K"
   },
   {
     "Class":"Itemtype",
-    "Name":"http:\/\/schema.org\/RefundTypeEnumeration",
+    "Name":"https://schema.org/RefundTypeEnumeration",
     "Domain Bucket":"< 1K"
   },
   {
     "Class":"Itemtype",
-    "Name":"http:\/\/schema.org\/RegisterAction",
+    "Name":"https://schema.org/RegisterAction",
     "Domain Bucket":"1K - 10K"
   },
   {
     "Class":"Itemtype",
-    "Name":"http:\/\/schema.org\/RejectAction",
+    "Name":"https://schema.org/RejectAction",
     "Domain Bucket":"< 1K"
   },
   {
     "Class":"Itemtype",
-    "Name":"http:\/\/schema.org\/RentAction",
+    "Name":"https://schema.org/RentAction",
     "Domain Bucket":"1K - 10K"
   },
   {
     "Class":"Itemtype",
-    "Name":"http:\/\/schema.org\/RentalCarReservation",
+    "Name":"https://schema.org/RentalCarReservation",
     "Domain Bucket":"< 1K"
   },
   {
     "Class":"Itemtype",
-    "Name":"http:\/\/schema.org\/RepaymentSpecification",
+    "Name":"https://schema.org/RepaymentSpecification",
     "Domain Bucket":"< 1K"
   },
   {
     "Class":"Itemtype",
-    "Name":"http:\/\/schema.org\/ReplaceAction",
+    "Name":"https://schema.org/ReplaceAction",
     "Domain Bucket":"< 1K"
   },
   {
     "Class":"Itemtype",
-    "Name":"http:\/\/schema.org\/ReplyAction",
+    "Name":"https://schema.org/ReplyAction",
     "Domain Bucket":"1K - 10K"
   },
   {
     "Class":"Itemtype",
-    "Name":"http:\/\/schema.org\/Report",
+    "Name":"https://schema.org/Report",
     "Domain Bucket":"1K - 10K"
   },
   {
     "Class":"Itemtype",
-    "Name":"http:\/\/schema.org\/ReportageNewsArticle",
+    "Name":"https://schema.org/ReportageNewsArticle",
     "Domain Bucket":"1K - 10K"
   },
   {
     "Class":"Itemtype",
-    "Name":"http:\/\/schema.org\/ReportedDoseSchedule",
+    "Name":"https://schema.org/ReportedDoseSchedule",
     "Domain Bucket":"< 1K"
   },
   {
     "Class":"Itemtype",
-    "Name":"http:\/\/schema.org\/ResearchOrganization",
+    "Name":"https://schema.org/ResearchOrganization",
     "Domain Bucket":"1K - 10K"
   },
   {
     "Class":"Itemtype",
-    "Name":"http:\/\/schema.org\/ResearchProject",
+    "Name":"https://schema.org/ResearchProject",
     "Domain Bucket":"1K - 10K"
   },
   {
     "Class":"Itemtype",
-    "Name":"http:\/\/schema.org\/Researcher",
+    "Name":"https://schema.org/Researcher",
     "Domain Bucket":"< 1K"
   },
   {
     "Class":"Itemtype",
-    "Name":"http:\/\/schema.org\/Reservation",
+    "Name":"https://schema.org/Reservation",
     "Domain Bucket":"10K - 100K"
   },
   {
     "Class":"Itemtype",
-    "Name":"http:\/\/schema.org\/ReservationPackage",
+    "Name":"https://schema.org/ReservationPackage",
     "Domain Bucket":"< 1K"
   },
   {
     "Class":"Itemtype",
-    "Name":"http:\/\/schema.org\/ReservationStatusType",
+    "Name":"https://schema.org/ReservationStatusType",
     "Domain Bucket":"< 1K"
   },
   {
     "Class":"Itemtype",
-    "Name":"http:\/\/schema.org\/ReserveAction",
+    "Name":"https://schema.org/ReserveAction",
     "Domain Bucket":"10K - 100K"
   },
   {
     "Class":"Itemtype",
-    "Name":"http:\/\/schema.org\/Reservoir",
+    "Name":"https://schema.org/Reservoir",
     "Domain Bucket":"< 1K"
   },
   {
     "Class":"Itemtype",
-    "Name":"http:\/\/schema.org\/ResetPasswordAction",
+    "Name":"https://schema.org/ResetPasswordAction",
     "Domain Bucket":"< 1K"
   },
   {
     "Class":"Itemtype",
-    "Name":"http:\/\/schema.org\/Residence",
+    "Name":"https://schema.org/Residence",
     "Domain Bucket":"10K - 100K"
   },
   {
     "Class":"Itemtype",
-    "Name":"http:\/\/schema.org\/Resort",
+    "Name":"https://schema.org/Resort",
     "Domain Bucket":"1K - 10K"
   },
   {
     "Class":"Itemtype",
-    "Name":"http:\/\/schema.org\/RespiratoryTherapy",
+    "Name":"https://schema.org/RespiratoryTherapy",
     "Domain Bucket":"< 1K"
   },
   {
     "Class":"Itemtype",
-    "Name":"http:\/\/schema.org\/Restaurant",
+    "Name":"https://schema.org/Restaurant",
     "Domain Bucket":"100K - 1M"
   },
   {
     "Class":"Itemtype",
-    "Name":"http:\/\/schema.org\/RestrictedDiet",
+    "Name":"https://schema.org/RestrictedDiet",
     "Domain Bucket":"1K - 10K"
   },
   {
     "Class":"Itemtype",
-    "Name":"http:\/\/schema.org\/ResumeAction",
+    "Name":"https://schema.org/ResumeAction",
     "Domain Bucket":"< 1K"
   },
   {
     "Class":"Itemtype",
-    "Name":"http:\/\/schema.org\/ReturnAction",
+    "Name":"https://schema.org/ReturnAction",
     "Domain Bucket":"< 1K"
   },
   {
     "Class":"Itemtype",
-    "Name":"http:\/\/schema.org\/ReturnFeesEnumeration",
+    "Name":"https://schema.org/ReturnFeesEnumeration",
     "Domain Bucket":"< 1K"
   },
   {
     "Class":"Itemtype",
-    "Name":"http:\/\/schema.org\/ReturnLabelSourceEnumeration",
+    "Name":"https://schema.org/ReturnLabelSourceEnumeration",
     "Domain Bucket":"< 1K"
   },
   {
     "Class":"Itemtype",
-    "Name":"http:\/\/schema.org\/ReturnMethodEnumeration",
+    "Name":"https://schema.org/ReturnMethodEnumeration",
     "Domain Bucket":"< 1K"
   },
   {
     "Class":"Itemtype",
-    "Name":"http:\/\/schema.org\/Review",
+    "Name":"https://schema.org/Review",
     "Domain Bucket":"1M - 10M"
   },
   {
     "Class":"Itemtype",
-    "Name":"http:\/\/schema.org\/ReviewAction",
+    "Name":"https://schema.org/ReviewAction",
     "Domain Bucket":"1K - 10K"
   },
   {
     "Class":"Itemtype",
-    "Name":"http:\/\/schema.org\/ReviewNewsArticle",
+    "Name":"https://schema.org/ReviewNewsArticle",
     "Domain Bucket":"< 1K"
   },
   {
     "Class":"Itemtype",
-    "Name":"http:\/\/schema.org\/RiverBodyOfWater",
+    "Name":"https://schema.org/RiverBodyOfWater",
     "Domain Bucket":"< 1K"
   },
   {
     "Class":"Itemtype",
-    "Name":"http:\/\/schema.org\/Role",
+    "Name":"https://schema.org/Role",
     "Domain Bucket":"1K - 10K"
   },
   {
     "Class":"Itemtype",
-    "Name":"http:\/\/schema.org\/RoofingContractor",
+    "Name":"https://schema.org/RoofingContractor",
     "Domain Bucket":"10K - 100K"
   },
   {
     "Class":"Itemtype",
-    "Name":"http:\/\/schema.org\/Room",
+    "Name":"https://schema.org/Room",
     "Domain Bucket":"1K - 10K"
   },
   {
     "Class":"Itemtype",
-    "Name":"http:\/\/schema.org\/RsvpAction",
+    "Name":"https://schema.org/RsvpAction",
     "Domain Bucket":"< 1K"
   },
   {
     "Class":"Itemtype",
-    "Name":"http:\/\/schema.org\/RsvpResponseType",
+    "Name":"https://schema.org/RsvpResponseType",
     "Domain Bucket":"< 1K"
   },
   {
     "Class":"Itemtype",
-    "Name":"http:\/\/schema.org\/RuntimePlatform",
+    "Name":"https://schema.org/RuntimePlatform",
     "Domain Bucket":"< 1K"
   },
   {
     "Class":"Itemtype",
-    "Name":"http:\/\/schema.org\/SaleEvent",
+    "Name":"https://schema.org/SaleEvent",
     "Domain Bucket":"1K - 10K"
   },
   {
     "Class":"Itemtype",
-    "Name":"http:\/\/schema.org\/SatiricalArticle",
+    "Name":"https://schema.org/SatiricalArticle",
     "Domain Bucket":"< 1K"
   },
   {
     "Class":"Itemtype",
-    "Name":"http:\/\/schema.org\/Schedule",
+    "Name":"https://schema.org/Schedule",
     "Domain Bucket":"10K - 100K"
   },
   {
     "Class":"Itemtype",
-    "Name":"http:\/\/schema.org\/ScheduleAction",
+    "Name":"https://schema.org/ScheduleAction",
     "Domain Bucket":"1K - 10K"
   },
   {
     "Class":"Itemtype",
-    "Name":"http:\/\/schema.org\/ScholarlyArticle",
+    "Name":"https://schema.org/ScholarlyArticle",
     "Domain Bucket":"10K - 100K"
   },
   {
     "Class":"Itemtype",
-    "Name":"http:\/\/schema.org\/School",
+    "Name":"https://schema.org/School",
     "Domain Bucket":"1K - 10K"
   },
   {
     "Class":"Itemtype",
-    "Name":"http:\/\/schema.org\/SchoolDistrict",
+    "Name":"https://schema.org/SchoolDistrict",
     "Domain Bucket":"< 1K"
   },
   {
     "Class":"Itemtype",
-    "Name":"http:\/\/schema.org\/ScreeningEvent",
+    "Name":"https://schema.org/ScreeningEvent",
     "Domain Bucket":"< 1K"
   },
   {
     "Class":"Itemtype",
-    "Name":"http:\/\/schema.org\/Sculpture",
+    "Name":"https://schema.org/Sculpture",
     "Domain Bucket":"< 1K"
   },
   {
     "Class":"Itemtype",
-    "Name":"http:\/\/schema.org\/SeaBodyOfWater",
+    "Name":"https://schema.org/SeaBodyOfWater",
     "Domain Bucket":"< 1K"
   },
   {
     "Class":"Itemtype",
-    "Name":"http:\/\/schema.org\/SearchAction",
+    "Name":"https://schema.org/SearchAction",
     "Domain Bucket":"10M+"
   },
   {
     "Class":"Itemtype",
-    "Name":"http:\/\/schema.org\/SearchRescueOrganization",
+    "Name":"https://schema.org/SearchRescueOrganization",
     "Domain Bucket":"< 1K"
   },
   {
     "Class":"Itemtype",
-    "Name":"http:\/\/schema.org\/SearchResultsPage",
+    "Name":"https://schema.org/SearchResultsPage",
     "Domain Bucket":"10K - 100K"
   },
   {
     "Class":"Itemtype",
-    "Name":"http:\/\/schema.org\/Season",
+    "Name":"https://schema.org/Season",
     "Domain Bucket":"< 1K"
   },
   {
     "Class":"Itemtype",
-    "Name":"http:\/\/schema.org\/Seat",
+    "Name":"https://schema.org/Seat",
     "Domain Bucket":"< 1K"
   },
   {
     "Class":"Itemtype",
-    "Name":"http:\/\/schema.org\/SeekToAction",
+    "Name":"https://schema.org/SeekToAction",
     "Domain Bucket":"10K - 100K"
   },
   {
     "Class":"Itemtype",
-    "Name":"http:\/\/schema.org\/SelfStorage",
+    "Name":"https://schema.org/SelfStorage",
     "Domain Bucket":"1K - 10K"
   },
   {
     "Class":"Itemtype",
-    "Name":"http:\/\/schema.org\/SellAction",
+    "Name":"https://schema.org/SellAction",
     "Domain Bucket":"1K - 10K"
   },
   {
     "Class":"Itemtype",
-    "Name":"http:\/\/schema.org\/SendAction",
+    "Name":"https://schema.org/SendAction",
     "Domain Bucket":"< 1K"
   },
   {
     "Class":"Itemtype",
-    "Name":"http:\/\/schema.org\/SequentialArt",
+    "Name":"https://schema.org/SequentialArt",
     "Domain Bucket":"< 1K"
   },
   {
     "Class":"Itemtype",
-    "Name":"http:\/\/schema.org\/Series",
+    "Name":"https://schema.org/Series",
     "Domain Bucket":"10K - 100K"
   },
   {
     "Class":"Itemtype",
-    "Name":"http:\/\/schema.org\/Service",
+    "Name":"https://schema.org/Service",
     "Domain Bucket":"1M - 10M"
   },
   {
     "Class":"Itemtype",
-    "Name":"http:\/\/schema.org\/ServiceChannel",
+    "Name":"https://schema.org/ServiceChannel",
     "Domain Bucket":"10K - 100K"
   },
   {
     "Class":"Itemtype",
-    "Name":"http:\/\/schema.org\/ServicePeriod",
+    "Name":"https://schema.org/ServicePeriod",
     "Domain Bucket":"1K - 10K"
   },
   {
     "Class":"Itemtype",
-    "Name":"http:\/\/schema.org\/ShareAction",
+    "Name":"https://schema.org/ShareAction",
     "Domain Bucket":"10K - 100K"
   },
   {
     "Class":"Itemtype",
-    "Name":"http:\/\/schema.org\/SheetMusic",
+    "Name":"https://schema.org/SheetMusic",
     "Domain Bucket":"< 1K"
   },
   {
     "Class":"Itemtype",
-    "Name":"http:\/\/schema.org\/ShippingConditions",
+    "Name":"https://schema.org/ShippingConditions",
     "Domain Bucket":"10K - 100K"
   },
   {
     "Class":"Itemtype",
-    "Name":"http:\/\/schema.org\/ShippingDeliveryTime",
+    "Name":"https://schema.org/ShippingDeliveryTime",
     "Domain Bucket":"100K - 1M"
   },
   {
     "Class":"Itemtype",
-    "Name":"http:\/\/schema.org\/ShippingRateSettings",
+    "Name":"https://schema.org/ShippingRateSettings",
     "Domain Bucket":"< 1K"
   },
   {
     "Class":"Itemtype",
-    "Name":"http:\/\/schema.org\/ShippingService",
+    "Name":"https://schema.org/ShippingService",
     "Domain Bucket":"10K - 100K"
   },
   {
     "Class":"Itemtype",
-    "Name":"http:\/\/schema.org\/ShoeStore",
+    "Name":"https://schema.org/ShoeStore",
     "Domain Bucket":"1K - 10K"
   },
   {
     "Class":"Itemtype",
-    "Name":"http:\/\/schema.org\/ShoppingCenter",
+    "Name":"https://schema.org/ShoppingCenter",
     "Domain Bucket":"1K - 10K"
   },
   {
     "Class":"Itemtype",
-    "Name":"http:\/\/schema.org\/ShortStory",
+    "Name":"https://schema.org/ShortStory",
     "Domain Bucket":"< 1K"
   },
   {
     "Class":"Itemtype",
-    "Name":"http:\/\/schema.org\/SingleFamilyResidence",
+    "Name":"https://schema.org/SingleFamilyResidence",
     "Domain Bucket":"10K - 100K"
   },
   {
     "Class":"Itemtype",
-    "Name":"http:\/\/schema.org\/SiteNavigationElement",
+    "Name":"https://schema.org/SiteNavigationElement",
     "Domain Bucket":"1M - 10M"
   },
   {
     "Class":"Itemtype",
-    "Name":"http:\/\/schema.org\/SizeGroupEnumeration",
+    "Name":"https://schema.org/SizeGroupEnumeration",
     "Domain Bucket":"< 1K"
   },
   {
     "Class":"Itemtype",
-    "Name":"http:\/\/schema.org\/SizeSpecification",
+    "Name":"https://schema.org/SizeSpecification",
     "Domain Bucket":"1K - 10K"
   },
   {
     "Class":"Itemtype",
-    "Name":"http:\/\/schema.org\/SizeSystemEnumeration",
+    "Name":"https://schema.org/SizeSystemEnumeration",
     "Domain Bucket":"< 1K"
   },
   {
     "Class":"Itemtype",
-    "Name":"http:\/\/schema.org\/SkiResort",
+    "Name":"https://schema.org/SkiResort",
     "Domain Bucket":"< 1K"
   },
   {
     "Class":"Itemtype",
-    "Name":"http:\/\/schema.org\/SocialEvent",
+    "Name":"https://schema.org/SocialEvent",
     "Domain Bucket":"1K - 10K"
   },
   {
     "Class":"Itemtype",
-    "Name":"http:\/\/schema.org\/SocialMediaPosting",
+    "Name":"https://schema.org/SocialMediaPosting",
     "Domain Bucket":"10K - 100K"
   },
   {
     "Class":"Itemtype",
-    "Name":"http:\/\/schema.org\/SoftwareApplication",
+    "Name":"https://schema.org/SoftwareApplication",
     "Domain Bucket":"100K - 1M"
   },
   {
     "Class":"Itemtype",
-    "Name":"http:\/\/schema.org\/SoftwareSourceCode",
+    "Name":"https://schema.org/SoftwareSourceCode",
     "Domain Bucket":"1K - 10K"
   },
   {
     "Class":"Itemtype",
-    "Name":"http:\/\/schema.org\/SolveMathAction",
+    "Name":"https://schema.org/SolveMathAction",
     "Domain Bucket":"< 1K"
   },
   {
     "Class":"Itemtype",
-    "Name":"http:\/\/schema.org\/SomeProducts",
+    "Name":"https://schema.org/SomeProducts",
     "Domain Bucket":"10K - 100K"
   },
   {
     "Class":"Itemtype",
-    "Name":"http:\/\/schema.org\/SpeakableSpecification",
+    "Name":"https://schema.org/SpeakableSpecification",
     "Domain Bucket":"100K - 1M"
   },
   {
     "Class":"Itemtype",
-    "Name":"http:\/\/schema.org\/SpecialAnnouncement",
+    "Name":"https://schema.org/SpecialAnnouncement",
     "Domain Bucket":"1K - 10K"
   },
   {
     "Class":"Itemtype",
-    "Name":"http:\/\/schema.org\/Specialty",
+    "Name":"https://schema.org/Specialty",
     "Domain Bucket":"1K - 10K"
   },
   {
     "Class":"Itemtype",
-    "Name":"http:\/\/schema.org\/SportingGoodsStore",
+    "Name":"https://schema.org/SportingGoodsStore",
     "Domain Bucket":"1K - 10K"
   },
   {
     "Class":"Itemtype",
-    "Name":"http:\/\/schema.org\/SportsActivityLocation",
+    "Name":"https://schema.org/SportsActivityLocation",
     "Domain Bucket":"10K - 100K"
   },
   {
     "Class":"Itemtype",
-    "Name":"http:\/\/schema.org\/SportsClub",
+    "Name":"https://schema.org/SportsClub",
     "Domain Bucket":"1K - 10K"
   },
   {
     "Class":"Itemtype",
-    "Name":"http:\/\/schema.org\/SportsEvent",
+    "Name":"https://schema.org/SportsEvent",
     "Domain Bucket":"10K - 100K"
   },
   {
     "Class":"Itemtype",
-    "Name":"http:\/\/schema.org\/SportsOrganization",
+    "Name":"https://schema.org/SportsOrganization",
     "Domain Bucket":"10K - 100K"
   },
   {
     "Class":"Itemtype",
-    "Name":"http:\/\/schema.org\/SportsTeam",
+    "Name":"https://schema.org/SportsTeam",
     "Domain Bucket":"10K - 100K"
   },
   {
     "Class":"Itemtype",
-    "Name":"http:\/\/schema.org\/SpreadsheetDigitalDocument",
+    "Name":"https://schema.org/SpreadsheetDigitalDocument",
     "Domain Bucket":"< 1K"
   },
   {
     "Class":"Itemtype",
-    "Name":"http:\/\/schema.org\/StadiumOrArena",
+    "Name":"https://schema.org/StadiumOrArena",
     "Domain Bucket":"1K - 10K"
   },
   {
     "Class":"Itemtype",
-    "Name":"http:\/\/schema.org\/State",
+    "Name":"https://schema.org/State",
     "Domain Bucket":"100K - 1M"
   },
   {
     "Class":"Itemtype",
-    "Name":"http:\/\/schema.org\/Statement",
+    "Name":"https://schema.org/Statement",
     "Domain Bucket":"< 1K"
   },
   {
     "Class":"Itemtype",
-    "Name":"http:\/\/schema.org\/StatisticalPopulation",
+    "Name":"https://schema.org/StatisticalPopulation",
     "Domain Bucket":"< 1K"
   },
   {
     "Class":"Itemtype",
-    "Name":"http:\/\/schema.org\/StatisticalVariable",
+    "Name":"https://schema.org/StatisticalVariable",
     "Domain Bucket":"< 1K"
   },
   {
     "Class":"Itemtype",
-    "Name":"http:\/\/schema.org\/StatusEnumeration",
+    "Name":"https://schema.org/StatusEnumeration",
     "Domain Bucket":"< 1K"
   },
   {
     "Class":"Itemtype",
-    "Name":"http:\/\/schema.org\/SteeringPositionValue",
+    "Name":"https://schema.org/SteeringPositionValue",
     "Domain Bucket":"< 1K"
   },
   {
     "Class":"Itemtype",
-    "Name":"http:\/\/schema.org\/Store",
+    "Name":"https://schema.org/Store",
     "Domain Bucket":"100K - 1M"
   },
   {
     "Class":"Itemtype",
-    "Name":"http:\/\/schema.org\/StructuredValue",
+    "Name":"https://schema.org/StructuredValue",
     "Domain Bucket":"1K - 10K"
   },
   {
     "Class":"Itemtype",
-    "Name":"http:\/\/schema.org\/StupidType",
+    "Name":"https://schema.org/StupidType",
     "Domain Bucket":"< 1K"
   },
   {
     "Class":"Itemtype",
-    "Name":"http:\/\/schema.org\/SubscribeAction",
+    "Name":"https://schema.org/SubscribeAction",
     "Domain Bucket":"10K - 100K"
   },
   {
     "Class":"Itemtype",
-    "Name":"http:\/\/schema.org\/Substance",
+    "Name":"https://schema.org/Substance",
     "Domain Bucket":"< 1K"
   },
   {
     "Class":"Itemtype",
-    "Name":"http:\/\/schema.org\/SubwayStation",
+    "Name":"https://schema.org/SubwayStation",
     "Domain Bucket":"< 1K"
   },
   {
     "Class":"Itemtype",
-    "Name":"http:\/\/schema.org\/Suite",
+    "Name":"https://schema.org/Suite",
     "Domain Bucket":"< 1K"
   },
   {
     "Class":"Itemtype",
-    "Name":"http:\/\/schema.org\/SuperficialAnatomy",
+    "Name":"https://schema.org/SuperficialAnatomy",
     "Domain Bucket":"< 1K"
   },
   {
     "Class":"Itemtype",
-    "Name":"http:\/\/schema.org\/SurgicalProcedure",
+    "Name":"https://schema.org/SurgicalProcedure",
     "Domain Bucket":"< 1K"
   },
   {
     "Class":"Itemtype",
-    "Name":"http:\/\/schema.org\/SuspendAction",
+    "Name":"https://schema.org/SuspendAction",
     "Domain Bucket":"< 1K"
   },
   {
     "Class":"Itemtype",
-    "Name":"http:\/\/schema.org\/Syllabus",
+    "Name":"https://schema.org/Syllabus",
     "Domain Bucket":"1K - 10K"
   },
   {
     "Class":"Itemtype",
-    "Name":"http:\/\/schema.org\/Synagogue",
+    "Name":"https://schema.org/Synagogue",
     "Domain Bucket":"< 1K"
   },
   {
     "Class":"Itemtype",
-    "Name":"http:\/\/schema.org\/TVClip",
+    "Name":"https://schema.org/TVClip",
     "Domain Bucket":"< 1K"
   },
   {
     "Class":"Itemtype",
-    "Name":"http:\/\/schema.org\/TVEpisode",
+    "Name":"https://schema.org/TVEpisode",
     "Domain Bucket":"1K - 10K"
   },
   {
     "Class":"Itemtype",
-    "Name":"http:\/\/schema.org\/TVSeason",
+    "Name":"https://schema.org/TVSeason",
     "Domain Bucket":"1K - 10K"
   },
   {
     "Class":"Itemtype",
-    "Name":"http:\/\/schema.org\/TVSeries",
+    "Name":"https://schema.org/TVSeries",
     "Domain Bucket":"10K - 100K"
   },
   {
     "Class":"Itemtype",
-    "Name":"http:\/\/schema.org\/Table",
+    "Name":"https://schema.org/Table",
     "Domain Bucket":"10K - 100K"
   },
   {
     "Class":"Itemtype",
-    "Name":"http:\/\/schema.org\/TakeAction",
+    "Name":"https://schema.org/TakeAction",
     "Domain Bucket":"< 1K"
   },
   {
     "Class":"Itemtype",
-    "Name":"http:\/\/schema.org\/TattooParlor",
+    "Name":"https://schema.org/TattooParlor",
     "Domain Bucket":"1K - 10K"
   },
   {
     "Class":"Itemtype",
-    "Name":"http:\/\/schema.org\/Taxi",
+    "Name":"https://schema.org/Taxi",
     "Domain Bucket":"< 1K"
   },
   {
     "Class":"Itemtype",
-    "Name":"http:\/\/schema.org\/TaxiReservation",
+    "Name":"https://schema.org/TaxiReservation",
     "Domain Bucket":"< 1K"
   },
   {
     "Class":"Itemtype",
-    "Name":"http:\/\/schema.org\/TaxiService",
+    "Name":"https://schema.org/TaxiService",
     "Domain Bucket":"1K - 10K"
   },
   {
     "Class":"Itemtype",
-    "Name":"http:\/\/schema.org\/TaxiStand",
+    "Name":"https://schema.org/TaxiStand",
     "Domain Bucket":"< 1K"
   },
   {
     "Class":"Itemtype",
-    "Name":"http:\/\/schema.org\/Taxon",
+    "Name":"https://schema.org/Taxon",
     "Domain Bucket":"< 1K"
   },
   {
     "Class":"Itemtype",
-    "Name":"http:\/\/schema.org\/TechArticle",
+    "Name":"https://schema.org/TechArticle",
     "Domain Bucket":"10K - 100K"
   },
   {
     "Class":"Itemtype",
-    "Name":"http:\/\/schema.org\/TelevisionChannel",
+    "Name":"https://schema.org/TelevisionChannel",
     "Domain Bucket":"< 1K"
   },
   {
     "Class":"Itemtype",
-    "Name":"http:\/\/schema.org\/TelevisionStation",
+    "Name":"https://schema.org/TelevisionStation",
     "Domain Bucket":"< 1K"
   },
   {
     "Class":"Itemtype",
-    "Name":"http:\/\/schema.org\/TennisComplex",
+    "Name":"https://schema.org/TennisComplex",
     "Domain Bucket":"< 1K"
   },
   {
     "Class":"Itemtype",
-    "Name":"http:\/\/schema.org\/Text",
+    "Name":"https://schema.org/Text",
     "Domain Bucket":"10K - 100K"
   },
   {
     "Class":"Itemtype",
-    "Name":"http:\/\/schema.org\/TextDigitalDocument",
+    "Name":"https://schema.org/TextDigitalDocument",
     "Domain Bucket":"< 1K"
   },
   {
     "Class":"Itemtype",
-    "Name":"http:\/\/schema.org\/TextObject",
+    "Name":"https://schema.org/TextObject",
     "Domain Bucket":"1K - 10K"
   },
   {
     "Class":"Itemtype",
-    "Name":"http:\/\/schema.org\/TheaterEvent",
+    "Name":"https://schema.org/TheaterEvent",
     "Domain Bucket":"1K - 10K"
   },
   {
     "Class":"Itemtype",
-    "Name":"http:\/\/schema.org\/TheaterGroup",
+    "Name":"https://schema.org/TheaterGroup",
     "Domain Bucket":"1K - 10K"
   },
   {
     "Class":"Itemtype",
-    "Name":"http:\/\/schema.org\/TherapeuticProcedure",
+    "Name":"https://schema.org/TherapeuticProcedure",
     "Domain Bucket":"1K - 10K"
   },
   {
     "Class":"Itemtype",
-    "Name":"http:\/\/schema.org\/Thesis",
+    "Name":"https://schema.org/Thesis",
     "Domain Bucket":"< 1K"
   },
   {
     "Class":"Itemtype",
-    "Name":"http:\/\/schema.org\/Thing",
+    "Name":"https://schema.org/Thing",
     "Domain Bucket":"10M+"
   },
   {
     "Class":"Itemtype",
-    "Name":"http:\/\/schema.org\/Ticket",
+    "Name":"https://schema.org/Ticket",
     "Domain Bucket":"< 1K"
   },
   {
     "Class":"Itemtype",
-    "Name":"http:\/\/schema.org\/TieAction",
+    "Name":"https://schema.org/TieAction",
     "Domain Bucket":"< 1K"
   },
   {
     "Class":"Itemtype",
-    "Name":"http:\/\/schema.org\/TierBenefitEnumeration",
+    "Name":"https://schema.org/TierBenefitEnumeration",
     "Domain Bucket":"< 1K"
   },
   {
     "Class":"Itemtype",
-    "Name":"http:\/\/schema.org\/Time",
+    "Name":"https://schema.org/Time",
     "Domain Bucket":"< 1K"
   },
   {
     "Class":"Itemtype",
-    "Name":"http:\/\/schema.org\/TipAction",
+    "Name":"https://schema.org/TipAction",
     "Domain Bucket":"< 1K"
   },
   {
     "Class":"Itemtype",
-    "Name":"http:\/\/schema.org\/TireShop",
+    "Name":"https://schema.org/TireShop",
     "Domain Bucket":"1K - 10K"
   },
   {
     "Class":"Itemtype",
-    "Name":"http:\/\/schema.org\/TouristAttraction",
+    "Name":"https://schema.org/TouristAttraction",
     "Domain Bucket":"10K - 100K"
   },
   {
     "Class":"Itemtype",
-    "Name":"http:\/\/schema.org\/TouristDestination",
+    "Name":"https://schema.org/TouristDestination",
     "Domain Bucket":"10K - 100K"
   },
   {
     "Class":"Itemtype",
-    "Name":"http:\/\/schema.org\/TouristInformationCenter",
+    "Name":"https://schema.org/TouristInformationCenter",
     "Domain Bucket":"1K - 10K"
   },
   {
     "Class":"Itemtype",
-    "Name":"http:\/\/schema.org\/TouristTrip",
+    "Name":"https://schema.org/TouristTrip",
     "Domain Bucket":"10K - 100K"
   },
   {
     "Class":"Itemtype",
-    "Name":"http:\/\/schema.org\/ToyStore",
+    "Name":"https://schema.org/ToyStore",
     "Domain Bucket":"1K - 10K"
   },
   {
     "Class":"Itemtype",
-    "Name":"http:\/\/schema.org\/TrackAction",
+    "Name":"https://schema.org/TrackAction",
     "Domain Bucket":"< 1K"
   },
   {
     "Class":"Itemtype",
-    "Name":"http:\/\/schema.org\/TradeAction",
+    "Name":"https://schema.org/TradeAction",
     "Domain Bucket":"1K - 10K"
   },
   {
     "Class":"Itemtype",
-    "Name":"http:\/\/schema.org\/TrainReservation",
+    "Name":"https://schema.org/TrainReservation",
     "Domain Bucket":"< 1K"
   },
   {
     "Class":"Itemtype",
-    "Name":"http:\/\/schema.org\/TrainStation",
+    "Name":"https://schema.org/TrainStation",
     "Domain Bucket":"< 1K"
   },
   {
     "Class":"Itemtype",
-    "Name":"http:\/\/schema.org\/TrainTrip",
+    "Name":"https://schema.org/TrainTrip",
     "Domain Bucket":"< 1K"
   },
   {
     "Class":"Itemtype",
-    "Name":"http:\/\/schema.org\/TransferAction",
+    "Name":"https://schema.org/TransferAction",
     "Domain Bucket":"< 1K"
   },
   {
     "Class":"Itemtype",
-    "Name":"http:\/\/schema.org\/TravelAction",
+    "Name":"https://schema.org/TravelAction",
     "Domain Bucket":"1K - 10K"
   },
   {
     "Class":"Itemtype",
-    "Name":"http:\/\/schema.org\/TravelAgency",
+    "Name":"https://schema.org/TravelAgency",
     "Domain Bucket":"10K - 100K"
   },
   {
     "Class":"Itemtype",
-    "Name":"http:\/\/schema.org\/TreatmentIndication",
+    "Name":"https://schema.org/TreatmentIndication",
     "Domain Bucket":"< 1K"
   },
   {
     "Class":"Itemtype",
-    "Name":"http:\/\/schema.org\/Trip",
+    "Name":"https://schema.org/Trip",
     "Domain Bucket":"10K - 100K"
   },
   {
     "Class":"Itemtype",
-    "Name":"http:\/\/schema.org\/TypeAndQuantityNode",
+    "Name":"https://schema.org/TypeAndQuantityNode",
     "Domain Bucket":"< 1K"
   },
   {
     "Class":"Itemtype",
-    "Name":"http:\/\/schema.org\/UKNonprofitType",
+    "Name":"https://schema.org/UKNonprofitType",
     "Domain Bucket":"< 1K"
   },
   {
     "Class":"Itemtype",
-    "Name":"http:\/\/schema.org\/URL",
+    "Name":"https://schema.org/URL",
     "Domain Bucket":"1K - 10K"
   },
   {
     "Class":"Itemtype",
-    "Name":"http:\/\/schema.org\/USNonprofitType",
+    "Name":"https://schema.org/USNonprofitType",
     "Domain Bucket":"< 1K"
   },
   {
     "Class":"Itemtype",
-    "Name":"http:\/\/schema.org\/UnRegisterAction",
+    "Name":"https://schema.org/UnRegisterAction",
     "Domain Bucket":"< 1K"
   },
   {
     "Class":"Itemtype",
-    "Name":"http:\/\/schema.org\/UnitPriceSpecification",
+    "Name":"https://schema.org/UnitPriceSpecification",
     "Domain Bucket":"1M - 10M"
   },
   {
     "Class":"Itemtype",
-    "Name":"http:\/\/schema.org\/UpdateAction",
+    "Name":"https://schema.org/UpdateAction",
     "Domain Bucket":"< 1K"
   },
   {
     "Class":"Itemtype",
-    "Name":"http:\/\/schema.org\/UseAction",
+    "Name":"https://schema.org/UseAction",
     "Domain Bucket":"1K - 10K"
   },
   {
     "Class":"Itemtype",
-    "Name":"http:\/\/schema.org\/UserBlocks",
+    "Name":"https://schema.org/UserBlocks",
     "Domain Bucket":"< 1K"
   },
   {
     "Class":"Itemtype",
-    "Name":"http:\/\/schema.org\/UserCheckins",
+    "Name":"https://schema.org/UserCheckins",
     "Domain Bucket":"1K - 10K"
   },
   {
     "Class":"Itemtype",
-    "Name":"http:\/\/schema.org\/UserComments",
+    "Name":"https://schema.org/UserComments",
     "Domain Bucket":"10K - 100K"
   },
   {
     "Class":"Itemtype",
-    "Name":"http:\/\/schema.org\/UserDownloads",
+    "Name":"https://schema.org/UserDownloads",
     "Domain Bucket":"< 1K"
   },
   {
     "Class":"Itemtype",
-    "Name":"http:\/\/schema.org\/UserInteraction",
+    "Name":"https://schema.org/UserInteraction",
     "Domain Bucket":"< 1K"
   },
   {
     "Class":"Itemtype",
-    "Name":"http:\/\/schema.org\/UserLikes",
+    "Name":"https://schema.org/UserLikes",
     "Domain Bucket":"< 1K"
   },
   {
     "Class":"Itemtype",
-    "Name":"http:\/\/schema.org\/UserPageVisits",
+    "Name":"https://schema.org/UserPageVisits",
     "Domain Bucket":"< 1K"
   },
   {
     "Class":"Itemtype",
-    "Name":"http:\/\/schema.org\/UserPlays",
+    "Name":"https://schema.org/UserPlays",
     "Domain Bucket":"< 1K"
   },
   {
     "Class":"Itemtype",
-    "Name":"http:\/\/schema.org\/UserPlusOnes",
+    "Name":"https://schema.org/UserPlusOnes",
     "Domain Bucket":"< 1K"
   },
   {
     "Class":"Itemtype",
-    "Name":"http:\/\/schema.org\/UserReview",
+    "Name":"https://schema.org/UserReview",
     "Domain Bucket":"1K - 10K"
   },
   {
     "Class":"Itemtype",
-    "Name":"http:\/\/schema.org\/UserTweets",
+    "Name":"https://schema.org/UserTweets",
     "Domain Bucket":"< 1K"
   },
   {
     "Class":"Itemtype",
-    "Name":"http:\/\/schema.org\/VacationRental",
+    "Name":"https://schema.org/VacationRental",
     "Domain Bucket":"10K - 100K"
   },
   {
     "Class":"Itemtype",
-    "Name":"http:\/\/schema.org\/Vehicle",
+    "Name":"https://schema.org/Vehicle",
     "Domain Bucket":"10K - 100K"
   },
   {
     "Class":"Itemtype",
-    "Name":"http:\/\/schema.org\/Vein",
+    "Name":"https://schema.org/Vein",
     "Domain Bucket":"< 1K"
   },
   {
     "Class":"Itemtype",
-    "Name":"http:\/\/schema.org\/Vessel",
+    "Name":"https://schema.org/Vessel",
     "Domain Bucket":"< 1K"
   },
   {
     "Class":"Itemtype",
-    "Name":"http:\/\/schema.org\/VeterinaryCare",
+    "Name":"https://schema.org/VeterinaryCare",
     "Domain Bucket":"1K - 10K"
   },
   {
     "Class":"Itemtype",
-    "Name":"http:\/\/schema.org\/VideoGallery",
+    "Name":"https://schema.org/VideoGallery",
     "Domain Bucket":"1K - 10K"
   },
   {
     "Class":"Itemtype",
-    "Name":"http:\/\/schema.org\/VideoGame",
+    "Name":"https://schema.org/VideoGame",
     "Domain Bucket":"10K - 100K"
   },
   {
     "Class":"Itemtype",
-    "Name":"http:\/\/schema.org\/VideoGameClip",
+    "Name":"https://schema.org/VideoGameClip",
     "Domain Bucket":"< 1K"
   },
   {
     "Class":"Itemtype",
-    "Name":"http:\/\/schema.org\/VideoGameSeries",
+    "Name":"https://schema.org/VideoGameSeries",
     "Domain Bucket":"< 1K"
   },
   {
     "Class":"Itemtype",
-    "Name":"http:\/\/schema.org\/VideoObject",
+    "Name":"https://schema.org/VideoObject",
     "Domain Bucket":"1M - 10M"
   },
   {
     "Class":"Itemtype",
-    "Name":"http:\/\/schema.org\/VideoObjectSnapshot",
+    "Name":"https://schema.org/VideoObjectSnapshot",
     "Domain Bucket":"< 1K"
   },
   {
     "Class":"Itemtype",
-    "Name":"http:\/\/schema.org\/ViewAction",
+    "Name":"https://schema.org/ViewAction",
     "Domain Bucket":"10K - 100K"
   },
   {
     "Class":"Itemtype",
-    "Name":"http:\/\/schema.org\/VirtualLocation",
+    "Name":"https://schema.org/VirtualLocation",
     "Domain Bucket":"10K - 100K"
   },
   {
     "Class":"Itemtype",
-    "Name":"http:\/\/schema.org\/VisualArtsEvent",
+    "Name":"https://schema.org/VisualArtsEvent",
     "Domain Bucket":"< 1K"
   },
   {
     "Class":"Itemtype",
-    "Name":"http:\/\/schema.org\/VisualArtwork",
+    "Name":"https://schema.org/VisualArtwork",
     "Domain Bucket":"1K - 10K"
   },
   {
     "Class":"Itemtype",
-    "Name":"http:\/\/schema.org\/VitalSign",
+    "Name":"https://schema.org/VitalSign",
     "Domain Bucket":"< 1K"
   },
   {
     "Class":"Itemtype",
-    "Name":"http:\/\/schema.org\/Volcano",
+    "Name":"https://schema.org/Volcano",
     "Domain Bucket":"< 1K"
   },
   {
     "Class":"Itemtype",
-    "Name":"http:\/\/schema.org\/VoteAction",
+    "Name":"https://schema.org/VoteAction",
     "Domain Bucket":"< 1K"
   },
   {
     "Class":"Itemtype",
-    "Name":"http:\/\/schema.org\/WPAdBlock",
+    "Name":"https://schema.org/WPAdBlock",
     "Domain Bucket":"10K - 100K"
   },
   {
     "Class":"Itemtype",
-    "Name":"http:\/\/schema.org\/WPFooter",
+    "Name":"https://schema.org/WPFooter",
     "Domain Bucket":"1M - 10M"
   },
   {
     "Class":"Itemtype",
-    "Name":"http:\/\/schema.org\/WPHeader",
+    "Name":"https://schema.org/WPHeader",
     "Domain Bucket":"1M - 10M"
   },
   {
     "Class":"Itemtype",
-    "Name":"http:\/\/schema.org\/WPSideBar",
+    "Name":"https://schema.org/WPSideBar",
     "Domain Bucket":"1M - 10M"
   },
   {
     "Class":"Itemtype",
-    "Name":"http:\/\/schema.org\/WantAction",
+    "Name":"https://schema.org/WantAction",
     "Domain Bucket":"< 1K"
   },
   {
     "Class":"Itemtype",
-    "Name":"http:\/\/schema.org\/WarrantyPromise",
+    "Name":"https://schema.org/WarrantyPromise",
     "Domain Bucket":"10K - 100K"
   },
   {
     "Class":"Itemtype",
-    "Name":"http:\/\/schema.org\/WarrantyScope",
+    "Name":"https://schema.org/WarrantyScope",
     "Domain Bucket":"< 1K"
   },
   {
     "Class":"Itemtype",
-    "Name":"http:\/\/schema.org\/WatchAction",
+    "Name":"https://schema.org/WatchAction",
     "Domain Bucket":"10K - 100K"
   },
   {
     "Class":"Itemtype",
-    "Name":"http:\/\/schema.org\/Waterfall",
+    "Name":"https://schema.org/Waterfall",
     "Domain Bucket":"< 1K"
   },
   {
     "Class":"Itemtype",
-    "Name":"http:\/\/schema.org\/WearAction",
+    "Name":"https://schema.org/WearAction",
     "Domain Bucket":"< 1K"
   },
   {
     "Class":"Itemtype",
-    "Name":"http:\/\/schema.org\/WearableMeasurementTypeEnumeration",
+    "Name":"https://schema.org/WearableMeasurementTypeEnumeration",
     "Domain Bucket":"< 1K"
   },
   {
     "Class":"Itemtype",
-    "Name":"http:\/\/schema.org\/WearableSizeGroupEnumeration",
+    "Name":"https://schema.org/WearableSizeGroupEnumeration",
     "Domain Bucket":"< 1K"
   },
   {
     "Class":"Itemtype",
-    "Name":"http:\/\/schema.org\/WearableSizeSystemEnumeration",
+    "Name":"https://schema.org/WearableSizeSystemEnumeration",
     "Domain Bucket":"< 1K"
   },
   {
     "Class":"Itemtype",
-    "Name":"http:\/\/schema.org\/WebAPI",
+    "Name":"https://schema.org/WebAPI",
     "Domain Bucket":"1K - 10K"
   },
   {
     "Class":"Itemtype",
-    "Name":"http:\/\/schema.org\/WebApplication",
+    "Name":"https://schema.org/WebApplication",
     "Domain Bucket":"100K - 1M"
   },
   {
     "Class":"Itemtype",
-    "Name":"http:\/\/schema.org\/WebContent",
+    "Name":"https://schema.org/WebContent",
     "Domain Bucket":"1K - 10K"
   },
   {
     "Class":"Itemtype",
-    "Name":"http:\/\/schema.org\/WebPage",
+    "Name":"https://schema.org/WebPage",
     "Domain Bucket":"10M+"
   },
   {
     "Class":"Itemtype",
-    "Name":"http:\/\/schema.org\/WebPageElement",
+    "Name":"https://schema.org/WebPageElement",
     "Domain Bucket":"1M - 10M"
   },
   {
     "Class":"Itemtype",
-    "Name":"http:\/\/schema.org\/WebSite",
+    "Name":"https://schema.org/WebSite",
     "Domain Bucket":"10M+"
   },
   {
     "Class":"Itemtype",
-    "Name":"http:\/\/schema.org\/WholesaleStore",
+    "Name":"https://schema.org/WholesaleStore",
     "Domain Bucket":"1K - 10K"
   },
   {
     "Class":"Itemtype",
-    "Name":"http:\/\/schema.org\/WinAction",
+    "Name":"https://schema.org/WinAction",
     "Domain Bucket":"< 1K"
   },
   {
     "Class":"Itemtype",
-    "Name":"http:\/\/schema.org\/Winery",
+    "Name":"https://schema.org/Winery",
     "Domain Bucket":"1K - 10K"
   },
   {
     "Class":"Itemtype",
-    "Name":"http:\/\/schema.org\/WorkBasedProgram",
+    "Name":"https://schema.org/WorkBasedProgram",
     "Domain Bucket":"< 1K"
   },
   {
     "Class":"Itemtype",
-    "Name":"http:\/\/schema.org\/WorkersUnion",
+    "Name":"https://schema.org/WorkersUnion",
     "Domain Bucket":"< 1K"
   },
   {
     "Class":"Itemtype",
-    "Name":"http:\/\/schema.org\/WriteAction",
+    "Name":"https://schema.org/WriteAction",
     "Domain Bucket":"10K - 100K"
   },
   {
     "Class":"Itemtype",
-    "Name":"http:\/\/schema.org\/XPathType",
+    "Name":"https://schema.org/XPathType",
     "Domain Bucket":"< 1K"
   },
   {
     "Class":"Itemtype",
-    "Name":"http:\/\/schema.org\/Zoo",
+    "Name":"https://schema.org/Zoo",
     "Domain Bucket":"< 1K"
   },
   {
     "Class":"Predicate",
-    "Name":"http:\/\/schema.org\/about",
+    "Name":"https://schema.org/about",
     "Domain Bucket":"10M+"
   },
   {
     "Class":"Predicate",
-    "Name":"http:\/\/schema.org\/about-input",
+    "Name":"https://schema.org/about-input",
     "Domain Bucket":"< 1K"
   },
   {
     "Class":"Predicate",
-    "Name":"http:\/\/schema.org\/about-output",
+    "Name":"https://schema.org/about-output",
     "Domain Bucket":"< 1K"
   },
   {
     "Class":"Predicate",
-    "Name":"http:\/\/schema.org\/abridged",
+    "Name":"https://schema.org/abridged",
     "Domain Bucket":"< 1K"
   },
   {
     "Class":"Predicate",
-    "Name":"http:\/\/schema.org\/abridged-input",
+    "Name":"https://schema.org/abridged-input",
     "Domain Bucket":"< 1K"
   },
   {
     "Class":"Predicate",
-    "Name":"http:\/\/schema.org\/abridged-output",
+    "Name":"https://schema.org/abridged-output",
     "Domain Bucket":"< 1K"
   },
   {
     "Class":"Predicate",
-    "Name":"http:\/\/schema.org\/abstract",
+    "Name":"https://schema.org/abstract",
     "Domain Bucket":"10K - 100K"
   },
   {
     "Class":"Predicate",
-    "Name":"http:\/\/schema.org\/abstract-input",
+    "Name":"https://schema.org/abstract-input",
     "Domain Bucket":"< 1K"
   },
   {
     "Class":"Predicate",
-    "Name":"http:\/\/schema.org\/abstract-output",
+    "Name":"https://schema.org/abstract-output",
     "Domain Bucket":"< 1K"
   },
   {
     "Class":"Predicate",
-    "Name":"http:\/\/schema.org\/accelerationTime",
+    "Name":"https://schema.org/accelerationTime",
     "Domain Bucket":"1K - 10K"
   },
   {
     "Class":"Predicate",
-    "Name":"http:\/\/schema.org\/accelerationTime-input",
+    "Name":"https://schema.org/accelerationTime-input",
     "Domain Bucket":"< 1K"
   },
   {
     "Class":"Predicate",
-    "Name":"http:\/\/schema.org\/accelerationTime-output",
+    "Name":"https://schema.org/accelerationTime-output",
     "Domain Bucket":"< 1K"
   },
   {
     "Class":"Predicate",
-    "Name":"http:\/\/schema.org\/acceptedAnswer",
+    "Name":"https://schema.org/acceptedAnswer",
     "Domain Bucket":"1M - 10M"
   },
   {
     "Class":"Predicate",
-    "Name":"http:\/\/schema.org\/acceptedAnswer-input",
+    "Name":"https://schema.org/acceptedAnswer-input",
     "Domain Bucket":"< 1K"
   },
   {
     "Class":"Predicate",
-    "Name":"http:\/\/schema.org\/acceptedAnswer-output",
+    "Name":"https://schema.org/acceptedAnswer-output",
     "Domain Bucket":"< 1K"
   },
   {
     "Class":"Predicate",
-    "Name":"http:\/\/schema.org\/acceptedOffer",
+    "Name":"https://schema.org/acceptedOffer",
     "Domain Bucket":"< 1K"
   },
   {
     "Class":"Predicate",
-    "Name":"http:\/\/schema.org\/acceptedOffer-input",
+    "Name":"https://schema.org/acceptedOffer-input",
     "Domain Bucket":"< 1K"
   },
   {
     "Class":"Predicate",
-    "Name":"http:\/\/schema.org\/acceptedOffer-output",
+    "Name":"https://schema.org/acceptedOffer-output",
     "Domain Bucket":"< 1K"
   },
   {
     "Class":"Predicate",
-    "Name":"http:\/\/schema.org\/acceptedPaymentMethod",
+    "Name":"https://schema.org/acceptedPaymentMethod",
     "Domain Bucket":"10K - 100K"
   },
   {
     "Class":"Predicate",
-    "Name":"http:\/\/schema.org\/acceptedPaymentMethod-input",
+    "Name":"https://schema.org/acceptedPaymentMethod-input",
     "Domain Bucket":"< 1K"
   },
   {
     "Class":"Predicate",
-    "Name":"http:\/\/schema.org\/acceptedPaymentMethod-output",
+    "Name":"https://schema.org/acceptedPaymentMethod-output",
     "Domain Bucket":"< 1K"
   },
   {
     "Class":"Predicate",
-    "Name":"http:\/\/schema.org\/acceptsReservations",
+    "Name":"https://schema.org/acceptsReservations",
     "Domain Bucket":"100K - 1M"
   },
   {
     "Class":"Predicate",
-    "Name":"http:\/\/schema.org\/acceptsReservations-input",
+    "Name":"https://schema.org/acceptsReservations-input",
     "Domain Bucket":"< 1K"
   },
   {
     "Class":"Predicate",
-    "Name":"http:\/\/schema.org\/acceptsReservations-output",
+    "Name":"https://schema.org/acceptsReservations-output",
     "Domain Bucket":"< 1K"
   },
   {
     "Class":"Predicate",
-    "Name":"http:\/\/schema.org\/accessCode",
+    "Name":"https://schema.org/accessCode",
     "Domain Bucket":"< 1K"
   },
   {
     "Class":"Predicate",
-    "Name":"http:\/\/schema.org\/accessCode-input",
+    "Name":"https://schema.org/accessCode-input",
     "Domain Bucket":"< 1K"
   },
   {
     "Class":"Predicate",
-    "Name":"http:\/\/schema.org\/accessCode-output",
+    "Name":"https://schema.org/accessCode-output",
     "Domain Bucket":"< 1K"
   },
   {
     "Class":"Predicate",
-    "Name":"http:\/\/schema.org\/accessMode",
+    "Name":"https://schema.org/accessMode",
     "Domain Bucket":"1K - 10K"
   },
   {
     "Class":"Predicate",
-    "Name":"http:\/\/schema.org\/accessMode-input",
+    "Name":"https://schema.org/accessMode-input",
     "Domain Bucket":"< 1K"
   },
   {
     "Class":"Predicate",
-    "Name":"http:\/\/schema.org\/accessMode-output",
+    "Name":"https://schema.org/accessMode-output",
     "Domain Bucket":"< 1K"
   },
   {
     "Class":"Predicate",
-    "Name":"http:\/\/schema.org\/accessModeSufficient",
+    "Name":"https://schema.org/accessModeSufficient",
     "Domain Bucket":"1K - 10K"
   },
   {
     "Class":"Predicate",
-    "Name":"http:\/\/schema.org\/accessModeSufficient-input",
+    "Name":"https://schema.org/accessModeSufficient-input",
     "Domain Bucket":"< 1K"
   },
   {
     "Class":"Predicate",
-    "Name":"http:\/\/schema.org\/accessModeSufficient-output",
+    "Name":"https://schema.org/accessModeSufficient-output",
     "Domain Bucket":"< 1K"
   },
   {
     "Class":"Predicate",
-    "Name":"http:\/\/schema.org\/accessibilityAPI",
+    "Name":"https://schema.org/accessibilityAPI",
     "Domain Bucket":"1K - 10K"
   },
   {
     "Class":"Predicate",
-    "Name":"http:\/\/schema.org\/accessibilityAPI-input",
+    "Name":"https://schema.org/accessibilityAPI-input",
     "Domain Bucket":"< 1K"
   },
   {
     "Class":"Predicate",
-    "Name":"http:\/\/schema.org\/accessibilityAPI-output",
+    "Name":"https://schema.org/accessibilityAPI-output",
     "Domain Bucket":"< 1K"
   },
   {
     "Class":"Predicate",
-    "Name":"http:\/\/schema.org\/accessibilityControl",
+    "Name":"https://schema.org/accessibilityControl",
     "Domain Bucket":"1K - 10K"
   },
   {
     "Class":"Predicate",
-    "Name":"http:\/\/schema.org\/accessibilityControl-input",
+    "Name":"https://schema.org/accessibilityControl-input",
     "Domain Bucket":"< 1K"
   },
   {
     "Class":"Predicate",
-    "Name":"http:\/\/schema.org\/accessibilityControl-output",
+    "Name":"https://schema.org/accessibilityControl-output",
     "Domain Bucket":"< 1K"
   },
   {
     "Class":"Predicate",
-    "Name":"http:\/\/schema.org\/accessibilityFeature",
+    "Name":"https://schema.org/accessibilityFeature",
     "Domain Bucket":"10K - 100K"
   },
   {
     "Class":"Predicate",
-    "Name":"http:\/\/schema.org\/accessibilityFeature-input",
+    "Name":"https://schema.org/accessibilityFeature-input",
     "Domain Bucket":"< 1K"
   },
   {
     "Class":"Predicate",
-    "Name":"http:\/\/schema.org\/accessibilityFeature-output",
+    "Name":"https://schema.org/accessibilityFeature-output",
     "Domain Bucket":"< 1K"
   },
   {
     "Class":"Predicate",
-    "Name":"http:\/\/schema.org\/accessibilityHazard",
+    "Name":"https://schema.org/accessibilityHazard",
     "Domain Bucket":"1K - 10K"
   },
   {
     "Class":"Predicate",
-    "Name":"http:\/\/schema.org\/accessibilityHazard-input",
+    "Name":"https://schema.org/accessibilityHazard-input",
     "Domain Bucket":"< 1K"
   },
   {
     "Class":"Predicate",
-    "Name":"http:\/\/schema.org\/accessibilityHazard-output",
+    "Name":"https://schema.org/accessibilityHazard-output",
     "Domain Bucket":"< 1K"
   },
   {
     "Class":"Predicate",
-    "Name":"http:\/\/schema.org\/accessibilitySummary",
+    "Name":"https://schema.org/accessibilitySummary",
     "Domain Bucket":"10K - 100K"
   },
   {
     "Class":"Predicate",
-    "Name":"http:\/\/schema.org\/accessibilitySummary-input",
+    "Name":"https://schema.org/accessibilitySummary-input",
     "Domain Bucket":"< 1K"
   },
   {
     "Class":"Predicate",
-    "Name":"http:\/\/schema.org\/accessibilitySummary-output",
+    "Name":"https://schema.org/accessibilitySummary-output",
     "Domain Bucket":"< 1K"
   },
   {
     "Class":"Predicate",
-    "Name":"http:\/\/schema.org\/accommodationCategory",
+    "Name":"https://schema.org/accommodationCategory",
     "Domain Bucket":"1K - 10K"
   },
   {
     "Class":"Predicate",
-    "Name":"http:\/\/schema.org\/accommodationCategory-input",
+    "Name":"https://schema.org/accommodationCategory-input",
     "Domain Bucket":"< 1K"
   },
   {
     "Class":"Predicate",
-    "Name":"http:\/\/schema.org\/accommodationCategory-output",
+    "Name":"https://schema.org/accommodationCategory-output",
     "Domain Bucket":"< 1K"
   },
   {
     "Class":"Predicate",
-    "Name":"http:\/\/schema.org\/accommodationFloorPlan",
+    "Name":"https://schema.org/accommodationFloorPlan",
     "Domain Bucket":"10K - 100K"
   },
   {
     "Class":"Predicate",
-    "Name":"http:\/\/schema.org\/accommodationFloorPlan-input",
+    "Name":"https://schema.org/accommodationFloorPlan-input",
     "Domain Bucket":"< 1K"
   },
   {
     "Class":"Predicate",
-    "Name":"http:\/\/schema.org\/accommodationFloorPlan-output",
+    "Name":"https://schema.org/accommodationFloorPlan-output",
     "Domain Bucket":"< 1K"
   },
   {
     "Class":"Predicate",
-    "Name":"http:\/\/schema.org\/accountId",
+    "Name":"https://schema.org/accountId",
     "Domain Bucket":"< 1K"
   },
   {
     "Class":"Predicate",
-    "Name":"http:\/\/schema.org\/accountId-input",
+    "Name":"https://schema.org/accountId-input",
     "Domain Bucket":"< 1K"
   },
   {
     "Class":"Predicate",
-    "Name":"http:\/\/schema.org\/accountId-output",
+    "Name":"https://schema.org/accountId-output",
     "Domain Bucket":"< 1K"
   },
   {
     "Class":"Predicate",
-    "Name":"http:\/\/schema.org\/accountMinimumInflow",
+    "Name":"https://schema.org/accountMinimumInflow",
     "Domain Bucket":"< 1K"
   },
   {
     "Class":"Predicate",
-    "Name":"http:\/\/schema.org\/accountMinimumInflow-input",
+    "Name":"https://schema.org/accountMinimumInflow-input",
     "Domain Bucket":"< 1K"
   },
   {
     "Class":"Predicate",
-    "Name":"http:\/\/schema.org\/accountMinimumInflow-output",
+    "Name":"https://schema.org/accountMinimumInflow-output",
     "Domain Bucket":"< 1K"
   },
   {
     "Class":"Predicate",
-    "Name":"http:\/\/schema.org\/accountOverdraftLimit",
+    "Name":"https://schema.org/accountOverdraftLimit",
     "Domain Bucket":"< 1K"
   },
   {
     "Class":"Predicate",
-    "Name":"http:\/\/schema.org\/accountOverdraftLimit-input",
+    "Name":"https://schema.org/accountOverdraftLimit-input",
     "Domain Bucket":"< 1K"
   },
   {
     "Class":"Predicate",
-    "Name":"http:\/\/schema.org\/accountOverdraftLimit-output",
+    "Name":"https://schema.org/accountOverdraftLimit-output",
     "Domain Bucket":"< 1K"
   },
   {
     "Class":"Predicate",
-    "Name":"http:\/\/schema.org\/accountablePerson",
+    "Name":"https://schema.org/accountablePerson",
     "Domain Bucket":"10K - 100K"
   },
   {
     "Class":"Predicate",
-    "Name":"http:\/\/schema.org\/accountablePerson-input",
+    "Name":"https://schema.org/accountablePerson-input",
     "Domain Bucket":"< 1K"
   },
   {
     "Class":"Predicate",
-    "Name":"http:\/\/schema.org\/accountablePerson-output",
+    "Name":"https://schema.org/accountablePerson-output",
     "Domain Bucket":"< 1K"
   },
   {
     "Class":"Predicate",
-    "Name":"http:\/\/schema.org\/acquireLicensePage",
+    "Name":"https://schema.org/acquireLicensePage",
     "Domain Bucket":"10K - 100K"
   },
   {
     "Class":"Predicate",
-    "Name":"http:\/\/schema.org\/acquireLicensePage-input",
+    "Name":"https://schema.org/acquireLicensePage-input",
     "Domain Bucket":"< 1K"
   },
   {
     "Class":"Predicate",
-    "Name":"http:\/\/schema.org\/acquireLicensePage-output",
+    "Name":"https://schema.org/acquireLicensePage-output",
     "Domain Bucket":"< 1K"
   },
   {
     "Class":"Predicate",
-    "Name":"http:\/\/schema.org\/acquiredFrom",
+    "Name":"https://schema.org/acquiredFrom",
     "Domain Bucket":"< 1K"
   },
   {
     "Class":"Predicate",
-    "Name":"http:\/\/schema.org\/acquiredFrom-input",
+    "Name":"https://schema.org/acquiredFrom-input",
     "Domain Bucket":"< 1K"
   },
   {
     "Class":"Predicate",
-    "Name":"http:\/\/schema.org\/acquiredFrom-output",
+    "Name":"https://schema.org/acquiredFrom-output",
     "Domain Bucket":"< 1K"
   },
   {
     "Class":"Predicate",
-    "Name":"http:\/\/schema.org\/acrissCode",
+    "Name":"https://schema.org/acrissCode",
     "Domain Bucket":"< 1K"
   },
   {
     "Class":"Predicate",
-    "Name":"http:\/\/schema.org\/acrissCode-input",
+    "Name":"https://schema.org/acrissCode-input",
     "Domain Bucket":"< 1K"
   },
   {
     "Class":"Predicate",
-    "Name":"http:\/\/schema.org\/acrissCode-output",
+    "Name":"https://schema.org/acrissCode-output",
     "Domain Bucket":"< 1K"
   },
   {
     "Class":"Predicate",
-    "Name":"http:\/\/schema.org\/actionAccessibilityRequirement",
+    "Name":"https://schema.org/actionAccessibilityRequirement",
     "Domain Bucket":"< 1K"
   },
   {
     "Class":"Predicate",
-    "Name":"http:\/\/schema.org\/actionAccessibilityRequirement-input",
+    "Name":"https://schema.org/actionAccessibilityRequirement-input",
     "Domain Bucket":"< 1K"
   },
   {
     "Class":"Predicate",
-    "Name":"http:\/\/schema.org\/actionAccessibilityRequirement-output",
+    "Name":"https://schema.org/actionAccessibilityRequirement-output",
     "Domain Bucket":"< 1K"
   },
   {
     "Class":"Predicate",
-    "Name":"http:\/\/schema.org\/actionApplication",
+    "Name":"https://schema.org/actionApplication",
     "Domain Bucket":"1K - 10K"
   },
   {
     "Class":"Predicate",
-    "Name":"http:\/\/schema.org\/actionApplication-input",
+    "Name":"https://schema.org/actionApplication-input",
     "Domain Bucket":"< 1K"
   },
   {
     "Class":"Predicate",
-    "Name":"http:\/\/schema.org\/actionApplication-output",
+    "Name":"https://schema.org/actionApplication-output",
     "Domain Bucket":"< 1K"
   },
   {
     "Class":"Predicate",
-    "Name":"http:\/\/schema.org\/actionOption",
+    "Name":"https://schema.org/actionOption",
     "Domain Bucket":"1K - 10K"
   },
   {
     "Class":"Predicate",
-    "Name":"http:\/\/schema.org\/actionOption-input",
+    "Name":"https://schema.org/actionOption-input",
     "Domain Bucket":"< 1K"
   },
   {
     "Class":"Predicate",
-    "Name":"http:\/\/schema.org\/actionOption-output",
+    "Name":"https://schema.org/actionOption-output",
     "Domain Bucket":"< 1K"
   },
   {
     "Class":"Predicate",
-    "Name":"http:\/\/schema.org\/actionPlatform",
+    "Name":"https://schema.org/actionPlatform",
     "Domain Bucket":"100K - 1M"
   },
   {
     "Class":"Predicate",
-    "Name":"http:\/\/schema.org\/actionPlatform-input",
+    "Name":"https://schema.org/actionPlatform-input",
     "Domain Bucket":"< 1K"
   },
   {
     "Class":"Predicate",
-    "Name":"http:\/\/schema.org\/actionPlatform-output",
+    "Name":"https://schema.org/actionPlatform-output",
     "Domain Bucket":"< 1K"
   },
   {
     "Class":"Predicate",
-    "Name":"http:\/\/schema.org\/actionProcess",
+    "Name":"https://schema.org/actionProcess",
     "Domain Bucket":"< 1K"
   },
   {
     "Class":"Predicate",
-    "Name":"http:\/\/schema.org\/actionProcess-input",
+    "Name":"https://schema.org/actionProcess-input",
     "Domain Bucket":"< 1K"
   },
   {
     "Class":"Predicate",
-    "Name":"http:\/\/schema.org\/actionProcess-output",
+    "Name":"https://schema.org/actionProcess-output",
     "Domain Bucket":"< 1K"
   },
   {
     "Class":"Predicate",
-    "Name":"http:\/\/schema.org\/actionStatus",
+    "Name":"https://schema.org/actionStatus",
     "Domain Bucket":"10K - 100K"
   },
   {
     "Class":"Predicate",
-    "Name":"http:\/\/schema.org\/actionStatus-input",
+    "Name":"https://schema.org/actionStatus-input",
     "Domain Bucket":"< 1K"
   },
   {
     "Class":"Predicate",
-    "Name":"http:\/\/schema.org\/actionStatus-output",
+    "Name":"https://schema.org/actionStatus-output",
     "Domain Bucket":"< 1K"
   },
   {
     "Class":"Predicate",
-    "Name":"http:\/\/schema.org\/actionableFeedbackPolicy",
+    "Name":"https://schema.org/actionableFeedbackPolicy",
     "Domain Bucket":"10K - 100K"
   },
   {
     "Class":"Predicate",
-    "Name":"http:\/\/schema.org\/actionableFeedbackPolicy-input",
+    "Name":"https://schema.org/actionableFeedbackPolicy-input",
     "Domain Bucket":"< 1K"
   },
   {
     "Class":"Predicate",
-    "Name":"http:\/\/schema.org\/actionableFeedbackPolicy-output",
+    "Name":"https://schema.org/actionableFeedbackPolicy-output",
     "Domain Bucket":"< 1K"
   },
   {
     "Class":"Predicate",
-    "Name":"http:\/\/schema.org\/activeIngredient",
+    "Name":"https://schema.org/activeIngredient",
     "Domain Bucket":"1K - 10K"
   },
   {
     "Class":"Predicate",
-    "Name":"http:\/\/schema.org\/activeIngredient-input",
+    "Name":"https://schema.org/activeIngredient-input",
     "Domain Bucket":"< 1K"
   },
   {
     "Class":"Predicate",
-    "Name":"http:\/\/schema.org\/activeIngredient-output",
+    "Name":"https://schema.org/activeIngredient-output",
     "Domain Bucket":"< 1K"
   },
   {
     "Class":"Predicate",
-    "Name":"http:\/\/schema.org\/activityDuration",
+    "Name":"https://schema.org/activityDuration",
     "Domain Bucket":"< 1K"
   },
   {
     "Class":"Predicate",
-    "Name":"http:\/\/schema.org\/activityDuration-input",
+    "Name":"https://schema.org/activityDuration-input",
     "Domain Bucket":"< 1K"
   },
   {
     "Class":"Predicate",
-    "Name":"http:\/\/schema.org\/activityDuration-output",
+    "Name":"https://schema.org/activityDuration-output",
     "Domain Bucket":"< 1K"
   },
   {
     "Class":"Predicate",
-    "Name":"http:\/\/schema.org\/activityFrequency",
+    "Name":"https://schema.org/activityFrequency",
     "Domain Bucket":"< 1K"
   },
   {
     "Class":"Predicate",
-    "Name":"http:\/\/schema.org\/activityFrequency-input",
+    "Name":"https://schema.org/activityFrequency-input",
     "Domain Bucket":"< 1K"
   },
   {
     "Class":"Predicate",
-    "Name":"http:\/\/schema.org\/activityFrequency-output",
+    "Name":"https://schema.org/activityFrequency-output",
     "Domain Bucket":"< 1K"
   },
   {
     "Class":"Predicate",
-    "Name":"http:\/\/schema.org\/actor",
+    "Name":"https://schema.org/actor",
     "Domain Bucket":"10K - 100K"
   },
   {
     "Class":"Predicate",
-    "Name":"http:\/\/schema.org\/actor-input",
+    "Name":"https://schema.org/actor-input",
     "Domain Bucket":"< 1K"
   },
   {
     "Class":"Predicate",
-    "Name":"http:\/\/schema.org\/actor-output",
+    "Name":"https://schema.org/actor-output",
     "Domain Bucket":"< 1K"
   },
   {
     "Class":"Predicate",
-    "Name":"http:\/\/schema.org\/actors",
+    "Name":"https://schema.org/actors",
     "Domain Bucket":"1K - 10K"
   },
   {
     "Class":"Predicate",
-    "Name":"http:\/\/schema.org\/actors-input",
+    "Name":"https://schema.org/actors-input",
     "Domain Bucket":"< 1K"
   },
   {
     "Class":"Predicate",
-    "Name":"http:\/\/schema.org\/actors-output",
+    "Name":"https://schema.org/actors-output",
     "Domain Bucket":"< 1K"
   },
   {
     "Class":"Predicate",
-    "Name":"http:\/\/schema.org\/addOn",
+    "Name":"https://schema.org/addOn",
     "Domain Bucket":"1K - 10K"
   },
   {
     "Class":"Predicate",
-    "Name":"http:\/\/schema.org\/addOn-input",
+    "Name":"https://schema.org/addOn-input",
     "Domain Bucket":"< 1K"
   },
   {
     "Class":"Predicate",
-    "Name":"http:\/\/schema.org\/addOn-output",
+    "Name":"https://schema.org/addOn-output",
     "Domain Bucket":"< 1K"
   },
   {
     "Class":"Predicate",
-    "Name":"http:\/\/schema.org\/additionalName",
+    "Name":"https://schema.org/additionalName",
     "Domain Bucket":"10K - 100K"
   },
   {
     "Class":"Predicate",
-    "Name":"http:\/\/schema.org\/additionalName-input",
+    "Name":"https://schema.org/additionalName-input",
     "Domain Bucket":"< 1K"
   },
   {
     "Class":"Predicate",
-    "Name":"http:\/\/schema.org\/additionalName-output",
+    "Name":"https://schema.org/additionalName-output",
     "Domain Bucket":"< 1K"
   },
   {
     "Class":"Predicate",
-    "Name":"http:\/\/schema.org\/additionalNumberOfGuests",
+    "Name":"https://schema.org/additionalNumberOfGuests",
     "Domain Bucket":"< 1K"
   },
   {
     "Class":"Predicate",
-    "Name":"http:\/\/schema.org\/additionalNumberOfGuests-input",
+    "Name":"https://schema.org/additionalNumberOfGuests-input",
     "Domain Bucket":"< 1K"
   },
   {
     "Class":"Predicate",
-    "Name":"http:\/\/schema.org\/additionalNumberOfGuests-output",
+    "Name":"https://schema.org/additionalNumberOfGuests-output",
     "Domain Bucket":"< 1K"
   },
   {
     "Class":"Predicate",
-    "Name":"http:\/\/schema.org\/additionalProperty",
+    "Name":"https://schema.org/additionalProperty",
     "Domain Bucket":"100K - 1M"
   },
   {
     "Class":"Predicate",
-    "Name":"http:\/\/schema.org\/additionalProperty-input",
+    "Name":"https://schema.org/additionalProperty-input",
     "Domain Bucket":"< 1K"
   },
   {
     "Class":"Predicate",
-    "Name":"http:\/\/schema.org\/additionalProperty-output",
+    "Name":"https://schema.org/additionalProperty-output",
     "Domain Bucket":"< 1K"
   },
   {
     "Class":"Predicate",
-    "Name":"http:\/\/schema.org\/additionalType",
+    "Name":"https://schema.org/additionalType",
     "Domain Bucket":"100K - 1M"
   },
   {
     "Class":"Predicate",
-    "Name":"http:\/\/schema.org\/additionalType-input",
+    "Name":"https://schema.org/additionalType-input",
     "Domain Bucket":"< 1K"
   },
   {
     "Class":"Predicate",
-    "Name":"http:\/\/schema.org\/additionalType-output",
+    "Name":"https://schema.org/additionalType-output",
     "Domain Bucket":"< 1K"
   },
   {
     "Class":"Predicate",
-    "Name":"http:\/\/schema.org\/additionalVariable",
+    "Name":"https://schema.org/additionalVariable",
     "Domain Bucket":"< 1K"
   },
   {
     "Class":"Predicate",
-    "Name":"http:\/\/schema.org\/additionalVariable-input",
+    "Name":"https://schema.org/additionalVariable-input",
     "Domain Bucket":"< 1K"
   },
   {
     "Class":"Predicate",
-    "Name":"http:\/\/schema.org\/additionalVariable-output",
+    "Name":"https://schema.org/additionalVariable-output",
     "Domain Bucket":"< 1K"
   },
   {
     "Class":"Predicate",
-    "Name":"http:\/\/schema.org\/address",
+    "Name":"https://schema.org/address",
     "Domain Bucket":"1M - 10M"
   },
   {
     "Class":"Predicate",
-    "Name":"http:\/\/schema.org\/address-input",
+    "Name":"https://schema.org/address-input",
     "Domain Bucket":"< 1K"
   },
   {
     "Class":"Predicate",
-    "Name":"http:\/\/schema.org\/address-output",
+    "Name":"https://schema.org/address-output",
     "Domain Bucket":"< 1K"
   },
   {
     "Class":"Predicate",
-    "Name":"http:\/\/schema.org\/addressCountry",
+    "Name":"https://schema.org/addressCountry",
     "Domain Bucket":"1M - 10M"
   },
   {
     "Class":"Predicate",
-    "Name":"http:\/\/schema.org\/addressCountry-input",
+    "Name":"https://schema.org/addressCountry-input",
     "Domain Bucket":"< 1K"
   },
   {
     "Class":"Predicate",
-    "Name":"http:\/\/schema.org\/addressCountry-output",
+    "Name":"https://schema.org/addressCountry-output",
     "Domain Bucket":"< 1K"
   },
   {
     "Class":"Predicate",
-    "Name":"http:\/\/schema.org\/addressLocality",
+    "Name":"https://schema.org/addressLocality",
     "Domain Bucket":"1M - 10M"
   },
   {
     "Class":"Predicate",
-    "Name":"http:\/\/schema.org\/addressLocality-input",
+    "Name":"https://schema.org/addressLocality-input",
     "Domain Bucket":"< 1K"
   },
   {
     "Class":"Predicate",
-    "Name":"http:\/\/schema.org\/addressLocality-output",
+    "Name":"https://schema.org/addressLocality-output",
     "Domain Bucket":"< 1K"
   },
   {
     "Class":"Predicate",
-    "Name":"http:\/\/schema.org\/addressRegion",
+    "Name":"https://schema.org/addressRegion",
     "Domain Bucket":"1M - 10M"
   },
   {
     "Class":"Predicate",
-    "Name":"http:\/\/schema.org\/addressRegion-input",
+    "Name":"https://schema.org/addressRegion-input",
     "Domain Bucket":"< 1K"
   },
   {
     "Class":"Predicate",
-    "Name":"http:\/\/schema.org\/addressRegion-output",
+    "Name":"https://schema.org/addressRegion-output",
     "Domain Bucket":"< 1K"
   },
   {
     "Class":"Predicate",
-    "Name":"http:\/\/schema.org\/administrationRoute",
+    "Name":"https://schema.org/administrationRoute",
     "Domain Bucket":"1K - 10K"
   },
   {
     "Class":"Predicate",
-    "Name":"http:\/\/schema.org\/administrationRoute-input",
+    "Name":"https://schema.org/administrationRoute-input",
     "Domain Bucket":"< 1K"
   },
   {
     "Class":"Predicate",
-    "Name":"http:\/\/schema.org\/administrationRoute-output",
+    "Name":"https://schema.org/administrationRoute-output",
     "Domain Bucket":"< 1K"
   },
   {
     "Class":"Predicate",
-    "Name":"http:\/\/schema.org\/advanceBookingRequirement",
+    "Name":"https://schema.org/advanceBookingRequirement",
     "Domain Bucket":"< 1K"
   },
   {
     "Class":"Predicate",
-    "Name":"http:\/\/schema.org\/advanceBookingRequirement-input",
+    "Name":"https://schema.org/advanceBookingRequirement-input",
     "Domain Bucket":"< 1K"
   },
   {
     "Class":"Predicate",
-    "Name":"http:\/\/schema.org\/advanceBookingRequirement-output",
+    "Name":"https://schema.org/advanceBookingRequirement-output",
     "Domain Bucket":"< 1K"
   },
   {
     "Class":"Predicate",
-    "Name":"http:\/\/schema.org\/adverseOutcome",
+    "Name":"https://schema.org/adverseOutcome",
     "Domain Bucket":"< 1K"
   },
   {
     "Class":"Predicate",
-    "Name":"http:\/\/schema.org\/adverseOutcome-input",
+    "Name":"https://schema.org/adverseOutcome-input",
     "Domain Bucket":"< 1K"
   },
   {
     "Class":"Predicate",
-    "Name":"http:\/\/schema.org\/adverseOutcome-output",
+    "Name":"https://schema.org/adverseOutcome-output",
     "Domain Bucket":"< 1K"
   },
   {
     "Class":"Predicate",
-    "Name":"http:\/\/schema.org\/affectedBy",
+    "Name":"https://schema.org/affectedBy",
     "Domain Bucket":"< 1K"
   },
   {
     "Class":"Predicate",
-    "Name":"http:\/\/schema.org\/affectedBy-input",
+    "Name":"https://schema.org/affectedBy-input",
     "Domain Bucket":"< 1K"
   },
   {
     "Class":"Predicate",
-    "Name":"http:\/\/schema.org\/affectedBy-output",
+    "Name":"https://schema.org/affectedBy-output",
     "Domain Bucket":"< 1K"
   },
   {
     "Class":"Predicate",
-    "Name":"http:\/\/schema.org\/affiliation",
+    "Name":"https://schema.org/affiliation",
     "Domain Bucket":"10K - 100K"
   },
   {
     "Class":"Predicate",
-    "Name":"http:\/\/schema.org\/affiliation-input",
+    "Name":"https://schema.org/affiliation-input",
     "Domain Bucket":"< 1K"
   },
   {
     "Class":"Predicate",
-    "Name":"http:\/\/schema.org\/affiliation-output",
+    "Name":"https://schema.org/affiliation-output",
     "Domain Bucket":"< 1K"
   },
   {
     "Class":"Predicate",
-    "Name":"http:\/\/schema.org\/afterMedia",
+    "Name":"https://schema.org/afterMedia",
     "Domain Bucket":"< 1K"
   },
   {
     "Class":"Predicate",
-    "Name":"http:\/\/schema.org\/afterMedia-input",
+    "Name":"https://schema.org/afterMedia-input",
     "Domain Bucket":"< 1K"
   },
   {
     "Class":"Predicate",
-    "Name":"http:\/\/schema.org\/afterMedia-output",
+    "Name":"https://schema.org/afterMedia-output",
     "Domain Bucket":"< 1K"
   },
   {
     "Class":"Predicate",
-    "Name":"http:\/\/schema.org\/agent",
+    "Name":"https://schema.org/agent",
     "Domain Bucket":"10K - 100K"
   },
   {
     "Class":"Predicate",
-    "Name":"http:\/\/schema.org\/agent-input",
+    "Name":"https://schema.org/agent-input",
     "Domain Bucket":"< 1K"
   },
   {
     "Class":"Predicate",
-    "Name":"http:\/\/schema.org\/agent-output",
+    "Name":"https://schema.org/agent-output",
     "Domain Bucket":"< 1K"
   },
   {
     "Class":"Predicate",
-    "Name":"http:\/\/schema.org\/agentInteractionStatistic",
+    "Name":"https://schema.org/agentInteractionStatistic",
     "Domain Bucket":"10K - 100K"
   },
   {
     "Class":"Predicate",
-    "Name":"http:\/\/schema.org\/agentInteractionStatistic-input",
+    "Name":"https://schema.org/agentInteractionStatistic-input",
     "Domain Bucket":"< 1K"
   },
   {
     "Class":"Predicate",
-    "Name":"http:\/\/schema.org\/agentInteractionStatistic-output",
+    "Name":"https://schema.org/agentInteractionStatistic-output",
     "Domain Bucket":"< 1K"
   },
   {
     "Class":"Predicate",
-    "Name":"http:\/\/schema.org\/aggregateElement",
+    "Name":"https://schema.org/aggregateElement",
     "Domain Bucket":"< 1K"
   },
   {
     "Class":"Predicate",
-    "Name":"http:\/\/schema.org\/aggregateElement-input",
+    "Name":"https://schema.org/aggregateElement-input",
     "Domain Bucket":"< 1K"
   },
   {
     "Class":"Predicate",
-    "Name":"http:\/\/schema.org\/aggregateElement-output",
+    "Name":"https://schema.org/aggregateElement-output",
     "Domain Bucket":"< 1K"
   },
   {
     "Class":"Predicate",
-    "Name":"http:\/\/schema.org\/aggregateRating",
+    "Name":"https://schema.org/aggregateRating",
     "Domain Bucket":"1M - 10M"
   },
   {
     "Class":"Predicate",
-    "Name":"http:\/\/schema.org\/aggregateRating-input",
+    "Name":"https://schema.org/aggregateRating-input",
     "Domain Bucket":"< 1K"
   },
   {
     "Class":"Predicate",
-    "Name":"http:\/\/schema.org\/aggregateRating-output",
+    "Name":"https://schema.org/aggregateRating-output",
     "Domain Bucket":"< 1K"
   },
   {
     "Class":"Predicate",
-    "Name":"http:\/\/schema.org\/aircraft",
+    "Name":"https://schema.org/aircraft",
     "Domain Bucket":"< 1K"
   },
   {
     "Class":"Predicate",
-    "Name":"http:\/\/schema.org\/aircraft-input",
+    "Name":"https://schema.org/aircraft-input",
     "Domain Bucket":"< 1K"
   },
   {
     "Class":"Predicate",
-    "Name":"http:\/\/schema.org\/aircraft-output",
+    "Name":"https://schema.org/aircraft-output",
     "Domain Bucket":"< 1K"
   },
   {
     "Class":"Predicate",
-    "Name":"http:\/\/schema.org\/album",
+    "Name":"https://schema.org/album",
     "Domain Bucket":"1K - 10K"
   },
   {
     "Class":"Predicate",
-    "Name":"http:\/\/schema.org\/album-input",
+    "Name":"https://schema.org/album-input",
     "Domain Bucket":"< 1K"
   },
   {
     "Class":"Predicate",
-    "Name":"http:\/\/schema.org\/album-output",
+    "Name":"https://schema.org/album-output",
     "Domain Bucket":"< 1K"
   },
   {
     "Class":"Predicate",
-    "Name":"http:\/\/schema.org\/albumProductionType",
+    "Name":"https://schema.org/albumProductionType",
     "Domain Bucket":"< 1K"
   },
   {
     "Class":"Predicate",
-    "Name":"http:\/\/schema.org\/albumProductionType-input",
+    "Name":"https://schema.org/albumProductionType-input",
     "Domain Bucket":"< 1K"
   },
   {
     "Class":"Predicate",
-    "Name":"http:\/\/schema.org\/albumProductionType-output",
+    "Name":"https://schema.org/albumProductionType-output",
     "Domain Bucket":"< 1K"
   },
   {
     "Class":"Predicate",
-    "Name":"http:\/\/schema.org\/albumRelease",
+    "Name":"https://schema.org/albumRelease",
     "Domain Bucket":"1K - 10K"
   },
   {
     "Class":"Predicate",
-    "Name":"http:\/\/schema.org\/albumRelease-input",
+    "Name":"https://schema.org/albumRelease-input",
     "Domain Bucket":"< 1K"
   },
   {
     "Class":"Predicate",
-    "Name":"http:\/\/schema.org\/albumRelease-output",
+    "Name":"https://schema.org/albumRelease-output",
     "Domain Bucket":"< 1K"
   },
   {
     "Class":"Predicate",
-    "Name":"http:\/\/schema.org\/albumReleaseType",
+    "Name":"https://schema.org/albumReleaseType",
     "Domain Bucket":"1K - 10K"
   },
   {
     "Class":"Predicate",
-    "Name":"http:\/\/schema.org\/albumReleaseType-input",
+    "Name":"https://schema.org/albumReleaseType-input",
     "Domain Bucket":"< 1K"
   },
   {
     "Class":"Predicate",
-    "Name":"http:\/\/schema.org\/albumReleaseType-output",
+    "Name":"https://schema.org/albumReleaseType-output",
     "Domain Bucket":"< 1K"
   },
   {
     "Class":"Predicate",
-    "Name":"http:\/\/schema.org\/albums",
+    "Name":"https://schema.org/albums",
     "Domain Bucket":"< 1K"
   },
   {
     "Class":"Predicate",
-    "Name":"http:\/\/schema.org\/albums-input",
+    "Name":"https://schema.org/albums-input",
     "Domain Bucket":"< 1K"
   },
   {
     "Class":"Predicate",
-    "Name":"http:\/\/schema.org\/albums-output",
+    "Name":"https://schema.org/albums-output",
     "Domain Bucket":"< 1K"
   },
   {
     "Class":"Predicate",
-    "Name":"http:\/\/schema.org\/alcoholWarning",
+    "Name":"https://schema.org/alcoholWarning",
     "Domain Bucket":"< 1K"
   },
   {
     "Class":"Predicate",
-    "Name":"http:\/\/schema.org\/alcoholWarning-input",
+    "Name":"https://schema.org/alcoholWarning-input",
     "Domain Bucket":"< 1K"
   },
   {
     "Class":"Predicate",
-    "Name":"http:\/\/schema.org\/alcoholWarning-output",
+    "Name":"https://schema.org/alcoholWarning-output",
     "Domain Bucket":"< 1K"
   },
   {
     "Class":"Predicate",
-    "Name":"http:\/\/schema.org\/algorithm",
+    "Name":"https://schema.org/algorithm",
     "Domain Bucket":"< 1K"
   },
   {
     "Class":"Predicate",
-    "Name":"http:\/\/schema.org\/algorithm-input",
+    "Name":"https://schema.org/algorithm-input",
     "Domain Bucket":"< 1K"
   },
   {
     "Class":"Predicate",
-    "Name":"http:\/\/schema.org\/algorithm-output",
+    "Name":"https://schema.org/algorithm-output",
     "Domain Bucket":"< 1K"
   },
   {
     "Class":"Predicate",
-    "Name":"http:\/\/schema.org\/alignmentType",
+    "Name":"https://schema.org/alignmentType",
     "Domain Bucket":"1K - 10K"
   },
   {
     "Class":"Predicate",
-    "Name":"http:\/\/schema.org\/alignmentType-input",
+    "Name":"https://schema.org/alignmentType-input",
     "Domain Bucket":"< 1K"
   },
   {
     "Class":"Predicate",
-    "Name":"http:\/\/schema.org\/alignmentType-output",
+    "Name":"https://schema.org/alignmentType-output",
     "Domain Bucket":"< 1K"
   },
   {
     "Class":"Predicate",
-    "Name":"http:\/\/schema.org\/alternateName",
+    "Name":"https://schema.org/alternateName",
     "Domain Bucket":"1M - 10M"
   },
   {
     "Class":"Predicate",
-    "Name":"http:\/\/schema.org\/alternateName-input",
+    "Name":"https://schema.org/alternateName-input",
     "Domain Bucket":"< 1K"
   },
   {
     "Class":"Predicate",
-    "Name":"http:\/\/schema.org\/alternateName-output",
+    "Name":"https://schema.org/alternateName-output",
     "Domain Bucket":"< 1K"
   },
   {
     "Class":"Predicate",
-    "Name":"http:\/\/schema.org\/alternativeHeadline",
+    "Name":"https://schema.org/alternativeHeadline",
     "Domain Bucket":"100K - 1M"
   },
   {
     "Class":"Predicate",
-    "Name":"http:\/\/schema.org\/alternativeHeadline-input",
+    "Name":"https://schema.org/alternativeHeadline-input",
     "Domain Bucket":"< 1K"
   },
   {
     "Class":"Predicate",
-    "Name":"http:\/\/schema.org\/alternativeHeadline-output",
+    "Name":"https://schema.org/alternativeHeadline-output",
     "Domain Bucket":"< 1K"
   },
   {
     "Class":"Predicate",
-    "Name":"http:\/\/schema.org\/alternativeOf",
+    "Name":"https://schema.org/alternativeOf",
     "Domain Bucket":"< 1K"
   },
   {
     "Class":"Predicate",
-    "Name":"http:\/\/schema.org\/alternativeOf-input",
+    "Name":"https://schema.org/alternativeOf-input",
     "Domain Bucket":"< 1K"
   },
   {
     "Class":"Predicate",
-    "Name":"http:\/\/schema.org\/alternativeOf-output",
+    "Name":"https://schema.org/alternativeOf-output",
     "Domain Bucket":"< 1K"
   },
   {
     "Class":"Predicate",
-    "Name":"http:\/\/schema.org\/alumni",
+    "Name":"https://schema.org/alumni",
     "Domain Bucket":"1K - 10K"
   },
   {
     "Class":"Predicate",
-    "Name":"http:\/\/schema.org\/alumni-input",
+    "Name":"https://schema.org/alumni-input",
     "Domain Bucket":"< 1K"
   },
   {
     "Class":"Predicate",
-    "Name":"http:\/\/schema.org\/alumni-output",
+    "Name":"https://schema.org/alumni-output",
     "Domain Bucket":"< 1K"
   },
   {
     "Class":"Predicate",
-    "Name":"http:\/\/schema.org\/alumniOf",
+    "Name":"https://schema.org/alumniOf",
     "Domain Bucket":"100K - 1M"
   },
   {
     "Class":"Predicate",
-    "Name":"http:\/\/schema.org\/alumniOf-input",
+    "Name":"https://schema.org/alumniOf-input",
     "Domain Bucket":"< 1K"
   },
   {
     "Class":"Predicate",
-    "Name":"http:\/\/schema.org\/alumniOf-output",
+    "Name":"https://schema.org/alumniOf-output",
     "Domain Bucket":"< 1K"
   },
   {
     "Class":"Predicate",
-    "Name":"http:\/\/schema.org\/amenityFeature",
+    "Name":"https://schema.org/amenityFeature",
     "Domain Bucket":"100K - 1M"
   },
   {
     "Class":"Predicate",
-    "Name":"http:\/\/schema.org\/amenityFeature-input",
+    "Name":"https://schema.org/amenityFeature-input",
     "Domain Bucket":"< 1K"
   },
   {
     "Class":"Predicate",
-    "Name":"http:\/\/schema.org\/amenityFeature-output",
+    "Name":"https://schema.org/amenityFeature-output",
     "Domain Bucket":"< 1K"
   },
   {
     "Class":"Predicate",
-    "Name":"http:\/\/schema.org\/amount",
+    "Name":"https://schema.org/amount",
     "Domain Bucket":"1K - 10K"
   },
   {
     "Class":"Predicate",
-    "Name":"http:\/\/schema.org\/amount-input",
+    "Name":"https://schema.org/amount-input",
     "Domain Bucket":"< 1K"
   },
   {
     "Class":"Predicate",
-    "Name":"http:\/\/schema.org\/amount-output",
+    "Name":"https://schema.org/amount-output",
     "Domain Bucket":"< 1K"
   },
   {
     "Class":"Predicate",
-    "Name":"http:\/\/schema.org\/amountOfThisGood",
+    "Name":"https://schema.org/amountOfThisGood",
     "Domain Bucket":"< 1K"
   },
   {
     "Class":"Predicate",
-    "Name":"http:\/\/schema.org\/amountOfThisGood-input",
+    "Name":"https://schema.org/amountOfThisGood-input",
     "Domain Bucket":"< 1K"
   },
   {
     "Class":"Predicate",
-    "Name":"http:\/\/schema.org\/amountOfThisGood-output",
+    "Name":"https://schema.org/amountOfThisGood-output",
     "Domain Bucket":"< 1K"
   },
   {
     "Class":"Predicate",
-    "Name":"http:\/\/schema.org\/announcementLocation",
+    "Name":"https://schema.org/announcementLocation",
     "Domain Bucket":"1K - 10K"
   },
   {
     "Class":"Predicate",
-    "Name":"http:\/\/schema.org\/announcementLocation-input",
+    "Name":"https://schema.org/announcementLocation-input",
     "Domain Bucket":"< 1K"
   },
   {
     "Class":"Predicate",
-    "Name":"http:\/\/schema.org\/announcementLocation-output",
+    "Name":"https://schema.org/announcementLocation-output",
     "Domain Bucket":"< 1K"
   },
   {
     "Class":"Predicate",
-    "Name":"http:\/\/schema.org\/annualPercentageRate",
+    "Name":"https://schema.org/annualPercentageRate",
     "Domain Bucket":"1K - 10K"
   },
   {
     "Class":"Predicate",
-    "Name":"http:\/\/schema.org\/annualPercentageRate-input",
+    "Name":"https://schema.org/annualPercentageRate-input",
     "Domain Bucket":"< 1K"
   },
   {
     "Class":"Predicate",
-    "Name":"http:\/\/schema.org\/annualPercentageRate-output",
+    "Name":"https://schema.org/annualPercentageRate-output",
     "Domain Bucket":"< 1K"
   },
   {
     "Class":"Predicate",
-    "Name":"http:\/\/schema.org\/answerCount",
+    "Name":"https://schema.org/answerCount",
     "Domain Bucket":"100K - 1M"
   },
   {
     "Class":"Predicate",
-    "Name":"http:\/\/schema.org\/answerCount-input",
+    "Name":"https://schema.org/answerCount-input",
     "Domain Bucket":"< 1K"
   },
   {
     "Class":"Predicate",
-    "Name":"http:\/\/schema.org\/answerCount-output",
+    "Name":"https://schema.org/answerCount-output",
     "Domain Bucket":"< 1K"
   },
   {
     "Class":"Predicate",
-    "Name":"http:\/\/schema.org\/answerExplanation",
+    "Name":"https://schema.org/answerExplanation",
     "Domain Bucket":"< 1K"
   },
   {
     "Class":"Predicate",
-    "Name":"http:\/\/schema.org\/answerExplanation-input",
+    "Name":"https://schema.org/answerExplanation-input",
     "Domain Bucket":"< 1K"
   },
   {
     "Class":"Predicate",
-    "Name":"http:\/\/schema.org\/answerExplanation-output",
+    "Name":"https://schema.org/answerExplanation-output",
     "Domain Bucket":"< 1K"
   },
   {
     "Class":"Predicate",
-    "Name":"http:\/\/schema.org\/antagonist",
+    "Name":"https://schema.org/antagonist",
     "Domain Bucket":"< 1K"
   },
   {
     "Class":"Predicate",
-    "Name":"http:\/\/schema.org\/antagonist-input",
+    "Name":"https://schema.org/antagonist-input",
     "Domain Bucket":"< 1K"
   },
   {
     "Class":"Predicate",
-    "Name":"http:\/\/schema.org\/antagonist-output",
+    "Name":"https://schema.org/antagonist-output",
     "Domain Bucket":"< 1K"
   },
   {
     "Class":"Predicate",
-    "Name":"http:\/\/schema.org\/appearance",
+    "Name":"https://schema.org/appearance",
     "Domain Bucket":"1K - 10K"
   },
   {
     "Class":"Predicate",
-    "Name":"http:\/\/schema.org\/appearance-input",
+    "Name":"https://schema.org/appearance-input",
     "Domain Bucket":"< 1K"
   },
   {
     "Class":"Predicate",
-    "Name":"http:\/\/schema.org\/appearance-output",
+    "Name":"https://schema.org/appearance-output",
     "Domain Bucket":"< 1K"
   },
   {
     "Class":"Predicate",
-    "Name":"http:\/\/schema.org\/applicableCountry",
+    "Name":"https://schema.org/applicableCountry",
     "Domain Bucket":"100K - 1M"
   },
   {
     "Class":"Predicate",
-    "Name":"http:\/\/schema.org\/applicableCountry-input",
+    "Name":"https://schema.org/applicableCountry-input",
     "Domain Bucket":"< 1K"
   },
   {
     "Class":"Predicate",
-    "Name":"http:\/\/schema.org\/applicableCountry-output",
+    "Name":"https://schema.org/applicableCountry-output",
     "Domain Bucket":"< 1K"
   },
   {
     "Class":"Predicate",
-    "Name":"http:\/\/schema.org\/applicableLocation",
+    "Name":"https://schema.org/applicableLocation",
     "Domain Bucket":"< 1K"
   },
   {
     "Class":"Predicate",
-    "Name":"http:\/\/schema.org\/applicableLocation-input",
+    "Name":"https://schema.org/applicableLocation-input",
     "Domain Bucket":"< 1K"
   },
   {
     "Class":"Predicate",
-    "Name":"http:\/\/schema.org\/applicableLocation-output",
+    "Name":"https://schema.org/applicableLocation-output",
     "Domain Bucket":"< 1K"
   },
   {
     "Class":"Predicate",
-    "Name":"http:\/\/schema.org\/applicantLocationRequirements",
+    "Name":"https://schema.org/applicantLocationRequirements",
     "Domain Bucket":"10K - 100K"
   },
   {
     "Class":"Predicate",
-    "Name":"http:\/\/schema.org\/applicantLocationRequirements-input",
+    "Name":"https://schema.org/applicantLocationRequirements-input",
     "Domain Bucket":"< 1K"
   },
   {
     "Class":"Predicate",
-    "Name":"http:\/\/schema.org\/applicantLocationRequirements-output",
+    "Name":"https://schema.org/applicantLocationRequirements-output",
     "Domain Bucket":"< 1K"
   },
   {
     "Class":"Predicate",
-    "Name":"http:\/\/schema.org\/application",
+    "Name":"https://schema.org/application",
     "Domain Bucket":"< 1K"
   },
   {
     "Class":"Predicate",
-    "Name":"http:\/\/schema.org\/application-input",
+    "Name":"https://schema.org/application-input",
     "Domain Bucket":"< 1K"
   },
   {
     "Class":"Predicate",
-    "Name":"http:\/\/schema.org\/application-output",
+    "Name":"https://schema.org/application-output",
     "Domain Bucket":"< 1K"
   },
   {
     "Class":"Predicate",
-    "Name":"http:\/\/schema.org\/applicationCategory",
+    "Name":"https://schema.org/applicationCategory",
     "Domain Bucket":"100K - 1M"
   },
   {
     "Class":"Predicate",
-    "Name":"http:\/\/schema.org\/applicationCategory-input",
+    "Name":"https://schema.org/applicationCategory-input",
     "Domain Bucket":"< 1K"
   },
   {
     "Class":"Predicate",
-    "Name":"http:\/\/schema.org\/applicationCategory-output",
+    "Name":"https://schema.org/applicationCategory-output",
     "Domain Bucket":"< 1K"
   },
   {
     "Class":"Predicate",
-    "Name":"http:\/\/schema.org\/applicationContact",
+    "Name":"https://schema.org/applicationContact",
     "Domain Bucket":"1K - 10K"
   },
   {
     "Class":"Predicate",
-    "Name":"http:\/\/schema.org\/applicationContact-input",
+    "Name":"https://schema.org/applicationContact-input",
     "Domain Bucket":"< 1K"
   },
   {
     "Class":"Predicate",
-    "Name":"http:\/\/schema.org\/applicationContact-output",
+    "Name":"https://schema.org/applicationContact-output",
     "Domain Bucket":"< 1K"
   },
   {
     "Class":"Predicate",
-    "Name":"http:\/\/schema.org\/applicationDeadline",
+    "Name":"https://schema.org/applicationDeadline",
     "Domain Bucket":"< 1K"
   },
   {
     "Class":"Predicate",
-    "Name":"http:\/\/schema.org\/applicationDeadline-input",
+    "Name":"https://schema.org/applicationDeadline-input",
     "Domain Bucket":"< 1K"
   },
   {
     "Class":"Predicate",
-    "Name":"http:\/\/schema.org\/applicationDeadline-output",
+    "Name":"https://schema.org/applicationDeadline-output",
     "Domain Bucket":"< 1K"
   },
   {
     "Class":"Predicate",
-    "Name":"http:\/\/schema.org\/applicationStartDate",
+    "Name":"https://schema.org/applicationStartDate",
     "Domain Bucket":"< 1K"
   },
   {
     "Class":"Predicate",
-    "Name":"http:\/\/schema.org\/applicationStartDate-input",
+    "Name":"https://schema.org/applicationStartDate-input",
     "Domain Bucket":"< 1K"
   },
   {
     "Class":"Predicate",
-    "Name":"http:\/\/schema.org\/applicationStartDate-output",
+    "Name":"https://schema.org/applicationStartDate-output",
     "Domain Bucket":"< 1K"
   },
   {
     "Class":"Predicate",
-    "Name":"http:\/\/schema.org\/applicationSubCategory",
+    "Name":"https://schema.org/applicationSubCategory",
     "Domain Bucket":"10K - 100K"
   },
   {
     "Class":"Predicate",
-    "Name":"http:\/\/schema.org\/applicationSubCategory-input",
+    "Name":"https://schema.org/applicationSubCategory-input",
     "Domain Bucket":"< 1K"
   },
   {
     "Class":"Predicate",
-    "Name":"http:\/\/schema.org\/applicationSubCategory-output",
+    "Name":"https://schema.org/applicationSubCategory-output",
     "Domain Bucket":"< 1K"
   },
   {
     "Class":"Predicate",
-    "Name":"http:\/\/schema.org\/applicationSuite",
+    "Name":"https://schema.org/applicationSuite",
     "Domain Bucket":"1K - 10K"
   },
   {
     "Class":"Predicate",
-    "Name":"http:\/\/schema.org\/applicationSuite-input",
+    "Name":"https://schema.org/applicationSuite-input",
     "Domain Bucket":"< 1K"
   },
   {
     "Class":"Predicate",
-    "Name":"http:\/\/schema.org\/applicationSuite-output",
+    "Name":"https://schema.org/applicationSuite-output",
     "Domain Bucket":"< 1K"
   },
   {
     "Class":"Predicate",
-    "Name":"http:\/\/schema.org\/appliesToDeliveryMethod",
+    "Name":"https://schema.org/appliesToDeliveryMethod",
     "Domain Bucket":"10K - 100K"
   },
   {
     "Class":"Predicate",
-    "Name":"http:\/\/schema.org\/appliesToDeliveryMethod-input",
+    "Name":"https://schema.org/appliesToDeliveryMethod-input",
     "Domain Bucket":"< 1K"
   },
   {
     "Class":"Predicate",
-    "Name":"http:\/\/schema.org\/appliesToDeliveryMethod-output",
+    "Name":"https://schema.org/appliesToDeliveryMethod-output",
     "Domain Bucket":"< 1K"
   },
   {
     "Class":"Predicate",
-    "Name":"http:\/\/schema.org\/appliesToPaymentMethod",
+    "Name":"https://schema.org/appliesToPaymentMethod",
     "Domain Bucket":"< 1K"
   },
   {
     "Class":"Predicate",
-    "Name":"http:\/\/schema.org\/appliesToPaymentMethod-input",
+    "Name":"https://schema.org/appliesToPaymentMethod-input",
     "Domain Bucket":"< 1K"
   },
   {
     "Class":"Predicate",
-    "Name":"http:\/\/schema.org\/appliesToPaymentMethod-output",
+    "Name":"https://schema.org/appliesToPaymentMethod-output",
     "Domain Bucket":"< 1K"
   },
   {
     "Class":"Predicate",
-    "Name":"http:\/\/schema.org\/archiveHeld",
+    "Name":"https://schema.org/archiveHeld",
     "Domain Bucket":"< 1K"
   },
   {
     "Class":"Predicate",
-    "Name":"http:\/\/schema.org\/archiveHeld-input",
+    "Name":"https://schema.org/archiveHeld-input",
     "Domain Bucket":"< 1K"
   },
   {
     "Class":"Predicate",
-    "Name":"http:\/\/schema.org\/archiveHeld-output",
+    "Name":"https://schema.org/archiveHeld-output",
     "Domain Bucket":"< 1K"
   },
   {
     "Class":"Predicate",
-    "Name":"http:\/\/schema.org\/archivedAt",
+    "Name":"https://schema.org/archivedAt",
     "Domain Bucket":"< 1K"
   },
   {
     "Class":"Predicate",
-    "Name":"http:\/\/schema.org\/archivedAt-input",
+    "Name":"https://schema.org/archivedAt-input",
     "Domain Bucket":"< 1K"
   },
   {
     "Class":"Predicate",
-    "Name":"http:\/\/schema.org\/archivedAt-output",
+    "Name":"https://schema.org/archivedAt-output",
     "Domain Bucket":"< 1K"
   },
   {
     "Class":"Predicate",
-    "Name":"http:\/\/schema.org\/area",
+    "Name":"https://schema.org/area",
     "Domain Bucket":"1K - 10K"
   },
   {
     "Class":"Predicate",
-    "Name":"http:\/\/schema.org\/area-input",
+    "Name":"https://schema.org/area-input",
     "Domain Bucket":"< 1K"
   },
   {
     "Class":"Predicate",
-    "Name":"http:\/\/schema.org\/area-output",
+    "Name":"https://schema.org/area-output",
     "Domain Bucket":"< 1K"
   },
   {
     "Class":"Predicate",
-    "Name":"http:\/\/schema.org\/areaServed",
+    "Name":"https://schema.org/areaServed",
     "Domain Bucket":"1M - 10M"
   },
   {
     "Class":"Predicate",
-    "Name":"http:\/\/schema.org\/areaServed-input",
+    "Name":"https://schema.org/areaServed-input",
     "Domain Bucket":"< 1K"
   },
   {
     "Class":"Predicate",
-    "Name":"http:\/\/schema.org\/areaServed-output",
+    "Name":"https://schema.org/areaServed-output",
     "Domain Bucket":"< 1K"
   },
   {
     "Class":"Predicate",
-    "Name":"http:\/\/schema.org\/arrivalAirport",
+    "Name":"https://schema.org/arrivalAirport",
     "Domain Bucket":"1K - 10K"
   },
   {
     "Class":"Predicate",
-    "Name":"http:\/\/schema.org\/arrivalAirport-input",
+    "Name":"https://schema.org/arrivalAirport-input",
     "Domain Bucket":"< 1K"
   },
   {
     "Class":"Predicate",
-    "Name":"http:\/\/schema.org\/arrivalAirport-output",
+    "Name":"https://schema.org/arrivalAirport-output",
     "Domain Bucket":"< 1K"
   },
   {
     "Class":"Predicate",
-    "Name":"http:\/\/schema.org\/arrivalBoatTerminal",
+    "Name":"https://schema.org/arrivalBoatTerminal",
     "Domain Bucket":"< 1K"
   },
   {
     "Class":"Predicate",
-    "Name":"http:\/\/schema.org\/arrivalBoatTerminal-input",
+    "Name":"https://schema.org/arrivalBoatTerminal-input",
     "Domain Bucket":"< 1K"
   },
   {
     "Class":"Predicate",
-    "Name":"http:\/\/schema.org\/arrivalBoatTerminal-output",
+    "Name":"https://schema.org/arrivalBoatTerminal-output",
     "Domain Bucket":"< 1K"
   },
   {
     "Class":"Predicate",
-    "Name":"http:\/\/schema.org\/arrivalBusStop",
+    "Name":"https://schema.org/arrivalBusStop",
     "Domain Bucket":"< 1K"
   },
   {
     "Class":"Predicate",
-    "Name":"http:\/\/schema.org\/arrivalBusStop-input",
+    "Name":"https://schema.org/arrivalBusStop-input",
     "Domain Bucket":"< 1K"
   },
   {
     "Class":"Predicate",
-    "Name":"http:\/\/schema.org\/arrivalBusStop-output",
+    "Name":"https://schema.org/arrivalBusStop-output",
     "Domain Bucket":"< 1K"
   },
   {
     "Class":"Predicate",
-    "Name":"http:\/\/schema.org\/arrivalGate",
+    "Name":"https://schema.org/arrivalGate",
     "Domain Bucket":"< 1K"
   },
   {
     "Class":"Predicate",
-    "Name":"http:\/\/schema.org\/arrivalGate-input",
+    "Name":"https://schema.org/arrivalGate-input",
     "Domain Bucket":"< 1K"
   },
   {
     "Class":"Predicate",
-    "Name":"http:\/\/schema.org\/arrivalGate-output",
+    "Name":"https://schema.org/arrivalGate-output",
     "Domain Bucket":"< 1K"
   },
   {
     "Class":"Predicate",
-    "Name":"http:\/\/schema.org\/arrivalPlatform",
+    "Name":"https://schema.org/arrivalPlatform",
     "Domain Bucket":"< 1K"
   },
   {
     "Class":"Predicate",
-    "Name":"http:\/\/schema.org\/arrivalPlatform-input",
+    "Name":"https://schema.org/arrivalPlatform-input",
     "Domain Bucket":"< 1K"
   },
   {
     "Class":"Predicate",
-    "Name":"http:\/\/schema.org\/arrivalPlatform-output",
+    "Name":"https://schema.org/arrivalPlatform-output",
     "Domain Bucket":"< 1K"
   },
   {
     "Class":"Predicate",
-    "Name":"http:\/\/schema.org\/arrivalStation",
+    "Name":"https://schema.org/arrivalStation",
     "Domain Bucket":"< 1K"
   },
   {
     "Class":"Predicate",
-    "Name":"http:\/\/schema.org\/arrivalStation-input",
+    "Name":"https://schema.org/arrivalStation-input",
     "Domain Bucket":"< 1K"
   },
   {
     "Class":"Predicate",
-    "Name":"http:\/\/schema.org\/arrivalStation-output",
+    "Name":"https://schema.org/arrivalStation-output",
     "Domain Bucket":"< 1K"
   },
   {
     "Class":"Predicate",
-    "Name":"http:\/\/schema.org\/arrivalTerminal",
+    "Name":"https://schema.org/arrivalTerminal",
     "Domain Bucket":"< 1K"
   },
   {
     "Class":"Predicate",
-    "Name":"http:\/\/schema.org\/arrivalTerminal-input",
+    "Name":"https://schema.org/arrivalTerminal-input",
     "Domain Bucket":"< 1K"
   },
   {
     "Class":"Predicate",
-    "Name":"http:\/\/schema.org\/arrivalTerminal-output",
+    "Name":"https://schema.org/arrivalTerminal-output",
     "Domain Bucket":"< 1K"
   },
   {
     "Class":"Predicate",
-    "Name":"http:\/\/schema.org\/arrivalTime",
+    "Name":"https://schema.org/arrivalTime",
     "Domain Bucket":"1K - 10K"
   },
   {
     "Class":"Predicate",
-    "Name":"http:\/\/schema.org\/arrivalTime-input",
+    "Name":"https://schema.org/arrivalTime-input",
     "Domain Bucket":"< 1K"
   },
   {
     "Class":"Predicate",
-    "Name":"http:\/\/schema.org\/arrivalTime-output",
+    "Name":"https://schema.org/arrivalTime-output",
     "Domain Bucket":"< 1K"
   },
   {
     "Class":"Predicate",
-    "Name":"http:\/\/schema.org\/artEdition",
+    "Name":"https://schema.org/artEdition",
     "Domain Bucket":"< 1K"
   },
   {
     "Class":"Predicate",
-    "Name":"http:\/\/schema.org\/artEdition-input",
+    "Name":"https://schema.org/artEdition-input",
     "Domain Bucket":"< 1K"
   },
   {
     "Class":"Predicate",
-    "Name":"http:\/\/schema.org\/artEdition-output",
+    "Name":"https://schema.org/artEdition-output",
     "Domain Bucket":"< 1K"
   },
   {
     "Class":"Predicate",
-    "Name":"http:\/\/schema.org\/artMedium",
+    "Name":"https://schema.org/artMedium",
     "Domain Bucket":"1K - 10K"
   },
   {
     "Class":"Predicate",
-    "Name":"http:\/\/schema.org\/artMedium-input",
+    "Name":"https://schema.org/artMedium-input",
     "Domain Bucket":"< 1K"
   },
   {
     "Class":"Predicate",
-    "Name":"http:\/\/schema.org\/artMedium-output",
+    "Name":"https://schema.org/artMedium-output",
     "Domain Bucket":"< 1K"
   },
   {
     "Class":"Predicate",
-    "Name":"http:\/\/schema.org\/arterialBranch",
+    "Name":"https://schema.org/arterialBranch",
     "Domain Bucket":"< 1K"
   },
   {
     "Class":"Predicate",
-    "Name":"http:\/\/schema.org\/arterialBranch-input",
+    "Name":"https://schema.org/arterialBranch-input",
     "Domain Bucket":"< 1K"
   },
   {
     "Class":"Predicate",
-    "Name":"http:\/\/schema.org\/arterialBranch-output",
+    "Name":"https://schema.org/arterialBranch-output",
     "Domain Bucket":"< 1K"
   },
   {
     "Class":"Predicate",
-    "Name":"http:\/\/schema.org\/artform",
+    "Name":"https://schema.org/artform",
     "Domain Bucket":"1K - 10K"
   },
   {
     "Class":"Predicate",
-    "Name":"http:\/\/schema.org\/artform-input",
+    "Name":"https://schema.org/artform-input",
     "Domain Bucket":"< 1K"
   },
   {
     "Class":"Predicate",
-    "Name":"http:\/\/schema.org\/artform-output",
+    "Name":"https://schema.org/artform-output",
     "Domain Bucket":"< 1K"
   },
   {
     "Class":"Predicate",
-    "Name":"http:\/\/schema.org\/articleBody",
+    "Name":"https://schema.org/articleBody",
     "Domain Bucket":"1M - 10M"
   },
   {
     "Class":"Predicate",
-    "Name":"http:\/\/schema.org\/articleBody-input",
+    "Name":"https://schema.org/articleBody-input",
     "Domain Bucket":"< 1K"
   },
   {
     "Class":"Predicate",
-    "Name":"http:\/\/schema.org\/articleBody-output",
+    "Name":"https://schema.org/articleBody-output",
     "Domain Bucket":"< 1K"
   },
   {
     "Class":"Predicate",
-    "Name":"http:\/\/schema.org\/articleSection",
+    "Name":"https://schema.org/articleSection",
     "Domain Bucket":"1M - 10M"
   },
   {
     "Class":"Predicate",
-    "Name":"http:\/\/schema.org\/articleSection-input",
+    "Name":"https://schema.org/articleSection-input",
     "Domain Bucket":"< 1K"
   },
   {
     "Class":"Predicate",
-    "Name":"http:\/\/schema.org\/articleSection-output",
+    "Name":"https://schema.org/articleSection-output",
     "Domain Bucket":"< 1K"
   },
   {
     "Class":"Predicate",
-    "Name":"http:\/\/schema.org\/artist",
+    "Name":"https://schema.org/artist",
     "Domain Bucket":"1K - 10K"
   },
   {
     "Class":"Predicate",
-    "Name":"http:\/\/schema.org\/artist-input",
+    "Name":"https://schema.org/artist-input",
     "Domain Bucket":"< 1K"
   },
   {
     "Class":"Predicate",
-    "Name":"http:\/\/schema.org\/artist-output",
+    "Name":"https://schema.org/artist-output",
     "Domain Bucket":"< 1K"
   },
   {
     "Class":"Predicate",
-    "Name":"http:\/\/schema.org\/artworkSurface",
+    "Name":"https://schema.org/artworkSurface",
     "Domain Bucket":"< 1K"
   },
   {
     "Class":"Predicate",
-    "Name":"http:\/\/schema.org\/artworkSurface-input",
+    "Name":"https://schema.org/artworkSurface-input",
     "Domain Bucket":"< 1K"
   },
   {
     "Class":"Predicate",
-    "Name":"http:\/\/schema.org\/artworkSurface-output",
+    "Name":"https://schema.org/artworkSurface-output",
     "Domain Bucket":"< 1K"
   },
   {
     "Class":"Predicate",
-    "Name":"http:\/\/schema.org\/asin",
+    "Name":"https://schema.org/asin",
     "Domain Bucket":"< 1K"
   },
   {
     "Class":"Predicate",
-    "Name":"http:\/\/schema.org\/asin-input",
+    "Name":"https://schema.org/asin-input",
     "Domain Bucket":"< 1K"
   },
   {
     "Class":"Predicate",
-    "Name":"http:\/\/schema.org\/asin-output",
+    "Name":"https://schema.org/asin-output",
     "Domain Bucket":"< 1K"
   },
   {
     "Class":"Predicate",
-    "Name":"http:\/\/schema.org\/aspect",
+    "Name":"https://schema.org/aspect",
     "Domain Bucket":"< 1K"
   },
   {
     "Class":"Predicate",
-    "Name":"http:\/\/schema.org\/aspect-input",
+    "Name":"https://schema.org/aspect-input",
     "Domain Bucket":"< 1K"
   },
   {
     "Class":"Predicate",
-    "Name":"http:\/\/schema.org\/aspect-output",
+    "Name":"https://schema.org/aspect-output",
     "Domain Bucket":"< 1K"
   },
   {
     "Class":"Predicate",
-    "Name":"http:\/\/schema.org\/assembly",
+    "Name":"https://schema.org/assembly",
     "Domain Bucket":"< 1K"
   },
   {
     "Class":"Predicate",
-    "Name":"http:\/\/schema.org\/assembly-input",
+    "Name":"https://schema.org/assembly-input",
     "Domain Bucket":"< 1K"
   },
   {
     "Class":"Predicate",
-    "Name":"http:\/\/schema.org\/assembly-output",
+    "Name":"https://schema.org/assembly-output",
     "Domain Bucket":"< 1K"
   },
   {
     "Class":"Predicate",
-    "Name":"http:\/\/schema.org\/assemblyVersion",
+    "Name":"https://schema.org/assemblyVersion",
     "Domain Bucket":"< 1K"
   },
   {
     "Class":"Predicate",
-    "Name":"http:\/\/schema.org\/assemblyVersion-input",
+    "Name":"https://schema.org/assemblyVersion-input",
     "Domain Bucket":"< 1K"
   },
   {
     "Class":"Predicate",
-    "Name":"http:\/\/schema.org\/assemblyVersion-output",
+    "Name":"https://schema.org/assemblyVersion-output",
     "Domain Bucket":"< 1K"
   },
   {
     "Class":"Predicate",
-    "Name":"http:\/\/schema.org\/assesses",
+    "Name":"https://schema.org/assesses",
     "Domain Bucket":"1K - 10K"
   },
   {
     "Class":"Predicate",
-    "Name":"http:\/\/schema.org\/assesses-input",
+    "Name":"https://schema.org/assesses-input",
     "Domain Bucket":"< 1K"
   },
   {
     "Class":"Predicate",
-    "Name":"http:\/\/schema.org\/assesses-output",
+    "Name":"https://schema.org/assesses-output",
     "Domain Bucket":"< 1K"
   },
   {
     "Class":"Predicate",
-    "Name":"http:\/\/schema.org\/associatedAnatomy",
+    "Name":"https://schema.org/associatedAnatomy",
     "Domain Bucket":"1K - 10K"
   },
   {
     "Class":"Predicate",
-    "Name":"http:\/\/schema.org\/associatedAnatomy-input",
+    "Name":"https://schema.org/associatedAnatomy-input",
     "Domain Bucket":"< 1K"
   },
   {
     "Class":"Predicate",
-    "Name":"http:\/\/schema.org\/associatedAnatomy-output",
+    "Name":"https://schema.org/associatedAnatomy-output",
     "Domain Bucket":"< 1K"
   },
   {
     "Class":"Predicate",
-    "Name":"http:\/\/schema.org\/associatedArticle",
+    "Name":"https://schema.org/associatedArticle",
     "Domain Bucket":"1K - 10K"
   },
   {
     "Class":"Predicate",
-    "Name":"http:\/\/schema.org\/associatedArticle-input",
+    "Name":"https://schema.org/associatedArticle-input",
     "Domain Bucket":"< 1K"
   },
   {
     "Class":"Predicate",
-    "Name":"http:\/\/schema.org\/associatedArticle-output",
+    "Name":"https://schema.org/associatedArticle-output",
     "Domain Bucket":"< 1K"
   },
   {
     "Class":"Predicate",
-    "Name":"http:\/\/schema.org\/associatedClaimReview",
+    "Name":"https://schema.org/associatedClaimReview",
     "Domain Bucket":"< 1K"
   },
   {
     "Class":"Predicate",
-    "Name":"http:\/\/schema.org\/associatedClaimReview-input",
+    "Name":"https://schema.org/associatedClaimReview-input",
     "Domain Bucket":"< 1K"
   },
   {
     "Class":"Predicate",
-    "Name":"http:\/\/schema.org\/associatedClaimReview-output",
+    "Name":"https://schema.org/associatedClaimReview-output",
     "Domain Bucket":"< 1K"
   },
   {
     "Class":"Predicate",
-    "Name":"http:\/\/schema.org\/associatedDisease",
+    "Name":"https://schema.org/associatedDisease",
     "Domain Bucket":"< 1K"
   },
   {
     "Class":"Predicate",
-    "Name":"http:\/\/schema.org\/associatedDisease-input",
+    "Name":"https://schema.org/associatedDisease-input",
     "Domain Bucket":"< 1K"
   },
   {
     "Class":"Predicate",
-    "Name":"http:\/\/schema.org\/associatedDisease-output",
+    "Name":"https://schema.org/associatedDisease-output",
     "Domain Bucket":"< 1K"
   },
   {
     "Class":"Predicate",
-    "Name":"http:\/\/schema.org\/associatedMedia",
+    "Name":"https://schema.org/associatedMedia",
     "Domain Bucket":"100K - 1M"
   },
   {
     "Class":"Predicate",
-    "Name":"http:\/\/schema.org\/associatedMedia-input",
+    "Name":"https://schema.org/associatedMedia-input",
     "Domain Bucket":"< 1K"
   },
   {
     "Class":"Predicate",
-    "Name":"http:\/\/schema.org\/associatedMedia-output",
+    "Name":"https://schema.org/associatedMedia-output",
     "Domain Bucket":"< 1K"
   },
   {
     "Class":"Predicate",
-    "Name":"http:\/\/schema.org\/associatedMediaReview",
+    "Name":"https://schema.org/associatedMediaReview",
     "Domain Bucket":"< 1K"
   },
   {
     "Class":"Predicate",
-    "Name":"http:\/\/schema.org\/associatedMediaReview-input",
+    "Name":"https://schema.org/associatedMediaReview-input",
     "Domain Bucket":"< 1K"
   },
   {
     "Class":"Predicate",
-    "Name":"http:\/\/schema.org\/associatedMediaReview-output",
+    "Name":"https://schema.org/associatedMediaReview-output",
     "Domain Bucket":"< 1K"
   },
   {
     "Class":"Predicate",
-    "Name":"http:\/\/schema.org\/associatedPathophysiology",
+    "Name":"https://schema.org/associatedPathophysiology",
     "Domain Bucket":"< 1K"
   },
   {
     "Class":"Predicate",
-    "Name":"http:\/\/schema.org\/associatedPathophysiology-input",
+    "Name":"https://schema.org/associatedPathophysiology-input",
     "Domain Bucket":"< 1K"
   },
   {
     "Class":"Predicate",
-    "Name":"http:\/\/schema.org\/associatedPathophysiology-output",
+    "Name":"https://schema.org/associatedPathophysiology-output",
     "Domain Bucket":"< 1K"
   },
   {
     "Class":"Predicate",
-    "Name":"http:\/\/schema.org\/associatedReview",
+    "Name":"https://schema.org/associatedReview",
     "Domain Bucket":"< 1K"
   },
   {
     "Class":"Predicate",
-    "Name":"http:\/\/schema.org\/associatedReview-input",
+    "Name":"https://schema.org/associatedReview-input",
     "Domain Bucket":"< 1K"
   },
   {
     "Class":"Predicate",
-    "Name":"http:\/\/schema.org\/associatedReview-output",
+    "Name":"https://schema.org/associatedReview-output",
     "Domain Bucket":"< 1K"
   },
   {
     "Class":"Predicate",
-    "Name":"http:\/\/schema.org\/athlete",
+    "Name":"https://schema.org/athlete",
     "Domain Bucket":"< 1K"
   },
   {
     "Class":"Predicate",
-    "Name":"http:\/\/schema.org\/athlete-input",
+    "Name":"https://schema.org/athlete-input",
     "Domain Bucket":"< 1K"
   },
   {
     "Class":"Predicate",
-    "Name":"http:\/\/schema.org\/athlete-output",
+    "Name":"https://schema.org/athlete-output",
     "Domain Bucket":"< 1K"
   },
   {
     "Class":"Predicate",
-    "Name":"http:\/\/schema.org\/attendee",
+    "Name":"https://schema.org/attendee",
     "Domain Bucket":"1K - 10K"
   },
   {
     "Class":"Predicate",
-    "Name":"http:\/\/schema.org\/attendee-input",
+    "Name":"https://schema.org/attendee-input",
     "Domain Bucket":"< 1K"
   },
   {
     "Class":"Predicate",
-    "Name":"http:\/\/schema.org\/attendee-output",
+    "Name":"https://schema.org/attendee-output",
     "Domain Bucket":"< 1K"
   },
   {
     "Class":"Predicate",
-    "Name":"http:\/\/schema.org\/attendees",
+    "Name":"https://schema.org/attendees",
     "Domain Bucket":"< 1K"
   },
   {
     "Class":"Predicate",
-    "Name":"http:\/\/schema.org\/attendees-input",
+    "Name":"https://schema.org/attendees-input",
     "Domain Bucket":"< 1K"
   },
   {
     "Class":"Predicate",
-    "Name":"http:\/\/schema.org\/attendees-output",
+    "Name":"https://schema.org/attendees-output",
     "Domain Bucket":"< 1K"
   },
   {
     "Class":"Predicate",
-    "Name":"http:\/\/schema.org\/audience",
+    "Name":"https://schema.org/audience",
     "Domain Bucket":"100K - 1M"
   },
   {
     "Class":"Predicate",
-    "Name":"http:\/\/schema.org\/audience-input",
+    "Name":"https://schema.org/audience-input",
     "Domain Bucket":"< 1K"
   },
   {
     "Class":"Predicate",
-    "Name":"http:\/\/schema.org\/audience-output",
+    "Name":"https://schema.org/audience-output",
     "Domain Bucket":"< 1K"
   },
   {
     "Class":"Predicate",
-    "Name":"http:\/\/schema.org\/audienceType",
+    "Name":"https://schema.org/audienceType",
     "Domain Bucket":"100K - 1M"
   },
   {
     "Class":"Predicate",
-    "Name":"http:\/\/schema.org\/audienceType-input",
+    "Name":"https://schema.org/audienceType-input",
     "Domain Bucket":"< 1K"
   },
   {
     "Class":"Predicate",
-    "Name":"http:\/\/schema.org\/audienceType-output",
+    "Name":"https://schema.org/audienceType-output",
     "Domain Bucket":"< 1K"
   },
   {
     "Class":"Predicate",
-    "Name":"http:\/\/schema.org\/audio",
+    "Name":"https://schema.org/audio",
     "Domain Bucket":"10K - 100K"
   },
   {
     "Class":"Predicate",
-    "Name":"http:\/\/schema.org\/audio-input",
+    "Name":"https://schema.org/audio-input",
     "Domain Bucket":"< 1K"
   },
   {
     "Class":"Predicate",
-    "Name":"http:\/\/schema.org\/audio-output",
+    "Name":"https://schema.org/audio-output",
     "Domain Bucket":"< 1K"
   },
   {
     "Class":"Predicate",
-    "Name":"http:\/\/schema.org\/auditDate",
+    "Name":"https://schema.org/auditDate",
     "Domain Bucket":"< 1K"
   },
   {
     "Class":"Predicate",
-    "Name":"http:\/\/schema.org\/auditDate-input",
+    "Name":"https://schema.org/auditDate-input",
     "Domain Bucket":"< 1K"
   },
   {
     "Class":"Predicate",
-    "Name":"http:\/\/schema.org\/auditDate-output",
+    "Name":"https://schema.org/auditDate-output",
     "Domain Bucket":"< 1K"
   },
   {
     "Class":"Predicate",
-    "Name":"http:\/\/schema.org\/authenticator",
+    "Name":"https://schema.org/authenticator",
     "Domain Bucket":"< 1K"
   },
   {
     "Class":"Predicate",
-    "Name":"http:\/\/schema.org\/authenticator-input",
+    "Name":"https://schema.org/authenticator-input",
     "Domain Bucket":"< 1K"
   },
   {
     "Class":"Predicate",
-    "Name":"http:\/\/schema.org\/authenticator-output",
+    "Name":"https://schema.org/authenticator-output",
     "Domain Bucket":"< 1K"
   },
   {
     "Class":"Predicate",
-    "Name":"http:\/\/schema.org\/author",
+    "Name":"https://schema.org/author",
     "Domain Bucket":"10M+"
   },
   {
     "Class":"Predicate",
-    "Name":"http:\/\/schema.org\/author-input",
+    "Name":"https://schema.org/author-input",
     "Domain Bucket":"< 1K"
   },
   {
     "Class":"Predicate",
-    "Name":"http:\/\/schema.org\/author-output",
+    "Name":"https://schema.org/author-output",
     "Domain Bucket":"< 1K"
   },
   {
     "Class":"Predicate",
-    "Name":"http:\/\/schema.org\/availability",
+    "Name":"https://schema.org/availability",
     "Domain Bucket":"1M - 10M"
   },
   {
     "Class":"Predicate",
-    "Name":"http:\/\/schema.org\/availability-input",
+    "Name":"https://schema.org/availability-input",
     "Domain Bucket":"< 1K"
   },
   {
     "Class":"Predicate",
-    "Name":"http:\/\/schema.org\/availability-output",
+    "Name":"https://schema.org/availability-output",
     "Domain Bucket":"< 1K"
   },
   {
     "Class":"Predicate",
-    "Name":"http:\/\/schema.org\/availabilityEnds",
+    "Name":"https://schema.org/availabilityEnds",
     "Domain Bucket":"1K - 10K"
   },
   {
     "Class":"Predicate",
-    "Name":"http:\/\/schema.org\/availabilityEnds-input",
+    "Name":"https://schema.org/availabilityEnds-input",
     "Domain Bucket":"< 1K"
   },
   {
     "Class":"Predicate",
-    "Name":"http:\/\/schema.org\/availabilityEnds-output",
+    "Name":"https://schema.org/availabilityEnds-output",
     "Domain Bucket":"< 1K"
   },
   {
     "Class":"Predicate",
-    "Name":"http:\/\/schema.org\/availabilityStarts",
+    "Name":"https://schema.org/availabilityStarts",
     "Domain Bucket":"10K - 100K"
   },
   {
     "Class":"Predicate",
-    "Name":"http:\/\/schema.org\/availabilityStarts-input",
+    "Name":"https://schema.org/availabilityStarts-input",
     "Domain Bucket":"< 1K"
   },
   {
     "Class":"Predicate",
-    "Name":"http:\/\/schema.org\/availabilityStarts-output",
+    "Name":"https://schema.org/availabilityStarts-output",
     "Domain Bucket":"< 1K"
   },
   {
     "Class":"Predicate",
-    "Name":"http:\/\/schema.org\/availableAtOrFrom",
+    "Name":"https://schema.org/availableAtOrFrom",
     "Domain Bucket":"10K - 100K"
   },
   {
     "Class":"Predicate",
-    "Name":"http:\/\/schema.org\/availableAtOrFrom-input",
+    "Name":"https://schema.org/availableAtOrFrom-input",
     "Domain Bucket":"< 1K"
   },
   {
     "Class":"Predicate",
-    "Name":"http:\/\/schema.org\/availableAtOrFrom-output",
+    "Name":"https://schema.org/availableAtOrFrom-output",
     "Domain Bucket":"< 1K"
   },
   {
     "Class":"Predicate",
-    "Name":"http:\/\/schema.org\/availableChannel",
+    "Name":"https://schema.org/availableChannel",
     "Domain Bucket":"10K - 100K"
   },
   {
     "Class":"Predicate",
-    "Name":"http:\/\/schema.org\/availableChannel-input",
+    "Name":"https://schema.org/availableChannel-input",
     "Domain Bucket":"< 1K"
   },
   {
     "Class":"Predicate",
-    "Name":"http:\/\/schema.org\/availableChannel-output",
+    "Name":"https://schema.org/availableChannel-output",
     "Domain Bucket":"< 1K"
   },
   {
     "Class":"Predicate",
-    "Name":"http:\/\/schema.org\/availableDeliveryMethod",
+    "Name":"https://schema.org/availableDeliveryMethod",
     "Domain Bucket":"10K - 100K"
   },
   {
     "Class":"Predicate",
-    "Name":"http:\/\/schema.org\/availableDeliveryMethod-input",
+    "Name":"https://schema.org/availableDeliveryMethod-input",
     "Domain Bucket":"< 1K"
   },
   {
     "Class":"Predicate",
-    "Name":"http:\/\/schema.org\/availableDeliveryMethod-output",
+    "Name":"https://schema.org/availableDeliveryMethod-output",
     "Domain Bucket":"< 1K"
   },
   {
     "Class":"Predicate",
-    "Name":"http:\/\/schema.org\/availableFrom",
+    "Name":"https://schema.org/availableFrom",
     "Domain Bucket":"< 1K"
   },
   {
     "Class":"Predicate",
-    "Name":"http:\/\/schema.org\/availableFrom-input",
+    "Name":"https://schema.org/availableFrom-input",
     "Domain Bucket":"< 1K"
   },
   {
     "Class":"Predicate",
-    "Name":"http:\/\/schema.org\/availableFrom-output",
+    "Name":"https://schema.org/availableFrom-output",
     "Domain Bucket":"< 1K"
   },
   {
     "Class":"Predicate",
-    "Name":"http:\/\/schema.org\/availableIn",
+    "Name":"https://schema.org/availableIn",
     "Domain Bucket":"< 1K"
   },
   {
     "Class":"Predicate",
-    "Name":"http:\/\/schema.org\/availableIn-input",
+    "Name":"https://schema.org/availableIn-input",
     "Domain Bucket":"< 1K"
   },
   {
     "Class":"Predicate",
-    "Name":"http:\/\/schema.org\/availableIn-output",
+    "Name":"https://schema.org/availableIn-output",
     "Domain Bucket":"< 1K"
   },
   {
     "Class":"Predicate",
-    "Name":"http:\/\/schema.org\/availableLanguage",
+    "Name":"https://schema.org/availableLanguage",
     "Domain Bucket":"1M - 10M"
   },
   {
     "Class":"Predicate",
-    "Name":"http:\/\/schema.org\/availableLanguage-input",
+    "Name":"https://schema.org/availableLanguage-input",
     "Domain Bucket":"< 1K"
   },
   {
     "Class":"Predicate",
-    "Name":"http:\/\/schema.org\/availableLanguage-output",
+    "Name":"https://schema.org/availableLanguage-output",
     "Domain Bucket":"< 1K"
   },
   {
     "Class":"Predicate",
-    "Name":"http:\/\/schema.org\/availableOnDevice",
+    "Name":"https://schema.org/availableOnDevice",
     "Domain Bucket":"1K - 10K"
   },
   {
     "Class":"Predicate",
-    "Name":"http:\/\/schema.org\/availableOnDevice-input",
+    "Name":"https://schema.org/availableOnDevice-input",
     "Domain Bucket":"< 1K"
   },
   {
     "Class":"Predicate",
-    "Name":"http:\/\/schema.org\/availableOnDevice-output",
+    "Name":"https://schema.org/availableOnDevice-output",
     "Domain Bucket":"< 1K"
   },
   {
     "Class":"Predicate",
-    "Name":"http:\/\/schema.org\/availableService",
+    "Name":"https://schema.org/availableService",
     "Domain Bucket":"10K - 100K"
   },
   {
     "Class":"Predicate",
-    "Name":"http:\/\/schema.org\/availableService-input",
+    "Name":"https://schema.org/availableService-input",
     "Domain Bucket":"< 1K"
   },
   {
     "Class":"Predicate",
-    "Name":"http:\/\/schema.org\/availableService-output",
+    "Name":"https://schema.org/availableService-output",
     "Domain Bucket":"< 1K"
   },
   {
     "Class":"Predicate",
-    "Name":"http:\/\/schema.org\/availableStrength",
+    "Name":"https://schema.org/availableStrength",
     "Domain Bucket":"< 1K"
   },
   {
     "Class":"Predicate",
-    "Name":"http:\/\/schema.org\/availableStrength-input",
+    "Name":"https://schema.org/availableStrength-input",
     "Domain Bucket":"< 1K"
   },
   {
     "Class":"Predicate",
-    "Name":"http:\/\/schema.org\/availableStrength-output",
+    "Name":"https://schema.org/availableStrength-output",
     "Domain Bucket":"< 1K"
   },
   {
     "Class":"Predicate",
-    "Name":"http:\/\/schema.org\/availableTest",
+    "Name":"https://schema.org/availableTest",
     "Domain Bucket":"< 1K"
   },
   {
     "Class":"Predicate",
-    "Name":"http:\/\/schema.org\/availableTest-input",
+    "Name":"https://schema.org/availableTest-input",
     "Domain Bucket":"< 1K"
   },
   {
     "Class":"Predicate",
-    "Name":"http:\/\/schema.org\/availableTest-output",
+    "Name":"https://schema.org/availableTest-output",
     "Domain Bucket":"< 1K"
   },
   {
     "Class":"Predicate",
-    "Name":"http:\/\/schema.org\/availableThrough",
+    "Name":"https://schema.org/availableThrough",
     "Domain Bucket":"< 1K"
   },
   {
     "Class":"Predicate",
-    "Name":"http:\/\/schema.org\/availableThrough-input",
+    "Name":"https://schema.org/availableThrough-input",
     "Domain Bucket":"< 1K"
   },
   {
     "Class":"Predicate",
-    "Name":"http:\/\/schema.org\/availableThrough-output",
+    "Name":"https://schema.org/availableThrough-output",
     "Domain Bucket":"< 1K"
   },
   {
     "Class":"Predicate",
-    "Name":"http:\/\/schema.org\/award",
+    "Name":"https://schema.org/award",
     "Domain Bucket":"10K - 100K"
   },
   {
     "Class":"Predicate",
-    "Name":"http:\/\/schema.org\/award-input",
+    "Name":"https://schema.org/award-input",
     "Domain Bucket":"< 1K"
   },
   {
     "Class":"Predicate",
-    "Name":"http:\/\/schema.org\/award-output",
+    "Name":"https://schema.org/award-output",
     "Domain Bucket":"< 1K"
   },
   {
     "Class":"Predicate",
-    "Name":"http:\/\/schema.org\/awards",
+    "Name":"https://schema.org/awards",
     "Domain Bucket":"1K - 10K"
   },
   {
     "Class":"Predicate",
-    "Name":"http:\/\/schema.org\/awards-input",
+    "Name":"https://schema.org/awards-input",
     "Domain Bucket":"< 1K"
   },
   {
     "Class":"Predicate",
-    "Name":"http:\/\/schema.org\/awards-output",
+    "Name":"https://schema.org/awards-output",
     "Domain Bucket":"< 1K"
   },
   {
     "Class":"Predicate",
-    "Name":"http:\/\/schema.org\/awayTeam",
+    "Name":"https://schema.org/awayTeam",
     "Domain Bucket":"10K - 100K"
   },
   {
     "Class":"Predicate",
-    "Name":"http:\/\/schema.org\/awayTeam-input",
+    "Name":"https://schema.org/awayTeam-input",
     "Domain Bucket":"< 1K"
   },
   {
     "Class":"Predicate",
-    "Name":"http:\/\/schema.org\/awayTeam-output",
+    "Name":"https://schema.org/awayTeam-output",
     "Domain Bucket":"< 1K"
   },
   {
     "Class":"Predicate",
-    "Name":"http:\/\/schema.org\/backstory",
+    "Name":"https://schema.org/backstory",
     "Domain Bucket":"1K - 10K"
   },
   {
     "Class":"Predicate",
-    "Name":"http:\/\/schema.org\/backstory-input",
+    "Name":"https://schema.org/backstory-input",
     "Domain Bucket":"< 1K"
   },
   {
     "Class":"Predicate",
-    "Name":"http:\/\/schema.org\/backstory-output",
+    "Name":"https://schema.org/backstory-output",
     "Domain Bucket":"< 1K"
   },
   {
     "Class":"Predicate",
-    "Name":"http:\/\/schema.org\/bankAccountType",
+    "Name":"https://schema.org/bankAccountType",
     "Domain Bucket":"< 1K"
   },
   {
     "Class":"Predicate",
-    "Name":"http:\/\/schema.org\/bankAccountType-input",
+    "Name":"https://schema.org/bankAccountType-input",
     "Domain Bucket":"< 1K"
   },
   {
     "Class":"Predicate",
-    "Name":"http:\/\/schema.org\/bankAccountType-output",
+    "Name":"https://schema.org/bankAccountType-output",
     "Domain Bucket":"< 1K"
   },
   {
     "Class":"Predicate",
-    "Name":"http:\/\/schema.org\/baseSalary",
+    "Name":"https://schema.org/baseSalary",
     "Domain Bucket":"10K - 100K"
   },
   {
     "Class":"Predicate",
-    "Name":"http:\/\/schema.org\/baseSalary-input",
+    "Name":"https://schema.org/baseSalary-input",
     "Domain Bucket":"< 1K"
   },
   {
     "Class":"Predicate",
-    "Name":"http:\/\/schema.org\/baseSalary-output",
+    "Name":"https://schema.org/baseSalary-output",
     "Domain Bucket":"< 1K"
   },
   {
     "Class":"Predicate",
-    "Name":"http:\/\/schema.org\/bccRecipient",
+    "Name":"https://schema.org/bccRecipient",
     "Domain Bucket":"< 1K"
   },
   {
     "Class":"Predicate",
-    "Name":"http:\/\/schema.org\/bccRecipient-input",
+    "Name":"https://schema.org/bccRecipient-input",
     "Domain Bucket":"< 1K"
   },
   {
     "Class":"Predicate",
-    "Name":"http:\/\/schema.org\/bccRecipient-output",
+    "Name":"https://schema.org/bccRecipient-output",
     "Domain Bucket":"< 1K"
   },
   {
     "Class":"Predicate",
-    "Name":"http:\/\/schema.org\/bed",
+    "Name":"https://schema.org/bed",
     "Domain Bucket":"10K - 100K"
   },
   {
     "Class":"Predicate",
-    "Name":"http:\/\/schema.org\/bed-input",
+    "Name":"https://schema.org/bed-input",
     "Domain Bucket":"< 1K"
   },
   {
     "Class":"Predicate",
-    "Name":"http:\/\/schema.org\/bed-output",
+    "Name":"https://schema.org/bed-output",
     "Domain Bucket":"< 1K"
   },
   {
     "Class":"Predicate",
-    "Name":"http:\/\/schema.org\/beforeMedia",
+    "Name":"https://schema.org/beforeMedia",
     "Domain Bucket":"< 1K"
   },
   {
     "Class":"Predicate",
-    "Name":"http:\/\/schema.org\/beforeMedia-input",
+    "Name":"https://schema.org/beforeMedia-input",
     "Domain Bucket":"< 1K"
   },
   {
     "Class":"Predicate",
-    "Name":"http:\/\/schema.org\/beforeMedia-output",
+    "Name":"https://schema.org/beforeMedia-output",
     "Domain Bucket":"< 1K"
   },
   {
     "Class":"Predicate",
-    "Name":"http:\/\/schema.org\/beneficiaryBank",
+    "Name":"https://schema.org/beneficiaryBank",
     "Domain Bucket":"< 1K"
   },
   {
     "Class":"Predicate",
-    "Name":"http:\/\/schema.org\/beneficiaryBank-input",
+    "Name":"https://schema.org/beneficiaryBank-input",
     "Domain Bucket":"< 1K"
   },
   {
     "Class":"Predicate",
-    "Name":"http:\/\/schema.org\/beneficiaryBank-output",
+    "Name":"https://schema.org/beneficiaryBank-output",
     "Domain Bucket":"< 1K"
   },
   {
     "Class":"Predicate",
-    "Name":"http:\/\/schema.org\/benefits",
+    "Name":"https://schema.org/benefits",
     "Domain Bucket":"1K - 10K"
   },
   {
     "Class":"Predicate",
-    "Name":"http:\/\/schema.org\/benefits-input",
+    "Name":"https://schema.org/benefits-input",
     "Domain Bucket":"< 1K"
   },
   {
     "Class":"Predicate",
-    "Name":"http:\/\/schema.org\/benefits-output",
+    "Name":"https://schema.org/benefits-output",
     "Domain Bucket":"< 1K"
   },
   {
     "Class":"Predicate",
-    "Name":"http:\/\/schema.org\/benefitsSummaryUrl",
+    "Name":"https://schema.org/benefitsSummaryUrl",
     "Domain Bucket":"< 1K"
   },
   {
     "Class":"Predicate",
-    "Name":"http:\/\/schema.org\/benefitsSummaryUrl-input",
+    "Name":"https://schema.org/benefitsSummaryUrl-input",
     "Domain Bucket":"< 1K"
   },
   {
     "Class":"Predicate",
-    "Name":"http:\/\/schema.org\/benefitsSummaryUrl-output",
+    "Name":"https://schema.org/benefitsSummaryUrl-output",
     "Domain Bucket":"< 1K"
   },
   {
     "Class":"Predicate",
-    "Name":"http:\/\/schema.org\/bestRating",
+    "Name":"https://schema.org/bestRating",
     "Domain Bucket":"1M - 10M"
   },
   {
     "Class":"Predicate",
-    "Name":"http:\/\/schema.org\/bestRating-input",
+    "Name":"https://schema.org/bestRating-input",
     "Domain Bucket":"< 1K"
   },
   {
     "Class":"Predicate",
-    "Name":"http:\/\/schema.org\/bestRating-output",
+    "Name":"https://schema.org/bestRating-output",
     "Domain Bucket":"< 1K"
   },
   {
     "Class":"Predicate",
-    "Name":"http:\/\/schema.org\/billingAddress",
+    "Name":"https://schema.org/billingAddress",
     "Domain Bucket":"< 1K"
   },
   {
     "Class":"Predicate",
-    "Name":"http:\/\/schema.org\/billingAddress-input",
+    "Name":"https://schema.org/billingAddress-input",
     "Domain Bucket":"< 1K"
   },
   {
     "Class":"Predicate",
-    "Name":"http:\/\/schema.org\/billingAddress-output",
+    "Name":"https://schema.org/billingAddress-output",
     "Domain Bucket":"< 1K"
   },
   {
     "Class":"Predicate",
-    "Name":"http:\/\/schema.org\/billingDuration",
+    "Name":"https://schema.org/billingDuration",
     "Domain Bucket":"10K - 100K"
   },
   {
     "Class":"Predicate",
-    "Name":"http:\/\/schema.org\/billingDuration-input",
+    "Name":"https://schema.org/billingDuration-input",
     "Domain Bucket":"< 1K"
   },
   {
     "Class":"Predicate",
-    "Name":"http:\/\/schema.org\/billingDuration-output",
+    "Name":"https://schema.org/billingDuration-output",
     "Domain Bucket":"< 1K"
   },
   {
     "Class":"Predicate",
-    "Name":"http:\/\/schema.org\/billingIncrement",
+    "Name":"https://schema.org/billingIncrement",
     "Domain Bucket":"10K - 100K"
   },
   {
     "Class":"Predicate",
-    "Name":"http:\/\/schema.org\/billingIncrement-input",
+    "Name":"https://schema.org/billingIncrement-input",
     "Domain Bucket":"< 1K"
   },
   {
     "Class":"Predicate",
-    "Name":"http:\/\/schema.org\/billingIncrement-output",
+    "Name":"https://schema.org/billingIncrement-output",
     "Domain Bucket":"< 1K"
   },
   {
     "Class":"Predicate",
-    "Name":"http:\/\/schema.org\/billingPeriod",
+    "Name":"https://schema.org/billingPeriod",
     "Domain Bucket":"1K - 10K"
   },
   {
     "Class":"Predicate",
-    "Name":"http:\/\/schema.org\/billingPeriod-input",
+    "Name":"https://schema.org/billingPeriod-input",
     "Domain Bucket":"< 1K"
   },
   {
     "Class":"Predicate",
-    "Name":"http:\/\/schema.org\/billingPeriod-output",
+    "Name":"https://schema.org/billingPeriod-output",
     "Domain Bucket":"< 1K"
   },
   {
     "Class":"Predicate",
-    "Name":"http:\/\/schema.org\/billingStart",
+    "Name":"https://schema.org/billingStart",
     "Domain Bucket":"< 1K"
   },
   {
     "Class":"Predicate",
-    "Name":"http:\/\/schema.org\/billingStart-input",
+    "Name":"https://schema.org/billingStart-input",
     "Domain Bucket":"< 1K"
   },
   {
     "Class":"Predicate",
-    "Name":"http:\/\/schema.org\/billingStart-output",
+    "Name":"https://schema.org/billingStart-output",
     "Domain Bucket":"< 1K"
   },
   {
     "Class":"Predicate",
-    "Name":"http:\/\/schema.org\/bioChemInteraction",
+    "Name":"https://schema.org/bioChemInteraction",
     "Domain Bucket":"< 1K"
   },
   {
     "Class":"Predicate",
-    "Name":"http:\/\/schema.org\/bioChemInteraction-input",
+    "Name":"https://schema.org/bioChemInteraction-input",
     "Domain Bucket":"< 1K"
   },
   {
     "Class":"Predicate",
-    "Name":"http:\/\/schema.org\/bioChemInteraction-output",
+    "Name":"https://schema.org/bioChemInteraction-output",
     "Domain Bucket":"< 1K"
   },
   {
     "Class":"Predicate",
-    "Name":"http:\/\/schema.org\/bioChemSimilarity",
+    "Name":"https://schema.org/bioChemSimilarity",
     "Domain Bucket":"< 1K"
   },
   {
     "Class":"Predicate",
-    "Name":"http:\/\/schema.org\/bioChemSimilarity-input",
+    "Name":"https://schema.org/bioChemSimilarity-input",
     "Domain Bucket":"< 1K"
   },
   {
     "Class":"Predicate",
-    "Name":"http:\/\/schema.org\/bioChemSimilarity-output",
+    "Name":"https://schema.org/bioChemSimilarity-output",
     "Domain Bucket":"< 1K"
   },
   {
     "Class":"Predicate",
-    "Name":"http:\/\/schema.org\/biologicalRole",
+    "Name":"https://schema.org/biologicalRole",
     "Domain Bucket":"< 1K"
   },
   {
     "Class":"Predicate",
-    "Name":"http:\/\/schema.org\/biologicalRole-input",
+    "Name":"https://schema.org/biologicalRole-input",
     "Domain Bucket":"< 1K"
   },
   {
     "Class":"Predicate",
-    "Name":"http:\/\/schema.org\/biologicalRole-output",
+    "Name":"https://schema.org/biologicalRole-output",
     "Domain Bucket":"< 1K"
   },
   {
     "Class":"Predicate",
-    "Name":"http:\/\/schema.org\/biomechnicalClass",
+    "Name":"https://schema.org/biomechnicalClass",
     "Domain Bucket":"< 1K"
   },
   {
     "Class":"Predicate",
-    "Name":"http:\/\/schema.org\/biomechnicalClass-input",
+    "Name":"https://schema.org/biomechnicalClass-input",
     "Domain Bucket":"< 1K"
   },
   {
     "Class":"Predicate",
-    "Name":"http:\/\/schema.org\/biomechnicalClass-output",
+    "Name":"https://schema.org/biomechnicalClass-output",
     "Domain Bucket":"< 1K"
   },
   {
     "Class":"Predicate",
-    "Name":"http:\/\/schema.org\/birthDate",
+    "Name":"https://schema.org/birthDate",
     "Domain Bucket":"10K - 100K"
   },
   {
     "Class":"Predicate",
-    "Name":"http:\/\/schema.org\/birthDate-input",
+    "Name":"https://schema.org/birthDate-input",
     "Domain Bucket":"< 1K"
   },
   {
     "Class":"Predicate",
-    "Name":"http:\/\/schema.org\/birthDate-output",
+    "Name":"https://schema.org/birthDate-output",
     "Domain Bucket":"< 1K"
   },
   {
     "Class":"Predicate",
-    "Name":"http:\/\/schema.org\/birthPlace",
+    "Name":"https://schema.org/birthPlace",
     "Domain Bucket":"10K - 100K"
   },
   {
     "Class":"Predicate",
-    "Name":"http:\/\/schema.org\/birthPlace-input",
+    "Name":"https://schema.org/birthPlace-input",
     "Domain Bucket":"< 1K"
   },
   {
     "Class":"Predicate",
-    "Name":"http:\/\/schema.org\/birthPlace-output",
+    "Name":"https://schema.org/birthPlace-output",
     "Domain Bucket":"< 1K"
   },
   {
     "Class":"Predicate",
-    "Name":"http:\/\/schema.org\/bitrate",
+    "Name":"https://schema.org/bitrate",
     "Domain Bucket":"1K - 10K"
   },
   {
     "Class":"Predicate",
-    "Name":"http:\/\/schema.org\/bitrate-input",
+    "Name":"https://schema.org/bitrate-input",
     "Domain Bucket":"< 1K"
   },
   {
     "Class":"Predicate",
-    "Name":"http:\/\/schema.org\/bitrate-output",
+    "Name":"https://schema.org/bitrate-output",
     "Domain Bucket":"< 1K"
   },
   {
     "Class":"Predicate",
-    "Name":"http:\/\/schema.org\/blogPost",
+    "Name":"https://schema.org/blogPost",
     "Domain Bucket":"100K - 1M"
   },
   {
     "Class":"Predicate",
-    "Name":"http:\/\/schema.org\/blogPost-input",
+    "Name":"https://schema.org/blogPost-input",
     "Domain Bucket":"< 1K"
   },
   {
     "Class":"Predicate",
-    "Name":"http:\/\/schema.org\/blogPost-output",
+    "Name":"https://schema.org/blogPost-output",
     "Domain Bucket":"< 1K"
   },
   {
     "Class":"Predicate",
-    "Name":"http:\/\/schema.org\/blogPosts",
+    "Name":"https://schema.org/blogPosts",
     "Domain Bucket":"10K - 100K"
   },
   {
     "Class":"Predicate",
-    "Name":"http:\/\/schema.org\/blogPosts-input",
+    "Name":"https://schema.org/blogPosts-input",
     "Domain Bucket":"< 1K"
   },
   {
     "Class":"Predicate",
-    "Name":"http:\/\/schema.org\/blogPosts-output",
+    "Name":"https://schema.org/blogPosts-output",
     "Domain Bucket":"< 1K"
   },
   {
     "Class":"Predicate",
-    "Name":"http:\/\/schema.org\/bloodSupply",
+    "Name":"https://schema.org/bloodSupply",
     "Domain Bucket":"< 1K"
   },
   {
     "Class":"Predicate",
-    "Name":"http:\/\/schema.org\/bloodSupply-input",
+    "Name":"https://schema.org/bloodSupply-input",
     "Domain Bucket":"< 1K"
   },
   {
     "Class":"Predicate",
-    "Name":"http:\/\/schema.org\/bloodSupply-output",
+    "Name":"https://schema.org/bloodSupply-output",
     "Domain Bucket":"< 1K"
   },
   {
     "Class":"Predicate",
-    "Name":"http:\/\/schema.org\/boardingGroup",
+    "Name":"https://schema.org/boardingGroup",
     "Domain Bucket":"< 1K"
   },
   {
     "Class":"Predicate",
-    "Name":"http:\/\/schema.org\/boardingGroup-input",
+    "Name":"https://schema.org/boardingGroup-input",
     "Domain Bucket":"< 1K"
   },
   {
     "Class":"Predicate",
-    "Name":"http:\/\/schema.org\/boardingGroup-output",
+    "Name":"https://schema.org/boardingGroup-output",
     "Domain Bucket":"< 1K"
   },
   {
     "Class":"Predicate",
-    "Name":"http:\/\/schema.org\/boardingPolicy",
+    "Name":"https://schema.org/boardingPolicy",
     "Domain Bucket":"< 1K"
   },
   {
     "Class":"Predicate",
-    "Name":"http:\/\/schema.org\/boardingPolicy-input",
+    "Name":"https://schema.org/boardingPolicy-input",
     "Domain Bucket":"< 1K"
   },
   {
     "Class":"Predicate",
-    "Name":"http:\/\/schema.org\/boardingPolicy-output",
+    "Name":"https://schema.org/boardingPolicy-output",
     "Domain Bucket":"< 1K"
   },
   {
     "Class":"Predicate",
-    "Name":"http:\/\/schema.org\/bodyLocation",
+    "Name":"https://schema.org/bodyLocation",
     "Domain Bucket":"1K - 10K"
   },
   {
     "Class":"Predicate",
-    "Name":"http:\/\/schema.org\/bodyLocation-input",
+    "Name":"https://schema.org/bodyLocation-input",
     "Domain Bucket":"< 1K"
   },
   {
     "Class":"Predicate",
-    "Name":"http:\/\/schema.org\/bodyLocation-output",
+    "Name":"https://schema.org/bodyLocation-output",
     "Domain Bucket":"< 1K"
   },
   {
     "Class":"Predicate",
-    "Name":"http:\/\/schema.org\/bodyType",
+    "Name":"https://schema.org/bodyType",
     "Domain Bucket":"10K - 100K"
   },
   {
     "Class":"Predicate",
-    "Name":"http:\/\/schema.org\/bodyType-input",
+    "Name":"https://schema.org/bodyType-input",
     "Domain Bucket":"< 1K"
   },
   {
     "Class":"Predicate",
-    "Name":"http:\/\/schema.org\/bodyType-output",
+    "Name":"https://schema.org/bodyType-output",
     "Domain Bucket":"< 1K"
   },
   {
     "Class":"Predicate",
-    "Name":"http:\/\/schema.org\/bookEdition",
+    "Name":"https://schema.org/bookEdition",
     "Domain Bucket":"1K - 10K"
   },
   {
     "Class":"Predicate",
-    "Name":"http:\/\/schema.org\/bookEdition-input",
+    "Name":"https://schema.org/bookEdition-input",
     "Domain Bucket":"< 1K"
   },
   {
     "Class":"Predicate",
-    "Name":"http:\/\/schema.org\/bookEdition-output",
+    "Name":"https://schema.org/bookEdition-output",
     "Domain Bucket":"< 1K"
   },
   {
     "Class":"Predicate",
-    "Name":"http:\/\/schema.org\/bookFormat",
+    "Name":"https://schema.org/bookFormat",
     "Domain Bucket":"10K - 100K"
   },
   {
     "Class":"Predicate",
-    "Name":"http:\/\/schema.org\/bookFormat-input",
+    "Name":"https://schema.org/bookFormat-input",
     "Domain Bucket":"< 1K"
   },
   {
     "Class":"Predicate",
-    "Name":"http:\/\/schema.org\/bookFormat-output",
+    "Name":"https://schema.org/bookFormat-output",
     "Domain Bucket":"< 1K"
   },
   {
     "Class":"Predicate",
-    "Name":"http:\/\/schema.org\/bookingAgent",
+    "Name":"https://schema.org/bookingAgent",
     "Domain Bucket":"< 1K"
   },
   {
     "Class":"Predicate",
-    "Name":"http:\/\/schema.org\/bookingAgent-input",
+    "Name":"https://schema.org/bookingAgent-input",
     "Domain Bucket":"< 1K"
   },
   {
     "Class":"Predicate",
-    "Name":"http:\/\/schema.org\/bookingAgent-output",
+    "Name":"https://schema.org/bookingAgent-output",
     "Domain Bucket":"< 1K"
   },
   {
     "Class":"Predicate",
-    "Name":"http:\/\/schema.org\/bookingTime",
+    "Name":"https://schema.org/bookingTime",
     "Domain Bucket":"< 1K"
   },
   {
     "Class":"Predicate",
-    "Name":"http:\/\/schema.org\/bookingTime-input",
+    "Name":"https://schema.org/bookingTime-input",
     "Domain Bucket":"< 1K"
   },
   {
     "Class":"Predicate",
-    "Name":"http:\/\/schema.org\/bookingTime-output",
+    "Name":"https://schema.org/bookingTime-output",
     "Domain Bucket":"< 1K"
   },
   {
     "Class":"Predicate",
-    "Name":"http:\/\/schema.org\/borrower",
+    "Name":"https://schema.org/borrower",
     "Domain Bucket":"< 1K"
   },
   {
     "Class":"Predicate",
-    "Name":"http:\/\/schema.org\/borrower-input",
+    "Name":"https://schema.org/borrower-input",
     "Domain Bucket":"< 1K"
   },
   {
     "Class":"Predicate",
-    "Name":"http:\/\/schema.org\/borrower-output",
+    "Name":"https://schema.org/borrower-output",
     "Domain Bucket":"< 1K"
   },
   {
     "Class":"Predicate",
-    "Name":"http:\/\/schema.org\/box",
+    "Name":"https://schema.org/box",
     "Domain Bucket":"1K - 10K"
   },
   {
     "Class":"Predicate",
-    "Name":"http:\/\/schema.org\/box-input",
+    "Name":"https://schema.org/box-input",
     "Domain Bucket":"< 1K"
   },
   {
     "Class":"Predicate",
-    "Name":"http:\/\/schema.org\/box-output",
+    "Name":"https://schema.org/box-output",
     "Domain Bucket":"< 1K"
   },
   {
     "Class":"Predicate",
-    "Name":"http:\/\/schema.org\/branch",
+    "Name":"https://schema.org/branch",
     "Domain Bucket":"< 1K"
   },
   {
     "Class":"Predicate",
-    "Name":"http:\/\/schema.org\/branch-input",
+    "Name":"https://schema.org/branch-input",
     "Domain Bucket":"< 1K"
   },
   {
     "Class":"Predicate",
-    "Name":"http:\/\/schema.org\/branch-output",
+    "Name":"https://schema.org/branch-output",
     "Domain Bucket":"< 1K"
   },
   {
     "Class":"Predicate",
-    "Name":"http:\/\/schema.org\/branchCode",
+    "Name":"https://schema.org/branchCode",
     "Domain Bucket":"1K - 10K"
   },
   {
     "Class":"Predicate",
-    "Name":"http:\/\/schema.org\/branchCode-input",
+    "Name":"https://schema.org/branchCode-input",
     "Domain Bucket":"< 1K"
   },
   {
     "Class":"Predicate",
-    "Name":"http:\/\/schema.org\/branchCode-output",
+    "Name":"https://schema.org/branchCode-output",
     "Domain Bucket":"< 1K"
   },
   {
     "Class":"Predicate",
-    "Name":"http:\/\/schema.org\/branchOf",
+    "Name":"https://schema.org/branchOf",
     "Domain Bucket":"10K - 100K"
   },
   {
     "Class":"Predicate",
-    "Name":"http:\/\/schema.org\/branchOf-input",
+    "Name":"https://schema.org/branchOf-input",
     "Domain Bucket":"< 1K"
   },
   {
     "Class":"Predicate",
-    "Name":"http:\/\/schema.org\/branchOf-output",
+    "Name":"https://schema.org/branchOf-output",
     "Domain Bucket":"< 1K"
   },
   {
     "Class":"Predicate",
-    "Name":"http:\/\/schema.org\/brand",
+    "Name":"https://schema.org/brand",
     "Domain Bucket":"1M - 10M"
   },
   {
     "Class":"Predicate",
-    "Name":"http:\/\/schema.org\/brand-input",
+    "Name":"https://schema.org/brand-input",
     "Domain Bucket":"< 1K"
   },
   {
     "Class":"Predicate",
-    "Name":"http:\/\/schema.org\/brand-output",
+    "Name":"https://schema.org/brand-output",
     "Domain Bucket":"< 1K"
   },
   {
     "Class":"Predicate",
-    "Name":"http:\/\/schema.org\/breadcrumb",
+    "Name":"https://schema.org/breadcrumb",
     "Domain Bucket":"10M+"
   },
   {
     "Class":"Predicate",
-    "Name":"http:\/\/schema.org\/breadcrumb-input",
+    "Name":"https://schema.org/breadcrumb-input",
     "Domain Bucket":"< 1K"
   },
   {
     "Class":"Predicate",
-    "Name":"http:\/\/schema.org\/breadcrumb-output",
+    "Name":"https://schema.org/breadcrumb-output",
     "Domain Bucket":"< 1K"
   },
   {
     "Class":"Predicate",
-    "Name":"http:\/\/schema.org\/breastfeedingWarning",
+    "Name":"https://schema.org/breastfeedingWarning",
     "Domain Bucket":"< 1K"
   },
   {
     "Class":"Predicate",
-    "Name":"http:\/\/schema.org\/breastfeedingWarning-input",
+    "Name":"https://schema.org/breastfeedingWarning-input",
     "Domain Bucket":"< 1K"
   },
   {
     "Class":"Predicate",
-    "Name":"http:\/\/schema.org\/breastfeedingWarning-output",
+    "Name":"https://schema.org/breastfeedingWarning-output",
     "Domain Bucket":"< 1K"
   },
   {
     "Class":"Predicate",
-    "Name":"http:\/\/schema.org\/broadcastAffiliateOf",
+    "Name":"https://schema.org/broadcastAffiliateOf",
     "Domain Bucket":"< 1K"
   },
   {
     "Class":"Predicate",
-    "Name":"http:\/\/schema.org\/broadcastAffiliateOf-input",
+    "Name":"https://schema.org/broadcastAffiliateOf-input",
     "Domain Bucket":"< 1K"
   },
   {
     "Class":"Predicate",
-    "Name":"http:\/\/schema.org\/broadcastAffiliateOf-output",
+    "Name":"https://schema.org/broadcastAffiliateOf-output",
     "Domain Bucket":"< 1K"
   },
   {
     "Class":"Predicate",
-    "Name":"http:\/\/schema.org\/broadcastChannelId",
+    "Name":"https://schema.org/broadcastChannelId",
     "Domain Bucket":"< 1K"
   },
   {
     "Class":"Predicate",
-    "Name":"http:\/\/schema.org\/broadcastChannelId-input",
+    "Name":"https://schema.org/broadcastChannelId-input",
     "Domain Bucket":"< 1K"
   },
   {
     "Class":"Predicate",
-    "Name":"http:\/\/schema.org\/broadcastChannelId-output",
+    "Name":"https://schema.org/broadcastChannelId-output",
     "Domain Bucket":"< 1K"
   },
   {
     "Class":"Predicate",
-    "Name":"http:\/\/schema.org\/broadcastDisplayName",
+    "Name":"https://schema.org/broadcastDisplayName",
     "Domain Bucket":"1K - 10K"
   },
   {
     "Class":"Predicate",
-    "Name":"http:\/\/schema.org\/broadcastDisplayName-input",
+    "Name":"https://schema.org/broadcastDisplayName-input",
     "Domain Bucket":"< 1K"
   },
   {
     "Class":"Predicate",
-    "Name":"http:\/\/schema.org\/broadcastDisplayName-output",
+    "Name":"https://schema.org/broadcastDisplayName-output",
     "Domain Bucket":"< 1K"
   },
   {
     "Class":"Predicate",
-    "Name":"http:\/\/schema.org\/broadcastFrequency",
+    "Name":"https://schema.org/broadcastFrequency",
     "Domain Bucket":"1K - 10K"
   },
   {
     "Class":"Predicate",
-    "Name":"http:\/\/schema.org\/broadcastFrequency-input",
+    "Name":"https://schema.org/broadcastFrequency-input",
     "Domain Bucket":"< 1K"
   },
   {
     "Class":"Predicate",
-    "Name":"http:\/\/schema.org\/broadcastFrequency-output",
+    "Name":"https://schema.org/broadcastFrequency-output",
     "Domain Bucket":"< 1K"
   },
   {
     "Class":"Predicate",
-    "Name":"http:\/\/schema.org\/broadcastFrequencyValue",
+    "Name":"https://schema.org/broadcastFrequencyValue",
     "Domain Bucket":"< 1K"
   },
   {
     "Class":"Predicate",
-    "Name":"http:\/\/schema.org\/broadcastFrequencyValue-input",
+    "Name":"https://schema.org/broadcastFrequencyValue-input",
     "Domain Bucket":"< 1K"
   },
   {
     "Class":"Predicate",
-    "Name":"http:\/\/schema.org\/broadcastFrequencyValue-output",
+    "Name":"https://schema.org/broadcastFrequencyValue-output",
     "Domain Bucket":"< 1K"
   },
   {
     "Class":"Predicate",
-    "Name":"http:\/\/schema.org\/broadcastOfEvent",
+    "Name":"https://schema.org/broadcastOfEvent",
     "Domain Bucket":"< 1K"
   },
   {
     "Class":"Predicate",
-    "Name":"http:\/\/schema.org\/broadcastOfEvent-input",
+    "Name":"https://schema.org/broadcastOfEvent-input",
     "Domain Bucket":"< 1K"
   },
   {
     "Class":"Predicate",
-    "Name":"http:\/\/schema.org\/broadcastOfEvent-output",
+    "Name":"https://schema.org/broadcastOfEvent-output",
     "Domain Bucket":"< 1K"
   },
   {
     "Class":"Predicate",
-    "Name":"http:\/\/schema.org\/broadcastServiceTier",
+    "Name":"https://schema.org/broadcastServiceTier",
     "Domain Bucket":"< 1K"
   },
   {
     "Class":"Predicate",
-    "Name":"http:\/\/schema.org\/broadcastServiceTier-input",
+    "Name":"https://schema.org/broadcastServiceTier-input",
     "Domain Bucket":"< 1K"
   },
   {
     "Class":"Predicate",
-    "Name":"http:\/\/schema.org\/broadcastServiceTier-output",
+    "Name":"https://schema.org/broadcastServiceTier-output",
     "Domain Bucket":"< 1K"
   },
   {
     "Class":"Predicate",
-    "Name":"http:\/\/schema.org\/broadcastSignalModulation",
+    "Name":"https://schema.org/broadcastSignalModulation",
     "Domain Bucket":"< 1K"
   },
   {
     "Class":"Predicate",
-    "Name":"http:\/\/schema.org\/broadcastSignalModulation-input",
+    "Name":"https://schema.org/broadcastSignalModulation-input",
     "Domain Bucket":"< 1K"
   },
   {
     "Class":"Predicate",
-    "Name":"http:\/\/schema.org\/broadcastSignalModulation-output",
+    "Name":"https://schema.org/broadcastSignalModulation-output",
     "Domain Bucket":"< 1K"
   },
   {
     "Class":"Predicate",
-    "Name":"http:\/\/schema.org\/broadcastSubChannel",
+    "Name":"https://schema.org/broadcastSubChannel",
     "Domain Bucket":"< 1K"
   },
   {
     "Class":"Predicate",
-    "Name":"http:\/\/schema.org\/broadcastSubChannel-input",
+    "Name":"https://schema.org/broadcastSubChannel-input",
     "Domain Bucket":"< 1K"
   },
   {
     "Class":"Predicate",
-    "Name":"http:\/\/schema.org\/broadcastSubChannel-output",
+    "Name":"https://schema.org/broadcastSubChannel-output",
     "Domain Bucket":"< 1K"
   },
   {
     "Class":"Predicate",
-    "Name":"http:\/\/schema.org\/broadcastTimezone",
+    "Name":"https://schema.org/broadcastTimezone",
     "Domain Bucket":"< 1K"
   },
   {
     "Class":"Predicate",
-    "Name":"http:\/\/schema.org\/broadcastTimezone-input",
+    "Name":"https://schema.org/broadcastTimezone-input",
     "Domain Bucket":"< 1K"
   },
   {
     "Class":"Predicate",
-    "Name":"http:\/\/schema.org\/broadcastTimezone-output",
+    "Name":"https://schema.org/broadcastTimezone-output",
     "Domain Bucket":"< 1K"
   },
   {
     "Class":"Predicate",
-    "Name":"http:\/\/schema.org\/broadcaster",
+    "Name":"https://schema.org/broadcaster",
     "Domain Bucket":"< 1K"
   },
   {
     "Class":"Predicate",
-    "Name":"http:\/\/schema.org\/broadcaster-input",
+    "Name":"https://schema.org/broadcaster-input",
     "Domain Bucket":"< 1K"
   },
   {
     "Class":"Predicate",
-    "Name":"http:\/\/schema.org\/broadcaster-output",
+    "Name":"https://schema.org/broadcaster-output",
     "Domain Bucket":"< 1K"
   },
   {
     "Class":"Predicate",
-    "Name":"http:\/\/schema.org\/broker",
+    "Name":"https://schema.org/broker",
     "Domain Bucket":"1K - 10K"
   },
   {
     "Class":"Predicate",
-    "Name":"http:\/\/schema.org\/broker-input",
+    "Name":"https://schema.org/broker-input",
     "Domain Bucket":"< 1K"
   },
   {
     "Class":"Predicate",
-    "Name":"http:\/\/schema.org\/broker-output",
+    "Name":"https://schema.org/broker-output",
     "Domain Bucket":"< 1K"
   },
   {
     "Class":"Predicate",
-    "Name":"http:\/\/schema.org\/browserRequirements",
+    "Name":"https://schema.org/browserRequirements",
     "Domain Bucket":"10K - 100K"
   },
   {
     "Class":"Predicate",
-    "Name":"http:\/\/schema.org\/browserRequirements-input",
+    "Name":"https://schema.org/browserRequirements-input",
     "Domain Bucket":"< 1K"
   },
   {
     "Class":"Predicate",
-    "Name":"http:\/\/schema.org\/browserRequirements-output",
+    "Name":"https://schema.org/browserRequirements-output",
     "Domain Bucket":"< 1K"
   },
   {
     "Class":"Predicate",
-    "Name":"http:\/\/schema.org\/busName",
+    "Name":"https://schema.org/busName",
     "Domain Bucket":"< 1K"
   },
   {
     "Class":"Predicate",
-    "Name":"http:\/\/schema.org\/busName-input",
+    "Name":"https://schema.org/busName-input",
     "Domain Bucket":"< 1K"
   },
   {
     "Class":"Predicate",
-    "Name":"http:\/\/schema.org\/busName-output",
+    "Name":"https://schema.org/busName-output",
     "Domain Bucket":"< 1K"
   },
   {
     "Class":"Predicate",
-    "Name":"http:\/\/schema.org\/busNumber",
+    "Name":"https://schema.org/busNumber",
     "Domain Bucket":"< 1K"
   },
   {
     "Class":"Predicate",
-    "Name":"http:\/\/schema.org\/busNumber-input",
+    "Name":"https://schema.org/busNumber-input",
     "Domain Bucket":"< 1K"
   },
   {
     "Class":"Predicate",
-    "Name":"http:\/\/schema.org\/busNumber-output",
+    "Name":"https://schema.org/busNumber-output",
     "Domain Bucket":"< 1K"
   },
   {
     "Class":"Predicate",
-    "Name":"http:\/\/schema.org\/businessDays",
+    "Name":"https://schema.org/businessDays",
     "Domain Bucket":"10K - 100K"
   },
   {
     "Class":"Predicate",
-    "Name":"http:\/\/schema.org\/businessDays-input",
+    "Name":"https://schema.org/businessDays-input",
     "Domain Bucket":"< 1K"
   },
   {
     "Class":"Predicate",
-    "Name":"http:\/\/schema.org\/businessDays-output",
+    "Name":"https://schema.org/businessDays-output",
     "Domain Bucket":"< 1K"
   },
   {
     "Class":"Predicate",
-    "Name":"http:\/\/schema.org\/businessFunction",
+    "Name":"https://schema.org/businessFunction",
     "Domain Bucket":"10K - 100K"
   },
   {
     "Class":"Predicate",
-    "Name":"http:\/\/schema.org\/businessFunction-input",
+    "Name":"https://schema.org/businessFunction-input",
     "Domain Bucket":"< 1K"
   },
   {
     "Class":"Predicate",
-    "Name":"http:\/\/schema.org\/businessFunction-output",
+    "Name":"https://schema.org/businessFunction-output",
     "Domain Bucket":"< 1K"
   },
   {
     "Class":"Predicate",
-    "Name":"http:\/\/schema.org\/buyer",
+    "Name":"https://schema.org/buyer",
     "Domain Bucket":"< 1K"
   },
   {
     "Class":"Predicate",
-    "Name":"http:\/\/schema.org\/buyer-input",
+    "Name":"https://schema.org/buyer-input",
     "Domain Bucket":"< 1K"
   },
   {
     "Class":"Predicate",
-    "Name":"http:\/\/schema.org\/buyer-output",
+    "Name":"https://schema.org/buyer-output",
     "Domain Bucket":"< 1K"
   },
   {
     "Class":"Predicate",
-    "Name":"http:\/\/schema.org\/byArtist",
+    "Name":"https://schema.org/byArtist",
     "Domain Bucket":"10K - 100K"
   },
   {
     "Class":"Predicate",
-    "Name":"http:\/\/schema.org\/byArtist-input",
+    "Name":"https://schema.org/byArtist-input",
     "Domain Bucket":"< 1K"
   },
   {
     "Class":"Predicate",
-    "Name":"http:\/\/schema.org\/byArtist-output",
+    "Name":"https://schema.org/byArtist-output",
     "Domain Bucket":"< 1K"
   },
   {
     "Class":"Predicate",
-    "Name":"http:\/\/schema.org\/byDay",
+    "Name":"https://schema.org/byDay",
     "Domain Bucket":"1K - 10K"
   },
   {
     "Class":"Predicate",
-    "Name":"http:\/\/schema.org\/byDay-input",
+    "Name":"https://schema.org/byDay-input",
     "Domain Bucket":"< 1K"
   },
   {
     "Class":"Predicate",
-    "Name":"http:\/\/schema.org\/byDay-output",
+    "Name":"https://schema.org/byDay-output",
     "Domain Bucket":"< 1K"
   },
   {
     "Class":"Predicate",
-    "Name":"http:\/\/schema.org\/byMonth",
+    "Name":"https://schema.org/byMonth",
     "Domain Bucket":"< 1K"
   },
   {
     "Class":"Predicate",
-    "Name":"http:\/\/schema.org\/byMonth-input",
+    "Name":"https://schema.org/byMonth-input",
     "Domain Bucket":"< 1K"
   },
   {
     "Class":"Predicate",
-    "Name":"http:\/\/schema.org\/byMonth-output",
+    "Name":"https://schema.org/byMonth-output",
     "Domain Bucket":"< 1K"
   },
   {
     "Class":"Predicate",
-    "Name":"http:\/\/schema.org\/byMonthDay",
+    "Name":"https://schema.org/byMonthDay",
     "Domain Bucket":"< 1K"
   },
   {
     "Class":"Predicate",
-    "Name":"http:\/\/schema.org\/byMonthDay-input",
+    "Name":"https://schema.org/byMonthDay-input",
     "Domain Bucket":"< 1K"
   },
   {
     "Class":"Predicate",
-    "Name":"http:\/\/schema.org\/byMonthDay-output",
+    "Name":"https://schema.org/byMonthDay-output",
     "Domain Bucket":"< 1K"
   },
   {
     "Class":"Predicate",
-    "Name":"http:\/\/schema.org\/byMonthWeek",
+    "Name":"https://schema.org/byMonthWeek",
     "Domain Bucket":"< 1K"
   },
   {
     "Class":"Predicate",
-    "Name":"http:\/\/schema.org\/byMonthWeek-input",
+    "Name":"https://schema.org/byMonthWeek-input",
     "Domain Bucket":"< 1K"
   },
   {
     "Class":"Predicate",
-    "Name":"http:\/\/schema.org\/byMonthWeek-output",
+    "Name":"https://schema.org/byMonthWeek-output",
     "Domain Bucket":"< 1K"
   },
   {
     "Class":"Predicate",
-    "Name":"http:\/\/schema.org\/callSign",
+    "Name":"https://schema.org/callSign",
     "Domain Bucket":"< 1K"
   },
   {
     "Class":"Predicate",
-    "Name":"http:\/\/schema.org\/callSign-input",
+    "Name":"https://schema.org/callSign-input",
     "Domain Bucket":"< 1K"
   },
   {
     "Class":"Predicate",
-    "Name":"http:\/\/schema.org\/callSign-output",
+    "Name":"https://schema.org/callSign-output",
     "Domain Bucket":"< 1K"
   },
   {
     "Class":"Predicate",
-    "Name":"http:\/\/schema.org\/calories",
+    "Name":"https://schema.org/calories",
     "Domain Bucket":"10K - 100K"
   },
   {
     "Class":"Predicate",
-    "Name":"http:\/\/schema.org\/calories-input",
+    "Name":"https://schema.org/calories-input",
     "Domain Bucket":"< 1K"
   },
   {
     "Class":"Predicate",
-    "Name":"http:\/\/schema.org\/calories-output",
+    "Name":"https://schema.org/calories-output",
     "Domain Bucket":"< 1K"
   },
   {
     "Class":"Predicate",
-    "Name":"http:\/\/schema.org\/candidate",
+    "Name":"https://schema.org/candidate",
     "Domain Bucket":"< 1K"
   },
   {
     "Class":"Predicate",
-    "Name":"http:\/\/schema.org\/candidate-input",
+    "Name":"https://schema.org/candidate-input",
     "Domain Bucket":"< 1K"
   },
   {
     "Class":"Predicate",
-    "Name":"http:\/\/schema.org\/candidate-output",
+    "Name":"https://schema.org/candidate-output",
     "Domain Bucket":"< 1K"
   },
   {
     "Class":"Predicate",
-    "Name":"http:\/\/schema.org\/caption",
+    "Name":"https://schema.org/caption",
     "Domain Bucket":"10M+"
   },
   {
     "Class":"Predicate",
-    "Name":"http:\/\/schema.org\/caption-input",
+    "Name":"https://schema.org/caption-input",
     "Domain Bucket":"< 1K"
   },
   {
     "Class":"Predicate",
-    "Name":"http:\/\/schema.org\/caption-output",
+    "Name":"https://schema.org/caption-output",
     "Domain Bucket":"< 1K"
   },
   {
     "Class":"Predicate",
-    "Name":"http:\/\/schema.org\/carbohydrateContent",
+    "Name":"https://schema.org/carbohydrateContent",
     "Domain Bucket":"10K - 100K"
   },
   {
     "Class":"Predicate",
-    "Name":"http:\/\/schema.org\/carbohydrateContent-input",
+    "Name":"https://schema.org/carbohydrateContent-input",
     "Domain Bucket":"< 1K"
   },
   {
     "Class":"Predicate",
-    "Name":"http:\/\/schema.org\/carbohydrateContent-output",
+    "Name":"https://schema.org/carbohydrateContent-output",
     "Domain Bucket":"< 1K"
   },
   {
     "Class":"Predicate",
-    "Name":"http:\/\/schema.org\/cargoVolume",
+    "Name":"https://schema.org/cargoVolume",
     "Domain Bucket":"1K - 10K"
   },
   {
     "Class":"Predicate",
-    "Name":"http:\/\/schema.org\/cargoVolume-input",
+    "Name":"https://schema.org/cargoVolume-input",
     "Domain Bucket":"< 1K"
   },
   {
     "Class":"Predicate",
-    "Name":"http:\/\/schema.org\/cargoVolume-output",
+    "Name":"https://schema.org/cargoVolume-output",
     "Domain Bucket":"< 1K"
   },
   {
     "Class":"Predicate",
-    "Name":"http:\/\/schema.org\/carrier",
+    "Name":"https://schema.org/carrier",
     "Domain Bucket":"< 1K"
   },
   {
     "Class":"Predicate",
-    "Name":"http:\/\/schema.org\/carrier-input",
+    "Name":"https://schema.org/carrier-input",
     "Domain Bucket":"< 1K"
   },
   {
     "Class":"Predicate",
-    "Name":"http:\/\/schema.org\/carrier-output",
+    "Name":"https://schema.org/carrier-output",
     "Domain Bucket":"< 1K"
   },
   {
     "Class":"Predicate",
-    "Name":"http:\/\/schema.org\/carrierRequirements",
+    "Name":"https://schema.org/carrierRequirements",
     "Domain Bucket":"< 1K"
   },
   {
     "Class":"Predicate",
-    "Name":"http:\/\/schema.org\/carrierRequirements-input",
+    "Name":"https://schema.org/carrierRequirements-input",
     "Domain Bucket":"< 1K"
   },
   {
     "Class":"Predicate",
-    "Name":"http:\/\/schema.org\/carrierRequirements-output",
+    "Name":"https://schema.org/carrierRequirements-output",
     "Domain Bucket":"< 1K"
   },
   {
     "Class":"Predicate",
-    "Name":"http:\/\/schema.org\/cashBack",
+    "Name":"https://schema.org/cashBack",
     "Domain Bucket":"< 1K"
   },
   {
     "Class":"Predicate",
-    "Name":"http:\/\/schema.org\/cashBack-input",
+    "Name":"https://schema.org/cashBack-input",
     "Domain Bucket":"< 1K"
   },
   {
     "Class":"Predicate",
-    "Name":"http:\/\/schema.org\/cashBack-output",
+    "Name":"https://schema.org/cashBack-output",
     "Domain Bucket":"< 1K"
   },
   {
     "Class":"Predicate",
-    "Name":"http:\/\/schema.org\/catalog",
+    "Name":"https://schema.org/catalog",
     "Domain Bucket":"< 1K"
   },
   {
     "Class":"Predicate",
-    "Name":"http:\/\/schema.org\/catalog-input",
+    "Name":"https://schema.org/catalog-input",
     "Domain Bucket":"< 1K"
   },
   {
     "Class":"Predicate",
-    "Name":"http:\/\/schema.org\/catalog-output",
+    "Name":"https://schema.org/catalog-output",
     "Domain Bucket":"< 1K"
   },
   {
     "Class":"Predicate",
-    "Name":"http:\/\/schema.org\/catalogNumber",
+    "Name":"https://schema.org/catalogNumber",
     "Domain Bucket":"< 1K"
   },
   {
     "Class":"Predicate",
-    "Name":"http:\/\/schema.org\/catalogNumber-input",
+    "Name":"https://schema.org/catalogNumber-input",
     "Domain Bucket":"< 1K"
   },
   {
     "Class":"Predicate",
-    "Name":"http:\/\/schema.org\/catalogNumber-output",
+    "Name":"https://schema.org/catalogNumber-output",
     "Domain Bucket":"< 1K"
   },
   {
     "Class":"Predicate",
-    "Name":"http:\/\/schema.org\/category",
+    "Name":"https://schema.org/category",
     "Domain Bucket":"1M - 10M"
   },
   {
     "Class":"Predicate",
-    "Name":"http:\/\/schema.org\/category-input",
+    "Name":"https://schema.org/category-input",
     "Domain Bucket":"< 1K"
   },
   {
     "Class":"Predicate",
-    "Name":"http:\/\/schema.org\/category-output",
+    "Name":"https://schema.org/category-output",
     "Domain Bucket":"< 1K"
   },
   {
     "Class":"Predicate",
-    "Name":"http:\/\/schema.org\/cause",
+    "Name":"https://schema.org/cause",
     "Domain Bucket":"1K - 10K"
   },
   {
     "Class":"Predicate",
-    "Name":"http:\/\/schema.org\/cause-input",
+    "Name":"https://schema.org/cause-input",
     "Domain Bucket":"< 1K"
   },
   {
     "Class":"Predicate",
-    "Name":"http:\/\/schema.org\/cause-output",
+    "Name":"https://schema.org/cause-output",
     "Domain Bucket":"< 1K"
   },
   {
     "Class":"Predicate",
-    "Name":"http:\/\/schema.org\/causeOf",
+    "Name":"https://schema.org/causeOf",
     "Domain Bucket":"< 1K"
   },
   {
     "Class":"Predicate",
-    "Name":"http:\/\/schema.org\/causeOf-input",
+    "Name":"https://schema.org/causeOf-input",
     "Domain Bucket":"< 1K"
   },
   {
     "Class":"Predicate",
-    "Name":"http:\/\/schema.org\/causeOf-output",
+    "Name":"https://schema.org/causeOf-output",
     "Domain Bucket":"< 1K"
   },
   {
     "Class":"Predicate",
-    "Name":"http:\/\/schema.org\/ccRecipient",
+    "Name":"https://schema.org/ccRecipient",
     "Domain Bucket":"< 1K"
   },
   {
     "Class":"Predicate",
-    "Name":"http:\/\/schema.org\/ccRecipient-input",
+    "Name":"https://schema.org/ccRecipient-input",
     "Domain Bucket":"< 1K"
   },
   {
     "Class":"Predicate",
-    "Name":"http:\/\/schema.org\/ccRecipient-output",
+    "Name":"https://schema.org/ccRecipient-output",
     "Domain Bucket":"< 1K"
   },
   {
     "Class":"Predicate",
-    "Name":"http:\/\/schema.org\/certificationIdentification",
+    "Name":"https://schema.org/certificationIdentification",
     "Domain Bucket":"1K - 10K"
   },
   {
     "Class":"Predicate",
-    "Name":"http:\/\/schema.org\/certificationIdentification-input",
+    "Name":"https://schema.org/certificationIdentification-input",
     "Domain Bucket":"< 1K"
   },
   {
     "Class":"Predicate",
-    "Name":"http:\/\/schema.org\/certificationIdentification-output",
+    "Name":"https://schema.org/certificationIdentification-output",
     "Domain Bucket":"< 1K"
   },
   {
     "Class":"Predicate",
-    "Name":"http:\/\/schema.org\/certificationRating",
+    "Name":"https://schema.org/certificationRating",
     "Domain Bucket":"< 1K"
   },
   {
     "Class":"Predicate",
-    "Name":"http:\/\/schema.org\/certificationRating-input",
+    "Name":"https://schema.org/certificationRating-input",
     "Domain Bucket":"< 1K"
   },
   {
     "Class":"Predicate",
-    "Name":"http:\/\/schema.org\/certificationRating-output",
+    "Name":"https://schema.org/certificationRating-output",
     "Domain Bucket":"< 1K"
   },
   {
     "Class":"Predicate",
-    "Name":"http:\/\/schema.org\/certificationStatus",
+    "Name":"https://schema.org/certificationStatus",
     "Domain Bucket":"< 1K"
   },
   {
     "Class":"Predicate",
-    "Name":"http:\/\/schema.org\/certificationStatus-input",
+    "Name":"https://schema.org/certificationStatus-input",
     "Domain Bucket":"< 1K"
   },
   {
     "Class":"Predicate",
-    "Name":"http:\/\/schema.org\/certificationStatus-output",
+    "Name":"https://schema.org/certificationStatus-output",
     "Domain Bucket":"< 1K"
   },
   {
     "Class":"Predicate",
-    "Name":"http:\/\/schema.org\/character",
+    "Name":"https://schema.org/character",
     "Domain Bucket":"< 1K"
   },
   {
     "Class":"Predicate",
-    "Name":"http:\/\/schema.org\/character-input",
+    "Name":"https://schema.org/character-input",
     "Domain Bucket":"< 1K"
   },
   {
     "Class":"Predicate",
-    "Name":"http:\/\/schema.org\/character-output",
+    "Name":"https://schema.org/character-output",
     "Domain Bucket":"< 1K"
   },
   {
     "Class":"Predicate",
-    "Name":"http:\/\/schema.org\/characterAttribute",
+    "Name":"https://schema.org/characterAttribute",
     "Domain Bucket":"< 1K"
   },
   {
     "Class":"Predicate",
-    "Name":"http:\/\/schema.org\/characterAttribute-input",
+    "Name":"https://schema.org/characterAttribute-input",
     "Domain Bucket":"< 1K"
   },
   {
     "Class":"Predicate",
-    "Name":"http:\/\/schema.org\/characterAttribute-output",
+    "Name":"https://schema.org/characterAttribute-output",
     "Domain Bucket":"< 1K"
   },
   {
     "Class":"Predicate",
-    "Name":"http:\/\/schema.org\/characterName",
+    "Name":"https://schema.org/characterName",
     "Domain Bucket":"< 1K"
   },
   {
     "Class":"Predicate",
-    "Name":"http:\/\/schema.org\/characterName-input",
+    "Name":"https://schema.org/characterName-input",
     "Domain Bucket":"< 1K"
   },
   {
     "Class":"Predicate",
-    "Name":"http:\/\/schema.org\/characterName-output",
+    "Name":"https://schema.org/characterName-output",
     "Domain Bucket":"< 1K"
   },
   {
     "Class":"Predicate",
-    "Name":"http:\/\/schema.org\/cheatCode",
+    "Name":"https://schema.org/cheatCode",
     "Domain Bucket":"< 1K"
   },
   {
     "Class":"Predicate",
-    "Name":"http:\/\/schema.org\/cheatCode-input",
+    "Name":"https://schema.org/cheatCode-input",
     "Domain Bucket":"< 1K"
   },
   {
     "Class":"Predicate",
-    "Name":"http:\/\/schema.org\/cheatCode-output",
+    "Name":"https://schema.org/cheatCode-output",
     "Domain Bucket":"< 1K"
   },
   {
     "Class":"Predicate",
-    "Name":"http:\/\/schema.org\/checkinTime",
+    "Name":"https://schema.org/checkinTime",
     "Domain Bucket":"10K - 100K"
   },
   {
     "Class":"Predicate",
-    "Name":"http:\/\/schema.org\/checkinTime-input",
+    "Name":"https://schema.org/checkinTime-input",
     "Domain Bucket":"< 1K"
   },
   {
     "Class":"Predicate",
-    "Name":"http:\/\/schema.org\/checkinTime-output",
+    "Name":"https://schema.org/checkinTime-output",
     "Domain Bucket":"< 1K"
   },
   {
     "Class":"Predicate",
-    "Name":"http:\/\/schema.org\/checkoutPageURLTemplate",
+    "Name":"https://schema.org/checkoutPageURLTemplate",
     "Domain Bucket":"10K - 100K"
   },
   {
     "Class":"Predicate",
-    "Name":"http:\/\/schema.org\/checkoutPageURLTemplate-input",
+    "Name":"https://schema.org/checkoutPageURLTemplate-input",
     "Domain Bucket":"< 1K"
   },
   {
     "Class":"Predicate",
-    "Name":"http:\/\/schema.org\/checkoutPageURLTemplate-output",
+    "Name":"https://schema.org/checkoutPageURLTemplate-output",
     "Domain Bucket":"< 1K"
   },
   {
     "Class":"Predicate",
-    "Name":"http:\/\/schema.org\/checkoutTime",
+    "Name":"https://schema.org/checkoutTime",
     "Domain Bucket":"10K - 100K"
   },
   {
     "Class":"Predicate",
-    "Name":"http:\/\/schema.org\/checkoutTime-input",
+    "Name":"https://schema.org/checkoutTime-input",
     "Domain Bucket":"< 1K"
   },
   {
     "Class":"Predicate",
-    "Name":"http:\/\/schema.org\/checkoutTime-output",
+    "Name":"https://schema.org/checkoutTime-output",
     "Domain Bucket":"< 1K"
   },
   {
     "Class":"Predicate",
-    "Name":"http:\/\/schema.org\/chemicalComposition",
+    "Name":"https://schema.org/chemicalComposition",
     "Domain Bucket":"< 1K"
   },
   {
     "Class":"Predicate",
-    "Name":"http:\/\/schema.org\/chemicalComposition-input",
+    "Name":"https://schema.org/chemicalComposition-input",
     "Domain Bucket":"< 1K"
   },
   {
     "Class":"Predicate",
-    "Name":"http:\/\/schema.org\/chemicalComposition-output",
+    "Name":"https://schema.org/chemicalComposition-output",
     "Domain Bucket":"< 1K"
   },
   {
     "Class":"Predicate",
-    "Name":"http:\/\/schema.org\/chemicalRole",
+    "Name":"https://schema.org/chemicalRole",
     "Domain Bucket":"< 1K"
   },
   {
     "Class":"Predicate",
-    "Name":"http:\/\/schema.org\/chemicalRole-input",
+    "Name":"https://schema.org/chemicalRole-input",
     "Domain Bucket":"< 1K"
   },
   {
     "Class":"Predicate",
-    "Name":"http:\/\/schema.org\/chemicalRole-output",
+    "Name":"https://schema.org/chemicalRole-output",
     "Domain Bucket":"< 1K"
   },
   {
     "Class":"Predicate",
-    "Name":"http:\/\/schema.org\/childMaxAge",
+    "Name":"https://schema.org/childMaxAge",
     "Domain Bucket":"< 1K"
   },
   {
     "Class":"Predicate",
-    "Name":"http:\/\/schema.org\/childMaxAge-input",
+    "Name":"https://schema.org/childMaxAge-input",
     "Domain Bucket":"< 1K"
   },
   {
     "Class":"Predicate",
-    "Name":"http:\/\/schema.org\/childMaxAge-output",
+    "Name":"https://schema.org/childMaxAge-output",
     "Domain Bucket":"< 1K"
   },
   {
     "Class":"Predicate",
-    "Name":"http:\/\/schema.org\/childMinAge",
+    "Name":"https://schema.org/childMinAge",
     "Domain Bucket":"< 1K"
   },
   {
     "Class":"Predicate",
-    "Name":"http:\/\/schema.org\/childMinAge-input",
+    "Name":"https://schema.org/childMinAge-input",
     "Domain Bucket":"< 1K"
   },
   {
     "Class":"Predicate",
-    "Name":"http:\/\/schema.org\/childMinAge-output",
+    "Name":"https://schema.org/childMinAge-output",
     "Domain Bucket":"< 1K"
   },
   {
     "Class":"Predicate",
-    "Name":"http:\/\/schema.org\/childTaxon",
+    "Name":"https://schema.org/childTaxon",
     "Domain Bucket":"< 1K"
   },
   {
     "Class":"Predicate",
-    "Name":"http:\/\/schema.org\/childTaxon-input",
+    "Name":"https://schema.org/childTaxon-input",
     "Domain Bucket":"< 1K"
   },
   {
     "Class":"Predicate",
-    "Name":"http:\/\/schema.org\/childTaxon-output",
+    "Name":"https://schema.org/childTaxon-output",
     "Domain Bucket":"< 1K"
   },
   {
     "Class":"Predicate",
-    "Name":"http:\/\/schema.org\/children",
+    "Name":"https://schema.org/children",
     "Domain Bucket":"1K - 10K"
   },
   {
     "Class":"Predicate",
-    "Name":"http:\/\/schema.org\/children-input",
+    "Name":"https://schema.org/children-input",
     "Domain Bucket":"< 1K"
   },
   {
     "Class":"Predicate",
-    "Name":"http:\/\/schema.org\/children-output",
+    "Name":"https://schema.org/children-output",
     "Domain Bucket":"< 1K"
   },
   {
     "Class":"Predicate",
-    "Name":"http:\/\/schema.org\/cholesterolContent",
+    "Name":"https://schema.org/cholesterolContent",
     "Domain Bucket":"10K - 100K"
   },
   {
     "Class":"Predicate",
-    "Name":"http:\/\/schema.org\/cholesterolContent-input",
+    "Name":"https://schema.org/cholesterolContent-input",
     "Domain Bucket":"< 1K"
   },
   {
     "Class":"Predicate",
-    "Name":"http:\/\/schema.org\/cholesterolContent-output",
+    "Name":"https://schema.org/cholesterolContent-output",
     "Domain Bucket":"< 1K"
   },
   {
     "Class":"Predicate",
-    "Name":"http:\/\/schema.org\/circle",
+    "Name":"https://schema.org/circle",
     "Domain Bucket":"1K - 10K"
   },
   {
     "Class":"Predicate",
-    "Name":"http:\/\/schema.org\/circle-input",
+    "Name":"https://schema.org/circle-input",
     "Domain Bucket":"< 1K"
   },
   {
     "Class":"Predicate",
-    "Name":"http:\/\/schema.org\/circle-output",
+    "Name":"https://schema.org/circle-output",
     "Domain Bucket":"< 1K"
   },
   {
     "Class":"Predicate",
-    "Name":"http:\/\/schema.org\/citation",
+    "Name":"https://schema.org/citation",
     "Domain Bucket":"10K - 100K"
   },
   {
     "Class":"Predicate",
-    "Name":"http:\/\/schema.org\/citation-input",
+    "Name":"https://schema.org/citation-input",
     "Domain Bucket":"< 1K"
   },
   {
     "Class":"Predicate",
-    "Name":"http:\/\/schema.org\/citation-output",
+    "Name":"https://schema.org/citation-output",
     "Domain Bucket":"< 1K"
   },
   {
     "Class":"Predicate",
-    "Name":"http:\/\/schema.org\/claimInterpreter",
+    "Name":"https://schema.org/claimInterpreter",
     "Domain Bucket":"< 1K"
   },
   {
     "Class":"Predicate",
-    "Name":"http:\/\/schema.org\/claimInterpreter-input",
+    "Name":"https://schema.org/claimInterpreter-input",
     "Domain Bucket":"< 1K"
   },
   {
     "Class":"Predicate",
-    "Name":"http:\/\/schema.org\/claimInterpreter-output",
+    "Name":"https://schema.org/claimInterpreter-output",
     "Domain Bucket":"< 1K"
   },
   {
     "Class":"Predicate",
-    "Name":"http:\/\/schema.org\/claimReviewed",
+    "Name":"https://schema.org/claimReviewed",
     "Domain Bucket":"1K - 10K"
   },
   {
     "Class":"Predicate",
-    "Name":"http:\/\/schema.org\/claimReviewed-input",
+    "Name":"https://schema.org/claimReviewed-input",
     "Domain Bucket":"< 1K"
   },
   {
     "Class":"Predicate",
-    "Name":"http:\/\/schema.org\/claimReviewed-output",
+    "Name":"https://schema.org/claimReviewed-output",
     "Domain Bucket":"< 1K"
   },
   {
     "Class":"Predicate",
-    "Name":"http:\/\/schema.org\/clincalPharmacology",
+    "Name":"https://schema.org/clincalPharmacology",
     "Domain Bucket":"< 1K"
   },
   {
     "Class":"Predicate",
-    "Name":"http:\/\/schema.org\/clincalPharmacology-input",
+    "Name":"https://schema.org/clincalPharmacology-input",
     "Domain Bucket":"< 1K"
   },
   {
     "Class":"Predicate",
-    "Name":"http:\/\/schema.org\/clincalPharmacology-output",
+    "Name":"https://schema.org/clincalPharmacology-output",
     "Domain Bucket":"< 1K"
   },
   {
     "Class":"Predicate",
-    "Name":"http:\/\/schema.org\/clinicalPharmacology",
+    "Name":"https://schema.org/clinicalPharmacology",
     "Domain Bucket":"< 1K"
   },
   {
     "Class":"Predicate",
-    "Name":"http:\/\/schema.org\/clinicalPharmacology-input",
+    "Name":"https://schema.org/clinicalPharmacology-input",
     "Domain Bucket":"< 1K"
   },
   {
     "Class":"Predicate",
-    "Name":"http:\/\/schema.org\/clinicalPharmacology-output",
+    "Name":"https://schema.org/clinicalPharmacology-output",
     "Domain Bucket":"< 1K"
   },
   {
     "Class":"Predicate",
-    "Name":"http:\/\/schema.org\/clipNumber",
+    "Name":"https://schema.org/clipNumber",
     "Domain Bucket":"< 1K"
   },
   {
     "Class":"Predicate",
-    "Name":"http:\/\/schema.org\/clipNumber-input",
+    "Name":"https://schema.org/clipNumber-input",
     "Domain Bucket":"< 1K"
   },
   {
     "Class":"Predicate",
-    "Name":"http:\/\/schema.org\/clipNumber-output",
+    "Name":"https://schema.org/clipNumber-output",
     "Domain Bucket":"< 1K"
   },
   {
     "Class":"Predicate",
-    "Name":"http:\/\/schema.org\/closes",
+    "Name":"https://schema.org/closes",
     "Domain Bucket":"1M - 10M"
   },
   {
     "Class":"Predicate",
-    "Name":"http:\/\/schema.org\/closes-input",
+    "Name":"https://schema.org/closes-input",
     "Domain Bucket":"< 1K"
   },
   {
     "Class":"Predicate",
-    "Name":"http:\/\/schema.org\/closes-output",
+    "Name":"https://schema.org/closes-output",
     "Domain Bucket":"< 1K"
   },
   {
     "Class":"Predicate",
-    "Name":"http:\/\/schema.org\/coach",
+    "Name":"https://schema.org/coach",
     "Domain Bucket":"< 1K"
   },
   {
     "Class":"Predicate",
-    "Name":"http:\/\/schema.org\/coach-input",
+    "Name":"https://schema.org/coach-input",
     "Domain Bucket":"< 1K"
   },
   {
     "Class":"Predicate",
-    "Name":"http:\/\/schema.org\/coach-output",
+    "Name":"https://schema.org/coach-output",
     "Domain Bucket":"< 1K"
   },
   {
     "Class":"Predicate",
-    "Name":"http:\/\/schema.org\/code",
+    "Name":"https://schema.org/code",
     "Domain Bucket":"1K - 10K"
   },
   {
     "Class":"Predicate",
-    "Name":"http:\/\/schema.org\/code-input",
+    "Name":"https://schema.org/code-input",
     "Domain Bucket":"< 1K"
   },
   {
     "Class":"Predicate",
-    "Name":"http:\/\/schema.org\/code-output",
+    "Name":"https://schema.org/code-output",
     "Domain Bucket":"< 1K"
   },
   {
     "Class":"Predicate",
-    "Name":"http:\/\/schema.org\/codeRepository",
+    "Name":"https://schema.org/codeRepository",
     "Domain Bucket":"1K - 10K"
   },
   {
     "Class":"Predicate",
-    "Name":"http:\/\/schema.org\/codeRepository-input",
+    "Name":"https://schema.org/codeRepository-input",
     "Domain Bucket":"< 1K"
   },
   {
     "Class":"Predicate",
-    "Name":"http:\/\/schema.org\/codeRepository-output",
+    "Name":"https://schema.org/codeRepository-output",
     "Domain Bucket":"< 1K"
   },
   {
     "Class":"Predicate",
-    "Name":"http:\/\/schema.org\/codeSampleType",
+    "Name":"https://schema.org/codeSampleType",
     "Domain Bucket":"< 1K"
   },
   {
     "Class":"Predicate",
-    "Name":"http:\/\/schema.org\/codeSampleType-input",
+    "Name":"https://schema.org/codeSampleType-input",
     "Domain Bucket":"< 1K"
   },
   {
     "Class":"Predicate",
-    "Name":"http:\/\/schema.org\/codeSampleType-output",
+    "Name":"https://schema.org/codeSampleType-output",
     "Domain Bucket":"< 1K"
   },
   {
     "Class":"Predicate",
-    "Name":"http:\/\/schema.org\/codeValue",
+    "Name":"https://schema.org/codeValue",
     "Domain Bucket":"1K - 10K"
   },
   {
     "Class":"Predicate",
-    "Name":"http:\/\/schema.org\/codeValue-input",
+    "Name":"https://schema.org/codeValue-input",
     "Domain Bucket":"< 1K"
   },
   {
     "Class":"Predicate",
-    "Name":"http:\/\/schema.org\/codeValue-output",
+    "Name":"https://schema.org/codeValue-output",
     "Domain Bucket":"< 1K"
   },
   {
     "Class":"Predicate",
-    "Name":"http:\/\/schema.org\/codingSystem",
+    "Name":"https://schema.org/codingSystem",
     "Domain Bucket":"1K - 10K"
   },
   {
     "Class":"Predicate",
-    "Name":"http:\/\/schema.org\/codingSystem-input",
+    "Name":"https://schema.org/codingSystem-input",
     "Domain Bucket":"< 1K"
   },
   {
     "Class":"Predicate",
-    "Name":"http:\/\/schema.org\/codingSystem-output",
+    "Name":"https://schema.org/codingSystem-output",
     "Domain Bucket":"< 1K"
   },
   {
     "Class":"Predicate",
-    "Name":"http:\/\/schema.org\/colleague",
+    "Name":"https://schema.org/colleague",
     "Domain Bucket":"1K - 10K"
   },
   {
     "Class":"Predicate",
-    "Name":"http:\/\/schema.org\/colleague-input",
+    "Name":"https://schema.org/colleague-input",
     "Domain Bucket":"< 1K"
   },
   {
     "Class":"Predicate",
-    "Name":"http:\/\/schema.org\/colleague-output",
+    "Name":"https://schema.org/colleague-output",
     "Domain Bucket":"< 1K"
   },
   {
     "Class":"Predicate",
-    "Name":"http:\/\/schema.org\/colleagues",
+    "Name":"https://schema.org/colleagues",
     "Domain Bucket":"< 1K"
   },
   {
     "Class":"Predicate",
-    "Name":"http:\/\/schema.org\/colleagues-input",
+    "Name":"https://schema.org/colleagues-input",
     "Domain Bucket":"< 1K"
   },
   {
     "Class":"Predicate",
-    "Name":"http:\/\/schema.org\/colleagues-output",
+    "Name":"https://schema.org/colleagues-output",
     "Domain Bucket":"< 1K"
   },
   {
     "Class":"Predicate",
-    "Name":"http:\/\/schema.org\/collection",
+    "Name":"https://schema.org/collection",
     "Domain Bucket":"< 1K"
   },
   {
     "Class":"Predicate",
-    "Name":"http:\/\/schema.org\/collection-input",
+    "Name":"https://schema.org/collection-input",
     "Domain Bucket":"< 1K"
   },
   {
     "Class":"Predicate",
-    "Name":"http:\/\/schema.org\/collection-output",
+    "Name":"https://schema.org/collection-output",
     "Domain Bucket":"< 1K"
   },
   {
     "Class":"Predicate",
-    "Name":"http:\/\/schema.org\/collectionSize",
+    "Name":"https://schema.org/collectionSize",
     "Domain Bucket":"1K - 10K"
   },
   {
     "Class":"Predicate",
-    "Name":"http:\/\/schema.org\/collectionSize-input",
+    "Name":"https://schema.org/collectionSize-input",
     "Domain Bucket":"< 1K"
   },
   {
     "Class":"Predicate",
-    "Name":"http:\/\/schema.org\/collectionSize-output",
+    "Name":"https://schema.org/collectionSize-output",
     "Domain Bucket":"< 1K"
   },
   {
     "Class":"Predicate",
-    "Name":"http:\/\/schema.org\/color",
+    "Name":"https://schema.org/color",
     "Domain Bucket":"100K - 1M"
   },
   {
     "Class":"Predicate",
-    "Name":"http:\/\/schema.org\/color-input",
+    "Name":"https://schema.org/color-input",
     "Domain Bucket":"< 1K"
   },
   {
     "Class":"Predicate",
-    "Name":"http:\/\/schema.org\/color-output",
+    "Name":"https://schema.org/color-output",
     "Domain Bucket":"< 1K"
   },
   {
     "Class":"Predicate",
-    "Name":"http:\/\/schema.org\/colorSwatch",
+    "Name":"https://schema.org/colorSwatch",
     "Domain Bucket":"< 1K"
   },
   {
     "Class":"Predicate",
-    "Name":"http:\/\/schema.org\/colorSwatch-input",
+    "Name":"https://schema.org/colorSwatch-input",
     "Domain Bucket":"< 1K"
   },
   {
     "Class":"Predicate",
-    "Name":"http:\/\/schema.org\/colorSwatch-output",
+    "Name":"https://schema.org/colorSwatch-output",
     "Domain Bucket":"< 1K"
   },
   {
     "Class":"Predicate",
-    "Name":"http:\/\/schema.org\/colorist",
+    "Name":"https://schema.org/colorist",
     "Domain Bucket":"< 1K"
   },
   {
     "Class":"Predicate",
-    "Name":"http:\/\/schema.org\/colorist-input",
+    "Name":"https://schema.org/colorist-input",
     "Domain Bucket":"< 1K"
   },
   {
     "Class":"Predicate",
-    "Name":"http:\/\/schema.org\/colorist-output",
+    "Name":"https://schema.org/colorist-output",
     "Domain Bucket":"< 1K"
   },
   {
     "Class":"Predicate",
-    "Name":"http:\/\/schema.org\/comment",
+    "Name":"https://schema.org/comment",
     "Domain Bucket":"10K - 100K"
   },
   {
     "Class":"Predicate",
-    "Name":"http:\/\/schema.org\/comment-input",
+    "Name":"https://schema.org/comment-input",
     "Domain Bucket":"< 1K"
   },
   {
     "Class":"Predicate",
-    "Name":"http:\/\/schema.org\/comment-output",
+    "Name":"https://schema.org/comment-output",
     "Domain Bucket":"< 1K"
   },
   {
     "Class":"Predicate",
-    "Name":"http:\/\/schema.org\/commentCount",
+    "Name":"https://schema.org/commentCount",
     "Domain Bucket":"1M - 10M"
   },
   {
     "Class":"Predicate",
-    "Name":"http:\/\/schema.org\/commentCount-input",
+    "Name":"https://schema.org/commentCount-input",
     "Domain Bucket":"< 1K"
   },
   {
     "Class":"Predicate",
-    "Name":"http:\/\/schema.org\/commentCount-output",
+    "Name":"https://schema.org/commentCount-output",
     "Domain Bucket":"< 1K"
   },
   {
     "Class":"Predicate",
-    "Name":"http:\/\/schema.org\/commentText",
+    "Name":"https://schema.org/commentText",
     "Domain Bucket":"10K - 100K"
   },
   {
     "Class":"Predicate",
-    "Name":"http:\/\/schema.org\/commentText-input",
+    "Name":"https://schema.org/commentText-input",
     "Domain Bucket":"< 1K"
   },
   {
     "Class":"Predicate",
-    "Name":"http:\/\/schema.org\/commentText-output",
+    "Name":"https://schema.org/commentText-output",
     "Domain Bucket":"< 1K"
   },
   {
     "Class":"Predicate",
-    "Name":"http:\/\/schema.org\/commentTime",
+    "Name":"https://schema.org/commentTime",
     "Domain Bucket":"10K - 100K"
   },
   {
     "Class":"Predicate",
-    "Name":"http:\/\/schema.org\/commentTime-input",
+    "Name":"https://schema.org/commentTime-input",
     "Domain Bucket":"< 1K"
   },
   {
     "Class":"Predicate",
-    "Name":"http:\/\/schema.org\/commentTime-output",
+    "Name":"https://schema.org/commentTime-output",
     "Domain Bucket":"< 1K"
   },
   {
     "Class":"Predicate",
-    "Name":"http:\/\/schema.org\/companyRegistration",
+    "Name":"https://schema.org/companyRegistration",
     "Domain Bucket":"< 1K"
   },
   {
     "Class":"Predicate",
-    "Name":"http:\/\/schema.org\/companyRegistration-input",
+    "Name":"https://schema.org/companyRegistration-input",
     "Domain Bucket":"< 1K"
   },
   {
     "Class":"Predicate",
-    "Name":"http:\/\/schema.org\/companyRegistration-output",
+    "Name":"https://schema.org/companyRegistration-output",
     "Domain Bucket":"< 1K"
   },
   {
     "Class":"Predicate",
-    "Name":"http:\/\/schema.org\/competencyRequired",
+    "Name":"https://schema.org/competencyRequired",
     "Domain Bucket":"1K - 10K"
   },
   {
     "Class":"Predicate",
-    "Name":"http:\/\/schema.org\/competencyRequired-input",
+    "Name":"https://schema.org/competencyRequired-input",
     "Domain Bucket":"< 1K"
   },
   {
     "Class":"Predicate",
-    "Name":"http:\/\/schema.org\/competencyRequired-output",
+    "Name":"https://schema.org/competencyRequired-output",
     "Domain Bucket":"< 1K"
   },
   {
     "Class":"Predicate",
-    "Name":"http:\/\/schema.org\/competitor",
+    "Name":"https://schema.org/competitor",
     "Domain Bucket":"1K - 10K"
   },
   {
     "Class":"Predicate",
-    "Name":"http:\/\/schema.org\/competitor-input",
+    "Name":"https://schema.org/competitor-input",
     "Domain Bucket":"< 1K"
   },
   {
     "Class":"Predicate",
-    "Name":"http:\/\/schema.org\/competitor-output",
+    "Name":"https://schema.org/competitor-output",
     "Domain Bucket":"< 1K"
   },
   {
     "Class":"Predicate",
-    "Name":"http:\/\/schema.org\/composer",
+    "Name":"https://schema.org/composer",
     "Domain Bucket":"1K - 10K"
   },
   {
     "Class":"Predicate",
-    "Name":"http:\/\/schema.org\/composer-input",
+    "Name":"https://schema.org/composer-input",
     "Domain Bucket":"< 1K"
   },
   {
     "Class":"Predicate",
-    "Name":"http:\/\/schema.org\/composer-output",
+    "Name":"https://schema.org/composer-output",
     "Domain Bucket":"< 1K"
   },
   {
     "Class":"Predicate",
-    "Name":"http:\/\/schema.org\/comprisedOf",
+    "Name":"https://schema.org/comprisedOf",
     "Domain Bucket":"< 1K"
   },
   {
     "Class":"Predicate",
-    "Name":"http:\/\/schema.org\/comprisedOf-input",
+    "Name":"https://schema.org/comprisedOf-input",
     "Domain Bucket":"< 1K"
   },
   {
     "Class":"Predicate",
-    "Name":"http:\/\/schema.org\/comprisedOf-output",
+    "Name":"https://schema.org/comprisedOf-output",
     "Domain Bucket":"< 1K"
   },
   {
     "Class":"Predicate",
-    "Name":"http:\/\/schema.org\/conditionsOfAccess",
+    "Name":"https://schema.org/conditionsOfAccess",
     "Domain Bucket":"< 1K"
   },
   {
     "Class":"Predicate",
-    "Name":"http:\/\/schema.org\/conditionsOfAccess-input",
+    "Name":"https://schema.org/conditionsOfAccess-input",
     "Domain Bucket":"< 1K"
   },
   {
     "Class":"Predicate",
-    "Name":"http:\/\/schema.org\/conditionsOfAccess-output",
+    "Name":"https://schema.org/conditionsOfAccess-output",
     "Domain Bucket":"< 1K"
   },
   {
     "Class":"Predicate",
-    "Name":"http:\/\/schema.org\/confirmationNumber",
+    "Name":"https://schema.org/confirmationNumber",
     "Domain Bucket":"< 1K"
   },
   {
     "Class":"Predicate",
-    "Name":"http:\/\/schema.org\/confirmationNumber-input",
+    "Name":"https://schema.org/confirmationNumber-input",
     "Domain Bucket":"< 1K"
   },
   {
     "Class":"Predicate",
-    "Name":"http:\/\/schema.org\/confirmationNumber-output",
+    "Name":"https://schema.org/confirmationNumber-output",
     "Domain Bucket":"< 1K"
   },
   {
     "Class":"Predicate",
-    "Name":"http:\/\/schema.org\/connectedTo",
+    "Name":"https://schema.org/connectedTo",
     "Domain Bucket":"< 1K"
   },
   {
     "Class":"Predicate",
-    "Name":"http:\/\/schema.org\/connectedTo-input",
+    "Name":"https://schema.org/connectedTo-input",
     "Domain Bucket":"< 1K"
   },
   {
     "Class":"Predicate",
-    "Name":"http:\/\/schema.org\/connectedTo-output",
+    "Name":"https://schema.org/connectedTo-output",
     "Domain Bucket":"< 1K"
   },
   {
     "Class":"Predicate",
-    "Name":"http:\/\/schema.org\/constraintProperty",
+    "Name":"https://schema.org/constraintProperty",
     "Domain Bucket":"< 1K"
   },
   {
     "Class":"Predicate",
-    "Name":"http:\/\/schema.org\/constraintProperty-input",
+    "Name":"https://schema.org/constraintProperty-input",
     "Domain Bucket":"< 1K"
   },
   {
     "Class":"Predicate",
-    "Name":"http:\/\/schema.org\/constraintProperty-output",
+    "Name":"https://schema.org/constraintProperty-output",
     "Domain Bucket":"< 1K"
   },
   {
     "Class":"Predicate",
-    "Name":"http:\/\/schema.org\/contactOption",
+    "Name":"https://schema.org/contactOption",
     "Domain Bucket":"100K - 1M"
   },
   {
     "Class":"Predicate",
-    "Name":"http:\/\/schema.org\/contactOption-input",
+    "Name":"https://schema.org/contactOption-input",
     "Domain Bucket":"< 1K"
   },
   {
     "Class":"Predicate",
-    "Name":"http:\/\/schema.org\/contactOption-output",
+    "Name":"https://schema.org/contactOption-output",
     "Domain Bucket":"< 1K"
   },
   {
     "Class":"Predicate",
-    "Name":"http:\/\/schema.org\/contactPoint",
+    "Name":"https://schema.org/contactPoint",
     "Domain Bucket":"1M - 10M"
   },
   {
     "Class":"Predicate",
-    "Name":"http:\/\/schema.org\/contactPoint-input",
+    "Name":"https://schema.org/contactPoint-input",
     "Domain Bucket":"< 1K"
   },
   {
     "Class":"Predicate",
-    "Name":"http:\/\/schema.org\/contactPoint-output",
+    "Name":"https://schema.org/contactPoint-output",
     "Domain Bucket":"< 1K"
   },
   {
     "Class":"Predicate",
-    "Name":"http:\/\/schema.org\/contactPoints",
+    "Name":"https://schema.org/contactPoints",
     "Domain Bucket":"< 1K"
   },
   {
     "Class":"Predicate",
-    "Name":"http:\/\/schema.org\/contactPoints-input",
+    "Name":"https://schema.org/contactPoints-input",
     "Domain Bucket":"< 1K"
   },
   {
     "Class":"Predicate",
-    "Name":"http:\/\/schema.org\/contactPoints-output",
+    "Name":"https://schema.org/contactPoints-output",
     "Domain Bucket":"< 1K"
   },
   {
     "Class":"Predicate",
-    "Name":"http:\/\/schema.org\/contactType",
+    "Name":"https://schema.org/contactType",
     "Domain Bucket":"1M - 10M"
   },
   {
     "Class":"Predicate",
-    "Name":"http:\/\/schema.org\/contactType-input",
+    "Name":"https://schema.org/contactType-input",
     "Domain Bucket":"< 1K"
   },
   {
     "Class":"Predicate",
-    "Name":"http:\/\/schema.org\/contactType-output",
+    "Name":"https://schema.org/contactType-output",
     "Domain Bucket":"< 1K"
   },
   {
     "Class":"Predicate",
-    "Name":"http:\/\/schema.org\/contactlessPayment",
+    "Name":"https://schema.org/contactlessPayment",
     "Domain Bucket":"< 1K"
   },
   {
     "Class":"Predicate",
-    "Name":"http:\/\/schema.org\/contactlessPayment-input",
+    "Name":"https://schema.org/contactlessPayment-input",
     "Domain Bucket":"< 1K"
   },
   {
     "Class":"Predicate",
-    "Name":"http:\/\/schema.org\/contactlessPayment-output",
+    "Name":"https://schema.org/contactlessPayment-output",
     "Domain Bucket":"< 1K"
   },
   {
     "Class":"Predicate",
-    "Name":"http:\/\/schema.org\/containedIn",
+    "Name":"https://schema.org/containedIn",
     "Domain Bucket":"1K - 10K"
   },
   {
     "Class":"Predicate",
-    "Name":"http:\/\/schema.org\/containedIn-input",
+    "Name":"https://schema.org/containedIn-input",
     "Domain Bucket":"< 1K"
   },
   {
     "Class":"Predicate",
-    "Name":"http:\/\/schema.org\/containedIn-output",
+    "Name":"https://schema.org/containedIn-output",
     "Domain Bucket":"< 1K"
   },
   {
     "Class":"Predicate",
-    "Name":"http:\/\/schema.org\/containedInPlace",
+    "Name":"https://schema.org/containedInPlace",
     "Domain Bucket":"100K - 1M"
   },
   {
     "Class":"Predicate",
-    "Name":"http:\/\/schema.org\/containedInPlace-input",
+    "Name":"https://schema.org/containedInPlace-input",
     "Domain Bucket":"< 1K"
   },
   {
     "Class":"Predicate",
-    "Name":"http:\/\/schema.org\/containedInPlace-output",
+    "Name":"https://schema.org/containedInPlace-output",
     "Domain Bucket":"< 1K"
   },
   {
     "Class":"Predicate",
-    "Name":"http:\/\/schema.org\/containsPlace",
+    "Name":"https://schema.org/containsPlace",
     "Domain Bucket":"10K - 100K"
   },
   {
     "Class":"Predicate",
-    "Name":"http:\/\/schema.org\/containsPlace-input",
+    "Name":"https://schema.org/containsPlace-input",
     "Domain Bucket":"< 1K"
   },
   {
     "Class":"Predicate",
-    "Name":"http:\/\/schema.org\/containsPlace-output",
+    "Name":"https://schema.org/containsPlace-output",
     "Domain Bucket":"< 1K"
   },
   {
     "Class":"Predicate",
-    "Name":"http:\/\/schema.org\/containsSeason",
+    "Name":"https://schema.org/containsSeason",
     "Domain Bucket":"1K - 10K"
   },
   {
     "Class":"Predicate",
-    "Name":"http:\/\/schema.org\/containsSeason-input",
+    "Name":"https://schema.org/containsSeason-input",
     "Domain Bucket":"< 1K"
   },
   {
     "Class":"Predicate",
-    "Name":"http:\/\/schema.org\/containsSeason-output",
+    "Name":"https://schema.org/containsSeason-output",
     "Domain Bucket":"< 1K"
   },
   {
     "Class":"Predicate",
-    "Name":"http:\/\/schema.org\/contentLocation",
+    "Name":"https://schema.org/contentLocation",
     "Domain Bucket":"10K - 100K"
   },
   {
     "Class":"Predicate",
-    "Name":"http:\/\/schema.org\/contentLocation-input",
+    "Name":"https://schema.org/contentLocation-input",
     "Domain Bucket":"< 1K"
   },
   {
     "Class":"Predicate",
-    "Name":"http:\/\/schema.org\/contentLocation-output",
+    "Name":"https://schema.org/contentLocation-output",
     "Domain Bucket":"< 1K"
   },
   {
     "Class":"Predicate",
-    "Name":"http:\/\/schema.org\/contentRating",
+    "Name":"https://schema.org/contentRating",
     "Domain Bucket":"10K - 100K"
   },
   {
     "Class":"Predicate",
-    "Name":"http:\/\/schema.org\/contentRating-input",
+    "Name":"https://schema.org/contentRating-input",
     "Domain Bucket":"< 1K"
   },
   {
     "Class":"Predicate",
-    "Name":"http:\/\/schema.org\/contentRating-output",
+    "Name":"https://schema.org/contentRating-output",
     "Domain Bucket":"< 1K"
   },
   {
     "Class":"Predicate",
-    "Name":"http:\/\/schema.org\/contentReferenceTime",
+    "Name":"https://schema.org/contentReferenceTime",
     "Domain Bucket":"1K - 10K"
   },
   {
     "Class":"Predicate",
-    "Name":"http:\/\/schema.org\/contentReferenceTime-input",
+    "Name":"https://schema.org/contentReferenceTime-input",
     "Domain Bucket":"< 1K"
   },
   {
     "Class":"Predicate",
-    "Name":"http:\/\/schema.org\/contentReferenceTime-output",
+    "Name":"https://schema.org/contentReferenceTime-output",
     "Domain Bucket":"< 1K"
   },
   {
     "Class":"Predicate",
-    "Name":"http:\/\/schema.org\/contentSize",
+    "Name":"https://schema.org/contentSize",
     "Domain Bucket":"100K - 1M"
   },
   {
     "Class":"Predicate",
-    "Name":"http:\/\/schema.org\/contentSize-input",
+    "Name":"https://schema.org/contentSize-input",
     "Domain Bucket":"< 1K"
   },
   {
     "Class":"Predicate",
-    "Name":"http:\/\/schema.org\/contentSize-output",
+    "Name":"https://schema.org/contentSize-output",
     "Domain Bucket":"< 1K"
   },
   {
     "Class":"Predicate",
-    "Name":"http:\/\/schema.org\/contentType",
+    "Name":"https://schema.org/contentType",
     "Domain Bucket":"1K - 10K"
   },
   {
     "Class":"Predicate",
-    "Name":"http:\/\/schema.org\/contentType-input",
+    "Name":"https://schema.org/contentType-input",
     "Domain Bucket":"< 1K"
   },
   {
     "Class":"Predicate",
-    "Name":"http:\/\/schema.org\/contentType-output",
+    "Name":"https://schema.org/contentType-output",
     "Domain Bucket":"< 1K"
   },
   {
     "Class":"Predicate",
-    "Name":"http:\/\/schema.org\/contentUrl",
+    "Name":"https://schema.org/contentUrl",
     "Domain Bucket":"10M+"
   },
   {
     "Class":"Predicate",
-    "Name":"http:\/\/schema.org\/contentUrl-input",
+    "Name":"https://schema.org/contentUrl-input",
     "Domain Bucket":"< 1K"
   },
   {
     "Class":"Predicate",
-    "Name":"http:\/\/schema.org\/contentUrl-output",
+    "Name":"https://schema.org/contentUrl-output",
     "Domain Bucket":"< 1K"
   },
   {
     "Class":"Predicate",
-    "Name":"http:\/\/schema.org\/contraindication",
+    "Name":"https://schema.org/contraindication",
     "Domain Bucket":"< 1K"
   },
   {
     "Class":"Predicate",
-    "Name":"http:\/\/schema.org\/contraindication-input",
+    "Name":"https://schema.org/contraindication-input",
     "Domain Bucket":"< 1K"
   },
   {
     "Class":"Predicate",
-    "Name":"http:\/\/schema.org\/contraindication-output",
+    "Name":"https://schema.org/contraindication-output",
     "Domain Bucket":"< 1K"
   },
   {
     "Class":"Predicate",
-    "Name":"http:\/\/schema.org\/contributor",
+    "Name":"https://schema.org/contributor",
     "Domain Bucket":"100K - 1M"
   },
   {
     "Class":"Predicate",
-    "Name":"http:\/\/schema.org\/contributor-input",
+    "Name":"https://schema.org/contributor-input",
     "Domain Bucket":"< 1K"
   },
   {
     "Class":"Predicate",
-    "Name":"http:\/\/schema.org\/contributor-output",
+    "Name":"https://schema.org/contributor-output",
     "Domain Bucket":"< 1K"
   },
   {
     "Class":"Predicate",
-    "Name":"http:\/\/schema.org\/cookTime",
+    "Name":"https://schema.org/cookTime",
     "Domain Bucket":"10K - 100K"
   },
   {
     "Class":"Predicate",
-    "Name":"http:\/\/schema.org\/cookTime-input",
+    "Name":"https://schema.org/cookTime-input",
     "Domain Bucket":"< 1K"
   },
   {
     "Class":"Predicate",
-    "Name":"http:\/\/schema.org\/cookTime-output",
+    "Name":"https://schema.org/cookTime-output",
     "Domain Bucket":"< 1K"
   },
   {
     "Class":"Predicate",
-    "Name":"http:\/\/schema.org\/cookingMethod",
+    "Name":"https://schema.org/cookingMethod",
     "Domain Bucket":"1K - 10K"
   },
   {
     "Class":"Predicate",
-    "Name":"http:\/\/schema.org\/cookingMethod-input",
+    "Name":"https://schema.org/cookingMethod-input",
     "Domain Bucket":"< 1K"
   },
   {
     "Class":"Predicate",
-    "Name":"http:\/\/schema.org\/cookingMethod-output",
+    "Name":"https://schema.org/cookingMethod-output",
     "Domain Bucket":"< 1K"
   },
   {
     "Class":"Predicate",
-    "Name":"http:\/\/schema.org\/copyrightHolder",
+    "Name":"https://schema.org/copyrightHolder",
     "Domain Bucket":"100K - 1M"
   },
   {
     "Class":"Predicate",
-    "Name":"http:\/\/schema.org\/copyrightHolder-input",
+    "Name":"https://schema.org/copyrightHolder-input",
     "Domain Bucket":"< 1K"
   },
   {
     "Class":"Predicate",
-    "Name":"http:\/\/schema.org\/copyrightHolder-output",
+    "Name":"https://schema.org/copyrightHolder-output",
     "Domain Bucket":"< 1K"
   },
   {
     "Class":"Predicate",
-    "Name":"http:\/\/schema.org\/copyrightNotice",
+    "Name":"https://schema.org/copyrightNotice",
     "Domain Bucket":"10K - 100K"
   },
   {
     "Class":"Predicate",
-    "Name":"http:\/\/schema.org\/copyrightNotice-input",
+    "Name":"https://schema.org/copyrightNotice-input",
     "Domain Bucket":"< 1K"
   },
   {
     "Class":"Predicate",
-    "Name":"http:\/\/schema.org\/copyrightNotice-output",
+    "Name":"https://schema.org/copyrightNotice-output",
     "Domain Bucket":"< 1K"
   },
   {
     "Class":"Predicate",
-    "Name":"http:\/\/schema.org\/copyrightYear",
+    "Name":"https://schema.org/copyrightYear",
     "Domain Bucket":"100K - 1M"
   },
   {
     "Class":"Predicate",
-    "Name":"http:\/\/schema.org\/copyrightYear-input",
+    "Name":"https://schema.org/copyrightYear-input",
     "Domain Bucket":"< 1K"
   },
   {
     "Class":"Predicate",
-    "Name":"http:\/\/schema.org\/copyrightYear-output",
+    "Name":"https://schema.org/copyrightYear-output",
     "Domain Bucket":"< 1K"
   },
   {
     "Class":"Predicate",
-    "Name":"http:\/\/schema.org\/correction",
+    "Name":"https://schema.org/correction",
     "Domain Bucket":"< 1K"
   },
   {
     "Class":"Predicate",
-    "Name":"http:\/\/schema.org\/correction-input",
+    "Name":"https://schema.org/correction-input",
     "Domain Bucket":"< 1K"
   },
   {
     "Class":"Predicate",
-    "Name":"http:\/\/schema.org\/correction-output",
+    "Name":"https://schema.org/correction-output",
     "Domain Bucket":"< 1K"
   },
   {
     "Class":"Predicate",
-    "Name":"http:\/\/schema.org\/correctionsPolicy",
+    "Name":"https://schema.org/correctionsPolicy",
     "Domain Bucket":"10K - 100K"
   },
   {
     "Class":"Predicate",
-    "Name":"http:\/\/schema.org\/correctionsPolicy-input",
+    "Name":"https://schema.org/correctionsPolicy-input",
     "Domain Bucket":"< 1K"
   },
   {
     "Class":"Predicate",
-    "Name":"http:\/\/schema.org\/correctionsPolicy-output",
+    "Name":"https://schema.org/correctionsPolicy-output",
     "Domain Bucket":"< 1K"
   },
   {
     "Class":"Predicate",
-    "Name":"http:\/\/schema.org\/costCategory",
+    "Name":"https://schema.org/costCategory",
     "Domain Bucket":"< 1K"
   },
   {
     "Class":"Predicate",
-    "Name":"http:\/\/schema.org\/costCategory-input",
+    "Name":"https://schema.org/costCategory-input",
     "Domain Bucket":"< 1K"
   },
   {
     "Class":"Predicate",
-    "Name":"http:\/\/schema.org\/costCategory-output",
+    "Name":"https://schema.org/costCategory-output",
     "Domain Bucket":"< 1K"
   },
   {
     "Class":"Predicate",
-    "Name":"http:\/\/schema.org\/costCurrency",
+    "Name":"https://schema.org/costCurrency",
     "Domain Bucket":"< 1K"
   },
   {
     "Class":"Predicate",
-    "Name":"http:\/\/schema.org\/costCurrency-input",
+    "Name":"https://schema.org/costCurrency-input",
     "Domain Bucket":"< 1K"
   },
   {
     "Class":"Predicate",
-    "Name":"http:\/\/schema.org\/costCurrency-output",
+    "Name":"https://schema.org/costCurrency-output",
     "Domain Bucket":"< 1K"
   },
   {
     "Class":"Predicate",
-    "Name":"http:\/\/schema.org\/costOrigin",
+    "Name":"https://schema.org/costOrigin",
     "Domain Bucket":"< 1K"
   },
   {
     "Class":"Predicate",
-    "Name":"http:\/\/schema.org\/costOrigin-input",
+    "Name":"https://schema.org/costOrigin-input",
     "Domain Bucket":"< 1K"
   },
   {
     "Class":"Predicate",
-    "Name":"http:\/\/schema.org\/costOrigin-output",
+    "Name":"https://schema.org/costOrigin-output",
     "Domain Bucket":"< 1K"
   },
   {
     "Class":"Predicate",
-    "Name":"http:\/\/schema.org\/costPerUnit",
+    "Name":"https://schema.org/costPerUnit",
     "Domain Bucket":"< 1K"
   },
   {
     "Class":"Predicate",
-    "Name":"http:\/\/schema.org\/costPerUnit-input",
+    "Name":"https://schema.org/costPerUnit-input",
     "Domain Bucket":"< 1K"
   },
   {
     "Class":"Predicate",
-    "Name":"http:\/\/schema.org\/costPerUnit-output",
+    "Name":"https://schema.org/costPerUnit-output",
     "Domain Bucket":"< 1K"
   },
   {
     "Class":"Predicate",
-    "Name":"http:\/\/schema.org\/countriesNotSupported",
+    "Name":"https://schema.org/countriesNotSupported",
     "Domain Bucket":"< 1K"
   },
   {
     "Class":"Predicate",
-    "Name":"http:\/\/schema.org\/countriesNotSupported-input",
+    "Name":"https://schema.org/countriesNotSupported-input",
     "Domain Bucket":"< 1K"
   },
   {
     "Class":"Predicate",
-    "Name":"http:\/\/schema.org\/countriesNotSupported-output",
+    "Name":"https://schema.org/countriesNotSupported-output",
     "Domain Bucket":"< 1K"
   },
   {
     "Class":"Predicate",
-    "Name":"http:\/\/schema.org\/countriesSupported",
+    "Name":"https://schema.org/countriesSupported",
     "Domain Bucket":"1K - 10K"
   },
   {
     "Class":"Predicate",
-    "Name":"http:\/\/schema.org\/countriesSupported-input",
+    "Name":"https://schema.org/countriesSupported-input",
     "Domain Bucket":"< 1K"
   },
   {
     "Class":"Predicate",
-    "Name":"http:\/\/schema.org\/countriesSupported-output",
+    "Name":"https://schema.org/countriesSupported-output",
     "Domain Bucket":"< 1K"
   },
   {
     "Class":"Predicate",
-    "Name":"http:\/\/schema.org\/countryOfAssembly",
+    "Name":"https://schema.org/countryOfAssembly",
     "Domain Bucket":"1K - 10K"
   },
   {
     "Class":"Predicate",
-    "Name":"http:\/\/schema.org\/countryOfAssembly-input",
+    "Name":"https://schema.org/countryOfAssembly-input",
     "Domain Bucket":"< 1K"
   },
   {
     "Class":"Predicate",
-    "Name":"http:\/\/schema.org\/countryOfAssembly-output",
+    "Name":"https://schema.org/countryOfAssembly-output",
     "Domain Bucket":"< 1K"
   },
   {
     "Class":"Predicate",
-    "Name":"http:\/\/schema.org\/countryOfLastProcessing",
+    "Name":"https://schema.org/countryOfLastProcessing",
     "Domain Bucket":"< 1K"
   },
   {
     "Class":"Predicate",
-    "Name":"http:\/\/schema.org\/countryOfLastProcessing-input",
+    "Name":"https://schema.org/countryOfLastProcessing-input",
     "Domain Bucket":"< 1K"
   },
   {
     "Class":"Predicate",
-    "Name":"http:\/\/schema.org\/countryOfLastProcessing-output",
+    "Name":"https://schema.org/countryOfLastProcessing-output",
     "Domain Bucket":"< 1K"
   },
   {
     "Class":"Predicate",
-    "Name":"http:\/\/schema.org\/countryOfOrigin",
+    "Name":"https://schema.org/countryOfOrigin",
     "Domain Bucket":"10K - 100K"
   },
   {
     "Class":"Predicate",
-    "Name":"http:\/\/schema.org\/countryOfOrigin-input",
+    "Name":"https://schema.org/countryOfOrigin-input",
     "Domain Bucket":"< 1K"
   },
   {
     "Class":"Predicate",
-    "Name":"http:\/\/schema.org\/countryOfOrigin-output",
+    "Name":"https://schema.org/countryOfOrigin-output",
     "Domain Bucket":"< 1K"
   },
   {
     "Class":"Predicate",
-    "Name":"http:\/\/schema.org\/course",
+    "Name":"https://schema.org/course",
     "Domain Bucket":"< 1K"
   },
   {
     "Class":"Predicate",
-    "Name":"http:\/\/schema.org\/course-input",
+    "Name":"https://schema.org/course-input",
     "Domain Bucket":"< 1K"
   },
   {
     "Class":"Predicate",
-    "Name":"http:\/\/schema.org\/course-output",
+    "Name":"https://schema.org/course-output",
     "Domain Bucket":"< 1K"
   },
   {
     "Class":"Predicate",
-    "Name":"http:\/\/schema.org\/courseCode",
+    "Name":"https://schema.org/courseCode",
     "Domain Bucket":"1K - 10K"
   },
   {
     "Class":"Predicate",
-    "Name":"http:\/\/schema.org\/courseCode-input",
+    "Name":"https://schema.org/courseCode-input",
     "Domain Bucket":"< 1K"
   },
   {
     "Class":"Predicate",
-    "Name":"http:\/\/schema.org\/courseCode-output",
+    "Name":"https://schema.org/courseCode-output",
     "Domain Bucket":"< 1K"
   },
   {
     "Class":"Predicate",
-    "Name":"http:\/\/schema.org\/courseMode",
+    "Name":"https://schema.org/courseMode",
     "Domain Bucket":"10K - 100K"
   },
   {
     "Class":"Predicate",
-    "Name":"http:\/\/schema.org\/courseMode-input",
+    "Name":"https://schema.org/courseMode-input",
     "Domain Bucket":"< 1K"
   },
   {
     "Class":"Predicate",
-    "Name":"http:\/\/schema.org\/courseMode-output",
+    "Name":"https://schema.org/courseMode-output",
     "Domain Bucket":"< 1K"
   },
   {
     "Class":"Predicate",
-    "Name":"http:\/\/schema.org\/coursePrerequisites",
+    "Name":"https://schema.org/coursePrerequisites",
     "Domain Bucket":"1K - 10K"
   },
   {
     "Class":"Predicate",
-    "Name":"http:\/\/schema.org\/coursePrerequisites-input",
+    "Name":"https://schema.org/coursePrerequisites-input",
     "Domain Bucket":"< 1K"
   },
   {
     "Class":"Predicate",
-    "Name":"http:\/\/schema.org\/coursePrerequisites-output",
+    "Name":"https://schema.org/coursePrerequisites-output",
     "Domain Bucket":"< 1K"
   },
   {
     "Class":"Predicate",
-    "Name":"http:\/\/schema.org\/courseSchedule",
+    "Name":"https://schema.org/courseSchedule",
     "Domain Bucket":"1K - 10K"
   },
   {
     "Class":"Predicate",
-    "Name":"http:\/\/schema.org\/courseSchedule-input",
+    "Name":"https://schema.org/courseSchedule-input",
     "Domain Bucket":"< 1K"
   },
   {
     "Class":"Predicate",
-    "Name":"http:\/\/schema.org\/courseSchedule-output",
+    "Name":"https://schema.org/courseSchedule-output",
     "Domain Bucket":"< 1K"
   },
   {
     "Class":"Predicate",
-    "Name":"http:\/\/schema.org\/courseWorkload",
+    "Name":"https://schema.org/courseWorkload",
     "Domain Bucket":"10K - 100K"
   },
   {
     "Class":"Predicate",
-    "Name":"http:\/\/schema.org\/courseWorkload-input",
+    "Name":"https://schema.org/courseWorkload-input",
     "Domain Bucket":"< 1K"
   },
   {
     "Class":"Predicate",
-    "Name":"http:\/\/schema.org\/courseWorkload-output",
+    "Name":"https://schema.org/courseWorkload-output",
     "Domain Bucket":"< 1K"
   },
   {
     "Class":"Predicate",
-    "Name":"http:\/\/schema.org\/coverageEndTime",
+    "Name":"https://schema.org/coverageEndTime",
     "Domain Bucket":"1K - 10K"
   },
   {
     "Class":"Predicate",
-    "Name":"http:\/\/schema.org\/coverageEndTime-input",
+    "Name":"https://schema.org/coverageEndTime-input",
     "Domain Bucket":"< 1K"
   },
   {
     "Class":"Predicate",
-    "Name":"http:\/\/schema.org\/coverageEndTime-output",
+    "Name":"https://schema.org/coverageEndTime-output",
     "Domain Bucket":"< 1K"
   },
   {
     "Class":"Predicate",
-    "Name":"http:\/\/schema.org\/coverageStartTime",
+    "Name":"https://schema.org/coverageStartTime",
     "Domain Bucket":"1K - 10K"
   },
   {
     "Class":"Predicate",
-    "Name":"http:\/\/schema.org\/coverageStartTime-input",
+    "Name":"https://schema.org/coverageStartTime-input",
     "Domain Bucket":"< 1K"
   },
   {
     "Class":"Predicate",
-    "Name":"http:\/\/schema.org\/coverageStartTime-output",
+    "Name":"https://schema.org/coverageStartTime-output",
     "Domain Bucket":"< 1K"
   },
   {
     "Class":"Predicate",
-    "Name":"http:\/\/schema.org\/creativeWorkStatus",
+    "Name":"https://schema.org/creativeWorkStatus",
     "Domain Bucket":"1K - 10K"
   },
   {
     "Class":"Predicate",
-    "Name":"http:\/\/schema.org\/creativeWorkStatus-input",
+    "Name":"https://schema.org/creativeWorkStatus-input",
     "Domain Bucket":"< 1K"
   },
   {
     "Class":"Predicate",
-    "Name":"http:\/\/schema.org\/creativeWorkStatus-output",
+    "Name":"https://schema.org/creativeWorkStatus-output",
     "Domain Bucket":"< 1K"
   },
   {
     "Class":"Predicate",
-    "Name":"http:\/\/schema.org\/creator",
+    "Name":"https://schema.org/creator",
     "Domain Bucket":"1M - 10M"
   },
   {
     "Class":"Predicate",
-    "Name":"http:\/\/schema.org\/creator-input",
+    "Name":"https://schema.org/creator-input",
     "Domain Bucket":"< 1K"
   },
   {
     "Class":"Predicate",
-    "Name":"http:\/\/schema.org\/creator-output",
+    "Name":"https://schema.org/creator-output",
     "Domain Bucket":"< 1K"
   },
   {
     "Class":"Predicate",
-    "Name":"http:\/\/schema.org\/credentialCategory",
+    "Name":"https://schema.org/credentialCategory",
     "Domain Bucket":"10K - 100K"
   },
   {
     "Class":"Predicate",
-    "Name":"http:\/\/schema.org\/credentialCategory-input",
+    "Name":"https://schema.org/credentialCategory-input",
     "Domain Bucket":"< 1K"
   },
   {
     "Class":"Predicate",
-    "Name":"http:\/\/schema.org\/credentialCategory-output",
+    "Name":"https://schema.org/credentialCategory-output",
     "Domain Bucket":"< 1K"
   },
   {
     "Class":"Predicate",
-    "Name":"http:\/\/schema.org\/creditText",
+    "Name":"https://schema.org/creditText",
     "Domain Bucket":"10K - 100K"
   },
   {
     "Class":"Predicate",
-    "Name":"http:\/\/schema.org\/creditText-input",
+    "Name":"https://schema.org/creditText-input",
     "Domain Bucket":"< 1K"
   },
   {
     "Class":"Predicate",
-    "Name":"http:\/\/schema.org\/creditText-output",
+    "Name":"https://schema.org/creditText-output",
     "Domain Bucket":"< 1K"
   },
   {
     "Class":"Predicate",
-    "Name":"http:\/\/schema.org\/creditedTo",
+    "Name":"https://schema.org/creditedTo",
     "Domain Bucket":"< 1K"
   },
   {
     "Class":"Predicate",
-    "Name":"http:\/\/schema.org\/creditedTo-input",
+    "Name":"https://schema.org/creditedTo-input",
     "Domain Bucket":"< 1K"
   },
   {
     "Class":"Predicate",
-    "Name":"http:\/\/schema.org\/creditedTo-output",
+    "Name":"https://schema.org/creditedTo-output",
     "Domain Bucket":"< 1K"
   },
   {
     "Class":"Predicate",
-    "Name":"http:\/\/schema.org\/cssSelector",
+    "Name":"https://schema.org/cssSelector",
     "Domain Bucket":"100K - 1M"
   },
   {
     "Class":"Predicate",
-    "Name":"http:\/\/schema.org\/cssSelector-input",
+    "Name":"https://schema.org/cssSelector-input",
     "Domain Bucket":"< 1K"
   },
   {
     "Class":"Predicate",
-    "Name":"http:\/\/schema.org\/cssSelector-output",
+    "Name":"https://schema.org/cssSelector-output",
     "Domain Bucket":"< 1K"
   },
   {
     "Class":"Predicate",
-    "Name":"http:\/\/schema.org\/currenciesAccepted",
+    "Name":"https://schema.org/currenciesAccepted",
     "Domain Bucket":"100K - 1M"
   },
   {
     "Class":"Predicate",
-    "Name":"http:\/\/schema.org\/currenciesAccepted-input",
+    "Name":"https://schema.org/currenciesAccepted-input",
     "Domain Bucket":"< 1K"
   },
   {
     "Class":"Predicate",
-    "Name":"http:\/\/schema.org\/currenciesAccepted-output",
+    "Name":"https://schema.org/currenciesAccepted-output",
     "Domain Bucket":"< 1K"
   },
   {
     "Class":"Predicate",
-    "Name":"http:\/\/schema.org\/currency",
+    "Name":"https://schema.org/currency",
     "Domain Bucket":"100K - 1M"
   },
   {
     "Class":"Predicate",
-    "Name":"http:\/\/schema.org\/currency-input",
+    "Name":"https://schema.org/currency-input",
     "Domain Bucket":"< 1K"
   },
   {
     "Class":"Predicate",
-    "Name":"http:\/\/schema.org\/currency-output",
+    "Name":"https://schema.org/currency-output",
     "Domain Bucket":"< 1K"
   },
   {
     "Class":"Predicate",
-    "Name":"http:\/\/schema.org\/currentExchangeRate",
+    "Name":"https://schema.org/currentExchangeRate",
     "Domain Bucket":"< 1K"
   },
   {
     "Class":"Predicate",
-    "Name":"http:\/\/schema.org\/currentExchangeRate-input",
+    "Name":"https://schema.org/currentExchangeRate-input",
     "Domain Bucket":"< 1K"
   },
   {
     "Class":"Predicate",
-    "Name":"http:\/\/schema.org\/currentExchangeRate-output",
+    "Name":"https://schema.org/currentExchangeRate-output",
     "Domain Bucket":"< 1K"
   },
   {
     "Class":"Predicate",
-    "Name":"http:\/\/schema.org\/customer",
+    "Name":"https://schema.org/customer",
     "Domain Bucket":"< 1K"
   },
   {
     "Class":"Predicate",
-    "Name":"http:\/\/schema.org\/customer-input",
+    "Name":"https://schema.org/customer-input",
     "Domain Bucket":"< 1K"
   },
   {
     "Class":"Predicate",
-    "Name":"http:\/\/schema.org\/customer-output",
+    "Name":"https://schema.org/customer-output",
     "Domain Bucket":"< 1K"
   },
   {
     "Class":"Predicate",
-    "Name":"http:\/\/schema.org\/customerRemorseReturnFees",
+    "Name":"https://schema.org/customerRemorseReturnFees",
     "Domain Bucket":"1K - 10K"
   },
   {
     "Class":"Predicate",
-    "Name":"http:\/\/schema.org\/customerRemorseReturnFees-input",
+    "Name":"https://schema.org/customerRemorseReturnFees-input",
     "Domain Bucket":"< 1K"
   },
   {
     "Class":"Predicate",
-    "Name":"http:\/\/schema.org\/customerRemorseReturnFees-output",
+    "Name":"https://schema.org/customerRemorseReturnFees-output",
     "Domain Bucket":"< 1K"
   },
   {
     "Class":"Predicate",
-    "Name":"http:\/\/schema.org\/customerRemorseReturnLabelSource",
+    "Name":"https://schema.org/customerRemorseReturnLabelSource",
     "Domain Bucket":"< 1K"
   },
   {
     "Class":"Predicate",
-    "Name":"http:\/\/schema.org\/customerRemorseReturnLabelSource-input",
+    "Name":"https://schema.org/customerRemorseReturnLabelSource-input",
     "Domain Bucket":"< 1K"
   },
   {
     "Class":"Predicate",
-    "Name":"http:\/\/schema.org\/customerRemorseReturnLabelSource-output",
+    "Name":"https://schema.org/customerRemorseReturnLabelSource-output",
     "Domain Bucket":"< 1K"
   },
   {
     "Class":"Predicate",
-    "Name":"http:\/\/schema.org\/customerRemorseReturnShippingFeesAmount",
+    "Name":"https://schema.org/customerRemorseReturnShippingFeesAmount",
     "Domain Bucket":"< 1K"
   },
   {
     "Class":"Predicate",
-    "Name":"http:\/\/schema.org\/customerRemorseReturnShippingFeesAmount-input",
+    "Name":"https://schema.org/customerRemorseReturnShippingFeesAmount-input",
     "Domain Bucket":"< 1K"
   },
   {
     "Class":"Predicate",
-    "Name":"http:\/\/schema.org\/customerRemorseReturnShippingFeesAmount-output",
+    "Name":"https://schema.org/customerRemorseReturnShippingFeesAmount-output",
     "Domain Bucket":"< 1K"
   },
   {
     "Class":"Predicate",
-    "Name":"http:\/\/schema.org\/cutoffTime",
+    "Name":"https://schema.org/cutoffTime",
     "Domain Bucket":"10K - 100K"
   },
   {
     "Class":"Predicate",
-    "Name":"http:\/\/schema.org\/cutoffTime-input",
+    "Name":"https://schema.org/cutoffTime-input",
     "Domain Bucket":"< 1K"
   },
   {
     "Class":"Predicate",
-    "Name":"http:\/\/schema.org\/cutoffTime-output",
+    "Name":"https://schema.org/cutoffTime-output",
     "Domain Bucket":"< 1K"
   },
   {
     "Class":"Predicate",
-    "Name":"http:\/\/schema.org\/cvdCollectionDate",
+    "Name":"https://schema.org/cvdCollectionDate",
     "Domain Bucket":"< 1K"
   },
   {
     "Class":"Predicate",
-    "Name":"http:\/\/schema.org\/cvdCollectionDate-input",
+    "Name":"https://schema.org/cvdCollectionDate-input",
     "Domain Bucket":"< 1K"
   },
   {
     "Class":"Predicate",
-    "Name":"http:\/\/schema.org\/cvdCollectionDate-output",
+    "Name":"https://schema.org/cvdCollectionDate-output",
     "Domain Bucket":"< 1K"
   },
   {
     "Class":"Predicate",
-    "Name":"http:\/\/schema.org\/cvdFacilityCounty",
+    "Name":"https://schema.org/cvdFacilityCounty",
     "Domain Bucket":"< 1K"
   },
   {
     "Class":"Predicate",
-    "Name":"http:\/\/schema.org\/cvdFacilityCounty-input",
+    "Name":"https://schema.org/cvdFacilityCounty-input",
     "Domain Bucket":"< 1K"
   },
   {
     "Class":"Predicate",
-    "Name":"http:\/\/schema.org\/cvdFacilityCounty-output",
+    "Name":"https://schema.org/cvdFacilityCounty-output",
     "Domain Bucket":"< 1K"
   },
   {
     "Class":"Predicate",
-    "Name":"http:\/\/schema.org\/cvdFacilityId",
+    "Name":"https://schema.org/cvdFacilityId",
     "Domain Bucket":"< 1K"
   },
   {
     "Class":"Predicate",
-    "Name":"http:\/\/schema.org\/cvdFacilityId-input",
+    "Name":"https://schema.org/cvdFacilityId-input",
     "Domain Bucket":"< 1K"
   },
   {
     "Class":"Predicate",
-    "Name":"http:\/\/schema.org\/cvdFacilityId-output",
+    "Name":"https://schema.org/cvdFacilityId-output",
     "Domain Bucket":"< 1K"
   },
   {
     "Class":"Predicate",
-    "Name":"http:\/\/schema.org\/cvdNumBeds",
+    "Name":"https://schema.org/cvdNumBeds",
     "Domain Bucket":"< 1K"
   },
   {
     "Class":"Predicate",
-    "Name":"http:\/\/schema.org\/cvdNumBeds-input",
+    "Name":"https://schema.org/cvdNumBeds-input",
     "Domain Bucket":"< 1K"
   },
   {
     "Class":"Predicate",
-    "Name":"http:\/\/schema.org\/cvdNumBeds-output",
+    "Name":"https://schema.org/cvdNumBeds-output",
     "Domain Bucket":"< 1K"
   },
   {
     "Class":"Predicate",
-    "Name":"http:\/\/schema.org\/cvdNumBedsOcc",
+    "Name":"https://schema.org/cvdNumBedsOcc",
     "Domain Bucket":"< 1K"
   },
   {
     "Class":"Predicate",
-    "Name":"http:\/\/schema.org\/cvdNumBedsOcc-input",
+    "Name":"https://schema.org/cvdNumBedsOcc-input",
     "Domain Bucket":"< 1K"
   },
   {
     "Class":"Predicate",
-    "Name":"http:\/\/schema.org\/cvdNumBedsOcc-output",
+    "Name":"https://schema.org/cvdNumBedsOcc-output",
     "Domain Bucket":"< 1K"
   },
   {
     "Class":"Predicate",
-    "Name":"http:\/\/schema.org\/cvdNumC19Died",
+    "Name":"https://schema.org/cvdNumC19Died",
     "Domain Bucket":"< 1K"
   },
   {
     "Class":"Predicate",
-    "Name":"http:\/\/schema.org\/cvdNumC19Died-input",
+    "Name":"https://schema.org/cvdNumC19Died-input",
     "Domain Bucket":"< 1K"
   },
   {
     "Class":"Predicate",
-    "Name":"http:\/\/schema.org\/cvdNumC19Died-output",
+    "Name":"https://schema.org/cvdNumC19Died-output",
     "Domain Bucket":"< 1K"
   },
   {
     "Class":"Predicate",
-    "Name":"http:\/\/schema.org\/cvdNumC19HOPats",
+    "Name":"https://schema.org/cvdNumC19HOPats",
     "Domain Bucket":"< 1K"
   },
   {
     "Class":"Predicate",
-    "Name":"http:\/\/schema.org\/cvdNumC19HOPats-input",
+    "Name":"https://schema.org/cvdNumC19HOPats-input",
     "Domain Bucket":"< 1K"
   },
   {
     "Class":"Predicate",
-    "Name":"http:\/\/schema.org\/cvdNumC19HOPats-output",
+    "Name":"https://schema.org/cvdNumC19HOPats-output",
     "Domain Bucket":"< 1K"
   },
   {
     "Class":"Predicate",
-    "Name":"http:\/\/schema.org\/cvdNumC19HospPats",
+    "Name":"https://schema.org/cvdNumC19HospPats",
     "Domain Bucket":"< 1K"
   },
   {
     "Class":"Predicate",
-    "Name":"http:\/\/schema.org\/cvdNumC19HospPats-input",
+    "Name":"https://schema.org/cvdNumC19HospPats-input",
     "Domain Bucket":"< 1K"
   },
   {
     "Class":"Predicate",
-    "Name":"http:\/\/schema.org\/cvdNumC19HospPats-output",
+    "Name":"https://schema.org/cvdNumC19HospPats-output",
     "Domain Bucket":"< 1K"
   },
   {
     "Class":"Predicate",
-    "Name":"http:\/\/schema.org\/cvdNumC19MechVentPats",
+    "Name":"https://schema.org/cvdNumC19MechVentPats",
     "Domain Bucket":"< 1K"
   },
   {
     "Class":"Predicate",
-    "Name":"http:\/\/schema.org\/cvdNumC19MechVentPats-input",
+    "Name":"https://schema.org/cvdNumC19MechVentPats-input",
     "Domain Bucket":"< 1K"
   },
   {
     "Class":"Predicate",
-    "Name":"http:\/\/schema.org\/cvdNumC19MechVentPats-output",
+    "Name":"https://schema.org/cvdNumC19MechVentPats-output",
     "Domain Bucket":"< 1K"
   },
   {
     "Class":"Predicate",
-    "Name":"http:\/\/schema.org\/cvdNumC19OFMechVentPats",
+    "Name":"https://schema.org/cvdNumC19OFMechVentPats",
     "Domain Bucket":"< 1K"
   },
   {
     "Class":"Predicate",
-    "Name":"http:\/\/schema.org\/cvdNumC19OFMechVentPats-input",
+    "Name":"https://schema.org/cvdNumC19OFMechVentPats-input",
     "Domain Bucket":"< 1K"
   },
   {
     "Class":"Predicate",
-    "Name":"http:\/\/schema.org\/cvdNumC19OFMechVentPats-output",
+    "Name":"https://schema.org/cvdNumC19OFMechVentPats-output",
     "Domain Bucket":"< 1K"
   },
   {
     "Class":"Predicate",
-    "Name":"http:\/\/schema.org\/cvdNumC19OverflowPats",
+    "Name":"https://schema.org/cvdNumC19OverflowPats",
     "Domain Bucket":"< 1K"
   },
   {
     "Class":"Predicate",
-    "Name":"http:\/\/schema.org\/cvdNumC19OverflowPats-input",
+    "Name":"https://schema.org/cvdNumC19OverflowPats-input",
     "Domain Bucket":"< 1K"
   },
   {
     "Class":"Predicate",
-    "Name":"http:\/\/schema.org\/cvdNumC19OverflowPats-output",
+    "Name":"https://schema.org/cvdNumC19OverflowPats-output",
     "Domain Bucket":"< 1K"
   },
   {
     "Class":"Predicate",
-    "Name":"http:\/\/schema.org\/cvdNumICUBeds",
+    "Name":"https://schema.org/cvdNumICUBeds",
     "Domain Bucket":"< 1K"
   },
   {
     "Class":"Predicate",
-    "Name":"http:\/\/schema.org\/cvdNumICUBeds-input",
+    "Name":"https://schema.org/cvdNumICUBeds-input",
     "Domain Bucket":"< 1K"
   },
   {
     "Class":"Predicate",
-    "Name":"http:\/\/schema.org\/cvdNumICUBeds-output",
+    "Name":"https://schema.org/cvdNumICUBeds-output",
     "Domain Bucket":"< 1K"
   },
   {
     "Class":"Predicate",
-    "Name":"http:\/\/schema.org\/cvdNumICUBedsOcc",
+    "Name":"https://schema.org/cvdNumICUBedsOcc",
     "Domain Bucket":"< 1K"
   },
   {
     "Class":"Predicate",
-    "Name":"http:\/\/schema.org\/cvdNumICUBedsOcc-input",
+    "Name":"https://schema.org/cvdNumICUBedsOcc-input",
     "Domain Bucket":"< 1K"
   },
   {
     "Class":"Predicate",
-    "Name":"http:\/\/schema.org\/cvdNumICUBedsOcc-output",
+    "Name":"https://schema.org/cvdNumICUBedsOcc-output",
     "Domain Bucket":"< 1K"
   },
   {
     "Class":"Predicate",
-    "Name":"http:\/\/schema.org\/cvdNumTotBeds",
+    "Name":"https://schema.org/cvdNumTotBeds",
     "Domain Bucket":"< 1K"
   },
   {
     "Class":"Predicate",
-    "Name":"http:\/\/schema.org\/cvdNumTotBeds-input",
+    "Name":"https://schema.org/cvdNumTotBeds-input",
     "Domain Bucket":"< 1K"
   },
   {
     "Class":"Predicate",
-    "Name":"http:\/\/schema.org\/cvdNumTotBeds-output",
+    "Name":"https://schema.org/cvdNumTotBeds-output",
     "Domain Bucket":"< 1K"
   },
   {
     "Class":"Predicate",
-    "Name":"http:\/\/schema.org\/cvdNumVent",
+    "Name":"https://schema.org/cvdNumVent",
     "Domain Bucket":"< 1K"
   },
   {
     "Class":"Predicate",
-    "Name":"http:\/\/schema.org\/cvdNumVent-input",
+    "Name":"https://schema.org/cvdNumVent-input",
     "Domain Bucket":"< 1K"
   },
   {
     "Class":"Predicate",
-    "Name":"http:\/\/schema.org\/cvdNumVent-output",
+    "Name":"https://schema.org/cvdNumVent-output",
     "Domain Bucket":"< 1K"
   },
   {
     "Class":"Predicate",
-    "Name":"http:\/\/schema.org\/cvdNumVentUse",
+    "Name":"https://schema.org/cvdNumVentUse",
     "Domain Bucket":"< 1K"
   },
   {
     "Class":"Predicate",
-    "Name":"http:\/\/schema.org\/cvdNumVentUse-input",
+    "Name":"https://schema.org/cvdNumVentUse-input",
     "Domain Bucket":"< 1K"
   },
   {
     "Class":"Predicate",
-    "Name":"http:\/\/schema.org\/cvdNumVentUse-output",
+    "Name":"https://schema.org/cvdNumVentUse-output",
     "Domain Bucket":"< 1K"
   },
   {
     "Class":"Predicate",
-    "Name":"http:\/\/schema.org\/data",
+    "Name":"https://schema.org/data",
     "Domain Bucket":"1K - 10K"
   },
   {
     "Class":"Predicate",
-    "Name":"http:\/\/schema.org\/data-input",
+    "Name":"https://schema.org/data-input",
     "Domain Bucket":"< 1K"
   },
   {
     "Class":"Predicate",
-    "Name":"http:\/\/schema.org\/data-output",
+    "Name":"https://schema.org/data-output",
     "Domain Bucket":"< 1K"
   },
   {
     "Class":"Predicate",
-    "Name":"http:\/\/schema.org\/dataFeedElement",
+    "Name":"https://schema.org/dataFeedElement",
     "Domain Bucket":"1K - 10K"
   },
   {
     "Class":"Predicate",
-    "Name":"http:\/\/schema.org\/dataFeedElement-input",
+    "Name":"https://schema.org/dataFeedElement-input",
     "Domain Bucket":"< 1K"
   },
   {
     "Class":"Predicate",
-    "Name":"http:\/\/schema.org\/dataFeedElement-output",
+    "Name":"https://schema.org/dataFeedElement-output",
     "Domain Bucket":"< 1K"
   },
   {
     "Class":"Predicate",
-    "Name":"http:\/\/schema.org\/dataset",
+    "Name":"https://schema.org/dataset",
     "Domain Bucket":"< 1K"
   },
   {
     "Class":"Predicate",
-    "Name":"http:\/\/schema.org\/dataset-input",
+    "Name":"https://schema.org/dataset-input",
     "Domain Bucket":"< 1K"
   },
   {
     "Class":"Predicate",
-    "Name":"http:\/\/schema.org\/dataset-output",
+    "Name":"https://schema.org/dataset-output",
     "Domain Bucket":"< 1K"
   },
   {
     "Class":"Predicate",
-    "Name":"http:\/\/schema.org\/datasetTimeInterval",
+    "Name":"https://schema.org/datasetTimeInterval",
     "Domain Bucket":"< 1K"
   },
   {
     "Class":"Predicate",
-    "Name":"http:\/\/schema.org\/datasetTimeInterval-input",
+    "Name":"https://schema.org/datasetTimeInterval-input",
     "Domain Bucket":"< 1K"
   },
   {
     "Class":"Predicate",
-    "Name":"http:\/\/schema.org\/datasetTimeInterval-output",
+    "Name":"https://schema.org/datasetTimeInterval-output",
     "Domain Bucket":"< 1K"
   },
   {
     "Class":"Predicate",
-    "Name":"http:\/\/schema.org\/dateCreated",
+    "Name":"https://schema.org/dateCreated",
     "Domain Bucket":"100K - 1M"
   },
   {
     "Class":"Predicate",
-    "Name":"http:\/\/schema.org\/dateCreated-input",
+    "Name":"https://schema.org/dateCreated-input",
     "Domain Bucket":"< 1K"
   },
   {
     "Class":"Predicate",
-    "Name":"http:\/\/schema.org\/dateCreated-output",
+    "Name":"https://schema.org/dateCreated-output",
     "Domain Bucket":"< 1K"
   },
   {
     "Class":"Predicate",
-    "Name":"http:\/\/schema.org\/dateDeleted",
+    "Name":"https://schema.org/dateDeleted",
     "Domain Bucket":"< 1K"
   },
   {
     "Class":"Predicate",
-    "Name":"http:\/\/schema.org\/dateDeleted-input",
+    "Name":"https://schema.org/dateDeleted-input",
     "Domain Bucket":"< 1K"
   },
   {
     "Class":"Predicate",
-    "Name":"http:\/\/schema.org\/dateDeleted-output",
+    "Name":"https://schema.org/dateDeleted-output",
     "Domain Bucket":"< 1K"
   },
   {
     "Class":"Predicate",
-    "Name":"http:\/\/schema.org\/dateIssued",
+    "Name":"https://schema.org/dateIssued",
     "Domain Bucket":"< 1K"
   },
   {
     "Class":"Predicate",
-    "Name":"http:\/\/schema.org\/dateIssued-input",
+    "Name":"https://schema.org/dateIssued-input",
     "Domain Bucket":"< 1K"
   },
   {
     "Class":"Predicate",
-    "Name":"http:\/\/schema.org\/dateIssued-output",
+    "Name":"https://schema.org/dateIssued-output",
     "Domain Bucket":"< 1K"
   },
   {
     "Class":"Predicate",
-    "Name":"http:\/\/schema.org\/dateModified",
+    "Name":"https://schema.org/dateModified",
     "Domain Bucket":"10M+"
   },
   {
     "Class":"Predicate",
-    "Name":"http:\/\/schema.org\/dateModified-input",
+    "Name":"https://schema.org/dateModified-input",
     "Domain Bucket":"< 1K"
   },
   {
     "Class":"Predicate",
-    "Name":"http:\/\/schema.org\/dateModified-output",
+    "Name":"https://schema.org/dateModified-output",
     "Domain Bucket":"< 1K"
   },
   {
     "Class":"Predicate",
-    "Name":"http:\/\/schema.org\/datePosted",
+    "Name":"https://schema.org/datePosted",
     "Domain Bucket":"100K - 1M"
   },
   {
     "Class":"Predicate",
-    "Name":"http:\/\/schema.org\/datePosted-input",
+    "Name":"https://schema.org/datePosted-input",
     "Domain Bucket":"< 1K"
   },
   {
     "Class":"Predicate",
-    "Name":"http:\/\/schema.org\/datePosted-output",
+    "Name":"https://schema.org/datePosted-output",
     "Domain Bucket":"< 1K"
   },
   {
     "Class":"Predicate",
-    "Name":"http:\/\/schema.org\/datePublished",
+    "Name":"https://schema.org/datePublished",
     "Domain Bucket":"10M+"
   },
   {
     "Class":"Predicate",
-    "Name":"http:\/\/schema.org\/datePublished-input",
+    "Name":"https://schema.org/datePublished-input",
     "Domain Bucket":"< 1K"
   },
   {
     "Class":"Predicate",
-    "Name":"http:\/\/schema.org\/datePublished-output",
+    "Name":"https://schema.org/datePublished-output",
     "Domain Bucket":"< 1K"
   },
   {
     "Class":"Predicate",
-    "Name":"http:\/\/schema.org\/dateRead",
+    "Name":"https://schema.org/dateRead",
     "Domain Bucket":"< 1K"
   },
   {
     "Class":"Predicate",
-    "Name":"http:\/\/schema.org\/dateRead-input",
+    "Name":"https://schema.org/dateRead-input",
     "Domain Bucket":"< 1K"
   },
   {
     "Class":"Predicate",
-    "Name":"http:\/\/schema.org\/dateRead-output",
+    "Name":"https://schema.org/dateRead-output",
     "Domain Bucket":"< 1K"
   },
   {
     "Class":"Predicate",
-    "Name":"http:\/\/schema.org\/dateReceived",
+    "Name":"https://schema.org/dateReceived",
     "Domain Bucket":"< 1K"
   },
   {
     "Class":"Predicate",
-    "Name":"http:\/\/schema.org\/dateReceived-input",
+    "Name":"https://schema.org/dateReceived-input",
     "Domain Bucket":"< 1K"
   },
   {
     "Class":"Predicate",
-    "Name":"http:\/\/schema.org\/dateReceived-output",
+    "Name":"https://schema.org/dateReceived-output",
     "Domain Bucket":"< 1K"
   },
   {
     "Class":"Predicate",
-    "Name":"http:\/\/schema.org\/dateSent",
+    "Name":"https://schema.org/dateSent",
     "Domain Bucket":"< 1K"
   },
   {
     "Class":"Predicate",
-    "Name":"http:\/\/schema.org\/dateSent-input",
+    "Name":"https://schema.org/dateSent-input",
     "Domain Bucket":"< 1K"
   },
   {
     "Class":"Predicate",
-    "Name":"http:\/\/schema.org\/dateSent-output",
+    "Name":"https://schema.org/dateSent-output",
     "Domain Bucket":"< 1K"
   },
   {
     "Class":"Predicate",
-    "Name":"http:\/\/schema.org\/dateVehicleFirstRegistered",
+    "Name":"https://schema.org/dateVehicleFirstRegistered",
     "Domain Bucket":"1K - 10K"
   },
   {
     "Class":"Predicate",
-    "Name":"http:\/\/schema.org\/dateVehicleFirstRegistered-input",
+    "Name":"https://schema.org/dateVehicleFirstRegistered-input",
     "Domain Bucket":"< 1K"
   },
   {
     "Class":"Predicate",
-    "Name":"http:\/\/schema.org\/dateVehicleFirstRegistered-output",
+    "Name":"https://schema.org/dateVehicleFirstRegistered-output",
     "Domain Bucket":"< 1K"
   },
   {
     "Class":"Predicate",
-    "Name":"http:\/\/schema.org\/dateline",
+    "Name":"https://schema.org/dateline",
     "Domain Bucket":"1K - 10K"
   },
   {
     "Class":"Predicate",
-    "Name":"http:\/\/schema.org\/dateline-input",
+    "Name":"https://schema.org/dateline-input",
     "Domain Bucket":"< 1K"
   },
   {
     "Class":"Predicate",
-    "Name":"http:\/\/schema.org\/dateline-output",
+    "Name":"https://schema.org/dateline-output",
     "Domain Bucket":"< 1K"
   },
   {
     "Class":"Predicate",
-    "Name":"http:\/\/schema.org\/dayOfWeek",
+    "Name":"https://schema.org/dayOfWeek",
     "Domain Bucket":"1M - 10M"
   },
   {
     "Class":"Predicate",
-    "Name":"http:\/\/schema.org\/dayOfWeek-input",
+    "Name":"https://schema.org/dayOfWeek-input",
     "Domain Bucket":"< 1K"
   },
   {
     "Class":"Predicate",
-    "Name":"http:\/\/schema.org\/dayOfWeek-output",
+    "Name":"https://schema.org/dayOfWeek-output",
     "Domain Bucket":"< 1K"
   },
   {
     "Class":"Predicate",
-    "Name":"http:\/\/schema.org\/deathDate",
+    "Name":"https://schema.org/deathDate",
     "Domain Bucket":"10K - 100K"
   },
   {
     "Class":"Predicate",
-    "Name":"http:\/\/schema.org\/deathDate-input",
+    "Name":"https://schema.org/deathDate-input",
     "Domain Bucket":"< 1K"
   },
   {
     "Class":"Predicate",
-    "Name":"http:\/\/schema.org\/deathDate-output",
+    "Name":"https://schema.org/deathDate-output",
     "Domain Bucket":"< 1K"
   },
   {
     "Class":"Predicate",
-    "Name":"http:\/\/schema.org\/deathPlace",
+    "Name":"https://schema.org/deathPlace",
     "Domain Bucket":"1K - 10K"
   },
   {
     "Class":"Predicate",
-    "Name":"http:\/\/schema.org\/deathPlace-input",
+    "Name":"https://schema.org/deathPlace-input",
     "Domain Bucket":"< 1K"
   },
   {
     "Class":"Predicate",
-    "Name":"http:\/\/schema.org\/deathPlace-output",
+    "Name":"https://schema.org/deathPlace-output",
     "Domain Bucket":"< 1K"
   },
   {
     "Class":"Predicate",
-    "Name":"http:\/\/schema.org\/defaultValue",
+    "Name":"https://schema.org/defaultValue",
     "Domain Bucket":"100K - 1M"
   },
   {
     "Class":"Predicate",
-    "Name":"http:\/\/schema.org\/defaultValue-input",
+    "Name":"https://schema.org/defaultValue-input",
     "Domain Bucket":"< 1K"
   },
   {
     "Class":"Predicate",
-    "Name":"http:\/\/schema.org\/defaultValue-output",
+    "Name":"https://schema.org/defaultValue-output",
     "Domain Bucket":"< 1K"
   },
   {
     "Class":"Predicate",
-    "Name":"http:\/\/schema.org\/deliveryAddress",
+    "Name":"https://schema.org/deliveryAddress",
     "Domain Bucket":"< 1K"
   },
   {
     "Class":"Predicate",
-    "Name":"http:\/\/schema.org\/deliveryAddress-input",
+    "Name":"https://schema.org/deliveryAddress-input",
     "Domain Bucket":"< 1K"
   },
   {
     "Class":"Predicate",
-    "Name":"http:\/\/schema.org\/deliveryAddress-output",
+    "Name":"https://schema.org/deliveryAddress-output",
     "Domain Bucket":"< 1K"
   },
   {
     "Class":"Predicate",
-    "Name":"http:\/\/schema.org\/deliveryLeadTime",
+    "Name":"https://schema.org/deliveryLeadTime",
     "Domain Bucket":"10K - 100K"
   },
   {
     "Class":"Predicate",
-    "Name":"http:\/\/schema.org\/deliveryLeadTime-input",
+    "Name":"https://schema.org/deliveryLeadTime-input",
     "Domain Bucket":"< 1K"
   },
   {
     "Class":"Predicate",
-    "Name":"http:\/\/schema.org\/deliveryLeadTime-output",
+    "Name":"https://schema.org/deliveryLeadTime-output",
     "Domain Bucket":"< 1K"
   },
   {
     "Class":"Predicate",
-    "Name":"http:\/\/schema.org\/deliveryMethod",
+    "Name":"https://schema.org/deliveryMethod",
     "Domain Bucket":"10K - 100K"
   },
   {
     "Class":"Predicate",
-    "Name":"http:\/\/schema.org\/deliveryMethod-input",
+    "Name":"https://schema.org/deliveryMethod-input",
     "Domain Bucket":"< 1K"
   },
   {
     "Class":"Predicate",
-    "Name":"http:\/\/schema.org\/deliveryMethod-output",
+    "Name":"https://schema.org/deliveryMethod-output",
     "Domain Bucket":"< 1K"
   },
   {
     "Class":"Predicate",
-    "Name":"http:\/\/schema.org\/deliveryStatus",
+    "Name":"https://schema.org/deliveryStatus",
     "Domain Bucket":"< 1K"
   },
   {
     "Class":"Predicate",
-    "Name":"http:\/\/schema.org\/deliveryStatus-input",
+    "Name":"https://schema.org/deliveryStatus-input",
     "Domain Bucket":"< 1K"
   },
   {
     "Class":"Predicate",
-    "Name":"http:\/\/schema.org\/deliveryStatus-output",
+    "Name":"https://schema.org/deliveryStatus-output",
     "Domain Bucket":"< 1K"
   },
   {
     "Class":"Predicate",
-    "Name":"http:\/\/schema.org\/deliveryTime",
+    "Name":"https://schema.org/deliveryTime",
     "Domain Bucket":"100K - 1M"
   },
   {
     "Class":"Predicate",
-    "Name":"http:\/\/schema.org\/deliveryTime-input",
+    "Name":"https://schema.org/deliveryTime-input",
     "Domain Bucket":"< 1K"
   },
   {
     "Class":"Predicate",
-    "Name":"http:\/\/schema.org\/deliveryTime-output",
+    "Name":"https://schema.org/deliveryTime-output",
     "Domain Bucket":"< 1K"
   },
   {
     "Class":"Predicate",
-    "Name":"http:\/\/schema.org\/department",
+    "Name":"https://schema.org/department",
     "Domain Bucket":"10K - 100K"
   },
   {
     "Class":"Predicate",
-    "Name":"http:\/\/schema.org\/department-input",
+    "Name":"https://schema.org/department-input",
     "Domain Bucket":"< 1K"
   },
   {
     "Class":"Predicate",
-    "Name":"http:\/\/schema.org\/department-output",
+    "Name":"https://schema.org/department-output",
     "Domain Bucket":"< 1K"
   },
   {
     "Class":"Predicate",
-    "Name":"http:\/\/schema.org\/departureAirport",
+    "Name":"https://schema.org/departureAirport",
     "Domain Bucket":"1K - 10K"
   },
   {
     "Class":"Predicate",
-    "Name":"http:\/\/schema.org\/departureAirport-input",
+    "Name":"https://schema.org/departureAirport-input",
     "Domain Bucket":"< 1K"
   },
   {
     "Class":"Predicate",
-    "Name":"http:\/\/schema.org\/departureAirport-output",
+    "Name":"https://schema.org/departureAirport-output",
     "Domain Bucket":"< 1K"
   },
   {
     "Class":"Predicate",
-    "Name":"http:\/\/schema.org\/departureBoatTerminal",
+    "Name":"https://schema.org/departureBoatTerminal",
     "Domain Bucket":"< 1K"
   },
   {
     "Class":"Predicate",
-    "Name":"http:\/\/schema.org\/departureBoatTerminal-input",
+    "Name":"https://schema.org/departureBoatTerminal-input",
     "Domain Bucket":"< 1K"
   },
   {
     "Class":"Predicate",
-    "Name":"http:\/\/schema.org\/departureBoatTerminal-output",
+    "Name":"https://schema.org/departureBoatTerminal-output",
     "Domain Bucket":"< 1K"
   },
   {
     "Class":"Predicate",
-    "Name":"http:\/\/schema.org\/departureBusStop",
+    "Name":"https://schema.org/departureBusStop",
     "Domain Bucket":"< 1K"
   },
   {
     "Class":"Predicate",
-    "Name":"http:\/\/schema.org\/departureBusStop-input",
+    "Name":"https://schema.org/departureBusStop-input",
     "Domain Bucket":"< 1K"
   },
   {
     "Class":"Predicate",
-    "Name":"http:\/\/schema.org\/departureBusStop-output",
+    "Name":"https://schema.org/departureBusStop-output",
     "Domain Bucket":"< 1K"
   },
   {
     "Class":"Predicate",
-    "Name":"http:\/\/schema.org\/departureGate",
+    "Name":"https://schema.org/departureGate",
     "Domain Bucket":"< 1K"
   },
   {
     "Class":"Predicate",
-    "Name":"http:\/\/schema.org\/departureGate-input",
+    "Name":"https://schema.org/departureGate-input",
     "Domain Bucket":"< 1K"
   },
   {
     "Class":"Predicate",
-    "Name":"http:\/\/schema.org\/departureGate-output",
+    "Name":"https://schema.org/departureGate-output",
     "Domain Bucket":"< 1K"
   },
   {
     "Class":"Predicate",
-    "Name":"http:\/\/schema.org\/departurePlatform",
+    "Name":"https://schema.org/departurePlatform",
     "Domain Bucket":"< 1K"
   },
   {
     "Class":"Predicate",
-    "Name":"http:\/\/schema.org\/departurePlatform-input",
+    "Name":"https://schema.org/departurePlatform-input",
     "Domain Bucket":"< 1K"
   },
   {
     "Class":"Predicate",
-    "Name":"http:\/\/schema.org\/departurePlatform-output",
+    "Name":"https://schema.org/departurePlatform-output",
     "Domain Bucket":"< 1K"
   },
   {
     "Class":"Predicate",
-    "Name":"http:\/\/schema.org\/departureStation",
+    "Name":"https://schema.org/departureStation",
     "Domain Bucket":"< 1K"
   },
   {
     "Class":"Predicate",
-    "Name":"http:\/\/schema.org\/departureStation-input",
+    "Name":"https://schema.org/departureStation-input",
     "Domain Bucket":"< 1K"
   },
   {
     "Class":"Predicate",
-    "Name":"http:\/\/schema.org\/departureStation-output",
+    "Name":"https://schema.org/departureStation-output",
     "Domain Bucket":"< 1K"
   },
   {
     "Class":"Predicate",
-    "Name":"http:\/\/schema.org\/departureTerminal",
+    "Name":"https://schema.org/departureTerminal",
     "Domain Bucket":"< 1K"
   },
   {
     "Class":"Predicate",
-    "Name":"http:\/\/schema.org\/departureTerminal-input",
+    "Name":"https://schema.org/departureTerminal-input",
     "Domain Bucket":"< 1K"
   },
   {
     "Class":"Predicate",
-    "Name":"http:\/\/schema.org\/departureTerminal-output",
+    "Name":"https://schema.org/departureTerminal-output",
     "Domain Bucket":"< 1K"
   },
   {
     "Class":"Predicate",
-    "Name":"http:\/\/schema.org\/departureTime",
+    "Name":"https://schema.org/departureTime",
     "Domain Bucket":"1K - 10K"
   },
   {
     "Class":"Predicate",
-    "Name":"http:\/\/schema.org\/departureTime-input",
+    "Name":"https://schema.org/departureTime-input",
     "Domain Bucket":"< 1K"
   },
   {
     "Class":"Predicate",
-    "Name":"http:\/\/schema.org\/departureTime-output",
+    "Name":"https://schema.org/departureTime-output",
     "Domain Bucket":"< 1K"
   },
   {
     "Class":"Predicate",
-    "Name":"http:\/\/schema.org\/dependencies",
+    "Name":"https://schema.org/dependencies",
     "Domain Bucket":"1K - 10K"
   },
   {
     "Class":"Predicate",
-    "Name":"http:\/\/schema.org\/dependencies-input",
+    "Name":"https://schema.org/dependencies-input",
     "Domain Bucket":"< 1K"
   },
   {
     "Class":"Predicate",
-    "Name":"http:\/\/schema.org\/dependencies-output",
+    "Name":"https://schema.org/dependencies-output",
     "Domain Bucket":"< 1K"
   },
   {
     "Class":"Predicate",
-    "Name":"http:\/\/schema.org\/depth",
+    "Name":"https://schema.org/depth",
     "Domain Bucket":"10K - 100K"
   },
   {
     "Class":"Predicate",
-    "Name":"http:\/\/schema.org\/depth-input",
+    "Name":"https://schema.org/depth-input",
     "Domain Bucket":"< 1K"
   },
   {
     "Class":"Predicate",
-    "Name":"http:\/\/schema.org\/depth-output",
+    "Name":"https://schema.org/depth-output",
     "Domain Bucket":"< 1K"
   },
   {
     "Class":"Predicate",
-    "Name":"http:\/\/schema.org\/description",
+    "Name":"https://schema.org/description",
     "Domain Bucket":"10M+"
   },
   {
     "Class":"Predicate",
-    "Name":"http:\/\/schema.org\/description-input",
+    "Name":"https://schema.org/description-input",
     "Domain Bucket":"< 1K"
   },
   {
     "Class":"Predicate",
-    "Name":"http:\/\/schema.org\/description-output",
+    "Name":"https://schema.org/description-output",
     "Domain Bucket":"< 1K"
   },
   {
     "Class":"Predicate",
-    "Name":"http:\/\/schema.org\/device",
+    "Name":"https://schema.org/device",
     "Domain Bucket":"< 1K"
   },
   {
     "Class":"Predicate",
-    "Name":"http:\/\/schema.org\/device-input",
+    "Name":"https://schema.org/device-input",
     "Domain Bucket":"< 1K"
   },
   {
     "Class":"Predicate",
-    "Name":"http:\/\/schema.org\/device-output",
+    "Name":"https://schema.org/device-output",
     "Domain Bucket":"< 1K"
   },
   {
     "Class":"Predicate",
-    "Name":"http:\/\/schema.org\/diagnosis",
+    "Name":"https://schema.org/diagnosis",
     "Domain Bucket":"< 1K"
   },
   {
     "Class":"Predicate",
-    "Name":"http:\/\/schema.org\/diagnosis-input",
+    "Name":"https://schema.org/diagnosis-input",
     "Domain Bucket":"< 1K"
   },
   {
     "Class":"Predicate",
-    "Name":"http:\/\/schema.org\/diagnosis-output",
+    "Name":"https://schema.org/diagnosis-output",
     "Domain Bucket":"< 1K"
   },
   {
     "Class":"Predicate",
-    "Name":"http:\/\/schema.org\/diagram",
+    "Name":"https://schema.org/diagram",
     "Domain Bucket":"< 1K"
   },
   {
     "Class":"Predicate",
-    "Name":"http:\/\/schema.org\/diagram-input",
+    "Name":"https://schema.org/diagram-input",
     "Domain Bucket":"< 1K"
   },
   {
     "Class":"Predicate",
-    "Name":"http:\/\/schema.org\/diagram-output",
+    "Name":"https://schema.org/diagram-output",
     "Domain Bucket":"< 1K"
   },
   {
     "Class":"Predicate",
-    "Name":"http:\/\/schema.org\/diet",
+    "Name":"https://schema.org/diet",
     "Domain Bucket":"< 1K"
   },
   {
     "Class":"Predicate",
-    "Name":"http:\/\/schema.org\/diet-input",
+    "Name":"https://schema.org/diet-input",
     "Domain Bucket":"< 1K"
   },
   {
     "Class":"Predicate",
-    "Name":"http:\/\/schema.org\/diet-output",
+    "Name":"https://schema.org/diet-output",
     "Domain Bucket":"< 1K"
   },
   {
     "Class":"Predicate",
-    "Name":"http:\/\/schema.org\/dietFeatures",
+    "Name":"https://schema.org/dietFeatures",
     "Domain Bucket":"< 1K"
   },
   {
     "Class":"Predicate",
-    "Name":"http:\/\/schema.org\/dietFeatures-input",
+    "Name":"https://schema.org/dietFeatures-input",
     "Domain Bucket":"< 1K"
   },
   {
     "Class":"Predicate",
-    "Name":"http:\/\/schema.org\/dietFeatures-output",
+    "Name":"https://schema.org/dietFeatures-output",
     "Domain Bucket":"< 1K"
   },
   {
     "Class":"Predicate",
-    "Name":"http:\/\/schema.org\/differentialDiagnosis",
+    "Name":"https://schema.org/differentialDiagnosis",
     "Domain Bucket":"< 1K"
   },
   {
     "Class":"Predicate",
-    "Name":"http:\/\/schema.org\/differentialDiagnosis-input",
+    "Name":"https://schema.org/differentialDiagnosis-input",
     "Domain Bucket":"< 1K"
   },
   {
     "Class":"Predicate",
-    "Name":"http:\/\/schema.org\/differentialDiagnosis-output",
+    "Name":"https://schema.org/differentialDiagnosis-output",
     "Domain Bucket":"< 1K"
   },
   {
     "Class":"Predicate",
-    "Name":"http:\/\/schema.org\/digitalSourceType",
+    "Name":"https://schema.org/digitalSourceType",
     "Domain Bucket":"< 1K"
   },
   {
     "Class":"Predicate",
-    "Name":"http:\/\/schema.org\/digitalSourceType-input",
+    "Name":"https://schema.org/digitalSourceType-input",
     "Domain Bucket":"< 1K"
   },
   {
     "Class":"Predicate",
-    "Name":"http:\/\/schema.org\/digitalSourceType-output",
+    "Name":"https://schema.org/digitalSourceType-output",
     "Domain Bucket":"< 1K"
   },
   {
     "Class":"Predicate",
-    "Name":"http:\/\/schema.org\/directApply",
+    "Name":"https://schema.org/directApply",
     "Domain Bucket":"10K - 100K"
   },
   {
     "Class":"Predicate",
-    "Name":"http:\/\/schema.org\/directApply-input",
+    "Name":"https://schema.org/directApply-input",
     "Domain Bucket":"< 1K"
   },
   {
     "Class":"Predicate",
-    "Name":"http:\/\/schema.org\/directApply-output",
+    "Name":"https://schema.org/directApply-output",
     "Domain Bucket":"< 1K"
   },
   {
     "Class":"Predicate",
-    "Name":"http:\/\/schema.org\/director",
+    "Name":"https://schema.org/director",
     "Domain Bucket":"10K - 100K"
   },
   {
     "Class":"Predicate",
-    "Name":"http:\/\/schema.org\/director-input",
+    "Name":"https://schema.org/director-input",
     "Domain Bucket":"< 1K"
   },
   {
     "Class":"Predicate",
-    "Name":"http:\/\/schema.org\/director-output",
+    "Name":"https://schema.org/director-output",
     "Domain Bucket":"< 1K"
   },
   {
     "Class":"Predicate",
-    "Name":"http:\/\/schema.org\/directors",
+    "Name":"https://schema.org/directors",
     "Domain Bucket":"< 1K"
   },
   {
     "Class":"Predicate",
-    "Name":"http:\/\/schema.org\/directors-input",
+    "Name":"https://schema.org/directors-input",
     "Domain Bucket":"< 1K"
   },
   {
     "Class":"Predicate",
-    "Name":"http:\/\/schema.org\/directors-output",
+    "Name":"https://schema.org/directors-output",
     "Domain Bucket":"< 1K"
   },
   {
     "Class":"Predicate",
-    "Name":"http:\/\/schema.org\/disambiguatingDescription",
+    "Name":"https://schema.org/disambiguatingDescription",
     "Domain Bucket":"10K - 100K"
   },
   {
     "Class":"Predicate",
-    "Name":"http:\/\/schema.org\/disambiguatingDescription-input",
+    "Name":"https://schema.org/disambiguatingDescription-input",
     "Domain Bucket":"< 1K"
   },
   {
     "Class":"Predicate",
-    "Name":"http:\/\/schema.org\/disambiguatingDescription-output",
+    "Name":"https://schema.org/disambiguatingDescription-output",
     "Domain Bucket":"< 1K"
   },
   {
     "Class":"Predicate",
-    "Name":"http:\/\/schema.org\/discount",
+    "Name":"https://schema.org/discount",
     "Domain Bucket":"10K - 100K"
   },
   {
     "Class":"Predicate",
-    "Name":"http:\/\/schema.org\/discount-input",
+    "Name":"https://schema.org/discount-input",
     "Domain Bucket":"< 1K"
   },
   {
     "Class":"Predicate",
-    "Name":"http:\/\/schema.org\/discount-output",
+    "Name":"https://schema.org/discount-output",
     "Domain Bucket":"< 1K"
   },
   {
     "Class":"Predicate",
-    "Name":"http:\/\/schema.org\/discountCode",
+    "Name":"https://schema.org/discountCode",
     "Domain Bucket":"< 1K"
   },
   {
     "Class":"Predicate",
-    "Name":"http:\/\/schema.org\/discountCode-input",
+    "Name":"https://schema.org/discountCode-input",
     "Domain Bucket":"< 1K"
   },
   {
     "Class":"Predicate",
-    "Name":"http:\/\/schema.org\/discountCode-output",
+    "Name":"https://schema.org/discountCode-output",
     "Domain Bucket":"< 1K"
   },
   {
     "Class":"Predicate",
-    "Name":"http:\/\/schema.org\/discountCurrency",
+    "Name":"https://schema.org/discountCurrency",
     "Domain Bucket":"< 1K"
   },
   {
     "Class":"Predicate",
-    "Name":"http:\/\/schema.org\/discountCurrency-input",
+    "Name":"https://schema.org/discountCurrency-input",
     "Domain Bucket":"< 1K"
   },
   {
     "Class":"Predicate",
-    "Name":"http:\/\/schema.org\/discountCurrency-output",
+    "Name":"https://schema.org/discountCurrency-output",
     "Domain Bucket":"< 1K"
   },
   {
     "Class":"Predicate",
-    "Name":"http:\/\/schema.org\/discusses",
+    "Name":"https://schema.org/discusses",
     "Domain Bucket":"1K - 10K"
   },
   {
     "Class":"Predicate",
-    "Name":"http:\/\/schema.org\/discusses-input",
+    "Name":"https://schema.org/discusses-input",
     "Domain Bucket":"< 1K"
   },
   {
     "Class":"Predicate",
-    "Name":"http:\/\/schema.org\/discusses-output",
+    "Name":"https://schema.org/discusses-output",
     "Domain Bucket":"< 1K"
   },
   {
     "Class":"Predicate",
-    "Name":"http:\/\/schema.org\/discussionUrl",
+    "Name":"https://schema.org/discussionUrl",
     "Domain Bucket":"10K - 100K"
   },
   {
     "Class":"Predicate",
-    "Name":"http:\/\/schema.org\/discussionUrl-input",
+    "Name":"https://schema.org/discussionUrl-input",
     "Domain Bucket":"< 1K"
   },
   {
     "Class":"Predicate",
-    "Name":"http:\/\/schema.org\/discussionUrl-output",
+    "Name":"https://schema.org/discussionUrl-output",
     "Domain Bucket":"< 1K"
   },
   {
     "Class":"Predicate",
-    "Name":"http:\/\/schema.org\/diseasePreventionInfo",
+    "Name":"https://schema.org/diseasePreventionInfo",
     "Domain Bucket":"< 1K"
   },
   {
     "Class":"Predicate",
-    "Name":"http:\/\/schema.org\/diseasePreventionInfo-input",
+    "Name":"https://schema.org/diseasePreventionInfo-input",
     "Domain Bucket":"< 1K"
   },
   {
     "Class":"Predicate",
-    "Name":"http:\/\/schema.org\/diseasePreventionInfo-output",
+    "Name":"https://schema.org/diseasePreventionInfo-output",
     "Domain Bucket":"< 1K"
   },
   {
     "Class":"Predicate",
-    "Name":"http:\/\/schema.org\/diseaseSpreadStatistics",
+    "Name":"https://schema.org/diseaseSpreadStatistics",
     "Domain Bucket":"< 1K"
   },
   {
     "Class":"Predicate",
-    "Name":"http:\/\/schema.org\/diseaseSpreadStatistics-input",
+    "Name":"https://schema.org/diseaseSpreadStatistics-input",
     "Domain Bucket":"< 1K"
   },
   {
     "Class":"Predicate",
-    "Name":"http:\/\/schema.org\/diseaseSpreadStatistics-output",
+    "Name":"https://schema.org/diseaseSpreadStatistics-output",
     "Domain Bucket":"< 1K"
   },
   {
     "Class":"Predicate",
-    "Name":"http:\/\/schema.org\/displayLocation",
+    "Name":"https://schema.org/displayLocation",
     "Domain Bucket":"< 1K"
   },
   {
     "Class":"Predicate",
-    "Name":"http:\/\/schema.org\/displayLocation-input",
+    "Name":"https://schema.org/displayLocation-input",
     "Domain Bucket":"< 1K"
   },
   {
     "Class":"Predicate",
-    "Name":"http:\/\/schema.org\/displayLocation-output",
+    "Name":"https://schema.org/displayLocation-output",
     "Domain Bucket":"< 1K"
   },
   {
     "Class":"Predicate",
-    "Name":"http:\/\/schema.org\/dissolutionDate",
+    "Name":"https://schema.org/dissolutionDate",
     "Domain Bucket":"< 1K"
   },
   {
     "Class":"Predicate",
-    "Name":"http:\/\/schema.org\/dissolutionDate-input",
+    "Name":"https://schema.org/dissolutionDate-input",
     "Domain Bucket":"< 1K"
   },
   {
     "Class":"Predicate",
-    "Name":"http:\/\/schema.org\/dissolutionDate-output",
+    "Name":"https://schema.org/dissolutionDate-output",
     "Domain Bucket":"< 1K"
   },
   {
     "Class":"Predicate",
-    "Name":"http:\/\/schema.org\/distance",
+    "Name":"https://schema.org/distance",
     "Domain Bucket":"1K - 10K"
   },
   {
     "Class":"Predicate",
-    "Name":"http:\/\/schema.org\/distance-input",
+    "Name":"https://schema.org/distance-input",
     "Domain Bucket":"< 1K"
   },
   {
     "Class":"Predicate",
-    "Name":"http:\/\/schema.org\/distance-output",
+    "Name":"https://schema.org/distance-output",
     "Domain Bucket":"< 1K"
   },
   {
     "Class":"Predicate",
-    "Name":"http:\/\/schema.org\/distinguishingSign",
+    "Name":"https://schema.org/distinguishingSign",
     "Domain Bucket":"< 1K"
   },
   {
     "Class":"Predicate",
-    "Name":"http:\/\/schema.org\/distinguishingSign-input",
+    "Name":"https://schema.org/distinguishingSign-input",
     "Domain Bucket":"< 1K"
   },
   {
     "Class":"Predicate",
-    "Name":"http:\/\/schema.org\/distinguishingSign-output",
+    "Name":"https://schema.org/distinguishingSign-output",
     "Domain Bucket":"< 1K"
   },
   {
     "Class":"Predicate",
-    "Name":"http:\/\/schema.org\/distribution",
+    "Name":"https://schema.org/distribution",
     "Domain Bucket":"10K - 100K"
   },
   {
     "Class":"Predicate",
-    "Name":"http:\/\/schema.org\/distribution-input",
+    "Name":"https://schema.org/distribution-input",
     "Domain Bucket":"< 1K"
   },
   {
     "Class":"Predicate",
-    "Name":"http:\/\/schema.org\/distribution-output",
+    "Name":"https://schema.org/distribution-output",
     "Domain Bucket":"< 1K"
   },
   {
     "Class":"Predicate",
-    "Name":"http:\/\/schema.org\/diversityPolicy",
+    "Name":"https://schema.org/diversityPolicy",
     "Domain Bucket":"10K - 100K"
   },
   {
     "Class":"Predicate",
-    "Name":"http:\/\/schema.org\/diversityPolicy-input",
+    "Name":"https://schema.org/diversityPolicy-input",
     "Domain Bucket":"< 1K"
   },
   {
     "Class":"Predicate",
-    "Name":"http:\/\/schema.org\/diversityPolicy-output",
+    "Name":"https://schema.org/diversityPolicy-output",
     "Domain Bucket":"< 1K"
   },
   {
     "Class":"Predicate",
-    "Name":"http:\/\/schema.org\/diversityStaffingReport",
+    "Name":"https://schema.org/diversityStaffingReport",
     "Domain Bucket":"1K - 10K"
   },
   {
     "Class":"Predicate",
-    "Name":"http:\/\/schema.org\/diversityStaffingReport-input",
+    "Name":"https://schema.org/diversityStaffingReport-input",
     "Domain Bucket":"< 1K"
   },
   {
     "Class":"Predicate",
-    "Name":"http:\/\/schema.org\/diversityStaffingReport-output",
+    "Name":"https://schema.org/diversityStaffingReport-output",
     "Domain Bucket":"< 1K"
   },
   {
     "Class":"Predicate",
-    "Name":"http:\/\/schema.org\/documentation",
+    "Name":"https://schema.org/documentation",
     "Domain Bucket":"1K - 10K"
   },
   {
     "Class":"Predicate",
-    "Name":"http:\/\/schema.org\/documentation-input",
+    "Name":"https://schema.org/documentation-input",
     "Domain Bucket":"< 1K"
   },
   {
     "Class":"Predicate",
-    "Name":"http:\/\/schema.org\/documentation-output",
+    "Name":"https://schema.org/documentation-output",
     "Domain Bucket":"< 1K"
   },
   {
     "Class":"Predicate",
-    "Name":"http:\/\/schema.org\/doesNotShip",
+    "Name":"https://schema.org/doesNotShip",
     "Domain Bucket":"10K - 100K"
   },
   {
     "Class":"Predicate",
-    "Name":"http:\/\/schema.org\/doesNotShip-input",
+    "Name":"https://schema.org/doesNotShip-input",
     "Domain Bucket":"< 1K"
   },
   {
     "Class":"Predicate",
-    "Name":"http:\/\/schema.org\/doesNotShip-output",
+    "Name":"https://schema.org/doesNotShip-output",
     "Domain Bucket":"< 1K"
   },
   {
     "Class":"Predicate",
-    "Name":"http:\/\/schema.org\/domainIncludes",
+    "Name":"https://schema.org/domainIncludes",
     "Domain Bucket":"< 1K"
   },
   {
     "Class":"Predicate",
-    "Name":"http:\/\/schema.org\/domainIncludes-input",
+    "Name":"https://schema.org/domainIncludes-input",
     "Domain Bucket":"< 1K"
   },
   {
     "Class":"Predicate",
-    "Name":"http:\/\/schema.org\/domainIncludes-output",
+    "Name":"https://schema.org/domainIncludes-output",
     "Domain Bucket":"< 1K"
   },
   {
     "Class":"Predicate",
-    "Name":"http:\/\/schema.org\/domiciledMortgage",
+    "Name":"https://schema.org/domiciledMortgage",
     "Domain Bucket":"< 1K"
   },
   {
     "Class":"Predicate",
-    "Name":"http:\/\/schema.org\/domiciledMortgage-input",
+    "Name":"https://schema.org/domiciledMortgage-input",
     "Domain Bucket":"< 1K"
   },
   {
     "Class":"Predicate",
-    "Name":"http:\/\/schema.org\/domiciledMortgage-output",
+    "Name":"https://schema.org/domiciledMortgage-output",
     "Domain Bucket":"< 1K"
   },
   {
     "Class":"Predicate",
-    "Name":"http:\/\/schema.org\/doorTime",
+    "Name":"https://schema.org/doorTime",
     "Domain Bucket":"1K - 10K"
   },
   {
     "Class":"Predicate",
-    "Name":"http:\/\/schema.org\/doorTime-input",
+    "Name":"https://schema.org/doorTime-input",
     "Domain Bucket":"< 1K"
   },
   {
     "Class":"Predicate",
-    "Name":"http:\/\/schema.org\/doorTime-output",
+    "Name":"https://schema.org/doorTime-output",
     "Domain Bucket":"< 1K"
   },
   {
     "Class":"Predicate",
-    "Name":"http:\/\/schema.org\/dosageForm",
+    "Name":"https://schema.org/dosageForm",
     "Domain Bucket":"1K - 10K"
   },
   {
     "Class":"Predicate",
-    "Name":"http:\/\/schema.org\/dosageForm-input",
+    "Name":"https://schema.org/dosageForm-input",
     "Domain Bucket":"< 1K"
   },
   {
     "Class":"Predicate",
-    "Name":"http:\/\/schema.org\/dosageForm-output",
+    "Name":"https://schema.org/dosageForm-output",
     "Domain Bucket":"< 1K"
   },
   {
     "Class":"Predicate",
-    "Name":"http:\/\/schema.org\/doseSchedule",
+    "Name":"https://schema.org/doseSchedule",
     "Domain Bucket":"< 1K"
   },
   {
     "Class":"Predicate",
-    "Name":"http:\/\/schema.org\/doseSchedule-input",
+    "Name":"https://schema.org/doseSchedule-input",
     "Domain Bucket":"< 1K"
   },
   {
     "Class":"Predicate",
-    "Name":"http:\/\/schema.org\/doseSchedule-output",
+    "Name":"https://schema.org/doseSchedule-output",
     "Domain Bucket":"< 1K"
   },
   {
     "Class":"Predicate",
-    "Name":"http:\/\/schema.org\/doseUnit",
+    "Name":"https://schema.org/doseUnit",
     "Domain Bucket":"< 1K"
   },
   {
     "Class":"Predicate",
-    "Name":"http:\/\/schema.org\/doseUnit-input",
+    "Name":"https://schema.org/doseUnit-input",
     "Domain Bucket":"< 1K"
   },
   {
     "Class":"Predicate",
-    "Name":"http:\/\/schema.org\/doseUnit-output",
+    "Name":"https://schema.org/doseUnit-output",
     "Domain Bucket":"< 1K"
   },
   {
     "Class":"Predicate",
-    "Name":"http:\/\/schema.org\/doseValue",
+    "Name":"https://schema.org/doseValue",
     "Domain Bucket":"< 1K"
   },
   {
     "Class":"Predicate",
-    "Name":"http:\/\/schema.org\/doseValue-input",
+    "Name":"https://schema.org/doseValue-input",
     "Domain Bucket":"< 1K"
   },
   {
     "Class":"Predicate",
-    "Name":"http:\/\/schema.org\/doseValue-output",
+    "Name":"https://schema.org/doseValue-output",
     "Domain Bucket":"< 1K"
   },
   {
     "Class":"Predicate",
-    "Name":"http:\/\/schema.org\/downPayment",
+    "Name":"https://schema.org/downPayment",
     "Domain Bucket":"< 1K"
   },
   {
     "Class":"Predicate",
-    "Name":"http:\/\/schema.org\/downPayment-input",
+    "Name":"https://schema.org/downPayment-input",
     "Domain Bucket":"< 1K"
   },
   {
     "Class":"Predicate",
-    "Name":"http:\/\/schema.org\/downPayment-output",
+    "Name":"https://schema.org/downPayment-output",
     "Domain Bucket":"< 1K"
   },
   {
     "Class":"Predicate",
-    "Name":"http:\/\/schema.org\/downloadUrl",
+    "Name":"https://schema.org/downloadUrl",
     "Domain Bucket":"100K - 1M"
   },
   {
     "Class":"Predicate",
-    "Name":"http:\/\/schema.org\/downloadUrl-input",
+    "Name":"https://schema.org/downloadUrl-input",
     "Domain Bucket":"< 1K"
   },
   {
     "Class":"Predicate",
-    "Name":"http:\/\/schema.org\/downloadUrl-output",
+    "Name":"https://schema.org/downloadUrl-output",
     "Domain Bucket":"< 1K"
   },
   {
     "Class":"Predicate",
-    "Name":"http:\/\/schema.org\/downvoteCount",
+    "Name":"https://schema.org/downvoteCount",
     "Domain Bucket":"1K - 10K"
   },
   {
     "Class":"Predicate",
-    "Name":"http:\/\/schema.org\/downvoteCount-input",
+    "Name":"https://schema.org/downvoteCount-input",
     "Domain Bucket":"< 1K"
   },
   {
     "Class":"Predicate",
-    "Name":"http:\/\/schema.org\/downvoteCount-output",
+    "Name":"https://schema.org/downvoteCount-output",
     "Domain Bucket":"< 1K"
   },
   {
     "Class":"Predicate",
-    "Name":"http:\/\/schema.org\/drainsTo",
+    "Name":"https://schema.org/drainsTo",
     "Domain Bucket":"< 1K"
   },
   {
     "Class":"Predicate",
-    "Name":"http:\/\/schema.org\/drainsTo-input",
+    "Name":"https://schema.org/drainsTo-input",
     "Domain Bucket":"< 1K"
   },
   {
     "Class":"Predicate",
-    "Name":"http:\/\/schema.org\/drainsTo-output",
+    "Name":"https://schema.org/drainsTo-output",
     "Domain Bucket":"< 1K"
   },
   {
     "Class":"Predicate",
-    "Name":"http:\/\/schema.org\/driveWheelConfiguration",
+    "Name":"https://schema.org/driveWheelConfiguration",
     "Domain Bucket":"10K - 100K"
   },
   {
     "Class":"Predicate",
-    "Name":"http:\/\/schema.org\/driveWheelConfiguration-input",
+    "Name":"https://schema.org/driveWheelConfiguration-input",
     "Domain Bucket":"< 1K"
   },
   {
     "Class":"Predicate",
-    "Name":"http:\/\/schema.org\/driveWheelConfiguration-output",
+    "Name":"https://schema.org/driveWheelConfiguration-output",
     "Domain Bucket":"< 1K"
   },
   {
     "Class":"Predicate",
-    "Name":"http:\/\/schema.org\/dropoffLocation",
+    "Name":"https://schema.org/dropoffLocation",
     "Domain Bucket":"< 1K"
   },
   {
     "Class":"Predicate",
-    "Name":"http:\/\/schema.org\/dropoffLocation-input",
+    "Name":"https://schema.org/dropoffLocation-input",
     "Domain Bucket":"< 1K"
   },
   {
     "Class":"Predicate",
-    "Name":"http:\/\/schema.org\/dropoffLocation-output",
+    "Name":"https://schema.org/dropoffLocation-output",
     "Domain Bucket":"< 1K"
   },
   {
     "Class":"Predicate",
-    "Name":"http:\/\/schema.org\/dropoffTime",
+    "Name":"https://schema.org/dropoffTime",
     "Domain Bucket":"< 1K"
   },
   {
     "Class":"Predicate",
-    "Name":"http:\/\/schema.org\/dropoffTime-input",
+    "Name":"https://schema.org/dropoffTime-input",
     "Domain Bucket":"< 1K"
   },
   {
     "Class":"Predicate",
-    "Name":"http:\/\/schema.org\/dropoffTime-output",
+    "Name":"https://schema.org/dropoffTime-output",
     "Domain Bucket":"< 1K"
   },
   {
     "Class":"Predicate",
-    "Name":"http:\/\/schema.org\/drug",
+    "Name":"https://schema.org/drug",
     "Domain Bucket":"< 1K"
   },
   {
     "Class":"Predicate",
-    "Name":"http:\/\/schema.org\/drug-input",
+    "Name":"https://schema.org/drug-input",
     "Domain Bucket":"< 1K"
   },
   {
     "Class":"Predicate",
-    "Name":"http:\/\/schema.org\/drug-output",
+    "Name":"https://schema.org/drug-output",
     "Domain Bucket":"< 1K"
   },
   {
     "Class":"Predicate",
-    "Name":"http:\/\/schema.org\/drugClass",
+    "Name":"https://schema.org/drugClass",
     "Domain Bucket":"1K - 10K"
   },
   {
     "Class":"Predicate",
-    "Name":"http:\/\/schema.org\/drugClass-input",
+    "Name":"https://schema.org/drugClass-input",
     "Domain Bucket":"< 1K"
   },
   {
     "Class":"Predicate",
-    "Name":"http:\/\/schema.org\/drugClass-output",
+    "Name":"https://schema.org/drugClass-output",
     "Domain Bucket":"< 1K"
   },
   {
     "Class":"Predicate",
-    "Name":"http:\/\/schema.org\/drugUnit",
+    "Name":"https://schema.org/drugUnit",
     "Domain Bucket":"< 1K"
   },
   {
     "Class":"Predicate",
-    "Name":"http:\/\/schema.org\/drugUnit-input",
+    "Name":"https://schema.org/drugUnit-input",
     "Domain Bucket":"< 1K"
   },
   {
     "Class":"Predicate",
-    "Name":"http:\/\/schema.org\/drugUnit-output",
+    "Name":"https://schema.org/drugUnit-output",
     "Domain Bucket":"< 1K"
   },
   {
     "Class":"Predicate",
-    "Name":"http:\/\/schema.org\/duns",
+    "Name":"https://schema.org/duns",
     "Domain Bucket":"1K - 10K"
   },
   {
     "Class":"Predicate",
-    "Name":"http:\/\/schema.org\/duns-input",
+    "Name":"https://schema.org/duns-input",
     "Domain Bucket":"< 1K"
   },
   {
     "Class":"Predicate",
-    "Name":"http:\/\/schema.org\/duns-output",
+    "Name":"https://schema.org/duns-output",
     "Domain Bucket":"< 1K"
   },
   {
     "Class":"Predicate",
-    "Name":"http:\/\/schema.org\/duplicateTherapy",
+    "Name":"https://schema.org/duplicateTherapy",
     "Domain Bucket":"< 1K"
   },
   {
     "Class":"Predicate",
-    "Name":"http:\/\/schema.org\/duplicateTherapy-input",
+    "Name":"https://schema.org/duplicateTherapy-input",
     "Domain Bucket":"< 1K"
   },
   {
     "Class":"Predicate",
-    "Name":"http:\/\/schema.org\/duplicateTherapy-output",
+    "Name":"https://schema.org/duplicateTherapy-output",
     "Domain Bucket":"< 1K"
   },
   {
     "Class":"Predicate",
-    "Name":"http:\/\/schema.org\/duration",
+    "Name":"https://schema.org/duration",
     "Domain Bucket":"1M - 10M"
   },
   {
     "Class":"Predicate",
-    "Name":"http:\/\/schema.org\/duration-input",
+    "Name":"https://schema.org/duration-input",
     "Domain Bucket":"< 1K"
   },
   {
     "Class":"Predicate",
-    "Name":"http:\/\/schema.org\/duration-output",
+    "Name":"https://schema.org/duration-output",
     "Domain Bucket":"< 1K"
   },
   {
     "Class":"Predicate",
-    "Name":"http:\/\/schema.org\/durationOfWarranty",
+    "Name":"https://schema.org/durationOfWarranty",
     "Domain Bucket":"1K - 10K"
   },
   {
     "Class":"Predicate",
-    "Name":"http:\/\/schema.org\/durationOfWarranty-input",
+    "Name":"https://schema.org/durationOfWarranty-input",
     "Domain Bucket":"< 1K"
   },
   {
     "Class":"Predicate",
-    "Name":"http:\/\/schema.org\/durationOfWarranty-output",
+    "Name":"https://schema.org/durationOfWarranty-output",
     "Domain Bucket":"< 1K"
   },
   {
     "Class":"Predicate",
-    "Name":"http:\/\/schema.org\/duringMedia",
+    "Name":"https://schema.org/duringMedia",
     "Domain Bucket":"< 1K"
   },
   {
     "Class":"Predicate",
-    "Name":"http:\/\/schema.org\/duringMedia-input",
+    "Name":"https://schema.org/duringMedia-input",
     "Domain Bucket":"< 1K"
   },
   {
     "Class":"Predicate",
-    "Name":"http:\/\/schema.org\/duringMedia-output",
+    "Name":"https://schema.org/duringMedia-output",
     "Domain Bucket":"< 1K"
   },
   {
     "Class":"Predicate",
-    "Name":"http:\/\/schema.org\/earlyPrepaymentPenalty",
+    "Name":"https://schema.org/earlyPrepaymentPenalty",
     "Domain Bucket":"< 1K"
   },
   {
     "Class":"Predicate",
-    "Name":"http:\/\/schema.org\/earlyPrepaymentPenalty-input",
+    "Name":"https://schema.org/earlyPrepaymentPenalty-input",
     "Domain Bucket":"< 1K"
   },
   {
     "Class":"Predicate",
-    "Name":"http:\/\/schema.org\/earlyPrepaymentPenalty-output",
+    "Name":"https://schema.org/earlyPrepaymentPenalty-output",
     "Domain Bucket":"< 1K"
   },
   {
     "Class":"Predicate",
-    "Name":"http:\/\/schema.org\/editEIDR",
+    "Name":"https://schema.org/editEIDR",
     "Domain Bucket":"< 1K"
   },
   {
     "Class":"Predicate",
-    "Name":"http:\/\/schema.org\/editEIDR-input",
+    "Name":"https://schema.org/editEIDR-input",
     "Domain Bucket":"< 1K"
   },
   {
     "Class":"Predicate",
-    "Name":"http:\/\/schema.org\/editEIDR-output",
+    "Name":"https://schema.org/editEIDR-output",
     "Domain Bucket":"< 1K"
   },
   {
     "Class":"Predicate",
-    "Name":"http:\/\/schema.org\/editor",
+    "Name":"https://schema.org/editor",
     "Domain Bucket":"100K - 1M"
   },
   {
     "Class":"Predicate",
-    "Name":"http:\/\/schema.org\/editor-input",
+    "Name":"https://schema.org/editor-input",
     "Domain Bucket":"< 1K"
   },
   {
     "Class":"Predicate",
-    "Name":"http:\/\/schema.org\/editor-output",
+    "Name":"https://schema.org/editor-output",
     "Domain Bucket":"< 1K"
   },
   {
     "Class":"Predicate",
-    "Name":"http:\/\/schema.org\/eduQuestionType",
+    "Name":"https://schema.org/eduQuestionType",
     "Domain Bucket":"< 1K"
   },
   {
     "Class":"Predicate",
-    "Name":"http:\/\/schema.org\/eduQuestionType-input",
+    "Name":"https://schema.org/eduQuestionType-input",
     "Domain Bucket":"< 1K"
   },
   {
     "Class":"Predicate",
-    "Name":"http:\/\/schema.org\/eduQuestionType-output",
+    "Name":"https://schema.org/eduQuestionType-output",
     "Domain Bucket":"< 1K"
   },
   {
     "Class":"Predicate",
-    "Name":"http:\/\/schema.org\/educationRequirements",
+    "Name":"https://schema.org/educationRequirements",
     "Domain Bucket":"10K - 100K"
   },
   {
     "Class":"Predicate",
-    "Name":"http:\/\/schema.org\/educationRequirements-input",
+    "Name":"https://schema.org/educationRequirements-input",
     "Domain Bucket":"< 1K"
   },
   {
     "Class":"Predicate",
-    "Name":"http:\/\/schema.org\/educationRequirements-output",
+    "Name":"https://schema.org/educationRequirements-output",
     "Domain Bucket":"< 1K"
   },
   {
     "Class":"Predicate",
-    "Name":"http:\/\/schema.org\/educationalAlignment",
+    "Name":"https://schema.org/educationalAlignment",
     "Domain Bucket":"1K - 10K"
   },
   {
     "Class":"Predicate",
-    "Name":"http:\/\/schema.org\/educationalAlignment-input",
+    "Name":"https://schema.org/educationalAlignment-input",
     "Domain Bucket":"< 1K"
   },
   {
     "Class":"Predicate",
-    "Name":"http:\/\/schema.org\/educationalAlignment-output",
+    "Name":"https://schema.org/educationalAlignment-output",
     "Domain Bucket":"< 1K"
   },
   {
     "Class":"Predicate",
-    "Name":"http:\/\/schema.org\/educationalCredentialAwarded",
+    "Name":"https://schema.org/educationalCredentialAwarded",
     "Domain Bucket":"10K - 100K"
   },
   {
     "Class":"Predicate",
-    "Name":"http:\/\/schema.org\/educationalCredentialAwarded-input",
+    "Name":"https://schema.org/educationalCredentialAwarded-input",
     "Domain Bucket":"< 1K"
   },
   {
     "Class":"Predicate",
-    "Name":"http:\/\/schema.org\/educationalCredentialAwarded-output",
+    "Name":"https://schema.org/educationalCredentialAwarded-output",
     "Domain Bucket":"< 1K"
   },
   {
     "Class":"Predicate",
-    "Name":"http:\/\/schema.org\/educationalFramework",
+    "Name":"https://schema.org/educationalFramework",
     "Domain Bucket":"< 1K"
   },
   {
     "Class":"Predicate",
-    "Name":"http:\/\/schema.org\/educationalFramework-input",
+    "Name":"https://schema.org/educationalFramework-input",
     "Domain Bucket":"< 1K"
   },
   {
     "Class":"Predicate",
-    "Name":"http:\/\/schema.org\/educationalFramework-output",
+    "Name":"https://schema.org/educationalFramework-output",
     "Domain Bucket":"< 1K"
   },
   {
     "Class":"Predicate",
-    "Name":"http:\/\/schema.org\/educationalLevel",
+    "Name":"https://schema.org/educationalLevel",
     "Domain Bucket":"10K - 100K"
   },
   {
     "Class":"Predicate",
-    "Name":"http:\/\/schema.org\/educationalLevel-input",
+    "Name":"https://schema.org/educationalLevel-input",
     "Domain Bucket":"< 1K"
   },
   {
     "Class":"Predicate",
-    "Name":"http:\/\/schema.org\/educationalLevel-output",
+    "Name":"https://schema.org/educationalLevel-output",
     "Domain Bucket":"< 1K"
   },
   {
     "Class":"Predicate",
-    "Name":"http:\/\/schema.org\/educationalProgramMode",
+    "Name":"https://schema.org/educationalProgramMode",
     "Domain Bucket":"1K - 10K"
   },
   {
     "Class":"Predicate",
-    "Name":"http:\/\/schema.org\/educationalProgramMode-input",
+    "Name":"https://schema.org/educationalProgramMode-input",
     "Domain Bucket":"< 1K"
   },
   {
     "Class":"Predicate",
-    "Name":"http:\/\/schema.org\/educationalProgramMode-output",
+    "Name":"https://schema.org/educationalProgramMode-output",
     "Domain Bucket":"< 1K"
   },
   {
     "Class":"Predicate",
-    "Name":"http:\/\/schema.org\/educationalRole",
+    "Name":"https://schema.org/educationalRole",
     "Domain Bucket":"10K - 100K"
   },
   {
     "Class":"Predicate",
-    "Name":"http:\/\/schema.org\/educationalRole-input",
+    "Name":"https://schema.org/educationalRole-input",
     "Domain Bucket":"< 1K"
   },
   {
     "Class":"Predicate",
-    "Name":"http:\/\/schema.org\/educationalRole-output",
+    "Name":"https://schema.org/educationalRole-output",
     "Domain Bucket":"< 1K"
   },
   {
     "Class":"Predicate",
-    "Name":"http:\/\/schema.org\/educationalUse",
+    "Name":"https://schema.org/educationalUse",
     "Domain Bucket":"1K - 10K"
   },
   {
     "Class":"Predicate",
-    "Name":"http:\/\/schema.org\/educationalUse-input",
+    "Name":"https://schema.org/educationalUse-input",
     "Domain Bucket":"< 1K"
   },
   {
     "Class":"Predicate",
-    "Name":"http:\/\/schema.org\/educationalUse-output",
+    "Name":"https://schema.org/educationalUse-output",
     "Domain Bucket":"< 1K"
   },
   {
     "Class":"Predicate",
-    "Name":"http:\/\/schema.org\/elevation",
+    "Name":"https://schema.org/elevation",
     "Domain Bucket":"1K - 10K"
   },
   {
     "Class":"Predicate",
-    "Name":"http:\/\/schema.org\/elevation-input",
+    "Name":"https://schema.org/elevation-input",
     "Domain Bucket":"< 1K"
   },
   {
     "Class":"Predicate",
-    "Name":"http:\/\/schema.org\/elevation-output",
+    "Name":"https://schema.org/elevation-output",
     "Domain Bucket":"< 1K"
   },
   {
     "Class":"Predicate",
-    "Name":"http:\/\/schema.org\/eligibilityToWorkRequirement",
+    "Name":"https://schema.org/eligibilityToWorkRequirement",
     "Domain Bucket":"< 1K"
   },
   {
     "Class":"Predicate",
-    "Name":"http:\/\/schema.org\/eligibilityToWorkRequirement-input",
+    "Name":"https://schema.org/eligibilityToWorkRequirement-input",
     "Domain Bucket":"< 1K"
   },
   {
     "Class":"Predicate",
-    "Name":"http:\/\/schema.org\/eligibilityToWorkRequirement-output",
+    "Name":"https://schema.org/eligibilityToWorkRequirement-output",
     "Domain Bucket":"< 1K"
   },
   {
     "Class":"Predicate",
-    "Name":"http:\/\/schema.org\/eligibleCustomerType",
+    "Name":"https://schema.org/eligibleCustomerType",
     "Domain Bucket":"1K - 10K"
   },
   {
     "Class":"Predicate",
-    "Name":"http:\/\/schema.org\/eligibleCustomerType-input",
+    "Name":"https://schema.org/eligibleCustomerType-input",
     "Domain Bucket":"< 1K"
   },
   {
     "Class":"Predicate",
-    "Name":"http:\/\/schema.org\/eligibleCustomerType-output",
+    "Name":"https://schema.org/eligibleCustomerType-output",
     "Domain Bucket":"< 1K"
   },
   {
     "Class":"Predicate",
-    "Name":"http:\/\/schema.org\/eligibleDuration",
+    "Name":"https://schema.org/eligibleDuration",
     "Domain Bucket":"10K - 100K"
   },
   {
     "Class":"Predicate",
-    "Name":"http:\/\/schema.org\/eligibleDuration-input",
+    "Name":"https://schema.org/eligibleDuration-input",
     "Domain Bucket":"< 1K"
   },
   {
     "Class":"Predicate",
-    "Name":"http:\/\/schema.org\/eligibleDuration-output",
+    "Name":"https://schema.org/eligibleDuration-output",
     "Domain Bucket":"< 1K"
   },
   {
     "Class":"Predicate",
-    "Name":"http:\/\/schema.org\/eligibleQuantity",
+    "Name":"https://schema.org/eligibleQuantity",
     "Domain Bucket":"10K - 100K"
   },
   {
     "Class":"Predicate",
-    "Name":"http:\/\/schema.org\/eligibleQuantity-input",
+    "Name":"https://schema.org/eligibleQuantity-input",
     "Domain Bucket":"< 1K"
   },
   {
     "Class":"Predicate",
-    "Name":"http:\/\/schema.org\/eligibleQuantity-output",
+    "Name":"https://schema.org/eligibleQuantity-output",
     "Domain Bucket":"< 1K"
   },
   {
     "Class":"Predicate",
-    "Name":"http:\/\/schema.org\/eligibleRegion",
+    "Name":"https://schema.org/eligibleRegion",
     "Domain Bucket":"10K - 100K"
   },
   {
     "Class":"Predicate",
-    "Name":"http:\/\/schema.org\/eligibleRegion-input",
+    "Name":"https://schema.org/eligibleRegion-input",
     "Domain Bucket":"< 1K"
   },
   {
     "Class":"Predicate",
-    "Name":"http:\/\/schema.org\/eligibleRegion-output",
+    "Name":"https://schema.org/eligibleRegion-output",
     "Domain Bucket":"< 1K"
   },
   {
     "Class":"Predicate",
-    "Name":"http:\/\/schema.org\/eligibleTransactionVolume",
+    "Name":"https://schema.org/eligibleTransactionVolume",
     "Domain Bucket":"10K - 100K"
   },
   {
     "Class":"Predicate",
-    "Name":"http:\/\/schema.org\/eligibleTransactionVolume-input",
+    "Name":"https://schema.org/eligibleTransactionVolume-input",
     "Domain Bucket":"< 1K"
   },
   {
     "Class":"Predicate",
-    "Name":"http:\/\/schema.org\/eligibleTransactionVolume-output",
+    "Name":"https://schema.org/eligibleTransactionVolume-output",
     "Domain Bucket":"< 1K"
   },
   {
     "Class":"Predicate",
-    "Name":"http:\/\/schema.org\/eligibleWithSupplier",
+    "Name":"https://schema.org/eligibleWithSupplier",
     "Domain Bucket":"< 1K"
   },
   {
     "Class":"Predicate",
-    "Name":"http:\/\/schema.org\/eligibleWithSupplier-input",
+    "Name":"https://schema.org/eligibleWithSupplier-input",
     "Domain Bucket":"< 1K"
   },
   {
     "Class":"Predicate",
-    "Name":"http:\/\/schema.org\/eligibleWithSupplier-output",
+    "Name":"https://schema.org/eligibleWithSupplier-output",
     "Domain Bucket":"< 1K"
   },
   {
     "Class":"Predicate",
-    "Name":"http:\/\/schema.org\/email",
+    "Name":"https://schema.org/email",
     "Domain Bucket":"1M - 10M"
   },
   {
     "Class":"Predicate",
-    "Name":"http:\/\/schema.org\/email-input",
+    "Name":"https://schema.org/email-input",
     "Domain Bucket":"< 1K"
   },
   {
     "Class":"Predicate",
-    "Name":"http:\/\/schema.org\/email-output",
+    "Name":"https://schema.org/email-output",
     "Domain Bucket":"< 1K"
   },
   {
     "Class":"Predicate",
-    "Name":"http:\/\/schema.org\/embedUrl",
+    "Name":"https://schema.org/embedUrl",
     "Domain Bucket":"1M - 10M"
   },
   {
     "Class":"Predicate",
-    "Name":"http:\/\/schema.org\/embedUrl-input",
+    "Name":"https://schema.org/embedUrl-input",
     "Domain Bucket":"< 1K"
   },
   {
     "Class":"Predicate",
-    "Name":"http:\/\/schema.org\/embedUrl-output",
+    "Name":"https://schema.org/embedUrl-output",
     "Domain Bucket":"< 1K"
   },
   {
     "Class":"Predicate",
-    "Name":"http:\/\/schema.org\/embeddedTextCaption",
+    "Name":"https://schema.org/embeddedTextCaption",
     "Domain Bucket":"1K - 10K"
   },
   {
     "Class":"Predicate",
-    "Name":"http:\/\/schema.org\/embeddedTextCaption-input",
+    "Name":"https://schema.org/embeddedTextCaption-input",
     "Domain Bucket":"< 1K"
   },
   {
     "Class":"Predicate",
-    "Name":"http:\/\/schema.org\/embeddedTextCaption-output",
+    "Name":"https://schema.org/embeddedTextCaption-output",
     "Domain Bucket":"< 1K"
   },
   {
     "Class":"Predicate",
-    "Name":"http:\/\/schema.org\/emissionsCO2",
+    "Name":"https://schema.org/emissionsCO2",
     "Domain Bucket":"1K - 10K"
   },
   {
     "Class":"Predicate",
-    "Name":"http:\/\/schema.org\/emissionsCO2-input",
+    "Name":"https://schema.org/emissionsCO2-input",
     "Domain Bucket":"< 1K"
   },
   {
     "Class":"Predicate",
-    "Name":"http:\/\/schema.org\/emissionsCO2-output",
+    "Name":"https://schema.org/emissionsCO2-output",
     "Domain Bucket":"< 1K"
   },
   {
     "Class":"Predicate",
-    "Name":"http:\/\/schema.org\/employee",
+    "Name":"https://schema.org/employee",
     "Domain Bucket":"100K - 1M"
   },
   {
     "Class":"Predicate",
-    "Name":"http:\/\/schema.org\/employee-input",
+    "Name":"https://schema.org/employee-input",
     "Domain Bucket":"< 1K"
   },
   {
     "Class":"Predicate",
-    "Name":"http:\/\/schema.org\/employee-output",
+    "Name":"https://schema.org/employee-output",
     "Domain Bucket":"< 1K"
   },
   {
     "Class":"Predicate",
-    "Name":"http:\/\/schema.org\/employees",
+    "Name":"https://schema.org/employees",
     "Domain Bucket":"1K - 10K"
   },
   {
     "Class":"Predicate",
-    "Name":"http:\/\/schema.org\/employees-input",
+    "Name":"https://schema.org/employees-input",
     "Domain Bucket":"< 1K"
   },
   {
     "Class":"Predicate",
-    "Name":"http:\/\/schema.org\/employees-output",
+    "Name":"https://schema.org/employees-output",
     "Domain Bucket":"< 1K"
   },
   {
     "Class":"Predicate",
-    "Name":"http:\/\/schema.org\/employerOverview",
+    "Name":"https://schema.org/employerOverview",
     "Domain Bucket":"1K - 10K"
   },
   {
     "Class":"Predicate",
-    "Name":"http:\/\/schema.org\/employerOverview-input",
+    "Name":"https://schema.org/employerOverview-input",
     "Domain Bucket":"< 1K"
   },
   {
     "Class":"Predicate",
-    "Name":"http:\/\/schema.org\/employerOverview-output",
+    "Name":"https://schema.org/employerOverview-output",
     "Domain Bucket":"< 1K"
   },
   {
     "Class":"Predicate",
-    "Name":"http:\/\/schema.org\/employmentType",
+    "Name":"https://schema.org/employmentType",
     "Domain Bucket":"100K - 1M"
   },
   {
     "Class":"Predicate",
-    "Name":"http:\/\/schema.org\/employmentType-input",
+    "Name":"https://schema.org/employmentType-input",
     "Domain Bucket":"< 1K"
   },
   {
     "Class":"Predicate",
-    "Name":"http:\/\/schema.org\/employmentType-output",
+    "Name":"https://schema.org/employmentType-output",
     "Domain Bucket":"< 1K"
   },
   {
     "Class":"Predicate",
-    "Name":"http:\/\/schema.org\/employmentUnit",
+    "Name":"https://schema.org/employmentUnit",
     "Domain Bucket":"1K - 10K"
   },
   {
     "Class":"Predicate",
-    "Name":"http:\/\/schema.org\/employmentUnit-input",
+    "Name":"https://schema.org/employmentUnit-input",
     "Domain Bucket":"< 1K"
   },
   {
     "Class":"Predicate",
-    "Name":"http:\/\/schema.org\/employmentUnit-output",
+    "Name":"https://schema.org/employmentUnit-output",
     "Domain Bucket":"< 1K"
   },
   {
     "Class":"Predicate",
-    "Name":"http:\/\/schema.org\/encodesBioChemEntity",
+    "Name":"https://schema.org/encodesBioChemEntity",
     "Domain Bucket":"< 1K"
   },
   {
     "Class":"Predicate",
-    "Name":"http:\/\/schema.org\/encodesBioChemEntity-input",
+    "Name":"https://schema.org/encodesBioChemEntity-input",
     "Domain Bucket":"< 1K"
   },
   {
     "Class":"Predicate",
-    "Name":"http:\/\/schema.org\/encodesBioChemEntity-output",
+    "Name":"https://schema.org/encodesBioChemEntity-output",
     "Domain Bucket":"< 1K"
   },
   {
     "Class":"Predicate",
-    "Name":"http:\/\/schema.org\/encodesCreativeWork",
+    "Name":"https://schema.org/encodesCreativeWork",
     "Domain Bucket":"< 1K"
   },
   {
     "Class":"Predicate",
-    "Name":"http:\/\/schema.org\/encodesCreativeWork-input",
+    "Name":"https://schema.org/encodesCreativeWork-input",
     "Domain Bucket":"< 1K"
   },
   {
     "Class":"Predicate",
-    "Name":"http:\/\/schema.org\/encodesCreativeWork-output",
+    "Name":"https://schema.org/encodesCreativeWork-output",
     "Domain Bucket":"< 1K"
   },
   {
     "Class":"Predicate",
-    "Name":"http:\/\/schema.org\/encoding",
+    "Name":"https://schema.org/encoding",
     "Domain Bucket":"100K - 1M"
   },
   {
     "Class":"Predicate",
-    "Name":"http:\/\/schema.org\/encoding-input",
+    "Name":"https://schema.org/encoding-input",
     "Domain Bucket":"< 1K"
   },
   {
     "Class":"Predicate",
-    "Name":"http:\/\/schema.org\/encoding-output",
+    "Name":"https://schema.org/encoding-output",
     "Domain Bucket":"< 1K"
   },
   {
     "Class":"Predicate",
-    "Name":"http:\/\/schema.org\/encodingFormat",
+    "Name":"https://schema.org/encodingFormat",
     "Domain Bucket":"10K - 100K"
   },
   {
     "Class":"Predicate",
-    "Name":"http:\/\/schema.org\/encodingFormat-input",
+    "Name":"https://schema.org/encodingFormat-input",
     "Domain Bucket":"< 1K"
   },
   {
     "Class":"Predicate",
-    "Name":"http:\/\/schema.org\/encodingFormat-output",
+    "Name":"https://schema.org/encodingFormat-output",
     "Domain Bucket":"< 1K"
   },
   {
     "Class":"Predicate",
-    "Name":"http:\/\/schema.org\/encodingType",
+    "Name":"https://schema.org/encodingType",
     "Domain Bucket":"< 1K"
   },
   {
     "Class":"Predicate",
-    "Name":"http:\/\/schema.org\/encodingType-input",
+    "Name":"https://schema.org/encodingType-input",
     "Domain Bucket":"< 1K"
   },
   {
     "Class":"Predicate",
-    "Name":"http:\/\/schema.org\/encodingType-output",
+    "Name":"https://schema.org/encodingType-output",
     "Domain Bucket":"< 1K"
   },
   {
     "Class":"Predicate",
-    "Name":"http:\/\/schema.org\/encodings",
+    "Name":"https://schema.org/encodings",
     "Domain Bucket":"< 1K"
   },
   {
     "Class":"Predicate",
-    "Name":"http:\/\/schema.org\/encodings-input",
+    "Name":"https://schema.org/encodings-input",
     "Domain Bucket":"< 1K"
   },
   {
     "Class":"Predicate",
-    "Name":"http:\/\/schema.org\/encodings-output",
+    "Name":"https://schema.org/encodings-output",
     "Domain Bucket":"< 1K"
   },
   {
     "Class":"Predicate",
-    "Name":"http:\/\/schema.org\/endDate",
+    "Name":"https://schema.org/endDate",
     "Domain Bucket":"100K - 1M"
   },
   {
     "Class":"Predicate",
-    "Name":"http:\/\/schema.org\/endDate-input",
+    "Name":"https://schema.org/endDate-input",
     "Domain Bucket":"< 1K"
   },
   {
     "Class":"Predicate",
-    "Name":"http:\/\/schema.org\/endDate-output",
+    "Name":"https://schema.org/endDate-output",
     "Domain Bucket":"< 1K"
   },
   {
     "Class":"Predicate",
-    "Name":"http:\/\/schema.org\/endOffset",
+    "Name":"https://schema.org/endOffset",
     "Domain Bucket":"10K - 100K"
   },
   {
     "Class":"Predicate",
-    "Name":"http:\/\/schema.org\/endOffset-input",
+    "Name":"https://schema.org/endOffset-input",
     "Domain Bucket":"< 1K"
   },
   {
     "Class":"Predicate",
-    "Name":"http:\/\/schema.org\/endOffset-output",
+    "Name":"https://schema.org/endOffset-output",
     "Domain Bucket":"< 1K"
   },
   {
     "Class":"Predicate",
-    "Name":"http:\/\/schema.org\/endTime",
+    "Name":"https://schema.org/endTime",
     "Domain Bucket":"1K - 10K"
   },
   {
     "Class":"Predicate",
-    "Name":"http:\/\/schema.org\/endTime-input",
+    "Name":"https://schema.org/endTime-input",
     "Domain Bucket":"< 1K"
   },
   {
     "Class":"Predicate",
-    "Name":"http:\/\/schema.org\/endTime-output",
+    "Name":"https://schema.org/endTime-output",
     "Domain Bucket":"< 1K"
   },
   {
     "Class":"Predicate",
-    "Name":"http:\/\/schema.org\/endorsee",
+    "Name":"https://schema.org/endorsee",
     "Domain Bucket":"< 1K"
   },
   {
     "Class":"Predicate",
-    "Name":"http:\/\/schema.org\/endorsee-input",
+    "Name":"https://schema.org/endorsee-input",
     "Domain Bucket":"< 1K"
   },
   {
     "Class":"Predicate",
-    "Name":"http:\/\/schema.org\/endorsee-output",
+    "Name":"https://schema.org/endorsee-output",
     "Domain Bucket":"< 1K"
   },
   {
     "Class":"Predicate",
-    "Name":"http:\/\/schema.org\/endorsers",
+    "Name":"https://schema.org/endorsers",
     "Domain Bucket":"< 1K"
   },
   {
     "Class":"Predicate",
-    "Name":"http:\/\/schema.org\/endorsers-input",
+    "Name":"https://schema.org/endorsers-input",
     "Domain Bucket":"< 1K"
   },
   {
     "Class":"Predicate",
-    "Name":"http:\/\/schema.org\/endorsers-output",
+    "Name":"https://schema.org/endorsers-output",
     "Domain Bucket":"< 1K"
   },
   {
     "Class":"Predicate",
-    "Name":"http:\/\/schema.org\/energyEfficiencyScaleMax",
+    "Name":"https://schema.org/energyEfficiencyScaleMax",
     "Domain Bucket":"1K - 10K"
   },
   {
     "Class":"Predicate",
-    "Name":"http:\/\/schema.org\/energyEfficiencyScaleMax-input",
+    "Name":"https://schema.org/energyEfficiencyScaleMax-input",
     "Domain Bucket":"< 1K"
   },
   {
     "Class":"Predicate",
-    "Name":"http:\/\/schema.org\/energyEfficiencyScaleMax-output",
+    "Name":"https://schema.org/energyEfficiencyScaleMax-output",
     "Domain Bucket":"< 1K"
   },
   {
     "Class":"Predicate",
-    "Name":"http:\/\/schema.org\/energyEfficiencyScaleMin",
+    "Name":"https://schema.org/energyEfficiencyScaleMin",
     "Domain Bucket":"1K - 10K"
   },
   {
     "Class":"Predicate",
-    "Name":"http:\/\/schema.org\/energyEfficiencyScaleMin-input",
+    "Name":"https://schema.org/energyEfficiencyScaleMin-input",
     "Domain Bucket":"< 1K"
   },
   {
     "Class":"Predicate",
-    "Name":"http:\/\/schema.org\/energyEfficiencyScaleMin-output",
+    "Name":"https://schema.org/energyEfficiencyScaleMin-output",
     "Domain Bucket":"< 1K"
   },
   {
     "Class":"Predicate",
-    "Name":"http:\/\/schema.org\/engineDisplacement",
+    "Name":"https://schema.org/engineDisplacement",
     "Domain Bucket":"10K - 100K"
   },
   {
     "Class":"Predicate",
-    "Name":"http:\/\/schema.org\/engineDisplacement-input",
+    "Name":"https://schema.org/engineDisplacement-input",
     "Domain Bucket":"< 1K"
   },
   {
     "Class":"Predicate",
-    "Name":"http:\/\/schema.org\/engineDisplacement-output",
+    "Name":"https://schema.org/engineDisplacement-output",
     "Domain Bucket":"< 1K"
   },
   {
     "Class":"Predicate",
-    "Name":"http:\/\/schema.org\/enginePower",
+    "Name":"https://schema.org/enginePower",
     "Domain Bucket":"10K - 100K"
   },
   {
     "Class":"Predicate",
-    "Name":"http:\/\/schema.org\/enginePower-input",
+    "Name":"https://schema.org/enginePower-input",
     "Domain Bucket":"< 1K"
   },
   {
     "Class":"Predicate",
-    "Name":"http:\/\/schema.org\/enginePower-output",
+    "Name":"https://schema.org/enginePower-output",
     "Domain Bucket":"< 1K"
   },
   {
     "Class":"Predicate",
-    "Name":"http:\/\/schema.org\/engineType",
+    "Name":"https://schema.org/engineType",
     "Domain Bucket":"1K - 10K"
   },
   {
     "Class":"Predicate",
-    "Name":"http:\/\/schema.org\/engineType-input",
+    "Name":"https://schema.org/engineType-input",
     "Domain Bucket":"< 1K"
   },
   {
     "Class":"Predicate",
-    "Name":"http:\/\/schema.org\/engineType-output",
+    "Name":"https://schema.org/engineType-output",
     "Domain Bucket":"< 1K"
   },
   {
     "Class":"Predicate",
-    "Name":"http:\/\/schema.org\/entertainmentBusiness",
+    "Name":"https://schema.org/entertainmentBusiness",
     "Domain Bucket":"< 1K"
   },
   {
     "Class":"Predicate",
-    "Name":"http:\/\/schema.org\/entertainmentBusiness-input",
+    "Name":"https://schema.org/entertainmentBusiness-input",
     "Domain Bucket":"< 1K"
   },
   {
     "Class":"Predicate",
-    "Name":"http:\/\/schema.org\/entertainmentBusiness-output",
+    "Name":"https://schema.org/entertainmentBusiness-output",
     "Domain Bucket":"< 1K"
   },
   {
     "Class":"Predicate",
-    "Name":"http:\/\/schema.org\/epidemiology",
+    "Name":"https://schema.org/epidemiology",
     "Domain Bucket":"< 1K"
   },
   {
     "Class":"Predicate",
-    "Name":"http:\/\/schema.org\/epidemiology-input",
+    "Name":"https://schema.org/epidemiology-input",
     "Domain Bucket":"< 1K"
   },
   {
     "Class":"Predicate",
-    "Name":"http:\/\/schema.org\/epidemiology-output",
+    "Name":"https://schema.org/epidemiology-output",
     "Domain Bucket":"< 1K"
   },
   {
     "Class":"Predicate",
-    "Name":"http:\/\/schema.org\/episode",
+    "Name":"https://schema.org/episode",
     "Domain Bucket":"1K - 10K"
   },
   {
     "Class":"Predicate",
-    "Name":"http:\/\/schema.org\/episode-input",
+    "Name":"https://schema.org/episode-input",
     "Domain Bucket":"< 1K"
   },
   {
     "Class":"Predicate",
-    "Name":"http:\/\/schema.org\/episode-output",
+    "Name":"https://schema.org/episode-output",
     "Domain Bucket":"< 1K"
   },
   {
     "Class":"Predicate",
-    "Name":"http:\/\/schema.org\/episodeNumber",
+    "Name":"https://schema.org/episodeNumber",
     "Domain Bucket":"10K - 100K"
   },
   {
     "Class":"Predicate",
-    "Name":"http:\/\/schema.org\/episodeNumber-input",
+    "Name":"https://schema.org/episodeNumber-input",
     "Domain Bucket":"< 1K"
   },
   {
     "Class":"Predicate",
-    "Name":"http:\/\/schema.org\/episodeNumber-output",
+    "Name":"https://schema.org/episodeNumber-output",
     "Domain Bucket":"< 1K"
   },
   {
     "Class":"Predicate",
-    "Name":"http:\/\/schema.org\/episodes",
+    "Name":"https://schema.org/episodes",
     "Domain Bucket":"< 1K"
   },
   {
     "Class":"Predicate",
-    "Name":"http:\/\/schema.org\/episodes-input",
+    "Name":"https://schema.org/episodes-input",
     "Domain Bucket":"< 1K"
   },
   {
     "Class":"Predicate",
-    "Name":"http:\/\/schema.org\/episodes-output",
+    "Name":"https://schema.org/episodes-output",
     "Domain Bucket":"< 1K"
   },
   {
     "Class":"Predicate",
-    "Name":"http:\/\/schema.org\/equal",
+    "Name":"https://schema.org/equal",
     "Domain Bucket":"< 1K"
   },
   {
     "Class":"Predicate",
-    "Name":"http:\/\/schema.org\/equal-input",
+    "Name":"https://schema.org/equal-input",
     "Domain Bucket":"< 1K"
   },
   {
     "Class":"Predicate",
-    "Name":"http:\/\/schema.org\/equal-output",
+    "Name":"https://schema.org/equal-output",
     "Domain Bucket":"< 1K"
   },
   {
     "Class":"Predicate",
-    "Name":"http:\/\/schema.org\/error",
+    "Name":"https://schema.org/error",
     "Domain Bucket":"1K - 10K"
   },
   {
     "Class":"Predicate",
-    "Name":"http:\/\/schema.org\/error-input",
+    "Name":"https://schema.org/error-input",
     "Domain Bucket":"< 1K"
   },
   {
     "Class":"Predicate",
-    "Name":"http:\/\/schema.org\/error-output",
+    "Name":"https://schema.org/error-output",
     "Domain Bucket":"< 1K"
   },
   {
     "Class":"Predicate",
-    "Name":"http:\/\/schema.org\/errorCode",
+    "Name":"https://schema.org/errorCode",
     "Domain Bucket":"< 1K"
   },
   {
     "Class":"Predicate",
-    "Name":"http:\/\/schema.org\/errorCode-input",
+    "Name":"https://schema.org/errorCode-input",
     "Domain Bucket":"< 1K"
   },
   {
     "Class":"Predicate",
-    "Name":"http:\/\/schema.org\/errorCode-output",
+    "Name":"https://schema.org/errorCode-output",
     "Domain Bucket":"< 1K"
   },
   {
     "Class":"Predicate",
-    "Name":"http:\/\/schema.org\/estimatedCost",
+    "Name":"https://schema.org/estimatedCost",
     "Domain Bucket":"10K - 100K"
   },
   {
     "Class":"Predicate",
-    "Name":"http:\/\/schema.org\/estimatedCost-input",
+    "Name":"https://schema.org/estimatedCost-input",
     "Domain Bucket":"< 1K"
   },
   {
     "Class":"Predicate",
-    "Name":"http:\/\/schema.org\/estimatedCost-output",
+    "Name":"https://schema.org/estimatedCost-output",
     "Domain Bucket":"< 1K"
   },
   {
     "Class":"Predicate",
-    "Name":"http:\/\/schema.org\/estimatedFlightDuration",
+    "Name":"https://schema.org/estimatedFlightDuration",
     "Domain Bucket":"< 1K"
   },
   {
     "Class":"Predicate",
-    "Name":"http:\/\/schema.org\/estimatedFlightDuration-input",
+    "Name":"https://schema.org/estimatedFlightDuration-input",
     "Domain Bucket":"< 1K"
   },
   {
     "Class":"Predicate",
-    "Name":"http:\/\/schema.org\/estimatedFlightDuration-output",
+    "Name":"https://schema.org/estimatedFlightDuration-output",
     "Domain Bucket":"< 1K"
   },
   {
     "Class":"Predicate",
-    "Name":"http:\/\/schema.org\/estimatedSalary",
+    "Name":"https://schema.org/estimatedSalary",
     "Domain Bucket":"1K - 10K"
   },
   {
     "Class":"Predicate",
-    "Name":"http:\/\/schema.org\/estimatedSalary-input",
+    "Name":"https://schema.org/estimatedSalary-input",
     "Domain Bucket":"< 1K"
   },
   {
     "Class":"Predicate",
-    "Name":"http:\/\/schema.org\/estimatedSalary-output",
+    "Name":"https://schema.org/estimatedSalary-output",
     "Domain Bucket":"< 1K"
   },
   {
     "Class":"Predicate",
-    "Name":"http:\/\/schema.org\/estimatesRiskOf",
+    "Name":"https://schema.org/estimatesRiskOf",
     "Domain Bucket":"< 1K"
   },
   {
     "Class":"Predicate",
-    "Name":"http:\/\/schema.org\/estimatesRiskOf-input",
+    "Name":"https://schema.org/estimatesRiskOf-input",
     "Domain Bucket":"< 1K"
   },
   {
     "Class":"Predicate",
-    "Name":"http:\/\/schema.org\/estimatesRiskOf-output",
+    "Name":"https://schema.org/estimatesRiskOf-output",
     "Domain Bucket":"< 1K"
   },
   {
     "Class":"Predicate",
-    "Name":"http:\/\/schema.org\/ethicsPolicy",
+    "Name":"https://schema.org/ethicsPolicy",
     "Domain Bucket":"10K - 100K"
   },
   {
     "Class":"Predicate",
-    "Name":"http:\/\/schema.org\/ethicsPolicy-input",
+    "Name":"https://schema.org/ethicsPolicy-input",
     "Domain Bucket":"< 1K"
   },
   {
     "Class":"Predicate",
-    "Name":"http:\/\/schema.org\/ethicsPolicy-output",
+    "Name":"https://schema.org/ethicsPolicy-output",
     "Domain Bucket":"< 1K"
   },
   {
     "Class":"Predicate",
-    "Name":"http:\/\/schema.org\/event",
+    "Name":"https://schema.org/event",
     "Domain Bucket":"10K - 100K"
   },
   {
     "Class":"Predicate",
-    "Name":"http:\/\/schema.org\/event-input",
+    "Name":"https://schema.org/event-input",
     "Domain Bucket":"< 1K"
   },
   {
     "Class":"Predicate",
-    "Name":"http:\/\/schema.org\/event-output",
+    "Name":"https://schema.org/event-output",
     "Domain Bucket":"< 1K"
   },
   {
     "Class":"Predicate",
-    "Name":"http:\/\/schema.org\/eventAttendanceMode",
+    "Name":"https://schema.org/eventAttendanceMode",
     "Domain Bucket":"100K - 1M"
   },
   {
     "Class":"Predicate",
-    "Name":"http:\/\/schema.org\/eventAttendanceMode-input",
+    "Name":"https://schema.org/eventAttendanceMode-input",
     "Domain Bucket":"< 1K"
   },
   {
     "Class":"Predicate",
-    "Name":"http:\/\/schema.org\/eventAttendanceMode-output",
+    "Name":"https://schema.org/eventAttendanceMode-output",
     "Domain Bucket":"< 1K"
   },
   {
     "Class":"Predicate",
-    "Name":"http:\/\/schema.org\/eventSchedule",
+    "Name":"https://schema.org/eventSchedule",
     "Domain Bucket":"1K - 10K"
   },
   {
     "Class":"Predicate",
-    "Name":"http:\/\/schema.org\/eventSchedule-input",
+    "Name":"https://schema.org/eventSchedule-input",
     "Domain Bucket":"< 1K"
   },
   {
     "Class":"Predicate",
-    "Name":"http:\/\/schema.org\/eventSchedule-output",
+    "Name":"https://schema.org/eventSchedule-output",
     "Domain Bucket":"< 1K"
   },
   {
     "Class":"Predicate",
-    "Name":"http:\/\/schema.org\/eventStatus",
+    "Name":"https://schema.org/eventStatus",
     "Domain Bucket":"100K - 1M"
   },
   {
     "Class":"Predicate",
-    "Name":"http:\/\/schema.org\/eventStatus-input",
+    "Name":"https://schema.org/eventStatus-input",
     "Domain Bucket":"< 1K"
   },
   {
     "Class":"Predicate",
-    "Name":"http:\/\/schema.org\/eventStatus-output",
+    "Name":"https://schema.org/eventStatus-output",
     "Domain Bucket":"< 1K"
   },
   {
     "Class":"Predicate",
-    "Name":"http:\/\/schema.org\/events",
+    "Name":"https://schema.org/events",
     "Domain Bucket":"1K - 10K"
   },
   {
     "Class":"Predicate",
-    "Name":"http:\/\/schema.org\/events-input",
+    "Name":"https://schema.org/events-input",
     "Domain Bucket":"< 1K"
   },
   {
     "Class":"Predicate",
-    "Name":"http:\/\/schema.org\/events-output",
+    "Name":"https://schema.org/events-output",
     "Domain Bucket":"< 1K"
   },
   {
     "Class":"Predicate",
-    "Name":"http:\/\/schema.org\/evidenceLevel",
+    "Name":"https://schema.org/evidenceLevel",
     "Domain Bucket":"< 1K"
   },
   {
     "Class":"Predicate",
-    "Name":"http:\/\/schema.org\/evidenceLevel-input",
+    "Name":"https://schema.org/evidenceLevel-input",
     "Domain Bucket":"< 1K"
   },
   {
     "Class":"Predicate",
-    "Name":"http:\/\/schema.org\/evidenceLevel-output",
+    "Name":"https://schema.org/evidenceLevel-output",
     "Domain Bucket":"< 1K"
   },
   {
     "Class":"Predicate",
-    "Name":"http:\/\/schema.org\/evidenceOrigin",
+    "Name":"https://schema.org/evidenceOrigin",
     "Domain Bucket":"< 1K"
   },
   {
     "Class":"Predicate",
-    "Name":"http:\/\/schema.org\/evidenceOrigin-input",
+    "Name":"https://schema.org/evidenceOrigin-input",
     "Domain Bucket":"< 1K"
   },
   {
     "Class":"Predicate",
-    "Name":"http:\/\/schema.org\/evidenceOrigin-output",
+    "Name":"https://schema.org/evidenceOrigin-output",
     "Domain Bucket":"< 1K"
   },
   {
     "Class":"Predicate",
-    "Name":"http:\/\/schema.org\/exampleOfWork",
+    "Name":"https://schema.org/exampleOfWork",
     "Domain Bucket":"1K - 10K"
   },
   {
     "Class":"Predicate",
-    "Name":"http:\/\/schema.org\/exampleOfWork-input",
+    "Name":"https://schema.org/exampleOfWork-input",
     "Domain Bucket":"< 1K"
   },
   {
     "Class":"Predicate",
-    "Name":"http:\/\/schema.org\/exampleOfWork-output",
+    "Name":"https://schema.org/exampleOfWork-output",
     "Domain Bucket":"< 1K"
   },
   {
     "Class":"Predicate",
-    "Name":"http:\/\/schema.org\/exceptDate",
+    "Name":"https://schema.org/exceptDate",
     "Domain Bucket":"< 1K"
   },
   {
     "Class":"Predicate",
-    "Name":"http:\/\/schema.org\/exceptDate-input",
+    "Name":"https://schema.org/exceptDate-input",
     "Domain Bucket":"< 1K"
   },
   {
     "Class":"Predicate",
-    "Name":"http:\/\/schema.org\/exceptDate-output",
+    "Name":"https://schema.org/exceptDate-output",
     "Domain Bucket":"< 1K"
   },
   {
     "Class":"Predicate",
-    "Name":"http:\/\/schema.org\/exchangeRateSpread",
+    "Name":"https://schema.org/exchangeRateSpread",
     "Domain Bucket":"< 1K"
   },
   {
     "Class":"Predicate",
-    "Name":"http:\/\/schema.org\/exchangeRateSpread-input",
+    "Name":"https://schema.org/exchangeRateSpread-input",
     "Domain Bucket":"< 1K"
   },
   {
     "Class":"Predicate",
-    "Name":"http:\/\/schema.org\/exchangeRateSpread-output",
+    "Name":"https://schema.org/exchangeRateSpread-output",
     "Domain Bucket":"< 1K"
   },
   {
     "Class":"Predicate",
-    "Name":"http:\/\/schema.org\/executableLibraryName",
+    "Name":"https://schema.org/executableLibraryName",
     "Domain Bucket":"< 1K"
   },
   {
     "Class":"Predicate",
-    "Name":"http:\/\/schema.org\/executableLibraryName-input",
+    "Name":"https://schema.org/executableLibraryName-input",
     "Domain Bucket":"< 1K"
   },
   {
     "Class":"Predicate",
-    "Name":"http:\/\/schema.org\/executableLibraryName-output",
+    "Name":"https://schema.org/executableLibraryName-output",
     "Domain Bucket":"< 1K"
   },
   {
     "Class":"Predicate",
-    "Name":"http:\/\/schema.org\/exerciseCourse",
+    "Name":"https://schema.org/exerciseCourse",
     "Domain Bucket":"< 1K"
   },
   {
     "Class":"Predicate",
-    "Name":"http:\/\/schema.org\/exerciseCourse-input",
+    "Name":"https://schema.org/exerciseCourse-input",
     "Domain Bucket":"< 1K"
   },
   {
     "Class":"Predicate",
-    "Name":"http:\/\/schema.org\/exerciseCourse-output",
+    "Name":"https://schema.org/exerciseCourse-output",
     "Domain Bucket":"< 1K"
   },
   {
     "Class":"Predicate",
-    "Name":"http:\/\/schema.org\/exercisePlan",
+    "Name":"https://schema.org/exercisePlan",
     "Domain Bucket":"< 1K"
   },
   {
     "Class":"Predicate",
-    "Name":"http:\/\/schema.org\/exercisePlan-input",
+    "Name":"https://schema.org/exercisePlan-input",
     "Domain Bucket":"< 1K"
   },
   {
     "Class":"Predicate",
-    "Name":"http:\/\/schema.org\/exercisePlan-output",
+    "Name":"https://schema.org/exercisePlan-output",
     "Domain Bucket":"< 1K"
   },
   {
     "Class":"Predicate",
-    "Name":"http:\/\/schema.org\/exerciseRelatedDiet",
+    "Name":"https://schema.org/exerciseRelatedDiet",
     "Domain Bucket":"< 1K"
   },
   {
     "Class":"Predicate",
-    "Name":"http:\/\/schema.org\/exerciseRelatedDiet-input",
+    "Name":"https://schema.org/exerciseRelatedDiet-input",
     "Domain Bucket":"< 1K"
   },
   {
     "Class":"Predicate",
-    "Name":"http:\/\/schema.org\/exerciseRelatedDiet-output",
+    "Name":"https://schema.org/exerciseRelatedDiet-output",
     "Domain Bucket":"< 1K"
   },
   {
     "Class":"Predicate",
-    "Name":"http:\/\/schema.org\/exerciseType",
+    "Name":"https://schema.org/exerciseType",
     "Domain Bucket":"< 1K"
   },
   {
     "Class":"Predicate",
-    "Name":"http:\/\/schema.org\/exerciseType-input",
+    "Name":"https://schema.org/exerciseType-input",
     "Domain Bucket":"< 1K"
   },
   {
     "Class":"Predicate",
-    "Name":"http:\/\/schema.org\/exerciseType-output",
+    "Name":"https://schema.org/exerciseType-output",
     "Domain Bucket":"< 1K"
   },
   {
     "Class":"Predicate",
-    "Name":"http:\/\/schema.org\/exifData",
+    "Name":"https://schema.org/exifData",
     "Domain Bucket":"1K - 10K"
   },
   {
     "Class":"Predicate",
-    "Name":"http:\/\/schema.org\/exifData-input",
+    "Name":"https://schema.org/exifData-input",
     "Domain Bucket":"< 1K"
   },
   {
     "Class":"Predicate",
-    "Name":"http:\/\/schema.org\/exifData-output",
+    "Name":"https://schema.org/exifData-output",
     "Domain Bucket":"< 1K"
   },
   {
     "Class":"Predicate",
-    "Name":"http:\/\/schema.org\/expectedArrivalFrom",
+    "Name":"https://schema.org/expectedArrivalFrom",
     "Domain Bucket":"< 1K"
   },
   {
     "Class":"Predicate",
-    "Name":"http:\/\/schema.org\/expectedArrivalFrom-input",
+    "Name":"https://schema.org/expectedArrivalFrom-input",
     "Domain Bucket":"< 1K"
   },
   {
     "Class":"Predicate",
-    "Name":"http:\/\/schema.org\/expectedArrivalFrom-output",
+    "Name":"https://schema.org/expectedArrivalFrom-output",
     "Domain Bucket":"< 1K"
   },
   {
     "Class":"Predicate",
-    "Name":"http:\/\/schema.org\/expectedArrivalUntil",
+    "Name":"https://schema.org/expectedArrivalUntil",
     "Domain Bucket":"< 1K"
   },
   {
     "Class":"Predicate",
-    "Name":"http:\/\/schema.org\/expectedArrivalUntil-input",
+    "Name":"https://schema.org/expectedArrivalUntil-input",
     "Domain Bucket":"< 1K"
   },
   {
     "Class":"Predicate",
-    "Name":"http:\/\/schema.org\/expectedArrivalUntil-output",
+    "Name":"https://schema.org/expectedArrivalUntil-output",
     "Domain Bucket":"< 1K"
   },
   {
     "Class":"Predicate",
-    "Name":"http:\/\/schema.org\/expectedPrognosis",
+    "Name":"https://schema.org/expectedPrognosis",
     "Domain Bucket":"< 1K"
   },
   {
     "Class":"Predicate",
-    "Name":"http:\/\/schema.org\/expectedPrognosis-input",
+    "Name":"https://schema.org/expectedPrognosis-input",
     "Domain Bucket":"< 1K"
   },
   {
     "Class":"Predicate",
-    "Name":"http:\/\/schema.org\/expectedPrognosis-output",
+    "Name":"https://schema.org/expectedPrognosis-output",
     "Domain Bucket":"< 1K"
   },
   {
     "Class":"Predicate",
-    "Name":"http:\/\/schema.org\/expectsAcceptanceOf",
+    "Name":"https://schema.org/expectsAcceptanceOf",
     "Domain Bucket":"1K - 10K"
   },
   {
     "Class":"Predicate",
-    "Name":"http:\/\/schema.org\/expectsAcceptanceOf-input",
+    "Name":"https://schema.org/expectsAcceptanceOf-input",
     "Domain Bucket":"< 1K"
   },
   {
     "Class":"Predicate",
-    "Name":"http:\/\/schema.org\/expectsAcceptanceOf-output",
+    "Name":"https://schema.org/expectsAcceptanceOf-output",
     "Domain Bucket":"< 1K"
   },
   {
     "Class":"Predicate",
-    "Name":"http:\/\/schema.org\/experienceInPlaceOfEducation",
+    "Name":"https://schema.org/experienceInPlaceOfEducation",
     "Domain Bucket":"1K - 10K"
   },
   {
     "Class":"Predicate",
-    "Name":"http:\/\/schema.org\/experienceInPlaceOfEducation-input",
+    "Name":"https://schema.org/experienceInPlaceOfEducation-input",
     "Domain Bucket":"< 1K"
   },
   {
     "Class":"Predicate",
-    "Name":"http:\/\/schema.org\/experienceInPlaceOfEducation-output",
+    "Name":"https://schema.org/experienceInPlaceOfEducation-output",
     "Domain Bucket":"< 1K"
   },
   {
     "Class":"Predicate",
-    "Name":"http:\/\/schema.org\/experienceRequirements",
+    "Name":"https://schema.org/experienceRequirements",
     "Domain Bucket":"10K - 100K"
   },
   {
     "Class":"Predicate",
-    "Name":"http:\/\/schema.org\/experienceRequirements-input",
+    "Name":"https://schema.org/experienceRequirements-input",
     "Domain Bucket":"< 1K"
   },
   {
     "Class":"Predicate",
-    "Name":"http:\/\/schema.org\/experienceRequirements-output",
+    "Name":"https://schema.org/experienceRequirements-output",
     "Domain Bucket":"< 1K"
   },
   {
     "Class":"Predicate",
-    "Name":"http:\/\/schema.org\/expertConsiderations",
+    "Name":"https://schema.org/expertConsiderations",
     "Domain Bucket":"< 1K"
   },
   {
     "Class":"Predicate",
-    "Name":"http:\/\/schema.org\/expertConsiderations-input",
+    "Name":"https://schema.org/expertConsiderations-input",
     "Domain Bucket":"< 1K"
   },
   {
     "Class":"Predicate",
-    "Name":"http:\/\/schema.org\/expertConsiderations-output",
+    "Name":"https://schema.org/expertConsiderations-output",
     "Domain Bucket":"< 1K"
   },
   {
     "Class":"Predicate",
-    "Name":"http:\/\/schema.org\/expires",
+    "Name":"https://schema.org/expires",
     "Domain Bucket":"1K - 10K"
   },
   {
     "Class":"Predicate",
-    "Name":"http:\/\/schema.org\/expires-input",
+    "Name":"https://schema.org/expires-input",
     "Domain Bucket":"< 1K"
   },
   {
     "Class":"Predicate",
-    "Name":"http:\/\/schema.org\/expires-output",
+    "Name":"https://schema.org/expires-output",
     "Domain Bucket":"< 1K"
   },
   {
     "Class":"Predicate",
-    "Name":"http:\/\/schema.org\/expressedIn",
+    "Name":"https://schema.org/expressedIn",
     "Domain Bucket":"< 1K"
   },
   {
     "Class":"Predicate",
-    "Name":"http:\/\/schema.org\/expressedIn-input",
+    "Name":"https://schema.org/expressedIn-input",
     "Domain Bucket":"< 1K"
   },
   {
     "Class":"Predicate",
-    "Name":"http:\/\/schema.org\/expressedIn-output",
+    "Name":"https://schema.org/expressedIn-output",
     "Domain Bucket":"< 1K"
   },
   {
     "Class":"Predicate",
-    "Name":"http:\/\/schema.org\/extendedAddress",
+    "Name":"https://schema.org/extendedAddress",
     "Domain Bucket":"< 1K"
   },
   {
     "Class":"Predicate",
-    "Name":"http:\/\/schema.org\/extendedAddress-input",
+    "Name":"https://schema.org/extendedAddress-input",
     "Domain Bucket":"< 1K"
   },
   {
     "Class":"Predicate",
-    "Name":"http:\/\/schema.org\/extendedAddress-output",
+    "Name":"https://schema.org/extendedAddress-output",
     "Domain Bucket":"< 1K"
   },
   {
     "Class":"Predicate",
-    "Name":"http:\/\/schema.org\/familyName",
+    "Name":"https://schema.org/familyName",
     "Domain Bucket":"100K - 1M"
   },
   {
     "Class":"Predicate",
-    "Name":"http:\/\/schema.org\/familyName-input",
+    "Name":"https://schema.org/familyName-input",
     "Domain Bucket":"< 1K"
   },
   {
     "Class":"Predicate",
-    "Name":"http:\/\/schema.org\/familyName-output",
+    "Name":"https://schema.org/familyName-output",
     "Domain Bucket":"< 1K"
   },
   {
     "Class":"Predicate",
-    "Name":"http:\/\/schema.org\/fatContent",
+    "Name":"https://schema.org/fatContent",
     "Domain Bucket":"10K - 100K"
   },
   {
     "Class":"Predicate",
-    "Name":"http:\/\/schema.org\/fatContent-input",
+    "Name":"https://schema.org/fatContent-input",
     "Domain Bucket":"< 1K"
   },
   {
     "Class":"Predicate",
-    "Name":"http:\/\/schema.org\/fatContent-output",
+    "Name":"https://schema.org/fatContent-output",
     "Domain Bucket":"< 1K"
   },
   {
     "Class":"Predicate",
-    "Name":"http:\/\/schema.org\/faxNumber",
+    "Name":"https://schema.org/faxNumber",
     "Domain Bucket":"100K - 1M"
   },
   {
     "Class":"Predicate",
-    "Name":"http:\/\/schema.org\/faxNumber-input",
+    "Name":"https://schema.org/faxNumber-input",
     "Domain Bucket":"< 1K"
   },
   {
     "Class":"Predicate",
-    "Name":"http:\/\/schema.org\/faxNumber-output",
+    "Name":"https://schema.org/faxNumber-output",
     "Domain Bucket":"< 1K"
   },
   {
     "Class":"Predicate",
-    "Name":"http:\/\/schema.org\/featureList",
+    "Name":"https://schema.org/featureList",
     "Domain Bucket":"100K - 1M"
   },
   {
     "Class":"Predicate",
-    "Name":"http:\/\/schema.org\/featureList-input",
+    "Name":"https://schema.org/featureList-input",
     "Domain Bucket":"< 1K"
   },
   {
     "Class":"Predicate",
-    "Name":"http:\/\/schema.org\/featureList-output",
+    "Name":"https://schema.org/featureList-output",
     "Domain Bucket":"< 1K"
   },
   {
     "Class":"Predicate",
-    "Name":"http:\/\/schema.org\/feesAndCommissionsSpecification",
+    "Name":"https://schema.org/feesAndCommissionsSpecification",
     "Domain Bucket":"1K - 10K"
   },
   {
     "Class":"Predicate",
-    "Name":"http:\/\/schema.org\/feesAndCommissionsSpecification-input",
+    "Name":"https://schema.org/feesAndCommissionsSpecification-input",
     "Domain Bucket":"< 1K"
   },
   {
     "Class":"Predicate",
-    "Name":"http:\/\/schema.org\/feesAndCommissionsSpecification-output",
+    "Name":"https://schema.org/feesAndCommissionsSpecification-output",
     "Domain Bucket":"< 1K"
   },
   {
     "Class":"Predicate",
-    "Name":"http:\/\/schema.org\/fiberContent",
+    "Name":"https://schema.org/fiberContent",
     "Domain Bucket":"10K - 100K"
   },
   {
     "Class":"Predicate",
-    "Name":"http:\/\/schema.org\/fiberContent-input",
+    "Name":"https://schema.org/fiberContent-input",
     "Domain Bucket":"< 1K"
   },
   {
     "Class":"Predicate",
-    "Name":"http:\/\/schema.org\/fiberContent-output",
+    "Name":"https://schema.org/fiberContent-output",
     "Domain Bucket":"< 1K"
   },
   {
     "Class":"Predicate",
-    "Name":"http:\/\/schema.org\/fileFormat",
+    "Name":"https://schema.org/fileFormat",
     "Domain Bucket":"10K - 100K"
   },
   {
     "Class":"Predicate",
-    "Name":"http:\/\/schema.org\/fileFormat-input",
+    "Name":"https://schema.org/fileFormat-input",
     "Domain Bucket":"< 1K"
   },
   {
     "Class":"Predicate",
-    "Name":"http:\/\/schema.org\/fileFormat-output",
+    "Name":"https://schema.org/fileFormat-output",
     "Domain Bucket":"< 1K"
   },
   {
     "Class":"Predicate",
-    "Name":"http:\/\/schema.org\/fileSize",
+    "Name":"https://schema.org/fileSize",
     "Domain Bucket":"10K - 100K"
   },
   {
     "Class":"Predicate",
-    "Name":"http:\/\/schema.org\/fileSize-input",
+    "Name":"https://schema.org/fileSize-input",
     "Domain Bucket":"< 1K"
   },
   {
     "Class":"Predicate",
-    "Name":"http:\/\/schema.org\/fileSize-output",
+    "Name":"https://schema.org/fileSize-output",
     "Domain Bucket":"< 1K"
   },
   {
     "Class":"Predicate",
-    "Name":"http:\/\/schema.org\/financialAidEligible",
+    "Name":"https://schema.org/financialAidEligible",
     "Domain Bucket":"< 1K"
   },
   {
     "Class":"Predicate",
-    "Name":"http:\/\/schema.org\/financialAidEligible-input",
+    "Name":"https://schema.org/financialAidEligible-input",
     "Domain Bucket":"< 1K"
   },
   {
     "Class":"Predicate",
-    "Name":"http:\/\/schema.org\/financialAidEligible-output",
+    "Name":"https://schema.org/financialAidEligible-output",
     "Domain Bucket":"< 1K"
   },
   {
     "Class":"Predicate",
-    "Name":"http:\/\/schema.org\/firstAppearance",
+    "Name":"https://schema.org/firstAppearance",
     "Domain Bucket":"< 1K"
   },
   {
     "Class":"Predicate",
-    "Name":"http:\/\/schema.org\/firstAppearance-input",
+    "Name":"https://schema.org/firstAppearance-input",
     "Domain Bucket":"< 1K"
   },
   {
     "Class":"Predicate",
-    "Name":"http:\/\/schema.org\/firstAppearance-output",
+    "Name":"https://schema.org/firstAppearance-output",
     "Domain Bucket":"< 1K"
   },
   {
     "Class":"Predicate",
-    "Name":"http:\/\/schema.org\/firstPerformance",
+    "Name":"https://schema.org/firstPerformance",
     "Domain Bucket":"< 1K"
   },
   {
     "Class":"Predicate",
-    "Name":"http:\/\/schema.org\/firstPerformance-input",
+    "Name":"https://schema.org/firstPerformance-input",
     "Domain Bucket":"< 1K"
   },
   {
     "Class":"Predicate",
-    "Name":"http:\/\/schema.org\/firstPerformance-output",
+    "Name":"https://schema.org/firstPerformance-output",
     "Domain Bucket":"< 1K"
   },
   {
     "Class":"Predicate",
-    "Name":"http:\/\/schema.org\/flightDistance",
+    "Name":"https://schema.org/flightDistance",
     "Domain Bucket":"< 1K"
   },
   {
     "Class":"Predicate",
-    "Name":"http:\/\/schema.org\/flightDistance-input",
+    "Name":"https://schema.org/flightDistance-input",
     "Domain Bucket":"< 1K"
   },
   {
     "Class":"Predicate",
-    "Name":"http:\/\/schema.org\/flightDistance-output",
+    "Name":"https://schema.org/flightDistance-output",
     "Domain Bucket":"< 1K"
   },
   {
     "Class":"Predicate",
-    "Name":"http:\/\/schema.org\/flightNumber",
+    "Name":"https://schema.org/flightNumber",
     "Domain Bucket":"< 1K"
   },
   {
     "Class":"Predicate",
-    "Name":"http:\/\/schema.org\/flightNumber-input",
+    "Name":"https://schema.org/flightNumber-input",
     "Domain Bucket":"< 1K"
   },
   {
     "Class":"Predicate",
-    "Name":"http:\/\/schema.org\/flightNumber-output",
+    "Name":"https://schema.org/flightNumber-output",
     "Domain Bucket":"< 1K"
   },
   {
     "Class":"Predicate",
-    "Name":"http:\/\/schema.org\/floorLevel",
+    "Name":"https://schema.org/floorLevel",
     "Domain Bucket":"1K - 10K"
   },
   {
     "Class":"Predicate",
-    "Name":"http:\/\/schema.org\/floorLevel-input",
+    "Name":"https://schema.org/floorLevel-input",
     "Domain Bucket":"< 1K"
   },
   {
     "Class":"Predicate",
-    "Name":"http:\/\/schema.org\/floorLevel-output",
+    "Name":"https://schema.org/floorLevel-output",
     "Domain Bucket":"< 1K"
   },
   {
     "Class":"Predicate",
-    "Name":"http:\/\/schema.org\/floorLimit",
+    "Name":"https://schema.org/floorLimit",
     "Domain Bucket":"< 1K"
   },
   {
     "Class":"Predicate",
-    "Name":"http:\/\/schema.org\/floorLimit-input",
+    "Name":"https://schema.org/floorLimit-input",
     "Domain Bucket":"< 1K"
   },
   {
     "Class":"Predicate",
-    "Name":"http:\/\/schema.org\/floorLimit-output",
+    "Name":"https://schema.org/floorLimit-output",
     "Domain Bucket":"< 1K"
   },
   {
     "Class":"Predicate",
-    "Name":"http:\/\/schema.org\/floorSize",
+    "Name":"https://schema.org/floorSize",
     "Domain Bucket":"100K - 1M"
   },
   {
     "Class":"Predicate",
-    "Name":"http:\/\/schema.org\/floorSize-input",
+    "Name":"https://schema.org/floorSize-input",
     "Domain Bucket":"< 1K"
   },
   {
     "Class":"Predicate",
-    "Name":"http:\/\/schema.org\/floorSize-output",
+    "Name":"https://schema.org/floorSize-output",
     "Domain Bucket":"< 1K"
   },
   {
     "Class":"Predicate",
-    "Name":"http:\/\/schema.org\/followee",
+    "Name":"https://schema.org/followee",
     "Domain Bucket":"< 1K"
   },
   {
     "Class":"Predicate",
-    "Name":"http:\/\/schema.org\/followee-input",
+    "Name":"https://schema.org/followee-input",
     "Domain Bucket":"< 1K"
   },
   {
     "Class":"Predicate",
-    "Name":"http:\/\/schema.org\/followee-output",
+    "Name":"https://schema.org/followee-output",
     "Domain Bucket":"< 1K"
   },
   {
     "Class":"Predicate",
-    "Name":"http:\/\/schema.org\/follows",
+    "Name":"https://schema.org/follows",
     "Domain Bucket":"< 1K"
   },
   {
     "Class":"Predicate",
-    "Name":"http:\/\/schema.org\/follows-input",
+    "Name":"https://schema.org/follows-input",
     "Domain Bucket":"< 1K"
   },
   {
     "Class":"Predicate",
-    "Name":"http:\/\/schema.org\/follows-output",
+    "Name":"https://schema.org/follows-output",
     "Domain Bucket":"< 1K"
   },
   {
     "Class":"Predicate",
-    "Name":"http:\/\/schema.org\/followup",
+    "Name":"https://schema.org/followup",
     "Domain Bucket":"1K - 10K"
   },
   {
     "Class":"Predicate",
-    "Name":"http:\/\/schema.org\/followup-input",
+    "Name":"https://schema.org/followup-input",
     "Domain Bucket":"< 1K"
   },
   {
     "Class":"Predicate",
-    "Name":"http:\/\/schema.org\/followup-output",
+    "Name":"https://schema.org/followup-output",
     "Domain Bucket":"< 1K"
   },
   {
     "Class":"Predicate",
-    "Name":"http:\/\/schema.org\/foodEstablishment",
+    "Name":"https://schema.org/foodEstablishment",
     "Domain Bucket":"< 1K"
   },
   {
     "Class":"Predicate",
-    "Name":"http:\/\/schema.org\/foodEstablishment-input",
+    "Name":"https://schema.org/foodEstablishment-input",
     "Domain Bucket":"< 1K"
   },
   {
     "Class":"Predicate",
-    "Name":"http:\/\/schema.org\/foodEstablishment-output",
+    "Name":"https://schema.org/foodEstablishment-output",
     "Domain Bucket":"< 1K"
   },
   {
     "Class":"Predicate",
-    "Name":"http:\/\/schema.org\/foodEvent",
+    "Name":"https://schema.org/foodEvent",
     "Domain Bucket":"< 1K"
   },
   {
     "Class":"Predicate",
-    "Name":"http:\/\/schema.org\/foodEvent-input",
+    "Name":"https://schema.org/foodEvent-input",
     "Domain Bucket":"< 1K"
   },
   {
     "Class":"Predicate",
-    "Name":"http:\/\/schema.org\/foodEvent-output",
+    "Name":"https://schema.org/foodEvent-output",
     "Domain Bucket":"< 1K"
   },
   {
     "Class":"Predicate",
-    "Name":"http:\/\/schema.org\/foodWarning",
+    "Name":"https://schema.org/foodWarning",
     "Domain Bucket":"< 1K"
   },
   {
     "Class":"Predicate",
-    "Name":"http:\/\/schema.org\/foodWarning-input",
+    "Name":"https://schema.org/foodWarning-input",
     "Domain Bucket":"< 1K"
   },
   {
     "Class":"Predicate",
-    "Name":"http:\/\/schema.org\/foodWarning-output",
+    "Name":"https://schema.org/foodWarning-output",
     "Domain Bucket":"< 1K"
   },
   {
     "Class":"Predicate",
-    "Name":"http:\/\/schema.org\/founder",
+    "Name":"https://schema.org/founder",
     "Domain Bucket":"100K - 1M"
   },
   {
     "Class":"Predicate",
-    "Name":"http:\/\/schema.org\/founder-input",
+    "Name":"https://schema.org/founder-input",
     "Domain Bucket":"< 1K"
   },
   {
     "Class":"Predicate",
-    "Name":"http:\/\/schema.org\/founder-output",
+    "Name":"https://schema.org/founder-output",
     "Domain Bucket":"< 1K"
   },
   {
     "Class":"Predicate",
-    "Name":"http:\/\/schema.org\/founders",
+    "Name":"https://schema.org/founders",
     "Domain Bucket":"10K - 100K"
   },
   {
     "Class":"Predicate",
-    "Name":"http:\/\/schema.org\/founders-input",
+    "Name":"https://schema.org/founders-input",
     "Domain Bucket":"< 1K"
   },
   {
     "Class":"Predicate",
-    "Name":"http:\/\/schema.org\/founders-output",
+    "Name":"https://schema.org/founders-output",
     "Domain Bucket":"< 1K"
   },
   {
     "Class":"Predicate",
-    "Name":"http:\/\/schema.org\/foundingDate",
+    "Name":"https://schema.org/foundingDate",
     "Domain Bucket":"100K - 1M"
   },
   {
     "Class":"Predicate",
-    "Name":"http:\/\/schema.org\/foundingDate-input",
+    "Name":"https://schema.org/foundingDate-input",
     "Domain Bucket":"< 1K"
   },
   {
     "Class":"Predicate",
-    "Name":"http:\/\/schema.org\/foundingDate-output",
+    "Name":"https://schema.org/foundingDate-output",
     "Domain Bucket":"< 1K"
   },
   {
     "Class":"Predicate",
-    "Name":"http:\/\/schema.org\/foundingLocation",
+    "Name":"https://schema.org/foundingLocation",
     "Domain Bucket":"10K - 100K"
   },
   {
     "Class":"Predicate",
-    "Name":"http:\/\/schema.org\/foundingLocation-input",
+    "Name":"https://schema.org/foundingLocation-input",
     "Domain Bucket":"< 1K"
   },
   {
     "Class":"Predicate",
-    "Name":"http:\/\/schema.org\/foundingLocation-output",
+    "Name":"https://schema.org/foundingLocation-output",
     "Domain Bucket":"< 1K"
   },
   {
     "Class":"Predicate",
-    "Name":"http:\/\/schema.org\/free",
+    "Name":"https://schema.org/free",
     "Domain Bucket":"1K - 10K"
   },
   {
     "Class":"Predicate",
-    "Name":"http:\/\/schema.org\/free-input",
+    "Name":"https://schema.org/free-input",
     "Domain Bucket":"< 1K"
   },
   {
     "Class":"Predicate",
-    "Name":"http:\/\/schema.org\/free-output",
+    "Name":"https://schema.org/free-output",
     "Domain Bucket":"< 1K"
   },
   {
     "Class":"Predicate",
-    "Name":"http:\/\/schema.org\/freeShippingThreshold",
+    "Name":"https://schema.org/freeShippingThreshold",
     "Domain Bucket":"10K - 100K"
   },
   {
     "Class":"Predicate",
-    "Name":"http:\/\/schema.org\/freeShippingThreshold-input",
+    "Name":"https://schema.org/freeShippingThreshold-input",
     "Domain Bucket":"< 1K"
   },
   {
     "Class":"Predicate",
-    "Name":"http:\/\/schema.org\/freeShippingThreshold-output",
+    "Name":"https://schema.org/freeShippingThreshold-output",
     "Domain Bucket":"< 1K"
   },
   {
     "Class":"Predicate",
-    "Name":"http:\/\/schema.org\/frequency",
+    "Name":"https://schema.org/frequency",
     "Domain Bucket":"< 1K"
   },
   {
     "Class":"Predicate",
-    "Name":"http:\/\/schema.org\/frequency-input",
+    "Name":"https://schema.org/frequency-input",
     "Domain Bucket":"< 1K"
   },
   {
     "Class":"Predicate",
-    "Name":"http:\/\/schema.org\/frequency-output",
+    "Name":"https://schema.org/frequency-output",
     "Domain Bucket":"< 1K"
   },
   {
     "Class":"Predicate",
-    "Name":"http:\/\/schema.org\/fromLocation",
+    "Name":"https://schema.org/fromLocation",
     "Domain Bucket":"1K - 10K"
   },
   {
     "Class":"Predicate",
-    "Name":"http:\/\/schema.org\/fromLocation-input",
+    "Name":"https://schema.org/fromLocation-input",
     "Domain Bucket":"< 1K"
   },
   {
     "Class":"Predicate",
-    "Name":"http:\/\/schema.org\/fromLocation-output",
+    "Name":"https://schema.org/fromLocation-output",
     "Domain Bucket":"< 1K"
   },
   {
     "Class":"Predicate",
-    "Name":"http:\/\/schema.org\/fuelCapacity",
+    "Name":"https://schema.org/fuelCapacity",
     "Domain Bucket":"1K - 10K"
   },
   {
     "Class":"Predicate",
-    "Name":"http:\/\/schema.org\/fuelCapacity-input",
+    "Name":"https://schema.org/fuelCapacity-input",
     "Domain Bucket":"< 1K"
   },
   {
     "Class":"Predicate",
-    "Name":"http:\/\/schema.org\/fuelCapacity-output",
+    "Name":"https://schema.org/fuelCapacity-output",
     "Domain Bucket":"< 1K"
   },
   {
     "Class":"Predicate",
-    "Name":"http:\/\/schema.org\/fuelConsumption",
+    "Name":"https://schema.org/fuelConsumption",
     "Domain Bucket":"1K - 10K"
   },
   {
     "Class":"Predicate",
-    "Name":"http:\/\/schema.org\/fuelConsumption-input",
+    "Name":"https://schema.org/fuelConsumption-input",
     "Domain Bucket":"< 1K"
   },
   {
     "Class":"Predicate",
-    "Name":"http:\/\/schema.org\/fuelConsumption-output",
+    "Name":"https://schema.org/fuelConsumption-output",
     "Domain Bucket":"< 1K"
   },
   {
     "Class":"Predicate",
-    "Name":"http:\/\/schema.org\/fuelEfficiency",
+    "Name":"https://schema.org/fuelEfficiency",
     "Domain Bucket":"1K - 10K"
   },
   {
     "Class":"Predicate",
-    "Name":"http:\/\/schema.org\/fuelEfficiency-input",
+    "Name":"https://schema.org/fuelEfficiency-input",
     "Domain Bucket":"< 1K"
   },
   {
     "Class":"Predicate",
-    "Name":"http:\/\/schema.org\/fuelEfficiency-output",
+    "Name":"https://schema.org/fuelEfficiency-output",
     "Domain Bucket":"< 1K"
   },
   {
     "Class":"Predicate",
-    "Name":"http:\/\/schema.org\/fuelType",
+    "Name":"https://schema.org/fuelType",
     "Domain Bucket":"10K - 100K"
   },
   {
     "Class":"Predicate",
-    "Name":"http:\/\/schema.org\/fuelType-input",
+    "Name":"https://schema.org/fuelType-input",
     "Domain Bucket":"< 1K"
   },
   {
     "Class":"Predicate",
-    "Name":"http:\/\/schema.org\/fuelType-output",
+    "Name":"https://schema.org/fuelType-output",
     "Domain Bucket":"< 1K"
   },
   {
     "Class":"Predicate",
-    "Name":"http:\/\/schema.org\/fulfillmentType",
+    "Name":"https://schema.org/fulfillmentType",
     "Domain Bucket":"10K - 100K"
   },
   {
     "Class":"Predicate",
-    "Name":"http:\/\/schema.org\/fulfillmentType-input",
+    "Name":"https://schema.org/fulfillmentType-input",
     "Domain Bucket":"< 1K"
   },
   {
     "Class":"Predicate",
-    "Name":"http:\/\/schema.org\/fulfillmentType-output",
+    "Name":"https://schema.org/fulfillmentType-output",
     "Domain Bucket":"< 1K"
   },
   {
     "Class":"Predicate",
-    "Name":"http:\/\/schema.org\/functionalClass",
+    "Name":"https://schema.org/functionalClass",
     "Domain Bucket":"< 1K"
   },
   {
     "Class":"Predicate",
-    "Name":"http:\/\/schema.org\/functionalClass-input",
+    "Name":"https://schema.org/functionalClass-input",
     "Domain Bucket":"< 1K"
   },
   {
     "Class":"Predicate",
-    "Name":"http:\/\/schema.org\/functionalClass-output",
+    "Name":"https://schema.org/functionalClass-output",
     "Domain Bucket":"< 1K"
   },
   {
     "Class":"Predicate",
-    "Name":"http:\/\/schema.org\/fundedItem",
+    "Name":"https://schema.org/fundedItem",
     "Domain Bucket":"< 1K"
   },
   {
     "Class":"Predicate",
-    "Name":"http:\/\/schema.org\/fundedItem-input",
+    "Name":"https://schema.org/fundedItem-input",
     "Domain Bucket":"< 1K"
   },
   {
     "Class":"Predicate",
-    "Name":"http:\/\/schema.org\/fundedItem-output",
+    "Name":"https://schema.org/fundedItem-output",
     "Domain Bucket":"< 1K"
   },
   {
     "Class":"Predicate",
-    "Name":"http:\/\/schema.org\/funder",
+    "Name":"https://schema.org/funder",
     "Domain Bucket":"1K - 10K"
   },
   {
     "Class":"Predicate",
-    "Name":"http:\/\/schema.org\/funder-input",
+    "Name":"https://schema.org/funder-input",
     "Domain Bucket":"< 1K"
   },
   {
     "Class":"Predicate",
-    "Name":"http:\/\/schema.org\/funder-output",
+    "Name":"https://schema.org/funder-output",
     "Domain Bucket":"< 1K"
   },
   {
     "Class":"Predicate",
-    "Name":"http:\/\/schema.org\/funding",
+    "Name":"https://schema.org/funding",
     "Domain Bucket":"1K - 10K"
   },
   {
     "Class":"Predicate",
-    "Name":"http:\/\/schema.org\/funding-input",
+    "Name":"https://schema.org/funding-input",
     "Domain Bucket":"< 1K"
   },
   {
     "Class":"Predicate",
-    "Name":"http:\/\/schema.org\/funding-output",
+    "Name":"https://schema.org/funding-output",
     "Domain Bucket":"< 1K"
   },
   {
     "Class":"Predicate",
-    "Name":"http:\/\/schema.org\/game",
+    "Name":"https://schema.org/game",
     "Domain Bucket":"10K - 100K"
   },
   {
     "Class":"Predicate",
-    "Name":"http:\/\/schema.org\/game-input",
+    "Name":"https://schema.org/game-input",
     "Domain Bucket":"< 1K"
   },
   {
     "Class":"Predicate",
-    "Name":"http:\/\/schema.org\/game-output",
+    "Name":"https://schema.org/game-output",
     "Domain Bucket":"< 1K"
   },
   {
     "Class":"Predicate",
-    "Name":"http:\/\/schema.org\/gameAvailabilityType",
+    "Name":"https://schema.org/gameAvailabilityType",
     "Domain Bucket":"< 1K"
   },
   {
     "Class":"Predicate",
-    "Name":"http:\/\/schema.org\/gameAvailabilityType-input",
+    "Name":"https://schema.org/gameAvailabilityType-input",
     "Domain Bucket":"< 1K"
   },
   {
     "Class":"Predicate",
-    "Name":"http:\/\/schema.org\/gameAvailabilityType-output",
+    "Name":"https://schema.org/gameAvailabilityType-output",
     "Domain Bucket":"< 1K"
   },
   {
     "Class":"Predicate",
-    "Name":"http:\/\/schema.org\/gameEdition",
+    "Name":"https://schema.org/gameEdition",
     "Domain Bucket":"< 1K"
   },
   {
     "Class":"Predicate",
-    "Name":"http:\/\/schema.org\/gameEdition-input",
+    "Name":"https://schema.org/gameEdition-input",
     "Domain Bucket":"< 1K"
   },
   {
     "Class":"Predicate",
-    "Name":"http:\/\/schema.org\/gameEdition-output",
+    "Name":"https://schema.org/gameEdition-output",
     "Domain Bucket":"< 1K"
   },
   {
     "Class":"Predicate",
-    "Name":"http:\/\/schema.org\/gameItem",
+    "Name":"https://schema.org/gameItem",
     "Domain Bucket":"1K - 10K"
   },
   {
     "Class":"Predicate",
-    "Name":"http:\/\/schema.org\/gameItem-input",
+    "Name":"https://schema.org/gameItem-input",
     "Domain Bucket":"< 1K"
   },
   {
     "Class":"Predicate",
-    "Name":"http:\/\/schema.org\/gameItem-output",
+    "Name":"https://schema.org/gameItem-output",
     "Domain Bucket":"< 1K"
   },
   {
     "Class":"Predicate",
-    "Name":"http:\/\/schema.org\/gameLocation",
+    "Name":"https://schema.org/gameLocation",
     "Domain Bucket":"10K - 100K"
   },
   {
     "Class":"Predicate",
-    "Name":"http:\/\/schema.org\/gameLocation-input",
+    "Name":"https://schema.org/gameLocation-input",
     "Domain Bucket":"< 1K"
   },
   {
     "Class":"Predicate",
-    "Name":"http:\/\/schema.org\/gameLocation-output",
+    "Name":"https://schema.org/gameLocation-output",
     "Domain Bucket":"< 1K"
   },
   {
     "Class":"Predicate",
-    "Name":"http:\/\/schema.org\/gamePlatform",
+    "Name":"https://schema.org/gamePlatform",
     "Domain Bucket":"10K - 100K"
   },
   {
     "Class":"Predicate",
-    "Name":"http:\/\/schema.org\/gamePlatform-input",
+    "Name":"https://schema.org/gamePlatform-input",
     "Domain Bucket":"< 1K"
   },
   {
     "Class":"Predicate",
-    "Name":"http:\/\/schema.org\/gamePlatform-output",
+    "Name":"https://schema.org/gamePlatform-output",
     "Domain Bucket":"< 1K"
   },
   {
     "Class":"Predicate",
-    "Name":"http:\/\/schema.org\/gameServer",
+    "Name":"https://schema.org/gameServer",
     "Domain Bucket":"< 1K"
   },
   {
     "Class":"Predicate",
-    "Name":"http:\/\/schema.org\/gameServer-input",
+    "Name":"https://schema.org/gameServer-input",
     "Domain Bucket":"< 1K"
   },
   {
     "Class":"Predicate",
-    "Name":"http:\/\/schema.org\/gameServer-output",
+    "Name":"https://schema.org/gameServer-output",
     "Domain Bucket":"< 1K"
   },
   {
     "Class":"Predicate",
-    "Name":"http:\/\/schema.org\/gameTip",
+    "Name":"https://schema.org/gameTip",
     "Domain Bucket":"< 1K"
   },
   {
     "Class":"Predicate",
-    "Name":"http:\/\/schema.org\/gameTip-input",
+    "Name":"https://schema.org/gameTip-input",
     "Domain Bucket":"< 1K"
   },
   {
     "Class":"Predicate",
-    "Name":"http:\/\/schema.org\/gameTip-output",
+    "Name":"https://schema.org/gameTip-output",
     "Domain Bucket":"< 1K"
   },
   {
     "Class":"Predicate",
-    "Name":"http:\/\/schema.org\/gender",
+    "Name":"https://schema.org/gender",
     "Domain Bucket":"10K - 100K"
   },
   {
     "Class":"Predicate",
-    "Name":"http:\/\/schema.org\/gender-input",
+    "Name":"https://schema.org/gender-input",
     "Domain Bucket":"< 1K"
   },
   {
     "Class":"Predicate",
-    "Name":"http:\/\/schema.org\/gender-output",
+    "Name":"https://schema.org/gender-output",
     "Domain Bucket":"< 1K"
   },
   {
     "Class":"Predicate",
-    "Name":"http:\/\/schema.org\/genre",
+    "Name":"https://schema.org/genre",
     "Domain Bucket":"100K - 1M"
   },
   {
     "Class":"Predicate",
-    "Name":"http:\/\/schema.org\/genre-input",
+    "Name":"https://schema.org/genre-input",
     "Domain Bucket":"< 1K"
   },
   {
     "Class":"Predicate",
-    "Name":"http:\/\/schema.org\/genre-output",
+    "Name":"https://schema.org/genre-output",
     "Domain Bucket":"< 1K"
   },
   {
     "Class":"Predicate",
-    "Name":"http:\/\/schema.org\/geo",
+    "Name":"https://schema.org/geo",
     "Domain Bucket":"1M - 10M"
   },
   {
     "Class":"Predicate",
-    "Name":"http:\/\/schema.org\/geo-input",
+    "Name":"https://schema.org/geo-input",
     "Domain Bucket":"< 1K"
   },
   {
     "Class":"Predicate",
-    "Name":"http:\/\/schema.org\/geo-output",
+    "Name":"https://schema.org/geo-output",
     "Domain Bucket":"< 1K"
   },
   {
     "Class":"Predicate",
-    "Name":"http:\/\/schema.org\/geoContains",
+    "Name":"https://schema.org/geoContains",
     "Domain Bucket":"< 1K"
   },
   {
     "Class":"Predicate",
-    "Name":"http:\/\/schema.org\/geoContains-input",
+    "Name":"https://schema.org/geoContains-input",
     "Domain Bucket":"< 1K"
   },
   {
     "Class":"Predicate",
-    "Name":"http:\/\/schema.org\/geoContains-output",
+    "Name":"https://schema.org/geoContains-output",
     "Domain Bucket":"< 1K"
   },
   {
     "Class":"Predicate",
-    "Name":"http:\/\/schema.org\/geoCoveredBy",
+    "Name":"https://schema.org/geoCoveredBy",
     "Domain Bucket":"< 1K"
   },
   {
     "Class":"Predicate",
-    "Name":"http:\/\/schema.org\/geoCoveredBy-input",
+    "Name":"https://schema.org/geoCoveredBy-input",
     "Domain Bucket":"< 1K"
   },
   {
     "Class":"Predicate",
-    "Name":"http:\/\/schema.org\/geoCoveredBy-output",
+    "Name":"https://schema.org/geoCoveredBy-output",
     "Domain Bucket":"< 1K"
   },
   {
     "Class":"Predicate",
-    "Name":"http:\/\/schema.org\/geoCovers",
+    "Name":"https://schema.org/geoCovers",
     "Domain Bucket":"< 1K"
   },
   {
     "Class":"Predicate",
-    "Name":"http:\/\/schema.org\/geoCovers-input",
+    "Name":"https://schema.org/geoCovers-input",
     "Domain Bucket":"< 1K"
   },
   {
     "Class":"Predicate",
-    "Name":"http:\/\/schema.org\/geoCovers-output",
+    "Name":"https://schema.org/geoCovers-output",
     "Domain Bucket":"< 1K"
   },
   {
     "Class":"Predicate",
-    "Name":"http:\/\/schema.org\/geoCrosses",
+    "Name":"https://schema.org/geoCrosses",
     "Domain Bucket":"< 1K"
   },
   {
     "Class":"Predicate",
-    "Name":"http:\/\/schema.org\/geoCrosses-input",
+    "Name":"https://schema.org/geoCrosses-input",
     "Domain Bucket":"< 1K"
   },
   {
     "Class":"Predicate",
-    "Name":"http:\/\/schema.org\/geoCrosses-output",
+    "Name":"https://schema.org/geoCrosses-output",
     "Domain Bucket":"< 1K"
   },
   {
     "Class":"Predicate",
-    "Name":"http:\/\/schema.org\/geoDisjoint",
+    "Name":"https://schema.org/geoDisjoint",
     "Domain Bucket":"< 1K"
   },
   {
     "Class":"Predicate",
-    "Name":"http:\/\/schema.org\/geoDisjoint-input",
+    "Name":"https://schema.org/geoDisjoint-input",
     "Domain Bucket":"< 1K"
   },
   {
     "Class":"Predicate",
-    "Name":"http:\/\/schema.org\/geoDisjoint-output",
+    "Name":"https://schema.org/geoDisjoint-output",
     "Domain Bucket":"< 1K"
   },
   {
     "Class":"Predicate",
-    "Name":"http:\/\/schema.org\/geoEquals",
+    "Name":"https://schema.org/geoEquals",
     "Domain Bucket":"< 1K"
   },
   {
     "Class":"Predicate",
-    "Name":"http:\/\/schema.org\/geoEquals-input",
+    "Name":"https://schema.org/geoEquals-input",
     "Domain Bucket":"< 1K"
   },
   {
     "Class":"Predicate",
-    "Name":"http:\/\/schema.org\/geoEquals-output",
+    "Name":"https://schema.org/geoEquals-output",
     "Domain Bucket":"< 1K"
   },
   {
     "Class":"Predicate",
-    "Name":"http:\/\/schema.org\/geoIntersects",
+    "Name":"https://schema.org/geoIntersects",
     "Domain Bucket":"< 1K"
   },
   {
     "Class":"Predicate",
-    "Name":"http:\/\/schema.org\/geoIntersects-input",
+    "Name":"https://schema.org/geoIntersects-input",
     "Domain Bucket":"< 1K"
   },
   {
     "Class":"Predicate",
-    "Name":"http:\/\/schema.org\/geoIntersects-output",
+    "Name":"https://schema.org/geoIntersects-output",
     "Domain Bucket":"< 1K"
   },
   {
     "Class":"Predicate",
-    "Name":"http:\/\/schema.org\/geoMidpoint",
+    "Name":"https://schema.org/geoMidpoint",
     "Domain Bucket":"100K - 1M"
   },
   {
     "Class":"Predicate",
-    "Name":"http:\/\/schema.org\/geoMidpoint-input",
+    "Name":"https://schema.org/geoMidpoint-input",
     "Domain Bucket":"< 1K"
   },
   {
     "Class":"Predicate",
-    "Name":"http:\/\/schema.org\/geoMidpoint-output",
+    "Name":"https://schema.org/geoMidpoint-output",
     "Domain Bucket":"< 1K"
   },
   {
     "Class":"Predicate",
-    "Name":"http:\/\/schema.org\/geoOverlaps",
+    "Name":"https://schema.org/geoOverlaps",
     "Domain Bucket":"< 1K"
   },
   {
     "Class":"Predicate",
-    "Name":"http:\/\/schema.org\/geoOverlaps-input",
+    "Name":"https://schema.org/geoOverlaps-input",
     "Domain Bucket":"< 1K"
   },
   {
     "Class":"Predicate",
-    "Name":"http:\/\/schema.org\/geoOverlaps-output",
+    "Name":"https://schema.org/geoOverlaps-output",
     "Domain Bucket":"< 1K"
   },
   {
     "Class":"Predicate",
-    "Name":"http:\/\/schema.org\/geoRadius",
+    "Name":"https://schema.org/geoRadius",
     "Domain Bucket":"100K - 1M"
   },
   {
     "Class":"Predicate",
-    "Name":"http:\/\/schema.org\/geoRadius-input",
+    "Name":"https://schema.org/geoRadius-input",
     "Domain Bucket":"< 1K"
   },
   {
     "Class":"Predicate",
-    "Name":"http:\/\/schema.org\/geoRadius-output",
+    "Name":"https://schema.org/geoRadius-output",
     "Domain Bucket":"< 1K"
   },
   {
     "Class":"Predicate",
-    "Name":"http:\/\/schema.org\/geoTouches",
+    "Name":"https://schema.org/geoTouches",
     "Domain Bucket":"< 1K"
   },
   {
     "Class":"Predicate",
-    "Name":"http:\/\/schema.org\/geoTouches-input",
+    "Name":"https://schema.org/geoTouches-input",
     "Domain Bucket":"< 1K"
   },
   {
     "Class":"Predicate",
-    "Name":"http:\/\/schema.org\/geoTouches-output",
+    "Name":"https://schema.org/geoTouches-output",
     "Domain Bucket":"< 1K"
   },
   {
     "Class":"Predicate",
-    "Name":"http:\/\/schema.org\/geoWithin",
+    "Name":"https://schema.org/geoWithin",
     "Domain Bucket":"< 1K"
   },
   {
     "Class":"Predicate",
-    "Name":"http:\/\/schema.org\/geoWithin-input",
+    "Name":"https://schema.org/geoWithin-input",
     "Domain Bucket":"< 1K"
   },
   {
     "Class":"Predicate",
-    "Name":"http:\/\/schema.org\/geoWithin-output",
+    "Name":"https://schema.org/geoWithin-output",
     "Domain Bucket":"< 1K"
   },
   {
     "Class":"Predicate",
-    "Name":"http:\/\/schema.org\/geographicArea",
+    "Name":"https://schema.org/geographicArea",
     "Domain Bucket":"10K - 100K"
   },
   {
     "Class":"Predicate",
-    "Name":"http:\/\/schema.org\/geographicArea-input",
+    "Name":"https://schema.org/geographicArea-input",
     "Domain Bucket":"< 1K"
   },
   {
     "Class":"Predicate",
-    "Name":"http:\/\/schema.org\/geographicArea-output",
+    "Name":"https://schema.org/geographicArea-output",
     "Domain Bucket":"< 1K"
   },
   {
     "Class":"Predicate",
-    "Name":"http:\/\/schema.org\/gettingTestedInfo",
+    "Name":"https://schema.org/gettingTestedInfo",
     "Domain Bucket":"< 1K"
   },
   {
     "Class":"Predicate",
-    "Name":"http:\/\/schema.org\/gettingTestedInfo-input",
+    "Name":"https://schema.org/gettingTestedInfo-input",
     "Domain Bucket":"< 1K"
   },
   {
     "Class":"Predicate",
-    "Name":"http:\/\/schema.org\/gettingTestedInfo-output",
+    "Name":"https://schema.org/gettingTestedInfo-output",
     "Domain Bucket":"< 1K"
   },
   {
     "Class":"Predicate",
-    "Name":"http:\/\/schema.org\/givenName",
+    "Name":"https://schema.org/givenName",
     "Domain Bucket":"100K - 1M"
   },
   {
     "Class":"Predicate",
-    "Name":"http:\/\/schema.org\/givenName-input",
+    "Name":"https://schema.org/givenName-input",
     "Domain Bucket":"< 1K"
   },
   {
     "Class":"Predicate",
-    "Name":"http:\/\/schema.org\/givenName-output",
+    "Name":"https://schema.org/givenName-output",
     "Domain Bucket":"< 1K"
   },
   {
     "Class":"Predicate",
-    "Name":"http:\/\/schema.org\/globalLocationNumber",
+    "Name":"https://schema.org/globalLocationNumber",
     "Domain Bucket":"1K - 10K"
   },
   {
     "Class":"Predicate",
-    "Name":"http:\/\/schema.org\/globalLocationNumber-input",
+    "Name":"https://schema.org/globalLocationNumber-input",
     "Domain Bucket":"< 1K"
   },
   {
     "Class":"Predicate",
-    "Name":"http:\/\/schema.org\/globalLocationNumber-output",
+    "Name":"https://schema.org/globalLocationNumber-output",
     "Domain Bucket":"< 1K"
   },
   {
     "Class":"Predicate",
-    "Name":"http:\/\/schema.org\/governmentBenefitsInfo",
+    "Name":"https://schema.org/governmentBenefitsInfo",
     "Domain Bucket":"< 1K"
   },
   {
     "Class":"Predicate",
-    "Name":"http:\/\/schema.org\/governmentBenefitsInfo-input",
+    "Name":"https://schema.org/governmentBenefitsInfo-input",
     "Domain Bucket":"< 1K"
   },
   {
     "Class":"Predicate",
-    "Name":"http:\/\/schema.org\/governmentBenefitsInfo-output",
+    "Name":"https://schema.org/governmentBenefitsInfo-output",
     "Domain Bucket":"< 1K"
   },
   {
     "Class":"Predicate",
-    "Name":"http:\/\/schema.org\/gracePeriod",
+    "Name":"https://schema.org/gracePeriod",
     "Domain Bucket":"< 1K"
   },
   {
     "Class":"Predicate",
-    "Name":"http:\/\/schema.org\/gracePeriod-input",
+    "Name":"https://schema.org/gracePeriod-input",
     "Domain Bucket":"< 1K"
   },
   {
     "Class":"Predicate",
-    "Name":"http:\/\/schema.org\/gracePeriod-output",
+    "Name":"https://schema.org/gracePeriod-output",
     "Domain Bucket":"< 1K"
   },
   {
     "Class":"Predicate",
-    "Name":"http:\/\/schema.org\/grantee",
+    "Name":"https://schema.org/grantee",
     "Domain Bucket":"< 1K"
   },
   {
     "Class":"Predicate",
-    "Name":"http:\/\/schema.org\/grantee-input",
+    "Name":"https://schema.org/grantee-input",
     "Domain Bucket":"< 1K"
   },
   {
     "Class":"Predicate",
-    "Name":"http:\/\/schema.org\/grantee-output",
+    "Name":"https://schema.org/grantee-output",
     "Domain Bucket":"< 1K"
   },
   {
     "Class":"Predicate",
-    "Name":"http:\/\/schema.org\/greater",
+    "Name":"https://schema.org/greater",
     "Domain Bucket":"< 1K"
   },
   {
     "Class":"Predicate",
-    "Name":"http:\/\/schema.org\/greater-input",
+    "Name":"https://schema.org/greater-input",
     "Domain Bucket":"< 1K"
   },
   {
     "Class":"Predicate",
-    "Name":"http:\/\/schema.org\/greater-output",
+    "Name":"https://schema.org/greater-output",
     "Domain Bucket":"< 1K"
   },
   {
     "Class":"Predicate",
-    "Name":"http:\/\/schema.org\/greaterOrEqual",
+    "Name":"https://schema.org/greaterOrEqual",
     "Domain Bucket":"< 1K"
   },
   {
     "Class":"Predicate",
-    "Name":"http:\/\/schema.org\/greaterOrEqual-input",
+    "Name":"https://schema.org/greaterOrEqual-input",
     "Domain Bucket":"< 1K"
   },
   {
     "Class":"Predicate",
-    "Name":"http:\/\/schema.org\/greaterOrEqual-output",
+    "Name":"https://schema.org/greaterOrEqual-output",
     "Domain Bucket":"< 1K"
   },
   {
     "Class":"Predicate",
-    "Name":"http:\/\/schema.org\/gtin",
+    "Name":"https://schema.org/gtin",
     "Domain Bucket":"100K - 1M"
   },
   {
     "Class":"Predicate",
-    "Name":"http:\/\/schema.org\/gtin-input",
+    "Name":"https://schema.org/gtin-input",
     "Domain Bucket":"< 1K"
   },
   {
     "Class":"Predicate",
-    "Name":"http:\/\/schema.org\/gtin-output",
+    "Name":"https://schema.org/gtin-output",
     "Domain Bucket":"< 1K"
   },
   {
     "Class":"Predicate",
-    "Name":"http:\/\/schema.org\/gtin12",
+    "Name":"https://schema.org/gtin12",
     "Domain Bucket":"100K - 1M"
   },
   {
     "Class":"Predicate",
-    "Name":"http:\/\/schema.org\/gtin12-input",
+    "Name":"https://schema.org/gtin12-input",
     "Domain Bucket":"< 1K"
   },
   {
     "Class":"Predicate",
-    "Name":"http:\/\/schema.org\/gtin12-output",
+    "Name":"https://schema.org/gtin12-output",
     "Domain Bucket":"< 1K"
   },
   {
     "Class":"Predicate",
-    "Name":"http:\/\/schema.org\/gtin13",
+    "Name":"https://schema.org/gtin13",
     "Domain Bucket":"100K - 1M"
   },
   {
     "Class":"Predicate",
-    "Name":"http:\/\/schema.org\/gtin13-input",
+    "Name":"https://schema.org/gtin13-input",
     "Domain Bucket":"< 1K"
   },
   {
     "Class":"Predicate",
-    "Name":"http:\/\/schema.org\/gtin13-output",
+    "Name":"https://schema.org/gtin13-output",
     "Domain Bucket":"< 1K"
   },
   {
     "Class":"Predicate",
-    "Name":"http:\/\/schema.org\/gtin14",
+    "Name":"https://schema.org/gtin14",
     "Domain Bucket":"10K - 100K"
   },
   {
     "Class":"Predicate",
-    "Name":"http:\/\/schema.org\/gtin14-input",
+    "Name":"https://schema.org/gtin14-input",
     "Domain Bucket":"< 1K"
   },
   {
     "Class":"Predicate",
-    "Name":"http:\/\/schema.org\/gtin14-output",
+    "Name":"https://schema.org/gtin14-output",
     "Domain Bucket":"< 1K"
   },
   {
     "Class":"Predicate",
-    "Name":"http:\/\/schema.org\/gtin8",
+    "Name":"https://schema.org/gtin8",
     "Domain Bucket":"10K - 100K"
   },
   {
     "Class":"Predicate",
-    "Name":"http:\/\/schema.org\/gtin8-input",
+    "Name":"https://schema.org/gtin8-input",
     "Domain Bucket":"< 1K"
   },
   {
     "Class":"Predicate",
-    "Name":"http:\/\/schema.org\/gtin8-output",
+    "Name":"https://schema.org/gtin8-output",
     "Domain Bucket":"< 1K"
   },
   {
     "Class":"Predicate",
-    "Name":"http:\/\/schema.org\/guideline",
+    "Name":"https://schema.org/guideline",
     "Domain Bucket":"< 1K"
   },
   {
     "Class":"Predicate",
-    "Name":"http:\/\/schema.org\/guideline-input",
+    "Name":"https://schema.org/guideline-input",
     "Domain Bucket":"< 1K"
   },
   {
     "Class":"Predicate",
-    "Name":"http:\/\/schema.org\/guideline-output",
+    "Name":"https://schema.org/guideline-output",
     "Domain Bucket":"< 1K"
   },
   {
     "Class":"Predicate",
-    "Name":"http:\/\/schema.org\/guidelineDate",
+    "Name":"https://schema.org/guidelineDate",
     "Domain Bucket":"< 1K"
   },
   {
     "Class":"Predicate",
-    "Name":"http:\/\/schema.org\/guidelineDate-input",
+    "Name":"https://schema.org/guidelineDate-input",
     "Domain Bucket":"< 1K"
   },
   {
     "Class":"Predicate",
-    "Name":"http:\/\/schema.org\/guidelineDate-output",
+    "Name":"https://schema.org/guidelineDate-output",
     "Domain Bucket":"< 1K"
   },
   {
     "Class":"Predicate",
-    "Name":"http:\/\/schema.org\/guidelineSubject",
+    "Name":"https://schema.org/guidelineSubject",
     "Domain Bucket":"< 1K"
   },
   {
     "Class":"Predicate",
-    "Name":"http:\/\/schema.org\/guidelineSubject-input",
+    "Name":"https://schema.org/guidelineSubject-input",
     "Domain Bucket":"< 1K"
   },
   {
     "Class":"Predicate",
-    "Name":"http:\/\/schema.org\/guidelineSubject-output",
+    "Name":"https://schema.org/guidelineSubject-output",
     "Domain Bucket":"< 1K"
   },
   {
     "Class":"Predicate",
-    "Name":"http:\/\/schema.org\/handlingTime",
+    "Name":"https://schema.org/handlingTime",
     "Domain Bucket":"100K - 1M"
   },
   {
     "Class":"Predicate",
-    "Name":"http:\/\/schema.org\/handlingTime-input",
+    "Name":"https://schema.org/handlingTime-input",
     "Domain Bucket":"< 1K"
   },
   {
     "Class":"Predicate",
-    "Name":"http:\/\/schema.org\/handlingTime-output",
+    "Name":"https://schema.org/handlingTime-output",
     "Domain Bucket":"< 1K"
   },
   {
     "Class":"Predicate",
-    "Name":"http:\/\/schema.org\/hasAdultConsideration",
+    "Name":"https://schema.org/hasAdultConsideration",
     "Domain Bucket":"< 1K"
   },
   {
     "Class":"Predicate",
-    "Name":"http:\/\/schema.org\/hasAdultConsideration-input",
+    "Name":"https://schema.org/hasAdultConsideration-input",
     "Domain Bucket":"< 1K"
   },
   {
     "Class":"Predicate",
-    "Name":"http:\/\/schema.org\/hasAdultConsideration-output",
+    "Name":"https://schema.org/hasAdultConsideration-output",
     "Domain Bucket":"< 1K"
   },
   {
     "Class":"Predicate",
-    "Name":"http:\/\/schema.org\/hasBioChemEntityPart",
+    "Name":"https://schema.org/hasBioChemEntityPart",
     "Domain Bucket":"< 1K"
   },
   {
     "Class":"Predicate",
-    "Name":"http:\/\/schema.org\/hasBioChemEntityPart-input",
+    "Name":"https://schema.org/hasBioChemEntityPart-input",
     "Domain Bucket":"< 1K"
   },
   {
     "Class":"Predicate",
-    "Name":"http:\/\/schema.org\/hasBioChemEntityPart-output",
+    "Name":"https://schema.org/hasBioChemEntityPart-output",
     "Domain Bucket":"< 1K"
   },
   {
     "Class":"Predicate",
-    "Name":"http:\/\/schema.org\/hasBioPolymerSequence",
+    "Name":"https://schema.org/hasBioPolymerSequence",
     "Domain Bucket":"< 1K"
   },
   {
     "Class":"Predicate",
-    "Name":"http:\/\/schema.org\/hasBioPolymerSequence-input",
+    "Name":"https://schema.org/hasBioPolymerSequence-input",
     "Domain Bucket":"< 1K"
   },
   {
     "Class":"Predicate",
-    "Name":"http:\/\/schema.org\/hasBioPolymerSequence-output",
+    "Name":"https://schema.org/hasBioPolymerSequence-output",
     "Domain Bucket":"< 1K"
   },
   {
     "Class":"Predicate",
-    "Name":"http:\/\/schema.org\/hasBroadcastChannel",
+    "Name":"https://schema.org/hasBroadcastChannel",
     "Domain Bucket":"< 1K"
   },
   {
     "Class":"Predicate",
-    "Name":"http:\/\/schema.org\/hasBroadcastChannel-input",
+    "Name":"https://schema.org/hasBroadcastChannel-input",
     "Domain Bucket":"< 1K"
   },
   {
     "Class":"Predicate",
-    "Name":"http:\/\/schema.org\/hasBroadcastChannel-output",
+    "Name":"https://schema.org/hasBroadcastChannel-output",
     "Domain Bucket":"< 1K"
   },
   {
     "Class":"Predicate",
-    "Name":"http:\/\/schema.org\/hasCategoryCode",
+    "Name":"https://schema.org/hasCategoryCode",
     "Domain Bucket":"< 1K"
   },
   {
     "Class":"Predicate",
-    "Name":"http:\/\/schema.org\/hasCategoryCode-input",
+    "Name":"https://schema.org/hasCategoryCode-input",
     "Domain Bucket":"< 1K"
   },
   {
     "Class":"Predicate",
-    "Name":"http:\/\/schema.org\/hasCategoryCode-output",
+    "Name":"https://schema.org/hasCategoryCode-output",
     "Domain Bucket":"< 1K"
   },
   {
     "Class":"Predicate",
-    "Name":"http:\/\/schema.org\/hasCertification",
+    "Name":"https://schema.org/hasCertification",
     "Domain Bucket":"1K - 10K"
   },
   {
     "Class":"Predicate",
-    "Name":"http:\/\/schema.org\/hasCertification-input",
+    "Name":"https://schema.org/hasCertification-input",
     "Domain Bucket":"< 1K"
   },
   {
     "Class":"Predicate",
-    "Name":"http:\/\/schema.org\/hasCertification-output",
+    "Name":"https://schema.org/hasCertification-output",
     "Domain Bucket":"< 1K"
   },
   {
     "Class":"Predicate",
-    "Name":"http:\/\/schema.org\/hasCourse",
+    "Name":"https://schema.org/hasCourse",
     "Domain Bucket":"1K - 10K"
   },
   {
     "Class":"Predicate",
-    "Name":"http:\/\/schema.org\/hasCourse-input",
+    "Name":"https://schema.org/hasCourse-input",
     "Domain Bucket":"< 1K"
   },
   {
     "Class":"Predicate",
-    "Name":"http:\/\/schema.org\/hasCourse-output",
+    "Name":"https://schema.org/hasCourse-output",
     "Domain Bucket":"< 1K"
   },
   {
     "Class":"Predicate",
-    "Name":"http:\/\/schema.org\/hasCourseInstance",
+    "Name":"https://schema.org/hasCourseInstance",
     "Domain Bucket":"10K - 100K"
   },
   {
     "Class":"Predicate",
-    "Name":"http:\/\/schema.org\/hasCourseInstance-input",
+    "Name":"https://schema.org/hasCourseInstance-input",
     "Domain Bucket":"< 1K"
   },
   {
     "Class":"Predicate",
-    "Name":"http:\/\/schema.org\/hasCourseInstance-output",
+    "Name":"https://schema.org/hasCourseInstance-output",
     "Domain Bucket":"< 1K"
   },
   {
     "Class":"Predicate",
-    "Name":"http:\/\/schema.org\/hasCredential",
+    "Name":"https://schema.org/hasCredential",
     "Domain Bucket":"10K - 100K"
   },
   {
     "Class":"Predicate",
-    "Name":"http:\/\/schema.org\/hasCredential-input",
+    "Name":"https://schema.org/hasCredential-input",
     "Domain Bucket":"< 1K"
   },
   {
     "Class":"Predicate",
-    "Name":"http:\/\/schema.org\/hasCredential-output",
+    "Name":"https://schema.org/hasCredential-output",
     "Domain Bucket":"< 1K"
   },
   {
     "Class":"Predicate",
-    "Name":"http:\/\/schema.org\/hasDefinedTerm",
+    "Name":"https://schema.org/hasDefinedTerm",
     "Domain Bucket":"1K - 10K"
   },
   {
     "Class":"Predicate",
-    "Name":"http:\/\/schema.org\/hasDefinedTerm-input",
+    "Name":"https://schema.org/hasDefinedTerm-input",
     "Domain Bucket":"< 1K"
   },
   {
     "Class":"Predicate",
-    "Name":"http:\/\/schema.org\/hasDefinedTerm-output",
+    "Name":"https://schema.org/hasDefinedTerm-output",
     "Domain Bucket":"< 1K"
   },
   {
     "Class":"Predicate",
-    "Name":"http:\/\/schema.org\/hasDeliveryMethod",
+    "Name":"https://schema.org/hasDeliveryMethod",
     "Domain Bucket":"< 1K"
   },
   {
     "Class":"Predicate",
-    "Name":"http:\/\/schema.org\/hasDeliveryMethod-input",
+    "Name":"https://schema.org/hasDeliveryMethod-input",
     "Domain Bucket":"< 1K"
   },
   {
     "Class":"Predicate",
-    "Name":"http:\/\/schema.org\/hasDeliveryMethod-output",
+    "Name":"https://schema.org/hasDeliveryMethod-output",
     "Domain Bucket":"< 1K"
   },
   {
     "Class":"Predicate",
-    "Name":"http:\/\/schema.org\/hasDigitalDocumentPermission",
+    "Name":"https://schema.org/hasDigitalDocumentPermission",
     "Domain Bucket":"< 1K"
   },
   {
     "Class":"Predicate",
-    "Name":"http:\/\/schema.org\/hasDigitalDocumentPermission-input",
+    "Name":"https://schema.org/hasDigitalDocumentPermission-input",
     "Domain Bucket":"< 1K"
   },
   {
     "Class":"Predicate",
-    "Name":"http:\/\/schema.org\/hasDigitalDocumentPermission-output",
+    "Name":"https://schema.org/hasDigitalDocumentPermission-output",
     "Domain Bucket":"< 1K"
   },
   {
     "Class":"Predicate",
-    "Name":"http:\/\/schema.org\/hasDriveThroughService",
+    "Name":"https://schema.org/hasDriveThroughService",
     "Domain Bucket":"< 1K"
   },
   {
     "Class":"Predicate",
-    "Name":"http:\/\/schema.org\/hasDriveThroughService-input",
+    "Name":"https://schema.org/hasDriveThroughService-input",
     "Domain Bucket":"< 1K"
   },
   {
     "Class":"Predicate",
-    "Name":"http:\/\/schema.org\/hasDriveThroughService-output",
+    "Name":"https://schema.org/hasDriveThroughService-output",
     "Domain Bucket":"< 1K"
   },
   {
     "Class":"Predicate",
-    "Name":"http:\/\/schema.org\/hasEnergyConsumptionDetails",
+    "Name":"https://schema.org/hasEnergyConsumptionDetails",
     "Domain Bucket":"1K - 10K"
   },
   {
     "Class":"Predicate",
-    "Name":"http:\/\/schema.org\/hasEnergyConsumptionDetails-input",
+    "Name":"https://schema.org/hasEnergyConsumptionDetails-input",
     "Domain Bucket":"< 1K"
   },
   {
     "Class":"Predicate",
-    "Name":"http:\/\/schema.org\/hasEnergyConsumptionDetails-output",
+    "Name":"https://schema.org/hasEnergyConsumptionDetails-output",
     "Domain Bucket":"< 1K"
   },
   {
     "Class":"Predicate",
-    "Name":"http:\/\/schema.org\/hasEnergyEfficiencyCategory",
+    "Name":"https://schema.org/hasEnergyEfficiencyCategory",
     "Domain Bucket":"1K - 10K"
   },
   {
     "Class":"Predicate",
-    "Name":"http:\/\/schema.org\/hasEnergyEfficiencyCategory-input",
+    "Name":"https://schema.org/hasEnergyEfficiencyCategory-input",
     "Domain Bucket":"< 1K"
   },
   {
     "Class":"Predicate",
-    "Name":"http:\/\/schema.org\/hasEnergyEfficiencyCategory-output",
+    "Name":"https://schema.org/hasEnergyEfficiencyCategory-output",
     "Domain Bucket":"< 1K"
   },
   {
     "Class":"Predicate",
-    "Name":"http:\/\/schema.org\/hasGS1DigitalLink",
+    "Name":"https://schema.org/hasGS1DigitalLink",
     "Domain Bucket":"< 1K"
   },
   {
     "Class":"Predicate",
-    "Name":"http:\/\/schema.org\/hasGS1DigitalLink-input",
+    "Name":"https://schema.org/hasGS1DigitalLink-input",
     "Domain Bucket":"< 1K"
   },
   {
     "Class":"Predicate",
-    "Name":"http:\/\/schema.org\/hasGS1DigitalLink-output",
+    "Name":"https://schema.org/hasGS1DigitalLink-output",
     "Domain Bucket":"< 1K"
   },
   {
     "Class":"Predicate",
-    "Name":"http:\/\/schema.org\/hasHealthAspect",
+    "Name":"https://schema.org/hasHealthAspect",
     "Domain Bucket":"< 1K"
   },
   {
     "Class":"Predicate",
-    "Name":"http:\/\/schema.org\/hasHealthAspect-input",
+    "Name":"https://schema.org/hasHealthAspect-input",
     "Domain Bucket":"< 1K"
   },
   {
     "Class":"Predicate",
-    "Name":"http:\/\/schema.org\/hasHealthAspect-output",
+    "Name":"https://schema.org/hasHealthAspect-output",
     "Domain Bucket":"< 1K"
   },
   {
     "Class":"Predicate",
-    "Name":"http:\/\/schema.org\/hasMap",
+    "Name":"https://schema.org/hasMap",
     "Domain Bucket":"100K - 1M"
   },
   {
     "Class":"Predicate",
-    "Name":"http:\/\/schema.org\/hasMap-input",
+    "Name":"https://schema.org/hasMap-input",
     "Domain Bucket":"< 1K"
   },
   {
     "Class":"Predicate",
-    "Name":"http:\/\/schema.org\/hasMap-output",
+    "Name":"https://schema.org/hasMap-output",
     "Domain Bucket":"< 1K"
   },
   {
     "Class":"Predicate",
-    "Name":"http:\/\/schema.org\/hasMeasurement",
+    "Name":"https://schema.org/hasMeasurement",
     "Domain Bucket":"1K - 10K"
   },
   {
     "Class":"Predicate",
-    "Name":"http:\/\/schema.org\/hasMeasurement-input",
+    "Name":"https://schema.org/hasMeasurement-input",
     "Domain Bucket":"< 1K"
   },
   {
     "Class":"Predicate",
-    "Name":"http:\/\/schema.org\/hasMeasurement-output",
+    "Name":"https://schema.org/hasMeasurement-output",
     "Domain Bucket":"< 1K"
   },
   {
     "Class":"Predicate",
-    "Name":"http:\/\/schema.org\/hasMemberProgram",
+    "Name":"https://schema.org/hasMemberProgram",
     "Domain Bucket":"1K - 10K"
   },
   {
     "Class":"Predicate",
-    "Name":"http:\/\/schema.org\/hasMemberProgram-input",
+    "Name":"https://schema.org/hasMemberProgram-input",
     "Domain Bucket":"< 1K"
   },
   {
     "Class":"Predicate",
-    "Name":"http:\/\/schema.org\/hasMemberProgram-output",
+    "Name":"https://schema.org/hasMemberProgram-output",
     "Domain Bucket":"< 1K"
   },
   {
     "Class":"Predicate",
-    "Name":"http:\/\/schema.org\/hasMenu",
+    "Name":"https://schema.org/hasMenu",
     "Domain Bucket":"10K - 100K"
   },
   {
     "Class":"Predicate",
-    "Name":"http:\/\/schema.org\/hasMenu-input",
+    "Name":"https://schema.org/hasMenu-input",
     "Domain Bucket":"< 1K"
   },
   {
     "Class":"Predicate",
-    "Name":"http:\/\/schema.org\/hasMenu-output",
+    "Name":"https://schema.org/hasMenu-output",
     "Domain Bucket":"< 1K"
   },
   {
     "Class":"Predicate",
-    "Name":"http:\/\/schema.org\/hasMenuItem",
+    "Name":"https://schema.org/hasMenuItem",
     "Domain Bucket":"10K - 100K"
   },
   {
     "Class":"Predicate",
-    "Name":"http:\/\/schema.org\/hasMenuItem-input",
+    "Name":"https://schema.org/hasMenuItem-input",
     "Domain Bucket":"< 1K"
   },
   {
     "Class":"Predicate",
-    "Name":"http:\/\/schema.org\/hasMenuItem-output",
+    "Name":"https://schema.org/hasMenuItem-output",
     "Domain Bucket":"< 1K"
   },
   {
     "Class":"Predicate",
-    "Name":"http:\/\/schema.org\/hasMenuSection",
+    "Name":"https://schema.org/hasMenuSection",
     "Domain Bucket":"10K - 100K"
   },
   {
     "Class":"Predicate",
-    "Name":"http:\/\/schema.org\/hasMenuSection-input",
+    "Name":"https://schema.org/hasMenuSection-input",
     "Domain Bucket":"< 1K"
   },
   {
     "Class":"Predicate",
-    "Name":"http:\/\/schema.org\/hasMenuSection-output",
+    "Name":"https://schema.org/hasMenuSection-output",
     "Domain Bucket":"< 1K"
   },
   {
     "Class":"Predicate",
-    "Name":"http:\/\/schema.org\/hasMerchantReturnPolicy",
+    "Name":"https://schema.org/hasMerchantReturnPolicy",
     "Domain Bucket":"100K - 1M"
   },
   {
     "Class":"Predicate",
-    "Name":"http:\/\/schema.org\/hasMerchantReturnPolicy-input",
+    "Name":"https://schema.org/hasMerchantReturnPolicy-input",
     "Domain Bucket":"< 1K"
   },
   {
     "Class":"Predicate",
-    "Name":"http:\/\/schema.org\/hasMerchantReturnPolicy-output",
+    "Name":"https://schema.org/hasMerchantReturnPolicy-output",
     "Domain Bucket":"< 1K"
   },
   {
     "Class":"Predicate",
-    "Name":"http:\/\/schema.org\/hasMolecularFunction",
+    "Name":"https://schema.org/hasMolecularFunction",
     "Domain Bucket":"< 1K"
   },
   {
     "Class":"Predicate",
-    "Name":"http:\/\/schema.org\/hasMolecularFunction-input",
+    "Name":"https://schema.org/hasMolecularFunction-input",
     "Domain Bucket":"< 1K"
   },
   {
     "Class":"Predicate",
-    "Name":"http:\/\/schema.org\/hasMolecularFunction-output",
+    "Name":"https://schema.org/hasMolecularFunction-output",
     "Domain Bucket":"< 1K"
   },
   {
     "Class":"Predicate",
-    "Name":"http:\/\/schema.org\/hasOccupation",
+    "Name":"https://schema.org/hasOccupation",
     "Domain Bucket":"10K - 100K"
   },
   {
     "Class":"Predicate",
-    "Name":"http:\/\/schema.org\/hasOccupation-input",
+    "Name":"https://schema.org/hasOccupation-input",
     "Domain Bucket":"< 1K"
   },
   {
     "Class":"Predicate",
-    "Name":"http:\/\/schema.org\/hasOccupation-output",
+    "Name":"https://schema.org/hasOccupation-output",
     "Domain Bucket":"< 1K"
   },
   {
     "Class":"Predicate",
-    "Name":"http:\/\/schema.org\/hasOfferCatalog",
+    "Name":"https://schema.org/hasOfferCatalog",
     "Domain Bucket":"100K - 1M"
   },
   {
     "Class":"Predicate",
-    "Name":"http:\/\/schema.org\/hasOfferCatalog-input",
+    "Name":"https://schema.org/hasOfferCatalog-input",
     "Domain Bucket":"< 1K"
   },
   {
     "Class":"Predicate",
-    "Name":"http:\/\/schema.org\/hasOfferCatalog-output",
+    "Name":"https://schema.org/hasOfferCatalog-output",
     "Domain Bucket":"< 1K"
   },
   {
     "Class":"Predicate",
-    "Name":"http:\/\/schema.org\/hasPOS",
+    "Name":"https://schema.org/hasPOS",
     "Domain Bucket":"1K - 10K"
   },
   {
     "Class":"Predicate",
-    "Name":"http:\/\/schema.org\/hasPOS-input",
+    "Name":"https://schema.org/hasPOS-input",
     "Domain Bucket":"< 1K"
   },
   {
     "Class":"Predicate",
-    "Name":"http:\/\/schema.org\/hasPOS-output",
+    "Name":"https://schema.org/hasPOS-output",
     "Domain Bucket":"< 1K"
   },
   {
     "Class":"Predicate",
-    "Name":"http:\/\/schema.org\/hasPart",
+    "Name":"https://schema.org/hasPart",
     "Domain Bucket":"100K - 1M"
   },
   {
     "Class":"Predicate",
-    "Name":"http:\/\/schema.org\/hasPart-input",
+    "Name":"https://schema.org/hasPart-input",
     "Domain Bucket":"< 1K"
   },
   {
     "Class":"Predicate",
-    "Name":"http:\/\/schema.org\/hasPart-output",
+    "Name":"https://schema.org/hasPart-output",
     "Domain Bucket":"< 1K"
   },
   {
     "Class":"Predicate",
-    "Name":"http:\/\/schema.org\/hasParticipationOffer",
+    "Name":"https://schema.org/hasParticipationOffer",
     "Domain Bucket":"< 1K"
   },
   {
     "Class":"Predicate",
-    "Name":"http:\/\/schema.org\/hasParticipationOffer-input",
+    "Name":"https://schema.org/hasParticipationOffer-input",
     "Domain Bucket":"< 1K"
   },
   {
     "Class":"Predicate",
-    "Name":"http:\/\/schema.org\/hasParticipationOffer-output",
+    "Name":"https://schema.org/hasParticipationOffer-output",
     "Domain Bucket":"< 1K"
   },
   {
     "Class":"Predicate",
-    "Name":"http:\/\/schema.org\/hasProductReturnPolicy",
+    "Name":"https://schema.org/hasProductReturnPolicy",
     "Domain Bucket":"< 1K"
   },
   {
     "Class":"Predicate",
-    "Name":"http:\/\/schema.org\/hasProductReturnPolicy-input",
+    "Name":"https://schema.org/hasProductReturnPolicy-input",
     "Domain Bucket":"< 1K"
   },
   {
     "Class":"Predicate",
-    "Name":"http:\/\/schema.org\/hasProductReturnPolicy-output",
+    "Name":"https://schema.org/hasProductReturnPolicy-output",
     "Domain Bucket":"< 1K"
   },
   {
     "Class":"Predicate",
-    "Name":"http:\/\/schema.org\/hasRepresentation",
+    "Name":"https://schema.org/hasRepresentation",
     "Domain Bucket":"< 1K"
   },
   {
     "Class":"Predicate",
-    "Name":"http:\/\/schema.org\/hasRepresentation-input",
+    "Name":"https://schema.org/hasRepresentation-input",
     "Domain Bucket":"< 1K"
   },
   {
     "Class":"Predicate",
-    "Name":"http:\/\/schema.org\/hasRepresentation-output",
+    "Name":"https://schema.org/hasRepresentation-output",
     "Domain Bucket":"< 1K"
   },
   {
     "Class":"Predicate",
-    "Name":"http:\/\/schema.org\/hasShippingService",
+    "Name":"https://schema.org/hasShippingService",
     "Domain Bucket":"10K - 100K"
   },
   {
     "Class":"Predicate",
-    "Name":"http:\/\/schema.org\/hasShippingService-input",
+    "Name":"https://schema.org/hasShippingService-input",
     "Domain Bucket":"< 1K"
   },
   {
     "Class":"Predicate",
-    "Name":"http:\/\/schema.org\/hasShippingService-output",
+    "Name":"https://schema.org/hasShippingService-output",
     "Domain Bucket":"< 1K"
   },
   {
     "Class":"Predicate",
-    "Name":"http:\/\/schema.org\/hasSponsorshipOffer",
+    "Name":"https://schema.org/hasSponsorshipOffer",
     "Domain Bucket":"< 1K"
   },
   {
     "Class":"Predicate",
-    "Name":"http:\/\/schema.org\/hasSponsorshipOffer-input",
+    "Name":"https://schema.org/hasSponsorshipOffer-input",
     "Domain Bucket":"< 1K"
   },
   {
     "Class":"Predicate",
-    "Name":"http:\/\/schema.org\/hasSponsorshipOffer-output",
+    "Name":"https://schema.org/hasSponsorshipOffer-output",
     "Domain Bucket":"< 1K"
   },
   {
     "Class":"Predicate",
-    "Name":"http:\/\/schema.org\/hasStore",
+    "Name":"https://schema.org/hasStore",
     "Domain Bucket":"< 1K"
   },
   {
     "Class":"Predicate",
-    "Name":"http:\/\/schema.org\/hasStore-input",
+    "Name":"https://schema.org/hasStore-input",
     "Domain Bucket":"< 1K"
   },
   {
     "Class":"Predicate",
-    "Name":"http:\/\/schema.org\/hasStore-output",
+    "Name":"https://schema.org/hasStore-output",
     "Domain Bucket":"< 1K"
   },
   {
     "Class":"Predicate",
-    "Name":"http:\/\/schema.org\/hasTierBenefit",
+    "Name":"https://schema.org/hasTierBenefit",
     "Domain Bucket":"< 1K"
   },
   {
     "Class":"Predicate",
-    "Name":"http:\/\/schema.org\/hasTierBenefit-input",
+    "Name":"https://schema.org/hasTierBenefit-input",
     "Domain Bucket":"< 1K"
   },
   {
     "Class":"Predicate",
-    "Name":"http:\/\/schema.org\/hasTierBenefit-output",
+    "Name":"https://schema.org/hasTierBenefit-output",
     "Domain Bucket":"< 1K"
   },
   {
     "Class":"Predicate",
-    "Name":"http:\/\/schema.org\/hasTierRequirement",
+    "Name":"https://schema.org/hasTierRequirement",
     "Domain Bucket":"< 1K"
   },
   {
     "Class":"Predicate",
-    "Name":"http:\/\/schema.org\/hasTierRequirement-input",
+    "Name":"https://schema.org/hasTierRequirement-input",
     "Domain Bucket":"< 1K"
   },
   {
     "Class":"Predicate",
-    "Name":"http:\/\/schema.org\/hasTierRequirement-output",
+    "Name":"https://schema.org/hasTierRequirement-output",
     "Domain Bucket":"< 1K"
   },
   {
     "Class":"Predicate",
-    "Name":"http:\/\/schema.org\/hasTiers",
+    "Name":"https://schema.org/hasTiers",
     "Domain Bucket":"< 1K"
   },
   {
     "Class":"Predicate",
-    "Name":"http:\/\/schema.org\/hasTiers-input",
+    "Name":"https://schema.org/hasTiers-input",
     "Domain Bucket":"< 1K"
   },
   {
     "Class":"Predicate",
-    "Name":"http:\/\/schema.org\/hasTiers-output",
+    "Name":"https://schema.org/hasTiers-output",
     "Domain Bucket":"< 1K"
   },
   {
     "Class":"Predicate",
-    "Name":"http:\/\/schema.org\/hasVariant",
+    "Name":"https://schema.org/hasVariant",
     "Domain Bucket":"100K - 1M"
   },
   {
     "Class":"Predicate",
-    "Name":"http:\/\/schema.org\/hasVariant-input",
+    "Name":"https://schema.org/hasVariant-input",
     "Domain Bucket":"< 1K"
   },
   {
     "Class":"Predicate",
-    "Name":"http:\/\/schema.org\/hasVariant-output",
+    "Name":"https://schema.org/hasVariant-output",
     "Domain Bucket":"< 1K"
   },
   {
     "Class":"Predicate",
-    "Name":"http:\/\/schema.org\/headline",
+    "Name":"https://schema.org/headline",
     "Domain Bucket":"10M+"
   },
   {
     "Class":"Predicate",
-    "Name":"http:\/\/schema.org\/headline-input",
+    "Name":"https://schema.org/headline-input",
     "Domain Bucket":"< 1K"
   },
   {
     "Class":"Predicate",
-    "Name":"http:\/\/schema.org\/headline-output",
+    "Name":"https://schema.org/headline-output",
     "Domain Bucket":"< 1K"
   },
   {
     "Class":"Predicate",
-    "Name":"http:\/\/schema.org\/healthCondition",
+    "Name":"https://schema.org/healthCondition",
     "Domain Bucket":"1K - 10K"
   },
   {
     "Class":"Predicate",
-    "Name":"http:\/\/schema.org\/healthCondition-input",
+    "Name":"https://schema.org/healthCondition-input",
     "Domain Bucket":"< 1K"
   },
   {
     "Class":"Predicate",
-    "Name":"http:\/\/schema.org\/healthCondition-output",
+    "Name":"https://schema.org/healthCondition-output",
     "Domain Bucket":"< 1K"
   },
   {
     "Class":"Predicate",
-    "Name":"http:\/\/schema.org\/healthPlanCoinsuranceOption",
+    "Name":"https://schema.org/healthPlanCoinsuranceOption",
     "Domain Bucket":"< 1K"
   },
   {
     "Class":"Predicate",
-    "Name":"http:\/\/schema.org\/healthPlanCoinsuranceOption-input",
+    "Name":"https://schema.org/healthPlanCoinsuranceOption-input",
     "Domain Bucket":"< 1K"
   },
   {
     "Class":"Predicate",
-    "Name":"http:\/\/schema.org\/healthPlanCoinsuranceOption-output",
+    "Name":"https://schema.org/healthPlanCoinsuranceOption-output",
     "Domain Bucket":"< 1K"
   },
   {
     "Class":"Predicate",
-    "Name":"http:\/\/schema.org\/healthPlanCoinsuranceRate",
+    "Name":"https://schema.org/healthPlanCoinsuranceRate",
     "Domain Bucket":"< 1K"
   },
   {
     "Class":"Predicate",
-    "Name":"http:\/\/schema.org\/healthPlanCoinsuranceRate-input",
+    "Name":"https://schema.org/healthPlanCoinsuranceRate-input",
     "Domain Bucket":"< 1K"
   },
   {
     "Class":"Predicate",
-    "Name":"http:\/\/schema.org\/healthPlanCoinsuranceRate-output",
+    "Name":"https://schema.org/healthPlanCoinsuranceRate-output",
     "Domain Bucket":"< 1K"
   },
   {
     "Class":"Predicate",
-    "Name":"http:\/\/schema.org\/healthPlanCopay",
+    "Name":"https://schema.org/healthPlanCopay",
     "Domain Bucket":"< 1K"
   },
   {
     "Class":"Predicate",
-    "Name":"http:\/\/schema.org\/healthPlanCopay-input",
+    "Name":"https://schema.org/healthPlanCopay-input",
     "Domain Bucket":"< 1K"
   },
   {
     "Class":"Predicate",
-    "Name":"http:\/\/schema.org\/healthPlanCopay-output",
+    "Name":"https://schema.org/healthPlanCopay-output",
     "Domain Bucket":"< 1K"
   },
   {
     "Class":"Predicate",
-    "Name":"http:\/\/schema.org\/healthPlanCopayOption",
+    "Name":"https://schema.org/healthPlanCopayOption",
     "Domain Bucket":"< 1K"
   },
   {
     "Class":"Predicate",
-    "Name":"http:\/\/schema.org\/healthPlanCopayOption-input",
+    "Name":"https://schema.org/healthPlanCopayOption-input",
     "Domain Bucket":"< 1K"
   },
   {
     "Class":"Predicate",
-    "Name":"http:\/\/schema.org\/healthPlanCopayOption-output",
+    "Name":"https://schema.org/healthPlanCopayOption-output",
     "Domain Bucket":"< 1K"
   },
   {
     "Class":"Predicate",
-    "Name":"http:\/\/schema.org\/healthPlanCostSharing",
+    "Name":"https://schema.org/healthPlanCostSharing",
     "Domain Bucket":"< 1K"
   },
   {
     "Class":"Predicate",
-    "Name":"http:\/\/schema.org\/healthPlanCostSharing-input",
+    "Name":"https://schema.org/healthPlanCostSharing-input",
     "Domain Bucket":"< 1K"
   },
   {
     "Class":"Predicate",
-    "Name":"http:\/\/schema.org\/healthPlanCostSharing-output",
+    "Name":"https://schema.org/healthPlanCostSharing-output",
     "Domain Bucket":"< 1K"
   },
   {
     "Class":"Predicate",
-    "Name":"http:\/\/schema.org\/healthPlanDrugOption",
+    "Name":"https://schema.org/healthPlanDrugOption",
     "Domain Bucket":"< 1K"
   },
   {
     "Class":"Predicate",
-    "Name":"http:\/\/schema.org\/healthPlanDrugOption-input",
+    "Name":"https://schema.org/healthPlanDrugOption-input",
     "Domain Bucket":"< 1K"
   },
   {
     "Class":"Predicate",
-    "Name":"http:\/\/schema.org\/healthPlanDrugOption-output",
+    "Name":"https://schema.org/healthPlanDrugOption-output",
     "Domain Bucket":"< 1K"
   },
   {
     "Class":"Predicate",
-    "Name":"http:\/\/schema.org\/healthPlanDrugTier",
+    "Name":"https://schema.org/healthPlanDrugTier",
     "Domain Bucket":"< 1K"
   },
   {
     "Class":"Predicate",
-    "Name":"http:\/\/schema.org\/healthPlanDrugTier-input",
+    "Name":"https://schema.org/healthPlanDrugTier-input",
     "Domain Bucket":"< 1K"
   },
   {
     "Class":"Predicate",
-    "Name":"http:\/\/schema.org\/healthPlanDrugTier-output",
+    "Name":"https://schema.org/healthPlanDrugTier-output",
     "Domain Bucket":"< 1K"
   },
   {
     "Class":"Predicate",
-    "Name":"http:\/\/schema.org\/healthPlanId",
+    "Name":"https://schema.org/healthPlanId",
     "Domain Bucket":"< 1K"
   },
   {
     "Class":"Predicate",
-    "Name":"http:\/\/schema.org\/healthPlanId-input",
+    "Name":"https://schema.org/healthPlanId-input",
     "Domain Bucket":"< 1K"
   },
   {
     "Class":"Predicate",
-    "Name":"http:\/\/schema.org\/healthPlanId-output",
+    "Name":"https://schema.org/healthPlanId-output",
     "Domain Bucket":"< 1K"
   },
   {
     "Class":"Predicate",
-    "Name":"http:\/\/schema.org\/healthPlanMarketingUrl",
+    "Name":"https://schema.org/healthPlanMarketingUrl",
     "Domain Bucket":"< 1K"
   },
   {
     "Class":"Predicate",
-    "Name":"http:\/\/schema.org\/healthPlanMarketingUrl-input",
+    "Name":"https://schema.org/healthPlanMarketingUrl-input",
     "Domain Bucket":"< 1K"
   },
   {
     "Class":"Predicate",
-    "Name":"http:\/\/schema.org\/healthPlanMarketingUrl-output",
+    "Name":"https://schema.org/healthPlanMarketingUrl-output",
     "Domain Bucket":"< 1K"
   },
   {
     "Class":"Predicate",
-    "Name":"http:\/\/schema.org\/healthPlanNetworkId",
+    "Name":"https://schema.org/healthPlanNetworkId",
     "Domain Bucket":"< 1K"
   },
   {
     "Class":"Predicate",
-    "Name":"http:\/\/schema.org\/healthPlanNetworkId-input",
+    "Name":"https://schema.org/healthPlanNetworkId-input",
     "Domain Bucket":"< 1K"
   },
   {
     "Class":"Predicate",
-    "Name":"http:\/\/schema.org\/healthPlanNetworkId-output",
+    "Name":"https://schema.org/healthPlanNetworkId-output",
     "Domain Bucket":"< 1K"
   },
   {
     "Class":"Predicate",
-    "Name":"http:\/\/schema.org\/healthPlanNetworkTier",
+    "Name":"https://schema.org/healthPlanNetworkTier",
     "Domain Bucket":"< 1K"
   },
   {
     "Class":"Predicate",
-    "Name":"http:\/\/schema.org\/healthPlanNetworkTier-input",
+    "Name":"https://schema.org/healthPlanNetworkTier-input",
     "Domain Bucket":"< 1K"
   },
   {
     "Class":"Predicate",
-    "Name":"http:\/\/schema.org\/healthPlanNetworkTier-output",
+    "Name":"https://schema.org/healthPlanNetworkTier-output",
     "Domain Bucket":"< 1K"
   },
   {
     "Class":"Predicate",
-    "Name":"http:\/\/schema.org\/healthPlanPharmacyCategory",
+    "Name":"https://schema.org/healthPlanPharmacyCategory",
     "Domain Bucket":"< 1K"
   },
   {
     "Class":"Predicate",
-    "Name":"http:\/\/schema.org\/healthPlanPharmacyCategory-input",
+    "Name":"https://schema.org/healthPlanPharmacyCategory-input",
     "Domain Bucket":"< 1K"
   },
   {
     "Class":"Predicate",
-    "Name":"http:\/\/schema.org\/healthPlanPharmacyCategory-output",
+    "Name":"https://schema.org/healthPlanPharmacyCategory-output",
     "Domain Bucket":"< 1K"
   },
   {
     "Class":"Predicate",
-    "Name":"http:\/\/schema.org\/healthcareReportingData",
+    "Name":"https://schema.org/healthcareReportingData",
     "Domain Bucket":"< 1K"
   },
   {
     "Class":"Predicate",
-    "Name":"http:\/\/schema.org\/healthcareReportingData-input",
+    "Name":"https://schema.org/healthcareReportingData-input",
     "Domain Bucket":"< 1K"
   },
   {
     "Class":"Predicate",
-    "Name":"http:\/\/schema.org\/healthcareReportingData-output",
+    "Name":"https://schema.org/healthcareReportingData-output",
     "Domain Bucket":"< 1K"
   },
   {
     "Class":"Predicate",
-    "Name":"http:\/\/schema.org\/height",
+    "Name":"https://schema.org/height",
     "Domain Bucket":"10M+"
   },
   {
     "Class":"Predicate",
-    "Name":"http:\/\/schema.org\/height-input",
+    "Name":"https://schema.org/height-input",
     "Domain Bucket":"< 1K"
   },
   {
     "Class":"Predicate",
-    "Name":"http:\/\/schema.org\/height-output",
+    "Name":"https://schema.org/height-output",
     "Domain Bucket":"< 1K"
   },
   {
     "Class":"Predicate",
-    "Name":"http:\/\/schema.org\/highPrice",
+    "Name":"https://schema.org/highPrice",
     "Domain Bucket":"1M - 10M"
   },
   {
     "Class":"Predicate",
-    "Name":"http:\/\/schema.org\/highPrice-input",
+    "Name":"https://schema.org/highPrice-input",
     "Domain Bucket":"< 1K"
   },
   {
     "Class":"Predicate",
-    "Name":"http:\/\/schema.org\/highPrice-output",
+    "Name":"https://schema.org/highPrice-output",
     "Domain Bucket":"< 1K"
   },
   {
     "Class":"Predicate",
-    "Name":"http:\/\/schema.org\/hiringOrganization",
+    "Name":"https://schema.org/hiringOrganization",
     "Domain Bucket":"100K - 1M"
   },
   {
     "Class":"Predicate",
-    "Name":"http:\/\/schema.org\/hiringOrganization-input",
+    "Name":"https://schema.org/hiringOrganization-input",
     "Domain Bucket":"< 1K"
   },
   {
     "Class":"Predicate",
-    "Name":"http:\/\/schema.org\/hiringOrganization-output",
+    "Name":"https://schema.org/hiringOrganization-output",
     "Domain Bucket":"< 1K"
   },
   {
     "Class":"Predicate",
-    "Name":"http:\/\/schema.org\/holdingArchive",
+    "Name":"https://schema.org/holdingArchive",
     "Domain Bucket":"< 1K"
   },
   {
     "Class":"Predicate",
-    "Name":"http:\/\/schema.org\/holdingArchive-input",
+    "Name":"https://schema.org/holdingArchive-input",
     "Domain Bucket":"< 1K"
   },
   {
     "Class":"Predicate",
-    "Name":"http:\/\/schema.org\/holdingArchive-output",
+    "Name":"https://schema.org/holdingArchive-output",
     "Domain Bucket":"< 1K"
   },
   {
     "Class":"Predicate",
-    "Name":"http:\/\/schema.org\/homeLocation",
+    "Name":"https://schema.org/homeLocation",
     "Domain Bucket":"10K - 100K"
   },
   {
     "Class":"Predicate",
-    "Name":"http:\/\/schema.org\/homeLocation-input",
+    "Name":"https://schema.org/homeLocation-input",
     "Domain Bucket":"< 1K"
   },
   {
     "Class":"Predicate",
-    "Name":"http:\/\/schema.org\/homeLocation-output",
+    "Name":"https://schema.org/homeLocation-output",
     "Domain Bucket":"< 1K"
   },
   {
     "Class":"Predicate",
-    "Name":"http:\/\/schema.org\/homeTeam",
+    "Name":"https://schema.org/homeTeam",
     "Domain Bucket":"10K - 100K"
   },
   {
     "Class":"Predicate",
-    "Name":"http:\/\/schema.org\/homeTeam-input",
+    "Name":"https://schema.org/homeTeam-input",
     "Domain Bucket":"< 1K"
   },
   {
     "Class":"Predicate",
-    "Name":"http:\/\/schema.org\/homeTeam-output",
+    "Name":"https://schema.org/homeTeam-output",
     "Domain Bucket":"< 1K"
   },
   {
     "Class":"Predicate",
-    "Name":"http:\/\/schema.org\/honorificPrefix",
+    "Name":"https://schema.org/honorificPrefix",
     "Domain Bucket":"10K - 100K"
   },
   {
     "Class":"Predicate",
-    "Name":"http:\/\/schema.org\/honorificPrefix-input",
+    "Name":"https://schema.org/honorificPrefix-input",
     "Domain Bucket":"< 1K"
   },
   {
     "Class":"Predicate",
-    "Name":"http:\/\/schema.org\/honorificPrefix-output",
+    "Name":"https://schema.org/honorificPrefix-output",
     "Domain Bucket":"< 1K"
   },
   {
     "Class":"Predicate",
-    "Name":"http:\/\/schema.org\/honorificSuffix",
+    "Name":"https://schema.org/honorificSuffix",
     "Domain Bucket":"10K - 100K"
   },
   {
     "Class":"Predicate",
-    "Name":"http:\/\/schema.org\/honorificSuffix-input",
+    "Name":"https://schema.org/honorificSuffix-input",
     "Domain Bucket":"< 1K"
   },
   {
     "Class":"Predicate",
-    "Name":"http:\/\/schema.org\/honorificSuffix-output",
+    "Name":"https://schema.org/honorificSuffix-output",
     "Domain Bucket":"< 1K"
   },
   {
     "Class":"Predicate",
-    "Name":"http:\/\/schema.org\/hospitalAffiliation",
+    "Name":"https://schema.org/hospitalAffiliation",
     "Domain Bucket":"1K - 10K"
   },
   {
     "Class":"Predicate",
-    "Name":"http:\/\/schema.org\/hospitalAffiliation-input",
+    "Name":"https://schema.org/hospitalAffiliation-input",
     "Domain Bucket":"< 1K"
   },
   {
     "Class":"Predicate",
-    "Name":"http:\/\/schema.org\/hospitalAffiliation-output",
+    "Name":"https://schema.org/hospitalAffiliation-output",
     "Domain Bucket":"< 1K"
   },
   {
     "Class":"Predicate",
-    "Name":"http:\/\/schema.org\/hostingOrganization",
+    "Name":"https://schema.org/hostingOrganization",
     "Domain Bucket":"1K - 10K"
   },
   {
     "Class":"Predicate",
-    "Name":"http:\/\/schema.org\/hostingOrganization-input",
+    "Name":"https://schema.org/hostingOrganization-input",
     "Domain Bucket":"< 1K"
   },
   {
     "Class":"Predicate",
-    "Name":"http:\/\/schema.org\/hostingOrganization-output",
+    "Name":"https://schema.org/hostingOrganization-output",
     "Domain Bucket":"< 1K"
   },
   {
     "Class":"Predicate",
-    "Name":"http:\/\/schema.org\/hoursAvailable",
+    "Name":"https://schema.org/hoursAvailable",
     "Domain Bucket":"100K - 1M"
   },
   {
     "Class":"Predicate",
-    "Name":"http:\/\/schema.org\/hoursAvailable-input",
+    "Name":"https://schema.org/hoursAvailable-input",
     "Domain Bucket":"< 1K"
   },
   {
     "Class":"Predicate",
-    "Name":"http:\/\/schema.org\/hoursAvailable-output",
+    "Name":"https://schema.org/hoursAvailable-output",
     "Domain Bucket":"< 1K"
   },
   {
     "Class":"Predicate",
-    "Name":"http:\/\/schema.org\/howPerformed",
+    "Name":"https://schema.org/howPerformed",
     "Domain Bucket":"1K - 10K"
   },
   {
     "Class":"Predicate",
-    "Name":"http:\/\/schema.org\/howPerformed-input",
+    "Name":"https://schema.org/howPerformed-input",
     "Domain Bucket":"< 1K"
   },
   {
     "Class":"Predicate",
-    "Name":"http:\/\/schema.org\/howPerformed-output",
+    "Name":"https://schema.org/howPerformed-output",
     "Domain Bucket":"< 1K"
   },
   {
     "Class":"Predicate",
-    "Name":"http:\/\/schema.org\/httpMethod",
+    "Name":"https://schema.org/httpMethod",
     "Domain Bucket":"1K - 10K"
   },
   {
     "Class":"Predicate",
-    "Name":"http:\/\/schema.org\/httpMethod-input",
+    "Name":"https://schema.org/httpMethod-input",
     "Domain Bucket":"< 1K"
   },
   {
     "Class":"Predicate",
-    "Name":"http:\/\/schema.org\/httpMethod-output",
+    "Name":"https://schema.org/httpMethod-output",
     "Domain Bucket":"< 1K"
   },
   {
     "Class":"Predicate",
-    "Name":"http:\/\/schema.org\/iataCode",
+    "Name":"https://schema.org/iataCode",
     "Domain Bucket":"1K - 10K"
   },
   {
     "Class":"Predicate",
-    "Name":"http:\/\/schema.org\/iataCode-input",
+    "Name":"https://schema.org/iataCode-input",
     "Domain Bucket":"< 1K"
   },
   {
     "Class":"Predicate",
-    "Name":"http:\/\/schema.org\/iataCode-output",
+    "Name":"https://schema.org/iataCode-output",
     "Domain Bucket":"< 1K"
   },
   {
     "Class":"Predicate",
-    "Name":"http:\/\/schema.org\/icaoCode",
+    "Name":"https://schema.org/icaoCode",
     "Domain Bucket":"< 1K"
   },
   {
     "Class":"Predicate",
-    "Name":"http:\/\/schema.org\/icaoCode-input",
+    "Name":"https://schema.org/icaoCode-input",
     "Domain Bucket":"< 1K"
   },
   {
     "Class":"Predicate",
-    "Name":"http:\/\/schema.org\/icaoCode-output",
+    "Name":"https://schema.org/icaoCode-output",
     "Domain Bucket":"< 1K"
   },
   {
     "Class":"Predicate",
-    "Name":"http:\/\/schema.org\/identifier",
+    "Name":"https://schema.org/identifier",
     "Domain Bucket":"100K - 1M"
   },
   {
     "Class":"Predicate",
-    "Name":"http:\/\/schema.org\/identifier-input",
+    "Name":"https://schema.org/identifier-input",
     "Domain Bucket":"< 1K"
   },
   {
     "Class":"Predicate",
-    "Name":"http:\/\/schema.org\/identifier-output",
+    "Name":"https://schema.org/identifier-output",
     "Domain Bucket":"< 1K"
   },
   {
     "Class":"Predicate",
-    "Name":"http:\/\/schema.org\/identifyingExam",
+    "Name":"https://schema.org/identifyingExam",
     "Domain Bucket":"< 1K"
   },
   {
     "Class":"Predicate",
-    "Name":"http:\/\/schema.org\/identifyingExam-input",
+    "Name":"https://schema.org/identifyingExam-input",
     "Domain Bucket":"< 1K"
   },
   {
     "Class":"Predicate",
-    "Name":"http:\/\/schema.org\/identifyingExam-output",
+    "Name":"https://schema.org/identifyingExam-output",
     "Domain Bucket":"< 1K"
   },
   {
     "Class":"Predicate",
-    "Name":"http:\/\/schema.org\/identifyingTest",
+    "Name":"https://schema.org/identifyingTest",
     "Domain Bucket":"< 1K"
   },
   {
     "Class":"Predicate",
-    "Name":"http:\/\/schema.org\/identifyingTest-input",
+    "Name":"https://schema.org/identifyingTest-input",
     "Domain Bucket":"< 1K"
   },
   {
     "Class":"Predicate",
-    "Name":"http:\/\/schema.org\/identifyingTest-output",
+    "Name":"https://schema.org/identifyingTest-output",
     "Domain Bucket":"< 1K"
   },
   {
     "Class":"Predicate",
-    "Name":"http:\/\/schema.org\/illustrator",
+    "Name":"https://schema.org/illustrator",
     "Domain Bucket":"1K - 10K"
   },
   {
     "Class":"Predicate",
-    "Name":"http:\/\/schema.org\/illustrator-input",
+    "Name":"https://schema.org/illustrator-input",
     "Domain Bucket":"< 1K"
   },
   {
     "Class":"Predicate",
-    "Name":"http:\/\/schema.org\/illustrator-output",
+    "Name":"https://schema.org/illustrator-output",
     "Domain Bucket":"< 1K"
   },
   {
     "Class":"Predicate",
-    "Name":"http:\/\/schema.org\/image",
+    "Name":"https://schema.org/image",
     "Domain Bucket":"10M+"
   },
   {
     "Class":"Predicate",
-    "Name":"http:\/\/schema.org\/image-input",
+    "Name":"https://schema.org/image-input",
     "Domain Bucket":"< 1K"
   },
   {
     "Class":"Predicate",
-    "Name":"http:\/\/schema.org\/image-output",
+    "Name":"https://schema.org/image-output",
     "Domain Bucket":"< 1K"
   },
   {
     "Class":"Predicate",
-    "Name":"http:\/\/schema.org\/imagingTechnique",
+    "Name":"https://schema.org/imagingTechnique",
     "Domain Bucket":"< 1K"
   },
   {
     "Class":"Predicate",
-    "Name":"http:\/\/schema.org\/imagingTechnique-input",
+    "Name":"https://schema.org/imagingTechnique-input",
     "Domain Bucket":"< 1K"
   },
   {
     "Class":"Predicate",
-    "Name":"http:\/\/schema.org\/imagingTechnique-output",
+    "Name":"https://schema.org/imagingTechnique-output",
     "Domain Bucket":"< 1K"
   },
   {
     "Class":"Predicate",
-    "Name":"http:\/\/schema.org\/inAlbum",
+    "Name":"https://schema.org/inAlbum",
     "Domain Bucket":"10K - 100K"
   },
   {
     "Class":"Predicate",
-    "Name":"http:\/\/schema.org\/inAlbum-input",
+    "Name":"https://schema.org/inAlbum-input",
     "Domain Bucket":"< 1K"
   },
   {
     "Class":"Predicate",
-    "Name":"http:\/\/schema.org\/inAlbum-output",
+    "Name":"https://schema.org/inAlbum-output",
     "Domain Bucket":"< 1K"
   },
   {
     "Class":"Predicate",
-    "Name":"http:\/\/schema.org\/inBroadcastLineup",
+    "Name":"https://schema.org/inBroadcastLineup",
     "Domain Bucket":"< 1K"
   },
   {
     "Class":"Predicate",
-    "Name":"http:\/\/schema.org\/inBroadcastLineup-input",
+    "Name":"https://schema.org/inBroadcastLineup-input",
     "Domain Bucket":"< 1K"
   },
   {
     "Class":"Predicate",
-    "Name":"http:\/\/schema.org\/inBroadcastLineup-output",
+    "Name":"https://schema.org/inBroadcastLineup-output",
     "Domain Bucket":"< 1K"
   },
   {
     "Class":"Predicate",
-    "Name":"http:\/\/schema.org\/inChI",
+    "Name":"https://schema.org/inChI",
     "Domain Bucket":"< 1K"
   },
   {
     "Class":"Predicate",
-    "Name":"http:\/\/schema.org\/inChI-input",
+    "Name":"https://schema.org/inChI-input",
     "Domain Bucket":"< 1K"
   },
   {
     "Class":"Predicate",
-    "Name":"http:\/\/schema.org\/inChI-output",
+    "Name":"https://schema.org/inChI-output",
     "Domain Bucket":"< 1K"
   },
   {
     "Class":"Predicate",
-    "Name":"http:\/\/schema.org\/inChIKey",
+    "Name":"https://schema.org/inChIKey",
     "Domain Bucket":"< 1K"
   },
   {
     "Class":"Predicate",
-    "Name":"http:\/\/schema.org\/inChIKey-input",
+    "Name":"https://schema.org/inChIKey-input",
     "Domain Bucket":"< 1K"
   },
   {
     "Class":"Predicate",
-    "Name":"http:\/\/schema.org\/inChIKey-output",
+    "Name":"https://schema.org/inChIKey-output",
     "Domain Bucket":"< 1K"
   },
   {
     "Class":"Predicate",
-    "Name":"http:\/\/schema.org\/inCodeSet",
+    "Name":"https://schema.org/inCodeSet",
     "Domain Bucket":"1K - 10K"
   },
   {
     "Class":"Predicate",
-    "Name":"http:\/\/schema.org\/inCodeSet-input",
+    "Name":"https://schema.org/inCodeSet-input",
     "Domain Bucket":"< 1K"
   },
   {
     "Class":"Predicate",
-    "Name":"http:\/\/schema.org\/inCodeSet-output",
+    "Name":"https://schema.org/inCodeSet-output",
     "Domain Bucket":"< 1K"
   },
   {
     "Class":"Predicate",
-    "Name":"http:\/\/schema.org\/inDefinedTermSet",
+    "Name":"https://schema.org/inDefinedTermSet",
     "Domain Bucket":"10K - 100K"
   },
   {
     "Class":"Predicate",
-    "Name":"http:\/\/schema.org\/inDefinedTermSet-input",
+    "Name":"https://schema.org/inDefinedTermSet-input",
     "Domain Bucket":"< 1K"
   },
   {
     "Class":"Predicate",
-    "Name":"http:\/\/schema.org\/inDefinedTermSet-output",
+    "Name":"https://schema.org/inDefinedTermSet-output",
     "Domain Bucket":"< 1K"
   },
   {
     "Class":"Predicate",
-    "Name":"http:\/\/schema.org\/inLanguage",
+    "Name":"https://schema.org/inLanguage",
     "Domain Bucket":"10M+"
   },
   {
     "Class":"Predicate",
-    "Name":"http:\/\/schema.org\/inLanguage-input",
+    "Name":"https://schema.org/inLanguage-input",
     "Domain Bucket":"< 1K"
   },
   {
     "Class":"Predicate",
-    "Name":"http:\/\/schema.org\/inLanguage-output",
+    "Name":"https://schema.org/inLanguage-output",
     "Domain Bucket":"< 1K"
   },
   {
     "Class":"Predicate",
-    "Name":"http:\/\/schema.org\/inPlaylist",
+    "Name":"https://schema.org/inPlaylist",
     "Domain Bucket":"< 1K"
   },
   {
     "Class":"Predicate",
-    "Name":"http:\/\/schema.org\/inPlaylist-input",
+    "Name":"https://schema.org/inPlaylist-input",
     "Domain Bucket":"< 1K"
   },
   {
     "Class":"Predicate",
-    "Name":"http:\/\/schema.org\/inPlaylist-output",
+    "Name":"https://schema.org/inPlaylist-output",
     "Domain Bucket":"< 1K"
   },
   {
     "Class":"Predicate",
-    "Name":"http:\/\/schema.org\/inProductGroupWithID",
+    "Name":"https://schema.org/inProductGroupWithID",
     "Domain Bucket":"1K - 10K"
   },
   {
     "Class":"Predicate",
-    "Name":"http:\/\/schema.org\/inProductGroupWithID-input",
+    "Name":"https://schema.org/inProductGroupWithID-input",
     "Domain Bucket":"< 1K"
   },
   {
     "Class":"Predicate",
-    "Name":"http:\/\/schema.org\/inProductGroupWithID-output",
+    "Name":"https://schema.org/inProductGroupWithID-output",
     "Domain Bucket":"< 1K"
   },
   {
     "Class":"Predicate",
-    "Name":"http:\/\/schema.org\/inStoreReturnsOffered",
+    "Name":"https://schema.org/inStoreReturnsOffered",
     "Domain Bucket":"1K - 10K"
   },
   {
     "Class":"Predicate",
-    "Name":"http:\/\/schema.org\/inStoreReturnsOffered-input",
+    "Name":"https://schema.org/inStoreReturnsOffered-input",
     "Domain Bucket":"< 1K"
   },
   {
     "Class":"Predicate",
-    "Name":"http:\/\/schema.org\/inStoreReturnsOffered-output",
+    "Name":"https://schema.org/inStoreReturnsOffered-output",
     "Domain Bucket":"< 1K"
   },
   {
     "Class":"Predicate",
-    "Name":"http:\/\/schema.org\/inSupportOf",
+    "Name":"https://schema.org/inSupportOf",
     "Domain Bucket":"< 1K"
   },
   {
     "Class":"Predicate",
-    "Name":"http:\/\/schema.org\/inSupportOf-input",
+    "Name":"https://schema.org/inSupportOf-input",
     "Domain Bucket":"< 1K"
   },
   {
     "Class":"Predicate",
-    "Name":"http:\/\/schema.org\/inSupportOf-output",
+    "Name":"https://schema.org/inSupportOf-output",
     "Domain Bucket":"< 1K"
   },
   {
     "Class":"Predicate",
-    "Name":"http:\/\/schema.org\/incentiveAmount",
+    "Name":"https://schema.org/incentiveAmount",
     "Domain Bucket":"< 1K"
   },
   {
     "Class":"Predicate",
-    "Name":"http:\/\/schema.org\/incentiveAmount-input",
+    "Name":"https://schema.org/incentiveAmount-input",
     "Domain Bucket":"< 1K"
   },
   {
     "Class":"Predicate",
-    "Name":"http:\/\/schema.org\/incentiveAmount-output",
+    "Name":"https://schema.org/incentiveAmount-output",
     "Domain Bucket":"< 1K"
   },
   {
     "Class":"Predicate",
-    "Name":"http:\/\/schema.org\/incentiveCompensation",
+    "Name":"https://schema.org/incentiveCompensation",
     "Domain Bucket":"1K - 10K"
   },
   {
     "Class":"Predicate",
-    "Name":"http:\/\/schema.org\/incentiveCompensation-input",
+    "Name":"https://schema.org/incentiveCompensation-input",
     "Domain Bucket":"< 1K"
   },
   {
     "Class":"Predicate",
-    "Name":"http:\/\/schema.org\/incentiveCompensation-output",
+    "Name":"https://schema.org/incentiveCompensation-output",
     "Domain Bucket":"< 1K"
   },
   {
     "Class":"Predicate",
-    "Name":"http:\/\/schema.org\/incentiveStatus",
+    "Name":"https://schema.org/incentiveStatus",
     "Domain Bucket":"< 1K"
   },
   {
     "Class":"Predicate",
-    "Name":"http:\/\/schema.org\/incentiveStatus-input",
+    "Name":"https://schema.org/incentiveStatus-input",
     "Domain Bucket":"< 1K"
   },
   {
     "Class":"Predicate",
-    "Name":"http:\/\/schema.org\/incentiveStatus-output",
+    "Name":"https://schema.org/incentiveStatus-output",
     "Domain Bucket":"< 1K"
   },
   {
     "Class":"Predicate",
-    "Name":"http:\/\/schema.org\/incentiveType",
+    "Name":"https://schema.org/incentiveType",
     "Domain Bucket":"< 1K"
   },
   {
     "Class":"Predicate",
-    "Name":"http:\/\/schema.org\/incentiveType-input",
+    "Name":"https://schema.org/incentiveType-input",
     "Domain Bucket":"< 1K"
   },
   {
     "Class":"Predicate",
-    "Name":"http:\/\/schema.org\/incentiveType-output",
+    "Name":"https://schema.org/incentiveType-output",
     "Domain Bucket":"< 1K"
   },
   {
     "Class":"Predicate",
-    "Name":"http:\/\/schema.org\/incentives",
+    "Name":"https://schema.org/incentives",
     "Domain Bucket":"< 1K"
   },
   {
     "Class":"Predicate",
-    "Name":"http:\/\/schema.org\/incentives-input",
+    "Name":"https://schema.org/incentives-input",
     "Domain Bucket":"< 1K"
   },
   {
     "Class":"Predicate",
-    "Name":"http:\/\/schema.org\/incentives-output",
+    "Name":"https://schema.org/incentives-output",
     "Domain Bucket":"< 1K"
   },
   {
     "Class":"Predicate",
-    "Name":"http:\/\/schema.org\/incentivizedItem",
+    "Name":"https://schema.org/incentivizedItem",
     "Domain Bucket":"< 1K"
   },
   {
     "Class":"Predicate",
-    "Name":"http:\/\/schema.org\/incentivizedItem-input",
+    "Name":"https://schema.org/incentivizedItem-input",
     "Domain Bucket":"< 1K"
   },
   {
     "Class":"Predicate",
-    "Name":"http:\/\/schema.org\/incentivizedItem-output",
+    "Name":"https://schema.org/incentivizedItem-output",
     "Domain Bucket":"< 1K"
   },
   {
     "Class":"Predicate",
-    "Name":"http:\/\/schema.org\/includedComposition",
+    "Name":"https://schema.org/includedComposition",
     "Domain Bucket":"< 1K"
   },
   {
     "Class":"Predicate",
-    "Name":"http:\/\/schema.org\/includedComposition-input",
+    "Name":"https://schema.org/includedComposition-input",
     "Domain Bucket":"< 1K"
   },
   {
     "Class":"Predicate",
-    "Name":"http:\/\/schema.org\/includedComposition-output",
+    "Name":"https://schema.org/includedComposition-output",
     "Domain Bucket":"< 1K"
   },
   {
     "Class":"Predicate",
-    "Name":"http:\/\/schema.org\/includedDataCatalog",
+    "Name":"https://schema.org/includedDataCatalog",
     "Domain Bucket":"< 1K"
   },
   {
     "Class":"Predicate",
-    "Name":"http:\/\/schema.org\/includedDataCatalog-input",
+    "Name":"https://schema.org/includedDataCatalog-input",
     "Domain Bucket":"< 1K"
   },
   {
     "Class":"Predicate",
-    "Name":"http:\/\/schema.org\/includedDataCatalog-output",
+    "Name":"https://schema.org/includedDataCatalog-output",
     "Domain Bucket":"< 1K"
   },
   {
     "Class":"Predicate",
-    "Name":"http:\/\/schema.org\/includedInDataCatalog",
+    "Name":"https://schema.org/includedInDataCatalog",
     "Domain Bucket":"1K - 10K"
   },
   {
     "Class":"Predicate",
-    "Name":"http:\/\/schema.org\/includedInDataCatalog-input",
+    "Name":"https://schema.org/includedInDataCatalog-input",
     "Domain Bucket":"< 1K"
   },
   {
     "Class":"Predicate",
-    "Name":"http:\/\/schema.org\/includedInDataCatalog-output",
+    "Name":"https://schema.org/includedInDataCatalog-output",
     "Domain Bucket":"< 1K"
   },
   {
     "Class":"Predicate",
-    "Name":"http:\/\/schema.org\/includedInHealthInsurancePlan",
+    "Name":"https://schema.org/includedInHealthInsurancePlan",
     "Domain Bucket":"< 1K"
   },
   {
     "Class":"Predicate",
-    "Name":"http:\/\/schema.org\/includedInHealthInsurancePlan-input",
+    "Name":"https://schema.org/includedInHealthInsurancePlan-input",
     "Domain Bucket":"< 1K"
   },
   {
     "Class":"Predicate",
-    "Name":"http:\/\/schema.org\/includedInHealthInsurancePlan-output",
+    "Name":"https://schema.org/includedInHealthInsurancePlan-output",
     "Domain Bucket":"< 1K"
   },
   {
     "Class":"Predicate",
-    "Name":"http:\/\/schema.org\/includedRiskFactor",
+    "Name":"https://schema.org/includedRiskFactor",
     "Domain Bucket":"< 1K"
   },
   {
     "Class":"Predicate",
-    "Name":"http:\/\/schema.org\/includedRiskFactor-input",
+    "Name":"https://schema.org/includedRiskFactor-input",
     "Domain Bucket":"< 1K"
   },
   {
     "Class":"Predicate",
-    "Name":"http:\/\/schema.org\/includedRiskFactor-output",
+    "Name":"https://schema.org/includedRiskFactor-output",
     "Domain Bucket":"< 1K"
   },
   {
     "Class":"Predicate",
-    "Name":"http:\/\/schema.org\/includesAttraction",
+    "Name":"https://schema.org/includesAttraction",
     "Domain Bucket":"1K - 10K"
   },
   {
     "Class":"Predicate",
-    "Name":"http:\/\/schema.org\/includesAttraction-input",
+    "Name":"https://schema.org/includesAttraction-input",
     "Domain Bucket":"< 1K"
   },
   {
     "Class":"Predicate",
-    "Name":"http:\/\/schema.org\/includesAttraction-output",
+    "Name":"https://schema.org/includesAttraction-output",
     "Domain Bucket":"< 1K"
   },
   {
     "Class":"Predicate",
-    "Name":"http:\/\/schema.org\/includesHealthPlanFormulary",
+    "Name":"https://schema.org/includesHealthPlanFormulary",
     "Domain Bucket":"< 1K"
   },
   {
     "Class":"Predicate",
-    "Name":"http:\/\/schema.org\/includesHealthPlanFormulary-input",
+    "Name":"https://schema.org/includesHealthPlanFormulary-input",
     "Domain Bucket":"< 1K"
   },
   {
     "Class":"Predicate",
-    "Name":"http:\/\/schema.org\/includesHealthPlanFormulary-output",
+    "Name":"https://schema.org/includesHealthPlanFormulary-output",
     "Domain Bucket":"< 1K"
   },
   {
     "Class":"Predicate",
-    "Name":"http:\/\/schema.org\/includesHealthPlanNetwork",
+    "Name":"https://schema.org/includesHealthPlanNetwork",
     "Domain Bucket":"< 1K"
   },
   {
     "Class":"Predicate",
-    "Name":"http:\/\/schema.org\/includesHealthPlanNetwork-input",
+    "Name":"https://schema.org/includesHealthPlanNetwork-input",
     "Domain Bucket":"< 1K"
   },
   {
     "Class":"Predicate",
-    "Name":"http:\/\/schema.org\/includesHealthPlanNetwork-output",
+    "Name":"https://schema.org/includesHealthPlanNetwork-output",
     "Domain Bucket":"< 1K"
   },
   {
     "Class":"Predicate",
-    "Name":"http:\/\/schema.org\/includesObject",
+    "Name":"https://schema.org/includesObject",
     "Domain Bucket":"1K - 10K"
   },
   {
     "Class":"Predicate",
-    "Name":"http:\/\/schema.org\/includesObject-input",
+    "Name":"https://schema.org/includesObject-input",
     "Domain Bucket":"< 1K"
   },
   {
     "Class":"Predicate",
-    "Name":"http:\/\/schema.org\/includesObject-output",
+    "Name":"https://schema.org/includesObject-output",
     "Domain Bucket":"< 1K"
   },
   {
     "Class":"Predicate",
-    "Name":"http:\/\/schema.org\/incomeLimit",
+    "Name":"https://schema.org/incomeLimit",
     "Domain Bucket":"< 1K"
   },
   {
     "Class":"Predicate",
-    "Name":"http:\/\/schema.org\/incomeLimit-input",
+    "Name":"https://schema.org/incomeLimit-input",
     "Domain Bucket":"< 1K"
   },
   {
     "Class":"Predicate",
-    "Name":"http:\/\/schema.org\/incomeLimit-output",
+    "Name":"https://schema.org/incomeLimit-output",
     "Domain Bucket":"< 1K"
   },
   {
     "Class":"Predicate",
-    "Name":"http:\/\/schema.org\/increasesRiskOf",
+    "Name":"https://schema.org/increasesRiskOf",
     "Domain Bucket":"< 1K"
   },
   {
     "Class":"Predicate",
-    "Name":"http:\/\/schema.org\/increasesRiskOf-input",
+    "Name":"https://schema.org/increasesRiskOf-input",
     "Domain Bucket":"< 1K"
   },
   {
     "Class":"Predicate",
-    "Name":"http:\/\/schema.org\/increasesRiskOf-output",
+    "Name":"https://schema.org/increasesRiskOf-output",
     "Domain Bucket":"< 1K"
   },
   {
     "Class":"Predicate",
-    "Name":"http:\/\/schema.org\/industry",
+    "Name":"https://schema.org/industry",
     "Domain Bucket":"10K - 100K"
   },
   {
     "Class":"Predicate",
-    "Name":"http:\/\/schema.org\/industry-input",
+    "Name":"https://schema.org/industry-input",
     "Domain Bucket":"< 1K"
   },
   {
     "Class":"Predicate",
-    "Name":"http:\/\/schema.org\/industry-output",
+    "Name":"https://schema.org/industry-output",
     "Domain Bucket":"< 1K"
   },
   {
     "Class":"Predicate",
-    "Name":"http:\/\/schema.org\/ineligibleRegion",
+    "Name":"https://schema.org/ineligibleRegion",
     "Domain Bucket":"< 1K"
   },
   {
     "Class":"Predicate",
-    "Name":"http:\/\/schema.org\/ineligibleRegion-input",
+    "Name":"https://schema.org/ineligibleRegion-input",
     "Domain Bucket":"< 1K"
   },
   {
     "Class":"Predicate",
-    "Name":"http:\/\/schema.org\/ineligibleRegion-output",
+    "Name":"https://schema.org/ineligibleRegion-output",
     "Domain Bucket":"< 1K"
   },
   {
     "Class":"Predicate",
-    "Name":"http:\/\/schema.org\/infectiousAgent",
+    "Name":"https://schema.org/infectiousAgent",
     "Domain Bucket":"< 1K"
   },
   {
     "Class":"Predicate",
-    "Name":"http:\/\/schema.org\/infectiousAgent-input",
+    "Name":"https://schema.org/infectiousAgent-input",
     "Domain Bucket":"< 1K"
   },
   {
     "Class":"Predicate",
-    "Name":"http:\/\/schema.org\/infectiousAgent-output",
+    "Name":"https://schema.org/infectiousAgent-output",
     "Domain Bucket":"< 1K"
   },
   {
     "Class":"Predicate",
-    "Name":"http:\/\/schema.org\/infectiousAgentClass",
+    "Name":"https://schema.org/infectiousAgentClass",
     "Domain Bucket":"< 1K"
   },
   {
     "Class":"Predicate",
-    "Name":"http:\/\/schema.org\/infectiousAgentClass-input",
+    "Name":"https://schema.org/infectiousAgentClass-input",
     "Domain Bucket":"< 1K"
   },
   {
     "Class":"Predicate",
-    "Name":"http:\/\/schema.org\/infectiousAgentClass-output",
+    "Name":"https://schema.org/infectiousAgentClass-output",
     "Domain Bucket":"< 1K"
   },
   {
     "Class":"Predicate",
-    "Name":"http:\/\/schema.org\/ingredients",
+    "Name":"https://schema.org/ingredients",
     "Domain Bucket":"1K - 10K"
   },
   {
     "Class":"Predicate",
-    "Name":"http:\/\/schema.org\/ingredients-input",
+    "Name":"https://schema.org/ingredients-input",
     "Domain Bucket":"< 1K"
   },
   {
     "Class":"Predicate",
-    "Name":"http:\/\/schema.org\/ingredients-output",
+    "Name":"https://schema.org/ingredients-output",
     "Domain Bucket":"< 1K"
   },
   {
     "Class":"Predicate",
-    "Name":"http:\/\/schema.org\/inker",
+    "Name":"https://schema.org/inker",
     "Domain Bucket":"< 1K"
   },
   {
     "Class":"Predicate",
-    "Name":"http:\/\/schema.org\/inker-input",
+    "Name":"https://schema.org/inker-input",
     "Domain Bucket":"< 1K"
   },
   {
     "Class":"Predicate",
-    "Name":"http:\/\/schema.org\/inker-output",
+    "Name":"https://schema.org/inker-output",
     "Domain Bucket":"< 1K"
   },
   {
     "Class":"Predicate",
-    "Name":"http:\/\/schema.org\/insertion",
+    "Name":"https://schema.org/insertion",
     "Domain Bucket":"< 1K"
   },
   {
     "Class":"Predicate",
-    "Name":"http:\/\/schema.org\/insertion-input",
+    "Name":"https://schema.org/insertion-input",
     "Domain Bucket":"< 1K"
   },
   {
     "Class":"Predicate",
-    "Name":"http:\/\/schema.org\/insertion-output",
+    "Name":"https://schema.org/insertion-output",
     "Domain Bucket":"< 1K"
   },
   {
     "Class":"Predicate",
-    "Name":"http:\/\/schema.org\/installUrl",
+    "Name":"https://schema.org/installUrl",
     "Domain Bucket":"10K - 100K"
   },
   {
     "Class":"Predicate",
-    "Name":"http:\/\/schema.org\/installUrl-input",
+    "Name":"https://schema.org/installUrl-input",
     "Domain Bucket":"< 1K"
   },
   {
     "Class":"Predicate",
-    "Name":"http:\/\/schema.org\/installUrl-output",
+    "Name":"https://schema.org/installUrl-output",
     "Domain Bucket":"< 1K"
   },
   {
     "Class":"Predicate",
-    "Name":"http:\/\/schema.org\/instructor",
+    "Name":"https://schema.org/instructor",
     "Domain Bucket":"10K - 100K"
   },
   {
     "Class":"Predicate",
-    "Name":"http:\/\/schema.org\/instructor-input",
+    "Name":"https://schema.org/instructor-input",
     "Domain Bucket":"< 1K"
   },
   {
     "Class":"Predicate",
-    "Name":"http:\/\/schema.org\/instructor-output",
+    "Name":"https://schema.org/instructor-output",
     "Domain Bucket":"< 1K"
   },
   {
     "Class":"Predicate",
-    "Name":"http:\/\/schema.org\/instrument",
+    "Name":"https://schema.org/instrument",
     "Domain Bucket":"1K - 10K"
   },
   {
     "Class":"Predicate",
-    "Name":"http:\/\/schema.org\/instrument-input",
+    "Name":"https://schema.org/instrument-input",
     "Domain Bucket":"< 1K"
   },
   {
     "Class":"Predicate",
-    "Name":"http:\/\/schema.org\/instrument-output",
+    "Name":"https://schema.org/instrument-output",
     "Domain Bucket":"< 1K"
   },
   {
     "Class":"Predicate",
-    "Name":"http:\/\/schema.org\/intensity",
+    "Name":"https://schema.org/intensity",
     "Domain Bucket":"< 1K"
   },
   {
     "Class":"Predicate",
-    "Name":"http:\/\/schema.org\/intensity-input",
+    "Name":"https://schema.org/intensity-input",
     "Domain Bucket":"< 1K"
   },
   {
     "Class":"Predicate",
-    "Name":"http:\/\/schema.org\/intensity-output",
+    "Name":"https://schema.org/intensity-output",
     "Domain Bucket":"< 1K"
   },
   {
     "Class":"Predicate",
-    "Name":"http:\/\/schema.org\/interactingDrug",
+    "Name":"https://schema.org/interactingDrug",
     "Domain Bucket":"< 1K"
   },
   {
     "Class":"Predicate",
-    "Name":"http:\/\/schema.org\/interactingDrug-input",
+    "Name":"https://schema.org/interactingDrug-input",
     "Domain Bucket":"< 1K"
   },
   {
     "Class":"Predicate",
-    "Name":"http:\/\/schema.org\/interactingDrug-output",
+    "Name":"https://schema.org/interactingDrug-output",
     "Domain Bucket":"< 1K"
   },
   {
     "Class":"Predicate",
-    "Name":"http:\/\/schema.org\/interactionCount",
+    "Name":"https://schema.org/interactionCount",
     "Domain Bucket":"100K - 1M"
   },
   {
     "Class":"Predicate",
-    "Name":"http:\/\/schema.org\/interactionCount-input",
+    "Name":"https://schema.org/interactionCount-input",
     "Domain Bucket":"< 1K"
   },
   {
     "Class":"Predicate",
-    "Name":"http:\/\/schema.org\/interactionCount-output",
+    "Name":"https://schema.org/interactionCount-output",
     "Domain Bucket":"< 1K"
   },
   {
     "Class":"Predicate",
-    "Name":"http:\/\/schema.org\/interactionService",
+    "Name":"https://schema.org/interactionService",
     "Domain Bucket":"< 1K"
   },
   {
     "Class":"Predicate",
-    "Name":"http:\/\/schema.org\/interactionService-input",
+    "Name":"https://schema.org/interactionService-input",
     "Domain Bucket":"< 1K"
   },
   {
     "Class":"Predicate",
-    "Name":"http:\/\/schema.org\/interactionService-output",
+    "Name":"https://schema.org/interactionService-output",
     "Domain Bucket":"< 1K"
   },
   {
     "Class":"Predicate",
-    "Name":"http:\/\/schema.org\/interactionStatistic",
+    "Name":"https://schema.org/interactionStatistic",
     "Domain Bucket":"100K - 1M"
   },
   {
     "Class":"Predicate",
-    "Name":"http:\/\/schema.org\/interactionStatistic-input",
+    "Name":"https://schema.org/interactionStatistic-input",
     "Domain Bucket":"< 1K"
   },
   {
     "Class":"Predicate",
-    "Name":"http:\/\/schema.org\/interactionStatistic-output",
+    "Name":"https://schema.org/interactionStatistic-output",
     "Domain Bucket":"< 1K"
   },
   {
     "Class":"Predicate",
-    "Name":"http:\/\/schema.org\/interactionType",
+    "Name":"https://schema.org/interactionType",
     "Domain Bucket":"100K - 1M"
   },
   {
     "Class":"Predicate",
-    "Name":"http:\/\/schema.org\/interactionType-input",
+    "Name":"https://schema.org/interactionType-input",
     "Domain Bucket":"< 1K"
   },
   {
     "Class":"Predicate",
-    "Name":"http:\/\/schema.org\/interactionType-output",
+    "Name":"https://schema.org/interactionType-output",
     "Domain Bucket":"< 1K"
   },
   {
     "Class":"Predicate",
-    "Name":"http:\/\/schema.org\/interactivityType",
+    "Name":"https://schema.org/interactivityType",
     "Domain Bucket":"1K - 10K"
   },
   {
     "Class":"Predicate",
-    "Name":"http:\/\/schema.org\/interactivityType-input",
+    "Name":"https://schema.org/interactivityType-input",
     "Domain Bucket":"< 1K"
   },
   {
     "Class":"Predicate",
-    "Name":"http:\/\/schema.org\/interactivityType-output",
+    "Name":"https://schema.org/interactivityType-output",
     "Domain Bucket":"< 1K"
   },
   {
     "Class":"Predicate",
-    "Name":"http:\/\/schema.org\/interestRate",
+    "Name":"https://schema.org/interestRate",
     "Domain Bucket":"1K - 10K"
   },
   {
     "Class":"Predicate",
-    "Name":"http:\/\/schema.org\/interestRate-input",
+    "Name":"https://schema.org/interestRate-input",
     "Domain Bucket":"< 1K"
   },
   {
     "Class":"Predicate",
-    "Name":"http:\/\/schema.org\/interestRate-output",
+    "Name":"https://schema.org/interestRate-output",
     "Domain Bucket":"< 1K"
   },
   {
     "Class":"Predicate",
-    "Name":"http:\/\/schema.org\/interpretedAsClaim",
+    "Name":"https://schema.org/interpretedAsClaim",
     "Domain Bucket":"< 1K"
   },
   {
     "Class":"Predicate",
-    "Name":"http:\/\/schema.org\/interpretedAsClaim-input",
+    "Name":"https://schema.org/interpretedAsClaim-input",
     "Domain Bucket":"< 1K"
   },
   {
     "Class":"Predicate",
-    "Name":"http:\/\/schema.org\/interpretedAsClaim-output",
+    "Name":"https://schema.org/interpretedAsClaim-output",
     "Domain Bucket":"< 1K"
   },
   {
     "Class":"Predicate",
-    "Name":"http:\/\/schema.org\/inventoryLevel",
+    "Name":"https://schema.org/inventoryLevel",
     "Domain Bucket":"100K - 1M"
   },
   {
     "Class":"Predicate",
-    "Name":"http:\/\/schema.org\/inventoryLevel-input",
+    "Name":"https://schema.org/inventoryLevel-input",
     "Domain Bucket":"< 1K"
   },
   {
     "Class":"Predicate",
-    "Name":"http:\/\/schema.org\/inventoryLevel-output",
+    "Name":"https://schema.org/inventoryLevel-output",
     "Domain Bucket":"< 1K"
   },
   {
     "Class":"Predicate",
-    "Name":"http:\/\/schema.org\/inverseOf",
+    "Name":"https://schema.org/inverseOf",
     "Domain Bucket":"< 1K"
   },
   {
     "Class":"Predicate",
-    "Name":"http:\/\/schema.org\/inverseOf-input",
+    "Name":"https://schema.org/inverseOf-input",
     "Domain Bucket":"< 1K"
   },
   {
     "Class":"Predicate",
-    "Name":"http:\/\/schema.org\/inverseOf-output",
+    "Name":"https://schema.org/inverseOf-output",
     "Domain Bucket":"< 1K"
   },
   {
     "Class":"Predicate",
-    "Name":"http:\/\/schema.org\/isAcceptingNewPatients",
+    "Name":"https://schema.org/isAcceptingNewPatients",
     "Domain Bucket":"10K - 100K"
   },
   {
     "Class":"Predicate",
-    "Name":"http:\/\/schema.org\/isAcceptingNewPatients-input",
+    "Name":"https://schema.org/isAcceptingNewPatients-input",
     "Domain Bucket":"< 1K"
   },
   {
     "Class":"Predicate",
-    "Name":"http:\/\/schema.org\/isAcceptingNewPatients-output",
+    "Name":"https://schema.org/isAcceptingNewPatients-output",
     "Domain Bucket":"< 1K"
   },
   {
     "Class":"Predicate",
-    "Name":"http:\/\/schema.org\/isAccessibleForFree",
+    "Name":"https://schema.org/isAccessibleForFree",
     "Domain Bucket":"100K - 1M"
   },
   {
     "Class":"Predicate",
-    "Name":"http:\/\/schema.org\/isAccessibleForFree-input",
+    "Name":"https://schema.org/isAccessibleForFree-input",
     "Domain Bucket":"< 1K"
   },
   {
     "Class":"Predicate",
-    "Name":"http:\/\/schema.org\/isAccessibleForFree-output",
+    "Name":"https://schema.org/isAccessibleForFree-output",
     "Domain Bucket":"< 1K"
   },
   {
     "Class":"Predicate",
-    "Name":"http:\/\/schema.org\/isAccessoryOrSparePartFor",
+    "Name":"https://schema.org/isAccessoryOrSparePartFor",
     "Domain Bucket":"1K - 10K"
   },
   {
     "Class":"Predicate",
-    "Name":"http:\/\/schema.org\/isAccessoryOrSparePartFor-input",
+    "Name":"https://schema.org/isAccessoryOrSparePartFor-input",
     "Domain Bucket":"< 1K"
   },
   {
     "Class":"Predicate",
-    "Name":"http:\/\/schema.org\/isAccessoryOrSparePartFor-output",
+    "Name":"https://schema.org/isAccessoryOrSparePartFor-output",
     "Domain Bucket":"< 1K"
   },
   {
     "Class":"Predicate",
-    "Name":"http:\/\/schema.org\/isAvailableGenerically",
+    "Name":"https://schema.org/isAvailableGenerically",
     "Domain Bucket":"< 1K"
   },
   {
     "Class":"Predicate",
-    "Name":"http:\/\/schema.org\/isAvailableGenerically-input",
+    "Name":"https://schema.org/isAvailableGenerically-input",
     "Domain Bucket":"< 1K"
   },
   {
     "Class":"Predicate",
-    "Name":"http:\/\/schema.org\/isAvailableGenerically-output",
+    "Name":"https://schema.org/isAvailableGenerically-output",
     "Domain Bucket":"< 1K"
   },
   {
     "Class":"Predicate",
-    "Name":"http:\/\/schema.org\/isBasedOn",
+    "Name":"https://schema.org/isBasedOn",
     "Domain Bucket":"10K - 100K"
   },
   {
     "Class":"Predicate",
-    "Name":"http:\/\/schema.org\/isBasedOn-input",
+    "Name":"https://schema.org/isBasedOn-input",
     "Domain Bucket":"< 1K"
   },
   {
     "Class":"Predicate",
-    "Name":"http:\/\/schema.org\/isBasedOn-output",
+    "Name":"https://schema.org/isBasedOn-output",
     "Domain Bucket":"< 1K"
   },
   {
     "Class":"Predicate",
-    "Name":"http:\/\/schema.org\/isBasedOnUrl",
+    "Name":"https://schema.org/isBasedOnUrl",
     "Domain Bucket":"< 1K"
   },
   {
     "Class":"Predicate",
-    "Name":"http:\/\/schema.org\/isBasedOnUrl-input",
+    "Name":"https://schema.org/isBasedOnUrl-input",
     "Domain Bucket":"< 1K"
   },
   {
     "Class":"Predicate",
-    "Name":"http:\/\/schema.org\/isBasedOnUrl-output",
+    "Name":"https://schema.org/isBasedOnUrl-output",
     "Domain Bucket":"< 1K"
   },
   {
     "Class":"Predicate",
-    "Name":"http:\/\/schema.org\/isConsumableFor",
+    "Name":"https://schema.org/isConsumableFor",
     "Domain Bucket":"< 1K"
   },
   {
     "Class":"Predicate",
-    "Name":"http:\/\/schema.org\/isConsumableFor-input",
+    "Name":"https://schema.org/isConsumableFor-input",
     "Domain Bucket":"< 1K"
   },
   {
     "Class":"Predicate",
-    "Name":"http:\/\/schema.org\/isConsumableFor-output",
+    "Name":"https://schema.org/isConsumableFor-output",
     "Domain Bucket":"< 1K"
   },
   {
     "Class":"Predicate",
-    "Name":"http:\/\/schema.org\/isEncodedByBioChemEntity",
+    "Name":"https://schema.org/isEncodedByBioChemEntity",
     "Domain Bucket":"< 1K"
   },
   {
     "Class":"Predicate",
-    "Name":"http:\/\/schema.org\/isEncodedByBioChemEntity-input",
+    "Name":"https://schema.org/isEncodedByBioChemEntity-input",
     "Domain Bucket":"< 1K"
   },
   {
     "Class":"Predicate",
-    "Name":"http:\/\/schema.org\/isEncodedByBioChemEntity-output",
+    "Name":"https://schema.org/isEncodedByBioChemEntity-output",
     "Domain Bucket":"< 1K"
   },
   {
     "Class":"Predicate",
-    "Name":"http:\/\/schema.org\/isFamilyFriendly",
+    "Name":"https://schema.org/isFamilyFriendly",
     "Domain Bucket":"100K - 1M"
   },
   {
     "Class":"Predicate",
-    "Name":"http:\/\/schema.org\/isFamilyFriendly-input",
+    "Name":"https://schema.org/isFamilyFriendly-input",
     "Domain Bucket":"< 1K"
   },
   {
     "Class":"Predicate",
-    "Name":"http:\/\/schema.org\/isFamilyFriendly-output",
+    "Name":"https://schema.org/isFamilyFriendly-output",
     "Domain Bucket":"< 1K"
   },
   {
     "Class":"Predicate",
-    "Name":"http:\/\/schema.org\/isGift",
+    "Name":"https://schema.org/isGift",
     "Domain Bucket":"< 1K"
   },
   {
     "Class":"Predicate",
-    "Name":"http:\/\/schema.org\/isGift-input",
+    "Name":"https://schema.org/isGift-input",
     "Domain Bucket":"< 1K"
   },
   {
     "Class":"Predicate",
-    "Name":"http:\/\/schema.org\/isGift-output",
+    "Name":"https://schema.org/isGift-output",
     "Domain Bucket":"< 1K"
   },
   {
     "Class":"Predicate",
-    "Name":"http:\/\/schema.org\/isInvolvedInBiologicalProcess",
+    "Name":"https://schema.org/isInvolvedInBiologicalProcess",
     "Domain Bucket":"< 1K"
   },
   {
     "Class":"Predicate",
-    "Name":"http:\/\/schema.org\/isInvolvedInBiologicalProcess-input",
+    "Name":"https://schema.org/isInvolvedInBiologicalProcess-input",
     "Domain Bucket":"< 1K"
   },
   {
     "Class":"Predicate",
-    "Name":"http:\/\/schema.org\/isInvolvedInBiologicalProcess-output",
+    "Name":"https://schema.org/isInvolvedInBiologicalProcess-output",
     "Domain Bucket":"< 1K"
   },
   {
     "Class":"Predicate",
-    "Name":"http:\/\/schema.org\/isLiveBroadcast",
+    "Name":"https://schema.org/isLiveBroadcast",
     "Domain Bucket":"10K - 100K"
   },
   {
     "Class":"Predicate",
-    "Name":"http:\/\/schema.org\/isLiveBroadcast-input",
+    "Name":"https://schema.org/isLiveBroadcast-input",
     "Domain Bucket":"< 1K"
   },
   {
     "Class":"Predicate",
-    "Name":"http:\/\/schema.org\/isLiveBroadcast-output",
+    "Name":"https://schema.org/isLiveBroadcast-output",
     "Domain Bucket":"< 1K"
   },
   {
     "Class":"Predicate",
-    "Name":"http:\/\/schema.org\/isLocatedInSubcellularLocation",
+    "Name":"https://schema.org/isLocatedInSubcellularLocation",
     "Domain Bucket":"< 1K"
   },
   {
     "Class":"Predicate",
-    "Name":"http:\/\/schema.org\/isLocatedInSubcellularLocation-input",
+    "Name":"https://schema.org/isLocatedInSubcellularLocation-input",
     "Domain Bucket":"< 1K"
   },
   {
     "Class":"Predicate",
-    "Name":"http:\/\/schema.org\/isLocatedInSubcellularLocation-output",
+    "Name":"https://schema.org/isLocatedInSubcellularLocation-output",
     "Domain Bucket":"< 1K"
   },
   {
     "Class":"Predicate",
-    "Name":"http:\/\/schema.org\/isPartOf",
+    "Name":"https://schema.org/isPartOf",
     "Domain Bucket":"10M+"
   },
   {
     "Class":"Predicate",
-    "Name":"http:\/\/schema.org\/isPartOf-input",
+    "Name":"https://schema.org/isPartOf-input",
     "Domain Bucket":"< 1K"
   },
   {
     "Class":"Predicate",
-    "Name":"http:\/\/schema.org\/isPartOf-output",
+    "Name":"https://schema.org/isPartOf-output",
     "Domain Bucket":"< 1K"
   },
   {
     "Class":"Predicate",
-    "Name":"http:\/\/schema.org\/isPartOfBioChemEntity",
+    "Name":"https://schema.org/isPartOfBioChemEntity",
     "Domain Bucket":"< 1K"
   },
   {
     "Class":"Predicate",
-    "Name":"http:\/\/schema.org\/isPartOfBioChemEntity-input",
+    "Name":"https://schema.org/isPartOfBioChemEntity-input",
     "Domain Bucket":"< 1K"
   },
   {
     "Class":"Predicate",
-    "Name":"http:\/\/schema.org\/isPartOfBioChemEntity-output",
+    "Name":"https://schema.org/isPartOfBioChemEntity-output",
     "Domain Bucket":"< 1K"
   },
   {
     "Class":"Predicate",
-    "Name":"http:\/\/schema.org\/isPlanForApartment",
+    "Name":"https://schema.org/isPlanForApartment",
     "Domain Bucket":"< 1K"
   },
   {
     "Class":"Predicate",
-    "Name":"http:\/\/schema.org\/isPlanForApartment-input",
+    "Name":"https://schema.org/isPlanForApartment-input",
     "Domain Bucket":"< 1K"
   },
   {
     "Class":"Predicate",
-    "Name":"http:\/\/schema.org\/isPlanForApartment-output",
+    "Name":"https://schema.org/isPlanForApartment-output",
     "Domain Bucket":"< 1K"
   },
   {
     "Class":"Predicate",
-    "Name":"http:\/\/schema.org\/isProprietary",
+    "Name":"https://schema.org/isProprietary",
     "Domain Bucket":"< 1K"
   },
   {
     "Class":"Predicate",
-    "Name":"http:\/\/schema.org\/isProprietary-input",
+    "Name":"https://schema.org/isProprietary-input",
     "Domain Bucket":"< 1K"
   },
   {
     "Class":"Predicate",
-    "Name":"http:\/\/schema.org\/isProprietary-output",
+    "Name":"https://schema.org/isProprietary-output",
     "Domain Bucket":"< 1K"
   },
   {
     "Class":"Predicate",
-    "Name":"http:\/\/schema.org\/isRelatedTo",
+    "Name":"https://schema.org/isRelatedTo",
     "Domain Bucket":"100K - 1M"
   },
   {
     "Class":"Predicate",
-    "Name":"http:\/\/schema.org\/isRelatedTo-input",
+    "Name":"https://schema.org/isRelatedTo-input",
     "Domain Bucket":"< 1K"
   },
   {
     "Class":"Predicate",
-    "Name":"http:\/\/schema.org\/isRelatedTo-output",
+    "Name":"https://schema.org/isRelatedTo-output",
     "Domain Bucket":"< 1K"
   },
   {
     "Class":"Predicate",
-    "Name":"http:\/\/schema.org\/isResizable",
+    "Name":"https://schema.org/isResizable",
     "Domain Bucket":"< 1K"
   },
   {
     "Class":"Predicate",
-    "Name":"http:\/\/schema.org\/isResizable-input",
+    "Name":"https://schema.org/isResizable-input",
     "Domain Bucket":"< 1K"
   },
   {
     "Class":"Predicate",
-    "Name":"http:\/\/schema.org\/isResizable-output",
+    "Name":"https://schema.org/isResizable-output",
     "Domain Bucket":"< 1K"
   },
   {
     "Class":"Predicate",
-    "Name":"http:\/\/schema.org\/isSimilarTo",
+    "Name":"https://schema.org/isSimilarTo",
     "Domain Bucket":"1K - 10K"
   },
   {
     "Class":"Predicate",
-    "Name":"http:\/\/schema.org\/isSimilarTo-input",
+    "Name":"https://schema.org/isSimilarTo-input",
     "Domain Bucket":"< 1K"
   },
   {
     "Class":"Predicate",
-    "Name":"http:\/\/schema.org\/isSimilarTo-output",
+    "Name":"https://schema.org/isSimilarTo-output",
     "Domain Bucket":"< 1K"
   },
   {
     "Class":"Predicate",
-    "Name":"http:\/\/schema.org\/isStoreOn",
+    "Name":"https://schema.org/isStoreOn",
     "Domain Bucket":"< 1K"
   },
   {
     "Class":"Predicate",
-    "Name":"http:\/\/schema.org\/isStoreOn-input",
+    "Name":"https://schema.org/isStoreOn-input",
     "Domain Bucket":"< 1K"
   },
   {
     "Class":"Predicate",
-    "Name":"http:\/\/schema.org\/isStoreOn-output",
+    "Name":"https://schema.org/isStoreOn-output",
     "Domain Bucket":"< 1K"
   },
   {
     "Class":"Predicate",
-    "Name":"http:\/\/schema.org\/isTierOf",
+    "Name":"https://schema.org/isTierOf",
     "Domain Bucket":"< 1K"
   },
   {
     "Class":"Predicate",
-    "Name":"http:\/\/schema.org\/isTierOf-input",
+    "Name":"https://schema.org/isTierOf-input",
     "Domain Bucket":"< 1K"
   },
   {
     "Class":"Predicate",
-    "Name":"http:\/\/schema.org\/isTierOf-output",
+    "Name":"https://schema.org/isTierOf-output",
     "Domain Bucket":"< 1K"
   },
   {
     "Class":"Predicate",
-    "Name":"http:\/\/schema.org\/isUnlabelledFallback",
+    "Name":"https://schema.org/isUnlabelledFallback",
     "Domain Bucket":"< 1K"
   },
   {
     "Class":"Predicate",
-    "Name":"http:\/\/schema.org\/isUnlabelledFallback-input",
+    "Name":"https://schema.org/isUnlabelledFallback-input",
     "Domain Bucket":"< 1K"
   },
   {
     "Class":"Predicate",
-    "Name":"http:\/\/schema.org\/isUnlabelledFallback-output",
+    "Name":"https://schema.org/isUnlabelledFallback-output",
     "Domain Bucket":"< 1K"
   },
   {
     "Class":"Predicate",
-    "Name":"http:\/\/schema.org\/isVariantOf",
+    "Name":"https://schema.org/isVariantOf",
     "Domain Bucket":"1K - 10K"
   },
   {
     "Class":"Predicate",
-    "Name":"http:\/\/schema.org\/isVariantOf-input",
+    "Name":"https://schema.org/isVariantOf-input",
     "Domain Bucket":"< 1K"
   },
   {
     "Class":"Predicate",
-    "Name":"http:\/\/schema.org\/isVariantOf-output",
+    "Name":"https://schema.org/isVariantOf-output",
     "Domain Bucket":"< 1K"
   },
   {
     "Class":"Predicate",
-    "Name":"http:\/\/schema.org\/isbn",
+    "Name":"https://schema.org/isbn",
     "Domain Bucket":"10K - 100K"
   },
   {
     "Class":"Predicate",
-    "Name":"http:\/\/schema.org\/isbn-input",
+    "Name":"https://schema.org/isbn-input",
     "Domain Bucket":"< 1K"
   },
   {
     "Class":"Predicate",
-    "Name":"http:\/\/schema.org\/isbn-output",
+    "Name":"https://schema.org/isbn-output",
     "Domain Bucket":"< 1K"
   },
   {
     "Class":"Predicate",
-    "Name":"http:\/\/schema.org\/isicV4",
+    "Name":"https://schema.org/isicV4",
     "Domain Bucket":"1K - 10K"
   },
   {
     "Class":"Predicate",
-    "Name":"http:\/\/schema.org\/isicV4-input",
+    "Name":"https://schema.org/isicV4-input",
     "Domain Bucket":"< 1K"
   },
   {
     "Class":"Predicate",
-    "Name":"http:\/\/schema.org\/isicV4-output",
+    "Name":"https://schema.org/isicV4-output",
     "Domain Bucket":"< 1K"
   },
   {
     "Class":"Predicate",
-    "Name":"http:\/\/schema.org\/iso6523Code",
+    "Name":"https://schema.org/iso6523Code",
     "Domain Bucket":"1K - 10K"
   },
   {
     "Class":"Predicate",
-    "Name":"http:\/\/schema.org\/iso6523Code-input",
+    "Name":"https://schema.org/iso6523Code-input",
     "Domain Bucket":"< 1K"
   },
   {
     "Class":"Predicate",
-    "Name":"http:\/\/schema.org\/iso6523Code-output",
+    "Name":"https://schema.org/iso6523Code-output",
     "Domain Bucket":"< 1K"
   },
   {
     "Class":"Predicate",
-    "Name":"http:\/\/schema.org\/isrcCode",
+    "Name":"https://schema.org/isrcCode",
     "Domain Bucket":"< 1K"
   },
   {
     "Class":"Predicate",
-    "Name":"http:\/\/schema.org\/isrcCode-input",
+    "Name":"https://schema.org/isrcCode-input",
     "Domain Bucket":"< 1K"
   },
   {
     "Class":"Predicate",
-    "Name":"http:\/\/schema.org\/isrcCode-output",
+    "Name":"https://schema.org/isrcCode-output",
     "Domain Bucket":"< 1K"
   },
   {
     "Class":"Predicate",
-    "Name":"http:\/\/schema.org\/issn",
+    "Name":"https://schema.org/issn",
     "Domain Bucket":"1K - 10K"
   },
   {
     "Class":"Predicate",
-    "Name":"http:\/\/schema.org\/issn-input",
+    "Name":"https://schema.org/issn-input",
     "Domain Bucket":"< 1K"
   },
   {
     "Class":"Predicate",
-    "Name":"http:\/\/schema.org\/issn-output",
+    "Name":"https://schema.org/issn-output",
     "Domain Bucket":"< 1K"
   },
   {
     "Class":"Predicate",
-    "Name":"http:\/\/schema.org\/issueNumber",
+    "Name":"https://schema.org/issueNumber",
     "Domain Bucket":"1K - 10K"
   },
   {
     "Class":"Predicate",
-    "Name":"http:\/\/schema.org\/issueNumber-input",
+    "Name":"https://schema.org/issueNumber-input",
     "Domain Bucket":"< 1K"
   },
   {
     "Class":"Predicate",
-    "Name":"http:\/\/schema.org\/issueNumber-output",
+    "Name":"https://schema.org/issueNumber-output",
     "Domain Bucket":"< 1K"
   },
   {
     "Class":"Predicate",
-    "Name":"http:\/\/schema.org\/issuedBy",
+    "Name":"https://schema.org/issuedBy",
     "Domain Bucket":"10K - 100K"
   },
   {
     "Class":"Predicate",
-    "Name":"http:\/\/schema.org\/issuedBy-input",
+    "Name":"https://schema.org/issuedBy-input",
     "Domain Bucket":"< 1K"
   },
   {
     "Class":"Predicate",
-    "Name":"http:\/\/schema.org\/issuedBy-output",
+    "Name":"https://schema.org/issuedBy-output",
     "Domain Bucket":"< 1K"
   },
   {
     "Class":"Predicate",
-    "Name":"http:\/\/schema.org\/issuedThrough",
+    "Name":"https://schema.org/issuedThrough",
     "Domain Bucket":"< 1K"
   },
   {
     "Class":"Predicate",
-    "Name":"http:\/\/schema.org\/issuedThrough-input",
+    "Name":"https://schema.org/issuedThrough-input",
     "Domain Bucket":"< 1K"
   },
   {
     "Class":"Predicate",
-    "Name":"http:\/\/schema.org\/issuedThrough-output",
+    "Name":"https://schema.org/issuedThrough-output",
     "Domain Bucket":"< 1K"
   },
   {
     "Class":"Predicate",
-    "Name":"http:\/\/schema.org\/iswcCode",
+    "Name":"https://schema.org/iswcCode",
     "Domain Bucket":"< 1K"
   },
   {
     "Class":"Predicate",
-    "Name":"http:\/\/schema.org\/iswcCode-input",
+    "Name":"https://schema.org/iswcCode-input",
     "Domain Bucket":"< 1K"
   },
   {
     "Class":"Predicate",
-    "Name":"http:\/\/schema.org\/iswcCode-output",
+    "Name":"https://schema.org/iswcCode-output",
     "Domain Bucket":"< 1K"
   },
   {
     "Class":"Predicate",
-    "Name":"http:\/\/schema.org\/item",
+    "Name":"https://schema.org/item",
     "Domain Bucket":"10M+"
   },
   {
     "Class":"Predicate",
-    "Name":"http:\/\/schema.org\/item-input",
+    "Name":"https://schema.org/item-input",
     "Domain Bucket":"< 1K"
   },
   {
     "Class":"Predicate",
-    "Name":"http:\/\/schema.org\/item-output",
+    "Name":"https://schema.org/item-output",
     "Domain Bucket":"< 1K"
   },
   {
     "Class":"Predicate",
-    "Name":"http:\/\/schema.org\/itemCondition",
+    "Name":"https://schema.org/itemCondition",
     "Domain Bucket":"1M - 10M"
   },
   {
     "Class":"Predicate",
-    "Name":"http:\/\/schema.org\/itemCondition-input",
+    "Name":"https://schema.org/itemCondition-input",
     "Domain Bucket":"< 1K"
   },
   {
     "Class":"Predicate",
-    "Name":"http:\/\/schema.org\/itemCondition-output",
+    "Name":"https://schema.org/itemCondition-output",
     "Domain Bucket":"< 1K"
   },
   {
     "Class":"Predicate",
-    "Name":"http:\/\/schema.org\/itemDefectReturnFees",
+    "Name":"https://schema.org/itemDefectReturnFees",
     "Domain Bucket":"1K - 10K"
   },
   {
     "Class":"Predicate",
-    "Name":"http:\/\/schema.org\/itemDefectReturnFees-input",
+    "Name":"https://schema.org/itemDefectReturnFees-input",
     "Domain Bucket":"< 1K"
   },
   {
     "Class":"Predicate",
-    "Name":"http:\/\/schema.org\/itemDefectReturnFees-output",
+    "Name":"https://schema.org/itemDefectReturnFees-output",
     "Domain Bucket":"< 1K"
   },
   {
     "Class":"Predicate",
-    "Name":"http:\/\/schema.org\/itemDefectReturnLabelSource",
+    "Name":"https://schema.org/itemDefectReturnLabelSource",
     "Domain Bucket":"< 1K"
   },
   {
     "Class":"Predicate",
-    "Name":"http:\/\/schema.org\/itemDefectReturnLabelSource-input",
+    "Name":"https://schema.org/itemDefectReturnLabelSource-input",
     "Domain Bucket":"< 1K"
   },
   {
     "Class":"Predicate",
-    "Name":"http:\/\/schema.org\/itemDefectReturnLabelSource-output",
+    "Name":"https://schema.org/itemDefectReturnLabelSource-output",
     "Domain Bucket":"< 1K"
   },
   {
     "Class":"Predicate",
-    "Name":"http:\/\/schema.org\/itemDefectReturnShippingFeesAmount",
+    "Name":"https://schema.org/itemDefectReturnShippingFeesAmount",
     "Domain Bucket":"< 1K"
   },
   {
     "Class":"Predicate",
-    "Name":"http:\/\/schema.org\/itemDefectReturnShippingFeesAmount-input",
+    "Name":"https://schema.org/itemDefectReturnShippingFeesAmount-input",
     "Domain Bucket":"< 1K"
   },
   {
     "Class":"Predicate",
-    "Name":"http:\/\/schema.org\/itemDefectReturnShippingFeesAmount-output",
+    "Name":"https://schema.org/itemDefectReturnShippingFeesAmount-output",
     "Domain Bucket":"< 1K"
   },
   {
     "Class":"Predicate",
-    "Name":"http:\/\/schema.org\/itemListElement",
+    "Name":"https://schema.org/itemListElement",
     "Domain Bucket":"10M+"
   },
   {
     "Class":"Predicate",
-    "Name":"http:\/\/schema.org\/itemListElement-input",
+    "Name":"https://schema.org/itemListElement-input",
     "Domain Bucket":"< 1K"
   },
   {
     "Class":"Predicate",
-    "Name":"http:\/\/schema.org\/itemListElement-output",
+    "Name":"https://schema.org/itemListElement-output",
     "Domain Bucket":"< 1K"
   },
   {
     "Class":"Predicate",
-    "Name":"http:\/\/schema.org\/itemListOrder",
+    "Name":"https://schema.org/itemListOrder",
     "Domain Bucket":"100K - 1M"
   },
   {
     "Class":"Predicate",
-    "Name":"http:\/\/schema.org\/itemListOrder-input",
+    "Name":"https://schema.org/itemListOrder-input",
     "Domain Bucket":"< 1K"
   },
   {
     "Class":"Predicate",
-    "Name":"http:\/\/schema.org\/itemListOrder-output",
+    "Name":"https://schema.org/itemListOrder-output",
     "Domain Bucket":"< 1K"
   },
   {
     "Class":"Predicate",
-    "Name":"http:\/\/schema.org\/itemLocation",
+    "Name":"https://schema.org/itemLocation",
     "Domain Bucket":"< 1K"
   },
   {
     "Class":"Predicate",
-    "Name":"http:\/\/schema.org\/itemLocation-input",
+    "Name":"https://schema.org/itemLocation-input",
     "Domain Bucket":"< 1K"
   },
   {
     "Class":"Predicate",
-    "Name":"http:\/\/schema.org\/itemLocation-output",
+    "Name":"https://schema.org/itemLocation-output",
     "Domain Bucket":"< 1K"
   },
   {
     "Class":"Predicate",
-    "Name":"http:\/\/schema.org\/itemOffered",
+    "Name":"https://schema.org/itemOffered",
     "Domain Bucket":"100K - 1M"
   },
   {
     "Class":"Predicate",
-    "Name":"http:\/\/schema.org\/itemOffered-input",
+    "Name":"https://schema.org/itemOffered-input",
     "Domain Bucket":"< 1K"
   },
   {
     "Class":"Predicate",
-    "Name":"http:\/\/schema.org\/itemOffered-output",
+    "Name":"https://schema.org/itemOffered-output",
     "Domain Bucket":"< 1K"
   },
   {
     "Class":"Predicate",
-    "Name":"http:\/\/schema.org\/itemReviewed",
+    "Name":"https://schema.org/itemReviewed",
     "Domain Bucket":"100K - 1M"
   },
   {
     "Class":"Predicate",
-    "Name":"http:\/\/schema.org\/itemReviewed-input",
+    "Name":"https://schema.org/itemReviewed-input",
     "Domain Bucket":"< 1K"
   },
   {
     "Class":"Predicate",
-    "Name":"http:\/\/schema.org\/itemReviewed-output",
+    "Name":"https://schema.org/itemReviewed-output",
     "Domain Bucket":"< 1K"
   },
   {
     "Class":"Predicate",
-    "Name":"http:\/\/schema.org\/itemShipped",
+    "Name":"https://schema.org/itemShipped",
     "Domain Bucket":"< 1K"
   },
   {
     "Class":"Predicate",
-    "Name":"http:\/\/schema.org\/itemShipped-input",
+    "Name":"https://schema.org/itemShipped-input",
     "Domain Bucket":"< 1K"
   },
   {
     "Class":"Predicate",
-    "Name":"http:\/\/schema.org\/itemShipped-output",
+    "Name":"https://schema.org/itemShipped-output",
     "Domain Bucket":"< 1K"
   },
   {
     "Class":"Predicate",
-    "Name":"http:\/\/schema.org\/itinerary",
+    "Name":"https://schema.org/itinerary",
     "Domain Bucket":"10K - 100K"
   },
   {
     "Class":"Predicate",
-    "Name":"http:\/\/schema.org\/itinerary-input",
+    "Name":"https://schema.org/itinerary-input",
     "Domain Bucket":"< 1K"
   },
   {
     "Class":"Predicate",
-    "Name":"http:\/\/schema.org\/itinerary-output",
+    "Name":"https://schema.org/itinerary-output",
     "Domain Bucket":"< 1K"
   },
   {
     "Class":"Predicate",
-    "Name":"http:\/\/schema.org\/iupacName",
+    "Name":"https://schema.org/iupacName",
     "Domain Bucket":"< 1K"
   },
   {
     "Class":"Predicate",
-    "Name":"http:\/\/schema.org\/iupacName-input",
+    "Name":"https://schema.org/iupacName-input",
     "Domain Bucket":"< 1K"
   },
   {
     "Class":"Predicate",
-    "Name":"http:\/\/schema.org\/iupacName-output",
+    "Name":"https://schema.org/iupacName-output",
     "Domain Bucket":"< 1K"
   },
   {
     "Class":"Predicate",
-    "Name":"http:\/\/schema.org\/jobBenefits",
+    "Name":"https://schema.org/jobBenefits",
     "Domain Bucket":"10K - 100K"
   },
   {
     "Class":"Predicate",
-    "Name":"http:\/\/schema.org\/jobBenefits-input",
+    "Name":"https://schema.org/jobBenefits-input",
     "Domain Bucket":"< 1K"
   },
   {
     "Class":"Predicate",
-    "Name":"http:\/\/schema.org\/jobBenefits-output",
+    "Name":"https://schema.org/jobBenefits-output",
     "Domain Bucket":"< 1K"
   },
   {
     "Class":"Predicate",
-    "Name":"http:\/\/schema.org\/jobDuration",
+    "Name":"https://schema.org/jobDuration",
     "Domain Bucket":"< 1K"
   },
   {
     "Class":"Predicate",
-    "Name":"http:\/\/schema.org\/jobDuration-input",
+    "Name":"https://schema.org/jobDuration-input",
     "Domain Bucket":"< 1K"
   },
   {
     "Class":"Predicate",
-    "Name":"http:\/\/schema.org\/jobDuration-output",
+    "Name":"https://schema.org/jobDuration-output",
     "Domain Bucket":"< 1K"
   },
   {
     "Class":"Predicate",
-    "Name":"http:\/\/schema.org\/jobImmediateStart",
+    "Name":"https://schema.org/jobImmediateStart",
     "Domain Bucket":"1K - 10K"
   },
   {
     "Class":"Predicate",
-    "Name":"http:\/\/schema.org\/jobImmediateStart-input",
+    "Name":"https://schema.org/jobImmediateStart-input",
     "Domain Bucket":"< 1K"
   },
   {
     "Class":"Predicate",
-    "Name":"http:\/\/schema.org\/jobImmediateStart-output",
+    "Name":"https://schema.org/jobImmediateStart-output",
     "Domain Bucket":"< 1K"
   },
   {
     "Class":"Predicate",
-    "Name":"http:\/\/schema.org\/jobLocation",
+    "Name":"https://schema.org/jobLocation",
     "Domain Bucket":"100K - 1M"
   },
   {
     "Class":"Predicate",
-    "Name":"http:\/\/schema.org\/jobLocation-input",
+    "Name":"https://schema.org/jobLocation-input",
     "Domain Bucket":"< 1K"
   },
   {
     "Class":"Predicate",
-    "Name":"http:\/\/schema.org\/jobLocation-output",
+    "Name":"https://schema.org/jobLocation-output",
     "Domain Bucket":"< 1K"
   },
   {
     "Class":"Predicate",
-    "Name":"http:\/\/schema.org\/jobLocationType",
+    "Name":"https://schema.org/jobLocationType",
     "Domain Bucket":"10K - 100K"
   },
   {
     "Class":"Predicate",
-    "Name":"http:\/\/schema.org\/jobLocationType-input",
+    "Name":"https://schema.org/jobLocationType-input",
     "Domain Bucket":"< 1K"
   },
   {
     "Class":"Predicate",
-    "Name":"http:\/\/schema.org\/jobLocationType-output",
+    "Name":"https://schema.org/jobLocationType-output",
     "Domain Bucket":"< 1K"
   },
   {
     "Class":"Predicate",
-    "Name":"http:\/\/schema.org\/jobStartDate",
+    "Name":"https://schema.org/jobStartDate",
     "Domain Bucket":"1K - 10K"
   },
   {
     "Class":"Predicate",
-    "Name":"http:\/\/schema.org\/jobStartDate-input",
+    "Name":"https://schema.org/jobStartDate-input",
     "Domain Bucket":"< 1K"
   },
   {
     "Class":"Predicate",
-    "Name":"http:\/\/schema.org\/jobStartDate-output",
+    "Name":"https://schema.org/jobStartDate-output",
     "Domain Bucket":"< 1K"
   },
   {
     "Class":"Predicate",
-    "Name":"http:\/\/schema.org\/jobTitle",
+    "Name":"https://schema.org/jobTitle",
     "Domain Bucket":"100K - 1M"
   },
   {
     "Class":"Predicate",
-    "Name":"http:\/\/schema.org\/jobTitle-input",
+    "Name":"https://schema.org/jobTitle-input",
     "Domain Bucket":"< 1K"
   },
   {
     "Class":"Predicate",
-    "Name":"http:\/\/schema.org\/jobTitle-output",
+    "Name":"https://schema.org/jobTitle-output",
     "Domain Bucket":"< 1K"
   },
   {
     "Class":"Predicate",
-    "Name":"http:\/\/schema.org\/jurisdiction",
+    "Name":"https://schema.org/jurisdiction",
     "Domain Bucket":"< 1K"
   },
   {
     "Class":"Predicate",
-    "Name":"http:\/\/schema.org\/jurisdiction-input",
+    "Name":"https://schema.org/jurisdiction-input",
     "Domain Bucket":"< 1K"
   },
   {
     "Class":"Predicate",
-    "Name":"http:\/\/schema.org\/jurisdiction-output",
+    "Name":"https://schema.org/jurisdiction-output",
     "Domain Bucket":"< 1K"
   },
   {
     "Class":"Predicate",
-    "Name":"http:\/\/schema.org\/keywords",
+    "Name":"https://schema.org/keywords",
     "Domain Bucket":"1M - 10M"
   },
   {
     "Class":"Predicate",
-    "Name":"http:\/\/schema.org\/keywords-input",
+    "Name":"https://schema.org/keywords-input",
     "Domain Bucket":"< 1K"
   },
   {
     "Class":"Predicate",
-    "Name":"http:\/\/schema.org\/keywords-output",
+    "Name":"https://schema.org/keywords-output",
     "Domain Bucket":"< 1K"
   },
   {
     "Class":"Predicate",
-    "Name":"http:\/\/schema.org\/knownVehicleDamages",
+    "Name":"https://schema.org/knownVehicleDamages",
     "Domain Bucket":"< 1K"
   },
   {
     "Class":"Predicate",
-    "Name":"http:\/\/schema.org\/knownVehicleDamages-input",
+    "Name":"https://schema.org/knownVehicleDamages-input",
     "Domain Bucket":"< 1K"
   },
   {
     "Class":"Predicate",
-    "Name":"http:\/\/schema.org\/knownVehicleDamages-output",
+    "Name":"https://schema.org/knownVehicleDamages-output",
     "Domain Bucket":"< 1K"
   },
   {
     "Class":"Predicate",
-    "Name":"http:\/\/schema.org\/knows",
+    "Name":"https://schema.org/knows",
     "Domain Bucket":"1K - 10K"
   },
   {
     "Class":"Predicate",
-    "Name":"http:\/\/schema.org\/knows-input",
+    "Name":"https://schema.org/knows-input",
     "Domain Bucket":"< 1K"
   },
   {
     "Class":"Predicate",
-    "Name":"http:\/\/schema.org\/knows-output",
+    "Name":"https://schema.org/knows-output",
     "Domain Bucket":"< 1K"
   },
   {
     "Class":"Predicate",
-    "Name":"http:\/\/schema.org\/knowsAbout",
+    "Name":"https://schema.org/knowsAbout",
     "Domain Bucket":"100K - 1M"
   },
   {
     "Class":"Predicate",
-    "Name":"http:\/\/schema.org\/knowsAbout-input",
+    "Name":"https://schema.org/knowsAbout-input",
     "Domain Bucket":"< 1K"
   },
   {
     "Class":"Predicate",
-    "Name":"http:\/\/schema.org\/knowsAbout-output",
+    "Name":"https://schema.org/knowsAbout-output",
     "Domain Bucket":"< 1K"
   },
   {
     "Class":"Predicate",
-    "Name":"http:\/\/schema.org\/knowsLanguage",
+    "Name":"https://schema.org/knowsLanguage",
     "Domain Bucket":"10K - 100K"
   },
   {
     "Class":"Predicate",
-    "Name":"http:\/\/schema.org\/knowsLanguage-input",
+    "Name":"https://schema.org/knowsLanguage-input",
     "Domain Bucket":"< 1K"
   },
   {
     "Class":"Predicate",
-    "Name":"http:\/\/schema.org\/knowsLanguage-output",
+    "Name":"https://schema.org/knowsLanguage-output",
     "Domain Bucket":"< 1K"
   },
   {
     "Class":"Predicate",
-    "Name":"http:\/\/schema.org\/labelDetails",
+    "Name":"https://schema.org/labelDetails",
     "Domain Bucket":"< 1K"
   },
   {
     "Class":"Predicate",
-    "Name":"http:\/\/schema.org\/labelDetails-input",
+    "Name":"https://schema.org/labelDetails-input",
     "Domain Bucket":"< 1K"
   },
   {
     "Class":"Predicate",
-    "Name":"http:\/\/schema.org\/labelDetails-output",
+    "Name":"https://schema.org/labelDetails-output",
     "Domain Bucket":"< 1K"
   },
   {
     "Class":"Predicate",
-    "Name":"http:\/\/schema.org\/landlord",
+    "Name":"https://schema.org/landlord",
     "Domain Bucket":"< 1K"
   },
   {
     "Class":"Predicate",
-    "Name":"http:\/\/schema.org\/landlord-input",
+    "Name":"https://schema.org/landlord-input",
     "Domain Bucket":"< 1K"
   },
   {
     "Class":"Predicate",
-    "Name":"http:\/\/schema.org\/landlord-output",
+    "Name":"https://schema.org/landlord-output",
     "Domain Bucket":"< 1K"
   },
   {
     "Class":"Predicate",
-    "Name":"http:\/\/schema.org\/language",
+    "Name":"https://schema.org/language",
     "Domain Bucket":"10K - 100K"
   },
   {
     "Class":"Predicate",
-    "Name":"http:\/\/schema.org\/language-input",
+    "Name":"https://schema.org/language-input",
     "Domain Bucket":"< 1K"
   },
   {
     "Class":"Predicate",
-    "Name":"http:\/\/schema.org\/language-output",
+    "Name":"https://schema.org/language-output",
     "Domain Bucket":"< 1K"
   },
   {
     "Class":"Predicate",
-    "Name":"http:\/\/schema.org\/lastReviewed",
+    "Name":"https://schema.org/lastReviewed",
     "Domain Bucket":"10K - 100K"
   },
   {
     "Class":"Predicate",
-    "Name":"http:\/\/schema.org\/lastReviewed-input",
+    "Name":"https://schema.org/lastReviewed-input",
     "Domain Bucket":"< 1K"
   },
   {
     "Class":"Predicate",
-    "Name":"http:\/\/schema.org\/lastReviewed-output",
+    "Name":"https://schema.org/lastReviewed-output",
     "Domain Bucket":"< 1K"
   },
   {
     "Class":"Predicate",
-    "Name":"http:\/\/schema.org\/latitude",
+    "Name":"https://schema.org/latitude",
     "Domain Bucket":"1M - 10M"
   },
   {
     "Class":"Predicate",
-    "Name":"http:\/\/schema.org\/latitude-input",
+    "Name":"https://schema.org/latitude-input",
     "Domain Bucket":"< 1K"
   },
   {
     "Class":"Predicate",
-    "Name":"http:\/\/schema.org\/latitude-output",
+    "Name":"https://schema.org/latitude-output",
     "Domain Bucket":"< 1K"
   },
   {
     "Class":"Predicate",
-    "Name":"http:\/\/schema.org\/layoutImage",
+    "Name":"https://schema.org/layoutImage",
     "Domain Bucket":"1K - 10K"
   },
   {
     "Class":"Predicate",
-    "Name":"http:\/\/schema.org\/layoutImage-input",
+    "Name":"https://schema.org/layoutImage-input",
     "Domain Bucket":"< 1K"
   },
   {
     "Class":"Predicate",
-    "Name":"http:\/\/schema.org\/layoutImage-output",
+    "Name":"https://schema.org/layoutImage-output",
     "Domain Bucket":"< 1K"
   },
   {
     "Class":"Predicate",
-    "Name":"http:\/\/schema.org\/learningResourceType",
+    "Name":"https://schema.org/learningResourceType",
     "Domain Bucket":"10K - 100K"
   },
   {
     "Class":"Predicate",
-    "Name":"http:\/\/schema.org\/learningResourceType-input",
+    "Name":"https://schema.org/learningResourceType-input",
     "Domain Bucket":"< 1K"
   },
   {
     "Class":"Predicate",
-    "Name":"http:\/\/schema.org\/learningResourceType-output",
+    "Name":"https://schema.org/learningResourceType-output",
     "Domain Bucket":"< 1K"
   },
   {
     "Class":"Predicate",
-    "Name":"http:\/\/schema.org\/leaseLength",
+    "Name":"https://schema.org/leaseLength",
     "Domain Bucket":"1K - 10K"
   },
   {
     "Class":"Predicate",
-    "Name":"http:\/\/schema.org\/leaseLength-input",
+    "Name":"https://schema.org/leaseLength-input",
     "Domain Bucket":"< 1K"
   },
   {
     "Class":"Predicate",
-    "Name":"http:\/\/schema.org\/leaseLength-output",
+    "Name":"https://schema.org/leaseLength-output",
     "Domain Bucket":"< 1K"
   },
   {
     "Class":"Predicate",
-    "Name":"http:\/\/schema.org\/legalAddress",
+    "Name":"https://schema.org/legalAddress",
     "Domain Bucket":"1K - 10K"
   },
   {
     "Class":"Predicate",
-    "Name":"http:\/\/schema.org\/legalAddress-input",
+    "Name":"https://schema.org/legalAddress-input",
     "Domain Bucket":"< 1K"
   },
   {
     "Class":"Predicate",
-    "Name":"http:\/\/schema.org\/legalAddress-output",
+    "Name":"https://schema.org/legalAddress-output",
     "Domain Bucket":"< 1K"
   },
   {
     "Class":"Predicate",
-    "Name":"http:\/\/schema.org\/legalName",
+    "Name":"https://schema.org/legalName",
     "Domain Bucket":"1M - 10M"
   },
   {
     "Class":"Predicate",
-    "Name":"http:\/\/schema.org\/legalName-input",
+    "Name":"https://schema.org/legalName-input",
     "Domain Bucket":"< 1K"
   },
   {
     "Class":"Predicate",
-    "Name":"http:\/\/schema.org\/legalName-output",
+    "Name":"https://schema.org/legalName-output",
     "Domain Bucket":"< 1K"
   },
   {
     "Class":"Predicate",
-    "Name":"http:\/\/schema.org\/legalRepresentative",
+    "Name":"https://schema.org/legalRepresentative",
     "Domain Bucket":"1K - 10K"
   },
   {
     "Class":"Predicate",
-    "Name":"http:\/\/schema.org\/legalRepresentative-input",
+    "Name":"https://schema.org/legalRepresentative-input",
     "Domain Bucket":"< 1K"
   },
   {
     "Class":"Predicate",
-    "Name":"http:\/\/schema.org\/legalRepresentative-output",
+    "Name":"https://schema.org/legalRepresentative-output",
     "Domain Bucket":"< 1K"
   },
   {
     "Class":"Predicate",
-    "Name":"http:\/\/schema.org\/legalStatus",
+    "Name":"https://schema.org/legalStatus",
     "Domain Bucket":"1K - 10K"
   },
   {
     "Class":"Predicate",
-    "Name":"http:\/\/schema.org\/legalStatus-input",
+    "Name":"https://schema.org/legalStatus-input",
     "Domain Bucket":"< 1K"
   },
   {
     "Class":"Predicate",
-    "Name":"http:\/\/schema.org\/legalStatus-output",
+    "Name":"https://schema.org/legalStatus-output",
     "Domain Bucket":"< 1K"
   },
   {
     "Class":"Predicate",
-    "Name":"http:\/\/schema.org\/legislationAmends",
+    "Name":"https://schema.org/legislationAmends",
     "Domain Bucket":"< 1K"
   },
   {
     "Class":"Predicate",
-    "Name":"http:\/\/schema.org\/legislationAmends-input",
+    "Name":"https://schema.org/legislationAmends-input",
     "Domain Bucket":"< 1K"
   },
   {
     "Class":"Predicate",
-    "Name":"http:\/\/schema.org\/legislationAmends-output",
+    "Name":"https://schema.org/legislationAmends-output",
     "Domain Bucket":"< 1K"
   },
   {
     "Class":"Predicate",
-    "Name":"http:\/\/schema.org\/legislationApplies",
+    "Name":"https://schema.org/legislationApplies",
     "Domain Bucket":"< 1K"
   },
   {
     "Class":"Predicate",
-    "Name":"http:\/\/schema.org\/legislationApplies-input",
+    "Name":"https://schema.org/legislationApplies-input",
     "Domain Bucket":"< 1K"
   },
   {
     "Class":"Predicate",
-    "Name":"http:\/\/schema.org\/legislationApplies-output",
+    "Name":"https://schema.org/legislationApplies-output",
     "Domain Bucket":"< 1K"
   },
   {
     "Class":"Predicate",
-    "Name":"http:\/\/schema.org\/legislationChanges",
+    "Name":"https://schema.org/legislationChanges",
     "Domain Bucket":"< 1K"
   },
   {
     "Class":"Predicate",
-    "Name":"http:\/\/schema.org\/legislationChanges-input",
+    "Name":"https://schema.org/legislationChanges-input",
     "Domain Bucket":"< 1K"
   },
   {
     "Class":"Predicate",
-    "Name":"http:\/\/schema.org\/legislationChanges-output",
+    "Name":"https://schema.org/legislationChanges-output",
     "Domain Bucket":"< 1K"
   },
   {
     "Class":"Predicate",
-    "Name":"http:\/\/schema.org\/legislationCommences",
+    "Name":"https://schema.org/legislationCommences",
     "Domain Bucket":"< 1K"
   },
   {
     "Class":"Predicate",
-    "Name":"http:\/\/schema.org\/legislationCommences-input",
+    "Name":"https://schema.org/legislationCommences-input",
     "Domain Bucket":"< 1K"
   },
   {
     "Class":"Predicate",
-    "Name":"http:\/\/schema.org\/legislationCommences-output",
+    "Name":"https://schema.org/legislationCommences-output",
     "Domain Bucket":"< 1K"
   },
   {
     "Class":"Predicate",
-    "Name":"http:\/\/schema.org\/legislationConsolidates",
+    "Name":"https://schema.org/legislationConsolidates",
     "Domain Bucket":"< 1K"
   },
   {
     "Class":"Predicate",
-    "Name":"http:\/\/schema.org\/legislationConsolidates-input",
+    "Name":"https://schema.org/legislationConsolidates-input",
     "Domain Bucket":"< 1K"
   },
   {
     "Class":"Predicate",
-    "Name":"http:\/\/schema.org\/legislationConsolidates-output",
+    "Name":"https://schema.org/legislationConsolidates-output",
     "Domain Bucket":"< 1K"
   },
   {
     "Class":"Predicate",
-    "Name":"http:\/\/schema.org\/legislationCorrects",
+    "Name":"https://schema.org/legislationCorrects",
     "Domain Bucket":"< 1K"
   },
   {
     "Class":"Predicate",
-    "Name":"http:\/\/schema.org\/legislationCorrects-input",
+    "Name":"https://schema.org/legislationCorrects-input",
     "Domain Bucket":"< 1K"
   },
   {
     "Class":"Predicate",
-    "Name":"http:\/\/schema.org\/legislationCorrects-output",
+    "Name":"https://schema.org/legislationCorrects-output",
     "Domain Bucket":"< 1K"
   },
   {
     "Class":"Predicate",
-    "Name":"http:\/\/schema.org\/legislationCountersignedBy",
+    "Name":"https://schema.org/legislationCountersignedBy",
     "Domain Bucket":"< 1K"
   },
   {
     "Class":"Predicate",
-    "Name":"http:\/\/schema.org\/legislationCountersignedBy-input",
+    "Name":"https://schema.org/legislationCountersignedBy-input",
     "Domain Bucket":"< 1K"
   },
   {
     "Class":"Predicate",
-    "Name":"http:\/\/schema.org\/legislationCountersignedBy-output",
+    "Name":"https://schema.org/legislationCountersignedBy-output",
     "Domain Bucket":"< 1K"
   },
   {
     "Class":"Predicate",
-    "Name":"http:\/\/schema.org\/legislationDate",
+    "Name":"https://schema.org/legislationDate",
     "Domain Bucket":"< 1K"
   },
   {
     "Class":"Predicate",
-    "Name":"http:\/\/schema.org\/legislationDate-input",
+    "Name":"https://schema.org/legislationDate-input",
     "Domain Bucket":"< 1K"
   },
   {
     "Class":"Predicate",
-    "Name":"http:\/\/schema.org\/legislationDate-output",
+    "Name":"https://schema.org/legislationDate-output",
     "Domain Bucket":"< 1K"
   },
   {
     "Class":"Predicate",
-    "Name":"http:\/\/schema.org\/legislationDateOfApplicability",
+    "Name":"https://schema.org/legislationDateOfApplicability",
     "Domain Bucket":"< 1K"
   },
   {
     "Class":"Predicate",
-    "Name":"http:\/\/schema.org\/legislationDateOfApplicability-input",
+    "Name":"https://schema.org/legislationDateOfApplicability-input",
     "Domain Bucket":"< 1K"
   },
   {
     "Class":"Predicate",
-    "Name":"http:\/\/schema.org\/legislationDateOfApplicability-output",
+    "Name":"https://schema.org/legislationDateOfApplicability-output",
     "Domain Bucket":"< 1K"
   },
   {
     "Class":"Predicate",
-    "Name":"http:\/\/schema.org\/legislationDateVersion",
+    "Name":"https://schema.org/legislationDateVersion",
     "Domain Bucket":"< 1K"
   },
   {
     "Class":"Predicate",
-    "Name":"http:\/\/schema.org\/legislationDateVersion-input",
+    "Name":"https://schema.org/legislationDateVersion-input",
     "Domain Bucket":"< 1K"
   },
   {
     "Class":"Predicate",
-    "Name":"http:\/\/schema.org\/legislationDateVersion-output",
+    "Name":"https://schema.org/legislationDateVersion-output",
     "Domain Bucket":"< 1K"
   },
   {
     "Class":"Predicate",
-    "Name":"http:\/\/schema.org\/legislationEnsuresImplementationOf",
+    "Name":"https://schema.org/legislationEnsuresImplementationOf",
     "Domain Bucket":"< 1K"
   },
   {
     "Class":"Predicate",
-    "Name":"http:\/\/schema.org\/legislationEnsuresImplementationOf-input",
+    "Name":"https://schema.org/legislationEnsuresImplementationOf-input",
     "Domain Bucket":"< 1K"
   },
   {
     "Class":"Predicate",
-    "Name":"http:\/\/schema.org\/legislationEnsuresImplementationOf-output",
+    "Name":"https://schema.org/legislationEnsuresImplementationOf-output",
     "Domain Bucket":"< 1K"
   },
   {
     "Class":"Predicate",
-    "Name":"http:\/\/schema.org\/legislationIdentifier",
+    "Name":"https://schema.org/legislationIdentifier",
     "Domain Bucket":"< 1K"
   },
   {
     "Class":"Predicate",
-    "Name":"http:\/\/schema.org\/legislationIdentifier-input",
+    "Name":"https://schema.org/legislationIdentifier-input",
     "Domain Bucket":"< 1K"
   },
   {
     "Class":"Predicate",
-    "Name":"http:\/\/schema.org\/legislationIdentifier-output",
+    "Name":"https://schema.org/legislationIdentifier-output",
     "Domain Bucket":"< 1K"
   },
   {
     "Class":"Predicate",
-    "Name":"http:\/\/schema.org\/legislationJurisdiction",
+    "Name":"https://schema.org/legislationJurisdiction",
     "Domain Bucket":"1K - 10K"
   },
   {
     "Class":"Predicate",
-    "Name":"http:\/\/schema.org\/legislationJurisdiction-input",
+    "Name":"https://schema.org/legislationJurisdiction-input",
     "Domain Bucket":"< 1K"
   },
   {
     "Class":"Predicate",
-    "Name":"http:\/\/schema.org\/legislationJurisdiction-output",
+    "Name":"https://schema.org/legislationJurisdiction-output",
     "Domain Bucket":"< 1K"
   },
   {
     "Class":"Predicate",
-    "Name":"http:\/\/schema.org\/legislationLegalForce",
+    "Name":"https://schema.org/legislationLegalForce",
     "Domain Bucket":"< 1K"
   },
   {
     "Class":"Predicate",
-    "Name":"http:\/\/schema.org\/legislationLegalForce-input",
+    "Name":"https://schema.org/legislationLegalForce-input",
     "Domain Bucket":"< 1K"
   },
   {
     "Class":"Predicate",
-    "Name":"http:\/\/schema.org\/legislationLegalForce-output",
+    "Name":"https://schema.org/legislationLegalForce-output",
     "Domain Bucket":"< 1K"
   },
   {
     "Class":"Predicate",
-    "Name":"http:\/\/schema.org\/legislationLegalValue",
+    "Name":"https://schema.org/legislationLegalValue",
     "Domain Bucket":"< 1K"
   },
   {
     "Class":"Predicate",
-    "Name":"http:\/\/schema.org\/legislationLegalValue-input",
+    "Name":"https://schema.org/legislationLegalValue-input",
     "Domain Bucket":"< 1K"
   },
   {
     "Class":"Predicate",
-    "Name":"http:\/\/schema.org\/legislationLegalValue-output",
+    "Name":"https://schema.org/legislationLegalValue-output",
     "Domain Bucket":"< 1K"
   },
   {
     "Class":"Predicate",
-    "Name":"http:\/\/schema.org\/legislationPassedBy",
+    "Name":"https://schema.org/legislationPassedBy",
     "Domain Bucket":"< 1K"
   },
   {
     "Class":"Predicate",
-    "Name":"http:\/\/schema.org\/legislationPassedBy-input",
+    "Name":"https://schema.org/legislationPassedBy-input",
     "Domain Bucket":"< 1K"
   },
   {
     "Class":"Predicate",
-    "Name":"http:\/\/schema.org\/legislationPassedBy-output",
+    "Name":"https://schema.org/legislationPassedBy-output",
     "Domain Bucket":"< 1K"
   },
   {
     "Class":"Predicate",
-    "Name":"http:\/\/schema.org\/legislationRepeals",
+    "Name":"https://schema.org/legislationRepeals",
     "Domain Bucket":"< 1K"
   },
   {
     "Class":"Predicate",
-    "Name":"http:\/\/schema.org\/legislationRepeals-input",
+    "Name":"https://schema.org/legislationRepeals-input",
     "Domain Bucket":"< 1K"
   },
   {
     "Class":"Predicate",
-    "Name":"http:\/\/schema.org\/legislationRepeals-output",
+    "Name":"https://schema.org/legislationRepeals-output",
     "Domain Bucket":"< 1K"
   },
   {
     "Class":"Predicate",
-    "Name":"http:\/\/schema.org\/legislationResponsible",
+    "Name":"https://schema.org/legislationResponsible",
     "Domain Bucket":"< 1K"
   },
   {
     "Class":"Predicate",
-    "Name":"http:\/\/schema.org\/legislationResponsible-input",
+    "Name":"https://schema.org/legislationResponsible-input",
     "Domain Bucket":"< 1K"
   },
   {
     "Class":"Predicate",
-    "Name":"http:\/\/schema.org\/legislationResponsible-output",
+    "Name":"https://schema.org/legislationResponsible-output",
     "Domain Bucket":"< 1K"
   },
   {
     "Class":"Predicate",
-    "Name":"http:\/\/schema.org\/legislationTransposes",
+    "Name":"https://schema.org/legislationTransposes",
     "Domain Bucket":"< 1K"
   },
   {
     "Class":"Predicate",
-    "Name":"http:\/\/schema.org\/legislationTransposes-input",
+    "Name":"https://schema.org/legislationTransposes-input",
     "Domain Bucket":"< 1K"
   },
   {
     "Class":"Predicate",
-    "Name":"http:\/\/schema.org\/legislationTransposes-output",
+    "Name":"https://schema.org/legislationTransposes-output",
     "Domain Bucket":"< 1K"
   },
   {
     "Class":"Predicate",
-    "Name":"http:\/\/schema.org\/legislationType",
+    "Name":"https://schema.org/legislationType",
     "Domain Bucket":"< 1K"
   },
   {
     "Class":"Predicate",
-    "Name":"http:\/\/schema.org\/legislationType-input",
+    "Name":"https://schema.org/legislationType-input",
     "Domain Bucket":"< 1K"
   },
   {
     "Class":"Predicate",
-    "Name":"http:\/\/schema.org\/legislationType-output",
+    "Name":"https://schema.org/legislationType-output",
     "Domain Bucket":"< 1K"
   },
   {
     "Class":"Predicate",
-    "Name":"http:\/\/schema.org\/leiCode",
+    "Name":"https://schema.org/leiCode",
     "Domain Bucket":"1K - 10K"
   },
   {
     "Class":"Predicate",
-    "Name":"http:\/\/schema.org\/leiCode-input",
+    "Name":"https://schema.org/leiCode-input",
     "Domain Bucket":"< 1K"
   },
   {
     "Class":"Predicate",
-    "Name":"http:\/\/schema.org\/leiCode-output",
+    "Name":"https://schema.org/leiCode-output",
     "Domain Bucket":"< 1K"
   },
   {
     "Class":"Predicate",
-    "Name":"http:\/\/schema.org\/lender",
+    "Name":"https://schema.org/lender",
     "Domain Bucket":"< 1K"
   },
   {
     "Class":"Predicate",
-    "Name":"http:\/\/schema.org\/lender-input",
+    "Name":"https://schema.org/lender-input",
     "Domain Bucket":"< 1K"
   },
   {
     "Class":"Predicate",
-    "Name":"http:\/\/schema.org\/lender-output",
+    "Name":"https://schema.org/lender-output",
     "Domain Bucket":"< 1K"
   },
   {
     "Class":"Predicate",
-    "Name":"http:\/\/schema.org\/lesser",
+    "Name":"https://schema.org/lesser",
     "Domain Bucket":"< 1K"
   },
   {
     "Class":"Predicate",
-    "Name":"http:\/\/schema.org\/lesser-input",
+    "Name":"https://schema.org/lesser-input",
     "Domain Bucket":"< 1K"
   },
   {
     "Class":"Predicate",
-    "Name":"http:\/\/schema.org\/lesser-output",
+    "Name":"https://schema.org/lesser-output",
     "Domain Bucket":"< 1K"
   },
   {
     "Class":"Predicate",
-    "Name":"http:\/\/schema.org\/lesserOrEqual",
+    "Name":"https://schema.org/lesserOrEqual",
     "Domain Bucket":"< 1K"
   },
   {
     "Class":"Predicate",
-    "Name":"http:\/\/schema.org\/lesserOrEqual-input",
+    "Name":"https://schema.org/lesserOrEqual-input",
     "Domain Bucket":"< 1K"
   },
   {
     "Class":"Predicate",
-    "Name":"http:\/\/schema.org\/lesserOrEqual-output",
+    "Name":"https://schema.org/lesserOrEqual-output",
     "Domain Bucket":"< 1K"
   },
   {
     "Class":"Predicate",
-    "Name":"http:\/\/schema.org\/letterer",
+    "Name":"https://schema.org/letterer",
     "Domain Bucket":"< 1K"
   },
   {
     "Class":"Predicate",
-    "Name":"http:\/\/schema.org\/letterer-input",
+    "Name":"https://schema.org/letterer-input",
     "Domain Bucket":"< 1K"
   },
   {
     "Class":"Predicate",
-    "Name":"http:\/\/schema.org\/letterer-output",
+    "Name":"https://schema.org/letterer-output",
     "Domain Bucket":"< 1K"
   },
   {
     "Class":"Predicate",
-    "Name":"http:\/\/schema.org\/license",
+    "Name":"https://schema.org/license",
     "Domain Bucket":"100K - 1M"
   },
   {
     "Class":"Predicate",
-    "Name":"http:\/\/schema.org\/license-input",
+    "Name":"https://schema.org/license-input",
     "Domain Bucket":"< 1K"
   },
   {
     "Class":"Predicate",
-    "Name":"http:\/\/schema.org\/license-output",
+    "Name":"https://schema.org/license-output",
     "Domain Bucket":"< 1K"
   },
   {
     "Class":"Predicate",
-    "Name":"http:\/\/schema.org\/lifeEvent",
+    "Name":"https://schema.org/lifeEvent",
     "Domain Bucket":"< 1K"
   },
   {
     "Class":"Predicate",
-    "Name":"http:\/\/schema.org\/lifeEvent-input",
+    "Name":"https://schema.org/lifeEvent-input",
     "Domain Bucket":"< 1K"
   },
   {
     "Class":"Predicate",
-    "Name":"http:\/\/schema.org\/lifeEvent-output",
+    "Name":"https://schema.org/lifeEvent-output",
     "Domain Bucket":"< 1K"
   },
   {
     "Class":"Predicate",
-    "Name":"http:\/\/schema.org\/line",
+    "Name":"https://schema.org/line",
     "Domain Bucket":"< 1K"
   },
   {
     "Class":"Predicate",
-    "Name":"http:\/\/schema.org\/line-input",
+    "Name":"https://schema.org/line-input",
     "Domain Bucket":"< 1K"
   },
   {
     "Class":"Predicate",
-    "Name":"http:\/\/schema.org\/line-output",
+    "Name":"https://schema.org/line-output",
     "Domain Bucket":"< 1K"
   },
   {
     "Class":"Predicate",
-    "Name":"http:\/\/schema.org\/linkRelationship",
+    "Name":"https://schema.org/linkRelationship",
     "Domain Bucket":"< 1K"
   },
   {
     "Class":"Predicate",
-    "Name":"http:\/\/schema.org\/linkRelationship-input",
+    "Name":"https://schema.org/linkRelationship-input",
     "Domain Bucket":"< 1K"
   },
   {
     "Class":"Predicate",
-    "Name":"http:\/\/schema.org\/linkRelationship-output",
+    "Name":"https://schema.org/linkRelationship-output",
     "Domain Bucket":"< 1K"
   },
   {
     "Class":"Predicate",
-    "Name":"http:\/\/schema.org\/liveBlogUpdate",
+    "Name":"https://schema.org/liveBlogUpdate",
     "Domain Bucket":"1K - 10K"
   },
   {
     "Class":"Predicate",
-    "Name":"http:\/\/schema.org\/liveBlogUpdate-input",
+    "Name":"https://schema.org/liveBlogUpdate-input",
     "Domain Bucket":"< 1K"
   },
   {
     "Class":"Predicate",
-    "Name":"http:\/\/schema.org\/liveBlogUpdate-output",
+    "Name":"https://schema.org/liveBlogUpdate-output",
     "Domain Bucket":"< 1K"
   },
   {
     "Class":"Predicate",
-    "Name":"http:\/\/schema.org\/loanMortgageMandateAmount",
+    "Name":"https://schema.org/loanMortgageMandateAmount",
     "Domain Bucket":"< 1K"
   },
   {
     "Class":"Predicate",
-    "Name":"http:\/\/schema.org\/loanMortgageMandateAmount-input",
+    "Name":"https://schema.org/loanMortgageMandateAmount-input",
     "Domain Bucket":"< 1K"
   },
   {
     "Class":"Predicate",
-    "Name":"http:\/\/schema.org\/loanMortgageMandateAmount-output",
+    "Name":"https://schema.org/loanMortgageMandateAmount-output",
     "Domain Bucket":"< 1K"
   },
   {
     "Class":"Predicate",
-    "Name":"http:\/\/schema.org\/loanPaymentAmount",
+    "Name":"https://schema.org/loanPaymentAmount",
     "Domain Bucket":"< 1K"
   },
   {
     "Class":"Predicate",
-    "Name":"http:\/\/schema.org\/loanPaymentAmount-input",
+    "Name":"https://schema.org/loanPaymentAmount-input",
     "Domain Bucket":"< 1K"
   },
   {
     "Class":"Predicate",
-    "Name":"http:\/\/schema.org\/loanPaymentAmount-output",
+    "Name":"https://schema.org/loanPaymentAmount-output",
     "Domain Bucket":"< 1K"
   },
   {
     "Class":"Predicate",
-    "Name":"http:\/\/schema.org\/loanPaymentFrequency",
+    "Name":"https://schema.org/loanPaymentFrequency",
     "Domain Bucket":"< 1K"
   },
   {
     "Class":"Predicate",
-    "Name":"http:\/\/schema.org\/loanPaymentFrequency-input",
+    "Name":"https://schema.org/loanPaymentFrequency-input",
     "Domain Bucket":"< 1K"
   },
   {
     "Class":"Predicate",
-    "Name":"http:\/\/schema.org\/loanPaymentFrequency-output",
+    "Name":"https://schema.org/loanPaymentFrequency-output",
     "Domain Bucket":"< 1K"
   },
   {
     "Class":"Predicate",
-    "Name":"http:\/\/schema.org\/loanRepaymentForm",
+    "Name":"https://schema.org/loanRepaymentForm",
     "Domain Bucket":"< 1K"
   },
   {
     "Class":"Predicate",
-    "Name":"http:\/\/schema.org\/loanRepaymentForm-input",
+    "Name":"https://schema.org/loanRepaymentForm-input",
     "Domain Bucket":"< 1K"
   },
   {
     "Class":"Predicate",
-    "Name":"http:\/\/schema.org\/loanRepaymentForm-output",
+    "Name":"https://schema.org/loanRepaymentForm-output",
     "Domain Bucket":"< 1K"
   },
   {
     "Class":"Predicate",
-    "Name":"http:\/\/schema.org\/loanTerm",
+    "Name":"https://schema.org/loanTerm",
     "Domain Bucket":"1K - 10K"
   },
   {
     "Class":"Predicate",
-    "Name":"http:\/\/schema.org\/loanTerm-input",
+    "Name":"https://schema.org/loanTerm-input",
     "Domain Bucket":"< 1K"
   },
   {
     "Class":"Predicate",
-    "Name":"http:\/\/schema.org\/loanTerm-output",
+    "Name":"https://schema.org/loanTerm-output",
     "Domain Bucket":"< 1K"
   },
   {
     "Class":"Predicate",
-    "Name":"http:\/\/schema.org\/loanType",
+    "Name":"https://schema.org/loanType",
     "Domain Bucket":"1K - 10K"
   },
   {
     "Class":"Predicate",
-    "Name":"http:\/\/schema.org\/loanType-input",
+    "Name":"https://schema.org/loanType-input",
     "Domain Bucket":"< 1K"
   },
   {
     "Class":"Predicate",
-    "Name":"http:\/\/schema.org\/loanType-output",
+    "Name":"https://schema.org/loanType-output",
     "Domain Bucket":"< 1K"
   },
   {
     "Class":"Predicate",
-    "Name":"http:\/\/schema.org\/location",
+    "Name":"https://schema.org/location",
     "Domain Bucket":"1M - 10M"
   },
   {
     "Class":"Predicate",
-    "Name":"http:\/\/schema.org\/location-input",
+    "Name":"https://schema.org/location-input",
     "Domain Bucket":"< 1K"
   },
   {
     "Class":"Predicate",
-    "Name":"http:\/\/schema.org\/location-output",
+    "Name":"https://schema.org/location-output",
     "Domain Bucket":"< 1K"
   },
   {
     "Class":"Predicate",
-    "Name":"http:\/\/schema.org\/locationCreated",
+    "Name":"https://schema.org/locationCreated",
     "Domain Bucket":"10K - 100K"
   },
   {
     "Class":"Predicate",
-    "Name":"http:\/\/schema.org\/locationCreated-input",
+    "Name":"https://schema.org/locationCreated-input",
     "Domain Bucket":"< 1K"
   },
   {
     "Class":"Predicate",
-    "Name":"http:\/\/schema.org\/locationCreated-output",
+    "Name":"https://schema.org/locationCreated-output",
     "Domain Bucket":"< 1K"
   },
   {
     "Class":"Predicate",
-    "Name":"http:\/\/schema.org\/lodgingUnitDescription",
+    "Name":"https://schema.org/lodgingUnitDescription",
     "Domain Bucket":"< 1K"
   },
   {
     "Class":"Predicate",
-    "Name":"http:\/\/schema.org\/lodgingUnitDescription-input",
+    "Name":"https://schema.org/lodgingUnitDescription-input",
     "Domain Bucket":"< 1K"
   },
   {
     "Class":"Predicate",
-    "Name":"http:\/\/schema.org\/lodgingUnitDescription-output",
+    "Name":"https://schema.org/lodgingUnitDescription-output",
     "Domain Bucket":"< 1K"
   },
   {
     "Class":"Predicate",
-    "Name":"http:\/\/schema.org\/lodgingUnitType",
+    "Name":"https://schema.org/lodgingUnitType",
     "Domain Bucket":"< 1K"
   },
   {
     "Class":"Predicate",
-    "Name":"http:\/\/schema.org\/lodgingUnitType-input",
+    "Name":"https://schema.org/lodgingUnitType-input",
     "Domain Bucket":"< 1K"
   },
   {
     "Class":"Predicate",
-    "Name":"http:\/\/schema.org\/lodgingUnitType-output",
+    "Name":"https://schema.org/lodgingUnitType-output",
     "Domain Bucket":"< 1K"
   },
   {
     "Class":"Predicate",
-    "Name":"http:\/\/schema.org\/logo",
+    "Name":"https://schema.org/logo",
     "Domain Bucket":"10M+"
   },
   {
     "Class":"Predicate",
-    "Name":"http:\/\/schema.org\/logo-input",
+    "Name":"https://schema.org/logo-input",
     "Domain Bucket":"< 1K"
   },
   {
     "Class":"Predicate",
-    "Name":"http:\/\/schema.org\/logo-output",
+    "Name":"https://schema.org/logo-output",
     "Domain Bucket":"< 1K"
   },
   {
     "Class":"Predicate",
-    "Name":"http:\/\/schema.org\/longitude",
+    "Name":"https://schema.org/longitude",
     "Domain Bucket":"1M - 10M"
   },
   {
     "Class":"Predicate",
-    "Name":"http:\/\/schema.org\/longitude-input",
+    "Name":"https://schema.org/longitude-input",
     "Domain Bucket":"< 1K"
   },
   {
     "Class":"Predicate",
-    "Name":"http:\/\/schema.org\/longitude-output",
+    "Name":"https://schema.org/longitude-output",
     "Domain Bucket":"< 1K"
   },
   {
     "Class":"Predicate",
-    "Name":"http:\/\/schema.org\/loser",
+    "Name":"https://schema.org/loser",
     "Domain Bucket":"< 1K"
   },
   {
     "Class":"Predicate",
-    "Name":"http:\/\/schema.org\/loser-input",
+    "Name":"https://schema.org/loser-input",
     "Domain Bucket":"< 1K"
   },
   {
     "Class":"Predicate",
-    "Name":"http:\/\/schema.org\/loser-output",
+    "Name":"https://schema.org/loser-output",
     "Domain Bucket":"< 1K"
   },
   {
     "Class":"Predicate",
-    "Name":"http:\/\/schema.org\/lowPrice",
+    "Name":"https://schema.org/lowPrice",
     "Domain Bucket":"1M - 10M"
   },
   {
     "Class":"Predicate",
-    "Name":"http:\/\/schema.org\/lowPrice-input",
+    "Name":"https://schema.org/lowPrice-input",
     "Domain Bucket":"< 1K"
   },
   {
     "Class":"Predicate",
-    "Name":"http:\/\/schema.org\/lowPrice-output",
+    "Name":"https://schema.org/lowPrice-output",
     "Domain Bucket":"< 1K"
   },
   {
     "Class":"Predicate",
-    "Name":"http:\/\/schema.org\/lyricist",
+    "Name":"https://schema.org/lyricist",
     "Domain Bucket":"< 1K"
   },
   {
     "Class":"Predicate",
-    "Name":"http:\/\/schema.org\/lyricist-input",
+    "Name":"https://schema.org/lyricist-input",
     "Domain Bucket":"< 1K"
   },
   {
     "Class":"Predicate",
-    "Name":"http:\/\/schema.org\/lyricist-output",
+    "Name":"https://schema.org/lyricist-output",
     "Domain Bucket":"< 1K"
   },
   {
     "Class":"Predicate",
-    "Name":"http:\/\/schema.org\/lyrics",
+    "Name":"https://schema.org/lyrics",
     "Domain Bucket":"1K - 10K"
   },
   {
     "Class":"Predicate",
-    "Name":"http:\/\/schema.org\/lyrics-input",
+    "Name":"https://schema.org/lyrics-input",
     "Domain Bucket":"< 1K"
   },
   {
     "Class":"Predicate",
-    "Name":"http:\/\/schema.org\/lyrics-output",
+    "Name":"https://schema.org/lyrics-output",
     "Domain Bucket":"< 1K"
   },
   {
     "Class":"Predicate",
-    "Name":"http:\/\/schema.org\/mainContentOfPage",
+    "Name":"https://schema.org/mainContentOfPage",
     "Domain Bucket":"1M - 10M"
   },
   {
     "Class":"Predicate",
-    "Name":"http:\/\/schema.org\/mainContentOfPage-input",
+    "Name":"https://schema.org/mainContentOfPage-input",
     "Domain Bucket":"< 1K"
   },
   {
     "Class":"Predicate",
-    "Name":"http:\/\/schema.org\/mainContentOfPage-output",
+    "Name":"https://schema.org/mainContentOfPage-output",
     "Domain Bucket":"< 1K"
   },
   {
     "Class":"Predicate",
-    "Name":"http:\/\/schema.org\/mainEntity",
+    "Name":"https://schema.org/mainEntity",
     "Domain Bucket":"1M - 10M"
   },
   {
     "Class":"Predicate",
-    "Name":"http:\/\/schema.org\/mainEntity-input",
+    "Name":"https://schema.org/mainEntity-input",
     "Domain Bucket":"< 1K"
   },
   {
     "Class":"Predicate",
-    "Name":"http:\/\/schema.org\/mainEntity-output",
+    "Name":"https://schema.org/mainEntity-output",
     "Domain Bucket":"< 1K"
   },
   {
     "Class":"Predicate",
-    "Name":"http:\/\/schema.org\/mainEntityOfPage",
+    "Name":"https://schema.org/mainEntityOfPage",
     "Domain Bucket":"10M+"
   },
   {
     "Class":"Predicate",
-    "Name":"http:\/\/schema.org\/mainEntityOfPage-input",
+    "Name":"https://schema.org/mainEntityOfPage-input",
     "Domain Bucket":"< 1K"
   },
   {
     "Class":"Predicate",
-    "Name":"http:\/\/schema.org\/mainEntityOfPage-output",
+    "Name":"https://schema.org/mainEntityOfPage-output",
     "Domain Bucket":"< 1K"
   },
   {
     "Class":"Predicate",
-    "Name":"http:\/\/schema.org\/maintainer",
+    "Name":"https://schema.org/maintainer",
     "Domain Bucket":"1K - 10K"
   },
   {
     "Class":"Predicate",
-    "Name":"http:\/\/schema.org\/maintainer-input",
+    "Name":"https://schema.org/maintainer-input",
     "Domain Bucket":"< 1K"
   },
   {
     "Class":"Predicate",
-    "Name":"http:\/\/schema.org\/maintainer-output",
+    "Name":"https://schema.org/maintainer-output",
     "Domain Bucket":"< 1K"
   },
   {
     "Class":"Predicate",
-    "Name":"http:\/\/schema.org\/makesOffer",
+    "Name":"https://schema.org/makesOffer",
     "Domain Bucket":"100K - 1M"
   },
   {
     "Class":"Predicate",
-    "Name":"http:\/\/schema.org\/makesOffer-input",
+    "Name":"https://schema.org/makesOffer-input",
     "Domain Bucket":"< 1K"
   },
   {
     "Class":"Predicate",
-    "Name":"http:\/\/schema.org\/makesOffer-output",
+    "Name":"https://schema.org/makesOffer-output",
     "Domain Bucket":"< 1K"
   },
   {
     "Class":"Predicate",
-    "Name":"http:\/\/schema.org\/manufacturer",
+    "Name":"https://schema.org/manufacturer",
     "Domain Bucket":"100K - 1M"
   },
   {
     "Class":"Predicate",
-    "Name":"http:\/\/schema.org\/manufacturer-input",
+    "Name":"https://schema.org/manufacturer-input",
     "Domain Bucket":"< 1K"
   },
   {
     "Class":"Predicate",
-    "Name":"http:\/\/schema.org\/manufacturer-output",
+    "Name":"https://schema.org/manufacturer-output",
     "Domain Bucket":"< 1K"
   },
   {
     "Class":"Predicate",
-    "Name":"http:\/\/schema.org\/map",
+    "Name":"https://schema.org/map",
     "Domain Bucket":"1K - 10K"
   },
   {
     "Class":"Predicate",
-    "Name":"http:\/\/schema.org\/map-input",
+    "Name":"https://schema.org/map-input",
     "Domain Bucket":"< 1K"
   },
   {
     "Class":"Predicate",
-    "Name":"http:\/\/schema.org\/map-output",
+    "Name":"https://schema.org/map-output",
     "Domain Bucket":"< 1K"
   },
   {
     "Class":"Predicate",
-    "Name":"http:\/\/schema.org\/mapType",
+    "Name":"https://schema.org/mapType",
     "Domain Bucket":"1K - 10K"
   },
   {
     "Class":"Predicate",
-    "Name":"http:\/\/schema.org\/mapType-input",
+    "Name":"https://schema.org/mapType-input",
     "Domain Bucket":"< 1K"
   },
   {
     "Class":"Predicate",
-    "Name":"http:\/\/schema.org\/mapType-output",
+    "Name":"https://schema.org/mapType-output",
     "Domain Bucket":"< 1K"
   },
   {
     "Class":"Predicate",
-    "Name":"http:\/\/schema.org\/maps",
+    "Name":"https://schema.org/maps",
     "Domain Bucket":"1K - 10K"
   },
   {
     "Class":"Predicate",
-    "Name":"http:\/\/schema.org\/maps-input",
+    "Name":"https://schema.org/maps-input",
     "Domain Bucket":"< 1K"
   },
   {
     "Class":"Predicate",
-    "Name":"http:\/\/schema.org\/maps-output",
+    "Name":"https://schema.org/maps-output",
     "Domain Bucket":"< 1K"
   },
   {
     "Class":"Predicate",
-    "Name":"http:\/\/schema.org\/marginOfError",
+    "Name":"https://schema.org/marginOfError",
     "Domain Bucket":"< 1K"
   },
   {
     "Class":"Predicate",
-    "Name":"http:\/\/schema.org\/marginOfError-input",
+    "Name":"https://schema.org/marginOfError-input",
     "Domain Bucket":"< 1K"
   },
   {
     "Class":"Predicate",
-    "Name":"http:\/\/schema.org\/marginOfError-output",
+    "Name":"https://schema.org/marginOfError-output",
     "Domain Bucket":"< 1K"
   },
   {
     "Class":"Predicate",
-    "Name":"http:\/\/schema.org\/masthead",
+    "Name":"https://schema.org/masthead",
     "Domain Bucket":"10K - 100K"
   },
   {
     "Class":"Predicate",
-    "Name":"http:\/\/schema.org\/masthead-input",
+    "Name":"https://schema.org/masthead-input",
     "Domain Bucket":"< 1K"
   },
   {
     "Class":"Predicate",
-    "Name":"http:\/\/schema.org\/masthead-output",
+    "Name":"https://schema.org/masthead-output",
     "Domain Bucket":"< 1K"
   },
   {
     "Class":"Predicate",
-    "Name":"http:\/\/schema.org\/material",
+    "Name":"https://schema.org/material",
     "Domain Bucket":"10K - 100K"
   },
   {
     "Class":"Predicate",
-    "Name":"http:\/\/schema.org\/material-input",
+    "Name":"https://schema.org/material-input",
     "Domain Bucket":"< 1K"
   },
   {
     "Class":"Predicate",
-    "Name":"http:\/\/schema.org\/material-output",
+    "Name":"https://schema.org/material-output",
     "Domain Bucket":"< 1K"
   },
   {
     "Class":"Predicate",
-    "Name":"http:\/\/schema.org\/materialExtent",
+    "Name":"https://schema.org/materialExtent",
     "Domain Bucket":"< 1K"
   },
   {
     "Class":"Predicate",
-    "Name":"http:\/\/schema.org\/materialExtent-input",
+    "Name":"https://schema.org/materialExtent-input",
     "Domain Bucket":"< 1K"
   },
   {
     "Class":"Predicate",
-    "Name":"http:\/\/schema.org\/materialExtent-output",
+    "Name":"https://schema.org/materialExtent-output",
     "Domain Bucket":"< 1K"
   },
   {
     "Class":"Predicate",
-    "Name":"http:\/\/schema.org\/mathExpression",
+    "Name":"https://schema.org/mathExpression",
     "Domain Bucket":"< 1K"
   },
   {
     "Class":"Predicate",
-    "Name":"http:\/\/schema.org\/mathExpression-input",
+    "Name":"https://schema.org/mathExpression-input",
     "Domain Bucket":"< 1K"
   },
   {
     "Class":"Predicate",
-    "Name":"http:\/\/schema.org\/mathExpression-output",
+    "Name":"https://schema.org/mathExpression-output",
     "Domain Bucket":"< 1K"
   },
   {
     "Class":"Predicate",
-    "Name":"http:\/\/schema.org\/maxPrice",
+    "Name":"https://schema.org/maxPrice",
     "Domain Bucket":"10K - 100K"
   },
   {
     "Class":"Predicate",
-    "Name":"http:\/\/schema.org\/maxPrice-input",
+    "Name":"https://schema.org/maxPrice-input",
     "Domain Bucket":"< 1K"
   },
   {
     "Class":"Predicate",
-    "Name":"http:\/\/schema.org\/maxPrice-output",
+    "Name":"https://schema.org/maxPrice-output",
     "Domain Bucket":"< 1K"
   },
   {
     "Class":"Predicate",
-    "Name":"http:\/\/schema.org\/maxValue",
+    "Name":"https://schema.org/maxValue",
     "Domain Bucket":"100K - 1M"
   },
   {
     "Class":"Predicate",
-    "Name":"http:\/\/schema.org\/maxValue-input",
+    "Name":"https://schema.org/maxValue-input",
     "Domain Bucket":"< 1K"
   },
   {
     "Class":"Predicate",
-    "Name":"http:\/\/schema.org\/maxValue-output",
+    "Name":"https://schema.org/maxValue-output",
     "Domain Bucket":"< 1K"
   },
   {
     "Class":"Predicate",
-    "Name":"http:\/\/schema.org\/maximumAttendeeCapacity",
+    "Name":"https://schema.org/maximumAttendeeCapacity",
     "Domain Bucket":"10K - 100K"
   },
   {
     "Class":"Predicate",
-    "Name":"http:\/\/schema.org\/maximumAttendeeCapacity-input",
+    "Name":"https://schema.org/maximumAttendeeCapacity-input",
     "Domain Bucket":"< 1K"
   },
   {
     "Class":"Predicate",
-    "Name":"http:\/\/schema.org\/maximumAttendeeCapacity-output",
+    "Name":"https://schema.org/maximumAttendeeCapacity-output",
     "Domain Bucket":"< 1K"
   },
   {
     "Class":"Predicate",
-    "Name":"http:\/\/schema.org\/maximumEnrollment",
+    "Name":"https://schema.org/maximumEnrollment",
     "Domain Bucket":"< 1K"
   },
   {
     "Class":"Predicate",
-    "Name":"http:\/\/schema.org\/maximumEnrollment-input",
+    "Name":"https://schema.org/maximumEnrollment-input",
     "Domain Bucket":"< 1K"
   },
   {
     "Class":"Predicate",
-    "Name":"http:\/\/schema.org\/maximumEnrollment-output",
+    "Name":"https://schema.org/maximumEnrollment-output",
     "Domain Bucket":"< 1K"
   },
   {
     "Class":"Predicate",
-    "Name":"http:\/\/schema.org\/maximumIntake",
+    "Name":"https://schema.org/maximumIntake",
     "Domain Bucket":"< 1K"
   },
   {
     "Class":"Predicate",
-    "Name":"http:\/\/schema.org\/maximumIntake-input",
+    "Name":"https://schema.org/maximumIntake-input",
     "Domain Bucket":"< 1K"
   },
   {
     "Class":"Predicate",
-    "Name":"http:\/\/schema.org\/maximumIntake-output",
+    "Name":"https://schema.org/maximumIntake-output",
     "Domain Bucket":"< 1K"
   },
   {
     "Class":"Predicate",
-    "Name":"http:\/\/schema.org\/maximumPhysicalAttendeeCapacity",
+    "Name":"https://schema.org/maximumPhysicalAttendeeCapacity",
     "Domain Bucket":"< 1K"
   },
   {
     "Class":"Predicate",
-    "Name":"http:\/\/schema.org\/maximumPhysicalAttendeeCapacity-input",
+    "Name":"https://schema.org/maximumPhysicalAttendeeCapacity-input",
     "Domain Bucket":"< 1K"
   },
   {
     "Class":"Predicate",
-    "Name":"http:\/\/schema.org\/maximumPhysicalAttendeeCapacity-output",
+    "Name":"https://schema.org/maximumPhysicalAttendeeCapacity-output",
     "Domain Bucket":"< 1K"
   },
   {
     "Class":"Predicate",
-    "Name":"http:\/\/schema.org\/maximumVirtualAttendeeCapacity",
+    "Name":"https://schema.org/maximumVirtualAttendeeCapacity",
     "Domain Bucket":"< 1K"
   },
   {
     "Class":"Predicate",
-    "Name":"http:\/\/schema.org\/maximumVirtualAttendeeCapacity-input",
+    "Name":"https://schema.org/maximumVirtualAttendeeCapacity-input",
     "Domain Bucket":"< 1K"
   },
   {
     "Class":"Predicate",
-    "Name":"http:\/\/schema.org\/maximumVirtualAttendeeCapacity-output",
+    "Name":"https://schema.org/maximumVirtualAttendeeCapacity-output",
     "Domain Bucket":"< 1K"
   },
   {
     "Class":"Predicate",
-    "Name":"http:\/\/schema.org\/mealService",
+    "Name":"https://schema.org/mealService",
     "Domain Bucket":"< 1K"
   },
   {
     "Class":"Predicate",
-    "Name":"http:\/\/schema.org\/mealService-input",
+    "Name":"https://schema.org/mealService-input",
     "Domain Bucket":"< 1K"
   },
   {
     "Class":"Predicate",
-    "Name":"http:\/\/schema.org\/mealService-output",
+    "Name":"https://schema.org/mealService-output",
     "Domain Bucket":"< 1K"
   },
   {
     "Class":"Predicate",
-    "Name":"http:\/\/schema.org\/measuredProperty",
+    "Name":"https://schema.org/measuredProperty",
     "Domain Bucket":"< 1K"
   },
   {
     "Class":"Predicate",
-    "Name":"http:\/\/schema.org\/measuredProperty-input",
+    "Name":"https://schema.org/measuredProperty-input",
     "Domain Bucket":"< 1K"
   },
   {
     "Class":"Predicate",
-    "Name":"http:\/\/schema.org\/measuredProperty-output",
+    "Name":"https://schema.org/measuredProperty-output",
     "Domain Bucket":"< 1K"
   },
   {
     "Class":"Predicate",
-    "Name":"http:\/\/schema.org\/measurementDenominator",
+    "Name":"https://schema.org/measurementDenominator",
     "Domain Bucket":"< 1K"
   },
   {
     "Class":"Predicate",
-    "Name":"http:\/\/schema.org\/measurementDenominator-input",
+    "Name":"https://schema.org/measurementDenominator-input",
     "Domain Bucket":"< 1K"
   },
   {
     "Class":"Predicate",
-    "Name":"http:\/\/schema.org\/measurementDenominator-output",
+    "Name":"https://schema.org/measurementDenominator-output",
     "Domain Bucket":"< 1K"
   },
   {
     "Class":"Predicate",
-    "Name":"http:\/\/schema.org\/measurementMethod",
+    "Name":"https://schema.org/measurementMethod",
     "Domain Bucket":"< 1K"
   },
   {
     "Class":"Predicate",
-    "Name":"http:\/\/schema.org\/measurementMethod-input",
+    "Name":"https://schema.org/measurementMethod-input",
     "Domain Bucket":"< 1K"
   },
   {
     "Class":"Predicate",
-    "Name":"http:\/\/schema.org\/measurementMethod-output",
+    "Name":"https://schema.org/measurementMethod-output",
     "Domain Bucket":"< 1K"
   },
   {
     "Class":"Predicate",
-    "Name":"http:\/\/schema.org\/measurementQualifier",
+    "Name":"https://schema.org/measurementQualifier",
     "Domain Bucket":"< 1K"
   },
   {
     "Class":"Predicate",
-    "Name":"http:\/\/schema.org\/measurementQualifier-input",
+    "Name":"https://schema.org/measurementQualifier-input",
     "Domain Bucket":"< 1K"
   },
   {
     "Class":"Predicate",
-    "Name":"http:\/\/schema.org\/measurementQualifier-output",
+    "Name":"https://schema.org/measurementQualifier-output",
     "Domain Bucket":"< 1K"
   },
   {
     "Class":"Predicate",
-    "Name":"http:\/\/schema.org\/measurementTechnique",
+    "Name":"https://schema.org/measurementTechnique",
     "Domain Bucket":"1K - 10K"
   },
   {
     "Class":"Predicate",
-    "Name":"http:\/\/schema.org\/measurementTechnique-input",
+    "Name":"https://schema.org/measurementTechnique-input",
     "Domain Bucket":"< 1K"
   },
   {
     "Class":"Predicate",
-    "Name":"http:\/\/schema.org\/measurementTechnique-output",
+    "Name":"https://schema.org/measurementTechnique-output",
     "Domain Bucket":"< 1K"
   },
   {
     "Class":"Predicate",
-    "Name":"http:\/\/schema.org\/mechanismOfAction",
+    "Name":"https://schema.org/mechanismOfAction",
     "Domain Bucket":"< 1K"
   },
   {
     "Class":"Predicate",
-    "Name":"http:\/\/schema.org\/mechanismOfAction-input",
+    "Name":"https://schema.org/mechanismOfAction-input",
     "Domain Bucket":"< 1K"
   },
   {
     "Class":"Predicate",
-    "Name":"http:\/\/schema.org\/mechanismOfAction-output",
+    "Name":"https://schema.org/mechanismOfAction-output",
     "Domain Bucket":"< 1K"
   },
   {
     "Class":"Predicate",
-    "Name":"http:\/\/schema.org\/mediaAuthenticityCategory",
+    "Name":"https://schema.org/mediaAuthenticityCategory",
     "Domain Bucket":"< 1K"
   },
   {
     "Class":"Predicate",
-    "Name":"http:\/\/schema.org\/mediaAuthenticityCategory-input",
+    "Name":"https://schema.org/mediaAuthenticityCategory-input",
     "Domain Bucket":"< 1K"
   },
   {
     "Class":"Predicate",
-    "Name":"http:\/\/schema.org\/mediaAuthenticityCategory-output",
+    "Name":"https://schema.org/mediaAuthenticityCategory-output",
     "Domain Bucket":"< 1K"
   },
   {
     "Class":"Predicate",
-    "Name":"http:\/\/schema.org\/mediaItemAppearance",
+    "Name":"https://schema.org/mediaItemAppearance",
     "Domain Bucket":"< 1K"
   },
   {
     "Class":"Predicate",
-    "Name":"http:\/\/schema.org\/mediaItemAppearance-input",
+    "Name":"https://schema.org/mediaItemAppearance-input",
     "Domain Bucket":"< 1K"
   },
   {
     "Class":"Predicate",
-    "Name":"http:\/\/schema.org\/mediaItemAppearance-output",
+    "Name":"https://schema.org/mediaItemAppearance-output",
     "Domain Bucket":"< 1K"
   },
   {
     "Class":"Predicate",
-    "Name":"http:\/\/schema.org\/median",
+    "Name":"https://schema.org/median",
     "Domain Bucket":"1K - 10K"
   },
   {
     "Class":"Predicate",
-    "Name":"http:\/\/schema.org\/median-input",
+    "Name":"https://schema.org/median-input",
     "Domain Bucket":"< 1K"
   },
   {
     "Class":"Predicate",
-    "Name":"http:\/\/schema.org\/median-output",
+    "Name":"https://schema.org/median-output",
     "Domain Bucket":"< 1K"
   },
   {
     "Class":"Predicate",
-    "Name":"http:\/\/schema.org\/medicalAudience",
+    "Name":"https://schema.org/medicalAudience",
     "Domain Bucket":"1K - 10K"
   },
   {
     "Class":"Predicate",
-    "Name":"http:\/\/schema.org\/medicalAudience-input",
+    "Name":"https://schema.org/medicalAudience-input",
     "Domain Bucket":"< 1K"
   },
   {
     "Class":"Predicate",
-    "Name":"http:\/\/schema.org\/medicalAudience-output",
+    "Name":"https://schema.org/medicalAudience-output",
     "Domain Bucket":"< 1K"
   },
   {
     "Class":"Predicate",
-    "Name":"http:\/\/schema.org\/medicalSpecialty",
+    "Name":"https://schema.org/medicalSpecialty",
     "Domain Bucket":"10K - 100K"
   },
   {
     "Class":"Predicate",
-    "Name":"http:\/\/schema.org\/medicalSpecialty-input",
+    "Name":"https://schema.org/medicalSpecialty-input",
     "Domain Bucket":"< 1K"
   },
   {
     "Class":"Predicate",
-    "Name":"http:\/\/schema.org\/medicalSpecialty-output",
+    "Name":"https://schema.org/medicalSpecialty-output",
     "Domain Bucket":"< 1K"
   },
   {
     "Class":"Predicate",
-    "Name":"http:\/\/schema.org\/medicineSystem",
+    "Name":"https://schema.org/medicineSystem",
     "Domain Bucket":"1K - 10K"
   },
   {
     "Class":"Predicate",
-    "Name":"http:\/\/schema.org\/medicineSystem-input",
+    "Name":"https://schema.org/medicineSystem-input",
     "Domain Bucket":"< 1K"
   },
   {
     "Class":"Predicate",
-    "Name":"http:\/\/schema.org\/medicineSystem-output",
+    "Name":"https://schema.org/medicineSystem-output",
     "Domain Bucket":"< 1K"
   },
   {
     "Class":"Predicate",
-    "Name":"http:\/\/schema.org\/meetsEmissionStandard",
+    "Name":"https://schema.org/meetsEmissionStandard",
     "Domain Bucket":"< 1K"
   },
   {
     "Class":"Predicate",
-    "Name":"http:\/\/schema.org\/meetsEmissionStandard-input",
+    "Name":"https://schema.org/meetsEmissionStandard-input",
     "Domain Bucket":"< 1K"
   },
   {
     "Class":"Predicate",
-    "Name":"http:\/\/schema.org\/meetsEmissionStandard-output",
+    "Name":"https://schema.org/meetsEmissionStandard-output",
     "Domain Bucket":"< 1K"
   },
   {
     "Class":"Predicate",
-    "Name":"http:\/\/schema.org\/member",
+    "Name":"https://schema.org/member",
     "Domain Bucket":"10K - 100K"
   },
   {
     "Class":"Predicate",
-    "Name":"http:\/\/schema.org\/member-input",
+    "Name":"https://schema.org/member-input",
     "Domain Bucket":"< 1K"
   },
   {
     "Class":"Predicate",
-    "Name":"http:\/\/schema.org\/member-output",
+    "Name":"https://schema.org/member-output",
     "Domain Bucket":"< 1K"
   },
   {
     "Class":"Predicate",
-    "Name":"http:\/\/schema.org\/memberOf",
+    "Name":"https://schema.org/memberOf",
     "Domain Bucket":"10K - 100K"
   },
   {
     "Class":"Predicate",
-    "Name":"http:\/\/schema.org\/memberOf-input",
+    "Name":"https://schema.org/memberOf-input",
     "Domain Bucket":"< 1K"
   },
   {
     "Class":"Predicate",
-    "Name":"http:\/\/schema.org\/memberOf-output",
+    "Name":"https://schema.org/memberOf-output",
     "Domain Bucket":"< 1K"
   },
   {
     "Class":"Predicate",
-    "Name":"http:\/\/schema.org\/members",
+    "Name":"https://schema.org/members",
     "Domain Bucket":"< 1K"
   },
   {
     "Class":"Predicate",
-    "Name":"http:\/\/schema.org\/members-input",
+    "Name":"https://schema.org/members-input",
     "Domain Bucket":"< 1K"
   },
   {
     "Class":"Predicate",
-    "Name":"http:\/\/schema.org\/members-output",
+    "Name":"https://schema.org/members-output",
     "Domain Bucket":"< 1K"
   },
   {
     "Class":"Predicate",
-    "Name":"http:\/\/schema.org\/membershipNumber",
+    "Name":"https://schema.org/membershipNumber",
     "Domain Bucket":"< 1K"
   },
   {
     "Class":"Predicate",
-    "Name":"http:\/\/schema.org\/membershipNumber-input",
+    "Name":"https://schema.org/membershipNumber-input",
     "Domain Bucket":"< 1K"
   },
   {
     "Class":"Predicate",
-    "Name":"http:\/\/schema.org\/membershipNumber-output",
+    "Name":"https://schema.org/membershipNumber-output",
     "Domain Bucket":"< 1K"
   },
   {
     "Class":"Predicate",
-    "Name":"http:\/\/schema.org\/membershipPointsEarned",
+    "Name":"https://schema.org/membershipPointsEarned",
     "Domain Bucket":"< 1K"
   },
   {
     "Class":"Predicate",
-    "Name":"http:\/\/schema.org\/membershipPointsEarned-input",
+    "Name":"https://schema.org/membershipPointsEarned-input",
     "Domain Bucket":"< 1K"
   },
   {
     "Class":"Predicate",
-    "Name":"http:\/\/schema.org\/membershipPointsEarned-output",
+    "Name":"https://schema.org/membershipPointsEarned-output",
     "Domain Bucket":"< 1K"
   },
   {
     "Class":"Predicate",
-    "Name":"http:\/\/schema.org\/memoryRequirements",
+    "Name":"https://schema.org/memoryRequirements",
     "Domain Bucket":"1K - 10K"
   },
   {
     "Class":"Predicate",
-    "Name":"http:\/\/schema.org\/memoryRequirements-input",
+    "Name":"https://schema.org/memoryRequirements-input",
     "Domain Bucket":"< 1K"
   },
   {
     "Class":"Predicate",
-    "Name":"http:\/\/schema.org\/memoryRequirements-output",
+    "Name":"https://schema.org/memoryRequirements-output",
     "Domain Bucket":"< 1K"
   },
   {
     "Class":"Predicate",
-    "Name":"http:\/\/schema.org\/mentions",
+    "Name":"https://schema.org/mentions",
     "Domain Bucket":"10K - 100K"
   },
   {
     "Class":"Predicate",
-    "Name":"http:\/\/schema.org\/mentions-input",
+    "Name":"https://schema.org/mentions-input",
     "Domain Bucket":"< 1K"
   },
   {
     "Class":"Predicate",
-    "Name":"http:\/\/schema.org\/mentions-output",
+    "Name":"https://schema.org/mentions-output",
     "Domain Bucket":"< 1K"
   },
   {
     "Class":"Predicate",
-    "Name":"http:\/\/schema.org\/menu",
+    "Name":"https://schema.org/menu",
     "Domain Bucket":"10K - 100K"
   },
   {
     "Class":"Predicate",
-    "Name":"http:\/\/schema.org\/menu-input",
+    "Name":"https://schema.org/menu-input",
     "Domain Bucket":"< 1K"
   },
   {
     "Class":"Predicate",
-    "Name":"http:\/\/schema.org\/menu-output",
+    "Name":"https://schema.org/menu-output",
     "Domain Bucket":"< 1K"
   },
   {
     "Class":"Predicate",
-    "Name":"http:\/\/schema.org\/menuAddOn",
+    "Name":"https://schema.org/menuAddOn",
     "Domain Bucket":"1K - 10K"
   },
   {
     "Class":"Predicate",
-    "Name":"http:\/\/schema.org\/menuAddOn-input",
+    "Name":"https://schema.org/menuAddOn-input",
     "Domain Bucket":"< 1K"
   },
   {
     "Class":"Predicate",
-    "Name":"http:\/\/schema.org\/menuAddOn-output",
+    "Name":"https://schema.org/menuAddOn-output",
     "Domain Bucket":"< 1K"
   },
   {
     "Class":"Predicate",
-    "Name":"http:\/\/schema.org\/merchant",
+    "Name":"https://schema.org/merchant",
     "Domain Bucket":"< 1K"
   },
   {
     "Class":"Predicate",
-    "Name":"http:\/\/schema.org\/merchant-input",
+    "Name":"https://schema.org/merchant-input",
     "Domain Bucket":"< 1K"
   },
   {
     "Class":"Predicate",
-    "Name":"http:\/\/schema.org\/merchant-output",
+    "Name":"https://schema.org/merchant-output",
     "Domain Bucket":"< 1K"
   },
   {
     "Class":"Predicate",
-    "Name":"http:\/\/schema.org\/merchantReturnDays",
+    "Name":"https://schema.org/merchantReturnDays",
     "Domain Bucket":"100K - 1M"
   },
   {
     "Class":"Predicate",
-    "Name":"http:\/\/schema.org\/merchantReturnDays-input",
+    "Name":"https://schema.org/merchantReturnDays-input",
     "Domain Bucket":"< 1K"
   },
   {
     "Class":"Predicate",
-    "Name":"http:\/\/schema.org\/merchantReturnDays-output",
+    "Name":"https://schema.org/merchantReturnDays-output",
     "Domain Bucket":"< 1K"
   },
   {
     "Class":"Predicate",
-    "Name":"http:\/\/schema.org\/merchantReturnLink",
+    "Name":"https://schema.org/merchantReturnLink",
     "Domain Bucket":"10K - 100K"
   },
   {
     "Class":"Predicate",
-    "Name":"http:\/\/schema.org\/merchantReturnLink-input",
+    "Name":"https://schema.org/merchantReturnLink-input",
     "Domain Bucket":"< 1K"
   },
   {
     "Class":"Predicate",
-    "Name":"http:\/\/schema.org\/merchantReturnLink-output",
+    "Name":"https://schema.org/merchantReturnLink-output",
     "Domain Bucket":"< 1K"
   },
   {
     "Class":"Predicate",
-    "Name":"http:\/\/schema.org\/messageAttachment",
+    "Name":"https://schema.org/messageAttachment",
     "Domain Bucket":"< 1K"
   },
   {
     "Class":"Predicate",
-    "Name":"http:\/\/schema.org\/messageAttachment-input",
+    "Name":"https://schema.org/messageAttachment-input",
     "Domain Bucket":"< 1K"
   },
   {
     "Class":"Predicate",
-    "Name":"http:\/\/schema.org\/messageAttachment-output",
+    "Name":"https://schema.org/messageAttachment-output",
     "Domain Bucket":"< 1K"
   },
   {
     "Class":"Predicate",
-    "Name":"http:\/\/schema.org\/mileageFromOdometer",
+    "Name":"https://schema.org/mileageFromOdometer",
     "Domain Bucket":"10K - 100K"
   },
   {
     "Class":"Predicate",
-    "Name":"http:\/\/schema.org\/mileageFromOdometer-input",
+    "Name":"https://schema.org/mileageFromOdometer-input",
     "Domain Bucket":"< 1K"
   },
   {
     "Class":"Predicate",
-    "Name":"http:\/\/schema.org\/mileageFromOdometer-output",
+    "Name":"https://schema.org/mileageFromOdometer-output",
     "Domain Bucket":"< 1K"
   },
   {
     "Class":"Predicate",
-    "Name":"http:\/\/schema.org\/minPrice",
+    "Name":"https://schema.org/minPrice",
     "Domain Bucket":"10K - 100K"
   },
   {
     "Class":"Predicate",
-    "Name":"http:\/\/schema.org\/minPrice-input",
+    "Name":"https://schema.org/minPrice-input",
     "Domain Bucket":"< 1K"
   },
   {
     "Class":"Predicate",
-    "Name":"http:\/\/schema.org\/minPrice-output",
+    "Name":"https://schema.org/minPrice-output",
     "Domain Bucket":"< 1K"
   },
   {
     "Class":"Predicate",
-    "Name":"http:\/\/schema.org\/minValue",
+    "Name":"https://schema.org/minValue",
     "Domain Bucket":"100K - 1M"
   },
   {
     "Class":"Predicate",
-    "Name":"http:\/\/schema.org\/minValue-input",
+    "Name":"https://schema.org/minValue-input",
     "Domain Bucket":"< 1K"
   },
   {
     "Class":"Predicate",
-    "Name":"http:\/\/schema.org\/minValue-output",
+    "Name":"https://schema.org/minValue-output",
     "Domain Bucket":"< 1K"
   },
   {
     "Class":"Predicate",
-    "Name":"http:\/\/schema.org\/minimumPaymentDue",
+    "Name":"https://schema.org/minimumPaymentDue",
     "Domain Bucket":"< 1K"
   },
   {
     "Class":"Predicate",
-    "Name":"http:\/\/schema.org\/minimumPaymentDue-input",
+    "Name":"https://schema.org/minimumPaymentDue-input",
     "Domain Bucket":"< 1K"
   },
   {
     "Class":"Predicate",
-    "Name":"http:\/\/schema.org\/minimumPaymentDue-output",
+    "Name":"https://schema.org/minimumPaymentDue-output",
     "Domain Bucket":"< 1K"
   },
   {
     "Class":"Predicate",
-    "Name":"http:\/\/schema.org\/missionCoveragePrioritiesPolicy",
+    "Name":"https://schema.org/missionCoveragePrioritiesPolicy",
     "Domain Bucket":"1K - 10K"
   },
   {
     "Class":"Predicate",
-    "Name":"http:\/\/schema.org\/missionCoveragePrioritiesPolicy-input",
+    "Name":"https://schema.org/missionCoveragePrioritiesPolicy-input",
     "Domain Bucket":"< 1K"
   },
   {
     "Class":"Predicate",
-    "Name":"http:\/\/schema.org\/missionCoveragePrioritiesPolicy-output",
+    "Name":"https://schema.org/missionCoveragePrioritiesPolicy-output",
     "Domain Bucket":"< 1K"
   },
   {
     "Class":"Predicate",
-    "Name":"http:\/\/schema.org\/mobileUrl",
+    "Name":"https://schema.org/mobileUrl",
     "Domain Bucket":"< 1K"
   },
   {
     "Class":"Predicate",
-    "Name":"http:\/\/schema.org\/mobileUrl-input",
+    "Name":"https://schema.org/mobileUrl-input",
     "Domain Bucket":"< 1K"
   },
   {
     "Class":"Predicate",
-    "Name":"http:\/\/schema.org\/mobileUrl-output",
+    "Name":"https://schema.org/mobileUrl-output",
     "Domain Bucket":"< 1K"
   },
   {
     "Class":"Predicate",
-    "Name":"http:\/\/schema.org\/model",
+    "Name":"https://schema.org/model",
     "Domain Bucket":"100K - 1M"
   },
   {
     "Class":"Predicate",
-    "Name":"http:\/\/schema.org\/model-input",
+    "Name":"https://schema.org/model-input",
     "Domain Bucket":"< 1K"
   },
   {
     "Class":"Predicate",
-    "Name":"http:\/\/schema.org\/model-output",
+    "Name":"https://schema.org/model-output",
     "Domain Bucket":"< 1K"
   },
   {
     "Class":"Predicate",
-    "Name":"http:\/\/schema.org\/modelDate",
+    "Name":"https://schema.org/modelDate",
     "Domain Bucket":"10K - 100K"
   },
   {
     "Class":"Predicate",
-    "Name":"http:\/\/schema.org\/modelDate-input",
+    "Name":"https://schema.org/modelDate-input",
     "Domain Bucket":"< 1K"
   },
   {
     "Class":"Predicate",
-    "Name":"http:\/\/schema.org\/modelDate-output",
+    "Name":"https://schema.org/modelDate-output",
     "Domain Bucket":"< 1K"
   },
   {
     "Class":"Predicate",
-    "Name":"http:\/\/schema.org\/modifiedTime",
+    "Name":"https://schema.org/modifiedTime",
     "Domain Bucket":"< 1K"
   },
   {
     "Class":"Predicate",
-    "Name":"http:\/\/schema.org\/modifiedTime-input",
+    "Name":"https://schema.org/modifiedTime-input",
     "Domain Bucket":"< 1K"
   },
   {
     "Class":"Predicate",
-    "Name":"http:\/\/schema.org\/modifiedTime-output",
+    "Name":"https://schema.org/modifiedTime-output",
     "Domain Bucket":"< 1K"
   },
   {
     "Class":"Predicate",
-    "Name":"http:\/\/schema.org\/molecularFormula",
+    "Name":"https://schema.org/molecularFormula",
     "Domain Bucket":"< 1K"
   },
   {
     "Class":"Predicate",
-    "Name":"http:\/\/schema.org\/molecularFormula-input",
+    "Name":"https://schema.org/molecularFormula-input",
     "Domain Bucket":"< 1K"
   },
   {
     "Class":"Predicate",
-    "Name":"http:\/\/schema.org\/molecularFormula-output",
+    "Name":"https://schema.org/molecularFormula-output",
     "Domain Bucket":"< 1K"
   },
   {
     "Class":"Predicate",
-    "Name":"http:\/\/schema.org\/molecularWeight",
+    "Name":"https://schema.org/molecularWeight",
     "Domain Bucket":"< 1K"
   },
   {
     "Class":"Predicate",
-    "Name":"http:\/\/schema.org\/molecularWeight-input",
+    "Name":"https://schema.org/molecularWeight-input",
     "Domain Bucket":"< 1K"
   },
   {
     "Class":"Predicate",
-    "Name":"http:\/\/schema.org\/molecularWeight-output",
+    "Name":"https://schema.org/molecularWeight-output",
     "Domain Bucket":"< 1K"
   },
   {
     "Class":"Predicate",
-    "Name":"http:\/\/schema.org\/monoisotopicMolecularWeight",
+    "Name":"https://schema.org/monoisotopicMolecularWeight",
     "Domain Bucket":"< 1K"
   },
   {
     "Class":"Predicate",
-    "Name":"http:\/\/schema.org\/monoisotopicMolecularWeight-input",
+    "Name":"https://schema.org/monoisotopicMolecularWeight-input",
     "Domain Bucket":"< 1K"
   },
   {
     "Class":"Predicate",
-    "Name":"http:\/\/schema.org\/monoisotopicMolecularWeight-output",
+    "Name":"https://schema.org/monoisotopicMolecularWeight-output",
     "Domain Bucket":"< 1K"
   },
   {
     "Class":"Predicate",
-    "Name":"http:\/\/schema.org\/monthlyMinimumRepaymentAmount",
+    "Name":"https://schema.org/monthlyMinimumRepaymentAmount",
     "Domain Bucket":"< 1K"
   },
   {
     "Class":"Predicate",
-    "Name":"http:\/\/schema.org\/monthlyMinimumRepaymentAmount-input",
+    "Name":"https://schema.org/monthlyMinimumRepaymentAmount-input",
     "Domain Bucket":"< 1K"
   },
   {
     "Class":"Predicate",
-    "Name":"http:\/\/schema.org\/monthlyMinimumRepaymentAmount-output",
+    "Name":"https://schema.org/monthlyMinimumRepaymentAmount-output",
     "Domain Bucket":"< 1K"
   },
   {
     "Class":"Predicate",
-    "Name":"http:\/\/schema.org\/monthsOfExperience",
+    "Name":"https://schema.org/monthsOfExperience",
     "Domain Bucket":"1K - 10K"
   },
   {
     "Class":"Predicate",
-    "Name":"http:\/\/schema.org\/monthsOfExperience-input",
+    "Name":"https://schema.org/monthsOfExperience-input",
     "Domain Bucket":"< 1K"
   },
   {
     "Class":"Predicate",
-    "Name":"http:\/\/schema.org\/monthsOfExperience-output",
+    "Name":"https://schema.org/monthsOfExperience-output",
     "Domain Bucket":"< 1K"
   },
   {
     "Class":"Predicate",
-    "Name":"http:\/\/schema.org\/mpn",
+    "Name":"https://schema.org/mpn",
     "Domain Bucket":"100K - 1M"
   },
   {
     "Class":"Predicate",
-    "Name":"http:\/\/schema.org\/mpn-input",
+    "Name":"https://schema.org/mpn-input",
     "Domain Bucket":"< 1K"
   },
   {
     "Class":"Predicate",
-    "Name":"http:\/\/schema.org\/mpn-output",
+    "Name":"https://schema.org/mpn-output",
     "Domain Bucket":"< 1K"
   },
   {
     "Class":"Predicate",
-    "Name":"http:\/\/schema.org\/multipleValues",
+    "Name":"https://schema.org/multipleValues",
     "Domain Bucket":"< 1K"
   },
   {
     "Class":"Predicate",
-    "Name":"http:\/\/schema.org\/multipleValues-input",
+    "Name":"https://schema.org/multipleValues-input",
     "Domain Bucket":"< 1K"
   },
   {
     "Class":"Predicate",
-    "Name":"http:\/\/schema.org\/multipleValues-output",
+    "Name":"https://schema.org/multipleValues-output",
     "Domain Bucket":"< 1K"
   },
   {
     "Class":"Predicate",
-    "Name":"http:\/\/schema.org\/muscleAction",
+    "Name":"https://schema.org/muscleAction",
     "Domain Bucket":"< 1K"
   },
   {
     "Class":"Predicate",
-    "Name":"http:\/\/schema.org\/muscleAction-input",
+    "Name":"https://schema.org/muscleAction-input",
     "Domain Bucket":"< 1K"
   },
   {
     "Class":"Predicate",
-    "Name":"http:\/\/schema.org\/muscleAction-output",
+    "Name":"https://schema.org/muscleAction-output",
     "Domain Bucket":"< 1K"
   },
   {
     "Class":"Predicate",
-    "Name":"http:\/\/schema.org\/musicArrangement",
+    "Name":"https://schema.org/musicArrangement",
     "Domain Bucket":"< 1K"
   },
   {
     "Class":"Predicate",
-    "Name":"http:\/\/schema.org\/musicArrangement-input",
+    "Name":"https://schema.org/musicArrangement-input",
     "Domain Bucket":"< 1K"
   },
   {
     "Class":"Predicate",
-    "Name":"http:\/\/schema.org\/musicArrangement-output",
+    "Name":"https://schema.org/musicArrangement-output",
     "Domain Bucket":"< 1K"
   },
   {
     "Class":"Predicate",
-    "Name":"http:\/\/schema.org\/musicBy",
+    "Name":"https://schema.org/musicBy",
     "Domain Bucket":"1K - 10K"
   },
   {
     "Class":"Predicate",
-    "Name":"http:\/\/schema.org\/musicBy-input",
+    "Name":"https://schema.org/musicBy-input",
     "Domain Bucket":"< 1K"
   },
   {
     "Class":"Predicate",
-    "Name":"http:\/\/schema.org\/musicBy-output",
+    "Name":"https://schema.org/musicBy-output",
     "Domain Bucket":"< 1K"
   },
   {
     "Class":"Predicate",
-    "Name":"http:\/\/schema.org\/musicCompositionForm",
+    "Name":"https://schema.org/musicCompositionForm",
     "Domain Bucket":"< 1K"
   },
   {
     "Class":"Predicate",
-    "Name":"http:\/\/schema.org\/musicCompositionForm-input",
+    "Name":"https://schema.org/musicCompositionForm-input",
     "Domain Bucket":"< 1K"
   },
   {
     "Class":"Predicate",
-    "Name":"http:\/\/schema.org\/musicCompositionForm-output",
+    "Name":"https://schema.org/musicCompositionForm-output",
     "Domain Bucket":"< 1K"
   },
   {
     "Class":"Predicate",
-    "Name":"http:\/\/schema.org\/musicGroupMember",
+    "Name":"https://schema.org/musicGroupMember",
     "Domain Bucket":"< 1K"
   },
   {
     "Class":"Predicate",
-    "Name":"http:\/\/schema.org\/musicGroupMember-input",
+    "Name":"https://schema.org/musicGroupMember-input",
     "Domain Bucket":"< 1K"
   },
   {
     "Class":"Predicate",
-    "Name":"http:\/\/schema.org\/musicGroupMember-output",
+    "Name":"https://schema.org/musicGroupMember-output",
     "Domain Bucket":"< 1K"
   },
   {
     "Class":"Predicate",
-    "Name":"http:\/\/schema.org\/musicReleaseFormat",
+    "Name":"https://schema.org/musicReleaseFormat",
     "Domain Bucket":"1K - 10K"
   },
   {
     "Class":"Predicate",
-    "Name":"http:\/\/schema.org\/musicReleaseFormat-input",
+    "Name":"https://schema.org/musicReleaseFormat-input",
     "Domain Bucket":"< 1K"
   },
   {
     "Class":"Predicate",
-    "Name":"http:\/\/schema.org\/musicReleaseFormat-output",
+    "Name":"https://schema.org/musicReleaseFormat-output",
     "Domain Bucket":"< 1K"
   },
   {
     "Class":"Predicate",
-    "Name":"http:\/\/schema.org\/musicalKey",
+    "Name":"https://schema.org/musicalKey",
     "Domain Bucket":"< 1K"
   },
   {
     "Class":"Predicate",
-    "Name":"http:\/\/schema.org\/musicalKey-input",
+    "Name":"https://schema.org/musicalKey-input",
     "Domain Bucket":"< 1K"
   },
   {
     "Class":"Predicate",
-    "Name":"http:\/\/schema.org\/musicalKey-output",
+    "Name":"https://schema.org/musicalKey-output",
     "Domain Bucket":"< 1K"
   },
   {
     "Class":"Predicate",
-    "Name":"http:\/\/schema.org\/naics",
+    "Name":"https://schema.org/naics",
     "Domain Bucket":"10K - 100K"
   },
   {
     "Class":"Predicate",
-    "Name":"http:\/\/schema.org\/naics-input",
+    "Name":"https://schema.org/naics-input",
     "Domain Bucket":"< 1K"
   },
   {
     "Class":"Predicate",
-    "Name":"http:\/\/schema.org\/naics-output",
+    "Name":"https://schema.org/naics-output",
     "Domain Bucket":"< 1K"
   },
   {
     "Class":"Predicate",
-    "Name":"http:\/\/schema.org\/name",
+    "Name":"https://schema.org/name",
     "Domain Bucket":"10M+"
   },
   {
     "Class":"Predicate",
-    "Name":"http:\/\/schema.org\/name-input",
+    "Name":"https://schema.org/name-input",
     "Domain Bucket":"< 1K"
   },
   {
     "Class":"Predicate",
-    "Name":"http:\/\/schema.org\/name-output",
+    "Name":"https://schema.org/name-output",
     "Domain Bucket":"< 1K"
   },
   {
     "Class":"Predicate",
-    "Name":"http:\/\/schema.org\/namedPosition",
+    "Name":"https://schema.org/namedPosition",
     "Domain Bucket":"< 1K"
   },
   {
     "Class":"Predicate",
-    "Name":"http:\/\/schema.org\/namedPosition-input",
+    "Name":"https://schema.org/namedPosition-input",
     "Domain Bucket":"< 1K"
   },
   {
     "Class":"Predicate",
-    "Name":"http:\/\/schema.org\/namedPosition-output",
+    "Name":"https://schema.org/namedPosition-output",
     "Domain Bucket":"< 1K"
   },
   {
     "Class":"Predicate",
-    "Name":"http:\/\/schema.org\/nationality",
+    "Name":"https://schema.org/nationality",
     "Domain Bucket":"10K - 100K"
   },
   {
     "Class":"Predicate",
-    "Name":"http:\/\/schema.org\/nationality-input",
+    "Name":"https://schema.org/nationality-input",
     "Domain Bucket":"< 1K"
   },
   {
     "Class":"Predicate",
-    "Name":"http:\/\/schema.org\/nationality-output",
+    "Name":"https://schema.org/nationality-output",
     "Domain Bucket":"< 1K"
   },
   {
     "Class":"Predicate",
-    "Name":"http:\/\/schema.org\/naturalProgression",
+    "Name":"https://schema.org/naturalProgression",
     "Domain Bucket":"< 1K"
   },
   {
     "Class":"Predicate",
-    "Name":"http:\/\/schema.org\/naturalProgression-input",
+    "Name":"https://schema.org/naturalProgression-input",
     "Domain Bucket":"< 1K"
   },
   {
     "Class":"Predicate",
-    "Name":"http:\/\/schema.org\/naturalProgression-output",
+    "Name":"https://schema.org/naturalProgression-output",
     "Domain Bucket":"< 1K"
   },
   {
     "Class":"Predicate",
-    "Name":"http:\/\/schema.org\/negativeNotes",
+    "Name":"https://schema.org/negativeNotes",
     "Domain Bucket":"10K - 100K"
   },
   {
     "Class":"Predicate",
-    "Name":"http:\/\/schema.org\/negativeNotes-input",
+    "Name":"https://schema.org/negativeNotes-input",
     "Domain Bucket":"< 1K"
   },
   {
     "Class":"Predicate",
-    "Name":"http:\/\/schema.org\/negativeNotes-output",
+    "Name":"https://schema.org/negativeNotes-output",
     "Domain Bucket":"< 1K"
   },
   {
     "Class":"Predicate",
-    "Name":"http:\/\/schema.org\/nerve",
+    "Name":"https://schema.org/nerve",
     "Domain Bucket":"< 1K"
   },
   {
     "Class":"Predicate",
-    "Name":"http:\/\/schema.org\/nerve-input",
+    "Name":"https://schema.org/nerve-input",
     "Domain Bucket":"< 1K"
   },
   {
     "Class":"Predicate",
-    "Name":"http:\/\/schema.org\/nerve-output",
+    "Name":"https://schema.org/nerve-output",
     "Domain Bucket":"< 1K"
   },
   {
     "Class":"Predicate",
-    "Name":"http:\/\/schema.org\/nerveMotor",
+    "Name":"https://schema.org/nerveMotor",
     "Domain Bucket":"< 1K"
   },
   {
     "Class":"Predicate",
-    "Name":"http:\/\/schema.org\/nerveMotor-input",
+    "Name":"https://schema.org/nerveMotor-input",
     "Domain Bucket":"< 1K"
   },
   {
     "Class":"Predicate",
-    "Name":"http:\/\/schema.org\/nerveMotor-output",
+    "Name":"https://schema.org/nerveMotor-output",
     "Domain Bucket":"< 1K"
   },
   {
     "Class":"Predicate",
-    "Name":"http:\/\/schema.org\/netWorth",
+    "Name":"https://schema.org/netWorth",
     "Domain Bucket":"< 1K"
   },
   {
     "Class":"Predicate",
-    "Name":"http:\/\/schema.org\/netWorth-input",
+    "Name":"https://schema.org/netWorth-input",
     "Domain Bucket":"< 1K"
   },
   {
     "Class":"Predicate",
-    "Name":"http:\/\/schema.org\/netWorth-output",
+    "Name":"https://schema.org/netWorth-output",
     "Domain Bucket":"< 1K"
   },
   {
     "Class":"Predicate",
-    "Name":"http:\/\/schema.org\/newsUpdatesAndGuidelines",
+    "Name":"https://schema.org/newsUpdatesAndGuidelines",
     "Domain Bucket":"< 1K"
   },
   {
     "Class":"Predicate",
-    "Name":"http:\/\/schema.org\/newsUpdatesAndGuidelines-input",
+    "Name":"https://schema.org/newsUpdatesAndGuidelines-input",
     "Domain Bucket":"< 1K"
   },
   {
     "Class":"Predicate",
-    "Name":"http:\/\/schema.org\/newsUpdatesAndGuidelines-output",
+    "Name":"https://schema.org/newsUpdatesAndGuidelines-output",
     "Domain Bucket":"< 1K"
   },
   {
     "Class":"Predicate",
-    "Name":"http:\/\/schema.org\/nextItem",
+    "Name":"https://schema.org/nextItem",
     "Domain Bucket":"1M - 10M"
   },
   {
     "Class":"Predicate",
-    "Name":"http:\/\/schema.org\/nextItem-input",
+    "Name":"https://schema.org/nextItem-input",
     "Domain Bucket":"< 1K"
   },
   {
     "Class":"Predicate",
-    "Name":"http:\/\/schema.org\/nextItem-output",
+    "Name":"https://schema.org/nextItem-output",
     "Domain Bucket":"< 1K"
   },
   {
     "Class":"Predicate",
-    "Name":"http:\/\/schema.org\/noBylinesPolicy",
+    "Name":"https://schema.org/noBylinesPolicy",
     "Domain Bucket":"1K - 10K"
   },
   {
     "Class":"Predicate",
-    "Name":"http:\/\/schema.org\/noBylinesPolicy-input",
+    "Name":"https://schema.org/noBylinesPolicy-input",
     "Domain Bucket":"< 1K"
   },
   {
     "Class":"Predicate",
-    "Name":"http:\/\/schema.org\/noBylinesPolicy-output",
+    "Name":"https://schema.org/noBylinesPolicy-output",
     "Domain Bucket":"< 1K"
   },
   {
     "Class":"Predicate",
-    "Name":"http:\/\/schema.org\/nonEqual",
+    "Name":"https://schema.org/nonEqual",
     "Domain Bucket":"< 1K"
   },
   {
     "Class":"Predicate",
-    "Name":"http:\/\/schema.org\/nonEqual-input",
+    "Name":"https://schema.org/nonEqual-input",
     "Domain Bucket":"< 1K"
   },
   {
     "Class":"Predicate",
-    "Name":"http:\/\/schema.org\/nonEqual-output",
+    "Name":"https://schema.org/nonEqual-output",
     "Domain Bucket":"< 1K"
   },
   {
     "Class":"Predicate",
-    "Name":"http:\/\/schema.org\/nonProprietaryName",
+    "Name":"https://schema.org/nonProprietaryName",
     "Domain Bucket":"1K - 10K"
   },
   {
     "Class":"Predicate",
-    "Name":"http:\/\/schema.org\/nonProprietaryName-input",
+    "Name":"https://schema.org/nonProprietaryName-input",
     "Domain Bucket":"< 1K"
   },
   {
     "Class":"Predicate",
-    "Name":"http:\/\/schema.org\/nonProprietaryName-output",
+    "Name":"https://schema.org/nonProprietaryName-output",
     "Domain Bucket":"< 1K"
   },
   {
     "Class":"Predicate",
-    "Name":"http:\/\/schema.org\/nonprofitStatus",
+    "Name":"https://schema.org/nonprofitStatus",
     "Domain Bucket":"1K - 10K"
   },
   {
     "Class":"Predicate",
-    "Name":"http:\/\/schema.org\/nonprofitStatus-input",
+    "Name":"https://schema.org/nonprofitStatus-input",
     "Domain Bucket":"< 1K"
   },
   {
     "Class":"Predicate",
-    "Name":"http:\/\/schema.org\/nonprofitStatus-output",
+    "Name":"https://schema.org/nonprofitStatus-output",
     "Domain Bucket":"< 1K"
   },
   {
     "Class":"Predicate",
-    "Name":"http:\/\/schema.org\/normalRange",
+    "Name":"https://schema.org/normalRange",
     "Domain Bucket":"< 1K"
   },
   {
     "Class":"Predicate",
-    "Name":"http:\/\/schema.org\/normalRange-input",
+    "Name":"https://schema.org/normalRange-input",
     "Domain Bucket":"< 1K"
   },
   {
     "Class":"Predicate",
-    "Name":"http:\/\/schema.org\/normalRange-output",
+    "Name":"https://schema.org/normalRange-output",
     "Domain Bucket":"< 1K"
   },
   {
     "Class":"Predicate",
-    "Name":"http:\/\/schema.org\/nsn",
+    "Name":"https://schema.org/nsn",
     "Domain Bucket":"< 1K"
   },
   {
     "Class":"Predicate",
-    "Name":"http:\/\/schema.org\/nsn-input",
+    "Name":"https://schema.org/nsn-input",
     "Domain Bucket":"< 1K"
   },
   {
     "Class":"Predicate",
-    "Name":"http:\/\/schema.org\/nsn-output",
+    "Name":"https://schema.org/nsn-output",
     "Domain Bucket":"< 1K"
   },
   {
     "Class":"Predicate",
-    "Name":"http:\/\/schema.org\/numAdults",
+    "Name":"https://schema.org/numAdults",
     "Domain Bucket":"< 1K"
   },
   {
     "Class":"Predicate",
-    "Name":"http:\/\/schema.org\/numAdults-input",
+    "Name":"https://schema.org/numAdults-input",
     "Domain Bucket":"< 1K"
   },
   {
     "Class":"Predicate",
-    "Name":"http:\/\/schema.org\/numAdults-output",
+    "Name":"https://schema.org/numAdults-output",
     "Domain Bucket":"< 1K"
   },
   {
     "Class":"Predicate",
-    "Name":"http:\/\/schema.org\/numChildren",
+    "Name":"https://schema.org/numChildren",
     "Domain Bucket":"< 1K"
   },
   {
     "Class":"Predicate",
-    "Name":"http:\/\/schema.org\/numChildren-input",
+    "Name":"https://schema.org/numChildren-input",
     "Domain Bucket":"< 1K"
   },
   {
     "Class":"Predicate",
-    "Name":"http:\/\/schema.org\/numChildren-output",
+    "Name":"https://schema.org/numChildren-output",
     "Domain Bucket":"< 1K"
   },
   {
     "Class":"Predicate",
-    "Name":"http:\/\/schema.org\/numConstraints",
+    "Name":"https://schema.org/numConstraints",
     "Domain Bucket":"< 1K"
   },
   {
     "Class":"Predicate",
-    "Name":"http:\/\/schema.org\/numConstraints-input",
+    "Name":"https://schema.org/numConstraints-input",
     "Domain Bucket":"< 1K"
   },
   {
     "Class":"Predicate",
-    "Name":"http:\/\/schema.org\/numConstraints-output",
+    "Name":"https://schema.org/numConstraints-output",
     "Domain Bucket":"< 1K"
   },
   {
     "Class":"Predicate",
-    "Name":"http:\/\/schema.org\/numItems",
+    "Name":"https://schema.org/numItems",
     "Domain Bucket":"< 1K"
   },
   {
     "Class":"Predicate",
-    "Name":"http:\/\/schema.org\/numItems-input",
+    "Name":"https://schema.org/numItems-input",
     "Domain Bucket":"< 1K"
   },
   {
     "Class":"Predicate",
-    "Name":"http:\/\/schema.org\/numItems-output",
+    "Name":"https://schema.org/numItems-output",
     "Domain Bucket":"< 1K"
   },
   {
     "Class":"Predicate",
-    "Name":"http:\/\/schema.org\/numTracks",
+    "Name":"https://schema.org/numTracks",
     "Domain Bucket":"10K - 100K"
   },
   {
     "Class":"Predicate",
-    "Name":"http:\/\/schema.org\/numTracks-input",
+    "Name":"https://schema.org/numTracks-input",
     "Domain Bucket":"< 1K"
   },
   {
     "Class":"Predicate",
-    "Name":"http:\/\/schema.org\/numTracks-output",
+    "Name":"https://schema.org/numTracks-output",
     "Domain Bucket":"< 1K"
   },
   {
     "Class":"Predicate",
-    "Name":"http:\/\/schema.org\/numberOfAccommodationUnits",
+    "Name":"https://schema.org/numberOfAccommodationUnits",
     "Domain Bucket":"1K - 10K"
   },
   {
     "Class":"Predicate",
-    "Name":"http:\/\/schema.org\/numberOfAccommodationUnits-input",
+    "Name":"https://schema.org/numberOfAccommodationUnits-input",
     "Domain Bucket":"< 1K"
   },
   {
     "Class":"Predicate",
-    "Name":"http:\/\/schema.org\/numberOfAccommodationUnits-output",
+    "Name":"https://schema.org/numberOfAccommodationUnits-output",
     "Domain Bucket":"< 1K"
   },
   {
     "Class":"Predicate",
-    "Name":"http:\/\/schema.org\/numberOfAirbags",
+    "Name":"https://schema.org/numberOfAirbags",
     "Domain Bucket":"< 1K"
   },
   {
     "Class":"Predicate",
-    "Name":"http:\/\/schema.org\/numberOfAirbags-input",
+    "Name":"https://schema.org/numberOfAirbags-input",
     "Domain Bucket":"< 1K"
   },
   {
     "Class":"Predicate",
-    "Name":"http:\/\/schema.org\/numberOfAirbags-output",
+    "Name":"https://schema.org/numberOfAirbags-output",
     "Domain Bucket":"< 1K"
   },
   {
     "Class":"Predicate",
-    "Name":"http:\/\/schema.org\/numberOfAvailableAccommodationUnits",
+    "Name":"https://schema.org/numberOfAvailableAccommodationUnits",
     "Domain Bucket":"1K - 10K"
   },
   {
     "Class":"Predicate",
-    "Name":"http:\/\/schema.org\/numberOfAvailableAccommodationUnits-input",
+    "Name":"https://schema.org/numberOfAvailableAccommodationUnits-input",
     "Domain Bucket":"< 1K"
   },
   {
     "Class":"Predicate",
-    "Name":"http:\/\/schema.org\/numberOfAvailableAccommodationUnits-output",
+    "Name":"https://schema.org/numberOfAvailableAccommodationUnits-output",
     "Domain Bucket":"< 1K"
   },
   {
     "Class":"Predicate",
-    "Name":"http:\/\/schema.org\/numberOfAxles",
+    "Name":"https://schema.org/numberOfAxles",
     "Domain Bucket":"< 1K"
   },
   {
     "Class":"Predicate",
-    "Name":"http:\/\/schema.org\/numberOfAxles-input",
+    "Name":"https://schema.org/numberOfAxles-input",
     "Domain Bucket":"< 1K"
   },
   {
     "Class":"Predicate",
-    "Name":"http:\/\/schema.org\/numberOfAxles-output",
+    "Name":"https://schema.org/numberOfAxles-output",
     "Domain Bucket":"< 1K"
   },
   {
     "Class":"Predicate",
-    "Name":"http:\/\/schema.org\/numberOfBathroomsTotal",
+    "Name":"https://schema.org/numberOfBathroomsTotal",
     "Domain Bucket":"10K - 100K"
   },
   {
     "Class":"Predicate",
-    "Name":"http:\/\/schema.org\/numberOfBathroomsTotal-input",
+    "Name":"https://schema.org/numberOfBathroomsTotal-input",
     "Domain Bucket":"< 1K"
   },
   {
     "Class":"Predicate",
-    "Name":"http:\/\/schema.org\/numberOfBathroomsTotal-output",
+    "Name":"https://schema.org/numberOfBathroomsTotal-output",
     "Domain Bucket":"< 1K"
   },
   {
     "Class":"Predicate",
-    "Name":"http:\/\/schema.org\/numberOfBedrooms",
+    "Name":"https://schema.org/numberOfBedrooms",
     "Domain Bucket":"10K - 100K"
   },
   {
     "Class":"Predicate",
-    "Name":"http:\/\/schema.org\/numberOfBedrooms-input",
+    "Name":"https://schema.org/numberOfBedrooms-input",
     "Domain Bucket":"< 1K"
   },
   {
     "Class":"Predicate",
-    "Name":"http:\/\/schema.org\/numberOfBedrooms-output",
+    "Name":"https://schema.org/numberOfBedrooms-output",
     "Domain Bucket":"< 1K"
   },
   {
     "Class":"Predicate",
-    "Name":"http:\/\/schema.org\/numberOfBeds",
+    "Name":"https://schema.org/numberOfBeds",
     "Domain Bucket":"10K - 100K"
   },
   {
     "Class":"Predicate",
-    "Name":"http:\/\/schema.org\/numberOfBeds-input",
+    "Name":"https://schema.org/numberOfBeds-input",
     "Domain Bucket":"< 1K"
   },
   {
     "Class":"Predicate",
-    "Name":"http:\/\/schema.org\/numberOfBeds-output",
+    "Name":"https://schema.org/numberOfBeds-output",
     "Domain Bucket":"< 1K"
   },
   {
     "Class":"Predicate",
-    "Name":"http:\/\/schema.org\/numberOfCredits",
+    "Name":"https://schema.org/numberOfCredits",
     "Domain Bucket":"1K - 10K"
   },
   {
     "Class":"Predicate",
-    "Name":"http:\/\/schema.org\/numberOfCredits-input",
+    "Name":"https://schema.org/numberOfCredits-input",
     "Domain Bucket":"< 1K"
   },
   {
     "Class":"Predicate",
-    "Name":"http:\/\/schema.org\/numberOfCredits-output",
+    "Name":"https://schema.org/numberOfCredits-output",
     "Domain Bucket":"< 1K"
   },
   {
     "Class":"Predicate",
-    "Name":"http:\/\/schema.org\/numberOfDoors",
+    "Name":"https://schema.org/numberOfDoors",
     "Domain Bucket":"10K - 100K"
   },
   {
     "Class":"Predicate",
-    "Name":"http:\/\/schema.org\/numberOfDoors-input",
+    "Name":"https://schema.org/numberOfDoors-input",
     "Domain Bucket":"< 1K"
   },
   {
     "Class":"Predicate",
-    "Name":"http:\/\/schema.org\/numberOfDoors-output",
+    "Name":"https://schema.org/numberOfDoors-output",
     "Domain Bucket":"< 1K"
   },
   {
     "Class":"Predicate",
-    "Name":"http:\/\/schema.org\/numberOfEmployees",
+    "Name":"https://schema.org/numberOfEmployees",
     "Domain Bucket":"100K - 1M"
   },
   {
     "Class":"Predicate",
-    "Name":"http:\/\/schema.org\/numberOfEmployees-input",
+    "Name":"https://schema.org/numberOfEmployees-input",
     "Domain Bucket":"< 1K"
   },
   {
     "Class":"Predicate",
-    "Name":"http:\/\/schema.org\/numberOfEmployees-output",
+    "Name":"https://schema.org/numberOfEmployees-output",
     "Domain Bucket":"< 1K"
   },
   {
     "Class":"Predicate",
-    "Name":"http:\/\/schema.org\/numberOfEpisodes",
+    "Name":"https://schema.org/numberOfEpisodes",
     "Domain Bucket":"1K - 10K"
   },
   {
     "Class":"Predicate",
-    "Name":"http:\/\/schema.org\/numberOfEpisodes-input",
+    "Name":"https://schema.org/numberOfEpisodes-input",
     "Domain Bucket":"< 1K"
   },
   {
     "Class":"Predicate",
-    "Name":"http:\/\/schema.org\/numberOfEpisodes-output",
+    "Name":"https://schema.org/numberOfEpisodes-output",
     "Domain Bucket":"< 1K"
   },
   {
     "Class":"Predicate",
-    "Name":"http:\/\/schema.org\/numberOfForwardGears",
+    "Name":"https://schema.org/numberOfForwardGears",
     "Domain Bucket":"1K - 10K"
   },
   {
     "Class":"Predicate",
-    "Name":"http:\/\/schema.org\/numberOfForwardGears-input",
+    "Name":"https://schema.org/numberOfForwardGears-input",
     "Domain Bucket":"< 1K"
   },
   {
     "Class":"Predicate",
-    "Name":"http:\/\/schema.org\/numberOfForwardGears-output",
+    "Name":"https://schema.org/numberOfForwardGears-output",
     "Domain Bucket":"< 1K"
   },
   {
     "Class":"Predicate",
-    "Name":"http:\/\/schema.org\/numberOfFullBathrooms",
+    "Name":"https://schema.org/numberOfFullBathrooms",
     "Domain Bucket":"10K - 100K"
   },
   {
     "Class":"Predicate",
-    "Name":"http:\/\/schema.org\/numberOfFullBathrooms-input",
+    "Name":"https://schema.org/numberOfFullBathrooms-input",
     "Domain Bucket":"< 1K"
   },
   {
     "Class":"Predicate",
-    "Name":"http:\/\/schema.org\/numberOfFullBathrooms-output",
+    "Name":"https://schema.org/numberOfFullBathrooms-output",
     "Domain Bucket":"< 1K"
   },
   {
     "Class":"Predicate",
-    "Name":"http:\/\/schema.org\/numberOfItems",
+    "Name":"https://schema.org/numberOfItems",
     "Domain Bucket":"100K - 1M"
   },
   {
     "Class":"Predicate",
-    "Name":"http:\/\/schema.org\/numberOfItems-input",
+    "Name":"https://schema.org/numberOfItems-input",
     "Domain Bucket":"< 1K"
   },
   {
     "Class":"Predicate",
-    "Name":"http:\/\/schema.org\/numberOfItems-output",
+    "Name":"https://schema.org/numberOfItems-output",
     "Domain Bucket":"< 1K"
   },
   {
     "Class":"Predicate",
-    "Name":"http:\/\/schema.org\/numberOfLoanPayments",
+    "Name":"https://schema.org/numberOfLoanPayments",
     "Domain Bucket":"< 1K"
   },
   {
     "Class":"Predicate",
-    "Name":"http:\/\/schema.org\/numberOfLoanPayments-input",
+    "Name":"https://schema.org/numberOfLoanPayments-input",
     "Domain Bucket":"< 1K"
   },
   {
     "Class":"Predicate",
-    "Name":"http:\/\/schema.org\/numberOfLoanPayments-output",
+    "Name":"https://schema.org/numberOfLoanPayments-output",
     "Domain Bucket":"< 1K"
   },
   {
     "Class":"Predicate",
-    "Name":"http:\/\/schema.org\/numberOfPages",
+    "Name":"https://schema.org/numberOfPages",
     "Domain Bucket":"10K - 100K"
   },
   {
     "Class":"Predicate",
-    "Name":"http:\/\/schema.org\/numberOfPages-input",
+    "Name":"https://schema.org/numberOfPages-input",
     "Domain Bucket":"< 1K"
   },
   {
     "Class":"Predicate",
-    "Name":"http:\/\/schema.org\/numberOfPages-output",
+    "Name":"https://schema.org/numberOfPages-output",
     "Domain Bucket":"< 1K"
   },
   {
     "Class":"Predicate",
-    "Name":"http:\/\/schema.org\/numberOfPartialBathrooms",
+    "Name":"https://schema.org/numberOfPartialBathrooms",
     "Domain Bucket":"1K - 10K"
   },
   {
     "Class":"Predicate",
-    "Name":"http:\/\/schema.org\/numberOfPartialBathrooms-input",
+    "Name":"https://schema.org/numberOfPartialBathrooms-input",
     "Domain Bucket":"< 1K"
   },
   {
     "Class":"Predicate",
-    "Name":"http:\/\/schema.org\/numberOfPartialBathrooms-output",
+    "Name":"https://schema.org/numberOfPartialBathrooms-output",
     "Domain Bucket":"< 1K"
   },
   {
     "Class":"Predicate",
-    "Name":"http:\/\/schema.org\/numberOfPlayers",
+    "Name":"https://schema.org/numberOfPlayers",
     "Domain Bucket":"10K - 100K"
   },
   {
     "Class":"Predicate",
-    "Name":"http:\/\/schema.org\/numberOfPlayers-input",
+    "Name":"https://schema.org/numberOfPlayers-input",
     "Domain Bucket":"< 1K"
   },
   {
     "Class":"Predicate",
-    "Name":"http:\/\/schema.org\/numberOfPlayers-output",
+    "Name":"https://schema.org/numberOfPlayers-output",
     "Domain Bucket":"< 1K"
   },
   {
     "Class":"Predicate",
-    "Name":"http:\/\/schema.org\/numberOfPreviousOwners",
+    "Name":"https://schema.org/numberOfPreviousOwners",
     "Domain Bucket":"1K - 10K"
   },
   {
     "Class":"Predicate",
-    "Name":"http:\/\/schema.org\/numberOfPreviousOwners-input",
+    "Name":"https://schema.org/numberOfPreviousOwners-input",
     "Domain Bucket":"< 1K"
   },
   {
     "Class":"Predicate",
-    "Name":"http:\/\/schema.org\/numberOfPreviousOwners-output",
+    "Name":"https://schema.org/numberOfPreviousOwners-output",
     "Domain Bucket":"< 1K"
   },
   {
     "Class":"Predicate",
-    "Name":"http:\/\/schema.org\/numberOfRooms",
+    "Name":"https://schema.org/numberOfRooms",
     "Domain Bucket":"10K - 100K"
   },
   {
     "Class":"Predicate",
-    "Name":"http:\/\/schema.org\/numberOfRooms-input",
+    "Name":"https://schema.org/numberOfRooms-input",
     "Domain Bucket":"< 1K"
   },
   {
     "Class":"Predicate",
-    "Name":"http:\/\/schema.org\/numberOfRooms-output",
+    "Name":"https://schema.org/numberOfRooms-output",
     "Domain Bucket":"< 1K"
   },
   {
     "Class":"Predicate",
-    "Name":"http:\/\/schema.org\/numberOfSeasons",
+    "Name":"https://schema.org/numberOfSeasons",
     "Domain Bucket":"1K - 10K"
   },
   {
     "Class":"Predicate",
-    "Name":"http:\/\/schema.org\/numberOfSeasons-input",
+    "Name":"https://schema.org/numberOfSeasons-input",
     "Domain Bucket":"< 1K"
   },
   {
     "Class":"Predicate",
-    "Name":"http:\/\/schema.org\/numberOfSeasons-output",
+    "Name":"https://schema.org/numberOfSeasons-output",
     "Domain Bucket":"< 1K"
   },
   {
     "Class":"Predicate",
-    "Name":"http:\/\/schema.org\/numberedPosition",
+    "Name":"https://schema.org/numberedPosition",
     "Domain Bucket":"< 1K"
   },
   {
     "Class":"Predicate",
-    "Name":"http:\/\/schema.org\/numberedPosition-input",
+    "Name":"https://schema.org/numberedPosition-input",
     "Domain Bucket":"< 1K"
   },
   {
     "Class":"Predicate",
-    "Name":"http:\/\/schema.org\/numberedPosition-output",
+    "Name":"https://schema.org/numberedPosition-output",
     "Domain Bucket":"< 1K"
   },
   {
     "Class":"Predicate",
-    "Name":"http:\/\/schema.org\/nutrition",
+    "Name":"https://schema.org/nutrition",
     "Domain Bucket":"10K - 100K"
   },
   {
     "Class":"Predicate",
-    "Name":"http:\/\/schema.org\/nutrition-input",
+    "Name":"https://schema.org/nutrition-input",
     "Domain Bucket":"< 1K"
   },
   {
     "Class":"Predicate",
-    "Name":"http:\/\/schema.org\/nutrition-output",
+    "Name":"https://schema.org/nutrition-output",
     "Domain Bucket":"< 1K"
   },
   {
     "Class":"Predicate",
-    "Name":"http:\/\/schema.org\/object",
+    "Name":"https://schema.org/object",
     "Domain Bucket":"10K - 100K"
   },
   {
     "Class":"Predicate",
-    "Name":"http:\/\/schema.org\/object-input",
+    "Name":"https://schema.org/object-input",
     "Domain Bucket":"< 1K"
   },
   {
     "Class":"Predicate",
-    "Name":"http:\/\/schema.org\/object-output",
+    "Name":"https://schema.org/object-output",
     "Domain Bucket":"< 1K"
   },
   {
     "Class":"Predicate",
-    "Name":"http:\/\/schema.org\/observationAbout",
+    "Name":"https://schema.org/observationAbout",
     "Domain Bucket":"< 1K"
   },
   {
     "Class":"Predicate",
-    "Name":"http:\/\/schema.org\/observationAbout-input",
+    "Name":"https://schema.org/observationAbout-input",
     "Domain Bucket":"< 1K"
   },
   {
     "Class":"Predicate",
-    "Name":"http:\/\/schema.org\/observationAbout-output",
+    "Name":"https://schema.org/observationAbout-output",
     "Domain Bucket":"< 1K"
   },
   {
     "Class":"Predicate",
-    "Name":"http:\/\/schema.org\/observationDate",
+    "Name":"https://schema.org/observationDate",
     "Domain Bucket":"< 1K"
   },
   {
     "Class":"Predicate",
-    "Name":"http:\/\/schema.org\/observationDate-input",
+    "Name":"https://schema.org/observationDate-input",
     "Domain Bucket":"< 1K"
   },
   {
     "Class":"Predicate",
-    "Name":"http:\/\/schema.org\/observationDate-output",
+    "Name":"https://schema.org/observationDate-output",
     "Domain Bucket":"< 1K"
   },
   {
     "Class":"Predicate",
-    "Name":"http:\/\/schema.org\/observationPeriod",
+    "Name":"https://schema.org/observationPeriod",
     "Domain Bucket":"< 1K"
   },
   {
     "Class":"Predicate",
-    "Name":"http:\/\/schema.org\/observationPeriod-input",
+    "Name":"https://schema.org/observationPeriod-input",
     "Domain Bucket":"< 1K"
   },
   {
     "Class":"Predicate",
-    "Name":"http:\/\/schema.org\/observationPeriod-output",
+    "Name":"https://schema.org/observationPeriod-output",
     "Domain Bucket":"< 1K"
   },
   {
     "Class":"Predicate",
-    "Name":"http:\/\/schema.org\/occupancy",
+    "Name":"https://schema.org/occupancy",
     "Domain Bucket":"10K - 100K"
   },
   {
     "Class":"Predicate",
-    "Name":"http:\/\/schema.org\/occupancy-input",
+    "Name":"https://schema.org/occupancy-input",
     "Domain Bucket":"< 1K"
   },
   {
     "Class":"Predicate",
-    "Name":"http:\/\/schema.org\/occupancy-output",
+    "Name":"https://schema.org/occupancy-output",
     "Domain Bucket":"< 1K"
   },
   {
     "Class":"Predicate",
-    "Name":"http:\/\/schema.org\/occupationLocation",
+    "Name":"https://schema.org/occupationLocation",
     "Domain Bucket":"10K - 100K"
   },
   {
     "Class":"Predicate",
-    "Name":"http:\/\/schema.org\/occupationLocation-input",
+    "Name":"https://schema.org/occupationLocation-input",
     "Domain Bucket":"< 1K"
   },
   {
     "Class":"Predicate",
-    "Name":"http:\/\/schema.org\/occupationLocation-output",
+    "Name":"https://schema.org/occupationLocation-output",
     "Domain Bucket":"< 1K"
   },
   {
     "Class":"Predicate",
-    "Name":"http:\/\/schema.org\/occupationalCategory",
+    "Name":"https://schema.org/occupationalCategory",
     "Domain Bucket":"10K - 100K"
   },
   {
     "Class":"Predicate",
-    "Name":"http:\/\/schema.org\/occupationalCategory-input",
+    "Name":"https://schema.org/occupationalCategory-input",
     "Domain Bucket":"< 1K"
   },
   {
     "Class":"Predicate",
-    "Name":"http:\/\/schema.org\/occupationalCategory-output",
+    "Name":"https://schema.org/occupationalCategory-output",
     "Domain Bucket":"< 1K"
   },
   {
     "Class":"Predicate",
-    "Name":"http:\/\/schema.org\/occupationalCredentialAwarded",
+    "Name":"https://schema.org/occupationalCredentialAwarded",
     "Domain Bucket":"1K - 10K"
   },
   {
     "Class":"Predicate",
-    "Name":"http:\/\/schema.org\/occupationalCredentialAwarded-input",
+    "Name":"https://schema.org/occupationalCredentialAwarded-input",
     "Domain Bucket":"< 1K"
   },
   {
     "Class":"Predicate",
-    "Name":"http:\/\/schema.org\/occupationalCredentialAwarded-output",
+    "Name":"https://schema.org/occupationalCredentialAwarded-output",
     "Domain Bucket":"< 1K"
   },
   {
     "Class":"Predicate",
-    "Name":"http:\/\/schema.org\/offerCount",
+    "Name":"https://schema.org/offerCount",
     "Domain Bucket":"100K - 1M"
   },
   {
     "Class":"Predicate",
-    "Name":"http:\/\/schema.org\/offerCount-input",
+    "Name":"https://schema.org/offerCount-input",
     "Domain Bucket":"< 1K"
   },
   {
     "Class":"Predicate",
-    "Name":"http:\/\/schema.org\/offerCount-output",
+    "Name":"https://schema.org/offerCount-output",
     "Domain Bucket":"< 1K"
   },
   {
     "Class":"Predicate",
-    "Name":"http:\/\/schema.org\/offeredBy",
+    "Name":"https://schema.org/offeredBy",
     "Domain Bucket":"10K - 100K"
   },
   {
     "Class":"Predicate",
-    "Name":"http:\/\/schema.org\/offeredBy-input",
+    "Name":"https://schema.org/offeredBy-input",
     "Domain Bucket":"< 1K"
   },
   {
     "Class":"Predicate",
-    "Name":"http:\/\/schema.org\/offeredBy-output",
+    "Name":"https://schema.org/offeredBy-output",
     "Domain Bucket":"< 1K"
   },
   {
     "Class":"Predicate",
-    "Name":"http:\/\/schema.org\/offers",
+    "Name":"https://schema.org/offers",
     "Domain Bucket":"1M - 10M"
   },
   {
     "Class":"Predicate",
-    "Name":"http:\/\/schema.org\/offers-input",
+    "Name":"https://schema.org/offers-input",
     "Domain Bucket":"< 1K"
   },
   {
     "Class":"Predicate",
-    "Name":"http:\/\/schema.org\/offers-output",
+    "Name":"https://schema.org/offers-output",
     "Domain Bucket":"< 1K"
   },
   {
     "Class":"Predicate",
-    "Name":"http:\/\/schema.org\/offersPrescriptionByMail",
+    "Name":"https://schema.org/offersPrescriptionByMail",
     "Domain Bucket":"< 1K"
   },
   {
     "Class":"Predicate",
-    "Name":"http:\/\/schema.org\/offersPrescriptionByMail-input",
+    "Name":"https://schema.org/offersPrescriptionByMail-input",
     "Domain Bucket":"< 1K"
   },
   {
     "Class":"Predicate",
-    "Name":"http:\/\/schema.org\/offersPrescriptionByMail-output",
+    "Name":"https://schema.org/offersPrescriptionByMail-output",
     "Domain Bucket":"< 1K"
   },
   {
     "Class":"Predicate",
-    "Name":"http:\/\/schema.org\/openingHours",
+    "Name":"https://schema.org/openingHours",
     "Domain Bucket":"1M - 10M"
   },
   {
     "Class":"Predicate",
-    "Name":"http:\/\/schema.org\/openingHours-input",
+    "Name":"https://schema.org/openingHours-input",
     "Domain Bucket":"< 1K"
   },
   {
     "Class":"Predicate",
-    "Name":"http:\/\/schema.org\/openingHours-output",
+    "Name":"https://schema.org/openingHours-output",
     "Domain Bucket":"< 1K"
   },
   {
     "Class":"Predicate",
-    "Name":"http:\/\/schema.org\/openingHoursSpecification",
+    "Name":"https://schema.org/openingHoursSpecification",
     "Domain Bucket":"1M - 10M"
   },
   {
     "Class":"Predicate",
-    "Name":"http:\/\/schema.org\/openingHoursSpecification-input",
+    "Name":"https://schema.org/openingHoursSpecification-input",
     "Domain Bucket":"< 1K"
   },
   {
     "Class":"Predicate",
-    "Name":"http:\/\/schema.org\/openingHoursSpecification-output",
+    "Name":"https://schema.org/openingHoursSpecification-output",
     "Domain Bucket":"< 1K"
   },
   {
     "Class":"Predicate",
-    "Name":"http:\/\/schema.org\/opens",
+    "Name":"https://schema.org/opens",
     "Domain Bucket":"1M - 10M"
   },
   {
     "Class":"Predicate",
-    "Name":"http:\/\/schema.org\/opens-input",
+    "Name":"https://schema.org/opens-input",
     "Domain Bucket":"< 1K"
   },
   {
     "Class":"Predicate",
-    "Name":"http:\/\/schema.org\/opens-output",
+    "Name":"https://schema.org/opens-output",
     "Domain Bucket":"< 1K"
   },
   {
     "Class":"Predicate",
-    "Name":"http:\/\/schema.org\/operatingSystem",
+    "Name":"https://schema.org/operatingSystem",
     "Domain Bucket":"100K - 1M"
   },
   {
     "Class":"Predicate",
-    "Name":"http:\/\/schema.org\/operatingSystem-input",
+    "Name":"https://schema.org/operatingSystem-input",
     "Domain Bucket":"< 1K"
   },
   {
     "Class":"Predicate",
-    "Name":"http:\/\/schema.org\/operatingSystem-output",
+    "Name":"https://schema.org/operatingSystem-output",
     "Domain Bucket":"< 1K"
   },
   {
     "Class":"Predicate",
-    "Name":"http:\/\/schema.org\/opponent",
+    "Name":"https://schema.org/opponent",
     "Domain Bucket":"< 1K"
   },
   {
     "Class":"Predicate",
-    "Name":"http:\/\/schema.org\/opponent-input",
+    "Name":"https://schema.org/opponent-input",
     "Domain Bucket":"< 1K"
   },
   {
     "Class":"Predicate",
-    "Name":"http:\/\/schema.org\/opponent-output",
+    "Name":"https://schema.org/opponent-output",
     "Domain Bucket":"< 1K"
   },
   {
     "Class":"Predicate",
-    "Name":"http:\/\/schema.org\/option",
+    "Name":"https://schema.org/option",
     "Domain Bucket":"< 1K"
   },
   {
     "Class":"Predicate",
-    "Name":"http:\/\/schema.org\/option-input",
+    "Name":"https://schema.org/option-input",
     "Domain Bucket":"< 1K"
   },
   {
     "Class":"Predicate",
-    "Name":"http:\/\/schema.org\/option-output",
+    "Name":"https://schema.org/option-output",
     "Domain Bucket":"< 1K"
   },
   {
     "Class":"Predicate",
-    "Name":"http:\/\/schema.org\/orderDate",
+    "Name":"https://schema.org/orderDate",
     "Domain Bucket":"< 1K"
   },
   {
     "Class":"Predicate",
-    "Name":"http:\/\/schema.org\/orderDate-input",
+    "Name":"https://schema.org/orderDate-input",
     "Domain Bucket":"< 1K"
   },
   {
     "Class":"Predicate",
-    "Name":"http:\/\/schema.org\/orderDate-output",
+    "Name":"https://schema.org/orderDate-output",
     "Domain Bucket":"< 1K"
   },
   {
     "Class":"Predicate",
-    "Name":"http:\/\/schema.org\/orderDelivery",
+    "Name":"https://schema.org/orderDelivery",
     "Domain Bucket":"< 1K"
   },
   {
     "Class":"Predicate",
-    "Name":"http:\/\/schema.org\/orderDelivery-input",
+    "Name":"https://schema.org/orderDelivery-input",
     "Domain Bucket":"< 1K"
   },
   {
     "Class":"Predicate",
-    "Name":"http:\/\/schema.org\/orderDelivery-output",
+    "Name":"https://schema.org/orderDelivery-output",
     "Domain Bucket":"< 1K"
   },
   {
     "Class":"Predicate",
-    "Name":"http:\/\/schema.org\/orderItemNumber",
+    "Name":"https://schema.org/orderItemNumber",
     "Domain Bucket":"< 1K"
   },
   {
     "Class":"Predicate",
-    "Name":"http:\/\/schema.org\/orderItemNumber-input",
+    "Name":"https://schema.org/orderItemNumber-input",
     "Domain Bucket":"< 1K"
   },
   {
     "Class":"Predicate",
-    "Name":"http:\/\/schema.org\/orderItemNumber-output",
+    "Name":"https://schema.org/orderItemNumber-output",
     "Domain Bucket":"< 1K"
   },
   {
     "Class":"Predicate",
-    "Name":"http:\/\/schema.org\/orderItemStatus",
+    "Name":"https://schema.org/orderItemStatus",
     "Domain Bucket":"< 1K"
   },
   {
     "Class":"Predicate",
-    "Name":"http:\/\/schema.org\/orderItemStatus-input",
+    "Name":"https://schema.org/orderItemStatus-input",
     "Domain Bucket":"< 1K"
   },
   {
     "Class":"Predicate",
-    "Name":"http:\/\/schema.org\/orderItemStatus-output",
+    "Name":"https://schema.org/orderItemStatus-output",
     "Domain Bucket":"< 1K"
   },
   {
     "Class":"Predicate",
-    "Name":"http:\/\/schema.org\/orderNumber",
+    "Name":"https://schema.org/orderNumber",
     "Domain Bucket":"< 1K"
   },
   {
     "Class":"Predicate",
-    "Name":"http:\/\/schema.org\/orderNumber-input",
+    "Name":"https://schema.org/orderNumber-input",
     "Domain Bucket":"< 1K"
   },
   {
     "Class":"Predicate",
-    "Name":"http:\/\/schema.org\/orderNumber-output",
+    "Name":"https://schema.org/orderNumber-output",
     "Domain Bucket":"< 1K"
   },
   {
     "Class":"Predicate",
-    "Name":"http:\/\/schema.org\/orderPercentage",
+    "Name":"https://schema.org/orderPercentage",
     "Domain Bucket":"< 1K"
   },
   {
     "Class":"Predicate",
-    "Name":"http:\/\/schema.org\/orderPercentage-input",
+    "Name":"https://schema.org/orderPercentage-input",
     "Domain Bucket":"< 1K"
   },
   {
     "Class":"Predicate",
-    "Name":"http:\/\/schema.org\/orderPercentage-output",
+    "Name":"https://schema.org/orderPercentage-output",
     "Domain Bucket":"< 1K"
   },
   {
     "Class":"Predicate",
-    "Name":"http:\/\/schema.org\/orderQuantity",
+    "Name":"https://schema.org/orderQuantity",
     "Domain Bucket":"< 1K"
   },
   {
     "Class":"Predicate",
-    "Name":"http:\/\/schema.org\/orderQuantity-input",
+    "Name":"https://schema.org/orderQuantity-input",
     "Domain Bucket":"< 1K"
   },
   {
     "Class":"Predicate",
-    "Name":"http:\/\/schema.org\/orderQuantity-output",
+    "Name":"https://schema.org/orderQuantity-output",
     "Domain Bucket":"< 1K"
   },
   {
     "Class":"Predicate",
-    "Name":"http:\/\/schema.org\/orderStatus",
+    "Name":"https://schema.org/orderStatus",
     "Domain Bucket":"< 1K"
   },
   {
     "Class":"Predicate",
-    "Name":"http:\/\/schema.org\/orderStatus-input",
+    "Name":"https://schema.org/orderStatus-input",
     "Domain Bucket":"< 1K"
   },
   {
     "Class":"Predicate",
-    "Name":"http:\/\/schema.org\/orderStatus-output",
+    "Name":"https://schema.org/orderStatus-output",
     "Domain Bucket":"< 1K"
   },
   {
     "Class":"Predicate",
-    "Name":"http:\/\/schema.org\/orderValue",
+    "Name":"https://schema.org/orderValue",
     "Domain Bucket":"< 1K"
   },
   {
     "Class":"Predicate",
-    "Name":"http:\/\/schema.org\/orderValue-input",
+    "Name":"https://schema.org/orderValue-input",
     "Domain Bucket":"< 1K"
   },
   {
     "Class":"Predicate",
-    "Name":"http:\/\/schema.org\/orderValue-output",
+    "Name":"https://schema.org/orderValue-output",
     "Domain Bucket":"< 1K"
   },
   {
     "Class":"Predicate",
-    "Name":"http:\/\/schema.org\/orderedItem",
+    "Name":"https://schema.org/orderedItem",
     "Domain Bucket":"< 1K"
   },
   {
     "Class":"Predicate",
-    "Name":"http:\/\/schema.org\/orderedItem-input",
+    "Name":"https://schema.org/orderedItem-input",
     "Domain Bucket":"< 1K"
   },
   {
     "Class":"Predicate",
-    "Name":"http:\/\/schema.org\/orderedItem-output",
+    "Name":"https://schema.org/orderedItem-output",
     "Domain Bucket":"< 1K"
   },
   {
     "Class":"Predicate",
-    "Name":"http:\/\/schema.org\/organizer",
+    "Name":"https://schema.org/organizer",
     "Domain Bucket":"100K - 1M"
   },
   {
     "Class":"Predicate",
-    "Name":"http:\/\/schema.org\/organizer-input",
+    "Name":"https://schema.org/organizer-input",
     "Domain Bucket":"< 1K"
   },
   {
     "Class":"Predicate",
-    "Name":"http:\/\/schema.org\/organizer-output",
+    "Name":"https://schema.org/organizer-output",
     "Domain Bucket":"< 1K"
   },
   {
     "Class":"Predicate",
-    "Name":"http:\/\/schema.org\/originAddress",
+    "Name":"https://schema.org/originAddress",
     "Domain Bucket":"< 1K"
   },
   {
     "Class":"Predicate",
-    "Name":"http:\/\/schema.org\/originAddress-input",
+    "Name":"https://schema.org/originAddress-input",
     "Domain Bucket":"< 1K"
   },
   {
     "Class":"Predicate",
-    "Name":"http:\/\/schema.org\/originAddress-output",
+    "Name":"https://schema.org/originAddress-output",
     "Domain Bucket":"< 1K"
   },
   {
     "Class":"Predicate",
-    "Name":"http:\/\/schema.org\/originalMediaContextDescription",
+    "Name":"https://schema.org/originalMediaContextDescription",
     "Domain Bucket":"< 1K"
   },
   {
     "Class":"Predicate",
-    "Name":"http:\/\/schema.org\/originalMediaContextDescription-input",
+    "Name":"https://schema.org/originalMediaContextDescription-input",
     "Domain Bucket":"< 1K"
   },
   {
     "Class":"Predicate",
-    "Name":"http:\/\/schema.org\/originalMediaContextDescription-output",
+    "Name":"https://schema.org/originalMediaContextDescription-output",
     "Domain Bucket":"< 1K"
   },
   {
     "Class":"Predicate",
-    "Name":"http:\/\/schema.org\/originalMediaLink",
+    "Name":"https://schema.org/originalMediaLink",
     "Domain Bucket":"< 1K"
   },
   {
     "Class":"Predicate",
-    "Name":"http:\/\/schema.org\/originalMediaLink-input",
+    "Name":"https://schema.org/originalMediaLink-input",
     "Domain Bucket":"< 1K"
   },
   {
     "Class":"Predicate",
-    "Name":"http:\/\/schema.org\/originalMediaLink-output",
+    "Name":"https://schema.org/originalMediaLink-output",
     "Domain Bucket":"< 1K"
   },
   {
     "Class":"Predicate",
-    "Name":"http:\/\/schema.org\/originatesFrom",
+    "Name":"https://schema.org/originatesFrom",
     "Domain Bucket":"< 1K"
   },
   {
     "Class":"Predicate",
-    "Name":"http:\/\/schema.org\/originatesFrom-input",
+    "Name":"https://schema.org/originatesFrom-input",
     "Domain Bucket":"< 1K"
   },
   {
     "Class":"Predicate",
-    "Name":"http:\/\/schema.org\/originatesFrom-output",
+    "Name":"https://schema.org/originatesFrom-output",
     "Domain Bucket":"< 1K"
   },
   {
     "Class":"Predicate",
-    "Name":"http:\/\/schema.org\/overdosage",
+    "Name":"https://schema.org/overdosage",
     "Domain Bucket":"< 1K"
   },
   {
     "Class":"Predicate",
-    "Name":"http:\/\/schema.org\/overdosage-input",
+    "Name":"https://schema.org/overdosage-input",
     "Domain Bucket":"< 1K"
   },
   {
     "Class":"Predicate",
-    "Name":"http:\/\/schema.org\/overdosage-output",
+    "Name":"https://schema.org/overdosage-output",
     "Domain Bucket":"< 1K"
   },
   {
     "Class":"Predicate",
-    "Name":"http:\/\/schema.org\/ownedFrom",
+    "Name":"https://schema.org/ownedFrom",
     "Domain Bucket":"< 1K"
   },
   {
     "Class":"Predicate",
-    "Name":"http:\/\/schema.org\/ownedFrom-input",
+    "Name":"https://schema.org/ownedFrom-input",
     "Domain Bucket":"< 1K"
   },
   {
     "Class":"Predicate",
-    "Name":"http:\/\/schema.org\/ownedFrom-output",
+    "Name":"https://schema.org/ownedFrom-output",
     "Domain Bucket":"< 1K"
   },
   {
     "Class":"Predicate",
-    "Name":"http:\/\/schema.org\/ownedThrough",
+    "Name":"https://schema.org/ownedThrough",
     "Domain Bucket":"< 1K"
   },
   {
     "Class":"Predicate",
-    "Name":"http:\/\/schema.org\/ownedThrough-input",
+    "Name":"https://schema.org/ownedThrough-input",
     "Domain Bucket":"< 1K"
   },
   {
     "Class":"Predicate",
-    "Name":"http:\/\/schema.org\/ownedThrough-output",
+    "Name":"https://schema.org/ownedThrough-output",
     "Domain Bucket":"< 1K"
   },
   {
     "Class":"Predicate",
-    "Name":"http:\/\/schema.org\/owner",
+    "Name":"https://schema.org/owner",
     "Domain Bucket":"1K - 10K"
   },
   {
     "Class":"Predicate",
-    "Name":"http:\/\/schema.org\/owner-input",
+    "Name":"https://schema.org/owner-input",
     "Domain Bucket":"< 1K"
   },
   {
     "Class":"Predicate",
-    "Name":"http:\/\/schema.org\/owner-output",
+    "Name":"https://schema.org/owner-output",
     "Domain Bucket":"< 1K"
   },
   {
     "Class":"Predicate",
-    "Name":"http:\/\/schema.org\/ownershipFundingInfo",
+    "Name":"https://schema.org/ownershipFundingInfo",
     "Domain Bucket":"10K - 100K"
   },
   {
     "Class":"Predicate",
-    "Name":"http:\/\/schema.org\/ownershipFundingInfo-input",
+    "Name":"https://schema.org/ownershipFundingInfo-input",
     "Domain Bucket":"< 1K"
   },
   {
     "Class":"Predicate",
-    "Name":"http:\/\/schema.org\/ownershipFundingInfo-output",
+    "Name":"https://schema.org/ownershipFundingInfo-output",
     "Domain Bucket":"< 1K"
   },
   {
     "Class":"Predicate",
-    "Name":"http:\/\/schema.org\/owns",
+    "Name":"https://schema.org/owns",
     "Domain Bucket":"10K - 100K"
   },
   {
     "Class":"Predicate",
-    "Name":"http:\/\/schema.org\/owns-input",
+    "Name":"https://schema.org/owns-input",
     "Domain Bucket":"< 1K"
   },
   {
     "Class":"Predicate",
-    "Name":"http:\/\/schema.org\/owns-output",
+    "Name":"https://schema.org/owns-output",
     "Domain Bucket":"< 1K"
   },
   {
     "Class":"Predicate",
-    "Name":"http:\/\/schema.org\/pageEnd",
+    "Name":"https://schema.org/pageEnd",
     "Domain Bucket":"1K - 10K"
   },
   {
     "Class":"Predicate",
-    "Name":"http:\/\/schema.org\/pageEnd-input",
+    "Name":"https://schema.org/pageEnd-input",
     "Domain Bucket":"< 1K"
   },
   {
     "Class":"Predicate",
-    "Name":"http:\/\/schema.org\/pageEnd-output",
+    "Name":"https://schema.org/pageEnd-output",
     "Domain Bucket":"< 1K"
   },
   {
     "Class":"Predicate",
-    "Name":"http:\/\/schema.org\/pageStart",
+    "Name":"https://schema.org/pageStart",
     "Domain Bucket":"1K - 10K"
   },
   {
     "Class":"Predicate",
-    "Name":"http:\/\/schema.org\/pageStart-input",
+    "Name":"https://schema.org/pageStart-input",
     "Domain Bucket":"< 1K"
   },
   {
     "Class":"Predicate",
-    "Name":"http:\/\/schema.org\/pageStart-output",
+    "Name":"https://schema.org/pageStart-output",
     "Domain Bucket":"< 1K"
   },
   {
     "Class":"Predicate",
-    "Name":"http:\/\/schema.org\/pagination",
+    "Name":"https://schema.org/pagination",
     "Domain Bucket":"1K - 10K"
   },
   {
     "Class":"Predicate",
-    "Name":"http:\/\/schema.org\/pagination-input",
+    "Name":"https://schema.org/pagination-input",
     "Domain Bucket":"< 1K"
   },
   {
     "Class":"Predicate",
-    "Name":"http:\/\/schema.org\/pagination-output",
+    "Name":"https://schema.org/pagination-output",
     "Domain Bucket":"< 1K"
   },
   {
     "Class":"Predicate",
-    "Name":"http:\/\/schema.org\/parent",
+    "Name":"https://schema.org/parent",
     "Domain Bucket":"< 1K"
   },
   {
     "Class":"Predicate",
-    "Name":"http:\/\/schema.org\/parent-input",
+    "Name":"https://schema.org/parent-input",
     "Domain Bucket":"< 1K"
   },
   {
     "Class":"Predicate",
-    "Name":"http:\/\/schema.org\/parent-output",
+    "Name":"https://schema.org/parent-output",
     "Domain Bucket":"< 1K"
   },
   {
     "Class":"Predicate",
-    "Name":"http:\/\/schema.org\/parentItem",
+    "Name":"https://schema.org/parentItem",
     "Domain Bucket":"1K - 10K"
   },
   {
     "Class":"Predicate",
-    "Name":"http:\/\/schema.org\/parentItem-input",
+    "Name":"https://schema.org/parentItem-input",
     "Domain Bucket":"< 1K"
   },
   {
     "Class":"Predicate",
-    "Name":"http:\/\/schema.org\/parentItem-output",
+    "Name":"https://schema.org/parentItem-output",
     "Domain Bucket":"< 1K"
   },
   {
     "Class":"Predicate",
-    "Name":"http:\/\/schema.org\/parentOrganization",
+    "Name":"https://schema.org/parentOrganization",
     "Domain Bucket":"100K - 1M"
   },
   {
     "Class":"Predicate",
-    "Name":"http:\/\/schema.org\/parentOrganization-input",
+    "Name":"https://schema.org/parentOrganization-input",
     "Domain Bucket":"< 1K"
   },
   {
     "Class":"Predicate",
-    "Name":"http:\/\/schema.org\/parentOrganization-output",
+    "Name":"https://schema.org/parentOrganization-output",
     "Domain Bucket":"< 1K"
   },
   {
     "Class":"Predicate",
-    "Name":"http:\/\/schema.org\/parentService",
+    "Name":"https://schema.org/parentService",
     "Domain Bucket":"< 1K"
   },
   {
     "Class":"Predicate",
-    "Name":"http:\/\/schema.org\/parentService-input",
+    "Name":"https://schema.org/parentService-input",
     "Domain Bucket":"< 1K"
   },
   {
     "Class":"Predicate",
-    "Name":"http:\/\/schema.org\/parentService-output",
+    "Name":"https://schema.org/parentService-output",
     "Domain Bucket":"< 1K"
   },
   {
     "Class":"Predicate",
-    "Name":"http:\/\/schema.org\/parentTaxon",
+    "Name":"https://schema.org/parentTaxon",
     "Domain Bucket":"< 1K"
   },
   {
     "Class":"Predicate",
-    "Name":"http:\/\/schema.org\/parentTaxon-input",
+    "Name":"https://schema.org/parentTaxon-input",
     "Domain Bucket":"< 1K"
   },
   {
     "Class":"Predicate",
-    "Name":"http:\/\/schema.org\/parentTaxon-output",
+    "Name":"https://schema.org/parentTaxon-output",
     "Domain Bucket":"< 1K"
   },
   {
     "Class":"Predicate",
-    "Name":"http:\/\/schema.org\/parents",
+    "Name":"https://schema.org/parents",
     "Domain Bucket":"< 1K"
   },
   {
     "Class":"Predicate",
-    "Name":"http:\/\/schema.org\/parents-input",
+    "Name":"https://schema.org/parents-input",
     "Domain Bucket":"< 1K"
   },
   {
     "Class":"Predicate",
-    "Name":"http:\/\/schema.org\/parents-output",
+    "Name":"https://schema.org/parents-output",
     "Domain Bucket":"< 1K"
   },
   {
     "Class":"Predicate",
-    "Name":"http:\/\/schema.org\/partOfEpisode",
+    "Name":"https://schema.org/partOfEpisode",
     "Domain Bucket":"< 1K"
   },
   {
     "Class":"Predicate",
-    "Name":"http:\/\/schema.org\/partOfEpisode-input",
+    "Name":"https://schema.org/partOfEpisode-input",
     "Domain Bucket":"< 1K"
   },
   {
     "Class":"Predicate",
-    "Name":"http:\/\/schema.org\/partOfEpisode-output",
+    "Name":"https://schema.org/partOfEpisode-output",
     "Domain Bucket":"< 1K"
   },
   {
     "Class":"Predicate",
-    "Name":"http:\/\/schema.org\/partOfInvoice",
+    "Name":"https://schema.org/partOfInvoice",
     "Domain Bucket":"< 1K"
   },
   {
     "Class":"Predicate",
-    "Name":"http:\/\/schema.org\/partOfInvoice-input",
+    "Name":"https://schema.org/partOfInvoice-input",
     "Domain Bucket":"< 1K"
   },
   {
     "Class":"Predicate",
-    "Name":"http:\/\/schema.org\/partOfInvoice-output",
+    "Name":"https://schema.org/partOfInvoice-output",
     "Domain Bucket":"< 1K"
   },
   {
     "Class":"Predicate",
-    "Name":"http:\/\/schema.org\/partOfOrder",
+    "Name":"https://schema.org/partOfOrder",
     "Domain Bucket":"< 1K"
   },
   {
     "Class":"Predicate",
-    "Name":"http:\/\/schema.org\/partOfOrder-input",
+    "Name":"https://schema.org/partOfOrder-input",
     "Domain Bucket":"< 1K"
   },
   {
     "Class":"Predicate",
-    "Name":"http:\/\/schema.org\/partOfOrder-output",
+    "Name":"https://schema.org/partOfOrder-output",
     "Domain Bucket":"< 1K"
   },
   {
     "Class":"Predicate",
-    "Name":"http:\/\/schema.org\/partOfSeason",
+    "Name":"https://schema.org/partOfSeason",
     "Domain Bucket":"1K - 10K"
   },
   {
     "Class":"Predicate",
-    "Name":"http:\/\/schema.org\/partOfSeason-input",
+    "Name":"https://schema.org/partOfSeason-input",
     "Domain Bucket":"< 1K"
   },
   {
     "Class":"Predicate",
-    "Name":"http:\/\/schema.org\/partOfSeason-output",
+    "Name":"https://schema.org/partOfSeason-output",
     "Domain Bucket":"< 1K"
   },
   {
     "Class":"Predicate",
-    "Name":"http:\/\/schema.org\/partOfSeries",
+    "Name":"https://schema.org/partOfSeries",
     "Domain Bucket":"10K - 100K"
   },
   {
     "Class":"Predicate",
-    "Name":"http:\/\/schema.org\/partOfSeries-input",
+    "Name":"https://schema.org/partOfSeries-input",
     "Domain Bucket":"< 1K"
   },
   {
     "Class":"Predicate",
-    "Name":"http:\/\/schema.org\/partOfSeries-output",
+    "Name":"https://schema.org/partOfSeries-output",
     "Domain Bucket":"< 1K"
   },
   {
     "Class":"Predicate",
-    "Name":"http:\/\/schema.org\/partOfSystem",
+    "Name":"https://schema.org/partOfSystem",
     "Domain Bucket":"< 1K"
   },
   {
     "Class":"Predicate",
-    "Name":"http:\/\/schema.org\/partOfSystem-input",
+    "Name":"https://schema.org/partOfSystem-input",
     "Domain Bucket":"< 1K"
   },
   {
     "Class":"Predicate",
-    "Name":"http:\/\/schema.org\/partOfSystem-output",
+    "Name":"https://schema.org/partOfSystem-output",
     "Domain Bucket":"< 1K"
   },
   {
     "Class":"Predicate",
-    "Name":"http:\/\/schema.org\/partOfTVSeries",
+    "Name":"https://schema.org/partOfTVSeries",
     "Domain Bucket":"< 1K"
   },
   {
     "Class":"Predicate",
-    "Name":"http:\/\/schema.org\/partOfTVSeries-input",
+    "Name":"https://schema.org/partOfTVSeries-input",
     "Domain Bucket":"< 1K"
   },
   {
     "Class":"Predicate",
-    "Name":"http:\/\/schema.org\/partOfTVSeries-output",
+    "Name":"https://schema.org/partOfTVSeries-output",
     "Domain Bucket":"< 1K"
   },
   {
     "Class":"Predicate",
-    "Name":"http:\/\/schema.org\/partOfTrip",
+    "Name":"https://schema.org/partOfTrip",
     "Domain Bucket":"< 1K"
   },
   {
     "Class":"Predicate",
-    "Name":"http:\/\/schema.org\/partOfTrip-input",
+    "Name":"https://schema.org/partOfTrip-input",
     "Domain Bucket":"< 1K"
   },
   {
     "Class":"Predicate",
-    "Name":"http:\/\/schema.org\/partOfTrip-output",
+    "Name":"https://schema.org/partOfTrip-output",
     "Domain Bucket":"< 1K"
   },
   {
     "Class":"Predicate",
-    "Name":"http:\/\/schema.org\/participant",
+    "Name":"https://schema.org/participant",
     "Domain Bucket":"1K - 10K"
   },
   {
     "Class":"Predicate",
-    "Name":"http:\/\/schema.org\/participant-input",
+    "Name":"https://schema.org/participant-input",
     "Domain Bucket":"< 1K"
   },
   {
     "Class":"Predicate",
-    "Name":"http:\/\/schema.org\/participant-output",
+    "Name":"https://schema.org/participant-output",
     "Domain Bucket":"< 1K"
   },
   {
     "Class":"Predicate",
-    "Name":"http:\/\/schema.org\/partySize",
+    "Name":"https://schema.org/partySize",
     "Domain Bucket":"< 1K"
   },
   {
     "Class":"Predicate",
-    "Name":"http:\/\/schema.org\/partySize-input",
+    "Name":"https://schema.org/partySize-input",
     "Domain Bucket":"< 1K"
   },
   {
     "Class":"Predicate",
-    "Name":"http:\/\/schema.org\/partySize-output",
+    "Name":"https://schema.org/partySize-output",
     "Domain Bucket":"< 1K"
   },
   {
     "Class":"Predicate",
-    "Name":"http:\/\/schema.org\/passengerPriorityStatus",
+    "Name":"https://schema.org/passengerPriorityStatus",
     "Domain Bucket":"< 1K"
   },
   {
     "Class":"Predicate",
-    "Name":"http:\/\/schema.org\/passengerPriorityStatus-input",
+    "Name":"https://schema.org/passengerPriorityStatus-input",
     "Domain Bucket":"< 1K"
   },
   {
     "Class":"Predicate",
-    "Name":"http:\/\/schema.org\/passengerPriorityStatus-output",
+    "Name":"https://schema.org/passengerPriorityStatus-output",
     "Domain Bucket":"< 1K"
   },
   {
     "Class":"Predicate",
-    "Name":"http:\/\/schema.org\/passengerSequenceNumber",
+    "Name":"https://schema.org/passengerSequenceNumber",
     "Domain Bucket":"< 1K"
   },
   {
     "Class":"Predicate",
-    "Name":"http:\/\/schema.org\/passengerSequenceNumber-input",
+    "Name":"https://schema.org/passengerSequenceNumber-input",
     "Domain Bucket":"< 1K"
   },
   {
     "Class":"Predicate",
-    "Name":"http:\/\/schema.org\/passengerSequenceNumber-output",
+    "Name":"https://schema.org/passengerSequenceNumber-output",
     "Domain Bucket":"< 1K"
   },
   {
     "Class":"Predicate",
-    "Name":"http:\/\/schema.org\/pathophysiology",
+    "Name":"https://schema.org/pathophysiology",
     "Domain Bucket":"< 1K"
   },
   {
     "Class":"Predicate",
-    "Name":"http:\/\/schema.org\/pathophysiology-input",
+    "Name":"https://schema.org/pathophysiology-input",
     "Domain Bucket":"< 1K"
   },
   {
     "Class":"Predicate",
-    "Name":"http:\/\/schema.org\/pathophysiology-output",
+    "Name":"https://schema.org/pathophysiology-output",
     "Domain Bucket":"< 1K"
   },
   {
     "Class":"Predicate",
-    "Name":"http:\/\/schema.org\/pattern",
+    "Name":"https://schema.org/pattern",
     "Domain Bucket":"1K - 10K"
   },
   {
     "Class":"Predicate",
-    "Name":"http:\/\/schema.org\/pattern-input",
+    "Name":"https://schema.org/pattern-input",
     "Domain Bucket":"< 1K"
   },
   {
     "Class":"Predicate",
-    "Name":"http:\/\/schema.org\/pattern-output",
+    "Name":"https://schema.org/pattern-output",
     "Domain Bucket":"< 1K"
   },
   {
     "Class":"Predicate",
-    "Name":"http:\/\/schema.org\/payload",
+    "Name":"https://schema.org/payload",
     "Domain Bucket":"1K - 10K"
   },
   {
     "Class":"Predicate",
-    "Name":"http:\/\/schema.org\/payload-input",
+    "Name":"https://schema.org/payload-input",
     "Domain Bucket":"< 1K"
   },
   {
     "Class":"Predicate",
-    "Name":"http:\/\/schema.org\/payload-output",
+    "Name":"https://schema.org/payload-output",
     "Domain Bucket":"< 1K"
   },
   {
     "Class":"Predicate",
-    "Name":"http:\/\/schema.org\/paymentAccepted",
+    "Name":"https://schema.org/paymentAccepted",
     "Domain Bucket":"100K - 1M"
   },
   {
     "Class":"Predicate",
-    "Name":"http:\/\/schema.org\/paymentAccepted-input",
+    "Name":"https://schema.org/paymentAccepted-input",
     "Domain Bucket":"< 1K"
   },
   {
     "Class":"Predicate",
-    "Name":"http:\/\/schema.org\/paymentAccepted-output",
+    "Name":"https://schema.org/paymentAccepted-output",
     "Domain Bucket":"< 1K"
   },
   {
     "Class":"Predicate",
-    "Name":"http:\/\/schema.org\/paymentDue",
+    "Name":"https://schema.org/paymentDue",
     "Domain Bucket":"< 1K"
   },
   {
     "Class":"Predicate",
-    "Name":"http:\/\/schema.org\/paymentDue-input",
+    "Name":"https://schema.org/paymentDue-input",
     "Domain Bucket":"< 1K"
   },
   {
     "Class":"Predicate",
-    "Name":"http:\/\/schema.org\/paymentDue-output",
+    "Name":"https://schema.org/paymentDue-output",
     "Domain Bucket":"< 1K"
   },
   {
     "Class":"Predicate",
-    "Name":"http:\/\/schema.org\/paymentDueDate",
+    "Name":"https://schema.org/paymentDueDate",
     "Domain Bucket":"< 1K"
   },
   {
     "Class":"Predicate",
-    "Name":"http:\/\/schema.org\/paymentDueDate-input",
+    "Name":"https://schema.org/paymentDueDate-input",
     "Domain Bucket":"< 1K"
   },
   {
     "Class":"Predicate",
-    "Name":"http:\/\/schema.org\/paymentDueDate-output",
+    "Name":"https://schema.org/paymentDueDate-output",
     "Domain Bucket":"< 1K"
   },
   {
     "Class":"Predicate",
-    "Name":"http:\/\/schema.org\/paymentMethod",
+    "Name":"https://schema.org/paymentMethod",
     "Domain Bucket":"< 1K"
   },
   {
     "Class":"Predicate",
-    "Name":"http:\/\/schema.org\/paymentMethod-input",
+    "Name":"https://schema.org/paymentMethod-input",
     "Domain Bucket":"< 1K"
   },
   {
     "Class":"Predicate",
-    "Name":"http:\/\/schema.org\/paymentMethod-output",
+    "Name":"https://schema.org/paymentMethod-output",
     "Domain Bucket":"< 1K"
   },
   {
     "Class":"Predicate",
-    "Name":"http:\/\/schema.org\/paymentMethodId",
+    "Name":"https://schema.org/paymentMethodId",
     "Domain Bucket":"< 1K"
   },
   {
     "Class":"Predicate",
-    "Name":"http:\/\/schema.org\/paymentMethodId-input",
+    "Name":"https://schema.org/paymentMethodId-input",
     "Domain Bucket":"< 1K"
   },
   {
     "Class":"Predicate",
-    "Name":"http:\/\/schema.org\/paymentMethodId-output",
+    "Name":"https://schema.org/paymentMethodId-output",
     "Domain Bucket":"< 1K"
   },
   {
     "Class":"Predicate",
-    "Name":"http:\/\/schema.org\/paymentMethodType",
+    "Name":"https://schema.org/paymentMethodType",
     "Domain Bucket":"1K - 10K"
   },
   {
     "Class":"Predicate",
-    "Name":"http:\/\/schema.org\/paymentMethodType-input",
+    "Name":"https://schema.org/paymentMethodType-input",
     "Domain Bucket":"< 1K"
   },
   {
     "Class":"Predicate",
-    "Name":"http:\/\/schema.org\/paymentMethodType-output",
+    "Name":"https://schema.org/paymentMethodType-output",
     "Domain Bucket":"< 1K"
   },
   {
     "Class":"Predicate",
-    "Name":"http:\/\/schema.org\/paymentStatus",
+    "Name":"https://schema.org/paymentStatus",
     "Domain Bucket":"< 1K"
   },
   {
     "Class":"Predicate",
-    "Name":"http:\/\/schema.org\/paymentStatus-input",
+    "Name":"https://schema.org/paymentStatus-input",
     "Domain Bucket":"< 1K"
   },
   {
     "Class":"Predicate",
-    "Name":"http:\/\/schema.org\/paymentStatus-output",
+    "Name":"https://schema.org/paymentStatus-output",
     "Domain Bucket":"< 1K"
   },
   {
     "Class":"Predicate",
-    "Name":"http:\/\/schema.org\/paymentUrl",
+    "Name":"https://schema.org/paymentUrl",
     "Domain Bucket":"< 1K"
   },
   {
     "Class":"Predicate",
-    "Name":"http:\/\/schema.org\/paymentUrl-input",
+    "Name":"https://schema.org/paymentUrl-input",
     "Domain Bucket":"< 1K"
   },
   {
     "Class":"Predicate",
-    "Name":"http:\/\/schema.org\/paymentUrl-output",
+    "Name":"https://schema.org/paymentUrl-output",
     "Domain Bucket":"< 1K"
   },
   {
     "Class":"Predicate",
-    "Name":"http:\/\/schema.org\/penciler",
+    "Name":"https://schema.org/penciler",
     "Domain Bucket":"< 1K"
   },
   {
     "Class":"Predicate",
-    "Name":"http:\/\/schema.org\/penciler-input",
+    "Name":"https://schema.org/penciler-input",
     "Domain Bucket":"< 1K"
   },
   {
     "Class":"Predicate",
-    "Name":"http:\/\/schema.org\/penciler-output",
+    "Name":"https://schema.org/penciler-output",
     "Domain Bucket":"< 1K"
   },
   {
     "Class":"Predicate",
-    "Name":"http:\/\/schema.org\/percentile10",
+    "Name":"https://schema.org/percentile10",
     "Domain Bucket":"1K - 10K"
   },
   {
     "Class":"Predicate",
-    "Name":"http:\/\/schema.org\/percentile10-input",
+    "Name":"https://schema.org/percentile10-input",
     "Domain Bucket":"< 1K"
   },
   {
     "Class":"Predicate",
-    "Name":"http:\/\/schema.org\/percentile10-output",
+    "Name":"https://schema.org/percentile10-output",
     "Domain Bucket":"< 1K"
   },
   {
     "Class":"Predicate",
-    "Name":"http:\/\/schema.org\/percentile25",
+    "Name":"https://schema.org/percentile25",
     "Domain Bucket":"< 1K"
   },
   {
     "Class":"Predicate",
-    "Name":"http:\/\/schema.org\/percentile25-input",
+    "Name":"https://schema.org/percentile25-input",
     "Domain Bucket":"< 1K"
   },
   {
     "Class":"Predicate",
-    "Name":"http:\/\/schema.org\/percentile25-output",
+    "Name":"https://schema.org/percentile25-output",
     "Domain Bucket":"< 1K"
   },
   {
     "Class":"Predicate",
-    "Name":"http:\/\/schema.org\/percentile75",
+    "Name":"https://schema.org/percentile75",
     "Domain Bucket":"< 1K"
   },
   {
     "Class":"Predicate",
-    "Name":"http:\/\/schema.org\/percentile75-input",
+    "Name":"https://schema.org/percentile75-input",
     "Domain Bucket":"< 1K"
   },
   {
     "Class":"Predicate",
-    "Name":"http:\/\/schema.org\/percentile75-output",
+    "Name":"https://schema.org/percentile75-output",
     "Domain Bucket":"< 1K"
   },
   {
     "Class":"Predicate",
-    "Name":"http:\/\/schema.org\/percentile90",
+    "Name":"https://schema.org/percentile90",
     "Domain Bucket":"1K - 10K"
   },
   {
     "Class":"Predicate",
-    "Name":"http:\/\/schema.org\/percentile90-input",
+    "Name":"https://schema.org/percentile90-input",
     "Domain Bucket":"< 1K"
   },
   {
     "Class":"Predicate",
-    "Name":"http:\/\/schema.org\/percentile90-output",
+    "Name":"https://schema.org/percentile90-output",
     "Domain Bucket":"< 1K"
   },
   {
     "Class":"Predicate",
-    "Name":"http:\/\/schema.org\/performTime",
+    "Name":"https://schema.org/performTime",
     "Domain Bucket":"1K - 10K"
   },
   {
     "Class":"Predicate",
-    "Name":"http:\/\/schema.org\/performTime-input",
+    "Name":"https://schema.org/performTime-input",
     "Domain Bucket":"< 1K"
   },
   {
     "Class":"Predicate",
-    "Name":"http:\/\/schema.org\/performTime-output",
+    "Name":"https://schema.org/performTime-output",
     "Domain Bucket":"< 1K"
   },
   {
     "Class":"Predicate",
-    "Name":"http:\/\/schema.org\/performer",
+    "Name":"https://schema.org/performer",
     "Domain Bucket":"100K - 1M"
   },
   {
     "Class":"Predicate",
-    "Name":"http:\/\/schema.org\/performer-input",
+    "Name":"https://schema.org/performer-input",
     "Domain Bucket":"< 1K"
   },
   {
     "Class":"Predicate",
-    "Name":"http:\/\/schema.org\/performer-output",
+    "Name":"https://schema.org/performer-output",
     "Domain Bucket":"< 1K"
   },
   {
     "Class":"Predicate",
-    "Name":"http:\/\/schema.org\/performerIn",
+    "Name":"https://schema.org/performerIn",
     "Domain Bucket":"1K - 10K"
   },
   {
     "Class":"Predicate",
-    "Name":"http:\/\/schema.org\/performerIn-input",
+    "Name":"https://schema.org/performerIn-input",
     "Domain Bucket":"< 1K"
   },
   {
     "Class":"Predicate",
-    "Name":"http:\/\/schema.org\/performerIn-output",
+    "Name":"https://schema.org/performerIn-output",
     "Domain Bucket":"< 1K"
   },
   {
     "Class":"Predicate",
-    "Name":"http:\/\/schema.org\/performers",
+    "Name":"https://schema.org/performers",
     "Domain Bucket":"1K - 10K"
   },
   {
     "Class":"Predicate",
-    "Name":"http:\/\/schema.org\/performers-input",
+    "Name":"https://schema.org/performers-input",
     "Domain Bucket":"< 1K"
   },
   {
     "Class":"Predicate",
-    "Name":"http:\/\/schema.org\/performers-output",
+    "Name":"https://schema.org/performers-output",
     "Domain Bucket":"< 1K"
   },
   {
     "Class":"Predicate",
-    "Name":"http:\/\/schema.org\/permissionType",
+    "Name":"https://schema.org/permissionType",
     "Domain Bucket":"< 1K"
   },
   {
     "Class":"Predicate",
-    "Name":"http:\/\/schema.org\/permissionType-input",
+    "Name":"https://schema.org/permissionType-input",
     "Domain Bucket":"< 1K"
   },
   {
     "Class":"Predicate",
-    "Name":"http:\/\/schema.org\/permissionType-output",
+    "Name":"https://schema.org/permissionType-output",
     "Domain Bucket":"< 1K"
   },
   {
     "Class":"Predicate",
-    "Name":"http:\/\/schema.org\/permissions",
+    "Name":"https://schema.org/permissions",
     "Domain Bucket":"10K - 100K"
   },
   {
     "Class":"Predicate",
-    "Name":"http:\/\/schema.org\/permissions-input",
+    "Name":"https://schema.org/permissions-input",
     "Domain Bucket":"< 1K"
   },
   {
     "Class":"Predicate",
-    "Name":"http:\/\/schema.org\/permissions-output",
+    "Name":"https://schema.org/permissions-output",
     "Domain Bucket":"< 1K"
   },
   {
     "Class":"Predicate",
-    "Name":"http:\/\/schema.org\/permitAudience",
+    "Name":"https://schema.org/permitAudience",
     "Domain Bucket":"< 1K"
   },
   {
     "Class":"Predicate",
-    "Name":"http:\/\/schema.org\/permitAudience-input",
+    "Name":"https://schema.org/permitAudience-input",
     "Domain Bucket":"< 1K"
   },
   {
     "Class":"Predicate",
-    "Name":"http:\/\/schema.org\/permitAudience-output",
+    "Name":"https://schema.org/permitAudience-output",
     "Domain Bucket":"< 1K"
   },
   {
     "Class":"Predicate",
-    "Name":"http:\/\/schema.org\/permittedUsage",
+    "Name":"https://schema.org/permittedUsage",
     "Domain Bucket":"< 1K"
   },
   {
     "Class":"Predicate",
-    "Name":"http:\/\/schema.org\/permittedUsage-input",
+    "Name":"https://schema.org/permittedUsage-input",
     "Domain Bucket":"< 1K"
   },
   {
     "Class":"Predicate",
-    "Name":"http:\/\/schema.org\/permittedUsage-output",
+    "Name":"https://schema.org/permittedUsage-output",
     "Domain Bucket":"< 1K"
   },
   {
     "Class":"Predicate",
-    "Name":"http:\/\/schema.org\/petsAllowed",
+    "Name":"https://schema.org/petsAllowed",
     "Domain Bucket":"10K - 100K"
   },
   {
     "Class":"Predicate",
-    "Name":"http:\/\/schema.org\/petsAllowed-input",
+    "Name":"https://schema.org/petsAllowed-input",
     "Domain Bucket":"< 1K"
   },
   {
     "Class":"Predicate",
-    "Name":"http:\/\/schema.org\/petsAllowed-output",
+    "Name":"https://schema.org/petsAllowed-output",
     "Domain Bucket":"< 1K"
   },
   {
     "Class":"Predicate",
-    "Name":"http:\/\/schema.org\/phoneticText",
+    "Name":"https://schema.org/phoneticText",
     "Domain Bucket":"< 1K"
   },
   {
     "Class":"Predicate",
-    "Name":"http:\/\/schema.org\/phoneticText-input",
+    "Name":"https://schema.org/phoneticText-input",
     "Domain Bucket":"< 1K"
   },
   {
     "Class":"Predicate",
-    "Name":"http:\/\/schema.org\/phoneticText-output",
+    "Name":"https://schema.org/phoneticText-output",
     "Domain Bucket":"< 1K"
   },
   {
     "Class":"Predicate",
-    "Name":"http:\/\/schema.org\/photo",
+    "Name":"https://schema.org/photo",
     "Domain Bucket":"10K - 100K"
   },
   {
     "Class":"Predicate",
-    "Name":"http:\/\/schema.org\/photo-input",
+    "Name":"https://schema.org/photo-input",
     "Domain Bucket":"< 1K"
   },
   {
     "Class":"Predicate",
-    "Name":"http:\/\/schema.org\/photo-output",
+    "Name":"https://schema.org/photo-output",
     "Domain Bucket":"< 1K"
   },
   {
     "Class":"Predicate",
-    "Name":"http:\/\/schema.org\/photos",
+    "Name":"https://schema.org/photos",
     "Domain Bucket":"10K - 100K"
   },
   {
     "Class":"Predicate",
-    "Name":"http:\/\/schema.org\/photos-input",
+    "Name":"https://schema.org/photos-input",
     "Domain Bucket":"< 1K"
   },
   {
     "Class":"Predicate",
-    "Name":"http:\/\/schema.org\/photos-output",
+    "Name":"https://schema.org/photos-output",
     "Domain Bucket":"< 1K"
   },
   {
     "Class":"Predicate",
-    "Name":"http:\/\/schema.org\/physicalRequirement",
+    "Name":"https://schema.org/physicalRequirement",
     "Domain Bucket":"< 1K"
   },
   {
     "Class":"Predicate",
-    "Name":"http:\/\/schema.org\/physicalRequirement-input",
+    "Name":"https://schema.org/physicalRequirement-input",
     "Domain Bucket":"< 1K"
   },
   {
     "Class":"Predicate",
-    "Name":"http:\/\/schema.org\/physicalRequirement-output",
+    "Name":"https://schema.org/physicalRequirement-output",
     "Domain Bucket":"< 1K"
   },
   {
     "Class":"Predicate",
-    "Name":"http:\/\/schema.org\/physiologicalBenefits",
+    "Name":"https://schema.org/physiologicalBenefits",
     "Domain Bucket":"< 1K"
   },
   {
     "Class":"Predicate",
-    "Name":"http:\/\/schema.org\/physiologicalBenefits-input",
+    "Name":"https://schema.org/physiologicalBenefits-input",
     "Domain Bucket":"< 1K"
   },
   {
     "Class":"Predicate",
-    "Name":"http:\/\/schema.org\/physiologicalBenefits-output",
+    "Name":"https://schema.org/physiologicalBenefits-output",
     "Domain Bucket":"< 1K"
   },
   {
     "Class":"Predicate",
-    "Name":"http:\/\/schema.org\/pickupLocation",
+    "Name":"https://schema.org/pickupLocation",
     "Domain Bucket":"< 1K"
   },
   {
     "Class":"Predicate",
-    "Name":"http:\/\/schema.org\/pickupLocation-input",
+    "Name":"https://schema.org/pickupLocation-input",
     "Domain Bucket":"< 1K"
   },
   {
     "Class":"Predicate",
-    "Name":"http:\/\/schema.org\/pickupLocation-output",
+    "Name":"https://schema.org/pickupLocation-output",
     "Domain Bucket":"< 1K"
   },
   {
     "Class":"Predicate",
-    "Name":"http:\/\/schema.org\/pickupTime",
+    "Name":"https://schema.org/pickupTime",
     "Domain Bucket":"< 1K"
   },
   {
     "Class":"Predicate",
-    "Name":"http:\/\/schema.org\/pickupTime-input",
+    "Name":"https://schema.org/pickupTime-input",
     "Domain Bucket":"< 1K"
   },
   {
     "Class":"Predicate",
-    "Name":"http:\/\/schema.org\/pickupTime-output",
+    "Name":"https://schema.org/pickupTime-output",
     "Domain Bucket":"< 1K"
   },
   {
     "Class":"Predicate",
-    "Name":"http:\/\/schema.org\/playMode",
+    "Name":"https://schema.org/playMode",
     "Domain Bucket":"10K - 100K"
   },
   {
     "Class":"Predicate",
-    "Name":"http:\/\/schema.org\/playMode-input",
+    "Name":"https://schema.org/playMode-input",
     "Domain Bucket":"< 1K"
   },
   {
     "Class":"Predicate",
-    "Name":"http:\/\/schema.org\/playMode-output",
+    "Name":"https://schema.org/playMode-output",
     "Domain Bucket":"< 1K"
   },
   {
     "Class":"Predicate",
-    "Name":"http:\/\/schema.org\/playerType",
+    "Name":"https://schema.org/playerType",
     "Domain Bucket":"1K - 10K"
   },
   {
     "Class":"Predicate",
-    "Name":"http:\/\/schema.org\/playerType-input",
+    "Name":"https://schema.org/playerType-input",
     "Domain Bucket":"< 1K"
   },
   {
     "Class":"Predicate",
-    "Name":"http:\/\/schema.org\/playerType-output",
+    "Name":"https://schema.org/playerType-output",
     "Domain Bucket":"< 1K"
   },
   {
     "Class":"Predicate",
-    "Name":"http:\/\/schema.org\/playersOnline",
+    "Name":"https://schema.org/playersOnline",
     "Domain Bucket":"1K - 10K"
   },
   {
     "Class":"Predicate",
-    "Name":"http:\/\/schema.org\/playersOnline-input",
+    "Name":"https://schema.org/playersOnline-input",
     "Domain Bucket":"< 1K"
   },
   {
     "Class":"Predicate",
-    "Name":"http:\/\/schema.org\/playersOnline-output",
+    "Name":"https://schema.org/playersOnline-output",
     "Domain Bucket":"< 1K"
   },
   {
     "Class":"Predicate",
-    "Name":"http:\/\/schema.org\/polygon",
+    "Name":"https://schema.org/polygon",
     "Domain Bucket":"< 1K"
   },
   {
     "Class":"Predicate",
-    "Name":"http:\/\/schema.org\/polygon-input",
+    "Name":"https://schema.org/polygon-input",
     "Domain Bucket":"< 1K"
   },
   {
     "Class":"Predicate",
-    "Name":"http:\/\/schema.org\/polygon-output",
+    "Name":"https://schema.org/polygon-output",
     "Domain Bucket":"< 1K"
   },
   {
     "Class":"Predicate",
-    "Name":"http:\/\/schema.org\/populationType",
+    "Name":"https://schema.org/populationType",
     "Domain Bucket":"< 1K"
   },
   {
     "Class":"Predicate",
-    "Name":"http:\/\/schema.org\/populationType-input",
+    "Name":"https://schema.org/populationType-input",
     "Domain Bucket":"< 1K"
   },
   {
     "Class":"Predicate",
-    "Name":"http:\/\/schema.org\/populationType-output",
+    "Name":"https://schema.org/populationType-output",
     "Domain Bucket":"< 1K"
   },
   {
     "Class":"Predicate",
-    "Name":"http:\/\/schema.org\/position",
+    "Name":"https://schema.org/position",
     "Domain Bucket":"10M+"
   },
   {
     "Class":"Predicate",
-    "Name":"http:\/\/schema.org\/position-input",
+    "Name":"https://schema.org/position-input",
     "Domain Bucket":"< 1K"
   },
   {
     "Class":"Predicate",
-    "Name":"http:\/\/schema.org\/position-output",
+    "Name":"https://schema.org/position-output",
     "Domain Bucket":"< 1K"
   },
   {
     "Class":"Predicate",
-    "Name":"http:\/\/schema.org\/positiveNotes",
+    "Name":"https://schema.org/positiveNotes",
     "Domain Bucket":"10K - 100K"
   },
   {
     "Class":"Predicate",
-    "Name":"http:\/\/schema.org\/positiveNotes-input",
+    "Name":"https://schema.org/positiveNotes-input",
     "Domain Bucket":"< 1K"
   },
   {
     "Class":"Predicate",
-    "Name":"http:\/\/schema.org\/positiveNotes-output",
+    "Name":"https://schema.org/positiveNotes-output",
     "Domain Bucket":"< 1K"
   },
   {
     "Class":"Predicate",
-    "Name":"http:\/\/schema.org\/possibleComplication",
+    "Name":"https://schema.org/possibleComplication",
     "Domain Bucket":"1K - 10K"
   },
   {
     "Class":"Predicate",
-    "Name":"http:\/\/schema.org\/possibleComplication-input",
+    "Name":"https://schema.org/possibleComplication-input",
     "Domain Bucket":"< 1K"
   },
   {
     "Class":"Predicate",
-    "Name":"http:\/\/schema.org\/possibleComplication-output",
+    "Name":"https://schema.org/possibleComplication-output",
     "Domain Bucket":"< 1K"
   },
   {
     "Class":"Predicate",
-    "Name":"http:\/\/schema.org\/possibleTreatment",
+    "Name":"https://schema.org/possibleTreatment",
     "Domain Bucket":"1K - 10K"
   },
   {
     "Class":"Predicate",
-    "Name":"http:\/\/schema.org\/possibleTreatment-input",
+    "Name":"https://schema.org/possibleTreatment-input",
     "Domain Bucket":"< 1K"
   },
   {
     "Class":"Predicate",
-    "Name":"http:\/\/schema.org\/possibleTreatment-output",
+    "Name":"https://schema.org/possibleTreatment-output",
     "Domain Bucket":"< 1K"
   },
   {
     "Class":"Predicate",
-    "Name":"http:\/\/schema.org\/postOfficeBoxNumber",
+    "Name":"https://schema.org/postOfficeBoxNumber",
     "Domain Bucket":"10K - 100K"
   },
   {
     "Class":"Predicate",
-    "Name":"http:\/\/schema.org\/postOfficeBoxNumber-input",
+    "Name":"https://schema.org/postOfficeBoxNumber-input",
     "Domain Bucket":"< 1K"
   },
   {
     "Class":"Predicate",
-    "Name":"http:\/\/schema.org\/postOfficeBoxNumber-output",
+    "Name":"https://schema.org/postOfficeBoxNumber-output",
     "Domain Bucket":"< 1K"
   },
   {
     "Class":"Predicate",
-    "Name":"http:\/\/schema.org\/postOp",
+    "Name":"https://schema.org/postOp",
     "Domain Bucket":"< 1K"
   },
   {
     "Class":"Predicate",
-    "Name":"http:\/\/schema.org\/postOp-input",
+    "Name":"https://schema.org/postOp-input",
     "Domain Bucket":"< 1K"
   },
   {
     "Class":"Predicate",
-    "Name":"http:\/\/schema.org\/postOp-output",
+    "Name":"https://schema.org/postOp-output",
     "Domain Bucket":"< 1K"
   },
   {
     "Class":"Predicate",
-    "Name":"http:\/\/schema.org\/postalCode",
+    "Name":"https://schema.org/postalCode",
     "Domain Bucket":"1M - 10M"
   },
   {
     "Class":"Predicate",
-    "Name":"http:\/\/schema.org\/postalCode-input",
+    "Name":"https://schema.org/postalCode-input",
     "Domain Bucket":"< 1K"
   },
   {
     "Class":"Predicate",
-    "Name":"http:\/\/schema.org\/postalCode-output",
+    "Name":"https://schema.org/postalCode-output",
     "Domain Bucket":"< 1K"
   },
   {
     "Class":"Predicate",
-    "Name":"http:\/\/schema.org\/postalCodeBegin",
+    "Name":"https://schema.org/postalCodeBegin",
     "Domain Bucket":"1K - 10K"
   },
   {
     "Class":"Predicate",
-    "Name":"http:\/\/schema.org\/postalCodeBegin-input",
+    "Name":"https://schema.org/postalCodeBegin-input",
     "Domain Bucket":"< 1K"
   },
   {
     "Class":"Predicate",
-    "Name":"http:\/\/schema.org\/postalCodeBegin-output",
+    "Name":"https://schema.org/postalCodeBegin-output",
     "Domain Bucket":"< 1K"
   },
   {
     "Class":"Predicate",
-    "Name":"http:\/\/schema.org\/postalCodeEnd",
+    "Name":"https://schema.org/postalCodeEnd",
     "Domain Bucket":"1K - 10K"
   },
   {
     "Class":"Predicate",
-    "Name":"http:\/\/schema.org\/postalCodeEnd-input",
+    "Name":"https://schema.org/postalCodeEnd-input",
     "Domain Bucket":"< 1K"
   },
   {
     "Class":"Predicate",
-    "Name":"http:\/\/schema.org\/postalCodeEnd-output",
+    "Name":"https://schema.org/postalCodeEnd-output",
     "Domain Bucket":"< 1K"
   },
   {
     "Class":"Predicate",
-    "Name":"http:\/\/schema.org\/postalCodePrefix",
+    "Name":"https://schema.org/postalCodePrefix",
     "Domain Bucket":"< 1K"
   },
   {
     "Class":"Predicate",
-    "Name":"http:\/\/schema.org\/postalCodePrefix-input",
+    "Name":"https://schema.org/postalCodePrefix-input",
     "Domain Bucket":"< 1K"
   },
   {
     "Class":"Predicate",
-    "Name":"http:\/\/schema.org\/postalCodePrefix-output",
+    "Name":"https://schema.org/postalCodePrefix-output",
     "Domain Bucket":"< 1K"
   },
   {
     "Class":"Predicate",
-    "Name":"http:\/\/schema.org\/postalCodeRange",
+    "Name":"https://schema.org/postalCodeRange",
     "Domain Bucket":"1K - 10K"
   },
   {
     "Class":"Predicate",
-    "Name":"http:\/\/schema.org\/postalCodeRange-input",
+    "Name":"https://schema.org/postalCodeRange-input",
     "Domain Bucket":"< 1K"
   },
   {
     "Class":"Predicate",
-    "Name":"http:\/\/schema.org\/postalCodeRange-output",
+    "Name":"https://schema.org/postalCodeRange-output",
     "Domain Bucket":"< 1K"
   },
   {
     "Class":"Predicate",
-    "Name":"http:\/\/schema.org\/potentialAction",
+    "Name":"https://schema.org/potentialAction",
     "Domain Bucket":"10M+"
   },
   {
     "Class":"Predicate",
-    "Name":"http:\/\/schema.org\/potentialAction-input",
+    "Name":"https://schema.org/potentialAction-input",
     "Domain Bucket":"< 1K"
   },
   {
     "Class":"Predicate",
-    "Name":"http:\/\/schema.org\/potentialAction-output",
+    "Name":"https://schema.org/potentialAction-output",
     "Domain Bucket":"< 1K"
   },
   {
     "Class":"Predicate",
-    "Name":"http:\/\/schema.org\/potentialUse",
+    "Name":"https://schema.org/potentialUse",
     "Domain Bucket":"< 1K"
   },
   {
     "Class":"Predicate",
-    "Name":"http:\/\/schema.org\/potentialUse-input",
+    "Name":"https://schema.org/potentialUse-input",
     "Domain Bucket":"< 1K"
   },
   {
     "Class":"Predicate",
-    "Name":"http:\/\/schema.org\/potentialUse-output",
+    "Name":"https://schema.org/potentialUse-output",
     "Domain Bucket":"< 1K"
   },
   {
     "Class":"Predicate",
-    "Name":"http:\/\/schema.org\/practicesAt",
+    "Name":"https://schema.org/practicesAt",
     "Domain Bucket":"< 1K"
   },
   {
     "Class":"Predicate",
-    "Name":"http:\/\/schema.org\/practicesAt-input",
+    "Name":"https://schema.org/practicesAt-input",
     "Domain Bucket":"< 1K"
   },
   {
     "Class":"Predicate",
-    "Name":"http:\/\/schema.org\/practicesAt-output",
+    "Name":"https://schema.org/practicesAt-output",
     "Domain Bucket":"< 1K"
   },
   {
     "Class":"Predicate",
-    "Name":"http:\/\/schema.org\/preOp",
+    "Name":"https://schema.org/preOp",
     "Domain Bucket":"< 1K"
   },
   {
     "Class":"Predicate",
-    "Name":"http:\/\/schema.org\/preOp-input",
+    "Name":"https://schema.org/preOp-input",
     "Domain Bucket":"< 1K"
   },
   {
     "Class":"Predicate",
-    "Name":"http:\/\/schema.org\/preOp-output",
+    "Name":"https://schema.org/preOp-output",
     "Domain Bucket":"< 1K"
   },
   {
     "Class":"Predicate",
-    "Name":"http:\/\/schema.org\/predecessorOf",
+    "Name":"https://schema.org/predecessorOf",
     "Domain Bucket":"< 1K"
   },
   {
     "Class":"Predicate",
-    "Name":"http:\/\/schema.org\/predecessorOf-input",
+    "Name":"https://schema.org/predecessorOf-input",
     "Domain Bucket":"< 1K"
   },
   {
     "Class":"Predicate",
-    "Name":"http:\/\/schema.org\/predecessorOf-output",
+    "Name":"https://schema.org/predecessorOf-output",
     "Domain Bucket":"< 1K"
   },
   {
     "Class":"Predicate",
-    "Name":"http:\/\/schema.org\/pregnancyCategory",
+    "Name":"https://schema.org/pregnancyCategory",
     "Domain Bucket":"< 1K"
   },
   {
     "Class":"Predicate",
-    "Name":"http:\/\/schema.org\/pregnancyCategory-input",
+    "Name":"https://schema.org/pregnancyCategory-input",
     "Domain Bucket":"< 1K"
   },
   {
     "Class":"Predicate",
-    "Name":"http:\/\/schema.org\/pregnancyCategory-output",
+    "Name":"https://schema.org/pregnancyCategory-output",
     "Domain Bucket":"< 1K"
   },
   {
     "Class":"Predicate",
-    "Name":"http:\/\/schema.org\/pregnancyWarning",
+    "Name":"https://schema.org/pregnancyWarning",
     "Domain Bucket":"< 1K"
   },
   {
     "Class":"Predicate",
-    "Name":"http:\/\/schema.org\/pregnancyWarning-input",
+    "Name":"https://schema.org/pregnancyWarning-input",
     "Domain Bucket":"< 1K"
   },
   {
     "Class":"Predicate",
-    "Name":"http:\/\/schema.org\/pregnancyWarning-output",
+    "Name":"https://schema.org/pregnancyWarning-output",
     "Domain Bucket":"< 1K"
   },
   {
     "Class":"Predicate",
-    "Name":"http:\/\/schema.org\/prepTime",
+    "Name":"https://schema.org/prepTime",
     "Domain Bucket":"10K - 100K"
   },
   {
     "Class":"Predicate",
-    "Name":"http:\/\/schema.org\/prepTime-input",
+    "Name":"https://schema.org/prepTime-input",
     "Domain Bucket":"< 1K"
   },
   {
     "Class":"Predicate",
-    "Name":"http:\/\/schema.org\/prepTime-output",
+    "Name":"https://schema.org/prepTime-output",
     "Domain Bucket":"< 1K"
   },
   {
     "Class":"Predicate",
-    "Name":"http:\/\/schema.org\/preparation",
+    "Name":"https://schema.org/preparation",
     "Domain Bucket":"1K - 10K"
   },
   {
     "Class":"Predicate",
-    "Name":"http:\/\/schema.org\/preparation-input",
+    "Name":"https://schema.org/preparation-input",
     "Domain Bucket":"< 1K"
   },
   {
     "Class":"Predicate",
-    "Name":"http:\/\/schema.org\/preparation-output",
+    "Name":"https://schema.org/preparation-output",
     "Domain Bucket":"< 1K"
   },
   {
     "Class":"Predicate",
-    "Name":"http:\/\/schema.org\/prescribingInfo",
+    "Name":"https://schema.org/prescribingInfo",
     "Domain Bucket":"< 1K"
   },
   {
     "Class":"Predicate",
-    "Name":"http:\/\/schema.org\/prescribingInfo-input",
+    "Name":"https://schema.org/prescribingInfo-input",
     "Domain Bucket":"< 1K"
   },
   {
     "Class":"Predicate",
-    "Name":"http:\/\/schema.org\/prescribingInfo-output",
+    "Name":"https://schema.org/prescribingInfo-output",
     "Domain Bucket":"< 1K"
   },
   {
     "Class":"Predicate",
-    "Name":"http:\/\/schema.org\/prescriptionStatus",
+    "Name":"https://schema.org/prescriptionStatus",
     "Domain Bucket":"1K - 10K"
   },
   {
     "Class":"Predicate",
-    "Name":"http:\/\/schema.org\/prescriptionStatus-input",
+    "Name":"https://schema.org/prescriptionStatus-input",
     "Domain Bucket":"< 1K"
   },
   {
     "Class":"Predicate",
-    "Name":"http:\/\/schema.org\/prescriptionStatus-output",
+    "Name":"https://schema.org/prescriptionStatus-output",
     "Domain Bucket":"< 1K"
   },
   {
     "Class":"Predicate",
-    "Name":"http:\/\/schema.org\/previousItem",
+    "Name":"https://schema.org/previousItem",
     "Domain Bucket":"1M - 10M"
   },
   {
     "Class":"Predicate",
-    "Name":"http:\/\/schema.org\/previousItem-input",
+    "Name":"https://schema.org/previousItem-input",
     "Domain Bucket":"< 1K"
   },
   {
     "Class":"Predicate",
-    "Name":"http:\/\/schema.org\/previousItem-output",
+    "Name":"https://schema.org/previousItem-output",
     "Domain Bucket":"< 1K"
   },
   {
     "Class":"Predicate",
-    "Name":"http:\/\/schema.org\/previousStartDate",
+    "Name":"https://schema.org/previousStartDate",
     "Domain Bucket":"1K - 10K"
   },
   {
     "Class":"Predicate",
-    "Name":"http:\/\/schema.org\/previousStartDate-input",
+    "Name":"https://schema.org/previousStartDate-input",
     "Domain Bucket":"< 1K"
   },
   {
     "Class":"Predicate",
-    "Name":"http:\/\/schema.org\/previousStartDate-output",
+    "Name":"https://schema.org/previousStartDate-output",
     "Domain Bucket":"< 1K"
   },
   {
     "Class":"Predicate",
-    "Name":"http:\/\/schema.org\/price",
+    "Name":"https://schema.org/price",
     "Domain Bucket":"1M - 10M"
   },
   {
     "Class":"Predicate",
-    "Name":"http:\/\/schema.org\/price-input",
+    "Name":"https://schema.org/price-input",
     "Domain Bucket":"< 1K"
   },
   {
     "Class":"Predicate",
-    "Name":"http:\/\/schema.org\/price-output",
+    "Name":"https://schema.org/price-output",
     "Domain Bucket":"< 1K"
   },
   {
     "Class":"Predicate",
-    "Name":"http:\/\/schema.org\/priceComponent",
+    "Name":"https://schema.org/priceComponent",
     "Domain Bucket":"1K - 10K"
   },
   {
     "Class":"Predicate",
-    "Name":"http:\/\/schema.org\/priceComponent-input",
+    "Name":"https://schema.org/priceComponent-input",
     "Domain Bucket":"< 1K"
   },
   {
     "Class":"Predicate",
-    "Name":"http:\/\/schema.org\/priceComponent-output",
+    "Name":"https://schema.org/priceComponent-output",
     "Domain Bucket":"< 1K"
   },
   {
     "Class":"Predicate",
-    "Name":"http:\/\/schema.org\/priceComponentType",
+    "Name":"https://schema.org/priceComponentType",
     "Domain Bucket":"< 1K"
   },
   {
     "Class":"Predicate",
-    "Name":"http:\/\/schema.org\/priceComponentType-input",
+    "Name":"https://schema.org/priceComponentType-input",
     "Domain Bucket":"< 1K"
   },
   {
     "Class":"Predicate",
-    "Name":"http:\/\/schema.org\/priceComponentType-output",
+    "Name":"https://schema.org/priceComponentType-output",
     "Domain Bucket":"< 1K"
   },
   {
     "Class":"Predicate",
-    "Name":"http:\/\/schema.org\/priceCurrency",
+    "Name":"https://schema.org/priceCurrency",
     "Domain Bucket":"1M - 10M"
   },
   {
     "Class":"Predicate",
-    "Name":"http:\/\/schema.org\/priceCurrency-input",
+    "Name":"https://schema.org/priceCurrency-input",
     "Domain Bucket":"< 1K"
   },
   {
     "Class":"Predicate",
-    "Name":"http:\/\/schema.org\/priceCurrency-output",
+    "Name":"https://schema.org/priceCurrency-output",
     "Domain Bucket":"< 1K"
   },
   {
     "Class":"Predicate",
-    "Name":"http:\/\/schema.org\/priceRange",
+    "Name":"https://schema.org/priceRange",
     "Domain Bucket":"1M - 10M"
   },
   {
     "Class":"Predicate",
-    "Name":"http:\/\/schema.org\/priceRange-input",
+    "Name":"https://schema.org/priceRange-input",
     "Domain Bucket":"< 1K"
   },
   {
     "Class":"Predicate",
-    "Name":"http:\/\/schema.org\/priceRange-output",
+    "Name":"https://schema.org/priceRange-output",
     "Domain Bucket":"< 1K"
   },
   {
     "Class":"Predicate",
-    "Name":"http:\/\/schema.org\/priceSpecification",
+    "Name":"https://schema.org/priceSpecification",
     "Domain Bucket":"1M - 10M"
   },
   {
     "Class":"Predicate",
-    "Name":"http:\/\/schema.org\/priceSpecification-input",
+    "Name":"https://schema.org/priceSpecification-input",
     "Domain Bucket":"< 1K"
   },
   {
     "Class":"Predicate",
-    "Name":"http:\/\/schema.org\/priceSpecification-output",
+    "Name":"https://schema.org/priceSpecification-output",
     "Domain Bucket":"< 1K"
   },
   {
     "Class":"Predicate",
-    "Name":"http:\/\/schema.org\/priceType",
+    "Name":"https://schema.org/priceType",
     "Domain Bucket":"100K - 1M"
   },
   {
     "Class":"Predicate",
-    "Name":"http:\/\/schema.org\/priceType-input",
+    "Name":"https://schema.org/priceType-input",
     "Domain Bucket":"< 1K"
   },
   {
     "Class":"Predicate",
-    "Name":"http:\/\/schema.org\/priceType-output",
+    "Name":"https://schema.org/priceType-output",
     "Domain Bucket":"< 1K"
   },
   {
     "Class":"Predicate",
-    "Name":"http:\/\/schema.org\/priceValidUntil",
+    "Name":"https://schema.org/priceValidUntil",
     "Domain Bucket":"1M - 10M"
   },
   {
     "Class":"Predicate",
-    "Name":"http:\/\/schema.org\/priceValidUntil-input",
+    "Name":"https://schema.org/priceValidUntil-input",
     "Domain Bucket":"< 1K"
   },
   {
     "Class":"Predicate",
-    "Name":"http:\/\/schema.org\/priceValidUntil-output",
+    "Name":"https://schema.org/priceValidUntil-output",
     "Domain Bucket":"< 1K"
   },
   {
     "Class":"Predicate",
-    "Name":"http:\/\/schema.org\/primaryImageOfPage",
+    "Name":"https://schema.org/primaryImageOfPage",
     "Domain Bucket":"10M+"
   },
   {
     "Class":"Predicate",
-    "Name":"http:\/\/schema.org\/primaryImageOfPage-input",
+    "Name":"https://schema.org/primaryImageOfPage-input",
     "Domain Bucket":"< 1K"
   },
   {
     "Class":"Predicate",
-    "Name":"http:\/\/schema.org\/primaryImageOfPage-output",
+    "Name":"https://schema.org/primaryImageOfPage-output",
     "Domain Bucket":"< 1K"
   },
   {
     "Class":"Predicate",
-    "Name":"http:\/\/schema.org\/primaryPrevention",
+    "Name":"https://schema.org/primaryPrevention",
     "Domain Bucket":"< 1K"
   },
   {
     "Class":"Predicate",
-    "Name":"http:\/\/schema.org\/primaryPrevention-input",
+    "Name":"https://schema.org/primaryPrevention-input",
     "Domain Bucket":"< 1K"
   },
   {
     "Class":"Predicate",
-    "Name":"http:\/\/schema.org\/primaryPrevention-output",
+    "Name":"https://schema.org/primaryPrevention-output",
     "Domain Bucket":"< 1K"
   },
   {
     "Class":"Predicate",
-    "Name":"http:\/\/schema.org\/printColumn",
+    "Name":"https://schema.org/printColumn",
     "Domain Bucket":"< 1K"
   },
   {
     "Class":"Predicate",
-    "Name":"http:\/\/schema.org\/printColumn-input",
+    "Name":"https://schema.org/printColumn-input",
     "Domain Bucket":"< 1K"
   },
   {
     "Class":"Predicate",
-    "Name":"http:\/\/schema.org\/printColumn-output",
+    "Name":"https://schema.org/printColumn-output",
     "Domain Bucket":"< 1K"
   },
   {
     "Class":"Predicate",
-    "Name":"http:\/\/schema.org\/printEdition",
+    "Name":"https://schema.org/printEdition",
     "Domain Bucket":"< 1K"
   },
   {
     "Class":"Predicate",
-    "Name":"http:\/\/schema.org\/printEdition-input",
+    "Name":"https://schema.org/printEdition-input",
     "Domain Bucket":"< 1K"
   },
   {
     "Class":"Predicate",
-    "Name":"http:\/\/schema.org\/printEdition-output",
+    "Name":"https://schema.org/printEdition-output",
     "Domain Bucket":"< 1K"
   },
   {
     "Class":"Predicate",
-    "Name":"http:\/\/schema.org\/printPage",
+    "Name":"https://schema.org/printPage",
     "Domain Bucket":"< 1K"
   },
   {
     "Class":"Predicate",
-    "Name":"http:\/\/schema.org\/printPage-input",
+    "Name":"https://schema.org/printPage-input",
     "Domain Bucket":"< 1K"
   },
   {
     "Class":"Predicate",
-    "Name":"http:\/\/schema.org\/printPage-output",
+    "Name":"https://schema.org/printPage-output",
     "Domain Bucket":"< 1K"
   },
   {
     "Class":"Predicate",
-    "Name":"http:\/\/schema.org\/printSection",
+    "Name":"https://schema.org/printSection",
     "Domain Bucket":"< 1K"
   },
   {
     "Class":"Predicate",
-    "Name":"http:\/\/schema.org\/printSection-input",
+    "Name":"https://schema.org/printSection-input",
     "Domain Bucket":"< 1K"
   },
   {
     "Class":"Predicate",
-    "Name":"http:\/\/schema.org\/printSection-output",
+    "Name":"https://schema.org/printSection-output",
     "Domain Bucket":"< 1K"
   },
   {
     "Class":"Predicate",
-    "Name":"http:\/\/schema.org\/procedure",
+    "Name":"https://schema.org/procedure",
     "Domain Bucket":"< 1K"
   },
   {
     "Class":"Predicate",
-    "Name":"http:\/\/schema.org\/procedure-input",
+    "Name":"https://schema.org/procedure-input",
     "Domain Bucket":"< 1K"
   },
   {
     "Class":"Predicate",
-    "Name":"http:\/\/schema.org\/procedure-output",
+    "Name":"https://schema.org/procedure-output",
     "Domain Bucket":"< 1K"
   },
   {
     "Class":"Predicate",
-    "Name":"http:\/\/schema.org\/procedureType",
+    "Name":"https://schema.org/procedureType",
     "Domain Bucket":"10K - 100K"
   },
   {
     "Class":"Predicate",
-    "Name":"http:\/\/schema.org\/procedureType-input",
+    "Name":"https://schema.org/procedureType-input",
     "Domain Bucket":"< 1K"
   },
   {
     "Class":"Predicate",
-    "Name":"http:\/\/schema.org\/procedureType-output",
+    "Name":"https://schema.org/procedureType-output",
     "Domain Bucket":"< 1K"
   },
   {
     "Class":"Predicate",
-    "Name":"http:\/\/schema.org\/processingTime",
+    "Name":"https://schema.org/processingTime",
     "Domain Bucket":"< 1K"
   },
   {
     "Class":"Predicate",
-    "Name":"http:\/\/schema.org\/processingTime-input",
+    "Name":"https://schema.org/processingTime-input",
     "Domain Bucket":"< 1K"
   },
   {
     "Class":"Predicate",
-    "Name":"http:\/\/schema.org\/processingTime-output",
+    "Name":"https://schema.org/processingTime-output",
     "Domain Bucket":"< 1K"
   },
   {
     "Class":"Predicate",
-    "Name":"http:\/\/schema.org\/processorRequirements",
+    "Name":"https://schema.org/processorRequirements",
     "Domain Bucket":"1K - 10K"
   },
   {
     "Class":"Predicate",
-    "Name":"http:\/\/schema.org\/processorRequirements-input",
+    "Name":"https://schema.org/processorRequirements-input",
     "Domain Bucket":"< 1K"
   },
   {
     "Class":"Predicate",
-    "Name":"http:\/\/schema.org\/processorRequirements-output",
+    "Name":"https://schema.org/processorRequirements-output",
     "Domain Bucket":"< 1K"
   },
   {
     "Class":"Predicate",
-    "Name":"http:\/\/schema.org\/producer",
+    "Name":"https://schema.org/producer",
     "Domain Bucket":"1K - 10K"
   },
   {
     "Class":"Predicate",
-    "Name":"http:\/\/schema.org\/producer-input",
+    "Name":"https://schema.org/producer-input",
     "Domain Bucket":"< 1K"
   },
   {
     "Class":"Predicate",
-    "Name":"http:\/\/schema.org\/producer-output",
+    "Name":"https://schema.org/producer-output",
     "Domain Bucket":"< 1K"
   },
   {
     "Class":"Predicate",
-    "Name":"http:\/\/schema.org\/produces",
+    "Name":"https://schema.org/produces",
     "Domain Bucket":"< 1K"
   },
   {
     "Class":"Predicate",
-    "Name":"http:\/\/schema.org\/produces-input",
+    "Name":"https://schema.org/produces-input",
     "Domain Bucket":"< 1K"
   },
   {
     "Class":"Predicate",
-    "Name":"http:\/\/schema.org\/produces-output",
+    "Name":"https://schema.org/produces-output",
     "Domain Bucket":"< 1K"
   },
   {
     "Class":"Predicate",
-    "Name":"http:\/\/schema.org\/productGroupID",
+    "Name":"https://schema.org/productGroupID",
     "Domain Bucket":"100K - 1M"
   },
   {
     "Class":"Predicate",
-    "Name":"http:\/\/schema.org\/productGroupID-input",
+    "Name":"https://schema.org/productGroupID-input",
     "Domain Bucket":"< 1K"
   },
   {
     "Class":"Predicate",
-    "Name":"http:\/\/schema.org\/productGroupID-output",
+    "Name":"https://schema.org/productGroupID-output",
     "Domain Bucket":"< 1K"
   },
   {
     "Class":"Predicate",
-    "Name":"http:\/\/schema.org\/productID",
+    "Name":"https://schema.org/productID",
     "Domain Bucket":"100K - 1M"
   },
   {
     "Class":"Predicate",
-    "Name":"http:\/\/schema.org\/productID-input",
+    "Name":"https://schema.org/productID-input",
     "Domain Bucket":"< 1K"
   },
   {
     "Class":"Predicate",
-    "Name":"http:\/\/schema.org\/productID-output",
+    "Name":"https://schema.org/productID-output",
     "Domain Bucket":"< 1K"
   },
   {
     "Class":"Predicate",
-    "Name":"http:\/\/schema.org\/productReturnDays",
+    "Name":"https://schema.org/productReturnDays",
     "Domain Bucket":"< 1K"
   },
   {
     "Class":"Predicate",
-    "Name":"http:\/\/schema.org\/productReturnDays-input",
+    "Name":"https://schema.org/productReturnDays-input",
     "Domain Bucket":"< 1K"
   },
   {
     "Class":"Predicate",
-    "Name":"http:\/\/schema.org\/productReturnDays-output",
+    "Name":"https://schema.org/productReturnDays-output",
     "Domain Bucket":"< 1K"
   },
   {
     "Class":"Predicate",
-    "Name":"http:\/\/schema.org\/productReturnLink",
+    "Name":"https://schema.org/productReturnLink",
     "Domain Bucket":"< 1K"
   },
   {
     "Class":"Predicate",
-    "Name":"http:\/\/schema.org\/productReturnLink-input",
+    "Name":"https://schema.org/productReturnLink-input",
     "Domain Bucket":"< 1K"
   },
   {
     "Class":"Predicate",
-    "Name":"http:\/\/schema.org\/productReturnLink-output",
+    "Name":"https://schema.org/productReturnLink-output",
     "Domain Bucket":"< 1K"
   },
   {
     "Class":"Predicate",
-    "Name":"http:\/\/schema.org\/productSupported",
+    "Name":"https://schema.org/productSupported",
     "Domain Bucket":"1K - 10K"
   },
   {
     "Class":"Predicate",
-    "Name":"http:\/\/schema.org\/productSupported-input",
+    "Name":"https://schema.org/productSupported-input",
     "Domain Bucket":"< 1K"
   },
   {
     "Class":"Predicate",
-    "Name":"http:\/\/schema.org\/productSupported-output",
+    "Name":"https://schema.org/productSupported-output",
     "Domain Bucket":"< 1K"
   },
   {
     "Class":"Predicate",
-    "Name":"http:\/\/schema.org\/productionCompany",
+    "Name":"https://schema.org/productionCompany",
     "Domain Bucket":"1K - 10K"
   },
   {
     "Class":"Predicate",
-    "Name":"http:\/\/schema.org\/productionCompany-input",
+    "Name":"https://schema.org/productionCompany-input",
     "Domain Bucket":"< 1K"
   },
   {
     "Class":"Predicate",
-    "Name":"http:\/\/schema.org\/productionCompany-output",
+    "Name":"https://schema.org/productionCompany-output",
     "Domain Bucket":"< 1K"
   },
   {
     "Class":"Predicate",
-    "Name":"http:\/\/schema.org\/productionDate",
+    "Name":"https://schema.org/productionDate",
     "Domain Bucket":"10K - 100K"
   },
   {
     "Class":"Predicate",
-    "Name":"http:\/\/schema.org\/productionDate-input",
+    "Name":"https://schema.org/productionDate-input",
     "Domain Bucket":"< 1K"
   },
   {
     "Class":"Predicate",
-    "Name":"http:\/\/schema.org\/productionDate-output",
+    "Name":"https://schema.org/productionDate-output",
     "Domain Bucket":"< 1K"
   },
   {
     "Class":"Predicate",
-    "Name":"http:\/\/schema.org\/proficiencyLevel",
+    "Name":"https://schema.org/proficiencyLevel",
     "Domain Bucket":"10K - 100K"
   },
   {
     "Class":"Predicate",
-    "Name":"http:\/\/schema.org\/proficiencyLevel-input",
+    "Name":"https://schema.org/proficiencyLevel-input",
     "Domain Bucket":"< 1K"
   },
   {
     "Class":"Predicate",
-    "Name":"http:\/\/schema.org\/proficiencyLevel-output",
+    "Name":"https://schema.org/proficiencyLevel-output",
     "Domain Bucket":"< 1K"
   },
   {
     "Class":"Predicate",
-    "Name":"http:\/\/schema.org\/program",
+    "Name":"https://schema.org/program",
     "Domain Bucket":"< 1K"
   },
   {
     "Class":"Predicate",
-    "Name":"http:\/\/schema.org\/program-input",
+    "Name":"https://schema.org/program-input",
     "Domain Bucket":"< 1K"
   },
   {
     "Class":"Predicate",
-    "Name":"http:\/\/schema.org\/program-output",
+    "Name":"https://schema.org/program-output",
     "Domain Bucket":"< 1K"
   },
   {
     "Class":"Predicate",
-    "Name":"http:\/\/schema.org\/programMembershipUsed",
+    "Name":"https://schema.org/programMembershipUsed",
     "Domain Bucket":"< 1K"
   },
   {
     "Class":"Predicate",
-    "Name":"http:\/\/schema.org\/programMembershipUsed-input",
+    "Name":"https://schema.org/programMembershipUsed-input",
     "Domain Bucket":"< 1K"
   },
   {
     "Class":"Predicate",
-    "Name":"http:\/\/schema.org\/programMembershipUsed-output",
+    "Name":"https://schema.org/programMembershipUsed-output",
     "Domain Bucket":"< 1K"
   },
   {
     "Class":"Predicate",
-    "Name":"http:\/\/schema.org\/programName",
+    "Name":"https://schema.org/programName",
     "Domain Bucket":"1K - 10K"
   },
   {
     "Class":"Predicate",
-    "Name":"http:\/\/schema.org\/programName-input",
+    "Name":"https://schema.org/programName-input",
     "Domain Bucket":"< 1K"
   },
   {
     "Class":"Predicate",
-    "Name":"http:\/\/schema.org\/programName-output",
+    "Name":"https://schema.org/programName-output",
     "Domain Bucket":"< 1K"
   },
   {
     "Class":"Predicate",
-    "Name":"http:\/\/schema.org\/programPrerequisites",
+    "Name":"https://schema.org/programPrerequisites",
     "Domain Bucket":"1K - 10K"
   },
   {
     "Class":"Predicate",
-    "Name":"http:\/\/schema.org\/programPrerequisites-input",
+    "Name":"https://schema.org/programPrerequisites-input",
     "Domain Bucket":"< 1K"
   },
   {
     "Class":"Predicate",
-    "Name":"http:\/\/schema.org\/programPrerequisites-output",
+    "Name":"https://schema.org/programPrerequisites-output",
     "Domain Bucket":"< 1K"
   },
   {
     "Class":"Predicate",
-    "Name":"http:\/\/schema.org\/programType",
+    "Name":"https://schema.org/programType",
     "Domain Bucket":"1K - 10K"
   },
   {
     "Class":"Predicate",
-    "Name":"http:\/\/schema.org\/programType-input",
+    "Name":"https://schema.org/programType-input",
     "Domain Bucket":"< 1K"
   },
   {
     "Class":"Predicate",
-    "Name":"http:\/\/schema.org\/programType-output",
+    "Name":"https://schema.org/programType-output",
     "Domain Bucket":"< 1K"
   },
   {
     "Class":"Predicate",
-    "Name":"http:\/\/schema.org\/programmingLanguage",
+    "Name":"https://schema.org/programmingLanguage",
     "Domain Bucket":"1K - 10K"
   },
   {
     "Class":"Predicate",
-    "Name":"http:\/\/schema.org\/programmingLanguage-input",
+    "Name":"https://schema.org/programmingLanguage-input",
     "Domain Bucket":"< 1K"
   },
   {
     "Class":"Predicate",
-    "Name":"http:\/\/schema.org\/programmingLanguage-output",
+    "Name":"https://schema.org/programmingLanguage-output",
     "Domain Bucket":"< 1K"
   },
   {
     "Class":"Predicate",
-    "Name":"http:\/\/schema.org\/programmingModel",
+    "Name":"https://schema.org/programmingModel",
     "Domain Bucket":"< 1K"
   },
   {
     "Class":"Predicate",
-    "Name":"http:\/\/schema.org\/programmingModel-input",
+    "Name":"https://schema.org/programmingModel-input",
     "Domain Bucket":"< 1K"
   },
   {
     "Class":"Predicate",
-    "Name":"http:\/\/schema.org\/programmingModel-output",
+    "Name":"https://schema.org/programmingModel-output",
     "Domain Bucket":"< 1K"
   },
   {
     "Class":"Predicate",
-    "Name":"http:\/\/schema.org\/pronouns",
+    "Name":"https://schema.org/pronouns",
     "Domain Bucket":"1K - 10K"
   },
   {
     "Class":"Predicate",
-    "Name":"http:\/\/schema.org\/pronouns-input",
+    "Name":"https://schema.org/pronouns-input",
     "Domain Bucket":"< 1K"
   },
   {
     "Class":"Predicate",
-    "Name":"http:\/\/schema.org\/pronouns-output",
+    "Name":"https://schema.org/pronouns-output",
     "Domain Bucket":"< 1K"
   },
   {
     "Class":"Predicate",
-    "Name":"http:\/\/schema.org\/propertyID",
+    "Name":"https://schema.org/propertyID",
     "Domain Bucket":"10K - 100K"
   },
   {
     "Class":"Predicate",
-    "Name":"http:\/\/schema.org\/propertyID-input",
+    "Name":"https://schema.org/propertyID-input",
     "Domain Bucket":"< 1K"
   },
   {
     "Class":"Predicate",
-    "Name":"http:\/\/schema.org\/propertyID-output",
+    "Name":"https://schema.org/propertyID-output",
     "Domain Bucket":"< 1K"
   },
   {
     "Class":"Predicate",
-    "Name":"http:\/\/schema.org\/proprietaryName",
+    "Name":"https://schema.org/proprietaryName",
     "Domain Bucket":"< 1K"
   },
   {
     "Class":"Predicate",
-    "Name":"http:\/\/schema.org\/proprietaryName-input",
+    "Name":"https://schema.org/proprietaryName-input",
     "Domain Bucket":"< 1K"
   },
   {
     "Class":"Predicate",
-    "Name":"http:\/\/schema.org\/proprietaryName-output",
+    "Name":"https://schema.org/proprietaryName-output",
     "Domain Bucket":"< 1K"
   },
   {
     "Class":"Predicate",
-    "Name":"http:\/\/schema.org\/proteinContent",
+    "Name":"https://schema.org/proteinContent",
     "Domain Bucket":"10K - 100K"
   },
   {
     "Class":"Predicate",
-    "Name":"http:\/\/schema.org\/proteinContent-input",
+    "Name":"https://schema.org/proteinContent-input",
     "Domain Bucket":"< 1K"
   },
   {
     "Class":"Predicate",
-    "Name":"http:\/\/schema.org\/proteinContent-output",
+    "Name":"https://schema.org/proteinContent-output",
     "Domain Bucket":"< 1K"
   },
   {
     "Class":"Predicate",
-    "Name":"http:\/\/schema.org\/provider",
+    "Name":"https://schema.org/provider",
     "Domain Bucket":"100K - 1M"
   },
   {
     "Class":"Predicate",
-    "Name":"http:\/\/schema.org\/provider-input",
+    "Name":"https://schema.org/provider-input",
     "Domain Bucket":"< 1K"
   },
   {
     "Class":"Predicate",
-    "Name":"http:\/\/schema.org\/provider-output",
+    "Name":"https://schema.org/provider-output",
     "Domain Bucket":"< 1K"
   },
   {
     "Class":"Predicate",
-    "Name":"http:\/\/schema.org\/providerMobility",
+    "Name":"https://schema.org/providerMobility",
     "Domain Bucket":"1K - 10K"
   },
   {
     "Class":"Predicate",
-    "Name":"http:\/\/schema.org\/providerMobility-input",
+    "Name":"https://schema.org/providerMobility-input",
     "Domain Bucket":"< 1K"
   },
   {
     "Class":"Predicate",
-    "Name":"http:\/\/schema.org\/providerMobility-output",
+    "Name":"https://schema.org/providerMobility-output",
     "Domain Bucket":"< 1K"
   },
   {
     "Class":"Predicate",
-    "Name":"http:\/\/schema.org\/providesBroadcastService",
+    "Name":"https://schema.org/providesBroadcastService",
     "Domain Bucket":"< 1K"
   },
   {
     "Class":"Predicate",
-    "Name":"http:\/\/schema.org\/providesBroadcastService-input",
+    "Name":"https://schema.org/providesBroadcastService-input",
     "Domain Bucket":"< 1K"
   },
   {
     "Class":"Predicate",
-    "Name":"http:\/\/schema.org\/providesBroadcastService-output",
+    "Name":"https://schema.org/providesBroadcastService-output",
     "Domain Bucket":"< 1K"
   },
   {
     "Class":"Predicate",
-    "Name":"http:\/\/schema.org\/providesService",
+    "Name":"https://schema.org/providesService",
     "Domain Bucket":"< 1K"
   },
   {
     "Class":"Predicate",
-    "Name":"http:\/\/schema.org\/providesService-input",
+    "Name":"https://schema.org/providesService-input",
     "Domain Bucket":"< 1K"
   },
   {
     "Class":"Predicate",
-    "Name":"http:\/\/schema.org\/providesService-output",
+    "Name":"https://schema.org/providesService-output",
     "Domain Bucket":"< 1K"
   },
   {
     "Class":"Predicate",
-    "Name":"http:\/\/schema.org\/publicAccess",
+    "Name":"https://schema.org/publicAccess",
     "Domain Bucket":"10K - 100K"
   },
   {
     "Class":"Predicate",
-    "Name":"http:\/\/schema.org\/publicAccess-input",
+    "Name":"https://schema.org/publicAccess-input",
     "Domain Bucket":"< 1K"
   },
   {
     "Class":"Predicate",
-    "Name":"http:\/\/schema.org\/publicAccess-output",
+    "Name":"https://schema.org/publicAccess-output",
     "Domain Bucket":"< 1K"
   },
   {
     "Class":"Predicate",
-    "Name":"http:\/\/schema.org\/publicTransportClosuresInfo",
+    "Name":"https://schema.org/publicTransportClosuresInfo",
     "Domain Bucket":"< 1K"
   },
   {
     "Class":"Predicate",
-    "Name":"http:\/\/schema.org\/publicTransportClosuresInfo-input",
+    "Name":"https://schema.org/publicTransportClosuresInfo-input",
     "Domain Bucket":"< 1K"
   },
   {
     "Class":"Predicate",
-    "Name":"http:\/\/schema.org\/publicTransportClosuresInfo-output",
+    "Name":"https://schema.org/publicTransportClosuresInfo-output",
     "Domain Bucket":"< 1K"
   },
   {
     "Class":"Predicate",
-    "Name":"http:\/\/schema.org\/publication",
+    "Name":"https://schema.org/publication",
     "Domain Bucket":"1K - 10K"
   },
   {
     "Class":"Predicate",
-    "Name":"http:\/\/schema.org\/publication-input",
+    "Name":"https://schema.org/publication-input",
     "Domain Bucket":"< 1K"
   },
   {
     "Class":"Predicate",
-    "Name":"http:\/\/schema.org\/publication-output",
+    "Name":"https://schema.org/publication-output",
     "Domain Bucket":"< 1K"
   },
   {
     "Class":"Predicate",
-    "Name":"http:\/\/schema.org\/publicationType",
+    "Name":"https://schema.org/publicationType",
     "Domain Bucket":"< 1K"
   },
   {
     "Class":"Predicate",
-    "Name":"http:\/\/schema.org\/publicationType-input",
+    "Name":"https://schema.org/publicationType-input",
     "Domain Bucket":"< 1K"
   },
   {
     "Class":"Predicate",
-    "Name":"http:\/\/schema.org\/publicationType-output",
+    "Name":"https://schema.org/publicationType-output",
     "Domain Bucket":"< 1K"
   },
   {
     "Class":"Predicate",
-    "Name":"http:\/\/schema.org\/publishedBy",
+    "Name":"https://schema.org/publishedBy",
     "Domain Bucket":"< 1K"
   },
   {
     "Class":"Predicate",
-    "Name":"http:\/\/schema.org\/publishedBy-input",
+    "Name":"https://schema.org/publishedBy-input",
     "Domain Bucket":"< 1K"
   },
   {
     "Class":"Predicate",
-    "Name":"http:\/\/schema.org\/publishedBy-output",
+    "Name":"https://schema.org/publishedBy-output",
     "Domain Bucket":"< 1K"
   },
   {
     "Class":"Predicate",
-    "Name":"http:\/\/schema.org\/publishedOn",
+    "Name":"https://schema.org/publishedOn",
     "Domain Bucket":"< 1K"
   },
   {
     "Class":"Predicate",
-    "Name":"http:\/\/schema.org\/publishedOn-input",
+    "Name":"https://schema.org/publishedOn-input",
     "Domain Bucket":"< 1K"
   },
   {
     "Class":"Predicate",
-    "Name":"http:\/\/schema.org\/publishedOn-output",
+    "Name":"https://schema.org/publishedOn-output",
     "Domain Bucket":"< 1K"
   },
   {
     "Class":"Predicate",
-    "Name":"http:\/\/schema.org\/publisher",
+    "Name":"https://schema.org/publisher",
     "Domain Bucket":"10M+"
   },
   {
     "Class":"Predicate",
-    "Name":"http:\/\/schema.org\/publisher-input",
+    "Name":"https://schema.org/publisher-input",
     "Domain Bucket":"< 1K"
   },
   {
     "Class":"Predicate",
-    "Name":"http:\/\/schema.org\/publisher-output",
+    "Name":"https://schema.org/publisher-output",
     "Domain Bucket":"< 1K"
   },
   {
     "Class":"Predicate",
-    "Name":"http:\/\/schema.org\/publisherImprint",
+    "Name":"https://schema.org/publisherImprint",
     "Domain Bucket":"< 1K"
   },
   {
     "Class":"Predicate",
-    "Name":"http:\/\/schema.org\/publisherImprint-input",
+    "Name":"https://schema.org/publisherImprint-input",
     "Domain Bucket":"< 1K"
   },
   {
     "Class":"Predicate",
-    "Name":"http:\/\/schema.org\/publisherImprint-output",
+    "Name":"https://schema.org/publisherImprint-output",
     "Domain Bucket":"< 1K"
   },
   {
     "Class":"Predicate",
-    "Name":"http:\/\/schema.org\/publishingPrinciples",
+    "Name":"https://schema.org/publishingPrinciples",
     "Domain Bucket":"10K - 100K"
   },
   {
     "Class":"Predicate",
-    "Name":"http:\/\/schema.org\/publishingPrinciples-input",
+    "Name":"https://schema.org/publishingPrinciples-input",
     "Domain Bucket":"< 1K"
   },
   {
     "Class":"Predicate",
-    "Name":"http:\/\/schema.org\/publishingPrinciples-output",
+    "Name":"https://schema.org/publishingPrinciples-output",
     "Domain Bucket":"< 1K"
   },
   {
     "Class":"Predicate",
-    "Name":"http:\/\/schema.org\/purchaseDate",
+    "Name":"https://schema.org/purchaseDate",
     "Domain Bucket":"1K - 10K"
   },
   {
     "Class":"Predicate",
-    "Name":"http:\/\/schema.org\/purchaseDate-input",
+    "Name":"https://schema.org/purchaseDate-input",
     "Domain Bucket":"< 1K"
   },
   {
     "Class":"Predicate",
-    "Name":"http:\/\/schema.org\/purchaseDate-output",
+    "Name":"https://schema.org/purchaseDate-output",
     "Domain Bucket":"< 1K"
   },
   {
     "Class":"Predicate",
-    "Name":"http:\/\/schema.org\/purchasePriceLimit",
+    "Name":"https://schema.org/purchasePriceLimit",
     "Domain Bucket":"< 1K"
   },
   {
     "Class":"Predicate",
-    "Name":"http:\/\/schema.org\/purchasePriceLimit-input",
+    "Name":"https://schema.org/purchasePriceLimit-input",
     "Domain Bucket":"< 1K"
   },
   {
     "Class":"Predicate",
-    "Name":"http:\/\/schema.org\/purchasePriceLimit-output",
+    "Name":"https://schema.org/purchasePriceLimit-output",
     "Domain Bucket":"< 1K"
   },
   {
     "Class":"Predicate",
-    "Name":"http:\/\/schema.org\/purchaseType",
+    "Name":"https://schema.org/purchaseType",
     "Domain Bucket":"< 1K"
   },
   {
     "Class":"Predicate",
-    "Name":"http:\/\/schema.org\/purchaseType-input",
+    "Name":"https://schema.org/purchaseType-input",
     "Domain Bucket":"< 1K"
   },
   {
     "Class":"Predicate",
-    "Name":"http:\/\/schema.org\/purchaseType-output",
+    "Name":"https://schema.org/purchaseType-output",
     "Domain Bucket":"< 1K"
   },
   {
     "Class":"Predicate",
-    "Name":"http:\/\/schema.org\/qualifications",
+    "Name":"https://schema.org/qualifications",
     "Domain Bucket":"10K - 100K"
   },
   {
     "Class":"Predicate",
-    "Name":"http:\/\/schema.org\/qualifications-input",
+    "Name":"https://schema.org/qualifications-input",
     "Domain Bucket":"< 1K"
   },
   {
     "Class":"Predicate",
-    "Name":"http:\/\/schema.org\/qualifications-output",
+    "Name":"https://schema.org/qualifications-output",
     "Domain Bucket":"< 1K"
   },
   {
     "Class":"Predicate",
-    "Name":"http:\/\/schema.org\/qualifiedExpense",
+    "Name":"https://schema.org/qualifiedExpense",
     "Domain Bucket":"< 1K"
   },
   {
     "Class":"Predicate",
-    "Name":"http:\/\/schema.org\/qualifiedExpense-input",
+    "Name":"https://schema.org/qualifiedExpense-input",
     "Domain Bucket":"< 1K"
   },
   {
     "Class":"Predicate",
-    "Name":"http:\/\/schema.org\/qualifiedExpense-output",
+    "Name":"https://schema.org/qualifiedExpense-output",
     "Domain Bucket":"< 1K"
   },
   {
     "Class":"Predicate",
-    "Name":"http:\/\/schema.org\/quarantineGuidelines",
+    "Name":"https://schema.org/quarantineGuidelines",
     "Domain Bucket":"< 1K"
   },
   {
     "Class":"Predicate",
-    "Name":"http:\/\/schema.org\/quarantineGuidelines-input",
+    "Name":"https://schema.org/quarantineGuidelines-input",
     "Domain Bucket":"< 1K"
   },
   {
     "Class":"Predicate",
-    "Name":"http:\/\/schema.org\/quarantineGuidelines-output",
+    "Name":"https://schema.org/quarantineGuidelines-output",
     "Domain Bucket":"< 1K"
   },
   {
     "Class":"Predicate",
-    "Name":"http:\/\/schema.org\/query",
+    "Name":"https://schema.org/query",
     "Domain Bucket":"10K - 100K"
   },
   {
     "Class":"Predicate",
-    "Name":"http:\/\/schema.org\/query-input",
+    "Name":"https://schema.org/query-input",
     "Domain Bucket":"10M+"
   },
   {
     "Class":"Predicate",
-    "Name":"http:\/\/schema.org\/query-output",
+    "Name":"https://schema.org/query-output",
     "Domain Bucket":"< 1K"
   },
   {
     "Class":"Predicate",
-    "Name":"http:\/\/schema.org\/quest",
+    "Name":"https://schema.org/quest",
     "Domain Bucket":"< 1K"
   },
   {
     "Class":"Predicate",
-    "Name":"http:\/\/schema.org\/quest-input",
+    "Name":"https://schema.org/quest-input",
     "Domain Bucket":"< 1K"
   },
   {
     "Class":"Predicate",
-    "Name":"http:\/\/schema.org\/quest-output",
+    "Name":"https://schema.org/quest-output",
     "Domain Bucket":"< 1K"
   },
   {
     "Class":"Predicate",
-    "Name":"http:\/\/schema.org\/question",
+    "Name":"https://schema.org/question",
     "Domain Bucket":"< 1K"
   },
   {
     "Class":"Predicate",
-    "Name":"http:\/\/schema.org\/question-input",
+    "Name":"https://schema.org/question-input",
     "Domain Bucket":"< 1K"
   },
   {
     "Class":"Predicate",
-    "Name":"http:\/\/schema.org\/question-output",
+    "Name":"https://schema.org/question-output",
     "Domain Bucket":"< 1K"
   },
   {
     "Class":"Predicate",
-    "Name":"http:\/\/schema.org\/rangeIncludes",
+    "Name":"https://schema.org/rangeIncludes",
     "Domain Bucket":"< 1K"
   },
   {
     "Class":"Predicate",
-    "Name":"http:\/\/schema.org\/rangeIncludes-input",
+    "Name":"https://schema.org/rangeIncludes-input",
     "Domain Bucket":"< 1K"
   },
   {
     "Class":"Predicate",
-    "Name":"http:\/\/schema.org\/rangeIncludes-output",
+    "Name":"https://schema.org/rangeIncludes-output",
     "Domain Bucket":"< 1K"
   },
   {
     "Class":"Predicate",
-    "Name":"http:\/\/schema.org\/ratingCount",
+    "Name":"https://schema.org/ratingCount",
     "Domain Bucket":"1M - 10M"
   },
   {
     "Class":"Predicate",
-    "Name":"http:\/\/schema.org\/ratingCount-input",
+    "Name":"https://schema.org/ratingCount-input",
     "Domain Bucket":"< 1K"
   },
   {
     "Class":"Predicate",
-    "Name":"http:\/\/schema.org\/ratingCount-output",
+    "Name":"https://schema.org/ratingCount-output",
     "Domain Bucket":"< 1K"
   },
   {
     "Class":"Predicate",
-    "Name":"http:\/\/schema.org\/ratingExplanation",
+    "Name":"https://schema.org/ratingExplanation",
     "Domain Bucket":"1K - 10K"
   },
   {
     "Class":"Predicate",
-    "Name":"http:\/\/schema.org\/ratingExplanation-input",
+    "Name":"https://schema.org/ratingExplanation-input",
     "Domain Bucket":"< 1K"
   },
   {
     "Class":"Predicate",
-    "Name":"http:\/\/schema.org\/ratingExplanation-output",
+    "Name":"https://schema.org/ratingExplanation-output",
     "Domain Bucket":"< 1K"
   },
   {
     "Class":"Predicate",
-    "Name":"http:\/\/schema.org\/ratingValue",
+    "Name":"https://schema.org/ratingValue",
     "Domain Bucket":"1M - 10M"
   },
   {
     "Class":"Predicate",
-    "Name":"http:\/\/schema.org\/ratingValue-input",
+    "Name":"https://schema.org/ratingValue-input",
     "Domain Bucket":"< 1K"
   },
   {
     "Class":"Predicate",
-    "Name":"http:\/\/schema.org\/ratingValue-output",
+    "Name":"https://schema.org/ratingValue-output",
     "Domain Bucket":"< 1K"
   },
   {
     "Class":"Predicate",
-    "Name":"http:\/\/schema.org\/readBy",
+    "Name":"https://schema.org/readBy",
     "Domain Bucket":"< 1K"
   },
   {
     "Class":"Predicate",
-    "Name":"http:\/\/schema.org\/readBy-input",
+    "Name":"https://schema.org/readBy-input",
     "Domain Bucket":"< 1K"
   },
   {
     "Class":"Predicate",
-    "Name":"http:\/\/schema.org\/readBy-output",
+    "Name":"https://schema.org/readBy-output",
     "Domain Bucket":"< 1K"
   },
   {
     "Class":"Predicate",
-    "Name":"http:\/\/schema.org\/readonlyValue",
+    "Name":"https://schema.org/readonlyValue",
     "Domain Bucket":"< 1K"
   },
   {
     "Class":"Predicate",
-    "Name":"http:\/\/schema.org\/readonlyValue-input",
+    "Name":"https://schema.org/readonlyValue-input",
     "Domain Bucket":"< 1K"
   },
   {
     "Class":"Predicate",
-    "Name":"http:\/\/schema.org\/readonlyValue-output",
+    "Name":"https://schema.org/readonlyValue-output",
     "Domain Bucket":"< 1K"
   },
   {
     "Class":"Predicate",
-    "Name":"http:\/\/schema.org\/realEstateAgent",
+    "Name":"https://schema.org/realEstateAgent",
     "Domain Bucket":"< 1K"
   },
   {
     "Class":"Predicate",
-    "Name":"http:\/\/schema.org\/realEstateAgent-input",
+    "Name":"https://schema.org/realEstateAgent-input",
     "Domain Bucket":"< 1K"
   },
   {
     "Class":"Predicate",
-    "Name":"http:\/\/schema.org\/realEstateAgent-output",
+    "Name":"https://schema.org/realEstateAgent-output",
     "Domain Bucket":"< 1K"
   },
   {
     "Class":"Predicate",
-    "Name":"http:\/\/schema.org\/recipe",
+    "Name":"https://schema.org/recipe",
     "Domain Bucket":"< 1K"
   },
   {
     "Class":"Predicate",
-    "Name":"http:\/\/schema.org\/recipe-input",
+    "Name":"https://schema.org/recipe-input",
     "Domain Bucket":"< 1K"
   },
   {
     "Class":"Predicate",
-    "Name":"http:\/\/schema.org\/recipe-output",
+    "Name":"https://schema.org/recipe-output",
     "Domain Bucket":"< 1K"
   },
   {
     "Class":"Predicate",
-    "Name":"http:\/\/schema.org\/recipeCategory",
+    "Name":"https://schema.org/recipeCategory",
     "Domain Bucket":"10K - 100K"
   },
   {
     "Class":"Predicate",
-    "Name":"http:\/\/schema.org\/recipeCategory-input",
+    "Name":"https://schema.org/recipeCategory-input",
     "Domain Bucket":"< 1K"
   },
   {
     "Class":"Predicate",
-    "Name":"http:\/\/schema.org\/recipeCategory-output",
+    "Name":"https://schema.org/recipeCategory-output",
     "Domain Bucket":"< 1K"
   },
   {
     "Class":"Predicate",
-    "Name":"http:\/\/schema.org\/recipeCuisine",
+    "Name":"https://schema.org/recipeCuisine",
     "Domain Bucket":"10K - 100K"
   },
   {
     "Class":"Predicate",
-    "Name":"http:\/\/schema.org\/recipeCuisine-input",
+    "Name":"https://schema.org/recipeCuisine-input",
     "Domain Bucket":"< 1K"
   },
   {
     "Class":"Predicate",
-    "Name":"http:\/\/schema.org\/recipeCuisine-output",
+    "Name":"https://schema.org/recipeCuisine-output",
     "Domain Bucket":"< 1K"
   },
   {
     "Class":"Predicate",
-    "Name":"http:\/\/schema.org\/recipeIngredient",
+    "Name":"https://schema.org/recipeIngredient",
     "Domain Bucket":"10K - 100K"
   },
   {
     "Class":"Predicate",
-    "Name":"http:\/\/schema.org\/recipeIngredient-input",
+    "Name":"https://schema.org/recipeIngredient-input",
     "Domain Bucket":"< 1K"
   },
   {
     "Class":"Predicate",
-    "Name":"http:\/\/schema.org\/recipeIngredient-output",
+    "Name":"https://schema.org/recipeIngredient-output",
     "Domain Bucket":"< 1K"
   },
   {
     "Class":"Predicate",
-    "Name":"http:\/\/schema.org\/recipeInstructions",
+    "Name":"https://schema.org/recipeInstructions",
     "Domain Bucket":"10K - 100K"
   },
   {
     "Class":"Predicate",
-    "Name":"http:\/\/schema.org\/recipeInstructions-input",
+    "Name":"https://schema.org/recipeInstructions-input",
     "Domain Bucket":"< 1K"
   },
   {
     "Class":"Predicate",
-    "Name":"http:\/\/schema.org\/recipeInstructions-output",
+    "Name":"https://schema.org/recipeInstructions-output",
     "Domain Bucket":"< 1K"
   },
   {
     "Class":"Predicate",
-    "Name":"http:\/\/schema.org\/recipeYield",
+    "Name":"https://schema.org/recipeYield",
     "Domain Bucket":"10K - 100K"
   },
   {
     "Class":"Predicate",
-    "Name":"http:\/\/schema.org\/recipeYield-input",
+    "Name":"https://schema.org/recipeYield-input",
     "Domain Bucket":"< 1K"
   },
   {
     "Class":"Predicate",
-    "Name":"http:\/\/schema.org\/recipeYield-output",
+    "Name":"https://schema.org/recipeYield-output",
     "Domain Bucket":"< 1K"
   },
   {
     "Class":"Predicate",
-    "Name":"http:\/\/schema.org\/recipient",
+    "Name":"https://schema.org/recipient",
     "Domain Bucket":"1K - 10K"
   },
   {
     "Class":"Predicate",
-    "Name":"http:\/\/schema.org\/recipient-input",
+    "Name":"https://schema.org/recipient-input",
     "Domain Bucket":"< 1K"
   },
   {
     "Class":"Predicate",
-    "Name":"http:\/\/schema.org\/recipient-output",
+    "Name":"https://schema.org/recipient-output",
     "Domain Bucket":"< 1K"
   },
   {
     "Class":"Predicate",
-    "Name":"http:\/\/schema.org\/recognizedBy",
+    "Name":"https://schema.org/recognizedBy",
     "Domain Bucket":"10K - 100K"
   },
   {
     "Class":"Predicate",
-    "Name":"http:\/\/schema.org\/recognizedBy-input",
+    "Name":"https://schema.org/recognizedBy-input",
     "Domain Bucket":"< 1K"
   },
   {
     "Class":"Predicate",
-    "Name":"http:\/\/schema.org\/recognizedBy-output",
+    "Name":"https://schema.org/recognizedBy-output",
     "Domain Bucket":"< 1K"
   },
   {
     "Class":"Predicate",
-    "Name":"http:\/\/schema.org\/recognizingAuthority",
+    "Name":"https://schema.org/recognizingAuthority",
     "Domain Bucket":"1K - 10K"
   },
   {
     "Class":"Predicate",
-    "Name":"http:\/\/schema.org\/recognizingAuthority-input",
+    "Name":"https://schema.org/recognizingAuthority-input",
     "Domain Bucket":"< 1K"
   },
   {
     "Class":"Predicate",
-    "Name":"http:\/\/schema.org\/recognizingAuthority-output",
+    "Name":"https://schema.org/recognizingAuthority-output",
     "Domain Bucket":"< 1K"
   },
   {
     "Class":"Predicate",
-    "Name":"http:\/\/schema.org\/recommendationStrength",
+    "Name":"https://schema.org/recommendationStrength",
     "Domain Bucket":"< 1K"
   },
   {
     "Class":"Predicate",
-    "Name":"http:\/\/schema.org\/recommendationStrength-input",
+    "Name":"https://schema.org/recommendationStrength-input",
     "Domain Bucket":"< 1K"
   },
   {
     "Class":"Predicate",
-    "Name":"http:\/\/schema.org\/recommendationStrength-output",
+    "Name":"https://schema.org/recommendationStrength-output",
     "Domain Bucket":"< 1K"
   },
   {
     "Class":"Predicate",
-    "Name":"http:\/\/schema.org\/recommendedIntake",
+    "Name":"https://schema.org/recommendedIntake",
     "Domain Bucket":"< 1K"
   },
   {
     "Class":"Predicate",
-    "Name":"http:\/\/schema.org\/recommendedIntake-input",
+    "Name":"https://schema.org/recommendedIntake-input",
     "Domain Bucket":"< 1K"
   },
   {
     "Class":"Predicate",
-    "Name":"http:\/\/schema.org\/recommendedIntake-output",
+    "Name":"https://schema.org/recommendedIntake-output",
     "Domain Bucket":"< 1K"
   },
   {
     "Class":"Predicate",
-    "Name":"http:\/\/schema.org\/recordLabel",
+    "Name":"https://schema.org/recordLabel",
     "Domain Bucket":"1K - 10K"
   },
   {
     "Class":"Predicate",
-    "Name":"http:\/\/schema.org\/recordLabel-input",
+    "Name":"https://schema.org/recordLabel-input",
     "Domain Bucket":"< 1K"
   },
   {
     "Class":"Predicate",
-    "Name":"http:\/\/schema.org\/recordLabel-output",
+    "Name":"https://schema.org/recordLabel-output",
     "Domain Bucket":"< 1K"
   },
   {
     "Class":"Predicate",
-    "Name":"http:\/\/schema.org\/recordedAs",
+    "Name":"https://schema.org/recordedAs",
     "Domain Bucket":"< 1K"
   },
   {
     "Class":"Predicate",
-    "Name":"http:\/\/schema.org\/recordedAs-input",
+    "Name":"https://schema.org/recordedAs-input",
     "Domain Bucket":"< 1K"
   },
   {
     "Class":"Predicate",
-    "Name":"http:\/\/schema.org\/recordedAs-output",
+    "Name":"https://schema.org/recordedAs-output",
     "Domain Bucket":"< 1K"
   },
   {
     "Class":"Predicate",
-    "Name":"http:\/\/schema.org\/recordedAt",
+    "Name":"https://schema.org/recordedAt",
     "Domain Bucket":"< 1K"
   },
   {
     "Class":"Predicate",
-    "Name":"http:\/\/schema.org\/recordedAt-input",
+    "Name":"https://schema.org/recordedAt-input",
     "Domain Bucket":"< 1K"
   },
   {
     "Class":"Predicate",
-    "Name":"http:\/\/schema.org\/recordedAt-output",
+    "Name":"https://schema.org/recordedAt-output",
     "Domain Bucket":"< 1K"
   },
   {
     "Class":"Predicate",
-    "Name":"http:\/\/schema.org\/recordedIn",
+    "Name":"https://schema.org/recordedIn",
     "Domain Bucket":"< 1K"
   },
   {
     "Class":"Predicate",
-    "Name":"http:\/\/schema.org\/recordedIn-input",
+    "Name":"https://schema.org/recordedIn-input",
     "Domain Bucket":"< 1K"
   },
   {
     "Class":"Predicate",
-    "Name":"http:\/\/schema.org\/recordedIn-output",
+    "Name":"https://schema.org/recordedIn-output",
     "Domain Bucket":"< 1K"
   },
   {
     "Class":"Predicate",
-    "Name":"http:\/\/schema.org\/recordingOf",
+    "Name":"https://schema.org/recordingOf",
     "Domain Bucket":"1K - 10K"
   },
   {
     "Class":"Predicate",
-    "Name":"http:\/\/schema.org\/recordingOf-input",
+    "Name":"https://schema.org/recordingOf-input",
     "Domain Bucket":"< 1K"
   },
   {
     "Class":"Predicate",
-    "Name":"http:\/\/schema.org\/recordingOf-output",
+    "Name":"https://schema.org/recordingOf-output",
     "Domain Bucket":"< 1K"
   },
   {
     "Class":"Predicate",
-    "Name":"http:\/\/schema.org\/recourseLoan",
+    "Name":"https://schema.org/recourseLoan",
     "Domain Bucket":"< 1K"
   },
   {
     "Class":"Predicate",
-    "Name":"http:\/\/schema.org\/recourseLoan-input",
+    "Name":"https://schema.org/recourseLoan-input",
     "Domain Bucket":"< 1K"
   },
   {
     "Class":"Predicate",
-    "Name":"http:\/\/schema.org\/recourseLoan-output",
+    "Name":"https://schema.org/recourseLoan-output",
     "Domain Bucket":"< 1K"
   },
   {
     "Class":"Predicate",
-    "Name":"http:\/\/schema.org\/referee",
+    "Name":"https://schema.org/referee",
     "Domain Bucket":"< 1K"
   },
   {
     "Class":"Predicate",
-    "Name":"http:\/\/schema.org\/referee-input",
+    "Name":"https://schema.org/referee-input",
     "Domain Bucket":"< 1K"
   },
   {
     "Class":"Predicate",
-    "Name":"http:\/\/schema.org\/referee-output",
+    "Name":"https://schema.org/referee-output",
     "Domain Bucket":"< 1K"
   },
   {
     "Class":"Predicate",
-    "Name":"http:\/\/schema.org\/referenceQuantity",
+    "Name":"https://schema.org/referenceQuantity",
     "Domain Bucket":"10K - 100K"
   },
   {
     "Class":"Predicate",
-    "Name":"http:\/\/schema.org\/referenceQuantity-input",
+    "Name":"https://schema.org/referenceQuantity-input",
     "Domain Bucket":"< 1K"
   },
   {
     "Class":"Predicate",
-    "Name":"http:\/\/schema.org\/referenceQuantity-output",
+    "Name":"https://schema.org/referenceQuantity-output",
     "Domain Bucket":"< 1K"
   },
   {
     "Class":"Predicate",
-    "Name":"http:\/\/schema.org\/referencesOrder",
+    "Name":"https://schema.org/referencesOrder",
     "Domain Bucket":"< 1K"
   },
   {
     "Class":"Predicate",
-    "Name":"http:\/\/schema.org\/referencesOrder-input",
+    "Name":"https://schema.org/referencesOrder-input",
     "Domain Bucket":"< 1K"
   },
   {
     "Class":"Predicate",
-    "Name":"http:\/\/schema.org\/referencesOrder-output",
+    "Name":"https://schema.org/referencesOrder-output",
     "Domain Bucket":"< 1K"
   },
   {
     "Class":"Predicate",
-    "Name":"http:\/\/schema.org\/refundType",
+    "Name":"https://schema.org/refundType",
     "Domain Bucket":"10K - 100K"
   },
   {
     "Class":"Predicate",
-    "Name":"http:\/\/schema.org\/refundType-input",
+    "Name":"https://schema.org/refundType-input",
     "Domain Bucket":"< 1K"
   },
   {
     "Class":"Predicate",
-    "Name":"http:\/\/schema.org\/refundType-output",
+    "Name":"https://schema.org/refundType-output",
     "Domain Bucket":"< 1K"
   },
   {
     "Class":"Predicate",
-    "Name":"http:\/\/schema.org\/regionDrained",
+    "Name":"https://schema.org/regionDrained",
     "Domain Bucket":"< 1K"
   },
   {
     "Class":"Predicate",
-    "Name":"http:\/\/schema.org\/regionDrained-input",
+    "Name":"https://schema.org/regionDrained-input",
     "Domain Bucket":"< 1K"
   },
   {
     "Class":"Predicate",
-    "Name":"http:\/\/schema.org\/regionDrained-output",
+    "Name":"https://schema.org/regionDrained-output",
     "Domain Bucket":"< 1K"
   },
   {
     "Class":"Predicate",
-    "Name":"http:\/\/schema.org\/regionsAllowed",
+    "Name":"https://schema.org/regionsAllowed",
     "Domain Bucket":"1K - 10K"
   },
   {
     "Class":"Predicate",
-    "Name":"http:\/\/schema.org\/regionsAllowed-input",
+    "Name":"https://schema.org/regionsAllowed-input",
     "Domain Bucket":"< 1K"
   },
   {
     "Class":"Predicate",
-    "Name":"http:\/\/schema.org\/regionsAllowed-output",
+    "Name":"https://schema.org/regionsAllowed-output",
     "Domain Bucket":"< 1K"
   },
   {
     "Class":"Predicate",
-    "Name":"http:\/\/schema.org\/relatedAnatomy",
+    "Name":"https://schema.org/relatedAnatomy",
     "Domain Bucket":"< 1K"
   },
   {
     "Class":"Predicate",
-    "Name":"http:\/\/schema.org\/relatedAnatomy-input",
+    "Name":"https://schema.org/relatedAnatomy-input",
     "Domain Bucket":"< 1K"
   },
   {
     "Class":"Predicate",
-    "Name":"http:\/\/schema.org\/relatedAnatomy-output",
+    "Name":"https://schema.org/relatedAnatomy-output",
     "Domain Bucket":"< 1K"
   },
   {
     "Class":"Predicate",
-    "Name":"http:\/\/schema.org\/relatedCondition",
+    "Name":"https://schema.org/relatedCondition",
     "Domain Bucket":"< 1K"
   },
   {
     "Class":"Predicate",
-    "Name":"http:\/\/schema.org\/relatedCondition-input",
+    "Name":"https://schema.org/relatedCondition-input",
     "Domain Bucket":"< 1K"
   },
   {
     "Class":"Predicate",
-    "Name":"http:\/\/schema.org\/relatedCondition-output",
+    "Name":"https://schema.org/relatedCondition-output",
     "Domain Bucket":"< 1K"
   },
   {
     "Class":"Predicate",
-    "Name":"http:\/\/schema.org\/relatedDrug",
+    "Name":"https://schema.org/relatedDrug",
     "Domain Bucket":"< 1K"
   },
   {
     "Class":"Predicate",
-    "Name":"http:\/\/schema.org\/relatedDrug-input",
+    "Name":"https://schema.org/relatedDrug-input",
     "Domain Bucket":"< 1K"
   },
   {
     "Class":"Predicate",
-    "Name":"http:\/\/schema.org\/relatedDrug-output",
+    "Name":"https://schema.org/relatedDrug-output",
     "Domain Bucket":"< 1K"
   },
   {
     "Class":"Predicate",
-    "Name":"http:\/\/schema.org\/relatedLink",
+    "Name":"https://schema.org/relatedLink",
     "Domain Bucket":"10K - 100K"
   },
   {
     "Class":"Predicate",
-    "Name":"http:\/\/schema.org\/relatedLink-input",
+    "Name":"https://schema.org/relatedLink-input",
     "Domain Bucket":"< 1K"
   },
   {
     "Class":"Predicate",
-    "Name":"http:\/\/schema.org\/relatedLink-output",
+    "Name":"https://schema.org/relatedLink-output",
     "Domain Bucket":"< 1K"
   },
   {
     "Class":"Predicate",
-    "Name":"http:\/\/schema.org\/relatedStructure",
+    "Name":"https://schema.org/relatedStructure",
     "Domain Bucket":"< 1K"
   },
   {
     "Class":"Predicate",
-    "Name":"http:\/\/schema.org\/relatedStructure-input",
+    "Name":"https://schema.org/relatedStructure-input",
     "Domain Bucket":"< 1K"
   },
   {
     "Class":"Predicate",
-    "Name":"http:\/\/schema.org\/relatedStructure-output",
+    "Name":"https://schema.org/relatedStructure-output",
     "Domain Bucket":"< 1K"
   },
   {
     "Class":"Predicate",
-    "Name":"http:\/\/schema.org\/relatedTherapy",
+    "Name":"https://schema.org/relatedTherapy",
     "Domain Bucket":"< 1K"
   },
   {
     "Class":"Predicate",
-    "Name":"http:\/\/schema.org\/relatedTherapy-input",
+    "Name":"https://schema.org/relatedTherapy-input",
     "Domain Bucket":"< 1K"
   },
   {
     "Class":"Predicate",
-    "Name":"http:\/\/schema.org\/relatedTherapy-output",
+    "Name":"https://schema.org/relatedTherapy-output",
     "Domain Bucket":"< 1K"
   },
   {
     "Class":"Predicate",
-    "Name":"http:\/\/schema.org\/relatedTo",
+    "Name":"https://schema.org/relatedTo",
     "Domain Bucket":"< 1K"
   },
   {
     "Class":"Predicate",
-    "Name":"http:\/\/schema.org\/relatedTo-input",
+    "Name":"https://schema.org/relatedTo-input",
     "Domain Bucket":"< 1K"
   },
   {
     "Class":"Predicate",
-    "Name":"http:\/\/schema.org\/relatedTo-output",
+    "Name":"https://schema.org/relatedTo-output",
     "Domain Bucket":"< 1K"
   },
   {
     "Class":"Predicate",
-    "Name":"http:\/\/schema.org\/releaseDate",
+    "Name":"https://schema.org/releaseDate",
     "Domain Bucket":"10K - 100K"
   },
   {
     "Class":"Predicate",
-    "Name":"http:\/\/schema.org\/releaseDate-input",
+    "Name":"https://schema.org/releaseDate-input",
     "Domain Bucket":"< 1K"
   },
   {
     "Class":"Predicate",
-    "Name":"http:\/\/schema.org\/releaseDate-output",
+    "Name":"https://schema.org/releaseDate-output",
     "Domain Bucket":"< 1K"
   },
   {
     "Class":"Predicate",
-    "Name":"http:\/\/schema.org\/releaseNotes",
+    "Name":"https://schema.org/releaseNotes",
     "Domain Bucket":"10K - 100K"
   },
   {
     "Class":"Predicate",
-    "Name":"http:\/\/schema.org\/releaseNotes-input",
+    "Name":"https://schema.org/releaseNotes-input",
     "Domain Bucket":"< 1K"
   },
   {
     "Class":"Predicate",
-    "Name":"http:\/\/schema.org\/releaseNotes-output",
+    "Name":"https://schema.org/releaseNotes-output",
     "Domain Bucket":"< 1K"
   },
   {
     "Class":"Predicate",
-    "Name":"http:\/\/schema.org\/releaseOf",
+    "Name":"https://schema.org/releaseOf",
     "Domain Bucket":"< 1K"
   },
   {
     "Class":"Predicate",
-    "Name":"http:\/\/schema.org\/releaseOf-input",
+    "Name":"https://schema.org/releaseOf-input",
     "Domain Bucket":"< 1K"
   },
   {
     "Class":"Predicate",
-    "Name":"http:\/\/schema.org\/releaseOf-output",
+    "Name":"https://schema.org/releaseOf-output",
     "Domain Bucket":"< 1K"
   },
   {
     "Class":"Predicate",
-    "Name":"http:\/\/schema.org\/releasedEvent",
+    "Name":"https://schema.org/releasedEvent",
     "Domain Bucket":"1K - 10K"
   },
   {
     "Class":"Predicate",
-    "Name":"http:\/\/schema.org\/releasedEvent-input",
+    "Name":"https://schema.org/releasedEvent-input",
     "Domain Bucket":"< 1K"
   },
   {
     "Class":"Predicate",
-    "Name":"http:\/\/schema.org\/releasedEvent-output",
+    "Name":"https://schema.org/releasedEvent-output",
     "Domain Bucket":"< 1K"
   },
   {
     "Class":"Predicate",
-    "Name":"http:\/\/schema.org\/relevantOccupation",
+    "Name":"https://schema.org/relevantOccupation",
     "Domain Bucket":"< 1K"
   },
   {
     "Class":"Predicate",
-    "Name":"http:\/\/schema.org\/relevantOccupation-input",
+    "Name":"https://schema.org/relevantOccupation-input",
     "Domain Bucket":"< 1K"
   },
   {
     "Class":"Predicate",
-    "Name":"http:\/\/schema.org\/relevantOccupation-output",
+    "Name":"https://schema.org/relevantOccupation-output",
     "Domain Bucket":"< 1K"
   },
   {
     "Class":"Predicate",
-    "Name":"http:\/\/schema.org\/relevantSpecialty",
+    "Name":"https://schema.org/relevantSpecialty",
     "Domain Bucket":"1K - 10K"
   },
   {
     "Class":"Predicate",
-    "Name":"http:\/\/schema.org\/relevantSpecialty-input",
+    "Name":"https://schema.org/relevantSpecialty-input",
     "Domain Bucket":"< 1K"
   },
   {
     "Class":"Predicate",
-    "Name":"http:\/\/schema.org\/relevantSpecialty-output",
+    "Name":"https://schema.org/relevantSpecialty-output",
     "Domain Bucket":"< 1K"
   },
   {
     "Class":"Predicate",
-    "Name":"http:\/\/schema.org\/remainingAttendeeCapacity",
+    "Name":"https://schema.org/remainingAttendeeCapacity",
     "Domain Bucket":"1K - 10K"
   },
   {
     "Class":"Predicate",
-    "Name":"http:\/\/schema.org\/remainingAttendeeCapacity-input",
+    "Name":"https://schema.org/remainingAttendeeCapacity-input",
     "Domain Bucket":"< 1K"
   },
   {
     "Class":"Predicate",
-    "Name":"http:\/\/schema.org\/remainingAttendeeCapacity-output",
+    "Name":"https://schema.org/remainingAttendeeCapacity-output",
     "Domain Bucket":"< 1K"
   },
   {
     "Class":"Predicate",
-    "Name":"http:\/\/schema.org\/renegotiableLoan",
+    "Name":"https://schema.org/renegotiableLoan",
     "Domain Bucket":"< 1K"
   },
   {
     "Class":"Predicate",
-    "Name":"http:\/\/schema.org\/renegotiableLoan-input",
+    "Name":"https://schema.org/renegotiableLoan-input",
     "Domain Bucket":"< 1K"
   },
   {
     "Class":"Predicate",
-    "Name":"http:\/\/schema.org\/renegotiableLoan-output",
+    "Name":"https://schema.org/renegotiableLoan-output",
     "Domain Bucket":"< 1K"
   },
   {
     "Class":"Predicate",
-    "Name":"http:\/\/schema.org\/repeatCount",
+    "Name":"https://schema.org/repeatCount",
     "Domain Bucket":"1K - 10K"
   },
   {
     "Class":"Predicate",
-    "Name":"http:\/\/schema.org\/repeatCount-input",
+    "Name":"https://schema.org/repeatCount-input",
     "Domain Bucket":"< 1K"
   },
   {
     "Class":"Predicate",
-    "Name":"http:\/\/schema.org\/repeatCount-output",
+    "Name":"https://schema.org/repeatCount-output",
     "Domain Bucket":"< 1K"
   },
   {
     "Class":"Predicate",
-    "Name":"http:\/\/schema.org\/repeatFrequency",
+    "Name":"https://schema.org/repeatFrequency",
     "Domain Bucket":"10K - 100K"
   },
   {
     "Class":"Predicate",
-    "Name":"http:\/\/schema.org\/repeatFrequency-input",
+    "Name":"https://schema.org/repeatFrequency-input",
     "Domain Bucket":"< 1K"
   },
   {
     "Class":"Predicate",
-    "Name":"http:\/\/schema.org\/repeatFrequency-output",
+    "Name":"https://schema.org/repeatFrequency-output",
     "Domain Bucket":"< 1K"
   },
   {
     "Class":"Predicate",
-    "Name":"http:\/\/schema.org\/repetitions",
+    "Name":"https://schema.org/repetitions",
     "Domain Bucket":"< 1K"
   },
   {
     "Class":"Predicate",
-    "Name":"http:\/\/schema.org\/repetitions-input",
+    "Name":"https://schema.org/repetitions-input",
     "Domain Bucket":"< 1K"
   },
   {
     "Class":"Predicate",
-    "Name":"http:\/\/schema.org\/repetitions-output",
+    "Name":"https://schema.org/repetitions-output",
     "Domain Bucket":"< 1K"
   },
   {
     "Class":"Predicate",
-    "Name":"http:\/\/schema.org\/replacee",
+    "Name":"https://schema.org/replacee",
     "Domain Bucket":"< 1K"
   },
   {
     "Class":"Predicate",
-    "Name":"http:\/\/schema.org\/replacee-input",
+    "Name":"https://schema.org/replacee-input",
     "Domain Bucket":"< 1K"
   },
   {
     "Class":"Predicate",
-    "Name":"http:\/\/schema.org\/replacee-output",
+    "Name":"https://schema.org/replacee-output",
     "Domain Bucket":"< 1K"
   },
   {
     "Class":"Predicate",
-    "Name":"http:\/\/schema.org\/replacer",
+    "Name":"https://schema.org/replacer",
     "Domain Bucket":"< 1K"
   },
   {
     "Class":"Predicate",
-    "Name":"http:\/\/schema.org\/replacer-input",
+    "Name":"https://schema.org/replacer-input",
     "Domain Bucket":"< 1K"
   },
   {
     "Class":"Predicate",
-    "Name":"http:\/\/schema.org\/replacer-output",
+    "Name":"https://schema.org/replacer-output",
     "Domain Bucket":"< 1K"
   },
   {
     "Class":"Predicate",
-    "Name":"http:\/\/schema.org\/replyToUrl",
+    "Name":"https://schema.org/replyToUrl",
     "Domain Bucket":"1K - 10K"
   },
   {
     "Class":"Predicate",
-    "Name":"http:\/\/schema.org\/replyToUrl-input",
+    "Name":"https://schema.org/replyToUrl-input",
     "Domain Bucket":"< 1K"
   },
   {
     "Class":"Predicate",
-    "Name":"http:\/\/schema.org\/replyToUrl-output",
+    "Name":"https://schema.org/replyToUrl-output",
     "Domain Bucket":"< 1K"
   },
   {
     "Class":"Predicate",
-    "Name":"http:\/\/schema.org\/reportNumber",
+    "Name":"https://schema.org/reportNumber",
     "Domain Bucket":"< 1K"
   },
   {
     "Class":"Predicate",
-    "Name":"http:\/\/schema.org\/reportNumber-input",
+    "Name":"https://schema.org/reportNumber-input",
     "Domain Bucket":"< 1K"
   },
   {
     "Class":"Predicate",
-    "Name":"http:\/\/schema.org\/reportNumber-output",
+    "Name":"https://schema.org/reportNumber-output",
     "Domain Bucket":"< 1K"
   },
   {
     "Class":"Predicate",
-    "Name":"http:\/\/schema.org\/representativeOfPage",
+    "Name":"https://schema.org/representativeOfPage",
     "Domain Bucket":"100K - 1M"
   },
   {
     "Class":"Predicate",
-    "Name":"http:\/\/schema.org\/representativeOfPage-input",
+    "Name":"https://schema.org/representativeOfPage-input",
     "Domain Bucket":"< 1K"
   },
   {
     "Class":"Predicate",
-    "Name":"http:\/\/schema.org\/representativeOfPage-output",
+    "Name":"https://schema.org/representativeOfPage-output",
     "Domain Bucket":"< 1K"
   },
   {
     "Class":"Predicate",
-    "Name":"http:\/\/schema.org\/requiredCollateral",
+    "Name":"https://schema.org/requiredCollateral",
     "Domain Bucket":"< 1K"
   },
   {
     "Class":"Predicate",
-    "Name":"http:\/\/schema.org\/requiredCollateral-input",
+    "Name":"https://schema.org/requiredCollateral-input",
     "Domain Bucket":"< 1K"
   },
   {
     "Class":"Predicate",
-    "Name":"http:\/\/schema.org\/requiredCollateral-output",
+    "Name":"https://schema.org/requiredCollateral-output",
     "Domain Bucket":"< 1K"
   },
   {
     "Class":"Predicate",
-    "Name":"http:\/\/schema.org\/requiredGender",
+    "Name":"https://schema.org/requiredGender",
     "Domain Bucket":"< 1K"
   },
   {
     "Class":"Predicate",
-    "Name":"http:\/\/schema.org\/requiredGender-input",
+    "Name":"https://schema.org/requiredGender-input",
     "Domain Bucket":"< 1K"
   },
   {
     "Class":"Predicate",
-    "Name":"http:\/\/schema.org\/requiredGender-output",
+    "Name":"https://schema.org/requiredGender-output",
     "Domain Bucket":"< 1K"
   },
   {
     "Class":"Predicate",
-    "Name":"http:\/\/schema.org\/requiredMaxAge",
+    "Name":"https://schema.org/requiredMaxAge",
     "Domain Bucket":"< 1K"
   },
   {
     "Class":"Predicate",
-    "Name":"http:\/\/schema.org\/requiredMaxAge-input",
+    "Name":"https://schema.org/requiredMaxAge-input",
     "Domain Bucket":"< 1K"
   },
   {
     "Class":"Predicate",
-    "Name":"http:\/\/schema.org\/requiredMaxAge-output",
+    "Name":"https://schema.org/requiredMaxAge-output",
     "Domain Bucket":"< 1K"
   },
   {
     "Class":"Predicate",
-    "Name":"http:\/\/schema.org\/requiredMinAge",
+    "Name":"https://schema.org/requiredMinAge",
     "Domain Bucket":"1K - 10K"
   },
   {
     "Class":"Predicate",
-    "Name":"http:\/\/schema.org\/requiredMinAge-input",
+    "Name":"https://schema.org/requiredMinAge-input",
     "Domain Bucket":"< 1K"
   },
   {
     "Class":"Predicate",
-    "Name":"http:\/\/schema.org\/requiredMinAge-output",
+    "Name":"https://schema.org/requiredMinAge-output",
     "Domain Bucket":"< 1K"
   },
   {
     "Class":"Predicate",
-    "Name":"http:\/\/schema.org\/requiredQuantity",
+    "Name":"https://schema.org/requiredQuantity",
     "Domain Bucket":"1K - 10K"
   },
   {
     "Class":"Predicate",
-    "Name":"http:\/\/schema.org\/requiredQuantity-input",
+    "Name":"https://schema.org/requiredQuantity-input",
     "Domain Bucket":"< 1K"
   },
   {
     "Class":"Predicate",
-    "Name":"http:\/\/schema.org\/requiredQuantity-output",
+    "Name":"https://schema.org/requiredQuantity-output",
     "Domain Bucket":"< 1K"
   },
   {
     "Class":"Predicate",
-    "Name":"http:\/\/schema.org\/requirements",
+    "Name":"https://schema.org/requirements",
     "Domain Bucket":"1K - 10K"
   },
   {
     "Class":"Predicate",
-    "Name":"http:\/\/schema.org\/requirements-input",
+    "Name":"https://schema.org/requirements-input",
     "Domain Bucket":"< 1K"
   },
   {
     "Class":"Predicate",
-    "Name":"http:\/\/schema.org\/requirements-output",
+    "Name":"https://schema.org/requirements-output",
     "Domain Bucket":"< 1K"
   },
   {
     "Class":"Predicate",
-    "Name":"http:\/\/schema.org\/requiresSubscription",
+    "Name":"https://schema.org/requiresSubscription",
     "Domain Bucket":"1K - 10K"
   },
   {
     "Class":"Predicate",
-    "Name":"http:\/\/schema.org\/requiresSubscription-input",
+    "Name":"https://schema.org/requiresSubscription-input",
     "Domain Bucket":"< 1K"
   },
   {
     "Class":"Predicate",
-    "Name":"http:\/\/schema.org\/requiresSubscription-output",
+    "Name":"https://schema.org/requiresSubscription-output",
     "Domain Bucket":"< 1K"
   },
   {
     "Class":"Predicate",
-    "Name":"http:\/\/schema.org\/reservationFor",
+    "Name":"https://schema.org/reservationFor",
     "Domain Bucket":"1K - 10K"
   },
   {
     "Class":"Predicate",
-    "Name":"http:\/\/schema.org\/reservationFor-input",
+    "Name":"https://schema.org/reservationFor-input",
     "Domain Bucket":"< 1K"
   },
   {
     "Class":"Predicate",
-    "Name":"http:\/\/schema.org\/reservationFor-output",
+    "Name":"https://schema.org/reservationFor-output",
     "Domain Bucket":"< 1K"
   },
   {
     "Class":"Predicate",
-    "Name":"http:\/\/schema.org\/reservationId",
+    "Name":"https://schema.org/reservationId",
     "Domain Bucket":"< 1K"
   },
   {
     "Class":"Predicate",
-    "Name":"http:\/\/schema.org\/reservationId-input",
+    "Name":"https://schema.org/reservationId-input",
     "Domain Bucket":"< 1K"
   },
   {
     "Class":"Predicate",
-    "Name":"http:\/\/schema.org\/reservationId-output",
+    "Name":"https://schema.org/reservationId-output",
     "Domain Bucket":"< 1K"
   },
   {
     "Class":"Predicate",
-    "Name":"http:\/\/schema.org\/reservationStatus",
+    "Name":"https://schema.org/reservationStatus",
     "Domain Bucket":"< 1K"
   },
   {
     "Class":"Predicate",
-    "Name":"http:\/\/schema.org\/reservationStatus-input",
+    "Name":"https://schema.org/reservationStatus-input",
     "Domain Bucket":"< 1K"
   },
   {
     "Class":"Predicate",
-    "Name":"http:\/\/schema.org\/reservationStatus-output",
+    "Name":"https://schema.org/reservationStatus-output",
     "Domain Bucket":"< 1K"
   },
   {
     "Class":"Predicate",
-    "Name":"http:\/\/schema.org\/reservedTicket",
+    "Name":"https://schema.org/reservedTicket",
     "Domain Bucket":"< 1K"
   },
   {
     "Class":"Predicate",
-    "Name":"http:\/\/schema.org\/reservedTicket-input",
+    "Name":"https://schema.org/reservedTicket-input",
     "Domain Bucket":"< 1K"
   },
   {
     "Class":"Predicate",
-    "Name":"http:\/\/schema.org\/reservedTicket-output",
+    "Name":"https://schema.org/reservedTicket-output",
     "Domain Bucket":"< 1K"
   },
   {
     "Class":"Predicate",
-    "Name":"http:\/\/schema.org\/responsibilities",
+    "Name":"https://schema.org/responsibilities",
     "Domain Bucket":"10K - 100K"
   },
   {
     "Class":"Predicate",
-    "Name":"http:\/\/schema.org\/responsibilities-input",
+    "Name":"https://schema.org/responsibilities-input",
     "Domain Bucket":"< 1K"
   },
   {
     "Class":"Predicate",
-    "Name":"http:\/\/schema.org\/responsibilities-output",
+    "Name":"https://schema.org/responsibilities-output",
     "Domain Bucket":"< 1K"
   },
   {
     "Class":"Predicate",
-    "Name":"http:\/\/schema.org\/restPeriods",
+    "Name":"https://schema.org/restPeriods",
     "Domain Bucket":"< 1K"
   },
   {
     "Class":"Predicate",
-    "Name":"http:\/\/schema.org\/restPeriods-input",
+    "Name":"https://schema.org/restPeriods-input",
     "Domain Bucket":"< 1K"
   },
   {
     "Class":"Predicate",
-    "Name":"http:\/\/schema.org\/restPeriods-output",
+    "Name":"https://schema.org/restPeriods-output",
     "Domain Bucket":"< 1K"
   },
   {
     "Class":"Predicate",
-    "Name":"http:\/\/schema.org\/restockingFee",
+    "Name":"https://schema.org/restockingFee",
     "Domain Bucket":"1K - 10K"
   },
   {
     "Class":"Predicate",
-    "Name":"http:\/\/schema.org\/restockingFee-input",
+    "Name":"https://schema.org/restockingFee-input",
     "Domain Bucket":"< 1K"
   },
   {
     "Class":"Predicate",
-    "Name":"http:\/\/schema.org\/restockingFee-output",
+    "Name":"https://schema.org/restockingFee-output",
     "Domain Bucket":"< 1K"
   },
   {
     "Class":"Predicate",
-    "Name":"http:\/\/schema.org\/result",
+    "Name":"https://schema.org/result",
     "Domain Bucket":"10K - 100K"
   },
   {
     "Class":"Predicate",
-    "Name":"http:\/\/schema.org\/result-input",
+    "Name":"https://schema.org/result-input",
     "Domain Bucket":"< 1K"
   },
   {
     "Class":"Predicate",
-    "Name":"http:\/\/schema.org\/result-output",
+    "Name":"https://schema.org/result-output",
     "Domain Bucket":"< 1K"
   },
   {
     "Class":"Predicate",
-    "Name":"http:\/\/schema.org\/resultComment",
+    "Name":"https://schema.org/resultComment",
     "Domain Bucket":"< 1K"
   },
   {
     "Class":"Predicate",
-    "Name":"http:\/\/schema.org\/resultComment-input",
+    "Name":"https://schema.org/resultComment-input",
     "Domain Bucket":"< 1K"
   },
   {
     "Class":"Predicate",
-    "Name":"http:\/\/schema.org\/resultComment-output",
+    "Name":"https://schema.org/resultComment-output",
     "Domain Bucket":"< 1K"
   },
   {
     "Class":"Predicate",
-    "Name":"http:\/\/schema.org\/resultReview",
+    "Name":"https://schema.org/resultReview",
     "Domain Bucket":"< 1K"
   },
   {
     "Class":"Predicate",
-    "Name":"http:\/\/schema.org\/resultReview-input",
+    "Name":"https://schema.org/resultReview-input",
     "Domain Bucket":"< 1K"
   },
   {
     "Class":"Predicate",
-    "Name":"http:\/\/schema.org\/resultReview-output",
+    "Name":"https://schema.org/resultReview-output",
     "Domain Bucket":"< 1K"
   },
   {
     "Class":"Predicate",
-    "Name":"http:\/\/schema.org\/returnFees",
+    "Name":"https://schema.org/returnFees",
     "Domain Bucket":"100K - 1M"
   },
   {
     "Class":"Predicate",
-    "Name":"http:\/\/schema.org\/returnFees-input",
+    "Name":"https://schema.org/returnFees-input",
     "Domain Bucket":"< 1K"
   },
   {
     "Class":"Predicate",
-    "Name":"http:\/\/schema.org\/returnFees-output",
+    "Name":"https://schema.org/returnFees-output",
     "Domain Bucket":"< 1K"
   },
   {
     "Class":"Predicate",
-    "Name":"http:\/\/schema.org\/returnLabelSource",
+    "Name":"https://schema.org/returnLabelSource",
     "Domain Bucket":"1K - 10K"
   },
   {
     "Class":"Predicate",
-    "Name":"http:\/\/schema.org\/returnLabelSource-input",
+    "Name":"https://schema.org/returnLabelSource-input",
     "Domain Bucket":"< 1K"
   },
   {
     "Class":"Predicate",
-    "Name":"http:\/\/schema.org\/returnLabelSource-output",
+    "Name":"https://schema.org/returnLabelSource-output",
     "Domain Bucket":"< 1K"
   },
   {
     "Class":"Predicate",
-    "Name":"http:\/\/schema.org\/returnMethod",
+    "Name":"https://schema.org/returnMethod",
     "Domain Bucket":"100K - 1M"
   },
   {
     "Class":"Predicate",
-    "Name":"http:\/\/schema.org\/returnMethod-input",
+    "Name":"https://schema.org/returnMethod-input",
     "Domain Bucket":"< 1K"
   },
   {
     "Class":"Predicate",
-    "Name":"http:\/\/schema.org\/returnMethod-output",
+    "Name":"https://schema.org/returnMethod-output",
     "Domain Bucket":"< 1K"
   },
   {
     "Class":"Predicate",
-    "Name":"http:\/\/schema.org\/returnPolicyCategory",
+    "Name":"https://schema.org/returnPolicyCategory",
     "Domain Bucket":"100K - 1M"
   },
   {
     "Class":"Predicate",
-    "Name":"http:\/\/schema.org\/returnPolicyCategory-input",
+    "Name":"https://schema.org/returnPolicyCategory-input",
     "Domain Bucket":"< 1K"
   },
   {
     "Class":"Predicate",
-    "Name":"http:\/\/schema.org\/returnPolicyCategory-output",
+    "Name":"https://schema.org/returnPolicyCategory-output",
     "Domain Bucket":"< 1K"
   },
   {
     "Class":"Predicate",
-    "Name":"http:\/\/schema.org\/returnPolicyCountry",
+    "Name":"https://schema.org/returnPolicyCountry",
     "Domain Bucket":"10K - 100K"
   },
   {
     "Class":"Predicate",
-    "Name":"http:\/\/schema.org\/returnPolicyCountry-input",
+    "Name":"https://schema.org/returnPolicyCountry-input",
     "Domain Bucket":"< 1K"
   },
   {
     "Class":"Predicate",
-    "Name":"http:\/\/schema.org\/returnPolicyCountry-output",
+    "Name":"https://schema.org/returnPolicyCountry-output",
     "Domain Bucket":"< 1K"
   },
   {
     "Class":"Predicate",
-    "Name":"http:\/\/schema.org\/returnPolicySeasonalOverride",
+    "Name":"https://schema.org/returnPolicySeasonalOverride",
     "Domain Bucket":"1K - 10K"
   },
   {
     "Class":"Predicate",
-    "Name":"http:\/\/schema.org\/returnPolicySeasonalOverride-input",
+    "Name":"https://schema.org/returnPolicySeasonalOverride-input",
     "Domain Bucket":"< 1K"
   },
   {
     "Class":"Predicate",
-    "Name":"http:\/\/schema.org\/returnPolicySeasonalOverride-output",
+    "Name":"https://schema.org/returnPolicySeasonalOverride-output",
     "Domain Bucket":"< 1K"
   },
   {
     "Class":"Predicate",
-    "Name":"http:\/\/schema.org\/returnShippingFeesAmount",
+    "Name":"https://schema.org/returnShippingFeesAmount",
     "Domain Bucket":"10K - 100K"
   },
   {
     "Class":"Predicate",
-    "Name":"http:\/\/schema.org\/returnShippingFeesAmount-input",
+    "Name":"https://schema.org/returnShippingFeesAmount-input",
     "Domain Bucket":"< 1K"
   },
   {
     "Class":"Predicate",
-    "Name":"http:\/\/schema.org\/returnShippingFeesAmount-output",
+    "Name":"https://schema.org/returnShippingFeesAmount-output",
     "Domain Bucket":"< 1K"
   },
   {
     "Class":"Predicate",
-    "Name":"http:\/\/schema.org\/review",
+    "Name":"https://schema.org/review",
     "Domain Bucket":"1M - 10M"
   },
   {
     "Class":"Predicate",
-    "Name":"http:\/\/schema.org\/review-input",
+    "Name":"https://schema.org/review-input",
     "Domain Bucket":"< 1K"
   },
   {
     "Class":"Predicate",
-    "Name":"http:\/\/schema.org\/review-output",
+    "Name":"https://schema.org/review-output",
     "Domain Bucket":"< 1K"
   },
   {
     "Class":"Predicate",
-    "Name":"http:\/\/schema.org\/reviewAspect",
+    "Name":"https://schema.org/reviewAspect",
     "Domain Bucket":"10K - 100K"
   },
   {
     "Class":"Predicate",
-    "Name":"http:\/\/schema.org\/reviewAspect-input",
+    "Name":"https://schema.org/reviewAspect-input",
     "Domain Bucket":"< 1K"
   },
   {
     "Class":"Predicate",
-    "Name":"http:\/\/schema.org\/reviewAspect-output",
+    "Name":"https://schema.org/reviewAspect-output",
     "Domain Bucket":"< 1K"
   },
   {
     "Class":"Predicate",
-    "Name":"http:\/\/schema.org\/reviewBody",
+    "Name":"https://schema.org/reviewBody",
     "Domain Bucket":"1M - 10M"
   },
   {
     "Class":"Predicate",
-    "Name":"http:\/\/schema.org\/reviewBody-input",
+    "Name":"https://schema.org/reviewBody-input",
     "Domain Bucket":"< 1K"
   },
   {
     "Class":"Predicate",
-    "Name":"http:\/\/schema.org\/reviewBody-output",
+    "Name":"https://schema.org/reviewBody-output",
     "Domain Bucket":"< 1K"
   },
   {
     "Class":"Predicate",
-    "Name":"http:\/\/schema.org\/reviewCount",
+    "Name":"https://schema.org/reviewCount",
     "Domain Bucket":"1M - 10M"
   },
   {
     "Class":"Predicate",
-    "Name":"http:\/\/schema.org\/reviewCount-input",
+    "Name":"https://schema.org/reviewCount-input",
     "Domain Bucket":"< 1K"
   },
   {
     "Class":"Predicate",
-    "Name":"http:\/\/schema.org\/reviewCount-output",
+    "Name":"https://schema.org/reviewCount-output",
     "Domain Bucket":"< 1K"
   },
   {
     "Class":"Predicate",
-    "Name":"http:\/\/schema.org\/reviewRating",
+    "Name":"https://schema.org/reviewRating",
     "Domain Bucket":"1M - 10M"
   },
   {
     "Class":"Predicate",
-    "Name":"http:\/\/schema.org\/reviewRating-input",
+    "Name":"https://schema.org/reviewRating-input",
     "Domain Bucket":"< 1K"
   },
   {
     "Class":"Predicate",
-    "Name":"http:\/\/schema.org\/reviewRating-output",
+    "Name":"https://schema.org/reviewRating-output",
     "Domain Bucket":"< 1K"
   },
   {
     "Class":"Predicate",
-    "Name":"http:\/\/schema.org\/reviewedBy",
+    "Name":"https://schema.org/reviewedBy",
     "Domain Bucket":"10K - 100K"
   },
   {
     "Class":"Predicate",
-    "Name":"http:\/\/schema.org\/reviewedBy-input",
+    "Name":"https://schema.org/reviewedBy-input",
     "Domain Bucket":"< 1K"
   },
   {
     "Class":"Predicate",
-    "Name":"http:\/\/schema.org\/reviewedBy-output",
+    "Name":"https://schema.org/reviewedBy-output",
     "Domain Bucket":"< 1K"
   },
   {
     "Class":"Predicate",
-    "Name":"http:\/\/schema.org\/reviews",
+    "Name":"https://schema.org/reviews",
     "Domain Bucket":"1K - 10K"
   },
   {
     "Class":"Predicate",
-    "Name":"http:\/\/schema.org\/reviews-input",
+    "Name":"https://schema.org/reviews-input",
     "Domain Bucket":"< 1K"
   },
   {
     "Class":"Predicate",
-    "Name":"http:\/\/schema.org\/reviews-output",
+    "Name":"https://schema.org/reviews-output",
     "Domain Bucket":"< 1K"
   },
   {
     "Class":"Predicate",
-    "Name":"http:\/\/schema.org\/riskFactor",
+    "Name":"https://schema.org/riskFactor",
     "Domain Bucket":"1K - 10K"
   },
   {
     "Class":"Predicate",
-    "Name":"http:\/\/schema.org\/riskFactor-input",
+    "Name":"https://schema.org/riskFactor-input",
     "Domain Bucket":"< 1K"
   },
   {
     "Class":"Predicate",
-    "Name":"http:\/\/schema.org\/riskFactor-output",
+    "Name":"https://schema.org/riskFactor-output",
     "Domain Bucket":"< 1K"
   },
   {
     "Class":"Predicate",
-    "Name":"http:\/\/schema.org\/risks",
+    "Name":"https://schema.org/risks",
     "Domain Bucket":"< 1K"
   },
   {
     "Class":"Predicate",
-    "Name":"http:\/\/schema.org\/risks-input",
+    "Name":"https://schema.org/risks-input",
     "Domain Bucket":"< 1K"
   },
   {
     "Class":"Predicate",
-    "Name":"http:\/\/schema.org\/risks-output",
+    "Name":"https://schema.org/risks-output",
     "Domain Bucket":"< 1K"
   },
   {
     "Class":"Predicate",
-    "Name":"http:\/\/schema.org\/roleName",
+    "Name":"https://schema.org/roleName",
     "Domain Bucket":"1K - 10K"
   },
   {
     "Class":"Predicate",
-    "Name":"http:\/\/schema.org\/roleName-input",
+    "Name":"https://schema.org/roleName-input",
     "Domain Bucket":"< 1K"
   },
   {
     "Class":"Predicate",
-    "Name":"http:\/\/schema.org\/roleName-output",
+    "Name":"https://schema.org/roleName-output",
     "Domain Bucket":"< 1K"
   },
   {
     "Class":"Predicate",
-    "Name":"http:\/\/schema.org\/roofLoad",
+    "Name":"https://schema.org/roofLoad",
     "Domain Bucket":"< 1K"
   },
   {
     "Class":"Predicate",
-    "Name":"http:\/\/schema.org\/roofLoad-input",
+    "Name":"https://schema.org/roofLoad-input",
     "Domain Bucket":"< 1K"
   },
   {
     "Class":"Predicate",
-    "Name":"http:\/\/schema.org\/roofLoad-output",
+    "Name":"https://schema.org/roofLoad-output",
     "Domain Bucket":"< 1K"
   },
   {
     "Class":"Predicate",
-    "Name":"http:\/\/schema.org\/rsvpResponse",
+    "Name":"https://schema.org/rsvpResponse",
     "Domain Bucket":"< 1K"
   },
   {
     "Class":"Predicate",
-    "Name":"http:\/\/schema.org\/rsvpResponse-input",
+    "Name":"https://schema.org/rsvpResponse-input",
     "Domain Bucket":"< 1K"
   },
   {
     "Class":"Predicate",
-    "Name":"http:\/\/schema.org\/rsvpResponse-output",
+    "Name":"https://schema.org/rsvpResponse-output",
     "Domain Bucket":"< 1K"
   },
   {
     "Class":"Predicate",
-    "Name":"http:\/\/schema.org\/runsTo",
+    "Name":"https://schema.org/runsTo",
     "Domain Bucket":"< 1K"
   },
   {
     "Class":"Predicate",
-    "Name":"http:\/\/schema.org\/runsTo-input",
+    "Name":"https://schema.org/runsTo-input",
     "Domain Bucket":"< 1K"
   },
   {
     "Class":"Predicate",
-    "Name":"http:\/\/schema.org\/runsTo-output",
+    "Name":"https://schema.org/runsTo-output",
     "Domain Bucket":"< 1K"
   },
   {
     "Class":"Predicate",
-    "Name":"http:\/\/schema.org\/runtime",
+    "Name":"https://schema.org/runtime",
     "Domain Bucket":"< 1K"
   },
   {
     "Class":"Predicate",
-    "Name":"http:\/\/schema.org\/runtime-input",
+    "Name":"https://schema.org/runtime-input",
     "Domain Bucket":"< 1K"
   },
   {
     "Class":"Predicate",
-    "Name":"http:\/\/schema.org\/runtime-output",
+    "Name":"https://schema.org/runtime-output",
     "Domain Bucket":"< 1K"
   },
   {
     "Class":"Predicate",
-    "Name":"http:\/\/schema.org\/runtimePlatform",
+    "Name":"https://schema.org/runtimePlatform",
     "Domain Bucket":"1K - 10K"
   },
   {
     "Class":"Predicate",
-    "Name":"http:\/\/schema.org\/runtimePlatform-input",
+    "Name":"https://schema.org/runtimePlatform-input",
     "Domain Bucket":"< 1K"
   },
   {
     "Class":"Predicate",
-    "Name":"http:\/\/schema.org\/runtimePlatform-output",
+    "Name":"https://schema.org/runtimePlatform-output",
     "Domain Bucket":"< 1K"
   },
   {
     "Class":"Predicate",
-    "Name":"http:\/\/schema.org\/rxcui",
+    "Name":"https://schema.org/rxcui",
     "Domain Bucket":"< 1K"
   },
   {
     "Class":"Predicate",
-    "Name":"http:\/\/schema.org\/rxcui-input",
+    "Name":"https://schema.org/rxcui-input",
     "Domain Bucket":"< 1K"
   },
   {
     "Class":"Predicate",
-    "Name":"http:\/\/schema.org\/rxcui-output",
+    "Name":"https://schema.org/rxcui-output",
     "Domain Bucket":"< 1K"
   },
   {
     "Class":"Predicate",
-    "Name":"http:\/\/schema.org\/safetyConsideration",
+    "Name":"https://schema.org/safetyConsideration",
     "Domain Bucket":"< 1K"
   },
   {
     "Class":"Predicate",
-    "Name":"http:\/\/schema.org\/safetyConsideration-input",
+    "Name":"https://schema.org/safetyConsideration-input",
     "Domain Bucket":"< 1K"
   },
   {
     "Class":"Predicate",
-    "Name":"http:\/\/schema.org\/safetyConsideration-output",
+    "Name":"https://schema.org/safetyConsideration-output",
     "Domain Bucket":"< 1K"
   },
   {
     "Class":"Predicate",
-    "Name":"http:\/\/schema.org\/salaryCurrency",
+    "Name":"https://schema.org/salaryCurrency",
     "Domain Bucket":"1K - 10K"
   },
   {
     "Class":"Predicate",
-    "Name":"http:\/\/schema.org\/salaryCurrency-input",
+    "Name":"https://schema.org/salaryCurrency-input",
     "Domain Bucket":"< 1K"
   },
   {
     "Class":"Predicate",
-    "Name":"http:\/\/schema.org\/salaryCurrency-output",
+    "Name":"https://schema.org/salaryCurrency-output",
     "Domain Bucket":"< 1K"
   },
   {
     "Class":"Predicate",
-    "Name":"http:\/\/schema.org\/salaryUponCompletion",
+    "Name":"https://schema.org/salaryUponCompletion",
     "Domain Bucket":"< 1K"
   },
   {
     "Class":"Predicate",
-    "Name":"http:\/\/schema.org\/salaryUponCompletion-input",
+    "Name":"https://schema.org/salaryUponCompletion-input",
     "Domain Bucket":"< 1K"
   },
   {
     "Class":"Predicate",
-    "Name":"http:\/\/schema.org\/salaryUponCompletion-output",
+    "Name":"https://schema.org/salaryUponCompletion-output",
     "Domain Bucket":"< 1K"
   },
   {
     "Class":"Predicate",
-    "Name":"http:\/\/schema.org\/sameAs",
+    "Name":"https://schema.org/sameAs",
     "Domain Bucket":"10M+"
   },
   {
     "Class":"Predicate",
-    "Name":"http:\/\/schema.org\/sameAs-input",
+    "Name":"https://schema.org/sameAs-input",
     "Domain Bucket":"< 1K"
   },
   {
     "Class":"Predicate",
-    "Name":"http:\/\/schema.org\/sameAs-output",
+    "Name":"https://schema.org/sameAs-output",
     "Domain Bucket":"< 1K"
   },
   {
     "Class":"Predicate",
-    "Name":"http:\/\/schema.org\/sampleType",
+    "Name":"https://schema.org/sampleType",
     "Domain Bucket":"< 1K"
   },
   {
     "Class":"Predicate",
-    "Name":"http:\/\/schema.org\/sampleType-input",
+    "Name":"https://schema.org/sampleType-input",
     "Domain Bucket":"< 1K"
   },
   {
     "Class":"Predicate",
-    "Name":"http:\/\/schema.org\/sampleType-output",
+    "Name":"https://schema.org/sampleType-output",
     "Domain Bucket":"< 1K"
   },
   {
     "Class":"Predicate",
-    "Name":"http:\/\/schema.org\/saturatedFatContent",
+    "Name":"https://schema.org/saturatedFatContent",
     "Domain Bucket":"10K - 100K"
   },
   {
     "Class":"Predicate",
-    "Name":"http:\/\/schema.org\/saturatedFatContent-input",
+    "Name":"https://schema.org/saturatedFatContent-input",
     "Domain Bucket":"< 1K"
   },
   {
     "Class":"Predicate",
-    "Name":"http:\/\/schema.org\/saturatedFatContent-output",
+    "Name":"https://schema.org/saturatedFatContent-output",
     "Domain Bucket":"< 1K"
   },
   {
     "Class":"Predicate",
-    "Name":"http:\/\/schema.org\/scheduleTimezone",
+    "Name":"https://schema.org/scheduleTimezone",
     "Domain Bucket":"1K - 10K"
   },
   {
     "Class":"Predicate",
-    "Name":"http:\/\/schema.org\/scheduleTimezone-input",
+    "Name":"https://schema.org/scheduleTimezone-input",
     "Domain Bucket":"< 1K"
   },
   {
     "Class":"Predicate",
-    "Name":"http:\/\/schema.org\/scheduleTimezone-output",
+    "Name":"https://schema.org/scheduleTimezone-output",
     "Domain Bucket":"< 1K"
   },
   {
     "Class":"Predicate",
-    "Name":"http:\/\/schema.org\/scheduledPaymentDate",
+    "Name":"https://schema.org/scheduledPaymentDate",
     "Domain Bucket":"< 1K"
   },
   {
     "Class":"Predicate",
-    "Name":"http:\/\/schema.org\/scheduledPaymentDate-input",
+    "Name":"https://schema.org/scheduledPaymentDate-input",
     "Domain Bucket":"< 1K"
   },
   {
     "Class":"Predicate",
-    "Name":"http:\/\/schema.org\/scheduledPaymentDate-output",
+    "Name":"https://schema.org/scheduledPaymentDate-output",
     "Domain Bucket":"< 1K"
   },
   {
     "Class":"Predicate",
-    "Name":"http:\/\/schema.org\/scheduledTime",
+    "Name":"https://schema.org/scheduledTime",
     "Domain Bucket":"< 1K"
   },
   {
     "Class":"Predicate",
-    "Name":"http:\/\/schema.org\/scheduledTime-input",
+    "Name":"https://schema.org/scheduledTime-input",
     "Domain Bucket":"< 1K"
   },
   {
     "Class":"Predicate",
-    "Name":"http:\/\/schema.org\/scheduledTime-output",
+    "Name":"https://schema.org/scheduledTime-output",
     "Domain Bucket":"< 1K"
   },
   {
     "Class":"Predicate",
-    "Name":"http:\/\/schema.org\/schemaVersion",
+    "Name":"https://schema.org/schemaVersion",
     "Domain Bucket":"< 1K"
   },
   {
     "Class":"Predicate",
-    "Name":"http:\/\/schema.org\/schemaVersion-input",
+    "Name":"https://schema.org/schemaVersion-input",
     "Domain Bucket":"< 1K"
   },
   {
     "Class":"Predicate",
-    "Name":"http:\/\/schema.org\/schemaVersion-output",
+    "Name":"https://schema.org/schemaVersion-output",
     "Domain Bucket":"< 1K"
   },
   {
     "Class":"Predicate",
-    "Name":"http:\/\/schema.org\/schoolClosuresInfo",
+    "Name":"https://schema.org/schoolClosuresInfo",
     "Domain Bucket":"< 1K"
   },
   {
     "Class":"Predicate",
-    "Name":"http:\/\/schema.org\/schoolClosuresInfo-input",
+    "Name":"https://schema.org/schoolClosuresInfo-input",
     "Domain Bucket":"< 1K"
   },
   {
     "Class":"Predicate",
-    "Name":"http:\/\/schema.org\/schoolClosuresInfo-output",
+    "Name":"https://schema.org/schoolClosuresInfo-output",
     "Domain Bucket":"< 1K"
   },
   {
     "Class":"Predicate",
-    "Name":"http:\/\/schema.org\/screenCount",
+    "Name":"https://schema.org/screenCount",
     "Domain Bucket":"< 1K"
   },
   {
     "Class":"Predicate",
-    "Name":"http:\/\/schema.org\/screenCount-input",
+    "Name":"https://schema.org/screenCount-input",
     "Domain Bucket":"< 1K"
   },
   {
     "Class":"Predicate",
-    "Name":"http:\/\/schema.org\/screenCount-output",
+    "Name":"https://schema.org/screenCount-output",
     "Domain Bucket":"< 1K"
   },
   {
     "Class":"Predicate",
-    "Name":"http:\/\/schema.org\/screenshot",
+    "Name":"https://schema.org/screenshot",
     "Domain Bucket":"100K - 1M"
   },
   {
     "Class":"Predicate",
-    "Name":"http:\/\/schema.org\/screenshot-input",
+    "Name":"https://schema.org/screenshot-input",
     "Domain Bucket":"< 1K"
   },
   {
     "Class":"Predicate",
-    "Name":"http:\/\/schema.org\/screenshot-output",
+    "Name":"https://schema.org/screenshot-output",
     "Domain Bucket":"< 1K"
   },
   {
     "Class":"Predicate",
-    "Name":"http:\/\/schema.org\/sdDatePublished",
+    "Name":"https://schema.org/sdDatePublished",
     "Domain Bucket":"1K - 10K"
   },
   {
     "Class":"Predicate",
-    "Name":"http:\/\/schema.org\/sdDatePublished-input",
+    "Name":"https://schema.org/sdDatePublished-input",
     "Domain Bucket":"< 1K"
   },
   {
     "Class":"Predicate",
-    "Name":"http:\/\/schema.org\/sdDatePublished-output",
+    "Name":"https://schema.org/sdDatePublished-output",
     "Domain Bucket":"< 1K"
   },
   {
     "Class":"Predicate",
-    "Name":"http:\/\/schema.org\/sdLicense",
+    "Name":"https://schema.org/sdLicense",
     "Domain Bucket":"< 1K"
   },
   {
     "Class":"Predicate",
-    "Name":"http:\/\/schema.org\/sdLicense-input",
+    "Name":"https://schema.org/sdLicense-input",
     "Domain Bucket":"< 1K"
   },
   {
     "Class":"Predicate",
-    "Name":"http:\/\/schema.org\/sdLicense-output",
+    "Name":"https://schema.org/sdLicense-output",
     "Domain Bucket":"< 1K"
   },
   {
     "Class":"Predicate",
-    "Name":"http:\/\/schema.org\/sdPublisher",
+    "Name":"https://schema.org/sdPublisher",
     "Domain Bucket":"1K - 10K"
   },
   {
     "Class":"Predicate",
-    "Name":"http:\/\/schema.org\/sdPublisher-input",
+    "Name":"https://schema.org/sdPublisher-input",
     "Domain Bucket":"< 1K"
   },
   {
     "Class":"Predicate",
-    "Name":"http:\/\/schema.org\/sdPublisher-output",
+    "Name":"https://schema.org/sdPublisher-output",
     "Domain Bucket":"< 1K"
   },
   {
     "Class":"Predicate",
-    "Name":"http:\/\/schema.org\/season",
+    "Name":"https://schema.org/season",
     "Domain Bucket":"< 1K"
   },
   {
     "Class":"Predicate",
-    "Name":"http:\/\/schema.org\/season-input",
+    "Name":"https://schema.org/season-input",
     "Domain Bucket":"< 1K"
   },
   {
     "Class":"Predicate",
-    "Name":"http:\/\/schema.org\/season-output",
+    "Name":"https://schema.org/season-output",
     "Domain Bucket":"< 1K"
   },
   {
     "Class":"Predicate",
-    "Name":"http:\/\/schema.org\/seasonNumber",
+    "Name":"https://schema.org/seasonNumber",
     "Domain Bucket":"1K - 10K"
   },
   {
     "Class":"Predicate",
-    "Name":"http:\/\/schema.org\/seasonNumber-input",
+    "Name":"https://schema.org/seasonNumber-input",
     "Domain Bucket":"< 1K"
   },
   {
     "Class":"Predicate",
-    "Name":"http:\/\/schema.org\/seasonNumber-output",
+    "Name":"https://schema.org/seasonNumber-output",
     "Domain Bucket":"< 1K"
   },
   {
     "Class":"Predicate",
-    "Name":"http:\/\/schema.org\/seasonalOverride",
+    "Name":"https://schema.org/seasonalOverride",
     "Domain Bucket":"< 1K"
   },
   {
     "Class":"Predicate",
-    "Name":"http:\/\/schema.org\/seasonalOverride-input",
+    "Name":"https://schema.org/seasonalOverride-input",
     "Domain Bucket":"< 1K"
   },
   {
     "Class":"Predicate",
-    "Name":"http:\/\/schema.org\/seasonalOverride-output",
+    "Name":"https://schema.org/seasonalOverride-output",
     "Domain Bucket":"< 1K"
   },
   {
     "Class":"Predicate",
-    "Name":"http:\/\/schema.org\/seasons",
+    "Name":"https://schema.org/seasons",
     "Domain Bucket":"< 1K"
   },
   {
     "Class":"Predicate",
-    "Name":"http:\/\/schema.org\/seasons-input",
+    "Name":"https://schema.org/seasons-input",
     "Domain Bucket":"< 1K"
   },
   {
     "Class":"Predicate",
-    "Name":"http:\/\/schema.org\/seasons-output",
+    "Name":"https://schema.org/seasons-output",
     "Domain Bucket":"< 1K"
   },
   {
     "Class":"Predicate",
-    "Name":"http:\/\/schema.org\/seatNumber",
+    "Name":"https://schema.org/seatNumber",
     "Domain Bucket":"< 1K"
   },
   {
     "Class":"Predicate",
-    "Name":"http:\/\/schema.org\/seatNumber-input",
+    "Name":"https://schema.org/seatNumber-input",
     "Domain Bucket":"< 1K"
   },
   {
     "Class":"Predicate",
-    "Name":"http:\/\/schema.org\/seatNumber-output",
+    "Name":"https://schema.org/seatNumber-output",
     "Domain Bucket":"< 1K"
   },
   {
     "Class":"Predicate",
-    "Name":"http:\/\/schema.org\/seatRow",
+    "Name":"https://schema.org/seatRow",
     "Domain Bucket":"< 1K"
   },
   {
     "Class":"Predicate",
-    "Name":"http:\/\/schema.org\/seatRow-input",
+    "Name":"https://schema.org/seatRow-input",
     "Domain Bucket":"< 1K"
   },
   {
     "Class":"Predicate",
-    "Name":"http:\/\/schema.org\/seatRow-output",
+    "Name":"https://schema.org/seatRow-output",
     "Domain Bucket":"< 1K"
   },
   {
     "Class":"Predicate",
-    "Name":"http:\/\/schema.org\/seatSection",
+    "Name":"https://schema.org/seatSection",
     "Domain Bucket":"< 1K"
   },
   {
     "Class":"Predicate",
-    "Name":"http:\/\/schema.org\/seatSection-input",
+    "Name":"https://schema.org/seatSection-input",
     "Domain Bucket":"< 1K"
   },
   {
     "Class":"Predicate",
-    "Name":"http:\/\/schema.org\/seatSection-output",
+    "Name":"https://schema.org/seatSection-output",
     "Domain Bucket":"< 1K"
   },
   {
     "Class":"Predicate",
-    "Name":"http:\/\/schema.org\/seatingCapacity",
+    "Name":"https://schema.org/seatingCapacity",
     "Domain Bucket":"1K - 10K"
   },
   {
     "Class":"Predicate",
-    "Name":"http:\/\/schema.org\/seatingCapacity-input",
+    "Name":"https://schema.org/seatingCapacity-input",
     "Domain Bucket":"< 1K"
   },
   {
     "Class":"Predicate",
-    "Name":"http:\/\/schema.org\/seatingCapacity-output",
+    "Name":"https://schema.org/seatingCapacity-output",
     "Domain Bucket":"< 1K"
   },
   {
     "Class":"Predicate",
-    "Name":"http:\/\/schema.org\/seatingType",
+    "Name":"https://schema.org/seatingType",
     "Domain Bucket":"< 1K"
   },
   {
     "Class":"Predicate",
-    "Name":"http:\/\/schema.org\/seatingType-input",
+    "Name":"https://schema.org/seatingType-input",
     "Domain Bucket":"< 1K"
   },
   {
     "Class":"Predicate",
-    "Name":"http:\/\/schema.org\/seatingType-output",
+    "Name":"https://schema.org/seatingType-output",
     "Domain Bucket":"< 1K"
   },
   {
     "Class":"Predicate",
-    "Name":"http:\/\/schema.org\/secondaryPrevention",
+    "Name":"https://schema.org/secondaryPrevention",
     "Domain Bucket":"< 1K"
   },
   {
     "Class":"Predicate",
-    "Name":"http:\/\/schema.org\/secondaryPrevention-input",
+    "Name":"https://schema.org/secondaryPrevention-input",
     "Domain Bucket":"< 1K"
   },
   {
     "Class":"Predicate",
-    "Name":"http:\/\/schema.org\/secondaryPrevention-output",
+    "Name":"https://schema.org/secondaryPrevention-output",
     "Domain Bucket":"< 1K"
   },
   {
     "Class":"Predicate",
-    "Name":"http:\/\/schema.org\/securityClearanceRequirement",
+    "Name":"https://schema.org/securityClearanceRequirement",
     "Domain Bucket":"< 1K"
   },
   {
     "Class":"Predicate",
-    "Name":"http:\/\/schema.org\/securityClearanceRequirement-input",
+    "Name":"https://schema.org/securityClearanceRequirement-input",
     "Domain Bucket":"< 1K"
   },
   {
     "Class":"Predicate",
-    "Name":"http:\/\/schema.org\/securityClearanceRequirement-output",
+    "Name":"https://schema.org/securityClearanceRequirement-output",
     "Domain Bucket":"< 1K"
   },
   {
     "Class":"Predicate",
-    "Name":"http:\/\/schema.org\/securityScreening",
+    "Name":"https://schema.org/securityScreening",
     "Domain Bucket":"< 1K"
   },
   {
     "Class":"Predicate",
-    "Name":"http:\/\/schema.org\/securityScreening-input",
+    "Name":"https://schema.org/securityScreening-input",
     "Domain Bucket":"< 1K"
   },
   {
     "Class":"Predicate",
-    "Name":"http:\/\/schema.org\/securityScreening-output",
+    "Name":"https://schema.org/securityScreening-output",
     "Domain Bucket":"< 1K"
   },
   {
     "Class":"Predicate",
-    "Name":"http:\/\/schema.org\/seeks",
+    "Name":"https://schema.org/seeks",
     "Domain Bucket":"1K - 10K"
   },
   {
     "Class":"Predicate",
-    "Name":"http:\/\/schema.org\/seeks-input",
+    "Name":"https://schema.org/seeks-input",
     "Domain Bucket":"< 1K"
   },
   {
     "Class":"Predicate",
-    "Name":"http:\/\/schema.org\/seeks-output",
+    "Name":"https://schema.org/seeks-output",
     "Domain Bucket":"< 1K"
   },
   {
     "Class":"Predicate",
-    "Name":"http:\/\/schema.org\/seller",
+    "Name":"https://schema.org/seller",
     "Domain Bucket":"1M - 10M"
   },
   {
     "Class":"Predicate",
-    "Name":"http:\/\/schema.org\/seller-input",
+    "Name":"https://schema.org/seller-input",
     "Domain Bucket":"< 1K"
   },
   {
     "Class":"Predicate",
-    "Name":"http:\/\/schema.org\/seller-output",
+    "Name":"https://schema.org/seller-output",
     "Domain Bucket":"< 1K"
   },
   {
     "Class":"Predicate",
-    "Name":"http:\/\/schema.org\/sender",
+    "Name":"https://schema.org/sender",
     "Domain Bucket":"< 1K"
   },
   {
     "Class":"Predicate",
-    "Name":"http:\/\/schema.org\/sender-input",
+    "Name":"https://schema.org/sender-input",
     "Domain Bucket":"< 1K"
   },
   {
     "Class":"Predicate",
-    "Name":"http:\/\/schema.org\/sender-output",
+    "Name":"https://schema.org/sender-output",
     "Domain Bucket":"< 1K"
   },
   {
     "Class":"Predicate",
-    "Name":"http:\/\/schema.org\/sensoryRequirement",
+    "Name":"https://schema.org/sensoryRequirement",
     "Domain Bucket":"< 1K"
   },
   {
     "Class":"Predicate",
-    "Name":"http:\/\/schema.org\/sensoryRequirement-input",
+    "Name":"https://schema.org/sensoryRequirement-input",
     "Domain Bucket":"< 1K"
   },
   {
     "Class":"Predicate",
-    "Name":"http:\/\/schema.org\/sensoryRequirement-output",
+    "Name":"https://schema.org/sensoryRequirement-output",
     "Domain Bucket":"< 1K"
   },
   {
     "Class":"Predicate",
-    "Name":"http:\/\/schema.org\/sensoryUnit",
+    "Name":"https://schema.org/sensoryUnit",
     "Domain Bucket":"< 1K"
   },
   {
     "Class":"Predicate",
-    "Name":"http:\/\/schema.org\/sensoryUnit-input",
+    "Name":"https://schema.org/sensoryUnit-input",
     "Domain Bucket":"< 1K"
   },
   {
     "Class":"Predicate",
-    "Name":"http:\/\/schema.org\/sensoryUnit-output",
+    "Name":"https://schema.org/sensoryUnit-output",
     "Domain Bucket":"< 1K"
   },
   {
     "Class":"Predicate",
-    "Name":"http:\/\/schema.org\/serialNumber",
+    "Name":"https://schema.org/serialNumber",
     "Domain Bucket":"10K - 100K"
   },
   {
     "Class":"Predicate",
-    "Name":"http:\/\/schema.org\/serialNumber-input",
+    "Name":"https://schema.org/serialNumber-input",
     "Domain Bucket":"< 1K"
   },
   {
     "Class":"Predicate",
-    "Name":"http:\/\/schema.org\/serialNumber-output",
+    "Name":"https://schema.org/serialNumber-output",
     "Domain Bucket":"< 1K"
   },
   {
     "Class":"Predicate",
-    "Name":"http:\/\/schema.org\/seriousAdverseOutcome",
+    "Name":"https://schema.org/seriousAdverseOutcome",
     "Domain Bucket":"< 1K"
   },
   {
     "Class":"Predicate",
-    "Name":"http:\/\/schema.org\/seriousAdverseOutcome-input",
+    "Name":"https://schema.org/seriousAdverseOutcome-input",
     "Domain Bucket":"< 1K"
   },
   {
     "Class":"Predicate",
-    "Name":"http:\/\/schema.org\/seriousAdverseOutcome-output",
+    "Name":"https://schema.org/seriousAdverseOutcome-output",
     "Domain Bucket":"< 1K"
   },
   {
     "Class":"Predicate",
-    "Name":"http:\/\/schema.org\/serverStatus",
+    "Name":"https://schema.org/serverStatus",
     "Domain Bucket":"< 1K"
   },
   {
     "Class":"Predicate",
-    "Name":"http:\/\/schema.org\/serverStatus-input",
+    "Name":"https://schema.org/serverStatus-input",
     "Domain Bucket":"< 1K"
   },
   {
     "Class":"Predicate",
-    "Name":"http:\/\/schema.org\/serverStatus-output",
+    "Name":"https://schema.org/serverStatus-output",
     "Domain Bucket":"< 1K"
   },
   {
     "Class":"Predicate",
-    "Name":"http:\/\/schema.org\/servesCuisine",
+    "Name":"https://schema.org/servesCuisine",
     "Domain Bucket":"100K - 1M"
   },
   {
     "Class":"Predicate",
-    "Name":"http:\/\/schema.org\/servesCuisine-input",
+    "Name":"https://schema.org/servesCuisine-input",
     "Domain Bucket":"< 1K"
   },
   {
     "Class":"Predicate",
-    "Name":"http:\/\/schema.org\/servesCuisine-output",
+    "Name":"https://schema.org/servesCuisine-output",
     "Domain Bucket":"< 1K"
   },
   {
     "Class":"Predicate",
-    "Name":"http:\/\/schema.org\/serviceArea",
+    "Name":"https://schema.org/serviceArea",
     "Domain Bucket":"10K - 100K"
   },
   {
     "Class":"Predicate",
-    "Name":"http:\/\/schema.org\/serviceArea-input",
+    "Name":"https://schema.org/serviceArea-input",
     "Domain Bucket":"< 1K"
   },
   {
     "Class":"Predicate",
-    "Name":"http:\/\/schema.org\/serviceArea-output",
+    "Name":"https://schema.org/serviceArea-output",
     "Domain Bucket":"< 1K"
   },
   {
     "Class":"Predicate",
-    "Name":"http:\/\/schema.org\/serviceAudience",
+    "Name":"https://schema.org/serviceAudience",
     "Domain Bucket":"1K - 10K"
   },
   {
     "Class":"Predicate",
-    "Name":"http:\/\/schema.org\/serviceAudience-input",
+    "Name":"https://schema.org/serviceAudience-input",
     "Domain Bucket":"< 1K"
   },
   {
     "Class":"Predicate",
-    "Name":"http:\/\/schema.org\/serviceAudience-output",
+    "Name":"https://schema.org/serviceAudience-output",
     "Domain Bucket":"< 1K"
   },
   {
     "Class":"Predicate",
-    "Name":"http:\/\/schema.org\/serviceLocation",
+    "Name":"https://schema.org/serviceLocation",
     "Domain Bucket":"10K - 100K"
   },
   {
     "Class":"Predicate",
-    "Name":"http:\/\/schema.org\/serviceLocation-input",
+    "Name":"https://schema.org/serviceLocation-input",
     "Domain Bucket":"< 1K"
   },
   {
     "Class":"Predicate",
-    "Name":"http:\/\/schema.org\/serviceLocation-output",
+    "Name":"https://schema.org/serviceLocation-output",
     "Domain Bucket":"< 1K"
   },
   {
     "Class":"Predicate",
-    "Name":"http:\/\/schema.org\/serviceOperator",
+    "Name":"https://schema.org/serviceOperator",
     "Domain Bucket":"1K - 10K"
   },
   {
     "Class":"Predicate",
-    "Name":"http:\/\/schema.org\/serviceOperator-input",
+    "Name":"https://schema.org/serviceOperator-input",
     "Domain Bucket":"< 1K"
   },
   {
     "Class":"Predicate",
-    "Name":"http:\/\/schema.org\/serviceOperator-output",
+    "Name":"https://schema.org/serviceOperator-output",
     "Domain Bucket":"< 1K"
   },
   {
     "Class":"Predicate",
-    "Name":"http:\/\/schema.org\/serviceOutput",
+    "Name":"https://schema.org/serviceOutput",
     "Domain Bucket":"10K - 100K"
   },
   {
     "Class":"Predicate",
-    "Name":"http:\/\/schema.org\/serviceOutput-input",
+    "Name":"https://schema.org/serviceOutput-input",
     "Domain Bucket":"< 1K"
   },
   {
     "Class":"Predicate",
-    "Name":"http:\/\/schema.org\/serviceOutput-output",
+    "Name":"https://schema.org/serviceOutput-output",
     "Domain Bucket":"< 1K"
   },
   {
     "Class":"Predicate",
-    "Name":"http:\/\/schema.org\/servicePhone",
+    "Name":"https://schema.org/servicePhone",
     "Domain Bucket":"10K - 100K"
   },
   {
     "Class":"Predicate",
-    "Name":"http:\/\/schema.org\/servicePhone-input",
+    "Name":"https://schema.org/servicePhone-input",
     "Domain Bucket":"< 1K"
   },
   {
     "Class":"Predicate",
-    "Name":"http:\/\/schema.org\/servicePhone-output",
+    "Name":"https://schema.org/servicePhone-output",
     "Domain Bucket":"< 1K"
   },
   {
     "Class":"Predicate",
-    "Name":"http:\/\/schema.org\/servicePostalAddress",
+    "Name":"https://schema.org/servicePostalAddress",
     "Domain Bucket":"< 1K"
   },
   {
     "Class":"Predicate",
-    "Name":"http:\/\/schema.org\/servicePostalAddress-input",
+    "Name":"https://schema.org/servicePostalAddress-input",
     "Domain Bucket":"< 1K"
   },
   {
     "Class":"Predicate",
-    "Name":"http:\/\/schema.org\/servicePostalAddress-output",
+    "Name":"https://schema.org/servicePostalAddress-output",
     "Domain Bucket":"< 1K"
   },
   {
     "Class":"Predicate",
-    "Name":"http:\/\/schema.org\/serviceSmsNumber",
+    "Name":"https://schema.org/serviceSmsNumber",
     "Domain Bucket":"1K - 10K"
   },
   {
     "Class":"Predicate",
-    "Name":"http:\/\/schema.org\/serviceSmsNumber-input",
+    "Name":"https://schema.org/serviceSmsNumber-input",
     "Domain Bucket":"< 1K"
   },
   {
     "Class":"Predicate",
-    "Name":"http:\/\/schema.org\/serviceSmsNumber-output",
+    "Name":"https://schema.org/serviceSmsNumber-output",
     "Domain Bucket":"< 1K"
   },
   {
     "Class":"Predicate",
-    "Name":"http:\/\/schema.org\/serviceType",
+    "Name":"https://schema.org/serviceType",
     "Domain Bucket":"100K - 1M"
   },
   {
     "Class":"Predicate",
-    "Name":"http:\/\/schema.org\/serviceType-input",
+    "Name":"https://schema.org/serviceType-input",
     "Domain Bucket":"< 1K"
   },
   {
     "Class":"Predicate",
-    "Name":"http:\/\/schema.org\/serviceType-output",
+    "Name":"https://schema.org/serviceType-output",
     "Domain Bucket":"< 1K"
   },
   {
     "Class":"Predicate",
-    "Name":"http:\/\/schema.org\/serviceUrl",
+    "Name":"https://schema.org/serviceUrl",
     "Domain Bucket":"10K - 100K"
   },
   {
     "Class":"Predicate",
-    "Name":"http:\/\/schema.org\/serviceUrl-input",
+    "Name":"https://schema.org/serviceUrl-input",
     "Domain Bucket":"< 1K"
   },
   {
     "Class":"Predicate",
-    "Name":"http:\/\/schema.org\/serviceUrl-output",
+    "Name":"https://schema.org/serviceUrl-output",
     "Domain Bucket":"< 1K"
   },
   {
     "Class":"Predicate",
-    "Name":"http:\/\/schema.org\/servingSize",
+    "Name":"https://schema.org/servingSize",
     "Domain Bucket":"10K - 100K"
   },
   {
     "Class":"Predicate",
-    "Name":"http:\/\/schema.org\/servingSize-input",
+    "Name":"https://schema.org/servingSize-input",
     "Domain Bucket":"< 1K"
   },
   {
     "Class":"Predicate",
-    "Name":"http:\/\/schema.org\/servingSize-output",
+    "Name":"https://schema.org/servingSize-output",
     "Domain Bucket":"< 1K"
   },
   {
     "Class":"Predicate",
-    "Name":"http:\/\/schema.org\/sha256",
+    "Name":"https://schema.org/sha256",
     "Domain Bucket":"< 1K"
   },
   {
     "Class":"Predicate",
-    "Name":"http:\/\/schema.org\/sha256-input",
+    "Name":"https://schema.org/sha256-input",
     "Domain Bucket":"< 1K"
   },
   {
     "Class":"Predicate",
-    "Name":"http:\/\/schema.org\/sha256-output",
+    "Name":"https://schema.org/sha256-output",
     "Domain Bucket":"< 1K"
   },
   {
     "Class":"Predicate",
-    "Name":"http:\/\/schema.org\/sharedContent",
+    "Name":"https://schema.org/sharedContent",
     "Domain Bucket":"1K - 10K"
   },
   {
     "Class":"Predicate",
-    "Name":"http:\/\/schema.org\/sharedContent-input",
+    "Name":"https://schema.org/sharedContent-input",
     "Domain Bucket":"< 1K"
   },
   {
     "Class":"Predicate",
-    "Name":"http:\/\/schema.org\/sharedContent-output",
+    "Name":"https://schema.org/sharedContent-output",
     "Domain Bucket":"< 1K"
   },
   {
     "Class":"Predicate",
-    "Name":"http:\/\/schema.org\/shippingConditions",
+    "Name":"https://schema.org/shippingConditions",
     "Domain Bucket":"10K - 100K"
   },
   {
     "Class":"Predicate",
-    "Name":"http:\/\/schema.org\/shippingConditions-input",
+    "Name":"https://schema.org/shippingConditions-input",
     "Domain Bucket":"< 1K"
   },
   {
     "Class":"Predicate",
-    "Name":"http:\/\/schema.org\/shippingConditions-output",
+    "Name":"https://schema.org/shippingConditions-output",
     "Domain Bucket":"< 1K"
   },
   {
     "Class":"Predicate",
-    "Name":"http:\/\/schema.org\/shippingDestination",
+    "Name":"https://schema.org/shippingDestination",
     "Domain Bucket":"100K - 1M"
   },
   {
     "Class":"Predicate",
-    "Name":"http:\/\/schema.org\/shippingDestination-input",
+    "Name":"https://schema.org/shippingDestination-input",
     "Domain Bucket":"< 1K"
   },
   {
     "Class":"Predicate",
-    "Name":"http:\/\/schema.org\/shippingDestination-output",
+    "Name":"https://schema.org/shippingDestination-output",
     "Domain Bucket":"< 1K"
   },
   {
     "Class":"Predicate",
-    "Name":"http:\/\/schema.org\/shippingDetails",
+    "Name":"https://schema.org/shippingDetails",
     "Domain Bucket":"100K - 1M"
   },
   {
     "Class":"Predicate",
-    "Name":"http:\/\/schema.org\/shippingDetails-input",
+    "Name":"https://schema.org/shippingDetails-input",
     "Domain Bucket":"< 1K"
   },
   {
     "Class":"Predicate",
-    "Name":"http:\/\/schema.org\/shippingDetails-output",
+    "Name":"https://schema.org/shippingDetails-output",
     "Domain Bucket":"< 1K"
   },
   {
     "Class":"Predicate",
-    "Name":"http:\/\/schema.org\/shippingLabel",
+    "Name":"https://schema.org/shippingLabel",
     "Domain Bucket":"1K - 10K"
   },
   {
     "Class":"Predicate",
-    "Name":"http:\/\/schema.org\/shippingLabel-input",
+    "Name":"https://schema.org/shippingLabel-input",
     "Domain Bucket":"< 1K"
   },
   {
     "Class":"Predicate",
-    "Name":"http:\/\/schema.org\/shippingLabel-output",
+    "Name":"https://schema.org/shippingLabel-output",
     "Domain Bucket":"< 1K"
   },
   {
     "Class":"Predicate",
-    "Name":"http:\/\/schema.org\/shippingOrigin",
+    "Name":"https://schema.org/shippingOrigin",
     "Domain Bucket":"10K - 100K"
   },
   {
     "Class":"Predicate",
-    "Name":"http:\/\/schema.org\/shippingOrigin-input",
+    "Name":"https://schema.org/shippingOrigin-input",
     "Domain Bucket":"< 1K"
   },
   {
     "Class":"Predicate",
-    "Name":"http:\/\/schema.org\/shippingOrigin-output",
+    "Name":"https://schema.org/shippingOrigin-output",
     "Domain Bucket":"< 1K"
   },
   {
     "Class":"Predicate",
-    "Name":"http:\/\/schema.org\/shippingRate",
+    "Name":"https://schema.org/shippingRate",
     "Domain Bucket":"100K - 1M"
   },
   {
     "Class":"Predicate",
-    "Name":"http:\/\/schema.org\/shippingRate-input",
+    "Name":"https://schema.org/shippingRate-input",
     "Domain Bucket":"< 1K"
   },
   {
     "Class":"Predicate",
-    "Name":"http:\/\/schema.org\/shippingRate-output",
+    "Name":"https://schema.org/shippingRate-output",
     "Domain Bucket":"< 1K"
   },
   {
     "Class":"Predicate",
-    "Name":"http:\/\/schema.org\/shippingSettingsLink",
+    "Name":"https://schema.org/shippingSettingsLink",
     "Domain Bucket":"1K - 10K"
   },
   {
     "Class":"Predicate",
-    "Name":"http:\/\/schema.org\/shippingSettingsLink-input",
+    "Name":"https://schema.org/shippingSettingsLink-input",
     "Domain Bucket":"< 1K"
   },
   {
     "Class":"Predicate",
-    "Name":"http:\/\/schema.org\/shippingSettingsLink-output",
+    "Name":"https://schema.org/shippingSettingsLink-output",
     "Domain Bucket":"< 1K"
   },
   {
     "Class":"Predicate",
-    "Name":"http:\/\/schema.org\/sibling",
+    "Name":"https://schema.org/sibling",
     "Domain Bucket":"< 1K"
   },
   {
     "Class":"Predicate",
-    "Name":"http:\/\/schema.org\/sibling-input",
+    "Name":"https://schema.org/sibling-input",
     "Domain Bucket":"< 1K"
   },
   {
     "Class":"Predicate",
-    "Name":"http:\/\/schema.org\/sibling-output",
+    "Name":"https://schema.org/sibling-output",
     "Domain Bucket":"< 1K"
   },
   {
     "Class":"Predicate",
-    "Name":"http:\/\/schema.org\/siblings",
+    "Name":"https://schema.org/siblings",
     "Domain Bucket":"< 1K"
   },
   {
     "Class":"Predicate",
-    "Name":"http:\/\/schema.org\/siblings-input",
+    "Name":"https://schema.org/siblings-input",
     "Domain Bucket":"< 1K"
   },
   {
     "Class":"Predicate",
-    "Name":"http:\/\/schema.org\/siblings-output",
+    "Name":"https://schema.org/siblings-output",
     "Domain Bucket":"< 1K"
   },
   {
     "Class":"Predicate",
-    "Name":"http:\/\/schema.org\/signDetected",
+    "Name":"https://schema.org/signDetected",
     "Domain Bucket":"< 1K"
   },
   {
     "Class":"Predicate",
-    "Name":"http:\/\/schema.org\/signDetected-input",
+    "Name":"https://schema.org/signDetected-input",
     "Domain Bucket":"< 1K"
   },
   {
     "Class":"Predicate",
-    "Name":"http:\/\/schema.org\/signDetected-output",
+    "Name":"https://schema.org/signDetected-output",
     "Domain Bucket":"< 1K"
   },
   {
     "Class":"Predicate",
-    "Name":"http:\/\/schema.org\/signOrSymptom",
+    "Name":"https://schema.org/signOrSymptom",
     "Domain Bucket":"1K - 10K"
   },
   {
     "Class":"Predicate",
-    "Name":"http:\/\/schema.org\/signOrSymptom-input",
+    "Name":"https://schema.org/signOrSymptom-input",
     "Domain Bucket":"< 1K"
   },
   {
     "Class":"Predicate",
-    "Name":"http:\/\/schema.org\/signOrSymptom-output",
+    "Name":"https://schema.org/signOrSymptom-output",
     "Domain Bucket":"< 1K"
   },
   {
     "Class":"Predicate",
-    "Name":"http:\/\/schema.org\/significance",
+    "Name":"https://schema.org/significance",
     "Domain Bucket":"< 1K"
   },
   {
     "Class":"Predicate",
-    "Name":"http:\/\/schema.org\/significance-input",
+    "Name":"https://schema.org/significance-input",
     "Domain Bucket":"< 1K"
   },
   {
     "Class":"Predicate",
-    "Name":"http:\/\/schema.org\/significance-output",
+    "Name":"https://schema.org/significance-output",
     "Domain Bucket":"< 1K"
   },
   {
     "Class":"Predicate",
-    "Name":"http:\/\/schema.org\/significantLink",
+    "Name":"https://schema.org/significantLink",
     "Domain Bucket":"10K - 100K"
   },
   {
     "Class":"Predicate",
-    "Name":"http:\/\/schema.org\/significantLink-input",
+    "Name":"https://schema.org/significantLink-input",
     "Domain Bucket":"< 1K"
   },
   {
     "Class":"Predicate",
-    "Name":"http:\/\/schema.org\/significantLink-output",
+    "Name":"https://schema.org/significantLink-output",
     "Domain Bucket":"< 1K"
   },
   {
     "Class":"Predicate",
-    "Name":"http:\/\/schema.org\/significantLinks",
+    "Name":"https://schema.org/significantLinks",
     "Domain Bucket":"1K - 10K"
   },
   {
     "Class":"Predicate",
-    "Name":"http:\/\/schema.org\/significantLinks-input",
+    "Name":"https://schema.org/significantLinks-input",
     "Domain Bucket":"< 1K"
   },
   {
     "Class":"Predicate",
-    "Name":"http:\/\/schema.org\/significantLinks-output",
+    "Name":"https://schema.org/significantLinks-output",
     "Domain Bucket":"< 1K"
   },
   {
     "Class":"Predicate",
-    "Name":"http:\/\/schema.org\/size",
+    "Name":"https://schema.org/size",
     "Domain Bucket":"10K - 100K"
   },
   {
     "Class":"Predicate",
-    "Name":"http:\/\/schema.org\/size-input",
+    "Name":"https://schema.org/size-input",
     "Domain Bucket":"< 1K"
   },
   {
     "Class":"Predicate",
-    "Name":"http:\/\/schema.org\/size-output",
+    "Name":"https://schema.org/size-output",
     "Domain Bucket":"< 1K"
   },
   {
     "Class":"Predicate",
-    "Name":"http:\/\/schema.org\/sizeGroup",
+    "Name":"https://schema.org/sizeGroup",
     "Domain Bucket":"< 1K"
   },
   {
     "Class":"Predicate",
-    "Name":"http:\/\/schema.org\/sizeGroup-input",
+    "Name":"https://schema.org/sizeGroup-input",
     "Domain Bucket":"< 1K"
   },
   {
     "Class":"Predicate",
-    "Name":"http:\/\/schema.org\/sizeGroup-output",
+    "Name":"https://schema.org/sizeGroup-output",
     "Domain Bucket":"< 1K"
   },
   {
     "Class":"Predicate",
-    "Name":"http:\/\/schema.org\/sizeSystem",
+    "Name":"https://schema.org/sizeSystem",
     "Domain Bucket":"< 1K"
   },
   {
     "Class":"Predicate",
-    "Name":"http:\/\/schema.org\/sizeSystem-input",
+    "Name":"https://schema.org/sizeSystem-input",
     "Domain Bucket":"< 1K"
   },
   {
     "Class":"Predicate",
-    "Name":"http:\/\/schema.org\/sizeSystem-output",
+    "Name":"https://schema.org/sizeSystem-output",
     "Domain Bucket":"< 1K"
   },
   {
     "Class":"Predicate",
-    "Name":"http:\/\/schema.org\/skills",
+    "Name":"https://schema.org/skills",
     "Domain Bucket":"10K - 100K"
   },
   {
     "Class":"Predicate",
-    "Name":"http:\/\/schema.org\/skills-input",
+    "Name":"https://schema.org/skills-input",
     "Domain Bucket":"< 1K"
   },
   {
     "Class":"Predicate",
-    "Name":"http:\/\/schema.org\/skills-output",
+    "Name":"https://schema.org/skills-output",
     "Domain Bucket":"< 1K"
   },
   {
     "Class":"Predicate",
-    "Name":"http:\/\/schema.org\/sku",
+    "Name":"https://schema.org/sku",
     "Domain Bucket":"1M - 10M"
   },
   {
     "Class":"Predicate",
-    "Name":"http:\/\/schema.org\/sku-input",
+    "Name":"https://schema.org/sku-input",
     "Domain Bucket":"< 1K"
   },
   {
     "Class":"Predicate",
-    "Name":"http:\/\/schema.org\/sku-output",
+    "Name":"https://schema.org/sku-output",
     "Domain Bucket":"< 1K"
   },
   {
     "Class":"Predicate",
-    "Name":"http:\/\/schema.org\/slogan",
+    "Name":"https://schema.org/slogan",
     "Domain Bucket":"100K - 1M"
   },
   {
     "Class":"Predicate",
-    "Name":"http:\/\/schema.org\/slogan-input",
+    "Name":"https://schema.org/slogan-input",
     "Domain Bucket":"< 1K"
   },
   {
     "Class":"Predicate",
-    "Name":"http:\/\/schema.org\/slogan-output",
+    "Name":"https://schema.org/slogan-output",
     "Domain Bucket":"< 1K"
   },
   {
     "Class":"Predicate",
-    "Name":"http:\/\/schema.org\/smiles",
+    "Name":"https://schema.org/smiles",
     "Domain Bucket":"< 1K"
   },
   {
     "Class":"Predicate",
-    "Name":"http:\/\/schema.org\/smiles-input",
+    "Name":"https://schema.org/smiles-input",
     "Domain Bucket":"< 1K"
   },
   {
     "Class":"Predicate",
-    "Name":"http:\/\/schema.org\/smiles-output",
+    "Name":"https://schema.org/smiles-output",
     "Domain Bucket":"< 1K"
   },
   {
     "Class":"Predicate",
-    "Name":"http:\/\/schema.org\/smokingAllowed",
+    "Name":"https://schema.org/smokingAllowed",
     "Domain Bucket":"10K - 100K"
   },
   {
     "Class":"Predicate",
-    "Name":"http:\/\/schema.org\/smokingAllowed-input",
+    "Name":"https://schema.org/smokingAllowed-input",
     "Domain Bucket":"< 1K"
   },
   {
     "Class":"Predicate",
-    "Name":"http:\/\/schema.org\/smokingAllowed-output",
+    "Name":"https://schema.org/smokingAllowed-output",
     "Domain Bucket":"< 1K"
   },
   {
     "Class":"Predicate",
-    "Name":"http:\/\/schema.org\/sodiumContent",
+    "Name":"https://schema.org/sodiumContent",
     "Domain Bucket":"10K - 100K"
   },
   {
     "Class":"Predicate",
-    "Name":"http:\/\/schema.org\/sodiumContent-input",
+    "Name":"https://schema.org/sodiumContent-input",
     "Domain Bucket":"< 1K"
   },
   {
     "Class":"Predicate",
-    "Name":"http:\/\/schema.org\/sodiumContent-output",
+    "Name":"https://schema.org/sodiumContent-output",
     "Domain Bucket":"< 1K"
   },
   {
     "Class":"Predicate",
-    "Name":"http:\/\/schema.org\/softwareAddOn",
+    "Name":"https://schema.org/softwareAddOn",
     "Domain Bucket":"< 1K"
   },
   {
     "Class":"Predicate",
-    "Name":"http:\/\/schema.org\/softwareAddOn-input",
+    "Name":"https://schema.org/softwareAddOn-input",
     "Domain Bucket":"< 1K"
   },
   {
     "Class":"Predicate",
-    "Name":"http:\/\/schema.org\/softwareAddOn-output",
+    "Name":"https://schema.org/softwareAddOn-output",
     "Domain Bucket":"< 1K"
   },
   {
     "Class":"Predicate",
-    "Name":"http:\/\/schema.org\/softwareHelp",
+    "Name":"https://schema.org/softwareHelp",
     "Domain Bucket":"10K - 100K"
   },
   {
     "Class":"Predicate",
-    "Name":"http:\/\/schema.org\/softwareHelp-input",
+    "Name":"https://schema.org/softwareHelp-input",
     "Domain Bucket":"< 1K"
   },
   {
     "Class":"Predicate",
-    "Name":"http:\/\/schema.org\/softwareHelp-output",
+    "Name":"https://schema.org/softwareHelp-output",
     "Domain Bucket":"< 1K"
   },
   {
     "Class":"Predicate",
-    "Name":"http:\/\/schema.org\/softwareRequirements",
+    "Name":"https://schema.org/softwareRequirements",
     "Domain Bucket":"10K - 100K"
   },
   {
     "Class":"Predicate",
-    "Name":"http:\/\/schema.org\/softwareRequirements-input",
+    "Name":"https://schema.org/softwareRequirements-input",
     "Domain Bucket":"< 1K"
   },
   {
     "Class":"Predicate",
-    "Name":"http:\/\/schema.org\/softwareRequirements-output",
+    "Name":"https://schema.org/softwareRequirements-output",
     "Domain Bucket":"< 1K"
   },
   {
     "Class":"Predicate",
-    "Name":"http:\/\/schema.org\/softwareVersion",
+    "Name":"https://schema.org/softwareVersion",
     "Domain Bucket":"100K - 1M"
   },
   {
     "Class":"Predicate",
-    "Name":"http:\/\/schema.org\/softwareVersion-input",
+    "Name":"https://schema.org/softwareVersion-input",
     "Domain Bucket":"< 1K"
   },
   {
     "Class":"Predicate",
-    "Name":"http:\/\/schema.org\/softwareVersion-output",
+    "Name":"https://schema.org/softwareVersion-output",
     "Domain Bucket":"< 1K"
   },
   {
     "Class":"Predicate",
-    "Name":"http:\/\/schema.org\/source",
+    "Name":"https://schema.org/source",
     "Domain Bucket":"1K - 10K"
   },
   {
     "Class":"Predicate",
-    "Name":"http:\/\/schema.org\/source-input",
+    "Name":"https://schema.org/source-input",
     "Domain Bucket":"< 1K"
   },
   {
     "Class":"Predicate",
-    "Name":"http:\/\/schema.org\/source-output",
+    "Name":"https://schema.org/source-output",
     "Domain Bucket":"< 1K"
   },
   {
     "Class":"Predicate",
-    "Name":"http:\/\/schema.org\/sourceOrganization",
+    "Name":"https://schema.org/sourceOrganization",
     "Domain Bucket":"10K - 100K"
   },
   {
     "Class":"Predicate",
-    "Name":"http:\/\/schema.org\/sourceOrganization-input",
+    "Name":"https://schema.org/sourceOrganization-input",
     "Domain Bucket":"< 1K"
   },
   {
     "Class":"Predicate",
-    "Name":"http:\/\/schema.org\/sourceOrganization-output",
+    "Name":"https://schema.org/sourceOrganization-output",
     "Domain Bucket":"< 1K"
   },
   {
     "Class":"Predicate",
-    "Name":"http:\/\/schema.org\/sourcedFrom",
+    "Name":"https://schema.org/sourcedFrom",
     "Domain Bucket":"< 1K"
   },
   {
     "Class":"Predicate",
-    "Name":"http:\/\/schema.org\/sourcedFrom-input",
+    "Name":"https://schema.org/sourcedFrom-input",
     "Domain Bucket":"< 1K"
   },
   {
     "Class":"Predicate",
-    "Name":"http:\/\/schema.org\/sourcedFrom-output",
+    "Name":"https://schema.org/sourcedFrom-output",
     "Domain Bucket":"< 1K"
   },
   {
     "Class":"Predicate",
-    "Name":"http:\/\/schema.org\/spatial",
+    "Name":"https://schema.org/spatial",
     "Domain Bucket":"1K - 10K"
   },
   {
     "Class":"Predicate",
-    "Name":"http:\/\/schema.org\/spatial-input",
+    "Name":"https://schema.org/spatial-input",
     "Domain Bucket":"< 1K"
   },
   {
     "Class":"Predicate",
-    "Name":"http:\/\/schema.org\/spatial-output",
+    "Name":"https://schema.org/spatial-output",
     "Domain Bucket":"< 1K"
   },
   {
     "Class":"Predicate",
-    "Name":"http:\/\/schema.org\/spatialCoverage",
+    "Name":"https://schema.org/spatialCoverage",
     "Domain Bucket":"10K - 100K"
   },
   {
     "Class":"Predicate",
-    "Name":"http:\/\/schema.org\/spatialCoverage-input",
+    "Name":"https://schema.org/spatialCoverage-input",
     "Domain Bucket":"< 1K"
   },
   {
     "Class":"Predicate",
-    "Name":"http:\/\/schema.org\/spatialCoverage-output",
+    "Name":"https://schema.org/spatialCoverage-output",
     "Domain Bucket":"< 1K"
   },
   {
     "Class":"Predicate",
-    "Name":"http:\/\/schema.org\/speakable",
+    "Name":"https://schema.org/speakable",
     "Domain Bucket":"100K - 1M"
   },
   {
     "Class":"Predicate",
-    "Name":"http:\/\/schema.org\/speakable-input",
+    "Name":"https://schema.org/speakable-input",
     "Domain Bucket":"< 1K"
   },
   {
     "Class":"Predicate",
-    "Name":"http:\/\/schema.org\/speakable-output",
+    "Name":"https://schema.org/speakable-output",
     "Domain Bucket":"< 1K"
   },
   {
     "Class":"Predicate",
-    "Name":"http:\/\/schema.org\/specialCommitments",
+    "Name":"https://schema.org/specialCommitments",
     "Domain Bucket":"< 1K"
   },
   {
     "Class":"Predicate",
-    "Name":"http:\/\/schema.org\/specialCommitments-input",
+    "Name":"https://schema.org/specialCommitments-input",
     "Domain Bucket":"< 1K"
   },
   {
     "Class":"Predicate",
-    "Name":"http:\/\/schema.org\/specialCommitments-output",
+    "Name":"https://schema.org/specialCommitments-output",
     "Domain Bucket":"< 1K"
   },
   {
     "Class":"Predicate",
-    "Name":"http:\/\/schema.org\/specialOpeningHoursSpecification",
+    "Name":"https://schema.org/specialOpeningHoursSpecification",
     "Domain Bucket":"1K - 10K"
   },
   {
     "Class":"Predicate",
-    "Name":"http:\/\/schema.org\/specialOpeningHoursSpecification-input",
+    "Name":"https://schema.org/specialOpeningHoursSpecification-input",
     "Domain Bucket":"< 1K"
   },
   {
     "Class":"Predicate",
-    "Name":"http:\/\/schema.org\/specialOpeningHoursSpecification-output",
+    "Name":"https://schema.org/specialOpeningHoursSpecification-output",
     "Domain Bucket":"< 1K"
   },
   {
     "Class":"Predicate",
-    "Name":"http:\/\/schema.org\/specialty",
+    "Name":"https://schema.org/specialty",
     "Domain Bucket":"10K - 100K"
   },
   {
     "Class":"Predicate",
-    "Name":"http:\/\/schema.org\/specialty-input",
+    "Name":"https://schema.org/specialty-input",
     "Domain Bucket":"< 1K"
   },
   {
     "Class":"Predicate",
-    "Name":"http:\/\/schema.org\/specialty-output",
+    "Name":"https://schema.org/specialty-output",
     "Domain Bucket":"< 1K"
   },
   {
     "Class":"Predicate",
-    "Name":"http:\/\/schema.org\/speechToTextMarkup",
+    "Name":"https://schema.org/speechToTextMarkup",
     "Domain Bucket":"< 1K"
   },
   {
     "Class":"Predicate",
-    "Name":"http:\/\/schema.org\/speechToTextMarkup-input",
+    "Name":"https://schema.org/speechToTextMarkup-input",
     "Domain Bucket":"< 1K"
   },
   {
     "Class":"Predicate",
-    "Name":"http:\/\/schema.org\/speechToTextMarkup-output",
+    "Name":"https://schema.org/speechToTextMarkup-output",
     "Domain Bucket":"< 1K"
   },
   {
     "Class":"Predicate",
-    "Name":"http:\/\/schema.org\/speed",
+    "Name":"https://schema.org/speed",
     "Domain Bucket":"1K - 10K"
   },
   {
     "Class":"Predicate",
-    "Name":"http:\/\/schema.org\/speed-input",
+    "Name":"https://schema.org/speed-input",
     "Domain Bucket":"< 1K"
   },
   {
     "Class":"Predicate",
-    "Name":"http:\/\/schema.org\/speed-output",
+    "Name":"https://schema.org/speed-output",
     "Domain Bucket":"< 1K"
   },
   {
     "Class":"Predicate",
-    "Name":"http:\/\/schema.org\/spokenByCharacter",
+    "Name":"https://schema.org/spokenByCharacter",
     "Domain Bucket":"< 1K"
   },
   {
     "Class":"Predicate",
-    "Name":"http:\/\/schema.org\/spokenByCharacter-input",
+    "Name":"https://schema.org/spokenByCharacter-input",
     "Domain Bucket":"< 1K"
   },
   {
     "Class":"Predicate",
-    "Name":"http:\/\/schema.org\/spokenByCharacter-output",
+    "Name":"https://schema.org/spokenByCharacter-output",
     "Domain Bucket":"< 1K"
   },
   {
     "Class":"Predicate",
-    "Name":"http:\/\/schema.org\/sponsor",
+    "Name":"https://schema.org/sponsor",
     "Domain Bucket":"10K - 100K"
   },
   {
     "Class":"Predicate",
-    "Name":"http:\/\/schema.org\/sponsor-input",
+    "Name":"https://schema.org/sponsor-input",
     "Domain Bucket":"< 1K"
   },
   {
     "Class":"Predicate",
-    "Name":"http:\/\/schema.org\/sponsor-output",
+    "Name":"https://schema.org/sponsor-output",
     "Domain Bucket":"< 1K"
   },
   {
     "Class":"Predicate",
-    "Name":"http:\/\/schema.org\/sport",
+    "Name":"https://schema.org/sport",
     "Domain Bucket":"10K - 100K"
   },
   {
     "Class":"Predicate",
-    "Name":"http:\/\/schema.org\/sport-input",
+    "Name":"https://schema.org/sport-input",
     "Domain Bucket":"< 1K"
   },
   {
     "Class":"Predicate",
-    "Name":"http:\/\/schema.org\/sport-output",
+    "Name":"https://schema.org/sport-output",
     "Domain Bucket":"< 1K"
   },
   {
     "Class":"Predicate",
-    "Name":"http:\/\/schema.org\/sportsActivityLocation",
+    "Name":"https://schema.org/sportsActivityLocation",
     "Domain Bucket":"< 1K"
   },
   {
     "Class":"Predicate",
-    "Name":"http:\/\/schema.org\/sportsActivityLocation-input",
+    "Name":"https://schema.org/sportsActivityLocation-input",
     "Domain Bucket":"< 1K"
   },
   {
     "Class":"Predicate",
-    "Name":"http:\/\/schema.org\/sportsActivityLocation-output",
+    "Name":"https://schema.org/sportsActivityLocation-output",
     "Domain Bucket":"< 1K"
   },
   {
     "Class":"Predicate",
-    "Name":"http:\/\/schema.org\/sportsEvent",
+    "Name":"https://schema.org/sportsEvent",
     "Domain Bucket":"< 1K"
   },
   {
     "Class":"Predicate",
-    "Name":"http:\/\/schema.org\/sportsEvent-input",
+    "Name":"https://schema.org/sportsEvent-input",
     "Domain Bucket":"< 1K"
   },
   {
     "Class":"Predicate",
-    "Name":"http:\/\/schema.org\/sportsEvent-output",
+    "Name":"https://schema.org/sportsEvent-output",
     "Domain Bucket":"< 1K"
   },
   {
     "Class":"Predicate",
-    "Name":"http:\/\/schema.org\/sportsTeam",
+    "Name":"https://schema.org/sportsTeam",
     "Domain Bucket":"< 1K"
   },
   {
     "Class":"Predicate",
-    "Name":"http:\/\/schema.org\/sportsTeam-input",
+    "Name":"https://schema.org/sportsTeam-input",
     "Domain Bucket":"< 1K"
   },
   {
     "Class":"Predicate",
-    "Name":"http:\/\/schema.org\/sportsTeam-output",
+    "Name":"https://schema.org/sportsTeam-output",
     "Domain Bucket":"< 1K"
   },
   {
     "Class":"Predicate",
-    "Name":"http:\/\/schema.org\/spouse",
+    "Name":"https://schema.org/spouse",
     "Domain Bucket":"1K - 10K"
   },
   {
     "Class":"Predicate",
-    "Name":"http:\/\/schema.org\/spouse-input",
+    "Name":"https://schema.org/spouse-input",
     "Domain Bucket":"< 1K"
   },
   {
     "Class":"Predicate",
-    "Name":"http:\/\/schema.org\/spouse-output",
+    "Name":"https://schema.org/spouse-output",
     "Domain Bucket":"< 1K"
   },
   {
     "Class":"Predicate",
-    "Name":"http:\/\/schema.org\/stage",
+    "Name":"https://schema.org/stage",
     "Domain Bucket":"< 1K"
   },
   {
     "Class":"Predicate",
-    "Name":"http:\/\/schema.org\/stage-input",
+    "Name":"https://schema.org/stage-input",
     "Domain Bucket":"< 1K"
   },
   {
     "Class":"Predicate",
-    "Name":"http:\/\/schema.org\/stage-output",
+    "Name":"https://schema.org/stage-output",
     "Domain Bucket":"< 1K"
   },
   {
     "Class":"Predicate",
-    "Name":"http:\/\/schema.org\/stageAsNumber",
+    "Name":"https://schema.org/stageAsNumber",
     "Domain Bucket":"< 1K"
   },
   {
     "Class":"Predicate",
-    "Name":"http:\/\/schema.org\/stageAsNumber-input",
+    "Name":"https://schema.org/stageAsNumber-input",
     "Domain Bucket":"< 1K"
   },
   {
     "Class":"Predicate",
-    "Name":"http:\/\/schema.org\/stageAsNumber-output",
+    "Name":"https://schema.org/stageAsNumber-output",
     "Domain Bucket":"< 1K"
   },
   {
     "Class":"Predicate",
-    "Name":"http:\/\/schema.org\/starRating",
+    "Name":"https://schema.org/starRating",
     "Domain Bucket":"10K - 100K"
   },
   {
     "Class":"Predicate",
-    "Name":"http:\/\/schema.org\/starRating-input",
+    "Name":"https://schema.org/starRating-input",
     "Domain Bucket":"< 1K"
   },
   {
     "Class":"Predicate",
-    "Name":"http:\/\/schema.org\/starRating-output",
+    "Name":"https://schema.org/starRating-output",
     "Domain Bucket":"< 1K"
   },
   {
     "Class":"Predicate",
-    "Name":"http:\/\/schema.org\/startDate",
+    "Name":"https://schema.org/startDate",
     "Domain Bucket":"100K - 1M"
   },
   {
     "Class":"Predicate",
-    "Name":"http:\/\/schema.org\/startDate-input",
+    "Name":"https://schema.org/startDate-input",
     "Domain Bucket":"< 1K"
   },
   {
     "Class":"Predicate",
-    "Name":"http:\/\/schema.org\/startDate-output",
+    "Name":"https://schema.org/startDate-output",
     "Domain Bucket":"< 1K"
   },
   {
     "Class":"Predicate",
-    "Name":"http:\/\/schema.org\/startOffset",
+    "Name":"https://schema.org/startOffset",
     "Domain Bucket":"10K - 100K"
   },
   {
     "Class":"Predicate",
-    "Name":"http:\/\/schema.org\/startOffset-input",
+    "Name":"https://schema.org/startOffset-input",
     "Domain Bucket":"10K - 100K"
   },
   {
     "Class":"Predicate",
-    "Name":"http:\/\/schema.org\/startOffset-output",
+    "Name":"https://schema.org/startOffset-output",
     "Domain Bucket":"< 1K"
   },
   {
     "Class":"Predicate",
-    "Name":"http:\/\/schema.org\/startTime",
+    "Name":"https://schema.org/startTime",
     "Domain Bucket":"1K - 10K"
   },
   {
     "Class":"Predicate",
-    "Name":"http:\/\/schema.org\/startTime-input",
+    "Name":"https://schema.org/startTime-input",
     "Domain Bucket":"< 1K"
   },
   {
     "Class":"Predicate",
-    "Name":"http:\/\/schema.org\/startTime-output",
+    "Name":"https://schema.org/startTime-output",
     "Domain Bucket":"< 1K"
   },
   {
     "Class":"Predicate",
-    "Name":"http:\/\/schema.org\/statType",
+    "Name":"https://schema.org/statType",
     "Domain Bucket":"< 1K"
   },
   {
     "Class":"Predicate",
-    "Name":"http:\/\/schema.org\/statType-input",
+    "Name":"https://schema.org/statType-input",
     "Domain Bucket":"< 1K"
   },
   {
     "Class":"Predicate",
-    "Name":"http:\/\/schema.org\/statType-output",
+    "Name":"https://schema.org/statType-output",
     "Domain Bucket":"< 1K"
   },
   {
     "Class":"Predicate",
-    "Name":"http:\/\/schema.org\/status",
+    "Name":"https://schema.org/status",
     "Domain Bucket":"1K - 10K"
   },
   {
     "Class":"Predicate",
-    "Name":"http:\/\/schema.org\/status-input",
+    "Name":"https://schema.org/status-input",
     "Domain Bucket":"< 1K"
   },
   {
     "Class":"Predicate",
-    "Name":"http:\/\/schema.org\/status-output",
+    "Name":"https://schema.org/status-output",
     "Domain Bucket":"< 1K"
   },
   {
     "Class":"Predicate",
-    "Name":"http:\/\/schema.org\/steeringPosition",
+    "Name":"https://schema.org/steeringPosition",
     "Domain Bucket":"1K - 10K"
   },
   {
     "Class":"Predicate",
-    "Name":"http:\/\/schema.org\/steeringPosition-input",
+    "Name":"https://schema.org/steeringPosition-input",
     "Domain Bucket":"< 1K"
   },
   {
     "Class":"Predicate",
-    "Name":"http:\/\/schema.org\/steeringPosition-output",
+    "Name":"https://schema.org/steeringPosition-output",
     "Domain Bucket":"< 1K"
   },
   {
     "Class":"Predicate",
-    "Name":"http:\/\/schema.org\/step",
+    "Name":"https://schema.org/step",
     "Domain Bucket":"100K - 1M"
   },
   {
     "Class":"Predicate",
-    "Name":"http:\/\/schema.org\/step-input",
+    "Name":"https://schema.org/step-input",
     "Domain Bucket":"< 1K"
   },
   {
     "Class":"Predicate",
-    "Name":"http:\/\/schema.org\/step-output",
+    "Name":"https://schema.org/step-output",
     "Domain Bucket":"< 1K"
   },
   {
     "Class":"Predicate",
-    "Name":"http:\/\/schema.org\/stepValue",
+    "Name":"https://schema.org/stepValue",
     "Domain Bucket":"< 1K"
   },
   {
     "Class":"Predicate",
-    "Name":"http:\/\/schema.org\/stepValue-input",
+    "Name":"https://schema.org/stepValue-input",
     "Domain Bucket":"< 1K"
   },
   {
     "Class":"Predicate",
-    "Name":"http:\/\/schema.org\/stepValue-output",
+    "Name":"https://schema.org/stepValue-output",
     "Domain Bucket":"< 1K"
   },
   {
     "Class":"Predicate",
-    "Name":"http:\/\/schema.org\/steps",
+    "Name":"https://schema.org/steps",
     "Domain Bucket":"< 1K"
   },
   {
     "Class":"Predicate",
-    "Name":"http:\/\/schema.org\/steps-input",
+    "Name":"https://schema.org/steps-input",
     "Domain Bucket":"< 1K"
   },
   {
     "Class":"Predicate",
-    "Name":"http:\/\/schema.org\/steps-output",
+    "Name":"https://schema.org/steps-output",
     "Domain Bucket":"< 1K"
   },
   {
     "Class":"Predicate",
-    "Name":"http:\/\/schema.org\/storageRequirements",
+    "Name":"https://schema.org/storageRequirements",
     "Domain Bucket":"10K - 100K"
   },
   {
     "Class":"Predicate",
-    "Name":"http:\/\/schema.org\/storageRequirements-input",
+    "Name":"https://schema.org/storageRequirements-input",
     "Domain Bucket":"< 1K"
   },
   {
     "Class":"Predicate",
-    "Name":"http:\/\/schema.org\/storageRequirements-output",
+    "Name":"https://schema.org/storageRequirements-output",
     "Domain Bucket":"< 1K"
   },
   {
     "Class":"Predicate",
-    "Name":"http:\/\/schema.org\/streetAddress",
+    "Name":"https://schema.org/streetAddress",
     "Domain Bucket":"1M - 10M"
   },
   {
     "Class":"Predicate",
-    "Name":"http:\/\/schema.org\/streetAddress-input",
+    "Name":"https://schema.org/streetAddress-input",
     "Domain Bucket":"< 1K"
   },
   {
     "Class":"Predicate",
-    "Name":"http:\/\/schema.org\/streetAddress-output",
+    "Name":"https://schema.org/streetAddress-output",
     "Domain Bucket":"< 1K"
   },
   {
     "Class":"Predicate",
-    "Name":"http:\/\/schema.org\/strengthUnit",
+    "Name":"https://schema.org/strengthUnit",
     "Domain Bucket":"< 1K"
   },
   {
     "Class":"Predicate",
-    "Name":"http:\/\/schema.org\/strengthUnit-input",
+    "Name":"https://schema.org/strengthUnit-input",
     "Domain Bucket":"< 1K"
   },
   {
     "Class":"Predicate",
-    "Name":"http:\/\/schema.org\/strengthUnit-output",
+    "Name":"https://schema.org/strengthUnit-output",
     "Domain Bucket":"< 1K"
   },
   {
     "Class":"Predicate",
-    "Name":"http:\/\/schema.org\/strengthValue",
+    "Name":"https://schema.org/strengthValue",
     "Domain Bucket":"< 1K"
   },
   {
     "Class":"Predicate",
-    "Name":"http:\/\/schema.org\/strengthValue-input",
+    "Name":"https://schema.org/strengthValue-input",
     "Domain Bucket":"< 1K"
   },
   {
     "Class":"Predicate",
-    "Name":"http:\/\/schema.org\/strengthValue-output",
+    "Name":"https://schema.org/strengthValue-output",
     "Domain Bucket":"< 1K"
   },
   {
     "Class":"Predicate",
-    "Name":"http:\/\/schema.org\/structuralClass",
+    "Name":"https://schema.org/structuralClass",
     "Domain Bucket":"< 1K"
   },
   {
     "Class":"Predicate",
-    "Name":"http:\/\/schema.org\/structuralClass-input",
+    "Name":"https://schema.org/structuralClass-input",
     "Domain Bucket":"< 1K"
   },
   {
     "Class":"Predicate",
-    "Name":"http:\/\/schema.org\/structuralClass-output",
+    "Name":"https://schema.org/structuralClass-output",
     "Domain Bucket":"< 1K"
   },
   {
     "Class":"Predicate",
-    "Name":"http:\/\/schema.org\/study",
+    "Name":"https://schema.org/study",
     "Domain Bucket":"< 1K"
   },
   {
     "Class":"Predicate",
-    "Name":"http:\/\/schema.org\/study-input",
+    "Name":"https://schema.org/study-input",
     "Domain Bucket":"< 1K"
   },
   {
     "Class":"Predicate",
-    "Name":"http:\/\/schema.org\/study-output",
+    "Name":"https://schema.org/study-output",
     "Domain Bucket":"< 1K"
   },
   {
     "Class":"Predicate",
-    "Name":"http:\/\/schema.org\/studyDesign",
+    "Name":"https://schema.org/studyDesign",
     "Domain Bucket":"< 1K"
   },
   {
     "Class":"Predicate",
-    "Name":"http:\/\/schema.org\/studyDesign-input",
+    "Name":"https://schema.org/studyDesign-input",
     "Domain Bucket":"< 1K"
   },
   {
     "Class":"Predicate",
-    "Name":"http:\/\/schema.org\/studyDesign-output",
+    "Name":"https://schema.org/studyDesign-output",
     "Domain Bucket":"< 1K"
   },
   {
     "Class":"Predicate",
-    "Name":"http:\/\/schema.org\/studyLocation",
+    "Name":"https://schema.org/studyLocation",
     "Domain Bucket":"< 1K"
   },
   {
     "Class":"Predicate",
-    "Name":"http:\/\/schema.org\/studyLocation-input",
+    "Name":"https://schema.org/studyLocation-input",
     "Domain Bucket":"< 1K"
   },
   {
     "Class":"Predicate",
-    "Name":"http:\/\/schema.org\/studyLocation-output",
+    "Name":"https://schema.org/studyLocation-output",
     "Domain Bucket":"< 1K"
   },
   {
     "Class":"Predicate",
-    "Name":"http:\/\/schema.org\/studySubject",
+    "Name":"https://schema.org/studySubject",
     "Domain Bucket":"< 1K"
   },
   {
     "Class":"Predicate",
-    "Name":"http:\/\/schema.org\/studySubject-input",
+    "Name":"https://schema.org/studySubject-input",
     "Domain Bucket":"< 1K"
   },
   {
     "Class":"Predicate",
-    "Name":"http:\/\/schema.org\/studySubject-output",
+    "Name":"https://schema.org/studySubject-output",
     "Domain Bucket":"< 1K"
   },
   {
     "Class":"Predicate",
-    "Name":"http:\/\/schema.org\/stupidProperty",
+    "Name":"https://schema.org/stupidProperty",
     "Domain Bucket":"< 1K"
   },
   {
     "Class":"Predicate",
-    "Name":"http:\/\/schema.org\/stupidProperty-input",
+    "Name":"https://schema.org/stupidProperty-input",
     "Domain Bucket":"< 1K"
   },
   {
     "Class":"Predicate",
-    "Name":"http:\/\/schema.org\/stupidProperty-output",
+    "Name":"https://schema.org/stupidProperty-output",
     "Domain Bucket":"< 1K"
   },
   {
     "Class":"Predicate",
-    "Name":"http:\/\/schema.org\/subEvent",
+    "Name":"https://schema.org/subEvent",
     "Domain Bucket":"1K - 10K"
   },
   {
     "Class":"Predicate",
-    "Name":"http:\/\/schema.org\/subEvent-input",
+    "Name":"https://schema.org/subEvent-input",
     "Domain Bucket":"< 1K"
   },
   {
     "Class":"Predicate",
-    "Name":"http:\/\/schema.org\/subEvent-output",
+    "Name":"https://schema.org/subEvent-output",
     "Domain Bucket":"< 1K"
   },
   {
     "Class":"Predicate",
-    "Name":"http:\/\/schema.org\/subEvents",
+    "Name":"https://schema.org/subEvents",
     "Domain Bucket":"< 1K"
   },
   {
     "Class":"Predicate",
-    "Name":"http:\/\/schema.org\/subEvents-input",
+    "Name":"https://schema.org/subEvents-input",
     "Domain Bucket":"< 1K"
   },
   {
     "Class":"Predicate",
-    "Name":"http:\/\/schema.org\/subEvents-output",
+    "Name":"https://schema.org/subEvents-output",
     "Domain Bucket":"< 1K"
   },
   {
     "Class":"Predicate",
-    "Name":"http:\/\/schema.org\/subOrganization",
+    "Name":"https://schema.org/subOrganization",
     "Domain Bucket":"10K - 100K"
   },
   {
     "Class":"Predicate",
-    "Name":"http:\/\/schema.org\/subOrganization-input",
+    "Name":"https://schema.org/subOrganization-input",
     "Domain Bucket":"< 1K"
   },
   {
     "Class":"Predicate",
-    "Name":"http:\/\/schema.org\/subOrganization-output",
+    "Name":"https://schema.org/subOrganization-output",
     "Domain Bucket":"< 1K"
   },
   {
     "Class":"Predicate",
-    "Name":"http:\/\/schema.org\/subReservation",
+    "Name":"https://schema.org/subReservation",
     "Domain Bucket":"< 1K"
   },
   {
     "Class":"Predicate",
-    "Name":"http:\/\/schema.org\/subReservation-input",
+    "Name":"https://schema.org/subReservation-input",
     "Domain Bucket":"< 1K"
   },
   {
     "Class":"Predicate",
-    "Name":"http:\/\/schema.org\/subReservation-output",
+    "Name":"https://schema.org/subReservation-output",
     "Domain Bucket":"< 1K"
   },
   {
     "Class":"Predicate",
-    "Name":"http:\/\/schema.org\/subStageSuffix",
+    "Name":"https://schema.org/subStageSuffix",
     "Domain Bucket":"< 1K"
   },
   {
     "Class":"Predicate",
-    "Name":"http:\/\/schema.org\/subStageSuffix-input",
+    "Name":"https://schema.org/subStageSuffix-input",
     "Domain Bucket":"< 1K"
   },
   {
     "Class":"Predicate",
-    "Name":"http:\/\/schema.org\/subStageSuffix-output",
+    "Name":"https://schema.org/subStageSuffix-output",
     "Domain Bucket":"< 1K"
   },
   {
     "Class":"Predicate",
-    "Name":"http:\/\/schema.org\/subStructure",
+    "Name":"https://schema.org/subStructure",
     "Domain Bucket":"< 1K"
   },
   {
     "Class":"Predicate",
-    "Name":"http:\/\/schema.org\/subStructure-input",
+    "Name":"https://schema.org/subStructure-input",
     "Domain Bucket":"< 1K"
   },
   {
     "Class":"Predicate",
-    "Name":"http:\/\/schema.org\/subStructure-output",
+    "Name":"https://schema.org/subStructure-output",
     "Domain Bucket":"< 1K"
   },
   {
     "Class":"Predicate",
-    "Name":"http:\/\/schema.org\/subTest",
+    "Name":"https://schema.org/subTest",
     "Domain Bucket":"< 1K"
   },
   {
     "Class":"Predicate",
-    "Name":"http:\/\/schema.org\/subTest-input",
+    "Name":"https://schema.org/subTest-input",
     "Domain Bucket":"< 1K"
   },
   {
     "Class":"Predicate",
-    "Name":"http:\/\/schema.org\/subTest-output",
+    "Name":"https://schema.org/subTest-output",
     "Domain Bucket":"< 1K"
   },
   {
     "Class":"Predicate",
-    "Name":"http:\/\/schema.org\/subTrip",
+    "Name":"https://schema.org/subTrip",
     "Domain Bucket":"< 1K"
   },
   {
     "Class":"Predicate",
-    "Name":"http:\/\/schema.org\/subTrip-input",
+    "Name":"https://schema.org/subTrip-input",
     "Domain Bucket":"< 1K"
   },
   {
     "Class":"Predicate",
-    "Name":"http:\/\/schema.org\/subTrip-output",
+    "Name":"https://schema.org/subTrip-output",
     "Domain Bucket":"< 1K"
   },
   {
     "Class":"Predicate",
-    "Name":"http:\/\/schema.org\/subjectOf",
+    "Name":"https://schema.org/subjectOf",
     "Domain Bucket":"100K - 1M"
   },
   {
     "Class":"Predicate",
-    "Name":"http:\/\/schema.org\/subjectOf-input",
+    "Name":"https://schema.org/subjectOf-input",
     "Domain Bucket":"< 1K"
   },
   {
     "Class":"Predicate",
-    "Name":"http:\/\/schema.org\/subjectOf-output",
+    "Name":"https://schema.org/subjectOf-output",
     "Domain Bucket":"< 1K"
   },
   {
     "Class":"Predicate",
-    "Name":"http:\/\/schema.org\/subtitleLanguage",
+    "Name":"https://schema.org/subtitleLanguage",
     "Domain Bucket":"< 1K"
   },
   {
     "Class":"Predicate",
-    "Name":"http:\/\/schema.org\/subtitleLanguage-input",
+    "Name":"https://schema.org/subtitleLanguage-input",
     "Domain Bucket":"< 1K"
   },
   {
     "Class":"Predicate",
-    "Name":"http:\/\/schema.org\/subtitleLanguage-output",
+    "Name":"https://schema.org/subtitleLanguage-output",
     "Domain Bucket":"< 1K"
   },
   {
     "Class":"Predicate",
-    "Name":"http:\/\/schema.org\/successorOf",
+    "Name":"https://schema.org/successorOf",
     "Domain Bucket":"< 1K"
   },
   {
     "Class":"Predicate",
-    "Name":"http:\/\/schema.org\/successorOf-input",
+    "Name":"https://schema.org/successorOf-input",
     "Domain Bucket":"< 1K"
   },
   {
     "Class":"Predicate",
-    "Name":"http:\/\/schema.org\/successorOf-output",
+    "Name":"https://schema.org/successorOf-output",
     "Domain Bucket":"< 1K"
   },
   {
     "Class":"Predicate",
-    "Name":"http:\/\/schema.org\/sugarContent",
+    "Name":"https://schema.org/sugarContent",
     "Domain Bucket":"10K - 100K"
   },
   {
     "Class":"Predicate",
-    "Name":"http:\/\/schema.org\/sugarContent-input",
+    "Name":"https://schema.org/sugarContent-input",
     "Domain Bucket":"< 1K"
   },
   {
     "Class":"Predicate",
-    "Name":"http:\/\/schema.org\/sugarContent-output",
+    "Name":"https://schema.org/sugarContent-output",
     "Domain Bucket":"< 1K"
   },
   {
     "Class":"Predicate",
-    "Name":"http:\/\/schema.org\/suggestedAge",
+    "Name":"https://schema.org/suggestedAge",
     "Domain Bucket":"1K - 10K"
   },
   {
     "Class":"Predicate",
-    "Name":"http:\/\/schema.org\/suggestedAge-input",
+    "Name":"https://schema.org/suggestedAge-input",
     "Domain Bucket":"< 1K"
   },
   {
     "Class":"Predicate",
-    "Name":"http:\/\/schema.org\/suggestedAge-output",
+    "Name":"https://schema.org/suggestedAge-output",
     "Domain Bucket":"< 1K"
   },
   {
     "Class":"Predicate",
-    "Name":"http:\/\/schema.org\/suggestedAnswer",
+    "Name":"https://schema.org/suggestedAnswer",
     "Domain Bucket":"10K - 100K"
   },
   {
     "Class":"Predicate",
-    "Name":"http:\/\/schema.org\/suggestedAnswer-input",
+    "Name":"https://schema.org/suggestedAnswer-input",
     "Domain Bucket":"< 1K"
   },
   {
     "Class":"Predicate",
-    "Name":"http:\/\/schema.org\/suggestedAnswer-output",
+    "Name":"https://schema.org/suggestedAnswer-output",
     "Domain Bucket":"< 1K"
   },
   {
     "Class":"Predicate",
-    "Name":"http:\/\/schema.org\/suggestedGender",
+    "Name":"https://schema.org/suggestedGender",
     "Domain Bucket":"10K - 100K"
   },
   {
     "Class":"Predicate",
-    "Name":"http:\/\/schema.org\/suggestedGender-input",
+    "Name":"https://schema.org/suggestedGender-input",
     "Domain Bucket":"< 1K"
   },
   {
     "Class":"Predicate",
-    "Name":"http:\/\/schema.org\/suggestedGender-output",
+    "Name":"https://schema.org/suggestedGender-output",
     "Domain Bucket":"< 1K"
   },
   {
     "Class":"Predicate",
-    "Name":"http:\/\/schema.org\/suggestedMaxAge",
+    "Name":"https://schema.org/suggestedMaxAge",
     "Domain Bucket":"1K - 10K"
   },
   {
     "Class":"Predicate",
-    "Name":"http:\/\/schema.org\/suggestedMaxAge-input",
+    "Name":"https://schema.org/suggestedMaxAge-input",
     "Domain Bucket":"< 1K"
   },
   {
     "Class":"Predicate",
-    "Name":"http:\/\/schema.org\/suggestedMaxAge-output",
+    "Name":"https://schema.org/suggestedMaxAge-output",
     "Domain Bucket":"< 1K"
   },
   {
     "Class":"Predicate",
-    "Name":"http:\/\/schema.org\/suggestedMeasurement",
+    "Name":"https://schema.org/suggestedMeasurement",
     "Domain Bucket":"< 1K"
   },
   {
     "Class":"Predicate",
-    "Name":"http:\/\/schema.org\/suggestedMeasurement-input",
+    "Name":"https://schema.org/suggestedMeasurement-input",
     "Domain Bucket":"< 1K"
   },
   {
     "Class":"Predicate",
-    "Name":"http:\/\/schema.org\/suggestedMeasurement-output",
+    "Name":"https://schema.org/suggestedMeasurement-output",
     "Domain Bucket":"< 1K"
   },
   {
     "Class":"Predicate",
-    "Name":"http:\/\/schema.org\/suggestedMinAge",
+    "Name":"https://schema.org/suggestedMinAge",
     "Domain Bucket":"10K - 100K"
   },
   {
     "Class":"Predicate",
-    "Name":"http:\/\/schema.org\/suggestedMinAge-input",
+    "Name":"https://schema.org/suggestedMinAge-input",
     "Domain Bucket":"< 1K"
   },
   {
     "Class":"Predicate",
-    "Name":"http:\/\/schema.org\/suggestedMinAge-output",
+    "Name":"https://schema.org/suggestedMinAge-output",
     "Domain Bucket":"< 1K"
   },
   {
     "Class":"Predicate",
-    "Name":"http:\/\/schema.org\/suitableForDiet",
+    "Name":"https://schema.org/suitableForDiet",
     "Domain Bucket":"10K - 100K"
   },
   {
     "Class":"Predicate",
-    "Name":"http:\/\/schema.org\/suitableForDiet-input",
+    "Name":"https://schema.org/suitableForDiet-input",
     "Domain Bucket":"< 1K"
   },
   {
     "Class":"Predicate",
-    "Name":"http:\/\/schema.org\/suitableForDiet-output",
+    "Name":"https://schema.org/suitableForDiet-output",
     "Domain Bucket":"< 1K"
   },
   {
     "Class":"Predicate",
-    "Name":"http:\/\/schema.org\/superEvent",
+    "Name":"https://schema.org/superEvent",
     "Domain Bucket":"1K - 10K"
   },
   {
     "Class":"Predicate",
-    "Name":"http:\/\/schema.org\/superEvent-input",
+    "Name":"https://schema.org/superEvent-input",
     "Domain Bucket":"< 1K"
   },
   {
     "Class":"Predicate",
-    "Name":"http:\/\/schema.org\/superEvent-output",
+    "Name":"https://schema.org/superEvent-output",
     "Domain Bucket":"< 1K"
   },
   {
     "Class":"Predicate",
-    "Name":"http:\/\/schema.org\/supersededBy",
+    "Name":"https://schema.org/supersededBy",
     "Domain Bucket":"1K - 10K"
   },
   {
     "Class":"Predicate",
-    "Name":"http:\/\/schema.org\/supersededBy-input",
+    "Name":"https://schema.org/supersededBy-input",
     "Domain Bucket":"< 1K"
   },
   {
     "Class":"Predicate",
-    "Name":"http:\/\/schema.org\/supersededBy-output",
+    "Name":"https://schema.org/supersededBy-output",
     "Domain Bucket":"< 1K"
   },
   {
     "Class":"Predicate",
-    "Name":"http:\/\/schema.org\/supply",
+    "Name":"https://schema.org/supply",
     "Domain Bucket":"10K - 100K"
   },
   {
     "Class":"Predicate",
-    "Name":"http:\/\/schema.org\/supply-input",
+    "Name":"https://schema.org/supply-input",
     "Domain Bucket":"< 1K"
   },
   {
     "Class":"Predicate",
-    "Name":"http:\/\/schema.org\/supply-output",
+    "Name":"https://schema.org/supply-output",
     "Domain Bucket":"< 1K"
   },
   {
     "Class":"Predicate",
-    "Name":"http:\/\/schema.org\/supplyTo",
+    "Name":"https://schema.org/supplyTo",
     "Domain Bucket":"< 1K"
   },
   {
     "Class":"Predicate",
-    "Name":"http:\/\/schema.org\/supplyTo-input",
+    "Name":"https://schema.org/supplyTo-input",
     "Domain Bucket":"< 1K"
   },
   {
     "Class":"Predicate",
-    "Name":"http:\/\/schema.org\/supplyTo-output",
+    "Name":"https://schema.org/supplyTo-output",
     "Domain Bucket":"< 1K"
   },
   {
     "Class":"Predicate",
-    "Name":"http:\/\/schema.org\/supportingData",
+    "Name":"https://schema.org/supportingData",
     "Domain Bucket":"< 1K"
   },
   {
     "Class":"Predicate",
-    "Name":"http:\/\/schema.org\/supportingData-input",
+    "Name":"https://schema.org/supportingData-input",
     "Domain Bucket":"< 1K"
   },
   {
     "Class":"Predicate",
-    "Name":"http:\/\/schema.org\/supportingData-output",
+    "Name":"https://schema.org/supportingData-output",
     "Domain Bucket":"< 1K"
   },
   {
     "Class":"Predicate",
-    "Name":"http:\/\/schema.org\/surface",
+    "Name":"https://schema.org/surface",
     "Domain Bucket":"< 1K"
   },
   {
     "Class":"Predicate",
-    "Name":"http:\/\/schema.org\/surface-input",
+    "Name":"https://schema.org/surface-input",
     "Domain Bucket":"< 1K"
   },
   {
     "Class":"Predicate",
-    "Name":"http:\/\/schema.org\/surface-output",
+    "Name":"https://schema.org/surface-output",
     "Domain Bucket":"< 1K"
   },
   {
     "Class":"Predicate",
-    "Name":"http:\/\/schema.org\/syllabusSections",
+    "Name":"https://schema.org/syllabusSections",
     "Domain Bucket":"1K - 10K"
   },
   {
     "Class":"Predicate",
-    "Name":"http:\/\/schema.org\/syllabusSections-input",
+    "Name":"https://schema.org/syllabusSections-input",
     "Domain Bucket":"< 1K"
   },
   {
     "Class":"Predicate",
-    "Name":"http:\/\/schema.org\/syllabusSections-output",
+    "Name":"https://schema.org/syllabusSections-output",
     "Domain Bucket":"< 1K"
   },
   {
     "Class":"Predicate",
-    "Name":"http:\/\/schema.org\/target",
+    "Name":"https://schema.org/target",
     "Domain Bucket":"10M+"
   },
   {
     "Class":"Predicate",
-    "Name":"http:\/\/schema.org\/target-input",
+    "Name":"https://schema.org/target-input",
     "Domain Bucket":"< 1K"
   },
   {
     "Class":"Predicate",
-    "Name":"http:\/\/schema.org\/target-output",
+    "Name":"https://schema.org/target-output",
     "Domain Bucket":"< 1K"
   },
   {
     "Class":"Predicate",
-    "Name":"http:\/\/schema.org\/targetCollection",
+    "Name":"https://schema.org/targetCollection",
     "Domain Bucket":"< 1K"
   },
   {
     "Class":"Predicate",
-    "Name":"http:\/\/schema.org\/targetCollection-input",
+    "Name":"https://schema.org/targetCollection-input",
     "Domain Bucket":"< 1K"
   },
   {
     "Class":"Predicate",
-    "Name":"http:\/\/schema.org\/targetCollection-output",
+    "Name":"https://schema.org/targetCollection-output",
     "Domain Bucket":"< 1K"
   },
   {
     "Class":"Predicate",
-    "Name":"http:\/\/schema.org\/targetDescription",
+    "Name":"https://schema.org/targetDescription",
     "Domain Bucket":"< 1K"
   },
   {
     "Class":"Predicate",
-    "Name":"http:\/\/schema.org\/targetDescription-input",
+    "Name":"https://schema.org/targetDescription-input",
     "Domain Bucket":"< 1K"
   },
   {
     "Class":"Predicate",
-    "Name":"http:\/\/schema.org\/targetDescription-output",
+    "Name":"https://schema.org/targetDescription-output",
     "Domain Bucket":"< 1K"
   },
   {
     "Class":"Predicate",
-    "Name":"http:\/\/schema.org\/targetName",
+    "Name":"https://schema.org/targetName",
     "Domain Bucket":"1K - 10K"
   },
   {
     "Class":"Predicate",
-    "Name":"http:\/\/schema.org\/targetName-input",
+    "Name":"https://schema.org/targetName-input",
     "Domain Bucket":"< 1K"
   },
   {
     "Class":"Predicate",
-    "Name":"http:\/\/schema.org\/targetName-output",
+    "Name":"https://schema.org/targetName-output",
     "Domain Bucket":"< 1K"
   },
   {
     "Class":"Predicate",
-    "Name":"http:\/\/schema.org\/targetPlatform",
+    "Name":"https://schema.org/targetPlatform",
     "Domain Bucket":"< 1K"
   },
   {
     "Class":"Predicate",
-    "Name":"http:\/\/schema.org\/targetPlatform-input",
+    "Name":"https://schema.org/targetPlatform-input",
     "Domain Bucket":"< 1K"
   },
   {
     "Class":"Predicate",
-    "Name":"http:\/\/schema.org\/targetPlatform-output",
+    "Name":"https://schema.org/targetPlatform-output",
     "Domain Bucket":"< 1K"
   },
   {
     "Class":"Predicate",
-    "Name":"http:\/\/schema.org\/targetPopulation",
+    "Name":"https://schema.org/targetPopulation",
     "Domain Bucket":"< 1K"
   },
   {
     "Class":"Predicate",
-    "Name":"http:\/\/schema.org\/targetPopulation-input",
+    "Name":"https://schema.org/targetPopulation-input",
     "Domain Bucket":"< 1K"
   },
   {
     "Class":"Predicate",
-    "Name":"http:\/\/schema.org\/targetPopulation-output",
+    "Name":"https://schema.org/targetPopulation-output",
     "Domain Bucket":"< 1K"
   },
   {
     "Class":"Predicate",
-    "Name":"http:\/\/schema.org\/targetProduct",
+    "Name":"https://schema.org/targetProduct",
     "Domain Bucket":"< 1K"
   },
   {
     "Class":"Predicate",
-    "Name":"http:\/\/schema.org\/targetProduct-input",
+    "Name":"https://schema.org/targetProduct-input",
     "Domain Bucket":"< 1K"
   },
   {
     "Class":"Predicate",
-    "Name":"http:\/\/schema.org\/targetProduct-output",
+    "Name":"https://schema.org/targetProduct-output",
     "Domain Bucket":"< 1K"
   },
   {
     "Class":"Predicate",
-    "Name":"http:\/\/schema.org\/targetUrl",
+    "Name":"https://schema.org/targetUrl",
     "Domain Bucket":"< 1K"
   },
   {
     "Class":"Predicate",
-    "Name":"http:\/\/schema.org\/targetUrl-input",
+    "Name":"https://schema.org/targetUrl-input",
     "Domain Bucket":"< 1K"
   },
   {
     "Class":"Predicate",
-    "Name":"http:\/\/schema.org\/targetUrl-output",
+    "Name":"https://schema.org/targetUrl-output",
     "Domain Bucket":"< 1K"
   },
   {
     "Class":"Predicate",
-    "Name":"http:\/\/schema.org\/taxID",
+    "Name":"https://schema.org/taxID",
     "Domain Bucket":"10K - 100K"
   },
   {
     "Class":"Predicate",
-    "Name":"http:\/\/schema.org\/taxID-input",
+    "Name":"https://schema.org/taxID-input",
     "Domain Bucket":"< 1K"
   },
   {
     "Class":"Predicate",
-    "Name":"http:\/\/schema.org\/taxID-output",
+    "Name":"https://schema.org/taxID-output",
     "Domain Bucket":"< 1K"
   },
   {
     "Class":"Predicate",
-    "Name":"http:\/\/schema.org\/taxonRank",
+    "Name":"https://schema.org/taxonRank",
     "Domain Bucket":"< 1K"
   },
   {
     "Class":"Predicate",
-    "Name":"http:\/\/schema.org\/taxonRank-input",
+    "Name":"https://schema.org/taxonRank-input",
     "Domain Bucket":"< 1K"
   },
   {
     "Class":"Predicate",
-    "Name":"http:\/\/schema.org\/taxonRank-output",
+    "Name":"https://schema.org/taxonRank-output",
     "Domain Bucket":"< 1K"
   },
   {
     "Class":"Predicate",
-    "Name":"http:\/\/schema.org\/taxonomicRange",
+    "Name":"https://schema.org/taxonomicRange",
     "Domain Bucket":"< 1K"
   },
   {
     "Class":"Predicate",
-    "Name":"http:\/\/schema.org\/taxonomicRange-input",
+    "Name":"https://schema.org/taxonomicRange-input",
     "Domain Bucket":"< 1K"
   },
   {
     "Class":"Predicate",
-    "Name":"http:\/\/schema.org\/taxonomicRange-output",
+    "Name":"https://schema.org/taxonomicRange-output",
     "Domain Bucket":"< 1K"
   },
   {
     "Class":"Predicate",
-    "Name":"http:\/\/schema.org\/teaches",
+    "Name":"https://schema.org/teaches",
     "Domain Bucket":"10K - 100K"
   },
   {
     "Class":"Predicate",
-    "Name":"http:\/\/schema.org\/teaches-input",
+    "Name":"https://schema.org/teaches-input",
     "Domain Bucket":"< 1K"
   },
   {
     "Class":"Predicate",
-    "Name":"http:\/\/schema.org\/teaches-output",
+    "Name":"https://schema.org/teaches-output",
     "Domain Bucket":"< 1K"
   },
   {
     "Class":"Predicate",
-    "Name":"http:\/\/schema.org\/telephone",
+    "Name":"https://schema.org/telephone",
     "Domain Bucket":"1M - 10M"
   },
   {
     "Class":"Predicate",
-    "Name":"http:\/\/schema.org\/telephone-input",
+    "Name":"https://schema.org/telephone-input",
     "Domain Bucket":"< 1K"
   },
   {
     "Class":"Predicate",
-    "Name":"http:\/\/schema.org\/telephone-output",
+    "Name":"https://schema.org/telephone-output",
     "Domain Bucket":"< 1K"
   },
   {
     "Class":"Predicate",
-    "Name":"http:\/\/schema.org\/temporal",
+    "Name":"https://schema.org/temporal",
     "Domain Bucket":"< 1K"
   },
   {
     "Class":"Predicate",
-    "Name":"http:\/\/schema.org\/temporal-input",
+    "Name":"https://schema.org/temporal-input",
     "Domain Bucket":"< 1K"
   },
   {
     "Class":"Predicate",
-    "Name":"http:\/\/schema.org\/temporal-output",
+    "Name":"https://schema.org/temporal-output",
     "Domain Bucket":"< 1K"
   },
   {
     "Class":"Predicate",
-    "Name":"http:\/\/schema.org\/temporalCoverage",
+    "Name":"https://schema.org/temporalCoverage",
     "Domain Bucket":"10K - 100K"
   },
   {
     "Class":"Predicate",
-    "Name":"http:\/\/schema.org\/temporalCoverage-input",
+    "Name":"https://schema.org/temporalCoverage-input",
     "Domain Bucket":"< 1K"
   },
   {
     "Class":"Predicate",
-    "Name":"http:\/\/schema.org\/temporalCoverage-output",
+    "Name":"https://schema.org/temporalCoverage-output",
     "Domain Bucket":"< 1K"
   },
   {
     "Class":"Predicate",
-    "Name":"http:\/\/schema.org\/termCode",
+    "Name":"https://schema.org/termCode",
     "Domain Bucket":"1K - 10K"
   },
   {
     "Class":"Predicate",
-    "Name":"http:\/\/schema.org\/termCode-input",
+    "Name":"https://schema.org/termCode-input",
     "Domain Bucket":"< 1K"
   },
   {
     "Class":"Predicate",
-    "Name":"http:\/\/schema.org\/termCode-output",
+    "Name":"https://schema.org/termCode-output",
     "Domain Bucket":"< 1K"
   },
   {
     "Class":"Predicate",
-    "Name":"http:\/\/schema.org\/termDuration",
+    "Name":"https://schema.org/termDuration",
     "Domain Bucket":"< 1K"
   },
   {
     "Class":"Predicate",
-    "Name":"http:\/\/schema.org\/termDuration-input",
+    "Name":"https://schema.org/termDuration-input",
     "Domain Bucket":"< 1K"
   },
   {
     "Class":"Predicate",
-    "Name":"http:\/\/schema.org\/termDuration-output",
+    "Name":"https://schema.org/termDuration-output",
     "Domain Bucket":"< 1K"
   },
   {
     "Class":"Predicate",
-    "Name":"http:\/\/schema.org\/termsOfService",
+    "Name":"https://schema.org/termsOfService",
     "Domain Bucket":"10K - 100K"
   },
   {
     "Class":"Predicate",
-    "Name":"http:\/\/schema.org\/termsOfService-input",
+    "Name":"https://schema.org/termsOfService-input",
     "Domain Bucket":"< 1K"
   },
   {
     "Class":"Predicate",
-    "Name":"http:\/\/schema.org\/termsOfService-output",
+    "Name":"https://schema.org/termsOfService-output",
     "Domain Bucket":"< 1K"
   },
   {
     "Class":"Predicate",
-    "Name":"http:\/\/schema.org\/termsPerYear",
+    "Name":"https://schema.org/termsPerYear",
     "Domain Bucket":"< 1K"
   },
   {
     "Class":"Predicate",
-    "Name":"http:\/\/schema.org\/termsPerYear-input",
+    "Name":"https://schema.org/termsPerYear-input",
     "Domain Bucket":"< 1K"
   },
   {
     "Class":"Predicate",
-    "Name":"http:\/\/schema.org\/termsPerYear-output",
+    "Name":"https://schema.org/termsPerYear-output",
     "Domain Bucket":"< 1K"
   },
   {
     "Class":"Predicate",
-    "Name":"http:\/\/schema.org\/text",
+    "Name":"https://schema.org/text",
     "Domain Bucket":"1M - 10M"
   },
   {
     "Class":"Predicate",
-    "Name":"http:\/\/schema.org\/text-input",
+    "Name":"https://schema.org/text-input",
     "Domain Bucket":"< 1K"
   },
   {
     "Class":"Predicate",
-    "Name":"http:\/\/schema.org\/text-output",
+    "Name":"https://schema.org/text-output",
     "Domain Bucket":"< 1K"
   },
   {
     "Class":"Predicate",
-    "Name":"http:\/\/schema.org\/textValue",
+    "Name":"https://schema.org/textValue",
     "Domain Bucket":"< 1K"
   },
   {
     "Class":"Predicate",
-    "Name":"http:\/\/schema.org\/textValue-input",
+    "Name":"https://schema.org/textValue-input",
     "Domain Bucket":"< 1K"
   },
   {
     "Class":"Predicate",
-    "Name":"http:\/\/schema.org\/textValue-output",
+    "Name":"https://schema.org/textValue-output",
     "Domain Bucket":"< 1K"
   },
   {
     "Class":"Predicate",
-    "Name":"http:\/\/schema.org\/thumbnail",
+    "Name":"https://schema.org/thumbnail",
     "Domain Bucket":"100K - 1M"
   },
   {
     "Class":"Predicate",
-    "Name":"http:\/\/schema.org\/thumbnail-input",
+    "Name":"https://schema.org/thumbnail-input",
     "Domain Bucket":"< 1K"
   },
   {
     "Class":"Predicate",
-    "Name":"http:\/\/schema.org\/thumbnail-output",
+    "Name":"https://schema.org/thumbnail-output",
     "Domain Bucket":"< 1K"
   },
   {
     "Class":"Predicate",
-    "Name":"http:\/\/schema.org\/thumbnailUrl",
+    "Name":"https://schema.org/thumbnailUrl",
     "Domain Bucket":"10M+"
   },
   {
     "Class":"Predicate",
-    "Name":"http:\/\/schema.org\/thumbnailUrl-input",
+    "Name":"https://schema.org/thumbnailUrl-input",
     "Domain Bucket":"< 1K"
   },
   {
     "Class":"Predicate",
-    "Name":"http:\/\/schema.org\/thumbnailUrl-output",
+    "Name":"https://schema.org/thumbnailUrl-output",
     "Domain Bucket":"< 1K"
   },
   {
     "Class":"Predicate",
-    "Name":"http:\/\/schema.org\/tickerSymbol",
+    "Name":"https://schema.org/tickerSymbol",
     "Domain Bucket":"1K - 10K"
   },
   {
     "Class":"Predicate",
-    "Name":"http:\/\/schema.org\/tickerSymbol-input",
+    "Name":"https://schema.org/tickerSymbol-input",
     "Domain Bucket":"< 1K"
   },
   {
     "Class":"Predicate",
-    "Name":"http:\/\/schema.org\/tickerSymbol-output",
+    "Name":"https://schema.org/tickerSymbol-output",
     "Domain Bucket":"< 1K"
   },
   {
     "Class":"Predicate",
-    "Name":"http:\/\/schema.org\/ticketNumber",
+    "Name":"https://schema.org/ticketNumber",
     "Domain Bucket":"< 1K"
   },
   {
     "Class":"Predicate",
-    "Name":"http:\/\/schema.org\/ticketNumber-input",
+    "Name":"https://schema.org/ticketNumber-input",
     "Domain Bucket":"< 1K"
   },
   {
     "Class":"Predicate",
-    "Name":"http:\/\/schema.org\/ticketNumber-output",
+    "Name":"https://schema.org/ticketNumber-output",
     "Domain Bucket":"< 1K"
   },
   {
     "Class":"Predicate",
-    "Name":"http:\/\/schema.org\/ticketToken",
+    "Name":"https://schema.org/ticketToken",
     "Domain Bucket":"< 1K"
   },
   {
     "Class":"Predicate",
-    "Name":"http:\/\/schema.org\/ticketToken-input",
+    "Name":"https://schema.org/ticketToken-input",
     "Domain Bucket":"< 1K"
   },
   {
     "Class":"Predicate",
-    "Name":"http:\/\/schema.org\/ticketToken-output",
+    "Name":"https://schema.org/ticketToken-output",
     "Domain Bucket":"< 1K"
   },
   {
     "Class":"Predicate",
-    "Name":"http:\/\/schema.org\/ticketedSeat",
+    "Name":"https://schema.org/ticketedSeat",
     "Domain Bucket":"< 1K"
   },
   {
     "Class":"Predicate",
-    "Name":"http:\/\/schema.org\/ticketedSeat-input",
+    "Name":"https://schema.org/ticketedSeat-input",
     "Domain Bucket":"< 1K"
   },
   {
     "Class":"Predicate",
-    "Name":"http:\/\/schema.org\/ticketedSeat-output",
+    "Name":"https://schema.org/ticketedSeat-output",
     "Domain Bucket":"< 1K"
   },
   {
     "Class":"Predicate",
-    "Name":"http:\/\/schema.org\/timeOfDay",
+    "Name":"https://schema.org/timeOfDay",
     "Domain Bucket":"< 1K"
   },
   {
     "Class":"Predicate",
-    "Name":"http:\/\/schema.org\/timeOfDay-input",
+    "Name":"https://schema.org/timeOfDay-input",
     "Domain Bucket":"< 1K"
   },
   {
     "Class":"Predicate",
-    "Name":"http:\/\/schema.org\/timeOfDay-output",
+    "Name":"https://schema.org/timeOfDay-output",
     "Domain Bucket":"< 1K"
   },
   {
     "Class":"Predicate",
-    "Name":"http:\/\/schema.org\/timeRequired",
+    "Name":"https://schema.org/timeRequired",
     "Domain Bucket":"100K - 1M"
   },
   {
     "Class":"Predicate",
-    "Name":"http:\/\/schema.org\/timeRequired-input",
+    "Name":"https://schema.org/timeRequired-input",
     "Domain Bucket":"< 1K"
   },
   {
     "Class":"Predicate",
-    "Name":"http:\/\/schema.org\/timeRequired-output",
+    "Name":"https://schema.org/timeRequired-output",
     "Domain Bucket":"< 1K"
   },
   {
     "Class":"Predicate",
-    "Name":"http:\/\/schema.org\/timeToComplete",
+    "Name":"https://schema.org/timeToComplete",
     "Domain Bucket":"1K - 10K"
   },
   {
     "Class":"Predicate",
-    "Name":"http:\/\/schema.org\/timeToComplete-input",
+    "Name":"https://schema.org/timeToComplete-input",
     "Domain Bucket":"< 1K"
   },
   {
     "Class":"Predicate",
-    "Name":"http:\/\/schema.org\/timeToComplete-output",
+    "Name":"https://schema.org/timeToComplete-output",
     "Domain Bucket":"< 1K"
   },
   {
     "Class":"Predicate",
-    "Name":"http:\/\/schema.org\/timestamp",
+    "Name":"https://schema.org/timestamp",
     "Domain Bucket":"1K - 10K"
   },
   {
     "Class":"Predicate",
-    "Name":"http:\/\/schema.org\/timestamp-input",
+    "Name":"https://schema.org/timestamp-input",
     "Domain Bucket":"< 1K"
   },
   {
     "Class":"Predicate",
-    "Name":"http:\/\/schema.org\/timestamp-output",
+    "Name":"https://schema.org/timestamp-output",
     "Domain Bucket":"< 1K"
   },
   {
     "Class":"Predicate",
-    "Name":"http:\/\/schema.org\/tissueSample",
+    "Name":"https://schema.org/tissueSample",
     "Domain Bucket":"< 1K"
   },
   {
     "Class":"Predicate",
-    "Name":"http:\/\/schema.org\/tissueSample-input",
+    "Name":"https://schema.org/tissueSample-input",
     "Domain Bucket":"< 1K"
   },
   {
     "Class":"Predicate",
-    "Name":"http:\/\/schema.org\/tissueSample-output",
+    "Name":"https://schema.org/tissueSample-output",
     "Domain Bucket":"< 1K"
   },
   {
     "Class":"Predicate",
-    "Name":"http:\/\/schema.org\/title",
+    "Name":"https://schema.org/title",
     "Domain Bucket":"100K - 1M"
   },
   {
     "Class":"Predicate",
-    "Name":"http:\/\/schema.org\/title-input",
+    "Name":"https://schema.org/title-input",
     "Domain Bucket":"< 1K"
   },
   {
     "Class":"Predicate",
-    "Name":"http:\/\/schema.org\/title-output",
+    "Name":"https://schema.org/title-output",
     "Domain Bucket":"< 1K"
   },
   {
     "Class":"Predicate",
-    "Name":"http:\/\/schema.org\/titleEIDR",
+    "Name":"https://schema.org/titleEIDR",
     "Domain Bucket":"< 1K"
   },
   {
     "Class":"Predicate",
-    "Name":"http:\/\/schema.org\/titleEIDR-input",
+    "Name":"https://schema.org/titleEIDR-input",
     "Domain Bucket":"< 1K"
   },
   {
     "Class":"Predicate",
-    "Name":"http:\/\/schema.org\/titleEIDR-output",
+    "Name":"https://schema.org/titleEIDR-output",
     "Domain Bucket":"< 1K"
   },
   {
     "Class":"Predicate",
-    "Name":"http:\/\/schema.org\/toLocation",
+    "Name":"https://schema.org/toLocation",
     "Domain Bucket":"1K - 10K"
   },
   {
     "Class":"Predicate",
-    "Name":"http:\/\/schema.org\/toLocation-input",
+    "Name":"https://schema.org/toLocation-input",
     "Domain Bucket":"< 1K"
   },
   {
     "Class":"Predicate",
-    "Name":"http:\/\/schema.org\/toLocation-output",
+    "Name":"https://schema.org/toLocation-output",
     "Domain Bucket":"< 1K"
   },
   {
     "Class":"Predicate",
-    "Name":"http:\/\/schema.org\/toRecipient",
+    "Name":"https://schema.org/toRecipient",
     "Domain Bucket":"< 1K"
   },
   {
     "Class":"Predicate",
-    "Name":"http:\/\/schema.org\/toRecipient-input",
+    "Name":"https://schema.org/toRecipient-input",
     "Domain Bucket":"< 1K"
   },
   {
     "Class":"Predicate",
-    "Name":"http:\/\/schema.org\/toRecipient-output",
+    "Name":"https://schema.org/toRecipient-output",
     "Domain Bucket":"< 1K"
   },
   {
     "Class":"Predicate",
-    "Name":"http:\/\/schema.org\/tocContinuation",
+    "Name":"https://schema.org/tocContinuation",
     "Domain Bucket":"< 1K"
   },
   {
     "Class":"Predicate",
-    "Name":"http:\/\/schema.org\/tocContinuation-input",
+    "Name":"https://schema.org/tocContinuation-input",
     "Domain Bucket":"< 1K"
   },
   {
     "Class":"Predicate",
-    "Name":"http:\/\/schema.org\/tocContinuation-output",
+    "Name":"https://schema.org/tocContinuation-output",
     "Domain Bucket":"< 1K"
   },
   {
     "Class":"Predicate",
-    "Name":"http:\/\/schema.org\/tocEntry",
+    "Name":"https://schema.org/tocEntry",
     "Domain Bucket":"< 1K"
   },
   {
     "Class":"Predicate",
-    "Name":"http:\/\/schema.org\/tocEntry-input",
+    "Name":"https://schema.org/tocEntry-input",
     "Domain Bucket":"< 1K"
   },
   {
     "Class":"Predicate",
-    "Name":"http:\/\/schema.org\/tocEntry-output",
+    "Name":"https://schema.org/tocEntry-output",
     "Domain Bucket":"< 1K"
   },
   {
     "Class":"Predicate",
-    "Name":"http:\/\/schema.org\/tongueWeight",
+    "Name":"https://schema.org/tongueWeight",
     "Domain Bucket":"< 1K"
   },
   {
     "Class":"Predicate",
-    "Name":"http:\/\/schema.org\/tongueWeight-input",
+    "Name":"https://schema.org/tongueWeight-input",
     "Domain Bucket":"< 1K"
   },
   {
     "Class":"Predicate",
-    "Name":"http:\/\/schema.org\/tongueWeight-output",
+    "Name":"https://schema.org/tongueWeight-output",
     "Domain Bucket":"< 1K"
   },
   {
     "Class":"Predicate",
-    "Name":"http:\/\/schema.org\/tool",
+    "Name":"https://schema.org/tool",
     "Domain Bucket":"10K - 100K"
   },
   {
     "Class":"Predicate",
-    "Name":"http:\/\/schema.org\/tool-input",
+    "Name":"https://schema.org/tool-input",
     "Domain Bucket":"< 1K"
   },
   {
     "Class":"Predicate",
-    "Name":"http:\/\/schema.org\/tool-output",
+    "Name":"https://schema.org/tool-output",
     "Domain Bucket":"< 1K"
   },
   {
     "Class":"Predicate",
-    "Name":"http:\/\/schema.org\/torque",
+    "Name":"https://schema.org/torque",
     "Domain Bucket":"1K - 10K"
   },
   {
     "Class":"Predicate",
-    "Name":"http:\/\/schema.org\/torque-input",
+    "Name":"https://schema.org/torque-input",
     "Domain Bucket":"< 1K"
   },
   {
     "Class":"Predicate",
-    "Name":"http:\/\/schema.org\/torque-output",
+    "Name":"https://schema.org/torque-output",
     "Domain Bucket":"< 1K"
   },
   {
     "Class":"Predicate",
-    "Name":"http:\/\/schema.org\/totalHistoricalEnrollment",
+    "Name":"https://schema.org/totalHistoricalEnrollment",
     "Domain Bucket":"< 1K"
   },
   {
     "Class":"Predicate",
-    "Name":"http:\/\/schema.org\/totalHistoricalEnrollment-input",
+    "Name":"https://schema.org/totalHistoricalEnrollment-input",
     "Domain Bucket":"< 1K"
   },
   {
     "Class":"Predicate",
-    "Name":"http:\/\/schema.org\/totalHistoricalEnrollment-output",
+    "Name":"https://schema.org/totalHistoricalEnrollment-output",
     "Domain Bucket":"< 1K"
   },
   {
     "Class":"Predicate",
-    "Name":"http:\/\/schema.org\/totalJobOpenings",
+    "Name":"https://schema.org/totalJobOpenings",
     "Domain Bucket":"< 1K"
   },
   {
     "Class":"Predicate",
-    "Name":"http:\/\/schema.org\/totalJobOpenings-input",
+    "Name":"https://schema.org/totalJobOpenings-input",
     "Domain Bucket":"< 1K"
   },
   {
     "Class":"Predicate",
-    "Name":"http:\/\/schema.org\/totalJobOpenings-output",
+    "Name":"https://schema.org/totalJobOpenings-output",
     "Domain Bucket":"< 1K"
   },
   {
     "Class":"Predicate",
-    "Name":"http:\/\/schema.org\/totalPaymentDue",
+    "Name":"https://schema.org/totalPaymentDue",
     "Domain Bucket":"< 1K"
   },
   {
     "Class":"Predicate",
-    "Name":"http:\/\/schema.org\/totalPaymentDue-input",
+    "Name":"https://schema.org/totalPaymentDue-input",
     "Domain Bucket":"< 1K"
   },
   {
     "Class":"Predicate",
-    "Name":"http:\/\/schema.org\/totalPaymentDue-output",
+    "Name":"https://schema.org/totalPaymentDue-output",
     "Domain Bucket":"< 1K"
   },
   {
     "Class":"Predicate",
-    "Name":"http:\/\/schema.org\/totalPrice",
+    "Name":"https://schema.org/totalPrice",
     "Domain Bucket":"< 1K"
   },
   {
     "Class":"Predicate",
-    "Name":"http:\/\/schema.org\/totalPrice-input",
+    "Name":"https://schema.org/totalPrice-input",
     "Domain Bucket":"< 1K"
   },
   {
     "Class":"Predicate",
-    "Name":"http:\/\/schema.org\/totalPrice-output",
+    "Name":"https://schema.org/totalPrice-output",
     "Domain Bucket":"< 1K"
   },
   {
     "Class":"Predicate",
-    "Name":"http:\/\/schema.org\/totalTime",
+    "Name":"https://schema.org/totalTime",
     "Domain Bucket":"100K - 1M"
   },
   {
     "Class":"Predicate",
-    "Name":"http:\/\/schema.org\/totalTime-input",
+    "Name":"https://schema.org/totalTime-input",
     "Domain Bucket":"< 1K"
   },
   {
     "Class":"Predicate",
-    "Name":"http:\/\/schema.org\/totalTime-output",
+    "Name":"https://schema.org/totalTime-output",
     "Domain Bucket":"< 1K"
   },
   {
     "Class":"Predicate",
-    "Name":"http:\/\/schema.org\/tourBookingPage",
+    "Name":"https://schema.org/tourBookingPage",
     "Domain Bucket":"10K - 100K"
   },
   {
     "Class":"Predicate",
-    "Name":"http:\/\/schema.org\/tourBookingPage-input",
+    "Name":"https://schema.org/tourBookingPage-input",
     "Domain Bucket":"< 1K"
   },
   {
     "Class":"Predicate",
-    "Name":"http:\/\/schema.org\/tourBookingPage-output",
+    "Name":"https://schema.org/tourBookingPage-output",
     "Domain Bucket":"< 1K"
   },
   {
     "Class":"Predicate",
-    "Name":"http:\/\/schema.org\/touristType",
+    "Name":"https://schema.org/touristType",
     "Domain Bucket":"10K - 100K"
   },
   {
     "Class":"Predicate",
-    "Name":"http:\/\/schema.org\/touristType-input",
+    "Name":"https://schema.org/touristType-input",
     "Domain Bucket":"< 1K"
   },
   {
     "Class":"Predicate",
-    "Name":"http:\/\/schema.org\/touristType-output",
+    "Name":"https://schema.org/touristType-output",
     "Domain Bucket":"< 1K"
   },
   {
     "Class":"Predicate",
-    "Name":"http:\/\/schema.org\/track",
+    "Name":"https://schema.org/track",
     "Domain Bucket":"10K - 100K"
   },
   {
     "Class":"Predicate",
-    "Name":"http:\/\/schema.org\/track-input",
+    "Name":"https://schema.org/track-input",
     "Domain Bucket":"< 1K"
   },
   {
     "Class":"Predicate",
-    "Name":"http:\/\/schema.org\/track-output",
+    "Name":"https://schema.org/track-output",
     "Domain Bucket":"< 1K"
   },
   {
     "Class":"Predicate",
-    "Name":"http:\/\/schema.org\/trackingNumber",
+    "Name":"https://schema.org/trackingNumber",
     "Domain Bucket":"< 1K"
   },
   {
     "Class":"Predicate",
-    "Name":"http:\/\/schema.org\/trackingNumber-input",
+    "Name":"https://schema.org/trackingNumber-input",
     "Domain Bucket":"< 1K"
   },
   {
     "Class":"Predicate",
-    "Name":"http:\/\/schema.org\/trackingNumber-output",
+    "Name":"https://schema.org/trackingNumber-output",
     "Domain Bucket":"< 1K"
   },
   {
     "Class":"Predicate",
-    "Name":"http:\/\/schema.org\/trackingUrl",
+    "Name":"https://schema.org/trackingUrl",
     "Domain Bucket":"< 1K"
   },
   {
     "Class":"Predicate",
-    "Name":"http:\/\/schema.org\/trackingUrl-input",
+    "Name":"https://schema.org/trackingUrl-input",
     "Domain Bucket":"< 1K"
   },
   {
     "Class":"Predicate",
-    "Name":"http:\/\/schema.org\/trackingUrl-output",
+    "Name":"https://schema.org/trackingUrl-output",
     "Domain Bucket":"< 1K"
   },
   {
     "Class":"Predicate",
-    "Name":"http:\/\/schema.org\/tracks",
+    "Name":"https://schema.org/tracks",
     "Domain Bucket":"< 1K"
   },
   {
     "Class":"Predicate",
-    "Name":"http:\/\/schema.org\/tracks-input",
+    "Name":"https://schema.org/tracks-input",
     "Domain Bucket":"< 1K"
   },
   {
     "Class":"Predicate",
-    "Name":"http:\/\/schema.org\/tracks-output",
+    "Name":"https://schema.org/tracks-output",
     "Domain Bucket":"< 1K"
   },
   {
     "Class":"Predicate",
-    "Name":"http:\/\/schema.org\/trailer",
+    "Name":"https://schema.org/trailer",
     "Domain Bucket":"1K - 10K"
   },
   {
     "Class":"Predicate",
-    "Name":"http:\/\/schema.org\/trailer-input",
+    "Name":"https://schema.org/trailer-input",
     "Domain Bucket":"< 1K"
   },
   {
     "Class":"Predicate",
-    "Name":"http:\/\/schema.org\/trailer-output",
+    "Name":"https://schema.org/trailer-output",
     "Domain Bucket":"< 1K"
   },
   {
     "Class":"Predicate",
-    "Name":"http:\/\/schema.org\/trailerWeight",
+    "Name":"https://schema.org/trailerWeight",
     "Domain Bucket":"< 1K"
   },
   {
     "Class":"Predicate",
-    "Name":"http:\/\/schema.org\/trailerWeight-input",
+    "Name":"https://schema.org/trailerWeight-input",
     "Domain Bucket":"< 1K"
   },
   {
     "Class":"Predicate",
-    "Name":"http:\/\/schema.org\/trailerWeight-output",
+    "Name":"https://schema.org/trailerWeight-output",
     "Domain Bucket":"< 1K"
   },
   {
     "Class":"Predicate",
-    "Name":"http:\/\/schema.org\/trainName",
+    "Name":"https://schema.org/trainName",
     "Domain Bucket":"< 1K"
   },
   {
     "Class":"Predicate",
-    "Name":"http:\/\/schema.org\/trainName-input",
+    "Name":"https://schema.org/trainName-input",
     "Domain Bucket":"< 1K"
   },
   {
     "Class":"Predicate",
-    "Name":"http:\/\/schema.org\/trainName-output",
+    "Name":"https://schema.org/trainName-output",
     "Domain Bucket":"< 1K"
   },
   {
     "Class":"Predicate",
-    "Name":"http:\/\/schema.org\/trainNumber",
+    "Name":"https://schema.org/trainNumber",
     "Domain Bucket":"< 1K"
   },
   {
     "Class":"Predicate",
-    "Name":"http:\/\/schema.org\/trainNumber-input",
+    "Name":"https://schema.org/trainNumber-input",
     "Domain Bucket":"< 1K"
   },
   {
     "Class":"Predicate",
-    "Name":"http:\/\/schema.org\/trainNumber-output",
+    "Name":"https://schema.org/trainNumber-output",
     "Domain Bucket":"< 1K"
   },
   {
     "Class":"Predicate",
-    "Name":"http:\/\/schema.org\/trainingSalary",
+    "Name":"https://schema.org/trainingSalary",
     "Domain Bucket":"< 1K"
   },
   {
     "Class":"Predicate",
-    "Name":"http:\/\/schema.org\/trainingSalary-input",
+    "Name":"https://schema.org/trainingSalary-input",
     "Domain Bucket":"< 1K"
   },
   {
     "Class":"Predicate",
-    "Name":"http:\/\/schema.org\/trainingSalary-output",
+    "Name":"https://schema.org/trainingSalary-output",
     "Domain Bucket":"< 1K"
   },
   {
     "Class":"Predicate",
-    "Name":"http:\/\/schema.org\/transFatContent",
+    "Name":"https://schema.org/transFatContent",
     "Domain Bucket":"10K - 100K"
   },
   {
     "Class":"Predicate",
-    "Name":"http:\/\/schema.org\/transFatContent-input",
+    "Name":"https://schema.org/transFatContent-input",
     "Domain Bucket":"< 1K"
   },
   {
     "Class":"Predicate",
-    "Name":"http:\/\/schema.org\/transFatContent-output",
+    "Name":"https://schema.org/transFatContent-output",
     "Domain Bucket":"< 1K"
   },
   {
     "Class":"Predicate",
-    "Name":"http:\/\/schema.org\/transcript",
+    "Name":"https://schema.org/transcript",
     "Domain Bucket":"10K - 100K"
   },
   {
     "Class":"Predicate",
-    "Name":"http:\/\/schema.org\/transcript-input",
+    "Name":"https://schema.org/transcript-input",
     "Domain Bucket":"< 1K"
   },
   {
     "Class":"Predicate",
-    "Name":"http:\/\/schema.org\/transcript-output",
+    "Name":"https://schema.org/transcript-output",
     "Domain Bucket":"< 1K"
   },
   {
     "Class":"Predicate",
-    "Name":"http:\/\/schema.org\/transitTime",
+    "Name":"https://schema.org/transitTime",
     "Domain Bucket":"100K - 1M"
   },
   {
     "Class":"Predicate",
-    "Name":"http:\/\/schema.org\/transitTime-input",
+    "Name":"https://schema.org/transitTime-input",
     "Domain Bucket":"< 1K"
   },
   {
     "Class":"Predicate",
-    "Name":"http:\/\/schema.org\/transitTime-output",
+    "Name":"https://schema.org/transitTime-output",
     "Domain Bucket":"< 1K"
   },
   {
     "Class":"Predicate",
-    "Name":"http:\/\/schema.org\/transitTimeLabel",
+    "Name":"https://schema.org/transitTimeLabel",
     "Domain Bucket":"< 1K"
   },
   {
     "Class":"Predicate",
-    "Name":"http:\/\/schema.org\/transitTimeLabel-input",
+    "Name":"https://schema.org/transitTimeLabel-input",
     "Domain Bucket":"< 1K"
   },
   {
     "Class":"Predicate",
-    "Name":"http:\/\/schema.org\/transitTimeLabel-output",
+    "Name":"https://schema.org/transitTimeLabel-output",
     "Domain Bucket":"< 1K"
   },
   {
     "Class":"Predicate",
-    "Name":"http:\/\/schema.org\/translationOfWork",
+    "Name":"https://schema.org/translationOfWork",
     "Domain Bucket":"1K - 10K"
   },
   {
     "Class":"Predicate",
-    "Name":"http:\/\/schema.org\/translationOfWork-input",
+    "Name":"https://schema.org/translationOfWork-input",
     "Domain Bucket":"< 1K"
   },
   {
     "Class":"Predicate",
-    "Name":"http:\/\/schema.org\/translationOfWork-output",
+    "Name":"https://schema.org/translationOfWork-output",
     "Domain Bucket":"< 1K"
   },
   {
     "Class":"Predicate",
-    "Name":"http:\/\/schema.org\/translator",
+    "Name":"https://schema.org/translator",
     "Domain Bucket":"1K - 10K"
   },
   {
     "Class":"Predicate",
-    "Name":"http:\/\/schema.org\/translator-input",
+    "Name":"https://schema.org/translator-input",
     "Domain Bucket":"< 1K"
   },
   {
     "Class":"Predicate",
-    "Name":"http:\/\/schema.org\/translator-output",
+    "Name":"https://schema.org/translator-output",
     "Domain Bucket":"< 1K"
   },
   {
     "Class":"Predicate",
-    "Name":"http:\/\/schema.org\/transmissionMethod",
+    "Name":"https://schema.org/transmissionMethod",
     "Domain Bucket":"< 1K"
   },
   {
     "Class":"Predicate",
-    "Name":"http:\/\/schema.org\/transmissionMethod-input",
+    "Name":"https://schema.org/transmissionMethod-input",
     "Domain Bucket":"< 1K"
   },
   {
     "Class":"Predicate",
-    "Name":"http:\/\/schema.org\/transmissionMethod-output",
+    "Name":"https://schema.org/transmissionMethod-output",
     "Domain Bucket":"< 1K"
   },
   {
     "Class":"Predicate",
-    "Name":"http:\/\/schema.org\/travelBans",
+    "Name":"https://schema.org/travelBans",
     "Domain Bucket":"< 1K"
   },
   {
     "Class":"Predicate",
-    "Name":"http:\/\/schema.org\/travelBans-input",
+    "Name":"https://schema.org/travelBans-input",
     "Domain Bucket":"< 1K"
   },
   {
     "Class":"Predicate",
-    "Name":"http:\/\/schema.org\/travelBans-output",
+    "Name":"https://schema.org/travelBans-output",
     "Domain Bucket":"< 1K"
   },
   {
     "Class":"Predicate",
-    "Name":"http:\/\/schema.org\/trialDesign",
+    "Name":"https://schema.org/trialDesign",
     "Domain Bucket":"< 1K"
   },
   {
     "Class":"Predicate",
-    "Name":"http:\/\/schema.org\/trialDesign-input",
+    "Name":"https://schema.org/trialDesign-input",
     "Domain Bucket":"< 1K"
   },
   {
     "Class":"Predicate",
-    "Name":"http:\/\/schema.org\/trialDesign-output",
+    "Name":"https://schema.org/trialDesign-output",
     "Domain Bucket":"< 1K"
   },
   {
     "Class":"Predicate",
-    "Name":"http:\/\/schema.org\/tributary",
+    "Name":"https://schema.org/tributary",
     "Domain Bucket":"< 1K"
   },
   {
     "Class":"Predicate",
-    "Name":"http:\/\/schema.org\/tributary-input",
+    "Name":"https://schema.org/tributary-input",
     "Domain Bucket":"< 1K"
   },
   {
     "Class":"Predicate",
-    "Name":"http:\/\/schema.org\/tributary-output",
+    "Name":"https://schema.org/tributary-output",
     "Domain Bucket":"< 1K"
   },
   {
     "Class":"Predicate",
-    "Name":"http:\/\/schema.org\/tripOrigin",
+    "Name":"https://schema.org/tripOrigin",
     "Domain Bucket":"< 1K"
   },
   {
     "Class":"Predicate",
-    "Name":"http:\/\/schema.org\/tripOrigin-input",
+    "Name":"https://schema.org/tripOrigin-input",
     "Domain Bucket":"< 1K"
   },
   {
     "Class":"Predicate",
-    "Name":"http:\/\/schema.org\/tripOrigin-output",
+    "Name":"https://schema.org/tripOrigin-output",
     "Domain Bucket":"< 1K"
   },
   {
     "Class":"Predicate",
-    "Name":"http:\/\/schema.org\/typeOfBed",
+    "Name":"https://schema.org/typeOfBed",
     "Domain Bucket":"10K - 100K"
   },
   {
     "Class":"Predicate",
-    "Name":"http:\/\/schema.org\/typeOfBed-input",
+    "Name":"https://schema.org/typeOfBed-input",
     "Domain Bucket":"< 1K"
   },
   {
     "Class":"Predicate",
-    "Name":"http:\/\/schema.org\/typeOfBed-output",
+    "Name":"https://schema.org/typeOfBed-output",
     "Domain Bucket":"< 1K"
   },
   {
     "Class":"Predicate",
-    "Name":"http:\/\/schema.org\/typeOfGood",
+    "Name":"https://schema.org/typeOfGood",
     "Domain Bucket":"< 1K"
   },
   {
     "Class":"Predicate",
-    "Name":"http:\/\/schema.org\/typeOfGood-input",
+    "Name":"https://schema.org/typeOfGood-input",
     "Domain Bucket":"< 1K"
   },
   {
     "Class":"Predicate",
-    "Name":"http:\/\/schema.org\/typeOfGood-output",
+    "Name":"https://schema.org/typeOfGood-output",
     "Domain Bucket":"< 1K"
   },
   {
     "Class":"Predicate",
-    "Name":"http:\/\/schema.org\/typicalAgeRange",
+    "Name":"https://schema.org/typicalAgeRange",
     "Domain Bucket":"10K - 100K"
   },
   {
     "Class":"Predicate",
-    "Name":"http:\/\/schema.org\/typicalAgeRange-input",
+    "Name":"https://schema.org/typicalAgeRange-input",
     "Domain Bucket":"< 1K"
   },
   {
     "Class":"Predicate",
-    "Name":"http:\/\/schema.org\/typicalAgeRange-output",
+    "Name":"https://schema.org/typicalAgeRange-output",
     "Domain Bucket":"< 1K"
   },
   {
     "Class":"Predicate",
-    "Name":"http:\/\/schema.org\/typicalCreditsPerTerm",
+    "Name":"https://schema.org/typicalCreditsPerTerm",
     "Domain Bucket":"< 1K"
   },
   {
     "Class":"Predicate",
-    "Name":"http:\/\/schema.org\/typicalCreditsPerTerm-input",
+    "Name":"https://schema.org/typicalCreditsPerTerm-input",
     "Domain Bucket":"< 1K"
   },
   {
     "Class":"Predicate",
-    "Name":"http:\/\/schema.org\/typicalCreditsPerTerm-output",
+    "Name":"https://schema.org/typicalCreditsPerTerm-output",
     "Domain Bucket":"< 1K"
   },
   {
     "Class":"Predicate",
-    "Name":"http:\/\/schema.org\/typicalTest",
+    "Name":"https://schema.org/typicalTest",
     "Domain Bucket":"< 1K"
   },
   {
     "Class":"Predicate",
-    "Name":"http:\/\/schema.org\/typicalTest-input",
+    "Name":"https://schema.org/typicalTest-input",
     "Domain Bucket":"< 1K"
   },
   {
     "Class":"Predicate",
-    "Name":"http:\/\/schema.org\/typicalTest-output",
+    "Name":"https://schema.org/typicalTest-output",
     "Domain Bucket":"< 1K"
   },
   {
     "Class":"Predicate",
-    "Name":"http:\/\/schema.org\/underName",
+    "Name":"https://schema.org/underName",
     "Domain Bucket":"< 1K"
   },
   {
     "Class":"Predicate",
-    "Name":"http:\/\/schema.org\/underName-input",
+    "Name":"https://schema.org/underName-input",
     "Domain Bucket":"< 1K"
   },
   {
     "Class":"Predicate",
-    "Name":"http:\/\/schema.org\/underName-output",
+    "Name":"https://schema.org/underName-output",
     "Domain Bucket":"< 1K"
   },
   {
     "Class":"Predicate",
-    "Name":"http:\/\/schema.org\/unitCode",
+    "Name":"https://schema.org/unitCode",
     "Domain Bucket":"100K - 1M"
   },
   {
     "Class":"Predicate",
-    "Name":"http:\/\/schema.org\/unitCode-input",
+    "Name":"https://schema.org/unitCode-input",
     "Domain Bucket":"< 1K"
   },
   {
     "Class":"Predicate",
-    "Name":"http:\/\/schema.org\/unitCode-output",
+    "Name":"https://schema.org/unitCode-output",
     "Domain Bucket":"< 1K"
   },
   {
     "Class":"Predicate",
-    "Name":"http:\/\/schema.org\/unitText",
+    "Name":"https://schema.org/unitText",
     "Domain Bucket":"100K - 1M"
   },
   {
     "Class":"Predicate",
-    "Name":"http:\/\/schema.org\/unitText-input",
+    "Name":"https://schema.org/unitText-input",
     "Domain Bucket":"< 1K"
   },
   {
     "Class":"Predicate",
-    "Name":"http:\/\/schema.org\/unitText-output",
+    "Name":"https://schema.org/unitText-output",
     "Domain Bucket":"< 1K"
   },
   {
     "Class":"Predicate",
-    "Name":"http:\/\/schema.org\/unnamedSourcesPolicy",
+    "Name":"https://schema.org/unnamedSourcesPolicy",
     "Domain Bucket":"1K - 10K"
   },
   {
     "Class":"Predicate",
-    "Name":"http:\/\/schema.org\/unnamedSourcesPolicy-input",
+    "Name":"https://schema.org/unnamedSourcesPolicy-input",
     "Domain Bucket":"< 1K"
   },
   {
     "Class":"Predicate",
-    "Name":"http:\/\/schema.org\/unnamedSourcesPolicy-output",
+    "Name":"https://schema.org/unnamedSourcesPolicy-output",
     "Domain Bucket":"< 1K"
   },
   {
     "Class":"Predicate",
-    "Name":"http:\/\/schema.org\/unsaturatedFatContent",
+    "Name":"https://schema.org/unsaturatedFatContent",
     "Domain Bucket":"10K - 100K"
   },
   {
     "Class":"Predicate",
-    "Name":"http:\/\/schema.org\/unsaturatedFatContent-input",
+    "Name":"https://schema.org/unsaturatedFatContent-input",
     "Domain Bucket":"< 1K"
   },
   {
     "Class":"Predicate",
-    "Name":"http:\/\/schema.org\/unsaturatedFatContent-output",
+    "Name":"https://schema.org/unsaturatedFatContent-output",
     "Domain Bucket":"< 1K"
   },
   {
     "Class":"Predicate",
-    "Name":"http:\/\/schema.org\/uploadDate",
+    "Name":"https://schema.org/uploadDate",
     "Domain Bucket":"1M - 10M"
   },
   {
     "Class":"Predicate",
-    "Name":"http:\/\/schema.org\/uploadDate-input",
+    "Name":"https://schema.org/uploadDate-input",
     "Domain Bucket":"< 1K"
   },
   {
     "Class":"Predicate",
-    "Name":"http:\/\/schema.org\/uploadDate-output",
+    "Name":"https://schema.org/uploadDate-output",
     "Domain Bucket":"< 1K"
   },
   {
     "Class":"Predicate",
-    "Name":"http:\/\/schema.org\/upvoteCount",
+    "Name":"https://schema.org/upvoteCount",
     "Domain Bucket":"10K - 100K"
   },
   {
     "Class":"Predicate",
-    "Name":"http:\/\/schema.org\/upvoteCount-input",
+    "Name":"https://schema.org/upvoteCount-input",
     "Domain Bucket":"< 1K"
   },
   {
     "Class":"Predicate",
-    "Name":"http:\/\/schema.org\/upvoteCount-output",
+    "Name":"https://schema.org/upvoteCount-output",
     "Domain Bucket":"< 1K"
   },
   {
     "Class":"Predicate",
-    "Name":"http:\/\/schema.org\/url",
+    "Name":"https://schema.org/url",
     "Domain Bucket":"10M+"
   },
   {
     "Class":"Predicate",
-    "Name":"http:\/\/schema.org\/url-input",
+    "Name":"https://schema.org/url-input",
     "Domain Bucket":"< 1K"
   },
   {
     "Class":"Predicate",
-    "Name":"http:\/\/schema.org\/url-output",
+    "Name":"https://schema.org/url-output",
     "Domain Bucket":"< 1K"
   },
   {
     "Class":"Predicate",
-    "Name":"http:\/\/schema.org\/urlTemplate",
+    "Name":"https://schema.org/urlTemplate",
     "Domain Bucket":"10M+"
   },
   {
     "Class":"Predicate",
-    "Name":"http:\/\/schema.org\/urlTemplate-input",
+    "Name":"https://schema.org/urlTemplate-input",
     "Domain Bucket":"< 1K"
   },
   {
     "Class":"Predicate",
-    "Name":"http:\/\/schema.org\/urlTemplate-output",
+    "Name":"https://schema.org/urlTemplate-output",
     "Domain Bucket":"< 1K"
   },
   {
     "Class":"Predicate",
-    "Name":"http:\/\/schema.org\/usNPI",
+    "Name":"https://schema.org/usNPI",
     "Domain Bucket":"< 1K"
   },
   {
     "Class":"Predicate",
-    "Name":"http:\/\/schema.org\/usNPI-input",
+    "Name":"https://schema.org/usNPI-input",
     "Domain Bucket":"< 1K"
   },
   {
     "Class":"Predicate",
-    "Name":"http:\/\/schema.org\/usNPI-output",
+    "Name":"https://schema.org/usNPI-output",
     "Domain Bucket":"< 1K"
   },
   {
     "Class":"Predicate",
-    "Name":"http:\/\/schema.org\/usageInfo",
+    "Name":"https://schema.org/usageInfo",
     "Domain Bucket":"1K - 10K"
   },
   {
     "Class":"Predicate",
-    "Name":"http:\/\/schema.org\/usageInfo-input",
+    "Name":"https://schema.org/usageInfo-input",
     "Domain Bucket":"< 1K"
   },
   {
     "Class":"Predicate",
-    "Name":"http:\/\/schema.org\/usageInfo-output",
+    "Name":"https://schema.org/usageInfo-output",
     "Domain Bucket":"< 1K"
   },
   {
     "Class":"Predicate",
-    "Name":"http:\/\/schema.org\/usedToDiagnose",
+    "Name":"https://schema.org/usedToDiagnose",
     "Domain Bucket":"1K - 10K"
   },
   {
     "Class":"Predicate",
-    "Name":"http:\/\/schema.org\/usedToDiagnose-input",
+    "Name":"https://schema.org/usedToDiagnose-input",
     "Domain Bucket":"< 1K"
   },
   {
     "Class":"Predicate",
-    "Name":"http:\/\/schema.org\/usedToDiagnose-output",
+    "Name":"https://schema.org/usedToDiagnose-output",
     "Domain Bucket":"< 1K"
   },
   {
     "Class":"Predicate",
-    "Name":"http:\/\/schema.org\/userInteractionCount",
+    "Name":"https://schema.org/userInteractionCount",
     "Domain Bucket":"100K - 1M"
   },
   {
     "Class":"Predicate",
-    "Name":"http:\/\/schema.org\/userInteractionCount-input",
+    "Name":"https://schema.org/userInteractionCount-input",
     "Domain Bucket":"< 1K"
   },
   {
     "Class":"Predicate",
-    "Name":"http:\/\/schema.org\/userInteractionCount-output",
+    "Name":"https://schema.org/userInteractionCount-output",
     "Domain Bucket":"< 1K"
   },
   {
     "Class":"Predicate",
-    "Name":"http:\/\/schema.org\/usesDevice",
+    "Name":"https://schema.org/usesDevice",
     "Domain Bucket":"< 1K"
   },
   {
     "Class":"Predicate",
-    "Name":"http:\/\/schema.org\/usesDevice-input",
+    "Name":"https://schema.org/usesDevice-input",
     "Domain Bucket":"< 1K"
   },
   {
     "Class":"Predicate",
-    "Name":"http:\/\/schema.org\/usesDevice-output",
+    "Name":"https://schema.org/usesDevice-output",
     "Domain Bucket":"< 1K"
   },
   {
     "Class":"Predicate",
-    "Name":"http:\/\/schema.org\/usesHealthPlanIdStandard",
+    "Name":"https://schema.org/usesHealthPlanIdStandard",
     "Domain Bucket":"< 1K"
   },
   {
     "Class":"Predicate",
-    "Name":"http:\/\/schema.org\/usesHealthPlanIdStandard-input",
+    "Name":"https://schema.org/usesHealthPlanIdStandard-input",
     "Domain Bucket":"< 1K"
   },
   {
     "Class":"Predicate",
-    "Name":"http:\/\/schema.org\/usesHealthPlanIdStandard-output",
+    "Name":"https://schema.org/usesHealthPlanIdStandard-output",
     "Domain Bucket":"< 1K"
   },
   {
     "Class":"Predicate",
-    "Name":"http:\/\/schema.org\/utterances",
+    "Name":"https://schema.org/utterances",
     "Domain Bucket":"< 1K"
   },
   {
     "Class":"Predicate",
-    "Name":"http:\/\/schema.org\/utterances-input",
+    "Name":"https://schema.org/utterances-input",
     "Domain Bucket":"< 1K"
   },
   {
     "Class":"Predicate",
-    "Name":"http:\/\/schema.org\/utterances-output",
+    "Name":"https://schema.org/utterances-output",
     "Domain Bucket":"< 1K"
   },
   {
     "Class":"Predicate",
-    "Name":"http:\/\/schema.org\/validFor",
+    "Name":"https://schema.org/validFor",
     "Domain Bucket":"< 1K"
   },
   {
     "Class":"Predicate",
-    "Name":"http:\/\/schema.org\/validFor-input",
+    "Name":"https://schema.org/validFor-input",
     "Domain Bucket":"< 1K"
   },
   {
     "Class":"Predicate",
-    "Name":"http:\/\/schema.org\/validFor-output",
+    "Name":"https://schema.org/validFor-output",
     "Domain Bucket":"< 1K"
   },
   {
     "Class":"Predicate",
-    "Name":"http:\/\/schema.org\/validForMemberTier",
+    "Name":"https://schema.org/validForMemberTier",
     "Domain Bucket":"< 1K"
   },
   {
     "Class":"Predicate",
-    "Name":"http:\/\/schema.org\/validForMemberTier-input",
+    "Name":"https://schema.org/validForMemberTier-input",
     "Domain Bucket":"< 1K"
   },
   {
     "Class":"Predicate",
-    "Name":"http:\/\/schema.org\/validForMemberTier-output",
+    "Name":"https://schema.org/validForMemberTier-output",
     "Domain Bucket":"< 1K"
   },
   {
     "Class":"Predicate",
-    "Name":"http:\/\/schema.org\/validFrom",
+    "Name":"https://schema.org/validFrom",
     "Domain Bucket":"100K - 1M"
   },
   {
     "Class":"Predicate",
-    "Name":"http:\/\/schema.org\/validFrom-input",
+    "Name":"https://schema.org/validFrom-input",
     "Domain Bucket":"< 1K"
   },
   {
     "Class":"Predicate",
-    "Name":"http:\/\/schema.org\/validFrom-output",
+    "Name":"https://schema.org/validFrom-output",
     "Domain Bucket":"< 1K"
   },
   {
     "Class":"Predicate",
-    "Name":"http:\/\/schema.org\/validIn",
+    "Name":"https://schema.org/validIn",
     "Domain Bucket":"1K - 10K"
   },
   {
     "Class":"Predicate",
-    "Name":"http:\/\/schema.org\/validIn-input",
+    "Name":"https://schema.org/validIn-input",
     "Domain Bucket":"< 1K"
   },
   {
     "Class":"Predicate",
-    "Name":"http:\/\/schema.org\/validIn-output",
+    "Name":"https://schema.org/validIn-output",
     "Domain Bucket":"< 1K"
   },
   {
     "Class":"Predicate",
-    "Name":"http:\/\/schema.org\/validThrough",
+    "Name":"https://schema.org/validThrough",
     "Domain Bucket":"1M - 10M"
   },
   {
     "Class":"Predicate",
-    "Name":"http:\/\/schema.org\/validThrough-input",
+    "Name":"https://schema.org/validThrough-input",
     "Domain Bucket":"< 1K"
   },
   {
     "Class":"Predicate",
-    "Name":"http:\/\/schema.org\/validThrough-output",
+    "Name":"https://schema.org/validThrough-output",
     "Domain Bucket":"< 1K"
   },
   {
     "Class":"Predicate",
-    "Name":"http:\/\/schema.org\/validUntil",
+    "Name":"https://schema.org/validUntil",
     "Domain Bucket":"< 1K"
   },
   {
     "Class":"Predicate",
-    "Name":"http:\/\/schema.org\/validUntil-input",
+    "Name":"https://schema.org/validUntil-input",
     "Domain Bucket":"< 1K"
   },
   {
     "Class":"Predicate",
-    "Name":"http:\/\/schema.org\/validUntil-output",
+    "Name":"https://schema.org/validUntil-output",
     "Domain Bucket":"< 1K"
   },
   {
     "Class":"Predicate",
-    "Name":"http:\/\/schema.org\/value",
+    "Name":"https://schema.org/value",
     "Domain Bucket":"1M - 10M"
   },
   {
     "Class":"Predicate",
-    "Name":"http:\/\/schema.org\/value-input",
+    "Name":"https://schema.org/value-input",
     "Domain Bucket":"< 1K"
   },
   {
     "Class":"Predicate",
-    "Name":"http:\/\/schema.org\/value-output",
+    "Name":"https://schema.org/value-output",
     "Domain Bucket":"< 1K"
   },
   {
     "Class":"Predicate",
-    "Name":"http:\/\/schema.org\/valueAddedTaxIncluded",
+    "Name":"https://schema.org/valueAddedTaxIncluded",
     "Domain Bucket":"1M - 10M"
   },
   {
     "Class":"Predicate",
-    "Name":"http:\/\/schema.org\/valueAddedTaxIncluded-input",
+    "Name":"https://schema.org/valueAddedTaxIncluded-input",
     "Domain Bucket":"< 1K"
   },
   {
     "Class":"Predicate",
-    "Name":"http:\/\/schema.org\/valueAddedTaxIncluded-output",
+    "Name":"https://schema.org/valueAddedTaxIncluded-output",
     "Domain Bucket":"< 1K"
   },
   {
     "Class":"Predicate",
-    "Name":"http:\/\/schema.org\/valueMaxLength",
+    "Name":"https://schema.org/valueMaxLength",
     "Domain Bucket":"1K - 10K"
   },
   {
     "Class":"Predicate",
-    "Name":"http:\/\/schema.org\/valueMaxLength-input",
+    "Name":"https://schema.org/valueMaxLength-input",
     "Domain Bucket":"< 1K"
   },
   {
     "Class":"Predicate",
-    "Name":"http:\/\/schema.org\/valueMaxLength-output",
+    "Name":"https://schema.org/valueMaxLength-output",
     "Domain Bucket":"< 1K"
   },
   {
     "Class":"Predicate",
-    "Name":"http:\/\/schema.org\/valueMinLength",
+    "Name":"https://schema.org/valueMinLength",
     "Domain Bucket":"< 1K"
   },
   {
     "Class":"Predicate",
-    "Name":"http:\/\/schema.org\/valueMinLength-input",
+    "Name":"https://schema.org/valueMinLength-input",
     "Domain Bucket":"< 1K"
   },
   {
     "Class":"Predicate",
-    "Name":"http:\/\/schema.org\/valueMinLength-output",
+    "Name":"https://schema.org/valueMinLength-output",
     "Domain Bucket":"< 1K"
   },
   {
     "Class":"Predicate",
-    "Name":"http:\/\/schema.org\/valueName",
+    "Name":"https://schema.org/valueName",
     "Domain Bucket":"10M+"
   },
   {
     "Class":"Predicate",
-    "Name":"http:\/\/schema.org\/valueName-input",
+    "Name":"https://schema.org/valueName-input",
     "Domain Bucket":"< 1K"
   },
   {
     "Class":"Predicate",
-    "Name":"http:\/\/schema.org\/valueName-output",
+    "Name":"https://schema.org/valueName-output",
     "Domain Bucket":"< 1K"
   },
   {
     "Class":"Predicate",
-    "Name":"http:\/\/schema.org\/valuePattern",
+    "Name":"https://schema.org/valuePattern",
     "Domain Bucket":"< 1K"
   },
   {
     "Class":"Predicate",
-    "Name":"http:\/\/schema.org\/valuePattern-input",
+    "Name":"https://schema.org/valuePattern-input",
     "Domain Bucket":"< 1K"
   },
   {
     "Class":"Predicate",
-    "Name":"http:\/\/schema.org\/valuePattern-output",
+    "Name":"https://schema.org/valuePattern-output",
     "Domain Bucket":"< 1K"
   },
   {
     "Class":"Predicate",
-    "Name":"http:\/\/schema.org\/valueReference",
+    "Name":"https://schema.org/valueReference",
     "Domain Bucket":"1K - 10K"
   },
   {
     "Class":"Predicate",
-    "Name":"http:\/\/schema.org\/valueReference-input",
+    "Name":"https://schema.org/valueReference-input",
     "Domain Bucket":"< 1K"
   },
   {
     "Class":"Predicate",
-    "Name":"http:\/\/schema.org\/valueReference-output",
+    "Name":"https://schema.org/valueReference-output",
     "Domain Bucket":"< 1K"
   },
   {
     "Class":"Predicate",
-    "Name":"http:\/\/schema.org\/valueRequired",
+    "Name":"https://schema.org/valueRequired",
     "Domain Bucket":"10M+"
   },
   {
     "Class":"Predicate",
-    "Name":"http:\/\/schema.org\/valueRequired-input",
+    "Name":"https://schema.org/valueRequired-input",
     "Domain Bucket":"< 1K"
   },
   {
     "Class":"Predicate",
-    "Name":"http:\/\/schema.org\/valueRequired-output",
+    "Name":"https://schema.org/valueRequired-output",
     "Domain Bucket":"< 1K"
   },
   {
     "Class":"Predicate",
-    "Name":"http:\/\/schema.org\/variableMeasured",
+    "Name":"https://schema.org/variableMeasured",
     "Domain Bucket":"10K - 100K"
   },
   {
     "Class":"Predicate",
-    "Name":"http:\/\/schema.org\/variableMeasured-input",
+    "Name":"https://schema.org/variableMeasured-input",
     "Domain Bucket":"< 1K"
   },
   {
     "Class":"Predicate",
-    "Name":"http:\/\/schema.org\/variableMeasured-output",
+    "Name":"https://schema.org/variableMeasured-output",
     "Domain Bucket":"< 1K"
   },
   {
     "Class":"Predicate",
-    "Name":"http:\/\/schema.org\/variablesMeasured",
+    "Name":"https://schema.org/variablesMeasured",
     "Domain Bucket":"< 1K"
   },
   {
     "Class":"Predicate",
-    "Name":"http:\/\/schema.org\/variablesMeasured-input",
+    "Name":"https://schema.org/variablesMeasured-input",
     "Domain Bucket":"< 1K"
   },
   {
     "Class":"Predicate",
-    "Name":"http:\/\/schema.org\/variablesMeasured-output",
+    "Name":"https://schema.org/variablesMeasured-output",
     "Domain Bucket":"< 1K"
   },
   {
     "Class":"Predicate",
-    "Name":"http:\/\/schema.org\/variantCover",
+    "Name":"https://schema.org/variantCover",
     "Domain Bucket":"< 1K"
   },
   {
     "Class":"Predicate",
-    "Name":"http:\/\/schema.org\/variantCover-input",
+    "Name":"https://schema.org/variantCover-input",
     "Domain Bucket":"< 1K"
   },
   {
     "Class":"Predicate",
-    "Name":"http:\/\/schema.org\/variantCover-output",
+    "Name":"https://schema.org/variantCover-output",
     "Domain Bucket":"< 1K"
   },
   {
     "Class":"Predicate",
-    "Name":"http:\/\/schema.org\/variesBy",
+    "Name":"https://schema.org/variesBy",
     "Domain Bucket":"10K - 100K"
   },
   {
     "Class":"Predicate",
-    "Name":"http:\/\/schema.org\/variesBy-input",
+    "Name":"https://schema.org/variesBy-input",
     "Domain Bucket":"< 1K"
   },
   {
     "Class":"Predicate",
-    "Name":"http:\/\/schema.org\/variesBy-output",
+    "Name":"https://schema.org/variesBy-output",
     "Domain Bucket":"< 1K"
   },
   {
     "Class":"Predicate",
-    "Name":"http:\/\/schema.org\/vatID",
+    "Name":"https://schema.org/vatID",
     "Domain Bucket":"100K - 1M"
   },
   {
     "Class":"Predicate",
-    "Name":"http:\/\/schema.org\/vatID-input",
+    "Name":"https://schema.org/vatID-input",
     "Domain Bucket":"< 1K"
   },
   {
     "Class":"Predicate",
-    "Name":"http:\/\/schema.org\/vatID-output",
+    "Name":"https://schema.org/vatID-output",
     "Domain Bucket":"< 1K"
   },
   {
     "Class":"Predicate",
-    "Name":"http:\/\/schema.org\/vehicleConfiguration",
+    "Name":"https://schema.org/vehicleConfiguration",
     "Domain Bucket":"10K - 100K"
   },
   {
     "Class":"Predicate",
-    "Name":"http:\/\/schema.org\/vehicleConfiguration-input",
+    "Name":"https://schema.org/vehicleConfiguration-input",
     "Domain Bucket":"< 1K"
   },
   {
     "Class":"Predicate",
-    "Name":"http:\/\/schema.org\/vehicleConfiguration-output",
+    "Name":"https://schema.org/vehicleConfiguration-output",
     "Domain Bucket":"< 1K"
   },
   {
     "Class":"Predicate",
-    "Name":"http:\/\/schema.org\/vehicleEngine",
+    "Name":"https://schema.org/vehicleEngine",
     "Domain Bucket":"10K - 100K"
   },
   {
     "Class":"Predicate",
-    "Name":"http:\/\/schema.org\/vehicleEngine-input",
+    "Name":"https://schema.org/vehicleEngine-input",
     "Domain Bucket":"< 1K"
   },
   {
     "Class":"Predicate",
-    "Name":"http:\/\/schema.org\/vehicleEngine-output",
+    "Name":"https://schema.org/vehicleEngine-output",
     "Domain Bucket":"< 1K"
   },
   {
     "Class":"Predicate",
-    "Name":"http:\/\/schema.org\/vehicleIdentificationNumber",
+    "Name":"https://schema.org/vehicleIdentificationNumber",
     "Domain Bucket":"10K - 100K"
   },
   {
     "Class":"Predicate",
-    "Name":"http:\/\/schema.org\/vehicleIdentificationNumber-input",
+    "Name":"https://schema.org/vehicleIdentificationNumber-input",
     "Domain Bucket":"< 1K"
   },
   {
     "Class":"Predicate",
-    "Name":"http:\/\/schema.org\/vehicleIdentificationNumber-output",
+    "Name":"https://schema.org/vehicleIdentificationNumber-output",
     "Domain Bucket":"< 1K"
   },
   {
     "Class":"Predicate",
-    "Name":"http:\/\/schema.org\/vehicleInteriorColor",
+    "Name":"https://schema.org/vehicleInteriorColor",
     "Domain Bucket":"10K - 100K"
   },
   {
     "Class":"Predicate",
-    "Name":"http:\/\/schema.org\/vehicleInteriorColor-input",
+    "Name":"https://schema.org/vehicleInteriorColor-input",
     "Domain Bucket":"< 1K"
   },
   {
     "Class":"Predicate",
-    "Name":"http:\/\/schema.org\/vehicleInteriorColor-output",
+    "Name":"https://schema.org/vehicleInteriorColor-output",
     "Domain Bucket":"< 1K"
   },
   {
     "Class":"Predicate",
-    "Name":"http:\/\/schema.org\/vehicleInteriorType",
+    "Name":"https://schema.org/vehicleInteriorType",
     "Domain Bucket":"10K - 100K"
   },
   {
     "Class":"Predicate",
-    "Name":"http:\/\/schema.org\/vehicleInteriorType-input",
+    "Name":"https://schema.org/vehicleInteriorType-input",
     "Domain Bucket":"< 1K"
   },
   {
     "Class":"Predicate",
-    "Name":"http:\/\/schema.org\/vehicleInteriorType-output",
+    "Name":"https://schema.org/vehicleInteriorType-output",
     "Domain Bucket":"< 1K"
   },
   {
     "Class":"Predicate",
-    "Name":"http:\/\/schema.org\/vehicleModelDate",
+    "Name":"https://schema.org/vehicleModelDate",
     "Domain Bucket":"10K - 100K"
   },
   {
     "Class":"Predicate",
-    "Name":"http:\/\/schema.org\/vehicleModelDate-input",
+    "Name":"https://schema.org/vehicleModelDate-input",
     "Domain Bucket":"< 1K"
   },
   {
     "Class":"Predicate",
-    "Name":"http:\/\/schema.org\/vehicleModelDate-output",
+    "Name":"https://schema.org/vehicleModelDate-output",
     "Domain Bucket":"< 1K"
   },
   {
     "Class":"Predicate",
-    "Name":"http:\/\/schema.org\/vehicleSeatingCapacity",
+    "Name":"https://schema.org/vehicleSeatingCapacity",
     "Domain Bucket":"10K - 100K"
   },
   {
     "Class":"Predicate",
-    "Name":"http:\/\/schema.org\/vehicleSeatingCapacity-input",
+    "Name":"https://schema.org/vehicleSeatingCapacity-input",
     "Domain Bucket":"< 1K"
   },
   {
     "Class":"Predicate",
-    "Name":"http:\/\/schema.org\/vehicleSeatingCapacity-output",
+    "Name":"https://schema.org/vehicleSeatingCapacity-output",
     "Domain Bucket":"< 1K"
   },
   {
     "Class":"Predicate",
-    "Name":"http:\/\/schema.org\/vehicleSpecialUsage",
+    "Name":"https://schema.org/vehicleSpecialUsage",
     "Domain Bucket":"< 1K"
   },
   {
     "Class":"Predicate",
-    "Name":"http:\/\/schema.org\/vehicleSpecialUsage-input",
+    "Name":"https://schema.org/vehicleSpecialUsage-input",
     "Domain Bucket":"< 1K"
   },
   {
     "Class":"Predicate",
-    "Name":"http:\/\/schema.org\/vehicleSpecialUsage-output",
+    "Name":"https://schema.org/vehicleSpecialUsage-output",
     "Domain Bucket":"< 1K"
   },
   {
     "Class":"Predicate",
-    "Name":"http:\/\/schema.org\/vehicleTransmission",
+    "Name":"https://schema.org/vehicleTransmission",
     "Domain Bucket":"10K - 100K"
   },
   {
     "Class":"Predicate",
-    "Name":"http:\/\/schema.org\/vehicleTransmission-input",
+    "Name":"https://schema.org/vehicleTransmission-input",
     "Domain Bucket":"< 1K"
   },
   {
     "Class":"Predicate",
-    "Name":"http:\/\/schema.org\/vehicleTransmission-output",
+    "Name":"https://schema.org/vehicleTransmission-output",
     "Domain Bucket":"< 1K"
   },
   {
     "Class":"Predicate",
-    "Name":"http:\/\/schema.org\/vendor",
+    "Name":"https://schema.org/vendor",
     "Domain Bucket":"< 1K"
   },
   {
     "Class":"Predicate",
-    "Name":"http:\/\/schema.org\/vendor-input",
+    "Name":"https://schema.org/vendor-input",
     "Domain Bucket":"< 1K"
   },
   {
     "Class":"Predicate",
-    "Name":"http:\/\/schema.org\/vendor-output",
+    "Name":"https://schema.org/vendor-output",
     "Domain Bucket":"< 1K"
   },
   {
     "Class":"Predicate",
-    "Name":"http:\/\/schema.org\/verificationFactCheckingPolicy",
+    "Name":"https://schema.org/verificationFactCheckingPolicy",
     "Domain Bucket":"1K - 10K"
   },
   {
     "Class":"Predicate",
-    "Name":"http:\/\/schema.org\/verificationFactCheckingPolicy-input",
+    "Name":"https://schema.org/verificationFactCheckingPolicy-input",
     "Domain Bucket":"< 1K"
   },
   {
     "Class":"Predicate",
-    "Name":"http:\/\/schema.org\/verificationFactCheckingPolicy-output",
+    "Name":"https://schema.org/verificationFactCheckingPolicy-output",
     "Domain Bucket":"< 1K"
   },
   {
     "Class":"Predicate",
-    "Name":"http:\/\/schema.org\/version",
+    "Name":"https://schema.org/version",
     "Domain Bucket":"1K - 10K"
   },
   {
     "Class":"Predicate",
-    "Name":"http:\/\/schema.org\/version-input",
+    "Name":"https://schema.org/version-input",
     "Domain Bucket":"< 1K"
   },
   {
     "Class":"Predicate",
-    "Name":"http:\/\/schema.org\/version-output",
+    "Name":"https://schema.org/version-output",
     "Domain Bucket":"< 1K"
   },
   {
     "Class":"Predicate",
-    "Name":"http:\/\/schema.org\/video",
+    "Name":"https://schema.org/video",
     "Domain Bucket":"100K - 1M"
   },
   {
     "Class":"Predicate",
-    "Name":"http:\/\/schema.org\/video-input",
+    "Name":"https://schema.org/video-input",
     "Domain Bucket":"< 1K"
   },
   {
     "Class":"Predicate",
-    "Name":"http:\/\/schema.org\/video-output",
+    "Name":"https://schema.org/video-output",
     "Domain Bucket":"< 1K"
   },
   {
     "Class":"Predicate",
-    "Name":"http:\/\/schema.org\/videoFormat",
+    "Name":"https://schema.org/videoFormat",
     "Domain Bucket":"1K - 10K"
   },
   {
     "Class":"Predicate",
-    "Name":"http:\/\/schema.org\/videoFormat-input",
+    "Name":"https://schema.org/videoFormat-input",
     "Domain Bucket":"< 1K"
   },
   {
     "Class":"Predicate",
-    "Name":"http:\/\/schema.org\/videoFormat-output",
+    "Name":"https://schema.org/videoFormat-output",
     "Domain Bucket":"< 1K"
   },
   {
     "Class":"Predicate",
-    "Name":"http:\/\/schema.org\/videoFrameSize",
+    "Name":"https://schema.org/videoFrameSize",
     "Domain Bucket":"< 1K"
   },
   {
     "Class":"Predicate",
-    "Name":"http:\/\/schema.org\/videoFrameSize-input",
+    "Name":"https://schema.org/videoFrameSize-input",
     "Domain Bucket":"< 1K"
   },
   {
     "Class":"Predicate",
-    "Name":"http:\/\/schema.org\/videoFrameSize-output",
+    "Name":"https://schema.org/videoFrameSize-output",
     "Domain Bucket":"< 1K"
   },
   {
     "Class":"Predicate",
-    "Name":"http:\/\/schema.org\/videoQuality",
+    "Name":"https://schema.org/videoQuality",
     "Domain Bucket":"10K - 100K"
   },
   {
     "Class":"Predicate",
-    "Name":"http:\/\/schema.org\/videoQuality-input",
+    "Name":"https://schema.org/videoQuality-input",
     "Domain Bucket":"< 1K"
   },
   {
     "Class":"Predicate",
-    "Name":"http:\/\/schema.org\/videoQuality-output",
+    "Name":"https://schema.org/videoQuality-output",
     "Domain Bucket":"< 1K"
   },
   {
     "Class":"Predicate",
-    "Name":"http:\/\/schema.org\/volumeNumber",
+    "Name":"https://schema.org/volumeNumber",
     "Domain Bucket":"1K - 10K"
   },
   {
     "Class":"Predicate",
-    "Name":"http:\/\/schema.org\/volumeNumber-input",
+    "Name":"https://schema.org/volumeNumber-input",
     "Domain Bucket":"< 1K"
   },
   {
     "Class":"Predicate",
-    "Name":"http:\/\/schema.org\/volumeNumber-output",
+    "Name":"https://schema.org/volumeNumber-output",
     "Domain Bucket":"< 1K"
   },
   {
     "Class":"Predicate",
-    "Name":"http:\/\/schema.org\/warning",
+    "Name":"https://schema.org/warning",
     "Domain Bucket":"< 1K"
   },
   {
     "Class":"Predicate",
-    "Name":"http:\/\/schema.org\/warning-input",
+    "Name":"https://schema.org/warning-input",
     "Domain Bucket":"< 1K"
   },
   {
     "Class":"Predicate",
-    "Name":"http:\/\/schema.org\/warning-output",
+    "Name":"https://schema.org/warning-output",
     "Domain Bucket":"< 1K"
   },
   {
     "Class":"Predicate",
-    "Name":"http:\/\/schema.org\/warranty",
+    "Name":"https://schema.org/warranty",
     "Domain Bucket":"10K - 100K"
   },
   {
     "Class":"Predicate",
-    "Name":"http:\/\/schema.org\/warranty-input",
+    "Name":"https://schema.org/warranty-input",
     "Domain Bucket":"< 1K"
   },
   {
     "Class":"Predicate",
-    "Name":"http:\/\/schema.org\/warranty-output",
+    "Name":"https://schema.org/warranty-output",
     "Domain Bucket":"< 1K"
   },
   {
     "Class":"Predicate",
-    "Name":"http:\/\/schema.org\/warrantyPromise",
+    "Name":"https://schema.org/warrantyPromise",
     "Domain Bucket":"< 1K"
   },
   {
     "Class":"Predicate",
-    "Name":"http:\/\/schema.org\/warrantyPromise-input",
+    "Name":"https://schema.org/warrantyPromise-input",
     "Domain Bucket":"< 1K"
   },
   {
     "Class":"Predicate",
-    "Name":"http:\/\/schema.org\/warrantyPromise-output",
+    "Name":"https://schema.org/warrantyPromise-output",
     "Domain Bucket":"< 1K"
   },
   {
     "Class":"Predicate",
-    "Name":"http:\/\/schema.org\/warrantyScope",
+    "Name":"https://schema.org/warrantyScope",
     "Domain Bucket":"1K - 10K"
   },
   {
     "Class":"Predicate",
-    "Name":"http:\/\/schema.org\/warrantyScope-input",
+    "Name":"https://schema.org/warrantyScope-input",
     "Domain Bucket":"< 1K"
   },
   {
     "Class":"Predicate",
-    "Name":"http:\/\/schema.org\/warrantyScope-output",
+    "Name":"https://schema.org/warrantyScope-output",
     "Domain Bucket":"< 1K"
   },
   {
     "Class":"Predicate",
-    "Name":"http:\/\/schema.org\/webCheckinTime",
+    "Name":"https://schema.org/webCheckinTime",
     "Domain Bucket":"< 1K"
   },
   {
     "Class":"Predicate",
-    "Name":"http:\/\/schema.org\/webCheckinTime-input",
+    "Name":"https://schema.org/webCheckinTime-input",
     "Domain Bucket":"< 1K"
   },
   {
     "Class":"Predicate",
-    "Name":"http:\/\/schema.org\/webCheckinTime-output",
+    "Name":"https://schema.org/webCheckinTime-output",
     "Domain Bucket":"< 1K"
   },
   {
     "Class":"Predicate",
-    "Name":"http:\/\/schema.org\/webFeed",
+    "Name":"https://schema.org/webFeed",
     "Domain Bucket":"1K - 10K"
   },
   {
     "Class":"Predicate",
-    "Name":"http:\/\/schema.org\/webFeed-input",
+    "Name":"https://schema.org/webFeed-input",
     "Domain Bucket":"< 1K"
   },
   {
     "Class":"Predicate",
-    "Name":"http:\/\/schema.org\/webFeed-output",
+    "Name":"https://schema.org/webFeed-output",
     "Domain Bucket":"< 1K"
   },
   {
     "Class":"Predicate",
-    "Name":"http:\/\/schema.org\/weight",
+    "Name":"https://schema.org/weight",
     "Domain Bucket":"100K - 1M"
   },
   {
     "Class":"Predicate",
-    "Name":"http:\/\/schema.org\/weight-input",
+    "Name":"https://schema.org/weight-input",
     "Domain Bucket":"< 1K"
   },
   {
     "Class":"Predicate",
-    "Name":"http:\/\/schema.org\/weight-output",
+    "Name":"https://schema.org/weight-output",
     "Domain Bucket":"< 1K"
   },
   {
     "Class":"Predicate",
-    "Name":"http:\/\/schema.org\/weightPercentage",
+    "Name":"https://schema.org/weightPercentage",
     "Domain Bucket":"< 1K"
   },
   {
     "Class":"Predicate",
-    "Name":"http:\/\/schema.org\/weightPercentage-input",
+    "Name":"https://schema.org/weightPercentage-input",
     "Domain Bucket":"< 1K"
   },
   {
     "Class":"Predicate",
-    "Name":"http:\/\/schema.org\/weightPercentage-output",
+    "Name":"https://schema.org/weightPercentage-output",
     "Domain Bucket":"< 1K"
   },
   {
     "Class":"Predicate",
-    "Name":"http:\/\/schema.org\/weightTotal",
+    "Name":"https://schema.org/weightTotal",
     "Domain Bucket":"1K - 10K"
   },
   {
     "Class":"Predicate",
-    "Name":"http:\/\/schema.org\/weightTotal-input",
+    "Name":"https://schema.org/weightTotal-input",
     "Domain Bucket":"< 1K"
   },
   {
     "Class":"Predicate",
-    "Name":"http:\/\/schema.org\/weightTotal-output",
+    "Name":"https://schema.org/weightTotal-output",
     "Domain Bucket":"< 1K"
   },
   {
     "Class":"Predicate",
-    "Name":"http:\/\/schema.org\/wheelbase",
+    "Name":"https://schema.org/wheelbase",
     "Domain Bucket":"1K - 10K"
   },
   {
     "Class":"Predicate",
-    "Name":"http:\/\/schema.org\/wheelbase-input",
+    "Name":"https://schema.org/wheelbase-input",
     "Domain Bucket":"< 1K"
   },
   {
     "Class":"Predicate",
-    "Name":"http:\/\/schema.org\/wheelbase-output",
+    "Name":"https://schema.org/wheelbase-output",
     "Domain Bucket":"< 1K"
   },
   {
     "Class":"Predicate",
-    "Name":"http:\/\/schema.org\/width",
+    "Name":"https://schema.org/width",
     "Domain Bucket":"10M+"
   },
   {
     "Class":"Predicate",
-    "Name":"http:\/\/schema.org\/width-input",
+    "Name":"https://schema.org/width-input",
     "Domain Bucket":"< 1K"
   },
   {
     "Class":"Predicate",
-    "Name":"http:\/\/schema.org\/width-output",
+    "Name":"https://schema.org/width-output",
     "Domain Bucket":"< 1K"
   },
   {
     "Class":"Predicate",
-    "Name":"http:\/\/schema.org\/winner",
+    "Name":"https://schema.org/winner",
     "Domain Bucket":"< 1K"
   },
   {
     "Class":"Predicate",
-    "Name":"http:\/\/schema.org\/winner-input",
+    "Name":"https://schema.org/winner-input",
     "Domain Bucket":"< 1K"
   },
   {
     "Class":"Predicate",
-    "Name":"http:\/\/schema.org\/winner-output",
+    "Name":"https://schema.org/winner-output",
     "Domain Bucket":"< 1K"
   },
   {
     "Class":"Predicate",
-    "Name":"http:\/\/schema.org\/wordCount",
+    "Name":"https://schema.org/wordCount",
     "Domain Bucket":"1M - 10M"
   },
   {
     "Class":"Predicate",
-    "Name":"http:\/\/schema.org\/wordCount-input",
+    "Name":"https://schema.org/wordCount-input",
     "Domain Bucket":"< 1K"
   },
   {
     "Class":"Predicate",
-    "Name":"http:\/\/schema.org\/wordCount-output",
+    "Name":"https://schema.org/wordCount-output",
     "Domain Bucket":"< 1K"
   },
   {
     "Class":"Predicate",
-    "Name":"http:\/\/schema.org\/workExample",
+    "Name":"https://schema.org/workExample",
     "Domain Bucket":"1K - 10K"
   },
   {
     "Class":"Predicate",
-    "Name":"http:\/\/schema.org\/workExample-input",
+    "Name":"https://schema.org/workExample-input",
     "Domain Bucket":"< 1K"
   },
   {
     "Class":"Predicate",
-    "Name":"http:\/\/schema.org\/workExample-output",
+    "Name":"https://schema.org/workExample-output",
     "Domain Bucket":"< 1K"
   },
   {
     "Class":"Predicate",
-    "Name":"http:\/\/schema.org\/workFeatured",
+    "Name":"https://schema.org/workFeatured",
     "Domain Bucket":"< 1K"
   },
   {
     "Class":"Predicate",
-    "Name":"http:\/\/schema.org\/workFeatured-input",
+    "Name":"https://schema.org/workFeatured-input",
     "Domain Bucket":"< 1K"
   },
   {
     "Class":"Predicate",
-    "Name":"http:\/\/schema.org\/workFeatured-output",
+    "Name":"https://schema.org/workFeatured-output",
     "Domain Bucket":"< 1K"
   },
   {
     "Class":"Predicate",
-    "Name":"http:\/\/schema.org\/workHours",
+    "Name":"https://schema.org/workHours",
     "Domain Bucket":"10K - 100K"
   },
   {
     "Class":"Predicate",
-    "Name":"http:\/\/schema.org\/workHours-input",
+    "Name":"https://schema.org/workHours-input",
     "Domain Bucket":"< 1K"
   },
   {
     "Class":"Predicate",
-    "Name":"http:\/\/schema.org\/workHours-output",
+    "Name":"https://schema.org/workHours-output",
     "Domain Bucket":"< 1K"
   },
   {
     "Class":"Predicate",
-    "Name":"http:\/\/schema.org\/workLocation",
+    "Name":"https://schema.org/workLocation",
     "Domain Bucket":"10K - 100K"
   },
   {
     "Class":"Predicate",
-    "Name":"http:\/\/schema.org\/workLocation-input",
+    "Name":"https://schema.org/workLocation-input",
     "Domain Bucket":"< 1K"
   },
   {
     "Class":"Predicate",
-    "Name":"http:\/\/schema.org\/workLocation-output",
+    "Name":"https://schema.org/workLocation-output",
     "Domain Bucket":"< 1K"
   },
   {
     "Class":"Predicate",
-    "Name":"http:\/\/schema.org\/workPerformed",
+    "Name":"https://schema.org/workPerformed",
     "Domain Bucket":"1K - 10K"
   },
   {
     "Class":"Predicate",
-    "Name":"http:\/\/schema.org\/workPerformed-input",
+    "Name":"https://schema.org/workPerformed-input",
     "Domain Bucket":"< 1K"
   },
   {
     "Class":"Predicate",
-    "Name":"http:\/\/schema.org\/workPerformed-output",
+    "Name":"https://schema.org/workPerformed-output",
     "Domain Bucket":"< 1K"
   },
   {
     "Class":"Predicate",
-    "Name":"http:\/\/schema.org\/workPresented",
+    "Name":"https://schema.org/workPresented",
     "Domain Bucket":"< 1K"
   },
   {
     "Class":"Predicate",
-    "Name":"http:\/\/schema.org\/workPresented-input",
+    "Name":"https://schema.org/workPresented-input",
     "Domain Bucket":"< 1K"
   },
   {
     "Class":"Predicate",
-    "Name":"http:\/\/schema.org\/workPresented-output",
+    "Name":"https://schema.org/workPresented-output",
     "Domain Bucket":"< 1K"
   },
   {
     "Class":"Predicate",
-    "Name":"http:\/\/schema.org\/workTranslation",
+    "Name":"https://schema.org/workTranslation",
     "Domain Bucket":"1K - 10K"
   },
   {
     "Class":"Predicate",
-    "Name":"http:\/\/schema.org\/workTranslation-input",
+    "Name":"https://schema.org/workTranslation-input",
     "Domain Bucket":"< 1K"
   },
   {
     "Class":"Predicate",
-    "Name":"http:\/\/schema.org\/workTranslation-output",
+    "Name":"https://schema.org/workTranslation-output",
     "Domain Bucket":"< 1K"
   },
   {
     "Class":"Predicate",
-    "Name":"http:\/\/schema.org\/workload",
+    "Name":"https://schema.org/workload",
     "Domain Bucket":"< 1K"
   },
   {
     "Class":"Predicate",
-    "Name":"http:\/\/schema.org\/workload-input",
+    "Name":"https://schema.org/workload-input",
     "Domain Bucket":"< 1K"
   },
   {
     "Class":"Predicate",
-    "Name":"http:\/\/schema.org\/workload-output",
+    "Name":"https://schema.org/workload-output",
     "Domain Bucket":"< 1K"
   },
   {
     "Class":"Predicate",
-    "Name":"http:\/\/schema.org\/worksFor",
+    "Name":"https://schema.org/worksFor",
     "Domain Bucket":"1M - 10M"
   },
   {
     "Class":"Predicate",
-    "Name":"http:\/\/schema.org\/worksFor-input",
+    "Name":"https://schema.org/worksFor-input",
     "Domain Bucket":"< 1K"
   },
   {
     "Class":"Predicate",
-    "Name":"http:\/\/schema.org\/worksFor-output",
+    "Name":"https://schema.org/worksFor-output",
     "Domain Bucket":"< 1K"
   },
   {
     "Class":"Predicate",
-    "Name":"http:\/\/schema.org\/worstRating",
+    "Name":"https://schema.org/worstRating",
     "Domain Bucket":"1M - 10M"
   },
   {
     "Class":"Predicate",
-    "Name":"http:\/\/schema.org\/worstRating-input",
+    "Name":"https://schema.org/worstRating-input",
     "Domain Bucket":"< 1K"
   },
   {
     "Class":"Predicate",
-    "Name":"http:\/\/schema.org\/worstRating-output",
+    "Name":"https://schema.org/worstRating-output",
     "Domain Bucket":"< 1K"
   },
   {
     "Class":"Predicate",
-    "Name":"http:\/\/schema.org\/xpath",
+    "Name":"https://schema.org/xpath",
     "Domain Bucket":"10K - 100K"
   },
   {
     "Class":"Predicate",
-    "Name":"http:\/\/schema.org\/xpath-input",
+    "Name":"https://schema.org/xpath-input",
     "Domain Bucket":"< 1K"
   },
   {
     "Class":"Predicate",
-    "Name":"http:\/\/schema.org\/xpath-output",
+    "Name":"https://schema.org/xpath-output",
     "Domain Bucket":"< 1K"
   },
   {
     "Class":"Predicate",
-    "Name":"http:\/\/schema.org\/yearBuilt",
+    "Name":"https://schema.org/yearBuilt",
     "Domain Bucket":"10K - 100K"
   },
   {
     "Class":"Predicate",
-    "Name":"http:\/\/schema.org\/yearBuilt-input",
+    "Name":"https://schema.org/yearBuilt-input",
     "Domain Bucket":"< 1K"
   },
   {
     "Class":"Predicate",
-    "Name":"http:\/\/schema.org\/yearBuilt-output",
+    "Name":"https://schema.org/yearBuilt-output",
     "Domain Bucket":"< 1K"
   },
   {
     "Class":"Predicate",
-    "Name":"http:\/\/schema.org\/yearlyRevenue",
+    "Name":"https://schema.org/yearlyRevenue",
     "Domain Bucket":"< 1K"
   },
   {
     "Class":"Predicate",
-    "Name":"http:\/\/schema.org\/yearlyRevenue-input",
+    "Name":"https://schema.org/yearlyRevenue-input",
     "Domain Bucket":"< 1K"
   },
   {
     "Class":"Predicate",
-    "Name":"http:\/\/schema.org\/yearlyRevenue-output",
+    "Name":"https://schema.org/yearlyRevenue-output",
     "Domain Bucket":"< 1K"
   },
   {
     "Class":"Predicate",
-    "Name":"http:\/\/schema.org\/yearsInOperation",
+    "Name":"https://schema.org/yearsInOperation",
     "Domain Bucket":"< 1K"
   },
   {
     "Class":"Predicate",
-    "Name":"http:\/\/schema.org\/yearsInOperation-input",
+    "Name":"https://schema.org/yearsInOperation-input",
     "Domain Bucket":"< 1K"
   },
   {
     "Class":"Predicate",
-    "Name":"http:\/\/schema.org\/yearsInOperation-output",
+    "Name":"https://schema.org/yearsInOperation-output",
     "Domain Bucket":"< 1K"
   },
   {
     "Class":"Predicate",
-    "Name":"http:\/\/schema.org\/yield",
+    "Name":"https://schema.org/yield",
     "Domain Bucket":"1K - 10K"
   },
   {
     "Class":"Predicate",
-    "Name":"http:\/\/schema.org\/yield-input",
+    "Name":"https://schema.org/yield-input",
     "Domain Bucket":"< 1K"
   },
   {
     "Class":"Predicate",
-    "Name":"http:\/\/schema.org\/yield-output",
+    "Name":"https://schema.org/yield-output",
     "Domain Bucket":"< 1K"
   }
 ]

--- a/data/public_stats/google/2026_06.csv
+++ b/data/public_stats/google/2026_06.csv
@@ -1,5546 +1,5546 @@
 Class,Name,Domain Bucket
-Itemtype,http://schema.org/3DModel,< 1K
-Itemtype,http://schema.org/AMRadioChannel,< 1K
-Itemtype,http://schema.org/APIReference,< 1K
-Itemtype,http://schema.org/AboutPage,100K - 1M
-Itemtype,http://schema.org/AcceptAction,< 1K
-Itemtype,http://schema.org/Accommodation,10K - 100K
-Itemtype,http://schema.org/AccountingService,10K - 100K
-Itemtype,http://schema.org/AchieveAction,< 1K
-Itemtype,http://schema.org/Action,10K - 100K
-Itemtype,http://schema.org/ActionAccessSpecification,< 1K
-Itemtype,http://schema.org/ActionStatusType,< 1K
-Itemtype,http://schema.org/ActivateAction,< 1K
-Itemtype,http://schema.org/AddAction,< 1K
-Itemtype,http://schema.org/AdministrativeArea,100K - 1M
-Itemtype,http://schema.org/AdultEntertainment,1K - 10K
-Itemtype,http://schema.org/AdultOrientedEnumeration,< 1K
-Itemtype,http://schema.org/AdvertiserContentArticle,1K - 10K
-Itemtype,http://schema.org/AggregateOffer,1M - 10M
-Itemtype,http://schema.org/AggregateRating,1M - 10M
-Itemtype,http://schema.org/AgreeAction,< 1K
-Itemtype,http://schema.org/Airline,1K - 10K
-Itemtype,http://schema.org/Airport,1K - 10K
-Itemtype,http://schema.org/AlignmentObject,1K - 10K
-Itemtype,http://schema.org/AllocateAction,< 1K
-Itemtype,http://schema.org/AmpStory,< 1K
-Itemtype,http://schema.org/AmusementPark,1K - 10K
-Itemtype,http://schema.org/AnalysisNewsArticle,1K - 10K
-Itemtype,http://schema.org/AnatomicalStructure,1K - 10K
-Itemtype,http://schema.org/AnatomicalSystem,< 1K
-Itemtype,http://schema.org/AnimalShelter,1K - 10K
-Itemtype,http://schema.org/Answer,1M - 10M
-Itemtype,http://schema.org/Apartment,10K - 100K
-Itemtype,http://schema.org/ApartmentComplex,10K - 100K
-Itemtype,http://schema.org/AppendAction,< 1K
-Itemtype,http://schema.org/ApplyAction,1K - 10K
-Itemtype,http://schema.org/ApprovedIndication,< 1K
-Itemtype,http://schema.org/Aquarium,< 1K
-Itemtype,http://schema.org/ArchiveComponent,< 1K
-Itemtype,http://schema.org/ArchiveOrganization,1K - 10K
-Itemtype,http://schema.org/ArriveAction,< 1K
-Itemtype,http://schema.org/ArtGallery,1K - 10K
-Itemtype,http://schema.org/Artery,< 1K
-Itemtype,http://schema.org/Article,1M - 10M
-Itemtype,http://schema.org/AskAction,< 1K
-Itemtype,http://schema.org/AskPublicNewsArticle,< 1K
-Itemtype,http://schema.org/AssessAction,< 1K
-Itemtype,http://schema.org/AssignAction,< 1K
-Itemtype,http://schema.org/Atlas,< 1K
-Itemtype,http://schema.org/Attorney,10K - 100K
-Itemtype,http://schema.org/Audience,100K - 1M
-Itemtype,http://schema.org/AudioObject,10K - 100K
-Itemtype,http://schema.org/AudioObjectSnapshot,< 1K
-Itemtype,http://schema.org/Audiobook,< 1K
-Itemtype,http://schema.org/AuthenticateAction,< 1K
-Itemtype,http://schema.org/AuthorizeAction,< 1K
-Itemtype,http://schema.org/AutoBodyShop,1K - 10K
-Itemtype,http://schema.org/AutoDealer,10K - 100K
-Itemtype,http://schema.org/AutoPartsStore,10K - 100K
-Itemtype,http://schema.org/AutoRental,10K - 100K
-Itemtype,http://schema.org/AutoRepair,10K - 100K
-Itemtype,http://schema.org/AutoWash,1K - 10K
-Itemtype,http://schema.org/AutomatedTeller,< 1K
-Itemtype,http://schema.org/AutomotiveBusiness,10K - 100K
-Itemtype,http://schema.org/BackgroundNewsArticle,< 1K
-Itemtype,http://schema.org/Bakery,1K - 10K
-Itemtype,http://schema.org/BankAccount,< 1K
-Itemtype,http://schema.org/BankOrCreditUnion,1K - 10K
-Itemtype,http://schema.org/BarOrPub,10K - 100K
-Itemtype,http://schema.org/Barcode,< 1K
-Itemtype,http://schema.org/Beach,1K - 10K
-Itemtype,http://schema.org/BeautySalon,10K - 100K
-Itemtype,http://schema.org/BedAndBreakfast,1K - 10K
-Itemtype,http://schema.org/BedDetails,10K - 100K
-Itemtype,http://schema.org/BedType,< 1K
-Itemtype,http://schema.org/BefriendAction,< 1K
-Itemtype,http://schema.org/BikeStore,1K - 10K
-Itemtype,http://schema.org/BioChemEntity,< 1K
-Itemtype,http://schema.org/Blog,1M - 10M
-Itemtype,http://schema.org/BlogPosting,1M - 10M
-Itemtype,http://schema.org/BloodTest,< 1K
-Itemtype,http://schema.org/BoardingPolicyType,< 1K
-Itemtype,http://schema.org/BoatReservation,< 1K
-Itemtype,http://schema.org/BoatTerminal,< 1K
-Itemtype,http://schema.org/BoatTrip,< 1K
-Itemtype,http://schema.org/BodyMeasurementTypeEnumeration,< 1K
-Itemtype,http://schema.org/BodyOfWater,< 1K
-Itemtype,http://schema.org/Bone,< 1K
-Itemtype,http://schema.org/Book,10K - 100K
-Itemtype,http://schema.org/BookFormatType,< 1K
-Itemtype,http://schema.org/BookSeries,1K - 10K
-Itemtype,http://schema.org/BookStore,1K - 10K
-Itemtype,http://schema.org/BookmarkAction,< 1K
-Itemtype,http://schema.org/Boolean,< 1K
-Itemtype,http://schema.org/BorrowAction,< 1K
-Itemtype,http://schema.org/BowlingAlley,< 1K
-Itemtype,http://schema.org/BrainStructure,< 1K
-Itemtype,http://schema.org/Brand,1M - 10M
-Itemtype,http://schema.org/BreadcrumbList,10M+
-Itemtype,http://schema.org/Brewery,1K - 10K
-Itemtype,http://schema.org/Bridge,< 1K
-Itemtype,http://schema.org/BroadcastChannel,< 1K
-Itemtype,http://schema.org/BroadcastEvent,10K - 100K
-Itemtype,http://schema.org/BroadcastFrequencySpecification,< 1K
-Itemtype,http://schema.org/BroadcastService,1K - 10K
-Itemtype,http://schema.org/BrokerageAccount,< 1K
-Itemtype,http://schema.org/BuddhistTemple,< 1K
-Itemtype,http://schema.org/BusOrCoach,< 1K
-Itemtype,http://schema.org/BusReservation,< 1K
-Itemtype,http://schema.org/BusStation,< 1K
-Itemtype,http://schema.org/BusStop,< 1K
-Itemtype,http://schema.org/BusTrip,< 1K
-Itemtype,http://schema.org/BusinessAudience,10K - 100K
-Itemtype,http://schema.org/BusinessEntityType,< 1K
-Itemtype,http://schema.org/BusinessEvent,1K - 10K
-Itemtype,http://schema.org/BusinessFunction,< 1K
-Itemtype,http://schema.org/BuyAction,1M - 10M
-Itemtype,http://schema.org/CDCPMDRecord,< 1K
-Itemtype,http://schema.org/CableOrSatelliteService,< 1K
-Itemtype,http://schema.org/CafeOrCoffeeShop,1K - 10K
-Itemtype,http://schema.org/Campground,1K - 10K
-Itemtype,http://schema.org/CampingPitch,< 1K
-Itemtype,http://schema.org/Canal,< 1K
-Itemtype,http://schema.org/CancelAction,< 1K
-Itemtype,http://schema.org/Car,10K - 100K
-Itemtype,http://schema.org/CarUsageType,< 1K
-Itemtype,http://schema.org/Casino,100K - 1M
-Itemtype,http://schema.org/CategoryCode,1K - 10K
-Itemtype,http://schema.org/CategoryCodeSet,< 1K
-Itemtype,http://schema.org/CatholicChurch,< 1K
-Itemtype,http://schema.org/Cemetery,< 1K
-Itemtype,http://schema.org/Certification,10K - 100K
-Itemtype,http://schema.org/CertificationStatusEnumeration,< 1K
-Itemtype,http://schema.org/Chapter,1K - 10K
-Itemtype,http://schema.org/CheckAction,< 1K
-Itemtype,http://schema.org/CheckInAction,< 1K
-Itemtype,http://schema.org/CheckOutAction,< 1K
-Itemtype,http://schema.org/CheckoutPage,1K - 10K
-Itemtype,http://schema.org/ChemicalSubstance,< 1K
-Itemtype,http://schema.org/ChildCare,1K - 10K
-Itemtype,http://schema.org/ChildrensEvent,< 1K
-Itemtype,http://schema.org/ChooseAction,1K - 10K
-Itemtype,http://schema.org/Church,1K - 10K
-Itemtype,http://schema.org/City,100K - 1M
-Itemtype,http://schema.org/CityHall,< 1K
-Itemtype,http://schema.org/CivicStructure,1K - 10K
-Itemtype,http://schema.org/Claim,1K - 10K
-Itemtype,http://schema.org/ClaimReview,1K - 10K
-Itemtype,http://schema.org/Class,< 1K
-Itemtype,http://schema.org/Clip,10K - 100K
-Itemtype,http://schema.org/ClothingStore,10K - 100K
-Itemtype,http://schema.org/Code,< 1K
-Itemtype,http://schema.org/Collection,10K - 100K
-Itemtype,http://schema.org/CollectionPage,1M - 10M
-Itemtype,http://schema.org/CollegeOrUniversity,10K - 100K
-Itemtype,http://schema.org/ComedyClub,< 1K
-Itemtype,http://schema.org/ComedyEvent,1K - 10K
-Itemtype,http://schema.org/ComicCoverArt,< 1K
-Itemtype,http://schema.org/ComicIssue,< 1K
-Itemtype,http://schema.org/ComicSeries,1K - 10K
-Itemtype,http://schema.org/ComicStory,< 1K
-Itemtype,http://schema.org/Comment,100K - 1M
-Itemtype,http://schema.org/CommentAction,1M - 10M
-Itemtype,http://schema.org/CommunicateAction,10K - 100K
-Itemtype,http://schema.org/CommunityHealth,1K - 10K
-Itemtype,http://schema.org/CompleteDataFeed,< 1K
-Itemtype,http://schema.org/CompoundPriceSpecification,1K - 10K
-Itemtype,http://schema.org/ComputerLanguage,< 1K
-Itemtype,http://schema.org/ComputerStore,1K - 10K
-Itemtype,http://schema.org/ConferenceEvent,< 1K
-Itemtype,http://schema.org/ConfirmAction,< 1K
-Itemtype,http://schema.org/Consortium,< 1K
-Itemtype,http://schema.org/ConstraintNode,< 1K
-Itemtype,http://schema.org/ConsumeAction,< 1K
-Itemtype,http://schema.org/ContactPage,100K - 1M
-Itemtype,http://schema.org/ContactPoint,1M - 10M
-Itemtype,http://schema.org/ContactPointOption,< 1K
-Itemtype,http://schema.org/Continent,1K - 10K
-Itemtype,http://schema.org/ControlAction,< 1K
-Itemtype,http://schema.org/ConvenienceStore,< 1K
-Itemtype,http://schema.org/Conversation,< 1K
-Itemtype,http://schema.org/CookAction,< 1K
-Itemtype,http://schema.org/Cooperative,< 1K
-Itemtype,http://schema.org/Corporation,100K - 1M
-Itemtype,http://schema.org/CorrectionComment,< 1K
-Itemtype,http://schema.org/Country,1M - 10M
-Itemtype,http://schema.org/Course,100K - 1M
-Itemtype,http://schema.org/CourseInstance,10K - 100K
-Itemtype,http://schema.org/Courthouse,< 1K
-Itemtype,http://schema.org/CoverArt,< 1K
-Itemtype,http://schema.org/CovidTestingFacility,< 1K
-Itemtype,http://schema.org/CreateAction,1K - 10K
-Itemtype,http://schema.org/CreativeWork,1M - 10M
-Itemtype,http://schema.org/CreativeWorkSeason,1K - 10K
-Itemtype,http://schema.org/CreativeWorkSeries,10K - 100K
-Itemtype,http://schema.org/Credential,10K - 100K
-Itemtype,http://schema.org/CreditCard,1K - 10K
-Itemtype,http://schema.org/Crematorium,< 1K
-Itemtype,http://schema.org/CriticReview,< 1K
-Itemtype,http://schema.org/CssSelectorType,< 1K
-Itemtype,http://schema.org/CurrencyConversionService,< 1K
-Itemtype,http://schema.org/DDxElement,< 1K
-Itemtype,http://schema.org/DENonprofitType,< 1K
-Itemtype,http://schema.org/DanceEvent,< 1K
-Itemtype,http://schema.org/DanceGroup,< 1K
-Itemtype,http://schema.org/DataCatalog,1K - 10K
-Itemtype,http://schema.org/DataDownload,10K - 100K
-Itemtype,http://schema.org/DataFeed,1K - 10K
-Itemtype,http://schema.org/DataFeedItem,1K - 10K
-Itemtype,http://schema.org/DataType,< 1K
-Itemtype,http://schema.org/Dataset,10K - 100K
-Itemtype,http://schema.org/Date,< 1K
-Itemtype,http://schema.org/DateTime,< 1K
-Itemtype,http://schema.org/DatedMoneySpecification,< 1K
-Itemtype,http://schema.org/DayOfWeek,10K - 100K
-Itemtype,http://schema.org/DaySpa,1K - 10K
-Itemtype,http://schema.org/DeactivateAction,< 1K
-Itemtype,http://schema.org/DefenceEstablishment,< 1K
-Itemtype,http://schema.org/DefinedRegion,100K - 1M
-Itemtype,http://schema.org/DefinedTerm,10K - 100K
-Itemtype,http://schema.org/DefinedTermSet,10K - 100K
-Itemtype,http://schema.org/DeleteAction,< 1K
-Itemtype,http://schema.org/DeliveryChargeSpecification,10K - 100K
-Itemtype,http://schema.org/DeliveryEvent,< 1K
-Itemtype,http://schema.org/DeliveryMethod,1K - 10K
-Itemtype,http://schema.org/DeliveryTimeSettings,< 1K
-Itemtype,http://schema.org/Demand,1K - 10K
-Itemtype,http://schema.org/Dentist,10K - 100K
-Itemtype,http://schema.org/DepartAction,< 1K
-Itemtype,http://schema.org/DepartmentStore,1K - 10K
-Itemtype,http://schema.org/DepositAccount,< 1K
-Itemtype,http://schema.org/Dermatology,1K - 10K
-Itemtype,http://schema.org/DiagnosticLab,1K - 10K
-Itemtype,http://schema.org/DiagnosticProcedure,< 1K
-Itemtype,http://schema.org/Diet,< 1K
-Itemtype,http://schema.org/DietNutrition,1K - 10K
-Itemtype,http://schema.org/DietarySupplement,< 1K
-Itemtype,http://schema.org/DigitalDocument,10K - 100K
-Itemtype,http://schema.org/DigitalDocumentPermission,< 1K
-Itemtype,http://schema.org/DigitalDocumentPermissionType,< 1K
-Itemtype,http://schema.org/DigitalPlatformEnumeration,< 1K
-Itemtype,http://schema.org/DisagreeAction,< 1K
-Itemtype,http://schema.org/DiscoverAction,< 1K
-Itemtype,http://schema.org/DiscussionForumPosting,10K - 100K
-Itemtype,http://schema.org/DislikeAction,1K - 10K
-Itemtype,http://schema.org/Distance,1K - 10K
-Itemtype,http://schema.org/Distillery,< 1K
-Itemtype,http://schema.org/DonateAction,1K - 10K
-Itemtype,http://schema.org/DoseSchedule,< 1K
-Itemtype,http://schema.org/DownloadAction,1K - 10K
-Itemtype,http://schema.org/DrawAction,< 1K
-Itemtype,http://schema.org/Drawing,< 1K
-Itemtype,http://schema.org/DrinkAction,< 1K
-Itemtype,http://schema.org/DriveWheelConfigurationValue,< 1K
-Itemtype,http://schema.org/Drug,1K - 10K
-Itemtype,http://schema.org/DrugClass,1K - 10K
-Itemtype,http://schema.org/DrugCost,< 1K
-Itemtype,http://schema.org/DrugCostCategory,< 1K
-Itemtype,http://schema.org/DrugLegalStatus,< 1K
-Itemtype,http://schema.org/DrugPregnancyCategory,< 1K
-Itemtype,http://schema.org/DrugPrescriptionStatus,< 1K
-Itemtype,http://schema.org/DrugStrength,< 1K
-Itemtype,http://schema.org/DryCleaningOrLaundry,1K - 10K
-Itemtype,http://schema.org/Duration,10K - 100K
-Itemtype,http://schema.org/EUEnergyEfficiencyEnumeration,< 1K
-Itemtype,http://schema.org/EatAction,< 1K
-Itemtype,http://schema.org/EducationEvent,1K - 10K
-Itemtype,http://schema.org/EducationalAudience,10K - 100K
-Itemtype,http://schema.org/EducationalOccupationalCredential,10K - 100K
-Itemtype,http://schema.org/EducationalOccupationalProgram,1K - 10K
-Itemtype,http://schema.org/EducationalOrganization,100K - 1M
-Itemtype,http://schema.org/Electrician,10K - 100K
-Itemtype,http://schema.org/ElectronicsStore,1K - 10K
-Itemtype,http://schema.org/ElementarySchool,< 1K
-Itemtype,http://schema.org/EmailMessage,< 1K
-Itemtype,http://schema.org/Embassy,< 1K
-Itemtype,http://schema.org/Emergency,< 1K
-Itemtype,http://schema.org/EmergencyService,1K - 10K
-Itemtype,http://schema.org/EmployeeRole,< 1K
-Itemtype,http://schema.org/EmployerAggregateRating,1K - 10K
-Itemtype,http://schema.org/EmployerReview,< 1K
-Itemtype,http://schema.org/EmploymentAgency,1K - 10K
-Itemtype,http://schema.org/EndorseAction,< 1K
-Itemtype,http://schema.org/EndorsementRating,< 1K
-Itemtype,http://schema.org/Energy,< 1K
-Itemtype,http://schema.org/EnergyConsumptionDetails,1K - 10K
-Itemtype,http://schema.org/EnergyEfficiencyEnumeration,< 1K
-Itemtype,http://schema.org/EnergyStarEnergyEfficiencyEnumeration,< 1K
-Itemtype,http://schema.org/EngineSpecification,10K - 100K
-Itemtype,http://schema.org/EntertainmentBusiness,10K - 100K
-Itemtype,http://schema.org/EntryPoint,10M+
-Itemtype,http://schema.org/Enumeration,1K - 10K
-Itemtype,http://schema.org/Episode,1K - 10K
-Itemtype,http://schema.org/Error,< 1K
-Itemtype,http://schema.org/Event,100K - 1M
-Itemtype,http://schema.org/EventAttendanceModeEnumeration,< 1K
-Itemtype,http://schema.org/EventReservation,< 1K
-Itemtype,http://schema.org/EventSeries,1K - 10K
-Itemtype,http://schema.org/EventStatusType,< 1K
-Itemtype,http://schema.org/EventVenue,10K - 100K
-Itemtype,http://schema.org/ExchangeRateSpecification,< 1K
-Itemtype,http://schema.org/ExerciseAction,< 1K
-Itemtype,http://schema.org/ExerciseGym,1K - 10K
-Itemtype,http://schema.org/ExercisePlan,< 1K
-Itemtype,http://schema.org/ExhibitionEvent,1K - 10K
-Itemtype,http://schema.org/FAQPage,1M - 10M
-Itemtype,http://schema.org/FMRadioChannel,< 1K
-Itemtype,http://schema.org/FastFoodRestaurant,1K - 10K
-Itemtype,http://schema.org/Festival,1K - 10K
-Itemtype,http://schema.org/FilmAction,< 1K
-Itemtype,http://schema.org/FinancialIncentive,< 1K
-Itemtype,http://schema.org/FinancialProduct,10K - 100K
-Itemtype,http://schema.org/FinancialService,10K - 100K
-Itemtype,http://schema.org/FindAction,< 1K
-Itemtype,http://schema.org/FireStation,< 1K
-Itemtype,http://schema.org/Flight,1K - 10K
-Itemtype,http://schema.org/FlightReservation,< 1K
-Itemtype,http://schema.org/Float,< 1K
-Itemtype,http://schema.org/FloorPlan,10K - 100K
-Itemtype,http://schema.org/Florist,10K - 100K
-Itemtype,http://schema.org/FollowAction,10K - 100K
-Itemtype,http://schema.org/FoodEstablishment,10K - 100K
-Itemtype,http://schema.org/FoodEstablishmentReservation,1K - 10K
-Itemtype,http://schema.org/FoodEvent,1K - 10K
-Itemtype,http://schema.org/FoodService,1K - 10K
-Itemtype,http://schema.org/FulfillmentTypeEnumeration,< 1K
-Itemtype,http://schema.org/FundingAgency,< 1K
-Itemtype,http://schema.org/FundingScheme,< 1K
-Itemtype,http://schema.org/FurnitureStore,10K - 100K
-Itemtype,http://schema.org/Game,100K - 1M
-Itemtype,http://schema.org/GameAvailabilityEnumeration,< 1K
-Itemtype,http://schema.org/GamePlayMode,< 1K
-Itemtype,http://schema.org/GameServer,1K - 10K
-Itemtype,http://schema.org/GameServerStatus,< 1K
-Itemtype,http://schema.org/GardenStore,1K - 10K
-Itemtype,http://schema.org/GasStation,1K - 10K
-Itemtype,http://schema.org/GatedResidenceCommunity,< 1K
-Itemtype,http://schema.org/GenderType,< 1K
-Itemtype,http://schema.org/Gene,< 1K
-Itemtype,http://schema.org/GeneralContractor,10K - 100K
-Itemtype,http://schema.org/GeoCircle,100K - 1M
-Itemtype,http://schema.org/GeoCoordinates,1M - 10M
-Itemtype,http://schema.org/GeoShape,10K - 100K
-Itemtype,http://schema.org/GeospatialGeometry,< 1K
-Itemtype,http://schema.org/Geriatric,< 1K
-Itemtype,http://schema.org/GiveAction,< 1K
-Itemtype,http://schema.org/GolfCourse,1K - 10K
-Itemtype,http://schema.org/GovernmentBenefitsType,< 1K
-Itemtype,http://schema.org/GovernmentBuilding,< 1K
-Itemtype,http://schema.org/GovernmentOffice,1K - 10K
-Itemtype,http://schema.org/GovernmentOrganization,10K - 100K
-Itemtype,http://schema.org/GovernmentPermit,< 1K
-Itemtype,http://schema.org/GovernmentService,1K - 10K
-Itemtype,http://schema.org/Grant,1K - 10K
-Itemtype,http://schema.org/GroceryStore,1K - 10K
-Itemtype,http://schema.org/Guide,1K - 10K
-Itemtype,http://schema.org/Gynecologic,< 1K
-Itemtype,http://schema.org/HVACBusiness,10K - 100K
-Itemtype,http://schema.org/Hackathon,< 1K
-Itemtype,http://schema.org/HairSalon,10K - 100K
-Itemtype,http://schema.org/HardwareStore,1K - 10K
-Itemtype,http://schema.org/HealthAndBeautyBusiness,10K - 100K
-Itemtype,http://schema.org/HealthAspectEnumeration,< 1K
-Itemtype,http://schema.org/HealthClub,1K - 10K
-Itemtype,http://schema.org/HealthInsurancePlan,< 1K
-Itemtype,http://schema.org/HealthPlanCostSharingSpecification,< 1K
-Itemtype,http://schema.org/HealthPlanFormulary,< 1K
-Itemtype,http://schema.org/HealthPlanNetwork,< 1K
-Itemtype,http://schema.org/HealthTopicContent,< 1K
-Itemtype,http://schema.org/HighSchool,1K - 10K
-Itemtype,http://schema.org/HinduTemple,< 1K
-Itemtype,http://schema.org/HobbyShop,1K - 10K
-Itemtype,http://schema.org/HomeAndConstructionBusiness,100K - 1M
-Itemtype,http://schema.org/HomeGoodsStore,1K - 10K
-Itemtype,http://schema.org/Hospital,10K - 100K
-Itemtype,http://schema.org/Hostel,1K - 10K
-Itemtype,http://schema.org/Hotel,10K - 100K
-Itemtype,http://schema.org/HotelRoom,10K - 100K
-Itemtype,http://schema.org/House,10K - 100K
-Itemtype,http://schema.org/HousePainter,1K - 10K
-Itemtype,http://schema.org/HowTo,100K - 1M
-Itemtype,http://schema.org/HowToDirection,10K - 100K
-Itemtype,http://schema.org/HowToItem,< 1K
-Itemtype,http://schema.org/HowToSection,10K - 100K
-Itemtype,http://schema.org/HowToStep,100K - 1M
-Itemtype,http://schema.org/HowToSupply,10K - 100K
-Itemtype,http://schema.org/HowToTip,1K - 10K
-Itemtype,http://schema.org/HowToTool,10K - 100K
-Itemtype,http://schema.org/HyperToc,< 1K
-Itemtype,http://schema.org/HyperTocEntry,< 1K
-Itemtype,http://schema.org/IPTCDigitalSourceEnumeration,< 1K
-Itemtype,http://schema.org/ITNonprofitType,< 1K
-Itemtype,http://schema.org/IceCreamShop,1K - 10K
-Itemtype,http://schema.org/IgnoreAction,< 1K
-Itemtype,http://schema.org/ImageGallery,1M - 10M
-Itemtype,http://schema.org/ImageObject,10M+
-Itemtype,http://schema.org/ImageObjectSnapshot,< 1K
-Itemtype,http://schema.org/ImagingTest,< 1K
-Itemtype,http://schema.org/IncentiveQualifiedExpenseType,< 1K
-Itemtype,http://schema.org/IncentiveStatus,< 1K
-Itemtype,http://schema.org/IncentiveType,< 1K
-Itemtype,http://schema.org/IndividualPhysician,1K - 10K
-Itemtype,http://schema.org/IndividualProduct,10K - 100K
-Itemtype,http://schema.org/InfectiousAgentClass,< 1K
-Itemtype,http://schema.org/InfectiousDisease,< 1K
-Itemtype,http://schema.org/InformAction,< 1K
-Itemtype,http://schema.org/InsertAction,< 1K
-Itemtype,http://schema.org/InstallAction,< 1K
-Itemtype,http://schema.org/InstantaneousEvent,< 1K
-Itemtype,http://schema.org/InsuranceAgency,10K - 100K
-Itemtype,http://schema.org/Intangible,1K - 10K
-Itemtype,http://schema.org/Integer,< 1K
-Itemtype,http://schema.org/InteractAction,1K - 10K
-Itemtype,http://schema.org/InteractionCounter,100K - 1M
-Itemtype,http://schema.org/InternetCafe,< 1K
-Itemtype,http://schema.org/InvestmentFund,< 1K
-Itemtype,http://schema.org/InvestmentOrDeposit,< 1K
-Itemtype,http://schema.org/InviteAction,< 1K
-Itemtype,http://schema.org/Invoice,< 1K
-Itemtype,http://schema.org/ItemAvailability,1K - 10K
-Itemtype,http://schema.org/ItemList,1M - 10M
-Itemtype,http://schema.org/ItemListOrderType,< 1K
-Itemtype,http://schema.org/ItemPage,1M - 10M
-Itemtype,http://schema.org/JewelryStore,10K - 100K
-Itemtype,http://schema.org/JobPosting,100K - 1M
-Itemtype,http://schema.org/JoinAction,1K - 10K
-Itemtype,http://schema.org/Joint,< 1K
-Itemtype,http://schema.org/LakeBodyOfWater,< 1K
-Itemtype,http://schema.org/Landform,1K - 10K
-Itemtype,http://schema.org/LandmarksOrHistoricalBuildings,1K - 10K
-Itemtype,http://schema.org/Language,10K - 100K
-Itemtype,http://schema.org/LearningResource,1K - 10K
-Itemtype,http://schema.org/LeaveAction,< 1K
-Itemtype,http://schema.org/LegalForceStatus,< 1K
-Itemtype,http://schema.org/LegalService,10K - 100K
-Itemtype,http://schema.org/LegalValueLevel,< 1K
-Itemtype,http://schema.org/Legislation,1K - 10K
-Itemtype,http://schema.org/LegislationObject,1K - 10K
-Itemtype,http://schema.org/LegislativeBuilding,< 1K
-Itemtype,http://schema.org/LendAction,< 1K
-Itemtype,http://schema.org/Library,1K - 10K
-Itemtype,http://schema.org/LibrarySystem,< 1K
-Itemtype,http://schema.org/LifestyleModification,< 1K
-Itemtype,http://schema.org/Ligament,< 1K
-Itemtype,http://schema.org/LikeAction,10K - 100K
-Itemtype,http://schema.org/LinkRole,< 1K
-Itemtype,http://schema.org/LiquorStore,1K - 10K
-Itemtype,http://schema.org/ListItem,10M+
-Itemtype,http://schema.org/ListenAction,1K - 10K
-Itemtype,http://schema.org/Literal,< 1K
-Itemtype,http://schema.org/LiteraryEvent,< 1K
-Itemtype,http://schema.org/LiveBlogPosting,1K - 10K
-Itemtype,http://schema.org/LoanOrCredit,1K - 10K
-Itemtype,http://schema.org/LocalBusiness,1M - 10M
-Itemtype,http://schema.org/LocationFeatureSpecification,100K - 1M
-Itemtype,http://schema.org/Locksmith,10K - 100K
-Itemtype,http://schema.org/LodgingBusiness,10K - 100K
-Itemtype,http://schema.org/LodgingReservation,1K - 10K
-Itemtype,http://schema.org/LoginAction,1K - 10K
-Itemtype,http://schema.org/LoseAction,< 1K
-Itemtype,http://schema.org/LymphaticVessel,< 1K
-Itemtype,http://schema.org/Manuscript,< 1K
-Itemtype,http://schema.org/Map,10K - 100K
-Itemtype,http://schema.org/MapCategoryType,< 1K
-Itemtype,http://schema.org/MarryAction,< 1K
-Itemtype,http://schema.org/Mass,< 1K
-Itemtype,http://schema.org/MathSolver,< 1K
-Itemtype,http://schema.org/MaximumDoseSchedule,< 1K
-Itemtype,http://schema.org/MeasurementMethodEnum,< 1K
-Itemtype,http://schema.org/MeasurementTypeEnumeration,< 1K
-Itemtype,http://schema.org/MediaEnumeration,< 1K
-Itemtype,http://schema.org/MediaGallery,1K - 10K
-Itemtype,http://schema.org/MediaManipulationRatingEnumeration,< 1K
-Itemtype,http://schema.org/MediaObject,100K - 1M
-Itemtype,http://schema.org/MediaReview,< 1K
-Itemtype,http://schema.org/MediaReviewItem,< 1K
-Itemtype,http://schema.org/MediaSubscription,< 1K
-Itemtype,http://schema.org/MedicalAudience,10K - 100K
-Itemtype,http://schema.org/MedicalAudienceType,< 1K
-Itemtype,http://schema.org/MedicalBusiness,10K - 100K
-Itemtype,http://schema.org/MedicalCause,1K - 10K
-Itemtype,http://schema.org/MedicalClinic,10K - 100K
-Itemtype,http://schema.org/MedicalCode,1K - 10K
-Itemtype,http://schema.org/MedicalCondition,10K - 100K
-Itemtype,http://schema.org/MedicalConditionStage,< 1K
-Itemtype,http://schema.org/MedicalContraindication,< 1K
-Itemtype,http://schema.org/MedicalDevice,1K - 10K
-Itemtype,http://schema.org/MedicalDevicePurpose,< 1K
-Itemtype,http://schema.org/MedicalEntity,1K - 10K
-Itemtype,http://schema.org/MedicalEnumeration,< 1K
-Itemtype,http://schema.org/MedicalEvidenceLevel,< 1K
-Itemtype,http://schema.org/MedicalGuideline,< 1K
-Itemtype,http://schema.org/MedicalGuidelineContraindication,< 1K
-Itemtype,http://schema.org/MedicalGuidelineRecommendation,< 1K
-Itemtype,http://schema.org/MedicalImagingTechnique,< 1K
-Itemtype,http://schema.org/MedicalIndication,1K - 10K
-Itemtype,http://schema.org/MedicalIntangible,< 1K
-Itemtype,http://schema.org/MedicalObservationalStudy,< 1K
-Itemtype,http://schema.org/MedicalObservationalStudyDesign,< 1K
-Itemtype,http://schema.org/MedicalOrganization,10K - 100K
-Itemtype,http://schema.org/MedicalProcedure,10K - 100K
-Itemtype,http://schema.org/MedicalProcedureType,< 1K
-Itemtype,http://schema.org/MedicalRiskCalculator,< 1K
-Itemtype,http://schema.org/MedicalRiskEstimator,< 1K
-Itemtype,http://schema.org/MedicalRiskFactor,1K - 10K
-Itemtype,http://schema.org/MedicalRiskScore,< 1K
-Itemtype,http://schema.org/MedicalScholarlyArticle,1K - 10K
-Itemtype,http://schema.org/MedicalSign,< 1K
-Itemtype,http://schema.org/MedicalSignOrSymptom,1K - 10K
-Itemtype,http://schema.org/MedicalSpecialty,10K - 100K
-Itemtype,http://schema.org/MedicalStudy,1K - 10K
-Itemtype,http://schema.org/MedicalStudyStatus,< 1K
-Itemtype,http://schema.org/MedicalSymptom,1K - 10K
-Itemtype,http://schema.org/MedicalTest,1K - 10K
-Itemtype,http://schema.org/MedicalTestPanel,< 1K
-Itemtype,http://schema.org/MedicalTherapy,10K - 100K
-Itemtype,http://schema.org/MedicalTrial,< 1K
-Itemtype,http://schema.org/MedicalTrialDesign,< 1K
-Itemtype,http://schema.org/MedicalWebPage,10K - 100K
-Itemtype,http://schema.org/MedicineSystem,< 1K
-Itemtype,http://schema.org/MeetingRoom,1K - 10K
-Itemtype,http://schema.org/MemberProgram,1K - 10K
-Itemtype,http://schema.org/MemberProgramTier,1K - 10K
-Itemtype,http://schema.org/MensClothingStore,< 1K
-Itemtype,http://schema.org/Menu,100K - 1M
-Itemtype,http://schema.org/MenuItem,10K - 100K
-Itemtype,http://schema.org/MenuSection,10K - 100K
-Itemtype,http://schema.org/MerchantReturnEnumeration,< 1K
-Itemtype,http://schema.org/MerchantReturnPolicy,100K - 1M
-Itemtype,http://schema.org/MerchantReturnPolicySeasonalOverride,1K - 10K
-Itemtype,http://schema.org/Message,1K - 10K
-Itemtype,http://schema.org/MiddleSchool,< 1K
-Itemtype,http://schema.org/Midwifery,< 1K
-Itemtype,http://schema.org/MobileApplication,100K - 1M
-Itemtype,http://schema.org/MobilePhoneStore,1K - 10K
-Itemtype,http://schema.org/MolecularEntity,< 1K
-Itemtype,http://schema.org/MonetaryAmount,100K - 1M
-Itemtype,http://schema.org/MonetaryAmountDistribution,1K - 10K
-Itemtype,http://schema.org/MonetaryGrant,1K - 10K
-Itemtype,http://schema.org/MoneyTransfer,< 1K
-Itemtype,http://schema.org/MortgageLoan,< 1K
-Itemtype,http://schema.org/Mosque,< 1K
-Itemtype,http://schema.org/Motel,< 1K
-Itemtype,http://schema.org/Motorcycle,1K - 10K
-Itemtype,http://schema.org/MotorcycleDealer,1K - 10K
-Itemtype,http://schema.org/MotorcycleRepair,< 1K
-Itemtype,http://schema.org/MotorizedBicycle,< 1K
-Itemtype,http://schema.org/Mountain,< 1K
-Itemtype,http://schema.org/MoveAction,< 1K
-Itemtype,http://schema.org/Movie,10K - 100K
-Itemtype,http://schema.org/MovieClip,< 1K
-Itemtype,http://schema.org/MovieRentalStore,< 1K
-Itemtype,http://schema.org/MovieSeries,< 1K
-Itemtype,http://schema.org/MovieTheater,1K - 10K
-Itemtype,http://schema.org/MovingCompany,10K - 100K
-Itemtype,http://schema.org/Muscle,< 1K
-Itemtype,http://schema.org/Museum,1K - 10K
-Itemtype,http://schema.org/MusicAlbum,10K - 100K
-Itemtype,http://schema.org/MusicAlbumProductionType,< 1K
-Itemtype,http://schema.org/MusicAlbumReleaseType,< 1K
-Itemtype,http://schema.org/MusicComposition,1K - 10K
-Itemtype,http://schema.org/MusicEvent,10K - 100K
-Itemtype,http://schema.org/MusicGroup,10K - 100K
-Itemtype,http://schema.org/MusicPlaylist,1K - 10K
-Itemtype,http://schema.org/MusicRecording,10K - 100K
-Itemtype,http://schema.org/MusicRelease,1K - 10K
-Itemtype,http://schema.org/MusicReleaseFormatType,< 1K
-Itemtype,http://schema.org/MusicStore,1K - 10K
-Itemtype,http://schema.org/MusicVenue,1K - 10K
-Itemtype,http://schema.org/MusicVideoObject,< 1K
-Itemtype,http://schema.org/NGO,10K - 100K
-Itemtype,http://schema.org/NLNonprofitType,< 1K
-Itemtype,http://schema.org/NailSalon,1K - 10K
-Itemtype,http://schema.org/Nerve,< 1K
-Itemtype,http://schema.org/NewsArticle,100K - 1M
-Itemtype,http://schema.org/NewsMediaOrganization,10K - 100K
-Itemtype,http://schema.org/Newspaper,< 1K
-Itemtype,http://schema.org/NightClub,1K - 10K
-Itemtype,http://schema.org/NonprofitType,< 1K
-Itemtype,http://schema.org/Notary,1K - 10K
-Itemtype,http://schema.org/NoteDigitalDocument,< 1K
-Itemtype,http://schema.org/Number,< 1K
-Itemtype,http://schema.org/Nursing,< 1K
-Itemtype,http://schema.org/NutritionInformation,10K - 100K
-Itemtype,http://schema.org/Observation,< 1K
-Itemtype,http://schema.org/Obstetric,< 1K
-Itemtype,http://schema.org/Occupation,10K - 100K
-Itemtype,http://schema.org/OccupationalExperienceRequirements,1K - 10K
-Itemtype,http://schema.org/OccupationalTherapy,< 1K
-Itemtype,http://schema.org/OceanBodyOfWater,< 1K
-Itemtype,http://schema.org/Offer,10M+
-Itemtype,http://schema.org/OfferCatalog,100K - 1M
-Itemtype,http://schema.org/OfferForLease,1K - 10K
-Itemtype,http://schema.org/OfferForPurchase,1K - 10K
-Itemtype,http://schema.org/OfferItemCondition,1K - 10K
-Itemtype,http://schema.org/OfferShippingDetails,100K - 1M
-Itemtype,http://schema.org/OfficeEquipmentStore,1K - 10K
-Itemtype,http://schema.org/OnDemandEvent,< 1K
-Itemtype,http://schema.org/Oncologic,< 1K
-Itemtype,http://schema.org/OnlineBusiness,10K - 100K
-Itemtype,http://schema.org/OnlineMarketplace,< 1K
-Itemtype,http://schema.org/OnlineStore,100K - 1M
-Itemtype,http://schema.org/OpeningHoursSpecification,1M - 10M
-Itemtype,http://schema.org/OperatingSystem,< 1K
-Itemtype,http://schema.org/OpinionNewsArticle,1K - 10K
-Itemtype,http://schema.org/Optician,1K - 10K
-Itemtype,http://schema.org/Optometric,1K - 10K
-Itemtype,http://schema.org/Order,1K - 10K
-Itemtype,http://schema.org/OrderAction,10K - 100K
-Itemtype,http://schema.org/OrderItem,< 1K
-Itemtype,http://schema.org/OrderStatus,< 1K
-Itemtype,http://schema.org/Organization,10M+
-Itemtype,http://schema.org/OrganizationRole,1K - 10K
-Itemtype,http://schema.org/OrganizeAction,< 1K
-Itemtype,http://schema.org/Otolaryngologic,< 1K
-Itemtype,http://schema.org/OutletStore,< 1K
-Itemtype,http://schema.org/OwnershipInfo,< 1K
-Itemtype,http://schema.org/PaintAction,< 1K
-Itemtype,http://schema.org/Painting,< 1K
-Itemtype,http://schema.org/PalliativeProcedure,< 1K
-Itemtype,http://schema.org/ParcelDelivery,< 1K
-Itemtype,http://schema.org/ParentAudience,< 1K
-Itemtype,http://schema.org/Park,1K - 10K
-Itemtype,http://schema.org/ParkingFacility,1K - 10K
-Itemtype,http://schema.org/PathologyTest,< 1K
-Itemtype,http://schema.org/Patient,1K - 10K
-Itemtype,http://schema.org/PawnShop,< 1K
-Itemtype,http://schema.org/PayAction,< 1K
-Itemtype,http://schema.org/PaymentCard,< 1K
-Itemtype,http://schema.org/PaymentChargeSpecification,< 1K
-Itemtype,http://schema.org/PaymentMethod,10K - 100K
-Itemtype,http://schema.org/PaymentMethodType,< 1K
-Itemtype,http://schema.org/PaymentService,1K - 10K
-Itemtype,http://schema.org/PaymentStatusType,< 1K
-Itemtype,http://schema.org/Pediatric,< 1K
-Itemtype,http://schema.org/PeopleAudience,10K - 100K
-Itemtype,http://schema.org/PerformAction,< 1K
-Itemtype,http://schema.org/PerformanceRole,< 1K
-Itemtype,http://schema.org/PerformingArtsEvent,< 1K
-Itemtype,http://schema.org/PerformingArtsTheater,1K - 10K
-Itemtype,http://schema.org/PerformingGroup,10K - 100K
-Itemtype,http://schema.org/Periodical,1K - 10K
-Itemtype,http://schema.org/Permit,10K - 100K
-Itemtype,http://schema.org/Person,10M+
-Itemtype,http://schema.org/PetStore,1K - 10K
-Itemtype,http://schema.org/Pharmacy,10K - 100K
-Itemtype,http://schema.org/Photograph,10K - 100K
-Itemtype,http://schema.org/PhotographAction,< 1K
-Itemtype,http://schema.org/PhysicalActivity,< 1K
-Itemtype,http://schema.org/PhysicalActivityCategory,1K - 10K
-Itemtype,http://schema.org/PhysicalExam,< 1K
-Itemtype,http://schema.org/PhysicalTherapy,< 1K
-Itemtype,http://schema.org/Physician,10K - 100K
-Itemtype,http://schema.org/PhysiciansOffice,< 1K
-Itemtype,http://schema.org/Physiotherapy,1K - 10K
-Itemtype,http://schema.org/Place,1M - 10M
-Itemtype,http://schema.org/PlaceOfWorship,1K - 10K
-Itemtype,http://schema.org/PlanAction,< 1K
-Itemtype,http://schema.org/PlasticSurgery,< 1K
-Itemtype,http://schema.org/Play,< 1K
-Itemtype,http://schema.org/PlayAction,10K - 100K
-Itemtype,http://schema.org/PlayGameAction,< 1K
-Itemtype,http://schema.org/Playground,< 1K
-Itemtype,http://schema.org/Plumber,10K - 100K
-Itemtype,http://schema.org/PodcastEpisode,10K - 100K
-Itemtype,http://schema.org/PodcastSeason,< 1K
-Itemtype,http://schema.org/PodcastSeries,10K - 100K
-Itemtype,http://schema.org/Podiatric,< 1K
-Itemtype,http://schema.org/PoliceStation,< 1K
-Itemtype,http://schema.org/PoliticalParty,< 1K
-Itemtype,http://schema.org/Pond,< 1K
-Itemtype,http://schema.org/PostOffice,< 1K
-Itemtype,http://schema.org/PostalAddress,10M+
-Itemtype,http://schema.org/PostalCodeRangeSpecification,1K - 10K
-Itemtype,http://schema.org/Poster,< 1K
-Itemtype,http://schema.org/PreOrderAction,< 1K
-Itemtype,http://schema.org/PrependAction,< 1K
-Itemtype,http://schema.org/Preschool,1K - 10K
-Itemtype,http://schema.org/PresentationDigitalDocument,< 1K
-Itemtype,http://schema.org/PreventionIndication,< 1K
-Itemtype,http://schema.org/PriceComponentTypeEnumeration,< 1K
-Itemtype,http://schema.org/PriceSpecification,100K - 1M
-Itemtype,http://schema.org/PriceTypeEnumeration,< 1K
-Itemtype,http://schema.org/PrimaryCare,< 1K
-Itemtype,http://schema.org/Product,10M+
-Itemtype,http://schema.org/ProductCollection,1K - 10K
-Itemtype,http://schema.org/ProductGroup,100K - 1M
-Itemtype,http://schema.org/ProductModel,1K - 10K
-Itemtype,http://schema.org/ProductReturnEnumeration,< 1K
-Itemtype,http://schema.org/ProductReturnPolicy,< 1K
-Itemtype,http://schema.org/ProfessionalService,100K - 1M
-Itemtype,http://schema.org/ProfilePage,1M - 10M
-Itemtype,http://schema.org/ProgramMembership,1K - 10K
-Itemtype,http://schema.org/Project,1K - 10K
-Itemtype,http://schema.org/PronounceableText,< 1K
-Itemtype,http://schema.org/Property,< 1K
-Itemtype,http://schema.org/PropertyValue,100K - 1M
-Itemtype,http://schema.org/PropertyValueSpecification,10M+
-Itemtype,http://schema.org/Protein,< 1K
-Itemtype,http://schema.org/Psychiatric,1K - 10K
-Itemtype,http://schema.org/PsychologicalTreatment,< 1K
-Itemtype,http://schema.org/PublicHealth,< 1K
-Itemtype,http://schema.org/PublicSwimmingPool,< 1K
-Itemtype,http://schema.org/PublicToilet,< 1K
-Itemtype,http://schema.org/PublicationEvent,1K - 10K
-Itemtype,http://schema.org/PublicationIssue,1K - 10K
-Itemtype,http://schema.org/PublicationVolume,1K - 10K
-Itemtype,http://schema.org/PurchaseType,< 1K
-Itemtype,http://schema.org/QAPage,10K - 100K
-Itemtype,http://schema.org/QualitativeValue,1K - 10K
-Itemtype,http://schema.org/QuantitativeValue,1M - 10M
-Itemtype,http://schema.org/QuantitativeValueDistribution,< 1K
-Itemtype,http://schema.org/Quantity,< 1K
-Itemtype,http://schema.org/Question,1M - 10M
-Itemtype,http://schema.org/Quiz,1K - 10K
-Itemtype,http://schema.org/Quotation,1K - 10K
-Itemtype,http://schema.org/QuoteAction,1K - 10K
-Itemtype,http://schema.org/RVPark,< 1K
-Itemtype,http://schema.org/RadiationTherapy,< 1K
-Itemtype,http://schema.org/RadioBroadcastService,< 1K
-Itemtype,http://schema.org/RadioChannel,< 1K
-Itemtype,http://schema.org/RadioClip,< 1K
-Itemtype,http://schema.org/RadioEpisode,1K - 10K
-Itemtype,http://schema.org/RadioSeason,< 1K
-Itemtype,http://schema.org/RadioSeries,1K - 10K
-Itemtype,http://schema.org/RadioStation,1K - 10K
-Itemtype,http://schema.org/Rating,1M - 10M
-Itemtype,http://schema.org/ReactAction,< 1K
-Itemtype,http://schema.org/ReadAction,10M+
-Itemtype,http://schema.org/RealEstateAgent,100K - 1M
-Itemtype,http://schema.org/RealEstateListing,10K - 100K
-Itemtype,http://schema.org/ReceiveAction,< 1K
-Itemtype,http://schema.org/Recipe,10K - 100K
-Itemtype,http://schema.org/Recommendation,< 1K
-Itemtype,http://schema.org/RecommendedDoseSchedule,< 1K
-Itemtype,http://schema.org/RecyclingCenter,1K - 10K
-Itemtype,http://schema.org/RefundTypeEnumeration,< 1K
-Itemtype,http://schema.org/RegisterAction,1K - 10K
-Itemtype,http://schema.org/RejectAction,< 1K
-Itemtype,http://schema.org/RentAction,1K - 10K
-Itemtype,http://schema.org/RentalCarReservation,< 1K
-Itemtype,http://schema.org/RepaymentSpecification,< 1K
-Itemtype,http://schema.org/ReplaceAction,< 1K
-Itemtype,http://schema.org/ReplyAction,1K - 10K
-Itemtype,http://schema.org/Report,1K - 10K
-Itemtype,http://schema.org/ReportageNewsArticle,1K - 10K
-Itemtype,http://schema.org/ReportedDoseSchedule,< 1K
-Itemtype,http://schema.org/ResearchOrganization,1K - 10K
-Itemtype,http://schema.org/ResearchProject,1K - 10K
-Itemtype,http://schema.org/Researcher,< 1K
-Itemtype,http://schema.org/Reservation,10K - 100K
-Itemtype,http://schema.org/ReservationPackage,< 1K
-Itemtype,http://schema.org/ReservationStatusType,< 1K
-Itemtype,http://schema.org/ReserveAction,10K - 100K
-Itemtype,http://schema.org/Reservoir,< 1K
-Itemtype,http://schema.org/ResetPasswordAction,< 1K
-Itemtype,http://schema.org/Residence,10K - 100K
-Itemtype,http://schema.org/Resort,1K - 10K
-Itemtype,http://schema.org/RespiratoryTherapy,< 1K
-Itemtype,http://schema.org/Restaurant,100K - 1M
-Itemtype,http://schema.org/RestrictedDiet,1K - 10K
-Itemtype,http://schema.org/ResumeAction,< 1K
-Itemtype,http://schema.org/ReturnAction,< 1K
-Itemtype,http://schema.org/ReturnFeesEnumeration,< 1K
-Itemtype,http://schema.org/ReturnLabelSourceEnumeration,< 1K
-Itemtype,http://schema.org/ReturnMethodEnumeration,< 1K
-Itemtype,http://schema.org/Review,1M - 10M
-Itemtype,http://schema.org/ReviewAction,1K - 10K
-Itemtype,http://schema.org/ReviewNewsArticle,< 1K
-Itemtype,http://schema.org/RiverBodyOfWater,< 1K
-Itemtype,http://schema.org/Role,1K - 10K
-Itemtype,http://schema.org/RoofingContractor,10K - 100K
-Itemtype,http://schema.org/Room,1K - 10K
-Itemtype,http://schema.org/RsvpAction,< 1K
-Itemtype,http://schema.org/RsvpResponseType,< 1K
-Itemtype,http://schema.org/RuntimePlatform,< 1K
-Itemtype,http://schema.org/SaleEvent,1K - 10K
-Itemtype,http://schema.org/SatiricalArticle,< 1K
-Itemtype,http://schema.org/Schedule,10K - 100K
-Itemtype,http://schema.org/ScheduleAction,1K - 10K
-Itemtype,http://schema.org/ScholarlyArticle,10K - 100K
-Itemtype,http://schema.org/School,1K - 10K
-Itemtype,http://schema.org/SchoolDistrict,< 1K
-Itemtype,http://schema.org/ScreeningEvent,1K - 10K
-Itemtype,http://schema.org/Sculpture,< 1K
-Itemtype,http://schema.org/SeaBodyOfWater,< 1K
-Itemtype,http://schema.org/SearchAction,10M+
-Itemtype,http://schema.org/SearchRescueOrganization,< 1K
-Itemtype,http://schema.org/SearchResultsPage,10K - 100K
-Itemtype,http://schema.org/Season,< 1K
-Itemtype,http://schema.org/Seat,< 1K
-Itemtype,http://schema.org/SeekToAction,10K - 100K
-Itemtype,http://schema.org/SelfStorage,10K - 100K
-Itemtype,http://schema.org/SellAction,1K - 10K
-Itemtype,http://schema.org/SendAction,< 1K
-Itemtype,http://schema.org/SequentialArt,< 1K
-Itemtype,http://schema.org/Series,10K - 100K
-Itemtype,http://schema.org/Service,1M - 10M
-Itemtype,http://schema.org/ServiceChannel,100K - 1M
-Itemtype,http://schema.org/ServicePeriod,1K - 10K
-Itemtype,http://schema.org/ShareAction,10K - 100K
-Itemtype,http://schema.org/SheetMusic,< 1K
-Itemtype,http://schema.org/ShippingConditions,10K - 100K
-Itemtype,http://schema.org/ShippingDeliveryTime,100K - 1M
-Itemtype,http://schema.org/ShippingRateSettings,< 1K
-Itemtype,http://schema.org/ShippingService,10K - 100K
-Itemtype,http://schema.org/ShoeStore,1K - 10K
-Itemtype,http://schema.org/ShoppingCenter,1K - 10K
-Itemtype,http://schema.org/ShortStory,< 1K
-Itemtype,http://schema.org/SingleFamilyResidence,10K - 100K
-Itemtype,http://schema.org/SiteNavigationElement,1M - 10M
-Itemtype,http://schema.org/SizeGroupEnumeration,< 1K
-Itemtype,http://schema.org/SizeSpecification,1K - 10K
-Itemtype,http://schema.org/SizeSystemEnumeration,< 1K
-Itemtype,http://schema.org/SkiResort,< 1K
-Itemtype,http://schema.org/SocialEvent,1K - 10K
-Itemtype,http://schema.org/SocialMediaPosting,10K - 100K
-Itemtype,http://schema.org/SoftwareApplication,100K - 1M
-Itemtype,http://schema.org/SoftwareSourceCode,1K - 10K
-Itemtype,http://schema.org/SolveMathAction,< 1K
-Itemtype,http://schema.org/SomeProducts,10K - 100K
-Itemtype,http://schema.org/SpeakableSpecification,100K - 1M
-Itemtype,http://schema.org/SpecialAnnouncement,1K - 10K
-Itemtype,http://schema.org/Specialty,1K - 10K
-Itemtype,http://schema.org/SportingGoodsStore,1K - 10K
-Itemtype,http://schema.org/SportsActivityLocation,10K - 100K
-Itemtype,http://schema.org/SportsClub,1K - 10K
-Itemtype,http://schema.org/SportsEvent,10K - 100K
-Itemtype,http://schema.org/SportsOrganization,10K - 100K
-Itemtype,http://schema.org/SportsTeam,10K - 100K
-Itemtype,http://schema.org/SpreadsheetDigitalDocument,< 1K
-Itemtype,http://schema.org/StadiumOrArena,1K - 10K
-Itemtype,http://schema.org/State,100K - 1M
-Itemtype,http://schema.org/Statement,< 1K
-Itemtype,http://schema.org/StatisticalPopulation,< 1K
-Itemtype,http://schema.org/StatisticalVariable,< 1K
-Itemtype,http://schema.org/StatusEnumeration,< 1K
-Itemtype,http://schema.org/SteeringPositionValue,< 1K
-Itemtype,http://schema.org/Store,100K - 1M
-Itemtype,http://schema.org/StructuredValue,1K - 10K
-Itemtype,http://schema.org/StupidType,< 1K
-Itemtype,http://schema.org/SubscribeAction,10K - 100K
-Itemtype,http://schema.org/Substance,< 1K
-Itemtype,http://schema.org/SubwayStation,< 1K
-Itemtype,http://schema.org/Suite,< 1K
-Itemtype,http://schema.org/SuperficialAnatomy,< 1K
-Itemtype,http://schema.org/SurgicalProcedure,1K - 10K
-Itemtype,http://schema.org/SuspendAction,< 1K
-Itemtype,http://schema.org/Syllabus,1K - 10K
-Itemtype,http://schema.org/Synagogue,< 1K
-Itemtype,http://schema.org/TVClip,< 1K
-Itemtype,http://schema.org/TVEpisode,1K - 10K
-Itemtype,http://schema.org/TVSeason,1K - 10K
-Itemtype,http://schema.org/TVSeries,10K - 100K
-Itemtype,http://schema.org/Table,10K - 100K
-Itemtype,http://schema.org/TakeAction,< 1K
-Itemtype,http://schema.org/TattooParlor,1K - 10K
-Itemtype,http://schema.org/Taxi,< 1K
-Itemtype,http://schema.org/TaxiReservation,< 1K
-Itemtype,http://schema.org/TaxiService,1K - 10K
-Itemtype,http://schema.org/TaxiStand,< 1K
-Itemtype,http://schema.org/Taxon,< 1K
-Itemtype,http://schema.org/TechArticle,10K - 100K
-Itemtype,http://schema.org/TelevisionChannel,< 1K
-Itemtype,http://schema.org/TelevisionStation,< 1K
-Itemtype,http://schema.org/TennisComplex,< 1K
-Itemtype,http://schema.org/Text,10K - 100K
-Itemtype,http://schema.org/TextDigitalDocument,< 1K
-Itemtype,http://schema.org/TextObject,1K - 10K
-Itemtype,http://schema.org/TheaterEvent,1K - 10K
-Itemtype,http://schema.org/TheaterGroup,1K - 10K
-Itemtype,http://schema.org/TherapeuticProcedure,1K - 10K
-Itemtype,http://schema.org/Thesis,< 1K
-Itemtype,http://schema.org/Thing,10M+
-Itemtype,http://schema.org/Ticket,< 1K
-Itemtype,http://schema.org/TieAction,< 1K
-Itemtype,http://schema.org/TierBenefitEnumeration,< 1K
-Itemtype,http://schema.org/Time,< 1K
-Itemtype,http://schema.org/TipAction,< 1K
-Itemtype,http://schema.org/TireShop,1K - 10K
-Itemtype,http://schema.org/TouristAttraction,10K - 100K
-Itemtype,http://schema.org/TouristDestination,10K - 100K
-Itemtype,http://schema.org/TouristInformationCenter,1K - 10K
-Itemtype,http://schema.org/TouristTrip,10K - 100K
-Itemtype,http://schema.org/ToyStore,1K - 10K
-Itemtype,http://schema.org/TrackAction,< 1K
-Itemtype,http://schema.org/TradeAction,1K - 10K
-Itemtype,http://schema.org/TrainReservation,< 1K
-Itemtype,http://schema.org/TrainStation,1K - 10K
-Itemtype,http://schema.org/TrainTrip,< 1K
-Itemtype,http://schema.org/TransferAction,< 1K
-Itemtype,http://schema.org/TravelAction,1K - 10K
-Itemtype,http://schema.org/TravelAgency,10K - 100K
-Itemtype,http://schema.org/TreatmentIndication,< 1K
-Itemtype,http://schema.org/Trip,10K - 100K
-Itemtype,http://schema.org/TypeAndQuantityNode,< 1K
-Itemtype,http://schema.org/UKNonprofitType,< 1K
-Itemtype,http://schema.org/URL,1K - 10K
-Itemtype,http://schema.org/USNonprofitType,< 1K
-Itemtype,http://schema.org/UnRegisterAction,< 1K
-Itemtype,http://schema.org/UnitPriceSpecification,1M - 10M
-Itemtype,http://schema.org/UpdateAction,< 1K
-Itemtype,http://schema.org/UseAction,1K - 10K
-Itemtype,http://schema.org/UserBlocks,< 1K
-Itemtype,http://schema.org/UserCheckins,1K - 10K
-Itemtype,http://schema.org/UserComments,10K - 100K
-Itemtype,http://schema.org/UserDownloads,< 1K
-Itemtype,http://schema.org/UserInteraction,< 1K
-Itemtype,http://schema.org/UserLikes,< 1K
-Itemtype,http://schema.org/UserPageVisits,< 1K
-Itemtype,http://schema.org/UserPlays,< 1K
-Itemtype,http://schema.org/UserPlusOnes,< 1K
-Itemtype,http://schema.org/UserReview,1K - 10K
-Itemtype,http://schema.org/UserTweets,< 1K
-Itemtype,http://schema.org/VacationRental,10K - 100K
-Itemtype,http://schema.org/Vehicle,10K - 100K
-Itemtype,http://schema.org/Vein,< 1K
-Itemtype,http://schema.org/Vessel,< 1K
-Itemtype,http://schema.org/VeterinaryCare,1K - 10K
-Itemtype,http://schema.org/VideoGallery,1K - 10K
-Itemtype,http://schema.org/VideoGame,10K - 100K
-Itemtype,http://schema.org/VideoGameClip,< 1K
-Itemtype,http://schema.org/VideoGameSeries,1K - 10K
-Itemtype,http://schema.org/VideoObject,1M - 10M
-Itemtype,http://schema.org/VideoObjectSnapshot,< 1K
-Itemtype,http://schema.org/ViewAction,10K - 100K
-Itemtype,http://schema.org/VirtualLocation,10K - 100K
-Itemtype,http://schema.org/VisualArtsEvent,< 1K
-Itemtype,http://schema.org/VisualArtwork,1K - 10K
-Itemtype,http://schema.org/VitalSign,< 1K
-Itemtype,http://schema.org/Volcano,< 1K
-Itemtype,http://schema.org/VoteAction,< 1K
-Itemtype,http://schema.org/WPAdBlock,10K - 100K
-Itemtype,http://schema.org/WPFooter,1M - 10M
-Itemtype,http://schema.org/WPHeader,1M - 10M
-Itemtype,http://schema.org/WPSideBar,1M - 10M
-Itemtype,http://schema.org/WantAction,< 1K
-Itemtype,http://schema.org/WarrantyPromise,10K - 100K
-Itemtype,http://schema.org/WarrantyScope,< 1K
-Itemtype,http://schema.org/WatchAction,100K - 1M
-Itemtype,http://schema.org/Waterfall,< 1K
-Itemtype,http://schema.org/WearAction,< 1K
-Itemtype,http://schema.org/WearableMeasurementTypeEnumeration,< 1K
-Itemtype,http://schema.org/WearableSizeGroupEnumeration,< 1K
-Itemtype,http://schema.org/WearableSizeSystemEnumeration,< 1K
-Itemtype,http://schema.org/WebAPI,1K - 10K
-Itemtype,http://schema.org/WebApplication,100K - 1M
-Itemtype,http://schema.org/WebContent,1K - 10K
-Itemtype,http://schema.org/WebPage,10M+
-Itemtype,http://schema.org/WebPageElement,1M - 10M
-Itemtype,http://schema.org/WebSite,10M+
-Itemtype,http://schema.org/WholesaleStore,1K - 10K
-Itemtype,http://schema.org/WinAction,< 1K
-Itemtype,http://schema.org/Winery,1K - 10K
-Itemtype,http://schema.org/WorkBasedProgram,< 1K
-Itemtype,http://schema.org/WorkersUnion,< 1K
-Itemtype,http://schema.org/WriteAction,10K - 100K
-Itemtype,http://schema.org/XPathType,< 1K
-Itemtype,http://schema.org/Zoo,< 1K
-Predicate,http://schema.org/about,10M+
-Predicate,http://schema.org/about-input,< 1K
-Predicate,http://schema.org/about-output,< 1K
-Predicate,http://schema.org/abridged,< 1K
-Predicate,http://schema.org/abridged-input,< 1K
-Predicate,http://schema.org/abridged-output,< 1K
-Predicate,http://schema.org/abstract,10K - 100K
-Predicate,http://schema.org/abstract-input,< 1K
-Predicate,http://schema.org/abstract-output,< 1K
-Predicate,http://schema.org/accelerationTime,1K - 10K
-Predicate,http://schema.org/accelerationTime-input,< 1K
-Predicate,http://schema.org/accelerationTime-output,< 1K
-Predicate,http://schema.org/acceptedAnswer,1M - 10M
-Predicate,http://schema.org/acceptedAnswer-input,< 1K
-Predicate,http://schema.org/acceptedAnswer-output,< 1K
-Predicate,http://schema.org/acceptedOffer,< 1K
-Predicate,http://schema.org/acceptedOffer-input,< 1K
-Predicate,http://schema.org/acceptedOffer-output,< 1K
-Predicate,http://schema.org/acceptedPaymentMethod,10K - 100K
-Predicate,http://schema.org/acceptedPaymentMethod-input,< 1K
-Predicate,http://schema.org/acceptedPaymentMethod-output,< 1K
-Predicate,http://schema.org/acceptsReservations,100K - 1M
-Predicate,http://schema.org/acceptsReservations-input,< 1K
-Predicate,http://schema.org/acceptsReservations-output,< 1K
-Predicate,http://schema.org/accessCode,< 1K
-Predicate,http://schema.org/accessCode-input,< 1K
-Predicate,http://schema.org/accessCode-output,< 1K
-Predicate,http://schema.org/accessMode,1K - 10K
-Predicate,http://schema.org/accessMode-input,< 1K
-Predicate,http://schema.org/accessMode-output,< 1K
-Predicate,http://schema.org/accessModeSufficient,1K - 10K
-Predicate,http://schema.org/accessModeSufficient-input,< 1K
-Predicate,http://schema.org/accessModeSufficient-output,< 1K
-Predicate,http://schema.org/accessibilityAPI,1K - 10K
-Predicate,http://schema.org/accessibilityAPI-input,< 1K
-Predicate,http://schema.org/accessibilityAPI-output,< 1K
-Predicate,http://schema.org/accessibilityControl,1K - 10K
-Predicate,http://schema.org/accessibilityControl-input,< 1K
-Predicate,http://schema.org/accessibilityControl-output,< 1K
-Predicate,http://schema.org/accessibilityFeature,10K - 100K
-Predicate,http://schema.org/accessibilityFeature-input,< 1K
-Predicate,http://schema.org/accessibilityFeature-output,< 1K
-Predicate,http://schema.org/accessibilityHazard,1K - 10K
-Predicate,http://schema.org/accessibilityHazard-input,< 1K
-Predicate,http://schema.org/accessibilityHazard-output,< 1K
-Predicate,http://schema.org/accessibilitySummary,10K - 100K
-Predicate,http://schema.org/accessibilitySummary-input,< 1K
-Predicate,http://schema.org/accessibilitySummary-output,< 1K
-Predicate,http://schema.org/accommodationCategory,1K - 10K
-Predicate,http://schema.org/accommodationCategory-input,< 1K
-Predicate,http://schema.org/accommodationCategory-output,< 1K
-Predicate,http://schema.org/accommodationFloorPlan,10K - 100K
-Predicate,http://schema.org/accommodationFloorPlan-input,< 1K
-Predicate,http://schema.org/accommodationFloorPlan-output,< 1K
-Predicate,http://schema.org/accountId,< 1K
-Predicate,http://schema.org/accountId-input,< 1K
-Predicate,http://schema.org/accountId-output,< 1K
-Predicate,http://schema.org/accountMinimumInflow,< 1K
-Predicate,http://schema.org/accountMinimumInflow-input,< 1K
-Predicate,http://schema.org/accountMinimumInflow-output,< 1K
-Predicate,http://schema.org/accountOverdraftLimit,< 1K
-Predicate,http://schema.org/accountOverdraftLimit-input,< 1K
-Predicate,http://schema.org/accountOverdraftLimit-output,< 1K
-Predicate,http://schema.org/accountablePerson,10K - 100K
-Predicate,http://schema.org/accountablePerson-input,< 1K
-Predicate,http://schema.org/accountablePerson-output,< 1K
-Predicate,http://schema.org/acquireLicensePage,10K - 100K
-Predicate,http://schema.org/acquireLicensePage-input,< 1K
-Predicate,http://schema.org/acquireLicensePage-output,< 1K
-Predicate,http://schema.org/acquiredFrom,< 1K
-Predicate,http://schema.org/acquiredFrom-input,< 1K
-Predicate,http://schema.org/acquiredFrom-output,< 1K
-Predicate,http://schema.org/acrissCode,< 1K
-Predicate,http://schema.org/acrissCode-input,< 1K
-Predicate,http://schema.org/acrissCode-output,< 1K
-Predicate,http://schema.org/actionAccessibilityRequirement,< 1K
-Predicate,http://schema.org/actionAccessibilityRequirement-input,< 1K
-Predicate,http://schema.org/actionAccessibilityRequirement-output,< 1K
-Predicate,http://schema.org/actionApplication,1K - 10K
-Predicate,http://schema.org/actionApplication-input,< 1K
-Predicate,http://schema.org/actionApplication-output,< 1K
-Predicate,http://schema.org/actionOption,1K - 10K
-Predicate,http://schema.org/actionOption-input,< 1K
-Predicate,http://schema.org/actionOption-output,< 1K
-Predicate,http://schema.org/actionPlatform,100K - 1M
-Predicate,http://schema.org/actionPlatform-input,< 1K
-Predicate,http://schema.org/actionPlatform-output,< 1K
-Predicate,http://schema.org/actionProcess,< 1K
-Predicate,http://schema.org/actionProcess-input,< 1K
-Predicate,http://schema.org/actionProcess-output,< 1K
-Predicate,http://schema.org/actionStatus,10K - 100K
-Predicate,http://schema.org/actionStatus-input,< 1K
-Predicate,http://schema.org/actionStatus-output,< 1K
-Predicate,http://schema.org/actionableFeedbackPolicy,10K - 100K
-Predicate,http://schema.org/actionableFeedbackPolicy-input,< 1K
-Predicate,http://schema.org/actionableFeedbackPolicy-output,< 1K
-Predicate,http://schema.org/activeIngredient,1K - 10K
-Predicate,http://schema.org/activeIngredient-input,< 1K
-Predicate,http://schema.org/activeIngredient-output,< 1K
-Predicate,http://schema.org/activityDuration,< 1K
-Predicate,http://schema.org/activityDuration-input,< 1K
-Predicate,http://schema.org/activityDuration-output,< 1K
-Predicate,http://schema.org/activityFrequency,< 1K
-Predicate,http://schema.org/activityFrequency-input,< 1K
-Predicate,http://schema.org/activityFrequency-output,< 1K
-Predicate,http://schema.org/actor,10K - 100K
-Predicate,http://schema.org/actor-input,< 1K
-Predicate,http://schema.org/actor-output,< 1K
-Predicate,http://schema.org/actors,1K - 10K
-Predicate,http://schema.org/actors-input,< 1K
-Predicate,http://schema.org/actors-output,< 1K
-Predicate,http://schema.org/addOn,1K - 10K
-Predicate,http://schema.org/addOn-input,< 1K
-Predicate,http://schema.org/addOn-output,< 1K
-Predicate,http://schema.org/additionalName,10K - 100K
-Predicate,http://schema.org/additionalName-input,< 1K
-Predicate,http://schema.org/additionalName-output,< 1K
-Predicate,http://schema.org/additionalNumberOfGuests,< 1K
-Predicate,http://schema.org/additionalNumberOfGuests-input,< 1K
-Predicate,http://schema.org/additionalNumberOfGuests-output,< 1K
-Predicate,http://schema.org/additionalProperty,100K - 1M
-Predicate,http://schema.org/additionalProperty-input,< 1K
-Predicate,http://schema.org/additionalProperty-output,< 1K
-Predicate,http://schema.org/additionalType,100K - 1M
-Predicate,http://schema.org/additionalType-input,< 1K
-Predicate,http://schema.org/additionalType-output,< 1K
-Predicate,http://schema.org/additionalVariable,< 1K
-Predicate,http://schema.org/additionalVariable-input,< 1K
-Predicate,http://schema.org/additionalVariable-output,< 1K
-Predicate,http://schema.org/address,10M+
-Predicate,http://schema.org/address-input,< 1K
-Predicate,http://schema.org/address-output,< 1K
-Predicate,http://schema.org/addressCountry,1M - 10M
-Predicate,http://schema.org/addressCountry-input,< 1K
-Predicate,http://schema.org/addressCountry-output,< 1K
-Predicate,http://schema.org/addressLocality,1M - 10M
-Predicate,http://schema.org/addressLocality-input,< 1K
-Predicate,http://schema.org/addressLocality-output,< 1K
-Predicate,http://schema.org/addressRegion,1M - 10M
-Predicate,http://schema.org/addressRegion-input,< 1K
-Predicate,http://schema.org/addressRegion-output,< 1K
-Predicate,http://schema.org/administrationRoute,1K - 10K
-Predicate,http://schema.org/administrationRoute-input,< 1K
-Predicate,http://schema.org/administrationRoute-output,< 1K
-Predicate,http://schema.org/advanceBookingRequirement,< 1K
-Predicate,http://schema.org/advanceBookingRequirement-input,< 1K
-Predicate,http://schema.org/advanceBookingRequirement-output,< 1K
-Predicate,http://schema.org/adverseOutcome,< 1K
-Predicate,http://schema.org/adverseOutcome-input,< 1K
-Predicate,http://schema.org/adverseOutcome-output,< 1K
-Predicate,http://schema.org/affectedBy,< 1K
-Predicate,http://schema.org/affectedBy-input,< 1K
-Predicate,http://schema.org/affectedBy-output,< 1K
-Predicate,http://schema.org/affiliation,10K - 100K
-Predicate,http://schema.org/affiliation-input,< 1K
-Predicate,http://schema.org/affiliation-output,< 1K
-Predicate,http://schema.org/afterMedia,< 1K
-Predicate,http://schema.org/afterMedia-input,< 1K
-Predicate,http://schema.org/afterMedia-output,< 1K
-Predicate,http://schema.org/agent,10K - 100K
-Predicate,http://schema.org/agent-input,< 1K
-Predicate,http://schema.org/agent-output,< 1K
-Predicate,http://schema.org/agentInteractionStatistic,10K - 100K
-Predicate,http://schema.org/agentInteractionStatistic-input,< 1K
-Predicate,http://schema.org/agentInteractionStatistic-output,< 1K
-Predicate,http://schema.org/aggregateElement,< 1K
-Predicate,http://schema.org/aggregateElement-input,< 1K
-Predicate,http://schema.org/aggregateElement-output,< 1K
-Predicate,http://schema.org/aggregateRating,1M - 10M
-Predicate,http://schema.org/aggregateRating-input,< 1K
-Predicate,http://schema.org/aggregateRating-output,< 1K
-Predicate,http://schema.org/aircraft,< 1K
-Predicate,http://schema.org/aircraft-input,< 1K
-Predicate,http://schema.org/aircraft-output,< 1K
-Predicate,http://schema.org/album,1K - 10K
-Predicate,http://schema.org/album-input,< 1K
-Predicate,http://schema.org/album-output,< 1K
-Predicate,http://schema.org/albumProductionType,1K - 10K
-Predicate,http://schema.org/albumProductionType-input,< 1K
-Predicate,http://schema.org/albumProductionType-output,< 1K
-Predicate,http://schema.org/albumRelease,1K - 10K
-Predicate,http://schema.org/albumRelease-input,< 1K
-Predicate,http://schema.org/albumRelease-output,< 1K
-Predicate,http://schema.org/albumReleaseType,1K - 10K
-Predicate,http://schema.org/albumReleaseType-input,< 1K
-Predicate,http://schema.org/albumReleaseType-output,< 1K
-Predicate,http://schema.org/albums,< 1K
-Predicate,http://schema.org/albums-input,< 1K
-Predicate,http://schema.org/albums-output,< 1K
-Predicate,http://schema.org/alcoholWarning,< 1K
-Predicate,http://schema.org/alcoholWarning-input,< 1K
-Predicate,http://schema.org/alcoholWarning-output,< 1K
-Predicate,http://schema.org/algorithm,< 1K
-Predicate,http://schema.org/algorithm-input,< 1K
-Predicate,http://schema.org/algorithm-output,< 1K
-Predicate,http://schema.org/alignmentType,1K - 10K
-Predicate,http://schema.org/alignmentType-input,< 1K
-Predicate,http://schema.org/alignmentType-output,< 1K
-Predicate,http://schema.org/alternateName,1M - 10M
-Predicate,http://schema.org/alternateName-input,< 1K
-Predicate,http://schema.org/alternateName-output,< 1K
-Predicate,http://schema.org/alternativeHeadline,100K - 1M
-Predicate,http://schema.org/alternativeHeadline-input,< 1K
-Predicate,http://schema.org/alternativeHeadline-output,< 1K
-Predicate,http://schema.org/alternativeOf,< 1K
-Predicate,http://schema.org/alternativeOf-input,< 1K
-Predicate,http://schema.org/alternativeOf-output,< 1K
-Predicate,http://schema.org/alumni,1K - 10K
-Predicate,http://schema.org/alumni-input,< 1K
-Predicate,http://schema.org/alumni-output,< 1K
-Predicate,http://schema.org/alumniOf,100K - 1M
-Predicate,http://schema.org/alumniOf-input,< 1K
-Predicate,http://schema.org/alumniOf-output,< 1K
-Predicate,http://schema.org/amenityFeature,100K - 1M
-Predicate,http://schema.org/amenityFeature-input,< 1K
-Predicate,http://schema.org/amenityFeature-output,< 1K
-Predicate,http://schema.org/amount,1K - 10K
-Predicate,http://schema.org/amount-input,< 1K
-Predicate,http://schema.org/amount-output,< 1K
-Predicate,http://schema.org/amountOfThisGood,< 1K
-Predicate,http://schema.org/amountOfThisGood-input,< 1K
-Predicate,http://schema.org/amountOfThisGood-output,< 1K
-Predicate,http://schema.org/announcementLocation,1K - 10K
-Predicate,http://schema.org/announcementLocation-input,< 1K
-Predicate,http://schema.org/announcementLocation-output,< 1K
-Predicate,http://schema.org/annualPercentageRate,1K - 10K
-Predicate,http://schema.org/annualPercentageRate-input,< 1K
-Predicate,http://schema.org/annualPercentageRate-output,< 1K
-Predicate,http://schema.org/answerCount,100K - 1M
-Predicate,http://schema.org/answerCount-input,< 1K
-Predicate,http://schema.org/answerCount-output,< 1K
-Predicate,http://schema.org/answerExplanation,< 1K
-Predicate,http://schema.org/answerExplanation-input,< 1K
-Predicate,http://schema.org/answerExplanation-output,< 1K
-Predicate,http://schema.org/antagonist,< 1K
-Predicate,http://schema.org/antagonist-input,< 1K
-Predicate,http://schema.org/antagonist-output,< 1K
-Predicate,http://schema.org/appearance,1K - 10K
-Predicate,http://schema.org/appearance-input,< 1K
-Predicate,http://schema.org/appearance-output,< 1K
-Predicate,http://schema.org/applicableCountry,100K - 1M
-Predicate,http://schema.org/applicableCountry-input,< 1K
-Predicate,http://schema.org/applicableCountry-output,< 1K
-Predicate,http://schema.org/applicableLocation,< 1K
-Predicate,http://schema.org/applicableLocation-input,< 1K
-Predicate,http://schema.org/applicableLocation-output,< 1K
-Predicate,http://schema.org/applicantLocationRequirements,10K - 100K
-Predicate,http://schema.org/applicantLocationRequirements-input,< 1K
-Predicate,http://schema.org/applicantLocationRequirements-output,< 1K
-Predicate,http://schema.org/application,< 1K
-Predicate,http://schema.org/application-input,< 1K
-Predicate,http://schema.org/application-output,< 1K
-Predicate,http://schema.org/applicationCategory,1M - 10M
-Predicate,http://schema.org/applicationCategory-input,< 1K
-Predicate,http://schema.org/applicationCategory-output,< 1K
-Predicate,http://schema.org/applicationContact,1K - 10K
-Predicate,http://schema.org/applicationContact-input,< 1K
-Predicate,http://schema.org/applicationContact-output,< 1K
-Predicate,http://schema.org/applicationDeadline,< 1K
-Predicate,http://schema.org/applicationDeadline-input,< 1K
-Predicate,http://schema.org/applicationDeadline-output,< 1K
-Predicate,http://schema.org/applicationStartDate,< 1K
-Predicate,http://schema.org/applicationStartDate-input,< 1K
-Predicate,http://schema.org/applicationStartDate-output,< 1K
-Predicate,http://schema.org/applicationSubCategory,10K - 100K
-Predicate,http://schema.org/applicationSubCategory-input,< 1K
-Predicate,http://schema.org/applicationSubCategory-output,< 1K
-Predicate,http://schema.org/applicationSuite,1K - 10K
-Predicate,http://schema.org/applicationSuite-input,< 1K
-Predicate,http://schema.org/applicationSuite-output,< 1K
-Predicate,http://schema.org/appliesToDeliveryMethod,10K - 100K
-Predicate,http://schema.org/appliesToDeliveryMethod-input,< 1K
-Predicate,http://schema.org/appliesToDeliveryMethod-output,< 1K
-Predicate,http://schema.org/appliesToPaymentMethod,< 1K
-Predicate,http://schema.org/appliesToPaymentMethod-input,< 1K
-Predicate,http://schema.org/appliesToPaymentMethod-output,< 1K
-Predicate,http://schema.org/archiveHeld,< 1K
-Predicate,http://schema.org/archiveHeld-input,< 1K
-Predicate,http://schema.org/archiveHeld-output,< 1K
-Predicate,http://schema.org/archivedAt,< 1K
-Predicate,http://schema.org/archivedAt-input,< 1K
-Predicate,http://schema.org/archivedAt-output,< 1K
-Predicate,http://schema.org/area,1K - 10K
-Predicate,http://schema.org/area-input,< 1K
-Predicate,http://schema.org/area-output,< 1K
-Predicate,http://schema.org/areaServed,1M - 10M
-Predicate,http://schema.org/areaServed-input,< 1K
-Predicate,http://schema.org/areaServed-output,< 1K
-Predicate,http://schema.org/arrivalAirport,1K - 10K
-Predicate,http://schema.org/arrivalAirport-input,< 1K
-Predicate,http://schema.org/arrivalAirport-output,< 1K
-Predicate,http://schema.org/arrivalBoatTerminal,< 1K
-Predicate,http://schema.org/arrivalBoatTerminal-input,< 1K
-Predicate,http://schema.org/arrivalBoatTerminal-output,< 1K
-Predicate,http://schema.org/arrivalBusStop,< 1K
-Predicate,http://schema.org/arrivalBusStop-input,< 1K
-Predicate,http://schema.org/arrivalBusStop-output,< 1K
-Predicate,http://schema.org/arrivalGate,< 1K
-Predicate,http://schema.org/arrivalGate-input,< 1K
-Predicate,http://schema.org/arrivalGate-output,< 1K
-Predicate,http://schema.org/arrivalPlatform,< 1K
-Predicate,http://schema.org/arrivalPlatform-input,< 1K
-Predicate,http://schema.org/arrivalPlatform-output,< 1K
-Predicate,http://schema.org/arrivalStation,< 1K
-Predicate,http://schema.org/arrivalStation-input,< 1K
-Predicate,http://schema.org/arrivalStation-output,< 1K
-Predicate,http://schema.org/arrivalTerminal,< 1K
-Predicate,http://schema.org/arrivalTerminal-input,< 1K
-Predicate,http://schema.org/arrivalTerminal-output,< 1K
-Predicate,http://schema.org/arrivalTime,1K - 10K
-Predicate,http://schema.org/arrivalTime-input,< 1K
-Predicate,http://schema.org/arrivalTime-output,< 1K
-Predicate,http://schema.org/artEdition,< 1K
-Predicate,http://schema.org/artEdition-input,< 1K
-Predicate,http://schema.org/artEdition-output,< 1K
-Predicate,http://schema.org/artMedium,1K - 10K
-Predicate,http://schema.org/artMedium-input,< 1K
-Predicate,http://schema.org/artMedium-output,< 1K
-Predicate,http://schema.org/arterialBranch,< 1K
-Predicate,http://schema.org/arterialBranch-input,< 1K
-Predicate,http://schema.org/arterialBranch-output,< 1K
-Predicate,http://schema.org/artform,1K - 10K
-Predicate,http://schema.org/artform-input,< 1K
-Predicate,http://schema.org/artform-output,< 1K
-Predicate,http://schema.org/articleBody,1M - 10M
-Predicate,http://schema.org/articleBody-input,< 1K
-Predicate,http://schema.org/articleBody-output,< 1K
-Predicate,http://schema.org/articleSection,1M - 10M
-Predicate,http://schema.org/articleSection-input,< 1K
-Predicate,http://schema.org/articleSection-output,< 1K
-Predicate,http://schema.org/artist,1K - 10K
-Predicate,http://schema.org/artist-input,< 1K
-Predicate,http://schema.org/artist-output,< 1K
-Predicate,http://schema.org/artworkSurface,< 1K
-Predicate,http://schema.org/artworkSurface-input,< 1K
-Predicate,http://schema.org/artworkSurface-output,< 1K
-Predicate,http://schema.org/asin,< 1K
-Predicate,http://schema.org/asin-input,< 1K
-Predicate,http://schema.org/asin-output,< 1K
-Predicate,http://schema.org/aspect,< 1K
-Predicate,http://schema.org/aspect-input,< 1K
-Predicate,http://schema.org/aspect-output,< 1K
-Predicate,http://schema.org/assembly,< 1K
-Predicate,http://schema.org/assembly-input,< 1K
-Predicate,http://schema.org/assembly-output,< 1K
-Predicate,http://schema.org/assemblyVersion,< 1K
-Predicate,http://schema.org/assemblyVersion-input,< 1K
-Predicate,http://schema.org/assemblyVersion-output,< 1K
-Predicate,http://schema.org/assesses,1K - 10K
-Predicate,http://schema.org/assesses-input,< 1K
-Predicate,http://schema.org/assesses-output,< 1K
-Predicate,http://schema.org/associatedAnatomy,1K - 10K
-Predicate,http://schema.org/associatedAnatomy-input,< 1K
-Predicate,http://schema.org/associatedAnatomy-output,< 1K
-Predicate,http://schema.org/associatedArticle,1K - 10K
-Predicate,http://schema.org/associatedArticle-input,< 1K
-Predicate,http://schema.org/associatedArticle-output,< 1K
-Predicate,http://schema.org/associatedClaimReview,< 1K
-Predicate,http://schema.org/associatedClaimReview-input,< 1K
-Predicate,http://schema.org/associatedClaimReview-output,< 1K
-Predicate,http://schema.org/associatedDisease,< 1K
-Predicate,http://schema.org/associatedDisease-input,< 1K
-Predicate,http://schema.org/associatedDisease-output,< 1K
-Predicate,http://schema.org/associatedMedia,100K - 1M
-Predicate,http://schema.org/associatedMedia-input,< 1K
-Predicate,http://schema.org/associatedMedia-output,< 1K
-Predicate,http://schema.org/associatedMediaReview,< 1K
-Predicate,http://schema.org/associatedMediaReview-input,< 1K
-Predicate,http://schema.org/associatedMediaReview-output,< 1K
-Predicate,http://schema.org/associatedPathophysiology,< 1K
-Predicate,http://schema.org/associatedPathophysiology-input,< 1K
-Predicate,http://schema.org/associatedPathophysiology-output,< 1K
-Predicate,http://schema.org/associatedReview,< 1K
-Predicate,http://schema.org/associatedReview-input,< 1K
-Predicate,http://schema.org/associatedReview-output,< 1K
-Predicate,http://schema.org/athlete,< 1K
-Predicate,http://schema.org/athlete-input,< 1K
-Predicate,http://schema.org/athlete-output,< 1K
-Predicate,http://schema.org/attendee,1K - 10K
-Predicate,http://schema.org/attendee-input,< 1K
-Predicate,http://schema.org/attendee-output,< 1K
-Predicate,http://schema.org/attendees,< 1K
-Predicate,http://schema.org/attendees-input,< 1K
-Predicate,http://schema.org/attendees-output,< 1K
-Predicate,http://schema.org/audience,100K - 1M
-Predicate,http://schema.org/audience-input,< 1K
-Predicate,http://schema.org/audience-output,< 1K
-Predicate,http://schema.org/audienceType,100K - 1M
-Predicate,http://schema.org/audienceType-input,< 1K
-Predicate,http://schema.org/audienceType-output,< 1K
-Predicate,http://schema.org/audio,10K - 100K
-Predicate,http://schema.org/audio-input,< 1K
-Predicate,http://schema.org/audio-output,< 1K
-Predicate,http://schema.org/auditDate,< 1K
-Predicate,http://schema.org/auditDate-input,< 1K
-Predicate,http://schema.org/auditDate-output,< 1K
-Predicate,http://schema.org/authenticator,< 1K
-Predicate,http://schema.org/authenticator-input,< 1K
-Predicate,http://schema.org/authenticator-output,< 1K
-Predicate,http://schema.org/author,10M+
-Predicate,http://schema.org/author-input,< 1K
-Predicate,http://schema.org/author-output,< 1K
-Predicate,http://schema.org/availability,10M+
-Predicate,http://schema.org/availability-input,< 1K
-Predicate,http://schema.org/availability-output,< 1K
-Predicate,http://schema.org/availabilityEnds,1K - 10K
-Predicate,http://schema.org/availabilityEnds-input,< 1K
-Predicate,http://schema.org/availabilityEnds-output,< 1K
-Predicate,http://schema.org/availabilityStarts,10K - 100K
-Predicate,http://schema.org/availabilityStarts-input,< 1K
-Predicate,http://schema.org/availabilityStarts-output,< 1K
-Predicate,http://schema.org/availableAtOrFrom,10K - 100K
-Predicate,http://schema.org/availableAtOrFrom-input,< 1K
-Predicate,http://schema.org/availableAtOrFrom-output,< 1K
-Predicate,http://schema.org/availableChannel,100K - 1M
-Predicate,http://schema.org/availableChannel-input,< 1K
-Predicate,http://schema.org/availableChannel-output,< 1K
-Predicate,http://schema.org/availableDeliveryMethod,10K - 100K
-Predicate,http://schema.org/availableDeliveryMethod-input,< 1K
-Predicate,http://schema.org/availableDeliveryMethod-output,< 1K
-Predicate,http://schema.org/availableFrom,< 1K
-Predicate,http://schema.org/availableFrom-input,< 1K
-Predicate,http://schema.org/availableFrom-output,< 1K
-Predicate,http://schema.org/availableIn,< 1K
-Predicate,http://schema.org/availableIn-input,< 1K
-Predicate,http://schema.org/availableIn-output,< 1K
-Predicate,http://schema.org/availableLanguage,1M - 10M
-Predicate,http://schema.org/availableLanguage-input,< 1K
-Predicate,http://schema.org/availableLanguage-output,< 1K
-Predicate,http://schema.org/availableOnDevice,1K - 10K
-Predicate,http://schema.org/availableOnDevice-input,< 1K
-Predicate,http://schema.org/availableOnDevice-output,< 1K
-Predicate,http://schema.org/availableService,10K - 100K
-Predicate,http://schema.org/availableService-input,< 1K
-Predicate,http://schema.org/availableService-output,< 1K
-Predicate,http://schema.org/availableStrength,< 1K
-Predicate,http://schema.org/availableStrength-input,< 1K
-Predicate,http://schema.org/availableStrength-output,< 1K
-Predicate,http://schema.org/availableTest,< 1K
-Predicate,http://schema.org/availableTest-input,< 1K
-Predicate,http://schema.org/availableTest-output,< 1K
-Predicate,http://schema.org/availableThrough,< 1K
-Predicate,http://schema.org/availableThrough-input,< 1K
-Predicate,http://schema.org/availableThrough-output,< 1K
-Predicate,http://schema.org/award,10K - 100K
-Predicate,http://schema.org/award-input,< 1K
-Predicate,http://schema.org/award-output,< 1K
-Predicate,http://schema.org/awards,1K - 10K
-Predicate,http://schema.org/awards-input,< 1K
-Predicate,http://schema.org/awards-output,< 1K
-Predicate,http://schema.org/awayTeam,10K - 100K
-Predicate,http://schema.org/awayTeam-input,< 1K
-Predicate,http://schema.org/awayTeam-output,< 1K
-Predicate,http://schema.org/backstory,1K - 10K
-Predicate,http://schema.org/backstory-input,< 1K
-Predicate,http://schema.org/backstory-output,< 1K
-Predicate,http://schema.org/bankAccountType,< 1K
-Predicate,http://schema.org/bankAccountType-input,< 1K
-Predicate,http://schema.org/bankAccountType-output,< 1K
-Predicate,http://schema.org/baseSalary,10K - 100K
-Predicate,http://schema.org/baseSalary-input,< 1K
-Predicate,http://schema.org/baseSalary-output,< 1K
-Predicate,http://schema.org/bccRecipient,< 1K
-Predicate,http://schema.org/bccRecipient-input,< 1K
-Predicate,http://schema.org/bccRecipient-output,< 1K
-Predicate,http://schema.org/bed,10K - 100K
-Predicate,http://schema.org/bed-input,< 1K
-Predicate,http://schema.org/bed-output,< 1K
-Predicate,http://schema.org/beforeMedia,< 1K
-Predicate,http://schema.org/beforeMedia-input,< 1K
-Predicate,http://schema.org/beforeMedia-output,< 1K
-Predicate,http://schema.org/beneficiaryBank,< 1K
-Predicate,http://schema.org/beneficiaryBank-input,< 1K
-Predicate,http://schema.org/beneficiaryBank-output,< 1K
-Predicate,http://schema.org/benefits,1K - 10K
-Predicate,http://schema.org/benefits-input,< 1K
-Predicate,http://schema.org/benefits-output,< 1K
-Predicate,http://schema.org/benefitsSummaryUrl,< 1K
-Predicate,http://schema.org/benefitsSummaryUrl-input,< 1K
-Predicate,http://schema.org/benefitsSummaryUrl-output,< 1K
-Predicate,http://schema.org/bestRating,1M - 10M
-Predicate,http://schema.org/bestRating-input,< 1K
-Predicate,http://schema.org/bestRating-output,< 1K
-Predicate,http://schema.org/billingAddress,< 1K
-Predicate,http://schema.org/billingAddress-input,< 1K
-Predicate,http://schema.org/billingAddress-output,< 1K
-Predicate,http://schema.org/billingDuration,10K - 100K
-Predicate,http://schema.org/billingDuration-input,< 1K
-Predicate,http://schema.org/billingDuration-output,< 1K
-Predicate,http://schema.org/billingIncrement,10K - 100K
-Predicate,http://schema.org/billingIncrement-input,< 1K
-Predicate,http://schema.org/billingIncrement-output,< 1K
-Predicate,http://schema.org/billingPeriod,1K - 10K
-Predicate,http://schema.org/billingPeriod-input,< 1K
-Predicate,http://schema.org/billingPeriod-output,< 1K
-Predicate,http://schema.org/billingStart,< 1K
-Predicate,http://schema.org/billingStart-input,< 1K
-Predicate,http://schema.org/billingStart-output,< 1K
-Predicate,http://schema.org/bioChemInteraction,< 1K
-Predicate,http://schema.org/bioChemInteraction-input,< 1K
-Predicate,http://schema.org/bioChemInteraction-output,< 1K
-Predicate,http://schema.org/bioChemSimilarity,< 1K
-Predicate,http://schema.org/bioChemSimilarity-input,< 1K
-Predicate,http://schema.org/bioChemSimilarity-output,< 1K
-Predicate,http://schema.org/biologicalRole,< 1K
-Predicate,http://schema.org/biologicalRole-input,< 1K
-Predicate,http://schema.org/biologicalRole-output,< 1K
-Predicate,http://schema.org/biomechnicalClass,< 1K
-Predicate,http://schema.org/biomechnicalClass-input,< 1K
-Predicate,http://schema.org/biomechnicalClass-output,< 1K
-Predicate,http://schema.org/birthDate,10K - 100K
-Predicate,http://schema.org/birthDate-input,< 1K
-Predicate,http://schema.org/birthDate-output,< 1K
-Predicate,http://schema.org/birthPlace,10K - 100K
-Predicate,http://schema.org/birthPlace-input,< 1K
-Predicate,http://schema.org/birthPlace-output,< 1K
-Predicate,http://schema.org/bitrate,1K - 10K
-Predicate,http://schema.org/bitrate-input,< 1K
-Predicate,http://schema.org/bitrate-output,< 1K
-Predicate,http://schema.org/blogPost,100K - 1M
-Predicate,http://schema.org/blogPost-input,< 1K
-Predicate,http://schema.org/blogPost-output,< 1K
-Predicate,http://schema.org/blogPosts,10K - 100K
-Predicate,http://schema.org/blogPosts-input,< 1K
-Predicate,http://schema.org/blogPosts-output,< 1K
-Predicate,http://schema.org/bloodSupply,< 1K
-Predicate,http://schema.org/bloodSupply-input,< 1K
-Predicate,http://schema.org/bloodSupply-output,< 1K
-Predicate,http://schema.org/boardingGroup,< 1K
-Predicate,http://schema.org/boardingGroup-input,< 1K
-Predicate,http://schema.org/boardingGroup-output,< 1K
-Predicate,http://schema.org/boardingPolicy,< 1K
-Predicate,http://schema.org/boardingPolicy-input,< 1K
-Predicate,http://schema.org/boardingPolicy-output,< 1K
-Predicate,http://schema.org/bodyLocation,10K - 100K
-Predicate,http://schema.org/bodyLocation-input,< 1K
-Predicate,http://schema.org/bodyLocation-output,< 1K
-Predicate,http://schema.org/bodyType,10K - 100K
-Predicate,http://schema.org/bodyType-input,< 1K
-Predicate,http://schema.org/bodyType-output,< 1K
-Predicate,http://schema.org/bookEdition,1K - 10K
-Predicate,http://schema.org/bookEdition-input,< 1K
-Predicate,http://schema.org/bookEdition-output,< 1K
-Predicate,http://schema.org/bookFormat,10K - 100K
-Predicate,http://schema.org/bookFormat-input,< 1K
-Predicate,http://schema.org/bookFormat-output,< 1K
-Predicate,http://schema.org/bookingAgent,< 1K
-Predicate,http://schema.org/bookingAgent-input,< 1K
-Predicate,http://schema.org/bookingAgent-output,< 1K
-Predicate,http://schema.org/bookingTime,< 1K
-Predicate,http://schema.org/bookingTime-input,< 1K
-Predicate,http://schema.org/bookingTime-output,< 1K
-Predicate,http://schema.org/borrower,< 1K
-Predicate,http://schema.org/borrower-input,< 1K
-Predicate,http://schema.org/borrower-output,< 1K
-Predicate,http://schema.org/box,1K - 10K
-Predicate,http://schema.org/box-input,< 1K
-Predicate,http://schema.org/box-output,< 1K
-Predicate,http://schema.org/branch,< 1K
-Predicate,http://schema.org/branch-input,< 1K
-Predicate,http://schema.org/branch-output,< 1K
-Predicate,http://schema.org/branchCode,1K - 10K
-Predicate,http://schema.org/branchCode-input,< 1K
-Predicate,http://schema.org/branchCode-output,< 1K
-Predicate,http://schema.org/branchOf,10K - 100K
-Predicate,http://schema.org/branchOf-input,< 1K
-Predicate,http://schema.org/branchOf-output,< 1K
-Predicate,http://schema.org/brand,1M - 10M
-Predicate,http://schema.org/brand-input,< 1K
-Predicate,http://schema.org/brand-output,< 1K
-Predicate,http://schema.org/breadcrumb,10M+
-Predicate,http://schema.org/breadcrumb-input,< 1K
-Predicate,http://schema.org/breadcrumb-output,< 1K
-Predicate,http://schema.org/breastfeedingWarning,< 1K
-Predicate,http://schema.org/breastfeedingWarning-input,< 1K
-Predicate,http://schema.org/breastfeedingWarning-output,< 1K
-Predicate,http://schema.org/broadcastAffiliateOf,< 1K
-Predicate,http://schema.org/broadcastAffiliateOf-input,< 1K
-Predicate,http://schema.org/broadcastAffiliateOf-output,< 1K
-Predicate,http://schema.org/broadcastChannelId,< 1K
-Predicate,http://schema.org/broadcastChannelId-input,< 1K
-Predicate,http://schema.org/broadcastChannelId-output,< 1K
-Predicate,http://schema.org/broadcastDisplayName,1K - 10K
-Predicate,http://schema.org/broadcastDisplayName-input,< 1K
-Predicate,http://schema.org/broadcastDisplayName-output,< 1K
-Predicate,http://schema.org/broadcastFrequency,1K - 10K
-Predicate,http://schema.org/broadcastFrequency-input,< 1K
-Predicate,http://schema.org/broadcastFrequency-output,< 1K
-Predicate,http://schema.org/broadcastFrequencyValue,< 1K
-Predicate,http://schema.org/broadcastFrequencyValue-input,< 1K
-Predicate,http://schema.org/broadcastFrequencyValue-output,< 1K
-Predicate,http://schema.org/broadcastOfEvent,1K - 10K
-Predicate,http://schema.org/broadcastOfEvent-input,< 1K
-Predicate,http://schema.org/broadcastOfEvent-output,< 1K
-Predicate,http://schema.org/broadcastServiceTier,< 1K
-Predicate,http://schema.org/broadcastServiceTier-input,< 1K
-Predicate,http://schema.org/broadcastServiceTier-output,< 1K
-Predicate,http://schema.org/broadcastSignalModulation,< 1K
-Predicate,http://schema.org/broadcastSignalModulation-input,< 1K
-Predicate,http://schema.org/broadcastSignalModulation-output,< 1K
-Predicate,http://schema.org/broadcastSubChannel,< 1K
-Predicate,http://schema.org/broadcastSubChannel-input,< 1K
-Predicate,http://schema.org/broadcastSubChannel-output,< 1K
-Predicate,http://schema.org/broadcastTimezone,< 1K
-Predicate,http://schema.org/broadcastTimezone-input,< 1K
-Predicate,http://schema.org/broadcastTimezone-output,< 1K
-Predicate,http://schema.org/broadcaster,< 1K
-Predicate,http://schema.org/broadcaster-input,< 1K
-Predicate,http://schema.org/broadcaster-output,< 1K
-Predicate,http://schema.org/broker,1K - 10K
-Predicate,http://schema.org/broker-input,< 1K
-Predicate,http://schema.org/broker-output,< 1K
-Predicate,http://schema.org/browserRequirements,10K - 100K
-Predicate,http://schema.org/browserRequirements-input,< 1K
-Predicate,http://schema.org/browserRequirements-output,< 1K
-Predicate,http://schema.org/busName,< 1K
-Predicate,http://schema.org/busName-input,< 1K
-Predicate,http://schema.org/busName-output,< 1K
-Predicate,http://schema.org/busNumber,< 1K
-Predicate,http://schema.org/busNumber-input,< 1K
-Predicate,http://schema.org/busNumber-output,< 1K
-Predicate,http://schema.org/businessDays,10K - 100K
-Predicate,http://schema.org/businessDays-input,< 1K
-Predicate,http://schema.org/businessDays-output,< 1K
-Predicate,http://schema.org/businessFunction,1M - 10M
-Predicate,http://schema.org/businessFunction-input,< 1K
-Predicate,http://schema.org/businessFunction-output,< 1K
-Predicate,http://schema.org/buyer,< 1K
-Predicate,http://schema.org/buyer-input,< 1K
-Predicate,http://schema.org/buyer-output,< 1K
-Predicate,http://schema.org/byArtist,10K - 100K
-Predicate,http://schema.org/byArtist-input,< 1K
-Predicate,http://schema.org/byArtist-output,< 1K
-Predicate,http://schema.org/byDay,1K - 10K
-Predicate,http://schema.org/byDay-input,< 1K
-Predicate,http://schema.org/byDay-output,< 1K
-Predicate,http://schema.org/byMonth,< 1K
-Predicate,http://schema.org/byMonth-input,< 1K
-Predicate,http://schema.org/byMonth-output,< 1K
-Predicate,http://schema.org/byMonthDay,< 1K
-Predicate,http://schema.org/byMonthDay-input,< 1K
-Predicate,http://schema.org/byMonthDay-output,< 1K
-Predicate,http://schema.org/byMonthWeek,< 1K
-Predicate,http://schema.org/byMonthWeek-input,< 1K
-Predicate,http://schema.org/byMonthWeek-output,< 1K
-Predicate,http://schema.org/callSign,< 1K
-Predicate,http://schema.org/callSign-input,< 1K
-Predicate,http://schema.org/callSign-output,< 1K
-Predicate,http://schema.org/calories,10K - 100K
-Predicate,http://schema.org/calories-input,< 1K
-Predicate,http://schema.org/calories-output,< 1K
-Predicate,http://schema.org/candidate,< 1K
-Predicate,http://schema.org/candidate-input,< 1K
-Predicate,http://schema.org/candidate-output,< 1K
-Predicate,http://schema.org/caption,10M+
-Predicate,http://schema.org/caption-input,< 1K
-Predicate,http://schema.org/caption-output,< 1K
-Predicate,http://schema.org/carbohydrateContent,10K - 100K
-Predicate,http://schema.org/carbohydrateContent-input,< 1K
-Predicate,http://schema.org/carbohydrateContent-output,< 1K
-Predicate,http://schema.org/cargoVolume,1K - 10K
-Predicate,http://schema.org/cargoVolume-input,< 1K
-Predicate,http://schema.org/cargoVolume-output,< 1K
-Predicate,http://schema.org/carrier,< 1K
-Predicate,http://schema.org/carrier-input,< 1K
-Predicate,http://schema.org/carrier-output,< 1K
-Predicate,http://schema.org/carrierRequirements,< 1K
-Predicate,http://schema.org/carrierRequirements-input,< 1K
-Predicate,http://schema.org/carrierRequirements-output,< 1K
-Predicate,http://schema.org/cashBack,< 1K
-Predicate,http://schema.org/cashBack-input,< 1K
-Predicate,http://schema.org/cashBack-output,< 1K
-Predicate,http://schema.org/catalog,< 1K
-Predicate,http://schema.org/catalog-input,< 1K
-Predicate,http://schema.org/catalog-output,< 1K
-Predicate,http://schema.org/catalogNumber,< 1K
-Predicate,http://schema.org/catalogNumber-input,< 1K
-Predicate,http://schema.org/catalogNumber-output,< 1K
-Predicate,http://schema.org/category,1M - 10M
-Predicate,http://schema.org/category-input,< 1K
-Predicate,http://schema.org/category-output,< 1K
-Predicate,http://schema.org/cause,1K - 10K
-Predicate,http://schema.org/cause-input,< 1K
-Predicate,http://schema.org/cause-output,< 1K
-Predicate,http://schema.org/causeOf,< 1K
-Predicate,http://schema.org/causeOf-input,< 1K
-Predicate,http://schema.org/causeOf-output,< 1K
-Predicate,http://schema.org/ccRecipient,< 1K
-Predicate,http://schema.org/ccRecipient-input,< 1K
-Predicate,http://schema.org/ccRecipient-output,< 1K
-Predicate,http://schema.org/certificationIdentification,1K - 10K
-Predicate,http://schema.org/certificationIdentification-input,< 1K
-Predicate,http://schema.org/certificationIdentification-output,< 1K
-Predicate,http://schema.org/certificationRating,< 1K
-Predicate,http://schema.org/certificationRating-input,< 1K
-Predicate,http://schema.org/certificationRating-output,< 1K
-Predicate,http://schema.org/certificationStatus,1K - 10K
-Predicate,http://schema.org/certificationStatus-input,< 1K
-Predicate,http://schema.org/certificationStatus-output,< 1K
-Predicate,http://schema.org/character,1K - 10K
-Predicate,http://schema.org/character-input,< 1K
-Predicate,http://schema.org/character-output,< 1K
-Predicate,http://schema.org/characterAttribute,< 1K
-Predicate,http://schema.org/characterAttribute-input,< 1K
-Predicate,http://schema.org/characterAttribute-output,< 1K
-Predicate,http://schema.org/characterName,< 1K
-Predicate,http://schema.org/characterName-input,< 1K
-Predicate,http://schema.org/characterName-output,< 1K
-Predicate,http://schema.org/cheatCode,< 1K
-Predicate,http://schema.org/cheatCode-input,< 1K
-Predicate,http://schema.org/cheatCode-output,< 1K
-Predicate,http://schema.org/checkinTime,10K - 100K
-Predicate,http://schema.org/checkinTime-input,< 1K
-Predicate,http://schema.org/checkinTime-output,< 1K
-Predicate,http://schema.org/checkoutPageURLTemplate,10K - 100K
-Predicate,http://schema.org/checkoutPageURLTemplate-input,< 1K
-Predicate,http://schema.org/checkoutPageURLTemplate-output,< 1K
-Predicate,http://schema.org/checkoutTime,10K - 100K
-Predicate,http://schema.org/checkoutTime-input,< 1K
-Predicate,http://schema.org/checkoutTime-output,< 1K
-Predicate,http://schema.org/chemicalComposition,< 1K
-Predicate,http://schema.org/chemicalComposition-input,< 1K
-Predicate,http://schema.org/chemicalComposition-output,< 1K
-Predicate,http://schema.org/chemicalRole,< 1K
-Predicate,http://schema.org/chemicalRole-input,< 1K
-Predicate,http://schema.org/chemicalRole-output,< 1K
-Predicate,http://schema.org/childMaxAge,< 1K
-Predicate,http://schema.org/childMaxAge-input,< 1K
-Predicate,http://schema.org/childMaxAge-output,< 1K
-Predicate,http://schema.org/childMinAge,< 1K
-Predicate,http://schema.org/childMinAge-input,< 1K
-Predicate,http://schema.org/childMinAge-output,< 1K
-Predicate,http://schema.org/childTaxon,< 1K
-Predicate,http://schema.org/childTaxon-input,< 1K
-Predicate,http://schema.org/childTaxon-output,< 1K
-Predicate,http://schema.org/children,1K - 10K
-Predicate,http://schema.org/children-input,< 1K
-Predicate,http://schema.org/children-output,< 1K
-Predicate,http://schema.org/cholesterolContent,10K - 100K
-Predicate,http://schema.org/cholesterolContent-input,< 1K
-Predicate,http://schema.org/cholesterolContent-output,< 1K
-Predicate,http://schema.org/circle,1K - 10K
-Predicate,http://schema.org/circle-input,< 1K
-Predicate,http://schema.org/circle-output,< 1K
-Predicate,http://schema.org/citation,10K - 100K
-Predicate,http://schema.org/citation-input,< 1K
-Predicate,http://schema.org/citation-output,< 1K
-Predicate,http://schema.org/claimInterpreter,< 1K
-Predicate,http://schema.org/claimInterpreter-input,< 1K
-Predicate,http://schema.org/claimInterpreter-output,< 1K
-Predicate,http://schema.org/claimReviewed,1K - 10K
-Predicate,http://schema.org/claimReviewed-input,< 1K
-Predicate,http://schema.org/claimReviewed-output,< 1K
-Predicate,http://schema.org/clincalPharmacology,< 1K
-Predicate,http://schema.org/clincalPharmacology-input,< 1K
-Predicate,http://schema.org/clincalPharmacology-output,< 1K
-Predicate,http://schema.org/clinicalPharmacology,< 1K
-Predicate,http://schema.org/clinicalPharmacology-input,< 1K
-Predicate,http://schema.org/clinicalPharmacology-output,< 1K
-Predicate,http://schema.org/clipNumber,< 1K
-Predicate,http://schema.org/clipNumber-input,< 1K
-Predicate,http://schema.org/clipNumber-output,< 1K
-Predicate,http://schema.org/closes,1M - 10M
-Predicate,http://schema.org/closes-input,< 1K
-Predicate,http://schema.org/closes-output,< 1K
-Predicate,http://schema.org/coach,< 1K
-Predicate,http://schema.org/coach-input,< 1K
-Predicate,http://schema.org/coach-output,< 1K
-Predicate,http://schema.org/code,1K - 10K
-Predicate,http://schema.org/code-input,< 1K
-Predicate,http://schema.org/code-output,< 1K
-Predicate,http://schema.org/codeRepository,1K - 10K
-Predicate,http://schema.org/codeRepository-input,< 1K
-Predicate,http://schema.org/codeRepository-output,< 1K
-Predicate,http://schema.org/codeSampleType,< 1K
-Predicate,http://schema.org/codeSampleType-input,< 1K
-Predicate,http://schema.org/codeSampleType-output,< 1K
-Predicate,http://schema.org/codeValue,1K - 10K
-Predicate,http://schema.org/codeValue-input,< 1K
-Predicate,http://schema.org/codeValue-output,< 1K
-Predicate,http://schema.org/codingSystem,1K - 10K
-Predicate,http://schema.org/codingSystem-input,< 1K
-Predicate,http://schema.org/codingSystem-output,< 1K
-Predicate,http://schema.org/colleague,1K - 10K
-Predicate,http://schema.org/colleague-input,< 1K
-Predicate,http://schema.org/colleague-output,< 1K
-Predicate,http://schema.org/colleagues,< 1K
-Predicate,http://schema.org/colleagues-input,< 1K
-Predicate,http://schema.org/colleagues-output,< 1K
-Predicate,http://schema.org/collection,< 1K
-Predicate,http://schema.org/collection-input,< 1K
-Predicate,http://schema.org/collection-output,< 1K
-Predicate,http://schema.org/collectionSize,1K - 10K
-Predicate,http://schema.org/collectionSize-input,< 1K
-Predicate,http://schema.org/collectionSize-output,< 1K
-Predicate,http://schema.org/color,100K - 1M
-Predicate,http://schema.org/color-input,< 1K
-Predicate,http://schema.org/color-output,< 1K
-Predicate,http://schema.org/colorSwatch,< 1K
-Predicate,http://schema.org/colorSwatch-input,< 1K
-Predicate,http://schema.org/colorSwatch-output,< 1K
-Predicate,http://schema.org/colorist,< 1K
-Predicate,http://schema.org/colorist-input,< 1K
-Predicate,http://schema.org/colorist-output,< 1K
-Predicate,http://schema.org/comment,10K - 100K
-Predicate,http://schema.org/comment-input,< 1K
-Predicate,http://schema.org/comment-output,< 1K
-Predicate,http://schema.org/commentCount,1M - 10M
-Predicate,http://schema.org/commentCount-input,< 1K
-Predicate,http://schema.org/commentCount-output,< 1K
-Predicate,http://schema.org/commentText,10K - 100K
-Predicate,http://schema.org/commentText-input,< 1K
-Predicate,http://schema.org/commentText-output,< 1K
-Predicate,http://schema.org/commentTime,10K - 100K
-Predicate,http://schema.org/commentTime-input,< 1K
-Predicate,http://schema.org/commentTime-output,< 1K
-Predicate,http://schema.org/companyRegistration,< 1K
-Predicate,http://schema.org/companyRegistration-input,< 1K
-Predicate,http://schema.org/companyRegistration-output,< 1K
-Predicate,http://schema.org/competencyRequired,1K - 10K
-Predicate,http://schema.org/competencyRequired-input,< 1K
-Predicate,http://schema.org/competencyRequired-output,< 1K
-Predicate,http://schema.org/competitor,1K - 10K
-Predicate,http://schema.org/competitor-input,< 1K
-Predicate,http://schema.org/competitor-output,< 1K
-Predicate,http://schema.org/composer,1K - 10K
-Predicate,http://schema.org/composer-input,< 1K
-Predicate,http://schema.org/composer-output,< 1K
-Predicate,http://schema.org/comprisedOf,< 1K
-Predicate,http://schema.org/comprisedOf-input,< 1K
-Predicate,http://schema.org/comprisedOf-output,< 1K
-Predicate,http://schema.org/conditionsOfAccess,< 1K
-Predicate,http://schema.org/conditionsOfAccess-input,< 1K
-Predicate,http://schema.org/conditionsOfAccess-output,< 1K
-Predicate,http://schema.org/confirmationNumber,< 1K
-Predicate,http://schema.org/confirmationNumber-input,< 1K
-Predicate,http://schema.org/confirmationNumber-output,< 1K
-Predicate,http://schema.org/connectedTo,< 1K
-Predicate,http://schema.org/connectedTo-input,< 1K
-Predicate,http://schema.org/connectedTo-output,< 1K
-Predicate,http://schema.org/constraintProperty,< 1K
-Predicate,http://schema.org/constraintProperty-input,< 1K
-Predicate,http://schema.org/constraintProperty-output,< 1K
-Predicate,http://schema.org/contactOption,100K - 1M
-Predicate,http://schema.org/contactOption-input,< 1K
-Predicate,http://schema.org/contactOption-output,< 1K
-Predicate,http://schema.org/contactPoint,1M - 10M
-Predicate,http://schema.org/contactPoint-input,< 1K
-Predicate,http://schema.org/contactPoint-output,< 1K
-Predicate,http://schema.org/contactPoints,< 1K
-Predicate,http://schema.org/contactPoints-input,< 1K
-Predicate,http://schema.org/contactPoints-output,< 1K
-Predicate,http://schema.org/contactType,1M - 10M
-Predicate,http://schema.org/contactType-input,< 1K
-Predicate,http://schema.org/contactType-output,< 1K
-Predicate,http://schema.org/contactlessPayment,< 1K
-Predicate,http://schema.org/contactlessPayment-input,< 1K
-Predicate,http://schema.org/contactlessPayment-output,< 1K
-Predicate,http://schema.org/containedIn,10K - 100K
-Predicate,http://schema.org/containedIn-input,< 1K
-Predicate,http://schema.org/containedIn-output,< 1K
-Predicate,http://schema.org/containedInPlace,100K - 1M
-Predicate,http://schema.org/containedInPlace-input,< 1K
-Predicate,http://schema.org/containedInPlace-output,< 1K
-Predicate,http://schema.org/containsPlace,10K - 100K
-Predicate,http://schema.org/containsPlace-input,< 1K
-Predicate,http://schema.org/containsPlace-output,< 1K
-Predicate,http://schema.org/containsSeason,1K - 10K
-Predicate,http://schema.org/containsSeason-input,< 1K
-Predicate,http://schema.org/containsSeason-output,< 1K
-Predicate,http://schema.org/contentLocation,10K - 100K
-Predicate,http://schema.org/contentLocation-input,< 1K
-Predicate,http://schema.org/contentLocation-output,< 1K
-Predicate,http://schema.org/contentRating,10K - 100K
-Predicate,http://schema.org/contentRating-input,< 1K
-Predicate,http://schema.org/contentRating-output,< 1K
-Predicate,http://schema.org/contentReferenceTime,1K - 10K
-Predicate,http://schema.org/contentReferenceTime-input,< 1K
-Predicate,http://schema.org/contentReferenceTime-output,< 1K
-Predicate,http://schema.org/contentSize,100K - 1M
-Predicate,http://schema.org/contentSize-input,< 1K
-Predicate,http://schema.org/contentSize-output,< 1K
-Predicate,http://schema.org/contentType,10K - 100K
-Predicate,http://schema.org/contentType-input,< 1K
-Predicate,http://schema.org/contentType-output,< 1K
-Predicate,http://schema.org/contentUrl,10M+
-Predicate,http://schema.org/contentUrl-input,< 1K
-Predicate,http://schema.org/contentUrl-output,< 1K
-Predicate,http://schema.org/contraindication,1K - 10K
-Predicate,http://schema.org/contraindication-input,< 1K
-Predicate,http://schema.org/contraindication-output,< 1K
-Predicate,http://schema.org/contributor,100K - 1M
-Predicate,http://schema.org/contributor-input,< 1K
-Predicate,http://schema.org/contributor-output,< 1K
-Predicate,http://schema.org/cookTime,10K - 100K
-Predicate,http://schema.org/cookTime-input,< 1K
-Predicate,http://schema.org/cookTime-output,< 1K
-Predicate,http://schema.org/cookingMethod,1K - 10K
-Predicate,http://schema.org/cookingMethod-input,< 1K
-Predicate,http://schema.org/cookingMethod-output,< 1K
-Predicate,http://schema.org/copyrightHolder,100K - 1M
-Predicate,http://schema.org/copyrightHolder-input,< 1K
-Predicate,http://schema.org/copyrightHolder-output,< 1K
-Predicate,http://schema.org/copyrightNotice,10K - 100K
-Predicate,http://schema.org/copyrightNotice-input,< 1K
-Predicate,http://schema.org/copyrightNotice-output,< 1K
-Predicate,http://schema.org/copyrightYear,100K - 1M
-Predicate,http://schema.org/copyrightYear-input,< 1K
-Predicate,http://schema.org/copyrightYear-output,< 1K
-Predicate,http://schema.org/correction,< 1K
-Predicate,http://schema.org/correction-input,< 1K
-Predicate,http://schema.org/correction-output,< 1K
-Predicate,http://schema.org/correctionsPolicy,10K - 100K
-Predicate,http://schema.org/correctionsPolicy-input,< 1K
-Predicate,http://schema.org/correctionsPolicy-output,< 1K
-Predicate,http://schema.org/costCategory,< 1K
-Predicate,http://schema.org/costCategory-input,< 1K
-Predicate,http://schema.org/costCategory-output,< 1K
-Predicate,http://schema.org/costCurrency,< 1K
-Predicate,http://schema.org/costCurrency-input,< 1K
-Predicate,http://schema.org/costCurrency-output,< 1K
-Predicate,http://schema.org/costOrigin,< 1K
-Predicate,http://schema.org/costOrigin-input,< 1K
-Predicate,http://schema.org/costOrigin-output,< 1K
-Predicate,http://schema.org/costPerUnit,< 1K
-Predicate,http://schema.org/costPerUnit-input,< 1K
-Predicate,http://schema.org/costPerUnit-output,< 1K
-Predicate,http://schema.org/countriesNotSupported,< 1K
-Predicate,http://schema.org/countriesNotSupported-input,< 1K
-Predicate,http://schema.org/countriesNotSupported-output,< 1K
-Predicate,http://schema.org/countriesSupported,1K - 10K
-Predicate,http://schema.org/countriesSupported-input,< 1K
-Predicate,http://schema.org/countriesSupported-output,< 1K
-Predicate,http://schema.org/countryOfAssembly,1K - 10K
-Predicate,http://schema.org/countryOfAssembly-input,< 1K
-Predicate,http://schema.org/countryOfAssembly-output,< 1K
-Predicate,http://schema.org/countryOfLastProcessing,< 1K
-Predicate,http://schema.org/countryOfLastProcessing-input,< 1K
-Predicate,http://schema.org/countryOfLastProcessing-output,< 1K
-Predicate,http://schema.org/countryOfOrigin,10K - 100K
-Predicate,http://schema.org/countryOfOrigin-input,< 1K
-Predicate,http://schema.org/countryOfOrigin-output,< 1K
-Predicate,http://schema.org/course,< 1K
-Predicate,http://schema.org/course-input,< 1K
-Predicate,http://schema.org/course-output,< 1K
-Predicate,http://schema.org/courseCode,10K - 100K
-Predicate,http://schema.org/courseCode-input,< 1K
-Predicate,http://schema.org/courseCode-output,< 1K
-Predicate,http://schema.org/courseMode,10K - 100K
-Predicate,http://schema.org/courseMode-input,< 1K
-Predicate,http://schema.org/courseMode-output,< 1K
-Predicate,http://schema.org/coursePrerequisites,1K - 10K
-Predicate,http://schema.org/coursePrerequisites-input,< 1K
-Predicate,http://schema.org/coursePrerequisites-output,< 1K
-Predicate,http://schema.org/courseSchedule,1K - 10K
-Predicate,http://schema.org/courseSchedule-input,< 1K
-Predicate,http://schema.org/courseSchedule-output,< 1K
-Predicate,http://schema.org/courseWorkload,10K - 100K
-Predicate,http://schema.org/courseWorkload-input,< 1K
-Predicate,http://schema.org/courseWorkload-output,< 1K
-Predicate,http://schema.org/coverageEndTime,1K - 10K
-Predicate,http://schema.org/coverageEndTime-input,< 1K
-Predicate,http://schema.org/coverageEndTime-output,< 1K
-Predicate,http://schema.org/coverageStartTime,1K - 10K
-Predicate,http://schema.org/coverageStartTime-input,< 1K
-Predicate,http://schema.org/coverageStartTime-output,< 1K
-Predicate,http://schema.org/creativeWorkStatus,1K - 10K
-Predicate,http://schema.org/creativeWorkStatus-input,< 1K
-Predicate,http://schema.org/creativeWorkStatus-output,< 1K
-Predicate,http://schema.org/creator,1M - 10M
-Predicate,http://schema.org/creator-input,< 1K
-Predicate,http://schema.org/creator-output,< 1K
-Predicate,http://schema.org/credentialCategory,10K - 100K
-Predicate,http://schema.org/credentialCategory-input,< 1K
-Predicate,http://schema.org/credentialCategory-output,< 1K
-Predicate,http://schema.org/creditText,100K - 1M
-Predicate,http://schema.org/creditText-input,< 1K
-Predicate,http://schema.org/creditText-output,< 1K
-Predicate,http://schema.org/creditedTo,< 1K
-Predicate,http://schema.org/creditedTo-input,< 1K
-Predicate,http://schema.org/creditedTo-output,< 1K
-Predicate,http://schema.org/cssSelector,100K - 1M
-Predicate,http://schema.org/cssSelector-input,< 1K
-Predicate,http://schema.org/cssSelector-output,< 1K
-Predicate,http://schema.org/currenciesAccepted,100K - 1M
-Predicate,http://schema.org/currenciesAccepted-input,< 1K
-Predicate,http://schema.org/currenciesAccepted-output,< 1K
-Predicate,http://schema.org/currency,100K - 1M
-Predicate,http://schema.org/currency-input,< 1K
-Predicate,http://schema.org/currency-output,< 1K
-Predicate,http://schema.org/currentExchangeRate,< 1K
-Predicate,http://schema.org/currentExchangeRate-input,< 1K
-Predicate,http://schema.org/currentExchangeRate-output,< 1K
-Predicate,http://schema.org/customer,< 1K
-Predicate,http://schema.org/customer-input,< 1K
-Predicate,http://schema.org/customer-output,< 1K
-Predicate,http://schema.org/customerRemorseReturnFees,1K - 10K
-Predicate,http://schema.org/customerRemorseReturnFees-input,< 1K
-Predicate,http://schema.org/customerRemorseReturnFees-output,< 1K
-Predicate,http://schema.org/customerRemorseReturnLabelSource,1K - 10K
-Predicate,http://schema.org/customerRemorseReturnLabelSource-input,< 1K
-Predicate,http://schema.org/customerRemorseReturnLabelSource-output,< 1K
-Predicate,http://schema.org/customerRemorseReturnShippingFeesAmount,< 1K
-Predicate,http://schema.org/customerRemorseReturnShippingFeesAmount-input,< 1K
-Predicate,http://schema.org/customerRemorseReturnShippingFeesAmount-output,< 1K
-Predicate,http://schema.org/cutoffTime,10K - 100K
-Predicate,http://schema.org/cutoffTime-input,< 1K
-Predicate,http://schema.org/cutoffTime-output,< 1K
-Predicate,http://schema.org/cvdCollectionDate,< 1K
-Predicate,http://schema.org/cvdCollectionDate-input,< 1K
-Predicate,http://schema.org/cvdCollectionDate-output,< 1K
-Predicate,http://schema.org/cvdFacilityCounty,< 1K
-Predicate,http://schema.org/cvdFacilityCounty-input,< 1K
-Predicate,http://schema.org/cvdFacilityCounty-output,< 1K
-Predicate,http://schema.org/cvdFacilityId,< 1K
-Predicate,http://schema.org/cvdFacilityId-input,< 1K
-Predicate,http://schema.org/cvdFacilityId-output,< 1K
-Predicate,http://schema.org/cvdNumBeds,< 1K
-Predicate,http://schema.org/cvdNumBeds-input,< 1K
-Predicate,http://schema.org/cvdNumBeds-output,< 1K
-Predicate,http://schema.org/cvdNumBedsOcc,< 1K
-Predicate,http://schema.org/cvdNumBedsOcc-input,< 1K
-Predicate,http://schema.org/cvdNumBedsOcc-output,< 1K
-Predicate,http://schema.org/cvdNumC19Died,< 1K
-Predicate,http://schema.org/cvdNumC19Died-input,< 1K
-Predicate,http://schema.org/cvdNumC19Died-output,< 1K
-Predicate,http://schema.org/cvdNumC19HOPats,< 1K
-Predicate,http://schema.org/cvdNumC19HOPats-input,< 1K
-Predicate,http://schema.org/cvdNumC19HOPats-output,< 1K
-Predicate,http://schema.org/cvdNumC19HospPats,< 1K
-Predicate,http://schema.org/cvdNumC19HospPats-input,< 1K
-Predicate,http://schema.org/cvdNumC19HospPats-output,< 1K
-Predicate,http://schema.org/cvdNumC19MechVentPats,< 1K
-Predicate,http://schema.org/cvdNumC19MechVentPats-input,< 1K
-Predicate,http://schema.org/cvdNumC19MechVentPats-output,< 1K
-Predicate,http://schema.org/cvdNumC19OFMechVentPats,< 1K
-Predicate,http://schema.org/cvdNumC19OFMechVentPats-input,< 1K
-Predicate,http://schema.org/cvdNumC19OFMechVentPats-output,< 1K
-Predicate,http://schema.org/cvdNumC19OverflowPats,< 1K
-Predicate,http://schema.org/cvdNumC19OverflowPats-input,< 1K
-Predicate,http://schema.org/cvdNumC19OverflowPats-output,< 1K
-Predicate,http://schema.org/cvdNumICUBeds,< 1K
-Predicate,http://schema.org/cvdNumICUBeds-input,< 1K
-Predicate,http://schema.org/cvdNumICUBeds-output,< 1K
-Predicate,http://schema.org/cvdNumICUBedsOcc,< 1K
-Predicate,http://schema.org/cvdNumICUBedsOcc-input,< 1K
-Predicate,http://schema.org/cvdNumICUBedsOcc-output,< 1K
-Predicate,http://schema.org/cvdNumTotBeds,< 1K
-Predicate,http://schema.org/cvdNumTotBeds-input,< 1K
-Predicate,http://schema.org/cvdNumTotBeds-output,< 1K
-Predicate,http://schema.org/cvdNumVent,< 1K
-Predicate,http://schema.org/cvdNumVent-input,< 1K
-Predicate,http://schema.org/cvdNumVent-output,< 1K
-Predicate,http://schema.org/cvdNumVentUse,< 1K
-Predicate,http://schema.org/cvdNumVentUse-input,< 1K
-Predicate,http://schema.org/cvdNumVentUse-output,< 1K
-Predicate,http://schema.org/data,1K - 10K
-Predicate,http://schema.org/data-input,< 1K
-Predicate,http://schema.org/data-output,< 1K
-Predicate,http://schema.org/dataFeedElement,1K - 10K
-Predicate,http://schema.org/dataFeedElement-input,< 1K
-Predicate,http://schema.org/dataFeedElement-output,< 1K
-Predicate,http://schema.org/dataset,1K - 10K
-Predicate,http://schema.org/dataset-input,< 1K
-Predicate,http://schema.org/dataset-output,< 1K
-Predicate,http://schema.org/datasetTimeInterval,< 1K
-Predicate,http://schema.org/datasetTimeInterval-input,< 1K
-Predicate,http://schema.org/datasetTimeInterval-output,< 1K
-Predicate,http://schema.org/dateCreated,100K - 1M
-Predicate,http://schema.org/dateCreated-input,< 1K
-Predicate,http://schema.org/dateCreated-output,< 1K
-Predicate,http://schema.org/dateDeleted,< 1K
-Predicate,http://schema.org/dateDeleted-input,< 1K
-Predicate,http://schema.org/dateDeleted-output,< 1K
-Predicate,http://schema.org/dateIssued,< 1K
-Predicate,http://schema.org/dateIssued-input,< 1K
-Predicate,http://schema.org/dateIssued-output,< 1K
-Predicate,http://schema.org/dateModified,10M+
-Predicate,http://schema.org/dateModified-input,< 1K
-Predicate,http://schema.org/dateModified-output,< 1K
-Predicate,http://schema.org/datePosted,100K - 1M
-Predicate,http://schema.org/datePosted-input,< 1K
-Predicate,http://schema.org/datePosted-output,< 1K
-Predicate,http://schema.org/datePublished,10M+
-Predicate,http://schema.org/datePublished-input,< 1K
-Predicate,http://schema.org/datePublished-output,< 1K
-Predicate,http://schema.org/dateRead,< 1K
-Predicate,http://schema.org/dateRead-input,< 1K
-Predicate,http://schema.org/dateRead-output,< 1K
-Predicate,http://schema.org/dateReceived,< 1K
-Predicate,http://schema.org/dateReceived-input,< 1K
-Predicate,http://schema.org/dateReceived-output,< 1K
-Predicate,http://schema.org/dateSent,< 1K
-Predicate,http://schema.org/dateSent-input,< 1K
-Predicate,http://schema.org/dateSent-output,< 1K
-Predicate,http://schema.org/dateVehicleFirstRegistered,1K - 10K
-Predicate,http://schema.org/dateVehicleFirstRegistered-input,< 1K
-Predicate,http://schema.org/dateVehicleFirstRegistered-output,< 1K
-Predicate,http://schema.org/dateline,1K - 10K
-Predicate,http://schema.org/dateline-input,< 1K
-Predicate,http://schema.org/dateline-output,< 1K
-Predicate,http://schema.org/dayOfWeek,1M - 10M
-Predicate,http://schema.org/dayOfWeek-input,< 1K
-Predicate,http://schema.org/dayOfWeek-output,< 1K
-Predicate,http://schema.org/deathDate,10K - 100K
-Predicate,http://schema.org/deathDate-input,< 1K
-Predicate,http://schema.org/deathDate-output,< 1K
-Predicate,http://schema.org/deathPlace,1K - 10K
-Predicate,http://schema.org/deathPlace-input,< 1K
-Predicate,http://schema.org/deathPlace-output,< 1K
-Predicate,http://schema.org/defaultValue,100K - 1M
-Predicate,http://schema.org/defaultValue-input,< 1K
-Predicate,http://schema.org/defaultValue-output,< 1K
-Predicate,http://schema.org/deliveryAddress,< 1K
-Predicate,http://schema.org/deliveryAddress-input,< 1K
-Predicate,http://schema.org/deliveryAddress-output,< 1K
-Predicate,http://schema.org/deliveryLeadTime,10K - 100K
-Predicate,http://schema.org/deliveryLeadTime-input,< 1K
-Predicate,http://schema.org/deliveryLeadTime-output,< 1K
-Predicate,http://schema.org/deliveryMethod,100K - 1M
-Predicate,http://schema.org/deliveryMethod-input,< 1K
-Predicate,http://schema.org/deliveryMethod-output,< 1K
-Predicate,http://schema.org/deliveryStatus,< 1K
-Predicate,http://schema.org/deliveryStatus-input,< 1K
-Predicate,http://schema.org/deliveryStatus-output,< 1K
-Predicate,http://schema.org/deliveryTime,100K - 1M
-Predicate,http://schema.org/deliveryTime-input,< 1K
-Predicate,http://schema.org/deliveryTime-output,< 1K
-Predicate,http://schema.org/department,10K - 100K
-Predicate,http://schema.org/department-input,< 1K
-Predicate,http://schema.org/department-output,< 1K
-Predicate,http://schema.org/departureAirport,1K - 10K
-Predicate,http://schema.org/departureAirport-input,< 1K
-Predicate,http://schema.org/departureAirport-output,< 1K
-Predicate,http://schema.org/departureBoatTerminal,< 1K
-Predicate,http://schema.org/departureBoatTerminal-input,< 1K
-Predicate,http://schema.org/departureBoatTerminal-output,< 1K
-Predicate,http://schema.org/departureBusStop,< 1K
-Predicate,http://schema.org/departureBusStop-input,< 1K
-Predicate,http://schema.org/departureBusStop-output,< 1K
-Predicate,http://schema.org/departureGate,< 1K
-Predicate,http://schema.org/departureGate-input,< 1K
-Predicate,http://schema.org/departureGate-output,< 1K
-Predicate,http://schema.org/departurePlatform,< 1K
-Predicate,http://schema.org/departurePlatform-input,< 1K
-Predicate,http://schema.org/departurePlatform-output,< 1K
-Predicate,http://schema.org/departureStation,< 1K
-Predicate,http://schema.org/departureStation-input,< 1K
-Predicate,http://schema.org/departureStation-output,< 1K
-Predicate,http://schema.org/departureTerminal,< 1K
-Predicate,http://schema.org/departureTerminal-input,< 1K
-Predicate,http://schema.org/departureTerminal-output,< 1K
-Predicate,http://schema.org/departureTime,1K - 10K
-Predicate,http://schema.org/departureTime-input,< 1K
-Predicate,http://schema.org/departureTime-output,< 1K
-Predicate,http://schema.org/dependencies,1K - 10K
-Predicate,http://schema.org/dependencies-input,< 1K
-Predicate,http://schema.org/dependencies-output,< 1K
-Predicate,http://schema.org/depth,10K - 100K
-Predicate,http://schema.org/depth-input,< 1K
-Predicate,http://schema.org/depth-output,< 1K
-Predicate,http://schema.org/description,10M+
-Predicate,http://schema.org/description-input,< 1K
-Predicate,http://schema.org/description-output,< 1K
-Predicate,http://schema.org/device,< 1K
-Predicate,http://schema.org/device-input,< 1K
-Predicate,http://schema.org/device-output,< 1K
-Predicate,http://schema.org/diagnosis,< 1K
-Predicate,http://schema.org/diagnosis-input,< 1K
-Predicate,http://schema.org/diagnosis-output,< 1K
-Predicate,http://schema.org/diagram,< 1K
-Predicate,http://schema.org/diagram-input,< 1K
-Predicate,http://schema.org/diagram-output,< 1K
-Predicate,http://schema.org/diet,< 1K
-Predicate,http://schema.org/diet-input,< 1K
-Predicate,http://schema.org/diet-output,< 1K
-Predicate,http://schema.org/dietFeatures,< 1K
-Predicate,http://schema.org/dietFeatures-input,< 1K
-Predicate,http://schema.org/dietFeatures-output,< 1K
-Predicate,http://schema.org/differentialDiagnosis,< 1K
-Predicate,http://schema.org/differentialDiagnosis-input,< 1K
-Predicate,http://schema.org/differentialDiagnosis-output,< 1K
-Predicate,http://schema.org/digitalSourceType,< 1K
-Predicate,http://schema.org/digitalSourceType-input,< 1K
-Predicate,http://schema.org/digitalSourceType-output,< 1K
-Predicate,http://schema.org/directApply,10K - 100K
-Predicate,http://schema.org/directApply-input,< 1K
-Predicate,http://schema.org/directApply-output,< 1K
-Predicate,http://schema.org/director,10K - 100K
-Predicate,http://schema.org/director-input,< 1K
-Predicate,http://schema.org/director-output,< 1K
-Predicate,http://schema.org/directors,< 1K
-Predicate,http://schema.org/directors-input,< 1K
-Predicate,http://schema.org/directors-output,< 1K
-Predicate,http://schema.org/disambiguatingDescription,10K - 100K
-Predicate,http://schema.org/disambiguatingDescription-input,< 1K
-Predicate,http://schema.org/disambiguatingDescription-output,< 1K
-Predicate,http://schema.org/discount,10K - 100K
-Predicate,http://schema.org/discount-input,< 1K
-Predicate,http://schema.org/discount-output,< 1K
-Predicate,http://schema.org/discountCode,< 1K
-Predicate,http://schema.org/discountCode-input,< 1K
-Predicate,http://schema.org/discountCode-output,< 1K
-Predicate,http://schema.org/discountCurrency,< 1K
-Predicate,http://schema.org/discountCurrency-input,< 1K
-Predicate,http://schema.org/discountCurrency-output,< 1K
-Predicate,http://schema.org/discusses,1K - 10K
-Predicate,http://schema.org/discusses-input,< 1K
-Predicate,http://schema.org/discusses-output,< 1K
-Predicate,http://schema.org/discussionUrl,10K - 100K
-Predicate,http://schema.org/discussionUrl-input,< 1K
-Predicate,http://schema.org/discussionUrl-output,< 1K
-Predicate,http://schema.org/diseasePreventionInfo,< 1K
-Predicate,http://schema.org/diseasePreventionInfo-input,< 1K
-Predicate,http://schema.org/diseasePreventionInfo-output,< 1K
-Predicate,http://schema.org/diseaseSpreadStatistics,< 1K
-Predicate,http://schema.org/diseaseSpreadStatistics-input,< 1K
-Predicate,http://schema.org/diseaseSpreadStatistics-output,< 1K
-Predicate,http://schema.org/displayLocation,< 1K
-Predicate,http://schema.org/displayLocation-input,< 1K
-Predicate,http://schema.org/displayLocation-output,< 1K
-Predicate,http://schema.org/dissolutionDate,< 1K
-Predicate,http://schema.org/dissolutionDate-input,< 1K
-Predicate,http://schema.org/dissolutionDate-output,< 1K
-Predicate,http://schema.org/distance,1K - 10K
-Predicate,http://schema.org/distance-input,< 1K
-Predicate,http://schema.org/distance-output,< 1K
-Predicate,http://schema.org/distinguishingSign,< 1K
-Predicate,http://schema.org/distinguishingSign-input,< 1K
-Predicate,http://schema.org/distinguishingSign-output,< 1K
-Predicate,http://schema.org/distribution,10K - 100K
-Predicate,http://schema.org/distribution-input,< 1K
-Predicate,http://schema.org/distribution-output,< 1K
-Predicate,http://schema.org/diversityPolicy,10K - 100K
-Predicate,http://schema.org/diversityPolicy-input,< 1K
-Predicate,http://schema.org/diversityPolicy-output,< 1K
-Predicate,http://schema.org/diversityStaffingReport,1K - 10K
-Predicate,http://schema.org/diversityStaffingReport-input,< 1K
-Predicate,http://schema.org/diversityStaffingReport-output,< 1K
-Predicate,http://schema.org/documentation,1K - 10K
-Predicate,http://schema.org/documentation-input,< 1K
-Predicate,http://schema.org/documentation-output,< 1K
-Predicate,http://schema.org/doesNotShip,10K - 100K
-Predicate,http://schema.org/doesNotShip-input,< 1K
-Predicate,http://schema.org/doesNotShip-output,< 1K
-Predicate,http://schema.org/domainIncludes,< 1K
-Predicate,http://schema.org/domainIncludes-input,< 1K
-Predicate,http://schema.org/domainIncludes-output,< 1K
-Predicate,http://schema.org/domiciledMortgage,< 1K
-Predicate,http://schema.org/domiciledMortgage-input,< 1K
-Predicate,http://schema.org/domiciledMortgage-output,< 1K
-Predicate,http://schema.org/doorTime,1K - 10K
-Predicate,http://schema.org/doorTime-input,< 1K
-Predicate,http://schema.org/doorTime-output,< 1K
-Predicate,http://schema.org/dosageForm,1K - 10K
-Predicate,http://schema.org/dosageForm-input,< 1K
-Predicate,http://schema.org/dosageForm-output,< 1K
-Predicate,http://schema.org/doseSchedule,< 1K
-Predicate,http://schema.org/doseSchedule-input,< 1K
-Predicate,http://schema.org/doseSchedule-output,< 1K
-Predicate,http://schema.org/doseUnit,< 1K
-Predicate,http://schema.org/doseUnit-input,< 1K
-Predicate,http://schema.org/doseUnit-output,< 1K
-Predicate,http://schema.org/doseValue,< 1K
-Predicate,http://schema.org/doseValue-input,< 1K
-Predicate,http://schema.org/doseValue-output,< 1K
-Predicate,http://schema.org/downPayment,< 1K
-Predicate,http://schema.org/downPayment-input,< 1K
-Predicate,http://schema.org/downPayment-output,< 1K
-Predicate,http://schema.org/downloadUrl,100K - 1M
-Predicate,http://schema.org/downloadUrl-input,< 1K
-Predicate,http://schema.org/downloadUrl-output,< 1K
-Predicate,http://schema.org/downvoteCount,1K - 10K
-Predicate,http://schema.org/downvoteCount-input,< 1K
-Predicate,http://schema.org/downvoteCount-output,< 1K
-Predicate,http://schema.org/drainsTo,< 1K
-Predicate,http://schema.org/drainsTo-input,< 1K
-Predicate,http://schema.org/drainsTo-output,< 1K
-Predicate,http://schema.org/driveWheelConfiguration,10K - 100K
-Predicate,http://schema.org/driveWheelConfiguration-input,< 1K
-Predicate,http://schema.org/driveWheelConfiguration-output,< 1K
-Predicate,http://schema.org/dropoffLocation,< 1K
-Predicate,http://schema.org/dropoffLocation-input,< 1K
-Predicate,http://schema.org/dropoffLocation-output,< 1K
-Predicate,http://schema.org/dropoffTime,< 1K
-Predicate,http://schema.org/dropoffTime-input,< 1K
-Predicate,http://schema.org/dropoffTime-output,< 1K
-Predicate,http://schema.org/drug,< 1K
-Predicate,http://schema.org/drug-input,< 1K
-Predicate,http://schema.org/drug-output,< 1K
-Predicate,http://schema.org/drugClass,1K - 10K
-Predicate,http://schema.org/drugClass-input,< 1K
-Predicate,http://schema.org/drugClass-output,< 1K
-Predicate,http://schema.org/drugUnit,< 1K
-Predicate,http://schema.org/drugUnit-input,< 1K
-Predicate,http://schema.org/drugUnit-output,< 1K
-Predicate,http://schema.org/duns,1K - 10K
-Predicate,http://schema.org/duns-input,< 1K
-Predicate,http://schema.org/duns-output,< 1K
-Predicate,http://schema.org/duplicateTherapy,< 1K
-Predicate,http://schema.org/duplicateTherapy-input,< 1K
-Predicate,http://schema.org/duplicateTherapy-output,< 1K
-Predicate,http://schema.org/duration,1M - 10M
-Predicate,http://schema.org/duration-input,< 1K
-Predicate,http://schema.org/duration-output,< 1K
-Predicate,http://schema.org/durationOfWarranty,1K - 10K
-Predicate,http://schema.org/durationOfWarranty-input,< 1K
-Predicate,http://schema.org/durationOfWarranty-output,< 1K
-Predicate,http://schema.org/duringMedia,< 1K
-Predicate,http://schema.org/duringMedia-input,< 1K
-Predicate,http://schema.org/duringMedia-output,< 1K
-Predicate,http://schema.org/earlyPrepaymentPenalty,< 1K
-Predicate,http://schema.org/earlyPrepaymentPenalty-input,< 1K
-Predicate,http://schema.org/earlyPrepaymentPenalty-output,< 1K
-Predicate,http://schema.org/editEIDR,< 1K
-Predicate,http://schema.org/editEIDR-input,< 1K
-Predicate,http://schema.org/editEIDR-output,< 1K
-Predicate,http://schema.org/editor,100K - 1M
-Predicate,http://schema.org/editor-input,< 1K
-Predicate,http://schema.org/editor-output,< 1K
-Predicate,http://schema.org/eduQuestionType,1K - 10K
-Predicate,http://schema.org/eduQuestionType-input,< 1K
-Predicate,http://schema.org/eduQuestionType-output,< 1K
-Predicate,http://schema.org/educationRequirements,10K - 100K
-Predicate,http://schema.org/educationRequirements-input,< 1K
-Predicate,http://schema.org/educationRequirements-output,< 1K
-Predicate,http://schema.org/educationalAlignment,1K - 10K
-Predicate,http://schema.org/educationalAlignment-input,< 1K
-Predicate,http://schema.org/educationalAlignment-output,< 1K
-Predicate,http://schema.org/educationalCredentialAwarded,10K - 100K
-Predicate,http://schema.org/educationalCredentialAwarded-input,< 1K
-Predicate,http://schema.org/educationalCredentialAwarded-output,< 1K
-Predicate,http://schema.org/educationalFramework,< 1K
-Predicate,http://schema.org/educationalFramework-input,< 1K
-Predicate,http://schema.org/educationalFramework-output,< 1K
-Predicate,http://schema.org/educationalLevel,10K - 100K
-Predicate,http://schema.org/educationalLevel-input,< 1K
-Predicate,http://schema.org/educationalLevel-output,< 1K
-Predicate,http://schema.org/educationalProgramMode,1K - 10K
-Predicate,http://schema.org/educationalProgramMode-input,< 1K
-Predicate,http://schema.org/educationalProgramMode-output,< 1K
-Predicate,http://schema.org/educationalRole,10K - 100K
-Predicate,http://schema.org/educationalRole-input,< 1K
-Predicate,http://schema.org/educationalRole-output,< 1K
-Predicate,http://schema.org/educationalUse,1K - 10K
-Predicate,http://schema.org/educationalUse-input,< 1K
-Predicate,http://schema.org/educationalUse-output,< 1K
-Predicate,http://schema.org/elevation,1K - 10K
-Predicate,http://schema.org/elevation-input,< 1K
-Predicate,http://schema.org/elevation-output,< 1K
-Predicate,http://schema.org/eligibilityToWorkRequirement,< 1K
-Predicate,http://schema.org/eligibilityToWorkRequirement-input,< 1K
-Predicate,http://schema.org/eligibilityToWorkRequirement-output,< 1K
-Predicate,http://schema.org/eligibleCustomerType,1K - 10K
-Predicate,http://schema.org/eligibleCustomerType-input,< 1K
-Predicate,http://schema.org/eligibleCustomerType-output,< 1K
-Predicate,http://schema.org/eligibleDuration,10K - 100K
-Predicate,http://schema.org/eligibleDuration-input,< 1K
-Predicate,http://schema.org/eligibleDuration-output,< 1K
-Predicate,http://schema.org/eligibleQuantity,10K - 100K
-Predicate,http://schema.org/eligibleQuantity-input,< 1K
-Predicate,http://schema.org/eligibleQuantity-output,< 1K
-Predicate,http://schema.org/eligibleRegion,10K - 100K
-Predicate,http://schema.org/eligibleRegion-input,< 1K
-Predicate,http://schema.org/eligibleRegion-output,< 1K
-Predicate,http://schema.org/eligibleTransactionVolume,10K - 100K
-Predicate,http://schema.org/eligibleTransactionVolume-input,< 1K
-Predicate,http://schema.org/eligibleTransactionVolume-output,< 1K
-Predicate,http://schema.org/eligibleWithSupplier,< 1K
-Predicate,http://schema.org/eligibleWithSupplier-input,< 1K
-Predicate,http://schema.org/eligibleWithSupplier-output,< 1K
-Predicate,http://schema.org/email,1M - 10M
-Predicate,http://schema.org/email-input,< 1K
-Predicate,http://schema.org/email-output,< 1K
-Predicate,http://schema.org/embedUrl,1M - 10M
-Predicate,http://schema.org/embedUrl-input,< 1K
-Predicate,http://schema.org/embedUrl-output,< 1K
-Predicate,http://schema.org/embeddedTextCaption,1K - 10K
-Predicate,http://schema.org/embeddedTextCaption-input,< 1K
-Predicate,http://schema.org/embeddedTextCaption-output,< 1K
-Predicate,http://schema.org/emissionsCO2,1K - 10K
-Predicate,http://schema.org/emissionsCO2-input,< 1K
-Predicate,http://schema.org/emissionsCO2-output,< 1K
-Predicate,http://schema.org/employee,100K - 1M
-Predicate,http://schema.org/employee-input,< 1K
-Predicate,http://schema.org/employee-output,< 1K
-Predicate,http://schema.org/employees,1K - 10K
-Predicate,http://schema.org/employees-input,< 1K
-Predicate,http://schema.org/employees-output,< 1K
-Predicate,http://schema.org/employerOverview,1K - 10K
-Predicate,http://schema.org/employerOverview-input,< 1K
-Predicate,http://schema.org/employerOverview-output,< 1K
-Predicate,http://schema.org/employmentType,100K - 1M
-Predicate,http://schema.org/employmentType-input,< 1K
-Predicate,http://schema.org/employmentType-output,< 1K
-Predicate,http://schema.org/employmentUnit,1K - 10K
-Predicate,http://schema.org/employmentUnit-input,< 1K
-Predicate,http://schema.org/employmentUnit-output,< 1K
-Predicate,http://schema.org/encodesBioChemEntity,< 1K
-Predicate,http://schema.org/encodesBioChemEntity-input,< 1K
-Predicate,http://schema.org/encodesBioChemEntity-output,< 1K
-Predicate,http://schema.org/encodesCreativeWork,< 1K
-Predicate,http://schema.org/encodesCreativeWork-input,< 1K
-Predicate,http://schema.org/encodesCreativeWork-output,< 1K
-Predicate,http://schema.org/encoding,100K - 1M
-Predicate,http://schema.org/encoding-input,< 1K
-Predicate,http://schema.org/encoding-output,< 1K
-Predicate,http://schema.org/encodingFormat,10K - 100K
-Predicate,http://schema.org/encodingFormat-input,< 1K
-Predicate,http://schema.org/encodingFormat-output,< 1K
-Predicate,http://schema.org/encodingType,< 1K
-Predicate,http://schema.org/encodingType-input,< 1K
-Predicate,http://schema.org/encodingType-output,< 1K
-Predicate,http://schema.org/encodings,< 1K
-Predicate,http://schema.org/encodings-input,< 1K
-Predicate,http://schema.org/encodings-output,< 1K
-Predicate,http://schema.org/endDate,100K - 1M
-Predicate,http://schema.org/endDate-input,< 1K
-Predicate,http://schema.org/endDate-output,< 1K
-Predicate,http://schema.org/endOffset,10K - 100K
-Predicate,http://schema.org/endOffset-input,< 1K
-Predicate,http://schema.org/endOffset-output,< 1K
-Predicate,http://schema.org/endTime,1K - 10K
-Predicate,http://schema.org/endTime-input,< 1K
-Predicate,http://schema.org/endTime-output,< 1K
-Predicate,http://schema.org/endorsee,< 1K
-Predicate,http://schema.org/endorsee-input,< 1K
-Predicate,http://schema.org/endorsee-output,< 1K
-Predicate,http://schema.org/endorsers,< 1K
-Predicate,http://schema.org/endorsers-input,< 1K
-Predicate,http://schema.org/endorsers-output,< 1K
-Predicate,http://schema.org/energyEfficiencyScaleMax,1K - 10K
-Predicate,http://schema.org/energyEfficiencyScaleMax-input,< 1K
-Predicate,http://schema.org/energyEfficiencyScaleMax-output,< 1K
-Predicate,http://schema.org/energyEfficiencyScaleMin,1K - 10K
-Predicate,http://schema.org/energyEfficiencyScaleMin-input,< 1K
-Predicate,http://schema.org/energyEfficiencyScaleMin-output,< 1K
-Predicate,http://schema.org/engineDisplacement,10K - 100K
-Predicate,http://schema.org/engineDisplacement-input,< 1K
-Predicate,http://schema.org/engineDisplacement-output,< 1K
-Predicate,http://schema.org/enginePower,10K - 100K
-Predicate,http://schema.org/enginePower-input,< 1K
-Predicate,http://schema.org/enginePower-output,< 1K
-Predicate,http://schema.org/engineType,1K - 10K
-Predicate,http://schema.org/engineType-input,< 1K
-Predicate,http://schema.org/engineType-output,< 1K
-Predicate,http://schema.org/entertainmentBusiness,< 1K
-Predicate,http://schema.org/entertainmentBusiness-input,< 1K
-Predicate,http://schema.org/entertainmentBusiness-output,< 1K
-Predicate,http://schema.org/epidemiology,< 1K
-Predicate,http://schema.org/epidemiology-input,< 1K
-Predicate,http://schema.org/epidemiology-output,< 1K
-Predicate,http://schema.org/episode,1K - 10K
-Predicate,http://schema.org/episode-input,< 1K
-Predicate,http://schema.org/episode-output,< 1K
-Predicate,http://schema.org/episodeNumber,10K - 100K
-Predicate,http://schema.org/episodeNumber-input,< 1K
-Predicate,http://schema.org/episodeNumber-output,< 1K
-Predicate,http://schema.org/episodes,< 1K
-Predicate,http://schema.org/episodes-input,< 1K
-Predicate,http://schema.org/episodes-output,< 1K
-Predicate,http://schema.org/equal,< 1K
-Predicate,http://schema.org/equal-input,< 1K
-Predicate,http://schema.org/equal-output,< 1K
-Predicate,http://schema.org/error,1K - 10K
-Predicate,http://schema.org/error-input,< 1K
-Predicate,http://schema.org/error-output,< 1K
-Predicate,http://schema.org/errorCode,< 1K
-Predicate,http://schema.org/errorCode-input,< 1K
-Predicate,http://schema.org/errorCode-output,< 1K
-Predicate,http://schema.org/estimatedCost,10K - 100K
-Predicate,http://schema.org/estimatedCost-input,< 1K
-Predicate,http://schema.org/estimatedCost-output,< 1K
-Predicate,http://schema.org/estimatedFlightDuration,< 1K
-Predicate,http://schema.org/estimatedFlightDuration-input,< 1K
-Predicate,http://schema.org/estimatedFlightDuration-output,< 1K
-Predicate,http://schema.org/estimatedSalary,1K - 10K
-Predicate,http://schema.org/estimatedSalary-input,< 1K
-Predicate,http://schema.org/estimatedSalary-output,< 1K
-Predicate,http://schema.org/estimatesRiskOf,< 1K
-Predicate,http://schema.org/estimatesRiskOf-input,< 1K
-Predicate,http://schema.org/estimatesRiskOf-output,< 1K
-Predicate,http://schema.org/ethicsPolicy,10K - 100K
-Predicate,http://schema.org/ethicsPolicy-input,< 1K
-Predicate,http://schema.org/ethicsPolicy-output,< 1K
-Predicate,http://schema.org/event,10K - 100K
-Predicate,http://schema.org/event-input,< 1K
-Predicate,http://schema.org/event-output,< 1K
-Predicate,http://schema.org/eventAttendanceMode,100K - 1M
-Predicate,http://schema.org/eventAttendanceMode-input,< 1K
-Predicate,http://schema.org/eventAttendanceMode-output,< 1K
-Predicate,http://schema.org/eventSchedule,1K - 10K
-Predicate,http://schema.org/eventSchedule-input,< 1K
-Predicate,http://schema.org/eventSchedule-output,< 1K
-Predicate,http://schema.org/eventStatus,100K - 1M
-Predicate,http://schema.org/eventStatus-input,< 1K
-Predicate,http://schema.org/eventStatus-output,< 1K
-Predicate,http://schema.org/events,1K - 10K
-Predicate,http://schema.org/events-input,< 1K
-Predicate,http://schema.org/events-output,< 1K
-Predicate,http://schema.org/evidenceLevel,< 1K
-Predicate,http://schema.org/evidenceLevel-input,< 1K
-Predicate,http://schema.org/evidenceLevel-output,< 1K
-Predicate,http://schema.org/evidenceOrigin,< 1K
-Predicate,http://schema.org/evidenceOrigin-input,< 1K
-Predicate,http://schema.org/evidenceOrigin-output,< 1K
-Predicate,http://schema.org/exampleOfWork,1K - 10K
-Predicate,http://schema.org/exampleOfWork-input,< 1K
-Predicate,http://schema.org/exampleOfWork-output,< 1K
-Predicate,http://schema.org/exceptDate,< 1K
-Predicate,http://schema.org/exceptDate-input,< 1K
-Predicate,http://schema.org/exceptDate-output,< 1K
-Predicate,http://schema.org/exchangeRateSpread,< 1K
-Predicate,http://schema.org/exchangeRateSpread-input,< 1K
-Predicate,http://schema.org/exchangeRateSpread-output,< 1K
-Predicate,http://schema.org/executableLibraryName,< 1K
-Predicate,http://schema.org/executableLibraryName-input,< 1K
-Predicate,http://schema.org/executableLibraryName-output,< 1K
-Predicate,http://schema.org/exerciseCourse,< 1K
-Predicate,http://schema.org/exerciseCourse-input,< 1K
-Predicate,http://schema.org/exerciseCourse-output,< 1K
-Predicate,http://schema.org/exercisePlan,< 1K
-Predicate,http://schema.org/exercisePlan-input,< 1K
-Predicate,http://schema.org/exercisePlan-output,< 1K
-Predicate,http://schema.org/exerciseRelatedDiet,< 1K
-Predicate,http://schema.org/exerciseRelatedDiet-input,< 1K
-Predicate,http://schema.org/exerciseRelatedDiet-output,< 1K
-Predicate,http://schema.org/exerciseType,< 1K
-Predicate,http://schema.org/exerciseType-input,< 1K
-Predicate,http://schema.org/exerciseType-output,< 1K
-Predicate,http://schema.org/exifData,1K - 10K
-Predicate,http://schema.org/exifData-input,< 1K
-Predicate,http://schema.org/exifData-output,< 1K
-Predicate,http://schema.org/expectedArrivalFrom,< 1K
-Predicate,http://schema.org/expectedArrivalFrom-input,< 1K
-Predicate,http://schema.org/expectedArrivalFrom-output,< 1K
-Predicate,http://schema.org/expectedArrivalUntil,< 1K
-Predicate,http://schema.org/expectedArrivalUntil-input,< 1K
-Predicate,http://schema.org/expectedArrivalUntil-output,< 1K
-Predicate,http://schema.org/expectedPrognosis,< 1K
-Predicate,http://schema.org/expectedPrognosis-input,< 1K
-Predicate,http://schema.org/expectedPrognosis-output,< 1K
-Predicate,http://schema.org/expectsAcceptanceOf,1K - 10K
-Predicate,http://schema.org/expectsAcceptanceOf-input,< 1K
-Predicate,http://schema.org/expectsAcceptanceOf-output,< 1K
-Predicate,http://schema.org/experienceInPlaceOfEducation,1K - 10K
-Predicate,http://schema.org/experienceInPlaceOfEducation-input,< 1K
-Predicate,http://schema.org/experienceInPlaceOfEducation-output,< 1K
-Predicate,http://schema.org/experienceRequirements,10K - 100K
-Predicate,http://schema.org/experienceRequirements-input,< 1K
-Predicate,http://schema.org/experienceRequirements-output,< 1K
-Predicate,http://schema.org/expertConsiderations,< 1K
-Predicate,http://schema.org/expertConsiderations-input,< 1K
-Predicate,http://schema.org/expertConsiderations-output,< 1K
-Predicate,http://schema.org/expires,1K - 10K
-Predicate,http://schema.org/expires-input,< 1K
-Predicate,http://schema.org/expires-output,< 1K
-Predicate,http://schema.org/expressedIn,< 1K
-Predicate,http://schema.org/expressedIn-input,< 1K
-Predicate,http://schema.org/expressedIn-output,< 1K
-Predicate,http://schema.org/extendedAddress,< 1K
-Predicate,http://schema.org/extendedAddress-input,< 1K
-Predicate,http://schema.org/extendedAddress-output,< 1K
-Predicate,http://schema.org/familyName,100K - 1M
-Predicate,http://schema.org/familyName-input,< 1K
-Predicate,http://schema.org/familyName-output,< 1K
-Predicate,http://schema.org/fatContent,10K - 100K
-Predicate,http://schema.org/fatContent-input,< 1K
-Predicate,http://schema.org/fatContent-output,< 1K
-Predicate,http://schema.org/faxNumber,100K - 1M
-Predicate,http://schema.org/faxNumber-input,< 1K
-Predicate,http://schema.org/faxNumber-output,< 1K
-Predicate,http://schema.org/featureList,100K - 1M
-Predicate,http://schema.org/featureList-input,< 1K
-Predicate,http://schema.org/featureList-output,< 1K
-Predicate,http://schema.org/feesAndCommissionsSpecification,1K - 10K
-Predicate,http://schema.org/feesAndCommissionsSpecification-input,< 1K
-Predicate,http://schema.org/feesAndCommissionsSpecification-output,< 1K
-Predicate,http://schema.org/fiberContent,10K - 100K
-Predicate,http://schema.org/fiberContent-input,< 1K
-Predicate,http://schema.org/fiberContent-output,< 1K
-Predicate,http://schema.org/fileFormat,10K - 100K
-Predicate,http://schema.org/fileFormat-input,< 1K
-Predicate,http://schema.org/fileFormat-output,< 1K
-Predicate,http://schema.org/fileSize,10K - 100K
-Predicate,http://schema.org/fileSize-input,< 1K
-Predicate,http://schema.org/fileSize-output,< 1K
-Predicate,http://schema.org/financialAidEligible,< 1K
-Predicate,http://schema.org/financialAidEligible-input,< 1K
-Predicate,http://schema.org/financialAidEligible-output,< 1K
-Predicate,http://schema.org/firstAppearance,< 1K
-Predicate,http://schema.org/firstAppearance-input,< 1K
-Predicate,http://schema.org/firstAppearance-output,< 1K
-Predicate,http://schema.org/firstPerformance,< 1K
-Predicate,http://schema.org/firstPerformance-input,< 1K
-Predicate,http://schema.org/firstPerformance-output,< 1K
-Predicate,http://schema.org/flightDistance,< 1K
-Predicate,http://schema.org/flightDistance-input,< 1K
-Predicate,http://schema.org/flightDistance-output,< 1K
-Predicate,http://schema.org/flightNumber,< 1K
-Predicate,http://schema.org/flightNumber-input,< 1K
-Predicate,http://schema.org/flightNumber-output,< 1K
-Predicate,http://schema.org/floorLevel,1K - 10K
-Predicate,http://schema.org/floorLevel-input,< 1K
-Predicate,http://schema.org/floorLevel-output,< 1K
-Predicate,http://schema.org/floorLimit,< 1K
-Predicate,http://schema.org/floorLimit-input,< 1K
-Predicate,http://schema.org/floorLimit-output,< 1K
-Predicate,http://schema.org/floorSize,100K - 1M
-Predicate,http://schema.org/floorSize-input,< 1K
-Predicate,http://schema.org/floorSize-output,< 1K
-Predicate,http://schema.org/followee,< 1K
-Predicate,http://schema.org/followee-input,< 1K
-Predicate,http://schema.org/followee-output,< 1K
-Predicate,http://schema.org/follows,< 1K
-Predicate,http://schema.org/follows-input,< 1K
-Predicate,http://schema.org/follows-output,< 1K
-Predicate,http://schema.org/followup,1K - 10K
-Predicate,http://schema.org/followup-input,< 1K
-Predicate,http://schema.org/followup-output,< 1K
-Predicate,http://schema.org/foodEstablishment,< 1K
-Predicate,http://schema.org/foodEstablishment-input,< 1K
-Predicate,http://schema.org/foodEstablishment-output,< 1K
-Predicate,http://schema.org/foodEvent,< 1K
-Predicate,http://schema.org/foodEvent-input,< 1K
-Predicate,http://schema.org/foodEvent-output,< 1K
-Predicate,http://schema.org/foodWarning,< 1K
-Predicate,http://schema.org/foodWarning-input,< 1K
-Predicate,http://schema.org/foodWarning-output,< 1K
-Predicate,http://schema.org/founder,100K - 1M
-Predicate,http://schema.org/founder-input,< 1K
-Predicate,http://schema.org/founder-output,< 1K
-Predicate,http://schema.org/founders,10K - 100K
-Predicate,http://schema.org/founders-input,< 1K
-Predicate,http://schema.org/founders-output,< 1K
-Predicate,http://schema.org/foundingDate,1M - 10M
-Predicate,http://schema.org/foundingDate-input,< 1K
-Predicate,http://schema.org/foundingDate-output,< 1K
-Predicate,http://schema.org/foundingLocation,100K - 1M
-Predicate,http://schema.org/foundingLocation-input,< 1K
-Predicate,http://schema.org/foundingLocation-output,< 1K
-Predicate,http://schema.org/free,1K - 10K
-Predicate,http://schema.org/free-input,< 1K
-Predicate,http://schema.org/free-output,< 1K
-Predicate,http://schema.org/freeShippingThreshold,10K - 100K
-Predicate,http://schema.org/freeShippingThreshold-input,< 1K
-Predicate,http://schema.org/freeShippingThreshold-output,< 1K
-Predicate,http://schema.org/frequency,< 1K
-Predicate,http://schema.org/frequency-input,< 1K
-Predicate,http://schema.org/frequency-output,< 1K
-Predicate,http://schema.org/fromLocation,1K - 10K
-Predicate,http://schema.org/fromLocation-input,< 1K
-Predicate,http://schema.org/fromLocation-output,< 1K
-Predicate,http://schema.org/fuelCapacity,1K - 10K
-Predicate,http://schema.org/fuelCapacity-input,< 1K
-Predicate,http://schema.org/fuelCapacity-output,< 1K
-Predicate,http://schema.org/fuelConsumption,1K - 10K
-Predicate,http://schema.org/fuelConsumption-input,< 1K
-Predicate,http://schema.org/fuelConsumption-output,< 1K
-Predicate,http://schema.org/fuelEfficiency,10K - 100K
-Predicate,http://schema.org/fuelEfficiency-input,< 1K
-Predicate,http://schema.org/fuelEfficiency-output,< 1K
-Predicate,http://schema.org/fuelType,10K - 100K
-Predicate,http://schema.org/fuelType-input,< 1K
-Predicate,http://schema.org/fuelType-output,< 1K
-Predicate,http://schema.org/fulfillmentType,10K - 100K
-Predicate,http://schema.org/fulfillmentType-input,< 1K
-Predicate,http://schema.org/fulfillmentType-output,< 1K
-Predicate,http://schema.org/functionalClass,< 1K
-Predicate,http://schema.org/functionalClass-input,< 1K
-Predicate,http://schema.org/functionalClass-output,< 1K
-Predicate,http://schema.org/fundedItem,< 1K
-Predicate,http://schema.org/fundedItem-input,< 1K
-Predicate,http://schema.org/fundedItem-output,< 1K
-Predicate,http://schema.org/funder,10K - 100K
-Predicate,http://schema.org/funder-input,< 1K
-Predicate,http://schema.org/funder-output,< 1K
-Predicate,http://schema.org/funding,1K - 10K
-Predicate,http://schema.org/funding-input,< 1K
-Predicate,http://schema.org/funding-output,< 1K
-Predicate,http://schema.org/game,10K - 100K
-Predicate,http://schema.org/game-input,< 1K
-Predicate,http://schema.org/game-output,< 1K
-Predicate,http://schema.org/gameAvailabilityType,< 1K
-Predicate,http://schema.org/gameAvailabilityType-input,< 1K
-Predicate,http://schema.org/gameAvailabilityType-output,< 1K
-Predicate,http://schema.org/gameEdition,< 1K
-Predicate,http://schema.org/gameEdition-input,< 1K
-Predicate,http://schema.org/gameEdition-output,< 1K
-Predicate,http://schema.org/gameItem,10K - 100K
-Predicate,http://schema.org/gameItem-input,< 1K
-Predicate,http://schema.org/gameItem-output,< 1K
-Predicate,http://schema.org/gameLocation,10K - 100K
-Predicate,http://schema.org/gameLocation-input,< 1K
-Predicate,http://schema.org/gameLocation-output,< 1K
-Predicate,http://schema.org/gamePlatform,10K - 100K
-Predicate,http://schema.org/gamePlatform-input,< 1K
-Predicate,http://schema.org/gamePlatform-output,< 1K
-Predicate,http://schema.org/gameServer,< 1K
-Predicate,http://schema.org/gameServer-input,< 1K
-Predicate,http://schema.org/gameServer-output,< 1K
-Predicate,http://schema.org/gameTip,< 1K
-Predicate,http://schema.org/gameTip-input,< 1K
-Predicate,http://schema.org/gameTip-output,< 1K
-Predicate,http://schema.org/gender,10K - 100K
-Predicate,http://schema.org/gender-input,< 1K
-Predicate,http://schema.org/gender-output,< 1K
-Predicate,http://schema.org/genre,100K - 1M
-Predicate,http://schema.org/genre-input,< 1K
-Predicate,http://schema.org/genre-output,< 1K
-Predicate,http://schema.org/geo,1M - 10M
-Predicate,http://schema.org/geo-input,< 1K
-Predicate,http://schema.org/geo-output,< 1K
-Predicate,http://schema.org/geoContains,< 1K
-Predicate,http://schema.org/geoContains-input,< 1K
-Predicate,http://schema.org/geoContains-output,< 1K
-Predicate,http://schema.org/geoCoveredBy,< 1K
-Predicate,http://schema.org/geoCoveredBy-input,< 1K
-Predicate,http://schema.org/geoCoveredBy-output,< 1K
-Predicate,http://schema.org/geoCovers,< 1K
-Predicate,http://schema.org/geoCovers-input,< 1K
-Predicate,http://schema.org/geoCovers-output,< 1K
-Predicate,http://schema.org/geoCrosses,< 1K
-Predicate,http://schema.org/geoCrosses-input,< 1K
-Predicate,http://schema.org/geoCrosses-output,< 1K
-Predicate,http://schema.org/geoDisjoint,< 1K
-Predicate,http://schema.org/geoDisjoint-input,< 1K
-Predicate,http://schema.org/geoDisjoint-output,< 1K
-Predicate,http://schema.org/geoEquals,< 1K
-Predicate,http://schema.org/geoEquals-input,< 1K
-Predicate,http://schema.org/geoEquals-output,< 1K
-Predicate,http://schema.org/geoIntersects,< 1K
-Predicate,http://schema.org/geoIntersects-input,< 1K
-Predicate,http://schema.org/geoIntersects-output,< 1K
-Predicate,http://schema.org/geoMidpoint,100K - 1M
-Predicate,http://schema.org/geoMidpoint-input,< 1K
-Predicate,http://schema.org/geoMidpoint-output,< 1K
-Predicate,http://schema.org/geoOverlaps,< 1K
-Predicate,http://schema.org/geoOverlaps-input,< 1K
-Predicate,http://schema.org/geoOverlaps-output,< 1K
-Predicate,http://schema.org/geoRadius,100K - 1M
-Predicate,http://schema.org/geoRadius-input,< 1K
-Predicate,http://schema.org/geoRadius-output,< 1K
-Predicate,http://schema.org/geoTouches,< 1K
-Predicate,http://schema.org/geoTouches-input,< 1K
-Predicate,http://schema.org/geoTouches-output,< 1K
-Predicate,http://schema.org/geoWithin,< 1K
-Predicate,http://schema.org/geoWithin-input,< 1K
-Predicate,http://schema.org/geoWithin-output,< 1K
-Predicate,http://schema.org/geographicArea,10K - 100K
-Predicate,http://schema.org/geographicArea-input,< 1K
-Predicate,http://schema.org/geographicArea-output,< 1K
-Predicate,http://schema.org/gettingTestedInfo,< 1K
-Predicate,http://schema.org/gettingTestedInfo-input,< 1K
-Predicate,http://schema.org/gettingTestedInfo-output,< 1K
-Predicate,http://schema.org/givenName,100K - 1M
-Predicate,http://schema.org/givenName-input,< 1K
-Predicate,http://schema.org/givenName-output,< 1K
-Predicate,http://schema.org/globalLocationNumber,1K - 10K
-Predicate,http://schema.org/globalLocationNumber-input,< 1K
-Predicate,http://schema.org/globalLocationNumber-output,< 1K
-Predicate,http://schema.org/governmentBenefitsInfo,< 1K
-Predicate,http://schema.org/governmentBenefitsInfo-input,< 1K
-Predicate,http://schema.org/governmentBenefitsInfo-output,< 1K
-Predicate,http://schema.org/gracePeriod,< 1K
-Predicate,http://schema.org/gracePeriod-input,< 1K
-Predicate,http://schema.org/gracePeriod-output,< 1K
-Predicate,http://schema.org/grantee,< 1K
-Predicate,http://schema.org/grantee-input,< 1K
-Predicate,http://schema.org/grantee-output,< 1K
-Predicate,http://schema.org/greater,< 1K
-Predicate,http://schema.org/greater-input,< 1K
-Predicate,http://schema.org/greater-output,< 1K
-Predicate,http://schema.org/greaterOrEqual,< 1K
-Predicate,http://schema.org/greaterOrEqual-input,< 1K
-Predicate,http://schema.org/greaterOrEqual-output,< 1K
-Predicate,http://schema.org/gtin,100K - 1M
-Predicate,http://schema.org/gtin-input,< 1K
-Predicate,http://schema.org/gtin-output,< 1K
-Predicate,http://schema.org/gtin12,100K - 1M
-Predicate,http://schema.org/gtin12-input,< 1K
-Predicate,http://schema.org/gtin12-output,< 1K
-Predicate,http://schema.org/gtin13,100K - 1M
-Predicate,http://schema.org/gtin13-input,< 1K
-Predicate,http://schema.org/gtin13-output,< 1K
-Predicate,http://schema.org/gtin14,10K - 100K
-Predicate,http://schema.org/gtin14-input,< 1K
-Predicate,http://schema.org/gtin14-output,< 1K
-Predicate,http://schema.org/gtin8,10K - 100K
-Predicate,http://schema.org/gtin8-input,< 1K
-Predicate,http://schema.org/gtin8-output,< 1K
-Predicate,http://schema.org/guideline,< 1K
-Predicate,http://schema.org/guideline-input,< 1K
-Predicate,http://schema.org/guideline-output,< 1K
-Predicate,http://schema.org/guidelineDate,< 1K
-Predicate,http://schema.org/guidelineDate-input,< 1K
-Predicate,http://schema.org/guidelineDate-output,< 1K
-Predicate,http://schema.org/guidelineSubject,< 1K
-Predicate,http://schema.org/guidelineSubject-input,< 1K
-Predicate,http://schema.org/guidelineSubject-output,< 1K
-Predicate,http://schema.org/handlingTime,100K - 1M
-Predicate,http://schema.org/handlingTime-input,< 1K
-Predicate,http://schema.org/handlingTime-output,< 1K
-Predicate,http://schema.org/hasAdultConsideration,< 1K
-Predicate,http://schema.org/hasAdultConsideration-input,< 1K
-Predicate,http://schema.org/hasAdultConsideration-output,< 1K
-Predicate,http://schema.org/hasBioChemEntityPart,< 1K
-Predicate,http://schema.org/hasBioChemEntityPart-input,< 1K
-Predicate,http://schema.org/hasBioChemEntityPart-output,< 1K
-Predicate,http://schema.org/hasBioPolymerSequence,< 1K
-Predicate,http://schema.org/hasBioPolymerSequence-input,< 1K
-Predicate,http://schema.org/hasBioPolymerSequence-output,< 1K
-Predicate,http://schema.org/hasBroadcastChannel,< 1K
-Predicate,http://schema.org/hasBroadcastChannel-input,< 1K
-Predicate,http://schema.org/hasBroadcastChannel-output,< 1K
-Predicate,http://schema.org/hasCategoryCode,< 1K
-Predicate,http://schema.org/hasCategoryCode-input,< 1K
-Predicate,http://schema.org/hasCategoryCode-output,< 1K
-Predicate,http://schema.org/hasCertification,1K - 10K
-Predicate,http://schema.org/hasCertification-input,< 1K
-Predicate,http://schema.org/hasCertification-output,< 1K
-Predicate,http://schema.org/hasCourse,1K - 10K
-Predicate,http://schema.org/hasCourse-input,< 1K
-Predicate,http://schema.org/hasCourse-output,< 1K
-Predicate,http://schema.org/hasCourseInstance,10K - 100K
-Predicate,http://schema.org/hasCourseInstance-input,< 1K
-Predicate,http://schema.org/hasCourseInstance-output,< 1K
-Predicate,http://schema.org/hasCredential,100K - 1M
-Predicate,http://schema.org/hasCredential-input,< 1K
-Predicate,http://schema.org/hasCredential-output,< 1K
-Predicate,http://schema.org/hasDefinedTerm,10K - 100K
-Predicate,http://schema.org/hasDefinedTerm-input,< 1K
-Predicate,http://schema.org/hasDefinedTerm-output,< 1K
-Predicate,http://schema.org/hasDeliveryMethod,< 1K
-Predicate,http://schema.org/hasDeliveryMethod-input,< 1K
-Predicate,http://schema.org/hasDeliveryMethod-output,< 1K
-Predicate,http://schema.org/hasDigitalDocumentPermission,< 1K
-Predicate,http://schema.org/hasDigitalDocumentPermission-input,< 1K
-Predicate,http://schema.org/hasDigitalDocumentPermission-output,< 1K
-Predicate,http://schema.org/hasDriveThroughService,< 1K
-Predicate,http://schema.org/hasDriveThroughService-input,< 1K
-Predicate,http://schema.org/hasDriveThroughService-output,< 1K
-Predicate,http://schema.org/hasEnergyConsumptionDetails,1K - 10K
-Predicate,http://schema.org/hasEnergyConsumptionDetails-input,< 1K
-Predicate,http://schema.org/hasEnergyConsumptionDetails-output,< 1K
-Predicate,http://schema.org/hasEnergyEfficiencyCategory,1K - 10K
-Predicate,http://schema.org/hasEnergyEfficiencyCategory-input,< 1K
-Predicate,http://schema.org/hasEnergyEfficiencyCategory-output,< 1K
-Predicate,http://schema.org/hasGS1DigitalLink,< 1K
-Predicate,http://schema.org/hasGS1DigitalLink-input,< 1K
-Predicate,http://schema.org/hasGS1DigitalLink-output,< 1K
-Predicate,http://schema.org/hasHealthAspect,< 1K
-Predicate,http://schema.org/hasHealthAspect-input,< 1K
-Predicate,http://schema.org/hasHealthAspect-output,< 1K
-Predicate,http://schema.org/hasMap,100K - 1M
-Predicate,http://schema.org/hasMap-input,< 1K
-Predicate,http://schema.org/hasMap-output,< 1K
-Predicate,http://schema.org/hasMeasurement,1K - 10K
-Predicate,http://schema.org/hasMeasurement-input,< 1K
-Predicate,http://schema.org/hasMeasurement-output,< 1K
-Predicate,http://schema.org/hasMemberProgram,1K - 10K
-Predicate,http://schema.org/hasMemberProgram-input,< 1K
-Predicate,http://schema.org/hasMemberProgram-output,< 1K
-Predicate,http://schema.org/hasMenu,10K - 100K
-Predicate,http://schema.org/hasMenu-input,< 1K
-Predicate,http://schema.org/hasMenu-output,< 1K
-Predicate,http://schema.org/hasMenuItem,10K - 100K
-Predicate,http://schema.org/hasMenuItem-input,< 1K
-Predicate,http://schema.org/hasMenuItem-output,< 1K
-Predicate,http://schema.org/hasMenuSection,10K - 100K
-Predicate,http://schema.org/hasMenuSection-input,< 1K
-Predicate,http://schema.org/hasMenuSection-output,< 1K
-Predicate,http://schema.org/hasMerchantReturnPolicy,100K - 1M
-Predicate,http://schema.org/hasMerchantReturnPolicy-input,< 1K
-Predicate,http://schema.org/hasMerchantReturnPolicy-output,< 1K
-Predicate,http://schema.org/hasMolecularFunction,< 1K
-Predicate,http://schema.org/hasMolecularFunction-input,< 1K
-Predicate,http://schema.org/hasMolecularFunction-output,< 1K
-Predicate,http://schema.org/hasOccupation,10K - 100K
-Predicate,http://schema.org/hasOccupation-input,< 1K
-Predicate,http://schema.org/hasOccupation-output,< 1K
-Predicate,http://schema.org/hasOfferCatalog,100K - 1M
-Predicate,http://schema.org/hasOfferCatalog-input,< 1K
-Predicate,http://schema.org/hasOfferCatalog-output,< 1K
-Predicate,http://schema.org/hasPOS,1K - 10K
-Predicate,http://schema.org/hasPOS-input,< 1K
-Predicate,http://schema.org/hasPOS-output,< 1K
-Predicate,http://schema.org/hasPart,100K - 1M
-Predicate,http://schema.org/hasPart-input,< 1K
-Predicate,http://schema.org/hasPart-output,< 1K
-Predicate,http://schema.org/hasParticipationOffer,< 1K
-Predicate,http://schema.org/hasParticipationOffer-input,< 1K
-Predicate,http://schema.org/hasParticipationOffer-output,< 1K
-Predicate,http://schema.org/hasProductReturnPolicy,< 1K
-Predicate,http://schema.org/hasProductReturnPolicy-input,< 1K
-Predicate,http://schema.org/hasProductReturnPolicy-output,< 1K
-Predicate,http://schema.org/hasRepresentation,< 1K
-Predicate,http://schema.org/hasRepresentation-input,< 1K
-Predicate,http://schema.org/hasRepresentation-output,< 1K
-Predicate,http://schema.org/hasShippingService,10K - 100K
-Predicate,http://schema.org/hasShippingService-input,< 1K
-Predicate,http://schema.org/hasShippingService-output,< 1K
-Predicate,http://schema.org/hasSponsorshipOffer,< 1K
-Predicate,http://schema.org/hasSponsorshipOffer-input,< 1K
-Predicate,http://schema.org/hasSponsorshipOffer-output,< 1K
-Predicate,http://schema.org/hasStore,< 1K
-Predicate,http://schema.org/hasStore-input,< 1K
-Predicate,http://schema.org/hasStore-output,< 1K
-Predicate,http://schema.org/hasTierBenefit,1K - 10K
-Predicate,http://schema.org/hasTierBenefit-input,< 1K
-Predicate,http://schema.org/hasTierBenefit-output,< 1K
-Predicate,http://schema.org/hasTierRequirement,< 1K
-Predicate,http://schema.org/hasTierRequirement-input,< 1K
-Predicate,http://schema.org/hasTierRequirement-output,< 1K
-Predicate,http://schema.org/hasTiers,1K - 10K
-Predicate,http://schema.org/hasTiers-input,< 1K
-Predicate,http://schema.org/hasTiers-output,< 1K
-Predicate,http://schema.org/hasVariant,100K - 1M
-Predicate,http://schema.org/hasVariant-input,< 1K
-Predicate,http://schema.org/hasVariant-output,< 1K
-Predicate,http://schema.org/headline,10M+
-Predicate,http://schema.org/headline-input,< 1K
-Predicate,http://schema.org/headline-output,< 1K
-Predicate,http://schema.org/healthCondition,1K - 10K
-Predicate,http://schema.org/healthCondition-input,< 1K
-Predicate,http://schema.org/healthCondition-output,< 1K
-Predicate,http://schema.org/healthPlanCoinsuranceOption,< 1K
-Predicate,http://schema.org/healthPlanCoinsuranceOption-input,< 1K
-Predicate,http://schema.org/healthPlanCoinsuranceOption-output,< 1K
-Predicate,http://schema.org/healthPlanCoinsuranceRate,< 1K
-Predicate,http://schema.org/healthPlanCoinsuranceRate-input,< 1K
-Predicate,http://schema.org/healthPlanCoinsuranceRate-output,< 1K
-Predicate,http://schema.org/healthPlanCopay,< 1K
-Predicate,http://schema.org/healthPlanCopay-input,< 1K
-Predicate,http://schema.org/healthPlanCopay-output,< 1K
-Predicate,http://schema.org/healthPlanCopayOption,< 1K
-Predicate,http://schema.org/healthPlanCopayOption-input,< 1K
-Predicate,http://schema.org/healthPlanCopayOption-output,< 1K
-Predicate,http://schema.org/healthPlanCostSharing,< 1K
-Predicate,http://schema.org/healthPlanCostSharing-input,< 1K
-Predicate,http://schema.org/healthPlanCostSharing-output,< 1K
-Predicate,http://schema.org/healthPlanDrugOption,< 1K
-Predicate,http://schema.org/healthPlanDrugOption-input,< 1K
-Predicate,http://schema.org/healthPlanDrugOption-output,< 1K
-Predicate,http://schema.org/healthPlanDrugTier,< 1K
-Predicate,http://schema.org/healthPlanDrugTier-input,< 1K
-Predicate,http://schema.org/healthPlanDrugTier-output,< 1K
-Predicate,http://schema.org/healthPlanId,< 1K
-Predicate,http://schema.org/healthPlanId-input,< 1K
-Predicate,http://schema.org/healthPlanId-output,< 1K
-Predicate,http://schema.org/healthPlanMarketingUrl,< 1K
-Predicate,http://schema.org/healthPlanMarketingUrl-input,< 1K
-Predicate,http://schema.org/healthPlanMarketingUrl-output,< 1K
-Predicate,http://schema.org/healthPlanNetworkId,< 1K
-Predicate,http://schema.org/healthPlanNetworkId-input,< 1K
-Predicate,http://schema.org/healthPlanNetworkId-output,< 1K
-Predicate,http://schema.org/healthPlanNetworkTier,< 1K
-Predicate,http://schema.org/healthPlanNetworkTier-input,< 1K
-Predicate,http://schema.org/healthPlanNetworkTier-output,< 1K
-Predicate,http://schema.org/healthPlanPharmacyCategory,< 1K
-Predicate,http://schema.org/healthPlanPharmacyCategory-input,< 1K
-Predicate,http://schema.org/healthPlanPharmacyCategory-output,< 1K
-Predicate,http://schema.org/healthcareReportingData,< 1K
-Predicate,http://schema.org/healthcareReportingData-input,< 1K
-Predicate,http://schema.org/healthcareReportingData-output,< 1K
-Predicate,http://schema.org/height,10M+
-Predicate,http://schema.org/height-input,< 1K
-Predicate,http://schema.org/height-output,< 1K
-Predicate,http://schema.org/highPrice,1M - 10M
-Predicate,http://schema.org/highPrice-input,< 1K
-Predicate,http://schema.org/highPrice-output,< 1K
-Predicate,http://schema.org/hiringOrganization,100K - 1M
-Predicate,http://schema.org/hiringOrganization-input,< 1K
-Predicate,http://schema.org/hiringOrganization-output,< 1K
-Predicate,http://schema.org/holdingArchive,< 1K
-Predicate,http://schema.org/holdingArchive-input,< 1K
-Predicate,http://schema.org/holdingArchive-output,< 1K
-Predicate,http://schema.org/homeLocation,10K - 100K
-Predicate,http://schema.org/homeLocation-input,< 1K
-Predicate,http://schema.org/homeLocation-output,< 1K
-Predicate,http://schema.org/homeTeam,10K - 100K
-Predicate,http://schema.org/homeTeam-input,< 1K
-Predicate,http://schema.org/homeTeam-output,< 1K
-Predicate,http://schema.org/honorificPrefix,10K - 100K
-Predicate,http://schema.org/honorificPrefix-input,< 1K
-Predicate,http://schema.org/honorificPrefix-output,< 1K
-Predicate,http://schema.org/honorificSuffix,10K - 100K
-Predicate,http://schema.org/honorificSuffix-input,< 1K
-Predicate,http://schema.org/honorificSuffix-output,< 1K
-Predicate,http://schema.org/hospitalAffiliation,1K - 10K
-Predicate,http://schema.org/hospitalAffiliation-input,< 1K
-Predicate,http://schema.org/hospitalAffiliation-output,< 1K
-Predicate,http://schema.org/hostingOrganization,1K - 10K
-Predicate,http://schema.org/hostingOrganization-input,< 1K
-Predicate,http://schema.org/hostingOrganization-output,< 1K
-Predicate,http://schema.org/hoursAvailable,100K - 1M
-Predicate,http://schema.org/hoursAvailable-input,< 1K
-Predicate,http://schema.org/hoursAvailable-output,< 1K
-Predicate,http://schema.org/howPerformed,1K - 10K
-Predicate,http://schema.org/howPerformed-input,< 1K
-Predicate,http://schema.org/howPerformed-output,< 1K
-Predicate,http://schema.org/httpMethod,1K - 10K
-Predicate,http://schema.org/httpMethod-input,< 1K
-Predicate,http://schema.org/httpMethod-output,< 1K
-Predicate,http://schema.org/iataCode,1K - 10K
-Predicate,http://schema.org/iataCode-input,< 1K
-Predicate,http://schema.org/iataCode-output,< 1K
-Predicate,http://schema.org/icaoCode,1K - 10K
-Predicate,http://schema.org/icaoCode-input,< 1K
-Predicate,http://schema.org/icaoCode-output,< 1K
-Predicate,http://schema.org/identifier,100K - 1M
-Predicate,http://schema.org/identifier-input,< 1K
-Predicate,http://schema.org/identifier-output,< 1K
-Predicate,http://schema.org/identifyingExam,< 1K
-Predicate,http://schema.org/identifyingExam-input,< 1K
-Predicate,http://schema.org/identifyingExam-output,< 1K
-Predicate,http://schema.org/identifyingTest,< 1K
-Predicate,http://schema.org/identifyingTest-input,< 1K
-Predicate,http://schema.org/identifyingTest-output,< 1K
-Predicate,http://schema.org/illustrator,1K - 10K
-Predicate,http://schema.org/illustrator-input,< 1K
-Predicate,http://schema.org/illustrator-output,< 1K
-Predicate,http://schema.org/image,10M+
-Predicate,http://schema.org/image-input,< 1K
-Predicate,http://schema.org/image-output,< 1K
-Predicate,http://schema.org/imagingTechnique,< 1K
-Predicate,http://schema.org/imagingTechnique-input,< 1K
-Predicate,http://schema.org/imagingTechnique-output,< 1K
-Predicate,http://schema.org/inAlbum,10K - 100K
-Predicate,http://schema.org/inAlbum-input,< 1K
-Predicate,http://schema.org/inAlbum-output,< 1K
-Predicate,http://schema.org/inBroadcastLineup,< 1K
-Predicate,http://schema.org/inBroadcastLineup-input,< 1K
-Predicate,http://schema.org/inBroadcastLineup-output,< 1K
-Predicate,http://schema.org/inChI,< 1K
-Predicate,http://schema.org/inChI-input,< 1K
-Predicate,http://schema.org/inChI-output,< 1K
-Predicate,http://schema.org/inChIKey,< 1K
-Predicate,http://schema.org/inChIKey-input,< 1K
-Predicate,http://schema.org/inChIKey-output,< 1K
-Predicate,http://schema.org/inCodeSet,1K - 10K
-Predicate,http://schema.org/inCodeSet-input,< 1K
-Predicate,http://schema.org/inCodeSet-output,< 1K
-Predicate,http://schema.org/inDefinedTermSet,10K - 100K
-Predicate,http://schema.org/inDefinedTermSet-input,< 1K
-Predicate,http://schema.org/inDefinedTermSet-output,< 1K
-Predicate,http://schema.org/inLanguage,10M+
-Predicate,http://schema.org/inLanguage-input,< 1K
-Predicate,http://schema.org/inLanguage-output,< 1K
-Predicate,http://schema.org/inPlaylist,< 1K
-Predicate,http://schema.org/inPlaylist-input,< 1K
-Predicate,http://schema.org/inPlaylist-output,< 1K
-Predicate,http://schema.org/inProductGroupWithID,10K - 100K
-Predicate,http://schema.org/inProductGroupWithID-input,< 1K
-Predicate,http://schema.org/inProductGroupWithID-output,< 1K
-Predicate,http://schema.org/inStoreReturnsOffered,1K - 10K
-Predicate,http://schema.org/inStoreReturnsOffered-input,< 1K
-Predicate,http://schema.org/inStoreReturnsOffered-output,< 1K
-Predicate,http://schema.org/inSupportOf,< 1K
-Predicate,http://schema.org/inSupportOf-input,< 1K
-Predicate,http://schema.org/inSupportOf-output,< 1K
-Predicate,http://schema.org/incentiveAmount,< 1K
-Predicate,http://schema.org/incentiveAmount-input,< 1K
-Predicate,http://schema.org/incentiveAmount-output,< 1K
-Predicate,http://schema.org/incentiveCompensation,1K - 10K
-Predicate,http://schema.org/incentiveCompensation-input,< 1K
-Predicate,http://schema.org/incentiveCompensation-output,< 1K
-Predicate,http://schema.org/incentiveStatus,< 1K
-Predicate,http://schema.org/incentiveStatus-input,< 1K
-Predicate,http://schema.org/incentiveStatus-output,< 1K
-Predicate,http://schema.org/incentiveType,< 1K
-Predicate,http://schema.org/incentiveType-input,< 1K
-Predicate,http://schema.org/incentiveType-output,< 1K
-Predicate,http://schema.org/incentives,< 1K
-Predicate,http://schema.org/incentives-input,< 1K
-Predicate,http://schema.org/incentives-output,< 1K
-Predicate,http://schema.org/incentivizedItem,< 1K
-Predicate,http://schema.org/incentivizedItem-input,< 1K
-Predicate,http://schema.org/incentivizedItem-output,< 1K
-Predicate,http://schema.org/includedComposition,< 1K
-Predicate,http://schema.org/includedComposition-input,< 1K
-Predicate,http://schema.org/includedComposition-output,< 1K
-Predicate,http://schema.org/includedDataCatalog,< 1K
-Predicate,http://schema.org/includedDataCatalog-input,< 1K
-Predicate,http://schema.org/includedDataCatalog-output,< 1K
-Predicate,http://schema.org/includedInDataCatalog,1K - 10K
-Predicate,http://schema.org/includedInDataCatalog-input,< 1K
-Predicate,http://schema.org/includedInDataCatalog-output,< 1K
-Predicate,http://schema.org/includedInHealthInsurancePlan,< 1K
-Predicate,http://schema.org/includedInHealthInsurancePlan-input,< 1K
-Predicate,http://schema.org/includedInHealthInsurancePlan-output,< 1K
-Predicate,http://schema.org/includedRiskFactor,< 1K
-Predicate,http://schema.org/includedRiskFactor-input,< 1K
-Predicate,http://schema.org/includedRiskFactor-output,< 1K
-Predicate,http://schema.org/includesAttraction,1K - 10K
-Predicate,http://schema.org/includesAttraction-input,< 1K
-Predicate,http://schema.org/includesAttraction-output,< 1K
-Predicate,http://schema.org/includesHealthPlanFormulary,< 1K
-Predicate,http://schema.org/includesHealthPlanFormulary-input,< 1K
-Predicate,http://schema.org/includesHealthPlanFormulary-output,< 1K
-Predicate,http://schema.org/includesHealthPlanNetwork,< 1K
-Predicate,http://schema.org/includesHealthPlanNetwork-input,< 1K
-Predicate,http://schema.org/includesHealthPlanNetwork-output,< 1K
-Predicate,http://schema.org/includesObject,1K - 10K
-Predicate,http://schema.org/includesObject-input,< 1K
-Predicate,http://schema.org/includesObject-output,< 1K
-Predicate,http://schema.org/incomeLimit,< 1K
-Predicate,http://schema.org/incomeLimit-input,< 1K
-Predicate,http://schema.org/incomeLimit-output,< 1K
-Predicate,http://schema.org/increasesRiskOf,< 1K
-Predicate,http://schema.org/increasesRiskOf-input,< 1K
-Predicate,http://schema.org/increasesRiskOf-output,< 1K
-Predicate,http://schema.org/industry,10K - 100K
-Predicate,http://schema.org/industry-input,< 1K
-Predicate,http://schema.org/industry-output,< 1K
-Predicate,http://schema.org/ineligibleRegion,< 1K
-Predicate,http://schema.org/ineligibleRegion-input,< 1K
-Predicate,http://schema.org/ineligibleRegion-output,< 1K
-Predicate,http://schema.org/infectiousAgent,< 1K
-Predicate,http://schema.org/infectiousAgent-input,< 1K
-Predicate,http://schema.org/infectiousAgent-output,< 1K
-Predicate,http://schema.org/infectiousAgentClass,< 1K
-Predicate,http://schema.org/infectiousAgentClass-input,< 1K
-Predicate,http://schema.org/infectiousAgentClass-output,< 1K
-Predicate,http://schema.org/ingredients,1K - 10K
-Predicate,http://schema.org/ingredients-input,< 1K
-Predicate,http://schema.org/ingredients-output,< 1K
-Predicate,http://schema.org/inker,< 1K
-Predicate,http://schema.org/inker-input,< 1K
-Predicate,http://schema.org/inker-output,< 1K
-Predicate,http://schema.org/insertion,< 1K
-Predicate,http://schema.org/insertion-input,< 1K
-Predicate,http://schema.org/insertion-output,< 1K
-Predicate,http://schema.org/installUrl,100K - 1M
-Predicate,http://schema.org/installUrl-input,< 1K
-Predicate,http://schema.org/installUrl-output,< 1K
-Predicate,http://schema.org/instructor,10K - 100K
-Predicate,http://schema.org/instructor-input,< 1K
-Predicate,http://schema.org/instructor-output,< 1K
-Predicate,http://schema.org/instrument,1K - 10K
-Predicate,http://schema.org/instrument-input,< 1K
-Predicate,http://schema.org/instrument-output,< 1K
-Predicate,http://schema.org/intensity,< 1K
-Predicate,http://schema.org/intensity-input,< 1K
-Predicate,http://schema.org/intensity-output,< 1K
-Predicate,http://schema.org/interactingDrug,< 1K
-Predicate,http://schema.org/interactingDrug-input,< 1K
-Predicate,http://schema.org/interactingDrug-output,< 1K
-Predicate,http://schema.org/interactionCount,100K - 1M
-Predicate,http://schema.org/interactionCount-input,< 1K
-Predicate,http://schema.org/interactionCount-output,< 1K
-Predicate,http://schema.org/interactionService,< 1K
-Predicate,http://schema.org/interactionService-input,< 1K
-Predicate,http://schema.org/interactionService-output,< 1K
-Predicate,http://schema.org/interactionStatistic,100K - 1M
-Predicate,http://schema.org/interactionStatistic-input,< 1K
-Predicate,http://schema.org/interactionStatistic-output,< 1K
-Predicate,http://schema.org/interactionType,100K - 1M
-Predicate,http://schema.org/interactionType-input,< 1K
-Predicate,http://schema.org/interactionType-output,< 1K
-Predicate,http://schema.org/interactivityType,1K - 10K
-Predicate,http://schema.org/interactivityType-input,< 1K
-Predicate,http://schema.org/interactivityType-output,< 1K
-Predicate,http://schema.org/interestRate,1K - 10K
-Predicate,http://schema.org/interestRate-input,< 1K
-Predicate,http://schema.org/interestRate-output,< 1K
-Predicate,http://schema.org/interpretedAsClaim,< 1K
-Predicate,http://schema.org/interpretedAsClaim-input,< 1K
-Predicate,http://schema.org/interpretedAsClaim-output,< 1K
-Predicate,http://schema.org/inventoryLevel,100K - 1M
-Predicate,http://schema.org/inventoryLevel-input,< 1K
-Predicate,http://schema.org/inventoryLevel-output,< 1K
-Predicate,http://schema.org/inverseOf,< 1K
-Predicate,http://schema.org/inverseOf-input,< 1K
-Predicate,http://schema.org/inverseOf-output,< 1K
-Predicate,http://schema.org/isAcceptingNewPatients,10K - 100K
-Predicate,http://schema.org/isAcceptingNewPatients-input,< 1K
-Predicate,http://schema.org/isAcceptingNewPatients-output,< 1K
-Predicate,http://schema.org/isAccessibleForFree,100K - 1M
-Predicate,http://schema.org/isAccessibleForFree-input,< 1K
-Predicate,http://schema.org/isAccessibleForFree-output,< 1K
-Predicate,http://schema.org/isAccessoryOrSparePartFor,1K - 10K
-Predicate,http://schema.org/isAccessoryOrSparePartFor-input,< 1K
-Predicate,http://schema.org/isAccessoryOrSparePartFor-output,< 1K
-Predicate,http://schema.org/isAvailableGenerically,< 1K
-Predicate,http://schema.org/isAvailableGenerically-input,< 1K
-Predicate,http://schema.org/isAvailableGenerically-output,< 1K
-Predicate,http://schema.org/isBasedOn,10K - 100K
-Predicate,http://schema.org/isBasedOn-input,< 1K
-Predicate,http://schema.org/isBasedOn-output,< 1K
-Predicate,http://schema.org/isBasedOnUrl,< 1K
-Predicate,http://schema.org/isBasedOnUrl-input,< 1K
-Predicate,http://schema.org/isBasedOnUrl-output,< 1K
-Predicate,http://schema.org/isConsumableFor,< 1K
-Predicate,http://schema.org/isConsumableFor-input,< 1K
-Predicate,http://schema.org/isConsumableFor-output,< 1K
-Predicate,http://schema.org/isEncodedByBioChemEntity,< 1K
-Predicate,http://schema.org/isEncodedByBioChemEntity-input,< 1K
-Predicate,http://schema.org/isEncodedByBioChemEntity-output,< 1K
-Predicate,http://schema.org/isFamilyFriendly,100K - 1M
-Predicate,http://schema.org/isFamilyFriendly-input,< 1K
-Predicate,http://schema.org/isFamilyFriendly-output,< 1K
-Predicate,http://schema.org/isGift,< 1K
-Predicate,http://schema.org/isGift-input,< 1K
-Predicate,http://schema.org/isGift-output,< 1K
-Predicate,http://schema.org/isInvolvedInBiologicalProcess,< 1K
-Predicate,http://schema.org/isInvolvedInBiologicalProcess-input,< 1K
-Predicate,http://schema.org/isInvolvedInBiologicalProcess-output,< 1K
-Predicate,http://schema.org/isLiveBroadcast,10K - 100K
-Predicate,http://schema.org/isLiveBroadcast-input,< 1K
-Predicate,http://schema.org/isLiveBroadcast-output,< 1K
-Predicate,http://schema.org/isLocatedInSubcellularLocation,< 1K
-Predicate,http://schema.org/isLocatedInSubcellularLocation-input,< 1K
-Predicate,http://schema.org/isLocatedInSubcellularLocation-output,< 1K
-Predicate,http://schema.org/isPartOf,10M+
-Predicate,http://schema.org/isPartOf-input,< 1K
-Predicate,http://schema.org/isPartOf-output,< 1K
-Predicate,http://schema.org/isPartOfBioChemEntity,< 1K
-Predicate,http://schema.org/isPartOfBioChemEntity-input,< 1K
-Predicate,http://schema.org/isPartOfBioChemEntity-output,< 1K
-Predicate,http://schema.org/isPlanForApartment,< 1K
-Predicate,http://schema.org/isPlanForApartment-input,< 1K
-Predicate,http://schema.org/isPlanForApartment-output,< 1K
-Predicate,http://schema.org/isProprietary,< 1K
-Predicate,http://schema.org/isProprietary-input,< 1K
-Predicate,http://schema.org/isProprietary-output,< 1K
-Predicate,http://schema.org/isRelatedTo,100K - 1M
-Predicate,http://schema.org/isRelatedTo-input,< 1K
-Predicate,http://schema.org/isRelatedTo-output,< 1K
-Predicate,http://schema.org/isResizable,< 1K
-Predicate,http://schema.org/isResizable-input,< 1K
-Predicate,http://schema.org/isResizable-output,< 1K
-Predicate,http://schema.org/isSimilarTo,1K - 10K
-Predicate,http://schema.org/isSimilarTo-input,< 1K
-Predicate,http://schema.org/isSimilarTo-output,< 1K
-Predicate,http://schema.org/isStoreOn,< 1K
-Predicate,http://schema.org/isStoreOn-input,< 1K
-Predicate,http://schema.org/isStoreOn-output,< 1K
-Predicate,http://schema.org/isTierOf,< 1K
-Predicate,http://schema.org/isTierOf-input,< 1K
-Predicate,http://schema.org/isTierOf-output,< 1K
-Predicate,http://schema.org/isUnlabelledFallback,< 1K
-Predicate,http://schema.org/isUnlabelledFallback-input,< 1K
-Predicate,http://schema.org/isUnlabelledFallback-output,< 1K
-Predicate,http://schema.org/isVariantOf,10K - 100K
-Predicate,http://schema.org/isVariantOf-input,< 1K
-Predicate,http://schema.org/isVariantOf-output,< 1K
-Predicate,http://schema.org/isbn,10K - 100K
-Predicate,http://schema.org/isbn-input,< 1K
-Predicate,http://schema.org/isbn-output,< 1K
-Predicate,http://schema.org/isicV4,1K - 10K
-Predicate,http://schema.org/isicV4-input,< 1K
-Predicate,http://schema.org/isicV4-output,< 1K
-Predicate,http://schema.org/iso6523Code,1K - 10K
-Predicate,http://schema.org/iso6523Code-input,< 1K
-Predicate,http://schema.org/iso6523Code-output,< 1K
-Predicate,http://schema.org/isrcCode,< 1K
-Predicate,http://schema.org/isrcCode-input,< 1K
-Predicate,http://schema.org/isrcCode-output,< 1K
-Predicate,http://schema.org/issn,1K - 10K
-Predicate,http://schema.org/issn-input,< 1K
-Predicate,http://schema.org/issn-output,< 1K
-Predicate,http://schema.org/issueNumber,1K - 10K
-Predicate,http://schema.org/issueNumber-input,< 1K
-Predicate,http://schema.org/issueNumber-output,< 1K
-Predicate,http://schema.org/issuedBy,10K - 100K
-Predicate,http://schema.org/issuedBy-input,< 1K
-Predicate,http://schema.org/issuedBy-output,< 1K
-Predicate,http://schema.org/issuedThrough,< 1K
-Predicate,http://schema.org/issuedThrough-input,< 1K
-Predicate,http://schema.org/issuedThrough-output,< 1K
-Predicate,http://schema.org/iswcCode,< 1K
-Predicate,http://schema.org/iswcCode-input,< 1K
-Predicate,http://schema.org/iswcCode-output,< 1K
-Predicate,http://schema.org/item,10M+
-Predicate,http://schema.org/item-input,< 1K
-Predicate,http://schema.org/item-output,< 1K
-Predicate,http://schema.org/itemCondition,1M - 10M
-Predicate,http://schema.org/itemCondition-input,< 1K
-Predicate,http://schema.org/itemCondition-output,< 1K
-Predicate,http://schema.org/itemDefectReturnFees,1K - 10K
-Predicate,http://schema.org/itemDefectReturnFees-input,< 1K
-Predicate,http://schema.org/itemDefectReturnFees-output,< 1K
-Predicate,http://schema.org/itemDefectReturnLabelSource,< 1K
-Predicate,http://schema.org/itemDefectReturnLabelSource-input,< 1K
-Predicate,http://schema.org/itemDefectReturnLabelSource-output,< 1K
-Predicate,http://schema.org/itemDefectReturnShippingFeesAmount,< 1K
-Predicate,http://schema.org/itemDefectReturnShippingFeesAmount-input,< 1K
-Predicate,http://schema.org/itemDefectReturnShippingFeesAmount-output,< 1K
-Predicate,http://schema.org/itemListElement,10M+
-Predicate,http://schema.org/itemListElement-input,< 1K
-Predicate,http://schema.org/itemListElement-output,< 1K
-Predicate,http://schema.org/itemListOrder,100K - 1M
-Predicate,http://schema.org/itemListOrder-input,< 1K
-Predicate,http://schema.org/itemListOrder-output,< 1K
-Predicate,http://schema.org/itemLocation,< 1K
-Predicate,http://schema.org/itemLocation-input,< 1K
-Predicate,http://schema.org/itemLocation-output,< 1K
-Predicate,http://schema.org/itemOffered,100K - 1M
-Predicate,http://schema.org/itemOffered-input,< 1K
-Predicate,http://schema.org/itemOffered-output,< 1K
-Predicate,http://schema.org/itemReviewed,100K - 1M
-Predicate,http://schema.org/itemReviewed-input,< 1K
-Predicate,http://schema.org/itemReviewed-output,< 1K
-Predicate,http://schema.org/itemShipped,< 1K
-Predicate,http://schema.org/itemShipped-input,< 1K
-Predicate,http://schema.org/itemShipped-output,< 1K
-Predicate,http://schema.org/itinerary,10K - 100K
-Predicate,http://schema.org/itinerary-input,< 1K
-Predicate,http://schema.org/itinerary-output,< 1K
-Predicate,http://schema.org/iupacName,< 1K
-Predicate,http://schema.org/iupacName-input,< 1K
-Predicate,http://schema.org/iupacName-output,< 1K
-Predicate,http://schema.org/jobBenefits,10K - 100K
-Predicate,http://schema.org/jobBenefits-input,< 1K
-Predicate,http://schema.org/jobBenefits-output,< 1K
-Predicate,http://schema.org/jobDuration,< 1K
-Predicate,http://schema.org/jobDuration-input,< 1K
-Predicate,http://schema.org/jobDuration-output,< 1K
-Predicate,http://schema.org/jobImmediateStart,1K - 10K
-Predicate,http://schema.org/jobImmediateStart-input,< 1K
-Predicate,http://schema.org/jobImmediateStart-output,< 1K
-Predicate,http://schema.org/jobLocation,100K - 1M
-Predicate,http://schema.org/jobLocation-input,< 1K
-Predicate,http://schema.org/jobLocation-output,< 1K
-Predicate,http://schema.org/jobLocationType,10K - 100K
-Predicate,http://schema.org/jobLocationType-input,< 1K
-Predicate,http://schema.org/jobLocationType-output,< 1K
-Predicate,http://schema.org/jobStartDate,1K - 10K
-Predicate,http://schema.org/jobStartDate-input,< 1K
-Predicate,http://schema.org/jobStartDate-output,< 1K
-Predicate,http://schema.org/jobTitle,1M - 10M
-Predicate,http://schema.org/jobTitle-input,< 1K
-Predicate,http://schema.org/jobTitle-output,< 1K
-Predicate,http://schema.org/jurisdiction,1K - 10K
-Predicate,http://schema.org/jurisdiction-input,< 1K
-Predicate,http://schema.org/jurisdiction-output,< 1K
-Predicate,http://schema.org/keywords,1M - 10M
-Predicate,http://schema.org/keywords-input,< 1K
-Predicate,http://schema.org/keywords-output,< 1K
-Predicate,http://schema.org/knownVehicleDamages,< 1K
-Predicate,http://schema.org/knownVehicleDamages-input,< 1K
-Predicate,http://schema.org/knownVehicleDamages-output,< 1K
-Predicate,http://schema.org/knows,1K - 10K
-Predicate,http://schema.org/knows-input,< 1K
-Predicate,http://schema.org/knows-output,< 1K
-Predicate,http://schema.org/knowsAbout,100K - 1M
-Predicate,http://schema.org/knowsAbout-input,< 1K
-Predicate,http://schema.org/knowsAbout-output,< 1K
-Predicate,http://schema.org/knowsLanguage,100K - 1M
-Predicate,http://schema.org/knowsLanguage-input,< 1K
-Predicate,http://schema.org/knowsLanguage-output,< 1K
-Predicate,http://schema.org/labelDetails,< 1K
-Predicate,http://schema.org/labelDetails-input,< 1K
-Predicate,http://schema.org/labelDetails-output,< 1K
-Predicate,http://schema.org/landlord,< 1K
-Predicate,http://schema.org/landlord-input,< 1K
-Predicate,http://schema.org/landlord-output,< 1K
-Predicate,http://schema.org/language,10K - 100K
-Predicate,http://schema.org/language-input,< 1K
-Predicate,http://schema.org/language-output,< 1K
-Predicate,http://schema.org/lastReviewed,10K - 100K
-Predicate,http://schema.org/lastReviewed-input,< 1K
-Predicate,http://schema.org/lastReviewed-output,< 1K
-Predicate,http://schema.org/latitude,1M - 10M
-Predicate,http://schema.org/latitude-input,< 1K
-Predicate,http://schema.org/latitude-output,< 1K
-Predicate,http://schema.org/layoutImage,1K - 10K
-Predicate,http://schema.org/layoutImage-input,< 1K
-Predicate,http://schema.org/layoutImage-output,< 1K
-Predicate,http://schema.org/learningResourceType,10K - 100K
-Predicate,http://schema.org/learningResourceType-input,< 1K
-Predicate,http://schema.org/learningResourceType-output,< 1K
-Predicate,http://schema.org/leaseLength,1K - 10K
-Predicate,http://schema.org/leaseLength-input,< 1K
-Predicate,http://schema.org/leaseLength-output,< 1K
-Predicate,http://schema.org/legalAddress,1K - 10K
-Predicate,http://schema.org/legalAddress-input,< 1K
-Predicate,http://schema.org/legalAddress-output,< 1K
-Predicate,http://schema.org/legalName,1M - 10M
-Predicate,http://schema.org/legalName-input,< 1K
-Predicate,http://schema.org/legalName-output,< 1K
-Predicate,http://schema.org/legalRepresentative,1K - 10K
-Predicate,http://schema.org/legalRepresentative-input,< 1K
-Predicate,http://schema.org/legalRepresentative-output,< 1K
-Predicate,http://schema.org/legalStatus,1K - 10K
-Predicate,http://schema.org/legalStatus-input,< 1K
-Predicate,http://schema.org/legalStatus-output,< 1K
-Predicate,http://schema.org/legislationAmends,< 1K
-Predicate,http://schema.org/legislationAmends-input,< 1K
-Predicate,http://schema.org/legislationAmends-output,< 1K
-Predicate,http://schema.org/legislationApplies,< 1K
-Predicate,http://schema.org/legislationApplies-input,< 1K
-Predicate,http://schema.org/legislationApplies-output,< 1K
-Predicate,http://schema.org/legislationChanges,< 1K
-Predicate,http://schema.org/legislationChanges-input,< 1K
-Predicate,http://schema.org/legislationChanges-output,< 1K
-Predicate,http://schema.org/legislationCommences,< 1K
-Predicate,http://schema.org/legislationCommences-input,< 1K
-Predicate,http://schema.org/legislationCommences-output,< 1K
-Predicate,http://schema.org/legislationConsolidates,< 1K
-Predicate,http://schema.org/legislationConsolidates-input,< 1K
-Predicate,http://schema.org/legislationConsolidates-output,< 1K
-Predicate,http://schema.org/legislationCorrects,< 1K
-Predicate,http://schema.org/legislationCorrects-input,< 1K
-Predicate,http://schema.org/legislationCorrects-output,< 1K
-Predicate,http://schema.org/legislationCountersignedBy,< 1K
-Predicate,http://schema.org/legislationCountersignedBy-input,< 1K
-Predicate,http://schema.org/legislationCountersignedBy-output,< 1K
-Predicate,http://schema.org/legislationDate,< 1K
-Predicate,http://schema.org/legislationDate-input,< 1K
-Predicate,http://schema.org/legislationDate-output,< 1K
-Predicate,http://schema.org/legislationDateOfApplicability,< 1K
-Predicate,http://schema.org/legislationDateOfApplicability-input,< 1K
-Predicate,http://schema.org/legislationDateOfApplicability-output,< 1K
-Predicate,http://schema.org/legislationDateVersion,< 1K
-Predicate,http://schema.org/legislationDateVersion-input,< 1K
-Predicate,http://schema.org/legislationDateVersion-output,< 1K
-Predicate,http://schema.org/legislationEnsuresImplementationOf,< 1K
-Predicate,http://schema.org/legislationEnsuresImplementationOf-input,< 1K
-Predicate,http://schema.org/legislationEnsuresImplementationOf-output,< 1K
-Predicate,http://schema.org/legislationIdentifier,1K - 10K
-Predicate,http://schema.org/legislationIdentifier-input,< 1K
-Predicate,http://schema.org/legislationIdentifier-output,< 1K
-Predicate,http://schema.org/legislationJurisdiction,1K - 10K
-Predicate,http://schema.org/legislationJurisdiction-input,< 1K
-Predicate,http://schema.org/legislationJurisdiction-output,< 1K
-Predicate,http://schema.org/legislationLegalForce,< 1K
-Predicate,http://schema.org/legislationLegalForce-input,< 1K
-Predicate,http://schema.org/legislationLegalForce-output,< 1K
-Predicate,http://schema.org/legislationLegalValue,< 1K
-Predicate,http://schema.org/legislationLegalValue-input,< 1K
-Predicate,http://schema.org/legislationLegalValue-output,< 1K
-Predicate,http://schema.org/legislationPassedBy,< 1K
-Predicate,http://schema.org/legislationPassedBy-input,< 1K
-Predicate,http://schema.org/legislationPassedBy-output,< 1K
-Predicate,http://schema.org/legislationRepeals,< 1K
-Predicate,http://schema.org/legislationRepeals-input,< 1K
-Predicate,http://schema.org/legislationRepeals-output,< 1K
-Predicate,http://schema.org/legislationResponsible,< 1K
-Predicate,http://schema.org/legislationResponsible-input,< 1K
-Predicate,http://schema.org/legislationResponsible-output,< 1K
-Predicate,http://schema.org/legislationTransposes,< 1K
-Predicate,http://schema.org/legislationTransposes-input,< 1K
-Predicate,http://schema.org/legislationTransposes-output,< 1K
-Predicate,http://schema.org/legislationType,< 1K
-Predicate,http://schema.org/legislationType-input,< 1K
-Predicate,http://schema.org/legislationType-output,< 1K
-Predicate,http://schema.org/leiCode,1K - 10K
-Predicate,http://schema.org/leiCode-input,< 1K
-Predicate,http://schema.org/leiCode-output,< 1K
-Predicate,http://schema.org/lender,< 1K
-Predicate,http://schema.org/lender-input,< 1K
-Predicate,http://schema.org/lender-output,< 1K
-Predicate,http://schema.org/lesser,< 1K
-Predicate,http://schema.org/lesser-input,< 1K
-Predicate,http://schema.org/lesser-output,< 1K
-Predicate,http://schema.org/lesserOrEqual,< 1K
-Predicate,http://schema.org/lesserOrEqual-input,< 1K
-Predicate,http://schema.org/lesserOrEqual-output,< 1K
-Predicate,http://schema.org/letterer,< 1K
-Predicate,http://schema.org/letterer-input,< 1K
-Predicate,http://schema.org/letterer-output,< 1K
-Predicate,http://schema.org/license,100K - 1M
-Predicate,http://schema.org/license-input,< 1K
-Predicate,http://schema.org/license-output,< 1K
-Predicate,http://schema.org/lifeEvent,< 1K
-Predicate,http://schema.org/lifeEvent-input,< 1K
-Predicate,http://schema.org/lifeEvent-output,< 1K
-Predicate,http://schema.org/line,< 1K
-Predicate,http://schema.org/line-input,< 1K
-Predicate,http://schema.org/line-output,< 1K
-Predicate,http://schema.org/linkRelationship,< 1K
-Predicate,http://schema.org/linkRelationship-input,< 1K
-Predicate,http://schema.org/linkRelationship-output,< 1K
-Predicate,http://schema.org/liveBlogUpdate,1K - 10K
-Predicate,http://schema.org/liveBlogUpdate-input,< 1K
-Predicate,http://schema.org/liveBlogUpdate-output,< 1K
-Predicate,http://schema.org/loanMortgageMandateAmount,< 1K
-Predicate,http://schema.org/loanMortgageMandateAmount-input,< 1K
-Predicate,http://schema.org/loanMortgageMandateAmount-output,< 1K
-Predicate,http://schema.org/loanPaymentAmount,< 1K
-Predicate,http://schema.org/loanPaymentAmount-input,< 1K
-Predicate,http://schema.org/loanPaymentAmount-output,< 1K
-Predicate,http://schema.org/loanPaymentFrequency,< 1K
-Predicate,http://schema.org/loanPaymentFrequency-input,< 1K
-Predicate,http://schema.org/loanPaymentFrequency-output,< 1K
-Predicate,http://schema.org/loanRepaymentForm,< 1K
-Predicate,http://schema.org/loanRepaymentForm-input,< 1K
-Predicate,http://schema.org/loanRepaymentForm-output,< 1K
-Predicate,http://schema.org/loanTerm,1K - 10K
-Predicate,http://schema.org/loanTerm-input,< 1K
-Predicate,http://schema.org/loanTerm-output,< 1K
-Predicate,http://schema.org/loanType,1K - 10K
-Predicate,http://schema.org/loanType-input,< 1K
-Predicate,http://schema.org/loanType-output,< 1K
-Predicate,http://schema.org/location,1M - 10M
-Predicate,http://schema.org/location-input,< 1K
-Predicate,http://schema.org/location-output,< 1K
-Predicate,http://schema.org/locationCreated,10K - 100K
-Predicate,http://schema.org/locationCreated-input,< 1K
-Predicate,http://schema.org/locationCreated-output,< 1K
-Predicate,http://schema.org/lodgingUnitDescription,< 1K
-Predicate,http://schema.org/lodgingUnitDescription-input,< 1K
-Predicate,http://schema.org/lodgingUnitDescription-output,< 1K
-Predicate,http://schema.org/lodgingUnitType,< 1K
-Predicate,http://schema.org/lodgingUnitType-input,< 1K
-Predicate,http://schema.org/lodgingUnitType-output,< 1K
-Predicate,http://schema.org/logo,10M+
-Predicate,http://schema.org/logo-input,< 1K
-Predicate,http://schema.org/logo-output,< 1K
-Predicate,http://schema.org/longitude,1M - 10M
-Predicate,http://schema.org/longitude-input,< 1K
-Predicate,http://schema.org/longitude-output,< 1K
-Predicate,http://schema.org/loser,< 1K
-Predicate,http://schema.org/loser-input,< 1K
-Predicate,http://schema.org/loser-output,< 1K
-Predicate,http://schema.org/lowPrice,1M - 10M
-Predicate,http://schema.org/lowPrice-input,< 1K
-Predicate,http://schema.org/lowPrice-output,< 1K
-Predicate,http://schema.org/lyricist,< 1K
-Predicate,http://schema.org/lyricist-input,< 1K
-Predicate,http://schema.org/lyricist-output,< 1K
-Predicate,http://schema.org/lyrics,1K - 10K
-Predicate,http://schema.org/lyrics-input,< 1K
-Predicate,http://schema.org/lyrics-output,< 1K
-Predicate,http://schema.org/mainContentOfPage,1M - 10M
-Predicate,http://schema.org/mainContentOfPage-input,< 1K
-Predicate,http://schema.org/mainContentOfPage-output,< 1K
-Predicate,http://schema.org/mainEntity,1M - 10M
-Predicate,http://schema.org/mainEntity-input,< 1K
-Predicate,http://schema.org/mainEntity-output,< 1K
-Predicate,http://schema.org/mainEntityOfPage,10M+
-Predicate,http://schema.org/mainEntityOfPage-input,< 1K
-Predicate,http://schema.org/mainEntityOfPage-output,< 1K
-Predicate,http://schema.org/maintainer,1K - 10K
-Predicate,http://schema.org/maintainer-input,< 1K
-Predicate,http://schema.org/maintainer-output,< 1K
-Predicate,http://schema.org/makesOffer,100K - 1M
-Predicate,http://schema.org/makesOffer-input,< 1K
-Predicate,http://schema.org/makesOffer-output,< 1K
-Predicate,http://schema.org/manufacturer,100K - 1M
-Predicate,http://schema.org/manufacturer-input,< 1K
-Predicate,http://schema.org/manufacturer-output,< 1K
-Predicate,http://schema.org/map,1K - 10K
-Predicate,http://schema.org/map-input,< 1K
-Predicate,http://schema.org/map-output,< 1K
-Predicate,http://schema.org/mapType,1K - 10K
-Predicate,http://schema.org/mapType-input,< 1K
-Predicate,http://schema.org/mapType-output,< 1K
-Predicate,http://schema.org/maps,1K - 10K
-Predicate,http://schema.org/maps-input,< 1K
-Predicate,http://schema.org/maps-output,< 1K
-Predicate,http://schema.org/marginOfError,< 1K
-Predicate,http://schema.org/marginOfError-input,< 1K
-Predicate,http://schema.org/marginOfError-output,< 1K
-Predicate,http://schema.org/masthead,1K - 10K
-Predicate,http://schema.org/masthead-input,< 1K
-Predicate,http://schema.org/masthead-output,< 1K
-Predicate,http://schema.org/material,10K - 100K
-Predicate,http://schema.org/material-input,< 1K
-Predicate,http://schema.org/material-output,< 1K
-Predicate,http://schema.org/materialExtent,< 1K
-Predicate,http://schema.org/materialExtent-input,< 1K
-Predicate,http://schema.org/materialExtent-output,< 1K
-Predicate,http://schema.org/mathExpression,< 1K
-Predicate,http://schema.org/mathExpression-input,< 1K
-Predicate,http://schema.org/mathExpression-output,< 1K
-Predicate,http://schema.org/maxPrice,10K - 100K
-Predicate,http://schema.org/maxPrice-input,< 1K
-Predicate,http://schema.org/maxPrice-output,< 1K
-Predicate,http://schema.org/maxValue,100K - 1M
-Predicate,http://schema.org/maxValue-input,< 1K
-Predicate,http://schema.org/maxValue-output,< 1K
-Predicate,http://schema.org/maximumAttendeeCapacity,10K - 100K
-Predicate,http://schema.org/maximumAttendeeCapacity-input,< 1K
-Predicate,http://schema.org/maximumAttendeeCapacity-output,< 1K
-Predicate,http://schema.org/maximumEnrollment,< 1K
-Predicate,http://schema.org/maximumEnrollment-input,< 1K
-Predicate,http://schema.org/maximumEnrollment-output,< 1K
-Predicate,http://schema.org/maximumIntake,< 1K
-Predicate,http://schema.org/maximumIntake-input,< 1K
-Predicate,http://schema.org/maximumIntake-output,< 1K
-Predicate,http://schema.org/maximumPhysicalAttendeeCapacity,< 1K
-Predicate,http://schema.org/maximumPhysicalAttendeeCapacity-input,< 1K
-Predicate,http://schema.org/maximumPhysicalAttendeeCapacity-output,< 1K
-Predicate,http://schema.org/maximumVirtualAttendeeCapacity,< 1K
-Predicate,http://schema.org/maximumVirtualAttendeeCapacity-input,< 1K
-Predicate,http://schema.org/maximumVirtualAttendeeCapacity-output,< 1K
-Predicate,http://schema.org/mealService,< 1K
-Predicate,http://schema.org/mealService-input,< 1K
-Predicate,http://schema.org/mealService-output,< 1K
-Predicate,http://schema.org/measuredProperty,< 1K
-Predicate,http://schema.org/measuredProperty-input,< 1K
-Predicate,http://schema.org/measuredProperty-output,< 1K
-Predicate,http://schema.org/measurementDenominator,< 1K
-Predicate,http://schema.org/measurementDenominator-input,< 1K
-Predicate,http://schema.org/measurementDenominator-output,< 1K
-Predicate,http://schema.org/measurementMethod,< 1K
-Predicate,http://schema.org/measurementMethod-input,< 1K
-Predicate,http://schema.org/measurementMethod-output,< 1K
-Predicate,http://schema.org/measurementQualifier,< 1K
-Predicate,http://schema.org/measurementQualifier-input,< 1K
-Predicate,http://schema.org/measurementQualifier-output,< 1K
-Predicate,http://schema.org/measurementTechnique,1K - 10K
-Predicate,http://schema.org/measurementTechnique-input,< 1K
-Predicate,http://schema.org/measurementTechnique-output,< 1K
-Predicate,http://schema.org/mechanismOfAction,< 1K
-Predicate,http://schema.org/mechanismOfAction-input,< 1K
-Predicate,http://schema.org/mechanismOfAction-output,< 1K
-Predicate,http://schema.org/mediaAuthenticityCategory,< 1K
-Predicate,http://schema.org/mediaAuthenticityCategory-input,< 1K
-Predicate,http://schema.org/mediaAuthenticityCategory-output,< 1K
-Predicate,http://schema.org/mediaItemAppearance,< 1K
-Predicate,http://schema.org/mediaItemAppearance-input,< 1K
-Predicate,http://schema.org/mediaItemAppearance-output,< 1K
-Predicate,http://schema.org/median,1K - 10K
-Predicate,http://schema.org/median-input,< 1K
-Predicate,http://schema.org/median-output,< 1K
-Predicate,http://schema.org/medicalAudience,1K - 10K
-Predicate,http://schema.org/medicalAudience-input,< 1K
-Predicate,http://schema.org/medicalAudience-output,< 1K
-Predicate,http://schema.org/medicalSpecialty,100K - 1M
-Predicate,http://schema.org/medicalSpecialty-input,< 1K
-Predicate,http://schema.org/medicalSpecialty-output,< 1K
-Predicate,http://schema.org/medicineSystem,1K - 10K
-Predicate,http://schema.org/medicineSystem-input,< 1K
-Predicate,http://schema.org/medicineSystem-output,< 1K
-Predicate,http://schema.org/meetsEmissionStandard,< 1K
-Predicate,http://schema.org/meetsEmissionStandard-input,< 1K
-Predicate,http://schema.org/meetsEmissionStandard-output,< 1K
-Predicate,http://schema.org/member,10K - 100K
-Predicate,http://schema.org/member-input,< 1K
-Predicate,http://schema.org/member-output,< 1K
-Predicate,http://schema.org/memberOf,10K - 100K
-Predicate,http://schema.org/memberOf-input,< 1K
-Predicate,http://schema.org/memberOf-output,< 1K
-Predicate,http://schema.org/members,< 1K
-Predicate,http://schema.org/members-input,< 1K
-Predicate,http://schema.org/members-output,< 1K
-Predicate,http://schema.org/membershipNumber,< 1K
-Predicate,http://schema.org/membershipNumber-input,< 1K
-Predicate,http://schema.org/membershipNumber-output,< 1K
-Predicate,http://schema.org/membershipPointsEarned,< 1K
-Predicate,http://schema.org/membershipPointsEarned-input,< 1K
-Predicate,http://schema.org/membershipPointsEarned-output,< 1K
-Predicate,http://schema.org/memoryRequirements,1K - 10K
-Predicate,http://schema.org/memoryRequirements-input,< 1K
-Predicate,http://schema.org/memoryRequirements-output,< 1K
-Predicate,http://schema.org/mentions,10K - 100K
-Predicate,http://schema.org/mentions-input,< 1K
-Predicate,http://schema.org/mentions-output,< 1K
-Predicate,http://schema.org/menu,10K - 100K
-Predicate,http://schema.org/menu-input,< 1K
-Predicate,http://schema.org/menu-output,< 1K
-Predicate,http://schema.org/menuAddOn,10K - 100K
-Predicate,http://schema.org/menuAddOn-input,< 1K
-Predicate,http://schema.org/menuAddOn-output,< 1K
-Predicate,http://schema.org/merchant,< 1K
-Predicate,http://schema.org/merchant-input,< 1K
-Predicate,http://schema.org/merchant-output,< 1K
-Predicate,http://schema.org/merchantReturnDays,100K - 1M
-Predicate,http://schema.org/merchantReturnDays-input,< 1K
-Predicate,http://schema.org/merchantReturnDays-output,< 1K
-Predicate,http://schema.org/merchantReturnLink,10K - 100K
-Predicate,http://schema.org/merchantReturnLink-input,< 1K
-Predicate,http://schema.org/merchantReturnLink-output,< 1K
-Predicate,http://schema.org/messageAttachment,< 1K
-Predicate,http://schema.org/messageAttachment-input,< 1K
-Predicate,http://schema.org/messageAttachment-output,< 1K
-Predicate,http://schema.org/mileageFromOdometer,10K - 100K
-Predicate,http://schema.org/mileageFromOdometer-input,< 1K
-Predicate,http://schema.org/mileageFromOdometer-output,< 1K
-Predicate,http://schema.org/minPrice,10K - 100K
-Predicate,http://schema.org/minPrice-input,< 1K
-Predicate,http://schema.org/minPrice-output,< 1K
-Predicate,http://schema.org/minValue,100K - 1M
-Predicate,http://schema.org/minValue-input,< 1K
-Predicate,http://schema.org/minValue-output,< 1K
-Predicate,http://schema.org/minimumPaymentDue,< 1K
-Predicate,http://schema.org/minimumPaymentDue-input,< 1K
-Predicate,http://schema.org/minimumPaymentDue-output,< 1K
-Predicate,http://schema.org/missionCoveragePrioritiesPolicy,1K - 10K
-Predicate,http://schema.org/missionCoveragePrioritiesPolicy-input,< 1K
-Predicate,http://schema.org/missionCoveragePrioritiesPolicy-output,< 1K
-Predicate,http://schema.org/mobileUrl,< 1K
-Predicate,http://schema.org/mobileUrl-input,< 1K
-Predicate,http://schema.org/mobileUrl-output,< 1K
-Predicate,http://schema.org/model,100K - 1M
-Predicate,http://schema.org/model-input,< 1K
-Predicate,http://schema.org/model-output,< 1K
-Predicate,http://schema.org/modelDate,10K - 100K
-Predicate,http://schema.org/modelDate-input,< 1K
-Predicate,http://schema.org/modelDate-output,< 1K
-Predicate,http://schema.org/modifiedTime,< 1K
-Predicate,http://schema.org/modifiedTime-input,< 1K
-Predicate,http://schema.org/modifiedTime-output,< 1K
-Predicate,http://schema.org/molecularFormula,< 1K
-Predicate,http://schema.org/molecularFormula-input,< 1K
-Predicate,http://schema.org/molecularFormula-output,< 1K
-Predicate,http://schema.org/molecularWeight,< 1K
-Predicate,http://schema.org/molecularWeight-input,< 1K
-Predicate,http://schema.org/molecularWeight-output,< 1K
-Predicate,http://schema.org/monoisotopicMolecularWeight,< 1K
-Predicate,http://schema.org/monoisotopicMolecularWeight-input,< 1K
-Predicate,http://schema.org/monoisotopicMolecularWeight-output,< 1K
-Predicate,http://schema.org/monthlyMinimumRepaymentAmount,< 1K
-Predicate,http://schema.org/monthlyMinimumRepaymentAmount-input,< 1K
-Predicate,http://schema.org/monthlyMinimumRepaymentAmount-output,< 1K
-Predicate,http://schema.org/monthsOfExperience,1K - 10K
-Predicate,http://schema.org/monthsOfExperience-input,< 1K
-Predicate,http://schema.org/monthsOfExperience-output,< 1K
-Predicate,http://schema.org/mpn,100K - 1M
-Predicate,http://schema.org/mpn-input,< 1K
-Predicate,http://schema.org/mpn-output,< 1K
-Predicate,http://schema.org/multipleValues,< 1K
-Predicate,http://schema.org/multipleValues-input,< 1K
-Predicate,http://schema.org/multipleValues-output,< 1K
-Predicate,http://schema.org/muscleAction,< 1K
-Predicate,http://schema.org/muscleAction-input,< 1K
-Predicate,http://schema.org/muscleAction-output,< 1K
-Predicate,http://schema.org/musicArrangement,< 1K
-Predicate,http://schema.org/musicArrangement-input,< 1K
-Predicate,http://schema.org/musicArrangement-output,< 1K
-Predicate,http://schema.org/musicBy,1K - 10K
-Predicate,http://schema.org/musicBy-input,< 1K
-Predicate,http://schema.org/musicBy-output,< 1K
-Predicate,http://schema.org/musicCompositionForm,< 1K
-Predicate,http://schema.org/musicCompositionForm-input,< 1K
-Predicate,http://schema.org/musicCompositionForm-output,< 1K
-Predicate,http://schema.org/musicGroupMember,< 1K
-Predicate,http://schema.org/musicGroupMember-input,< 1K
-Predicate,http://schema.org/musicGroupMember-output,< 1K
-Predicate,http://schema.org/musicReleaseFormat,1K - 10K
-Predicate,http://schema.org/musicReleaseFormat-input,< 1K
-Predicate,http://schema.org/musicReleaseFormat-output,< 1K
-Predicate,http://schema.org/musicalKey,< 1K
-Predicate,http://schema.org/musicalKey-input,< 1K
-Predicate,http://schema.org/musicalKey-output,< 1K
-Predicate,http://schema.org/naics,10K - 100K
-Predicate,http://schema.org/naics-input,< 1K
-Predicate,http://schema.org/naics-output,< 1K
-Predicate,http://schema.org/name,10M+
-Predicate,http://schema.org/name-input,< 1K
-Predicate,http://schema.org/name-output,< 1K
-Predicate,http://schema.org/namedPosition,< 1K
-Predicate,http://schema.org/namedPosition-input,< 1K
-Predicate,http://schema.org/namedPosition-output,< 1K
-Predicate,http://schema.org/nationality,10K - 100K
-Predicate,http://schema.org/nationality-input,< 1K
-Predicate,http://schema.org/nationality-output,< 1K
-Predicate,http://schema.org/naturalProgression,< 1K
-Predicate,http://schema.org/naturalProgression-input,< 1K
-Predicate,http://schema.org/naturalProgression-output,< 1K
-Predicate,http://schema.org/negativeNotes,10K - 100K
-Predicate,http://schema.org/negativeNotes-input,< 1K
-Predicate,http://schema.org/negativeNotes-output,< 1K
-Predicate,http://schema.org/nerve,< 1K
-Predicate,http://schema.org/nerve-input,< 1K
-Predicate,http://schema.org/nerve-output,< 1K
-Predicate,http://schema.org/nerveMotor,< 1K
-Predicate,http://schema.org/nerveMotor-input,< 1K
-Predicate,http://schema.org/nerveMotor-output,< 1K
-Predicate,http://schema.org/netWorth,< 1K
-Predicate,http://schema.org/netWorth-input,< 1K
-Predicate,http://schema.org/netWorth-output,< 1K
-Predicate,http://schema.org/newsUpdatesAndGuidelines,< 1K
-Predicate,http://schema.org/newsUpdatesAndGuidelines-input,< 1K
-Predicate,http://schema.org/newsUpdatesAndGuidelines-output,< 1K
-Predicate,http://schema.org/nextItem,1M - 10M
-Predicate,http://schema.org/nextItem-input,< 1K
-Predicate,http://schema.org/nextItem-output,< 1K
-Predicate,http://schema.org/noBylinesPolicy,1K - 10K
-Predicate,http://schema.org/noBylinesPolicy-input,< 1K
-Predicate,http://schema.org/noBylinesPolicy-output,< 1K
-Predicate,http://schema.org/nonEqual,< 1K
-Predicate,http://schema.org/nonEqual-input,< 1K
-Predicate,http://schema.org/nonEqual-output,< 1K
-Predicate,http://schema.org/nonProprietaryName,1K - 10K
-Predicate,http://schema.org/nonProprietaryName-input,< 1K
-Predicate,http://schema.org/nonProprietaryName-output,< 1K
-Predicate,http://schema.org/nonprofitStatus,1K - 10K
-Predicate,http://schema.org/nonprofitStatus-input,< 1K
-Predicate,http://schema.org/nonprofitStatus-output,< 1K
-Predicate,http://schema.org/normalRange,< 1K
-Predicate,http://schema.org/normalRange-input,< 1K
-Predicate,http://schema.org/normalRange-output,< 1K
-Predicate,http://schema.org/nsn,< 1K
-Predicate,http://schema.org/nsn-input,< 1K
-Predicate,http://schema.org/nsn-output,< 1K
-Predicate,http://schema.org/numAdults,< 1K
-Predicate,http://schema.org/numAdults-input,< 1K
-Predicate,http://schema.org/numAdults-output,< 1K
-Predicate,http://schema.org/numChildren,< 1K
-Predicate,http://schema.org/numChildren-input,< 1K
-Predicate,http://schema.org/numChildren-output,< 1K
-Predicate,http://schema.org/numConstraints,< 1K
-Predicate,http://schema.org/numConstraints-input,< 1K
-Predicate,http://schema.org/numConstraints-output,< 1K
-Predicate,http://schema.org/numItems,< 1K
-Predicate,http://schema.org/numItems-input,< 1K
-Predicate,http://schema.org/numItems-output,< 1K
-Predicate,http://schema.org/numTracks,10K - 100K
-Predicate,http://schema.org/numTracks-input,< 1K
-Predicate,http://schema.org/numTracks-output,< 1K
-Predicate,http://schema.org/numberOfAccommodationUnits,1K - 10K
-Predicate,http://schema.org/numberOfAccommodationUnits-input,< 1K
-Predicate,http://schema.org/numberOfAccommodationUnits-output,< 1K
-Predicate,http://schema.org/numberOfAirbags,< 1K
-Predicate,http://schema.org/numberOfAirbags-input,< 1K
-Predicate,http://schema.org/numberOfAirbags-output,< 1K
-Predicate,http://schema.org/numberOfAvailableAccommodationUnits,1K - 10K
-Predicate,http://schema.org/numberOfAvailableAccommodationUnits-input,< 1K
-Predicate,http://schema.org/numberOfAvailableAccommodationUnits-output,< 1K
-Predicate,http://schema.org/numberOfAxles,< 1K
-Predicate,http://schema.org/numberOfAxles-input,< 1K
-Predicate,http://schema.org/numberOfAxles-output,< 1K
-Predicate,http://schema.org/numberOfBathroomsTotal,10K - 100K
-Predicate,http://schema.org/numberOfBathroomsTotal-input,< 1K
-Predicate,http://schema.org/numberOfBathroomsTotal-output,< 1K
-Predicate,http://schema.org/numberOfBedrooms,10K - 100K
-Predicate,http://schema.org/numberOfBedrooms-input,< 1K
-Predicate,http://schema.org/numberOfBedrooms-output,< 1K
-Predicate,http://schema.org/numberOfBeds,10K - 100K
-Predicate,http://schema.org/numberOfBeds-input,< 1K
-Predicate,http://schema.org/numberOfBeds-output,< 1K
-Predicate,http://schema.org/numberOfCredits,1K - 10K
-Predicate,http://schema.org/numberOfCredits-input,< 1K
-Predicate,http://schema.org/numberOfCredits-output,< 1K
-Predicate,http://schema.org/numberOfDoors,10K - 100K
-Predicate,http://schema.org/numberOfDoors-input,< 1K
-Predicate,http://schema.org/numberOfDoors-output,< 1K
-Predicate,http://schema.org/numberOfEmployees,100K - 1M
-Predicate,http://schema.org/numberOfEmployees-input,< 1K
-Predicate,http://schema.org/numberOfEmployees-output,< 1K
-Predicate,http://schema.org/numberOfEpisodes,10K - 100K
-Predicate,http://schema.org/numberOfEpisodes-input,< 1K
-Predicate,http://schema.org/numberOfEpisodes-output,< 1K
-Predicate,http://schema.org/numberOfForwardGears,1K - 10K
-Predicate,http://schema.org/numberOfForwardGears-input,< 1K
-Predicate,http://schema.org/numberOfForwardGears-output,< 1K
-Predicate,http://schema.org/numberOfFullBathrooms,10K - 100K
-Predicate,http://schema.org/numberOfFullBathrooms-input,< 1K
-Predicate,http://schema.org/numberOfFullBathrooms-output,< 1K
-Predicate,http://schema.org/numberOfItems,100K - 1M
-Predicate,http://schema.org/numberOfItems-input,< 1K
-Predicate,http://schema.org/numberOfItems-output,< 1K
-Predicate,http://schema.org/numberOfLoanPayments,< 1K
-Predicate,http://schema.org/numberOfLoanPayments-input,< 1K
-Predicate,http://schema.org/numberOfLoanPayments-output,< 1K
-Predicate,http://schema.org/numberOfPages,10K - 100K
-Predicate,http://schema.org/numberOfPages-input,< 1K
-Predicate,http://schema.org/numberOfPages-output,< 1K
-Predicate,http://schema.org/numberOfPartialBathrooms,1K - 10K
-Predicate,http://schema.org/numberOfPartialBathrooms-input,< 1K
-Predicate,http://schema.org/numberOfPartialBathrooms-output,< 1K
-Predicate,http://schema.org/numberOfPlayers,10K - 100K
-Predicate,http://schema.org/numberOfPlayers-input,< 1K
-Predicate,http://schema.org/numberOfPlayers-output,< 1K
-Predicate,http://schema.org/numberOfPreviousOwners,1K - 10K
-Predicate,http://schema.org/numberOfPreviousOwners-input,< 1K
-Predicate,http://schema.org/numberOfPreviousOwners-output,< 1K
-Predicate,http://schema.org/numberOfRooms,10K - 100K
-Predicate,http://schema.org/numberOfRooms-input,< 1K
-Predicate,http://schema.org/numberOfRooms-output,< 1K
-Predicate,http://schema.org/numberOfSeasons,1K - 10K
-Predicate,http://schema.org/numberOfSeasons-input,< 1K
-Predicate,http://schema.org/numberOfSeasons-output,< 1K
-Predicate,http://schema.org/numberedPosition,< 1K
-Predicate,http://schema.org/numberedPosition-input,< 1K
-Predicate,http://schema.org/numberedPosition-output,< 1K
-Predicate,http://schema.org/nutrition,10K - 100K
-Predicate,http://schema.org/nutrition-input,< 1K
-Predicate,http://schema.org/nutrition-output,< 1K
-Predicate,http://schema.org/object,10K - 100K
-Predicate,http://schema.org/object-input,< 1K
-Predicate,http://schema.org/object-output,< 1K
-Predicate,http://schema.org/observationAbout,< 1K
-Predicate,http://schema.org/observationAbout-input,< 1K
-Predicate,http://schema.org/observationAbout-output,< 1K
-Predicate,http://schema.org/observationDate,< 1K
-Predicate,http://schema.org/observationDate-input,< 1K
-Predicate,http://schema.org/observationDate-output,< 1K
-Predicate,http://schema.org/observationPeriod,< 1K
-Predicate,http://schema.org/observationPeriod-input,< 1K
-Predicate,http://schema.org/observationPeriod-output,< 1K
-Predicate,http://schema.org/occupancy,10K - 100K
-Predicate,http://schema.org/occupancy-input,< 1K
-Predicate,http://schema.org/occupancy-output,< 1K
-Predicate,http://schema.org/occupationLocation,10K - 100K
-Predicate,http://schema.org/occupationLocation-input,< 1K
-Predicate,http://schema.org/occupationLocation-output,< 1K
-Predicate,http://schema.org/occupationalCategory,10K - 100K
-Predicate,http://schema.org/occupationalCategory-input,< 1K
-Predicate,http://schema.org/occupationalCategory-output,< 1K
-Predicate,http://schema.org/occupationalCredentialAwarded,1K - 10K
-Predicate,http://schema.org/occupationalCredentialAwarded-input,< 1K
-Predicate,http://schema.org/occupationalCredentialAwarded-output,< 1K
-Predicate,http://schema.org/offerCount,1M - 10M
-Predicate,http://schema.org/offerCount-input,< 1K
-Predicate,http://schema.org/offerCount-output,< 1K
-Predicate,http://schema.org/offeredBy,10K - 100K
-Predicate,http://schema.org/offeredBy-input,< 1K
-Predicate,http://schema.org/offeredBy-output,< 1K
-Predicate,http://schema.org/offers,10M+
-Predicate,http://schema.org/offers-input,< 1K
-Predicate,http://schema.org/offers-output,< 1K
-Predicate,http://schema.org/offersPrescriptionByMail,< 1K
-Predicate,http://schema.org/offersPrescriptionByMail-input,< 1K
-Predicate,http://schema.org/offersPrescriptionByMail-output,< 1K
-Predicate,http://schema.org/openingHours,1M - 10M
-Predicate,http://schema.org/openingHours-input,< 1K
-Predicate,http://schema.org/openingHours-output,< 1K
-Predicate,http://schema.org/openingHoursSpecification,1M - 10M
-Predicate,http://schema.org/openingHoursSpecification-input,< 1K
-Predicate,http://schema.org/openingHoursSpecification-output,< 1K
-Predicate,http://schema.org/opens,1M - 10M
-Predicate,http://schema.org/opens-input,< 1K
-Predicate,http://schema.org/opens-output,< 1K
-Predicate,http://schema.org/operatingSystem,1M - 10M
-Predicate,http://schema.org/operatingSystem-input,< 1K
-Predicate,http://schema.org/operatingSystem-output,< 1K
-Predicate,http://schema.org/opponent,< 1K
-Predicate,http://schema.org/opponent-input,< 1K
-Predicate,http://schema.org/opponent-output,< 1K
-Predicate,http://schema.org/option,< 1K
-Predicate,http://schema.org/option-input,< 1K
-Predicate,http://schema.org/option-output,< 1K
-Predicate,http://schema.org/orderDate,< 1K
-Predicate,http://schema.org/orderDate-input,< 1K
-Predicate,http://schema.org/orderDate-output,< 1K
-Predicate,http://schema.org/orderDelivery,< 1K
-Predicate,http://schema.org/orderDelivery-input,< 1K
-Predicate,http://schema.org/orderDelivery-output,< 1K
-Predicate,http://schema.org/orderItemNumber,< 1K
-Predicate,http://schema.org/orderItemNumber-input,< 1K
-Predicate,http://schema.org/orderItemNumber-output,< 1K
-Predicate,http://schema.org/orderItemStatus,< 1K
-Predicate,http://schema.org/orderItemStatus-input,< 1K
-Predicate,http://schema.org/orderItemStatus-output,< 1K
-Predicate,http://schema.org/orderNumber,< 1K
-Predicate,http://schema.org/orderNumber-input,< 1K
-Predicate,http://schema.org/orderNumber-output,< 1K
-Predicate,http://schema.org/orderPercentage,< 1K
-Predicate,http://schema.org/orderPercentage-input,< 1K
-Predicate,http://schema.org/orderPercentage-output,< 1K
-Predicate,http://schema.org/orderQuantity,< 1K
-Predicate,http://schema.org/orderQuantity-input,< 1K
-Predicate,http://schema.org/orderQuantity-output,< 1K
-Predicate,http://schema.org/orderStatus,< 1K
-Predicate,http://schema.org/orderStatus-input,< 1K
-Predicate,http://schema.org/orderStatus-output,< 1K
-Predicate,http://schema.org/orderValue,< 1K
-Predicate,http://schema.org/orderValue-input,< 1K
-Predicate,http://schema.org/orderValue-output,< 1K
-Predicate,http://schema.org/orderedItem,< 1K
-Predicate,http://schema.org/orderedItem-input,< 1K
-Predicate,http://schema.org/orderedItem-output,< 1K
-Predicate,http://schema.org/organizer,100K - 1M
-Predicate,http://schema.org/organizer-input,< 1K
-Predicate,http://schema.org/organizer-output,< 1K
-Predicate,http://schema.org/originAddress,< 1K
-Predicate,http://schema.org/originAddress-input,< 1K
-Predicate,http://schema.org/originAddress-output,< 1K
-Predicate,http://schema.org/originalMediaContextDescription,< 1K
-Predicate,http://schema.org/originalMediaContextDescription-input,< 1K
-Predicate,http://schema.org/originalMediaContextDescription-output,< 1K
-Predicate,http://schema.org/originalMediaLink,< 1K
-Predicate,http://schema.org/originalMediaLink-input,< 1K
-Predicate,http://schema.org/originalMediaLink-output,< 1K
-Predicate,http://schema.org/originatesFrom,< 1K
-Predicate,http://schema.org/originatesFrom-input,< 1K
-Predicate,http://schema.org/originatesFrom-output,< 1K
-Predicate,http://schema.org/overdosage,< 1K
-Predicate,http://schema.org/overdosage-input,< 1K
-Predicate,http://schema.org/overdosage-output,< 1K
-Predicate,http://schema.org/ownedFrom,< 1K
-Predicate,http://schema.org/ownedFrom-input,< 1K
-Predicate,http://schema.org/ownedFrom-output,< 1K
-Predicate,http://schema.org/ownedThrough,< 1K
-Predicate,http://schema.org/ownedThrough-input,< 1K
-Predicate,http://schema.org/ownedThrough-output,< 1K
-Predicate,http://schema.org/owner,1K - 10K
-Predicate,http://schema.org/owner-input,< 1K
-Predicate,http://schema.org/owner-output,< 1K
-Predicate,http://schema.org/ownershipFundingInfo,10K - 100K
-Predicate,http://schema.org/ownershipFundingInfo-input,< 1K
-Predicate,http://schema.org/ownershipFundingInfo-output,< 1K
-Predicate,http://schema.org/owns,10K - 100K
-Predicate,http://schema.org/owns-input,< 1K
-Predicate,http://schema.org/owns-output,< 1K
-Predicate,http://schema.org/pageEnd,1K - 10K
-Predicate,http://schema.org/pageEnd-input,< 1K
-Predicate,http://schema.org/pageEnd-output,< 1K
-Predicate,http://schema.org/pageStart,1K - 10K
-Predicate,http://schema.org/pageStart-input,< 1K
-Predicate,http://schema.org/pageStart-output,< 1K
-Predicate,http://schema.org/pagination,1K - 10K
-Predicate,http://schema.org/pagination-input,< 1K
-Predicate,http://schema.org/pagination-output,< 1K
-Predicate,http://schema.org/parent,1K - 10K
-Predicate,http://schema.org/parent-input,< 1K
-Predicate,http://schema.org/parent-output,< 1K
-Predicate,http://schema.org/parentItem,1K - 10K
-Predicate,http://schema.org/parentItem-input,< 1K
-Predicate,http://schema.org/parentItem-output,< 1K
-Predicate,http://schema.org/parentOrganization,100K - 1M
-Predicate,http://schema.org/parentOrganization-input,< 1K
-Predicate,http://schema.org/parentOrganization-output,< 1K
-Predicate,http://schema.org/parentService,< 1K
-Predicate,http://schema.org/parentService-input,< 1K
-Predicate,http://schema.org/parentService-output,< 1K
-Predicate,http://schema.org/parentTaxon,< 1K
-Predicate,http://schema.org/parentTaxon-input,< 1K
-Predicate,http://schema.org/parentTaxon-output,< 1K
-Predicate,http://schema.org/parents,< 1K
-Predicate,http://schema.org/parents-input,< 1K
-Predicate,http://schema.org/parents-output,< 1K
-Predicate,http://schema.org/partOfEpisode,< 1K
-Predicate,http://schema.org/partOfEpisode-input,< 1K
-Predicate,http://schema.org/partOfEpisode-output,< 1K
-Predicate,http://schema.org/partOfInvoice,< 1K
-Predicate,http://schema.org/partOfInvoice-input,< 1K
-Predicate,http://schema.org/partOfInvoice-output,< 1K
-Predicate,http://schema.org/partOfOrder,< 1K
-Predicate,http://schema.org/partOfOrder-input,< 1K
-Predicate,http://schema.org/partOfOrder-output,< 1K
-Predicate,http://schema.org/partOfSeason,1K - 10K
-Predicate,http://schema.org/partOfSeason-input,< 1K
-Predicate,http://schema.org/partOfSeason-output,< 1K
-Predicate,http://schema.org/partOfSeries,10K - 100K
-Predicate,http://schema.org/partOfSeries-input,< 1K
-Predicate,http://schema.org/partOfSeries-output,< 1K
-Predicate,http://schema.org/partOfSystem,< 1K
-Predicate,http://schema.org/partOfSystem-input,< 1K
-Predicate,http://schema.org/partOfSystem-output,< 1K
-Predicate,http://schema.org/partOfTVSeries,< 1K
-Predicate,http://schema.org/partOfTVSeries-input,< 1K
-Predicate,http://schema.org/partOfTVSeries-output,< 1K
-Predicate,http://schema.org/partOfTrip,< 1K
-Predicate,http://schema.org/partOfTrip-input,< 1K
-Predicate,http://schema.org/partOfTrip-output,< 1K
-Predicate,http://schema.org/participant,1K - 10K
-Predicate,http://schema.org/participant-input,< 1K
-Predicate,http://schema.org/participant-output,< 1K
-Predicate,http://schema.org/partySize,< 1K
-Predicate,http://schema.org/partySize-input,< 1K
-Predicate,http://schema.org/partySize-output,< 1K
-Predicate,http://schema.org/passengerPriorityStatus,< 1K
-Predicate,http://schema.org/passengerPriorityStatus-input,< 1K
-Predicate,http://schema.org/passengerPriorityStatus-output,< 1K
-Predicate,http://schema.org/passengerSequenceNumber,< 1K
-Predicate,http://schema.org/passengerSequenceNumber-input,< 1K
-Predicate,http://schema.org/passengerSequenceNumber-output,< 1K
-Predicate,http://schema.org/pathophysiology,< 1K
-Predicate,http://schema.org/pathophysiology-input,< 1K
-Predicate,http://schema.org/pathophysiology-output,< 1K
-Predicate,http://schema.org/pattern,1K - 10K
-Predicate,http://schema.org/pattern-input,< 1K
-Predicate,http://schema.org/pattern-output,< 1K
-Predicate,http://schema.org/payload,1K - 10K
-Predicate,http://schema.org/payload-input,< 1K
-Predicate,http://schema.org/payload-output,< 1K
-Predicate,http://schema.org/paymentAccepted,100K - 1M
-Predicate,http://schema.org/paymentAccepted-input,< 1K
-Predicate,http://schema.org/paymentAccepted-output,< 1K
-Predicate,http://schema.org/paymentDue,< 1K
-Predicate,http://schema.org/paymentDue-input,< 1K
-Predicate,http://schema.org/paymentDue-output,< 1K
-Predicate,http://schema.org/paymentDueDate,< 1K
-Predicate,http://schema.org/paymentDueDate-input,< 1K
-Predicate,http://schema.org/paymentDueDate-output,< 1K
-Predicate,http://schema.org/paymentMethod,< 1K
-Predicate,http://schema.org/paymentMethod-input,< 1K
-Predicate,http://schema.org/paymentMethod-output,< 1K
-Predicate,http://schema.org/paymentMethodId,< 1K
-Predicate,http://schema.org/paymentMethodId-input,< 1K
-Predicate,http://schema.org/paymentMethodId-output,< 1K
-Predicate,http://schema.org/paymentMethodType,1K - 10K
-Predicate,http://schema.org/paymentMethodType-input,< 1K
-Predicate,http://schema.org/paymentMethodType-output,< 1K
-Predicate,http://schema.org/paymentStatus,< 1K
-Predicate,http://schema.org/paymentStatus-input,< 1K
-Predicate,http://schema.org/paymentStatus-output,< 1K
-Predicate,http://schema.org/paymentUrl,< 1K
-Predicate,http://schema.org/paymentUrl-input,< 1K
-Predicate,http://schema.org/paymentUrl-output,< 1K
-Predicate,http://schema.org/penciler,< 1K
-Predicate,http://schema.org/penciler-input,< 1K
-Predicate,http://schema.org/penciler-output,< 1K
-Predicate,http://schema.org/percentile10,1K - 10K
-Predicate,http://schema.org/percentile10-input,< 1K
-Predicate,http://schema.org/percentile10-output,< 1K
-Predicate,http://schema.org/percentile25,1K - 10K
-Predicate,http://schema.org/percentile25-input,< 1K
-Predicate,http://schema.org/percentile25-output,< 1K
-Predicate,http://schema.org/percentile75,1K - 10K
-Predicate,http://schema.org/percentile75-input,< 1K
-Predicate,http://schema.org/percentile75-output,< 1K
-Predicate,http://schema.org/percentile90,1K - 10K
-Predicate,http://schema.org/percentile90-input,< 1K
-Predicate,http://schema.org/percentile90-output,< 1K
-Predicate,http://schema.org/performTime,1K - 10K
-Predicate,http://schema.org/performTime-input,< 1K
-Predicate,http://schema.org/performTime-output,< 1K
-Predicate,http://schema.org/performer,100K - 1M
-Predicate,http://schema.org/performer-input,< 1K
-Predicate,http://schema.org/performer-output,< 1K
-Predicate,http://schema.org/performerIn,1K - 10K
-Predicate,http://schema.org/performerIn-input,< 1K
-Predicate,http://schema.org/performerIn-output,< 1K
-Predicate,http://schema.org/performers,10K - 100K
-Predicate,http://schema.org/performers-input,< 1K
-Predicate,http://schema.org/performers-output,< 1K
-Predicate,http://schema.org/permissionType,< 1K
-Predicate,http://schema.org/permissionType-input,< 1K
-Predicate,http://schema.org/permissionType-output,< 1K
-Predicate,http://schema.org/permissions,10K - 100K
-Predicate,http://schema.org/permissions-input,< 1K
-Predicate,http://schema.org/permissions-output,< 1K
-Predicate,http://schema.org/permitAudience,< 1K
-Predicate,http://schema.org/permitAudience-input,< 1K
-Predicate,http://schema.org/permitAudience-output,< 1K
-Predicate,http://schema.org/permittedUsage,< 1K
-Predicate,http://schema.org/permittedUsage-input,< 1K
-Predicate,http://schema.org/permittedUsage-output,< 1K
-Predicate,http://schema.org/petsAllowed,10K - 100K
-Predicate,http://schema.org/petsAllowed-input,< 1K
-Predicate,http://schema.org/petsAllowed-output,< 1K
-Predicate,http://schema.org/phoneticText,< 1K
-Predicate,http://schema.org/phoneticText-input,< 1K
-Predicate,http://schema.org/phoneticText-output,< 1K
-Predicate,http://schema.org/photo,10K - 100K
-Predicate,http://schema.org/photo-input,< 1K
-Predicate,http://schema.org/photo-output,< 1K
-Predicate,http://schema.org/photos,10K - 100K
-Predicate,http://schema.org/photos-input,< 1K
-Predicate,http://schema.org/photos-output,< 1K
-Predicate,http://schema.org/physicalRequirement,< 1K
-Predicate,http://schema.org/physicalRequirement-input,< 1K
-Predicate,http://schema.org/physicalRequirement-output,< 1K
-Predicate,http://schema.org/physiologicalBenefits,< 1K
-Predicate,http://schema.org/physiologicalBenefits-input,< 1K
-Predicate,http://schema.org/physiologicalBenefits-output,< 1K
-Predicate,http://schema.org/pickupLocation,< 1K
-Predicate,http://schema.org/pickupLocation-input,< 1K
-Predicate,http://schema.org/pickupLocation-output,< 1K
-Predicate,http://schema.org/pickupTime,< 1K
-Predicate,http://schema.org/pickupTime-input,< 1K
-Predicate,http://schema.org/pickupTime-output,< 1K
-Predicate,http://schema.org/playMode,10K - 100K
-Predicate,http://schema.org/playMode-input,< 1K
-Predicate,http://schema.org/playMode-output,< 1K
-Predicate,http://schema.org/playerType,1K - 10K
-Predicate,http://schema.org/playerType-input,< 1K
-Predicate,http://schema.org/playerType-output,< 1K
-Predicate,http://schema.org/playersOnline,1K - 10K
-Predicate,http://schema.org/playersOnline-input,< 1K
-Predicate,http://schema.org/playersOnline-output,< 1K
-Predicate,http://schema.org/polygon,1K - 10K
-Predicate,http://schema.org/polygon-input,< 1K
-Predicate,http://schema.org/polygon-output,< 1K
-Predicate,http://schema.org/populationType,< 1K
-Predicate,http://schema.org/populationType-input,< 1K
-Predicate,http://schema.org/populationType-output,< 1K
-Predicate,http://schema.org/position,10M+
-Predicate,http://schema.org/position-input,< 1K
-Predicate,http://schema.org/position-output,< 1K
-Predicate,http://schema.org/positiveNotes,10K - 100K
-Predicate,http://schema.org/positiveNotes-input,< 1K
-Predicate,http://schema.org/positiveNotes-output,< 1K
-Predicate,http://schema.org/possibleComplication,1K - 10K
-Predicate,http://schema.org/possibleComplication-input,< 1K
-Predicate,http://schema.org/possibleComplication-output,< 1K
-Predicate,http://schema.org/possibleTreatment,1K - 10K
-Predicate,http://schema.org/possibleTreatment-input,< 1K
-Predicate,http://schema.org/possibleTreatment-output,< 1K
-Predicate,http://schema.org/postOfficeBoxNumber,10K - 100K
-Predicate,http://schema.org/postOfficeBoxNumber-input,< 1K
-Predicate,http://schema.org/postOfficeBoxNumber-output,< 1K
-Predicate,http://schema.org/postOp,< 1K
-Predicate,http://schema.org/postOp-input,< 1K
-Predicate,http://schema.org/postOp-output,< 1K
-Predicate,http://schema.org/postalCode,1M - 10M
-Predicate,http://schema.org/postalCode-input,< 1K
-Predicate,http://schema.org/postalCode-output,< 1K
-Predicate,http://schema.org/postalCodeBegin,1K - 10K
-Predicate,http://schema.org/postalCodeBegin-input,< 1K
-Predicate,http://schema.org/postalCodeBegin-output,< 1K
-Predicate,http://schema.org/postalCodeEnd,1K - 10K
-Predicate,http://schema.org/postalCodeEnd-input,< 1K
-Predicate,http://schema.org/postalCodeEnd-output,< 1K
-Predicate,http://schema.org/postalCodePrefix,< 1K
-Predicate,http://schema.org/postalCodePrefix-input,< 1K
-Predicate,http://schema.org/postalCodePrefix-output,< 1K
-Predicate,http://schema.org/postalCodeRange,1K - 10K
-Predicate,http://schema.org/postalCodeRange-input,< 1K
-Predicate,http://schema.org/postalCodeRange-output,< 1K
-Predicate,http://schema.org/potentialAction,10M+
-Predicate,http://schema.org/potentialAction-input,< 1K
-Predicate,http://schema.org/potentialAction-output,< 1K
-Predicate,http://schema.org/potentialUse,< 1K
-Predicate,http://schema.org/potentialUse-input,< 1K
-Predicate,http://schema.org/potentialUse-output,< 1K
-Predicate,http://schema.org/practicesAt,1K - 10K
-Predicate,http://schema.org/practicesAt-input,< 1K
-Predicate,http://schema.org/practicesAt-output,< 1K
-Predicate,http://schema.org/preOp,< 1K
-Predicate,http://schema.org/preOp-input,< 1K
-Predicate,http://schema.org/preOp-output,< 1K
-Predicate,http://schema.org/predecessorOf,< 1K
-Predicate,http://schema.org/predecessorOf-input,< 1K
-Predicate,http://schema.org/predecessorOf-output,< 1K
-Predicate,http://schema.org/pregnancyCategory,< 1K
-Predicate,http://schema.org/pregnancyCategory-input,< 1K
-Predicate,http://schema.org/pregnancyCategory-output,< 1K
-Predicate,http://schema.org/pregnancyWarning,< 1K
-Predicate,http://schema.org/pregnancyWarning-input,< 1K
-Predicate,http://schema.org/pregnancyWarning-output,< 1K
-Predicate,http://schema.org/prepTime,10K - 100K
-Predicate,http://schema.org/prepTime-input,< 1K
-Predicate,http://schema.org/prepTime-output,< 1K
-Predicate,http://schema.org/preparation,1K - 10K
-Predicate,http://schema.org/preparation-input,< 1K
-Predicate,http://schema.org/preparation-output,< 1K
-Predicate,http://schema.org/prescribingInfo,< 1K
-Predicate,http://schema.org/prescribingInfo-input,< 1K
-Predicate,http://schema.org/prescribingInfo-output,< 1K
-Predicate,http://schema.org/prescriptionStatus,1K - 10K
-Predicate,http://schema.org/prescriptionStatus-input,< 1K
-Predicate,http://schema.org/prescriptionStatus-output,< 1K
-Predicate,http://schema.org/previousItem,1M - 10M
-Predicate,http://schema.org/previousItem-input,< 1K
-Predicate,http://schema.org/previousItem-output,< 1K
-Predicate,http://schema.org/previousStartDate,1K - 10K
-Predicate,http://schema.org/previousStartDate-input,< 1K
-Predicate,http://schema.org/previousStartDate-output,< 1K
-Predicate,http://schema.org/price,10M+
-Predicate,http://schema.org/price-input,< 1K
-Predicate,http://schema.org/price-output,< 1K
-Predicate,http://schema.org/priceComponent,1K - 10K
-Predicate,http://schema.org/priceComponent-input,< 1K
-Predicate,http://schema.org/priceComponent-output,< 1K
-Predicate,http://schema.org/priceComponentType,< 1K
-Predicate,http://schema.org/priceComponentType-input,< 1K
-Predicate,http://schema.org/priceComponentType-output,< 1K
-Predicate,http://schema.org/priceCurrency,10M+
-Predicate,http://schema.org/priceCurrency-input,< 1K
-Predicate,http://schema.org/priceCurrency-output,< 1K
-Predicate,http://schema.org/priceRange,1M - 10M
-Predicate,http://schema.org/priceRange-input,< 1K
-Predicate,http://schema.org/priceRange-output,< 1K
-Predicate,http://schema.org/priceSpecification,1M - 10M
-Predicate,http://schema.org/priceSpecification-input,< 1K
-Predicate,http://schema.org/priceSpecification-output,< 1K
-Predicate,http://schema.org/priceType,100K - 1M
-Predicate,http://schema.org/priceType-input,< 1K
-Predicate,http://schema.org/priceType-output,< 1K
-Predicate,http://schema.org/priceValidUntil,1M - 10M
-Predicate,http://schema.org/priceValidUntil-input,< 1K
-Predicate,http://schema.org/priceValidUntil-output,< 1K
-Predicate,http://schema.org/primaryImageOfPage,10M+
-Predicate,http://schema.org/primaryImageOfPage-input,< 1K
-Predicate,http://schema.org/primaryImageOfPage-output,< 1K
-Predicate,http://schema.org/primaryPrevention,< 1K
-Predicate,http://schema.org/primaryPrevention-input,< 1K
-Predicate,http://schema.org/primaryPrevention-output,< 1K
-Predicate,http://schema.org/printColumn,< 1K
-Predicate,http://schema.org/printColumn-input,< 1K
-Predicate,http://schema.org/printColumn-output,< 1K
-Predicate,http://schema.org/printEdition,< 1K
-Predicate,http://schema.org/printEdition-input,< 1K
-Predicate,http://schema.org/printEdition-output,< 1K
-Predicate,http://schema.org/printPage,< 1K
-Predicate,http://schema.org/printPage-input,< 1K
-Predicate,http://schema.org/printPage-output,< 1K
-Predicate,http://schema.org/printSection,< 1K
-Predicate,http://schema.org/printSection-input,< 1K
-Predicate,http://schema.org/printSection-output,< 1K
-Predicate,http://schema.org/procedure,< 1K
-Predicate,http://schema.org/procedure-input,< 1K
-Predicate,http://schema.org/procedure-output,< 1K
-Predicate,http://schema.org/procedureType,10K - 100K
-Predicate,http://schema.org/procedureType-input,< 1K
-Predicate,http://schema.org/procedureType-output,< 1K
-Predicate,http://schema.org/processingTime,< 1K
-Predicate,http://schema.org/processingTime-input,< 1K
-Predicate,http://schema.org/processingTime-output,< 1K
-Predicate,http://schema.org/processorRequirements,1K - 10K
-Predicate,http://schema.org/processorRequirements-input,< 1K
-Predicate,http://schema.org/processorRequirements-output,< 1K
-Predicate,http://schema.org/producer,1K - 10K
-Predicate,http://schema.org/producer-input,< 1K
-Predicate,http://schema.org/producer-output,< 1K
-Predicate,http://schema.org/produces,< 1K
-Predicate,http://schema.org/produces-input,< 1K
-Predicate,http://schema.org/produces-output,< 1K
-Predicate,http://schema.org/productGroupID,100K - 1M
-Predicate,http://schema.org/productGroupID-input,< 1K
-Predicate,http://schema.org/productGroupID-output,< 1K
-Predicate,http://schema.org/productID,100K - 1M
-Predicate,http://schema.org/productID-input,< 1K
-Predicate,http://schema.org/productID-output,< 1K
-Predicate,http://schema.org/productReturnDays,< 1K
-Predicate,http://schema.org/productReturnDays-input,< 1K
-Predicate,http://schema.org/productReturnDays-output,< 1K
-Predicate,http://schema.org/productReturnLink,< 1K
-Predicate,http://schema.org/productReturnLink-input,< 1K
-Predicate,http://schema.org/productReturnLink-output,< 1K
-Predicate,http://schema.org/productSupported,1K - 10K
-Predicate,http://schema.org/productSupported-input,< 1K
-Predicate,http://schema.org/productSupported-output,< 1K
-Predicate,http://schema.org/productionCompany,1K - 10K
-Predicate,http://schema.org/productionCompany-input,< 1K
-Predicate,http://schema.org/productionCompany-output,< 1K
-Predicate,http://schema.org/productionDate,10K - 100K
-Predicate,http://schema.org/productionDate-input,< 1K
-Predicate,http://schema.org/productionDate-output,< 1K
-Predicate,http://schema.org/proficiencyLevel,10K - 100K
-Predicate,http://schema.org/proficiencyLevel-input,< 1K
-Predicate,http://schema.org/proficiencyLevel-output,< 1K
-Predicate,http://schema.org/program,< 1K
-Predicate,http://schema.org/program-input,< 1K
-Predicate,http://schema.org/program-output,< 1K
-Predicate,http://schema.org/programMembershipUsed,< 1K
-Predicate,http://schema.org/programMembershipUsed-input,< 1K
-Predicate,http://schema.org/programMembershipUsed-output,< 1K
-Predicate,http://schema.org/programName,1K - 10K
-Predicate,http://schema.org/programName-input,< 1K
-Predicate,http://schema.org/programName-output,< 1K
-Predicate,http://schema.org/programPrerequisites,1K - 10K
-Predicate,http://schema.org/programPrerequisites-input,< 1K
-Predicate,http://schema.org/programPrerequisites-output,< 1K
-Predicate,http://schema.org/programType,1K - 10K
-Predicate,http://schema.org/programType-input,< 1K
-Predicate,http://schema.org/programType-output,< 1K
-Predicate,http://schema.org/programmingLanguage,1K - 10K
-Predicate,http://schema.org/programmingLanguage-input,< 1K
-Predicate,http://schema.org/programmingLanguage-output,< 1K
-Predicate,http://schema.org/programmingModel,< 1K
-Predicate,http://schema.org/programmingModel-input,< 1K
-Predicate,http://schema.org/programmingModel-output,< 1K
-Predicate,http://schema.org/pronouns,1K - 10K
-Predicate,http://schema.org/pronouns-input,< 1K
-Predicate,http://schema.org/pronouns-output,< 1K
-Predicate,http://schema.org/propertyID,10K - 100K
-Predicate,http://schema.org/propertyID-input,< 1K
-Predicate,http://schema.org/propertyID-output,< 1K
-Predicate,http://schema.org/proprietaryName,< 1K
-Predicate,http://schema.org/proprietaryName-input,< 1K
-Predicate,http://schema.org/proprietaryName-output,< 1K
-Predicate,http://schema.org/proteinContent,10K - 100K
-Predicate,http://schema.org/proteinContent-input,< 1K
-Predicate,http://schema.org/proteinContent-output,< 1K
-Predicate,http://schema.org/provider,1M - 10M
-Predicate,http://schema.org/provider-input,< 1K
-Predicate,http://schema.org/provider-output,< 1K
-Predicate,http://schema.org/providerMobility,1K - 10K
-Predicate,http://schema.org/providerMobility-input,< 1K
-Predicate,http://schema.org/providerMobility-output,< 1K
-Predicate,http://schema.org/providesBroadcastService,< 1K
-Predicate,http://schema.org/providesBroadcastService-input,< 1K
-Predicate,http://schema.org/providesBroadcastService-output,< 1K
-Predicate,http://schema.org/providesService,< 1K
-Predicate,http://schema.org/providesService-input,< 1K
-Predicate,http://schema.org/providesService-output,< 1K
-Predicate,http://schema.org/publicAccess,10K - 100K
-Predicate,http://schema.org/publicAccess-input,< 1K
-Predicate,http://schema.org/publicAccess-output,< 1K
-Predicate,http://schema.org/publicTransportClosuresInfo,< 1K
-Predicate,http://schema.org/publicTransportClosuresInfo-input,< 1K
-Predicate,http://schema.org/publicTransportClosuresInfo-output,< 1K
-Predicate,http://schema.org/publication,1K - 10K
-Predicate,http://schema.org/publication-input,< 1K
-Predicate,http://schema.org/publication-output,< 1K
-Predicate,http://schema.org/publicationType,< 1K
-Predicate,http://schema.org/publicationType-input,< 1K
-Predicate,http://schema.org/publicationType-output,< 1K
-Predicate,http://schema.org/publishedBy,< 1K
-Predicate,http://schema.org/publishedBy-input,< 1K
-Predicate,http://schema.org/publishedBy-output,< 1K
-Predicate,http://schema.org/publishedOn,< 1K
-Predicate,http://schema.org/publishedOn-input,< 1K
-Predicate,http://schema.org/publishedOn-output,< 1K
-Predicate,http://schema.org/publisher,10M+
-Predicate,http://schema.org/publisher-input,< 1K
-Predicate,http://schema.org/publisher-output,< 1K
-Predicate,http://schema.org/publisherImprint,< 1K
-Predicate,http://schema.org/publisherImprint-input,< 1K
-Predicate,http://schema.org/publisherImprint-output,< 1K
-Predicate,http://schema.org/publishingPrinciples,10K - 100K
-Predicate,http://schema.org/publishingPrinciples-input,< 1K
-Predicate,http://schema.org/publishingPrinciples-output,< 1K
-Predicate,http://schema.org/purchaseDate,< 1K
-Predicate,http://schema.org/purchaseDate-input,< 1K
-Predicate,http://schema.org/purchaseDate-output,< 1K
-Predicate,http://schema.org/purchasePriceLimit,< 1K
-Predicate,http://schema.org/purchasePriceLimit-input,< 1K
-Predicate,http://schema.org/purchasePriceLimit-output,< 1K
-Predicate,http://schema.org/purchaseType,< 1K
-Predicate,http://schema.org/purchaseType-input,< 1K
-Predicate,http://schema.org/purchaseType-output,< 1K
-Predicate,http://schema.org/qualifications,10K - 100K
-Predicate,http://schema.org/qualifications-input,< 1K
-Predicate,http://schema.org/qualifications-output,< 1K
-Predicate,http://schema.org/qualifiedExpense,< 1K
-Predicate,http://schema.org/qualifiedExpense-input,< 1K
-Predicate,http://schema.org/qualifiedExpense-output,< 1K
-Predicate,http://schema.org/quarantineGuidelines,< 1K
-Predicate,http://schema.org/quarantineGuidelines-input,< 1K
-Predicate,http://schema.org/quarantineGuidelines-output,< 1K
-Predicate,http://schema.org/query,10K - 100K
-Predicate,http://schema.org/query-input,10M+
-Predicate,http://schema.org/query-output,< 1K
-Predicate,http://schema.org/quest,< 1K
-Predicate,http://schema.org/quest-input,< 1K
-Predicate,http://schema.org/quest-output,< 1K
-Predicate,http://schema.org/question,< 1K
-Predicate,http://schema.org/question-input,< 1K
-Predicate,http://schema.org/question-output,< 1K
-Predicate,http://schema.org/rangeIncludes,< 1K
-Predicate,http://schema.org/rangeIncludes-input,< 1K
-Predicate,http://schema.org/rangeIncludes-output,< 1K
-Predicate,http://schema.org/ratingCount,1M - 10M
-Predicate,http://schema.org/ratingCount-input,< 1K
-Predicate,http://schema.org/ratingCount-output,< 1K
-Predicate,http://schema.org/ratingExplanation,1K - 10K
-Predicate,http://schema.org/ratingExplanation-input,< 1K
-Predicate,http://schema.org/ratingExplanation-output,< 1K
-Predicate,http://schema.org/ratingValue,1M - 10M
-Predicate,http://schema.org/ratingValue-input,< 1K
-Predicate,http://schema.org/ratingValue-output,< 1K
-Predicate,http://schema.org/readBy,< 1K
-Predicate,http://schema.org/readBy-input,< 1K
-Predicate,http://schema.org/readBy-output,< 1K
-Predicate,http://schema.org/readonlyValue,< 1K
-Predicate,http://schema.org/readonlyValue-input,< 1K
-Predicate,http://schema.org/readonlyValue-output,< 1K
-Predicate,http://schema.org/realEstateAgent,< 1K
-Predicate,http://schema.org/realEstateAgent-input,< 1K
-Predicate,http://schema.org/realEstateAgent-output,< 1K
-Predicate,http://schema.org/recipe,< 1K
-Predicate,http://schema.org/recipe-input,< 1K
-Predicate,http://schema.org/recipe-output,< 1K
-Predicate,http://schema.org/recipeCategory,10K - 100K
-Predicate,http://schema.org/recipeCategory-input,< 1K
-Predicate,http://schema.org/recipeCategory-output,< 1K
-Predicate,http://schema.org/recipeCuisine,10K - 100K
-Predicate,http://schema.org/recipeCuisine-input,< 1K
-Predicate,http://schema.org/recipeCuisine-output,< 1K
-Predicate,http://schema.org/recipeIngredient,10K - 100K
-Predicate,http://schema.org/recipeIngredient-input,< 1K
-Predicate,http://schema.org/recipeIngredient-output,< 1K
-Predicate,http://schema.org/recipeInstructions,10K - 100K
-Predicate,http://schema.org/recipeInstructions-input,< 1K
-Predicate,http://schema.org/recipeInstructions-output,< 1K
-Predicate,http://schema.org/recipeYield,10K - 100K
-Predicate,http://schema.org/recipeYield-input,< 1K
-Predicate,http://schema.org/recipeYield-output,< 1K
-Predicate,http://schema.org/recipient,1K - 10K
-Predicate,http://schema.org/recipient-input,< 1K
-Predicate,http://schema.org/recipient-output,< 1K
-Predicate,http://schema.org/recognizedBy,10K - 100K
-Predicate,http://schema.org/recognizedBy-input,< 1K
-Predicate,http://schema.org/recognizedBy-output,< 1K
-Predicate,http://schema.org/recognizingAuthority,1K - 10K
-Predicate,http://schema.org/recognizingAuthority-input,< 1K
-Predicate,http://schema.org/recognizingAuthority-output,< 1K
-Predicate,http://schema.org/recommendationStrength,< 1K
-Predicate,http://schema.org/recommendationStrength-input,< 1K
-Predicate,http://schema.org/recommendationStrength-output,< 1K
-Predicate,http://schema.org/recommendedIntake,< 1K
-Predicate,http://schema.org/recommendedIntake-input,< 1K
-Predicate,http://schema.org/recommendedIntake-output,< 1K
-Predicate,http://schema.org/recordLabel,1K - 10K
-Predicate,http://schema.org/recordLabel-input,< 1K
-Predicate,http://schema.org/recordLabel-output,< 1K
-Predicate,http://schema.org/recordedAs,< 1K
-Predicate,http://schema.org/recordedAs-input,< 1K
-Predicate,http://schema.org/recordedAs-output,< 1K
-Predicate,http://schema.org/recordedAt,< 1K
-Predicate,http://schema.org/recordedAt-input,< 1K
-Predicate,http://schema.org/recordedAt-output,< 1K
-Predicate,http://schema.org/recordedIn,< 1K
-Predicate,http://schema.org/recordedIn-input,< 1K
-Predicate,http://schema.org/recordedIn-output,< 1K
-Predicate,http://schema.org/recordingOf,1K - 10K
-Predicate,http://schema.org/recordingOf-input,< 1K
-Predicate,http://schema.org/recordingOf-output,< 1K
-Predicate,http://schema.org/recourseLoan,< 1K
-Predicate,http://schema.org/recourseLoan-input,< 1K
-Predicate,http://schema.org/recourseLoan-output,< 1K
-Predicate,http://schema.org/referee,< 1K
-Predicate,http://schema.org/referee-input,< 1K
-Predicate,http://schema.org/referee-output,< 1K
-Predicate,http://schema.org/referenceQuantity,1M - 10M
-Predicate,http://schema.org/referenceQuantity-input,< 1K
-Predicate,http://schema.org/referenceQuantity-output,< 1K
-Predicate,http://schema.org/referencesOrder,< 1K
-Predicate,http://schema.org/referencesOrder-input,< 1K
-Predicate,http://schema.org/referencesOrder-output,< 1K
-Predicate,http://schema.org/refundType,10K - 100K
-Predicate,http://schema.org/refundType-input,< 1K
-Predicate,http://schema.org/refundType-output,< 1K
-Predicate,http://schema.org/regionDrained,< 1K
-Predicate,http://schema.org/regionDrained-input,< 1K
-Predicate,http://schema.org/regionDrained-output,< 1K
-Predicate,http://schema.org/regionsAllowed,10K - 100K
-Predicate,http://schema.org/regionsAllowed-input,< 1K
-Predicate,http://schema.org/regionsAllowed-output,< 1K
-Predicate,http://schema.org/relatedAnatomy,< 1K
-Predicate,http://schema.org/relatedAnatomy-input,< 1K
-Predicate,http://schema.org/relatedAnatomy-output,< 1K
-Predicate,http://schema.org/relatedCondition,< 1K
-Predicate,http://schema.org/relatedCondition-input,< 1K
-Predicate,http://schema.org/relatedCondition-output,< 1K
-Predicate,http://schema.org/relatedDrug,< 1K
-Predicate,http://schema.org/relatedDrug-input,< 1K
-Predicate,http://schema.org/relatedDrug-output,< 1K
-Predicate,http://schema.org/relatedLink,10K - 100K
-Predicate,http://schema.org/relatedLink-input,< 1K
-Predicate,http://schema.org/relatedLink-output,< 1K
-Predicate,http://schema.org/relatedStructure,< 1K
-Predicate,http://schema.org/relatedStructure-input,< 1K
-Predicate,http://schema.org/relatedStructure-output,< 1K
-Predicate,http://schema.org/relatedTherapy,< 1K
-Predicate,http://schema.org/relatedTherapy-input,< 1K
-Predicate,http://schema.org/relatedTherapy-output,< 1K
-Predicate,http://schema.org/relatedTo,< 1K
-Predicate,http://schema.org/relatedTo-input,< 1K
-Predicate,http://schema.org/relatedTo-output,< 1K
-Predicate,http://schema.org/releaseDate,10K - 100K
-Predicate,http://schema.org/releaseDate-input,< 1K
-Predicate,http://schema.org/releaseDate-output,< 1K
-Predicate,http://schema.org/releaseNotes,10K - 100K
-Predicate,http://schema.org/releaseNotes-input,< 1K
-Predicate,http://schema.org/releaseNotes-output,< 1K
-Predicate,http://schema.org/releaseOf,< 1K
-Predicate,http://schema.org/releaseOf-input,< 1K
-Predicate,http://schema.org/releaseOf-output,< 1K
-Predicate,http://schema.org/releasedEvent,1K - 10K
-Predicate,http://schema.org/releasedEvent-input,< 1K
-Predicate,http://schema.org/releasedEvent-output,< 1K
-Predicate,http://schema.org/relevantOccupation,< 1K
-Predicate,http://schema.org/relevantOccupation-input,< 1K
-Predicate,http://schema.org/relevantOccupation-output,< 1K
-Predicate,http://schema.org/relevantSpecialty,1K - 10K
-Predicate,http://schema.org/relevantSpecialty-input,< 1K
-Predicate,http://schema.org/relevantSpecialty-output,< 1K
-Predicate,http://schema.org/remainingAttendeeCapacity,1K - 10K
-Predicate,http://schema.org/remainingAttendeeCapacity-input,< 1K
-Predicate,http://schema.org/remainingAttendeeCapacity-output,< 1K
-Predicate,http://schema.org/renegotiableLoan,< 1K
-Predicate,http://schema.org/renegotiableLoan-input,< 1K
-Predicate,http://schema.org/renegotiableLoan-output,< 1K
-Predicate,http://schema.org/repeatCount,1K - 10K
-Predicate,http://schema.org/repeatCount-input,< 1K
-Predicate,http://schema.org/repeatCount-output,< 1K
-Predicate,http://schema.org/repeatFrequency,10K - 100K
-Predicate,http://schema.org/repeatFrequency-input,< 1K
-Predicate,http://schema.org/repeatFrequency-output,< 1K
-Predicate,http://schema.org/repetitions,< 1K
-Predicate,http://schema.org/repetitions-input,< 1K
-Predicate,http://schema.org/repetitions-output,< 1K
-Predicate,http://schema.org/replacee,< 1K
-Predicate,http://schema.org/replacee-input,< 1K
-Predicate,http://schema.org/replacee-output,< 1K
-Predicate,http://schema.org/replacer,< 1K
-Predicate,http://schema.org/replacer-input,< 1K
-Predicate,http://schema.org/replacer-output,< 1K
-Predicate,http://schema.org/replyToUrl,1K - 10K
-Predicate,http://schema.org/replyToUrl-input,< 1K
-Predicate,http://schema.org/replyToUrl-output,< 1K
-Predicate,http://schema.org/reportNumber,< 1K
-Predicate,http://schema.org/reportNumber-input,< 1K
-Predicate,http://schema.org/reportNumber-output,< 1K
-Predicate,http://schema.org/representativeOfPage,100K - 1M
-Predicate,http://schema.org/representativeOfPage-input,< 1K
-Predicate,http://schema.org/representativeOfPage-output,< 1K
-Predicate,http://schema.org/requiredCollateral,< 1K
-Predicate,http://schema.org/requiredCollateral-input,< 1K
-Predicate,http://schema.org/requiredCollateral-output,< 1K
-Predicate,http://schema.org/requiredGender,< 1K
-Predicate,http://schema.org/requiredGender-input,< 1K
-Predicate,http://schema.org/requiredGender-output,< 1K
-Predicate,http://schema.org/requiredMaxAge,< 1K
-Predicate,http://schema.org/requiredMaxAge-input,< 1K
-Predicate,http://schema.org/requiredMaxAge-output,< 1K
-Predicate,http://schema.org/requiredMinAge,1K - 10K
-Predicate,http://schema.org/requiredMinAge-input,< 1K
-Predicate,http://schema.org/requiredMinAge-output,< 1K
-Predicate,http://schema.org/requiredQuantity,1K - 10K
-Predicate,http://schema.org/requiredQuantity-input,< 1K
-Predicate,http://schema.org/requiredQuantity-output,< 1K
-Predicate,http://schema.org/requirements,1K - 10K
-Predicate,http://schema.org/requirements-input,< 1K
-Predicate,http://schema.org/requirements-output,< 1K
-Predicate,http://schema.org/requiresSubscription,1K - 10K
-Predicate,http://schema.org/requiresSubscription-input,< 1K
-Predicate,http://schema.org/requiresSubscription-output,< 1K
-Predicate,http://schema.org/reservationFor,1K - 10K
-Predicate,http://schema.org/reservationFor-input,< 1K
-Predicate,http://schema.org/reservationFor-output,< 1K
-Predicate,http://schema.org/reservationId,< 1K
-Predicate,http://schema.org/reservationId-input,< 1K
-Predicate,http://schema.org/reservationId-output,< 1K
-Predicate,http://schema.org/reservationStatus,< 1K
-Predicate,http://schema.org/reservationStatus-input,< 1K
-Predicate,http://schema.org/reservationStatus-output,< 1K
-Predicate,http://schema.org/reservedTicket,< 1K
-Predicate,http://schema.org/reservedTicket-input,< 1K
-Predicate,http://schema.org/reservedTicket-output,< 1K
-Predicate,http://schema.org/responsibilities,10K - 100K
-Predicate,http://schema.org/responsibilities-input,< 1K
-Predicate,http://schema.org/responsibilities-output,< 1K
-Predicate,http://schema.org/restPeriods,< 1K
-Predicate,http://schema.org/restPeriods-input,< 1K
-Predicate,http://schema.org/restPeriods-output,< 1K
-Predicate,http://schema.org/restockingFee,1K - 10K
-Predicate,http://schema.org/restockingFee-input,< 1K
-Predicate,http://schema.org/restockingFee-output,< 1K
-Predicate,http://schema.org/result,10K - 100K
-Predicate,http://schema.org/result-input,< 1K
-Predicate,http://schema.org/result-output,< 1K
-Predicate,http://schema.org/resultComment,< 1K
-Predicate,http://schema.org/resultComment-input,< 1K
-Predicate,http://schema.org/resultComment-output,< 1K
-Predicate,http://schema.org/resultReview,< 1K
-Predicate,http://schema.org/resultReview-input,< 1K
-Predicate,http://schema.org/resultReview-output,< 1K
-Predicate,http://schema.org/returnFees,100K - 1M
-Predicate,http://schema.org/returnFees-input,< 1K
-Predicate,http://schema.org/returnFees-output,< 1K
-Predicate,http://schema.org/returnLabelSource,1K - 10K
-Predicate,http://schema.org/returnLabelSource-input,< 1K
-Predicate,http://schema.org/returnLabelSource-output,< 1K
-Predicate,http://schema.org/returnMethod,100K - 1M
-Predicate,http://schema.org/returnMethod-input,< 1K
-Predicate,http://schema.org/returnMethod-output,< 1K
-Predicate,http://schema.org/returnPolicyCategory,100K - 1M
-Predicate,http://schema.org/returnPolicyCategory-input,< 1K
-Predicate,http://schema.org/returnPolicyCategory-output,< 1K
-Predicate,http://schema.org/returnPolicyCountry,10K - 100K
-Predicate,http://schema.org/returnPolicyCountry-input,< 1K
-Predicate,http://schema.org/returnPolicyCountry-output,< 1K
-Predicate,http://schema.org/returnPolicySeasonalOverride,1K - 10K
-Predicate,http://schema.org/returnPolicySeasonalOverride-input,< 1K
-Predicate,http://schema.org/returnPolicySeasonalOverride-output,< 1K
-Predicate,http://schema.org/returnShippingFeesAmount,10K - 100K
-Predicate,http://schema.org/returnShippingFeesAmount-input,< 1K
-Predicate,http://schema.org/returnShippingFeesAmount-output,< 1K
-Predicate,http://schema.org/review,1M - 10M
-Predicate,http://schema.org/review-input,< 1K
-Predicate,http://schema.org/review-output,< 1K
-Predicate,http://schema.org/reviewAspect,10K - 100K
-Predicate,http://schema.org/reviewAspect-input,< 1K
-Predicate,http://schema.org/reviewAspect-output,< 1K
-Predicate,http://schema.org/reviewBody,1M - 10M
-Predicate,http://schema.org/reviewBody-input,< 1K
-Predicate,http://schema.org/reviewBody-output,< 1K
-Predicate,http://schema.org/reviewCount,1M - 10M
-Predicate,http://schema.org/reviewCount-input,< 1K
-Predicate,http://schema.org/reviewCount-output,< 1K
-Predicate,http://schema.org/reviewRating,1M - 10M
-Predicate,http://schema.org/reviewRating-input,< 1K
-Predicate,http://schema.org/reviewRating-output,< 1K
-Predicate,http://schema.org/reviewedBy,10K - 100K
-Predicate,http://schema.org/reviewedBy-input,< 1K
-Predicate,http://schema.org/reviewedBy-output,< 1K
-Predicate,http://schema.org/reviews,1K - 10K
-Predicate,http://schema.org/reviews-input,< 1K
-Predicate,http://schema.org/reviews-output,< 1K
-Predicate,http://schema.org/riskFactor,1K - 10K
-Predicate,http://schema.org/riskFactor-input,< 1K
-Predicate,http://schema.org/riskFactor-output,< 1K
-Predicate,http://schema.org/risks,< 1K
-Predicate,http://schema.org/risks-input,< 1K
-Predicate,http://schema.org/risks-output,< 1K
-Predicate,http://schema.org/roleName,1K - 10K
-Predicate,http://schema.org/roleName-input,< 1K
-Predicate,http://schema.org/roleName-output,< 1K
-Predicate,http://schema.org/roofLoad,< 1K
-Predicate,http://schema.org/roofLoad-input,< 1K
-Predicate,http://schema.org/roofLoad-output,< 1K
-Predicate,http://schema.org/rsvpResponse,< 1K
-Predicate,http://schema.org/rsvpResponse-input,< 1K
-Predicate,http://schema.org/rsvpResponse-output,< 1K
-Predicate,http://schema.org/runsTo,< 1K
-Predicate,http://schema.org/runsTo-input,< 1K
-Predicate,http://schema.org/runsTo-output,< 1K
-Predicate,http://schema.org/runtime,< 1K
-Predicate,http://schema.org/runtime-input,< 1K
-Predicate,http://schema.org/runtime-output,< 1K
-Predicate,http://schema.org/runtimePlatform,1K - 10K
-Predicate,http://schema.org/runtimePlatform-input,< 1K
-Predicate,http://schema.org/runtimePlatform-output,< 1K
-Predicate,http://schema.org/rxcui,< 1K
-Predicate,http://schema.org/rxcui-input,< 1K
-Predicate,http://schema.org/rxcui-output,< 1K
-Predicate,http://schema.org/safetyConsideration,< 1K
-Predicate,http://schema.org/safetyConsideration-input,< 1K
-Predicate,http://schema.org/safetyConsideration-output,< 1K
-Predicate,http://schema.org/salaryCurrency,1K - 10K
-Predicate,http://schema.org/salaryCurrency-input,< 1K
-Predicate,http://schema.org/salaryCurrency-output,< 1K
-Predicate,http://schema.org/salaryUponCompletion,< 1K
-Predicate,http://schema.org/salaryUponCompletion-input,< 1K
-Predicate,http://schema.org/salaryUponCompletion-output,< 1K
-Predicate,http://schema.org/sameAs,10M+
-Predicate,http://schema.org/sameAs-input,< 1K
-Predicate,http://schema.org/sameAs-output,< 1K
-Predicate,http://schema.org/sampleType,< 1K
-Predicate,http://schema.org/sampleType-input,< 1K
-Predicate,http://schema.org/sampleType-output,< 1K
-Predicate,http://schema.org/saturatedFatContent,10K - 100K
-Predicate,http://schema.org/saturatedFatContent-input,< 1K
-Predicate,http://schema.org/saturatedFatContent-output,< 1K
-Predicate,http://schema.org/scheduleTimezone,1K - 10K
-Predicate,http://schema.org/scheduleTimezone-input,< 1K
-Predicate,http://schema.org/scheduleTimezone-output,< 1K
-Predicate,http://schema.org/scheduledPaymentDate,< 1K
-Predicate,http://schema.org/scheduledPaymentDate-input,< 1K
-Predicate,http://schema.org/scheduledPaymentDate-output,< 1K
-Predicate,http://schema.org/scheduledTime,< 1K
-Predicate,http://schema.org/scheduledTime-input,< 1K
-Predicate,http://schema.org/scheduledTime-output,< 1K
-Predicate,http://schema.org/schemaVersion,< 1K
-Predicate,http://schema.org/schemaVersion-input,< 1K
-Predicate,http://schema.org/schemaVersion-output,< 1K
-Predicate,http://schema.org/schoolClosuresInfo,< 1K
-Predicate,http://schema.org/schoolClosuresInfo-input,< 1K
-Predicate,http://schema.org/schoolClosuresInfo-output,< 1K
-Predicate,http://schema.org/screenCount,< 1K
-Predicate,http://schema.org/screenCount-input,< 1K
-Predicate,http://schema.org/screenCount-output,< 1K
-Predicate,http://schema.org/screenshot,100K - 1M
-Predicate,http://schema.org/screenshot-input,< 1K
-Predicate,http://schema.org/screenshot-output,< 1K
-Predicate,http://schema.org/sdDatePublished,1K - 10K
-Predicate,http://schema.org/sdDatePublished-input,< 1K
-Predicate,http://schema.org/sdDatePublished-output,< 1K
-Predicate,http://schema.org/sdLicense,< 1K
-Predicate,http://schema.org/sdLicense-input,< 1K
-Predicate,http://schema.org/sdLicense-output,< 1K
-Predicate,http://schema.org/sdPublisher,1K - 10K
-Predicate,http://schema.org/sdPublisher-input,< 1K
-Predicate,http://schema.org/sdPublisher-output,< 1K
-Predicate,http://schema.org/season,1K - 10K
-Predicate,http://schema.org/season-input,< 1K
-Predicate,http://schema.org/season-output,< 1K
-Predicate,http://schema.org/seasonNumber,1K - 10K
-Predicate,http://schema.org/seasonNumber-input,< 1K
-Predicate,http://schema.org/seasonNumber-output,< 1K
-Predicate,http://schema.org/seasonalOverride,< 1K
-Predicate,http://schema.org/seasonalOverride-input,< 1K
-Predicate,http://schema.org/seasonalOverride-output,< 1K
-Predicate,http://schema.org/seasons,< 1K
-Predicate,http://schema.org/seasons-input,< 1K
-Predicate,http://schema.org/seasons-output,< 1K
-Predicate,http://schema.org/seatNumber,< 1K
-Predicate,http://schema.org/seatNumber-input,< 1K
-Predicate,http://schema.org/seatNumber-output,< 1K
-Predicate,http://schema.org/seatRow,< 1K
-Predicate,http://schema.org/seatRow-input,< 1K
-Predicate,http://schema.org/seatRow-output,< 1K
-Predicate,http://schema.org/seatSection,< 1K
-Predicate,http://schema.org/seatSection-input,< 1K
-Predicate,http://schema.org/seatSection-output,< 1K
-Predicate,http://schema.org/seatingCapacity,1K - 10K
-Predicate,http://schema.org/seatingCapacity-input,< 1K
-Predicate,http://schema.org/seatingCapacity-output,< 1K
-Predicate,http://schema.org/seatingType,< 1K
-Predicate,http://schema.org/seatingType-input,< 1K
-Predicate,http://schema.org/seatingType-output,< 1K
-Predicate,http://schema.org/secondaryPrevention,< 1K
-Predicate,http://schema.org/secondaryPrevention-input,< 1K
-Predicate,http://schema.org/secondaryPrevention-output,< 1K
-Predicate,http://schema.org/securityClearanceRequirement,< 1K
-Predicate,http://schema.org/securityClearanceRequirement-input,< 1K
-Predicate,http://schema.org/securityClearanceRequirement-output,< 1K
-Predicate,http://schema.org/securityScreening,< 1K
-Predicate,http://schema.org/securityScreening-input,< 1K
-Predicate,http://schema.org/securityScreening-output,< 1K
-Predicate,http://schema.org/seeks,1K - 10K
-Predicate,http://schema.org/seeks-input,< 1K
-Predicate,http://schema.org/seeks-output,< 1K
-Predicate,http://schema.org/seller,1M - 10M
-Predicate,http://schema.org/seller-input,< 1K
-Predicate,http://schema.org/seller-output,< 1K
-Predicate,http://schema.org/sender,< 1K
-Predicate,http://schema.org/sender-input,< 1K
-Predicate,http://schema.org/sender-output,< 1K
-Predicate,http://schema.org/sensoryRequirement,< 1K
-Predicate,http://schema.org/sensoryRequirement-input,< 1K
-Predicate,http://schema.org/sensoryRequirement-output,< 1K
-Predicate,http://schema.org/sensoryUnit,< 1K
-Predicate,http://schema.org/sensoryUnit-input,< 1K
-Predicate,http://schema.org/sensoryUnit-output,< 1K
-Predicate,http://schema.org/serialNumber,10K - 100K
-Predicate,http://schema.org/serialNumber-input,< 1K
-Predicate,http://schema.org/serialNumber-output,< 1K
-Predicate,http://schema.org/seriousAdverseOutcome,< 1K
-Predicate,http://schema.org/seriousAdverseOutcome-input,< 1K
-Predicate,http://schema.org/seriousAdverseOutcome-output,< 1K
-Predicate,http://schema.org/serverStatus,< 1K
-Predicate,http://schema.org/serverStatus-input,< 1K
-Predicate,http://schema.org/serverStatus-output,< 1K
-Predicate,http://schema.org/servesCuisine,100K - 1M
-Predicate,http://schema.org/servesCuisine-input,< 1K
-Predicate,http://schema.org/servesCuisine-output,< 1K
-Predicate,http://schema.org/serviceArea,10K - 100K
-Predicate,http://schema.org/serviceArea-input,< 1K
-Predicate,http://schema.org/serviceArea-output,< 1K
-Predicate,http://schema.org/serviceAudience,1K - 10K
-Predicate,http://schema.org/serviceAudience-input,< 1K
-Predicate,http://schema.org/serviceAudience-output,< 1K
-Predicate,http://schema.org/serviceLocation,10K - 100K
-Predicate,http://schema.org/serviceLocation-input,< 1K
-Predicate,http://schema.org/serviceLocation-output,< 1K
-Predicate,http://schema.org/serviceOperator,1K - 10K
-Predicate,http://schema.org/serviceOperator-input,< 1K
-Predicate,http://schema.org/serviceOperator-output,< 1K
-Predicate,http://schema.org/serviceOutput,10K - 100K
-Predicate,http://schema.org/serviceOutput-input,< 1K
-Predicate,http://schema.org/serviceOutput-output,< 1K
-Predicate,http://schema.org/servicePhone,10K - 100K
-Predicate,http://schema.org/servicePhone-input,< 1K
-Predicate,http://schema.org/servicePhone-output,< 1K
-Predicate,http://schema.org/servicePostalAddress,< 1K
-Predicate,http://schema.org/servicePostalAddress-input,< 1K
-Predicate,http://schema.org/servicePostalAddress-output,< 1K
-Predicate,http://schema.org/serviceSmsNumber,1K - 10K
-Predicate,http://schema.org/serviceSmsNumber-input,< 1K
-Predicate,http://schema.org/serviceSmsNumber-output,< 1K
-Predicate,http://schema.org/serviceType,100K - 1M
-Predicate,http://schema.org/serviceType-input,< 1K
-Predicate,http://schema.org/serviceType-output,< 1K
-Predicate,http://schema.org/serviceUrl,10K - 100K
-Predicate,http://schema.org/serviceUrl-input,< 1K
-Predicate,http://schema.org/serviceUrl-output,< 1K
-Predicate,http://schema.org/servingSize,10K - 100K
-Predicate,http://schema.org/servingSize-input,< 1K
-Predicate,http://schema.org/servingSize-output,< 1K
-Predicate,http://schema.org/sha256,< 1K
-Predicate,http://schema.org/sha256-input,< 1K
-Predicate,http://schema.org/sha256-output,< 1K
-Predicate,http://schema.org/sharedContent,1K - 10K
-Predicate,http://schema.org/sharedContent-input,< 1K
-Predicate,http://schema.org/sharedContent-output,< 1K
-Predicate,http://schema.org/shippingConditions,10K - 100K
-Predicate,http://schema.org/shippingConditions-input,< 1K
-Predicate,http://schema.org/shippingConditions-output,< 1K
-Predicate,http://schema.org/shippingDestination,100K - 1M
-Predicate,http://schema.org/shippingDestination-input,< 1K
-Predicate,http://schema.org/shippingDestination-output,< 1K
-Predicate,http://schema.org/shippingDetails,100K - 1M
-Predicate,http://schema.org/shippingDetails-input,< 1K
-Predicate,http://schema.org/shippingDetails-output,< 1K
-Predicate,http://schema.org/shippingLabel,1K - 10K
-Predicate,http://schema.org/shippingLabel-input,< 1K
-Predicate,http://schema.org/shippingLabel-output,< 1K
-Predicate,http://schema.org/shippingOrigin,10K - 100K
-Predicate,http://schema.org/shippingOrigin-input,< 1K
-Predicate,http://schema.org/shippingOrigin-output,< 1K
-Predicate,http://schema.org/shippingRate,100K - 1M
-Predicate,http://schema.org/shippingRate-input,< 1K
-Predicate,http://schema.org/shippingRate-output,< 1K
-Predicate,http://schema.org/shippingSettingsLink,1K - 10K
-Predicate,http://schema.org/shippingSettingsLink-input,< 1K
-Predicate,http://schema.org/shippingSettingsLink-output,< 1K
-Predicate,http://schema.org/sibling,< 1K
-Predicate,http://schema.org/sibling-input,< 1K
-Predicate,http://schema.org/sibling-output,< 1K
-Predicate,http://schema.org/siblings,< 1K
-Predicate,http://schema.org/siblings-input,< 1K
-Predicate,http://schema.org/siblings-output,< 1K
-Predicate,http://schema.org/signDetected,< 1K
-Predicate,http://schema.org/signDetected-input,< 1K
-Predicate,http://schema.org/signDetected-output,< 1K
-Predicate,http://schema.org/signOrSymptom,1K - 10K
-Predicate,http://schema.org/signOrSymptom-input,< 1K
-Predicate,http://schema.org/signOrSymptom-output,< 1K
-Predicate,http://schema.org/significance,< 1K
-Predicate,http://schema.org/significance-input,< 1K
-Predicate,http://schema.org/significance-output,< 1K
-Predicate,http://schema.org/significantLink,10K - 100K
-Predicate,http://schema.org/significantLink-input,< 1K
-Predicate,http://schema.org/significantLink-output,< 1K
-Predicate,http://schema.org/significantLinks,1K - 10K
-Predicate,http://schema.org/significantLinks-input,< 1K
-Predicate,http://schema.org/significantLinks-output,< 1K
-Predicate,http://schema.org/size,10K - 100K
-Predicate,http://schema.org/size-input,< 1K
-Predicate,http://schema.org/size-output,< 1K
-Predicate,http://schema.org/sizeGroup,< 1K
-Predicate,http://schema.org/sizeGroup-input,< 1K
-Predicate,http://schema.org/sizeGroup-output,< 1K
-Predicate,http://schema.org/sizeSystem,< 1K
-Predicate,http://schema.org/sizeSystem-input,< 1K
-Predicate,http://schema.org/sizeSystem-output,< 1K
-Predicate,http://schema.org/skills,10K - 100K
-Predicate,http://schema.org/skills-input,< 1K
-Predicate,http://schema.org/skills-output,< 1K
-Predicate,http://schema.org/sku,1M - 10M
-Predicate,http://schema.org/sku-input,< 1K
-Predicate,http://schema.org/sku-output,< 1K
-Predicate,http://schema.org/slogan,100K - 1M
-Predicate,http://schema.org/slogan-input,< 1K
-Predicate,http://schema.org/slogan-output,< 1K
-Predicate,http://schema.org/smiles,< 1K
-Predicate,http://schema.org/smiles-input,< 1K
-Predicate,http://schema.org/smiles-output,< 1K
-Predicate,http://schema.org/smokingAllowed,10K - 100K
-Predicate,http://schema.org/smokingAllowed-input,< 1K
-Predicate,http://schema.org/smokingAllowed-output,< 1K
-Predicate,http://schema.org/sodiumContent,10K - 100K
-Predicate,http://schema.org/sodiumContent-input,< 1K
-Predicate,http://schema.org/sodiumContent-output,< 1K
-Predicate,http://schema.org/softwareAddOn,< 1K
-Predicate,http://schema.org/softwareAddOn-input,< 1K
-Predicate,http://schema.org/softwareAddOn-output,< 1K
-Predicate,http://schema.org/softwareHelp,10K - 100K
-Predicate,http://schema.org/softwareHelp-input,< 1K
-Predicate,http://schema.org/softwareHelp-output,< 1K
-Predicate,http://schema.org/softwareRequirements,10K - 100K
-Predicate,http://schema.org/softwareRequirements-input,< 1K
-Predicate,http://schema.org/softwareRequirements-output,< 1K
-Predicate,http://schema.org/softwareVersion,100K - 1M
-Predicate,http://schema.org/softwareVersion-input,< 1K
-Predicate,http://schema.org/softwareVersion-output,< 1K
-Predicate,http://schema.org/source,1K - 10K
-Predicate,http://schema.org/source-input,< 1K
-Predicate,http://schema.org/source-output,< 1K
-Predicate,http://schema.org/sourceOrganization,10K - 100K
-Predicate,http://schema.org/sourceOrganization-input,< 1K
-Predicate,http://schema.org/sourceOrganization-output,< 1K
-Predicate,http://schema.org/sourcedFrom,< 1K
-Predicate,http://schema.org/sourcedFrom-input,< 1K
-Predicate,http://schema.org/sourcedFrom-output,< 1K
-Predicate,http://schema.org/spatial,1K - 10K
-Predicate,http://schema.org/spatial-input,< 1K
-Predicate,http://schema.org/spatial-output,< 1K
-Predicate,http://schema.org/spatialCoverage,10K - 100K
-Predicate,http://schema.org/spatialCoverage-input,< 1K
-Predicate,http://schema.org/spatialCoverage-output,< 1K
-Predicate,http://schema.org/speakable,100K - 1M
-Predicate,http://schema.org/speakable-input,< 1K
-Predicate,http://schema.org/speakable-output,< 1K
-Predicate,http://schema.org/specialCommitments,1K - 10K
-Predicate,http://schema.org/specialCommitments-input,< 1K
-Predicate,http://schema.org/specialCommitments-output,< 1K
-Predicate,http://schema.org/specialOpeningHoursSpecification,1K - 10K
-Predicate,http://schema.org/specialOpeningHoursSpecification-input,< 1K
-Predicate,http://schema.org/specialOpeningHoursSpecification-output,< 1K
-Predicate,http://schema.org/specialty,10K - 100K
-Predicate,http://schema.org/specialty-input,< 1K
-Predicate,http://schema.org/specialty-output,< 1K
-Predicate,http://schema.org/speechToTextMarkup,< 1K
-Predicate,http://schema.org/speechToTextMarkup-input,< 1K
-Predicate,http://schema.org/speechToTextMarkup-output,< 1K
-Predicate,http://schema.org/speed,1K - 10K
-Predicate,http://schema.org/speed-input,< 1K
-Predicate,http://schema.org/speed-output,< 1K
-Predicate,http://schema.org/spokenByCharacter,1K - 10K
-Predicate,http://schema.org/spokenByCharacter-input,< 1K
-Predicate,http://schema.org/spokenByCharacter-output,< 1K
-Predicate,http://schema.org/sponsor,10K - 100K
-Predicate,http://schema.org/sponsor-input,< 1K
-Predicate,http://schema.org/sponsor-output,< 1K
-Predicate,http://schema.org/sport,10K - 100K
-Predicate,http://schema.org/sport-input,< 1K
-Predicate,http://schema.org/sport-output,< 1K
-Predicate,http://schema.org/sportsActivityLocation,< 1K
-Predicate,http://schema.org/sportsActivityLocation-input,< 1K
-Predicate,http://schema.org/sportsActivityLocation-output,< 1K
-Predicate,http://schema.org/sportsEvent,< 1K
-Predicate,http://schema.org/sportsEvent-input,< 1K
-Predicate,http://schema.org/sportsEvent-output,< 1K
-Predicate,http://schema.org/sportsTeam,< 1K
-Predicate,http://schema.org/sportsTeam-input,< 1K
-Predicate,http://schema.org/sportsTeam-output,< 1K
-Predicate,http://schema.org/spouse,1K - 10K
-Predicate,http://schema.org/spouse-input,< 1K
-Predicate,http://schema.org/spouse-output,< 1K
-Predicate,http://schema.org/stage,< 1K
-Predicate,http://schema.org/stage-input,< 1K
-Predicate,http://schema.org/stage-output,< 1K
-Predicate,http://schema.org/stageAsNumber,< 1K
-Predicate,http://schema.org/stageAsNumber-input,< 1K
-Predicate,http://schema.org/stageAsNumber-output,< 1K
-Predicate,http://schema.org/starRating,10K - 100K
-Predicate,http://schema.org/starRating-input,< 1K
-Predicate,http://schema.org/starRating-output,< 1K
-Predicate,http://schema.org/startDate,100K - 1M
-Predicate,http://schema.org/startDate-input,< 1K
-Predicate,http://schema.org/startDate-output,< 1K
-Predicate,http://schema.org/startOffset,10K - 100K
-Predicate,http://schema.org/startOffset-input,10K - 100K
-Predicate,http://schema.org/startOffset-output,< 1K
-Predicate,http://schema.org/startTime,1K - 10K
-Predicate,http://schema.org/startTime-input,< 1K
-Predicate,http://schema.org/startTime-output,< 1K
-Predicate,http://schema.org/statType,< 1K
-Predicate,http://schema.org/statType-input,< 1K
-Predicate,http://schema.org/statType-output,< 1K
-Predicate,http://schema.org/status,1K - 10K
-Predicate,http://schema.org/status-input,< 1K
-Predicate,http://schema.org/status-output,< 1K
-Predicate,http://schema.org/steeringPosition,1K - 10K
-Predicate,http://schema.org/steeringPosition-input,< 1K
-Predicate,http://schema.org/steeringPosition-output,< 1K
-Predicate,http://schema.org/step,100K - 1M
-Predicate,http://schema.org/step-input,< 1K
-Predicate,http://schema.org/step-output,< 1K
-Predicate,http://schema.org/stepValue,< 1K
-Predicate,http://schema.org/stepValue-input,< 1K
-Predicate,http://schema.org/stepValue-output,< 1K
-Predicate,http://schema.org/steps,< 1K
-Predicate,http://schema.org/steps-input,< 1K
-Predicate,http://schema.org/steps-output,< 1K
-Predicate,http://schema.org/storageRequirements,10K - 100K
-Predicate,http://schema.org/storageRequirements-input,< 1K
-Predicate,http://schema.org/storageRequirements-output,< 1K
-Predicate,http://schema.org/streetAddress,1M - 10M
-Predicate,http://schema.org/streetAddress-input,< 1K
-Predicate,http://schema.org/streetAddress-output,< 1K
-Predicate,http://schema.org/strengthUnit,< 1K
-Predicate,http://schema.org/strengthUnit-input,< 1K
-Predicate,http://schema.org/strengthUnit-output,< 1K
-Predicate,http://schema.org/strengthValue,< 1K
-Predicate,http://schema.org/strengthValue-input,< 1K
-Predicate,http://schema.org/strengthValue-output,< 1K
-Predicate,http://schema.org/structuralClass,< 1K
-Predicate,http://schema.org/structuralClass-input,< 1K
-Predicate,http://schema.org/structuralClass-output,< 1K
-Predicate,http://schema.org/study,< 1K
-Predicate,http://schema.org/study-input,< 1K
-Predicate,http://schema.org/study-output,< 1K
-Predicate,http://schema.org/studyDesign,< 1K
-Predicate,http://schema.org/studyDesign-input,< 1K
-Predicate,http://schema.org/studyDesign-output,< 1K
-Predicate,http://schema.org/studyLocation,< 1K
-Predicate,http://schema.org/studyLocation-input,< 1K
-Predicate,http://schema.org/studyLocation-output,< 1K
-Predicate,http://schema.org/studySubject,< 1K
-Predicate,http://schema.org/studySubject-input,< 1K
-Predicate,http://schema.org/studySubject-output,< 1K
-Predicate,http://schema.org/stupidProperty,< 1K
-Predicate,http://schema.org/stupidProperty-input,< 1K
-Predicate,http://schema.org/stupidProperty-output,< 1K
-Predicate,http://schema.org/subEvent,1K - 10K
-Predicate,http://schema.org/subEvent-input,< 1K
-Predicate,http://schema.org/subEvent-output,< 1K
-Predicate,http://schema.org/subEvents,< 1K
-Predicate,http://schema.org/subEvents-input,< 1K
-Predicate,http://schema.org/subEvents-output,< 1K
-Predicate,http://schema.org/subOrganization,10K - 100K
-Predicate,http://schema.org/subOrganization-input,< 1K
-Predicate,http://schema.org/subOrganization-output,< 1K
-Predicate,http://schema.org/subReservation,< 1K
-Predicate,http://schema.org/subReservation-input,< 1K
-Predicate,http://schema.org/subReservation-output,< 1K
-Predicate,http://schema.org/subStageSuffix,< 1K
-Predicate,http://schema.org/subStageSuffix-input,< 1K
-Predicate,http://schema.org/subStageSuffix-output,< 1K
-Predicate,http://schema.org/subStructure,< 1K
-Predicate,http://schema.org/subStructure-input,< 1K
-Predicate,http://schema.org/subStructure-output,< 1K
-Predicate,http://schema.org/subTest,< 1K
-Predicate,http://schema.org/subTest-input,< 1K
-Predicate,http://schema.org/subTest-output,< 1K
-Predicate,http://schema.org/subTrip,< 1K
-Predicate,http://schema.org/subTrip-input,< 1K
-Predicate,http://schema.org/subTrip-output,< 1K
-Predicate,http://schema.org/subjectOf,100K - 1M
-Predicate,http://schema.org/subjectOf-input,< 1K
-Predicate,http://schema.org/subjectOf-output,< 1K
-Predicate,http://schema.org/subtitleLanguage,< 1K
-Predicate,http://schema.org/subtitleLanguage-input,< 1K
-Predicate,http://schema.org/subtitleLanguage-output,< 1K
-Predicate,http://schema.org/successorOf,< 1K
-Predicate,http://schema.org/successorOf-input,< 1K
-Predicate,http://schema.org/successorOf-output,< 1K
-Predicate,http://schema.org/sugarContent,10K - 100K
-Predicate,http://schema.org/sugarContent-input,< 1K
-Predicate,http://schema.org/sugarContent-output,< 1K
-Predicate,http://schema.org/suggestedAge,1K - 10K
-Predicate,http://schema.org/suggestedAge-input,< 1K
-Predicate,http://schema.org/suggestedAge-output,< 1K
-Predicate,http://schema.org/suggestedAnswer,10K - 100K
-Predicate,http://schema.org/suggestedAnswer-input,< 1K
-Predicate,http://schema.org/suggestedAnswer-output,< 1K
-Predicate,http://schema.org/suggestedGender,10K - 100K
-Predicate,http://schema.org/suggestedGender-input,< 1K
-Predicate,http://schema.org/suggestedGender-output,< 1K
-Predicate,http://schema.org/suggestedMaxAge,1K - 10K
-Predicate,http://schema.org/suggestedMaxAge-input,< 1K
-Predicate,http://schema.org/suggestedMaxAge-output,< 1K
-Predicate,http://schema.org/suggestedMeasurement,< 1K
-Predicate,http://schema.org/suggestedMeasurement-input,< 1K
-Predicate,http://schema.org/suggestedMeasurement-output,< 1K
-Predicate,http://schema.org/suggestedMinAge,10K - 100K
-Predicate,http://schema.org/suggestedMinAge-input,< 1K
-Predicate,http://schema.org/suggestedMinAge-output,< 1K
-Predicate,http://schema.org/suitableForDiet,10K - 100K
-Predicate,http://schema.org/suitableForDiet-input,< 1K
-Predicate,http://schema.org/suitableForDiet-output,< 1K
-Predicate,http://schema.org/superEvent,1K - 10K
-Predicate,http://schema.org/superEvent-input,< 1K
-Predicate,http://schema.org/superEvent-output,< 1K
-Predicate,http://schema.org/supersededBy,1K - 10K
-Predicate,http://schema.org/supersededBy-input,< 1K
-Predicate,http://schema.org/supersededBy-output,< 1K
-Predicate,http://schema.org/supply,10K - 100K
-Predicate,http://schema.org/supply-input,< 1K
-Predicate,http://schema.org/supply-output,< 1K
-Predicate,http://schema.org/supplyTo,< 1K
-Predicate,http://schema.org/supplyTo-input,< 1K
-Predicate,http://schema.org/supplyTo-output,< 1K
-Predicate,http://schema.org/supportingData,< 1K
-Predicate,http://schema.org/supportingData-input,< 1K
-Predicate,http://schema.org/supportingData-output,< 1K
-Predicate,http://schema.org/surface,< 1K
-Predicate,http://schema.org/surface-input,< 1K
-Predicate,http://schema.org/surface-output,< 1K
-Predicate,http://schema.org/syllabusSections,1K - 10K
-Predicate,http://schema.org/syllabusSections-input,< 1K
-Predicate,http://schema.org/syllabusSections-output,< 1K
-Predicate,http://schema.org/target,10M+
-Predicate,http://schema.org/target-input,< 1K
-Predicate,http://schema.org/target-output,< 1K
-Predicate,http://schema.org/targetCollection,< 1K
-Predicate,http://schema.org/targetCollection-input,< 1K
-Predicate,http://schema.org/targetCollection-output,< 1K
-Predicate,http://schema.org/targetDescription,< 1K
-Predicate,http://schema.org/targetDescription-input,< 1K
-Predicate,http://schema.org/targetDescription-output,< 1K
-Predicate,http://schema.org/targetName,1K - 10K
-Predicate,http://schema.org/targetName-input,< 1K
-Predicate,http://schema.org/targetName-output,< 1K
-Predicate,http://schema.org/targetPlatform,< 1K
-Predicate,http://schema.org/targetPlatform-input,< 1K
-Predicate,http://schema.org/targetPlatform-output,< 1K
-Predicate,http://schema.org/targetPopulation,< 1K
-Predicate,http://schema.org/targetPopulation-input,< 1K
-Predicate,http://schema.org/targetPopulation-output,< 1K
-Predicate,http://schema.org/targetProduct,< 1K
-Predicate,http://schema.org/targetProduct-input,< 1K
-Predicate,http://schema.org/targetProduct-output,< 1K
-Predicate,http://schema.org/targetUrl,< 1K
-Predicate,http://schema.org/targetUrl-input,< 1K
-Predicate,http://schema.org/targetUrl-output,< 1K
-Predicate,http://schema.org/taxID,100K - 1M
-Predicate,http://schema.org/taxID-input,< 1K
-Predicate,http://schema.org/taxID-output,< 1K
-Predicate,http://schema.org/taxonRank,< 1K
-Predicate,http://schema.org/taxonRank-input,< 1K
-Predicate,http://schema.org/taxonRank-output,< 1K
-Predicate,http://schema.org/taxonomicRange,< 1K
-Predicate,http://schema.org/taxonomicRange-input,< 1K
-Predicate,http://schema.org/taxonomicRange-output,< 1K
-Predicate,http://schema.org/teaches,10K - 100K
-Predicate,http://schema.org/teaches-input,< 1K
-Predicate,http://schema.org/teaches-output,< 1K
-Predicate,http://schema.org/telephone,1M - 10M
-Predicate,http://schema.org/telephone-input,< 1K
-Predicate,http://schema.org/telephone-output,< 1K
-Predicate,http://schema.org/temporal,< 1K
-Predicate,http://schema.org/temporal-input,< 1K
-Predicate,http://schema.org/temporal-output,< 1K
-Predicate,http://schema.org/temporalCoverage,10K - 100K
-Predicate,http://schema.org/temporalCoverage-input,< 1K
-Predicate,http://schema.org/temporalCoverage-output,< 1K
-Predicate,http://schema.org/termCode,1K - 10K
-Predicate,http://schema.org/termCode-input,< 1K
-Predicate,http://schema.org/termCode-output,< 1K
-Predicate,http://schema.org/termDuration,< 1K
-Predicate,http://schema.org/termDuration-input,< 1K
-Predicate,http://schema.org/termDuration-output,< 1K
-Predicate,http://schema.org/termsOfService,10K - 100K
-Predicate,http://schema.org/termsOfService-input,< 1K
-Predicate,http://schema.org/termsOfService-output,< 1K
-Predicate,http://schema.org/termsPerYear,< 1K
-Predicate,http://schema.org/termsPerYear-input,< 1K
-Predicate,http://schema.org/termsPerYear-output,< 1K
-Predicate,http://schema.org/text,1M - 10M
-Predicate,http://schema.org/text-input,< 1K
-Predicate,http://schema.org/text-output,< 1K
-Predicate,http://schema.org/textValue,< 1K
-Predicate,http://schema.org/textValue-input,< 1K
-Predicate,http://schema.org/textValue-output,< 1K
-Predicate,http://schema.org/thumbnail,100K - 1M
-Predicate,http://schema.org/thumbnail-input,< 1K
-Predicate,http://schema.org/thumbnail-output,< 1K
-Predicate,http://schema.org/thumbnailUrl,10M+
-Predicate,http://schema.org/thumbnailUrl-input,< 1K
-Predicate,http://schema.org/thumbnailUrl-output,< 1K
-Predicate,http://schema.org/tickerSymbol,1K - 10K
-Predicate,http://schema.org/tickerSymbol-input,< 1K
-Predicate,http://schema.org/tickerSymbol-output,< 1K
-Predicate,http://schema.org/ticketNumber,< 1K
-Predicate,http://schema.org/ticketNumber-input,< 1K
-Predicate,http://schema.org/ticketNumber-output,< 1K
-Predicate,http://schema.org/ticketToken,< 1K
-Predicate,http://schema.org/ticketToken-input,< 1K
-Predicate,http://schema.org/ticketToken-output,< 1K
-Predicate,http://schema.org/ticketedSeat,< 1K
-Predicate,http://schema.org/ticketedSeat-input,< 1K
-Predicate,http://schema.org/ticketedSeat-output,< 1K
-Predicate,http://schema.org/timeOfDay,< 1K
-Predicate,http://schema.org/timeOfDay-input,< 1K
-Predicate,http://schema.org/timeOfDay-output,< 1K
-Predicate,http://schema.org/timeRequired,100K - 1M
-Predicate,http://schema.org/timeRequired-input,< 1K
-Predicate,http://schema.org/timeRequired-output,< 1K
-Predicate,http://schema.org/timeToComplete,1K - 10K
-Predicate,http://schema.org/timeToComplete-input,< 1K
-Predicate,http://schema.org/timeToComplete-output,< 1K
-Predicate,http://schema.org/timestamp,1K - 10K
-Predicate,http://schema.org/timestamp-input,< 1K
-Predicate,http://schema.org/timestamp-output,< 1K
-Predicate,http://schema.org/tissueSample,< 1K
-Predicate,http://schema.org/tissueSample-input,< 1K
-Predicate,http://schema.org/tissueSample-output,< 1K
-Predicate,http://schema.org/title,100K - 1M
-Predicate,http://schema.org/title-input,< 1K
-Predicate,http://schema.org/title-output,< 1K
-Predicate,http://schema.org/titleEIDR,< 1K
-Predicate,http://schema.org/titleEIDR-input,< 1K
-Predicate,http://schema.org/titleEIDR-output,< 1K
-Predicate,http://schema.org/toLocation,1K - 10K
-Predicate,http://schema.org/toLocation-input,< 1K
-Predicate,http://schema.org/toLocation-output,< 1K
-Predicate,http://schema.org/toRecipient,< 1K
-Predicate,http://schema.org/toRecipient-input,< 1K
-Predicate,http://schema.org/toRecipient-output,< 1K
-Predicate,http://schema.org/tocContinuation,< 1K
-Predicate,http://schema.org/tocContinuation-input,< 1K
-Predicate,http://schema.org/tocContinuation-output,< 1K
-Predicate,http://schema.org/tocEntry,< 1K
-Predicate,http://schema.org/tocEntry-input,< 1K
-Predicate,http://schema.org/tocEntry-output,< 1K
-Predicate,http://schema.org/tongueWeight,< 1K
-Predicate,http://schema.org/tongueWeight-input,< 1K
-Predicate,http://schema.org/tongueWeight-output,< 1K
-Predicate,http://schema.org/tool,10K - 100K
-Predicate,http://schema.org/tool-input,< 1K
-Predicate,http://schema.org/tool-output,< 1K
-Predicate,http://schema.org/torque,1K - 10K
-Predicate,http://schema.org/torque-input,< 1K
-Predicate,http://schema.org/torque-output,< 1K
-Predicate,http://schema.org/totalHistoricalEnrollment,< 1K
-Predicate,http://schema.org/totalHistoricalEnrollment-input,< 1K
-Predicate,http://schema.org/totalHistoricalEnrollment-output,< 1K
-Predicate,http://schema.org/totalJobOpenings,< 1K
-Predicate,http://schema.org/totalJobOpenings-input,< 1K
-Predicate,http://schema.org/totalJobOpenings-output,< 1K
-Predicate,http://schema.org/totalPaymentDue,< 1K
-Predicate,http://schema.org/totalPaymentDue-input,< 1K
-Predicate,http://schema.org/totalPaymentDue-output,< 1K
-Predicate,http://schema.org/totalPrice,< 1K
-Predicate,http://schema.org/totalPrice-input,< 1K
-Predicate,http://schema.org/totalPrice-output,< 1K
-Predicate,http://schema.org/totalTime,100K - 1M
-Predicate,http://schema.org/totalTime-input,< 1K
-Predicate,http://schema.org/totalTime-output,< 1K
-Predicate,http://schema.org/tourBookingPage,10K - 100K
-Predicate,http://schema.org/tourBookingPage-input,< 1K
-Predicate,http://schema.org/tourBookingPage-output,< 1K
-Predicate,http://schema.org/touristType,10K - 100K
-Predicate,http://schema.org/touristType-input,< 1K
-Predicate,http://schema.org/touristType-output,< 1K
-Predicate,http://schema.org/track,10K - 100K
-Predicate,http://schema.org/track-input,< 1K
-Predicate,http://schema.org/track-output,< 1K
-Predicate,http://schema.org/trackingNumber,< 1K
-Predicate,http://schema.org/trackingNumber-input,< 1K
-Predicate,http://schema.org/trackingNumber-output,< 1K
-Predicate,http://schema.org/trackingUrl,< 1K
-Predicate,http://schema.org/trackingUrl-input,< 1K
-Predicate,http://schema.org/trackingUrl-output,< 1K
-Predicate,http://schema.org/tracks,< 1K
-Predicate,http://schema.org/tracks-input,< 1K
-Predicate,http://schema.org/tracks-output,< 1K
-Predicate,http://schema.org/trailer,1K - 10K
-Predicate,http://schema.org/trailer-input,< 1K
-Predicate,http://schema.org/trailer-output,< 1K
-Predicate,http://schema.org/trailerWeight,< 1K
-Predicate,http://schema.org/trailerWeight-input,< 1K
-Predicate,http://schema.org/trailerWeight-output,< 1K
-Predicate,http://schema.org/trainName,< 1K
-Predicate,http://schema.org/trainName-input,< 1K
-Predicate,http://schema.org/trainName-output,< 1K
-Predicate,http://schema.org/trainNumber,< 1K
-Predicate,http://schema.org/trainNumber-input,< 1K
-Predicate,http://schema.org/trainNumber-output,< 1K
-Predicate,http://schema.org/trainingSalary,< 1K
-Predicate,http://schema.org/trainingSalary-input,< 1K
-Predicate,http://schema.org/trainingSalary-output,< 1K
-Predicate,http://schema.org/transFatContent,10K - 100K
-Predicate,http://schema.org/transFatContent-input,< 1K
-Predicate,http://schema.org/transFatContent-output,< 1K
-Predicate,http://schema.org/transcript,10K - 100K
-Predicate,http://schema.org/transcript-input,< 1K
-Predicate,http://schema.org/transcript-output,< 1K
-Predicate,http://schema.org/transitTime,100K - 1M
-Predicate,http://schema.org/transitTime-input,< 1K
-Predicate,http://schema.org/transitTime-output,< 1K
-Predicate,http://schema.org/transitTimeLabel,< 1K
-Predicate,http://schema.org/transitTimeLabel-input,< 1K
-Predicate,http://schema.org/transitTimeLabel-output,< 1K
-Predicate,http://schema.org/translationOfWork,1K - 10K
-Predicate,http://schema.org/translationOfWork-input,< 1K
-Predicate,http://schema.org/translationOfWork-output,< 1K
-Predicate,http://schema.org/translator,1K - 10K
-Predicate,http://schema.org/translator-input,< 1K
-Predicate,http://schema.org/translator-output,< 1K
-Predicate,http://schema.org/transmissionMethod,< 1K
-Predicate,http://schema.org/transmissionMethod-input,< 1K
-Predicate,http://schema.org/transmissionMethod-output,< 1K
-Predicate,http://schema.org/travelBans,< 1K
-Predicate,http://schema.org/travelBans-input,< 1K
-Predicate,http://schema.org/travelBans-output,< 1K
-Predicate,http://schema.org/trialDesign,< 1K
-Predicate,http://schema.org/trialDesign-input,< 1K
-Predicate,http://schema.org/trialDesign-output,< 1K
-Predicate,http://schema.org/tributary,< 1K
-Predicate,http://schema.org/tributary-input,< 1K
-Predicate,http://schema.org/tributary-output,< 1K
-Predicate,http://schema.org/tripOrigin,< 1K
-Predicate,http://schema.org/tripOrigin-input,< 1K
-Predicate,http://schema.org/tripOrigin-output,< 1K
-Predicate,http://schema.org/typeOfBed,10K - 100K
-Predicate,http://schema.org/typeOfBed-input,< 1K
-Predicate,http://schema.org/typeOfBed-output,< 1K
-Predicate,http://schema.org/typeOfGood,< 1K
-Predicate,http://schema.org/typeOfGood-input,< 1K
-Predicate,http://schema.org/typeOfGood-output,< 1K
-Predicate,http://schema.org/typicalAgeRange,10K - 100K
-Predicate,http://schema.org/typicalAgeRange-input,< 1K
-Predicate,http://schema.org/typicalAgeRange-output,< 1K
-Predicate,http://schema.org/typicalCreditsPerTerm,< 1K
-Predicate,http://schema.org/typicalCreditsPerTerm-input,< 1K
-Predicate,http://schema.org/typicalCreditsPerTerm-output,< 1K
-Predicate,http://schema.org/typicalTest,1K - 10K
-Predicate,http://schema.org/typicalTest-input,< 1K
-Predicate,http://schema.org/typicalTest-output,< 1K
-Predicate,http://schema.org/underName,< 1K
-Predicate,http://schema.org/underName-input,< 1K
-Predicate,http://schema.org/underName-output,< 1K
-Predicate,http://schema.org/unitCode,1M - 10M
-Predicate,http://schema.org/unitCode-input,< 1K
-Predicate,http://schema.org/unitCode-output,< 1K
-Predicate,http://schema.org/unitText,100K - 1M
-Predicate,http://schema.org/unitText-input,< 1K
-Predicate,http://schema.org/unitText-output,< 1K
-Predicate,http://schema.org/unnamedSourcesPolicy,1K - 10K
-Predicate,http://schema.org/unnamedSourcesPolicy-input,< 1K
-Predicate,http://schema.org/unnamedSourcesPolicy-output,< 1K
-Predicate,http://schema.org/unsaturatedFatContent,10K - 100K
-Predicate,http://schema.org/unsaturatedFatContent-input,< 1K
-Predicate,http://schema.org/unsaturatedFatContent-output,< 1K
-Predicate,http://schema.org/uploadDate,1M - 10M
-Predicate,http://schema.org/uploadDate-input,< 1K
-Predicate,http://schema.org/uploadDate-output,< 1K
-Predicate,http://schema.org/upvoteCount,10K - 100K
-Predicate,http://schema.org/upvoteCount-input,< 1K
-Predicate,http://schema.org/upvoteCount-output,< 1K
-Predicate,http://schema.org/url,10M+
-Predicate,http://schema.org/url-input,< 1K
-Predicate,http://schema.org/url-output,< 1K
-Predicate,http://schema.org/urlTemplate,10M+
-Predicate,http://schema.org/urlTemplate-input,< 1K
-Predicate,http://schema.org/urlTemplate-output,< 1K
-Predicate,http://schema.org/usNPI,< 1K
-Predicate,http://schema.org/usNPI-input,< 1K
-Predicate,http://schema.org/usNPI-output,< 1K
-Predicate,http://schema.org/usageInfo,1K - 10K
-Predicate,http://schema.org/usageInfo-input,< 1K
-Predicate,http://schema.org/usageInfo-output,< 1K
-Predicate,http://schema.org/usedToDiagnose,1K - 10K
-Predicate,http://schema.org/usedToDiagnose-input,< 1K
-Predicate,http://schema.org/usedToDiagnose-output,< 1K
-Predicate,http://schema.org/userInteractionCount,100K - 1M
-Predicate,http://schema.org/userInteractionCount-input,< 1K
-Predicate,http://schema.org/userInteractionCount-output,< 1K
-Predicate,http://schema.org/usesDevice,< 1K
-Predicate,http://schema.org/usesDevice-input,< 1K
-Predicate,http://schema.org/usesDevice-output,< 1K
-Predicate,http://schema.org/usesHealthPlanIdStandard,< 1K
-Predicate,http://schema.org/usesHealthPlanIdStandard-input,< 1K
-Predicate,http://schema.org/usesHealthPlanIdStandard-output,< 1K
-Predicate,http://schema.org/utterances,< 1K
-Predicate,http://schema.org/utterances-input,< 1K
-Predicate,http://schema.org/utterances-output,< 1K
-Predicate,http://schema.org/validFor,< 1K
-Predicate,http://schema.org/validFor-input,< 1K
-Predicate,http://schema.org/validFor-output,< 1K
-Predicate,http://schema.org/validForMemberTier,< 1K
-Predicate,http://schema.org/validForMemberTier-input,< 1K
-Predicate,http://schema.org/validForMemberTier-output,< 1K
-Predicate,http://schema.org/validFrom,100K - 1M
-Predicate,http://schema.org/validFrom-input,< 1K
-Predicate,http://schema.org/validFrom-output,< 1K
-Predicate,http://schema.org/validIn,1K - 10K
-Predicate,http://schema.org/validIn-input,< 1K
-Predicate,http://schema.org/validIn-output,< 1K
-Predicate,http://schema.org/validThrough,1M - 10M
-Predicate,http://schema.org/validThrough-input,< 1K
-Predicate,http://schema.org/validThrough-output,< 1K
-Predicate,http://schema.org/validUntil,1K - 10K
-Predicate,http://schema.org/validUntil-input,< 1K
-Predicate,http://schema.org/validUntil-output,< 1K
-Predicate,http://schema.org/value,1M - 10M
-Predicate,http://schema.org/value-input,< 1K
-Predicate,http://schema.org/value-output,< 1K
-Predicate,http://schema.org/valueAddedTaxIncluded,1M - 10M
-Predicate,http://schema.org/valueAddedTaxIncluded-input,< 1K
-Predicate,http://schema.org/valueAddedTaxIncluded-output,< 1K
-Predicate,http://schema.org/valueMaxLength,1K - 10K
-Predicate,http://schema.org/valueMaxLength-input,< 1K
-Predicate,http://schema.org/valueMaxLength-output,< 1K
-Predicate,http://schema.org/valueMinLength,< 1K
-Predicate,http://schema.org/valueMinLength-input,< 1K
-Predicate,http://schema.org/valueMinLength-output,< 1K
-Predicate,http://schema.org/valueName,10M+
-Predicate,http://schema.org/valueName-input,< 1K
-Predicate,http://schema.org/valueName-output,< 1K
-Predicate,http://schema.org/valuePattern,< 1K
-Predicate,http://schema.org/valuePattern-input,< 1K
-Predicate,http://schema.org/valuePattern-output,< 1K
-Predicate,http://schema.org/valueReference,1K - 10K
-Predicate,http://schema.org/valueReference-input,< 1K
-Predicate,http://schema.org/valueReference-output,< 1K
-Predicate,http://schema.org/valueRequired,10M+
-Predicate,http://schema.org/valueRequired-input,< 1K
-Predicate,http://schema.org/valueRequired-output,< 1K
-Predicate,http://schema.org/variableMeasured,10K - 100K
-Predicate,http://schema.org/variableMeasured-input,< 1K
-Predicate,http://schema.org/variableMeasured-output,< 1K
-Predicate,http://schema.org/variablesMeasured,< 1K
-Predicate,http://schema.org/variablesMeasured-input,< 1K
-Predicate,http://schema.org/variablesMeasured-output,< 1K
-Predicate,http://schema.org/variantCover,< 1K
-Predicate,http://schema.org/variantCover-input,< 1K
-Predicate,http://schema.org/variantCover-output,< 1K
-Predicate,http://schema.org/variesBy,100K - 1M
-Predicate,http://schema.org/variesBy-input,< 1K
-Predicate,http://schema.org/variesBy-output,< 1K
-Predicate,http://schema.org/vatID,100K - 1M
-Predicate,http://schema.org/vatID-input,< 1K
-Predicate,http://schema.org/vatID-output,< 1K
-Predicate,http://schema.org/vehicleConfiguration,10K - 100K
-Predicate,http://schema.org/vehicleConfiguration-input,< 1K
-Predicate,http://schema.org/vehicleConfiguration-output,< 1K
-Predicate,http://schema.org/vehicleEngine,10K - 100K
-Predicate,http://schema.org/vehicleEngine-input,< 1K
-Predicate,http://schema.org/vehicleEngine-output,< 1K
-Predicate,http://schema.org/vehicleIdentificationNumber,10K - 100K
-Predicate,http://schema.org/vehicleIdentificationNumber-input,< 1K
-Predicate,http://schema.org/vehicleIdentificationNumber-output,< 1K
-Predicate,http://schema.org/vehicleInteriorColor,10K - 100K
-Predicate,http://schema.org/vehicleInteriorColor-input,< 1K
-Predicate,http://schema.org/vehicleInteriorColor-output,< 1K
-Predicate,http://schema.org/vehicleInteriorType,10K - 100K
-Predicate,http://schema.org/vehicleInteriorType-input,< 1K
-Predicate,http://schema.org/vehicleInteriorType-output,< 1K
-Predicate,http://schema.org/vehicleModelDate,10K - 100K
-Predicate,http://schema.org/vehicleModelDate-input,< 1K
-Predicate,http://schema.org/vehicleModelDate-output,< 1K
-Predicate,http://schema.org/vehicleSeatingCapacity,10K - 100K
-Predicate,http://schema.org/vehicleSeatingCapacity-input,< 1K
-Predicate,http://schema.org/vehicleSeatingCapacity-output,< 1K
-Predicate,http://schema.org/vehicleSpecialUsage,< 1K
-Predicate,http://schema.org/vehicleSpecialUsage-input,< 1K
-Predicate,http://schema.org/vehicleSpecialUsage-output,< 1K
-Predicate,http://schema.org/vehicleTransmission,10K - 100K
-Predicate,http://schema.org/vehicleTransmission-input,< 1K
-Predicate,http://schema.org/vehicleTransmission-output,< 1K
-Predicate,http://schema.org/vendor,< 1K
-Predicate,http://schema.org/vendor-input,< 1K
-Predicate,http://schema.org/vendor-output,< 1K
-Predicate,http://schema.org/verificationFactCheckingPolicy,1K - 10K
-Predicate,http://schema.org/verificationFactCheckingPolicy-input,< 1K
-Predicate,http://schema.org/verificationFactCheckingPolicy-output,< 1K
-Predicate,http://schema.org/version,1K - 10K
-Predicate,http://schema.org/version-input,< 1K
-Predicate,http://schema.org/version-output,< 1K
-Predicate,http://schema.org/video,100K - 1M
-Predicate,http://schema.org/video-input,< 1K
-Predicate,http://schema.org/video-output,< 1K
-Predicate,http://schema.org/videoFormat,1K - 10K
-Predicate,http://schema.org/videoFormat-input,< 1K
-Predicate,http://schema.org/videoFormat-output,< 1K
-Predicate,http://schema.org/videoFrameSize,< 1K
-Predicate,http://schema.org/videoFrameSize-input,< 1K
-Predicate,http://schema.org/videoFrameSize-output,< 1K
-Predicate,http://schema.org/videoQuality,10K - 100K
-Predicate,http://schema.org/videoQuality-input,< 1K
-Predicate,http://schema.org/videoQuality-output,< 1K
-Predicate,http://schema.org/volumeNumber,1K - 10K
-Predicate,http://schema.org/volumeNumber-input,< 1K
-Predicate,http://schema.org/volumeNumber-output,< 1K
-Predicate,http://schema.org/warning,< 1K
-Predicate,http://schema.org/warning-input,< 1K
-Predicate,http://schema.org/warning-output,< 1K
-Predicate,http://schema.org/warranty,10K - 100K
-Predicate,http://schema.org/warranty-input,< 1K
-Predicate,http://schema.org/warranty-output,< 1K
-Predicate,http://schema.org/warrantyPromise,< 1K
-Predicate,http://schema.org/warrantyPromise-input,< 1K
-Predicate,http://schema.org/warrantyPromise-output,< 1K
-Predicate,http://schema.org/warrantyScope,1K - 10K
-Predicate,http://schema.org/warrantyScope-input,< 1K
-Predicate,http://schema.org/warrantyScope-output,< 1K
-Predicate,http://schema.org/webCheckinTime,< 1K
-Predicate,http://schema.org/webCheckinTime-input,< 1K
-Predicate,http://schema.org/webCheckinTime-output,< 1K
-Predicate,http://schema.org/webFeed,10K - 100K
-Predicate,http://schema.org/webFeed-input,< 1K
-Predicate,http://schema.org/webFeed-output,< 1K
-Predicate,http://schema.org/weight,100K - 1M
-Predicate,http://schema.org/weight-input,< 1K
-Predicate,http://schema.org/weight-output,< 1K
-Predicate,http://schema.org/weightPercentage,< 1K
-Predicate,http://schema.org/weightPercentage-input,< 1K
-Predicate,http://schema.org/weightPercentage-output,< 1K
-Predicate,http://schema.org/weightTotal,1K - 10K
-Predicate,http://schema.org/weightTotal-input,< 1K
-Predicate,http://schema.org/weightTotal-output,< 1K
-Predicate,http://schema.org/wheelbase,1K - 10K
-Predicate,http://schema.org/wheelbase-input,< 1K
-Predicate,http://schema.org/wheelbase-output,< 1K
-Predicate,http://schema.org/width,10M+
-Predicate,http://schema.org/width-input,< 1K
-Predicate,http://schema.org/width-output,< 1K
-Predicate,http://schema.org/winner,< 1K
-Predicate,http://schema.org/winner-input,< 1K
-Predicate,http://schema.org/winner-output,< 1K
-Predicate,http://schema.org/wordCount,1M - 10M
-Predicate,http://schema.org/wordCount-input,< 1K
-Predicate,http://schema.org/wordCount-output,< 1K
-Predicate,http://schema.org/workExample,1K - 10K
-Predicate,http://schema.org/workExample-input,< 1K
-Predicate,http://schema.org/workExample-output,< 1K
-Predicate,http://schema.org/workFeatured,< 1K
-Predicate,http://schema.org/workFeatured-input,< 1K
-Predicate,http://schema.org/workFeatured-output,< 1K
-Predicate,http://schema.org/workHours,10K - 100K
-Predicate,http://schema.org/workHours-input,< 1K
-Predicate,http://schema.org/workHours-output,< 1K
-Predicate,http://schema.org/workLocation,10K - 100K
-Predicate,http://schema.org/workLocation-input,< 1K
-Predicate,http://schema.org/workLocation-output,< 1K
-Predicate,http://schema.org/workPerformed,1K - 10K
-Predicate,http://schema.org/workPerformed-input,< 1K
-Predicate,http://schema.org/workPerformed-output,< 1K
-Predicate,http://schema.org/workPresented,< 1K
-Predicate,http://schema.org/workPresented-input,< 1K
-Predicate,http://schema.org/workPresented-output,< 1K
-Predicate,http://schema.org/workTranslation,10K - 100K
-Predicate,http://schema.org/workTranslation-input,< 1K
-Predicate,http://schema.org/workTranslation-output,< 1K
-Predicate,http://schema.org/workload,< 1K
-Predicate,http://schema.org/workload-input,< 1K
-Predicate,http://schema.org/workload-output,< 1K
-Predicate,http://schema.org/worksFor,1M - 10M
-Predicate,http://schema.org/worksFor-input,< 1K
-Predicate,http://schema.org/worksFor-output,< 1K
-Predicate,http://schema.org/worstRating,1M - 10M
-Predicate,http://schema.org/worstRating-input,< 1K
-Predicate,http://schema.org/worstRating-output,< 1K
-Predicate,http://schema.org/xpath,10K - 100K
-Predicate,http://schema.org/xpath-input,< 1K
-Predicate,http://schema.org/xpath-output,< 1K
-Predicate,http://schema.org/yearBuilt,10K - 100K
-Predicate,http://schema.org/yearBuilt-input,< 1K
-Predicate,http://schema.org/yearBuilt-output,< 1K
-Predicate,http://schema.org/yearlyRevenue,< 1K
-Predicate,http://schema.org/yearlyRevenue-input,< 1K
-Predicate,http://schema.org/yearlyRevenue-output,< 1K
-Predicate,http://schema.org/yearsInOperation,< 1K
-Predicate,http://schema.org/yearsInOperation-input,< 1K
-Predicate,http://schema.org/yearsInOperation-output,< 1K
-Predicate,http://schema.org/yield,1K - 10K
-Predicate,http://schema.org/yield-input,< 1K
-Predicate,http://schema.org/yield-output,< 1K
+Itemtype,https://schema.org/3DModel,< 1K
+Itemtype,https://schema.org/AMRadioChannel,< 1K
+Itemtype,https://schema.org/APIReference,< 1K
+Itemtype,https://schema.org/AboutPage,100K - 1M
+Itemtype,https://schema.org/AcceptAction,< 1K
+Itemtype,https://schema.org/Accommodation,10K - 100K
+Itemtype,https://schema.org/AccountingService,10K - 100K
+Itemtype,https://schema.org/AchieveAction,< 1K
+Itemtype,https://schema.org/Action,10K - 100K
+Itemtype,https://schema.org/ActionAccessSpecification,< 1K
+Itemtype,https://schema.org/ActionStatusType,< 1K
+Itemtype,https://schema.org/ActivateAction,< 1K
+Itemtype,https://schema.org/AddAction,< 1K
+Itemtype,https://schema.org/AdministrativeArea,100K - 1M
+Itemtype,https://schema.org/AdultEntertainment,1K - 10K
+Itemtype,https://schema.org/AdultOrientedEnumeration,< 1K
+Itemtype,https://schema.org/AdvertiserContentArticle,1K - 10K
+Itemtype,https://schema.org/AggregateOffer,1M - 10M
+Itemtype,https://schema.org/AggregateRating,1M - 10M
+Itemtype,https://schema.org/AgreeAction,< 1K
+Itemtype,https://schema.org/Airline,1K - 10K
+Itemtype,https://schema.org/Airport,1K - 10K
+Itemtype,https://schema.org/AlignmentObject,1K - 10K
+Itemtype,https://schema.org/AllocateAction,< 1K
+Itemtype,https://schema.org/AmpStory,< 1K
+Itemtype,https://schema.org/AmusementPark,1K - 10K
+Itemtype,https://schema.org/AnalysisNewsArticle,1K - 10K
+Itemtype,https://schema.org/AnatomicalStructure,1K - 10K
+Itemtype,https://schema.org/AnatomicalSystem,< 1K
+Itemtype,https://schema.org/AnimalShelter,1K - 10K
+Itemtype,https://schema.org/Answer,1M - 10M
+Itemtype,https://schema.org/Apartment,10K - 100K
+Itemtype,https://schema.org/ApartmentComplex,10K - 100K
+Itemtype,https://schema.org/AppendAction,< 1K
+Itemtype,https://schema.org/ApplyAction,1K - 10K
+Itemtype,https://schema.org/ApprovedIndication,< 1K
+Itemtype,https://schema.org/Aquarium,< 1K
+Itemtype,https://schema.org/ArchiveComponent,< 1K
+Itemtype,https://schema.org/ArchiveOrganization,1K - 10K
+Itemtype,https://schema.org/ArriveAction,< 1K
+Itemtype,https://schema.org/ArtGallery,1K - 10K
+Itemtype,https://schema.org/Artery,< 1K
+Itemtype,https://schema.org/Article,1M - 10M
+Itemtype,https://schema.org/AskAction,< 1K
+Itemtype,https://schema.org/AskPublicNewsArticle,< 1K
+Itemtype,https://schema.org/AssessAction,< 1K
+Itemtype,https://schema.org/AssignAction,< 1K
+Itemtype,https://schema.org/Atlas,< 1K
+Itemtype,https://schema.org/Attorney,10K - 100K
+Itemtype,https://schema.org/Audience,100K - 1M
+Itemtype,https://schema.org/AudioObject,10K - 100K
+Itemtype,https://schema.org/AudioObjectSnapshot,< 1K
+Itemtype,https://schema.org/Audiobook,< 1K
+Itemtype,https://schema.org/AuthenticateAction,< 1K
+Itemtype,https://schema.org/AuthorizeAction,< 1K
+Itemtype,https://schema.org/AutoBodyShop,1K - 10K
+Itemtype,https://schema.org/AutoDealer,10K - 100K
+Itemtype,https://schema.org/AutoPartsStore,10K - 100K
+Itemtype,https://schema.org/AutoRental,10K - 100K
+Itemtype,https://schema.org/AutoRepair,10K - 100K
+Itemtype,https://schema.org/AutoWash,1K - 10K
+Itemtype,https://schema.org/AutomatedTeller,< 1K
+Itemtype,https://schema.org/AutomotiveBusiness,10K - 100K
+Itemtype,https://schema.org/BackgroundNewsArticle,< 1K
+Itemtype,https://schema.org/Bakery,1K - 10K
+Itemtype,https://schema.org/BankAccount,< 1K
+Itemtype,https://schema.org/BankOrCreditUnion,1K - 10K
+Itemtype,https://schema.org/BarOrPub,10K - 100K
+Itemtype,https://schema.org/Barcode,< 1K
+Itemtype,https://schema.org/Beach,1K - 10K
+Itemtype,https://schema.org/BeautySalon,10K - 100K
+Itemtype,https://schema.org/BedAndBreakfast,1K - 10K
+Itemtype,https://schema.org/BedDetails,10K - 100K
+Itemtype,https://schema.org/BedType,< 1K
+Itemtype,https://schema.org/BefriendAction,< 1K
+Itemtype,https://schema.org/BikeStore,1K - 10K
+Itemtype,https://schema.org/BioChemEntity,< 1K
+Itemtype,https://schema.org/Blog,1M - 10M
+Itemtype,https://schema.org/BlogPosting,1M - 10M
+Itemtype,https://schema.org/BloodTest,< 1K
+Itemtype,https://schema.org/BoardingPolicyType,< 1K
+Itemtype,https://schema.org/BoatReservation,< 1K
+Itemtype,https://schema.org/BoatTerminal,< 1K
+Itemtype,https://schema.org/BoatTrip,< 1K
+Itemtype,https://schema.org/BodyMeasurementTypeEnumeration,< 1K
+Itemtype,https://schema.org/BodyOfWater,< 1K
+Itemtype,https://schema.org/Bone,< 1K
+Itemtype,https://schema.org/Book,10K - 100K
+Itemtype,https://schema.org/BookFormatType,< 1K
+Itemtype,https://schema.org/BookSeries,1K - 10K
+Itemtype,https://schema.org/BookStore,1K - 10K
+Itemtype,https://schema.org/BookmarkAction,< 1K
+Itemtype,https://schema.org/Boolean,< 1K
+Itemtype,https://schema.org/BorrowAction,< 1K
+Itemtype,https://schema.org/BowlingAlley,< 1K
+Itemtype,https://schema.org/BrainStructure,< 1K
+Itemtype,https://schema.org/Brand,1M - 10M
+Itemtype,https://schema.org/BreadcrumbList,10M+
+Itemtype,https://schema.org/Brewery,1K - 10K
+Itemtype,https://schema.org/Bridge,< 1K
+Itemtype,https://schema.org/BroadcastChannel,< 1K
+Itemtype,https://schema.org/BroadcastEvent,10K - 100K
+Itemtype,https://schema.org/BroadcastFrequencySpecification,< 1K
+Itemtype,https://schema.org/BroadcastService,1K - 10K
+Itemtype,https://schema.org/BrokerageAccount,< 1K
+Itemtype,https://schema.org/BuddhistTemple,< 1K
+Itemtype,https://schema.org/BusOrCoach,< 1K
+Itemtype,https://schema.org/BusReservation,< 1K
+Itemtype,https://schema.org/BusStation,< 1K
+Itemtype,https://schema.org/BusStop,< 1K
+Itemtype,https://schema.org/BusTrip,< 1K
+Itemtype,https://schema.org/BusinessAudience,10K - 100K
+Itemtype,https://schema.org/BusinessEntityType,< 1K
+Itemtype,https://schema.org/BusinessEvent,1K - 10K
+Itemtype,https://schema.org/BusinessFunction,< 1K
+Itemtype,https://schema.org/BuyAction,1M - 10M
+Itemtype,https://schema.org/CDCPMDRecord,< 1K
+Itemtype,https://schema.org/CableOrSatelliteService,< 1K
+Itemtype,https://schema.org/CafeOrCoffeeShop,1K - 10K
+Itemtype,https://schema.org/Campground,1K - 10K
+Itemtype,https://schema.org/CampingPitch,< 1K
+Itemtype,https://schema.org/Canal,< 1K
+Itemtype,https://schema.org/CancelAction,< 1K
+Itemtype,https://schema.org/Car,10K - 100K
+Itemtype,https://schema.org/CarUsageType,< 1K
+Itemtype,https://schema.org/Casino,100K - 1M
+Itemtype,https://schema.org/CategoryCode,1K - 10K
+Itemtype,https://schema.org/CategoryCodeSet,< 1K
+Itemtype,https://schema.org/CatholicChurch,< 1K
+Itemtype,https://schema.org/Cemetery,< 1K
+Itemtype,https://schema.org/Certification,10K - 100K
+Itemtype,https://schema.org/CertificationStatusEnumeration,< 1K
+Itemtype,https://schema.org/Chapter,1K - 10K
+Itemtype,https://schema.org/CheckAction,< 1K
+Itemtype,https://schema.org/CheckInAction,< 1K
+Itemtype,https://schema.org/CheckOutAction,< 1K
+Itemtype,https://schema.org/CheckoutPage,1K - 10K
+Itemtype,https://schema.org/ChemicalSubstance,< 1K
+Itemtype,https://schema.org/ChildCare,1K - 10K
+Itemtype,https://schema.org/ChildrensEvent,< 1K
+Itemtype,https://schema.org/ChooseAction,1K - 10K
+Itemtype,https://schema.org/Church,1K - 10K
+Itemtype,https://schema.org/City,100K - 1M
+Itemtype,https://schema.org/CityHall,< 1K
+Itemtype,https://schema.org/CivicStructure,1K - 10K
+Itemtype,https://schema.org/Claim,1K - 10K
+Itemtype,https://schema.org/ClaimReview,1K - 10K
+Itemtype,https://schema.org/Class,< 1K
+Itemtype,https://schema.org/Clip,10K - 100K
+Itemtype,https://schema.org/ClothingStore,10K - 100K
+Itemtype,https://schema.org/Code,< 1K
+Itemtype,https://schema.org/Collection,10K - 100K
+Itemtype,https://schema.org/CollectionPage,1M - 10M
+Itemtype,https://schema.org/CollegeOrUniversity,10K - 100K
+Itemtype,https://schema.org/ComedyClub,< 1K
+Itemtype,https://schema.org/ComedyEvent,1K - 10K
+Itemtype,https://schema.org/ComicCoverArt,< 1K
+Itemtype,https://schema.org/ComicIssue,< 1K
+Itemtype,https://schema.org/ComicSeries,1K - 10K
+Itemtype,https://schema.org/ComicStory,< 1K
+Itemtype,https://schema.org/Comment,100K - 1M
+Itemtype,https://schema.org/CommentAction,1M - 10M
+Itemtype,https://schema.org/CommunicateAction,10K - 100K
+Itemtype,https://schema.org/CommunityHealth,1K - 10K
+Itemtype,https://schema.org/CompleteDataFeed,< 1K
+Itemtype,https://schema.org/CompoundPriceSpecification,1K - 10K
+Itemtype,https://schema.org/ComputerLanguage,< 1K
+Itemtype,https://schema.org/ComputerStore,1K - 10K
+Itemtype,https://schema.org/ConferenceEvent,< 1K
+Itemtype,https://schema.org/ConfirmAction,< 1K
+Itemtype,https://schema.org/Consortium,< 1K
+Itemtype,https://schema.org/ConstraintNode,< 1K
+Itemtype,https://schema.org/ConsumeAction,< 1K
+Itemtype,https://schema.org/ContactPage,100K - 1M
+Itemtype,https://schema.org/ContactPoint,1M - 10M
+Itemtype,https://schema.org/ContactPointOption,< 1K
+Itemtype,https://schema.org/Continent,1K - 10K
+Itemtype,https://schema.org/ControlAction,< 1K
+Itemtype,https://schema.org/ConvenienceStore,< 1K
+Itemtype,https://schema.org/Conversation,< 1K
+Itemtype,https://schema.org/CookAction,< 1K
+Itemtype,https://schema.org/Cooperative,< 1K
+Itemtype,https://schema.org/Corporation,100K - 1M
+Itemtype,https://schema.org/CorrectionComment,< 1K
+Itemtype,https://schema.org/Country,1M - 10M
+Itemtype,https://schema.org/Course,100K - 1M
+Itemtype,https://schema.org/CourseInstance,10K - 100K
+Itemtype,https://schema.org/Courthouse,< 1K
+Itemtype,https://schema.org/CoverArt,< 1K
+Itemtype,https://schema.org/CovidTestingFacility,< 1K
+Itemtype,https://schema.org/CreateAction,1K - 10K
+Itemtype,https://schema.org/CreativeWork,1M - 10M
+Itemtype,https://schema.org/CreativeWorkSeason,1K - 10K
+Itemtype,https://schema.org/CreativeWorkSeries,10K - 100K
+Itemtype,https://schema.org/Credential,10K - 100K
+Itemtype,https://schema.org/CreditCard,1K - 10K
+Itemtype,https://schema.org/Crematorium,< 1K
+Itemtype,https://schema.org/CriticReview,< 1K
+Itemtype,https://schema.org/CssSelectorType,< 1K
+Itemtype,https://schema.org/CurrencyConversionService,< 1K
+Itemtype,https://schema.org/DDxElement,< 1K
+Itemtype,https://schema.org/DENonprofitType,< 1K
+Itemtype,https://schema.org/DanceEvent,< 1K
+Itemtype,https://schema.org/DanceGroup,< 1K
+Itemtype,https://schema.org/DataCatalog,1K - 10K
+Itemtype,https://schema.org/DataDownload,10K - 100K
+Itemtype,https://schema.org/DataFeed,1K - 10K
+Itemtype,https://schema.org/DataFeedItem,1K - 10K
+Itemtype,https://schema.org/DataType,< 1K
+Itemtype,https://schema.org/Dataset,10K - 100K
+Itemtype,https://schema.org/Date,< 1K
+Itemtype,https://schema.org/DateTime,< 1K
+Itemtype,https://schema.org/DatedMoneySpecification,< 1K
+Itemtype,https://schema.org/DayOfWeek,10K - 100K
+Itemtype,https://schema.org/DaySpa,1K - 10K
+Itemtype,https://schema.org/DeactivateAction,< 1K
+Itemtype,https://schema.org/DefenceEstablishment,< 1K
+Itemtype,https://schema.org/DefinedRegion,100K - 1M
+Itemtype,https://schema.org/DefinedTerm,10K - 100K
+Itemtype,https://schema.org/DefinedTermSet,10K - 100K
+Itemtype,https://schema.org/DeleteAction,< 1K
+Itemtype,https://schema.org/DeliveryChargeSpecification,10K - 100K
+Itemtype,https://schema.org/DeliveryEvent,< 1K
+Itemtype,https://schema.org/DeliveryMethod,1K - 10K
+Itemtype,https://schema.org/DeliveryTimeSettings,< 1K
+Itemtype,https://schema.org/Demand,1K - 10K
+Itemtype,https://schema.org/Dentist,10K - 100K
+Itemtype,https://schema.org/DepartAction,< 1K
+Itemtype,https://schema.org/DepartmentStore,1K - 10K
+Itemtype,https://schema.org/DepositAccount,< 1K
+Itemtype,https://schema.org/Dermatology,1K - 10K
+Itemtype,https://schema.org/DiagnosticLab,1K - 10K
+Itemtype,https://schema.org/DiagnosticProcedure,< 1K
+Itemtype,https://schema.org/Diet,< 1K
+Itemtype,https://schema.org/DietNutrition,1K - 10K
+Itemtype,https://schema.org/DietarySupplement,< 1K
+Itemtype,https://schema.org/DigitalDocument,10K - 100K
+Itemtype,https://schema.org/DigitalDocumentPermission,< 1K
+Itemtype,https://schema.org/DigitalDocumentPermissionType,< 1K
+Itemtype,https://schema.org/DigitalPlatformEnumeration,< 1K
+Itemtype,https://schema.org/DisagreeAction,< 1K
+Itemtype,https://schema.org/DiscoverAction,< 1K
+Itemtype,https://schema.org/DiscussionForumPosting,10K - 100K
+Itemtype,https://schema.org/DislikeAction,1K - 10K
+Itemtype,https://schema.org/Distance,1K - 10K
+Itemtype,https://schema.org/Distillery,< 1K
+Itemtype,https://schema.org/DonateAction,1K - 10K
+Itemtype,https://schema.org/DoseSchedule,< 1K
+Itemtype,https://schema.org/DownloadAction,1K - 10K
+Itemtype,https://schema.org/DrawAction,< 1K
+Itemtype,https://schema.org/Drawing,< 1K
+Itemtype,https://schema.org/DrinkAction,< 1K
+Itemtype,https://schema.org/DriveWheelConfigurationValue,< 1K
+Itemtype,https://schema.org/Drug,1K - 10K
+Itemtype,https://schema.org/DrugClass,1K - 10K
+Itemtype,https://schema.org/DrugCost,< 1K
+Itemtype,https://schema.org/DrugCostCategory,< 1K
+Itemtype,https://schema.org/DrugLegalStatus,< 1K
+Itemtype,https://schema.org/DrugPregnancyCategory,< 1K
+Itemtype,https://schema.org/DrugPrescriptionStatus,< 1K
+Itemtype,https://schema.org/DrugStrength,< 1K
+Itemtype,https://schema.org/DryCleaningOrLaundry,1K - 10K
+Itemtype,https://schema.org/Duration,10K - 100K
+Itemtype,https://schema.org/EUEnergyEfficiencyEnumeration,< 1K
+Itemtype,https://schema.org/EatAction,< 1K
+Itemtype,https://schema.org/EducationEvent,1K - 10K
+Itemtype,https://schema.org/EducationalAudience,10K - 100K
+Itemtype,https://schema.org/EducationalOccupationalCredential,10K - 100K
+Itemtype,https://schema.org/EducationalOccupationalProgram,1K - 10K
+Itemtype,https://schema.org/EducationalOrganization,100K - 1M
+Itemtype,https://schema.org/Electrician,10K - 100K
+Itemtype,https://schema.org/ElectronicsStore,1K - 10K
+Itemtype,https://schema.org/ElementarySchool,< 1K
+Itemtype,https://schema.org/EmailMessage,< 1K
+Itemtype,https://schema.org/Embassy,< 1K
+Itemtype,https://schema.org/Emergency,< 1K
+Itemtype,https://schema.org/EmergencyService,1K - 10K
+Itemtype,https://schema.org/EmployeeRole,< 1K
+Itemtype,https://schema.org/EmployerAggregateRating,1K - 10K
+Itemtype,https://schema.org/EmployerReview,< 1K
+Itemtype,https://schema.org/EmploymentAgency,1K - 10K
+Itemtype,https://schema.org/EndorseAction,< 1K
+Itemtype,https://schema.org/EndorsementRating,< 1K
+Itemtype,https://schema.org/Energy,< 1K
+Itemtype,https://schema.org/EnergyConsumptionDetails,1K - 10K
+Itemtype,https://schema.org/EnergyEfficiencyEnumeration,< 1K
+Itemtype,https://schema.org/EnergyStarEnergyEfficiencyEnumeration,< 1K
+Itemtype,https://schema.org/EngineSpecification,10K - 100K
+Itemtype,https://schema.org/EntertainmentBusiness,10K - 100K
+Itemtype,https://schema.org/EntryPoint,10M+
+Itemtype,https://schema.org/Enumeration,1K - 10K
+Itemtype,https://schema.org/Episode,1K - 10K
+Itemtype,https://schema.org/Error,< 1K
+Itemtype,https://schema.org/Event,100K - 1M
+Itemtype,https://schema.org/EventAttendanceModeEnumeration,< 1K
+Itemtype,https://schema.org/EventReservation,< 1K
+Itemtype,https://schema.org/EventSeries,1K - 10K
+Itemtype,https://schema.org/EventStatusType,< 1K
+Itemtype,https://schema.org/EventVenue,10K - 100K
+Itemtype,https://schema.org/ExchangeRateSpecification,< 1K
+Itemtype,https://schema.org/ExerciseAction,< 1K
+Itemtype,https://schema.org/ExerciseGym,1K - 10K
+Itemtype,https://schema.org/ExercisePlan,< 1K
+Itemtype,https://schema.org/ExhibitionEvent,1K - 10K
+Itemtype,https://schema.org/FAQPage,1M - 10M
+Itemtype,https://schema.org/FMRadioChannel,< 1K
+Itemtype,https://schema.org/FastFoodRestaurant,1K - 10K
+Itemtype,https://schema.org/Festival,1K - 10K
+Itemtype,https://schema.org/FilmAction,< 1K
+Itemtype,https://schema.org/FinancialIncentive,< 1K
+Itemtype,https://schema.org/FinancialProduct,10K - 100K
+Itemtype,https://schema.org/FinancialService,10K - 100K
+Itemtype,https://schema.org/FindAction,< 1K
+Itemtype,https://schema.org/FireStation,< 1K
+Itemtype,https://schema.org/Flight,1K - 10K
+Itemtype,https://schema.org/FlightReservation,< 1K
+Itemtype,https://schema.org/Float,< 1K
+Itemtype,https://schema.org/FloorPlan,10K - 100K
+Itemtype,https://schema.org/Florist,10K - 100K
+Itemtype,https://schema.org/FollowAction,10K - 100K
+Itemtype,https://schema.org/FoodEstablishment,10K - 100K
+Itemtype,https://schema.org/FoodEstablishmentReservation,1K - 10K
+Itemtype,https://schema.org/FoodEvent,1K - 10K
+Itemtype,https://schema.org/FoodService,1K - 10K
+Itemtype,https://schema.org/FulfillmentTypeEnumeration,< 1K
+Itemtype,https://schema.org/FundingAgency,< 1K
+Itemtype,https://schema.org/FundingScheme,< 1K
+Itemtype,https://schema.org/FurnitureStore,10K - 100K
+Itemtype,https://schema.org/Game,100K - 1M
+Itemtype,https://schema.org/GameAvailabilityEnumeration,< 1K
+Itemtype,https://schema.org/GamePlayMode,< 1K
+Itemtype,https://schema.org/GameServer,1K - 10K
+Itemtype,https://schema.org/GameServerStatus,< 1K
+Itemtype,https://schema.org/GardenStore,1K - 10K
+Itemtype,https://schema.org/GasStation,1K - 10K
+Itemtype,https://schema.org/GatedResidenceCommunity,< 1K
+Itemtype,https://schema.org/GenderType,< 1K
+Itemtype,https://schema.org/Gene,< 1K
+Itemtype,https://schema.org/GeneralContractor,10K - 100K
+Itemtype,https://schema.org/GeoCircle,100K - 1M
+Itemtype,https://schema.org/GeoCoordinates,1M - 10M
+Itemtype,https://schema.org/GeoShape,10K - 100K
+Itemtype,https://schema.org/GeospatialGeometry,< 1K
+Itemtype,https://schema.org/Geriatric,< 1K
+Itemtype,https://schema.org/GiveAction,< 1K
+Itemtype,https://schema.org/GolfCourse,1K - 10K
+Itemtype,https://schema.org/GovernmentBenefitsType,< 1K
+Itemtype,https://schema.org/GovernmentBuilding,< 1K
+Itemtype,https://schema.org/GovernmentOffice,1K - 10K
+Itemtype,https://schema.org/GovernmentOrganization,10K - 100K
+Itemtype,https://schema.org/GovernmentPermit,< 1K
+Itemtype,https://schema.org/GovernmentService,1K - 10K
+Itemtype,https://schema.org/Grant,1K - 10K
+Itemtype,https://schema.org/GroceryStore,1K - 10K
+Itemtype,https://schema.org/Guide,1K - 10K
+Itemtype,https://schema.org/Gynecologic,< 1K
+Itemtype,https://schema.org/HVACBusiness,10K - 100K
+Itemtype,https://schema.org/Hackathon,< 1K
+Itemtype,https://schema.org/HairSalon,10K - 100K
+Itemtype,https://schema.org/HardwareStore,1K - 10K
+Itemtype,https://schema.org/HealthAndBeautyBusiness,10K - 100K
+Itemtype,https://schema.org/HealthAspectEnumeration,< 1K
+Itemtype,https://schema.org/HealthClub,1K - 10K
+Itemtype,https://schema.org/HealthInsurancePlan,< 1K
+Itemtype,https://schema.org/HealthPlanCostSharingSpecification,< 1K
+Itemtype,https://schema.org/HealthPlanFormulary,< 1K
+Itemtype,https://schema.org/HealthPlanNetwork,< 1K
+Itemtype,https://schema.org/HealthTopicContent,< 1K
+Itemtype,https://schema.org/HighSchool,1K - 10K
+Itemtype,https://schema.org/HinduTemple,< 1K
+Itemtype,https://schema.org/HobbyShop,1K - 10K
+Itemtype,https://schema.org/HomeAndConstructionBusiness,100K - 1M
+Itemtype,https://schema.org/HomeGoodsStore,1K - 10K
+Itemtype,https://schema.org/Hospital,10K - 100K
+Itemtype,https://schema.org/Hostel,1K - 10K
+Itemtype,https://schema.org/Hotel,10K - 100K
+Itemtype,https://schema.org/HotelRoom,10K - 100K
+Itemtype,https://schema.org/House,10K - 100K
+Itemtype,https://schema.org/HousePainter,1K - 10K
+Itemtype,https://schema.org/HowTo,100K - 1M
+Itemtype,https://schema.org/HowToDirection,10K - 100K
+Itemtype,https://schema.org/HowToItem,< 1K
+Itemtype,https://schema.org/HowToSection,10K - 100K
+Itemtype,https://schema.org/HowToStep,100K - 1M
+Itemtype,https://schema.org/HowToSupply,10K - 100K
+Itemtype,https://schema.org/HowToTip,1K - 10K
+Itemtype,https://schema.org/HowToTool,10K - 100K
+Itemtype,https://schema.org/HyperToc,< 1K
+Itemtype,https://schema.org/HyperTocEntry,< 1K
+Itemtype,https://schema.org/IPTCDigitalSourceEnumeration,< 1K
+Itemtype,https://schema.org/ITNonprofitType,< 1K
+Itemtype,https://schema.org/IceCreamShop,1K - 10K
+Itemtype,https://schema.org/IgnoreAction,< 1K
+Itemtype,https://schema.org/ImageGallery,1M - 10M
+Itemtype,https://schema.org/ImageObject,10M+
+Itemtype,https://schema.org/ImageObjectSnapshot,< 1K
+Itemtype,https://schema.org/ImagingTest,< 1K
+Itemtype,https://schema.org/IncentiveQualifiedExpenseType,< 1K
+Itemtype,https://schema.org/IncentiveStatus,< 1K
+Itemtype,https://schema.org/IncentiveType,< 1K
+Itemtype,https://schema.org/IndividualPhysician,1K - 10K
+Itemtype,https://schema.org/IndividualProduct,10K - 100K
+Itemtype,https://schema.org/InfectiousAgentClass,< 1K
+Itemtype,https://schema.org/InfectiousDisease,< 1K
+Itemtype,https://schema.org/InformAction,< 1K
+Itemtype,https://schema.org/InsertAction,< 1K
+Itemtype,https://schema.org/InstallAction,< 1K
+Itemtype,https://schema.org/InstantaneousEvent,< 1K
+Itemtype,https://schema.org/InsuranceAgency,10K - 100K
+Itemtype,https://schema.org/Intangible,1K - 10K
+Itemtype,https://schema.org/Integer,< 1K
+Itemtype,https://schema.org/InteractAction,1K - 10K
+Itemtype,https://schema.org/InteractionCounter,100K - 1M
+Itemtype,https://schema.org/InternetCafe,< 1K
+Itemtype,https://schema.org/InvestmentFund,< 1K
+Itemtype,https://schema.org/InvestmentOrDeposit,< 1K
+Itemtype,https://schema.org/InviteAction,< 1K
+Itemtype,https://schema.org/Invoice,< 1K
+Itemtype,https://schema.org/ItemAvailability,1K - 10K
+Itemtype,https://schema.org/ItemList,1M - 10M
+Itemtype,https://schema.org/ItemListOrderType,< 1K
+Itemtype,https://schema.org/ItemPage,1M - 10M
+Itemtype,https://schema.org/JewelryStore,10K - 100K
+Itemtype,https://schema.org/JobPosting,100K - 1M
+Itemtype,https://schema.org/JoinAction,1K - 10K
+Itemtype,https://schema.org/Joint,< 1K
+Itemtype,https://schema.org/LakeBodyOfWater,< 1K
+Itemtype,https://schema.org/Landform,1K - 10K
+Itemtype,https://schema.org/LandmarksOrHistoricalBuildings,1K - 10K
+Itemtype,https://schema.org/Language,10K - 100K
+Itemtype,https://schema.org/LearningResource,1K - 10K
+Itemtype,https://schema.org/LeaveAction,< 1K
+Itemtype,https://schema.org/LegalForceStatus,< 1K
+Itemtype,https://schema.org/LegalService,10K - 100K
+Itemtype,https://schema.org/LegalValueLevel,< 1K
+Itemtype,https://schema.org/Legislation,1K - 10K
+Itemtype,https://schema.org/LegislationObject,1K - 10K
+Itemtype,https://schema.org/LegislativeBuilding,< 1K
+Itemtype,https://schema.org/LendAction,< 1K
+Itemtype,https://schema.org/Library,1K - 10K
+Itemtype,https://schema.org/LibrarySystem,< 1K
+Itemtype,https://schema.org/LifestyleModification,< 1K
+Itemtype,https://schema.org/Ligament,< 1K
+Itemtype,https://schema.org/LikeAction,10K - 100K
+Itemtype,https://schema.org/LinkRole,< 1K
+Itemtype,https://schema.org/LiquorStore,1K - 10K
+Itemtype,https://schema.org/ListItem,10M+
+Itemtype,https://schema.org/ListenAction,1K - 10K
+Itemtype,https://schema.org/Literal,< 1K
+Itemtype,https://schema.org/LiteraryEvent,< 1K
+Itemtype,https://schema.org/LiveBlogPosting,1K - 10K
+Itemtype,https://schema.org/LoanOrCredit,1K - 10K
+Itemtype,https://schema.org/LocalBusiness,1M - 10M
+Itemtype,https://schema.org/LocationFeatureSpecification,100K - 1M
+Itemtype,https://schema.org/Locksmith,10K - 100K
+Itemtype,https://schema.org/LodgingBusiness,10K - 100K
+Itemtype,https://schema.org/LodgingReservation,1K - 10K
+Itemtype,https://schema.org/LoginAction,1K - 10K
+Itemtype,https://schema.org/LoseAction,< 1K
+Itemtype,https://schema.org/LymphaticVessel,< 1K
+Itemtype,https://schema.org/Manuscript,< 1K
+Itemtype,https://schema.org/Map,10K - 100K
+Itemtype,https://schema.org/MapCategoryType,< 1K
+Itemtype,https://schema.org/MarryAction,< 1K
+Itemtype,https://schema.org/Mass,< 1K
+Itemtype,https://schema.org/MathSolver,< 1K
+Itemtype,https://schema.org/MaximumDoseSchedule,< 1K
+Itemtype,https://schema.org/MeasurementMethodEnum,< 1K
+Itemtype,https://schema.org/MeasurementTypeEnumeration,< 1K
+Itemtype,https://schema.org/MediaEnumeration,< 1K
+Itemtype,https://schema.org/MediaGallery,1K - 10K
+Itemtype,https://schema.org/MediaManipulationRatingEnumeration,< 1K
+Itemtype,https://schema.org/MediaObject,100K - 1M
+Itemtype,https://schema.org/MediaReview,< 1K
+Itemtype,https://schema.org/MediaReviewItem,< 1K
+Itemtype,https://schema.org/MediaSubscription,< 1K
+Itemtype,https://schema.org/MedicalAudience,10K - 100K
+Itemtype,https://schema.org/MedicalAudienceType,< 1K
+Itemtype,https://schema.org/MedicalBusiness,10K - 100K
+Itemtype,https://schema.org/MedicalCause,1K - 10K
+Itemtype,https://schema.org/MedicalClinic,10K - 100K
+Itemtype,https://schema.org/MedicalCode,1K - 10K
+Itemtype,https://schema.org/MedicalCondition,10K - 100K
+Itemtype,https://schema.org/MedicalConditionStage,< 1K
+Itemtype,https://schema.org/MedicalContraindication,< 1K
+Itemtype,https://schema.org/MedicalDevice,1K - 10K
+Itemtype,https://schema.org/MedicalDevicePurpose,< 1K
+Itemtype,https://schema.org/MedicalEntity,1K - 10K
+Itemtype,https://schema.org/MedicalEnumeration,< 1K
+Itemtype,https://schema.org/MedicalEvidenceLevel,< 1K
+Itemtype,https://schema.org/MedicalGuideline,< 1K
+Itemtype,https://schema.org/MedicalGuidelineContraindication,< 1K
+Itemtype,https://schema.org/MedicalGuidelineRecommendation,< 1K
+Itemtype,https://schema.org/MedicalImagingTechnique,< 1K
+Itemtype,https://schema.org/MedicalIndication,1K - 10K
+Itemtype,https://schema.org/MedicalIntangible,< 1K
+Itemtype,https://schema.org/MedicalObservationalStudy,< 1K
+Itemtype,https://schema.org/MedicalObservationalStudyDesign,< 1K
+Itemtype,https://schema.org/MedicalOrganization,10K - 100K
+Itemtype,https://schema.org/MedicalProcedure,10K - 100K
+Itemtype,https://schema.org/MedicalProcedureType,< 1K
+Itemtype,https://schema.org/MedicalRiskCalculator,< 1K
+Itemtype,https://schema.org/MedicalRiskEstimator,< 1K
+Itemtype,https://schema.org/MedicalRiskFactor,1K - 10K
+Itemtype,https://schema.org/MedicalRiskScore,< 1K
+Itemtype,https://schema.org/MedicalScholarlyArticle,1K - 10K
+Itemtype,https://schema.org/MedicalSign,< 1K
+Itemtype,https://schema.org/MedicalSignOrSymptom,1K - 10K
+Itemtype,https://schema.org/MedicalSpecialty,10K - 100K
+Itemtype,https://schema.org/MedicalStudy,1K - 10K
+Itemtype,https://schema.org/MedicalStudyStatus,< 1K
+Itemtype,https://schema.org/MedicalSymptom,1K - 10K
+Itemtype,https://schema.org/MedicalTest,1K - 10K
+Itemtype,https://schema.org/MedicalTestPanel,< 1K
+Itemtype,https://schema.org/MedicalTherapy,10K - 100K
+Itemtype,https://schema.org/MedicalTrial,< 1K
+Itemtype,https://schema.org/MedicalTrialDesign,< 1K
+Itemtype,https://schema.org/MedicalWebPage,10K - 100K
+Itemtype,https://schema.org/MedicineSystem,< 1K
+Itemtype,https://schema.org/MeetingRoom,1K - 10K
+Itemtype,https://schema.org/MemberProgram,1K - 10K
+Itemtype,https://schema.org/MemberProgramTier,1K - 10K
+Itemtype,https://schema.org/MensClothingStore,< 1K
+Itemtype,https://schema.org/Menu,100K - 1M
+Itemtype,https://schema.org/MenuItem,10K - 100K
+Itemtype,https://schema.org/MenuSection,10K - 100K
+Itemtype,https://schema.org/MerchantReturnEnumeration,< 1K
+Itemtype,https://schema.org/MerchantReturnPolicy,100K - 1M
+Itemtype,https://schema.org/MerchantReturnPolicySeasonalOverride,1K - 10K
+Itemtype,https://schema.org/Message,1K - 10K
+Itemtype,https://schema.org/MiddleSchool,< 1K
+Itemtype,https://schema.org/Midwifery,< 1K
+Itemtype,https://schema.org/MobileApplication,100K - 1M
+Itemtype,https://schema.org/MobilePhoneStore,1K - 10K
+Itemtype,https://schema.org/MolecularEntity,< 1K
+Itemtype,https://schema.org/MonetaryAmount,100K - 1M
+Itemtype,https://schema.org/MonetaryAmountDistribution,1K - 10K
+Itemtype,https://schema.org/MonetaryGrant,1K - 10K
+Itemtype,https://schema.org/MoneyTransfer,< 1K
+Itemtype,https://schema.org/MortgageLoan,< 1K
+Itemtype,https://schema.org/Mosque,< 1K
+Itemtype,https://schema.org/Motel,< 1K
+Itemtype,https://schema.org/Motorcycle,1K - 10K
+Itemtype,https://schema.org/MotorcycleDealer,1K - 10K
+Itemtype,https://schema.org/MotorcycleRepair,< 1K
+Itemtype,https://schema.org/MotorizedBicycle,< 1K
+Itemtype,https://schema.org/Mountain,< 1K
+Itemtype,https://schema.org/MoveAction,< 1K
+Itemtype,https://schema.org/Movie,10K - 100K
+Itemtype,https://schema.org/MovieClip,< 1K
+Itemtype,https://schema.org/MovieRentalStore,< 1K
+Itemtype,https://schema.org/MovieSeries,< 1K
+Itemtype,https://schema.org/MovieTheater,1K - 10K
+Itemtype,https://schema.org/MovingCompany,10K - 100K
+Itemtype,https://schema.org/Muscle,< 1K
+Itemtype,https://schema.org/Museum,1K - 10K
+Itemtype,https://schema.org/MusicAlbum,10K - 100K
+Itemtype,https://schema.org/MusicAlbumProductionType,< 1K
+Itemtype,https://schema.org/MusicAlbumReleaseType,< 1K
+Itemtype,https://schema.org/MusicComposition,1K - 10K
+Itemtype,https://schema.org/MusicEvent,10K - 100K
+Itemtype,https://schema.org/MusicGroup,10K - 100K
+Itemtype,https://schema.org/MusicPlaylist,1K - 10K
+Itemtype,https://schema.org/MusicRecording,10K - 100K
+Itemtype,https://schema.org/MusicRelease,1K - 10K
+Itemtype,https://schema.org/MusicReleaseFormatType,< 1K
+Itemtype,https://schema.org/MusicStore,1K - 10K
+Itemtype,https://schema.org/MusicVenue,1K - 10K
+Itemtype,https://schema.org/MusicVideoObject,< 1K
+Itemtype,https://schema.org/NGO,10K - 100K
+Itemtype,https://schema.org/NLNonprofitType,< 1K
+Itemtype,https://schema.org/NailSalon,1K - 10K
+Itemtype,https://schema.org/Nerve,< 1K
+Itemtype,https://schema.org/NewsArticle,100K - 1M
+Itemtype,https://schema.org/NewsMediaOrganization,10K - 100K
+Itemtype,https://schema.org/Newspaper,< 1K
+Itemtype,https://schema.org/NightClub,1K - 10K
+Itemtype,https://schema.org/NonprofitType,< 1K
+Itemtype,https://schema.org/Notary,1K - 10K
+Itemtype,https://schema.org/NoteDigitalDocument,< 1K
+Itemtype,https://schema.org/Number,< 1K
+Itemtype,https://schema.org/Nursing,< 1K
+Itemtype,https://schema.org/NutritionInformation,10K - 100K
+Itemtype,https://schema.org/Observation,< 1K
+Itemtype,https://schema.org/Obstetric,< 1K
+Itemtype,https://schema.org/Occupation,10K - 100K
+Itemtype,https://schema.org/OccupationalExperienceRequirements,1K - 10K
+Itemtype,https://schema.org/OccupationalTherapy,< 1K
+Itemtype,https://schema.org/OceanBodyOfWater,< 1K
+Itemtype,https://schema.org/Offer,10M+
+Itemtype,https://schema.org/OfferCatalog,100K - 1M
+Itemtype,https://schema.org/OfferForLease,1K - 10K
+Itemtype,https://schema.org/OfferForPurchase,1K - 10K
+Itemtype,https://schema.org/OfferItemCondition,1K - 10K
+Itemtype,https://schema.org/OfferShippingDetails,100K - 1M
+Itemtype,https://schema.org/OfficeEquipmentStore,1K - 10K
+Itemtype,https://schema.org/OnDemandEvent,< 1K
+Itemtype,https://schema.org/Oncologic,< 1K
+Itemtype,https://schema.org/OnlineBusiness,10K - 100K
+Itemtype,https://schema.org/OnlineMarketplace,< 1K
+Itemtype,https://schema.org/OnlineStore,100K - 1M
+Itemtype,https://schema.org/OpeningHoursSpecification,1M - 10M
+Itemtype,https://schema.org/OperatingSystem,< 1K
+Itemtype,https://schema.org/OpinionNewsArticle,1K - 10K
+Itemtype,https://schema.org/Optician,1K - 10K
+Itemtype,https://schema.org/Optometric,1K - 10K
+Itemtype,https://schema.org/Order,1K - 10K
+Itemtype,https://schema.org/OrderAction,10K - 100K
+Itemtype,https://schema.org/OrderItem,< 1K
+Itemtype,https://schema.org/OrderStatus,< 1K
+Itemtype,https://schema.org/Organization,10M+
+Itemtype,https://schema.org/OrganizationRole,1K - 10K
+Itemtype,https://schema.org/OrganizeAction,< 1K
+Itemtype,https://schema.org/Otolaryngologic,< 1K
+Itemtype,https://schema.org/OutletStore,< 1K
+Itemtype,https://schema.org/OwnershipInfo,< 1K
+Itemtype,https://schema.org/PaintAction,< 1K
+Itemtype,https://schema.org/Painting,< 1K
+Itemtype,https://schema.org/PalliativeProcedure,< 1K
+Itemtype,https://schema.org/ParcelDelivery,< 1K
+Itemtype,https://schema.org/ParentAudience,< 1K
+Itemtype,https://schema.org/Park,1K - 10K
+Itemtype,https://schema.org/ParkingFacility,1K - 10K
+Itemtype,https://schema.org/PathologyTest,< 1K
+Itemtype,https://schema.org/Patient,1K - 10K
+Itemtype,https://schema.org/PawnShop,< 1K
+Itemtype,https://schema.org/PayAction,< 1K
+Itemtype,https://schema.org/PaymentCard,< 1K
+Itemtype,https://schema.org/PaymentChargeSpecification,< 1K
+Itemtype,https://schema.org/PaymentMethod,10K - 100K
+Itemtype,https://schema.org/PaymentMethodType,< 1K
+Itemtype,https://schema.org/PaymentService,1K - 10K
+Itemtype,https://schema.org/PaymentStatusType,< 1K
+Itemtype,https://schema.org/Pediatric,< 1K
+Itemtype,https://schema.org/PeopleAudience,10K - 100K
+Itemtype,https://schema.org/PerformAction,< 1K
+Itemtype,https://schema.org/PerformanceRole,< 1K
+Itemtype,https://schema.org/PerformingArtsEvent,< 1K
+Itemtype,https://schema.org/PerformingArtsTheater,1K - 10K
+Itemtype,https://schema.org/PerformingGroup,10K - 100K
+Itemtype,https://schema.org/Periodical,1K - 10K
+Itemtype,https://schema.org/Permit,10K - 100K
+Itemtype,https://schema.org/Person,10M+
+Itemtype,https://schema.org/PetStore,1K - 10K
+Itemtype,https://schema.org/Pharmacy,10K - 100K
+Itemtype,https://schema.org/Photograph,10K - 100K
+Itemtype,https://schema.org/PhotographAction,< 1K
+Itemtype,https://schema.org/PhysicalActivity,< 1K
+Itemtype,https://schema.org/PhysicalActivityCategory,1K - 10K
+Itemtype,https://schema.org/PhysicalExam,< 1K
+Itemtype,https://schema.org/PhysicalTherapy,< 1K
+Itemtype,https://schema.org/Physician,10K - 100K
+Itemtype,https://schema.org/PhysiciansOffice,< 1K
+Itemtype,https://schema.org/Physiotherapy,1K - 10K
+Itemtype,https://schema.org/Place,1M - 10M
+Itemtype,https://schema.org/PlaceOfWorship,1K - 10K
+Itemtype,https://schema.org/PlanAction,< 1K
+Itemtype,https://schema.org/PlasticSurgery,< 1K
+Itemtype,https://schema.org/Play,< 1K
+Itemtype,https://schema.org/PlayAction,10K - 100K
+Itemtype,https://schema.org/PlayGameAction,< 1K
+Itemtype,https://schema.org/Playground,< 1K
+Itemtype,https://schema.org/Plumber,10K - 100K
+Itemtype,https://schema.org/PodcastEpisode,10K - 100K
+Itemtype,https://schema.org/PodcastSeason,< 1K
+Itemtype,https://schema.org/PodcastSeries,10K - 100K
+Itemtype,https://schema.org/Podiatric,< 1K
+Itemtype,https://schema.org/PoliceStation,< 1K
+Itemtype,https://schema.org/PoliticalParty,< 1K
+Itemtype,https://schema.org/Pond,< 1K
+Itemtype,https://schema.org/PostOffice,< 1K
+Itemtype,https://schema.org/PostalAddress,10M+
+Itemtype,https://schema.org/PostalCodeRangeSpecification,1K - 10K
+Itemtype,https://schema.org/Poster,< 1K
+Itemtype,https://schema.org/PreOrderAction,< 1K
+Itemtype,https://schema.org/PrependAction,< 1K
+Itemtype,https://schema.org/Preschool,1K - 10K
+Itemtype,https://schema.org/PresentationDigitalDocument,< 1K
+Itemtype,https://schema.org/PreventionIndication,< 1K
+Itemtype,https://schema.org/PriceComponentTypeEnumeration,< 1K
+Itemtype,https://schema.org/PriceSpecification,100K - 1M
+Itemtype,https://schema.org/PriceTypeEnumeration,< 1K
+Itemtype,https://schema.org/PrimaryCare,< 1K
+Itemtype,https://schema.org/Product,10M+
+Itemtype,https://schema.org/ProductCollection,1K - 10K
+Itemtype,https://schema.org/ProductGroup,100K - 1M
+Itemtype,https://schema.org/ProductModel,1K - 10K
+Itemtype,https://schema.org/ProductReturnEnumeration,< 1K
+Itemtype,https://schema.org/ProductReturnPolicy,< 1K
+Itemtype,https://schema.org/ProfessionalService,100K - 1M
+Itemtype,https://schema.org/ProfilePage,1M - 10M
+Itemtype,https://schema.org/ProgramMembership,1K - 10K
+Itemtype,https://schema.org/Project,1K - 10K
+Itemtype,https://schema.org/PronounceableText,< 1K
+Itemtype,https://schema.org/Property,< 1K
+Itemtype,https://schema.org/PropertyValue,100K - 1M
+Itemtype,https://schema.org/PropertyValueSpecification,10M+
+Itemtype,https://schema.org/Protein,< 1K
+Itemtype,https://schema.org/Psychiatric,1K - 10K
+Itemtype,https://schema.org/PsychologicalTreatment,< 1K
+Itemtype,https://schema.org/PublicHealth,< 1K
+Itemtype,https://schema.org/PublicSwimmingPool,< 1K
+Itemtype,https://schema.org/PublicToilet,< 1K
+Itemtype,https://schema.org/PublicationEvent,1K - 10K
+Itemtype,https://schema.org/PublicationIssue,1K - 10K
+Itemtype,https://schema.org/PublicationVolume,1K - 10K
+Itemtype,https://schema.org/PurchaseType,< 1K
+Itemtype,https://schema.org/QAPage,10K - 100K
+Itemtype,https://schema.org/QualitativeValue,1K - 10K
+Itemtype,https://schema.org/QuantitativeValue,1M - 10M
+Itemtype,https://schema.org/QuantitativeValueDistribution,< 1K
+Itemtype,https://schema.org/Quantity,< 1K
+Itemtype,https://schema.org/Question,1M - 10M
+Itemtype,https://schema.org/Quiz,1K - 10K
+Itemtype,https://schema.org/Quotation,1K - 10K
+Itemtype,https://schema.org/QuoteAction,1K - 10K
+Itemtype,https://schema.org/RVPark,< 1K
+Itemtype,https://schema.org/RadiationTherapy,< 1K
+Itemtype,https://schema.org/RadioBroadcastService,< 1K
+Itemtype,https://schema.org/RadioChannel,< 1K
+Itemtype,https://schema.org/RadioClip,< 1K
+Itemtype,https://schema.org/RadioEpisode,1K - 10K
+Itemtype,https://schema.org/RadioSeason,< 1K
+Itemtype,https://schema.org/RadioSeries,1K - 10K
+Itemtype,https://schema.org/RadioStation,1K - 10K
+Itemtype,https://schema.org/Rating,1M - 10M
+Itemtype,https://schema.org/ReactAction,< 1K
+Itemtype,https://schema.org/ReadAction,10M+
+Itemtype,https://schema.org/RealEstateAgent,100K - 1M
+Itemtype,https://schema.org/RealEstateListing,10K - 100K
+Itemtype,https://schema.org/ReceiveAction,< 1K
+Itemtype,https://schema.org/Recipe,10K - 100K
+Itemtype,https://schema.org/Recommendation,< 1K
+Itemtype,https://schema.org/RecommendedDoseSchedule,< 1K
+Itemtype,https://schema.org/RecyclingCenter,1K - 10K
+Itemtype,https://schema.org/RefundTypeEnumeration,< 1K
+Itemtype,https://schema.org/RegisterAction,1K - 10K
+Itemtype,https://schema.org/RejectAction,< 1K
+Itemtype,https://schema.org/RentAction,1K - 10K
+Itemtype,https://schema.org/RentalCarReservation,< 1K
+Itemtype,https://schema.org/RepaymentSpecification,< 1K
+Itemtype,https://schema.org/ReplaceAction,< 1K
+Itemtype,https://schema.org/ReplyAction,1K - 10K
+Itemtype,https://schema.org/Report,1K - 10K
+Itemtype,https://schema.org/ReportageNewsArticle,1K - 10K
+Itemtype,https://schema.org/ReportedDoseSchedule,< 1K
+Itemtype,https://schema.org/ResearchOrganization,1K - 10K
+Itemtype,https://schema.org/ResearchProject,1K - 10K
+Itemtype,https://schema.org/Researcher,< 1K
+Itemtype,https://schema.org/Reservation,10K - 100K
+Itemtype,https://schema.org/ReservationPackage,< 1K
+Itemtype,https://schema.org/ReservationStatusType,< 1K
+Itemtype,https://schema.org/ReserveAction,10K - 100K
+Itemtype,https://schema.org/Reservoir,< 1K
+Itemtype,https://schema.org/ResetPasswordAction,< 1K
+Itemtype,https://schema.org/Residence,10K - 100K
+Itemtype,https://schema.org/Resort,1K - 10K
+Itemtype,https://schema.org/RespiratoryTherapy,< 1K
+Itemtype,https://schema.org/Restaurant,100K - 1M
+Itemtype,https://schema.org/RestrictedDiet,1K - 10K
+Itemtype,https://schema.org/ResumeAction,< 1K
+Itemtype,https://schema.org/ReturnAction,< 1K
+Itemtype,https://schema.org/ReturnFeesEnumeration,< 1K
+Itemtype,https://schema.org/ReturnLabelSourceEnumeration,< 1K
+Itemtype,https://schema.org/ReturnMethodEnumeration,< 1K
+Itemtype,https://schema.org/Review,1M - 10M
+Itemtype,https://schema.org/ReviewAction,1K - 10K
+Itemtype,https://schema.org/ReviewNewsArticle,< 1K
+Itemtype,https://schema.org/RiverBodyOfWater,< 1K
+Itemtype,https://schema.org/Role,1K - 10K
+Itemtype,https://schema.org/RoofingContractor,10K - 100K
+Itemtype,https://schema.org/Room,1K - 10K
+Itemtype,https://schema.org/RsvpAction,< 1K
+Itemtype,https://schema.org/RsvpResponseType,< 1K
+Itemtype,https://schema.org/RuntimePlatform,< 1K
+Itemtype,https://schema.org/SaleEvent,1K - 10K
+Itemtype,https://schema.org/SatiricalArticle,< 1K
+Itemtype,https://schema.org/Schedule,10K - 100K
+Itemtype,https://schema.org/ScheduleAction,1K - 10K
+Itemtype,https://schema.org/ScholarlyArticle,10K - 100K
+Itemtype,https://schema.org/School,1K - 10K
+Itemtype,https://schema.org/SchoolDistrict,< 1K
+Itemtype,https://schema.org/ScreeningEvent,1K - 10K
+Itemtype,https://schema.org/Sculpture,< 1K
+Itemtype,https://schema.org/SeaBodyOfWater,< 1K
+Itemtype,https://schema.org/SearchAction,10M+
+Itemtype,https://schema.org/SearchRescueOrganization,< 1K
+Itemtype,https://schema.org/SearchResultsPage,10K - 100K
+Itemtype,https://schema.org/Season,< 1K
+Itemtype,https://schema.org/Seat,< 1K
+Itemtype,https://schema.org/SeekToAction,10K - 100K
+Itemtype,https://schema.org/SelfStorage,10K - 100K
+Itemtype,https://schema.org/SellAction,1K - 10K
+Itemtype,https://schema.org/SendAction,< 1K
+Itemtype,https://schema.org/SequentialArt,< 1K
+Itemtype,https://schema.org/Series,10K - 100K
+Itemtype,https://schema.org/Service,1M - 10M
+Itemtype,https://schema.org/ServiceChannel,100K - 1M
+Itemtype,https://schema.org/ServicePeriod,1K - 10K
+Itemtype,https://schema.org/ShareAction,10K - 100K
+Itemtype,https://schema.org/SheetMusic,< 1K
+Itemtype,https://schema.org/ShippingConditions,10K - 100K
+Itemtype,https://schema.org/ShippingDeliveryTime,100K - 1M
+Itemtype,https://schema.org/ShippingRateSettings,< 1K
+Itemtype,https://schema.org/ShippingService,10K - 100K
+Itemtype,https://schema.org/ShoeStore,1K - 10K
+Itemtype,https://schema.org/ShoppingCenter,1K - 10K
+Itemtype,https://schema.org/ShortStory,< 1K
+Itemtype,https://schema.org/SingleFamilyResidence,10K - 100K
+Itemtype,https://schema.org/SiteNavigationElement,1M - 10M
+Itemtype,https://schema.org/SizeGroupEnumeration,< 1K
+Itemtype,https://schema.org/SizeSpecification,1K - 10K
+Itemtype,https://schema.org/SizeSystemEnumeration,< 1K
+Itemtype,https://schema.org/SkiResort,< 1K
+Itemtype,https://schema.org/SocialEvent,1K - 10K
+Itemtype,https://schema.org/SocialMediaPosting,10K - 100K
+Itemtype,https://schema.org/SoftwareApplication,100K - 1M
+Itemtype,https://schema.org/SoftwareSourceCode,1K - 10K
+Itemtype,https://schema.org/SolveMathAction,< 1K
+Itemtype,https://schema.org/SomeProducts,10K - 100K
+Itemtype,https://schema.org/SpeakableSpecification,100K - 1M
+Itemtype,https://schema.org/SpecialAnnouncement,1K - 10K
+Itemtype,https://schema.org/Specialty,1K - 10K
+Itemtype,https://schema.org/SportingGoodsStore,1K - 10K
+Itemtype,https://schema.org/SportsActivityLocation,10K - 100K
+Itemtype,https://schema.org/SportsClub,1K - 10K
+Itemtype,https://schema.org/SportsEvent,10K - 100K
+Itemtype,https://schema.org/SportsOrganization,10K - 100K
+Itemtype,https://schema.org/SportsTeam,10K - 100K
+Itemtype,https://schema.org/SpreadsheetDigitalDocument,< 1K
+Itemtype,https://schema.org/StadiumOrArena,1K - 10K
+Itemtype,https://schema.org/State,100K - 1M
+Itemtype,https://schema.org/Statement,< 1K
+Itemtype,https://schema.org/StatisticalPopulation,< 1K
+Itemtype,https://schema.org/StatisticalVariable,< 1K
+Itemtype,https://schema.org/StatusEnumeration,< 1K
+Itemtype,https://schema.org/SteeringPositionValue,< 1K
+Itemtype,https://schema.org/Store,100K - 1M
+Itemtype,https://schema.org/StructuredValue,1K - 10K
+Itemtype,https://schema.org/StupidType,< 1K
+Itemtype,https://schema.org/SubscribeAction,10K - 100K
+Itemtype,https://schema.org/Substance,< 1K
+Itemtype,https://schema.org/SubwayStation,< 1K
+Itemtype,https://schema.org/Suite,< 1K
+Itemtype,https://schema.org/SuperficialAnatomy,< 1K
+Itemtype,https://schema.org/SurgicalProcedure,1K - 10K
+Itemtype,https://schema.org/SuspendAction,< 1K
+Itemtype,https://schema.org/Syllabus,1K - 10K
+Itemtype,https://schema.org/Synagogue,< 1K
+Itemtype,https://schema.org/TVClip,< 1K
+Itemtype,https://schema.org/TVEpisode,1K - 10K
+Itemtype,https://schema.org/TVSeason,1K - 10K
+Itemtype,https://schema.org/TVSeries,10K - 100K
+Itemtype,https://schema.org/Table,10K - 100K
+Itemtype,https://schema.org/TakeAction,< 1K
+Itemtype,https://schema.org/TattooParlor,1K - 10K
+Itemtype,https://schema.org/Taxi,< 1K
+Itemtype,https://schema.org/TaxiReservation,< 1K
+Itemtype,https://schema.org/TaxiService,1K - 10K
+Itemtype,https://schema.org/TaxiStand,< 1K
+Itemtype,https://schema.org/Taxon,< 1K
+Itemtype,https://schema.org/TechArticle,10K - 100K
+Itemtype,https://schema.org/TelevisionChannel,< 1K
+Itemtype,https://schema.org/TelevisionStation,< 1K
+Itemtype,https://schema.org/TennisComplex,< 1K
+Itemtype,https://schema.org/Text,10K - 100K
+Itemtype,https://schema.org/TextDigitalDocument,< 1K
+Itemtype,https://schema.org/TextObject,1K - 10K
+Itemtype,https://schema.org/TheaterEvent,1K - 10K
+Itemtype,https://schema.org/TheaterGroup,1K - 10K
+Itemtype,https://schema.org/TherapeuticProcedure,1K - 10K
+Itemtype,https://schema.org/Thesis,< 1K
+Itemtype,https://schema.org/Thing,10M+
+Itemtype,https://schema.org/Ticket,< 1K
+Itemtype,https://schema.org/TieAction,< 1K
+Itemtype,https://schema.org/TierBenefitEnumeration,< 1K
+Itemtype,https://schema.org/Time,< 1K
+Itemtype,https://schema.org/TipAction,< 1K
+Itemtype,https://schema.org/TireShop,1K - 10K
+Itemtype,https://schema.org/TouristAttraction,10K - 100K
+Itemtype,https://schema.org/TouristDestination,10K - 100K
+Itemtype,https://schema.org/TouristInformationCenter,1K - 10K
+Itemtype,https://schema.org/TouristTrip,10K - 100K
+Itemtype,https://schema.org/ToyStore,1K - 10K
+Itemtype,https://schema.org/TrackAction,< 1K
+Itemtype,https://schema.org/TradeAction,1K - 10K
+Itemtype,https://schema.org/TrainReservation,< 1K
+Itemtype,https://schema.org/TrainStation,1K - 10K
+Itemtype,https://schema.org/TrainTrip,< 1K
+Itemtype,https://schema.org/TransferAction,< 1K
+Itemtype,https://schema.org/TravelAction,1K - 10K
+Itemtype,https://schema.org/TravelAgency,10K - 100K
+Itemtype,https://schema.org/TreatmentIndication,< 1K
+Itemtype,https://schema.org/Trip,10K - 100K
+Itemtype,https://schema.org/TypeAndQuantityNode,< 1K
+Itemtype,https://schema.org/UKNonprofitType,< 1K
+Itemtype,https://schema.org/URL,1K - 10K
+Itemtype,https://schema.org/USNonprofitType,< 1K
+Itemtype,https://schema.org/UnRegisterAction,< 1K
+Itemtype,https://schema.org/UnitPriceSpecification,1M - 10M
+Itemtype,https://schema.org/UpdateAction,< 1K
+Itemtype,https://schema.org/UseAction,1K - 10K
+Itemtype,https://schema.org/UserBlocks,< 1K
+Itemtype,https://schema.org/UserCheckins,1K - 10K
+Itemtype,https://schema.org/UserComments,10K - 100K
+Itemtype,https://schema.org/UserDownloads,< 1K
+Itemtype,https://schema.org/UserInteraction,< 1K
+Itemtype,https://schema.org/UserLikes,< 1K
+Itemtype,https://schema.org/UserPageVisits,< 1K
+Itemtype,https://schema.org/UserPlays,< 1K
+Itemtype,https://schema.org/UserPlusOnes,< 1K
+Itemtype,https://schema.org/UserReview,1K - 10K
+Itemtype,https://schema.org/UserTweets,< 1K
+Itemtype,https://schema.org/VacationRental,10K - 100K
+Itemtype,https://schema.org/Vehicle,10K - 100K
+Itemtype,https://schema.org/Vein,< 1K
+Itemtype,https://schema.org/Vessel,< 1K
+Itemtype,https://schema.org/VeterinaryCare,1K - 10K
+Itemtype,https://schema.org/VideoGallery,1K - 10K
+Itemtype,https://schema.org/VideoGame,10K - 100K
+Itemtype,https://schema.org/VideoGameClip,< 1K
+Itemtype,https://schema.org/VideoGameSeries,1K - 10K
+Itemtype,https://schema.org/VideoObject,1M - 10M
+Itemtype,https://schema.org/VideoObjectSnapshot,< 1K
+Itemtype,https://schema.org/ViewAction,10K - 100K
+Itemtype,https://schema.org/VirtualLocation,10K - 100K
+Itemtype,https://schema.org/VisualArtsEvent,< 1K
+Itemtype,https://schema.org/VisualArtwork,1K - 10K
+Itemtype,https://schema.org/VitalSign,< 1K
+Itemtype,https://schema.org/Volcano,< 1K
+Itemtype,https://schema.org/VoteAction,< 1K
+Itemtype,https://schema.org/WPAdBlock,10K - 100K
+Itemtype,https://schema.org/WPFooter,1M - 10M
+Itemtype,https://schema.org/WPHeader,1M - 10M
+Itemtype,https://schema.org/WPSideBar,1M - 10M
+Itemtype,https://schema.org/WantAction,< 1K
+Itemtype,https://schema.org/WarrantyPromise,10K - 100K
+Itemtype,https://schema.org/WarrantyScope,< 1K
+Itemtype,https://schema.org/WatchAction,100K - 1M
+Itemtype,https://schema.org/Waterfall,< 1K
+Itemtype,https://schema.org/WearAction,< 1K
+Itemtype,https://schema.org/WearableMeasurementTypeEnumeration,< 1K
+Itemtype,https://schema.org/WearableSizeGroupEnumeration,< 1K
+Itemtype,https://schema.org/WearableSizeSystemEnumeration,< 1K
+Itemtype,https://schema.org/WebAPI,1K - 10K
+Itemtype,https://schema.org/WebApplication,100K - 1M
+Itemtype,https://schema.org/WebContent,1K - 10K
+Itemtype,https://schema.org/WebPage,10M+
+Itemtype,https://schema.org/WebPageElement,1M - 10M
+Itemtype,https://schema.org/WebSite,10M+
+Itemtype,https://schema.org/WholesaleStore,1K - 10K
+Itemtype,https://schema.org/WinAction,< 1K
+Itemtype,https://schema.org/Winery,1K - 10K
+Itemtype,https://schema.org/WorkBasedProgram,< 1K
+Itemtype,https://schema.org/WorkersUnion,< 1K
+Itemtype,https://schema.org/WriteAction,10K - 100K
+Itemtype,https://schema.org/XPathType,< 1K
+Itemtype,https://schema.org/Zoo,< 1K
+Predicate,https://schema.org/about,10M+
+Predicate,https://schema.org/about-input,< 1K
+Predicate,https://schema.org/about-output,< 1K
+Predicate,https://schema.org/abridged,< 1K
+Predicate,https://schema.org/abridged-input,< 1K
+Predicate,https://schema.org/abridged-output,< 1K
+Predicate,https://schema.org/abstract,10K - 100K
+Predicate,https://schema.org/abstract-input,< 1K
+Predicate,https://schema.org/abstract-output,< 1K
+Predicate,https://schema.org/accelerationTime,1K - 10K
+Predicate,https://schema.org/accelerationTime-input,< 1K
+Predicate,https://schema.org/accelerationTime-output,< 1K
+Predicate,https://schema.org/acceptedAnswer,1M - 10M
+Predicate,https://schema.org/acceptedAnswer-input,< 1K
+Predicate,https://schema.org/acceptedAnswer-output,< 1K
+Predicate,https://schema.org/acceptedOffer,< 1K
+Predicate,https://schema.org/acceptedOffer-input,< 1K
+Predicate,https://schema.org/acceptedOffer-output,< 1K
+Predicate,https://schema.org/acceptedPaymentMethod,10K - 100K
+Predicate,https://schema.org/acceptedPaymentMethod-input,< 1K
+Predicate,https://schema.org/acceptedPaymentMethod-output,< 1K
+Predicate,https://schema.org/acceptsReservations,100K - 1M
+Predicate,https://schema.org/acceptsReservations-input,< 1K
+Predicate,https://schema.org/acceptsReservations-output,< 1K
+Predicate,https://schema.org/accessCode,< 1K
+Predicate,https://schema.org/accessCode-input,< 1K
+Predicate,https://schema.org/accessCode-output,< 1K
+Predicate,https://schema.org/accessMode,1K - 10K
+Predicate,https://schema.org/accessMode-input,< 1K
+Predicate,https://schema.org/accessMode-output,< 1K
+Predicate,https://schema.org/accessModeSufficient,1K - 10K
+Predicate,https://schema.org/accessModeSufficient-input,< 1K
+Predicate,https://schema.org/accessModeSufficient-output,< 1K
+Predicate,https://schema.org/accessibilityAPI,1K - 10K
+Predicate,https://schema.org/accessibilityAPI-input,< 1K
+Predicate,https://schema.org/accessibilityAPI-output,< 1K
+Predicate,https://schema.org/accessibilityControl,1K - 10K
+Predicate,https://schema.org/accessibilityControl-input,< 1K
+Predicate,https://schema.org/accessibilityControl-output,< 1K
+Predicate,https://schema.org/accessibilityFeature,10K - 100K
+Predicate,https://schema.org/accessibilityFeature-input,< 1K
+Predicate,https://schema.org/accessibilityFeature-output,< 1K
+Predicate,https://schema.org/accessibilityHazard,1K - 10K
+Predicate,https://schema.org/accessibilityHazard-input,< 1K
+Predicate,https://schema.org/accessibilityHazard-output,< 1K
+Predicate,https://schema.org/accessibilitySummary,10K - 100K
+Predicate,https://schema.org/accessibilitySummary-input,< 1K
+Predicate,https://schema.org/accessibilitySummary-output,< 1K
+Predicate,https://schema.org/accommodationCategory,1K - 10K
+Predicate,https://schema.org/accommodationCategory-input,< 1K
+Predicate,https://schema.org/accommodationCategory-output,< 1K
+Predicate,https://schema.org/accommodationFloorPlan,10K - 100K
+Predicate,https://schema.org/accommodationFloorPlan-input,< 1K
+Predicate,https://schema.org/accommodationFloorPlan-output,< 1K
+Predicate,https://schema.org/accountId,< 1K
+Predicate,https://schema.org/accountId-input,< 1K
+Predicate,https://schema.org/accountId-output,< 1K
+Predicate,https://schema.org/accountMinimumInflow,< 1K
+Predicate,https://schema.org/accountMinimumInflow-input,< 1K
+Predicate,https://schema.org/accountMinimumInflow-output,< 1K
+Predicate,https://schema.org/accountOverdraftLimit,< 1K
+Predicate,https://schema.org/accountOverdraftLimit-input,< 1K
+Predicate,https://schema.org/accountOverdraftLimit-output,< 1K
+Predicate,https://schema.org/accountablePerson,10K - 100K
+Predicate,https://schema.org/accountablePerson-input,< 1K
+Predicate,https://schema.org/accountablePerson-output,< 1K
+Predicate,https://schema.org/acquireLicensePage,10K - 100K
+Predicate,https://schema.org/acquireLicensePage-input,< 1K
+Predicate,https://schema.org/acquireLicensePage-output,< 1K
+Predicate,https://schema.org/acquiredFrom,< 1K
+Predicate,https://schema.org/acquiredFrom-input,< 1K
+Predicate,https://schema.org/acquiredFrom-output,< 1K
+Predicate,https://schema.org/acrissCode,< 1K
+Predicate,https://schema.org/acrissCode-input,< 1K
+Predicate,https://schema.org/acrissCode-output,< 1K
+Predicate,https://schema.org/actionAccessibilityRequirement,< 1K
+Predicate,https://schema.org/actionAccessibilityRequirement-input,< 1K
+Predicate,https://schema.org/actionAccessibilityRequirement-output,< 1K
+Predicate,https://schema.org/actionApplication,1K - 10K
+Predicate,https://schema.org/actionApplication-input,< 1K
+Predicate,https://schema.org/actionApplication-output,< 1K
+Predicate,https://schema.org/actionOption,1K - 10K
+Predicate,https://schema.org/actionOption-input,< 1K
+Predicate,https://schema.org/actionOption-output,< 1K
+Predicate,https://schema.org/actionPlatform,100K - 1M
+Predicate,https://schema.org/actionPlatform-input,< 1K
+Predicate,https://schema.org/actionPlatform-output,< 1K
+Predicate,https://schema.org/actionProcess,< 1K
+Predicate,https://schema.org/actionProcess-input,< 1K
+Predicate,https://schema.org/actionProcess-output,< 1K
+Predicate,https://schema.org/actionStatus,10K - 100K
+Predicate,https://schema.org/actionStatus-input,< 1K
+Predicate,https://schema.org/actionStatus-output,< 1K
+Predicate,https://schema.org/actionableFeedbackPolicy,10K - 100K
+Predicate,https://schema.org/actionableFeedbackPolicy-input,< 1K
+Predicate,https://schema.org/actionableFeedbackPolicy-output,< 1K
+Predicate,https://schema.org/activeIngredient,1K - 10K
+Predicate,https://schema.org/activeIngredient-input,< 1K
+Predicate,https://schema.org/activeIngredient-output,< 1K
+Predicate,https://schema.org/activityDuration,< 1K
+Predicate,https://schema.org/activityDuration-input,< 1K
+Predicate,https://schema.org/activityDuration-output,< 1K
+Predicate,https://schema.org/activityFrequency,< 1K
+Predicate,https://schema.org/activityFrequency-input,< 1K
+Predicate,https://schema.org/activityFrequency-output,< 1K
+Predicate,https://schema.org/actor,10K - 100K
+Predicate,https://schema.org/actor-input,< 1K
+Predicate,https://schema.org/actor-output,< 1K
+Predicate,https://schema.org/actors,1K - 10K
+Predicate,https://schema.org/actors-input,< 1K
+Predicate,https://schema.org/actors-output,< 1K
+Predicate,https://schema.org/addOn,1K - 10K
+Predicate,https://schema.org/addOn-input,< 1K
+Predicate,https://schema.org/addOn-output,< 1K
+Predicate,https://schema.org/additionalName,10K - 100K
+Predicate,https://schema.org/additionalName-input,< 1K
+Predicate,https://schema.org/additionalName-output,< 1K
+Predicate,https://schema.org/additionalNumberOfGuests,< 1K
+Predicate,https://schema.org/additionalNumberOfGuests-input,< 1K
+Predicate,https://schema.org/additionalNumberOfGuests-output,< 1K
+Predicate,https://schema.org/additionalProperty,100K - 1M
+Predicate,https://schema.org/additionalProperty-input,< 1K
+Predicate,https://schema.org/additionalProperty-output,< 1K
+Predicate,https://schema.org/additionalType,100K - 1M
+Predicate,https://schema.org/additionalType-input,< 1K
+Predicate,https://schema.org/additionalType-output,< 1K
+Predicate,https://schema.org/additionalVariable,< 1K
+Predicate,https://schema.org/additionalVariable-input,< 1K
+Predicate,https://schema.org/additionalVariable-output,< 1K
+Predicate,https://schema.org/address,10M+
+Predicate,https://schema.org/address-input,< 1K
+Predicate,https://schema.org/address-output,< 1K
+Predicate,https://schema.org/addressCountry,1M - 10M
+Predicate,https://schema.org/addressCountry-input,< 1K
+Predicate,https://schema.org/addressCountry-output,< 1K
+Predicate,https://schema.org/addressLocality,1M - 10M
+Predicate,https://schema.org/addressLocality-input,< 1K
+Predicate,https://schema.org/addressLocality-output,< 1K
+Predicate,https://schema.org/addressRegion,1M - 10M
+Predicate,https://schema.org/addressRegion-input,< 1K
+Predicate,https://schema.org/addressRegion-output,< 1K
+Predicate,https://schema.org/administrationRoute,1K - 10K
+Predicate,https://schema.org/administrationRoute-input,< 1K
+Predicate,https://schema.org/administrationRoute-output,< 1K
+Predicate,https://schema.org/advanceBookingRequirement,< 1K
+Predicate,https://schema.org/advanceBookingRequirement-input,< 1K
+Predicate,https://schema.org/advanceBookingRequirement-output,< 1K
+Predicate,https://schema.org/adverseOutcome,< 1K
+Predicate,https://schema.org/adverseOutcome-input,< 1K
+Predicate,https://schema.org/adverseOutcome-output,< 1K
+Predicate,https://schema.org/affectedBy,< 1K
+Predicate,https://schema.org/affectedBy-input,< 1K
+Predicate,https://schema.org/affectedBy-output,< 1K
+Predicate,https://schema.org/affiliation,10K - 100K
+Predicate,https://schema.org/affiliation-input,< 1K
+Predicate,https://schema.org/affiliation-output,< 1K
+Predicate,https://schema.org/afterMedia,< 1K
+Predicate,https://schema.org/afterMedia-input,< 1K
+Predicate,https://schema.org/afterMedia-output,< 1K
+Predicate,https://schema.org/agent,10K - 100K
+Predicate,https://schema.org/agent-input,< 1K
+Predicate,https://schema.org/agent-output,< 1K
+Predicate,https://schema.org/agentInteractionStatistic,10K - 100K
+Predicate,https://schema.org/agentInteractionStatistic-input,< 1K
+Predicate,https://schema.org/agentInteractionStatistic-output,< 1K
+Predicate,https://schema.org/aggregateElement,< 1K
+Predicate,https://schema.org/aggregateElement-input,< 1K
+Predicate,https://schema.org/aggregateElement-output,< 1K
+Predicate,https://schema.org/aggregateRating,1M - 10M
+Predicate,https://schema.org/aggregateRating-input,< 1K
+Predicate,https://schema.org/aggregateRating-output,< 1K
+Predicate,https://schema.org/aircraft,< 1K
+Predicate,https://schema.org/aircraft-input,< 1K
+Predicate,https://schema.org/aircraft-output,< 1K
+Predicate,https://schema.org/album,1K - 10K
+Predicate,https://schema.org/album-input,< 1K
+Predicate,https://schema.org/album-output,< 1K
+Predicate,https://schema.org/albumProductionType,1K - 10K
+Predicate,https://schema.org/albumProductionType-input,< 1K
+Predicate,https://schema.org/albumProductionType-output,< 1K
+Predicate,https://schema.org/albumRelease,1K - 10K
+Predicate,https://schema.org/albumRelease-input,< 1K
+Predicate,https://schema.org/albumRelease-output,< 1K
+Predicate,https://schema.org/albumReleaseType,1K - 10K
+Predicate,https://schema.org/albumReleaseType-input,< 1K
+Predicate,https://schema.org/albumReleaseType-output,< 1K
+Predicate,https://schema.org/albums,< 1K
+Predicate,https://schema.org/albums-input,< 1K
+Predicate,https://schema.org/albums-output,< 1K
+Predicate,https://schema.org/alcoholWarning,< 1K
+Predicate,https://schema.org/alcoholWarning-input,< 1K
+Predicate,https://schema.org/alcoholWarning-output,< 1K
+Predicate,https://schema.org/algorithm,< 1K
+Predicate,https://schema.org/algorithm-input,< 1K
+Predicate,https://schema.org/algorithm-output,< 1K
+Predicate,https://schema.org/alignmentType,1K - 10K
+Predicate,https://schema.org/alignmentType-input,< 1K
+Predicate,https://schema.org/alignmentType-output,< 1K
+Predicate,https://schema.org/alternateName,1M - 10M
+Predicate,https://schema.org/alternateName-input,< 1K
+Predicate,https://schema.org/alternateName-output,< 1K
+Predicate,https://schema.org/alternativeHeadline,100K - 1M
+Predicate,https://schema.org/alternativeHeadline-input,< 1K
+Predicate,https://schema.org/alternativeHeadline-output,< 1K
+Predicate,https://schema.org/alternativeOf,< 1K
+Predicate,https://schema.org/alternativeOf-input,< 1K
+Predicate,https://schema.org/alternativeOf-output,< 1K
+Predicate,https://schema.org/alumni,1K - 10K
+Predicate,https://schema.org/alumni-input,< 1K
+Predicate,https://schema.org/alumni-output,< 1K
+Predicate,https://schema.org/alumniOf,100K - 1M
+Predicate,https://schema.org/alumniOf-input,< 1K
+Predicate,https://schema.org/alumniOf-output,< 1K
+Predicate,https://schema.org/amenityFeature,100K - 1M
+Predicate,https://schema.org/amenityFeature-input,< 1K
+Predicate,https://schema.org/amenityFeature-output,< 1K
+Predicate,https://schema.org/amount,1K - 10K
+Predicate,https://schema.org/amount-input,< 1K
+Predicate,https://schema.org/amount-output,< 1K
+Predicate,https://schema.org/amountOfThisGood,< 1K
+Predicate,https://schema.org/amountOfThisGood-input,< 1K
+Predicate,https://schema.org/amountOfThisGood-output,< 1K
+Predicate,https://schema.org/announcementLocation,1K - 10K
+Predicate,https://schema.org/announcementLocation-input,< 1K
+Predicate,https://schema.org/announcementLocation-output,< 1K
+Predicate,https://schema.org/annualPercentageRate,1K - 10K
+Predicate,https://schema.org/annualPercentageRate-input,< 1K
+Predicate,https://schema.org/annualPercentageRate-output,< 1K
+Predicate,https://schema.org/answerCount,100K - 1M
+Predicate,https://schema.org/answerCount-input,< 1K
+Predicate,https://schema.org/answerCount-output,< 1K
+Predicate,https://schema.org/answerExplanation,< 1K
+Predicate,https://schema.org/answerExplanation-input,< 1K
+Predicate,https://schema.org/answerExplanation-output,< 1K
+Predicate,https://schema.org/antagonist,< 1K
+Predicate,https://schema.org/antagonist-input,< 1K
+Predicate,https://schema.org/antagonist-output,< 1K
+Predicate,https://schema.org/appearance,1K - 10K
+Predicate,https://schema.org/appearance-input,< 1K
+Predicate,https://schema.org/appearance-output,< 1K
+Predicate,https://schema.org/applicableCountry,100K - 1M
+Predicate,https://schema.org/applicableCountry-input,< 1K
+Predicate,https://schema.org/applicableCountry-output,< 1K
+Predicate,https://schema.org/applicableLocation,< 1K
+Predicate,https://schema.org/applicableLocation-input,< 1K
+Predicate,https://schema.org/applicableLocation-output,< 1K
+Predicate,https://schema.org/applicantLocationRequirements,10K - 100K
+Predicate,https://schema.org/applicantLocationRequirements-input,< 1K
+Predicate,https://schema.org/applicantLocationRequirements-output,< 1K
+Predicate,https://schema.org/application,< 1K
+Predicate,https://schema.org/application-input,< 1K
+Predicate,https://schema.org/application-output,< 1K
+Predicate,https://schema.org/applicationCategory,1M - 10M
+Predicate,https://schema.org/applicationCategory-input,< 1K
+Predicate,https://schema.org/applicationCategory-output,< 1K
+Predicate,https://schema.org/applicationContact,1K - 10K
+Predicate,https://schema.org/applicationContact-input,< 1K
+Predicate,https://schema.org/applicationContact-output,< 1K
+Predicate,https://schema.org/applicationDeadline,< 1K
+Predicate,https://schema.org/applicationDeadline-input,< 1K
+Predicate,https://schema.org/applicationDeadline-output,< 1K
+Predicate,https://schema.org/applicationStartDate,< 1K
+Predicate,https://schema.org/applicationStartDate-input,< 1K
+Predicate,https://schema.org/applicationStartDate-output,< 1K
+Predicate,https://schema.org/applicationSubCategory,10K - 100K
+Predicate,https://schema.org/applicationSubCategory-input,< 1K
+Predicate,https://schema.org/applicationSubCategory-output,< 1K
+Predicate,https://schema.org/applicationSuite,1K - 10K
+Predicate,https://schema.org/applicationSuite-input,< 1K
+Predicate,https://schema.org/applicationSuite-output,< 1K
+Predicate,https://schema.org/appliesToDeliveryMethod,10K - 100K
+Predicate,https://schema.org/appliesToDeliveryMethod-input,< 1K
+Predicate,https://schema.org/appliesToDeliveryMethod-output,< 1K
+Predicate,https://schema.org/appliesToPaymentMethod,< 1K
+Predicate,https://schema.org/appliesToPaymentMethod-input,< 1K
+Predicate,https://schema.org/appliesToPaymentMethod-output,< 1K
+Predicate,https://schema.org/archiveHeld,< 1K
+Predicate,https://schema.org/archiveHeld-input,< 1K
+Predicate,https://schema.org/archiveHeld-output,< 1K
+Predicate,https://schema.org/archivedAt,< 1K
+Predicate,https://schema.org/archivedAt-input,< 1K
+Predicate,https://schema.org/archivedAt-output,< 1K
+Predicate,https://schema.org/area,1K - 10K
+Predicate,https://schema.org/area-input,< 1K
+Predicate,https://schema.org/area-output,< 1K
+Predicate,https://schema.org/areaServed,1M - 10M
+Predicate,https://schema.org/areaServed-input,< 1K
+Predicate,https://schema.org/areaServed-output,< 1K
+Predicate,https://schema.org/arrivalAirport,1K - 10K
+Predicate,https://schema.org/arrivalAirport-input,< 1K
+Predicate,https://schema.org/arrivalAirport-output,< 1K
+Predicate,https://schema.org/arrivalBoatTerminal,< 1K
+Predicate,https://schema.org/arrivalBoatTerminal-input,< 1K
+Predicate,https://schema.org/arrivalBoatTerminal-output,< 1K
+Predicate,https://schema.org/arrivalBusStop,< 1K
+Predicate,https://schema.org/arrivalBusStop-input,< 1K
+Predicate,https://schema.org/arrivalBusStop-output,< 1K
+Predicate,https://schema.org/arrivalGate,< 1K
+Predicate,https://schema.org/arrivalGate-input,< 1K
+Predicate,https://schema.org/arrivalGate-output,< 1K
+Predicate,https://schema.org/arrivalPlatform,< 1K
+Predicate,https://schema.org/arrivalPlatform-input,< 1K
+Predicate,https://schema.org/arrivalPlatform-output,< 1K
+Predicate,https://schema.org/arrivalStation,< 1K
+Predicate,https://schema.org/arrivalStation-input,< 1K
+Predicate,https://schema.org/arrivalStation-output,< 1K
+Predicate,https://schema.org/arrivalTerminal,< 1K
+Predicate,https://schema.org/arrivalTerminal-input,< 1K
+Predicate,https://schema.org/arrivalTerminal-output,< 1K
+Predicate,https://schema.org/arrivalTime,1K - 10K
+Predicate,https://schema.org/arrivalTime-input,< 1K
+Predicate,https://schema.org/arrivalTime-output,< 1K
+Predicate,https://schema.org/artEdition,< 1K
+Predicate,https://schema.org/artEdition-input,< 1K
+Predicate,https://schema.org/artEdition-output,< 1K
+Predicate,https://schema.org/artMedium,1K - 10K
+Predicate,https://schema.org/artMedium-input,< 1K
+Predicate,https://schema.org/artMedium-output,< 1K
+Predicate,https://schema.org/arterialBranch,< 1K
+Predicate,https://schema.org/arterialBranch-input,< 1K
+Predicate,https://schema.org/arterialBranch-output,< 1K
+Predicate,https://schema.org/artform,1K - 10K
+Predicate,https://schema.org/artform-input,< 1K
+Predicate,https://schema.org/artform-output,< 1K
+Predicate,https://schema.org/articleBody,1M - 10M
+Predicate,https://schema.org/articleBody-input,< 1K
+Predicate,https://schema.org/articleBody-output,< 1K
+Predicate,https://schema.org/articleSection,1M - 10M
+Predicate,https://schema.org/articleSection-input,< 1K
+Predicate,https://schema.org/articleSection-output,< 1K
+Predicate,https://schema.org/artist,1K - 10K
+Predicate,https://schema.org/artist-input,< 1K
+Predicate,https://schema.org/artist-output,< 1K
+Predicate,https://schema.org/artworkSurface,< 1K
+Predicate,https://schema.org/artworkSurface-input,< 1K
+Predicate,https://schema.org/artworkSurface-output,< 1K
+Predicate,https://schema.org/asin,< 1K
+Predicate,https://schema.org/asin-input,< 1K
+Predicate,https://schema.org/asin-output,< 1K
+Predicate,https://schema.org/aspect,< 1K
+Predicate,https://schema.org/aspect-input,< 1K
+Predicate,https://schema.org/aspect-output,< 1K
+Predicate,https://schema.org/assembly,< 1K
+Predicate,https://schema.org/assembly-input,< 1K
+Predicate,https://schema.org/assembly-output,< 1K
+Predicate,https://schema.org/assemblyVersion,< 1K
+Predicate,https://schema.org/assemblyVersion-input,< 1K
+Predicate,https://schema.org/assemblyVersion-output,< 1K
+Predicate,https://schema.org/assesses,1K - 10K
+Predicate,https://schema.org/assesses-input,< 1K
+Predicate,https://schema.org/assesses-output,< 1K
+Predicate,https://schema.org/associatedAnatomy,1K - 10K
+Predicate,https://schema.org/associatedAnatomy-input,< 1K
+Predicate,https://schema.org/associatedAnatomy-output,< 1K
+Predicate,https://schema.org/associatedArticle,1K - 10K
+Predicate,https://schema.org/associatedArticle-input,< 1K
+Predicate,https://schema.org/associatedArticle-output,< 1K
+Predicate,https://schema.org/associatedClaimReview,< 1K
+Predicate,https://schema.org/associatedClaimReview-input,< 1K
+Predicate,https://schema.org/associatedClaimReview-output,< 1K
+Predicate,https://schema.org/associatedDisease,< 1K
+Predicate,https://schema.org/associatedDisease-input,< 1K
+Predicate,https://schema.org/associatedDisease-output,< 1K
+Predicate,https://schema.org/associatedMedia,100K - 1M
+Predicate,https://schema.org/associatedMedia-input,< 1K
+Predicate,https://schema.org/associatedMedia-output,< 1K
+Predicate,https://schema.org/associatedMediaReview,< 1K
+Predicate,https://schema.org/associatedMediaReview-input,< 1K
+Predicate,https://schema.org/associatedMediaReview-output,< 1K
+Predicate,https://schema.org/associatedPathophysiology,< 1K
+Predicate,https://schema.org/associatedPathophysiology-input,< 1K
+Predicate,https://schema.org/associatedPathophysiology-output,< 1K
+Predicate,https://schema.org/associatedReview,< 1K
+Predicate,https://schema.org/associatedReview-input,< 1K
+Predicate,https://schema.org/associatedReview-output,< 1K
+Predicate,https://schema.org/athlete,< 1K
+Predicate,https://schema.org/athlete-input,< 1K
+Predicate,https://schema.org/athlete-output,< 1K
+Predicate,https://schema.org/attendee,1K - 10K
+Predicate,https://schema.org/attendee-input,< 1K
+Predicate,https://schema.org/attendee-output,< 1K
+Predicate,https://schema.org/attendees,< 1K
+Predicate,https://schema.org/attendees-input,< 1K
+Predicate,https://schema.org/attendees-output,< 1K
+Predicate,https://schema.org/audience,100K - 1M
+Predicate,https://schema.org/audience-input,< 1K
+Predicate,https://schema.org/audience-output,< 1K
+Predicate,https://schema.org/audienceType,100K - 1M
+Predicate,https://schema.org/audienceType-input,< 1K
+Predicate,https://schema.org/audienceType-output,< 1K
+Predicate,https://schema.org/audio,10K - 100K
+Predicate,https://schema.org/audio-input,< 1K
+Predicate,https://schema.org/audio-output,< 1K
+Predicate,https://schema.org/auditDate,< 1K
+Predicate,https://schema.org/auditDate-input,< 1K
+Predicate,https://schema.org/auditDate-output,< 1K
+Predicate,https://schema.org/authenticator,< 1K
+Predicate,https://schema.org/authenticator-input,< 1K
+Predicate,https://schema.org/authenticator-output,< 1K
+Predicate,https://schema.org/author,10M+
+Predicate,https://schema.org/author-input,< 1K
+Predicate,https://schema.org/author-output,< 1K
+Predicate,https://schema.org/availability,10M+
+Predicate,https://schema.org/availability-input,< 1K
+Predicate,https://schema.org/availability-output,< 1K
+Predicate,https://schema.org/availabilityEnds,1K - 10K
+Predicate,https://schema.org/availabilityEnds-input,< 1K
+Predicate,https://schema.org/availabilityEnds-output,< 1K
+Predicate,https://schema.org/availabilityStarts,10K - 100K
+Predicate,https://schema.org/availabilityStarts-input,< 1K
+Predicate,https://schema.org/availabilityStarts-output,< 1K
+Predicate,https://schema.org/availableAtOrFrom,10K - 100K
+Predicate,https://schema.org/availableAtOrFrom-input,< 1K
+Predicate,https://schema.org/availableAtOrFrom-output,< 1K
+Predicate,https://schema.org/availableChannel,100K - 1M
+Predicate,https://schema.org/availableChannel-input,< 1K
+Predicate,https://schema.org/availableChannel-output,< 1K
+Predicate,https://schema.org/availableDeliveryMethod,10K - 100K
+Predicate,https://schema.org/availableDeliveryMethod-input,< 1K
+Predicate,https://schema.org/availableDeliveryMethod-output,< 1K
+Predicate,https://schema.org/availableFrom,< 1K
+Predicate,https://schema.org/availableFrom-input,< 1K
+Predicate,https://schema.org/availableFrom-output,< 1K
+Predicate,https://schema.org/availableIn,< 1K
+Predicate,https://schema.org/availableIn-input,< 1K
+Predicate,https://schema.org/availableIn-output,< 1K
+Predicate,https://schema.org/availableLanguage,1M - 10M
+Predicate,https://schema.org/availableLanguage-input,< 1K
+Predicate,https://schema.org/availableLanguage-output,< 1K
+Predicate,https://schema.org/availableOnDevice,1K - 10K
+Predicate,https://schema.org/availableOnDevice-input,< 1K
+Predicate,https://schema.org/availableOnDevice-output,< 1K
+Predicate,https://schema.org/availableService,10K - 100K
+Predicate,https://schema.org/availableService-input,< 1K
+Predicate,https://schema.org/availableService-output,< 1K
+Predicate,https://schema.org/availableStrength,< 1K
+Predicate,https://schema.org/availableStrength-input,< 1K
+Predicate,https://schema.org/availableStrength-output,< 1K
+Predicate,https://schema.org/availableTest,< 1K
+Predicate,https://schema.org/availableTest-input,< 1K
+Predicate,https://schema.org/availableTest-output,< 1K
+Predicate,https://schema.org/availableThrough,< 1K
+Predicate,https://schema.org/availableThrough-input,< 1K
+Predicate,https://schema.org/availableThrough-output,< 1K
+Predicate,https://schema.org/award,10K - 100K
+Predicate,https://schema.org/award-input,< 1K
+Predicate,https://schema.org/award-output,< 1K
+Predicate,https://schema.org/awards,1K - 10K
+Predicate,https://schema.org/awards-input,< 1K
+Predicate,https://schema.org/awards-output,< 1K
+Predicate,https://schema.org/awayTeam,10K - 100K
+Predicate,https://schema.org/awayTeam-input,< 1K
+Predicate,https://schema.org/awayTeam-output,< 1K
+Predicate,https://schema.org/backstory,1K - 10K
+Predicate,https://schema.org/backstory-input,< 1K
+Predicate,https://schema.org/backstory-output,< 1K
+Predicate,https://schema.org/bankAccountType,< 1K
+Predicate,https://schema.org/bankAccountType-input,< 1K
+Predicate,https://schema.org/bankAccountType-output,< 1K
+Predicate,https://schema.org/baseSalary,10K - 100K
+Predicate,https://schema.org/baseSalary-input,< 1K
+Predicate,https://schema.org/baseSalary-output,< 1K
+Predicate,https://schema.org/bccRecipient,< 1K
+Predicate,https://schema.org/bccRecipient-input,< 1K
+Predicate,https://schema.org/bccRecipient-output,< 1K
+Predicate,https://schema.org/bed,10K - 100K
+Predicate,https://schema.org/bed-input,< 1K
+Predicate,https://schema.org/bed-output,< 1K
+Predicate,https://schema.org/beforeMedia,< 1K
+Predicate,https://schema.org/beforeMedia-input,< 1K
+Predicate,https://schema.org/beforeMedia-output,< 1K
+Predicate,https://schema.org/beneficiaryBank,< 1K
+Predicate,https://schema.org/beneficiaryBank-input,< 1K
+Predicate,https://schema.org/beneficiaryBank-output,< 1K
+Predicate,https://schema.org/benefits,1K - 10K
+Predicate,https://schema.org/benefits-input,< 1K
+Predicate,https://schema.org/benefits-output,< 1K
+Predicate,https://schema.org/benefitsSummaryUrl,< 1K
+Predicate,https://schema.org/benefitsSummaryUrl-input,< 1K
+Predicate,https://schema.org/benefitsSummaryUrl-output,< 1K
+Predicate,https://schema.org/bestRating,1M - 10M
+Predicate,https://schema.org/bestRating-input,< 1K
+Predicate,https://schema.org/bestRating-output,< 1K
+Predicate,https://schema.org/billingAddress,< 1K
+Predicate,https://schema.org/billingAddress-input,< 1K
+Predicate,https://schema.org/billingAddress-output,< 1K
+Predicate,https://schema.org/billingDuration,10K - 100K
+Predicate,https://schema.org/billingDuration-input,< 1K
+Predicate,https://schema.org/billingDuration-output,< 1K
+Predicate,https://schema.org/billingIncrement,10K - 100K
+Predicate,https://schema.org/billingIncrement-input,< 1K
+Predicate,https://schema.org/billingIncrement-output,< 1K
+Predicate,https://schema.org/billingPeriod,1K - 10K
+Predicate,https://schema.org/billingPeriod-input,< 1K
+Predicate,https://schema.org/billingPeriod-output,< 1K
+Predicate,https://schema.org/billingStart,< 1K
+Predicate,https://schema.org/billingStart-input,< 1K
+Predicate,https://schema.org/billingStart-output,< 1K
+Predicate,https://schema.org/bioChemInteraction,< 1K
+Predicate,https://schema.org/bioChemInteraction-input,< 1K
+Predicate,https://schema.org/bioChemInteraction-output,< 1K
+Predicate,https://schema.org/bioChemSimilarity,< 1K
+Predicate,https://schema.org/bioChemSimilarity-input,< 1K
+Predicate,https://schema.org/bioChemSimilarity-output,< 1K
+Predicate,https://schema.org/biologicalRole,< 1K
+Predicate,https://schema.org/biologicalRole-input,< 1K
+Predicate,https://schema.org/biologicalRole-output,< 1K
+Predicate,https://schema.org/biomechnicalClass,< 1K
+Predicate,https://schema.org/biomechnicalClass-input,< 1K
+Predicate,https://schema.org/biomechnicalClass-output,< 1K
+Predicate,https://schema.org/birthDate,10K - 100K
+Predicate,https://schema.org/birthDate-input,< 1K
+Predicate,https://schema.org/birthDate-output,< 1K
+Predicate,https://schema.org/birthPlace,10K - 100K
+Predicate,https://schema.org/birthPlace-input,< 1K
+Predicate,https://schema.org/birthPlace-output,< 1K
+Predicate,https://schema.org/bitrate,1K - 10K
+Predicate,https://schema.org/bitrate-input,< 1K
+Predicate,https://schema.org/bitrate-output,< 1K
+Predicate,https://schema.org/blogPost,100K - 1M
+Predicate,https://schema.org/blogPost-input,< 1K
+Predicate,https://schema.org/blogPost-output,< 1K
+Predicate,https://schema.org/blogPosts,10K - 100K
+Predicate,https://schema.org/blogPosts-input,< 1K
+Predicate,https://schema.org/blogPosts-output,< 1K
+Predicate,https://schema.org/bloodSupply,< 1K
+Predicate,https://schema.org/bloodSupply-input,< 1K
+Predicate,https://schema.org/bloodSupply-output,< 1K
+Predicate,https://schema.org/boardingGroup,< 1K
+Predicate,https://schema.org/boardingGroup-input,< 1K
+Predicate,https://schema.org/boardingGroup-output,< 1K
+Predicate,https://schema.org/boardingPolicy,< 1K
+Predicate,https://schema.org/boardingPolicy-input,< 1K
+Predicate,https://schema.org/boardingPolicy-output,< 1K
+Predicate,https://schema.org/bodyLocation,10K - 100K
+Predicate,https://schema.org/bodyLocation-input,< 1K
+Predicate,https://schema.org/bodyLocation-output,< 1K
+Predicate,https://schema.org/bodyType,10K - 100K
+Predicate,https://schema.org/bodyType-input,< 1K
+Predicate,https://schema.org/bodyType-output,< 1K
+Predicate,https://schema.org/bookEdition,1K - 10K
+Predicate,https://schema.org/bookEdition-input,< 1K
+Predicate,https://schema.org/bookEdition-output,< 1K
+Predicate,https://schema.org/bookFormat,10K - 100K
+Predicate,https://schema.org/bookFormat-input,< 1K
+Predicate,https://schema.org/bookFormat-output,< 1K
+Predicate,https://schema.org/bookingAgent,< 1K
+Predicate,https://schema.org/bookingAgent-input,< 1K
+Predicate,https://schema.org/bookingAgent-output,< 1K
+Predicate,https://schema.org/bookingTime,< 1K
+Predicate,https://schema.org/bookingTime-input,< 1K
+Predicate,https://schema.org/bookingTime-output,< 1K
+Predicate,https://schema.org/borrower,< 1K
+Predicate,https://schema.org/borrower-input,< 1K
+Predicate,https://schema.org/borrower-output,< 1K
+Predicate,https://schema.org/box,1K - 10K
+Predicate,https://schema.org/box-input,< 1K
+Predicate,https://schema.org/box-output,< 1K
+Predicate,https://schema.org/branch,< 1K
+Predicate,https://schema.org/branch-input,< 1K
+Predicate,https://schema.org/branch-output,< 1K
+Predicate,https://schema.org/branchCode,1K - 10K
+Predicate,https://schema.org/branchCode-input,< 1K
+Predicate,https://schema.org/branchCode-output,< 1K
+Predicate,https://schema.org/branchOf,10K - 100K
+Predicate,https://schema.org/branchOf-input,< 1K
+Predicate,https://schema.org/branchOf-output,< 1K
+Predicate,https://schema.org/brand,1M - 10M
+Predicate,https://schema.org/brand-input,< 1K
+Predicate,https://schema.org/brand-output,< 1K
+Predicate,https://schema.org/breadcrumb,10M+
+Predicate,https://schema.org/breadcrumb-input,< 1K
+Predicate,https://schema.org/breadcrumb-output,< 1K
+Predicate,https://schema.org/breastfeedingWarning,< 1K
+Predicate,https://schema.org/breastfeedingWarning-input,< 1K
+Predicate,https://schema.org/breastfeedingWarning-output,< 1K
+Predicate,https://schema.org/broadcastAffiliateOf,< 1K
+Predicate,https://schema.org/broadcastAffiliateOf-input,< 1K
+Predicate,https://schema.org/broadcastAffiliateOf-output,< 1K
+Predicate,https://schema.org/broadcastChannelId,< 1K
+Predicate,https://schema.org/broadcastChannelId-input,< 1K
+Predicate,https://schema.org/broadcastChannelId-output,< 1K
+Predicate,https://schema.org/broadcastDisplayName,1K - 10K
+Predicate,https://schema.org/broadcastDisplayName-input,< 1K
+Predicate,https://schema.org/broadcastDisplayName-output,< 1K
+Predicate,https://schema.org/broadcastFrequency,1K - 10K
+Predicate,https://schema.org/broadcastFrequency-input,< 1K
+Predicate,https://schema.org/broadcastFrequency-output,< 1K
+Predicate,https://schema.org/broadcastFrequencyValue,< 1K
+Predicate,https://schema.org/broadcastFrequencyValue-input,< 1K
+Predicate,https://schema.org/broadcastFrequencyValue-output,< 1K
+Predicate,https://schema.org/broadcastOfEvent,1K - 10K
+Predicate,https://schema.org/broadcastOfEvent-input,< 1K
+Predicate,https://schema.org/broadcastOfEvent-output,< 1K
+Predicate,https://schema.org/broadcastServiceTier,< 1K
+Predicate,https://schema.org/broadcastServiceTier-input,< 1K
+Predicate,https://schema.org/broadcastServiceTier-output,< 1K
+Predicate,https://schema.org/broadcastSignalModulation,< 1K
+Predicate,https://schema.org/broadcastSignalModulation-input,< 1K
+Predicate,https://schema.org/broadcastSignalModulation-output,< 1K
+Predicate,https://schema.org/broadcastSubChannel,< 1K
+Predicate,https://schema.org/broadcastSubChannel-input,< 1K
+Predicate,https://schema.org/broadcastSubChannel-output,< 1K
+Predicate,https://schema.org/broadcastTimezone,< 1K
+Predicate,https://schema.org/broadcastTimezone-input,< 1K
+Predicate,https://schema.org/broadcastTimezone-output,< 1K
+Predicate,https://schema.org/broadcaster,< 1K
+Predicate,https://schema.org/broadcaster-input,< 1K
+Predicate,https://schema.org/broadcaster-output,< 1K
+Predicate,https://schema.org/broker,1K - 10K
+Predicate,https://schema.org/broker-input,< 1K
+Predicate,https://schema.org/broker-output,< 1K
+Predicate,https://schema.org/browserRequirements,10K - 100K
+Predicate,https://schema.org/browserRequirements-input,< 1K
+Predicate,https://schema.org/browserRequirements-output,< 1K
+Predicate,https://schema.org/busName,< 1K
+Predicate,https://schema.org/busName-input,< 1K
+Predicate,https://schema.org/busName-output,< 1K
+Predicate,https://schema.org/busNumber,< 1K
+Predicate,https://schema.org/busNumber-input,< 1K
+Predicate,https://schema.org/busNumber-output,< 1K
+Predicate,https://schema.org/businessDays,10K - 100K
+Predicate,https://schema.org/businessDays-input,< 1K
+Predicate,https://schema.org/businessDays-output,< 1K
+Predicate,https://schema.org/businessFunction,1M - 10M
+Predicate,https://schema.org/businessFunction-input,< 1K
+Predicate,https://schema.org/businessFunction-output,< 1K
+Predicate,https://schema.org/buyer,< 1K
+Predicate,https://schema.org/buyer-input,< 1K
+Predicate,https://schema.org/buyer-output,< 1K
+Predicate,https://schema.org/byArtist,10K - 100K
+Predicate,https://schema.org/byArtist-input,< 1K
+Predicate,https://schema.org/byArtist-output,< 1K
+Predicate,https://schema.org/byDay,1K - 10K
+Predicate,https://schema.org/byDay-input,< 1K
+Predicate,https://schema.org/byDay-output,< 1K
+Predicate,https://schema.org/byMonth,< 1K
+Predicate,https://schema.org/byMonth-input,< 1K
+Predicate,https://schema.org/byMonth-output,< 1K
+Predicate,https://schema.org/byMonthDay,< 1K
+Predicate,https://schema.org/byMonthDay-input,< 1K
+Predicate,https://schema.org/byMonthDay-output,< 1K
+Predicate,https://schema.org/byMonthWeek,< 1K
+Predicate,https://schema.org/byMonthWeek-input,< 1K
+Predicate,https://schema.org/byMonthWeek-output,< 1K
+Predicate,https://schema.org/callSign,< 1K
+Predicate,https://schema.org/callSign-input,< 1K
+Predicate,https://schema.org/callSign-output,< 1K
+Predicate,https://schema.org/calories,10K - 100K
+Predicate,https://schema.org/calories-input,< 1K
+Predicate,https://schema.org/calories-output,< 1K
+Predicate,https://schema.org/candidate,< 1K
+Predicate,https://schema.org/candidate-input,< 1K
+Predicate,https://schema.org/candidate-output,< 1K
+Predicate,https://schema.org/caption,10M+
+Predicate,https://schema.org/caption-input,< 1K
+Predicate,https://schema.org/caption-output,< 1K
+Predicate,https://schema.org/carbohydrateContent,10K - 100K
+Predicate,https://schema.org/carbohydrateContent-input,< 1K
+Predicate,https://schema.org/carbohydrateContent-output,< 1K
+Predicate,https://schema.org/cargoVolume,1K - 10K
+Predicate,https://schema.org/cargoVolume-input,< 1K
+Predicate,https://schema.org/cargoVolume-output,< 1K
+Predicate,https://schema.org/carrier,< 1K
+Predicate,https://schema.org/carrier-input,< 1K
+Predicate,https://schema.org/carrier-output,< 1K
+Predicate,https://schema.org/carrierRequirements,< 1K
+Predicate,https://schema.org/carrierRequirements-input,< 1K
+Predicate,https://schema.org/carrierRequirements-output,< 1K
+Predicate,https://schema.org/cashBack,< 1K
+Predicate,https://schema.org/cashBack-input,< 1K
+Predicate,https://schema.org/cashBack-output,< 1K
+Predicate,https://schema.org/catalog,< 1K
+Predicate,https://schema.org/catalog-input,< 1K
+Predicate,https://schema.org/catalog-output,< 1K
+Predicate,https://schema.org/catalogNumber,< 1K
+Predicate,https://schema.org/catalogNumber-input,< 1K
+Predicate,https://schema.org/catalogNumber-output,< 1K
+Predicate,https://schema.org/category,1M - 10M
+Predicate,https://schema.org/category-input,< 1K
+Predicate,https://schema.org/category-output,< 1K
+Predicate,https://schema.org/cause,1K - 10K
+Predicate,https://schema.org/cause-input,< 1K
+Predicate,https://schema.org/cause-output,< 1K
+Predicate,https://schema.org/causeOf,< 1K
+Predicate,https://schema.org/causeOf-input,< 1K
+Predicate,https://schema.org/causeOf-output,< 1K
+Predicate,https://schema.org/ccRecipient,< 1K
+Predicate,https://schema.org/ccRecipient-input,< 1K
+Predicate,https://schema.org/ccRecipient-output,< 1K
+Predicate,https://schema.org/certificationIdentification,1K - 10K
+Predicate,https://schema.org/certificationIdentification-input,< 1K
+Predicate,https://schema.org/certificationIdentification-output,< 1K
+Predicate,https://schema.org/certificationRating,< 1K
+Predicate,https://schema.org/certificationRating-input,< 1K
+Predicate,https://schema.org/certificationRating-output,< 1K
+Predicate,https://schema.org/certificationStatus,1K - 10K
+Predicate,https://schema.org/certificationStatus-input,< 1K
+Predicate,https://schema.org/certificationStatus-output,< 1K
+Predicate,https://schema.org/character,1K - 10K
+Predicate,https://schema.org/character-input,< 1K
+Predicate,https://schema.org/character-output,< 1K
+Predicate,https://schema.org/characterAttribute,< 1K
+Predicate,https://schema.org/characterAttribute-input,< 1K
+Predicate,https://schema.org/characterAttribute-output,< 1K
+Predicate,https://schema.org/characterName,< 1K
+Predicate,https://schema.org/characterName-input,< 1K
+Predicate,https://schema.org/characterName-output,< 1K
+Predicate,https://schema.org/cheatCode,< 1K
+Predicate,https://schema.org/cheatCode-input,< 1K
+Predicate,https://schema.org/cheatCode-output,< 1K
+Predicate,https://schema.org/checkinTime,10K - 100K
+Predicate,https://schema.org/checkinTime-input,< 1K
+Predicate,https://schema.org/checkinTime-output,< 1K
+Predicate,https://schema.org/checkoutPageURLTemplate,10K - 100K
+Predicate,https://schema.org/checkoutPageURLTemplate-input,< 1K
+Predicate,https://schema.org/checkoutPageURLTemplate-output,< 1K
+Predicate,https://schema.org/checkoutTime,10K - 100K
+Predicate,https://schema.org/checkoutTime-input,< 1K
+Predicate,https://schema.org/checkoutTime-output,< 1K
+Predicate,https://schema.org/chemicalComposition,< 1K
+Predicate,https://schema.org/chemicalComposition-input,< 1K
+Predicate,https://schema.org/chemicalComposition-output,< 1K
+Predicate,https://schema.org/chemicalRole,< 1K
+Predicate,https://schema.org/chemicalRole-input,< 1K
+Predicate,https://schema.org/chemicalRole-output,< 1K
+Predicate,https://schema.org/childMaxAge,< 1K
+Predicate,https://schema.org/childMaxAge-input,< 1K
+Predicate,https://schema.org/childMaxAge-output,< 1K
+Predicate,https://schema.org/childMinAge,< 1K
+Predicate,https://schema.org/childMinAge-input,< 1K
+Predicate,https://schema.org/childMinAge-output,< 1K
+Predicate,https://schema.org/childTaxon,< 1K
+Predicate,https://schema.org/childTaxon-input,< 1K
+Predicate,https://schema.org/childTaxon-output,< 1K
+Predicate,https://schema.org/children,1K - 10K
+Predicate,https://schema.org/children-input,< 1K
+Predicate,https://schema.org/children-output,< 1K
+Predicate,https://schema.org/cholesterolContent,10K - 100K
+Predicate,https://schema.org/cholesterolContent-input,< 1K
+Predicate,https://schema.org/cholesterolContent-output,< 1K
+Predicate,https://schema.org/circle,1K - 10K
+Predicate,https://schema.org/circle-input,< 1K
+Predicate,https://schema.org/circle-output,< 1K
+Predicate,https://schema.org/citation,10K - 100K
+Predicate,https://schema.org/citation-input,< 1K
+Predicate,https://schema.org/citation-output,< 1K
+Predicate,https://schema.org/claimInterpreter,< 1K
+Predicate,https://schema.org/claimInterpreter-input,< 1K
+Predicate,https://schema.org/claimInterpreter-output,< 1K
+Predicate,https://schema.org/claimReviewed,1K - 10K
+Predicate,https://schema.org/claimReviewed-input,< 1K
+Predicate,https://schema.org/claimReviewed-output,< 1K
+Predicate,https://schema.org/clincalPharmacology,< 1K
+Predicate,https://schema.org/clincalPharmacology-input,< 1K
+Predicate,https://schema.org/clincalPharmacology-output,< 1K
+Predicate,https://schema.org/clinicalPharmacology,< 1K
+Predicate,https://schema.org/clinicalPharmacology-input,< 1K
+Predicate,https://schema.org/clinicalPharmacology-output,< 1K
+Predicate,https://schema.org/clipNumber,< 1K
+Predicate,https://schema.org/clipNumber-input,< 1K
+Predicate,https://schema.org/clipNumber-output,< 1K
+Predicate,https://schema.org/closes,1M - 10M
+Predicate,https://schema.org/closes-input,< 1K
+Predicate,https://schema.org/closes-output,< 1K
+Predicate,https://schema.org/coach,< 1K
+Predicate,https://schema.org/coach-input,< 1K
+Predicate,https://schema.org/coach-output,< 1K
+Predicate,https://schema.org/code,1K - 10K
+Predicate,https://schema.org/code-input,< 1K
+Predicate,https://schema.org/code-output,< 1K
+Predicate,https://schema.org/codeRepository,1K - 10K
+Predicate,https://schema.org/codeRepository-input,< 1K
+Predicate,https://schema.org/codeRepository-output,< 1K
+Predicate,https://schema.org/codeSampleType,< 1K
+Predicate,https://schema.org/codeSampleType-input,< 1K
+Predicate,https://schema.org/codeSampleType-output,< 1K
+Predicate,https://schema.org/codeValue,1K - 10K
+Predicate,https://schema.org/codeValue-input,< 1K
+Predicate,https://schema.org/codeValue-output,< 1K
+Predicate,https://schema.org/codingSystem,1K - 10K
+Predicate,https://schema.org/codingSystem-input,< 1K
+Predicate,https://schema.org/codingSystem-output,< 1K
+Predicate,https://schema.org/colleague,1K - 10K
+Predicate,https://schema.org/colleague-input,< 1K
+Predicate,https://schema.org/colleague-output,< 1K
+Predicate,https://schema.org/colleagues,< 1K
+Predicate,https://schema.org/colleagues-input,< 1K
+Predicate,https://schema.org/colleagues-output,< 1K
+Predicate,https://schema.org/collection,< 1K
+Predicate,https://schema.org/collection-input,< 1K
+Predicate,https://schema.org/collection-output,< 1K
+Predicate,https://schema.org/collectionSize,1K - 10K
+Predicate,https://schema.org/collectionSize-input,< 1K
+Predicate,https://schema.org/collectionSize-output,< 1K
+Predicate,https://schema.org/color,100K - 1M
+Predicate,https://schema.org/color-input,< 1K
+Predicate,https://schema.org/color-output,< 1K
+Predicate,https://schema.org/colorSwatch,< 1K
+Predicate,https://schema.org/colorSwatch-input,< 1K
+Predicate,https://schema.org/colorSwatch-output,< 1K
+Predicate,https://schema.org/colorist,< 1K
+Predicate,https://schema.org/colorist-input,< 1K
+Predicate,https://schema.org/colorist-output,< 1K
+Predicate,https://schema.org/comment,10K - 100K
+Predicate,https://schema.org/comment-input,< 1K
+Predicate,https://schema.org/comment-output,< 1K
+Predicate,https://schema.org/commentCount,1M - 10M
+Predicate,https://schema.org/commentCount-input,< 1K
+Predicate,https://schema.org/commentCount-output,< 1K
+Predicate,https://schema.org/commentText,10K - 100K
+Predicate,https://schema.org/commentText-input,< 1K
+Predicate,https://schema.org/commentText-output,< 1K
+Predicate,https://schema.org/commentTime,10K - 100K
+Predicate,https://schema.org/commentTime-input,< 1K
+Predicate,https://schema.org/commentTime-output,< 1K
+Predicate,https://schema.org/companyRegistration,< 1K
+Predicate,https://schema.org/companyRegistration-input,< 1K
+Predicate,https://schema.org/companyRegistration-output,< 1K
+Predicate,https://schema.org/competencyRequired,1K - 10K
+Predicate,https://schema.org/competencyRequired-input,< 1K
+Predicate,https://schema.org/competencyRequired-output,< 1K
+Predicate,https://schema.org/competitor,1K - 10K
+Predicate,https://schema.org/competitor-input,< 1K
+Predicate,https://schema.org/competitor-output,< 1K
+Predicate,https://schema.org/composer,1K - 10K
+Predicate,https://schema.org/composer-input,< 1K
+Predicate,https://schema.org/composer-output,< 1K
+Predicate,https://schema.org/comprisedOf,< 1K
+Predicate,https://schema.org/comprisedOf-input,< 1K
+Predicate,https://schema.org/comprisedOf-output,< 1K
+Predicate,https://schema.org/conditionsOfAccess,< 1K
+Predicate,https://schema.org/conditionsOfAccess-input,< 1K
+Predicate,https://schema.org/conditionsOfAccess-output,< 1K
+Predicate,https://schema.org/confirmationNumber,< 1K
+Predicate,https://schema.org/confirmationNumber-input,< 1K
+Predicate,https://schema.org/confirmationNumber-output,< 1K
+Predicate,https://schema.org/connectedTo,< 1K
+Predicate,https://schema.org/connectedTo-input,< 1K
+Predicate,https://schema.org/connectedTo-output,< 1K
+Predicate,https://schema.org/constraintProperty,< 1K
+Predicate,https://schema.org/constraintProperty-input,< 1K
+Predicate,https://schema.org/constraintProperty-output,< 1K
+Predicate,https://schema.org/contactOption,100K - 1M
+Predicate,https://schema.org/contactOption-input,< 1K
+Predicate,https://schema.org/contactOption-output,< 1K
+Predicate,https://schema.org/contactPoint,1M - 10M
+Predicate,https://schema.org/contactPoint-input,< 1K
+Predicate,https://schema.org/contactPoint-output,< 1K
+Predicate,https://schema.org/contactPoints,< 1K
+Predicate,https://schema.org/contactPoints-input,< 1K
+Predicate,https://schema.org/contactPoints-output,< 1K
+Predicate,https://schema.org/contactType,1M - 10M
+Predicate,https://schema.org/contactType-input,< 1K
+Predicate,https://schema.org/contactType-output,< 1K
+Predicate,https://schema.org/contactlessPayment,< 1K
+Predicate,https://schema.org/contactlessPayment-input,< 1K
+Predicate,https://schema.org/contactlessPayment-output,< 1K
+Predicate,https://schema.org/containedIn,10K - 100K
+Predicate,https://schema.org/containedIn-input,< 1K
+Predicate,https://schema.org/containedIn-output,< 1K
+Predicate,https://schema.org/containedInPlace,100K - 1M
+Predicate,https://schema.org/containedInPlace-input,< 1K
+Predicate,https://schema.org/containedInPlace-output,< 1K
+Predicate,https://schema.org/containsPlace,10K - 100K
+Predicate,https://schema.org/containsPlace-input,< 1K
+Predicate,https://schema.org/containsPlace-output,< 1K
+Predicate,https://schema.org/containsSeason,1K - 10K
+Predicate,https://schema.org/containsSeason-input,< 1K
+Predicate,https://schema.org/containsSeason-output,< 1K
+Predicate,https://schema.org/contentLocation,10K - 100K
+Predicate,https://schema.org/contentLocation-input,< 1K
+Predicate,https://schema.org/contentLocation-output,< 1K
+Predicate,https://schema.org/contentRating,10K - 100K
+Predicate,https://schema.org/contentRating-input,< 1K
+Predicate,https://schema.org/contentRating-output,< 1K
+Predicate,https://schema.org/contentReferenceTime,1K - 10K
+Predicate,https://schema.org/contentReferenceTime-input,< 1K
+Predicate,https://schema.org/contentReferenceTime-output,< 1K
+Predicate,https://schema.org/contentSize,100K - 1M
+Predicate,https://schema.org/contentSize-input,< 1K
+Predicate,https://schema.org/contentSize-output,< 1K
+Predicate,https://schema.org/contentType,10K - 100K
+Predicate,https://schema.org/contentType-input,< 1K
+Predicate,https://schema.org/contentType-output,< 1K
+Predicate,https://schema.org/contentUrl,10M+
+Predicate,https://schema.org/contentUrl-input,< 1K
+Predicate,https://schema.org/contentUrl-output,< 1K
+Predicate,https://schema.org/contraindication,1K - 10K
+Predicate,https://schema.org/contraindication-input,< 1K
+Predicate,https://schema.org/contraindication-output,< 1K
+Predicate,https://schema.org/contributor,100K - 1M
+Predicate,https://schema.org/contributor-input,< 1K
+Predicate,https://schema.org/contributor-output,< 1K
+Predicate,https://schema.org/cookTime,10K - 100K
+Predicate,https://schema.org/cookTime-input,< 1K
+Predicate,https://schema.org/cookTime-output,< 1K
+Predicate,https://schema.org/cookingMethod,1K - 10K
+Predicate,https://schema.org/cookingMethod-input,< 1K
+Predicate,https://schema.org/cookingMethod-output,< 1K
+Predicate,https://schema.org/copyrightHolder,100K - 1M
+Predicate,https://schema.org/copyrightHolder-input,< 1K
+Predicate,https://schema.org/copyrightHolder-output,< 1K
+Predicate,https://schema.org/copyrightNotice,10K - 100K
+Predicate,https://schema.org/copyrightNotice-input,< 1K
+Predicate,https://schema.org/copyrightNotice-output,< 1K
+Predicate,https://schema.org/copyrightYear,100K - 1M
+Predicate,https://schema.org/copyrightYear-input,< 1K
+Predicate,https://schema.org/copyrightYear-output,< 1K
+Predicate,https://schema.org/correction,< 1K
+Predicate,https://schema.org/correction-input,< 1K
+Predicate,https://schema.org/correction-output,< 1K
+Predicate,https://schema.org/correctionsPolicy,10K - 100K
+Predicate,https://schema.org/correctionsPolicy-input,< 1K
+Predicate,https://schema.org/correctionsPolicy-output,< 1K
+Predicate,https://schema.org/costCategory,< 1K
+Predicate,https://schema.org/costCategory-input,< 1K
+Predicate,https://schema.org/costCategory-output,< 1K
+Predicate,https://schema.org/costCurrency,< 1K
+Predicate,https://schema.org/costCurrency-input,< 1K
+Predicate,https://schema.org/costCurrency-output,< 1K
+Predicate,https://schema.org/costOrigin,< 1K
+Predicate,https://schema.org/costOrigin-input,< 1K
+Predicate,https://schema.org/costOrigin-output,< 1K
+Predicate,https://schema.org/costPerUnit,< 1K
+Predicate,https://schema.org/costPerUnit-input,< 1K
+Predicate,https://schema.org/costPerUnit-output,< 1K
+Predicate,https://schema.org/countriesNotSupported,< 1K
+Predicate,https://schema.org/countriesNotSupported-input,< 1K
+Predicate,https://schema.org/countriesNotSupported-output,< 1K
+Predicate,https://schema.org/countriesSupported,1K - 10K
+Predicate,https://schema.org/countriesSupported-input,< 1K
+Predicate,https://schema.org/countriesSupported-output,< 1K
+Predicate,https://schema.org/countryOfAssembly,1K - 10K
+Predicate,https://schema.org/countryOfAssembly-input,< 1K
+Predicate,https://schema.org/countryOfAssembly-output,< 1K
+Predicate,https://schema.org/countryOfLastProcessing,< 1K
+Predicate,https://schema.org/countryOfLastProcessing-input,< 1K
+Predicate,https://schema.org/countryOfLastProcessing-output,< 1K
+Predicate,https://schema.org/countryOfOrigin,10K - 100K
+Predicate,https://schema.org/countryOfOrigin-input,< 1K
+Predicate,https://schema.org/countryOfOrigin-output,< 1K
+Predicate,https://schema.org/course,< 1K
+Predicate,https://schema.org/course-input,< 1K
+Predicate,https://schema.org/course-output,< 1K
+Predicate,https://schema.org/courseCode,10K - 100K
+Predicate,https://schema.org/courseCode-input,< 1K
+Predicate,https://schema.org/courseCode-output,< 1K
+Predicate,https://schema.org/courseMode,10K - 100K
+Predicate,https://schema.org/courseMode-input,< 1K
+Predicate,https://schema.org/courseMode-output,< 1K
+Predicate,https://schema.org/coursePrerequisites,1K - 10K
+Predicate,https://schema.org/coursePrerequisites-input,< 1K
+Predicate,https://schema.org/coursePrerequisites-output,< 1K
+Predicate,https://schema.org/courseSchedule,1K - 10K
+Predicate,https://schema.org/courseSchedule-input,< 1K
+Predicate,https://schema.org/courseSchedule-output,< 1K
+Predicate,https://schema.org/courseWorkload,10K - 100K
+Predicate,https://schema.org/courseWorkload-input,< 1K
+Predicate,https://schema.org/courseWorkload-output,< 1K
+Predicate,https://schema.org/coverageEndTime,1K - 10K
+Predicate,https://schema.org/coverageEndTime-input,< 1K
+Predicate,https://schema.org/coverageEndTime-output,< 1K
+Predicate,https://schema.org/coverageStartTime,1K - 10K
+Predicate,https://schema.org/coverageStartTime-input,< 1K
+Predicate,https://schema.org/coverageStartTime-output,< 1K
+Predicate,https://schema.org/creativeWorkStatus,1K - 10K
+Predicate,https://schema.org/creativeWorkStatus-input,< 1K
+Predicate,https://schema.org/creativeWorkStatus-output,< 1K
+Predicate,https://schema.org/creator,1M - 10M
+Predicate,https://schema.org/creator-input,< 1K
+Predicate,https://schema.org/creator-output,< 1K
+Predicate,https://schema.org/credentialCategory,10K - 100K
+Predicate,https://schema.org/credentialCategory-input,< 1K
+Predicate,https://schema.org/credentialCategory-output,< 1K
+Predicate,https://schema.org/creditText,100K - 1M
+Predicate,https://schema.org/creditText-input,< 1K
+Predicate,https://schema.org/creditText-output,< 1K
+Predicate,https://schema.org/creditedTo,< 1K
+Predicate,https://schema.org/creditedTo-input,< 1K
+Predicate,https://schema.org/creditedTo-output,< 1K
+Predicate,https://schema.org/cssSelector,100K - 1M
+Predicate,https://schema.org/cssSelector-input,< 1K
+Predicate,https://schema.org/cssSelector-output,< 1K
+Predicate,https://schema.org/currenciesAccepted,100K - 1M
+Predicate,https://schema.org/currenciesAccepted-input,< 1K
+Predicate,https://schema.org/currenciesAccepted-output,< 1K
+Predicate,https://schema.org/currency,100K - 1M
+Predicate,https://schema.org/currency-input,< 1K
+Predicate,https://schema.org/currency-output,< 1K
+Predicate,https://schema.org/currentExchangeRate,< 1K
+Predicate,https://schema.org/currentExchangeRate-input,< 1K
+Predicate,https://schema.org/currentExchangeRate-output,< 1K
+Predicate,https://schema.org/customer,< 1K
+Predicate,https://schema.org/customer-input,< 1K
+Predicate,https://schema.org/customer-output,< 1K
+Predicate,https://schema.org/customerRemorseReturnFees,1K - 10K
+Predicate,https://schema.org/customerRemorseReturnFees-input,< 1K
+Predicate,https://schema.org/customerRemorseReturnFees-output,< 1K
+Predicate,https://schema.org/customerRemorseReturnLabelSource,1K - 10K
+Predicate,https://schema.org/customerRemorseReturnLabelSource-input,< 1K
+Predicate,https://schema.org/customerRemorseReturnLabelSource-output,< 1K
+Predicate,https://schema.org/customerRemorseReturnShippingFeesAmount,< 1K
+Predicate,https://schema.org/customerRemorseReturnShippingFeesAmount-input,< 1K
+Predicate,https://schema.org/customerRemorseReturnShippingFeesAmount-output,< 1K
+Predicate,https://schema.org/cutoffTime,10K - 100K
+Predicate,https://schema.org/cutoffTime-input,< 1K
+Predicate,https://schema.org/cutoffTime-output,< 1K
+Predicate,https://schema.org/cvdCollectionDate,< 1K
+Predicate,https://schema.org/cvdCollectionDate-input,< 1K
+Predicate,https://schema.org/cvdCollectionDate-output,< 1K
+Predicate,https://schema.org/cvdFacilityCounty,< 1K
+Predicate,https://schema.org/cvdFacilityCounty-input,< 1K
+Predicate,https://schema.org/cvdFacilityCounty-output,< 1K
+Predicate,https://schema.org/cvdFacilityId,< 1K
+Predicate,https://schema.org/cvdFacilityId-input,< 1K
+Predicate,https://schema.org/cvdFacilityId-output,< 1K
+Predicate,https://schema.org/cvdNumBeds,< 1K
+Predicate,https://schema.org/cvdNumBeds-input,< 1K
+Predicate,https://schema.org/cvdNumBeds-output,< 1K
+Predicate,https://schema.org/cvdNumBedsOcc,< 1K
+Predicate,https://schema.org/cvdNumBedsOcc-input,< 1K
+Predicate,https://schema.org/cvdNumBedsOcc-output,< 1K
+Predicate,https://schema.org/cvdNumC19Died,< 1K
+Predicate,https://schema.org/cvdNumC19Died-input,< 1K
+Predicate,https://schema.org/cvdNumC19Died-output,< 1K
+Predicate,https://schema.org/cvdNumC19HOPats,< 1K
+Predicate,https://schema.org/cvdNumC19HOPats-input,< 1K
+Predicate,https://schema.org/cvdNumC19HOPats-output,< 1K
+Predicate,https://schema.org/cvdNumC19HospPats,< 1K
+Predicate,https://schema.org/cvdNumC19HospPats-input,< 1K
+Predicate,https://schema.org/cvdNumC19HospPats-output,< 1K
+Predicate,https://schema.org/cvdNumC19MechVentPats,< 1K
+Predicate,https://schema.org/cvdNumC19MechVentPats-input,< 1K
+Predicate,https://schema.org/cvdNumC19MechVentPats-output,< 1K
+Predicate,https://schema.org/cvdNumC19OFMechVentPats,< 1K
+Predicate,https://schema.org/cvdNumC19OFMechVentPats-input,< 1K
+Predicate,https://schema.org/cvdNumC19OFMechVentPats-output,< 1K
+Predicate,https://schema.org/cvdNumC19OverflowPats,< 1K
+Predicate,https://schema.org/cvdNumC19OverflowPats-input,< 1K
+Predicate,https://schema.org/cvdNumC19OverflowPats-output,< 1K
+Predicate,https://schema.org/cvdNumICUBeds,< 1K
+Predicate,https://schema.org/cvdNumICUBeds-input,< 1K
+Predicate,https://schema.org/cvdNumICUBeds-output,< 1K
+Predicate,https://schema.org/cvdNumICUBedsOcc,< 1K
+Predicate,https://schema.org/cvdNumICUBedsOcc-input,< 1K
+Predicate,https://schema.org/cvdNumICUBedsOcc-output,< 1K
+Predicate,https://schema.org/cvdNumTotBeds,< 1K
+Predicate,https://schema.org/cvdNumTotBeds-input,< 1K
+Predicate,https://schema.org/cvdNumTotBeds-output,< 1K
+Predicate,https://schema.org/cvdNumVent,< 1K
+Predicate,https://schema.org/cvdNumVent-input,< 1K
+Predicate,https://schema.org/cvdNumVent-output,< 1K
+Predicate,https://schema.org/cvdNumVentUse,< 1K
+Predicate,https://schema.org/cvdNumVentUse-input,< 1K
+Predicate,https://schema.org/cvdNumVentUse-output,< 1K
+Predicate,https://schema.org/data,1K - 10K
+Predicate,https://schema.org/data-input,< 1K
+Predicate,https://schema.org/data-output,< 1K
+Predicate,https://schema.org/dataFeedElement,1K - 10K
+Predicate,https://schema.org/dataFeedElement-input,< 1K
+Predicate,https://schema.org/dataFeedElement-output,< 1K
+Predicate,https://schema.org/dataset,1K - 10K
+Predicate,https://schema.org/dataset-input,< 1K
+Predicate,https://schema.org/dataset-output,< 1K
+Predicate,https://schema.org/datasetTimeInterval,< 1K
+Predicate,https://schema.org/datasetTimeInterval-input,< 1K
+Predicate,https://schema.org/datasetTimeInterval-output,< 1K
+Predicate,https://schema.org/dateCreated,100K - 1M
+Predicate,https://schema.org/dateCreated-input,< 1K
+Predicate,https://schema.org/dateCreated-output,< 1K
+Predicate,https://schema.org/dateDeleted,< 1K
+Predicate,https://schema.org/dateDeleted-input,< 1K
+Predicate,https://schema.org/dateDeleted-output,< 1K
+Predicate,https://schema.org/dateIssued,< 1K
+Predicate,https://schema.org/dateIssued-input,< 1K
+Predicate,https://schema.org/dateIssued-output,< 1K
+Predicate,https://schema.org/dateModified,10M+
+Predicate,https://schema.org/dateModified-input,< 1K
+Predicate,https://schema.org/dateModified-output,< 1K
+Predicate,https://schema.org/datePosted,100K - 1M
+Predicate,https://schema.org/datePosted-input,< 1K
+Predicate,https://schema.org/datePosted-output,< 1K
+Predicate,https://schema.org/datePublished,10M+
+Predicate,https://schema.org/datePublished-input,< 1K
+Predicate,https://schema.org/datePublished-output,< 1K
+Predicate,https://schema.org/dateRead,< 1K
+Predicate,https://schema.org/dateRead-input,< 1K
+Predicate,https://schema.org/dateRead-output,< 1K
+Predicate,https://schema.org/dateReceived,< 1K
+Predicate,https://schema.org/dateReceived-input,< 1K
+Predicate,https://schema.org/dateReceived-output,< 1K
+Predicate,https://schema.org/dateSent,< 1K
+Predicate,https://schema.org/dateSent-input,< 1K
+Predicate,https://schema.org/dateSent-output,< 1K
+Predicate,https://schema.org/dateVehicleFirstRegistered,1K - 10K
+Predicate,https://schema.org/dateVehicleFirstRegistered-input,< 1K
+Predicate,https://schema.org/dateVehicleFirstRegistered-output,< 1K
+Predicate,https://schema.org/dateline,1K - 10K
+Predicate,https://schema.org/dateline-input,< 1K
+Predicate,https://schema.org/dateline-output,< 1K
+Predicate,https://schema.org/dayOfWeek,1M - 10M
+Predicate,https://schema.org/dayOfWeek-input,< 1K
+Predicate,https://schema.org/dayOfWeek-output,< 1K
+Predicate,https://schema.org/deathDate,10K - 100K
+Predicate,https://schema.org/deathDate-input,< 1K
+Predicate,https://schema.org/deathDate-output,< 1K
+Predicate,https://schema.org/deathPlace,1K - 10K
+Predicate,https://schema.org/deathPlace-input,< 1K
+Predicate,https://schema.org/deathPlace-output,< 1K
+Predicate,https://schema.org/defaultValue,100K - 1M
+Predicate,https://schema.org/defaultValue-input,< 1K
+Predicate,https://schema.org/defaultValue-output,< 1K
+Predicate,https://schema.org/deliveryAddress,< 1K
+Predicate,https://schema.org/deliveryAddress-input,< 1K
+Predicate,https://schema.org/deliveryAddress-output,< 1K
+Predicate,https://schema.org/deliveryLeadTime,10K - 100K
+Predicate,https://schema.org/deliveryLeadTime-input,< 1K
+Predicate,https://schema.org/deliveryLeadTime-output,< 1K
+Predicate,https://schema.org/deliveryMethod,100K - 1M
+Predicate,https://schema.org/deliveryMethod-input,< 1K
+Predicate,https://schema.org/deliveryMethod-output,< 1K
+Predicate,https://schema.org/deliveryStatus,< 1K
+Predicate,https://schema.org/deliveryStatus-input,< 1K
+Predicate,https://schema.org/deliveryStatus-output,< 1K
+Predicate,https://schema.org/deliveryTime,100K - 1M
+Predicate,https://schema.org/deliveryTime-input,< 1K
+Predicate,https://schema.org/deliveryTime-output,< 1K
+Predicate,https://schema.org/department,10K - 100K
+Predicate,https://schema.org/department-input,< 1K
+Predicate,https://schema.org/department-output,< 1K
+Predicate,https://schema.org/departureAirport,1K - 10K
+Predicate,https://schema.org/departureAirport-input,< 1K
+Predicate,https://schema.org/departureAirport-output,< 1K
+Predicate,https://schema.org/departureBoatTerminal,< 1K
+Predicate,https://schema.org/departureBoatTerminal-input,< 1K
+Predicate,https://schema.org/departureBoatTerminal-output,< 1K
+Predicate,https://schema.org/departureBusStop,< 1K
+Predicate,https://schema.org/departureBusStop-input,< 1K
+Predicate,https://schema.org/departureBusStop-output,< 1K
+Predicate,https://schema.org/departureGate,< 1K
+Predicate,https://schema.org/departureGate-input,< 1K
+Predicate,https://schema.org/departureGate-output,< 1K
+Predicate,https://schema.org/departurePlatform,< 1K
+Predicate,https://schema.org/departurePlatform-input,< 1K
+Predicate,https://schema.org/departurePlatform-output,< 1K
+Predicate,https://schema.org/departureStation,< 1K
+Predicate,https://schema.org/departureStation-input,< 1K
+Predicate,https://schema.org/departureStation-output,< 1K
+Predicate,https://schema.org/departureTerminal,< 1K
+Predicate,https://schema.org/departureTerminal-input,< 1K
+Predicate,https://schema.org/departureTerminal-output,< 1K
+Predicate,https://schema.org/departureTime,1K - 10K
+Predicate,https://schema.org/departureTime-input,< 1K
+Predicate,https://schema.org/departureTime-output,< 1K
+Predicate,https://schema.org/dependencies,1K - 10K
+Predicate,https://schema.org/dependencies-input,< 1K
+Predicate,https://schema.org/dependencies-output,< 1K
+Predicate,https://schema.org/depth,10K - 100K
+Predicate,https://schema.org/depth-input,< 1K
+Predicate,https://schema.org/depth-output,< 1K
+Predicate,https://schema.org/description,10M+
+Predicate,https://schema.org/description-input,< 1K
+Predicate,https://schema.org/description-output,< 1K
+Predicate,https://schema.org/device,< 1K
+Predicate,https://schema.org/device-input,< 1K
+Predicate,https://schema.org/device-output,< 1K
+Predicate,https://schema.org/diagnosis,< 1K
+Predicate,https://schema.org/diagnosis-input,< 1K
+Predicate,https://schema.org/diagnosis-output,< 1K
+Predicate,https://schema.org/diagram,< 1K
+Predicate,https://schema.org/diagram-input,< 1K
+Predicate,https://schema.org/diagram-output,< 1K
+Predicate,https://schema.org/diet,< 1K
+Predicate,https://schema.org/diet-input,< 1K
+Predicate,https://schema.org/diet-output,< 1K
+Predicate,https://schema.org/dietFeatures,< 1K
+Predicate,https://schema.org/dietFeatures-input,< 1K
+Predicate,https://schema.org/dietFeatures-output,< 1K
+Predicate,https://schema.org/differentialDiagnosis,< 1K
+Predicate,https://schema.org/differentialDiagnosis-input,< 1K
+Predicate,https://schema.org/differentialDiagnosis-output,< 1K
+Predicate,https://schema.org/digitalSourceType,< 1K
+Predicate,https://schema.org/digitalSourceType-input,< 1K
+Predicate,https://schema.org/digitalSourceType-output,< 1K
+Predicate,https://schema.org/directApply,10K - 100K
+Predicate,https://schema.org/directApply-input,< 1K
+Predicate,https://schema.org/directApply-output,< 1K
+Predicate,https://schema.org/director,10K - 100K
+Predicate,https://schema.org/director-input,< 1K
+Predicate,https://schema.org/director-output,< 1K
+Predicate,https://schema.org/directors,< 1K
+Predicate,https://schema.org/directors-input,< 1K
+Predicate,https://schema.org/directors-output,< 1K
+Predicate,https://schema.org/disambiguatingDescription,10K - 100K
+Predicate,https://schema.org/disambiguatingDescription-input,< 1K
+Predicate,https://schema.org/disambiguatingDescription-output,< 1K
+Predicate,https://schema.org/discount,10K - 100K
+Predicate,https://schema.org/discount-input,< 1K
+Predicate,https://schema.org/discount-output,< 1K
+Predicate,https://schema.org/discountCode,< 1K
+Predicate,https://schema.org/discountCode-input,< 1K
+Predicate,https://schema.org/discountCode-output,< 1K
+Predicate,https://schema.org/discountCurrency,< 1K
+Predicate,https://schema.org/discountCurrency-input,< 1K
+Predicate,https://schema.org/discountCurrency-output,< 1K
+Predicate,https://schema.org/discusses,1K - 10K
+Predicate,https://schema.org/discusses-input,< 1K
+Predicate,https://schema.org/discusses-output,< 1K
+Predicate,https://schema.org/discussionUrl,10K - 100K
+Predicate,https://schema.org/discussionUrl-input,< 1K
+Predicate,https://schema.org/discussionUrl-output,< 1K
+Predicate,https://schema.org/diseasePreventionInfo,< 1K
+Predicate,https://schema.org/diseasePreventionInfo-input,< 1K
+Predicate,https://schema.org/diseasePreventionInfo-output,< 1K
+Predicate,https://schema.org/diseaseSpreadStatistics,< 1K
+Predicate,https://schema.org/diseaseSpreadStatistics-input,< 1K
+Predicate,https://schema.org/diseaseSpreadStatistics-output,< 1K
+Predicate,https://schema.org/displayLocation,< 1K
+Predicate,https://schema.org/displayLocation-input,< 1K
+Predicate,https://schema.org/displayLocation-output,< 1K
+Predicate,https://schema.org/dissolutionDate,< 1K
+Predicate,https://schema.org/dissolutionDate-input,< 1K
+Predicate,https://schema.org/dissolutionDate-output,< 1K
+Predicate,https://schema.org/distance,1K - 10K
+Predicate,https://schema.org/distance-input,< 1K
+Predicate,https://schema.org/distance-output,< 1K
+Predicate,https://schema.org/distinguishingSign,< 1K
+Predicate,https://schema.org/distinguishingSign-input,< 1K
+Predicate,https://schema.org/distinguishingSign-output,< 1K
+Predicate,https://schema.org/distribution,10K - 100K
+Predicate,https://schema.org/distribution-input,< 1K
+Predicate,https://schema.org/distribution-output,< 1K
+Predicate,https://schema.org/diversityPolicy,10K - 100K
+Predicate,https://schema.org/diversityPolicy-input,< 1K
+Predicate,https://schema.org/diversityPolicy-output,< 1K
+Predicate,https://schema.org/diversityStaffingReport,1K - 10K
+Predicate,https://schema.org/diversityStaffingReport-input,< 1K
+Predicate,https://schema.org/diversityStaffingReport-output,< 1K
+Predicate,https://schema.org/documentation,1K - 10K
+Predicate,https://schema.org/documentation-input,< 1K
+Predicate,https://schema.org/documentation-output,< 1K
+Predicate,https://schema.org/doesNotShip,10K - 100K
+Predicate,https://schema.org/doesNotShip-input,< 1K
+Predicate,https://schema.org/doesNotShip-output,< 1K
+Predicate,https://schema.org/domainIncludes,< 1K
+Predicate,https://schema.org/domainIncludes-input,< 1K
+Predicate,https://schema.org/domainIncludes-output,< 1K
+Predicate,https://schema.org/domiciledMortgage,< 1K
+Predicate,https://schema.org/domiciledMortgage-input,< 1K
+Predicate,https://schema.org/domiciledMortgage-output,< 1K
+Predicate,https://schema.org/doorTime,1K - 10K
+Predicate,https://schema.org/doorTime-input,< 1K
+Predicate,https://schema.org/doorTime-output,< 1K
+Predicate,https://schema.org/dosageForm,1K - 10K
+Predicate,https://schema.org/dosageForm-input,< 1K
+Predicate,https://schema.org/dosageForm-output,< 1K
+Predicate,https://schema.org/doseSchedule,< 1K
+Predicate,https://schema.org/doseSchedule-input,< 1K
+Predicate,https://schema.org/doseSchedule-output,< 1K
+Predicate,https://schema.org/doseUnit,< 1K
+Predicate,https://schema.org/doseUnit-input,< 1K
+Predicate,https://schema.org/doseUnit-output,< 1K
+Predicate,https://schema.org/doseValue,< 1K
+Predicate,https://schema.org/doseValue-input,< 1K
+Predicate,https://schema.org/doseValue-output,< 1K
+Predicate,https://schema.org/downPayment,< 1K
+Predicate,https://schema.org/downPayment-input,< 1K
+Predicate,https://schema.org/downPayment-output,< 1K
+Predicate,https://schema.org/downloadUrl,100K - 1M
+Predicate,https://schema.org/downloadUrl-input,< 1K
+Predicate,https://schema.org/downloadUrl-output,< 1K
+Predicate,https://schema.org/downvoteCount,1K - 10K
+Predicate,https://schema.org/downvoteCount-input,< 1K
+Predicate,https://schema.org/downvoteCount-output,< 1K
+Predicate,https://schema.org/drainsTo,< 1K
+Predicate,https://schema.org/drainsTo-input,< 1K
+Predicate,https://schema.org/drainsTo-output,< 1K
+Predicate,https://schema.org/driveWheelConfiguration,10K - 100K
+Predicate,https://schema.org/driveWheelConfiguration-input,< 1K
+Predicate,https://schema.org/driveWheelConfiguration-output,< 1K
+Predicate,https://schema.org/dropoffLocation,< 1K
+Predicate,https://schema.org/dropoffLocation-input,< 1K
+Predicate,https://schema.org/dropoffLocation-output,< 1K
+Predicate,https://schema.org/dropoffTime,< 1K
+Predicate,https://schema.org/dropoffTime-input,< 1K
+Predicate,https://schema.org/dropoffTime-output,< 1K
+Predicate,https://schema.org/drug,< 1K
+Predicate,https://schema.org/drug-input,< 1K
+Predicate,https://schema.org/drug-output,< 1K
+Predicate,https://schema.org/drugClass,1K - 10K
+Predicate,https://schema.org/drugClass-input,< 1K
+Predicate,https://schema.org/drugClass-output,< 1K
+Predicate,https://schema.org/drugUnit,< 1K
+Predicate,https://schema.org/drugUnit-input,< 1K
+Predicate,https://schema.org/drugUnit-output,< 1K
+Predicate,https://schema.org/duns,1K - 10K
+Predicate,https://schema.org/duns-input,< 1K
+Predicate,https://schema.org/duns-output,< 1K
+Predicate,https://schema.org/duplicateTherapy,< 1K
+Predicate,https://schema.org/duplicateTherapy-input,< 1K
+Predicate,https://schema.org/duplicateTherapy-output,< 1K
+Predicate,https://schema.org/duration,1M - 10M
+Predicate,https://schema.org/duration-input,< 1K
+Predicate,https://schema.org/duration-output,< 1K
+Predicate,https://schema.org/durationOfWarranty,1K - 10K
+Predicate,https://schema.org/durationOfWarranty-input,< 1K
+Predicate,https://schema.org/durationOfWarranty-output,< 1K
+Predicate,https://schema.org/duringMedia,< 1K
+Predicate,https://schema.org/duringMedia-input,< 1K
+Predicate,https://schema.org/duringMedia-output,< 1K
+Predicate,https://schema.org/earlyPrepaymentPenalty,< 1K
+Predicate,https://schema.org/earlyPrepaymentPenalty-input,< 1K
+Predicate,https://schema.org/earlyPrepaymentPenalty-output,< 1K
+Predicate,https://schema.org/editEIDR,< 1K
+Predicate,https://schema.org/editEIDR-input,< 1K
+Predicate,https://schema.org/editEIDR-output,< 1K
+Predicate,https://schema.org/editor,100K - 1M
+Predicate,https://schema.org/editor-input,< 1K
+Predicate,https://schema.org/editor-output,< 1K
+Predicate,https://schema.org/eduQuestionType,1K - 10K
+Predicate,https://schema.org/eduQuestionType-input,< 1K
+Predicate,https://schema.org/eduQuestionType-output,< 1K
+Predicate,https://schema.org/educationRequirements,10K - 100K
+Predicate,https://schema.org/educationRequirements-input,< 1K
+Predicate,https://schema.org/educationRequirements-output,< 1K
+Predicate,https://schema.org/educationalAlignment,1K - 10K
+Predicate,https://schema.org/educationalAlignment-input,< 1K
+Predicate,https://schema.org/educationalAlignment-output,< 1K
+Predicate,https://schema.org/educationalCredentialAwarded,10K - 100K
+Predicate,https://schema.org/educationalCredentialAwarded-input,< 1K
+Predicate,https://schema.org/educationalCredentialAwarded-output,< 1K
+Predicate,https://schema.org/educationalFramework,< 1K
+Predicate,https://schema.org/educationalFramework-input,< 1K
+Predicate,https://schema.org/educationalFramework-output,< 1K
+Predicate,https://schema.org/educationalLevel,10K - 100K
+Predicate,https://schema.org/educationalLevel-input,< 1K
+Predicate,https://schema.org/educationalLevel-output,< 1K
+Predicate,https://schema.org/educationalProgramMode,1K - 10K
+Predicate,https://schema.org/educationalProgramMode-input,< 1K
+Predicate,https://schema.org/educationalProgramMode-output,< 1K
+Predicate,https://schema.org/educationalRole,10K - 100K
+Predicate,https://schema.org/educationalRole-input,< 1K
+Predicate,https://schema.org/educationalRole-output,< 1K
+Predicate,https://schema.org/educationalUse,1K - 10K
+Predicate,https://schema.org/educationalUse-input,< 1K
+Predicate,https://schema.org/educationalUse-output,< 1K
+Predicate,https://schema.org/elevation,1K - 10K
+Predicate,https://schema.org/elevation-input,< 1K
+Predicate,https://schema.org/elevation-output,< 1K
+Predicate,https://schema.org/eligibilityToWorkRequirement,< 1K
+Predicate,https://schema.org/eligibilityToWorkRequirement-input,< 1K
+Predicate,https://schema.org/eligibilityToWorkRequirement-output,< 1K
+Predicate,https://schema.org/eligibleCustomerType,1K - 10K
+Predicate,https://schema.org/eligibleCustomerType-input,< 1K
+Predicate,https://schema.org/eligibleCustomerType-output,< 1K
+Predicate,https://schema.org/eligibleDuration,10K - 100K
+Predicate,https://schema.org/eligibleDuration-input,< 1K
+Predicate,https://schema.org/eligibleDuration-output,< 1K
+Predicate,https://schema.org/eligibleQuantity,10K - 100K
+Predicate,https://schema.org/eligibleQuantity-input,< 1K
+Predicate,https://schema.org/eligibleQuantity-output,< 1K
+Predicate,https://schema.org/eligibleRegion,10K - 100K
+Predicate,https://schema.org/eligibleRegion-input,< 1K
+Predicate,https://schema.org/eligibleRegion-output,< 1K
+Predicate,https://schema.org/eligibleTransactionVolume,10K - 100K
+Predicate,https://schema.org/eligibleTransactionVolume-input,< 1K
+Predicate,https://schema.org/eligibleTransactionVolume-output,< 1K
+Predicate,https://schema.org/eligibleWithSupplier,< 1K
+Predicate,https://schema.org/eligibleWithSupplier-input,< 1K
+Predicate,https://schema.org/eligibleWithSupplier-output,< 1K
+Predicate,https://schema.org/email,1M - 10M
+Predicate,https://schema.org/email-input,< 1K
+Predicate,https://schema.org/email-output,< 1K
+Predicate,https://schema.org/embedUrl,1M - 10M
+Predicate,https://schema.org/embedUrl-input,< 1K
+Predicate,https://schema.org/embedUrl-output,< 1K
+Predicate,https://schema.org/embeddedTextCaption,1K - 10K
+Predicate,https://schema.org/embeddedTextCaption-input,< 1K
+Predicate,https://schema.org/embeddedTextCaption-output,< 1K
+Predicate,https://schema.org/emissionsCO2,1K - 10K
+Predicate,https://schema.org/emissionsCO2-input,< 1K
+Predicate,https://schema.org/emissionsCO2-output,< 1K
+Predicate,https://schema.org/employee,100K - 1M
+Predicate,https://schema.org/employee-input,< 1K
+Predicate,https://schema.org/employee-output,< 1K
+Predicate,https://schema.org/employees,1K - 10K
+Predicate,https://schema.org/employees-input,< 1K
+Predicate,https://schema.org/employees-output,< 1K
+Predicate,https://schema.org/employerOverview,1K - 10K
+Predicate,https://schema.org/employerOverview-input,< 1K
+Predicate,https://schema.org/employerOverview-output,< 1K
+Predicate,https://schema.org/employmentType,100K - 1M
+Predicate,https://schema.org/employmentType-input,< 1K
+Predicate,https://schema.org/employmentType-output,< 1K
+Predicate,https://schema.org/employmentUnit,1K - 10K
+Predicate,https://schema.org/employmentUnit-input,< 1K
+Predicate,https://schema.org/employmentUnit-output,< 1K
+Predicate,https://schema.org/encodesBioChemEntity,< 1K
+Predicate,https://schema.org/encodesBioChemEntity-input,< 1K
+Predicate,https://schema.org/encodesBioChemEntity-output,< 1K
+Predicate,https://schema.org/encodesCreativeWork,< 1K
+Predicate,https://schema.org/encodesCreativeWork-input,< 1K
+Predicate,https://schema.org/encodesCreativeWork-output,< 1K
+Predicate,https://schema.org/encoding,100K - 1M
+Predicate,https://schema.org/encoding-input,< 1K
+Predicate,https://schema.org/encoding-output,< 1K
+Predicate,https://schema.org/encodingFormat,10K - 100K
+Predicate,https://schema.org/encodingFormat-input,< 1K
+Predicate,https://schema.org/encodingFormat-output,< 1K
+Predicate,https://schema.org/encodingType,< 1K
+Predicate,https://schema.org/encodingType-input,< 1K
+Predicate,https://schema.org/encodingType-output,< 1K
+Predicate,https://schema.org/encodings,< 1K
+Predicate,https://schema.org/encodings-input,< 1K
+Predicate,https://schema.org/encodings-output,< 1K
+Predicate,https://schema.org/endDate,100K - 1M
+Predicate,https://schema.org/endDate-input,< 1K
+Predicate,https://schema.org/endDate-output,< 1K
+Predicate,https://schema.org/endOffset,10K - 100K
+Predicate,https://schema.org/endOffset-input,< 1K
+Predicate,https://schema.org/endOffset-output,< 1K
+Predicate,https://schema.org/endTime,1K - 10K
+Predicate,https://schema.org/endTime-input,< 1K
+Predicate,https://schema.org/endTime-output,< 1K
+Predicate,https://schema.org/endorsee,< 1K
+Predicate,https://schema.org/endorsee-input,< 1K
+Predicate,https://schema.org/endorsee-output,< 1K
+Predicate,https://schema.org/endorsers,< 1K
+Predicate,https://schema.org/endorsers-input,< 1K
+Predicate,https://schema.org/endorsers-output,< 1K
+Predicate,https://schema.org/energyEfficiencyScaleMax,1K - 10K
+Predicate,https://schema.org/energyEfficiencyScaleMax-input,< 1K
+Predicate,https://schema.org/energyEfficiencyScaleMax-output,< 1K
+Predicate,https://schema.org/energyEfficiencyScaleMin,1K - 10K
+Predicate,https://schema.org/energyEfficiencyScaleMin-input,< 1K
+Predicate,https://schema.org/energyEfficiencyScaleMin-output,< 1K
+Predicate,https://schema.org/engineDisplacement,10K - 100K
+Predicate,https://schema.org/engineDisplacement-input,< 1K
+Predicate,https://schema.org/engineDisplacement-output,< 1K
+Predicate,https://schema.org/enginePower,10K - 100K
+Predicate,https://schema.org/enginePower-input,< 1K
+Predicate,https://schema.org/enginePower-output,< 1K
+Predicate,https://schema.org/engineType,1K - 10K
+Predicate,https://schema.org/engineType-input,< 1K
+Predicate,https://schema.org/engineType-output,< 1K
+Predicate,https://schema.org/entertainmentBusiness,< 1K
+Predicate,https://schema.org/entertainmentBusiness-input,< 1K
+Predicate,https://schema.org/entertainmentBusiness-output,< 1K
+Predicate,https://schema.org/epidemiology,< 1K
+Predicate,https://schema.org/epidemiology-input,< 1K
+Predicate,https://schema.org/epidemiology-output,< 1K
+Predicate,https://schema.org/episode,1K - 10K
+Predicate,https://schema.org/episode-input,< 1K
+Predicate,https://schema.org/episode-output,< 1K
+Predicate,https://schema.org/episodeNumber,10K - 100K
+Predicate,https://schema.org/episodeNumber-input,< 1K
+Predicate,https://schema.org/episodeNumber-output,< 1K
+Predicate,https://schema.org/episodes,< 1K
+Predicate,https://schema.org/episodes-input,< 1K
+Predicate,https://schema.org/episodes-output,< 1K
+Predicate,https://schema.org/equal,< 1K
+Predicate,https://schema.org/equal-input,< 1K
+Predicate,https://schema.org/equal-output,< 1K
+Predicate,https://schema.org/error,1K - 10K
+Predicate,https://schema.org/error-input,< 1K
+Predicate,https://schema.org/error-output,< 1K
+Predicate,https://schema.org/errorCode,< 1K
+Predicate,https://schema.org/errorCode-input,< 1K
+Predicate,https://schema.org/errorCode-output,< 1K
+Predicate,https://schema.org/estimatedCost,10K - 100K
+Predicate,https://schema.org/estimatedCost-input,< 1K
+Predicate,https://schema.org/estimatedCost-output,< 1K
+Predicate,https://schema.org/estimatedFlightDuration,< 1K
+Predicate,https://schema.org/estimatedFlightDuration-input,< 1K
+Predicate,https://schema.org/estimatedFlightDuration-output,< 1K
+Predicate,https://schema.org/estimatedSalary,1K - 10K
+Predicate,https://schema.org/estimatedSalary-input,< 1K
+Predicate,https://schema.org/estimatedSalary-output,< 1K
+Predicate,https://schema.org/estimatesRiskOf,< 1K
+Predicate,https://schema.org/estimatesRiskOf-input,< 1K
+Predicate,https://schema.org/estimatesRiskOf-output,< 1K
+Predicate,https://schema.org/ethicsPolicy,10K - 100K
+Predicate,https://schema.org/ethicsPolicy-input,< 1K
+Predicate,https://schema.org/ethicsPolicy-output,< 1K
+Predicate,https://schema.org/event,10K - 100K
+Predicate,https://schema.org/event-input,< 1K
+Predicate,https://schema.org/event-output,< 1K
+Predicate,https://schema.org/eventAttendanceMode,100K - 1M
+Predicate,https://schema.org/eventAttendanceMode-input,< 1K
+Predicate,https://schema.org/eventAttendanceMode-output,< 1K
+Predicate,https://schema.org/eventSchedule,1K - 10K
+Predicate,https://schema.org/eventSchedule-input,< 1K
+Predicate,https://schema.org/eventSchedule-output,< 1K
+Predicate,https://schema.org/eventStatus,100K - 1M
+Predicate,https://schema.org/eventStatus-input,< 1K
+Predicate,https://schema.org/eventStatus-output,< 1K
+Predicate,https://schema.org/events,1K - 10K
+Predicate,https://schema.org/events-input,< 1K
+Predicate,https://schema.org/events-output,< 1K
+Predicate,https://schema.org/evidenceLevel,< 1K
+Predicate,https://schema.org/evidenceLevel-input,< 1K
+Predicate,https://schema.org/evidenceLevel-output,< 1K
+Predicate,https://schema.org/evidenceOrigin,< 1K
+Predicate,https://schema.org/evidenceOrigin-input,< 1K
+Predicate,https://schema.org/evidenceOrigin-output,< 1K
+Predicate,https://schema.org/exampleOfWork,1K - 10K
+Predicate,https://schema.org/exampleOfWork-input,< 1K
+Predicate,https://schema.org/exampleOfWork-output,< 1K
+Predicate,https://schema.org/exceptDate,< 1K
+Predicate,https://schema.org/exceptDate-input,< 1K
+Predicate,https://schema.org/exceptDate-output,< 1K
+Predicate,https://schema.org/exchangeRateSpread,< 1K
+Predicate,https://schema.org/exchangeRateSpread-input,< 1K
+Predicate,https://schema.org/exchangeRateSpread-output,< 1K
+Predicate,https://schema.org/executableLibraryName,< 1K
+Predicate,https://schema.org/executableLibraryName-input,< 1K
+Predicate,https://schema.org/executableLibraryName-output,< 1K
+Predicate,https://schema.org/exerciseCourse,< 1K
+Predicate,https://schema.org/exerciseCourse-input,< 1K
+Predicate,https://schema.org/exerciseCourse-output,< 1K
+Predicate,https://schema.org/exercisePlan,< 1K
+Predicate,https://schema.org/exercisePlan-input,< 1K
+Predicate,https://schema.org/exercisePlan-output,< 1K
+Predicate,https://schema.org/exerciseRelatedDiet,< 1K
+Predicate,https://schema.org/exerciseRelatedDiet-input,< 1K
+Predicate,https://schema.org/exerciseRelatedDiet-output,< 1K
+Predicate,https://schema.org/exerciseType,< 1K
+Predicate,https://schema.org/exerciseType-input,< 1K
+Predicate,https://schema.org/exerciseType-output,< 1K
+Predicate,https://schema.org/exifData,1K - 10K
+Predicate,https://schema.org/exifData-input,< 1K
+Predicate,https://schema.org/exifData-output,< 1K
+Predicate,https://schema.org/expectedArrivalFrom,< 1K
+Predicate,https://schema.org/expectedArrivalFrom-input,< 1K
+Predicate,https://schema.org/expectedArrivalFrom-output,< 1K
+Predicate,https://schema.org/expectedArrivalUntil,< 1K
+Predicate,https://schema.org/expectedArrivalUntil-input,< 1K
+Predicate,https://schema.org/expectedArrivalUntil-output,< 1K
+Predicate,https://schema.org/expectedPrognosis,< 1K
+Predicate,https://schema.org/expectedPrognosis-input,< 1K
+Predicate,https://schema.org/expectedPrognosis-output,< 1K
+Predicate,https://schema.org/expectsAcceptanceOf,1K - 10K
+Predicate,https://schema.org/expectsAcceptanceOf-input,< 1K
+Predicate,https://schema.org/expectsAcceptanceOf-output,< 1K
+Predicate,https://schema.org/experienceInPlaceOfEducation,1K - 10K
+Predicate,https://schema.org/experienceInPlaceOfEducation-input,< 1K
+Predicate,https://schema.org/experienceInPlaceOfEducation-output,< 1K
+Predicate,https://schema.org/experienceRequirements,10K - 100K
+Predicate,https://schema.org/experienceRequirements-input,< 1K
+Predicate,https://schema.org/experienceRequirements-output,< 1K
+Predicate,https://schema.org/expertConsiderations,< 1K
+Predicate,https://schema.org/expertConsiderations-input,< 1K
+Predicate,https://schema.org/expertConsiderations-output,< 1K
+Predicate,https://schema.org/expires,1K - 10K
+Predicate,https://schema.org/expires-input,< 1K
+Predicate,https://schema.org/expires-output,< 1K
+Predicate,https://schema.org/expressedIn,< 1K
+Predicate,https://schema.org/expressedIn-input,< 1K
+Predicate,https://schema.org/expressedIn-output,< 1K
+Predicate,https://schema.org/extendedAddress,< 1K
+Predicate,https://schema.org/extendedAddress-input,< 1K
+Predicate,https://schema.org/extendedAddress-output,< 1K
+Predicate,https://schema.org/familyName,100K - 1M
+Predicate,https://schema.org/familyName-input,< 1K
+Predicate,https://schema.org/familyName-output,< 1K
+Predicate,https://schema.org/fatContent,10K - 100K
+Predicate,https://schema.org/fatContent-input,< 1K
+Predicate,https://schema.org/fatContent-output,< 1K
+Predicate,https://schema.org/faxNumber,100K - 1M
+Predicate,https://schema.org/faxNumber-input,< 1K
+Predicate,https://schema.org/faxNumber-output,< 1K
+Predicate,https://schema.org/featureList,100K - 1M
+Predicate,https://schema.org/featureList-input,< 1K
+Predicate,https://schema.org/featureList-output,< 1K
+Predicate,https://schema.org/feesAndCommissionsSpecification,1K - 10K
+Predicate,https://schema.org/feesAndCommissionsSpecification-input,< 1K
+Predicate,https://schema.org/feesAndCommissionsSpecification-output,< 1K
+Predicate,https://schema.org/fiberContent,10K - 100K
+Predicate,https://schema.org/fiberContent-input,< 1K
+Predicate,https://schema.org/fiberContent-output,< 1K
+Predicate,https://schema.org/fileFormat,10K - 100K
+Predicate,https://schema.org/fileFormat-input,< 1K
+Predicate,https://schema.org/fileFormat-output,< 1K
+Predicate,https://schema.org/fileSize,10K - 100K
+Predicate,https://schema.org/fileSize-input,< 1K
+Predicate,https://schema.org/fileSize-output,< 1K
+Predicate,https://schema.org/financialAidEligible,< 1K
+Predicate,https://schema.org/financialAidEligible-input,< 1K
+Predicate,https://schema.org/financialAidEligible-output,< 1K
+Predicate,https://schema.org/firstAppearance,< 1K
+Predicate,https://schema.org/firstAppearance-input,< 1K
+Predicate,https://schema.org/firstAppearance-output,< 1K
+Predicate,https://schema.org/firstPerformance,< 1K
+Predicate,https://schema.org/firstPerformance-input,< 1K
+Predicate,https://schema.org/firstPerformance-output,< 1K
+Predicate,https://schema.org/flightDistance,< 1K
+Predicate,https://schema.org/flightDistance-input,< 1K
+Predicate,https://schema.org/flightDistance-output,< 1K
+Predicate,https://schema.org/flightNumber,< 1K
+Predicate,https://schema.org/flightNumber-input,< 1K
+Predicate,https://schema.org/flightNumber-output,< 1K
+Predicate,https://schema.org/floorLevel,1K - 10K
+Predicate,https://schema.org/floorLevel-input,< 1K
+Predicate,https://schema.org/floorLevel-output,< 1K
+Predicate,https://schema.org/floorLimit,< 1K
+Predicate,https://schema.org/floorLimit-input,< 1K
+Predicate,https://schema.org/floorLimit-output,< 1K
+Predicate,https://schema.org/floorSize,100K - 1M
+Predicate,https://schema.org/floorSize-input,< 1K
+Predicate,https://schema.org/floorSize-output,< 1K
+Predicate,https://schema.org/followee,< 1K
+Predicate,https://schema.org/followee-input,< 1K
+Predicate,https://schema.org/followee-output,< 1K
+Predicate,https://schema.org/follows,< 1K
+Predicate,https://schema.org/follows-input,< 1K
+Predicate,https://schema.org/follows-output,< 1K
+Predicate,https://schema.org/followup,1K - 10K
+Predicate,https://schema.org/followup-input,< 1K
+Predicate,https://schema.org/followup-output,< 1K
+Predicate,https://schema.org/foodEstablishment,< 1K
+Predicate,https://schema.org/foodEstablishment-input,< 1K
+Predicate,https://schema.org/foodEstablishment-output,< 1K
+Predicate,https://schema.org/foodEvent,< 1K
+Predicate,https://schema.org/foodEvent-input,< 1K
+Predicate,https://schema.org/foodEvent-output,< 1K
+Predicate,https://schema.org/foodWarning,< 1K
+Predicate,https://schema.org/foodWarning-input,< 1K
+Predicate,https://schema.org/foodWarning-output,< 1K
+Predicate,https://schema.org/founder,100K - 1M
+Predicate,https://schema.org/founder-input,< 1K
+Predicate,https://schema.org/founder-output,< 1K
+Predicate,https://schema.org/founders,10K - 100K
+Predicate,https://schema.org/founders-input,< 1K
+Predicate,https://schema.org/founders-output,< 1K
+Predicate,https://schema.org/foundingDate,1M - 10M
+Predicate,https://schema.org/foundingDate-input,< 1K
+Predicate,https://schema.org/foundingDate-output,< 1K
+Predicate,https://schema.org/foundingLocation,100K - 1M
+Predicate,https://schema.org/foundingLocation-input,< 1K
+Predicate,https://schema.org/foundingLocation-output,< 1K
+Predicate,https://schema.org/free,1K - 10K
+Predicate,https://schema.org/free-input,< 1K
+Predicate,https://schema.org/free-output,< 1K
+Predicate,https://schema.org/freeShippingThreshold,10K - 100K
+Predicate,https://schema.org/freeShippingThreshold-input,< 1K
+Predicate,https://schema.org/freeShippingThreshold-output,< 1K
+Predicate,https://schema.org/frequency,< 1K
+Predicate,https://schema.org/frequency-input,< 1K
+Predicate,https://schema.org/frequency-output,< 1K
+Predicate,https://schema.org/fromLocation,1K - 10K
+Predicate,https://schema.org/fromLocation-input,< 1K
+Predicate,https://schema.org/fromLocation-output,< 1K
+Predicate,https://schema.org/fuelCapacity,1K - 10K
+Predicate,https://schema.org/fuelCapacity-input,< 1K
+Predicate,https://schema.org/fuelCapacity-output,< 1K
+Predicate,https://schema.org/fuelConsumption,1K - 10K
+Predicate,https://schema.org/fuelConsumption-input,< 1K
+Predicate,https://schema.org/fuelConsumption-output,< 1K
+Predicate,https://schema.org/fuelEfficiency,10K - 100K
+Predicate,https://schema.org/fuelEfficiency-input,< 1K
+Predicate,https://schema.org/fuelEfficiency-output,< 1K
+Predicate,https://schema.org/fuelType,10K - 100K
+Predicate,https://schema.org/fuelType-input,< 1K
+Predicate,https://schema.org/fuelType-output,< 1K
+Predicate,https://schema.org/fulfillmentType,10K - 100K
+Predicate,https://schema.org/fulfillmentType-input,< 1K
+Predicate,https://schema.org/fulfillmentType-output,< 1K
+Predicate,https://schema.org/functionalClass,< 1K
+Predicate,https://schema.org/functionalClass-input,< 1K
+Predicate,https://schema.org/functionalClass-output,< 1K
+Predicate,https://schema.org/fundedItem,< 1K
+Predicate,https://schema.org/fundedItem-input,< 1K
+Predicate,https://schema.org/fundedItem-output,< 1K
+Predicate,https://schema.org/funder,10K - 100K
+Predicate,https://schema.org/funder-input,< 1K
+Predicate,https://schema.org/funder-output,< 1K
+Predicate,https://schema.org/funding,1K - 10K
+Predicate,https://schema.org/funding-input,< 1K
+Predicate,https://schema.org/funding-output,< 1K
+Predicate,https://schema.org/game,10K - 100K
+Predicate,https://schema.org/game-input,< 1K
+Predicate,https://schema.org/game-output,< 1K
+Predicate,https://schema.org/gameAvailabilityType,< 1K
+Predicate,https://schema.org/gameAvailabilityType-input,< 1K
+Predicate,https://schema.org/gameAvailabilityType-output,< 1K
+Predicate,https://schema.org/gameEdition,< 1K
+Predicate,https://schema.org/gameEdition-input,< 1K
+Predicate,https://schema.org/gameEdition-output,< 1K
+Predicate,https://schema.org/gameItem,10K - 100K
+Predicate,https://schema.org/gameItem-input,< 1K
+Predicate,https://schema.org/gameItem-output,< 1K
+Predicate,https://schema.org/gameLocation,10K - 100K
+Predicate,https://schema.org/gameLocation-input,< 1K
+Predicate,https://schema.org/gameLocation-output,< 1K
+Predicate,https://schema.org/gamePlatform,10K - 100K
+Predicate,https://schema.org/gamePlatform-input,< 1K
+Predicate,https://schema.org/gamePlatform-output,< 1K
+Predicate,https://schema.org/gameServer,< 1K
+Predicate,https://schema.org/gameServer-input,< 1K
+Predicate,https://schema.org/gameServer-output,< 1K
+Predicate,https://schema.org/gameTip,< 1K
+Predicate,https://schema.org/gameTip-input,< 1K
+Predicate,https://schema.org/gameTip-output,< 1K
+Predicate,https://schema.org/gender,10K - 100K
+Predicate,https://schema.org/gender-input,< 1K
+Predicate,https://schema.org/gender-output,< 1K
+Predicate,https://schema.org/genre,100K - 1M
+Predicate,https://schema.org/genre-input,< 1K
+Predicate,https://schema.org/genre-output,< 1K
+Predicate,https://schema.org/geo,1M - 10M
+Predicate,https://schema.org/geo-input,< 1K
+Predicate,https://schema.org/geo-output,< 1K
+Predicate,https://schema.org/geoContains,< 1K
+Predicate,https://schema.org/geoContains-input,< 1K
+Predicate,https://schema.org/geoContains-output,< 1K
+Predicate,https://schema.org/geoCoveredBy,< 1K
+Predicate,https://schema.org/geoCoveredBy-input,< 1K
+Predicate,https://schema.org/geoCoveredBy-output,< 1K
+Predicate,https://schema.org/geoCovers,< 1K
+Predicate,https://schema.org/geoCovers-input,< 1K
+Predicate,https://schema.org/geoCovers-output,< 1K
+Predicate,https://schema.org/geoCrosses,< 1K
+Predicate,https://schema.org/geoCrosses-input,< 1K
+Predicate,https://schema.org/geoCrosses-output,< 1K
+Predicate,https://schema.org/geoDisjoint,< 1K
+Predicate,https://schema.org/geoDisjoint-input,< 1K
+Predicate,https://schema.org/geoDisjoint-output,< 1K
+Predicate,https://schema.org/geoEquals,< 1K
+Predicate,https://schema.org/geoEquals-input,< 1K
+Predicate,https://schema.org/geoEquals-output,< 1K
+Predicate,https://schema.org/geoIntersects,< 1K
+Predicate,https://schema.org/geoIntersects-input,< 1K
+Predicate,https://schema.org/geoIntersects-output,< 1K
+Predicate,https://schema.org/geoMidpoint,100K - 1M
+Predicate,https://schema.org/geoMidpoint-input,< 1K
+Predicate,https://schema.org/geoMidpoint-output,< 1K
+Predicate,https://schema.org/geoOverlaps,< 1K
+Predicate,https://schema.org/geoOverlaps-input,< 1K
+Predicate,https://schema.org/geoOverlaps-output,< 1K
+Predicate,https://schema.org/geoRadius,100K - 1M
+Predicate,https://schema.org/geoRadius-input,< 1K
+Predicate,https://schema.org/geoRadius-output,< 1K
+Predicate,https://schema.org/geoTouches,< 1K
+Predicate,https://schema.org/geoTouches-input,< 1K
+Predicate,https://schema.org/geoTouches-output,< 1K
+Predicate,https://schema.org/geoWithin,< 1K
+Predicate,https://schema.org/geoWithin-input,< 1K
+Predicate,https://schema.org/geoWithin-output,< 1K
+Predicate,https://schema.org/geographicArea,10K - 100K
+Predicate,https://schema.org/geographicArea-input,< 1K
+Predicate,https://schema.org/geographicArea-output,< 1K
+Predicate,https://schema.org/gettingTestedInfo,< 1K
+Predicate,https://schema.org/gettingTestedInfo-input,< 1K
+Predicate,https://schema.org/gettingTestedInfo-output,< 1K
+Predicate,https://schema.org/givenName,100K - 1M
+Predicate,https://schema.org/givenName-input,< 1K
+Predicate,https://schema.org/givenName-output,< 1K
+Predicate,https://schema.org/globalLocationNumber,1K - 10K
+Predicate,https://schema.org/globalLocationNumber-input,< 1K
+Predicate,https://schema.org/globalLocationNumber-output,< 1K
+Predicate,https://schema.org/governmentBenefitsInfo,< 1K
+Predicate,https://schema.org/governmentBenefitsInfo-input,< 1K
+Predicate,https://schema.org/governmentBenefitsInfo-output,< 1K
+Predicate,https://schema.org/gracePeriod,< 1K
+Predicate,https://schema.org/gracePeriod-input,< 1K
+Predicate,https://schema.org/gracePeriod-output,< 1K
+Predicate,https://schema.org/grantee,< 1K
+Predicate,https://schema.org/grantee-input,< 1K
+Predicate,https://schema.org/grantee-output,< 1K
+Predicate,https://schema.org/greater,< 1K
+Predicate,https://schema.org/greater-input,< 1K
+Predicate,https://schema.org/greater-output,< 1K
+Predicate,https://schema.org/greaterOrEqual,< 1K
+Predicate,https://schema.org/greaterOrEqual-input,< 1K
+Predicate,https://schema.org/greaterOrEqual-output,< 1K
+Predicate,https://schema.org/gtin,100K - 1M
+Predicate,https://schema.org/gtin-input,< 1K
+Predicate,https://schema.org/gtin-output,< 1K
+Predicate,https://schema.org/gtin12,100K - 1M
+Predicate,https://schema.org/gtin12-input,< 1K
+Predicate,https://schema.org/gtin12-output,< 1K
+Predicate,https://schema.org/gtin13,100K - 1M
+Predicate,https://schema.org/gtin13-input,< 1K
+Predicate,https://schema.org/gtin13-output,< 1K
+Predicate,https://schema.org/gtin14,10K - 100K
+Predicate,https://schema.org/gtin14-input,< 1K
+Predicate,https://schema.org/gtin14-output,< 1K
+Predicate,https://schema.org/gtin8,10K - 100K
+Predicate,https://schema.org/gtin8-input,< 1K
+Predicate,https://schema.org/gtin8-output,< 1K
+Predicate,https://schema.org/guideline,< 1K
+Predicate,https://schema.org/guideline-input,< 1K
+Predicate,https://schema.org/guideline-output,< 1K
+Predicate,https://schema.org/guidelineDate,< 1K
+Predicate,https://schema.org/guidelineDate-input,< 1K
+Predicate,https://schema.org/guidelineDate-output,< 1K
+Predicate,https://schema.org/guidelineSubject,< 1K
+Predicate,https://schema.org/guidelineSubject-input,< 1K
+Predicate,https://schema.org/guidelineSubject-output,< 1K
+Predicate,https://schema.org/handlingTime,100K - 1M
+Predicate,https://schema.org/handlingTime-input,< 1K
+Predicate,https://schema.org/handlingTime-output,< 1K
+Predicate,https://schema.org/hasAdultConsideration,< 1K
+Predicate,https://schema.org/hasAdultConsideration-input,< 1K
+Predicate,https://schema.org/hasAdultConsideration-output,< 1K
+Predicate,https://schema.org/hasBioChemEntityPart,< 1K
+Predicate,https://schema.org/hasBioChemEntityPart-input,< 1K
+Predicate,https://schema.org/hasBioChemEntityPart-output,< 1K
+Predicate,https://schema.org/hasBioPolymerSequence,< 1K
+Predicate,https://schema.org/hasBioPolymerSequence-input,< 1K
+Predicate,https://schema.org/hasBioPolymerSequence-output,< 1K
+Predicate,https://schema.org/hasBroadcastChannel,< 1K
+Predicate,https://schema.org/hasBroadcastChannel-input,< 1K
+Predicate,https://schema.org/hasBroadcastChannel-output,< 1K
+Predicate,https://schema.org/hasCategoryCode,< 1K
+Predicate,https://schema.org/hasCategoryCode-input,< 1K
+Predicate,https://schema.org/hasCategoryCode-output,< 1K
+Predicate,https://schema.org/hasCertification,1K - 10K
+Predicate,https://schema.org/hasCertification-input,< 1K
+Predicate,https://schema.org/hasCertification-output,< 1K
+Predicate,https://schema.org/hasCourse,1K - 10K
+Predicate,https://schema.org/hasCourse-input,< 1K
+Predicate,https://schema.org/hasCourse-output,< 1K
+Predicate,https://schema.org/hasCourseInstance,10K - 100K
+Predicate,https://schema.org/hasCourseInstance-input,< 1K
+Predicate,https://schema.org/hasCourseInstance-output,< 1K
+Predicate,https://schema.org/hasCredential,100K - 1M
+Predicate,https://schema.org/hasCredential-input,< 1K
+Predicate,https://schema.org/hasCredential-output,< 1K
+Predicate,https://schema.org/hasDefinedTerm,10K - 100K
+Predicate,https://schema.org/hasDefinedTerm-input,< 1K
+Predicate,https://schema.org/hasDefinedTerm-output,< 1K
+Predicate,https://schema.org/hasDeliveryMethod,< 1K
+Predicate,https://schema.org/hasDeliveryMethod-input,< 1K
+Predicate,https://schema.org/hasDeliveryMethod-output,< 1K
+Predicate,https://schema.org/hasDigitalDocumentPermission,< 1K
+Predicate,https://schema.org/hasDigitalDocumentPermission-input,< 1K
+Predicate,https://schema.org/hasDigitalDocumentPermission-output,< 1K
+Predicate,https://schema.org/hasDriveThroughService,< 1K
+Predicate,https://schema.org/hasDriveThroughService-input,< 1K
+Predicate,https://schema.org/hasDriveThroughService-output,< 1K
+Predicate,https://schema.org/hasEnergyConsumptionDetails,1K - 10K
+Predicate,https://schema.org/hasEnergyConsumptionDetails-input,< 1K
+Predicate,https://schema.org/hasEnergyConsumptionDetails-output,< 1K
+Predicate,https://schema.org/hasEnergyEfficiencyCategory,1K - 10K
+Predicate,https://schema.org/hasEnergyEfficiencyCategory-input,< 1K
+Predicate,https://schema.org/hasEnergyEfficiencyCategory-output,< 1K
+Predicate,https://schema.org/hasGS1DigitalLink,< 1K
+Predicate,https://schema.org/hasGS1DigitalLink-input,< 1K
+Predicate,https://schema.org/hasGS1DigitalLink-output,< 1K
+Predicate,https://schema.org/hasHealthAspect,< 1K
+Predicate,https://schema.org/hasHealthAspect-input,< 1K
+Predicate,https://schema.org/hasHealthAspect-output,< 1K
+Predicate,https://schema.org/hasMap,100K - 1M
+Predicate,https://schema.org/hasMap-input,< 1K
+Predicate,https://schema.org/hasMap-output,< 1K
+Predicate,https://schema.org/hasMeasurement,1K - 10K
+Predicate,https://schema.org/hasMeasurement-input,< 1K
+Predicate,https://schema.org/hasMeasurement-output,< 1K
+Predicate,https://schema.org/hasMemberProgram,1K - 10K
+Predicate,https://schema.org/hasMemberProgram-input,< 1K
+Predicate,https://schema.org/hasMemberProgram-output,< 1K
+Predicate,https://schema.org/hasMenu,10K - 100K
+Predicate,https://schema.org/hasMenu-input,< 1K
+Predicate,https://schema.org/hasMenu-output,< 1K
+Predicate,https://schema.org/hasMenuItem,10K - 100K
+Predicate,https://schema.org/hasMenuItem-input,< 1K
+Predicate,https://schema.org/hasMenuItem-output,< 1K
+Predicate,https://schema.org/hasMenuSection,10K - 100K
+Predicate,https://schema.org/hasMenuSection-input,< 1K
+Predicate,https://schema.org/hasMenuSection-output,< 1K
+Predicate,https://schema.org/hasMerchantReturnPolicy,100K - 1M
+Predicate,https://schema.org/hasMerchantReturnPolicy-input,< 1K
+Predicate,https://schema.org/hasMerchantReturnPolicy-output,< 1K
+Predicate,https://schema.org/hasMolecularFunction,< 1K
+Predicate,https://schema.org/hasMolecularFunction-input,< 1K
+Predicate,https://schema.org/hasMolecularFunction-output,< 1K
+Predicate,https://schema.org/hasOccupation,10K - 100K
+Predicate,https://schema.org/hasOccupation-input,< 1K
+Predicate,https://schema.org/hasOccupation-output,< 1K
+Predicate,https://schema.org/hasOfferCatalog,100K - 1M
+Predicate,https://schema.org/hasOfferCatalog-input,< 1K
+Predicate,https://schema.org/hasOfferCatalog-output,< 1K
+Predicate,https://schema.org/hasPOS,1K - 10K
+Predicate,https://schema.org/hasPOS-input,< 1K
+Predicate,https://schema.org/hasPOS-output,< 1K
+Predicate,https://schema.org/hasPart,100K - 1M
+Predicate,https://schema.org/hasPart-input,< 1K
+Predicate,https://schema.org/hasPart-output,< 1K
+Predicate,https://schema.org/hasParticipationOffer,< 1K
+Predicate,https://schema.org/hasParticipationOffer-input,< 1K
+Predicate,https://schema.org/hasParticipationOffer-output,< 1K
+Predicate,https://schema.org/hasProductReturnPolicy,< 1K
+Predicate,https://schema.org/hasProductReturnPolicy-input,< 1K
+Predicate,https://schema.org/hasProductReturnPolicy-output,< 1K
+Predicate,https://schema.org/hasRepresentation,< 1K
+Predicate,https://schema.org/hasRepresentation-input,< 1K
+Predicate,https://schema.org/hasRepresentation-output,< 1K
+Predicate,https://schema.org/hasShippingService,10K - 100K
+Predicate,https://schema.org/hasShippingService-input,< 1K
+Predicate,https://schema.org/hasShippingService-output,< 1K
+Predicate,https://schema.org/hasSponsorshipOffer,< 1K
+Predicate,https://schema.org/hasSponsorshipOffer-input,< 1K
+Predicate,https://schema.org/hasSponsorshipOffer-output,< 1K
+Predicate,https://schema.org/hasStore,< 1K
+Predicate,https://schema.org/hasStore-input,< 1K
+Predicate,https://schema.org/hasStore-output,< 1K
+Predicate,https://schema.org/hasTierBenefit,1K - 10K
+Predicate,https://schema.org/hasTierBenefit-input,< 1K
+Predicate,https://schema.org/hasTierBenefit-output,< 1K
+Predicate,https://schema.org/hasTierRequirement,< 1K
+Predicate,https://schema.org/hasTierRequirement-input,< 1K
+Predicate,https://schema.org/hasTierRequirement-output,< 1K
+Predicate,https://schema.org/hasTiers,1K - 10K
+Predicate,https://schema.org/hasTiers-input,< 1K
+Predicate,https://schema.org/hasTiers-output,< 1K
+Predicate,https://schema.org/hasVariant,100K - 1M
+Predicate,https://schema.org/hasVariant-input,< 1K
+Predicate,https://schema.org/hasVariant-output,< 1K
+Predicate,https://schema.org/headline,10M+
+Predicate,https://schema.org/headline-input,< 1K
+Predicate,https://schema.org/headline-output,< 1K
+Predicate,https://schema.org/healthCondition,1K - 10K
+Predicate,https://schema.org/healthCondition-input,< 1K
+Predicate,https://schema.org/healthCondition-output,< 1K
+Predicate,https://schema.org/healthPlanCoinsuranceOption,< 1K
+Predicate,https://schema.org/healthPlanCoinsuranceOption-input,< 1K
+Predicate,https://schema.org/healthPlanCoinsuranceOption-output,< 1K
+Predicate,https://schema.org/healthPlanCoinsuranceRate,< 1K
+Predicate,https://schema.org/healthPlanCoinsuranceRate-input,< 1K
+Predicate,https://schema.org/healthPlanCoinsuranceRate-output,< 1K
+Predicate,https://schema.org/healthPlanCopay,< 1K
+Predicate,https://schema.org/healthPlanCopay-input,< 1K
+Predicate,https://schema.org/healthPlanCopay-output,< 1K
+Predicate,https://schema.org/healthPlanCopayOption,< 1K
+Predicate,https://schema.org/healthPlanCopayOption-input,< 1K
+Predicate,https://schema.org/healthPlanCopayOption-output,< 1K
+Predicate,https://schema.org/healthPlanCostSharing,< 1K
+Predicate,https://schema.org/healthPlanCostSharing-input,< 1K
+Predicate,https://schema.org/healthPlanCostSharing-output,< 1K
+Predicate,https://schema.org/healthPlanDrugOption,< 1K
+Predicate,https://schema.org/healthPlanDrugOption-input,< 1K
+Predicate,https://schema.org/healthPlanDrugOption-output,< 1K
+Predicate,https://schema.org/healthPlanDrugTier,< 1K
+Predicate,https://schema.org/healthPlanDrugTier-input,< 1K
+Predicate,https://schema.org/healthPlanDrugTier-output,< 1K
+Predicate,https://schema.org/healthPlanId,< 1K
+Predicate,https://schema.org/healthPlanId-input,< 1K
+Predicate,https://schema.org/healthPlanId-output,< 1K
+Predicate,https://schema.org/healthPlanMarketingUrl,< 1K
+Predicate,https://schema.org/healthPlanMarketingUrl-input,< 1K
+Predicate,https://schema.org/healthPlanMarketingUrl-output,< 1K
+Predicate,https://schema.org/healthPlanNetworkId,< 1K
+Predicate,https://schema.org/healthPlanNetworkId-input,< 1K
+Predicate,https://schema.org/healthPlanNetworkId-output,< 1K
+Predicate,https://schema.org/healthPlanNetworkTier,< 1K
+Predicate,https://schema.org/healthPlanNetworkTier-input,< 1K
+Predicate,https://schema.org/healthPlanNetworkTier-output,< 1K
+Predicate,https://schema.org/healthPlanPharmacyCategory,< 1K
+Predicate,https://schema.org/healthPlanPharmacyCategory-input,< 1K
+Predicate,https://schema.org/healthPlanPharmacyCategory-output,< 1K
+Predicate,https://schema.org/healthcareReportingData,< 1K
+Predicate,https://schema.org/healthcareReportingData-input,< 1K
+Predicate,https://schema.org/healthcareReportingData-output,< 1K
+Predicate,https://schema.org/height,10M+
+Predicate,https://schema.org/height-input,< 1K
+Predicate,https://schema.org/height-output,< 1K
+Predicate,https://schema.org/highPrice,1M - 10M
+Predicate,https://schema.org/highPrice-input,< 1K
+Predicate,https://schema.org/highPrice-output,< 1K
+Predicate,https://schema.org/hiringOrganization,100K - 1M
+Predicate,https://schema.org/hiringOrganization-input,< 1K
+Predicate,https://schema.org/hiringOrganization-output,< 1K
+Predicate,https://schema.org/holdingArchive,< 1K
+Predicate,https://schema.org/holdingArchive-input,< 1K
+Predicate,https://schema.org/holdingArchive-output,< 1K
+Predicate,https://schema.org/homeLocation,10K - 100K
+Predicate,https://schema.org/homeLocation-input,< 1K
+Predicate,https://schema.org/homeLocation-output,< 1K
+Predicate,https://schema.org/homeTeam,10K - 100K
+Predicate,https://schema.org/homeTeam-input,< 1K
+Predicate,https://schema.org/homeTeam-output,< 1K
+Predicate,https://schema.org/honorificPrefix,10K - 100K
+Predicate,https://schema.org/honorificPrefix-input,< 1K
+Predicate,https://schema.org/honorificPrefix-output,< 1K
+Predicate,https://schema.org/honorificSuffix,10K - 100K
+Predicate,https://schema.org/honorificSuffix-input,< 1K
+Predicate,https://schema.org/honorificSuffix-output,< 1K
+Predicate,https://schema.org/hospitalAffiliation,1K - 10K
+Predicate,https://schema.org/hospitalAffiliation-input,< 1K
+Predicate,https://schema.org/hospitalAffiliation-output,< 1K
+Predicate,https://schema.org/hostingOrganization,1K - 10K
+Predicate,https://schema.org/hostingOrganization-input,< 1K
+Predicate,https://schema.org/hostingOrganization-output,< 1K
+Predicate,https://schema.org/hoursAvailable,100K - 1M
+Predicate,https://schema.org/hoursAvailable-input,< 1K
+Predicate,https://schema.org/hoursAvailable-output,< 1K
+Predicate,https://schema.org/howPerformed,1K - 10K
+Predicate,https://schema.org/howPerformed-input,< 1K
+Predicate,https://schema.org/howPerformed-output,< 1K
+Predicate,https://schema.org/httpMethod,1K - 10K
+Predicate,https://schema.org/httpMethod-input,< 1K
+Predicate,https://schema.org/httpMethod-output,< 1K
+Predicate,https://schema.org/iataCode,1K - 10K
+Predicate,https://schema.org/iataCode-input,< 1K
+Predicate,https://schema.org/iataCode-output,< 1K
+Predicate,https://schema.org/icaoCode,1K - 10K
+Predicate,https://schema.org/icaoCode-input,< 1K
+Predicate,https://schema.org/icaoCode-output,< 1K
+Predicate,https://schema.org/identifier,100K - 1M
+Predicate,https://schema.org/identifier-input,< 1K
+Predicate,https://schema.org/identifier-output,< 1K
+Predicate,https://schema.org/identifyingExam,< 1K
+Predicate,https://schema.org/identifyingExam-input,< 1K
+Predicate,https://schema.org/identifyingExam-output,< 1K
+Predicate,https://schema.org/identifyingTest,< 1K
+Predicate,https://schema.org/identifyingTest-input,< 1K
+Predicate,https://schema.org/identifyingTest-output,< 1K
+Predicate,https://schema.org/illustrator,1K - 10K
+Predicate,https://schema.org/illustrator-input,< 1K
+Predicate,https://schema.org/illustrator-output,< 1K
+Predicate,https://schema.org/image,10M+
+Predicate,https://schema.org/image-input,< 1K
+Predicate,https://schema.org/image-output,< 1K
+Predicate,https://schema.org/imagingTechnique,< 1K
+Predicate,https://schema.org/imagingTechnique-input,< 1K
+Predicate,https://schema.org/imagingTechnique-output,< 1K
+Predicate,https://schema.org/inAlbum,10K - 100K
+Predicate,https://schema.org/inAlbum-input,< 1K
+Predicate,https://schema.org/inAlbum-output,< 1K
+Predicate,https://schema.org/inBroadcastLineup,< 1K
+Predicate,https://schema.org/inBroadcastLineup-input,< 1K
+Predicate,https://schema.org/inBroadcastLineup-output,< 1K
+Predicate,https://schema.org/inChI,< 1K
+Predicate,https://schema.org/inChI-input,< 1K
+Predicate,https://schema.org/inChI-output,< 1K
+Predicate,https://schema.org/inChIKey,< 1K
+Predicate,https://schema.org/inChIKey-input,< 1K
+Predicate,https://schema.org/inChIKey-output,< 1K
+Predicate,https://schema.org/inCodeSet,1K - 10K
+Predicate,https://schema.org/inCodeSet-input,< 1K
+Predicate,https://schema.org/inCodeSet-output,< 1K
+Predicate,https://schema.org/inDefinedTermSet,10K - 100K
+Predicate,https://schema.org/inDefinedTermSet-input,< 1K
+Predicate,https://schema.org/inDefinedTermSet-output,< 1K
+Predicate,https://schema.org/inLanguage,10M+
+Predicate,https://schema.org/inLanguage-input,< 1K
+Predicate,https://schema.org/inLanguage-output,< 1K
+Predicate,https://schema.org/inPlaylist,< 1K
+Predicate,https://schema.org/inPlaylist-input,< 1K
+Predicate,https://schema.org/inPlaylist-output,< 1K
+Predicate,https://schema.org/inProductGroupWithID,10K - 100K
+Predicate,https://schema.org/inProductGroupWithID-input,< 1K
+Predicate,https://schema.org/inProductGroupWithID-output,< 1K
+Predicate,https://schema.org/inStoreReturnsOffered,1K - 10K
+Predicate,https://schema.org/inStoreReturnsOffered-input,< 1K
+Predicate,https://schema.org/inStoreReturnsOffered-output,< 1K
+Predicate,https://schema.org/inSupportOf,< 1K
+Predicate,https://schema.org/inSupportOf-input,< 1K
+Predicate,https://schema.org/inSupportOf-output,< 1K
+Predicate,https://schema.org/incentiveAmount,< 1K
+Predicate,https://schema.org/incentiveAmount-input,< 1K
+Predicate,https://schema.org/incentiveAmount-output,< 1K
+Predicate,https://schema.org/incentiveCompensation,1K - 10K
+Predicate,https://schema.org/incentiveCompensation-input,< 1K
+Predicate,https://schema.org/incentiveCompensation-output,< 1K
+Predicate,https://schema.org/incentiveStatus,< 1K
+Predicate,https://schema.org/incentiveStatus-input,< 1K
+Predicate,https://schema.org/incentiveStatus-output,< 1K
+Predicate,https://schema.org/incentiveType,< 1K
+Predicate,https://schema.org/incentiveType-input,< 1K
+Predicate,https://schema.org/incentiveType-output,< 1K
+Predicate,https://schema.org/incentives,< 1K
+Predicate,https://schema.org/incentives-input,< 1K
+Predicate,https://schema.org/incentives-output,< 1K
+Predicate,https://schema.org/incentivizedItem,< 1K
+Predicate,https://schema.org/incentivizedItem-input,< 1K
+Predicate,https://schema.org/incentivizedItem-output,< 1K
+Predicate,https://schema.org/includedComposition,< 1K
+Predicate,https://schema.org/includedComposition-input,< 1K
+Predicate,https://schema.org/includedComposition-output,< 1K
+Predicate,https://schema.org/includedDataCatalog,< 1K
+Predicate,https://schema.org/includedDataCatalog-input,< 1K
+Predicate,https://schema.org/includedDataCatalog-output,< 1K
+Predicate,https://schema.org/includedInDataCatalog,1K - 10K
+Predicate,https://schema.org/includedInDataCatalog-input,< 1K
+Predicate,https://schema.org/includedInDataCatalog-output,< 1K
+Predicate,https://schema.org/includedInHealthInsurancePlan,< 1K
+Predicate,https://schema.org/includedInHealthInsurancePlan-input,< 1K
+Predicate,https://schema.org/includedInHealthInsurancePlan-output,< 1K
+Predicate,https://schema.org/includedRiskFactor,< 1K
+Predicate,https://schema.org/includedRiskFactor-input,< 1K
+Predicate,https://schema.org/includedRiskFactor-output,< 1K
+Predicate,https://schema.org/includesAttraction,1K - 10K
+Predicate,https://schema.org/includesAttraction-input,< 1K
+Predicate,https://schema.org/includesAttraction-output,< 1K
+Predicate,https://schema.org/includesHealthPlanFormulary,< 1K
+Predicate,https://schema.org/includesHealthPlanFormulary-input,< 1K
+Predicate,https://schema.org/includesHealthPlanFormulary-output,< 1K
+Predicate,https://schema.org/includesHealthPlanNetwork,< 1K
+Predicate,https://schema.org/includesHealthPlanNetwork-input,< 1K
+Predicate,https://schema.org/includesHealthPlanNetwork-output,< 1K
+Predicate,https://schema.org/includesObject,1K - 10K
+Predicate,https://schema.org/includesObject-input,< 1K
+Predicate,https://schema.org/includesObject-output,< 1K
+Predicate,https://schema.org/incomeLimit,< 1K
+Predicate,https://schema.org/incomeLimit-input,< 1K
+Predicate,https://schema.org/incomeLimit-output,< 1K
+Predicate,https://schema.org/increasesRiskOf,< 1K
+Predicate,https://schema.org/increasesRiskOf-input,< 1K
+Predicate,https://schema.org/increasesRiskOf-output,< 1K
+Predicate,https://schema.org/industry,10K - 100K
+Predicate,https://schema.org/industry-input,< 1K
+Predicate,https://schema.org/industry-output,< 1K
+Predicate,https://schema.org/ineligibleRegion,< 1K
+Predicate,https://schema.org/ineligibleRegion-input,< 1K
+Predicate,https://schema.org/ineligibleRegion-output,< 1K
+Predicate,https://schema.org/infectiousAgent,< 1K
+Predicate,https://schema.org/infectiousAgent-input,< 1K
+Predicate,https://schema.org/infectiousAgent-output,< 1K
+Predicate,https://schema.org/infectiousAgentClass,< 1K
+Predicate,https://schema.org/infectiousAgentClass-input,< 1K
+Predicate,https://schema.org/infectiousAgentClass-output,< 1K
+Predicate,https://schema.org/ingredients,1K - 10K
+Predicate,https://schema.org/ingredients-input,< 1K
+Predicate,https://schema.org/ingredients-output,< 1K
+Predicate,https://schema.org/inker,< 1K
+Predicate,https://schema.org/inker-input,< 1K
+Predicate,https://schema.org/inker-output,< 1K
+Predicate,https://schema.org/insertion,< 1K
+Predicate,https://schema.org/insertion-input,< 1K
+Predicate,https://schema.org/insertion-output,< 1K
+Predicate,https://schema.org/installUrl,100K - 1M
+Predicate,https://schema.org/installUrl-input,< 1K
+Predicate,https://schema.org/installUrl-output,< 1K
+Predicate,https://schema.org/instructor,10K - 100K
+Predicate,https://schema.org/instructor-input,< 1K
+Predicate,https://schema.org/instructor-output,< 1K
+Predicate,https://schema.org/instrument,1K - 10K
+Predicate,https://schema.org/instrument-input,< 1K
+Predicate,https://schema.org/instrument-output,< 1K
+Predicate,https://schema.org/intensity,< 1K
+Predicate,https://schema.org/intensity-input,< 1K
+Predicate,https://schema.org/intensity-output,< 1K
+Predicate,https://schema.org/interactingDrug,< 1K
+Predicate,https://schema.org/interactingDrug-input,< 1K
+Predicate,https://schema.org/interactingDrug-output,< 1K
+Predicate,https://schema.org/interactionCount,100K - 1M
+Predicate,https://schema.org/interactionCount-input,< 1K
+Predicate,https://schema.org/interactionCount-output,< 1K
+Predicate,https://schema.org/interactionService,< 1K
+Predicate,https://schema.org/interactionService-input,< 1K
+Predicate,https://schema.org/interactionService-output,< 1K
+Predicate,https://schema.org/interactionStatistic,100K - 1M
+Predicate,https://schema.org/interactionStatistic-input,< 1K
+Predicate,https://schema.org/interactionStatistic-output,< 1K
+Predicate,https://schema.org/interactionType,100K - 1M
+Predicate,https://schema.org/interactionType-input,< 1K
+Predicate,https://schema.org/interactionType-output,< 1K
+Predicate,https://schema.org/interactivityType,1K - 10K
+Predicate,https://schema.org/interactivityType-input,< 1K
+Predicate,https://schema.org/interactivityType-output,< 1K
+Predicate,https://schema.org/interestRate,1K - 10K
+Predicate,https://schema.org/interestRate-input,< 1K
+Predicate,https://schema.org/interestRate-output,< 1K
+Predicate,https://schema.org/interpretedAsClaim,< 1K
+Predicate,https://schema.org/interpretedAsClaim-input,< 1K
+Predicate,https://schema.org/interpretedAsClaim-output,< 1K
+Predicate,https://schema.org/inventoryLevel,100K - 1M
+Predicate,https://schema.org/inventoryLevel-input,< 1K
+Predicate,https://schema.org/inventoryLevel-output,< 1K
+Predicate,https://schema.org/inverseOf,< 1K
+Predicate,https://schema.org/inverseOf-input,< 1K
+Predicate,https://schema.org/inverseOf-output,< 1K
+Predicate,https://schema.org/isAcceptingNewPatients,10K - 100K
+Predicate,https://schema.org/isAcceptingNewPatients-input,< 1K
+Predicate,https://schema.org/isAcceptingNewPatients-output,< 1K
+Predicate,https://schema.org/isAccessibleForFree,100K - 1M
+Predicate,https://schema.org/isAccessibleForFree-input,< 1K
+Predicate,https://schema.org/isAccessibleForFree-output,< 1K
+Predicate,https://schema.org/isAccessoryOrSparePartFor,1K - 10K
+Predicate,https://schema.org/isAccessoryOrSparePartFor-input,< 1K
+Predicate,https://schema.org/isAccessoryOrSparePartFor-output,< 1K
+Predicate,https://schema.org/isAvailableGenerically,< 1K
+Predicate,https://schema.org/isAvailableGenerically-input,< 1K
+Predicate,https://schema.org/isAvailableGenerically-output,< 1K
+Predicate,https://schema.org/isBasedOn,10K - 100K
+Predicate,https://schema.org/isBasedOn-input,< 1K
+Predicate,https://schema.org/isBasedOn-output,< 1K
+Predicate,https://schema.org/isBasedOnUrl,< 1K
+Predicate,https://schema.org/isBasedOnUrl-input,< 1K
+Predicate,https://schema.org/isBasedOnUrl-output,< 1K
+Predicate,https://schema.org/isConsumableFor,< 1K
+Predicate,https://schema.org/isConsumableFor-input,< 1K
+Predicate,https://schema.org/isConsumableFor-output,< 1K
+Predicate,https://schema.org/isEncodedByBioChemEntity,< 1K
+Predicate,https://schema.org/isEncodedByBioChemEntity-input,< 1K
+Predicate,https://schema.org/isEncodedByBioChemEntity-output,< 1K
+Predicate,https://schema.org/isFamilyFriendly,100K - 1M
+Predicate,https://schema.org/isFamilyFriendly-input,< 1K
+Predicate,https://schema.org/isFamilyFriendly-output,< 1K
+Predicate,https://schema.org/isGift,< 1K
+Predicate,https://schema.org/isGift-input,< 1K
+Predicate,https://schema.org/isGift-output,< 1K
+Predicate,https://schema.org/isInvolvedInBiologicalProcess,< 1K
+Predicate,https://schema.org/isInvolvedInBiologicalProcess-input,< 1K
+Predicate,https://schema.org/isInvolvedInBiologicalProcess-output,< 1K
+Predicate,https://schema.org/isLiveBroadcast,10K - 100K
+Predicate,https://schema.org/isLiveBroadcast-input,< 1K
+Predicate,https://schema.org/isLiveBroadcast-output,< 1K
+Predicate,https://schema.org/isLocatedInSubcellularLocation,< 1K
+Predicate,https://schema.org/isLocatedInSubcellularLocation-input,< 1K
+Predicate,https://schema.org/isLocatedInSubcellularLocation-output,< 1K
+Predicate,https://schema.org/isPartOf,10M+
+Predicate,https://schema.org/isPartOf-input,< 1K
+Predicate,https://schema.org/isPartOf-output,< 1K
+Predicate,https://schema.org/isPartOfBioChemEntity,< 1K
+Predicate,https://schema.org/isPartOfBioChemEntity-input,< 1K
+Predicate,https://schema.org/isPartOfBioChemEntity-output,< 1K
+Predicate,https://schema.org/isPlanForApartment,< 1K
+Predicate,https://schema.org/isPlanForApartment-input,< 1K
+Predicate,https://schema.org/isPlanForApartment-output,< 1K
+Predicate,https://schema.org/isProprietary,< 1K
+Predicate,https://schema.org/isProprietary-input,< 1K
+Predicate,https://schema.org/isProprietary-output,< 1K
+Predicate,https://schema.org/isRelatedTo,100K - 1M
+Predicate,https://schema.org/isRelatedTo-input,< 1K
+Predicate,https://schema.org/isRelatedTo-output,< 1K
+Predicate,https://schema.org/isResizable,< 1K
+Predicate,https://schema.org/isResizable-input,< 1K
+Predicate,https://schema.org/isResizable-output,< 1K
+Predicate,https://schema.org/isSimilarTo,1K - 10K
+Predicate,https://schema.org/isSimilarTo-input,< 1K
+Predicate,https://schema.org/isSimilarTo-output,< 1K
+Predicate,https://schema.org/isStoreOn,< 1K
+Predicate,https://schema.org/isStoreOn-input,< 1K
+Predicate,https://schema.org/isStoreOn-output,< 1K
+Predicate,https://schema.org/isTierOf,< 1K
+Predicate,https://schema.org/isTierOf-input,< 1K
+Predicate,https://schema.org/isTierOf-output,< 1K
+Predicate,https://schema.org/isUnlabelledFallback,< 1K
+Predicate,https://schema.org/isUnlabelledFallback-input,< 1K
+Predicate,https://schema.org/isUnlabelledFallback-output,< 1K
+Predicate,https://schema.org/isVariantOf,10K - 100K
+Predicate,https://schema.org/isVariantOf-input,< 1K
+Predicate,https://schema.org/isVariantOf-output,< 1K
+Predicate,https://schema.org/isbn,10K - 100K
+Predicate,https://schema.org/isbn-input,< 1K
+Predicate,https://schema.org/isbn-output,< 1K
+Predicate,https://schema.org/isicV4,1K - 10K
+Predicate,https://schema.org/isicV4-input,< 1K
+Predicate,https://schema.org/isicV4-output,< 1K
+Predicate,https://schema.org/iso6523Code,1K - 10K
+Predicate,https://schema.org/iso6523Code-input,< 1K
+Predicate,https://schema.org/iso6523Code-output,< 1K
+Predicate,https://schema.org/isrcCode,< 1K
+Predicate,https://schema.org/isrcCode-input,< 1K
+Predicate,https://schema.org/isrcCode-output,< 1K
+Predicate,https://schema.org/issn,1K - 10K
+Predicate,https://schema.org/issn-input,< 1K
+Predicate,https://schema.org/issn-output,< 1K
+Predicate,https://schema.org/issueNumber,1K - 10K
+Predicate,https://schema.org/issueNumber-input,< 1K
+Predicate,https://schema.org/issueNumber-output,< 1K
+Predicate,https://schema.org/issuedBy,10K - 100K
+Predicate,https://schema.org/issuedBy-input,< 1K
+Predicate,https://schema.org/issuedBy-output,< 1K
+Predicate,https://schema.org/issuedThrough,< 1K
+Predicate,https://schema.org/issuedThrough-input,< 1K
+Predicate,https://schema.org/issuedThrough-output,< 1K
+Predicate,https://schema.org/iswcCode,< 1K
+Predicate,https://schema.org/iswcCode-input,< 1K
+Predicate,https://schema.org/iswcCode-output,< 1K
+Predicate,https://schema.org/item,10M+
+Predicate,https://schema.org/item-input,< 1K
+Predicate,https://schema.org/item-output,< 1K
+Predicate,https://schema.org/itemCondition,1M - 10M
+Predicate,https://schema.org/itemCondition-input,< 1K
+Predicate,https://schema.org/itemCondition-output,< 1K
+Predicate,https://schema.org/itemDefectReturnFees,1K - 10K
+Predicate,https://schema.org/itemDefectReturnFees-input,< 1K
+Predicate,https://schema.org/itemDefectReturnFees-output,< 1K
+Predicate,https://schema.org/itemDefectReturnLabelSource,< 1K
+Predicate,https://schema.org/itemDefectReturnLabelSource-input,< 1K
+Predicate,https://schema.org/itemDefectReturnLabelSource-output,< 1K
+Predicate,https://schema.org/itemDefectReturnShippingFeesAmount,< 1K
+Predicate,https://schema.org/itemDefectReturnShippingFeesAmount-input,< 1K
+Predicate,https://schema.org/itemDefectReturnShippingFeesAmount-output,< 1K
+Predicate,https://schema.org/itemListElement,10M+
+Predicate,https://schema.org/itemListElement-input,< 1K
+Predicate,https://schema.org/itemListElement-output,< 1K
+Predicate,https://schema.org/itemListOrder,100K - 1M
+Predicate,https://schema.org/itemListOrder-input,< 1K
+Predicate,https://schema.org/itemListOrder-output,< 1K
+Predicate,https://schema.org/itemLocation,< 1K
+Predicate,https://schema.org/itemLocation-input,< 1K
+Predicate,https://schema.org/itemLocation-output,< 1K
+Predicate,https://schema.org/itemOffered,100K - 1M
+Predicate,https://schema.org/itemOffered-input,< 1K
+Predicate,https://schema.org/itemOffered-output,< 1K
+Predicate,https://schema.org/itemReviewed,100K - 1M
+Predicate,https://schema.org/itemReviewed-input,< 1K
+Predicate,https://schema.org/itemReviewed-output,< 1K
+Predicate,https://schema.org/itemShipped,< 1K
+Predicate,https://schema.org/itemShipped-input,< 1K
+Predicate,https://schema.org/itemShipped-output,< 1K
+Predicate,https://schema.org/itinerary,10K - 100K
+Predicate,https://schema.org/itinerary-input,< 1K
+Predicate,https://schema.org/itinerary-output,< 1K
+Predicate,https://schema.org/iupacName,< 1K
+Predicate,https://schema.org/iupacName-input,< 1K
+Predicate,https://schema.org/iupacName-output,< 1K
+Predicate,https://schema.org/jobBenefits,10K - 100K
+Predicate,https://schema.org/jobBenefits-input,< 1K
+Predicate,https://schema.org/jobBenefits-output,< 1K
+Predicate,https://schema.org/jobDuration,< 1K
+Predicate,https://schema.org/jobDuration-input,< 1K
+Predicate,https://schema.org/jobDuration-output,< 1K
+Predicate,https://schema.org/jobImmediateStart,1K - 10K
+Predicate,https://schema.org/jobImmediateStart-input,< 1K
+Predicate,https://schema.org/jobImmediateStart-output,< 1K
+Predicate,https://schema.org/jobLocation,100K - 1M
+Predicate,https://schema.org/jobLocation-input,< 1K
+Predicate,https://schema.org/jobLocation-output,< 1K
+Predicate,https://schema.org/jobLocationType,10K - 100K
+Predicate,https://schema.org/jobLocationType-input,< 1K
+Predicate,https://schema.org/jobLocationType-output,< 1K
+Predicate,https://schema.org/jobStartDate,1K - 10K
+Predicate,https://schema.org/jobStartDate-input,< 1K
+Predicate,https://schema.org/jobStartDate-output,< 1K
+Predicate,https://schema.org/jobTitle,1M - 10M
+Predicate,https://schema.org/jobTitle-input,< 1K
+Predicate,https://schema.org/jobTitle-output,< 1K
+Predicate,https://schema.org/jurisdiction,1K - 10K
+Predicate,https://schema.org/jurisdiction-input,< 1K
+Predicate,https://schema.org/jurisdiction-output,< 1K
+Predicate,https://schema.org/keywords,1M - 10M
+Predicate,https://schema.org/keywords-input,< 1K
+Predicate,https://schema.org/keywords-output,< 1K
+Predicate,https://schema.org/knownVehicleDamages,< 1K
+Predicate,https://schema.org/knownVehicleDamages-input,< 1K
+Predicate,https://schema.org/knownVehicleDamages-output,< 1K
+Predicate,https://schema.org/knows,1K - 10K
+Predicate,https://schema.org/knows-input,< 1K
+Predicate,https://schema.org/knows-output,< 1K
+Predicate,https://schema.org/knowsAbout,100K - 1M
+Predicate,https://schema.org/knowsAbout-input,< 1K
+Predicate,https://schema.org/knowsAbout-output,< 1K
+Predicate,https://schema.org/knowsLanguage,100K - 1M
+Predicate,https://schema.org/knowsLanguage-input,< 1K
+Predicate,https://schema.org/knowsLanguage-output,< 1K
+Predicate,https://schema.org/labelDetails,< 1K
+Predicate,https://schema.org/labelDetails-input,< 1K
+Predicate,https://schema.org/labelDetails-output,< 1K
+Predicate,https://schema.org/landlord,< 1K
+Predicate,https://schema.org/landlord-input,< 1K
+Predicate,https://schema.org/landlord-output,< 1K
+Predicate,https://schema.org/language,10K - 100K
+Predicate,https://schema.org/language-input,< 1K
+Predicate,https://schema.org/language-output,< 1K
+Predicate,https://schema.org/lastReviewed,10K - 100K
+Predicate,https://schema.org/lastReviewed-input,< 1K
+Predicate,https://schema.org/lastReviewed-output,< 1K
+Predicate,https://schema.org/latitude,1M - 10M
+Predicate,https://schema.org/latitude-input,< 1K
+Predicate,https://schema.org/latitude-output,< 1K
+Predicate,https://schema.org/layoutImage,1K - 10K
+Predicate,https://schema.org/layoutImage-input,< 1K
+Predicate,https://schema.org/layoutImage-output,< 1K
+Predicate,https://schema.org/learningResourceType,10K - 100K
+Predicate,https://schema.org/learningResourceType-input,< 1K
+Predicate,https://schema.org/learningResourceType-output,< 1K
+Predicate,https://schema.org/leaseLength,1K - 10K
+Predicate,https://schema.org/leaseLength-input,< 1K
+Predicate,https://schema.org/leaseLength-output,< 1K
+Predicate,https://schema.org/legalAddress,1K - 10K
+Predicate,https://schema.org/legalAddress-input,< 1K
+Predicate,https://schema.org/legalAddress-output,< 1K
+Predicate,https://schema.org/legalName,1M - 10M
+Predicate,https://schema.org/legalName-input,< 1K
+Predicate,https://schema.org/legalName-output,< 1K
+Predicate,https://schema.org/legalRepresentative,1K - 10K
+Predicate,https://schema.org/legalRepresentative-input,< 1K
+Predicate,https://schema.org/legalRepresentative-output,< 1K
+Predicate,https://schema.org/legalStatus,1K - 10K
+Predicate,https://schema.org/legalStatus-input,< 1K
+Predicate,https://schema.org/legalStatus-output,< 1K
+Predicate,https://schema.org/legislationAmends,< 1K
+Predicate,https://schema.org/legislationAmends-input,< 1K
+Predicate,https://schema.org/legislationAmends-output,< 1K
+Predicate,https://schema.org/legislationApplies,< 1K
+Predicate,https://schema.org/legislationApplies-input,< 1K
+Predicate,https://schema.org/legislationApplies-output,< 1K
+Predicate,https://schema.org/legislationChanges,< 1K
+Predicate,https://schema.org/legislationChanges-input,< 1K
+Predicate,https://schema.org/legislationChanges-output,< 1K
+Predicate,https://schema.org/legislationCommences,< 1K
+Predicate,https://schema.org/legislationCommences-input,< 1K
+Predicate,https://schema.org/legislationCommences-output,< 1K
+Predicate,https://schema.org/legislationConsolidates,< 1K
+Predicate,https://schema.org/legislationConsolidates-input,< 1K
+Predicate,https://schema.org/legislationConsolidates-output,< 1K
+Predicate,https://schema.org/legislationCorrects,< 1K
+Predicate,https://schema.org/legislationCorrects-input,< 1K
+Predicate,https://schema.org/legislationCorrects-output,< 1K
+Predicate,https://schema.org/legislationCountersignedBy,< 1K
+Predicate,https://schema.org/legislationCountersignedBy-input,< 1K
+Predicate,https://schema.org/legislationCountersignedBy-output,< 1K
+Predicate,https://schema.org/legislationDate,< 1K
+Predicate,https://schema.org/legislationDate-input,< 1K
+Predicate,https://schema.org/legislationDate-output,< 1K
+Predicate,https://schema.org/legislationDateOfApplicability,< 1K
+Predicate,https://schema.org/legislationDateOfApplicability-input,< 1K
+Predicate,https://schema.org/legislationDateOfApplicability-output,< 1K
+Predicate,https://schema.org/legislationDateVersion,< 1K
+Predicate,https://schema.org/legislationDateVersion-input,< 1K
+Predicate,https://schema.org/legislationDateVersion-output,< 1K
+Predicate,https://schema.org/legislationEnsuresImplementationOf,< 1K
+Predicate,https://schema.org/legislationEnsuresImplementationOf-input,< 1K
+Predicate,https://schema.org/legislationEnsuresImplementationOf-output,< 1K
+Predicate,https://schema.org/legislationIdentifier,1K - 10K
+Predicate,https://schema.org/legislationIdentifier-input,< 1K
+Predicate,https://schema.org/legislationIdentifier-output,< 1K
+Predicate,https://schema.org/legislationJurisdiction,1K - 10K
+Predicate,https://schema.org/legislationJurisdiction-input,< 1K
+Predicate,https://schema.org/legislationJurisdiction-output,< 1K
+Predicate,https://schema.org/legislationLegalForce,< 1K
+Predicate,https://schema.org/legislationLegalForce-input,< 1K
+Predicate,https://schema.org/legislationLegalForce-output,< 1K
+Predicate,https://schema.org/legislationLegalValue,< 1K
+Predicate,https://schema.org/legislationLegalValue-input,< 1K
+Predicate,https://schema.org/legislationLegalValue-output,< 1K
+Predicate,https://schema.org/legislationPassedBy,< 1K
+Predicate,https://schema.org/legislationPassedBy-input,< 1K
+Predicate,https://schema.org/legislationPassedBy-output,< 1K
+Predicate,https://schema.org/legislationRepeals,< 1K
+Predicate,https://schema.org/legislationRepeals-input,< 1K
+Predicate,https://schema.org/legislationRepeals-output,< 1K
+Predicate,https://schema.org/legislationResponsible,< 1K
+Predicate,https://schema.org/legislationResponsible-input,< 1K
+Predicate,https://schema.org/legislationResponsible-output,< 1K
+Predicate,https://schema.org/legislationTransposes,< 1K
+Predicate,https://schema.org/legislationTransposes-input,< 1K
+Predicate,https://schema.org/legislationTransposes-output,< 1K
+Predicate,https://schema.org/legislationType,< 1K
+Predicate,https://schema.org/legislationType-input,< 1K
+Predicate,https://schema.org/legislationType-output,< 1K
+Predicate,https://schema.org/leiCode,1K - 10K
+Predicate,https://schema.org/leiCode-input,< 1K
+Predicate,https://schema.org/leiCode-output,< 1K
+Predicate,https://schema.org/lender,< 1K
+Predicate,https://schema.org/lender-input,< 1K
+Predicate,https://schema.org/lender-output,< 1K
+Predicate,https://schema.org/lesser,< 1K
+Predicate,https://schema.org/lesser-input,< 1K
+Predicate,https://schema.org/lesser-output,< 1K
+Predicate,https://schema.org/lesserOrEqual,< 1K
+Predicate,https://schema.org/lesserOrEqual-input,< 1K
+Predicate,https://schema.org/lesserOrEqual-output,< 1K
+Predicate,https://schema.org/letterer,< 1K
+Predicate,https://schema.org/letterer-input,< 1K
+Predicate,https://schema.org/letterer-output,< 1K
+Predicate,https://schema.org/license,100K - 1M
+Predicate,https://schema.org/license-input,< 1K
+Predicate,https://schema.org/license-output,< 1K
+Predicate,https://schema.org/lifeEvent,< 1K
+Predicate,https://schema.org/lifeEvent-input,< 1K
+Predicate,https://schema.org/lifeEvent-output,< 1K
+Predicate,https://schema.org/line,< 1K
+Predicate,https://schema.org/line-input,< 1K
+Predicate,https://schema.org/line-output,< 1K
+Predicate,https://schema.org/linkRelationship,< 1K
+Predicate,https://schema.org/linkRelationship-input,< 1K
+Predicate,https://schema.org/linkRelationship-output,< 1K
+Predicate,https://schema.org/liveBlogUpdate,1K - 10K
+Predicate,https://schema.org/liveBlogUpdate-input,< 1K
+Predicate,https://schema.org/liveBlogUpdate-output,< 1K
+Predicate,https://schema.org/loanMortgageMandateAmount,< 1K
+Predicate,https://schema.org/loanMortgageMandateAmount-input,< 1K
+Predicate,https://schema.org/loanMortgageMandateAmount-output,< 1K
+Predicate,https://schema.org/loanPaymentAmount,< 1K
+Predicate,https://schema.org/loanPaymentAmount-input,< 1K
+Predicate,https://schema.org/loanPaymentAmount-output,< 1K
+Predicate,https://schema.org/loanPaymentFrequency,< 1K
+Predicate,https://schema.org/loanPaymentFrequency-input,< 1K
+Predicate,https://schema.org/loanPaymentFrequency-output,< 1K
+Predicate,https://schema.org/loanRepaymentForm,< 1K
+Predicate,https://schema.org/loanRepaymentForm-input,< 1K
+Predicate,https://schema.org/loanRepaymentForm-output,< 1K
+Predicate,https://schema.org/loanTerm,1K - 10K
+Predicate,https://schema.org/loanTerm-input,< 1K
+Predicate,https://schema.org/loanTerm-output,< 1K
+Predicate,https://schema.org/loanType,1K - 10K
+Predicate,https://schema.org/loanType-input,< 1K
+Predicate,https://schema.org/loanType-output,< 1K
+Predicate,https://schema.org/location,1M - 10M
+Predicate,https://schema.org/location-input,< 1K
+Predicate,https://schema.org/location-output,< 1K
+Predicate,https://schema.org/locationCreated,10K - 100K
+Predicate,https://schema.org/locationCreated-input,< 1K
+Predicate,https://schema.org/locationCreated-output,< 1K
+Predicate,https://schema.org/lodgingUnitDescription,< 1K
+Predicate,https://schema.org/lodgingUnitDescription-input,< 1K
+Predicate,https://schema.org/lodgingUnitDescription-output,< 1K
+Predicate,https://schema.org/lodgingUnitType,< 1K
+Predicate,https://schema.org/lodgingUnitType-input,< 1K
+Predicate,https://schema.org/lodgingUnitType-output,< 1K
+Predicate,https://schema.org/logo,10M+
+Predicate,https://schema.org/logo-input,< 1K
+Predicate,https://schema.org/logo-output,< 1K
+Predicate,https://schema.org/longitude,1M - 10M
+Predicate,https://schema.org/longitude-input,< 1K
+Predicate,https://schema.org/longitude-output,< 1K
+Predicate,https://schema.org/loser,< 1K
+Predicate,https://schema.org/loser-input,< 1K
+Predicate,https://schema.org/loser-output,< 1K
+Predicate,https://schema.org/lowPrice,1M - 10M
+Predicate,https://schema.org/lowPrice-input,< 1K
+Predicate,https://schema.org/lowPrice-output,< 1K
+Predicate,https://schema.org/lyricist,< 1K
+Predicate,https://schema.org/lyricist-input,< 1K
+Predicate,https://schema.org/lyricist-output,< 1K
+Predicate,https://schema.org/lyrics,1K - 10K
+Predicate,https://schema.org/lyrics-input,< 1K
+Predicate,https://schema.org/lyrics-output,< 1K
+Predicate,https://schema.org/mainContentOfPage,1M - 10M
+Predicate,https://schema.org/mainContentOfPage-input,< 1K
+Predicate,https://schema.org/mainContentOfPage-output,< 1K
+Predicate,https://schema.org/mainEntity,1M - 10M
+Predicate,https://schema.org/mainEntity-input,< 1K
+Predicate,https://schema.org/mainEntity-output,< 1K
+Predicate,https://schema.org/mainEntityOfPage,10M+
+Predicate,https://schema.org/mainEntityOfPage-input,< 1K
+Predicate,https://schema.org/mainEntityOfPage-output,< 1K
+Predicate,https://schema.org/maintainer,1K - 10K
+Predicate,https://schema.org/maintainer-input,< 1K
+Predicate,https://schema.org/maintainer-output,< 1K
+Predicate,https://schema.org/makesOffer,100K - 1M
+Predicate,https://schema.org/makesOffer-input,< 1K
+Predicate,https://schema.org/makesOffer-output,< 1K
+Predicate,https://schema.org/manufacturer,100K - 1M
+Predicate,https://schema.org/manufacturer-input,< 1K
+Predicate,https://schema.org/manufacturer-output,< 1K
+Predicate,https://schema.org/map,1K - 10K
+Predicate,https://schema.org/map-input,< 1K
+Predicate,https://schema.org/map-output,< 1K
+Predicate,https://schema.org/mapType,1K - 10K
+Predicate,https://schema.org/mapType-input,< 1K
+Predicate,https://schema.org/mapType-output,< 1K
+Predicate,https://schema.org/maps,1K - 10K
+Predicate,https://schema.org/maps-input,< 1K
+Predicate,https://schema.org/maps-output,< 1K
+Predicate,https://schema.org/marginOfError,< 1K
+Predicate,https://schema.org/marginOfError-input,< 1K
+Predicate,https://schema.org/marginOfError-output,< 1K
+Predicate,https://schema.org/masthead,1K - 10K
+Predicate,https://schema.org/masthead-input,< 1K
+Predicate,https://schema.org/masthead-output,< 1K
+Predicate,https://schema.org/material,10K - 100K
+Predicate,https://schema.org/material-input,< 1K
+Predicate,https://schema.org/material-output,< 1K
+Predicate,https://schema.org/materialExtent,< 1K
+Predicate,https://schema.org/materialExtent-input,< 1K
+Predicate,https://schema.org/materialExtent-output,< 1K
+Predicate,https://schema.org/mathExpression,< 1K
+Predicate,https://schema.org/mathExpression-input,< 1K
+Predicate,https://schema.org/mathExpression-output,< 1K
+Predicate,https://schema.org/maxPrice,10K - 100K
+Predicate,https://schema.org/maxPrice-input,< 1K
+Predicate,https://schema.org/maxPrice-output,< 1K
+Predicate,https://schema.org/maxValue,100K - 1M
+Predicate,https://schema.org/maxValue-input,< 1K
+Predicate,https://schema.org/maxValue-output,< 1K
+Predicate,https://schema.org/maximumAttendeeCapacity,10K - 100K
+Predicate,https://schema.org/maximumAttendeeCapacity-input,< 1K
+Predicate,https://schema.org/maximumAttendeeCapacity-output,< 1K
+Predicate,https://schema.org/maximumEnrollment,< 1K
+Predicate,https://schema.org/maximumEnrollment-input,< 1K
+Predicate,https://schema.org/maximumEnrollment-output,< 1K
+Predicate,https://schema.org/maximumIntake,< 1K
+Predicate,https://schema.org/maximumIntake-input,< 1K
+Predicate,https://schema.org/maximumIntake-output,< 1K
+Predicate,https://schema.org/maximumPhysicalAttendeeCapacity,< 1K
+Predicate,https://schema.org/maximumPhysicalAttendeeCapacity-input,< 1K
+Predicate,https://schema.org/maximumPhysicalAttendeeCapacity-output,< 1K
+Predicate,https://schema.org/maximumVirtualAttendeeCapacity,< 1K
+Predicate,https://schema.org/maximumVirtualAttendeeCapacity-input,< 1K
+Predicate,https://schema.org/maximumVirtualAttendeeCapacity-output,< 1K
+Predicate,https://schema.org/mealService,< 1K
+Predicate,https://schema.org/mealService-input,< 1K
+Predicate,https://schema.org/mealService-output,< 1K
+Predicate,https://schema.org/measuredProperty,< 1K
+Predicate,https://schema.org/measuredProperty-input,< 1K
+Predicate,https://schema.org/measuredProperty-output,< 1K
+Predicate,https://schema.org/measurementDenominator,< 1K
+Predicate,https://schema.org/measurementDenominator-input,< 1K
+Predicate,https://schema.org/measurementDenominator-output,< 1K
+Predicate,https://schema.org/measurementMethod,< 1K
+Predicate,https://schema.org/measurementMethod-input,< 1K
+Predicate,https://schema.org/measurementMethod-output,< 1K
+Predicate,https://schema.org/measurementQualifier,< 1K
+Predicate,https://schema.org/measurementQualifier-input,< 1K
+Predicate,https://schema.org/measurementQualifier-output,< 1K
+Predicate,https://schema.org/measurementTechnique,1K - 10K
+Predicate,https://schema.org/measurementTechnique-input,< 1K
+Predicate,https://schema.org/measurementTechnique-output,< 1K
+Predicate,https://schema.org/mechanismOfAction,< 1K
+Predicate,https://schema.org/mechanismOfAction-input,< 1K
+Predicate,https://schema.org/mechanismOfAction-output,< 1K
+Predicate,https://schema.org/mediaAuthenticityCategory,< 1K
+Predicate,https://schema.org/mediaAuthenticityCategory-input,< 1K
+Predicate,https://schema.org/mediaAuthenticityCategory-output,< 1K
+Predicate,https://schema.org/mediaItemAppearance,< 1K
+Predicate,https://schema.org/mediaItemAppearance-input,< 1K
+Predicate,https://schema.org/mediaItemAppearance-output,< 1K
+Predicate,https://schema.org/median,1K - 10K
+Predicate,https://schema.org/median-input,< 1K
+Predicate,https://schema.org/median-output,< 1K
+Predicate,https://schema.org/medicalAudience,1K - 10K
+Predicate,https://schema.org/medicalAudience-input,< 1K
+Predicate,https://schema.org/medicalAudience-output,< 1K
+Predicate,https://schema.org/medicalSpecialty,100K - 1M
+Predicate,https://schema.org/medicalSpecialty-input,< 1K
+Predicate,https://schema.org/medicalSpecialty-output,< 1K
+Predicate,https://schema.org/medicineSystem,1K - 10K
+Predicate,https://schema.org/medicineSystem-input,< 1K
+Predicate,https://schema.org/medicineSystem-output,< 1K
+Predicate,https://schema.org/meetsEmissionStandard,< 1K
+Predicate,https://schema.org/meetsEmissionStandard-input,< 1K
+Predicate,https://schema.org/meetsEmissionStandard-output,< 1K
+Predicate,https://schema.org/member,10K - 100K
+Predicate,https://schema.org/member-input,< 1K
+Predicate,https://schema.org/member-output,< 1K
+Predicate,https://schema.org/memberOf,10K - 100K
+Predicate,https://schema.org/memberOf-input,< 1K
+Predicate,https://schema.org/memberOf-output,< 1K
+Predicate,https://schema.org/members,< 1K
+Predicate,https://schema.org/members-input,< 1K
+Predicate,https://schema.org/members-output,< 1K
+Predicate,https://schema.org/membershipNumber,< 1K
+Predicate,https://schema.org/membershipNumber-input,< 1K
+Predicate,https://schema.org/membershipNumber-output,< 1K
+Predicate,https://schema.org/membershipPointsEarned,< 1K
+Predicate,https://schema.org/membershipPointsEarned-input,< 1K
+Predicate,https://schema.org/membershipPointsEarned-output,< 1K
+Predicate,https://schema.org/memoryRequirements,1K - 10K
+Predicate,https://schema.org/memoryRequirements-input,< 1K
+Predicate,https://schema.org/memoryRequirements-output,< 1K
+Predicate,https://schema.org/mentions,10K - 100K
+Predicate,https://schema.org/mentions-input,< 1K
+Predicate,https://schema.org/mentions-output,< 1K
+Predicate,https://schema.org/menu,10K - 100K
+Predicate,https://schema.org/menu-input,< 1K
+Predicate,https://schema.org/menu-output,< 1K
+Predicate,https://schema.org/menuAddOn,10K - 100K
+Predicate,https://schema.org/menuAddOn-input,< 1K
+Predicate,https://schema.org/menuAddOn-output,< 1K
+Predicate,https://schema.org/merchant,< 1K
+Predicate,https://schema.org/merchant-input,< 1K
+Predicate,https://schema.org/merchant-output,< 1K
+Predicate,https://schema.org/merchantReturnDays,100K - 1M
+Predicate,https://schema.org/merchantReturnDays-input,< 1K
+Predicate,https://schema.org/merchantReturnDays-output,< 1K
+Predicate,https://schema.org/merchantReturnLink,10K - 100K
+Predicate,https://schema.org/merchantReturnLink-input,< 1K
+Predicate,https://schema.org/merchantReturnLink-output,< 1K
+Predicate,https://schema.org/messageAttachment,< 1K
+Predicate,https://schema.org/messageAttachment-input,< 1K
+Predicate,https://schema.org/messageAttachment-output,< 1K
+Predicate,https://schema.org/mileageFromOdometer,10K - 100K
+Predicate,https://schema.org/mileageFromOdometer-input,< 1K
+Predicate,https://schema.org/mileageFromOdometer-output,< 1K
+Predicate,https://schema.org/minPrice,10K - 100K
+Predicate,https://schema.org/minPrice-input,< 1K
+Predicate,https://schema.org/minPrice-output,< 1K
+Predicate,https://schema.org/minValue,100K - 1M
+Predicate,https://schema.org/minValue-input,< 1K
+Predicate,https://schema.org/minValue-output,< 1K
+Predicate,https://schema.org/minimumPaymentDue,< 1K
+Predicate,https://schema.org/minimumPaymentDue-input,< 1K
+Predicate,https://schema.org/minimumPaymentDue-output,< 1K
+Predicate,https://schema.org/missionCoveragePrioritiesPolicy,1K - 10K
+Predicate,https://schema.org/missionCoveragePrioritiesPolicy-input,< 1K
+Predicate,https://schema.org/missionCoveragePrioritiesPolicy-output,< 1K
+Predicate,https://schema.org/mobileUrl,< 1K
+Predicate,https://schema.org/mobileUrl-input,< 1K
+Predicate,https://schema.org/mobileUrl-output,< 1K
+Predicate,https://schema.org/model,100K - 1M
+Predicate,https://schema.org/model-input,< 1K
+Predicate,https://schema.org/model-output,< 1K
+Predicate,https://schema.org/modelDate,10K - 100K
+Predicate,https://schema.org/modelDate-input,< 1K
+Predicate,https://schema.org/modelDate-output,< 1K
+Predicate,https://schema.org/modifiedTime,< 1K
+Predicate,https://schema.org/modifiedTime-input,< 1K
+Predicate,https://schema.org/modifiedTime-output,< 1K
+Predicate,https://schema.org/molecularFormula,< 1K
+Predicate,https://schema.org/molecularFormula-input,< 1K
+Predicate,https://schema.org/molecularFormula-output,< 1K
+Predicate,https://schema.org/molecularWeight,< 1K
+Predicate,https://schema.org/molecularWeight-input,< 1K
+Predicate,https://schema.org/molecularWeight-output,< 1K
+Predicate,https://schema.org/monoisotopicMolecularWeight,< 1K
+Predicate,https://schema.org/monoisotopicMolecularWeight-input,< 1K
+Predicate,https://schema.org/monoisotopicMolecularWeight-output,< 1K
+Predicate,https://schema.org/monthlyMinimumRepaymentAmount,< 1K
+Predicate,https://schema.org/monthlyMinimumRepaymentAmount-input,< 1K
+Predicate,https://schema.org/monthlyMinimumRepaymentAmount-output,< 1K
+Predicate,https://schema.org/monthsOfExperience,1K - 10K
+Predicate,https://schema.org/monthsOfExperience-input,< 1K
+Predicate,https://schema.org/monthsOfExperience-output,< 1K
+Predicate,https://schema.org/mpn,100K - 1M
+Predicate,https://schema.org/mpn-input,< 1K
+Predicate,https://schema.org/mpn-output,< 1K
+Predicate,https://schema.org/multipleValues,< 1K
+Predicate,https://schema.org/multipleValues-input,< 1K
+Predicate,https://schema.org/multipleValues-output,< 1K
+Predicate,https://schema.org/muscleAction,< 1K
+Predicate,https://schema.org/muscleAction-input,< 1K
+Predicate,https://schema.org/muscleAction-output,< 1K
+Predicate,https://schema.org/musicArrangement,< 1K
+Predicate,https://schema.org/musicArrangement-input,< 1K
+Predicate,https://schema.org/musicArrangement-output,< 1K
+Predicate,https://schema.org/musicBy,1K - 10K
+Predicate,https://schema.org/musicBy-input,< 1K
+Predicate,https://schema.org/musicBy-output,< 1K
+Predicate,https://schema.org/musicCompositionForm,< 1K
+Predicate,https://schema.org/musicCompositionForm-input,< 1K
+Predicate,https://schema.org/musicCompositionForm-output,< 1K
+Predicate,https://schema.org/musicGroupMember,< 1K
+Predicate,https://schema.org/musicGroupMember-input,< 1K
+Predicate,https://schema.org/musicGroupMember-output,< 1K
+Predicate,https://schema.org/musicReleaseFormat,1K - 10K
+Predicate,https://schema.org/musicReleaseFormat-input,< 1K
+Predicate,https://schema.org/musicReleaseFormat-output,< 1K
+Predicate,https://schema.org/musicalKey,< 1K
+Predicate,https://schema.org/musicalKey-input,< 1K
+Predicate,https://schema.org/musicalKey-output,< 1K
+Predicate,https://schema.org/naics,10K - 100K
+Predicate,https://schema.org/naics-input,< 1K
+Predicate,https://schema.org/naics-output,< 1K
+Predicate,https://schema.org/name,10M+
+Predicate,https://schema.org/name-input,< 1K
+Predicate,https://schema.org/name-output,< 1K
+Predicate,https://schema.org/namedPosition,< 1K
+Predicate,https://schema.org/namedPosition-input,< 1K
+Predicate,https://schema.org/namedPosition-output,< 1K
+Predicate,https://schema.org/nationality,10K - 100K
+Predicate,https://schema.org/nationality-input,< 1K
+Predicate,https://schema.org/nationality-output,< 1K
+Predicate,https://schema.org/naturalProgression,< 1K
+Predicate,https://schema.org/naturalProgression-input,< 1K
+Predicate,https://schema.org/naturalProgression-output,< 1K
+Predicate,https://schema.org/negativeNotes,10K - 100K
+Predicate,https://schema.org/negativeNotes-input,< 1K
+Predicate,https://schema.org/negativeNotes-output,< 1K
+Predicate,https://schema.org/nerve,< 1K
+Predicate,https://schema.org/nerve-input,< 1K
+Predicate,https://schema.org/nerve-output,< 1K
+Predicate,https://schema.org/nerveMotor,< 1K
+Predicate,https://schema.org/nerveMotor-input,< 1K
+Predicate,https://schema.org/nerveMotor-output,< 1K
+Predicate,https://schema.org/netWorth,< 1K
+Predicate,https://schema.org/netWorth-input,< 1K
+Predicate,https://schema.org/netWorth-output,< 1K
+Predicate,https://schema.org/newsUpdatesAndGuidelines,< 1K
+Predicate,https://schema.org/newsUpdatesAndGuidelines-input,< 1K
+Predicate,https://schema.org/newsUpdatesAndGuidelines-output,< 1K
+Predicate,https://schema.org/nextItem,1M - 10M
+Predicate,https://schema.org/nextItem-input,< 1K
+Predicate,https://schema.org/nextItem-output,< 1K
+Predicate,https://schema.org/noBylinesPolicy,1K - 10K
+Predicate,https://schema.org/noBylinesPolicy-input,< 1K
+Predicate,https://schema.org/noBylinesPolicy-output,< 1K
+Predicate,https://schema.org/nonEqual,< 1K
+Predicate,https://schema.org/nonEqual-input,< 1K
+Predicate,https://schema.org/nonEqual-output,< 1K
+Predicate,https://schema.org/nonProprietaryName,1K - 10K
+Predicate,https://schema.org/nonProprietaryName-input,< 1K
+Predicate,https://schema.org/nonProprietaryName-output,< 1K
+Predicate,https://schema.org/nonprofitStatus,1K - 10K
+Predicate,https://schema.org/nonprofitStatus-input,< 1K
+Predicate,https://schema.org/nonprofitStatus-output,< 1K
+Predicate,https://schema.org/normalRange,< 1K
+Predicate,https://schema.org/normalRange-input,< 1K
+Predicate,https://schema.org/normalRange-output,< 1K
+Predicate,https://schema.org/nsn,< 1K
+Predicate,https://schema.org/nsn-input,< 1K
+Predicate,https://schema.org/nsn-output,< 1K
+Predicate,https://schema.org/numAdults,< 1K
+Predicate,https://schema.org/numAdults-input,< 1K
+Predicate,https://schema.org/numAdults-output,< 1K
+Predicate,https://schema.org/numChildren,< 1K
+Predicate,https://schema.org/numChildren-input,< 1K
+Predicate,https://schema.org/numChildren-output,< 1K
+Predicate,https://schema.org/numConstraints,< 1K
+Predicate,https://schema.org/numConstraints-input,< 1K
+Predicate,https://schema.org/numConstraints-output,< 1K
+Predicate,https://schema.org/numItems,< 1K
+Predicate,https://schema.org/numItems-input,< 1K
+Predicate,https://schema.org/numItems-output,< 1K
+Predicate,https://schema.org/numTracks,10K - 100K
+Predicate,https://schema.org/numTracks-input,< 1K
+Predicate,https://schema.org/numTracks-output,< 1K
+Predicate,https://schema.org/numberOfAccommodationUnits,1K - 10K
+Predicate,https://schema.org/numberOfAccommodationUnits-input,< 1K
+Predicate,https://schema.org/numberOfAccommodationUnits-output,< 1K
+Predicate,https://schema.org/numberOfAirbags,< 1K
+Predicate,https://schema.org/numberOfAirbags-input,< 1K
+Predicate,https://schema.org/numberOfAirbags-output,< 1K
+Predicate,https://schema.org/numberOfAvailableAccommodationUnits,1K - 10K
+Predicate,https://schema.org/numberOfAvailableAccommodationUnits-input,< 1K
+Predicate,https://schema.org/numberOfAvailableAccommodationUnits-output,< 1K
+Predicate,https://schema.org/numberOfAxles,< 1K
+Predicate,https://schema.org/numberOfAxles-input,< 1K
+Predicate,https://schema.org/numberOfAxles-output,< 1K
+Predicate,https://schema.org/numberOfBathroomsTotal,10K - 100K
+Predicate,https://schema.org/numberOfBathroomsTotal-input,< 1K
+Predicate,https://schema.org/numberOfBathroomsTotal-output,< 1K
+Predicate,https://schema.org/numberOfBedrooms,10K - 100K
+Predicate,https://schema.org/numberOfBedrooms-input,< 1K
+Predicate,https://schema.org/numberOfBedrooms-output,< 1K
+Predicate,https://schema.org/numberOfBeds,10K - 100K
+Predicate,https://schema.org/numberOfBeds-input,< 1K
+Predicate,https://schema.org/numberOfBeds-output,< 1K
+Predicate,https://schema.org/numberOfCredits,1K - 10K
+Predicate,https://schema.org/numberOfCredits-input,< 1K
+Predicate,https://schema.org/numberOfCredits-output,< 1K
+Predicate,https://schema.org/numberOfDoors,10K - 100K
+Predicate,https://schema.org/numberOfDoors-input,< 1K
+Predicate,https://schema.org/numberOfDoors-output,< 1K
+Predicate,https://schema.org/numberOfEmployees,100K - 1M
+Predicate,https://schema.org/numberOfEmployees-input,< 1K
+Predicate,https://schema.org/numberOfEmployees-output,< 1K
+Predicate,https://schema.org/numberOfEpisodes,10K - 100K
+Predicate,https://schema.org/numberOfEpisodes-input,< 1K
+Predicate,https://schema.org/numberOfEpisodes-output,< 1K
+Predicate,https://schema.org/numberOfForwardGears,1K - 10K
+Predicate,https://schema.org/numberOfForwardGears-input,< 1K
+Predicate,https://schema.org/numberOfForwardGears-output,< 1K
+Predicate,https://schema.org/numberOfFullBathrooms,10K - 100K
+Predicate,https://schema.org/numberOfFullBathrooms-input,< 1K
+Predicate,https://schema.org/numberOfFullBathrooms-output,< 1K
+Predicate,https://schema.org/numberOfItems,100K - 1M
+Predicate,https://schema.org/numberOfItems-input,< 1K
+Predicate,https://schema.org/numberOfItems-output,< 1K
+Predicate,https://schema.org/numberOfLoanPayments,< 1K
+Predicate,https://schema.org/numberOfLoanPayments-input,< 1K
+Predicate,https://schema.org/numberOfLoanPayments-output,< 1K
+Predicate,https://schema.org/numberOfPages,10K - 100K
+Predicate,https://schema.org/numberOfPages-input,< 1K
+Predicate,https://schema.org/numberOfPages-output,< 1K
+Predicate,https://schema.org/numberOfPartialBathrooms,1K - 10K
+Predicate,https://schema.org/numberOfPartialBathrooms-input,< 1K
+Predicate,https://schema.org/numberOfPartialBathrooms-output,< 1K
+Predicate,https://schema.org/numberOfPlayers,10K - 100K
+Predicate,https://schema.org/numberOfPlayers-input,< 1K
+Predicate,https://schema.org/numberOfPlayers-output,< 1K
+Predicate,https://schema.org/numberOfPreviousOwners,1K - 10K
+Predicate,https://schema.org/numberOfPreviousOwners-input,< 1K
+Predicate,https://schema.org/numberOfPreviousOwners-output,< 1K
+Predicate,https://schema.org/numberOfRooms,10K - 100K
+Predicate,https://schema.org/numberOfRooms-input,< 1K
+Predicate,https://schema.org/numberOfRooms-output,< 1K
+Predicate,https://schema.org/numberOfSeasons,1K - 10K
+Predicate,https://schema.org/numberOfSeasons-input,< 1K
+Predicate,https://schema.org/numberOfSeasons-output,< 1K
+Predicate,https://schema.org/numberedPosition,< 1K
+Predicate,https://schema.org/numberedPosition-input,< 1K
+Predicate,https://schema.org/numberedPosition-output,< 1K
+Predicate,https://schema.org/nutrition,10K - 100K
+Predicate,https://schema.org/nutrition-input,< 1K
+Predicate,https://schema.org/nutrition-output,< 1K
+Predicate,https://schema.org/object,10K - 100K
+Predicate,https://schema.org/object-input,< 1K
+Predicate,https://schema.org/object-output,< 1K
+Predicate,https://schema.org/observationAbout,< 1K
+Predicate,https://schema.org/observationAbout-input,< 1K
+Predicate,https://schema.org/observationAbout-output,< 1K
+Predicate,https://schema.org/observationDate,< 1K
+Predicate,https://schema.org/observationDate-input,< 1K
+Predicate,https://schema.org/observationDate-output,< 1K
+Predicate,https://schema.org/observationPeriod,< 1K
+Predicate,https://schema.org/observationPeriod-input,< 1K
+Predicate,https://schema.org/observationPeriod-output,< 1K
+Predicate,https://schema.org/occupancy,10K - 100K
+Predicate,https://schema.org/occupancy-input,< 1K
+Predicate,https://schema.org/occupancy-output,< 1K
+Predicate,https://schema.org/occupationLocation,10K - 100K
+Predicate,https://schema.org/occupationLocation-input,< 1K
+Predicate,https://schema.org/occupationLocation-output,< 1K
+Predicate,https://schema.org/occupationalCategory,10K - 100K
+Predicate,https://schema.org/occupationalCategory-input,< 1K
+Predicate,https://schema.org/occupationalCategory-output,< 1K
+Predicate,https://schema.org/occupationalCredentialAwarded,1K - 10K
+Predicate,https://schema.org/occupationalCredentialAwarded-input,< 1K
+Predicate,https://schema.org/occupationalCredentialAwarded-output,< 1K
+Predicate,https://schema.org/offerCount,1M - 10M
+Predicate,https://schema.org/offerCount-input,< 1K
+Predicate,https://schema.org/offerCount-output,< 1K
+Predicate,https://schema.org/offeredBy,10K - 100K
+Predicate,https://schema.org/offeredBy-input,< 1K
+Predicate,https://schema.org/offeredBy-output,< 1K
+Predicate,https://schema.org/offers,10M+
+Predicate,https://schema.org/offers-input,< 1K
+Predicate,https://schema.org/offers-output,< 1K
+Predicate,https://schema.org/offersPrescriptionByMail,< 1K
+Predicate,https://schema.org/offersPrescriptionByMail-input,< 1K
+Predicate,https://schema.org/offersPrescriptionByMail-output,< 1K
+Predicate,https://schema.org/openingHours,1M - 10M
+Predicate,https://schema.org/openingHours-input,< 1K
+Predicate,https://schema.org/openingHours-output,< 1K
+Predicate,https://schema.org/openingHoursSpecification,1M - 10M
+Predicate,https://schema.org/openingHoursSpecification-input,< 1K
+Predicate,https://schema.org/openingHoursSpecification-output,< 1K
+Predicate,https://schema.org/opens,1M - 10M
+Predicate,https://schema.org/opens-input,< 1K
+Predicate,https://schema.org/opens-output,< 1K
+Predicate,https://schema.org/operatingSystem,1M - 10M
+Predicate,https://schema.org/operatingSystem-input,< 1K
+Predicate,https://schema.org/operatingSystem-output,< 1K
+Predicate,https://schema.org/opponent,< 1K
+Predicate,https://schema.org/opponent-input,< 1K
+Predicate,https://schema.org/opponent-output,< 1K
+Predicate,https://schema.org/option,< 1K
+Predicate,https://schema.org/option-input,< 1K
+Predicate,https://schema.org/option-output,< 1K
+Predicate,https://schema.org/orderDate,< 1K
+Predicate,https://schema.org/orderDate-input,< 1K
+Predicate,https://schema.org/orderDate-output,< 1K
+Predicate,https://schema.org/orderDelivery,< 1K
+Predicate,https://schema.org/orderDelivery-input,< 1K
+Predicate,https://schema.org/orderDelivery-output,< 1K
+Predicate,https://schema.org/orderItemNumber,< 1K
+Predicate,https://schema.org/orderItemNumber-input,< 1K
+Predicate,https://schema.org/orderItemNumber-output,< 1K
+Predicate,https://schema.org/orderItemStatus,< 1K
+Predicate,https://schema.org/orderItemStatus-input,< 1K
+Predicate,https://schema.org/orderItemStatus-output,< 1K
+Predicate,https://schema.org/orderNumber,< 1K
+Predicate,https://schema.org/orderNumber-input,< 1K
+Predicate,https://schema.org/orderNumber-output,< 1K
+Predicate,https://schema.org/orderPercentage,< 1K
+Predicate,https://schema.org/orderPercentage-input,< 1K
+Predicate,https://schema.org/orderPercentage-output,< 1K
+Predicate,https://schema.org/orderQuantity,< 1K
+Predicate,https://schema.org/orderQuantity-input,< 1K
+Predicate,https://schema.org/orderQuantity-output,< 1K
+Predicate,https://schema.org/orderStatus,< 1K
+Predicate,https://schema.org/orderStatus-input,< 1K
+Predicate,https://schema.org/orderStatus-output,< 1K
+Predicate,https://schema.org/orderValue,< 1K
+Predicate,https://schema.org/orderValue-input,< 1K
+Predicate,https://schema.org/orderValue-output,< 1K
+Predicate,https://schema.org/orderedItem,< 1K
+Predicate,https://schema.org/orderedItem-input,< 1K
+Predicate,https://schema.org/orderedItem-output,< 1K
+Predicate,https://schema.org/organizer,100K - 1M
+Predicate,https://schema.org/organizer-input,< 1K
+Predicate,https://schema.org/organizer-output,< 1K
+Predicate,https://schema.org/originAddress,< 1K
+Predicate,https://schema.org/originAddress-input,< 1K
+Predicate,https://schema.org/originAddress-output,< 1K
+Predicate,https://schema.org/originalMediaContextDescription,< 1K
+Predicate,https://schema.org/originalMediaContextDescription-input,< 1K
+Predicate,https://schema.org/originalMediaContextDescription-output,< 1K
+Predicate,https://schema.org/originalMediaLink,< 1K
+Predicate,https://schema.org/originalMediaLink-input,< 1K
+Predicate,https://schema.org/originalMediaLink-output,< 1K
+Predicate,https://schema.org/originatesFrom,< 1K
+Predicate,https://schema.org/originatesFrom-input,< 1K
+Predicate,https://schema.org/originatesFrom-output,< 1K
+Predicate,https://schema.org/overdosage,< 1K
+Predicate,https://schema.org/overdosage-input,< 1K
+Predicate,https://schema.org/overdosage-output,< 1K
+Predicate,https://schema.org/ownedFrom,< 1K
+Predicate,https://schema.org/ownedFrom-input,< 1K
+Predicate,https://schema.org/ownedFrom-output,< 1K
+Predicate,https://schema.org/ownedThrough,< 1K
+Predicate,https://schema.org/ownedThrough-input,< 1K
+Predicate,https://schema.org/ownedThrough-output,< 1K
+Predicate,https://schema.org/owner,1K - 10K
+Predicate,https://schema.org/owner-input,< 1K
+Predicate,https://schema.org/owner-output,< 1K
+Predicate,https://schema.org/ownershipFundingInfo,10K - 100K
+Predicate,https://schema.org/ownershipFundingInfo-input,< 1K
+Predicate,https://schema.org/ownershipFundingInfo-output,< 1K
+Predicate,https://schema.org/owns,10K - 100K
+Predicate,https://schema.org/owns-input,< 1K
+Predicate,https://schema.org/owns-output,< 1K
+Predicate,https://schema.org/pageEnd,1K - 10K
+Predicate,https://schema.org/pageEnd-input,< 1K
+Predicate,https://schema.org/pageEnd-output,< 1K
+Predicate,https://schema.org/pageStart,1K - 10K
+Predicate,https://schema.org/pageStart-input,< 1K
+Predicate,https://schema.org/pageStart-output,< 1K
+Predicate,https://schema.org/pagination,1K - 10K
+Predicate,https://schema.org/pagination-input,< 1K
+Predicate,https://schema.org/pagination-output,< 1K
+Predicate,https://schema.org/parent,1K - 10K
+Predicate,https://schema.org/parent-input,< 1K
+Predicate,https://schema.org/parent-output,< 1K
+Predicate,https://schema.org/parentItem,1K - 10K
+Predicate,https://schema.org/parentItem-input,< 1K
+Predicate,https://schema.org/parentItem-output,< 1K
+Predicate,https://schema.org/parentOrganization,100K - 1M
+Predicate,https://schema.org/parentOrganization-input,< 1K
+Predicate,https://schema.org/parentOrganization-output,< 1K
+Predicate,https://schema.org/parentService,< 1K
+Predicate,https://schema.org/parentService-input,< 1K
+Predicate,https://schema.org/parentService-output,< 1K
+Predicate,https://schema.org/parentTaxon,< 1K
+Predicate,https://schema.org/parentTaxon-input,< 1K
+Predicate,https://schema.org/parentTaxon-output,< 1K
+Predicate,https://schema.org/parents,< 1K
+Predicate,https://schema.org/parents-input,< 1K
+Predicate,https://schema.org/parents-output,< 1K
+Predicate,https://schema.org/partOfEpisode,< 1K
+Predicate,https://schema.org/partOfEpisode-input,< 1K
+Predicate,https://schema.org/partOfEpisode-output,< 1K
+Predicate,https://schema.org/partOfInvoice,< 1K
+Predicate,https://schema.org/partOfInvoice-input,< 1K
+Predicate,https://schema.org/partOfInvoice-output,< 1K
+Predicate,https://schema.org/partOfOrder,< 1K
+Predicate,https://schema.org/partOfOrder-input,< 1K
+Predicate,https://schema.org/partOfOrder-output,< 1K
+Predicate,https://schema.org/partOfSeason,1K - 10K
+Predicate,https://schema.org/partOfSeason-input,< 1K
+Predicate,https://schema.org/partOfSeason-output,< 1K
+Predicate,https://schema.org/partOfSeries,10K - 100K
+Predicate,https://schema.org/partOfSeries-input,< 1K
+Predicate,https://schema.org/partOfSeries-output,< 1K
+Predicate,https://schema.org/partOfSystem,< 1K
+Predicate,https://schema.org/partOfSystem-input,< 1K
+Predicate,https://schema.org/partOfSystem-output,< 1K
+Predicate,https://schema.org/partOfTVSeries,< 1K
+Predicate,https://schema.org/partOfTVSeries-input,< 1K
+Predicate,https://schema.org/partOfTVSeries-output,< 1K
+Predicate,https://schema.org/partOfTrip,< 1K
+Predicate,https://schema.org/partOfTrip-input,< 1K
+Predicate,https://schema.org/partOfTrip-output,< 1K
+Predicate,https://schema.org/participant,1K - 10K
+Predicate,https://schema.org/participant-input,< 1K
+Predicate,https://schema.org/participant-output,< 1K
+Predicate,https://schema.org/partySize,< 1K
+Predicate,https://schema.org/partySize-input,< 1K
+Predicate,https://schema.org/partySize-output,< 1K
+Predicate,https://schema.org/passengerPriorityStatus,< 1K
+Predicate,https://schema.org/passengerPriorityStatus-input,< 1K
+Predicate,https://schema.org/passengerPriorityStatus-output,< 1K
+Predicate,https://schema.org/passengerSequenceNumber,< 1K
+Predicate,https://schema.org/passengerSequenceNumber-input,< 1K
+Predicate,https://schema.org/passengerSequenceNumber-output,< 1K
+Predicate,https://schema.org/pathophysiology,< 1K
+Predicate,https://schema.org/pathophysiology-input,< 1K
+Predicate,https://schema.org/pathophysiology-output,< 1K
+Predicate,https://schema.org/pattern,1K - 10K
+Predicate,https://schema.org/pattern-input,< 1K
+Predicate,https://schema.org/pattern-output,< 1K
+Predicate,https://schema.org/payload,1K - 10K
+Predicate,https://schema.org/payload-input,< 1K
+Predicate,https://schema.org/payload-output,< 1K
+Predicate,https://schema.org/paymentAccepted,100K - 1M
+Predicate,https://schema.org/paymentAccepted-input,< 1K
+Predicate,https://schema.org/paymentAccepted-output,< 1K
+Predicate,https://schema.org/paymentDue,< 1K
+Predicate,https://schema.org/paymentDue-input,< 1K
+Predicate,https://schema.org/paymentDue-output,< 1K
+Predicate,https://schema.org/paymentDueDate,< 1K
+Predicate,https://schema.org/paymentDueDate-input,< 1K
+Predicate,https://schema.org/paymentDueDate-output,< 1K
+Predicate,https://schema.org/paymentMethod,< 1K
+Predicate,https://schema.org/paymentMethod-input,< 1K
+Predicate,https://schema.org/paymentMethod-output,< 1K
+Predicate,https://schema.org/paymentMethodId,< 1K
+Predicate,https://schema.org/paymentMethodId-input,< 1K
+Predicate,https://schema.org/paymentMethodId-output,< 1K
+Predicate,https://schema.org/paymentMethodType,1K - 10K
+Predicate,https://schema.org/paymentMethodType-input,< 1K
+Predicate,https://schema.org/paymentMethodType-output,< 1K
+Predicate,https://schema.org/paymentStatus,< 1K
+Predicate,https://schema.org/paymentStatus-input,< 1K
+Predicate,https://schema.org/paymentStatus-output,< 1K
+Predicate,https://schema.org/paymentUrl,< 1K
+Predicate,https://schema.org/paymentUrl-input,< 1K
+Predicate,https://schema.org/paymentUrl-output,< 1K
+Predicate,https://schema.org/penciler,< 1K
+Predicate,https://schema.org/penciler-input,< 1K
+Predicate,https://schema.org/penciler-output,< 1K
+Predicate,https://schema.org/percentile10,1K - 10K
+Predicate,https://schema.org/percentile10-input,< 1K
+Predicate,https://schema.org/percentile10-output,< 1K
+Predicate,https://schema.org/percentile25,1K - 10K
+Predicate,https://schema.org/percentile25-input,< 1K
+Predicate,https://schema.org/percentile25-output,< 1K
+Predicate,https://schema.org/percentile75,1K - 10K
+Predicate,https://schema.org/percentile75-input,< 1K
+Predicate,https://schema.org/percentile75-output,< 1K
+Predicate,https://schema.org/percentile90,1K - 10K
+Predicate,https://schema.org/percentile90-input,< 1K
+Predicate,https://schema.org/percentile90-output,< 1K
+Predicate,https://schema.org/performTime,1K - 10K
+Predicate,https://schema.org/performTime-input,< 1K
+Predicate,https://schema.org/performTime-output,< 1K
+Predicate,https://schema.org/performer,100K - 1M
+Predicate,https://schema.org/performer-input,< 1K
+Predicate,https://schema.org/performer-output,< 1K
+Predicate,https://schema.org/performerIn,1K - 10K
+Predicate,https://schema.org/performerIn-input,< 1K
+Predicate,https://schema.org/performerIn-output,< 1K
+Predicate,https://schema.org/performers,10K - 100K
+Predicate,https://schema.org/performers-input,< 1K
+Predicate,https://schema.org/performers-output,< 1K
+Predicate,https://schema.org/permissionType,< 1K
+Predicate,https://schema.org/permissionType-input,< 1K
+Predicate,https://schema.org/permissionType-output,< 1K
+Predicate,https://schema.org/permissions,10K - 100K
+Predicate,https://schema.org/permissions-input,< 1K
+Predicate,https://schema.org/permissions-output,< 1K
+Predicate,https://schema.org/permitAudience,< 1K
+Predicate,https://schema.org/permitAudience-input,< 1K
+Predicate,https://schema.org/permitAudience-output,< 1K
+Predicate,https://schema.org/permittedUsage,< 1K
+Predicate,https://schema.org/permittedUsage-input,< 1K
+Predicate,https://schema.org/permittedUsage-output,< 1K
+Predicate,https://schema.org/petsAllowed,10K - 100K
+Predicate,https://schema.org/petsAllowed-input,< 1K
+Predicate,https://schema.org/petsAllowed-output,< 1K
+Predicate,https://schema.org/phoneticText,< 1K
+Predicate,https://schema.org/phoneticText-input,< 1K
+Predicate,https://schema.org/phoneticText-output,< 1K
+Predicate,https://schema.org/photo,10K - 100K
+Predicate,https://schema.org/photo-input,< 1K
+Predicate,https://schema.org/photo-output,< 1K
+Predicate,https://schema.org/photos,10K - 100K
+Predicate,https://schema.org/photos-input,< 1K
+Predicate,https://schema.org/photos-output,< 1K
+Predicate,https://schema.org/physicalRequirement,< 1K
+Predicate,https://schema.org/physicalRequirement-input,< 1K
+Predicate,https://schema.org/physicalRequirement-output,< 1K
+Predicate,https://schema.org/physiologicalBenefits,< 1K
+Predicate,https://schema.org/physiologicalBenefits-input,< 1K
+Predicate,https://schema.org/physiologicalBenefits-output,< 1K
+Predicate,https://schema.org/pickupLocation,< 1K
+Predicate,https://schema.org/pickupLocation-input,< 1K
+Predicate,https://schema.org/pickupLocation-output,< 1K
+Predicate,https://schema.org/pickupTime,< 1K
+Predicate,https://schema.org/pickupTime-input,< 1K
+Predicate,https://schema.org/pickupTime-output,< 1K
+Predicate,https://schema.org/playMode,10K - 100K
+Predicate,https://schema.org/playMode-input,< 1K
+Predicate,https://schema.org/playMode-output,< 1K
+Predicate,https://schema.org/playerType,1K - 10K
+Predicate,https://schema.org/playerType-input,< 1K
+Predicate,https://schema.org/playerType-output,< 1K
+Predicate,https://schema.org/playersOnline,1K - 10K
+Predicate,https://schema.org/playersOnline-input,< 1K
+Predicate,https://schema.org/playersOnline-output,< 1K
+Predicate,https://schema.org/polygon,1K - 10K
+Predicate,https://schema.org/polygon-input,< 1K
+Predicate,https://schema.org/polygon-output,< 1K
+Predicate,https://schema.org/populationType,< 1K
+Predicate,https://schema.org/populationType-input,< 1K
+Predicate,https://schema.org/populationType-output,< 1K
+Predicate,https://schema.org/position,10M+
+Predicate,https://schema.org/position-input,< 1K
+Predicate,https://schema.org/position-output,< 1K
+Predicate,https://schema.org/positiveNotes,10K - 100K
+Predicate,https://schema.org/positiveNotes-input,< 1K
+Predicate,https://schema.org/positiveNotes-output,< 1K
+Predicate,https://schema.org/possibleComplication,1K - 10K
+Predicate,https://schema.org/possibleComplication-input,< 1K
+Predicate,https://schema.org/possibleComplication-output,< 1K
+Predicate,https://schema.org/possibleTreatment,1K - 10K
+Predicate,https://schema.org/possibleTreatment-input,< 1K
+Predicate,https://schema.org/possibleTreatment-output,< 1K
+Predicate,https://schema.org/postOfficeBoxNumber,10K - 100K
+Predicate,https://schema.org/postOfficeBoxNumber-input,< 1K
+Predicate,https://schema.org/postOfficeBoxNumber-output,< 1K
+Predicate,https://schema.org/postOp,< 1K
+Predicate,https://schema.org/postOp-input,< 1K
+Predicate,https://schema.org/postOp-output,< 1K
+Predicate,https://schema.org/postalCode,1M - 10M
+Predicate,https://schema.org/postalCode-input,< 1K
+Predicate,https://schema.org/postalCode-output,< 1K
+Predicate,https://schema.org/postalCodeBegin,1K - 10K
+Predicate,https://schema.org/postalCodeBegin-input,< 1K
+Predicate,https://schema.org/postalCodeBegin-output,< 1K
+Predicate,https://schema.org/postalCodeEnd,1K - 10K
+Predicate,https://schema.org/postalCodeEnd-input,< 1K
+Predicate,https://schema.org/postalCodeEnd-output,< 1K
+Predicate,https://schema.org/postalCodePrefix,< 1K
+Predicate,https://schema.org/postalCodePrefix-input,< 1K
+Predicate,https://schema.org/postalCodePrefix-output,< 1K
+Predicate,https://schema.org/postalCodeRange,1K - 10K
+Predicate,https://schema.org/postalCodeRange-input,< 1K
+Predicate,https://schema.org/postalCodeRange-output,< 1K
+Predicate,https://schema.org/potentialAction,10M+
+Predicate,https://schema.org/potentialAction-input,< 1K
+Predicate,https://schema.org/potentialAction-output,< 1K
+Predicate,https://schema.org/potentialUse,< 1K
+Predicate,https://schema.org/potentialUse-input,< 1K
+Predicate,https://schema.org/potentialUse-output,< 1K
+Predicate,https://schema.org/practicesAt,1K - 10K
+Predicate,https://schema.org/practicesAt-input,< 1K
+Predicate,https://schema.org/practicesAt-output,< 1K
+Predicate,https://schema.org/preOp,< 1K
+Predicate,https://schema.org/preOp-input,< 1K
+Predicate,https://schema.org/preOp-output,< 1K
+Predicate,https://schema.org/predecessorOf,< 1K
+Predicate,https://schema.org/predecessorOf-input,< 1K
+Predicate,https://schema.org/predecessorOf-output,< 1K
+Predicate,https://schema.org/pregnancyCategory,< 1K
+Predicate,https://schema.org/pregnancyCategory-input,< 1K
+Predicate,https://schema.org/pregnancyCategory-output,< 1K
+Predicate,https://schema.org/pregnancyWarning,< 1K
+Predicate,https://schema.org/pregnancyWarning-input,< 1K
+Predicate,https://schema.org/pregnancyWarning-output,< 1K
+Predicate,https://schema.org/prepTime,10K - 100K
+Predicate,https://schema.org/prepTime-input,< 1K
+Predicate,https://schema.org/prepTime-output,< 1K
+Predicate,https://schema.org/preparation,1K - 10K
+Predicate,https://schema.org/preparation-input,< 1K
+Predicate,https://schema.org/preparation-output,< 1K
+Predicate,https://schema.org/prescribingInfo,< 1K
+Predicate,https://schema.org/prescribingInfo-input,< 1K
+Predicate,https://schema.org/prescribingInfo-output,< 1K
+Predicate,https://schema.org/prescriptionStatus,1K - 10K
+Predicate,https://schema.org/prescriptionStatus-input,< 1K
+Predicate,https://schema.org/prescriptionStatus-output,< 1K
+Predicate,https://schema.org/previousItem,1M - 10M
+Predicate,https://schema.org/previousItem-input,< 1K
+Predicate,https://schema.org/previousItem-output,< 1K
+Predicate,https://schema.org/previousStartDate,1K - 10K
+Predicate,https://schema.org/previousStartDate-input,< 1K
+Predicate,https://schema.org/previousStartDate-output,< 1K
+Predicate,https://schema.org/price,10M+
+Predicate,https://schema.org/price-input,< 1K
+Predicate,https://schema.org/price-output,< 1K
+Predicate,https://schema.org/priceComponent,1K - 10K
+Predicate,https://schema.org/priceComponent-input,< 1K
+Predicate,https://schema.org/priceComponent-output,< 1K
+Predicate,https://schema.org/priceComponentType,< 1K
+Predicate,https://schema.org/priceComponentType-input,< 1K
+Predicate,https://schema.org/priceComponentType-output,< 1K
+Predicate,https://schema.org/priceCurrency,10M+
+Predicate,https://schema.org/priceCurrency-input,< 1K
+Predicate,https://schema.org/priceCurrency-output,< 1K
+Predicate,https://schema.org/priceRange,1M - 10M
+Predicate,https://schema.org/priceRange-input,< 1K
+Predicate,https://schema.org/priceRange-output,< 1K
+Predicate,https://schema.org/priceSpecification,1M - 10M
+Predicate,https://schema.org/priceSpecification-input,< 1K
+Predicate,https://schema.org/priceSpecification-output,< 1K
+Predicate,https://schema.org/priceType,100K - 1M
+Predicate,https://schema.org/priceType-input,< 1K
+Predicate,https://schema.org/priceType-output,< 1K
+Predicate,https://schema.org/priceValidUntil,1M - 10M
+Predicate,https://schema.org/priceValidUntil-input,< 1K
+Predicate,https://schema.org/priceValidUntil-output,< 1K
+Predicate,https://schema.org/primaryImageOfPage,10M+
+Predicate,https://schema.org/primaryImageOfPage-input,< 1K
+Predicate,https://schema.org/primaryImageOfPage-output,< 1K
+Predicate,https://schema.org/primaryPrevention,< 1K
+Predicate,https://schema.org/primaryPrevention-input,< 1K
+Predicate,https://schema.org/primaryPrevention-output,< 1K
+Predicate,https://schema.org/printColumn,< 1K
+Predicate,https://schema.org/printColumn-input,< 1K
+Predicate,https://schema.org/printColumn-output,< 1K
+Predicate,https://schema.org/printEdition,< 1K
+Predicate,https://schema.org/printEdition-input,< 1K
+Predicate,https://schema.org/printEdition-output,< 1K
+Predicate,https://schema.org/printPage,< 1K
+Predicate,https://schema.org/printPage-input,< 1K
+Predicate,https://schema.org/printPage-output,< 1K
+Predicate,https://schema.org/printSection,< 1K
+Predicate,https://schema.org/printSection-input,< 1K
+Predicate,https://schema.org/printSection-output,< 1K
+Predicate,https://schema.org/procedure,< 1K
+Predicate,https://schema.org/procedure-input,< 1K
+Predicate,https://schema.org/procedure-output,< 1K
+Predicate,https://schema.org/procedureType,10K - 100K
+Predicate,https://schema.org/procedureType-input,< 1K
+Predicate,https://schema.org/procedureType-output,< 1K
+Predicate,https://schema.org/processingTime,< 1K
+Predicate,https://schema.org/processingTime-input,< 1K
+Predicate,https://schema.org/processingTime-output,< 1K
+Predicate,https://schema.org/processorRequirements,1K - 10K
+Predicate,https://schema.org/processorRequirements-input,< 1K
+Predicate,https://schema.org/processorRequirements-output,< 1K
+Predicate,https://schema.org/producer,1K - 10K
+Predicate,https://schema.org/producer-input,< 1K
+Predicate,https://schema.org/producer-output,< 1K
+Predicate,https://schema.org/produces,< 1K
+Predicate,https://schema.org/produces-input,< 1K
+Predicate,https://schema.org/produces-output,< 1K
+Predicate,https://schema.org/productGroupID,100K - 1M
+Predicate,https://schema.org/productGroupID-input,< 1K
+Predicate,https://schema.org/productGroupID-output,< 1K
+Predicate,https://schema.org/productID,100K - 1M
+Predicate,https://schema.org/productID-input,< 1K
+Predicate,https://schema.org/productID-output,< 1K
+Predicate,https://schema.org/productReturnDays,< 1K
+Predicate,https://schema.org/productReturnDays-input,< 1K
+Predicate,https://schema.org/productReturnDays-output,< 1K
+Predicate,https://schema.org/productReturnLink,< 1K
+Predicate,https://schema.org/productReturnLink-input,< 1K
+Predicate,https://schema.org/productReturnLink-output,< 1K
+Predicate,https://schema.org/productSupported,1K - 10K
+Predicate,https://schema.org/productSupported-input,< 1K
+Predicate,https://schema.org/productSupported-output,< 1K
+Predicate,https://schema.org/productionCompany,1K - 10K
+Predicate,https://schema.org/productionCompany-input,< 1K
+Predicate,https://schema.org/productionCompany-output,< 1K
+Predicate,https://schema.org/productionDate,10K - 100K
+Predicate,https://schema.org/productionDate-input,< 1K
+Predicate,https://schema.org/productionDate-output,< 1K
+Predicate,https://schema.org/proficiencyLevel,10K - 100K
+Predicate,https://schema.org/proficiencyLevel-input,< 1K
+Predicate,https://schema.org/proficiencyLevel-output,< 1K
+Predicate,https://schema.org/program,< 1K
+Predicate,https://schema.org/program-input,< 1K
+Predicate,https://schema.org/program-output,< 1K
+Predicate,https://schema.org/programMembershipUsed,< 1K
+Predicate,https://schema.org/programMembershipUsed-input,< 1K
+Predicate,https://schema.org/programMembershipUsed-output,< 1K
+Predicate,https://schema.org/programName,1K - 10K
+Predicate,https://schema.org/programName-input,< 1K
+Predicate,https://schema.org/programName-output,< 1K
+Predicate,https://schema.org/programPrerequisites,1K - 10K
+Predicate,https://schema.org/programPrerequisites-input,< 1K
+Predicate,https://schema.org/programPrerequisites-output,< 1K
+Predicate,https://schema.org/programType,1K - 10K
+Predicate,https://schema.org/programType-input,< 1K
+Predicate,https://schema.org/programType-output,< 1K
+Predicate,https://schema.org/programmingLanguage,1K - 10K
+Predicate,https://schema.org/programmingLanguage-input,< 1K
+Predicate,https://schema.org/programmingLanguage-output,< 1K
+Predicate,https://schema.org/programmingModel,< 1K
+Predicate,https://schema.org/programmingModel-input,< 1K
+Predicate,https://schema.org/programmingModel-output,< 1K
+Predicate,https://schema.org/pronouns,1K - 10K
+Predicate,https://schema.org/pronouns-input,< 1K
+Predicate,https://schema.org/pronouns-output,< 1K
+Predicate,https://schema.org/propertyID,10K - 100K
+Predicate,https://schema.org/propertyID-input,< 1K
+Predicate,https://schema.org/propertyID-output,< 1K
+Predicate,https://schema.org/proprietaryName,< 1K
+Predicate,https://schema.org/proprietaryName-input,< 1K
+Predicate,https://schema.org/proprietaryName-output,< 1K
+Predicate,https://schema.org/proteinContent,10K - 100K
+Predicate,https://schema.org/proteinContent-input,< 1K
+Predicate,https://schema.org/proteinContent-output,< 1K
+Predicate,https://schema.org/provider,1M - 10M
+Predicate,https://schema.org/provider-input,< 1K
+Predicate,https://schema.org/provider-output,< 1K
+Predicate,https://schema.org/providerMobility,1K - 10K
+Predicate,https://schema.org/providerMobility-input,< 1K
+Predicate,https://schema.org/providerMobility-output,< 1K
+Predicate,https://schema.org/providesBroadcastService,< 1K
+Predicate,https://schema.org/providesBroadcastService-input,< 1K
+Predicate,https://schema.org/providesBroadcastService-output,< 1K
+Predicate,https://schema.org/providesService,< 1K
+Predicate,https://schema.org/providesService-input,< 1K
+Predicate,https://schema.org/providesService-output,< 1K
+Predicate,https://schema.org/publicAccess,10K - 100K
+Predicate,https://schema.org/publicAccess-input,< 1K
+Predicate,https://schema.org/publicAccess-output,< 1K
+Predicate,https://schema.org/publicTransportClosuresInfo,< 1K
+Predicate,https://schema.org/publicTransportClosuresInfo-input,< 1K
+Predicate,https://schema.org/publicTransportClosuresInfo-output,< 1K
+Predicate,https://schema.org/publication,1K - 10K
+Predicate,https://schema.org/publication-input,< 1K
+Predicate,https://schema.org/publication-output,< 1K
+Predicate,https://schema.org/publicationType,< 1K
+Predicate,https://schema.org/publicationType-input,< 1K
+Predicate,https://schema.org/publicationType-output,< 1K
+Predicate,https://schema.org/publishedBy,< 1K
+Predicate,https://schema.org/publishedBy-input,< 1K
+Predicate,https://schema.org/publishedBy-output,< 1K
+Predicate,https://schema.org/publishedOn,< 1K
+Predicate,https://schema.org/publishedOn-input,< 1K
+Predicate,https://schema.org/publishedOn-output,< 1K
+Predicate,https://schema.org/publisher,10M+
+Predicate,https://schema.org/publisher-input,< 1K
+Predicate,https://schema.org/publisher-output,< 1K
+Predicate,https://schema.org/publisherImprint,< 1K
+Predicate,https://schema.org/publisherImprint-input,< 1K
+Predicate,https://schema.org/publisherImprint-output,< 1K
+Predicate,https://schema.org/publishingPrinciples,10K - 100K
+Predicate,https://schema.org/publishingPrinciples-input,< 1K
+Predicate,https://schema.org/publishingPrinciples-output,< 1K
+Predicate,https://schema.org/purchaseDate,< 1K
+Predicate,https://schema.org/purchaseDate-input,< 1K
+Predicate,https://schema.org/purchaseDate-output,< 1K
+Predicate,https://schema.org/purchasePriceLimit,< 1K
+Predicate,https://schema.org/purchasePriceLimit-input,< 1K
+Predicate,https://schema.org/purchasePriceLimit-output,< 1K
+Predicate,https://schema.org/purchaseType,< 1K
+Predicate,https://schema.org/purchaseType-input,< 1K
+Predicate,https://schema.org/purchaseType-output,< 1K
+Predicate,https://schema.org/qualifications,10K - 100K
+Predicate,https://schema.org/qualifications-input,< 1K
+Predicate,https://schema.org/qualifications-output,< 1K
+Predicate,https://schema.org/qualifiedExpense,< 1K
+Predicate,https://schema.org/qualifiedExpense-input,< 1K
+Predicate,https://schema.org/qualifiedExpense-output,< 1K
+Predicate,https://schema.org/quarantineGuidelines,< 1K
+Predicate,https://schema.org/quarantineGuidelines-input,< 1K
+Predicate,https://schema.org/quarantineGuidelines-output,< 1K
+Predicate,https://schema.org/query,10K - 100K
+Predicate,https://schema.org/query-input,10M+
+Predicate,https://schema.org/query-output,< 1K
+Predicate,https://schema.org/quest,< 1K
+Predicate,https://schema.org/quest-input,< 1K
+Predicate,https://schema.org/quest-output,< 1K
+Predicate,https://schema.org/question,< 1K
+Predicate,https://schema.org/question-input,< 1K
+Predicate,https://schema.org/question-output,< 1K
+Predicate,https://schema.org/rangeIncludes,< 1K
+Predicate,https://schema.org/rangeIncludes-input,< 1K
+Predicate,https://schema.org/rangeIncludes-output,< 1K
+Predicate,https://schema.org/ratingCount,1M - 10M
+Predicate,https://schema.org/ratingCount-input,< 1K
+Predicate,https://schema.org/ratingCount-output,< 1K
+Predicate,https://schema.org/ratingExplanation,1K - 10K
+Predicate,https://schema.org/ratingExplanation-input,< 1K
+Predicate,https://schema.org/ratingExplanation-output,< 1K
+Predicate,https://schema.org/ratingValue,1M - 10M
+Predicate,https://schema.org/ratingValue-input,< 1K
+Predicate,https://schema.org/ratingValue-output,< 1K
+Predicate,https://schema.org/readBy,< 1K
+Predicate,https://schema.org/readBy-input,< 1K
+Predicate,https://schema.org/readBy-output,< 1K
+Predicate,https://schema.org/readonlyValue,< 1K
+Predicate,https://schema.org/readonlyValue-input,< 1K
+Predicate,https://schema.org/readonlyValue-output,< 1K
+Predicate,https://schema.org/realEstateAgent,< 1K
+Predicate,https://schema.org/realEstateAgent-input,< 1K
+Predicate,https://schema.org/realEstateAgent-output,< 1K
+Predicate,https://schema.org/recipe,< 1K
+Predicate,https://schema.org/recipe-input,< 1K
+Predicate,https://schema.org/recipe-output,< 1K
+Predicate,https://schema.org/recipeCategory,10K - 100K
+Predicate,https://schema.org/recipeCategory-input,< 1K
+Predicate,https://schema.org/recipeCategory-output,< 1K
+Predicate,https://schema.org/recipeCuisine,10K - 100K
+Predicate,https://schema.org/recipeCuisine-input,< 1K
+Predicate,https://schema.org/recipeCuisine-output,< 1K
+Predicate,https://schema.org/recipeIngredient,10K - 100K
+Predicate,https://schema.org/recipeIngredient-input,< 1K
+Predicate,https://schema.org/recipeIngredient-output,< 1K
+Predicate,https://schema.org/recipeInstructions,10K - 100K
+Predicate,https://schema.org/recipeInstructions-input,< 1K
+Predicate,https://schema.org/recipeInstructions-output,< 1K
+Predicate,https://schema.org/recipeYield,10K - 100K
+Predicate,https://schema.org/recipeYield-input,< 1K
+Predicate,https://schema.org/recipeYield-output,< 1K
+Predicate,https://schema.org/recipient,1K - 10K
+Predicate,https://schema.org/recipient-input,< 1K
+Predicate,https://schema.org/recipient-output,< 1K
+Predicate,https://schema.org/recognizedBy,10K - 100K
+Predicate,https://schema.org/recognizedBy-input,< 1K
+Predicate,https://schema.org/recognizedBy-output,< 1K
+Predicate,https://schema.org/recognizingAuthority,1K - 10K
+Predicate,https://schema.org/recognizingAuthority-input,< 1K
+Predicate,https://schema.org/recognizingAuthority-output,< 1K
+Predicate,https://schema.org/recommendationStrength,< 1K
+Predicate,https://schema.org/recommendationStrength-input,< 1K
+Predicate,https://schema.org/recommendationStrength-output,< 1K
+Predicate,https://schema.org/recommendedIntake,< 1K
+Predicate,https://schema.org/recommendedIntake-input,< 1K
+Predicate,https://schema.org/recommendedIntake-output,< 1K
+Predicate,https://schema.org/recordLabel,1K - 10K
+Predicate,https://schema.org/recordLabel-input,< 1K
+Predicate,https://schema.org/recordLabel-output,< 1K
+Predicate,https://schema.org/recordedAs,< 1K
+Predicate,https://schema.org/recordedAs-input,< 1K
+Predicate,https://schema.org/recordedAs-output,< 1K
+Predicate,https://schema.org/recordedAt,< 1K
+Predicate,https://schema.org/recordedAt-input,< 1K
+Predicate,https://schema.org/recordedAt-output,< 1K
+Predicate,https://schema.org/recordedIn,< 1K
+Predicate,https://schema.org/recordedIn-input,< 1K
+Predicate,https://schema.org/recordedIn-output,< 1K
+Predicate,https://schema.org/recordingOf,1K - 10K
+Predicate,https://schema.org/recordingOf-input,< 1K
+Predicate,https://schema.org/recordingOf-output,< 1K
+Predicate,https://schema.org/recourseLoan,< 1K
+Predicate,https://schema.org/recourseLoan-input,< 1K
+Predicate,https://schema.org/recourseLoan-output,< 1K
+Predicate,https://schema.org/referee,< 1K
+Predicate,https://schema.org/referee-input,< 1K
+Predicate,https://schema.org/referee-output,< 1K
+Predicate,https://schema.org/referenceQuantity,1M - 10M
+Predicate,https://schema.org/referenceQuantity-input,< 1K
+Predicate,https://schema.org/referenceQuantity-output,< 1K
+Predicate,https://schema.org/referencesOrder,< 1K
+Predicate,https://schema.org/referencesOrder-input,< 1K
+Predicate,https://schema.org/referencesOrder-output,< 1K
+Predicate,https://schema.org/refundType,10K - 100K
+Predicate,https://schema.org/refundType-input,< 1K
+Predicate,https://schema.org/refundType-output,< 1K
+Predicate,https://schema.org/regionDrained,< 1K
+Predicate,https://schema.org/regionDrained-input,< 1K
+Predicate,https://schema.org/regionDrained-output,< 1K
+Predicate,https://schema.org/regionsAllowed,10K - 100K
+Predicate,https://schema.org/regionsAllowed-input,< 1K
+Predicate,https://schema.org/regionsAllowed-output,< 1K
+Predicate,https://schema.org/relatedAnatomy,< 1K
+Predicate,https://schema.org/relatedAnatomy-input,< 1K
+Predicate,https://schema.org/relatedAnatomy-output,< 1K
+Predicate,https://schema.org/relatedCondition,< 1K
+Predicate,https://schema.org/relatedCondition-input,< 1K
+Predicate,https://schema.org/relatedCondition-output,< 1K
+Predicate,https://schema.org/relatedDrug,< 1K
+Predicate,https://schema.org/relatedDrug-input,< 1K
+Predicate,https://schema.org/relatedDrug-output,< 1K
+Predicate,https://schema.org/relatedLink,10K - 100K
+Predicate,https://schema.org/relatedLink-input,< 1K
+Predicate,https://schema.org/relatedLink-output,< 1K
+Predicate,https://schema.org/relatedStructure,< 1K
+Predicate,https://schema.org/relatedStructure-input,< 1K
+Predicate,https://schema.org/relatedStructure-output,< 1K
+Predicate,https://schema.org/relatedTherapy,< 1K
+Predicate,https://schema.org/relatedTherapy-input,< 1K
+Predicate,https://schema.org/relatedTherapy-output,< 1K
+Predicate,https://schema.org/relatedTo,< 1K
+Predicate,https://schema.org/relatedTo-input,< 1K
+Predicate,https://schema.org/relatedTo-output,< 1K
+Predicate,https://schema.org/releaseDate,10K - 100K
+Predicate,https://schema.org/releaseDate-input,< 1K
+Predicate,https://schema.org/releaseDate-output,< 1K
+Predicate,https://schema.org/releaseNotes,10K - 100K
+Predicate,https://schema.org/releaseNotes-input,< 1K
+Predicate,https://schema.org/releaseNotes-output,< 1K
+Predicate,https://schema.org/releaseOf,< 1K
+Predicate,https://schema.org/releaseOf-input,< 1K
+Predicate,https://schema.org/releaseOf-output,< 1K
+Predicate,https://schema.org/releasedEvent,1K - 10K
+Predicate,https://schema.org/releasedEvent-input,< 1K
+Predicate,https://schema.org/releasedEvent-output,< 1K
+Predicate,https://schema.org/relevantOccupation,< 1K
+Predicate,https://schema.org/relevantOccupation-input,< 1K
+Predicate,https://schema.org/relevantOccupation-output,< 1K
+Predicate,https://schema.org/relevantSpecialty,1K - 10K
+Predicate,https://schema.org/relevantSpecialty-input,< 1K
+Predicate,https://schema.org/relevantSpecialty-output,< 1K
+Predicate,https://schema.org/remainingAttendeeCapacity,1K - 10K
+Predicate,https://schema.org/remainingAttendeeCapacity-input,< 1K
+Predicate,https://schema.org/remainingAttendeeCapacity-output,< 1K
+Predicate,https://schema.org/renegotiableLoan,< 1K
+Predicate,https://schema.org/renegotiableLoan-input,< 1K
+Predicate,https://schema.org/renegotiableLoan-output,< 1K
+Predicate,https://schema.org/repeatCount,1K - 10K
+Predicate,https://schema.org/repeatCount-input,< 1K
+Predicate,https://schema.org/repeatCount-output,< 1K
+Predicate,https://schema.org/repeatFrequency,10K - 100K
+Predicate,https://schema.org/repeatFrequency-input,< 1K
+Predicate,https://schema.org/repeatFrequency-output,< 1K
+Predicate,https://schema.org/repetitions,< 1K
+Predicate,https://schema.org/repetitions-input,< 1K
+Predicate,https://schema.org/repetitions-output,< 1K
+Predicate,https://schema.org/replacee,< 1K
+Predicate,https://schema.org/replacee-input,< 1K
+Predicate,https://schema.org/replacee-output,< 1K
+Predicate,https://schema.org/replacer,< 1K
+Predicate,https://schema.org/replacer-input,< 1K
+Predicate,https://schema.org/replacer-output,< 1K
+Predicate,https://schema.org/replyToUrl,1K - 10K
+Predicate,https://schema.org/replyToUrl-input,< 1K
+Predicate,https://schema.org/replyToUrl-output,< 1K
+Predicate,https://schema.org/reportNumber,< 1K
+Predicate,https://schema.org/reportNumber-input,< 1K
+Predicate,https://schema.org/reportNumber-output,< 1K
+Predicate,https://schema.org/representativeOfPage,100K - 1M
+Predicate,https://schema.org/representativeOfPage-input,< 1K
+Predicate,https://schema.org/representativeOfPage-output,< 1K
+Predicate,https://schema.org/requiredCollateral,< 1K
+Predicate,https://schema.org/requiredCollateral-input,< 1K
+Predicate,https://schema.org/requiredCollateral-output,< 1K
+Predicate,https://schema.org/requiredGender,< 1K
+Predicate,https://schema.org/requiredGender-input,< 1K
+Predicate,https://schema.org/requiredGender-output,< 1K
+Predicate,https://schema.org/requiredMaxAge,< 1K
+Predicate,https://schema.org/requiredMaxAge-input,< 1K
+Predicate,https://schema.org/requiredMaxAge-output,< 1K
+Predicate,https://schema.org/requiredMinAge,1K - 10K
+Predicate,https://schema.org/requiredMinAge-input,< 1K
+Predicate,https://schema.org/requiredMinAge-output,< 1K
+Predicate,https://schema.org/requiredQuantity,1K - 10K
+Predicate,https://schema.org/requiredQuantity-input,< 1K
+Predicate,https://schema.org/requiredQuantity-output,< 1K
+Predicate,https://schema.org/requirements,1K - 10K
+Predicate,https://schema.org/requirements-input,< 1K
+Predicate,https://schema.org/requirements-output,< 1K
+Predicate,https://schema.org/requiresSubscription,1K - 10K
+Predicate,https://schema.org/requiresSubscription-input,< 1K
+Predicate,https://schema.org/requiresSubscription-output,< 1K
+Predicate,https://schema.org/reservationFor,1K - 10K
+Predicate,https://schema.org/reservationFor-input,< 1K
+Predicate,https://schema.org/reservationFor-output,< 1K
+Predicate,https://schema.org/reservationId,< 1K
+Predicate,https://schema.org/reservationId-input,< 1K
+Predicate,https://schema.org/reservationId-output,< 1K
+Predicate,https://schema.org/reservationStatus,< 1K
+Predicate,https://schema.org/reservationStatus-input,< 1K
+Predicate,https://schema.org/reservationStatus-output,< 1K
+Predicate,https://schema.org/reservedTicket,< 1K
+Predicate,https://schema.org/reservedTicket-input,< 1K
+Predicate,https://schema.org/reservedTicket-output,< 1K
+Predicate,https://schema.org/responsibilities,10K - 100K
+Predicate,https://schema.org/responsibilities-input,< 1K
+Predicate,https://schema.org/responsibilities-output,< 1K
+Predicate,https://schema.org/restPeriods,< 1K
+Predicate,https://schema.org/restPeriods-input,< 1K
+Predicate,https://schema.org/restPeriods-output,< 1K
+Predicate,https://schema.org/restockingFee,1K - 10K
+Predicate,https://schema.org/restockingFee-input,< 1K
+Predicate,https://schema.org/restockingFee-output,< 1K
+Predicate,https://schema.org/result,10K - 100K
+Predicate,https://schema.org/result-input,< 1K
+Predicate,https://schema.org/result-output,< 1K
+Predicate,https://schema.org/resultComment,< 1K
+Predicate,https://schema.org/resultComment-input,< 1K
+Predicate,https://schema.org/resultComment-output,< 1K
+Predicate,https://schema.org/resultReview,< 1K
+Predicate,https://schema.org/resultReview-input,< 1K
+Predicate,https://schema.org/resultReview-output,< 1K
+Predicate,https://schema.org/returnFees,100K - 1M
+Predicate,https://schema.org/returnFees-input,< 1K
+Predicate,https://schema.org/returnFees-output,< 1K
+Predicate,https://schema.org/returnLabelSource,1K - 10K
+Predicate,https://schema.org/returnLabelSource-input,< 1K
+Predicate,https://schema.org/returnLabelSource-output,< 1K
+Predicate,https://schema.org/returnMethod,100K - 1M
+Predicate,https://schema.org/returnMethod-input,< 1K
+Predicate,https://schema.org/returnMethod-output,< 1K
+Predicate,https://schema.org/returnPolicyCategory,100K - 1M
+Predicate,https://schema.org/returnPolicyCategory-input,< 1K
+Predicate,https://schema.org/returnPolicyCategory-output,< 1K
+Predicate,https://schema.org/returnPolicyCountry,10K - 100K
+Predicate,https://schema.org/returnPolicyCountry-input,< 1K
+Predicate,https://schema.org/returnPolicyCountry-output,< 1K
+Predicate,https://schema.org/returnPolicySeasonalOverride,1K - 10K
+Predicate,https://schema.org/returnPolicySeasonalOverride-input,< 1K
+Predicate,https://schema.org/returnPolicySeasonalOverride-output,< 1K
+Predicate,https://schema.org/returnShippingFeesAmount,10K - 100K
+Predicate,https://schema.org/returnShippingFeesAmount-input,< 1K
+Predicate,https://schema.org/returnShippingFeesAmount-output,< 1K
+Predicate,https://schema.org/review,1M - 10M
+Predicate,https://schema.org/review-input,< 1K
+Predicate,https://schema.org/review-output,< 1K
+Predicate,https://schema.org/reviewAspect,10K - 100K
+Predicate,https://schema.org/reviewAspect-input,< 1K
+Predicate,https://schema.org/reviewAspect-output,< 1K
+Predicate,https://schema.org/reviewBody,1M - 10M
+Predicate,https://schema.org/reviewBody-input,< 1K
+Predicate,https://schema.org/reviewBody-output,< 1K
+Predicate,https://schema.org/reviewCount,1M - 10M
+Predicate,https://schema.org/reviewCount-input,< 1K
+Predicate,https://schema.org/reviewCount-output,< 1K
+Predicate,https://schema.org/reviewRating,1M - 10M
+Predicate,https://schema.org/reviewRating-input,< 1K
+Predicate,https://schema.org/reviewRating-output,< 1K
+Predicate,https://schema.org/reviewedBy,10K - 100K
+Predicate,https://schema.org/reviewedBy-input,< 1K
+Predicate,https://schema.org/reviewedBy-output,< 1K
+Predicate,https://schema.org/reviews,1K - 10K
+Predicate,https://schema.org/reviews-input,< 1K
+Predicate,https://schema.org/reviews-output,< 1K
+Predicate,https://schema.org/riskFactor,1K - 10K
+Predicate,https://schema.org/riskFactor-input,< 1K
+Predicate,https://schema.org/riskFactor-output,< 1K
+Predicate,https://schema.org/risks,< 1K
+Predicate,https://schema.org/risks-input,< 1K
+Predicate,https://schema.org/risks-output,< 1K
+Predicate,https://schema.org/roleName,1K - 10K
+Predicate,https://schema.org/roleName-input,< 1K
+Predicate,https://schema.org/roleName-output,< 1K
+Predicate,https://schema.org/roofLoad,< 1K
+Predicate,https://schema.org/roofLoad-input,< 1K
+Predicate,https://schema.org/roofLoad-output,< 1K
+Predicate,https://schema.org/rsvpResponse,< 1K
+Predicate,https://schema.org/rsvpResponse-input,< 1K
+Predicate,https://schema.org/rsvpResponse-output,< 1K
+Predicate,https://schema.org/runsTo,< 1K
+Predicate,https://schema.org/runsTo-input,< 1K
+Predicate,https://schema.org/runsTo-output,< 1K
+Predicate,https://schema.org/runtime,< 1K
+Predicate,https://schema.org/runtime-input,< 1K
+Predicate,https://schema.org/runtime-output,< 1K
+Predicate,https://schema.org/runtimePlatform,1K - 10K
+Predicate,https://schema.org/runtimePlatform-input,< 1K
+Predicate,https://schema.org/runtimePlatform-output,< 1K
+Predicate,https://schema.org/rxcui,< 1K
+Predicate,https://schema.org/rxcui-input,< 1K
+Predicate,https://schema.org/rxcui-output,< 1K
+Predicate,https://schema.org/safetyConsideration,< 1K
+Predicate,https://schema.org/safetyConsideration-input,< 1K
+Predicate,https://schema.org/safetyConsideration-output,< 1K
+Predicate,https://schema.org/salaryCurrency,1K - 10K
+Predicate,https://schema.org/salaryCurrency-input,< 1K
+Predicate,https://schema.org/salaryCurrency-output,< 1K
+Predicate,https://schema.org/salaryUponCompletion,< 1K
+Predicate,https://schema.org/salaryUponCompletion-input,< 1K
+Predicate,https://schema.org/salaryUponCompletion-output,< 1K
+Predicate,https://schema.org/sameAs,10M+
+Predicate,https://schema.org/sameAs-input,< 1K
+Predicate,https://schema.org/sameAs-output,< 1K
+Predicate,https://schema.org/sampleType,< 1K
+Predicate,https://schema.org/sampleType-input,< 1K
+Predicate,https://schema.org/sampleType-output,< 1K
+Predicate,https://schema.org/saturatedFatContent,10K - 100K
+Predicate,https://schema.org/saturatedFatContent-input,< 1K
+Predicate,https://schema.org/saturatedFatContent-output,< 1K
+Predicate,https://schema.org/scheduleTimezone,1K - 10K
+Predicate,https://schema.org/scheduleTimezone-input,< 1K
+Predicate,https://schema.org/scheduleTimezone-output,< 1K
+Predicate,https://schema.org/scheduledPaymentDate,< 1K
+Predicate,https://schema.org/scheduledPaymentDate-input,< 1K
+Predicate,https://schema.org/scheduledPaymentDate-output,< 1K
+Predicate,https://schema.org/scheduledTime,< 1K
+Predicate,https://schema.org/scheduledTime-input,< 1K
+Predicate,https://schema.org/scheduledTime-output,< 1K
+Predicate,https://schema.org/schemaVersion,< 1K
+Predicate,https://schema.org/schemaVersion-input,< 1K
+Predicate,https://schema.org/schemaVersion-output,< 1K
+Predicate,https://schema.org/schoolClosuresInfo,< 1K
+Predicate,https://schema.org/schoolClosuresInfo-input,< 1K
+Predicate,https://schema.org/schoolClosuresInfo-output,< 1K
+Predicate,https://schema.org/screenCount,< 1K
+Predicate,https://schema.org/screenCount-input,< 1K
+Predicate,https://schema.org/screenCount-output,< 1K
+Predicate,https://schema.org/screenshot,100K - 1M
+Predicate,https://schema.org/screenshot-input,< 1K
+Predicate,https://schema.org/screenshot-output,< 1K
+Predicate,https://schema.org/sdDatePublished,1K - 10K
+Predicate,https://schema.org/sdDatePublished-input,< 1K
+Predicate,https://schema.org/sdDatePublished-output,< 1K
+Predicate,https://schema.org/sdLicense,< 1K
+Predicate,https://schema.org/sdLicense-input,< 1K
+Predicate,https://schema.org/sdLicense-output,< 1K
+Predicate,https://schema.org/sdPublisher,1K - 10K
+Predicate,https://schema.org/sdPublisher-input,< 1K
+Predicate,https://schema.org/sdPublisher-output,< 1K
+Predicate,https://schema.org/season,1K - 10K
+Predicate,https://schema.org/season-input,< 1K
+Predicate,https://schema.org/season-output,< 1K
+Predicate,https://schema.org/seasonNumber,1K - 10K
+Predicate,https://schema.org/seasonNumber-input,< 1K
+Predicate,https://schema.org/seasonNumber-output,< 1K
+Predicate,https://schema.org/seasonalOverride,< 1K
+Predicate,https://schema.org/seasonalOverride-input,< 1K
+Predicate,https://schema.org/seasonalOverride-output,< 1K
+Predicate,https://schema.org/seasons,< 1K
+Predicate,https://schema.org/seasons-input,< 1K
+Predicate,https://schema.org/seasons-output,< 1K
+Predicate,https://schema.org/seatNumber,< 1K
+Predicate,https://schema.org/seatNumber-input,< 1K
+Predicate,https://schema.org/seatNumber-output,< 1K
+Predicate,https://schema.org/seatRow,< 1K
+Predicate,https://schema.org/seatRow-input,< 1K
+Predicate,https://schema.org/seatRow-output,< 1K
+Predicate,https://schema.org/seatSection,< 1K
+Predicate,https://schema.org/seatSection-input,< 1K
+Predicate,https://schema.org/seatSection-output,< 1K
+Predicate,https://schema.org/seatingCapacity,1K - 10K
+Predicate,https://schema.org/seatingCapacity-input,< 1K
+Predicate,https://schema.org/seatingCapacity-output,< 1K
+Predicate,https://schema.org/seatingType,< 1K
+Predicate,https://schema.org/seatingType-input,< 1K
+Predicate,https://schema.org/seatingType-output,< 1K
+Predicate,https://schema.org/secondaryPrevention,< 1K
+Predicate,https://schema.org/secondaryPrevention-input,< 1K
+Predicate,https://schema.org/secondaryPrevention-output,< 1K
+Predicate,https://schema.org/securityClearanceRequirement,< 1K
+Predicate,https://schema.org/securityClearanceRequirement-input,< 1K
+Predicate,https://schema.org/securityClearanceRequirement-output,< 1K
+Predicate,https://schema.org/securityScreening,< 1K
+Predicate,https://schema.org/securityScreening-input,< 1K
+Predicate,https://schema.org/securityScreening-output,< 1K
+Predicate,https://schema.org/seeks,1K - 10K
+Predicate,https://schema.org/seeks-input,< 1K
+Predicate,https://schema.org/seeks-output,< 1K
+Predicate,https://schema.org/seller,1M - 10M
+Predicate,https://schema.org/seller-input,< 1K
+Predicate,https://schema.org/seller-output,< 1K
+Predicate,https://schema.org/sender,< 1K
+Predicate,https://schema.org/sender-input,< 1K
+Predicate,https://schema.org/sender-output,< 1K
+Predicate,https://schema.org/sensoryRequirement,< 1K
+Predicate,https://schema.org/sensoryRequirement-input,< 1K
+Predicate,https://schema.org/sensoryRequirement-output,< 1K
+Predicate,https://schema.org/sensoryUnit,< 1K
+Predicate,https://schema.org/sensoryUnit-input,< 1K
+Predicate,https://schema.org/sensoryUnit-output,< 1K
+Predicate,https://schema.org/serialNumber,10K - 100K
+Predicate,https://schema.org/serialNumber-input,< 1K
+Predicate,https://schema.org/serialNumber-output,< 1K
+Predicate,https://schema.org/seriousAdverseOutcome,< 1K
+Predicate,https://schema.org/seriousAdverseOutcome-input,< 1K
+Predicate,https://schema.org/seriousAdverseOutcome-output,< 1K
+Predicate,https://schema.org/serverStatus,< 1K
+Predicate,https://schema.org/serverStatus-input,< 1K
+Predicate,https://schema.org/serverStatus-output,< 1K
+Predicate,https://schema.org/servesCuisine,100K - 1M
+Predicate,https://schema.org/servesCuisine-input,< 1K
+Predicate,https://schema.org/servesCuisine-output,< 1K
+Predicate,https://schema.org/serviceArea,10K - 100K
+Predicate,https://schema.org/serviceArea-input,< 1K
+Predicate,https://schema.org/serviceArea-output,< 1K
+Predicate,https://schema.org/serviceAudience,1K - 10K
+Predicate,https://schema.org/serviceAudience-input,< 1K
+Predicate,https://schema.org/serviceAudience-output,< 1K
+Predicate,https://schema.org/serviceLocation,10K - 100K
+Predicate,https://schema.org/serviceLocation-input,< 1K
+Predicate,https://schema.org/serviceLocation-output,< 1K
+Predicate,https://schema.org/serviceOperator,1K - 10K
+Predicate,https://schema.org/serviceOperator-input,< 1K
+Predicate,https://schema.org/serviceOperator-output,< 1K
+Predicate,https://schema.org/serviceOutput,10K - 100K
+Predicate,https://schema.org/serviceOutput-input,< 1K
+Predicate,https://schema.org/serviceOutput-output,< 1K
+Predicate,https://schema.org/servicePhone,10K - 100K
+Predicate,https://schema.org/servicePhone-input,< 1K
+Predicate,https://schema.org/servicePhone-output,< 1K
+Predicate,https://schema.org/servicePostalAddress,< 1K
+Predicate,https://schema.org/servicePostalAddress-input,< 1K
+Predicate,https://schema.org/servicePostalAddress-output,< 1K
+Predicate,https://schema.org/serviceSmsNumber,1K - 10K
+Predicate,https://schema.org/serviceSmsNumber-input,< 1K
+Predicate,https://schema.org/serviceSmsNumber-output,< 1K
+Predicate,https://schema.org/serviceType,100K - 1M
+Predicate,https://schema.org/serviceType-input,< 1K
+Predicate,https://schema.org/serviceType-output,< 1K
+Predicate,https://schema.org/serviceUrl,10K - 100K
+Predicate,https://schema.org/serviceUrl-input,< 1K
+Predicate,https://schema.org/serviceUrl-output,< 1K
+Predicate,https://schema.org/servingSize,10K - 100K
+Predicate,https://schema.org/servingSize-input,< 1K
+Predicate,https://schema.org/servingSize-output,< 1K
+Predicate,https://schema.org/sha256,< 1K
+Predicate,https://schema.org/sha256-input,< 1K
+Predicate,https://schema.org/sha256-output,< 1K
+Predicate,https://schema.org/sharedContent,1K - 10K
+Predicate,https://schema.org/sharedContent-input,< 1K
+Predicate,https://schema.org/sharedContent-output,< 1K
+Predicate,https://schema.org/shippingConditions,10K - 100K
+Predicate,https://schema.org/shippingConditions-input,< 1K
+Predicate,https://schema.org/shippingConditions-output,< 1K
+Predicate,https://schema.org/shippingDestination,100K - 1M
+Predicate,https://schema.org/shippingDestination-input,< 1K
+Predicate,https://schema.org/shippingDestination-output,< 1K
+Predicate,https://schema.org/shippingDetails,100K - 1M
+Predicate,https://schema.org/shippingDetails-input,< 1K
+Predicate,https://schema.org/shippingDetails-output,< 1K
+Predicate,https://schema.org/shippingLabel,1K - 10K
+Predicate,https://schema.org/shippingLabel-input,< 1K
+Predicate,https://schema.org/shippingLabel-output,< 1K
+Predicate,https://schema.org/shippingOrigin,10K - 100K
+Predicate,https://schema.org/shippingOrigin-input,< 1K
+Predicate,https://schema.org/shippingOrigin-output,< 1K
+Predicate,https://schema.org/shippingRate,100K - 1M
+Predicate,https://schema.org/shippingRate-input,< 1K
+Predicate,https://schema.org/shippingRate-output,< 1K
+Predicate,https://schema.org/shippingSettingsLink,1K - 10K
+Predicate,https://schema.org/shippingSettingsLink-input,< 1K
+Predicate,https://schema.org/shippingSettingsLink-output,< 1K
+Predicate,https://schema.org/sibling,< 1K
+Predicate,https://schema.org/sibling-input,< 1K
+Predicate,https://schema.org/sibling-output,< 1K
+Predicate,https://schema.org/siblings,< 1K
+Predicate,https://schema.org/siblings-input,< 1K
+Predicate,https://schema.org/siblings-output,< 1K
+Predicate,https://schema.org/signDetected,< 1K
+Predicate,https://schema.org/signDetected-input,< 1K
+Predicate,https://schema.org/signDetected-output,< 1K
+Predicate,https://schema.org/signOrSymptom,1K - 10K
+Predicate,https://schema.org/signOrSymptom-input,< 1K
+Predicate,https://schema.org/signOrSymptom-output,< 1K
+Predicate,https://schema.org/significance,< 1K
+Predicate,https://schema.org/significance-input,< 1K
+Predicate,https://schema.org/significance-output,< 1K
+Predicate,https://schema.org/significantLink,10K - 100K
+Predicate,https://schema.org/significantLink-input,< 1K
+Predicate,https://schema.org/significantLink-output,< 1K
+Predicate,https://schema.org/significantLinks,1K - 10K
+Predicate,https://schema.org/significantLinks-input,< 1K
+Predicate,https://schema.org/significantLinks-output,< 1K
+Predicate,https://schema.org/size,10K - 100K
+Predicate,https://schema.org/size-input,< 1K
+Predicate,https://schema.org/size-output,< 1K
+Predicate,https://schema.org/sizeGroup,< 1K
+Predicate,https://schema.org/sizeGroup-input,< 1K
+Predicate,https://schema.org/sizeGroup-output,< 1K
+Predicate,https://schema.org/sizeSystem,< 1K
+Predicate,https://schema.org/sizeSystem-input,< 1K
+Predicate,https://schema.org/sizeSystem-output,< 1K
+Predicate,https://schema.org/skills,10K - 100K
+Predicate,https://schema.org/skills-input,< 1K
+Predicate,https://schema.org/skills-output,< 1K
+Predicate,https://schema.org/sku,1M - 10M
+Predicate,https://schema.org/sku-input,< 1K
+Predicate,https://schema.org/sku-output,< 1K
+Predicate,https://schema.org/slogan,100K - 1M
+Predicate,https://schema.org/slogan-input,< 1K
+Predicate,https://schema.org/slogan-output,< 1K
+Predicate,https://schema.org/smiles,< 1K
+Predicate,https://schema.org/smiles-input,< 1K
+Predicate,https://schema.org/smiles-output,< 1K
+Predicate,https://schema.org/smokingAllowed,10K - 100K
+Predicate,https://schema.org/smokingAllowed-input,< 1K
+Predicate,https://schema.org/smokingAllowed-output,< 1K
+Predicate,https://schema.org/sodiumContent,10K - 100K
+Predicate,https://schema.org/sodiumContent-input,< 1K
+Predicate,https://schema.org/sodiumContent-output,< 1K
+Predicate,https://schema.org/softwareAddOn,< 1K
+Predicate,https://schema.org/softwareAddOn-input,< 1K
+Predicate,https://schema.org/softwareAddOn-output,< 1K
+Predicate,https://schema.org/softwareHelp,10K - 100K
+Predicate,https://schema.org/softwareHelp-input,< 1K
+Predicate,https://schema.org/softwareHelp-output,< 1K
+Predicate,https://schema.org/softwareRequirements,10K - 100K
+Predicate,https://schema.org/softwareRequirements-input,< 1K
+Predicate,https://schema.org/softwareRequirements-output,< 1K
+Predicate,https://schema.org/softwareVersion,100K - 1M
+Predicate,https://schema.org/softwareVersion-input,< 1K
+Predicate,https://schema.org/softwareVersion-output,< 1K
+Predicate,https://schema.org/source,1K - 10K
+Predicate,https://schema.org/source-input,< 1K
+Predicate,https://schema.org/source-output,< 1K
+Predicate,https://schema.org/sourceOrganization,10K - 100K
+Predicate,https://schema.org/sourceOrganization-input,< 1K
+Predicate,https://schema.org/sourceOrganization-output,< 1K
+Predicate,https://schema.org/sourcedFrom,< 1K
+Predicate,https://schema.org/sourcedFrom-input,< 1K
+Predicate,https://schema.org/sourcedFrom-output,< 1K
+Predicate,https://schema.org/spatial,1K - 10K
+Predicate,https://schema.org/spatial-input,< 1K
+Predicate,https://schema.org/spatial-output,< 1K
+Predicate,https://schema.org/spatialCoverage,10K - 100K
+Predicate,https://schema.org/spatialCoverage-input,< 1K
+Predicate,https://schema.org/spatialCoverage-output,< 1K
+Predicate,https://schema.org/speakable,100K - 1M
+Predicate,https://schema.org/speakable-input,< 1K
+Predicate,https://schema.org/speakable-output,< 1K
+Predicate,https://schema.org/specialCommitments,1K - 10K
+Predicate,https://schema.org/specialCommitments-input,< 1K
+Predicate,https://schema.org/specialCommitments-output,< 1K
+Predicate,https://schema.org/specialOpeningHoursSpecification,1K - 10K
+Predicate,https://schema.org/specialOpeningHoursSpecification-input,< 1K
+Predicate,https://schema.org/specialOpeningHoursSpecification-output,< 1K
+Predicate,https://schema.org/specialty,10K - 100K
+Predicate,https://schema.org/specialty-input,< 1K
+Predicate,https://schema.org/specialty-output,< 1K
+Predicate,https://schema.org/speechToTextMarkup,< 1K
+Predicate,https://schema.org/speechToTextMarkup-input,< 1K
+Predicate,https://schema.org/speechToTextMarkup-output,< 1K
+Predicate,https://schema.org/speed,1K - 10K
+Predicate,https://schema.org/speed-input,< 1K
+Predicate,https://schema.org/speed-output,< 1K
+Predicate,https://schema.org/spokenByCharacter,1K - 10K
+Predicate,https://schema.org/spokenByCharacter-input,< 1K
+Predicate,https://schema.org/spokenByCharacter-output,< 1K
+Predicate,https://schema.org/sponsor,10K - 100K
+Predicate,https://schema.org/sponsor-input,< 1K
+Predicate,https://schema.org/sponsor-output,< 1K
+Predicate,https://schema.org/sport,10K - 100K
+Predicate,https://schema.org/sport-input,< 1K
+Predicate,https://schema.org/sport-output,< 1K
+Predicate,https://schema.org/sportsActivityLocation,< 1K
+Predicate,https://schema.org/sportsActivityLocation-input,< 1K
+Predicate,https://schema.org/sportsActivityLocation-output,< 1K
+Predicate,https://schema.org/sportsEvent,< 1K
+Predicate,https://schema.org/sportsEvent-input,< 1K
+Predicate,https://schema.org/sportsEvent-output,< 1K
+Predicate,https://schema.org/sportsTeam,< 1K
+Predicate,https://schema.org/sportsTeam-input,< 1K
+Predicate,https://schema.org/sportsTeam-output,< 1K
+Predicate,https://schema.org/spouse,1K - 10K
+Predicate,https://schema.org/spouse-input,< 1K
+Predicate,https://schema.org/spouse-output,< 1K
+Predicate,https://schema.org/stage,< 1K
+Predicate,https://schema.org/stage-input,< 1K
+Predicate,https://schema.org/stage-output,< 1K
+Predicate,https://schema.org/stageAsNumber,< 1K
+Predicate,https://schema.org/stageAsNumber-input,< 1K
+Predicate,https://schema.org/stageAsNumber-output,< 1K
+Predicate,https://schema.org/starRating,10K - 100K
+Predicate,https://schema.org/starRating-input,< 1K
+Predicate,https://schema.org/starRating-output,< 1K
+Predicate,https://schema.org/startDate,100K - 1M
+Predicate,https://schema.org/startDate-input,< 1K
+Predicate,https://schema.org/startDate-output,< 1K
+Predicate,https://schema.org/startOffset,10K - 100K
+Predicate,https://schema.org/startOffset-input,10K - 100K
+Predicate,https://schema.org/startOffset-output,< 1K
+Predicate,https://schema.org/startTime,1K - 10K
+Predicate,https://schema.org/startTime-input,< 1K
+Predicate,https://schema.org/startTime-output,< 1K
+Predicate,https://schema.org/statType,< 1K
+Predicate,https://schema.org/statType-input,< 1K
+Predicate,https://schema.org/statType-output,< 1K
+Predicate,https://schema.org/status,1K - 10K
+Predicate,https://schema.org/status-input,< 1K
+Predicate,https://schema.org/status-output,< 1K
+Predicate,https://schema.org/steeringPosition,1K - 10K
+Predicate,https://schema.org/steeringPosition-input,< 1K
+Predicate,https://schema.org/steeringPosition-output,< 1K
+Predicate,https://schema.org/step,100K - 1M
+Predicate,https://schema.org/step-input,< 1K
+Predicate,https://schema.org/step-output,< 1K
+Predicate,https://schema.org/stepValue,< 1K
+Predicate,https://schema.org/stepValue-input,< 1K
+Predicate,https://schema.org/stepValue-output,< 1K
+Predicate,https://schema.org/steps,< 1K
+Predicate,https://schema.org/steps-input,< 1K
+Predicate,https://schema.org/steps-output,< 1K
+Predicate,https://schema.org/storageRequirements,10K - 100K
+Predicate,https://schema.org/storageRequirements-input,< 1K
+Predicate,https://schema.org/storageRequirements-output,< 1K
+Predicate,https://schema.org/streetAddress,1M - 10M
+Predicate,https://schema.org/streetAddress-input,< 1K
+Predicate,https://schema.org/streetAddress-output,< 1K
+Predicate,https://schema.org/strengthUnit,< 1K
+Predicate,https://schema.org/strengthUnit-input,< 1K
+Predicate,https://schema.org/strengthUnit-output,< 1K
+Predicate,https://schema.org/strengthValue,< 1K
+Predicate,https://schema.org/strengthValue-input,< 1K
+Predicate,https://schema.org/strengthValue-output,< 1K
+Predicate,https://schema.org/structuralClass,< 1K
+Predicate,https://schema.org/structuralClass-input,< 1K
+Predicate,https://schema.org/structuralClass-output,< 1K
+Predicate,https://schema.org/study,< 1K
+Predicate,https://schema.org/study-input,< 1K
+Predicate,https://schema.org/study-output,< 1K
+Predicate,https://schema.org/studyDesign,< 1K
+Predicate,https://schema.org/studyDesign-input,< 1K
+Predicate,https://schema.org/studyDesign-output,< 1K
+Predicate,https://schema.org/studyLocation,< 1K
+Predicate,https://schema.org/studyLocation-input,< 1K
+Predicate,https://schema.org/studyLocation-output,< 1K
+Predicate,https://schema.org/studySubject,< 1K
+Predicate,https://schema.org/studySubject-input,< 1K
+Predicate,https://schema.org/studySubject-output,< 1K
+Predicate,https://schema.org/stupidProperty,< 1K
+Predicate,https://schema.org/stupidProperty-input,< 1K
+Predicate,https://schema.org/stupidProperty-output,< 1K
+Predicate,https://schema.org/subEvent,1K - 10K
+Predicate,https://schema.org/subEvent-input,< 1K
+Predicate,https://schema.org/subEvent-output,< 1K
+Predicate,https://schema.org/subEvents,< 1K
+Predicate,https://schema.org/subEvents-input,< 1K
+Predicate,https://schema.org/subEvents-output,< 1K
+Predicate,https://schema.org/subOrganization,10K - 100K
+Predicate,https://schema.org/subOrganization-input,< 1K
+Predicate,https://schema.org/subOrganization-output,< 1K
+Predicate,https://schema.org/subReservation,< 1K
+Predicate,https://schema.org/subReservation-input,< 1K
+Predicate,https://schema.org/subReservation-output,< 1K
+Predicate,https://schema.org/subStageSuffix,< 1K
+Predicate,https://schema.org/subStageSuffix-input,< 1K
+Predicate,https://schema.org/subStageSuffix-output,< 1K
+Predicate,https://schema.org/subStructure,< 1K
+Predicate,https://schema.org/subStructure-input,< 1K
+Predicate,https://schema.org/subStructure-output,< 1K
+Predicate,https://schema.org/subTest,< 1K
+Predicate,https://schema.org/subTest-input,< 1K
+Predicate,https://schema.org/subTest-output,< 1K
+Predicate,https://schema.org/subTrip,< 1K
+Predicate,https://schema.org/subTrip-input,< 1K
+Predicate,https://schema.org/subTrip-output,< 1K
+Predicate,https://schema.org/subjectOf,100K - 1M
+Predicate,https://schema.org/subjectOf-input,< 1K
+Predicate,https://schema.org/subjectOf-output,< 1K
+Predicate,https://schema.org/subtitleLanguage,< 1K
+Predicate,https://schema.org/subtitleLanguage-input,< 1K
+Predicate,https://schema.org/subtitleLanguage-output,< 1K
+Predicate,https://schema.org/successorOf,< 1K
+Predicate,https://schema.org/successorOf-input,< 1K
+Predicate,https://schema.org/successorOf-output,< 1K
+Predicate,https://schema.org/sugarContent,10K - 100K
+Predicate,https://schema.org/sugarContent-input,< 1K
+Predicate,https://schema.org/sugarContent-output,< 1K
+Predicate,https://schema.org/suggestedAge,1K - 10K
+Predicate,https://schema.org/suggestedAge-input,< 1K
+Predicate,https://schema.org/suggestedAge-output,< 1K
+Predicate,https://schema.org/suggestedAnswer,10K - 100K
+Predicate,https://schema.org/suggestedAnswer-input,< 1K
+Predicate,https://schema.org/suggestedAnswer-output,< 1K
+Predicate,https://schema.org/suggestedGender,10K - 100K
+Predicate,https://schema.org/suggestedGender-input,< 1K
+Predicate,https://schema.org/suggestedGender-output,< 1K
+Predicate,https://schema.org/suggestedMaxAge,1K - 10K
+Predicate,https://schema.org/suggestedMaxAge-input,< 1K
+Predicate,https://schema.org/suggestedMaxAge-output,< 1K
+Predicate,https://schema.org/suggestedMeasurement,< 1K
+Predicate,https://schema.org/suggestedMeasurement-input,< 1K
+Predicate,https://schema.org/suggestedMeasurement-output,< 1K
+Predicate,https://schema.org/suggestedMinAge,10K - 100K
+Predicate,https://schema.org/suggestedMinAge-input,< 1K
+Predicate,https://schema.org/suggestedMinAge-output,< 1K
+Predicate,https://schema.org/suitableForDiet,10K - 100K
+Predicate,https://schema.org/suitableForDiet-input,< 1K
+Predicate,https://schema.org/suitableForDiet-output,< 1K
+Predicate,https://schema.org/superEvent,1K - 10K
+Predicate,https://schema.org/superEvent-input,< 1K
+Predicate,https://schema.org/superEvent-output,< 1K
+Predicate,https://schema.org/supersededBy,1K - 10K
+Predicate,https://schema.org/supersededBy-input,< 1K
+Predicate,https://schema.org/supersededBy-output,< 1K
+Predicate,https://schema.org/supply,10K - 100K
+Predicate,https://schema.org/supply-input,< 1K
+Predicate,https://schema.org/supply-output,< 1K
+Predicate,https://schema.org/supplyTo,< 1K
+Predicate,https://schema.org/supplyTo-input,< 1K
+Predicate,https://schema.org/supplyTo-output,< 1K
+Predicate,https://schema.org/supportingData,< 1K
+Predicate,https://schema.org/supportingData-input,< 1K
+Predicate,https://schema.org/supportingData-output,< 1K
+Predicate,https://schema.org/surface,< 1K
+Predicate,https://schema.org/surface-input,< 1K
+Predicate,https://schema.org/surface-output,< 1K
+Predicate,https://schema.org/syllabusSections,1K - 10K
+Predicate,https://schema.org/syllabusSections-input,< 1K
+Predicate,https://schema.org/syllabusSections-output,< 1K
+Predicate,https://schema.org/target,10M+
+Predicate,https://schema.org/target-input,< 1K
+Predicate,https://schema.org/target-output,< 1K
+Predicate,https://schema.org/targetCollection,< 1K
+Predicate,https://schema.org/targetCollection-input,< 1K
+Predicate,https://schema.org/targetCollection-output,< 1K
+Predicate,https://schema.org/targetDescription,< 1K
+Predicate,https://schema.org/targetDescription-input,< 1K
+Predicate,https://schema.org/targetDescription-output,< 1K
+Predicate,https://schema.org/targetName,1K - 10K
+Predicate,https://schema.org/targetName-input,< 1K
+Predicate,https://schema.org/targetName-output,< 1K
+Predicate,https://schema.org/targetPlatform,< 1K
+Predicate,https://schema.org/targetPlatform-input,< 1K
+Predicate,https://schema.org/targetPlatform-output,< 1K
+Predicate,https://schema.org/targetPopulation,< 1K
+Predicate,https://schema.org/targetPopulation-input,< 1K
+Predicate,https://schema.org/targetPopulation-output,< 1K
+Predicate,https://schema.org/targetProduct,< 1K
+Predicate,https://schema.org/targetProduct-input,< 1K
+Predicate,https://schema.org/targetProduct-output,< 1K
+Predicate,https://schema.org/targetUrl,< 1K
+Predicate,https://schema.org/targetUrl-input,< 1K
+Predicate,https://schema.org/targetUrl-output,< 1K
+Predicate,https://schema.org/taxID,100K - 1M
+Predicate,https://schema.org/taxID-input,< 1K
+Predicate,https://schema.org/taxID-output,< 1K
+Predicate,https://schema.org/taxonRank,< 1K
+Predicate,https://schema.org/taxonRank-input,< 1K
+Predicate,https://schema.org/taxonRank-output,< 1K
+Predicate,https://schema.org/taxonomicRange,< 1K
+Predicate,https://schema.org/taxonomicRange-input,< 1K
+Predicate,https://schema.org/taxonomicRange-output,< 1K
+Predicate,https://schema.org/teaches,10K - 100K
+Predicate,https://schema.org/teaches-input,< 1K
+Predicate,https://schema.org/teaches-output,< 1K
+Predicate,https://schema.org/telephone,1M - 10M
+Predicate,https://schema.org/telephone-input,< 1K
+Predicate,https://schema.org/telephone-output,< 1K
+Predicate,https://schema.org/temporal,< 1K
+Predicate,https://schema.org/temporal-input,< 1K
+Predicate,https://schema.org/temporal-output,< 1K
+Predicate,https://schema.org/temporalCoverage,10K - 100K
+Predicate,https://schema.org/temporalCoverage-input,< 1K
+Predicate,https://schema.org/temporalCoverage-output,< 1K
+Predicate,https://schema.org/termCode,1K - 10K
+Predicate,https://schema.org/termCode-input,< 1K
+Predicate,https://schema.org/termCode-output,< 1K
+Predicate,https://schema.org/termDuration,< 1K
+Predicate,https://schema.org/termDuration-input,< 1K
+Predicate,https://schema.org/termDuration-output,< 1K
+Predicate,https://schema.org/termsOfService,10K - 100K
+Predicate,https://schema.org/termsOfService-input,< 1K
+Predicate,https://schema.org/termsOfService-output,< 1K
+Predicate,https://schema.org/termsPerYear,< 1K
+Predicate,https://schema.org/termsPerYear-input,< 1K
+Predicate,https://schema.org/termsPerYear-output,< 1K
+Predicate,https://schema.org/text,1M - 10M
+Predicate,https://schema.org/text-input,< 1K
+Predicate,https://schema.org/text-output,< 1K
+Predicate,https://schema.org/textValue,< 1K
+Predicate,https://schema.org/textValue-input,< 1K
+Predicate,https://schema.org/textValue-output,< 1K
+Predicate,https://schema.org/thumbnail,100K - 1M
+Predicate,https://schema.org/thumbnail-input,< 1K
+Predicate,https://schema.org/thumbnail-output,< 1K
+Predicate,https://schema.org/thumbnailUrl,10M+
+Predicate,https://schema.org/thumbnailUrl-input,< 1K
+Predicate,https://schema.org/thumbnailUrl-output,< 1K
+Predicate,https://schema.org/tickerSymbol,1K - 10K
+Predicate,https://schema.org/tickerSymbol-input,< 1K
+Predicate,https://schema.org/tickerSymbol-output,< 1K
+Predicate,https://schema.org/ticketNumber,< 1K
+Predicate,https://schema.org/ticketNumber-input,< 1K
+Predicate,https://schema.org/ticketNumber-output,< 1K
+Predicate,https://schema.org/ticketToken,< 1K
+Predicate,https://schema.org/ticketToken-input,< 1K
+Predicate,https://schema.org/ticketToken-output,< 1K
+Predicate,https://schema.org/ticketedSeat,< 1K
+Predicate,https://schema.org/ticketedSeat-input,< 1K
+Predicate,https://schema.org/ticketedSeat-output,< 1K
+Predicate,https://schema.org/timeOfDay,< 1K
+Predicate,https://schema.org/timeOfDay-input,< 1K
+Predicate,https://schema.org/timeOfDay-output,< 1K
+Predicate,https://schema.org/timeRequired,100K - 1M
+Predicate,https://schema.org/timeRequired-input,< 1K
+Predicate,https://schema.org/timeRequired-output,< 1K
+Predicate,https://schema.org/timeToComplete,1K - 10K
+Predicate,https://schema.org/timeToComplete-input,< 1K
+Predicate,https://schema.org/timeToComplete-output,< 1K
+Predicate,https://schema.org/timestamp,1K - 10K
+Predicate,https://schema.org/timestamp-input,< 1K
+Predicate,https://schema.org/timestamp-output,< 1K
+Predicate,https://schema.org/tissueSample,< 1K
+Predicate,https://schema.org/tissueSample-input,< 1K
+Predicate,https://schema.org/tissueSample-output,< 1K
+Predicate,https://schema.org/title,100K - 1M
+Predicate,https://schema.org/title-input,< 1K
+Predicate,https://schema.org/title-output,< 1K
+Predicate,https://schema.org/titleEIDR,< 1K
+Predicate,https://schema.org/titleEIDR-input,< 1K
+Predicate,https://schema.org/titleEIDR-output,< 1K
+Predicate,https://schema.org/toLocation,1K - 10K
+Predicate,https://schema.org/toLocation-input,< 1K
+Predicate,https://schema.org/toLocation-output,< 1K
+Predicate,https://schema.org/toRecipient,< 1K
+Predicate,https://schema.org/toRecipient-input,< 1K
+Predicate,https://schema.org/toRecipient-output,< 1K
+Predicate,https://schema.org/tocContinuation,< 1K
+Predicate,https://schema.org/tocContinuation-input,< 1K
+Predicate,https://schema.org/tocContinuation-output,< 1K
+Predicate,https://schema.org/tocEntry,< 1K
+Predicate,https://schema.org/tocEntry-input,< 1K
+Predicate,https://schema.org/tocEntry-output,< 1K
+Predicate,https://schema.org/tongueWeight,< 1K
+Predicate,https://schema.org/tongueWeight-input,< 1K
+Predicate,https://schema.org/tongueWeight-output,< 1K
+Predicate,https://schema.org/tool,10K - 100K
+Predicate,https://schema.org/tool-input,< 1K
+Predicate,https://schema.org/tool-output,< 1K
+Predicate,https://schema.org/torque,1K - 10K
+Predicate,https://schema.org/torque-input,< 1K
+Predicate,https://schema.org/torque-output,< 1K
+Predicate,https://schema.org/totalHistoricalEnrollment,< 1K
+Predicate,https://schema.org/totalHistoricalEnrollment-input,< 1K
+Predicate,https://schema.org/totalHistoricalEnrollment-output,< 1K
+Predicate,https://schema.org/totalJobOpenings,< 1K
+Predicate,https://schema.org/totalJobOpenings-input,< 1K
+Predicate,https://schema.org/totalJobOpenings-output,< 1K
+Predicate,https://schema.org/totalPaymentDue,< 1K
+Predicate,https://schema.org/totalPaymentDue-input,< 1K
+Predicate,https://schema.org/totalPaymentDue-output,< 1K
+Predicate,https://schema.org/totalPrice,< 1K
+Predicate,https://schema.org/totalPrice-input,< 1K
+Predicate,https://schema.org/totalPrice-output,< 1K
+Predicate,https://schema.org/totalTime,100K - 1M
+Predicate,https://schema.org/totalTime-input,< 1K
+Predicate,https://schema.org/totalTime-output,< 1K
+Predicate,https://schema.org/tourBookingPage,10K - 100K
+Predicate,https://schema.org/tourBookingPage-input,< 1K
+Predicate,https://schema.org/tourBookingPage-output,< 1K
+Predicate,https://schema.org/touristType,10K - 100K
+Predicate,https://schema.org/touristType-input,< 1K
+Predicate,https://schema.org/touristType-output,< 1K
+Predicate,https://schema.org/track,10K - 100K
+Predicate,https://schema.org/track-input,< 1K
+Predicate,https://schema.org/track-output,< 1K
+Predicate,https://schema.org/trackingNumber,< 1K
+Predicate,https://schema.org/trackingNumber-input,< 1K
+Predicate,https://schema.org/trackingNumber-output,< 1K
+Predicate,https://schema.org/trackingUrl,< 1K
+Predicate,https://schema.org/trackingUrl-input,< 1K
+Predicate,https://schema.org/trackingUrl-output,< 1K
+Predicate,https://schema.org/tracks,< 1K
+Predicate,https://schema.org/tracks-input,< 1K
+Predicate,https://schema.org/tracks-output,< 1K
+Predicate,https://schema.org/trailer,1K - 10K
+Predicate,https://schema.org/trailer-input,< 1K
+Predicate,https://schema.org/trailer-output,< 1K
+Predicate,https://schema.org/trailerWeight,< 1K
+Predicate,https://schema.org/trailerWeight-input,< 1K
+Predicate,https://schema.org/trailerWeight-output,< 1K
+Predicate,https://schema.org/trainName,< 1K
+Predicate,https://schema.org/trainName-input,< 1K
+Predicate,https://schema.org/trainName-output,< 1K
+Predicate,https://schema.org/trainNumber,< 1K
+Predicate,https://schema.org/trainNumber-input,< 1K
+Predicate,https://schema.org/trainNumber-output,< 1K
+Predicate,https://schema.org/trainingSalary,< 1K
+Predicate,https://schema.org/trainingSalary-input,< 1K
+Predicate,https://schema.org/trainingSalary-output,< 1K
+Predicate,https://schema.org/transFatContent,10K - 100K
+Predicate,https://schema.org/transFatContent-input,< 1K
+Predicate,https://schema.org/transFatContent-output,< 1K
+Predicate,https://schema.org/transcript,10K - 100K
+Predicate,https://schema.org/transcript-input,< 1K
+Predicate,https://schema.org/transcript-output,< 1K
+Predicate,https://schema.org/transitTime,100K - 1M
+Predicate,https://schema.org/transitTime-input,< 1K
+Predicate,https://schema.org/transitTime-output,< 1K
+Predicate,https://schema.org/transitTimeLabel,< 1K
+Predicate,https://schema.org/transitTimeLabel-input,< 1K
+Predicate,https://schema.org/transitTimeLabel-output,< 1K
+Predicate,https://schema.org/translationOfWork,1K - 10K
+Predicate,https://schema.org/translationOfWork-input,< 1K
+Predicate,https://schema.org/translationOfWork-output,< 1K
+Predicate,https://schema.org/translator,1K - 10K
+Predicate,https://schema.org/translator-input,< 1K
+Predicate,https://schema.org/translator-output,< 1K
+Predicate,https://schema.org/transmissionMethod,< 1K
+Predicate,https://schema.org/transmissionMethod-input,< 1K
+Predicate,https://schema.org/transmissionMethod-output,< 1K
+Predicate,https://schema.org/travelBans,< 1K
+Predicate,https://schema.org/travelBans-input,< 1K
+Predicate,https://schema.org/travelBans-output,< 1K
+Predicate,https://schema.org/trialDesign,< 1K
+Predicate,https://schema.org/trialDesign-input,< 1K
+Predicate,https://schema.org/trialDesign-output,< 1K
+Predicate,https://schema.org/tributary,< 1K
+Predicate,https://schema.org/tributary-input,< 1K
+Predicate,https://schema.org/tributary-output,< 1K
+Predicate,https://schema.org/tripOrigin,< 1K
+Predicate,https://schema.org/tripOrigin-input,< 1K
+Predicate,https://schema.org/tripOrigin-output,< 1K
+Predicate,https://schema.org/typeOfBed,10K - 100K
+Predicate,https://schema.org/typeOfBed-input,< 1K
+Predicate,https://schema.org/typeOfBed-output,< 1K
+Predicate,https://schema.org/typeOfGood,< 1K
+Predicate,https://schema.org/typeOfGood-input,< 1K
+Predicate,https://schema.org/typeOfGood-output,< 1K
+Predicate,https://schema.org/typicalAgeRange,10K - 100K
+Predicate,https://schema.org/typicalAgeRange-input,< 1K
+Predicate,https://schema.org/typicalAgeRange-output,< 1K
+Predicate,https://schema.org/typicalCreditsPerTerm,< 1K
+Predicate,https://schema.org/typicalCreditsPerTerm-input,< 1K
+Predicate,https://schema.org/typicalCreditsPerTerm-output,< 1K
+Predicate,https://schema.org/typicalTest,1K - 10K
+Predicate,https://schema.org/typicalTest-input,< 1K
+Predicate,https://schema.org/typicalTest-output,< 1K
+Predicate,https://schema.org/underName,< 1K
+Predicate,https://schema.org/underName-input,< 1K
+Predicate,https://schema.org/underName-output,< 1K
+Predicate,https://schema.org/unitCode,1M - 10M
+Predicate,https://schema.org/unitCode-input,< 1K
+Predicate,https://schema.org/unitCode-output,< 1K
+Predicate,https://schema.org/unitText,100K - 1M
+Predicate,https://schema.org/unitText-input,< 1K
+Predicate,https://schema.org/unitText-output,< 1K
+Predicate,https://schema.org/unnamedSourcesPolicy,1K - 10K
+Predicate,https://schema.org/unnamedSourcesPolicy-input,< 1K
+Predicate,https://schema.org/unnamedSourcesPolicy-output,< 1K
+Predicate,https://schema.org/unsaturatedFatContent,10K - 100K
+Predicate,https://schema.org/unsaturatedFatContent-input,< 1K
+Predicate,https://schema.org/unsaturatedFatContent-output,< 1K
+Predicate,https://schema.org/uploadDate,1M - 10M
+Predicate,https://schema.org/uploadDate-input,< 1K
+Predicate,https://schema.org/uploadDate-output,< 1K
+Predicate,https://schema.org/upvoteCount,10K - 100K
+Predicate,https://schema.org/upvoteCount-input,< 1K
+Predicate,https://schema.org/upvoteCount-output,< 1K
+Predicate,https://schema.org/url,10M+
+Predicate,https://schema.org/url-input,< 1K
+Predicate,https://schema.org/url-output,< 1K
+Predicate,https://schema.org/urlTemplate,10M+
+Predicate,https://schema.org/urlTemplate-input,< 1K
+Predicate,https://schema.org/urlTemplate-output,< 1K
+Predicate,https://schema.org/usNPI,< 1K
+Predicate,https://schema.org/usNPI-input,< 1K
+Predicate,https://schema.org/usNPI-output,< 1K
+Predicate,https://schema.org/usageInfo,1K - 10K
+Predicate,https://schema.org/usageInfo-input,< 1K
+Predicate,https://schema.org/usageInfo-output,< 1K
+Predicate,https://schema.org/usedToDiagnose,1K - 10K
+Predicate,https://schema.org/usedToDiagnose-input,< 1K
+Predicate,https://schema.org/usedToDiagnose-output,< 1K
+Predicate,https://schema.org/userInteractionCount,100K - 1M
+Predicate,https://schema.org/userInteractionCount-input,< 1K
+Predicate,https://schema.org/userInteractionCount-output,< 1K
+Predicate,https://schema.org/usesDevice,< 1K
+Predicate,https://schema.org/usesDevice-input,< 1K
+Predicate,https://schema.org/usesDevice-output,< 1K
+Predicate,https://schema.org/usesHealthPlanIdStandard,< 1K
+Predicate,https://schema.org/usesHealthPlanIdStandard-input,< 1K
+Predicate,https://schema.org/usesHealthPlanIdStandard-output,< 1K
+Predicate,https://schema.org/utterances,< 1K
+Predicate,https://schema.org/utterances-input,< 1K
+Predicate,https://schema.org/utterances-output,< 1K
+Predicate,https://schema.org/validFor,< 1K
+Predicate,https://schema.org/validFor-input,< 1K
+Predicate,https://schema.org/validFor-output,< 1K
+Predicate,https://schema.org/validForMemberTier,< 1K
+Predicate,https://schema.org/validForMemberTier-input,< 1K
+Predicate,https://schema.org/validForMemberTier-output,< 1K
+Predicate,https://schema.org/validFrom,100K - 1M
+Predicate,https://schema.org/validFrom-input,< 1K
+Predicate,https://schema.org/validFrom-output,< 1K
+Predicate,https://schema.org/validIn,1K - 10K
+Predicate,https://schema.org/validIn-input,< 1K
+Predicate,https://schema.org/validIn-output,< 1K
+Predicate,https://schema.org/validThrough,1M - 10M
+Predicate,https://schema.org/validThrough-input,< 1K
+Predicate,https://schema.org/validThrough-output,< 1K
+Predicate,https://schema.org/validUntil,1K - 10K
+Predicate,https://schema.org/validUntil-input,< 1K
+Predicate,https://schema.org/validUntil-output,< 1K
+Predicate,https://schema.org/value,1M - 10M
+Predicate,https://schema.org/value-input,< 1K
+Predicate,https://schema.org/value-output,< 1K
+Predicate,https://schema.org/valueAddedTaxIncluded,1M - 10M
+Predicate,https://schema.org/valueAddedTaxIncluded-input,< 1K
+Predicate,https://schema.org/valueAddedTaxIncluded-output,< 1K
+Predicate,https://schema.org/valueMaxLength,1K - 10K
+Predicate,https://schema.org/valueMaxLength-input,< 1K
+Predicate,https://schema.org/valueMaxLength-output,< 1K
+Predicate,https://schema.org/valueMinLength,< 1K
+Predicate,https://schema.org/valueMinLength-input,< 1K
+Predicate,https://schema.org/valueMinLength-output,< 1K
+Predicate,https://schema.org/valueName,10M+
+Predicate,https://schema.org/valueName-input,< 1K
+Predicate,https://schema.org/valueName-output,< 1K
+Predicate,https://schema.org/valuePattern,< 1K
+Predicate,https://schema.org/valuePattern-input,< 1K
+Predicate,https://schema.org/valuePattern-output,< 1K
+Predicate,https://schema.org/valueReference,1K - 10K
+Predicate,https://schema.org/valueReference-input,< 1K
+Predicate,https://schema.org/valueReference-output,< 1K
+Predicate,https://schema.org/valueRequired,10M+
+Predicate,https://schema.org/valueRequired-input,< 1K
+Predicate,https://schema.org/valueRequired-output,< 1K
+Predicate,https://schema.org/variableMeasured,10K - 100K
+Predicate,https://schema.org/variableMeasured-input,< 1K
+Predicate,https://schema.org/variableMeasured-output,< 1K
+Predicate,https://schema.org/variablesMeasured,< 1K
+Predicate,https://schema.org/variablesMeasured-input,< 1K
+Predicate,https://schema.org/variablesMeasured-output,< 1K
+Predicate,https://schema.org/variantCover,< 1K
+Predicate,https://schema.org/variantCover-input,< 1K
+Predicate,https://schema.org/variantCover-output,< 1K
+Predicate,https://schema.org/variesBy,100K - 1M
+Predicate,https://schema.org/variesBy-input,< 1K
+Predicate,https://schema.org/variesBy-output,< 1K
+Predicate,https://schema.org/vatID,100K - 1M
+Predicate,https://schema.org/vatID-input,< 1K
+Predicate,https://schema.org/vatID-output,< 1K
+Predicate,https://schema.org/vehicleConfiguration,10K - 100K
+Predicate,https://schema.org/vehicleConfiguration-input,< 1K
+Predicate,https://schema.org/vehicleConfiguration-output,< 1K
+Predicate,https://schema.org/vehicleEngine,10K - 100K
+Predicate,https://schema.org/vehicleEngine-input,< 1K
+Predicate,https://schema.org/vehicleEngine-output,< 1K
+Predicate,https://schema.org/vehicleIdentificationNumber,10K - 100K
+Predicate,https://schema.org/vehicleIdentificationNumber-input,< 1K
+Predicate,https://schema.org/vehicleIdentificationNumber-output,< 1K
+Predicate,https://schema.org/vehicleInteriorColor,10K - 100K
+Predicate,https://schema.org/vehicleInteriorColor-input,< 1K
+Predicate,https://schema.org/vehicleInteriorColor-output,< 1K
+Predicate,https://schema.org/vehicleInteriorType,10K - 100K
+Predicate,https://schema.org/vehicleInteriorType-input,< 1K
+Predicate,https://schema.org/vehicleInteriorType-output,< 1K
+Predicate,https://schema.org/vehicleModelDate,10K - 100K
+Predicate,https://schema.org/vehicleModelDate-input,< 1K
+Predicate,https://schema.org/vehicleModelDate-output,< 1K
+Predicate,https://schema.org/vehicleSeatingCapacity,10K - 100K
+Predicate,https://schema.org/vehicleSeatingCapacity-input,< 1K
+Predicate,https://schema.org/vehicleSeatingCapacity-output,< 1K
+Predicate,https://schema.org/vehicleSpecialUsage,< 1K
+Predicate,https://schema.org/vehicleSpecialUsage-input,< 1K
+Predicate,https://schema.org/vehicleSpecialUsage-output,< 1K
+Predicate,https://schema.org/vehicleTransmission,10K - 100K
+Predicate,https://schema.org/vehicleTransmission-input,< 1K
+Predicate,https://schema.org/vehicleTransmission-output,< 1K
+Predicate,https://schema.org/vendor,< 1K
+Predicate,https://schema.org/vendor-input,< 1K
+Predicate,https://schema.org/vendor-output,< 1K
+Predicate,https://schema.org/verificationFactCheckingPolicy,1K - 10K
+Predicate,https://schema.org/verificationFactCheckingPolicy-input,< 1K
+Predicate,https://schema.org/verificationFactCheckingPolicy-output,< 1K
+Predicate,https://schema.org/version,1K - 10K
+Predicate,https://schema.org/version-input,< 1K
+Predicate,https://schema.org/version-output,< 1K
+Predicate,https://schema.org/video,100K - 1M
+Predicate,https://schema.org/video-input,< 1K
+Predicate,https://schema.org/video-output,< 1K
+Predicate,https://schema.org/videoFormat,1K - 10K
+Predicate,https://schema.org/videoFormat-input,< 1K
+Predicate,https://schema.org/videoFormat-output,< 1K
+Predicate,https://schema.org/videoFrameSize,< 1K
+Predicate,https://schema.org/videoFrameSize-input,< 1K
+Predicate,https://schema.org/videoFrameSize-output,< 1K
+Predicate,https://schema.org/videoQuality,10K - 100K
+Predicate,https://schema.org/videoQuality-input,< 1K
+Predicate,https://schema.org/videoQuality-output,< 1K
+Predicate,https://schema.org/volumeNumber,1K - 10K
+Predicate,https://schema.org/volumeNumber-input,< 1K
+Predicate,https://schema.org/volumeNumber-output,< 1K
+Predicate,https://schema.org/warning,< 1K
+Predicate,https://schema.org/warning-input,< 1K
+Predicate,https://schema.org/warning-output,< 1K
+Predicate,https://schema.org/warranty,10K - 100K
+Predicate,https://schema.org/warranty-input,< 1K
+Predicate,https://schema.org/warranty-output,< 1K
+Predicate,https://schema.org/warrantyPromise,< 1K
+Predicate,https://schema.org/warrantyPromise-input,< 1K
+Predicate,https://schema.org/warrantyPromise-output,< 1K
+Predicate,https://schema.org/warrantyScope,1K - 10K
+Predicate,https://schema.org/warrantyScope-input,< 1K
+Predicate,https://schema.org/warrantyScope-output,< 1K
+Predicate,https://schema.org/webCheckinTime,< 1K
+Predicate,https://schema.org/webCheckinTime-input,< 1K
+Predicate,https://schema.org/webCheckinTime-output,< 1K
+Predicate,https://schema.org/webFeed,10K - 100K
+Predicate,https://schema.org/webFeed-input,< 1K
+Predicate,https://schema.org/webFeed-output,< 1K
+Predicate,https://schema.org/weight,100K - 1M
+Predicate,https://schema.org/weight-input,< 1K
+Predicate,https://schema.org/weight-output,< 1K
+Predicate,https://schema.org/weightPercentage,< 1K
+Predicate,https://schema.org/weightPercentage-input,< 1K
+Predicate,https://schema.org/weightPercentage-output,< 1K
+Predicate,https://schema.org/weightTotal,1K - 10K
+Predicate,https://schema.org/weightTotal-input,< 1K
+Predicate,https://schema.org/weightTotal-output,< 1K
+Predicate,https://schema.org/wheelbase,1K - 10K
+Predicate,https://schema.org/wheelbase-input,< 1K
+Predicate,https://schema.org/wheelbase-output,< 1K
+Predicate,https://schema.org/width,10M+
+Predicate,https://schema.org/width-input,< 1K
+Predicate,https://schema.org/width-output,< 1K
+Predicate,https://schema.org/winner,< 1K
+Predicate,https://schema.org/winner-input,< 1K
+Predicate,https://schema.org/winner-output,< 1K
+Predicate,https://schema.org/wordCount,1M - 10M
+Predicate,https://schema.org/wordCount-input,< 1K
+Predicate,https://schema.org/wordCount-output,< 1K
+Predicate,https://schema.org/workExample,1K - 10K
+Predicate,https://schema.org/workExample-input,< 1K
+Predicate,https://schema.org/workExample-output,< 1K
+Predicate,https://schema.org/workFeatured,< 1K
+Predicate,https://schema.org/workFeatured-input,< 1K
+Predicate,https://schema.org/workFeatured-output,< 1K
+Predicate,https://schema.org/workHours,10K - 100K
+Predicate,https://schema.org/workHours-input,< 1K
+Predicate,https://schema.org/workHours-output,< 1K
+Predicate,https://schema.org/workLocation,10K - 100K
+Predicate,https://schema.org/workLocation-input,< 1K
+Predicate,https://schema.org/workLocation-output,< 1K
+Predicate,https://schema.org/workPerformed,1K - 10K
+Predicate,https://schema.org/workPerformed-input,< 1K
+Predicate,https://schema.org/workPerformed-output,< 1K
+Predicate,https://schema.org/workPresented,< 1K
+Predicate,https://schema.org/workPresented-input,< 1K
+Predicate,https://schema.org/workPresented-output,< 1K
+Predicate,https://schema.org/workTranslation,10K - 100K
+Predicate,https://schema.org/workTranslation-input,< 1K
+Predicate,https://schema.org/workTranslation-output,< 1K
+Predicate,https://schema.org/workload,< 1K
+Predicate,https://schema.org/workload-input,< 1K
+Predicate,https://schema.org/workload-output,< 1K
+Predicate,https://schema.org/worksFor,1M - 10M
+Predicate,https://schema.org/worksFor-input,< 1K
+Predicate,https://schema.org/worksFor-output,< 1K
+Predicate,https://schema.org/worstRating,1M - 10M
+Predicate,https://schema.org/worstRating-input,< 1K
+Predicate,https://schema.org/worstRating-output,< 1K
+Predicate,https://schema.org/xpath,10K - 100K
+Predicate,https://schema.org/xpath-input,< 1K
+Predicate,https://schema.org/xpath-output,< 1K
+Predicate,https://schema.org/yearBuilt,10K - 100K
+Predicate,https://schema.org/yearBuilt-input,< 1K
+Predicate,https://schema.org/yearBuilt-output,< 1K
+Predicate,https://schema.org/yearlyRevenue,< 1K
+Predicate,https://schema.org/yearlyRevenue-input,< 1K
+Predicate,https://schema.org/yearlyRevenue-output,< 1K
+Predicate,https://schema.org/yearsInOperation,< 1K
+Predicate,https://schema.org/yearsInOperation-input,< 1K
+Predicate,https://schema.org/yearsInOperation-output,< 1K
+Predicate,https://schema.org/yield,1K - 10K
+Predicate,https://schema.org/yield-input,< 1K
+Predicate,https://schema.org/yield-output,< 1K

--- a/data/public_stats/google/2026_06.json
+++ b/data/public_stats/google/2026_06.json
@@ -1,27727 +1,27727 @@
 [
   {
     "Class":"Itemtype",
-    "Name":"http:\/\/schema.org\/3DModel",
+    "Name":"https://schema.org/3DModel",
     "Domain Bucket":"< 1K"
   },
   {
     "Class":"Itemtype",
-    "Name":"http:\/\/schema.org\/AMRadioChannel",
+    "Name":"https://schema.org/AMRadioChannel",
     "Domain Bucket":"< 1K"
   },
   {
     "Class":"Itemtype",
-    "Name":"http:\/\/schema.org\/APIReference",
+    "Name":"https://schema.org/APIReference",
     "Domain Bucket":"< 1K"
   },
   {
     "Class":"Itemtype",
-    "Name":"http:\/\/schema.org\/AboutPage",
+    "Name":"https://schema.org/AboutPage",
     "Domain Bucket":"100K - 1M"
   },
   {
     "Class":"Itemtype",
-    "Name":"http:\/\/schema.org\/AcceptAction",
+    "Name":"https://schema.org/AcceptAction",
     "Domain Bucket":"< 1K"
   },
   {
     "Class":"Itemtype",
-    "Name":"http:\/\/schema.org\/Accommodation",
+    "Name":"https://schema.org/Accommodation",
     "Domain Bucket":"10K - 100K"
   },
   {
     "Class":"Itemtype",
-    "Name":"http:\/\/schema.org\/AccountingService",
+    "Name":"https://schema.org/AccountingService",
     "Domain Bucket":"10K - 100K"
   },
   {
     "Class":"Itemtype",
-    "Name":"http:\/\/schema.org\/AchieveAction",
+    "Name":"https://schema.org/AchieveAction",
     "Domain Bucket":"< 1K"
   },
   {
     "Class":"Itemtype",
-    "Name":"http:\/\/schema.org\/Action",
+    "Name":"https://schema.org/Action",
     "Domain Bucket":"10K - 100K"
   },
   {
     "Class":"Itemtype",
-    "Name":"http:\/\/schema.org\/ActionAccessSpecification",
+    "Name":"https://schema.org/ActionAccessSpecification",
     "Domain Bucket":"< 1K"
   },
   {
     "Class":"Itemtype",
-    "Name":"http:\/\/schema.org\/ActionStatusType",
+    "Name":"https://schema.org/ActionStatusType",
     "Domain Bucket":"< 1K"
   },
   {
     "Class":"Itemtype",
-    "Name":"http:\/\/schema.org\/ActivateAction",
+    "Name":"https://schema.org/ActivateAction",
     "Domain Bucket":"< 1K"
   },
   {
     "Class":"Itemtype",
-    "Name":"http:\/\/schema.org\/AddAction",
+    "Name":"https://schema.org/AddAction",
     "Domain Bucket":"< 1K"
   },
   {
     "Class":"Itemtype",
-    "Name":"http:\/\/schema.org\/AdministrativeArea",
+    "Name":"https://schema.org/AdministrativeArea",
     "Domain Bucket":"100K - 1M"
   },
   {
     "Class":"Itemtype",
-    "Name":"http:\/\/schema.org\/AdultEntertainment",
+    "Name":"https://schema.org/AdultEntertainment",
     "Domain Bucket":"1K - 10K"
   },
   {
     "Class":"Itemtype",
-    "Name":"http:\/\/schema.org\/AdultOrientedEnumeration",
+    "Name":"https://schema.org/AdultOrientedEnumeration",
     "Domain Bucket":"< 1K"
   },
   {
     "Class":"Itemtype",
-    "Name":"http:\/\/schema.org\/AdvertiserContentArticle",
+    "Name":"https://schema.org/AdvertiserContentArticle",
     "Domain Bucket":"1K - 10K"
   },
   {
     "Class":"Itemtype",
-    "Name":"http:\/\/schema.org\/AggregateOffer",
+    "Name":"https://schema.org/AggregateOffer",
     "Domain Bucket":"1M - 10M"
   },
   {
     "Class":"Itemtype",
-    "Name":"http:\/\/schema.org\/AggregateRating",
+    "Name":"https://schema.org/AggregateRating",
     "Domain Bucket":"1M - 10M"
   },
   {
     "Class":"Itemtype",
-    "Name":"http:\/\/schema.org\/AgreeAction",
+    "Name":"https://schema.org/AgreeAction",
     "Domain Bucket":"< 1K"
   },
   {
     "Class":"Itemtype",
-    "Name":"http:\/\/schema.org\/Airline",
+    "Name":"https://schema.org/Airline",
     "Domain Bucket":"1K - 10K"
   },
   {
     "Class":"Itemtype",
-    "Name":"http:\/\/schema.org\/Airport",
+    "Name":"https://schema.org/Airport",
     "Domain Bucket":"1K - 10K"
   },
   {
     "Class":"Itemtype",
-    "Name":"http:\/\/schema.org\/AlignmentObject",
+    "Name":"https://schema.org/AlignmentObject",
     "Domain Bucket":"1K - 10K"
   },
   {
     "Class":"Itemtype",
-    "Name":"http:\/\/schema.org\/AllocateAction",
+    "Name":"https://schema.org/AllocateAction",
     "Domain Bucket":"< 1K"
   },
   {
     "Class":"Itemtype",
-    "Name":"http:\/\/schema.org\/AmpStory",
+    "Name":"https://schema.org/AmpStory",
     "Domain Bucket":"< 1K"
   },
   {
     "Class":"Itemtype",
-    "Name":"http:\/\/schema.org\/AmusementPark",
+    "Name":"https://schema.org/AmusementPark",
     "Domain Bucket":"1K - 10K"
   },
   {
     "Class":"Itemtype",
-    "Name":"http:\/\/schema.org\/AnalysisNewsArticle",
+    "Name":"https://schema.org/AnalysisNewsArticle",
     "Domain Bucket":"1K - 10K"
   },
   {
     "Class":"Itemtype",
-    "Name":"http:\/\/schema.org\/AnatomicalStructure",
+    "Name":"https://schema.org/AnatomicalStructure",
     "Domain Bucket":"1K - 10K"
   },
   {
     "Class":"Itemtype",
-    "Name":"http:\/\/schema.org\/AnatomicalSystem",
+    "Name":"https://schema.org/AnatomicalSystem",
     "Domain Bucket":"< 1K"
   },
   {
     "Class":"Itemtype",
-    "Name":"http:\/\/schema.org\/AnimalShelter",
+    "Name":"https://schema.org/AnimalShelter",
     "Domain Bucket":"1K - 10K"
   },
   {
     "Class":"Itemtype",
-    "Name":"http:\/\/schema.org\/Answer",
+    "Name":"https://schema.org/Answer",
     "Domain Bucket":"1M - 10M"
   },
   {
     "Class":"Itemtype",
-    "Name":"http:\/\/schema.org\/Apartment",
+    "Name":"https://schema.org/Apartment",
     "Domain Bucket":"10K - 100K"
   },
   {
     "Class":"Itemtype",
-    "Name":"http:\/\/schema.org\/ApartmentComplex",
+    "Name":"https://schema.org/ApartmentComplex",
     "Domain Bucket":"10K - 100K"
   },
   {
     "Class":"Itemtype",
-    "Name":"http:\/\/schema.org\/AppendAction",
+    "Name":"https://schema.org/AppendAction",
     "Domain Bucket":"< 1K"
   },
   {
     "Class":"Itemtype",
-    "Name":"http:\/\/schema.org\/ApplyAction",
+    "Name":"https://schema.org/ApplyAction",
     "Domain Bucket":"1K - 10K"
   },
   {
     "Class":"Itemtype",
-    "Name":"http:\/\/schema.org\/ApprovedIndication",
+    "Name":"https://schema.org/ApprovedIndication",
     "Domain Bucket":"< 1K"
   },
   {
     "Class":"Itemtype",
-    "Name":"http:\/\/schema.org\/Aquarium",
+    "Name":"https://schema.org/Aquarium",
     "Domain Bucket":"< 1K"
   },
   {
     "Class":"Itemtype",
-    "Name":"http:\/\/schema.org\/ArchiveComponent",
+    "Name":"https://schema.org/ArchiveComponent",
     "Domain Bucket":"< 1K"
   },
   {
     "Class":"Itemtype",
-    "Name":"http:\/\/schema.org\/ArchiveOrganization",
+    "Name":"https://schema.org/ArchiveOrganization",
     "Domain Bucket":"1K - 10K"
   },
   {
     "Class":"Itemtype",
-    "Name":"http:\/\/schema.org\/ArriveAction",
+    "Name":"https://schema.org/ArriveAction",
     "Domain Bucket":"< 1K"
   },
   {
     "Class":"Itemtype",
-    "Name":"http:\/\/schema.org\/ArtGallery",
+    "Name":"https://schema.org/ArtGallery",
     "Domain Bucket":"1K - 10K"
   },
   {
     "Class":"Itemtype",
-    "Name":"http:\/\/schema.org\/Artery",
+    "Name":"https://schema.org/Artery",
     "Domain Bucket":"< 1K"
   },
   {
     "Class":"Itemtype",
-    "Name":"http:\/\/schema.org\/Article",
+    "Name":"https://schema.org/Article",
     "Domain Bucket":"1M - 10M"
   },
   {
     "Class":"Itemtype",
-    "Name":"http:\/\/schema.org\/AskAction",
+    "Name":"https://schema.org/AskAction",
     "Domain Bucket":"< 1K"
   },
   {
     "Class":"Itemtype",
-    "Name":"http:\/\/schema.org\/AskPublicNewsArticle",
+    "Name":"https://schema.org/AskPublicNewsArticle",
     "Domain Bucket":"< 1K"
   },
   {
     "Class":"Itemtype",
-    "Name":"http:\/\/schema.org\/AssessAction",
+    "Name":"https://schema.org/AssessAction",
     "Domain Bucket":"< 1K"
   },
   {
     "Class":"Itemtype",
-    "Name":"http:\/\/schema.org\/AssignAction",
+    "Name":"https://schema.org/AssignAction",
     "Domain Bucket":"< 1K"
   },
   {
     "Class":"Itemtype",
-    "Name":"http:\/\/schema.org\/Atlas",
+    "Name":"https://schema.org/Atlas",
     "Domain Bucket":"< 1K"
   },
   {
     "Class":"Itemtype",
-    "Name":"http:\/\/schema.org\/Attorney",
+    "Name":"https://schema.org/Attorney",
     "Domain Bucket":"10K - 100K"
   },
   {
     "Class":"Itemtype",
-    "Name":"http:\/\/schema.org\/Audience",
+    "Name":"https://schema.org/Audience",
     "Domain Bucket":"100K - 1M"
   },
   {
     "Class":"Itemtype",
-    "Name":"http:\/\/schema.org\/AudioObject",
+    "Name":"https://schema.org/AudioObject",
     "Domain Bucket":"10K - 100K"
   },
   {
     "Class":"Itemtype",
-    "Name":"http:\/\/schema.org\/AudioObjectSnapshot",
+    "Name":"https://schema.org/AudioObjectSnapshot",
     "Domain Bucket":"< 1K"
   },
   {
     "Class":"Itemtype",
-    "Name":"http:\/\/schema.org\/Audiobook",
+    "Name":"https://schema.org/Audiobook",
     "Domain Bucket":"< 1K"
   },
   {
     "Class":"Itemtype",
-    "Name":"http:\/\/schema.org\/AuthenticateAction",
+    "Name":"https://schema.org/AuthenticateAction",
     "Domain Bucket":"< 1K"
   },
   {
     "Class":"Itemtype",
-    "Name":"http:\/\/schema.org\/AuthorizeAction",
+    "Name":"https://schema.org/AuthorizeAction",
     "Domain Bucket":"< 1K"
   },
   {
     "Class":"Itemtype",
-    "Name":"http:\/\/schema.org\/AutoBodyShop",
+    "Name":"https://schema.org/AutoBodyShop",
     "Domain Bucket":"1K - 10K"
   },
   {
     "Class":"Itemtype",
-    "Name":"http:\/\/schema.org\/AutoDealer",
+    "Name":"https://schema.org/AutoDealer",
     "Domain Bucket":"10K - 100K"
   },
   {
     "Class":"Itemtype",
-    "Name":"http:\/\/schema.org\/AutoPartsStore",
+    "Name":"https://schema.org/AutoPartsStore",
     "Domain Bucket":"10K - 100K"
   },
   {
     "Class":"Itemtype",
-    "Name":"http:\/\/schema.org\/AutoRental",
+    "Name":"https://schema.org/AutoRental",
     "Domain Bucket":"10K - 100K"
   },
   {
     "Class":"Itemtype",
-    "Name":"http:\/\/schema.org\/AutoRepair",
+    "Name":"https://schema.org/AutoRepair",
     "Domain Bucket":"10K - 100K"
   },
   {
     "Class":"Itemtype",
-    "Name":"http:\/\/schema.org\/AutoWash",
+    "Name":"https://schema.org/AutoWash",
     "Domain Bucket":"1K - 10K"
   },
   {
     "Class":"Itemtype",
-    "Name":"http:\/\/schema.org\/AutomatedTeller",
+    "Name":"https://schema.org/AutomatedTeller",
     "Domain Bucket":"< 1K"
   },
   {
     "Class":"Itemtype",
-    "Name":"http:\/\/schema.org\/AutomotiveBusiness",
+    "Name":"https://schema.org/AutomotiveBusiness",
     "Domain Bucket":"10K - 100K"
   },
   {
     "Class":"Itemtype",
-    "Name":"http:\/\/schema.org\/BackgroundNewsArticle",
+    "Name":"https://schema.org/BackgroundNewsArticle",
     "Domain Bucket":"< 1K"
   },
   {
     "Class":"Itemtype",
-    "Name":"http:\/\/schema.org\/Bakery",
+    "Name":"https://schema.org/Bakery",
     "Domain Bucket":"1K - 10K"
   },
   {
     "Class":"Itemtype",
-    "Name":"http:\/\/schema.org\/BankAccount",
+    "Name":"https://schema.org/BankAccount",
     "Domain Bucket":"< 1K"
   },
   {
     "Class":"Itemtype",
-    "Name":"http:\/\/schema.org\/BankOrCreditUnion",
+    "Name":"https://schema.org/BankOrCreditUnion",
     "Domain Bucket":"1K - 10K"
   },
   {
     "Class":"Itemtype",
-    "Name":"http:\/\/schema.org\/BarOrPub",
+    "Name":"https://schema.org/BarOrPub",
     "Domain Bucket":"10K - 100K"
   },
   {
     "Class":"Itemtype",
-    "Name":"http:\/\/schema.org\/Barcode",
+    "Name":"https://schema.org/Barcode",
     "Domain Bucket":"< 1K"
   },
   {
     "Class":"Itemtype",
-    "Name":"http:\/\/schema.org\/Beach",
+    "Name":"https://schema.org/Beach",
     "Domain Bucket":"1K - 10K"
   },
   {
     "Class":"Itemtype",
-    "Name":"http:\/\/schema.org\/BeautySalon",
+    "Name":"https://schema.org/BeautySalon",
     "Domain Bucket":"10K - 100K"
   },
   {
     "Class":"Itemtype",
-    "Name":"http:\/\/schema.org\/BedAndBreakfast",
+    "Name":"https://schema.org/BedAndBreakfast",
     "Domain Bucket":"1K - 10K"
   },
   {
     "Class":"Itemtype",
-    "Name":"http:\/\/schema.org\/BedDetails",
+    "Name":"https://schema.org/BedDetails",
     "Domain Bucket":"10K - 100K"
   },
   {
     "Class":"Itemtype",
-    "Name":"http:\/\/schema.org\/BedType",
+    "Name":"https://schema.org/BedType",
     "Domain Bucket":"< 1K"
   },
   {
     "Class":"Itemtype",
-    "Name":"http:\/\/schema.org\/BefriendAction",
+    "Name":"https://schema.org/BefriendAction",
     "Domain Bucket":"< 1K"
   },
   {
     "Class":"Itemtype",
-    "Name":"http:\/\/schema.org\/BikeStore",
+    "Name":"https://schema.org/BikeStore",
     "Domain Bucket":"1K - 10K"
   },
   {
     "Class":"Itemtype",
-    "Name":"http:\/\/schema.org\/BioChemEntity",
+    "Name":"https://schema.org/BioChemEntity",
     "Domain Bucket":"< 1K"
   },
   {
     "Class":"Itemtype",
-    "Name":"http:\/\/schema.org\/Blog",
+    "Name":"https://schema.org/Blog",
     "Domain Bucket":"1M - 10M"
   },
   {
     "Class":"Itemtype",
-    "Name":"http:\/\/schema.org\/BlogPosting",
+    "Name":"https://schema.org/BlogPosting",
     "Domain Bucket":"1M - 10M"
   },
   {
     "Class":"Itemtype",
-    "Name":"http:\/\/schema.org\/BloodTest",
+    "Name":"https://schema.org/BloodTest",
     "Domain Bucket":"< 1K"
   },
   {
     "Class":"Itemtype",
-    "Name":"http:\/\/schema.org\/BoardingPolicyType",
+    "Name":"https://schema.org/BoardingPolicyType",
     "Domain Bucket":"< 1K"
   },
   {
     "Class":"Itemtype",
-    "Name":"http:\/\/schema.org\/BoatReservation",
+    "Name":"https://schema.org/BoatReservation",
     "Domain Bucket":"< 1K"
   },
   {
     "Class":"Itemtype",
-    "Name":"http:\/\/schema.org\/BoatTerminal",
+    "Name":"https://schema.org/BoatTerminal",
     "Domain Bucket":"< 1K"
   },
   {
     "Class":"Itemtype",
-    "Name":"http:\/\/schema.org\/BoatTrip",
+    "Name":"https://schema.org/BoatTrip",
     "Domain Bucket":"< 1K"
   },
   {
     "Class":"Itemtype",
-    "Name":"http:\/\/schema.org\/BodyMeasurementTypeEnumeration",
+    "Name":"https://schema.org/BodyMeasurementTypeEnumeration",
     "Domain Bucket":"< 1K"
   },
   {
     "Class":"Itemtype",
-    "Name":"http:\/\/schema.org\/BodyOfWater",
+    "Name":"https://schema.org/BodyOfWater",
     "Domain Bucket":"< 1K"
   },
   {
     "Class":"Itemtype",
-    "Name":"http:\/\/schema.org\/Bone",
+    "Name":"https://schema.org/Bone",
     "Domain Bucket":"< 1K"
   },
   {
     "Class":"Itemtype",
-    "Name":"http:\/\/schema.org\/Book",
+    "Name":"https://schema.org/Book",
     "Domain Bucket":"10K - 100K"
   },
   {
     "Class":"Itemtype",
-    "Name":"http:\/\/schema.org\/BookFormatType",
+    "Name":"https://schema.org/BookFormatType",
     "Domain Bucket":"< 1K"
   },
   {
     "Class":"Itemtype",
-    "Name":"http:\/\/schema.org\/BookSeries",
+    "Name":"https://schema.org/BookSeries",
     "Domain Bucket":"1K - 10K"
   },
   {
     "Class":"Itemtype",
-    "Name":"http:\/\/schema.org\/BookStore",
+    "Name":"https://schema.org/BookStore",
     "Domain Bucket":"1K - 10K"
   },
   {
     "Class":"Itemtype",
-    "Name":"http:\/\/schema.org\/BookmarkAction",
+    "Name":"https://schema.org/BookmarkAction",
     "Domain Bucket":"< 1K"
   },
   {
     "Class":"Itemtype",
-    "Name":"http:\/\/schema.org\/Boolean",
+    "Name":"https://schema.org/Boolean",
     "Domain Bucket":"< 1K"
   },
   {
     "Class":"Itemtype",
-    "Name":"http:\/\/schema.org\/BorrowAction",
+    "Name":"https://schema.org/BorrowAction",
     "Domain Bucket":"< 1K"
   },
   {
     "Class":"Itemtype",
-    "Name":"http:\/\/schema.org\/BowlingAlley",
+    "Name":"https://schema.org/BowlingAlley",
     "Domain Bucket":"< 1K"
   },
   {
     "Class":"Itemtype",
-    "Name":"http:\/\/schema.org\/BrainStructure",
+    "Name":"https://schema.org/BrainStructure",
     "Domain Bucket":"< 1K"
   },
   {
     "Class":"Itemtype",
-    "Name":"http:\/\/schema.org\/Brand",
+    "Name":"https://schema.org/Brand",
     "Domain Bucket":"1M - 10M"
   },
   {
     "Class":"Itemtype",
-    "Name":"http:\/\/schema.org\/BreadcrumbList",
+    "Name":"https://schema.org/BreadcrumbList",
     "Domain Bucket":"10M+"
   },
   {
     "Class":"Itemtype",
-    "Name":"http:\/\/schema.org\/Brewery",
+    "Name":"https://schema.org/Brewery",
     "Domain Bucket":"1K - 10K"
   },
   {
     "Class":"Itemtype",
-    "Name":"http:\/\/schema.org\/Bridge",
+    "Name":"https://schema.org/Bridge",
     "Domain Bucket":"< 1K"
   },
   {
     "Class":"Itemtype",
-    "Name":"http:\/\/schema.org\/BroadcastChannel",
+    "Name":"https://schema.org/BroadcastChannel",
     "Domain Bucket":"< 1K"
   },
   {
     "Class":"Itemtype",
-    "Name":"http:\/\/schema.org\/BroadcastEvent",
+    "Name":"https://schema.org/BroadcastEvent",
     "Domain Bucket":"10K - 100K"
   },
   {
     "Class":"Itemtype",
-    "Name":"http:\/\/schema.org\/BroadcastFrequencySpecification",
+    "Name":"https://schema.org/BroadcastFrequencySpecification",
     "Domain Bucket":"< 1K"
   },
   {
     "Class":"Itemtype",
-    "Name":"http:\/\/schema.org\/BroadcastService",
+    "Name":"https://schema.org/BroadcastService",
     "Domain Bucket":"1K - 10K"
   },
   {
     "Class":"Itemtype",
-    "Name":"http:\/\/schema.org\/BrokerageAccount",
+    "Name":"https://schema.org/BrokerageAccount",
     "Domain Bucket":"< 1K"
   },
   {
     "Class":"Itemtype",
-    "Name":"http:\/\/schema.org\/BuddhistTemple",
+    "Name":"https://schema.org/BuddhistTemple",
     "Domain Bucket":"< 1K"
   },
   {
     "Class":"Itemtype",
-    "Name":"http:\/\/schema.org\/BusOrCoach",
+    "Name":"https://schema.org/BusOrCoach",
     "Domain Bucket":"< 1K"
   },
   {
     "Class":"Itemtype",
-    "Name":"http:\/\/schema.org\/BusReservation",
+    "Name":"https://schema.org/BusReservation",
     "Domain Bucket":"< 1K"
   },
   {
     "Class":"Itemtype",
-    "Name":"http:\/\/schema.org\/BusStation",
+    "Name":"https://schema.org/BusStation",
     "Domain Bucket":"< 1K"
   },
   {
     "Class":"Itemtype",
-    "Name":"http:\/\/schema.org\/BusStop",
+    "Name":"https://schema.org/BusStop",
     "Domain Bucket":"< 1K"
   },
   {
     "Class":"Itemtype",
-    "Name":"http:\/\/schema.org\/BusTrip",
+    "Name":"https://schema.org/BusTrip",
     "Domain Bucket":"< 1K"
   },
   {
     "Class":"Itemtype",
-    "Name":"http:\/\/schema.org\/BusinessAudience",
+    "Name":"https://schema.org/BusinessAudience",
     "Domain Bucket":"10K - 100K"
   },
   {
     "Class":"Itemtype",
-    "Name":"http:\/\/schema.org\/BusinessEntityType",
+    "Name":"https://schema.org/BusinessEntityType",
     "Domain Bucket":"< 1K"
   },
   {
     "Class":"Itemtype",
-    "Name":"http:\/\/schema.org\/BusinessEvent",
+    "Name":"https://schema.org/BusinessEvent",
     "Domain Bucket":"1K - 10K"
   },
   {
     "Class":"Itemtype",
-    "Name":"http:\/\/schema.org\/BusinessFunction",
+    "Name":"https://schema.org/BusinessFunction",
     "Domain Bucket":"< 1K"
   },
   {
     "Class":"Itemtype",
-    "Name":"http:\/\/schema.org\/BuyAction",
+    "Name":"https://schema.org/BuyAction",
     "Domain Bucket":"1M - 10M"
   },
   {
     "Class":"Itemtype",
-    "Name":"http:\/\/schema.org\/CDCPMDRecord",
+    "Name":"https://schema.org/CDCPMDRecord",
     "Domain Bucket":"< 1K"
   },
   {
     "Class":"Itemtype",
-    "Name":"http:\/\/schema.org\/CableOrSatelliteService",
+    "Name":"https://schema.org/CableOrSatelliteService",
     "Domain Bucket":"< 1K"
   },
   {
     "Class":"Itemtype",
-    "Name":"http:\/\/schema.org\/CafeOrCoffeeShop",
+    "Name":"https://schema.org/CafeOrCoffeeShop",
     "Domain Bucket":"1K - 10K"
   },
   {
     "Class":"Itemtype",
-    "Name":"http:\/\/schema.org\/Campground",
+    "Name":"https://schema.org/Campground",
     "Domain Bucket":"1K - 10K"
   },
   {
     "Class":"Itemtype",
-    "Name":"http:\/\/schema.org\/CampingPitch",
+    "Name":"https://schema.org/CampingPitch",
     "Domain Bucket":"< 1K"
   },
   {
     "Class":"Itemtype",
-    "Name":"http:\/\/schema.org\/Canal",
+    "Name":"https://schema.org/Canal",
     "Domain Bucket":"< 1K"
   },
   {
     "Class":"Itemtype",
-    "Name":"http:\/\/schema.org\/CancelAction",
+    "Name":"https://schema.org/CancelAction",
     "Domain Bucket":"< 1K"
   },
   {
     "Class":"Itemtype",
-    "Name":"http:\/\/schema.org\/Car",
+    "Name":"https://schema.org/Car",
     "Domain Bucket":"10K - 100K"
   },
   {
     "Class":"Itemtype",
-    "Name":"http:\/\/schema.org\/CarUsageType",
+    "Name":"https://schema.org/CarUsageType",
     "Domain Bucket":"< 1K"
   },
   {
     "Class":"Itemtype",
-    "Name":"http:\/\/schema.org\/Casino",
+    "Name":"https://schema.org/Casino",
     "Domain Bucket":"100K - 1M"
   },
   {
     "Class":"Itemtype",
-    "Name":"http:\/\/schema.org\/CategoryCode",
+    "Name":"https://schema.org/CategoryCode",
     "Domain Bucket":"1K - 10K"
   },
   {
     "Class":"Itemtype",
-    "Name":"http:\/\/schema.org\/CategoryCodeSet",
+    "Name":"https://schema.org/CategoryCodeSet",
     "Domain Bucket":"< 1K"
   },
   {
     "Class":"Itemtype",
-    "Name":"http:\/\/schema.org\/CatholicChurch",
+    "Name":"https://schema.org/CatholicChurch",
     "Domain Bucket":"< 1K"
   },
   {
     "Class":"Itemtype",
-    "Name":"http:\/\/schema.org\/Cemetery",
+    "Name":"https://schema.org/Cemetery",
     "Domain Bucket":"< 1K"
   },
   {
     "Class":"Itemtype",
-    "Name":"http:\/\/schema.org\/Certification",
+    "Name":"https://schema.org/Certification",
     "Domain Bucket":"10K - 100K"
   },
   {
     "Class":"Itemtype",
-    "Name":"http:\/\/schema.org\/CertificationStatusEnumeration",
+    "Name":"https://schema.org/CertificationStatusEnumeration",
     "Domain Bucket":"< 1K"
   },
   {
     "Class":"Itemtype",
-    "Name":"http:\/\/schema.org\/Chapter",
+    "Name":"https://schema.org/Chapter",
     "Domain Bucket":"1K - 10K"
   },
   {
     "Class":"Itemtype",
-    "Name":"http:\/\/schema.org\/CheckAction",
+    "Name":"https://schema.org/CheckAction",
     "Domain Bucket":"< 1K"
   },
   {
     "Class":"Itemtype",
-    "Name":"http:\/\/schema.org\/CheckInAction",
+    "Name":"https://schema.org/CheckInAction",
     "Domain Bucket":"< 1K"
   },
   {
     "Class":"Itemtype",
-    "Name":"http:\/\/schema.org\/CheckOutAction",
+    "Name":"https://schema.org/CheckOutAction",
     "Domain Bucket":"< 1K"
   },
   {
     "Class":"Itemtype",
-    "Name":"http:\/\/schema.org\/CheckoutPage",
+    "Name":"https://schema.org/CheckoutPage",
     "Domain Bucket":"1K - 10K"
   },
   {
     "Class":"Itemtype",
-    "Name":"http:\/\/schema.org\/ChemicalSubstance",
+    "Name":"https://schema.org/ChemicalSubstance",
     "Domain Bucket":"< 1K"
   },
   {
     "Class":"Itemtype",
-    "Name":"http:\/\/schema.org\/ChildCare",
+    "Name":"https://schema.org/ChildCare",
     "Domain Bucket":"1K - 10K"
   },
   {
     "Class":"Itemtype",
-    "Name":"http:\/\/schema.org\/ChildrensEvent",
+    "Name":"https://schema.org/ChildrensEvent",
     "Domain Bucket":"< 1K"
   },
   {
     "Class":"Itemtype",
-    "Name":"http:\/\/schema.org\/ChooseAction",
+    "Name":"https://schema.org/ChooseAction",
     "Domain Bucket":"1K - 10K"
   },
   {
     "Class":"Itemtype",
-    "Name":"http:\/\/schema.org\/Church",
+    "Name":"https://schema.org/Church",
     "Domain Bucket":"1K - 10K"
   },
   {
     "Class":"Itemtype",
-    "Name":"http:\/\/schema.org\/City",
+    "Name":"https://schema.org/City",
     "Domain Bucket":"100K - 1M"
   },
   {
     "Class":"Itemtype",
-    "Name":"http:\/\/schema.org\/CityHall",
+    "Name":"https://schema.org/CityHall",
     "Domain Bucket":"< 1K"
   },
   {
     "Class":"Itemtype",
-    "Name":"http:\/\/schema.org\/CivicStructure",
+    "Name":"https://schema.org/CivicStructure",
     "Domain Bucket":"1K - 10K"
   },
   {
     "Class":"Itemtype",
-    "Name":"http:\/\/schema.org\/Claim",
+    "Name":"https://schema.org/Claim",
     "Domain Bucket":"1K - 10K"
   },
   {
     "Class":"Itemtype",
-    "Name":"http:\/\/schema.org\/ClaimReview",
+    "Name":"https://schema.org/ClaimReview",
     "Domain Bucket":"1K - 10K"
   },
   {
     "Class":"Itemtype",
-    "Name":"http:\/\/schema.org\/Class",
+    "Name":"https://schema.org/Class",
     "Domain Bucket":"< 1K"
   },
   {
     "Class":"Itemtype",
-    "Name":"http:\/\/schema.org\/Clip",
+    "Name":"https://schema.org/Clip",
     "Domain Bucket":"10K - 100K"
   },
   {
     "Class":"Itemtype",
-    "Name":"http:\/\/schema.org\/ClothingStore",
+    "Name":"https://schema.org/ClothingStore",
     "Domain Bucket":"10K - 100K"
   },
   {
     "Class":"Itemtype",
-    "Name":"http:\/\/schema.org\/Code",
+    "Name":"https://schema.org/Code",
     "Domain Bucket":"< 1K"
   },
   {
     "Class":"Itemtype",
-    "Name":"http:\/\/schema.org\/Collection",
+    "Name":"https://schema.org/Collection",
     "Domain Bucket":"10K - 100K"
   },
   {
     "Class":"Itemtype",
-    "Name":"http:\/\/schema.org\/CollectionPage",
+    "Name":"https://schema.org/CollectionPage",
     "Domain Bucket":"1M - 10M"
   },
   {
     "Class":"Itemtype",
-    "Name":"http:\/\/schema.org\/CollegeOrUniversity",
+    "Name":"https://schema.org/CollegeOrUniversity",
     "Domain Bucket":"10K - 100K"
   },
   {
     "Class":"Itemtype",
-    "Name":"http:\/\/schema.org\/ComedyClub",
+    "Name":"https://schema.org/ComedyClub",
     "Domain Bucket":"< 1K"
   },
   {
     "Class":"Itemtype",
-    "Name":"http:\/\/schema.org\/ComedyEvent",
+    "Name":"https://schema.org/ComedyEvent",
     "Domain Bucket":"1K - 10K"
   },
   {
     "Class":"Itemtype",
-    "Name":"http:\/\/schema.org\/ComicCoverArt",
+    "Name":"https://schema.org/ComicCoverArt",
     "Domain Bucket":"< 1K"
   },
   {
     "Class":"Itemtype",
-    "Name":"http:\/\/schema.org\/ComicIssue",
+    "Name":"https://schema.org/ComicIssue",
     "Domain Bucket":"< 1K"
   },
   {
     "Class":"Itemtype",
-    "Name":"http:\/\/schema.org\/ComicSeries",
+    "Name":"https://schema.org/ComicSeries",
     "Domain Bucket":"1K - 10K"
   },
   {
     "Class":"Itemtype",
-    "Name":"http:\/\/schema.org\/ComicStory",
+    "Name":"https://schema.org/ComicStory",
     "Domain Bucket":"< 1K"
   },
   {
     "Class":"Itemtype",
-    "Name":"http:\/\/schema.org\/Comment",
+    "Name":"https://schema.org/Comment",
     "Domain Bucket":"100K - 1M"
   },
   {
     "Class":"Itemtype",
-    "Name":"http:\/\/schema.org\/CommentAction",
+    "Name":"https://schema.org/CommentAction",
     "Domain Bucket":"1M - 10M"
   },
   {
     "Class":"Itemtype",
-    "Name":"http:\/\/schema.org\/CommunicateAction",
+    "Name":"https://schema.org/CommunicateAction",
     "Domain Bucket":"10K - 100K"
   },
   {
     "Class":"Itemtype",
-    "Name":"http:\/\/schema.org\/CommunityHealth",
+    "Name":"https://schema.org/CommunityHealth",
     "Domain Bucket":"1K - 10K"
   },
   {
     "Class":"Itemtype",
-    "Name":"http:\/\/schema.org\/CompleteDataFeed",
+    "Name":"https://schema.org/CompleteDataFeed",
     "Domain Bucket":"< 1K"
   },
   {
     "Class":"Itemtype",
-    "Name":"http:\/\/schema.org\/CompoundPriceSpecification",
+    "Name":"https://schema.org/CompoundPriceSpecification",
     "Domain Bucket":"1K - 10K"
   },
   {
     "Class":"Itemtype",
-    "Name":"http:\/\/schema.org\/ComputerLanguage",
+    "Name":"https://schema.org/ComputerLanguage",
     "Domain Bucket":"< 1K"
   },
   {
     "Class":"Itemtype",
-    "Name":"http:\/\/schema.org\/ComputerStore",
+    "Name":"https://schema.org/ComputerStore",
     "Domain Bucket":"1K - 10K"
   },
   {
     "Class":"Itemtype",
-    "Name":"http:\/\/schema.org\/ConferenceEvent",
+    "Name":"https://schema.org/ConferenceEvent",
     "Domain Bucket":"< 1K"
   },
   {
     "Class":"Itemtype",
-    "Name":"http:\/\/schema.org\/ConfirmAction",
+    "Name":"https://schema.org/ConfirmAction",
     "Domain Bucket":"< 1K"
   },
   {
     "Class":"Itemtype",
-    "Name":"http:\/\/schema.org\/Consortium",
+    "Name":"https://schema.org/Consortium",
     "Domain Bucket":"< 1K"
   },
   {
     "Class":"Itemtype",
-    "Name":"http:\/\/schema.org\/ConstraintNode",
+    "Name":"https://schema.org/ConstraintNode",
     "Domain Bucket":"< 1K"
   },
   {
     "Class":"Itemtype",
-    "Name":"http:\/\/schema.org\/ConsumeAction",
+    "Name":"https://schema.org/ConsumeAction",
     "Domain Bucket":"< 1K"
   },
   {
     "Class":"Itemtype",
-    "Name":"http:\/\/schema.org\/ContactPage",
+    "Name":"https://schema.org/ContactPage",
     "Domain Bucket":"100K - 1M"
   },
   {
     "Class":"Itemtype",
-    "Name":"http:\/\/schema.org\/ContactPoint",
+    "Name":"https://schema.org/ContactPoint",
     "Domain Bucket":"1M - 10M"
   },
   {
     "Class":"Itemtype",
-    "Name":"http:\/\/schema.org\/ContactPointOption",
+    "Name":"https://schema.org/ContactPointOption",
     "Domain Bucket":"< 1K"
   },
   {
     "Class":"Itemtype",
-    "Name":"http:\/\/schema.org\/Continent",
+    "Name":"https://schema.org/Continent",
     "Domain Bucket":"1K - 10K"
   },
   {
     "Class":"Itemtype",
-    "Name":"http:\/\/schema.org\/ControlAction",
+    "Name":"https://schema.org/ControlAction",
     "Domain Bucket":"< 1K"
   },
   {
     "Class":"Itemtype",
-    "Name":"http:\/\/schema.org\/ConvenienceStore",
+    "Name":"https://schema.org/ConvenienceStore",
     "Domain Bucket":"< 1K"
   },
   {
     "Class":"Itemtype",
-    "Name":"http:\/\/schema.org\/Conversation",
+    "Name":"https://schema.org/Conversation",
     "Domain Bucket":"< 1K"
   },
   {
     "Class":"Itemtype",
-    "Name":"http:\/\/schema.org\/CookAction",
+    "Name":"https://schema.org/CookAction",
     "Domain Bucket":"< 1K"
   },
   {
     "Class":"Itemtype",
-    "Name":"http:\/\/schema.org\/Cooperative",
+    "Name":"https://schema.org/Cooperative",
     "Domain Bucket":"< 1K"
   },
   {
     "Class":"Itemtype",
-    "Name":"http:\/\/schema.org\/Corporation",
+    "Name":"https://schema.org/Corporation",
     "Domain Bucket":"100K - 1M"
   },
   {
     "Class":"Itemtype",
-    "Name":"http:\/\/schema.org\/CorrectionComment",
+    "Name":"https://schema.org/CorrectionComment",
     "Domain Bucket":"< 1K"
   },
   {
     "Class":"Itemtype",
-    "Name":"http:\/\/schema.org\/Country",
+    "Name":"https://schema.org/Country",
     "Domain Bucket":"1M - 10M"
   },
   {
     "Class":"Itemtype",
-    "Name":"http:\/\/schema.org\/Course",
+    "Name":"https://schema.org/Course",
     "Domain Bucket":"100K - 1M"
   },
   {
     "Class":"Itemtype",
-    "Name":"http:\/\/schema.org\/CourseInstance",
+    "Name":"https://schema.org/CourseInstance",
     "Domain Bucket":"10K - 100K"
   },
   {
     "Class":"Itemtype",
-    "Name":"http:\/\/schema.org\/Courthouse",
+    "Name":"https://schema.org/Courthouse",
     "Domain Bucket":"< 1K"
   },
   {
     "Class":"Itemtype",
-    "Name":"http:\/\/schema.org\/CoverArt",
+    "Name":"https://schema.org/CoverArt",
     "Domain Bucket":"< 1K"
   },
   {
     "Class":"Itemtype",
-    "Name":"http:\/\/schema.org\/CovidTestingFacility",
+    "Name":"https://schema.org/CovidTestingFacility",
     "Domain Bucket":"< 1K"
   },
   {
     "Class":"Itemtype",
-    "Name":"http:\/\/schema.org\/CreateAction",
+    "Name":"https://schema.org/CreateAction",
     "Domain Bucket":"1K - 10K"
   },
   {
     "Class":"Itemtype",
-    "Name":"http:\/\/schema.org\/CreativeWork",
+    "Name":"https://schema.org/CreativeWork",
     "Domain Bucket":"1M - 10M"
   },
   {
     "Class":"Itemtype",
-    "Name":"http:\/\/schema.org\/CreativeWorkSeason",
+    "Name":"https://schema.org/CreativeWorkSeason",
     "Domain Bucket":"1K - 10K"
   },
   {
     "Class":"Itemtype",
-    "Name":"http:\/\/schema.org\/CreativeWorkSeries",
+    "Name":"https://schema.org/CreativeWorkSeries",
     "Domain Bucket":"10K - 100K"
   },
   {
     "Class":"Itemtype",
-    "Name":"http:\/\/schema.org\/Credential",
+    "Name":"https://schema.org/Credential",
     "Domain Bucket":"10K - 100K"
   },
   {
     "Class":"Itemtype",
-    "Name":"http:\/\/schema.org\/CreditCard",
+    "Name":"https://schema.org/CreditCard",
     "Domain Bucket":"1K - 10K"
   },
   {
     "Class":"Itemtype",
-    "Name":"http:\/\/schema.org\/Crematorium",
+    "Name":"https://schema.org/Crematorium",
     "Domain Bucket":"< 1K"
   },
   {
     "Class":"Itemtype",
-    "Name":"http:\/\/schema.org\/CriticReview",
+    "Name":"https://schema.org/CriticReview",
     "Domain Bucket":"< 1K"
   },
   {
     "Class":"Itemtype",
-    "Name":"http:\/\/schema.org\/CssSelectorType",
+    "Name":"https://schema.org/CssSelectorType",
     "Domain Bucket":"< 1K"
   },
   {
     "Class":"Itemtype",
-    "Name":"http:\/\/schema.org\/CurrencyConversionService",
+    "Name":"https://schema.org/CurrencyConversionService",
     "Domain Bucket":"< 1K"
   },
   {
     "Class":"Itemtype",
-    "Name":"http:\/\/schema.org\/DDxElement",
+    "Name":"https://schema.org/DDxElement",
     "Domain Bucket":"< 1K"
   },
   {
     "Class":"Itemtype",
-    "Name":"http:\/\/schema.org\/DENonprofitType",
+    "Name":"https://schema.org/DENonprofitType",
     "Domain Bucket":"< 1K"
   },
   {
     "Class":"Itemtype",
-    "Name":"http:\/\/schema.org\/DanceEvent",
+    "Name":"https://schema.org/DanceEvent",
     "Domain Bucket":"< 1K"
   },
   {
     "Class":"Itemtype",
-    "Name":"http:\/\/schema.org\/DanceGroup",
+    "Name":"https://schema.org/DanceGroup",
     "Domain Bucket":"< 1K"
   },
   {
     "Class":"Itemtype",
-    "Name":"http:\/\/schema.org\/DataCatalog",
+    "Name":"https://schema.org/DataCatalog",
     "Domain Bucket":"1K - 10K"
   },
   {
     "Class":"Itemtype",
-    "Name":"http:\/\/schema.org\/DataDownload",
+    "Name":"https://schema.org/DataDownload",
     "Domain Bucket":"10K - 100K"
   },
   {
     "Class":"Itemtype",
-    "Name":"http:\/\/schema.org\/DataFeed",
+    "Name":"https://schema.org/DataFeed",
     "Domain Bucket":"1K - 10K"
   },
   {
     "Class":"Itemtype",
-    "Name":"http:\/\/schema.org\/DataFeedItem",
+    "Name":"https://schema.org/DataFeedItem",
     "Domain Bucket":"1K - 10K"
   },
   {
     "Class":"Itemtype",
-    "Name":"http:\/\/schema.org\/DataType",
+    "Name":"https://schema.org/DataType",
     "Domain Bucket":"< 1K"
   },
   {
     "Class":"Itemtype",
-    "Name":"http:\/\/schema.org\/Dataset",
+    "Name":"https://schema.org/Dataset",
     "Domain Bucket":"10K - 100K"
   },
   {
     "Class":"Itemtype",
-    "Name":"http:\/\/schema.org\/Date",
+    "Name":"https://schema.org/Date",
     "Domain Bucket":"< 1K"
   },
   {
     "Class":"Itemtype",
-    "Name":"http:\/\/schema.org\/DateTime",
+    "Name":"https://schema.org/DateTime",
     "Domain Bucket":"< 1K"
   },
   {
     "Class":"Itemtype",
-    "Name":"http:\/\/schema.org\/DatedMoneySpecification",
+    "Name":"https://schema.org/DatedMoneySpecification",
     "Domain Bucket":"< 1K"
   },
   {
     "Class":"Itemtype",
-    "Name":"http:\/\/schema.org\/DayOfWeek",
+    "Name":"https://schema.org/DayOfWeek",
     "Domain Bucket":"10K - 100K"
   },
   {
     "Class":"Itemtype",
-    "Name":"http:\/\/schema.org\/DaySpa",
+    "Name":"https://schema.org/DaySpa",
     "Domain Bucket":"1K - 10K"
   },
   {
     "Class":"Itemtype",
-    "Name":"http:\/\/schema.org\/DeactivateAction",
+    "Name":"https://schema.org/DeactivateAction",
     "Domain Bucket":"< 1K"
   },
   {
     "Class":"Itemtype",
-    "Name":"http:\/\/schema.org\/DefenceEstablishment",
+    "Name":"https://schema.org/DefenceEstablishment",
     "Domain Bucket":"< 1K"
   },
   {
     "Class":"Itemtype",
-    "Name":"http:\/\/schema.org\/DefinedRegion",
+    "Name":"https://schema.org/DefinedRegion",
     "Domain Bucket":"100K - 1M"
   },
   {
     "Class":"Itemtype",
-    "Name":"http:\/\/schema.org\/DefinedTerm",
+    "Name":"https://schema.org/DefinedTerm",
     "Domain Bucket":"10K - 100K"
   },
   {
     "Class":"Itemtype",
-    "Name":"http:\/\/schema.org\/DefinedTermSet",
+    "Name":"https://schema.org/DefinedTermSet",
     "Domain Bucket":"10K - 100K"
   },
   {
     "Class":"Itemtype",
-    "Name":"http:\/\/schema.org\/DeleteAction",
+    "Name":"https://schema.org/DeleteAction",
     "Domain Bucket":"< 1K"
   },
   {
     "Class":"Itemtype",
-    "Name":"http:\/\/schema.org\/DeliveryChargeSpecification",
+    "Name":"https://schema.org/DeliveryChargeSpecification",
     "Domain Bucket":"10K - 100K"
   },
   {
     "Class":"Itemtype",
-    "Name":"http:\/\/schema.org\/DeliveryEvent",
+    "Name":"https://schema.org/DeliveryEvent",
     "Domain Bucket":"< 1K"
   },
   {
     "Class":"Itemtype",
-    "Name":"http:\/\/schema.org\/DeliveryMethod",
+    "Name":"https://schema.org/DeliveryMethod",
     "Domain Bucket":"1K - 10K"
   },
   {
     "Class":"Itemtype",
-    "Name":"http:\/\/schema.org\/DeliveryTimeSettings",
+    "Name":"https://schema.org/DeliveryTimeSettings",
     "Domain Bucket":"< 1K"
   },
   {
     "Class":"Itemtype",
-    "Name":"http:\/\/schema.org\/Demand",
+    "Name":"https://schema.org/Demand",
     "Domain Bucket":"1K - 10K"
   },
   {
     "Class":"Itemtype",
-    "Name":"http:\/\/schema.org\/Dentist",
+    "Name":"https://schema.org/Dentist",
     "Domain Bucket":"10K - 100K"
   },
   {
     "Class":"Itemtype",
-    "Name":"http:\/\/schema.org\/DepartAction",
+    "Name":"https://schema.org/DepartAction",
     "Domain Bucket":"< 1K"
   },
   {
     "Class":"Itemtype",
-    "Name":"http:\/\/schema.org\/DepartmentStore",
+    "Name":"https://schema.org/DepartmentStore",
     "Domain Bucket":"1K - 10K"
   },
   {
     "Class":"Itemtype",
-    "Name":"http:\/\/schema.org\/DepositAccount",
+    "Name":"https://schema.org/DepositAccount",
     "Domain Bucket":"< 1K"
   },
   {
     "Class":"Itemtype",
-    "Name":"http:\/\/schema.org\/Dermatology",
+    "Name":"https://schema.org/Dermatology",
     "Domain Bucket":"1K - 10K"
   },
   {
     "Class":"Itemtype",
-    "Name":"http:\/\/schema.org\/DiagnosticLab",
+    "Name":"https://schema.org/DiagnosticLab",
     "Domain Bucket":"1K - 10K"
   },
   {
     "Class":"Itemtype",
-    "Name":"http:\/\/schema.org\/DiagnosticProcedure",
+    "Name":"https://schema.org/DiagnosticProcedure",
     "Domain Bucket":"< 1K"
   },
   {
     "Class":"Itemtype",
-    "Name":"http:\/\/schema.org\/Diet",
+    "Name":"https://schema.org/Diet",
     "Domain Bucket":"< 1K"
   },
   {
     "Class":"Itemtype",
-    "Name":"http:\/\/schema.org\/DietNutrition",
+    "Name":"https://schema.org/DietNutrition",
     "Domain Bucket":"1K - 10K"
   },
   {
     "Class":"Itemtype",
-    "Name":"http:\/\/schema.org\/DietarySupplement",
+    "Name":"https://schema.org/DietarySupplement",
     "Domain Bucket":"< 1K"
   },
   {
     "Class":"Itemtype",
-    "Name":"http:\/\/schema.org\/DigitalDocument",
+    "Name":"https://schema.org/DigitalDocument",
     "Domain Bucket":"10K - 100K"
   },
   {
     "Class":"Itemtype",
-    "Name":"http:\/\/schema.org\/DigitalDocumentPermission",
+    "Name":"https://schema.org/DigitalDocumentPermission",
     "Domain Bucket":"< 1K"
   },
   {
     "Class":"Itemtype",
-    "Name":"http:\/\/schema.org\/DigitalDocumentPermissionType",
+    "Name":"https://schema.org/DigitalDocumentPermissionType",
     "Domain Bucket":"< 1K"
   },
   {
     "Class":"Itemtype",
-    "Name":"http:\/\/schema.org\/DigitalPlatformEnumeration",
+    "Name":"https://schema.org/DigitalPlatformEnumeration",
     "Domain Bucket":"< 1K"
   },
   {
     "Class":"Itemtype",
-    "Name":"http:\/\/schema.org\/DisagreeAction",
+    "Name":"https://schema.org/DisagreeAction",
     "Domain Bucket":"< 1K"
   },
   {
     "Class":"Itemtype",
-    "Name":"http:\/\/schema.org\/DiscoverAction",
+    "Name":"https://schema.org/DiscoverAction",
     "Domain Bucket":"< 1K"
   },
   {
     "Class":"Itemtype",
-    "Name":"http:\/\/schema.org\/DiscussionForumPosting",
+    "Name":"https://schema.org/DiscussionForumPosting",
     "Domain Bucket":"10K - 100K"
   },
   {
     "Class":"Itemtype",
-    "Name":"http:\/\/schema.org\/DislikeAction",
+    "Name":"https://schema.org/DislikeAction",
     "Domain Bucket":"1K - 10K"
   },
   {
     "Class":"Itemtype",
-    "Name":"http:\/\/schema.org\/Distance",
+    "Name":"https://schema.org/Distance",
     "Domain Bucket":"1K - 10K"
   },
   {
     "Class":"Itemtype",
-    "Name":"http:\/\/schema.org\/Distillery",
+    "Name":"https://schema.org/Distillery",
     "Domain Bucket":"< 1K"
   },
   {
     "Class":"Itemtype",
-    "Name":"http:\/\/schema.org\/DonateAction",
+    "Name":"https://schema.org/DonateAction",
     "Domain Bucket":"1K - 10K"
   },
   {
     "Class":"Itemtype",
-    "Name":"http:\/\/schema.org\/DoseSchedule",
+    "Name":"https://schema.org/DoseSchedule",
     "Domain Bucket":"< 1K"
   },
   {
     "Class":"Itemtype",
-    "Name":"http:\/\/schema.org\/DownloadAction",
+    "Name":"https://schema.org/DownloadAction",
     "Domain Bucket":"1K - 10K"
   },
   {
     "Class":"Itemtype",
-    "Name":"http:\/\/schema.org\/DrawAction",
+    "Name":"https://schema.org/DrawAction",
     "Domain Bucket":"< 1K"
   },
   {
     "Class":"Itemtype",
-    "Name":"http:\/\/schema.org\/Drawing",
+    "Name":"https://schema.org/Drawing",
     "Domain Bucket":"< 1K"
   },
   {
     "Class":"Itemtype",
-    "Name":"http:\/\/schema.org\/DrinkAction",
+    "Name":"https://schema.org/DrinkAction",
     "Domain Bucket":"< 1K"
   },
   {
     "Class":"Itemtype",
-    "Name":"http:\/\/schema.org\/DriveWheelConfigurationValue",
+    "Name":"https://schema.org/DriveWheelConfigurationValue",
     "Domain Bucket":"< 1K"
   },
   {
     "Class":"Itemtype",
-    "Name":"http:\/\/schema.org\/Drug",
+    "Name":"https://schema.org/Drug",
     "Domain Bucket":"1K - 10K"
   },
   {
     "Class":"Itemtype",
-    "Name":"http:\/\/schema.org\/DrugClass",
+    "Name":"https://schema.org/DrugClass",
     "Domain Bucket":"1K - 10K"
   },
   {
     "Class":"Itemtype",
-    "Name":"http:\/\/schema.org\/DrugCost",
+    "Name":"https://schema.org/DrugCost",
     "Domain Bucket":"< 1K"
   },
   {
     "Class":"Itemtype",
-    "Name":"http:\/\/schema.org\/DrugCostCategory",
+    "Name":"https://schema.org/DrugCostCategory",
     "Domain Bucket":"< 1K"
   },
   {
     "Class":"Itemtype",
-    "Name":"http:\/\/schema.org\/DrugLegalStatus",
+    "Name":"https://schema.org/DrugLegalStatus",
     "Domain Bucket":"< 1K"
   },
   {
     "Class":"Itemtype",
-    "Name":"http:\/\/schema.org\/DrugPregnancyCategory",
+    "Name":"https://schema.org/DrugPregnancyCategory",
     "Domain Bucket":"< 1K"
   },
   {
     "Class":"Itemtype",
-    "Name":"http:\/\/schema.org\/DrugPrescriptionStatus",
+    "Name":"https://schema.org/DrugPrescriptionStatus",
     "Domain Bucket":"< 1K"
   },
   {
     "Class":"Itemtype",
-    "Name":"http:\/\/schema.org\/DrugStrength",
+    "Name":"https://schema.org/DrugStrength",
     "Domain Bucket":"< 1K"
   },
   {
     "Class":"Itemtype",
-    "Name":"http:\/\/schema.org\/DryCleaningOrLaundry",
+    "Name":"https://schema.org/DryCleaningOrLaundry",
     "Domain Bucket":"1K - 10K"
   },
   {
     "Class":"Itemtype",
-    "Name":"http:\/\/schema.org\/Duration",
+    "Name":"https://schema.org/Duration",
     "Domain Bucket":"10K - 100K"
   },
   {
     "Class":"Itemtype",
-    "Name":"http:\/\/schema.org\/EUEnergyEfficiencyEnumeration",
+    "Name":"https://schema.org/EUEnergyEfficiencyEnumeration",
     "Domain Bucket":"< 1K"
   },
   {
     "Class":"Itemtype",
-    "Name":"http:\/\/schema.org\/EatAction",
+    "Name":"https://schema.org/EatAction",
     "Domain Bucket":"< 1K"
   },
   {
     "Class":"Itemtype",
-    "Name":"http:\/\/schema.org\/EducationEvent",
+    "Name":"https://schema.org/EducationEvent",
     "Domain Bucket":"1K - 10K"
   },
   {
     "Class":"Itemtype",
-    "Name":"http:\/\/schema.org\/EducationalAudience",
+    "Name":"https://schema.org/EducationalAudience",
     "Domain Bucket":"10K - 100K"
   },
   {
     "Class":"Itemtype",
-    "Name":"http:\/\/schema.org\/EducationalOccupationalCredential",
+    "Name":"https://schema.org/EducationalOccupationalCredential",
     "Domain Bucket":"10K - 100K"
   },
   {
     "Class":"Itemtype",
-    "Name":"http:\/\/schema.org\/EducationalOccupationalProgram",
+    "Name":"https://schema.org/EducationalOccupationalProgram",
     "Domain Bucket":"1K - 10K"
   },
   {
     "Class":"Itemtype",
-    "Name":"http:\/\/schema.org\/EducationalOrganization",
+    "Name":"https://schema.org/EducationalOrganization",
     "Domain Bucket":"100K - 1M"
   },
   {
     "Class":"Itemtype",
-    "Name":"http:\/\/schema.org\/Electrician",
+    "Name":"https://schema.org/Electrician",
     "Domain Bucket":"10K - 100K"
   },
   {
     "Class":"Itemtype",
-    "Name":"http:\/\/schema.org\/ElectronicsStore",
+    "Name":"https://schema.org/ElectronicsStore",
     "Domain Bucket":"1K - 10K"
   },
   {
     "Class":"Itemtype",
-    "Name":"http:\/\/schema.org\/ElementarySchool",
+    "Name":"https://schema.org/ElementarySchool",
     "Domain Bucket":"< 1K"
   },
   {
     "Class":"Itemtype",
-    "Name":"http:\/\/schema.org\/EmailMessage",
+    "Name":"https://schema.org/EmailMessage",
     "Domain Bucket":"< 1K"
   },
   {
     "Class":"Itemtype",
-    "Name":"http:\/\/schema.org\/Embassy",
+    "Name":"https://schema.org/Embassy",
     "Domain Bucket":"< 1K"
   },
   {
     "Class":"Itemtype",
-    "Name":"http:\/\/schema.org\/Emergency",
+    "Name":"https://schema.org/Emergency",
     "Domain Bucket":"< 1K"
   },
   {
     "Class":"Itemtype",
-    "Name":"http:\/\/schema.org\/EmergencyService",
+    "Name":"https://schema.org/EmergencyService",
     "Domain Bucket":"1K - 10K"
   },
   {
     "Class":"Itemtype",
-    "Name":"http:\/\/schema.org\/EmployeeRole",
+    "Name":"https://schema.org/EmployeeRole",
     "Domain Bucket":"< 1K"
   },
   {
     "Class":"Itemtype",
-    "Name":"http:\/\/schema.org\/EmployerAggregateRating",
+    "Name":"https://schema.org/EmployerAggregateRating",
     "Domain Bucket":"1K - 10K"
   },
   {
     "Class":"Itemtype",
-    "Name":"http:\/\/schema.org\/EmployerReview",
+    "Name":"https://schema.org/EmployerReview",
     "Domain Bucket":"< 1K"
   },
   {
     "Class":"Itemtype",
-    "Name":"http:\/\/schema.org\/EmploymentAgency",
+    "Name":"https://schema.org/EmploymentAgency",
     "Domain Bucket":"1K - 10K"
   },
   {
     "Class":"Itemtype",
-    "Name":"http:\/\/schema.org\/EndorseAction",
+    "Name":"https://schema.org/EndorseAction",
     "Domain Bucket":"< 1K"
   },
   {
     "Class":"Itemtype",
-    "Name":"http:\/\/schema.org\/EndorsementRating",
+    "Name":"https://schema.org/EndorsementRating",
     "Domain Bucket":"< 1K"
   },
   {
     "Class":"Itemtype",
-    "Name":"http:\/\/schema.org\/Energy",
+    "Name":"https://schema.org/Energy",
     "Domain Bucket":"< 1K"
   },
   {
     "Class":"Itemtype",
-    "Name":"http:\/\/schema.org\/EnergyConsumptionDetails",
+    "Name":"https://schema.org/EnergyConsumptionDetails",
     "Domain Bucket":"1K - 10K"
   },
   {
     "Class":"Itemtype",
-    "Name":"http:\/\/schema.org\/EnergyEfficiencyEnumeration",
+    "Name":"https://schema.org/EnergyEfficiencyEnumeration",
     "Domain Bucket":"< 1K"
   },
   {
     "Class":"Itemtype",
-    "Name":"http:\/\/schema.org\/EnergyStarEnergyEfficiencyEnumeration",
+    "Name":"https://schema.org/EnergyStarEnergyEfficiencyEnumeration",
     "Domain Bucket":"< 1K"
   },
   {
     "Class":"Itemtype",
-    "Name":"http:\/\/schema.org\/EngineSpecification",
+    "Name":"https://schema.org/EngineSpecification",
     "Domain Bucket":"10K - 100K"
   },
   {
     "Class":"Itemtype",
-    "Name":"http:\/\/schema.org\/EntertainmentBusiness",
+    "Name":"https://schema.org/EntertainmentBusiness",
     "Domain Bucket":"10K - 100K"
   },
   {
     "Class":"Itemtype",
-    "Name":"http:\/\/schema.org\/EntryPoint",
+    "Name":"https://schema.org/EntryPoint",
     "Domain Bucket":"10M+"
   },
   {
     "Class":"Itemtype",
-    "Name":"http:\/\/schema.org\/Enumeration",
+    "Name":"https://schema.org/Enumeration",
     "Domain Bucket":"1K - 10K"
   },
   {
     "Class":"Itemtype",
-    "Name":"http:\/\/schema.org\/Episode",
+    "Name":"https://schema.org/Episode",
     "Domain Bucket":"1K - 10K"
   },
   {
     "Class":"Itemtype",
-    "Name":"http:\/\/schema.org\/Error",
+    "Name":"https://schema.org/Error",
     "Domain Bucket":"< 1K"
   },
   {
     "Class":"Itemtype",
-    "Name":"http:\/\/schema.org\/Event",
+    "Name":"https://schema.org/Event",
     "Domain Bucket":"100K - 1M"
   },
   {
     "Class":"Itemtype",
-    "Name":"http:\/\/schema.org\/EventAttendanceModeEnumeration",
+    "Name":"https://schema.org/EventAttendanceModeEnumeration",
     "Domain Bucket":"< 1K"
   },
   {
     "Class":"Itemtype",
-    "Name":"http:\/\/schema.org\/EventReservation",
+    "Name":"https://schema.org/EventReservation",
     "Domain Bucket":"< 1K"
   },
   {
     "Class":"Itemtype",
-    "Name":"http:\/\/schema.org\/EventSeries",
+    "Name":"https://schema.org/EventSeries",
     "Domain Bucket":"1K - 10K"
   },
   {
     "Class":"Itemtype",
-    "Name":"http:\/\/schema.org\/EventStatusType",
+    "Name":"https://schema.org/EventStatusType",
     "Domain Bucket":"< 1K"
   },
   {
     "Class":"Itemtype",
-    "Name":"http:\/\/schema.org\/EventVenue",
+    "Name":"https://schema.org/EventVenue",
     "Domain Bucket":"10K - 100K"
   },
   {
     "Class":"Itemtype",
-    "Name":"http:\/\/schema.org\/ExchangeRateSpecification",
+    "Name":"https://schema.org/ExchangeRateSpecification",
     "Domain Bucket":"< 1K"
   },
   {
     "Class":"Itemtype",
-    "Name":"http:\/\/schema.org\/ExerciseAction",
+    "Name":"https://schema.org/ExerciseAction",
     "Domain Bucket":"< 1K"
   },
   {
     "Class":"Itemtype",
-    "Name":"http:\/\/schema.org\/ExerciseGym",
+    "Name":"https://schema.org/ExerciseGym",
     "Domain Bucket":"1K - 10K"
   },
   {
     "Class":"Itemtype",
-    "Name":"http:\/\/schema.org\/ExercisePlan",
+    "Name":"https://schema.org/ExercisePlan",
     "Domain Bucket":"< 1K"
   },
   {
     "Class":"Itemtype",
-    "Name":"http:\/\/schema.org\/ExhibitionEvent",
+    "Name":"https://schema.org/ExhibitionEvent",
     "Domain Bucket":"1K - 10K"
   },
   {
     "Class":"Itemtype",
-    "Name":"http:\/\/schema.org\/FAQPage",
+    "Name":"https://schema.org/FAQPage",
     "Domain Bucket":"1M - 10M"
   },
   {
     "Class":"Itemtype",
-    "Name":"http:\/\/schema.org\/FMRadioChannel",
+    "Name":"https://schema.org/FMRadioChannel",
     "Domain Bucket":"< 1K"
   },
   {
     "Class":"Itemtype",
-    "Name":"http:\/\/schema.org\/FastFoodRestaurant",
+    "Name":"https://schema.org/FastFoodRestaurant",
     "Domain Bucket":"1K - 10K"
   },
   {
     "Class":"Itemtype",
-    "Name":"http:\/\/schema.org\/Festival",
+    "Name":"https://schema.org/Festival",
     "Domain Bucket":"1K - 10K"
   },
   {
     "Class":"Itemtype",
-    "Name":"http:\/\/schema.org\/FilmAction",
+    "Name":"https://schema.org/FilmAction",
     "Domain Bucket":"< 1K"
   },
   {
     "Class":"Itemtype",
-    "Name":"http:\/\/schema.org\/FinancialIncentive",
+    "Name":"https://schema.org/FinancialIncentive",
     "Domain Bucket":"< 1K"
   },
   {
     "Class":"Itemtype",
-    "Name":"http:\/\/schema.org\/FinancialProduct",
+    "Name":"https://schema.org/FinancialProduct",
     "Domain Bucket":"10K - 100K"
   },
   {
     "Class":"Itemtype",
-    "Name":"http:\/\/schema.org\/FinancialService",
+    "Name":"https://schema.org/FinancialService",
     "Domain Bucket":"10K - 100K"
   },
   {
     "Class":"Itemtype",
-    "Name":"http:\/\/schema.org\/FindAction",
+    "Name":"https://schema.org/FindAction",
     "Domain Bucket":"< 1K"
   },
   {
     "Class":"Itemtype",
-    "Name":"http:\/\/schema.org\/FireStation",
+    "Name":"https://schema.org/FireStation",
     "Domain Bucket":"< 1K"
   },
   {
     "Class":"Itemtype",
-    "Name":"http:\/\/schema.org\/Flight",
+    "Name":"https://schema.org/Flight",
     "Domain Bucket":"1K - 10K"
   },
   {
     "Class":"Itemtype",
-    "Name":"http:\/\/schema.org\/FlightReservation",
+    "Name":"https://schema.org/FlightReservation",
     "Domain Bucket":"< 1K"
   },
   {
     "Class":"Itemtype",
-    "Name":"http:\/\/schema.org\/Float",
+    "Name":"https://schema.org/Float",
     "Domain Bucket":"< 1K"
   },
   {
     "Class":"Itemtype",
-    "Name":"http:\/\/schema.org\/FloorPlan",
+    "Name":"https://schema.org/FloorPlan",
     "Domain Bucket":"10K - 100K"
   },
   {
     "Class":"Itemtype",
-    "Name":"http:\/\/schema.org\/Florist",
+    "Name":"https://schema.org/Florist",
     "Domain Bucket":"10K - 100K"
   },
   {
     "Class":"Itemtype",
-    "Name":"http:\/\/schema.org\/FollowAction",
+    "Name":"https://schema.org/FollowAction",
     "Domain Bucket":"10K - 100K"
   },
   {
     "Class":"Itemtype",
-    "Name":"http:\/\/schema.org\/FoodEstablishment",
+    "Name":"https://schema.org/FoodEstablishment",
     "Domain Bucket":"10K - 100K"
   },
   {
     "Class":"Itemtype",
-    "Name":"http:\/\/schema.org\/FoodEstablishmentReservation",
+    "Name":"https://schema.org/FoodEstablishmentReservation",
     "Domain Bucket":"1K - 10K"
   },
   {
     "Class":"Itemtype",
-    "Name":"http:\/\/schema.org\/FoodEvent",
+    "Name":"https://schema.org/FoodEvent",
     "Domain Bucket":"1K - 10K"
   },
   {
     "Class":"Itemtype",
-    "Name":"http:\/\/schema.org\/FoodService",
+    "Name":"https://schema.org/FoodService",
     "Domain Bucket":"1K - 10K"
   },
   {
     "Class":"Itemtype",
-    "Name":"http:\/\/schema.org\/FulfillmentTypeEnumeration",
+    "Name":"https://schema.org/FulfillmentTypeEnumeration",
     "Domain Bucket":"< 1K"
   },
   {
     "Class":"Itemtype",
-    "Name":"http:\/\/schema.org\/FundingAgency",
+    "Name":"https://schema.org/FundingAgency",
     "Domain Bucket":"< 1K"
   },
   {
     "Class":"Itemtype",
-    "Name":"http:\/\/schema.org\/FundingScheme",
+    "Name":"https://schema.org/FundingScheme",
     "Domain Bucket":"< 1K"
   },
   {
     "Class":"Itemtype",
-    "Name":"http:\/\/schema.org\/FurnitureStore",
+    "Name":"https://schema.org/FurnitureStore",
     "Domain Bucket":"10K - 100K"
   },
   {
     "Class":"Itemtype",
-    "Name":"http:\/\/schema.org\/Game",
+    "Name":"https://schema.org/Game",
     "Domain Bucket":"100K - 1M"
   },
   {
     "Class":"Itemtype",
-    "Name":"http:\/\/schema.org\/GameAvailabilityEnumeration",
+    "Name":"https://schema.org/GameAvailabilityEnumeration",
     "Domain Bucket":"< 1K"
   },
   {
     "Class":"Itemtype",
-    "Name":"http:\/\/schema.org\/GamePlayMode",
+    "Name":"https://schema.org/GamePlayMode",
     "Domain Bucket":"< 1K"
   },
   {
     "Class":"Itemtype",
-    "Name":"http:\/\/schema.org\/GameServer",
+    "Name":"https://schema.org/GameServer",
     "Domain Bucket":"1K - 10K"
   },
   {
     "Class":"Itemtype",
-    "Name":"http:\/\/schema.org\/GameServerStatus",
+    "Name":"https://schema.org/GameServerStatus",
     "Domain Bucket":"< 1K"
   },
   {
     "Class":"Itemtype",
-    "Name":"http:\/\/schema.org\/GardenStore",
+    "Name":"https://schema.org/GardenStore",
     "Domain Bucket":"1K - 10K"
   },
   {
     "Class":"Itemtype",
-    "Name":"http:\/\/schema.org\/GasStation",
+    "Name":"https://schema.org/GasStation",
     "Domain Bucket":"1K - 10K"
   },
   {
     "Class":"Itemtype",
-    "Name":"http:\/\/schema.org\/GatedResidenceCommunity",
+    "Name":"https://schema.org/GatedResidenceCommunity",
     "Domain Bucket":"< 1K"
   },
   {
     "Class":"Itemtype",
-    "Name":"http:\/\/schema.org\/GenderType",
+    "Name":"https://schema.org/GenderType",
     "Domain Bucket":"< 1K"
   },
   {
     "Class":"Itemtype",
-    "Name":"http:\/\/schema.org\/Gene",
+    "Name":"https://schema.org/Gene",
     "Domain Bucket":"< 1K"
   },
   {
     "Class":"Itemtype",
-    "Name":"http:\/\/schema.org\/GeneralContractor",
+    "Name":"https://schema.org/GeneralContractor",
     "Domain Bucket":"10K - 100K"
   },
   {
     "Class":"Itemtype",
-    "Name":"http:\/\/schema.org\/GeoCircle",
+    "Name":"https://schema.org/GeoCircle",
     "Domain Bucket":"100K - 1M"
   },
   {
     "Class":"Itemtype",
-    "Name":"http:\/\/schema.org\/GeoCoordinates",
+    "Name":"https://schema.org/GeoCoordinates",
     "Domain Bucket":"1M - 10M"
   },
   {
     "Class":"Itemtype",
-    "Name":"http:\/\/schema.org\/GeoShape",
+    "Name":"https://schema.org/GeoShape",
     "Domain Bucket":"10K - 100K"
   },
   {
     "Class":"Itemtype",
-    "Name":"http:\/\/schema.org\/GeospatialGeometry",
+    "Name":"https://schema.org/GeospatialGeometry",
     "Domain Bucket":"< 1K"
   },
   {
     "Class":"Itemtype",
-    "Name":"http:\/\/schema.org\/Geriatric",
+    "Name":"https://schema.org/Geriatric",
     "Domain Bucket":"< 1K"
   },
   {
     "Class":"Itemtype",
-    "Name":"http:\/\/schema.org\/GiveAction",
+    "Name":"https://schema.org/GiveAction",
     "Domain Bucket":"< 1K"
   },
   {
     "Class":"Itemtype",
-    "Name":"http:\/\/schema.org\/GolfCourse",
+    "Name":"https://schema.org/GolfCourse",
     "Domain Bucket":"1K - 10K"
   },
   {
     "Class":"Itemtype",
-    "Name":"http:\/\/schema.org\/GovernmentBenefitsType",
+    "Name":"https://schema.org/GovernmentBenefitsType",
     "Domain Bucket":"< 1K"
   },
   {
     "Class":"Itemtype",
-    "Name":"http:\/\/schema.org\/GovernmentBuilding",
+    "Name":"https://schema.org/GovernmentBuilding",
     "Domain Bucket":"< 1K"
   },
   {
     "Class":"Itemtype",
-    "Name":"http:\/\/schema.org\/GovernmentOffice",
+    "Name":"https://schema.org/GovernmentOffice",
     "Domain Bucket":"1K - 10K"
   },
   {
     "Class":"Itemtype",
-    "Name":"http:\/\/schema.org\/GovernmentOrganization",
+    "Name":"https://schema.org/GovernmentOrganization",
     "Domain Bucket":"10K - 100K"
   },
   {
     "Class":"Itemtype",
-    "Name":"http:\/\/schema.org\/GovernmentPermit",
+    "Name":"https://schema.org/GovernmentPermit",
     "Domain Bucket":"< 1K"
   },
   {
     "Class":"Itemtype",
-    "Name":"http:\/\/schema.org\/GovernmentService",
+    "Name":"https://schema.org/GovernmentService",
     "Domain Bucket":"1K - 10K"
   },
   {
     "Class":"Itemtype",
-    "Name":"http:\/\/schema.org\/Grant",
+    "Name":"https://schema.org/Grant",
     "Domain Bucket":"1K - 10K"
   },
   {
     "Class":"Itemtype",
-    "Name":"http:\/\/schema.org\/GroceryStore",
+    "Name":"https://schema.org/GroceryStore",
     "Domain Bucket":"1K - 10K"
   },
   {
     "Class":"Itemtype",
-    "Name":"http:\/\/schema.org\/Guide",
+    "Name":"https://schema.org/Guide",
     "Domain Bucket":"1K - 10K"
   },
   {
     "Class":"Itemtype",
-    "Name":"http:\/\/schema.org\/Gynecologic",
+    "Name":"https://schema.org/Gynecologic",
     "Domain Bucket":"< 1K"
   },
   {
     "Class":"Itemtype",
-    "Name":"http:\/\/schema.org\/HVACBusiness",
+    "Name":"https://schema.org/HVACBusiness",
     "Domain Bucket":"10K - 100K"
   },
   {
     "Class":"Itemtype",
-    "Name":"http:\/\/schema.org\/Hackathon",
+    "Name":"https://schema.org/Hackathon",
     "Domain Bucket":"< 1K"
   },
   {
     "Class":"Itemtype",
-    "Name":"http:\/\/schema.org\/HairSalon",
+    "Name":"https://schema.org/HairSalon",
     "Domain Bucket":"10K - 100K"
   },
   {
     "Class":"Itemtype",
-    "Name":"http:\/\/schema.org\/HardwareStore",
+    "Name":"https://schema.org/HardwareStore",
     "Domain Bucket":"1K - 10K"
   },
   {
     "Class":"Itemtype",
-    "Name":"http:\/\/schema.org\/HealthAndBeautyBusiness",
+    "Name":"https://schema.org/HealthAndBeautyBusiness",
     "Domain Bucket":"10K - 100K"
   },
   {
     "Class":"Itemtype",
-    "Name":"http:\/\/schema.org\/HealthAspectEnumeration",
+    "Name":"https://schema.org/HealthAspectEnumeration",
     "Domain Bucket":"< 1K"
   },
   {
     "Class":"Itemtype",
-    "Name":"http:\/\/schema.org\/HealthClub",
+    "Name":"https://schema.org/HealthClub",
     "Domain Bucket":"1K - 10K"
   },
   {
     "Class":"Itemtype",
-    "Name":"http:\/\/schema.org\/HealthInsurancePlan",
+    "Name":"https://schema.org/HealthInsurancePlan",
     "Domain Bucket":"< 1K"
   },
   {
     "Class":"Itemtype",
-    "Name":"http:\/\/schema.org\/HealthPlanCostSharingSpecification",
+    "Name":"https://schema.org/HealthPlanCostSharingSpecification",
     "Domain Bucket":"< 1K"
   },
   {
     "Class":"Itemtype",
-    "Name":"http:\/\/schema.org\/HealthPlanFormulary",
+    "Name":"https://schema.org/HealthPlanFormulary",
     "Domain Bucket":"< 1K"
   },
   {
     "Class":"Itemtype",
-    "Name":"http:\/\/schema.org\/HealthPlanNetwork",
+    "Name":"https://schema.org/HealthPlanNetwork",
     "Domain Bucket":"< 1K"
   },
   {
     "Class":"Itemtype",
-    "Name":"http:\/\/schema.org\/HealthTopicContent",
+    "Name":"https://schema.org/HealthTopicContent",
     "Domain Bucket":"< 1K"
   },
   {
     "Class":"Itemtype",
-    "Name":"http:\/\/schema.org\/HighSchool",
+    "Name":"https://schema.org/HighSchool",
     "Domain Bucket":"1K - 10K"
   },
   {
     "Class":"Itemtype",
-    "Name":"http:\/\/schema.org\/HinduTemple",
+    "Name":"https://schema.org/HinduTemple",
     "Domain Bucket":"< 1K"
   },
   {
     "Class":"Itemtype",
-    "Name":"http:\/\/schema.org\/HobbyShop",
+    "Name":"https://schema.org/HobbyShop",
     "Domain Bucket":"1K - 10K"
   },
   {
     "Class":"Itemtype",
-    "Name":"http:\/\/schema.org\/HomeAndConstructionBusiness",
+    "Name":"https://schema.org/HomeAndConstructionBusiness",
     "Domain Bucket":"100K - 1M"
   },
   {
     "Class":"Itemtype",
-    "Name":"http:\/\/schema.org\/HomeGoodsStore",
+    "Name":"https://schema.org/HomeGoodsStore",
     "Domain Bucket":"1K - 10K"
   },
   {
     "Class":"Itemtype",
-    "Name":"http:\/\/schema.org\/Hospital",
+    "Name":"https://schema.org/Hospital",
     "Domain Bucket":"10K - 100K"
   },
   {
     "Class":"Itemtype",
-    "Name":"http:\/\/schema.org\/Hostel",
+    "Name":"https://schema.org/Hostel",
     "Domain Bucket":"1K - 10K"
   },
   {
     "Class":"Itemtype",
-    "Name":"http:\/\/schema.org\/Hotel",
+    "Name":"https://schema.org/Hotel",
     "Domain Bucket":"10K - 100K"
   },
   {
     "Class":"Itemtype",
-    "Name":"http:\/\/schema.org\/HotelRoom",
+    "Name":"https://schema.org/HotelRoom",
     "Domain Bucket":"10K - 100K"
   },
   {
     "Class":"Itemtype",
-    "Name":"http:\/\/schema.org\/House",
+    "Name":"https://schema.org/House",
     "Domain Bucket":"10K - 100K"
   },
   {
     "Class":"Itemtype",
-    "Name":"http:\/\/schema.org\/HousePainter",
+    "Name":"https://schema.org/HousePainter",
     "Domain Bucket":"1K - 10K"
   },
   {
     "Class":"Itemtype",
-    "Name":"http:\/\/schema.org\/HowTo",
+    "Name":"https://schema.org/HowTo",
     "Domain Bucket":"100K - 1M"
   },
   {
     "Class":"Itemtype",
-    "Name":"http:\/\/schema.org\/HowToDirection",
+    "Name":"https://schema.org/HowToDirection",
     "Domain Bucket":"10K - 100K"
   },
   {
     "Class":"Itemtype",
-    "Name":"http:\/\/schema.org\/HowToItem",
+    "Name":"https://schema.org/HowToItem",
     "Domain Bucket":"< 1K"
   },
   {
     "Class":"Itemtype",
-    "Name":"http:\/\/schema.org\/HowToSection",
+    "Name":"https://schema.org/HowToSection",
     "Domain Bucket":"10K - 100K"
   },
   {
     "Class":"Itemtype",
-    "Name":"http:\/\/schema.org\/HowToStep",
+    "Name":"https://schema.org/HowToStep",
     "Domain Bucket":"100K - 1M"
   },
   {
     "Class":"Itemtype",
-    "Name":"http:\/\/schema.org\/HowToSupply",
+    "Name":"https://schema.org/HowToSupply",
     "Domain Bucket":"10K - 100K"
   },
   {
     "Class":"Itemtype",
-    "Name":"http:\/\/schema.org\/HowToTip",
+    "Name":"https://schema.org/HowToTip",
     "Domain Bucket":"1K - 10K"
   },
   {
     "Class":"Itemtype",
-    "Name":"http:\/\/schema.org\/HowToTool",
+    "Name":"https://schema.org/HowToTool",
     "Domain Bucket":"10K - 100K"
   },
   {
     "Class":"Itemtype",
-    "Name":"http:\/\/schema.org\/HyperToc",
+    "Name":"https://schema.org/HyperToc",
     "Domain Bucket":"< 1K"
   },
   {
     "Class":"Itemtype",
-    "Name":"http:\/\/schema.org\/HyperTocEntry",
+    "Name":"https://schema.org/HyperTocEntry",
     "Domain Bucket":"< 1K"
   },
   {
     "Class":"Itemtype",
-    "Name":"http:\/\/schema.org\/IPTCDigitalSourceEnumeration",
+    "Name":"https://schema.org/IPTCDigitalSourceEnumeration",
     "Domain Bucket":"< 1K"
   },
   {
     "Class":"Itemtype",
-    "Name":"http:\/\/schema.org\/ITNonprofitType",
+    "Name":"https://schema.org/ITNonprofitType",
     "Domain Bucket":"< 1K"
   },
   {
     "Class":"Itemtype",
-    "Name":"http:\/\/schema.org\/IceCreamShop",
+    "Name":"https://schema.org/IceCreamShop",
     "Domain Bucket":"1K - 10K"
   },
   {
     "Class":"Itemtype",
-    "Name":"http:\/\/schema.org\/IgnoreAction",
+    "Name":"https://schema.org/IgnoreAction",
     "Domain Bucket":"< 1K"
   },
   {
     "Class":"Itemtype",
-    "Name":"http:\/\/schema.org\/ImageGallery",
+    "Name":"https://schema.org/ImageGallery",
     "Domain Bucket":"1M - 10M"
   },
   {
     "Class":"Itemtype",
-    "Name":"http:\/\/schema.org\/ImageObject",
+    "Name":"https://schema.org/ImageObject",
     "Domain Bucket":"10M+"
   },
   {
     "Class":"Itemtype",
-    "Name":"http:\/\/schema.org\/ImageObjectSnapshot",
+    "Name":"https://schema.org/ImageObjectSnapshot",
     "Domain Bucket":"< 1K"
   },
   {
     "Class":"Itemtype",
-    "Name":"http:\/\/schema.org\/ImagingTest",
+    "Name":"https://schema.org/ImagingTest",
     "Domain Bucket":"< 1K"
   },
   {
     "Class":"Itemtype",
-    "Name":"http:\/\/schema.org\/IncentiveQualifiedExpenseType",
+    "Name":"https://schema.org/IncentiveQualifiedExpenseType",
     "Domain Bucket":"< 1K"
   },
   {
     "Class":"Itemtype",
-    "Name":"http:\/\/schema.org\/IncentiveStatus",
+    "Name":"https://schema.org/IncentiveStatus",
     "Domain Bucket":"< 1K"
   },
   {
     "Class":"Itemtype",
-    "Name":"http:\/\/schema.org\/IncentiveType",
+    "Name":"https://schema.org/IncentiveType",
     "Domain Bucket":"< 1K"
   },
   {
     "Class":"Itemtype",
-    "Name":"http:\/\/schema.org\/IndividualPhysician",
+    "Name":"https://schema.org/IndividualPhysician",
     "Domain Bucket":"1K - 10K"
   },
   {
     "Class":"Itemtype",
-    "Name":"http:\/\/schema.org\/IndividualProduct",
+    "Name":"https://schema.org/IndividualProduct",
     "Domain Bucket":"10K - 100K"
   },
   {
     "Class":"Itemtype",
-    "Name":"http:\/\/schema.org\/InfectiousAgentClass",
+    "Name":"https://schema.org/InfectiousAgentClass",
     "Domain Bucket":"< 1K"
   },
   {
     "Class":"Itemtype",
-    "Name":"http:\/\/schema.org\/InfectiousDisease",
+    "Name":"https://schema.org/InfectiousDisease",
     "Domain Bucket":"< 1K"
   },
   {
     "Class":"Itemtype",
-    "Name":"http:\/\/schema.org\/InformAction",
+    "Name":"https://schema.org/InformAction",
     "Domain Bucket":"< 1K"
   },
   {
     "Class":"Itemtype",
-    "Name":"http:\/\/schema.org\/InsertAction",
+    "Name":"https://schema.org/InsertAction",
     "Domain Bucket":"< 1K"
   },
   {
     "Class":"Itemtype",
-    "Name":"http:\/\/schema.org\/InstallAction",
+    "Name":"https://schema.org/InstallAction",
     "Domain Bucket":"< 1K"
   },
   {
     "Class":"Itemtype",
-    "Name":"http:\/\/schema.org\/InstantaneousEvent",
+    "Name":"https://schema.org/InstantaneousEvent",
     "Domain Bucket":"< 1K"
   },
   {
     "Class":"Itemtype",
-    "Name":"http:\/\/schema.org\/InsuranceAgency",
+    "Name":"https://schema.org/InsuranceAgency",
     "Domain Bucket":"10K - 100K"
   },
   {
     "Class":"Itemtype",
-    "Name":"http:\/\/schema.org\/Intangible",
+    "Name":"https://schema.org/Intangible",
     "Domain Bucket":"1K - 10K"
   },
   {
     "Class":"Itemtype",
-    "Name":"http:\/\/schema.org\/Integer",
+    "Name":"https://schema.org/Integer",
     "Domain Bucket":"< 1K"
   },
   {
     "Class":"Itemtype",
-    "Name":"http:\/\/schema.org\/InteractAction",
+    "Name":"https://schema.org/InteractAction",
     "Domain Bucket":"1K - 10K"
   },
   {
     "Class":"Itemtype",
-    "Name":"http:\/\/schema.org\/InteractionCounter",
+    "Name":"https://schema.org/InteractionCounter",
     "Domain Bucket":"100K - 1M"
   },
   {
     "Class":"Itemtype",
-    "Name":"http:\/\/schema.org\/InternetCafe",
+    "Name":"https://schema.org/InternetCafe",
     "Domain Bucket":"< 1K"
   },
   {
     "Class":"Itemtype",
-    "Name":"http:\/\/schema.org\/InvestmentFund",
+    "Name":"https://schema.org/InvestmentFund",
     "Domain Bucket":"< 1K"
   },
   {
     "Class":"Itemtype",
-    "Name":"http:\/\/schema.org\/InvestmentOrDeposit",
+    "Name":"https://schema.org/InvestmentOrDeposit",
     "Domain Bucket":"< 1K"
   },
   {
     "Class":"Itemtype",
-    "Name":"http:\/\/schema.org\/InviteAction",
+    "Name":"https://schema.org/InviteAction",
     "Domain Bucket":"< 1K"
   },
   {
     "Class":"Itemtype",
-    "Name":"http:\/\/schema.org\/Invoice",
+    "Name":"https://schema.org/Invoice",
     "Domain Bucket":"< 1K"
   },
   {
     "Class":"Itemtype",
-    "Name":"http:\/\/schema.org\/ItemAvailability",
+    "Name":"https://schema.org/ItemAvailability",
     "Domain Bucket":"1K - 10K"
   },
   {
     "Class":"Itemtype",
-    "Name":"http:\/\/schema.org\/ItemList",
+    "Name":"https://schema.org/ItemList",
     "Domain Bucket":"1M - 10M"
   },
   {
     "Class":"Itemtype",
-    "Name":"http:\/\/schema.org\/ItemListOrderType",
+    "Name":"https://schema.org/ItemListOrderType",
     "Domain Bucket":"< 1K"
   },
   {
     "Class":"Itemtype",
-    "Name":"http:\/\/schema.org\/ItemPage",
+    "Name":"https://schema.org/ItemPage",
     "Domain Bucket":"1M - 10M"
   },
   {
     "Class":"Itemtype",
-    "Name":"http:\/\/schema.org\/JewelryStore",
+    "Name":"https://schema.org/JewelryStore",
     "Domain Bucket":"10K - 100K"
   },
   {
     "Class":"Itemtype",
-    "Name":"http:\/\/schema.org\/JobPosting",
+    "Name":"https://schema.org/JobPosting",
     "Domain Bucket":"100K - 1M"
   },
   {
     "Class":"Itemtype",
-    "Name":"http:\/\/schema.org\/JoinAction",
+    "Name":"https://schema.org/JoinAction",
     "Domain Bucket":"1K - 10K"
   },
   {
     "Class":"Itemtype",
-    "Name":"http:\/\/schema.org\/Joint",
+    "Name":"https://schema.org/Joint",
     "Domain Bucket":"< 1K"
   },
   {
     "Class":"Itemtype",
-    "Name":"http:\/\/schema.org\/LakeBodyOfWater",
+    "Name":"https://schema.org/LakeBodyOfWater",
     "Domain Bucket":"< 1K"
   },
   {
     "Class":"Itemtype",
-    "Name":"http:\/\/schema.org\/Landform",
+    "Name":"https://schema.org/Landform",
     "Domain Bucket":"1K - 10K"
   },
   {
     "Class":"Itemtype",
-    "Name":"http:\/\/schema.org\/LandmarksOrHistoricalBuildings",
+    "Name":"https://schema.org/LandmarksOrHistoricalBuildings",
     "Domain Bucket":"1K - 10K"
   },
   {
     "Class":"Itemtype",
-    "Name":"http:\/\/schema.org\/Language",
+    "Name":"https://schema.org/Language",
     "Domain Bucket":"10K - 100K"
   },
   {
     "Class":"Itemtype",
-    "Name":"http:\/\/schema.org\/LearningResource",
+    "Name":"https://schema.org/LearningResource",
     "Domain Bucket":"1K - 10K"
   },
   {
     "Class":"Itemtype",
-    "Name":"http:\/\/schema.org\/LeaveAction",
+    "Name":"https://schema.org/LeaveAction",
     "Domain Bucket":"< 1K"
   },
   {
     "Class":"Itemtype",
-    "Name":"http:\/\/schema.org\/LegalForceStatus",
+    "Name":"https://schema.org/LegalForceStatus",
     "Domain Bucket":"< 1K"
   },
   {
     "Class":"Itemtype",
-    "Name":"http:\/\/schema.org\/LegalService",
+    "Name":"https://schema.org/LegalService",
     "Domain Bucket":"10K - 100K"
   },
   {
     "Class":"Itemtype",
-    "Name":"http:\/\/schema.org\/LegalValueLevel",
+    "Name":"https://schema.org/LegalValueLevel",
     "Domain Bucket":"< 1K"
   },
   {
     "Class":"Itemtype",
-    "Name":"http:\/\/schema.org\/Legislation",
+    "Name":"https://schema.org/Legislation",
     "Domain Bucket":"1K - 10K"
   },
   {
     "Class":"Itemtype",
-    "Name":"http:\/\/schema.org\/LegislationObject",
+    "Name":"https://schema.org/LegislationObject",
     "Domain Bucket":"1K - 10K"
   },
   {
     "Class":"Itemtype",
-    "Name":"http:\/\/schema.org\/LegislativeBuilding",
+    "Name":"https://schema.org/LegislativeBuilding",
     "Domain Bucket":"< 1K"
   },
   {
     "Class":"Itemtype",
-    "Name":"http:\/\/schema.org\/LendAction",
+    "Name":"https://schema.org/LendAction",
     "Domain Bucket":"< 1K"
   },
   {
     "Class":"Itemtype",
-    "Name":"http:\/\/schema.org\/Library",
+    "Name":"https://schema.org/Library",
     "Domain Bucket":"1K - 10K"
   },
   {
     "Class":"Itemtype",
-    "Name":"http:\/\/schema.org\/LibrarySystem",
+    "Name":"https://schema.org/LibrarySystem",
     "Domain Bucket":"< 1K"
   },
   {
     "Class":"Itemtype",
-    "Name":"http:\/\/schema.org\/LifestyleModification",
+    "Name":"https://schema.org/LifestyleModification",
     "Domain Bucket":"< 1K"
   },
   {
     "Class":"Itemtype",
-    "Name":"http:\/\/schema.org\/Ligament",
+    "Name":"https://schema.org/Ligament",
     "Domain Bucket":"< 1K"
   },
   {
     "Class":"Itemtype",
-    "Name":"http:\/\/schema.org\/LikeAction",
+    "Name":"https://schema.org/LikeAction",
     "Domain Bucket":"10K - 100K"
   },
   {
     "Class":"Itemtype",
-    "Name":"http:\/\/schema.org\/LinkRole",
+    "Name":"https://schema.org/LinkRole",
     "Domain Bucket":"< 1K"
   },
   {
     "Class":"Itemtype",
-    "Name":"http:\/\/schema.org\/LiquorStore",
+    "Name":"https://schema.org/LiquorStore",
     "Domain Bucket":"1K - 10K"
   },
   {
     "Class":"Itemtype",
-    "Name":"http:\/\/schema.org\/ListItem",
+    "Name":"https://schema.org/ListItem",
     "Domain Bucket":"10M+"
   },
   {
     "Class":"Itemtype",
-    "Name":"http:\/\/schema.org\/ListenAction",
+    "Name":"https://schema.org/ListenAction",
     "Domain Bucket":"1K - 10K"
   },
   {
     "Class":"Itemtype",
-    "Name":"http:\/\/schema.org\/Literal",
+    "Name":"https://schema.org/Literal",
     "Domain Bucket":"< 1K"
   },
   {
     "Class":"Itemtype",
-    "Name":"http:\/\/schema.org\/LiteraryEvent",
+    "Name":"https://schema.org/LiteraryEvent",
     "Domain Bucket":"< 1K"
   },
   {
     "Class":"Itemtype",
-    "Name":"http:\/\/schema.org\/LiveBlogPosting",
+    "Name":"https://schema.org/LiveBlogPosting",
     "Domain Bucket":"1K - 10K"
   },
   {
     "Class":"Itemtype",
-    "Name":"http:\/\/schema.org\/LoanOrCredit",
+    "Name":"https://schema.org/LoanOrCredit",
     "Domain Bucket":"1K - 10K"
   },
   {
     "Class":"Itemtype",
-    "Name":"http:\/\/schema.org\/LocalBusiness",
+    "Name":"https://schema.org/LocalBusiness",
     "Domain Bucket":"1M - 10M"
   },
   {
     "Class":"Itemtype",
-    "Name":"http:\/\/schema.org\/LocationFeatureSpecification",
+    "Name":"https://schema.org/LocationFeatureSpecification",
     "Domain Bucket":"100K - 1M"
   },
   {
     "Class":"Itemtype",
-    "Name":"http:\/\/schema.org\/Locksmith",
+    "Name":"https://schema.org/Locksmith",
     "Domain Bucket":"10K - 100K"
   },
   {
     "Class":"Itemtype",
-    "Name":"http:\/\/schema.org\/LodgingBusiness",
+    "Name":"https://schema.org/LodgingBusiness",
     "Domain Bucket":"10K - 100K"
   },
   {
     "Class":"Itemtype",
-    "Name":"http:\/\/schema.org\/LodgingReservation",
+    "Name":"https://schema.org/LodgingReservation",
     "Domain Bucket":"1K - 10K"
   },
   {
     "Class":"Itemtype",
-    "Name":"http:\/\/schema.org\/LoginAction",
+    "Name":"https://schema.org/LoginAction",
     "Domain Bucket":"1K - 10K"
   },
   {
     "Class":"Itemtype",
-    "Name":"http:\/\/schema.org\/LoseAction",
+    "Name":"https://schema.org/LoseAction",
     "Domain Bucket":"< 1K"
   },
   {
     "Class":"Itemtype",
-    "Name":"http:\/\/schema.org\/LymphaticVessel",
+    "Name":"https://schema.org/LymphaticVessel",
     "Domain Bucket":"< 1K"
   },
   {
     "Class":"Itemtype",
-    "Name":"http:\/\/schema.org\/Manuscript",
+    "Name":"https://schema.org/Manuscript",
     "Domain Bucket":"< 1K"
   },
   {
     "Class":"Itemtype",
-    "Name":"http:\/\/schema.org\/Map",
+    "Name":"https://schema.org/Map",
     "Domain Bucket":"10K - 100K"
   },
   {
     "Class":"Itemtype",
-    "Name":"http:\/\/schema.org\/MapCategoryType",
+    "Name":"https://schema.org/MapCategoryType",
     "Domain Bucket":"< 1K"
   },
   {
     "Class":"Itemtype",
-    "Name":"http:\/\/schema.org\/MarryAction",
+    "Name":"https://schema.org/MarryAction",
     "Domain Bucket":"< 1K"
   },
   {
     "Class":"Itemtype",
-    "Name":"http:\/\/schema.org\/Mass",
+    "Name":"https://schema.org/Mass",
     "Domain Bucket":"< 1K"
   },
   {
     "Class":"Itemtype",
-    "Name":"http:\/\/schema.org\/MathSolver",
+    "Name":"https://schema.org/MathSolver",
     "Domain Bucket":"< 1K"
   },
   {
     "Class":"Itemtype",
-    "Name":"http:\/\/schema.org\/MaximumDoseSchedule",
+    "Name":"https://schema.org/MaximumDoseSchedule",
     "Domain Bucket":"< 1K"
   },
   {
     "Class":"Itemtype",
-    "Name":"http:\/\/schema.org\/MeasurementMethodEnum",
+    "Name":"https://schema.org/MeasurementMethodEnum",
     "Domain Bucket":"< 1K"
   },
   {
     "Class":"Itemtype",
-    "Name":"http:\/\/schema.org\/MeasurementTypeEnumeration",
+    "Name":"https://schema.org/MeasurementTypeEnumeration",
     "Domain Bucket":"< 1K"
   },
   {
     "Class":"Itemtype",
-    "Name":"http:\/\/schema.org\/MediaEnumeration",
+    "Name":"https://schema.org/MediaEnumeration",
     "Domain Bucket":"< 1K"
   },
   {
     "Class":"Itemtype",
-    "Name":"http:\/\/schema.org\/MediaGallery",
+    "Name":"https://schema.org/MediaGallery",
     "Domain Bucket":"1K - 10K"
   },
   {
     "Class":"Itemtype",
-    "Name":"http:\/\/schema.org\/MediaManipulationRatingEnumeration",
+    "Name":"https://schema.org/MediaManipulationRatingEnumeration",
     "Domain Bucket":"< 1K"
   },
   {
     "Class":"Itemtype",
-    "Name":"http:\/\/schema.org\/MediaObject",
+    "Name":"https://schema.org/MediaObject",
     "Domain Bucket":"100K - 1M"
   },
   {
     "Class":"Itemtype",
-    "Name":"http:\/\/schema.org\/MediaReview",
+    "Name":"https://schema.org/MediaReview",
     "Domain Bucket":"< 1K"
   },
   {
     "Class":"Itemtype",
-    "Name":"http:\/\/schema.org\/MediaReviewItem",
+    "Name":"https://schema.org/MediaReviewItem",
     "Domain Bucket":"< 1K"
   },
   {
     "Class":"Itemtype",
-    "Name":"http:\/\/schema.org\/MediaSubscription",
+    "Name":"https://schema.org/MediaSubscription",
     "Domain Bucket":"< 1K"
   },
   {
     "Class":"Itemtype",
-    "Name":"http:\/\/schema.org\/MedicalAudience",
+    "Name":"https://schema.org/MedicalAudience",
     "Domain Bucket":"10K - 100K"
   },
   {
     "Class":"Itemtype",
-    "Name":"http:\/\/schema.org\/MedicalAudienceType",
+    "Name":"https://schema.org/MedicalAudienceType",
     "Domain Bucket":"< 1K"
   },
   {
     "Class":"Itemtype",
-    "Name":"http:\/\/schema.org\/MedicalBusiness",
+    "Name":"https://schema.org/MedicalBusiness",
     "Domain Bucket":"10K - 100K"
   },
   {
     "Class":"Itemtype",
-    "Name":"http:\/\/schema.org\/MedicalCause",
+    "Name":"https://schema.org/MedicalCause",
     "Domain Bucket":"1K - 10K"
   },
   {
     "Class":"Itemtype",
-    "Name":"http:\/\/schema.org\/MedicalClinic",
+    "Name":"https://schema.org/MedicalClinic",
     "Domain Bucket":"10K - 100K"
   },
   {
     "Class":"Itemtype",
-    "Name":"http:\/\/schema.org\/MedicalCode",
+    "Name":"https://schema.org/MedicalCode",
     "Domain Bucket":"1K - 10K"
   },
   {
     "Class":"Itemtype",
-    "Name":"http:\/\/schema.org\/MedicalCondition",
+    "Name":"https://schema.org/MedicalCondition",
     "Domain Bucket":"10K - 100K"
   },
   {
     "Class":"Itemtype",
-    "Name":"http:\/\/schema.org\/MedicalConditionStage",
+    "Name":"https://schema.org/MedicalConditionStage",
     "Domain Bucket":"< 1K"
   },
   {
     "Class":"Itemtype",
-    "Name":"http:\/\/schema.org\/MedicalContraindication",
+    "Name":"https://schema.org/MedicalContraindication",
     "Domain Bucket":"< 1K"
   },
   {
     "Class":"Itemtype",
-    "Name":"http:\/\/schema.org\/MedicalDevice",
+    "Name":"https://schema.org/MedicalDevice",
     "Domain Bucket":"1K - 10K"
   },
   {
     "Class":"Itemtype",
-    "Name":"http:\/\/schema.org\/MedicalDevicePurpose",
+    "Name":"https://schema.org/MedicalDevicePurpose",
     "Domain Bucket":"< 1K"
   },
   {
     "Class":"Itemtype",
-    "Name":"http:\/\/schema.org\/MedicalEntity",
+    "Name":"https://schema.org/MedicalEntity",
     "Domain Bucket":"1K - 10K"
   },
   {
     "Class":"Itemtype",
-    "Name":"http:\/\/schema.org\/MedicalEnumeration",
+    "Name":"https://schema.org/MedicalEnumeration",
     "Domain Bucket":"< 1K"
   },
   {
     "Class":"Itemtype",
-    "Name":"http:\/\/schema.org\/MedicalEvidenceLevel",
+    "Name":"https://schema.org/MedicalEvidenceLevel",
     "Domain Bucket":"< 1K"
   },
   {
     "Class":"Itemtype",
-    "Name":"http:\/\/schema.org\/MedicalGuideline",
+    "Name":"https://schema.org/MedicalGuideline",
     "Domain Bucket":"< 1K"
   },
   {
     "Class":"Itemtype",
-    "Name":"http:\/\/schema.org\/MedicalGuidelineContraindication",
+    "Name":"https://schema.org/MedicalGuidelineContraindication",
     "Domain Bucket":"< 1K"
   },
   {
     "Class":"Itemtype",
-    "Name":"http:\/\/schema.org\/MedicalGuidelineRecommendation",
+    "Name":"https://schema.org/MedicalGuidelineRecommendation",
     "Domain Bucket":"< 1K"
   },
   {
     "Class":"Itemtype",
-    "Name":"http:\/\/schema.org\/MedicalImagingTechnique",
+    "Name":"https://schema.org/MedicalImagingTechnique",
     "Domain Bucket":"< 1K"
   },
   {
     "Class":"Itemtype",
-    "Name":"http:\/\/schema.org\/MedicalIndication",
+    "Name":"https://schema.org/MedicalIndication",
     "Domain Bucket":"1K - 10K"
   },
   {
     "Class":"Itemtype",
-    "Name":"http:\/\/schema.org\/MedicalIntangible",
+    "Name":"https://schema.org/MedicalIntangible",
     "Domain Bucket":"< 1K"
   },
   {
     "Class":"Itemtype",
-    "Name":"http:\/\/schema.org\/MedicalObservationalStudy",
+    "Name":"https://schema.org/MedicalObservationalStudy",
     "Domain Bucket":"< 1K"
   },
   {
     "Class":"Itemtype",
-    "Name":"http:\/\/schema.org\/MedicalObservationalStudyDesign",
+    "Name":"https://schema.org/MedicalObservationalStudyDesign",
     "Domain Bucket":"< 1K"
   },
   {
     "Class":"Itemtype",
-    "Name":"http:\/\/schema.org\/MedicalOrganization",
+    "Name":"https://schema.org/MedicalOrganization",
     "Domain Bucket":"10K - 100K"
   },
   {
     "Class":"Itemtype",
-    "Name":"http:\/\/schema.org\/MedicalProcedure",
+    "Name":"https://schema.org/MedicalProcedure",
     "Domain Bucket":"10K - 100K"
   },
   {
     "Class":"Itemtype",
-    "Name":"http:\/\/schema.org\/MedicalProcedureType",
+    "Name":"https://schema.org/MedicalProcedureType",
     "Domain Bucket":"< 1K"
   },
   {
     "Class":"Itemtype",
-    "Name":"http:\/\/schema.org\/MedicalRiskCalculator",
+    "Name":"https://schema.org/MedicalRiskCalculator",
     "Domain Bucket":"< 1K"
   },
   {
     "Class":"Itemtype",
-    "Name":"http:\/\/schema.org\/MedicalRiskEstimator",
+    "Name":"https://schema.org/MedicalRiskEstimator",
     "Domain Bucket":"< 1K"
   },
   {
     "Class":"Itemtype",
-    "Name":"http:\/\/schema.org\/MedicalRiskFactor",
+    "Name":"https://schema.org/MedicalRiskFactor",
     "Domain Bucket":"1K - 10K"
   },
   {
     "Class":"Itemtype",
-    "Name":"http:\/\/schema.org\/MedicalRiskScore",
+    "Name":"https://schema.org/MedicalRiskScore",
     "Domain Bucket":"< 1K"
   },
   {
     "Class":"Itemtype",
-    "Name":"http:\/\/schema.org\/MedicalScholarlyArticle",
+    "Name":"https://schema.org/MedicalScholarlyArticle",
     "Domain Bucket":"1K - 10K"
   },
   {
     "Class":"Itemtype",
-    "Name":"http:\/\/schema.org\/MedicalSign",
+    "Name":"https://schema.org/MedicalSign",
     "Domain Bucket":"< 1K"
   },
   {
     "Class":"Itemtype",
-    "Name":"http:\/\/schema.org\/MedicalSignOrSymptom",
+    "Name":"https://schema.org/MedicalSignOrSymptom",
     "Domain Bucket":"1K - 10K"
   },
   {
     "Class":"Itemtype",
-    "Name":"http:\/\/schema.org\/MedicalSpecialty",
+    "Name":"https://schema.org/MedicalSpecialty",
     "Domain Bucket":"10K - 100K"
   },
   {
     "Class":"Itemtype",
-    "Name":"http:\/\/schema.org\/MedicalStudy",
+    "Name":"https://schema.org/MedicalStudy",
     "Domain Bucket":"1K - 10K"
   },
   {
     "Class":"Itemtype",
-    "Name":"http:\/\/schema.org\/MedicalStudyStatus",
+    "Name":"https://schema.org/MedicalStudyStatus",
     "Domain Bucket":"< 1K"
   },
   {
     "Class":"Itemtype",
-    "Name":"http:\/\/schema.org\/MedicalSymptom",
+    "Name":"https://schema.org/MedicalSymptom",
     "Domain Bucket":"1K - 10K"
   },
   {
     "Class":"Itemtype",
-    "Name":"http:\/\/schema.org\/MedicalTest",
+    "Name":"https://schema.org/MedicalTest",
     "Domain Bucket":"1K - 10K"
   },
   {
     "Class":"Itemtype",
-    "Name":"http:\/\/schema.org\/MedicalTestPanel",
+    "Name":"https://schema.org/MedicalTestPanel",
     "Domain Bucket":"< 1K"
   },
   {
     "Class":"Itemtype",
-    "Name":"http:\/\/schema.org\/MedicalTherapy",
+    "Name":"https://schema.org/MedicalTherapy",
     "Domain Bucket":"10K - 100K"
   },
   {
     "Class":"Itemtype",
-    "Name":"http:\/\/schema.org\/MedicalTrial",
+    "Name":"https://schema.org/MedicalTrial",
     "Domain Bucket":"< 1K"
   },
   {
     "Class":"Itemtype",
-    "Name":"http:\/\/schema.org\/MedicalTrialDesign",
+    "Name":"https://schema.org/MedicalTrialDesign",
     "Domain Bucket":"< 1K"
   },
   {
     "Class":"Itemtype",
-    "Name":"http:\/\/schema.org\/MedicalWebPage",
+    "Name":"https://schema.org/MedicalWebPage",
     "Domain Bucket":"10K - 100K"
   },
   {
     "Class":"Itemtype",
-    "Name":"http:\/\/schema.org\/MedicineSystem",
+    "Name":"https://schema.org/MedicineSystem",
     "Domain Bucket":"< 1K"
   },
   {
     "Class":"Itemtype",
-    "Name":"http:\/\/schema.org\/MeetingRoom",
+    "Name":"https://schema.org/MeetingRoom",
     "Domain Bucket":"1K - 10K"
   },
   {
     "Class":"Itemtype",
-    "Name":"http:\/\/schema.org\/MemberProgram",
+    "Name":"https://schema.org/MemberProgram",
     "Domain Bucket":"1K - 10K"
   },
   {
     "Class":"Itemtype",
-    "Name":"http:\/\/schema.org\/MemberProgramTier",
+    "Name":"https://schema.org/MemberProgramTier",
     "Domain Bucket":"1K - 10K"
   },
   {
     "Class":"Itemtype",
-    "Name":"http:\/\/schema.org\/MensClothingStore",
+    "Name":"https://schema.org/MensClothingStore",
     "Domain Bucket":"< 1K"
   },
   {
     "Class":"Itemtype",
-    "Name":"http:\/\/schema.org\/Menu",
+    "Name":"https://schema.org/Menu",
     "Domain Bucket":"100K - 1M"
   },
   {
     "Class":"Itemtype",
-    "Name":"http:\/\/schema.org\/MenuItem",
+    "Name":"https://schema.org/MenuItem",
     "Domain Bucket":"10K - 100K"
   },
   {
     "Class":"Itemtype",
-    "Name":"http:\/\/schema.org\/MenuSection",
+    "Name":"https://schema.org/MenuSection",
     "Domain Bucket":"10K - 100K"
   },
   {
     "Class":"Itemtype",
-    "Name":"http:\/\/schema.org\/MerchantReturnEnumeration",
+    "Name":"https://schema.org/MerchantReturnEnumeration",
     "Domain Bucket":"< 1K"
   },
   {
     "Class":"Itemtype",
-    "Name":"http:\/\/schema.org\/MerchantReturnPolicy",
+    "Name":"https://schema.org/MerchantReturnPolicy",
     "Domain Bucket":"100K - 1M"
   },
   {
     "Class":"Itemtype",
-    "Name":"http:\/\/schema.org\/MerchantReturnPolicySeasonalOverride",
+    "Name":"https://schema.org/MerchantReturnPolicySeasonalOverride",
     "Domain Bucket":"1K - 10K"
   },
   {
     "Class":"Itemtype",
-    "Name":"http:\/\/schema.org\/Message",
+    "Name":"https://schema.org/Message",
     "Domain Bucket":"1K - 10K"
   },
   {
     "Class":"Itemtype",
-    "Name":"http:\/\/schema.org\/MiddleSchool",
+    "Name":"https://schema.org/MiddleSchool",
     "Domain Bucket":"< 1K"
   },
   {
     "Class":"Itemtype",
-    "Name":"http:\/\/schema.org\/Midwifery",
+    "Name":"https://schema.org/Midwifery",
     "Domain Bucket":"< 1K"
   },
   {
     "Class":"Itemtype",
-    "Name":"http:\/\/schema.org\/MobileApplication",
+    "Name":"https://schema.org/MobileApplication",
     "Domain Bucket":"100K - 1M"
   },
   {
     "Class":"Itemtype",
-    "Name":"http:\/\/schema.org\/MobilePhoneStore",
+    "Name":"https://schema.org/MobilePhoneStore",
     "Domain Bucket":"1K - 10K"
   },
   {
     "Class":"Itemtype",
-    "Name":"http:\/\/schema.org\/MolecularEntity",
+    "Name":"https://schema.org/MolecularEntity",
     "Domain Bucket":"< 1K"
   },
   {
     "Class":"Itemtype",
-    "Name":"http:\/\/schema.org\/MonetaryAmount",
+    "Name":"https://schema.org/MonetaryAmount",
     "Domain Bucket":"100K - 1M"
   },
   {
     "Class":"Itemtype",
-    "Name":"http:\/\/schema.org\/MonetaryAmountDistribution",
+    "Name":"https://schema.org/MonetaryAmountDistribution",
     "Domain Bucket":"1K - 10K"
   },
   {
     "Class":"Itemtype",
-    "Name":"http:\/\/schema.org\/MonetaryGrant",
+    "Name":"https://schema.org/MonetaryGrant",
     "Domain Bucket":"1K - 10K"
   },
   {
     "Class":"Itemtype",
-    "Name":"http:\/\/schema.org\/MoneyTransfer",
+    "Name":"https://schema.org/MoneyTransfer",
     "Domain Bucket":"< 1K"
   },
   {
     "Class":"Itemtype",
-    "Name":"http:\/\/schema.org\/MortgageLoan",
+    "Name":"https://schema.org/MortgageLoan",
     "Domain Bucket":"< 1K"
   },
   {
     "Class":"Itemtype",
-    "Name":"http:\/\/schema.org\/Mosque",
+    "Name":"https://schema.org/Mosque",
     "Domain Bucket":"< 1K"
   },
   {
     "Class":"Itemtype",
-    "Name":"http:\/\/schema.org\/Motel",
+    "Name":"https://schema.org/Motel",
     "Domain Bucket":"< 1K"
   },
   {
     "Class":"Itemtype",
-    "Name":"http:\/\/schema.org\/Motorcycle",
+    "Name":"https://schema.org/Motorcycle",
     "Domain Bucket":"1K - 10K"
   },
   {
     "Class":"Itemtype",
-    "Name":"http:\/\/schema.org\/MotorcycleDealer",
+    "Name":"https://schema.org/MotorcycleDealer",
     "Domain Bucket":"1K - 10K"
   },
   {
     "Class":"Itemtype",
-    "Name":"http:\/\/schema.org\/MotorcycleRepair",
+    "Name":"https://schema.org/MotorcycleRepair",
     "Domain Bucket":"< 1K"
   },
   {
     "Class":"Itemtype",
-    "Name":"http:\/\/schema.org\/MotorizedBicycle",
+    "Name":"https://schema.org/MotorizedBicycle",
     "Domain Bucket":"< 1K"
   },
   {
     "Class":"Itemtype",
-    "Name":"http:\/\/schema.org\/Mountain",
+    "Name":"https://schema.org/Mountain",
     "Domain Bucket":"< 1K"
   },
   {
     "Class":"Itemtype",
-    "Name":"http:\/\/schema.org\/MoveAction",
+    "Name":"https://schema.org/MoveAction",
     "Domain Bucket":"< 1K"
   },
   {
     "Class":"Itemtype",
-    "Name":"http:\/\/schema.org\/Movie",
+    "Name":"https://schema.org/Movie",
     "Domain Bucket":"10K - 100K"
   },
   {
     "Class":"Itemtype",
-    "Name":"http:\/\/schema.org\/MovieClip",
+    "Name":"https://schema.org/MovieClip",
     "Domain Bucket":"< 1K"
   },
   {
     "Class":"Itemtype",
-    "Name":"http:\/\/schema.org\/MovieRentalStore",
+    "Name":"https://schema.org/MovieRentalStore",
     "Domain Bucket":"< 1K"
   },
   {
     "Class":"Itemtype",
-    "Name":"http:\/\/schema.org\/MovieSeries",
+    "Name":"https://schema.org/MovieSeries",
     "Domain Bucket":"< 1K"
   },
   {
     "Class":"Itemtype",
-    "Name":"http:\/\/schema.org\/MovieTheater",
+    "Name":"https://schema.org/MovieTheater",
     "Domain Bucket":"1K - 10K"
   },
   {
     "Class":"Itemtype",
-    "Name":"http:\/\/schema.org\/MovingCompany",
+    "Name":"https://schema.org/MovingCompany",
     "Domain Bucket":"10K - 100K"
   },
   {
     "Class":"Itemtype",
-    "Name":"http:\/\/schema.org\/Muscle",
+    "Name":"https://schema.org/Muscle",
     "Domain Bucket":"< 1K"
   },
   {
     "Class":"Itemtype",
-    "Name":"http:\/\/schema.org\/Museum",
+    "Name":"https://schema.org/Museum",
     "Domain Bucket":"1K - 10K"
   },
   {
     "Class":"Itemtype",
-    "Name":"http:\/\/schema.org\/MusicAlbum",
+    "Name":"https://schema.org/MusicAlbum",
     "Domain Bucket":"10K - 100K"
   },
   {
     "Class":"Itemtype",
-    "Name":"http:\/\/schema.org\/MusicAlbumProductionType",
+    "Name":"https://schema.org/MusicAlbumProductionType",
     "Domain Bucket":"< 1K"
   },
   {
     "Class":"Itemtype",
-    "Name":"http:\/\/schema.org\/MusicAlbumReleaseType",
+    "Name":"https://schema.org/MusicAlbumReleaseType",
     "Domain Bucket":"< 1K"
   },
   {
     "Class":"Itemtype",
-    "Name":"http:\/\/schema.org\/MusicComposition",
+    "Name":"https://schema.org/MusicComposition",
     "Domain Bucket":"1K - 10K"
   },
   {
     "Class":"Itemtype",
-    "Name":"http:\/\/schema.org\/MusicEvent",
+    "Name":"https://schema.org/MusicEvent",
     "Domain Bucket":"10K - 100K"
   },
   {
     "Class":"Itemtype",
-    "Name":"http:\/\/schema.org\/MusicGroup",
+    "Name":"https://schema.org/MusicGroup",
     "Domain Bucket":"10K - 100K"
   },
   {
     "Class":"Itemtype",
-    "Name":"http:\/\/schema.org\/MusicPlaylist",
+    "Name":"https://schema.org/MusicPlaylist",
     "Domain Bucket":"1K - 10K"
   },
   {
     "Class":"Itemtype",
-    "Name":"http:\/\/schema.org\/MusicRecording",
+    "Name":"https://schema.org/MusicRecording",
     "Domain Bucket":"10K - 100K"
   },
   {
     "Class":"Itemtype",
-    "Name":"http:\/\/schema.org\/MusicRelease",
+    "Name":"https://schema.org/MusicRelease",
     "Domain Bucket":"1K - 10K"
   },
   {
     "Class":"Itemtype",
-    "Name":"http:\/\/schema.org\/MusicReleaseFormatType",
+    "Name":"https://schema.org/MusicReleaseFormatType",
     "Domain Bucket":"< 1K"
   },
   {
     "Class":"Itemtype",
-    "Name":"http:\/\/schema.org\/MusicStore",
+    "Name":"https://schema.org/MusicStore",
     "Domain Bucket":"1K - 10K"
   },
   {
     "Class":"Itemtype",
-    "Name":"http:\/\/schema.org\/MusicVenue",
+    "Name":"https://schema.org/MusicVenue",
     "Domain Bucket":"1K - 10K"
   },
   {
     "Class":"Itemtype",
-    "Name":"http:\/\/schema.org\/MusicVideoObject",
+    "Name":"https://schema.org/MusicVideoObject",
     "Domain Bucket":"< 1K"
   },
   {
     "Class":"Itemtype",
-    "Name":"http:\/\/schema.org\/NGO",
+    "Name":"https://schema.org/NGO",
     "Domain Bucket":"10K - 100K"
   },
   {
     "Class":"Itemtype",
-    "Name":"http:\/\/schema.org\/NLNonprofitType",
+    "Name":"https://schema.org/NLNonprofitType",
     "Domain Bucket":"< 1K"
   },
   {
     "Class":"Itemtype",
-    "Name":"http:\/\/schema.org\/NailSalon",
+    "Name":"https://schema.org/NailSalon",
     "Domain Bucket":"1K - 10K"
   },
   {
     "Class":"Itemtype",
-    "Name":"http:\/\/schema.org\/Nerve",
+    "Name":"https://schema.org/Nerve",
     "Domain Bucket":"< 1K"
   },
   {
     "Class":"Itemtype",
-    "Name":"http:\/\/schema.org\/NewsArticle",
+    "Name":"https://schema.org/NewsArticle",
     "Domain Bucket":"100K - 1M"
   },
   {
     "Class":"Itemtype",
-    "Name":"http:\/\/schema.org\/NewsMediaOrganization",
+    "Name":"https://schema.org/NewsMediaOrganization",
     "Domain Bucket":"10K - 100K"
   },
   {
     "Class":"Itemtype",
-    "Name":"http:\/\/schema.org\/Newspaper",
+    "Name":"https://schema.org/Newspaper",
     "Domain Bucket":"< 1K"
   },
   {
     "Class":"Itemtype",
-    "Name":"http:\/\/schema.org\/NightClub",
+    "Name":"https://schema.org/NightClub",
     "Domain Bucket":"1K - 10K"
   },
   {
     "Class":"Itemtype",
-    "Name":"http:\/\/schema.org\/NonprofitType",
+    "Name":"https://schema.org/NonprofitType",
     "Domain Bucket":"< 1K"
   },
   {
     "Class":"Itemtype",
-    "Name":"http:\/\/schema.org\/Notary",
+    "Name":"https://schema.org/Notary",
     "Domain Bucket":"1K - 10K"
   },
   {
     "Class":"Itemtype",
-    "Name":"http:\/\/schema.org\/NoteDigitalDocument",
+    "Name":"https://schema.org/NoteDigitalDocument",
     "Domain Bucket":"< 1K"
   },
   {
     "Class":"Itemtype",
-    "Name":"http:\/\/schema.org\/Number",
+    "Name":"https://schema.org/Number",
     "Domain Bucket":"< 1K"
   },
   {
     "Class":"Itemtype",
-    "Name":"http:\/\/schema.org\/Nursing",
+    "Name":"https://schema.org/Nursing",
     "Domain Bucket":"< 1K"
   },
   {
     "Class":"Itemtype",
-    "Name":"http:\/\/schema.org\/NutritionInformation",
+    "Name":"https://schema.org/NutritionInformation",
     "Domain Bucket":"10K - 100K"
   },
   {
     "Class":"Itemtype",
-    "Name":"http:\/\/schema.org\/Observation",
+    "Name":"https://schema.org/Observation",
     "Domain Bucket":"< 1K"
   },
   {
     "Class":"Itemtype",
-    "Name":"http:\/\/schema.org\/Obstetric",
+    "Name":"https://schema.org/Obstetric",
     "Domain Bucket":"< 1K"
   },
   {
     "Class":"Itemtype",
-    "Name":"http:\/\/schema.org\/Occupation",
+    "Name":"https://schema.org/Occupation",
     "Domain Bucket":"10K - 100K"
   },
   {
     "Class":"Itemtype",
-    "Name":"http:\/\/schema.org\/OccupationalExperienceRequirements",
+    "Name":"https://schema.org/OccupationalExperienceRequirements",
     "Domain Bucket":"1K - 10K"
   },
   {
     "Class":"Itemtype",
-    "Name":"http:\/\/schema.org\/OccupationalTherapy",
+    "Name":"https://schema.org/OccupationalTherapy",
     "Domain Bucket":"< 1K"
   },
   {
     "Class":"Itemtype",
-    "Name":"http:\/\/schema.org\/OceanBodyOfWater",
+    "Name":"https://schema.org/OceanBodyOfWater",
     "Domain Bucket":"< 1K"
   },
   {
     "Class":"Itemtype",
-    "Name":"http:\/\/schema.org\/Offer",
+    "Name":"https://schema.org/Offer",
     "Domain Bucket":"10M+"
   },
   {
     "Class":"Itemtype",
-    "Name":"http:\/\/schema.org\/OfferCatalog",
+    "Name":"https://schema.org/OfferCatalog",
     "Domain Bucket":"100K - 1M"
   },
   {
     "Class":"Itemtype",
-    "Name":"http:\/\/schema.org\/OfferForLease",
+    "Name":"https://schema.org/OfferForLease",
     "Domain Bucket":"1K - 10K"
   },
   {
     "Class":"Itemtype",
-    "Name":"http:\/\/schema.org\/OfferForPurchase",
+    "Name":"https://schema.org/OfferForPurchase",
     "Domain Bucket":"1K - 10K"
   },
   {
     "Class":"Itemtype",
-    "Name":"http:\/\/schema.org\/OfferItemCondition",
+    "Name":"https://schema.org/OfferItemCondition",
     "Domain Bucket":"1K - 10K"
   },
   {
     "Class":"Itemtype",
-    "Name":"http:\/\/schema.org\/OfferShippingDetails",
+    "Name":"https://schema.org/OfferShippingDetails",
     "Domain Bucket":"100K - 1M"
   },
   {
     "Class":"Itemtype",
-    "Name":"http:\/\/schema.org\/OfficeEquipmentStore",
+    "Name":"https://schema.org/OfficeEquipmentStore",
     "Domain Bucket":"1K - 10K"
   },
   {
     "Class":"Itemtype",
-    "Name":"http:\/\/schema.org\/OnDemandEvent",
+    "Name":"https://schema.org/OnDemandEvent",
     "Domain Bucket":"< 1K"
   },
   {
     "Class":"Itemtype",
-    "Name":"http:\/\/schema.org\/Oncologic",
+    "Name":"https://schema.org/Oncologic",
     "Domain Bucket":"< 1K"
   },
   {
     "Class":"Itemtype",
-    "Name":"http:\/\/schema.org\/OnlineBusiness",
+    "Name":"https://schema.org/OnlineBusiness",
     "Domain Bucket":"10K - 100K"
   },
   {
     "Class":"Itemtype",
-    "Name":"http:\/\/schema.org\/OnlineMarketplace",
+    "Name":"https://schema.org/OnlineMarketplace",
     "Domain Bucket":"< 1K"
   },
   {
     "Class":"Itemtype",
-    "Name":"http:\/\/schema.org\/OnlineStore",
+    "Name":"https://schema.org/OnlineStore",
     "Domain Bucket":"100K - 1M"
   },
   {
     "Class":"Itemtype",
-    "Name":"http:\/\/schema.org\/OpeningHoursSpecification",
+    "Name":"https://schema.org/OpeningHoursSpecification",
     "Domain Bucket":"1M - 10M"
   },
   {
     "Class":"Itemtype",
-    "Name":"http:\/\/schema.org\/OperatingSystem",
+    "Name":"https://schema.org/OperatingSystem",
     "Domain Bucket":"< 1K"
   },
   {
     "Class":"Itemtype",
-    "Name":"http:\/\/schema.org\/OpinionNewsArticle",
+    "Name":"https://schema.org/OpinionNewsArticle",
     "Domain Bucket":"1K - 10K"
   },
   {
     "Class":"Itemtype",
-    "Name":"http:\/\/schema.org\/Optician",
+    "Name":"https://schema.org/Optician",
     "Domain Bucket":"1K - 10K"
   },
   {
     "Class":"Itemtype",
-    "Name":"http:\/\/schema.org\/Optometric",
+    "Name":"https://schema.org/Optometric",
     "Domain Bucket":"1K - 10K"
   },
   {
     "Class":"Itemtype",
-    "Name":"http:\/\/schema.org\/Order",
+    "Name":"https://schema.org/Order",
     "Domain Bucket":"1K - 10K"
   },
   {
     "Class":"Itemtype",
-    "Name":"http:\/\/schema.org\/OrderAction",
+    "Name":"https://schema.org/OrderAction",
     "Domain Bucket":"10K - 100K"
   },
   {
     "Class":"Itemtype",
-    "Name":"http:\/\/schema.org\/OrderItem",
+    "Name":"https://schema.org/OrderItem",
     "Domain Bucket":"< 1K"
   },
   {
     "Class":"Itemtype",
-    "Name":"http:\/\/schema.org\/OrderStatus",
+    "Name":"https://schema.org/OrderStatus",
     "Domain Bucket":"< 1K"
   },
   {
     "Class":"Itemtype",
-    "Name":"http:\/\/schema.org\/Organization",
+    "Name":"https://schema.org/Organization",
     "Domain Bucket":"10M+"
   },
   {
     "Class":"Itemtype",
-    "Name":"http:\/\/schema.org\/OrganizationRole",
+    "Name":"https://schema.org/OrganizationRole",
     "Domain Bucket":"1K - 10K"
   },
   {
     "Class":"Itemtype",
-    "Name":"http:\/\/schema.org\/OrganizeAction",
+    "Name":"https://schema.org/OrganizeAction",
     "Domain Bucket":"< 1K"
   },
   {
     "Class":"Itemtype",
-    "Name":"http:\/\/schema.org\/Otolaryngologic",
+    "Name":"https://schema.org/Otolaryngologic",
     "Domain Bucket":"< 1K"
   },
   {
     "Class":"Itemtype",
-    "Name":"http:\/\/schema.org\/OutletStore",
+    "Name":"https://schema.org/OutletStore",
     "Domain Bucket":"< 1K"
   },
   {
     "Class":"Itemtype",
-    "Name":"http:\/\/schema.org\/OwnershipInfo",
+    "Name":"https://schema.org/OwnershipInfo",
     "Domain Bucket":"< 1K"
   },
   {
     "Class":"Itemtype",
-    "Name":"http:\/\/schema.org\/PaintAction",
+    "Name":"https://schema.org/PaintAction",
     "Domain Bucket":"< 1K"
   },
   {
     "Class":"Itemtype",
-    "Name":"http:\/\/schema.org\/Painting",
+    "Name":"https://schema.org/Painting",
     "Domain Bucket":"< 1K"
   },
   {
     "Class":"Itemtype",
-    "Name":"http:\/\/schema.org\/PalliativeProcedure",
+    "Name":"https://schema.org/PalliativeProcedure",
     "Domain Bucket":"< 1K"
   },
   {
     "Class":"Itemtype",
-    "Name":"http:\/\/schema.org\/ParcelDelivery",
+    "Name":"https://schema.org/ParcelDelivery",
     "Domain Bucket":"< 1K"
   },
   {
     "Class":"Itemtype",
-    "Name":"http:\/\/schema.org\/ParentAudience",
+    "Name":"https://schema.org/ParentAudience",
     "Domain Bucket":"< 1K"
   },
   {
     "Class":"Itemtype",
-    "Name":"http:\/\/schema.org\/Park",
+    "Name":"https://schema.org/Park",
     "Domain Bucket":"1K - 10K"
   },
   {
     "Class":"Itemtype",
-    "Name":"http:\/\/schema.org\/ParkingFacility",
+    "Name":"https://schema.org/ParkingFacility",
     "Domain Bucket":"1K - 10K"
   },
   {
     "Class":"Itemtype",
-    "Name":"http:\/\/schema.org\/PathologyTest",
+    "Name":"https://schema.org/PathologyTest",
     "Domain Bucket":"< 1K"
   },
   {
     "Class":"Itemtype",
-    "Name":"http:\/\/schema.org\/Patient",
+    "Name":"https://schema.org/Patient",
     "Domain Bucket":"1K - 10K"
   },
   {
     "Class":"Itemtype",
-    "Name":"http:\/\/schema.org\/PawnShop",
+    "Name":"https://schema.org/PawnShop",
     "Domain Bucket":"< 1K"
   },
   {
     "Class":"Itemtype",
-    "Name":"http:\/\/schema.org\/PayAction",
+    "Name":"https://schema.org/PayAction",
     "Domain Bucket":"< 1K"
   },
   {
     "Class":"Itemtype",
-    "Name":"http:\/\/schema.org\/PaymentCard",
+    "Name":"https://schema.org/PaymentCard",
     "Domain Bucket":"< 1K"
   },
   {
     "Class":"Itemtype",
-    "Name":"http:\/\/schema.org\/PaymentChargeSpecification",
+    "Name":"https://schema.org/PaymentChargeSpecification",
     "Domain Bucket":"< 1K"
   },
   {
     "Class":"Itemtype",
-    "Name":"http:\/\/schema.org\/PaymentMethod",
+    "Name":"https://schema.org/PaymentMethod",
     "Domain Bucket":"10K - 100K"
   },
   {
     "Class":"Itemtype",
-    "Name":"http:\/\/schema.org\/PaymentMethodType",
+    "Name":"https://schema.org/PaymentMethodType",
     "Domain Bucket":"< 1K"
   },
   {
     "Class":"Itemtype",
-    "Name":"http:\/\/schema.org\/PaymentService",
+    "Name":"https://schema.org/PaymentService",
     "Domain Bucket":"1K - 10K"
   },
   {
     "Class":"Itemtype",
-    "Name":"http:\/\/schema.org\/PaymentStatusType",
+    "Name":"https://schema.org/PaymentStatusType",
     "Domain Bucket":"< 1K"
   },
   {
     "Class":"Itemtype",
-    "Name":"http:\/\/schema.org\/Pediatric",
+    "Name":"https://schema.org/Pediatric",
     "Domain Bucket":"< 1K"
   },
   {
     "Class":"Itemtype",
-    "Name":"http:\/\/schema.org\/PeopleAudience",
+    "Name":"https://schema.org/PeopleAudience",
     "Domain Bucket":"10K - 100K"
   },
   {
     "Class":"Itemtype",
-    "Name":"http:\/\/schema.org\/PerformAction",
+    "Name":"https://schema.org/PerformAction",
     "Domain Bucket":"< 1K"
   },
   {
     "Class":"Itemtype",
-    "Name":"http:\/\/schema.org\/PerformanceRole",
+    "Name":"https://schema.org/PerformanceRole",
     "Domain Bucket":"< 1K"
   },
   {
     "Class":"Itemtype",
-    "Name":"http:\/\/schema.org\/PerformingArtsEvent",
+    "Name":"https://schema.org/PerformingArtsEvent",
     "Domain Bucket":"< 1K"
   },
   {
     "Class":"Itemtype",
-    "Name":"http:\/\/schema.org\/PerformingArtsTheater",
+    "Name":"https://schema.org/PerformingArtsTheater",
     "Domain Bucket":"1K - 10K"
   },
   {
     "Class":"Itemtype",
-    "Name":"http:\/\/schema.org\/PerformingGroup",
+    "Name":"https://schema.org/PerformingGroup",
     "Domain Bucket":"10K - 100K"
   },
   {
     "Class":"Itemtype",
-    "Name":"http:\/\/schema.org\/Periodical",
+    "Name":"https://schema.org/Periodical",
     "Domain Bucket":"1K - 10K"
   },
   {
     "Class":"Itemtype",
-    "Name":"http:\/\/schema.org\/Permit",
+    "Name":"https://schema.org/Permit",
     "Domain Bucket":"10K - 100K"
   },
   {
     "Class":"Itemtype",
-    "Name":"http:\/\/schema.org\/Person",
+    "Name":"https://schema.org/Person",
     "Domain Bucket":"10M+"
   },
   {
     "Class":"Itemtype",
-    "Name":"http:\/\/schema.org\/PetStore",
+    "Name":"https://schema.org/PetStore",
     "Domain Bucket":"1K - 10K"
   },
   {
     "Class":"Itemtype",
-    "Name":"http:\/\/schema.org\/Pharmacy",
+    "Name":"https://schema.org/Pharmacy",
     "Domain Bucket":"10K - 100K"
   },
   {
     "Class":"Itemtype",
-    "Name":"http:\/\/schema.org\/Photograph",
+    "Name":"https://schema.org/Photograph",
     "Domain Bucket":"10K - 100K"
   },
   {
     "Class":"Itemtype",
-    "Name":"http:\/\/schema.org\/PhotographAction",
+    "Name":"https://schema.org/PhotographAction",
     "Domain Bucket":"< 1K"
   },
   {
     "Class":"Itemtype",
-    "Name":"http:\/\/schema.org\/PhysicalActivity",
+    "Name":"https://schema.org/PhysicalActivity",
     "Domain Bucket":"< 1K"
   },
   {
     "Class":"Itemtype",
-    "Name":"http:\/\/schema.org\/PhysicalActivityCategory",
+    "Name":"https://schema.org/PhysicalActivityCategory",
     "Domain Bucket":"1K - 10K"
   },
   {
     "Class":"Itemtype",
-    "Name":"http:\/\/schema.org\/PhysicalExam",
+    "Name":"https://schema.org/PhysicalExam",
     "Domain Bucket":"< 1K"
   },
   {
     "Class":"Itemtype",
-    "Name":"http:\/\/schema.org\/PhysicalTherapy",
+    "Name":"https://schema.org/PhysicalTherapy",
     "Domain Bucket":"< 1K"
   },
   {
     "Class":"Itemtype",
-    "Name":"http:\/\/schema.org\/Physician",
+    "Name":"https://schema.org/Physician",
     "Domain Bucket":"10K - 100K"
   },
   {
     "Class":"Itemtype",
-    "Name":"http:\/\/schema.org\/PhysiciansOffice",
+    "Name":"https://schema.org/PhysiciansOffice",
     "Domain Bucket":"< 1K"
   },
   {
     "Class":"Itemtype",
-    "Name":"http:\/\/schema.org\/Physiotherapy",
+    "Name":"https://schema.org/Physiotherapy",
     "Domain Bucket":"1K - 10K"
   },
   {
     "Class":"Itemtype",
-    "Name":"http:\/\/schema.org\/Place",
+    "Name":"https://schema.org/Place",
     "Domain Bucket":"1M - 10M"
   },
   {
     "Class":"Itemtype",
-    "Name":"http:\/\/schema.org\/PlaceOfWorship",
+    "Name":"https://schema.org/PlaceOfWorship",
     "Domain Bucket":"1K - 10K"
   },
   {
     "Class":"Itemtype",
-    "Name":"http:\/\/schema.org\/PlanAction",
+    "Name":"https://schema.org/PlanAction",
     "Domain Bucket":"< 1K"
   },
   {
     "Class":"Itemtype",
-    "Name":"http:\/\/schema.org\/PlasticSurgery",
+    "Name":"https://schema.org/PlasticSurgery",
     "Domain Bucket":"< 1K"
   },
   {
     "Class":"Itemtype",
-    "Name":"http:\/\/schema.org\/Play",
+    "Name":"https://schema.org/Play",
     "Domain Bucket":"< 1K"
   },
   {
     "Class":"Itemtype",
-    "Name":"http:\/\/schema.org\/PlayAction",
+    "Name":"https://schema.org/PlayAction",
     "Domain Bucket":"10K - 100K"
   },
   {
     "Class":"Itemtype",
-    "Name":"http:\/\/schema.org\/PlayGameAction",
+    "Name":"https://schema.org/PlayGameAction",
     "Domain Bucket":"< 1K"
   },
   {
     "Class":"Itemtype",
-    "Name":"http:\/\/schema.org\/Playground",
+    "Name":"https://schema.org/Playground",
     "Domain Bucket":"< 1K"
   },
   {
     "Class":"Itemtype",
-    "Name":"http:\/\/schema.org\/Plumber",
+    "Name":"https://schema.org/Plumber",
     "Domain Bucket":"10K - 100K"
   },
   {
     "Class":"Itemtype",
-    "Name":"http:\/\/schema.org\/PodcastEpisode",
+    "Name":"https://schema.org/PodcastEpisode",
     "Domain Bucket":"10K - 100K"
   },
   {
     "Class":"Itemtype",
-    "Name":"http:\/\/schema.org\/PodcastSeason",
+    "Name":"https://schema.org/PodcastSeason",
     "Domain Bucket":"< 1K"
   },
   {
     "Class":"Itemtype",
-    "Name":"http:\/\/schema.org\/PodcastSeries",
+    "Name":"https://schema.org/PodcastSeries",
     "Domain Bucket":"10K - 100K"
   },
   {
     "Class":"Itemtype",
-    "Name":"http:\/\/schema.org\/Podiatric",
+    "Name":"https://schema.org/Podiatric",
     "Domain Bucket":"< 1K"
   },
   {
     "Class":"Itemtype",
-    "Name":"http:\/\/schema.org\/PoliceStation",
+    "Name":"https://schema.org/PoliceStation",
     "Domain Bucket":"< 1K"
   },
   {
     "Class":"Itemtype",
-    "Name":"http:\/\/schema.org\/PoliticalParty",
+    "Name":"https://schema.org/PoliticalParty",
     "Domain Bucket":"< 1K"
   },
   {
     "Class":"Itemtype",
-    "Name":"http:\/\/schema.org\/Pond",
+    "Name":"https://schema.org/Pond",
     "Domain Bucket":"< 1K"
   },
   {
     "Class":"Itemtype",
-    "Name":"http:\/\/schema.org\/PostOffice",
+    "Name":"https://schema.org/PostOffice",
     "Domain Bucket":"< 1K"
   },
   {
     "Class":"Itemtype",
-    "Name":"http:\/\/schema.org\/PostalAddress",
+    "Name":"https://schema.org/PostalAddress",
     "Domain Bucket":"10M+"
   },
   {
     "Class":"Itemtype",
-    "Name":"http:\/\/schema.org\/PostalCodeRangeSpecification",
+    "Name":"https://schema.org/PostalCodeRangeSpecification",
     "Domain Bucket":"1K - 10K"
   },
   {
     "Class":"Itemtype",
-    "Name":"http:\/\/schema.org\/Poster",
+    "Name":"https://schema.org/Poster",
     "Domain Bucket":"< 1K"
   },
   {
     "Class":"Itemtype",
-    "Name":"http:\/\/schema.org\/PreOrderAction",
+    "Name":"https://schema.org/PreOrderAction",
     "Domain Bucket":"< 1K"
   },
   {
     "Class":"Itemtype",
-    "Name":"http:\/\/schema.org\/PrependAction",
+    "Name":"https://schema.org/PrependAction",
     "Domain Bucket":"< 1K"
   },
   {
     "Class":"Itemtype",
-    "Name":"http:\/\/schema.org\/Preschool",
+    "Name":"https://schema.org/Preschool",
     "Domain Bucket":"1K - 10K"
   },
   {
     "Class":"Itemtype",
-    "Name":"http:\/\/schema.org\/PresentationDigitalDocument",
+    "Name":"https://schema.org/PresentationDigitalDocument",
     "Domain Bucket":"< 1K"
   },
   {
     "Class":"Itemtype",
-    "Name":"http:\/\/schema.org\/PreventionIndication",
+    "Name":"https://schema.org/PreventionIndication",
     "Domain Bucket":"< 1K"
   },
   {
     "Class":"Itemtype",
-    "Name":"http:\/\/schema.org\/PriceComponentTypeEnumeration",
+    "Name":"https://schema.org/PriceComponentTypeEnumeration",
     "Domain Bucket":"< 1K"
   },
   {
     "Class":"Itemtype",
-    "Name":"http:\/\/schema.org\/PriceSpecification",
+    "Name":"https://schema.org/PriceSpecification",
     "Domain Bucket":"100K - 1M"
   },
   {
     "Class":"Itemtype",
-    "Name":"http:\/\/schema.org\/PriceTypeEnumeration",
+    "Name":"https://schema.org/PriceTypeEnumeration",
     "Domain Bucket":"< 1K"
   },
   {
     "Class":"Itemtype",
-    "Name":"http:\/\/schema.org\/PrimaryCare",
+    "Name":"https://schema.org/PrimaryCare",
     "Domain Bucket":"< 1K"
   },
   {
     "Class":"Itemtype",
-    "Name":"http:\/\/schema.org\/Product",
+    "Name":"https://schema.org/Product",
     "Domain Bucket":"10M+"
   },
   {
     "Class":"Itemtype",
-    "Name":"http:\/\/schema.org\/ProductCollection",
+    "Name":"https://schema.org/ProductCollection",
     "Domain Bucket":"1K - 10K"
   },
   {
     "Class":"Itemtype",
-    "Name":"http:\/\/schema.org\/ProductGroup",
+    "Name":"https://schema.org/ProductGroup",
     "Domain Bucket":"100K - 1M"
   },
   {
     "Class":"Itemtype",
-    "Name":"http:\/\/schema.org\/ProductModel",
+    "Name":"https://schema.org/ProductModel",
     "Domain Bucket":"1K - 10K"
   },
   {
     "Class":"Itemtype",
-    "Name":"http:\/\/schema.org\/ProductReturnEnumeration",
+    "Name":"https://schema.org/ProductReturnEnumeration",
     "Domain Bucket":"< 1K"
   },
   {
     "Class":"Itemtype",
-    "Name":"http:\/\/schema.org\/ProductReturnPolicy",
+    "Name":"https://schema.org/ProductReturnPolicy",
     "Domain Bucket":"< 1K"
   },
   {
     "Class":"Itemtype",
-    "Name":"http:\/\/schema.org\/ProfessionalService",
+    "Name":"https://schema.org/ProfessionalService",
     "Domain Bucket":"100K - 1M"
   },
   {
     "Class":"Itemtype",
-    "Name":"http:\/\/schema.org\/ProfilePage",
+    "Name":"https://schema.org/ProfilePage",
     "Domain Bucket":"1M - 10M"
   },
   {
     "Class":"Itemtype",
-    "Name":"http:\/\/schema.org\/ProgramMembership",
+    "Name":"https://schema.org/ProgramMembership",
     "Domain Bucket":"1K - 10K"
   },
   {
     "Class":"Itemtype",
-    "Name":"http:\/\/schema.org\/Project",
+    "Name":"https://schema.org/Project",
     "Domain Bucket":"1K - 10K"
   },
   {
     "Class":"Itemtype",
-    "Name":"http:\/\/schema.org\/PronounceableText",
+    "Name":"https://schema.org/PronounceableText",
     "Domain Bucket":"< 1K"
   },
   {
     "Class":"Itemtype",
-    "Name":"http:\/\/schema.org\/Property",
+    "Name":"https://schema.org/Property",
     "Domain Bucket":"< 1K"
   },
   {
     "Class":"Itemtype",
-    "Name":"http:\/\/schema.org\/PropertyValue",
+    "Name":"https://schema.org/PropertyValue",
     "Domain Bucket":"100K - 1M"
   },
   {
     "Class":"Itemtype",
-    "Name":"http:\/\/schema.org\/PropertyValueSpecification",
+    "Name":"https://schema.org/PropertyValueSpecification",
     "Domain Bucket":"10M+"
   },
   {
     "Class":"Itemtype",
-    "Name":"http:\/\/schema.org\/Protein",
+    "Name":"https://schema.org/Protein",
     "Domain Bucket":"< 1K"
   },
   {
     "Class":"Itemtype",
-    "Name":"http:\/\/schema.org\/Psychiatric",
+    "Name":"https://schema.org/Psychiatric",
     "Domain Bucket":"1K - 10K"
   },
   {
     "Class":"Itemtype",
-    "Name":"http:\/\/schema.org\/PsychologicalTreatment",
+    "Name":"https://schema.org/PsychologicalTreatment",
     "Domain Bucket":"< 1K"
   },
   {
     "Class":"Itemtype",
-    "Name":"http:\/\/schema.org\/PublicHealth",
+    "Name":"https://schema.org/PublicHealth",
     "Domain Bucket":"< 1K"
   },
   {
     "Class":"Itemtype",
-    "Name":"http:\/\/schema.org\/PublicSwimmingPool",
+    "Name":"https://schema.org/PublicSwimmingPool",
     "Domain Bucket":"< 1K"
   },
   {
     "Class":"Itemtype",
-    "Name":"http:\/\/schema.org\/PublicToilet",
+    "Name":"https://schema.org/PublicToilet",
     "Domain Bucket":"< 1K"
   },
   {
     "Class":"Itemtype",
-    "Name":"http:\/\/schema.org\/PublicationEvent",
+    "Name":"https://schema.org/PublicationEvent",
     "Domain Bucket":"1K - 10K"
   },
   {
     "Class":"Itemtype",
-    "Name":"http:\/\/schema.org\/PublicationIssue",
+    "Name":"https://schema.org/PublicationIssue",
     "Domain Bucket":"1K - 10K"
   },
   {
     "Class":"Itemtype",
-    "Name":"http:\/\/schema.org\/PublicationVolume",
+    "Name":"https://schema.org/PublicationVolume",
     "Domain Bucket":"1K - 10K"
   },
   {
     "Class":"Itemtype",
-    "Name":"http:\/\/schema.org\/PurchaseType",
+    "Name":"https://schema.org/PurchaseType",
     "Domain Bucket":"< 1K"
   },
   {
     "Class":"Itemtype",
-    "Name":"http:\/\/schema.org\/QAPage",
+    "Name":"https://schema.org/QAPage",
     "Domain Bucket":"10K - 100K"
   },
   {
     "Class":"Itemtype",
-    "Name":"http:\/\/schema.org\/QualitativeValue",
+    "Name":"https://schema.org/QualitativeValue",
     "Domain Bucket":"1K - 10K"
   },
   {
     "Class":"Itemtype",
-    "Name":"http:\/\/schema.org\/QuantitativeValue",
+    "Name":"https://schema.org/QuantitativeValue",
     "Domain Bucket":"1M - 10M"
   },
   {
     "Class":"Itemtype",
-    "Name":"http:\/\/schema.org\/QuantitativeValueDistribution",
+    "Name":"https://schema.org/QuantitativeValueDistribution",
     "Domain Bucket":"< 1K"
   },
   {
     "Class":"Itemtype",
-    "Name":"http:\/\/schema.org\/Quantity",
+    "Name":"https://schema.org/Quantity",
     "Domain Bucket":"< 1K"
   },
   {
     "Class":"Itemtype",
-    "Name":"http:\/\/schema.org\/Question",
+    "Name":"https://schema.org/Question",
     "Domain Bucket":"1M - 10M"
   },
   {
     "Class":"Itemtype",
-    "Name":"http:\/\/schema.org\/Quiz",
+    "Name":"https://schema.org/Quiz",
     "Domain Bucket":"1K - 10K"
   },
   {
     "Class":"Itemtype",
-    "Name":"http:\/\/schema.org\/Quotation",
+    "Name":"https://schema.org/Quotation",
     "Domain Bucket":"1K - 10K"
   },
   {
     "Class":"Itemtype",
-    "Name":"http:\/\/schema.org\/QuoteAction",
+    "Name":"https://schema.org/QuoteAction",
     "Domain Bucket":"1K - 10K"
   },
   {
     "Class":"Itemtype",
-    "Name":"http:\/\/schema.org\/RVPark",
+    "Name":"https://schema.org/RVPark",
     "Domain Bucket":"< 1K"
   },
   {
     "Class":"Itemtype",
-    "Name":"http:\/\/schema.org\/RadiationTherapy",
+    "Name":"https://schema.org/RadiationTherapy",
     "Domain Bucket":"< 1K"
   },
   {
     "Class":"Itemtype",
-    "Name":"http:\/\/schema.org\/RadioBroadcastService",
+    "Name":"https://schema.org/RadioBroadcastService",
     "Domain Bucket":"< 1K"
   },
   {
     "Class":"Itemtype",
-    "Name":"http:\/\/schema.org\/RadioChannel",
+    "Name":"https://schema.org/RadioChannel",
     "Domain Bucket":"< 1K"
   },
   {
     "Class":"Itemtype",
-    "Name":"http:\/\/schema.org\/RadioClip",
+    "Name":"https://schema.org/RadioClip",
     "Domain Bucket":"< 1K"
   },
   {
     "Class":"Itemtype",
-    "Name":"http:\/\/schema.org\/RadioEpisode",
+    "Name":"https://schema.org/RadioEpisode",
     "Domain Bucket":"1K - 10K"
   },
   {
     "Class":"Itemtype",
-    "Name":"http:\/\/schema.org\/RadioSeason",
+    "Name":"https://schema.org/RadioSeason",
     "Domain Bucket":"< 1K"
   },
   {
     "Class":"Itemtype",
-    "Name":"http:\/\/schema.org\/RadioSeries",
+    "Name":"https://schema.org/RadioSeries",
     "Domain Bucket":"1K - 10K"
   },
   {
     "Class":"Itemtype",
-    "Name":"http:\/\/schema.org\/RadioStation",
+    "Name":"https://schema.org/RadioStation",
     "Domain Bucket":"1K - 10K"
   },
   {
     "Class":"Itemtype",
-    "Name":"http:\/\/schema.org\/Rating",
+    "Name":"https://schema.org/Rating",
     "Domain Bucket":"1M - 10M"
   },
   {
     "Class":"Itemtype",
-    "Name":"http:\/\/schema.org\/ReactAction",
+    "Name":"https://schema.org/ReactAction",
     "Domain Bucket":"< 1K"
   },
   {
     "Class":"Itemtype",
-    "Name":"http:\/\/schema.org\/ReadAction",
+    "Name":"https://schema.org/ReadAction",
     "Domain Bucket":"10M+"
   },
   {
     "Class":"Itemtype",
-    "Name":"http:\/\/schema.org\/RealEstateAgent",
+    "Name":"https://schema.org/RealEstateAgent",
     "Domain Bucket":"100K - 1M"
   },
   {
     "Class":"Itemtype",
-    "Name":"http:\/\/schema.org\/RealEstateListing",
+    "Name":"https://schema.org/RealEstateListing",
     "Domain Bucket":"10K - 100K"
   },
   {
     "Class":"Itemtype",
-    "Name":"http:\/\/schema.org\/ReceiveAction",
+    "Name":"https://schema.org/ReceiveAction",
     "Domain Bucket":"< 1K"
   },
   {
     "Class":"Itemtype",
-    "Name":"http:\/\/schema.org\/Recipe",
+    "Name":"https://schema.org/Recipe",
     "Domain Bucket":"10K - 100K"
   },
   {
     "Class":"Itemtype",
-    "Name":"http:\/\/schema.org\/Recommendation",
+    "Name":"https://schema.org/Recommendation",
     "Domain Bucket":"< 1K"
   },
   {
     "Class":"Itemtype",
-    "Name":"http:\/\/schema.org\/RecommendedDoseSchedule",
+    "Name":"https://schema.org/RecommendedDoseSchedule",
     "Domain Bucket":"< 1K"
   },
   {
     "Class":"Itemtype",
-    "Name":"http:\/\/schema.org\/RecyclingCenter",
+    "Name":"https://schema.org/RecyclingCenter",
     "Domain Bucket":"1K - 10K"
   },
   {
     "Class":"Itemtype",
-    "Name":"http:\/\/schema.org\/RefundTypeEnumeration",
+    "Name":"https://schema.org/RefundTypeEnumeration",
     "Domain Bucket":"< 1K"
   },
   {
     "Class":"Itemtype",
-    "Name":"http:\/\/schema.org\/RegisterAction",
+    "Name":"https://schema.org/RegisterAction",
     "Domain Bucket":"1K - 10K"
   },
   {
     "Class":"Itemtype",
-    "Name":"http:\/\/schema.org\/RejectAction",
+    "Name":"https://schema.org/RejectAction",
     "Domain Bucket":"< 1K"
   },
   {
     "Class":"Itemtype",
-    "Name":"http:\/\/schema.org\/RentAction",
+    "Name":"https://schema.org/RentAction",
     "Domain Bucket":"1K - 10K"
   },
   {
     "Class":"Itemtype",
-    "Name":"http:\/\/schema.org\/RentalCarReservation",
+    "Name":"https://schema.org/RentalCarReservation",
     "Domain Bucket":"< 1K"
   },
   {
     "Class":"Itemtype",
-    "Name":"http:\/\/schema.org\/RepaymentSpecification",
+    "Name":"https://schema.org/RepaymentSpecification",
     "Domain Bucket":"< 1K"
   },
   {
     "Class":"Itemtype",
-    "Name":"http:\/\/schema.org\/ReplaceAction",
+    "Name":"https://schema.org/ReplaceAction",
     "Domain Bucket":"< 1K"
   },
   {
     "Class":"Itemtype",
-    "Name":"http:\/\/schema.org\/ReplyAction",
+    "Name":"https://schema.org/ReplyAction",
     "Domain Bucket":"1K - 10K"
   },
   {
     "Class":"Itemtype",
-    "Name":"http:\/\/schema.org\/Report",
+    "Name":"https://schema.org/Report",
     "Domain Bucket":"1K - 10K"
   },
   {
     "Class":"Itemtype",
-    "Name":"http:\/\/schema.org\/ReportageNewsArticle",
+    "Name":"https://schema.org/ReportageNewsArticle",
     "Domain Bucket":"1K - 10K"
   },
   {
     "Class":"Itemtype",
-    "Name":"http:\/\/schema.org\/ReportedDoseSchedule",
+    "Name":"https://schema.org/ReportedDoseSchedule",
     "Domain Bucket":"< 1K"
   },
   {
     "Class":"Itemtype",
-    "Name":"http:\/\/schema.org\/ResearchOrganization",
+    "Name":"https://schema.org/ResearchOrganization",
     "Domain Bucket":"1K - 10K"
   },
   {
     "Class":"Itemtype",
-    "Name":"http:\/\/schema.org\/ResearchProject",
+    "Name":"https://schema.org/ResearchProject",
     "Domain Bucket":"1K - 10K"
   },
   {
     "Class":"Itemtype",
-    "Name":"http:\/\/schema.org\/Researcher",
+    "Name":"https://schema.org/Researcher",
     "Domain Bucket":"< 1K"
   },
   {
     "Class":"Itemtype",
-    "Name":"http:\/\/schema.org\/Reservation",
+    "Name":"https://schema.org/Reservation",
     "Domain Bucket":"10K - 100K"
   },
   {
     "Class":"Itemtype",
-    "Name":"http:\/\/schema.org\/ReservationPackage",
+    "Name":"https://schema.org/ReservationPackage",
     "Domain Bucket":"< 1K"
   },
   {
     "Class":"Itemtype",
-    "Name":"http:\/\/schema.org\/ReservationStatusType",
+    "Name":"https://schema.org/ReservationStatusType",
     "Domain Bucket":"< 1K"
   },
   {
     "Class":"Itemtype",
-    "Name":"http:\/\/schema.org\/ReserveAction",
+    "Name":"https://schema.org/ReserveAction",
     "Domain Bucket":"10K - 100K"
   },
   {
     "Class":"Itemtype",
-    "Name":"http:\/\/schema.org\/Reservoir",
+    "Name":"https://schema.org/Reservoir",
     "Domain Bucket":"< 1K"
   },
   {
     "Class":"Itemtype",
-    "Name":"http:\/\/schema.org\/ResetPasswordAction",
+    "Name":"https://schema.org/ResetPasswordAction",
     "Domain Bucket":"< 1K"
   },
   {
     "Class":"Itemtype",
-    "Name":"http:\/\/schema.org\/Residence",
+    "Name":"https://schema.org/Residence",
     "Domain Bucket":"10K - 100K"
   },
   {
     "Class":"Itemtype",
-    "Name":"http:\/\/schema.org\/Resort",
+    "Name":"https://schema.org/Resort",
     "Domain Bucket":"1K - 10K"
   },
   {
     "Class":"Itemtype",
-    "Name":"http:\/\/schema.org\/RespiratoryTherapy",
+    "Name":"https://schema.org/RespiratoryTherapy",
     "Domain Bucket":"< 1K"
   },
   {
     "Class":"Itemtype",
-    "Name":"http:\/\/schema.org\/Restaurant",
+    "Name":"https://schema.org/Restaurant",
     "Domain Bucket":"100K - 1M"
   },
   {
     "Class":"Itemtype",
-    "Name":"http:\/\/schema.org\/RestrictedDiet",
+    "Name":"https://schema.org/RestrictedDiet",
     "Domain Bucket":"1K - 10K"
   },
   {
     "Class":"Itemtype",
-    "Name":"http:\/\/schema.org\/ResumeAction",
+    "Name":"https://schema.org/ResumeAction",
     "Domain Bucket":"< 1K"
   },
   {
     "Class":"Itemtype",
-    "Name":"http:\/\/schema.org\/ReturnAction",
+    "Name":"https://schema.org/ReturnAction",
     "Domain Bucket":"< 1K"
   },
   {
     "Class":"Itemtype",
-    "Name":"http:\/\/schema.org\/ReturnFeesEnumeration",
+    "Name":"https://schema.org/ReturnFeesEnumeration",
     "Domain Bucket":"< 1K"
   },
   {
     "Class":"Itemtype",
-    "Name":"http:\/\/schema.org\/ReturnLabelSourceEnumeration",
+    "Name":"https://schema.org/ReturnLabelSourceEnumeration",
     "Domain Bucket":"< 1K"
   },
   {
     "Class":"Itemtype",
-    "Name":"http:\/\/schema.org\/ReturnMethodEnumeration",
+    "Name":"https://schema.org/ReturnMethodEnumeration",
     "Domain Bucket":"< 1K"
   },
   {
     "Class":"Itemtype",
-    "Name":"http:\/\/schema.org\/Review",
+    "Name":"https://schema.org/Review",
     "Domain Bucket":"1M - 10M"
   },
   {
     "Class":"Itemtype",
-    "Name":"http:\/\/schema.org\/ReviewAction",
+    "Name":"https://schema.org/ReviewAction",
     "Domain Bucket":"1K - 10K"
   },
   {
     "Class":"Itemtype",
-    "Name":"http:\/\/schema.org\/ReviewNewsArticle",
+    "Name":"https://schema.org/ReviewNewsArticle",
     "Domain Bucket":"< 1K"
   },
   {
     "Class":"Itemtype",
-    "Name":"http:\/\/schema.org\/RiverBodyOfWater",
+    "Name":"https://schema.org/RiverBodyOfWater",
     "Domain Bucket":"< 1K"
   },
   {
     "Class":"Itemtype",
-    "Name":"http:\/\/schema.org\/Role",
+    "Name":"https://schema.org/Role",
     "Domain Bucket":"1K - 10K"
   },
   {
     "Class":"Itemtype",
-    "Name":"http:\/\/schema.org\/RoofingContractor",
+    "Name":"https://schema.org/RoofingContractor",
     "Domain Bucket":"10K - 100K"
   },
   {
     "Class":"Itemtype",
-    "Name":"http:\/\/schema.org\/Room",
+    "Name":"https://schema.org/Room",
     "Domain Bucket":"1K - 10K"
   },
   {
     "Class":"Itemtype",
-    "Name":"http:\/\/schema.org\/RsvpAction",
+    "Name":"https://schema.org/RsvpAction",
     "Domain Bucket":"< 1K"
   },
   {
     "Class":"Itemtype",
-    "Name":"http:\/\/schema.org\/RsvpResponseType",
+    "Name":"https://schema.org/RsvpResponseType",
     "Domain Bucket":"< 1K"
   },
   {
     "Class":"Itemtype",
-    "Name":"http:\/\/schema.org\/RuntimePlatform",
+    "Name":"https://schema.org/RuntimePlatform",
     "Domain Bucket":"< 1K"
   },
   {
     "Class":"Itemtype",
-    "Name":"http:\/\/schema.org\/SaleEvent",
+    "Name":"https://schema.org/SaleEvent",
     "Domain Bucket":"1K - 10K"
   },
   {
     "Class":"Itemtype",
-    "Name":"http:\/\/schema.org\/SatiricalArticle",
+    "Name":"https://schema.org/SatiricalArticle",
     "Domain Bucket":"< 1K"
   },
   {
     "Class":"Itemtype",
-    "Name":"http:\/\/schema.org\/Schedule",
+    "Name":"https://schema.org/Schedule",
     "Domain Bucket":"10K - 100K"
   },
   {
     "Class":"Itemtype",
-    "Name":"http:\/\/schema.org\/ScheduleAction",
+    "Name":"https://schema.org/ScheduleAction",
     "Domain Bucket":"1K - 10K"
   },
   {
     "Class":"Itemtype",
-    "Name":"http:\/\/schema.org\/ScholarlyArticle",
+    "Name":"https://schema.org/ScholarlyArticle",
     "Domain Bucket":"10K - 100K"
   },
   {
     "Class":"Itemtype",
-    "Name":"http:\/\/schema.org\/School",
+    "Name":"https://schema.org/School",
     "Domain Bucket":"1K - 10K"
   },
   {
     "Class":"Itemtype",
-    "Name":"http:\/\/schema.org\/SchoolDistrict",
+    "Name":"https://schema.org/SchoolDistrict",
     "Domain Bucket":"< 1K"
   },
   {
     "Class":"Itemtype",
-    "Name":"http:\/\/schema.org\/ScreeningEvent",
+    "Name":"https://schema.org/ScreeningEvent",
     "Domain Bucket":"1K - 10K"
   },
   {
     "Class":"Itemtype",
-    "Name":"http:\/\/schema.org\/Sculpture",
+    "Name":"https://schema.org/Sculpture",
     "Domain Bucket":"< 1K"
   },
   {
     "Class":"Itemtype",
-    "Name":"http:\/\/schema.org\/SeaBodyOfWater",
+    "Name":"https://schema.org/SeaBodyOfWater",
     "Domain Bucket":"< 1K"
   },
   {
     "Class":"Itemtype",
-    "Name":"http:\/\/schema.org\/SearchAction",
+    "Name":"https://schema.org/SearchAction",
     "Domain Bucket":"10M+"
   },
   {
     "Class":"Itemtype",
-    "Name":"http:\/\/schema.org\/SearchRescueOrganization",
+    "Name":"https://schema.org/SearchRescueOrganization",
     "Domain Bucket":"< 1K"
   },
   {
     "Class":"Itemtype",
-    "Name":"http:\/\/schema.org\/SearchResultsPage",
+    "Name":"https://schema.org/SearchResultsPage",
     "Domain Bucket":"10K - 100K"
   },
   {
     "Class":"Itemtype",
-    "Name":"http:\/\/schema.org\/Season",
+    "Name":"https://schema.org/Season",
     "Domain Bucket":"< 1K"
   },
   {
     "Class":"Itemtype",
-    "Name":"http:\/\/schema.org\/Seat",
+    "Name":"https://schema.org/Seat",
     "Domain Bucket":"< 1K"
   },
   {
     "Class":"Itemtype",
-    "Name":"http:\/\/schema.org\/SeekToAction",
+    "Name":"https://schema.org/SeekToAction",
     "Domain Bucket":"10K - 100K"
   },
   {
     "Class":"Itemtype",
-    "Name":"http:\/\/schema.org\/SelfStorage",
+    "Name":"https://schema.org/SelfStorage",
     "Domain Bucket":"10K - 100K"
   },
   {
     "Class":"Itemtype",
-    "Name":"http:\/\/schema.org\/SellAction",
+    "Name":"https://schema.org/SellAction",
     "Domain Bucket":"1K - 10K"
   },
   {
     "Class":"Itemtype",
-    "Name":"http:\/\/schema.org\/SendAction",
+    "Name":"https://schema.org/SendAction",
     "Domain Bucket":"< 1K"
   },
   {
     "Class":"Itemtype",
-    "Name":"http:\/\/schema.org\/SequentialArt",
+    "Name":"https://schema.org/SequentialArt",
     "Domain Bucket":"< 1K"
   },
   {
     "Class":"Itemtype",
-    "Name":"http:\/\/schema.org\/Series",
+    "Name":"https://schema.org/Series",
     "Domain Bucket":"10K - 100K"
   },
   {
     "Class":"Itemtype",
-    "Name":"http:\/\/schema.org\/Service",
+    "Name":"https://schema.org/Service",
     "Domain Bucket":"1M - 10M"
   },
   {
     "Class":"Itemtype",
-    "Name":"http:\/\/schema.org\/ServiceChannel",
+    "Name":"https://schema.org/ServiceChannel",
     "Domain Bucket":"100K - 1M"
   },
   {
     "Class":"Itemtype",
-    "Name":"http:\/\/schema.org\/ServicePeriod",
+    "Name":"https://schema.org/ServicePeriod",
     "Domain Bucket":"1K - 10K"
   },
   {
     "Class":"Itemtype",
-    "Name":"http:\/\/schema.org\/ShareAction",
+    "Name":"https://schema.org/ShareAction",
     "Domain Bucket":"10K - 100K"
   },
   {
     "Class":"Itemtype",
-    "Name":"http:\/\/schema.org\/SheetMusic",
+    "Name":"https://schema.org/SheetMusic",
     "Domain Bucket":"< 1K"
   },
   {
     "Class":"Itemtype",
-    "Name":"http:\/\/schema.org\/ShippingConditions",
+    "Name":"https://schema.org/ShippingConditions",
     "Domain Bucket":"10K - 100K"
   },
   {
     "Class":"Itemtype",
-    "Name":"http:\/\/schema.org\/ShippingDeliveryTime",
+    "Name":"https://schema.org/ShippingDeliveryTime",
     "Domain Bucket":"100K - 1M"
   },
   {
     "Class":"Itemtype",
-    "Name":"http:\/\/schema.org\/ShippingRateSettings",
+    "Name":"https://schema.org/ShippingRateSettings",
     "Domain Bucket":"< 1K"
   },
   {
     "Class":"Itemtype",
-    "Name":"http:\/\/schema.org\/ShippingService",
+    "Name":"https://schema.org/ShippingService",
     "Domain Bucket":"10K - 100K"
   },
   {
     "Class":"Itemtype",
-    "Name":"http:\/\/schema.org\/ShoeStore",
+    "Name":"https://schema.org/ShoeStore",
     "Domain Bucket":"1K - 10K"
   },
   {
     "Class":"Itemtype",
-    "Name":"http:\/\/schema.org\/ShoppingCenter",
+    "Name":"https://schema.org/ShoppingCenter",
     "Domain Bucket":"1K - 10K"
   },
   {
     "Class":"Itemtype",
-    "Name":"http:\/\/schema.org\/ShortStory",
+    "Name":"https://schema.org/ShortStory",
     "Domain Bucket":"< 1K"
   },
   {
     "Class":"Itemtype",
-    "Name":"http:\/\/schema.org\/SingleFamilyResidence",
+    "Name":"https://schema.org/SingleFamilyResidence",
     "Domain Bucket":"10K - 100K"
   },
   {
     "Class":"Itemtype",
-    "Name":"http:\/\/schema.org\/SiteNavigationElement",
+    "Name":"https://schema.org/SiteNavigationElement",
     "Domain Bucket":"1M - 10M"
   },
   {
     "Class":"Itemtype",
-    "Name":"http:\/\/schema.org\/SizeGroupEnumeration",
+    "Name":"https://schema.org/SizeGroupEnumeration",
     "Domain Bucket":"< 1K"
   },
   {
     "Class":"Itemtype",
-    "Name":"http:\/\/schema.org\/SizeSpecification",
+    "Name":"https://schema.org/SizeSpecification",
     "Domain Bucket":"1K - 10K"
   },
   {
     "Class":"Itemtype",
-    "Name":"http:\/\/schema.org\/SizeSystemEnumeration",
+    "Name":"https://schema.org/SizeSystemEnumeration",
     "Domain Bucket":"< 1K"
   },
   {
     "Class":"Itemtype",
-    "Name":"http:\/\/schema.org\/SkiResort",
+    "Name":"https://schema.org/SkiResort",
     "Domain Bucket":"< 1K"
   },
   {
     "Class":"Itemtype",
-    "Name":"http:\/\/schema.org\/SocialEvent",
+    "Name":"https://schema.org/SocialEvent",
     "Domain Bucket":"1K - 10K"
   },
   {
     "Class":"Itemtype",
-    "Name":"http:\/\/schema.org\/SocialMediaPosting",
+    "Name":"https://schema.org/SocialMediaPosting",
     "Domain Bucket":"10K - 100K"
   },
   {
     "Class":"Itemtype",
-    "Name":"http:\/\/schema.org\/SoftwareApplication",
+    "Name":"https://schema.org/SoftwareApplication",
     "Domain Bucket":"100K - 1M"
   },
   {
     "Class":"Itemtype",
-    "Name":"http:\/\/schema.org\/SoftwareSourceCode",
+    "Name":"https://schema.org/SoftwareSourceCode",
     "Domain Bucket":"1K - 10K"
   },
   {
     "Class":"Itemtype",
-    "Name":"http:\/\/schema.org\/SolveMathAction",
+    "Name":"https://schema.org/SolveMathAction",
     "Domain Bucket":"< 1K"
   },
   {
     "Class":"Itemtype",
-    "Name":"http:\/\/schema.org\/SomeProducts",
+    "Name":"https://schema.org/SomeProducts",
     "Domain Bucket":"10K - 100K"
   },
   {
     "Class":"Itemtype",
-    "Name":"http:\/\/schema.org\/SpeakableSpecification",
+    "Name":"https://schema.org/SpeakableSpecification",
     "Domain Bucket":"100K - 1M"
   },
   {
     "Class":"Itemtype",
-    "Name":"http:\/\/schema.org\/SpecialAnnouncement",
+    "Name":"https://schema.org/SpecialAnnouncement",
     "Domain Bucket":"1K - 10K"
   },
   {
     "Class":"Itemtype",
-    "Name":"http:\/\/schema.org\/Specialty",
+    "Name":"https://schema.org/Specialty",
     "Domain Bucket":"1K - 10K"
   },
   {
     "Class":"Itemtype",
-    "Name":"http:\/\/schema.org\/SportingGoodsStore",
+    "Name":"https://schema.org/SportingGoodsStore",
     "Domain Bucket":"1K - 10K"
   },
   {
     "Class":"Itemtype",
-    "Name":"http:\/\/schema.org\/SportsActivityLocation",
+    "Name":"https://schema.org/SportsActivityLocation",
     "Domain Bucket":"10K - 100K"
   },
   {
     "Class":"Itemtype",
-    "Name":"http:\/\/schema.org\/SportsClub",
+    "Name":"https://schema.org/SportsClub",
     "Domain Bucket":"1K - 10K"
   },
   {
     "Class":"Itemtype",
-    "Name":"http:\/\/schema.org\/SportsEvent",
+    "Name":"https://schema.org/SportsEvent",
     "Domain Bucket":"10K - 100K"
   },
   {
     "Class":"Itemtype",
-    "Name":"http:\/\/schema.org\/SportsOrganization",
+    "Name":"https://schema.org/SportsOrganization",
     "Domain Bucket":"10K - 100K"
   },
   {
     "Class":"Itemtype",
-    "Name":"http:\/\/schema.org\/SportsTeam",
+    "Name":"https://schema.org/SportsTeam",
     "Domain Bucket":"10K - 100K"
   },
   {
     "Class":"Itemtype",
-    "Name":"http:\/\/schema.org\/SpreadsheetDigitalDocument",
+    "Name":"https://schema.org/SpreadsheetDigitalDocument",
     "Domain Bucket":"< 1K"
   },
   {
     "Class":"Itemtype",
-    "Name":"http:\/\/schema.org\/StadiumOrArena",
+    "Name":"https://schema.org/StadiumOrArena",
     "Domain Bucket":"1K - 10K"
   },
   {
     "Class":"Itemtype",
-    "Name":"http:\/\/schema.org\/State",
+    "Name":"https://schema.org/State",
     "Domain Bucket":"100K - 1M"
   },
   {
     "Class":"Itemtype",
-    "Name":"http:\/\/schema.org\/Statement",
+    "Name":"https://schema.org/Statement",
     "Domain Bucket":"< 1K"
   },
   {
     "Class":"Itemtype",
-    "Name":"http:\/\/schema.org\/StatisticalPopulation",
+    "Name":"https://schema.org/StatisticalPopulation",
     "Domain Bucket":"< 1K"
   },
   {
     "Class":"Itemtype",
-    "Name":"http:\/\/schema.org\/StatisticalVariable",
+    "Name":"https://schema.org/StatisticalVariable",
     "Domain Bucket":"< 1K"
   },
   {
     "Class":"Itemtype",
-    "Name":"http:\/\/schema.org\/StatusEnumeration",
+    "Name":"https://schema.org/StatusEnumeration",
     "Domain Bucket":"< 1K"
   },
   {
     "Class":"Itemtype",
-    "Name":"http:\/\/schema.org\/SteeringPositionValue",
+    "Name":"https://schema.org/SteeringPositionValue",
     "Domain Bucket":"< 1K"
   },
   {
     "Class":"Itemtype",
-    "Name":"http:\/\/schema.org\/Store",
+    "Name":"https://schema.org/Store",
     "Domain Bucket":"100K - 1M"
   },
   {
     "Class":"Itemtype",
-    "Name":"http:\/\/schema.org\/StructuredValue",
+    "Name":"https://schema.org/StructuredValue",
     "Domain Bucket":"1K - 10K"
   },
   {
     "Class":"Itemtype",
-    "Name":"http:\/\/schema.org\/StupidType",
+    "Name":"https://schema.org/StupidType",
     "Domain Bucket":"< 1K"
   },
   {
     "Class":"Itemtype",
-    "Name":"http:\/\/schema.org\/SubscribeAction",
+    "Name":"https://schema.org/SubscribeAction",
     "Domain Bucket":"10K - 100K"
   },
   {
     "Class":"Itemtype",
-    "Name":"http:\/\/schema.org\/Substance",
+    "Name":"https://schema.org/Substance",
     "Domain Bucket":"< 1K"
   },
   {
     "Class":"Itemtype",
-    "Name":"http:\/\/schema.org\/SubwayStation",
+    "Name":"https://schema.org/SubwayStation",
     "Domain Bucket":"< 1K"
   },
   {
     "Class":"Itemtype",
-    "Name":"http:\/\/schema.org\/Suite",
+    "Name":"https://schema.org/Suite",
     "Domain Bucket":"< 1K"
   },
   {
     "Class":"Itemtype",
-    "Name":"http:\/\/schema.org\/SuperficialAnatomy",
+    "Name":"https://schema.org/SuperficialAnatomy",
     "Domain Bucket":"< 1K"
   },
   {
     "Class":"Itemtype",
-    "Name":"http:\/\/schema.org\/SurgicalProcedure",
+    "Name":"https://schema.org/SurgicalProcedure",
     "Domain Bucket":"1K - 10K"
   },
   {
     "Class":"Itemtype",
-    "Name":"http:\/\/schema.org\/SuspendAction",
+    "Name":"https://schema.org/SuspendAction",
     "Domain Bucket":"< 1K"
   },
   {
     "Class":"Itemtype",
-    "Name":"http:\/\/schema.org\/Syllabus",
+    "Name":"https://schema.org/Syllabus",
     "Domain Bucket":"1K - 10K"
   },
   {
     "Class":"Itemtype",
-    "Name":"http:\/\/schema.org\/Synagogue",
+    "Name":"https://schema.org/Synagogue",
     "Domain Bucket":"< 1K"
   },
   {
     "Class":"Itemtype",
-    "Name":"http:\/\/schema.org\/TVClip",
+    "Name":"https://schema.org/TVClip",
     "Domain Bucket":"< 1K"
   },
   {
     "Class":"Itemtype",
-    "Name":"http:\/\/schema.org\/TVEpisode",
+    "Name":"https://schema.org/TVEpisode",
     "Domain Bucket":"1K - 10K"
   },
   {
     "Class":"Itemtype",
-    "Name":"http:\/\/schema.org\/TVSeason",
+    "Name":"https://schema.org/TVSeason",
     "Domain Bucket":"1K - 10K"
   },
   {
     "Class":"Itemtype",
-    "Name":"http:\/\/schema.org\/TVSeries",
+    "Name":"https://schema.org/TVSeries",
     "Domain Bucket":"10K - 100K"
   },
   {
     "Class":"Itemtype",
-    "Name":"http:\/\/schema.org\/Table",
+    "Name":"https://schema.org/Table",
     "Domain Bucket":"10K - 100K"
   },
   {
     "Class":"Itemtype",
-    "Name":"http:\/\/schema.org\/TakeAction",
+    "Name":"https://schema.org/TakeAction",
     "Domain Bucket":"< 1K"
   },
   {
     "Class":"Itemtype",
-    "Name":"http:\/\/schema.org\/TattooParlor",
+    "Name":"https://schema.org/TattooParlor",
     "Domain Bucket":"1K - 10K"
   },
   {
     "Class":"Itemtype",
-    "Name":"http:\/\/schema.org\/Taxi",
+    "Name":"https://schema.org/Taxi",
     "Domain Bucket":"< 1K"
   },
   {
     "Class":"Itemtype",
-    "Name":"http:\/\/schema.org\/TaxiReservation",
+    "Name":"https://schema.org/TaxiReservation",
     "Domain Bucket":"< 1K"
   },
   {
     "Class":"Itemtype",
-    "Name":"http:\/\/schema.org\/TaxiService",
+    "Name":"https://schema.org/TaxiService",
     "Domain Bucket":"1K - 10K"
   },
   {
     "Class":"Itemtype",
-    "Name":"http:\/\/schema.org\/TaxiStand",
+    "Name":"https://schema.org/TaxiStand",
     "Domain Bucket":"< 1K"
   },
   {
     "Class":"Itemtype",
-    "Name":"http:\/\/schema.org\/Taxon",
+    "Name":"https://schema.org/Taxon",
     "Domain Bucket":"< 1K"
   },
   {
     "Class":"Itemtype",
-    "Name":"http:\/\/schema.org\/TechArticle",
+    "Name":"https://schema.org/TechArticle",
     "Domain Bucket":"10K - 100K"
   },
   {
     "Class":"Itemtype",
-    "Name":"http:\/\/schema.org\/TelevisionChannel",
+    "Name":"https://schema.org/TelevisionChannel",
     "Domain Bucket":"< 1K"
   },
   {
     "Class":"Itemtype",
-    "Name":"http:\/\/schema.org\/TelevisionStation",
+    "Name":"https://schema.org/TelevisionStation",
     "Domain Bucket":"< 1K"
   },
   {
     "Class":"Itemtype",
-    "Name":"http:\/\/schema.org\/TennisComplex",
+    "Name":"https://schema.org/TennisComplex",
     "Domain Bucket":"< 1K"
   },
   {
     "Class":"Itemtype",
-    "Name":"http:\/\/schema.org\/Text",
+    "Name":"https://schema.org/Text",
     "Domain Bucket":"10K - 100K"
   },
   {
     "Class":"Itemtype",
-    "Name":"http:\/\/schema.org\/TextDigitalDocument",
+    "Name":"https://schema.org/TextDigitalDocument",
     "Domain Bucket":"< 1K"
   },
   {
     "Class":"Itemtype",
-    "Name":"http:\/\/schema.org\/TextObject",
+    "Name":"https://schema.org/TextObject",
     "Domain Bucket":"1K - 10K"
   },
   {
     "Class":"Itemtype",
-    "Name":"http:\/\/schema.org\/TheaterEvent",
+    "Name":"https://schema.org/TheaterEvent",
     "Domain Bucket":"1K - 10K"
   },
   {
     "Class":"Itemtype",
-    "Name":"http:\/\/schema.org\/TheaterGroup",
+    "Name":"https://schema.org/TheaterGroup",
     "Domain Bucket":"1K - 10K"
   },
   {
     "Class":"Itemtype",
-    "Name":"http:\/\/schema.org\/TherapeuticProcedure",
+    "Name":"https://schema.org/TherapeuticProcedure",
     "Domain Bucket":"1K - 10K"
   },
   {
     "Class":"Itemtype",
-    "Name":"http:\/\/schema.org\/Thesis",
+    "Name":"https://schema.org/Thesis",
     "Domain Bucket":"< 1K"
   },
   {
     "Class":"Itemtype",
-    "Name":"http:\/\/schema.org\/Thing",
+    "Name":"https://schema.org/Thing",
     "Domain Bucket":"10M+"
   },
   {
     "Class":"Itemtype",
-    "Name":"http:\/\/schema.org\/Ticket",
+    "Name":"https://schema.org/Ticket",
     "Domain Bucket":"< 1K"
   },
   {
     "Class":"Itemtype",
-    "Name":"http:\/\/schema.org\/TieAction",
+    "Name":"https://schema.org/TieAction",
     "Domain Bucket":"< 1K"
   },
   {
     "Class":"Itemtype",
-    "Name":"http:\/\/schema.org\/TierBenefitEnumeration",
+    "Name":"https://schema.org/TierBenefitEnumeration",
     "Domain Bucket":"< 1K"
   },
   {
     "Class":"Itemtype",
-    "Name":"http:\/\/schema.org\/Time",
+    "Name":"https://schema.org/Time",
     "Domain Bucket":"< 1K"
   },
   {
     "Class":"Itemtype",
-    "Name":"http:\/\/schema.org\/TipAction",
+    "Name":"https://schema.org/TipAction",
     "Domain Bucket":"< 1K"
   },
   {
     "Class":"Itemtype",
-    "Name":"http:\/\/schema.org\/TireShop",
+    "Name":"https://schema.org/TireShop",
     "Domain Bucket":"1K - 10K"
   },
   {
     "Class":"Itemtype",
-    "Name":"http:\/\/schema.org\/TouristAttraction",
+    "Name":"https://schema.org/TouristAttraction",
     "Domain Bucket":"10K - 100K"
   },
   {
     "Class":"Itemtype",
-    "Name":"http:\/\/schema.org\/TouristDestination",
+    "Name":"https://schema.org/TouristDestination",
     "Domain Bucket":"10K - 100K"
   },
   {
     "Class":"Itemtype",
-    "Name":"http:\/\/schema.org\/TouristInformationCenter",
+    "Name":"https://schema.org/TouristInformationCenter",
     "Domain Bucket":"1K - 10K"
   },
   {
     "Class":"Itemtype",
-    "Name":"http:\/\/schema.org\/TouristTrip",
+    "Name":"https://schema.org/TouristTrip",
     "Domain Bucket":"10K - 100K"
   },
   {
     "Class":"Itemtype",
-    "Name":"http:\/\/schema.org\/ToyStore",
+    "Name":"https://schema.org/ToyStore",
     "Domain Bucket":"1K - 10K"
   },
   {
     "Class":"Itemtype",
-    "Name":"http:\/\/schema.org\/TrackAction",
+    "Name":"https://schema.org/TrackAction",
     "Domain Bucket":"< 1K"
   },
   {
     "Class":"Itemtype",
-    "Name":"http:\/\/schema.org\/TradeAction",
+    "Name":"https://schema.org/TradeAction",
     "Domain Bucket":"1K - 10K"
   },
   {
     "Class":"Itemtype",
-    "Name":"http:\/\/schema.org\/TrainReservation",
+    "Name":"https://schema.org/TrainReservation",
     "Domain Bucket":"< 1K"
   },
   {
     "Class":"Itemtype",
-    "Name":"http:\/\/schema.org\/TrainStation",
+    "Name":"https://schema.org/TrainStation",
     "Domain Bucket":"1K - 10K"
   },
   {
     "Class":"Itemtype",
-    "Name":"http:\/\/schema.org\/TrainTrip",
+    "Name":"https://schema.org/TrainTrip",
     "Domain Bucket":"< 1K"
   },
   {
     "Class":"Itemtype",
-    "Name":"http:\/\/schema.org\/TransferAction",
+    "Name":"https://schema.org/TransferAction",
     "Domain Bucket":"< 1K"
   },
   {
     "Class":"Itemtype",
-    "Name":"http:\/\/schema.org\/TravelAction",
+    "Name":"https://schema.org/TravelAction",
     "Domain Bucket":"1K - 10K"
   },
   {
     "Class":"Itemtype",
-    "Name":"http:\/\/schema.org\/TravelAgency",
+    "Name":"https://schema.org/TravelAgency",
     "Domain Bucket":"10K - 100K"
   },
   {
     "Class":"Itemtype",
-    "Name":"http:\/\/schema.org\/TreatmentIndication",
+    "Name":"https://schema.org/TreatmentIndication",
     "Domain Bucket":"< 1K"
   },
   {
     "Class":"Itemtype",
-    "Name":"http:\/\/schema.org\/Trip",
+    "Name":"https://schema.org/Trip",
     "Domain Bucket":"10K - 100K"
   },
   {
     "Class":"Itemtype",
-    "Name":"http:\/\/schema.org\/TypeAndQuantityNode",
+    "Name":"https://schema.org/TypeAndQuantityNode",
     "Domain Bucket":"< 1K"
   },
   {
     "Class":"Itemtype",
-    "Name":"http:\/\/schema.org\/UKNonprofitType",
+    "Name":"https://schema.org/UKNonprofitType",
     "Domain Bucket":"< 1K"
   },
   {
     "Class":"Itemtype",
-    "Name":"http:\/\/schema.org\/URL",
+    "Name":"https://schema.org/URL",
     "Domain Bucket":"1K - 10K"
   },
   {
     "Class":"Itemtype",
-    "Name":"http:\/\/schema.org\/USNonprofitType",
+    "Name":"https://schema.org/USNonprofitType",
     "Domain Bucket":"< 1K"
   },
   {
     "Class":"Itemtype",
-    "Name":"http:\/\/schema.org\/UnRegisterAction",
+    "Name":"https://schema.org/UnRegisterAction",
     "Domain Bucket":"< 1K"
   },
   {
     "Class":"Itemtype",
-    "Name":"http:\/\/schema.org\/UnitPriceSpecification",
+    "Name":"https://schema.org/UnitPriceSpecification",
     "Domain Bucket":"1M - 10M"
   },
   {
     "Class":"Itemtype",
-    "Name":"http:\/\/schema.org\/UpdateAction",
+    "Name":"https://schema.org/UpdateAction",
     "Domain Bucket":"< 1K"
   },
   {
     "Class":"Itemtype",
-    "Name":"http:\/\/schema.org\/UseAction",
+    "Name":"https://schema.org/UseAction",
     "Domain Bucket":"1K - 10K"
   },
   {
     "Class":"Itemtype",
-    "Name":"http:\/\/schema.org\/UserBlocks",
+    "Name":"https://schema.org/UserBlocks",
     "Domain Bucket":"< 1K"
   },
   {
     "Class":"Itemtype",
-    "Name":"http:\/\/schema.org\/UserCheckins",
+    "Name":"https://schema.org/UserCheckins",
     "Domain Bucket":"1K - 10K"
   },
   {
     "Class":"Itemtype",
-    "Name":"http:\/\/schema.org\/UserComments",
+    "Name":"https://schema.org/UserComments",
     "Domain Bucket":"10K - 100K"
   },
   {
     "Class":"Itemtype",
-    "Name":"http:\/\/schema.org\/UserDownloads",
+    "Name":"https://schema.org/UserDownloads",
     "Domain Bucket":"< 1K"
   },
   {
     "Class":"Itemtype",
-    "Name":"http:\/\/schema.org\/UserInteraction",
+    "Name":"https://schema.org/UserInteraction",
     "Domain Bucket":"< 1K"
   },
   {
     "Class":"Itemtype",
-    "Name":"http:\/\/schema.org\/UserLikes",
+    "Name":"https://schema.org/UserLikes",
     "Domain Bucket":"< 1K"
   },
   {
     "Class":"Itemtype",
-    "Name":"http:\/\/schema.org\/UserPageVisits",
+    "Name":"https://schema.org/UserPageVisits",
     "Domain Bucket":"< 1K"
   },
   {
     "Class":"Itemtype",
-    "Name":"http:\/\/schema.org\/UserPlays",
+    "Name":"https://schema.org/UserPlays",
     "Domain Bucket":"< 1K"
   },
   {
     "Class":"Itemtype",
-    "Name":"http:\/\/schema.org\/UserPlusOnes",
+    "Name":"https://schema.org/UserPlusOnes",
     "Domain Bucket":"< 1K"
   },
   {
     "Class":"Itemtype",
-    "Name":"http:\/\/schema.org\/UserReview",
+    "Name":"https://schema.org/UserReview",
     "Domain Bucket":"1K - 10K"
   },
   {
     "Class":"Itemtype",
-    "Name":"http:\/\/schema.org\/UserTweets",
+    "Name":"https://schema.org/UserTweets",
     "Domain Bucket":"< 1K"
   },
   {
     "Class":"Itemtype",
-    "Name":"http:\/\/schema.org\/VacationRental",
+    "Name":"https://schema.org/VacationRental",
     "Domain Bucket":"10K - 100K"
   },
   {
     "Class":"Itemtype",
-    "Name":"http:\/\/schema.org\/Vehicle",
+    "Name":"https://schema.org/Vehicle",
     "Domain Bucket":"10K - 100K"
   },
   {
     "Class":"Itemtype",
-    "Name":"http:\/\/schema.org\/Vein",
+    "Name":"https://schema.org/Vein",
     "Domain Bucket":"< 1K"
   },
   {
     "Class":"Itemtype",
-    "Name":"http:\/\/schema.org\/Vessel",
+    "Name":"https://schema.org/Vessel",
     "Domain Bucket":"< 1K"
   },
   {
     "Class":"Itemtype",
-    "Name":"http:\/\/schema.org\/VeterinaryCare",
+    "Name":"https://schema.org/VeterinaryCare",
     "Domain Bucket":"1K - 10K"
   },
   {
     "Class":"Itemtype",
-    "Name":"http:\/\/schema.org\/VideoGallery",
+    "Name":"https://schema.org/VideoGallery",
     "Domain Bucket":"1K - 10K"
   },
   {
     "Class":"Itemtype",
-    "Name":"http:\/\/schema.org\/VideoGame",
+    "Name":"https://schema.org/VideoGame",
     "Domain Bucket":"10K - 100K"
   },
   {
     "Class":"Itemtype",
-    "Name":"http:\/\/schema.org\/VideoGameClip",
+    "Name":"https://schema.org/VideoGameClip",
     "Domain Bucket":"< 1K"
   },
   {
     "Class":"Itemtype",
-    "Name":"http:\/\/schema.org\/VideoGameSeries",
+    "Name":"https://schema.org/VideoGameSeries",
     "Domain Bucket":"1K - 10K"
   },
   {
     "Class":"Itemtype",
-    "Name":"http:\/\/schema.org\/VideoObject",
+    "Name":"https://schema.org/VideoObject",
     "Domain Bucket":"1M - 10M"
   },
   {
     "Class":"Itemtype",
-    "Name":"http:\/\/schema.org\/VideoObjectSnapshot",
+    "Name":"https://schema.org/VideoObjectSnapshot",
     "Domain Bucket":"< 1K"
   },
   {
     "Class":"Itemtype",
-    "Name":"http:\/\/schema.org\/ViewAction",
+    "Name":"https://schema.org/ViewAction",
     "Domain Bucket":"10K - 100K"
   },
   {
     "Class":"Itemtype",
-    "Name":"http:\/\/schema.org\/VirtualLocation",
+    "Name":"https://schema.org/VirtualLocation",
     "Domain Bucket":"10K - 100K"
   },
   {
     "Class":"Itemtype",
-    "Name":"http:\/\/schema.org\/VisualArtsEvent",
+    "Name":"https://schema.org/VisualArtsEvent",
     "Domain Bucket":"< 1K"
   },
   {
     "Class":"Itemtype",
-    "Name":"http:\/\/schema.org\/VisualArtwork",
+    "Name":"https://schema.org/VisualArtwork",
     "Domain Bucket":"1K - 10K"
   },
   {
     "Class":"Itemtype",
-    "Name":"http:\/\/schema.org\/VitalSign",
+    "Name":"https://schema.org/VitalSign",
     "Domain Bucket":"< 1K"
   },
   {
     "Class":"Itemtype",
-    "Name":"http:\/\/schema.org\/Volcano",
+    "Name":"https://schema.org/Volcano",
     "Domain Bucket":"< 1K"
   },
   {
     "Class":"Itemtype",
-    "Name":"http:\/\/schema.org\/VoteAction",
+    "Name":"https://schema.org/VoteAction",
     "Domain Bucket":"< 1K"
   },
   {
     "Class":"Itemtype",
-    "Name":"http:\/\/schema.org\/WPAdBlock",
+    "Name":"https://schema.org/WPAdBlock",
     "Domain Bucket":"10K - 100K"
   },
   {
     "Class":"Itemtype",
-    "Name":"http:\/\/schema.org\/WPFooter",
+    "Name":"https://schema.org/WPFooter",
     "Domain Bucket":"1M - 10M"
   },
   {
     "Class":"Itemtype",
-    "Name":"http:\/\/schema.org\/WPHeader",
+    "Name":"https://schema.org/WPHeader",
     "Domain Bucket":"1M - 10M"
   },
   {
     "Class":"Itemtype",
-    "Name":"http:\/\/schema.org\/WPSideBar",
+    "Name":"https://schema.org/WPSideBar",
     "Domain Bucket":"1M - 10M"
   },
   {
     "Class":"Itemtype",
-    "Name":"http:\/\/schema.org\/WantAction",
+    "Name":"https://schema.org/WantAction",
     "Domain Bucket":"< 1K"
   },
   {
     "Class":"Itemtype",
-    "Name":"http:\/\/schema.org\/WarrantyPromise",
+    "Name":"https://schema.org/WarrantyPromise",
     "Domain Bucket":"10K - 100K"
   },
   {
     "Class":"Itemtype",
-    "Name":"http:\/\/schema.org\/WarrantyScope",
+    "Name":"https://schema.org/WarrantyScope",
     "Domain Bucket":"< 1K"
   },
   {
     "Class":"Itemtype",
-    "Name":"http:\/\/schema.org\/WatchAction",
+    "Name":"https://schema.org/WatchAction",
     "Domain Bucket":"100K - 1M"
   },
   {
     "Class":"Itemtype",
-    "Name":"http:\/\/schema.org\/Waterfall",
+    "Name":"https://schema.org/Waterfall",
     "Domain Bucket":"< 1K"
   },
   {
     "Class":"Itemtype",
-    "Name":"http:\/\/schema.org\/WearAction",
+    "Name":"https://schema.org/WearAction",
     "Domain Bucket":"< 1K"
   },
   {
     "Class":"Itemtype",
-    "Name":"http:\/\/schema.org\/WearableMeasurementTypeEnumeration",
+    "Name":"https://schema.org/WearableMeasurementTypeEnumeration",
     "Domain Bucket":"< 1K"
   },
   {
     "Class":"Itemtype",
-    "Name":"http:\/\/schema.org\/WearableSizeGroupEnumeration",
+    "Name":"https://schema.org/WearableSizeGroupEnumeration",
     "Domain Bucket":"< 1K"
   },
   {
     "Class":"Itemtype",
-    "Name":"http:\/\/schema.org\/WearableSizeSystemEnumeration",
+    "Name":"https://schema.org/WearableSizeSystemEnumeration",
     "Domain Bucket":"< 1K"
   },
   {
     "Class":"Itemtype",
-    "Name":"http:\/\/schema.org\/WebAPI",
+    "Name":"https://schema.org/WebAPI",
     "Domain Bucket":"1K - 10K"
   },
   {
     "Class":"Itemtype",
-    "Name":"http:\/\/schema.org\/WebApplication",
+    "Name":"https://schema.org/WebApplication",
     "Domain Bucket":"100K - 1M"
   },
   {
     "Class":"Itemtype",
-    "Name":"http:\/\/schema.org\/WebContent",
+    "Name":"https://schema.org/WebContent",
     "Domain Bucket":"1K - 10K"
   },
   {
     "Class":"Itemtype",
-    "Name":"http:\/\/schema.org\/WebPage",
+    "Name":"https://schema.org/WebPage",
     "Domain Bucket":"10M+"
   },
   {
     "Class":"Itemtype",
-    "Name":"http:\/\/schema.org\/WebPageElement",
+    "Name":"https://schema.org/WebPageElement",
     "Domain Bucket":"1M - 10M"
   },
   {
     "Class":"Itemtype",
-    "Name":"http:\/\/schema.org\/WebSite",
+    "Name":"https://schema.org/WebSite",
     "Domain Bucket":"10M+"
   },
   {
     "Class":"Itemtype",
-    "Name":"http:\/\/schema.org\/WholesaleStore",
+    "Name":"https://schema.org/WholesaleStore",
     "Domain Bucket":"1K - 10K"
   },
   {
     "Class":"Itemtype",
-    "Name":"http:\/\/schema.org\/WinAction",
+    "Name":"https://schema.org/WinAction",
     "Domain Bucket":"< 1K"
   },
   {
     "Class":"Itemtype",
-    "Name":"http:\/\/schema.org\/Winery",
+    "Name":"https://schema.org/Winery",
     "Domain Bucket":"1K - 10K"
   },
   {
     "Class":"Itemtype",
-    "Name":"http:\/\/schema.org\/WorkBasedProgram",
+    "Name":"https://schema.org/WorkBasedProgram",
     "Domain Bucket":"< 1K"
   },
   {
     "Class":"Itemtype",
-    "Name":"http:\/\/schema.org\/WorkersUnion",
+    "Name":"https://schema.org/WorkersUnion",
     "Domain Bucket":"< 1K"
   },
   {
     "Class":"Itemtype",
-    "Name":"http:\/\/schema.org\/WriteAction",
+    "Name":"https://schema.org/WriteAction",
     "Domain Bucket":"10K - 100K"
   },
   {
     "Class":"Itemtype",
-    "Name":"http:\/\/schema.org\/XPathType",
+    "Name":"https://schema.org/XPathType",
     "Domain Bucket":"< 1K"
   },
   {
     "Class":"Itemtype",
-    "Name":"http:\/\/schema.org\/Zoo",
+    "Name":"https://schema.org/Zoo",
     "Domain Bucket":"< 1K"
   },
   {
     "Class":"Predicate",
-    "Name":"http:\/\/schema.org\/about",
+    "Name":"https://schema.org/about",
     "Domain Bucket":"10M+"
   },
   {
     "Class":"Predicate",
-    "Name":"http:\/\/schema.org\/about-input",
+    "Name":"https://schema.org/about-input",
     "Domain Bucket":"< 1K"
   },
   {
     "Class":"Predicate",
-    "Name":"http:\/\/schema.org\/about-output",
+    "Name":"https://schema.org/about-output",
     "Domain Bucket":"< 1K"
   },
   {
     "Class":"Predicate",
-    "Name":"http:\/\/schema.org\/abridged",
+    "Name":"https://schema.org/abridged",
     "Domain Bucket":"< 1K"
   },
   {
     "Class":"Predicate",
-    "Name":"http:\/\/schema.org\/abridged-input",
+    "Name":"https://schema.org/abridged-input",
     "Domain Bucket":"< 1K"
   },
   {
     "Class":"Predicate",
-    "Name":"http:\/\/schema.org\/abridged-output",
+    "Name":"https://schema.org/abridged-output",
     "Domain Bucket":"< 1K"
   },
   {
     "Class":"Predicate",
-    "Name":"http:\/\/schema.org\/abstract",
+    "Name":"https://schema.org/abstract",
     "Domain Bucket":"10K - 100K"
   },
   {
     "Class":"Predicate",
-    "Name":"http:\/\/schema.org\/abstract-input",
+    "Name":"https://schema.org/abstract-input",
     "Domain Bucket":"< 1K"
   },
   {
     "Class":"Predicate",
-    "Name":"http:\/\/schema.org\/abstract-output",
+    "Name":"https://schema.org/abstract-output",
     "Domain Bucket":"< 1K"
   },
   {
     "Class":"Predicate",
-    "Name":"http:\/\/schema.org\/accelerationTime",
+    "Name":"https://schema.org/accelerationTime",
     "Domain Bucket":"1K - 10K"
   },
   {
     "Class":"Predicate",
-    "Name":"http:\/\/schema.org\/accelerationTime-input",
+    "Name":"https://schema.org/accelerationTime-input",
     "Domain Bucket":"< 1K"
   },
   {
     "Class":"Predicate",
-    "Name":"http:\/\/schema.org\/accelerationTime-output",
+    "Name":"https://schema.org/accelerationTime-output",
     "Domain Bucket":"< 1K"
   },
   {
     "Class":"Predicate",
-    "Name":"http:\/\/schema.org\/acceptedAnswer",
+    "Name":"https://schema.org/acceptedAnswer",
     "Domain Bucket":"1M - 10M"
   },
   {
     "Class":"Predicate",
-    "Name":"http:\/\/schema.org\/acceptedAnswer-input",
+    "Name":"https://schema.org/acceptedAnswer-input",
     "Domain Bucket":"< 1K"
   },
   {
     "Class":"Predicate",
-    "Name":"http:\/\/schema.org\/acceptedAnswer-output",
+    "Name":"https://schema.org/acceptedAnswer-output",
     "Domain Bucket":"< 1K"
   },
   {
     "Class":"Predicate",
-    "Name":"http:\/\/schema.org\/acceptedOffer",
+    "Name":"https://schema.org/acceptedOffer",
     "Domain Bucket":"< 1K"
   },
   {
     "Class":"Predicate",
-    "Name":"http:\/\/schema.org\/acceptedOffer-input",
+    "Name":"https://schema.org/acceptedOffer-input",
     "Domain Bucket":"< 1K"
   },
   {
     "Class":"Predicate",
-    "Name":"http:\/\/schema.org\/acceptedOffer-output",
+    "Name":"https://schema.org/acceptedOffer-output",
     "Domain Bucket":"< 1K"
   },
   {
     "Class":"Predicate",
-    "Name":"http:\/\/schema.org\/acceptedPaymentMethod",
+    "Name":"https://schema.org/acceptedPaymentMethod",
     "Domain Bucket":"10K - 100K"
   },
   {
     "Class":"Predicate",
-    "Name":"http:\/\/schema.org\/acceptedPaymentMethod-input",
+    "Name":"https://schema.org/acceptedPaymentMethod-input",
     "Domain Bucket":"< 1K"
   },
   {
     "Class":"Predicate",
-    "Name":"http:\/\/schema.org\/acceptedPaymentMethod-output",
+    "Name":"https://schema.org/acceptedPaymentMethod-output",
     "Domain Bucket":"< 1K"
   },
   {
     "Class":"Predicate",
-    "Name":"http:\/\/schema.org\/acceptsReservations",
+    "Name":"https://schema.org/acceptsReservations",
     "Domain Bucket":"100K - 1M"
   },
   {
     "Class":"Predicate",
-    "Name":"http:\/\/schema.org\/acceptsReservations-input",
+    "Name":"https://schema.org/acceptsReservations-input",
     "Domain Bucket":"< 1K"
   },
   {
     "Class":"Predicate",
-    "Name":"http:\/\/schema.org\/acceptsReservations-output",
+    "Name":"https://schema.org/acceptsReservations-output",
     "Domain Bucket":"< 1K"
   },
   {
     "Class":"Predicate",
-    "Name":"http:\/\/schema.org\/accessCode",
+    "Name":"https://schema.org/accessCode",
     "Domain Bucket":"< 1K"
   },
   {
     "Class":"Predicate",
-    "Name":"http:\/\/schema.org\/accessCode-input",
+    "Name":"https://schema.org/accessCode-input",
     "Domain Bucket":"< 1K"
   },
   {
     "Class":"Predicate",
-    "Name":"http:\/\/schema.org\/accessCode-output",
+    "Name":"https://schema.org/accessCode-output",
     "Domain Bucket":"< 1K"
   },
   {
     "Class":"Predicate",
-    "Name":"http:\/\/schema.org\/accessMode",
+    "Name":"https://schema.org/accessMode",
     "Domain Bucket":"1K - 10K"
   },
   {
     "Class":"Predicate",
-    "Name":"http:\/\/schema.org\/accessMode-input",
+    "Name":"https://schema.org/accessMode-input",
     "Domain Bucket":"< 1K"
   },
   {
     "Class":"Predicate",
-    "Name":"http:\/\/schema.org\/accessMode-output",
+    "Name":"https://schema.org/accessMode-output",
     "Domain Bucket":"< 1K"
   },
   {
     "Class":"Predicate",
-    "Name":"http:\/\/schema.org\/accessModeSufficient",
+    "Name":"https://schema.org/accessModeSufficient",
     "Domain Bucket":"1K - 10K"
   },
   {
     "Class":"Predicate",
-    "Name":"http:\/\/schema.org\/accessModeSufficient-input",
+    "Name":"https://schema.org/accessModeSufficient-input",
     "Domain Bucket":"< 1K"
   },
   {
     "Class":"Predicate",
-    "Name":"http:\/\/schema.org\/accessModeSufficient-output",
+    "Name":"https://schema.org/accessModeSufficient-output",
     "Domain Bucket":"< 1K"
   },
   {
     "Class":"Predicate",
-    "Name":"http:\/\/schema.org\/accessibilityAPI",
+    "Name":"https://schema.org/accessibilityAPI",
     "Domain Bucket":"1K - 10K"
   },
   {
     "Class":"Predicate",
-    "Name":"http:\/\/schema.org\/accessibilityAPI-input",
+    "Name":"https://schema.org/accessibilityAPI-input",
     "Domain Bucket":"< 1K"
   },
   {
     "Class":"Predicate",
-    "Name":"http:\/\/schema.org\/accessibilityAPI-output",
+    "Name":"https://schema.org/accessibilityAPI-output",
     "Domain Bucket":"< 1K"
   },
   {
     "Class":"Predicate",
-    "Name":"http:\/\/schema.org\/accessibilityControl",
+    "Name":"https://schema.org/accessibilityControl",
     "Domain Bucket":"1K - 10K"
   },
   {
     "Class":"Predicate",
-    "Name":"http:\/\/schema.org\/accessibilityControl-input",
+    "Name":"https://schema.org/accessibilityControl-input",
     "Domain Bucket":"< 1K"
   },
   {
     "Class":"Predicate",
-    "Name":"http:\/\/schema.org\/accessibilityControl-output",
+    "Name":"https://schema.org/accessibilityControl-output",
     "Domain Bucket":"< 1K"
   },
   {
     "Class":"Predicate",
-    "Name":"http:\/\/schema.org\/accessibilityFeature",
+    "Name":"https://schema.org/accessibilityFeature",
     "Domain Bucket":"10K - 100K"
   },
   {
     "Class":"Predicate",
-    "Name":"http:\/\/schema.org\/accessibilityFeature-input",
+    "Name":"https://schema.org/accessibilityFeature-input",
     "Domain Bucket":"< 1K"
   },
   {
     "Class":"Predicate",
-    "Name":"http:\/\/schema.org\/accessibilityFeature-output",
+    "Name":"https://schema.org/accessibilityFeature-output",
     "Domain Bucket":"< 1K"
   },
   {
     "Class":"Predicate",
-    "Name":"http:\/\/schema.org\/accessibilityHazard",
+    "Name":"https://schema.org/accessibilityHazard",
     "Domain Bucket":"1K - 10K"
   },
   {
     "Class":"Predicate",
-    "Name":"http:\/\/schema.org\/accessibilityHazard-input",
+    "Name":"https://schema.org/accessibilityHazard-input",
     "Domain Bucket":"< 1K"
   },
   {
     "Class":"Predicate",
-    "Name":"http:\/\/schema.org\/accessibilityHazard-output",
+    "Name":"https://schema.org/accessibilityHazard-output",
     "Domain Bucket":"< 1K"
   },
   {
     "Class":"Predicate",
-    "Name":"http:\/\/schema.org\/accessibilitySummary",
+    "Name":"https://schema.org/accessibilitySummary",
     "Domain Bucket":"10K - 100K"
   },
   {
     "Class":"Predicate",
-    "Name":"http:\/\/schema.org\/accessibilitySummary-input",
+    "Name":"https://schema.org/accessibilitySummary-input",
     "Domain Bucket":"< 1K"
   },
   {
     "Class":"Predicate",
-    "Name":"http:\/\/schema.org\/accessibilitySummary-output",
+    "Name":"https://schema.org/accessibilitySummary-output",
     "Domain Bucket":"< 1K"
   },
   {
     "Class":"Predicate",
-    "Name":"http:\/\/schema.org\/accommodationCategory",
+    "Name":"https://schema.org/accommodationCategory",
     "Domain Bucket":"1K - 10K"
   },
   {
     "Class":"Predicate",
-    "Name":"http:\/\/schema.org\/accommodationCategory-input",
+    "Name":"https://schema.org/accommodationCategory-input",
     "Domain Bucket":"< 1K"
   },
   {
     "Class":"Predicate",
-    "Name":"http:\/\/schema.org\/accommodationCategory-output",
+    "Name":"https://schema.org/accommodationCategory-output",
     "Domain Bucket":"< 1K"
   },
   {
     "Class":"Predicate",
-    "Name":"http:\/\/schema.org\/accommodationFloorPlan",
+    "Name":"https://schema.org/accommodationFloorPlan",
     "Domain Bucket":"10K - 100K"
   },
   {
     "Class":"Predicate",
-    "Name":"http:\/\/schema.org\/accommodationFloorPlan-input",
+    "Name":"https://schema.org/accommodationFloorPlan-input",
     "Domain Bucket":"< 1K"
   },
   {
     "Class":"Predicate",
-    "Name":"http:\/\/schema.org\/accommodationFloorPlan-output",
+    "Name":"https://schema.org/accommodationFloorPlan-output",
     "Domain Bucket":"< 1K"
   },
   {
     "Class":"Predicate",
-    "Name":"http:\/\/schema.org\/accountId",
+    "Name":"https://schema.org/accountId",
     "Domain Bucket":"< 1K"
   },
   {
     "Class":"Predicate",
-    "Name":"http:\/\/schema.org\/accountId-input",
+    "Name":"https://schema.org/accountId-input",
     "Domain Bucket":"< 1K"
   },
   {
     "Class":"Predicate",
-    "Name":"http:\/\/schema.org\/accountId-output",
+    "Name":"https://schema.org/accountId-output",
     "Domain Bucket":"< 1K"
   },
   {
     "Class":"Predicate",
-    "Name":"http:\/\/schema.org\/accountMinimumInflow",
+    "Name":"https://schema.org/accountMinimumInflow",
     "Domain Bucket":"< 1K"
   },
   {
     "Class":"Predicate",
-    "Name":"http:\/\/schema.org\/accountMinimumInflow-input",
+    "Name":"https://schema.org/accountMinimumInflow-input",
     "Domain Bucket":"< 1K"
   },
   {
     "Class":"Predicate",
-    "Name":"http:\/\/schema.org\/accountMinimumInflow-output",
+    "Name":"https://schema.org/accountMinimumInflow-output",
     "Domain Bucket":"< 1K"
   },
   {
     "Class":"Predicate",
-    "Name":"http:\/\/schema.org\/accountOverdraftLimit",
+    "Name":"https://schema.org/accountOverdraftLimit",
     "Domain Bucket":"< 1K"
   },
   {
     "Class":"Predicate",
-    "Name":"http:\/\/schema.org\/accountOverdraftLimit-input",
+    "Name":"https://schema.org/accountOverdraftLimit-input",
     "Domain Bucket":"< 1K"
   },
   {
     "Class":"Predicate",
-    "Name":"http:\/\/schema.org\/accountOverdraftLimit-output",
+    "Name":"https://schema.org/accountOverdraftLimit-output",
     "Domain Bucket":"< 1K"
   },
   {
     "Class":"Predicate",
-    "Name":"http:\/\/schema.org\/accountablePerson",
+    "Name":"https://schema.org/accountablePerson",
     "Domain Bucket":"10K - 100K"
   },
   {
     "Class":"Predicate",
-    "Name":"http:\/\/schema.org\/accountablePerson-input",
+    "Name":"https://schema.org/accountablePerson-input",
     "Domain Bucket":"< 1K"
   },
   {
     "Class":"Predicate",
-    "Name":"http:\/\/schema.org\/accountablePerson-output",
+    "Name":"https://schema.org/accountablePerson-output",
     "Domain Bucket":"< 1K"
   },
   {
     "Class":"Predicate",
-    "Name":"http:\/\/schema.org\/acquireLicensePage",
+    "Name":"https://schema.org/acquireLicensePage",
     "Domain Bucket":"10K - 100K"
   },
   {
     "Class":"Predicate",
-    "Name":"http:\/\/schema.org\/acquireLicensePage-input",
+    "Name":"https://schema.org/acquireLicensePage-input",
     "Domain Bucket":"< 1K"
   },
   {
     "Class":"Predicate",
-    "Name":"http:\/\/schema.org\/acquireLicensePage-output",
+    "Name":"https://schema.org/acquireLicensePage-output",
     "Domain Bucket":"< 1K"
   },
   {
     "Class":"Predicate",
-    "Name":"http:\/\/schema.org\/acquiredFrom",
+    "Name":"https://schema.org/acquiredFrom",
     "Domain Bucket":"< 1K"
   },
   {
     "Class":"Predicate",
-    "Name":"http:\/\/schema.org\/acquiredFrom-input",
+    "Name":"https://schema.org/acquiredFrom-input",
     "Domain Bucket":"< 1K"
   },
   {
     "Class":"Predicate",
-    "Name":"http:\/\/schema.org\/acquiredFrom-output",
+    "Name":"https://schema.org/acquiredFrom-output",
     "Domain Bucket":"< 1K"
   },
   {
     "Class":"Predicate",
-    "Name":"http:\/\/schema.org\/acrissCode",
+    "Name":"https://schema.org/acrissCode",
     "Domain Bucket":"< 1K"
   },
   {
     "Class":"Predicate",
-    "Name":"http:\/\/schema.org\/acrissCode-input",
+    "Name":"https://schema.org/acrissCode-input",
     "Domain Bucket":"< 1K"
   },
   {
     "Class":"Predicate",
-    "Name":"http:\/\/schema.org\/acrissCode-output",
+    "Name":"https://schema.org/acrissCode-output",
     "Domain Bucket":"< 1K"
   },
   {
     "Class":"Predicate",
-    "Name":"http:\/\/schema.org\/actionAccessibilityRequirement",
+    "Name":"https://schema.org/actionAccessibilityRequirement",
     "Domain Bucket":"< 1K"
   },
   {
     "Class":"Predicate",
-    "Name":"http:\/\/schema.org\/actionAccessibilityRequirement-input",
+    "Name":"https://schema.org/actionAccessibilityRequirement-input",
     "Domain Bucket":"< 1K"
   },
   {
     "Class":"Predicate",
-    "Name":"http:\/\/schema.org\/actionAccessibilityRequirement-output",
+    "Name":"https://schema.org/actionAccessibilityRequirement-output",
     "Domain Bucket":"< 1K"
   },
   {
     "Class":"Predicate",
-    "Name":"http:\/\/schema.org\/actionApplication",
+    "Name":"https://schema.org/actionApplication",
     "Domain Bucket":"1K - 10K"
   },
   {
     "Class":"Predicate",
-    "Name":"http:\/\/schema.org\/actionApplication-input",
+    "Name":"https://schema.org/actionApplication-input",
     "Domain Bucket":"< 1K"
   },
   {
     "Class":"Predicate",
-    "Name":"http:\/\/schema.org\/actionApplication-output",
+    "Name":"https://schema.org/actionApplication-output",
     "Domain Bucket":"< 1K"
   },
   {
     "Class":"Predicate",
-    "Name":"http:\/\/schema.org\/actionOption",
+    "Name":"https://schema.org/actionOption",
     "Domain Bucket":"1K - 10K"
   },
   {
     "Class":"Predicate",
-    "Name":"http:\/\/schema.org\/actionOption-input",
+    "Name":"https://schema.org/actionOption-input",
     "Domain Bucket":"< 1K"
   },
   {
     "Class":"Predicate",
-    "Name":"http:\/\/schema.org\/actionOption-output",
+    "Name":"https://schema.org/actionOption-output",
     "Domain Bucket":"< 1K"
   },
   {
     "Class":"Predicate",
-    "Name":"http:\/\/schema.org\/actionPlatform",
+    "Name":"https://schema.org/actionPlatform",
     "Domain Bucket":"100K - 1M"
   },
   {
     "Class":"Predicate",
-    "Name":"http:\/\/schema.org\/actionPlatform-input",
+    "Name":"https://schema.org/actionPlatform-input",
     "Domain Bucket":"< 1K"
   },
   {
     "Class":"Predicate",
-    "Name":"http:\/\/schema.org\/actionPlatform-output",
+    "Name":"https://schema.org/actionPlatform-output",
     "Domain Bucket":"< 1K"
   },
   {
     "Class":"Predicate",
-    "Name":"http:\/\/schema.org\/actionProcess",
+    "Name":"https://schema.org/actionProcess",
     "Domain Bucket":"< 1K"
   },
   {
     "Class":"Predicate",
-    "Name":"http:\/\/schema.org\/actionProcess-input",
+    "Name":"https://schema.org/actionProcess-input",
     "Domain Bucket":"< 1K"
   },
   {
     "Class":"Predicate",
-    "Name":"http:\/\/schema.org\/actionProcess-output",
+    "Name":"https://schema.org/actionProcess-output",
     "Domain Bucket":"< 1K"
   },
   {
     "Class":"Predicate",
-    "Name":"http:\/\/schema.org\/actionStatus",
+    "Name":"https://schema.org/actionStatus",
     "Domain Bucket":"10K - 100K"
   },
   {
     "Class":"Predicate",
-    "Name":"http:\/\/schema.org\/actionStatus-input",
+    "Name":"https://schema.org/actionStatus-input",
     "Domain Bucket":"< 1K"
   },
   {
     "Class":"Predicate",
-    "Name":"http:\/\/schema.org\/actionStatus-output",
+    "Name":"https://schema.org/actionStatus-output",
     "Domain Bucket":"< 1K"
   },
   {
     "Class":"Predicate",
-    "Name":"http:\/\/schema.org\/actionableFeedbackPolicy",
+    "Name":"https://schema.org/actionableFeedbackPolicy",
     "Domain Bucket":"10K - 100K"
   },
   {
     "Class":"Predicate",
-    "Name":"http:\/\/schema.org\/actionableFeedbackPolicy-input",
+    "Name":"https://schema.org/actionableFeedbackPolicy-input",
     "Domain Bucket":"< 1K"
   },
   {
     "Class":"Predicate",
-    "Name":"http:\/\/schema.org\/actionableFeedbackPolicy-output",
+    "Name":"https://schema.org/actionableFeedbackPolicy-output",
     "Domain Bucket":"< 1K"
   },
   {
     "Class":"Predicate",
-    "Name":"http:\/\/schema.org\/activeIngredient",
+    "Name":"https://schema.org/activeIngredient",
     "Domain Bucket":"1K - 10K"
   },
   {
     "Class":"Predicate",
-    "Name":"http:\/\/schema.org\/activeIngredient-input",
+    "Name":"https://schema.org/activeIngredient-input",
     "Domain Bucket":"< 1K"
   },
   {
     "Class":"Predicate",
-    "Name":"http:\/\/schema.org\/activeIngredient-output",
+    "Name":"https://schema.org/activeIngredient-output",
     "Domain Bucket":"< 1K"
   },
   {
     "Class":"Predicate",
-    "Name":"http:\/\/schema.org\/activityDuration",
+    "Name":"https://schema.org/activityDuration",
     "Domain Bucket":"< 1K"
   },
   {
     "Class":"Predicate",
-    "Name":"http:\/\/schema.org\/activityDuration-input",
+    "Name":"https://schema.org/activityDuration-input",
     "Domain Bucket":"< 1K"
   },
   {
     "Class":"Predicate",
-    "Name":"http:\/\/schema.org\/activityDuration-output",
+    "Name":"https://schema.org/activityDuration-output",
     "Domain Bucket":"< 1K"
   },
   {
     "Class":"Predicate",
-    "Name":"http:\/\/schema.org\/activityFrequency",
+    "Name":"https://schema.org/activityFrequency",
     "Domain Bucket":"< 1K"
   },
   {
     "Class":"Predicate",
-    "Name":"http:\/\/schema.org\/activityFrequency-input",
+    "Name":"https://schema.org/activityFrequency-input",
     "Domain Bucket":"< 1K"
   },
   {
     "Class":"Predicate",
-    "Name":"http:\/\/schema.org\/activityFrequency-output",
+    "Name":"https://schema.org/activityFrequency-output",
     "Domain Bucket":"< 1K"
   },
   {
     "Class":"Predicate",
-    "Name":"http:\/\/schema.org\/actor",
+    "Name":"https://schema.org/actor",
     "Domain Bucket":"10K - 100K"
   },
   {
     "Class":"Predicate",
-    "Name":"http:\/\/schema.org\/actor-input",
+    "Name":"https://schema.org/actor-input",
     "Domain Bucket":"< 1K"
   },
   {
     "Class":"Predicate",
-    "Name":"http:\/\/schema.org\/actor-output",
+    "Name":"https://schema.org/actor-output",
     "Domain Bucket":"< 1K"
   },
   {
     "Class":"Predicate",
-    "Name":"http:\/\/schema.org\/actors",
+    "Name":"https://schema.org/actors",
     "Domain Bucket":"1K - 10K"
   },
   {
     "Class":"Predicate",
-    "Name":"http:\/\/schema.org\/actors-input",
+    "Name":"https://schema.org/actors-input",
     "Domain Bucket":"< 1K"
   },
   {
     "Class":"Predicate",
-    "Name":"http:\/\/schema.org\/actors-output",
+    "Name":"https://schema.org/actors-output",
     "Domain Bucket":"< 1K"
   },
   {
     "Class":"Predicate",
-    "Name":"http:\/\/schema.org\/addOn",
+    "Name":"https://schema.org/addOn",
     "Domain Bucket":"1K - 10K"
   },
   {
     "Class":"Predicate",
-    "Name":"http:\/\/schema.org\/addOn-input",
+    "Name":"https://schema.org/addOn-input",
     "Domain Bucket":"< 1K"
   },
   {
     "Class":"Predicate",
-    "Name":"http:\/\/schema.org\/addOn-output",
+    "Name":"https://schema.org/addOn-output",
     "Domain Bucket":"< 1K"
   },
   {
     "Class":"Predicate",
-    "Name":"http:\/\/schema.org\/additionalName",
+    "Name":"https://schema.org/additionalName",
     "Domain Bucket":"10K - 100K"
   },
   {
     "Class":"Predicate",
-    "Name":"http:\/\/schema.org\/additionalName-input",
+    "Name":"https://schema.org/additionalName-input",
     "Domain Bucket":"< 1K"
   },
   {
     "Class":"Predicate",
-    "Name":"http:\/\/schema.org\/additionalName-output",
+    "Name":"https://schema.org/additionalName-output",
     "Domain Bucket":"< 1K"
   },
   {
     "Class":"Predicate",
-    "Name":"http:\/\/schema.org\/additionalNumberOfGuests",
+    "Name":"https://schema.org/additionalNumberOfGuests",
     "Domain Bucket":"< 1K"
   },
   {
     "Class":"Predicate",
-    "Name":"http:\/\/schema.org\/additionalNumberOfGuests-input",
+    "Name":"https://schema.org/additionalNumberOfGuests-input",
     "Domain Bucket":"< 1K"
   },
   {
     "Class":"Predicate",
-    "Name":"http:\/\/schema.org\/additionalNumberOfGuests-output",
+    "Name":"https://schema.org/additionalNumberOfGuests-output",
     "Domain Bucket":"< 1K"
   },
   {
     "Class":"Predicate",
-    "Name":"http:\/\/schema.org\/additionalProperty",
+    "Name":"https://schema.org/additionalProperty",
     "Domain Bucket":"100K - 1M"
   },
   {
     "Class":"Predicate",
-    "Name":"http:\/\/schema.org\/additionalProperty-input",
+    "Name":"https://schema.org/additionalProperty-input",
     "Domain Bucket":"< 1K"
   },
   {
     "Class":"Predicate",
-    "Name":"http:\/\/schema.org\/additionalProperty-output",
+    "Name":"https://schema.org/additionalProperty-output",
     "Domain Bucket":"< 1K"
   },
   {
     "Class":"Predicate",
-    "Name":"http:\/\/schema.org\/additionalType",
+    "Name":"https://schema.org/additionalType",
     "Domain Bucket":"100K - 1M"
   },
   {
     "Class":"Predicate",
-    "Name":"http:\/\/schema.org\/additionalType-input",
+    "Name":"https://schema.org/additionalType-input",
     "Domain Bucket":"< 1K"
   },
   {
     "Class":"Predicate",
-    "Name":"http:\/\/schema.org\/additionalType-output",
+    "Name":"https://schema.org/additionalType-output",
     "Domain Bucket":"< 1K"
   },
   {
     "Class":"Predicate",
-    "Name":"http:\/\/schema.org\/additionalVariable",
+    "Name":"https://schema.org/additionalVariable",
     "Domain Bucket":"< 1K"
   },
   {
     "Class":"Predicate",
-    "Name":"http:\/\/schema.org\/additionalVariable-input",
+    "Name":"https://schema.org/additionalVariable-input",
     "Domain Bucket":"< 1K"
   },
   {
     "Class":"Predicate",
-    "Name":"http:\/\/schema.org\/additionalVariable-output",
+    "Name":"https://schema.org/additionalVariable-output",
     "Domain Bucket":"< 1K"
   },
   {
     "Class":"Predicate",
-    "Name":"http:\/\/schema.org\/address",
+    "Name":"https://schema.org/address",
     "Domain Bucket":"10M+"
   },
   {
     "Class":"Predicate",
-    "Name":"http:\/\/schema.org\/address-input",
+    "Name":"https://schema.org/address-input",
     "Domain Bucket":"< 1K"
   },
   {
     "Class":"Predicate",
-    "Name":"http:\/\/schema.org\/address-output",
+    "Name":"https://schema.org/address-output",
     "Domain Bucket":"< 1K"
   },
   {
     "Class":"Predicate",
-    "Name":"http:\/\/schema.org\/addressCountry",
+    "Name":"https://schema.org/addressCountry",
     "Domain Bucket":"1M - 10M"
   },
   {
     "Class":"Predicate",
-    "Name":"http:\/\/schema.org\/addressCountry-input",
+    "Name":"https://schema.org/addressCountry-input",
     "Domain Bucket":"< 1K"
   },
   {
     "Class":"Predicate",
-    "Name":"http:\/\/schema.org\/addressCountry-output",
+    "Name":"https://schema.org/addressCountry-output",
     "Domain Bucket":"< 1K"
   },
   {
     "Class":"Predicate",
-    "Name":"http:\/\/schema.org\/addressLocality",
+    "Name":"https://schema.org/addressLocality",
     "Domain Bucket":"1M - 10M"
   },
   {
     "Class":"Predicate",
-    "Name":"http:\/\/schema.org\/addressLocality-input",
+    "Name":"https://schema.org/addressLocality-input",
     "Domain Bucket":"< 1K"
   },
   {
     "Class":"Predicate",
-    "Name":"http:\/\/schema.org\/addressLocality-output",
+    "Name":"https://schema.org/addressLocality-output",
     "Domain Bucket":"< 1K"
   },
   {
     "Class":"Predicate",
-    "Name":"http:\/\/schema.org\/addressRegion",
+    "Name":"https://schema.org/addressRegion",
     "Domain Bucket":"1M - 10M"
   },
   {
     "Class":"Predicate",
-    "Name":"http:\/\/schema.org\/addressRegion-input",
+    "Name":"https://schema.org/addressRegion-input",
     "Domain Bucket":"< 1K"
   },
   {
     "Class":"Predicate",
-    "Name":"http:\/\/schema.org\/addressRegion-output",
+    "Name":"https://schema.org/addressRegion-output",
     "Domain Bucket":"< 1K"
   },
   {
     "Class":"Predicate",
-    "Name":"http:\/\/schema.org\/administrationRoute",
+    "Name":"https://schema.org/administrationRoute",
     "Domain Bucket":"1K - 10K"
   },
   {
     "Class":"Predicate",
-    "Name":"http:\/\/schema.org\/administrationRoute-input",
+    "Name":"https://schema.org/administrationRoute-input",
     "Domain Bucket":"< 1K"
   },
   {
     "Class":"Predicate",
-    "Name":"http:\/\/schema.org\/administrationRoute-output",
+    "Name":"https://schema.org/administrationRoute-output",
     "Domain Bucket":"< 1K"
   },
   {
     "Class":"Predicate",
-    "Name":"http:\/\/schema.org\/advanceBookingRequirement",
+    "Name":"https://schema.org/advanceBookingRequirement",
     "Domain Bucket":"< 1K"
   },
   {
     "Class":"Predicate",
-    "Name":"http:\/\/schema.org\/advanceBookingRequirement-input",
+    "Name":"https://schema.org/advanceBookingRequirement-input",
     "Domain Bucket":"< 1K"
   },
   {
     "Class":"Predicate",
-    "Name":"http:\/\/schema.org\/advanceBookingRequirement-output",
+    "Name":"https://schema.org/advanceBookingRequirement-output",
     "Domain Bucket":"< 1K"
   },
   {
     "Class":"Predicate",
-    "Name":"http:\/\/schema.org\/adverseOutcome",
+    "Name":"https://schema.org/adverseOutcome",
     "Domain Bucket":"< 1K"
   },
   {
     "Class":"Predicate",
-    "Name":"http:\/\/schema.org\/adverseOutcome-input",
+    "Name":"https://schema.org/adverseOutcome-input",
     "Domain Bucket":"< 1K"
   },
   {
     "Class":"Predicate",
-    "Name":"http:\/\/schema.org\/adverseOutcome-output",
+    "Name":"https://schema.org/adverseOutcome-output",
     "Domain Bucket":"< 1K"
   },
   {
     "Class":"Predicate",
-    "Name":"http:\/\/schema.org\/affectedBy",
+    "Name":"https://schema.org/affectedBy",
     "Domain Bucket":"< 1K"
   },
   {
     "Class":"Predicate",
-    "Name":"http:\/\/schema.org\/affectedBy-input",
+    "Name":"https://schema.org/affectedBy-input",
     "Domain Bucket":"< 1K"
   },
   {
     "Class":"Predicate",
-    "Name":"http:\/\/schema.org\/affectedBy-output",
+    "Name":"https://schema.org/affectedBy-output",
     "Domain Bucket":"< 1K"
   },
   {
     "Class":"Predicate",
-    "Name":"http:\/\/schema.org\/affiliation",
+    "Name":"https://schema.org/affiliation",
     "Domain Bucket":"10K - 100K"
   },
   {
     "Class":"Predicate",
-    "Name":"http:\/\/schema.org\/affiliation-input",
+    "Name":"https://schema.org/affiliation-input",
     "Domain Bucket":"< 1K"
   },
   {
     "Class":"Predicate",
-    "Name":"http:\/\/schema.org\/affiliation-output",
+    "Name":"https://schema.org/affiliation-output",
     "Domain Bucket":"< 1K"
   },
   {
     "Class":"Predicate",
-    "Name":"http:\/\/schema.org\/afterMedia",
+    "Name":"https://schema.org/afterMedia",
     "Domain Bucket":"< 1K"
   },
   {
     "Class":"Predicate",
-    "Name":"http:\/\/schema.org\/afterMedia-input",
+    "Name":"https://schema.org/afterMedia-input",
     "Domain Bucket":"< 1K"
   },
   {
     "Class":"Predicate",
-    "Name":"http:\/\/schema.org\/afterMedia-output",
+    "Name":"https://schema.org/afterMedia-output",
     "Domain Bucket":"< 1K"
   },
   {
     "Class":"Predicate",
-    "Name":"http:\/\/schema.org\/agent",
+    "Name":"https://schema.org/agent",
     "Domain Bucket":"10K - 100K"
   },
   {
     "Class":"Predicate",
-    "Name":"http:\/\/schema.org\/agent-input",
+    "Name":"https://schema.org/agent-input",
     "Domain Bucket":"< 1K"
   },
   {
     "Class":"Predicate",
-    "Name":"http:\/\/schema.org\/agent-output",
+    "Name":"https://schema.org/agent-output",
     "Domain Bucket":"< 1K"
   },
   {
     "Class":"Predicate",
-    "Name":"http:\/\/schema.org\/agentInteractionStatistic",
+    "Name":"https://schema.org/agentInteractionStatistic",
     "Domain Bucket":"10K - 100K"
   },
   {
     "Class":"Predicate",
-    "Name":"http:\/\/schema.org\/agentInteractionStatistic-input",
+    "Name":"https://schema.org/agentInteractionStatistic-input",
     "Domain Bucket":"< 1K"
   },
   {
     "Class":"Predicate",
-    "Name":"http:\/\/schema.org\/agentInteractionStatistic-output",
+    "Name":"https://schema.org/agentInteractionStatistic-output",
     "Domain Bucket":"< 1K"
   },
   {
     "Class":"Predicate",
-    "Name":"http:\/\/schema.org\/aggregateElement",
+    "Name":"https://schema.org/aggregateElement",
     "Domain Bucket":"< 1K"
   },
   {
     "Class":"Predicate",
-    "Name":"http:\/\/schema.org\/aggregateElement-input",
+    "Name":"https://schema.org/aggregateElement-input",
     "Domain Bucket":"< 1K"
   },
   {
     "Class":"Predicate",
-    "Name":"http:\/\/schema.org\/aggregateElement-output",
+    "Name":"https://schema.org/aggregateElement-output",
     "Domain Bucket":"< 1K"
   },
   {
     "Class":"Predicate",
-    "Name":"http:\/\/schema.org\/aggregateRating",
+    "Name":"https://schema.org/aggregateRating",
     "Domain Bucket":"1M - 10M"
   },
   {
     "Class":"Predicate",
-    "Name":"http:\/\/schema.org\/aggregateRating-input",
+    "Name":"https://schema.org/aggregateRating-input",
     "Domain Bucket":"< 1K"
   },
   {
     "Class":"Predicate",
-    "Name":"http:\/\/schema.org\/aggregateRating-output",
+    "Name":"https://schema.org/aggregateRating-output",
     "Domain Bucket":"< 1K"
   },
   {
     "Class":"Predicate",
-    "Name":"http:\/\/schema.org\/aircraft",
+    "Name":"https://schema.org/aircraft",
     "Domain Bucket":"< 1K"
   },
   {
     "Class":"Predicate",
-    "Name":"http:\/\/schema.org\/aircraft-input",
+    "Name":"https://schema.org/aircraft-input",
     "Domain Bucket":"< 1K"
   },
   {
     "Class":"Predicate",
-    "Name":"http:\/\/schema.org\/aircraft-output",
+    "Name":"https://schema.org/aircraft-output",
     "Domain Bucket":"< 1K"
   },
   {
     "Class":"Predicate",
-    "Name":"http:\/\/schema.org\/album",
+    "Name":"https://schema.org/album",
     "Domain Bucket":"1K - 10K"
   },
   {
     "Class":"Predicate",
-    "Name":"http:\/\/schema.org\/album-input",
+    "Name":"https://schema.org/album-input",
     "Domain Bucket":"< 1K"
   },
   {
     "Class":"Predicate",
-    "Name":"http:\/\/schema.org\/album-output",
+    "Name":"https://schema.org/album-output",
     "Domain Bucket":"< 1K"
   },
   {
     "Class":"Predicate",
-    "Name":"http:\/\/schema.org\/albumProductionType",
+    "Name":"https://schema.org/albumProductionType",
     "Domain Bucket":"1K - 10K"
   },
   {
     "Class":"Predicate",
-    "Name":"http:\/\/schema.org\/albumProductionType-input",
+    "Name":"https://schema.org/albumProductionType-input",
     "Domain Bucket":"< 1K"
   },
   {
     "Class":"Predicate",
-    "Name":"http:\/\/schema.org\/albumProductionType-output",
+    "Name":"https://schema.org/albumProductionType-output",
     "Domain Bucket":"< 1K"
   },
   {
     "Class":"Predicate",
-    "Name":"http:\/\/schema.org\/albumRelease",
+    "Name":"https://schema.org/albumRelease",
     "Domain Bucket":"1K - 10K"
   },
   {
     "Class":"Predicate",
-    "Name":"http:\/\/schema.org\/albumRelease-input",
+    "Name":"https://schema.org/albumRelease-input",
     "Domain Bucket":"< 1K"
   },
   {
     "Class":"Predicate",
-    "Name":"http:\/\/schema.org\/albumRelease-output",
+    "Name":"https://schema.org/albumRelease-output",
     "Domain Bucket":"< 1K"
   },
   {
     "Class":"Predicate",
-    "Name":"http:\/\/schema.org\/albumReleaseType",
+    "Name":"https://schema.org/albumReleaseType",
     "Domain Bucket":"1K - 10K"
   },
   {
     "Class":"Predicate",
-    "Name":"http:\/\/schema.org\/albumReleaseType-input",
+    "Name":"https://schema.org/albumReleaseType-input",
     "Domain Bucket":"< 1K"
   },
   {
     "Class":"Predicate",
-    "Name":"http:\/\/schema.org\/albumReleaseType-output",
+    "Name":"https://schema.org/albumReleaseType-output",
     "Domain Bucket":"< 1K"
   },
   {
     "Class":"Predicate",
-    "Name":"http:\/\/schema.org\/albums",
+    "Name":"https://schema.org/albums",
     "Domain Bucket":"< 1K"
   },
   {
     "Class":"Predicate",
-    "Name":"http:\/\/schema.org\/albums-input",
+    "Name":"https://schema.org/albums-input",
     "Domain Bucket":"< 1K"
   },
   {
     "Class":"Predicate",
-    "Name":"http:\/\/schema.org\/albums-output",
+    "Name":"https://schema.org/albums-output",
     "Domain Bucket":"< 1K"
   },
   {
     "Class":"Predicate",
-    "Name":"http:\/\/schema.org\/alcoholWarning",
+    "Name":"https://schema.org/alcoholWarning",
     "Domain Bucket":"< 1K"
   },
   {
     "Class":"Predicate",
-    "Name":"http:\/\/schema.org\/alcoholWarning-input",
+    "Name":"https://schema.org/alcoholWarning-input",
     "Domain Bucket":"< 1K"
   },
   {
     "Class":"Predicate",
-    "Name":"http:\/\/schema.org\/alcoholWarning-output",
+    "Name":"https://schema.org/alcoholWarning-output",
     "Domain Bucket":"< 1K"
   },
   {
     "Class":"Predicate",
-    "Name":"http:\/\/schema.org\/algorithm",
+    "Name":"https://schema.org/algorithm",
     "Domain Bucket":"< 1K"
   },
   {
     "Class":"Predicate",
-    "Name":"http:\/\/schema.org\/algorithm-input",
+    "Name":"https://schema.org/algorithm-input",
     "Domain Bucket":"< 1K"
   },
   {
     "Class":"Predicate",
-    "Name":"http:\/\/schema.org\/algorithm-output",
+    "Name":"https://schema.org/algorithm-output",
     "Domain Bucket":"< 1K"
   },
   {
     "Class":"Predicate",
-    "Name":"http:\/\/schema.org\/alignmentType",
+    "Name":"https://schema.org/alignmentType",
     "Domain Bucket":"1K - 10K"
   },
   {
     "Class":"Predicate",
-    "Name":"http:\/\/schema.org\/alignmentType-input",
+    "Name":"https://schema.org/alignmentType-input",
     "Domain Bucket":"< 1K"
   },
   {
     "Class":"Predicate",
-    "Name":"http:\/\/schema.org\/alignmentType-output",
+    "Name":"https://schema.org/alignmentType-output",
     "Domain Bucket":"< 1K"
   },
   {
     "Class":"Predicate",
-    "Name":"http:\/\/schema.org\/alternateName",
+    "Name":"https://schema.org/alternateName",
     "Domain Bucket":"1M - 10M"
   },
   {
     "Class":"Predicate",
-    "Name":"http:\/\/schema.org\/alternateName-input",
+    "Name":"https://schema.org/alternateName-input",
     "Domain Bucket":"< 1K"
   },
   {
     "Class":"Predicate",
-    "Name":"http:\/\/schema.org\/alternateName-output",
+    "Name":"https://schema.org/alternateName-output",
     "Domain Bucket":"< 1K"
   },
   {
     "Class":"Predicate",
-    "Name":"http:\/\/schema.org\/alternativeHeadline",
+    "Name":"https://schema.org/alternativeHeadline",
     "Domain Bucket":"100K - 1M"
   },
   {
     "Class":"Predicate",
-    "Name":"http:\/\/schema.org\/alternativeHeadline-input",
+    "Name":"https://schema.org/alternativeHeadline-input",
     "Domain Bucket":"< 1K"
   },
   {
     "Class":"Predicate",
-    "Name":"http:\/\/schema.org\/alternativeHeadline-output",
+    "Name":"https://schema.org/alternativeHeadline-output",
     "Domain Bucket":"< 1K"
   },
   {
     "Class":"Predicate",
-    "Name":"http:\/\/schema.org\/alternativeOf",
+    "Name":"https://schema.org/alternativeOf",
     "Domain Bucket":"< 1K"
   },
   {
     "Class":"Predicate",
-    "Name":"http:\/\/schema.org\/alternativeOf-input",
+    "Name":"https://schema.org/alternativeOf-input",
     "Domain Bucket":"< 1K"
   },
   {
     "Class":"Predicate",
-    "Name":"http:\/\/schema.org\/alternativeOf-output",
+    "Name":"https://schema.org/alternativeOf-output",
     "Domain Bucket":"< 1K"
   },
   {
     "Class":"Predicate",
-    "Name":"http:\/\/schema.org\/alumni",
+    "Name":"https://schema.org/alumni",
     "Domain Bucket":"1K - 10K"
   },
   {
     "Class":"Predicate",
-    "Name":"http:\/\/schema.org\/alumni-input",
+    "Name":"https://schema.org/alumni-input",
     "Domain Bucket":"< 1K"
   },
   {
     "Class":"Predicate",
-    "Name":"http:\/\/schema.org\/alumni-output",
+    "Name":"https://schema.org/alumni-output",
     "Domain Bucket":"< 1K"
   },
   {
     "Class":"Predicate",
-    "Name":"http:\/\/schema.org\/alumniOf",
+    "Name":"https://schema.org/alumniOf",
     "Domain Bucket":"100K - 1M"
   },
   {
     "Class":"Predicate",
-    "Name":"http:\/\/schema.org\/alumniOf-input",
+    "Name":"https://schema.org/alumniOf-input",
     "Domain Bucket":"< 1K"
   },
   {
     "Class":"Predicate",
-    "Name":"http:\/\/schema.org\/alumniOf-output",
+    "Name":"https://schema.org/alumniOf-output",
     "Domain Bucket":"< 1K"
   },
   {
     "Class":"Predicate",
-    "Name":"http:\/\/schema.org\/amenityFeature",
+    "Name":"https://schema.org/amenityFeature",
     "Domain Bucket":"100K - 1M"
   },
   {
     "Class":"Predicate",
-    "Name":"http:\/\/schema.org\/amenityFeature-input",
+    "Name":"https://schema.org/amenityFeature-input",
     "Domain Bucket":"< 1K"
   },
   {
     "Class":"Predicate",
-    "Name":"http:\/\/schema.org\/amenityFeature-output",
+    "Name":"https://schema.org/amenityFeature-output",
     "Domain Bucket":"< 1K"
   },
   {
     "Class":"Predicate",
-    "Name":"http:\/\/schema.org\/amount",
+    "Name":"https://schema.org/amount",
     "Domain Bucket":"1K - 10K"
   },
   {
     "Class":"Predicate",
-    "Name":"http:\/\/schema.org\/amount-input",
+    "Name":"https://schema.org/amount-input",
     "Domain Bucket":"< 1K"
   },
   {
     "Class":"Predicate",
-    "Name":"http:\/\/schema.org\/amount-output",
+    "Name":"https://schema.org/amount-output",
     "Domain Bucket":"< 1K"
   },
   {
     "Class":"Predicate",
-    "Name":"http:\/\/schema.org\/amountOfThisGood",
+    "Name":"https://schema.org/amountOfThisGood",
     "Domain Bucket":"< 1K"
   },
   {
     "Class":"Predicate",
-    "Name":"http:\/\/schema.org\/amountOfThisGood-input",
+    "Name":"https://schema.org/amountOfThisGood-input",
     "Domain Bucket":"< 1K"
   },
   {
     "Class":"Predicate",
-    "Name":"http:\/\/schema.org\/amountOfThisGood-output",
+    "Name":"https://schema.org/amountOfThisGood-output",
     "Domain Bucket":"< 1K"
   },
   {
     "Class":"Predicate",
-    "Name":"http:\/\/schema.org\/announcementLocation",
+    "Name":"https://schema.org/announcementLocation",
     "Domain Bucket":"1K - 10K"
   },
   {
     "Class":"Predicate",
-    "Name":"http:\/\/schema.org\/announcementLocation-input",
+    "Name":"https://schema.org/announcementLocation-input",
     "Domain Bucket":"< 1K"
   },
   {
     "Class":"Predicate",
-    "Name":"http:\/\/schema.org\/announcementLocation-output",
+    "Name":"https://schema.org/announcementLocation-output",
     "Domain Bucket":"< 1K"
   },
   {
     "Class":"Predicate",
-    "Name":"http:\/\/schema.org\/annualPercentageRate",
+    "Name":"https://schema.org/annualPercentageRate",
     "Domain Bucket":"1K - 10K"
   },
   {
     "Class":"Predicate",
-    "Name":"http:\/\/schema.org\/annualPercentageRate-input",
+    "Name":"https://schema.org/annualPercentageRate-input",
     "Domain Bucket":"< 1K"
   },
   {
     "Class":"Predicate",
-    "Name":"http:\/\/schema.org\/annualPercentageRate-output",
+    "Name":"https://schema.org/annualPercentageRate-output",
     "Domain Bucket":"< 1K"
   },
   {
     "Class":"Predicate",
-    "Name":"http:\/\/schema.org\/answerCount",
+    "Name":"https://schema.org/answerCount",
     "Domain Bucket":"100K - 1M"
   },
   {
     "Class":"Predicate",
-    "Name":"http:\/\/schema.org\/answerCount-input",
+    "Name":"https://schema.org/answerCount-input",
     "Domain Bucket":"< 1K"
   },
   {
     "Class":"Predicate",
-    "Name":"http:\/\/schema.org\/answerCount-output",
+    "Name":"https://schema.org/answerCount-output",
     "Domain Bucket":"< 1K"
   },
   {
     "Class":"Predicate",
-    "Name":"http:\/\/schema.org\/answerExplanation",
+    "Name":"https://schema.org/answerExplanation",
     "Domain Bucket":"< 1K"
   },
   {
     "Class":"Predicate",
-    "Name":"http:\/\/schema.org\/answerExplanation-input",
+    "Name":"https://schema.org/answerExplanation-input",
     "Domain Bucket":"< 1K"
   },
   {
     "Class":"Predicate",
-    "Name":"http:\/\/schema.org\/answerExplanation-output",
+    "Name":"https://schema.org/answerExplanation-output",
     "Domain Bucket":"< 1K"
   },
   {
     "Class":"Predicate",
-    "Name":"http:\/\/schema.org\/antagonist",
+    "Name":"https://schema.org/antagonist",
     "Domain Bucket":"< 1K"
   },
   {
     "Class":"Predicate",
-    "Name":"http:\/\/schema.org\/antagonist-input",
+    "Name":"https://schema.org/antagonist-input",
     "Domain Bucket":"< 1K"
   },
   {
     "Class":"Predicate",
-    "Name":"http:\/\/schema.org\/antagonist-output",
+    "Name":"https://schema.org/antagonist-output",
     "Domain Bucket":"< 1K"
   },
   {
     "Class":"Predicate",
-    "Name":"http:\/\/schema.org\/appearance",
+    "Name":"https://schema.org/appearance",
     "Domain Bucket":"1K - 10K"
   },
   {
     "Class":"Predicate",
-    "Name":"http:\/\/schema.org\/appearance-input",
+    "Name":"https://schema.org/appearance-input",
     "Domain Bucket":"< 1K"
   },
   {
     "Class":"Predicate",
-    "Name":"http:\/\/schema.org\/appearance-output",
+    "Name":"https://schema.org/appearance-output",
     "Domain Bucket":"< 1K"
   },
   {
     "Class":"Predicate",
-    "Name":"http:\/\/schema.org\/applicableCountry",
+    "Name":"https://schema.org/applicableCountry",
     "Domain Bucket":"100K - 1M"
   },
   {
     "Class":"Predicate",
-    "Name":"http:\/\/schema.org\/applicableCountry-input",
+    "Name":"https://schema.org/applicableCountry-input",
     "Domain Bucket":"< 1K"
   },
   {
     "Class":"Predicate",
-    "Name":"http:\/\/schema.org\/applicableCountry-output",
+    "Name":"https://schema.org/applicableCountry-output",
     "Domain Bucket":"< 1K"
   },
   {
     "Class":"Predicate",
-    "Name":"http:\/\/schema.org\/applicableLocation",
+    "Name":"https://schema.org/applicableLocation",
     "Domain Bucket":"< 1K"
   },
   {
     "Class":"Predicate",
-    "Name":"http:\/\/schema.org\/applicableLocation-input",
+    "Name":"https://schema.org/applicableLocation-input",
     "Domain Bucket":"< 1K"
   },
   {
     "Class":"Predicate",
-    "Name":"http:\/\/schema.org\/applicableLocation-output",
+    "Name":"https://schema.org/applicableLocation-output",
     "Domain Bucket":"< 1K"
   },
   {
     "Class":"Predicate",
-    "Name":"http:\/\/schema.org\/applicantLocationRequirements",
+    "Name":"https://schema.org/applicantLocationRequirements",
     "Domain Bucket":"10K - 100K"
   },
   {
     "Class":"Predicate",
-    "Name":"http:\/\/schema.org\/applicantLocationRequirements-input",
+    "Name":"https://schema.org/applicantLocationRequirements-input",
     "Domain Bucket":"< 1K"
   },
   {
     "Class":"Predicate",
-    "Name":"http:\/\/schema.org\/applicantLocationRequirements-output",
+    "Name":"https://schema.org/applicantLocationRequirements-output",
     "Domain Bucket":"< 1K"
   },
   {
     "Class":"Predicate",
-    "Name":"http:\/\/schema.org\/application",
+    "Name":"https://schema.org/application",
     "Domain Bucket":"< 1K"
   },
   {
     "Class":"Predicate",
-    "Name":"http:\/\/schema.org\/application-input",
+    "Name":"https://schema.org/application-input",
     "Domain Bucket":"< 1K"
   },
   {
     "Class":"Predicate",
-    "Name":"http:\/\/schema.org\/application-output",
+    "Name":"https://schema.org/application-output",
     "Domain Bucket":"< 1K"
   },
   {
     "Class":"Predicate",
-    "Name":"http:\/\/schema.org\/applicationCategory",
+    "Name":"https://schema.org/applicationCategory",
     "Domain Bucket":"1M - 10M"
   },
   {
     "Class":"Predicate",
-    "Name":"http:\/\/schema.org\/applicationCategory-input",
+    "Name":"https://schema.org/applicationCategory-input",
     "Domain Bucket":"< 1K"
   },
   {
     "Class":"Predicate",
-    "Name":"http:\/\/schema.org\/applicationCategory-output",
+    "Name":"https://schema.org/applicationCategory-output",
     "Domain Bucket":"< 1K"
   },
   {
     "Class":"Predicate",
-    "Name":"http:\/\/schema.org\/applicationContact",
+    "Name":"https://schema.org/applicationContact",
     "Domain Bucket":"1K - 10K"
   },
   {
     "Class":"Predicate",
-    "Name":"http:\/\/schema.org\/applicationContact-input",
+    "Name":"https://schema.org/applicationContact-input",
     "Domain Bucket":"< 1K"
   },
   {
     "Class":"Predicate",
-    "Name":"http:\/\/schema.org\/applicationContact-output",
+    "Name":"https://schema.org/applicationContact-output",
     "Domain Bucket":"< 1K"
   },
   {
     "Class":"Predicate",
-    "Name":"http:\/\/schema.org\/applicationDeadline",
+    "Name":"https://schema.org/applicationDeadline",
     "Domain Bucket":"< 1K"
   },
   {
     "Class":"Predicate",
-    "Name":"http:\/\/schema.org\/applicationDeadline-input",
+    "Name":"https://schema.org/applicationDeadline-input",
     "Domain Bucket":"< 1K"
   },
   {
     "Class":"Predicate",
-    "Name":"http:\/\/schema.org\/applicationDeadline-output",
+    "Name":"https://schema.org/applicationDeadline-output",
     "Domain Bucket":"< 1K"
   },
   {
     "Class":"Predicate",
-    "Name":"http:\/\/schema.org\/applicationStartDate",
+    "Name":"https://schema.org/applicationStartDate",
     "Domain Bucket":"< 1K"
   },
   {
     "Class":"Predicate",
-    "Name":"http:\/\/schema.org\/applicationStartDate-input",
+    "Name":"https://schema.org/applicationStartDate-input",
     "Domain Bucket":"< 1K"
   },
   {
     "Class":"Predicate",
-    "Name":"http:\/\/schema.org\/applicationStartDate-output",
+    "Name":"https://schema.org/applicationStartDate-output",
     "Domain Bucket":"< 1K"
   },
   {
     "Class":"Predicate",
-    "Name":"http:\/\/schema.org\/applicationSubCategory",
+    "Name":"https://schema.org/applicationSubCategory",
     "Domain Bucket":"10K - 100K"
   },
   {
     "Class":"Predicate",
-    "Name":"http:\/\/schema.org\/applicationSubCategory-input",
+    "Name":"https://schema.org/applicationSubCategory-input",
     "Domain Bucket":"< 1K"
   },
   {
     "Class":"Predicate",
-    "Name":"http:\/\/schema.org\/applicationSubCategory-output",
+    "Name":"https://schema.org/applicationSubCategory-output",
     "Domain Bucket":"< 1K"
   },
   {
     "Class":"Predicate",
-    "Name":"http:\/\/schema.org\/applicationSuite",
+    "Name":"https://schema.org/applicationSuite",
     "Domain Bucket":"1K - 10K"
   },
   {
     "Class":"Predicate",
-    "Name":"http:\/\/schema.org\/applicationSuite-input",
+    "Name":"https://schema.org/applicationSuite-input",
     "Domain Bucket":"< 1K"
   },
   {
     "Class":"Predicate",
-    "Name":"http:\/\/schema.org\/applicationSuite-output",
+    "Name":"https://schema.org/applicationSuite-output",
     "Domain Bucket":"< 1K"
   },
   {
     "Class":"Predicate",
-    "Name":"http:\/\/schema.org\/appliesToDeliveryMethod",
+    "Name":"https://schema.org/appliesToDeliveryMethod",
     "Domain Bucket":"10K - 100K"
   },
   {
     "Class":"Predicate",
-    "Name":"http:\/\/schema.org\/appliesToDeliveryMethod-input",
+    "Name":"https://schema.org/appliesToDeliveryMethod-input",
     "Domain Bucket":"< 1K"
   },
   {
     "Class":"Predicate",
-    "Name":"http:\/\/schema.org\/appliesToDeliveryMethod-output",
+    "Name":"https://schema.org/appliesToDeliveryMethod-output",
     "Domain Bucket":"< 1K"
   },
   {
     "Class":"Predicate",
-    "Name":"http:\/\/schema.org\/appliesToPaymentMethod",
+    "Name":"https://schema.org/appliesToPaymentMethod",
     "Domain Bucket":"< 1K"
   },
   {
     "Class":"Predicate",
-    "Name":"http:\/\/schema.org\/appliesToPaymentMethod-input",
+    "Name":"https://schema.org/appliesToPaymentMethod-input",
     "Domain Bucket":"< 1K"
   },
   {
     "Class":"Predicate",
-    "Name":"http:\/\/schema.org\/appliesToPaymentMethod-output",
+    "Name":"https://schema.org/appliesToPaymentMethod-output",
     "Domain Bucket":"< 1K"
   },
   {
     "Class":"Predicate",
-    "Name":"http:\/\/schema.org\/archiveHeld",
+    "Name":"https://schema.org/archiveHeld",
     "Domain Bucket":"< 1K"
   },
   {
     "Class":"Predicate",
-    "Name":"http:\/\/schema.org\/archiveHeld-input",
+    "Name":"https://schema.org/archiveHeld-input",
     "Domain Bucket":"< 1K"
   },
   {
     "Class":"Predicate",
-    "Name":"http:\/\/schema.org\/archiveHeld-output",
+    "Name":"https://schema.org/archiveHeld-output",
     "Domain Bucket":"< 1K"
   },
   {
     "Class":"Predicate",
-    "Name":"http:\/\/schema.org\/archivedAt",
+    "Name":"https://schema.org/archivedAt",
     "Domain Bucket":"< 1K"
   },
   {
     "Class":"Predicate",
-    "Name":"http:\/\/schema.org\/archivedAt-input",
+    "Name":"https://schema.org/archivedAt-input",
     "Domain Bucket":"< 1K"
   },
   {
     "Class":"Predicate",
-    "Name":"http:\/\/schema.org\/archivedAt-output",
+    "Name":"https://schema.org/archivedAt-output",
     "Domain Bucket":"< 1K"
   },
   {
     "Class":"Predicate",
-    "Name":"http:\/\/schema.org\/area",
+    "Name":"https://schema.org/area",
     "Domain Bucket":"1K - 10K"
   },
   {
     "Class":"Predicate",
-    "Name":"http:\/\/schema.org\/area-input",
+    "Name":"https://schema.org/area-input",
     "Domain Bucket":"< 1K"
   },
   {
     "Class":"Predicate",
-    "Name":"http:\/\/schema.org\/area-output",
+    "Name":"https://schema.org/area-output",
     "Domain Bucket":"< 1K"
   },
   {
     "Class":"Predicate",
-    "Name":"http:\/\/schema.org\/areaServed",
+    "Name":"https://schema.org/areaServed",
     "Domain Bucket":"1M - 10M"
   },
   {
     "Class":"Predicate",
-    "Name":"http:\/\/schema.org\/areaServed-input",
+    "Name":"https://schema.org/areaServed-input",
     "Domain Bucket":"< 1K"
   },
   {
     "Class":"Predicate",
-    "Name":"http:\/\/schema.org\/areaServed-output",
+    "Name":"https://schema.org/areaServed-output",
     "Domain Bucket":"< 1K"
   },
   {
     "Class":"Predicate",
-    "Name":"http:\/\/schema.org\/arrivalAirport",
+    "Name":"https://schema.org/arrivalAirport",
     "Domain Bucket":"1K - 10K"
   },
   {
     "Class":"Predicate",
-    "Name":"http:\/\/schema.org\/arrivalAirport-input",
+    "Name":"https://schema.org/arrivalAirport-input",
     "Domain Bucket":"< 1K"
   },
   {
     "Class":"Predicate",
-    "Name":"http:\/\/schema.org\/arrivalAirport-output",
+    "Name":"https://schema.org/arrivalAirport-output",
     "Domain Bucket":"< 1K"
   },
   {
     "Class":"Predicate",
-    "Name":"http:\/\/schema.org\/arrivalBoatTerminal",
+    "Name":"https://schema.org/arrivalBoatTerminal",
     "Domain Bucket":"< 1K"
   },
   {
     "Class":"Predicate",
-    "Name":"http:\/\/schema.org\/arrivalBoatTerminal-input",
+    "Name":"https://schema.org/arrivalBoatTerminal-input",
     "Domain Bucket":"< 1K"
   },
   {
     "Class":"Predicate",
-    "Name":"http:\/\/schema.org\/arrivalBoatTerminal-output",
+    "Name":"https://schema.org/arrivalBoatTerminal-output",
     "Domain Bucket":"< 1K"
   },
   {
     "Class":"Predicate",
-    "Name":"http:\/\/schema.org\/arrivalBusStop",
+    "Name":"https://schema.org/arrivalBusStop",
     "Domain Bucket":"< 1K"
   },
   {
     "Class":"Predicate",
-    "Name":"http:\/\/schema.org\/arrivalBusStop-input",
+    "Name":"https://schema.org/arrivalBusStop-input",
     "Domain Bucket":"< 1K"
   },
   {
     "Class":"Predicate",
-    "Name":"http:\/\/schema.org\/arrivalBusStop-output",
+    "Name":"https://schema.org/arrivalBusStop-output",
     "Domain Bucket":"< 1K"
   },
   {
     "Class":"Predicate",
-    "Name":"http:\/\/schema.org\/arrivalGate",
+    "Name":"https://schema.org/arrivalGate",
     "Domain Bucket":"< 1K"
   },
   {
     "Class":"Predicate",
-    "Name":"http:\/\/schema.org\/arrivalGate-input",
+    "Name":"https://schema.org/arrivalGate-input",
     "Domain Bucket":"< 1K"
   },
   {
     "Class":"Predicate",
-    "Name":"http:\/\/schema.org\/arrivalGate-output",
+    "Name":"https://schema.org/arrivalGate-output",
     "Domain Bucket":"< 1K"
   },
   {
     "Class":"Predicate",
-    "Name":"http:\/\/schema.org\/arrivalPlatform",
+    "Name":"https://schema.org/arrivalPlatform",
     "Domain Bucket":"< 1K"
   },
   {
     "Class":"Predicate",
-    "Name":"http:\/\/schema.org\/arrivalPlatform-input",
+    "Name":"https://schema.org/arrivalPlatform-input",
     "Domain Bucket":"< 1K"
   },
   {
     "Class":"Predicate",
-    "Name":"http:\/\/schema.org\/arrivalPlatform-output",
+    "Name":"https://schema.org/arrivalPlatform-output",
     "Domain Bucket":"< 1K"
   },
   {
     "Class":"Predicate",
-    "Name":"http:\/\/schema.org\/arrivalStation",
+    "Name":"https://schema.org/arrivalStation",
     "Domain Bucket":"< 1K"
   },
   {
     "Class":"Predicate",
-    "Name":"http:\/\/schema.org\/arrivalStation-input",
+    "Name":"https://schema.org/arrivalStation-input",
     "Domain Bucket":"< 1K"
   },
   {
     "Class":"Predicate",
-    "Name":"http:\/\/schema.org\/arrivalStation-output",
+    "Name":"https://schema.org/arrivalStation-output",
     "Domain Bucket":"< 1K"
   },
   {
     "Class":"Predicate",
-    "Name":"http:\/\/schema.org\/arrivalTerminal",
+    "Name":"https://schema.org/arrivalTerminal",
     "Domain Bucket":"< 1K"
   },
   {
     "Class":"Predicate",
-    "Name":"http:\/\/schema.org\/arrivalTerminal-input",
+    "Name":"https://schema.org/arrivalTerminal-input",
     "Domain Bucket":"< 1K"
   },
   {
     "Class":"Predicate",
-    "Name":"http:\/\/schema.org\/arrivalTerminal-output",
+    "Name":"https://schema.org/arrivalTerminal-output",
     "Domain Bucket":"< 1K"
   },
   {
     "Class":"Predicate",
-    "Name":"http:\/\/schema.org\/arrivalTime",
+    "Name":"https://schema.org/arrivalTime",
     "Domain Bucket":"1K - 10K"
   },
   {
     "Class":"Predicate",
-    "Name":"http:\/\/schema.org\/arrivalTime-input",
+    "Name":"https://schema.org/arrivalTime-input",
     "Domain Bucket":"< 1K"
   },
   {
     "Class":"Predicate",
-    "Name":"http:\/\/schema.org\/arrivalTime-output",
+    "Name":"https://schema.org/arrivalTime-output",
     "Domain Bucket":"< 1K"
   },
   {
     "Class":"Predicate",
-    "Name":"http:\/\/schema.org\/artEdition",
+    "Name":"https://schema.org/artEdition",
     "Domain Bucket":"< 1K"
   },
   {
     "Class":"Predicate",
-    "Name":"http:\/\/schema.org\/artEdition-input",
+    "Name":"https://schema.org/artEdition-input",
     "Domain Bucket":"< 1K"
   },
   {
     "Class":"Predicate",
-    "Name":"http:\/\/schema.org\/artEdition-output",
+    "Name":"https://schema.org/artEdition-output",
     "Domain Bucket":"< 1K"
   },
   {
     "Class":"Predicate",
-    "Name":"http:\/\/schema.org\/artMedium",
+    "Name":"https://schema.org/artMedium",
     "Domain Bucket":"1K - 10K"
   },
   {
     "Class":"Predicate",
-    "Name":"http:\/\/schema.org\/artMedium-input",
+    "Name":"https://schema.org/artMedium-input",
     "Domain Bucket":"< 1K"
   },
   {
     "Class":"Predicate",
-    "Name":"http:\/\/schema.org\/artMedium-output",
+    "Name":"https://schema.org/artMedium-output",
     "Domain Bucket":"< 1K"
   },
   {
     "Class":"Predicate",
-    "Name":"http:\/\/schema.org\/arterialBranch",
+    "Name":"https://schema.org/arterialBranch",
     "Domain Bucket":"< 1K"
   },
   {
     "Class":"Predicate",
-    "Name":"http:\/\/schema.org\/arterialBranch-input",
+    "Name":"https://schema.org/arterialBranch-input",
     "Domain Bucket":"< 1K"
   },
   {
     "Class":"Predicate",
-    "Name":"http:\/\/schema.org\/arterialBranch-output",
+    "Name":"https://schema.org/arterialBranch-output",
     "Domain Bucket":"< 1K"
   },
   {
     "Class":"Predicate",
-    "Name":"http:\/\/schema.org\/artform",
+    "Name":"https://schema.org/artform",
     "Domain Bucket":"1K - 10K"
   },
   {
     "Class":"Predicate",
-    "Name":"http:\/\/schema.org\/artform-input",
+    "Name":"https://schema.org/artform-input",
     "Domain Bucket":"< 1K"
   },
   {
     "Class":"Predicate",
-    "Name":"http:\/\/schema.org\/artform-output",
+    "Name":"https://schema.org/artform-output",
     "Domain Bucket":"< 1K"
   },
   {
     "Class":"Predicate",
-    "Name":"http:\/\/schema.org\/articleBody",
+    "Name":"https://schema.org/articleBody",
     "Domain Bucket":"1M - 10M"
   },
   {
     "Class":"Predicate",
-    "Name":"http:\/\/schema.org\/articleBody-input",
+    "Name":"https://schema.org/articleBody-input",
     "Domain Bucket":"< 1K"
   },
   {
     "Class":"Predicate",
-    "Name":"http:\/\/schema.org\/articleBody-output",
+    "Name":"https://schema.org/articleBody-output",
     "Domain Bucket":"< 1K"
   },
   {
     "Class":"Predicate",
-    "Name":"http:\/\/schema.org\/articleSection",
+    "Name":"https://schema.org/articleSection",
     "Domain Bucket":"1M - 10M"
   },
   {
     "Class":"Predicate",
-    "Name":"http:\/\/schema.org\/articleSection-input",
+    "Name":"https://schema.org/articleSection-input",
     "Domain Bucket":"< 1K"
   },
   {
     "Class":"Predicate",
-    "Name":"http:\/\/schema.org\/articleSection-output",
+    "Name":"https://schema.org/articleSection-output",
     "Domain Bucket":"< 1K"
   },
   {
     "Class":"Predicate",
-    "Name":"http:\/\/schema.org\/artist",
+    "Name":"https://schema.org/artist",
     "Domain Bucket":"1K - 10K"
   },
   {
     "Class":"Predicate",
-    "Name":"http:\/\/schema.org\/artist-input",
+    "Name":"https://schema.org/artist-input",
     "Domain Bucket":"< 1K"
   },
   {
     "Class":"Predicate",
-    "Name":"http:\/\/schema.org\/artist-output",
+    "Name":"https://schema.org/artist-output",
     "Domain Bucket":"< 1K"
   },
   {
     "Class":"Predicate",
-    "Name":"http:\/\/schema.org\/artworkSurface",
+    "Name":"https://schema.org/artworkSurface",
     "Domain Bucket":"< 1K"
   },
   {
     "Class":"Predicate",
-    "Name":"http:\/\/schema.org\/artworkSurface-input",
+    "Name":"https://schema.org/artworkSurface-input",
     "Domain Bucket":"< 1K"
   },
   {
     "Class":"Predicate",
-    "Name":"http:\/\/schema.org\/artworkSurface-output",
+    "Name":"https://schema.org/artworkSurface-output",
     "Domain Bucket":"< 1K"
   },
   {
     "Class":"Predicate",
-    "Name":"http:\/\/schema.org\/asin",
+    "Name":"https://schema.org/asin",
     "Domain Bucket":"< 1K"
   },
   {
     "Class":"Predicate",
-    "Name":"http:\/\/schema.org\/asin-input",
+    "Name":"https://schema.org/asin-input",
     "Domain Bucket":"< 1K"
   },
   {
     "Class":"Predicate",
-    "Name":"http:\/\/schema.org\/asin-output",
+    "Name":"https://schema.org/asin-output",
     "Domain Bucket":"< 1K"
   },
   {
     "Class":"Predicate",
-    "Name":"http:\/\/schema.org\/aspect",
+    "Name":"https://schema.org/aspect",
     "Domain Bucket":"< 1K"
   },
   {
     "Class":"Predicate",
-    "Name":"http:\/\/schema.org\/aspect-input",
+    "Name":"https://schema.org/aspect-input",
     "Domain Bucket":"< 1K"
   },
   {
     "Class":"Predicate",
-    "Name":"http:\/\/schema.org\/aspect-output",
+    "Name":"https://schema.org/aspect-output",
     "Domain Bucket":"< 1K"
   },
   {
     "Class":"Predicate",
-    "Name":"http:\/\/schema.org\/assembly",
+    "Name":"https://schema.org/assembly",
     "Domain Bucket":"< 1K"
   },
   {
     "Class":"Predicate",
-    "Name":"http:\/\/schema.org\/assembly-input",
+    "Name":"https://schema.org/assembly-input",
     "Domain Bucket":"< 1K"
   },
   {
     "Class":"Predicate",
-    "Name":"http:\/\/schema.org\/assembly-output",
+    "Name":"https://schema.org/assembly-output",
     "Domain Bucket":"< 1K"
   },
   {
     "Class":"Predicate",
-    "Name":"http:\/\/schema.org\/assemblyVersion",
+    "Name":"https://schema.org/assemblyVersion",
     "Domain Bucket":"< 1K"
   },
   {
     "Class":"Predicate",
-    "Name":"http:\/\/schema.org\/assemblyVersion-input",
+    "Name":"https://schema.org/assemblyVersion-input",
     "Domain Bucket":"< 1K"
   },
   {
     "Class":"Predicate",
-    "Name":"http:\/\/schema.org\/assemblyVersion-output",
+    "Name":"https://schema.org/assemblyVersion-output",
     "Domain Bucket":"< 1K"
   },
   {
     "Class":"Predicate",
-    "Name":"http:\/\/schema.org\/assesses",
+    "Name":"https://schema.org/assesses",
     "Domain Bucket":"1K - 10K"
   },
   {
     "Class":"Predicate",
-    "Name":"http:\/\/schema.org\/assesses-input",
+    "Name":"https://schema.org/assesses-input",
     "Domain Bucket":"< 1K"
   },
   {
     "Class":"Predicate",
-    "Name":"http:\/\/schema.org\/assesses-output",
+    "Name":"https://schema.org/assesses-output",
     "Domain Bucket":"< 1K"
   },
   {
     "Class":"Predicate",
-    "Name":"http:\/\/schema.org\/associatedAnatomy",
+    "Name":"https://schema.org/associatedAnatomy",
     "Domain Bucket":"1K - 10K"
   },
   {
     "Class":"Predicate",
-    "Name":"http:\/\/schema.org\/associatedAnatomy-input",
+    "Name":"https://schema.org/associatedAnatomy-input",
     "Domain Bucket":"< 1K"
   },
   {
     "Class":"Predicate",
-    "Name":"http:\/\/schema.org\/associatedAnatomy-output",
+    "Name":"https://schema.org/associatedAnatomy-output",
     "Domain Bucket":"< 1K"
   },
   {
     "Class":"Predicate",
-    "Name":"http:\/\/schema.org\/associatedArticle",
+    "Name":"https://schema.org/associatedArticle",
     "Domain Bucket":"1K - 10K"
   },
   {
     "Class":"Predicate",
-    "Name":"http:\/\/schema.org\/associatedArticle-input",
+    "Name":"https://schema.org/associatedArticle-input",
     "Domain Bucket":"< 1K"
   },
   {
     "Class":"Predicate",
-    "Name":"http:\/\/schema.org\/associatedArticle-output",
+    "Name":"https://schema.org/associatedArticle-output",
     "Domain Bucket":"< 1K"
   },
   {
     "Class":"Predicate",
-    "Name":"http:\/\/schema.org\/associatedClaimReview",
+    "Name":"https://schema.org/associatedClaimReview",
     "Domain Bucket":"< 1K"
   },
   {
     "Class":"Predicate",
-    "Name":"http:\/\/schema.org\/associatedClaimReview-input",
+    "Name":"https://schema.org/associatedClaimReview-input",
     "Domain Bucket":"< 1K"
   },
   {
     "Class":"Predicate",
-    "Name":"http:\/\/schema.org\/associatedClaimReview-output",
+    "Name":"https://schema.org/associatedClaimReview-output",
     "Domain Bucket":"< 1K"
   },
   {
     "Class":"Predicate",
-    "Name":"http:\/\/schema.org\/associatedDisease",
+    "Name":"https://schema.org/associatedDisease",
     "Domain Bucket":"< 1K"
   },
   {
     "Class":"Predicate",
-    "Name":"http:\/\/schema.org\/associatedDisease-input",
+    "Name":"https://schema.org/associatedDisease-input",
     "Domain Bucket":"< 1K"
   },
   {
     "Class":"Predicate",
-    "Name":"http:\/\/schema.org\/associatedDisease-output",
+    "Name":"https://schema.org/associatedDisease-output",
     "Domain Bucket":"< 1K"
   },
   {
     "Class":"Predicate",
-    "Name":"http:\/\/schema.org\/associatedMedia",
+    "Name":"https://schema.org/associatedMedia",
     "Domain Bucket":"100K - 1M"
   },
   {
     "Class":"Predicate",
-    "Name":"http:\/\/schema.org\/associatedMedia-input",
+    "Name":"https://schema.org/associatedMedia-input",
     "Domain Bucket":"< 1K"
   },
   {
     "Class":"Predicate",
-    "Name":"http:\/\/schema.org\/associatedMedia-output",
+    "Name":"https://schema.org/associatedMedia-output",
     "Domain Bucket":"< 1K"
   },
   {
     "Class":"Predicate",
-    "Name":"http:\/\/schema.org\/associatedMediaReview",
+    "Name":"https://schema.org/associatedMediaReview",
     "Domain Bucket":"< 1K"
   },
   {
     "Class":"Predicate",
-    "Name":"http:\/\/schema.org\/associatedMediaReview-input",
+    "Name":"https://schema.org/associatedMediaReview-input",
     "Domain Bucket":"< 1K"
   },
   {
     "Class":"Predicate",
-    "Name":"http:\/\/schema.org\/associatedMediaReview-output",
+    "Name":"https://schema.org/associatedMediaReview-output",
     "Domain Bucket":"< 1K"
   },
   {
     "Class":"Predicate",
-    "Name":"http:\/\/schema.org\/associatedPathophysiology",
+    "Name":"https://schema.org/associatedPathophysiology",
     "Domain Bucket":"< 1K"
   },
   {
     "Class":"Predicate",
-    "Name":"http:\/\/schema.org\/associatedPathophysiology-input",
+    "Name":"https://schema.org/associatedPathophysiology-input",
     "Domain Bucket":"< 1K"
   },
   {
     "Class":"Predicate",
-    "Name":"http:\/\/schema.org\/associatedPathophysiology-output",
+    "Name":"https://schema.org/associatedPathophysiology-output",
     "Domain Bucket":"< 1K"
   },
   {
     "Class":"Predicate",
-    "Name":"http:\/\/schema.org\/associatedReview",
+    "Name":"https://schema.org/associatedReview",
     "Domain Bucket":"< 1K"
   },
   {
     "Class":"Predicate",
-    "Name":"http:\/\/schema.org\/associatedReview-input",
+    "Name":"https://schema.org/associatedReview-input",
     "Domain Bucket":"< 1K"
   },
   {
     "Class":"Predicate",
-    "Name":"http:\/\/schema.org\/associatedReview-output",
+    "Name":"https://schema.org/associatedReview-output",
     "Domain Bucket":"< 1K"
   },
   {
     "Class":"Predicate",
-    "Name":"http:\/\/schema.org\/athlete",
+    "Name":"https://schema.org/athlete",
     "Domain Bucket":"< 1K"
   },
   {
     "Class":"Predicate",
-    "Name":"http:\/\/schema.org\/athlete-input",
+    "Name":"https://schema.org/athlete-input",
     "Domain Bucket":"< 1K"
   },
   {
     "Class":"Predicate",
-    "Name":"http:\/\/schema.org\/athlete-output",
+    "Name":"https://schema.org/athlete-output",
     "Domain Bucket":"< 1K"
   },
   {
     "Class":"Predicate",
-    "Name":"http:\/\/schema.org\/attendee",
+    "Name":"https://schema.org/attendee",
     "Domain Bucket":"1K - 10K"
   },
   {
     "Class":"Predicate",
-    "Name":"http:\/\/schema.org\/attendee-input",
+    "Name":"https://schema.org/attendee-input",
     "Domain Bucket":"< 1K"
   },
   {
     "Class":"Predicate",
-    "Name":"http:\/\/schema.org\/attendee-output",
+    "Name":"https://schema.org/attendee-output",
     "Domain Bucket":"< 1K"
   },
   {
     "Class":"Predicate",
-    "Name":"http:\/\/schema.org\/attendees",
+    "Name":"https://schema.org/attendees",
     "Domain Bucket":"< 1K"
   },
   {
     "Class":"Predicate",
-    "Name":"http:\/\/schema.org\/attendees-input",
+    "Name":"https://schema.org/attendees-input",
     "Domain Bucket":"< 1K"
   },
   {
     "Class":"Predicate",
-    "Name":"http:\/\/schema.org\/attendees-output",
+    "Name":"https://schema.org/attendees-output",
     "Domain Bucket":"< 1K"
   },
   {
     "Class":"Predicate",
-    "Name":"http:\/\/schema.org\/audience",
+    "Name":"https://schema.org/audience",
     "Domain Bucket":"100K - 1M"
   },
   {
     "Class":"Predicate",
-    "Name":"http:\/\/schema.org\/audience-input",
+    "Name":"https://schema.org/audience-input",
     "Domain Bucket":"< 1K"
   },
   {
     "Class":"Predicate",
-    "Name":"http:\/\/schema.org\/audience-output",
+    "Name":"https://schema.org/audience-output",
     "Domain Bucket":"< 1K"
   },
   {
     "Class":"Predicate",
-    "Name":"http:\/\/schema.org\/audienceType",
+    "Name":"https://schema.org/audienceType",
     "Domain Bucket":"100K - 1M"
   },
   {
     "Class":"Predicate",
-    "Name":"http:\/\/schema.org\/audienceType-input",
+    "Name":"https://schema.org/audienceType-input",
     "Domain Bucket":"< 1K"
   },
   {
     "Class":"Predicate",
-    "Name":"http:\/\/schema.org\/audienceType-output",
+    "Name":"https://schema.org/audienceType-output",
     "Domain Bucket":"< 1K"
   },
   {
     "Class":"Predicate",
-    "Name":"http:\/\/schema.org\/audio",
+    "Name":"https://schema.org/audio",
     "Domain Bucket":"10K - 100K"
   },
   {
     "Class":"Predicate",
-    "Name":"http:\/\/schema.org\/audio-input",
+    "Name":"https://schema.org/audio-input",
     "Domain Bucket":"< 1K"
   },
   {
     "Class":"Predicate",
-    "Name":"http:\/\/schema.org\/audio-output",
+    "Name":"https://schema.org/audio-output",
     "Domain Bucket":"< 1K"
   },
   {
     "Class":"Predicate",
-    "Name":"http:\/\/schema.org\/auditDate",
+    "Name":"https://schema.org/auditDate",
     "Domain Bucket":"< 1K"
   },
   {
     "Class":"Predicate",
-    "Name":"http:\/\/schema.org\/auditDate-input",
+    "Name":"https://schema.org/auditDate-input",
     "Domain Bucket":"< 1K"
   },
   {
     "Class":"Predicate",
-    "Name":"http:\/\/schema.org\/auditDate-output",
+    "Name":"https://schema.org/auditDate-output",
     "Domain Bucket":"< 1K"
   },
   {
     "Class":"Predicate",
-    "Name":"http:\/\/schema.org\/authenticator",
+    "Name":"https://schema.org/authenticator",
     "Domain Bucket":"< 1K"
   },
   {
     "Class":"Predicate",
-    "Name":"http:\/\/schema.org\/authenticator-input",
+    "Name":"https://schema.org/authenticator-input",
     "Domain Bucket":"< 1K"
   },
   {
     "Class":"Predicate",
-    "Name":"http:\/\/schema.org\/authenticator-output",
+    "Name":"https://schema.org/authenticator-output",
     "Domain Bucket":"< 1K"
   },
   {
     "Class":"Predicate",
-    "Name":"http:\/\/schema.org\/author",
+    "Name":"https://schema.org/author",
     "Domain Bucket":"10M+"
   },
   {
     "Class":"Predicate",
-    "Name":"http:\/\/schema.org\/author-input",
+    "Name":"https://schema.org/author-input",
     "Domain Bucket":"< 1K"
   },
   {
     "Class":"Predicate",
-    "Name":"http:\/\/schema.org\/author-output",
+    "Name":"https://schema.org/author-output",
     "Domain Bucket":"< 1K"
   },
   {
     "Class":"Predicate",
-    "Name":"http:\/\/schema.org\/availability",
+    "Name":"https://schema.org/availability",
     "Domain Bucket":"10M+"
   },
   {
     "Class":"Predicate",
-    "Name":"http:\/\/schema.org\/availability-input",
+    "Name":"https://schema.org/availability-input",
     "Domain Bucket":"< 1K"
   },
   {
     "Class":"Predicate",
-    "Name":"http:\/\/schema.org\/availability-output",
+    "Name":"https://schema.org/availability-output",
     "Domain Bucket":"< 1K"
   },
   {
     "Class":"Predicate",
-    "Name":"http:\/\/schema.org\/availabilityEnds",
+    "Name":"https://schema.org/availabilityEnds",
     "Domain Bucket":"1K - 10K"
   },
   {
     "Class":"Predicate",
-    "Name":"http:\/\/schema.org\/availabilityEnds-input",
+    "Name":"https://schema.org/availabilityEnds-input",
     "Domain Bucket":"< 1K"
   },
   {
     "Class":"Predicate",
-    "Name":"http:\/\/schema.org\/availabilityEnds-output",
+    "Name":"https://schema.org/availabilityEnds-output",
     "Domain Bucket":"< 1K"
   },
   {
     "Class":"Predicate",
-    "Name":"http:\/\/schema.org\/availabilityStarts",
+    "Name":"https://schema.org/availabilityStarts",
     "Domain Bucket":"10K - 100K"
   },
   {
     "Class":"Predicate",
-    "Name":"http:\/\/schema.org\/availabilityStarts-input",
+    "Name":"https://schema.org/availabilityStarts-input",
     "Domain Bucket":"< 1K"
   },
   {
     "Class":"Predicate",
-    "Name":"http:\/\/schema.org\/availabilityStarts-output",
+    "Name":"https://schema.org/availabilityStarts-output",
     "Domain Bucket":"< 1K"
   },
   {
     "Class":"Predicate",
-    "Name":"http:\/\/schema.org\/availableAtOrFrom",
+    "Name":"https://schema.org/availableAtOrFrom",
     "Domain Bucket":"10K - 100K"
   },
   {
     "Class":"Predicate",
-    "Name":"http:\/\/schema.org\/availableAtOrFrom-input",
+    "Name":"https://schema.org/availableAtOrFrom-input",
     "Domain Bucket":"< 1K"
   },
   {
     "Class":"Predicate",
-    "Name":"http:\/\/schema.org\/availableAtOrFrom-output",
+    "Name":"https://schema.org/availableAtOrFrom-output",
     "Domain Bucket":"< 1K"
   },
   {
     "Class":"Predicate",
-    "Name":"http:\/\/schema.org\/availableChannel",
+    "Name":"https://schema.org/availableChannel",
     "Domain Bucket":"100K - 1M"
   },
   {
     "Class":"Predicate",
-    "Name":"http:\/\/schema.org\/availableChannel-input",
+    "Name":"https://schema.org/availableChannel-input",
     "Domain Bucket":"< 1K"
   },
   {
     "Class":"Predicate",
-    "Name":"http:\/\/schema.org\/availableChannel-output",
+    "Name":"https://schema.org/availableChannel-output",
     "Domain Bucket":"< 1K"
   },
   {
     "Class":"Predicate",
-    "Name":"http:\/\/schema.org\/availableDeliveryMethod",
+    "Name":"https://schema.org/availableDeliveryMethod",
     "Domain Bucket":"10K - 100K"
   },
   {
     "Class":"Predicate",
-    "Name":"http:\/\/schema.org\/availableDeliveryMethod-input",
+    "Name":"https://schema.org/availableDeliveryMethod-input",
     "Domain Bucket":"< 1K"
   },
   {
     "Class":"Predicate",
-    "Name":"http:\/\/schema.org\/availableDeliveryMethod-output",
+    "Name":"https://schema.org/availableDeliveryMethod-output",
     "Domain Bucket":"< 1K"
   },
   {
     "Class":"Predicate",
-    "Name":"http:\/\/schema.org\/availableFrom",
+    "Name":"https://schema.org/availableFrom",
     "Domain Bucket":"< 1K"
   },
   {
     "Class":"Predicate",
-    "Name":"http:\/\/schema.org\/availableFrom-input",
+    "Name":"https://schema.org/availableFrom-input",
     "Domain Bucket":"< 1K"
   },
   {
     "Class":"Predicate",
-    "Name":"http:\/\/schema.org\/availableFrom-output",
+    "Name":"https://schema.org/availableFrom-output",
     "Domain Bucket":"< 1K"
   },
   {
     "Class":"Predicate",
-    "Name":"http:\/\/schema.org\/availableIn",
+    "Name":"https://schema.org/availableIn",
     "Domain Bucket":"< 1K"
   },
   {
     "Class":"Predicate",
-    "Name":"http:\/\/schema.org\/availableIn-input",
+    "Name":"https://schema.org/availableIn-input",
     "Domain Bucket":"< 1K"
   },
   {
     "Class":"Predicate",
-    "Name":"http:\/\/schema.org\/availableIn-output",
+    "Name":"https://schema.org/availableIn-output",
     "Domain Bucket":"< 1K"
   },
   {
     "Class":"Predicate",
-    "Name":"http:\/\/schema.org\/availableLanguage",
+    "Name":"https://schema.org/availableLanguage",
     "Domain Bucket":"1M - 10M"
   },
   {
     "Class":"Predicate",
-    "Name":"http:\/\/schema.org\/availableLanguage-input",
+    "Name":"https://schema.org/availableLanguage-input",
     "Domain Bucket":"< 1K"
   },
   {
     "Class":"Predicate",
-    "Name":"http:\/\/schema.org\/availableLanguage-output",
+    "Name":"https://schema.org/availableLanguage-output",
     "Domain Bucket":"< 1K"
   },
   {
     "Class":"Predicate",
-    "Name":"http:\/\/schema.org\/availableOnDevice",
+    "Name":"https://schema.org/availableOnDevice",
     "Domain Bucket":"1K - 10K"
   },
   {
     "Class":"Predicate",
-    "Name":"http:\/\/schema.org\/availableOnDevice-input",
+    "Name":"https://schema.org/availableOnDevice-input",
     "Domain Bucket":"< 1K"
   },
   {
     "Class":"Predicate",
-    "Name":"http:\/\/schema.org\/availableOnDevice-output",
+    "Name":"https://schema.org/availableOnDevice-output",
     "Domain Bucket":"< 1K"
   },
   {
     "Class":"Predicate",
-    "Name":"http:\/\/schema.org\/availableService",
+    "Name":"https://schema.org/availableService",
     "Domain Bucket":"10K - 100K"
   },
   {
     "Class":"Predicate",
-    "Name":"http:\/\/schema.org\/availableService-input",
+    "Name":"https://schema.org/availableService-input",
     "Domain Bucket":"< 1K"
   },
   {
     "Class":"Predicate",
-    "Name":"http:\/\/schema.org\/availableService-output",
+    "Name":"https://schema.org/availableService-output",
     "Domain Bucket":"< 1K"
   },
   {
     "Class":"Predicate",
-    "Name":"http:\/\/schema.org\/availableStrength",
+    "Name":"https://schema.org/availableStrength",
     "Domain Bucket":"< 1K"
   },
   {
     "Class":"Predicate",
-    "Name":"http:\/\/schema.org\/availableStrength-input",
+    "Name":"https://schema.org/availableStrength-input",
     "Domain Bucket":"< 1K"
   },
   {
     "Class":"Predicate",
-    "Name":"http:\/\/schema.org\/availableStrength-output",
+    "Name":"https://schema.org/availableStrength-output",
     "Domain Bucket":"< 1K"
   },
   {
     "Class":"Predicate",
-    "Name":"http:\/\/schema.org\/availableTest",
+    "Name":"https://schema.org/availableTest",
     "Domain Bucket":"< 1K"
   },
   {
     "Class":"Predicate",
-    "Name":"http:\/\/schema.org\/availableTest-input",
+    "Name":"https://schema.org/availableTest-input",
     "Domain Bucket":"< 1K"
   },
   {
     "Class":"Predicate",
-    "Name":"http:\/\/schema.org\/availableTest-output",
+    "Name":"https://schema.org/availableTest-output",
     "Domain Bucket":"< 1K"
   },
   {
     "Class":"Predicate",
-    "Name":"http:\/\/schema.org\/availableThrough",
+    "Name":"https://schema.org/availableThrough",
     "Domain Bucket":"< 1K"
   },
   {
     "Class":"Predicate",
-    "Name":"http:\/\/schema.org\/availableThrough-input",
+    "Name":"https://schema.org/availableThrough-input",
     "Domain Bucket":"< 1K"
   },
   {
     "Class":"Predicate",
-    "Name":"http:\/\/schema.org\/availableThrough-output",
+    "Name":"https://schema.org/availableThrough-output",
     "Domain Bucket":"< 1K"
   },
   {
     "Class":"Predicate",
-    "Name":"http:\/\/schema.org\/award",
+    "Name":"https://schema.org/award",
     "Domain Bucket":"10K - 100K"
   },
   {
     "Class":"Predicate",
-    "Name":"http:\/\/schema.org\/award-input",
+    "Name":"https://schema.org/award-input",
     "Domain Bucket":"< 1K"
   },
   {
     "Class":"Predicate",
-    "Name":"http:\/\/schema.org\/award-output",
+    "Name":"https://schema.org/award-output",
     "Domain Bucket":"< 1K"
   },
   {
     "Class":"Predicate",
-    "Name":"http:\/\/schema.org\/awards",
+    "Name":"https://schema.org/awards",
     "Domain Bucket":"1K - 10K"
   },
   {
     "Class":"Predicate",
-    "Name":"http:\/\/schema.org\/awards-input",
+    "Name":"https://schema.org/awards-input",
     "Domain Bucket":"< 1K"
   },
   {
     "Class":"Predicate",
-    "Name":"http:\/\/schema.org\/awards-output",
+    "Name":"https://schema.org/awards-output",
     "Domain Bucket":"< 1K"
   },
   {
     "Class":"Predicate",
-    "Name":"http:\/\/schema.org\/awayTeam",
+    "Name":"https://schema.org/awayTeam",
     "Domain Bucket":"10K - 100K"
   },
   {
     "Class":"Predicate",
-    "Name":"http:\/\/schema.org\/awayTeam-input",
+    "Name":"https://schema.org/awayTeam-input",
     "Domain Bucket":"< 1K"
   },
   {
     "Class":"Predicate",
-    "Name":"http:\/\/schema.org\/awayTeam-output",
+    "Name":"https://schema.org/awayTeam-output",
     "Domain Bucket":"< 1K"
   },
   {
     "Class":"Predicate",
-    "Name":"http:\/\/schema.org\/backstory",
+    "Name":"https://schema.org/backstory",
     "Domain Bucket":"1K - 10K"
   },
   {
     "Class":"Predicate",
-    "Name":"http:\/\/schema.org\/backstory-input",
+    "Name":"https://schema.org/backstory-input",
     "Domain Bucket":"< 1K"
   },
   {
     "Class":"Predicate",
-    "Name":"http:\/\/schema.org\/backstory-output",
+    "Name":"https://schema.org/backstory-output",
     "Domain Bucket":"< 1K"
   },
   {
     "Class":"Predicate",
-    "Name":"http:\/\/schema.org\/bankAccountType",
+    "Name":"https://schema.org/bankAccountType",
     "Domain Bucket":"< 1K"
   },
   {
     "Class":"Predicate",
-    "Name":"http:\/\/schema.org\/bankAccountType-input",
+    "Name":"https://schema.org/bankAccountType-input",
     "Domain Bucket":"< 1K"
   },
   {
     "Class":"Predicate",
-    "Name":"http:\/\/schema.org\/bankAccountType-output",
+    "Name":"https://schema.org/bankAccountType-output",
     "Domain Bucket":"< 1K"
   },
   {
     "Class":"Predicate",
-    "Name":"http:\/\/schema.org\/baseSalary",
+    "Name":"https://schema.org/baseSalary",
     "Domain Bucket":"10K - 100K"
   },
   {
     "Class":"Predicate",
-    "Name":"http:\/\/schema.org\/baseSalary-input",
+    "Name":"https://schema.org/baseSalary-input",
     "Domain Bucket":"< 1K"
   },
   {
     "Class":"Predicate",
-    "Name":"http:\/\/schema.org\/baseSalary-output",
+    "Name":"https://schema.org/baseSalary-output",
     "Domain Bucket":"< 1K"
   },
   {
     "Class":"Predicate",
-    "Name":"http:\/\/schema.org\/bccRecipient",
+    "Name":"https://schema.org/bccRecipient",
     "Domain Bucket":"< 1K"
   },
   {
     "Class":"Predicate",
-    "Name":"http:\/\/schema.org\/bccRecipient-input",
+    "Name":"https://schema.org/bccRecipient-input",
     "Domain Bucket":"< 1K"
   },
   {
     "Class":"Predicate",
-    "Name":"http:\/\/schema.org\/bccRecipient-output",
+    "Name":"https://schema.org/bccRecipient-output",
     "Domain Bucket":"< 1K"
   },
   {
     "Class":"Predicate",
-    "Name":"http:\/\/schema.org\/bed",
+    "Name":"https://schema.org/bed",
     "Domain Bucket":"10K - 100K"
   },
   {
     "Class":"Predicate",
-    "Name":"http:\/\/schema.org\/bed-input",
+    "Name":"https://schema.org/bed-input",
     "Domain Bucket":"< 1K"
   },
   {
     "Class":"Predicate",
-    "Name":"http:\/\/schema.org\/bed-output",
+    "Name":"https://schema.org/bed-output",
     "Domain Bucket":"< 1K"
   },
   {
     "Class":"Predicate",
-    "Name":"http:\/\/schema.org\/beforeMedia",
+    "Name":"https://schema.org/beforeMedia",
     "Domain Bucket":"< 1K"
   },
   {
     "Class":"Predicate",
-    "Name":"http:\/\/schema.org\/beforeMedia-input",
+    "Name":"https://schema.org/beforeMedia-input",
     "Domain Bucket":"< 1K"
   },
   {
     "Class":"Predicate",
-    "Name":"http:\/\/schema.org\/beforeMedia-output",
+    "Name":"https://schema.org/beforeMedia-output",
     "Domain Bucket":"< 1K"
   },
   {
     "Class":"Predicate",
-    "Name":"http:\/\/schema.org\/beneficiaryBank",
+    "Name":"https://schema.org/beneficiaryBank",
     "Domain Bucket":"< 1K"
   },
   {
     "Class":"Predicate",
-    "Name":"http:\/\/schema.org\/beneficiaryBank-input",
+    "Name":"https://schema.org/beneficiaryBank-input",
     "Domain Bucket":"< 1K"
   },
   {
     "Class":"Predicate",
-    "Name":"http:\/\/schema.org\/beneficiaryBank-output",
+    "Name":"https://schema.org/beneficiaryBank-output",
     "Domain Bucket":"< 1K"
   },
   {
     "Class":"Predicate",
-    "Name":"http:\/\/schema.org\/benefits",
+    "Name":"https://schema.org/benefits",
     "Domain Bucket":"1K - 10K"
   },
   {
     "Class":"Predicate",
-    "Name":"http:\/\/schema.org\/benefits-input",
+    "Name":"https://schema.org/benefits-input",
     "Domain Bucket":"< 1K"
   },
   {
     "Class":"Predicate",
-    "Name":"http:\/\/schema.org\/benefits-output",
+    "Name":"https://schema.org/benefits-output",
     "Domain Bucket":"< 1K"
   },
   {
     "Class":"Predicate",
-    "Name":"http:\/\/schema.org\/benefitsSummaryUrl",
+    "Name":"https://schema.org/benefitsSummaryUrl",
     "Domain Bucket":"< 1K"
   },
   {
     "Class":"Predicate",
-    "Name":"http:\/\/schema.org\/benefitsSummaryUrl-input",
+    "Name":"https://schema.org/benefitsSummaryUrl-input",
     "Domain Bucket":"< 1K"
   },
   {
     "Class":"Predicate",
-    "Name":"http:\/\/schema.org\/benefitsSummaryUrl-output",
+    "Name":"https://schema.org/benefitsSummaryUrl-output",
     "Domain Bucket":"< 1K"
   },
   {
     "Class":"Predicate",
-    "Name":"http:\/\/schema.org\/bestRating",
+    "Name":"https://schema.org/bestRating",
     "Domain Bucket":"1M - 10M"
   },
   {
     "Class":"Predicate",
-    "Name":"http:\/\/schema.org\/bestRating-input",
+    "Name":"https://schema.org/bestRating-input",
     "Domain Bucket":"< 1K"
   },
   {
     "Class":"Predicate",
-    "Name":"http:\/\/schema.org\/bestRating-output",
+    "Name":"https://schema.org/bestRating-output",
     "Domain Bucket":"< 1K"
   },
   {
     "Class":"Predicate",
-    "Name":"http:\/\/schema.org\/billingAddress",
+    "Name":"https://schema.org/billingAddress",
     "Domain Bucket":"< 1K"
   },
   {
     "Class":"Predicate",
-    "Name":"http:\/\/schema.org\/billingAddress-input",
+    "Name":"https://schema.org/billingAddress-input",
     "Domain Bucket":"< 1K"
   },
   {
     "Class":"Predicate",
-    "Name":"http:\/\/schema.org\/billingAddress-output",
+    "Name":"https://schema.org/billingAddress-output",
     "Domain Bucket":"< 1K"
   },
   {
     "Class":"Predicate",
-    "Name":"http:\/\/schema.org\/billingDuration",
+    "Name":"https://schema.org/billingDuration",
     "Domain Bucket":"10K - 100K"
   },
   {
     "Class":"Predicate",
-    "Name":"http:\/\/schema.org\/billingDuration-input",
+    "Name":"https://schema.org/billingDuration-input",
     "Domain Bucket":"< 1K"
   },
   {
     "Class":"Predicate",
-    "Name":"http:\/\/schema.org\/billingDuration-output",
+    "Name":"https://schema.org/billingDuration-output",
     "Domain Bucket":"< 1K"
   },
   {
     "Class":"Predicate",
-    "Name":"http:\/\/schema.org\/billingIncrement",
+    "Name":"https://schema.org/billingIncrement",
     "Domain Bucket":"10K - 100K"
   },
   {
     "Class":"Predicate",
-    "Name":"http:\/\/schema.org\/billingIncrement-input",
+    "Name":"https://schema.org/billingIncrement-input",
     "Domain Bucket":"< 1K"
   },
   {
     "Class":"Predicate",
-    "Name":"http:\/\/schema.org\/billingIncrement-output",
+    "Name":"https://schema.org/billingIncrement-output",
     "Domain Bucket":"< 1K"
   },
   {
     "Class":"Predicate",
-    "Name":"http:\/\/schema.org\/billingPeriod",
+    "Name":"https://schema.org/billingPeriod",
     "Domain Bucket":"1K - 10K"
   },
   {
     "Class":"Predicate",
-    "Name":"http:\/\/schema.org\/billingPeriod-input",
+    "Name":"https://schema.org/billingPeriod-input",
     "Domain Bucket":"< 1K"
   },
   {
     "Class":"Predicate",
-    "Name":"http:\/\/schema.org\/billingPeriod-output",
+    "Name":"https://schema.org/billingPeriod-output",
     "Domain Bucket":"< 1K"
   },
   {
     "Class":"Predicate",
-    "Name":"http:\/\/schema.org\/billingStart",
+    "Name":"https://schema.org/billingStart",
     "Domain Bucket":"< 1K"
   },
   {
     "Class":"Predicate",
-    "Name":"http:\/\/schema.org\/billingStart-input",
+    "Name":"https://schema.org/billingStart-input",
     "Domain Bucket":"< 1K"
   },
   {
     "Class":"Predicate",
-    "Name":"http:\/\/schema.org\/billingStart-output",
+    "Name":"https://schema.org/billingStart-output",
     "Domain Bucket":"< 1K"
   },
   {
     "Class":"Predicate",
-    "Name":"http:\/\/schema.org\/bioChemInteraction",
+    "Name":"https://schema.org/bioChemInteraction",
     "Domain Bucket":"< 1K"
   },
   {
     "Class":"Predicate",
-    "Name":"http:\/\/schema.org\/bioChemInteraction-input",
+    "Name":"https://schema.org/bioChemInteraction-input",
     "Domain Bucket":"< 1K"
   },
   {
     "Class":"Predicate",
-    "Name":"http:\/\/schema.org\/bioChemInteraction-output",
+    "Name":"https://schema.org/bioChemInteraction-output",
     "Domain Bucket":"< 1K"
   },
   {
     "Class":"Predicate",
-    "Name":"http:\/\/schema.org\/bioChemSimilarity",
+    "Name":"https://schema.org/bioChemSimilarity",
     "Domain Bucket":"< 1K"
   },
   {
     "Class":"Predicate",
-    "Name":"http:\/\/schema.org\/bioChemSimilarity-input",
+    "Name":"https://schema.org/bioChemSimilarity-input",
     "Domain Bucket":"< 1K"
   },
   {
     "Class":"Predicate",
-    "Name":"http:\/\/schema.org\/bioChemSimilarity-output",
+    "Name":"https://schema.org/bioChemSimilarity-output",
     "Domain Bucket":"< 1K"
   },
   {
     "Class":"Predicate",
-    "Name":"http:\/\/schema.org\/biologicalRole",
+    "Name":"https://schema.org/biologicalRole",
     "Domain Bucket":"< 1K"
   },
   {
     "Class":"Predicate",
-    "Name":"http:\/\/schema.org\/biologicalRole-input",
+    "Name":"https://schema.org/biologicalRole-input",
     "Domain Bucket":"< 1K"
   },
   {
     "Class":"Predicate",
-    "Name":"http:\/\/schema.org\/biologicalRole-output",
+    "Name":"https://schema.org/biologicalRole-output",
     "Domain Bucket":"< 1K"
   },
   {
     "Class":"Predicate",
-    "Name":"http:\/\/schema.org\/biomechnicalClass",
+    "Name":"https://schema.org/biomechnicalClass",
     "Domain Bucket":"< 1K"
   },
   {
     "Class":"Predicate",
-    "Name":"http:\/\/schema.org\/biomechnicalClass-input",
+    "Name":"https://schema.org/biomechnicalClass-input",
     "Domain Bucket":"< 1K"
   },
   {
     "Class":"Predicate",
-    "Name":"http:\/\/schema.org\/biomechnicalClass-output",
+    "Name":"https://schema.org/biomechnicalClass-output",
     "Domain Bucket":"< 1K"
   },
   {
     "Class":"Predicate",
-    "Name":"http:\/\/schema.org\/birthDate",
+    "Name":"https://schema.org/birthDate",
     "Domain Bucket":"10K - 100K"
   },
   {
     "Class":"Predicate",
-    "Name":"http:\/\/schema.org\/birthDate-input",
+    "Name":"https://schema.org/birthDate-input",
     "Domain Bucket":"< 1K"
   },
   {
     "Class":"Predicate",
-    "Name":"http:\/\/schema.org\/birthDate-output",
+    "Name":"https://schema.org/birthDate-output",
     "Domain Bucket":"< 1K"
   },
   {
     "Class":"Predicate",
-    "Name":"http:\/\/schema.org\/birthPlace",
+    "Name":"https://schema.org/birthPlace",
     "Domain Bucket":"10K - 100K"
   },
   {
     "Class":"Predicate",
-    "Name":"http:\/\/schema.org\/birthPlace-input",
+    "Name":"https://schema.org/birthPlace-input",
     "Domain Bucket":"< 1K"
   },
   {
     "Class":"Predicate",
-    "Name":"http:\/\/schema.org\/birthPlace-output",
+    "Name":"https://schema.org/birthPlace-output",
     "Domain Bucket":"< 1K"
   },
   {
     "Class":"Predicate",
-    "Name":"http:\/\/schema.org\/bitrate",
+    "Name":"https://schema.org/bitrate",
     "Domain Bucket":"1K - 10K"
   },
   {
     "Class":"Predicate",
-    "Name":"http:\/\/schema.org\/bitrate-input",
+    "Name":"https://schema.org/bitrate-input",
     "Domain Bucket":"< 1K"
   },
   {
     "Class":"Predicate",
-    "Name":"http:\/\/schema.org\/bitrate-output",
+    "Name":"https://schema.org/bitrate-output",
     "Domain Bucket":"< 1K"
   },
   {
     "Class":"Predicate",
-    "Name":"http:\/\/schema.org\/blogPost",
+    "Name":"https://schema.org/blogPost",
     "Domain Bucket":"100K - 1M"
   },
   {
     "Class":"Predicate",
-    "Name":"http:\/\/schema.org\/blogPost-input",
+    "Name":"https://schema.org/blogPost-input",
     "Domain Bucket":"< 1K"
   },
   {
     "Class":"Predicate",
-    "Name":"http:\/\/schema.org\/blogPost-output",
+    "Name":"https://schema.org/blogPost-output",
     "Domain Bucket":"< 1K"
   },
   {
     "Class":"Predicate",
-    "Name":"http:\/\/schema.org\/blogPosts",
+    "Name":"https://schema.org/blogPosts",
     "Domain Bucket":"10K - 100K"
   },
   {
     "Class":"Predicate",
-    "Name":"http:\/\/schema.org\/blogPosts-input",
+    "Name":"https://schema.org/blogPosts-input",
     "Domain Bucket":"< 1K"
   },
   {
     "Class":"Predicate",
-    "Name":"http:\/\/schema.org\/blogPosts-output",
+    "Name":"https://schema.org/blogPosts-output",
     "Domain Bucket":"< 1K"
   },
   {
     "Class":"Predicate",
-    "Name":"http:\/\/schema.org\/bloodSupply",
+    "Name":"https://schema.org/bloodSupply",
     "Domain Bucket":"< 1K"
   },
   {
     "Class":"Predicate",
-    "Name":"http:\/\/schema.org\/bloodSupply-input",
+    "Name":"https://schema.org/bloodSupply-input",
     "Domain Bucket":"< 1K"
   },
   {
     "Class":"Predicate",
-    "Name":"http:\/\/schema.org\/bloodSupply-output",
+    "Name":"https://schema.org/bloodSupply-output",
     "Domain Bucket":"< 1K"
   },
   {
     "Class":"Predicate",
-    "Name":"http:\/\/schema.org\/boardingGroup",
+    "Name":"https://schema.org/boardingGroup",
     "Domain Bucket":"< 1K"
   },
   {
     "Class":"Predicate",
-    "Name":"http:\/\/schema.org\/boardingGroup-input",
+    "Name":"https://schema.org/boardingGroup-input",
     "Domain Bucket":"< 1K"
   },
   {
     "Class":"Predicate",
-    "Name":"http:\/\/schema.org\/boardingGroup-output",
+    "Name":"https://schema.org/boardingGroup-output",
     "Domain Bucket":"< 1K"
   },
   {
     "Class":"Predicate",
-    "Name":"http:\/\/schema.org\/boardingPolicy",
+    "Name":"https://schema.org/boardingPolicy",
     "Domain Bucket":"< 1K"
   },
   {
     "Class":"Predicate",
-    "Name":"http:\/\/schema.org\/boardingPolicy-input",
+    "Name":"https://schema.org/boardingPolicy-input",
     "Domain Bucket":"< 1K"
   },
   {
     "Class":"Predicate",
-    "Name":"http:\/\/schema.org\/boardingPolicy-output",
+    "Name":"https://schema.org/boardingPolicy-output",
     "Domain Bucket":"< 1K"
   },
   {
     "Class":"Predicate",
-    "Name":"http:\/\/schema.org\/bodyLocation",
+    "Name":"https://schema.org/bodyLocation",
     "Domain Bucket":"10K - 100K"
   },
   {
     "Class":"Predicate",
-    "Name":"http:\/\/schema.org\/bodyLocation-input",
+    "Name":"https://schema.org/bodyLocation-input",
     "Domain Bucket":"< 1K"
   },
   {
     "Class":"Predicate",
-    "Name":"http:\/\/schema.org\/bodyLocation-output",
+    "Name":"https://schema.org/bodyLocation-output",
     "Domain Bucket":"< 1K"
   },
   {
     "Class":"Predicate",
-    "Name":"http:\/\/schema.org\/bodyType",
+    "Name":"https://schema.org/bodyType",
     "Domain Bucket":"10K - 100K"
   },
   {
     "Class":"Predicate",
-    "Name":"http:\/\/schema.org\/bodyType-input",
+    "Name":"https://schema.org/bodyType-input",
     "Domain Bucket":"< 1K"
   },
   {
     "Class":"Predicate",
-    "Name":"http:\/\/schema.org\/bodyType-output",
+    "Name":"https://schema.org/bodyType-output",
     "Domain Bucket":"< 1K"
   },
   {
     "Class":"Predicate",
-    "Name":"http:\/\/schema.org\/bookEdition",
+    "Name":"https://schema.org/bookEdition",
     "Domain Bucket":"1K - 10K"
   },
   {
     "Class":"Predicate",
-    "Name":"http:\/\/schema.org\/bookEdition-input",
+    "Name":"https://schema.org/bookEdition-input",
     "Domain Bucket":"< 1K"
   },
   {
     "Class":"Predicate",
-    "Name":"http:\/\/schema.org\/bookEdition-output",
+    "Name":"https://schema.org/bookEdition-output",
     "Domain Bucket":"< 1K"
   },
   {
     "Class":"Predicate",
-    "Name":"http:\/\/schema.org\/bookFormat",
+    "Name":"https://schema.org/bookFormat",
     "Domain Bucket":"10K - 100K"
   },
   {
     "Class":"Predicate",
-    "Name":"http:\/\/schema.org\/bookFormat-input",
+    "Name":"https://schema.org/bookFormat-input",
     "Domain Bucket":"< 1K"
   },
   {
     "Class":"Predicate",
-    "Name":"http:\/\/schema.org\/bookFormat-output",
+    "Name":"https://schema.org/bookFormat-output",
     "Domain Bucket":"< 1K"
   },
   {
     "Class":"Predicate",
-    "Name":"http:\/\/schema.org\/bookingAgent",
+    "Name":"https://schema.org/bookingAgent",
     "Domain Bucket":"< 1K"
   },
   {
     "Class":"Predicate",
-    "Name":"http:\/\/schema.org\/bookingAgent-input",
+    "Name":"https://schema.org/bookingAgent-input",
     "Domain Bucket":"< 1K"
   },
   {
     "Class":"Predicate",
-    "Name":"http:\/\/schema.org\/bookingAgent-output",
+    "Name":"https://schema.org/bookingAgent-output",
     "Domain Bucket":"< 1K"
   },
   {
     "Class":"Predicate",
-    "Name":"http:\/\/schema.org\/bookingTime",
+    "Name":"https://schema.org/bookingTime",
     "Domain Bucket":"< 1K"
   },
   {
     "Class":"Predicate",
-    "Name":"http:\/\/schema.org\/bookingTime-input",
+    "Name":"https://schema.org/bookingTime-input",
     "Domain Bucket":"< 1K"
   },
   {
     "Class":"Predicate",
-    "Name":"http:\/\/schema.org\/bookingTime-output",
+    "Name":"https://schema.org/bookingTime-output",
     "Domain Bucket":"< 1K"
   },
   {
     "Class":"Predicate",
-    "Name":"http:\/\/schema.org\/borrower",
+    "Name":"https://schema.org/borrower",
     "Domain Bucket":"< 1K"
   },
   {
     "Class":"Predicate",
-    "Name":"http:\/\/schema.org\/borrower-input",
+    "Name":"https://schema.org/borrower-input",
     "Domain Bucket":"< 1K"
   },
   {
     "Class":"Predicate",
-    "Name":"http:\/\/schema.org\/borrower-output",
+    "Name":"https://schema.org/borrower-output",
     "Domain Bucket":"< 1K"
   },
   {
     "Class":"Predicate",
-    "Name":"http:\/\/schema.org\/box",
+    "Name":"https://schema.org/box",
     "Domain Bucket":"1K - 10K"
   },
   {
     "Class":"Predicate",
-    "Name":"http:\/\/schema.org\/box-input",
+    "Name":"https://schema.org/box-input",
     "Domain Bucket":"< 1K"
   },
   {
     "Class":"Predicate",
-    "Name":"http:\/\/schema.org\/box-output",
+    "Name":"https://schema.org/box-output",
     "Domain Bucket":"< 1K"
   },
   {
     "Class":"Predicate",
-    "Name":"http:\/\/schema.org\/branch",
+    "Name":"https://schema.org/branch",
     "Domain Bucket":"< 1K"
   },
   {
     "Class":"Predicate",
-    "Name":"http:\/\/schema.org\/branch-input",
+    "Name":"https://schema.org/branch-input",
     "Domain Bucket":"< 1K"
   },
   {
     "Class":"Predicate",
-    "Name":"http:\/\/schema.org\/branch-output",
+    "Name":"https://schema.org/branch-output",
     "Domain Bucket":"< 1K"
   },
   {
     "Class":"Predicate",
-    "Name":"http:\/\/schema.org\/branchCode",
+    "Name":"https://schema.org/branchCode",
     "Domain Bucket":"1K - 10K"
   },
   {
     "Class":"Predicate",
-    "Name":"http:\/\/schema.org\/branchCode-input",
+    "Name":"https://schema.org/branchCode-input",
     "Domain Bucket":"< 1K"
   },
   {
     "Class":"Predicate",
-    "Name":"http:\/\/schema.org\/branchCode-output",
+    "Name":"https://schema.org/branchCode-output",
     "Domain Bucket":"< 1K"
   },
   {
     "Class":"Predicate",
-    "Name":"http:\/\/schema.org\/branchOf",
+    "Name":"https://schema.org/branchOf",
     "Domain Bucket":"10K - 100K"
   },
   {
     "Class":"Predicate",
-    "Name":"http:\/\/schema.org\/branchOf-input",
+    "Name":"https://schema.org/branchOf-input",
     "Domain Bucket":"< 1K"
   },
   {
     "Class":"Predicate",
-    "Name":"http:\/\/schema.org\/branchOf-output",
+    "Name":"https://schema.org/branchOf-output",
     "Domain Bucket":"< 1K"
   },
   {
     "Class":"Predicate",
-    "Name":"http:\/\/schema.org\/brand",
+    "Name":"https://schema.org/brand",
     "Domain Bucket":"1M - 10M"
   },
   {
     "Class":"Predicate",
-    "Name":"http:\/\/schema.org\/brand-input",
+    "Name":"https://schema.org/brand-input",
     "Domain Bucket":"< 1K"
   },
   {
     "Class":"Predicate",
-    "Name":"http:\/\/schema.org\/brand-output",
+    "Name":"https://schema.org/brand-output",
     "Domain Bucket":"< 1K"
   },
   {
     "Class":"Predicate",
-    "Name":"http:\/\/schema.org\/breadcrumb",
+    "Name":"https://schema.org/breadcrumb",
     "Domain Bucket":"10M+"
   },
   {
     "Class":"Predicate",
-    "Name":"http:\/\/schema.org\/breadcrumb-input",
+    "Name":"https://schema.org/breadcrumb-input",
     "Domain Bucket":"< 1K"
   },
   {
     "Class":"Predicate",
-    "Name":"http:\/\/schema.org\/breadcrumb-output",
+    "Name":"https://schema.org/breadcrumb-output",
     "Domain Bucket":"< 1K"
   },
   {
     "Class":"Predicate",
-    "Name":"http:\/\/schema.org\/breastfeedingWarning",
+    "Name":"https://schema.org/breastfeedingWarning",
     "Domain Bucket":"< 1K"
   },
   {
     "Class":"Predicate",
-    "Name":"http:\/\/schema.org\/breastfeedingWarning-input",
+    "Name":"https://schema.org/breastfeedingWarning-input",
     "Domain Bucket":"< 1K"
   },
   {
     "Class":"Predicate",
-    "Name":"http:\/\/schema.org\/breastfeedingWarning-output",
+    "Name":"https://schema.org/breastfeedingWarning-output",
     "Domain Bucket":"< 1K"
   },
   {
     "Class":"Predicate",
-    "Name":"http:\/\/schema.org\/broadcastAffiliateOf",
+    "Name":"https://schema.org/broadcastAffiliateOf",
     "Domain Bucket":"< 1K"
   },
   {
     "Class":"Predicate",
-    "Name":"http:\/\/schema.org\/broadcastAffiliateOf-input",
+    "Name":"https://schema.org/broadcastAffiliateOf-input",
     "Domain Bucket":"< 1K"
   },
   {
     "Class":"Predicate",
-    "Name":"http:\/\/schema.org\/broadcastAffiliateOf-output",
+    "Name":"https://schema.org/broadcastAffiliateOf-output",
     "Domain Bucket":"< 1K"
   },
   {
     "Class":"Predicate",
-    "Name":"http:\/\/schema.org\/broadcastChannelId",
+    "Name":"https://schema.org/broadcastChannelId",
     "Domain Bucket":"< 1K"
   },
   {
     "Class":"Predicate",
-    "Name":"http:\/\/schema.org\/broadcastChannelId-input",
+    "Name":"https://schema.org/broadcastChannelId-input",
     "Domain Bucket":"< 1K"
   },
   {
     "Class":"Predicate",
-    "Name":"http:\/\/schema.org\/broadcastChannelId-output",
+    "Name":"https://schema.org/broadcastChannelId-output",
     "Domain Bucket":"< 1K"
   },
   {
     "Class":"Predicate",
-    "Name":"http:\/\/schema.org\/broadcastDisplayName",
+    "Name":"https://schema.org/broadcastDisplayName",
     "Domain Bucket":"1K - 10K"
   },
   {
     "Class":"Predicate",
-    "Name":"http:\/\/schema.org\/broadcastDisplayName-input",
+    "Name":"https://schema.org/broadcastDisplayName-input",
     "Domain Bucket":"< 1K"
   },
   {
     "Class":"Predicate",
-    "Name":"http:\/\/schema.org\/broadcastDisplayName-output",
+    "Name":"https://schema.org/broadcastDisplayName-output",
     "Domain Bucket":"< 1K"
   },
   {
     "Class":"Predicate",
-    "Name":"http:\/\/schema.org\/broadcastFrequency",
+    "Name":"https://schema.org/broadcastFrequency",
     "Domain Bucket":"1K - 10K"
   },
   {
     "Class":"Predicate",
-    "Name":"http:\/\/schema.org\/broadcastFrequency-input",
+    "Name":"https://schema.org/broadcastFrequency-input",
     "Domain Bucket":"< 1K"
   },
   {
     "Class":"Predicate",
-    "Name":"http:\/\/schema.org\/broadcastFrequency-output",
+    "Name":"https://schema.org/broadcastFrequency-output",
     "Domain Bucket":"< 1K"
   },
   {
     "Class":"Predicate",
-    "Name":"http:\/\/schema.org\/broadcastFrequencyValue",
+    "Name":"https://schema.org/broadcastFrequencyValue",
     "Domain Bucket":"< 1K"
   },
   {
     "Class":"Predicate",
-    "Name":"http:\/\/schema.org\/broadcastFrequencyValue-input",
+    "Name":"https://schema.org/broadcastFrequencyValue-input",
     "Domain Bucket":"< 1K"
   },
   {
     "Class":"Predicate",
-    "Name":"http:\/\/schema.org\/broadcastFrequencyValue-output",
+    "Name":"https://schema.org/broadcastFrequencyValue-output",
     "Domain Bucket":"< 1K"
   },
   {
     "Class":"Predicate",
-    "Name":"http:\/\/schema.org\/broadcastOfEvent",
+    "Name":"https://schema.org/broadcastOfEvent",
     "Domain Bucket":"1K - 10K"
   },
   {
     "Class":"Predicate",
-    "Name":"http:\/\/schema.org\/broadcastOfEvent-input",
+    "Name":"https://schema.org/broadcastOfEvent-input",
     "Domain Bucket":"< 1K"
   },
   {
     "Class":"Predicate",
-    "Name":"http:\/\/schema.org\/broadcastOfEvent-output",
+    "Name":"https://schema.org/broadcastOfEvent-output",
     "Domain Bucket":"< 1K"
   },
   {
     "Class":"Predicate",
-    "Name":"http:\/\/schema.org\/broadcastServiceTier",
+    "Name":"https://schema.org/broadcastServiceTier",
     "Domain Bucket":"< 1K"
   },
   {
     "Class":"Predicate",
-    "Name":"http:\/\/schema.org\/broadcastServiceTier-input",
+    "Name":"https://schema.org/broadcastServiceTier-input",
     "Domain Bucket":"< 1K"
   },
   {
     "Class":"Predicate",
-    "Name":"http:\/\/schema.org\/broadcastServiceTier-output",
+    "Name":"https://schema.org/broadcastServiceTier-output",
     "Domain Bucket":"< 1K"
   },
   {
     "Class":"Predicate",
-    "Name":"http:\/\/schema.org\/broadcastSignalModulation",
+    "Name":"https://schema.org/broadcastSignalModulation",
     "Domain Bucket":"< 1K"
   },
   {
     "Class":"Predicate",
-    "Name":"http:\/\/schema.org\/broadcastSignalModulation-input",
+    "Name":"https://schema.org/broadcastSignalModulation-input",
     "Domain Bucket":"< 1K"
   },
   {
     "Class":"Predicate",
-    "Name":"http:\/\/schema.org\/broadcastSignalModulation-output",
+    "Name":"https://schema.org/broadcastSignalModulation-output",
     "Domain Bucket":"< 1K"
   },
   {
     "Class":"Predicate",
-    "Name":"http:\/\/schema.org\/broadcastSubChannel",
+    "Name":"https://schema.org/broadcastSubChannel",
     "Domain Bucket":"< 1K"
   },
   {
     "Class":"Predicate",
-    "Name":"http:\/\/schema.org\/broadcastSubChannel-input",
+    "Name":"https://schema.org/broadcastSubChannel-input",
     "Domain Bucket":"< 1K"
   },
   {
     "Class":"Predicate",
-    "Name":"http:\/\/schema.org\/broadcastSubChannel-output",
+    "Name":"https://schema.org/broadcastSubChannel-output",
     "Domain Bucket":"< 1K"
   },
   {
     "Class":"Predicate",
-    "Name":"http:\/\/schema.org\/broadcastTimezone",
+    "Name":"https://schema.org/broadcastTimezone",
     "Domain Bucket":"< 1K"
   },
   {
     "Class":"Predicate",
-    "Name":"http:\/\/schema.org\/broadcastTimezone-input",
+    "Name":"https://schema.org/broadcastTimezone-input",
     "Domain Bucket":"< 1K"
   },
   {
     "Class":"Predicate",
-    "Name":"http:\/\/schema.org\/broadcastTimezone-output",
+    "Name":"https://schema.org/broadcastTimezone-output",
     "Domain Bucket":"< 1K"
   },
   {
     "Class":"Predicate",
-    "Name":"http:\/\/schema.org\/broadcaster",
+    "Name":"https://schema.org/broadcaster",
     "Domain Bucket":"< 1K"
   },
   {
     "Class":"Predicate",
-    "Name":"http:\/\/schema.org\/broadcaster-input",
+    "Name":"https://schema.org/broadcaster-input",
     "Domain Bucket":"< 1K"
   },
   {
     "Class":"Predicate",
-    "Name":"http:\/\/schema.org\/broadcaster-output",
+    "Name":"https://schema.org/broadcaster-output",
     "Domain Bucket":"< 1K"
   },
   {
     "Class":"Predicate",
-    "Name":"http:\/\/schema.org\/broker",
+    "Name":"https://schema.org/broker",
     "Domain Bucket":"1K - 10K"
   },
   {
     "Class":"Predicate",
-    "Name":"http:\/\/schema.org\/broker-input",
+    "Name":"https://schema.org/broker-input",
     "Domain Bucket":"< 1K"
   },
   {
     "Class":"Predicate",
-    "Name":"http:\/\/schema.org\/broker-output",
+    "Name":"https://schema.org/broker-output",
     "Domain Bucket":"< 1K"
   },
   {
     "Class":"Predicate",
-    "Name":"http:\/\/schema.org\/browserRequirements",
+    "Name":"https://schema.org/browserRequirements",
     "Domain Bucket":"10K - 100K"
   },
   {
     "Class":"Predicate",
-    "Name":"http:\/\/schema.org\/browserRequirements-input",
+    "Name":"https://schema.org/browserRequirements-input",
     "Domain Bucket":"< 1K"
   },
   {
     "Class":"Predicate",
-    "Name":"http:\/\/schema.org\/browserRequirements-output",
+    "Name":"https://schema.org/browserRequirements-output",
     "Domain Bucket":"< 1K"
   },
   {
     "Class":"Predicate",
-    "Name":"http:\/\/schema.org\/busName",
+    "Name":"https://schema.org/busName",
     "Domain Bucket":"< 1K"
   },
   {
     "Class":"Predicate",
-    "Name":"http:\/\/schema.org\/busName-input",
+    "Name":"https://schema.org/busName-input",
     "Domain Bucket":"< 1K"
   },
   {
     "Class":"Predicate",
-    "Name":"http:\/\/schema.org\/busName-output",
+    "Name":"https://schema.org/busName-output",
     "Domain Bucket":"< 1K"
   },
   {
     "Class":"Predicate",
-    "Name":"http:\/\/schema.org\/busNumber",
+    "Name":"https://schema.org/busNumber",
     "Domain Bucket":"< 1K"
   },
   {
     "Class":"Predicate",
-    "Name":"http:\/\/schema.org\/busNumber-input",
+    "Name":"https://schema.org/busNumber-input",
     "Domain Bucket":"< 1K"
   },
   {
     "Class":"Predicate",
-    "Name":"http:\/\/schema.org\/busNumber-output",
+    "Name":"https://schema.org/busNumber-output",
     "Domain Bucket":"< 1K"
   },
   {
     "Class":"Predicate",
-    "Name":"http:\/\/schema.org\/businessDays",
+    "Name":"https://schema.org/businessDays",
     "Domain Bucket":"10K - 100K"
   },
   {
     "Class":"Predicate",
-    "Name":"http:\/\/schema.org\/businessDays-input",
+    "Name":"https://schema.org/businessDays-input",
     "Domain Bucket":"< 1K"
   },
   {
     "Class":"Predicate",
-    "Name":"http:\/\/schema.org\/businessDays-output",
+    "Name":"https://schema.org/businessDays-output",
     "Domain Bucket":"< 1K"
   },
   {
     "Class":"Predicate",
-    "Name":"http:\/\/schema.org\/businessFunction",
+    "Name":"https://schema.org/businessFunction",
     "Domain Bucket":"1M - 10M"
   },
   {
     "Class":"Predicate",
-    "Name":"http:\/\/schema.org\/businessFunction-input",
+    "Name":"https://schema.org/businessFunction-input",
     "Domain Bucket":"< 1K"
   },
   {
     "Class":"Predicate",
-    "Name":"http:\/\/schema.org\/businessFunction-output",
+    "Name":"https://schema.org/businessFunction-output",
     "Domain Bucket":"< 1K"
   },
   {
     "Class":"Predicate",
-    "Name":"http:\/\/schema.org\/buyer",
+    "Name":"https://schema.org/buyer",
     "Domain Bucket":"< 1K"
   },
   {
     "Class":"Predicate",
-    "Name":"http:\/\/schema.org\/buyer-input",
+    "Name":"https://schema.org/buyer-input",
     "Domain Bucket":"< 1K"
   },
   {
     "Class":"Predicate",
-    "Name":"http:\/\/schema.org\/buyer-output",
+    "Name":"https://schema.org/buyer-output",
     "Domain Bucket":"< 1K"
   },
   {
     "Class":"Predicate",
-    "Name":"http:\/\/schema.org\/byArtist",
+    "Name":"https://schema.org/byArtist",
     "Domain Bucket":"10K - 100K"
   },
   {
     "Class":"Predicate",
-    "Name":"http:\/\/schema.org\/byArtist-input",
+    "Name":"https://schema.org/byArtist-input",
     "Domain Bucket":"< 1K"
   },
   {
     "Class":"Predicate",
-    "Name":"http:\/\/schema.org\/byArtist-output",
+    "Name":"https://schema.org/byArtist-output",
     "Domain Bucket":"< 1K"
   },
   {
     "Class":"Predicate",
-    "Name":"http:\/\/schema.org\/byDay",
+    "Name":"https://schema.org/byDay",
     "Domain Bucket":"1K - 10K"
   },
   {
     "Class":"Predicate",
-    "Name":"http:\/\/schema.org\/byDay-input",
+    "Name":"https://schema.org/byDay-input",
     "Domain Bucket":"< 1K"
   },
   {
     "Class":"Predicate",
-    "Name":"http:\/\/schema.org\/byDay-output",
+    "Name":"https://schema.org/byDay-output",
     "Domain Bucket":"< 1K"
   },
   {
     "Class":"Predicate",
-    "Name":"http:\/\/schema.org\/byMonth",
+    "Name":"https://schema.org/byMonth",
     "Domain Bucket":"< 1K"
   },
   {
     "Class":"Predicate",
-    "Name":"http:\/\/schema.org\/byMonth-input",
+    "Name":"https://schema.org/byMonth-input",
     "Domain Bucket":"< 1K"
   },
   {
     "Class":"Predicate",
-    "Name":"http:\/\/schema.org\/byMonth-output",
+    "Name":"https://schema.org/byMonth-output",
     "Domain Bucket":"< 1K"
   },
   {
     "Class":"Predicate",
-    "Name":"http:\/\/schema.org\/byMonthDay",
+    "Name":"https://schema.org/byMonthDay",
     "Domain Bucket":"< 1K"
   },
   {
     "Class":"Predicate",
-    "Name":"http:\/\/schema.org\/byMonthDay-input",
+    "Name":"https://schema.org/byMonthDay-input",
     "Domain Bucket":"< 1K"
   },
   {
     "Class":"Predicate",
-    "Name":"http:\/\/schema.org\/byMonthDay-output",
+    "Name":"https://schema.org/byMonthDay-output",
     "Domain Bucket":"< 1K"
   },
   {
     "Class":"Predicate",
-    "Name":"http:\/\/schema.org\/byMonthWeek",
+    "Name":"https://schema.org/byMonthWeek",
     "Domain Bucket":"< 1K"
   },
   {
     "Class":"Predicate",
-    "Name":"http:\/\/schema.org\/byMonthWeek-input",
+    "Name":"https://schema.org/byMonthWeek-input",
     "Domain Bucket":"< 1K"
   },
   {
     "Class":"Predicate",
-    "Name":"http:\/\/schema.org\/byMonthWeek-output",
+    "Name":"https://schema.org/byMonthWeek-output",
     "Domain Bucket":"< 1K"
   },
   {
     "Class":"Predicate",
-    "Name":"http:\/\/schema.org\/callSign",
+    "Name":"https://schema.org/callSign",
     "Domain Bucket":"< 1K"
   },
   {
     "Class":"Predicate",
-    "Name":"http:\/\/schema.org\/callSign-input",
+    "Name":"https://schema.org/callSign-input",
     "Domain Bucket":"< 1K"
   },
   {
     "Class":"Predicate",
-    "Name":"http:\/\/schema.org\/callSign-output",
+    "Name":"https://schema.org/callSign-output",
     "Domain Bucket":"< 1K"
   },
   {
     "Class":"Predicate",
-    "Name":"http:\/\/schema.org\/calories",
+    "Name":"https://schema.org/calories",
     "Domain Bucket":"10K - 100K"
   },
   {
     "Class":"Predicate",
-    "Name":"http:\/\/schema.org\/calories-input",
+    "Name":"https://schema.org/calories-input",
     "Domain Bucket":"< 1K"
   },
   {
     "Class":"Predicate",
-    "Name":"http:\/\/schema.org\/calories-output",
+    "Name":"https://schema.org/calories-output",
     "Domain Bucket":"< 1K"
   },
   {
     "Class":"Predicate",
-    "Name":"http:\/\/schema.org\/candidate",
+    "Name":"https://schema.org/candidate",
     "Domain Bucket":"< 1K"
   },
   {
     "Class":"Predicate",
-    "Name":"http:\/\/schema.org\/candidate-input",
+    "Name":"https://schema.org/candidate-input",
     "Domain Bucket":"< 1K"
   },
   {
     "Class":"Predicate",
-    "Name":"http:\/\/schema.org\/candidate-output",
+    "Name":"https://schema.org/candidate-output",
     "Domain Bucket":"< 1K"
   },
   {
     "Class":"Predicate",
-    "Name":"http:\/\/schema.org\/caption",
+    "Name":"https://schema.org/caption",
     "Domain Bucket":"10M+"
   },
   {
     "Class":"Predicate",
-    "Name":"http:\/\/schema.org\/caption-input",
+    "Name":"https://schema.org/caption-input",
     "Domain Bucket":"< 1K"
   },
   {
     "Class":"Predicate",
-    "Name":"http:\/\/schema.org\/caption-output",
+    "Name":"https://schema.org/caption-output",
     "Domain Bucket":"< 1K"
   },
   {
     "Class":"Predicate",
-    "Name":"http:\/\/schema.org\/carbohydrateContent",
+    "Name":"https://schema.org/carbohydrateContent",
     "Domain Bucket":"10K - 100K"
   },
   {
     "Class":"Predicate",
-    "Name":"http:\/\/schema.org\/carbohydrateContent-input",
+    "Name":"https://schema.org/carbohydrateContent-input",
     "Domain Bucket":"< 1K"
   },
   {
     "Class":"Predicate",
-    "Name":"http:\/\/schema.org\/carbohydrateContent-output",
+    "Name":"https://schema.org/carbohydrateContent-output",
     "Domain Bucket":"< 1K"
   },
   {
     "Class":"Predicate",
-    "Name":"http:\/\/schema.org\/cargoVolume",
+    "Name":"https://schema.org/cargoVolume",
     "Domain Bucket":"1K - 10K"
   },
   {
     "Class":"Predicate",
-    "Name":"http:\/\/schema.org\/cargoVolume-input",
+    "Name":"https://schema.org/cargoVolume-input",
     "Domain Bucket":"< 1K"
   },
   {
     "Class":"Predicate",
-    "Name":"http:\/\/schema.org\/cargoVolume-output",
+    "Name":"https://schema.org/cargoVolume-output",
     "Domain Bucket":"< 1K"
   },
   {
     "Class":"Predicate",
-    "Name":"http:\/\/schema.org\/carrier",
+    "Name":"https://schema.org/carrier",
     "Domain Bucket":"< 1K"
   },
   {
     "Class":"Predicate",
-    "Name":"http:\/\/schema.org\/carrier-input",
+    "Name":"https://schema.org/carrier-input",
     "Domain Bucket":"< 1K"
   },
   {
     "Class":"Predicate",
-    "Name":"http:\/\/schema.org\/carrier-output",
+    "Name":"https://schema.org/carrier-output",
     "Domain Bucket":"< 1K"
   },
   {
     "Class":"Predicate",
-    "Name":"http:\/\/schema.org\/carrierRequirements",
+    "Name":"https://schema.org/carrierRequirements",
     "Domain Bucket":"< 1K"
   },
   {
     "Class":"Predicate",
-    "Name":"http:\/\/schema.org\/carrierRequirements-input",
+    "Name":"https://schema.org/carrierRequirements-input",
     "Domain Bucket":"< 1K"
   },
   {
     "Class":"Predicate",
-    "Name":"http:\/\/schema.org\/carrierRequirements-output",
+    "Name":"https://schema.org/carrierRequirements-output",
     "Domain Bucket":"< 1K"
   },
   {
     "Class":"Predicate",
-    "Name":"http:\/\/schema.org\/cashBack",
+    "Name":"https://schema.org/cashBack",
     "Domain Bucket":"< 1K"
   },
   {
     "Class":"Predicate",
-    "Name":"http:\/\/schema.org\/cashBack-input",
+    "Name":"https://schema.org/cashBack-input",
     "Domain Bucket":"< 1K"
   },
   {
     "Class":"Predicate",
-    "Name":"http:\/\/schema.org\/cashBack-output",
+    "Name":"https://schema.org/cashBack-output",
     "Domain Bucket":"< 1K"
   },
   {
     "Class":"Predicate",
-    "Name":"http:\/\/schema.org\/catalog",
+    "Name":"https://schema.org/catalog",
     "Domain Bucket":"< 1K"
   },
   {
     "Class":"Predicate",
-    "Name":"http:\/\/schema.org\/catalog-input",
+    "Name":"https://schema.org/catalog-input",
     "Domain Bucket":"< 1K"
   },
   {
     "Class":"Predicate",
-    "Name":"http:\/\/schema.org\/catalog-output",
+    "Name":"https://schema.org/catalog-output",
     "Domain Bucket":"< 1K"
   },
   {
     "Class":"Predicate",
-    "Name":"http:\/\/schema.org\/catalogNumber",
+    "Name":"https://schema.org/catalogNumber",
     "Domain Bucket":"< 1K"
   },
   {
     "Class":"Predicate",
-    "Name":"http:\/\/schema.org\/catalogNumber-input",
+    "Name":"https://schema.org/catalogNumber-input",
     "Domain Bucket":"< 1K"
   },
   {
     "Class":"Predicate",
-    "Name":"http:\/\/schema.org\/catalogNumber-output",
+    "Name":"https://schema.org/catalogNumber-output",
     "Domain Bucket":"< 1K"
   },
   {
     "Class":"Predicate",
-    "Name":"http:\/\/schema.org\/category",
+    "Name":"https://schema.org/category",
     "Domain Bucket":"1M - 10M"
   },
   {
     "Class":"Predicate",
-    "Name":"http:\/\/schema.org\/category-input",
+    "Name":"https://schema.org/category-input",
     "Domain Bucket":"< 1K"
   },
   {
     "Class":"Predicate",
-    "Name":"http:\/\/schema.org\/category-output",
+    "Name":"https://schema.org/category-output",
     "Domain Bucket":"< 1K"
   },
   {
     "Class":"Predicate",
-    "Name":"http:\/\/schema.org\/cause",
+    "Name":"https://schema.org/cause",
     "Domain Bucket":"1K - 10K"
   },
   {
     "Class":"Predicate",
-    "Name":"http:\/\/schema.org\/cause-input",
+    "Name":"https://schema.org/cause-input",
     "Domain Bucket":"< 1K"
   },
   {
     "Class":"Predicate",
-    "Name":"http:\/\/schema.org\/cause-output",
+    "Name":"https://schema.org/cause-output",
     "Domain Bucket":"< 1K"
   },
   {
     "Class":"Predicate",
-    "Name":"http:\/\/schema.org\/causeOf",
+    "Name":"https://schema.org/causeOf",
     "Domain Bucket":"< 1K"
   },
   {
     "Class":"Predicate",
-    "Name":"http:\/\/schema.org\/causeOf-input",
+    "Name":"https://schema.org/causeOf-input",
     "Domain Bucket":"< 1K"
   },
   {
     "Class":"Predicate",
-    "Name":"http:\/\/schema.org\/causeOf-output",
+    "Name":"https://schema.org/causeOf-output",
     "Domain Bucket":"< 1K"
   },
   {
     "Class":"Predicate",
-    "Name":"http:\/\/schema.org\/ccRecipient",
+    "Name":"https://schema.org/ccRecipient",
     "Domain Bucket":"< 1K"
   },
   {
     "Class":"Predicate",
-    "Name":"http:\/\/schema.org\/ccRecipient-input",
+    "Name":"https://schema.org/ccRecipient-input",
     "Domain Bucket":"< 1K"
   },
   {
     "Class":"Predicate",
-    "Name":"http:\/\/schema.org\/ccRecipient-output",
+    "Name":"https://schema.org/ccRecipient-output",
     "Domain Bucket":"< 1K"
   },
   {
     "Class":"Predicate",
-    "Name":"http:\/\/schema.org\/certificationIdentification",
+    "Name":"https://schema.org/certificationIdentification",
     "Domain Bucket":"1K - 10K"
   },
   {
     "Class":"Predicate",
-    "Name":"http:\/\/schema.org\/certificationIdentification-input",
+    "Name":"https://schema.org/certificationIdentification-input",
     "Domain Bucket":"< 1K"
   },
   {
     "Class":"Predicate",
-    "Name":"http:\/\/schema.org\/certificationIdentification-output",
+    "Name":"https://schema.org/certificationIdentification-output",
     "Domain Bucket":"< 1K"
   },
   {
     "Class":"Predicate",
-    "Name":"http:\/\/schema.org\/certificationRating",
+    "Name":"https://schema.org/certificationRating",
     "Domain Bucket":"< 1K"
   },
   {
     "Class":"Predicate",
-    "Name":"http:\/\/schema.org\/certificationRating-input",
+    "Name":"https://schema.org/certificationRating-input",
     "Domain Bucket":"< 1K"
   },
   {
     "Class":"Predicate",
-    "Name":"http:\/\/schema.org\/certificationRating-output",
+    "Name":"https://schema.org/certificationRating-output",
     "Domain Bucket":"< 1K"
   },
   {
     "Class":"Predicate",
-    "Name":"http:\/\/schema.org\/certificationStatus",
+    "Name":"https://schema.org/certificationStatus",
     "Domain Bucket":"1K - 10K"
   },
   {
     "Class":"Predicate",
-    "Name":"http:\/\/schema.org\/certificationStatus-input",
+    "Name":"https://schema.org/certificationStatus-input",
     "Domain Bucket":"< 1K"
   },
   {
     "Class":"Predicate",
-    "Name":"http:\/\/schema.org\/certificationStatus-output",
+    "Name":"https://schema.org/certificationStatus-output",
     "Domain Bucket":"< 1K"
   },
   {
     "Class":"Predicate",
-    "Name":"http:\/\/schema.org\/character",
+    "Name":"https://schema.org/character",
     "Domain Bucket":"1K - 10K"
   },
   {
     "Class":"Predicate",
-    "Name":"http:\/\/schema.org\/character-input",
+    "Name":"https://schema.org/character-input",
     "Domain Bucket":"< 1K"
   },
   {
     "Class":"Predicate",
-    "Name":"http:\/\/schema.org\/character-output",
+    "Name":"https://schema.org/character-output",
     "Domain Bucket":"< 1K"
   },
   {
     "Class":"Predicate",
-    "Name":"http:\/\/schema.org\/characterAttribute",
+    "Name":"https://schema.org/characterAttribute",
     "Domain Bucket":"< 1K"
   },
   {
     "Class":"Predicate",
-    "Name":"http:\/\/schema.org\/characterAttribute-input",
+    "Name":"https://schema.org/characterAttribute-input",
     "Domain Bucket":"< 1K"
   },
   {
     "Class":"Predicate",
-    "Name":"http:\/\/schema.org\/characterAttribute-output",
+    "Name":"https://schema.org/characterAttribute-output",
     "Domain Bucket":"< 1K"
   },
   {
     "Class":"Predicate",
-    "Name":"http:\/\/schema.org\/characterName",
+    "Name":"https://schema.org/characterName",
     "Domain Bucket":"< 1K"
   },
   {
     "Class":"Predicate",
-    "Name":"http:\/\/schema.org\/characterName-input",
+    "Name":"https://schema.org/characterName-input",
     "Domain Bucket":"< 1K"
   },
   {
     "Class":"Predicate",
-    "Name":"http:\/\/schema.org\/characterName-output",
+    "Name":"https://schema.org/characterName-output",
     "Domain Bucket":"< 1K"
   },
   {
     "Class":"Predicate",
-    "Name":"http:\/\/schema.org\/cheatCode",
+    "Name":"https://schema.org/cheatCode",
     "Domain Bucket":"< 1K"
   },
   {
     "Class":"Predicate",
-    "Name":"http:\/\/schema.org\/cheatCode-input",
+    "Name":"https://schema.org/cheatCode-input",
     "Domain Bucket":"< 1K"
   },
   {
     "Class":"Predicate",
-    "Name":"http:\/\/schema.org\/cheatCode-output",
+    "Name":"https://schema.org/cheatCode-output",
     "Domain Bucket":"< 1K"
   },
   {
     "Class":"Predicate",
-    "Name":"http:\/\/schema.org\/checkinTime",
+    "Name":"https://schema.org/checkinTime",
     "Domain Bucket":"10K - 100K"
   },
   {
     "Class":"Predicate",
-    "Name":"http:\/\/schema.org\/checkinTime-input",
+    "Name":"https://schema.org/checkinTime-input",
     "Domain Bucket":"< 1K"
   },
   {
     "Class":"Predicate",
-    "Name":"http:\/\/schema.org\/checkinTime-output",
+    "Name":"https://schema.org/checkinTime-output",
     "Domain Bucket":"< 1K"
   },
   {
     "Class":"Predicate",
-    "Name":"http:\/\/schema.org\/checkoutPageURLTemplate",
+    "Name":"https://schema.org/checkoutPageURLTemplate",
     "Domain Bucket":"10K - 100K"
   },
   {
     "Class":"Predicate",
-    "Name":"http:\/\/schema.org\/checkoutPageURLTemplate-input",
+    "Name":"https://schema.org/checkoutPageURLTemplate-input",
     "Domain Bucket":"< 1K"
   },
   {
     "Class":"Predicate",
-    "Name":"http:\/\/schema.org\/checkoutPageURLTemplate-output",
+    "Name":"https://schema.org/checkoutPageURLTemplate-output",
     "Domain Bucket":"< 1K"
   },
   {
     "Class":"Predicate",
-    "Name":"http:\/\/schema.org\/checkoutTime",
+    "Name":"https://schema.org/checkoutTime",
     "Domain Bucket":"10K - 100K"
   },
   {
     "Class":"Predicate",
-    "Name":"http:\/\/schema.org\/checkoutTime-input",
+    "Name":"https://schema.org/checkoutTime-input",
     "Domain Bucket":"< 1K"
   },
   {
     "Class":"Predicate",
-    "Name":"http:\/\/schema.org\/checkoutTime-output",
+    "Name":"https://schema.org/checkoutTime-output",
     "Domain Bucket":"< 1K"
   },
   {
     "Class":"Predicate",
-    "Name":"http:\/\/schema.org\/chemicalComposition",
+    "Name":"https://schema.org/chemicalComposition",
     "Domain Bucket":"< 1K"
   },
   {
     "Class":"Predicate",
-    "Name":"http:\/\/schema.org\/chemicalComposition-input",
+    "Name":"https://schema.org/chemicalComposition-input",
     "Domain Bucket":"< 1K"
   },
   {
     "Class":"Predicate",
-    "Name":"http:\/\/schema.org\/chemicalComposition-output",
+    "Name":"https://schema.org/chemicalComposition-output",
     "Domain Bucket":"< 1K"
   },
   {
     "Class":"Predicate",
-    "Name":"http:\/\/schema.org\/chemicalRole",
+    "Name":"https://schema.org/chemicalRole",
     "Domain Bucket":"< 1K"
   },
   {
     "Class":"Predicate",
-    "Name":"http:\/\/schema.org\/chemicalRole-input",
+    "Name":"https://schema.org/chemicalRole-input",
     "Domain Bucket":"< 1K"
   },
   {
     "Class":"Predicate",
-    "Name":"http:\/\/schema.org\/chemicalRole-output",
+    "Name":"https://schema.org/chemicalRole-output",
     "Domain Bucket":"< 1K"
   },
   {
     "Class":"Predicate",
-    "Name":"http:\/\/schema.org\/childMaxAge",
+    "Name":"https://schema.org/childMaxAge",
     "Domain Bucket":"< 1K"
   },
   {
     "Class":"Predicate",
-    "Name":"http:\/\/schema.org\/childMaxAge-input",
+    "Name":"https://schema.org/childMaxAge-input",
     "Domain Bucket":"< 1K"
   },
   {
     "Class":"Predicate",
-    "Name":"http:\/\/schema.org\/childMaxAge-output",
+    "Name":"https://schema.org/childMaxAge-output",
     "Domain Bucket":"< 1K"
   },
   {
     "Class":"Predicate",
-    "Name":"http:\/\/schema.org\/childMinAge",
+    "Name":"https://schema.org/childMinAge",
     "Domain Bucket":"< 1K"
   },
   {
     "Class":"Predicate",
-    "Name":"http:\/\/schema.org\/childMinAge-input",
+    "Name":"https://schema.org/childMinAge-input",
     "Domain Bucket":"< 1K"
   },
   {
     "Class":"Predicate",
-    "Name":"http:\/\/schema.org\/childMinAge-output",
+    "Name":"https://schema.org/childMinAge-output",
     "Domain Bucket":"< 1K"
   },
   {
     "Class":"Predicate",
-    "Name":"http:\/\/schema.org\/childTaxon",
+    "Name":"https://schema.org/childTaxon",
     "Domain Bucket":"< 1K"
   },
   {
     "Class":"Predicate",
-    "Name":"http:\/\/schema.org\/childTaxon-input",
+    "Name":"https://schema.org/childTaxon-input",
     "Domain Bucket":"< 1K"
   },
   {
     "Class":"Predicate",
-    "Name":"http:\/\/schema.org\/childTaxon-output",
+    "Name":"https://schema.org/childTaxon-output",
     "Domain Bucket":"< 1K"
   },
   {
     "Class":"Predicate",
-    "Name":"http:\/\/schema.org\/children",
+    "Name":"https://schema.org/children",
     "Domain Bucket":"1K - 10K"
   },
   {
     "Class":"Predicate",
-    "Name":"http:\/\/schema.org\/children-input",
+    "Name":"https://schema.org/children-input",
     "Domain Bucket":"< 1K"
   },
   {
     "Class":"Predicate",
-    "Name":"http:\/\/schema.org\/children-output",
+    "Name":"https://schema.org/children-output",
     "Domain Bucket":"< 1K"
   },
   {
     "Class":"Predicate",
-    "Name":"http:\/\/schema.org\/cholesterolContent",
+    "Name":"https://schema.org/cholesterolContent",
     "Domain Bucket":"10K - 100K"
   },
   {
     "Class":"Predicate",
-    "Name":"http:\/\/schema.org\/cholesterolContent-input",
+    "Name":"https://schema.org/cholesterolContent-input",
     "Domain Bucket":"< 1K"
   },
   {
     "Class":"Predicate",
-    "Name":"http:\/\/schema.org\/cholesterolContent-output",
+    "Name":"https://schema.org/cholesterolContent-output",
     "Domain Bucket":"< 1K"
   },
   {
     "Class":"Predicate",
-    "Name":"http:\/\/schema.org\/circle",
+    "Name":"https://schema.org/circle",
     "Domain Bucket":"1K - 10K"
   },
   {
     "Class":"Predicate",
-    "Name":"http:\/\/schema.org\/circle-input",
+    "Name":"https://schema.org/circle-input",
     "Domain Bucket":"< 1K"
   },
   {
     "Class":"Predicate",
-    "Name":"http:\/\/schema.org\/circle-output",
+    "Name":"https://schema.org/circle-output",
     "Domain Bucket":"< 1K"
   },
   {
     "Class":"Predicate",
-    "Name":"http:\/\/schema.org\/citation",
+    "Name":"https://schema.org/citation",
     "Domain Bucket":"10K - 100K"
   },
   {
     "Class":"Predicate",
-    "Name":"http:\/\/schema.org\/citation-input",
+    "Name":"https://schema.org/citation-input",
     "Domain Bucket":"< 1K"
   },
   {
     "Class":"Predicate",
-    "Name":"http:\/\/schema.org\/citation-output",
+    "Name":"https://schema.org/citation-output",
     "Domain Bucket":"< 1K"
   },
   {
     "Class":"Predicate",
-    "Name":"http:\/\/schema.org\/claimInterpreter",
+    "Name":"https://schema.org/claimInterpreter",
     "Domain Bucket":"< 1K"
   },
   {
     "Class":"Predicate",
-    "Name":"http:\/\/schema.org\/claimInterpreter-input",
+    "Name":"https://schema.org/claimInterpreter-input",
     "Domain Bucket":"< 1K"
   },
   {
     "Class":"Predicate",
-    "Name":"http:\/\/schema.org\/claimInterpreter-output",
+    "Name":"https://schema.org/claimInterpreter-output",
     "Domain Bucket":"< 1K"
   },
   {
     "Class":"Predicate",
-    "Name":"http:\/\/schema.org\/claimReviewed",
+    "Name":"https://schema.org/claimReviewed",
     "Domain Bucket":"1K - 10K"
   },
   {
     "Class":"Predicate",
-    "Name":"http:\/\/schema.org\/claimReviewed-input",
+    "Name":"https://schema.org/claimReviewed-input",
     "Domain Bucket":"< 1K"
   },
   {
     "Class":"Predicate",
-    "Name":"http:\/\/schema.org\/claimReviewed-output",
+    "Name":"https://schema.org/claimReviewed-output",
     "Domain Bucket":"< 1K"
   },
   {
     "Class":"Predicate",
-    "Name":"http:\/\/schema.org\/clincalPharmacology",
+    "Name":"https://schema.org/clincalPharmacology",
     "Domain Bucket":"< 1K"
   },
   {
     "Class":"Predicate",
-    "Name":"http:\/\/schema.org\/clincalPharmacology-input",
+    "Name":"https://schema.org/clincalPharmacology-input",
     "Domain Bucket":"< 1K"
   },
   {
     "Class":"Predicate",
-    "Name":"http:\/\/schema.org\/clincalPharmacology-output",
+    "Name":"https://schema.org/clincalPharmacology-output",
     "Domain Bucket":"< 1K"
   },
   {
     "Class":"Predicate",
-    "Name":"http:\/\/schema.org\/clinicalPharmacology",
+    "Name":"https://schema.org/clinicalPharmacology",
     "Domain Bucket":"< 1K"
   },
   {
     "Class":"Predicate",
-    "Name":"http:\/\/schema.org\/clinicalPharmacology-input",
+    "Name":"https://schema.org/clinicalPharmacology-input",
     "Domain Bucket":"< 1K"
   },
   {
     "Class":"Predicate",
-    "Name":"http:\/\/schema.org\/clinicalPharmacology-output",
+    "Name":"https://schema.org/clinicalPharmacology-output",
     "Domain Bucket":"< 1K"
   },
   {
     "Class":"Predicate",
-    "Name":"http:\/\/schema.org\/clipNumber",
+    "Name":"https://schema.org/clipNumber",
     "Domain Bucket":"< 1K"
   },
   {
     "Class":"Predicate",
-    "Name":"http:\/\/schema.org\/clipNumber-input",
+    "Name":"https://schema.org/clipNumber-input",
     "Domain Bucket":"< 1K"
   },
   {
     "Class":"Predicate",
-    "Name":"http:\/\/schema.org\/clipNumber-output",
+    "Name":"https://schema.org/clipNumber-output",
     "Domain Bucket":"< 1K"
   },
   {
     "Class":"Predicate",
-    "Name":"http:\/\/schema.org\/closes",
+    "Name":"https://schema.org/closes",
     "Domain Bucket":"1M - 10M"
   },
   {
     "Class":"Predicate",
-    "Name":"http:\/\/schema.org\/closes-input",
+    "Name":"https://schema.org/closes-input",
     "Domain Bucket":"< 1K"
   },
   {
     "Class":"Predicate",
-    "Name":"http:\/\/schema.org\/closes-output",
+    "Name":"https://schema.org/closes-output",
     "Domain Bucket":"< 1K"
   },
   {
     "Class":"Predicate",
-    "Name":"http:\/\/schema.org\/coach",
+    "Name":"https://schema.org/coach",
     "Domain Bucket":"< 1K"
   },
   {
     "Class":"Predicate",
-    "Name":"http:\/\/schema.org\/coach-input",
+    "Name":"https://schema.org/coach-input",
     "Domain Bucket":"< 1K"
   },
   {
     "Class":"Predicate",
-    "Name":"http:\/\/schema.org\/coach-output",
+    "Name":"https://schema.org/coach-output",
     "Domain Bucket":"< 1K"
   },
   {
     "Class":"Predicate",
-    "Name":"http:\/\/schema.org\/code",
+    "Name":"https://schema.org/code",
     "Domain Bucket":"1K - 10K"
   },
   {
     "Class":"Predicate",
-    "Name":"http:\/\/schema.org\/code-input",
+    "Name":"https://schema.org/code-input",
     "Domain Bucket":"< 1K"
   },
   {
     "Class":"Predicate",
-    "Name":"http:\/\/schema.org\/code-output",
+    "Name":"https://schema.org/code-output",
     "Domain Bucket":"< 1K"
   },
   {
     "Class":"Predicate",
-    "Name":"http:\/\/schema.org\/codeRepository",
+    "Name":"https://schema.org/codeRepository",
     "Domain Bucket":"1K - 10K"
   },
   {
     "Class":"Predicate",
-    "Name":"http:\/\/schema.org\/codeRepository-input",
+    "Name":"https://schema.org/codeRepository-input",
     "Domain Bucket":"< 1K"
   },
   {
     "Class":"Predicate",
-    "Name":"http:\/\/schema.org\/codeRepository-output",
+    "Name":"https://schema.org/codeRepository-output",
     "Domain Bucket":"< 1K"
   },
   {
     "Class":"Predicate",
-    "Name":"http:\/\/schema.org\/codeSampleType",
+    "Name":"https://schema.org/codeSampleType",
     "Domain Bucket":"< 1K"
   },
   {
     "Class":"Predicate",
-    "Name":"http:\/\/schema.org\/codeSampleType-input",
+    "Name":"https://schema.org/codeSampleType-input",
     "Domain Bucket":"< 1K"
   },
   {
     "Class":"Predicate",
-    "Name":"http:\/\/schema.org\/codeSampleType-output",
+    "Name":"https://schema.org/codeSampleType-output",
     "Domain Bucket":"< 1K"
   },
   {
     "Class":"Predicate",
-    "Name":"http:\/\/schema.org\/codeValue",
+    "Name":"https://schema.org/codeValue",
     "Domain Bucket":"1K - 10K"
   },
   {
     "Class":"Predicate",
-    "Name":"http:\/\/schema.org\/codeValue-input",
+    "Name":"https://schema.org/codeValue-input",
     "Domain Bucket":"< 1K"
   },
   {
     "Class":"Predicate",
-    "Name":"http:\/\/schema.org\/codeValue-output",
+    "Name":"https://schema.org/codeValue-output",
     "Domain Bucket":"< 1K"
   },
   {
     "Class":"Predicate",
-    "Name":"http:\/\/schema.org\/codingSystem",
+    "Name":"https://schema.org/codingSystem",
     "Domain Bucket":"1K - 10K"
   },
   {
     "Class":"Predicate",
-    "Name":"http:\/\/schema.org\/codingSystem-input",
+    "Name":"https://schema.org/codingSystem-input",
     "Domain Bucket":"< 1K"
   },
   {
     "Class":"Predicate",
-    "Name":"http:\/\/schema.org\/codingSystem-output",
+    "Name":"https://schema.org/codingSystem-output",
     "Domain Bucket":"< 1K"
   },
   {
     "Class":"Predicate",
-    "Name":"http:\/\/schema.org\/colleague",
+    "Name":"https://schema.org/colleague",
     "Domain Bucket":"1K - 10K"
   },
   {
     "Class":"Predicate",
-    "Name":"http:\/\/schema.org\/colleague-input",
+    "Name":"https://schema.org/colleague-input",
     "Domain Bucket":"< 1K"
   },
   {
     "Class":"Predicate",
-    "Name":"http:\/\/schema.org\/colleague-output",
+    "Name":"https://schema.org/colleague-output",
     "Domain Bucket":"< 1K"
   },
   {
     "Class":"Predicate",
-    "Name":"http:\/\/schema.org\/colleagues",
+    "Name":"https://schema.org/colleagues",
     "Domain Bucket":"< 1K"
   },
   {
     "Class":"Predicate",
-    "Name":"http:\/\/schema.org\/colleagues-input",
+    "Name":"https://schema.org/colleagues-input",
     "Domain Bucket":"< 1K"
   },
   {
     "Class":"Predicate",
-    "Name":"http:\/\/schema.org\/colleagues-output",
+    "Name":"https://schema.org/colleagues-output",
     "Domain Bucket":"< 1K"
   },
   {
     "Class":"Predicate",
-    "Name":"http:\/\/schema.org\/collection",
+    "Name":"https://schema.org/collection",
     "Domain Bucket":"< 1K"
   },
   {
     "Class":"Predicate",
-    "Name":"http:\/\/schema.org\/collection-input",
+    "Name":"https://schema.org/collection-input",
     "Domain Bucket":"< 1K"
   },
   {
     "Class":"Predicate",
-    "Name":"http:\/\/schema.org\/collection-output",
+    "Name":"https://schema.org/collection-output",
     "Domain Bucket":"< 1K"
   },
   {
     "Class":"Predicate",
-    "Name":"http:\/\/schema.org\/collectionSize",
+    "Name":"https://schema.org/collectionSize",
     "Domain Bucket":"1K - 10K"
   },
   {
     "Class":"Predicate",
-    "Name":"http:\/\/schema.org\/collectionSize-input",
+    "Name":"https://schema.org/collectionSize-input",
     "Domain Bucket":"< 1K"
   },
   {
     "Class":"Predicate",
-    "Name":"http:\/\/schema.org\/collectionSize-output",
+    "Name":"https://schema.org/collectionSize-output",
     "Domain Bucket":"< 1K"
   },
   {
     "Class":"Predicate",
-    "Name":"http:\/\/schema.org\/color",
+    "Name":"https://schema.org/color",
     "Domain Bucket":"100K - 1M"
   },
   {
     "Class":"Predicate",
-    "Name":"http:\/\/schema.org\/color-input",
+    "Name":"https://schema.org/color-input",
     "Domain Bucket":"< 1K"
   },
   {
     "Class":"Predicate",
-    "Name":"http:\/\/schema.org\/color-output",
+    "Name":"https://schema.org/color-output",
     "Domain Bucket":"< 1K"
   },
   {
     "Class":"Predicate",
-    "Name":"http:\/\/schema.org\/colorSwatch",
+    "Name":"https://schema.org/colorSwatch",
     "Domain Bucket":"< 1K"
   },
   {
     "Class":"Predicate",
-    "Name":"http:\/\/schema.org\/colorSwatch-input",
+    "Name":"https://schema.org/colorSwatch-input",
     "Domain Bucket":"< 1K"
   },
   {
     "Class":"Predicate",
-    "Name":"http:\/\/schema.org\/colorSwatch-output",
+    "Name":"https://schema.org/colorSwatch-output",
     "Domain Bucket":"< 1K"
   },
   {
     "Class":"Predicate",
-    "Name":"http:\/\/schema.org\/colorist",
+    "Name":"https://schema.org/colorist",
     "Domain Bucket":"< 1K"
   },
   {
     "Class":"Predicate",
-    "Name":"http:\/\/schema.org\/colorist-input",
+    "Name":"https://schema.org/colorist-input",
     "Domain Bucket":"< 1K"
   },
   {
     "Class":"Predicate",
-    "Name":"http:\/\/schema.org\/colorist-output",
+    "Name":"https://schema.org/colorist-output",
     "Domain Bucket":"< 1K"
   },
   {
     "Class":"Predicate",
-    "Name":"http:\/\/schema.org\/comment",
+    "Name":"https://schema.org/comment",
     "Domain Bucket":"10K - 100K"
   },
   {
     "Class":"Predicate",
-    "Name":"http:\/\/schema.org\/comment-input",
+    "Name":"https://schema.org/comment-input",
     "Domain Bucket":"< 1K"
   },
   {
     "Class":"Predicate",
-    "Name":"http:\/\/schema.org\/comment-output",
+    "Name":"https://schema.org/comment-output",
     "Domain Bucket":"< 1K"
   },
   {
     "Class":"Predicate",
-    "Name":"http:\/\/schema.org\/commentCount",
+    "Name":"https://schema.org/commentCount",
     "Domain Bucket":"1M - 10M"
   },
   {
     "Class":"Predicate",
-    "Name":"http:\/\/schema.org\/commentCount-input",
+    "Name":"https://schema.org/commentCount-input",
     "Domain Bucket":"< 1K"
   },
   {
     "Class":"Predicate",
-    "Name":"http:\/\/schema.org\/commentCount-output",
+    "Name":"https://schema.org/commentCount-output",
     "Domain Bucket":"< 1K"
   },
   {
     "Class":"Predicate",
-    "Name":"http:\/\/schema.org\/commentText",
+    "Name":"https://schema.org/commentText",
     "Domain Bucket":"10K - 100K"
   },
   {
     "Class":"Predicate",
-    "Name":"http:\/\/schema.org\/commentText-input",
+    "Name":"https://schema.org/commentText-input",
     "Domain Bucket":"< 1K"
   },
   {
     "Class":"Predicate",
-    "Name":"http:\/\/schema.org\/commentText-output",
+    "Name":"https://schema.org/commentText-output",
     "Domain Bucket":"< 1K"
   },
   {
     "Class":"Predicate",
-    "Name":"http:\/\/schema.org\/commentTime",
+    "Name":"https://schema.org/commentTime",
     "Domain Bucket":"10K - 100K"
   },
   {
     "Class":"Predicate",
-    "Name":"http:\/\/schema.org\/commentTime-input",
+    "Name":"https://schema.org/commentTime-input",
     "Domain Bucket":"< 1K"
   },
   {
     "Class":"Predicate",
-    "Name":"http:\/\/schema.org\/commentTime-output",
+    "Name":"https://schema.org/commentTime-output",
     "Domain Bucket":"< 1K"
   },
   {
     "Class":"Predicate",
-    "Name":"http:\/\/schema.org\/companyRegistration",
+    "Name":"https://schema.org/companyRegistration",
     "Domain Bucket":"< 1K"
   },
   {
     "Class":"Predicate",
-    "Name":"http:\/\/schema.org\/companyRegistration-input",
+    "Name":"https://schema.org/companyRegistration-input",
     "Domain Bucket":"< 1K"
   },
   {
     "Class":"Predicate",
-    "Name":"http:\/\/schema.org\/companyRegistration-output",
+    "Name":"https://schema.org/companyRegistration-output",
     "Domain Bucket":"< 1K"
   },
   {
     "Class":"Predicate",
-    "Name":"http:\/\/schema.org\/competencyRequired",
+    "Name":"https://schema.org/competencyRequired",
     "Domain Bucket":"1K - 10K"
   },
   {
     "Class":"Predicate",
-    "Name":"http:\/\/schema.org\/competencyRequired-input",
+    "Name":"https://schema.org/competencyRequired-input",
     "Domain Bucket":"< 1K"
   },
   {
     "Class":"Predicate",
-    "Name":"http:\/\/schema.org\/competencyRequired-output",
+    "Name":"https://schema.org/competencyRequired-output",
     "Domain Bucket":"< 1K"
   },
   {
     "Class":"Predicate",
-    "Name":"http:\/\/schema.org\/competitor",
+    "Name":"https://schema.org/competitor",
     "Domain Bucket":"1K - 10K"
   },
   {
     "Class":"Predicate",
-    "Name":"http:\/\/schema.org\/competitor-input",
+    "Name":"https://schema.org/competitor-input",
     "Domain Bucket":"< 1K"
   },
   {
     "Class":"Predicate",
-    "Name":"http:\/\/schema.org\/competitor-output",
+    "Name":"https://schema.org/competitor-output",
     "Domain Bucket":"< 1K"
   },
   {
     "Class":"Predicate",
-    "Name":"http:\/\/schema.org\/composer",
+    "Name":"https://schema.org/composer",
     "Domain Bucket":"1K - 10K"
   },
   {
     "Class":"Predicate",
-    "Name":"http:\/\/schema.org\/composer-input",
+    "Name":"https://schema.org/composer-input",
     "Domain Bucket":"< 1K"
   },
   {
     "Class":"Predicate",
-    "Name":"http:\/\/schema.org\/composer-output",
+    "Name":"https://schema.org/composer-output",
     "Domain Bucket":"< 1K"
   },
   {
     "Class":"Predicate",
-    "Name":"http:\/\/schema.org\/comprisedOf",
+    "Name":"https://schema.org/comprisedOf",
     "Domain Bucket":"< 1K"
   },
   {
     "Class":"Predicate",
-    "Name":"http:\/\/schema.org\/comprisedOf-input",
+    "Name":"https://schema.org/comprisedOf-input",
     "Domain Bucket":"< 1K"
   },
   {
     "Class":"Predicate",
-    "Name":"http:\/\/schema.org\/comprisedOf-output",
+    "Name":"https://schema.org/comprisedOf-output",
     "Domain Bucket":"< 1K"
   },
   {
     "Class":"Predicate",
-    "Name":"http:\/\/schema.org\/conditionsOfAccess",
+    "Name":"https://schema.org/conditionsOfAccess",
     "Domain Bucket":"< 1K"
   },
   {
     "Class":"Predicate",
-    "Name":"http:\/\/schema.org\/conditionsOfAccess-input",
+    "Name":"https://schema.org/conditionsOfAccess-input",
     "Domain Bucket":"< 1K"
   },
   {
     "Class":"Predicate",
-    "Name":"http:\/\/schema.org\/conditionsOfAccess-output",
+    "Name":"https://schema.org/conditionsOfAccess-output",
     "Domain Bucket":"< 1K"
   },
   {
     "Class":"Predicate",
-    "Name":"http:\/\/schema.org\/confirmationNumber",
+    "Name":"https://schema.org/confirmationNumber",
     "Domain Bucket":"< 1K"
   },
   {
     "Class":"Predicate",
-    "Name":"http:\/\/schema.org\/confirmationNumber-input",
+    "Name":"https://schema.org/confirmationNumber-input",
     "Domain Bucket":"< 1K"
   },
   {
     "Class":"Predicate",
-    "Name":"http:\/\/schema.org\/confirmationNumber-output",
+    "Name":"https://schema.org/confirmationNumber-output",
     "Domain Bucket":"< 1K"
   },
   {
     "Class":"Predicate",
-    "Name":"http:\/\/schema.org\/connectedTo",
+    "Name":"https://schema.org/connectedTo",
     "Domain Bucket":"< 1K"
   },
   {
     "Class":"Predicate",
-    "Name":"http:\/\/schema.org\/connectedTo-input",
+    "Name":"https://schema.org/connectedTo-input",
     "Domain Bucket":"< 1K"
   },
   {
     "Class":"Predicate",
-    "Name":"http:\/\/schema.org\/connectedTo-output",
+    "Name":"https://schema.org/connectedTo-output",
     "Domain Bucket":"< 1K"
   },
   {
     "Class":"Predicate",
-    "Name":"http:\/\/schema.org\/constraintProperty",
+    "Name":"https://schema.org/constraintProperty",
     "Domain Bucket":"< 1K"
   },
   {
     "Class":"Predicate",
-    "Name":"http:\/\/schema.org\/constraintProperty-input",
+    "Name":"https://schema.org/constraintProperty-input",
     "Domain Bucket":"< 1K"
   },
   {
     "Class":"Predicate",
-    "Name":"http:\/\/schema.org\/constraintProperty-output",
+    "Name":"https://schema.org/constraintProperty-output",
     "Domain Bucket":"< 1K"
   },
   {
     "Class":"Predicate",
-    "Name":"http:\/\/schema.org\/contactOption",
+    "Name":"https://schema.org/contactOption",
     "Domain Bucket":"100K - 1M"
   },
   {
     "Class":"Predicate",
-    "Name":"http:\/\/schema.org\/contactOption-input",
+    "Name":"https://schema.org/contactOption-input",
     "Domain Bucket":"< 1K"
   },
   {
     "Class":"Predicate",
-    "Name":"http:\/\/schema.org\/contactOption-output",
+    "Name":"https://schema.org/contactOption-output",
     "Domain Bucket":"< 1K"
   },
   {
     "Class":"Predicate",
-    "Name":"http:\/\/schema.org\/contactPoint",
+    "Name":"https://schema.org/contactPoint",
     "Domain Bucket":"1M - 10M"
   },
   {
     "Class":"Predicate",
-    "Name":"http:\/\/schema.org\/contactPoint-input",
+    "Name":"https://schema.org/contactPoint-input",
     "Domain Bucket":"< 1K"
   },
   {
     "Class":"Predicate",
-    "Name":"http:\/\/schema.org\/contactPoint-output",
+    "Name":"https://schema.org/contactPoint-output",
     "Domain Bucket":"< 1K"
   },
   {
     "Class":"Predicate",
-    "Name":"http:\/\/schema.org\/contactPoints",
+    "Name":"https://schema.org/contactPoints",
     "Domain Bucket":"< 1K"
   },
   {
     "Class":"Predicate",
-    "Name":"http:\/\/schema.org\/contactPoints-input",
+    "Name":"https://schema.org/contactPoints-input",
     "Domain Bucket":"< 1K"
   },
   {
     "Class":"Predicate",
-    "Name":"http:\/\/schema.org\/contactPoints-output",
+    "Name":"https://schema.org/contactPoints-output",
     "Domain Bucket":"< 1K"
   },
   {
     "Class":"Predicate",
-    "Name":"http:\/\/schema.org\/contactType",
+    "Name":"https://schema.org/contactType",
     "Domain Bucket":"1M - 10M"
   },
   {
     "Class":"Predicate",
-    "Name":"http:\/\/schema.org\/contactType-input",
+    "Name":"https://schema.org/contactType-input",
     "Domain Bucket":"< 1K"
   },
   {
     "Class":"Predicate",
-    "Name":"http:\/\/schema.org\/contactType-output",
+    "Name":"https://schema.org/contactType-output",
     "Domain Bucket":"< 1K"
   },
   {
     "Class":"Predicate",
-    "Name":"http:\/\/schema.org\/contactlessPayment",
+    "Name":"https://schema.org/contactlessPayment",
     "Domain Bucket":"< 1K"
   },
   {
     "Class":"Predicate",
-    "Name":"http:\/\/schema.org\/contactlessPayment-input",
+    "Name":"https://schema.org/contactlessPayment-input",
     "Domain Bucket":"< 1K"
   },
   {
     "Class":"Predicate",
-    "Name":"http:\/\/schema.org\/contactlessPayment-output",
+    "Name":"https://schema.org/contactlessPayment-output",
     "Domain Bucket":"< 1K"
   },
   {
     "Class":"Predicate",
-    "Name":"http:\/\/schema.org\/containedIn",
+    "Name":"https://schema.org/containedIn",
     "Domain Bucket":"10K - 100K"
   },
   {
     "Class":"Predicate",
-    "Name":"http:\/\/schema.org\/containedIn-input",
+    "Name":"https://schema.org/containedIn-input",
     "Domain Bucket":"< 1K"
   },
   {
     "Class":"Predicate",
-    "Name":"http:\/\/schema.org\/containedIn-output",
+    "Name":"https://schema.org/containedIn-output",
     "Domain Bucket":"< 1K"
   },
   {
     "Class":"Predicate",
-    "Name":"http:\/\/schema.org\/containedInPlace",
+    "Name":"https://schema.org/containedInPlace",
     "Domain Bucket":"100K - 1M"
   },
   {
     "Class":"Predicate",
-    "Name":"http:\/\/schema.org\/containedInPlace-input",
+    "Name":"https://schema.org/containedInPlace-input",
     "Domain Bucket":"< 1K"
   },
   {
     "Class":"Predicate",
-    "Name":"http:\/\/schema.org\/containedInPlace-output",
+    "Name":"https://schema.org/containedInPlace-output",
     "Domain Bucket":"< 1K"
   },
   {
     "Class":"Predicate",
-    "Name":"http:\/\/schema.org\/containsPlace",
+    "Name":"https://schema.org/containsPlace",
     "Domain Bucket":"10K - 100K"
   },
   {
     "Class":"Predicate",
-    "Name":"http:\/\/schema.org\/containsPlace-input",
+    "Name":"https://schema.org/containsPlace-input",
     "Domain Bucket":"< 1K"
   },
   {
     "Class":"Predicate",
-    "Name":"http:\/\/schema.org\/containsPlace-output",
+    "Name":"https://schema.org/containsPlace-output",
     "Domain Bucket":"< 1K"
   },
   {
     "Class":"Predicate",
-    "Name":"http:\/\/schema.org\/containsSeason",
+    "Name":"https://schema.org/containsSeason",
     "Domain Bucket":"1K - 10K"
   },
   {
     "Class":"Predicate",
-    "Name":"http:\/\/schema.org\/containsSeason-input",
+    "Name":"https://schema.org/containsSeason-input",
     "Domain Bucket":"< 1K"
   },
   {
     "Class":"Predicate",
-    "Name":"http:\/\/schema.org\/containsSeason-output",
+    "Name":"https://schema.org/containsSeason-output",
     "Domain Bucket":"< 1K"
   },
   {
     "Class":"Predicate",
-    "Name":"http:\/\/schema.org\/contentLocation",
+    "Name":"https://schema.org/contentLocation",
     "Domain Bucket":"10K - 100K"
   },
   {
     "Class":"Predicate",
-    "Name":"http:\/\/schema.org\/contentLocation-input",
+    "Name":"https://schema.org/contentLocation-input",
     "Domain Bucket":"< 1K"
   },
   {
     "Class":"Predicate",
-    "Name":"http:\/\/schema.org\/contentLocation-output",
+    "Name":"https://schema.org/contentLocation-output",
     "Domain Bucket":"< 1K"
   },
   {
     "Class":"Predicate",
-    "Name":"http:\/\/schema.org\/contentRating",
+    "Name":"https://schema.org/contentRating",
     "Domain Bucket":"10K - 100K"
   },
   {
     "Class":"Predicate",
-    "Name":"http:\/\/schema.org\/contentRating-input",
+    "Name":"https://schema.org/contentRating-input",
     "Domain Bucket":"< 1K"
   },
   {
     "Class":"Predicate",
-    "Name":"http:\/\/schema.org\/contentRating-output",
+    "Name":"https://schema.org/contentRating-output",
     "Domain Bucket":"< 1K"
   },
   {
     "Class":"Predicate",
-    "Name":"http:\/\/schema.org\/contentReferenceTime",
+    "Name":"https://schema.org/contentReferenceTime",
     "Domain Bucket":"1K - 10K"
   },
   {
     "Class":"Predicate",
-    "Name":"http:\/\/schema.org\/contentReferenceTime-input",
+    "Name":"https://schema.org/contentReferenceTime-input",
     "Domain Bucket":"< 1K"
   },
   {
     "Class":"Predicate",
-    "Name":"http:\/\/schema.org\/contentReferenceTime-output",
+    "Name":"https://schema.org/contentReferenceTime-output",
     "Domain Bucket":"< 1K"
   },
   {
     "Class":"Predicate",
-    "Name":"http:\/\/schema.org\/contentSize",
+    "Name":"https://schema.org/contentSize",
     "Domain Bucket":"100K - 1M"
   },
   {
     "Class":"Predicate",
-    "Name":"http:\/\/schema.org\/contentSize-input",
+    "Name":"https://schema.org/contentSize-input",
     "Domain Bucket":"< 1K"
   },
   {
     "Class":"Predicate",
-    "Name":"http:\/\/schema.org\/contentSize-output",
+    "Name":"https://schema.org/contentSize-output",
     "Domain Bucket":"< 1K"
   },
   {
     "Class":"Predicate",
-    "Name":"http:\/\/schema.org\/contentType",
+    "Name":"https://schema.org/contentType",
     "Domain Bucket":"10K - 100K"
   },
   {
     "Class":"Predicate",
-    "Name":"http:\/\/schema.org\/contentType-input",
+    "Name":"https://schema.org/contentType-input",
     "Domain Bucket":"< 1K"
   },
   {
     "Class":"Predicate",
-    "Name":"http:\/\/schema.org\/contentType-output",
+    "Name":"https://schema.org/contentType-output",
     "Domain Bucket":"< 1K"
   },
   {
     "Class":"Predicate",
-    "Name":"http:\/\/schema.org\/contentUrl",
+    "Name":"https://schema.org/contentUrl",
     "Domain Bucket":"10M+"
   },
   {
     "Class":"Predicate",
-    "Name":"http:\/\/schema.org\/contentUrl-input",
+    "Name":"https://schema.org/contentUrl-input",
     "Domain Bucket":"< 1K"
   },
   {
     "Class":"Predicate",
-    "Name":"http:\/\/schema.org\/contentUrl-output",
+    "Name":"https://schema.org/contentUrl-output",
     "Domain Bucket":"< 1K"
   },
   {
     "Class":"Predicate",
-    "Name":"http:\/\/schema.org\/contraindication",
+    "Name":"https://schema.org/contraindication",
     "Domain Bucket":"1K - 10K"
   },
   {
     "Class":"Predicate",
-    "Name":"http:\/\/schema.org\/contraindication-input",
+    "Name":"https://schema.org/contraindication-input",
     "Domain Bucket":"< 1K"
   },
   {
     "Class":"Predicate",
-    "Name":"http:\/\/schema.org\/contraindication-output",
+    "Name":"https://schema.org/contraindication-output",
     "Domain Bucket":"< 1K"
   },
   {
     "Class":"Predicate",
-    "Name":"http:\/\/schema.org\/contributor",
+    "Name":"https://schema.org/contributor",
     "Domain Bucket":"100K - 1M"
   },
   {
     "Class":"Predicate",
-    "Name":"http:\/\/schema.org\/contributor-input",
+    "Name":"https://schema.org/contributor-input",
     "Domain Bucket":"< 1K"
   },
   {
     "Class":"Predicate",
-    "Name":"http:\/\/schema.org\/contributor-output",
+    "Name":"https://schema.org/contributor-output",
     "Domain Bucket":"< 1K"
   },
   {
     "Class":"Predicate",
-    "Name":"http:\/\/schema.org\/cookTime",
+    "Name":"https://schema.org/cookTime",
     "Domain Bucket":"10K - 100K"
   },
   {
     "Class":"Predicate",
-    "Name":"http:\/\/schema.org\/cookTime-input",
+    "Name":"https://schema.org/cookTime-input",
     "Domain Bucket":"< 1K"
   },
   {
     "Class":"Predicate",
-    "Name":"http:\/\/schema.org\/cookTime-output",
+    "Name":"https://schema.org/cookTime-output",
     "Domain Bucket":"< 1K"
   },
   {
     "Class":"Predicate",
-    "Name":"http:\/\/schema.org\/cookingMethod",
+    "Name":"https://schema.org/cookingMethod",
     "Domain Bucket":"1K - 10K"
   },
   {
     "Class":"Predicate",
-    "Name":"http:\/\/schema.org\/cookingMethod-input",
+    "Name":"https://schema.org/cookingMethod-input",
     "Domain Bucket":"< 1K"
   },
   {
     "Class":"Predicate",
-    "Name":"http:\/\/schema.org\/cookingMethod-output",
+    "Name":"https://schema.org/cookingMethod-output",
     "Domain Bucket":"< 1K"
   },
   {
     "Class":"Predicate",
-    "Name":"http:\/\/schema.org\/copyrightHolder",
+    "Name":"https://schema.org/copyrightHolder",
     "Domain Bucket":"100K - 1M"
   },
   {
     "Class":"Predicate",
-    "Name":"http:\/\/schema.org\/copyrightHolder-input",
+    "Name":"https://schema.org/copyrightHolder-input",
     "Domain Bucket":"< 1K"
   },
   {
     "Class":"Predicate",
-    "Name":"http:\/\/schema.org\/copyrightHolder-output",
+    "Name":"https://schema.org/copyrightHolder-output",
     "Domain Bucket":"< 1K"
   },
   {
     "Class":"Predicate",
-    "Name":"http:\/\/schema.org\/copyrightNotice",
+    "Name":"https://schema.org/copyrightNotice",
     "Domain Bucket":"10K - 100K"
   },
   {
     "Class":"Predicate",
-    "Name":"http:\/\/schema.org\/copyrightNotice-input",
+    "Name":"https://schema.org/copyrightNotice-input",
     "Domain Bucket":"< 1K"
   },
   {
     "Class":"Predicate",
-    "Name":"http:\/\/schema.org\/copyrightNotice-output",
+    "Name":"https://schema.org/copyrightNotice-output",
     "Domain Bucket":"< 1K"
   },
   {
     "Class":"Predicate",
-    "Name":"http:\/\/schema.org\/copyrightYear",
+    "Name":"https://schema.org/copyrightYear",
     "Domain Bucket":"100K - 1M"
   },
   {
     "Class":"Predicate",
-    "Name":"http:\/\/schema.org\/copyrightYear-input",
+    "Name":"https://schema.org/copyrightYear-input",
     "Domain Bucket":"< 1K"
   },
   {
     "Class":"Predicate",
-    "Name":"http:\/\/schema.org\/copyrightYear-output",
+    "Name":"https://schema.org/copyrightYear-output",
     "Domain Bucket":"< 1K"
   },
   {
     "Class":"Predicate",
-    "Name":"http:\/\/schema.org\/correction",
+    "Name":"https://schema.org/correction",
     "Domain Bucket":"< 1K"
   },
   {
     "Class":"Predicate",
-    "Name":"http:\/\/schema.org\/correction-input",
+    "Name":"https://schema.org/correction-input",
     "Domain Bucket":"< 1K"
   },
   {
     "Class":"Predicate",
-    "Name":"http:\/\/schema.org\/correction-output",
+    "Name":"https://schema.org/correction-output",
     "Domain Bucket":"< 1K"
   },
   {
     "Class":"Predicate",
-    "Name":"http:\/\/schema.org\/correctionsPolicy",
+    "Name":"https://schema.org/correctionsPolicy",
     "Domain Bucket":"10K - 100K"
   },
   {
     "Class":"Predicate",
-    "Name":"http:\/\/schema.org\/correctionsPolicy-input",
+    "Name":"https://schema.org/correctionsPolicy-input",
     "Domain Bucket":"< 1K"
   },
   {
     "Class":"Predicate",
-    "Name":"http:\/\/schema.org\/correctionsPolicy-output",
+    "Name":"https://schema.org/correctionsPolicy-output",
     "Domain Bucket":"< 1K"
   },
   {
     "Class":"Predicate",
-    "Name":"http:\/\/schema.org\/costCategory",
+    "Name":"https://schema.org/costCategory",
     "Domain Bucket":"< 1K"
   },
   {
     "Class":"Predicate",
-    "Name":"http:\/\/schema.org\/costCategory-input",
+    "Name":"https://schema.org/costCategory-input",
     "Domain Bucket":"< 1K"
   },
   {
     "Class":"Predicate",
-    "Name":"http:\/\/schema.org\/costCategory-output",
+    "Name":"https://schema.org/costCategory-output",
     "Domain Bucket":"< 1K"
   },
   {
     "Class":"Predicate",
-    "Name":"http:\/\/schema.org\/costCurrency",
+    "Name":"https://schema.org/costCurrency",
     "Domain Bucket":"< 1K"
   },
   {
     "Class":"Predicate",
-    "Name":"http:\/\/schema.org\/costCurrency-input",
+    "Name":"https://schema.org/costCurrency-input",
     "Domain Bucket":"< 1K"
   },
   {
     "Class":"Predicate",
-    "Name":"http:\/\/schema.org\/costCurrency-output",
+    "Name":"https://schema.org/costCurrency-output",
     "Domain Bucket":"< 1K"
   },
   {
     "Class":"Predicate",
-    "Name":"http:\/\/schema.org\/costOrigin",
+    "Name":"https://schema.org/costOrigin",
     "Domain Bucket":"< 1K"
   },
   {
     "Class":"Predicate",
-    "Name":"http:\/\/schema.org\/costOrigin-input",
+    "Name":"https://schema.org/costOrigin-input",
     "Domain Bucket":"< 1K"
   },
   {
     "Class":"Predicate",
-    "Name":"http:\/\/schema.org\/costOrigin-output",
+    "Name":"https://schema.org/costOrigin-output",
     "Domain Bucket":"< 1K"
   },
   {
     "Class":"Predicate",
-    "Name":"http:\/\/schema.org\/costPerUnit",
+    "Name":"https://schema.org/costPerUnit",
     "Domain Bucket":"< 1K"
   },
   {
     "Class":"Predicate",
-    "Name":"http:\/\/schema.org\/costPerUnit-input",
+    "Name":"https://schema.org/costPerUnit-input",
     "Domain Bucket":"< 1K"
   },
   {
     "Class":"Predicate",
-    "Name":"http:\/\/schema.org\/costPerUnit-output",
+    "Name":"https://schema.org/costPerUnit-output",
     "Domain Bucket":"< 1K"
   },
   {
     "Class":"Predicate",
-    "Name":"http:\/\/schema.org\/countriesNotSupported",
+    "Name":"https://schema.org/countriesNotSupported",
     "Domain Bucket":"< 1K"
   },
   {
     "Class":"Predicate",
-    "Name":"http:\/\/schema.org\/countriesNotSupported-input",
+    "Name":"https://schema.org/countriesNotSupported-input",
     "Domain Bucket":"< 1K"
   },
   {
     "Class":"Predicate",
-    "Name":"http:\/\/schema.org\/countriesNotSupported-output",
+    "Name":"https://schema.org/countriesNotSupported-output",
     "Domain Bucket":"< 1K"
   },
   {
     "Class":"Predicate",
-    "Name":"http:\/\/schema.org\/countriesSupported",
+    "Name":"https://schema.org/countriesSupported",
     "Domain Bucket":"1K - 10K"
   },
   {
     "Class":"Predicate",
-    "Name":"http:\/\/schema.org\/countriesSupported-input",
+    "Name":"https://schema.org/countriesSupported-input",
     "Domain Bucket":"< 1K"
   },
   {
     "Class":"Predicate",
-    "Name":"http:\/\/schema.org\/countriesSupported-output",
+    "Name":"https://schema.org/countriesSupported-output",
     "Domain Bucket":"< 1K"
   },
   {
     "Class":"Predicate",
-    "Name":"http:\/\/schema.org\/countryOfAssembly",
+    "Name":"https://schema.org/countryOfAssembly",
     "Domain Bucket":"1K - 10K"
   },
   {
     "Class":"Predicate",
-    "Name":"http:\/\/schema.org\/countryOfAssembly-input",
+    "Name":"https://schema.org/countryOfAssembly-input",
     "Domain Bucket":"< 1K"
   },
   {
     "Class":"Predicate",
-    "Name":"http:\/\/schema.org\/countryOfAssembly-output",
+    "Name":"https://schema.org/countryOfAssembly-output",
     "Domain Bucket":"< 1K"
   },
   {
     "Class":"Predicate",
-    "Name":"http:\/\/schema.org\/countryOfLastProcessing",
+    "Name":"https://schema.org/countryOfLastProcessing",
     "Domain Bucket":"< 1K"
   },
   {
     "Class":"Predicate",
-    "Name":"http:\/\/schema.org\/countryOfLastProcessing-input",
+    "Name":"https://schema.org/countryOfLastProcessing-input",
     "Domain Bucket":"< 1K"
   },
   {
     "Class":"Predicate",
-    "Name":"http:\/\/schema.org\/countryOfLastProcessing-output",
+    "Name":"https://schema.org/countryOfLastProcessing-output",
     "Domain Bucket":"< 1K"
   },
   {
     "Class":"Predicate",
-    "Name":"http:\/\/schema.org\/countryOfOrigin",
+    "Name":"https://schema.org/countryOfOrigin",
     "Domain Bucket":"10K - 100K"
   },
   {
     "Class":"Predicate",
-    "Name":"http:\/\/schema.org\/countryOfOrigin-input",
+    "Name":"https://schema.org/countryOfOrigin-input",
     "Domain Bucket":"< 1K"
   },
   {
     "Class":"Predicate",
-    "Name":"http:\/\/schema.org\/countryOfOrigin-output",
+    "Name":"https://schema.org/countryOfOrigin-output",
     "Domain Bucket":"< 1K"
   },
   {
     "Class":"Predicate",
-    "Name":"http:\/\/schema.org\/course",
+    "Name":"https://schema.org/course",
     "Domain Bucket":"< 1K"
   },
   {
     "Class":"Predicate",
-    "Name":"http:\/\/schema.org\/course-input",
+    "Name":"https://schema.org/course-input",
     "Domain Bucket":"< 1K"
   },
   {
     "Class":"Predicate",
-    "Name":"http:\/\/schema.org\/course-output",
+    "Name":"https://schema.org/course-output",
     "Domain Bucket":"< 1K"
   },
   {
     "Class":"Predicate",
-    "Name":"http:\/\/schema.org\/courseCode",
+    "Name":"https://schema.org/courseCode",
     "Domain Bucket":"10K - 100K"
   },
   {
     "Class":"Predicate",
-    "Name":"http:\/\/schema.org\/courseCode-input",
+    "Name":"https://schema.org/courseCode-input",
     "Domain Bucket":"< 1K"
   },
   {
     "Class":"Predicate",
-    "Name":"http:\/\/schema.org\/courseCode-output",
+    "Name":"https://schema.org/courseCode-output",
     "Domain Bucket":"< 1K"
   },
   {
     "Class":"Predicate",
-    "Name":"http:\/\/schema.org\/courseMode",
+    "Name":"https://schema.org/courseMode",
     "Domain Bucket":"10K - 100K"
   },
   {
     "Class":"Predicate",
-    "Name":"http:\/\/schema.org\/courseMode-input",
+    "Name":"https://schema.org/courseMode-input",
     "Domain Bucket":"< 1K"
   },
   {
     "Class":"Predicate",
-    "Name":"http:\/\/schema.org\/courseMode-output",
+    "Name":"https://schema.org/courseMode-output",
     "Domain Bucket":"< 1K"
   },
   {
     "Class":"Predicate",
-    "Name":"http:\/\/schema.org\/coursePrerequisites",
+    "Name":"https://schema.org/coursePrerequisites",
     "Domain Bucket":"1K - 10K"
   },
   {
     "Class":"Predicate",
-    "Name":"http:\/\/schema.org\/coursePrerequisites-input",
+    "Name":"https://schema.org/coursePrerequisites-input",
     "Domain Bucket":"< 1K"
   },
   {
     "Class":"Predicate",
-    "Name":"http:\/\/schema.org\/coursePrerequisites-output",
+    "Name":"https://schema.org/coursePrerequisites-output",
     "Domain Bucket":"< 1K"
   },
   {
     "Class":"Predicate",
-    "Name":"http:\/\/schema.org\/courseSchedule",
+    "Name":"https://schema.org/courseSchedule",
     "Domain Bucket":"1K - 10K"
   },
   {
     "Class":"Predicate",
-    "Name":"http:\/\/schema.org\/courseSchedule-input",
+    "Name":"https://schema.org/courseSchedule-input",
     "Domain Bucket":"< 1K"
   },
   {
     "Class":"Predicate",
-    "Name":"http:\/\/schema.org\/courseSchedule-output",
+    "Name":"https://schema.org/courseSchedule-output",
     "Domain Bucket":"< 1K"
   },
   {
     "Class":"Predicate",
-    "Name":"http:\/\/schema.org\/courseWorkload",
+    "Name":"https://schema.org/courseWorkload",
     "Domain Bucket":"10K - 100K"
   },
   {
     "Class":"Predicate",
-    "Name":"http:\/\/schema.org\/courseWorkload-input",
+    "Name":"https://schema.org/courseWorkload-input",
     "Domain Bucket":"< 1K"
   },
   {
     "Class":"Predicate",
-    "Name":"http:\/\/schema.org\/courseWorkload-output",
+    "Name":"https://schema.org/courseWorkload-output",
     "Domain Bucket":"< 1K"
   },
   {
     "Class":"Predicate",
-    "Name":"http:\/\/schema.org\/coverageEndTime",
+    "Name":"https://schema.org/coverageEndTime",
     "Domain Bucket":"1K - 10K"
   },
   {
     "Class":"Predicate",
-    "Name":"http:\/\/schema.org\/coverageEndTime-input",
+    "Name":"https://schema.org/coverageEndTime-input",
     "Domain Bucket":"< 1K"
   },
   {
     "Class":"Predicate",
-    "Name":"http:\/\/schema.org\/coverageEndTime-output",
+    "Name":"https://schema.org/coverageEndTime-output",
     "Domain Bucket":"< 1K"
   },
   {
     "Class":"Predicate",
-    "Name":"http:\/\/schema.org\/coverageStartTime",
+    "Name":"https://schema.org/coverageStartTime",
     "Domain Bucket":"1K - 10K"
   },
   {
     "Class":"Predicate",
-    "Name":"http:\/\/schema.org\/coverageStartTime-input",
+    "Name":"https://schema.org/coverageStartTime-input",
     "Domain Bucket":"< 1K"
   },
   {
     "Class":"Predicate",
-    "Name":"http:\/\/schema.org\/coverageStartTime-output",
+    "Name":"https://schema.org/coverageStartTime-output",
     "Domain Bucket":"< 1K"
   },
   {
     "Class":"Predicate",
-    "Name":"http:\/\/schema.org\/creativeWorkStatus",
+    "Name":"https://schema.org/creativeWorkStatus",
     "Domain Bucket":"1K - 10K"
   },
   {
     "Class":"Predicate",
-    "Name":"http:\/\/schema.org\/creativeWorkStatus-input",
+    "Name":"https://schema.org/creativeWorkStatus-input",
     "Domain Bucket":"< 1K"
   },
   {
     "Class":"Predicate",
-    "Name":"http:\/\/schema.org\/creativeWorkStatus-output",
+    "Name":"https://schema.org/creativeWorkStatus-output",
     "Domain Bucket":"< 1K"
   },
   {
     "Class":"Predicate",
-    "Name":"http:\/\/schema.org\/creator",
+    "Name":"https://schema.org/creator",
     "Domain Bucket":"1M - 10M"
   },
   {
     "Class":"Predicate",
-    "Name":"http:\/\/schema.org\/creator-input",
+    "Name":"https://schema.org/creator-input",
     "Domain Bucket":"< 1K"
   },
   {
     "Class":"Predicate",
-    "Name":"http:\/\/schema.org\/creator-output",
+    "Name":"https://schema.org/creator-output",
     "Domain Bucket":"< 1K"
   },
   {
     "Class":"Predicate",
-    "Name":"http:\/\/schema.org\/credentialCategory",
+    "Name":"https://schema.org/credentialCategory",
     "Domain Bucket":"10K - 100K"
   },
   {
     "Class":"Predicate",
-    "Name":"http:\/\/schema.org\/credentialCategory-input",
+    "Name":"https://schema.org/credentialCategory-input",
     "Domain Bucket":"< 1K"
   },
   {
     "Class":"Predicate",
-    "Name":"http:\/\/schema.org\/credentialCategory-output",
+    "Name":"https://schema.org/credentialCategory-output",
     "Domain Bucket":"< 1K"
   },
   {
     "Class":"Predicate",
-    "Name":"http:\/\/schema.org\/creditText",
+    "Name":"https://schema.org/creditText",
     "Domain Bucket":"100K - 1M"
   },
   {
     "Class":"Predicate",
-    "Name":"http:\/\/schema.org\/creditText-input",
+    "Name":"https://schema.org/creditText-input",
     "Domain Bucket":"< 1K"
   },
   {
     "Class":"Predicate",
-    "Name":"http:\/\/schema.org\/creditText-output",
+    "Name":"https://schema.org/creditText-output",
     "Domain Bucket":"< 1K"
   },
   {
     "Class":"Predicate",
-    "Name":"http:\/\/schema.org\/creditedTo",
+    "Name":"https://schema.org/creditedTo",
     "Domain Bucket":"< 1K"
   },
   {
     "Class":"Predicate",
-    "Name":"http:\/\/schema.org\/creditedTo-input",
+    "Name":"https://schema.org/creditedTo-input",
     "Domain Bucket":"< 1K"
   },
   {
     "Class":"Predicate",
-    "Name":"http:\/\/schema.org\/creditedTo-output",
+    "Name":"https://schema.org/creditedTo-output",
     "Domain Bucket":"< 1K"
   },
   {
     "Class":"Predicate",
-    "Name":"http:\/\/schema.org\/cssSelector",
+    "Name":"https://schema.org/cssSelector",
     "Domain Bucket":"100K - 1M"
   },
   {
     "Class":"Predicate",
-    "Name":"http:\/\/schema.org\/cssSelector-input",
+    "Name":"https://schema.org/cssSelector-input",
     "Domain Bucket":"< 1K"
   },
   {
     "Class":"Predicate",
-    "Name":"http:\/\/schema.org\/cssSelector-output",
+    "Name":"https://schema.org/cssSelector-output",
     "Domain Bucket":"< 1K"
   },
   {
     "Class":"Predicate",
-    "Name":"http:\/\/schema.org\/currenciesAccepted",
+    "Name":"https://schema.org/currenciesAccepted",
     "Domain Bucket":"100K - 1M"
   },
   {
     "Class":"Predicate",
-    "Name":"http:\/\/schema.org\/currenciesAccepted-input",
+    "Name":"https://schema.org/currenciesAccepted-input",
     "Domain Bucket":"< 1K"
   },
   {
     "Class":"Predicate",
-    "Name":"http:\/\/schema.org\/currenciesAccepted-output",
+    "Name":"https://schema.org/currenciesAccepted-output",
     "Domain Bucket":"< 1K"
   },
   {
     "Class":"Predicate",
-    "Name":"http:\/\/schema.org\/currency",
+    "Name":"https://schema.org/currency",
     "Domain Bucket":"100K - 1M"
   },
   {
     "Class":"Predicate",
-    "Name":"http:\/\/schema.org\/currency-input",
+    "Name":"https://schema.org/currency-input",
     "Domain Bucket":"< 1K"
   },
   {
     "Class":"Predicate",
-    "Name":"http:\/\/schema.org\/currency-output",
+    "Name":"https://schema.org/currency-output",
     "Domain Bucket":"< 1K"
   },
   {
     "Class":"Predicate",
-    "Name":"http:\/\/schema.org\/currentExchangeRate",
+    "Name":"https://schema.org/currentExchangeRate",
     "Domain Bucket":"< 1K"
   },
   {
     "Class":"Predicate",
-    "Name":"http:\/\/schema.org\/currentExchangeRate-input",
+    "Name":"https://schema.org/currentExchangeRate-input",
     "Domain Bucket":"< 1K"
   },
   {
     "Class":"Predicate",
-    "Name":"http:\/\/schema.org\/currentExchangeRate-output",
+    "Name":"https://schema.org/currentExchangeRate-output",
     "Domain Bucket":"< 1K"
   },
   {
     "Class":"Predicate",
-    "Name":"http:\/\/schema.org\/customer",
+    "Name":"https://schema.org/customer",
     "Domain Bucket":"< 1K"
   },
   {
     "Class":"Predicate",
-    "Name":"http:\/\/schema.org\/customer-input",
+    "Name":"https://schema.org/customer-input",
     "Domain Bucket":"< 1K"
   },
   {
     "Class":"Predicate",
-    "Name":"http:\/\/schema.org\/customer-output",
+    "Name":"https://schema.org/customer-output",
     "Domain Bucket":"< 1K"
   },
   {
     "Class":"Predicate",
-    "Name":"http:\/\/schema.org\/customerRemorseReturnFees",
+    "Name":"https://schema.org/customerRemorseReturnFees",
     "Domain Bucket":"1K - 10K"
   },
   {
     "Class":"Predicate",
-    "Name":"http:\/\/schema.org\/customerRemorseReturnFees-input",
+    "Name":"https://schema.org/customerRemorseReturnFees-input",
     "Domain Bucket":"< 1K"
   },
   {
     "Class":"Predicate",
-    "Name":"http:\/\/schema.org\/customerRemorseReturnFees-output",
+    "Name":"https://schema.org/customerRemorseReturnFees-output",
     "Domain Bucket":"< 1K"
   },
   {
     "Class":"Predicate",
-    "Name":"http:\/\/schema.org\/customerRemorseReturnLabelSource",
+    "Name":"https://schema.org/customerRemorseReturnLabelSource",
     "Domain Bucket":"1K - 10K"
   },
   {
     "Class":"Predicate",
-    "Name":"http:\/\/schema.org\/customerRemorseReturnLabelSource-input",
+    "Name":"https://schema.org/customerRemorseReturnLabelSource-input",
     "Domain Bucket":"< 1K"
   },
   {
     "Class":"Predicate",
-    "Name":"http:\/\/schema.org\/customerRemorseReturnLabelSource-output",
+    "Name":"https://schema.org/customerRemorseReturnLabelSource-output",
     "Domain Bucket":"< 1K"
   },
   {
     "Class":"Predicate",
-    "Name":"http:\/\/schema.org\/customerRemorseReturnShippingFeesAmount",
+    "Name":"https://schema.org/customerRemorseReturnShippingFeesAmount",
     "Domain Bucket":"< 1K"
   },
   {
     "Class":"Predicate",
-    "Name":"http:\/\/schema.org\/customerRemorseReturnShippingFeesAmount-input",
+    "Name":"https://schema.org/customerRemorseReturnShippingFeesAmount-input",
     "Domain Bucket":"< 1K"
   },
   {
     "Class":"Predicate",
-    "Name":"http:\/\/schema.org\/customerRemorseReturnShippingFeesAmount-output",
+    "Name":"https://schema.org/customerRemorseReturnShippingFeesAmount-output",
     "Domain Bucket":"< 1K"
   },
   {
     "Class":"Predicate",
-    "Name":"http:\/\/schema.org\/cutoffTime",
+    "Name":"https://schema.org/cutoffTime",
     "Domain Bucket":"10K - 100K"
   },
   {
     "Class":"Predicate",
-    "Name":"http:\/\/schema.org\/cutoffTime-input",
+    "Name":"https://schema.org/cutoffTime-input",
     "Domain Bucket":"< 1K"
   },
   {
     "Class":"Predicate",
-    "Name":"http:\/\/schema.org\/cutoffTime-output",
+    "Name":"https://schema.org/cutoffTime-output",
     "Domain Bucket":"< 1K"
   },
   {
     "Class":"Predicate",
-    "Name":"http:\/\/schema.org\/cvdCollectionDate",
+    "Name":"https://schema.org/cvdCollectionDate",
     "Domain Bucket":"< 1K"
   },
   {
     "Class":"Predicate",
-    "Name":"http:\/\/schema.org\/cvdCollectionDate-input",
+    "Name":"https://schema.org/cvdCollectionDate-input",
     "Domain Bucket":"< 1K"
   },
   {
     "Class":"Predicate",
-    "Name":"http:\/\/schema.org\/cvdCollectionDate-output",
+    "Name":"https://schema.org/cvdCollectionDate-output",
     "Domain Bucket":"< 1K"
   },
   {
     "Class":"Predicate",
-    "Name":"http:\/\/schema.org\/cvdFacilityCounty",
+    "Name":"https://schema.org/cvdFacilityCounty",
     "Domain Bucket":"< 1K"
   },
   {
     "Class":"Predicate",
-    "Name":"http:\/\/schema.org\/cvdFacilityCounty-input",
+    "Name":"https://schema.org/cvdFacilityCounty-input",
     "Domain Bucket":"< 1K"
   },
   {
     "Class":"Predicate",
-    "Name":"http:\/\/schema.org\/cvdFacilityCounty-output",
+    "Name":"https://schema.org/cvdFacilityCounty-output",
     "Domain Bucket":"< 1K"
   },
   {
     "Class":"Predicate",
-    "Name":"http:\/\/schema.org\/cvdFacilityId",
+    "Name":"https://schema.org/cvdFacilityId",
     "Domain Bucket":"< 1K"
   },
   {
     "Class":"Predicate",
-    "Name":"http:\/\/schema.org\/cvdFacilityId-input",
+    "Name":"https://schema.org/cvdFacilityId-input",
     "Domain Bucket":"< 1K"
   },
   {
     "Class":"Predicate",
-    "Name":"http:\/\/schema.org\/cvdFacilityId-output",
+    "Name":"https://schema.org/cvdFacilityId-output",
     "Domain Bucket":"< 1K"
   },
   {
     "Class":"Predicate",
-    "Name":"http:\/\/schema.org\/cvdNumBeds",
+    "Name":"https://schema.org/cvdNumBeds",
     "Domain Bucket":"< 1K"
   },
   {
     "Class":"Predicate",
-    "Name":"http:\/\/schema.org\/cvdNumBeds-input",
+    "Name":"https://schema.org/cvdNumBeds-input",
     "Domain Bucket":"< 1K"
   },
   {
     "Class":"Predicate",
-    "Name":"http:\/\/schema.org\/cvdNumBeds-output",
+    "Name":"https://schema.org/cvdNumBeds-output",
     "Domain Bucket":"< 1K"
   },
   {
     "Class":"Predicate",
-    "Name":"http:\/\/schema.org\/cvdNumBedsOcc",
+    "Name":"https://schema.org/cvdNumBedsOcc",
     "Domain Bucket":"< 1K"
   },
   {
     "Class":"Predicate",
-    "Name":"http:\/\/schema.org\/cvdNumBedsOcc-input",
+    "Name":"https://schema.org/cvdNumBedsOcc-input",
     "Domain Bucket":"< 1K"
   },
   {
     "Class":"Predicate",
-    "Name":"http:\/\/schema.org\/cvdNumBedsOcc-output",
+    "Name":"https://schema.org/cvdNumBedsOcc-output",
     "Domain Bucket":"< 1K"
   },
   {
     "Class":"Predicate",
-    "Name":"http:\/\/schema.org\/cvdNumC19Died",
+    "Name":"https://schema.org/cvdNumC19Died",
     "Domain Bucket":"< 1K"
   },
   {
     "Class":"Predicate",
-    "Name":"http:\/\/schema.org\/cvdNumC19Died-input",
+    "Name":"https://schema.org/cvdNumC19Died-input",
     "Domain Bucket":"< 1K"
   },
   {
     "Class":"Predicate",
-    "Name":"http:\/\/schema.org\/cvdNumC19Died-output",
+    "Name":"https://schema.org/cvdNumC19Died-output",
     "Domain Bucket":"< 1K"
   },
   {
     "Class":"Predicate",
-    "Name":"http:\/\/schema.org\/cvdNumC19HOPats",
+    "Name":"https://schema.org/cvdNumC19HOPats",
     "Domain Bucket":"< 1K"
   },
   {
     "Class":"Predicate",
-    "Name":"http:\/\/schema.org\/cvdNumC19HOPats-input",
+    "Name":"https://schema.org/cvdNumC19HOPats-input",
     "Domain Bucket":"< 1K"
   },
   {
     "Class":"Predicate",
-    "Name":"http:\/\/schema.org\/cvdNumC19HOPats-output",
+    "Name":"https://schema.org/cvdNumC19HOPats-output",
     "Domain Bucket":"< 1K"
   },
   {
     "Class":"Predicate",
-    "Name":"http:\/\/schema.org\/cvdNumC19HospPats",
+    "Name":"https://schema.org/cvdNumC19HospPats",
     "Domain Bucket":"< 1K"
   },
   {
     "Class":"Predicate",
-    "Name":"http:\/\/schema.org\/cvdNumC19HospPats-input",
+    "Name":"https://schema.org/cvdNumC19HospPats-input",
     "Domain Bucket":"< 1K"
   },
   {
     "Class":"Predicate",
-    "Name":"http:\/\/schema.org\/cvdNumC19HospPats-output",
+    "Name":"https://schema.org/cvdNumC19HospPats-output",
     "Domain Bucket":"< 1K"
   },
   {
     "Class":"Predicate",
-    "Name":"http:\/\/schema.org\/cvdNumC19MechVentPats",
+    "Name":"https://schema.org/cvdNumC19MechVentPats",
     "Domain Bucket":"< 1K"
   },
   {
     "Class":"Predicate",
-    "Name":"http:\/\/schema.org\/cvdNumC19MechVentPats-input",
+    "Name":"https://schema.org/cvdNumC19MechVentPats-input",
     "Domain Bucket":"< 1K"
   },
   {
     "Class":"Predicate",
-    "Name":"http:\/\/schema.org\/cvdNumC19MechVentPats-output",
+    "Name":"https://schema.org/cvdNumC19MechVentPats-output",
     "Domain Bucket":"< 1K"
   },
   {
     "Class":"Predicate",
-    "Name":"http:\/\/schema.org\/cvdNumC19OFMechVentPats",
+    "Name":"https://schema.org/cvdNumC19OFMechVentPats",
     "Domain Bucket":"< 1K"
   },
   {
     "Class":"Predicate",
-    "Name":"http:\/\/schema.org\/cvdNumC19OFMechVentPats-input",
+    "Name":"https://schema.org/cvdNumC19OFMechVentPats-input",
     "Domain Bucket":"< 1K"
   },
   {
     "Class":"Predicate",
-    "Name":"http:\/\/schema.org\/cvdNumC19OFMechVentPats-output",
+    "Name":"https://schema.org/cvdNumC19OFMechVentPats-output",
     "Domain Bucket":"< 1K"
   },
   {
     "Class":"Predicate",
-    "Name":"http:\/\/schema.org\/cvdNumC19OverflowPats",
+    "Name":"https://schema.org/cvdNumC19OverflowPats",
     "Domain Bucket":"< 1K"
   },
   {
     "Class":"Predicate",
-    "Name":"http:\/\/schema.org\/cvdNumC19OverflowPats-input",
+    "Name":"https://schema.org/cvdNumC19OverflowPats-input",
     "Domain Bucket":"< 1K"
   },
   {
     "Class":"Predicate",
-    "Name":"http:\/\/schema.org\/cvdNumC19OverflowPats-output",
+    "Name":"https://schema.org/cvdNumC19OverflowPats-output",
     "Domain Bucket":"< 1K"
   },
   {
     "Class":"Predicate",
-    "Name":"http:\/\/schema.org\/cvdNumICUBeds",
+    "Name":"https://schema.org/cvdNumICUBeds",
     "Domain Bucket":"< 1K"
   },
   {
     "Class":"Predicate",
-    "Name":"http:\/\/schema.org\/cvdNumICUBeds-input",
+    "Name":"https://schema.org/cvdNumICUBeds-input",
     "Domain Bucket":"< 1K"
   },
   {
     "Class":"Predicate",
-    "Name":"http:\/\/schema.org\/cvdNumICUBeds-output",
+    "Name":"https://schema.org/cvdNumICUBeds-output",
     "Domain Bucket":"< 1K"
   },
   {
     "Class":"Predicate",
-    "Name":"http:\/\/schema.org\/cvdNumICUBedsOcc",
+    "Name":"https://schema.org/cvdNumICUBedsOcc",
     "Domain Bucket":"< 1K"
   },
   {
     "Class":"Predicate",
-    "Name":"http:\/\/schema.org\/cvdNumICUBedsOcc-input",
+    "Name":"https://schema.org/cvdNumICUBedsOcc-input",
     "Domain Bucket":"< 1K"
   },
   {
     "Class":"Predicate",
-    "Name":"http:\/\/schema.org\/cvdNumICUBedsOcc-output",
+    "Name":"https://schema.org/cvdNumICUBedsOcc-output",
     "Domain Bucket":"< 1K"
   },
   {
     "Class":"Predicate",
-    "Name":"http:\/\/schema.org\/cvdNumTotBeds",
+    "Name":"https://schema.org/cvdNumTotBeds",
     "Domain Bucket":"< 1K"
   },
   {
     "Class":"Predicate",
-    "Name":"http:\/\/schema.org\/cvdNumTotBeds-input",
+    "Name":"https://schema.org/cvdNumTotBeds-input",
     "Domain Bucket":"< 1K"
   },
   {
     "Class":"Predicate",
-    "Name":"http:\/\/schema.org\/cvdNumTotBeds-output",
+    "Name":"https://schema.org/cvdNumTotBeds-output",
     "Domain Bucket":"< 1K"
   },
   {
     "Class":"Predicate",
-    "Name":"http:\/\/schema.org\/cvdNumVent",
+    "Name":"https://schema.org/cvdNumVent",
     "Domain Bucket":"< 1K"
   },
   {
     "Class":"Predicate",
-    "Name":"http:\/\/schema.org\/cvdNumVent-input",
+    "Name":"https://schema.org/cvdNumVent-input",
     "Domain Bucket":"< 1K"
   },
   {
     "Class":"Predicate",
-    "Name":"http:\/\/schema.org\/cvdNumVent-output",
+    "Name":"https://schema.org/cvdNumVent-output",
     "Domain Bucket":"< 1K"
   },
   {
     "Class":"Predicate",
-    "Name":"http:\/\/schema.org\/cvdNumVentUse",
+    "Name":"https://schema.org/cvdNumVentUse",
     "Domain Bucket":"< 1K"
   },
   {
     "Class":"Predicate",
-    "Name":"http:\/\/schema.org\/cvdNumVentUse-input",
+    "Name":"https://schema.org/cvdNumVentUse-input",
     "Domain Bucket":"< 1K"
   },
   {
     "Class":"Predicate",
-    "Name":"http:\/\/schema.org\/cvdNumVentUse-output",
+    "Name":"https://schema.org/cvdNumVentUse-output",
     "Domain Bucket":"< 1K"
   },
   {
     "Class":"Predicate",
-    "Name":"http:\/\/schema.org\/data",
+    "Name":"https://schema.org/data",
     "Domain Bucket":"1K - 10K"
   },
   {
     "Class":"Predicate",
-    "Name":"http:\/\/schema.org\/data-input",
+    "Name":"https://schema.org/data-input",
     "Domain Bucket":"< 1K"
   },
   {
     "Class":"Predicate",
-    "Name":"http:\/\/schema.org\/data-output",
+    "Name":"https://schema.org/data-output",
     "Domain Bucket":"< 1K"
   },
   {
     "Class":"Predicate",
-    "Name":"http:\/\/schema.org\/dataFeedElement",
+    "Name":"https://schema.org/dataFeedElement",
     "Domain Bucket":"1K - 10K"
   },
   {
     "Class":"Predicate",
-    "Name":"http:\/\/schema.org\/dataFeedElement-input",
+    "Name":"https://schema.org/dataFeedElement-input",
     "Domain Bucket":"< 1K"
   },
   {
     "Class":"Predicate",
-    "Name":"http:\/\/schema.org\/dataFeedElement-output",
+    "Name":"https://schema.org/dataFeedElement-output",
     "Domain Bucket":"< 1K"
   },
   {
     "Class":"Predicate",
-    "Name":"http:\/\/schema.org\/dataset",
+    "Name":"https://schema.org/dataset",
     "Domain Bucket":"1K - 10K"
   },
   {
     "Class":"Predicate",
-    "Name":"http:\/\/schema.org\/dataset-input",
+    "Name":"https://schema.org/dataset-input",
     "Domain Bucket":"< 1K"
   },
   {
     "Class":"Predicate",
-    "Name":"http:\/\/schema.org\/dataset-output",
+    "Name":"https://schema.org/dataset-output",
     "Domain Bucket":"< 1K"
   },
   {
     "Class":"Predicate",
-    "Name":"http:\/\/schema.org\/datasetTimeInterval",
+    "Name":"https://schema.org/datasetTimeInterval",
     "Domain Bucket":"< 1K"
   },
   {
     "Class":"Predicate",
-    "Name":"http:\/\/schema.org\/datasetTimeInterval-input",
+    "Name":"https://schema.org/datasetTimeInterval-input",
     "Domain Bucket":"< 1K"
   },
   {
     "Class":"Predicate",
-    "Name":"http:\/\/schema.org\/datasetTimeInterval-output",
+    "Name":"https://schema.org/datasetTimeInterval-output",
     "Domain Bucket":"< 1K"
   },
   {
     "Class":"Predicate",
-    "Name":"http:\/\/schema.org\/dateCreated",
+    "Name":"https://schema.org/dateCreated",
     "Domain Bucket":"100K - 1M"
   },
   {
     "Class":"Predicate",
-    "Name":"http:\/\/schema.org\/dateCreated-input",
+    "Name":"https://schema.org/dateCreated-input",
     "Domain Bucket":"< 1K"
   },
   {
     "Class":"Predicate",
-    "Name":"http:\/\/schema.org\/dateCreated-output",
+    "Name":"https://schema.org/dateCreated-output",
     "Domain Bucket":"< 1K"
   },
   {
     "Class":"Predicate",
-    "Name":"http:\/\/schema.org\/dateDeleted",
+    "Name":"https://schema.org/dateDeleted",
     "Domain Bucket":"< 1K"
   },
   {
     "Class":"Predicate",
-    "Name":"http:\/\/schema.org\/dateDeleted-input",
+    "Name":"https://schema.org/dateDeleted-input",
     "Domain Bucket":"< 1K"
   },
   {
     "Class":"Predicate",
-    "Name":"http:\/\/schema.org\/dateDeleted-output",
+    "Name":"https://schema.org/dateDeleted-output",
     "Domain Bucket":"< 1K"
   },
   {
     "Class":"Predicate",
-    "Name":"http:\/\/schema.org\/dateIssued",
+    "Name":"https://schema.org/dateIssued",
     "Domain Bucket":"< 1K"
   },
   {
     "Class":"Predicate",
-    "Name":"http:\/\/schema.org\/dateIssued-input",
+    "Name":"https://schema.org/dateIssued-input",
     "Domain Bucket":"< 1K"
   },
   {
     "Class":"Predicate",
-    "Name":"http:\/\/schema.org\/dateIssued-output",
+    "Name":"https://schema.org/dateIssued-output",
     "Domain Bucket":"< 1K"
   },
   {
     "Class":"Predicate",
-    "Name":"http:\/\/schema.org\/dateModified",
+    "Name":"https://schema.org/dateModified",
     "Domain Bucket":"10M+"
   },
   {
     "Class":"Predicate",
-    "Name":"http:\/\/schema.org\/dateModified-input",
+    "Name":"https://schema.org/dateModified-input",
     "Domain Bucket":"< 1K"
   },
   {
     "Class":"Predicate",
-    "Name":"http:\/\/schema.org\/dateModified-output",
+    "Name":"https://schema.org/dateModified-output",
     "Domain Bucket":"< 1K"
   },
   {
     "Class":"Predicate",
-    "Name":"http:\/\/schema.org\/datePosted",
+    "Name":"https://schema.org/datePosted",
     "Domain Bucket":"100K - 1M"
   },
   {
     "Class":"Predicate",
-    "Name":"http:\/\/schema.org\/datePosted-input",
+    "Name":"https://schema.org/datePosted-input",
     "Domain Bucket":"< 1K"
   },
   {
     "Class":"Predicate",
-    "Name":"http:\/\/schema.org\/datePosted-output",
+    "Name":"https://schema.org/datePosted-output",
     "Domain Bucket":"< 1K"
   },
   {
     "Class":"Predicate",
-    "Name":"http:\/\/schema.org\/datePublished",
+    "Name":"https://schema.org/datePublished",
     "Domain Bucket":"10M+"
   },
   {
     "Class":"Predicate",
-    "Name":"http:\/\/schema.org\/datePublished-input",
+    "Name":"https://schema.org/datePublished-input",
     "Domain Bucket":"< 1K"
   },
   {
     "Class":"Predicate",
-    "Name":"http:\/\/schema.org\/datePublished-output",
+    "Name":"https://schema.org/datePublished-output",
     "Domain Bucket":"< 1K"
   },
   {
     "Class":"Predicate",
-    "Name":"http:\/\/schema.org\/dateRead",
+    "Name":"https://schema.org/dateRead",
     "Domain Bucket":"< 1K"
   },
   {
     "Class":"Predicate",
-    "Name":"http:\/\/schema.org\/dateRead-input",
+    "Name":"https://schema.org/dateRead-input",
     "Domain Bucket":"< 1K"
   },
   {
     "Class":"Predicate",
-    "Name":"http:\/\/schema.org\/dateRead-output",
+    "Name":"https://schema.org/dateRead-output",
     "Domain Bucket":"< 1K"
   },
   {
     "Class":"Predicate",
-    "Name":"http:\/\/schema.org\/dateReceived",
+    "Name":"https://schema.org/dateReceived",
     "Domain Bucket":"< 1K"
   },
   {
     "Class":"Predicate",
-    "Name":"http:\/\/schema.org\/dateReceived-input",
+    "Name":"https://schema.org/dateReceived-input",
     "Domain Bucket":"< 1K"
   },
   {
     "Class":"Predicate",
-    "Name":"http:\/\/schema.org\/dateReceived-output",
+    "Name":"https://schema.org/dateReceived-output",
     "Domain Bucket":"< 1K"
   },
   {
     "Class":"Predicate",
-    "Name":"http:\/\/schema.org\/dateSent",
+    "Name":"https://schema.org/dateSent",
     "Domain Bucket":"< 1K"
   },
   {
     "Class":"Predicate",
-    "Name":"http:\/\/schema.org\/dateSent-input",
+    "Name":"https://schema.org/dateSent-input",
     "Domain Bucket":"< 1K"
   },
   {
     "Class":"Predicate",
-    "Name":"http:\/\/schema.org\/dateSent-output",
+    "Name":"https://schema.org/dateSent-output",
     "Domain Bucket":"< 1K"
   },
   {
     "Class":"Predicate",
-    "Name":"http:\/\/schema.org\/dateVehicleFirstRegistered",
+    "Name":"https://schema.org/dateVehicleFirstRegistered",
     "Domain Bucket":"1K - 10K"
   },
   {
     "Class":"Predicate",
-    "Name":"http:\/\/schema.org\/dateVehicleFirstRegistered-input",
+    "Name":"https://schema.org/dateVehicleFirstRegistered-input",
     "Domain Bucket":"< 1K"
   },
   {
     "Class":"Predicate",
-    "Name":"http:\/\/schema.org\/dateVehicleFirstRegistered-output",
+    "Name":"https://schema.org/dateVehicleFirstRegistered-output",
     "Domain Bucket":"< 1K"
   },
   {
     "Class":"Predicate",
-    "Name":"http:\/\/schema.org\/dateline",
+    "Name":"https://schema.org/dateline",
     "Domain Bucket":"1K - 10K"
   },
   {
     "Class":"Predicate",
-    "Name":"http:\/\/schema.org\/dateline-input",
+    "Name":"https://schema.org/dateline-input",
     "Domain Bucket":"< 1K"
   },
   {
     "Class":"Predicate",
-    "Name":"http:\/\/schema.org\/dateline-output",
+    "Name":"https://schema.org/dateline-output",
     "Domain Bucket":"< 1K"
   },
   {
     "Class":"Predicate",
-    "Name":"http:\/\/schema.org\/dayOfWeek",
+    "Name":"https://schema.org/dayOfWeek",
     "Domain Bucket":"1M - 10M"
   },
   {
     "Class":"Predicate",
-    "Name":"http:\/\/schema.org\/dayOfWeek-input",
+    "Name":"https://schema.org/dayOfWeek-input",
     "Domain Bucket":"< 1K"
   },
   {
     "Class":"Predicate",
-    "Name":"http:\/\/schema.org\/dayOfWeek-output",
+    "Name":"https://schema.org/dayOfWeek-output",
     "Domain Bucket":"< 1K"
   },
   {
     "Class":"Predicate",
-    "Name":"http:\/\/schema.org\/deathDate",
+    "Name":"https://schema.org/deathDate",
     "Domain Bucket":"10K - 100K"
   },
   {
     "Class":"Predicate",
-    "Name":"http:\/\/schema.org\/deathDate-input",
+    "Name":"https://schema.org/deathDate-input",
     "Domain Bucket":"< 1K"
   },
   {
     "Class":"Predicate",
-    "Name":"http:\/\/schema.org\/deathDate-output",
+    "Name":"https://schema.org/deathDate-output",
     "Domain Bucket":"< 1K"
   },
   {
     "Class":"Predicate",
-    "Name":"http:\/\/schema.org\/deathPlace",
+    "Name":"https://schema.org/deathPlace",
     "Domain Bucket":"1K - 10K"
   },
   {
     "Class":"Predicate",
-    "Name":"http:\/\/schema.org\/deathPlace-input",
+    "Name":"https://schema.org/deathPlace-input",
     "Domain Bucket":"< 1K"
   },
   {
     "Class":"Predicate",
-    "Name":"http:\/\/schema.org\/deathPlace-output",
+    "Name":"https://schema.org/deathPlace-output",
     "Domain Bucket":"< 1K"
   },
   {
     "Class":"Predicate",
-    "Name":"http:\/\/schema.org\/defaultValue",
+    "Name":"https://schema.org/defaultValue",
     "Domain Bucket":"100K - 1M"
   },
   {
     "Class":"Predicate",
-    "Name":"http:\/\/schema.org\/defaultValue-input",
+    "Name":"https://schema.org/defaultValue-input",
     "Domain Bucket":"< 1K"
   },
   {
     "Class":"Predicate",
-    "Name":"http:\/\/schema.org\/defaultValue-output",
+    "Name":"https://schema.org/defaultValue-output",
     "Domain Bucket":"< 1K"
   },
   {
     "Class":"Predicate",
-    "Name":"http:\/\/schema.org\/deliveryAddress",
+    "Name":"https://schema.org/deliveryAddress",
     "Domain Bucket":"< 1K"
   },
   {
     "Class":"Predicate",
-    "Name":"http:\/\/schema.org\/deliveryAddress-input",
+    "Name":"https://schema.org/deliveryAddress-input",
     "Domain Bucket":"< 1K"
   },
   {
     "Class":"Predicate",
-    "Name":"http:\/\/schema.org\/deliveryAddress-output",
+    "Name":"https://schema.org/deliveryAddress-output",
     "Domain Bucket":"< 1K"
   },
   {
     "Class":"Predicate",
-    "Name":"http:\/\/schema.org\/deliveryLeadTime",
+    "Name":"https://schema.org/deliveryLeadTime",
     "Domain Bucket":"10K - 100K"
   },
   {
     "Class":"Predicate",
-    "Name":"http:\/\/schema.org\/deliveryLeadTime-input",
+    "Name":"https://schema.org/deliveryLeadTime-input",
     "Domain Bucket":"< 1K"
   },
   {
     "Class":"Predicate",
-    "Name":"http:\/\/schema.org\/deliveryLeadTime-output",
+    "Name":"https://schema.org/deliveryLeadTime-output",
     "Domain Bucket":"< 1K"
   },
   {
     "Class":"Predicate",
-    "Name":"http:\/\/schema.org\/deliveryMethod",
+    "Name":"https://schema.org/deliveryMethod",
     "Domain Bucket":"100K - 1M"
   },
   {
     "Class":"Predicate",
-    "Name":"http:\/\/schema.org\/deliveryMethod-input",
+    "Name":"https://schema.org/deliveryMethod-input",
     "Domain Bucket":"< 1K"
   },
   {
     "Class":"Predicate",
-    "Name":"http:\/\/schema.org\/deliveryMethod-output",
+    "Name":"https://schema.org/deliveryMethod-output",
     "Domain Bucket":"< 1K"
   },
   {
     "Class":"Predicate",
-    "Name":"http:\/\/schema.org\/deliveryStatus",
+    "Name":"https://schema.org/deliveryStatus",
     "Domain Bucket":"< 1K"
   },
   {
     "Class":"Predicate",
-    "Name":"http:\/\/schema.org\/deliveryStatus-input",
+    "Name":"https://schema.org/deliveryStatus-input",
     "Domain Bucket":"< 1K"
   },
   {
     "Class":"Predicate",
-    "Name":"http:\/\/schema.org\/deliveryStatus-output",
+    "Name":"https://schema.org/deliveryStatus-output",
     "Domain Bucket":"< 1K"
   },
   {
     "Class":"Predicate",
-    "Name":"http:\/\/schema.org\/deliveryTime",
+    "Name":"https://schema.org/deliveryTime",
     "Domain Bucket":"100K - 1M"
   },
   {
     "Class":"Predicate",
-    "Name":"http:\/\/schema.org\/deliveryTime-input",
+    "Name":"https://schema.org/deliveryTime-input",
     "Domain Bucket":"< 1K"
   },
   {
     "Class":"Predicate",
-    "Name":"http:\/\/schema.org\/deliveryTime-output",
+    "Name":"https://schema.org/deliveryTime-output",
     "Domain Bucket":"< 1K"
   },
   {
     "Class":"Predicate",
-    "Name":"http:\/\/schema.org\/department",
+    "Name":"https://schema.org/department",
     "Domain Bucket":"10K - 100K"
   },
   {
     "Class":"Predicate",
-    "Name":"http:\/\/schema.org\/department-input",
+    "Name":"https://schema.org/department-input",
     "Domain Bucket":"< 1K"
   },
   {
     "Class":"Predicate",
-    "Name":"http:\/\/schema.org\/department-output",
+    "Name":"https://schema.org/department-output",
     "Domain Bucket":"< 1K"
   },
   {
     "Class":"Predicate",
-    "Name":"http:\/\/schema.org\/departureAirport",
+    "Name":"https://schema.org/departureAirport",
     "Domain Bucket":"1K - 10K"
   },
   {
     "Class":"Predicate",
-    "Name":"http:\/\/schema.org\/departureAirport-input",
+    "Name":"https://schema.org/departureAirport-input",
     "Domain Bucket":"< 1K"
   },
   {
     "Class":"Predicate",
-    "Name":"http:\/\/schema.org\/departureAirport-output",
+    "Name":"https://schema.org/departureAirport-output",
     "Domain Bucket":"< 1K"
   },
   {
     "Class":"Predicate",
-    "Name":"http:\/\/schema.org\/departureBoatTerminal",
+    "Name":"https://schema.org/departureBoatTerminal",
     "Domain Bucket":"< 1K"
   },
   {
     "Class":"Predicate",
-    "Name":"http:\/\/schema.org\/departureBoatTerminal-input",
+    "Name":"https://schema.org/departureBoatTerminal-input",
     "Domain Bucket":"< 1K"
   },
   {
     "Class":"Predicate",
-    "Name":"http:\/\/schema.org\/departureBoatTerminal-output",
+    "Name":"https://schema.org/departureBoatTerminal-output",
     "Domain Bucket":"< 1K"
   },
   {
     "Class":"Predicate",
-    "Name":"http:\/\/schema.org\/departureBusStop",
+    "Name":"https://schema.org/departureBusStop",
     "Domain Bucket":"< 1K"
   },
   {
     "Class":"Predicate",
-    "Name":"http:\/\/schema.org\/departureBusStop-input",
+    "Name":"https://schema.org/departureBusStop-input",
     "Domain Bucket":"< 1K"
   },
   {
     "Class":"Predicate",
-    "Name":"http:\/\/schema.org\/departureBusStop-output",
+    "Name":"https://schema.org/departureBusStop-output",
     "Domain Bucket":"< 1K"
   },
   {
     "Class":"Predicate",
-    "Name":"http:\/\/schema.org\/departureGate",
+    "Name":"https://schema.org/departureGate",
     "Domain Bucket":"< 1K"
   },
   {
     "Class":"Predicate",
-    "Name":"http:\/\/schema.org\/departureGate-input",
+    "Name":"https://schema.org/departureGate-input",
     "Domain Bucket":"< 1K"
   },
   {
     "Class":"Predicate",
-    "Name":"http:\/\/schema.org\/departureGate-output",
+    "Name":"https://schema.org/departureGate-output",
     "Domain Bucket":"< 1K"
   },
   {
     "Class":"Predicate",
-    "Name":"http:\/\/schema.org\/departurePlatform",
+    "Name":"https://schema.org/departurePlatform",
     "Domain Bucket":"< 1K"
   },
   {
     "Class":"Predicate",
-    "Name":"http:\/\/schema.org\/departurePlatform-input",
+    "Name":"https://schema.org/departurePlatform-input",
     "Domain Bucket":"< 1K"
   },
   {
     "Class":"Predicate",
-    "Name":"http:\/\/schema.org\/departurePlatform-output",
+    "Name":"https://schema.org/departurePlatform-output",
     "Domain Bucket":"< 1K"
   },
   {
     "Class":"Predicate",
-    "Name":"http:\/\/schema.org\/departureStation",
+    "Name":"https://schema.org/departureStation",
     "Domain Bucket":"< 1K"
   },
   {
     "Class":"Predicate",
-    "Name":"http:\/\/schema.org\/departureStation-input",
+    "Name":"https://schema.org/departureStation-input",
     "Domain Bucket":"< 1K"
   },
   {
     "Class":"Predicate",
-    "Name":"http:\/\/schema.org\/departureStation-output",
+    "Name":"https://schema.org/departureStation-output",
     "Domain Bucket":"< 1K"
   },
   {
     "Class":"Predicate",
-    "Name":"http:\/\/schema.org\/departureTerminal",
+    "Name":"https://schema.org/departureTerminal",
     "Domain Bucket":"< 1K"
   },
   {
     "Class":"Predicate",
-    "Name":"http:\/\/schema.org\/departureTerminal-input",
+    "Name":"https://schema.org/departureTerminal-input",
     "Domain Bucket":"< 1K"
   },
   {
     "Class":"Predicate",
-    "Name":"http:\/\/schema.org\/departureTerminal-output",
+    "Name":"https://schema.org/departureTerminal-output",
     "Domain Bucket":"< 1K"
   },
   {
     "Class":"Predicate",
-    "Name":"http:\/\/schema.org\/departureTime",
+    "Name":"https://schema.org/departureTime",
     "Domain Bucket":"1K - 10K"
   },
   {
     "Class":"Predicate",
-    "Name":"http:\/\/schema.org\/departureTime-input",
+    "Name":"https://schema.org/departureTime-input",
     "Domain Bucket":"< 1K"
   },
   {
     "Class":"Predicate",
-    "Name":"http:\/\/schema.org\/departureTime-output",
+    "Name":"https://schema.org/departureTime-output",
     "Domain Bucket":"< 1K"
   },
   {
     "Class":"Predicate",
-    "Name":"http:\/\/schema.org\/dependencies",
+    "Name":"https://schema.org/dependencies",
     "Domain Bucket":"1K - 10K"
   },
   {
     "Class":"Predicate",
-    "Name":"http:\/\/schema.org\/dependencies-input",
+    "Name":"https://schema.org/dependencies-input",
     "Domain Bucket":"< 1K"
   },
   {
     "Class":"Predicate",
-    "Name":"http:\/\/schema.org\/dependencies-output",
+    "Name":"https://schema.org/dependencies-output",
     "Domain Bucket":"< 1K"
   },
   {
     "Class":"Predicate",
-    "Name":"http:\/\/schema.org\/depth",
+    "Name":"https://schema.org/depth",
     "Domain Bucket":"10K - 100K"
   },
   {
     "Class":"Predicate",
-    "Name":"http:\/\/schema.org\/depth-input",
+    "Name":"https://schema.org/depth-input",
     "Domain Bucket":"< 1K"
   },
   {
     "Class":"Predicate",
-    "Name":"http:\/\/schema.org\/depth-output",
+    "Name":"https://schema.org/depth-output",
     "Domain Bucket":"< 1K"
   },
   {
     "Class":"Predicate",
-    "Name":"http:\/\/schema.org\/description",
+    "Name":"https://schema.org/description",
     "Domain Bucket":"10M+"
   },
   {
     "Class":"Predicate",
-    "Name":"http:\/\/schema.org\/description-input",
+    "Name":"https://schema.org/description-input",
     "Domain Bucket":"< 1K"
   },
   {
     "Class":"Predicate",
-    "Name":"http:\/\/schema.org\/description-output",
+    "Name":"https://schema.org/description-output",
     "Domain Bucket":"< 1K"
   },
   {
     "Class":"Predicate",
-    "Name":"http:\/\/schema.org\/device",
+    "Name":"https://schema.org/device",
     "Domain Bucket":"< 1K"
   },
   {
     "Class":"Predicate",
-    "Name":"http:\/\/schema.org\/device-input",
+    "Name":"https://schema.org/device-input",
     "Domain Bucket":"< 1K"
   },
   {
     "Class":"Predicate",
-    "Name":"http:\/\/schema.org\/device-output",
+    "Name":"https://schema.org/device-output",
     "Domain Bucket":"< 1K"
   },
   {
     "Class":"Predicate",
-    "Name":"http:\/\/schema.org\/diagnosis",
+    "Name":"https://schema.org/diagnosis",
     "Domain Bucket":"< 1K"
   },
   {
     "Class":"Predicate",
-    "Name":"http:\/\/schema.org\/diagnosis-input",
+    "Name":"https://schema.org/diagnosis-input",
     "Domain Bucket":"< 1K"
   },
   {
     "Class":"Predicate",
-    "Name":"http:\/\/schema.org\/diagnosis-output",
+    "Name":"https://schema.org/diagnosis-output",
     "Domain Bucket":"< 1K"
   },
   {
     "Class":"Predicate",
-    "Name":"http:\/\/schema.org\/diagram",
+    "Name":"https://schema.org/diagram",
     "Domain Bucket":"< 1K"
   },
   {
     "Class":"Predicate",
-    "Name":"http:\/\/schema.org\/diagram-input",
+    "Name":"https://schema.org/diagram-input",
     "Domain Bucket":"< 1K"
   },
   {
     "Class":"Predicate",
-    "Name":"http:\/\/schema.org\/diagram-output",
+    "Name":"https://schema.org/diagram-output",
     "Domain Bucket":"< 1K"
   },
   {
     "Class":"Predicate",
-    "Name":"http:\/\/schema.org\/diet",
+    "Name":"https://schema.org/diet",
     "Domain Bucket":"< 1K"
   },
   {
     "Class":"Predicate",
-    "Name":"http:\/\/schema.org\/diet-input",
+    "Name":"https://schema.org/diet-input",
     "Domain Bucket":"< 1K"
   },
   {
     "Class":"Predicate",
-    "Name":"http:\/\/schema.org\/diet-output",
+    "Name":"https://schema.org/diet-output",
     "Domain Bucket":"< 1K"
   },
   {
     "Class":"Predicate",
-    "Name":"http:\/\/schema.org\/dietFeatures",
+    "Name":"https://schema.org/dietFeatures",
     "Domain Bucket":"< 1K"
   },
   {
     "Class":"Predicate",
-    "Name":"http:\/\/schema.org\/dietFeatures-input",
+    "Name":"https://schema.org/dietFeatures-input",
     "Domain Bucket":"< 1K"
   },
   {
     "Class":"Predicate",
-    "Name":"http:\/\/schema.org\/dietFeatures-output",
+    "Name":"https://schema.org/dietFeatures-output",
     "Domain Bucket":"< 1K"
   },
   {
     "Class":"Predicate",
-    "Name":"http:\/\/schema.org\/differentialDiagnosis",
+    "Name":"https://schema.org/differentialDiagnosis",
     "Domain Bucket":"< 1K"
   },
   {
     "Class":"Predicate",
-    "Name":"http:\/\/schema.org\/differentialDiagnosis-input",
+    "Name":"https://schema.org/differentialDiagnosis-input",
     "Domain Bucket":"< 1K"
   },
   {
     "Class":"Predicate",
-    "Name":"http:\/\/schema.org\/differentialDiagnosis-output",
+    "Name":"https://schema.org/differentialDiagnosis-output",
     "Domain Bucket":"< 1K"
   },
   {
     "Class":"Predicate",
-    "Name":"http:\/\/schema.org\/digitalSourceType",
+    "Name":"https://schema.org/digitalSourceType",
     "Domain Bucket":"< 1K"
   },
   {
     "Class":"Predicate",
-    "Name":"http:\/\/schema.org\/digitalSourceType-input",
+    "Name":"https://schema.org/digitalSourceType-input",
     "Domain Bucket":"< 1K"
   },
   {
     "Class":"Predicate",
-    "Name":"http:\/\/schema.org\/digitalSourceType-output",
+    "Name":"https://schema.org/digitalSourceType-output",
     "Domain Bucket":"< 1K"
   },
   {
     "Class":"Predicate",
-    "Name":"http:\/\/schema.org\/directApply",
+    "Name":"https://schema.org/directApply",
     "Domain Bucket":"10K - 100K"
   },
   {
     "Class":"Predicate",
-    "Name":"http:\/\/schema.org\/directApply-input",
+    "Name":"https://schema.org/directApply-input",
     "Domain Bucket":"< 1K"
   },
   {
     "Class":"Predicate",
-    "Name":"http:\/\/schema.org\/directApply-output",
+    "Name":"https://schema.org/directApply-output",
     "Domain Bucket":"< 1K"
   },
   {
     "Class":"Predicate",
-    "Name":"http:\/\/schema.org\/director",
+    "Name":"https://schema.org/director",
     "Domain Bucket":"10K - 100K"
   },
   {
     "Class":"Predicate",
-    "Name":"http:\/\/schema.org\/director-input",
+    "Name":"https://schema.org/director-input",
     "Domain Bucket":"< 1K"
   },
   {
     "Class":"Predicate",
-    "Name":"http:\/\/schema.org\/director-output",
+    "Name":"https://schema.org/director-output",
     "Domain Bucket":"< 1K"
   },
   {
     "Class":"Predicate",
-    "Name":"http:\/\/schema.org\/directors",
+    "Name":"https://schema.org/directors",
     "Domain Bucket":"< 1K"
   },
   {
     "Class":"Predicate",
-    "Name":"http:\/\/schema.org\/directors-input",
+    "Name":"https://schema.org/directors-input",
     "Domain Bucket":"< 1K"
   },
   {
     "Class":"Predicate",
-    "Name":"http:\/\/schema.org\/directors-output",
+    "Name":"https://schema.org/directors-output",
     "Domain Bucket":"< 1K"
   },
   {
     "Class":"Predicate",
-    "Name":"http:\/\/schema.org\/disambiguatingDescription",
+    "Name":"https://schema.org/disambiguatingDescription",
     "Domain Bucket":"10K - 100K"
   },
   {
     "Class":"Predicate",
-    "Name":"http:\/\/schema.org\/disambiguatingDescription-input",
+    "Name":"https://schema.org/disambiguatingDescription-input",
     "Domain Bucket":"< 1K"
   },
   {
     "Class":"Predicate",
-    "Name":"http:\/\/schema.org\/disambiguatingDescription-output",
+    "Name":"https://schema.org/disambiguatingDescription-output",
     "Domain Bucket":"< 1K"
   },
   {
     "Class":"Predicate",
-    "Name":"http:\/\/schema.org\/discount",
+    "Name":"https://schema.org/discount",
     "Domain Bucket":"10K - 100K"
   },
   {
     "Class":"Predicate",
-    "Name":"http:\/\/schema.org\/discount-input",
+    "Name":"https://schema.org/discount-input",
     "Domain Bucket":"< 1K"
   },
   {
     "Class":"Predicate",
-    "Name":"http:\/\/schema.org\/discount-output",
+    "Name":"https://schema.org/discount-output",
     "Domain Bucket":"< 1K"
   },
   {
     "Class":"Predicate",
-    "Name":"http:\/\/schema.org\/discountCode",
+    "Name":"https://schema.org/discountCode",
     "Domain Bucket":"< 1K"
   },
   {
     "Class":"Predicate",
-    "Name":"http:\/\/schema.org\/discountCode-input",
+    "Name":"https://schema.org/discountCode-input",
     "Domain Bucket":"< 1K"
   },
   {
     "Class":"Predicate",
-    "Name":"http:\/\/schema.org\/discountCode-output",
+    "Name":"https://schema.org/discountCode-output",
     "Domain Bucket":"< 1K"
   },
   {
     "Class":"Predicate",
-    "Name":"http:\/\/schema.org\/discountCurrency",
+    "Name":"https://schema.org/discountCurrency",
     "Domain Bucket":"< 1K"
   },
   {
     "Class":"Predicate",
-    "Name":"http:\/\/schema.org\/discountCurrency-input",
+    "Name":"https://schema.org/discountCurrency-input",
     "Domain Bucket":"< 1K"
   },
   {
     "Class":"Predicate",
-    "Name":"http:\/\/schema.org\/discountCurrency-output",
+    "Name":"https://schema.org/discountCurrency-output",
     "Domain Bucket":"< 1K"
   },
   {
     "Class":"Predicate",
-    "Name":"http:\/\/schema.org\/discusses",
+    "Name":"https://schema.org/discusses",
     "Domain Bucket":"1K - 10K"
   },
   {
     "Class":"Predicate",
-    "Name":"http:\/\/schema.org\/discusses-input",
+    "Name":"https://schema.org/discusses-input",
     "Domain Bucket":"< 1K"
   },
   {
     "Class":"Predicate",
-    "Name":"http:\/\/schema.org\/discusses-output",
+    "Name":"https://schema.org/discusses-output",
     "Domain Bucket":"< 1K"
   },
   {
     "Class":"Predicate",
-    "Name":"http:\/\/schema.org\/discussionUrl",
+    "Name":"https://schema.org/discussionUrl",
     "Domain Bucket":"10K - 100K"
   },
   {
     "Class":"Predicate",
-    "Name":"http:\/\/schema.org\/discussionUrl-input",
+    "Name":"https://schema.org/discussionUrl-input",
     "Domain Bucket":"< 1K"
   },
   {
     "Class":"Predicate",
-    "Name":"http:\/\/schema.org\/discussionUrl-output",
+    "Name":"https://schema.org/discussionUrl-output",
     "Domain Bucket":"< 1K"
   },
   {
     "Class":"Predicate",
-    "Name":"http:\/\/schema.org\/diseasePreventionInfo",
+    "Name":"https://schema.org/diseasePreventionInfo",
     "Domain Bucket":"< 1K"
   },
   {
     "Class":"Predicate",
-    "Name":"http:\/\/schema.org\/diseasePreventionInfo-input",
+    "Name":"https://schema.org/diseasePreventionInfo-input",
     "Domain Bucket":"< 1K"
   },
   {
     "Class":"Predicate",
-    "Name":"http:\/\/schema.org\/diseasePreventionInfo-output",
+    "Name":"https://schema.org/diseasePreventionInfo-output",
     "Domain Bucket":"< 1K"
   },
   {
     "Class":"Predicate",
-    "Name":"http:\/\/schema.org\/diseaseSpreadStatistics",
+    "Name":"https://schema.org/diseaseSpreadStatistics",
     "Domain Bucket":"< 1K"
   },
   {
     "Class":"Predicate",
-    "Name":"http:\/\/schema.org\/diseaseSpreadStatistics-input",
+    "Name":"https://schema.org/diseaseSpreadStatistics-input",
     "Domain Bucket":"< 1K"
   },
   {
     "Class":"Predicate",
-    "Name":"http:\/\/schema.org\/diseaseSpreadStatistics-output",
+    "Name":"https://schema.org/diseaseSpreadStatistics-output",
     "Domain Bucket":"< 1K"
   },
   {
     "Class":"Predicate",
-    "Name":"http:\/\/schema.org\/displayLocation",
+    "Name":"https://schema.org/displayLocation",
     "Domain Bucket":"< 1K"
   },
   {
     "Class":"Predicate",
-    "Name":"http:\/\/schema.org\/displayLocation-input",
+    "Name":"https://schema.org/displayLocation-input",
     "Domain Bucket":"< 1K"
   },
   {
     "Class":"Predicate",
-    "Name":"http:\/\/schema.org\/displayLocation-output",
+    "Name":"https://schema.org/displayLocation-output",
     "Domain Bucket":"< 1K"
   },
   {
     "Class":"Predicate",
-    "Name":"http:\/\/schema.org\/dissolutionDate",
+    "Name":"https://schema.org/dissolutionDate",
     "Domain Bucket":"< 1K"
   },
   {
     "Class":"Predicate",
-    "Name":"http:\/\/schema.org\/dissolutionDate-input",
+    "Name":"https://schema.org/dissolutionDate-input",
     "Domain Bucket":"< 1K"
   },
   {
     "Class":"Predicate",
-    "Name":"http:\/\/schema.org\/dissolutionDate-output",
+    "Name":"https://schema.org/dissolutionDate-output",
     "Domain Bucket":"< 1K"
   },
   {
     "Class":"Predicate",
-    "Name":"http:\/\/schema.org\/distance",
+    "Name":"https://schema.org/distance",
     "Domain Bucket":"1K - 10K"
   },
   {
     "Class":"Predicate",
-    "Name":"http:\/\/schema.org\/distance-input",
+    "Name":"https://schema.org/distance-input",
     "Domain Bucket":"< 1K"
   },
   {
     "Class":"Predicate",
-    "Name":"http:\/\/schema.org\/distance-output",
+    "Name":"https://schema.org/distance-output",
     "Domain Bucket":"< 1K"
   },
   {
     "Class":"Predicate",
-    "Name":"http:\/\/schema.org\/distinguishingSign",
+    "Name":"https://schema.org/distinguishingSign",
     "Domain Bucket":"< 1K"
   },
   {
     "Class":"Predicate",
-    "Name":"http:\/\/schema.org\/distinguishingSign-input",
+    "Name":"https://schema.org/distinguishingSign-input",
     "Domain Bucket":"< 1K"
   },
   {
     "Class":"Predicate",
-    "Name":"http:\/\/schema.org\/distinguishingSign-output",
+    "Name":"https://schema.org/distinguishingSign-output",
     "Domain Bucket":"< 1K"
   },
   {
     "Class":"Predicate",
-    "Name":"http:\/\/schema.org\/distribution",
+    "Name":"https://schema.org/distribution",
     "Domain Bucket":"10K - 100K"
   },
   {
     "Class":"Predicate",
-    "Name":"http:\/\/schema.org\/distribution-input",
+    "Name":"https://schema.org/distribution-input",
     "Domain Bucket":"< 1K"
   },
   {
     "Class":"Predicate",
-    "Name":"http:\/\/schema.org\/distribution-output",
+    "Name":"https://schema.org/distribution-output",
     "Domain Bucket":"< 1K"
   },
   {
     "Class":"Predicate",
-    "Name":"http:\/\/schema.org\/diversityPolicy",
+    "Name":"https://schema.org/diversityPolicy",
     "Domain Bucket":"10K - 100K"
   },
   {
     "Class":"Predicate",
-    "Name":"http:\/\/schema.org\/diversityPolicy-input",
+    "Name":"https://schema.org/diversityPolicy-input",
     "Domain Bucket":"< 1K"
   },
   {
     "Class":"Predicate",
-    "Name":"http:\/\/schema.org\/diversityPolicy-output",
+    "Name":"https://schema.org/diversityPolicy-output",
     "Domain Bucket":"< 1K"
   },
   {
     "Class":"Predicate",
-    "Name":"http:\/\/schema.org\/diversityStaffingReport",
+    "Name":"https://schema.org/diversityStaffingReport",
     "Domain Bucket":"1K - 10K"
   },
   {
     "Class":"Predicate",
-    "Name":"http:\/\/schema.org\/diversityStaffingReport-input",
+    "Name":"https://schema.org/diversityStaffingReport-input",
     "Domain Bucket":"< 1K"
   },
   {
     "Class":"Predicate",
-    "Name":"http:\/\/schema.org\/diversityStaffingReport-output",
+    "Name":"https://schema.org/diversityStaffingReport-output",
     "Domain Bucket":"< 1K"
   },
   {
     "Class":"Predicate",
-    "Name":"http:\/\/schema.org\/documentation",
+    "Name":"https://schema.org/documentation",
     "Domain Bucket":"1K - 10K"
   },
   {
     "Class":"Predicate",
-    "Name":"http:\/\/schema.org\/documentation-input",
+    "Name":"https://schema.org/documentation-input",
     "Domain Bucket":"< 1K"
   },
   {
     "Class":"Predicate",
-    "Name":"http:\/\/schema.org\/documentation-output",
+    "Name":"https://schema.org/documentation-output",
     "Domain Bucket":"< 1K"
   },
   {
     "Class":"Predicate",
-    "Name":"http:\/\/schema.org\/doesNotShip",
+    "Name":"https://schema.org/doesNotShip",
     "Domain Bucket":"10K - 100K"
   },
   {
     "Class":"Predicate",
-    "Name":"http:\/\/schema.org\/doesNotShip-input",
+    "Name":"https://schema.org/doesNotShip-input",
     "Domain Bucket":"< 1K"
   },
   {
     "Class":"Predicate",
-    "Name":"http:\/\/schema.org\/doesNotShip-output",
+    "Name":"https://schema.org/doesNotShip-output",
     "Domain Bucket":"< 1K"
   },
   {
     "Class":"Predicate",
-    "Name":"http:\/\/schema.org\/domainIncludes",
+    "Name":"https://schema.org/domainIncludes",
     "Domain Bucket":"< 1K"
   },
   {
     "Class":"Predicate",
-    "Name":"http:\/\/schema.org\/domainIncludes-input",
+    "Name":"https://schema.org/domainIncludes-input",
     "Domain Bucket":"< 1K"
   },
   {
     "Class":"Predicate",
-    "Name":"http:\/\/schema.org\/domainIncludes-output",
+    "Name":"https://schema.org/domainIncludes-output",
     "Domain Bucket":"< 1K"
   },
   {
     "Class":"Predicate",
-    "Name":"http:\/\/schema.org\/domiciledMortgage",
+    "Name":"https://schema.org/domiciledMortgage",
     "Domain Bucket":"< 1K"
   },
   {
     "Class":"Predicate",
-    "Name":"http:\/\/schema.org\/domiciledMortgage-input",
+    "Name":"https://schema.org/domiciledMortgage-input",
     "Domain Bucket":"< 1K"
   },
   {
     "Class":"Predicate",
-    "Name":"http:\/\/schema.org\/domiciledMortgage-output",
+    "Name":"https://schema.org/domiciledMortgage-output",
     "Domain Bucket":"< 1K"
   },
   {
     "Class":"Predicate",
-    "Name":"http:\/\/schema.org\/doorTime",
+    "Name":"https://schema.org/doorTime",
     "Domain Bucket":"1K - 10K"
   },
   {
     "Class":"Predicate",
-    "Name":"http:\/\/schema.org\/doorTime-input",
+    "Name":"https://schema.org/doorTime-input",
     "Domain Bucket":"< 1K"
   },
   {
     "Class":"Predicate",
-    "Name":"http:\/\/schema.org\/doorTime-output",
+    "Name":"https://schema.org/doorTime-output",
     "Domain Bucket":"< 1K"
   },
   {
     "Class":"Predicate",
-    "Name":"http:\/\/schema.org\/dosageForm",
+    "Name":"https://schema.org/dosageForm",
     "Domain Bucket":"1K - 10K"
   },
   {
     "Class":"Predicate",
-    "Name":"http:\/\/schema.org\/dosageForm-input",
+    "Name":"https://schema.org/dosageForm-input",
     "Domain Bucket":"< 1K"
   },
   {
     "Class":"Predicate",
-    "Name":"http:\/\/schema.org\/dosageForm-output",
+    "Name":"https://schema.org/dosageForm-output",
     "Domain Bucket":"< 1K"
   },
   {
     "Class":"Predicate",
-    "Name":"http:\/\/schema.org\/doseSchedule",
+    "Name":"https://schema.org/doseSchedule",
     "Domain Bucket":"< 1K"
   },
   {
     "Class":"Predicate",
-    "Name":"http:\/\/schema.org\/doseSchedule-input",
+    "Name":"https://schema.org/doseSchedule-input",
     "Domain Bucket":"< 1K"
   },
   {
     "Class":"Predicate",
-    "Name":"http:\/\/schema.org\/doseSchedule-output",
+    "Name":"https://schema.org/doseSchedule-output",
     "Domain Bucket":"< 1K"
   },
   {
     "Class":"Predicate",
-    "Name":"http:\/\/schema.org\/doseUnit",
+    "Name":"https://schema.org/doseUnit",
     "Domain Bucket":"< 1K"
   },
   {
     "Class":"Predicate",
-    "Name":"http:\/\/schema.org\/doseUnit-input",
+    "Name":"https://schema.org/doseUnit-input",
     "Domain Bucket":"< 1K"
   },
   {
     "Class":"Predicate",
-    "Name":"http:\/\/schema.org\/doseUnit-output",
+    "Name":"https://schema.org/doseUnit-output",
     "Domain Bucket":"< 1K"
   },
   {
     "Class":"Predicate",
-    "Name":"http:\/\/schema.org\/doseValue",
+    "Name":"https://schema.org/doseValue",
     "Domain Bucket":"< 1K"
   },
   {
     "Class":"Predicate",
-    "Name":"http:\/\/schema.org\/doseValue-input",
+    "Name":"https://schema.org/doseValue-input",
     "Domain Bucket":"< 1K"
   },
   {
     "Class":"Predicate",
-    "Name":"http:\/\/schema.org\/doseValue-output",
+    "Name":"https://schema.org/doseValue-output",
     "Domain Bucket":"< 1K"
   },
   {
     "Class":"Predicate",
-    "Name":"http:\/\/schema.org\/downPayment",
+    "Name":"https://schema.org/downPayment",
     "Domain Bucket":"< 1K"
   },
   {
     "Class":"Predicate",
-    "Name":"http:\/\/schema.org\/downPayment-input",
+    "Name":"https://schema.org/downPayment-input",
     "Domain Bucket":"< 1K"
   },
   {
     "Class":"Predicate",
-    "Name":"http:\/\/schema.org\/downPayment-output",
+    "Name":"https://schema.org/downPayment-output",
     "Domain Bucket":"< 1K"
   },
   {
     "Class":"Predicate",
-    "Name":"http:\/\/schema.org\/downloadUrl",
+    "Name":"https://schema.org/downloadUrl",
     "Domain Bucket":"100K - 1M"
   },
   {
     "Class":"Predicate",
-    "Name":"http:\/\/schema.org\/downloadUrl-input",
+    "Name":"https://schema.org/downloadUrl-input",
     "Domain Bucket":"< 1K"
   },
   {
     "Class":"Predicate",
-    "Name":"http:\/\/schema.org\/downloadUrl-output",
+    "Name":"https://schema.org/downloadUrl-output",
     "Domain Bucket":"< 1K"
   },
   {
     "Class":"Predicate",
-    "Name":"http:\/\/schema.org\/downvoteCount",
+    "Name":"https://schema.org/downvoteCount",
     "Domain Bucket":"1K - 10K"
   },
   {
     "Class":"Predicate",
-    "Name":"http:\/\/schema.org\/downvoteCount-input",
+    "Name":"https://schema.org/downvoteCount-input",
     "Domain Bucket":"< 1K"
   },
   {
     "Class":"Predicate",
-    "Name":"http:\/\/schema.org\/downvoteCount-output",
+    "Name":"https://schema.org/downvoteCount-output",
     "Domain Bucket":"< 1K"
   },
   {
     "Class":"Predicate",
-    "Name":"http:\/\/schema.org\/drainsTo",
+    "Name":"https://schema.org/drainsTo",
     "Domain Bucket":"< 1K"
   },
   {
     "Class":"Predicate",
-    "Name":"http:\/\/schema.org\/drainsTo-input",
+    "Name":"https://schema.org/drainsTo-input",
     "Domain Bucket":"< 1K"
   },
   {
     "Class":"Predicate",
-    "Name":"http:\/\/schema.org\/drainsTo-output",
+    "Name":"https://schema.org/drainsTo-output",
     "Domain Bucket":"< 1K"
   },
   {
     "Class":"Predicate",
-    "Name":"http:\/\/schema.org\/driveWheelConfiguration",
+    "Name":"https://schema.org/driveWheelConfiguration",
     "Domain Bucket":"10K - 100K"
   },
   {
     "Class":"Predicate",
-    "Name":"http:\/\/schema.org\/driveWheelConfiguration-input",
+    "Name":"https://schema.org/driveWheelConfiguration-input",
     "Domain Bucket":"< 1K"
   },
   {
     "Class":"Predicate",
-    "Name":"http:\/\/schema.org\/driveWheelConfiguration-output",
+    "Name":"https://schema.org/driveWheelConfiguration-output",
     "Domain Bucket":"< 1K"
   },
   {
     "Class":"Predicate",
-    "Name":"http:\/\/schema.org\/dropoffLocation",
+    "Name":"https://schema.org/dropoffLocation",
     "Domain Bucket":"< 1K"
   },
   {
     "Class":"Predicate",
-    "Name":"http:\/\/schema.org\/dropoffLocation-input",
+    "Name":"https://schema.org/dropoffLocation-input",
     "Domain Bucket":"< 1K"
   },
   {
     "Class":"Predicate",
-    "Name":"http:\/\/schema.org\/dropoffLocation-output",
+    "Name":"https://schema.org/dropoffLocation-output",
     "Domain Bucket":"< 1K"
   },
   {
     "Class":"Predicate",
-    "Name":"http:\/\/schema.org\/dropoffTime",
+    "Name":"https://schema.org/dropoffTime",
     "Domain Bucket":"< 1K"
   },
   {
     "Class":"Predicate",
-    "Name":"http:\/\/schema.org\/dropoffTime-input",
+    "Name":"https://schema.org/dropoffTime-input",
     "Domain Bucket":"< 1K"
   },
   {
     "Class":"Predicate",
-    "Name":"http:\/\/schema.org\/dropoffTime-output",
+    "Name":"https://schema.org/dropoffTime-output",
     "Domain Bucket":"< 1K"
   },
   {
     "Class":"Predicate",
-    "Name":"http:\/\/schema.org\/drug",
+    "Name":"https://schema.org/drug",
     "Domain Bucket":"< 1K"
   },
   {
     "Class":"Predicate",
-    "Name":"http:\/\/schema.org\/drug-input",
+    "Name":"https://schema.org/drug-input",
     "Domain Bucket":"< 1K"
   },
   {
     "Class":"Predicate",
-    "Name":"http:\/\/schema.org\/drug-output",
+    "Name":"https://schema.org/drug-output",
     "Domain Bucket":"< 1K"
   },
   {
     "Class":"Predicate",
-    "Name":"http:\/\/schema.org\/drugClass",
+    "Name":"https://schema.org/drugClass",
     "Domain Bucket":"1K - 10K"
   },
   {
     "Class":"Predicate",
-    "Name":"http:\/\/schema.org\/drugClass-input",
+    "Name":"https://schema.org/drugClass-input",
     "Domain Bucket":"< 1K"
   },
   {
     "Class":"Predicate",
-    "Name":"http:\/\/schema.org\/drugClass-output",
+    "Name":"https://schema.org/drugClass-output",
     "Domain Bucket":"< 1K"
   },
   {
     "Class":"Predicate",
-    "Name":"http:\/\/schema.org\/drugUnit",
+    "Name":"https://schema.org/drugUnit",
     "Domain Bucket":"< 1K"
   },
   {
     "Class":"Predicate",
-    "Name":"http:\/\/schema.org\/drugUnit-input",
+    "Name":"https://schema.org/drugUnit-input",
     "Domain Bucket":"< 1K"
   },
   {
     "Class":"Predicate",
-    "Name":"http:\/\/schema.org\/drugUnit-output",
+    "Name":"https://schema.org/drugUnit-output",
     "Domain Bucket":"< 1K"
   },
   {
     "Class":"Predicate",
-    "Name":"http:\/\/schema.org\/duns",
+    "Name":"https://schema.org/duns",
     "Domain Bucket":"1K - 10K"
   },
   {
     "Class":"Predicate",
-    "Name":"http:\/\/schema.org\/duns-input",
+    "Name":"https://schema.org/duns-input",
     "Domain Bucket":"< 1K"
   },
   {
     "Class":"Predicate",
-    "Name":"http:\/\/schema.org\/duns-output",
+    "Name":"https://schema.org/duns-output",
     "Domain Bucket":"< 1K"
   },
   {
     "Class":"Predicate",
-    "Name":"http:\/\/schema.org\/duplicateTherapy",
+    "Name":"https://schema.org/duplicateTherapy",
     "Domain Bucket":"< 1K"
   },
   {
     "Class":"Predicate",
-    "Name":"http:\/\/schema.org\/duplicateTherapy-input",
+    "Name":"https://schema.org/duplicateTherapy-input",
     "Domain Bucket":"< 1K"
   },
   {
     "Class":"Predicate",
-    "Name":"http:\/\/schema.org\/duplicateTherapy-output",
+    "Name":"https://schema.org/duplicateTherapy-output",
     "Domain Bucket":"< 1K"
   },
   {
     "Class":"Predicate",
-    "Name":"http:\/\/schema.org\/duration",
+    "Name":"https://schema.org/duration",
     "Domain Bucket":"1M - 10M"
   },
   {
     "Class":"Predicate",
-    "Name":"http:\/\/schema.org\/duration-input",
+    "Name":"https://schema.org/duration-input",
     "Domain Bucket":"< 1K"
   },
   {
     "Class":"Predicate",
-    "Name":"http:\/\/schema.org\/duration-output",
+    "Name":"https://schema.org/duration-output",
     "Domain Bucket":"< 1K"
   },
   {
     "Class":"Predicate",
-    "Name":"http:\/\/schema.org\/durationOfWarranty",
+    "Name":"https://schema.org/durationOfWarranty",
     "Domain Bucket":"1K - 10K"
   },
   {
     "Class":"Predicate",
-    "Name":"http:\/\/schema.org\/durationOfWarranty-input",
+    "Name":"https://schema.org/durationOfWarranty-input",
     "Domain Bucket":"< 1K"
   },
   {
     "Class":"Predicate",
-    "Name":"http:\/\/schema.org\/durationOfWarranty-output",
+    "Name":"https://schema.org/durationOfWarranty-output",
     "Domain Bucket":"< 1K"
   },
   {
     "Class":"Predicate",
-    "Name":"http:\/\/schema.org\/duringMedia",
+    "Name":"https://schema.org/duringMedia",
     "Domain Bucket":"< 1K"
   },
   {
     "Class":"Predicate",
-    "Name":"http:\/\/schema.org\/duringMedia-input",
+    "Name":"https://schema.org/duringMedia-input",
     "Domain Bucket":"< 1K"
   },
   {
     "Class":"Predicate",
-    "Name":"http:\/\/schema.org\/duringMedia-output",
+    "Name":"https://schema.org/duringMedia-output",
     "Domain Bucket":"< 1K"
   },
   {
     "Class":"Predicate",
-    "Name":"http:\/\/schema.org\/earlyPrepaymentPenalty",
+    "Name":"https://schema.org/earlyPrepaymentPenalty",
     "Domain Bucket":"< 1K"
   },
   {
     "Class":"Predicate",
-    "Name":"http:\/\/schema.org\/earlyPrepaymentPenalty-input",
+    "Name":"https://schema.org/earlyPrepaymentPenalty-input",
     "Domain Bucket":"< 1K"
   },
   {
     "Class":"Predicate",
-    "Name":"http:\/\/schema.org\/earlyPrepaymentPenalty-output",
+    "Name":"https://schema.org/earlyPrepaymentPenalty-output",
     "Domain Bucket":"< 1K"
   },
   {
     "Class":"Predicate",
-    "Name":"http:\/\/schema.org\/editEIDR",
+    "Name":"https://schema.org/editEIDR",
     "Domain Bucket":"< 1K"
   },
   {
     "Class":"Predicate",
-    "Name":"http:\/\/schema.org\/editEIDR-input",
+    "Name":"https://schema.org/editEIDR-input",
     "Domain Bucket":"< 1K"
   },
   {
     "Class":"Predicate",
-    "Name":"http:\/\/schema.org\/editEIDR-output",
+    "Name":"https://schema.org/editEIDR-output",
     "Domain Bucket":"< 1K"
   },
   {
     "Class":"Predicate",
-    "Name":"http:\/\/schema.org\/editor",
+    "Name":"https://schema.org/editor",
     "Domain Bucket":"100K - 1M"
   },
   {
     "Class":"Predicate",
-    "Name":"http:\/\/schema.org\/editor-input",
+    "Name":"https://schema.org/editor-input",
     "Domain Bucket":"< 1K"
   },
   {
     "Class":"Predicate",
-    "Name":"http:\/\/schema.org\/editor-output",
+    "Name":"https://schema.org/editor-output",
     "Domain Bucket":"< 1K"
   },
   {
     "Class":"Predicate",
-    "Name":"http:\/\/schema.org\/eduQuestionType",
+    "Name":"https://schema.org/eduQuestionType",
     "Domain Bucket":"1K - 10K"
   },
   {
     "Class":"Predicate",
-    "Name":"http:\/\/schema.org\/eduQuestionType-input",
+    "Name":"https://schema.org/eduQuestionType-input",
     "Domain Bucket":"< 1K"
   },
   {
     "Class":"Predicate",
-    "Name":"http:\/\/schema.org\/eduQuestionType-output",
+    "Name":"https://schema.org/eduQuestionType-output",
     "Domain Bucket":"< 1K"
   },
   {
     "Class":"Predicate",
-    "Name":"http:\/\/schema.org\/educationRequirements",
+    "Name":"https://schema.org/educationRequirements",
     "Domain Bucket":"10K - 100K"
   },
   {
     "Class":"Predicate",
-    "Name":"http:\/\/schema.org\/educationRequirements-input",
+    "Name":"https://schema.org/educationRequirements-input",
     "Domain Bucket":"< 1K"
   },
   {
     "Class":"Predicate",
-    "Name":"http:\/\/schema.org\/educationRequirements-output",
+    "Name":"https://schema.org/educationRequirements-output",
     "Domain Bucket":"< 1K"
   },
   {
     "Class":"Predicate",
-    "Name":"http:\/\/schema.org\/educationalAlignment",
+    "Name":"https://schema.org/educationalAlignment",
     "Domain Bucket":"1K - 10K"
   },
   {
     "Class":"Predicate",
-    "Name":"http:\/\/schema.org\/educationalAlignment-input",
+    "Name":"https://schema.org/educationalAlignment-input",
     "Domain Bucket":"< 1K"
   },
   {
     "Class":"Predicate",
-    "Name":"http:\/\/schema.org\/educationalAlignment-output",
+    "Name":"https://schema.org/educationalAlignment-output",
     "Domain Bucket":"< 1K"
   },
   {
     "Class":"Predicate",
-    "Name":"http:\/\/schema.org\/educationalCredentialAwarded",
+    "Name":"https://schema.org/educationalCredentialAwarded",
     "Domain Bucket":"10K - 100K"
   },
   {
     "Class":"Predicate",
-    "Name":"http:\/\/schema.org\/educationalCredentialAwarded-input",
+    "Name":"https://schema.org/educationalCredentialAwarded-input",
     "Domain Bucket":"< 1K"
   },
   {
     "Class":"Predicate",
-    "Name":"http:\/\/schema.org\/educationalCredentialAwarded-output",
+    "Name":"https://schema.org/educationalCredentialAwarded-output",
     "Domain Bucket":"< 1K"
   },
   {
     "Class":"Predicate",
-    "Name":"http:\/\/schema.org\/educationalFramework",
+    "Name":"https://schema.org/educationalFramework",
     "Domain Bucket":"< 1K"
   },
   {
     "Class":"Predicate",
-    "Name":"http:\/\/schema.org\/educationalFramework-input",
+    "Name":"https://schema.org/educationalFramework-input",
     "Domain Bucket":"< 1K"
   },
   {
     "Class":"Predicate",
-    "Name":"http:\/\/schema.org\/educationalFramework-output",
+    "Name":"https://schema.org/educationalFramework-output",
     "Domain Bucket":"< 1K"
   },
   {
     "Class":"Predicate",
-    "Name":"http:\/\/schema.org\/educationalLevel",
+    "Name":"https://schema.org/educationalLevel",
     "Domain Bucket":"10K - 100K"
   },
   {
     "Class":"Predicate",
-    "Name":"http:\/\/schema.org\/educationalLevel-input",
+    "Name":"https://schema.org/educationalLevel-input",
     "Domain Bucket":"< 1K"
   },
   {
     "Class":"Predicate",
-    "Name":"http:\/\/schema.org\/educationalLevel-output",
+    "Name":"https://schema.org/educationalLevel-output",
     "Domain Bucket":"< 1K"
   },
   {
     "Class":"Predicate",
-    "Name":"http:\/\/schema.org\/educationalProgramMode",
+    "Name":"https://schema.org/educationalProgramMode",
     "Domain Bucket":"1K - 10K"
   },
   {
     "Class":"Predicate",
-    "Name":"http:\/\/schema.org\/educationalProgramMode-input",
+    "Name":"https://schema.org/educationalProgramMode-input",
     "Domain Bucket":"< 1K"
   },
   {
     "Class":"Predicate",
-    "Name":"http:\/\/schema.org\/educationalProgramMode-output",
+    "Name":"https://schema.org/educationalProgramMode-output",
     "Domain Bucket":"< 1K"
   },
   {
     "Class":"Predicate",
-    "Name":"http:\/\/schema.org\/educationalRole",
+    "Name":"https://schema.org/educationalRole",
     "Domain Bucket":"10K - 100K"
   },
   {
     "Class":"Predicate",
-    "Name":"http:\/\/schema.org\/educationalRole-input",
+    "Name":"https://schema.org/educationalRole-input",
     "Domain Bucket":"< 1K"
   },
   {
     "Class":"Predicate",
-    "Name":"http:\/\/schema.org\/educationalRole-output",
+    "Name":"https://schema.org/educationalRole-output",
     "Domain Bucket":"< 1K"
   },
   {
     "Class":"Predicate",
-    "Name":"http:\/\/schema.org\/educationalUse",
+    "Name":"https://schema.org/educationalUse",
     "Domain Bucket":"1K - 10K"
   },
   {
     "Class":"Predicate",
-    "Name":"http:\/\/schema.org\/educationalUse-input",
+    "Name":"https://schema.org/educationalUse-input",
     "Domain Bucket":"< 1K"
   },
   {
     "Class":"Predicate",
-    "Name":"http:\/\/schema.org\/educationalUse-output",
+    "Name":"https://schema.org/educationalUse-output",
     "Domain Bucket":"< 1K"
   },
   {
     "Class":"Predicate",
-    "Name":"http:\/\/schema.org\/elevation",
+    "Name":"https://schema.org/elevation",
     "Domain Bucket":"1K - 10K"
   },
   {
     "Class":"Predicate",
-    "Name":"http:\/\/schema.org\/elevation-input",
+    "Name":"https://schema.org/elevation-input",
     "Domain Bucket":"< 1K"
   },
   {
     "Class":"Predicate",
-    "Name":"http:\/\/schema.org\/elevation-output",
+    "Name":"https://schema.org/elevation-output",
     "Domain Bucket":"< 1K"
   },
   {
     "Class":"Predicate",
-    "Name":"http:\/\/schema.org\/eligibilityToWorkRequirement",
+    "Name":"https://schema.org/eligibilityToWorkRequirement",
     "Domain Bucket":"< 1K"
   },
   {
     "Class":"Predicate",
-    "Name":"http:\/\/schema.org\/eligibilityToWorkRequirement-input",
+    "Name":"https://schema.org/eligibilityToWorkRequirement-input",
     "Domain Bucket":"< 1K"
   },
   {
     "Class":"Predicate",
-    "Name":"http:\/\/schema.org\/eligibilityToWorkRequirement-output",
+    "Name":"https://schema.org/eligibilityToWorkRequirement-output",
     "Domain Bucket":"< 1K"
   },
   {
     "Class":"Predicate",
-    "Name":"http:\/\/schema.org\/eligibleCustomerType",
+    "Name":"https://schema.org/eligibleCustomerType",
     "Domain Bucket":"1K - 10K"
   },
   {
     "Class":"Predicate",
-    "Name":"http:\/\/schema.org\/eligibleCustomerType-input",
+    "Name":"https://schema.org/eligibleCustomerType-input",
     "Domain Bucket":"< 1K"
   },
   {
     "Class":"Predicate",
-    "Name":"http:\/\/schema.org\/eligibleCustomerType-output",
+    "Name":"https://schema.org/eligibleCustomerType-output",
     "Domain Bucket":"< 1K"
   },
   {
     "Class":"Predicate",
-    "Name":"http:\/\/schema.org\/eligibleDuration",
+    "Name":"https://schema.org/eligibleDuration",
     "Domain Bucket":"10K - 100K"
   },
   {
     "Class":"Predicate",
-    "Name":"http:\/\/schema.org\/eligibleDuration-input",
+    "Name":"https://schema.org/eligibleDuration-input",
     "Domain Bucket":"< 1K"
   },
   {
     "Class":"Predicate",
-    "Name":"http:\/\/schema.org\/eligibleDuration-output",
+    "Name":"https://schema.org/eligibleDuration-output",
     "Domain Bucket":"< 1K"
   },
   {
     "Class":"Predicate",
-    "Name":"http:\/\/schema.org\/eligibleQuantity",
+    "Name":"https://schema.org/eligibleQuantity",
     "Domain Bucket":"10K - 100K"
   },
   {
     "Class":"Predicate",
-    "Name":"http:\/\/schema.org\/eligibleQuantity-input",
+    "Name":"https://schema.org/eligibleQuantity-input",
     "Domain Bucket":"< 1K"
   },
   {
     "Class":"Predicate",
-    "Name":"http:\/\/schema.org\/eligibleQuantity-output",
+    "Name":"https://schema.org/eligibleQuantity-output",
     "Domain Bucket":"< 1K"
   },
   {
     "Class":"Predicate",
-    "Name":"http:\/\/schema.org\/eligibleRegion",
+    "Name":"https://schema.org/eligibleRegion",
     "Domain Bucket":"10K - 100K"
   },
   {
     "Class":"Predicate",
-    "Name":"http:\/\/schema.org\/eligibleRegion-input",
+    "Name":"https://schema.org/eligibleRegion-input",
     "Domain Bucket":"< 1K"
   },
   {
     "Class":"Predicate",
-    "Name":"http:\/\/schema.org\/eligibleRegion-output",
+    "Name":"https://schema.org/eligibleRegion-output",
     "Domain Bucket":"< 1K"
   },
   {
     "Class":"Predicate",
-    "Name":"http:\/\/schema.org\/eligibleTransactionVolume",
+    "Name":"https://schema.org/eligibleTransactionVolume",
     "Domain Bucket":"10K - 100K"
   },
   {
     "Class":"Predicate",
-    "Name":"http:\/\/schema.org\/eligibleTransactionVolume-input",
+    "Name":"https://schema.org/eligibleTransactionVolume-input",
     "Domain Bucket":"< 1K"
   },
   {
     "Class":"Predicate",
-    "Name":"http:\/\/schema.org\/eligibleTransactionVolume-output",
+    "Name":"https://schema.org/eligibleTransactionVolume-output",
     "Domain Bucket":"< 1K"
   },
   {
     "Class":"Predicate",
-    "Name":"http:\/\/schema.org\/eligibleWithSupplier",
+    "Name":"https://schema.org/eligibleWithSupplier",
     "Domain Bucket":"< 1K"
   },
   {
     "Class":"Predicate",
-    "Name":"http:\/\/schema.org\/eligibleWithSupplier-input",
+    "Name":"https://schema.org/eligibleWithSupplier-input",
     "Domain Bucket":"< 1K"
   },
   {
     "Class":"Predicate",
-    "Name":"http:\/\/schema.org\/eligibleWithSupplier-output",
+    "Name":"https://schema.org/eligibleWithSupplier-output",
     "Domain Bucket":"< 1K"
   },
   {
     "Class":"Predicate",
-    "Name":"http:\/\/schema.org\/email",
+    "Name":"https://schema.org/email",
     "Domain Bucket":"1M - 10M"
   },
   {
     "Class":"Predicate",
-    "Name":"http:\/\/schema.org\/email-input",
+    "Name":"https://schema.org/email-input",
     "Domain Bucket":"< 1K"
   },
   {
     "Class":"Predicate",
-    "Name":"http:\/\/schema.org\/email-output",
+    "Name":"https://schema.org/email-output",
     "Domain Bucket":"< 1K"
   },
   {
     "Class":"Predicate",
-    "Name":"http:\/\/schema.org\/embedUrl",
+    "Name":"https://schema.org/embedUrl",
     "Domain Bucket":"1M - 10M"
   },
   {
     "Class":"Predicate",
-    "Name":"http:\/\/schema.org\/embedUrl-input",
+    "Name":"https://schema.org/embedUrl-input",
     "Domain Bucket":"< 1K"
   },
   {
     "Class":"Predicate",
-    "Name":"http:\/\/schema.org\/embedUrl-output",
+    "Name":"https://schema.org/embedUrl-output",
     "Domain Bucket":"< 1K"
   },
   {
     "Class":"Predicate",
-    "Name":"http:\/\/schema.org\/embeddedTextCaption",
+    "Name":"https://schema.org/embeddedTextCaption",
     "Domain Bucket":"1K - 10K"
   },
   {
     "Class":"Predicate",
-    "Name":"http:\/\/schema.org\/embeddedTextCaption-input",
+    "Name":"https://schema.org/embeddedTextCaption-input",
     "Domain Bucket":"< 1K"
   },
   {
     "Class":"Predicate",
-    "Name":"http:\/\/schema.org\/embeddedTextCaption-output",
+    "Name":"https://schema.org/embeddedTextCaption-output",
     "Domain Bucket":"< 1K"
   },
   {
     "Class":"Predicate",
-    "Name":"http:\/\/schema.org\/emissionsCO2",
+    "Name":"https://schema.org/emissionsCO2",
     "Domain Bucket":"1K - 10K"
   },
   {
     "Class":"Predicate",
-    "Name":"http:\/\/schema.org\/emissionsCO2-input",
+    "Name":"https://schema.org/emissionsCO2-input",
     "Domain Bucket":"< 1K"
   },
   {
     "Class":"Predicate",
-    "Name":"http:\/\/schema.org\/emissionsCO2-output",
+    "Name":"https://schema.org/emissionsCO2-output",
     "Domain Bucket":"< 1K"
   },
   {
     "Class":"Predicate",
-    "Name":"http:\/\/schema.org\/employee",
+    "Name":"https://schema.org/employee",
     "Domain Bucket":"100K - 1M"
   },
   {
     "Class":"Predicate",
-    "Name":"http:\/\/schema.org\/employee-input",
+    "Name":"https://schema.org/employee-input",
     "Domain Bucket":"< 1K"
   },
   {
     "Class":"Predicate",
-    "Name":"http:\/\/schema.org\/employee-output",
+    "Name":"https://schema.org/employee-output",
     "Domain Bucket":"< 1K"
   },
   {
     "Class":"Predicate",
-    "Name":"http:\/\/schema.org\/employees",
+    "Name":"https://schema.org/employees",
     "Domain Bucket":"1K - 10K"
   },
   {
     "Class":"Predicate",
-    "Name":"http:\/\/schema.org\/employees-input",
+    "Name":"https://schema.org/employees-input",
     "Domain Bucket":"< 1K"
   },
   {
     "Class":"Predicate",
-    "Name":"http:\/\/schema.org\/employees-output",
+    "Name":"https://schema.org/employees-output",
     "Domain Bucket":"< 1K"
   },
   {
     "Class":"Predicate",
-    "Name":"http:\/\/schema.org\/employerOverview",
+    "Name":"https://schema.org/employerOverview",
     "Domain Bucket":"1K - 10K"
   },
   {
     "Class":"Predicate",
-    "Name":"http:\/\/schema.org\/employerOverview-input",
+    "Name":"https://schema.org/employerOverview-input",
     "Domain Bucket":"< 1K"
   },
   {
     "Class":"Predicate",
-    "Name":"http:\/\/schema.org\/employerOverview-output",
+    "Name":"https://schema.org/employerOverview-output",
     "Domain Bucket":"< 1K"
   },
   {
     "Class":"Predicate",
-    "Name":"http:\/\/schema.org\/employmentType",
+    "Name":"https://schema.org/employmentType",
     "Domain Bucket":"100K - 1M"
   },
   {
     "Class":"Predicate",
-    "Name":"http:\/\/schema.org\/employmentType-input",
+    "Name":"https://schema.org/employmentType-input",
     "Domain Bucket":"< 1K"
   },
   {
     "Class":"Predicate",
-    "Name":"http:\/\/schema.org\/employmentType-output",
+    "Name":"https://schema.org/employmentType-output",
     "Domain Bucket":"< 1K"
   },
   {
     "Class":"Predicate",
-    "Name":"http:\/\/schema.org\/employmentUnit",
+    "Name":"https://schema.org/employmentUnit",
     "Domain Bucket":"1K - 10K"
   },
   {
     "Class":"Predicate",
-    "Name":"http:\/\/schema.org\/employmentUnit-input",
+    "Name":"https://schema.org/employmentUnit-input",
     "Domain Bucket":"< 1K"
   },
   {
     "Class":"Predicate",
-    "Name":"http:\/\/schema.org\/employmentUnit-output",
+    "Name":"https://schema.org/employmentUnit-output",
     "Domain Bucket":"< 1K"
   },
   {
     "Class":"Predicate",
-    "Name":"http:\/\/schema.org\/encodesBioChemEntity",
+    "Name":"https://schema.org/encodesBioChemEntity",
     "Domain Bucket":"< 1K"
   },
   {
     "Class":"Predicate",
-    "Name":"http:\/\/schema.org\/encodesBioChemEntity-input",
+    "Name":"https://schema.org/encodesBioChemEntity-input",
     "Domain Bucket":"< 1K"
   },
   {
     "Class":"Predicate",
-    "Name":"http:\/\/schema.org\/encodesBioChemEntity-output",
+    "Name":"https://schema.org/encodesBioChemEntity-output",
     "Domain Bucket":"< 1K"
   },
   {
     "Class":"Predicate",
-    "Name":"http:\/\/schema.org\/encodesCreativeWork",
+    "Name":"https://schema.org/encodesCreativeWork",
     "Domain Bucket":"< 1K"
   },
   {
     "Class":"Predicate",
-    "Name":"http:\/\/schema.org\/encodesCreativeWork-input",
+    "Name":"https://schema.org/encodesCreativeWork-input",
     "Domain Bucket":"< 1K"
   },
   {
     "Class":"Predicate",
-    "Name":"http:\/\/schema.org\/encodesCreativeWork-output",
+    "Name":"https://schema.org/encodesCreativeWork-output",
     "Domain Bucket":"< 1K"
   },
   {
     "Class":"Predicate",
-    "Name":"http:\/\/schema.org\/encoding",
+    "Name":"https://schema.org/encoding",
     "Domain Bucket":"100K - 1M"
   },
   {
     "Class":"Predicate",
-    "Name":"http:\/\/schema.org\/encoding-input",
+    "Name":"https://schema.org/encoding-input",
     "Domain Bucket":"< 1K"
   },
   {
     "Class":"Predicate",
-    "Name":"http:\/\/schema.org\/encoding-output",
+    "Name":"https://schema.org/encoding-output",
     "Domain Bucket":"< 1K"
   },
   {
     "Class":"Predicate",
-    "Name":"http:\/\/schema.org\/encodingFormat",
+    "Name":"https://schema.org/encodingFormat",
     "Domain Bucket":"10K - 100K"
   },
   {
     "Class":"Predicate",
-    "Name":"http:\/\/schema.org\/encodingFormat-input",
+    "Name":"https://schema.org/encodingFormat-input",
     "Domain Bucket":"< 1K"
   },
   {
     "Class":"Predicate",
-    "Name":"http:\/\/schema.org\/encodingFormat-output",
+    "Name":"https://schema.org/encodingFormat-output",
     "Domain Bucket":"< 1K"
   },
   {
     "Class":"Predicate",
-    "Name":"http:\/\/schema.org\/encodingType",
+    "Name":"https://schema.org/encodingType",
     "Domain Bucket":"< 1K"
   },
   {
     "Class":"Predicate",
-    "Name":"http:\/\/schema.org\/encodingType-input",
+    "Name":"https://schema.org/encodingType-input",
     "Domain Bucket":"< 1K"
   },
   {
     "Class":"Predicate",
-    "Name":"http:\/\/schema.org\/encodingType-output",
+    "Name":"https://schema.org/encodingType-output",
     "Domain Bucket":"< 1K"
   },
   {
     "Class":"Predicate",
-    "Name":"http:\/\/schema.org\/encodings",
+    "Name":"https://schema.org/encodings",
     "Domain Bucket":"< 1K"
   },
   {
     "Class":"Predicate",
-    "Name":"http:\/\/schema.org\/encodings-input",
+    "Name":"https://schema.org/encodings-input",
     "Domain Bucket":"< 1K"
   },
   {
     "Class":"Predicate",
-    "Name":"http:\/\/schema.org\/encodings-output",
+    "Name":"https://schema.org/encodings-output",
     "Domain Bucket":"< 1K"
   },
   {
     "Class":"Predicate",
-    "Name":"http:\/\/schema.org\/endDate",
+    "Name":"https://schema.org/endDate",
     "Domain Bucket":"100K - 1M"
   },
   {
     "Class":"Predicate",
-    "Name":"http:\/\/schema.org\/endDate-input",
+    "Name":"https://schema.org/endDate-input",
     "Domain Bucket":"< 1K"
   },
   {
     "Class":"Predicate",
-    "Name":"http:\/\/schema.org\/endDate-output",
+    "Name":"https://schema.org/endDate-output",
     "Domain Bucket":"< 1K"
   },
   {
     "Class":"Predicate",
-    "Name":"http:\/\/schema.org\/endOffset",
+    "Name":"https://schema.org/endOffset",
     "Domain Bucket":"10K - 100K"
   },
   {
     "Class":"Predicate",
-    "Name":"http:\/\/schema.org\/endOffset-input",
+    "Name":"https://schema.org/endOffset-input",
     "Domain Bucket":"< 1K"
   },
   {
     "Class":"Predicate",
-    "Name":"http:\/\/schema.org\/endOffset-output",
+    "Name":"https://schema.org/endOffset-output",
     "Domain Bucket":"< 1K"
   },
   {
     "Class":"Predicate",
-    "Name":"http:\/\/schema.org\/endTime",
+    "Name":"https://schema.org/endTime",
     "Domain Bucket":"1K - 10K"
   },
   {
     "Class":"Predicate",
-    "Name":"http:\/\/schema.org\/endTime-input",
+    "Name":"https://schema.org/endTime-input",
     "Domain Bucket":"< 1K"
   },
   {
     "Class":"Predicate",
-    "Name":"http:\/\/schema.org\/endTime-output",
+    "Name":"https://schema.org/endTime-output",
     "Domain Bucket":"< 1K"
   },
   {
     "Class":"Predicate",
-    "Name":"http:\/\/schema.org\/endorsee",
+    "Name":"https://schema.org/endorsee",
     "Domain Bucket":"< 1K"
   },
   {
     "Class":"Predicate",
-    "Name":"http:\/\/schema.org\/endorsee-input",
+    "Name":"https://schema.org/endorsee-input",
     "Domain Bucket":"< 1K"
   },
   {
     "Class":"Predicate",
-    "Name":"http:\/\/schema.org\/endorsee-output",
+    "Name":"https://schema.org/endorsee-output",
     "Domain Bucket":"< 1K"
   },
   {
     "Class":"Predicate",
-    "Name":"http:\/\/schema.org\/endorsers",
+    "Name":"https://schema.org/endorsers",
     "Domain Bucket":"< 1K"
   },
   {
     "Class":"Predicate",
-    "Name":"http:\/\/schema.org\/endorsers-input",
+    "Name":"https://schema.org/endorsers-input",
     "Domain Bucket":"< 1K"
   },
   {
     "Class":"Predicate",
-    "Name":"http:\/\/schema.org\/endorsers-output",
+    "Name":"https://schema.org/endorsers-output",
     "Domain Bucket":"< 1K"
   },
   {
     "Class":"Predicate",
-    "Name":"http:\/\/schema.org\/energyEfficiencyScaleMax",
+    "Name":"https://schema.org/energyEfficiencyScaleMax",
     "Domain Bucket":"1K - 10K"
   },
   {
     "Class":"Predicate",
-    "Name":"http:\/\/schema.org\/energyEfficiencyScaleMax-input",
+    "Name":"https://schema.org/energyEfficiencyScaleMax-input",
     "Domain Bucket":"< 1K"
   },
   {
     "Class":"Predicate",
-    "Name":"http:\/\/schema.org\/energyEfficiencyScaleMax-output",
+    "Name":"https://schema.org/energyEfficiencyScaleMax-output",
     "Domain Bucket":"< 1K"
   },
   {
     "Class":"Predicate",
-    "Name":"http:\/\/schema.org\/energyEfficiencyScaleMin",
+    "Name":"https://schema.org/energyEfficiencyScaleMin",
     "Domain Bucket":"1K - 10K"
   },
   {
     "Class":"Predicate",
-    "Name":"http:\/\/schema.org\/energyEfficiencyScaleMin-input",
+    "Name":"https://schema.org/energyEfficiencyScaleMin-input",
     "Domain Bucket":"< 1K"
   },
   {
     "Class":"Predicate",
-    "Name":"http:\/\/schema.org\/energyEfficiencyScaleMin-output",
+    "Name":"https://schema.org/energyEfficiencyScaleMin-output",
     "Domain Bucket":"< 1K"
   },
   {
     "Class":"Predicate",
-    "Name":"http:\/\/schema.org\/engineDisplacement",
+    "Name":"https://schema.org/engineDisplacement",
     "Domain Bucket":"10K - 100K"
   },
   {
     "Class":"Predicate",
-    "Name":"http:\/\/schema.org\/engineDisplacement-input",
+    "Name":"https://schema.org/engineDisplacement-input",
     "Domain Bucket":"< 1K"
   },
   {
     "Class":"Predicate",
-    "Name":"http:\/\/schema.org\/engineDisplacement-output",
+    "Name":"https://schema.org/engineDisplacement-output",
     "Domain Bucket":"< 1K"
   },
   {
     "Class":"Predicate",
-    "Name":"http:\/\/schema.org\/enginePower",
+    "Name":"https://schema.org/enginePower",
     "Domain Bucket":"10K - 100K"
   },
   {
     "Class":"Predicate",
-    "Name":"http:\/\/schema.org\/enginePower-input",
+    "Name":"https://schema.org/enginePower-input",
     "Domain Bucket":"< 1K"
   },
   {
     "Class":"Predicate",
-    "Name":"http:\/\/schema.org\/enginePower-output",
+    "Name":"https://schema.org/enginePower-output",
     "Domain Bucket":"< 1K"
   },
   {
     "Class":"Predicate",
-    "Name":"http:\/\/schema.org\/engineType",
+    "Name":"https://schema.org/engineType",
     "Domain Bucket":"1K - 10K"
   },
   {
     "Class":"Predicate",
-    "Name":"http:\/\/schema.org\/engineType-input",
+    "Name":"https://schema.org/engineType-input",
     "Domain Bucket":"< 1K"
   },
   {
     "Class":"Predicate",
-    "Name":"http:\/\/schema.org\/engineType-output",
+    "Name":"https://schema.org/engineType-output",
     "Domain Bucket":"< 1K"
   },
   {
     "Class":"Predicate",
-    "Name":"http:\/\/schema.org\/entertainmentBusiness",
+    "Name":"https://schema.org/entertainmentBusiness",
     "Domain Bucket":"< 1K"
   },
   {
     "Class":"Predicate",
-    "Name":"http:\/\/schema.org\/entertainmentBusiness-input",
+    "Name":"https://schema.org/entertainmentBusiness-input",
     "Domain Bucket":"< 1K"
   },
   {
     "Class":"Predicate",
-    "Name":"http:\/\/schema.org\/entertainmentBusiness-output",
+    "Name":"https://schema.org/entertainmentBusiness-output",
     "Domain Bucket":"< 1K"
   },
   {
     "Class":"Predicate",
-    "Name":"http:\/\/schema.org\/epidemiology",
+    "Name":"https://schema.org/epidemiology",
     "Domain Bucket":"< 1K"
   },
   {
     "Class":"Predicate",
-    "Name":"http:\/\/schema.org\/epidemiology-input",
+    "Name":"https://schema.org/epidemiology-input",
     "Domain Bucket":"< 1K"
   },
   {
     "Class":"Predicate",
-    "Name":"http:\/\/schema.org\/epidemiology-output",
+    "Name":"https://schema.org/epidemiology-output",
     "Domain Bucket":"< 1K"
   },
   {
     "Class":"Predicate",
-    "Name":"http:\/\/schema.org\/episode",
+    "Name":"https://schema.org/episode",
     "Domain Bucket":"1K - 10K"
   },
   {
     "Class":"Predicate",
-    "Name":"http:\/\/schema.org\/episode-input",
+    "Name":"https://schema.org/episode-input",
     "Domain Bucket":"< 1K"
   },
   {
     "Class":"Predicate",
-    "Name":"http:\/\/schema.org\/episode-output",
+    "Name":"https://schema.org/episode-output",
     "Domain Bucket":"< 1K"
   },
   {
     "Class":"Predicate",
-    "Name":"http:\/\/schema.org\/episodeNumber",
+    "Name":"https://schema.org/episodeNumber",
     "Domain Bucket":"10K - 100K"
   },
   {
     "Class":"Predicate",
-    "Name":"http:\/\/schema.org\/episodeNumber-input",
+    "Name":"https://schema.org/episodeNumber-input",
     "Domain Bucket":"< 1K"
   },
   {
     "Class":"Predicate",
-    "Name":"http:\/\/schema.org\/episodeNumber-output",
+    "Name":"https://schema.org/episodeNumber-output",
     "Domain Bucket":"< 1K"
   },
   {
     "Class":"Predicate",
-    "Name":"http:\/\/schema.org\/episodes",
+    "Name":"https://schema.org/episodes",
     "Domain Bucket":"< 1K"
   },
   {
     "Class":"Predicate",
-    "Name":"http:\/\/schema.org\/episodes-input",
+    "Name":"https://schema.org/episodes-input",
     "Domain Bucket":"< 1K"
   },
   {
     "Class":"Predicate",
-    "Name":"http:\/\/schema.org\/episodes-output",
+    "Name":"https://schema.org/episodes-output",
     "Domain Bucket":"< 1K"
   },
   {
     "Class":"Predicate",
-    "Name":"http:\/\/schema.org\/equal",
+    "Name":"https://schema.org/equal",
     "Domain Bucket":"< 1K"
   },
   {
     "Class":"Predicate",
-    "Name":"http:\/\/schema.org\/equal-input",
+    "Name":"https://schema.org/equal-input",
     "Domain Bucket":"< 1K"
   },
   {
     "Class":"Predicate",
-    "Name":"http:\/\/schema.org\/equal-output",
+    "Name":"https://schema.org/equal-output",
     "Domain Bucket":"< 1K"
   },
   {
     "Class":"Predicate",
-    "Name":"http:\/\/schema.org\/error",
+    "Name":"https://schema.org/error",
     "Domain Bucket":"1K - 10K"
   },
   {
     "Class":"Predicate",
-    "Name":"http:\/\/schema.org\/error-input",
+    "Name":"https://schema.org/error-input",
     "Domain Bucket":"< 1K"
   },
   {
     "Class":"Predicate",
-    "Name":"http:\/\/schema.org\/error-output",
+    "Name":"https://schema.org/error-output",
     "Domain Bucket":"< 1K"
   },
   {
     "Class":"Predicate",
-    "Name":"http:\/\/schema.org\/errorCode",
+    "Name":"https://schema.org/errorCode",
     "Domain Bucket":"< 1K"
   },
   {
     "Class":"Predicate",
-    "Name":"http:\/\/schema.org\/errorCode-input",
+    "Name":"https://schema.org/errorCode-input",
     "Domain Bucket":"< 1K"
   },
   {
     "Class":"Predicate",
-    "Name":"http:\/\/schema.org\/errorCode-output",
+    "Name":"https://schema.org/errorCode-output",
     "Domain Bucket":"< 1K"
   },
   {
     "Class":"Predicate",
-    "Name":"http:\/\/schema.org\/estimatedCost",
+    "Name":"https://schema.org/estimatedCost",
     "Domain Bucket":"10K - 100K"
   },
   {
     "Class":"Predicate",
-    "Name":"http:\/\/schema.org\/estimatedCost-input",
+    "Name":"https://schema.org/estimatedCost-input",
     "Domain Bucket":"< 1K"
   },
   {
     "Class":"Predicate",
-    "Name":"http:\/\/schema.org\/estimatedCost-output",
+    "Name":"https://schema.org/estimatedCost-output",
     "Domain Bucket":"< 1K"
   },
   {
     "Class":"Predicate",
-    "Name":"http:\/\/schema.org\/estimatedFlightDuration",
+    "Name":"https://schema.org/estimatedFlightDuration",
     "Domain Bucket":"< 1K"
   },
   {
     "Class":"Predicate",
-    "Name":"http:\/\/schema.org\/estimatedFlightDuration-input",
+    "Name":"https://schema.org/estimatedFlightDuration-input",
     "Domain Bucket":"< 1K"
   },
   {
     "Class":"Predicate",
-    "Name":"http:\/\/schema.org\/estimatedFlightDuration-output",
+    "Name":"https://schema.org/estimatedFlightDuration-output",
     "Domain Bucket":"< 1K"
   },
   {
     "Class":"Predicate",
-    "Name":"http:\/\/schema.org\/estimatedSalary",
+    "Name":"https://schema.org/estimatedSalary",
     "Domain Bucket":"1K - 10K"
   },
   {
     "Class":"Predicate",
-    "Name":"http:\/\/schema.org\/estimatedSalary-input",
+    "Name":"https://schema.org/estimatedSalary-input",
     "Domain Bucket":"< 1K"
   },
   {
     "Class":"Predicate",
-    "Name":"http:\/\/schema.org\/estimatedSalary-output",
+    "Name":"https://schema.org/estimatedSalary-output",
     "Domain Bucket":"< 1K"
   },
   {
     "Class":"Predicate",
-    "Name":"http:\/\/schema.org\/estimatesRiskOf",
+    "Name":"https://schema.org/estimatesRiskOf",
     "Domain Bucket":"< 1K"
   },
   {
     "Class":"Predicate",
-    "Name":"http:\/\/schema.org\/estimatesRiskOf-input",
+    "Name":"https://schema.org/estimatesRiskOf-input",
     "Domain Bucket":"< 1K"
   },
   {
     "Class":"Predicate",
-    "Name":"http:\/\/schema.org\/estimatesRiskOf-output",
+    "Name":"https://schema.org/estimatesRiskOf-output",
     "Domain Bucket":"< 1K"
   },
   {
     "Class":"Predicate",
-    "Name":"http:\/\/schema.org\/ethicsPolicy",
+    "Name":"https://schema.org/ethicsPolicy",
     "Domain Bucket":"10K - 100K"
   },
   {
     "Class":"Predicate",
-    "Name":"http:\/\/schema.org\/ethicsPolicy-input",
+    "Name":"https://schema.org/ethicsPolicy-input",
     "Domain Bucket":"< 1K"
   },
   {
     "Class":"Predicate",
-    "Name":"http:\/\/schema.org\/ethicsPolicy-output",
+    "Name":"https://schema.org/ethicsPolicy-output",
     "Domain Bucket":"< 1K"
   },
   {
     "Class":"Predicate",
-    "Name":"http:\/\/schema.org\/event",
+    "Name":"https://schema.org/event",
     "Domain Bucket":"10K - 100K"
   },
   {
     "Class":"Predicate",
-    "Name":"http:\/\/schema.org\/event-input",
+    "Name":"https://schema.org/event-input",
     "Domain Bucket":"< 1K"
   },
   {
     "Class":"Predicate",
-    "Name":"http:\/\/schema.org\/event-output",
+    "Name":"https://schema.org/event-output",
     "Domain Bucket":"< 1K"
   },
   {
     "Class":"Predicate",
-    "Name":"http:\/\/schema.org\/eventAttendanceMode",
+    "Name":"https://schema.org/eventAttendanceMode",
     "Domain Bucket":"100K - 1M"
   },
   {
     "Class":"Predicate",
-    "Name":"http:\/\/schema.org\/eventAttendanceMode-input",
+    "Name":"https://schema.org/eventAttendanceMode-input",
     "Domain Bucket":"< 1K"
   },
   {
     "Class":"Predicate",
-    "Name":"http:\/\/schema.org\/eventAttendanceMode-output",
+    "Name":"https://schema.org/eventAttendanceMode-output",
     "Domain Bucket":"< 1K"
   },
   {
     "Class":"Predicate",
-    "Name":"http:\/\/schema.org\/eventSchedule",
+    "Name":"https://schema.org/eventSchedule",
     "Domain Bucket":"1K - 10K"
   },
   {
     "Class":"Predicate",
-    "Name":"http:\/\/schema.org\/eventSchedule-input",
+    "Name":"https://schema.org/eventSchedule-input",
     "Domain Bucket":"< 1K"
   },
   {
     "Class":"Predicate",
-    "Name":"http:\/\/schema.org\/eventSchedule-output",
+    "Name":"https://schema.org/eventSchedule-output",
     "Domain Bucket":"< 1K"
   },
   {
     "Class":"Predicate",
-    "Name":"http:\/\/schema.org\/eventStatus",
+    "Name":"https://schema.org/eventStatus",
     "Domain Bucket":"100K - 1M"
   },
   {
     "Class":"Predicate",
-    "Name":"http:\/\/schema.org\/eventStatus-input",
+    "Name":"https://schema.org/eventStatus-input",
     "Domain Bucket":"< 1K"
   },
   {
     "Class":"Predicate",
-    "Name":"http:\/\/schema.org\/eventStatus-output",
+    "Name":"https://schema.org/eventStatus-output",
     "Domain Bucket":"< 1K"
   },
   {
     "Class":"Predicate",
-    "Name":"http:\/\/schema.org\/events",
+    "Name":"https://schema.org/events",
     "Domain Bucket":"1K - 10K"
   },
   {
     "Class":"Predicate",
-    "Name":"http:\/\/schema.org\/events-input",
+    "Name":"https://schema.org/events-input",
     "Domain Bucket":"< 1K"
   },
   {
     "Class":"Predicate",
-    "Name":"http:\/\/schema.org\/events-output",
+    "Name":"https://schema.org/events-output",
     "Domain Bucket":"< 1K"
   },
   {
     "Class":"Predicate",
-    "Name":"http:\/\/schema.org\/evidenceLevel",
+    "Name":"https://schema.org/evidenceLevel",
     "Domain Bucket":"< 1K"
   },
   {
     "Class":"Predicate",
-    "Name":"http:\/\/schema.org\/evidenceLevel-input",
+    "Name":"https://schema.org/evidenceLevel-input",
     "Domain Bucket":"< 1K"
   },
   {
     "Class":"Predicate",
-    "Name":"http:\/\/schema.org\/evidenceLevel-output",
+    "Name":"https://schema.org/evidenceLevel-output",
     "Domain Bucket":"< 1K"
   },
   {
     "Class":"Predicate",
-    "Name":"http:\/\/schema.org\/evidenceOrigin",
+    "Name":"https://schema.org/evidenceOrigin",
     "Domain Bucket":"< 1K"
   },
   {
     "Class":"Predicate",
-    "Name":"http:\/\/schema.org\/evidenceOrigin-input",
+    "Name":"https://schema.org/evidenceOrigin-input",
     "Domain Bucket":"< 1K"
   },
   {
     "Class":"Predicate",
-    "Name":"http:\/\/schema.org\/evidenceOrigin-output",
+    "Name":"https://schema.org/evidenceOrigin-output",
     "Domain Bucket":"< 1K"
   },
   {
     "Class":"Predicate",
-    "Name":"http:\/\/schema.org\/exampleOfWork",
+    "Name":"https://schema.org/exampleOfWork",
     "Domain Bucket":"1K - 10K"
   },
   {
     "Class":"Predicate",
-    "Name":"http:\/\/schema.org\/exampleOfWork-input",
+    "Name":"https://schema.org/exampleOfWork-input",
     "Domain Bucket":"< 1K"
   },
   {
     "Class":"Predicate",
-    "Name":"http:\/\/schema.org\/exampleOfWork-output",
+    "Name":"https://schema.org/exampleOfWork-output",
     "Domain Bucket":"< 1K"
   },
   {
     "Class":"Predicate",
-    "Name":"http:\/\/schema.org\/exceptDate",
+    "Name":"https://schema.org/exceptDate",
     "Domain Bucket":"< 1K"
   },
   {
     "Class":"Predicate",
-    "Name":"http:\/\/schema.org\/exceptDate-input",
+    "Name":"https://schema.org/exceptDate-input",
     "Domain Bucket":"< 1K"
   },
   {
     "Class":"Predicate",
-    "Name":"http:\/\/schema.org\/exceptDate-output",
+    "Name":"https://schema.org/exceptDate-output",
     "Domain Bucket":"< 1K"
   },
   {
     "Class":"Predicate",
-    "Name":"http:\/\/schema.org\/exchangeRateSpread",
+    "Name":"https://schema.org/exchangeRateSpread",
     "Domain Bucket":"< 1K"
   },
   {
     "Class":"Predicate",
-    "Name":"http:\/\/schema.org\/exchangeRateSpread-input",
+    "Name":"https://schema.org/exchangeRateSpread-input",
     "Domain Bucket":"< 1K"
   },
   {
     "Class":"Predicate",
-    "Name":"http:\/\/schema.org\/exchangeRateSpread-output",
+    "Name":"https://schema.org/exchangeRateSpread-output",
     "Domain Bucket":"< 1K"
   },
   {
     "Class":"Predicate",
-    "Name":"http:\/\/schema.org\/executableLibraryName",
+    "Name":"https://schema.org/executableLibraryName",
     "Domain Bucket":"< 1K"
   },
   {
     "Class":"Predicate",
-    "Name":"http:\/\/schema.org\/executableLibraryName-input",
+    "Name":"https://schema.org/executableLibraryName-input",
     "Domain Bucket":"< 1K"
   },
   {
     "Class":"Predicate",
-    "Name":"http:\/\/schema.org\/executableLibraryName-output",
+    "Name":"https://schema.org/executableLibraryName-output",
     "Domain Bucket":"< 1K"
   },
   {
     "Class":"Predicate",
-    "Name":"http:\/\/schema.org\/exerciseCourse",
+    "Name":"https://schema.org/exerciseCourse",
     "Domain Bucket":"< 1K"
   },
   {
     "Class":"Predicate",
-    "Name":"http:\/\/schema.org\/exerciseCourse-input",
+    "Name":"https://schema.org/exerciseCourse-input",
     "Domain Bucket":"< 1K"
   },
   {
     "Class":"Predicate",
-    "Name":"http:\/\/schema.org\/exerciseCourse-output",
+    "Name":"https://schema.org/exerciseCourse-output",
     "Domain Bucket":"< 1K"
   },
   {
     "Class":"Predicate",
-    "Name":"http:\/\/schema.org\/exercisePlan",
+    "Name":"https://schema.org/exercisePlan",
     "Domain Bucket":"< 1K"
   },
   {
     "Class":"Predicate",
-    "Name":"http:\/\/schema.org\/exercisePlan-input",
+    "Name":"https://schema.org/exercisePlan-input",
     "Domain Bucket":"< 1K"
   },
   {
     "Class":"Predicate",
-    "Name":"http:\/\/schema.org\/exercisePlan-output",
+    "Name":"https://schema.org/exercisePlan-output",
     "Domain Bucket":"< 1K"
   },
   {
     "Class":"Predicate",
-    "Name":"http:\/\/schema.org\/exerciseRelatedDiet",
+    "Name":"https://schema.org/exerciseRelatedDiet",
     "Domain Bucket":"< 1K"
   },
   {
     "Class":"Predicate",
-    "Name":"http:\/\/schema.org\/exerciseRelatedDiet-input",
+    "Name":"https://schema.org/exerciseRelatedDiet-input",
     "Domain Bucket":"< 1K"
   },
   {
     "Class":"Predicate",
-    "Name":"http:\/\/schema.org\/exerciseRelatedDiet-output",
+    "Name":"https://schema.org/exerciseRelatedDiet-output",
     "Domain Bucket":"< 1K"
   },
   {
     "Class":"Predicate",
-    "Name":"http:\/\/schema.org\/exerciseType",
+    "Name":"https://schema.org/exerciseType",
     "Domain Bucket":"< 1K"
   },
   {
     "Class":"Predicate",
-    "Name":"http:\/\/schema.org\/exerciseType-input",
+    "Name":"https://schema.org/exerciseType-input",
     "Domain Bucket":"< 1K"
   },
   {
     "Class":"Predicate",
-    "Name":"http:\/\/schema.org\/exerciseType-output",
+    "Name":"https://schema.org/exerciseType-output",
     "Domain Bucket":"< 1K"
   },
   {
     "Class":"Predicate",
-    "Name":"http:\/\/schema.org\/exifData",
+    "Name":"https://schema.org/exifData",
     "Domain Bucket":"1K - 10K"
   },
   {
     "Class":"Predicate",
-    "Name":"http:\/\/schema.org\/exifData-input",
+    "Name":"https://schema.org/exifData-input",
     "Domain Bucket":"< 1K"
   },
   {
     "Class":"Predicate",
-    "Name":"http:\/\/schema.org\/exifData-output",
+    "Name":"https://schema.org/exifData-output",
     "Domain Bucket":"< 1K"
   },
   {
     "Class":"Predicate",
-    "Name":"http:\/\/schema.org\/expectedArrivalFrom",
+    "Name":"https://schema.org/expectedArrivalFrom",
     "Domain Bucket":"< 1K"
   },
   {
     "Class":"Predicate",
-    "Name":"http:\/\/schema.org\/expectedArrivalFrom-input",
+    "Name":"https://schema.org/expectedArrivalFrom-input",
     "Domain Bucket":"< 1K"
   },
   {
     "Class":"Predicate",
-    "Name":"http:\/\/schema.org\/expectedArrivalFrom-output",
+    "Name":"https://schema.org/expectedArrivalFrom-output",
     "Domain Bucket":"< 1K"
   },
   {
     "Class":"Predicate",
-    "Name":"http:\/\/schema.org\/expectedArrivalUntil",
+    "Name":"https://schema.org/expectedArrivalUntil",
     "Domain Bucket":"< 1K"
   },
   {
     "Class":"Predicate",
-    "Name":"http:\/\/schema.org\/expectedArrivalUntil-input",
+    "Name":"https://schema.org/expectedArrivalUntil-input",
     "Domain Bucket":"< 1K"
   },
   {
     "Class":"Predicate",
-    "Name":"http:\/\/schema.org\/expectedArrivalUntil-output",
+    "Name":"https://schema.org/expectedArrivalUntil-output",
     "Domain Bucket":"< 1K"
   },
   {
     "Class":"Predicate",
-    "Name":"http:\/\/schema.org\/expectedPrognosis",
+    "Name":"https://schema.org/expectedPrognosis",
     "Domain Bucket":"< 1K"
   },
   {
     "Class":"Predicate",
-    "Name":"http:\/\/schema.org\/expectedPrognosis-input",
+    "Name":"https://schema.org/expectedPrognosis-input",
     "Domain Bucket":"< 1K"
   },
   {
     "Class":"Predicate",
-    "Name":"http:\/\/schema.org\/expectedPrognosis-output",
+    "Name":"https://schema.org/expectedPrognosis-output",
     "Domain Bucket":"< 1K"
   },
   {
     "Class":"Predicate",
-    "Name":"http:\/\/schema.org\/expectsAcceptanceOf",
+    "Name":"https://schema.org/expectsAcceptanceOf",
     "Domain Bucket":"1K - 10K"
   },
   {
     "Class":"Predicate",
-    "Name":"http:\/\/schema.org\/expectsAcceptanceOf-input",
+    "Name":"https://schema.org/expectsAcceptanceOf-input",
     "Domain Bucket":"< 1K"
   },
   {
     "Class":"Predicate",
-    "Name":"http:\/\/schema.org\/expectsAcceptanceOf-output",
+    "Name":"https://schema.org/expectsAcceptanceOf-output",
     "Domain Bucket":"< 1K"
   },
   {
     "Class":"Predicate",
-    "Name":"http:\/\/schema.org\/experienceInPlaceOfEducation",
+    "Name":"https://schema.org/experienceInPlaceOfEducation",
     "Domain Bucket":"1K - 10K"
   },
   {
     "Class":"Predicate",
-    "Name":"http:\/\/schema.org\/experienceInPlaceOfEducation-input",
+    "Name":"https://schema.org/experienceInPlaceOfEducation-input",
     "Domain Bucket":"< 1K"
   },
   {
     "Class":"Predicate",
-    "Name":"http:\/\/schema.org\/experienceInPlaceOfEducation-output",
+    "Name":"https://schema.org/experienceInPlaceOfEducation-output",
     "Domain Bucket":"< 1K"
   },
   {
     "Class":"Predicate",
-    "Name":"http:\/\/schema.org\/experienceRequirements",
+    "Name":"https://schema.org/experienceRequirements",
     "Domain Bucket":"10K - 100K"
   },
   {
     "Class":"Predicate",
-    "Name":"http:\/\/schema.org\/experienceRequirements-input",
+    "Name":"https://schema.org/experienceRequirements-input",
     "Domain Bucket":"< 1K"
   },
   {
     "Class":"Predicate",
-    "Name":"http:\/\/schema.org\/experienceRequirements-output",
+    "Name":"https://schema.org/experienceRequirements-output",
     "Domain Bucket":"< 1K"
   },
   {
     "Class":"Predicate",
-    "Name":"http:\/\/schema.org\/expertConsiderations",
+    "Name":"https://schema.org/expertConsiderations",
     "Domain Bucket":"< 1K"
   },
   {
     "Class":"Predicate",
-    "Name":"http:\/\/schema.org\/expertConsiderations-input",
+    "Name":"https://schema.org/expertConsiderations-input",
     "Domain Bucket":"< 1K"
   },
   {
     "Class":"Predicate",
-    "Name":"http:\/\/schema.org\/expertConsiderations-output",
+    "Name":"https://schema.org/expertConsiderations-output",
     "Domain Bucket":"< 1K"
   },
   {
     "Class":"Predicate",
-    "Name":"http:\/\/schema.org\/expires",
+    "Name":"https://schema.org/expires",
     "Domain Bucket":"1K - 10K"
   },
   {
     "Class":"Predicate",
-    "Name":"http:\/\/schema.org\/expires-input",
+    "Name":"https://schema.org/expires-input",
     "Domain Bucket":"< 1K"
   },
   {
     "Class":"Predicate",
-    "Name":"http:\/\/schema.org\/expires-output",
+    "Name":"https://schema.org/expires-output",
     "Domain Bucket":"< 1K"
   },
   {
     "Class":"Predicate",
-    "Name":"http:\/\/schema.org\/expressedIn",
+    "Name":"https://schema.org/expressedIn",
     "Domain Bucket":"< 1K"
   },
   {
     "Class":"Predicate",
-    "Name":"http:\/\/schema.org\/expressedIn-input",
+    "Name":"https://schema.org/expressedIn-input",
     "Domain Bucket":"< 1K"
   },
   {
     "Class":"Predicate",
-    "Name":"http:\/\/schema.org\/expressedIn-output",
+    "Name":"https://schema.org/expressedIn-output",
     "Domain Bucket":"< 1K"
   },
   {
     "Class":"Predicate",
-    "Name":"http:\/\/schema.org\/extendedAddress",
+    "Name":"https://schema.org/extendedAddress",
     "Domain Bucket":"< 1K"
   },
   {
     "Class":"Predicate",
-    "Name":"http:\/\/schema.org\/extendedAddress-input",
+    "Name":"https://schema.org/extendedAddress-input",
     "Domain Bucket":"< 1K"
   },
   {
     "Class":"Predicate",
-    "Name":"http:\/\/schema.org\/extendedAddress-output",
+    "Name":"https://schema.org/extendedAddress-output",
     "Domain Bucket":"< 1K"
   },
   {
     "Class":"Predicate",
-    "Name":"http:\/\/schema.org\/familyName",
+    "Name":"https://schema.org/familyName",
     "Domain Bucket":"100K - 1M"
   },
   {
     "Class":"Predicate",
-    "Name":"http:\/\/schema.org\/familyName-input",
+    "Name":"https://schema.org/familyName-input",
     "Domain Bucket":"< 1K"
   },
   {
     "Class":"Predicate",
-    "Name":"http:\/\/schema.org\/familyName-output",
+    "Name":"https://schema.org/familyName-output",
     "Domain Bucket":"< 1K"
   },
   {
     "Class":"Predicate",
-    "Name":"http:\/\/schema.org\/fatContent",
+    "Name":"https://schema.org/fatContent",
     "Domain Bucket":"10K - 100K"
   },
   {
     "Class":"Predicate",
-    "Name":"http:\/\/schema.org\/fatContent-input",
+    "Name":"https://schema.org/fatContent-input",
     "Domain Bucket":"< 1K"
   },
   {
     "Class":"Predicate",
-    "Name":"http:\/\/schema.org\/fatContent-output",
+    "Name":"https://schema.org/fatContent-output",
     "Domain Bucket":"< 1K"
   },
   {
     "Class":"Predicate",
-    "Name":"http:\/\/schema.org\/faxNumber",
+    "Name":"https://schema.org/faxNumber",
     "Domain Bucket":"100K - 1M"
   },
   {
     "Class":"Predicate",
-    "Name":"http:\/\/schema.org\/faxNumber-input",
+    "Name":"https://schema.org/faxNumber-input",
     "Domain Bucket":"< 1K"
   },
   {
     "Class":"Predicate",
-    "Name":"http:\/\/schema.org\/faxNumber-output",
+    "Name":"https://schema.org/faxNumber-output",
     "Domain Bucket":"< 1K"
   },
   {
     "Class":"Predicate",
-    "Name":"http:\/\/schema.org\/featureList",
+    "Name":"https://schema.org/featureList",
     "Domain Bucket":"100K - 1M"
   },
   {
     "Class":"Predicate",
-    "Name":"http:\/\/schema.org\/featureList-input",
+    "Name":"https://schema.org/featureList-input",
     "Domain Bucket":"< 1K"
   },
   {
     "Class":"Predicate",
-    "Name":"http:\/\/schema.org\/featureList-output",
+    "Name":"https://schema.org/featureList-output",
     "Domain Bucket":"< 1K"
   },
   {
     "Class":"Predicate",
-    "Name":"http:\/\/schema.org\/feesAndCommissionsSpecification",
+    "Name":"https://schema.org/feesAndCommissionsSpecification",
     "Domain Bucket":"1K - 10K"
   },
   {
     "Class":"Predicate",
-    "Name":"http:\/\/schema.org\/feesAndCommissionsSpecification-input",
+    "Name":"https://schema.org/feesAndCommissionsSpecification-input",
     "Domain Bucket":"< 1K"
   },
   {
     "Class":"Predicate",
-    "Name":"http:\/\/schema.org\/feesAndCommissionsSpecification-output",
+    "Name":"https://schema.org/feesAndCommissionsSpecification-output",
     "Domain Bucket":"< 1K"
   },
   {
     "Class":"Predicate",
-    "Name":"http:\/\/schema.org\/fiberContent",
+    "Name":"https://schema.org/fiberContent",
     "Domain Bucket":"10K - 100K"
   },
   {
     "Class":"Predicate",
-    "Name":"http:\/\/schema.org\/fiberContent-input",
+    "Name":"https://schema.org/fiberContent-input",
     "Domain Bucket":"< 1K"
   },
   {
     "Class":"Predicate",
-    "Name":"http:\/\/schema.org\/fiberContent-output",
+    "Name":"https://schema.org/fiberContent-output",
     "Domain Bucket":"< 1K"
   },
   {
     "Class":"Predicate",
-    "Name":"http:\/\/schema.org\/fileFormat",
+    "Name":"https://schema.org/fileFormat",
     "Domain Bucket":"10K - 100K"
   },
   {
     "Class":"Predicate",
-    "Name":"http:\/\/schema.org\/fileFormat-input",
+    "Name":"https://schema.org/fileFormat-input",
     "Domain Bucket":"< 1K"
   },
   {
     "Class":"Predicate",
-    "Name":"http:\/\/schema.org\/fileFormat-output",
+    "Name":"https://schema.org/fileFormat-output",
     "Domain Bucket":"< 1K"
   },
   {
     "Class":"Predicate",
-    "Name":"http:\/\/schema.org\/fileSize",
+    "Name":"https://schema.org/fileSize",
     "Domain Bucket":"10K - 100K"
   },
   {
     "Class":"Predicate",
-    "Name":"http:\/\/schema.org\/fileSize-input",
+    "Name":"https://schema.org/fileSize-input",
     "Domain Bucket":"< 1K"
   },
   {
     "Class":"Predicate",
-    "Name":"http:\/\/schema.org\/fileSize-output",
+    "Name":"https://schema.org/fileSize-output",
     "Domain Bucket":"< 1K"
   },
   {
     "Class":"Predicate",
-    "Name":"http:\/\/schema.org\/financialAidEligible",
+    "Name":"https://schema.org/financialAidEligible",
     "Domain Bucket":"< 1K"
   },
   {
     "Class":"Predicate",
-    "Name":"http:\/\/schema.org\/financialAidEligible-input",
+    "Name":"https://schema.org/financialAidEligible-input",
     "Domain Bucket":"< 1K"
   },
   {
     "Class":"Predicate",
-    "Name":"http:\/\/schema.org\/financialAidEligible-output",
+    "Name":"https://schema.org/financialAidEligible-output",
     "Domain Bucket":"< 1K"
   },
   {
     "Class":"Predicate",
-    "Name":"http:\/\/schema.org\/firstAppearance",
+    "Name":"https://schema.org/firstAppearance",
     "Domain Bucket":"< 1K"
   },
   {
     "Class":"Predicate",
-    "Name":"http:\/\/schema.org\/firstAppearance-input",
+    "Name":"https://schema.org/firstAppearance-input",
     "Domain Bucket":"< 1K"
   },
   {
     "Class":"Predicate",
-    "Name":"http:\/\/schema.org\/firstAppearance-output",
+    "Name":"https://schema.org/firstAppearance-output",
     "Domain Bucket":"< 1K"
   },
   {
     "Class":"Predicate",
-    "Name":"http:\/\/schema.org\/firstPerformance",
+    "Name":"https://schema.org/firstPerformance",
     "Domain Bucket":"< 1K"
   },
   {
     "Class":"Predicate",
-    "Name":"http:\/\/schema.org\/firstPerformance-input",
+    "Name":"https://schema.org/firstPerformance-input",
     "Domain Bucket":"< 1K"
   },
   {
     "Class":"Predicate",
-    "Name":"http:\/\/schema.org\/firstPerformance-output",
+    "Name":"https://schema.org/firstPerformance-output",
     "Domain Bucket":"< 1K"
   },
   {
     "Class":"Predicate",
-    "Name":"http:\/\/schema.org\/flightDistance",
+    "Name":"https://schema.org/flightDistance",
     "Domain Bucket":"< 1K"
   },
   {
     "Class":"Predicate",
-    "Name":"http:\/\/schema.org\/flightDistance-input",
+    "Name":"https://schema.org/flightDistance-input",
     "Domain Bucket":"< 1K"
   },
   {
     "Class":"Predicate",
-    "Name":"http:\/\/schema.org\/flightDistance-output",
+    "Name":"https://schema.org/flightDistance-output",
     "Domain Bucket":"< 1K"
   },
   {
     "Class":"Predicate",
-    "Name":"http:\/\/schema.org\/flightNumber",
+    "Name":"https://schema.org/flightNumber",
     "Domain Bucket":"< 1K"
   },
   {
     "Class":"Predicate",
-    "Name":"http:\/\/schema.org\/flightNumber-input",
+    "Name":"https://schema.org/flightNumber-input",
     "Domain Bucket":"< 1K"
   },
   {
     "Class":"Predicate",
-    "Name":"http:\/\/schema.org\/flightNumber-output",
+    "Name":"https://schema.org/flightNumber-output",
     "Domain Bucket":"< 1K"
   },
   {
     "Class":"Predicate",
-    "Name":"http:\/\/schema.org\/floorLevel",
+    "Name":"https://schema.org/floorLevel",
     "Domain Bucket":"1K - 10K"
   },
   {
     "Class":"Predicate",
-    "Name":"http:\/\/schema.org\/floorLevel-input",
+    "Name":"https://schema.org/floorLevel-input",
     "Domain Bucket":"< 1K"
   },
   {
     "Class":"Predicate",
-    "Name":"http:\/\/schema.org\/floorLevel-output",
+    "Name":"https://schema.org/floorLevel-output",
     "Domain Bucket":"< 1K"
   },
   {
     "Class":"Predicate",
-    "Name":"http:\/\/schema.org\/floorLimit",
+    "Name":"https://schema.org/floorLimit",
     "Domain Bucket":"< 1K"
   },
   {
     "Class":"Predicate",
-    "Name":"http:\/\/schema.org\/floorLimit-input",
+    "Name":"https://schema.org/floorLimit-input",
     "Domain Bucket":"< 1K"
   },
   {
     "Class":"Predicate",
-    "Name":"http:\/\/schema.org\/floorLimit-output",
+    "Name":"https://schema.org/floorLimit-output",
     "Domain Bucket":"< 1K"
   },
   {
     "Class":"Predicate",
-    "Name":"http:\/\/schema.org\/floorSize",
+    "Name":"https://schema.org/floorSize",
     "Domain Bucket":"100K - 1M"
   },
   {
     "Class":"Predicate",
-    "Name":"http:\/\/schema.org\/floorSize-input",
+    "Name":"https://schema.org/floorSize-input",
     "Domain Bucket":"< 1K"
   },
   {
     "Class":"Predicate",
-    "Name":"http:\/\/schema.org\/floorSize-output",
+    "Name":"https://schema.org/floorSize-output",
     "Domain Bucket":"< 1K"
   },
   {
     "Class":"Predicate",
-    "Name":"http:\/\/schema.org\/followee",
+    "Name":"https://schema.org/followee",
     "Domain Bucket":"< 1K"
   },
   {
     "Class":"Predicate",
-    "Name":"http:\/\/schema.org\/followee-input",
+    "Name":"https://schema.org/followee-input",
     "Domain Bucket":"< 1K"
   },
   {
     "Class":"Predicate",
-    "Name":"http:\/\/schema.org\/followee-output",
+    "Name":"https://schema.org/followee-output",
     "Domain Bucket":"< 1K"
   },
   {
     "Class":"Predicate",
-    "Name":"http:\/\/schema.org\/follows",
+    "Name":"https://schema.org/follows",
     "Domain Bucket":"< 1K"
   },
   {
     "Class":"Predicate",
-    "Name":"http:\/\/schema.org\/follows-input",
+    "Name":"https://schema.org/follows-input",
     "Domain Bucket":"< 1K"
   },
   {
     "Class":"Predicate",
-    "Name":"http:\/\/schema.org\/follows-output",
+    "Name":"https://schema.org/follows-output",
     "Domain Bucket":"< 1K"
   },
   {
     "Class":"Predicate",
-    "Name":"http:\/\/schema.org\/followup",
+    "Name":"https://schema.org/followup",
     "Domain Bucket":"1K - 10K"
   },
   {
     "Class":"Predicate",
-    "Name":"http:\/\/schema.org\/followup-input",
+    "Name":"https://schema.org/followup-input",
     "Domain Bucket":"< 1K"
   },
   {
     "Class":"Predicate",
-    "Name":"http:\/\/schema.org\/followup-output",
+    "Name":"https://schema.org/followup-output",
     "Domain Bucket":"< 1K"
   },
   {
     "Class":"Predicate",
-    "Name":"http:\/\/schema.org\/foodEstablishment",
+    "Name":"https://schema.org/foodEstablishment",
     "Domain Bucket":"< 1K"
   },
   {
     "Class":"Predicate",
-    "Name":"http:\/\/schema.org\/foodEstablishment-input",
+    "Name":"https://schema.org/foodEstablishment-input",
     "Domain Bucket":"< 1K"
   },
   {
     "Class":"Predicate",
-    "Name":"http:\/\/schema.org\/foodEstablishment-output",
+    "Name":"https://schema.org/foodEstablishment-output",
     "Domain Bucket":"< 1K"
   },
   {
     "Class":"Predicate",
-    "Name":"http:\/\/schema.org\/foodEvent",
+    "Name":"https://schema.org/foodEvent",
     "Domain Bucket":"< 1K"
   },
   {
     "Class":"Predicate",
-    "Name":"http:\/\/schema.org\/foodEvent-input",
+    "Name":"https://schema.org/foodEvent-input",
     "Domain Bucket":"< 1K"
   },
   {
     "Class":"Predicate",
-    "Name":"http:\/\/schema.org\/foodEvent-output",
+    "Name":"https://schema.org/foodEvent-output",
     "Domain Bucket":"< 1K"
   },
   {
     "Class":"Predicate",
-    "Name":"http:\/\/schema.org\/foodWarning",
+    "Name":"https://schema.org/foodWarning",
     "Domain Bucket":"< 1K"
   },
   {
     "Class":"Predicate",
-    "Name":"http:\/\/schema.org\/foodWarning-input",
+    "Name":"https://schema.org/foodWarning-input",
     "Domain Bucket":"< 1K"
   },
   {
     "Class":"Predicate",
-    "Name":"http:\/\/schema.org\/foodWarning-output",
+    "Name":"https://schema.org/foodWarning-output",
     "Domain Bucket":"< 1K"
   },
   {
     "Class":"Predicate",
-    "Name":"http:\/\/schema.org\/founder",
+    "Name":"https://schema.org/founder",
     "Domain Bucket":"100K - 1M"
   },
   {
     "Class":"Predicate",
-    "Name":"http:\/\/schema.org\/founder-input",
+    "Name":"https://schema.org/founder-input",
     "Domain Bucket":"< 1K"
   },
   {
     "Class":"Predicate",
-    "Name":"http:\/\/schema.org\/founder-output",
+    "Name":"https://schema.org/founder-output",
     "Domain Bucket":"< 1K"
   },
   {
     "Class":"Predicate",
-    "Name":"http:\/\/schema.org\/founders",
+    "Name":"https://schema.org/founders",
     "Domain Bucket":"10K - 100K"
   },
   {
     "Class":"Predicate",
-    "Name":"http:\/\/schema.org\/founders-input",
+    "Name":"https://schema.org/founders-input",
     "Domain Bucket":"< 1K"
   },
   {
     "Class":"Predicate",
-    "Name":"http:\/\/schema.org\/founders-output",
+    "Name":"https://schema.org/founders-output",
     "Domain Bucket":"< 1K"
   },
   {
     "Class":"Predicate",
-    "Name":"http:\/\/schema.org\/foundingDate",
+    "Name":"https://schema.org/foundingDate",
     "Domain Bucket":"1M - 10M"
   },
   {
     "Class":"Predicate",
-    "Name":"http:\/\/schema.org\/foundingDate-input",
+    "Name":"https://schema.org/foundingDate-input",
     "Domain Bucket":"< 1K"
   },
   {
     "Class":"Predicate",
-    "Name":"http:\/\/schema.org\/foundingDate-output",
+    "Name":"https://schema.org/foundingDate-output",
     "Domain Bucket":"< 1K"
   },
   {
     "Class":"Predicate",
-    "Name":"http:\/\/schema.org\/foundingLocation",
+    "Name":"https://schema.org/foundingLocation",
     "Domain Bucket":"100K - 1M"
   },
   {
     "Class":"Predicate",
-    "Name":"http:\/\/schema.org\/foundingLocation-input",
+    "Name":"https://schema.org/foundingLocation-input",
     "Domain Bucket":"< 1K"
   },
   {
     "Class":"Predicate",
-    "Name":"http:\/\/schema.org\/foundingLocation-output",
+    "Name":"https://schema.org/foundingLocation-output",
     "Domain Bucket":"< 1K"
   },
   {
     "Class":"Predicate",
-    "Name":"http:\/\/schema.org\/free",
+    "Name":"https://schema.org/free",
     "Domain Bucket":"1K - 10K"
   },
   {
     "Class":"Predicate",
-    "Name":"http:\/\/schema.org\/free-input",
+    "Name":"https://schema.org/free-input",
     "Domain Bucket":"< 1K"
   },
   {
     "Class":"Predicate",
-    "Name":"http:\/\/schema.org\/free-output",
+    "Name":"https://schema.org/free-output",
     "Domain Bucket":"< 1K"
   },
   {
     "Class":"Predicate",
-    "Name":"http:\/\/schema.org\/freeShippingThreshold",
+    "Name":"https://schema.org/freeShippingThreshold",
     "Domain Bucket":"10K - 100K"
   },
   {
     "Class":"Predicate",
-    "Name":"http:\/\/schema.org\/freeShippingThreshold-input",
+    "Name":"https://schema.org/freeShippingThreshold-input",
     "Domain Bucket":"< 1K"
   },
   {
     "Class":"Predicate",
-    "Name":"http:\/\/schema.org\/freeShippingThreshold-output",
+    "Name":"https://schema.org/freeShippingThreshold-output",
     "Domain Bucket":"< 1K"
   },
   {
     "Class":"Predicate",
-    "Name":"http:\/\/schema.org\/frequency",
+    "Name":"https://schema.org/frequency",
     "Domain Bucket":"< 1K"
   },
   {
     "Class":"Predicate",
-    "Name":"http:\/\/schema.org\/frequency-input",
+    "Name":"https://schema.org/frequency-input",
     "Domain Bucket":"< 1K"
   },
   {
     "Class":"Predicate",
-    "Name":"http:\/\/schema.org\/frequency-output",
+    "Name":"https://schema.org/frequency-output",
     "Domain Bucket":"< 1K"
   },
   {
     "Class":"Predicate",
-    "Name":"http:\/\/schema.org\/fromLocation",
+    "Name":"https://schema.org/fromLocation",
     "Domain Bucket":"1K - 10K"
   },
   {
     "Class":"Predicate",
-    "Name":"http:\/\/schema.org\/fromLocation-input",
+    "Name":"https://schema.org/fromLocation-input",
     "Domain Bucket":"< 1K"
   },
   {
     "Class":"Predicate",
-    "Name":"http:\/\/schema.org\/fromLocation-output",
+    "Name":"https://schema.org/fromLocation-output",
     "Domain Bucket":"< 1K"
   },
   {
     "Class":"Predicate",
-    "Name":"http:\/\/schema.org\/fuelCapacity",
+    "Name":"https://schema.org/fuelCapacity",
     "Domain Bucket":"1K - 10K"
   },
   {
     "Class":"Predicate",
-    "Name":"http:\/\/schema.org\/fuelCapacity-input",
+    "Name":"https://schema.org/fuelCapacity-input",
     "Domain Bucket":"< 1K"
   },
   {
     "Class":"Predicate",
-    "Name":"http:\/\/schema.org\/fuelCapacity-output",
+    "Name":"https://schema.org/fuelCapacity-output",
     "Domain Bucket":"< 1K"
   },
   {
     "Class":"Predicate",
-    "Name":"http:\/\/schema.org\/fuelConsumption",
+    "Name":"https://schema.org/fuelConsumption",
     "Domain Bucket":"1K - 10K"
   },
   {
     "Class":"Predicate",
-    "Name":"http:\/\/schema.org\/fuelConsumption-input",
+    "Name":"https://schema.org/fuelConsumption-input",
     "Domain Bucket":"< 1K"
   },
   {
     "Class":"Predicate",
-    "Name":"http:\/\/schema.org\/fuelConsumption-output",
+    "Name":"https://schema.org/fuelConsumption-output",
     "Domain Bucket":"< 1K"
   },
   {
     "Class":"Predicate",
-    "Name":"http:\/\/schema.org\/fuelEfficiency",
+    "Name":"https://schema.org/fuelEfficiency",
     "Domain Bucket":"10K - 100K"
   },
   {
     "Class":"Predicate",
-    "Name":"http:\/\/schema.org\/fuelEfficiency-input",
+    "Name":"https://schema.org/fuelEfficiency-input",
     "Domain Bucket":"< 1K"
   },
   {
     "Class":"Predicate",
-    "Name":"http:\/\/schema.org\/fuelEfficiency-output",
+    "Name":"https://schema.org/fuelEfficiency-output",
     "Domain Bucket":"< 1K"
   },
   {
     "Class":"Predicate",
-    "Name":"http:\/\/schema.org\/fuelType",
+    "Name":"https://schema.org/fuelType",
     "Domain Bucket":"10K - 100K"
   },
   {
     "Class":"Predicate",
-    "Name":"http:\/\/schema.org\/fuelType-input",
+    "Name":"https://schema.org/fuelType-input",
     "Domain Bucket":"< 1K"
   },
   {
     "Class":"Predicate",
-    "Name":"http:\/\/schema.org\/fuelType-output",
+    "Name":"https://schema.org/fuelType-output",
     "Domain Bucket":"< 1K"
   },
   {
     "Class":"Predicate",
-    "Name":"http:\/\/schema.org\/fulfillmentType",
+    "Name":"https://schema.org/fulfillmentType",
     "Domain Bucket":"10K - 100K"
   },
   {
     "Class":"Predicate",
-    "Name":"http:\/\/schema.org\/fulfillmentType-input",
+    "Name":"https://schema.org/fulfillmentType-input",
     "Domain Bucket":"< 1K"
   },
   {
     "Class":"Predicate",
-    "Name":"http:\/\/schema.org\/fulfillmentType-output",
+    "Name":"https://schema.org/fulfillmentType-output",
     "Domain Bucket":"< 1K"
   },
   {
     "Class":"Predicate",
-    "Name":"http:\/\/schema.org\/functionalClass",
+    "Name":"https://schema.org/functionalClass",
     "Domain Bucket":"< 1K"
   },
   {
     "Class":"Predicate",
-    "Name":"http:\/\/schema.org\/functionalClass-input",
+    "Name":"https://schema.org/functionalClass-input",
     "Domain Bucket":"< 1K"
   },
   {
     "Class":"Predicate",
-    "Name":"http:\/\/schema.org\/functionalClass-output",
+    "Name":"https://schema.org/functionalClass-output",
     "Domain Bucket":"< 1K"
   },
   {
     "Class":"Predicate",
-    "Name":"http:\/\/schema.org\/fundedItem",
+    "Name":"https://schema.org/fundedItem",
     "Domain Bucket":"< 1K"
   },
   {
     "Class":"Predicate",
-    "Name":"http:\/\/schema.org\/fundedItem-input",
+    "Name":"https://schema.org/fundedItem-input",
     "Domain Bucket":"< 1K"
   },
   {
     "Class":"Predicate",
-    "Name":"http:\/\/schema.org\/fundedItem-output",
+    "Name":"https://schema.org/fundedItem-output",
     "Domain Bucket":"< 1K"
   },
   {
     "Class":"Predicate",
-    "Name":"http:\/\/schema.org\/funder",
+    "Name":"https://schema.org/funder",
     "Domain Bucket":"10K - 100K"
   },
   {
     "Class":"Predicate",
-    "Name":"http:\/\/schema.org\/funder-input",
+    "Name":"https://schema.org/funder-input",
     "Domain Bucket":"< 1K"
   },
   {
     "Class":"Predicate",
-    "Name":"http:\/\/schema.org\/funder-output",
+    "Name":"https://schema.org/funder-output",
     "Domain Bucket":"< 1K"
   },
   {
     "Class":"Predicate",
-    "Name":"http:\/\/schema.org\/funding",
+    "Name":"https://schema.org/funding",
     "Domain Bucket":"1K - 10K"
   },
   {
     "Class":"Predicate",
-    "Name":"http:\/\/schema.org\/funding-input",
+    "Name":"https://schema.org/funding-input",
     "Domain Bucket":"< 1K"
   },
   {
     "Class":"Predicate",
-    "Name":"http:\/\/schema.org\/funding-output",
+    "Name":"https://schema.org/funding-output",
     "Domain Bucket":"< 1K"
   },
   {
     "Class":"Predicate",
-    "Name":"http:\/\/schema.org\/game",
+    "Name":"https://schema.org/game",
     "Domain Bucket":"10K - 100K"
   },
   {
     "Class":"Predicate",
-    "Name":"http:\/\/schema.org\/game-input",
+    "Name":"https://schema.org/game-input",
     "Domain Bucket":"< 1K"
   },
   {
     "Class":"Predicate",
-    "Name":"http:\/\/schema.org\/game-output",
+    "Name":"https://schema.org/game-output",
     "Domain Bucket":"< 1K"
   },
   {
     "Class":"Predicate",
-    "Name":"http:\/\/schema.org\/gameAvailabilityType",
+    "Name":"https://schema.org/gameAvailabilityType",
     "Domain Bucket":"< 1K"
   },
   {
     "Class":"Predicate",
-    "Name":"http:\/\/schema.org\/gameAvailabilityType-input",
+    "Name":"https://schema.org/gameAvailabilityType-input",
     "Domain Bucket":"< 1K"
   },
   {
     "Class":"Predicate",
-    "Name":"http:\/\/schema.org\/gameAvailabilityType-output",
+    "Name":"https://schema.org/gameAvailabilityType-output",
     "Domain Bucket":"< 1K"
   },
   {
     "Class":"Predicate",
-    "Name":"http:\/\/schema.org\/gameEdition",
+    "Name":"https://schema.org/gameEdition",
     "Domain Bucket":"< 1K"
   },
   {
     "Class":"Predicate",
-    "Name":"http:\/\/schema.org\/gameEdition-input",
+    "Name":"https://schema.org/gameEdition-input",
     "Domain Bucket":"< 1K"
   },
   {
     "Class":"Predicate",
-    "Name":"http:\/\/schema.org\/gameEdition-output",
+    "Name":"https://schema.org/gameEdition-output",
     "Domain Bucket":"< 1K"
   },
   {
     "Class":"Predicate",
-    "Name":"http:\/\/schema.org\/gameItem",
+    "Name":"https://schema.org/gameItem",
     "Domain Bucket":"10K - 100K"
   },
   {
     "Class":"Predicate",
-    "Name":"http:\/\/schema.org\/gameItem-input",
+    "Name":"https://schema.org/gameItem-input",
     "Domain Bucket":"< 1K"
   },
   {
     "Class":"Predicate",
-    "Name":"http:\/\/schema.org\/gameItem-output",
+    "Name":"https://schema.org/gameItem-output",
     "Domain Bucket":"< 1K"
   },
   {
     "Class":"Predicate",
-    "Name":"http:\/\/schema.org\/gameLocation",
+    "Name":"https://schema.org/gameLocation",
     "Domain Bucket":"10K - 100K"
   },
   {
     "Class":"Predicate",
-    "Name":"http:\/\/schema.org\/gameLocation-input",
+    "Name":"https://schema.org/gameLocation-input",
     "Domain Bucket":"< 1K"
   },
   {
     "Class":"Predicate",
-    "Name":"http:\/\/schema.org\/gameLocation-output",
+    "Name":"https://schema.org/gameLocation-output",
     "Domain Bucket":"< 1K"
   },
   {
     "Class":"Predicate",
-    "Name":"http:\/\/schema.org\/gamePlatform",
+    "Name":"https://schema.org/gamePlatform",
     "Domain Bucket":"10K - 100K"
   },
   {
     "Class":"Predicate",
-    "Name":"http:\/\/schema.org\/gamePlatform-input",
+    "Name":"https://schema.org/gamePlatform-input",
     "Domain Bucket":"< 1K"
   },
   {
     "Class":"Predicate",
-    "Name":"http:\/\/schema.org\/gamePlatform-output",
+    "Name":"https://schema.org/gamePlatform-output",
     "Domain Bucket":"< 1K"
   },
   {
     "Class":"Predicate",
-    "Name":"http:\/\/schema.org\/gameServer",
+    "Name":"https://schema.org/gameServer",
     "Domain Bucket":"< 1K"
   },
   {
     "Class":"Predicate",
-    "Name":"http:\/\/schema.org\/gameServer-input",
+    "Name":"https://schema.org/gameServer-input",
     "Domain Bucket":"< 1K"
   },
   {
     "Class":"Predicate",
-    "Name":"http:\/\/schema.org\/gameServer-output",
+    "Name":"https://schema.org/gameServer-output",
     "Domain Bucket":"< 1K"
   },
   {
     "Class":"Predicate",
-    "Name":"http:\/\/schema.org\/gameTip",
+    "Name":"https://schema.org/gameTip",
     "Domain Bucket":"< 1K"
   },
   {
     "Class":"Predicate",
-    "Name":"http:\/\/schema.org\/gameTip-input",
+    "Name":"https://schema.org/gameTip-input",
     "Domain Bucket":"< 1K"
   },
   {
     "Class":"Predicate",
-    "Name":"http:\/\/schema.org\/gameTip-output",
+    "Name":"https://schema.org/gameTip-output",
     "Domain Bucket":"< 1K"
   },
   {
     "Class":"Predicate",
-    "Name":"http:\/\/schema.org\/gender",
+    "Name":"https://schema.org/gender",
     "Domain Bucket":"10K - 100K"
   },
   {
     "Class":"Predicate",
-    "Name":"http:\/\/schema.org\/gender-input",
+    "Name":"https://schema.org/gender-input",
     "Domain Bucket":"< 1K"
   },
   {
     "Class":"Predicate",
-    "Name":"http:\/\/schema.org\/gender-output",
+    "Name":"https://schema.org/gender-output",
     "Domain Bucket":"< 1K"
   },
   {
     "Class":"Predicate",
-    "Name":"http:\/\/schema.org\/genre",
+    "Name":"https://schema.org/genre",
     "Domain Bucket":"100K - 1M"
   },
   {
     "Class":"Predicate",
-    "Name":"http:\/\/schema.org\/genre-input",
+    "Name":"https://schema.org/genre-input",
     "Domain Bucket":"< 1K"
   },
   {
     "Class":"Predicate",
-    "Name":"http:\/\/schema.org\/genre-output",
+    "Name":"https://schema.org/genre-output",
     "Domain Bucket":"< 1K"
   },
   {
     "Class":"Predicate",
-    "Name":"http:\/\/schema.org\/geo",
+    "Name":"https://schema.org/geo",
     "Domain Bucket":"1M - 10M"
   },
   {
     "Class":"Predicate",
-    "Name":"http:\/\/schema.org\/geo-input",
+    "Name":"https://schema.org/geo-input",
     "Domain Bucket":"< 1K"
   },
   {
     "Class":"Predicate",
-    "Name":"http:\/\/schema.org\/geo-output",
+    "Name":"https://schema.org/geo-output",
     "Domain Bucket":"< 1K"
   },
   {
     "Class":"Predicate",
-    "Name":"http:\/\/schema.org\/geoContains",
+    "Name":"https://schema.org/geoContains",
     "Domain Bucket":"< 1K"
   },
   {
     "Class":"Predicate",
-    "Name":"http:\/\/schema.org\/geoContains-input",
+    "Name":"https://schema.org/geoContains-input",
     "Domain Bucket":"< 1K"
   },
   {
     "Class":"Predicate",
-    "Name":"http:\/\/schema.org\/geoContains-output",
+    "Name":"https://schema.org/geoContains-output",
     "Domain Bucket":"< 1K"
   },
   {
     "Class":"Predicate",
-    "Name":"http:\/\/schema.org\/geoCoveredBy",
+    "Name":"https://schema.org/geoCoveredBy",
     "Domain Bucket":"< 1K"
   },
   {
     "Class":"Predicate",
-    "Name":"http:\/\/schema.org\/geoCoveredBy-input",
+    "Name":"https://schema.org/geoCoveredBy-input",
     "Domain Bucket":"< 1K"
   },
   {
     "Class":"Predicate",
-    "Name":"http:\/\/schema.org\/geoCoveredBy-output",
+    "Name":"https://schema.org/geoCoveredBy-output",
     "Domain Bucket":"< 1K"
   },
   {
     "Class":"Predicate",
-    "Name":"http:\/\/schema.org\/geoCovers",
+    "Name":"https://schema.org/geoCovers",
     "Domain Bucket":"< 1K"
   },
   {
     "Class":"Predicate",
-    "Name":"http:\/\/schema.org\/geoCovers-input",
+    "Name":"https://schema.org/geoCovers-input",
     "Domain Bucket":"< 1K"
   },
   {
     "Class":"Predicate",
-    "Name":"http:\/\/schema.org\/geoCovers-output",
+    "Name":"https://schema.org/geoCovers-output",
     "Domain Bucket":"< 1K"
   },
   {
     "Class":"Predicate",
-    "Name":"http:\/\/schema.org\/geoCrosses",
+    "Name":"https://schema.org/geoCrosses",
     "Domain Bucket":"< 1K"
   },
   {
     "Class":"Predicate",
-    "Name":"http:\/\/schema.org\/geoCrosses-input",
+    "Name":"https://schema.org/geoCrosses-input",
     "Domain Bucket":"< 1K"
   },
   {
     "Class":"Predicate",
-    "Name":"http:\/\/schema.org\/geoCrosses-output",
+    "Name":"https://schema.org/geoCrosses-output",
     "Domain Bucket":"< 1K"
   },
   {
     "Class":"Predicate",
-    "Name":"http:\/\/schema.org\/geoDisjoint",
+    "Name":"https://schema.org/geoDisjoint",
     "Domain Bucket":"< 1K"
   },
   {
     "Class":"Predicate",
-    "Name":"http:\/\/schema.org\/geoDisjoint-input",
+    "Name":"https://schema.org/geoDisjoint-input",
     "Domain Bucket":"< 1K"
   },
   {
     "Class":"Predicate",
-    "Name":"http:\/\/schema.org\/geoDisjoint-output",
+    "Name":"https://schema.org/geoDisjoint-output",
     "Domain Bucket":"< 1K"
   },
   {
     "Class":"Predicate",
-    "Name":"http:\/\/schema.org\/geoEquals",
+    "Name":"https://schema.org/geoEquals",
     "Domain Bucket":"< 1K"
   },
   {
     "Class":"Predicate",
-    "Name":"http:\/\/schema.org\/geoEquals-input",
+    "Name":"https://schema.org/geoEquals-input",
     "Domain Bucket":"< 1K"
   },
   {
     "Class":"Predicate",
-    "Name":"http:\/\/schema.org\/geoEquals-output",
+    "Name":"https://schema.org/geoEquals-output",
     "Domain Bucket":"< 1K"
   },
   {
     "Class":"Predicate",
-    "Name":"http:\/\/schema.org\/geoIntersects",
+    "Name":"https://schema.org/geoIntersects",
     "Domain Bucket":"< 1K"
   },
   {
     "Class":"Predicate",
-    "Name":"http:\/\/schema.org\/geoIntersects-input",
+    "Name":"https://schema.org/geoIntersects-input",
     "Domain Bucket":"< 1K"
   },
   {
     "Class":"Predicate",
-    "Name":"http:\/\/schema.org\/geoIntersects-output",
+    "Name":"https://schema.org/geoIntersects-output",
     "Domain Bucket":"< 1K"
   },
   {
     "Class":"Predicate",
-    "Name":"http:\/\/schema.org\/geoMidpoint",
+    "Name":"https://schema.org/geoMidpoint",
     "Domain Bucket":"100K - 1M"
   },
   {
     "Class":"Predicate",
-    "Name":"http:\/\/schema.org\/geoMidpoint-input",
+    "Name":"https://schema.org/geoMidpoint-input",
     "Domain Bucket":"< 1K"
   },
   {
     "Class":"Predicate",
-    "Name":"http:\/\/schema.org\/geoMidpoint-output",
+    "Name":"https://schema.org/geoMidpoint-output",
     "Domain Bucket":"< 1K"
   },
   {
     "Class":"Predicate",
-    "Name":"http:\/\/schema.org\/geoOverlaps",
+    "Name":"https://schema.org/geoOverlaps",
     "Domain Bucket":"< 1K"
   },
   {
     "Class":"Predicate",
-    "Name":"http:\/\/schema.org\/geoOverlaps-input",
+    "Name":"https://schema.org/geoOverlaps-input",
     "Domain Bucket":"< 1K"
   },
   {
     "Class":"Predicate",
-    "Name":"http:\/\/schema.org\/geoOverlaps-output",
+    "Name":"https://schema.org/geoOverlaps-output",
     "Domain Bucket":"< 1K"
   },
   {
     "Class":"Predicate",
-    "Name":"http:\/\/schema.org\/geoRadius",
+    "Name":"https://schema.org/geoRadius",
     "Domain Bucket":"100K - 1M"
   },
   {
     "Class":"Predicate",
-    "Name":"http:\/\/schema.org\/geoRadius-input",
+    "Name":"https://schema.org/geoRadius-input",
     "Domain Bucket":"< 1K"
   },
   {
     "Class":"Predicate",
-    "Name":"http:\/\/schema.org\/geoRadius-output",
+    "Name":"https://schema.org/geoRadius-output",
     "Domain Bucket":"< 1K"
   },
   {
     "Class":"Predicate",
-    "Name":"http:\/\/schema.org\/geoTouches",
+    "Name":"https://schema.org/geoTouches",
     "Domain Bucket":"< 1K"
   },
   {
     "Class":"Predicate",
-    "Name":"http:\/\/schema.org\/geoTouches-input",
+    "Name":"https://schema.org/geoTouches-input",
     "Domain Bucket":"< 1K"
   },
   {
     "Class":"Predicate",
-    "Name":"http:\/\/schema.org\/geoTouches-output",
+    "Name":"https://schema.org/geoTouches-output",
     "Domain Bucket":"< 1K"
   },
   {
     "Class":"Predicate",
-    "Name":"http:\/\/schema.org\/geoWithin",
+    "Name":"https://schema.org/geoWithin",
     "Domain Bucket":"< 1K"
   },
   {
     "Class":"Predicate",
-    "Name":"http:\/\/schema.org\/geoWithin-input",
+    "Name":"https://schema.org/geoWithin-input",
     "Domain Bucket":"< 1K"
   },
   {
     "Class":"Predicate",
-    "Name":"http:\/\/schema.org\/geoWithin-output",
+    "Name":"https://schema.org/geoWithin-output",
     "Domain Bucket":"< 1K"
   },
   {
     "Class":"Predicate",
-    "Name":"http:\/\/schema.org\/geographicArea",
+    "Name":"https://schema.org/geographicArea",
     "Domain Bucket":"10K - 100K"
   },
   {
     "Class":"Predicate",
-    "Name":"http:\/\/schema.org\/geographicArea-input",
+    "Name":"https://schema.org/geographicArea-input",
     "Domain Bucket":"< 1K"
   },
   {
     "Class":"Predicate",
-    "Name":"http:\/\/schema.org\/geographicArea-output",
+    "Name":"https://schema.org/geographicArea-output",
     "Domain Bucket":"< 1K"
   },
   {
     "Class":"Predicate",
-    "Name":"http:\/\/schema.org\/gettingTestedInfo",
+    "Name":"https://schema.org/gettingTestedInfo",
     "Domain Bucket":"< 1K"
   },
   {
     "Class":"Predicate",
-    "Name":"http:\/\/schema.org\/gettingTestedInfo-input",
+    "Name":"https://schema.org/gettingTestedInfo-input",
     "Domain Bucket":"< 1K"
   },
   {
     "Class":"Predicate",
-    "Name":"http:\/\/schema.org\/gettingTestedInfo-output",
+    "Name":"https://schema.org/gettingTestedInfo-output",
     "Domain Bucket":"< 1K"
   },
   {
     "Class":"Predicate",
-    "Name":"http:\/\/schema.org\/givenName",
+    "Name":"https://schema.org/givenName",
     "Domain Bucket":"100K - 1M"
   },
   {
     "Class":"Predicate",
-    "Name":"http:\/\/schema.org\/givenName-input",
+    "Name":"https://schema.org/givenName-input",
     "Domain Bucket":"< 1K"
   },
   {
     "Class":"Predicate",
-    "Name":"http:\/\/schema.org\/givenName-output",
+    "Name":"https://schema.org/givenName-output",
     "Domain Bucket":"< 1K"
   },
   {
     "Class":"Predicate",
-    "Name":"http:\/\/schema.org\/globalLocationNumber",
+    "Name":"https://schema.org/globalLocationNumber",
     "Domain Bucket":"1K - 10K"
   },
   {
     "Class":"Predicate",
-    "Name":"http:\/\/schema.org\/globalLocationNumber-input",
+    "Name":"https://schema.org/globalLocationNumber-input",
     "Domain Bucket":"< 1K"
   },
   {
     "Class":"Predicate",
-    "Name":"http:\/\/schema.org\/globalLocationNumber-output",
+    "Name":"https://schema.org/globalLocationNumber-output",
     "Domain Bucket":"< 1K"
   },
   {
     "Class":"Predicate",
-    "Name":"http:\/\/schema.org\/governmentBenefitsInfo",
+    "Name":"https://schema.org/governmentBenefitsInfo",
     "Domain Bucket":"< 1K"
   },
   {
     "Class":"Predicate",
-    "Name":"http:\/\/schema.org\/governmentBenefitsInfo-input",
+    "Name":"https://schema.org/governmentBenefitsInfo-input",
     "Domain Bucket":"< 1K"
   },
   {
     "Class":"Predicate",
-    "Name":"http:\/\/schema.org\/governmentBenefitsInfo-output",
+    "Name":"https://schema.org/governmentBenefitsInfo-output",
     "Domain Bucket":"< 1K"
   },
   {
     "Class":"Predicate",
-    "Name":"http:\/\/schema.org\/gracePeriod",
+    "Name":"https://schema.org/gracePeriod",
     "Domain Bucket":"< 1K"
   },
   {
     "Class":"Predicate",
-    "Name":"http:\/\/schema.org\/gracePeriod-input",
+    "Name":"https://schema.org/gracePeriod-input",
     "Domain Bucket":"< 1K"
   },
   {
     "Class":"Predicate",
-    "Name":"http:\/\/schema.org\/gracePeriod-output",
+    "Name":"https://schema.org/gracePeriod-output",
     "Domain Bucket":"< 1K"
   },
   {
     "Class":"Predicate",
-    "Name":"http:\/\/schema.org\/grantee",
+    "Name":"https://schema.org/grantee",
     "Domain Bucket":"< 1K"
   },
   {
     "Class":"Predicate",
-    "Name":"http:\/\/schema.org\/grantee-input",
+    "Name":"https://schema.org/grantee-input",
     "Domain Bucket":"< 1K"
   },
   {
     "Class":"Predicate",
-    "Name":"http:\/\/schema.org\/grantee-output",
+    "Name":"https://schema.org/grantee-output",
     "Domain Bucket":"< 1K"
   },
   {
     "Class":"Predicate",
-    "Name":"http:\/\/schema.org\/greater",
+    "Name":"https://schema.org/greater",
     "Domain Bucket":"< 1K"
   },
   {
     "Class":"Predicate",
-    "Name":"http:\/\/schema.org\/greater-input",
+    "Name":"https://schema.org/greater-input",
     "Domain Bucket":"< 1K"
   },
   {
     "Class":"Predicate",
-    "Name":"http:\/\/schema.org\/greater-output",
+    "Name":"https://schema.org/greater-output",
     "Domain Bucket":"< 1K"
   },
   {
     "Class":"Predicate",
-    "Name":"http:\/\/schema.org\/greaterOrEqual",
+    "Name":"https://schema.org/greaterOrEqual",
     "Domain Bucket":"< 1K"
   },
   {
     "Class":"Predicate",
-    "Name":"http:\/\/schema.org\/greaterOrEqual-input",
+    "Name":"https://schema.org/greaterOrEqual-input",
     "Domain Bucket":"< 1K"
   },
   {
     "Class":"Predicate",
-    "Name":"http:\/\/schema.org\/greaterOrEqual-output",
+    "Name":"https://schema.org/greaterOrEqual-output",
     "Domain Bucket":"< 1K"
   },
   {
     "Class":"Predicate",
-    "Name":"http:\/\/schema.org\/gtin",
+    "Name":"https://schema.org/gtin",
     "Domain Bucket":"100K - 1M"
   },
   {
     "Class":"Predicate",
-    "Name":"http:\/\/schema.org\/gtin-input",
+    "Name":"https://schema.org/gtin-input",
     "Domain Bucket":"< 1K"
   },
   {
     "Class":"Predicate",
-    "Name":"http:\/\/schema.org\/gtin-output",
+    "Name":"https://schema.org/gtin-output",
     "Domain Bucket":"< 1K"
   },
   {
     "Class":"Predicate",
-    "Name":"http:\/\/schema.org\/gtin12",
+    "Name":"https://schema.org/gtin12",
     "Domain Bucket":"100K - 1M"
   },
   {
     "Class":"Predicate",
-    "Name":"http:\/\/schema.org\/gtin12-input",
+    "Name":"https://schema.org/gtin12-input",
     "Domain Bucket":"< 1K"
   },
   {
     "Class":"Predicate",
-    "Name":"http:\/\/schema.org\/gtin12-output",
+    "Name":"https://schema.org/gtin12-output",
     "Domain Bucket":"< 1K"
   },
   {
     "Class":"Predicate",
-    "Name":"http:\/\/schema.org\/gtin13",
+    "Name":"https://schema.org/gtin13",
     "Domain Bucket":"100K - 1M"
   },
   {
     "Class":"Predicate",
-    "Name":"http:\/\/schema.org\/gtin13-input",
+    "Name":"https://schema.org/gtin13-input",
     "Domain Bucket":"< 1K"
   },
   {
     "Class":"Predicate",
-    "Name":"http:\/\/schema.org\/gtin13-output",
+    "Name":"https://schema.org/gtin13-output",
     "Domain Bucket":"< 1K"
   },
   {
     "Class":"Predicate",
-    "Name":"http:\/\/schema.org\/gtin14",
+    "Name":"https://schema.org/gtin14",
     "Domain Bucket":"10K - 100K"
   },
   {
     "Class":"Predicate",
-    "Name":"http:\/\/schema.org\/gtin14-input",
+    "Name":"https://schema.org/gtin14-input",
     "Domain Bucket":"< 1K"
   },
   {
     "Class":"Predicate",
-    "Name":"http:\/\/schema.org\/gtin14-output",
+    "Name":"https://schema.org/gtin14-output",
     "Domain Bucket":"< 1K"
   },
   {
     "Class":"Predicate",
-    "Name":"http:\/\/schema.org\/gtin8",
+    "Name":"https://schema.org/gtin8",
     "Domain Bucket":"10K - 100K"
   },
   {
     "Class":"Predicate",
-    "Name":"http:\/\/schema.org\/gtin8-input",
+    "Name":"https://schema.org/gtin8-input",
     "Domain Bucket":"< 1K"
   },
   {
     "Class":"Predicate",
-    "Name":"http:\/\/schema.org\/gtin8-output",
+    "Name":"https://schema.org/gtin8-output",
     "Domain Bucket":"< 1K"
   },
   {
     "Class":"Predicate",
-    "Name":"http:\/\/schema.org\/guideline",
+    "Name":"https://schema.org/guideline",
     "Domain Bucket":"< 1K"
   },
   {
     "Class":"Predicate",
-    "Name":"http:\/\/schema.org\/guideline-input",
+    "Name":"https://schema.org/guideline-input",
     "Domain Bucket":"< 1K"
   },
   {
     "Class":"Predicate",
-    "Name":"http:\/\/schema.org\/guideline-output",
+    "Name":"https://schema.org/guideline-output",
     "Domain Bucket":"< 1K"
   },
   {
     "Class":"Predicate",
-    "Name":"http:\/\/schema.org\/guidelineDate",
+    "Name":"https://schema.org/guidelineDate",
     "Domain Bucket":"< 1K"
   },
   {
     "Class":"Predicate",
-    "Name":"http:\/\/schema.org\/guidelineDate-input",
+    "Name":"https://schema.org/guidelineDate-input",
     "Domain Bucket":"< 1K"
   },
   {
     "Class":"Predicate",
-    "Name":"http:\/\/schema.org\/guidelineDate-output",
+    "Name":"https://schema.org/guidelineDate-output",
     "Domain Bucket":"< 1K"
   },
   {
     "Class":"Predicate",
-    "Name":"http:\/\/schema.org\/guidelineSubject",
+    "Name":"https://schema.org/guidelineSubject",
     "Domain Bucket":"< 1K"
   },
   {
     "Class":"Predicate",
-    "Name":"http:\/\/schema.org\/guidelineSubject-input",
+    "Name":"https://schema.org/guidelineSubject-input",
     "Domain Bucket":"< 1K"
   },
   {
     "Class":"Predicate",
-    "Name":"http:\/\/schema.org\/guidelineSubject-output",
+    "Name":"https://schema.org/guidelineSubject-output",
     "Domain Bucket":"< 1K"
   },
   {
     "Class":"Predicate",
-    "Name":"http:\/\/schema.org\/handlingTime",
+    "Name":"https://schema.org/handlingTime",
     "Domain Bucket":"100K - 1M"
   },
   {
     "Class":"Predicate",
-    "Name":"http:\/\/schema.org\/handlingTime-input",
+    "Name":"https://schema.org/handlingTime-input",
     "Domain Bucket":"< 1K"
   },
   {
     "Class":"Predicate",
-    "Name":"http:\/\/schema.org\/handlingTime-output",
+    "Name":"https://schema.org/handlingTime-output",
     "Domain Bucket":"< 1K"
   },
   {
     "Class":"Predicate",
-    "Name":"http:\/\/schema.org\/hasAdultConsideration",
+    "Name":"https://schema.org/hasAdultConsideration",
     "Domain Bucket":"< 1K"
   },
   {
     "Class":"Predicate",
-    "Name":"http:\/\/schema.org\/hasAdultConsideration-input",
+    "Name":"https://schema.org/hasAdultConsideration-input",
     "Domain Bucket":"< 1K"
   },
   {
     "Class":"Predicate",
-    "Name":"http:\/\/schema.org\/hasAdultConsideration-output",
+    "Name":"https://schema.org/hasAdultConsideration-output",
     "Domain Bucket":"< 1K"
   },
   {
     "Class":"Predicate",
-    "Name":"http:\/\/schema.org\/hasBioChemEntityPart",
+    "Name":"https://schema.org/hasBioChemEntityPart",
     "Domain Bucket":"< 1K"
   },
   {
     "Class":"Predicate",
-    "Name":"http:\/\/schema.org\/hasBioChemEntityPart-input",
+    "Name":"https://schema.org/hasBioChemEntityPart-input",
     "Domain Bucket":"< 1K"
   },
   {
     "Class":"Predicate",
-    "Name":"http:\/\/schema.org\/hasBioChemEntityPart-output",
+    "Name":"https://schema.org/hasBioChemEntityPart-output",
     "Domain Bucket":"< 1K"
   },
   {
     "Class":"Predicate",
-    "Name":"http:\/\/schema.org\/hasBioPolymerSequence",
+    "Name":"https://schema.org/hasBioPolymerSequence",
     "Domain Bucket":"< 1K"
   },
   {
     "Class":"Predicate",
-    "Name":"http:\/\/schema.org\/hasBioPolymerSequence-input",
+    "Name":"https://schema.org/hasBioPolymerSequence-input",
     "Domain Bucket":"< 1K"
   },
   {
     "Class":"Predicate",
-    "Name":"http:\/\/schema.org\/hasBioPolymerSequence-output",
+    "Name":"https://schema.org/hasBioPolymerSequence-output",
     "Domain Bucket":"< 1K"
   },
   {
     "Class":"Predicate",
-    "Name":"http:\/\/schema.org\/hasBroadcastChannel",
+    "Name":"https://schema.org/hasBroadcastChannel",
     "Domain Bucket":"< 1K"
   },
   {
     "Class":"Predicate",
-    "Name":"http:\/\/schema.org\/hasBroadcastChannel-input",
+    "Name":"https://schema.org/hasBroadcastChannel-input",
     "Domain Bucket":"< 1K"
   },
   {
     "Class":"Predicate",
-    "Name":"http:\/\/schema.org\/hasBroadcastChannel-output",
+    "Name":"https://schema.org/hasBroadcastChannel-output",
     "Domain Bucket":"< 1K"
   },
   {
     "Class":"Predicate",
-    "Name":"http:\/\/schema.org\/hasCategoryCode",
+    "Name":"https://schema.org/hasCategoryCode",
     "Domain Bucket":"< 1K"
   },
   {
     "Class":"Predicate",
-    "Name":"http:\/\/schema.org\/hasCategoryCode-input",
+    "Name":"https://schema.org/hasCategoryCode-input",
     "Domain Bucket":"< 1K"
   },
   {
     "Class":"Predicate",
-    "Name":"http:\/\/schema.org\/hasCategoryCode-output",
+    "Name":"https://schema.org/hasCategoryCode-output",
     "Domain Bucket":"< 1K"
   },
   {
     "Class":"Predicate",
-    "Name":"http:\/\/schema.org\/hasCertification",
+    "Name":"https://schema.org/hasCertification",
     "Domain Bucket":"1K - 10K"
   },
   {
     "Class":"Predicate",
-    "Name":"http:\/\/schema.org\/hasCertification-input",
+    "Name":"https://schema.org/hasCertification-input",
     "Domain Bucket":"< 1K"
   },
   {
     "Class":"Predicate",
-    "Name":"http:\/\/schema.org\/hasCertification-output",
+    "Name":"https://schema.org/hasCertification-output",
     "Domain Bucket":"< 1K"
   },
   {
     "Class":"Predicate",
-    "Name":"http:\/\/schema.org\/hasCourse",
+    "Name":"https://schema.org/hasCourse",
     "Domain Bucket":"1K - 10K"
   },
   {
     "Class":"Predicate",
-    "Name":"http:\/\/schema.org\/hasCourse-input",
+    "Name":"https://schema.org/hasCourse-input",
     "Domain Bucket":"< 1K"
   },
   {
     "Class":"Predicate",
-    "Name":"http:\/\/schema.org\/hasCourse-output",
+    "Name":"https://schema.org/hasCourse-output",
     "Domain Bucket":"< 1K"
   },
   {
     "Class":"Predicate",
-    "Name":"http:\/\/schema.org\/hasCourseInstance",
+    "Name":"https://schema.org/hasCourseInstance",
     "Domain Bucket":"10K - 100K"
   },
   {
     "Class":"Predicate",
-    "Name":"http:\/\/schema.org\/hasCourseInstance-input",
+    "Name":"https://schema.org/hasCourseInstance-input",
     "Domain Bucket":"< 1K"
   },
   {
     "Class":"Predicate",
-    "Name":"http:\/\/schema.org\/hasCourseInstance-output",
+    "Name":"https://schema.org/hasCourseInstance-output",
     "Domain Bucket":"< 1K"
   },
   {
     "Class":"Predicate",
-    "Name":"http:\/\/schema.org\/hasCredential",
+    "Name":"https://schema.org/hasCredential",
     "Domain Bucket":"100K - 1M"
   },
   {
     "Class":"Predicate",
-    "Name":"http:\/\/schema.org\/hasCredential-input",
+    "Name":"https://schema.org/hasCredential-input",
     "Domain Bucket":"< 1K"
   },
   {
     "Class":"Predicate",
-    "Name":"http:\/\/schema.org\/hasCredential-output",
+    "Name":"https://schema.org/hasCredential-output",
     "Domain Bucket":"< 1K"
   },
   {
     "Class":"Predicate",
-    "Name":"http:\/\/schema.org\/hasDefinedTerm",
+    "Name":"https://schema.org/hasDefinedTerm",
     "Domain Bucket":"10K - 100K"
   },
   {
     "Class":"Predicate",
-    "Name":"http:\/\/schema.org\/hasDefinedTerm-input",
+    "Name":"https://schema.org/hasDefinedTerm-input",
     "Domain Bucket":"< 1K"
   },
   {
     "Class":"Predicate",
-    "Name":"http:\/\/schema.org\/hasDefinedTerm-output",
+    "Name":"https://schema.org/hasDefinedTerm-output",
     "Domain Bucket":"< 1K"
   },
   {
     "Class":"Predicate",
-    "Name":"http:\/\/schema.org\/hasDeliveryMethod",
+    "Name":"https://schema.org/hasDeliveryMethod",
     "Domain Bucket":"< 1K"
   },
   {
     "Class":"Predicate",
-    "Name":"http:\/\/schema.org\/hasDeliveryMethod-input",
+    "Name":"https://schema.org/hasDeliveryMethod-input",
     "Domain Bucket":"< 1K"
   },
   {
     "Class":"Predicate",
-    "Name":"http:\/\/schema.org\/hasDeliveryMethod-output",
+    "Name":"https://schema.org/hasDeliveryMethod-output",
     "Domain Bucket":"< 1K"
   },
   {
     "Class":"Predicate",
-    "Name":"http:\/\/schema.org\/hasDigitalDocumentPermission",
+    "Name":"https://schema.org/hasDigitalDocumentPermission",
     "Domain Bucket":"< 1K"
   },
   {
     "Class":"Predicate",
-    "Name":"http:\/\/schema.org\/hasDigitalDocumentPermission-input",
+    "Name":"https://schema.org/hasDigitalDocumentPermission-input",
     "Domain Bucket":"< 1K"
   },
   {
     "Class":"Predicate",
-    "Name":"http:\/\/schema.org\/hasDigitalDocumentPermission-output",
+    "Name":"https://schema.org/hasDigitalDocumentPermission-output",
     "Domain Bucket":"< 1K"
   },
   {
     "Class":"Predicate",
-    "Name":"http:\/\/schema.org\/hasDriveThroughService",
+    "Name":"https://schema.org/hasDriveThroughService",
     "Domain Bucket":"< 1K"
   },
   {
     "Class":"Predicate",
-    "Name":"http:\/\/schema.org\/hasDriveThroughService-input",
+    "Name":"https://schema.org/hasDriveThroughService-input",
     "Domain Bucket":"< 1K"
   },
   {
     "Class":"Predicate",
-    "Name":"http:\/\/schema.org\/hasDriveThroughService-output",
+    "Name":"https://schema.org/hasDriveThroughService-output",
     "Domain Bucket":"< 1K"
   },
   {
     "Class":"Predicate",
-    "Name":"http:\/\/schema.org\/hasEnergyConsumptionDetails",
+    "Name":"https://schema.org/hasEnergyConsumptionDetails",
     "Domain Bucket":"1K - 10K"
   },
   {
     "Class":"Predicate",
-    "Name":"http:\/\/schema.org\/hasEnergyConsumptionDetails-input",
+    "Name":"https://schema.org/hasEnergyConsumptionDetails-input",
     "Domain Bucket":"< 1K"
   },
   {
     "Class":"Predicate",
-    "Name":"http:\/\/schema.org\/hasEnergyConsumptionDetails-output",
+    "Name":"https://schema.org/hasEnergyConsumptionDetails-output",
     "Domain Bucket":"< 1K"
   },
   {
     "Class":"Predicate",
-    "Name":"http:\/\/schema.org\/hasEnergyEfficiencyCategory",
+    "Name":"https://schema.org/hasEnergyEfficiencyCategory",
     "Domain Bucket":"1K - 10K"
   },
   {
     "Class":"Predicate",
-    "Name":"http:\/\/schema.org\/hasEnergyEfficiencyCategory-input",
+    "Name":"https://schema.org/hasEnergyEfficiencyCategory-input",
     "Domain Bucket":"< 1K"
   },
   {
     "Class":"Predicate",
-    "Name":"http:\/\/schema.org\/hasEnergyEfficiencyCategory-output",
+    "Name":"https://schema.org/hasEnergyEfficiencyCategory-output",
     "Domain Bucket":"< 1K"
   },
   {
     "Class":"Predicate",
-    "Name":"http:\/\/schema.org\/hasGS1DigitalLink",
+    "Name":"https://schema.org/hasGS1DigitalLink",
     "Domain Bucket":"< 1K"
   },
   {
     "Class":"Predicate",
-    "Name":"http:\/\/schema.org\/hasGS1DigitalLink-input",
+    "Name":"https://schema.org/hasGS1DigitalLink-input",
     "Domain Bucket":"< 1K"
   },
   {
     "Class":"Predicate",
-    "Name":"http:\/\/schema.org\/hasGS1DigitalLink-output",
+    "Name":"https://schema.org/hasGS1DigitalLink-output",
     "Domain Bucket":"< 1K"
   },
   {
     "Class":"Predicate",
-    "Name":"http:\/\/schema.org\/hasHealthAspect",
+    "Name":"https://schema.org/hasHealthAspect",
     "Domain Bucket":"< 1K"
   },
   {
     "Class":"Predicate",
-    "Name":"http:\/\/schema.org\/hasHealthAspect-input",
+    "Name":"https://schema.org/hasHealthAspect-input",
     "Domain Bucket":"< 1K"
   },
   {
     "Class":"Predicate",
-    "Name":"http:\/\/schema.org\/hasHealthAspect-output",
+    "Name":"https://schema.org/hasHealthAspect-output",
     "Domain Bucket":"< 1K"
   },
   {
     "Class":"Predicate",
-    "Name":"http:\/\/schema.org\/hasMap",
+    "Name":"https://schema.org/hasMap",
     "Domain Bucket":"100K - 1M"
   },
   {
     "Class":"Predicate",
-    "Name":"http:\/\/schema.org\/hasMap-input",
+    "Name":"https://schema.org/hasMap-input",
     "Domain Bucket":"< 1K"
   },
   {
     "Class":"Predicate",
-    "Name":"http:\/\/schema.org\/hasMap-output",
+    "Name":"https://schema.org/hasMap-output",
     "Domain Bucket":"< 1K"
   },
   {
     "Class":"Predicate",
-    "Name":"http:\/\/schema.org\/hasMeasurement",
+    "Name":"https://schema.org/hasMeasurement",
     "Domain Bucket":"1K - 10K"
   },
   {
     "Class":"Predicate",
-    "Name":"http:\/\/schema.org\/hasMeasurement-input",
+    "Name":"https://schema.org/hasMeasurement-input",
     "Domain Bucket":"< 1K"
   },
   {
     "Class":"Predicate",
-    "Name":"http:\/\/schema.org\/hasMeasurement-output",
+    "Name":"https://schema.org/hasMeasurement-output",
     "Domain Bucket":"< 1K"
   },
   {
     "Class":"Predicate",
-    "Name":"http:\/\/schema.org\/hasMemberProgram",
+    "Name":"https://schema.org/hasMemberProgram",
     "Domain Bucket":"1K - 10K"
   },
   {
     "Class":"Predicate",
-    "Name":"http:\/\/schema.org\/hasMemberProgram-input",
+    "Name":"https://schema.org/hasMemberProgram-input",
     "Domain Bucket":"< 1K"
   },
   {
     "Class":"Predicate",
-    "Name":"http:\/\/schema.org\/hasMemberProgram-output",
+    "Name":"https://schema.org/hasMemberProgram-output",
     "Domain Bucket":"< 1K"
   },
   {
     "Class":"Predicate",
-    "Name":"http:\/\/schema.org\/hasMenu",
+    "Name":"https://schema.org/hasMenu",
     "Domain Bucket":"10K - 100K"
   },
   {
     "Class":"Predicate",
-    "Name":"http:\/\/schema.org\/hasMenu-input",
+    "Name":"https://schema.org/hasMenu-input",
     "Domain Bucket":"< 1K"
   },
   {
     "Class":"Predicate",
-    "Name":"http:\/\/schema.org\/hasMenu-output",
+    "Name":"https://schema.org/hasMenu-output",
     "Domain Bucket":"< 1K"
   },
   {
     "Class":"Predicate",
-    "Name":"http:\/\/schema.org\/hasMenuItem",
+    "Name":"https://schema.org/hasMenuItem",
     "Domain Bucket":"10K - 100K"
   },
   {
     "Class":"Predicate",
-    "Name":"http:\/\/schema.org\/hasMenuItem-input",
+    "Name":"https://schema.org/hasMenuItem-input",
     "Domain Bucket":"< 1K"
   },
   {
     "Class":"Predicate",
-    "Name":"http:\/\/schema.org\/hasMenuItem-output",
+    "Name":"https://schema.org/hasMenuItem-output",
     "Domain Bucket":"< 1K"
   },
   {
     "Class":"Predicate",
-    "Name":"http:\/\/schema.org\/hasMenuSection",
+    "Name":"https://schema.org/hasMenuSection",
     "Domain Bucket":"10K - 100K"
   },
   {
     "Class":"Predicate",
-    "Name":"http:\/\/schema.org\/hasMenuSection-input",
+    "Name":"https://schema.org/hasMenuSection-input",
     "Domain Bucket":"< 1K"
   },
   {
     "Class":"Predicate",
-    "Name":"http:\/\/schema.org\/hasMenuSection-output",
+    "Name":"https://schema.org/hasMenuSection-output",
     "Domain Bucket":"< 1K"
   },
   {
     "Class":"Predicate",
-    "Name":"http:\/\/schema.org\/hasMerchantReturnPolicy",
+    "Name":"https://schema.org/hasMerchantReturnPolicy",
     "Domain Bucket":"100K - 1M"
   },
   {
     "Class":"Predicate",
-    "Name":"http:\/\/schema.org\/hasMerchantReturnPolicy-input",
+    "Name":"https://schema.org/hasMerchantReturnPolicy-input",
     "Domain Bucket":"< 1K"
   },
   {
     "Class":"Predicate",
-    "Name":"http:\/\/schema.org\/hasMerchantReturnPolicy-output",
+    "Name":"https://schema.org/hasMerchantReturnPolicy-output",
     "Domain Bucket":"< 1K"
   },
   {
     "Class":"Predicate",
-    "Name":"http:\/\/schema.org\/hasMolecularFunction",
+    "Name":"https://schema.org/hasMolecularFunction",
     "Domain Bucket":"< 1K"
   },
   {
     "Class":"Predicate",
-    "Name":"http:\/\/schema.org\/hasMolecularFunction-input",
+    "Name":"https://schema.org/hasMolecularFunction-input",
     "Domain Bucket":"< 1K"
   },
   {
     "Class":"Predicate",
-    "Name":"http:\/\/schema.org\/hasMolecularFunction-output",
+    "Name":"https://schema.org/hasMolecularFunction-output",
     "Domain Bucket":"< 1K"
   },
   {
     "Class":"Predicate",
-    "Name":"http:\/\/schema.org\/hasOccupation",
+    "Name":"https://schema.org/hasOccupation",
     "Domain Bucket":"10K - 100K"
   },
   {
     "Class":"Predicate",
-    "Name":"http:\/\/schema.org\/hasOccupation-input",
+    "Name":"https://schema.org/hasOccupation-input",
     "Domain Bucket":"< 1K"
   },
   {
     "Class":"Predicate",
-    "Name":"http:\/\/schema.org\/hasOccupation-output",
+    "Name":"https://schema.org/hasOccupation-output",
     "Domain Bucket":"< 1K"
   },
   {
     "Class":"Predicate",
-    "Name":"http:\/\/schema.org\/hasOfferCatalog",
+    "Name":"https://schema.org/hasOfferCatalog",
     "Domain Bucket":"100K - 1M"
   },
   {
     "Class":"Predicate",
-    "Name":"http:\/\/schema.org\/hasOfferCatalog-input",
+    "Name":"https://schema.org/hasOfferCatalog-input",
     "Domain Bucket":"< 1K"
   },
   {
     "Class":"Predicate",
-    "Name":"http:\/\/schema.org\/hasOfferCatalog-output",
+    "Name":"https://schema.org/hasOfferCatalog-output",
     "Domain Bucket":"< 1K"
   },
   {
     "Class":"Predicate",
-    "Name":"http:\/\/schema.org\/hasPOS",
+    "Name":"https://schema.org/hasPOS",
     "Domain Bucket":"1K - 10K"
   },
   {
     "Class":"Predicate",
-    "Name":"http:\/\/schema.org\/hasPOS-input",
+    "Name":"https://schema.org/hasPOS-input",
     "Domain Bucket":"< 1K"
   },
   {
     "Class":"Predicate",
-    "Name":"http:\/\/schema.org\/hasPOS-output",
+    "Name":"https://schema.org/hasPOS-output",
     "Domain Bucket":"< 1K"
   },
   {
     "Class":"Predicate",
-    "Name":"http:\/\/schema.org\/hasPart",
+    "Name":"https://schema.org/hasPart",
     "Domain Bucket":"100K - 1M"
   },
   {
     "Class":"Predicate",
-    "Name":"http:\/\/schema.org\/hasPart-input",
+    "Name":"https://schema.org/hasPart-input",
     "Domain Bucket":"< 1K"
   },
   {
     "Class":"Predicate",
-    "Name":"http:\/\/schema.org\/hasPart-output",
+    "Name":"https://schema.org/hasPart-output",
     "Domain Bucket":"< 1K"
   },
   {
     "Class":"Predicate",
-    "Name":"http:\/\/schema.org\/hasParticipationOffer",
+    "Name":"https://schema.org/hasParticipationOffer",
     "Domain Bucket":"< 1K"
   },
   {
     "Class":"Predicate",
-    "Name":"http:\/\/schema.org\/hasParticipationOffer-input",
+    "Name":"https://schema.org/hasParticipationOffer-input",
     "Domain Bucket":"< 1K"
   },
   {
     "Class":"Predicate",
-    "Name":"http:\/\/schema.org\/hasParticipationOffer-output",
+    "Name":"https://schema.org/hasParticipationOffer-output",
     "Domain Bucket":"< 1K"
   },
   {
     "Class":"Predicate",
-    "Name":"http:\/\/schema.org\/hasProductReturnPolicy",
+    "Name":"https://schema.org/hasProductReturnPolicy",
     "Domain Bucket":"< 1K"
   },
   {
     "Class":"Predicate",
-    "Name":"http:\/\/schema.org\/hasProductReturnPolicy-input",
+    "Name":"https://schema.org/hasProductReturnPolicy-input",
     "Domain Bucket":"< 1K"
   },
   {
     "Class":"Predicate",
-    "Name":"http:\/\/schema.org\/hasProductReturnPolicy-output",
+    "Name":"https://schema.org/hasProductReturnPolicy-output",
     "Domain Bucket":"< 1K"
   },
   {
     "Class":"Predicate",
-    "Name":"http:\/\/schema.org\/hasRepresentation",
+    "Name":"https://schema.org/hasRepresentation",
     "Domain Bucket":"< 1K"
   },
   {
     "Class":"Predicate",
-    "Name":"http:\/\/schema.org\/hasRepresentation-input",
+    "Name":"https://schema.org/hasRepresentation-input",
     "Domain Bucket":"< 1K"
   },
   {
     "Class":"Predicate",
-    "Name":"http:\/\/schema.org\/hasRepresentation-output",
+    "Name":"https://schema.org/hasRepresentation-output",
     "Domain Bucket":"< 1K"
   },
   {
     "Class":"Predicate",
-    "Name":"http:\/\/schema.org\/hasShippingService",
+    "Name":"https://schema.org/hasShippingService",
     "Domain Bucket":"10K - 100K"
   },
   {
     "Class":"Predicate",
-    "Name":"http:\/\/schema.org\/hasShippingService-input",
+    "Name":"https://schema.org/hasShippingService-input",
     "Domain Bucket":"< 1K"
   },
   {
     "Class":"Predicate",
-    "Name":"http:\/\/schema.org\/hasShippingService-output",
+    "Name":"https://schema.org/hasShippingService-output",
     "Domain Bucket":"< 1K"
   },
   {
     "Class":"Predicate",
-    "Name":"http:\/\/schema.org\/hasSponsorshipOffer",
+    "Name":"https://schema.org/hasSponsorshipOffer",
     "Domain Bucket":"< 1K"
   },
   {
     "Class":"Predicate",
-    "Name":"http:\/\/schema.org\/hasSponsorshipOffer-input",
+    "Name":"https://schema.org/hasSponsorshipOffer-input",
     "Domain Bucket":"< 1K"
   },
   {
     "Class":"Predicate",
-    "Name":"http:\/\/schema.org\/hasSponsorshipOffer-output",
+    "Name":"https://schema.org/hasSponsorshipOffer-output",
     "Domain Bucket":"< 1K"
   },
   {
     "Class":"Predicate",
-    "Name":"http:\/\/schema.org\/hasStore",
+    "Name":"https://schema.org/hasStore",
     "Domain Bucket":"< 1K"
   },
   {
     "Class":"Predicate",
-    "Name":"http:\/\/schema.org\/hasStore-input",
+    "Name":"https://schema.org/hasStore-input",
     "Domain Bucket":"< 1K"
   },
   {
     "Class":"Predicate",
-    "Name":"http:\/\/schema.org\/hasStore-output",
+    "Name":"https://schema.org/hasStore-output",
     "Domain Bucket":"< 1K"
   },
   {
     "Class":"Predicate",
-    "Name":"http:\/\/schema.org\/hasTierBenefit",
+    "Name":"https://schema.org/hasTierBenefit",
     "Domain Bucket":"1K - 10K"
   },
   {
     "Class":"Predicate",
-    "Name":"http:\/\/schema.org\/hasTierBenefit-input",
+    "Name":"https://schema.org/hasTierBenefit-input",
     "Domain Bucket":"< 1K"
   },
   {
     "Class":"Predicate",
-    "Name":"http:\/\/schema.org\/hasTierBenefit-output",
+    "Name":"https://schema.org/hasTierBenefit-output",
     "Domain Bucket":"< 1K"
   },
   {
     "Class":"Predicate",
-    "Name":"http:\/\/schema.org\/hasTierRequirement",
+    "Name":"https://schema.org/hasTierRequirement",
     "Domain Bucket":"< 1K"
   },
   {
     "Class":"Predicate",
-    "Name":"http:\/\/schema.org\/hasTierRequirement-input",
+    "Name":"https://schema.org/hasTierRequirement-input",
     "Domain Bucket":"< 1K"
   },
   {
     "Class":"Predicate",
-    "Name":"http:\/\/schema.org\/hasTierRequirement-output",
+    "Name":"https://schema.org/hasTierRequirement-output",
     "Domain Bucket":"< 1K"
   },
   {
     "Class":"Predicate",
-    "Name":"http:\/\/schema.org\/hasTiers",
+    "Name":"https://schema.org/hasTiers",
     "Domain Bucket":"1K - 10K"
   },
   {
     "Class":"Predicate",
-    "Name":"http:\/\/schema.org\/hasTiers-input",
+    "Name":"https://schema.org/hasTiers-input",
     "Domain Bucket":"< 1K"
   },
   {
     "Class":"Predicate",
-    "Name":"http:\/\/schema.org\/hasTiers-output",
+    "Name":"https://schema.org/hasTiers-output",
     "Domain Bucket":"< 1K"
   },
   {
     "Class":"Predicate",
-    "Name":"http:\/\/schema.org\/hasVariant",
+    "Name":"https://schema.org/hasVariant",
     "Domain Bucket":"100K - 1M"
   },
   {
     "Class":"Predicate",
-    "Name":"http:\/\/schema.org\/hasVariant-input",
+    "Name":"https://schema.org/hasVariant-input",
     "Domain Bucket":"< 1K"
   },
   {
     "Class":"Predicate",
-    "Name":"http:\/\/schema.org\/hasVariant-output",
+    "Name":"https://schema.org/hasVariant-output",
     "Domain Bucket":"< 1K"
   },
   {
     "Class":"Predicate",
-    "Name":"http:\/\/schema.org\/headline",
+    "Name":"https://schema.org/headline",
     "Domain Bucket":"10M+"
   },
   {
     "Class":"Predicate",
-    "Name":"http:\/\/schema.org\/headline-input",
+    "Name":"https://schema.org/headline-input",
     "Domain Bucket":"< 1K"
   },
   {
     "Class":"Predicate",
-    "Name":"http:\/\/schema.org\/headline-output",
+    "Name":"https://schema.org/headline-output",
     "Domain Bucket":"< 1K"
   },
   {
     "Class":"Predicate",
-    "Name":"http:\/\/schema.org\/healthCondition",
+    "Name":"https://schema.org/healthCondition",
     "Domain Bucket":"1K - 10K"
   },
   {
     "Class":"Predicate",
-    "Name":"http:\/\/schema.org\/healthCondition-input",
+    "Name":"https://schema.org/healthCondition-input",
     "Domain Bucket":"< 1K"
   },
   {
     "Class":"Predicate",
-    "Name":"http:\/\/schema.org\/healthCondition-output",
+    "Name":"https://schema.org/healthCondition-output",
     "Domain Bucket":"< 1K"
   },
   {
     "Class":"Predicate",
-    "Name":"http:\/\/schema.org\/healthPlanCoinsuranceOption",
+    "Name":"https://schema.org/healthPlanCoinsuranceOption",
     "Domain Bucket":"< 1K"
   },
   {
     "Class":"Predicate",
-    "Name":"http:\/\/schema.org\/healthPlanCoinsuranceOption-input",
+    "Name":"https://schema.org/healthPlanCoinsuranceOption-input",
     "Domain Bucket":"< 1K"
   },
   {
     "Class":"Predicate",
-    "Name":"http:\/\/schema.org\/healthPlanCoinsuranceOption-output",
+    "Name":"https://schema.org/healthPlanCoinsuranceOption-output",
     "Domain Bucket":"< 1K"
   },
   {
     "Class":"Predicate",
-    "Name":"http:\/\/schema.org\/healthPlanCoinsuranceRate",
+    "Name":"https://schema.org/healthPlanCoinsuranceRate",
     "Domain Bucket":"< 1K"
   },
   {
     "Class":"Predicate",
-    "Name":"http:\/\/schema.org\/healthPlanCoinsuranceRate-input",
+    "Name":"https://schema.org/healthPlanCoinsuranceRate-input",
     "Domain Bucket":"< 1K"
   },
   {
     "Class":"Predicate",
-    "Name":"http:\/\/schema.org\/healthPlanCoinsuranceRate-output",
+    "Name":"https://schema.org/healthPlanCoinsuranceRate-output",
     "Domain Bucket":"< 1K"
   },
   {
     "Class":"Predicate",
-    "Name":"http:\/\/schema.org\/healthPlanCopay",
+    "Name":"https://schema.org/healthPlanCopay",
     "Domain Bucket":"< 1K"
   },
   {
     "Class":"Predicate",
-    "Name":"http:\/\/schema.org\/healthPlanCopay-input",
+    "Name":"https://schema.org/healthPlanCopay-input",
     "Domain Bucket":"< 1K"
   },
   {
     "Class":"Predicate",
-    "Name":"http:\/\/schema.org\/healthPlanCopay-output",
+    "Name":"https://schema.org/healthPlanCopay-output",
     "Domain Bucket":"< 1K"
   },
   {
     "Class":"Predicate",
-    "Name":"http:\/\/schema.org\/healthPlanCopayOption",
+    "Name":"https://schema.org/healthPlanCopayOption",
     "Domain Bucket":"< 1K"
   },
   {
     "Class":"Predicate",
-    "Name":"http:\/\/schema.org\/healthPlanCopayOption-input",
+    "Name":"https://schema.org/healthPlanCopayOption-input",
     "Domain Bucket":"< 1K"
   },
   {
     "Class":"Predicate",
-    "Name":"http:\/\/schema.org\/healthPlanCopayOption-output",
+    "Name":"https://schema.org/healthPlanCopayOption-output",
     "Domain Bucket":"< 1K"
   },
   {
     "Class":"Predicate",
-    "Name":"http:\/\/schema.org\/healthPlanCostSharing",
+    "Name":"https://schema.org/healthPlanCostSharing",
     "Domain Bucket":"< 1K"
   },
   {
     "Class":"Predicate",
-    "Name":"http:\/\/schema.org\/healthPlanCostSharing-input",
+    "Name":"https://schema.org/healthPlanCostSharing-input",
     "Domain Bucket":"< 1K"
   },
   {
     "Class":"Predicate",
-    "Name":"http:\/\/schema.org\/healthPlanCostSharing-output",
+    "Name":"https://schema.org/healthPlanCostSharing-output",
     "Domain Bucket":"< 1K"
   },
   {
     "Class":"Predicate",
-    "Name":"http:\/\/schema.org\/healthPlanDrugOption",
+    "Name":"https://schema.org/healthPlanDrugOption",
     "Domain Bucket":"< 1K"
   },
   {
     "Class":"Predicate",
-    "Name":"http:\/\/schema.org\/healthPlanDrugOption-input",
+    "Name":"https://schema.org/healthPlanDrugOption-input",
     "Domain Bucket":"< 1K"
   },
   {
     "Class":"Predicate",
-    "Name":"http:\/\/schema.org\/healthPlanDrugOption-output",
+    "Name":"https://schema.org/healthPlanDrugOption-output",
     "Domain Bucket":"< 1K"
   },
   {
     "Class":"Predicate",
-    "Name":"http:\/\/schema.org\/healthPlanDrugTier",
+    "Name":"https://schema.org/healthPlanDrugTier",
     "Domain Bucket":"< 1K"
   },
   {
     "Class":"Predicate",
-    "Name":"http:\/\/schema.org\/healthPlanDrugTier-input",
+    "Name":"https://schema.org/healthPlanDrugTier-input",
     "Domain Bucket":"< 1K"
   },
   {
     "Class":"Predicate",
-    "Name":"http:\/\/schema.org\/healthPlanDrugTier-output",
+    "Name":"https://schema.org/healthPlanDrugTier-output",
     "Domain Bucket":"< 1K"
   },
   {
     "Class":"Predicate",
-    "Name":"http:\/\/schema.org\/healthPlanId",
+    "Name":"https://schema.org/healthPlanId",
     "Domain Bucket":"< 1K"
   },
   {
     "Class":"Predicate",
-    "Name":"http:\/\/schema.org\/healthPlanId-input",
+    "Name":"https://schema.org/healthPlanId-input",
     "Domain Bucket":"< 1K"
   },
   {
     "Class":"Predicate",
-    "Name":"http:\/\/schema.org\/healthPlanId-output",
+    "Name":"https://schema.org/healthPlanId-output",
     "Domain Bucket":"< 1K"
   },
   {
     "Class":"Predicate",
-    "Name":"http:\/\/schema.org\/healthPlanMarketingUrl",
+    "Name":"https://schema.org/healthPlanMarketingUrl",
     "Domain Bucket":"< 1K"
   },
   {
     "Class":"Predicate",
-    "Name":"http:\/\/schema.org\/healthPlanMarketingUrl-input",
+    "Name":"https://schema.org/healthPlanMarketingUrl-input",
     "Domain Bucket":"< 1K"
   },
   {
     "Class":"Predicate",
-    "Name":"http:\/\/schema.org\/healthPlanMarketingUrl-output",
+    "Name":"https://schema.org/healthPlanMarketingUrl-output",
     "Domain Bucket":"< 1K"
   },
   {
     "Class":"Predicate",
-    "Name":"http:\/\/schema.org\/healthPlanNetworkId",
+    "Name":"https://schema.org/healthPlanNetworkId",
     "Domain Bucket":"< 1K"
   },
   {
     "Class":"Predicate",
-    "Name":"http:\/\/schema.org\/healthPlanNetworkId-input",
+    "Name":"https://schema.org/healthPlanNetworkId-input",
     "Domain Bucket":"< 1K"
   },
   {
     "Class":"Predicate",
-    "Name":"http:\/\/schema.org\/healthPlanNetworkId-output",
+    "Name":"https://schema.org/healthPlanNetworkId-output",
     "Domain Bucket":"< 1K"
   },
   {
     "Class":"Predicate",
-    "Name":"http:\/\/schema.org\/healthPlanNetworkTier",
+    "Name":"https://schema.org/healthPlanNetworkTier",
     "Domain Bucket":"< 1K"
   },
   {
     "Class":"Predicate",
-    "Name":"http:\/\/schema.org\/healthPlanNetworkTier-input",
+    "Name":"https://schema.org/healthPlanNetworkTier-input",
     "Domain Bucket":"< 1K"
   },
   {
     "Class":"Predicate",
-    "Name":"http:\/\/schema.org\/healthPlanNetworkTier-output",
+    "Name":"https://schema.org/healthPlanNetworkTier-output",
     "Domain Bucket":"< 1K"
   },
   {
     "Class":"Predicate",
-    "Name":"http:\/\/schema.org\/healthPlanPharmacyCategory",
+    "Name":"https://schema.org/healthPlanPharmacyCategory",
     "Domain Bucket":"< 1K"
   },
   {
     "Class":"Predicate",
-    "Name":"http:\/\/schema.org\/healthPlanPharmacyCategory-input",
+    "Name":"https://schema.org/healthPlanPharmacyCategory-input",
     "Domain Bucket":"< 1K"
   },
   {
     "Class":"Predicate",
-    "Name":"http:\/\/schema.org\/healthPlanPharmacyCategory-output",
+    "Name":"https://schema.org/healthPlanPharmacyCategory-output",
     "Domain Bucket":"< 1K"
   },
   {
     "Class":"Predicate",
-    "Name":"http:\/\/schema.org\/healthcareReportingData",
+    "Name":"https://schema.org/healthcareReportingData",
     "Domain Bucket":"< 1K"
   },
   {
     "Class":"Predicate",
-    "Name":"http:\/\/schema.org\/healthcareReportingData-input",
+    "Name":"https://schema.org/healthcareReportingData-input",
     "Domain Bucket":"< 1K"
   },
   {
     "Class":"Predicate",
-    "Name":"http:\/\/schema.org\/healthcareReportingData-output",
+    "Name":"https://schema.org/healthcareReportingData-output",
     "Domain Bucket":"< 1K"
   },
   {
     "Class":"Predicate",
-    "Name":"http:\/\/schema.org\/height",
+    "Name":"https://schema.org/height",
     "Domain Bucket":"10M+"
   },
   {
     "Class":"Predicate",
-    "Name":"http:\/\/schema.org\/height-input",
+    "Name":"https://schema.org/height-input",
     "Domain Bucket":"< 1K"
   },
   {
     "Class":"Predicate",
-    "Name":"http:\/\/schema.org\/height-output",
+    "Name":"https://schema.org/height-output",
     "Domain Bucket":"< 1K"
   },
   {
     "Class":"Predicate",
-    "Name":"http:\/\/schema.org\/highPrice",
+    "Name":"https://schema.org/highPrice",
     "Domain Bucket":"1M - 10M"
   },
   {
     "Class":"Predicate",
-    "Name":"http:\/\/schema.org\/highPrice-input",
+    "Name":"https://schema.org/highPrice-input",
     "Domain Bucket":"< 1K"
   },
   {
     "Class":"Predicate",
-    "Name":"http:\/\/schema.org\/highPrice-output",
+    "Name":"https://schema.org/highPrice-output",
     "Domain Bucket":"< 1K"
   },
   {
     "Class":"Predicate",
-    "Name":"http:\/\/schema.org\/hiringOrganization",
+    "Name":"https://schema.org/hiringOrganization",
     "Domain Bucket":"100K - 1M"
   },
   {
     "Class":"Predicate",
-    "Name":"http:\/\/schema.org\/hiringOrganization-input",
+    "Name":"https://schema.org/hiringOrganization-input",
     "Domain Bucket":"< 1K"
   },
   {
     "Class":"Predicate",
-    "Name":"http:\/\/schema.org\/hiringOrganization-output",
+    "Name":"https://schema.org/hiringOrganization-output",
     "Domain Bucket":"< 1K"
   },
   {
     "Class":"Predicate",
-    "Name":"http:\/\/schema.org\/holdingArchive",
+    "Name":"https://schema.org/holdingArchive",
     "Domain Bucket":"< 1K"
   },
   {
     "Class":"Predicate",
-    "Name":"http:\/\/schema.org\/holdingArchive-input",
+    "Name":"https://schema.org/holdingArchive-input",
     "Domain Bucket":"< 1K"
   },
   {
     "Class":"Predicate",
-    "Name":"http:\/\/schema.org\/holdingArchive-output",
+    "Name":"https://schema.org/holdingArchive-output",
     "Domain Bucket":"< 1K"
   },
   {
     "Class":"Predicate",
-    "Name":"http:\/\/schema.org\/homeLocation",
+    "Name":"https://schema.org/homeLocation",
     "Domain Bucket":"10K - 100K"
   },
   {
     "Class":"Predicate",
-    "Name":"http:\/\/schema.org\/homeLocation-input",
+    "Name":"https://schema.org/homeLocation-input",
     "Domain Bucket":"< 1K"
   },
   {
     "Class":"Predicate",
-    "Name":"http:\/\/schema.org\/homeLocation-output",
+    "Name":"https://schema.org/homeLocation-output",
     "Domain Bucket":"< 1K"
   },
   {
     "Class":"Predicate",
-    "Name":"http:\/\/schema.org\/homeTeam",
+    "Name":"https://schema.org/homeTeam",
     "Domain Bucket":"10K - 100K"
   },
   {
     "Class":"Predicate",
-    "Name":"http:\/\/schema.org\/homeTeam-input",
+    "Name":"https://schema.org/homeTeam-input",
     "Domain Bucket":"< 1K"
   },
   {
     "Class":"Predicate",
-    "Name":"http:\/\/schema.org\/homeTeam-output",
+    "Name":"https://schema.org/homeTeam-output",
     "Domain Bucket":"< 1K"
   },
   {
     "Class":"Predicate",
-    "Name":"http:\/\/schema.org\/honorificPrefix",
+    "Name":"https://schema.org/honorificPrefix",
     "Domain Bucket":"10K - 100K"
   },
   {
     "Class":"Predicate",
-    "Name":"http:\/\/schema.org\/honorificPrefix-input",
+    "Name":"https://schema.org/honorificPrefix-input",
     "Domain Bucket":"< 1K"
   },
   {
     "Class":"Predicate",
-    "Name":"http:\/\/schema.org\/honorificPrefix-output",
+    "Name":"https://schema.org/honorificPrefix-output",
     "Domain Bucket":"< 1K"
   },
   {
     "Class":"Predicate",
-    "Name":"http:\/\/schema.org\/honorificSuffix",
+    "Name":"https://schema.org/honorificSuffix",
     "Domain Bucket":"10K - 100K"
   },
   {
     "Class":"Predicate",
-    "Name":"http:\/\/schema.org\/honorificSuffix-input",
+    "Name":"https://schema.org/honorificSuffix-input",
     "Domain Bucket":"< 1K"
   },
   {
     "Class":"Predicate",
-    "Name":"http:\/\/schema.org\/honorificSuffix-output",
+    "Name":"https://schema.org/honorificSuffix-output",
     "Domain Bucket":"< 1K"
   },
   {
     "Class":"Predicate",
-    "Name":"http:\/\/schema.org\/hospitalAffiliation",
+    "Name":"https://schema.org/hospitalAffiliation",
     "Domain Bucket":"1K - 10K"
   },
   {
     "Class":"Predicate",
-    "Name":"http:\/\/schema.org\/hospitalAffiliation-input",
+    "Name":"https://schema.org/hospitalAffiliation-input",
     "Domain Bucket":"< 1K"
   },
   {
     "Class":"Predicate",
-    "Name":"http:\/\/schema.org\/hospitalAffiliation-output",
+    "Name":"https://schema.org/hospitalAffiliation-output",
     "Domain Bucket":"< 1K"
   },
   {
     "Class":"Predicate",
-    "Name":"http:\/\/schema.org\/hostingOrganization",
+    "Name":"https://schema.org/hostingOrganization",
     "Domain Bucket":"1K - 10K"
   },
   {
     "Class":"Predicate",
-    "Name":"http:\/\/schema.org\/hostingOrganization-input",
+    "Name":"https://schema.org/hostingOrganization-input",
     "Domain Bucket":"< 1K"
   },
   {
     "Class":"Predicate",
-    "Name":"http:\/\/schema.org\/hostingOrganization-output",
+    "Name":"https://schema.org/hostingOrganization-output",
     "Domain Bucket":"< 1K"
   },
   {
     "Class":"Predicate",
-    "Name":"http:\/\/schema.org\/hoursAvailable",
+    "Name":"https://schema.org/hoursAvailable",
     "Domain Bucket":"100K - 1M"
   },
   {
     "Class":"Predicate",
-    "Name":"http:\/\/schema.org\/hoursAvailable-input",
+    "Name":"https://schema.org/hoursAvailable-input",
     "Domain Bucket":"< 1K"
   },
   {
     "Class":"Predicate",
-    "Name":"http:\/\/schema.org\/hoursAvailable-output",
+    "Name":"https://schema.org/hoursAvailable-output",
     "Domain Bucket":"< 1K"
   },
   {
     "Class":"Predicate",
-    "Name":"http:\/\/schema.org\/howPerformed",
+    "Name":"https://schema.org/howPerformed",
     "Domain Bucket":"1K - 10K"
   },
   {
     "Class":"Predicate",
-    "Name":"http:\/\/schema.org\/howPerformed-input",
+    "Name":"https://schema.org/howPerformed-input",
     "Domain Bucket":"< 1K"
   },
   {
     "Class":"Predicate",
-    "Name":"http:\/\/schema.org\/howPerformed-output",
+    "Name":"https://schema.org/howPerformed-output",
     "Domain Bucket":"< 1K"
   },
   {
     "Class":"Predicate",
-    "Name":"http:\/\/schema.org\/httpMethod",
+    "Name":"https://schema.org/httpMethod",
     "Domain Bucket":"1K - 10K"
   },
   {
     "Class":"Predicate",
-    "Name":"http:\/\/schema.org\/httpMethod-input",
+    "Name":"https://schema.org/httpMethod-input",
     "Domain Bucket":"< 1K"
   },
   {
     "Class":"Predicate",
-    "Name":"http:\/\/schema.org\/httpMethod-output",
+    "Name":"https://schema.org/httpMethod-output",
     "Domain Bucket":"< 1K"
   },
   {
     "Class":"Predicate",
-    "Name":"http:\/\/schema.org\/iataCode",
+    "Name":"https://schema.org/iataCode",
     "Domain Bucket":"1K - 10K"
   },
   {
     "Class":"Predicate",
-    "Name":"http:\/\/schema.org\/iataCode-input",
+    "Name":"https://schema.org/iataCode-input",
     "Domain Bucket":"< 1K"
   },
   {
     "Class":"Predicate",
-    "Name":"http:\/\/schema.org\/iataCode-output",
+    "Name":"https://schema.org/iataCode-output",
     "Domain Bucket":"< 1K"
   },
   {
     "Class":"Predicate",
-    "Name":"http:\/\/schema.org\/icaoCode",
+    "Name":"https://schema.org/icaoCode",
     "Domain Bucket":"1K - 10K"
   },
   {
     "Class":"Predicate",
-    "Name":"http:\/\/schema.org\/icaoCode-input",
+    "Name":"https://schema.org/icaoCode-input",
     "Domain Bucket":"< 1K"
   },
   {
     "Class":"Predicate",
-    "Name":"http:\/\/schema.org\/icaoCode-output",
+    "Name":"https://schema.org/icaoCode-output",
     "Domain Bucket":"< 1K"
   },
   {
     "Class":"Predicate",
-    "Name":"http:\/\/schema.org\/identifier",
+    "Name":"https://schema.org/identifier",
     "Domain Bucket":"100K - 1M"
   },
   {
     "Class":"Predicate",
-    "Name":"http:\/\/schema.org\/identifier-input",
+    "Name":"https://schema.org/identifier-input",
     "Domain Bucket":"< 1K"
   },
   {
     "Class":"Predicate",
-    "Name":"http:\/\/schema.org\/identifier-output",
+    "Name":"https://schema.org/identifier-output",
     "Domain Bucket":"< 1K"
   },
   {
     "Class":"Predicate",
-    "Name":"http:\/\/schema.org\/identifyingExam",
+    "Name":"https://schema.org/identifyingExam",
     "Domain Bucket":"< 1K"
   },
   {
     "Class":"Predicate",
-    "Name":"http:\/\/schema.org\/identifyingExam-input",
+    "Name":"https://schema.org/identifyingExam-input",
     "Domain Bucket":"< 1K"
   },
   {
     "Class":"Predicate",
-    "Name":"http:\/\/schema.org\/identifyingExam-output",
+    "Name":"https://schema.org/identifyingExam-output",
     "Domain Bucket":"< 1K"
   },
   {
     "Class":"Predicate",
-    "Name":"http:\/\/schema.org\/identifyingTest",
+    "Name":"https://schema.org/identifyingTest",
     "Domain Bucket":"< 1K"
   },
   {
     "Class":"Predicate",
-    "Name":"http:\/\/schema.org\/identifyingTest-input",
+    "Name":"https://schema.org/identifyingTest-input",
     "Domain Bucket":"< 1K"
   },
   {
     "Class":"Predicate",
-    "Name":"http:\/\/schema.org\/identifyingTest-output",
+    "Name":"https://schema.org/identifyingTest-output",
     "Domain Bucket":"< 1K"
   },
   {
     "Class":"Predicate",
-    "Name":"http:\/\/schema.org\/illustrator",
+    "Name":"https://schema.org/illustrator",
     "Domain Bucket":"1K - 10K"
   },
   {
     "Class":"Predicate",
-    "Name":"http:\/\/schema.org\/illustrator-input",
+    "Name":"https://schema.org/illustrator-input",
     "Domain Bucket":"< 1K"
   },
   {
     "Class":"Predicate",
-    "Name":"http:\/\/schema.org\/illustrator-output",
+    "Name":"https://schema.org/illustrator-output",
     "Domain Bucket":"< 1K"
   },
   {
     "Class":"Predicate",
-    "Name":"http:\/\/schema.org\/image",
+    "Name":"https://schema.org/image",
     "Domain Bucket":"10M+"
   },
   {
     "Class":"Predicate",
-    "Name":"http:\/\/schema.org\/image-input",
+    "Name":"https://schema.org/image-input",
     "Domain Bucket":"< 1K"
   },
   {
     "Class":"Predicate",
-    "Name":"http:\/\/schema.org\/image-output",
+    "Name":"https://schema.org/image-output",
     "Domain Bucket":"< 1K"
   },
   {
     "Class":"Predicate",
-    "Name":"http:\/\/schema.org\/imagingTechnique",
+    "Name":"https://schema.org/imagingTechnique",
     "Domain Bucket":"< 1K"
   },
   {
     "Class":"Predicate",
-    "Name":"http:\/\/schema.org\/imagingTechnique-input",
+    "Name":"https://schema.org/imagingTechnique-input",
     "Domain Bucket":"< 1K"
   },
   {
     "Class":"Predicate",
-    "Name":"http:\/\/schema.org\/imagingTechnique-output",
+    "Name":"https://schema.org/imagingTechnique-output",
     "Domain Bucket":"< 1K"
   },
   {
     "Class":"Predicate",
-    "Name":"http:\/\/schema.org\/inAlbum",
+    "Name":"https://schema.org/inAlbum",
     "Domain Bucket":"10K - 100K"
   },
   {
     "Class":"Predicate",
-    "Name":"http:\/\/schema.org\/inAlbum-input",
+    "Name":"https://schema.org/inAlbum-input",
     "Domain Bucket":"< 1K"
   },
   {
     "Class":"Predicate",
-    "Name":"http:\/\/schema.org\/inAlbum-output",
+    "Name":"https://schema.org/inAlbum-output",
     "Domain Bucket":"< 1K"
   },
   {
     "Class":"Predicate",
-    "Name":"http:\/\/schema.org\/inBroadcastLineup",
+    "Name":"https://schema.org/inBroadcastLineup",
     "Domain Bucket":"< 1K"
   },
   {
     "Class":"Predicate",
-    "Name":"http:\/\/schema.org\/inBroadcastLineup-input",
+    "Name":"https://schema.org/inBroadcastLineup-input",
     "Domain Bucket":"< 1K"
   },
   {
     "Class":"Predicate",
-    "Name":"http:\/\/schema.org\/inBroadcastLineup-output",
+    "Name":"https://schema.org/inBroadcastLineup-output",
     "Domain Bucket":"< 1K"
   },
   {
     "Class":"Predicate",
-    "Name":"http:\/\/schema.org\/inChI",
+    "Name":"https://schema.org/inChI",
     "Domain Bucket":"< 1K"
   },
   {
     "Class":"Predicate",
-    "Name":"http:\/\/schema.org\/inChI-input",
+    "Name":"https://schema.org/inChI-input",
     "Domain Bucket":"< 1K"
   },
   {
     "Class":"Predicate",
-    "Name":"http:\/\/schema.org\/inChI-output",
+    "Name":"https://schema.org/inChI-output",
     "Domain Bucket":"< 1K"
   },
   {
     "Class":"Predicate",
-    "Name":"http:\/\/schema.org\/inChIKey",
+    "Name":"https://schema.org/inChIKey",
     "Domain Bucket":"< 1K"
   },
   {
     "Class":"Predicate",
-    "Name":"http:\/\/schema.org\/inChIKey-input",
+    "Name":"https://schema.org/inChIKey-input",
     "Domain Bucket":"< 1K"
   },
   {
     "Class":"Predicate",
-    "Name":"http:\/\/schema.org\/inChIKey-output",
+    "Name":"https://schema.org/inChIKey-output",
     "Domain Bucket":"< 1K"
   },
   {
     "Class":"Predicate",
-    "Name":"http:\/\/schema.org\/inCodeSet",
+    "Name":"https://schema.org/inCodeSet",
     "Domain Bucket":"1K - 10K"
   },
   {
     "Class":"Predicate",
-    "Name":"http:\/\/schema.org\/inCodeSet-input",
+    "Name":"https://schema.org/inCodeSet-input",
     "Domain Bucket":"< 1K"
   },
   {
     "Class":"Predicate",
-    "Name":"http:\/\/schema.org\/inCodeSet-output",
+    "Name":"https://schema.org/inCodeSet-output",
     "Domain Bucket":"< 1K"
   },
   {
     "Class":"Predicate",
-    "Name":"http:\/\/schema.org\/inDefinedTermSet",
+    "Name":"https://schema.org/inDefinedTermSet",
     "Domain Bucket":"10K - 100K"
   },
   {
     "Class":"Predicate",
-    "Name":"http:\/\/schema.org\/inDefinedTermSet-input",
+    "Name":"https://schema.org/inDefinedTermSet-input",
     "Domain Bucket":"< 1K"
   },
   {
     "Class":"Predicate",
-    "Name":"http:\/\/schema.org\/inDefinedTermSet-output",
+    "Name":"https://schema.org/inDefinedTermSet-output",
     "Domain Bucket":"< 1K"
   },
   {
     "Class":"Predicate",
-    "Name":"http:\/\/schema.org\/inLanguage",
+    "Name":"https://schema.org/inLanguage",
     "Domain Bucket":"10M+"
   },
   {
     "Class":"Predicate",
-    "Name":"http:\/\/schema.org\/inLanguage-input",
+    "Name":"https://schema.org/inLanguage-input",
     "Domain Bucket":"< 1K"
   },
   {
     "Class":"Predicate",
-    "Name":"http:\/\/schema.org\/inLanguage-output",
+    "Name":"https://schema.org/inLanguage-output",
     "Domain Bucket":"< 1K"
   },
   {
     "Class":"Predicate",
-    "Name":"http:\/\/schema.org\/inPlaylist",
+    "Name":"https://schema.org/inPlaylist",
     "Domain Bucket":"< 1K"
   },
   {
     "Class":"Predicate",
-    "Name":"http:\/\/schema.org\/inPlaylist-input",
+    "Name":"https://schema.org/inPlaylist-input",
     "Domain Bucket":"< 1K"
   },
   {
     "Class":"Predicate",
-    "Name":"http:\/\/schema.org\/inPlaylist-output",
+    "Name":"https://schema.org/inPlaylist-output",
     "Domain Bucket":"< 1K"
   },
   {
     "Class":"Predicate",
-    "Name":"http:\/\/schema.org\/inProductGroupWithID",
+    "Name":"https://schema.org/inProductGroupWithID",
     "Domain Bucket":"10K - 100K"
   },
   {
     "Class":"Predicate",
-    "Name":"http:\/\/schema.org\/inProductGroupWithID-input",
+    "Name":"https://schema.org/inProductGroupWithID-input",
     "Domain Bucket":"< 1K"
   },
   {
     "Class":"Predicate",
-    "Name":"http:\/\/schema.org\/inProductGroupWithID-output",
+    "Name":"https://schema.org/inProductGroupWithID-output",
     "Domain Bucket":"< 1K"
   },
   {
     "Class":"Predicate",
-    "Name":"http:\/\/schema.org\/inStoreReturnsOffered",
+    "Name":"https://schema.org/inStoreReturnsOffered",
     "Domain Bucket":"1K - 10K"
   },
   {
     "Class":"Predicate",
-    "Name":"http:\/\/schema.org\/inStoreReturnsOffered-input",
+    "Name":"https://schema.org/inStoreReturnsOffered-input",
     "Domain Bucket":"< 1K"
   },
   {
     "Class":"Predicate",
-    "Name":"http:\/\/schema.org\/inStoreReturnsOffered-output",
+    "Name":"https://schema.org/inStoreReturnsOffered-output",
     "Domain Bucket":"< 1K"
   },
   {
     "Class":"Predicate",
-    "Name":"http:\/\/schema.org\/inSupportOf",
+    "Name":"https://schema.org/inSupportOf",
     "Domain Bucket":"< 1K"
   },
   {
     "Class":"Predicate",
-    "Name":"http:\/\/schema.org\/inSupportOf-input",
+    "Name":"https://schema.org/inSupportOf-input",
     "Domain Bucket":"< 1K"
   },
   {
     "Class":"Predicate",
-    "Name":"http:\/\/schema.org\/inSupportOf-output",
+    "Name":"https://schema.org/inSupportOf-output",
     "Domain Bucket":"< 1K"
   },
   {
     "Class":"Predicate",
-    "Name":"http:\/\/schema.org\/incentiveAmount",
+    "Name":"https://schema.org/incentiveAmount",
     "Domain Bucket":"< 1K"
   },
   {
     "Class":"Predicate",
-    "Name":"http:\/\/schema.org\/incentiveAmount-input",
+    "Name":"https://schema.org/incentiveAmount-input",
     "Domain Bucket":"< 1K"
   },
   {
     "Class":"Predicate",
-    "Name":"http:\/\/schema.org\/incentiveAmount-output",
+    "Name":"https://schema.org/incentiveAmount-output",
     "Domain Bucket":"< 1K"
   },
   {
     "Class":"Predicate",
-    "Name":"http:\/\/schema.org\/incentiveCompensation",
+    "Name":"https://schema.org/incentiveCompensation",
     "Domain Bucket":"1K - 10K"
   },
   {
     "Class":"Predicate",
-    "Name":"http:\/\/schema.org\/incentiveCompensation-input",
+    "Name":"https://schema.org/incentiveCompensation-input",
     "Domain Bucket":"< 1K"
   },
   {
     "Class":"Predicate",
-    "Name":"http:\/\/schema.org\/incentiveCompensation-output",
+    "Name":"https://schema.org/incentiveCompensation-output",
     "Domain Bucket":"< 1K"
   },
   {
     "Class":"Predicate",
-    "Name":"http:\/\/schema.org\/incentiveStatus",
+    "Name":"https://schema.org/incentiveStatus",
     "Domain Bucket":"< 1K"
   },
   {
     "Class":"Predicate",
-    "Name":"http:\/\/schema.org\/incentiveStatus-input",
+    "Name":"https://schema.org/incentiveStatus-input",
     "Domain Bucket":"< 1K"
   },
   {
     "Class":"Predicate",
-    "Name":"http:\/\/schema.org\/incentiveStatus-output",
+    "Name":"https://schema.org/incentiveStatus-output",
     "Domain Bucket":"< 1K"
   },
   {
     "Class":"Predicate",
-    "Name":"http:\/\/schema.org\/incentiveType",
+    "Name":"https://schema.org/incentiveType",
     "Domain Bucket":"< 1K"
   },
   {
     "Class":"Predicate",
-    "Name":"http:\/\/schema.org\/incentiveType-input",
+    "Name":"https://schema.org/incentiveType-input",
     "Domain Bucket":"< 1K"
   },
   {
     "Class":"Predicate",
-    "Name":"http:\/\/schema.org\/incentiveType-output",
+    "Name":"https://schema.org/incentiveType-output",
     "Domain Bucket":"< 1K"
   },
   {
     "Class":"Predicate",
-    "Name":"http:\/\/schema.org\/incentives",
+    "Name":"https://schema.org/incentives",
     "Domain Bucket":"< 1K"
   },
   {
     "Class":"Predicate",
-    "Name":"http:\/\/schema.org\/incentives-input",
+    "Name":"https://schema.org/incentives-input",
     "Domain Bucket":"< 1K"
   },
   {
     "Class":"Predicate",
-    "Name":"http:\/\/schema.org\/incentives-output",
+    "Name":"https://schema.org/incentives-output",
     "Domain Bucket":"< 1K"
   },
   {
     "Class":"Predicate",
-    "Name":"http:\/\/schema.org\/incentivizedItem",
+    "Name":"https://schema.org/incentivizedItem",
     "Domain Bucket":"< 1K"
   },
   {
     "Class":"Predicate",
-    "Name":"http:\/\/schema.org\/incentivizedItem-input",
+    "Name":"https://schema.org/incentivizedItem-input",
     "Domain Bucket":"< 1K"
   },
   {
     "Class":"Predicate",
-    "Name":"http:\/\/schema.org\/incentivizedItem-output",
+    "Name":"https://schema.org/incentivizedItem-output",
     "Domain Bucket":"< 1K"
   },
   {
     "Class":"Predicate",
-    "Name":"http:\/\/schema.org\/includedComposition",
+    "Name":"https://schema.org/includedComposition",
     "Domain Bucket":"< 1K"
   },
   {
     "Class":"Predicate",
-    "Name":"http:\/\/schema.org\/includedComposition-input",
+    "Name":"https://schema.org/includedComposition-input",
     "Domain Bucket":"< 1K"
   },
   {
     "Class":"Predicate",
-    "Name":"http:\/\/schema.org\/includedComposition-output",
+    "Name":"https://schema.org/includedComposition-output",
     "Domain Bucket":"< 1K"
   },
   {
     "Class":"Predicate",
-    "Name":"http:\/\/schema.org\/includedDataCatalog",
+    "Name":"https://schema.org/includedDataCatalog",
     "Domain Bucket":"< 1K"
   },
   {
     "Class":"Predicate",
-    "Name":"http:\/\/schema.org\/includedDataCatalog-input",
+    "Name":"https://schema.org/includedDataCatalog-input",
     "Domain Bucket":"< 1K"
   },
   {
     "Class":"Predicate",
-    "Name":"http:\/\/schema.org\/includedDataCatalog-output",
+    "Name":"https://schema.org/includedDataCatalog-output",
     "Domain Bucket":"< 1K"
   },
   {
     "Class":"Predicate",
-    "Name":"http:\/\/schema.org\/includedInDataCatalog",
+    "Name":"https://schema.org/includedInDataCatalog",
     "Domain Bucket":"1K - 10K"
   },
   {
     "Class":"Predicate",
-    "Name":"http:\/\/schema.org\/includedInDataCatalog-input",
+    "Name":"https://schema.org/includedInDataCatalog-input",
     "Domain Bucket":"< 1K"
   },
   {
     "Class":"Predicate",
-    "Name":"http:\/\/schema.org\/includedInDataCatalog-output",
+    "Name":"https://schema.org/includedInDataCatalog-output",
     "Domain Bucket":"< 1K"
   },
   {
     "Class":"Predicate",
-    "Name":"http:\/\/schema.org\/includedInHealthInsurancePlan",
+    "Name":"https://schema.org/includedInHealthInsurancePlan",
     "Domain Bucket":"< 1K"
   },
   {
     "Class":"Predicate",
-    "Name":"http:\/\/schema.org\/includedInHealthInsurancePlan-input",
+    "Name":"https://schema.org/includedInHealthInsurancePlan-input",
     "Domain Bucket":"< 1K"
   },
   {
     "Class":"Predicate",
-    "Name":"http:\/\/schema.org\/includedInHealthInsurancePlan-output",
+    "Name":"https://schema.org/includedInHealthInsurancePlan-output",
     "Domain Bucket":"< 1K"
   },
   {
     "Class":"Predicate",
-    "Name":"http:\/\/schema.org\/includedRiskFactor",
+    "Name":"https://schema.org/includedRiskFactor",
     "Domain Bucket":"< 1K"
   },
   {
     "Class":"Predicate",
-    "Name":"http:\/\/schema.org\/includedRiskFactor-input",
+    "Name":"https://schema.org/includedRiskFactor-input",
     "Domain Bucket":"< 1K"
   },
   {
     "Class":"Predicate",
-    "Name":"http:\/\/schema.org\/includedRiskFactor-output",
+    "Name":"https://schema.org/includedRiskFactor-output",
     "Domain Bucket":"< 1K"
   },
   {
     "Class":"Predicate",
-    "Name":"http:\/\/schema.org\/includesAttraction",
+    "Name":"https://schema.org/includesAttraction",
     "Domain Bucket":"1K - 10K"
   },
   {
     "Class":"Predicate",
-    "Name":"http:\/\/schema.org\/includesAttraction-input",
+    "Name":"https://schema.org/includesAttraction-input",
     "Domain Bucket":"< 1K"
   },
   {
     "Class":"Predicate",
-    "Name":"http:\/\/schema.org\/includesAttraction-output",
+    "Name":"https://schema.org/includesAttraction-output",
     "Domain Bucket":"< 1K"
   },
   {
     "Class":"Predicate",
-    "Name":"http:\/\/schema.org\/includesHealthPlanFormulary",
+    "Name":"https://schema.org/includesHealthPlanFormulary",
     "Domain Bucket":"< 1K"
   },
   {
     "Class":"Predicate",
-    "Name":"http:\/\/schema.org\/includesHealthPlanFormulary-input",
+    "Name":"https://schema.org/includesHealthPlanFormulary-input",
     "Domain Bucket":"< 1K"
   },
   {
     "Class":"Predicate",
-    "Name":"http:\/\/schema.org\/includesHealthPlanFormulary-output",
+    "Name":"https://schema.org/includesHealthPlanFormulary-output",
     "Domain Bucket":"< 1K"
   },
   {
     "Class":"Predicate",
-    "Name":"http:\/\/schema.org\/includesHealthPlanNetwork",
+    "Name":"https://schema.org/includesHealthPlanNetwork",
     "Domain Bucket":"< 1K"
   },
   {
     "Class":"Predicate",
-    "Name":"http:\/\/schema.org\/includesHealthPlanNetwork-input",
+    "Name":"https://schema.org/includesHealthPlanNetwork-input",
     "Domain Bucket":"< 1K"
   },
   {
     "Class":"Predicate",
-    "Name":"http:\/\/schema.org\/includesHealthPlanNetwork-output",
+    "Name":"https://schema.org/includesHealthPlanNetwork-output",
     "Domain Bucket":"< 1K"
   },
   {
     "Class":"Predicate",
-    "Name":"http:\/\/schema.org\/includesObject",
+    "Name":"https://schema.org/includesObject",
     "Domain Bucket":"1K - 10K"
   },
   {
     "Class":"Predicate",
-    "Name":"http:\/\/schema.org\/includesObject-input",
+    "Name":"https://schema.org/includesObject-input",
     "Domain Bucket":"< 1K"
   },
   {
     "Class":"Predicate",
-    "Name":"http:\/\/schema.org\/includesObject-output",
+    "Name":"https://schema.org/includesObject-output",
     "Domain Bucket":"< 1K"
   },
   {
     "Class":"Predicate",
-    "Name":"http:\/\/schema.org\/incomeLimit",
+    "Name":"https://schema.org/incomeLimit",
     "Domain Bucket":"< 1K"
   },
   {
     "Class":"Predicate",
-    "Name":"http:\/\/schema.org\/incomeLimit-input",
+    "Name":"https://schema.org/incomeLimit-input",
     "Domain Bucket":"< 1K"
   },
   {
     "Class":"Predicate",
-    "Name":"http:\/\/schema.org\/incomeLimit-output",
+    "Name":"https://schema.org/incomeLimit-output",
     "Domain Bucket":"< 1K"
   },
   {
     "Class":"Predicate",
-    "Name":"http:\/\/schema.org\/increasesRiskOf",
+    "Name":"https://schema.org/increasesRiskOf",
     "Domain Bucket":"< 1K"
   },
   {
     "Class":"Predicate",
-    "Name":"http:\/\/schema.org\/increasesRiskOf-input",
+    "Name":"https://schema.org/increasesRiskOf-input",
     "Domain Bucket":"< 1K"
   },
   {
     "Class":"Predicate",
-    "Name":"http:\/\/schema.org\/increasesRiskOf-output",
+    "Name":"https://schema.org/increasesRiskOf-output",
     "Domain Bucket":"< 1K"
   },
   {
     "Class":"Predicate",
-    "Name":"http:\/\/schema.org\/industry",
+    "Name":"https://schema.org/industry",
     "Domain Bucket":"10K - 100K"
   },
   {
     "Class":"Predicate",
-    "Name":"http:\/\/schema.org\/industry-input",
+    "Name":"https://schema.org/industry-input",
     "Domain Bucket":"< 1K"
   },
   {
     "Class":"Predicate",
-    "Name":"http:\/\/schema.org\/industry-output",
+    "Name":"https://schema.org/industry-output",
     "Domain Bucket":"< 1K"
   },
   {
     "Class":"Predicate",
-    "Name":"http:\/\/schema.org\/ineligibleRegion",
+    "Name":"https://schema.org/ineligibleRegion",
     "Domain Bucket":"< 1K"
   },
   {
     "Class":"Predicate",
-    "Name":"http:\/\/schema.org\/ineligibleRegion-input",
+    "Name":"https://schema.org/ineligibleRegion-input",
     "Domain Bucket":"< 1K"
   },
   {
     "Class":"Predicate",
-    "Name":"http:\/\/schema.org\/ineligibleRegion-output",
+    "Name":"https://schema.org/ineligibleRegion-output",
     "Domain Bucket":"< 1K"
   },
   {
     "Class":"Predicate",
-    "Name":"http:\/\/schema.org\/infectiousAgent",
+    "Name":"https://schema.org/infectiousAgent",
     "Domain Bucket":"< 1K"
   },
   {
     "Class":"Predicate",
-    "Name":"http:\/\/schema.org\/infectiousAgent-input",
+    "Name":"https://schema.org/infectiousAgent-input",
     "Domain Bucket":"< 1K"
   },
   {
     "Class":"Predicate",
-    "Name":"http:\/\/schema.org\/infectiousAgent-output",
+    "Name":"https://schema.org/infectiousAgent-output",
     "Domain Bucket":"< 1K"
   },
   {
     "Class":"Predicate",
-    "Name":"http:\/\/schema.org\/infectiousAgentClass",
+    "Name":"https://schema.org/infectiousAgentClass",
     "Domain Bucket":"< 1K"
   },
   {
     "Class":"Predicate",
-    "Name":"http:\/\/schema.org\/infectiousAgentClass-input",
+    "Name":"https://schema.org/infectiousAgentClass-input",
     "Domain Bucket":"< 1K"
   },
   {
     "Class":"Predicate",
-    "Name":"http:\/\/schema.org\/infectiousAgentClass-output",
+    "Name":"https://schema.org/infectiousAgentClass-output",
     "Domain Bucket":"< 1K"
   },
   {
     "Class":"Predicate",
-    "Name":"http:\/\/schema.org\/ingredients",
+    "Name":"https://schema.org/ingredients",
     "Domain Bucket":"1K - 10K"
   },
   {
     "Class":"Predicate",
-    "Name":"http:\/\/schema.org\/ingredients-input",
+    "Name":"https://schema.org/ingredients-input",
     "Domain Bucket":"< 1K"
   },
   {
     "Class":"Predicate",
-    "Name":"http:\/\/schema.org\/ingredients-output",
+    "Name":"https://schema.org/ingredients-output",
     "Domain Bucket":"< 1K"
   },
   {
     "Class":"Predicate",
-    "Name":"http:\/\/schema.org\/inker",
+    "Name":"https://schema.org/inker",
     "Domain Bucket":"< 1K"
   },
   {
     "Class":"Predicate",
-    "Name":"http:\/\/schema.org\/inker-input",
+    "Name":"https://schema.org/inker-input",
     "Domain Bucket":"< 1K"
   },
   {
     "Class":"Predicate",
-    "Name":"http:\/\/schema.org\/inker-output",
+    "Name":"https://schema.org/inker-output",
     "Domain Bucket":"< 1K"
   },
   {
     "Class":"Predicate",
-    "Name":"http:\/\/schema.org\/insertion",
+    "Name":"https://schema.org/insertion",
     "Domain Bucket":"< 1K"
   },
   {
     "Class":"Predicate",
-    "Name":"http:\/\/schema.org\/insertion-input",
+    "Name":"https://schema.org/insertion-input",
     "Domain Bucket":"< 1K"
   },
   {
     "Class":"Predicate",
-    "Name":"http:\/\/schema.org\/insertion-output",
+    "Name":"https://schema.org/insertion-output",
     "Domain Bucket":"< 1K"
   },
   {
     "Class":"Predicate",
-    "Name":"http:\/\/schema.org\/installUrl",
+    "Name":"https://schema.org/installUrl",
     "Domain Bucket":"100K - 1M"
   },
   {
     "Class":"Predicate",
-    "Name":"http:\/\/schema.org\/installUrl-input",
+    "Name":"https://schema.org/installUrl-input",
     "Domain Bucket":"< 1K"
   },
   {
     "Class":"Predicate",
-    "Name":"http:\/\/schema.org\/installUrl-output",
+    "Name":"https://schema.org/installUrl-output",
     "Domain Bucket":"< 1K"
   },
   {
     "Class":"Predicate",
-    "Name":"http:\/\/schema.org\/instructor",
+    "Name":"https://schema.org/instructor",
     "Domain Bucket":"10K - 100K"
   },
   {
     "Class":"Predicate",
-    "Name":"http:\/\/schema.org\/instructor-input",
+    "Name":"https://schema.org/instructor-input",
     "Domain Bucket":"< 1K"
   },
   {
     "Class":"Predicate",
-    "Name":"http:\/\/schema.org\/instructor-output",
+    "Name":"https://schema.org/instructor-output",
     "Domain Bucket":"< 1K"
   },
   {
     "Class":"Predicate",
-    "Name":"http:\/\/schema.org\/instrument",
+    "Name":"https://schema.org/instrument",
     "Domain Bucket":"1K - 10K"
   },
   {
     "Class":"Predicate",
-    "Name":"http:\/\/schema.org\/instrument-input",
+    "Name":"https://schema.org/instrument-input",
     "Domain Bucket":"< 1K"
   },
   {
     "Class":"Predicate",
-    "Name":"http:\/\/schema.org\/instrument-output",
+    "Name":"https://schema.org/instrument-output",
     "Domain Bucket":"< 1K"
   },
   {
     "Class":"Predicate",
-    "Name":"http:\/\/schema.org\/intensity",
+    "Name":"https://schema.org/intensity",
     "Domain Bucket":"< 1K"
   },
   {
     "Class":"Predicate",
-    "Name":"http:\/\/schema.org\/intensity-input",
+    "Name":"https://schema.org/intensity-input",
     "Domain Bucket":"< 1K"
   },
   {
     "Class":"Predicate",
-    "Name":"http:\/\/schema.org\/intensity-output",
+    "Name":"https://schema.org/intensity-output",
     "Domain Bucket":"< 1K"
   },
   {
     "Class":"Predicate",
-    "Name":"http:\/\/schema.org\/interactingDrug",
+    "Name":"https://schema.org/interactingDrug",
     "Domain Bucket":"< 1K"
   },
   {
     "Class":"Predicate",
-    "Name":"http:\/\/schema.org\/interactingDrug-input",
+    "Name":"https://schema.org/interactingDrug-input",
     "Domain Bucket":"< 1K"
   },
   {
     "Class":"Predicate",
-    "Name":"http:\/\/schema.org\/interactingDrug-output",
+    "Name":"https://schema.org/interactingDrug-output",
     "Domain Bucket":"< 1K"
   },
   {
     "Class":"Predicate",
-    "Name":"http:\/\/schema.org\/interactionCount",
+    "Name":"https://schema.org/interactionCount",
     "Domain Bucket":"100K - 1M"
   },
   {
     "Class":"Predicate",
-    "Name":"http:\/\/schema.org\/interactionCount-input",
+    "Name":"https://schema.org/interactionCount-input",
     "Domain Bucket":"< 1K"
   },
   {
     "Class":"Predicate",
-    "Name":"http:\/\/schema.org\/interactionCount-output",
+    "Name":"https://schema.org/interactionCount-output",
     "Domain Bucket":"< 1K"
   },
   {
     "Class":"Predicate",
-    "Name":"http:\/\/schema.org\/interactionService",
+    "Name":"https://schema.org/interactionService",
     "Domain Bucket":"< 1K"
   },
   {
     "Class":"Predicate",
-    "Name":"http:\/\/schema.org\/interactionService-input",
+    "Name":"https://schema.org/interactionService-input",
     "Domain Bucket":"< 1K"
   },
   {
     "Class":"Predicate",
-    "Name":"http:\/\/schema.org\/interactionService-output",
+    "Name":"https://schema.org/interactionService-output",
     "Domain Bucket":"< 1K"
   },
   {
     "Class":"Predicate",
-    "Name":"http:\/\/schema.org\/interactionStatistic",
+    "Name":"https://schema.org/interactionStatistic",
     "Domain Bucket":"100K - 1M"
   },
   {
     "Class":"Predicate",
-    "Name":"http:\/\/schema.org\/interactionStatistic-input",
+    "Name":"https://schema.org/interactionStatistic-input",
     "Domain Bucket":"< 1K"
   },
   {
     "Class":"Predicate",
-    "Name":"http:\/\/schema.org\/interactionStatistic-output",
+    "Name":"https://schema.org/interactionStatistic-output",
     "Domain Bucket":"< 1K"
   },
   {
     "Class":"Predicate",
-    "Name":"http:\/\/schema.org\/interactionType",
+    "Name":"https://schema.org/interactionType",
     "Domain Bucket":"100K - 1M"
   },
   {
     "Class":"Predicate",
-    "Name":"http:\/\/schema.org\/interactionType-input",
+    "Name":"https://schema.org/interactionType-input",
     "Domain Bucket":"< 1K"
   },
   {
     "Class":"Predicate",
-    "Name":"http:\/\/schema.org\/interactionType-output",
+    "Name":"https://schema.org/interactionType-output",
     "Domain Bucket":"< 1K"
   },
   {
     "Class":"Predicate",
-    "Name":"http:\/\/schema.org\/interactivityType",
+    "Name":"https://schema.org/interactivityType",
     "Domain Bucket":"1K - 10K"
   },
   {
     "Class":"Predicate",
-    "Name":"http:\/\/schema.org\/interactivityType-input",
+    "Name":"https://schema.org/interactivityType-input",
     "Domain Bucket":"< 1K"
   },
   {
     "Class":"Predicate",
-    "Name":"http:\/\/schema.org\/interactivityType-output",
+    "Name":"https://schema.org/interactivityType-output",
     "Domain Bucket":"< 1K"
   },
   {
     "Class":"Predicate",
-    "Name":"http:\/\/schema.org\/interestRate",
+    "Name":"https://schema.org/interestRate",
     "Domain Bucket":"1K - 10K"
   },
   {
     "Class":"Predicate",
-    "Name":"http:\/\/schema.org\/interestRate-input",
+    "Name":"https://schema.org/interestRate-input",
     "Domain Bucket":"< 1K"
   },
   {
     "Class":"Predicate",
-    "Name":"http:\/\/schema.org\/interestRate-output",
+    "Name":"https://schema.org/interestRate-output",
     "Domain Bucket":"< 1K"
   },
   {
     "Class":"Predicate",
-    "Name":"http:\/\/schema.org\/interpretedAsClaim",
+    "Name":"https://schema.org/interpretedAsClaim",
     "Domain Bucket":"< 1K"
   },
   {
     "Class":"Predicate",
-    "Name":"http:\/\/schema.org\/interpretedAsClaim-input",
+    "Name":"https://schema.org/interpretedAsClaim-input",
     "Domain Bucket":"< 1K"
   },
   {
     "Class":"Predicate",
-    "Name":"http:\/\/schema.org\/interpretedAsClaim-output",
+    "Name":"https://schema.org/interpretedAsClaim-output",
     "Domain Bucket":"< 1K"
   },
   {
     "Class":"Predicate",
-    "Name":"http:\/\/schema.org\/inventoryLevel",
+    "Name":"https://schema.org/inventoryLevel",
     "Domain Bucket":"100K - 1M"
   },
   {
     "Class":"Predicate",
-    "Name":"http:\/\/schema.org\/inventoryLevel-input",
+    "Name":"https://schema.org/inventoryLevel-input",
     "Domain Bucket":"< 1K"
   },
   {
     "Class":"Predicate",
-    "Name":"http:\/\/schema.org\/inventoryLevel-output",
+    "Name":"https://schema.org/inventoryLevel-output",
     "Domain Bucket":"< 1K"
   },
   {
     "Class":"Predicate",
-    "Name":"http:\/\/schema.org\/inverseOf",
+    "Name":"https://schema.org/inverseOf",
     "Domain Bucket":"< 1K"
   },
   {
     "Class":"Predicate",
-    "Name":"http:\/\/schema.org\/inverseOf-input",
+    "Name":"https://schema.org/inverseOf-input",
     "Domain Bucket":"< 1K"
   },
   {
     "Class":"Predicate",
-    "Name":"http:\/\/schema.org\/inverseOf-output",
+    "Name":"https://schema.org/inverseOf-output",
     "Domain Bucket":"< 1K"
   },
   {
     "Class":"Predicate",
-    "Name":"http:\/\/schema.org\/isAcceptingNewPatients",
+    "Name":"https://schema.org/isAcceptingNewPatients",
     "Domain Bucket":"10K - 100K"
   },
   {
     "Class":"Predicate",
-    "Name":"http:\/\/schema.org\/isAcceptingNewPatients-input",
+    "Name":"https://schema.org/isAcceptingNewPatients-input",
     "Domain Bucket":"< 1K"
   },
   {
     "Class":"Predicate",
-    "Name":"http:\/\/schema.org\/isAcceptingNewPatients-output",
+    "Name":"https://schema.org/isAcceptingNewPatients-output",
     "Domain Bucket":"< 1K"
   },
   {
     "Class":"Predicate",
-    "Name":"http:\/\/schema.org\/isAccessibleForFree",
+    "Name":"https://schema.org/isAccessibleForFree",
     "Domain Bucket":"100K - 1M"
   },
   {
     "Class":"Predicate",
-    "Name":"http:\/\/schema.org\/isAccessibleForFree-input",
+    "Name":"https://schema.org/isAccessibleForFree-input",
     "Domain Bucket":"< 1K"
   },
   {
     "Class":"Predicate",
-    "Name":"http:\/\/schema.org\/isAccessibleForFree-output",
+    "Name":"https://schema.org/isAccessibleForFree-output",
     "Domain Bucket":"< 1K"
   },
   {
     "Class":"Predicate",
-    "Name":"http:\/\/schema.org\/isAccessoryOrSparePartFor",
+    "Name":"https://schema.org/isAccessoryOrSparePartFor",
     "Domain Bucket":"1K - 10K"
   },
   {
     "Class":"Predicate",
-    "Name":"http:\/\/schema.org\/isAccessoryOrSparePartFor-input",
+    "Name":"https://schema.org/isAccessoryOrSparePartFor-input",
     "Domain Bucket":"< 1K"
   },
   {
     "Class":"Predicate",
-    "Name":"http:\/\/schema.org\/isAccessoryOrSparePartFor-output",
+    "Name":"https://schema.org/isAccessoryOrSparePartFor-output",
     "Domain Bucket":"< 1K"
   },
   {
     "Class":"Predicate",
-    "Name":"http:\/\/schema.org\/isAvailableGenerically",
+    "Name":"https://schema.org/isAvailableGenerically",
     "Domain Bucket":"< 1K"
   },
   {
     "Class":"Predicate",
-    "Name":"http:\/\/schema.org\/isAvailableGenerically-input",
+    "Name":"https://schema.org/isAvailableGenerically-input",
     "Domain Bucket":"< 1K"
   },
   {
     "Class":"Predicate",
-    "Name":"http:\/\/schema.org\/isAvailableGenerically-output",
+    "Name":"https://schema.org/isAvailableGenerically-output",
     "Domain Bucket":"< 1K"
   },
   {
     "Class":"Predicate",
-    "Name":"http:\/\/schema.org\/isBasedOn",
+    "Name":"https://schema.org/isBasedOn",
     "Domain Bucket":"10K - 100K"
   },
   {
     "Class":"Predicate",
-    "Name":"http:\/\/schema.org\/isBasedOn-input",
+    "Name":"https://schema.org/isBasedOn-input",
     "Domain Bucket":"< 1K"
   },
   {
     "Class":"Predicate",
-    "Name":"http:\/\/schema.org\/isBasedOn-output",
+    "Name":"https://schema.org/isBasedOn-output",
     "Domain Bucket":"< 1K"
   },
   {
     "Class":"Predicate",
-    "Name":"http:\/\/schema.org\/isBasedOnUrl",
+    "Name":"https://schema.org/isBasedOnUrl",
     "Domain Bucket":"< 1K"
   },
   {
     "Class":"Predicate",
-    "Name":"http:\/\/schema.org\/isBasedOnUrl-input",
+    "Name":"https://schema.org/isBasedOnUrl-input",
     "Domain Bucket":"< 1K"
   },
   {
     "Class":"Predicate",
-    "Name":"http:\/\/schema.org\/isBasedOnUrl-output",
+    "Name":"https://schema.org/isBasedOnUrl-output",
     "Domain Bucket":"< 1K"
   },
   {
     "Class":"Predicate",
-    "Name":"http:\/\/schema.org\/isConsumableFor",
+    "Name":"https://schema.org/isConsumableFor",
     "Domain Bucket":"< 1K"
   },
   {
     "Class":"Predicate",
-    "Name":"http:\/\/schema.org\/isConsumableFor-input",
+    "Name":"https://schema.org/isConsumableFor-input",
     "Domain Bucket":"< 1K"
   },
   {
     "Class":"Predicate",
-    "Name":"http:\/\/schema.org\/isConsumableFor-output",
+    "Name":"https://schema.org/isConsumableFor-output",
     "Domain Bucket":"< 1K"
   },
   {
     "Class":"Predicate",
-    "Name":"http:\/\/schema.org\/isEncodedByBioChemEntity",
+    "Name":"https://schema.org/isEncodedByBioChemEntity",
     "Domain Bucket":"< 1K"
   },
   {
     "Class":"Predicate",
-    "Name":"http:\/\/schema.org\/isEncodedByBioChemEntity-input",
+    "Name":"https://schema.org/isEncodedByBioChemEntity-input",
     "Domain Bucket":"< 1K"
   },
   {
     "Class":"Predicate",
-    "Name":"http:\/\/schema.org\/isEncodedByBioChemEntity-output",
+    "Name":"https://schema.org/isEncodedByBioChemEntity-output",
     "Domain Bucket":"< 1K"
   },
   {
     "Class":"Predicate",
-    "Name":"http:\/\/schema.org\/isFamilyFriendly",
+    "Name":"https://schema.org/isFamilyFriendly",
     "Domain Bucket":"100K - 1M"
   },
   {
     "Class":"Predicate",
-    "Name":"http:\/\/schema.org\/isFamilyFriendly-input",
+    "Name":"https://schema.org/isFamilyFriendly-input",
     "Domain Bucket":"< 1K"
   },
   {
     "Class":"Predicate",
-    "Name":"http:\/\/schema.org\/isFamilyFriendly-output",
+    "Name":"https://schema.org/isFamilyFriendly-output",
     "Domain Bucket":"< 1K"
   },
   {
     "Class":"Predicate",
-    "Name":"http:\/\/schema.org\/isGift",
+    "Name":"https://schema.org/isGift",
     "Domain Bucket":"< 1K"
   },
   {
     "Class":"Predicate",
-    "Name":"http:\/\/schema.org\/isGift-input",
+    "Name":"https://schema.org/isGift-input",
     "Domain Bucket":"< 1K"
   },
   {
     "Class":"Predicate",
-    "Name":"http:\/\/schema.org\/isGift-output",
+    "Name":"https://schema.org/isGift-output",
     "Domain Bucket":"< 1K"
   },
   {
     "Class":"Predicate",
-    "Name":"http:\/\/schema.org\/isInvolvedInBiologicalProcess",
+    "Name":"https://schema.org/isInvolvedInBiologicalProcess",
     "Domain Bucket":"< 1K"
   },
   {
     "Class":"Predicate",
-    "Name":"http:\/\/schema.org\/isInvolvedInBiologicalProcess-input",
+    "Name":"https://schema.org/isInvolvedInBiologicalProcess-input",
     "Domain Bucket":"< 1K"
   },
   {
     "Class":"Predicate",
-    "Name":"http:\/\/schema.org\/isInvolvedInBiologicalProcess-output",
+    "Name":"https://schema.org/isInvolvedInBiologicalProcess-output",
     "Domain Bucket":"< 1K"
   },
   {
     "Class":"Predicate",
-    "Name":"http:\/\/schema.org\/isLiveBroadcast",
+    "Name":"https://schema.org/isLiveBroadcast",
     "Domain Bucket":"10K - 100K"
   },
   {
     "Class":"Predicate",
-    "Name":"http:\/\/schema.org\/isLiveBroadcast-input",
+    "Name":"https://schema.org/isLiveBroadcast-input",
     "Domain Bucket":"< 1K"
   },
   {
     "Class":"Predicate",
-    "Name":"http:\/\/schema.org\/isLiveBroadcast-output",
+    "Name":"https://schema.org/isLiveBroadcast-output",
     "Domain Bucket":"< 1K"
   },
   {
     "Class":"Predicate",
-    "Name":"http:\/\/schema.org\/isLocatedInSubcellularLocation",
+    "Name":"https://schema.org/isLocatedInSubcellularLocation",
     "Domain Bucket":"< 1K"
   },
   {
     "Class":"Predicate",
-    "Name":"http:\/\/schema.org\/isLocatedInSubcellularLocation-input",
+    "Name":"https://schema.org/isLocatedInSubcellularLocation-input",
     "Domain Bucket":"< 1K"
   },
   {
     "Class":"Predicate",
-    "Name":"http:\/\/schema.org\/isLocatedInSubcellularLocation-output",
+    "Name":"https://schema.org/isLocatedInSubcellularLocation-output",
     "Domain Bucket":"< 1K"
   },
   {
     "Class":"Predicate",
-    "Name":"http:\/\/schema.org\/isPartOf",
+    "Name":"https://schema.org/isPartOf",
     "Domain Bucket":"10M+"
   },
   {
     "Class":"Predicate",
-    "Name":"http:\/\/schema.org\/isPartOf-input",
+    "Name":"https://schema.org/isPartOf-input",
     "Domain Bucket":"< 1K"
   },
   {
     "Class":"Predicate",
-    "Name":"http:\/\/schema.org\/isPartOf-output",
+    "Name":"https://schema.org/isPartOf-output",
     "Domain Bucket":"< 1K"
   },
   {
     "Class":"Predicate",
-    "Name":"http:\/\/schema.org\/isPartOfBioChemEntity",
+    "Name":"https://schema.org/isPartOfBioChemEntity",
     "Domain Bucket":"< 1K"
   },
   {
     "Class":"Predicate",
-    "Name":"http:\/\/schema.org\/isPartOfBioChemEntity-input",
+    "Name":"https://schema.org/isPartOfBioChemEntity-input",
     "Domain Bucket":"< 1K"
   },
   {
     "Class":"Predicate",
-    "Name":"http:\/\/schema.org\/isPartOfBioChemEntity-output",
+    "Name":"https://schema.org/isPartOfBioChemEntity-output",
     "Domain Bucket":"< 1K"
   },
   {
     "Class":"Predicate",
-    "Name":"http:\/\/schema.org\/isPlanForApartment",
+    "Name":"https://schema.org/isPlanForApartment",
     "Domain Bucket":"< 1K"
   },
   {
     "Class":"Predicate",
-    "Name":"http:\/\/schema.org\/isPlanForApartment-input",
+    "Name":"https://schema.org/isPlanForApartment-input",
     "Domain Bucket":"< 1K"
   },
   {
     "Class":"Predicate",
-    "Name":"http:\/\/schema.org\/isPlanForApartment-output",
+    "Name":"https://schema.org/isPlanForApartment-output",
     "Domain Bucket":"< 1K"
   },
   {
     "Class":"Predicate",
-    "Name":"http:\/\/schema.org\/isProprietary",
+    "Name":"https://schema.org/isProprietary",
     "Domain Bucket":"< 1K"
   },
   {
     "Class":"Predicate",
-    "Name":"http:\/\/schema.org\/isProprietary-input",
+    "Name":"https://schema.org/isProprietary-input",
     "Domain Bucket":"< 1K"
   },
   {
     "Class":"Predicate",
-    "Name":"http:\/\/schema.org\/isProprietary-output",
+    "Name":"https://schema.org/isProprietary-output",
     "Domain Bucket":"< 1K"
   },
   {
     "Class":"Predicate",
-    "Name":"http:\/\/schema.org\/isRelatedTo",
+    "Name":"https://schema.org/isRelatedTo",
     "Domain Bucket":"100K - 1M"
   },
   {
     "Class":"Predicate",
-    "Name":"http:\/\/schema.org\/isRelatedTo-input",
+    "Name":"https://schema.org/isRelatedTo-input",
     "Domain Bucket":"< 1K"
   },
   {
     "Class":"Predicate",
-    "Name":"http:\/\/schema.org\/isRelatedTo-output",
+    "Name":"https://schema.org/isRelatedTo-output",
     "Domain Bucket":"< 1K"
   },
   {
     "Class":"Predicate",
-    "Name":"http:\/\/schema.org\/isResizable",
+    "Name":"https://schema.org/isResizable",
     "Domain Bucket":"< 1K"
   },
   {
     "Class":"Predicate",
-    "Name":"http:\/\/schema.org\/isResizable-input",
+    "Name":"https://schema.org/isResizable-input",
     "Domain Bucket":"< 1K"
   },
   {
     "Class":"Predicate",
-    "Name":"http:\/\/schema.org\/isResizable-output",
+    "Name":"https://schema.org/isResizable-output",
     "Domain Bucket":"< 1K"
   },
   {
     "Class":"Predicate",
-    "Name":"http:\/\/schema.org\/isSimilarTo",
+    "Name":"https://schema.org/isSimilarTo",
     "Domain Bucket":"1K - 10K"
   },
   {
     "Class":"Predicate",
-    "Name":"http:\/\/schema.org\/isSimilarTo-input",
+    "Name":"https://schema.org/isSimilarTo-input",
     "Domain Bucket":"< 1K"
   },
   {
     "Class":"Predicate",
-    "Name":"http:\/\/schema.org\/isSimilarTo-output",
+    "Name":"https://schema.org/isSimilarTo-output",
     "Domain Bucket":"< 1K"
   },
   {
     "Class":"Predicate",
-    "Name":"http:\/\/schema.org\/isStoreOn",
+    "Name":"https://schema.org/isStoreOn",
     "Domain Bucket":"< 1K"
   },
   {
     "Class":"Predicate",
-    "Name":"http:\/\/schema.org\/isStoreOn-input",
+    "Name":"https://schema.org/isStoreOn-input",
     "Domain Bucket":"< 1K"
   },
   {
     "Class":"Predicate",
-    "Name":"http:\/\/schema.org\/isStoreOn-output",
+    "Name":"https://schema.org/isStoreOn-output",
     "Domain Bucket":"< 1K"
   },
   {
     "Class":"Predicate",
-    "Name":"http:\/\/schema.org\/isTierOf",
+    "Name":"https://schema.org/isTierOf",
     "Domain Bucket":"< 1K"
   },
   {
     "Class":"Predicate",
-    "Name":"http:\/\/schema.org\/isTierOf-input",
+    "Name":"https://schema.org/isTierOf-input",
     "Domain Bucket":"< 1K"
   },
   {
     "Class":"Predicate",
-    "Name":"http:\/\/schema.org\/isTierOf-output",
+    "Name":"https://schema.org/isTierOf-output",
     "Domain Bucket":"< 1K"
   },
   {
     "Class":"Predicate",
-    "Name":"http:\/\/schema.org\/isUnlabelledFallback",
+    "Name":"https://schema.org/isUnlabelledFallback",
     "Domain Bucket":"< 1K"
   },
   {
     "Class":"Predicate",
-    "Name":"http:\/\/schema.org\/isUnlabelledFallback-input",
+    "Name":"https://schema.org/isUnlabelledFallback-input",
     "Domain Bucket":"< 1K"
   },
   {
     "Class":"Predicate",
-    "Name":"http:\/\/schema.org\/isUnlabelledFallback-output",
+    "Name":"https://schema.org/isUnlabelledFallback-output",
     "Domain Bucket":"< 1K"
   },
   {
     "Class":"Predicate",
-    "Name":"http:\/\/schema.org\/isVariantOf",
+    "Name":"https://schema.org/isVariantOf",
     "Domain Bucket":"10K - 100K"
   },
   {
     "Class":"Predicate",
-    "Name":"http:\/\/schema.org\/isVariantOf-input",
+    "Name":"https://schema.org/isVariantOf-input",
     "Domain Bucket":"< 1K"
   },
   {
     "Class":"Predicate",
-    "Name":"http:\/\/schema.org\/isVariantOf-output",
+    "Name":"https://schema.org/isVariantOf-output",
     "Domain Bucket":"< 1K"
   },
   {
     "Class":"Predicate",
-    "Name":"http:\/\/schema.org\/isbn",
+    "Name":"https://schema.org/isbn",
     "Domain Bucket":"10K - 100K"
   },
   {
     "Class":"Predicate",
-    "Name":"http:\/\/schema.org\/isbn-input",
+    "Name":"https://schema.org/isbn-input",
     "Domain Bucket":"< 1K"
   },
   {
     "Class":"Predicate",
-    "Name":"http:\/\/schema.org\/isbn-output",
+    "Name":"https://schema.org/isbn-output",
     "Domain Bucket":"< 1K"
   },
   {
     "Class":"Predicate",
-    "Name":"http:\/\/schema.org\/isicV4",
+    "Name":"https://schema.org/isicV4",
     "Domain Bucket":"1K - 10K"
   },
   {
     "Class":"Predicate",
-    "Name":"http:\/\/schema.org\/isicV4-input",
+    "Name":"https://schema.org/isicV4-input",
     "Domain Bucket":"< 1K"
   },
   {
     "Class":"Predicate",
-    "Name":"http:\/\/schema.org\/isicV4-output",
+    "Name":"https://schema.org/isicV4-output",
     "Domain Bucket":"< 1K"
   },
   {
     "Class":"Predicate",
-    "Name":"http:\/\/schema.org\/iso6523Code",
+    "Name":"https://schema.org/iso6523Code",
     "Domain Bucket":"1K - 10K"
   },
   {
     "Class":"Predicate",
-    "Name":"http:\/\/schema.org\/iso6523Code-input",
+    "Name":"https://schema.org/iso6523Code-input",
     "Domain Bucket":"< 1K"
   },
   {
     "Class":"Predicate",
-    "Name":"http:\/\/schema.org\/iso6523Code-output",
+    "Name":"https://schema.org/iso6523Code-output",
     "Domain Bucket":"< 1K"
   },
   {
     "Class":"Predicate",
-    "Name":"http:\/\/schema.org\/isrcCode",
+    "Name":"https://schema.org/isrcCode",
     "Domain Bucket":"< 1K"
   },
   {
     "Class":"Predicate",
-    "Name":"http:\/\/schema.org\/isrcCode-input",
+    "Name":"https://schema.org/isrcCode-input",
     "Domain Bucket":"< 1K"
   },
   {
     "Class":"Predicate",
-    "Name":"http:\/\/schema.org\/isrcCode-output",
+    "Name":"https://schema.org/isrcCode-output",
     "Domain Bucket":"< 1K"
   },
   {
     "Class":"Predicate",
-    "Name":"http:\/\/schema.org\/issn",
+    "Name":"https://schema.org/issn",
     "Domain Bucket":"1K - 10K"
   },
   {
     "Class":"Predicate",
-    "Name":"http:\/\/schema.org\/issn-input",
+    "Name":"https://schema.org/issn-input",
     "Domain Bucket":"< 1K"
   },
   {
     "Class":"Predicate",
-    "Name":"http:\/\/schema.org\/issn-output",
+    "Name":"https://schema.org/issn-output",
     "Domain Bucket":"< 1K"
   },
   {
     "Class":"Predicate",
-    "Name":"http:\/\/schema.org\/issueNumber",
+    "Name":"https://schema.org/issueNumber",
     "Domain Bucket":"1K - 10K"
   },
   {
     "Class":"Predicate",
-    "Name":"http:\/\/schema.org\/issueNumber-input",
+    "Name":"https://schema.org/issueNumber-input",
     "Domain Bucket":"< 1K"
   },
   {
     "Class":"Predicate",
-    "Name":"http:\/\/schema.org\/issueNumber-output",
+    "Name":"https://schema.org/issueNumber-output",
     "Domain Bucket":"< 1K"
   },
   {
     "Class":"Predicate",
-    "Name":"http:\/\/schema.org\/issuedBy",
+    "Name":"https://schema.org/issuedBy",
     "Domain Bucket":"10K - 100K"
   },
   {
     "Class":"Predicate",
-    "Name":"http:\/\/schema.org\/issuedBy-input",
+    "Name":"https://schema.org/issuedBy-input",
     "Domain Bucket":"< 1K"
   },
   {
     "Class":"Predicate",
-    "Name":"http:\/\/schema.org\/issuedBy-output",
+    "Name":"https://schema.org/issuedBy-output",
     "Domain Bucket":"< 1K"
   },
   {
     "Class":"Predicate",
-    "Name":"http:\/\/schema.org\/issuedThrough",
+    "Name":"https://schema.org/issuedThrough",
     "Domain Bucket":"< 1K"
   },
   {
     "Class":"Predicate",
-    "Name":"http:\/\/schema.org\/issuedThrough-input",
+    "Name":"https://schema.org/issuedThrough-input",
     "Domain Bucket":"< 1K"
   },
   {
     "Class":"Predicate",
-    "Name":"http:\/\/schema.org\/issuedThrough-output",
+    "Name":"https://schema.org/issuedThrough-output",
     "Domain Bucket":"< 1K"
   },
   {
     "Class":"Predicate",
-    "Name":"http:\/\/schema.org\/iswcCode",
+    "Name":"https://schema.org/iswcCode",
     "Domain Bucket":"< 1K"
   },
   {
     "Class":"Predicate",
-    "Name":"http:\/\/schema.org\/iswcCode-input",
+    "Name":"https://schema.org/iswcCode-input",
     "Domain Bucket":"< 1K"
   },
   {
     "Class":"Predicate",
-    "Name":"http:\/\/schema.org\/iswcCode-output",
+    "Name":"https://schema.org/iswcCode-output",
     "Domain Bucket":"< 1K"
   },
   {
     "Class":"Predicate",
-    "Name":"http:\/\/schema.org\/item",
+    "Name":"https://schema.org/item",
     "Domain Bucket":"10M+"
   },
   {
     "Class":"Predicate",
-    "Name":"http:\/\/schema.org\/item-input",
+    "Name":"https://schema.org/item-input",
     "Domain Bucket":"< 1K"
   },
   {
     "Class":"Predicate",
-    "Name":"http:\/\/schema.org\/item-output",
+    "Name":"https://schema.org/item-output",
     "Domain Bucket":"< 1K"
   },
   {
     "Class":"Predicate",
-    "Name":"http:\/\/schema.org\/itemCondition",
+    "Name":"https://schema.org/itemCondition",
     "Domain Bucket":"1M - 10M"
   },
   {
     "Class":"Predicate",
-    "Name":"http:\/\/schema.org\/itemCondition-input",
+    "Name":"https://schema.org/itemCondition-input",
     "Domain Bucket":"< 1K"
   },
   {
     "Class":"Predicate",
-    "Name":"http:\/\/schema.org\/itemCondition-output",
+    "Name":"https://schema.org/itemCondition-output",
     "Domain Bucket":"< 1K"
   },
   {
     "Class":"Predicate",
-    "Name":"http:\/\/schema.org\/itemDefectReturnFees",
+    "Name":"https://schema.org/itemDefectReturnFees",
     "Domain Bucket":"1K - 10K"
   },
   {
     "Class":"Predicate",
-    "Name":"http:\/\/schema.org\/itemDefectReturnFees-input",
+    "Name":"https://schema.org/itemDefectReturnFees-input",
     "Domain Bucket":"< 1K"
   },
   {
     "Class":"Predicate",
-    "Name":"http:\/\/schema.org\/itemDefectReturnFees-output",
+    "Name":"https://schema.org/itemDefectReturnFees-output",
     "Domain Bucket":"< 1K"
   },
   {
     "Class":"Predicate",
-    "Name":"http:\/\/schema.org\/itemDefectReturnLabelSource",
+    "Name":"https://schema.org/itemDefectReturnLabelSource",
     "Domain Bucket":"< 1K"
   },
   {
     "Class":"Predicate",
-    "Name":"http:\/\/schema.org\/itemDefectReturnLabelSource-input",
+    "Name":"https://schema.org/itemDefectReturnLabelSource-input",
     "Domain Bucket":"< 1K"
   },
   {
     "Class":"Predicate",
-    "Name":"http:\/\/schema.org\/itemDefectReturnLabelSource-output",
+    "Name":"https://schema.org/itemDefectReturnLabelSource-output",
     "Domain Bucket":"< 1K"
   },
   {
     "Class":"Predicate",
-    "Name":"http:\/\/schema.org\/itemDefectReturnShippingFeesAmount",
+    "Name":"https://schema.org/itemDefectReturnShippingFeesAmount",
     "Domain Bucket":"< 1K"
   },
   {
     "Class":"Predicate",
-    "Name":"http:\/\/schema.org\/itemDefectReturnShippingFeesAmount-input",
+    "Name":"https://schema.org/itemDefectReturnShippingFeesAmount-input",
     "Domain Bucket":"< 1K"
   },
   {
     "Class":"Predicate",
-    "Name":"http:\/\/schema.org\/itemDefectReturnShippingFeesAmount-output",
+    "Name":"https://schema.org/itemDefectReturnShippingFeesAmount-output",
     "Domain Bucket":"< 1K"
   },
   {
     "Class":"Predicate",
-    "Name":"http:\/\/schema.org\/itemListElement",
+    "Name":"https://schema.org/itemListElement",
     "Domain Bucket":"10M+"
   },
   {
     "Class":"Predicate",
-    "Name":"http:\/\/schema.org\/itemListElement-input",
+    "Name":"https://schema.org/itemListElement-input",
     "Domain Bucket":"< 1K"
   },
   {
     "Class":"Predicate",
-    "Name":"http:\/\/schema.org\/itemListElement-output",
+    "Name":"https://schema.org/itemListElement-output",
     "Domain Bucket":"< 1K"
   },
   {
     "Class":"Predicate",
-    "Name":"http:\/\/schema.org\/itemListOrder",
+    "Name":"https://schema.org/itemListOrder",
     "Domain Bucket":"100K - 1M"
   },
   {
     "Class":"Predicate",
-    "Name":"http:\/\/schema.org\/itemListOrder-input",
+    "Name":"https://schema.org/itemListOrder-input",
     "Domain Bucket":"< 1K"
   },
   {
     "Class":"Predicate",
-    "Name":"http:\/\/schema.org\/itemListOrder-output",
+    "Name":"https://schema.org/itemListOrder-output",
     "Domain Bucket":"< 1K"
   },
   {
     "Class":"Predicate",
-    "Name":"http:\/\/schema.org\/itemLocation",
+    "Name":"https://schema.org/itemLocation",
     "Domain Bucket":"< 1K"
   },
   {
     "Class":"Predicate",
-    "Name":"http:\/\/schema.org\/itemLocation-input",
+    "Name":"https://schema.org/itemLocation-input",
     "Domain Bucket":"< 1K"
   },
   {
     "Class":"Predicate",
-    "Name":"http:\/\/schema.org\/itemLocation-output",
+    "Name":"https://schema.org/itemLocation-output",
     "Domain Bucket":"< 1K"
   },
   {
     "Class":"Predicate",
-    "Name":"http:\/\/schema.org\/itemOffered",
+    "Name":"https://schema.org/itemOffered",
     "Domain Bucket":"100K - 1M"
   },
   {
     "Class":"Predicate",
-    "Name":"http:\/\/schema.org\/itemOffered-input",
+    "Name":"https://schema.org/itemOffered-input",
     "Domain Bucket":"< 1K"
   },
   {
     "Class":"Predicate",
-    "Name":"http:\/\/schema.org\/itemOffered-output",
+    "Name":"https://schema.org/itemOffered-output",
     "Domain Bucket":"< 1K"
   },
   {
     "Class":"Predicate",
-    "Name":"http:\/\/schema.org\/itemReviewed",
+    "Name":"https://schema.org/itemReviewed",
     "Domain Bucket":"100K - 1M"
   },
   {
     "Class":"Predicate",
-    "Name":"http:\/\/schema.org\/itemReviewed-input",
+    "Name":"https://schema.org/itemReviewed-input",
     "Domain Bucket":"< 1K"
   },
   {
     "Class":"Predicate",
-    "Name":"http:\/\/schema.org\/itemReviewed-output",
+    "Name":"https://schema.org/itemReviewed-output",
     "Domain Bucket":"< 1K"
   },
   {
     "Class":"Predicate",
-    "Name":"http:\/\/schema.org\/itemShipped",
+    "Name":"https://schema.org/itemShipped",
     "Domain Bucket":"< 1K"
   },
   {
     "Class":"Predicate",
-    "Name":"http:\/\/schema.org\/itemShipped-input",
+    "Name":"https://schema.org/itemShipped-input",
     "Domain Bucket":"< 1K"
   },
   {
     "Class":"Predicate",
-    "Name":"http:\/\/schema.org\/itemShipped-output",
+    "Name":"https://schema.org/itemShipped-output",
     "Domain Bucket":"< 1K"
   },
   {
     "Class":"Predicate",
-    "Name":"http:\/\/schema.org\/itinerary",
+    "Name":"https://schema.org/itinerary",
     "Domain Bucket":"10K - 100K"
   },
   {
     "Class":"Predicate",
-    "Name":"http:\/\/schema.org\/itinerary-input",
+    "Name":"https://schema.org/itinerary-input",
     "Domain Bucket":"< 1K"
   },
   {
     "Class":"Predicate",
-    "Name":"http:\/\/schema.org\/itinerary-output",
+    "Name":"https://schema.org/itinerary-output",
     "Domain Bucket":"< 1K"
   },
   {
     "Class":"Predicate",
-    "Name":"http:\/\/schema.org\/iupacName",
+    "Name":"https://schema.org/iupacName",
     "Domain Bucket":"< 1K"
   },
   {
     "Class":"Predicate",
-    "Name":"http:\/\/schema.org\/iupacName-input",
+    "Name":"https://schema.org/iupacName-input",
     "Domain Bucket":"< 1K"
   },
   {
     "Class":"Predicate",
-    "Name":"http:\/\/schema.org\/iupacName-output",
+    "Name":"https://schema.org/iupacName-output",
     "Domain Bucket":"< 1K"
   },
   {
     "Class":"Predicate",
-    "Name":"http:\/\/schema.org\/jobBenefits",
+    "Name":"https://schema.org/jobBenefits",
     "Domain Bucket":"10K - 100K"
   },
   {
     "Class":"Predicate",
-    "Name":"http:\/\/schema.org\/jobBenefits-input",
+    "Name":"https://schema.org/jobBenefits-input",
     "Domain Bucket":"< 1K"
   },
   {
     "Class":"Predicate",
-    "Name":"http:\/\/schema.org\/jobBenefits-output",
+    "Name":"https://schema.org/jobBenefits-output",
     "Domain Bucket":"< 1K"
   },
   {
     "Class":"Predicate",
-    "Name":"http:\/\/schema.org\/jobDuration",
+    "Name":"https://schema.org/jobDuration",
     "Domain Bucket":"< 1K"
   },
   {
     "Class":"Predicate",
-    "Name":"http:\/\/schema.org\/jobDuration-input",
+    "Name":"https://schema.org/jobDuration-input",
     "Domain Bucket":"< 1K"
   },
   {
     "Class":"Predicate",
-    "Name":"http:\/\/schema.org\/jobDuration-output",
+    "Name":"https://schema.org/jobDuration-output",
     "Domain Bucket":"< 1K"
   },
   {
     "Class":"Predicate",
-    "Name":"http:\/\/schema.org\/jobImmediateStart",
+    "Name":"https://schema.org/jobImmediateStart",
     "Domain Bucket":"1K - 10K"
   },
   {
     "Class":"Predicate",
-    "Name":"http:\/\/schema.org\/jobImmediateStart-input",
+    "Name":"https://schema.org/jobImmediateStart-input",
     "Domain Bucket":"< 1K"
   },
   {
     "Class":"Predicate",
-    "Name":"http:\/\/schema.org\/jobImmediateStart-output",
+    "Name":"https://schema.org/jobImmediateStart-output",
     "Domain Bucket":"< 1K"
   },
   {
     "Class":"Predicate",
-    "Name":"http:\/\/schema.org\/jobLocation",
+    "Name":"https://schema.org/jobLocation",
     "Domain Bucket":"100K - 1M"
   },
   {
     "Class":"Predicate",
-    "Name":"http:\/\/schema.org\/jobLocation-input",
+    "Name":"https://schema.org/jobLocation-input",
     "Domain Bucket":"< 1K"
   },
   {
     "Class":"Predicate",
-    "Name":"http:\/\/schema.org\/jobLocation-output",
+    "Name":"https://schema.org/jobLocation-output",
     "Domain Bucket":"< 1K"
   },
   {
     "Class":"Predicate",
-    "Name":"http:\/\/schema.org\/jobLocationType",
+    "Name":"https://schema.org/jobLocationType",
     "Domain Bucket":"10K - 100K"
   },
   {
     "Class":"Predicate",
-    "Name":"http:\/\/schema.org\/jobLocationType-input",
+    "Name":"https://schema.org/jobLocationType-input",
     "Domain Bucket":"< 1K"
   },
   {
     "Class":"Predicate",
-    "Name":"http:\/\/schema.org\/jobLocationType-output",
+    "Name":"https://schema.org/jobLocationType-output",
     "Domain Bucket":"< 1K"
   },
   {
     "Class":"Predicate",
-    "Name":"http:\/\/schema.org\/jobStartDate",
+    "Name":"https://schema.org/jobStartDate",
     "Domain Bucket":"1K - 10K"
   },
   {
     "Class":"Predicate",
-    "Name":"http:\/\/schema.org\/jobStartDate-input",
+    "Name":"https://schema.org/jobStartDate-input",
     "Domain Bucket":"< 1K"
   },
   {
     "Class":"Predicate",
-    "Name":"http:\/\/schema.org\/jobStartDate-output",
+    "Name":"https://schema.org/jobStartDate-output",
     "Domain Bucket":"< 1K"
   },
   {
     "Class":"Predicate",
-    "Name":"http:\/\/schema.org\/jobTitle",
+    "Name":"https://schema.org/jobTitle",
     "Domain Bucket":"1M - 10M"
   },
   {
     "Class":"Predicate",
-    "Name":"http:\/\/schema.org\/jobTitle-input",
+    "Name":"https://schema.org/jobTitle-input",
     "Domain Bucket":"< 1K"
   },
   {
     "Class":"Predicate",
-    "Name":"http:\/\/schema.org\/jobTitle-output",
+    "Name":"https://schema.org/jobTitle-output",
     "Domain Bucket":"< 1K"
   },
   {
     "Class":"Predicate",
-    "Name":"http:\/\/schema.org\/jurisdiction",
+    "Name":"https://schema.org/jurisdiction",
     "Domain Bucket":"1K - 10K"
   },
   {
     "Class":"Predicate",
-    "Name":"http:\/\/schema.org\/jurisdiction-input",
+    "Name":"https://schema.org/jurisdiction-input",
     "Domain Bucket":"< 1K"
   },
   {
     "Class":"Predicate",
-    "Name":"http:\/\/schema.org\/jurisdiction-output",
+    "Name":"https://schema.org/jurisdiction-output",
     "Domain Bucket":"< 1K"
   },
   {
     "Class":"Predicate",
-    "Name":"http:\/\/schema.org\/keywords",
+    "Name":"https://schema.org/keywords",
     "Domain Bucket":"1M - 10M"
   },
   {
     "Class":"Predicate",
-    "Name":"http:\/\/schema.org\/keywords-input",
+    "Name":"https://schema.org/keywords-input",
     "Domain Bucket":"< 1K"
   },
   {
     "Class":"Predicate",
-    "Name":"http:\/\/schema.org\/keywords-output",
+    "Name":"https://schema.org/keywords-output",
     "Domain Bucket":"< 1K"
   },
   {
     "Class":"Predicate",
-    "Name":"http:\/\/schema.org\/knownVehicleDamages",
+    "Name":"https://schema.org/knownVehicleDamages",
     "Domain Bucket":"< 1K"
   },
   {
     "Class":"Predicate",
-    "Name":"http:\/\/schema.org\/knownVehicleDamages-input",
+    "Name":"https://schema.org/knownVehicleDamages-input",
     "Domain Bucket":"< 1K"
   },
   {
     "Class":"Predicate",
-    "Name":"http:\/\/schema.org\/knownVehicleDamages-output",
+    "Name":"https://schema.org/knownVehicleDamages-output",
     "Domain Bucket":"< 1K"
   },
   {
     "Class":"Predicate",
-    "Name":"http:\/\/schema.org\/knows",
+    "Name":"https://schema.org/knows",
     "Domain Bucket":"1K - 10K"
   },
   {
     "Class":"Predicate",
-    "Name":"http:\/\/schema.org\/knows-input",
+    "Name":"https://schema.org/knows-input",
     "Domain Bucket":"< 1K"
   },
   {
     "Class":"Predicate",
-    "Name":"http:\/\/schema.org\/knows-output",
+    "Name":"https://schema.org/knows-output",
     "Domain Bucket":"< 1K"
   },
   {
     "Class":"Predicate",
-    "Name":"http:\/\/schema.org\/knowsAbout",
+    "Name":"https://schema.org/knowsAbout",
     "Domain Bucket":"100K - 1M"
   },
   {
     "Class":"Predicate",
-    "Name":"http:\/\/schema.org\/knowsAbout-input",
+    "Name":"https://schema.org/knowsAbout-input",
     "Domain Bucket":"< 1K"
   },
   {
     "Class":"Predicate",
-    "Name":"http:\/\/schema.org\/knowsAbout-output",
+    "Name":"https://schema.org/knowsAbout-output",
     "Domain Bucket":"< 1K"
   },
   {
     "Class":"Predicate",
-    "Name":"http:\/\/schema.org\/knowsLanguage",
+    "Name":"https://schema.org/knowsLanguage",
     "Domain Bucket":"100K - 1M"
   },
   {
     "Class":"Predicate",
-    "Name":"http:\/\/schema.org\/knowsLanguage-input",
+    "Name":"https://schema.org/knowsLanguage-input",
     "Domain Bucket":"< 1K"
   },
   {
     "Class":"Predicate",
-    "Name":"http:\/\/schema.org\/knowsLanguage-output",
+    "Name":"https://schema.org/knowsLanguage-output",
     "Domain Bucket":"< 1K"
   },
   {
     "Class":"Predicate",
-    "Name":"http:\/\/schema.org\/labelDetails",
+    "Name":"https://schema.org/labelDetails",
     "Domain Bucket":"< 1K"
   },
   {
     "Class":"Predicate",
-    "Name":"http:\/\/schema.org\/labelDetails-input",
+    "Name":"https://schema.org/labelDetails-input",
     "Domain Bucket":"< 1K"
   },
   {
     "Class":"Predicate",
-    "Name":"http:\/\/schema.org\/labelDetails-output",
+    "Name":"https://schema.org/labelDetails-output",
     "Domain Bucket":"< 1K"
   },
   {
     "Class":"Predicate",
-    "Name":"http:\/\/schema.org\/landlord",
+    "Name":"https://schema.org/landlord",
     "Domain Bucket":"< 1K"
   },
   {
     "Class":"Predicate",
-    "Name":"http:\/\/schema.org\/landlord-input",
+    "Name":"https://schema.org/landlord-input",
     "Domain Bucket":"< 1K"
   },
   {
     "Class":"Predicate",
-    "Name":"http:\/\/schema.org\/landlord-output",
+    "Name":"https://schema.org/landlord-output",
     "Domain Bucket":"< 1K"
   },
   {
     "Class":"Predicate",
-    "Name":"http:\/\/schema.org\/language",
+    "Name":"https://schema.org/language",
     "Domain Bucket":"10K - 100K"
   },
   {
     "Class":"Predicate",
-    "Name":"http:\/\/schema.org\/language-input",
+    "Name":"https://schema.org/language-input",
     "Domain Bucket":"< 1K"
   },
   {
     "Class":"Predicate",
-    "Name":"http:\/\/schema.org\/language-output",
+    "Name":"https://schema.org/language-output",
     "Domain Bucket":"< 1K"
   },
   {
     "Class":"Predicate",
-    "Name":"http:\/\/schema.org\/lastReviewed",
+    "Name":"https://schema.org/lastReviewed",
     "Domain Bucket":"10K - 100K"
   },
   {
     "Class":"Predicate",
-    "Name":"http:\/\/schema.org\/lastReviewed-input",
+    "Name":"https://schema.org/lastReviewed-input",
     "Domain Bucket":"< 1K"
   },
   {
     "Class":"Predicate",
-    "Name":"http:\/\/schema.org\/lastReviewed-output",
+    "Name":"https://schema.org/lastReviewed-output",
     "Domain Bucket":"< 1K"
   },
   {
     "Class":"Predicate",
-    "Name":"http:\/\/schema.org\/latitude",
+    "Name":"https://schema.org/latitude",
     "Domain Bucket":"1M - 10M"
   },
   {
     "Class":"Predicate",
-    "Name":"http:\/\/schema.org\/latitude-input",
+    "Name":"https://schema.org/latitude-input",
     "Domain Bucket":"< 1K"
   },
   {
     "Class":"Predicate",
-    "Name":"http:\/\/schema.org\/latitude-output",
+    "Name":"https://schema.org/latitude-output",
     "Domain Bucket":"< 1K"
   },
   {
     "Class":"Predicate",
-    "Name":"http:\/\/schema.org\/layoutImage",
+    "Name":"https://schema.org/layoutImage",
     "Domain Bucket":"1K - 10K"
   },
   {
     "Class":"Predicate",
-    "Name":"http:\/\/schema.org\/layoutImage-input",
+    "Name":"https://schema.org/layoutImage-input",
     "Domain Bucket":"< 1K"
   },
   {
     "Class":"Predicate",
-    "Name":"http:\/\/schema.org\/layoutImage-output",
+    "Name":"https://schema.org/layoutImage-output",
     "Domain Bucket":"< 1K"
   },
   {
     "Class":"Predicate",
-    "Name":"http:\/\/schema.org\/learningResourceType",
+    "Name":"https://schema.org/learningResourceType",
     "Domain Bucket":"10K - 100K"
   },
   {
     "Class":"Predicate",
-    "Name":"http:\/\/schema.org\/learningResourceType-input",
+    "Name":"https://schema.org/learningResourceType-input",
     "Domain Bucket":"< 1K"
   },
   {
     "Class":"Predicate",
-    "Name":"http:\/\/schema.org\/learningResourceType-output",
+    "Name":"https://schema.org/learningResourceType-output",
     "Domain Bucket":"< 1K"
   },
   {
     "Class":"Predicate",
-    "Name":"http:\/\/schema.org\/leaseLength",
+    "Name":"https://schema.org/leaseLength",
     "Domain Bucket":"1K - 10K"
   },
   {
     "Class":"Predicate",
-    "Name":"http:\/\/schema.org\/leaseLength-input",
+    "Name":"https://schema.org/leaseLength-input",
     "Domain Bucket":"< 1K"
   },
   {
     "Class":"Predicate",
-    "Name":"http:\/\/schema.org\/leaseLength-output",
+    "Name":"https://schema.org/leaseLength-output",
     "Domain Bucket":"< 1K"
   },
   {
     "Class":"Predicate",
-    "Name":"http:\/\/schema.org\/legalAddress",
+    "Name":"https://schema.org/legalAddress",
     "Domain Bucket":"1K - 10K"
   },
   {
     "Class":"Predicate",
-    "Name":"http:\/\/schema.org\/legalAddress-input",
+    "Name":"https://schema.org/legalAddress-input",
     "Domain Bucket":"< 1K"
   },
   {
     "Class":"Predicate",
-    "Name":"http:\/\/schema.org\/legalAddress-output",
+    "Name":"https://schema.org/legalAddress-output",
     "Domain Bucket":"< 1K"
   },
   {
     "Class":"Predicate",
-    "Name":"http:\/\/schema.org\/legalName",
+    "Name":"https://schema.org/legalName",
     "Domain Bucket":"1M - 10M"
   },
   {
     "Class":"Predicate",
-    "Name":"http:\/\/schema.org\/legalName-input",
+    "Name":"https://schema.org/legalName-input",
     "Domain Bucket":"< 1K"
   },
   {
     "Class":"Predicate",
-    "Name":"http:\/\/schema.org\/legalName-output",
+    "Name":"https://schema.org/legalName-output",
     "Domain Bucket":"< 1K"
   },
   {
     "Class":"Predicate",
-    "Name":"http:\/\/schema.org\/legalRepresentative",
+    "Name":"https://schema.org/legalRepresentative",
     "Domain Bucket":"1K - 10K"
   },
   {
     "Class":"Predicate",
-    "Name":"http:\/\/schema.org\/legalRepresentative-input",
+    "Name":"https://schema.org/legalRepresentative-input",
     "Domain Bucket":"< 1K"
   },
   {
     "Class":"Predicate",
-    "Name":"http:\/\/schema.org\/legalRepresentative-output",
+    "Name":"https://schema.org/legalRepresentative-output",
     "Domain Bucket":"< 1K"
   },
   {
     "Class":"Predicate",
-    "Name":"http:\/\/schema.org\/legalStatus",
+    "Name":"https://schema.org/legalStatus",
     "Domain Bucket":"1K - 10K"
   },
   {
     "Class":"Predicate",
-    "Name":"http:\/\/schema.org\/legalStatus-input",
+    "Name":"https://schema.org/legalStatus-input",
     "Domain Bucket":"< 1K"
   },
   {
     "Class":"Predicate",
-    "Name":"http:\/\/schema.org\/legalStatus-output",
+    "Name":"https://schema.org/legalStatus-output",
     "Domain Bucket":"< 1K"
   },
   {
     "Class":"Predicate",
-    "Name":"http:\/\/schema.org\/legislationAmends",
+    "Name":"https://schema.org/legislationAmends",
     "Domain Bucket":"< 1K"
   },
   {
     "Class":"Predicate",
-    "Name":"http:\/\/schema.org\/legislationAmends-input",
+    "Name":"https://schema.org/legislationAmends-input",
     "Domain Bucket":"< 1K"
   },
   {
     "Class":"Predicate",
-    "Name":"http:\/\/schema.org\/legislationAmends-output",
+    "Name":"https://schema.org/legislationAmends-output",
     "Domain Bucket":"< 1K"
   },
   {
     "Class":"Predicate",
-    "Name":"http:\/\/schema.org\/legislationApplies",
+    "Name":"https://schema.org/legislationApplies",
     "Domain Bucket":"< 1K"
   },
   {
     "Class":"Predicate",
-    "Name":"http:\/\/schema.org\/legislationApplies-input",
+    "Name":"https://schema.org/legislationApplies-input",
     "Domain Bucket":"< 1K"
   },
   {
     "Class":"Predicate",
-    "Name":"http:\/\/schema.org\/legislationApplies-output",
+    "Name":"https://schema.org/legislationApplies-output",
     "Domain Bucket":"< 1K"
   },
   {
     "Class":"Predicate",
-    "Name":"http:\/\/schema.org\/legislationChanges",
+    "Name":"https://schema.org/legislationChanges",
     "Domain Bucket":"< 1K"
   },
   {
     "Class":"Predicate",
-    "Name":"http:\/\/schema.org\/legislationChanges-input",
+    "Name":"https://schema.org/legislationChanges-input",
     "Domain Bucket":"< 1K"
   },
   {
     "Class":"Predicate",
-    "Name":"http:\/\/schema.org\/legislationChanges-output",
+    "Name":"https://schema.org/legislationChanges-output",
     "Domain Bucket":"< 1K"
   },
   {
     "Class":"Predicate",
-    "Name":"http:\/\/schema.org\/legislationCommences",
+    "Name":"https://schema.org/legislationCommences",
     "Domain Bucket":"< 1K"
   },
   {
     "Class":"Predicate",
-    "Name":"http:\/\/schema.org\/legislationCommences-input",
+    "Name":"https://schema.org/legislationCommences-input",
     "Domain Bucket":"< 1K"
   },
   {
     "Class":"Predicate",
-    "Name":"http:\/\/schema.org\/legislationCommences-output",
+    "Name":"https://schema.org/legislationCommences-output",
     "Domain Bucket":"< 1K"
   },
   {
     "Class":"Predicate",
-    "Name":"http:\/\/schema.org\/legislationConsolidates",
+    "Name":"https://schema.org/legislationConsolidates",
     "Domain Bucket":"< 1K"
   },
   {
     "Class":"Predicate",
-    "Name":"http:\/\/schema.org\/legislationConsolidates-input",
+    "Name":"https://schema.org/legislationConsolidates-input",
     "Domain Bucket":"< 1K"
   },
   {
     "Class":"Predicate",
-    "Name":"http:\/\/schema.org\/legislationConsolidates-output",
+    "Name":"https://schema.org/legislationConsolidates-output",
     "Domain Bucket":"< 1K"
   },
   {
     "Class":"Predicate",
-    "Name":"http:\/\/schema.org\/legislationCorrects",
+    "Name":"https://schema.org/legislationCorrects",
     "Domain Bucket":"< 1K"
   },
   {
     "Class":"Predicate",
-    "Name":"http:\/\/schema.org\/legislationCorrects-input",
+    "Name":"https://schema.org/legislationCorrects-input",
     "Domain Bucket":"< 1K"
   },
   {
     "Class":"Predicate",
-    "Name":"http:\/\/schema.org\/legislationCorrects-output",
+    "Name":"https://schema.org/legislationCorrects-output",
     "Domain Bucket":"< 1K"
   },
   {
     "Class":"Predicate",
-    "Name":"http:\/\/schema.org\/legislationCountersignedBy",
+    "Name":"https://schema.org/legislationCountersignedBy",
     "Domain Bucket":"< 1K"
   },
   {
     "Class":"Predicate",
-    "Name":"http:\/\/schema.org\/legislationCountersignedBy-input",
+    "Name":"https://schema.org/legislationCountersignedBy-input",
     "Domain Bucket":"< 1K"
   },
   {
     "Class":"Predicate",
-    "Name":"http:\/\/schema.org\/legislationCountersignedBy-output",
+    "Name":"https://schema.org/legislationCountersignedBy-output",
     "Domain Bucket":"< 1K"
   },
   {
     "Class":"Predicate",
-    "Name":"http:\/\/schema.org\/legislationDate",
+    "Name":"https://schema.org/legislationDate",
     "Domain Bucket":"< 1K"
   },
   {
     "Class":"Predicate",
-    "Name":"http:\/\/schema.org\/legislationDate-input",
+    "Name":"https://schema.org/legislationDate-input",
     "Domain Bucket":"< 1K"
   },
   {
     "Class":"Predicate",
-    "Name":"http:\/\/schema.org\/legislationDate-output",
+    "Name":"https://schema.org/legislationDate-output",
     "Domain Bucket":"< 1K"
   },
   {
     "Class":"Predicate",
-    "Name":"http:\/\/schema.org\/legislationDateOfApplicability",
+    "Name":"https://schema.org/legislationDateOfApplicability",
     "Domain Bucket":"< 1K"
   },
   {
     "Class":"Predicate",
-    "Name":"http:\/\/schema.org\/legislationDateOfApplicability-input",
+    "Name":"https://schema.org/legislationDateOfApplicability-input",
     "Domain Bucket":"< 1K"
   },
   {
     "Class":"Predicate",
-    "Name":"http:\/\/schema.org\/legislationDateOfApplicability-output",
+    "Name":"https://schema.org/legislationDateOfApplicability-output",
     "Domain Bucket":"< 1K"
   },
   {
     "Class":"Predicate",
-    "Name":"http:\/\/schema.org\/legislationDateVersion",
+    "Name":"https://schema.org/legislationDateVersion",
     "Domain Bucket":"< 1K"
   },
   {
     "Class":"Predicate",
-    "Name":"http:\/\/schema.org\/legislationDateVersion-input",
+    "Name":"https://schema.org/legislationDateVersion-input",
     "Domain Bucket":"< 1K"
   },
   {
     "Class":"Predicate",
-    "Name":"http:\/\/schema.org\/legislationDateVersion-output",
+    "Name":"https://schema.org/legislationDateVersion-output",
     "Domain Bucket":"< 1K"
   },
   {
     "Class":"Predicate",
-    "Name":"http:\/\/schema.org\/legislationEnsuresImplementationOf",
+    "Name":"https://schema.org/legislationEnsuresImplementationOf",
     "Domain Bucket":"< 1K"
   },
   {
     "Class":"Predicate",
-    "Name":"http:\/\/schema.org\/legislationEnsuresImplementationOf-input",
+    "Name":"https://schema.org/legislationEnsuresImplementationOf-input",
     "Domain Bucket":"< 1K"
   },
   {
     "Class":"Predicate",
-    "Name":"http:\/\/schema.org\/legislationEnsuresImplementationOf-output",
+    "Name":"https://schema.org/legislationEnsuresImplementationOf-output",
     "Domain Bucket":"< 1K"
   },
   {
     "Class":"Predicate",
-    "Name":"http:\/\/schema.org\/legislationIdentifier",
+    "Name":"https://schema.org/legislationIdentifier",
     "Domain Bucket":"1K - 10K"
   },
   {
     "Class":"Predicate",
-    "Name":"http:\/\/schema.org\/legislationIdentifier-input",
+    "Name":"https://schema.org/legislationIdentifier-input",
     "Domain Bucket":"< 1K"
   },
   {
     "Class":"Predicate",
-    "Name":"http:\/\/schema.org\/legislationIdentifier-output",
+    "Name":"https://schema.org/legislationIdentifier-output",
     "Domain Bucket":"< 1K"
   },
   {
     "Class":"Predicate",
-    "Name":"http:\/\/schema.org\/legislationJurisdiction",
+    "Name":"https://schema.org/legislationJurisdiction",
     "Domain Bucket":"1K - 10K"
   },
   {
     "Class":"Predicate",
-    "Name":"http:\/\/schema.org\/legislationJurisdiction-input",
+    "Name":"https://schema.org/legislationJurisdiction-input",
     "Domain Bucket":"< 1K"
   },
   {
     "Class":"Predicate",
-    "Name":"http:\/\/schema.org\/legislationJurisdiction-output",
+    "Name":"https://schema.org/legislationJurisdiction-output",
     "Domain Bucket":"< 1K"
   },
   {
     "Class":"Predicate",
-    "Name":"http:\/\/schema.org\/legislationLegalForce",
+    "Name":"https://schema.org/legislationLegalForce",
     "Domain Bucket":"< 1K"
   },
   {
     "Class":"Predicate",
-    "Name":"http:\/\/schema.org\/legislationLegalForce-input",
+    "Name":"https://schema.org/legislationLegalForce-input",
     "Domain Bucket":"< 1K"
   },
   {
     "Class":"Predicate",
-    "Name":"http:\/\/schema.org\/legislationLegalForce-output",
+    "Name":"https://schema.org/legislationLegalForce-output",
     "Domain Bucket":"< 1K"
   },
   {
     "Class":"Predicate",
-    "Name":"http:\/\/schema.org\/legislationLegalValue",
+    "Name":"https://schema.org/legislationLegalValue",
     "Domain Bucket":"< 1K"
   },
   {
     "Class":"Predicate",
-    "Name":"http:\/\/schema.org\/legislationLegalValue-input",
+    "Name":"https://schema.org/legislationLegalValue-input",
     "Domain Bucket":"< 1K"
   },
   {
     "Class":"Predicate",
-    "Name":"http:\/\/schema.org\/legislationLegalValue-output",
+    "Name":"https://schema.org/legislationLegalValue-output",
     "Domain Bucket":"< 1K"
   },
   {
     "Class":"Predicate",
-    "Name":"http:\/\/schema.org\/legislationPassedBy",
+    "Name":"https://schema.org/legislationPassedBy",
     "Domain Bucket":"< 1K"
   },
   {
     "Class":"Predicate",
-    "Name":"http:\/\/schema.org\/legislationPassedBy-input",
+    "Name":"https://schema.org/legislationPassedBy-input",
     "Domain Bucket":"< 1K"
   },
   {
     "Class":"Predicate",
-    "Name":"http:\/\/schema.org\/legislationPassedBy-output",
+    "Name":"https://schema.org/legislationPassedBy-output",
     "Domain Bucket":"< 1K"
   },
   {
     "Class":"Predicate",
-    "Name":"http:\/\/schema.org\/legislationRepeals",
+    "Name":"https://schema.org/legislationRepeals",
     "Domain Bucket":"< 1K"
   },
   {
     "Class":"Predicate",
-    "Name":"http:\/\/schema.org\/legislationRepeals-input",
+    "Name":"https://schema.org/legislationRepeals-input",
     "Domain Bucket":"< 1K"
   },
   {
     "Class":"Predicate",
-    "Name":"http:\/\/schema.org\/legislationRepeals-output",
+    "Name":"https://schema.org/legislationRepeals-output",
     "Domain Bucket":"< 1K"
   },
   {
     "Class":"Predicate",
-    "Name":"http:\/\/schema.org\/legislationResponsible",
+    "Name":"https://schema.org/legislationResponsible",
     "Domain Bucket":"< 1K"
   },
   {
     "Class":"Predicate",
-    "Name":"http:\/\/schema.org\/legislationResponsible-input",
+    "Name":"https://schema.org/legislationResponsible-input",
     "Domain Bucket":"< 1K"
   },
   {
     "Class":"Predicate",
-    "Name":"http:\/\/schema.org\/legislationResponsible-output",
+    "Name":"https://schema.org/legislationResponsible-output",
     "Domain Bucket":"< 1K"
   },
   {
     "Class":"Predicate",
-    "Name":"http:\/\/schema.org\/legislationTransposes",
+    "Name":"https://schema.org/legislationTransposes",
     "Domain Bucket":"< 1K"
   },
   {
     "Class":"Predicate",
-    "Name":"http:\/\/schema.org\/legislationTransposes-input",
+    "Name":"https://schema.org/legislationTransposes-input",
     "Domain Bucket":"< 1K"
   },
   {
     "Class":"Predicate",
-    "Name":"http:\/\/schema.org\/legislationTransposes-output",
+    "Name":"https://schema.org/legislationTransposes-output",
     "Domain Bucket":"< 1K"
   },
   {
     "Class":"Predicate",
-    "Name":"http:\/\/schema.org\/legislationType",
+    "Name":"https://schema.org/legislationType",
     "Domain Bucket":"< 1K"
   },
   {
     "Class":"Predicate",
-    "Name":"http:\/\/schema.org\/legislationType-input",
+    "Name":"https://schema.org/legislationType-input",
     "Domain Bucket":"< 1K"
   },
   {
     "Class":"Predicate",
-    "Name":"http:\/\/schema.org\/legislationType-output",
+    "Name":"https://schema.org/legislationType-output",
     "Domain Bucket":"< 1K"
   },
   {
     "Class":"Predicate",
-    "Name":"http:\/\/schema.org\/leiCode",
+    "Name":"https://schema.org/leiCode",
     "Domain Bucket":"1K - 10K"
   },
   {
     "Class":"Predicate",
-    "Name":"http:\/\/schema.org\/leiCode-input",
+    "Name":"https://schema.org/leiCode-input",
     "Domain Bucket":"< 1K"
   },
   {
     "Class":"Predicate",
-    "Name":"http:\/\/schema.org\/leiCode-output",
+    "Name":"https://schema.org/leiCode-output",
     "Domain Bucket":"< 1K"
   },
   {
     "Class":"Predicate",
-    "Name":"http:\/\/schema.org\/lender",
+    "Name":"https://schema.org/lender",
     "Domain Bucket":"< 1K"
   },
   {
     "Class":"Predicate",
-    "Name":"http:\/\/schema.org\/lender-input",
+    "Name":"https://schema.org/lender-input",
     "Domain Bucket":"< 1K"
   },
   {
     "Class":"Predicate",
-    "Name":"http:\/\/schema.org\/lender-output",
+    "Name":"https://schema.org/lender-output",
     "Domain Bucket":"< 1K"
   },
   {
     "Class":"Predicate",
-    "Name":"http:\/\/schema.org\/lesser",
+    "Name":"https://schema.org/lesser",
     "Domain Bucket":"< 1K"
   },
   {
     "Class":"Predicate",
-    "Name":"http:\/\/schema.org\/lesser-input",
+    "Name":"https://schema.org/lesser-input",
     "Domain Bucket":"< 1K"
   },
   {
     "Class":"Predicate",
-    "Name":"http:\/\/schema.org\/lesser-output",
+    "Name":"https://schema.org/lesser-output",
     "Domain Bucket":"< 1K"
   },
   {
     "Class":"Predicate",
-    "Name":"http:\/\/schema.org\/lesserOrEqual",
+    "Name":"https://schema.org/lesserOrEqual",
     "Domain Bucket":"< 1K"
   },
   {
     "Class":"Predicate",
-    "Name":"http:\/\/schema.org\/lesserOrEqual-input",
+    "Name":"https://schema.org/lesserOrEqual-input",
     "Domain Bucket":"< 1K"
   },
   {
     "Class":"Predicate",
-    "Name":"http:\/\/schema.org\/lesserOrEqual-output",
+    "Name":"https://schema.org/lesserOrEqual-output",
     "Domain Bucket":"< 1K"
   },
   {
     "Class":"Predicate",
-    "Name":"http:\/\/schema.org\/letterer",
+    "Name":"https://schema.org/letterer",
     "Domain Bucket":"< 1K"
   },
   {
     "Class":"Predicate",
-    "Name":"http:\/\/schema.org\/letterer-input",
+    "Name":"https://schema.org/letterer-input",
     "Domain Bucket":"< 1K"
   },
   {
     "Class":"Predicate",
-    "Name":"http:\/\/schema.org\/letterer-output",
+    "Name":"https://schema.org/letterer-output",
     "Domain Bucket":"< 1K"
   },
   {
     "Class":"Predicate",
-    "Name":"http:\/\/schema.org\/license",
+    "Name":"https://schema.org/license",
     "Domain Bucket":"100K - 1M"
   },
   {
     "Class":"Predicate",
-    "Name":"http:\/\/schema.org\/license-input",
+    "Name":"https://schema.org/license-input",
     "Domain Bucket":"< 1K"
   },
   {
     "Class":"Predicate",
-    "Name":"http:\/\/schema.org\/license-output",
+    "Name":"https://schema.org/license-output",
     "Domain Bucket":"< 1K"
   },
   {
     "Class":"Predicate",
-    "Name":"http:\/\/schema.org\/lifeEvent",
+    "Name":"https://schema.org/lifeEvent",
     "Domain Bucket":"< 1K"
   },
   {
     "Class":"Predicate",
-    "Name":"http:\/\/schema.org\/lifeEvent-input",
+    "Name":"https://schema.org/lifeEvent-input",
     "Domain Bucket":"< 1K"
   },
   {
     "Class":"Predicate",
-    "Name":"http:\/\/schema.org\/lifeEvent-output",
+    "Name":"https://schema.org/lifeEvent-output",
     "Domain Bucket":"< 1K"
   },
   {
     "Class":"Predicate",
-    "Name":"http:\/\/schema.org\/line",
+    "Name":"https://schema.org/line",
     "Domain Bucket":"< 1K"
   },
   {
     "Class":"Predicate",
-    "Name":"http:\/\/schema.org\/line-input",
+    "Name":"https://schema.org/line-input",
     "Domain Bucket":"< 1K"
   },
   {
     "Class":"Predicate",
-    "Name":"http:\/\/schema.org\/line-output",
+    "Name":"https://schema.org/line-output",
     "Domain Bucket":"< 1K"
   },
   {
     "Class":"Predicate",
-    "Name":"http:\/\/schema.org\/linkRelationship",
+    "Name":"https://schema.org/linkRelationship",
     "Domain Bucket":"< 1K"
   },
   {
     "Class":"Predicate",
-    "Name":"http:\/\/schema.org\/linkRelationship-input",
+    "Name":"https://schema.org/linkRelationship-input",
     "Domain Bucket":"< 1K"
   },
   {
     "Class":"Predicate",
-    "Name":"http:\/\/schema.org\/linkRelationship-output",
+    "Name":"https://schema.org/linkRelationship-output",
     "Domain Bucket":"< 1K"
   },
   {
     "Class":"Predicate",
-    "Name":"http:\/\/schema.org\/liveBlogUpdate",
+    "Name":"https://schema.org/liveBlogUpdate",
     "Domain Bucket":"1K - 10K"
   },
   {
     "Class":"Predicate",
-    "Name":"http:\/\/schema.org\/liveBlogUpdate-input",
+    "Name":"https://schema.org/liveBlogUpdate-input",
     "Domain Bucket":"< 1K"
   },
   {
     "Class":"Predicate",
-    "Name":"http:\/\/schema.org\/liveBlogUpdate-output",
+    "Name":"https://schema.org/liveBlogUpdate-output",
     "Domain Bucket":"< 1K"
   },
   {
     "Class":"Predicate",
-    "Name":"http:\/\/schema.org\/loanMortgageMandateAmount",
+    "Name":"https://schema.org/loanMortgageMandateAmount",
     "Domain Bucket":"< 1K"
   },
   {
     "Class":"Predicate",
-    "Name":"http:\/\/schema.org\/loanMortgageMandateAmount-input",
+    "Name":"https://schema.org/loanMortgageMandateAmount-input",
     "Domain Bucket":"< 1K"
   },
   {
     "Class":"Predicate",
-    "Name":"http:\/\/schema.org\/loanMortgageMandateAmount-output",
+    "Name":"https://schema.org/loanMortgageMandateAmount-output",
     "Domain Bucket":"< 1K"
   },
   {
     "Class":"Predicate",
-    "Name":"http:\/\/schema.org\/loanPaymentAmount",
+    "Name":"https://schema.org/loanPaymentAmount",
     "Domain Bucket":"< 1K"
   },
   {
     "Class":"Predicate",
-    "Name":"http:\/\/schema.org\/loanPaymentAmount-input",
+    "Name":"https://schema.org/loanPaymentAmount-input",
     "Domain Bucket":"< 1K"
   },
   {
     "Class":"Predicate",
-    "Name":"http:\/\/schema.org\/loanPaymentAmount-output",
+    "Name":"https://schema.org/loanPaymentAmount-output",
     "Domain Bucket":"< 1K"
   },
   {
     "Class":"Predicate",
-    "Name":"http:\/\/schema.org\/loanPaymentFrequency",
+    "Name":"https://schema.org/loanPaymentFrequency",
     "Domain Bucket":"< 1K"
   },
   {
     "Class":"Predicate",
-    "Name":"http:\/\/schema.org\/loanPaymentFrequency-input",
+    "Name":"https://schema.org/loanPaymentFrequency-input",
     "Domain Bucket":"< 1K"
   },
   {
     "Class":"Predicate",
-    "Name":"http:\/\/schema.org\/loanPaymentFrequency-output",
+    "Name":"https://schema.org/loanPaymentFrequency-output",
     "Domain Bucket":"< 1K"
   },
   {
     "Class":"Predicate",
-    "Name":"http:\/\/schema.org\/loanRepaymentForm",
+    "Name":"https://schema.org/loanRepaymentForm",
     "Domain Bucket":"< 1K"
   },
   {
     "Class":"Predicate",
-    "Name":"http:\/\/schema.org\/loanRepaymentForm-input",
+    "Name":"https://schema.org/loanRepaymentForm-input",
     "Domain Bucket":"< 1K"
   },
   {
     "Class":"Predicate",
-    "Name":"http:\/\/schema.org\/loanRepaymentForm-output",
+    "Name":"https://schema.org/loanRepaymentForm-output",
     "Domain Bucket":"< 1K"
   },
   {
     "Class":"Predicate",
-    "Name":"http:\/\/schema.org\/loanTerm",
+    "Name":"https://schema.org/loanTerm",
     "Domain Bucket":"1K - 10K"
   },
   {
     "Class":"Predicate",
-    "Name":"http:\/\/schema.org\/loanTerm-input",
+    "Name":"https://schema.org/loanTerm-input",
     "Domain Bucket":"< 1K"
   },
   {
     "Class":"Predicate",
-    "Name":"http:\/\/schema.org\/loanTerm-output",
+    "Name":"https://schema.org/loanTerm-output",
     "Domain Bucket":"< 1K"
   },
   {
     "Class":"Predicate",
-    "Name":"http:\/\/schema.org\/loanType",
+    "Name":"https://schema.org/loanType",
     "Domain Bucket":"1K - 10K"
   },
   {
     "Class":"Predicate",
-    "Name":"http:\/\/schema.org\/loanType-input",
+    "Name":"https://schema.org/loanType-input",
     "Domain Bucket":"< 1K"
   },
   {
     "Class":"Predicate",
-    "Name":"http:\/\/schema.org\/loanType-output",
+    "Name":"https://schema.org/loanType-output",
     "Domain Bucket":"< 1K"
   },
   {
     "Class":"Predicate",
-    "Name":"http:\/\/schema.org\/location",
+    "Name":"https://schema.org/location",
     "Domain Bucket":"1M - 10M"
   },
   {
     "Class":"Predicate",
-    "Name":"http:\/\/schema.org\/location-input",
+    "Name":"https://schema.org/location-input",
     "Domain Bucket":"< 1K"
   },
   {
     "Class":"Predicate",
-    "Name":"http:\/\/schema.org\/location-output",
+    "Name":"https://schema.org/location-output",
     "Domain Bucket":"< 1K"
   },
   {
     "Class":"Predicate",
-    "Name":"http:\/\/schema.org\/locationCreated",
+    "Name":"https://schema.org/locationCreated",
     "Domain Bucket":"10K - 100K"
   },
   {
     "Class":"Predicate",
-    "Name":"http:\/\/schema.org\/locationCreated-input",
+    "Name":"https://schema.org/locationCreated-input",
     "Domain Bucket":"< 1K"
   },
   {
     "Class":"Predicate",
-    "Name":"http:\/\/schema.org\/locationCreated-output",
+    "Name":"https://schema.org/locationCreated-output",
     "Domain Bucket":"< 1K"
   },
   {
     "Class":"Predicate",
-    "Name":"http:\/\/schema.org\/lodgingUnitDescription",
+    "Name":"https://schema.org/lodgingUnitDescription",
     "Domain Bucket":"< 1K"
   },
   {
     "Class":"Predicate",
-    "Name":"http:\/\/schema.org\/lodgingUnitDescription-input",
+    "Name":"https://schema.org/lodgingUnitDescription-input",
     "Domain Bucket":"< 1K"
   },
   {
     "Class":"Predicate",
-    "Name":"http:\/\/schema.org\/lodgingUnitDescription-output",
+    "Name":"https://schema.org/lodgingUnitDescription-output",
     "Domain Bucket":"< 1K"
   },
   {
     "Class":"Predicate",
-    "Name":"http:\/\/schema.org\/lodgingUnitType",
+    "Name":"https://schema.org/lodgingUnitType",
     "Domain Bucket":"< 1K"
   },
   {
     "Class":"Predicate",
-    "Name":"http:\/\/schema.org\/lodgingUnitType-input",
+    "Name":"https://schema.org/lodgingUnitType-input",
     "Domain Bucket":"< 1K"
   },
   {
     "Class":"Predicate",
-    "Name":"http:\/\/schema.org\/lodgingUnitType-output",
+    "Name":"https://schema.org/lodgingUnitType-output",
     "Domain Bucket":"< 1K"
   },
   {
     "Class":"Predicate",
-    "Name":"http:\/\/schema.org\/logo",
+    "Name":"https://schema.org/logo",
     "Domain Bucket":"10M+"
   },
   {
     "Class":"Predicate",
-    "Name":"http:\/\/schema.org\/logo-input",
+    "Name":"https://schema.org/logo-input",
     "Domain Bucket":"< 1K"
   },
   {
     "Class":"Predicate",
-    "Name":"http:\/\/schema.org\/logo-output",
+    "Name":"https://schema.org/logo-output",
     "Domain Bucket":"< 1K"
   },
   {
     "Class":"Predicate",
-    "Name":"http:\/\/schema.org\/longitude",
+    "Name":"https://schema.org/longitude",
     "Domain Bucket":"1M - 10M"
   },
   {
     "Class":"Predicate",
-    "Name":"http:\/\/schema.org\/longitude-input",
+    "Name":"https://schema.org/longitude-input",
     "Domain Bucket":"< 1K"
   },
   {
     "Class":"Predicate",
-    "Name":"http:\/\/schema.org\/longitude-output",
+    "Name":"https://schema.org/longitude-output",
     "Domain Bucket":"< 1K"
   },
   {
     "Class":"Predicate",
-    "Name":"http:\/\/schema.org\/loser",
+    "Name":"https://schema.org/loser",
     "Domain Bucket":"< 1K"
   },
   {
     "Class":"Predicate",
-    "Name":"http:\/\/schema.org\/loser-input",
+    "Name":"https://schema.org/loser-input",
     "Domain Bucket":"< 1K"
   },
   {
     "Class":"Predicate",
-    "Name":"http:\/\/schema.org\/loser-output",
+    "Name":"https://schema.org/loser-output",
     "Domain Bucket":"< 1K"
   },
   {
     "Class":"Predicate",
-    "Name":"http:\/\/schema.org\/lowPrice",
+    "Name":"https://schema.org/lowPrice",
     "Domain Bucket":"1M - 10M"
   },
   {
     "Class":"Predicate",
-    "Name":"http:\/\/schema.org\/lowPrice-input",
+    "Name":"https://schema.org/lowPrice-input",
     "Domain Bucket":"< 1K"
   },
   {
     "Class":"Predicate",
-    "Name":"http:\/\/schema.org\/lowPrice-output",
+    "Name":"https://schema.org/lowPrice-output",
     "Domain Bucket":"< 1K"
   },
   {
     "Class":"Predicate",
-    "Name":"http:\/\/schema.org\/lyricist",
+    "Name":"https://schema.org/lyricist",
     "Domain Bucket":"< 1K"
   },
   {
     "Class":"Predicate",
-    "Name":"http:\/\/schema.org\/lyricist-input",
+    "Name":"https://schema.org/lyricist-input",
     "Domain Bucket":"< 1K"
   },
   {
     "Class":"Predicate",
-    "Name":"http:\/\/schema.org\/lyricist-output",
+    "Name":"https://schema.org/lyricist-output",
     "Domain Bucket":"< 1K"
   },
   {
     "Class":"Predicate",
-    "Name":"http:\/\/schema.org\/lyrics",
+    "Name":"https://schema.org/lyrics",
     "Domain Bucket":"1K - 10K"
   },
   {
     "Class":"Predicate",
-    "Name":"http:\/\/schema.org\/lyrics-input",
+    "Name":"https://schema.org/lyrics-input",
     "Domain Bucket":"< 1K"
   },
   {
     "Class":"Predicate",
-    "Name":"http:\/\/schema.org\/lyrics-output",
+    "Name":"https://schema.org/lyrics-output",
     "Domain Bucket":"< 1K"
   },
   {
     "Class":"Predicate",
-    "Name":"http:\/\/schema.org\/mainContentOfPage",
+    "Name":"https://schema.org/mainContentOfPage",
     "Domain Bucket":"1M - 10M"
   },
   {
     "Class":"Predicate",
-    "Name":"http:\/\/schema.org\/mainContentOfPage-input",
+    "Name":"https://schema.org/mainContentOfPage-input",
     "Domain Bucket":"< 1K"
   },
   {
     "Class":"Predicate",
-    "Name":"http:\/\/schema.org\/mainContentOfPage-output",
+    "Name":"https://schema.org/mainContentOfPage-output",
     "Domain Bucket":"< 1K"
   },
   {
     "Class":"Predicate",
-    "Name":"http:\/\/schema.org\/mainEntity",
+    "Name":"https://schema.org/mainEntity",
     "Domain Bucket":"1M - 10M"
   },
   {
     "Class":"Predicate",
-    "Name":"http:\/\/schema.org\/mainEntity-input",
+    "Name":"https://schema.org/mainEntity-input",
     "Domain Bucket":"< 1K"
   },
   {
     "Class":"Predicate",
-    "Name":"http:\/\/schema.org\/mainEntity-output",
+    "Name":"https://schema.org/mainEntity-output",
     "Domain Bucket":"< 1K"
   },
   {
     "Class":"Predicate",
-    "Name":"http:\/\/schema.org\/mainEntityOfPage",
+    "Name":"https://schema.org/mainEntityOfPage",
     "Domain Bucket":"10M+"
   },
   {
     "Class":"Predicate",
-    "Name":"http:\/\/schema.org\/mainEntityOfPage-input",
+    "Name":"https://schema.org/mainEntityOfPage-input",
     "Domain Bucket":"< 1K"
   },
   {
     "Class":"Predicate",
-    "Name":"http:\/\/schema.org\/mainEntityOfPage-output",
+    "Name":"https://schema.org/mainEntityOfPage-output",
     "Domain Bucket":"< 1K"
   },
   {
     "Class":"Predicate",
-    "Name":"http:\/\/schema.org\/maintainer",
+    "Name":"https://schema.org/maintainer",
     "Domain Bucket":"1K - 10K"
   },
   {
     "Class":"Predicate",
-    "Name":"http:\/\/schema.org\/maintainer-input",
+    "Name":"https://schema.org/maintainer-input",
     "Domain Bucket":"< 1K"
   },
   {
     "Class":"Predicate",
-    "Name":"http:\/\/schema.org\/maintainer-output",
+    "Name":"https://schema.org/maintainer-output",
     "Domain Bucket":"< 1K"
   },
   {
     "Class":"Predicate",
-    "Name":"http:\/\/schema.org\/makesOffer",
+    "Name":"https://schema.org/makesOffer",
     "Domain Bucket":"100K - 1M"
   },
   {
     "Class":"Predicate",
-    "Name":"http:\/\/schema.org\/makesOffer-input",
+    "Name":"https://schema.org/makesOffer-input",
     "Domain Bucket":"< 1K"
   },
   {
     "Class":"Predicate",
-    "Name":"http:\/\/schema.org\/makesOffer-output",
+    "Name":"https://schema.org/makesOffer-output",
     "Domain Bucket":"< 1K"
   },
   {
     "Class":"Predicate",
-    "Name":"http:\/\/schema.org\/manufacturer",
+    "Name":"https://schema.org/manufacturer",
     "Domain Bucket":"100K - 1M"
   },
   {
     "Class":"Predicate",
-    "Name":"http:\/\/schema.org\/manufacturer-input",
+    "Name":"https://schema.org/manufacturer-input",
     "Domain Bucket":"< 1K"
   },
   {
     "Class":"Predicate",
-    "Name":"http:\/\/schema.org\/manufacturer-output",
+    "Name":"https://schema.org/manufacturer-output",
     "Domain Bucket":"< 1K"
   },
   {
     "Class":"Predicate",
-    "Name":"http:\/\/schema.org\/map",
+    "Name":"https://schema.org/map",
     "Domain Bucket":"1K - 10K"
   },
   {
     "Class":"Predicate",
-    "Name":"http:\/\/schema.org\/map-input",
+    "Name":"https://schema.org/map-input",
     "Domain Bucket":"< 1K"
   },
   {
     "Class":"Predicate",
-    "Name":"http:\/\/schema.org\/map-output",
+    "Name":"https://schema.org/map-output",
     "Domain Bucket":"< 1K"
   },
   {
     "Class":"Predicate",
-    "Name":"http:\/\/schema.org\/mapType",
+    "Name":"https://schema.org/mapType",
     "Domain Bucket":"1K - 10K"
   },
   {
     "Class":"Predicate",
-    "Name":"http:\/\/schema.org\/mapType-input",
+    "Name":"https://schema.org/mapType-input",
     "Domain Bucket":"< 1K"
   },
   {
     "Class":"Predicate",
-    "Name":"http:\/\/schema.org\/mapType-output",
+    "Name":"https://schema.org/mapType-output",
     "Domain Bucket":"< 1K"
   },
   {
     "Class":"Predicate",
-    "Name":"http:\/\/schema.org\/maps",
+    "Name":"https://schema.org/maps",
     "Domain Bucket":"1K - 10K"
   },
   {
     "Class":"Predicate",
-    "Name":"http:\/\/schema.org\/maps-input",
+    "Name":"https://schema.org/maps-input",
     "Domain Bucket":"< 1K"
   },
   {
     "Class":"Predicate",
-    "Name":"http:\/\/schema.org\/maps-output",
+    "Name":"https://schema.org/maps-output",
     "Domain Bucket":"< 1K"
   },
   {
     "Class":"Predicate",
-    "Name":"http:\/\/schema.org\/marginOfError",
+    "Name":"https://schema.org/marginOfError",
     "Domain Bucket":"< 1K"
   },
   {
     "Class":"Predicate",
-    "Name":"http:\/\/schema.org\/marginOfError-input",
+    "Name":"https://schema.org/marginOfError-input",
     "Domain Bucket":"< 1K"
   },
   {
     "Class":"Predicate",
-    "Name":"http:\/\/schema.org\/marginOfError-output",
+    "Name":"https://schema.org/marginOfError-output",
     "Domain Bucket":"< 1K"
   },
   {
     "Class":"Predicate",
-    "Name":"http:\/\/schema.org\/masthead",
+    "Name":"https://schema.org/masthead",
     "Domain Bucket":"1K - 10K"
   },
   {
     "Class":"Predicate",
-    "Name":"http:\/\/schema.org\/masthead-input",
+    "Name":"https://schema.org/masthead-input",
     "Domain Bucket":"< 1K"
   },
   {
     "Class":"Predicate",
-    "Name":"http:\/\/schema.org\/masthead-output",
+    "Name":"https://schema.org/masthead-output",
     "Domain Bucket":"< 1K"
   },
   {
     "Class":"Predicate",
-    "Name":"http:\/\/schema.org\/material",
+    "Name":"https://schema.org/material",
     "Domain Bucket":"10K - 100K"
   },
   {
     "Class":"Predicate",
-    "Name":"http:\/\/schema.org\/material-input",
+    "Name":"https://schema.org/material-input",
     "Domain Bucket":"< 1K"
   },
   {
     "Class":"Predicate",
-    "Name":"http:\/\/schema.org\/material-output",
+    "Name":"https://schema.org/material-output",
     "Domain Bucket":"< 1K"
   },
   {
     "Class":"Predicate",
-    "Name":"http:\/\/schema.org\/materialExtent",
+    "Name":"https://schema.org/materialExtent",
     "Domain Bucket":"< 1K"
   },
   {
     "Class":"Predicate",
-    "Name":"http:\/\/schema.org\/materialExtent-input",
+    "Name":"https://schema.org/materialExtent-input",
     "Domain Bucket":"< 1K"
   },
   {
     "Class":"Predicate",
-    "Name":"http:\/\/schema.org\/materialExtent-output",
+    "Name":"https://schema.org/materialExtent-output",
     "Domain Bucket":"< 1K"
   },
   {
     "Class":"Predicate",
-    "Name":"http:\/\/schema.org\/mathExpression",
+    "Name":"https://schema.org/mathExpression",
     "Domain Bucket":"< 1K"
   },
   {
     "Class":"Predicate",
-    "Name":"http:\/\/schema.org\/mathExpression-input",
+    "Name":"https://schema.org/mathExpression-input",
     "Domain Bucket":"< 1K"
   },
   {
     "Class":"Predicate",
-    "Name":"http:\/\/schema.org\/mathExpression-output",
+    "Name":"https://schema.org/mathExpression-output",
     "Domain Bucket":"< 1K"
   },
   {
     "Class":"Predicate",
-    "Name":"http:\/\/schema.org\/maxPrice",
+    "Name":"https://schema.org/maxPrice",
     "Domain Bucket":"10K - 100K"
   },
   {
     "Class":"Predicate",
-    "Name":"http:\/\/schema.org\/maxPrice-input",
+    "Name":"https://schema.org/maxPrice-input",
     "Domain Bucket":"< 1K"
   },
   {
     "Class":"Predicate",
-    "Name":"http:\/\/schema.org\/maxPrice-output",
+    "Name":"https://schema.org/maxPrice-output",
     "Domain Bucket":"< 1K"
   },
   {
     "Class":"Predicate",
-    "Name":"http:\/\/schema.org\/maxValue",
+    "Name":"https://schema.org/maxValue",
     "Domain Bucket":"100K - 1M"
   },
   {
     "Class":"Predicate",
-    "Name":"http:\/\/schema.org\/maxValue-input",
+    "Name":"https://schema.org/maxValue-input",
     "Domain Bucket":"< 1K"
   },
   {
     "Class":"Predicate",
-    "Name":"http:\/\/schema.org\/maxValue-output",
+    "Name":"https://schema.org/maxValue-output",
     "Domain Bucket":"< 1K"
   },
   {
     "Class":"Predicate",
-    "Name":"http:\/\/schema.org\/maximumAttendeeCapacity",
+    "Name":"https://schema.org/maximumAttendeeCapacity",
     "Domain Bucket":"10K - 100K"
   },
   {
     "Class":"Predicate",
-    "Name":"http:\/\/schema.org\/maximumAttendeeCapacity-input",
+    "Name":"https://schema.org/maximumAttendeeCapacity-input",
     "Domain Bucket":"< 1K"
   },
   {
     "Class":"Predicate",
-    "Name":"http:\/\/schema.org\/maximumAttendeeCapacity-output",
+    "Name":"https://schema.org/maximumAttendeeCapacity-output",
     "Domain Bucket":"< 1K"
   },
   {
     "Class":"Predicate",
-    "Name":"http:\/\/schema.org\/maximumEnrollment",
+    "Name":"https://schema.org/maximumEnrollment",
     "Domain Bucket":"< 1K"
   },
   {
     "Class":"Predicate",
-    "Name":"http:\/\/schema.org\/maximumEnrollment-input",
+    "Name":"https://schema.org/maximumEnrollment-input",
     "Domain Bucket":"< 1K"
   },
   {
     "Class":"Predicate",
-    "Name":"http:\/\/schema.org\/maximumEnrollment-output",
+    "Name":"https://schema.org/maximumEnrollment-output",
     "Domain Bucket":"< 1K"
   },
   {
     "Class":"Predicate",
-    "Name":"http:\/\/schema.org\/maximumIntake",
+    "Name":"https://schema.org/maximumIntake",
     "Domain Bucket":"< 1K"
   },
   {
     "Class":"Predicate",
-    "Name":"http:\/\/schema.org\/maximumIntake-input",
+    "Name":"https://schema.org/maximumIntake-input",
     "Domain Bucket":"< 1K"
   },
   {
     "Class":"Predicate",
-    "Name":"http:\/\/schema.org\/maximumIntake-output",
+    "Name":"https://schema.org/maximumIntake-output",
     "Domain Bucket":"< 1K"
   },
   {
     "Class":"Predicate",
-    "Name":"http:\/\/schema.org\/maximumPhysicalAttendeeCapacity",
+    "Name":"https://schema.org/maximumPhysicalAttendeeCapacity",
     "Domain Bucket":"< 1K"
   },
   {
     "Class":"Predicate",
-    "Name":"http:\/\/schema.org\/maximumPhysicalAttendeeCapacity-input",
+    "Name":"https://schema.org/maximumPhysicalAttendeeCapacity-input",
     "Domain Bucket":"< 1K"
   },
   {
     "Class":"Predicate",
-    "Name":"http:\/\/schema.org\/maximumPhysicalAttendeeCapacity-output",
+    "Name":"https://schema.org/maximumPhysicalAttendeeCapacity-output",
     "Domain Bucket":"< 1K"
   },
   {
     "Class":"Predicate",
-    "Name":"http:\/\/schema.org\/maximumVirtualAttendeeCapacity",
+    "Name":"https://schema.org/maximumVirtualAttendeeCapacity",
     "Domain Bucket":"< 1K"
   },
   {
     "Class":"Predicate",
-    "Name":"http:\/\/schema.org\/maximumVirtualAttendeeCapacity-input",
+    "Name":"https://schema.org/maximumVirtualAttendeeCapacity-input",
     "Domain Bucket":"< 1K"
   },
   {
     "Class":"Predicate",
-    "Name":"http:\/\/schema.org\/maximumVirtualAttendeeCapacity-output",
+    "Name":"https://schema.org/maximumVirtualAttendeeCapacity-output",
     "Domain Bucket":"< 1K"
   },
   {
     "Class":"Predicate",
-    "Name":"http:\/\/schema.org\/mealService",
+    "Name":"https://schema.org/mealService",
     "Domain Bucket":"< 1K"
   },
   {
     "Class":"Predicate",
-    "Name":"http:\/\/schema.org\/mealService-input",
+    "Name":"https://schema.org/mealService-input",
     "Domain Bucket":"< 1K"
   },
   {
     "Class":"Predicate",
-    "Name":"http:\/\/schema.org\/mealService-output",
+    "Name":"https://schema.org/mealService-output",
     "Domain Bucket":"< 1K"
   },
   {
     "Class":"Predicate",
-    "Name":"http:\/\/schema.org\/measuredProperty",
+    "Name":"https://schema.org/measuredProperty",
     "Domain Bucket":"< 1K"
   },
   {
     "Class":"Predicate",
-    "Name":"http:\/\/schema.org\/measuredProperty-input",
+    "Name":"https://schema.org/measuredProperty-input",
     "Domain Bucket":"< 1K"
   },
   {
     "Class":"Predicate",
-    "Name":"http:\/\/schema.org\/measuredProperty-output",
+    "Name":"https://schema.org/measuredProperty-output",
     "Domain Bucket":"< 1K"
   },
   {
     "Class":"Predicate",
-    "Name":"http:\/\/schema.org\/measurementDenominator",
+    "Name":"https://schema.org/measurementDenominator",
     "Domain Bucket":"< 1K"
   },
   {
     "Class":"Predicate",
-    "Name":"http:\/\/schema.org\/measurementDenominator-input",
+    "Name":"https://schema.org/measurementDenominator-input",
     "Domain Bucket":"< 1K"
   },
   {
     "Class":"Predicate",
-    "Name":"http:\/\/schema.org\/measurementDenominator-output",
+    "Name":"https://schema.org/measurementDenominator-output",
     "Domain Bucket":"< 1K"
   },
   {
     "Class":"Predicate",
-    "Name":"http:\/\/schema.org\/measurementMethod",
+    "Name":"https://schema.org/measurementMethod",
     "Domain Bucket":"< 1K"
   },
   {
     "Class":"Predicate",
-    "Name":"http:\/\/schema.org\/measurementMethod-input",
+    "Name":"https://schema.org/measurementMethod-input",
     "Domain Bucket":"< 1K"
   },
   {
     "Class":"Predicate",
-    "Name":"http:\/\/schema.org\/measurementMethod-output",
+    "Name":"https://schema.org/measurementMethod-output",
     "Domain Bucket":"< 1K"
   },
   {
     "Class":"Predicate",
-    "Name":"http:\/\/schema.org\/measurementQualifier",
+    "Name":"https://schema.org/measurementQualifier",
     "Domain Bucket":"< 1K"
   },
   {
     "Class":"Predicate",
-    "Name":"http:\/\/schema.org\/measurementQualifier-input",
+    "Name":"https://schema.org/measurementQualifier-input",
     "Domain Bucket":"< 1K"
   },
   {
     "Class":"Predicate",
-    "Name":"http:\/\/schema.org\/measurementQualifier-output",
+    "Name":"https://schema.org/measurementQualifier-output",
     "Domain Bucket":"< 1K"
   },
   {
     "Class":"Predicate",
-    "Name":"http:\/\/schema.org\/measurementTechnique",
+    "Name":"https://schema.org/measurementTechnique",
     "Domain Bucket":"1K - 10K"
   },
   {
     "Class":"Predicate",
-    "Name":"http:\/\/schema.org\/measurementTechnique-input",
+    "Name":"https://schema.org/measurementTechnique-input",
     "Domain Bucket":"< 1K"
   },
   {
     "Class":"Predicate",
-    "Name":"http:\/\/schema.org\/measurementTechnique-output",
+    "Name":"https://schema.org/measurementTechnique-output",
     "Domain Bucket":"< 1K"
   },
   {
     "Class":"Predicate",
-    "Name":"http:\/\/schema.org\/mechanismOfAction",
+    "Name":"https://schema.org/mechanismOfAction",
     "Domain Bucket":"< 1K"
   },
   {
     "Class":"Predicate",
-    "Name":"http:\/\/schema.org\/mechanismOfAction-input",
+    "Name":"https://schema.org/mechanismOfAction-input",
     "Domain Bucket":"< 1K"
   },
   {
     "Class":"Predicate",
-    "Name":"http:\/\/schema.org\/mechanismOfAction-output",
+    "Name":"https://schema.org/mechanismOfAction-output",
     "Domain Bucket":"< 1K"
   },
   {
     "Class":"Predicate",
-    "Name":"http:\/\/schema.org\/mediaAuthenticityCategory",
+    "Name":"https://schema.org/mediaAuthenticityCategory",
     "Domain Bucket":"< 1K"
   },
   {
     "Class":"Predicate",
-    "Name":"http:\/\/schema.org\/mediaAuthenticityCategory-input",
+    "Name":"https://schema.org/mediaAuthenticityCategory-input",
     "Domain Bucket":"< 1K"
   },
   {
     "Class":"Predicate",
-    "Name":"http:\/\/schema.org\/mediaAuthenticityCategory-output",
+    "Name":"https://schema.org/mediaAuthenticityCategory-output",
     "Domain Bucket":"< 1K"
   },
   {
     "Class":"Predicate",
-    "Name":"http:\/\/schema.org\/mediaItemAppearance",
+    "Name":"https://schema.org/mediaItemAppearance",
     "Domain Bucket":"< 1K"
   },
   {
     "Class":"Predicate",
-    "Name":"http:\/\/schema.org\/mediaItemAppearance-input",
+    "Name":"https://schema.org/mediaItemAppearance-input",
     "Domain Bucket":"< 1K"
   },
   {
     "Class":"Predicate",
-    "Name":"http:\/\/schema.org\/mediaItemAppearance-output",
+    "Name":"https://schema.org/mediaItemAppearance-output",
     "Domain Bucket":"< 1K"
   },
   {
     "Class":"Predicate",
-    "Name":"http:\/\/schema.org\/median",
+    "Name":"https://schema.org/median",
     "Domain Bucket":"1K - 10K"
   },
   {
     "Class":"Predicate",
-    "Name":"http:\/\/schema.org\/median-input",
+    "Name":"https://schema.org/median-input",
     "Domain Bucket":"< 1K"
   },
   {
     "Class":"Predicate",
-    "Name":"http:\/\/schema.org\/median-output",
+    "Name":"https://schema.org/median-output",
     "Domain Bucket":"< 1K"
   },
   {
     "Class":"Predicate",
-    "Name":"http:\/\/schema.org\/medicalAudience",
+    "Name":"https://schema.org/medicalAudience",
     "Domain Bucket":"1K - 10K"
   },
   {
     "Class":"Predicate",
-    "Name":"http:\/\/schema.org\/medicalAudience-input",
+    "Name":"https://schema.org/medicalAudience-input",
     "Domain Bucket":"< 1K"
   },
   {
     "Class":"Predicate",
-    "Name":"http:\/\/schema.org\/medicalAudience-output",
+    "Name":"https://schema.org/medicalAudience-output",
     "Domain Bucket":"< 1K"
   },
   {
     "Class":"Predicate",
-    "Name":"http:\/\/schema.org\/medicalSpecialty",
+    "Name":"https://schema.org/medicalSpecialty",
     "Domain Bucket":"100K - 1M"
   },
   {
     "Class":"Predicate",
-    "Name":"http:\/\/schema.org\/medicalSpecialty-input",
+    "Name":"https://schema.org/medicalSpecialty-input",
     "Domain Bucket":"< 1K"
   },
   {
     "Class":"Predicate",
-    "Name":"http:\/\/schema.org\/medicalSpecialty-output",
+    "Name":"https://schema.org/medicalSpecialty-output",
     "Domain Bucket":"< 1K"
   },
   {
     "Class":"Predicate",
-    "Name":"http:\/\/schema.org\/medicineSystem",
+    "Name":"https://schema.org/medicineSystem",
     "Domain Bucket":"1K - 10K"
   },
   {
     "Class":"Predicate",
-    "Name":"http:\/\/schema.org\/medicineSystem-input",
+    "Name":"https://schema.org/medicineSystem-input",
     "Domain Bucket":"< 1K"
   },
   {
     "Class":"Predicate",
-    "Name":"http:\/\/schema.org\/medicineSystem-output",
+    "Name":"https://schema.org/medicineSystem-output",
     "Domain Bucket":"< 1K"
   },
   {
     "Class":"Predicate",
-    "Name":"http:\/\/schema.org\/meetsEmissionStandard",
+    "Name":"https://schema.org/meetsEmissionStandard",
     "Domain Bucket":"< 1K"
   },
   {
     "Class":"Predicate",
-    "Name":"http:\/\/schema.org\/meetsEmissionStandard-input",
+    "Name":"https://schema.org/meetsEmissionStandard-input",
     "Domain Bucket":"< 1K"
   },
   {
     "Class":"Predicate",
-    "Name":"http:\/\/schema.org\/meetsEmissionStandard-output",
+    "Name":"https://schema.org/meetsEmissionStandard-output",
     "Domain Bucket":"< 1K"
   },
   {
     "Class":"Predicate",
-    "Name":"http:\/\/schema.org\/member",
+    "Name":"https://schema.org/member",
     "Domain Bucket":"10K - 100K"
   },
   {
     "Class":"Predicate",
-    "Name":"http:\/\/schema.org\/member-input",
+    "Name":"https://schema.org/member-input",
     "Domain Bucket":"< 1K"
   },
   {
     "Class":"Predicate",
-    "Name":"http:\/\/schema.org\/member-output",
+    "Name":"https://schema.org/member-output",
     "Domain Bucket":"< 1K"
   },
   {
     "Class":"Predicate",
-    "Name":"http:\/\/schema.org\/memberOf",
+    "Name":"https://schema.org/memberOf",
     "Domain Bucket":"10K - 100K"
   },
   {
     "Class":"Predicate",
-    "Name":"http:\/\/schema.org\/memberOf-input",
+    "Name":"https://schema.org/memberOf-input",
     "Domain Bucket":"< 1K"
   },
   {
     "Class":"Predicate",
-    "Name":"http:\/\/schema.org\/memberOf-output",
+    "Name":"https://schema.org/memberOf-output",
     "Domain Bucket":"< 1K"
   },
   {
     "Class":"Predicate",
-    "Name":"http:\/\/schema.org\/members",
+    "Name":"https://schema.org/members",
     "Domain Bucket":"< 1K"
   },
   {
     "Class":"Predicate",
-    "Name":"http:\/\/schema.org\/members-input",
+    "Name":"https://schema.org/members-input",
     "Domain Bucket":"< 1K"
   },
   {
     "Class":"Predicate",
-    "Name":"http:\/\/schema.org\/members-output",
+    "Name":"https://schema.org/members-output",
     "Domain Bucket":"< 1K"
   },
   {
     "Class":"Predicate",
-    "Name":"http:\/\/schema.org\/membershipNumber",
+    "Name":"https://schema.org/membershipNumber",
     "Domain Bucket":"< 1K"
   },
   {
     "Class":"Predicate",
-    "Name":"http:\/\/schema.org\/membershipNumber-input",
+    "Name":"https://schema.org/membershipNumber-input",
     "Domain Bucket":"< 1K"
   },
   {
     "Class":"Predicate",
-    "Name":"http:\/\/schema.org\/membershipNumber-output",
+    "Name":"https://schema.org/membershipNumber-output",
     "Domain Bucket":"< 1K"
   },
   {
     "Class":"Predicate",
-    "Name":"http:\/\/schema.org\/membershipPointsEarned",
+    "Name":"https://schema.org/membershipPointsEarned",
     "Domain Bucket":"< 1K"
   },
   {
     "Class":"Predicate",
-    "Name":"http:\/\/schema.org\/membershipPointsEarned-input",
+    "Name":"https://schema.org/membershipPointsEarned-input",
     "Domain Bucket":"< 1K"
   },
   {
     "Class":"Predicate",
-    "Name":"http:\/\/schema.org\/membershipPointsEarned-output",
+    "Name":"https://schema.org/membershipPointsEarned-output",
     "Domain Bucket":"< 1K"
   },
   {
     "Class":"Predicate",
-    "Name":"http:\/\/schema.org\/memoryRequirements",
+    "Name":"https://schema.org/memoryRequirements",
     "Domain Bucket":"1K - 10K"
   },
   {
     "Class":"Predicate",
-    "Name":"http:\/\/schema.org\/memoryRequirements-input",
+    "Name":"https://schema.org/memoryRequirements-input",
     "Domain Bucket":"< 1K"
   },
   {
     "Class":"Predicate",
-    "Name":"http:\/\/schema.org\/memoryRequirements-output",
+    "Name":"https://schema.org/memoryRequirements-output",
     "Domain Bucket":"< 1K"
   },
   {
     "Class":"Predicate",
-    "Name":"http:\/\/schema.org\/mentions",
+    "Name":"https://schema.org/mentions",
     "Domain Bucket":"10K - 100K"
   },
   {
     "Class":"Predicate",
-    "Name":"http:\/\/schema.org\/mentions-input",
+    "Name":"https://schema.org/mentions-input",
     "Domain Bucket":"< 1K"
   },
   {
     "Class":"Predicate",
-    "Name":"http:\/\/schema.org\/mentions-output",
+    "Name":"https://schema.org/mentions-output",
     "Domain Bucket":"< 1K"
   },
   {
     "Class":"Predicate",
-    "Name":"http:\/\/schema.org\/menu",
+    "Name":"https://schema.org/menu",
     "Domain Bucket":"10K - 100K"
   },
   {
     "Class":"Predicate",
-    "Name":"http:\/\/schema.org\/menu-input",
+    "Name":"https://schema.org/menu-input",
     "Domain Bucket":"< 1K"
   },
   {
     "Class":"Predicate",
-    "Name":"http:\/\/schema.org\/menu-output",
+    "Name":"https://schema.org/menu-output",
     "Domain Bucket":"< 1K"
   },
   {
     "Class":"Predicate",
-    "Name":"http:\/\/schema.org\/menuAddOn",
+    "Name":"https://schema.org/menuAddOn",
     "Domain Bucket":"10K - 100K"
   },
   {
     "Class":"Predicate",
-    "Name":"http:\/\/schema.org\/menuAddOn-input",
+    "Name":"https://schema.org/menuAddOn-input",
     "Domain Bucket":"< 1K"
   },
   {
     "Class":"Predicate",
-    "Name":"http:\/\/schema.org\/menuAddOn-output",
+    "Name":"https://schema.org/menuAddOn-output",
     "Domain Bucket":"< 1K"
   },
   {
     "Class":"Predicate",
-    "Name":"http:\/\/schema.org\/merchant",
+    "Name":"https://schema.org/merchant",
     "Domain Bucket":"< 1K"
   },
   {
     "Class":"Predicate",
-    "Name":"http:\/\/schema.org\/merchant-input",
+    "Name":"https://schema.org/merchant-input",
     "Domain Bucket":"< 1K"
   },
   {
     "Class":"Predicate",
-    "Name":"http:\/\/schema.org\/merchant-output",
+    "Name":"https://schema.org/merchant-output",
     "Domain Bucket":"< 1K"
   },
   {
     "Class":"Predicate",
-    "Name":"http:\/\/schema.org\/merchantReturnDays",
+    "Name":"https://schema.org/merchantReturnDays",
     "Domain Bucket":"100K - 1M"
   },
   {
     "Class":"Predicate",
-    "Name":"http:\/\/schema.org\/merchantReturnDays-input",
+    "Name":"https://schema.org/merchantReturnDays-input",
     "Domain Bucket":"< 1K"
   },
   {
     "Class":"Predicate",
-    "Name":"http:\/\/schema.org\/merchantReturnDays-output",
+    "Name":"https://schema.org/merchantReturnDays-output",
     "Domain Bucket":"< 1K"
   },
   {
     "Class":"Predicate",
-    "Name":"http:\/\/schema.org\/merchantReturnLink",
+    "Name":"https://schema.org/merchantReturnLink",
     "Domain Bucket":"10K - 100K"
   },
   {
     "Class":"Predicate",
-    "Name":"http:\/\/schema.org\/merchantReturnLink-input",
+    "Name":"https://schema.org/merchantReturnLink-input",
     "Domain Bucket":"< 1K"
   },
   {
     "Class":"Predicate",
-    "Name":"http:\/\/schema.org\/merchantReturnLink-output",
+    "Name":"https://schema.org/merchantReturnLink-output",
     "Domain Bucket":"< 1K"
   },
   {
     "Class":"Predicate",
-    "Name":"http:\/\/schema.org\/messageAttachment",
+    "Name":"https://schema.org/messageAttachment",
     "Domain Bucket":"< 1K"
   },
   {
     "Class":"Predicate",
-    "Name":"http:\/\/schema.org\/messageAttachment-input",
+    "Name":"https://schema.org/messageAttachment-input",
     "Domain Bucket":"< 1K"
   },
   {
     "Class":"Predicate",
-    "Name":"http:\/\/schema.org\/messageAttachment-output",
+    "Name":"https://schema.org/messageAttachment-output",
     "Domain Bucket":"< 1K"
   },
   {
     "Class":"Predicate",
-    "Name":"http:\/\/schema.org\/mileageFromOdometer",
+    "Name":"https://schema.org/mileageFromOdometer",
     "Domain Bucket":"10K - 100K"
   },
   {
     "Class":"Predicate",
-    "Name":"http:\/\/schema.org\/mileageFromOdometer-input",
+    "Name":"https://schema.org/mileageFromOdometer-input",
     "Domain Bucket":"< 1K"
   },
   {
     "Class":"Predicate",
-    "Name":"http:\/\/schema.org\/mileageFromOdometer-output",
+    "Name":"https://schema.org/mileageFromOdometer-output",
     "Domain Bucket":"< 1K"
   },
   {
     "Class":"Predicate",
-    "Name":"http:\/\/schema.org\/minPrice",
+    "Name":"https://schema.org/minPrice",
     "Domain Bucket":"10K - 100K"
   },
   {
     "Class":"Predicate",
-    "Name":"http:\/\/schema.org\/minPrice-input",
+    "Name":"https://schema.org/minPrice-input",
     "Domain Bucket":"< 1K"
   },
   {
     "Class":"Predicate",
-    "Name":"http:\/\/schema.org\/minPrice-output",
+    "Name":"https://schema.org/minPrice-output",
     "Domain Bucket":"< 1K"
   },
   {
     "Class":"Predicate",
-    "Name":"http:\/\/schema.org\/minValue",
+    "Name":"https://schema.org/minValue",
     "Domain Bucket":"100K - 1M"
   },
   {
     "Class":"Predicate",
-    "Name":"http:\/\/schema.org\/minValue-input",
+    "Name":"https://schema.org/minValue-input",
     "Domain Bucket":"< 1K"
   },
   {
     "Class":"Predicate",
-    "Name":"http:\/\/schema.org\/minValue-output",
+    "Name":"https://schema.org/minValue-output",
     "Domain Bucket":"< 1K"
   },
   {
     "Class":"Predicate",
-    "Name":"http:\/\/schema.org\/minimumPaymentDue",
+    "Name":"https://schema.org/minimumPaymentDue",
     "Domain Bucket":"< 1K"
   },
   {
     "Class":"Predicate",
-    "Name":"http:\/\/schema.org\/minimumPaymentDue-input",
+    "Name":"https://schema.org/minimumPaymentDue-input",
     "Domain Bucket":"< 1K"
   },
   {
     "Class":"Predicate",
-    "Name":"http:\/\/schema.org\/minimumPaymentDue-output",
+    "Name":"https://schema.org/minimumPaymentDue-output",
     "Domain Bucket":"< 1K"
   },
   {
     "Class":"Predicate",
-    "Name":"http:\/\/schema.org\/missionCoveragePrioritiesPolicy",
+    "Name":"https://schema.org/missionCoveragePrioritiesPolicy",
     "Domain Bucket":"1K - 10K"
   },
   {
     "Class":"Predicate",
-    "Name":"http:\/\/schema.org\/missionCoveragePrioritiesPolicy-input",
+    "Name":"https://schema.org/missionCoveragePrioritiesPolicy-input",
     "Domain Bucket":"< 1K"
   },
   {
     "Class":"Predicate",
-    "Name":"http:\/\/schema.org\/missionCoveragePrioritiesPolicy-output",
+    "Name":"https://schema.org/missionCoveragePrioritiesPolicy-output",
     "Domain Bucket":"< 1K"
   },
   {
     "Class":"Predicate",
-    "Name":"http:\/\/schema.org\/mobileUrl",
+    "Name":"https://schema.org/mobileUrl",
     "Domain Bucket":"< 1K"
   },
   {
     "Class":"Predicate",
-    "Name":"http:\/\/schema.org\/mobileUrl-input",
+    "Name":"https://schema.org/mobileUrl-input",
     "Domain Bucket":"< 1K"
   },
   {
     "Class":"Predicate",
-    "Name":"http:\/\/schema.org\/mobileUrl-output",
+    "Name":"https://schema.org/mobileUrl-output",
     "Domain Bucket":"< 1K"
   },
   {
     "Class":"Predicate",
-    "Name":"http:\/\/schema.org\/model",
+    "Name":"https://schema.org/model",
     "Domain Bucket":"100K - 1M"
   },
   {
     "Class":"Predicate",
-    "Name":"http:\/\/schema.org\/model-input",
+    "Name":"https://schema.org/model-input",
     "Domain Bucket":"< 1K"
   },
   {
     "Class":"Predicate",
-    "Name":"http:\/\/schema.org\/model-output",
+    "Name":"https://schema.org/model-output",
     "Domain Bucket":"< 1K"
   },
   {
     "Class":"Predicate",
-    "Name":"http:\/\/schema.org\/modelDate",
+    "Name":"https://schema.org/modelDate",
     "Domain Bucket":"10K - 100K"
   },
   {
     "Class":"Predicate",
-    "Name":"http:\/\/schema.org\/modelDate-input",
+    "Name":"https://schema.org/modelDate-input",
     "Domain Bucket":"< 1K"
   },
   {
     "Class":"Predicate",
-    "Name":"http:\/\/schema.org\/modelDate-output",
+    "Name":"https://schema.org/modelDate-output",
     "Domain Bucket":"< 1K"
   },
   {
     "Class":"Predicate",
-    "Name":"http:\/\/schema.org\/modifiedTime",
+    "Name":"https://schema.org/modifiedTime",
     "Domain Bucket":"< 1K"
   },
   {
     "Class":"Predicate",
-    "Name":"http:\/\/schema.org\/modifiedTime-input",
+    "Name":"https://schema.org/modifiedTime-input",
     "Domain Bucket":"< 1K"
   },
   {
     "Class":"Predicate",
-    "Name":"http:\/\/schema.org\/modifiedTime-output",
+    "Name":"https://schema.org/modifiedTime-output",
     "Domain Bucket":"< 1K"
   },
   {
     "Class":"Predicate",
-    "Name":"http:\/\/schema.org\/molecularFormula",
+    "Name":"https://schema.org/molecularFormula",
     "Domain Bucket":"< 1K"
   },
   {
     "Class":"Predicate",
-    "Name":"http:\/\/schema.org\/molecularFormula-input",
+    "Name":"https://schema.org/molecularFormula-input",
     "Domain Bucket":"< 1K"
   },
   {
     "Class":"Predicate",
-    "Name":"http:\/\/schema.org\/molecularFormula-output",
+    "Name":"https://schema.org/molecularFormula-output",
     "Domain Bucket":"< 1K"
   },
   {
     "Class":"Predicate",
-    "Name":"http:\/\/schema.org\/molecularWeight",
+    "Name":"https://schema.org/molecularWeight",
     "Domain Bucket":"< 1K"
   },
   {
     "Class":"Predicate",
-    "Name":"http:\/\/schema.org\/molecularWeight-input",
+    "Name":"https://schema.org/molecularWeight-input",
     "Domain Bucket":"< 1K"
   },
   {
     "Class":"Predicate",
-    "Name":"http:\/\/schema.org\/molecularWeight-output",
+    "Name":"https://schema.org/molecularWeight-output",
     "Domain Bucket":"< 1K"
   },
   {
     "Class":"Predicate",
-    "Name":"http:\/\/schema.org\/monoisotopicMolecularWeight",
+    "Name":"https://schema.org/monoisotopicMolecularWeight",
     "Domain Bucket":"< 1K"
   },
   {
     "Class":"Predicate",
-    "Name":"http:\/\/schema.org\/monoisotopicMolecularWeight-input",
+    "Name":"https://schema.org/monoisotopicMolecularWeight-input",
     "Domain Bucket":"< 1K"
   },
   {
     "Class":"Predicate",
-    "Name":"http:\/\/schema.org\/monoisotopicMolecularWeight-output",
+    "Name":"https://schema.org/monoisotopicMolecularWeight-output",
     "Domain Bucket":"< 1K"
   },
   {
     "Class":"Predicate",
-    "Name":"http:\/\/schema.org\/monthlyMinimumRepaymentAmount",
+    "Name":"https://schema.org/monthlyMinimumRepaymentAmount",
     "Domain Bucket":"< 1K"
   },
   {
     "Class":"Predicate",
-    "Name":"http:\/\/schema.org\/monthlyMinimumRepaymentAmount-input",
+    "Name":"https://schema.org/monthlyMinimumRepaymentAmount-input",
     "Domain Bucket":"< 1K"
   },
   {
     "Class":"Predicate",
-    "Name":"http:\/\/schema.org\/monthlyMinimumRepaymentAmount-output",
+    "Name":"https://schema.org/monthlyMinimumRepaymentAmount-output",
     "Domain Bucket":"< 1K"
   },
   {
     "Class":"Predicate",
-    "Name":"http:\/\/schema.org\/monthsOfExperience",
+    "Name":"https://schema.org/monthsOfExperience",
     "Domain Bucket":"1K - 10K"
   },
   {
     "Class":"Predicate",
-    "Name":"http:\/\/schema.org\/monthsOfExperience-input",
+    "Name":"https://schema.org/monthsOfExperience-input",
     "Domain Bucket":"< 1K"
   },
   {
     "Class":"Predicate",
-    "Name":"http:\/\/schema.org\/monthsOfExperience-output",
+    "Name":"https://schema.org/monthsOfExperience-output",
     "Domain Bucket":"< 1K"
   },
   {
     "Class":"Predicate",
-    "Name":"http:\/\/schema.org\/mpn",
+    "Name":"https://schema.org/mpn",
     "Domain Bucket":"100K - 1M"
   },
   {
     "Class":"Predicate",
-    "Name":"http:\/\/schema.org\/mpn-input",
+    "Name":"https://schema.org/mpn-input",
     "Domain Bucket":"< 1K"
   },
   {
     "Class":"Predicate",
-    "Name":"http:\/\/schema.org\/mpn-output",
+    "Name":"https://schema.org/mpn-output",
     "Domain Bucket":"< 1K"
   },
   {
     "Class":"Predicate",
-    "Name":"http:\/\/schema.org\/multipleValues",
+    "Name":"https://schema.org/multipleValues",
     "Domain Bucket":"< 1K"
   },
   {
     "Class":"Predicate",
-    "Name":"http:\/\/schema.org\/multipleValues-input",
+    "Name":"https://schema.org/multipleValues-input",
     "Domain Bucket":"< 1K"
   },
   {
     "Class":"Predicate",
-    "Name":"http:\/\/schema.org\/multipleValues-output",
+    "Name":"https://schema.org/multipleValues-output",
     "Domain Bucket":"< 1K"
   },
   {
     "Class":"Predicate",
-    "Name":"http:\/\/schema.org\/muscleAction",
+    "Name":"https://schema.org/muscleAction",
     "Domain Bucket":"< 1K"
   },
   {
     "Class":"Predicate",
-    "Name":"http:\/\/schema.org\/muscleAction-input",
+    "Name":"https://schema.org/muscleAction-input",
     "Domain Bucket":"< 1K"
   },
   {
     "Class":"Predicate",
-    "Name":"http:\/\/schema.org\/muscleAction-output",
+    "Name":"https://schema.org/muscleAction-output",
     "Domain Bucket":"< 1K"
   },
   {
     "Class":"Predicate",
-    "Name":"http:\/\/schema.org\/musicArrangement",
+    "Name":"https://schema.org/musicArrangement",
     "Domain Bucket":"< 1K"
   },
   {
     "Class":"Predicate",
-    "Name":"http:\/\/schema.org\/musicArrangement-input",
+    "Name":"https://schema.org/musicArrangement-input",
     "Domain Bucket":"< 1K"
   },
   {
     "Class":"Predicate",
-    "Name":"http:\/\/schema.org\/musicArrangement-output",
+    "Name":"https://schema.org/musicArrangement-output",
     "Domain Bucket":"< 1K"
   },
   {
     "Class":"Predicate",
-    "Name":"http:\/\/schema.org\/musicBy",
+    "Name":"https://schema.org/musicBy",
     "Domain Bucket":"1K - 10K"
   },
   {
     "Class":"Predicate",
-    "Name":"http:\/\/schema.org\/musicBy-input",
+    "Name":"https://schema.org/musicBy-input",
     "Domain Bucket":"< 1K"
   },
   {
     "Class":"Predicate",
-    "Name":"http:\/\/schema.org\/musicBy-output",
+    "Name":"https://schema.org/musicBy-output",
     "Domain Bucket":"< 1K"
   },
   {
     "Class":"Predicate",
-    "Name":"http:\/\/schema.org\/musicCompositionForm",
+    "Name":"https://schema.org/musicCompositionForm",
     "Domain Bucket":"< 1K"
   },
   {
     "Class":"Predicate",
-    "Name":"http:\/\/schema.org\/musicCompositionForm-input",
+    "Name":"https://schema.org/musicCompositionForm-input",
     "Domain Bucket":"< 1K"
   },
   {
     "Class":"Predicate",
-    "Name":"http:\/\/schema.org\/musicCompositionForm-output",
+    "Name":"https://schema.org/musicCompositionForm-output",
     "Domain Bucket":"< 1K"
   },
   {
     "Class":"Predicate",
-    "Name":"http:\/\/schema.org\/musicGroupMember",
+    "Name":"https://schema.org/musicGroupMember",
     "Domain Bucket":"< 1K"
   },
   {
     "Class":"Predicate",
-    "Name":"http:\/\/schema.org\/musicGroupMember-input",
+    "Name":"https://schema.org/musicGroupMember-input",
     "Domain Bucket":"< 1K"
   },
   {
     "Class":"Predicate",
-    "Name":"http:\/\/schema.org\/musicGroupMember-output",
+    "Name":"https://schema.org/musicGroupMember-output",
     "Domain Bucket":"< 1K"
   },
   {
     "Class":"Predicate",
-    "Name":"http:\/\/schema.org\/musicReleaseFormat",
+    "Name":"https://schema.org/musicReleaseFormat",
     "Domain Bucket":"1K - 10K"
   },
   {
     "Class":"Predicate",
-    "Name":"http:\/\/schema.org\/musicReleaseFormat-input",
+    "Name":"https://schema.org/musicReleaseFormat-input",
     "Domain Bucket":"< 1K"
   },
   {
     "Class":"Predicate",
-    "Name":"http:\/\/schema.org\/musicReleaseFormat-output",
+    "Name":"https://schema.org/musicReleaseFormat-output",
     "Domain Bucket":"< 1K"
   },
   {
     "Class":"Predicate",
-    "Name":"http:\/\/schema.org\/musicalKey",
+    "Name":"https://schema.org/musicalKey",
     "Domain Bucket":"< 1K"
   },
   {
     "Class":"Predicate",
-    "Name":"http:\/\/schema.org\/musicalKey-input",
+    "Name":"https://schema.org/musicalKey-input",
     "Domain Bucket":"< 1K"
   },
   {
     "Class":"Predicate",
-    "Name":"http:\/\/schema.org\/musicalKey-output",
+    "Name":"https://schema.org/musicalKey-output",
     "Domain Bucket":"< 1K"
   },
   {
     "Class":"Predicate",
-    "Name":"http:\/\/schema.org\/naics",
+    "Name":"https://schema.org/naics",
     "Domain Bucket":"10K - 100K"
   },
   {
     "Class":"Predicate",
-    "Name":"http:\/\/schema.org\/naics-input",
+    "Name":"https://schema.org/naics-input",
     "Domain Bucket":"< 1K"
   },
   {
     "Class":"Predicate",
-    "Name":"http:\/\/schema.org\/naics-output",
+    "Name":"https://schema.org/naics-output",
     "Domain Bucket":"< 1K"
   },
   {
     "Class":"Predicate",
-    "Name":"http:\/\/schema.org\/name",
+    "Name":"https://schema.org/name",
     "Domain Bucket":"10M+"
   },
   {
     "Class":"Predicate",
-    "Name":"http:\/\/schema.org\/name-input",
+    "Name":"https://schema.org/name-input",
     "Domain Bucket":"< 1K"
   },
   {
     "Class":"Predicate",
-    "Name":"http:\/\/schema.org\/name-output",
+    "Name":"https://schema.org/name-output",
     "Domain Bucket":"< 1K"
   },
   {
     "Class":"Predicate",
-    "Name":"http:\/\/schema.org\/namedPosition",
+    "Name":"https://schema.org/namedPosition",
     "Domain Bucket":"< 1K"
   },
   {
     "Class":"Predicate",
-    "Name":"http:\/\/schema.org\/namedPosition-input",
+    "Name":"https://schema.org/namedPosition-input",
     "Domain Bucket":"< 1K"
   },
   {
     "Class":"Predicate",
-    "Name":"http:\/\/schema.org\/namedPosition-output",
+    "Name":"https://schema.org/namedPosition-output",
     "Domain Bucket":"< 1K"
   },
   {
     "Class":"Predicate",
-    "Name":"http:\/\/schema.org\/nationality",
+    "Name":"https://schema.org/nationality",
     "Domain Bucket":"10K - 100K"
   },
   {
     "Class":"Predicate",
-    "Name":"http:\/\/schema.org\/nationality-input",
+    "Name":"https://schema.org/nationality-input",
     "Domain Bucket":"< 1K"
   },
   {
     "Class":"Predicate",
-    "Name":"http:\/\/schema.org\/nationality-output",
+    "Name":"https://schema.org/nationality-output",
     "Domain Bucket":"< 1K"
   },
   {
     "Class":"Predicate",
-    "Name":"http:\/\/schema.org\/naturalProgression",
+    "Name":"https://schema.org/naturalProgression",
     "Domain Bucket":"< 1K"
   },
   {
     "Class":"Predicate",
-    "Name":"http:\/\/schema.org\/naturalProgression-input",
+    "Name":"https://schema.org/naturalProgression-input",
     "Domain Bucket":"< 1K"
   },
   {
     "Class":"Predicate",
-    "Name":"http:\/\/schema.org\/naturalProgression-output",
+    "Name":"https://schema.org/naturalProgression-output",
     "Domain Bucket":"< 1K"
   },
   {
     "Class":"Predicate",
-    "Name":"http:\/\/schema.org\/negativeNotes",
+    "Name":"https://schema.org/negativeNotes",
     "Domain Bucket":"10K - 100K"
   },
   {
     "Class":"Predicate",
-    "Name":"http:\/\/schema.org\/negativeNotes-input",
+    "Name":"https://schema.org/negativeNotes-input",
     "Domain Bucket":"< 1K"
   },
   {
     "Class":"Predicate",
-    "Name":"http:\/\/schema.org\/negativeNotes-output",
+    "Name":"https://schema.org/negativeNotes-output",
     "Domain Bucket":"< 1K"
   },
   {
     "Class":"Predicate",
-    "Name":"http:\/\/schema.org\/nerve",
+    "Name":"https://schema.org/nerve",
     "Domain Bucket":"< 1K"
   },
   {
     "Class":"Predicate",
-    "Name":"http:\/\/schema.org\/nerve-input",
+    "Name":"https://schema.org/nerve-input",
     "Domain Bucket":"< 1K"
   },
   {
     "Class":"Predicate",
-    "Name":"http:\/\/schema.org\/nerve-output",
+    "Name":"https://schema.org/nerve-output",
     "Domain Bucket":"< 1K"
   },
   {
     "Class":"Predicate",
-    "Name":"http:\/\/schema.org\/nerveMotor",
+    "Name":"https://schema.org/nerveMotor",
     "Domain Bucket":"< 1K"
   },
   {
     "Class":"Predicate",
-    "Name":"http:\/\/schema.org\/nerveMotor-input",
+    "Name":"https://schema.org/nerveMotor-input",
     "Domain Bucket":"< 1K"
   },
   {
     "Class":"Predicate",
-    "Name":"http:\/\/schema.org\/nerveMotor-output",
+    "Name":"https://schema.org/nerveMotor-output",
     "Domain Bucket":"< 1K"
   },
   {
     "Class":"Predicate",
-    "Name":"http:\/\/schema.org\/netWorth",
+    "Name":"https://schema.org/netWorth",
     "Domain Bucket":"< 1K"
   },
   {
     "Class":"Predicate",
-    "Name":"http:\/\/schema.org\/netWorth-input",
+    "Name":"https://schema.org/netWorth-input",
     "Domain Bucket":"< 1K"
   },
   {
     "Class":"Predicate",
-    "Name":"http:\/\/schema.org\/netWorth-output",
+    "Name":"https://schema.org/netWorth-output",
     "Domain Bucket":"< 1K"
   },
   {
     "Class":"Predicate",
-    "Name":"http:\/\/schema.org\/newsUpdatesAndGuidelines",
+    "Name":"https://schema.org/newsUpdatesAndGuidelines",
     "Domain Bucket":"< 1K"
   },
   {
     "Class":"Predicate",
-    "Name":"http:\/\/schema.org\/newsUpdatesAndGuidelines-input",
+    "Name":"https://schema.org/newsUpdatesAndGuidelines-input",
     "Domain Bucket":"< 1K"
   },
   {
     "Class":"Predicate",
-    "Name":"http:\/\/schema.org\/newsUpdatesAndGuidelines-output",
+    "Name":"https://schema.org/newsUpdatesAndGuidelines-output",
     "Domain Bucket":"< 1K"
   },
   {
     "Class":"Predicate",
-    "Name":"http:\/\/schema.org\/nextItem",
+    "Name":"https://schema.org/nextItem",
     "Domain Bucket":"1M - 10M"
   },
   {
     "Class":"Predicate",
-    "Name":"http:\/\/schema.org\/nextItem-input",
+    "Name":"https://schema.org/nextItem-input",
     "Domain Bucket":"< 1K"
   },
   {
     "Class":"Predicate",
-    "Name":"http:\/\/schema.org\/nextItem-output",
+    "Name":"https://schema.org/nextItem-output",
     "Domain Bucket":"< 1K"
   },
   {
     "Class":"Predicate",
-    "Name":"http:\/\/schema.org\/noBylinesPolicy",
+    "Name":"https://schema.org/noBylinesPolicy",
     "Domain Bucket":"1K - 10K"
   },
   {
     "Class":"Predicate",
-    "Name":"http:\/\/schema.org\/noBylinesPolicy-input",
+    "Name":"https://schema.org/noBylinesPolicy-input",
     "Domain Bucket":"< 1K"
   },
   {
     "Class":"Predicate",
-    "Name":"http:\/\/schema.org\/noBylinesPolicy-output",
+    "Name":"https://schema.org/noBylinesPolicy-output",
     "Domain Bucket":"< 1K"
   },
   {
     "Class":"Predicate",
-    "Name":"http:\/\/schema.org\/nonEqual",
+    "Name":"https://schema.org/nonEqual",
     "Domain Bucket":"< 1K"
   },
   {
     "Class":"Predicate",
-    "Name":"http:\/\/schema.org\/nonEqual-input",
+    "Name":"https://schema.org/nonEqual-input",
     "Domain Bucket":"< 1K"
   },
   {
     "Class":"Predicate",
-    "Name":"http:\/\/schema.org\/nonEqual-output",
+    "Name":"https://schema.org/nonEqual-output",
     "Domain Bucket":"< 1K"
   },
   {
     "Class":"Predicate",
-    "Name":"http:\/\/schema.org\/nonProprietaryName",
+    "Name":"https://schema.org/nonProprietaryName",
     "Domain Bucket":"1K - 10K"
   },
   {
     "Class":"Predicate",
-    "Name":"http:\/\/schema.org\/nonProprietaryName-input",
+    "Name":"https://schema.org/nonProprietaryName-input",
     "Domain Bucket":"< 1K"
   },
   {
     "Class":"Predicate",
-    "Name":"http:\/\/schema.org\/nonProprietaryName-output",
+    "Name":"https://schema.org/nonProprietaryName-output",
     "Domain Bucket":"< 1K"
   },
   {
     "Class":"Predicate",
-    "Name":"http:\/\/schema.org\/nonprofitStatus",
+    "Name":"https://schema.org/nonprofitStatus",
     "Domain Bucket":"1K - 10K"
   },
   {
     "Class":"Predicate",
-    "Name":"http:\/\/schema.org\/nonprofitStatus-input",
+    "Name":"https://schema.org/nonprofitStatus-input",
     "Domain Bucket":"< 1K"
   },
   {
     "Class":"Predicate",
-    "Name":"http:\/\/schema.org\/nonprofitStatus-output",
+    "Name":"https://schema.org/nonprofitStatus-output",
     "Domain Bucket":"< 1K"
   },
   {
     "Class":"Predicate",
-    "Name":"http:\/\/schema.org\/normalRange",
+    "Name":"https://schema.org/normalRange",
     "Domain Bucket":"< 1K"
   },
   {
     "Class":"Predicate",
-    "Name":"http:\/\/schema.org\/normalRange-input",
+    "Name":"https://schema.org/normalRange-input",
     "Domain Bucket":"< 1K"
   },
   {
     "Class":"Predicate",
-    "Name":"http:\/\/schema.org\/normalRange-output",
+    "Name":"https://schema.org/normalRange-output",
     "Domain Bucket":"< 1K"
   },
   {
     "Class":"Predicate",
-    "Name":"http:\/\/schema.org\/nsn",
+    "Name":"https://schema.org/nsn",
     "Domain Bucket":"< 1K"
   },
   {
     "Class":"Predicate",
-    "Name":"http:\/\/schema.org\/nsn-input",
+    "Name":"https://schema.org/nsn-input",
     "Domain Bucket":"< 1K"
   },
   {
     "Class":"Predicate",
-    "Name":"http:\/\/schema.org\/nsn-output",
+    "Name":"https://schema.org/nsn-output",
     "Domain Bucket":"< 1K"
   },
   {
     "Class":"Predicate",
-    "Name":"http:\/\/schema.org\/numAdults",
+    "Name":"https://schema.org/numAdults",
     "Domain Bucket":"< 1K"
   },
   {
     "Class":"Predicate",
-    "Name":"http:\/\/schema.org\/numAdults-input",
+    "Name":"https://schema.org/numAdults-input",
     "Domain Bucket":"< 1K"
   },
   {
     "Class":"Predicate",
-    "Name":"http:\/\/schema.org\/numAdults-output",
+    "Name":"https://schema.org/numAdults-output",
     "Domain Bucket":"< 1K"
   },
   {
     "Class":"Predicate",
-    "Name":"http:\/\/schema.org\/numChildren",
+    "Name":"https://schema.org/numChildren",
     "Domain Bucket":"< 1K"
   },
   {
     "Class":"Predicate",
-    "Name":"http:\/\/schema.org\/numChildren-input",
+    "Name":"https://schema.org/numChildren-input",
     "Domain Bucket":"< 1K"
   },
   {
     "Class":"Predicate",
-    "Name":"http:\/\/schema.org\/numChildren-output",
+    "Name":"https://schema.org/numChildren-output",
     "Domain Bucket":"< 1K"
   },
   {
     "Class":"Predicate",
-    "Name":"http:\/\/schema.org\/numConstraints",
+    "Name":"https://schema.org/numConstraints",
     "Domain Bucket":"< 1K"
   },
   {
     "Class":"Predicate",
-    "Name":"http:\/\/schema.org\/numConstraints-input",
+    "Name":"https://schema.org/numConstraints-input",
     "Domain Bucket":"< 1K"
   },
   {
     "Class":"Predicate",
-    "Name":"http:\/\/schema.org\/numConstraints-output",
+    "Name":"https://schema.org/numConstraints-output",
     "Domain Bucket":"< 1K"
   },
   {
     "Class":"Predicate",
-    "Name":"http:\/\/schema.org\/numItems",
+    "Name":"https://schema.org/numItems",
     "Domain Bucket":"< 1K"
   },
   {
     "Class":"Predicate",
-    "Name":"http:\/\/schema.org\/numItems-input",
+    "Name":"https://schema.org/numItems-input",
     "Domain Bucket":"< 1K"
   },
   {
     "Class":"Predicate",
-    "Name":"http:\/\/schema.org\/numItems-output",
+    "Name":"https://schema.org/numItems-output",
     "Domain Bucket":"< 1K"
   },
   {
     "Class":"Predicate",
-    "Name":"http:\/\/schema.org\/numTracks",
+    "Name":"https://schema.org/numTracks",
     "Domain Bucket":"10K - 100K"
   },
   {
     "Class":"Predicate",
-    "Name":"http:\/\/schema.org\/numTracks-input",
+    "Name":"https://schema.org/numTracks-input",
     "Domain Bucket":"< 1K"
   },
   {
     "Class":"Predicate",
-    "Name":"http:\/\/schema.org\/numTracks-output",
+    "Name":"https://schema.org/numTracks-output",
     "Domain Bucket":"< 1K"
   },
   {
     "Class":"Predicate",
-    "Name":"http:\/\/schema.org\/numberOfAccommodationUnits",
+    "Name":"https://schema.org/numberOfAccommodationUnits",
     "Domain Bucket":"1K - 10K"
   },
   {
     "Class":"Predicate",
-    "Name":"http:\/\/schema.org\/numberOfAccommodationUnits-input",
+    "Name":"https://schema.org/numberOfAccommodationUnits-input",
     "Domain Bucket":"< 1K"
   },
   {
     "Class":"Predicate",
-    "Name":"http:\/\/schema.org\/numberOfAccommodationUnits-output",
+    "Name":"https://schema.org/numberOfAccommodationUnits-output",
     "Domain Bucket":"< 1K"
   },
   {
     "Class":"Predicate",
-    "Name":"http:\/\/schema.org\/numberOfAirbags",
+    "Name":"https://schema.org/numberOfAirbags",
     "Domain Bucket":"< 1K"
   },
   {
     "Class":"Predicate",
-    "Name":"http:\/\/schema.org\/numberOfAirbags-input",
+    "Name":"https://schema.org/numberOfAirbags-input",
     "Domain Bucket":"< 1K"
   },
   {
     "Class":"Predicate",
-    "Name":"http:\/\/schema.org\/numberOfAirbags-output",
+    "Name":"https://schema.org/numberOfAirbags-output",
     "Domain Bucket":"< 1K"
   },
   {
     "Class":"Predicate",
-    "Name":"http:\/\/schema.org\/numberOfAvailableAccommodationUnits",
+    "Name":"https://schema.org/numberOfAvailableAccommodationUnits",
     "Domain Bucket":"1K - 10K"
   },
   {
     "Class":"Predicate",
-    "Name":"http:\/\/schema.org\/numberOfAvailableAccommodationUnits-input",
+    "Name":"https://schema.org/numberOfAvailableAccommodationUnits-input",
     "Domain Bucket":"< 1K"
   },
   {
     "Class":"Predicate",
-    "Name":"http:\/\/schema.org\/numberOfAvailableAccommodationUnits-output",
+    "Name":"https://schema.org/numberOfAvailableAccommodationUnits-output",
     "Domain Bucket":"< 1K"
   },
   {
     "Class":"Predicate",
-    "Name":"http:\/\/schema.org\/numberOfAxles",
+    "Name":"https://schema.org/numberOfAxles",
     "Domain Bucket":"< 1K"
   },
   {
     "Class":"Predicate",
-    "Name":"http:\/\/schema.org\/numberOfAxles-input",
+    "Name":"https://schema.org/numberOfAxles-input",
     "Domain Bucket":"< 1K"
   },
   {
     "Class":"Predicate",
-    "Name":"http:\/\/schema.org\/numberOfAxles-output",
+    "Name":"https://schema.org/numberOfAxles-output",
     "Domain Bucket":"< 1K"
   },
   {
     "Class":"Predicate",
-    "Name":"http:\/\/schema.org\/numberOfBathroomsTotal",
+    "Name":"https://schema.org/numberOfBathroomsTotal",
     "Domain Bucket":"10K - 100K"
   },
   {
     "Class":"Predicate",
-    "Name":"http:\/\/schema.org\/numberOfBathroomsTotal-input",
+    "Name":"https://schema.org/numberOfBathroomsTotal-input",
     "Domain Bucket":"< 1K"
   },
   {
     "Class":"Predicate",
-    "Name":"http:\/\/schema.org\/numberOfBathroomsTotal-output",
+    "Name":"https://schema.org/numberOfBathroomsTotal-output",
     "Domain Bucket":"< 1K"
   },
   {
     "Class":"Predicate",
-    "Name":"http:\/\/schema.org\/numberOfBedrooms",
+    "Name":"https://schema.org/numberOfBedrooms",
     "Domain Bucket":"10K - 100K"
   },
   {
     "Class":"Predicate",
-    "Name":"http:\/\/schema.org\/numberOfBedrooms-input",
+    "Name":"https://schema.org/numberOfBedrooms-input",
     "Domain Bucket":"< 1K"
   },
   {
     "Class":"Predicate",
-    "Name":"http:\/\/schema.org\/numberOfBedrooms-output",
+    "Name":"https://schema.org/numberOfBedrooms-output",
     "Domain Bucket":"< 1K"
   },
   {
     "Class":"Predicate",
-    "Name":"http:\/\/schema.org\/numberOfBeds",
+    "Name":"https://schema.org/numberOfBeds",
     "Domain Bucket":"10K - 100K"
   },
   {
     "Class":"Predicate",
-    "Name":"http:\/\/schema.org\/numberOfBeds-input",
+    "Name":"https://schema.org/numberOfBeds-input",
     "Domain Bucket":"< 1K"
   },
   {
     "Class":"Predicate",
-    "Name":"http:\/\/schema.org\/numberOfBeds-output",
+    "Name":"https://schema.org/numberOfBeds-output",
     "Domain Bucket":"< 1K"
   },
   {
     "Class":"Predicate",
-    "Name":"http:\/\/schema.org\/numberOfCredits",
+    "Name":"https://schema.org/numberOfCredits",
     "Domain Bucket":"1K - 10K"
   },
   {
     "Class":"Predicate",
-    "Name":"http:\/\/schema.org\/numberOfCredits-input",
+    "Name":"https://schema.org/numberOfCredits-input",
     "Domain Bucket":"< 1K"
   },
   {
     "Class":"Predicate",
-    "Name":"http:\/\/schema.org\/numberOfCredits-output",
+    "Name":"https://schema.org/numberOfCredits-output",
     "Domain Bucket":"< 1K"
   },
   {
     "Class":"Predicate",
-    "Name":"http:\/\/schema.org\/numberOfDoors",
+    "Name":"https://schema.org/numberOfDoors",
     "Domain Bucket":"10K - 100K"
   },
   {
     "Class":"Predicate",
-    "Name":"http:\/\/schema.org\/numberOfDoors-input",
+    "Name":"https://schema.org/numberOfDoors-input",
     "Domain Bucket":"< 1K"
   },
   {
     "Class":"Predicate",
-    "Name":"http:\/\/schema.org\/numberOfDoors-output",
+    "Name":"https://schema.org/numberOfDoors-output",
     "Domain Bucket":"< 1K"
   },
   {
     "Class":"Predicate",
-    "Name":"http:\/\/schema.org\/numberOfEmployees",
+    "Name":"https://schema.org/numberOfEmployees",
     "Domain Bucket":"100K - 1M"
   },
   {
     "Class":"Predicate",
-    "Name":"http:\/\/schema.org\/numberOfEmployees-input",
+    "Name":"https://schema.org/numberOfEmployees-input",
     "Domain Bucket":"< 1K"
   },
   {
     "Class":"Predicate",
-    "Name":"http:\/\/schema.org\/numberOfEmployees-output",
+    "Name":"https://schema.org/numberOfEmployees-output",
     "Domain Bucket":"< 1K"
   },
   {
     "Class":"Predicate",
-    "Name":"http:\/\/schema.org\/numberOfEpisodes",
+    "Name":"https://schema.org/numberOfEpisodes",
     "Domain Bucket":"10K - 100K"
   },
   {
     "Class":"Predicate",
-    "Name":"http:\/\/schema.org\/numberOfEpisodes-input",
+    "Name":"https://schema.org/numberOfEpisodes-input",
     "Domain Bucket":"< 1K"
   },
   {
     "Class":"Predicate",
-    "Name":"http:\/\/schema.org\/numberOfEpisodes-output",
+    "Name":"https://schema.org/numberOfEpisodes-output",
     "Domain Bucket":"< 1K"
   },
   {
     "Class":"Predicate",
-    "Name":"http:\/\/schema.org\/numberOfForwardGears",
+    "Name":"https://schema.org/numberOfForwardGears",
     "Domain Bucket":"1K - 10K"
   },
   {
     "Class":"Predicate",
-    "Name":"http:\/\/schema.org\/numberOfForwardGears-input",
+    "Name":"https://schema.org/numberOfForwardGears-input",
     "Domain Bucket":"< 1K"
   },
   {
     "Class":"Predicate",
-    "Name":"http:\/\/schema.org\/numberOfForwardGears-output",
+    "Name":"https://schema.org/numberOfForwardGears-output",
     "Domain Bucket":"< 1K"
   },
   {
     "Class":"Predicate",
-    "Name":"http:\/\/schema.org\/numberOfFullBathrooms",
+    "Name":"https://schema.org/numberOfFullBathrooms",
     "Domain Bucket":"10K - 100K"
   },
   {
     "Class":"Predicate",
-    "Name":"http:\/\/schema.org\/numberOfFullBathrooms-input",
+    "Name":"https://schema.org/numberOfFullBathrooms-input",
     "Domain Bucket":"< 1K"
   },
   {
     "Class":"Predicate",
-    "Name":"http:\/\/schema.org\/numberOfFullBathrooms-output",
+    "Name":"https://schema.org/numberOfFullBathrooms-output",
     "Domain Bucket":"< 1K"
   },
   {
     "Class":"Predicate",
-    "Name":"http:\/\/schema.org\/numberOfItems",
+    "Name":"https://schema.org/numberOfItems",
     "Domain Bucket":"100K - 1M"
   },
   {
     "Class":"Predicate",
-    "Name":"http:\/\/schema.org\/numberOfItems-input",
+    "Name":"https://schema.org/numberOfItems-input",
     "Domain Bucket":"< 1K"
   },
   {
     "Class":"Predicate",
-    "Name":"http:\/\/schema.org\/numberOfItems-output",
+    "Name":"https://schema.org/numberOfItems-output",
     "Domain Bucket":"< 1K"
   },
   {
     "Class":"Predicate",
-    "Name":"http:\/\/schema.org\/numberOfLoanPayments",
+    "Name":"https://schema.org/numberOfLoanPayments",
     "Domain Bucket":"< 1K"
   },
   {
     "Class":"Predicate",
-    "Name":"http:\/\/schema.org\/numberOfLoanPayments-input",
+    "Name":"https://schema.org/numberOfLoanPayments-input",
     "Domain Bucket":"< 1K"
   },
   {
     "Class":"Predicate",
-    "Name":"http:\/\/schema.org\/numberOfLoanPayments-output",
+    "Name":"https://schema.org/numberOfLoanPayments-output",
     "Domain Bucket":"< 1K"
   },
   {
     "Class":"Predicate",
-    "Name":"http:\/\/schema.org\/numberOfPages",
+    "Name":"https://schema.org/numberOfPages",
     "Domain Bucket":"10K - 100K"
   },
   {
     "Class":"Predicate",
-    "Name":"http:\/\/schema.org\/numberOfPages-input",
+    "Name":"https://schema.org/numberOfPages-input",
     "Domain Bucket":"< 1K"
   },
   {
     "Class":"Predicate",
-    "Name":"http:\/\/schema.org\/numberOfPages-output",
+    "Name":"https://schema.org/numberOfPages-output",
     "Domain Bucket":"< 1K"
   },
   {
     "Class":"Predicate",
-    "Name":"http:\/\/schema.org\/numberOfPartialBathrooms",
+    "Name":"https://schema.org/numberOfPartialBathrooms",
     "Domain Bucket":"1K - 10K"
   },
   {
     "Class":"Predicate",
-    "Name":"http:\/\/schema.org\/numberOfPartialBathrooms-input",
+    "Name":"https://schema.org/numberOfPartialBathrooms-input",
     "Domain Bucket":"< 1K"
   },
   {
     "Class":"Predicate",
-    "Name":"http:\/\/schema.org\/numberOfPartialBathrooms-output",
+    "Name":"https://schema.org/numberOfPartialBathrooms-output",
     "Domain Bucket":"< 1K"
   },
   {
     "Class":"Predicate",
-    "Name":"http:\/\/schema.org\/numberOfPlayers",
+    "Name":"https://schema.org/numberOfPlayers",
     "Domain Bucket":"10K - 100K"
   },
   {
     "Class":"Predicate",
-    "Name":"http:\/\/schema.org\/numberOfPlayers-input",
+    "Name":"https://schema.org/numberOfPlayers-input",
     "Domain Bucket":"< 1K"
   },
   {
     "Class":"Predicate",
-    "Name":"http:\/\/schema.org\/numberOfPlayers-output",
+    "Name":"https://schema.org/numberOfPlayers-output",
     "Domain Bucket":"< 1K"
   },
   {
     "Class":"Predicate",
-    "Name":"http:\/\/schema.org\/numberOfPreviousOwners",
+    "Name":"https://schema.org/numberOfPreviousOwners",
     "Domain Bucket":"1K - 10K"
   },
   {
     "Class":"Predicate",
-    "Name":"http:\/\/schema.org\/numberOfPreviousOwners-input",
+    "Name":"https://schema.org/numberOfPreviousOwners-input",
     "Domain Bucket":"< 1K"
   },
   {
     "Class":"Predicate",
-    "Name":"http:\/\/schema.org\/numberOfPreviousOwners-output",
+    "Name":"https://schema.org/numberOfPreviousOwners-output",
     "Domain Bucket":"< 1K"
   },
   {
     "Class":"Predicate",
-    "Name":"http:\/\/schema.org\/numberOfRooms",
+    "Name":"https://schema.org/numberOfRooms",
     "Domain Bucket":"10K - 100K"
   },
   {
     "Class":"Predicate",
-    "Name":"http:\/\/schema.org\/numberOfRooms-input",
+    "Name":"https://schema.org/numberOfRooms-input",
     "Domain Bucket":"< 1K"
   },
   {
     "Class":"Predicate",
-    "Name":"http:\/\/schema.org\/numberOfRooms-output",
+    "Name":"https://schema.org/numberOfRooms-output",
     "Domain Bucket":"< 1K"
   },
   {
     "Class":"Predicate",
-    "Name":"http:\/\/schema.org\/numberOfSeasons",
+    "Name":"https://schema.org/numberOfSeasons",
     "Domain Bucket":"1K - 10K"
   },
   {
     "Class":"Predicate",
-    "Name":"http:\/\/schema.org\/numberOfSeasons-input",
+    "Name":"https://schema.org/numberOfSeasons-input",
     "Domain Bucket":"< 1K"
   },
   {
     "Class":"Predicate",
-    "Name":"http:\/\/schema.org\/numberOfSeasons-output",
+    "Name":"https://schema.org/numberOfSeasons-output",
     "Domain Bucket":"< 1K"
   },
   {
     "Class":"Predicate",
-    "Name":"http:\/\/schema.org\/numberedPosition",
+    "Name":"https://schema.org/numberedPosition",
     "Domain Bucket":"< 1K"
   },
   {
     "Class":"Predicate",
-    "Name":"http:\/\/schema.org\/numberedPosition-input",
+    "Name":"https://schema.org/numberedPosition-input",
     "Domain Bucket":"< 1K"
   },
   {
     "Class":"Predicate",
-    "Name":"http:\/\/schema.org\/numberedPosition-output",
+    "Name":"https://schema.org/numberedPosition-output",
     "Domain Bucket":"< 1K"
   },
   {
     "Class":"Predicate",
-    "Name":"http:\/\/schema.org\/nutrition",
+    "Name":"https://schema.org/nutrition",
     "Domain Bucket":"10K - 100K"
   },
   {
     "Class":"Predicate",
-    "Name":"http:\/\/schema.org\/nutrition-input",
+    "Name":"https://schema.org/nutrition-input",
     "Domain Bucket":"< 1K"
   },
   {
     "Class":"Predicate",
-    "Name":"http:\/\/schema.org\/nutrition-output",
+    "Name":"https://schema.org/nutrition-output",
     "Domain Bucket":"< 1K"
   },
   {
     "Class":"Predicate",
-    "Name":"http:\/\/schema.org\/object",
+    "Name":"https://schema.org/object",
     "Domain Bucket":"10K - 100K"
   },
   {
     "Class":"Predicate",
-    "Name":"http:\/\/schema.org\/object-input",
+    "Name":"https://schema.org/object-input",
     "Domain Bucket":"< 1K"
   },
   {
     "Class":"Predicate",
-    "Name":"http:\/\/schema.org\/object-output",
+    "Name":"https://schema.org/object-output",
     "Domain Bucket":"< 1K"
   },
   {
     "Class":"Predicate",
-    "Name":"http:\/\/schema.org\/observationAbout",
+    "Name":"https://schema.org/observationAbout",
     "Domain Bucket":"< 1K"
   },
   {
     "Class":"Predicate",
-    "Name":"http:\/\/schema.org\/observationAbout-input",
+    "Name":"https://schema.org/observationAbout-input",
     "Domain Bucket":"< 1K"
   },
   {
     "Class":"Predicate",
-    "Name":"http:\/\/schema.org\/observationAbout-output",
+    "Name":"https://schema.org/observationAbout-output",
     "Domain Bucket":"< 1K"
   },
   {
     "Class":"Predicate",
-    "Name":"http:\/\/schema.org\/observationDate",
+    "Name":"https://schema.org/observationDate",
     "Domain Bucket":"< 1K"
   },
   {
     "Class":"Predicate",
-    "Name":"http:\/\/schema.org\/observationDate-input",
+    "Name":"https://schema.org/observationDate-input",
     "Domain Bucket":"< 1K"
   },
   {
     "Class":"Predicate",
-    "Name":"http:\/\/schema.org\/observationDate-output",
+    "Name":"https://schema.org/observationDate-output",
     "Domain Bucket":"< 1K"
   },
   {
     "Class":"Predicate",
-    "Name":"http:\/\/schema.org\/observationPeriod",
+    "Name":"https://schema.org/observationPeriod",
     "Domain Bucket":"< 1K"
   },
   {
     "Class":"Predicate",
-    "Name":"http:\/\/schema.org\/observationPeriod-input",
+    "Name":"https://schema.org/observationPeriod-input",
     "Domain Bucket":"< 1K"
   },
   {
     "Class":"Predicate",
-    "Name":"http:\/\/schema.org\/observationPeriod-output",
+    "Name":"https://schema.org/observationPeriod-output",
     "Domain Bucket":"< 1K"
   },
   {
     "Class":"Predicate",
-    "Name":"http:\/\/schema.org\/occupancy",
+    "Name":"https://schema.org/occupancy",
     "Domain Bucket":"10K - 100K"
   },
   {
     "Class":"Predicate",
-    "Name":"http:\/\/schema.org\/occupancy-input",
+    "Name":"https://schema.org/occupancy-input",
     "Domain Bucket":"< 1K"
   },
   {
     "Class":"Predicate",
-    "Name":"http:\/\/schema.org\/occupancy-output",
+    "Name":"https://schema.org/occupancy-output",
     "Domain Bucket":"< 1K"
   },
   {
     "Class":"Predicate",
-    "Name":"http:\/\/schema.org\/occupationLocation",
+    "Name":"https://schema.org/occupationLocation",
     "Domain Bucket":"10K - 100K"
   },
   {
     "Class":"Predicate",
-    "Name":"http:\/\/schema.org\/occupationLocation-input",
+    "Name":"https://schema.org/occupationLocation-input",
     "Domain Bucket":"< 1K"
   },
   {
     "Class":"Predicate",
-    "Name":"http:\/\/schema.org\/occupationLocation-output",
+    "Name":"https://schema.org/occupationLocation-output",
     "Domain Bucket":"< 1K"
   },
   {
     "Class":"Predicate",
-    "Name":"http:\/\/schema.org\/occupationalCategory",
+    "Name":"https://schema.org/occupationalCategory",
     "Domain Bucket":"10K - 100K"
   },
   {
     "Class":"Predicate",
-    "Name":"http:\/\/schema.org\/occupationalCategory-input",
+    "Name":"https://schema.org/occupationalCategory-input",
     "Domain Bucket":"< 1K"
   },
   {
     "Class":"Predicate",
-    "Name":"http:\/\/schema.org\/occupationalCategory-output",
+    "Name":"https://schema.org/occupationalCategory-output",
     "Domain Bucket":"< 1K"
   },
   {
     "Class":"Predicate",
-    "Name":"http:\/\/schema.org\/occupationalCredentialAwarded",
+    "Name":"https://schema.org/occupationalCredentialAwarded",
     "Domain Bucket":"1K - 10K"
   },
   {
     "Class":"Predicate",
-    "Name":"http:\/\/schema.org\/occupationalCredentialAwarded-input",
+    "Name":"https://schema.org/occupationalCredentialAwarded-input",
     "Domain Bucket":"< 1K"
   },
   {
     "Class":"Predicate",
-    "Name":"http:\/\/schema.org\/occupationalCredentialAwarded-output",
+    "Name":"https://schema.org/occupationalCredentialAwarded-output",
     "Domain Bucket":"< 1K"
   },
   {
     "Class":"Predicate",
-    "Name":"http:\/\/schema.org\/offerCount",
+    "Name":"https://schema.org/offerCount",
     "Domain Bucket":"1M - 10M"
   },
   {
     "Class":"Predicate",
-    "Name":"http:\/\/schema.org\/offerCount-input",
+    "Name":"https://schema.org/offerCount-input",
     "Domain Bucket":"< 1K"
   },
   {
     "Class":"Predicate",
-    "Name":"http:\/\/schema.org\/offerCount-output",
+    "Name":"https://schema.org/offerCount-output",
     "Domain Bucket":"< 1K"
   },
   {
     "Class":"Predicate",
-    "Name":"http:\/\/schema.org\/offeredBy",
+    "Name":"https://schema.org/offeredBy",
     "Domain Bucket":"10K - 100K"
   },
   {
     "Class":"Predicate",
-    "Name":"http:\/\/schema.org\/offeredBy-input",
+    "Name":"https://schema.org/offeredBy-input",
     "Domain Bucket":"< 1K"
   },
   {
     "Class":"Predicate",
-    "Name":"http:\/\/schema.org\/offeredBy-output",
+    "Name":"https://schema.org/offeredBy-output",
     "Domain Bucket":"< 1K"
   },
   {
     "Class":"Predicate",
-    "Name":"http:\/\/schema.org\/offers",
+    "Name":"https://schema.org/offers",
     "Domain Bucket":"10M+"
   },
   {
     "Class":"Predicate",
-    "Name":"http:\/\/schema.org\/offers-input",
+    "Name":"https://schema.org/offers-input",
     "Domain Bucket":"< 1K"
   },
   {
     "Class":"Predicate",
-    "Name":"http:\/\/schema.org\/offers-output",
+    "Name":"https://schema.org/offers-output",
     "Domain Bucket":"< 1K"
   },
   {
     "Class":"Predicate",
-    "Name":"http:\/\/schema.org\/offersPrescriptionByMail",
+    "Name":"https://schema.org/offersPrescriptionByMail",
     "Domain Bucket":"< 1K"
   },
   {
     "Class":"Predicate",
-    "Name":"http:\/\/schema.org\/offersPrescriptionByMail-input",
+    "Name":"https://schema.org/offersPrescriptionByMail-input",
     "Domain Bucket":"< 1K"
   },
   {
     "Class":"Predicate",
-    "Name":"http:\/\/schema.org\/offersPrescriptionByMail-output",
+    "Name":"https://schema.org/offersPrescriptionByMail-output",
     "Domain Bucket":"< 1K"
   },
   {
     "Class":"Predicate",
-    "Name":"http:\/\/schema.org\/openingHours",
+    "Name":"https://schema.org/openingHours",
     "Domain Bucket":"1M - 10M"
   },
   {
     "Class":"Predicate",
-    "Name":"http:\/\/schema.org\/openingHours-input",
+    "Name":"https://schema.org/openingHours-input",
     "Domain Bucket":"< 1K"
   },
   {
     "Class":"Predicate",
-    "Name":"http:\/\/schema.org\/openingHours-output",
+    "Name":"https://schema.org/openingHours-output",
     "Domain Bucket":"< 1K"
   },
   {
     "Class":"Predicate",
-    "Name":"http:\/\/schema.org\/openingHoursSpecification",
+    "Name":"https://schema.org/openingHoursSpecification",
     "Domain Bucket":"1M - 10M"
   },
   {
     "Class":"Predicate",
-    "Name":"http:\/\/schema.org\/openingHoursSpecification-input",
+    "Name":"https://schema.org/openingHoursSpecification-input",
     "Domain Bucket":"< 1K"
   },
   {
     "Class":"Predicate",
-    "Name":"http:\/\/schema.org\/openingHoursSpecification-output",
+    "Name":"https://schema.org/openingHoursSpecification-output",
     "Domain Bucket":"< 1K"
   },
   {
     "Class":"Predicate",
-    "Name":"http:\/\/schema.org\/opens",
+    "Name":"https://schema.org/opens",
     "Domain Bucket":"1M - 10M"
   },
   {
     "Class":"Predicate",
-    "Name":"http:\/\/schema.org\/opens-input",
+    "Name":"https://schema.org/opens-input",
     "Domain Bucket":"< 1K"
   },
   {
     "Class":"Predicate",
-    "Name":"http:\/\/schema.org\/opens-output",
+    "Name":"https://schema.org/opens-output",
     "Domain Bucket":"< 1K"
   },
   {
     "Class":"Predicate",
-    "Name":"http:\/\/schema.org\/operatingSystem",
+    "Name":"https://schema.org/operatingSystem",
     "Domain Bucket":"1M - 10M"
   },
   {
     "Class":"Predicate",
-    "Name":"http:\/\/schema.org\/operatingSystem-input",
+    "Name":"https://schema.org/operatingSystem-input",
     "Domain Bucket":"< 1K"
   },
   {
     "Class":"Predicate",
-    "Name":"http:\/\/schema.org\/operatingSystem-output",
+    "Name":"https://schema.org/operatingSystem-output",
     "Domain Bucket":"< 1K"
   },
   {
     "Class":"Predicate",
-    "Name":"http:\/\/schema.org\/opponent",
+    "Name":"https://schema.org/opponent",
     "Domain Bucket":"< 1K"
   },
   {
     "Class":"Predicate",
-    "Name":"http:\/\/schema.org\/opponent-input",
+    "Name":"https://schema.org/opponent-input",
     "Domain Bucket":"< 1K"
   },
   {
     "Class":"Predicate",
-    "Name":"http:\/\/schema.org\/opponent-output",
+    "Name":"https://schema.org/opponent-output",
     "Domain Bucket":"< 1K"
   },
   {
     "Class":"Predicate",
-    "Name":"http:\/\/schema.org\/option",
+    "Name":"https://schema.org/option",
     "Domain Bucket":"< 1K"
   },
   {
     "Class":"Predicate",
-    "Name":"http:\/\/schema.org\/option-input",
+    "Name":"https://schema.org/option-input",
     "Domain Bucket":"< 1K"
   },
   {
     "Class":"Predicate",
-    "Name":"http:\/\/schema.org\/option-output",
+    "Name":"https://schema.org/option-output",
     "Domain Bucket":"< 1K"
   },
   {
     "Class":"Predicate",
-    "Name":"http:\/\/schema.org\/orderDate",
+    "Name":"https://schema.org/orderDate",
     "Domain Bucket":"< 1K"
   },
   {
     "Class":"Predicate",
-    "Name":"http:\/\/schema.org\/orderDate-input",
+    "Name":"https://schema.org/orderDate-input",
     "Domain Bucket":"< 1K"
   },
   {
     "Class":"Predicate",
-    "Name":"http:\/\/schema.org\/orderDate-output",
+    "Name":"https://schema.org/orderDate-output",
     "Domain Bucket":"< 1K"
   },
   {
     "Class":"Predicate",
-    "Name":"http:\/\/schema.org\/orderDelivery",
+    "Name":"https://schema.org/orderDelivery",
     "Domain Bucket":"< 1K"
   },
   {
     "Class":"Predicate",
-    "Name":"http:\/\/schema.org\/orderDelivery-input",
+    "Name":"https://schema.org/orderDelivery-input",
     "Domain Bucket":"< 1K"
   },
   {
     "Class":"Predicate",
-    "Name":"http:\/\/schema.org\/orderDelivery-output",
+    "Name":"https://schema.org/orderDelivery-output",
     "Domain Bucket":"< 1K"
   },
   {
     "Class":"Predicate",
-    "Name":"http:\/\/schema.org\/orderItemNumber",
+    "Name":"https://schema.org/orderItemNumber",
     "Domain Bucket":"< 1K"
   },
   {
     "Class":"Predicate",
-    "Name":"http:\/\/schema.org\/orderItemNumber-input",
+    "Name":"https://schema.org/orderItemNumber-input",
     "Domain Bucket":"< 1K"
   },
   {
     "Class":"Predicate",
-    "Name":"http:\/\/schema.org\/orderItemNumber-output",
+    "Name":"https://schema.org/orderItemNumber-output",
     "Domain Bucket":"< 1K"
   },
   {
     "Class":"Predicate",
-    "Name":"http:\/\/schema.org\/orderItemStatus",
+    "Name":"https://schema.org/orderItemStatus",
     "Domain Bucket":"< 1K"
   },
   {
     "Class":"Predicate",
-    "Name":"http:\/\/schema.org\/orderItemStatus-input",
+    "Name":"https://schema.org/orderItemStatus-input",
     "Domain Bucket":"< 1K"
   },
   {
     "Class":"Predicate",
-    "Name":"http:\/\/schema.org\/orderItemStatus-output",
+    "Name":"https://schema.org/orderItemStatus-output",
     "Domain Bucket":"< 1K"
   },
   {
     "Class":"Predicate",
-    "Name":"http:\/\/schema.org\/orderNumber",
+    "Name":"https://schema.org/orderNumber",
     "Domain Bucket":"< 1K"
   },
   {
     "Class":"Predicate",
-    "Name":"http:\/\/schema.org\/orderNumber-input",
+    "Name":"https://schema.org/orderNumber-input",
     "Domain Bucket":"< 1K"
   },
   {
     "Class":"Predicate",
-    "Name":"http:\/\/schema.org\/orderNumber-output",
+    "Name":"https://schema.org/orderNumber-output",
     "Domain Bucket":"< 1K"
   },
   {
     "Class":"Predicate",
-    "Name":"http:\/\/schema.org\/orderPercentage",
+    "Name":"https://schema.org/orderPercentage",
     "Domain Bucket":"< 1K"
   },
   {
     "Class":"Predicate",
-    "Name":"http:\/\/schema.org\/orderPercentage-input",
+    "Name":"https://schema.org/orderPercentage-input",
     "Domain Bucket":"< 1K"
   },
   {
     "Class":"Predicate",
-    "Name":"http:\/\/schema.org\/orderPercentage-output",
+    "Name":"https://schema.org/orderPercentage-output",
     "Domain Bucket":"< 1K"
   },
   {
     "Class":"Predicate",
-    "Name":"http:\/\/schema.org\/orderQuantity",
+    "Name":"https://schema.org/orderQuantity",
     "Domain Bucket":"< 1K"
   },
   {
     "Class":"Predicate",
-    "Name":"http:\/\/schema.org\/orderQuantity-input",
+    "Name":"https://schema.org/orderQuantity-input",
     "Domain Bucket":"< 1K"
   },
   {
     "Class":"Predicate",
-    "Name":"http:\/\/schema.org\/orderQuantity-output",
+    "Name":"https://schema.org/orderQuantity-output",
     "Domain Bucket":"< 1K"
   },
   {
     "Class":"Predicate",
-    "Name":"http:\/\/schema.org\/orderStatus",
+    "Name":"https://schema.org/orderStatus",
     "Domain Bucket":"< 1K"
   },
   {
     "Class":"Predicate",
-    "Name":"http:\/\/schema.org\/orderStatus-input",
+    "Name":"https://schema.org/orderStatus-input",
     "Domain Bucket":"< 1K"
   },
   {
     "Class":"Predicate",
-    "Name":"http:\/\/schema.org\/orderStatus-output",
+    "Name":"https://schema.org/orderStatus-output",
     "Domain Bucket":"< 1K"
   },
   {
     "Class":"Predicate",
-    "Name":"http:\/\/schema.org\/orderValue",
+    "Name":"https://schema.org/orderValue",
     "Domain Bucket":"< 1K"
   },
   {
     "Class":"Predicate",
-    "Name":"http:\/\/schema.org\/orderValue-input",
+    "Name":"https://schema.org/orderValue-input",
     "Domain Bucket":"< 1K"
   },
   {
     "Class":"Predicate",
-    "Name":"http:\/\/schema.org\/orderValue-output",
+    "Name":"https://schema.org/orderValue-output",
     "Domain Bucket":"< 1K"
   },
   {
     "Class":"Predicate",
-    "Name":"http:\/\/schema.org\/orderedItem",
+    "Name":"https://schema.org/orderedItem",
     "Domain Bucket":"< 1K"
   },
   {
     "Class":"Predicate",
-    "Name":"http:\/\/schema.org\/orderedItem-input",
+    "Name":"https://schema.org/orderedItem-input",
     "Domain Bucket":"< 1K"
   },
   {
     "Class":"Predicate",
-    "Name":"http:\/\/schema.org\/orderedItem-output",
+    "Name":"https://schema.org/orderedItem-output",
     "Domain Bucket":"< 1K"
   },
   {
     "Class":"Predicate",
-    "Name":"http:\/\/schema.org\/organizer",
+    "Name":"https://schema.org/organizer",
     "Domain Bucket":"100K - 1M"
   },
   {
     "Class":"Predicate",
-    "Name":"http:\/\/schema.org\/organizer-input",
+    "Name":"https://schema.org/organizer-input",
     "Domain Bucket":"< 1K"
   },
   {
     "Class":"Predicate",
-    "Name":"http:\/\/schema.org\/organizer-output",
+    "Name":"https://schema.org/organizer-output",
     "Domain Bucket":"< 1K"
   },
   {
     "Class":"Predicate",
-    "Name":"http:\/\/schema.org\/originAddress",
+    "Name":"https://schema.org/originAddress",
     "Domain Bucket":"< 1K"
   },
   {
     "Class":"Predicate",
-    "Name":"http:\/\/schema.org\/originAddress-input",
+    "Name":"https://schema.org/originAddress-input",
     "Domain Bucket":"< 1K"
   },
   {
     "Class":"Predicate",
-    "Name":"http:\/\/schema.org\/originAddress-output",
+    "Name":"https://schema.org/originAddress-output",
     "Domain Bucket":"< 1K"
   },
   {
     "Class":"Predicate",
-    "Name":"http:\/\/schema.org\/originalMediaContextDescription",
+    "Name":"https://schema.org/originalMediaContextDescription",
     "Domain Bucket":"< 1K"
   },
   {
     "Class":"Predicate",
-    "Name":"http:\/\/schema.org\/originalMediaContextDescription-input",
+    "Name":"https://schema.org/originalMediaContextDescription-input",
     "Domain Bucket":"< 1K"
   },
   {
     "Class":"Predicate",
-    "Name":"http:\/\/schema.org\/originalMediaContextDescription-output",
+    "Name":"https://schema.org/originalMediaContextDescription-output",
     "Domain Bucket":"< 1K"
   },
   {
     "Class":"Predicate",
-    "Name":"http:\/\/schema.org\/originalMediaLink",
+    "Name":"https://schema.org/originalMediaLink",
     "Domain Bucket":"< 1K"
   },
   {
     "Class":"Predicate",
-    "Name":"http:\/\/schema.org\/originalMediaLink-input",
+    "Name":"https://schema.org/originalMediaLink-input",
     "Domain Bucket":"< 1K"
   },
   {
     "Class":"Predicate",
-    "Name":"http:\/\/schema.org\/originalMediaLink-output",
+    "Name":"https://schema.org/originalMediaLink-output",
     "Domain Bucket":"< 1K"
   },
   {
     "Class":"Predicate",
-    "Name":"http:\/\/schema.org\/originatesFrom",
+    "Name":"https://schema.org/originatesFrom",
     "Domain Bucket":"< 1K"
   },
   {
     "Class":"Predicate",
-    "Name":"http:\/\/schema.org\/originatesFrom-input",
+    "Name":"https://schema.org/originatesFrom-input",
     "Domain Bucket":"< 1K"
   },
   {
     "Class":"Predicate",
-    "Name":"http:\/\/schema.org\/originatesFrom-output",
+    "Name":"https://schema.org/originatesFrom-output",
     "Domain Bucket":"< 1K"
   },
   {
     "Class":"Predicate",
-    "Name":"http:\/\/schema.org\/overdosage",
+    "Name":"https://schema.org/overdosage",
     "Domain Bucket":"< 1K"
   },
   {
     "Class":"Predicate",
-    "Name":"http:\/\/schema.org\/overdosage-input",
+    "Name":"https://schema.org/overdosage-input",
     "Domain Bucket":"< 1K"
   },
   {
     "Class":"Predicate",
-    "Name":"http:\/\/schema.org\/overdosage-output",
+    "Name":"https://schema.org/overdosage-output",
     "Domain Bucket":"< 1K"
   },
   {
     "Class":"Predicate",
-    "Name":"http:\/\/schema.org\/ownedFrom",
+    "Name":"https://schema.org/ownedFrom",
     "Domain Bucket":"< 1K"
   },
   {
     "Class":"Predicate",
-    "Name":"http:\/\/schema.org\/ownedFrom-input",
+    "Name":"https://schema.org/ownedFrom-input",
     "Domain Bucket":"< 1K"
   },
   {
     "Class":"Predicate",
-    "Name":"http:\/\/schema.org\/ownedFrom-output",
+    "Name":"https://schema.org/ownedFrom-output",
     "Domain Bucket":"< 1K"
   },
   {
     "Class":"Predicate",
-    "Name":"http:\/\/schema.org\/ownedThrough",
+    "Name":"https://schema.org/ownedThrough",
     "Domain Bucket":"< 1K"
   },
   {
     "Class":"Predicate",
-    "Name":"http:\/\/schema.org\/ownedThrough-input",
+    "Name":"https://schema.org/ownedThrough-input",
     "Domain Bucket":"< 1K"
   },
   {
     "Class":"Predicate",
-    "Name":"http:\/\/schema.org\/ownedThrough-output",
+    "Name":"https://schema.org/ownedThrough-output",
     "Domain Bucket":"< 1K"
   },
   {
     "Class":"Predicate",
-    "Name":"http:\/\/schema.org\/owner",
+    "Name":"https://schema.org/owner",
     "Domain Bucket":"1K - 10K"
   },
   {
     "Class":"Predicate",
-    "Name":"http:\/\/schema.org\/owner-input",
+    "Name":"https://schema.org/owner-input",
     "Domain Bucket":"< 1K"
   },
   {
     "Class":"Predicate",
-    "Name":"http:\/\/schema.org\/owner-output",
+    "Name":"https://schema.org/owner-output",
     "Domain Bucket":"< 1K"
   },
   {
     "Class":"Predicate",
-    "Name":"http:\/\/schema.org\/ownershipFundingInfo",
+    "Name":"https://schema.org/ownershipFundingInfo",
     "Domain Bucket":"10K - 100K"
   },
   {
     "Class":"Predicate",
-    "Name":"http:\/\/schema.org\/ownershipFundingInfo-input",
+    "Name":"https://schema.org/ownershipFundingInfo-input",
     "Domain Bucket":"< 1K"
   },
   {
     "Class":"Predicate",
-    "Name":"http:\/\/schema.org\/ownershipFundingInfo-output",
+    "Name":"https://schema.org/ownershipFundingInfo-output",
     "Domain Bucket":"< 1K"
   },
   {
     "Class":"Predicate",
-    "Name":"http:\/\/schema.org\/owns",
+    "Name":"https://schema.org/owns",
     "Domain Bucket":"10K - 100K"
   },
   {
     "Class":"Predicate",
-    "Name":"http:\/\/schema.org\/owns-input",
+    "Name":"https://schema.org/owns-input",
     "Domain Bucket":"< 1K"
   },
   {
     "Class":"Predicate",
-    "Name":"http:\/\/schema.org\/owns-output",
+    "Name":"https://schema.org/owns-output",
     "Domain Bucket":"< 1K"
   },
   {
     "Class":"Predicate",
-    "Name":"http:\/\/schema.org\/pageEnd",
+    "Name":"https://schema.org/pageEnd",
     "Domain Bucket":"1K - 10K"
   },
   {
     "Class":"Predicate",
-    "Name":"http:\/\/schema.org\/pageEnd-input",
+    "Name":"https://schema.org/pageEnd-input",
     "Domain Bucket":"< 1K"
   },
   {
     "Class":"Predicate",
-    "Name":"http:\/\/schema.org\/pageEnd-output",
+    "Name":"https://schema.org/pageEnd-output",
     "Domain Bucket":"< 1K"
   },
   {
     "Class":"Predicate",
-    "Name":"http:\/\/schema.org\/pageStart",
+    "Name":"https://schema.org/pageStart",
     "Domain Bucket":"1K - 10K"
   },
   {
     "Class":"Predicate",
-    "Name":"http:\/\/schema.org\/pageStart-input",
+    "Name":"https://schema.org/pageStart-input",
     "Domain Bucket":"< 1K"
   },
   {
     "Class":"Predicate",
-    "Name":"http:\/\/schema.org\/pageStart-output",
+    "Name":"https://schema.org/pageStart-output",
     "Domain Bucket":"< 1K"
   },
   {
     "Class":"Predicate",
-    "Name":"http:\/\/schema.org\/pagination",
+    "Name":"https://schema.org/pagination",
     "Domain Bucket":"1K - 10K"
   },
   {
     "Class":"Predicate",
-    "Name":"http:\/\/schema.org\/pagination-input",
+    "Name":"https://schema.org/pagination-input",
     "Domain Bucket":"< 1K"
   },
   {
     "Class":"Predicate",
-    "Name":"http:\/\/schema.org\/pagination-output",
+    "Name":"https://schema.org/pagination-output",
     "Domain Bucket":"< 1K"
   },
   {
     "Class":"Predicate",
-    "Name":"http:\/\/schema.org\/parent",
+    "Name":"https://schema.org/parent",
     "Domain Bucket":"1K - 10K"
   },
   {
     "Class":"Predicate",
-    "Name":"http:\/\/schema.org\/parent-input",
+    "Name":"https://schema.org/parent-input",
     "Domain Bucket":"< 1K"
   },
   {
     "Class":"Predicate",
-    "Name":"http:\/\/schema.org\/parent-output",
+    "Name":"https://schema.org/parent-output",
     "Domain Bucket":"< 1K"
   },
   {
     "Class":"Predicate",
-    "Name":"http:\/\/schema.org\/parentItem",
+    "Name":"https://schema.org/parentItem",
     "Domain Bucket":"1K - 10K"
   },
   {
     "Class":"Predicate",
-    "Name":"http:\/\/schema.org\/parentItem-input",
+    "Name":"https://schema.org/parentItem-input",
     "Domain Bucket":"< 1K"
   },
   {
     "Class":"Predicate",
-    "Name":"http:\/\/schema.org\/parentItem-output",
+    "Name":"https://schema.org/parentItem-output",
     "Domain Bucket":"< 1K"
   },
   {
     "Class":"Predicate",
-    "Name":"http:\/\/schema.org\/parentOrganization",
+    "Name":"https://schema.org/parentOrganization",
     "Domain Bucket":"100K - 1M"
   },
   {
     "Class":"Predicate",
-    "Name":"http:\/\/schema.org\/parentOrganization-input",
+    "Name":"https://schema.org/parentOrganization-input",
     "Domain Bucket":"< 1K"
   },
   {
     "Class":"Predicate",
-    "Name":"http:\/\/schema.org\/parentOrganization-output",
+    "Name":"https://schema.org/parentOrganization-output",
     "Domain Bucket":"< 1K"
   },
   {
     "Class":"Predicate",
-    "Name":"http:\/\/schema.org\/parentService",
+    "Name":"https://schema.org/parentService",
     "Domain Bucket":"< 1K"
   },
   {
     "Class":"Predicate",
-    "Name":"http:\/\/schema.org\/parentService-input",
+    "Name":"https://schema.org/parentService-input",
     "Domain Bucket":"< 1K"
   },
   {
     "Class":"Predicate",
-    "Name":"http:\/\/schema.org\/parentService-output",
+    "Name":"https://schema.org/parentService-output",
     "Domain Bucket":"< 1K"
   },
   {
     "Class":"Predicate",
-    "Name":"http:\/\/schema.org\/parentTaxon",
+    "Name":"https://schema.org/parentTaxon",
     "Domain Bucket":"< 1K"
   },
   {
     "Class":"Predicate",
-    "Name":"http:\/\/schema.org\/parentTaxon-input",
+    "Name":"https://schema.org/parentTaxon-input",
     "Domain Bucket":"< 1K"
   },
   {
     "Class":"Predicate",
-    "Name":"http:\/\/schema.org\/parentTaxon-output",
+    "Name":"https://schema.org/parentTaxon-output",
     "Domain Bucket":"< 1K"
   },
   {
     "Class":"Predicate",
-    "Name":"http:\/\/schema.org\/parents",
+    "Name":"https://schema.org/parents",
     "Domain Bucket":"< 1K"
   },
   {
     "Class":"Predicate",
-    "Name":"http:\/\/schema.org\/parents-input",
+    "Name":"https://schema.org/parents-input",
     "Domain Bucket":"< 1K"
   },
   {
     "Class":"Predicate",
-    "Name":"http:\/\/schema.org\/parents-output",
+    "Name":"https://schema.org/parents-output",
     "Domain Bucket":"< 1K"
   },
   {
     "Class":"Predicate",
-    "Name":"http:\/\/schema.org\/partOfEpisode",
+    "Name":"https://schema.org/partOfEpisode",
     "Domain Bucket":"< 1K"
   },
   {
     "Class":"Predicate",
-    "Name":"http:\/\/schema.org\/partOfEpisode-input",
+    "Name":"https://schema.org/partOfEpisode-input",
     "Domain Bucket":"< 1K"
   },
   {
     "Class":"Predicate",
-    "Name":"http:\/\/schema.org\/partOfEpisode-output",
+    "Name":"https://schema.org/partOfEpisode-output",
     "Domain Bucket":"< 1K"
   },
   {
     "Class":"Predicate",
-    "Name":"http:\/\/schema.org\/partOfInvoice",
+    "Name":"https://schema.org/partOfInvoice",
     "Domain Bucket":"< 1K"
   },
   {
     "Class":"Predicate",
-    "Name":"http:\/\/schema.org\/partOfInvoice-input",
+    "Name":"https://schema.org/partOfInvoice-input",
     "Domain Bucket":"< 1K"
   },
   {
     "Class":"Predicate",
-    "Name":"http:\/\/schema.org\/partOfInvoice-output",
+    "Name":"https://schema.org/partOfInvoice-output",
     "Domain Bucket":"< 1K"
   },
   {
     "Class":"Predicate",
-    "Name":"http:\/\/schema.org\/partOfOrder",
+    "Name":"https://schema.org/partOfOrder",
     "Domain Bucket":"< 1K"
   },
   {
     "Class":"Predicate",
-    "Name":"http:\/\/schema.org\/partOfOrder-input",
+    "Name":"https://schema.org/partOfOrder-input",
     "Domain Bucket":"< 1K"
   },
   {
     "Class":"Predicate",
-    "Name":"http:\/\/schema.org\/partOfOrder-output",
+    "Name":"https://schema.org/partOfOrder-output",
     "Domain Bucket":"< 1K"
   },
   {
     "Class":"Predicate",
-    "Name":"http:\/\/schema.org\/partOfSeason",
+    "Name":"https://schema.org/partOfSeason",
     "Domain Bucket":"1K - 10K"
   },
   {
     "Class":"Predicate",
-    "Name":"http:\/\/schema.org\/partOfSeason-input",
+    "Name":"https://schema.org/partOfSeason-input",
     "Domain Bucket":"< 1K"
   },
   {
     "Class":"Predicate",
-    "Name":"http:\/\/schema.org\/partOfSeason-output",
+    "Name":"https://schema.org/partOfSeason-output",
     "Domain Bucket":"< 1K"
   },
   {
     "Class":"Predicate",
-    "Name":"http:\/\/schema.org\/partOfSeries",
+    "Name":"https://schema.org/partOfSeries",
     "Domain Bucket":"10K - 100K"
   },
   {
     "Class":"Predicate",
-    "Name":"http:\/\/schema.org\/partOfSeries-input",
+    "Name":"https://schema.org/partOfSeries-input",
     "Domain Bucket":"< 1K"
   },
   {
     "Class":"Predicate",
-    "Name":"http:\/\/schema.org\/partOfSeries-output",
+    "Name":"https://schema.org/partOfSeries-output",
     "Domain Bucket":"< 1K"
   },
   {
     "Class":"Predicate",
-    "Name":"http:\/\/schema.org\/partOfSystem",
+    "Name":"https://schema.org/partOfSystem",
     "Domain Bucket":"< 1K"
   },
   {
     "Class":"Predicate",
-    "Name":"http:\/\/schema.org\/partOfSystem-input",
+    "Name":"https://schema.org/partOfSystem-input",
     "Domain Bucket":"< 1K"
   },
   {
     "Class":"Predicate",
-    "Name":"http:\/\/schema.org\/partOfSystem-output",
+    "Name":"https://schema.org/partOfSystem-output",
     "Domain Bucket":"< 1K"
   },
   {
     "Class":"Predicate",
-    "Name":"http:\/\/schema.org\/partOfTVSeries",
+    "Name":"https://schema.org/partOfTVSeries",
     "Domain Bucket":"< 1K"
   },
   {
     "Class":"Predicate",
-    "Name":"http:\/\/schema.org\/partOfTVSeries-input",
+    "Name":"https://schema.org/partOfTVSeries-input",
     "Domain Bucket":"< 1K"
   },
   {
     "Class":"Predicate",
-    "Name":"http:\/\/schema.org\/partOfTVSeries-output",
+    "Name":"https://schema.org/partOfTVSeries-output",
     "Domain Bucket":"< 1K"
   },
   {
     "Class":"Predicate",
-    "Name":"http:\/\/schema.org\/partOfTrip",
+    "Name":"https://schema.org/partOfTrip",
     "Domain Bucket":"< 1K"
   },
   {
     "Class":"Predicate",
-    "Name":"http:\/\/schema.org\/partOfTrip-input",
+    "Name":"https://schema.org/partOfTrip-input",
     "Domain Bucket":"< 1K"
   },
   {
     "Class":"Predicate",
-    "Name":"http:\/\/schema.org\/partOfTrip-output",
+    "Name":"https://schema.org/partOfTrip-output",
     "Domain Bucket":"< 1K"
   },
   {
     "Class":"Predicate",
-    "Name":"http:\/\/schema.org\/participant",
+    "Name":"https://schema.org/participant",
     "Domain Bucket":"1K - 10K"
   },
   {
     "Class":"Predicate",
-    "Name":"http:\/\/schema.org\/participant-input",
+    "Name":"https://schema.org/participant-input",
     "Domain Bucket":"< 1K"
   },
   {
     "Class":"Predicate",
-    "Name":"http:\/\/schema.org\/participant-output",
+    "Name":"https://schema.org/participant-output",
     "Domain Bucket":"< 1K"
   },
   {
     "Class":"Predicate",
-    "Name":"http:\/\/schema.org\/partySize",
+    "Name":"https://schema.org/partySize",
     "Domain Bucket":"< 1K"
   },
   {
     "Class":"Predicate",
-    "Name":"http:\/\/schema.org\/partySize-input",
+    "Name":"https://schema.org/partySize-input",
     "Domain Bucket":"< 1K"
   },
   {
     "Class":"Predicate",
-    "Name":"http:\/\/schema.org\/partySize-output",
+    "Name":"https://schema.org/partySize-output",
     "Domain Bucket":"< 1K"
   },
   {
     "Class":"Predicate",
-    "Name":"http:\/\/schema.org\/passengerPriorityStatus",
+    "Name":"https://schema.org/passengerPriorityStatus",
     "Domain Bucket":"< 1K"
   },
   {
     "Class":"Predicate",
-    "Name":"http:\/\/schema.org\/passengerPriorityStatus-input",
+    "Name":"https://schema.org/passengerPriorityStatus-input",
     "Domain Bucket":"< 1K"
   },
   {
     "Class":"Predicate",
-    "Name":"http:\/\/schema.org\/passengerPriorityStatus-output",
+    "Name":"https://schema.org/passengerPriorityStatus-output",
     "Domain Bucket":"< 1K"
   },
   {
     "Class":"Predicate",
-    "Name":"http:\/\/schema.org\/passengerSequenceNumber",
+    "Name":"https://schema.org/passengerSequenceNumber",
     "Domain Bucket":"< 1K"
   },
   {
     "Class":"Predicate",
-    "Name":"http:\/\/schema.org\/passengerSequenceNumber-input",
+    "Name":"https://schema.org/passengerSequenceNumber-input",
     "Domain Bucket":"< 1K"
   },
   {
     "Class":"Predicate",
-    "Name":"http:\/\/schema.org\/passengerSequenceNumber-output",
+    "Name":"https://schema.org/passengerSequenceNumber-output",
     "Domain Bucket":"< 1K"
   },
   {
     "Class":"Predicate",
-    "Name":"http:\/\/schema.org\/pathophysiology",
+    "Name":"https://schema.org/pathophysiology",
     "Domain Bucket":"< 1K"
   },
   {
     "Class":"Predicate",
-    "Name":"http:\/\/schema.org\/pathophysiology-input",
+    "Name":"https://schema.org/pathophysiology-input",
     "Domain Bucket":"< 1K"
   },
   {
     "Class":"Predicate",
-    "Name":"http:\/\/schema.org\/pathophysiology-output",
+    "Name":"https://schema.org/pathophysiology-output",
     "Domain Bucket":"< 1K"
   },
   {
     "Class":"Predicate",
-    "Name":"http:\/\/schema.org\/pattern",
+    "Name":"https://schema.org/pattern",
     "Domain Bucket":"1K - 10K"
   },
   {
     "Class":"Predicate",
-    "Name":"http:\/\/schema.org\/pattern-input",
+    "Name":"https://schema.org/pattern-input",
     "Domain Bucket":"< 1K"
   },
   {
     "Class":"Predicate",
-    "Name":"http:\/\/schema.org\/pattern-output",
+    "Name":"https://schema.org/pattern-output",
     "Domain Bucket":"< 1K"
   },
   {
     "Class":"Predicate",
-    "Name":"http:\/\/schema.org\/payload",
+    "Name":"https://schema.org/payload",
     "Domain Bucket":"1K - 10K"
   },
   {
     "Class":"Predicate",
-    "Name":"http:\/\/schema.org\/payload-input",
+    "Name":"https://schema.org/payload-input",
     "Domain Bucket":"< 1K"
   },
   {
     "Class":"Predicate",
-    "Name":"http:\/\/schema.org\/payload-output",
+    "Name":"https://schema.org/payload-output",
     "Domain Bucket":"< 1K"
   },
   {
     "Class":"Predicate",
-    "Name":"http:\/\/schema.org\/paymentAccepted",
+    "Name":"https://schema.org/paymentAccepted",
     "Domain Bucket":"100K - 1M"
   },
   {
     "Class":"Predicate",
-    "Name":"http:\/\/schema.org\/paymentAccepted-input",
+    "Name":"https://schema.org/paymentAccepted-input",
     "Domain Bucket":"< 1K"
   },
   {
     "Class":"Predicate",
-    "Name":"http:\/\/schema.org\/paymentAccepted-output",
+    "Name":"https://schema.org/paymentAccepted-output",
     "Domain Bucket":"< 1K"
   },
   {
     "Class":"Predicate",
-    "Name":"http:\/\/schema.org\/paymentDue",
+    "Name":"https://schema.org/paymentDue",
     "Domain Bucket":"< 1K"
   },
   {
     "Class":"Predicate",
-    "Name":"http:\/\/schema.org\/paymentDue-input",
+    "Name":"https://schema.org/paymentDue-input",
     "Domain Bucket":"< 1K"
   },
   {
     "Class":"Predicate",
-    "Name":"http:\/\/schema.org\/paymentDue-output",
+    "Name":"https://schema.org/paymentDue-output",
     "Domain Bucket":"< 1K"
   },
   {
     "Class":"Predicate",
-    "Name":"http:\/\/schema.org\/paymentDueDate",
+    "Name":"https://schema.org/paymentDueDate",
     "Domain Bucket":"< 1K"
   },
   {
     "Class":"Predicate",
-    "Name":"http:\/\/schema.org\/paymentDueDate-input",
+    "Name":"https://schema.org/paymentDueDate-input",
     "Domain Bucket":"< 1K"
   },
   {
     "Class":"Predicate",
-    "Name":"http:\/\/schema.org\/paymentDueDate-output",
+    "Name":"https://schema.org/paymentDueDate-output",
     "Domain Bucket":"< 1K"
   },
   {
     "Class":"Predicate",
-    "Name":"http:\/\/schema.org\/paymentMethod",
+    "Name":"https://schema.org/paymentMethod",
     "Domain Bucket":"< 1K"
   },
   {
     "Class":"Predicate",
-    "Name":"http:\/\/schema.org\/paymentMethod-input",
+    "Name":"https://schema.org/paymentMethod-input",
     "Domain Bucket":"< 1K"
   },
   {
     "Class":"Predicate",
-    "Name":"http:\/\/schema.org\/paymentMethod-output",
+    "Name":"https://schema.org/paymentMethod-output",
     "Domain Bucket":"< 1K"
   },
   {
     "Class":"Predicate",
-    "Name":"http:\/\/schema.org\/paymentMethodId",
+    "Name":"https://schema.org/paymentMethodId",
     "Domain Bucket":"< 1K"
   },
   {
     "Class":"Predicate",
-    "Name":"http:\/\/schema.org\/paymentMethodId-input",
+    "Name":"https://schema.org/paymentMethodId-input",
     "Domain Bucket":"< 1K"
   },
   {
     "Class":"Predicate",
-    "Name":"http:\/\/schema.org\/paymentMethodId-output",
+    "Name":"https://schema.org/paymentMethodId-output",
     "Domain Bucket":"< 1K"
   },
   {
     "Class":"Predicate",
-    "Name":"http:\/\/schema.org\/paymentMethodType",
+    "Name":"https://schema.org/paymentMethodType",
     "Domain Bucket":"1K - 10K"
   },
   {
     "Class":"Predicate",
-    "Name":"http:\/\/schema.org\/paymentMethodType-input",
+    "Name":"https://schema.org/paymentMethodType-input",
     "Domain Bucket":"< 1K"
   },
   {
     "Class":"Predicate",
-    "Name":"http:\/\/schema.org\/paymentMethodType-output",
+    "Name":"https://schema.org/paymentMethodType-output",
     "Domain Bucket":"< 1K"
   },
   {
     "Class":"Predicate",
-    "Name":"http:\/\/schema.org\/paymentStatus",
+    "Name":"https://schema.org/paymentStatus",
     "Domain Bucket":"< 1K"
   },
   {
     "Class":"Predicate",
-    "Name":"http:\/\/schema.org\/paymentStatus-input",
+    "Name":"https://schema.org/paymentStatus-input",
     "Domain Bucket":"< 1K"
   },
   {
     "Class":"Predicate",
-    "Name":"http:\/\/schema.org\/paymentStatus-output",
+    "Name":"https://schema.org/paymentStatus-output",
     "Domain Bucket":"< 1K"
   },
   {
     "Class":"Predicate",
-    "Name":"http:\/\/schema.org\/paymentUrl",
+    "Name":"https://schema.org/paymentUrl",
     "Domain Bucket":"< 1K"
   },
   {
     "Class":"Predicate",
-    "Name":"http:\/\/schema.org\/paymentUrl-input",
+    "Name":"https://schema.org/paymentUrl-input",
     "Domain Bucket":"< 1K"
   },
   {
     "Class":"Predicate",
-    "Name":"http:\/\/schema.org\/paymentUrl-output",
+    "Name":"https://schema.org/paymentUrl-output",
     "Domain Bucket":"< 1K"
   },
   {
     "Class":"Predicate",
-    "Name":"http:\/\/schema.org\/penciler",
+    "Name":"https://schema.org/penciler",
     "Domain Bucket":"< 1K"
   },
   {
     "Class":"Predicate",
-    "Name":"http:\/\/schema.org\/penciler-input",
+    "Name":"https://schema.org/penciler-input",
     "Domain Bucket":"< 1K"
   },
   {
     "Class":"Predicate",
-    "Name":"http:\/\/schema.org\/penciler-output",
+    "Name":"https://schema.org/penciler-output",
     "Domain Bucket":"< 1K"
   },
   {
     "Class":"Predicate",
-    "Name":"http:\/\/schema.org\/percentile10",
+    "Name":"https://schema.org/percentile10",
     "Domain Bucket":"1K - 10K"
   },
   {
     "Class":"Predicate",
-    "Name":"http:\/\/schema.org\/percentile10-input",
+    "Name":"https://schema.org/percentile10-input",
     "Domain Bucket":"< 1K"
   },
   {
     "Class":"Predicate",
-    "Name":"http:\/\/schema.org\/percentile10-output",
+    "Name":"https://schema.org/percentile10-output",
     "Domain Bucket":"< 1K"
   },
   {
     "Class":"Predicate",
-    "Name":"http:\/\/schema.org\/percentile25",
+    "Name":"https://schema.org/percentile25",
     "Domain Bucket":"1K - 10K"
   },
   {
     "Class":"Predicate",
-    "Name":"http:\/\/schema.org\/percentile25-input",
+    "Name":"https://schema.org/percentile25-input",
     "Domain Bucket":"< 1K"
   },
   {
     "Class":"Predicate",
-    "Name":"http:\/\/schema.org\/percentile25-output",
+    "Name":"https://schema.org/percentile25-output",
     "Domain Bucket":"< 1K"
   },
   {
     "Class":"Predicate",
-    "Name":"http:\/\/schema.org\/percentile75",
+    "Name":"https://schema.org/percentile75",
     "Domain Bucket":"1K - 10K"
   },
   {
     "Class":"Predicate",
-    "Name":"http:\/\/schema.org\/percentile75-input",
+    "Name":"https://schema.org/percentile75-input",
     "Domain Bucket":"< 1K"
   },
   {
     "Class":"Predicate",
-    "Name":"http:\/\/schema.org\/percentile75-output",
+    "Name":"https://schema.org/percentile75-output",
     "Domain Bucket":"< 1K"
   },
   {
     "Class":"Predicate",
-    "Name":"http:\/\/schema.org\/percentile90",
+    "Name":"https://schema.org/percentile90",
     "Domain Bucket":"1K - 10K"
   },
   {
     "Class":"Predicate",
-    "Name":"http:\/\/schema.org\/percentile90-input",
+    "Name":"https://schema.org/percentile90-input",
     "Domain Bucket":"< 1K"
   },
   {
     "Class":"Predicate",
-    "Name":"http:\/\/schema.org\/percentile90-output",
+    "Name":"https://schema.org/percentile90-output",
     "Domain Bucket":"< 1K"
   },
   {
     "Class":"Predicate",
-    "Name":"http:\/\/schema.org\/performTime",
+    "Name":"https://schema.org/performTime",
     "Domain Bucket":"1K - 10K"
   },
   {
     "Class":"Predicate",
-    "Name":"http:\/\/schema.org\/performTime-input",
+    "Name":"https://schema.org/performTime-input",
     "Domain Bucket":"< 1K"
   },
   {
     "Class":"Predicate",
-    "Name":"http:\/\/schema.org\/performTime-output",
+    "Name":"https://schema.org/performTime-output",
     "Domain Bucket":"< 1K"
   },
   {
     "Class":"Predicate",
-    "Name":"http:\/\/schema.org\/performer",
+    "Name":"https://schema.org/performer",
     "Domain Bucket":"100K - 1M"
   },
   {
     "Class":"Predicate",
-    "Name":"http:\/\/schema.org\/performer-input",
+    "Name":"https://schema.org/performer-input",
     "Domain Bucket":"< 1K"
   },
   {
     "Class":"Predicate",
-    "Name":"http:\/\/schema.org\/performer-output",
+    "Name":"https://schema.org/performer-output",
     "Domain Bucket":"< 1K"
   },
   {
     "Class":"Predicate",
-    "Name":"http:\/\/schema.org\/performerIn",
+    "Name":"https://schema.org/performerIn",
     "Domain Bucket":"1K - 10K"
   },
   {
     "Class":"Predicate",
-    "Name":"http:\/\/schema.org\/performerIn-input",
+    "Name":"https://schema.org/performerIn-input",
     "Domain Bucket":"< 1K"
   },
   {
     "Class":"Predicate",
-    "Name":"http:\/\/schema.org\/performerIn-output",
+    "Name":"https://schema.org/performerIn-output",
     "Domain Bucket":"< 1K"
   },
   {
     "Class":"Predicate",
-    "Name":"http:\/\/schema.org\/performers",
+    "Name":"https://schema.org/performers",
     "Domain Bucket":"10K - 100K"
   },
   {
     "Class":"Predicate",
-    "Name":"http:\/\/schema.org\/performers-input",
+    "Name":"https://schema.org/performers-input",
     "Domain Bucket":"< 1K"
   },
   {
     "Class":"Predicate",
-    "Name":"http:\/\/schema.org\/performers-output",
+    "Name":"https://schema.org/performers-output",
     "Domain Bucket":"< 1K"
   },
   {
     "Class":"Predicate",
-    "Name":"http:\/\/schema.org\/permissionType",
+    "Name":"https://schema.org/permissionType",
     "Domain Bucket":"< 1K"
   },
   {
     "Class":"Predicate",
-    "Name":"http:\/\/schema.org\/permissionType-input",
+    "Name":"https://schema.org/permissionType-input",
     "Domain Bucket":"< 1K"
   },
   {
     "Class":"Predicate",
-    "Name":"http:\/\/schema.org\/permissionType-output",
+    "Name":"https://schema.org/permissionType-output",
     "Domain Bucket":"< 1K"
   },
   {
     "Class":"Predicate",
-    "Name":"http:\/\/schema.org\/permissions",
+    "Name":"https://schema.org/permissions",
     "Domain Bucket":"10K - 100K"
   },
   {
     "Class":"Predicate",
-    "Name":"http:\/\/schema.org\/permissions-input",
+    "Name":"https://schema.org/permissions-input",
     "Domain Bucket":"< 1K"
   },
   {
     "Class":"Predicate",
-    "Name":"http:\/\/schema.org\/permissions-output",
+    "Name":"https://schema.org/permissions-output",
     "Domain Bucket":"< 1K"
   },
   {
     "Class":"Predicate",
-    "Name":"http:\/\/schema.org\/permitAudience",
+    "Name":"https://schema.org/permitAudience",
     "Domain Bucket":"< 1K"
   },
   {
     "Class":"Predicate",
-    "Name":"http:\/\/schema.org\/permitAudience-input",
+    "Name":"https://schema.org/permitAudience-input",
     "Domain Bucket":"< 1K"
   },
   {
     "Class":"Predicate",
-    "Name":"http:\/\/schema.org\/permitAudience-output",
+    "Name":"https://schema.org/permitAudience-output",
     "Domain Bucket":"< 1K"
   },
   {
     "Class":"Predicate",
-    "Name":"http:\/\/schema.org\/permittedUsage",
+    "Name":"https://schema.org/permittedUsage",
     "Domain Bucket":"< 1K"
   },
   {
     "Class":"Predicate",
-    "Name":"http:\/\/schema.org\/permittedUsage-input",
+    "Name":"https://schema.org/permittedUsage-input",
     "Domain Bucket":"< 1K"
   },
   {
     "Class":"Predicate",
-    "Name":"http:\/\/schema.org\/permittedUsage-output",
+    "Name":"https://schema.org/permittedUsage-output",
     "Domain Bucket":"< 1K"
   },
   {
     "Class":"Predicate",
-    "Name":"http:\/\/schema.org\/petsAllowed",
+    "Name":"https://schema.org/petsAllowed",
     "Domain Bucket":"10K - 100K"
   },
   {
     "Class":"Predicate",
-    "Name":"http:\/\/schema.org\/petsAllowed-input",
+    "Name":"https://schema.org/petsAllowed-input",
     "Domain Bucket":"< 1K"
   },
   {
     "Class":"Predicate",
-    "Name":"http:\/\/schema.org\/petsAllowed-output",
+    "Name":"https://schema.org/petsAllowed-output",
     "Domain Bucket":"< 1K"
   },
   {
     "Class":"Predicate",
-    "Name":"http:\/\/schema.org\/phoneticText",
+    "Name":"https://schema.org/phoneticText",
     "Domain Bucket":"< 1K"
   },
   {
     "Class":"Predicate",
-    "Name":"http:\/\/schema.org\/phoneticText-input",
+    "Name":"https://schema.org/phoneticText-input",
     "Domain Bucket":"< 1K"
   },
   {
     "Class":"Predicate",
-    "Name":"http:\/\/schema.org\/phoneticText-output",
+    "Name":"https://schema.org/phoneticText-output",
     "Domain Bucket":"< 1K"
   },
   {
     "Class":"Predicate",
-    "Name":"http:\/\/schema.org\/photo",
+    "Name":"https://schema.org/photo",
     "Domain Bucket":"10K - 100K"
   },
   {
     "Class":"Predicate",
-    "Name":"http:\/\/schema.org\/photo-input",
+    "Name":"https://schema.org/photo-input",
     "Domain Bucket":"< 1K"
   },
   {
     "Class":"Predicate",
-    "Name":"http:\/\/schema.org\/photo-output",
+    "Name":"https://schema.org/photo-output",
     "Domain Bucket":"< 1K"
   },
   {
     "Class":"Predicate",
-    "Name":"http:\/\/schema.org\/photos",
+    "Name":"https://schema.org/photos",
     "Domain Bucket":"10K - 100K"
   },
   {
     "Class":"Predicate",
-    "Name":"http:\/\/schema.org\/photos-input",
+    "Name":"https://schema.org/photos-input",
     "Domain Bucket":"< 1K"
   },
   {
     "Class":"Predicate",
-    "Name":"http:\/\/schema.org\/photos-output",
+    "Name":"https://schema.org/photos-output",
     "Domain Bucket":"< 1K"
   },
   {
     "Class":"Predicate",
-    "Name":"http:\/\/schema.org\/physicalRequirement",
+    "Name":"https://schema.org/physicalRequirement",
     "Domain Bucket":"< 1K"
   },
   {
     "Class":"Predicate",
-    "Name":"http:\/\/schema.org\/physicalRequirement-input",
+    "Name":"https://schema.org/physicalRequirement-input",
     "Domain Bucket":"< 1K"
   },
   {
     "Class":"Predicate",
-    "Name":"http:\/\/schema.org\/physicalRequirement-output",
+    "Name":"https://schema.org/physicalRequirement-output",
     "Domain Bucket":"< 1K"
   },
   {
     "Class":"Predicate",
-    "Name":"http:\/\/schema.org\/physiologicalBenefits",
+    "Name":"https://schema.org/physiologicalBenefits",
     "Domain Bucket":"< 1K"
   },
   {
     "Class":"Predicate",
-    "Name":"http:\/\/schema.org\/physiologicalBenefits-input",
+    "Name":"https://schema.org/physiologicalBenefits-input",
     "Domain Bucket":"< 1K"
   },
   {
     "Class":"Predicate",
-    "Name":"http:\/\/schema.org\/physiologicalBenefits-output",
+    "Name":"https://schema.org/physiologicalBenefits-output",
     "Domain Bucket":"< 1K"
   },
   {
     "Class":"Predicate",
-    "Name":"http:\/\/schema.org\/pickupLocation",
+    "Name":"https://schema.org/pickupLocation",
     "Domain Bucket":"< 1K"
   },
   {
     "Class":"Predicate",
-    "Name":"http:\/\/schema.org\/pickupLocation-input",
+    "Name":"https://schema.org/pickupLocation-input",
     "Domain Bucket":"< 1K"
   },
   {
     "Class":"Predicate",
-    "Name":"http:\/\/schema.org\/pickupLocation-output",
+    "Name":"https://schema.org/pickupLocation-output",
     "Domain Bucket":"< 1K"
   },
   {
     "Class":"Predicate",
-    "Name":"http:\/\/schema.org\/pickupTime",
+    "Name":"https://schema.org/pickupTime",
     "Domain Bucket":"< 1K"
   },
   {
     "Class":"Predicate",
-    "Name":"http:\/\/schema.org\/pickupTime-input",
+    "Name":"https://schema.org/pickupTime-input",
     "Domain Bucket":"< 1K"
   },
   {
     "Class":"Predicate",
-    "Name":"http:\/\/schema.org\/pickupTime-output",
+    "Name":"https://schema.org/pickupTime-output",
     "Domain Bucket":"< 1K"
   },
   {
     "Class":"Predicate",
-    "Name":"http:\/\/schema.org\/playMode",
+    "Name":"https://schema.org/playMode",
     "Domain Bucket":"10K - 100K"
   },
   {
     "Class":"Predicate",
-    "Name":"http:\/\/schema.org\/playMode-input",
+    "Name":"https://schema.org/playMode-input",
     "Domain Bucket":"< 1K"
   },
   {
     "Class":"Predicate",
-    "Name":"http:\/\/schema.org\/playMode-output",
+    "Name":"https://schema.org/playMode-output",
     "Domain Bucket":"< 1K"
   },
   {
     "Class":"Predicate",
-    "Name":"http:\/\/schema.org\/playerType",
+    "Name":"https://schema.org/playerType",
     "Domain Bucket":"1K - 10K"
   },
   {
     "Class":"Predicate",
-    "Name":"http:\/\/schema.org\/playerType-input",
+    "Name":"https://schema.org/playerType-input",
     "Domain Bucket":"< 1K"
   },
   {
     "Class":"Predicate",
-    "Name":"http:\/\/schema.org\/playerType-output",
+    "Name":"https://schema.org/playerType-output",
     "Domain Bucket":"< 1K"
   },
   {
     "Class":"Predicate",
-    "Name":"http:\/\/schema.org\/playersOnline",
+    "Name":"https://schema.org/playersOnline",
     "Domain Bucket":"1K - 10K"
   },
   {
     "Class":"Predicate",
-    "Name":"http:\/\/schema.org\/playersOnline-input",
+    "Name":"https://schema.org/playersOnline-input",
     "Domain Bucket":"< 1K"
   },
   {
     "Class":"Predicate",
-    "Name":"http:\/\/schema.org\/playersOnline-output",
+    "Name":"https://schema.org/playersOnline-output",
     "Domain Bucket":"< 1K"
   },
   {
     "Class":"Predicate",
-    "Name":"http:\/\/schema.org\/polygon",
+    "Name":"https://schema.org/polygon",
     "Domain Bucket":"1K - 10K"
   },
   {
     "Class":"Predicate",
-    "Name":"http:\/\/schema.org\/polygon-input",
+    "Name":"https://schema.org/polygon-input",
     "Domain Bucket":"< 1K"
   },
   {
     "Class":"Predicate",
-    "Name":"http:\/\/schema.org\/polygon-output",
+    "Name":"https://schema.org/polygon-output",
     "Domain Bucket":"< 1K"
   },
   {
     "Class":"Predicate",
-    "Name":"http:\/\/schema.org\/populationType",
+    "Name":"https://schema.org/populationType",
     "Domain Bucket":"< 1K"
   },
   {
     "Class":"Predicate",
-    "Name":"http:\/\/schema.org\/populationType-input",
+    "Name":"https://schema.org/populationType-input",
     "Domain Bucket":"< 1K"
   },
   {
     "Class":"Predicate",
-    "Name":"http:\/\/schema.org\/populationType-output",
+    "Name":"https://schema.org/populationType-output",
     "Domain Bucket":"< 1K"
   },
   {
     "Class":"Predicate",
-    "Name":"http:\/\/schema.org\/position",
+    "Name":"https://schema.org/position",
     "Domain Bucket":"10M+"
   },
   {
     "Class":"Predicate",
-    "Name":"http:\/\/schema.org\/position-input",
+    "Name":"https://schema.org/position-input",
     "Domain Bucket":"< 1K"
   },
   {
     "Class":"Predicate",
-    "Name":"http:\/\/schema.org\/position-output",
+    "Name":"https://schema.org/position-output",
     "Domain Bucket":"< 1K"
   },
   {
     "Class":"Predicate",
-    "Name":"http:\/\/schema.org\/positiveNotes",
+    "Name":"https://schema.org/positiveNotes",
     "Domain Bucket":"10K - 100K"
   },
   {
     "Class":"Predicate",
-    "Name":"http:\/\/schema.org\/positiveNotes-input",
+    "Name":"https://schema.org/positiveNotes-input",
     "Domain Bucket":"< 1K"
   },
   {
     "Class":"Predicate",
-    "Name":"http:\/\/schema.org\/positiveNotes-output",
+    "Name":"https://schema.org/positiveNotes-output",
     "Domain Bucket":"< 1K"
   },
   {
     "Class":"Predicate",
-    "Name":"http:\/\/schema.org\/possibleComplication",
+    "Name":"https://schema.org/possibleComplication",
     "Domain Bucket":"1K - 10K"
   },
   {
     "Class":"Predicate",
-    "Name":"http:\/\/schema.org\/possibleComplication-input",
+    "Name":"https://schema.org/possibleComplication-input",
     "Domain Bucket":"< 1K"
   },
   {
     "Class":"Predicate",
-    "Name":"http:\/\/schema.org\/possibleComplication-output",
+    "Name":"https://schema.org/possibleComplication-output",
     "Domain Bucket":"< 1K"
   },
   {
     "Class":"Predicate",
-    "Name":"http:\/\/schema.org\/possibleTreatment",
+    "Name":"https://schema.org/possibleTreatment",
     "Domain Bucket":"1K - 10K"
   },
   {
     "Class":"Predicate",
-    "Name":"http:\/\/schema.org\/possibleTreatment-input",
+    "Name":"https://schema.org/possibleTreatment-input",
     "Domain Bucket":"< 1K"
   },
   {
     "Class":"Predicate",
-    "Name":"http:\/\/schema.org\/possibleTreatment-output",
+    "Name":"https://schema.org/possibleTreatment-output",
     "Domain Bucket":"< 1K"
   },
   {
     "Class":"Predicate",
-    "Name":"http:\/\/schema.org\/postOfficeBoxNumber",
+    "Name":"https://schema.org/postOfficeBoxNumber",
     "Domain Bucket":"10K - 100K"
   },
   {
     "Class":"Predicate",
-    "Name":"http:\/\/schema.org\/postOfficeBoxNumber-input",
+    "Name":"https://schema.org/postOfficeBoxNumber-input",
     "Domain Bucket":"< 1K"
   },
   {
     "Class":"Predicate",
-    "Name":"http:\/\/schema.org\/postOfficeBoxNumber-output",
+    "Name":"https://schema.org/postOfficeBoxNumber-output",
     "Domain Bucket":"< 1K"
   },
   {
     "Class":"Predicate",
-    "Name":"http:\/\/schema.org\/postOp",
+    "Name":"https://schema.org/postOp",
     "Domain Bucket":"< 1K"
   },
   {
     "Class":"Predicate",
-    "Name":"http:\/\/schema.org\/postOp-input",
+    "Name":"https://schema.org/postOp-input",
     "Domain Bucket":"< 1K"
   },
   {
     "Class":"Predicate",
-    "Name":"http:\/\/schema.org\/postOp-output",
+    "Name":"https://schema.org/postOp-output",
     "Domain Bucket":"< 1K"
   },
   {
     "Class":"Predicate",
-    "Name":"http:\/\/schema.org\/postalCode",
+    "Name":"https://schema.org/postalCode",
     "Domain Bucket":"1M - 10M"
   },
   {
     "Class":"Predicate",
-    "Name":"http:\/\/schema.org\/postalCode-input",
+    "Name":"https://schema.org/postalCode-input",
     "Domain Bucket":"< 1K"
   },
   {
     "Class":"Predicate",
-    "Name":"http:\/\/schema.org\/postalCode-output",
+    "Name":"https://schema.org/postalCode-output",
     "Domain Bucket":"< 1K"
   },
   {
     "Class":"Predicate",
-    "Name":"http:\/\/schema.org\/postalCodeBegin",
+    "Name":"https://schema.org/postalCodeBegin",
     "Domain Bucket":"1K - 10K"
   },
   {
     "Class":"Predicate",
-    "Name":"http:\/\/schema.org\/postalCodeBegin-input",
+    "Name":"https://schema.org/postalCodeBegin-input",
     "Domain Bucket":"< 1K"
   },
   {
     "Class":"Predicate",
-    "Name":"http:\/\/schema.org\/postalCodeBegin-output",
+    "Name":"https://schema.org/postalCodeBegin-output",
     "Domain Bucket":"< 1K"
   },
   {
     "Class":"Predicate",
-    "Name":"http:\/\/schema.org\/postalCodeEnd",
+    "Name":"https://schema.org/postalCodeEnd",
     "Domain Bucket":"1K - 10K"
   },
   {
     "Class":"Predicate",
-    "Name":"http:\/\/schema.org\/postalCodeEnd-input",
+    "Name":"https://schema.org/postalCodeEnd-input",
     "Domain Bucket":"< 1K"
   },
   {
     "Class":"Predicate",
-    "Name":"http:\/\/schema.org\/postalCodeEnd-output",
+    "Name":"https://schema.org/postalCodeEnd-output",
     "Domain Bucket":"< 1K"
   },
   {
     "Class":"Predicate",
-    "Name":"http:\/\/schema.org\/postalCodePrefix",
+    "Name":"https://schema.org/postalCodePrefix",
     "Domain Bucket":"< 1K"
   },
   {
     "Class":"Predicate",
-    "Name":"http:\/\/schema.org\/postalCodePrefix-input",
+    "Name":"https://schema.org/postalCodePrefix-input",
     "Domain Bucket":"< 1K"
   },
   {
     "Class":"Predicate",
-    "Name":"http:\/\/schema.org\/postalCodePrefix-output",
+    "Name":"https://schema.org/postalCodePrefix-output",
     "Domain Bucket":"< 1K"
   },
   {
     "Class":"Predicate",
-    "Name":"http:\/\/schema.org\/postalCodeRange",
+    "Name":"https://schema.org/postalCodeRange",
     "Domain Bucket":"1K - 10K"
   },
   {
     "Class":"Predicate",
-    "Name":"http:\/\/schema.org\/postalCodeRange-input",
+    "Name":"https://schema.org/postalCodeRange-input",
     "Domain Bucket":"< 1K"
   },
   {
     "Class":"Predicate",
-    "Name":"http:\/\/schema.org\/postalCodeRange-output",
+    "Name":"https://schema.org/postalCodeRange-output",
     "Domain Bucket":"< 1K"
   },
   {
     "Class":"Predicate",
-    "Name":"http:\/\/schema.org\/potentialAction",
+    "Name":"https://schema.org/potentialAction",
     "Domain Bucket":"10M+"
   },
   {
     "Class":"Predicate",
-    "Name":"http:\/\/schema.org\/potentialAction-input",
+    "Name":"https://schema.org/potentialAction-input",
     "Domain Bucket":"< 1K"
   },
   {
     "Class":"Predicate",
-    "Name":"http:\/\/schema.org\/potentialAction-output",
+    "Name":"https://schema.org/potentialAction-output",
     "Domain Bucket":"< 1K"
   },
   {
     "Class":"Predicate",
-    "Name":"http:\/\/schema.org\/potentialUse",
+    "Name":"https://schema.org/potentialUse",
     "Domain Bucket":"< 1K"
   },
   {
     "Class":"Predicate",
-    "Name":"http:\/\/schema.org\/potentialUse-input",
+    "Name":"https://schema.org/potentialUse-input",
     "Domain Bucket":"< 1K"
   },
   {
     "Class":"Predicate",
-    "Name":"http:\/\/schema.org\/potentialUse-output",
+    "Name":"https://schema.org/potentialUse-output",
     "Domain Bucket":"< 1K"
   },
   {
     "Class":"Predicate",
-    "Name":"http:\/\/schema.org\/practicesAt",
+    "Name":"https://schema.org/practicesAt",
     "Domain Bucket":"1K - 10K"
   },
   {
     "Class":"Predicate",
-    "Name":"http:\/\/schema.org\/practicesAt-input",
+    "Name":"https://schema.org/practicesAt-input",
     "Domain Bucket":"< 1K"
   },
   {
     "Class":"Predicate",
-    "Name":"http:\/\/schema.org\/practicesAt-output",
+    "Name":"https://schema.org/practicesAt-output",
     "Domain Bucket":"< 1K"
   },
   {
     "Class":"Predicate",
-    "Name":"http:\/\/schema.org\/preOp",
+    "Name":"https://schema.org/preOp",
     "Domain Bucket":"< 1K"
   },
   {
     "Class":"Predicate",
-    "Name":"http:\/\/schema.org\/preOp-input",
+    "Name":"https://schema.org/preOp-input",
     "Domain Bucket":"< 1K"
   },
   {
     "Class":"Predicate",
-    "Name":"http:\/\/schema.org\/preOp-output",
+    "Name":"https://schema.org/preOp-output",
     "Domain Bucket":"< 1K"
   },
   {
     "Class":"Predicate",
-    "Name":"http:\/\/schema.org\/predecessorOf",
+    "Name":"https://schema.org/predecessorOf",
     "Domain Bucket":"< 1K"
   },
   {
     "Class":"Predicate",
-    "Name":"http:\/\/schema.org\/predecessorOf-input",
+    "Name":"https://schema.org/predecessorOf-input",
     "Domain Bucket":"< 1K"
   },
   {
     "Class":"Predicate",
-    "Name":"http:\/\/schema.org\/predecessorOf-output",
+    "Name":"https://schema.org/predecessorOf-output",
     "Domain Bucket":"< 1K"
   },
   {
     "Class":"Predicate",
-    "Name":"http:\/\/schema.org\/pregnancyCategory",
+    "Name":"https://schema.org/pregnancyCategory",
     "Domain Bucket":"< 1K"
   },
   {
     "Class":"Predicate",
-    "Name":"http:\/\/schema.org\/pregnancyCategory-input",
+    "Name":"https://schema.org/pregnancyCategory-input",
     "Domain Bucket":"< 1K"
   },
   {
     "Class":"Predicate",
-    "Name":"http:\/\/schema.org\/pregnancyCategory-output",
+    "Name":"https://schema.org/pregnancyCategory-output",
     "Domain Bucket":"< 1K"
   },
   {
     "Class":"Predicate",
-    "Name":"http:\/\/schema.org\/pregnancyWarning",
+    "Name":"https://schema.org/pregnancyWarning",
     "Domain Bucket":"< 1K"
   },
   {
     "Class":"Predicate",
-    "Name":"http:\/\/schema.org\/pregnancyWarning-input",
+    "Name":"https://schema.org/pregnancyWarning-input",
     "Domain Bucket":"< 1K"
   },
   {
     "Class":"Predicate",
-    "Name":"http:\/\/schema.org\/pregnancyWarning-output",
+    "Name":"https://schema.org/pregnancyWarning-output",
     "Domain Bucket":"< 1K"
   },
   {
     "Class":"Predicate",
-    "Name":"http:\/\/schema.org\/prepTime",
+    "Name":"https://schema.org/prepTime",
     "Domain Bucket":"10K - 100K"
   },
   {
     "Class":"Predicate",
-    "Name":"http:\/\/schema.org\/prepTime-input",
+    "Name":"https://schema.org/prepTime-input",
     "Domain Bucket":"< 1K"
   },
   {
     "Class":"Predicate",
-    "Name":"http:\/\/schema.org\/prepTime-output",
+    "Name":"https://schema.org/prepTime-output",
     "Domain Bucket":"< 1K"
   },
   {
     "Class":"Predicate",
-    "Name":"http:\/\/schema.org\/preparation",
+    "Name":"https://schema.org/preparation",
     "Domain Bucket":"1K - 10K"
   },
   {
     "Class":"Predicate",
-    "Name":"http:\/\/schema.org\/preparation-input",
+    "Name":"https://schema.org/preparation-input",
     "Domain Bucket":"< 1K"
   },
   {
     "Class":"Predicate",
-    "Name":"http:\/\/schema.org\/preparation-output",
+    "Name":"https://schema.org/preparation-output",
     "Domain Bucket":"< 1K"
   },
   {
     "Class":"Predicate",
-    "Name":"http:\/\/schema.org\/prescribingInfo",
+    "Name":"https://schema.org/prescribingInfo",
     "Domain Bucket":"< 1K"
   },
   {
     "Class":"Predicate",
-    "Name":"http:\/\/schema.org\/prescribingInfo-input",
+    "Name":"https://schema.org/prescribingInfo-input",
     "Domain Bucket":"< 1K"
   },
   {
     "Class":"Predicate",
-    "Name":"http:\/\/schema.org\/prescribingInfo-output",
+    "Name":"https://schema.org/prescribingInfo-output",
     "Domain Bucket":"< 1K"
   },
   {
     "Class":"Predicate",
-    "Name":"http:\/\/schema.org\/prescriptionStatus",
+    "Name":"https://schema.org/prescriptionStatus",
     "Domain Bucket":"1K - 10K"
   },
   {
     "Class":"Predicate",
-    "Name":"http:\/\/schema.org\/prescriptionStatus-input",
+    "Name":"https://schema.org/prescriptionStatus-input",
     "Domain Bucket":"< 1K"
   },
   {
     "Class":"Predicate",
-    "Name":"http:\/\/schema.org\/prescriptionStatus-output",
+    "Name":"https://schema.org/prescriptionStatus-output",
     "Domain Bucket":"< 1K"
   },
   {
     "Class":"Predicate",
-    "Name":"http:\/\/schema.org\/previousItem",
+    "Name":"https://schema.org/previousItem",
     "Domain Bucket":"1M - 10M"
   },
   {
     "Class":"Predicate",
-    "Name":"http:\/\/schema.org\/previousItem-input",
+    "Name":"https://schema.org/previousItem-input",
     "Domain Bucket":"< 1K"
   },
   {
     "Class":"Predicate",
-    "Name":"http:\/\/schema.org\/previousItem-output",
+    "Name":"https://schema.org/previousItem-output",
     "Domain Bucket":"< 1K"
   },
   {
     "Class":"Predicate",
-    "Name":"http:\/\/schema.org\/previousStartDate",
+    "Name":"https://schema.org/previousStartDate",
     "Domain Bucket":"1K - 10K"
   },
   {
     "Class":"Predicate",
-    "Name":"http:\/\/schema.org\/previousStartDate-input",
+    "Name":"https://schema.org/previousStartDate-input",
     "Domain Bucket":"< 1K"
   },
   {
     "Class":"Predicate",
-    "Name":"http:\/\/schema.org\/previousStartDate-output",
+    "Name":"https://schema.org/previousStartDate-output",
     "Domain Bucket":"< 1K"
   },
   {
     "Class":"Predicate",
-    "Name":"http:\/\/schema.org\/price",
+    "Name":"https://schema.org/price",
     "Domain Bucket":"10M+"
   },
   {
     "Class":"Predicate",
-    "Name":"http:\/\/schema.org\/price-input",
+    "Name":"https://schema.org/price-input",
     "Domain Bucket":"< 1K"
   },
   {
     "Class":"Predicate",
-    "Name":"http:\/\/schema.org\/price-output",
+    "Name":"https://schema.org/price-output",
     "Domain Bucket":"< 1K"
   },
   {
     "Class":"Predicate",
-    "Name":"http:\/\/schema.org\/priceComponent",
+    "Name":"https://schema.org/priceComponent",
     "Domain Bucket":"1K - 10K"
   },
   {
     "Class":"Predicate",
-    "Name":"http:\/\/schema.org\/priceComponent-input",
+    "Name":"https://schema.org/priceComponent-input",
     "Domain Bucket":"< 1K"
   },
   {
     "Class":"Predicate",
-    "Name":"http:\/\/schema.org\/priceComponent-output",
+    "Name":"https://schema.org/priceComponent-output",
     "Domain Bucket":"< 1K"
   },
   {
     "Class":"Predicate",
-    "Name":"http:\/\/schema.org\/priceComponentType",
+    "Name":"https://schema.org/priceComponentType",
     "Domain Bucket":"< 1K"
   },
   {
     "Class":"Predicate",
-    "Name":"http:\/\/schema.org\/priceComponentType-input",
+    "Name":"https://schema.org/priceComponentType-input",
     "Domain Bucket":"< 1K"
   },
   {
     "Class":"Predicate",
-    "Name":"http:\/\/schema.org\/priceComponentType-output",
+    "Name":"https://schema.org/priceComponentType-output",
     "Domain Bucket":"< 1K"
   },
   {
     "Class":"Predicate",
-    "Name":"http:\/\/schema.org\/priceCurrency",
+    "Name":"https://schema.org/priceCurrency",
     "Domain Bucket":"10M+"
   },
   {
     "Class":"Predicate",
-    "Name":"http:\/\/schema.org\/priceCurrency-input",
+    "Name":"https://schema.org/priceCurrency-input",
     "Domain Bucket":"< 1K"
   },
   {
     "Class":"Predicate",
-    "Name":"http:\/\/schema.org\/priceCurrency-output",
+    "Name":"https://schema.org/priceCurrency-output",
     "Domain Bucket":"< 1K"
   },
   {
     "Class":"Predicate",
-    "Name":"http:\/\/schema.org\/priceRange",
+    "Name":"https://schema.org/priceRange",
     "Domain Bucket":"1M - 10M"
   },
   {
     "Class":"Predicate",
-    "Name":"http:\/\/schema.org\/priceRange-input",
+    "Name":"https://schema.org/priceRange-input",
     "Domain Bucket":"< 1K"
   },
   {
     "Class":"Predicate",
-    "Name":"http:\/\/schema.org\/priceRange-output",
+    "Name":"https://schema.org/priceRange-output",
     "Domain Bucket":"< 1K"
   },
   {
     "Class":"Predicate",
-    "Name":"http:\/\/schema.org\/priceSpecification",
+    "Name":"https://schema.org/priceSpecification",
     "Domain Bucket":"1M - 10M"
   },
   {
     "Class":"Predicate",
-    "Name":"http:\/\/schema.org\/priceSpecification-input",
+    "Name":"https://schema.org/priceSpecification-input",
     "Domain Bucket":"< 1K"
   },
   {
     "Class":"Predicate",
-    "Name":"http:\/\/schema.org\/priceSpecification-output",
+    "Name":"https://schema.org/priceSpecification-output",
     "Domain Bucket":"< 1K"
   },
   {
     "Class":"Predicate",
-    "Name":"http:\/\/schema.org\/priceType",
+    "Name":"https://schema.org/priceType",
     "Domain Bucket":"100K - 1M"
   },
   {
     "Class":"Predicate",
-    "Name":"http:\/\/schema.org\/priceType-input",
+    "Name":"https://schema.org/priceType-input",
     "Domain Bucket":"< 1K"
   },
   {
     "Class":"Predicate",
-    "Name":"http:\/\/schema.org\/priceType-output",
+    "Name":"https://schema.org/priceType-output",
     "Domain Bucket":"< 1K"
   },
   {
     "Class":"Predicate",
-    "Name":"http:\/\/schema.org\/priceValidUntil",
+    "Name":"https://schema.org/priceValidUntil",
     "Domain Bucket":"1M - 10M"
   },
   {
     "Class":"Predicate",
-    "Name":"http:\/\/schema.org\/priceValidUntil-input",
+    "Name":"https://schema.org/priceValidUntil-input",
     "Domain Bucket":"< 1K"
   },
   {
     "Class":"Predicate",
-    "Name":"http:\/\/schema.org\/priceValidUntil-output",
+    "Name":"https://schema.org/priceValidUntil-output",
     "Domain Bucket":"< 1K"
   },
   {
     "Class":"Predicate",
-    "Name":"http:\/\/schema.org\/primaryImageOfPage",
+    "Name":"https://schema.org/primaryImageOfPage",
     "Domain Bucket":"10M+"
   },
   {
     "Class":"Predicate",
-    "Name":"http:\/\/schema.org\/primaryImageOfPage-input",
+    "Name":"https://schema.org/primaryImageOfPage-input",
     "Domain Bucket":"< 1K"
   },
   {
     "Class":"Predicate",
-    "Name":"http:\/\/schema.org\/primaryImageOfPage-output",
+    "Name":"https://schema.org/primaryImageOfPage-output",
     "Domain Bucket":"< 1K"
   },
   {
     "Class":"Predicate",
-    "Name":"http:\/\/schema.org\/primaryPrevention",
+    "Name":"https://schema.org/primaryPrevention",
     "Domain Bucket":"< 1K"
   },
   {
     "Class":"Predicate",
-    "Name":"http:\/\/schema.org\/primaryPrevention-input",
+    "Name":"https://schema.org/primaryPrevention-input",
     "Domain Bucket":"< 1K"
   },
   {
     "Class":"Predicate",
-    "Name":"http:\/\/schema.org\/primaryPrevention-output",
+    "Name":"https://schema.org/primaryPrevention-output",
     "Domain Bucket":"< 1K"
   },
   {
     "Class":"Predicate",
-    "Name":"http:\/\/schema.org\/printColumn",
+    "Name":"https://schema.org/printColumn",
     "Domain Bucket":"< 1K"
   },
   {
     "Class":"Predicate",
-    "Name":"http:\/\/schema.org\/printColumn-input",
+    "Name":"https://schema.org/printColumn-input",
     "Domain Bucket":"< 1K"
   },
   {
     "Class":"Predicate",
-    "Name":"http:\/\/schema.org\/printColumn-output",
+    "Name":"https://schema.org/printColumn-output",
     "Domain Bucket":"< 1K"
   },
   {
     "Class":"Predicate",
-    "Name":"http:\/\/schema.org\/printEdition",
+    "Name":"https://schema.org/printEdition",
     "Domain Bucket":"< 1K"
   },
   {
     "Class":"Predicate",
-    "Name":"http:\/\/schema.org\/printEdition-input",
+    "Name":"https://schema.org/printEdition-input",
     "Domain Bucket":"< 1K"
   },
   {
     "Class":"Predicate",
-    "Name":"http:\/\/schema.org\/printEdition-output",
+    "Name":"https://schema.org/printEdition-output",
     "Domain Bucket":"< 1K"
   },
   {
     "Class":"Predicate",
-    "Name":"http:\/\/schema.org\/printPage",
+    "Name":"https://schema.org/printPage",
     "Domain Bucket":"< 1K"
   },
   {
     "Class":"Predicate",
-    "Name":"http:\/\/schema.org\/printPage-input",
+    "Name":"https://schema.org/printPage-input",
     "Domain Bucket":"< 1K"
   },
   {
     "Class":"Predicate",
-    "Name":"http:\/\/schema.org\/printPage-output",
+    "Name":"https://schema.org/printPage-output",
     "Domain Bucket":"< 1K"
   },
   {
     "Class":"Predicate",
-    "Name":"http:\/\/schema.org\/printSection",
+    "Name":"https://schema.org/printSection",
     "Domain Bucket":"< 1K"
   },
   {
     "Class":"Predicate",
-    "Name":"http:\/\/schema.org\/printSection-input",
+    "Name":"https://schema.org/printSection-input",
     "Domain Bucket":"< 1K"
   },
   {
     "Class":"Predicate",
-    "Name":"http:\/\/schema.org\/printSection-output",
+    "Name":"https://schema.org/printSection-output",
     "Domain Bucket":"< 1K"
   },
   {
     "Class":"Predicate",
-    "Name":"http:\/\/schema.org\/procedure",
+    "Name":"https://schema.org/procedure",
     "Domain Bucket":"< 1K"
   },
   {
     "Class":"Predicate",
-    "Name":"http:\/\/schema.org\/procedure-input",
+    "Name":"https://schema.org/procedure-input",
     "Domain Bucket":"< 1K"
   },
   {
     "Class":"Predicate",
-    "Name":"http:\/\/schema.org\/procedure-output",
+    "Name":"https://schema.org/procedure-output",
     "Domain Bucket":"< 1K"
   },
   {
     "Class":"Predicate",
-    "Name":"http:\/\/schema.org\/procedureType",
+    "Name":"https://schema.org/procedureType",
     "Domain Bucket":"10K - 100K"
   },
   {
     "Class":"Predicate",
-    "Name":"http:\/\/schema.org\/procedureType-input",
+    "Name":"https://schema.org/procedureType-input",
     "Domain Bucket":"< 1K"
   },
   {
     "Class":"Predicate",
-    "Name":"http:\/\/schema.org\/procedureType-output",
+    "Name":"https://schema.org/procedureType-output",
     "Domain Bucket":"< 1K"
   },
   {
     "Class":"Predicate",
-    "Name":"http:\/\/schema.org\/processingTime",
+    "Name":"https://schema.org/processingTime",
     "Domain Bucket":"< 1K"
   },
   {
     "Class":"Predicate",
-    "Name":"http:\/\/schema.org\/processingTime-input",
+    "Name":"https://schema.org/processingTime-input",
     "Domain Bucket":"< 1K"
   },
   {
     "Class":"Predicate",
-    "Name":"http:\/\/schema.org\/processingTime-output",
+    "Name":"https://schema.org/processingTime-output",
     "Domain Bucket":"< 1K"
   },
   {
     "Class":"Predicate",
-    "Name":"http:\/\/schema.org\/processorRequirements",
+    "Name":"https://schema.org/processorRequirements",
     "Domain Bucket":"1K - 10K"
   },
   {
     "Class":"Predicate",
-    "Name":"http:\/\/schema.org\/processorRequirements-input",
+    "Name":"https://schema.org/processorRequirements-input",
     "Domain Bucket":"< 1K"
   },
   {
     "Class":"Predicate",
-    "Name":"http:\/\/schema.org\/processorRequirements-output",
+    "Name":"https://schema.org/processorRequirements-output",
     "Domain Bucket":"< 1K"
   },
   {
     "Class":"Predicate",
-    "Name":"http:\/\/schema.org\/producer",
+    "Name":"https://schema.org/producer",
     "Domain Bucket":"1K - 10K"
   },
   {
     "Class":"Predicate",
-    "Name":"http:\/\/schema.org\/producer-input",
+    "Name":"https://schema.org/producer-input",
     "Domain Bucket":"< 1K"
   },
   {
     "Class":"Predicate",
-    "Name":"http:\/\/schema.org\/producer-output",
+    "Name":"https://schema.org/producer-output",
     "Domain Bucket":"< 1K"
   },
   {
     "Class":"Predicate",
-    "Name":"http:\/\/schema.org\/produces",
+    "Name":"https://schema.org/produces",
     "Domain Bucket":"< 1K"
   },
   {
     "Class":"Predicate",
-    "Name":"http:\/\/schema.org\/produces-input",
+    "Name":"https://schema.org/produces-input",
     "Domain Bucket":"< 1K"
   },
   {
     "Class":"Predicate",
-    "Name":"http:\/\/schema.org\/produces-output",
+    "Name":"https://schema.org/produces-output",
     "Domain Bucket":"< 1K"
   },
   {
     "Class":"Predicate",
-    "Name":"http:\/\/schema.org\/productGroupID",
+    "Name":"https://schema.org/productGroupID",
     "Domain Bucket":"100K - 1M"
   },
   {
     "Class":"Predicate",
-    "Name":"http:\/\/schema.org\/productGroupID-input",
+    "Name":"https://schema.org/productGroupID-input",
     "Domain Bucket":"< 1K"
   },
   {
     "Class":"Predicate",
-    "Name":"http:\/\/schema.org\/productGroupID-output",
+    "Name":"https://schema.org/productGroupID-output",
     "Domain Bucket":"< 1K"
   },
   {
     "Class":"Predicate",
-    "Name":"http:\/\/schema.org\/productID",
+    "Name":"https://schema.org/productID",
     "Domain Bucket":"100K - 1M"
   },
   {
     "Class":"Predicate",
-    "Name":"http:\/\/schema.org\/productID-input",
+    "Name":"https://schema.org/productID-input",
     "Domain Bucket":"< 1K"
   },
   {
     "Class":"Predicate",
-    "Name":"http:\/\/schema.org\/productID-output",
+    "Name":"https://schema.org/productID-output",
     "Domain Bucket":"< 1K"
   },
   {
     "Class":"Predicate",
-    "Name":"http:\/\/schema.org\/productReturnDays",
+    "Name":"https://schema.org/productReturnDays",
     "Domain Bucket":"< 1K"
   },
   {
     "Class":"Predicate",
-    "Name":"http:\/\/schema.org\/productReturnDays-input",
+    "Name":"https://schema.org/productReturnDays-input",
     "Domain Bucket":"< 1K"
   },
   {
     "Class":"Predicate",
-    "Name":"http:\/\/schema.org\/productReturnDays-output",
+    "Name":"https://schema.org/productReturnDays-output",
     "Domain Bucket":"< 1K"
   },
   {
     "Class":"Predicate",
-    "Name":"http:\/\/schema.org\/productReturnLink",
+    "Name":"https://schema.org/productReturnLink",
     "Domain Bucket":"< 1K"
   },
   {
     "Class":"Predicate",
-    "Name":"http:\/\/schema.org\/productReturnLink-input",
+    "Name":"https://schema.org/productReturnLink-input",
     "Domain Bucket":"< 1K"
   },
   {
     "Class":"Predicate",
-    "Name":"http:\/\/schema.org\/productReturnLink-output",
+    "Name":"https://schema.org/productReturnLink-output",
     "Domain Bucket":"< 1K"
   },
   {
     "Class":"Predicate",
-    "Name":"http:\/\/schema.org\/productSupported",
+    "Name":"https://schema.org/productSupported",
     "Domain Bucket":"1K - 10K"
   },
   {
     "Class":"Predicate",
-    "Name":"http:\/\/schema.org\/productSupported-input",
+    "Name":"https://schema.org/productSupported-input",
     "Domain Bucket":"< 1K"
   },
   {
     "Class":"Predicate",
-    "Name":"http:\/\/schema.org\/productSupported-output",
+    "Name":"https://schema.org/productSupported-output",
     "Domain Bucket":"< 1K"
   },
   {
     "Class":"Predicate",
-    "Name":"http:\/\/schema.org\/productionCompany",
+    "Name":"https://schema.org/productionCompany",
     "Domain Bucket":"1K - 10K"
   },
   {
     "Class":"Predicate",
-    "Name":"http:\/\/schema.org\/productionCompany-input",
+    "Name":"https://schema.org/productionCompany-input",
     "Domain Bucket":"< 1K"
   },
   {
     "Class":"Predicate",
-    "Name":"http:\/\/schema.org\/productionCompany-output",
+    "Name":"https://schema.org/productionCompany-output",
     "Domain Bucket":"< 1K"
   },
   {
     "Class":"Predicate",
-    "Name":"http:\/\/schema.org\/productionDate",
+    "Name":"https://schema.org/productionDate",
     "Domain Bucket":"10K - 100K"
   },
   {
     "Class":"Predicate",
-    "Name":"http:\/\/schema.org\/productionDate-input",
+    "Name":"https://schema.org/productionDate-input",
     "Domain Bucket":"< 1K"
   },
   {
     "Class":"Predicate",
-    "Name":"http:\/\/schema.org\/productionDate-output",
+    "Name":"https://schema.org/productionDate-output",
     "Domain Bucket":"< 1K"
   },
   {
     "Class":"Predicate",
-    "Name":"http:\/\/schema.org\/proficiencyLevel",
+    "Name":"https://schema.org/proficiencyLevel",
     "Domain Bucket":"10K - 100K"
   },
   {
     "Class":"Predicate",
-    "Name":"http:\/\/schema.org\/proficiencyLevel-input",
+    "Name":"https://schema.org/proficiencyLevel-input",
     "Domain Bucket":"< 1K"
   },
   {
     "Class":"Predicate",
-    "Name":"http:\/\/schema.org\/proficiencyLevel-output",
+    "Name":"https://schema.org/proficiencyLevel-output",
     "Domain Bucket":"< 1K"
   },
   {
     "Class":"Predicate",
-    "Name":"http:\/\/schema.org\/program",
+    "Name":"https://schema.org/program",
     "Domain Bucket":"< 1K"
   },
   {
     "Class":"Predicate",
-    "Name":"http:\/\/schema.org\/program-input",
+    "Name":"https://schema.org/program-input",
     "Domain Bucket":"< 1K"
   },
   {
     "Class":"Predicate",
-    "Name":"http:\/\/schema.org\/program-output",
+    "Name":"https://schema.org/program-output",
     "Domain Bucket":"< 1K"
   },
   {
     "Class":"Predicate",
-    "Name":"http:\/\/schema.org\/programMembershipUsed",
+    "Name":"https://schema.org/programMembershipUsed",
     "Domain Bucket":"< 1K"
   },
   {
     "Class":"Predicate",
-    "Name":"http:\/\/schema.org\/programMembershipUsed-input",
+    "Name":"https://schema.org/programMembershipUsed-input",
     "Domain Bucket":"< 1K"
   },
   {
     "Class":"Predicate",
-    "Name":"http:\/\/schema.org\/programMembershipUsed-output",
+    "Name":"https://schema.org/programMembershipUsed-output",
     "Domain Bucket":"< 1K"
   },
   {
     "Class":"Predicate",
-    "Name":"http:\/\/schema.org\/programName",
+    "Name":"https://schema.org/programName",
     "Domain Bucket":"1K - 10K"
   },
   {
     "Class":"Predicate",
-    "Name":"http:\/\/schema.org\/programName-input",
+    "Name":"https://schema.org/programName-input",
     "Domain Bucket":"< 1K"
   },
   {
     "Class":"Predicate",
-    "Name":"http:\/\/schema.org\/programName-output",
+    "Name":"https://schema.org/programName-output",
     "Domain Bucket":"< 1K"
   },
   {
     "Class":"Predicate",
-    "Name":"http:\/\/schema.org\/programPrerequisites",
+    "Name":"https://schema.org/programPrerequisites",
     "Domain Bucket":"1K - 10K"
   },
   {
     "Class":"Predicate",
-    "Name":"http:\/\/schema.org\/programPrerequisites-input",
+    "Name":"https://schema.org/programPrerequisites-input",
     "Domain Bucket":"< 1K"
   },
   {
     "Class":"Predicate",
-    "Name":"http:\/\/schema.org\/programPrerequisites-output",
+    "Name":"https://schema.org/programPrerequisites-output",
     "Domain Bucket":"< 1K"
   },
   {
     "Class":"Predicate",
-    "Name":"http:\/\/schema.org\/programType",
+    "Name":"https://schema.org/programType",
     "Domain Bucket":"1K - 10K"
   },
   {
     "Class":"Predicate",
-    "Name":"http:\/\/schema.org\/programType-input",
+    "Name":"https://schema.org/programType-input",
     "Domain Bucket":"< 1K"
   },
   {
     "Class":"Predicate",
-    "Name":"http:\/\/schema.org\/programType-output",
+    "Name":"https://schema.org/programType-output",
     "Domain Bucket":"< 1K"
   },
   {
     "Class":"Predicate",
-    "Name":"http:\/\/schema.org\/programmingLanguage",
+    "Name":"https://schema.org/programmingLanguage",
     "Domain Bucket":"1K - 10K"
   },
   {
     "Class":"Predicate",
-    "Name":"http:\/\/schema.org\/programmingLanguage-input",
+    "Name":"https://schema.org/programmingLanguage-input",
     "Domain Bucket":"< 1K"
   },
   {
     "Class":"Predicate",
-    "Name":"http:\/\/schema.org\/programmingLanguage-output",
+    "Name":"https://schema.org/programmingLanguage-output",
     "Domain Bucket":"< 1K"
   },
   {
     "Class":"Predicate",
-    "Name":"http:\/\/schema.org\/programmingModel",
+    "Name":"https://schema.org/programmingModel",
     "Domain Bucket":"< 1K"
   },
   {
     "Class":"Predicate",
-    "Name":"http:\/\/schema.org\/programmingModel-input",
+    "Name":"https://schema.org/programmingModel-input",
     "Domain Bucket":"< 1K"
   },
   {
     "Class":"Predicate",
-    "Name":"http:\/\/schema.org\/programmingModel-output",
+    "Name":"https://schema.org/programmingModel-output",
     "Domain Bucket":"< 1K"
   },
   {
     "Class":"Predicate",
-    "Name":"http:\/\/schema.org\/pronouns",
+    "Name":"https://schema.org/pronouns",
     "Domain Bucket":"1K - 10K"
   },
   {
     "Class":"Predicate",
-    "Name":"http:\/\/schema.org\/pronouns-input",
+    "Name":"https://schema.org/pronouns-input",
     "Domain Bucket":"< 1K"
   },
   {
     "Class":"Predicate",
-    "Name":"http:\/\/schema.org\/pronouns-output",
+    "Name":"https://schema.org/pronouns-output",
     "Domain Bucket":"< 1K"
   },
   {
     "Class":"Predicate",
-    "Name":"http:\/\/schema.org\/propertyID",
+    "Name":"https://schema.org/propertyID",
     "Domain Bucket":"10K - 100K"
   },
   {
     "Class":"Predicate",
-    "Name":"http:\/\/schema.org\/propertyID-input",
+    "Name":"https://schema.org/propertyID-input",
     "Domain Bucket":"< 1K"
   },
   {
     "Class":"Predicate",
-    "Name":"http:\/\/schema.org\/propertyID-output",
+    "Name":"https://schema.org/propertyID-output",
     "Domain Bucket":"< 1K"
   },
   {
     "Class":"Predicate",
-    "Name":"http:\/\/schema.org\/proprietaryName",
+    "Name":"https://schema.org/proprietaryName",
     "Domain Bucket":"< 1K"
   },
   {
     "Class":"Predicate",
-    "Name":"http:\/\/schema.org\/proprietaryName-input",
+    "Name":"https://schema.org/proprietaryName-input",
     "Domain Bucket":"< 1K"
   },
   {
     "Class":"Predicate",
-    "Name":"http:\/\/schema.org\/proprietaryName-output",
+    "Name":"https://schema.org/proprietaryName-output",
     "Domain Bucket":"< 1K"
   },
   {
     "Class":"Predicate",
-    "Name":"http:\/\/schema.org\/proteinContent",
+    "Name":"https://schema.org/proteinContent",
     "Domain Bucket":"10K - 100K"
   },
   {
     "Class":"Predicate",
-    "Name":"http:\/\/schema.org\/proteinContent-input",
+    "Name":"https://schema.org/proteinContent-input",
     "Domain Bucket":"< 1K"
   },
   {
     "Class":"Predicate",
-    "Name":"http:\/\/schema.org\/proteinContent-output",
+    "Name":"https://schema.org/proteinContent-output",
     "Domain Bucket":"< 1K"
   },
   {
     "Class":"Predicate",
-    "Name":"http:\/\/schema.org\/provider",
+    "Name":"https://schema.org/provider",
     "Domain Bucket":"1M - 10M"
   },
   {
     "Class":"Predicate",
-    "Name":"http:\/\/schema.org\/provider-input",
+    "Name":"https://schema.org/provider-input",
     "Domain Bucket":"< 1K"
   },
   {
     "Class":"Predicate",
-    "Name":"http:\/\/schema.org\/provider-output",
+    "Name":"https://schema.org/provider-output",
     "Domain Bucket":"< 1K"
   },
   {
     "Class":"Predicate",
-    "Name":"http:\/\/schema.org\/providerMobility",
+    "Name":"https://schema.org/providerMobility",
     "Domain Bucket":"1K - 10K"
   },
   {
     "Class":"Predicate",
-    "Name":"http:\/\/schema.org\/providerMobility-input",
+    "Name":"https://schema.org/providerMobility-input",
     "Domain Bucket":"< 1K"
   },
   {
     "Class":"Predicate",
-    "Name":"http:\/\/schema.org\/providerMobility-output",
+    "Name":"https://schema.org/providerMobility-output",
     "Domain Bucket":"< 1K"
   },
   {
     "Class":"Predicate",
-    "Name":"http:\/\/schema.org\/providesBroadcastService",
+    "Name":"https://schema.org/providesBroadcastService",
     "Domain Bucket":"< 1K"
   },
   {
     "Class":"Predicate",
-    "Name":"http:\/\/schema.org\/providesBroadcastService-input",
+    "Name":"https://schema.org/providesBroadcastService-input",
     "Domain Bucket":"< 1K"
   },
   {
     "Class":"Predicate",
-    "Name":"http:\/\/schema.org\/providesBroadcastService-output",
+    "Name":"https://schema.org/providesBroadcastService-output",
     "Domain Bucket":"< 1K"
   },
   {
     "Class":"Predicate",
-    "Name":"http:\/\/schema.org\/providesService",
+    "Name":"https://schema.org/providesService",
     "Domain Bucket":"< 1K"
   },
   {
     "Class":"Predicate",
-    "Name":"http:\/\/schema.org\/providesService-input",
+    "Name":"https://schema.org/providesService-input",
     "Domain Bucket":"< 1K"
   },
   {
     "Class":"Predicate",
-    "Name":"http:\/\/schema.org\/providesService-output",
+    "Name":"https://schema.org/providesService-output",
     "Domain Bucket":"< 1K"
   },
   {
     "Class":"Predicate",
-    "Name":"http:\/\/schema.org\/publicAccess",
+    "Name":"https://schema.org/publicAccess",
     "Domain Bucket":"10K - 100K"
   },
   {
     "Class":"Predicate",
-    "Name":"http:\/\/schema.org\/publicAccess-input",
+    "Name":"https://schema.org/publicAccess-input",
     "Domain Bucket":"< 1K"
   },
   {
     "Class":"Predicate",
-    "Name":"http:\/\/schema.org\/publicAccess-output",
+    "Name":"https://schema.org/publicAccess-output",
     "Domain Bucket":"< 1K"
   },
   {
     "Class":"Predicate",
-    "Name":"http:\/\/schema.org\/publicTransportClosuresInfo",
+    "Name":"https://schema.org/publicTransportClosuresInfo",
     "Domain Bucket":"< 1K"
   },
   {
     "Class":"Predicate",
-    "Name":"http:\/\/schema.org\/publicTransportClosuresInfo-input",
+    "Name":"https://schema.org/publicTransportClosuresInfo-input",
     "Domain Bucket":"< 1K"
   },
   {
     "Class":"Predicate",
-    "Name":"http:\/\/schema.org\/publicTransportClosuresInfo-output",
+    "Name":"https://schema.org/publicTransportClosuresInfo-output",
     "Domain Bucket":"< 1K"
   },
   {
     "Class":"Predicate",
-    "Name":"http:\/\/schema.org\/publication",
+    "Name":"https://schema.org/publication",
     "Domain Bucket":"1K - 10K"
   },
   {
     "Class":"Predicate",
-    "Name":"http:\/\/schema.org\/publication-input",
+    "Name":"https://schema.org/publication-input",
     "Domain Bucket":"< 1K"
   },
   {
     "Class":"Predicate",
-    "Name":"http:\/\/schema.org\/publication-output",
+    "Name":"https://schema.org/publication-output",
     "Domain Bucket":"< 1K"
   },
   {
     "Class":"Predicate",
-    "Name":"http:\/\/schema.org\/publicationType",
+    "Name":"https://schema.org/publicationType",
     "Domain Bucket":"< 1K"
   },
   {
     "Class":"Predicate",
-    "Name":"http:\/\/schema.org\/publicationType-input",
+    "Name":"https://schema.org/publicationType-input",
     "Domain Bucket":"< 1K"
   },
   {
     "Class":"Predicate",
-    "Name":"http:\/\/schema.org\/publicationType-output",
+    "Name":"https://schema.org/publicationType-output",
     "Domain Bucket":"< 1K"
   },
   {
     "Class":"Predicate",
-    "Name":"http:\/\/schema.org\/publishedBy",
+    "Name":"https://schema.org/publishedBy",
     "Domain Bucket":"< 1K"
   },
   {
     "Class":"Predicate",
-    "Name":"http:\/\/schema.org\/publishedBy-input",
+    "Name":"https://schema.org/publishedBy-input",
     "Domain Bucket":"< 1K"
   },
   {
     "Class":"Predicate",
-    "Name":"http:\/\/schema.org\/publishedBy-output",
+    "Name":"https://schema.org/publishedBy-output",
     "Domain Bucket":"< 1K"
   },
   {
     "Class":"Predicate",
-    "Name":"http:\/\/schema.org\/publishedOn",
+    "Name":"https://schema.org/publishedOn",
     "Domain Bucket":"< 1K"
   },
   {
     "Class":"Predicate",
-    "Name":"http:\/\/schema.org\/publishedOn-input",
+    "Name":"https://schema.org/publishedOn-input",
     "Domain Bucket":"< 1K"
   },
   {
     "Class":"Predicate",
-    "Name":"http:\/\/schema.org\/publishedOn-output",
+    "Name":"https://schema.org/publishedOn-output",
     "Domain Bucket":"< 1K"
   },
   {
     "Class":"Predicate",
-    "Name":"http:\/\/schema.org\/publisher",
+    "Name":"https://schema.org/publisher",
     "Domain Bucket":"10M+"
   },
   {
     "Class":"Predicate",
-    "Name":"http:\/\/schema.org\/publisher-input",
+    "Name":"https://schema.org/publisher-input",
     "Domain Bucket":"< 1K"
   },
   {
     "Class":"Predicate",
-    "Name":"http:\/\/schema.org\/publisher-output",
+    "Name":"https://schema.org/publisher-output",
     "Domain Bucket":"< 1K"
   },
   {
     "Class":"Predicate",
-    "Name":"http:\/\/schema.org\/publisherImprint",
+    "Name":"https://schema.org/publisherImprint",
     "Domain Bucket":"< 1K"
   },
   {
     "Class":"Predicate",
-    "Name":"http:\/\/schema.org\/publisherImprint-input",
+    "Name":"https://schema.org/publisherImprint-input",
     "Domain Bucket":"< 1K"
   },
   {
     "Class":"Predicate",
-    "Name":"http:\/\/schema.org\/publisherImprint-output",
+    "Name":"https://schema.org/publisherImprint-output",
     "Domain Bucket":"< 1K"
   },
   {
     "Class":"Predicate",
-    "Name":"http:\/\/schema.org\/publishingPrinciples",
+    "Name":"https://schema.org/publishingPrinciples",
     "Domain Bucket":"10K - 100K"
   },
   {
     "Class":"Predicate",
-    "Name":"http:\/\/schema.org\/publishingPrinciples-input",
+    "Name":"https://schema.org/publishingPrinciples-input",
     "Domain Bucket":"< 1K"
   },
   {
     "Class":"Predicate",
-    "Name":"http:\/\/schema.org\/publishingPrinciples-output",
+    "Name":"https://schema.org/publishingPrinciples-output",
     "Domain Bucket":"< 1K"
   },
   {
     "Class":"Predicate",
-    "Name":"http:\/\/schema.org\/purchaseDate",
+    "Name":"https://schema.org/purchaseDate",
     "Domain Bucket":"< 1K"
   },
   {
     "Class":"Predicate",
-    "Name":"http:\/\/schema.org\/purchaseDate-input",
+    "Name":"https://schema.org/purchaseDate-input",
     "Domain Bucket":"< 1K"
   },
   {
     "Class":"Predicate",
-    "Name":"http:\/\/schema.org\/purchaseDate-output",
+    "Name":"https://schema.org/purchaseDate-output",
     "Domain Bucket":"< 1K"
   },
   {
     "Class":"Predicate",
-    "Name":"http:\/\/schema.org\/purchasePriceLimit",
+    "Name":"https://schema.org/purchasePriceLimit",
     "Domain Bucket":"< 1K"
   },
   {
     "Class":"Predicate",
-    "Name":"http:\/\/schema.org\/purchasePriceLimit-input",
+    "Name":"https://schema.org/purchasePriceLimit-input",
     "Domain Bucket":"< 1K"
   },
   {
     "Class":"Predicate",
-    "Name":"http:\/\/schema.org\/purchasePriceLimit-output",
+    "Name":"https://schema.org/purchasePriceLimit-output",
     "Domain Bucket":"< 1K"
   },
   {
     "Class":"Predicate",
-    "Name":"http:\/\/schema.org\/purchaseType",
+    "Name":"https://schema.org/purchaseType",
     "Domain Bucket":"< 1K"
   },
   {
     "Class":"Predicate",
-    "Name":"http:\/\/schema.org\/purchaseType-input",
+    "Name":"https://schema.org/purchaseType-input",
     "Domain Bucket":"< 1K"
   },
   {
     "Class":"Predicate",
-    "Name":"http:\/\/schema.org\/purchaseType-output",
+    "Name":"https://schema.org/purchaseType-output",
     "Domain Bucket":"< 1K"
   },
   {
     "Class":"Predicate",
-    "Name":"http:\/\/schema.org\/qualifications",
+    "Name":"https://schema.org/qualifications",
     "Domain Bucket":"10K - 100K"
   },
   {
     "Class":"Predicate",
-    "Name":"http:\/\/schema.org\/qualifications-input",
+    "Name":"https://schema.org/qualifications-input",
     "Domain Bucket":"< 1K"
   },
   {
     "Class":"Predicate",
-    "Name":"http:\/\/schema.org\/qualifications-output",
+    "Name":"https://schema.org/qualifications-output",
     "Domain Bucket":"< 1K"
   },
   {
     "Class":"Predicate",
-    "Name":"http:\/\/schema.org\/qualifiedExpense",
+    "Name":"https://schema.org/qualifiedExpense",
     "Domain Bucket":"< 1K"
   },
   {
     "Class":"Predicate",
-    "Name":"http:\/\/schema.org\/qualifiedExpense-input",
+    "Name":"https://schema.org/qualifiedExpense-input",
     "Domain Bucket":"< 1K"
   },
   {
     "Class":"Predicate",
-    "Name":"http:\/\/schema.org\/qualifiedExpense-output",
+    "Name":"https://schema.org/qualifiedExpense-output",
     "Domain Bucket":"< 1K"
   },
   {
     "Class":"Predicate",
-    "Name":"http:\/\/schema.org\/quarantineGuidelines",
+    "Name":"https://schema.org/quarantineGuidelines",
     "Domain Bucket":"< 1K"
   },
   {
     "Class":"Predicate",
-    "Name":"http:\/\/schema.org\/quarantineGuidelines-input",
+    "Name":"https://schema.org/quarantineGuidelines-input",
     "Domain Bucket":"< 1K"
   },
   {
     "Class":"Predicate",
-    "Name":"http:\/\/schema.org\/quarantineGuidelines-output",
+    "Name":"https://schema.org/quarantineGuidelines-output",
     "Domain Bucket":"< 1K"
   },
   {
     "Class":"Predicate",
-    "Name":"http:\/\/schema.org\/query",
+    "Name":"https://schema.org/query",
     "Domain Bucket":"10K - 100K"
   },
   {
     "Class":"Predicate",
-    "Name":"http:\/\/schema.org\/query-input",
+    "Name":"https://schema.org/query-input",
     "Domain Bucket":"10M+"
   },
   {
     "Class":"Predicate",
-    "Name":"http:\/\/schema.org\/query-output",
+    "Name":"https://schema.org/query-output",
     "Domain Bucket":"< 1K"
   },
   {
     "Class":"Predicate",
-    "Name":"http:\/\/schema.org\/quest",
+    "Name":"https://schema.org/quest",
     "Domain Bucket":"< 1K"
   },
   {
     "Class":"Predicate",
-    "Name":"http:\/\/schema.org\/quest-input",
+    "Name":"https://schema.org/quest-input",
     "Domain Bucket":"< 1K"
   },
   {
     "Class":"Predicate",
-    "Name":"http:\/\/schema.org\/quest-output",
+    "Name":"https://schema.org/quest-output",
     "Domain Bucket":"< 1K"
   },
   {
     "Class":"Predicate",
-    "Name":"http:\/\/schema.org\/question",
+    "Name":"https://schema.org/question",
     "Domain Bucket":"< 1K"
   },
   {
     "Class":"Predicate",
-    "Name":"http:\/\/schema.org\/question-input",
+    "Name":"https://schema.org/question-input",
     "Domain Bucket":"< 1K"
   },
   {
     "Class":"Predicate",
-    "Name":"http:\/\/schema.org\/question-output",
+    "Name":"https://schema.org/question-output",
     "Domain Bucket":"< 1K"
   },
   {
     "Class":"Predicate",
-    "Name":"http:\/\/schema.org\/rangeIncludes",
+    "Name":"https://schema.org/rangeIncludes",
     "Domain Bucket":"< 1K"
   },
   {
     "Class":"Predicate",
-    "Name":"http:\/\/schema.org\/rangeIncludes-input",
+    "Name":"https://schema.org/rangeIncludes-input",
     "Domain Bucket":"< 1K"
   },
   {
     "Class":"Predicate",
-    "Name":"http:\/\/schema.org\/rangeIncludes-output",
+    "Name":"https://schema.org/rangeIncludes-output",
     "Domain Bucket":"< 1K"
   },
   {
     "Class":"Predicate",
-    "Name":"http:\/\/schema.org\/ratingCount",
+    "Name":"https://schema.org/ratingCount",
     "Domain Bucket":"1M - 10M"
   },
   {
     "Class":"Predicate",
-    "Name":"http:\/\/schema.org\/ratingCount-input",
+    "Name":"https://schema.org/ratingCount-input",
     "Domain Bucket":"< 1K"
   },
   {
     "Class":"Predicate",
-    "Name":"http:\/\/schema.org\/ratingCount-output",
+    "Name":"https://schema.org/ratingCount-output",
     "Domain Bucket":"< 1K"
   },
   {
     "Class":"Predicate",
-    "Name":"http:\/\/schema.org\/ratingExplanation",
+    "Name":"https://schema.org/ratingExplanation",
     "Domain Bucket":"1K - 10K"
   },
   {
     "Class":"Predicate",
-    "Name":"http:\/\/schema.org\/ratingExplanation-input",
+    "Name":"https://schema.org/ratingExplanation-input",
     "Domain Bucket":"< 1K"
   },
   {
     "Class":"Predicate",
-    "Name":"http:\/\/schema.org\/ratingExplanation-output",
+    "Name":"https://schema.org/ratingExplanation-output",
     "Domain Bucket":"< 1K"
   },
   {
     "Class":"Predicate",
-    "Name":"http:\/\/schema.org\/ratingValue",
+    "Name":"https://schema.org/ratingValue",
     "Domain Bucket":"1M - 10M"
   },
   {
     "Class":"Predicate",
-    "Name":"http:\/\/schema.org\/ratingValue-input",
+    "Name":"https://schema.org/ratingValue-input",
     "Domain Bucket":"< 1K"
   },
   {
     "Class":"Predicate",
-    "Name":"http:\/\/schema.org\/ratingValue-output",
+    "Name":"https://schema.org/ratingValue-output",
     "Domain Bucket":"< 1K"
   },
   {
     "Class":"Predicate",
-    "Name":"http:\/\/schema.org\/readBy",
+    "Name":"https://schema.org/readBy",
     "Domain Bucket":"< 1K"
   },
   {
     "Class":"Predicate",
-    "Name":"http:\/\/schema.org\/readBy-input",
+    "Name":"https://schema.org/readBy-input",
     "Domain Bucket":"< 1K"
   },
   {
     "Class":"Predicate",
-    "Name":"http:\/\/schema.org\/readBy-output",
+    "Name":"https://schema.org/readBy-output",
     "Domain Bucket":"< 1K"
   },
   {
     "Class":"Predicate",
-    "Name":"http:\/\/schema.org\/readonlyValue",
+    "Name":"https://schema.org/readonlyValue",
     "Domain Bucket":"< 1K"
   },
   {
     "Class":"Predicate",
-    "Name":"http:\/\/schema.org\/readonlyValue-input",
+    "Name":"https://schema.org/readonlyValue-input",
     "Domain Bucket":"< 1K"
   },
   {
     "Class":"Predicate",
-    "Name":"http:\/\/schema.org\/readonlyValue-output",
+    "Name":"https://schema.org/readonlyValue-output",
     "Domain Bucket":"< 1K"
   },
   {
     "Class":"Predicate",
-    "Name":"http:\/\/schema.org\/realEstateAgent",
+    "Name":"https://schema.org/realEstateAgent",
     "Domain Bucket":"< 1K"
   },
   {
     "Class":"Predicate",
-    "Name":"http:\/\/schema.org\/realEstateAgent-input",
+    "Name":"https://schema.org/realEstateAgent-input",
     "Domain Bucket":"< 1K"
   },
   {
     "Class":"Predicate",
-    "Name":"http:\/\/schema.org\/realEstateAgent-output",
+    "Name":"https://schema.org/realEstateAgent-output",
     "Domain Bucket":"< 1K"
   },
   {
     "Class":"Predicate",
-    "Name":"http:\/\/schema.org\/recipe",
+    "Name":"https://schema.org/recipe",
     "Domain Bucket":"< 1K"
   },
   {
     "Class":"Predicate",
-    "Name":"http:\/\/schema.org\/recipe-input",
+    "Name":"https://schema.org/recipe-input",
     "Domain Bucket":"< 1K"
   },
   {
     "Class":"Predicate",
-    "Name":"http:\/\/schema.org\/recipe-output",
+    "Name":"https://schema.org/recipe-output",
     "Domain Bucket":"< 1K"
   },
   {
     "Class":"Predicate",
-    "Name":"http:\/\/schema.org\/recipeCategory",
+    "Name":"https://schema.org/recipeCategory",
     "Domain Bucket":"10K - 100K"
   },
   {
     "Class":"Predicate",
-    "Name":"http:\/\/schema.org\/recipeCategory-input",
+    "Name":"https://schema.org/recipeCategory-input",
     "Domain Bucket":"< 1K"
   },
   {
     "Class":"Predicate",
-    "Name":"http:\/\/schema.org\/recipeCategory-output",
+    "Name":"https://schema.org/recipeCategory-output",
     "Domain Bucket":"< 1K"
   },
   {
     "Class":"Predicate",
-    "Name":"http:\/\/schema.org\/recipeCuisine",
+    "Name":"https://schema.org/recipeCuisine",
     "Domain Bucket":"10K - 100K"
   },
   {
     "Class":"Predicate",
-    "Name":"http:\/\/schema.org\/recipeCuisine-input",
+    "Name":"https://schema.org/recipeCuisine-input",
     "Domain Bucket":"< 1K"
   },
   {
     "Class":"Predicate",
-    "Name":"http:\/\/schema.org\/recipeCuisine-output",
+    "Name":"https://schema.org/recipeCuisine-output",
     "Domain Bucket":"< 1K"
   },
   {
     "Class":"Predicate",
-    "Name":"http:\/\/schema.org\/recipeIngredient",
+    "Name":"https://schema.org/recipeIngredient",
     "Domain Bucket":"10K - 100K"
   },
   {
     "Class":"Predicate",
-    "Name":"http:\/\/schema.org\/recipeIngredient-input",
+    "Name":"https://schema.org/recipeIngredient-input",
     "Domain Bucket":"< 1K"
   },
   {
     "Class":"Predicate",
-    "Name":"http:\/\/schema.org\/recipeIngredient-output",
+    "Name":"https://schema.org/recipeIngredient-output",
     "Domain Bucket":"< 1K"
   },
   {
     "Class":"Predicate",
-    "Name":"http:\/\/schema.org\/recipeInstructions",
+    "Name":"https://schema.org/recipeInstructions",
     "Domain Bucket":"10K - 100K"
   },
   {
     "Class":"Predicate",
-    "Name":"http:\/\/schema.org\/recipeInstructions-input",
+    "Name":"https://schema.org/recipeInstructions-input",
     "Domain Bucket":"< 1K"
   },
   {
     "Class":"Predicate",
-    "Name":"http:\/\/schema.org\/recipeInstructions-output",
+    "Name":"https://schema.org/recipeInstructions-output",
     "Domain Bucket":"< 1K"
   },
   {
     "Class":"Predicate",
-    "Name":"http:\/\/schema.org\/recipeYield",
+    "Name":"https://schema.org/recipeYield",
     "Domain Bucket":"10K - 100K"
   },
   {
     "Class":"Predicate",
-    "Name":"http:\/\/schema.org\/recipeYield-input",
+    "Name":"https://schema.org/recipeYield-input",
     "Domain Bucket":"< 1K"
   },
   {
     "Class":"Predicate",
-    "Name":"http:\/\/schema.org\/recipeYield-output",
+    "Name":"https://schema.org/recipeYield-output",
     "Domain Bucket":"< 1K"
   },
   {
     "Class":"Predicate",
-    "Name":"http:\/\/schema.org\/recipient",
+    "Name":"https://schema.org/recipient",
     "Domain Bucket":"1K - 10K"
   },
   {
     "Class":"Predicate",
-    "Name":"http:\/\/schema.org\/recipient-input",
+    "Name":"https://schema.org/recipient-input",
     "Domain Bucket":"< 1K"
   },
   {
     "Class":"Predicate",
-    "Name":"http:\/\/schema.org\/recipient-output",
+    "Name":"https://schema.org/recipient-output",
     "Domain Bucket":"< 1K"
   },
   {
     "Class":"Predicate",
-    "Name":"http:\/\/schema.org\/recognizedBy",
+    "Name":"https://schema.org/recognizedBy",
     "Domain Bucket":"10K - 100K"
   },
   {
     "Class":"Predicate",
-    "Name":"http:\/\/schema.org\/recognizedBy-input",
+    "Name":"https://schema.org/recognizedBy-input",
     "Domain Bucket":"< 1K"
   },
   {
     "Class":"Predicate",
-    "Name":"http:\/\/schema.org\/recognizedBy-output",
+    "Name":"https://schema.org/recognizedBy-output",
     "Domain Bucket":"< 1K"
   },
   {
     "Class":"Predicate",
-    "Name":"http:\/\/schema.org\/recognizingAuthority",
+    "Name":"https://schema.org/recognizingAuthority",
     "Domain Bucket":"1K - 10K"
   },
   {
     "Class":"Predicate",
-    "Name":"http:\/\/schema.org\/recognizingAuthority-input",
+    "Name":"https://schema.org/recognizingAuthority-input",
     "Domain Bucket":"< 1K"
   },
   {
     "Class":"Predicate",
-    "Name":"http:\/\/schema.org\/recognizingAuthority-output",
+    "Name":"https://schema.org/recognizingAuthority-output",
     "Domain Bucket":"< 1K"
   },
   {
     "Class":"Predicate",
-    "Name":"http:\/\/schema.org\/recommendationStrength",
+    "Name":"https://schema.org/recommendationStrength",
     "Domain Bucket":"< 1K"
   },
   {
     "Class":"Predicate",
-    "Name":"http:\/\/schema.org\/recommendationStrength-input",
+    "Name":"https://schema.org/recommendationStrength-input",
     "Domain Bucket":"< 1K"
   },
   {
     "Class":"Predicate",
-    "Name":"http:\/\/schema.org\/recommendationStrength-output",
+    "Name":"https://schema.org/recommendationStrength-output",
     "Domain Bucket":"< 1K"
   },
   {
     "Class":"Predicate",
-    "Name":"http:\/\/schema.org\/recommendedIntake",
+    "Name":"https://schema.org/recommendedIntake",
     "Domain Bucket":"< 1K"
   },
   {
     "Class":"Predicate",
-    "Name":"http:\/\/schema.org\/recommendedIntake-input",
+    "Name":"https://schema.org/recommendedIntake-input",
     "Domain Bucket":"< 1K"
   },
   {
     "Class":"Predicate",
-    "Name":"http:\/\/schema.org\/recommendedIntake-output",
+    "Name":"https://schema.org/recommendedIntake-output",
     "Domain Bucket":"< 1K"
   },
   {
     "Class":"Predicate",
-    "Name":"http:\/\/schema.org\/recordLabel",
+    "Name":"https://schema.org/recordLabel",
     "Domain Bucket":"1K - 10K"
   },
   {
     "Class":"Predicate",
-    "Name":"http:\/\/schema.org\/recordLabel-input",
+    "Name":"https://schema.org/recordLabel-input",
     "Domain Bucket":"< 1K"
   },
   {
     "Class":"Predicate",
-    "Name":"http:\/\/schema.org\/recordLabel-output",
+    "Name":"https://schema.org/recordLabel-output",
     "Domain Bucket":"< 1K"
   },
   {
     "Class":"Predicate",
-    "Name":"http:\/\/schema.org\/recordedAs",
+    "Name":"https://schema.org/recordedAs",
     "Domain Bucket":"< 1K"
   },
   {
     "Class":"Predicate",
-    "Name":"http:\/\/schema.org\/recordedAs-input",
+    "Name":"https://schema.org/recordedAs-input",
     "Domain Bucket":"< 1K"
   },
   {
     "Class":"Predicate",
-    "Name":"http:\/\/schema.org\/recordedAs-output",
+    "Name":"https://schema.org/recordedAs-output",
     "Domain Bucket":"< 1K"
   },
   {
     "Class":"Predicate",
-    "Name":"http:\/\/schema.org\/recordedAt",
+    "Name":"https://schema.org/recordedAt",
     "Domain Bucket":"< 1K"
   },
   {
     "Class":"Predicate",
-    "Name":"http:\/\/schema.org\/recordedAt-input",
+    "Name":"https://schema.org/recordedAt-input",
     "Domain Bucket":"< 1K"
   },
   {
     "Class":"Predicate",
-    "Name":"http:\/\/schema.org\/recordedAt-output",
+    "Name":"https://schema.org/recordedAt-output",
     "Domain Bucket":"< 1K"
   },
   {
     "Class":"Predicate",
-    "Name":"http:\/\/schema.org\/recordedIn",
+    "Name":"https://schema.org/recordedIn",
     "Domain Bucket":"< 1K"
   },
   {
     "Class":"Predicate",
-    "Name":"http:\/\/schema.org\/recordedIn-input",
+    "Name":"https://schema.org/recordedIn-input",
     "Domain Bucket":"< 1K"
   },
   {
     "Class":"Predicate",
-    "Name":"http:\/\/schema.org\/recordedIn-output",
+    "Name":"https://schema.org/recordedIn-output",
     "Domain Bucket":"< 1K"
   },
   {
     "Class":"Predicate",
-    "Name":"http:\/\/schema.org\/recordingOf",
+    "Name":"https://schema.org/recordingOf",
     "Domain Bucket":"1K - 10K"
   },
   {
     "Class":"Predicate",
-    "Name":"http:\/\/schema.org\/recordingOf-input",
+    "Name":"https://schema.org/recordingOf-input",
     "Domain Bucket":"< 1K"
   },
   {
     "Class":"Predicate",
-    "Name":"http:\/\/schema.org\/recordingOf-output",
+    "Name":"https://schema.org/recordingOf-output",
     "Domain Bucket":"< 1K"
   },
   {
     "Class":"Predicate",
-    "Name":"http:\/\/schema.org\/recourseLoan",
+    "Name":"https://schema.org/recourseLoan",
     "Domain Bucket":"< 1K"
   },
   {
     "Class":"Predicate",
-    "Name":"http:\/\/schema.org\/recourseLoan-input",
+    "Name":"https://schema.org/recourseLoan-input",
     "Domain Bucket":"< 1K"
   },
   {
     "Class":"Predicate",
-    "Name":"http:\/\/schema.org\/recourseLoan-output",
+    "Name":"https://schema.org/recourseLoan-output",
     "Domain Bucket":"< 1K"
   },
   {
     "Class":"Predicate",
-    "Name":"http:\/\/schema.org\/referee",
+    "Name":"https://schema.org/referee",
     "Domain Bucket":"< 1K"
   },
   {
     "Class":"Predicate",
-    "Name":"http:\/\/schema.org\/referee-input",
+    "Name":"https://schema.org/referee-input",
     "Domain Bucket":"< 1K"
   },
   {
     "Class":"Predicate",
-    "Name":"http:\/\/schema.org\/referee-output",
+    "Name":"https://schema.org/referee-output",
     "Domain Bucket":"< 1K"
   },
   {
     "Class":"Predicate",
-    "Name":"http:\/\/schema.org\/referenceQuantity",
+    "Name":"https://schema.org/referenceQuantity",
     "Domain Bucket":"1M - 10M"
   },
   {
     "Class":"Predicate",
-    "Name":"http:\/\/schema.org\/referenceQuantity-input",
+    "Name":"https://schema.org/referenceQuantity-input",
     "Domain Bucket":"< 1K"
   },
   {
     "Class":"Predicate",
-    "Name":"http:\/\/schema.org\/referenceQuantity-output",
+    "Name":"https://schema.org/referenceQuantity-output",
     "Domain Bucket":"< 1K"
   },
   {
     "Class":"Predicate",
-    "Name":"http:\/\/schema.org\/referencesOrder",
+    "Name":"https://schema.org/referencesOrder",
     "Domain Bucket":"< 1K"
   },
   {
     "Class":"Predicate",
-    "Name":"http:\/\/schema.org\/referencesOrder-input",
+    "Name":"https://schema.org/referencesOrder-input",
     "Domain Bucket":"< 1K"
   },
   {
     "Class":"Predicate",
-    "Name":"http:\/\/schema.org\/referencesOrder-output",
+    "Name":"https://schema.org/referencesOrder-output",
     "Domain Bucket":"< 1K"
   },
   {
     "Class":"Predicate",
-    "Name":"http:\/\/schema.org\/refundType",
+    "Name":"https://schema.org/refundType",
     "Domain Bucket":"10K - 100K"
   },
   {
     "Class":"Predicate",
-    "Name":"http:\/\/schema.org\/refundType-input",
+    "Name":"https://schema.org/refundType-input",
     "Domain Bucket":"< 1K"
   },
   {
     "Class":"Predicate",
-    "Name":"http:\/\/schema.org\/refundType-output",
+    "Name":"https://schema.org/refundType-output",
     "Domain Bucket":"< 1K"
   },
   {
     "Class":"Predicate",
-    "Name":"http:\/\/schema.org\/regionDrained",
+    "Name":"https://schema.org/regionDrained",
     "Domain Bucket":"< 1K"
   },
   {
     "Class":"Predicate",
-    "Name":"http:\/\/schema.org\/regionDrained-input",
+    "Name":"https://schema.org/regionDrained-input",
     "Domain Bucket":"< 1K"
   },
   {
     "Class":"Predicate",
-    "Name":"http:\/\/schema.org\/regionDrained-output",
+    "Name":"https://schema.org/regionDrained-output",
     "Domain Bucket":"< 1K"
   },
   {
     "Class":"Predicate",
-    "Name":"http:\/\/schema.org\/regionsAllowed",
+    "Name":"https://schema.org/regionsAllowed",
     "Domain Bucket":"10K - 100K"
   },
   {
     "Class":"Predicate",
-    "Name":"http:\/\/schema.org\/regionsAllowed-input",
+    "Name":"https://schema.org/regionsAllowed-input",
     "Domain Bucket":"< 1K"
   },
   {
     "Class":"Predicate",
-    "Name":"http:\/\/schema.org\/regionsAllowed-output",
+    "Name":"https://schema.org/regionsAllowed-output",
     "Domain Bucket":"< 1K"
   },
   {
     "Class":"Predicate",
-    "Name":"http:\/\/schema.org\/relatedAnatomy",
+    "Name":"https://schema.org/relatedAnatomy",
     "Domain Bucket":"< 1K"
   },
   {
     "Class":"Predicate",
-    "Name":"http:\/\/schema.org\/relatedAnatomy-input",
+    "Name":"https://schema.org/relatedAnatomy-input",
     "Domain Bucket":"< 1K"
   },
   {
     "Class":"Predicate",
-    "Name":"http:\/\/schema.org\/relatedAnatomy-output",
+    "Name":"https://schema.org/relatedAnatomy-output",
     "Domain Bucket":"< 1K"
   },
   {
     "Class":"Predicate",
-    "Name":"http:\/\/schema.org\/relatedCondition",
+    "Name":"https://schema.org/relatedCondition",
     "Domain Bucket":"< 1K"
   },
   {
     "Class":"Predicate",
-    "Name":"http:\/\/schema.org\/relatedCondition-input",
+    "Name":"https://schema.org/relatedCondition-input",
     "Domain Bucket":"< 1K"
   },
   {
     "Class":"Predicate",
-    "Name":"http:\/\/schema.org\/relatedCondition-output",
+    "Name":"https://schema.org/relatedCondition-output",
     "Domain Bucket":"< 1K"
   },
   {
     "Class":"Predicate",
-    "Name":"http:\/\/schema.org\/relatedDrug",
+    "Name":"https://schema.org/relatedDrug",
     "Domain Bucket":"< 1K"
   },
   {
     "Class":"Predicate",
-    "Name":"http:\/\/schema.org\/relatedDrug-input",
+    "Name":"https://schema.org/relatedDrug-input",
     "Domain Bucket":"< 1K"
   },
   {
     "Class":"Predicate",
-    "Name":"http:\/\/schema.org\/relatedDrug-output",
+    "Name":"https://schema.org/relatedDrug-output",
     "Domain Bucket":"< 1K"
   },
   {
     "Class":"Predicate",
-    "Name":"http:\/\/schema.org\/relatedLink",
+    "Name":"https://schema.org/relatedLink",
     "Domain Bucket":"10K - 100K"
   },
   {
     "Class":"Predicate",
-    "Name":"http:\/\/schema.org\/relatedLink-input",
+    "Name":"https://schema.org/relatedLink-input",
     "Domain Bucket":"< 1K"
   },
   {
     "Class":"Predicate",
-    "Name":"http:\/\/schema.org\/relatedLink-output",
+    "Name":"https://schema.org/relatedLink-output",
     "Domain Bucket":"< 1K"
   },
   {
     "Class":"Predicate",
-    "Name":"http:\/\/schema.org\/relatedStructure",
+    "Name":"https://schema.org/relatedStructure",
     "Domain Bucket":"< 1K"
   },
   {
     "Class":"Predicate",
-    "Name":"http:\/\/schema.org\/relatedStructure-input",
+    "Name":"https://schema.org/relatedStructure-input",
     "Domain Bucket":"< 1K"
   },
   {
     "Class":"Predicate",
-    "Name":"http:\/\/schema.org\/relatedStructure-output",
+    "Name":"https://schema.org/relatedStructure-output",
     "Domain Bucket":"< 1K"
   },
   {
     "Class":"Predicate",
-    "Name":"http:\/\/schema.org\/relatedTherapy",
+    "Name":"https://schema.org/relatedTherapy",
     "Domain Bucket":"< 1K"
   },
   {
     "Class":"Predicate",
-    "Name":"http:\/\/schema.org\/relatedTherapy-input",
+    "Name":"https://schema.org/relatedTherapy-input",
     "Domain Bucket":"< 1K"
   },
   {
     "Class":"Predicate",
-    "Name":"http:\/\/schema.org\/relatedTherapy-output",
+    "Name":"https://schema.org/relatedTherapy-output",
     "Domain Bucket":"< 1K"
   },
   {
     "Class":"Predicate",
-    "Name":"http:\/\/schema.org\/relatedTo",
+    "Name":"https://schema.org/relatedTo",
     "Domain Bucket":"< 1K"
   },
   {
     "Class":"Predicate",
-    "Name":"http:\/\/schema.org\/relatedTo-input",
+    "Name":"https://schema.org/relatedTo-input",
     "Domain Bucket":"< 1K"
   },
   {
     "Class":"Predicate",
-    "Name":"http:\/\/schema.org\/relatedTo-output",
+    "Name":"https://schema.org/relatedTo-output",
     "Domain Bucket":"< 1K"
   },
   {
     "Class":"Predicate",
-    "Name":"http:\/\/schema.org\/releaseDate",
+    "Name":"https://schema.org/releaseDate",
     "Domain Bucket":"10K - 100K"
   },
   {
     "Class":"Predicate",
-    "Name":"http:\/\/schema.org\/releaseDate-input",
+    "Name":"https://schema.org/releaseDate-input",
     "Domain Bucket":"< 1K"
   },
   {
     "Class":"Predicate",
-    "Name":"http:\/\/schema.org\/releaseDate-output",
+    "Name":"https://schema.org/releaseDate-output",
     "Domain Bucket":"< 1K"
   },
   {
     "Class":"Predicate",
-    "Name":"http:\/\/schema.org\/releaseNotes",
+    "Name":"https://schema.org/releaseNotes",
     "Domain Bucket":"10K - 100K"
   },
   {
     "Class":"Predicate",
-    "Name":"http:\/\/schema.org\/releaseNotes-input",
+    "Name":"https://schema.org/releaseNotes-input",
     "Domain Bucket":"< 1K"
   },
   {
     "Class":"Predicate",
-    "Name":"http:\/\/schema.org\/releaseNotes-output",
+    "Name":"https://schema.org/releaseNotes-output",
     "Domain Bucket":"< 1K"
   },
   {
     "Class":"Predicate",
-    "Name":"http:\/\/schema.org\/releaseOf",
+    "Name":"https://schema.org/releaseOf",
     "Domain Bucket":"< 1K"
   },
   {
     "Class":"Predicate",
-    "Name":"http:\/\/schema.org\/releaseOf-input",
+    "Name":"https://schema.org/releaseOf-input",
     "Domain Bucket":"< 1K"
   },
   {
     "Class":"Predicate",
-    "Name":"http:\/\/schema.org\/releaseOf-output",
+    "Name":"https://schema.org/releaseOf-output",
     "Domain Bucket":"< 1K"
   },
   {
     "Class":"Predicate",
-    "Name":"http:\/\/schema.org\/releasedEvent",
+    "Name":"https://schema.org/releasedEvent",
     "Domain Bucket":"1K - 10K"
   },
   {
     "Class":"Predicate",
-    "Name":"http:\/\/schema.org\/releasedEvent-input",
+    "Name":"https://schema.org/releasedEvent-input",
     "Domain Bucket":"< 1K"
   },
   {
     "Class":"Predicate",
-    "Name":"http:\/\/schema.org\/releasedEvent-output",
+    "Name":"https://schema.org/releasedEvent-output",
     "Domain Bucket":"< 1K"
   },
   {
     "Class":"Predicate",
-    "Name":"http:\/\/schema.org\/relevantOccupation",
+    "Name":"https://schema.org/relevantOccupation",
     "Domain Bucket":"< 1K"
   },
   {
     "Class":"Predicate",
-    "Name":"http:\/\/schema.org\/relevantOccupation-input",
+    "Name":"https://schema.org/relevantOccupation-input",
     "Domain Bucket":"< 1K"
   },
   {
     "Class":"Predicate",
-    "Name":"http:\/\/schema.org\/relevantOccupation-output",
+    "Name":"https://schema.org/relevantOccupation-output",
     "Domain Bucket":"< 1K"
   },
   {
     "Class":"Predicate",
-    "Name":"http:\/\/schema.org\/relevantSpecialty",
+    "Name":"https://schema.org/relevantSpecialty",
     "Domain Bucket":"1K - 10K"
   },
   {
     "Class":"Predicate",
-    "Name":"http:\/\/schema.org\/relevantSpecialty-input",
+    "Name":"https://schema.org/relevantSpecialty-input",
     "Domain Bucket":"< 1K"
   },
   {
     "Class":"Predicate",
-    "Name":"http:\/\/schema.org\/relevantSpecialty-output",
+    "Name":"https://schema.org/relevantSpecialty-output",
     "Domain Bucket":"< 1K"
   },
   {
     "Class":"Predicate",
-    "Name":"http:\/\/schema.org\/remainingAttendeeCapacity",
+    "Name":"https://schema.org/remainingAttendeeCapacity",
     "Domain Bucket":"1K - 10K"
   },
   {
     "Class":"Predicate",
-    "Name":"http:\/\/schema.org\/remainingAttendeeCapacity-input",
+    "Name":"https://schema.org/remainingAttendeeCapacity-input",
     "Domain Bucket":"< 1K"
   },
   {
     "Class":"Predicate",
-    "Name":"http:\/\/schema.org\/remainingAttendeeCapacity-output",
+    "Name":"https://schema.org/remainingAttendeeCapacity-output",
     "Domain Bucket":"< 1K"
   },
   {
     "Class":"Predicate",
-    "Name":"http:\/\/schema.org\/renegotiableLoan",
+    "Name":"https://schema.org/renegotiableLoan",
     "Domain Bucket":"< 1K"
   },
   {
     "Class":"Predicate",
-    "Name":"http:\/\/schema.org\/renegotiableLoan-input",
+    "Name":"https://schema.org/renegotiableLoan-input",
     "Domain Bucket":"< 1K"
   },
   {
     "Class":"Predicate",
-    "Name":"http:\/\/schema.org\/renegotiableLoan-output",
+    "Name":"https://schema.org/renegotiableLoan-output",
     "Domain Bucket":"< 1K"
   },
   {
     "Class":"Predicate",
-    "Name":"http:\/\/schema.org\/repeatCount",
+    "Name":"https://schema.org/repeatCount",
     "Domain Bucket":"1K - 10K"
   },
   {
     "Class":"Predicate",
-    "Name":"http:\/\/schema.org\/repeatCount-input",
+    "Name":"https://schema.org/repeatCount-input",
     "Domain Bucket":"< 1K"
   },
   {
     "Class":"Predicate",
-    "Name":"http:\/\/schema.org\/repeatCount-output",
+    "Name":"https://schema.org/repeatCount-output",
     "Domain Bucket":"< 1K"
   },
   {
     "Class":"Predicate",
-    "Name":"http:\/\/schema.org\/repeatFrequency",
+    "Name":"https://schema.org/repeatFrequency",
     "Domain Bucket":"10K - 100K"
   },
   {
     "Class":"Predicate",
-    "Name":"http:\/\/schema.org\/repeatFrequency-input",
+    "Name":"https://schema.org/repeatFrequency-input",
     "Domain Bucket":"< 1K"
   },
   {
     "Class":"Predicate",
-    "Name":"http:\/\/schema.org\/repeatFrequency-output",
+    "Name":"https://schema.org/repeatFrequency-output",
     "Domain Bucket":"< 1K"
   },
   {
     "Class":"Predicate",
-    "Name":"http:\/\/schema.org\/repetitions",
+    "Name":"https://schema.org/repetitions",
     "Domain Bucket":"< 1K"
   },
   {
     "Class":"Predicate",
-    "Name":"http:\/\/schema.org\/repetitions-input",
+    "Name":"https://schema.org/repetitions-input",
     "Domain Bucket":"< 1K"
   },
   {
     "Class":"Predicate",
-    "Name":"http:\/\/schema.org\/repetitions-output",
+    "Name":"https://schema.org/repetitions-output",
     "Domain Bucket":"< 1K"
   },
   {
     "Class":"Predicate",
-    "Name":"http:\/\/schema.org\/replacee",
+    "Name":"https://schema.org/replacee",
     "Domain Bucket":"< 1K"
   },
   {
     "Class":"Predicate",
-    "Name":"http:\/\/schema.org\/replacee-input",
+    "Name":"https://schema.org/replacee-input",
     "Domain Bucket":"< 1K"
   },
   {
     "Class":"Predicate",
-    "Name":"http:\/\/schema.org\/replacee-output",
+    "Name":"https://schema.org/replacee-output",
     "Domain Bucket":"< 1K"
   },
   {
     "Class":"Predicate",
-    "Name":"http:\/\/schema.org\/replacer",
+    "Name":"https://schema.org/replacer",
     "Domain Bucket":"< 1K"
   },
   {
     "Class":"Predicate",
-    "Name":"http:\/\/schema.org\/replacer-input",
+    "Name":"https://schema.org/replacer-input",
     "Domain Bucket":"< 1K"
   },
   {
     "Class":"Predicate",
-    "Name":"http:\/\/schema.org\/replacer-output",
+    "Name":"https://schema.org/replacer-output",
     "Domain Bucket":"< 1K"
   },
   {
     "Class":"Predicate",
-    "Name":"http:\/\/schema.org\/replyToUrl",
+    "Name":"https://schema.org/replyToUrl",
     "Domain Bucket":"1K - 10K"
   },
   {
     "Class":"Predicate",
-    "Name":"http:\/\/schema.org\/replyToUrl-input",
+    "Name":"https://schema.org/replyToUrl-input",
     "Domain Bucket":"< 1K"
   },
   {
     "Class":"Predicate",
-    "Name":"http:\/\/schema.org\/replyToUrl-output",
+    "Name":"https://schema.org/replyToUrl-output",
     "Domain Bucket":"< 1K"
   },
   {
     "Class":"Predicate",
-    "Name":"http:\/\/schema.org\/reportNumber",
+    "Name":"https://schema.org/reportNumber",
     "Domain Bucket":"< 1K"
   },
   {
     "Class":"Predicate",
-    "Name":"http:\/\/schema.org\/reportNumber-input",
+    "Name":"https://schema.org/reportNumber-input",
     "Domain Bucket":"< 1K"
   },
   {
     "Class":"Predicate",
-    "Name":"http:\/\/schema.org\/reportNumber-output",
+    "Name":"https://schema.org/reportNumber-output",
     "Domain Bucket":"< 1K"
   },
   {
     "Class":"Predicate",
-    "Name":"http:\/\/schema.org\/representativeOfPage",
+    "Name":"https://schema.org/representativeOfPage",
     "Domain Bucket":"100K - 1M"
   },
   {
     "Class":"Predicate",
-    "Name":"http:\/\/schema.org\/representativeOfPage-input",
+    "Name":"https://schema.org/representativeOfPage-input",
     "Domain Bucket":"< 1K"
   },
   {
     "Class":"Predicate",
-    "Name":"http:\/\/schema.org\/representativeOfPage-output",
+    "Name":"https://schema.org/representativeOfPage-output",
     "Domain Bucket":"< 1K"
   },
   {
     "Class":"Predicate",
-    "Name":"http:\/\/schema.org\/requiredCollateral",
+    "Name":"https://schema.org/requiredCollateral",
     "Domain Bucket":"< 1K"
   },
   {
     "Class":"Predicate",
-    "Name":"http:\/\/schema.org\/requiredCollateral-input",
+    "Name":"https://schema.org/requiredCollateral-input",
     "Domain Bucket":"< 1K"
   },
   {
     "Class":"Predicate",
-    "Name":"http:\/\/schema.org\/requiredCollateral-output",
+    "Name":"https://schema.org/requiredCollateral-output",
     "Domain Bucket":"< 1K"
   },
   {
     "Class":"Predicate",
-    "Name":"http:\/\/schema.org\/requiredGender",
+    "Name":"https://schema.org/requiredGender",
     "Domain Bucket":"< 1K"
   },
   {
     "Class":"Predicate",
-    "Name":"http:\/\/schema.org\/requiredGender-input",
+    "Name":"https://schema.org/requiredGender-input",
     "Domain Bucket":"< 1K"
   },
   {
     "Class":"Predicate",
-    "Name":"http:\/\/schema.org\/requiredGender-output",
+    "Name":"https://schema.org/requiredGender-output",
     "Domain Bucket":"< 1K"
   },
   {
     "Class":"Predicate",
-    "Name":"http:\/\/schema.org\/requiredMaxAge",
+    "Name":"https://schema.org/requiredMaxAge",
     "Domain Bucket":"< 1K"
   },
   {
     "Class":"Predicate",
-    "Name":"http:\/\/schema.org\/requiredMaxAge-input",
+    "Name":"https://schema.org/requiredMaxAge-input",
     "Domain Bucket":"< 1K"
   },
   {
     "Class":"Predicate",
-    "Name":"http:\/\/schema.org\/requiredMaxAge-output",
+    "Name":"https://schema.org/requiredMaxAge-output",
     "Domain Bucket":"< 1K"
   },
   {
     "Class":"Predicate",
-    "Name":"http:\/\/schema.org\/requiredMinAge",
+    "Name":"https://schema.org/requiredMinAge",
     "Domain Bucket":"1K - 10K"
   },
   {
     "Class":"Predicate",
-    "Name":"http:\/\/schema.org\/requiredMinAge-input",
+    "Name":"https://schema.org/requiredMinAge-input",
     "Domain Bucket":"< 1K"
   },
   {
     "Class":"Predicate",
-    "Name":"http:\/\/schema.org\/requiredMinAge-output",
+    "Name":"https://schema.org/requiredMinAge-output",
     "Domain Bucket":"< 1K"
   },
   {
     "Class":"Predicate",
-    "Name":"http:\/\/schema.org\/requiredQuantity",
+    "Name":"https://schema.org/requiredQuantity",
     "Domain Bucket":"1K - 10K"
   },
   {
     "Class":"Predicate",
-    "Name":"http:\/\/schema.org\/requiredQuantity-input",
+    "Name":"https://schema.org/requiredQuantity-input",
     "Domain Bucket":"< 1K"
   },
   {
     "Class":"Predicate",
-    "Name":"http:\/\/schema.org\/requiredQuantity-output",
+    "Name":"https://schema.org/requiredQuantity-output",
     "Domain Bucket":"< 1K"
   },
   {
     "Class":"Predicate",
-    "Name":"http:\/\/schema.org\/requirements",
+    "Name":"https://schema.org/requirements",
     "Domain Bucket":"1K - 10K"
   },
   {
     "Class":"Predicate",
-    "Name":"http:\/\/schema.org\/requirements-input",
+    "Name":"https://schema.org/requirements-input",
     "Domain Bucket":"< 1K"
   },
   {
     "Class":"Predicate",
-    "Name":"http:\/\/schema.org\/requirements-output",
+    "Name":"https://schema.org/requirements-output",
     "Domain Bucket":"< 1K"
   },
   {
     "Class":"Predicate",
-    "Name":"http:\/\/schema.org\/requiresSubscription",
+    "Name":"https://schema.org/requiresSubscription",
     "Domain Bucket":"1K - 10K"
   },
   {
     "Class":"Predicate",
-    "Name":"http:\/\/schema.org\/requiresSubscription-input",
+    "Name":"https://schema.org/requiresSubscription-input",
     "Domain Bucket":"< 1K"
   },
   {
     "Class":"Predicate",
-    "Name":"http:\/\/schema.org\/requiresSubscription-output",
+    "Name":"https://schema.org/requiresSubscription-output",
     "Domain Bucket":"< 1K"
   },
   {
     "Class":"Predicate",
-    "Name":"http:\/\/schema.org\/reservationFor",
+    "Name":"https://schema.org/reservationFor",
     "Domain Bucket":"1K - 10K"
   },
   {
     "Class":"Predicate",
-    "Name":"http:\/\/schema.org\/reservationFor-input",
+    "Name":"https://schema.org/reservationFor-input",
     "Domain Bucket":"< 1K"
   },
   {
     "Class":"Predicate",
-    "Name":"http:\/\/schema.org\/reservationFor-output",
+    "Name":"https://schema.org/reservationFor-output",
     "Domain Bucket":"< 1K"
   },
   {
     "Class":"Predicate",
-    "Name":"http:\/\/schema.org\/reservationId",
+    "Name":"https://schema.org/reservationId",
     "Domain Bucket":"< 1K"
   },
   {
     "Class":"Predicate",
-    "Name":"http:\/\/schema.org\/reservationId-input",
+    "Name":"https://schema.org/reservationId-input",
     "Domain Bucket":"< 1K"
   },
   {
     "Class":"Predicate",
-    "Name":"http:\/\/schema.org\/reservationId-output",
+    "Name":"https://schema.org/reservationId-output",
     "Domain Bucket":"< 1K"
   },
   {
     "Class":"Predicate",
-    "Name":"http:\/\/schema.org\/reservationStatus",
+    "Name":"https://schema.org/reservationStatus",
     "Domain Bucket":"< 1K"
   },
   {
     "Class":"Predicate",
-    "Name":"http:\/\/schema.org\/reservationStatus-input",
+    "Name":"https://schema.org/reservationStatus-input",
     "Domain Bucket":"< 1K"
   },
   {
     "Class":"Predicate",
-    "Name":"http:\/\/schema.org\/reservationStatus-output",
+    "Name":"https://schema.org/reservationStatus-output",
     "Domain Bucket":"< 1K"
   },
   {
     "Class":"Predicate",
-    "Name":"http:\/\/schema.org\/reservedTicket",
+    "Name":"https://schema.org/reservedTicket",
     "Domain Bucket":"< 1K"
   },
   {
     "Class":"Predicate",
-    "Name":"http:\/\/schema.org\/reservedTicket-input",
+    "Name":"https://schema.org/reservedTicket-input",
     "Domain Bucket":"< 1K"
   },
   {
     "Class":"Predicate",
-    "Name":"http:\/\/schema.org\/reservedTicket-output",
+    "Name":"https://schema.org/reservedTicket-output",
     "Domain Bucket":"< 1K"
   },
   {
     "Class":"Predicate",
-    "Name":"http:\/\/schema.org\/responsibilities",
+    "Name":"https://schema.org/responsibilities",
     "Domain Bucket":"10K - 100K"
   },
   {
     "Class":"Predicate",
-    "Name":"http:\/\/schema.org\/responsibilities-input",
+    "Name":"https://schema.org/responsibilities-input",
     "Domain Bucket":"< 1K"
   },
   {
     "Class":"Predicate",
-    "Name":"http:\/\/schema.org\/responsibilities-output",
+    "Name":"https://schema.org/responsibilities-output",
     "Domain Bucket":"< 1K"
   },
   {
     "Class":"Predicate",
-    "Name":"http:\/\/schema.org\/restPeriods",
+    "Name":"https://schema.org/restPeriods",
     "Domain Bucket":"< 1K"
   },
   {
     "Class":"Predicate",
-    "Name":"http:\/\/schema.org\/restPeriods-input",
+    "Name":"https://schema.org/restPeriods-input",
     "Domain Bucket":"< 1K"
   },
   {
     "Class":"Predicate",
-    "Name":"http:\/\/schema.org\/restPeriods-output",
+    "Name":"https://schema.org/restPeriods-output",
     "Domain Bucket":"< 1K"
   },
   {
     "Class":"Predicate",
-    "Name":"http:\/\/schema.org\/restockingFee",
+    "Name":"https://schema.org/restockingFee",
     "Domain Bucket":"1K - 10K"
   },
   {
     "Class":"Predicate",
-    "Name":"http:\/\/schema.org\/restockingFee-input",
+    "Name":"https://schema.org/restockingFee-input",
     "Domain Bucket":"< 1K"
   },
   {
     "Class":"Predicate",
-    "Name":"http:\/\/schema.org\/restockingFee-output",
+    "Name":"https://schema.org/restockingFee-output",
     "Domain Bucket":"< 1K"
   },
   {
     "Class":"Predicate",
-    "Name":"http:\/\/schema.org\/result",
+    "Name":"https://schema.org/result",
     "Domain Bucket":"10K - 100K"
   },
   {
     "Class":"Predicate",
-    "Name":"http:\/\/schema.org\/result-input",
+    "Name":"https://schema.org/result-input",
     "Domain Bucket":"< 1K"
   },
   {
     "Class":"Predicate",
-    "Name":"http:\/\/schema.org\/result-output",
+    "Name":"https://schema.org/result-output",
     "Domain Bucket":"< 1K"
   },
   {
     "Class":"Predicate",
-    "Name":"http:\/\/schema.org\/resultComment",
+    "Name":"https://schema.org/resultComment",
     "Domain Bucket":"< 1K"
   },
   {
     "Class":"Predicate",
-    "Name":"http:\/\/schema.org\/resultComment-input",
+    "Name":"https://schema.org/resultComment-input",
     "Domain Bucket":"< 1K"
   },
   {
     "Class":"Predicate",
-    "Name":"http:\/\/schema.org\/resultComment-output",
+    "Name":"https://schema.org/resultComment-output",
     "Domain Bucket":"< 1K"
   },
   {
     "Class":"Predicate",
-    "Name":"http:\/\/schema.org\/resultReview",
+    "Name":"https://schema.org/resultReview",
     "Domain Bucket":"< 1K"
   },
   {
     "Class":"Predicate",
-    "Name":"http:\/\/schema.org\/resultReview-input",
+    "Name":"https://schema.org/resultReview-input",
     "Domain Bucket":"< 1K"
   },
   {
     "Class":"Predicate",
-    "Name":"http:\/\/schema.org\/resultReview-output",
+    "Name":"https://schema.org/resultReview-output",
     "Domain Bucket":"< 1K"
   },
   {
     "Class":"Predicate",
-    "Name":"http:\/\/schema.org\/returnFees",
+    "Name":"https://schema.org/returnFees",
     "Domain Bucket":"100K - 1M"
   },
   {
     "Class":"Predicate",
-    "Name":"http:\/\/schema.org\/returnFees-input",
+    "Name":"https://schema.org/returnFees-input",
     "Domain Bucket":"< 1K"
   },
   {
     "Class":"Predicate",
-    "Name":"http:\/\/schema.org\/returnFees-output",
+    "Name":"https://schema.org/returnFees-output",
     "Domain Bucket":"< 1K"
   },
   {
     "Class":"Predicate",
-    "Name":"http:\/\/schema.org\/returnLabelSource",
+    "Name":"https://schema.org/returnLabelSource",
     "Domain Bucket":"1K - 10K"
   },
   {
     "Class":"Predicate",
-    "Name":"http:\/\/schema.org\/returnLabelSource-input",
+    "Name":"https://schema.org/returnLabelSource-input",
     "Domain Bucket":"< 1K"
   },
   {
     "Class":"Predicate",
-    "Name":"http:\/\/schema.org\/returnLabelSource-output",
+    "Name":"https://schema.org/returnLabelSource-output",
     "Domain Bucket":"< 1K"
   },
   {
     "Class":"Predicate",
-    "Name":"http:\/\/schema.org\/returnMethod",
+    "Name":"https://schema.org/returnMethod",
     "Domain Bucket":"100K - 1M"
   },
   {
     "Class":"Predicate",
-    "Name":"http:\/\/schema.org\/returnMethod-input",
+    "Name":"https://schema.org/returnMethod-input",
     "Domain Bucket":"< 1K"
   },
   {
     "Class":"Predicate",
-    "Name":"http:\/\/schema.org\/returnMethod-output",
+    "Name":"https://schema.org/returnMethod-output",
     "Domain Bucket":"< 1K"
   },
   {
     "Class":"Predicate",
-    "Name":"http:\/\/schema.org\/returnPolicyCategory",
+    "Name":"https://schema.org/returnPolicyCategory",
     "Domain Bucket":"100K - 1M"
   },
   {
     "Class":"Predicate",
-    "Name":"http:\/\/schema.org\/returnPolicyCategory-input",
+    "Name":"https://schema.org/returnPolicyCategory-input",
     "Domain Bucket":"< 1K"
   },
   {
     "Class":"Predicate",
-    "Name":"http:\/\/schema.org\/returnPolicyCategory-output",
+    "Name":"https://schema.org/returnPolicyCategory-output",
     "Domain Bucket":"< 1K"
   },
   {
     "Class":"Predicate",
-    "Name":"http:\/\/schema.org\/returnPolicyCountry",
+    "Name":"https://schema.org/returnPolicyCountry",
     "Domain Bucket":"10K - 100K"
   },
   {
     "Class":"Predicate",
-    "Name":"http:\/\/schema.org\/returnPolicyCountry-input",
+    "Name":"https://schema.org/returnPolicyCountry-input",
     "Domain Bucket":"< 1K"
   },
   {
     "Class":"Predicate",
-    "Name":"http:\/\/schema.org\/returnPolicyCountry-output",
+    "Name":"https://schema.org/returnPolicyCountry-output",
     "Domain Bucket":"< 1K"
   },
   {
     "Class":"Predicate",
-    "Name":"http:\/\/schema.org\/returnPolicySeasonalOverride",
+    "Name":"https://schema.org/returnPolicySeasonalOverride",
     "Domain Bucket":"1K - 10K"
   },
   {
     "Class":"Predicate",
-    "Name":"http:\/\/schema.org\/returnPolicySeasonalOverride-input",
+    "Name":"https://schema.org/returnPolicySeasonalOverride-input",
     "Domain Bucket":"< 1K"
   },
   {
     "Class":"Predicate",
-    "Name":"http:\/\/schema.org\/returnPolicySeasonalOverride-output",
+    "Name":"https://schema.org/returnPolicySeasonalOverride-output",
     "Domain Bucket":"< 1K"
   },
   {
     "Class":"Predicate",
-    "Name":"http:\/\/schema.org\/returnShippingFeesAmount",
+    "Name":"https://schema.org/returnShippingFeesAmount",
     "Domain Bucket":"10K - 100K"
   },
   {
     "Class":"Predicate",
-    "Name":"http:\/\/schema.org\/returnShippingFeesAmount-input",
+    "Name":"https://schema.org/returnShippingFeesAmount-input",
     "Domain Bucket":"< 1K"
   },
   {
     "Class":"Predicate",
-    "Name":"http:\/\/schema.org\/returnShippingFeesAmount-output",
+    "Name":"https://schema.org/returnShippingFeesAmount-output",
     "Domain Bucket":"< 1K"
   },
   {
     "Class":"Predicate",
-    "Name":"http:\/\/schema.org\/review",
+    "Name":"https://schema.org/review",
     "Domain Bucket":"1M - 10M"
   },
   {
     "Class":"Predicate",
-    "Name":"http:\/\/schema.org\/review-input",
+    "Name":"https://schema.org/review-input",
     "Domain Bucket":"< 1K"
   },
   {
     "Class":"Predicate",
-    "Name":"http:\/\/schema.org\/review-output",
+    "Name":"https://schema.org/review-output",
     "Domain Bucket":"< 1K"
   },
   {
     "Class":"Predicate",
-    "Name":"http:\/\/schema.org\/reviewAspect",
+    "Name":"https://schema.org/reviewAspect",
     "Domain Bucket":"10K - 100K"
   },
   {
     "Class":"Predicate",
-    "Name":"http:\/\/schema.org\/reviewAspect-input",
+    "Name":"https://schema.org/reviewAspect-input",
     "Domain Bucket":"< 1K"
   },
   {
     "Class":"Predicate",
-    "Name":"http:\/\/schema.org\/reviewAspect-output",
+    "Name":"https://schema.org/reviewAspect-output",
     "Domain Bucket":"< 1K"
   },
   {
     "Class":"Predicate",
-    "Name":"http:\/\/schema.org\/reviewBody",
+    "Name":"https://schema.org/reviewBody",
     "Domain Bucket":"1M - 10M"
   },
   {
     "Class":"Predicate",
-    "Name":"http:\/\/schema.org\/reviewBody-input",
+    "Name":"https://schema.org/reviewBody-input",
     "Domain Bucket":"< 1K"
   },
   {
     "Class":"Predicate",
-    "Name":"http:\/\/schema.org\/reviewBody-output",
+    "Name":"https://schema.org/reviewBody-output",
     "Domain Bucket":"< 1K"
   },
   {
     "Class":"Predicate",
-    "Name":"http:\/\/schema.org\/reviewCount",
+    "Name":"https://schema.org/reviewCount",
     "Domain Bucket":"1M - 10M"
   },
   {
     "Class":"Predicate",
-    "Name":"http:\/\/schema.org\/reviewCount-input",
+    "Name":"https://schema.org/reviewCount-input",
     "Domain Bucket":"< 1K"
   },
   {
     "Class":"Predicate",
-    "Name":"http:\/\/schema.org\/reviewCount-output",
+    "Name":"https://schema.org/reviewCount-output",
     "Domain Bucket":"< 1K"
   },
   {
     "Class":"Predicate",
-    "Name":"http:\/\/schema.org\/reviewRating",
+    "Name":"https://schema.org/reviewRating",
     "Domain Bucket":"1M - 10M"
   },
   {
     "Class":"Predicate",
-    "Name":"http:\/\/schema.org\/reviewRating-input",
+    "Name":"https://schema.org/reviewRating-input",
     "Domain Bucket":"< 1K"
   },
   {
     "Class":"Predicate",
-    "Name":"http:\/\/schema.org\/reviewRating-output",
+    "Name":"https://schema.org/reviewRating-output",
     "Domain Bucket":"< 1K"
   },
   {
     "Class":"Predicate",
-    "Name":"http:\/\/schema.org\/reviewedBy",
+    "Name":"https://schema.org/reviewedBy",
     "Domain Bucket":"10K - 100K"
   },
   {
     "Class":"Predicate",
-    "Name":"http:\/\/schema.org\/reviewedBy-input",
+    "Name":"https://schema.org/reviewedBy-input",
     "Domain Bucket":"< 1K"
   },
   {
     "Class":"Predicate",
-    "Name":"http:\/\/schema.org\/reviewedBy-output",
+    "Name":"https://schema.org/reviewedBy-output",
     "Domain Bucket":"< 1K"
   },
   {
     "Class":"Predicate",
-    "Name":"http:\/\/schema.org\/reviews",
+    "Name":"https://schema.org/reviews",
     "Domain Bucket":"1K - 10K"
   },
   {
     "Class":"Predicate",
-    "Name":"http:\/\/schema.org\/reviews-input",
+    "Name":"https://schema.org/reviews-input",
     "Domain Bucket":"< 1K"
   },
   {
     "Class":"Predicate",
-    "Name":"http:\/\/schema.org\/reviews-output",
+    "Name":"https://schema.org/reviews-output",
     "Domain Bucket":"< 1K"
   },
   {
     "Class":"Predicate",
-    "Name":"http:\/\/schema.org\/riskFactor",
+    "Name":"https://schema.org/riskFactor",
     "Domain Bucket":"1K - 10K"
   },
   {
     "Class":"Predicate",
-    "Name":"http:\/\/schema.org\/riskFactor-input",
+    "Name":"https://schema.org/riskFactor-input",
     "Domain Bucket":"< 1K"
   },
   {
     "Class":"Predicate",
-    "Name":"http:\/\/schema.org\/riskFactor-output",
+    "Name":"https://schema.org/riskFactor-output",
     "Domain Bucket":"< 1K"
   },
   {
     "Class":"Predicate",
-    "Name":"http:\/\/schema.org\/risks",
+    "Name":"https://schema.org/risks",
     "Domain Bucket":"< 1K"
   },
   {
     "Class":"Predicate",
-    "Name":"http:\/\/schema.org\/risks-input",
+    "Name":"https://schema.org/risks-input",
     "Domain Bucket":"< 1K"
   },
   {
     "Class":"Predicate",
-    "Name":"http:\/\/schema.org\/risks-output",
+    "Name":"https://schema.org/risks-output",
     "Domain Bucket":"< 1K"
   },
   {
     "Class":"Predicate",
-    "Name":"http:\/\/schema.org\/roleName",
+    "Name":"https://schema.org/roleName",
     "Domain Bucket":"1K - 10K"
   },
   {
     "Class":"Predicate",
-    "Name":"http:\/\/schema.org\/roleName-input",
+    "Name":"https://schema.org/roleName-input",
     "Domain Bucket":"< 1K"
   },
   {
     "Class":"Predicate",
-    "Name":"http:\/\/schema.org\/roleName-output",
+    "Name":"https://schema.org/roleName-output",
     "Domain Bucket":"< 1K"
   },
   {
     "Class":"Predicate",
-    "Name":"http:\/\/schema.org\/roofLoad",
+    "Name":"https://schema.org/roofLoad",
     "Domain Bucket":"< 1K"
   },
   {
     "Class":"Predicate",
-    "Name":"http:\/\/schema.org\/roofLoad-input",
+    "Name":"https://schema.org/roofLoad-input",
     "Domain Bucket":"< 1K"
   },
   {
     "Class":"Predicate",
-    "Name":"http:\/\/schema.org\/roofLoad-output",
+    "Name":"https://schema.org/roofLoad-output",
     "Domain Bucket":"< 1K"
   },
   {
     "Class":"Predicate",
-    "Name":"http:\/\/schema.org\/rsvpResponse",
+    "Name":"https://schema.org/rsvpResponse",
     "Domain Bucket":"< 1K"
   },
   {
     "Class":"Predicate",
-    "Name":"http:\/\/schema.org\/rsvpResponse-input",
+    "Name":"https://schema.org/rsvpResponse-input",
     "Domain Bucket":"< 1K"
   },
   {
     "Class":"Predicate",
-    "Name":"http:\/\/schema.org\/rsvpResponse-output",
+    "Name":"https://schema.org/rsvpResponse-output",
     "Domain Bucket":"< 1K"
   },
   {
     "Class":"Predicate",
-    "Name":"http:\/\/schema.org\/runsTo",
+    "Name":"https://schema.org/runsTo",
     "Domain Bucket":"< 1K"
   },
   {
     "Class":"Predicate",
-    "Name":"http:\/\/schema.org\/runsTo-input",
+    "Name":"https://schema.org/runsTo-input",
     "Domain Bucket":"< 1K"
   },
   {
     "Class":"Predicate",
-    "Name":"http:\/\/schema.org\/runsTo-output",
+    "Name":"https://schema.org/runsTo-output",
     "Domain Bucket":"< 1K"
   },
   {
     "Class":"Predicate",
-    "Name":"http:\/\/schema.org\/runtime",
+    "Name":"https://schema.org/runtime",
     "Domain Bucket":"< 1K"
   },
   {
     "Class":"Predicate",
-    "Name":"http:\/\/schema.org\/runtime-input",
+    "Name":"https://schema.org/runtime-input",
     "Domain Bucket":"< 1K"
   },
   {
     "Class":"Predicate",
-    "Name":"http:\/\/schema.org\/runtime-output",
+    "Name":"https://schema.org/runtime-output",
     "Domain Bucket":"< 1K"
   },
   {
     "Class":"Predicate",
-    "Name":"http:\/\/schema.org\/runtimePlatform",
+    "Name":"https://schema.org/runtimePlatform",
     "Domain Bucket":"1K - 10K"
   },
   {
     "Class":"Predicate",
-    "Name":"http:\/\/schema.org\/runtimePlatform-input",
+    "Name":"https://schema.org/runtimePlatform-input",
     "Domain Bucket":"< 1K"
   },
   {
     "Class":"Predicate",
-    "Name":"http:\/\/schema.org\/runtimePlatform-output",
+    "Name":"https://schema.org/runtimePlatform-output",
     "Domain Bucket":"< 1K"
   },
   {
     "Class":"Predicate",
-    "Name":"http:\/\/schema.org\/rxcui",
+    "Name":"https://schema.org/rxcui",
     "Domain Bucket":"< 1K"
   },
   {
     "Class":"Predicate",
-    "Name":"http:\/\/schema.org\/rxcui-input",
+    "Name":"https://schema.org/rxcui-input",
     "Domain Bucket":"< 1K"
   },
   {
     "Class":"Predicate",
-    "Name":"http:\/\/schema.org\/rxcui-output",
+    "Name":"https://schema.org/rxcui-output",
     "Domain Bucket":"< 1K"
   },
   {
     "Class":"Predicate",
-    "Name":"http:\/\/schema.org\/safetyConsideration",
+    "Name":"https://schema.org/safetyConsideration",
     "Domain Bucket":"< 1K"
   },
   {
     "Class":"Predicate",
-    "Name":"http:\/\/schema.org\/safetyConsideration-input",
+    "Name":"https://schema.org/safetyConsideration-input",
     "Domain Bucket":"< 1K"
   },
   {
     "Class":"Predicate",
-    "Name":"http:\/\/schema.org\/safetyConsideration-output",
+    "Name":"https://schema.org/safetyConsideration-output",
     "Domain Bucket":"< 1K"
   },
   {
     "Class":"Predicate",
-    "Name":"http:\/\/schema.org\/salaryCurrency",
+    "Name":"https://schema.org/salaryCurrency",
     "Domain Bucket":"1K - 10K"
   },
   {
     "Class":"Predicate",
-    "Name":"http:\/\/schema.org\/salaryCurrency-input",
+    "Name":"https://schema.org/salaryCurrency-input",
     "Domain Bucket":"< 1K"
   },
   {
     "Class":"Predicate",
-    "Name":"http:\/\/schema.org\/salaryCurrency-output",
+    "Name":"https://schema.org/salaryCurrency-output",
     "Domain Bucket":"< 1K"
   },
   {
     "Class":"Predicate",
-    "Name":"http:\/\/schema.org\/salaryUponCompletion",
+    "Name":"https://schema.org/salaryUponCompletion",
     "Domain Bucket":"< 1K"
   },
   {
     "Class":"Predicate",
-    "Name":"http:\/\/schema.org\/salaryUponCompletion-input",
+    "Name":"https://schema.org/salaryUponCompletion-input",
     "Domain Bucket":"< 1K"
   },
   {
     "Class":"Predicate",
-    "Name":"http:\/\/schema.org\/salaryUponCompletion-output",
+    "Name":"https://schema.org/salaryUponCompletion-output",
     "Domain Bucket":"< 1K"
   },
   {
     "Class":"Predicate",
-    "Name":"http:\/\/schema.org\/sameAs",
+    "Name":"https://schema.org/sameAs",
     "Domain Bucket":"10M+"
   },
   {
     "Class":"Predicate",
-    "Name":"http:\/\/schema.org\/sameAs-input",
+    "Name":"https://schema.org/sameAs-input",
     "Domain Bucket":"< 1K"
   },
   {
     "Class":"Predicate",
-    "Name":"http:\/\/schema.org\/sameAs-output",
+    "Name":"https://schema.org/sameAs-output",
     "Domain Bucket":"< 1K"
   },
   {
     "Class":"Predicate",
-    "Name":"http:\/\/schema.org\/sampleType",
+    "Name":"https://schema.org/sampleType",
     "Domain Bucket":"< 1K"
   },
   {
     "Class":"Predicate",
-    "Name":"http:\/\/schema.org\/sampleType-input",
+    "Name":"https://schema.org/sampleType-input",
     "Domain Bucket":"< 1K"
   },
   {
     "Class":"Predicate",
-    "Name":"http:\/\/schema.org\/sampleType-output",
+    "Name":"https://schema.org/sampleType-output",
     "Domain Bucket":"< 1K"
   },
   {
     "Class":"Predicate",
-    "Name":"http:\/\/schema.org\/saturatedFatContent",
+    "Name":"https://schema.org/saturatedFatContent",
     "Domain Bucket":"10K - 100K"
   },
   {
     "Class":"Predicate",
-    "Name":"http:\/\/schema.org\/saturatedFatContent-input",
+    "Name":"https://schema.org/saturatedFatContent-input",
     "Domain Bucket":"< 1K"
   },
   {
     "Class":"Predicate",
-    "Name":"http:\/\/schema.org\/saturatedFatContent-output",
+    "Name":"https://schema.org/saturatedFatContent-output",
     "Domain Bucket":"< 1K"
   },
   {
     "Class":"Predicate",
-    "Name":"http:\/\/schema.org\/scheduleTimezone",
+    "Name":"https://schema.org/scheduleTimezone",
     "Domain Bucket":"1K - 10K"
   },
   {
     "Class":"Predicate",
-    "Name":"http:\/\/schema.org\/scheduleTimezone-input",
+    "Name":"https://schema.org/scheduleTimezone-input",
     "Domain Bucket":"< 1K"
   },
   {
     "Class":"Predicate",
-    "Name":"http:\/\/schema.org\/scheduleTimezone-output",
+    "Name":"https://schema.org/scheduleTimezone-output",
     "Domain Bucket":"< 1K"
   },
   {
     "Class":"Predicate",
-    "Name":"http:\/\/schema.org\/scheduledPaymentDate",
+    "Name":"https://schema.org/scheduledPaymentDate",
     "Domain Bucket":"< 1K"
   },
   {
     "Class":"Predicate",
-    "Name":"http:\/\/schema.org\/scheduledPaymentDate-input",
+    "Name":"https://schema.org/scheduledPaymentDate-input",
     "Domain Bucket":"< 1K"
   },
   {
     "Class":"Predicate",
-    "Name":"http:\/\/schema.org\/scheduledPaymentDate-output",
+    "Name":"https://schema.org/scheduledPaymentDate-output",
     "Domain Bucket":"< 1K"
   },
   {
     "Class":"Predicate",
-    "Name":"http:\/\/schema.org\/scheduledTime",
+    "Name":"https://schema.org/scheduledTime",
     "Domain Bucket":"< 1K"
   },
   {
     "Class":"Predicate",
-    "Name":"http:\/\/schema.org\/scheduledTime-input",
+    "Name":"https://schema.org/scheduledTime-input",
     "Domain Bucket":"< 1K"
   },
   {
     "Class":"Predicate",
-    "Name":"http:\/\/schema.org\/scheduledTime-output",
+    "Name":"https://schema.org/scheduledTime-output",
     "Domain Bucket":"< 1K"
   },
   {
     "Class":"Predicate",
-    "Name":"http:\/\/schema.org\/schemaVersion",
+    "Name":"https://schema.org/schemaVersion",
     "Domain Bucket":"< 1K"
   },
   {
     "Class":"Predicate",
-    "Name":"http:\/\/schema.org\/schemaVersion-input",
+    "Name":"https://schema.org/schemaVersion-input",
     "Domain Bucket":"< 1K"
   },
   {
     "Class":"Predicate",
-    "Name":"http:\/\/schema.org\/schemaVersion-output",
+    "Name":"https://schema.org/schemaVersion-output",
     "Domain Bucket":"< 1K"
   },
   {
     "Class":"Predicate",
-    "Name":"http:\/\/schema.org\/schoolClosuresInfo",
+    "Name":"https://schema.org/schoolClosuresInfo",
     "Domain Bucket":"< 1K"
   },
   {
     "Class":"Predicate",
-    "Name":"http:\/\/schema.org\/schoolClosuresInfo-input",
+    "Name":"https://schema.org/schoolClosuresInfo-input",
     "Domain Bucket":"< 1K"
   },
   {
     "Class":"Predicate",
-    "Name":"http:\/\/schema.org\/schoolClosuresInfo-output",
+    "Name":"https://schema.org/schoolClosuresInfo-output",
     "Domain Bucket":"< 1K"
   },
   {
     "Class":"Predicate",
-    "Name":"http:\/\/schema.org\/screenCount",
+    "Name":"https://schema.org/screenCount",
     "Domain Bucket":"< 1K"
   },
   {
     "Class":"Predicate",
-    "Name":"http:\/\/schema.org\/screenCount-input",
+    "Name":"https://schema.org/screenCount-input",
     "Domain Bucket":"< 1K"
   },
   {
     "Class":"Predicate",
-    "Name":"http:\/\/schema.org\/screenCount-output",
+    "Name":"https://schema.org/screenCount-output",
     "Domain Bucket":"< 1K"
   },
   {
     "Class":"Predicate",
-    "Name":"http:\/\/schema.org\/screenshot",
+    "Name":"https://schema.org/screenshot",
     "Domain Bucket":"100K - 1M"
   },
   {
     "Class":"Predicate",
-    "Name":"http:\/\/schema.org\/screenshot-input",
+    "Name":"https://schema.org/screenshot-input",
     "Domain Bucket":"< 1K"
   },
   {
     "Class":"Predicate",
-    "Name":"http:\/\/schema.org\/screenshot-output",
+    "Name":"https://schema.org/screenshot-output",
     "Domain Bucket":"< 1K"
   },
   {
     "Class":"Predicate",
-    "Name":"http:\/\/schema.org\/sdDatePublished",
+    "Name":"https://schema.org/sdDatePublished",
     "Domain Bucket":"1K - 10K"
   },
   {
     "Class":"Predicate",
-    "Name":"http:\/\/schema.org\/sdDatePublished-input",
+    "Name":"https://schema.org/sdDatePublished-input",
     "Domain Bucket":"< 1K"
   },
   {
     "Class":"Predicate",
-    "Name":"http:\/\/schema.org\/sdDatePublished-output",
+    "Name":"https://schema.org/sdDatePublished-output",
     "Domain Bucket":"< 1K"
   },
   {
     "Class":"Predicate",
-    "Name":"http:\/\/schema.org\/sdLicense",
+    "Name":"https://schema.org/sdLicense",
     "Domain Bucket":"< 1K"
   },
   {
     "Class":"Predicate",
-    "Name":"http:\/\/schema.org\/sdLicense-input",
+    "Name":"https://schema.org/sdLicense-input",
     "Domain Bucket":"< 1K"
   },
   {
     "Class":"Predicate",
-    "Name":"http:\/\/schema.org\/sdLicense-output",
+    "Name":"https://schema.org/sdLicense-output",
     "Domain Bucket":"< 1K"
   },
   {
     "Class":"Predicate",
-    "Name":"http:\/\/schema.org\/sdPublisher",
+    "Name":"https://schema.org/sdPublisher",
     "Domain Bucket":"1K - 10K"
   },
   {
     "Class":"Predicate",
-    "Name":"http:\/\/schema.org\/sdPublisher-input",
+    "Name":"https://schema.org/sdPublisher-input",
     "Domain Bucket":"< 1K"
   },
   {
     "Class":"Predicate",
-    "Name":"http:\/\/schema.org\/sdPublisher-output",
+    "Name":"https://schema.org/sdPublisher-output",
     "Domain Bucket":"< 1K"
   },
   {
     "Class":"Predicate",
-    "Name":"http:\/\/schema.org\/season",
+    "Name":"https://schema.org/season",
     "Domain Bucket":"1K - 10K"
   },
   {
     "Class":"Predicate",
-    "Name":"http:\/\/schema.org\/season-input",
+    "Name":"https://schema.org/season-input",
     "Domain Bucket":"< 1K"
   },
   {
     "Class":"Predicate",
-    "Name":"http:\/\/schema.org\/season-output",
+    "Name":"https://schema.org/season-output",
     "Domain Bucket":"< 1K"
   },
   {
     "Class":"Predicate",
-    "Name":"http:\/\/schema.org\/seasonNumber",
+    "Name":"https://schema.org/seasonNumber",
     "Domain Bucket":"1K - 10K"
   },
   {
     "Class":"Predicate",
-    "Name":"http:\/\/schema.org\/seasonNumber-input",
+    "Name":"https://schema.org/seasonNumber-input",
     "Domain Bucket":"< 1K"
   },
   {
     "Class":"Predicate",
-    "Name":"http:\/\/schema.org\/seasonNumber-output",
+    "Name":"https://schema.org/seasonNumber-output",
     "Domain Bucket":"< 1K"
   },
   {
     "Class":"Predicate",
-    "Name":"http:\/\/schema.org\/seasonalOverride",
+    "Name":"https://schema.org/seasonalOverride",
     "Domain Bucket":"< 1K"
   },
   {
     "Class":"Predicate",
-    "Name":"http:\/\/schema.org\/seasonalOverride-input",
+    "Name":"https://schema.org/seasonalOverride-input",
     "Domain Bucket":"< 1K"
   },
   {
     "Class":"Predicate",
-    "Name":"http:\/\/schema.org\/seasonalOverride-output",
+    "Name":"https://schema.org/seasonalOverride-output",
     "Domain Bucket":"< 1K"
   },
   {
     "Class":"Predicate",
-    "Name":"http:\/\/schema.org\/seasons",
+    "Name":"https://schema.org/seasons",
     "Domain Bucket":"< 1K"
   },
   {
     "Class":"Predicate",
-    "Name":"http:\/\/schema.org\/seasons-input",
+    "Name":"https://schema.org/seasons-input",
     "Domain Bucket":"< 1K"
   },
   {
     "Class":"Predicate",
-    "Name":"http:\/\/schema.org\/seasons-output",
+    "Name":"https://schema.org/seasons-output",
     "Domain Bucket":"< 1K"
   },
   {
     "Class":"Predicate",
-    "Name":"http:\/\/schema.org\/seatNumber",
+    "Name":"https://schema.org/seatNumber",
     "Domain Bucket":"< 1K"
   },
   {
     "Class":"Predicate",
-    "Name":"http:\/\/schema.org\/seatNumber-input",
+    "Name":"https://schema.org/seatNumber-input",
     "Domain Bucket":"< 1K"
   },
   {
     "Class":"Predicate",
-    "Name":"http:\/\/schema.org\/seatNumber-output",
+    "Name":"https://schema.org/seatNumber-output",
     "Domain Bucket":"< 1K"
   },
   {
     "Class":"Predicate",
-    "Name":"http:\/\/schema.org\/seatRow",
+    "Name":"https://schema.org/seatRow",
     "Domain Bucket":"< 1K"
   },
   {
     "Class":"Predicate",
-    "Name":"http:\/\/schema.org\/seatRow-input",
+    "Name":"https://schema.org/seatRow-input",
     "Domain Bucket":"< 1K"
   },
   {
     "Class":"Predicate",
-    "Name":"http:\/\/schema.org\/seatRow-output",
+    "Name":"https://schema.org/seatRow-output",
     "Domain Bucket":"< 1K"
   },
   {
     "Class":"Predicate",
-    "Name":"http:\/\/schema.org\/seatSection",
+    "Name":"https://schema.org/seatSection",
     "Domain Bucket":"< 1K"
   },
   {
     "Class":"Predicate",
-    "Name":"http:\/\/schema.org\/seatSection-input",
+    "Name":"https://schema.org/seatSection-input",
     "Domain Bucket":"< 1K"
   },
   {
     "Class":"Predicate",
-    "Name":"http:\/\/schema.org\/seatSection-output",
+    "Name":"https://schema.org/seatSection-output",
     "Domain Bucket":"< 1K"
   },
   {
     "Class":"Predicate",
-    "Name":"http:\/\/schema.org\/seatingCapacity",
+    "Name":"https://schema.org/seatingCapacity",
     "Domain Bucket":"1K - 10K"
   },
   {
     "Class":"Predicate",
-    "Name":"http:\/\/schema.org\/seatingCapacity-input",
+    "Name":"https://schema.org/seatingCapacity-input",
     "Domain Bucket":"< 1K"
   },
   {
     "Class":"Predicate",
-    "Name":"http:\/\/schema.org\/seatingCapacity-output",
+    "Name":"https://schema.org/seatingCapacity-output",
     "Domain Bucket":"< 1K"
   },
   {
     "Class":"Predicate",
-    "Name":"http:\/\/schema.org\/seatingType",
+    "Name":"https://schema.org/seatingType",
     "Domain Bucket":"< 1K"
   },
   {
     "Class":"Predicate",
-    "Name":"http:\/\/schema.org\/seatingType-input",
+    "Name":"https://schema.org/seatingType-input",
     "Domain Bucket":"< 1K"
   },
   {
     "Class":"Predicate",
-    "Name":"http:\/\/schema.org\/seatingType-output",
+    "Name":"https://schema.org/seatingType-output",
     "Domain Bucket":"< 1K"
   },
   {
     "Class":"Predicate",
-    "Name":"http:\/\/schema.org\/secondaryPrevention",
+    "Name":"https://schema.org/secondaryPrevention",
     "Domain Bucket":"< 1K"
   },
   {
     "Class":"Predicate",
-    "Name":"http:\/\/schema.org\/secondaryPrevention-input",
+    "Name":"https://schema.org/secondaryPrevention-input",
     "Domain Bucket":"< 1K"
   },
   {
     "Class":"Predicate",
-    "Name":"http:\/\/schema.org\/secondaryPrevention-output",
+    "Name":"https://schema.org/secondaryPrevention-output",
     "Domain Bucket":"< 1K"
   },
   {
     "Class":"Predicate",
-    "Name":"http:\/\/schema.org\/securityClearanceRequirement",
+    "Name":"https://schema.org/securityClearanceRequirement",
     "Domain Bucket":"< 1K"
   },
   {
     "Class":"Predicate",
-    "Name":"http:\/\/schema.org\/securityClearanceRequirement-input",
+    "Name":"https://schema.org/securityClearanceRequirement-input",
     "Domain Bucket":"< 1K"
   },
   {
     "Class":"Predicate",
-    "Name":"http:\/\/schema.org\/securityClearanceRequirement-output",
+    "Name":"https://schema.org/securityClearanceRequirement-output",
     "Domain Bucket":"< 1K"
   },
   {
     "Class":"Predicate",
-    "Name":"http:\/\/schema.org\/securityScreening",
+    "Name":"https://schema.org/securityScreening",
     "Domain Bucket":"< 1K"
   },
   {
     "Class":"Predicate",
-    "Name":"http:\/\/schema.org\/securityScreening-input",
+    "Name":"https://schema.org/securityScreening-input",
     "Domain Bucket":"< 1K"
   },
   {
     "Class":"Predicate",
-    "Name":"http:\/\/schema.org\/securityScreening-output",
+    "Name":"https://schema.org/securityScreening-output",
     "Domain Bucket":"< 1K"
   },
   {
     "Class":"Predicate",
-    "Name":"http:\/\/schema.org\/seeks",
+    "Name":"https://schema.org/seeks",
     "Domain Bucket":"1K - 10K"
   },
   {
     "Class":"Predicate",
-    "Name":"http:\/\/schema.org\/seeks-input",
+    "Name":"https://schema.org/seeks-input",
     "Domain Bucket":"< 1K"
   },
   {
     "Class":"Predicate",
-    "Name":"http:\/\/schema.org\/seeks-output",
+    "Name":"https://schema.org/seeks-output",
     "Domain Bucket":"< 1K"
   },
   {
     "Class":"Predicate",
-    "Name":"http:\/\/schema.org\/seller",
+    "Name":"https://schema.org/seller",
     "Domain Bucket":"1M - 10M"
   },
   {
     "Class":"Predicate",
-    "Name":"http:\/\/schema.org\/seller-input",
+    "Name":"https://schema.org/seller-input",
     "Domain Bucket":"< 1K"
   },
   {
     "Class":"Predicate",
-    "Name":"http:\/\/schema.org\/seller-output",
+    "Name":"https://schema.org/seller-output",
     "Domain Bucket":"< 1K"
   },
   {
     "Class":"Predicate",
-    "Name":"http:\/\/schema.org\/sender",
+    "Name":"https://schema.org/sender",
     "Domain Bucket":"< 1K"
   },
   {
     "Class":"Predicate",
-    "Name":"http:\/\/schema.org\/sender-input",
+    "Name":"https://schema.org/sender-input",
     "Domain Bucket":"< 1K"
   },
   {
     "Class":"Predicate",
-    "Name":"http:\/\/schema.org\/sender-output",
+    "Name":"https://schema.org/sender-output",
     "Domain Bucket":"< 1K"
   },
   {
     "Class":"Predicate",
-    "Name":"http:\/\/schema.org\/sensoryRequirement",
+    "Name":"https://schema.org/sensoryRequirement",
     "Domain Bucket":"< 1K"
   },
   {
     "Class":"Predicate",
-    "Name":"http:\/\/schema.org\/sensoryRequirement-input",
+    "Name":"https://schema.org/sensoryRequirement-input",
     "Domain Bucket":"< 1K"
   },
   {
     "Class":"Predicate",
-    "Name":"http:\/\/schema.org\/sensoryRequirement-output",
+    "Name":"https://schema.org/sensoryRequirement-output",
     "Domain Bucket":"< 1K"
   },
   {
     "Class":"Predicate",
-    "Name":"http:\/\/schema.org\/sensoryUnit",
+    "Name":"https://schema.org/sensoryUnit",
     "Domain Bucket":"< 1K"
   },
   {
     "Class":"Predicate",
-    "Name":"http:\/\/schema.org\/sensoryUnit-input",
+    "Name":"https://schema.org/sensoryUnit-input",
     "Domain Bucket":"< 1K"
   },
   {
     "Class":"Predicate",
-    "Name":"http:\/\/schema.org\/sensoryUnit-output",
+    "Name":"https://schema.org/sensoryUnit-output",
     "Domain Bucket":"< 1K"
   },
   {
     "Class":"Predicate",
-    "Name":"http:\/\/schema.org\/serialNumber",
+    "Name":"https://schema.org/serialNumber",
     "Domain Bucket":"10K - 100K"
   },
   {
     "Class":"Predicate",
-    "Name":"http:\/\/schema.org\/serialNumber-input",
+    "Name":"https://schema.org/serialNumber-input",
     "Domain Bucket":"< 1K"
   },
   {
     "Class":"Predicate",
-    "Name":"http:\/\/schema.org\/serialNumber-output",
+    "Name":"https://schema.org/serialNumber-output",
     "Domain Bucket":"< 1K"
   },
   {
     "Class":"Predicate",
-    "Name":"http:\/\/schema.org\/seriousAdverseOutcome",
+    "Name":"https://schema.org/seriousAdverseOutcome",
     "Domain Bucket":"< 1K"
   },
   {
     "Class":"Predicate",
-    "Name":"http:\/\/schema.org\/seriousAdverseOutcome-input",
+    "Name":"https://schema.org/seriousAdverseOutcome-input",
     "Domain Bucket":"< 1K"
   },
   {
     "Class":"Predicate",
-    "Name":"http:\/\/schema.org\/seriousAdverseOutcome-output",
+    "Name":"https://schema.org/seriousAdverseOutcome-output",
     "Domain Bucket":"< 1K"
   },
   {
     "Class":"Predicate",
-    "Name":"http:\/\/schema.org\/serverStatus",
+    "Name":"https://schema.org/serverStatus",
     "Domain Bucket":"< 1K"
   },
   {
     "Class":"Predicate",
-    "Name":"http:\/\/schema.org\/serverStatus-input",
+    "Name":"https://schema.org/serverStatus-input",
     "Domain Bucket":"< 1K"
   },
   {
     "Class":"Predicate",
-    "Name":"http:\/\/schema.org\/serverStatus-output",
+    "Name":"https://schema.org/serverStatus-output",
     "Domain Bucket":"< 1K"
   },
   {
     "Class":"Predicate",
-    "Name":"http:\/\/schema.org\/servesCuisine",
+    "Name":"https://schema.org/servesCuisine",
     "Domain Bucket":"100K - 1M"
   },
   {
     "Class":"Predicate",
-    "Name":"http:\/\/schema.org\/servesCuisine-input",
+    "Name":"https://schema.org/servesCuisine-input",
     "Domain Bucket":"< 1K"
   },
   {
     "Class":"Predicate",
-    "Name":"http:\/\/schema.org\/servesCuisine-output",
+    "Name":"https://schema.org/servesCuisine-output",
     "Domain Bucket":"< 1K"
   },
   {
     "Class":"Predicate",
-    "Name":"http:\/\/schema.org\/serviceArea",
+    "Name":"https://schema.org/serviceArea",
     "Domain Bucket":"10K - 100K"
   },
   {
     "Class":"Predicate",
-    "Name":"http:\/\/schema.org\/serviceArea-input",
+    "Name":"https://schema.org/serviceArea-input",
     "Domain Bucket":"< 1K"
   },
   {
     "Class":"Predicate",
-    "Name":"http:\/\/schema.org\/serviceArea-output",
+    "Name":"https://schema.org/serviceArea-output",
     "Domain Bucket":"< 1K"
   },
   {
     "Class":"Predicate",
-    "Name":"http:\/\/schema.org\/serviceAudience",
+    "Name":"https://schema.org/serviceAudience",
     "Domain Bucket":"1K - 10K"
   },
   {
     "Class":"Predicate",
-    "Name":"http:\/\/schema.org\/serviceAudience-input",
+    "Name":"https://schema.org/serviceAudience-input",
     "Domain Bucket":"< 1K"
   },
   {
     "Class":"Predicate",
-    "Name":"http:\/\/schema.org\/serviceAudience-output",
+    "Name":"https://schema.org/serviceAudience-output",
     "Domain Bucket":"< 1K"
   },
   {
     "Class":"Predicate",
-    "Name":"http:\/\/schema.org\/serviceLocation",
+    "Name":"https://schema.org/serviceLocation",
     "Domain Bucket":"10K - 100K"
   },
   {
     "Class":"Predicate",
-    "Name":"http:\/\/schema.org\/serviceLocation-input",
+    "Name":"https://schema.org/serviceLocation-input",
     "Domain Bucket":"< 1K"
   },
   {
     "Class":"Predicate",
-    "Name":"http:\/\/schema.org\/serviceLocation-output",
+    "Name":"https://schema.org/serviceLocation-output",
     "Domain Bucket":"< 1K"
   },
   {
     "Class":"Predicate",
-    "Name":"http:\/\/schema.org\/serviceOperator",
+    "Name":"https://schema.org/serviceOperator",
     "Domain Bucket":"1K - 10K"
   },
   {
     "Class":"Predicate",
-    "Name":"http:\/\/schema.org\/serviceOperator-input",
+    "Name":"https://schema.org/serviceOperator-input",
     "Domain Bucket":"< 1K"
   },
   {
     "Class":"Predicate",
-    "Name":"http:\/\/schema.org\/serviceOperator-output",
+    "Name":"https://schema.org/serviceOperator-output",
     "Domain Bucket":"< 1K"
   },
   {
     "Class":"Predicate",
-    "Name":"http:\/\/schema.org\/serviceOutput",
+    "Name":"https://schema.org/serviceOutput",
     "Domain Bucket":"10K - 100K"
   },
   {
     "Class":"Predicate",
-    "Name":"http:\/\/schema.org\/serviceOutput-input",
+    "Name":"https://schema.org/serviceOutput-input",
     "Domain Bucket":"< 1K"
   },
   {
     "Class":"Predicate",
-    "Name":"http:\/\/schema.org\/serviceOutput-output",
+    "Name":"https://schema.org/serviceOutput-output",
     "Domain Bucket":"< 1K"
   },
   {
     "Class":"Predicate",
-    "Name":"http:\/\/schema.org\/servicePhone",
+    "Name":"https://schema.org/servicePhone",
     "Domain Bucket":"10K - 100K"
   },
   {
     "Class":"Predicate",
-    "Name":"http:\/\/schema.org\/servicePhone-input",
+    "Name":"https://schema.org/servicePhone-input",
     "Domain Bucket":"< 1K"
   },
   {
     "Class":"Predicate",
-    "Name":"http:\/\/schema.org\/servicePhone-output",
+    "Name":"https://schema.org/servicePhone-output",
     "Domain Bucket":"< 1K"
   },
   {
     "Class":"Predicate",
-    "Name":"http:\/\/schema.org\/servicePostalAddress",
+    "Name":"https://schema.org/servicePostalAddress",
     "Domain Bucket":"< 1K"
   },
   {
     "Class":"Predicate",
-    "Name":"http:\/\/schema.org\/servicePostalAddress-input",
+    "Name":"https://schema.org/servicePostalAddress-input",
     "Domain Bucket":"< 1K"
   },
   {
     "Class":"Predicate",
-    "Name":"http:\/\/schema.org\/servicePostalAddress-output",
+    "Name":"https://schema.org/servicePostalAddress-output",
     "Domain Bucket":"< 1K"
   },
   {
     "Class":"Predicate",
-    "Name":"http:\/\/schema.org\/serviceSmsNumber",
+    "Name":"https://schema.org/serviceSmsNumber",
     "Domain Bucket":"1K - 10K"
   },
   {
     "Class":"Predicate",
-    "Name":"http:\/\/schema.org\/serviceSmsNumber-input",
+    "Name":"https://schema.org/serviceSmsNumber-input",
     "Domain Bucket":"< 1K"
   },
   {
     "Class":"Predicate",
-    "Name":"http:\/\/schema.org\/serviceSmsNumber-output",
+    "Name":"https://schema.org/serviceSmsNumber-output",
     "Domain Bucket":"< 1K"
   },
   {
     "Class":"Predicate",
-    "Name":"http:\/\/schema.org\/serviceType",
+    "Name":"https://schema.org/serviceType",
     "Domain Bucket":"100K - 1M"
   },
   {
     "Class":"Predicate",
-    "Name":"http:\/\/schema.org\/serviceType-input",
+    "Name":"https://schema.org/serviceType-input",
     "Domain Bucket":"< 1K"
   },
   {
     "Class":"Predicate",
-    "Name":"http:\/\/schema.org\/serviceType-output",
+    "Name":"https://schema.org/serviceType-output",
     "Domain Bucket":"< 1K"
   },
   {
     "Class":"Predicate",
-    "Name":"http:\/\/schema.org\/serviceUrl",
+    "Name":"https://schema.org/serviceUrl",
     "Domain Bucket":"10K - 100K"
   },
   {
     "Class":"Predicate",
-    "Name":"http:\/\/schema.org\/serviceUrl-input",
+    "Name":"https://schema.org/serviceUrl-input",
     "Domain Bucket":"< 1K"
   },
   {
     "Class":"Predicate",
-    "Name":"http:\/\/schema.org\/serviceUrl-output",
+    "Name":"https://schema.org/serviceUrl-output",
     "Domain Bucket":"< 1K"
   },
   {
     "Class":"Predicate",
-    "Name":"http:\/\/schema.org\/servingSize",
+    "Name":"https://schema.org/servingSize",
     "Domain Bucket":"10K - 100K"
   },
   {
     "Class":"Predicate",
-    "Name":"http:\/\/schema.org\/servingSize-input",
+    "Name":"https://schema.org/servingSize-input",
     "Domain Bucket":"< 1K"
   },
   {
     "Class":"Predicate",
-    "Name":"http:\/\/schema.org\/servingSize-output",
+    "Name":"https://schema.org/servingSize-output",
     "Domain Bucket":"< 1K"
   },
   {
     "Class":"Predicate",
-    "Name":"http:\/\/schema.org\/sha256",
+    "Name":"https://schema.org/sha256",
     "Domain Bucket":"< 1K"
   },
   {
     "Class":"Predicate",
-    "Name":"http:\/\/schema.org\/sha256-input",
+    "Name":"https://schema.org/sha256-input",
     "Domain Bucket":"< 1K"
   },
   {
     "Class":"Predicate",
-    "Name":"http:\/\/schema.org\/sha256-output",
+    "Name":"https://schema.org/sha256-output",
     "Domain Bucket":"< 1K"
   },
   {
     "Class":"Predicate",
-    "Name":"http:\/\/schema.org\/sharedContent",
+    "Name":"https://schema.org/sharedContent",
     "Domain Bucket":"1K - 10K"
   },
   {
     "Class":"Predicate",
-    "Name":"http:\/\/schema.org\/sharedContent-input",
+    "Name":"https://schema.org/sharedContent-input",
     "Domain Bucket":"< 1K"
   },
   {
     "Class":"Predicate",
-    "Name":"http:\/\/schema.org\/sharedContent-output",
+    "Name":"https://schema.org/sharedContent-output",
     "Domain Bucket":"< 1K"
   },
   {
     "Class":"Predicate",
-    "Name":"http:\/\/schema.org\/shippingConditions",
+    "Name":"https://schema.org/shippingConditions",
     "Domain Bucket":"10K - 100K"
   },
   {
     "Class":"Predicate",
-    "Name":"http:\/\/schema.org\/shippingConditions-input",
+    "Name":"https://schema.org/shippingConditions-input",
     "Domain Bucket":"< 1K"
   },
   {
     "Class":"Predicate",
-    "Name":"http:\/\/schema.org\/shippingConditions-output",
+    "Name":"https://schema.org/shippingConditions-output",
     "Domain Bucket":"< 1K"
   },
   {
     "Class":"Predicate",
-    "Name":"http:\/\/schema.org\/shippingDestination",
+    "Name":"https://schema.org/shippingDestination",
     "Domain Bucket":"100K - 1M"
   },
   {
     "Class":"Predicate",
-    "Name":"http:\/\/schema.org\/shippingDestination-input",
+    "Name":"https://schema.org/shippingDestination-input",
     "Domain Bucket":"< 1K"
   },
   {
     "Class":"Predicate",
-    "Name":"http:\/\/schema.org\/shippingDestination-output",
+    "Name":"https://schema.org/shippingDestination-output",
     "Domain Bucket":"< 1K"
   },
   {
     "Class":"Predicate",
-    "Name":"http:\/\/schema.org\/shippingDetails",
+    "Name":"https://schema.org/shippingDetails",
     "Domain Bucket":"100K - 1M"
   },
   {
     "Class":"Predicate",
-    "Name":"http:\/\/schema.org\/shippingDetails-input",
+    "Name":"https://schema.org/shippingDetails-input",
     "Domain Bucket":"< 1K"
   },
   {
     "Class":"Predicate",
-    "Name":"http:\/\/schema.org\/shippingDetails-output",
+    "Name":"https://schema.org/shippingDetails-output",
     "Domain Bucket":"< 1K"
   },
   {
     "Class":"Predicate",
-    "Name":"http:\/\/schema.org\/shippingLabel",
+    "Name":"https://schema.org/shippingLabel",
     "Domain Bucket":"1K - 10K"
   },
   {
     "Class":"Predicate",
-    "Name":"http:\/\/schema.org\/shippingLabel-input",
+    "Name":"https://schema.org/shippingLabel-input",
     "Domain Bucket":"< 1K"
   },
   {
     "Class":"Predicate",
-    "Name":"http:\/\/schema.org\/shippingLabel-output",
+    "Name":"https://schema.org/shippingLabel-output",
     "Domain Bucket":"< 1K"
   },
   {
     "Class":"Predicate",
-    "Name":"http:\/\/schema.org\/shippingOrigin",
+    "Name":"https://schema.org/shippingOrigin",
     "Domain Bucket":"10K - 100K"
   },
   {
     "Class":"Predicate",
-    "Name":"http:\/\/schema.org\/shippingOrigin-input",
+    "Name":"https://schema.org/shippingOrigin-input",
     "Domain Bucket":"< 1K"
   },
   {
     "Class":"Predicate",
-    "Name":"http:\/\/schema.org\/shippingOrigin-output",
+    "Name":"https://schema.org/shippingOrigin-output",
     "Domain Bucket":"< 1K"
   },
   {
     "Class":"Predicate",
-    "Name":"http:\/\/schema.org\/shippingRate",
+    "Name":"https://schema.org/shippingRate",
     "Domain Bucket":"100K - 1M"
   },
   {
     "Class":"Predicate",
-    "Name":"http:\/\/schema.org\/shippingRate-input",
+    "Name":"https://schema.org/shippingRate-input",
     "Domain Bucket":"< 1K"
   },
   {
     "Class":"Predicate",
-    "Name":"http:\/\/schema.org\/shippingRate-output",
+    "Name":"https://schema.org/shippingRate-output",
     "Domain Bucket":"< 1K"
   },
   {
     "Class":"Predicate",
-    "Name":"http:\/\/schema.org\/shippingSettingsLink",
+    "Name":"https://schema.org/shippingSettingsLink",
     "Domain Bucket":"1K - 10K"
   },
   {
     "Class":"Predicate",
-    "Name":"http:\/\/schema.org\/shippingSettingsLink-input",
+    "Name":"https://schema.org/shippingSettingsLink-input",
     "Domain Bucket":"< 1K"
   },
   {
     "Class":"Predicate",
-    "Name":"http:\/\/schema.org\/shippingSettingsLink-output",
+    "Name":"https://schema.org/shippingSettingsLink-output",
     "Domain Bucket":"< 1K"
   },
   {
     "Class":"Predicate",
-    "Name":"http:\/\/schema.org\/sibling",
+    "Name":"https://schema.org/sibling",
     "Domain Bucket":"< 1K"
   },
   {
     "Class":"Predicate",
-    "Name":"http:\/\/schema.org\/sibling-input",
+    "Name":"https://schema.org/sibling-input",
     "Domain Bucket":"< 1K"
   },
   {
     "Class":"Predicate",
-    "Name":"http:\/\/schema.org\/sibling-output",
+    "Name":"https://schema.org/sibling-output",
     "Domain Bucket":"< 1K"
   },
   {
     "Class":"Predicate",
-    "Name":"http:\/\/schema.org\/siblings",
+    "Name":"https://schema.org/siblings",
     "Domain Bucket":"< 1K"
   },
   {
     "Class":"Predicate",
-    "Name":"http:\/\/schema.org\/siblings-input",
+    "Name":"https://schema.org/siblings-input",
     "Domain Bucket":"< 1K"
   },
   {
     "Class":"Predicate",
-    "Name":"http:\/\/schema.org\/siblings-output",
+    "Name":"https://schema.org/siblings-output",
     "Domain Bucket":"< 1K"
   },
   {
     "Class":"Predicate",
-    "Name":"http:\/\/schema.org\/signDetected",
+    "Name":"https://schema.org/signDetected",
     "Domain Bucket":"< 1K"
   },
   {
     "Class":"Predicate",
-    "Name":"http:\/\/schema.org\/signDetected-input",
+    "Name":"https://schema.org/signDetected-input",
     "Domain Bucket":"< 1K"
   },
   {
     "Class":"Predicate",
-    "Name":"http:\/\/schema.org\/signDetected-output",
+    "Name":"https://schema.org/signDetected-output",
     "Domain Bucket":"< 1K"
   },
   {
     "Class":"Predicate",
-    "Name":"http:\/\/schema.org\/signOrSymptom",
+    "Name":"https://schema.org/signOrSymptom",
     "Domain Bucket":"1K - 10K"
   },
   {
     "Class":"Predicate",
-    "Name":"http:\/\/schema.org\/signOrSymptom-input",
+    "Name":"https://schema.org/signOrSymptom-input",
     "Domain Bucket":"< 1K"
   },
   {
     "Class":"Predicate",
-    "Name":"http:\/\/schema.org\/signOrSymptom-output",
+    "Name":"https://schema.org/signOrSymptom-output",
     "Domain Bucket":"< 1K"
   },
   {
     "Class":"Predicate",
-    "Name":"http:\/\/schema.org\/significance",
+    "Name":"https://schema.org/significance",
     "Domain Bucket":"< 1K"
   },
   {
     "Class":"Predicate",
-    "Name":"http:\/\/schema.org\/significance-input",
+    "Name":"https://schema.org/significance-input",
     "Domain Bucket":"< 1K"
   },
   {
     "Class":"Predicate",
-    "Name":"http:\/\/schema.org\/significance-output",
+    "Name":"https://schema.org/significance-output",
     "Domain Bucket":"< 1K"
   },
   {
     "Class":"Predicate",
-    "Name":"http:\/\/schema.org\/significantLink",
+    "Name":"https://schema.org/significantLink",
     "Domain Bucket":"10K - 100K"
   },
   {
     "Class":"Predicate",
-    "Name":"http:\/\/schema.org\/significantLink-input",
+    "Name":"https://schema.org/significantLink-input",
     "Domain Bucket":"< 1K"
   },
   {
     "Class":"Predicate",
-    "Name":"http:\/\/schema.org\/significantLink-output",
+    "Name":"https://schema.org/significantLink-output",
     "Domain Bucket":"< 1K"
   },
   {
     "Class":"Predicate",
-    "Name":"http:\/\/schema.org\/significantLinks",
+    "Name":"https://schema.org/significantLinks",
     "Domain Bucket":"1K - 10K"
   },
   {
     "Class":"Predicate",
-    "Name":"http:\/\/schema.org\/significantLinks-input",
+    "Name":"https://schema.org/significantLinks-input",
     "Domain Bucket":"< 1K"
   },
   {
     "Class":"Predicate",
-    "Name":"http:\/\/schema.org\/significantLinks-output",
+    "Name":"https://schema.org/significantLinks-output",
     "Domain Bucket":"< 1K"
   },
   {
     "Class":"Predicate",
-    "Name":"http:\/\/schema.org\/size",
+    "Name":"https://schema.org/size",
     "Domain Bucket":"10K - 100K"
   },
   {
     "Class":"Predicate",
-    "Name":"http:\/\/schema.org\/size-input",
+    "Name":"https://schema.org/size-input",
     "Domain Bucket":"< 1K"
   },
   {
     "Class":"Predicate",
-    "Name":"http:\/\/schema.org\/size-output",
+    "Name":"https://schema.org/size-output",
     "Domain Bucket":"< 1K"
   },
   {
     "Class":"Predicate",
-    "Name":"http:\/\/schema.org\/sizeGroup",
+    "Name":"https://schema.org/sizeGroup",
     "Domain Bucket":"< 1K"
   },
   {
     "Class":"Predicate",
-    "Name":"http:\/\/schema.org\/sizeGroup-input",
+    "Name":"https://schema.org/sizeGroup-input",
     "Domain Bucket":"< 1K"
   },
   {
     "Class":"Predicate",
-    "Name":"http:\/\/schema.org\/sizeGroup-output",
+    "Name":"https://schema.org/sizeGroup-output",
     "Domain Bucket":"< 1K"
   },
   {
     "Class":"Predicate",
-    "Name":"http:\/\/schema.org\/sizeSystem",
+    "Name":"https://schema.org/sizeSystem",
     "Domain Bucket":"< 1K"
   },
   {
     "Class":"Predicate",
-    "Name":"http:\/\/schema.org\/sizeSystem-input",
+    "Name":"https://schema.org/sizeSystem-input",
     "Domain Bucket":"< 1K"
   },
   {
     "Class":"Predicate",
-    "Name":"http:\/\/schema.org\/sizeSystem-output",
+    "Name":"https://schema.org/sizeSystem-output",
     "Domain Bucket":"< 1K"
   },
   {
     "Class":"Predicate",
-    "Name":"http:\/\/schema.org\/skills",
+    "Name":"https://schema.org/skills",
     "Domain Bucket":"10K - 100K"
   },
   {
     "Class":"Predicate",
-    "Name":"http:\/\/schema.org\/skills-input",
+    "Name":"https://schema.org/skills-input",
     "Domain Bucket":"< 1K"
   },
   {
     "Class":"Predicate",
-    "Name":"http:\/\/schema.org\/skills-output",
+    "Name":"https://schema.org/skills-output",
     "Domain Bucket":"< 1K"
   },
   {
     "Class":"Predicate",
-    "Name":"http:\/\/schema.org\/sku",
+    "Name":"https://schema.org/sku",
     "Domain Bucket":"1M - 10M"
   },
   {
     "Class":"Predicate",
-    "Name":"http:\/\/schema.org\/sku-input",
+    "Name":"https://schema.org/sku-input",
     "Domain Bucket":"< 1K"
   },
   {
     "Class":"Predicate",
-    "Name":"http:\/\/schema.org\/sku-output",
+    "Name":"https://schema.org/sku-output",
     "Domain Bucket":"< 1K"
   },
   {
     "Class":"Predicate",
-    "Name":"http:\/\/schema.org\/slogan",
+    "Name":"https://schema.org/slogan",
     "Domain Bucket":"100K - 1M"
   },
   {
     "Class":"Predicate",
-    "Name":"http:\/\/schema.org\/slogan-input",
+    "Name":"https://schema.org/slogan-input",
     "Domain Bucket":"< 1K"
   },
   {
     "Class":"Predicate",
-    "Name":"http:\/\/schema.org\/slogan-output",
+    "Name":"https://schema.org/slogan-output",
     "Domain Bucket":"< 1K"
   },
   {
     "Class":"Predicate",
-    "Name":"http:\/\/schema.org\/smiles",
+    "Name":"https://schema.org/smiles",
     "Domain Bucket":"< 1K"
   },
   {
     "Class":"Predicate",
-    "Name":"http:\/\/schema.org\/smiles-input",
+    "Name":"https://schema.org/smiles-input",
     "Domain Bucket":"< 1K"
   },
   {
     "Class":"Predicate",
-    "Name":"http:\/\/schema.org\/smiles-output",
+    "Name":"https://schema.org/smiles-output",
     "Domain Bucket":"< 1K"
   },
   {
     "Class":"Predicate",
-    "Name":"http:\/\/schema.org\/smokingAllowed",
+    "Name":"https://schema.org/smokingAllowed",
     "Domain Bucket":"10K - 100K"
   },
   {
     "Class":"Predicate",
-    "Name":"http:\/\/schema.org\/smokingAllowed-input",
+    "Name":"https://schema.org/smokingAllowed-input",
     "Domain Bucket":"< 1K"
   },
   {
     "Class":"Predicate",
-    "Name":"http:\/\/schema.org\/smokingAllowed-output",
+    "Name":"https://schema.org/smokingAllowed-output",
     "Domain Bucket":"< 1K"
   },
   {
     "Class":"Predicate",
-    "Name":"http:\/\/schema.org\/sodiumContent",
+    "Name":"https://schema.org/sodiumContent",
     "Domain Bucket":"10K - 100K"
   },
   {
     "Class":"Predicate",
-    "Name":"http:\/\/schema.org\/sodiumContent-input",
+    "Name":"https://schema.org/sodiumContent-input",
     "Domain Bucket":"< 1K"
   },
   {
     "Class":"Predicate",
-    "Name":"http:\/\/schema.org\/sodiumContent-output",
+    "Name":"https://schema.org/sodiumContent-output",
     "Domain Bucket":"< 1K"
   },
   {
     "Class":"Predicate",
-    "Name":"http:\/\/schema.org\/softwareAddOn",
+    "Name":"https://schema.org/softwareAddOn",
     "Domain Bucket":"< 1K"
   },
   {
     "Class":"Predicate",
-    "Name":"http:\/\/schema.org\/softwareAddOn-input",
+    "Name":"https://schema.org/softwareAddOn-input",
     "Domain Bucket":"< 1K"
   },
   {
     "Class":"Predicate",
-    "Name":"http:\/\/schema.org\/softwareAddOn-output",
+    "Name":"https://schema.org/softwareAddOn-output",
     "Domain Bucket":"< 1K"
   },
   {
     "Class":"Predicate",
-    "Name":"http:\/\/schema.org\/softwareHelp",
+    "Name":"https://schema.org/softwareHelp",
     "Domain Bucket":"10K - 100K"
   },
   {
     "Class":"Predicate",
-    "Name":"http:\/\/schema.org\/softwareHelp-input",
+    "Name":"https://schema.org/softwareHelp-input",
     "Domain Bucket":"< 1K"
   },
   {
     "Class":"Predicate",
-    "Name":"http:\/\/schema.org\/softwareHelp-output",
+    "Name":"https://schema.org/softwareHelp-output",
     "Domain Bucket":"< 1K"
   },
   {
     "Class":"Predicate",
-    "Name":"http:\/\/schema.org\/softwareRequirements",
+    "Name":"https://schema.org/softwareRequirements",
     "Domain Bucket":"10K - 100K"
   },
   {
     "Class":"Predicate",
-    "Name":"http:\/\/schema.org\/softwareRequirements-input",
+    "Name":"https://schema.org/softwareRequirements-input",
     "Domain Bucket":"< 1K"
   },
   {
     "Class":"Predicate",
-    "Name":"http:\/\/schema.org\/softwareRequirements-output",
+    "Name":"https://schema.org/softwareRequirements-output",
     "Domain Bucket":"< 1K"
   },
   {
     "Class":"Predicate",
-    "Name":"http:\/\/schema.org\/softwareVersion",
+    "Name":"https://schema.org/softwareVersion",
     "Domain Bucket":"100K - 1M"
   },
   {
     "Class":"Predicate",
-    "Name":"http:\/\/schema.org\/softwareVersion-input",
+    "Name":"https://schema.org/softwareVersion-input",
     "Domain Bucket":"< 1K"
   },
   {
     "Class":"Predicate",
-    "Name":"http:\/\/schema.org\/softwareVersion-output",
+    "Name":"https://schema.org/softwareVersion-output",
     "Domain Bucket":"< 1K"
   },
   {
     "Class":"Predicate",
-    "Name":"http:\/\/schema.org\/source",
+    "Name":"https://schema.org/source",
     "Domain Bucket":"1K - 10K"
   },
   {
     "Class":"Predicate",
-    "Name":"http:\/\/schema.org\/source-input",
+    "Name":"https://schema.org/source-input",
     "Domain Bucket":"< 1K"
   },
   {
     "Class":"Predicate",
-    "Name":"http:\/\/schema.org\/source-output",
+    "Name":"https://schema.org/source-output",
     "Domain Bucket":"< 1K"
   },
   {
     "Class":"Predicate",
-    "Name":"http:\/\/schema.org\/sourceOrganization",
+    "Name":"https://schema.org/sourceOrganization",
     "Domain Bucket":"10K - 100K"
   },
   {
     "Class":"Predicate",
-    "Name":"http:\/\/schema.org\/sourceOrganization-input",
+    "Name":"https://schema.org/sourceOrganization-input",
     "Domain Bucket":"< 1K"
   },
   {
     "Class":"Predicate",
-    "Name":"http:\/\/schema.org\/sourceOrganization-output",
+    "Name":"https://schema.org/sourceOrganization-output",
     "Domain Bucket":"< 1K"
   },
   {
     "Class":"Predicate",
-    "Name":"http:\/\/schema.org\/sourcedFrom",
+    "Name":"https://schema.org/sourcedFrom",
     "Domain Bucket":"< 1K"
   },
   {
     "Class":"Predicate",
-    "Name":"http:\/\/schema.org\/sourcedFrom-input",
+    "Name":"https://schema.org/sourcedFrom-input",
     "Domain Bucket":"< 1K"
   },
   {
     "Class":"Predicate",
-    "Name":"http:\/\/schema.org\/sourcedFrom-output",
+    "Name":"https://schema.org/sourcedFrom-output",
     "Domain Bucket":"< 1K"
   },
   {
     "Class":"Predicate",
-    "Name":"http:\/\/schema.org\/spatial",
+    "Name":"https://schema.org/spatial",
     "Domain Bucket":"1K - 10K"
   },
   {
     "Class":"Predicate",
-    "Name":"http:\/\/schema.org\/spatial-input",
+    "Name":"https://schema.org/spatial-input",
     "Domain Bucket":"< 1K"
   },
   {
     "Class":"Predicate",
-    "Name":"http:\/\/schema.org\/spatial-output",
+    "Name":"https://schema.org/spatial-output",
     "Domain Bucket":"< 1K"
   },
   {
     "Class":"Predicate",
-    "Name":"http:\/\/schema.org\/spatialCoverage",
+    "Name":"https://schema.org/spatialCoverage",
     "Domain Bucket":"10K - 100K"
   },
   {
     "Class":"Predicate",
-    "Name":"http:\/\/schema.org\/spatialCoverage-input",
+    "Name":"https://schema.org/spatialCoverage-input",
     "Domain Bucket":"< 1K"
   },
   {
     "Class":"Predicate",
-    "Name":"http:\/\/schema.org\/spatialCoverage-output",
+    "Name":"https://schema.org/spatialCoverage-output",
     "Domain Bucket":"< 1K"
   },
   {
     "Class":"Predicate",
-    "Name":"http:\/\/schema.org\/speakable",
+    "Name":"https://schema.org/speakable",
     "Domain Bucket":"100K - 1M"
   },
   {
     "Class":"Predicate",
-    "Name":"http:\/\/schema.org\/speakable-input",
+    "Name":"https://schema.org/speakable-input",
     "Domain Bucket":"< 1K"
   },
   {
     "Class":"Predicate",
-    "Name":"http:\/\/schema.org\/speakable-output",
+    "Name":"https://schema.org/speakable-output",
     "Domain Bucket":"< 1K"
   },
   {
     "Class":"Predicate",
-    "Name":"http:\/\/schema.org\/specialCommitments",
+    "Name":"https://schema.org/specialCommitments",
     "Domain Bucket":"1K - 10K"
   },
   {
     "Class":"Predicate",
-    "Name":"http:\/\/schema.org\/specialCommitments-input",
+    "Name":"https://schema.org/specialCommitments-input",
     "Domain Bucket":"< 1K"
   },
   {
     "Class":"Predicate",
-    "Name":"http:\/\/schema.org\/specialCommitments-output",
+    "Name":"https://schema.org/specialCommitments-output",
     "Domain Bucket":"< 1K"
   },
   {
     "Class":"Predicate",
-    "Name":"http:\/\/schema.org\/specialOpeningHoursSpecification",
+    "Name":"https://schema.org/specialOpeningHoursSpecification",
     "Domain Bucket":"1K - 10K"
   },
   {
     "Class":"Predicate",
-    "Name":"http:\/\/schema.org\/specialOpeningHoursSpecification-input",
+    "Name":"https://schema.org/specialOpeningHoursSpecification-input",
     "Domain Bucket":"< 1K"
   },
   {
     "Class":"Predicate",
-    "Name":"http:\/\/schema.org\/specialOpeningHoursSpecification-output",
+    "Name":"https://schema.org/specialOpeningHoursSpecification-output",
     "Domain Bucket":"< 1K"
   },
   {
     "Class":"Predicate",
-    "Name":"http:\/\/schema.org\/specialty",
+    "Name":"https://schema.org/specialty",
     "Domain Bucket":"10K - 100K"
   },
   {
     "Class":"Predicate",
-    "Name":"http:\/\/schema.org\/specialty-input",
+    "Name":"https://schema.org/specialty-input",
     "Domain Bucket":"< 1K"
   },
   {
     "Class":"Predicate",
-    "Name":"http:\/\/schema.org\/specialty-output",
+    "Name":"https://schema.org/specialty-output",
     "Domain Bucket":"< 1K"
   },
   {
     "Class":"Predicate",
-    "Name":"http:\/\/schema.org\/speechToTextMarkup",
+    "Name":"https://schema.org/speechToTextMarkup",
     "Domain Bucket":"< 1K"
   },
   {
     "Class":"Predicate",
-    "Name":"http:\/\/schema.org\/speechToTextMarkup-input",
+    "Name":"https://schema.org/speechToTextMarkup-input",
     "Domain Bucket":"< 1K"
   },
   {
     "Class":"Predicate",
-    "Name":"http:\/\/schema.org\/speechToTextMarkup-output",
+    "Name":"https://schema.org/speechToTextMarkup-output",
     "Domain Bucket":"< 1K"
   },
   {
     "Class":"Predicate",
-    "Name":"http:\/\/schema.org\/speed",
+    "Name":"https://schema.org/speed",
     "Domain Bucket":"1K - 10K"
   },
   {
     "Class":"Predicate",
-    "Name":"http:\/\/schema.org\/speed-input",
+    "Name":"https://schema.org/speed-input",
     "Domain Bucket":"< 1K"
   },
   {
     "Class":"Predicate",
-    "Name":"http:\/\/schema.org\/speed-output",
+    "Name":"https://schema.org/speed-output",
     "Domain Bucket":"< 1K"
   },
   {
     "Class":"Predicate",
-    "Name":"http:\/\/schema.org\/spokenByCharacter",
+    "Name":"https://schema.org/spokenByCharacter",
     "Domain Bucket":"1K - 10K"
   },
   {
     "Class":"Predicate",
-    "Name":"http:\/\/schema.org\/spokenByCharacter-input",
+    "Name":"https://schema.org/spokenByCharacter-input",
     "Domain Bucket":"< 1K"
   },
   {
     "Class":"Predicate",
-    "Name":"http:\/\/schema.org\/spokenByCharacter-output",
+    "Name":"https://schema.org/spokenByCharacter-output",
     "Domain Bucket":"< 1K"
   },
   {
     "Class":"Predicate",
-    "Name":"http:\/\/schema.org\/sponsor",
+    "Name":"https://schema.org/sponsor",
     "Domain Bucket":"10K - 100K"
   },
   {
     "Class":"Predicate",
-    "Name":"http:\/\/schema.org\/sponsor-input",
+    "Name":"https://schema.org/sponsor-input",
     "Domain Bucket":"< 1K"
   },
   {
     "Class":"Predicate",
-    "Name":"http:\/\/schema.org\/sponsor-output",
+    "Name":"https://schema.org/sponsor-output",
     "Domain Bucket":"< 1K"
   },
   {
     "Class":"Predicate",
-    "Name":"http:\/\/schema.org\/sport",
+    "Name":"https://schema.org/sport",
     "Domain Bucket":"10K - 100K"
   },
   {
     "Class":"Predicate",
-    "Name":"http:\/\/schema.org\/sport-input",
+    "Name":"https://schema.org/sport-input",
     "Domain Bucket":"< 1K"
   },
   {
     "Class":"Predicate",
-    "Name":"http:\/\/schema.org\/sport-output",
+    "Name":"https://schema.org/sport-output",
     "Domain Bucket":"< 1K"
   },
   {
     "Class":"Predicate",
-    "Name":"http:\/\/schema.org\/sportsActivityLocation",
+    "Name":"https://schema.org/sportsActivityLocation",
     "Domain Bucket":"< 1K"
   },
   {
     "Class":"Predicate",
-    "Name":"http:\/\/schema.org\/sportsActivityLocation-input",
+    "Name":"https://schema.org/sportsActivityLocation-input",
     "Domain Bucket":"< 1K"
   },
   {
     "Class":"Predicate",
-    "Name":"http:\/\/schema.org\/sportsActivityLocation-output",
+    "Name":"https://schema.org/sportsActivityLocation-output",
     "Domain Bucket":"< 1K"
   },
   {
     "Class":"Predicate",
-    "Name":"http:\/\/schema.org\/sportsEvent",
+    "Name":"https://schema.org/sportsEvent",
     "Domain Bucket":"< 1K"
   },
   {
     "Class":"Predicate",
-    "Name":"http:\/\/schema.org\/sportsEvent-input",
+    "Name":"https://schema.org/sportsEvent-input",
     "Domain Bucket":"< 1K"
   },
   {
     "Class":"Predicate",
-    "Name":"http:\/\/schema.org\/sportsEvent-output",
+    "Name":"https://schema.org/sportsEvent-output",
     "Domain Bucket":"< 1K"
   },
   {
     "Class":"Predicate",
-    "Name":"http:\/\/schema.org\/sportsTeam",
+    "Name":"https://schema.org/sportsTeam",
     "Domain Bucket":"< 1K"
   },
   {
     "Class":"Predicate",
-    "Name":"http:\/\/schema.org\/sportsTeam-input",
+    "Name":"https://schema.org/sportsTeam-input",
     "Domain Bucket":"< 1K"
   },
   {
     "Class":"Predicate",
-    "Name":"http:\/\/schema.org\/sportsTeam-output",
+    "Name":"https://schema.org/sportsTeam-output",
     "Domain Bucket":"< 1K"
   },
   {
     "Class":"Predicate",
-    "Name":"http:\/\/schema.org\/spouse",
+    "Name":"https://schema.org/spouse",
     "Domain Bucket":"1K - 10K"
   },
   {
     "Class":"Predicate",
-    "Name":"http:\/\/schema.org\/spouse-input",
+    "Name":"https://schema.org/spouse-input",
     "Domain Bucket":"< 1K"
   },
   {
     "Class":"Predicate",
-    "Name":"http:\/\/schema.org\/spouse-output",
+    "Name":"https://schema.org/spouse-output",
     "Domain Bucket":"< 1K"
   },
   {
     "Class":"Predicate",
-    "Name":"http:\/\/schema.org\/stage",
+    "Name":"https://schema.org/stage",
     "Domain Bucket":"< 1K"
   },
   {
     "Class":"Predicate",
-    "Name":"http:\/\/schema.org\/stage-input",
+    "Name":"https://schema.org/stage-input",
     "Domain Bucket":"< 1K"
   },
   {
     "Class":"Predicate",
-    "Name":"http:\/\/schema.org\/stage-output",
+    "Name":"https://schema.org/stage-output",
     "Domain Bucket":"< 1K"
   },
   {
     "Class":"Predicate",
-    "Name":"http:\/\/schema.org\/stageAsNumber",
+    "Name":"https://schema.org/stageAsNumber",
     "Domain Bucket":"< 1K"
   },
   {
     "Class":"Predicate",
-    "Name":"http:\/\/schema.org\/stageAsNumber-input",
+    "Name":"https://schema.org/stageAsNumber-input",
     "Domain Bucket":"< 1K"
   },
   {
     "Class":"Predicate",
-    "Name":"http:\/\/schema.org\/stageAsNumber-output",
+    "Name":"https://schema.org/stageAsNumber-output",
     "Domain Bucket":"< 1K"
   },
   {
     "Class":"Predicate",
-    "Name":"http:\/\/schema.org\/starRating",
+    "Name":"https://schema.org/starRating",
     "Domain Bucket":"10K - 100K"
   },
   {
     "Class":"Predicate",
-    "Name":"http:\/\/schema.org\/starRating-input",
+    "Name":"https://schema.org/starRating-input",
     "Domain Bucket":"< 1K"
   },
   {
     "Class":"Predicate",
-    "Name":"http:\/\/schema.org\/starRating-output",
+    "Name":"https://schema.org/starRating-output",
     "Domain Bucket":"< 1K"
   },
   {
     "Class":"Predicate",
-    "Name":"http:\/\/schema.org\/startDate",
+    "Name":"https://schema.org/startDate",
     "Domain Bucket":"100K - 1M"
   },
   {
     "Class":"Predicate",
-    "Name":"http:\/\/schema.org\/startDate-input",
+    "Name":"https://schema.org/startDate-input",
     "Domain Bucket":"< 1K"
   },
   {
     "Class":"Predicate",
-    "Name":"http:\/\/schema.org\/startDate-output",
+    "Name":"https://schema.org/startDate-output",
     "Domain Bucket":"< 1K"
   },
   {
     "Class":"Predicate",
-    "Name":"http:\/\/schema.org\/startOffset",
+    "Name":"https://schema.org/startOffset",
     "Domain Bucket":"10K - 100K"
   },
   {
     "Class":"Predicate",
-    "Name":"http:\/\/schema.org\/startOffset-input",
+    "Name":"https://schema.org/startOffset-input",
     "Domain Bucket":"10K - 100K"
   },
   {
     "Class":"Predicate",
-    "Name":"http:\/\/schema.org\/startOffset-output",
+    "Name":"https://schema.org/startOffset-output",
     "Domain Bucket":"< 1K"
   },
   {
     "Class":"Predicate",
-    "Name":"http:\/\/schema.org\/startTime",
+    "Name":"https://schema.org/startTime",
     "Domain Bucket":"1K - 10K"
   },
   {
     "Class":"Predicate",
-    "Name":"http:\/\/schema.org\/startTime-input",
+    "Name":"https://schema.org/startTime-input",
     "Domain Bucket":"< 1K"
   },
   {
     "Class":"Predicate",
-    "Name":"http:\/\/schema.org\/startTime-output",
+    "Name":"https://schema.org/startTime-output",
     "Domain Bucket":"< 1K"
   },
   {
     "Class":"Predicate",
-    "Name":"http:\/\/schema.org\/statType",
+    "Name":"https://schema.org/statType",
     "Domain Bucket":"< 1K"
   },
   {
     "Class":"Predicate",
-    "Name":"http:\/\/schema.org\/statType-input",
+    "Name":"https://schema.org/statType-input",
     "Domain Bucket":"< 1K"
   },
   {
     "Class":"Predicate",
-    "Name":"http:\/\/schema.org\/statType-output",
+    "Name":"https://schema.org/statType-output",
     "Domain Bucket":"< 1K"
   },
   {
     "Class":"Predicate",
-    "Name":"http:\/\/schema.org\/status",
+    "Name":"https://schema.org/status",
     "Domain Bucket":"1K - 10K"
   },
   {
     "Class":"Predicate",
-    "Name":"http:\/\/schema.org\/status-input",
+    "Name":"https://schema.org/status-input",
     "Domain Bucket":"< 1K"
   },
   {
     "Class":"Predicate",
-    "Name":"http:\/\/schema.org\/status-output",
+    "Name":"https://schema.org/status-output",
     "Domain Bucket":"< 1K"
   },
   {
     "Class":"Predicate",
-    "Name":"http:\/\/schema.org\/steeringPosition",
+    "Name":"https://schema.org/steeringPosition",
     "Domain Bucket":"1K - 10K"
   },
   {
     "Class":"Predicate",
-    "Name":"http:\/\/schema.org\/steeringPosition-input",
+    "Name":"https://schema.org/steeringPosition-input",
     "Domain Bucket":"< 1K"
   },
   {
     "Class":"Predicate",
-    "Name":"http:\/\/schema.org\/steeringPosition-output",
+    "Name":"https://schema.org/steeringPosition-output",
     "Domain Bucket":"< 1K"
   },
   {
     "Class":"Predicate",
-    "Name":"http:\/\/schema.org\/step",
+    "Name":"https://schema.org/step",
     "Domain Bucket":"100K - 1M"
   },
   {
     "Class":"Predicate",
-    "Name":"http:\/\/schema.org\/step-input",
+    "Name":"https://schema.org/step-input",
     "Domain Bucket":"< 1K"
   },
   {
     "Class":"Predicate",
-    "Name":"http:\/\/schema.org\/step-output",
+    "Name":"https://schema.org/step-output",
     "Domain Bucket":"< 1K"
   },
   {
     "Class":"Predicate",
-    "Name":"http:\/\/schema.org\/stepValue",
+    "Name":"https://schema.org/stepValue",
     "Domain Bucket":"< 1K"
   },
   {
     "Class":"Predicate",
-    "Name":"http:\/\/schema.org\/stepValue-input",
+    "Name":"https://schema.org/stepValue-input",
     "Domain Bucket":"< 1K"
   },
   {
     "Class":"Predicate",
-    "Name":"http:\/\/schema.org\/stepValue-output",
+    "Name":"https://schema.org/stepValue-output",
     "Domain Bucket":"< 1K"
   },
   {
     "Class":"Predicate",
-    "Name":"http:\/\/schema.org\/steps",
+    "Name":"https://schema.org/steps",
     "Domain Bucket":"< 1K"
   },
   {
     "Class":"Predicate",
-    "Name":"http:\/\/schema.org\/steps-input",
+    "Name":"https://schema.org/steps-input",
     "Domain Bucket":"< 1K"
   },
   {
     "Class":"Predicate",
-    "Name":"http:\/\/schema.org\/steps-output",
+    "Name":"https://schema.org/steps-output",
     "Domain Bucket":"< 1K"
   },
   {
     "Class":"Predicate",
-    "Name":"http:\/\/schema.org\/storageRequirements",
+    "Name":"https://schema.org/storageRequirements",
     "Domain Bucket":"10K - 100K"
   },
   {
     "Class":"Predicate",
-    "Name":"http:\/\/schema.org\/storageRequirements-input",
+    "Name":"https://schema.org/storageRequirements-input",
     "Domain Bucket":"< 1K"
   },
   {
     "Class":"Predicate",
-    "Name":"http:\/\/schema.org\/storageRequirements-output",
+    "Name":"https://schema.org/storageRequirements-output",
     "Domain Bucket":"< 1K"
   },
   {
     "Class":"Predicate",
-    "Name":"http:\/\/schema.org\/streetAddress",
+    "Name":"https://schema.org/streetAddress",
     "Domain Bucket":"1M - 10M"
   },
   {
     "Class":"Predicate",
-    "Name":"http:\/\/schema.org\/streetAddress-input",
+    "Name":"https://schema.org/streetAddress-input",
     "Domain Bucket":"< 1K"
   },
   {
     "Class":"Predicate",
-    "Name":"http:\/\/schema.org\/streetAddress-output",
+    "Name":"https://schema.org/streetAddress-output",
     "Domain Bucket":"< 1K"
   },
   {
     "Class":"Predicate",
-    "Name":"http:\/\/schema.org\/strengthUnit",
+    "Name":"https://schema.org/strengthUnit",
     "Domain Bucket":"< 1K"
   },
   {
     "Class":"Predicate",
-    "Name":"http:\/\/schema.org\/strengthUnit-input",
+    "Name":"https://schema.org/strengthUnit-input",
     "Domain Bucket":"< 1K"
   },
   {
     "Class":"Predicate",
-    "Name":"http:\/\/schema.org\/strengthUnit-output",
+    "Name":"https://schema.org/strengthUnit-output",
     "Domain Bucket":"< 1K"
   },
   {
     "Class":"Predicate",
-    "Name":"http:\/\/schema.org\/strengthValue",
+    "Name":"https://schema.org/strengthValue",
     "Domain Bucket":"< 1K"
   },
   {
     "Class":"Predicate",
-    "Name":"http:\/\/schema.org\/strengthValue-input",
+    "Name":"https://schema.org/strengthValue-input",
     "Domain Bucket":"< 1K"
   },
   {
     "Class":"Predicate",
-    "Name":"http:\/\/schema.org\/strengthValue-output",
+    "Name":"https://schema.org/strengthValue-output",
     "Domain Bucket":"< 1K"
   },
   {
     "Class":"Predicate",
-    "Name":"http:\/\/schema.org\/structuralClass",
+    "Name":"https://schema.org/structuralClass",
     "Domain Bucket":"< 1K"
   },
   {
     "Class":"Predicate",
-    "Name":"http:\/\/schema.org\/structuralClass-input",
+    "Name":"https://schema.org/structuralClass-input",
     "Domain Bucket":"< 1K"
   },
   {
     "Class":"Predicate",
-    "Name":"http:\/\/schema.org\/structuralClass-output",
+    "Name":"https://schema.org/structuralClass-output",
     "Domain Bucket":"< 1K"
   },
   {
     "Class":"Predicate",
-    "Name":"http:\/\/schema.org\/study",
+    "Name":"https://schema.org/study",
     "Domain Bucket":"< 1K"
   },
   {
     "Class":"Predicate",
-    "Name":"http:\/\/schema.org\/study-input",
+    "Name":"https://schema.org/study-input",
     "Domain Bucket":"< 1K"
   },
   {
     "Class":"Predicate",
-    "Name":"http:\/\/schema.org\/study-output",
+    "Name":"https://schema.org/study-output",
     "Domain Bucket":"< 1K"
   },
   {
     "Class":"Predicate",
-    "Name":"http:\/\/schema.org\/studyDesign",
+    "Name":"https://schema.org/studyDesign",
     "Domain Bucket":"< 1K"
   },
   {
     "Class":"Predicate",
-    "Name":"http:\/\/schema.org\/studyDesign-input",
+    "Name":"https://schema.org/studyDesign-input",
     "Domain Bucket":"< 1K"
   },
   {
     "Class":"Predicate",
-    "Name":"http:\/\/schema.org\/studyDesign-output",
+    "Name":"https://schema.org/studyDesign-output",
     "Domain Bucket":"< 1K"
   },
   {
     "Class":"Predicate",
-    "Name":"http:\/\/schema.org\/studyLocation",
+    "Name":"https://schema.org/studyLocation",
     "Domain Bucket":"< 1K"
   },
   {
     "Class":"Predicate",
-    "Name":"http:\/\/schema.org\/studyLocation-input",
+    "Name":"https://schema.org/studyLocation-input",
     "Domain Bucket":"< 1K"
   },
   {
     "Class":"Predicate",
-    "Name":"http:\/\/schema.org\/studyLocation-output",
+    "Name":"https://schema.org/studyLocation-output",
     "Domain Bucket":"< 1K"
   },
   {
     "Class":"Predicate",
-    "Name":"http:\/\/schema.org\/studySubject",
+    "Name":"https://schema.org/studySubject",
     "Domain Bucket":"< 1K"
   },
   {
     "Class":"Predicate",
-    "Name":"http:\/\/schema.org\/studySubject-input",
+    "Name":"https://schema.org/studySubject-input",
     "Domain Bucket":"< 1K"
   },
   {
     "Class":"Predicate",
-    "Name":"http:\/\/schema.org\/studySubject-output",
+    "Name":"https://schema.org/studySubject-output",
     "Domain Bucket":"< 1K"
   },
   {
     "Class":"Predicate",
-    "Name":"http:\/\/schema.org\/stupidProperty",
+    "Name":"https://schema.org/stupidProperty",
     "Domain Bucket":"< 1K"
   },
   {
     "Class":"Predicate",
-    "Name":"http:\/\/schema.org\/stupidProperty-input",
+    "Name":"https://schema.org/stupidProperty-input",
     "Domain Bucket":"< 1K"
   },
   {
     "Class":"Predicate",
-    "Name":"http:\/\/schema.org\/stupidProperty-output",
+    "Name":"https://schema.org/stupidProperty-output",
     "Domain Bucket":"< 1K"
   },
   {
     "Class":"Predicate",
-    "Name":"http:\/\/schema.org\/subEvent",
+    "Name":"https://schema.org/subEvent",
     "Domain Bucket":"1K - 10K"
   },
   {
     "Class":"Predicate",
-    "Name":"http:\/\/schema.org\/subEvent-input",
+    "Name":"https://schema.org/subEvent-input",
     "Domain Bucket":"< 1K"
   },
   {
     "Class":"Predicate",
-    "Name":"http:\/\/schema.org\/subEvent-output",
+    "Name":"https://schema.org/subEvent-output",
     "Domain Bucket":"< 1K"
   },
   {
     "Class":"Predicate",
-    "Name":"http:\/\/schema.org\/subEvents",
+    "Name":"https://schema.org/subEvents",
     "Domain Bucket":"< 1K"
   },
   {
     "Class":"Predicate",
-    "Name":"http:\/\/schema.org\/subEvents-input",
+    "Name":"https://schema.org/subEvents-input",
     "Domain Bucket":"< 1K"
   },
   {
     "Class":"Predicate",
-    "Name":"http:\/\/schema.org\/subEvents-output",
+    "Name":"https://schema.org/subEvents-output",
     "Domain Bucket":"< 1K"
   },
   {
     "Class":"Predicate",
-    "Name":"http:\/\/schema.org\/subOrganization",
+    "Name":"https://schema.org/subOrganization",
     "Domain Bucket":"10K - 100K"
   },
   {
     "Class":"Predicate",
-    "Name":"http:\/\/schema.org\/subOrganization-input",
+    "Name":"https://schema.org/subOrganization-input",
     "Domain Bucket":"< 1K"
   },
   {
     "Class":"Predicate",
-    "Name":"http:\/\/schema.org\/subOrganization-output",
+    "Name":"https://schema.org/subOrganization-output",
     "Domain Bucket":"< 1K"
   },
   {
     "Class":"Predicate",
-    "Name":"http:\/\/schema.org\/subReservation",
+    "Name":"https://schema.org/subReservation",
     "Domain Bucket":"< 1K"
   },
   {
     "Class":"Predicate",
-    "Name":"http:\/\/schema.org\/subReservation-input",
+    "Name":"https://schema.org/subReservation-input",
     "Domain Bucket":"< 1K"
   },
   {
     "Class":"Predicate",
-    "Name":"http:\/\/schema.org\/subReservation-output",
+    "Name":"https://schema.org/subReservation-output",
     "Domain Bucket":"< 1K"
   },
   {
     "Class":"Predicate",
-    "Name":"http:\/\/schema.org\/subStageSuffix",
+    "Name":"https://schema.org/subStageSuffix",
     "Domain Bucket":"< 1K"
   },
   {
     "Class":"Predicate",
-    "Name":"http:\/\/schema.org\/subStageSuffix-input",
+    "Name":"https://schema.org/subStageSuffix-input",
     "Domain Bucket":"< 1K"
   },
   {
     "Class":"Predicate",
-    "Name":"http:\/\/schema.org\/subStageSuffix-output",
+    "Name":"https://schema.org/subStageSuffix-output",
     "Domain Bucket":"< 1K"
   },
   {
     "Class":"Predicate",
-    "Name":"http:\/\/schema.org\/subStructure",
+    "Name":"https://schema.org/subStructure",
     "Domain Bucket":"< 1K"
   },
   {
     "Class":"Predicate",
-    "Name":"http:\/\/schema.org\/subStructure-input",
+    "Name":"https://schema.org/subStructure-input",
     "Domain Bucket":"< 1K"
   },
   {
     "Class":"Predicate",
-    "Name":"http:\/\/schema.org\/subStructure-output",
+    "Name":"https://schema.org/subStructure-output",
     "Domain Bucket":"< 1K"
   },
   {
     "Class":"Predicate",
-    "Name":"http:\/\/schema.org\/subTest",
+    "Name":"https://schema.org/subTest",
     "Domain Bucket":"< 1K"
   },
   {
     "Class":"Predicate",
-    "Name":"http:\/\/schema.org\/subTest-input",
+    "Name":"https://schema.org/subTest-input",
     "Domain Bucket":"< 1K"
   },
   {
     "Class":"Predicate",
-    "Name":"http:\/\/schema.org\/subTest-output",
+    "Name":"https://schema.org/subTest-output",
     "Domain Bucket":"< 1K"
   },
   {
     "Class":"Predicate",
-    "Name":"http:\/\/schema.org\/subTrip",
+    "Name":"https://schema.org/subTrip",
     "Domain Bucket":"< 1K"
   },
   {
     "Class":"Predicate",
-    "Name":"http:\/\/schema.org\/subTrip-input",
+    "Name":"https://schema.org/subTrip-input",
     "Domain Bucket":"< 1K"
   },
   {
     "Class":"Predicate",
-    "Name":"http:\/\/schema.org\/subTrip-output",
+    "Name":"https://schema.org/subTrip-output",
     "Domain Bucket":"< 1K"
   },
   {
     "Class":"Predicate",
-    "Name":"http:\/\/schema.org\/subjectOf",
+    "Name":"https://schema.org/subjectOf",
     "Domain Bucket":"100K - 1M"
   },
   {
     "Class":"Predicate",
-    "Name":"http:\/\/schema.org\/subjectOf-input",
+    "Name":"https://schema.org/subjectOf-input",
     "Domain Bucket":"< 1K"
   },
   {
     "Class":"Predicate",
-    "Name":"http:\/\/schema.org\/subjectOf-output",
+    "Name":"https://schema.org/subjectOf-output",
     "Domain Bucket":"< 1K"
   },
   {
     "Class":"Predicate",
-    "Name":"http:\/\/schema.org\/subtitleLanguage",
+    "Name":"https://schema.org/subtitleLanguage",
     "Domain Bucket":"< 1K"
   },
   {
     "Class":"Predicate",
-    "Name":"http:\/\/schema.org\/subtitleLanguage-input",
+    "Name":"https://schema.org/subtitleLanguage-input",
     "Domain Bucket":"< 1K"
   },
   {
     "Class":"Predicate",
-    "Name":"http:\/\/schema.org\/subtitleLanguage-output",
+    "Name":"https://schema.org/subtitleLanguage-output",
     "Domain Bucket":"< 1K"
   },
   {
     "Class":"Predicate",
-    "Name":"http:\/\/schema.org\/successorOf",
+    "Name":"https://schema.org/successorOf",
     "Domain Bucket":"< 1K"
   },
   {
     "Class":"Predicate",
-    "Name":"http:\/\/schema.org\/successorOf-input",
+    "Name":"https://schema.org/successorOf-input",
     "Domain Bucket":"< 1K"
   },
   {
     "Class":"Predicate",
-    "Name":"http:\/\/schema.org\/successorOf-output",
+    "Name":"https://schema.org/successorOf-output",
     "Domain Bucket":"< 1K"
   },
   {
     "Class":"Predicate",
-    "Name":"http:\/\/schema.org\/sugarContent",
+    "Name":"https://schema.org/sugarContent",
     "Domain Bucket":"10K - 100K"
   },
   {
     "Class":"Predicate",
-    "Name":"http:\/\/schema.org\/sugarContent-input",
+    "Name":"https://schema.org/sugarContent-input",
     "Domain Bucket":"< 1K"
   },
   {
     "Class":"Predicate",
-    "Name":"http:\/\/schema.org\/sugarContent-output",
+    "Name":"https://schema.org/sugarContent-output",
     "Domain Bucket":"< 1K"
   },
   {
     "Class":"Predicate",
-    "Name":"http:\/\/schema.org\/suggestedAge",
+    "Name":"https://schema.org/suggestedAge",
     "Domain Bucket":"1K - 10K"
   },
   {
     "Class":"Predicate",
-    "Name":"http:\/\/schema.org\/suggestedAge-input",
+    "Name":"https://schema.org/suggestedAge-input",
     "Domain Bucket":"< 1K"
   },
   {
     "Class":"Predicate",
-    "Name":"http:\/\/schema.org\/suggestedAge-output",
+    "Name":"https://schema.org/suggestedAge-output",
     "Domain Bucket":"< 1K"
   },
   {
     "Class":"Predicate",
-    "Name":"http:\/\/schema.org\/suggestedAnswer",
+    "Name":"https://schema.org/suggestedAnswer",
     "Domain Bucket":"10K - 100K"
   },
   {
     "Class":"Predicate",
-    "Name":"http:\/\/schema.org\/suggestedAnswer-input",
+    "Name":"https://schema.org/suggestedAnswer-input",
     "Domain Bucket":"< 1K"
   },
   {
     "Class":"Predicate",
-    "Name":"http:\/\/schema.org\/suggestedAnswer-output",
+    "Name":"https://schema.org/suggestedAnswer-output",
     "Domain Bucket":"< 1K"
   },
   {
     "Class":"Predicate",
-    "Name":"http:\/\/schema.org\/suggestedGender",
+    "Name":"https://schema.org/suggestedGender",
     "Domain Bucket":"10K - 100K"
   },
   {
     "Class":"Predicate",
-    "Name":"http:\/\/schema.org\/suggestedGender-input",
+    "Name":"https://schema.org/suggestedGender-input",
     "Domain Bucket":"< 1K"
   },
   {
     "Class":"Predicate",
-    "Name":"http:\/\/schema.org\/suggestedGender-output",
+    "Name":"https://schema.org/suggestedGender-output",
     "Domain Bucket":"< 1K"
   },
   {
     "Class":"Predicate",
-    "Name":"http:\/\/schema.org\/suggestedMaxAge",
+    "Name":"https://schema.org/suggestedMaxAge",
     "Domain Bucket":"1K - 10K"
   },
   {
     "Class":"Predicate",
-    "Name":"http:\/\/schema.org\/suggestedMaxAge-input",
+    "Name":"https://schema.org/suggestedMaxAge-input",
     "Domain Bucket":"< 1K"
   },
   {
     "Class":"Predicate",
-    "Name":"http:\/\/schema.org\/suggestedMaxAge-output",
+    "Name":"https://schema.org/suggestedMaxAge-output",
     "Domain Bucket":"< 1K"
   },
   {
     "Class":"Predicate",
-    "Name":"http:\/\/schema.org\/suggestedMeasurement",
+    "Name":"https://schema.org/suggestedMeasurement",
     "Domain Bucket":"< 1K"
   },
   {
     "Class":"Predicate",
-    "Name":"http:\/\/schema.org\/suggestedMeasurement-input",
+    "Name":"https://schema.org/suggestedMeasurement-input",
     "Domain Bucket":"< 1K"
   },
   {
     "Class":"Predicate",
-    "Name":"http:\/\/schema.org\/suggestedMeasurement-output",
+    "Name":"https://schema.org/suggestedMeasurement-output",
     "Domain Bucket":"< 1K"
   },
   {
     "Class":"Predicate",
-    "Name":"http:\/\/schema.org\/suggestedMinAge",
+    "Name":"https://schema.org/suggestedMinAge",
     "Domain Bucket":"10K - 100K"
   },
   {
     "Class":"Predicate",
-    "Name":"http:\/\/schema.org\/suggestedMinAge-input",
+    "Name":"https://schema.org/suggestedMinAge-input",
     "Domain Bucket":"< 1K"
   },
   {
     "Class":"Predicate",
-    "Name":"http:\/\/schema.org\/suggestedMinAge-output",
+    "Name":"https://schema.org/suggestedMinAge-output",
     "Domain Bucket":"< 1K"
   },
   {
     "Class":"Predicate",
-    "Name":"http:\/\/schema.org\/suitableForDiet",
+    "Name":"https://schema.org/suitableForDiet",
     "Domain Bucket":"10K - 100K"
   },
   {
     "Class":"Predicate",
-    "Name":"http:\/\/schema.org\/suitableForDiet-input",
+    "Name":"https://schema.org/suitableForDiet-input",
     "Domain Bucket":"< 1K"
   },
   {
     "Class":"Predicate",
-    "Name":"http:\/\/schema.org\/suitableForDiet-output",
+    "Name":"https://schema.org/suitableForDiet-output",
     "Domain Bucket":"< 1K"
   },
   {
     "Class":"Predicate",
-    "Name":"http:\/\/schema.org\/superEvent",
+    "Name":"https://schema.org/superEvent",
     "Domain Bucket":"1K - 10K"
   },
   {
     "Class":"Predicate",
-    "Name":"http:\/\/schema.org\/superEvent-input",
+    "Name":"https://schema.org/superEvent-input",
     "Domain Bucket":"< 1K"
   },
   {
     "Class":"Predicate",
-    "Name":"http:\/\/schema.org\/superEvent-output",
+    "Name":"https://schema.org/superEvent-output",
     "Domain Bucket":"< 1K"
   },
   {
     "Class":"Predicate",
-    "Name":"http:\/\/schema.org\/supersededBy",
+    "Name":"https://schema.org/supersededBy",
     "Domain Bucket":"1K - 10K"
   },
   {
     "Class":"Predicate",
-    "Name":"http:\/\/schema.org\/supersededBy-input",
+    "Name":"https://schema.org/supersededBy-input",
     "Domain Bucket":"< 1K"
   },
   {
     "Class":"Predicate",
-    "Name":"http:\/\/schema.org\/supersededBy-output",
+    "Name":"https://schema.org/supersededBy-output",
     "Domain Bucket":"< 1K"
   },
   {
     "Class":"Predicate",
-    "Name":"http:\/\/schema.org\/supply",
+    "Name":"https://schema.org/supply",
     "Domain Bucket":"10K - 100K"
   },
   {
     "Class":"Predicate",
-    "Name":"http:\/\/schema.org\/supply-input",
+    "Name":"https://schema.org/supply-input",
     "Domain Bucket":"< 1K"
   },
   {
     "Class":"Predicate",
-    "Name":"http:\/\/schema.org\/supply-output",
+    "Name":"https://schema.org/supply-output",
     "Domain Bucket":"< 1K"
   },
   {
     "Class":"Predicate",
-    "Name":"http:\/\/schema.org\/supplyTo",
+    "Name":"https://schema.org/supplyTo",
     "Domain Bucket":"< 1K"
   },
   {
     "Class":"Predicate",
-    "Name":"http:\/\/schema.org\/supplyTo-input",
+    "Name":"https://schema.org/supplyTo-input",
     "Domain Bucket":"< 1K"
   },
   {
     "Class":"Predicate",
-    "Name":"http:\/\/schema.org\/supplyTo-output",
+    "Name":"https://schema.org/supplyTo-output",
     "Domain Bucket":"< 1K"
   },
   {
     "Class":"Predicate",
-    "Name":"http:\/\/schema.org\/supportingData",
+    "Name":"https://schema.org/supportingData",
     "Domain Bucket":"< 1K"
   },
   {
     "Class":"Predicate",
-    "Name":"http:\/\/schema.org\/supportingData-input",
+    "Name":"https://schema.org/supportingData-input",
     "Domain Bucket":"< 1K"
   },
   {
     "Class":"Predicate",
-    "Name":"http:\/\/schema.org\/supportingData-output",
+    "Name":"https://schema.org/supportingData-output",
     "Domain Bucket":"< 1K"
   },
   {
     "Class":"Predicate",
-    "Name":"http:\/\/schema.org\/surface",
+    "Name":"https://schema.org/surface",
     "Domain Bucket":"< 1K"
   },
   {
     "Class":"Predicate",
-    "Name":"http:\/\/schema.org\/surface-input",
+    "Name":"https://schema.org/surface-input",
     "Domain Bucket":"< 1K"
   },
   {
     "Class":"Predicate",
-    "Name":"http:\/\/schema.org\/surface-output",
+    "Name":"https://schema.org/surface-output",
     "Domain Bucket":"< 1K"
   },
   {
     "Class":"Predicate",
-    "Name":"http:\/\/schema.org\/syllabusSections",
+    "Name":"https://schema.org/syllabusSections",
     "Domain Bucket":"1K - 10K"
   },
   {
     "Class":"Predicate",
-    "Name":"http:\/\/schema.org\/syllabusSections-input",
+    "Name":"https://schema.org/syllabusSections-input",
     "Domain Bucket":"< 1K"
   },
   {
     "Class":"Predicate",
-    "Name":"http:\/\/schema.org\/syllabusSections-output",
+    "Name":"https://schema.org/syllabusSections-output",
     "Domain Bucket":"< 1K"
   },
   {
     "Class":"Predicate",
-    "Name":"http:\/\/schema.org\/target",
+    "Name":"https://schema.org/target",
     "Domain Bucket":"10M+"
   },
   {
     "Class":"Predicate",
-    "Name":"http:\/\/schema.org\/target-input",
+    "Name":"https://schema.org/target-input",
     "Domain Bucket":"< 1K"
   },
   {
     "Class":"Predicate",
-    "Name":"http:\/\/schema.org\/target-output",
+    "Name":"https://schema.org/target-output",
     "Domain Bucket":"< 1K"
   },
   {
     "Class":"Predicate",
-    "Name":"http:\/\/schema.org\/targetCollection",
+    "Name":"https://schema.org/targetCollection",
     "Domain Bucket":"< 1K"
   },
   {
     "Class":"Predicate",
-    "Name":"http:\/\/schema.org\/targetCollection-input",
+    "Name":"https://schema.org/targetCollection-input",
     "Domain Bucket":"< 1K"
   },
   {
     "Class":"Predicate",
-    "Name":"http:\/\/schema.org\/targetCollection-output",
+    "Name":"https://schema.org/targetCollection-output",
     "Domain Bucket":"< 1K"
   },
   {
     "Class":"Predicate",
-    "Name":"http:\/\/schema.org\/targetDescription",
+    "Name":"https://schema.org/targetDescription",
     "Domain Bucket":"< 1K"
   },
   {
     "Class":"Predicate",
-    "Name":"http:\/\/schema.org\/targetDescription-input",
+    "Name":"https://schema.org/targetDescription-input",
     "Domain Bucket":"< 1K"
   },
   {
     "Class":"Predicate",
-    "Name":"http:\/\/schema.org\/targetDescription-output",
+    "Name":"https://schema.org/targetDescription-output",
     "Domain Bucket":"< 1K"
   },
   {
     "Class":"Predicate",
-    "Name":"http:\/\/schema.org\/targetName",
+    "Name":"https://schema.org/targetName",
     "Domain Bucket":"1K - 10K"
   },
   {
     "Class":"Predicate",
-    "Name":"http:\/\/schema.org\/targetName-input",
+    "Name":"https://schema.org/targetName-input",
     "Domain Bucket":"< 1K"
   },
   {
     "Class":"Predicate",
-    "Name":"http:\/\/schema.org\/targetName-output",
+    "Name":"https://schema.org/targetName-output",
     "Domain Bucket":"< 1K"
   },
   {
     "Class":"Predicate",
-    "Name":"http:\/\/schema.org\/targetPlatform",
+    "Name":"https://schema.org/targetPlatform",
     "Domain Bucket":"< 1K"
   },
   {
     "Class":"Predicate",
-    "Name":"http:\/\/schema.org\/targetPlatform-input",
+    "Name":"https://schema.org/targetPlatform-input",
     "Domain Bucket":"< 1K"
   },
   {
     "Class":"Predicate",
-    "Name":"http:\/\/schema.org\/targetPlatform-output",
+    "Name":"https://schema.org/targetPlatform-output",
     "Domain Bucket":"< 1K"
   },
   {
     "Class":"Predicate",
-    "Name":"http:\/\/schema.org\/targetPopulation",
+    "Name":"https://schema.org/targetPopulation",
     "Domain Bucket":"< 1K"
   },
   {
     "Class":"Predicate",
-    "Name":"http:\/\/schema.org\/targetPopulation-input",
+    "Name":"https://schema.org/targetPopulation-input",
     "Domain Bucket":"< 1K"
   },
   {
     "Class":"Predicate",
-    "Name":"http:\/\/schema.org\/targetPopulation-output",
+    "Name":"https://schema.org/targetPopulation-output",
     "Domain Bucket":"< 1K"
   },
   {
     "Class":"Predicate",
-    "Name":"http:\/\/schema.org\/targetProduct",
+    "Name":"https://schema.org/targetProduct",
     "Domain Bucket":"< 1K"
   },
   {
     "Class":"Predicate",
-    "Name":"http:\/\/schema.org\/targetProduct-input",
+    "Name":"https://schema.org/targetProduct-input",
     "Domain Bucket":"< 1K"
   },
   {
     "Class":"Predicate",
-    "Name":"http:\/\/schema.org\/targetProduct-output",
+    "Name":"https://schema.org/targetProduct-output",
     "Domain Bucket":"< 1K"
   },
   {
     "Class":"Predicate",
-    "Name":"http:\/\/schema.org\/targetUrl",
+    "Name":"https://schema.org/targetUrl",
     "Domain Bucket":"< 1K"
   },
   {
     "Class":"Predicate",
-    "Name":"http:\/\/schema.org\/targetUrl-input",
+    "Name":"https://schema.org/targetUrl-input",
     "Domain Bucket":"< 1K"
   },
   {
     "Class":"Predicate",
-    "Name":"http:\/\/schema.org\/targetUrl-output",
+    "Name":"https://schema.org/targetUrl-output",
     "Domain Bucket":"< 1K"
   },
   {
     "Class":"Predicate",
-    "Name":"http:\/\/schema.org\/taxID",
+    "Name":"https://schema.org/taxID",
     "Domain Bucket":"100K - 1M"
   },
   {
     "Class":"Predicate",
-    "Name":"http:\/\/schema.org\/taxID-input",
+    "Name":"https://schema.org/taxID-input",
     "Domain Bucket":"< 1K"
   },
   {
     "Class":"Predicate",
-    "Name":"http:\/\/schema.org\/taxID-output",
+    "Name":"https://schema.org/taxID-output",
     "Domain Bucket":"< 1K"
   },
   {
     "Class":"Predicate",
-    "Name":"http:\/\/schema.org\/taxonRank",
+    "Name":"https://schema.org/taxonRank",
     "Domain Bucket":"< 1K"
   },
   {
     "Class":"Predicate",
-    "Name":"http:\/\/schema.org\/taxonRank-input",
+    "Name":"https://schema.org/taxonRank-input",
     "Domain Bucket":"< 1K"
   },
   {
     "Class":"Predicate",
-    "Name":"http:\/\/schema.org\/taxonRank-output",
+    "Name":"https://schema.org/taxonRank-output",
     "Domain Bucket":"< 1K"
   },
   {
     "Class":"Predicate",
-    "Name":"http:\/\/schema.org\/taxonomicRange",
+    "Name":"https://schema.org/taxonomicRange",
     "Domain Bucket":"< 1K"
   },
   {
     "Class":"Predicate",
-    "Name":"http:\/\/schema.org\/taxonomicRange-input",
+    "Name":"https://schema.org/taxonomicRange-input",
     "Domain Bucket":"< 1K"
   },
   {
     "Class":"Predicate",
-    "Name":"http:\/\/schema.org\/taxonomicRange-output",
+    "Name":"https://schema.org/taxonomicRange-output",
     "Domain Bucket":"< 1K"
   },
   {
     "Class":"Predicate",
-    "Name":"http:\/\/schema.org\/teaches",
+    "Name":"https://schema.org/teaches",
     "Domain Bucket":"10K - 100K"
   },
   {
     "Class":"Predicate",
-    "Name":"http:\/\/schema.org\/teaches-input",
+    "Name":"https://schema.org/teaches-input",
     "Domain Bucket":"< 1K"
   },
   {
     "Class":"Predicate",
-    "Name":"http:\/\/schema.org\/teaches-output",
+    "Name":"https://schema.org/teaches-output",
     "Domain Bucket":"< 1K"
   },
   {
     "Class":"Predicate",
-    "Name":"http:\/\/schema.org\/telephone",
+    "Name":"https://schema.org/telephone",
     "Domain Bucket":"1M - 10M"
   },
   {
     "Class":"Predicate",
-    "Name":"http:\/\/schema.org\/telephone-input",
+    "Name":"https://schema.org/telephone-input",
     "Domain Bucket":"< 1K"
   },
   {
     "Class":"Predicate",
-    "Name":"http:\/\/schema.org\/telephone-output",
+    "Name":"https://schema.org/telephone-output",
     "Domain Bucket":"< 1K"
   },
   {
     "Class":"Predicate",
-    "Name":"http:\/\/schema.org\/temporal",
+    "Name":"https://schema.org/temporal",
     "Domain Bucket":"< 1K"
   },
   {
     "Class":"Predicate",
-    "Name":"http:\/\/schema.org\/temporal-input",
+    "Name":"https://schema.org/temporal-input",
     "Domain Bucket":"< 1K"
   },
   {
     "Class":"Predicate",
-    "Name":"http:\/\/schema.org\/temporal-output",
+    "Name":"https://schema.org/temporal-output",
     "Domain Bucket":"< 1K"
   },
   {
     "Class":"Predicate",
-    "Name":"http:\/\/schema.org\/temporalCoverage",
+    "Name":"https://schema.org/temporalCoverage",
     "Domain Bucket":"10K - 100K"
   },
   {
     "Class":"Predicate",
-    "Name":"http:\/\/schema.org\/temporalCoverage-input",
+    "Name":"https://schema.org/temporalCoverage-input",
     "Domain Bucket":"< 1K"
   },
   {
     "Class":"Predicate",
-    "Name":"http:\/\/schema.org\/temporalCoverage-output",
+    "Name":"https://schema.org/temporalCoverage-output",
     "Domain Bucket":"< 1K"
   },
   {
     "Class":"Predicate",
-    "Name":"http:\/\/schema.org\/termCode",
+    "Name":"https://schema.org/termCode",
     "Domain Bucket":"1K - 10K"
   },
   {
     "Class":"Predicate",
-    "Name":"http:\/\/schema.org\/termCode-input",
+    "Name":"https://schema.org/termCode-input",
     "Domain Bucket":"< 1K"
   },
   {
     "Class":"Predicate",
-    "Name":"http:\/\/schema.org\/termCode-output",
+    "Name":"https://schema.org/termCode-output",
     "Domain Bucket":"< 1K"
   },
   {
     "Class":"Predicate",
-    "Name":"http:\/\/schema.org\/termDuration",
+    "Name":"https://schema.org/termDuration",
     "Domain Bucket":"< 1K"
   },
   {
     "Class":"Predicate",
-    "Name":"http:\/\/schema.org\/termDuration-input",
+    "Name":"https://schema.org/termDuration-input",
     "Domain Bucket":"< 1K"
   },
   {
     "Class":"Predicate",
-    "Name":"http:\/\/schema.org\/termDuration-output",
+    "Name":"https://schema.org/termDuration-output",
     "Domain Bucket":"< 1K"
   },
   {
     "Class":"Predicate",
-    "Name":"http:\/\/schema.org\/termsOfService",
+    "Name":"https://schema.org/termsOfService",
     "Domain Bucket":"10K - 100K"
   },
   {
     "Class":"Predicate",
-    "Name":"http:\/\/schema.org\/termsOfService-input",
+    "Name":"https://schema.org/termsOfService-input",
     "Domain Bucket":"< 1K"
   },
   {
     "Class":"Predicate",
-    "Name":"http:\/\/schema.org\/termsOfService-output",
+    "Name":"https://schema.org/termsOfService-output",
     "Domain Bucket":"< 1K"
   },
   {
     "Class":"Predicate",
-    "Name":"http:\/\/schema.org\/termsPerYear",
+    "Name":"https://schema.org/termsPerYear",
     "Domain Bucket":"< 1K"
   },
   {
     "Class":"Predicate",
-    "Name":"http:\/\/schema.org\/termsPerYear-input",
+    "Name":"https://schema.org/termsPerYear-input",
     "Domain Bucket":"< 1K"
   },
   {
     "Class":"Predicate",
-    "Name":"http:\/\/schema.org\/termsPerYear-output",
+    "Name":"https://schema.org/termsPerYear-output",
     "Domain Bucket":"< 1K"
   },
   {
     "Class":"Predicate",
-    "Name":"http:\/\/schema.org\/text",
+    "Name":"https://schema.org/text",
     "Domain Bucket":"1M - 10M"
   },
   {
     "Class":"Predicate",
-    "Name":"http:\/\/schema.org\/text-input",
+    "Name":"https://schema.org/text-input",
     "Domain Bucket":"< 1K"
   },
   {
     "Class":"Predicate",
-    "Name":"http:\/\/schema.org\/text-output",
+    "Name":"https://schema.org/text-output",
     "Domain Bucket":"< 1K"
   },
   {
     "Class":"Predicate",
-    "Name":"http:\/\/schema.org\/textValue",
+    "Name":"https://schema.org/textValue",
     "Domain Bucket":"< 1K"
   },
   {
     "Class":"Predicate",
-    "Name":"http:\/\/schema.org\/textValue-input",
+    "Name":"https://schema.org/textValue-input",
     "Domain Bucket":"< 1K"
   },
   {
     "Class":"Predicate",
-    "Name":"http:\/\/schema.org\/textValue-output",
+    "Name":"https://schema.org/textValue-output",
     "Domain Bucket":"< 1K"
   },
   {
     "Class":"Predicate",
-    "Name":"http:\/\/schema.org\/thumbnail",
+    "Name":"https://schema.org/thumbnail",
     "Domain Bucket":"100K - 1M"
   },
   {
     "Class":"Predicate",
-    "Name":"http:\/\/schema.org\/thumbnail-input",
+    "Name":"https://schema.org/thumbnail-input",
     "Domain Bucket":"< 1K"
   },
   {
     "Class":"Predicate",
-    "Name":"http:\/\/schema.org\/thumbnail-output",
+    "Name":"https://schema.org/thumbnail-output",
     "Domain Bucket":"< 1K"
   },
   {
     "Class":"Predicate",
-    "Name":"http:\/\/schema.org\/thumbnailUrl",
+    "Name":"https://schema.org/thumbnailUrl",
     "Domain Bucket":"10M+"
   },
   {
     "Class":"Predicate",
-    "Name":"http:\/\/schema.org\/thumbnailUrl-input",
+    "Name":"https://schema.org/thumbnailUrl-input",
     "Domain Bucket":"< 1K"
   },
   {
     "Class":"Predicate",
-    "Name":"http:\/\/schema.org\/thumbnailUrl-output",
+    "Name":"https://schema.org/thumbnailUrl-output",
     "Domain Bucket":"< 1K"
   },
   {
     "Class":"Predicate",
-    "Name":"http:\/\/schema.org\/tickerSymbol",
+    "Name":"https://schema.org/tickerSymbol",
     "Domain Bucket":"1K - 10K"
   },
   {
     "Class":"Predicate",
-    "Name":"http:\/\/schema.org\/tickerSymbol-input",
+    "Name":"https://schema.org/tickerSymbol-input",
     "Domain Bucket":"< 1K"
   },
   {
     "Class":"Predicate",
-    "Name":"http:\/\/schema.org\/tickerSymbol-output",
+    "Name":"https://schema.org/tickerSymbol-output",
     "Domain Bucket":"< 1K"
   },
   {
     "Class":"Predicate",
-    "Name":"http:\/\/schema.org\/ticketNumber",
+    "Name":"https://schema.org/ticketNumber",
     "Domain Bucket":"< 1K"
   },
   {
     "Class":"Predicate",
-    "Name":"http:\/\/schema.org\/ticketNumber-input",
+    "Name":"https://schema.org/ticketNumber-input",
     "Domain Bucket":"< 1K"
   },
   {
     "Class":"Predicate",
-    "Name":"http:\/\/schema.org\/ticketNumber-output",
+    "Name":"https://schema.org/ticketNumber-output",
     "Domain Bucket":"< 1K"
   },
   {
     "Class":"Predicate",
-    "Name":"http:\/\/schema.org\/ticketToken",
+    "Name":"https://schema.org/ticketToken",
     "Domain Bucket":"< 1K"
   },
   {
     "Class":"Predicate",
-    "Name":"http:\/\/schema.org\/ticketToken-input",
+    "Name":"https://schema.org/ticketToken-input",
     "Domain Bucket":"< 1K"
   },
   {
     "Class":"Predicate",
-    "Name":"http:\/\/schema.org\/ticketToken-output",
+    "Name":"https://schema.org/ticketToken-output",
     "Domain Bucket":"< 1K"
   },
   {
     "Class":"Predicate",
-    "Name":"http:\/\/schema.org\/ticketedSeat",
+    "Name":"https://schema.org/ticketedSeat",
     "Domain Bucket":"< 1K"
   },
   {
     "Class":"Predicate",
-    "Name":"http:\/\/schema.org\/ticketedSeat-input",
+    "Name":"https://schema.org/ticketedSeat-input",
     "Domain Bucket":"< 1K"
   },
   {
     "Class":"Predicate",
-    "Name":"http:\/\/schema.org\/ticketedSeat-output",
+    "Name":"https://schema.org/ticketedSeat-output",
     "Domain Bucket":"< 1K"
   },
   {
     "Class":"Predicate",
-    "Name":"http:\/\/schema.org\/timeOfDay",
+    "Name":"https://schema.org/timeOfDay",
     "Domain Bucket":"< 1K"
   },
   {
     "Class":"Predicate",
-    "Name":"http:\/\/schema.org\/timeOfDay-input",
+    "Name":"https://schema.org/timeOfDay-input",
     "Domain Bucket":"< 1K"
   },
   {
     "Class":"Predicate",
-    "Name":"http:\/\/schema.org\/timeOfDay-output",
+    "Name":"https://schema.org/timeOfDay-output",
     "Domain Bucket":"< 1K"
   },
   {
     "Class":"Predicate",
-    "Name":"http:\/\/schema.org\/timeRequired",
+    "Name":"https://schema.org/timeRequired",
     "Domain Bucket":"100K - 1M"
   },
   {
     "Class":"Predicate",
-    "Name":"http:\/\/schema.org\/timeRequired-input",
+    "Name":"https://schema.org/timeRequired-input",
     "Domain Bucket":"< 1K"
   },
   {
     "Class":"Predicate",
-    "Name":"http:\/\/schema.org\/timeRequired-output",
+    "Name":"https://schema.org/timeRequired-output",
     "Domain Bucket":"< 1K"
   },
   {
     "Class":"Predicate",
-    "Name":"http:\/\/schema.org\/timeToComplete",
+    "Name":"https://schema.org/timeToComplete",
     "Domain Bucket":"1K - 10K"
   },
   {
     "Class":"Predicate",
-    "Name":"http:\/\/schema.org\/timeToComplete-input",
+    "Name":"https://schema.org/timeToComplete-input",
     "Domain Bucket":"< 1K"
   },
   {
     "Class":"Predicate",
-    "Name":"http:\/\/schema.org\/timeToComplete-output",
+    "Name":"https://schema.org/timeToComplete-output",
     "Domain Bucket":"< 1K"
   },
   {
     "Class":"Predicate",
-    "Name":"http:\/\/schema.org\/timestamp",
+    "Name":"https://schema.org/timestamp",
     "Domain Bucket":"1K - 10K"
   },
   {
     "Class":"Predicate",
-    "Name":"http:\/\/schema.org\/timestamp-input",
+    "Name":"https://schema.org/timestamp-input",
     "Domain Bucket":"< 1K"
   },
   {
     "Class":"Predicate",
-    "Name":"http:\/\/schema.org\/timestamp-output",
+    "Name":"https://schema.org/timestamp-output",
     "Domain Bucket":"< 1K"
   },
   {
     "Class":"Predicate",
-    "Name":"http:\/\/schema.org\/tissueSample",
+    "Name":"https://schema.org/tissueSample",
     "Domain Bucket":"< 1K"
   },
   {
     "Class":"Predicate",
-    "Name":"http:\/\/schema.org\/tissueSample-input",
+    "Name":"https://schema.org/tissueSample-input",
     "Domain Bucket":"< 1K"
   },
   {
     "Class":"Predicate",
-    "Name":"http:\/\/schema.org\/tissueSample-output",
+    "Name":"https://schema.org/tissueSample-output",
     "Domain Bucket":"< 1K"
   },
   {
     "Class":"Predicate",
-    "Name":"http:\/\/schema.org\/title",
+    "Name":"https://schema.org/title",
     "Domain Bucket":"100K - 1M"
   },
   {
     "Class":"Predicate",
-    "Name":"http:\/\/schema.org\/title-input",
+    "Name":"https://schema.org/title-input",
     "Domain Bucket":"< 1K"
   },
   {
     "Class":"Predicate",
-    "Name":"http:\/\/schema.org\/title-output",
+    "Name":"https://schema.org/title-output",
     "Domain Bucket":"< 1K"
   },
   {
     "Class":"Predicate",
-    "Name":"http:\/\/schema.org\/titleEIDR",
+    "Name":"https://schema.org/titleEIDR",
     "Domain Bucket":"< 1K"
   },
   {
     "Class":"Predicate",
-    "Name":"http:\/\/schema.org\/titleEIDR-input",
+    "Name":"https://schema.org/titleEIDR-input",
     "Domain Bucket":"< 1K"
   },
   {
     "Class":"Predicate",
-    "Name":"http:\/\/schema.org\/titleEIDR-output",
+    "Name":"https://schema.org/titleEIDR-output",
     "Domain Bucket":"< 1K"
   },
   {
     "Class":"Predicate",
-    "Name":"http:\/\/schema.org\/toLocation",
+    "Name":"https://schema.org/toLocation",
     "Domain Bucket":"1K - 10K"
   },
   {
     "Class":"Predicate",
-    "Name":"http:\/\/schema.org\/toLocation-input",
+    "Name":"https://schema.org/toLocation-input",
     "Domain Bucket":"< 1K"
   },
   {
     "Class":"Predicate",
-    "Name":"http:\/\/schema.org\/toLocation-output",
+    "Name":"https://schema.org/toLocation-output",
     "Domain Bucket":"< 1K"
   },
   {
     "Class":"Predicate",
-    "Name":"http:\/\/schema.org\/toRecipient",
+    "Name":"https://schema.org/toRecipient",
     "Domain Bucket":"< 1K"
   },
   {
     "Class":"Predicate",
-    "Name":"http:\/\/schema.org\/toRecipient-input",
+    "Name":"https://schema.org/toRecipient-input",
     "Domain Bucket":"< 1K"
   },
   {
     "Class":"Predicate",
-    "Name":"http:\/\/schema.org\/toRecipient-output",
+    "Name":"https://schema.org/toRecipient-output",
     "Domain Bucket":"< 1K"
   },
   {
     "Class":"Predicate",
-    "Name":"http:\/\/schema.org\/tocContinuation",
+    "Name":"https://schema.org/tocContinuation",
     "Domain Bucket":"< 1K"
   },
   {
     "Class":"Predicate",
-    "Name":"http:\/\/schema.org\/tocContinuation-input",
+    "Name":"https://schema.org/tocContinuation-input",
     "Domain Bucket":"< 1K"
   },
   {
     "Class":"Predicate",
-    "Name":"http:\/\/schema.org\/tocContinuation-output",
+    "Name":"https://schema.org/tocContinuation-output",
     "Domain Bucket":"< 1K"
   },
   {
     "Class":"Predicate",
-    "Name":"http:\/\/schema.org\/tocEntry",
+    "Name":"https://schema.org/tocEntry",
     "Domain Bucket":"< 1K"
   },
   {
     "Class":"Predicate",
-    "Name":"http:\/\/schema.org\/tocEntry-input",
+    "Name":"https://schema.org/tocEntry-input",
     "Domain Bucket":"< 1K"
   },
   {
     "Class":"Predicate",
-    "Name":"http:\/\/schema.org\/tocEntry-output",
+    "Name":"https://schema.org/tocEntry-output",
     "Domain Bucket":"< 1K"
   },
   {
     "Class":"Predicate",
-    "Name":"http:\/\/schema.org\/tongueWeight",
+    "Name":"https://schema.org/tongueWeight",
     "Domain Bucket":"< 1K"
   },
   {
     "Class":"Predicate",
-    "Name":"http:\/\/schema.org\/tongueWeight-input",
+    "Name":"https://schema.org/tongueWeight-input",
     "Domain Bucket":"< 1K"
   },
   {
     "Class":"Predicate",
-    "Name":"http:\/\/schema.org\/tongueWeight-output",
+    "Name":"https://schema.org/tongueWeight-output",
     "Domain Bucket":"< 1K"
   },
   {
     "Class":"Predicate",
-    "Name":"http:\/\/schema.org\/tool",
+    "Name":"https://schema.org/tool",
     "Domain Bucket":"10K - 100K"
   },
   {
     "Class":"Predicate",
-    "Name":"http:\/\/schema.org\/tool-input",
+    "Name":"https://schema.org/tool-input",
     "Domain Bucket":"< 1K"
   },
   {
     "Class":"Predicate",
-    "Name":"http:\/\/schema.org\/tool-output",
+    "Name":"https://schema.org/tool-output",
     "Domain Bucket":"< 1K"
   },
   {
     "Class":"Predicate",
-    "Name":"http:\/\/schema.org\/torque",
+    "Name":"https://schema.org/torque",
     "Domain Bucket":"1K - 10K"
   },
   {
     "Class":"Predicate",
-    "Name":"http:\/\/schema.org\/torque-input",
+    "Name":"https://schema.org/torque-input",
     "Domain Bucket":"< 1K"
   },
   {
     "Class":"Predicate",
-    "Name":"http:\/\/schema.org\/torque-output",
+    "Name":"https://schema.org/torque-output",
     "Domain Bucket":"< 1K"
   },
   {
     "Class":"Predicate",
-    "Name":"http:\/\/schema.org\/totalHistoricalEnrollment",
+    "Name":"https://schema.org/totalHistoricalEnrollment",
     "Domain Bucket":"< 1K"
   },
   {
     "Class":"Predicate",
-    "Name":"http:\/\/schema.org\/totalHistoricalEnrollment-input",
+    "Name":"https://schema.org/totalHistoricalEnrollment-input",
     "Domain Bucket":"< 1K"
   },
   {
     "Class":"Predicate",
-    "Name":"http:\/\/schema.org\/totalHistoricalEnrollment-output",
+    "Name":"https://schema.org/totalHistoricalEnrollment-output",
     "Domain Bucket":"< 1K"
   },
   {
     "Class":"Predicate",
-    "Name":"http:\/\/schema.org\/totalJobOpenings",
+    "Name":"https://schema.org/totalJobOpenings",
     "Domain Bucket":"< 1K"
   },
   {
     "Class":"Predicate",
-    "Name":"http:\/\/schema.org\/totalJobOpenings-input",
+    "Name":"https://schema.org/totalJobOpenings-input",
     "Domain Bucket":"< 1K"
   },
   {
     "Class":"Predicate",
-    "Name":"http:\/\/schema.org\/totalJobOpenings-output",
+    "Name":"https://schema.org/totalJobOpenings-output",
     "Domain Bucket":"< 1K"
   },
   {
     "Class":"Predicate",
-    "Name":"http:\/\/schema.org\/totalPaymentDue",
+    "Name":"https://schema.org/totalPaymentDue",
     "Domain Bucket":"< 1K"
   },
   {
     "Class":"Predicate",
-    "Name":"http:\/\/schema.org\/totalPaymentDue-input",
+    "Name":"https://schema.org/totalPaymentDue-input",
     "Domain Bucket":"< 1K"
   },
   {
     "Class":"Predicate",
-    "Name":"http:\/\/schema.org\/totalPaymentDue-output",
+    "Name":"https://schema.org/totalPaymentDue-output",
     "Domain Bucket":"< 1K"
   },
   {
     "Class":"Predicate",
-    "Name":"http:\/\/schema.org\/totalPrice",
+    "Name":"https://schema.org/totalPrice",
     "Domain Bucket":"< 1K"
   },
   {
     "Class":"Predicate",
-    "Name":"http:\/\/schema.org\/totalPrice-input",
+    "Name":"https://schema.org/totalPrice-input",
     "Domain Bucket":"< 1K"
   },
   {
     "Class":"Predicate",
-    "Name":"http:\/\/schema.org\/totalPrice-output",
+    "Name":"https://schema.org/totalPrice-output",
     "Domain Bucket":"< 1K"
   },
   {
     "Class":"Predicate",
-    "Name":"http:\/\/schema.org\/totalTime",
+    "Name":"https://schema.org/totalTime",
     "Domain Bucket":"100K - 1M"
   },
   {
     "Class":"Predicate",
-    "Name":"http:\/\/schema.org\/totalTime-input",
+    "Name":"https://schema.org/totalTime-input",
     "Domain Bucket":"< 1K"
   },
   {
     "Class":"Predicate",
-    "Name":"http:\/\/schema.org\/totalTime-output",
+    "Name":"https://schema.org/totalTime-output",
     "Domain Bucket":"< 1K"
   },
   {
     "Class":"Predicate",
-    "Name":"http:\/\/schema.org\/tourBookingPage",
+    "Name":"https://schema.org/tourBookingPage",
     "Domain Bucket":"10K - 100K"
   },
   {
     "Class":"Predicate",
-    "Name":"http:\/\/schema.org\/tourBookingPage-input",
+    "Name":"https://schema.org/tourBookingPage-input",
     "Domain Bucket":"< 1K"
   },
   {
     "Class":"Predicate",
-    "Name":"http:\/\/schema.org\/tourBookingPage-output",
+    "Name":"https://schema.org/tourBookingPage-output",
     "Domain Bucket":"< 1K"
   },
   {
     "Class":"Predicate",
-    "Name":"http:\/\/schema.org\/touristType",
+    "Name":"https://schema.org/touristType",
     "Domain Bucket":"10K - 100K"
   },
   {
     "Class":"Predicate",
-    "Name":"http:\/\/schema.org\/touristType-input",
+    "Name":"https://schema.org/touristType-input",
     "Domain Bucket":"< 1K"
   },
   {
     "Class":"Predicate",
-    "Name":"http:\/\/schema.org\/touristType-output",
+    "Name":"https://schema.org/touristType-output",
     "Domain Bucket":"< 1K"
   },
   {
     "Class":"Predicate",
-    "Name":"http:\/\/schema.org\/track",
+    "Name":"https://schema.org/track",
     "Domain Bucket":"10K - 100K"
   },
   {
     "Class":"Predicate",
-    "Name":"http:\/\/schema.org\/track-input",
+    "Name":"https://schema.org/track-input",
     "Domain Bucket":"< 1K"
   },
   {
     "Class":"Predicate",
-    "Name":"http:\/\/schema.org\/track-output",
+    "Name":"https://schema.org/track-output",
     "Domain Bucket":"< 1K"
   },
   {
     "Class":"Predicate",
-    "Name":"http:\/\/schema.org\/trackingNumber",
+    "Name":"https://schema.org/trackingNumber",
     "Domain Bucket":"< 1K"
   },
   {
     "Class":"Predicate",
-    "Name":"http:\/\/schema.org\/trackingNumber-input",
+    "Name":"https://schema.org/trackingNumber-input",
     "Domain Bucket":"< 1K"
   },
   {
     "Class":"Predicate",
-    "Name":"http:\/\/schema.org\/trackingNumber-output",
+    "Name":"https://schema.org/trackingNumber-output",
     "Domain Bucket":"< 1K"
   },
   {
     "Class":"Predicate",
-    "Name":"http:\/\/schema.org\/trackingUrl",
+    "Name":"https://schema.org/trackingUrl",
     "Domain Bucket":"< 1K"
   },
   {
     "Class":"Predicate",
-    "Name":"http:\/\/schema.org\/trackingUrl-input",
+    "Name":"https://schema.org/trackingUrl-input",
     "Domain Bucket":"< 1K"
   },
   {
     "Class":"Predicate",
-    "Name":"http:\/\/schema.org\/trackingUrl-output",
+    "Name":"https://schema.org/trackingUrl-output",
     "Domain Bucket":"< 1K"
   },
   {
     "Class":"Predicate",
-    "Name":"http:\/\/schema.org\/tracks",
+    "Name":"https://schema.org/tracks",
     "Domain Bucket":"< 1K"
   },
   {
     "Class":"Predicate",
-    "Name":"http:\/\/schema.org\/tracks-input",
+    "Name":"https://schema.org/tracks-input",
     "Domain Bucket":"< 1K"
   },
   {
     "Class":"Predicate",
-    "Name":"http:\/\/schema.org\/tracks-output",
+    "Name":"https://schema.org/tracks-output",
     "Domain Bucket":"< 1K"
   },
   {
     "Class":"Predicate",
-    "Name":"http:\/\/schema.org\/trailer",
+    "Name":"https://schema.org/trailer",
     "Domain Bucket":"1K - 10K"
   },
   {
     "Class":"Predicate",
-    "Name":"http:\/\/schema.org\/trailer-input",
+    "Name":"https://schema.org/trailer-input",
     "Domain Bucket":"< 1K"
   },
   {
     "Class":"Predicate",
-    "Name":"http:\/\/schema.org\/trailer-output",
+    "Name":"https://schema.org/trailer-output",
     "Domain Bucket":"< 1K"
   },
   {
     "Class":"Predicate",
-    "Name":"http:\/\/schema.org\/trailerWeight",
+    "Name":"https://schema.org/trailerWeight",
     "Domain Bucket":"< 1K"
   },
   {
     "Class":"Predicate",
-    "Name":"http:\/\/schema.org\/trailerWeight-input",
+    "Name":"https://schema.org/trailerWeight-input",
     "Domain Bucket":"< 1K"
   },
   {
     "Class":"Predicate",
-    "Name":"http:\/\/schema.org\/trailerWeight-output",
+    "Name":"https://schema.org/trailerWeight-output",
     "Domain Bucket":"< 1K"
   },
   {
     "Class":"Predicate",
-    "Name":"http:\/\/schema.org\/trainName",
+    "Name":"https://schema.org/trainName",
     "Domain Bucket":"< 1K"
   },
   {
     "Class":"Predicate",
-    "Name":"http:\/\/schema.org\/trainName-input",
+    "Name":"https://schema.org/trainName-input",
     "Domain Bucket":"< 1K"
   },
   {
     "Class":"Predicate",
-    "Name":"http:\/\/schema.org\/trainName-output",
+    "Name":"https://schema.org/trainName-output",
     "Domain Bucket":"< 1K"
   },
   {
     "Class":"Predicate",
-    "Name":"http:\/\/schema.org\/trainNumber",
+    "Name":"https://schema.org/trainNumber",
     "Domain Bucket":"< 1K"
   },
   {
     "Class":"Predicate",
-    "Name":"http:\/\/schema.org\/trainNumber-input",
+    "Name":"https://schema.org/trainNumber-input",
     "Domain Bucket":"< 1K"
   },
   {
     "Class":"Predicate",
-    "Name":"http:\/\/schema.org\/trainNumber-output",
+    "Name":"https://schema.org/trainNumber-output",
     "Domain Bucket":"< 1K"
   },
   {
     "Class":"Predicate",
-    "Name":"http:\/\/schema.org\/trainingSalary",
+    "Name":"https://schema.org/trainingSalary",
     "Domain Bucket":"< 1K"
   },
   {
     "Class":"Predicate",
-    "Name":"http:\/\/schema.org\/trainingSalary-input",
+    "Name":"https://schema.org/trainingSalary-input",
     "Domain Bucket":"< 1K"
   },
   {
     "Class":"Predicate",
-    "Name":"http:\/\/schema.org\/trainingSalary-output",
+    "Name":"https://schema.org/trainingSalary-output",
     "Domain Bucket":"< 1K"
   },
   {
     "Class":"Predicate",
-    "Name":"http:\/\/schema.org\/transFatContent",
+    "Name":"https://schema.org/transFatContent",
     "Domain Bucket":"10K - 100K"
   },
   {
     "Class":"Predicate",
-    "Name":"http:\/\/schema.org\/transFatContent-input",
+    "Name":"https://schema.org/transFatContent-input",
     "Domain Bucket":"< 1K"
   },
   {
     "Class":"Predicate",
-    "Name":"http:\/\/schema.org\/transFatContent-output",
+    "Name":"https://schema.org/transFatContent-output",
     "Domain Bucket":"< 1K"
   },
   {
     "Class":"Predicate",
-    "Name":"http:\/\/schema.org\/transcript",
+    "Name":"https://schema.org/transcript",
     "Domain Bucket":"10K - 100K"
   },
   {
     "Class":"Predicate",
-    "Name":"http:\/\/schema.org\/transcript-input",
+    "Name":"https://schema.org/transcript-input",
     "Domain Bucket":"< 1K"
   },
   {
     "Class":"Predicate",
-    "Name":"http:\/\/schema.org\/transcript-output",
+    "Name":"https://schema.org/transcript-output",
     "Domain Bucket":"< 1K"
   },
   {
     "Class":"Predicate",
-    "Name":"http:\/\/schema.org\/transitTime",
+    "Name":"https://schema.org/transitTime",
     "Domain Bucket":"100K - 1M"
   },
   {
     "Class":"Predicate",
-    "Name":"http:\/\/schema.org\/transitTime-input",
+    "Name":"https://schema.org/transitTime-input",
     "Domain Bucket":"< 1K"
   },
   {
     "Class":"Predicate",
-    "Name":"http:\/\/schema.org\/transitTime-output",
+    "Name":"https://schema.org/transitTime-output",
     "Domain Bucket":"< 1K"
   },
   {
     "Class":"Predicate",
-    "Name":"http:\/\/schema.org\/transitTimeLabel",
+    "Name":"https://schema.org/transitTimeLabel",
     "Domain Bucket":"< 1K"
   },
   {
     "Class":"Predicate",
-    "Name":"http:\/\/schema.org\/transitTimeLabel-input",
+    "Name":"https://schema.org/transitTimeLabel-input",
     "Domain Bucket":"< 1K"
   },
   {
     "Class":"Predicate",
-    "Name":"http:\/\/schema.org\/transitTimeLabel-output",
+    "Name":"https://schema.org/transitTimeLabel-output",
     "Domain Bucket":"< 1K"
   },
   {
     "Class":"Predicate",
-    "Name":"http:\/\/schema.org\/translationOfWork",
+    "Name":"https://schema.org/translationOfWork",
     "Domain Bucket":"1K - 10K"
   },
   {
     "Class":"Predicate",
-    "Name":"http:\/\/schema.org\/translationOfWork-input",
+    "Name":"https://schema.org/translationOfWork-input",
     "Domain Bucket":"< 1K"
   },
   {
     "Class":"Predicate",
-    "Name":"http:\/\/schema.org\/translationOfWork-output",
+    "Name":"https://schema.org/translationOfWork-output",
     "Domain Bucket":"< 1K"
   },
   {
     "Class":"Predicate",
-    "Name":"http:\/\/schema.org\/translator",
+    "Name":"https://schema.org/translator",
     "Domain Bucket":"1K - 10K"
   },
   {
     "Class":"Predicate",
-    "Name":"http:\/\/schema.org\/translator-input",
+    "Name":"https://schema.org/translator-input",
     "Domain Bucket":"< 1K"
   },
   {
     "Class":"Predicate",
-    "Name":"http:\/\/schema.org\/translator-output",
+    "Name":"https://schema.org/translator-output",
     "Domain Bucket":"< 1K"
   },
   {
     "Class":"Predicate",
-    "Name":"http:\/\/schema.org\/transmissionMethod",
+    "Name":"https://schema.org/transmissionMethod",
     "Domain Bucket":"< 1K"
   },
   {
     "Class":"Predicate",
-    "Name":"http:\/\/schema.org\/transmissionMethod-input",
+    "Name":"https://schema.org/transmissionMethod-input",
     "Domain Bucket":"< 1K"
   },
   {
     "Class":"Predicate",
-    "Name":"http:\/\/schema.org\/transmissionMethod-output",
+    "Name":"https://schema.org/transmissionMethod-output",
     "Domain Bucket":"< 1K"
   },
   {
     "Class":"Predicate",
-    "Name":"http:\/\/schema.org\/travelBans",
+    "Name":"https://schema.org/travelBans",
     "Domain Bucket":"< 1K"
   },
   {
     "Class":"Predicate",
-    "Name":"http:\/\/schema.org\/travelBans-input",
+    "Name":"https://schema.org/travelBans-input",
     "Domain Bucket":"< 1K"
   },
   {
     "Class":"Predicate",
-    "Name":"http:\/\/schema.org\/travelBans-output",
+    "Name":"https://schema.org/travelBans-output",
     "Domain Bucket":"< 1K"
   },
   {
     "Class":"Predicate",
-    "Name":"http:\/\/schema.org\/trialDesign",
+    "Name":"https://schema.org/trialDesign",
     "Domain Bucket":"< 1K"
   },
   {
     "Class":"Predicate",
-    "Name":"http:\/\/schema.org\/trialDesign-input",
+    "Name":"https://schema.org/trialDesign-input",
     "Domain Bucket":"< 1K"
   },
   {
     "Class":"Predicate",
-    "Name":"http:\/\/schema.org\/trialDesign-output",
+    "Name":"https://schema.org/trialDesign-output",
     "Domain Bucket":"< 1K"
   },
   {
     "Class":"Predicate",
-    "Name":"http:\/\/schema.org\/tributary",
+    "Name":"https://schema.org/tributary",
     "Domain Bucket":"< 1K"
   },
   {
     "Class":"Predicate",
-    "Name":"http:\/\/schema.org\/tributary-input",
+    "Name":"https://schema.org/tributary-input",
     "Domain Bucket":"< 1K"
   },
   {
     "Class":"Predicate",
-    "Name":"http:\/\/schema.org\/tributary-output",
+    "Name":"https://schema.org/tributary-output",
     "Domain Bucket":"< 1K"
   },
   {
     "Class":"Predicate",
-    "Name":"http:\/\/schema.org\/tripOrigin",
+    "Name":"https://schema.org/tripOrigin",
     "Domain Bucket":"< 1K"
   },
   {
     "Class":"Predicate",
-    "Name":"http:\/\/schema.org\/tripOrigin-input",
+    "Name":"https://schema.org/tripOrigin-input",
     "Domain Bucket":"< 1K"
   },
   {
     "Class":"Predicate",
-    "Name":"http:\/\/schema.org\/tripOrigin-output",
+    "Name":"https://schema.org/tripOrigin-output",
     "Domain Bucket":"< 1K"
   },
   {
     "Class":"Predicate",
-    "Name":"http:\/\/schema.org\/typeOfBed",
+    "Name":"https://schema.org/typeOfBed",
     "Domain Bucket":"10K - 100K"
   },
   {
     "Class":"Predicate",
-    "Name":"http:\/\/schema.org\/typeOfBed-input",
+    "Name":"https://schema.org/typeOfBed-input",
     "Domain Bucket":"< 1K"
   },
   {
     "Class":"Predicate",
-    "Name":"http:\/\/schema.org\/typeOfBed-output",
+    "Name":"https://schema.org/typeOfBed-output",
     "Domain Bucket":"< 1K"
   },
   {
     "Class":"Predicate",
-    "Name":"http:\/\/schema.org\/typeOfGood",
+    "Name":"https://schema.org/typeOfGood",
     "Domain Bucket":"< 1K"
   },
   {
     "Class":"Predicate",
-    "Name":"http:\/\/schema.org\/typeOfGood-input",
+    "Name":"https://schema.org/typeOfGood-input",
     "Domain Bucket":"< 1K"
   },
   {
     "Class":"Predicate",
-    "Name":"http:\/\/schema.org\/typeOfGood-output",
+    "Name":"https://schema.org/typeOfGood-output",
     "Domain Bucket":"< 1K"
   },
   {
     "Class":"Predicate",
-    "Name":"http:\/\/schema.org\/typicalAgeRange",
+    "Name":"https://schema.org/typicalAgeRange",
     "Domain Bucket":"10K - 100K"
   },
   {
     "Class":"Predicate",
-    "Name":"http:\/\/schema.org\/typicalAgeRange-input",
+    "Name":"https://schema.org/typicalAgeRange-input",
     "Domain Bucket":"< 1K"
   },
   {
     "Class":"Predicate",
-    "Name":"http:\/\/schema.org\/typicalAgeRange-output",
+    "Name":"https://schema.org/typicalAgeRange-output",
     "Domain Bucket":"< 1K"
   },
   {
     "Class":"Predicate",
-    "Name":"http:\/\/schema.org\/typicalCreditsPerTerm",
+    "Name":"https://schema.org/typicalCreditsPerTerm",
     "Domain Bucket":"< 1K"
   },
   {
     "Class":"Predicate",
-    "Name":"http:\/\/schema.org\/typicalCreditsPerTerm-input",
+    "Name":"https://schema.org/typicalCreditsPerTerm-input",
     "Domain Bucket":"< 1K"
   },
   {
     "Class":"Predicate",
-    "Name":"http:\/\/schema.org\/typicalCreditsPerTerm-output",
+    "Name":"https://schema.org/typicalCreditsPerTerm-output",
     "Domain Bucket":"< 1K"
   },
   {
     "Class":"Predicate",
-    "Name":"http:\/\/schema.org\/typicalTest",
+    "Name":"https://schema.org/typicalTest",
     "Domain Bucket":"1K - 10K"
   },
   {
     "Class":"Predicate",
-    "Name":"http:\/\/schema.org\/typicalTest-input",
+    "Name":"https://schema.org/typicalTest-input",
     "Domain Bucket":"< 1K"
   },
   {
     "Class":"Predicate",
-    "Name":"http:\/\/schema.org\/typicalTest-output",
+    "Name":"https://schema.org/typicalTest-output",
     "Domain Bucket":"< 1K"
   },
   {
     "Class":"Predicate",
-    "Name":"http:\/\/schema.org\/underName",
+    "Name":"https://schema.org/underName",
     "Domain Bucket":"< 1K"
   },
   {
     "Class":"Predicate",
-    "Name":"http:\/\/schema.org\/underName-input",
+    "Name":"https://schema.org/underName-input",
     "Domain Bucket":"< 1K"
   },
   {
     "Class":"Predicate",
-    "Name":"http:\/\/schema.org\/underName-output",
+    "Name":"https://schema.org/underName-output",
     "Domain Bucket":"< 1K"
   },
   {
     "Class":"Predicate",
-    "Name":"http:\/\/schema.org\/unitCode",
+    "Name":"https://schema.org/unitCode",
     "Domain Bucket":"1M - 10M"
   },
   {
     "Class":"Predicate",
-    "Name":"http:\/\/schema.org\/unitCode-input",
+    "Name":"https://schema.org/unitCode-input",
     "Domain Bucket":"< 1K"
   },
   {
     "Class":"Predicate",
-    "Name":"http:\/\/schema.org\/unitCode-output",
+    "Name":"https://schema.org/unitCode-output",
     "Domain Bucket":"< 1K"
   },
   {
     "Class":"Predicate",
-    "Name":"http:\/\/schema.org\/unitText",
+    "Name":"https://schema.org/unitText",
     "Domain Bucket":"100K - 1M"
   },
   {
     "Class":"Predicate",
-    "Name":"http:\/\/schema.org\/unitText-input",
+    "Name":"https://schema.org/unitText-input",
     "Domain Bucket":"< 1K"
   },
   {
     "Class":"Predicate",
-    "Name":"http:\/\/schema.org\/unitText-output",
+    "Name":"https://schema.org/unitText-output",
     "Domain Bucket":"< 1K"
   },
   {
     "Class":"Predicate",
-    "Name":"http:\/\/schema.org\/unnamedSourcesPolicy",
+    "Name":"https://schema.org/unnamedSourcesPolicy",
     "Domain Bucket":"1K - 10K"
   },
   {
     "Class":"Predicate",
-    "Name":"http:\/\/schema.org\/unnamedSourcesPolicy-input",
+    "Name":"https://schema.org/unnamedSourcesPolicy-input",
     "Domain Bucket":"< 1K"
   },
   {
     "Class":"Predicate",
-    "Name":"http:\/\/schema.org\/unnamedSourcesPolicy-output",
+    "Name":"https://schema.org/unnamedSourcesPolicy-output",
     "Domain Bucket":"< 1K"
   },
   {
     "Class":"Predicate",
-    "Name":"http:\/\/schema.org\/unsaturatedFatContent",
+    "Name":"https://schema.org/unsaturatedFatContent",
     "Domain Bucket":"10K - 100K"
   },
   {
     "Class":"Predicate",
-    "Name":"http:\/\/schema.org\/unsaturatedFatContent-input",
+    "Name":"https://schema.org/unsaturatedFatContent-input",
     "Domain Bucket":"< 1K"
   },
   {
     "Class":"Predicate",
-    "Name":"http:\/\/schema.org\/unsaturatedFatContent-output",
+    "Name":"https://schema.org/unsaturatedFatContent-output",
     "Domain Bucket":"< 1K"
   },
   {
     "Class":"Predicate",
-    "Name":"http:\/\/schema.org\/uploadDate",
+    "Name":"https://schema.org/uploadDate",
     "Domain Bucket":"1M - 10M"
   },
   {
     "Class":"Predicate",
-    "Name":"http:\/\/schema.org\/uploadDate-input",
+    "Name":"https://schema.org/uploadDate-input",
     "Domain Bucket":"< 1K"
   },
   {
     "Class":"Predicate",
-    "Name":"http:\/\/schema.org\/uploadDate-output",
+    "Name":"https://schema.org/uploadDate-output",
     "Domain Bucket":"< 1K"
   },
   {
     "Class":"Predicate",
-    "Name":"http:\/\/schema.org\/upvoteCount",
+    "Name":"https://schema.org/upvoteCount",
     "Domain Bucket":"10K - 100K"
   },
   {
     "Class":"Predicate",
-    "Name":"http:\/\/schema.org\/upvoteCount-input",
+    "Name":"https://schema.org/upvoteCount-input",
     "Domain Bucket":"< 1K"
   },
   {
     "Class":"Predicate",
-    "Name":"http:\/\/schema.org\/upvoteCount-output",
+    "Name":"https://schema.org/upvoteCount-output",
     "Domain Bucket":"< 1K"
   },
   {
     "Class":"Predicate",
-    "Name":"http:\/\/schema.org\/url",
+    "Name":"https://schema.org/url",
     "Domain Bucket":"10M+"
   },
   {
     "Class":"Predicate",
-    "Name":"http:\/\/schema.org\/url-input",
+    "Name":"https://schema.org/url-input",
     "Domain Bucket":"< 1K"
   },
   {
     "Class":"Predicate",
-    "Name":"http:\/\/schema.org\/url-output",
+    "Name":"https://schema.org/url-output",
     "Domain Bucket":"< 1K"
   },
   {
     "Class":"Predicate",
-    "Name":"http:\/\/schema.org\/urlTemplate",
+    "Name":"https://schema.org/urlTemplate",
     "Domain Bucket":"10M+"
   },
   {
     "Class":"Predicate",
-    "Name":"http:\/\/schema.org\/urlTemplate-input",
+    "Name":"https://schema.org/urlTemplate-input",
     "Domain Bucket":"< 1K"
   },
   {
     "Class":"Predicate",
-    "Name":"http:\/\/schema.org\/urlTemplate-output",
+    "Name":"https://schema.org/urlTemplate-output",
     "Domain Bucket":"< 1K"
   },
   {
     "Class":"Predicate",
-    "Name":"http:\/\/schema.org\/usNPI",
+    "Name":"https://schema.org/usNPI",
     "Domain Bucket":"< 1K"
   },
   {
     "Class":"Predicate",
-    "Name":"http:\/\/schema.org\/usNPI-input",
+    "Name":"https://schema.org/usNPI-input",
     "Domain Bucket":"< 1K"
   },
   {
     "Class":"Predicate",
-    "Name":"http:\/\/schema.org\/usNPI-output",
+    "Name":"https://schema.org/usNPI-output",
     "Domain Bucket":"< 1K"
   },
   {
     "Class":"Predicate",
-    "Name":"http:\/\/schema.org\/usageInfo",
+    "Name":"https://schema.org/usageInfo",
     "Domain Bucket":"1K - 10K"
   },
   {
     "Class":"Predicate",
-    "Name":"http:\/\/schema.org\/usageInfo-input",
+    "Name":"https://schema.org/usageInfo-input",
     "Domain Bucket":"< 1K"
   },
   {
     "Class":"Predicate",
-    "Name":"http:\/\/schema.org\/usageInfo-output",
+    "Name":"https://schema.org/usageInfo-output",
     "Domain Bucket":"< 1K"
   },
   {
     "Class":"Predicate",
-    "Name":"http:\/\/schema.org\/usedToDiagnose",
+    "Name":"https://schema.org/usedToDiagnose",
     "Domain Bucket":"1K - 10K"
   },
   {
     "Class":"Predicate",
-    "Name":"http:\/\/schema.org\/usedToDiagnose-input",
+    "Name":"https://schema.org/usedToDiagnose-input",
     "Domain Bucket":"< 1K"
   },
   {
     "Class":"Predicate",
-    "Name":"http:\/\/schema.org\/usedToDiagnose-output",
+    "Name":"https://schema.org/usedToDiagnose-output",
     "Domain Bucket":"< 1K"
   },
   {
     "Class":"Predicate",
-    "Name":"http:\/\/schema.org\/userInteractionCount",
+    "Name":"https://schema.org/userInteractionCount",
     "Domain Bucket":"100K - 1M"
   },
   {
     "Class":"Predicate",
-    "Name":"http:\/\/schema.org\/userInteractionCount-input",
+    "Name":"https://schema.org/userInteractionCount-input",
     "Domain Bucket":"< 1K"
   },
   {
     "Class":"Predicate",
-    "Name":"http:\/\/schema.org\/userInteractionCount-output",
+    "Name":"https://schema.org/userInteractionCount-output",
     "Domain Bucket":"< 1K"
   },
   {
     "Class":"Predicate",
-    "Name":"http:\/\/schema.org\/usesDevice",
+    "Name":"https://schema.org/usesDevice",
     "Domain Bucket":"< 1K"
   },
   {
     "Class":"Predicate",
-    "Name":"http:\/\/schema.org\/usesDevice-input",
+    "Name":"https://schema.org/usesDevice-input",
     "Domain Bucket":"< 1K"
   },
   {
     "Class":"Predicate",
-    "Name":"http:\/\/schema.org\/usesDevice-output",
+    "Name":"https://schema.org/usesDevice-output",
     "Domain Bucket":"< 1K"
   },
   {
     "Class":"Predicate",
-    "Name":"http:\/\/schema.org\/usesHealthPlanIdStandard",
+    "Name":"https://schema.org/usesHealthPlanIdStandard",
     "Domain Bucket":"< 1K"
   },
   {
     "Class":"Predicate",
-    "Name":"http:\/\/schema.org\/usesHealthPlanIdStandard-input",
+    "Name":"https://schema.org/usesHealthPlanIdStandard-input",
     "Domain Bucket":"< 1K"
   },
   {
     "Class":"Predicate",
-    "Name":"http:\/\/schema.org\/usesHealthPlanIdStandard-output",
+    "Name":"https://schema.org/usesHealthPlanIdStandard-output",
     "Domain Bucket":"< 1K"
   },
   {
     "Class":"Predicate",
-    "Name":"http:\/\/schema.org\/utterances",
+    "Name":"https://schema.org/utterances",
     "Domain Bucket":"< 1K"
   },
   {
     "Class":"Predicate",
-    "Name":"http:\/\/schema.org\/utterances-input",
+    "Name":"https://schema.org/utterances-input",
     "Domain Bucket":"< 1K"
   },
   {
     "Class":"Predicate",
-    "Name":"http:\/\/schema.org\/utterances-output",
+    "Name":"https://schema.org/utterances-output",
     "Domain Bucket":"< 1K"
   },
   {
     "Class":"Predicate",
-    "Name":"http:\/\/schema.org\/validFor",
+    "Name":"https://schema.org/validFor",
     "Domain Bucket":"< 1K"
   },
   {
     "Class":"Predicate",
-    "Name":"http:\/\/schema.org\/validFor-input",
+    "Name":"https://schema.org/validFor-input",
     "Domain Bucket":"< 1K"
   },
   {
     "Class":"Predicate",
-    "Name":"http:\/\/schema.org\/validFor-output",
+    "Name":"https://schema.org/validFor-output",
     "Domain Bucket":"< 1K"
   },
   {
     "Class":"Predicate",
-    "Name":"http:\/\/schema.org\/validForMemberTier",
+    "Name":"https://schema.org/validForMemberTier",
     "Domain Bucket":"< 1K"
   },
   {
     "Class":"Predicate",
-    "Name":"http:\/\/schema.org\/validForMemberTier-input",
+    "Name":"https://schema.org/validForMemberTier-input",
     "Domain Bucket":"< 1K"
   },
   {
     "Class":"Predicate",
-    "Name":"http:\/\/schema.org\/validForMemberTier-output",
+    "Name":"https://schema.org/validForMemberTier-output",
     "Domain Bucket":"< 1K"
   },
   {
     "Class":"Predicate",
-    "Name":"http:\/\/schema.org\/validFrom",
+    "Name":"https://schema.org/validFrom",
     "Domain Bucket":"100K - 1M"
   },
   {
     "Class":"Predicate",
-    "Name":"http:\/\/schema.org\/validFrom-input",
+    "Name":"https://schema.org/validFrom-input",
     "Domain Bucket":"< 1K"
   },
   {
     "Class":"Predicate",
-    "Name":"http:\/\/schema.org\/validFrom-output",
+    "Name":"https://schema.org/validFrom-output",
     "Domain Bucket":"< 1K"
   },
   {
     "Class":"Predicate",
-    "Name":"http:\/\/schema.org\/validIn",
+    "Name":"https://schema.org/validIn",
     "Domain Bucket":"1K - 10K"
   },
   {
     "Class":"Predicate",
-    "Name":"http:\/\/schema.org\/validIn-input",
+    "Name":"https://schema.org/validIn-input",
     "Domain Bucket":"< 1K"
   },
   {
     "Class":"Predicate",
-    "Name":"http:\/\/schema.org\/validIn-output",
+    "Name":"https://schema.org/validIn-output",
     "Domain Bucket":"< 1K"
   },
   {
     "Class":"Predicate",
-    "Name":"http:\/\/schema.org\/validThrough",
+    "Name":"https://schema.org/validThrough",
     "Domain Bucket":"1M - 10M"
   },
   {
     "Class":"Predicate",
-    "Name":"http:\/\/schema.org\/validThrough-input",
+    "Name":"https://schema.org/validThrough-input",
     "Domain Bucket":"< 1K"
   },
   {
     "Class":"Predicate",
-    "Name":"http:\/\/schema.org\/validThrough-output",
+    "Name":"https://schema.org/validThrough-output",
     "Domain Bucket":"< 1K"
   },
   {
     "Class":"Predicate",
-    "Name":"http:\/\/schema.org\/validUntil",
+    "Name":"https://schema.org/validUntil",
     "Domain Bucket":"1K - 10K"
   },
   {
     "Class":"Predicate",
-    "Name":"http:\/\/schema.org\/validUntil-input",
+    "Name":"https://schema.org/validUntil-input",
     "Domain Bucket":"< 1K"
   },
   {
     "Class":"Predicate",
-    "Name":"http:\/\/schema.org\/validUntil-output",
+    "Name":"https://schema.org/validUntil-output",
     "Domain Bucket":"< 1K"
   },
   {
     "Class":"Predicate",
-    "Name":"http:\/\/schema.org\/value",
+    "Name":"https://schema.org/value",
     "Domain Bucket":"1M - 10M"
   },
   {
     "Class":"Predicate",
-    "Name":"http:\/\/schema.org\/value-input",
+    "Name":"https://schema.org/value-input",
     "Domain Bucket":"< 1K"
   },
   {
     "Class":"Predicate",
-    "Name":"http:\/\/schema.org\/value-output",
+    "Name":"https://schema.org/value-output",
     "Domain Bucket":"< 1K"
   },
   {
     "Class":"Predicate",
-    "Name":"http:\/\/schema.org\/valueAddedTaxIncluded",
+    "Name":"https://schema.org/valueAddedTaxIncluded",
     "Domain Bucket":"1M - 10M"
   },
   {
     "Class":"Predicate",
-    "Name":"http:\/\/schema.org\/valueAddedTaxIncluded-input",
+    "Name":"https://schema.org/valueAddedTaxIncluded-input",
     "Domain Bucket":"< 1K"
   },
   {
     "Class":"Predicate",
-    "Name":"http:\/\/schema.org\/valueAddedTaxIncluded-output",
+    "Name":"https://schema.org/valueAddedTaxIncluded-output",
     "Domain Bucket":"< 1K"
   },
   {
     "Class":"Predicate",
-    "Name":"http:\/\/schema.org\/valueMaxLength",
+    "Name":"https://schema.org/valueMaxLength",
     "Domain Bucket":"1K - 10K"
   },
   {
     "Class":"Predicate",
-    "Name":"http:\/\/schema.org\/valueMaxLength-input",
+    "Name":"https://schema.org/valueMaxLength-input",
     "Domain Bucket":"< 1K"
   },
   {
     "Class":"Predicate",
-    "Name":"http:\/\/schema.org\/valueMaxLength-output",
+    "Name":"https://schema.org/valueMaxLength-output",
     "Domain Bucket":"< 1K"
   },
   {
     "Class":"Predicate",
-    "Name":"http:\/\/schema.org\/valueMinLength",
+    "Name":"https://schema.org/valueMinLength",
     "Domain Bucket":"< 1K"
   },
   {
     "Class":"Predicate",
-    "Name":"http:\/\/schema.org\/valueMinLength-input",
+    "Name":"https://schema.org/valueMinLength-input",
     "Domain Bucket":"< 1K"
   },
   {
     "Class":"Predicate",
-    "Name":"http:\/\/schema.org\/valueMinLength-output",
+    "Name":"https://schema.org/valueMinLength-output",
     "Domain Bucket":"< 1K"
   },
   {
     "Class":"Predicate",
-    "Name":"http:\/\/schema.org\/valueName",
+    "Name":"https://schema.org/valueName",
     "Domain Bucket":"10M+"
   },
   {
     "Class":"Predicate",
-    "Name":"http:\/\/schema.org\/valueName-input",
+    "Name":"https://schema.org/valueName-input",
     "Domain Bucket":"< 1K"
   },
   {
     "Class":"Predicate",
-    "Name":"http:\/\/schema.org\/valueName-output",
+    "Name":"https://schema.org/valueName-output",
     "Domain Bucket":"< 1K"
   },
   {
     "Class":"Predicate",
-    "Name":"http:\/\/schema.org\/valuePattern",
+    "Name":"https://schema.org/valuePattern",
     "Domain Bucket":"< 1K"
   },
   {
     "Class":"Predicate",
-    "Name":"http:\/\/schema.org\/valuePattern-input",
+    "Name":"https://schema.org/valuePattern-input",
     "Domain Bucket":"< 1K"
   },
   {
     "Class":"Predicate",
-    "Name":"http:\/\/schema.org\/valuePattern-output",
+    "Name":"https://schema.org/valuePattern-output",
     "Domain Bucket":"< 1K"
   },
   {
     "Class":"Predicate",
-    "Name":"http:\/\/schema.org\/valueReference",
+    "Name":"https://schema.org/valueReference",
     "Domain Bucket":"1K - 10K"
   },
   {
     "Class":"Predicate",
-    "Name":"http:\/\/schema.org\/valueReference-input",
+    "Name":"https://schema.org/valueReference-input",
     "Domain Bucket":"< 1K"
   },
   {
     "Class":"Predicate",
-    "Name":"http:\/\/schema.org\/valueReference-output",
+    "Name":"https://schema.org/valueReference-output",
     "Domain Bucket":"< 1K"
   },
   {
     "Class":"Predicate",
-    "Name":"http:\/\/schema.org\/valueRequired",
+    "Name":"https://schema.org/valueRequired",
     "Domain Bucket":"10M+"
   },
   {
     "Class":"Predicate",
-    "Name":"http:\/\/schema.org\/valueRequired-input",
+    "Name":"https://schema.org/valueRequired-input",
     "Domain Bucket":"< 1K"
   },
   {
     "Class":"Predicate",
-    "Name":"http:\/\/schema.org\/valueRequired-output",
+    "Name":"https://schema.org/valueRequired-output",
     "Domain Bucket":"< 1K"
   },
   {
     "Class":"Predicate",
-    "Name":"http:\/\/schema.org\/variableMeasured",
+    "Name":"https://schema.org/variableMeasured",
     "Domain Bucket":"10K - 100K"
   },
   {
     "Class":"Predicate",
-    "Name":"http:\/\/schema.org\/variableMeasured-input",
+    "Name":"https://schema.org/variableMeasured-input",
     "Domain Bucket":"< 1K"
   },
   {
     "Class":"Predicate",
-    "Name":"http:\/\/schema.org\/variableMeasured-output",
+    "Name":"https://schema.org/variableMeasured-output",
     "Domain Bucket":"< 1K"
   },
   {
     "Class":"Predicate",
-    "Name":"http:\/\/schema.org\/variablesMeasured",
+    "Name":"https://schema.org/variablesMeasured",
     "Domain Bucket":"< 1K"
   },
   {
     "Class":"Predicate",
-    "Name":"http:\/\/schema.org\/variablesMeasured-input",
+    "Name":"https://schema.org/variablesMeasured-input",
     "Domain Bucket":"< 1K"
   },
   {
     "Class":"Predicate",
-    "Name":"http:\/\/schema.org\/variablesMeasured-output",
+    "Name":"https://schema.org/variablesMeasured-output",
     "Domain Bucket":"< 1K"
   },
   {
     "Class":"Predicate",
-    "Name":"http:\/\/schema.org\/variantCover",
+    "Name":"https://schema.org/variantCover",
     "Domain Bucket":"< 1K"
   },
   {
     "Class":"Predicate",
-    "Name":"http:\/\/schema.org\/variantCover-input",
+    "Name":"https://schema.org/variantCover-input",
     "Domain Bucket":"< 1K"
   },
   {
     "Class":"Predicate",
-    "Name":"http:\/\/schema.org\/variantCover-output",
+    "Name":"https://schema.org/variantCover-output",
     "Domain Bucket":"< 1K"
   },
   {
     "Class":"Predicate",
-    "Name":"http:\/\/schema.org\/variesBy",
+    "Name":"https://schema.org/variesBy",
     "Domain Bucket":"100K - 1M"
   },
   {
     "Class":"Predicate",
-    "Name":"http:\/\/schema.org\/variesBy-input",
+    "Name":"https://schema.org/variesBy-input",
     "Domain Bucket":"< 1K"
   },
   {
     "Class":"Predicate",
-    "Name":"http:\/\/schema.org\/variesBy-output",
+    "Name":"https://schema.org/variesBy-output",
     "Domain Bucket":"< 1K"
   },
   {
     "Class":"Predicate",
-    "Name":"http:\/\/schema.org\/vatID",
+    "Name":"https://schema.org/vatID",
     "Domain Bucket":"100K - 1M"
   },
   {
     "Class":"Predicate",
-    "Name":"http:\/\/schema.org\/vatID-input",
+    "Name":"https://schema.org/vatID-input",
     "Domain Bucket":"< 1K"
   },
   {
     "Class":"Predicate",
-    "Name":"http:\/\/schema.org\/vatID-output",
+    "Name":"https://schema.org/vatID-output",
     "Domain Bucket":"< 1K"
   },
   {
     "Class":"Predicate",
-    "Name":"http:\/\/schema.org\/vehicleConfiguration",
+    "Name":"https://schema.org/vehicleConfiguration",
     "Domain Bucket":"10K - 100K"
   },
   {
     "Class":"Predicate",
-    "Name":"http:\/\/schema.org\/vehicleConfiguration-input",
+    "Name":"https://schema.org/vehicleConfiguration-input",
     "Domain Bucket":"< 1K"
   },
   {
     "Class":"Predicate",
-    "Name":"http:\/\/schema.org\/vehicleConfiguration-output",
+    "Name":"https://schema.org/vehicleConfiguration-output",
     "Domain Bucket":"< 1K"
   },
   {
     "Class":"Predicate",
-    "Name":"http:\/\/schema.org\/vehicleEngine",
+    "Name":"https://schema.org/vehicleEngine",
     "Domain Bucket":"10K - 100K"
   },
   {
     "Class":"Predicate",
-    "Name":"http:\/\/schema.org\/vehicleEngine-input",
+    "Name":"https://schema.org/vehicleEngine-input",
     "Domain Bucket":"< 1K"
   },
   {
     "Class":"Predicate",
-    "Name":"http:\/\/schema.org\/vehicleEngine-output",
+    "Name":"https://schema.org/vehicleEngine-output",
     "Domain Bucket":"< 1K"
   },
   {
     "Class":"Predicate",
-    "Name":"http:\/\/schema.org\/vehicleIdentificationNumber",
+    "Name":"https://schema.org/vehicleIdentificationNumber",
     "Domain Bucket":"10K - 100K"
   },
   {
     "Class":"Predicate",
-    "Name":"http:\/\/schema.org\/vehicleIdentificationNumber-input",
+    "Name":"https://schema.org/vehicleIdentificationNumber-input",
     "Domain Bucket":"< 1K"
   },
   {
     "Class":"Predicate",
-    "Name":"http:\/\/schema.org\/vehicleIdentificationNumber-output",
+    "Name":"https://schema.org/vehicleIdentificationNumber-output",
     "Domain Bucket":"< 1K"
   },
   {
     "Class":"Predicate",
-    "Name":"http:\/\/schema.org\/vehicleInteriorColor",
+    "Name":"https://schema.org/vehicleInteriorColor",
     "Domain Bucket":"10K - 100K"
   },
   {
     "Class":"Predicate",
-    "Name":"http:\/\/schema.org\/vehicleInteriorColor-input",
+    "Name":"https://schema.org/vehicleInteriorColor-input",
     "Domain Bucket":"< 1K"
   },
   {
     "Class":"Predicate",
-    "Name":"http:\/\/schema.org\/vehicleInteriorColor-output",
+    "Name":"https://schema.org/vehicleInteriorColor-output",
     "Domain Bucket":"< 1K"
   },
   {
     "Class":"Predicate",
-    "Name":"http:\/\/schema.org\/vehicleInteriorType",
+    "Name":"https://schema.org/vehicleInteriorType",
     "Domain Bucket":"10K - 100K"
   },
   {
     "Class":"Predicate",
-    "Name":"http:\/\/schema.org\/vehicleInteriorType-input",
+    "Name":"https://schema.org/vehicleInteriorType-input",
     "Domain Bucket":"< 1K"
   },
   {
     "Class":"Predicate",
-    "Name":"http:\/\/schema.org\/vehicleInteriorType-output",
+    "Name":"https://schema.org/vehicleInteriorType-output",
     "Domain Bucket":"< 1K"
   },
   {
     "Class":"Predicate",
-    "Name":"http:\/\/schema.org\/vehicleModelDate",
+    "Name":"https://schema.org/vehicleModelDate",
     "Domain Bucket":"10K - 100K"
   },
   {
     "Class":"Predicate",
-    "Name":"http:\/\/schema.org\/vehicleModelDate-input",
+    "Name":"https://schema.org/vehicleModelDate-input",
     "Domain Bucket":"< 1K"
   },
   {
     "Class":"Predicate",
-    "Name":"http:\/\/schema.org\/vehicleModelDate-output",
+    "Name":"https://schema.org/vehicleModelDate-output",
     "Domain Bucket":"< 1K"
   },
   {
     "Class":"Predicate",
-    "Name":"http:\/\/schema.org\/vehicleSeatingCapacity",
+    "Name":"https://schema.org/vehicleSeatingCapacity",
     "Domain Bucket":"10K - 100K"
   },
   {
     "Class":"Predicate",
-    "Name":"http:\/\/schema.org\/vehicleSeatingCapacity-input",
+    "Name":"https://schema.org/vehicleSeatingCapacity-input",
     "Domain Bucket":"< 1K"
   },
   {
     "Class":"Predicate",
-    "Name":"http:\/\/schema.org\/vehicleSeatingCapacity-output",
+    "Name":"https://schema.org/vehicleSeatingCapacity-output",
     "Domain Bucket":"< 1K"
   },
   {
     "Class":"Predicate",
-    "Name":"http:\/\/schema.org\/vehicleSpecialUsage",
+    "Name":"https://schema.org/vehicleSpecialUsage",
     "Domain Bucket":"< 1K"
   },
   {
     "Class":"Predicate",
-    "Name":"http:\/\/schema.org\/vehicleSpecialUsage-input",
+    "Name":"https://schema.org/vehicleSpecialUsage-input",
     "Domain Bucket":"< 1K"
   },
   {
     "Class":"Predicate",
-    "Name":"http:\/\/schema.org\/vehicleSpecialUsage-output",
+    "Name":"https://schema.org/vehicleSpecialUsage-output",
     "Domain Bucket":"< 1K"
   },
   {
     "Class":"Predicate",
-    "Name":"http:\/\/schema.org\/vehicleTransmission",
+    "Name":"https://schema.org/vehicleTransmission",
     "Domain Bucket":"10K - 100K"
   },
   {
     "Class":"Predicate",
-    "Name":"http:\/\/schema.org\/vehicleTransmission-input",
+    "Name":"https://schema.org/vehicleTransmission-input",
     "Domain Bucket":"< 1K"
   },
   {
     "Class":"Predicate",
-    "Name":"http:\/\/schema.org\/vehicleTransmission-output",
+    "Name":"https://schema.org/vehicleTransmission-output",
     "Domain Bucket":"< 1K"
   },
   {
     "Class":"Predicate",
-    "Name":"http:\/\/schema.org\/vendor",
+    "Name":"https://schema.org/vendor",
     "Domain Bucket":"< 1K"
   },
   {
     "Class":"Predicate",
-    "Name":"http:\/\/schema.org\/vendor-input",
+    "Name":"https://schema.org/vendor-input",
     "Domain Bucket":"< 1K"
   },
   {
     "Class":"Predicate",
-    "Name":"http:\/\/schema.org\/vendor-output",
+    "Name":"https://schema.org/vendor-output",
     "Domain Bucket":"< 1K"
   },
   {
     "Class":"Predicate",
-    "Name":"http:\/\/schema.org\/verificationFactCheckingPolicy",
+    "Name":"https://schema.org/verificationFactCheckingPolicy",
     "Domain Bucket":"1K - 10K"
   },
   {
     "Class":"Predicate",
-    "Name":"http:\/\/schema.org\/verificationFactCheckingPolicy-input",
+    "Name":"https://schema.org/verificationFactCheckingPolicy-input",
     "Domain Bucket":"< 1K"
   },
   {
     "Class":"Predicate",
-    "Name":"http:\/\/schema.org\/verificationFactCheckingPolicy-output",
+    "Name":"https://schema.org/verificationFactCheckingPolicy-output",
     "Domain Bucket":"< 1K"
   },
   {
     "Class":"Predicate",
-    "Name":"http:\/\/schema.org\/version",
+    "Name":"https://schema.org/version",
     "Domain Bucket":"1K - 10K"
   },
   {
     "Class":"Predicate",
-    "Name":"http:\/\/schema.org\/version-input",
+    "Name":"https://schema.org/version-input",
     "Domain Bucket":"< 1K"
   },
   {
     "Class":"Predicate",
-    "Name":"http:\/\/schema.org\/version-output",
+    "Name":"https://schema.org/version-output",
     "Domain Bucket":"< 1K"
   },
   {
     "Class":"Predicate",
-    "Name":"http:\/\/schema.org\/video",
+    "Name":"https://schema.org/video",
     "Domain Bucket":"100K - 1M"
   },
   {
     "Class":"Predicate",
-    "Name":"http:\/\/schema.org\/video-input",
+    "Name":"https://schema.org/video-input",
     "Domain Bucket":"< 1K"
   },
   {
     "Class":"Predicate",
-    "Name":"http:\/\/schema.org\/video-output",
+    "Name":"https://schema.org/video-output",
     "Domain Bucket":"< 1K"
   },
   {
     "Class":"Predicate",
-    "Name":"http:\/\/schema.org\/videoFormat",
+    "Name":"https://schema.org/videoFormat",
     "Domain Bucket":"1K - 10K"
   },
   {
     "Class":"Predicate",
-    "Name":"http:\/\/schema.org\/videoFormat-input",
+    "Name":"https://schema.org/videoFormat-input",
     "Domain Bucket":"< 1K"
   },
   {
     "Class":"Predicate",
-    "Name":"http:\/\/schema.org\/videoFormat-output",
+    "Name":"https://schema.org/videoFormat-output",
     "Domain Bucket":"< 1K"
   },
   {
     "Class":"Predicate",
-    "Name":"http:\/\/schema.org\/videoFrameSize",
+    "Name":"https://schema.org/videoFrameSize",
     "Domain Bucket":"< 1K"
   },
   {
     "Class":"Predicate",
-    "Name":"http:\/\/schema.org\/videoFrameSize-input",
+    "Name":"https://schema.org/videoFrameSize-input",
     "Domain Bucket":"< 1K"
   },
   {
     "Class":"Predicate",
-    "Name":"http:\/\/schema.org\/videoFrameSize-output",
+    "Name":"https://schema.org/videoFrameSize-output",
     "Domain Bucket":"< 1K"
   },
   {
     "Class":"Predicate",
-    "Name":"http:\/\/schema.org\/videoQuality",
+    "Name":"https://schema.org/videoQuality",
     "Domain Bucket":"10K - 100K"
   },
   {
     "Class":"Predicate",
-    "Name":"http:\/\/schema.org\/videoQuality-input",
+    "Name":"https://schema.org/videoQuality-input",
     "Domain Bucket":"< 1K"
   },
   {
     "Class":"Predicate",
-    "Name":"http:\/\/schema.org\/videoQuality-output",
+    "Name":"https://schema.org/videoQuality-output",
     "Domain Bucket":"< 1K"
   },
   {
     "Class":"Predicate",
-    "Name":"http:\/\/schema.org\/volumeNumber",
+    "Name":"https://schema.org/volumeNumber",
     "Domain Bucket":"1K - 10K"
   },
   {
     "Class":"Predicate",
-    "Name":"http:\/\/schema.org\/volumeNumber-input",
+    "Name":"https://schema.org/volumeNumber-input",
     "Domain Bucket":"< 1K"
   },
   {
     "Class":"Predicate",
-    "Name":"http:\/\/schema.org\/volumeNumber-output",
+    "Name":"https://schema.org/volumeNumber-output",
     "Domain Bucket":"< 1K"
   },
   {
     "Class":"Predicate",
-    "Name":"http:\/\/schema.org\/warning",
+    "Name":"https://schema.org/warning",
     "Domain Bucket":"< 1K"
   },
   {
     "Class":"Predicate",
-    "Name":"http:\/\/schema.org\/warning-input",
+    "Name":"https://schema.org/warning-input",
     "Domain Bucket":"< 1K"
   },
   {
     "Class":"Predicate",
-    "Name":"http:\/\/schema.org\/warning-output",
+    "Name":"https://schema.org/warning-output",
     "Domain Bucket":"< 1K"
   },
   {
     "Class":"Predicate",
-    "Name":"http:\/\/schema.org\/warranty",
+    "Name":"https://schema.org/warranty",
     "Domain Bucket":"10K - 100K"
   },
   {
     "Class":"Predicate",
-    "Name":"http:\/\/schema.org\/warranty-input",
+    "Name":"https://schema.org/warranty-input",
     "Domain Bucket":"< 1K"
   },
   {
     "Class":"Predicate",
-    "Name":"http:\/\/schema.org\/warranty-output",
+    "Name":"https://schema.org/warranty-output",
     "Domain Bucket":"< 1K"
   },
   {
     "Class":"Predicate",
-    "Name":"http:\/\/schema.org\/warrantyPromise",
+    "Name":"https://schema.org/warrantyPromise",
     "Domain Bucket":"< 1K"
   },
   {
     "Class":"Predicate",
-    "Name":"http:\/\/schema.org\/warrantyPromise-input",
+    "Name":"https://schema.org/warrantyPromise-input",
     "Domain Bucket":"< 1K"
   },
   {
     "Class":"Predicate",
-    "Name":"http:\/\/schema.org\/warrantyPromise-output",
+    "Name":"https://schema.org/warrantyPromise-output",
     "Domain Bucket":"< 1K"
   },
   {
     "Class":"Predicate",
-    "Name":"http:\/\/schema.org\/warrantyScope",
+    "Name":"https://schema.org/warrantyScope",
     "Domain Bucket":"1K - 10K"
   },
   {
     "Class":"Predicate",
-    "Name":"http:\/\/schema.org\/warrantyScope-input",
+    "Name":"https://schema.org/warrantyScope-input",
     "Domain Bucket":"< 1K"
   },
   {
     "Class":"Predicate",
-    "Name":"http:\/\/schema.org\/warrantyScope-output",
+    "Name":"https://schema.org/warrantyScope-output",
     "Domain Bucket":"< 1K"
   },
   {
     "Class":"Predicate",
-    "Name":"http:\/\/schema.org\/webCheckinTime",
+    "Name":"https://schema.org/webCheckinTime",
     "Domain Bucket":"< 1K"
   },
   {
     "Class":"Predicate",
-    "Name":"http:\/\/schema.org\/webCheckinTime-input",
+    "Name":"https://schema.org/webCheckinTime-input",
     "Domain Bucket":"< 1K"
   },
   {
     "Class":"Predicate",
-    "Name":"http:\/\/schema.org\/webCheckinTime-output",
+    "Name":"https://schema.org/webCheckinTime-output",
     "Domain Bucket":"< 1K"
   },
   {
     "Class":"Predicate",
-    "Name":"http:\/\/schema.org\/webFeed",
+    "Name":"https://schema.org/webFeed",
     "Domain Bucket":"10K - 100K"
   },
   {
     "Class":"Predicate",
-    "Name":"http:\/\/schema.org\/webFeed-input",
+    "Name":"https://schema.org/webFeed-input",
     "Domain Bucket":"< 1K"
   },
   {
     "Class":"Predicate",
-    "Name":"http:\/\/schema.org\/webFeed-output",
+    "Name":"https://schema.org/webFeed-output",
     "Domain Bucket":"< 1K"
   },
   {
     "Class":"Predicate",
-    "Name":"http:\/\/schema.org\/weight",
+    "Name":"https://schema.org/weight",
     "Domain Bucket":"100K - 1M"
   },
   {
     "Class":"Predicate",
-    "Name":"http:\/\/schema.org\/weight-input",
+    "Name":"https://schema.org/weight-input",
     "Domain Bucket":"< 1K"
   },
   {
     "Class":"Predicate",
-    "Name":"http:\/\/schema.org\/weight-output",
+    "Name":"https://schema.org/weight-output",
     "Domain Bucket":"< 1K"
   },
   {
     "Class":"Predicate",
-    "Name":"http:\/\/schema.org\/weightPercentage",
+    "Name":"https://schema.org/weightPercentage",
     "Domain Bucket":"< 1K"
   },
   {
     "Class":"Predicate",
-    "Name":"http:\/\/schema.org\/weightPercentage-input",
+    "Name":"https://schema.org/weightPercentage-input",
     "Domain Bucket":"< 1K"
   },
   {
     "Class":"Predicate",
-    "Name":"http:\/\/schema.org\/weightPercentage-output",
+    "Name":"https://schema.org/weightPercentage-output",
     "Domain Bucket":"< 1K"
   },
   {
     "Class":"Predicate",
-    "Name":"http:\/\/schema.org\/weightTotal",
+    "Name":"https://schema.org/weightTotal",
     "Domain Bucket":"1K - 10K"
   },
   {
     "Class":"Predicate",
-    "Name":"http:\/\/schema.org\/weightTotal-input",
+    "Name":"https://schema.org/weightTotal-input",
     "Domain Bucket":"< 1K"
   },
   {
     "Class":"Predicate",
-    "Name":"http:\/\/schema.org\/weightTotal-output",
+    "Name":"https://schema.org/weightTotal-output",
     "Domain Bucket":"< 1K"
   },
   {
     "Class":"Predicate",
-    "Name":"http:\/\/schema.org\/wheelbase",
+    "Name":"https://schema.org/wheelbase",
     "Domain Bucket":"1K - 10K"
   },
   {
     "Class":"Predicate",
-    "Name":"http:\/\/schema.org\/wheelbase-input",
+    "Name":"https://schema.org/wheelbase-input",
     "Domain Bucket":"< 1K"
   },
   {
     "Class":"Predicate",
-    "Name":"http:\/\/schema.org\/wheelbase-output",
+    "Name":"https://schema.org/wheelbase-output",
     "Domain Bucket":"< 1K"
   },
   {
     "Class":"Predicate",
-    "Name":"http:\/\/schema.org\/width",
+    "Name":"https://schema.org/width",
     "Domain Bucket":"10M+"
   },
   {
     "Class":"Predicate",
-    "Name":"http:\/\/schema.org\/width-input",
+    "Name":"https://schema.org/width-input",
     "Domain Bucket":"< 1K"
   },
   {
     "Class":"Predicate",
-    "Name":"http:\/\/schema.org\/width-output",
+    "Name":"https://schema.org/width-output",
     "Domain Bucket":"< 1K"
   },
   {
     "Class":"Predicate",
-    "Name":"http:\/\/schema.org\/winner",
+    "Name":"https://schema.org/winner",
     "Domain Bucket":"< 1K"
   },
   {
     "Class":"Predicate",
-    "Name":"http:\/\/schema.org\/winner-input",
+    "Name":"https://schema.org/winner-input",
     "Domain Bucket":"< 1K"
   },
   {
     "Class":"Predicate",
-    "Name":"http:\/\/schema.org\/winner-output",
+    "Name":"https://schema.org/winner-output",
     "Domain Bucket":"< 1K"
   },
   {
     "Class":"Predicate",
-    "Name":"http:\/\/schema.org\/wordCount",
+    "Name":"https://schema.org/wordCount",
     "Domain Bucket":"1M - 10M"
   },
   {
     "Class":"Predicate",
-    "Name":"http:\/\/schema.org\/wordCount-input",
+    "Name":"https://schema.org/wordCount-input",
     "Domain Bucket":"< 1K"
   },
   {
     "Class":"Predicate",
-    "Name":"http:\/\/schema.org\/wordCount-output",
+    "Name":"https://schema.org/wordCount-output",
     "Domain Bucket":"< 1K"
   },
   {
     "Class":"Predicate",
-    "Name":"http:\/\/schema.org\/workExample",
+    "Name":"https://schema.org/workExample",
     "Domain Bucket":"1K - 10K"
   },
   {
     "Class":"Predicate",
-    "Name":"http:\/\/schema.org\/workExample-input",
+    "Name":"https://schema.org/workExample-input",
     "Domain Bucket":"< 1K"
   },
   {
     "Class":"Predicate",
-    "Name":"http:\/\/schema.org\/workExample-output",
+    "Name":"https://schema.org/workExample-output",
     "Domain Bucket":"< 1K"
   },
   {
     "Class":"Predicate",
-    "Name":"http:\/\/schema.org\/workFeatured",
+    "Name":"https://schema.org/workFeatured",
     "Domain Bucket":"< 1K"
   },
   {
     "Class":"Predicate",
-    "Name":"http:\/\/schema.org\/workFeatured-input",
+    "Name":"https://schema.org/workFeatured-input",
     "Domain Bucket":"< 1K"
   },
   {
     "Class":"Predicate",
-    "Name":"http:\/\/schema.org\/workFeatured-output",
+    "Name":"https://schema.org/workFeatured-output",
     "Domain Bucket":"< 1K"
   },
   {
     "Class":"Predicate",
-    "Name":"http:\/\/schema.org\/workHours",
+    "Name":"https://schema.org/workHours",
     "Domain Bucket":"10K - 100K"
   },
   {
     "Class":"Predicate",
-    "Name":"http:\/\/schema.org\/workHours-input",
+    "Name":"https://schema.org/workHours-input",
     "Domain Bucket":"< 1K"
   },
   {
     "Class":"Predicate",
-    "Name":"http:\/\/schema.org\/workHours-output",
+    "Name":"https://schema.org/workHours-output",
     "Domain Bucket":"< 1K"
   },
   {
     "Class":"Predicate",
-    "Name":"http:\/\/schema.org\/workLocation",
+    "Name":"https://schema.org/workLocation",
     "Domain Bucket":"10K - 100K"
   },
   {
     "Class":"Predicate",
-    "Name":"http:\/\/schema.org\/workLocation-input",
+    "Name":"https://schema.org/workLocation-input",
     "Domain Bucket":"< 1K"
   },
   {
     "Class":"Predicate",
-    "Name":"http:\/\/schema.org\/workLocation-output",
+    "Name":"https://schema.org/workLocation-output",
     "Domain Bucket":"< 1K"
   },
   {
     "Class":"Predicate",
-    "Name":"http:\/\/schema.org\/workPerformed",
+    "Name":"https://schema.org/workPerformed",
     "Domain Bucket":"1K - 10K"
   },
   {
     "Class":"Predicate",
-    "Name":"http:\/\/schema.org\/workPerformed-input",
+    "Name":"https://schema.org/workPerformed-input",
     "Domain Bucket":"< 1K"
   },
   {
     "Class":"Predicate",
-    "Name":"http:\/\/schema.org\/workPerformed-output",
+    "Name":"https://schema.org/workPerformed-output",
     "Domain Bucket":"< 1K"
   },
   {
     "Class":"Predicate",
-    "Name":"http:\/\/schema.org\/workPresented",
+    "Name":"https://schema.org/workPresented",
     "Domain Bucket":"< 1K"
   },
   {
     "Class":"Predicate",
-    "Name":"http:\/\/schema.org\/workPresented-input",
+    "Name":"https://schema.org/workPresented-input",
     "Domain Bucket":"< 1K"
   },
   {
     "Class":"Predicate",
-    "Name":"http:\/\/schema.org\/workPresented-output",
+    "Name":"https://schema.org/workPresented-output",
     "Domain Bucket":"< 1K"
   },
   {
     "Class":"Predicate",
-    "Name":"http:\/\/schema.org\/workTranslation",
+    "Name":"https://schema.org/workTranslation",
     "Domain Bucket":"10K - 100K"
   },
   {
     "Class":"Predicate",
-    "Name":"http:\/\/schema.org\/workTranslation-input",
+    "Name":"https://schema.org/workTranslation-input",
     "Domain Bucket":"< 1K"
   },
   {
     "Class":"Predicate",
-    "Name":"http:\/\/schema.org\/workTranslation-output",
+    "Name":"https://schema.org/workTranslation-output",
     "Domain Bucket":"< 1K"
   },
   {
     "Class":"Predicate",
-    "Name":"http:\/\/schema.org\/workload",
+    "Name":"https://schema.org/workload",
     "Domain Bucket":"< 1K"
   },
   {
     "Class":"Predicate",
-    "Name":"http:\/\/schema.org\/workload-input",
+    "Name":"https://schema.org/workload-input",
     "Domain Bucket":"< 1K"
   },
   {
     "Class":"Predicate",
-    "Name":"http:\/\/schema.org\/workload-output",
+    "Name":"https://schema.org/workload-output",
     "Domain Bucket":"< 1K"
   },
   {
     "Class":"Predicate",
-    "Name":"http:\/\/schema.org\/worksFor",
+    "Name":"https://schema.org/worksFor",
     "Domain Bucket":"1M - 10M"
   },
   {
     "Class":"Predicate",
-    "Name":"http:\/\/schema.org\/worksFor-input",
+    "Name":"https://schema.org/worksFor-input",
     "Domain Bucket":"< 1K"
   },
   {
     "Class":"Predicate",
-    "Name":"http:\/\/schema.org\/worksFor-output",
+    "Name":"https://schema.org/worksFor-output",
     "Domain Bucket":"< 1K"
   },
   {
     "Class":"Predicate",
-    "Name":"http:\/\/schema.org\/worstRating",
+    "Name":"https://schema.org/worstRating",
     "Domain Bucket":"1M - 10M"
   },
   {
     "Class":"Predicate",
-    "Name":"http:\/\/schema.org\/worstRating-input",
+    "Name":"https://schema.org/worstRating-input",
     "Domain Bucket":"< 1K"
   },
   {
     "Class":"Predicate",
-    "Name":"http:\/\/schema.org\/worstRating-output",
+    "Name":"https://schema.org/worstRating-output",
     "Domain Bucket":"< 1K"
   },
   {
     "Class":"Predicate",
-    "Name":"http:\/\/schema.org\/xpath",
+    "Name":"https://schema.org/xpath",
     "Domain Bucket":"10K - 100K"
   },
   {
     "Class":"Predicate",
-    "Name":"http:\/\/schema.org\/xpath-input",
+    "Name":"https://schema.org/xpath-input",
     "Domain Bucket":"< 1K"
   },
   {
     "Class":"Predicate",
-    "Name":"http:\/\/schema.org\/xpath-output",
+    "Name":"https://schema.org/xpath-output",
     "Domain Bucket":"< 1K"
   },
   {
     "Class":"Predicate",
-    "Name":"http:\/\/schema.org\/yearBuilt",
+    "Name":"https://schema.org/yearBuilt",
     "Domain Bucket":"10K - 100K"
   },
   {
     "Class":"Predicate",
-    "Name":"http:\/\/schema.org\/yearBuilt-input",
+    "Name":"https://schema.org/yearBuilt-input",
     "Domain Bucket":"< 1K"
   },
   {
     "Class":"Predicate",
-    "Name":"http:\/\/schema.org\/yearBuilt-output",
+    "Name":"https://schema.org/yearBuilt-output",
     "Domain Bucket":"< 1K"
   },
   {
     "Class":"Predicate",
-    "Name":"http:\/\/schema.org\/yearlyRevenue",
+    "Name":"https://schema.org/yearlyRevenue",
     "Domain Bucket":"< 1K"
   },
   {
     "Class":"Predicate",
-    "Name":"http:\/\/schema.org\/yearlyRevenue-input",
+    "Name":"https://schema.org/yearlyRevenue-input",
     "Domain Bucket":"< 1K"
   },
   {
     "Class":"Predicate",
-    "Name":"http:\/\/schema.org\/yearlyRevenue-output",
+    "Name":"https://schema.org/yearlyRevenue-output",
     "Domain Bucket":"< 1K"
   },
   {
     "Class":"Predicate",
-    "Name":"http:\/\/schema.org\/yearsInOperation",
+    "Name":"https://schema.org/yearsInOperation",
     "Domain Bucket":"< 1K"
   },
   {
     "Class":"Predicate",
-    "Name":"http:\/\/schema.org\/yearsInOperation-input",
+    "Name":"https://schema.org/yearsInOperation-input",
     "Domain Bucket":"< 1K"
   },
   {
     "Class":"Predicate",
-    "Name":"http:\/\/schema.org\/yearsInOperation-output",
+    "Name":"https://schema.org/yearsInOperation-output",
     "Domain Bucket":"< 1K"
   },
   {
     "Class":"Predicate",
-    "Name":"http:\/\/schema.org\/yield",
+    "Name":"https://schema.org/yield",
     "Domain Bucket":"1K - 10K"
   },
   {
     "Class":"Predicate",
-    "Name":"http:\/\/schema.org\/yield-input",
+    "Name":"https://schema.org/yield-input",
     "Domain Bucket":"< 1K"
   },
   {
     "Class":"Predicate",
-    "Name":"http:\/\/schema.org\/yield-output",
+    "Name":"https://schema.org/yield-output",
     "Domain Bucket":"< 1K"
   }
 ]

--- a/data/public_stats/google/2026_07.csv
+++ b/data/public_stats/google/2026_07.csv
@@ -1,5546 +1,5546 @@
 Class,Name,Domain Bucket
-Itemtype,http://schema.org/3DModel,< 1K
-Itemtype,http://schema.org/AMRadioChannel,< 1K
-Itemtype,http://schema.org/APIReference,< 1K
-Itemtype,http://schema.org/AboutPage,100K - 1M
-Itemtype,http://schema.org/AcceptAction,< 1K
-Itemtype,http://schema.org/Accommodation,10K - 100K
-Itemtype,http://schema.org/AccountingService,10K - 100K
-Itemtype,http://schema.org/AchieveAction,< 1K
-Itemtype,http://schema.org/Action,10K - 100K
-Itemtype,http://schema.org/ActionAccessSpecification,< 1K
-Itemtype,http://schema.org/ActionStatusType,< 1K
-Itemtype,http://schema.org/ActivateAction,< 1K
-Itemtype,http://schema.org/AddAction,< 1K
-Itemtype,http://schema.org/AdministrativeArea,100K - 1M
-Itemtype,http://schema.org/AdultEntertainment,1K - 10K
-Itemtype,http://schema.org/AdultOrientedEnumeration,< 1K
-Itemtype,http://schema.org/AdvertiserContentArticle,1K - 10K
-Itemtype,http://schema.org/AggregateOffer,1M - 10M
-Itemtype,http://schema.org/AggregateRating,1M - 10M
-Itemtype,http://schema.org/AgreeAction,< 1K
-Itemtype,http://schema.org/Airline,1K - 10K
-Itemtype,http://schema.org/Airport,1K - 10K
-Itemtype,http://schema.org/AlignmentObject,1K - 10K
-Itemtype,http://schema.org/AllocateAction,< 1K
-Itemtype,http://schema.org/AmpStory,< 1K
-Itemtype,http://schema.org/AmusementPark,1K - 10K
-Itemtype,http://schema.org/AnalysisNewsArticle,1K - 10K
-Itemtype,http://schema.org/AnatomicalStructure,1K - 10K
-Itemtype,http://schema.org/AnatomicalSystem,< 1K
-Itemtype,http://schema.org/AnimalShelter,1K - 10K
-Itemtype,http://schema.org/Answer,1M - 10M
-Itemtype,http://schema.org/Apartment,10K - 100K
-Itemtype,http://schema.org/ApartmentComplex,10K - 100K
-Itemtype,http://schema.org/AppendAction,< 1K
-Itemtype,http://schema.org/ApplyAction,1K - 10K
-Itemtype,http://schema.org/ApprovedIndication,< 1K
-Itemtype,http://schema.org/Aquarium,< 1K
-Itemtype,http://schema.org/ArchiveComponent,< 1K
-Itemtype,http://schema.org/ArchiveOrganization,1K - 10K
-Itemtype,http://schema.org/ArriveAction,< 1K
-Itemtype,http://schema.org/ArtGallery,1K - 10K
-Itemtype,http://schema.org/Artery,< 1K
-Itemtype,http://schema.org/Article,10M+
-Itemtype,http://schema.org/AskAction,1K - 10K
-Itemtype,http://schema.org/AskPublicNewsArticle,< 1K
-Itemtype,http://schema.org/AssessAction,< 1K
-Itemtype,http://schema.org/AssignAction,< 1K
-Itemtype,http://schema.org/Atlas,< 1K
-Itemtype,http://schema.org/Attorney,10K - 100K
-Itemtype,http://schema.org/Audience,100K - 1M
-Itemtype,http://schema.org/AudioObject,10K - 100K
-Itemtype,http://schema.org/AudioObjectSnapshot,< 1K
-Itemtype,http://schema.org/Audiobook,< 1K
-Itemtype,http://schema.org/AuthenticateAction,< 1K
-Itemtype,http://schema.org/AuthorizeAction,< 1K
-Itemtype,http://schema.org/AutoBodyShop,1K - 10K
-Itemtype,http://schema.org/AutoDealer,10K - 100K
-Itemtype,http://schema.org/AutoPartsStore,10K - 100K
-Itemtype,http://schema.org/AutoRental,10K - 100K
-Itemtype,http://schema.org/AutoRepair,10K - 100K
-Itemtype,http://schema.org/AutoWash,1K - 10K
-Itemtype,http://schema.org/AutomatedTeller,< 1K
-Itemtype,http://schema.org/AutomotiveBusiness,10K - 100K
-Itemtype,http://schema.org/BackgroundNewsArticle,< 1K
-Itemtype,http://schema.org/Bakery,1K - 10K
-Itemtype,http://schema.org/BankAccount,< 1K
-Itemtype,http://schema.org/BankOrCreditUnion,1K - 10K
-Itemtype,http://schema.org/BarOrPub,10K - 100K
-Itemtype,http://schema.org/Barcode,< 1K
-Itemtype,http://schema.org/Beach,1K - 10K
-Itemtype,http://schema.org/BeautySalon,10K - 100K
-Itemtype,http://schema.org/BedAndBreakfast,1K - 10K
-Itemtype,http://schema.org/BedDetails,10K - 100K
-Itemtype,http://schema.org/BedType,< 1K
-Itemtype,http://schema.org/BefriendAction,< 1K
-Itemtype,http://schema.org/BikeStore,1K - 10K
-Itemtype,http://schema.org/BioChemEntity,< 1K
-Itemtype,http://schema.org/Blog,1M - 10M
-Itemtype,http://schema.org/BlogPosting,1M - 10M
-Itemtype,http://schema.org/BloodTest,< 1K
-Itemtype,http://schema.org/BoardingPolicyType,< 1K
-Itemtype,http://schema.org/BoatReservation,< 1K
-Itemtype,http://schema.org/BoatTerminal,< 1K
-Itemtype,http://schema.org/BoatTrip,< 1K
-Itemtype,http://schema.org/BodyMeasurementTypeEnumeration,< 1K
-Itemtype,http://schema.org/BodyOfWater,< 1K
-Itemtype,http://schema.org/Bone,< 1K
-Itemtype,http://schema.org/Book,10K - 100K
-Itemtype,http://schema.org/BookFormatType,< 1K
-Itemtype,http://schema.org/BookSeries,1K - 10K
-Itemtype,http://schema.org/BookStore,1K - 10K
-Itemtype,http://schema.org/BookmarkAction,< 1K
-Itemtype,http://schema.org/Boolean,< 1K
-Itemtype,http://schema.org/BorrowAction,< 1K
-Itemtype,http://schema.org/BowlingAlley,< 1K
-Itemtype,http://schema.org/BrainStructure,< 1K
-Itemtype,http://schema.org/Brand,1M - 10M
-Itemtype,http://schema.org/BreadcrumbList,10M+
-Itemtype,http://schema.org/Brewery,1K - 10K
-Itemtype,http://schema.org/Bridge,< 1K
-Itemtype,http://schema.org/BroadcastChannel,< 1K
-Itemtype,http://schema.org/BroadcastEvent,10K - 100K
-Itemtype,http://schema.org/BroadcastFrequencySpecification,< 1K
-Itemtype,http://schema.org/BroadcastService,1K - 10K
-Itemtype,http://schema.org/BrokerageAccount,< 1K
-Itemtype,http://schema.org/BuddhistTemple,< 1K
-Itemtype,http://schema.org/BusOrCoach,< 1K
-Itemtype,http://schema.org/BusReservation,< 1K
-Itemtype,http://schema.org/BusStation,< 1K
-Itemtype,http://schema.org/BusStop,< 1K
-Itemtype,http://schema.org/BusTrip,1K - 10K
-Itemtype,http://schema.org/BusinessAudience,10K - 100K
-Itemtype,http://schema.org/BusinessEntityType,< 1K
-Itemtype,http://schema.org/BusinessEvent,1K - 10K
-Itemtype,http://schema.org/BusinessFunction,< 1K
-Itemtype,http://schema.org/BuyAction,1M - 10M
-Itemtype,http://schema.org/CDCPMDRecord,< 1K
-Itemtype,http://schema.org/CableOrSatelliteService,< 1K
-Itemtype,http://schema.org/CafeOrCoffeeShop,1K - 10K
-Itemtype,http://schema.org/Campground,1K - 10K
-Itemtype,http://schema.org/CampingPitch,< 1K
-Itemtype,http://schema.org/Canal,< 1K
-Itemtype,http://schema.org/CancelAction,< 1K
-Itemtype,http://schema.org/Car,10K - 100K
-Itemtype,http://schema.org/CarUsageType,< 1K
-Itemtype,http://schema.org/Casino,100K - 1M
-Itemtype,http://schema.org/CategoryCode,1K - 10K
-Itemtype,http://schema.org/CategoryCodeSet,< 1K
-Itemtype,http://schema.org/CatholicChurch,< 1K
-Itemtype,http://schema.org/Cemetery,< 1K
-Itemtype,http://schema.org/Certification,10K - 100K
-Itemtype,http://schema.org/CertificationStatusEnumeration,< 1K
-Itemtype,http://schema.org/Chapter,1K - 10K
-Itemtype,http://schema.org/CheckAction,< 1K
-Itemtype,http://schema.org/CheckInAction,< 1K
-Itemtype,http://schema.org/CheckOutAction,< 1K
-Itemtype,http://schema.org/CheckoutPage,1K - 10K
-Itemtype,http://schema.org/ChemicalSubstance,1K - 10K
-Itemtype,http://schema.org/ChildCare,1K - 10K
-Itemtype,http://schema.org/ChildrensEvent,< 1K
-Itemtype,http://schema.org/ChooseAction,1K - 10K
-Itemtype,http://schema.org/Church,1K - 10K
-Itemtype,http://schema.org/City,100K - 1M
-Itemtype,http://schema.org/CityHall,< 1K
-Itemtype,http://schema.org/CivicStructure,1K - 10K
-Itemtype,http://schema.org/Claim,1K - 10K
-Itemtype,http://schema.org/ClaimReview,1K - 10K
-Itemtype,http://schema.org/Class,< 1K
-Itemtype,http://schema.org/Clip,10K - 100K
-Itemtype,http://schema.org/ClothingStore,10K - 100K
-Itemtype,http://schema.org/Code,< 1K
-Itemtype,http://schema.org/Collection,10K - 100K
-Itemtype,http://schema.org/CollectionPage,1M - 10M
-Itemtype,http://schema.org/CollegeOrUniversity,10K - 100K
-Itemtype,http://schema.org/ComedyClub,< 1K
-Itemtype,http://schema.org/ComedyEvent,1K - 10K
-Itemtype,http://schema.org/ComicCoverArt,< 1K
-Itemtype,http://schema.org/ComicIssue,< 1K
-Itemtype,http://schema.org/ComicSeries,1K - 10K
-Itemtype,http://schema.org/ComicStory,< 1K
-Itemtype,http://schema.org/Comment,100K - 1M
-Itemtype,http://schema.org/CommentAction,1M - 10M
-Itemtype,http://schema.org/CommunicateAction,10K - 100K
-Itemtype,http://schema.org/CommunityHealth,1K - 10K
-Itemtype,http://schema.org/CompleteDataFeed,< 1K
-Itemtype,http://schema.org/CompoundPriceSpecification,1K - 10K
-Itemtype,http://schema.org/ComputerLanguage,< 1K
-Itemtype,http://schema.org/ComputerStore,1K - 10K
-Itemtype,http://schema.org/ConferenceEvent,< 1K
-Itemtype,http://schema.org/ConfirmAction,< 1K
-Itemtype,http://schema.org/Consortium,< 1K
-Itemtype,http://schema.org/ConstraintNode,< 1K
-Itemtype,http://schema.org/ConsumeAction,< 1K
-Itemtype,http://schema.org/ContactPage,100K - 1M
-Itemtype,http://schema.org/ContactPoint,1M - 10M
-Itemtype,http://schema.org/ContactPointOption,< 1K
-Itemtype,http://schema.org/Continent,1K - 10K
-Itemtype,http://schema.org/ControlAction,< 1K
-Itemtype,http://schema.org/ConvenienceStore,< 1K
-Itemtype,http://schema.org/Conversation,< 1K
-Itemtype,http://schema.org/CookAction,< 1K
-Itemtype,http://schema.org/Cooperative,< 1K
-Itemtype,http://schema.org/Corporation,100K - 1M
-Itemtype,http://schema.org/CorrectionComment,< 1K
-Itemtype,http://schema.org/Country,1M - 10M
-Itemtype,http://schema.org/Course,100K - 1M
-Itemtype,http://schema.org/CourseInstance,10K - 100K
-Itemtype,http://schema.org/Courthouse,< 1K
-Itemtype,http://schema.org/CoverArt,< 1K
-Itemtype,http://schema.org/CovidTestingFacility,< 1K
-Itemtype,http://schema.org/CreateAction,1K - 10K
-Itemtype,http://schema.org/CreativeWork,1M - 10M
-Itemtype,http://schema.org/CreativeWorkSeason,1K - 10K
-Itemtype,http://schema.org/CreativeWorkSeries,10K - 100K
-Itemtype,http://schema.org/Credential,10K - 100K
-Itemtype,http://schema.org/CreditCard,1K - 10K
-Itemtype,http://schema.org/Crematorium,< 1K
-Itemtype,http://schema.org/CriticReview,< 1K
-Itemtype,http://schema.org/CssSelectorType,< 1K
-Itemtype,http://schema.org/CurrencyConversionService,< 1K
-Itemtype,http://schema.org/DDxElement,< 1K
-Itemtype,http://schema.org/DENonprofitType,< 1K
-Itemtype,http://schema.org/DanceEvent,< 1K
-Itemtype,http://schema.org/DanceGroup,< 1K
-Itemtype,http://schema.org/DataCatalog,1K - 10K
-Itemtype,http://schema.org/DataDownload,10K - 100K
-Itemtype,http://schema.org/DataFeed,1K - 10K
-Itemtype,http://schema.org/DataFeedItem,1K - 10K
-Itemtype,http://schema.org/DataType,< 1K
-Itemtype,http://schema.org/Dataset,10K - 100K
-Itemtype,http://schema.org/Date,< 1K
-Itemtype,http://schema.org/DateTime,< 1K
-Itemtype,http://schema.org/DatedMoneySpecification,< 1K
-Itemtype,http://schema.org/DayOfWeek,10K - 100K
-Itemtype,http://schema.org/DaySpa,1K - 10K
-Itemtype,http://schema.org/DeactivateAction,< 1K
-Itemtype,http://schema.org/DefenceEstablishment,< 1K
-Itemtype,http://schema.org/DefinedRegion,100K - 1M
-Itemtype,http://schema.org/DefinedTerm,10K - 100K
-Itemtype,http://schema.org/DefinedTermSet,10K - 100K
-Itemtype,http://schema.org/DeleteAction,< 1K
-Itemtype,http://schema.org/DeliveryChargeSpecification,10K - 100K
-Itemtype,http://schema.org/DeliveryEvent,< 1K
-Itemtype,http://schema.org/DeliveryMethod,1K - 10K
-Itemtype,http://schema.org/DeliveryTimeSettings,< 1K
-Itemtype,http://schema.org/Demand,1K - 10K
-Itemtype,http://schema.org/Dentist,10K - 100K
-Itemtype,http://schema.org/DepartAction,< 1K
-Itemtype,http://schema.org/DepartmentStore,1K - 10K
-Itemtype,http://schema.org/DepositAccount,< 1K
-Itemtype,http://schema.org/Dermatology,1K - 10K
-Itemtype,http://schema.org/DiagnosticLab,1K - 10K
-Itemtype,http://schema.org/DiagnosticProcedure,< 1K
-Itemtype,http://schema.org/Diet,< 1K
-Itemtype,http://schema.org/DietNutrition,1K - 10K
-Itemtype,http://schema.org/DietarySupplement,< 1K
-Itemtype,http://schema.org/DigitalDocument,10K - 100K
-Itemtype,http://schema.org/DigitalDocumentPermission,< 1K
-Itemtype,http://schema.org/DigitalDocumentPermissionType,< 1K
-Itemtype,http://schema.org/DigitalPlatformEnumeration,< 1K
-Itemtype,http://schema.org/DisagreeAction,< 1K
-Itemtype,http://schema.org/DiscoverAction,< 1K
-Itemtype,http://schema.org/DiscussionForumPosting,10K - 100K
-Itemtype,http://schema.org/DislikeAction,1K - 10K
-Itemtype,http://schema.org/Distance,1K - 10K
-Itemtype,http://schema.org/Distillery,< 1K
-Itemtype,http://schema.org/DonateAction,1K - 10K
-Itemtype,http://schema.org/DoseSchedule,< 1K
-Itemtype,http://schema.org/DownloadAction,1K - 10K
-Itemtype,http://schema.org/DrawAction,< 1K
-Itemtype,http://schema.org/Drawing,< 1K
-Itemtype,http://schema.org/DrinkAction,< 1K
-Itemtype,http://schema.org/DriveWheelConfigurationValue,< 1K
-Itemtype,http://schema.org/Drug,1K - 10K
-Itemtype,http://schema.org/DrugClass,1K - 10K
-Itemtype,http://schema.org/DrugCost,< 1K
-Itemtype,http://schema.org/DrugCostCategory,< 1K
-Itemtype,http://schema.org/DrugLegalStatus,< 1K
-Itemtype,http://schema.org/DrugPregnancyCategory,< 1K
-Itemtype,http://schema.org/DrugPrescriptionStatus,< 1K
-Itemtype,http://schema.org/DrugStrength,< 1K
-Itemtype,http://schema.org/DryCleaningOrLaundry,1K - 10K
-Itemtype,http://schema.org/Duration,10K - 100K
-Itemtype,http://schema.org/EUEnergyEfficiencyEnumeration,< 1K
-Itemtype,http://schema.org/EatAction,< 1K
-Itemtype,http://schema.org/EducationEvent,1K - 10K
-Itemtype,http://schema.org/EducationalAudience,10K - 100K
-Itemtype,http://schema.org/EducationalOccupationalCredential,100K - 1M
-Itemtype,http://schema.org/EducationalOccupationalProgram,1K - 10K
-Itemtype,http://schema.org/EducationalOrganization,100K - 1M
-Itemtype,http://schema.org/Electrician,10K - 100K
-Itemtype,http://schema.org/ElectronicsStore,1K - 10K
-Itemtype,http://schema.org/ElementarySchool,< 1K
-Itemtype,http://schema.org/EmailMessage,< 1K
-Itemtype,http://schema.org/Embassy,< 1K
-Itemtype,http://schema.org/Emergency,< 1K
-Itemtype,http://schema.org/EmergencyService,1K - 10K
-Itemtype,http://schema.org/EmployeeRole,< 1K
-Itemtype,http://schema.org/EmployerAggregateRating,1K - 10K
-Itemtype,http://schema.org/EmployerReview,< 1K
-Itemtype,http://schema.org/EmploymentAgency,1K - 10K
-Itemtype,http://schema.org/EndorseAction,< 1K
-Itemtype,http://schema.org/EndorsementRating,< 1K
-Itemtype,http://schema.org/Energy,< 1K
-Itemtype,http://schema.org/EnergyConsumptionDetails,1K - 10K
-Itemtype,http://schema.org/EnergyEfficiencyEnumeration,< 1K
-Itemtype,http://schema.org/EnergyStarEnergyEfficiencyEnumeration,< 1K
-Itemtype,http://schema.org/EngineSpecification,10K - 100K
-Itemtype,http://schema.org/EntertainmentBusiness,10K - 100K
-Itemtype,http://schema.org/EntryPoint,10M+
-Itemtype,http://schema.org/Enumeration,1K - 10K
-Itemtype,http://schema.org/Episode,1K - 10K
-Itemtype,http://schema.org/Error,< 1K
-Itemtype,http://schema.org/Event,100K - 1M
-Itemtype,http://schema.org/EventAttendanceModeEnumeration,< 1K
-Itemtype,http://schema.org/EventReservation,< 1K
-Itemtype,http://schema.org/EventSeries,1K - 10K
-Itemtype,http://schema.org/EventStatusType,< 1K
-Itemtype,http://schema.org/EventVenue,10K - 100K
-Itemtype,http://schema.org/ExchangeRateSpecification,< 1K
-Itemtype,http://schema.org/ExerciseAction,< 1K
-Itemtype,http://schema.org/ExerciseGym,1K - 10K
-Itemtype,http://schema.org/ExercisePlan,< 1K
-Itemtype,http://schema.org/ExhibitionEvent,1K - 10K
-Itemtype,http://schema.org/FAQPage,1M - 10M
-Itemtype,http://schema.org/FMRadioChannel,< 1K
-Itemtype,http://schema.org/FastFoodRestaurant,1K - 10K
-Itemtype,http://schema.org/Festival,1K - 10K
-Itemtype,http://schema.org/FilmAction,< 1K
-Itemtype,http://schema.org/FinancialIncentive,< 1K
-Itemtype,http://schema.org/FinancialProduct,10K - 100K
-Itemtype,http://schema.org/FinancialService,10K - 100K
-Itemtype,http://schema.org/FindAction,1K - 10K
-Itemtype,http://schema.org/FireStation,< 1K
-Itemtype,http://schema.org/Flight,1K - 10K
-Itemtype,http://schema.org/FlightReservation,< 1K
-Itemtype,http://schema.org/Float,< 1K
-Itemtype,http://schema.org/FloorPlan,10K - 100K
-Itemtype,http://schema.org/Florist,10K - 100K
-Itemtype,http://schema.org/FollowAction,10K - 100K
-Itemtype,http://schema.org/FoodEstablishment,10K - 100K
-Itemtype,http://schema.org/FoodEstablishmentReservation,1K - 10K
-Itemtype,http://schema.org/FoodEvent,1K - 10K
-Itemtype,http://schema.org/FoodService,1K - 10K
-Itemtype,http://schema.org/FulfillmentTypeEnumeration,< 1K
-Itemtype,http://schema.org/FundingAgency,< 1K
-Itemtype,http://schema.org/FundingScheme,< 1K
-Itemtype,http://schema.org/FurnitureStore,10K - 100K
-Itemtype,http://schema.org/Game,100K - 1M
-Itemtype,http://schema.org/GameAvailabilityEnumeration,< 1K
-Itemtype,http://schema.org/GamePlayMode,< 1K
-Itemtype,http://schema.org/GameServer,1K - 10K
-Itemtype,http://schema.org/GameServerStatus,< 1K
-Itemtype,http://schema.org/GardenStore,1K - 10K
-Itemtype,http://schema.org/GasStation,1K - 10K
-Itemtype,http://schema.org/GatedResidenceCommunity,< 1K
-Itemtype,http://schema.org/GenderType,< 1K
-Itemtype,http://schema.org/Gene,< 1K
-Itemtype,http://schema.org/GeneralContractor,10K - 100K
-Itemtype,http://schema.org/GeoCircle,100K - 1M
-Itemtype,http://schema.org/GeoCoordinates,1M - 10M
-Itemtype,http://schema.org/GeoShape,10K - 100K
-Itemtype,http://schema.org/GeospatialGeometry,< 1K
-Itemtype,http://schema.org/Geriatric,< 1K
-Itemtype,http://schema.org/GiveAction,< 1K
-Itemtype,http://schema.org/GolfCourse,1K - 10K
-Itemtype,http://schema.org/GovernmentBenefitsType,< 1K
-Itemtype,http://schema.org/GovernmentBuilding,< 1K
-Itemtype,http://schema.org/GovernmentOffice,1K - 10K
-Itemtype,http://schema.org/GovernmentOrganization,10K - 100K
-Itemtype,http://schema.org/GovernmentPermit,< 1K
-Itemtype,http://schema.org/GovernmentService,1K - 10K
-Itemtype,http://schema.org/Grant,1K - 10K
-Itemtype,http://schema.org/GroceryStore,1K - 10K
-Itemtype,http://schema.org/Guide,1K - 10K
-Itemtype,http://schema.org/Gynecologic,< 1K
-Itemtype,http://schema.org/HVACBusiness,10K - 100K
-Itemtype,http://schema.org/Hackathon,< 1K
-Itemtype,http://schema.org/HairSalon,10K - 100K
-Itemtype,http://schema.org/HardwareStore,1K - 10K
-Itemtype,http://schema.org/HealthAndBeautyBusiness,10K - 100K
-Itemtype,http://schema.org/HealthAspectEnumeration,< 1K
-Itemtype,http://schema.org/HealthClub,1K - 10K
-Itemtype,http://schema.org/HealthInsurancePlan,< 1K
-Itemtype,http://schema.org/HealthPlanCostSharingSpecification,< 1K
-Itemtype,http://schema.org/HealthPlanFormulary,< 1K
-Itemtype,http://schema.org/HealthPlanNetwork,< 1K
-Itemtype,http://schema.org/HealthTopicContent,< 1K
-Itemtype,http://schema.org/HighSchool,1K - 10K
-Itemtype,http://schema.org/HinduTemple,< 1K
-Itemtype,http://schema.org/HobbyShop,1K - 10K
-Itemtype,http://schema.org/HomeAndConstructionBusiness,100K - 1M
-Itemtype,http://schema.org/HomeGoodsStore,1K - 10K
-Itemtype,http://schema.org/Hospital,10K - 100K
-Itemtype,http://schema.org/Hostel,1K - 10K
-Itemtype,http://schema.org/Hotel,100K - 1M
-Itemtype,http://schema.org/HotelRoom,10K - 100K
-Itemtype,http://schema.org/House,10K - 100K
-Itemtype,http://schema.org/HousePainter,1K - 10K
-Itemtype,http://schema.org/HowTo,100K - 1M
-Itemtype,http://schema.org/HowToDirection,10K - 100K
-Itemtype,http://schema.org/HowToItem,< 1K
-Itemtype,http://schema.org/HowToSection,10K - 100K
-Itemtype,http://schema.org/HowToStep,100K - 1M
-Itemtype,http://schema.org/HowToSupply,10K - 100K
-Itemtype,http://schema.org/HowToTip,1K - 10K
-Itemtype,http://schema.org/HowToTool,10K - 100K
-Itemtype,http://schema.org/HyperToc,< 1K
-Itemtype,http://schema.org/HyperTocEntry,< 1K
-Itemtype,http://schema.org/IPTCDigitalSourceEnumeration,< 1K
-Itemtype,http://schema.org/ITNonprofitType,< 1K
-Itemtype,http://schema.org/IceCreamShop,1K - 10K
-Itemtype,http://schema.org/IgnoreAction,< 1K
-Itemtype,http://schema.org/ImageGallery,1M - 10M
-Itemtype,http://schema.org/ImageObject,10M+
-Itemtype,http://schema.org/ImageObjectSnapshot,< 1K
-Itemtype,http://schema.org/ImagingTest,< 1K
-Itemtype,http://schema.org/IncentiveQualifiedExpenseType,< 1K
-Itemtype,http://schema.org/IncentiveStatus,< 1K
-Itemtype,http://schema.org/IncentiveType,< 1K
-Itemtype,http://schema.org/IndividualPhysician,1K - 10K
-Itemtype,http://schema.org/IndividualProduct,10K - 100K
-Itemtype,http://schema.org/InfectiousAgentClass,< 1K
-Itemtype,http://schema.org/InfectiousDisease,< 1K
-Itemtype,http://schema.org/InformAction,< 1K
-Itemtype,http://schema.org/InsertAction,< 1K
-Itemtype,http://schema.org/InstallAction,< 1K
-Itemtype,http://schema.org/InstantaneousEvent,< 1K
-Itemtype,http://schema.org/InsuranceAgency,10K - 100K
-Itemtype,http://schema.org/Intangible,1K - 10K
-Itemtype,http://schema.org/Integer,< 1K
-Itemtype,http://schema.org/InteractAction,1K - 10K
-Itemtype,http://schema.org/InteractionCounter,100K - 1M
-Itemtype,http://schema.org/InternetCafe,< 1K
-Itemtype,http://schema.org/InvestmentFund,< 1K
-Itemtype,http://schema.org/InvestmentOrDeposit,< 1K
-Itemtype,http://schema.org/InviteAction,< 1K
-Itemtype,http://schema.org/Invoice,< 1K
-Itemtype,http://schema.org/ItemAvailability,1K - 10K
-Itemtype,http://schema.org/ItemList,1M - 10M
-Itemtype,http://schema.org/ItemListOrderType,< 1K
-Itemtype,http://schema.org/ItemPage,1M - 10M
-Itemtype,http://schema.org/JewelryStore,10K - 100K
-Itemtype,http://schema.org/JobPosting,100K - 1M
-Itemtype,http://schema.org/JoinAction,1K - 10K
-Itemtype,http://schema.org/Joint,< 1K
-Itemtype,http://schema.org/LakeBodyOfWater,< 1K
-Itemtype,http://schema.org/Landform,1K - 10K
-Itemtype,http://schema.org/LandmarksOrHistoricalBuildings,1K - 10K
-Itemtype,http://schema.org/Language,10K - 100K
-Itemtype,http://schema.org/LearningResource,1K - 10K
-Itemtype,http://schema.org/LeaveAction,< 1K
-Itemtype,http://schema.org/LegalForceStatus,< 1K
-Itemtype,http://schema.org/LegalService,10K - 100K
-Itemtype,http://schema.org/LegalValueLevel,< 1K
-Itemtype,http://schema.org/Legislation,1K - 10K
-Itemtype,http://schema.org/LegislationObject,1K - 10K
-Itemtype,http://schema.org/LegislativeBuilding,< 1K
-Itemtype,http://schema.org/LendAction,< 1K
-Itemtype,http://schema.org/Library,1K - 10K
-Itemtype,http://schema.org/LibrarySystem,< 1K
-Itemtype,http://schema.org/LifestyleModification,< 1K
-Itemtype,http://schema.org/Ligament,< 1K
-Itemtype,http://schema.org/LikeAction,10K - 100K
-Itemtype,http://schema.org/LinkRole,< 1K
-Itemtype,http://schema.org/LiquorStore,1K - 10K
-Itemtype,http://schema.org/ListItem,10M+
-Itemtype,http://schema.org/ListenAction,1K - 10K
-Itemtype,http://schema.org/Literal,< 1K
-Itemtype,http://schema.org/LiteraryEvent,< 1K
-Itemtype,http://schema.org/LiveBlogPosting,1K - 10K
-Itemtype,http://schema.org/LoanOrCredit,1K - 10K
-Itemtype,http://schema.org/LocalBusiness,1M - 10M
-Itemtype,http://schema.org/LocationFeatureSpecification,100K - 1M
-Itemtype,http://schema.org/Locksmith,10K - 100K
-Itemtype,http://schema.org/LodgingBusiness,10K - 100K
-Itemtype,http://schema.org/LodgingReservation,1K - 10K
-Itemtype,http://schema.org/LoginAction,1K - 10K
-Itemtype,http://schema.org/LoseAction,< 1K
-Itemtype,http://schema.org/LymphaticVessel,< 1K
-Itemtype,http://schema.org/Manuscript,< 1K
-Itemtype,http://schema.org/Map,10K - 100K
-Itemtype,http://schema.org/MapCategoryType,< 1K
-Itemtype,http://schema.org/MarryAction,< 1K
-Itemtype,http://schema.org/Mass,< 1K
-Itemtype,http://schema.org/MathSolver,< 1K
-Itemtype,http://schema.org/MaximumDoseSchedule,< 1K
-Itemtype,http://schema.org/MeasurementMethodEnum,< 1K
-Itemtype,http://schema.org/MeasurementTypeEnumeration,< 1K
-Itemtype,http://schema.org/MediaEnumeration,< 1K
-Itemtype,http://schema.org/MediaGallery,1K - 10K
-Itemtype,http://schema.org/MediaManipulationRatingEnumeration,< 1K
-Itemtype,http://schema.org/MediaObject,100K - 1M
-Itemtype,http://schema.org/MediaReview,< 1K
-Itemtype,http://schema.org/MediaReviewItem,< 1K
-Itemtype,http://schema.org/MediaSubscription,< 1K
-Itemtype,http://schema.org/MedicalAudience,10K - 100K
-Itemtype,http://schema.org/MedicalAudienceType,< 1K
-Itemtype,http://schema.org/MedicalBusiness,100K - 1M
-Itemtype,http://schema.org/MedicalCause,1K - 10K
-Itemtype,http://schema.org/MedicalClinic,10K - 100K
-Itemtype,http://schema.org/MedicalCode,1K - 10K
-Itemtype,http://schema.org/MedicalCondition,10K - 100K
-Itemtype,http://schema.org/MedicalConditionStage,< 1K
-Itemtype,http://schema.org/MedicalContraindication,< 1K
-Itemtype,http://schema.org/MedicalDevice,1K - 10K
-Itemtype,http://schema.org/MedicalDevicePurpose,< 1K
-Itemtype,http://schema.org/MedicalEntity,1K - 10K
-Itemtype,http://schema.org/MedicalEnumeration,< 1K
-Itemtype,http://schema.org/MedicalEvidenceLevel,< 1K
-Itemtype,http://schema.org/MedicalGuideline,1K - 10K
-Itemtype,http://schema.org/MedicalGuidelineContraindication,< 1K
-Itemtype,http://schema.org/MedicalGuidelineRecommendation,< 1K
-Itemtype,http://schema.org/MedicalImagingTechnique,< 1K
-Itemtype,http://schema.org/MedicalIndication,1K - 10K
-Itemtype,http://schema.org/MedicalIntangible,< 1K
-Itemtype,http://schema.org/MedicalObservationalStudy,< 1K
-Itemtype,http://schema.org/MedicalObservationalStudyDesign,< 1K
-Itemtype,http://schema.org/MedicalOrganization,10K - 100K
-Itemtype,http://schema.org/MedicalProcedure,10K - 100K
-Itemtype,http://schema.org/MedicalProcedureType,< 1K
-Itemtype,http://schema.org/MedicalRiskCalculator,< 1K
-Itemtype,http://schema.org/MedicalRiskEstimator,< 1K
-Itemtype,http://schema.org/MedicalRiskFactor,1K - 10K
-Itemtype,http://schema.org/MedicalRiskScore,< 1K
-Itemtype,http://schema.org/MedicalScholarlyArticle,1K - 10K
-Itemtype,http://schema.org/MedicalSign,< 1K
-Itemtype,http://schema.org/MedicalSignOrSymptom,1K - 10K
-Itemtype,http://schema.org/MedicalSpecialty,10K - 100K
-Itemtype,http://schema.org/MedicalStudy,1K - 10K
-Itemtype,http://schema.org/MedicalStudyStatus,< 1K
-Itemtype,http://schema.org/MedicalSymptom,1K - 10K
-Itemtype,http://schema.org/MedicalTest,1K - 10K
-Itemtype,http://schema.org/MedicalTestPanel,< 1K
-Itemtype,http://schema.org/MedicalTherapy,10K - 100K
-Itemtype,http://schema.org/MedicalTrial,< 1K
-Itemtype,http://schema.org/MedicalTrialDesign,< 1K
-Itemtype,http://schema.org/MedicalWebPage,10K - 100K
-Itemtype,http://schema.org/MedicineSystem,< 1K
-Itemtype,http://schema.org/MeetingRoom,1K - 10K
-Itemtype,http://schema.org/MemberProgram,1K - 10K
-Itemtype,http://schema.org/MemberProgramTier,1K - 10K
-Itemtype,http://schema.org/MensClothingStore,< 1K
-Itemtype,http://schema.org/Menu,100K - 1M
-Itemtype,http://schema.org/MenuItem,10K - 100K
-Itemtype,http://schema.org/MenuSection,10K - 100K
-Itemtype,http://schema.org/MerchantReturnEnumeration,< 1K
-Itemtype,http://schema.org/MerchantReturnPolicy,100K - 1M
-Itemtype,http://schema.org/MerchantReturnPolicySeasonalOverride,1K - 10K
-Itemtype,http://schema.org/Message,1K - 10K
-Itemtype,http://schema.org/MiddleSchool,< 1K
-Itemtype,http://schema.org/Midwifery,< 1K
-Itemtype,http://schema.org/MobileApplication,100K - 1M
-Itemtype,http://schema.org/MobilePhoneStore,1K - 10K
-Itemtype,http://schema.org/MolecularEntity,< 1K
-Itemtype,http://schema.org/MonetaryAmount,100K - 1M
-Itemtype,http://schema.org/MonetaryAmountDistribution,1K - 10K
-Itemtype,http://schema.org/MonetaryGrant,1K - 10K
-Itemtype,http://schema.org/MoneyTransfer,< 1K
-Itemtype,http://schema.org/MortgageLoan,< 1K
-Itemtype,http://schema.org/Mosque,< 1K
-Itemtype,http://schema.org/Motel,< 1K
-Itemtype,http://schema.org/Motorcycle,1K - 10K
-Itemtype,http://schema.org/MotorcycleDealer,1K - 10K
-Itemtype,http://schema.org/MotorcycleRepair,< 1K
-Itemtype,http://schema.org/MotorizedBicycle,< 1K
-Itemtype,http://schema.org/Mountain,< 1K
-Itemtype,http://schema.org/MoveAction,< 1K
-Itemtype,http://schema.org/Movie,10K - 100K
-Itemtype,http://schema.org/MovieClip,< 1K
-Itemtype,http://schema.org/MovieRentalStore,< 1K
-Itemtype,http://schema.org/MovieSeries,< 1K
-Itemtype,http://schema.org/MovieTheater,1K - 10K
-Itemtype,http://schema.org/MovingCompany,10K - 100K
-Itemtype,http://schema.org/Muscle,< 1K
-Itemtype,http://schema.org/Museum,1K - 10K
-Itemtype,http://schema.org/MusicAlbum,10K - 100K
-Itemtype,http://schema.org/MusicAlbumProductionType,< 1K
-Itemtype,http://schema.org/MusicAlbumReleaseType,< 1K
-Itemtype,http://schema.org/MusicComposition,1K - 10K
-Itemtype,http://schema.org/MusicEvent,10K - 100K
-Itemtype,http://schema.org/MusicGroup,10K - 100K
-Itemtype,http://schema.org/MusicPlaylist,1K - 10K
-Itemtype,http://schema.org/MusicRecording,10K - 100K
-Itemtype,http://schema.org/MusicRelease,1K - 10K
-Itemtype,http://schema.org/MusicReleaseFormatType,< 1K
-Itemtype,http://schema.org/MusicStore,1K - 10K
-Itemtype,http://schema.org/MusicVenue,1K - 10K
-Itemtype,http://schema.org/MusicVideoObject,< 1K
-Itemtype,http://schema.org/NGO,10K - 100K
-Itemtype,http://schema.org/NLNonprofitType,< 1K
-Itemtype,http://schema.org/NailSalon,1K - 10K
-Itemtype,http://schema.org/Nerve,< 1K
-Itemtype,http://schema.org/NewsArticle,100K - 1M
-Itemtype,http://schema.org/NewsMediaOrganization,10K - 100K
-Itemtype,http://schema.org/Newspaper,< 1K
-Itemtype,http://schema.org/NightClub,1K - 10K
-Itemtype,http://schema.org/NonprofitType,< 1K
-Itemtype,http://schema.org/Notary,1K - 10K
-Itemtype,http://schema.org/NoteDigitalDocument,< 1K
-Itemtype,http://schema.org/Number,< 1K
-Itemtype,http://schema.org/Nursing,< 1K
-Itemtype,http://schema.org/NutritionInformation,10K - 100K
-Itemtype,http://schema.org/Observation,< 1K
-Itemtype,http://schema.org/Obstetric,< 1K
-Itemtype,http://schema.org/Occupation,10K - 100K
-Itemtype,http://schema.org/OccupationalExperienceRequirements,1K - 10K
-Itemtype,http://schema.org/OccupationalTherapy,< 1K
-Itemtype,http://schema.org/OceanBodyOfWater,< 1K
-Itemtype,http://schema.org/Offer,10M+
-Itemtype,http://schema.org/OfferCatalog,100K - 1M
-Itemtype,http://schema.org/OfferForLease,1K - 10K
-Itemtype,http://schema.org/OfferForPurchase,1K - 10K
-Itemtype,http://schema.org/OfferItemCondition,1K - 10K
-Itemtype,http://schema.org/OfferShippingDetails,100K - 1M
-Itemtype,http://schema.org/OfficeEquipmentStore,1K - 10K
-Itemtype,http://schema.org/OnDemandEvent,< 1K
-Itemtype,http://schema.org/Oncologic,< 1K
-Itemtype,http://schema.org/OnlineBusiness,10K - 100K
-Itemtype,http://schema.org/OnlineMarketplace,< 1K
-Itemtype,http://schema.org/OnlineStore,100K - 1M
-Itemtype,http://schema.org/OpeningHoursSpecification,1M - 10M
-Itemtype,http://schema.org/OperatingSystem,< 1K
-Itemtype,http://schema.org/OpinionNewsArticle,1K - 10K
-Itemtype,http://schema.org/Optician,1K - 10K
-Itemtype,http://schema.org/Optometric,1K - 10K
-Itemtype,http://schema.org/Order,1K - 10K
-Itemtype,http://schema.org/OrderAction,10K - 100K
-Itemtype,http://schema.org/OrderItem,< 1K
-Itemtype,http://schema.org/OrderStatus,< 1K
-Itemtype,http://schema.org/Organization,10M+
-Itemtype,http://schema.org/OrganizationRole,1K - 10K
-Itemtype,http://schema.org/OrganizeAction,< 1K
-Itemtype,http://schema.org/Otolaryngologic,< 1K
-Itemtype,http://schema.org/OutletStore,< 1K
-Itemtype,http://schema.org/OwnershipInfo,< 1K
-Itemtype,http://schema.org/PaintAction,< 1K
-Itemtype,http://schema.org/Painting,< 1K
-Itemtype,http://schema.org/PalliativeProcedure,< 1K
-Itemtype,http://schema.org/ParcelDelivery,< 1K
-Itemtype,http://schema.org/ParentAudience,< 1K
-Itemtype,http://schema.org/Park,1K - 10K
-Itemtype,http://schema.org/ParkingFacility,1K - 10K
-Itemtype,http://schema.org/PathologyTest,< 1K
-Itemtype,http://schema.org/Patient,1K - 10K
-Itemtype,http://schema.org/PawnShop,< 1K
-Itemtype,http://schema.org/PayAction,< 1K
-Itemtype,http://schema.org/PaymentCard,< 1K
-Itemtype,http://schema.org/PaymentChargeSpecification,< 1K
-Itemtype,http://schema.org/PaymentMethod,10K - 100K
-Itemtype,http://schema.org/PaymentMethodType,< 1K
-Itemtype,http://schema.org/PaymentService,1K - 10K
-Itemtype,http://schema.org/PaymentStatusType,< 1K
-Itemtype,http://schema.org/Pediatric,< 1K
-Itemtype,http://schema.org/PeopleAudience,10K - 100K
-Itemtype,http://schema.org/PerformAction,< 1K
-Itemtype,http://schema.org/PerformanceRole,< 1K
-Itemtype,http://schema.org/PerformingArtsEvent,< 1K
-Itemtype,http://schema.org/PerformingArtsTheater,1K - 10K
-Itemtype,http://schema.org/PerformingGroup,10K - 100K
-Itemtype,http://schema.org/Periodical,1K - 10K
-Itemtype,http://schema.org/Permit,10K - 100K
-Itemtype,http://schema.org/Person,10M+
-Itemtype,http://schema.org/PetStore,1K - 10K
-Itemtype,http://schema.org/Pharmacy,10K - 100K
-Itemtype,http://schema.org/Photograph,10K - 100K
-Itemtype,http://schema.org/PhotographAction,< 1K
-Itemtype,http://schema.org/PhysicalActivity,< 1K
-Itemtype,http://schema.org/PhysicalActivityCategory,1K - 10K
-Itemtype,http://schema.org/PhysicalExam,< 1K
-Itemtype,http://schema.org/PhysicalTherapy,< 1K
-Itemtype,http://schema.org/Physician,10K - 100K
-Itemtype,http://schema.org/PhysiciansOffice,< 1K
-Itemtype,http://schema.org/Physiotherapy,1K - 10K
-Itemtype,http://schema.org/Place,1M - 10M
-Itemtype,http://schema.org/PlaceOfWorship,1K - 10K
-Itemtype,http://schema.org/PlanAction,< 1K
-Itemtype,http://schema.org/PlasticSurgery,< 1K
-Itemtype,http://schema.org/Play,< 1K
-Itemtype,http://schema.org/PlayAction,1K - 10K
-Itemtype,http://schema.org/PlayGameAction,< 1K
-Itemtype,http://schema.org/Playground,< 1K
-Itemtype,http://schema.org/Plumber,10K - 100K
-Itemtype,http://schema.org/PodcastEpisode,10K - 100K
-Itemtype,http://schema.org/PodcastSeason,< 1K
-Itemtype,http://schema.org/PodcastSeries,10K - 100K
-Itemtype,http://schema.org/Podiatric,< 1K
-Itemtype,http://schema.org/PoliceStation,< 1K
-Itemtype,http://schema.org/PoliticalParty,< 1K
-Itemtype,http://schema.org/Pond,< 1K
-Itemtype,http://schema.org/PostOffice,< 1K
-Itemtype,http://schema.org/PostalAddress,10M+
-Itemtype,http://schema.org/PostalCodeRangeSpecification,1K - 10K
-Itemtype,http://schema.org/Poster,< 1K
-Itemtype,http://schema.org/PreOrderAction,< 1K
-Itemtype,http://schema.org/PrependAction,< 1K
-Itemtype,http://schema.org/Preschool,1K - 10K
-Itemtype,http://schema.org/PresentationDigitalDocument,< 1K
-Itemtype,http://schema.org/PreventionIndication,< 1K
-Itemtype,http://schema.org/PriceComponentTypeEnumeration,< 1K
-Itemtype,http://schema.org/PriceSpecification,100K - 1M
-Itemtype,http://schema.org/PriceTypeEnumeration,< 1K
-Itemtype,http://schema.org/PrimaryCare,< 1K
-Itemtype,http://schema.org/Product,10M+
-Itemtype,http://schema.org/ProductCollection,1K - 10K
-Itemtype,http://schema.org/ProductGroup,100K - 1M
-Itemtype,http://schema.org/ProductModel,1K - 10K
-Itemtype,http://schema.org/ProductReturnEnumeration,< 1K
-Itemtype,http://schema.org/ProductReturnPolicy,< 1K
-Itemtype,http://schema.org/ProfessionalService,100K - 1M
-Itemtype,http://schema.org/ProfilePage,1M - 10M
-Itemtype,http://schema.org/ProgramMembership,1K - 10K
-Itemtype,http://schema.org/Project,1K - 10K
-Itemtype,http://schema.org/PronounceableText,< 1K
-Itemtype,http://schema.org/Property,< 1K
-Itemtype,http://schema.org/PropertyValue,100K - 1M
-Itemtype,http://schema.org/PropertyValueSpecification,10M+
-Itemtype,http://schema.org/Protein,< 1K
-Itemtype,http://schema.org/Psychiatric,1K - 10K
-Itemtype,http://schema.org/PsychologicalTreatment,< 1K
-Itemtype,http://schema.org/PublicHealth,< 1K
-Itemtype,http://schema.org/PublicSwimmingPool,< 1K
-Itemtype,http://schema.org/PublicToilet,< 1K
-Itemtype,http://schema.org/PublicationEvent,1K - 10K
-Itemtype,http://schema.org/PublicationIssue,1K - 10K
-Itemtype,http://schema.org/PublicationVolume,1K - 10K
-Itemtype,http://schema.org/PurchaseType,< 1K
-Itemtype,http://schema.org/QAPage,10K - 100K
-Itemtype,http://schema.org/QualitativeValue,1K - 10K
-Itemtype,http://schema.org/QuantitativeValue,1M - 10M
-Itemtype,http://schema.org/QuantitativeValueDistribution,< 1K
-Itemtype,http://schema.org/Quantity,< 1K
-Itemtype,http://schema.org/Question,1M - 10M
-Itemtype,http://schema.org/Quiz,1K - 10K
-Itemtype,http://schema.org/Quotation,1K - 10K
-Itemtype,http://schema.org/QuoteAction,1K - 10K
-Itemtype,http://schema.org/RVPark,< 1K
-Itemtype,http://schema.org/RadiationTherapy,< 1K
-Itemtype,http://schema.org/RadioBroadcastService,< 1K
-Itemtype,http://schema.org/RadioChannel,< 1K
-Itemtype,http://schema.org/RadioClip,< 1K
-Itemtype,http://schema.org/RadioEpisode,< 1K
-Itemtype,http://schema.org/RadioSeason,< 1K
-Itemtype,http://schema.org/RadioSeries,1K - 10K
-Itemtype,http://schema.org/RadioStation,1K - 10K
-Itemtype,http://schema.org/Rating,1M - 10M
-Itemtype,http://schema.org/ReactAction,< 1K
-Itemtype,http://schema.org/ReadAction,10M+
-Itemtype,http://schema.org/RealEstateAgent,100K - 1M
-Itemtype,http://schema.org/RealEstateListing,10K - 100K
-Itemtype,http://schema.org/ReceiveAction,< 1K
-Itemtype,http://schema.org/Recipe,10K - 100K
-Itemtype,http://schema.org/Recommendation,< 1K
-Itemtype,http://schema.org/RecommendedDoseSchedule,< 1K
-Itemtype,http://schema.org/RecyclingCenter,1K - 10K
-Itemtype,http://schema.org/RefundTypeEnumeration,< 1K
-Itemtype,http://schema.org/RegisterAction,10K - 100K
-Itemtype,http://schema.org/RejectAction,< 1K
-Itemtype,http://schema.org/RentAction,1K - 10K
-Itemtype,http://schema.org/RentalCarReservation,< 1K
-Itemtype,http://schema.org/RepaymentSpecification,< 1K
-Itemtype,http://schema.org/ReplaceAction,< 1K
-Itemtype,http://schema.org/ReplyAction,1K - 10K
-Itemtype,http://schema.org/Report,1K - 10K
-Itemtype,http://schema.org/ReportageNewsArticle,1K - 10K
-Itemtype,http://schema.org/ReportedDoseSchedule,< 1K
-Itemtype,http://schema.org/ResearchOrganization,1K - 10K
-Itemtype,http://schema.org/ResearchProject,1K - 10K
-Itemtype,http://schema.org/Researcher,< 1K
-Itemtype,http://schema.org/Reservation,10K - 100K
-Itemtype,http://schema.org/ReservationPackage,< 1K
-Itemtype,http://schema.org/ReservationStatusType,< 1K
-Itemtype,http://schema.org/ReserveAction,10K - 100K
-Itemtype,http://schema.org/Reservoir,< 1K
-Itemtype,http://schema.org/ResetPasswordAction,< 1K
-Itemtype,http://schema.org/Residence,10K - 100K
-Itemtype,http://schema.org/Resort,1K - 10K
-Itemtype,http://schema.org/RespiratoryTherapy,< 1K
-Itemtype,http://schema.org/Restaurant,100K - 1M
-Itemtype,http://schema.org/RestrictedDiet,1K - 10K
-Itemtype,http://schema.org/ResumeAction,< 1K
-Itemtype,http://schema.org/ReturnAction,< 1K
-Itemtype,http://schema.org/ReturnFeesEnumeration,< 1K
-Itemtype,http://schema.org/ReturnLabelSourceEnumeration,< 1K
-Itemtype,http://schema.org/ReturnMethodEnumeration,< 1K
-Itemtype,http://schema.org/Review,1M - 10M
-Itemtype,http://schema.org/ReviewAction,1K - 10K
-Itemtype,http://schema.org/ReviewNewsArticle,< 1K
-Itemtype,http://schema.org/RiverBodyOfWater,< 1K
-Itemtype,http://schema.org/Role,1K - 10K
-Itemtype,http://schema.org/RoofingContractor,10K - 100K
-Itemtype,http://schema.org/Room,1K - 10K
-Itemtype,http://schema.org/RsvpAction,< 1K
-Itemtype,http://schema.org/RsvpResponseType,< 1K
-Itemtype,http://schema.org/RuntimePlatform,< 1K
-Itemtype,http://schema.org/SaleEvent,1K - 10K
-Itemtype,http://schema.org/SatiricalArticle,< 1K
-Itemtype,http://schema.org/Schedule,10K - 100K
-Itemtype,http://schema.org/ScheduleAction,1K - 10K
-Itemtype,http://schema.org/ScholarlyArticle,10K - 100K
-Itemtype,http://schema.org/School,10K - 100K
-Itemtype,http://schema.org/SchoolDistrict,< 1K
-Itemtype,http://schema.org/ScreeningEvent,1K - 10K
-Itemtype,http://schema.org/Sculpture,< 1K
-Itemtype,http://schema.org/SeaBodyOfWater,< 1K
-Itemtype,http://schema.org/SearchAction,10M+
-Itemtype,http://schema.org/SearchRescueOrganization,< 1K
-Itemtype,http://schema.org/SearchResultsPage,10K - 100K
-Itemtype,http://schema.org/Season,< 1K
-Itemtype,http://schema.org/Seat,< 1K
-Itemtype,http://schema.org/SeekToAction,10K - 100K
-Itemtype,http://schema.org/SelfStorage,10K - 100K
-Itemtype,http://schema.org/SellAction,1K - 10K
-Itemtype,http://schema.org/SendAction,< 1K
-Itemtype,http://schema.org/SequentialArt,< 1K
-Itemtype,http://schema.org/Series,10K - 100K
-Itemtype,http://schema.org/Service,1M - 10M
-Itemtype,http://schema.org/ServiceChannel,100K - 1M
-Itemtype,http://schema.org/ServicePeriod,1K - 10K
-Itemtype,http://schema.org/ShareAction,10K - 100K
-Itemtype,http://schema.org/SheetMusic,< 1K
-Itemtype,http://schema.org/ShippingConditions,10K - 100K
-Itemtype,http://schema.org/ShippingDeliveryTime,100K - 1M
-Itemtype,http://schema.org/ShippingRateSettings,< 1K
-Itemtype,http://schema.org/ShippingService,10K - 100K
-Itemtype,http://schema.org/ShoeStore,1K - 10K
-Itemtype,http://schema.org/ShoppingCenter,1K - 10K
-Itemtype,http://schema.org/ShortStory,< 1K
-Itemtype,http://schema.org/SingleFamilyResidence,10K - 100K
-Itemtype,http://schema.org/SiteNavigationElement,1M - 10M
-Itemtype,http://schema.org/SizeGroupEnumeration,< 1K
-Itemtype,http://schema.org/SizeSpecification,1K - 10K
-Itemtype,http://schema.org/SizeSystemEnumeration,< 1K
-Itemtype,http://schema.org/SkiResort,< 1K
-Itemtype,http://schema.org/SocialEvent,1K - 10K
-Itemtype,http://schema.org/SocialMediaPosting,10K - 100K
-Itemtype,http://schema.org/SoftwareApplication,1M - 10M
-Itemtype,http://schema.org/SoftwareSourceCode,1K - 10K
-Itemtype,http://schema.org/SolveMathAction,< 1K
-Itemtype,http://schema.org/SomeProducts,10K - 100K
-Itemtype,http://schema.org/SpeakableSpecification,100K - 1M
-Itemtype,http://schema.org/SpecialAnnouncement,1K - 10K
-Itemtype,http://schema.org/Specialty,1K - 10K
-Itemtype,http://schema.org/SportingGoodsStore,1K - 10K
-Itemtype,http://schema.org/SportsActivityLocation,10K - 100K
-Itemtype,http://schema.org/SportsClub,1K - 10K
-Itemtype,http://schema.org/SportsEvent,10K - 100K
-Itemtype,http://schema.org/SportsOrganization,10K - 100K
-Itemtype,http://schema.org/SportsTeam,10K - 100K
-Itemtype,http://schema.org/SpreadsheetDigitalDocument,< 1K
-Itemtype,http://schema.org/StadiumOrArena,1K - 10K
-Itemtype,http://schema.org/State,100K - 1M
-Itemtype,http://schema.org/Statement,< 1K
-Itemtype,http://schema.org/StatisticalPopulation,< 1K
-Itemtype,http://schema.org/StatisticalVariable,< 1K
-Itemtype,http://schema.org/StatusEnumeration,< 1K
-Itemtype,http://schema.org/SteeringPositionValue,< 1K
-Itemtype,http://schema.org/Store,100K - 1M
-Itemtype,http://schema.org/StructuredValue,1K - 10K
-Itemtype,http://schema.org/StupidType,< 1K
-Itemtype,http://schema.org/SubscribeAction,10K - 100K
-Itemtype,http://schema.org/Substance,< 1K
-Itemtype,http://schema.org/SubwayStation,< 1K
-Itemtype,http://schema.org/Suite,< 1K
-Itemtype,http://schema.org/SuperficialAnatomy,< 1K
-Itemtype,http://schema.org/SurgicalProcedure,1K - 10K
-Itemtype,http://schema.org/SuspendAction,< 1K
-Itemtype,http://schema.org/Syllabus,1K - 10K
-Itemtype,http://schema.org/Synagogue,< 1K
-Itemtype,http://schema.org/TVClip,< 1K
-Itemtype,http://schema.org/TVEpisode,1K - 10K
-Itemtype,http://schema.org/TVSeason,1K - 10K
-Itemtype,http://schema.org/TVSeries,10K - 100K
-Itemtype,http://schema.org/Table,10K - 100K
-Itemtype,http://schema.org/TakeAction,< 1K
-Itemtype,http://schema.org/TattooParlor,1K - 10K
-Itemtype,http://schema.org/Taxi,< 1K
-Itemtype,http://schema.org/TaxiReservation,< 1K
-Itemtype,http://schema.org/TaxiService,10K - 100K
-Itemtype,http://schema.org/TaxiStand,< 1K
-Itemtype,http://schema.org/Taxon,< 1K
-Itemtype,http://schema.org/TechArticle,10K - 100K
-Itemtype,http://schema.org/TelevisionChannel,< 1K
-Itemtype,http://schema.org/TelevisionStation,< 1K
-Itemtype,http://schema.org/TennisComplex,< 1K
-Itemtype,http://schema.org/Text,10K - 100K
-Itemtype,http://schema.org/TextDigitalDocument,< 1K
-Itemtype,http://schema.org/TextObject,1K - 10K
-Itemtype,http://schema.org/TheaterEvent,1K - 10K
-Itemtype,http://schema.org/TheaterGroup,1K - 10K
-Itemtype,http://schema.org/TherapeuticProcedure,1K - 10K
-Itemtype,http://schema.org/Thesis,< 1K
-Itemtype,http://schema.org/Thing,10M+
-Itemtype,http://schema.org/Ticket,< 1K
-Itemtype,http://schema.org/TieAction,< 1K
-Itemtype,http://schema.org/TierBenefitEnumeration,< 1K
-Itemtype,http://schema.org/Time,< 1K
-Itemtype,http://schema.org/TipAction,< 1K
-Itemtype,http://schema.org/TireShop,1K - 10K
-Itemtype,http://schema.org/TouristAttraction,10K - 100K
-Itemtype,http://schema.org/TouristDestination,10K - 100K
-Itemtype,http://schema.org/TouristInformationCenter,1K - 10K
-Itemtype,http://schema.org/TouristTrip,10K - 100K
-Itemtype,http://schema.org/ToyStore,1K - 10K
-Itemtype,http://schema.org/TrackAction,< 1K
-Itemtype,http://schema.org/TradeAction,1K - 10K
-Itemtype,http://schema.org/TrainReservation,< 1K
-Itemtype,http://schema.org/TrainStation,1K - 10K
-Itemtype,http://schema.org/TrainTrip,< 1K
-Itemtype,http://schema.org/TransferAction,< 1K
-Itemtype,http://schema.org/TravelAction,1K - 10K
-Itemtype,http://schema.org/TravelAgency,10K - 100K
-Itemtype,http://schema.org/TreatmentIndication,< 1K
-Itemtype,http://schema.org/Trip,10K - 100K
-Itemtype,http://schema.org/TypeAndQuantityNode,1K - 10K
-Itemtype,http://schema.org/UKNonprofitType,< 1K
-Itemtype,http://schema.org/URL,1K - 10K
-Itemtype,http://schema.org/USNonprofitType,< 1K
-Itemtype,http://schema.org/UnRegisterAction,< 1K
-Itemtype,http://schema.org/UnitPriceSpecification,1M - 10M
-Itemtype,http://schema.org/UpdateAction,< 1K
-Itemtype,http://schema.org/UseAction,1K - 10K
-Itemtype,http://schema.org/UserBlocks,< 1K
-Itemtype,http://schema.org/UserCheckins,1K - 10K
-Itemtype,http://schema.org/UserComments,10K - 100K
-Itemtype,http://schema.org/UserDownloads,< 1K
-Itemtype,http://schema.org/UserInteraction,< 1K
-Itemtype,http://schema.org/UserLikes,< 1K
-Itemtype,http://schema.org/UserPageVisits,< 1K
-Itemtype,http://schema.org/UserPlays,< 1K
-Itemtype,http://schema.org/UserPlusOnes,< 1K
-Itemtype,http://schema.org/UserReview,1K - 10K
-Itemtype,http://schema.org/UserTweets,< 1K
-Itemtype,http://schema.org/VacationRental,10K - 100K
-Itemtype,http://schema.org/Vehicle,10K - 100K
-Itemtype,http://schema.org/Vein,< 1K
-Itemtype,http://schema.org/Vessel,< 1K
-Itemtype,http://schema.org/VeterinaryCare,1K - 10K
-Itemtype,http://schema.org/VideoGallery,1K - 10K
-Itemtype,http://schema.org/VideoGame,10K - 100K
-Itemtype,http://schema.org/VideoGameClip,< 1K
-Itemtype,http://schema.org/VideoGameSeries,1K - 10K
-Itemtype,http://schema.org/VideoObject,1M - 10M
-Itemtype,http://schema.org/VideoObjectSnapshot,< 1K
-Itemtype,http://schema.org/ViewAction,10K - 100K
-Itemtype,http://schema.org/VirtualLocation,10K - 100K
-Itemtype,http://schema.org/VisualArtsEvent,< 1K
-Itemtype,http://schema.org/VisualArtwork,1K - 10K
-Itemtype,http://schema.org/VitalSign,< 1K
-Itemtype,http://schema.org/Volcano,< 1K
-Itemtype,http://schema.org/VoteAction,< 1K
-Itemtype,http://schema.org/WPAdBlock,10K - 100K
-Itemtype,http://schema.org/WPFooter,1M - 10M
-Itemtype,http://schema.org/WPHeader,1M - 10M
-Itemtype,http://schema.org/WPSideBar,1M - 10M
-Itemtype,http://schema.org/WantAction,< 1K
-Itemtype,http://schema.org/WarrantyPromise,10K - 100K
-Itemtype,http://schema.org/WarrantyScope,< 1K
-Itemtype,http://schema.org/WatchAction,100K - 1M
-Itemtype,http://schema.org/Waterfall,< 1K
-Itemtype,http://schema.org/WearAction,< 1K
-Itemtype,http://schema.org/WearableMeasurementTypeEnumeration,< 1K
-Itemtype,http://schema.org/WearableSizeGroupEnumeration,< 1K
-Itemtype,http://schema.org/WearableSizeSystemEnumeration,< 1K
-Itemtype,http://schema.org/WebAPI,1K - 10K
-Itemtype,http://schema.org/WebApplication,100K - 1M
-Itemtype,http://schema.org/WebContent,1K - 10K
-Itemtype,http://schema.org/WebPage,10M+
-Itemtype,http://schema.org/WebPageElement,1M - 10M
-Itemtype,http://schema.org/WebSite,10M+
-Itemtype,http://schema.org/WholesaleStore,1K - 10K
-Itemtype,http://schema.org/WinAction,< 1K
-Itemtype,http://schema.org/Winery,1K - 10K
-Itemtype,http://schema.org/WorkBasedProgram,< 1K
-Itemtype,http://schema.org/WorkersUnion,< 1K
-Itemtype,http://schema.org/WriteAction,10K - 100K
-Itemtype,http://schema.org/XPathType,< 1K
-Itemtype,http://schema.org/Zoo,< 1K
-Predicate,http://schema.org/about,10M+
-Predicate,http://schema.org/about-input,< 1K
-Predicate,http://schema.org/about-output,< 1K
-Predicate,http://schema.org/abridged,< 1K
-Predicate,http://schema.org/abridged-input,< 1K
-Predicate,http://schema.org/abridged-output,< 1K
-Predicate,http://schema.org/abstract,10K - 100K
-Predicate,http://schema.org/abstract-input,< 1K
-Predicate,http://schema.org/abstract-output,< 1K
-Predicate,http://schema.org/accelerationTime,1K - 10K
-Predicate,http://schema.org/accelerationTime-input,< 1K
-Predicate,http://schema.org/accelerationTime-output,< 1K
-Predicate,http://schema.org/acceptedAnswer,1M - 10M
-Predicate,http://schema.org/acceptedAnswer-input,< 1K
-Predicate,http://schema.org/acceptedAnswer-output,< 1K
-Predicate,http://schema.org/acceptedOffer,< 1K
-Predicate,http://schema.org/acceptedOffer-input,< 1K
-Predicate,http://schema.org/acceptedOffer-output,< 1K
-Predicate,http://schema.org/acceptedPaymentMethod,10K - 100K
-Predicate,http://schema.org/acceptedPaymentMethod-input,< 1K
-Predicate,http://schema.org/acceptedPaymentMethod-output,< 1K
-Predicate,http://schema.org/acceptsReservations,100K - 1M
-Predicate,http://schema.org/acceptsReservations-input,< 1K
-Predicate,http://schema.org/acceptsReservations-output,< 1K
-Predicate,http://schema.org/accessCode,< 1K
-Predicate,http://schema.org/accessCode-input,< 1K
-Predicate,http://schema.org/accessCode-output,< 1K
-Predicate,http://schema.org/accessMode,1K - 10K
-Predicate,http://schema.org/accessMode-input,< 1K
-Predicate,http://schema.org/accessMode-output,< 1K
-Predicate,http://schema.org/accessModeSufficient,1K - 10K
-Predicate,http://schema.org/accessModeSufficient-input,< 1K
-Predicate,http://schema.org/accessModeSufficient-output,< 1K
-Predicate,http://schema.org/accessibilityAPI,1K - 10K
-Predicate,http://schema.org/accessibilityAPI-input,< 1K
-Predicate,http://schema.org/accessibilityAPI-output,< 1K
-Predicate,http://schema.org/accessibilityControl,1K - 10K
-Predicate,http://schema.org/accessibilityControl-input,< 1K
-Predicate,http://schema.org/accessibilityControl-output,< 1K
-Predicate,http://schema.org/accessibilityFeature,10K - 100K
-Predicate,http://schema.org/accessibilityFeature-input,< 1K
-Predicate,http://schema.org/accessibilityFeature-output,< 1K
-Predicate,http://schema.org/accessibilityHazard,1K - 10K
-Predicate,http://schema.org/accessibilityHazard-input,< 1K
-Predicate,http://schema.org/accessibilityHazard-output,< 1K
-Predicate,http://schema.org/accessibilitySummary,10K - 100K
-Predicate,http://schema.org/accessibilitySummary-input,< 1K
-Predicate,http://schema.org/accessibilitySummary-output,< 1K
-Predicate,http://schema.org/accommodationCategory,1K - 10K
-Predicate,http://schema.org/accommodationCategory-input,< 1K
-Predicate,http://schema.org/accommodationCategory-output,< 1K
-Predicate,http://schema.org/accommodationFloorPlan,10K - 100K
-Predicate,http://schema.org/accommodationFloorPlan-input,< 1K
-Predicate,http://schema.org/accommodationFloorPlan-output,< 1K
-Predicate,http://schema.org/accountId,< 1K
-Predicate,http://schema.org/accountId-input,< 1K
-Predicate,http://schema.org/accountId-output,< 1K
-Predicate,http://schema.org/accountMinimumInflow,< 1K
-Predicate,http://schema.org/accountMinimumInflow-input,< 1K
-Predicate,http://schema.org/accountMinimumInflow-output,< 1K
-Predicate,http://schema.org/accountOverdraftLimit,< 1K
-Predicate,http://schema.org/accountOverdraftLimit-input,< 1K
-Predicate,http://schema.org/accountOverdraftLimit-output,< 1K
-Predicate,http://schema.org/accountablePerson,10K - 100K
-Predicate,http://schema.org/accountablePerson-input,< 1K
-Predicate,http://schema.org/accountablePerson-output,< 1K
-Predicate,http://schema.org/acquireLicensePage,10K - 100K
-Predicate,http://schema.org/acquireLicensePage-input,< 1K
-Predicate,http://schema.org/acquireLicensePage-output,< 1K
-Predicate,http://schema.org/acquiredFrom,< 1K
-Predicate,http://schema.org/acquiredFrom-input,< 1K
-Predicate,http://schema.org/acquiredFrom-output,< 1K
-Predicate,http://schema.org/acrissCode,< 1K
-Predicate,http://schema.org/acrissCode-input,< 1K
-Predicate,http://schema.org/acrissCode-output,< 1K
-Predicate,http://schema.org/actionAccessibilityRequirement,< 1K
-Predicate,http://schema.org/actionAccessibilityRequirement-input,< 1K
-Predicate,http://schema.org/actionAccessibilityRequirement-output,< 1K
-Predicate,http://schema.org/actionApplication,1K - 10K
-Predicate,http://schema.org/actionApplication-input,< 1K
-Predicate,http://schema.org/actionApplication-output,< 1K
-Predicate,http://schema.org/actionOption,1K - 10K
-Predicate,http://schema.org/actionOption-input,< 1K
-Predicate,http://schema.org/actionOption-output,< 1K
-Predicate,http://schema.org/actionPlatform,100K - 1M
-Predicate,http://schema.org/actionPlatform-input,< 1K
-Predicate,http://schema.org/actionPlatform-output,< 1K
-Predicate,http://schema.org/actionProcess,< 1K
-Predicate,http://schema.org/actionProcess-input,< 1K
-Predicate,http://schema.org/actionProcess-output,< 1K
-Predicate,http://schema.org/actionStatus,10K - 100K
-Predicate,http://schema.org/actionStatus-input,< 1K
-Predicate,http://schema.org/actionStatus-output,< 1K
-Predicate,http://schema.org/actionableFeedbackPolicy,10K - 100K
-Predicate,http://schema.org/actionableFeedbackPolicy-input,< 1K
-Predicate,http://schema.org/actionableFeedbackPolicy-output,< 1K
-Predicate,http://schema.org/activeIngredient,1K - 10K
-Predicate,http://schema.org/activeIngredient-input,< 1K
-Predicate,http://schema.org/activeIngredient-output,< 1K
-Predicate,http://schema.org/activityDuration,< 1K
-Predicate,http://schema.org/activityDuration-input,< 1K
-Predicate,http://schema.org/activityDuration-output,< 1K
-Predicate,http://schema.org/activityFrequency,< 1K
-Predicate,http://schema.org/activityFrequency-input,< 1K
-Predicate,http://schema.org/activityFrequency-output,< 1K
-Predicate,http://schema.org/actor,10K - 100K
-Predicate,http://schema.org/actor-input,< 1K
-Predicate,http://schema.org/actor-output,< 1K
-Predicate,http://schema.org/actors,1K - 10K
-Predicate,http://schema.org/actors-input,< 1K
-Predicate,http://schema.org/actors-output,< 1K
-Predicate,http://schema.org/addOn,1K - 10K
-Predicate,http://schema.org/addOn-input,< 1K
-Predicate,http://schema.org/addOn-output,< 1K
-Predicate,http://schema.org/additionalName,10K - 100K
-Predicate,http://schema.org/additionalName-input,< 1K
-Predicate,http://schema.org/additionalName-output,< 1K
-Predicate,http://schema.org/additionalNumberOfGuests,< 1K
-Predicate,http://schema.org/additionalNumberOfGuests-input,< 1K
-Predicate,http://schema.org/additionalNumberOfGuests-output,< 1K
-Predicate,http://schema.org/additionalProperty,100K - 1M
-Predicate,http://schema.org/additionalProperty-input,< 1K
-Predicate,http://schema.org/additionalProperty-output,< 1K
-Predicate,http://schema.org/additionalType,100K - 1M
-Predicate,http://schema.org/additionalType-input,< 1K
-Predicate,http://schema.org/additionalType-output,< 1K
-Predicate,http://schema.org/additionalVariable,< 1K
-Predicate,http://schema.org/additionalVariable-input,< 1K
-Predicate,http://schema.org/additionalVariable-output,< 1K
-Predicate,http://schema.org/address,10M+
-Predicate,http://schema.org/address-input,< 1K
-Predicate,http://schema.org/address-output,< 1K
-Predicate,http://schema.org/addressCountry,1M - 10M
-Predicate,http://schema.org/addressCountry-input,< 1K
-Predicate,http://schema.org/addressCountry-output,< 1K
-Predicate,http://schema.org/addressLocality,1M - 10M
-Predicate,http://schema.org/addressLocality-input,< 1K
-Predicate,http://schema.org/addressLocality-output,< 1K
-Predicate,http://schema.org/addressRegion,1M - 10M
-Predicate,http://schema.org/addressRegion-input,< 1K
-Predicate,http://schema.org/addressRegion-output,< 1K
-Predicate,http://schema.org/administrationRoute,1K - 10K
-Predicate,http://schema.org/administrationRoute-input,< 1K
-Predicate,http://schema.org/administrationRoute-output,< 1K
-Predicate,http://schema.org/advanceBookingRequirement,< 1K
-Predicate,http://schema.org/advanceBookingRequirement-input,< 1K
-Predicate,http://schema.org/advanceBookingRequirement-output,< 1K
-Predicate,http://schema.org/adverseOutcome,< 1K
-Predicate,http://schema.org/adverseOutcome-input,< 1K
-Predicate,http://schema.org/adverseOutcome-output,< 1K
-Predicate,http://schema.org/affectedBy,< 1K
-Predicate,http://schema.org/affectedBy-input,< 1K
-Predicate,http://schema.org/affectedBy-output,< 1K
-Predicate,http://schema.org/affiliation,100K - 1M
-Predicate,http://schema.org/affiliation-input,< 1K
-Predicate,http://schema.org/affiliation-output,< 1K
-Predicate,http://schema.org/afterMedia,< 1K
-Predicate,http://schema.org/afterMedia-input,< 1K
-Predicate,http://schema.org/afterMedia-output,< 1K
-Predicate,http://schema.org/agent,10K - 100K
-Predicate,http://schema.org/agent-input,< 1K
-Predicate,http://schema.org/agent-output,< 1K
-Predicate,http://schema.org/agentInteractionStatistic,10K - 100K
-Predicate,http://schema.org/agentInteractionStatistic-input,< 1K
-Predicate,http://schema.org/agentInteractionStatistic-output,< 1K
-Predicate,http://schema.org/aggregateElement,< 1K
-Predicate,http://schema.org/aggregateElement-input,< 1K
-Predicate,http://schema.org/aggregateElement-output,< 1K
-Predicate,http://schema.org/aggregateRating,1M - 10M
-Predicate,http://schema.org/aggregateRating-input,< 1K
-Predicate,http://schema.org/aggregateRating-output,< 1K
-Predicate,http://schema.org/aircraft,< 1K
-Predicate,http://schema.org/aircraft-input,< 1K
-Predicate,http://schema.org/aircraft-output,< 1K
-Predicate,http://schema.org/album,1K - 10K
-Predicate,http://schema.org/album-input,< 1K
-Predicate,http://schema.org/album-output,< 1K
-Predicate,http://schema.org/albumProductionType,1K - 10K
-Predicate,http://schema.org/albumProductionType-input,< 1K
-Predicate,http://schema.org/albumProductionType-output,< 1K
-Predicate,http://schema.org/albumRelease,1K - 10K
-Predicate,http://schema.org/albumRelease-input,< 1K
-Predicate,http://schema.org/albumRelease-output,< 1K
-Predicate,http://schema.org/albumReleaseType,1K - 10K
-Predicate,http://schema.org/albumReleaseType-input,< 1K
-Predicate,http://schema.org/albumReleaseType-output,< 1K
-Predicate,http://schema.org/albums,< 1K
-Predicate,http://schema.org/albums-input,< 1K
-Predicate,http://schema.org/albums-output,< 1K
-Predicate,http://schema.org/alcoholWarning,< 1K
-Predicate,http://schema.org/alcoholWarning-input,< 1K
-Predicate,http://schema.org/alcoholWarning-output,< 1K
-Predicate,http://schema.org/algorithm,< 1K
-Predicate,http://schema.org/algorithm-input,< 1K
-Predicate,http://schema.org/algorithm-output,< 1K
-Predicate,http://schema.org/alignmentType,1K - 10K
-Predicate,http://schema.org/alignmentType-input,< 1K
-Predicate,http://schema.org/alignmentType-output,< 1K
-Predicate,http://schema.org/alternateName,1M - 10M
-Predicate,http://schema.org/alternateName-input,< 1K
-Predicate,http://schema.org/alternateName-output,< 1K
-Predicate,http://schema.org/alternativeHeadline,100K - 1M
-Predicate,http://schema.org/alternativeHeadline-input,< 1K
-Predicate,http://schema.org/alternativeHeadline-output,< 1K
-Predicate,http://schema.org/alternativeOf,< 1K
-Predicate,http://schema.org/alternativeOf-input,< 1K
-Predicate,http://schema.org/alternativeOf-output,< 1K
-Predicate,http://schema.org/alumni,1K - 10K
-Predicate,http://schema.org/alumni-input,< 1K
-Predicate,http://schema.org/alumni-output,< 1K
-Predicate,http://schema.org/alumniOf,100K - 1M
-Predicate,http://schema.org/alumniOf-input,< 1K
-Predicate,http://schema.org/alumniOf-output,< 1K
-Predicate,http://schema.org/amenityFeature,100K - 1M
-Predicate,http://schema.org/amenityFeature-input,< 1K
-Predicate,http://schema.org/amenityFeature-output,< 1K
-Predicate,http://schema.org/amount,1K - 10K
-Predicate,http://schema.org/amount-input,< 1K
-Predicate,http://schema.org/amount-output,< 1K
-Predicate,http://schema.org/amountOfThisGood,< 1K
-Predicate,http://schema.org/amountOfThisGood-input,< 1K
-Predicate,http://schema.org/amountOfThisGood-output,< 1K
-Predicate,http://schema.org/announcementLocation,1K - 10K
-Predicate,http://schema.org/announcementLocation-input,< 1K
-Predicate,http://schema.org/announcementLocation-output,< 1K
-Predicate,http://schema.org/annualPercentageRate,1K - 10K
-Predicate,http://schema.org/annualPercentageRate-input,< 1K
-Predicate,http://schema.org/annualPercentageRate-output,< 1K
-Predicate,http://schema.org/answerCount,100K - 1M
-Predicate,http://schema.org/answerCount-input,< 1K
-Predicate,http://schema.org/answerCount-output,< 1K
-Predicate,http://schema.org/answerExplanation,< 1K
-Predicate,http://schema.org/answerExplanation-input,< 1K
-Predicate,http://schema.org/answerExplanation-output,< 1K
-Predicate,http://schema.org/antagonist,< 1K
-Predicate,http://schema.org/antagonist-input,< 1K
-Predicate,http://schema.org/antagonist-output,< 1K
-Predicate,http://schema.org/appearance,1K - 10K
-Predicate,http://schema.org/appearance-input,< 1K
-Predicate,http://schema.org/appearance-output,< 1K
-Predicate,http://schema.org/applicableCountry,100K - 1M
-Predicate,http://schema.org/applicableCountry-input,< 1K
-Predicate,http://schema.org/applicableCountry-output,< 1K
-Predicate,http://schema.org/applicableLocation,< 1K
-Predicate,http://schema.org/applicableLocation-input,< 1K
-Predicate,http://schema.org/applicableLocation-output,< 1K
-Predicate,http://schema.org/applicantLocationRequirements,10K - 100K
-Predicate,http://schema.org/applicantLocationRequirements-input,< 1K
-Predicate,http://schema.org/applicantLocationRequirements-output,< 1K
-Predicate,http://schema.org/application,< 1K
-Predicate,http://schema.org/application-input,< 1K
-Predicate,http://schema.org/application-output,< 1K
-Predicate,http://schema.org/applicationCategory,1M - 10M
-Predicate,http://schema.org/applicationCategory-input,< 1K
-Predicate,http://schema.org/applicationCategory-output,< 1K
-Predicate,http://schema.org/applicationContact,1K - 10K
-Predicate,http://schema.org/applicationContact-input,< 1K
-Predicate,http://schema.org/applicationContact-output,< 1K
-Predicate,http://schema.org/applicationDeadline,1K - 10K
-Predicate,http://schema.org/applicationDeadline-input,< 1K
-Predicate,http://schema.org/applicationDeadline-output,< 1K
-Predicate,http://schema.org/applicationStartDate,< 1K
-Predicate,http://schema.org/applicationStartDate-input,< 1K
-Predicate,http://schema.org/applicationStartDate-output,< 1K
-Predicate,http://schema.org/applicationSubCategory,10K - 100K
-Predicate,http://schema.org/applicationSubCategory-input,< 1K
-Predicate,http://schema.org/applicationSubCategory-output,< 1K
-Predicate,http://schema.org/applicationSuite,1K - 10K
-Predicate,http://schema.org/applicationSuite-input,< 1K
-Predicate,http://schema.org/applicationSuite-output,< 1K
-Predicate,http://schema.org/appliesToDeliveryMethod,10K - 100K
-Predicate,http://schema.org/appliesToDeliveryMethod-input,< 1K
-Predicate,http://schema.org/appliesToDeliveryMethod-output,< 1K
-Predicate,http://schema.org/appliesToPaymentMethod,< 1K
-Predicate,http://schema.org/appliesToPaymentMethod-input,< 1K
-Predicate,http://schema.org/appliesToPaymentMethod-output,< 1K
-Predicate,http://schema.org/archiveHeld,< 1K
-Predicate,http://schema.org/archiveHeld-input,< 1K
-Predicate,http://schema.org/archiveHeld-output,< 1K
-Predicate,http://schema.org/archivedAt,< 1K
-Predicate,http://schema.org/archivedAt-input,< 1K
-Predicate,http://schema.org/archivedAt-output,< 1K
-Predicate,http://schema.org/area,1K - 10K
-Predicate,http://schema.org/area-input,< 1K
-Predicate,http://schema.org/area-output,< 1K
-Predicate,http://schema.org/areaServed,1M - 10M
-Predicate,http://schema.org/areaServed-input,< 1K
-Predicate,http://schema.org/areaServed-output,< 1K
-Predicate,http://schema.org/arrivalAirport,1K - 10K
-Predicate,http://schema.org/arrivalAirport-input,< 1K
-Predicate,http://schema.org/arrivalAirport-output,< 1K
-Predicate,http://schema.org/arrivalBoatTerminal,< 1K
-Predicate,http://schema.org/arrivalBoatTerminal-input,< 1K
-Predicate,http://schema.org/arrivalBoatTerminal-output,< 1K
-Predicate,http://schema.org/arrivalBusStop,< 1K
-Predicate,http://schema.org/arrivalBusStop-input,< 1K
-Predicate,http://schema.org/arrivalBusStop-output,< 1K
-Predicate,http://schema.org/arrivalGate,< 1K
-Predicate,http://schema.org/arrivalGate-input,< 1K
-Predicate,http://schema.org/arrivalGate-output,< 1K
-Predicate,http://schema.org/arrivalPlatform,< 1K
-Predicate,http://schema.org/arrivalPlatform-input,< 1K
-Predicate,http://schema.org/arrivalPlatform-output,< 1K
-Predicate,http://schema.org/arrivalStation,< 1K
-Predicate,http://schema.org/arrivalStation-input,< 1K
-Predicate,http://schema.org/arrivalStation-output,< 1K
-Predicate,http://schema.org/arrivalTerminal,< 1K
-Predicate,http://schema.org/arrivalTerminal-input,< 1K
-Predicate,http://schema.org/arrivalTerminal-output,< 1K
-Predicate,http://schema.org/arrivalTime,1K - 10K
-Predicate,http://schema.org/arrivalTime-input,< 1K
-Predicate,http://schema.org/arrivalTime-output,< 1K
-Predicate,http://schema.org/artEdition,< 1K
-Predicate,http://schema.org/artEdition-input,< 1K
-Predicate,http://schema.org/artEdition-output,< 1K
-Predicate,http://schema.org/artMedium,1K - 10K
-Predicate,http://schema.org/artMedium-input,< 1K
-Predicate,http://schema.org/artMedium-output,< 1K
-Predicate,http://schema.org/arterialBranch,< 1K
-Predicate,http://schema.org/arterialBranch-input,< 1K
-Predicate,http://schema.org/arterialBranch-output,< 1K
-Predicate,http://schema.org/artform,1K - 10K
-Predicate,http://schema.org/artform-input,< 1K
-Predicate,http://schema.org/artform-output,< 1K
-Predicate,http://schema.org/articleBody,1M - 10M
-Predicate,http://schema.org/articleBody-input,< 1K
-Predicate,http://schema.org/articleBody-output,< 1K
-Predicate,http://schema.org/articleSection,1M - 10M
-Predicate,http://schema.org/articleSection-input,< 1K
-Predicate,http://schema.org/articleSection-output,< 1K
-Predicate,http://schema.org/artist,1K - 10K
-Predicate,http://schema.org/artist-input,< 1K
-Predicate,http://schema.org/artist-output,< 1K
-Predicate,http://schema.org/artworkSurface,1K - 10K
-Predicate,http://schema.org/artworkSurface-input,< 1K
-Predicate,http://schema.org/artworkSurface-output,< 1K
-Predicate,http://schema.org/asin,< 1K
-Predicate,http://schema.org/asin-input,< 1K
-Predicate,http://schema.org/asin-output,< 1K
-Predicate,http://schema.org/aspect,< 1K
-Predicate,http://schema.org/aspect-input,< 1K
-Predicate,http://schema.org/aspect-output,< 1K
-Predicate,http://schema.org/assembly,< 1K
-Predicate,http://schema.org/assembly-input,< 1K
-Predicate,http://schema.org/assembly-output,< 1K
-Predicate,http://schema.org/assemblyVersion,< 1K
-Predicate,http://schema.org/assemblyVersion-input,< 1K
-Predicate,http://schema.org/assemblyVersion-output,< 1K
-Predicate,http://schema.org/assesses,1K - 10K
-Predicate,http://schema.org/assesses-input,< 1K
-Predicate,http://schema.org/assesses-output,< 1K
-Predicate,http://schema.org/associatedAnatomy,1K - 10K
-Predicate,http://schema.org/associatedAnatomy-input,< 1K
-Predicate,http://schema.org/associatedAnatomy-output,< 1K
-Predicate,http://schema.org/associatedArticle,1K - 10K
-Predicate,http://schema.org/associatedArticle-input,< 1K
-Predicate,http://schema.org/associatedArticle-output,< 1K
-Predicate,http://schema.org/associatedClaimReview,< 1K
-Predicate,http://schema.org/associatedClaimReview-input,< 1K
-Predicate,http://schema.org/associatedClaimReview-output,< 1K
-Predicate,http://schema.org/associatedDisease,< 1K
-Predicate,http://schema.org/associatedDisease-input,< 1K
-Predicate,http://schema.org/associatedDisease-output,< 1K
-Predicate,http://schema.org/associatedMedia,100K - 1M
-Predicate,http://schema.org/associatedMedia-input,< 1K
-Predicate,http://schema.org/associatedMedia-output,< 1K
-Predicate,http://schema.org/associatedMediaReview,< 1K
-Predicate,http://schema.org/associatedMediaReview-input,< 1K
-Predicate,http://schema.org/associatedMediaReview-output,< 1K
-Predicate,http://schema.org/associatedPathophysiology,< 1K
-Predicate,http://schema.org/associatedPathophysiology-input,< 1K
-Predicate,http://schema.org/associatedPathophysiology-output,< 1K
-Predicate,http://schema.org/associatedReview,< 1K
-Predicate,http://schema.org/associatedReview-input,< 1K
-Predicate,http://schema.org/associatedReview-output,< 1K
-Predicate,http://schema.org/athlete,1K - 10K
-Predicate,http://schema.org/athlete-input,< 1K
-Predicate,http://schema.org/athlete-output,< 1K
-Predicate,http://schema.org/attendee,1K - 10K
-Predicate,http://schema.org/attendee-input,< 1K
-Predicate,http://schema.org/attendee-output,< 1K
-Predicate,http://schema.org/attendees,< 1K
-Predicate,http://schema.org/attendees-input,< 1K
-Predicate,http://schema.org/attendees-output,< 1K
-Predicate,http://schema.org/audience,100K - 1M
-Predicate,http://schema.org/audience-input,< 1K
-Predicate,http://schema.org/audience-output,< 1K
-Predicate,http://schema.org/audienceType,100K - 1M
-Predicate,http://schema.org/audienceType-input,< 1K
-Predicate,http://schema.org/audienceType-output,< 1K
-Predicate,http://schema.org/audio,10K - 100K
-Predicate,http://schema.org/audio-input,< 1K
-Predicate,http://schema.org/audio-output,< 1K
-Predicate,http://schema.org/auditDate,< 1K
-Predicate,http://schema.org/auditDate-input,< 1K
-Predicate,http://schema.org/auditDate-output,< 1K
-Predicate,http://schema.org/authenticator,< 1K
-Predicate,http://schema.org/authenticator-input,< 1K
-Predicate,http://schema.org/authenticator-output,< 1K
-Predicate,http://schema.org/author,10M+
-Predicate,http://schema.org/author-input,< 1K
-Predicate,http://schema.org/author-output,< 1K
-Predicate,http://schema.org/availability,10M+
-Predicate,http://schema.org/availability-input,< 1K
-Predicate,http://schema.org/availability-output,< 1K
-Predicate,http://schema.org/availabilityEnds,10K - 100K
-Predicate,http://schema.org/availabilityEnds-input,< 1K
-Predicate,http://schema.org/availabilityEnds-output,< 1K
-Predicate,http://schema.org/availabilityStarts,10K - 100K
-Predicate,http://schema.org/availabilityStarts-input,< 1K
-Predicate,http://schema.org/availabilityStarts-output,< 1K
-Predicate,http://schema.org/availableAtOrFrom,10K - 100K
-Predicate,http://schema.org/availableAtOrFrom-input,< 1K
-Predicate,http://schema.org/availableAtOrFrom-output,< 1K
-Predicate,http://schema.org/availableChannel,100K - 1M
-Predicate,http://schema.org/availableChannel-input,< 1K
-Predicate,http://schema.org/availableChannel-output,< 1K
-Predicate,http://schema.org/availableDeliveryMethod,10K - 100K
-Predicate,http://schema.org/availableDeliveryMethod-input,< 1K
-Predicate,http://schema.org/availableDeliveryMethod-output,< 1K
-Predicate,http://schema.org/availableFrom,< 1K
-Predicate,http://schema.org/availableFrom-input,< 1K
-Predicate,http://schema.org/availableFrom-output,< 1K
-Predicate,http://schema.org/availableIn,< 1K
-Predicate,http://schema.org/availableIn-input,< 1K
-Predicate,http://schema.org/availableIn-output,< 1K
-Predicate,http://schema.org/availableLanguage,1M - 10M
-Predicate,http://schema.org/availableLanguage-input,< 1K
-Predicate,http://schema.org/availableLanguage-output,< 1K
-Predicate,http://schema.org/availableOnDevice,1K - 10K
-Predicate,http://schema.org/availableOnDevice-input,< 1K
-Predicate,http://schema.org/availableOnDevice-output,< 1K
-Predicate,http://schema.org/availableService,10K - 100K
-Predicate,http://schema.org/availableService-input,< 1K
-Predicate,http://schema.org/availableService-output,< 1K
-Predicate,http://schema.org/availableStrength,< 1K
-Predicate,http://schema.org/availableStrength-input,< 1K
-Predicate,http://schema.org/availableStrength-output,< 1K
-Predicate,http://schema.org/availableTest,< 1K
-Predicate,http://schema.org/availableTest-input,< 1K
-Predicate,http://schema.org/availableTest-output,< 1K
-Predicate,http://schema.org/availableThrough,< 1K
-Predicate,http://schema.org/availableThrough-input,< 1K
-Predicate,http://schema.org/availableThrough-output,< 1K
-Predicate,http://schema.org/award,100K - 1M
-Predicate,http://schema.org/award-input,< 1K
-Predicate,http://schema.org/award-output,< 1K
-Predicate,http://schema.org/awards,1K - 10K
-Predicate,http://schema.org/awards-input,< 1K
-Predicate,http://schema.org/awards-output,< 1K
-Predicate,http://schema.org/awayTeam,10K - 100K
-Predicate,http://schema.org/awayTeam-input,< 1K
-Predicate,http://schema.org/awayTeam-output,< 1K
-Predicate,http://schema.org/backstory,1K - 10K
-Predicate,http://schema.org/backstory-input,< 1K
-Predicate,http://schema.org/backstory-output,< 1K
-Predicate,http://schema.org/bankAccountType,< 1K
-Predicate,http://schema.org/bankAccountType-input,< 1K
-Predicate,http://schema.org/bankAccountType-output,< 1K
-Predicate,http://schema.org/baseSalary,10K - 100K
-Predicate,http://schema.org/baseSalary-input,< 1K
-Predicate,http://schema.org/baseSalary-output,< 1K
-Predicate,http://schema.org/bccRecipient,< 1K
-Predicate,http://schema.org/bccRecipient-input,< 1K
-Predicate,http://schema.org/bccRecipient-output,< 1K
-Predicate,http://schema.org/bed,10K - 100K
-Predicate,http://schema.org/bed-input,< 1K
-Predicate,http://schema.org/bed-output,< 1K
-Predicate,http://schema.org/beforeMedia,< 1K
-Predicate,http://schema.org/beforeMedia-input,< 1K
-Predicate,http://schema.org/beforeMedia-output,< 1K
-Predicate,http://schema.org/beneficiaryBank,< 1K
-Predicate,http://schema.org/beneficiaryBank-input,< 1K
-Predicate,http://schema.org/beneficiaryBank-output,< 1K
-Predicate,http://schema.org/benefits,1K - 10K
-Predicate,http://schema.org/benefits-input,< 1K
-Predicate,http://schema.org/benefits-output,< 1K
-Predicate,http://schema.org/benefitsSummaryUrl,< 1K
-Predicate,http://schema.org/benefitsSummaryUrl-input,< 1K
-Predicate,http://schema.org/benefitsSummaryUrl-output,< 1K
-Predicate,http://schema.org/bestRating,1M - 10M
-Predicate,http://schema.org/bestRating-input,< 1K
-Predicate,http://schema.org/bestRating-output,< 1K
-Predicate,http://schema.org/billingAddress,< 1K
-Predicate,http://schema.org/billingAddress-input,< 1K
-Predicate,http://schema.org/billingAddress-output,< 1K
-Predicate,http://schema.org/billingDuration,10K - 100K
-Predicate,http://schema.org/billingDuration-input,< 1K
-Predicate,http://schema.org/billingDuration-output,< 1K
-Predicate,http://schema.org/billingIncrement,10K - 100K
-Predicate,http://schema.org/billingIncrement-input,< 1K
-Predicate,http://schema.org/billingIncrement-output,< 1K
-Predicate,http://schema.org/billingPeriod,1K - 10K
-Predicate,http://schema.org/billingPeriod-input,< 1K
-Predicate,http://schema.org/billingPeriod-output,< 1K
-Predicate,http://schema.org/billingStart,< 1K
-Predicate,http://schema.org/billingStart-input,< 1K
-Predicate,http://schema.org/billingStart-output,< 1K
-Predicate,http://schema.org/bioChemInteraction,< 1K
-Predicate,http://schema.org/bioChemInteraction-input,< 1K
-Predicate,http://schema.org/bioChemInteraction-output,< 1K
-Predicate,http://schema.org/bioChemSimilarity,< 1K
-Predicate,http://schema.org/bioChemSimilarity-input,< 1K
-Predicate,http://schema.org/bioChemSimilarity-output,< 1K
-Predicate,http://schema.org/biologicalRole,< 1K
-Predicate,http://schema.org/biologicalRole-input,< 1K
-Predicate,http://schema.org/biologicalRole-output,< 1K
-Predicate,http://schema.org/biomechnicalClass,< 1K
-Predicate,http://schema.org/biomechnicalClass-input,< 1K
-Predicate,http://schema.org/biomechnicalClass-output,< 1K
-Predicate,http://schema.org/birthDate,10K - 100K
-Predicate,http://schema.org/birthDate-input,< 1K
-Predicate,http://schema.org/birthDate-output,< 1K
-Predicate,http://schema.org/birthPlace,10K - 100K
-Predicate,http://schema.org/birthPlace-input,< 1K
-Predicate,http://schema.org/birthPlace-output,< 1K
-Predicate,http://schema.org/bitrate,1K - 10K
-Predicate,http://schema.org/bitrate-input,< 1K
-Predicate,http://schema.org/bitrate-output,< 1K
-Predicate,http://schema.org/blogPost,100K - 1M
-Predicate,http://schema.org/blogPost-input,< 1K
-Predicate,http://schema.org/blogPost-output,< 1K
-Predicate,http://schema.org/blogPosts,10K - 100K
-Predicate,http://schema.org/blogPosts-input,< 1K
-Predicate,http://schema.org/blogPosts-output,< 1K
-Predicate,http://schema.org/bloodSupply,< 1K
-Predicate,http://schema.org/bloodSupply-input,< 1K
-Predicate,http://schema.org/bloodSupply-output,< 1K
-Predicate,http://schema.org/boardingGroup,< 1K
-Predicate,http://schema.org/boardingGroup-input,< 1K
-Predicate,http://schema.org/boardingGroup-output,< 1K
-Predicate,http://schema.org/boardingPolicy,< 1K
-Predicate,http://schema.org/boardingPolicy-input,< 1K
-Predicate,http://schema.org/boardingPolicy-output,< 1K
-Predicate,http://schema.org/bodyLocation,10K - 100K
-Predicate,http://schema.org/bodyLocation-input,< 1K
-Predicate,http://schema.org/bodyLocation-output,< 1K
-Predicate,http://schema.org/bodyType,10K - 100K
-Predicate,http://schema.org/bodyType-input,< 1K
-Predicate,http://schema.org/bodyType-output,< 1K
-Predicate,http://schema.org/bookEdition,1K - 10K
-Predicate,http://schema.org/bookEdition-input,< 1K
-Predicate,http://schema.org/bookEdition-output,< 1K
-Predicate,http://schema.org/bookFormat,10K - 100K
-Predicate,http://schema.org/bookFormat-input,< 1K
-Predicate,http://schema.org/bookFormat-output,< 1K
-Predicate,http://schema.org/bookingAgent,< 1K
-Predicate,http://schema.org/bookingAgent-input,< 1K
-Predicate,http://schema.org/bookingAgent-output,< 1K
-Predicate,http://schema.org/bookingTime,< 1K
-Predicate,http://schema.org/bookingTime-input,< 1K
-Predicate,http://schema.org/bookingTime-output,< 1K
-Predicate,http://schema.org/borrower,< 1K
-Predicate,http://schema.org/borrower-input,< 1K
-Predicate,http://schema.org/borrower-output,< 1K
-Predicate,http://schema.org/box,1K - 10K
-Predicate,http://schema.org/box-input,< 1K
-Predicate,http://schema.org/box-output,< 1K
-Predicate,http://schema.org/branch,< 1K
-Predicate,http://schema.org/branch-input,< 1K
-Predicate,http://schema.org/branch-output,< 1K
-Predicate,http://schema.org/branchCode,1K - 10K
-Predicate,http://schema.org/branchCode-input,< 1K
-Predicate,http://schema.org/branchCode-output,< 1K
-Predicate,http://schema.org/branchOf,10K - 100K
-Predicate,http://schema.org/branchOf-input,< 1K
-Predicate,http://schema.org/branchOf-output,< 1K
-Predicate,http://schema.org/brand,1M - 10M
-Predicate,http://schema.org/brand-input,< 1K
-Predicate,http://schema.org/brand-output,< 1K
-Predicate,http://schema.org/breadcrumb,10M+
-Predicate,http://schema.org/breadcrumb-input,< 1K
-Predicate,http://schema.org/breadcrumb-output,< 1K
-Predicate,http://schema.org/breastfeedingWarning,< 1K
-Predicate,http://schema.org/breastfeedingWarning-input,< 1K
-Predicate,http://schema.org/breastfeedingWarning-output,< 1K
-Predicate,http://schema.org/broadcastAffiliateOf,< 1K
-Predicate,http://schema.org/broadcastAffiliateOf-input,< 1K
-Predicate,http://schema.org/broadcastAffiliateOf-output,< 1K
-Predicate,http://schema.org/broadcastChannelId,< 1K
-Predicate,http://schema.org/broadcastChannelId-input,< 1K
-Predicate,http://schema.org/broadcastChannelId-output,< 1K
-Predicate,http://schema.org/broadcastDisplayName,1K - 10K
-Predicate,http://schema.org/broadcastDisplayName-input,< 1K
-Predicate,http://schema.org/broadcastDisplayName-output,< 1K
-Predicate,http://schema.org/broadcastFrequency,1K - 10K
-Predicate,http://schema.org/broadcastFrequency-input,< 1K
-Predicate,http://schema.org/broadcastFrequency-output,< 1K
-Predicate,http://schema.org/broadcastFrequencyValue,< 1K
-Predicate,http://schema.org/broadcastFrequencyValue-input,< 1K
-Predicate,http://schema.org/broadcastFrequencyValue-output,< 1K
-Predicate,http://schema.org/broadcastOfEvent,1K - 10K
-Predicate,http://schema.org/broadcastOfEvent-input,< 1K
-Predicate,http://schema.org/broadcastOfEvent-output,< 1K
-Predicate,http://schema.org/broadcastServiceTier,< 1K
-Predicate,http://schema.org/broadcastServiceTier-input,< 1K
-Predicate,http://schema.org/broadcastServiceTier-output,< 1K
-Predicate,http://schema.org/broadcastSignalModulation,< 1K
-Predicate,http://schema.org/broadcastSignalModulation-input,< 1K
-Predicate,http://schema.org/broadcastSignalModulation-output,< 1K
-Predicate,http://schema.org/broadcastSubChannel,< 1K
-Predicate,http://schema.org/broadcastSubChannel-input,< 1K
-Predicate,http://schema.org/broadcastSubChannel-output,< 1K
-Predicate,http://schema.org/broadcastTimezone,< 1K
-Predicate,http://schema.org/broadcastTimezone-input,< 1K
-Predicate,http://schema.org/broadcastTimezone-output,< 1K
-Predicate,http://schema.org/broadcaster,< 1K
-Predicate,http://schema.org/broadcaster-input,< 1K
-Predicate,http://schema.org/broadcaster-output,< 1K
-Predicate,http://schema.org/broker,1K - 10K
-Predicate,http://schema.org/broker-input,< 1K
-Predicate,http://schema.org/broker-output,< 1K
-Predicate,http://schema.org/browserRequirements,10K - 100K
-Predicate,http://schema.org/browserRequirements-input,< 1K
-Predicate,http://schema.org/browserRequirements-output,< 1K
-Predicate,http://schema.org/busName,< 1K
-Predicate,http://schema.org/busName-input,< 1K
-Predicate,http://schema.org/busName-output,< 1K
-Predicate,http://schema.org/busNumber,< 1K
-Predicate,http://schema.org/busNumber-input,< 1K
-Predicate,http://schema.org/busNumber-output,< 1K
-Predicate,http://schema.org/businessDays,10K - 100K
-Predicate,http://schema.org/businessDays-input,< 1K
-Predicate,http://schema.org/businessDays-output,< 1K
-Predicate,http://schema.org/businessFunction,1M - 10M
-Predicate,http://schema.org/businessFunction-input,< 1K
-Predicate,http://schema.org/businessFunction-output,< 1K
-Predicate,http://schema.org/buyer,< 1K
-Predicate,http://schema.org/buyer-input,< 1K
-Predicate,http://schema.org/buyer-output,< 1K
-Predicate,http://schema.org/byArtist,10K - 100K
-Predicate,http://schema.org/byArtist-input,< 1K
-Predicate,http://schema.org/byArtist-output,< 1K
-Predicate,http://schema.org/byDay,1K - 10K
-Predicate,http://schema.org/byDay-input,< 1K
-Predicate,http://schema.org/byDay-output,< 1K
-Predicate,http://schema.org/byMonth,< 1K
-Predicate,http://schema.org/byMonth-input,< 1K
-Predicate,http://schema.org/byMonth-output,< 1K
-Predicate,http://schema.org/byMonthDay,< 1K
-Predicate,http://schema.org/byMonthDay-input,< 1K
-Predicate,http://schema.org/byMonthDay-output,< 1K
-Predicate,http://schema.org/byMonthWeek,< 1K
-Predicate,http://schema.org/byMonthWeek-input,< 1K
-Predicate,http://schema.org/byMonthWeek-output,< 1K
-Predicate,http://schema.org/callSign,< 1K
-Predicate,http://schema.org/callSign-input,< 1K
-Predicate,http://schema.org/callSign-output,< 1K
-Predicate,http://schema.org/calories,10K - 100K
-Predicate,http://schema.org/calories-input,< 1K
-Predicate,http://schema.org/calories-output,< 1K
-Predicate,http://schema.org/candidate,< 1K
-Predicate,http://schema.org/candidate-input,< 1K
-Predicate,http://schema.org/candidate-output,< 1K
-Predicate,http://schema.org/caption,10M+
-Predicate,http://schema.org/caption-input,< 1K
-Predicate,http://schema.org/caption-output,< 1K
-Predicate,http://schema.org/carbohydrateContent,10K - 100K
-Predicate,http://schema.org/carbohydrateContent-input,< 1K
-Predicate,http://schema.org/carbohydrateContent-output,< 1K
-Predicate,http://schema.org/cargoVolume,1K - 10K
-Predicate,http://schema.org/cargoVolume-input,< 1K
-Predicate,http://schema.org/cargoVolume-output,< 1K
-Predicate,http://schema.org/carrier,< 1K
-Predicate,http://schema.org/carrier-input,< 1K
-Predicate,http://schema.org/carrier-output,< 1K
-Predicate,http://schema.org/carrierRequirements,< 1K
-Predicate,http://schema.org/carrierRequirements-input,< 1K
-Predicate,http://schema.org/carrierRequirements-output,< 1K
-Predicate,http://schema.org/cashBack,< 1K
-Predicate,http://schema.org/cashBack-input,< 1K
-Predicate,http://schema.org/cashBack-output,< 1K
-Predicate,http://schema.org/catalog,< 1K
-Predicate,http://schema.org/catalog-input,< 1K
-Predicate,http://schema.org/catalog-output,< 1K
-Predicate,http://schema.org/catalogNumber,< 1K
-Predicate,http://schema.org/catalogNumber-input,< 1K
-Predicate,http://schema.org/catalogNumber-output,< 1K
-Predicate,http://schema.org/category,1M - 10M
-Predicate,http://schema.org/category-input,< 1K
-Predicate,http://schema.org/category-output,< 1K
-Predicate,http://schema.org/cause,1K - 10K
-Predicate,http://schema.org/cause-input,< 1K
-Predicate,http://schema.org/cause-output,< 1K
-Predicate,http://schema.org/causeOf,< 1K
-Predicate,http://schema.org/causeOf-input,< 1K
-Predicate,http://schema.org/causeOf-output,< 1K
-Predicate,http://schema.org/ccRecipient,< 1K
-Predicate,http://schema.org/ccRecipient-input,< 1K
-Predicate,http://schema.org/ccRecipient-output,< 1K
-Predicate,http://schema.org/certificationIdentification,1K - 10K
-Predicate,http://schema.org/certificationIdentification-input,< 1K
-Predicate,http://schema.org/certificationIdentification-output,< 1K
-Predicate,http://schema.org/certificationRating,< 1K
-Predicate,http://schema.org/certificationRating-input,< 1K
-Predicate,http://schema.org/certificationRating-output,< 1K
-Predicate,http://schema.org/certificationStatus,1K - 10K
-Predicate,http://schema.org/certificationStatus-input,< 1K
-Predicate,http://schema.org/certificationStatus-output,< 1K
-Predicate,http://schema.org/character,1K - 10K
-Predicate,http://schema.org/character-input,< 1K
-Predicate,http://schema.org/character-output,< 1K
-Predicate,http://schema.org/characterAttribute,< 1K
-Predicate,http://schema.org/characterAttribute-input,< 1K
-Predicate,http://schema.org/characterAttribute-output,< 1K
-Predicate,http://schema.org/characterName,< 1K
-Predicate,http://schema.org/characterName-input,< 1K
-Predicate,http://schema.org/characterName-output,< 1K
-Predicate,http://schema.org/cheatCode,< 1K
-Predicate,http://schema.org/cheatCode-input,< 1K
-Predicate,http://schema.org/cheatCode-output,< 1K
-Predicate,http://schema.org/checkinTime,10K - 100K
-Predicate,http://schema.org/checkinTime-input,< 1K
-Predicate,http://schema.org/checkinTime-output,< 1K
-Predicate,http://schema.org/checkoutPageURLTemplate,10K - 100K
-Predicate,http://schema.org/checkoutPageURLTemplate-input,< 1K
-Predicate,http://schema.org/checkoutPageURLTemplate-output,< 1K
-Predicate,http://schema.org/checkoutTime,10K - 100K
-Predicate,http://schema.org/checkoutTime-input,< 1K
-Predicate,http://schema.org/checkoutTime-output,< 1K
-Predicate,http://schema.org/chemicalComposition,< 1K
-Predicate,http://schema.org/chemicalComposition-input,< 1K
-Predicate,http://schema.org/chemicalComposition-output,< 1K
-Predicate,http://schema.org/chemicalRole,< 1K
-Predicate,http://schema.org/chemicalRole-input,< 1K
-Predicate,http://schema.org/chemicalRole-output,< 1K
-Predicate,http://schema.org/childMaxAge,< 1K
-Predicate,http://schema.org/childMaxAge-input,< 1K
-Predicate,http://schema.org/childMaxAge-output,< 1K
-Predicate,http://schema.org/childMinAge,< 1K
-Predicate,http://schema.org/childMinAge-input,< 1K
-Predicate,http://schema.org/childMinAge-output,< 1K
-Predicate,http://schema.org/childTaxon,< 1K
-Predicate,http://schema.org/childTaxon-input,< 1K
-Predicate,http://schema.org/childTaxon-output,< 1K
-Predicate,http://schema.org/children,1K - 10K
-Predicate,http://schema.org/children-input,< 1K
-Predicate,http://schema.org/children-output,< 1K
-Predicate,http://schema.org/cholesterolContent,10K - 100K
-Predicate,http://schema.org/cholesterolContent-input,< 1K
-Predicate,http://schema.org/cholesterolContent-output,< 1K
-Predicate,http://schema.org/circle,1K - 10K
-Predicate,http://schema.org/circle-input,< 1K
-Predicate,http://schema.org/circle-output,< 1K
-Predicate,http://schema.org/citation,10K - 100K
-Predicate,http://schema.org/citation-input,< 1K
-Predicate,http://schema.org/citation-output,< 1K
-Predicate,http://schema.org/claimInterpreter,< 1K
-Predicate,http://schema.org/claimInterpreter-input,< 1K
-Predicate,http://schema.org/claimInterpreter-output,< 1K
-Predicate,http://schema.org/claimReviewed,1K - 10K
-Predicate,http://schema.org/claimReviewed-input,< 1K
-Predicate,http://schema.org/claimReviewed-output,< 1K
-Predicate,http://schema.org/clincalPharmacology,< 1K
-Predicate,http://schema.org/clincalPharmacology-input,< 1K
-Predicate,http://schema.org/clincalPharmacology-output,< 1K
-Predicate,http://schema.org/clinicalPharmacology,< 1K
-Predicate,http://schema.org/clinicalPharmacology-input,< 1K
-Predicate,http://schema.org/clinicalPharmacology-output,< 1K
-Predicate,http://schema.org/clipNumber,< 1K
-Predicate,http://schema.org/clipNumber-input,< 1K
-Predicate,http://schema.org/clipNumber-output,< 1K
-Predicate,http://schema.org/closes,1M - 10M
-Predicate,http://schema.org/closes-input,< 1K
-Predicate,http://schema.org/closes-output,< 1K
-Predicate,http://schema.org/coach,1K - 10K
-Predicate,http://schema.org/coach-input,< 1K
-Predicate,http://schema.org/coach-output,< 1K
-Predicate,http://schema.org/code,1K - 10K
-Predicate,http://schema.org/code-input,< 1K
-Predicate,http://schema.org/code-output,< 1K
-Predicate,http://schema.org/codeRepository,1K - 10K
-Predicate,http://schema.org/codeRepository-input,< 1K
-Predicate,http://schema.org/codeRepository-output,< 1K
-Predicate,http://schema.org/codeSampleType,< 1K
-Predicate,http://schema.org/codeSampleType-input,< 1K
-Predicate,http://schema.org/codeSampleType-output,< 1K
-Predicate,http://schema.org/codeValue,1K - 10K
-Predicate,http://schema.org/codeValue-input,< 1K
-Predicate,http://schema.org/codeValue-output,< 1K
-Predicate,http://schema.org/codingSystem,1K - 10K
-Predicate,http://schema.org/codingSystem-input,< 1K
-Predicate,http://schema.org/codingSystem-output,< 1K
-Predicate,http://schema.org/colleague,1K - 10K
-Predicate,http://schema.org/colleague-input,< 1K
-Predicate,http://schema.org/colleague-output,< 1K
-Predicate,http://schema.org/colleagues,< 1K
-Predicate,http://schema.org/colleagues-input,< 1K
-Predicate,http://schema.org/colleagues-output,< 1K
-Predicate,http://schema.org/collection,< 1K
-Predicate,http://schema.org/collection-input,< 1K
-Predicate,http://schema.org/collection-output,< 1K
-Predicate,http://schema.org/collectionSize,1K - 10K
-Predicate,http://schema.org/collectionSize-input,< 1K
-Predicate,http://schema.org/collectionSize-output,< 1K
-Predicate,http://schema.org/color,100K - 1M
-Predicate,http://schema.org/color-input,< 1K
-Predicate,http://schema.org/color-output,< 1K
-Predicate,http://schema.org/colorSwatch,< 1K
-Predicate,http://schema.org/colorSwatch-input,< 1K
-Predicate,http://schema.org/colorSwatch-output,< 1K
-Predicate,http://schema.org/colorist,< 1K
-Predicate,http://schema.org/colorist-input,< 1K
-Predicate,http://schema.org/colorist-output,< 1K
-Predicate,http://schema.org/comment,10K - 100K
-Predicate,http://schema.org/comment-input,< 1K
-Predicate,http://schema.org/comment-output,< 1K
-Predicate,http://schema.org/commentCount,1M - 10M
-Predicate,http://schema.org/commentCount-input,< 1K
-Predicate,http://schema.org/commentCount-output,< 1K
-Predicate,http://schema.org/commentText,10K - 100K
-Predicate,http://schema.org/commentText-input,< 1K
-Predicate,http://schema.org/commentText-output,< 1K
-Predicate,http://schema.org/commentTime,10K - 100K
-Predicate,http://schema.org/commentTime-input,< 1K
-Predicate,http://schema.org/commentTime-output,< 1K
-Predicate,http://schema.org/companyRegistration,< 1K
-Predicate,http://schema.org/companyRegistration-input,< 1K
-Predicate,http://schema.org/companyRegistration-output,< 1K
-Predicate,http://schema.org/competencyRequired,1K - 10K
-Predicate,http://schema.org/competencyRequired-input,< 1K
-Predicate,http://schema.org/competencyRequired-output,< 1K
-Predicate,http://schema.org/competitor,10K - 100K
-Predicate,http://schema.org/competitor-input,< 1K
-Predicate,http://schema.org/competitor-output,< 1K
-Predicate,http://schema.org/composer,1K - 10K
-Predicate,http://schema.org/composer-input,< 1K
-Predicate,http://schema.org/composer-output,< 1K
-Predicate,http://schema.org/comprisedOf,< 1K
-Predicate,http://schema.org/comprisedOf-input,< 1K
-Predicate,http://schema.org/comprisedOf-output,< 1K
-Predicate,http://schema.org/conditionsOfAccess,< 1K
-Predicate,http://schema.org/conditionsOfAccess-input,< 1K
-Predicate,http://schema.org/conditionsOfAccess-output,< 1K
-Predicate,http://schema.org/confirmationNumber,< 1K
-Predicate,http://schema.org/confirmationNumber-input,< 1K
-Predicate,http://schema.org/confirmationNumber-output,< 1K
-Predicate,http://schema.org/connectedTo,< 1K
-Predicate,http://schema.org/connectedTo-input,< 1K
-Predicate,http://schema.org/connectedTo-output,< 1K
-Predicate,http://schema.org/constraintProperty,< 1K
-Predicate,http://schema.org/constraintProperty-input,< 1K
-Predicate,http://schema.org/constraintProperty-output,< 1K
-Predicate,http://schema.org/contactOption,100K - 1M
-Predicate,http://schema.org/contactOption-input,< 1K
-Predicate,http://schema.org/contactOption-output,< 1K
-Predicate,http://schema.org/contactPoint,1M - 10M
-Predicate,http://schema.org/contactPoint-input,< 1K
-Predicate,http://schema.org/contactPoint-output,< 1K
-Predicate,http://schema.org/contactPoints,< 1K
-Predicate,http://schema.org/contactPoints-input,< 1K
-Predicate,http://schema.org/contactPoints-output,< 1K
-Predicate,http://schema.org/contactType,1M - 10M
-Predicate,http://schema.org/contactType-input,< 1K
-Predicate,http://schema.org/contactType-output,< 1K
-Predicate,http://schema.org/contactlessPayment,< 1K
-Predicate,http://schema.org/contactlessPayment-input,< 1K
-Predicate,http://schema.org/contactlessPayment-output,< 1K
-Predicate,http://schema.org/containedIn,10K - 100K
-Predicate,http://schema.org/containedIn-input,< 1K
-Predicate,http://schema.org/containedIn-output,< 1K
-Predicate,http://schema.org/containedInPlace,100K - 1M
-Predicate,http://schema.org/containedInPlace-input,< 1K
-Predicate,http://schema.org/containedInPlace-output,< 1K
-Predicate,http://schema.org/containsPlace,10K - 100K
-Predicate,http://schema.org/containsPlace-input,< 1K
-Predicate,http://schema.org/containsPlace-output,< 1K
-Predicate,http://schema.org/containsSeason,1K - 10K
-Predicate,http://schema.org/containsSeason-input,< 1K
-Predicate,http://schema.org/containsSeason-output,< 1K
-Predicate,http://schema.org/contentLocation,10K - 100K
-Predicate,http://schema.org/contentLocation-input,< 1K
-Predicate,http://schema.org/contentLocation-output,< 1K
-Predicate,http://schema.org/contentRating,10K - 100K
-Predicate,http://schema.org/contentRating-input,< 1K
-Predicate,http://schema.org/contentRating-output,< 1K
-Predicate,http://schema.org/contentReferenceTime,1K - 10K
-Predicate,http://schema.org/contentReferenceTime-input,< 1K
-Predicate,http://schema.org/contentReferenceTime-output,< 1K
-Predicate,http://schema.org/contentSize,100K - 1M
-Predicate,http://schema.org/contentSize-input,< 1K
-Predicate,http://schema.org/contentSize-output,< 1K
-Predicate,http://schema.org/contentType,10K - 100K
-Predicate,http://schema.org/contentType-input,< 1K
-Predicate,http://schema.org/contentType-output,< 1K
-Predicate,http://schema.org/contentUrl,10M+
-Predicate,http://schema.org/contentUrl-input,< 1K
-Predicate,http://schema.org/contentUrl-output,< 1K
-Predicate,http://schema.org/contraindication,1K - 10K
-Predicate,http://schema.org/contraindication-input,< 1K
-Predicate,http://schema.org/contraindication-output,< 1K
-Predicate,http://schema.org/contributor,100K - 1M
-Predicate,http://schema.org/contributor-input,< 1K
-Predicate,http://schema.org/contributor-output,< 1K
-Predicate,http://schema.org/cookTime,10K - 100K
-Predicate,http://schema.org/cookTime-input,< 1K
-Predicate,http://schema.org/cookTime-output,< 1K
-Predicate,http://schema.org/cookingMethod,1K - 10K
-Predicate,http://schema.org/cookingMethod-input,< 1K
-Predicate,http://schema.org/cookingMethod-output,< 1K
-Predicate,http://schema.org/copyrightHolder,100K - 1M
-Predicate,http://schema.org/copyrightHolder-input,< 1K
-Predicate,http://schema.org/copyrightHolder-output,< 1K
-Predicate,http://schema.org/copyrightNotice,10K - 100K
-Predicate,http://schema.org/copyrightNotice-input,< 1K
-Predicate,http://schema.org/copyrightNotice-output,< 1K
-Predicate,http://schema.org/copyrightYear,100K - 1M
-Predicate,http://schema.org/copyrightYear-input,< 1K
-Predicate,http://schema.org/copyrightYear-output,< 1K
-Predicate,http://schema.org/correction,< 1K
-Predicate,http://schema.org/correction-input,< 1K
-Predicate,http://schema.org/correction-output,< 1K
-Predicate,http://schema.org/correctionsPolicy,10K - 100K
-Predicate,http://schema.org/correctionsPolicy-input,< 1K
-Predicate,http://schema.org/correctionsPolicy-output,< 1K
-Predicate,http://schema.org/costCategory,< 1K
-Predicate,http://schema.org/costCategory-input,< 1K
-Predicate,http://schema.org/costCategory-output,< 1K
-Predicate,http://schema.org/costCurrency,< 1K
-Predicate,http://schema.org/costCurrency-input,< 1K
-Predicate,http://schema.org/costCurrency-output,< 1K
-Predicate,http://schema.org/costOrigin,< 1K
-Predicate,http://schema.org/costOrigin-input,< 1K
-Predicate,http://schema.org/costOrigin-output,< 1K
-Predicate,http://schema.org/costPerUnit,< 1K
-Predicate,http://schema.org/costPerUnit-input,< 1K
-Predicate,http://schema.org/costPerUnit-output,< 1K
-Predicate,http://schema.org/countriesNotSupported,< 1K
-Predicate,http://schema.org/countriesNotSupported-input,< 1K
-Predicate,http://schema.org/countriesNotSupported-output,< 1K
-Predicate,http://schema.org/countriesSupported,1K - 10K
-Predicate,http://schema.org/countriesSupported-input,< 1K
-Predicate,http://schema.org/countriesSupported-output,< 1K
-Predicate,http://schema.org/countryOfAssembly,1K - 10K
-Predicate,http://schema.org/countryOfAssembly-input,< 1K
-Predicate,http://schema.org/countryOfAssembly-output,< 1K
-Predicate,http://schema.org/countryOfLastProcessing,< 1K
-Predicate,http://schema.org/countryOfLastProcessing-input,< 1K
-Predicate,http://schema.org/countryOfLastProcessing-output,< 1K
-Predicate,http://schema.org/countryOfOrigin,10K - 100K
-Predicate,http://schema.org/countryOfOrigin-input,< 1K
-Predicate,http://schema.org/countryOfOrigin-output,< 1K
-Predicate,http://schema.org/course,< 1K
-Predicate,http://schema.org/course-input,< 1K
-Predicate,http://schema.org/course-output,< 1K
-Predicate,http://schema.org/courseCode,10K - 100K
-Predicate,http://schema.org/courseCode-input,< 1K
-Predicate,http://schema.org/courseCode-output,< 1K
-Predicate,http://schema.org/courseMode,10K - 100K
-Predicate,http://schema.org/courseMode-input,< 1K
-Predicate,http://schema.org/courseMode-output,< 1K
-Predicate,http://schema.org/coursePrerequisites,1K - 10K
-Predicate,http://schema.org/coursePrerequisites-input,< 1K
-Predicate,http://schema.org/coursePrerequisites-output,< 1K
-Predicate,http://schema.org/courseSchedule,1K - 10K
-Predicate,http://schema.org/courseSchedule-input,< 1K
-Predicate,http://schema.org/courseSchedule-output,< 1K
-Predicate,http://schema.org/courseWorkload,10K - 100K
-Predicate,http://schema.org/courseWorkload-input,< 1K
-Predicate,http://schema.org/courseWorkload-output,< 1K
-Predicate,http://schema.org/coverageEndTime,1K - 10K
-Predicate,http://schema.org/coverageEndTime-input,< 1K
-Predicate,http://schema.org/coverageEndTime-output,< 1K
-Predicate,http://schema.org/coverageStartTime,1K - 10K
-Predicate,http://schema.org/coverageStartTime-input,< 1K
-Predicate,http://schema.org/coverageStartTime-output,< 1K
-Predicate,http://schema.org/creativeWorkStatus,1K - 10K
-Predicate,http://schema.org/creativeWorkStatus-input,< 1K
-Predicate,http://schema.org/creativeWorkStatus-output,< 1K
-Predicate,http://schema.org/creator,1M - 10M
-Predicate,http://schema.org/creator-input,< 1K
-Predicate,http://schema.org/creator-output,< 1K
-Predicate,http://schema.org/credentialCategory,10K - 100K
-Predicate,http://schema.org/credentialCategory-input,< 1K
-Predicate,http://schema.org/credentialCategory-output,< 1K
-Predicate,http://schema.org/creditText,100K - 1M
-Predicate,http://schema.org/creditText-input,< 1K
-Predicate,http://schema.org/creditText-output,< 1K
-Predicate,http://schema.org/creditedTo,< 1K
-Predicate,http://schema.org/creditedTo-input,< 1K
-Predicate,http://schema.org/creditedTo-output,< 1K
-Predicate,http://schema.org/cssSelector,100K - 1M
-Predicate,http://schema.org/cssSelector-input,< 1K
-Predicate,http://schema.org/cssSelector-output,< 1K
-Predicate,http://schema.org/currenciesAccepted,100K - 1M
-Predicate,http://schema.org/currenciesAccepted-input,< 1K
-Predicate,http://schema.org/currenciesAccepted-output,< 1K
-Predicate,http://schema.org/currency,100K - 1M
-Predicate,http://schema.org/currency-input,< 1K
-Predicate,http://schema.org/currency-output,< 1K
-Predicate,http://schema.org/currentExchangeRate,< 1K
-Predicate,http://schema.org/currentExchangeRate-input,< 1K
-Predicate,http://schema.org/currentExchangeRate-output,< 1K
-Predicate,http://schema.org/customer,< 1K
-Predicate,http://schema.org/customer-input,< 1K
-Predicate,http://schema.org/customer-output,< 1K
-Predicate,http://schema.org/customerRemorseReturnFees,1K - 10K
-Predicate,http://schema.org/customerRemorseReturnFees-input,< 1K
-Predicate,http://schema.org/customerRemorseReturnFees-output,< 1K
-Predicate,http://schema.org/customerRemorseReturnLabelSource,< 1K
-Predicate,http://schema.org/customerRemorseReturnLabelSource-input,< 1K
-Predicate,http://schema.org/customerRemorseReturnLabelSource-output,< 1K
-Predicate,http://schema.org/customerRemorseReturnShippingFeesAmount,< 1K
-Predicate,http://schema.org/customerRemorseReturnShippingFeesAmount-input,< 1K
-Predicate,http://schema.org/customerRemorseReturnShippingFeesAmount-output,< 1K
-Predicate,http://schema.org/cutoffTime,10K - 100K
-Predicate,http://schema.org/cutoffTime-input,< 1K
-Predicate,http://schema.org/cutoffTime-output,< 1K
-Predicate,http://schema.org/cvdCollectionDate,< 1K
-Predicate,http://schema.org/cvdCollectionDate-input,< 1K
-Predicate,http://schema.org/cvdCollectionDate-output,< 1K
-Predicate,http://schema.org/cvdFacilityCounty,< 1K
-Predicate,http://schema.org/cvdFacilityCounty-input,< 1K
-Predicate,http://schema.org/cvdFacilityCounty-output,< 1K
-Predicate,http://schema.org/cvdFacilityId,< 1K
-Predicate,http://schema.org/cvdFacilityId-input,< 1K
-Predicate,http://schema.org/cvdFacilityId-output,< 1K
-Predicate,http://schema.org/cvdNumBeds,< 1K
-Predicate,http://schema.org/cvdNumBeds-input,< 1K
-Predicate,http://schema.org/cvdNumBeds-output,< 1K
-Predicate,http://schema.org/cvdNumBedsOcc,< 1K
-Predicate,http://schema.org/cvdNumBedsOcc-input,< 1K
-Predicate,http://schema.org/cvdNumBedsOcc-output,< 1K
-Predicate,http://schema.org/cvdNumC19Died,< 1K
-Predicate,http://schema.org/cvdNumC19Died-input,< 1K
-Predicate,http://schema.org/cvdNumC19Died-output,< 1K
-Predicate,http://schema.org/cvdNumC19HOPats,< 1K
-Predicate,http://schema.org/cvdNumC19HOPats-input,< 1K
-Predicate,http://schema.org/cvdNumC19HOPats-output,< 1K
-Predicate,http://schema.org/cvdNumC19HospPats,< 1K
-Predicate,http://schema.org/cvdNumC19HospPats-input,< 1K
-Predicate,http://schema.org/cvdNumC19HospPats-output,< 1K
-Predicate,http://schema.org/cvdNumC19MechVentPats,< 1K
-Predicate,http://schema.org/cvdNumC19MechVentPats-input,< 1K
-Predicate,http://schema.org/cvdNumC19MechVentPats-output,< 1K
-Predicate,http://schema.org/cvdNumC19OFMechVentPats,< 1K
-Predicate,http://schema.org/cvdNumC19OFMechVentPats-input,< 1K
-Predicate,http://schema.org/cvdNumC19OFMechVentPats-output,< 1K
-Predicate,http://schema.org/cvdNumC19OverflowPats,< 1K
-Predicate,http://schema.org/cvdNumC19OverflowPats-input,< 1K
-Predicate,http://schema.org/cvdNumC19OverflowPats-output,< 1K
-Predicate,http://schema.org/cvdNumICUBeds,< 1K
-Predicate,http://schema.org/cvdNumICUBeds-input,< 1K
-Predicate,http://schema.org/cvdNumICUBeds-output,< 1K
-Predicate,http://schema.org/cvdNumICUBedsOcc,< 1K
-Predicate,http://schema.org/cvdNumICUBedsOcc-input,< 1K
-Predicate,http://schema.org/cvdNumICUBedsOcc-output,< 1K
-Predicate,http://schema.org/cvdNumTotBeds,< 1K
-Predicate,http://schema.org/cvdNumTotBeds-input,< 1K
-Predicate,http://schema.org/cvdNumTotBeds-output,< 1K
-Predicate,http://schema.org/cvdNumVent,< 1K
-Predicate,http://schema.org/cvdNumVent-input,< 1K
-Predicate,http://schema.org/cvdNumVent-output,< 1K
-Predicate,http://schema.org/cvdNumVentUse,< 1K
-Predicate,http://schema.org/cvdNumVentUse-input,< 1K
-Predicate,http://schema.org/cvdNumVentUse-output,< 1K
-Predicate,http://schema.org/data,1K - 10K
-Predicate,http://schema.org/data-input,< 1K
-Predicate,http://schema.org/data-output,< 1K
-Predicate,http://schema.org/dataFeedElement,1K - 10K
-Predicate,http://schema.org/dataFeedElement-input,< 1K
-Predicate,http://schema.org/dataFeedElement-output,< 1K
-Predicate,http://schema.org/dataset,1K - 10K
-Predicate,http://schema.org/dataset-input,< 1K
-Predicate,http://schema.org/dataset-output,< 1K
-Predicate,http://schema.org/datasetTimeInterval,< 1K
-Predicate,http://schema.org/datasetTimeInterval-input,< 1K
-Predicate,http://schema.org/datasetTimeInterval-output,< 1K
-Predicate,http://schema.org/dateCreated,100K - 1M
-Predicate,http://schema.org/dateCreated-input,< 1K
-Predicate,http://schema.org/dateCreated-output,< 1K
-Predicate,http://schema.org/dateDeleted,< 1K
-Predicate,http://schema.org/dateDeleted-input,< 1K
-Predicate,http://schema.org/dateDeleted-output,< 1K
-Predicate,http://schema.org/dateIssued,< 1K
-Predicate,http://schema.org/dateIssued-input,< 1K
-Predicate,http://schema.org/dateIssued-output,< 1K
-Predicate,http://schema.org/dateModified,10M+
-Predicate,http://schema.org/dateModified-input,< 1K
-Predicate,http://schema.org/dateModified-output,< 1K
-Predicate,http://schema.org/datePosted,100K - 1M
-Predicate,http://schema.org/datePosted-input,< 1K
-Predicate,http://schema.org/datePosted-output,< 1K
-Predicate,http://schema.org/datePublished,10M+
-Predicate,http://schema.org/datePublished-input,< 1K
-Predicate,http://schema.org/datePublished-output,< 1K
-Predicate,http://schema.org/dateRead,< 1K
-Predicate,http://schema.org/dateRead-input,< 1K
-Predicate,http://schema.org/dateRead-output,< 1K
-Predicate,http://schema.org/dateReceived,< 1K
-Predicate,http://schema.org/dateReceived-input,< 1K
-Predicate,http://schema.org/dateReceived-output,< 1K
-Predicate,http://schema.org/dateSent,< 1K
-Predicate,http://schema.org/dateSent-input,< 1K
-Predicate,http://schema.org/dateSent-output,< 1K
-Predicate,http://schema.org/dateVehicleFirstRegistered,1K - 10K
-Predicate,http://schema.org/dateVehicleFirstRegistered-input,< 1K
-Predicate,http://schema.org/dateVehicleFirstRegistered-output,< 1K
-Predicate,http://schema.org/dateline,1K - 10K
-Predicate,http://schema.org/dateline-input,< 1K
-Predicate,http://schema.org/dateline-output,< 1K
-Predicate,http://schema.org/dayOfWeek,1M - 10M
-Predicate,http://schema.org/dayOfWeek-input,< 1K
-Predicate,http://schema.org/dayOfWeek-output,< 1K
-Predicate,http://schema.org/deathDate,10K - 100K
-Predicate,http://schema.org/deathDate-input,< 1K
-Predicate,http://schema.org/deathDate-output,< 1K
-Predicate,http://schema.org/deathPlace,1K - 10K
-Predicate,http://schema.org/deathPlace-input,< 1K
-Predicate,http://schema.org/deathPlace-output,< 1K
-Predicate,http://schema.org/defaultValue,100K - 1M
-Predicate,http://schema.org/defaultValue-input,< 1K
-Predicate,http://schema.org/defaultValue-output,< 1K
-Predicate,http://schema.org/deliveryAddress,< 1K
-Predicate,http://schema.org/deliveryAddress-input,< 1K
-Predicate,http://schema.org/deliveryAddress-output,< 1K
-Predicate,http://schema.org/deliveryLeadTime,10K - 100K
-Predicate,http://schema.org/deliveryLeadTime-input,< 1K
-Predicate,http://schema.org/deliveryLeadTime-output,< 1K
-Predicate,http://schema.org/deliveryMethod,100K - 1M
-Predicate,http://schema.org/deliveryMethod-input,< 1K
-Predicate,http://schema.org/deliveryMethod-output,< 1K
-Predicate,http://schema.org/deliveryStatus,< 1K
-Predicate,http://schema.org/deliveryStatus-input,< 1K
-Predicate,http://schema.org/deliveryStatus-output,< 1K
-Predicate,http://schema.org/deliveryTime,100K - 1M
-Predicate,http://schema.org/deliveryTime-input,< 1K
-Predicate,http://schema.org/deliveryTime-output,< 1K
-Predicate,http://schema.org/department,10K - 100K
-Predicate,http://schema.org/department-input,< 1K
-Predicate,http://schema.org/department-output,< 1K
-Predicate,http://schema.org/departureAirport,1K - 10K
-Predicate,http://schema.org/departureAirport-input,< 1K
-Predicate,http://schema.org/departureAirport-output,< 1K
-Predicate,http://schema.org/departureBoatTerminal,< 1K
-Predicate,http://schema.org/departureBoatTerminal-input,< 1K
-Predicate,http://schema.org/departureBoatTerminal-output,< 1K
-Predicate,http://schema.org/departureBusStop,< 1K
-Predicate,http://schema.org/departureBusStop-input,< 1K
-Predicate,http://schema.org/departureBusStop-output,< 1K
-Predicate,http://schema.org/departureGate,< 1K
-Predicate,http://schema.org/departureGate-input,< 1K
-Predicate,http://schema.org/departureGate-output,< 1K
-Predicate,http://schema.org/departurePlatform,< 1K
-Predicate,http://schema.org/departurePlatform-input,< 1K
-Predicate,http://schema.org/departurePlatform-output,< 1K
-Predicate,http://schema.org/departureStation,< 1K
-Predicate,http://schema.org/departureStation-input,< 1K
-Predicate,http://schema.org/departureStation-output,< 1K
-Predicate,http://schema.org/departureTerminal,< 1K
-Predicate,http://schema.org/departureTerminal-input,< 1K
-Predicate,http://schema.org/departureTerminal-output,< 1K
-Predicate,http://schema.org/departureTime,1K - 10K
-Predicate,http://schema.org/departureTime-input,< 1K
-Predicate,http://schema.org/departureTime-output,< 1K
-Predicate,http://schema.org/dependencies,10K - 100K
-Predicate,http://schema.org/dependencies-input,< 1K
-Predicate,http://schema.org/dependencies-output,< 1K
-Predicate,http://schema.org/depth,10K - 100K
-Predicate,http://schema.org/depth-input,< 1K
-Predicate,http://schema.org/depth-output,< 1K
-Predicate,http://schema.org/description,10M+
-Predicate,http://schema.org/description-input,< 1K
-Predicate,http://schema.org/description-output,< 1K
-Predicate,http://schema.org/device,< 1K
-Predicate,http://schema.org/device-input,< 1K
-Predicate,http://schema.org/device-output,< 1K
-Predicate,http://schema.org/diagnosis,< 1K
-Predicate,http://schema.org/diagnosis-input,< 1K
-Predicate,http://schema.org/diagnosis-output,< 1K
-Predicate,http://schema.org/diagram,< 1K
-Predicate,http://schema.org/diagram-input,< 1K
-Predicate,http://schema.org/diagram-output,< 1K
-Predicate,http://schema.org/diet,< 1K
-Predicate,http://schema.org/diet-input,< 1K
-Predicate,http://schema.org/diet-output,< 1K
-Predicate,http://schema.org/dietFeatures,< 1K
-Predicate,http://schema.org/dietFeatures-input,< 1K
-Predicate,http://schema.org/dietFeatures-output,< 1K
-Predicate,http://schema.org/differentialDiagnosis,< 1K
-Predicate,http://schema.org/differentialDiagnosis-input,< 1K
-Predicate,http://schema.org/differentialDiagnosis-output,< 1K
-Predicate,http://schema.org/digitalSourceType,< 1K
-Predicate,http://schema.org/digitalSourceType-input,< 1K
-Predicate,http://schema.org/digitalSourceType-output,< 1K
-Predicate,http://schema.org/directApply,10K - 100K
-Predicate,http://schema.org/directApply-input,< 1K
-Predicate,http://schema.org/directApply-output,< 1K
-Predicate,http://schema.org/director,10K - 100K
-Predicate,http://schema.org/director-input,< 1K
-Predicate,http://schema.org/director-output,< 1K
-Predicate,http://schema.org/directors,< 1K
-Predicate,http://schema.org/directors-input,< 1K
-Predicate,http://schema.org/directors-output,< 1K
-Predicate,http://schema.org/disambiguatingDescription,10K - 100K
-Predicate,http://schema.org/disambiguatingDescription-input,< 1K
-Predicate,http://schema.org/disambiguatingDescription-output,< 1K
-Predicate,http://schema.org/discount,10K - 100K
-Predicate,http://schema.org/discount-input,< 1K
-Predicate,http://schema.org/discount-output,< 1K
-Predicate,http://schema.org/discountCode,< 1K
-Predicate,http://schema.org/discountCode-input,< 1K
-Predicate,http://schema.org/discountCode-output,< 1K
-Predicate,http://schema.org/discountCurrency,< 1K
-Predicate,http://schema.org/discountCurrency-input,< 1K
-Predicate,http://schema.org/discountCurrency-output,< 1K
-Predicate,http://schema.org/discusses,1K - 10K
-Predicate,http://schema.org/discusses-input,< 1K
-Predicate,http://schema.org/discusses-output,< 1K
-Predicate,http://schema.org/discussionUrl,10K - 100K
-Predicate,http://schema.org/discussionUrl-input,< 1K
-Predicate,http://schema.org/discussionUrl-output,< 1K
-Predicate,http://schema.org/diseasePreventionInfo,< 1K
-Predicate,http://schema.org/diseasePreventionInfo-input,< 1K
-Predicate,http://schema.org/diseasePreventionInfo-output,< 1K
-Predicate,http://schema.org/diseaseSpreadStatistics,< 1K
-Predicate,http://schema.org/diseaseSpreadStatistics-input,< 1K
-Predicate,http://schema.org/diseaseSpreadStatistics-output,< 1K
-Predicate,http://schema.org/displayLocation,< 1K
-Predicate,http://schema.org/displayLocation-input,< 1K
-Predicate,http://schema.org/displayLocation-output,< 1K
-Predicate,http://schema.org/dissolutionDate,< 1K
-Predicate,http://schema.org/dissolutionDate-input,< 1K
-Predicate,http://schema.org/dissolutionDate-output,< 1K
-Predicate,http://schema.org/distance,1K - 10K
-Predicate,http://schema.org/distance-input,< 1K
-Predicate,http://schema.org/distance-output,< 1K
-Predicate,http://schema.org/distinguishingSign,< 1K
-Predicate,http://schema.org/distinguishingSign-input,< 1K
-Predicate,http://schema.org/distinguishingSign-output,< 1K
-Predicate,http://schema.org/distribution,10K - 100K
-Predicate,http://schema.org/distribution-input,< 1K
-Predicate,http://schema.org/distribution-output,< 1K
-Predicate,http://schema.org/diversityPolicy,10K - 100K
-Predicate,http://schema.org/diversityPolicy-input,< 1K
-Predicate,http://schema.org/diversityPolicy-output,< 1K
-Predicate,http://schema.org/diversityStaffingReport,1K - 10K
-Predicate,http://schema.org/diversityStaffingReport-input,< 1K
-Predicate,http://schema.org/diversityStaffingReport-output,< 1K
-Predicate,http://schema.org/documentation,1K - 10K
-Predicate,http://schema.org/documentation-input,< 1K
-Predicate,http://schema.org/documentation-output,< 1K
-Predicate,http://schema.org/doesNotShip,10K - 100K
-Predicate,http://schema.org/doesNotShip-input,< 1K
-Predicate,http://schema.org/doesNotShip-output,< 1K
-Predicate,http://schema.org/domainIncludes,< 1K
-Predicate,http://schema.org/domainIncludes-input,< 1K
-Predicate,http://schema.org/domainIncludes-output,< 1K
-Predicate,http://schema.org/domiciledMortgage,< 1K
-Predicate,http://schema.org/domiciledMortgage-input,< 1K
-Predicate,http://schema.org/domiciledMortgage-output,< 1K
-Predicate,http://schema.org/doorTime,1K - 10K
-Predicate,http://schema.org/doorTime-input,< 1K
-Predicate,http://schema.org/doorTime-output,< 1K
-Predicate,http://schema.org/dosageForm,1K - 10K
-Predicate,http://schema.org/dosageForm-input,< 1K
-Predicate,http://schema.org/dosageForm-output,< 1K
-Predicate,http://schema.org/doseSchedule,< 1K
-Predicate,http://schema.org/doseSchedule-input,< 1K
-Predicate,http://schema.org/doseSchedule-output,< 1K
-Predicate,http://schema.org/doseUnit,< 1K
-Predicate,http://schema.org/doseUnit-input,< 1K
-Predicate,http://schema.org/doseUnit-output,< 1K
-Predicate,http://schema.org/doseValue,< 1K
-Predicate,http://schema.org/doseValue-input,< 1K
-Predicate,http://schema.org/doseValue-output,< 1K
-Predicate,http://schema.org/downPayment,< 1K
-Predicate,http://schema.org/downPayment-input,< 1K
-Predicate,http://schema.org/downPayment-output,< 1K
-Predicate,http://schema.org/downloadUrl,100K - 1M
-Predicate,http://schema.org/downloadUrl-input,< 1K
-Predicate,http://schema.org/downloadUrl-output,< 1K
-Predicate,http://schema.org/downvoteCount,1K - 10K
-Predicate,http://schema.org/downvoteCount-input,< 1K
-Predicate,http://schema.org/downvoteCount-output,< 1K
-Predicate,http://schema.org/drainsTo,< 1K
-Predicate,http://schema.org/drainsTo-input,< 1K
-Predicate,http://schema.org/drainsTo-output,< 1K
-Predicate,http://schema.org/driveWheelConfiguration,10K - 100K
-Predicate,http://schema.org/driveWheelConfiguration-input,< 1K
-Predicate,http://schema.org/driveWheelConfiguration-output,< 1K
-Predicate,http://schema.org/dropoffLocation,< 1K
-Predicate,http://schema.org/dropoffLocation-input,< 1K
-Predicate,http://schema.org/dropoffLocation-output,< 1K
-Predicate,http://schema.org/dropoffTime,< 1K
-Predicate,http://schema.org/dropoffTime-input,< 1K
-Predicate,http://schema.org/dropoffTime-output,< 1K
-Predicate,http://schema.org/drug,< 1K
-Predicate,http://schema.org/drug-input,< 1K
-Predicate,http://schema.org/drug-output,< 1K
-Predicate,http://schema.org/drugClass,1K - 10K
-Predicate,http://schema.org/drugClass-input,< 1K
-Predicate,http://schema.org/drugClass-output,< 1K
-Predicate,http://schema.org/drugUnit,< 1K
-Predicate,http://schema.org/drugUnit-input,< 1K
-Predicate,http://schema.org/drugUnit-output,< 1K
-Predicate,http://schema.org/duns,1K - 10K
-Predicate,http://schema.org/duns-input,< 1K
-Predicate,http://schema.org/duns-output,< 1K
-Predicate,http://schema.org/duplicateTherapy,< 1K
-Predicate,http://schema.org/duplicateTherapy-input,< 1K
-Predicate,http://schema.org/duplicateTherapy-output,< 1K
-Predicate,http://schema.org/duration,1M - 10M
-Predicate,http://schema.org/duration-input,< 1K
-Predicate,http://schema.org/duration-output,< 1K
-Predicate,http://schema.org/durationOfWarranty,1K - 10K
-Predicate,http://schema.org/durationOfWarranty-input,< 1K
-Predicate,http://schema.org/durationOfWarranty-output,< 1K
-Predicate,http://schema.org/duringMedia,< 1K
-Predicate,http://schema.org/duringMedia-input,< 1K
-Predicate,http://schema.org/duringMedia-output,< 1K
-Predicate,http://schema.org/earlyPrepaymentPenalty,< 1K
-Predicate,http://schema.org/earlyPrepaymentPenalty-input,< 1K
-Predicate,http://schema.org/earlyPrepaymentPenalty-output,< 1K
-Predicate,http://schema.org/editEIDR,< 1K
-Predicate,http://schema.org/editEIDR-input,< 1K
-Predicate,http://schema.org/editEIDR-output,< 1K
-Predicate,http://schema.org/editor,100K - 1M
-Predicate,http://schema.org/editor-input,< 1K
-Predicate,http://schema.org/editor-output,< 1K
-Predicate,http://schema.org/eduQuestionType,1K - 10K
-Predicate,http://schema.org/eduQuestionType-input,< 1K
-Predicate,http://schema.org/eduQuestionType-output,< 1K
-Predicate,http://schema.org/educationRequirements,10K - 100K
-Predicate,http://schema.org/educationRequirements-input,< 1K
-Predicate,http://schema.org/educationRequirements-output,< 1K
-Predicate,http://schema.org/educationalAlignment,1K - 10K
-Predicate,http://schema.org/educationalAlignment-input,< 1K
-Predicate,http://schema.org/educationalAlignment-output,< 1K
-Predicate,http://schema.org/educationalCredentialAwarded,10K - 100K
-Predicate,http://schema.org/educationalCredentialAwarded-input,< 1K
-Predicate,http://schema.org/educationalCredentialAwarded-output,< 1K
-Predicate,http://schema.org/educationalFramework,< 1K
-Predicate,http://schema.org/educationalFramework-input,< 1K
-Predicate,http://schema.org/educationalFramework-output,< 1K
-Predicate,http://schema.org/educationalLevel,10K - 100K
-Predicate,http://schema.org/educationalLevel-input,< 1K
-Predicate,http://schema.org/educationalLevel-output,< 1K
-Predicate,http://schema.org/educationalProgramMode,1K - 10K
-Predicate,http://schema.org/educationalProgramMode-input,< 1K
-Predicate,http://schema.org/educationalProgramMode-output,< 1K
-Predicate,http://schema.org/educationalRole,10K - 100K
-Predicate,http://schema.org/educationalRole-input,< 1K
-Predicate,http://schema.org/educationalRole-output,< 1K
-Predicate,http://schema.org/educationalUse,1K - 10K
-Predicate,http://schema.org/educationalUse-input,< 1K
-Predicate,http://schema.org/educationalUse-output,< 1K
-Predicate,http://schema.org/elevation,1K - 10K
-Predicate,http://schema.org/elevation-input,< 1K
-Predicate,http://schema.org/elevation-output,< 1K
-Predicate,http://schema.org/eligibilityToWorkRequirement,< 1K
-Predicate,http://schema.org/eligibilityToWorkRequirement-input,< 1K
-Predicate,http://schema.org/eligibilityToWorkRequirement-output,< 1K
-Predicate,http://schema.org/eligibleCustomerType,1K - 10K
-Predicate,http://schema.org/eligibleCustomerType-input,< 1K
-Predicate,http://schema.org/eligibleCustomerType-output,< 1K
-Predicate,http://schema.org/eligibleDuration,10K - 100K
-Predicate,http://schema.org/eligibleDuration-input,< 1K
-Predicate,http://schema.org/eligibleDuration-output,< 1K
-Predicate,http://schema.org/eligibleQuantity,100K - 1M
-Predicate,http://schema.org/eligibleQuantity-input,< 1K
-Predicate,http://schema.org/eligibleQuantity-output,< 1K
-Predicate,http://schema.org/eligibleRegion,10K - 100K
-Predicate,http://schema.org/eligibleRegion-input,< 1K
-Predicate,http://schema.org/eligibleRegion-output,< 1K
-Predicate,http://schema.org/eligibleTransactionVolume,10K - 100K
-Predicate,http://schema.org/eligibleTransactionVolume-input,< 1K
-Predicate,http://schema.org/eligibleTransactionVolume-output,< 1K
-Predicate,http://schema.org/eligibleWithSupplier,< 1K
-Predicate,http://schema.org/eligibleWithSupplier-input,< 1K
-Predicate,http://schema.org/eligibleWithSupplier-output,< 1K
-Predicate,http://schema.org/email,1M - 10M
-Predicate,http://schema.org/email-input,< 1K
-Predicate,http://schema.org/email-output,< 1K
-Predicate,http://schema.org/embedUrl,1M - 10M
-Predicate,http://schema.org/embedUrl-input,< 1K
-Predicate,http://schema.org/embedUrl-output,< 1K
-Predicate,http://schema.org/embeddedTextCaption,1K - 10K
-Predicate,http://schema.org/embeddedTextCaption-input,< 1K
-Predicate,http://schema.org/embeddedTextCaption-output,< 1K
-Predicate,http://schema.org/emissionsCO2,1K - 10K
-Predicate,http://schema.org/emissionsCO2-input,< 1K
-Predicate,http://schema.org/emissionsCO2-output,< 1K
-Predicate,http://schema.org/employee,100K - 1M
-Predicate,http://schema.org/employee-input,< 1K
-Predicate,http://schema.org/employee-output,< 1K
-Predicate,http://schema.org/employees,1K - 10K
-Predicate,http://schema.org/employees-input,< 1K
-Predicate,http://schema.org/employees-output,< 1K
-Predicate,http://schema.org/employerOverview,1K - 10K
-Predicate,http://schema.org/employerOverview-input,< 1K
-Predicate,http://schema.org/employerOverview-output,< 1K
-Predicate,http://schema.org/employmentType,100K - 1M
-Predicate,http://schema.org/employmentType-input,< 1K
-Predicate,http://schema.org/employmentType-output,< 1K
-Predicate,http://schema.org/employmentUnit,1K - 10K
-Predicate,http://schema.org/employmentUnit-input,< 1K
-Predicate,http://schema.org/employmentUnit-output,< 1K
-Predicate,http://schema.org/encodesBioChemEntity,< 1K
-Predicate,http://schema.org/encodesBioChemEntity-input,< 1K
-Predicate,http://schema.org/encodesBioChemEntity-output,< 1K
-Predicate,http://schema.org/encodesCreativeWork,< 1K
-Predicate,http://schema.org/encodesCreativeWork-input,< 1K
-Predicate,http://schema.org/encodesCreativeWork-output,< 1K
-Predicate,http://schema.org/encoding,100K - 1M
-Predicate,http://schema.org/encoding-input,< 1K
-Predicate,http://schema.org/encoding-output,< 1K
-Predicate,http://schema.org/encodingFormat,10K - 100K
-Predicate,http://schema.org/encodingFormat-input,< 1K
-Predicate,http://schema.org/encodingFormat-output,< 1K
-Predicate,http://schema.org/encodingType,< 1K
-Predicate,http://schema.org/encodingType-input,< 1K
-Predicate,http://schema.org/encodingType-output,< 1K
-Predicate,http://schema.org/encodings,< 1K
-Predicate,http://schema.org/encodings-input,< 1K
-Predicate,http://schema.org/encodings-output,< 1K
-Predicate,http://schema.org/endDate,100K - 1M
-Predicate,http://schema.org/endDate-input,< 1K
-Predicate,http://schema.org/endDate-output,< 1K
-Predicate,http://schema.org/endOffset,10K - 100K
-Predicate,http://schema.org/endOffset-input,< 1K
-Predicate,http://schema.org/endOffset-output,< 1K
-Predicate,http://schema.org/endTime,1K - 10K
-Predicate,http://schema.org/endTime-input,< 1K
-Predicate,http://schema.org/endTime-output,< 1K
-Predicate,http://schema.org/endorsee,< 1K
-Predicate,http://schema.org/endorsee-input,< 1K
-Predicate,http://schema.org/endorsee-output,< 1K
-Predicate,http://schema.org/endorsers,< 1K
-Predicate,http://schema.org/endorsers-input,< 1K
-Predicate,http://schema.org/endorsers-output,< 1K
-Predicate,http://schema.org/energyEfficiencyScaleMax,1K - 10K
-Predicate,http://schema.org/energyEfficiencyScaleMax-input,< 1K
-Predicate,http://schema.org/energyEfficiencyScaleMax-output,< 1K
-Predicate,http://schema.org/energyEfficiencyScaleMin,1K - 10K
-Predicate,http://schema.org/energyEfficiencyScaleMin-input,< 1K
-Predicate,http://schema.org/energyEfficiencyScaleMin-output,< 1K
-Predicate,http://schema.org/engineDisplacement,10K - 100K
-Predicate,http://schema.org/engineDisplacement-input,< 1K
-Predicate,http://schema.org/engineDisplacement-output,< 1K
-Predicate,http://schema.org/enginePower,10K - 100K
-Predicate,http://schema.org/enginePower-input,< 1K
-Predicate,http://schema.org/enginePower-output,< 1K
-Predicate,http://schema.org/engineType,1K - 10K
-Predicate,http://schema.org/engineType-input,< 1K
-Predicate,http://schema.org/engineType-output,< 1K
-Predicate,http://schema.org/entertainmentBusiness,< 1K
-Predicate,http://schema.org/entertainmentBusiness-input,< 1K
-Predicate,http://schema.org/entertainmentBusiness-output,< 1K
-Predicate,http://schema.org/epidemiology,1K - 10K
-Predicate,http://schema.org/epidemiology-input,< 1K
-Predicate,http://schema.org/epidemiology-output,< 1K
-Predicate,http://schema.org/episode,1K - 10K
-Predicate,http://schema.org/episode-input,< 1K
-Predicate,http://schema.org/episode-output,< 1K
-Predicate,http://schema.org/episodeNumber,10K - 100K
-Predicate,http://schema.org/episodeNumber-input,< 1K
-Predicate,http://schema.org/episodeNumber-output,< 1K
-Predicate,http://schema.org/episodes,< 1K
-Predicate,http://schema.org/episodes-input,< 1K
-Predicate,http://schema.org/episodes-output,< 1K
-Predicate,http://schema.org/equal,< 1K
-Predicate,http://schema.org/equal-input,< 1K
-Predicate,http://schema.org/equal-output,< 1K
-Predicate,http://schema.org/error,1K - 10K
-Predicate,http://schema.org/error-input,< 1K
-Predicate,http://schema.org/error-output,< 1K
-Predicate,http://schema.org/errorCode,< 1K
-Predicate,http://schema.org/errorCode-input,< 1K
-Predicate,http://schema.org/errorCode-output,< 1K
-Predicate,http://schema.org/estimatedCost,10K - 100K
-Predicate,http://schema.org/estimatedCost-input,< 1K
-Predicate,http://schema.org/estimatedCost-output,< 1K
-Predicate,http://schema.org/estimatedFlightDuration,< 1K
-Predicate,http://schema.org/estimatedFlightDuration-input,< 1K
-Predicate,http://schema.org/estimatedFlightDuration-output,< 1K
-Predicate,http://schema.org/estimatedSalary,1K - 10K
-Predicate,http://schema.org/estimatedSalary-input,< 1K
-Predicate,http://schema.org/estimatedSalary-output,< 1K
-Predicate,http://schema.org/estimatesRiskOf,< 1K
-Predicate,http://schema.org/estimatesRiskOf-input,< 1K
-Predicate,http://schema.org/estimatesRiskOf-output,< 1K
-Predicate,http://schema.org/ethicsPolicy,10K - 100K
-Predicate,http://schema.org/ethicsPolicy-input,< 1K
-Predicate,http://schema.org/ethicsPolicy-output,< 1K
-Predicate,http://schema.org/event,10K - 100K
-Predicate,http://schema.org/event-input,< 1K
-Predicate,http://schema.org/event-output,< 1K
-Predicate,http://schema.org/eventAttendanceMode,100K - 1M
-Predicate,http://schema.org/eventAttendanceMode-input,< 1K
-Predicate,http://schema.org/eventAttendanceMode-output,< 1K
-Predicate,http://schema.org/eventSchedule,1K - 10K
-Predicate,http://schema.org/eventSchedule-input,< 1K
-Predicate,http://schema.org/eventSchedule-output,< 1K
-Predicate,http://schema.org/eventStatus,100K - 1M
-Predicate,http://schema.org/eventStatus-input,< 1K
-Predicate,http://schema.org/eventStatus-output,< 1K
-Predicate,http://schema.org/events,1K - 10K
-Predicate,http://schema.org/events-input,< 1K
-Predicate,http://schema.org/events-output,< 1K
-Predicate,http://schema.org/evidenceLevel,< 1K
-Predicate,http://schema.org/evidenceLevel-input,< 1K
-Predicate,http://schema.org/evidenceLevel-output,< 1K
-Predicate,http://schema.org/evidenceOrigin,< 1K
-Predicate,http://schema.org/evidenceOrigin-input,< 1K
-Predicate,http://schema.org/evidenceOrigin-output,< 1K
-Predicate,http://schema.org/exampleOfWork,1K - 10K
-Predicate,http://schema.org/exampleOfWork-input,< 1K
-Predicate,http://schema.org/exampleOfWork-output,< 1K
-Predicate,http://schema.org/exceptDate,< 1K
-Predicate,http://schema.org/exceptDate-input,< 1K
-Predicate,http://schema.org/exceptDate-output,< 1K
-Predicate,http://schema.org/exchangeRateSpread,< 1K
-Predicate,http://schema.org/exchangeRateSpread-input,< 1K
-Predicate,http://schema.org/exchangeRateSpread-output,< 1K
-Predicate,http://schema.org/executableLibraryName,< 1K
-Predicate,http://schema.org/executableLibraryName-input,< 1K
-Predicate,http://schema.org/executableLibraryName-output,< 1K
-Predicate,http://schema.org/exerciseCourse,< 1K
-Predicate,http://schema.org/exerciseCourse-input,< 1K
-Predicate,http://schema.org/exerciseCourse-output,< 1K
-Predicate,http://schema.org/exercisePlan,< 1K
-Predicate,http://schema.org/exercisePlan-input,< 1K
-Predicate,http://schema.org/exercisePlan-output,< 1K
-Predicate,http://schema.org/exerciseRelatedDiet,< 1K
-Predicate,http://schema.org/exerciseRelatedDiet-input,< 1K
-Predicate,http://schema.org/exerciseRelatedDiet-output,< 1K
-Predicate,http://schema.org/exerciseType,< 1K
-Predicate,http://schema.org/exerciseType-input,< 1K
-Predicate,http://schema.org/exerciseType-output,< 1K
-Predicate,http://schema.org/exifData,1K - 10K
-Predicate,http://schema.org/exifData-input,< 1K
-Predicate,http://schema.org/exifData-output,< 1K
-Predicate,http://schema.org/expectedArrivalFrom,< 1K
-Predicate,http://schema.org/expectedArrivalFrom-input,< 1K
-Predicate,http://schema.org/expectedArrivalFrom-output,< 1K
-Predicate,http://schema.org/expectedArrivalUntil,< 1K
-Predicate,http://schema.org/expectedArrivalUntil-input,< 1K
-Predicate,http://schema.org/expectedArrivalUntil-output,< 1K
-Predicate,http://schema.org/expectedPrognosis,< 1K
-Predicate,http://schema.org/expectedPrognosis-input,< 1K
-Predicate,http://schema.org/expectedPrognosis-output,< 1K
-Predicate,http://schema.org/expectsAcceptanceOf,1K - 10K
-Predicate,http://schema.org/expectsAcceptanceOf-input,< 1K
-Predicate,http://schema.org/expectsAcceptanceOf-output,< 1K
-Predicate,http://schema.org/experienceInPlaceOfEducation,1K - 10K
-Predicate,http://schema.org/experienceInPlaceOfEducation-input,< 1K
-Predicate,http://schema.org/experienceInPlaceOfEducation-output,< 1K
-Predicate,http://schema.org/experienceRequirements,10K - 100K
-Predicate,http://schema.org/experienceRequirements-input,< 1K
-Predicate,http://schema.org/experienceRequirements-output,< 1K
-Predicate,http://schema.org/expertConsiderations,< 1K
-Predicate,http://schema.org/expertConsiderations-input,< 1K
-Predicate,http://schema.org/expertConsiderations-output,< 1K
-Predicate,http://schema.org/expires,1K - 10K
-Predicate,http://schema.org/expires-input,< 1K
-Predicate,http://schema.org/expires-output,< 1K
-Predicate,http://schema.org/expressedIn,< 1K
-Predicate,http://schema.org/expressedIn-input,< 1K
-Predicate,http://schema.org/expressedIn-output,< 1K
-Predicate,http://schema.org/extendedAddress,< 1K
-Predicate,http://schema.org/extendedAddress-input,< 1K
-Predicate,http://schema.org/extendedAddress-output,< 1K
-Predicate,http://schema.org/familyName,100K - 1M
-Predicate,http://schema.org/familyName-input,< 1K
-Predicate,http://schema.org/familyName-output,< 1K
-Predicate,http://schema.org/fatContent,10K - 100K
-Predicate,http://schema.org/fatContent-input,< 1K
-Predicate,http://schema.org/fatContent-output,< 1K
-Predicate,http://schema.org/faxNumber,100K - 1M
-Predicate,http://schema.org/faxNumber-input,< 1K
-Predicate,http://schema.org/faxNumber-output,< 1K
-Predicate,http://schema.org/featureList,100K - 1M
-Predicate,http://schema.org/featureList-input,< 1K
-Predicate,http://schema.org/featureList-output,< 1K
-Predicate,http://schema.org/feesAndCommissionsSpecification,1K - 10K
-Predicate,http://schema.org/feesAndCommissionsSpecification-input,< 1K
-Predicate,http://schema.org/feesAndCommissionsSpecification-output,< 1K
-Predicate,http://schema.org/fiberContent,10K - 100K
-Predicate,http://schema.org/fiberContent-input,< 1K
-Predicate,http://schema.org/fiberContent-output,< 1K
-Predicate,http://schema.org/fileFormat,10K - 100K
-Predicate,http://schema.org/fileFormat-input,< 1K
-Predicate,http://schema.org/fileFormat-output,< 1K
-Predicate,http://schema.org/fileSize,100K - 1M
-Predicate,http://schema.org/fileSize-input,< 1K
-Predicate,http://schema.org/fileSize-output,< 1K
-Predicate,http://schema.org/financialAidEligible,< 1K
-Predicate,http://schema.org/financialAidEligible-input,< 1K
-Predicate,http://schema.org/financialAidEligible-output,< 1K
-Predicate,http://schema.org/firstAppearance,< 1K
-Predicate,http://schema.org/firstAppearance-input,< 1K
-Predicate,http://schema.org/firstAppearance-output,< 1K
-Predicate,http://schema.org/firstPerformance,< 1K
-Predicate,http://schema.org/firstPerformance-input,< 1K
-Predicate,http://schema.org/firstPerformance-output,< 1K
-Predicate,http://schema.org/flightDistance,< 1K
-Predicate,http://schema.org/flightDistance-input,< 1K
-Predicate,http://schema.org/flightDistance-output,< 1K
-Predicate,http://schema.org/flightNumber,< 1K
-Predicate,http://schema.org/flightNumber-input,< 1K
-Predicate,http://schema.org/flightNumber-output,< 1K
-Predicate,http://schema.org/floorLevel,1K - 10K
-Predicate,http://schema.org/floorLevel-input,< 1K
-Predicate,http://schema.org/floorLevel-output,< 1K
-Predicate,http://schema.org/floorLimit,< 1K
-Predicate,http://schema.org/floorLimit-input,< 1K
-Predicate,http://schema.org/floorLimit-output,< 1K
-Predicate,http://schema.org/floorSize,100K - 1M
-Predicate,http://schema.org/floorSize-input,< 1K
-Predicate,http://schema.org/floorSize-output,< 1K
-Predicate,http://schema.org/followee,< 1K
-Predicate,http://schema.org/followee-input,< 1K
-Predicate,http://schema.org/followee-output,< 1K
-Predicate,http://schema.org/follows,< 1K
-Predicate,http://schema.org/follows-input,< 1K
-Predicate,http://schema.org/follows-output,< 1K
-Predicate,http://schema.org/followup,1K - 10K
-Predicate,http://schema.org/followup-input,< 1K
-Predicate,http://schema.org/followup-output,< 1K
-Predicate,http://schema.org/foodEstablishment,< 1K
-Predicate,http://schema.org/foodEstablishment-input,< 1K
-Predicate,http://schema.org/foodEstablishment-output,< 1K
-Predicate,http://schema.org/foodEvent,< 1K
-Predicate,http://schema.org/foodEvent-input,< 1K
-Predicate,http://schema.org/foodEvent-output,< 1K
-Predicate,http://schema.org/foodWarning,< 1K
-Predicate,http://schema.org/foodWarning-input,< 1K
-Predicate,http://schema.org/foodWarning-output,< 1K
-Predicate,http://schema.org/founder,100K - 1M
-Predicate,http://schema.org/founder-input,< 1K
-Predicate,http://schema.org/founder-output,< 1K
-Predicate,http://schema.org/founders,10K - 100K
-Predicate,http://schema.org/founders-input,< 1K
-Predicate,http://schema.org/founders-output,< 1K
-Predicate,http://schema.org/foundingDate,1M - 10M
-Predicate,http://schema.org/foundingDate-input,< 1K
-Predicate,http://schema.org/foundingDate-output,< 1K
-Predicate,http://schema.org/foundingLocation,100K - 1M
-Predicate,http://schema.org/foundingLocation-input,< 1K
-Predicate,http://schema.org/foundingLocation-output,< 1K
-Predicate,http://schema.org/free,1K - 10K
-Predicate,http://schema.org/free-input,< 1K
-Predicate,http://schema.org/free-output,< 1K
-Predicate,http://schema.org/freeShippingThreshold,10K - 100K
-Predicate,http://schema.org/freeShippingThreshold-input,< 1K
-Predicate,http://schema.org/freeShippingThreshold-output,< 1K
-Predicate,http://schema.org/frequency,< 1K
-Predicate,http://schema.org/frequency-input,< 1K
-Predicate,http://schema.org/frequency-output,< 1K
-Predicate,http://schema.org/fromLocation,1K - 10K
-Predicate,http://schema.org/fromLocation-input,< 1K
-Predicate,http://schema.org/fromLocation-output,< 1K
-Predicate,http://schema.org/fuelCapacity,1K - 10K
-Predicate,http://schema.org/fuelCapacity-input,< 1K
-Predicate,http://schema.org/fuelCapacity-output,< 1K
-Predicate,http://schema.org/fuelConsumption,1K - 10K
-Predicate,http://schema.org/fuelConsumption-input,< 1K
-Predicate,http://schema.org/fuelConsumption-output,< 1K
-Predicate,http://schema.org/fuelEfficiency,10K - 100K
-Predicate,http://schema.org/fuelEfficiency-input,< 1K
-Predicate,http://schema.org/fuelEfficiency-output,< 1K
-Predicate,http://schema.org/fuelType,10K - 100K
-Predicate,http://schema.org/fuelType-input,< 1K
-Predicate,http://schema.org/fuelType-output,< 1K
-Predicate,http://schema.org/fulfillmentType,10K - 100K
-Predicate,http://schema.org/fulfillmentType-input,< 1K
-Predicate,http://schema.org/fulfillmentType-output,< 1K
-Predicate,http://schema.org/functionalClass,< 1K
-Predicate,http://schema.org/functionalClass-input,< 1K
-Predicate,http://schema.org/functionalClass-output,< 1K
-Predicate,http://schema.org/fundedItem,< 1K
-Predicate,http://schema.org/fundedItem-input,< 1K
-Predicate,http://schema.org/fundedItem-output,< 1K
-Predicate,http://schema.org/funder,10K - 100K
-Predicate,http://schema.org/funder-input,< 1K
-Predicate,http://schema.org/funder-output,< 1K
-Predicate,http://schema.org/funding,1K - 10K
-Predicate,http://schema.org/funding-input,< 1K
-Predicate,http://schema.org/funding-output,< 1K
-Predicate,http://schema.org/game,10K - 100K
-Predicate,http://schema.org/game-input,< 1K
-Predicate,http://schema.org/game-output,< 1K
-Predicate,http://schema.org/gameAvailabilityType,< 1K
-Predicate,http://schema.org/gameAvailabilityType-input,< 1K
-Predicate,http://schema.org/gameAvailabilityType-output,< 1K
-Predicate,http://schema.org/gameEdition,< 1K
-Predicate,http://schema.org/gameEdition-input,< 1K
-Predicate,http://schema.org/gameEdition-output,< 1K
-Predicate,http://schema.org/gameItem,10K - 100K
-Predicate,http://schema.org/gameItem-input,< 1K
-Predicate,http://schema.org/gameItem-output,< 1K
-Predicate,http://schema.org/gameLocation,10K - 100K
-Predicate,http://schema.org/gameLocation-input,< 1K
-Predicate,http://schema.org/gameLocation-output,< 1K
-Predicate,http://schema.org/gamePlatform,10K - 100K
-Predicate,http://schema.org/gamePlatform-input,< 1K
-Predicate,http://schema.org/gamePlatform-output,< 1K
-Predicate,http://schema.org/gameServer,< 1K
-Predicate,http://schema.org/gameServer-input,< 1K
-Predicate,http://schema.org/gameServer-output,< 1K
-Predicate,http://schema.org/gameTip,< 1K
-Predicate,http://schema.org/gameTip-input,< 1K
-Predicate,http://schema.org/gameTip-output,< 1K
-Predicate,http://schema.org/gender,10K - 100K
-Predicate,http://schema.org/gender-input,< 1K
-Predicate,http://schema.org/gender-output,< 1K
-Predicate,http://schema.org/genre,100K - 1M
-Predicate,http://schema.org/genre-input,< 1K
-Predicate,http://schema.org/genre-output,< 1K
-Predicate,http://schema.org/geo,1M - 10M
-Predicate,http://schema.org/geo-input,< 1K
-Predicate,http://schema.org/geo-output,< 1K
-Predicate,http://schema.org/geoContains,< 1K
-Predicate,http://schema.org/geoContains-input,< 1K
-Predicate,http://schema.org/geoContains-output,< 1K
-Predicate,http://schema.org/geoCoveredBy,< 1K
-Predicate,http://schema.org/geoCoveredBy-input,< 1K
-Predicate,http://schema.org/geoCoveredBy-output,< 1K
-Predicate,http://schema.org/geoCovers,< 1K
-Predicate,http://schema.org/geoCovers-input,< 1K
-Predicate,http://schema.org/geoCovers-output,< 1K
-Predicate,http://schema.org/geoCrosses,< 1K
-Predicate,http://schema.org/geoCrosses-input,< 1K
-Predicate,http://schema.org/geoCrosses-output,< 1K
-Predicate,http://schema.org/geoDisjoint,< 1K
-Predicate,http://schema.org/geoDisjoint-input,< 1K
-Predicate,http://schema.org/geoDisjoint-output,< 1K
-Predicate,http://schema.org/geoEquals,< 1K
-Predicate,http://schema.org/geoEquals-input,< 1K
-Predicate,http://schema.org/geoEquals-output,< 1K
-Predicate,http://schema.org/geoIntersects,< 1K
-Predicate,http://schema.org/geoIntersects-input,< 1K
-Predicate,http://schema.org/geoIntersects-output,< 1K
-Predicate,http://schema.org/geoMidpoint,100K - 1M
-Predicate,http://schema.org/geoMidpoint-input,< 1K
-Predicate,http://schema.org/geoMidpoint-output,< 1K
-Predicate,http://schema.org/geoOverlaps,< 1K
-Predicate,http://schema.org/geoOverlaps-input,< 1K
-Predicate,http://schema.org/geoOverlaps-output,< 1K
-Predicate,http://schema.org/geoRadius,100K - 1M
-Predicate,http://schema.org/geoRadius-input,< 1K
-Predicate,http://schema.org/geoRadius-output,< 1K
-Predicate,http://schema.org/geoTouches,< 1K
-Predicate,http://schema.org/geoTouches-input,< 1K
-Predicate,http://schema.org/geoTouches-output,< 1K
-Predicate,http://schema.org/geoWithin,< 1K
-Predicate,http://schema.org/geoWithin-input,< 1K
-Predicate,http://schema.org/geoWithin-output,< 1K
-Predicate,http://schema.org/geographicArea,10K - 100K
-Predicate,http://schema.org/geographicArea-input,< 1K
-Predicate,http://schema.org/geographicArea-output,< 1K
-Predicate,http://schema.org/gettingTestedInfo,< 1K
-Predicate,http://schema.org/gettingTestedInfo-input,< 1K
-Predicate,http://schema.org/gettingTestedInfo-output,< 1K
-Predicate,http://schema.org/givenName,100K - 1M
-Predicate,http://schema.org/givenName-input,< 1K
-Predicate,http://schema.org/givenName-output,< 1K
-Predicate,http://schema.org/globalLocationNumber,1K - 10K
-Predicate,http://schema.org/globalLocationNumber-input,< 1K
-Predicate,http://schema.org/globalLocationNumber-output,< 1K
-Predicate,http://schema.org/governmentBenefitsInfo,< 1K
-Predicate,http://schema.org/governmentBenefitsInfo-input,< 1K
-Predicate,http://schema.org/governmentBenefitsInfo-output,< 1K
-Predicate,http://schema.org/gracePeriod,< 1K
-Predicate,http://schema.org/gracePeriod-input,< 1K
-Predicate,http://schema.org/gracePeriod-output,< 1K
-Predicate,http://schema.org/grantee,< 1K
-Predicate,http://schema.org/grantee-input,< 1K
-Predicate,http://schema.org/grantee-output,< 1K
-Predicate,http://schema.org/greater,< 1K
-Predicate,http://schema.org/greater-input,< 1K
-Predicate,http://schema.org/greater-output,< 1K
-Predicate,http://schema.org/greaterOrEqual,< 1K
-Predicate,http://schema.org/greaterOrEqual-input,< 1K
-Predicate,http://schema.org/greaterOrEqual-output,< 1K
-Predicate,http://schema.org/gtin,100K - 1M
-Predicate,http://schema.org/gtin-input,< 1K
-Predicate,http://schema.org/gtin-output,< 1K
-Predicate,http://schema.org/gtin12,100K - 1M
-Predicate,http://schema.org/gtin12-input,< 1K
-Predicate,http://schema.org/gtin12-output,< 1K
-Predicate,http://schema.org/gtin13,100K - 1M
-Predicate,http://schema.org/gtin13-input,< 1K
-Predicate,http://schema.org/gtin13-output,< 1K
-Predicate,http://schema.org/gtin14,10K - 100K
-Predicate,http://schema.org/gtin14-input,< 1K
-Predicate,http://schema.org/gtin14-output,< 1K
-Predicate,http://schema.org/gtin8,10K - 100K
-Predicate,http://schema.org/gtin8-input,< 1K
-Predicate,http://schema.org/gtin8-output,< 1K
-Predicate,http://schema.org/guideline,< 1K
-Predicate,http://schema.org/guideline-input,< 1K
-Predicate,http://schema.org/guideline-output,< 1K
-Predicate,http://schema.org/guidelineDate,< 1K
-Predicate,http://schema.org/guidelineDate-input,< 1K
-Predicate,http://schema.org/guidelineDate-output,< 1K
-Predicate,http://schema.org/guidelineSubject,< 1K
-Predicate,http://schema.org/guidelineSubject-input,< 1K
-Predicate,http://schema.org/guidelineSubject-output,< 1K
-Predicate,http://schema.org/handlingTime,100K - 1M
-Predicate,http://schema.org/handlingTime-input,< 1K
-Predicate,http://schema.org/handlingTime-output,< 1K
-Predicate,http://schema.org/hasAdultConsideration,< 1K
-Predicate,http://schema.org/hasAdultConsideration-input,< 1K
-Predicate,http://schema.org/hasAdultConsideration-output,< 1K
-Predicate,http://schema.org/hasBioChemEntityPart,< 1K
-Predicate,http://schema.org/hasBioChemEntityPart-input,< 1K
-Predicate,http://schema.org/hasBioChemEntityPart-output,< 1K
-Predicate,http://schema.org/hasBioPolymerSequence,< 1K
-Predicate,http://schema.org/hasBioPolymerSequence-input,< 1K
-Predicate,http://schema.org/hasBioPolymerSequence-output,< 1K
-Predicate,http://schema.org/hasBroadcastChannel,< 1K
-Predicate,http://schema.org/hasBroadcastChannel-input,< 1K
-Predicate,http://schema.org/hasBroadcastChannel-output,< 1K
-Predicate,http://schema.org/hasCategoryCode,< 1K
-Predicate,http://schema.org/hasCategoryCode-input,< 1K
-Predicate,http://schema.org/hasCategoryCode-output,< 1K
-Predicate,http://schema.org/hasCertification,10K - 100K
-Predicate,http://schema.org/hasCertification-input,< 1K
-Predicate,http://schema.org/hasCertification-output,< 1K
-Predicate,http://schema.org/hasCourse,1K - 10K
-Predicate,http://schema.org/hasCourse-input,< 1K
-Predicate,http://schema.org/hasCourse-output,< 1K
-Predicate,http://schema.org/hasCourseInstance,10K - 100K
-Predicate,http://schema.org/hasCourseInstance-input,< 1K
-Predicate,http://schema.org/hasCourseInstance-output,< 1K
-Predicate,http://schema.org/hasCredential,100K - 1M
-Predicate,http://schema.org/hasCredential-input,< 1K
-Predicate,http://schema.org/hasCredential-output,< 1K
-Predicate,http://schema.org/hasDefinedTerm,10K - 100K
-Predicate,http://schema.org/hasDefinedTerm-input,< 1K
-Predicate,http://schema.org/hasDefinedTerm-output,< 1K
-Predicate,http://schema.org/hasDeliveryMethod,< 1K
-Predicate,http://schema.org/hasDeliveryMethod-input,< 1K
-Predicate,http://schema.org/hasDeliveryMethod-output,< 1K
-Predicate,http://schema.org/hasDigitalDocumentPermission,< 1K
-Predicate,http://schema.org/hasDigitalDocumentPermission-input,< 1K
-Predicate,http://schema.org/hasDigitalDocumentPermission-output,< 1K
-Predicate,http://schema.org/hasDriveThroughService,< 1K
-Predicate,http://schema.org/hasDriveThroughService-input,< 1K
-Predicate,http://schema.org/hasDriveThroughService-output,< 1K
-Predicate,http://schema.org/hasEnergyConsumptionDetails,1K - 10K
-Predicate,http://schema.org/hasEnergyConsumptionDetails-input,< 1K
-Predicate,http://schema.org/hasEnergyConsumptionDetails-output,< 1K
-Predicate,http://schema.org/hasEnergyEfficiencyCategory,1K - 10K
-Predicate,http://schema.org/hasEnergyEfficiencyCategory-input,< 1K
-Predicate,http://schema.org/hasEnergyEfficiencyCategory-output,< 1K
-Predicate,http://schema.org/hasGS1DigitalLink,< 1K
-Predicate,http://schema.org/hasGS1DigitalLink-input,< 1K
-Predicate,http://schema.org/hasGS1DigitalLink-output,< 1K
-Predicate,http://schema.org/hasHealthAspect,< 1K
-Predicate,http://schema.org/hasHealthAspect-input,< 1K
-Predicate,http://schema.org/hasHealthAspect-output,< 1K
-Predicate,http://schema.org/hasMap,100K - 1M
-Predicate,http://schema.org/hasMap-input,< 1K
-Predicate,http://schema.org/hasMap-output,< 1K
-Predicate,http://schema.org/hasMeasurement,1K - 10K
-Predicate,http://schema.org/hasMeasurement-input,< 1K
-Predicate,http://schema.org/hasMeasurement-output,< 1K
-Predicate,http://schema.org/hasMemberProgram,1K - 10K
-Predicate,http://schema.org/hasMemberProgram-input,< 1K
-Predicate,http://schema.org/hasMemberProgram-output,< 1K
-Predicate,http://schema.org/hasMenu,10K - 100K
-Predicate,http://schema.org/hasMenu-input,< 1K
-Predicate,http://schema.org/hasMenu-output,< 1K
-Predicate,http://schema.org/hasMenuItem,10K - 100K
-Predicate,http://schema.org/hasMenuItem-input,< 1K
-Predicate,http://schema.org/hasMenuItem-output,< 1K
-Predicate,http://schema.org/hasMenuSection,10K - 100K
-Predicate,http://schema.org/hasMenuSection-input,< 1K
-Predicate,http://schema.org/hasMenuSection-output,< 1K
-Predicate,http://schema.org/hasMerchantReturnPolicy,100K - 1M
-Predicate,http://schema.org/hasMerchantReturnPolicy-input,< 1K
-Predicate,http://schema.org/hasMerchantReturnPolicy-output,< 1K
-Predicate,http://schema.org/hasMolecularFunction,< 1K
-Predicate,http://schema.org/hasMolecularFunction-input,< 1K
-Predicate,http://schema.org/hasMolecularFunction-output,< 1K
-Predicate,http://schema.org/hasOccupation,10K - 100K
-Predicate,http://schema.org/hasOccupation-input,< 1K
-Predicate,http://schema.org/hasOccupation-output,< 1K
-Predicate,http://schema.org/hasOfferCatalog,100K - 1M
-Predicate,http://schema.org/hasOfferCatalog-input,< 1K
-Predicate,http://schema.org/hasOfferCatalog-output,< 1K
-Predicate,http://schema.org/hasPOS,1K - 10K
-Predicate,http://schema.org/hasPOS-input,< 1K
-Predicate,http://schema.org/hasPOS-output,< 1K
-Predicate,http://schema.org/hasPart,100K - 1M
-Predicate,http://schema.org/hasPart-input,< 1K
-Predicate,http://schema.org/hasPart-output,< 1K
-Predicate,http://schema.org/hasParticipationOffer,< 1K
-Predicate,http://schema.org/hasParticipationOffer-input,< 1K
-Predicate,http://schema.org/hasParticipationOffer-output,< 1K
-Predicate,http://schema.org/hasProductReturnPolicy,< 1K
-Predicate,http://schema.org/hasProductReturnPolicy-input,< 1K
-Predicate,http://schema.org/hasProductReturnPolicy-output,< 1K
-Predicate,http://schema.org/hasRepresentation,< 1K
-Predicate,http://schema.org/hasRepresentation-input,< 1K
-Predicate,http://schema.org/hasRepresentation-output,< 1K
-Predicate,http://schema.org/hasShippingService,10K - 100K
-Predicate,http://schema.org/hasShippingService-input,< 1K
-Predicate,http://schema.org/hasShippingService-output,< 1K
-Predicate,http://schema.org/hasSponsorshipOffer,< 1K
-Predicate,http://schema.org/hasSponsorshipOffer-input,< 1K
-Predicate,http://schema.org/hasSponsorshipOffer-output,< 1K
-Predicate,http://schema.org/hasStore,< 1K
-Predicate,http://schema.org/hasStore-input,< 1K
-Predicate,http://schema.org/hasStore-output,< 1K
-Predicate,http://schema.org/hasTierBenefit,1K - 10K
-Predicate,http://schema.org/hasTierBenefit-input,< 1K
-Predicate,http://schema.org/hasTierBenefit-output,< 1K
-Predicate,http://schema.org/hasTierRequirement,< 1K
-Predicate,http://schema.org/hasTierRequirement-input,< 1K
-Predicate,http://schema.org/hasTierRequirement-output,< 1K
-Predicate,http://schema.org/hasTiers,1K - 10K
-Predicate,http://schema.org/hasTiers-input,< 1K
-Predicate,http://schema.org/hasTiers-output,< 1K
-Predicate,http://schema.org/hasVariant,100K - 1M
-Predicate,http://schema.org/hasVariant-input,< 1K
-Predicate,http://schema.org/hasVariant-output,< 1K
-Predicate,http://schema.org/headline,10M+
-Predicate,http://schema.org/headline-input,< 1K
-Predicate,http://schema.org/headline-output,< 1K
-Predicate,http://schema.org/healthCondition,1K - 10K
-Predicate,http://schema.org/healthCondition-input,< 1K
-Predicate,http://schema.org/healthCondition-output,< 1K
-Predicate,http://schema.org/healthPlanCoinsuranceOption,< 1K
-Predicate,http://schema.org/healthPlanCoinsuranceOption-input,< 1K
-Predicate,http://schema.org/healthPlanCoinsuranceOption-output,< 1K
-Predicate,http://schema.org/healthPlanCoinsuranceRate,< 1K
-Predicate,http://schema.org/healthPlanCoinsuranceRate-input,< 1K
-Predicate,http://schema.org/healthPlanCoinsuranceRate-output,< 1K
-Predicate,http://schema.org/healthPlanCopay,< 1K
-Predicate,http://schema.org/healthPlanCopay-input,< 1K
-Predicate,http://schema.org/healthPlanCopay-output,< 1K
-Predicate,http://schema.org/healthPlanCopayOption,< 1K
-Predicate,http://schema.org/healthPlanCopayOption-input,< 1K
-Predicate,http://schema.org/healthPlanCopayOption-output,< 1K
-Predicate,http://schema.org/healthPlanCostSharing,< 1K
-Predicate,http://schema.org/healthPlanCostSharing-input,< 1K
-Predicate,http://schema.org/healthPlanCostSharing-output,< 1K
-Predicate,http://schema.org/healthPlanDrugOption,< 1K
-Predicate,http://schema.org/healthPlanDrugOption-input,< 1K
-Predicate,http://schema.org/healthPlanDrugOption-output,< 1K
-Predicate,http://schema.org/healthPlanDrugTier,< 1K
-Predicate,http://schema.org/healthPlanDrugTier-input,< 1K
-Predicate,http://schema.org/healthPlanDrugTier-output,< 1K
-Predicate,http://schema.org/healthPlanId,< 1K
-Predicate,http://schema.org/healthPlanId-input,< 1K
-Predicate,http://schema.org/healthPlanId-output,< 1K
-Predicate,http://schema.org/healthPlanMarketingUrl,< 1K
-Predicate,http://schema.org/healthPlanMarketingUrl-input,< 1K
-Predicate,http://schema.org/healthPlanMarketingUrl-output,< 1K
-Predicate,http://schema.org/healthPlanNetworkId,< 1K
-Predicate,http://schema.org/healthPlanNetworkId-input,< 1K
-Predicate,http://schema.org/healthPlanNetworkId-output,< 1K
-Predicate,http://schema.org/healthPlanNetworkTier,< 1K
-Predicate,http://schema.org/healthPlanNetworkTier-input,< 1K
-Predicate,http://schema.org/healthPlanNetworkTier-output,< 1K
-Predicate,http://schema.org/healthPlanPharmacyCategory,< 1K
-Predicate,http://schema.org/healthPlanPharmacyCategory-input,< 1K
-Predicate,http://schema.org/healthPlanPharmacyCategory-output,< 1K
-Predicate,http://schema.org/healthcareReportingData,< 1K
-Predicate,http://schema.org/healthcareReportingData-input,< 1K
-Predicate,http://schema.org/healthcareReportingData-output,< 1K
-Predicate,http://schema.org/height,10M+
-Predicate,http://schema.org/height-input,< 1K
-Predicate,http://schema.org/height-output,< 1K
-Predicate,http://schema.org/highPrice,1M - 10M
-Predicate,http://schema.org/highPrice-input,< 1K
-Predicate,http://schema.org/highPrice-output,< 1K
-Predicate,http://schema.org/hiringOrganization,100K - 1M
-Predicate,http://schema.org/hiringOrganization-input,< 1K
-Predicate,http://schema.org/hiringOrganization-output,< 1K
-Predicate,http://schema.org/holdingArchive,< 1K
-Predicate,http://schema.org/holdingArchive-input,< 1K
-Predicate,http://schema.org/holdingArchive-output,< 1K
-Predicate,http://schema.org/homeLocation,10K - 100K
-Predicate,http://schema.org/homeLocation-input,< 1K
-Predicate,http://schema.org/homeLocation-output,< 1K
-Predicate,http://schema.org/homeTeam,10K - 100K
-Predicate,http://schema.org/homeTeam-input,< 1K
-Predicate,http://schema.org/homeTeam-output,< 1K
-Predicate,http://schema.org/honorificPrefix,10K - 100K
-Predicate,http://schema.org/honorificPrefix-input,< 1K
-Predicate,http://schema.org/honorificPrefix-output,< 1K
-Predicate,http://schema.org/honorificSuffix,10K - 100K
-Predicate,http://schema.org/honorificSuffix-input,< 1K
-Predicate,http://schema.org/honorificSuffix-output,< 1K
-Predicate,http://schema.org/hospitalAffiliation,1K - 10K
-Predicate,http://schema.org/hospitalAffiliation-input,< 1K
-Predicate,http://schema.org/hospitalAffiliation-output,< 1K
-Predicate,http://schema.org/hostingOrganization,1K - 10K
-Predicate,http://schema.org/hostingOrganization-input,< 1K
-Predicate,http://schema.org/hostingOrganization-output,< 1K
-Predicate,http://schema.org/hoursAvailable,100K - 1M
-Predicate,http://schema.org/hoursAvailable-input,< 1K
-Predicate,http://schema.org/hoursAvailable-output,< 1K
-Predicate,http://schema.org/howPerformed,10K - 100K
-Predicate,http://schema.org/howPerformed-input,< 1K
-Predicate,http://schema.org/howPerformed-output,< 1K
-Predicate,http://schema.org/httpMethod,1K - 10K
-Predicate,http://schema.org/httpMethod-input,< 1K
-Predicate,http://schema.org/httpMethod-output,< 1K
-Predicate,http://schema.org/iataCode,1K - 10K
-Predicate,http://schema.org/iataCode-input,< 1K
-Predicate,http://schema.org/iataCode-output,< 1K
-Predicate,http://schema.org/icaoCode,1K - 10K
-Predicate,http://schema.org/icaoCode-input,< 1K
-Predicate,http://schema.org/icaoCode-output,< 1K
-Predicate,http://schema.org/identifier,100K - 1M
-Predicate,http://schema.org/identifier-input,< 1K
-Predicate,http://schema.org/identifier-output,< 1K
-Predicate,http://schema.org/identifyingExam,< 1K
-Predicate,http://schema.org/identifyingExam-input,< 1K
-Predicate,http://schema.org/identifyingExam-output,< 1K
-Predicate,http://schema.org/identifyingTest,< 1K
-Predicate,http://schema.org/identifyingTest-input,< 1K
-Predicate,http://schema.org/identifyingTest-output,< 1K
-Predicate,http://schema.org/illustrator,1K - 10K
-Predicate,http://schema.org/illustrator-input,< 1K
-Predicate,http://schema.org/illustrator-output,< 1K
-Predicate,http://schema.org/image,10M+
-Predicate,http://schema.org/image-input,< 1K
-Predicate,http://schema.org/image-output,< 1K
-Predicate,http://schema.org/imagingTechnique,< 1K
-Predicate,http://schema.org/imagingTechnique-input,< 1K
-Predicate,http://schema.org/imagingTechnique-output,< 1K
-Predicate,http://schema.org/inAlbum,10K - 100K
-Predicate,http://schema.org/inAlbum-input,< 1K
-Predicate,http://schema.org/inAlbum-output,< 1K
-Predicate,http://schema.org/inBroadcastLineup,< 1K
-Predicate,http://schema.org/inBroadcastLineup-input,< 1K
-Predicate,http://schema.org/inBroadcastLineup-output,< 1K
-Predicate,http://schema.org/inChI,< 1K
-Predicate,http://schema.org/inChI-input,< 1K
-Predicate,http://schema.org/inChI-output,< 1K
-Predicate,http://schema.org/inChIKey,< 1K
-Predicate,http://schema.org/inChIKey-input,< 1K
-Predicate,http://schema.org/inChIKey-output,< 1K
-Predicate,http://schema.org/inCodeSet,1K - 10K
-Predicate,http://schema.org/inCodeSet-input,< 1K
-Predicate,http://schema.org/inCodeSet-output,< 1K
-Predicate,http://schema.org/inDefinedTermSet,10K - 100K
-Predicate,http://schema.org/inDefinedTermSet-input,< 1K
-Predicate,http://schema.org/inDefinedTermSet-output,< 1K
-Predicate,http://schema.org/inLanguage,10M+
-Predicate,http://schema.org/inLanguage-input,< 1K
-Predicate,http://schema.org/inLanguage-output,< 1K
-Predicate,http://schema.org/inPlaylist,< 1K
-Predicate,http://schema.org/inPlaylist-input,< 1K
-Predicate,http://schema.org/inPlaylist-output,< 1K
-Predicate,http://schema.org/inProductGroupWithID,10K - 100K
-Predicate,http://schema.org/inProductGroupWithID-input,< 1K
-Predicate,http://schema.org/inProductGroupWithID-output,< 1K
-Predicate,http://schema.org/inStoreReturnsOffered,1K - 10K
-Predicate,http://schema.org/inStoreReturnsOffered-input,< 1K
-Predicate,http://schema.org/inStoreReturnsOffered-output,< 1K
-Predicate,http://schema.org/inSupportOf,< 1K
-Predicate,http://schema.org/inSupportOf-input,< 1K
-Predicate,http://schema.org/inSupportOf-output,< 1K
-Predicate,http://schema.org/incentiveAmount,< 1K
-Predicate,http://schema.org/incentiveAmount-input,< 1K
-Predicate,http://schema.org/incentiveAmount-output,< 1K
-Predicate,http://schema.org/incentiveCompensation,1K - 10K
-Predicate,http://schema.org/incentiveCompensation-input,< 1K
-Predicate,http://schema.org/incentiveCompensation-output,< 1K
-Predicate,http://schema.org/incentiveStatus,< 1K
-Predicate,http://schema.org/incentiveStatus-input,< 1K
-Predicate,http://schema.org/incentiveStatus-output,< 1K
-Predicate,http://schema.org/incentiveType,< 1K
-Predicate,http://schema.org/incentiveType-input,< 1K
-Predicate,http://schema.org/incentiveType-output,< 1K
-Predicate,http://schema.org/incentives,< 1K
-Predicate,http://schema.org/incentives-input,< 1K
-Predicate,http://schema.org/incentives-output,< 1K
-Predicate,http://schema.org/incentivizedItem,< 1K
-Predicate,http://schema.org/incentivizedItem-input,< 1K
-Predicate,http://schema.org/incentivizedItem-output,< 1K
-Predicate,http://schema.org/includedComposition,< 1K
-Predicate,http://schema.org/includedComposition-input,< 1K
-Predicate,http://schema.org/includedComposition-output,< 1K
-Predicate,http://schema.org/includedDataCatalog,< 1K
-Predicate,http://schema.org/includedDataCatalog-input,< 1K
-Predicate,http://schema.org/includedDataCatalog-output,< 1K
-Predicate,http://schema.org/includedInDataCatalog,1K - 10K
-Predicate,http://schema.org/includedInDataCatalog-input,< 1K
-Predicate,http://schema.org/includedInDataCatalog-output,< 1K
-Predicate,http://schema.org/includedInHealthInsurancePlan,< 1K
-Predicate,http://schema.org/includedInHealthInsurancePlan-input,< 1K
-Predicate,http://schema.org/includedInHealthInsurancePlan-output,< 1K
-Predicate,http://schema.org/includedRiskFactor,< 1K
-Predicate,http://schema.org/includedRiskFactor-input,< 1K
-Predicate,http://schema.org/includedRiskFactor-output,< 1K
-Predicate,http://schema.org/includesAttraction,1K - 10K
-Predicate,http://schema.org/includesAttraction-input,< 1K
-Predicate,http://schema.org/includesAttraction-output,< 1K
-Predicate,http://schema.org/includesHealthPlanFormulary,< 1K
-Predicate,http://schema.org/includesHealthPlanFormulary-input,< 1K
-Predicate,http://schema.org/includesHealthPlanFormulary-output,< 1K
-Predicate,http://schema.org/includesHealthPlanNetwork,< 1K
-Predicate,http://schema.org/includesHealthPlanNetwork-input,< 1K
-Predicate,http://schema.org/includesHealthPlanNetwork-output,< 1K
-Predicate,http://schema.org/includesObject,1K - 10K
-Predicate,http://schema.org/includesObject-input,< 1K
-Predicate,http://schema.org/includesObject-output,< 1K
-Predicate,http://schema.org/incomeLimit,< 1K
-Predicate,http://schema.org/incomeLimit-input,< 1K
-Predicate,http://schema.org/incomeLimit-output,< 1K
-Predicate,http://schema.org/increasesRiskOf,< 1K
-Predicate,http://schema.org/increasesRiskOf-input,< 1K
-Predicate,http://schema.org/increasesRiskOf-output,< 1K
-Predicate,http://schema.org/industry,10K - 100K
-Predicate,http://schema.org/industry-input,< 1K
-Predicate,http://schema.org/industry-output,< 1K
-Predicate,http://schema.org/ineligibleRegion,< 1K
-Predicate,http://schema.org/ineligibleRegion-input,< 1K
-Predicate,http://schema.org/ineligibleRegion-output,< 1K
-Predicate,http://schema.org/infectiousAgent,< 1K
-Predicate,http://schema.org/infectiousAgent-input,< 1K
-Predicate,http://schema.org/infectiousAgent-output,< 1K
-Predicate,http://schema.org/infectiousAgentClass,< 1K
-Predicate,http://schema.org/infectiousAgentClass-input,< 1K
-Predicate,http://schema.org/infectiousAgentClass-output,< 1K
-Predicate,http://schema.org/ingredients,1K - 10K
-Predicate,http://schema.org/ingredients-input,< 1K
-Predicate,http://schema.org/ingredients-output,< 1K
-Predicate,http://schema.org/inker,< 1K
-Predicate,http://schema.org/inker-input,< 1K
-Predicate,http://schema.org/inker-output,< 1K
-Predicate,http://schema.org/insertion,< 1K
-Predicate,http://schema.org/insertion-input,< 1K
-Predicate,http://schema.org/insertion-output,< 1K
-Predicate,http://schema.org/installUrl,100K - 1M
-Predicate,http://schema.org/installUrl-input,< 1K
-Predicate,http://schema.org/installUrl-output,< 1K
-Predicate,http://schema.org/instructor,10K - 100K
-Predicate,http://schema.org/instructor-input,< 1K
-Predicate,http://schema.org/instructor-output,< 1K
-Predicate,http://schema.org/instrument,1K - 10K
-Predicate,http://schema.org/instrument-input,< 1K
-Predicate,http://schema.org/instrument-output,< 1K
-Predicate,http://schema.org/intensity,< 1K
-Predicate,http://schema.org/intensity-input,< 1K
-Predicate,http://schema.org/intensity-output,< 1K
-Predicate,http://schema.org/interactingDrug,< 1K
-Predicate,http://schema.org/interactingDrug-input,< 1K
-Predicate,http://schema.org/interactingDrug-output,< 1K
-Predicate,http://schema.org/interactionCount,100K - 1M
-Predicate,http://schema.org/interactionCount-input,< 1K
-Predicate,http://schema.org/interactionCount-output,< 1K
-Predicate,http://schema.org/interactionService,< 1K
-Predicate,http://schema.org/interactionService-input,< 1K
-Predicate,http://schema.org/interactionService-output,< 1K
-Predicate,http://schema.org/interactionStatistic,100K - 1M
-Predicate,http://schema.org/interactionStatistic-input,< 1K
-Predicate,http://schema.org/interactionStatistic-output,< 1K
-Predicate,http://schema.org/interactionType,100K - 1M
-Predicate,http://schema.org/interactionType-input,< 1K
-Predicate,http://schema.org/interactionType-output,< 1K
-Predicate,http://schema.org/interactivityType,1K - 10K
-Predicate,http://schema.org/interactivityType-input,< 1K
-Predicate,http://schema.org/interactivityType-output,< 1K
-Predicate,http://schema.org/interestRate,1K - 10K
-Predicate,http://schema.org/interestRate-input,< 1K
-Predicate,http://schema.org/interestRate-output,< 1K
-Predicate,http://schema.org/interpretedAsClaim,< 1K
-Predicate,http://schema.org/interpretedAsClaim-input,< 1K
-Predicate,http://schema.org/interpretedAsClaim-output,< 1K
-Predicate,http://schema.org/inventoryLevel,100K - 1M
-Predicate,http://schema.org/inventoryLevel-input,< 1K
-Predicate,http://schema.org/inventoryLevel-output,< 1K
-Predicate,http://schema.org/inverseOf,< 1K
-Predicate,http://schema.org/inverseOf-input,< 1K
-Predicate,http://schema.org/inverseOf-output,< 1K
-Predicate,http://schema.org/isAcceptingNewPatients,10K - 100K
-Predicate,http://schema.org/isAcceptingNewPatients-input,< 1K
-Predicate,http://schema.org/isAcceptingNewPatients-output,< 1K
-Predicate,http://schema.org/isAccessibleForFree,100K - 1M
-Predicate,http://schema.org/isAccessibleForFree-input,< 1K
-Predicate,http://schema.org/isAccessibleForFree-output,< 1K
-Predicate,http://schema.org/isAccessoryOrSparePartFor,1K - 10K
-Predicate,http://schema.org/isAccessoryOrSparePartFor-input,< 1K
-Predicate,http://schema.org/isAccessoryOrSparePartFor-output,< 1K
-Predicate,http://schema.org/isAvailableGenerically,< 1K
-Predicate,http://schema.org/isAvailableGenerically-input,< 1K
-Predicate,http://schema.org/isAvailableGenerically-output,< 1K
-Predicate,http://schema.org/isBasedOn,10K - 100K
-Predicate,http://schema.org/isBasedOn-input,< 1K
-Predicate,http://schema.org/isBasedOn-output,< 1K
-Predicate,http://schema.org/isBasedOnUrl,< 1K
-Predicate,http://schema.org/isBasedOnUrl-input,< 1K
-Predicate,http://schema.org/isBasedOnUrl-output,< 1K
-Predicate,http://schema.org/isConsumableFor,< 1K
-Predicate,http://schema.org/isConsumableFor-input,< 1K
-Predicate,http://schema.org/isConsumableFor-output,< 1K
-Predicate,http://schema.org/isEncodedByBioChemEntity,< 1K
-Predicate,http://schema.org/isEncodedByBioChemEntity-input,< 1K
-Predicate,http://schema.org/isEncodedByBioChemEntity-output,< 1K
-Predicate,http://schema.org/isFamilyFriendly,100K - 1M
-Predicate,http://schema.org/isFamilyFriendly-input,< 1K
-Predicate,http://schema.org/isFamilyFriendly-output,< 1K
-Predicate,http://schema.org/isGift,< 1K
-Predicate,http://schema.org/isGift-input,< 1K
-Predicate,http://schema.org/isGift-output,< 1K
-Predicate,http://schema.org/isInvolvedInBiologicalProcess,< 1K
-Predicate,http://schema.org/isInvolvedInBiologicalProcess-input,< 1K
-Predicate,http://schema.org/isInvolvedInBiologicalProcess-output,< 1K
-Predicate,http://schema.org/isLiveBroadcast,10K - 100K
-Predicate,http://schema.org/isLiveBroadcast-input,< 1K
-Predicate,http://schema.org/isLiveBroadcast-output,< 1K
-Predicate,http://schema.org/isLocatedInSubcellularLocation,< 1K
-Predicate,http://schema.org/isLocatedInSubcellularLocation-input,< 1K
-Predicate,http://schema.org/isLocatedInSubcellularLocation-output,< 1K
-Predicate,http://schema.org/isPartOf,10M+
-Predicate,http://schema.org/isPartOf-input,< 1K
-Predicate,http://schema.org/isPartOf-output,< 1K
-Predicate,http://schema.org/isPartOfBioChemEntity,< 1K
-Predicate,http://schema.org/isPartOfBioChemEntity-input,< 1K
-Predicate,http://schema.org/isPartOfBioChemEntity-output,< 1K
-Predicate,http://schema.org/isPlanForApartment,< 1K
-Predicate,http://schema.org/isPlanForApartment-input,< 1K
-Predicate,http://schema.org/isPlanForApartment-output,< 1K
-Predicate,http://schema.org/isProprietary,< 1K
-Predicate,http://schema.org/isProprietary-input,< 1K
-Predicate,http://schema.org/isProprietary-output,< 1K
-Predicate,http://schema.org/isRelatedTo,100K - 1M
-Predicate,http://schema.org/isRelatedTo-input,< 1K
-Predicate,http://schema.org/isRelatedTo-output,< 1K
-Predicate,http://schema.org/isResizable,< 1K
-Predicate,http://schema.org/isResizable-input,< 1K
-Predicate,http://schema.org/isResizable-output,< 1K
-Predicate,http://schema.org/isSimilarTo,10K - 100K
-Predicate,http://schema.org/isSimilarTo-input,< 1K
-Predicate,http://schema.org/isSimilarTo-output,< 1K
-Predicate,http://schema.org/isStoreOn,< 1K
-Predicate,http://schema.org/isStoreOn-input,< 1K
-Predicate,http://schema.org/isStoreOn-output,< 1K
-Predicate,http://schema.org/isTierOf,< 1K
-Predicate,http://schema.org/isTierOf-input,< 1K
-Predicate,http://schema.org/isTierOf-output,< 1K
-Predicate,http://schema.org/isUnlabelledFallback,< 1K
-Predicate,http://schema.org/isUnlabelledFallback-input,< 1K
-Predicate,http://schema.org/isUnlabelledFallback-output,< 1K
-Predicate,http://schema.org/isVariantOf,10K - 100K
-Predicate,http://schema.org/isVariantOf-input,< 1K
-Predicate,http://schema.org/isVariantOf-output,< 1K
-Predicate,http://schema.org/isbn,10K - 100K
-Predicate,http://schema.org/isbn-input,< 1K
-Predicate,http://schema.org/isbn-output,< 1K
-Predicate,http://schema.org/isicV4,1K - 10K
-Predicate,http://schema.org/isicV4-input,< 1K
-Predicate,http://schema.org/isicV4-output,< 1K
-Predicate,http://schema.org/iso6523Code,1K - 10K
-Predicate,http://schema.org/iso6523Code-input,< 1K
-Predicate,http://schema.org/iso6523Code-output,< 1K
-Predicate,http://schema.org/isrcCode,< 1K
-Predicate,http://schema.org/isrcCode-input,< 1K
-Predicate,http://schema.org/isrcCode-output,< 1K
-Predicate,http://schema.org/issn,1K - 10K
-Predicate,http://schema.org/issn-input,< 1K
-Predicate,http://schema.org/issn-output,< 1K
-Predicate,http://schema.org/issueNumber,1K - 10K
-Predicate,http://schema.org/issueNumber-input,< 1K
-Predicate,http://schema.org/issueNumber-output,< 1K
-Predicate,http://schema.org/issuedBy,10K - 100K
-Predicate,http://schema.org/issuedBy-input,< 1K
-Predicate,http://schema.org/issuedBy-output,< 1K
-Predicate,http://schema.org/issuedThrough,< 1K
-Predicate,http://schema.org/issuedThrough-input,< 1K
-Predicate,http://schema.org/issuedThrough-output,< 1K
-Predicate,http://schema.org/iswcCode,< 1K
-Predicate,http://schema.org/iswcCode-input,< 1K
-Predicate,http://schema.org/iswcCode-output,< 1K
-Predicate,http://schema.org/item,10M+
-Predicate,http://schema.org/item-input,< 1K
-Predicate,http://schema.org/item-output,< 1K
-Predicate,http://schema.org/itemCondition,1M - 10M
-Predicate,http://schema.org/itemCondition-input,< 1K
-Predicate,http://schema.org/itemCondition-output,< 1K
-Predicate,http://schema.org/itemDefectReturnFees,1K - 10K
-Predicate,http://schema.org/itemDefectReturnFees-input,< 1K
-Predicate,http://schema.org/itemDefectReturnFees-output,< 1K
-Predicate,http://schema.org/itemDefectReturnLabelSource,< 1K
-Predicate,http://schema.org/itemDefectReturnLabelSource-input,< 1K
-Predicate,http://schema.org/itemDefectReturnLabelSource-output,< 1K
-Predicate,http://schema.org/itemDefectReturnShippingFeesAmount,< 1K
-Predicate,http://schema.org/itemDefectReturnShippingFeesAmount-input,< 1K
-Predicate,http://schema.org/itemDefectReturnShippingFeesAmount-output,< 1K
-Predicate,http://schema.org/itemListElement,10M+
-Predicate,http://schema.org/itemListElement-input,< 1K
-Predicate,http://schema.org/itemListElement-output,< 1K
-Predicate,http://schema.org/itemListOrder,100K - 1M
-Predicate,http://schema.org/itemListOrder-input,< 1K
-Predicate,http://schema.org/itemListOrder-output,< 1K
-Predicate,http://schema.org/itemLocation,< 1K
-Predicate,http://schema.org/itemLocation-input,< 1K
-Predicate,http://schema.org/itemLocation-output,< 1K
-Predicate,http://schema.org/itemOffered,100K - 1M
-Predicate,http://schema.org/itemOffered-input,< 1K
-Predicate,http://schema.org/itemOffered-output,< 1K
-Predicate,http://schema.org/itemReviewed,100K - 1M
-Predicate,http://schema.org/itemReviewed-input,< 1K
-Predicate,http://schema.org/itemReviewed-output,< 1K
-Predicate,http://schema.org/itemShipped,< 1K
-Predicate,http://schema.org/itemShipped-input,< 1K
-Predicate,http://schema.org/itemShipped-output,< 1K
-Predicate,http://schema.org/itinerary,10K - 100K
-Predicate,http://schema.org/itinerary-input,< 1K
-Predicate,http://schema.org/itinerary-output,< 1K
-Predicate,http://schema.org/iupacName,< 1K
-Predicate,http://schema.org/iupacName-input,< 1K
-Predicate,http://schema.org/iupacName-output,< 1K
-Predicate,http://schema.org/jobBenefits,10K - 100K
-Predicate,http://schema.org/jobBenefits-input,< 1K
-Predicate,http://schema.org/jobBenefits-output,< 1K
-Predicate,http://schema.org/jobDuration,< 1K
-Predicate,http://schema.org/jobDuration-input,< 1K
-Predicate,http://schema.org/jobDuration-output,< 1K
-Predicate,http://schema.org/jobImmediateStart,1K - 10K
-Predicate,http://schema.org/jobImmediateStart-input,< 1K
-Predicate,http://schema.org/jobImmediateStart-output,< 1K
-Predicate,http://schema.org/jobLocation,100K - 1M
-Predicate,http://schema.org/jobLocation-input,< 1K
-Predicate,http://schema.org/jobLocation-output,< 1K
-Predicate,http://schema.org/jobLocationType,10K - 100K
-Predicate,http://schema.org/jobLocationType-input,< 1K
-Predicate,http://schema.org/jobLocationType-output,< 1K
-Predicate,http://schema.org/jobStartDate,1K - 10K
-Predicate,http://schema.org/jobStartDate-input,< 1K
-Predicate,http://schema.org/jobStartDate-output,< 1K
-Predicate,http://schema.org/jobTitle,1M - 10M
-Predicate,http://schema.org/jobTitle-input,< 1K
-Predicate,http://schema.org/jobTitle-output,< 1K
-Predicate,http://schema.org/jurisdiction,1K - 10K
-Predicate,http://schema.org/jurisdiction-input,< 1K
-Predicate,http://schema.org/jurisdiction-output,< 1K
-Predicate,http://schema.org/keywords,1M - 10M
-Predicate,http://schema.org/keywords-input,< 1K
-Predicate,http://schema.org/keywords-output,< 1K
-Predicate,http://schema.org/knownVehicleDamages,< 1K
-Predicate,http://schema.org/knownVehicleDamages-input,< 1K
-Predicate,http://schema.org/knownVehicleDamages-output,< 1K
-Predicate,http://schema.org/knows,1K - 10K
-Predicate,http://schema.org/knows-input,< 1K
-Predicate,http://schema.org/knows-output,< 1K
-Predicate,http://schema.org/knowsAbout,100K - 1M
-Predicate,http://schema.org/knowsAbout-input,< 1K
-Predicate,http://schema.org/knowsAbout-output,< 1K
-Predicate,http://schema.org/knowsLanguage,100K - 1M
-Predicate,http://schema.org/knowsLanguage-input,< 1K
-Predicate,http://schema.org/knowsLanguage-output,< 1K
-Predicate,http://schema.org/labelDetails,< 1K
-Predicate,http://schema.org/labelDetails-input,< 1K
-Predicate,http://schema.org/labelDetails-output,< 1K
-Predicate,http://schema.org/landlord,< 1K
-Predicate,http://schema.org/landlord-input,< 1K
-Predicate,http://schema.org/landlord-output,< 1K
-Predicate,http://schema.org/language,10K - 100K
-Predicate,http://schema.org/language-input,< 1K
-Predicate,http://schema.org/language-output,< 1K
-Predicate,http://schema.org/lastReviewed,10K - 100K
-Predicate,http://schema.org/lastReviewed-input,< 1K
-Predicate,http://schema.org/lastReviewed-output,< 1K
-Predicate,http://schema.org/latitude,1M - 10M
-Predicate,http://schema.org/latitude-input,< 1K
-Predicate,http://schema.org/latitude-output,< 1K
-Predicate,http://schema.org/layoutImage,1K - 10K
-Predicate,http://schema.org/layoutImage-input,< 1K
-Predicate,http://schema.org/layoutImage-output,< 1K
-Predicate,http://schema.org/learningResourceType,10K - 100K
-Predicate,http://schema.org/learningResourceType-input,< 1K
-Predicate,http://schema.org/learningResourceType-output,< 1K
-Predicate,http://schema.org/leaseLength,1K - 10K
-Predicate,http://schema.org/leaseLength-input,< 1K
-Predicate,http://schema.org/leaseLength-output,< 1K
-Predicate,http://schema.org/legalAddress,1K - 10K
-Predicate,http://schema.org/legalAddress-input,< 1K
-Predicate,http://schema.org/legalAddress-output,< 1K
-Predicate,http://schema.org/legalName,1M - 10M
-Predicate,http://schema.org/legalName-input,< 1K
-Predicate,http://schema.org/legalName-output,< 1K
-Predicate,http://schema.org/legalRepresentative,1K - 10K
-Predicate,http://schema.org/legalRepresentative-input,< 1K
-Predicate,http://schema.org/legalRepresentative-output,< 1K
-Predicate,http://schema.org/legalStatus,1K - 10K
-Predicate,http://schema.org/legalStatus-input,< 1K
-Predicate,http://schema.org/legalStatus-output,< 1K
-Predicate,http://schema.org/legislationAmends,< 1K
-Predicate,http://schema.org/legislationAmends-input,< 1K
-Predicate,http://schema.org/legislationAmends-output,< 1K
-Predicate,http://schema.org/legislationApplies,< 1K
-Predicate,http://schema.org/legislationApplies-input,< 1K
-Predicate,http://schema.org/legislationApplies-output,< 1K
-Predicate,http://schema.org/legislationChanges,< 1K
-Predicate,http://schema.org/legislationChanges-input,< 1K
-Predicate,http://schema.org/legislationChanges-output,< 1K
-Predicate,http://schema.org/legislationCommences,< 1K
-Predicate,http://schema.org/legislationCommences-input,< 1K
-Predicate,http://schema.org/legislationCommences-output,< 1K
-Predicate,http://schema.org/legislationConsolidates,< 1K
-Predicate,http://schema.org/legislationConsolidates-input,< 1K
-Predicate,http://schema.org/legislationConsolidates-output,< 1K
-Predicate,http://schema.org/legislationCorrects,< 1K
-Predicate,http://schema.org/legislationCorrects-input,< 1K
-Predicate,http://schema.org/legislationCorrects-output,< 1K
-Predicate,http://schema.org/legislationCountersignedBy,< 1K
-Predicate,http://schema.org/legislationCountersignedBy-input,< 1K
-Predicate,http://schema.org/legislationCountersignedBy-output,< 1K
-Predicate,http://schema.org/legislationDate,< 1K
-Predicate,http://schema.org/legislationDate-input,< 1K
-Predicate,http://schema.org/legislationDate-output,< 1K
-Predicate,http://schema.org/legislationDateOfApplicability,< 1K
-Predicate,http://schema.org/legislationDateOfApplicability-input,< 1K
-Predicate,http://schema.org/legislationDateOfApplicability-output,< 1K
-Predicate,http://schema.org/legislationDateVersion,< 1K
-Predicate,http://schema.org/legislationDateVersion-input,< 1K
-Predicate,http://schema.org/legislationDateVersion-output,< 1K
-Predicate,http://schema.org/legislationEnsuresImplementationOf,< 1K
-Predicate,http://schema.org/legislationEnsuresImplementationOf-input,< 1K
-Predicate,http://schema.org/legislationEnsuresImplementationOf-output,< 1K
-Predicate,http://schema.org/legislationIdentifier,1K - 10K
-Predicate,http://schema.org/legislationIdentifier-input,< 1K
-Predicate,http://schema.org/legislationIdentifier-output,< 1K
-Predicate,http://schema.org/legislationJurisdiction,1K - 10K
-Predicate,http://schema.org/legislationJurisdiction-input,< 1K
-Predicate,http://schema.org/legislationJurisdiction-output,< 1K
-Predicate,http://schema.org/legislationLegalForce,< 1K
-Predicate,http://schema.org/legislationLegalForce-input,< 1K
-Predicate,http://schema.org/legislationLegalForce-output,< 1K
-Predicate,http://schema.org/legislationLegalValue,< 1K
-Predicate,http://schema.org/legislationLegalValue-input,< 1K
-Predicate,http://schema.org/legislationLegalValue-output,< 1K
-Predicate,http://schema.org/legislationPassedBy,< 1K
-Predicate,http://schema.org/legislationPassedBy-input,< 1K
-Predicate,http://schema.org/legislationPassedBy-output,< 1K
-Predicate,http://schema.org/legislationRepeals,< 1K
-Predicate,http://schema.org/legislationRepeals-input,< 1K
-Predicate,http://schema.org/legislationRepeals-output,< 1K
-Predicate,http://schema.org/legislationResponsible,< 1K
-Predicate,http://schema.org/legislationResponsible-input,< 1K
-Predicate,http://schema.org/legislationResponsible-output,< 1K
-Predicate,http://schema.org/legislationTransposes,< 1K
-Predicate,http://schema.org/legislationTransposes-input,< 1K
-Predicate,http://schema.org/legislationTransposes-output,< 1K
-Predicate,http://schema.org/legislationType,1K - 10K
-Predicate,http://schema.org/legislationType-input,< 1K
-Predicate,http://schema.org/legislationType-output,< 1K
-Predicate,http://schema.org/leiCode,1K - 10K
-Predicate,http://schema.org/leiCode-input,< 1K
-Predicate,http://schema.org/leiCode-output,< 1K
-Predicate,http://schema.org/lender,< 1K
-Predicate,http://schema.org/lender-input,< 1K
-Predicate,http://schema.org/lender-output,< 1K
-Predicate,http://schema.org/lesser,< 1K
-Predicate,http://schema.org/lesser-input,< 1K
-Predicate,http://schema.org/lesser-output,< 1K
-Predicate,http://schema.org/lesserOrEqual,< 1K
-Predicate,http://schema.org/lesserOrEqual-input,< 1K
-Predicate,http://schema.org/lesserOrEqual-output,< 1K
-Predicate,http://schema.org/letterer,< 1K
-Predicate,http://schema.org/letterer-input,< 1K
-Predicate,http://schema.org/letterer-output,< 1K
-Predicate,http://schema.org/license,100K - 1M
-Predicate,http://schema.org/license-input,< 1K
-Predicate,http://schema.org/license-output,< 1K
-Predicate,http://schema.org/lifeEvent,< 1K
-Predicate,http://schema.org/lifeEvent-input,< 1K
-Predicate,http://schema.org/lifeEvent-output,< 1K
-Predicate,http://schema.org/line,< 1K
-Predicate,http://schema.org/line-input,< 1K
-Predicate,http://schema.org/line-output,< 1K
-Predicate,http://schema.org/linkRelationship,< 1K
-Predicate,http://schema.org/linkRelationship-input,< 1K
-Predicate,http://schema.org/linkRelationship-output,< 1K
-Predicate,http://schema.org/liveBlogUpdate,1K - 10K
-Predicate,http://schema.org/liveBlogUpdate-input,< 1K
-Predicate,http://schema.org/liveBlogUpdate-output,< 1K
-Predicate,http://schema.org/loanMortgageMandateAmount,< 1K
-Predicate,http://schema.org/loanMortgageMandateAmount-input,< 1K
-Predicate,http://schema.org/loanMortgageMandateAmount-output,< 1K
-Predicate,http://schema.org/loanPaymentAmount,< 1K
-Predicate,http://schema.org/loanPaymentAmount-input,< 1K
-Predicate,http://schema.org/loanPaymentAmount-output,< 1K
-Predicate,http://schema.org/loanPaymentFrequency,< 1K
-Predicate,http://schema.org/loanPaymentFrequency-input,< 1K
-Predicate,http://schema.org/loanPaymentFrequency-output,< 1K
-Predicate,http://schema.org/loanRepaymentForm,< 1K
-Predicate,http://schema.org/loanRepaymentForm-input,< 1K
-Predicate,http://schema.org/loanRepaymentForm-output,< 1K
-Predicate,http://schema.org/loanTerm,1K - 10K
-Predicate,http://schema.org/loanTerm-input,< 1K
-Predicate,http://schema.org/loanTerm-output,< 1K
-Predicate,http://schema.org/loanType,1K - 10K
-Predicate,http://schema.org/loanType-input,< 1K
-Predicate,http://schema.org/loanType-output,< 1K
-Predicate,http://schema.org/location,1M - 10M
-Predicate,http://schema.org/location-input,< 1K
-Predicate,http://schema.org/location-output,< 1K
-Predicate,http://schema.org/locationCreated,10K - 100K
-Predicate,http://schema.org/locationCreated-input,< 1K
-Predicate,http://schema.org/locationCreated-output,< 1K
-Predicate,http://schema.org/lodgingUnitDescription,< 1K
-Predicate,http://schema.org/lodgingUnitDescription-input,< 1K
-Predicate,http://schema.org/lodgingUnitDescription-output,< 1K
-Predicate,http://schema.org/lodgingUnitType,< 1K
-Predicate,http://schema.org/lodgingUnitType-input,< 1K
-Predicate,http://schema.org/lodgingUnitType-output,< 1K
-Predicate,http://schema.org/logo,10M+
-Predicate,http://schema.org/logo-input,< 1K
-Predicate,http://schema.org/logo-output,< 1K
-Predicate,http://schema.org/longitude,1M - 10M
-Predicate,http://schema.org/longitude-input,< 1K
-Predicate,http://schema.org/longitude-output,< 1K
-Predicate,http://schema.org/loser,< 1K
-Predicate,http://schema.org/loser-input,< 1K
-Predicate,http://schema.org/loser-output,< 1K
-Predicate,http://schema.org/lowPrice,1M - 10M
-Predicate,http://schema.org/lowPrice-input,< 1K
-Predicate,http://schema.org/lowPrice-output,< 1K
-Predicate,http://schema.org/lyricist,< 1K
-Predicate,http://schema.org/lyricist-input,< 1K
-Predicate,http://schema.org/lyricist-output,< 1K
-Predicate,http://schema.org/lyrics,1K - 10K
-Predicate,http://schema.org/lyrics-input,< 1K
-Predicate,http://schema.org/lyrics-output,< 1K
-Predicate,http://schema.org/mainContentOfPage,1M - 10M
-Predicate,http://schema.org/mainContentOfPage-input,< 1K
-Predicate,http://schema.org/mainContentOfPage-output,< 1K
-Predicate,http://schema.org/mainEntity,1M - 10M
-Predicate,http://schema.org/mainEntity-input,< 1K
-Predicate,http://schema.org/mainEntity-output,< 1K
-Predicate,http://schema.org/mainEntityOfPage,10M+
-Predicate,http://schema.org/mainEntityOfPage-input,< 1K
-Predicate,http://schema.org/mainEntityOfPage-output,< 1K
-Predicate,http://schema.org/maintainer,1K - 10K
-Predicate,http://schema.org/maintainer-input,< 1K
-Predicate,http://schema.org/maintainer-output,< 1K
-Predicate,http://schema.org/makesOffer,100K - 1M
-Predicate,http://schema.org/makesOffer-input,< 1K
-Predicate,http://schema.org/makesOffer-output,< 1K
-Predicate,http://schema.org/manufacturer,100K - 1M
-Predicate,http://schema.org/manufacturer-input,< 1K
-Predicate,http://schema.org/manufacturer-output,< 1K
-Predicate,http://schema.org/map,1K - 10K
-Predicate,http://schema.org/map-input,< 1K
-Predicate,http://schema.org/map-output,< 1K
-Predicate,http://schema.org/mapType,1K - 10K
-Predicate,http://schema.org/mapType-input,< 1K
-Predicate,http://schema.org/mapType-output,< 1K
-Predicate,http://schema.org/maps,1K - 10K
-Predicate,http://schema.org/maps-input,< 1K
-Predicate,http://schema.org/maps-output,< 1K
-Predicate,http://schema.org/marginOfError,< 1K
-Predicate,http://schema.org/marginOfError-input,< 1K
-Predicate,http://schema.org/marginOfError-output,< 1K
-Predicate,http://schema.org/masthead,1K - 10K
-Predicate,http://schema.org/masthead-input,< 1K
-Predicate,http://schema.org/masthead-output,< 1K
-Predicate,http://schema.org/material,10K - 100K
-Predicate,http://schema.org/material-input,< 1K
-Predicate,http://schema.org/material-output,< 1K
-Predicate,http://schema.org/materialExtent,< 1K
-Predicate,http://schema.org/materialExtent-input,< 1K
-Predicate,http://schema.org/materialExtent-output,< 1K
-Predicate,http://schema.org/mathExpression,< 1K
-Predicate,http://schema.org/mathExpression-input,< 1K
-Predicate,http://schema.org/mathExpression-output,< 1K
-Predicate,http://schema.org/maxPrice,10K - 100K
-Predicate,http://schema.org/maxPrice-input,< 1K
-Predicate,http://schema.org/maxPrice-output,< 1K
-Predicate,http://schema.org/maxValue,100K - 1M
-Predicate,http://schema.org/maxValue-input,< 1K
-Predicate,http://schema.org/maxValue-output,< 1K
-Predicate,http://schema.org/maximumAttendeeCapacity,10K - 100K
-Predicate,http://schema.org/maximumAttendeeCapacity-input,< 1K
-Predicate,http://schema.org/maximumAttendeeCapacity-output,< 1K
-Predicate,http://schema.org/maximumEnrollment,< 1K
-Predicate,http://schema.org/maximumEnrollment-input,< 1K
-Predicate,http://schema.org/maximumEnrollment-output,< 1K
-Predicate,http://schema.org/maximumIntake,< 1K
-Predicate,http://schema.org/maximumIntake-input,< 1K
-Predicate,http://schema.org/maximumIntake-output,< 1K
-Predicate,http://schema.org/maximumPhysicalAttendeeCapacity,< 1K
-Predicate,http://schema.org/maximumPhysicalAttendeeCapacity-input,< 1K
-Predicate,http://schema.org/maximumPhysicalAttendeeCapacity-output,< 1K
-Predicate,http://schema.org/maximumVirtualAttendeeCapacity,< 1K
-Predicate,http://schema.org/maximumVirtualAttendeeCapacity-input,< 1K
-Predicate,http://schema.org/maximumVirtualAttendeeCapacity-output,< 1K
-Predicate,http://schema.org/mealService,< 1K
-Predicate,http://schema.org/mealService-input,< 1K
-Predicate,http://schema.org/mealService-output,< 1K
-Predicate,http://schema.org/measuredProperty,< 1K
-Predicate,http://schema.org/measuredProperty-input,< 1K
-Predicate,http://schema.org/measuredProperty-output,< 1K
-Predicate,http://schema.org/measurementDenominator,< 1K
-Predicate,http://schema.org/measurementDenominator-input,< 1K
-Predicate,http://schema.org/measurementDenominator-output,< 1K
-Predicate,http://schema.org/measurementMethod,< 1K
-Predicate,http://schema.org/measurementMethod-input,< 1K
-Predicate,http://schema.org/measurementMethod-output,< 1K
-Predicate,http://schema.org/measurementQualifier,< 1K
-Predicate,http://schema.org/measurementQualifier-input,< 1K
-Predicate,http://schema.org/measurementQualifier-output,< 1K
-Predicate,http://schema.org/measurementTechnique,1K - 10K
-Predicate,http://schema.org/measurementTechnique-input,< 1K
-Predicate,http://schema.org/measurementTechnique-output,< 1K
-Predicate,http://schema.org/mechanismOfAction,< 1K
-Predicate,http://schema.org/mechanismOfAction-input,< 1K
-Predicate,http://schema.org/mechanismOfAction-output,< 1K
-Predicate,http://schema.org/mediaAuthenticityCategory,< 1K
-Predicate,http://schema.org/mediaAuthenticityCategory-input,< 1K
-Predicate,http://schema.org/mediaAuthenticityCategory-output,< 1K
-Predicate,http://schema.org/mediaItemAppearance,< 1K
-Predicate,http://schema.org/mediaItemAppearance-input,< 1K
-Predicate,http://schema.org/mediaItemAppearance-output,< 1K
-Predicate,http://schema.org/median,1K - 10K
-Predicate,http://schema.org/median-input,< 1K
-Predicate,http://schema.org/median-output,< 1K
-Predicate,http://schema.org/medicalAudience,1K - 10K
-Predicate,http://schema.org/medicalAudience-input,< 1K
-Predicate,http://schema.org/medicalAudience-output,< 1K
-Predicate,http://schema.org/medicalSpecialty,100K - 1M
-Predicate,http://schema.org/medicalSpecialty-input,< 1K
-Predicate,http://schema.org/medicalSpecialty-output,< 1K
-Predicate,http://schema.org/medicineSystem,1K - 10K
-Predicate,http://schema.org/medicineSystem-input,< 1K
-Predicate,http://schema.org/medicineSystem-output,< 1K
-Predicate,http://schema.org/meetsEmissionStandard,< 1K
-Predicate,http://schema.org/meetsEmissionStandard-input,< 1K
-Predicate,http://schema.org/meetsEmissionStandard-output,< 1K
-Predicate,http://schema.org/member,10K - 100K
-Predicate,http://schema.org/member-input,< 1K
-Predicate,http://schema.org/member-output,< 1K
-Predicate,http://schema.org/memberOf,100K - 1M
-Predicate,http://schema.org/memberOf-input,< 1K
-Predicate,http://schema.org/memberOf-output,< 1K
-Predicate,http://schema.org/members,< 1K
-Predicate,http://schema.org/members-input,< 1K
-Predicate,http://schema.org/members-output,< 1K
-Predicate,http://schema.org/membershipNumber,< 1K
-Predicate,http://schema.org/membershipNumber-input,< 1K
-Predicate,http://schema.org/membershipNumber-output,< 1K
-Predicate,http://schema.org/membershipPointsEarned,1K - 10K
-Predicate,http://schema.org/membershipPointsEarned-input,< 1K
-Predicate,http://schema.org/membershipPointsEarned-output,< 1K
-Predicate,http://schema.org/memoryRequirements,1K - 10K
-Predicate,http://schema.org/memoryRequirements-input,< 1K
-Predicate,http://schema.org/memoryRequirements-output,< 1K
-Predicate,http://schema.org/mentions,10K - 100K
-Predicate,http://schema.org/mentions-input,< 1K
-Predicate,http://schema.org/mentions-output,< 1K
-Predicate,http://schema.org/menu,10K - 100K
-Predicate,http://schema.org/menu-input,< 1K
-Predicate,http://schema.org/menu-output,< 1K
-Predicate,http://schema.org/menuAddOn,10K - 100K
-Predicate,http://schema.org/menuAddOn-input,< 1K
-Predicate,http://schema.org/menuAddOn-output,< 1K
-Predicate,http://schema.org/merchant,< 1K
-Predicate,http://schema.org/merchant-input,< 1K
-Predicate,http://schema.org/merchant-output,< 1K
-Predicate,http://schema.org/merchantReturnDays,100K - 1M
-Predicate,http://schema.org/merchantReturnDays-input,< 1K
-Predicate,http://schema.org/merchantReturnDays-output,< 1K
-Predicate,http://schema.org/merchantReturnLink,10K - 100K
-Predicate,http://schema.org/merchantReturnLink-input,< 1K
-Predicate,http://schema.org/merchantReturnLink-output,< 1K
-Predicate,http://schema.org/messageAttachment,< 1K
-Predicate,http://schema.org/messageAttachment-input,< 1K
-Predicate,http://schema.org/messageAttachment-output,< 1K
-Predicate,http://schema.org/mileageFromOdometer,10K - 100K
-Predicate,http://schema.org/mileageFromOdometer-input,< 1K
-Predicate,http://schema.org/mileageFromOdometer-output,< 1K
-Predicate,http://schema.org/minPrice,10K - 100K
-Predicate,http://schema.org/minPrice-input,< 1K
-Predicate,http://schema.org/minPrice-output,< 1K
-Predicate,http://schema.org/minValue,100K - 1M
-Predicate,http://schema.org/minValue-input,< 1K
-Predicate,http://schema.org/minValue-output,< 1K
-Predicate,http://schema.org/minimumPaymentDue,< 1K
-Predicate,http://schema.org/minimumPaymentDue-input,< 1K
-Predicate,http://schema.org/minimumPaymentDue-output,< 1K
-Predicate,http://schema.org/missionCoveragePrioritiesPolicy,1K - 10K
-Predicate,http://schema.org/missionCoveragePrioritiesPolicy-input,< 1K
-Predicate,http://schema.org/missionCoveragePrioritiesPolicy-output,< 1K
-Predicate,http://schema.org/mobileUrl,< 1K
-Predicate,http://schema.org/mobileUrl-input,< 1K
-Predicate,http://schema.org/mobileUrl-output,< 1K
-Predicate,http://schema.org/model,100K - 1M
-Predicate,http://schema.org/model-input,< 1K
-Predicate,http://schema.org/model-output,< 1K
-Predicate,http://schema.org/modelDate,10K - 100K
-Predicate,http://schema.org/modelDate-input,< 1K
-Predicate,http://schema.org/modelDate-output,< 1K
-Predicate,http://schema.org/modifiedTime,< 1K
-Predicate,http://schema.org/modifiedTime-input,< 1K
-Predicate,http://schema.org/modifiedTime-output,< 1K
-Predicate,http://schema.org/molecularFormula,< 1K
-Predicate,http://schema.org/molecularFormula-input,< 1K
-Predicate,http://schema.org/molecularFormula-output,< 1K
-Predicate,http://schema.org/molecularWeight,< 1K
-Predicate,http://schema.org/molecularWeight-input,< 1K
-Predicate,http://schema.org/molecularWeight-output,< 1K
-Predicate,http://schema.org/monoisotopicMolecularWeight,< 1K
-Predicate,http://schema.org/monoisotopicMolecularWeight-input,< 1K
-Predicate,http://schema.org/monoisotopicMolecularWeight-output,< 1K
-Predicate,http://schema.org/monthlyMinimumRepaymentAmount,< 1K
-Predicate,http://schema.org/monthlyMinimumRepaymentAmount-input,< 1K
-Predicate,http://schema.org/monthlyMinimumRepaymentAmount-output,< 1K
-Predicate,http://schema.org/monthsOfExperience,1K - 10K
-Predicate,http://schema.org/monthsOfExperience-input,< 1K
-Predicate,http://schema.org/monthsOfExperience-output,< 1K
-Predicate,http://schema.org/mpn,100K - 1M
-Predicate,http://schema.org/mpn-input,< 1K
-Predicate,http://schema.org/mpn-output,< 1K
-Predicate,http://schema.org/multipleValues,< 1K
-Predicate,http://schema.org/multipleValues-input,< 1K
-Predicate,http://schema.org/multipleValues-output,< 1K
-Predicate,http://schema.org/muscleAction,< 1K
-Predicate,http://schema.org/muscleAction-input,< 1K
-Predicate,http://schema.org/muscleAction-output,< 1K
-Predicate,http://schema.org/musicArrangement,< 1K
-Predicate,http://schema.org/musicArrangement-input,< 1K
-Predicate,http://schema.org/musicArrangement-output,< 1K
-Predicate,http://schema.org/musicBy,1K - 10K
-Predicate,http://schema.org/musicBy-input,< 1K
-Predicate,http://schema.org/musicBy-output,< 1K
-Predicate,http://schema.org/musicCompositionForm,< 1K
-Predicate,http://schema.org/musicCompositionForm-input,< 1K
-Predicate,http://schema.org/musicCompositionForm-output,< 1K
-Predicate,http://schema.org/musicGroupMember,< 1K
-Predicate,http://schema.org/musicGroupMember-input,< 1K
-Predicate,http://schema.org/musicGroupMember-output,< 1K
-Predicate,http://schema.org/musicReleaseFormat,1K - 10K
-Predicate,http://schema.org/musicReleaseFormat-input,< 1K
-Predicate,http://schema.org/musicReleaseFormat-output,< 1K
-Predicate,http://schema.org/musicalKey,< 1K
-Predicate,http://schema.org/musicalKey-input,< 1K
-Predicate,http://schema.org/musicalKey-output,< 1K
-Predicate,http://schema.org/naics,10K - 100K
-Predicate,http://schema.org/naics-input,< 1K
-Predicate,http://schema.org/naics-output,< 1K
-Predicate,http://schema.org/name,10M+
-Predicate,http://schema.org/name-input,< 1K
-Predicate,http://schema.org/name-output,< 1K
-Predicate,http://schema.org/namedPosition,< 1K
-Predicate,http://schema.org/namedPosition-input,< 1K
-Predicate,http://schema.org/namedPosition-output,< 1K
-Predicate,http://schema.org/nationality,10K - 100K
-Predicate,http://schema.org/nationality-input,< 1K
-Predicate,http://schema.org/nationality-output,< 1K
-Predicate,http://schema.org/naturalProgression,< 1K
-Predicate,http://schema.org/naturalProgression-input,< 1K
-Predicate,http://schema.org/naturalProgression-output,< 1K
-Predicate,http://schema.org/negativeNotes,10K - 100K
-Predicate,http://schema.org/negativeNotes-input,< 1K
-Predicate,http://schema.org/negativeNotes-output,< 1K
-Predicate,http://schema.org/nerve,< 1K
-Predicate,http://schema.org/nerve-input,< 1K
-Predicate,http://schema.org/nerve-output,< 1K
-Predicate,http://schema.org/nerveMotor,< 1K
-Predicate,http://schema.org/nerveMotor-input,< 1K
-Predicate,http://schema.org/nerveMotor-output,< 1K
-Predicate,http://schema.org/netWorth,< 1K
-Predicate,http://schema.org/netWorth-input,< 1K
-Predicate,http://schema.org/netWorth-output,< 1K
-Predicate,http://schema.org/newsUpdatesAndGuidelines,< 1K
-Predicate,http://schema.org/newsUpdatesAndGuidelines-input,< 1K
-Predicate,http://schema.org/newsUpdatesAndGuidelines-output,< 1K
-Predicate,http://schema.org/nextItem,1M - 10M
-Predicate,http://schema.org/nextItem-input,< 1K
-Predicate,http://schema.org/nextItem-output,< 1K
-Predicate,http://schema.org/noBylinesPolicy,1K - 10K
-Predicate,http://schema.org/noBylinesPolicy-input,< 1K
-Predicate,http://schema.org/noBylinesPolicy-output,< 1K
-Predicate,http://schema.org/nonEqual,< 1K
-Predicate,http://schema.org/nonEqual-input,< 1K
-Predicate,http://schema.org/nonEqual-output,< 1K
-Predicate,http://schema.org/nonProprietaryName,1K - 10K
-Predicate,http://schema.org/nonProprietaryName-input,< 1K
-Predicate,http://schema.org/nonProprietaryName-output,< 1K
-Predicate,http://schema.org/nonprofitStatus,1K - 10K
-Predicate,http://schema.org/nonprofitStatus-input,< 1K
-Predicate,http://schema.org/nonprofitStatus-output,< 1K
-Predicate,http://schema.org/normalRange,< 1K
-Predicate,http://schema.org/normalRange-input,< 1K
-Predicate,http://schema.org/normalRange-output,< 1K
-Predicate,http://schema.org/nsn,< 1K
-Predicate,http://schema.org/nsn-input,< 1K
-Predicate,http://schema.org/nsn-output,< 1K
-Predicate,http://schema.org/numAdults,< 1K
-Predicate,http://schema.org/numAdults-input,< 1K
-Predicate,http://schema.org/numAdults-output,< 1K
-Predicate,http://schema.org/numChildren,< 1K
-Predicate,http://schema.org/numChildren-input,< 1K
-Predicate,http://schema.org/numChildren-output,< 1K
-Predicate,http://schema.org/numConstraints,< 1K
-Predicate,http://schema.org/numConstraints-input,< 1K
-Predicate,http://schema.org/numConstraints-output,< 1K
-Predicate,http://schema.org/numItems,< 1K
-Predicate,http://schema.org/numItems-input,< 1K
-Predicate,http://schema.org/numItems-output,< 1K
-Predicate,http://schema.org/numTracks,10K - 100K
-Predicate,http://schema.org/numTracks-input,< 1K
-Predicate,http://schema.org/numTracks-output,< 1K
-Predicate,http://schema.org/numberOfAccommodationUnits,1K - 10K
-Predicate,http://schema.org/numberOfAccommodationUnits-input,< 1K
-Predicate,http://schema.org/numberOfAccommodationUnits-output,< 1K
-Predicate,http://schema.org/numberOfAirbags,< 1K
-Predicate,http://schema.org/numberOfAirbags-input,< 1K
-Predicate,http://schema.org/numberOfAirbags-output,< 1K
-Predicate,http://schema.org/numberOfAvailableAccommodationUnits,1K - 10K
-Predicate,http://schema.org/numberOfAvailableAccommodationUnits-input,< 1K
-Predicate,http://schema.org/numberOfAvailableAccommodationUnits-output,< 1K
-Predicate,http://schema.org/numberOfAxles,1K - 10K
-Predicate,http://schema.org/numberOfAxles-input,< 1K
-Predicate,http://schema.org/numberOfAxles-output,< 1K
-Predicate,http://schema.org/numberOfBathroomsTotal,10K - 100K
-Predicate,http://schema.org/numberOfBathroomsTotal-input,< 1K
-Predicate,http://schema.org/numberOfBathroomsTotal-output,< 1K
-Predicate,http://schema.org/numberOfBedrooms,100K - 1M
-Predicate,http://schema.org/numberOfBedrooms-input,< 1K
-Predicate,http://schema.org/numberOfBedrooms-output,< 1K
-Predicate,http://schema.org/numberOfBeds,10K - 100K
-Predicate,http://schema.org/numberOfBeds-input,< 1K
-Predicate,http://schema.org/numberOfBeds-output,< 1K
-Predicate,http://schema.org/numberOfCredits,1K - 10K
-Predicate,http://schema.org/numberOfCredits-input,< 1K
-Predicate,http://schema.org/numberOfCredits-output,< 1K
-Predicate,http://schema.org/numberOfDoors,10K - 100K
-Predicate,http://schema.org/numberOfDoors-input,< 1K
-Predicate,http://schema.org/numberOfDoors-output,< 1K
-Predicate,http://schema.org/numberOfEmployees,100K - 1M
-Predicate,http://schema.org/numberOfEmployees-input,< 1K
-Predicate,http://schema.org/numberOfEmployees-output,< 1K
-Predicate,http://schema.org/numberOfEpisodes,10K - 100K
-Predicate,http://schema.org/numberOfEpisodes-input,< 1K
-Predicate,http://schema.org/numberOfEpisodes-output,< 1K
-Predicate,http://schema.org/numberOfForwardGears,1K - 10K
-Predicate,http://schema.org/numberOfForwardGears-input,< 1K
-Predicate,http://schema.org/numberOfForwardGears-output,< 1K
-Predicate,http://schema.org/numberOfFullBathrooms,10K - 100K
-Predicate,http://schema.org/numberOfFullBathrooms-input,< 1K
-Predicate,http://schema.org/numberOfFullBathrooms-output,< 1K
-Predicate,http://schema.org/numberOfItems,100K - 1M
-Predicate,http://schema.org/numberOfItems-input,< 1K
-Predicate,http://schema.org/numberOfItems-output,< 1K
-Predicate,http://schema.org/numberOfLoanPayments,< 1K
-Predicate,http://schema.org/numberOfLoanPayments-input,< 1K
-Predicate,http://schema.org/numberOfLoanPayments-output,< 1K
-Predicate,http://schema.org/numberOfPages,10K - 100K
-Predicate,http://schema.org/numberOfPages-input,< 1K
-Predicate,http://schema.org/numberOfPages-output,< 1K
-Predicate,http://schema.org/numberOfPartialBathrooms,1K - 10K
-Predicate,http://schema.org/numberOfPartialBathrooms-input,< 1K
-Predicate,http://schema.org/numberOfPartialBathrooms-output,< 1K
-Predicate,http://schema.org/numberOfPlayers,10K - 100K
-Predicate,http://schema.org/numberOfPlayers-input,< 1K
-Predicate,http://schema.org/numberOfPlayers-output,< 1K
-Predicate,http://schema.org/numberOfPreviousOwners,1K - 10K
-Predicate,http://schema.org/numberOfPreviousOwners-input,< 1K
-Predicate,http://schema.org/numberOfPreviousOwners-output,< 1K
-Predicate,http://schema.org/numberOfRooms,10K - 100K
-Predicate,http://schema.org/numberOfRooms-input,< 1K
-Predicate,http://schema.org/numberOfRooms-output,< 1K
-Predicate,http://schema.org/numberOfSeasons,1K - 10K
-Predicate,http://schema.org/numberOfSeasons-input,< 1K
-Predicate,http://schema.org/numberOfSeasons-output,< 1K
-Predicate,http://schema.org/numberedPosition,< 1K
-Predicate,http://schema.org/numberedPosition-input,< 1K
-Predicate,http://schema.org/numberedPosition-output,< 1K
-Predicate,http://schema.org/nutrition,10K - 100K
-Predicate,http://schema.org/nutrition-input,< 1K
-Predicate,http://schema.org/nutrition-output,< 1K
-Predicate,http://schema.org/object,10K - 100K
-Predicate,http://schema.org/object-input,< 1K
-Predicate,http://schema.org/object-output,< 1K
-Predicate,http://schema.org/observationAbout,< 1K
-Predicate,http://schema.org/observationAbout-input,< 1K
-Predicate,http://schema.org/observationAbout-output,< 1K
-Predicate,http://schema.org/observationDate,< 1K
-Predicate,http://schema.org/observationDate-input,< 1K
-Predicate,http://schema.org/observationDate-output,< 1K
-Predicate,http://schema.org/observationPeriod,< 1K
-Predicate,http://schema.org/observationPeriod-input,< 1K
-Predicate,http://schema.org/observationPeriod-output,< 1K
-Predicate,http://schema.org/occupancy,10K - 100K
-Predicate,http://schema.org/occupancy-input,< 1K
-Predicate,http://schema.org/occupancy-output,< 1K
-Predicate,http://schema.org/occupationLocation,10K - 100K
-Predicate,http://schema.org/occupationLocation-input,< 1K
-Predicate,http://schema.org/occupationLocation-output,< 1K
-Predicate,http://schema.org/occupationalCategory,10K - 100K
-Predicate,http://schema.org/occupationalCategory-input,< 1K
-Predicate,http://schema.org/occupationalCategory-output,< 1K
-Predicate,http://schema.org/occupationalCredentialAwarded,1K - 10K
-Predicate,http://schema.org/occupationalCredentialAwarded-input,< 1K
-Predicate,http://schema.org/occupationalCredentialAwarded-output,< 1K
-Predicate,http://schema.org/offerCount,1M - 10M
-Predicate,http://schema.org/offerCount-input,< 1K
-Predicate,http://schema.org/offerCount-output,< 1K
-Predicate,http://schema.org/offeredBy,10K - 100K
-Predicate,http://schema.org/offeredBy-input,< 1K
-Predicate,http://schema.org/offeredBy-output,< 1K
-Predicate,http://schema.org/offers,10M+
-Predicate,http://schema.org/offers-input,< 1K
-Predicate,http://schema.org/offers-output,< 1K
-Predicate,http://schema.org/offersPrescriptionByMail,< 1K
-Predicate,http://schema.org/offersPrescriptionByMail-input,< 1K
-Predicate,http://schema.org/offersPrescriptionByMail-output,< 1K
-Predicate,http://schema.org/openingHours,1M - 10M
-Predicate,http://schema.org/openingHours-input,< 1K
-Predicate,http://schema.org/openingHours-output,< 1K
-Predicate,http://schema.org/openingHoursSpecification,1M - 10M
-Predicate,http://schema.org/openingHoursSpecification-input,< 1K
-Predicate,http://schema.org/openingHoursSpecification-output,< 1K
-Predicate,http://schema.org/opens,1M - 10M
-Predicate,http://schema.org/opens-input,< 1K
-Predicate,http://schema.org/opens-output,< 1K
-Predicate,http://schema.org/operatingSystem,1M - 10M
-Predicate,http://schema.org/operatingSystem-input,< 1K
-Predicate,http://schema.org/operatingSystem-output,< 1K
-Predicate,http://schema.org/opponent,< 1K
-Predicate,http://schema.org/opponent-input,< 1K
-Predicate,http://schema.org/opponent-output,< 1K
-Predicate,http://schema.org/option,< 1K
-Predicate,http://schema.org/option-input,< 1K
-Predicate,http://schema.org/option-output,< 1K
-Predicate,http://schema.org/orderDate,< 1K
-Predicate,http://schema.org/orderDate-input,< 1K
-Predicate,http://schema.org/orderDate-output,< 1K
-Predicate,http://schema.org/orderDelivery,< 1K
-Predicate,http://schema.org/orderDelivery-input,< 1K
-Predicate,http://schema.org/orderDelivery-output,< 1K
-Predicate,http://schema.org/orderItemNumber,< 1K
-Predicate,http://schema.org/orderItemNumber-input,< 1K
-Predicate,http://schema.org/orderItemNumber-output,< 1K
-Predicate,http://schema.org/orderItemStatus,< 1K
-Predicate,http://schema.org/orderItemStatus-input,< 1K
-Predicate,http://schema.org/orderItemStatus-output,< 1K
-Predicate,http://schema.org/orderNumber,< 1K
-Predicate,http://schema.org/orderNumber-input,< 1K
-Predicate,http://schema.org/orderNumber-output,< 1K
-Predicate,http://schema.org/orderPercentage,< 1K
-Predicate,http://schema.org/orderPercentage-input,< 1K
-Predicate,http://schema.org/orderPercentage-output,< 1K
-Predicate,http://schema.org/orderQuantity,< 1K
-Predicate,http://schema.org/orderQuantity-input,< 1K
-Predicate,http://schema.org/orderQuantity-output,< 1K
-Predicate,http://schema.org/orderStatus,< 1K
-Predicate,http://schema.org/orderStatus-input,< 1K
-Predicate,http://schema.org/orderStatus-output,< 1K
-Predicate,http://schema.org/orderValue,< 1K
-Predicate,http://schema.org/orderValue-input,< 1K
-Predicate,http://schema.org/orderValue-output,< 1K
-Predicate,http://schema.org/orderedItem,< 1K
-Predicate,http://schema.org/orderedItem-input,< 1K
-Predicate,http://schema.org/orderedItem-output,< 1K
-Predicate,http://schema.org/organizer,100K - 1M
-Predicate,http://schema.org/organizer-input,< 1K
-Predicate,http://schema.org/organizer-output,< 1K
-Predicate,http://schema.org/originAddress,< 1K
-Predicate,http://schema.org/originAddress-input,< 1K
-Predicate,http://schema.org/originAddress-output,< 1K
-Predicate,http://schema.org/originalMediaContextDescription,< 1K
-Predicate,http://schema.org/originalMediaContextDescription-input,< 1K
-Predicate,http://schema.org/originalMediaContextDescription-output,< 1K
-Predicate,http://schema.org/originalMediaLink,< 1K
-Predicate,http://schema.org/originalMediaLink-input,< 1K
-Predicate,http://schema.org/originalMediaLink-output,< 1K
-Predicate,http://schema.org/originatesFrom,< 1K
-Predicate,http://schema.org/originatesFrom-input,< 1K
-Predicate,http://schema.org/originatesFrom-output,< 1K
-Predicate,http://schema.org/overdosage,< 1K
-Predicate,http://schema.org/overdosage-input,< 1K
-Predicate,http://schema.org/overdosage-output,< 1K
-Predicate,http://schema.org/ownedFrom,< 1K
-Predicate,http://schema.org/ownedFrom-input,< 1K
-Predicate,http://schema.org/ownedFrom-output,< 1K
-Predicate,http://schema.org/ownedThrough,< 1K
-Predicate,http://schema.org/ownedThrough-input,< 1K
-Predicate,http://schema.org/ownedThrough-output,< 1K
-Predicate,http://schema.org/owner,1K - 10K
-Predicate,http://schema.org/owner-input,< 1K
-Predicate,http://schema.org/owner-output,< 1K
-Predicate,http://schema.org/ownershipFundingInfo,10K - 100K
-Predicate,http://schema.org/ownershipFundingInfo-input,< 1K
-Predicate,http://schema.org/ownershipFundingInfo-output,< 1K
-Predicate,http://schema.org/owns,10K - 100K
-Predicate,http://schema.org/owns-input,< 1K
-Predicate,http://schema.org/owns-output,< 1K
-Predicate,http://schema.org/pageEnd,1K - 10K
-Predicate,http://schema.org/pageEnd-input,< 1K
-Predicate,http://schema.org/pageEnd-output,< 1K
-Predicate,http://schema.org/pageStart,1K - 10K
-Predicate,http://schema.org/pageStart-input,< 1K
-Predicate,http://schema.org/pageStart-output,< 1K
-Predicate,http://schema.org/pagination,1K - 10K
-Predicate,http://schema.org/pagination-input,< 1K
-Predicate,http://schema.org/pagination-output,< 1K
-Predicate,http://schema.org/parent,1K - 10K
-Predicate,http://schema.org/parent-input,< 1K
-Predicate,http://schema.org/parent-output,< 1K
-Predicate,http://schema.org/parentItem,1K - 10K
-Predicate,http://schema.org/parentItem-input,< 1K
-Predicate,http://schema.org/parentItem-output,< 1K
-Predicate,http://schema.org/parentOrganization,100K - 1M
-Predicate,http://schema.org/parentOrganization-input,< 1K
-Predicate,http://schema.org/parentOrganization-output,< 1K
-Predicate,http://schema.org/parentService,< 1K
-Predicate,http://schema.org/parentService-input,< 1K
-Predicate,http://schema.org/parentService-output,< 1K
-Predicate,http://schema.org/parentTaxon,< 1K
-Predicate,http://schema.org/parentTaxon-input,< 1K
-Predicate,http://schema.org/parentTaxon-output,< 1K
-Predicate,http://schema.org/parents,< 1K
-Predicate,http://schema.org/parents-input,< 1K
-Predicate,http://schema.org/parents-output,< 1K
-Predicate,http://schema.org/partOfEpisode,< 1K
-Predicate,http://schema.org/partOfEpisode-input,< 1K
-Predicate,http://schema.org/partOfEpisode-output,< 1K
-Predicate,http://schema.org/partOfInvoice,< 1K
-Predicate,http://schema.org/partOfInvoice-input,< 1K
-Predicate,http://schema.org/partOfInvoice-output,< 1K
-Predicate,http://schema.org/partOfOrder,< 1K
-Predicate,http://schema.org/partOfOrder-input,< 1K
-Predicate,http://schema.org/partOfOrder-output,< 1K
-Predicate,http://schema.org/partOfSeason,1K - 10K
-Predicate,http://schema.org/partOfSeason-input,< 1K
-Predicate,http://schema.org/partOfSeason-output,< 1K
-Predicate,http://schema.org/partOfSeries,10K - 100K
-Predicate,http://schema.org/partOfSeries-input,< 1K
-Predicate,http://schema.org/partOfSeries-output,< 1K
-Predicate,http://schema.org/partOfSystem,< 1K
-Predicate,http://schema.org/partOfSystem-input,< 1K
-Predicate,http://schema.org/partOfSystem-output,< 1K
-Predicate,http://schema.org/partOfTVSeries,< 1K
-Predicate,http://schema.org/partOfTVSeries-input,< 1K
-Predicate,http://schema.org/partOfTVSeries-output,< 1K
-Predicate,http://schema.org/partOfTrip,< 1K
-Predicate,http://schema.org/partOfTrip-input,< 1K
-Predicate,http://schema.org/partOfTrip-output,< 1K
-Predicate,http://schema.org/participant,1K - 10K
-Predicate,http://schema.org/participant-input,< 1K
-Predicate,http://schema.org/participant-output,< 1K
-Predicate,http://schema.org/partySize,< 1K
-Predicate,http://schema.org/partySize-input,< 1K
-Predicate,http://schema.org/partySize-output,< 1K
-Predicate,http://schema.org/passengerPriorityStatus,< 1K
-Predicate,http://schema.org/passengerPriorityStatus-input,< 1K
-Predicate,http://schema.org/passengerPriorityStatus-output,< 1K
-Predicate,http://schema.org/passengerSequenceNumber,< 1K
-Predicate,http://schema.org/passengerSequenceNumber-input,< 1K
-Predicate,http://schema.org/passengerSequenceNumber-output,< 1K
-Predicate,http://schema.org/pathophysiology,< 1K
-Predicate,http://schema.org/pathophysiology-input,< 1K
-Predicate,http://schema.org/pathophysiology-output,< 1K
-Predicate,http://schema.org/pattern,1K - 10K
-Predicate,http://schema.org/pattern-input,< 1K
-Predicate,http://schema.org/pattern-output,< 1K
-Predicate,http://schema.org/payload,1K - 10K
-Predicate,http://schema.org/payload-input,< 1K
-Predicate,http://schema.org/payload-output,< 1K
-Predicate,http://schema.org/paymentAccepted,100K - 1M
-Predicate,http://schema.org/paymentAccepted-input,< 1K
-Predicate,http://schema.org/paymentAccepted-output,< 1K
-Predicate,http://schema.org/paymentDue,< 1K
-Predicate,http://schema.org/paymentDue-input,< 1K
-Predicate,http://schema.org/paymentDue-output,< 1K
-Predicate,http://schema.org/paymentDueDate,< 1K
-Predicate,http://schema.org/paymentDueDate-input,< 1K
-Predicate,http://schema.org/paymentDueDate-output,< 1K
-Predicate,http://schema.org/paymentMethod,< 1K
-Predicate,http://schema.org/paymentMethod-input,< 1K
-Predicate,http://schema.org/paymentMethod-output,< 1K
-Predicate,http://schema.org/paymentMethodId,< 1K
-Predicate,http://schema.org/paymentMethodId-input,< 1K
-Predicate,http://schema.org/paymentMethodId-output,< 1K
-Predicate,http://schema.org/paymentMethodType,< 1K
-Predicate,http://schema.org/paymentMethodType-input,< 1K
-Predicate,http://schema.org/paymentMethodType-output,< 1K
-Predicate,http://schema.org/paymentStatus,< 1K
-Predicate,http://schema.org/paymentStatus-input,< 1K
-Predicate,http://schema.org/paymentStatus-output,< 1K
-Predicate,http://schema.org/paymentUrl,< 1K
-Predicate,http://schema.org/paymentUrl-input,< 1K
-Predicate,http://schema.org/paymentUrl-output,< 1K
-Predicate,http://schema.org/penciler,< 1K
-Predicate,http://schema.org/penciler-input,< 1K
-Predicate,http://schema.org/penciler-output,< 1K
-Predicate,http://schema.org/percentile10,1K - 10K
-Predicate,http://schema.org/percentile10-input,< 1K
-Predicate,http://schema.org/percentile10-output,< 1K
-Predicate,http://schema.org/percentile25,1K - 10K
-Predicate,http://schema.org/percentile25-input,< 1K
-Predicate,http://schema.org/percentile25-output,< 1K
-Predicate,http://schema.org/percentile75,1K - 10K
-Predicate,http://schema.org/percentile75-input,< 1K
-Predicate,http://schema.org/percentile75-output,< 1K
-Predicate,http://schema.org/percentile90,1K - 10K
-Predicate,http://schema.org/percentile90-input,< 1K
-Predicate,http://schema.org/percentile90-output,< 1K
-Predicate,http://schema.org/performTime,10K - 100K
-Predicate,http://schema.org/performTime-input,< 1K
-Predicate,http://schema.org/performTime-output,< 1K
-Predicate,http://schema.org/performer,100K - 1M
-Predicate,http://schema.org/performer-input,< 1K
-Predicate,http://schema.org/performer-output,< 1K
-Predicate,http://schema.org/performerIn,1K - 10K
-Predicate,http://schema.org/performerIn-input,< 1K
-Predicate,http://schema.org/performerIn-output,< 1K
-Predicate,http://schema.org/performers,10K - 100K
-Predicate,http://schema.org/performers-input,< 1K
-Predicate,http://schema.org/performers-output,< 1K
-Predicate,http://schema.org/permissionType,< 1K
-Predicate,http://schema.org/permissionType-input,< 1K
-Predicate,http://schema.org/permissionType-output,< 1K
-Predicate,http://schema.org/permissions,10K - 100K
-Predicate,http://schema.org/permissions-input,< 1K
-Predicate,http://schema.org/permissions-output,< 1K
-Predicate,http://schema.org/permitAudience,< 1K
-Predicate,http://schema.org/permitAudience-input,< 1K
-Predicate,http://schema.org/permitAudience-output,< 1K
-Predicate,http://schema.org/permittedUsage,< 1K
-Predicate,http://schema.org/permittedUsage-input,< 1K
-Predicate,http://schema.org/permittedUsage-output,< 1K
-Predicate,http://schema.org/petsAllowed,10K - 100K
-Predicate,http://schema.org/petsAllowed-input,< 1K
-Predicate,http://schema.org/petsAllowed-output,< 1K
-Predicate,http://schema.org/phoneticText,< 1K
-Predicate,http://schema.org/phoneticText-input,< 1K
-Predicate,http://schema.org/phoneticText-output,< 1K
-Predicate,http://schema.org/photo,10K - 100K
-Predicate,http://schema.org/photo-input,< 1K
-Predicate,http://schema.org/photo-output,< 1K
-Predicate,http://schema.org/photos,10K - 100K
-Predicate,http://schema.org/photos-input,< 1K
-Predicate,http://schema.org/photos-output,< 1K
-Predicate,http://schema.org/physicalRequirement,< 1K
-Predicate,http://schema.org/physicalRequirement-input,< 1K
-Predicate,http://schema.org/physicalRequirement-output,< 1K
-Predicate,http://schema.org/physiologicalBenefits,< 1K
-Predicate,http://schema.org/physiologicalBenefits-input,< 1K
-Predicate,http://schema.org/physiologicalBenefits-output,< 1K
-Predicate,http://schema.org/pickupLocation,< 1K
-Predicate,http://schema.org/pickupLocation-input,< 1K
-Predicate,http://schema.org/pickupLocation-output,< 1K
-Predicate,http://schema.org/pickupTime,< 1K
-Predicate,http://schema.org/pickupTime-input,< 1K
-Predicate,http://schema.org/pickupTime-output,< 1K
-Predicate,http://schema.org/playMode,10K - 100K
-Predicate,http://schema.org/playMode-input,< 1K
-Predicate,http://schema.org/playMode-output,< 1K
-Predicate,http://schema.org/playerType,10K - 100K
-Predicate,http://schema.org/playerType-input,< 1K
-Predicate,http://schema.org/playerType-output,< 1K
-Predicate,http://schema.org/playersOnline,1K - 10K
-Predicate,http://schema.org/playersOnline-input,< 1K
-Predicate,http://schema.org/playersOnline-output,< 1K
-Predicate,http://schema.org/polygon,1K - 10K
-Predicate,http://schema.org/polygon-input,< 1K
-Predicate,http://schema.org/polygon-output,< 1K
-Predicate,http://schema.org/populationType,< 1K
-Predicate,http://schema.org/populationType-input,< 1K
-Predicate,http://schema.org/populationType-output,< 1K
-Predicate,http://schema.org/position,10M+
-Predicate,http://schema.org/position-input,< 1K
-Predicate,http://schema.org/position-output,< 1K
-Predicate,http://schema.org/positiveNotes,10K - 100K
-Predicate,http://schema.org/positiveNotes-input,< 1K
-Predicate,http://schema.org/positiveNotes-output,< 1K
-Predicate,http://schema.org/possibleComplication,1K - 10K
-Predicate,http://schema.org/possibleComplication-input,< 1K
-Predicate,http://schema.org/possibleComplication-output,< 1K
-Predicate,http://schema.org/possibleTreatment,1K - 10K
-Predicate,http://schema.org/possibleTreatment-input,< 1K
-Predicate,http://schema.org/possibleTreatment-output,< 1K
-Predicate,http://schema.org/postOfficeBoxNumber,10K - 100K
-Predicate,http://schema.org/postOfficeBoxNumber-input,< 1K
-Predicate,http://schema.org/postOfficeBoxNumber-output,< 1K
-Predicate,http://schema.org/postOp,< 1K
-Predicate,http://schema.org/postOp-input,< 1K
-Predicate,http://schema.org/postOp-output,< 1K
-Predicate,http://schema.org/postalCode,1M - 10M
-Predicate,http://schema.org/postalCode-input,< 1K
-Predicate,http://schema.org/postalCode-output,< 1K
-Predicate,http://schema.org/postalCodeBegin,1K - 10K
-Predicate,http://schema.org/postalCodeBegin-input,< 1K
-Predicate,http://schema.org/postalCodeBegin-output,< 1K
-Predicate,http://schema.org/postalCodeEnd,1K - 10K
-Predicate,http://schema.org/postalCodeEnd-input,< 1K
-Predicate,http://schema.org/postalCodeEnd-output,< 1K
-Predicate,http://schema.org/postalCodePrefix,< 1K
-Predicate,http://schema.org/postalCodePrefix-input,< 1K
-Predicate,http://schema.org/postalCodePrefix-output,< 1K
-Predicate,http://schema.org/postalCodeRange,1K - 10K
-Predicate,http://schema.org/postalCodeRange-input,< 1K
-Predicate,http://schema.org/postalCodeRange-output,< 1K
-Predicate,http://schema.org/potentialAction,10M+
-Predicate,http://schema.org/potentialAction-input,< 1K
-Predicate,http://schema.org/potentialAction-output,< 1K
-Predicate,http://schema.org/potentialUse,< 1K
-Predicate,http://schema.org/potentialUse-input,< 1K
-Predicate,http://schema.org/potentialUse-output,< 1K
-Predicate,http://schema.org/practicesAt,1K - 10K
-Predicate,http://schema.org/practicesAt-input,< 1K
-Predicate,http://schema.org/practicesAt-output,< 1K
-Predicate,http://schema.org/preOp,< 1K
-Predicate,http://schema.org/preOp-input,< 1K
-Predicate,http://schema.org/preOp-output,< 1K
-Predicate,http://schema.org/predecessorOf,< 1K
-Predicate,http://schema.org/predecessorOf-input,< 1K
-Predicate,http://schema.org/predecessorOf-output,< 1K
-Predicate,http://schema.org/pregnancyCategory,< 1K
-Predicate,http://schema.org/pregnancyCategory-input,< 1K
-Predicate,http://schema.org/pregnancyCategory-output,< 1K
-Predicate,http://schema.org/pregnancyWarning,< 1K
-Predicate,http://schema.org/pregnancyWarning-input,< 1K
-Predicate,http://schema.org/pregnancyWarning-output,< 1K
-Predicate,http://schema.org/prepTime,10K - 100K
-Predicate,http://schema.org/prepTime-input,< 1K
-Predicate,http://schema.org/prepTime-output,< 1K
-Predicate,http://schema.org/preparation,1K - 10K
-Predicate,http://schema.org/preparation-input,< 1K
-Predicate,http://schema.org/preparation-output,< 1K
-Predicate,http://schema.org/prescribingInfo,< 1K
-Predicate,http://schema.org/prescribingInfo-input,< 1K
-Predicate,http://schema.org/prescribingInfo-output,< 1K
-Predicate,http://schema.org/prescriptionStatus,1K - 10K
-Predicate,http://schema.org/prescriptionStatus-input,< 1K
-Predicate,http://schema.org/prescriptionStatus-output,< 1K
-Predicate,http://schema.org/previousItem,1M - 10M
-Predicate,http://schema.org/previousItem-input,< 1K
-Predicate,http://schema.org/previousItem-output,< 1K
-Predicate,http://schema.org/previousStartDate,1K - 10K
-Predicate,http://schema.org/previousStartDate-input,< 1K
-Predicate,http://schema.org/previousStartDate-output,< 1K
-Predicate,http://schema.org/price,10M+
-Predicate,http://schema.org/price-input,< 1K
-Predicate,http://schema.org/price-output,< 1K
-Predicate,http://schema.org/priceComponent,1K - 10K
-Predicate,http://schema.org/priceComponent-input,< 1K
-Predicate,http://schema.org/priceComponent-output,< 1K
-Predicate,http://schema.org/priceComponentType,< 1K
-Predicate,http://schema.org/priceComponentType-input,< 1K
-Predicate,http://schema.org/priceComponentType-output,< 1K
-Predicate,http://schema.org/priceCurrency,10M+
-Predicate,http://schema.org/priceCurrency-input,< 1K
-Predicate,http://schema.org/priceCurrency-output,< 1K
-Predicate,http://schema.org/priceRange,1M - 10M
-Predicate,http://schema.org/priceRange-input,< 1K
-Predicate,http://schema.org/priceRange-output,< 1K
-Predicate,http://schema.org/priceSpecification,1M - 10M
-Predicate,http://schema.org/priceSpecification-input,< 1K
-Predicate,http://schema.org/priceSpecification-output,< 1K
-Predicate,http://schema.org/priceType,100K - 1M
-Predicate,http://schema.org/priceType-input,< 1K
-Predicate,http://schema.org/priceType-output,< 1K
-Predicate,http://schema.org/priceValidUntil,1M - 10M
-Predicate,http://schema.org/priceValidUntil-input,< 1K
-Predicate,http://schema.org/priceValidUntil-output,< 1K
-Predicate,http://schema.org/primaryImageOfPage,10M+
-Predicate,http://schema.org/primaryImageOfPage-input,< 1K
-Predicate,http://schema.org/primaryImageOfPage-output,< 1K
-Predicate,http://schema.org/primaryPrevention,< 1K
-Predicate,http://schema.org/primaryPrevention-input,< 1K
-Predicate,http://schema.org/primaryPrevention-output,< 1K
-Predicate,http://schema.org/printColumn,< 1K
-Predicate,http://schema.org/printColumn-input,< 1K
-Predicate,http://schema.org/printColumn-output,< 1K
-Predicate,http://schema.org/printEdition,< 1K
-Predicate,http://schema.org/printEdition-input,< 1K
-Predicate,http://schema.org/printEdition-output,< 1K
-Predicate,http://schema.org/printPage,< 1K
-Predicate,http://schema.org/printPage-input,< 1K
-Predicate,http://schema.org/printPage-output,< 1K
-Predicate,http://schema.org/printSection,< 1K
-Predicate,http://schema.org/printSection-input,< 1K
-Predicate,http://schema.org/printSection-output,< 1K
-Predicate,http://schema.org/procedure,< 1K
-Predicate,http://schema.org/procedure-input,< 1K
-Predicate,http://schema.org/procedure-output,< 1K
-Predicate,http://schema.org/procedureType,10K - 100K
-Predicate,http://schema.org/procedureType-input,< 1K
-Predicate,http://schema.org/procedureType-output,< 1K
-Predicate,http://schema.org/processingTime,< 1K
-Predicate,http://schema.org/processingTime-input,< 1K
-Predicate,http://schema.org/processingTime-output,< 1K
-Predicate,http://schema.org/processorRequirements,1K - 10K
-Predicate,http://schema.org/processorRequirements-input,< 1K
-Predicate,http://schema.org/processorRequirements-output,< 1K
-Predicate,http://schema.org/producer,1K - 10K
-Predicate,http://schema.org/producer-input,< 1K
-Predicate,http://schema.org/producer-output,< 1K
-Predicate,http://schema.org/produces,< 1K
-Predicate,http://schema.org/produces-input,< 1K
-Predicate,http://schema.org/produces-output,< 1K
-Predicate,http://schema.org/productGroupID,100K - 1M
-Predicate,http://schema.org/productGroupID-input,< 1K
-Predicate,http://schema.org/productGroupID-output,< 1K
-Predicate,http://schema.org/productID,100K - 1M
-Predicate,http://schema.org/productID-input,< 1K
-Predicate,http://schema.org/productID-output,< 1K
-Predicate,http://schema.org/productReturnDays,< 1K
-Predicate,http://schema.org/productReturnDays-input,< 1K
-Predicate,http://schema.org/productReturnDays-output,< 1K
-Predicate,http://schema.org/productReturnLink,< 1K
-Predicate,http://schema.org/productReturnLink-input,< 1K
-Predicate,http://schema.org/productReturnLink-output,< 1K
-Predicate,http://schema.org/productSupported,1K - 10K
-Predicate,http://schema.org/productSupported-input,< 1K
-Predicate,http://schema.org/productSupported-output,< 1K
-Predicate,http://schema.org/productionCompany,1K - 10K
-Predicate,http://schema.org/productionCompany-input,< 1K
-Predicate,http://schema.org/productionCompany-output,< 1K
-Predicate,http://schema.org/productionDate,10K - 100K
-Predicate,http://schema.org/productionDate-input,< 1K
-Predicate,http://schema.org/productionDate-output,< 1K
-Predicate,http://schema.org/proficiencyLevel,10K - 100K
-Predicate,http://schema.org/proficiencyLevel-input,< 1K
-Predicate,http://schema.org/proficiencyLevel-output,< 1K
-Predicate,http://schema.org/program,< 1K
-Predicate,http://schema.org/program-input,< 1K
-Predicate,http://schema.org/program-output,< 1K
-Predicate,http://schema.org/programMembershipUsed,< 1K
-Predicate,http://schema.org/programMembershipUsed-input,< 1K
-Predicate,http://schema.org/programMembershipUsed-output,< 1K
-Predicate,http://schema.org/programName,1K - 10K
-Predicate,http://schema.org/programName-input,< 1K
-Predicate,http://schema.org/programName-output,< 1K
-Predicate,http://schema.org/programPrerequisites,1K - 10K
-Predicate,http://schema.org/programPrerequisites-input,< 1K
-Predicate,http://schema.org/programPrerequisites-output,< 1K
-Predicate,http://schema.org/programType,1K - 10K
-Predicate,http://schema.org/programType-input,< 1K
-Predicate,http://schema.org/programType-output,< 1K
-Predicate,http://schema.org/programmingLanguage,1K - 10K
-Predicate,http://schema.org/programmingLanguage-input,< 1K
-Predicate,http://schema.org/programmingLanguage-output,< 1K
-Predicate,http://schema.org/programmingModel,< 1K
-Predicate,http://schema.org/programmingModel-input,< 1K
-Predicate,http://schema.org/programmingModel-output,< 1K
-Predicate,http://schema.org/pronouns,1K - 10K
-Predicate,http://schema.org/pronouns-input,< 1K
-Predicate,http://schema.org/pronouns-output,< 1K
-Predicate,http://schema.org/propertyID,10K - 100K
-Predicate,http://schema.org/propertyID-input,< 1K
-Predicate,http://schema.org/propertyID-output,< 1K
-Predicate,http://schema.org/proprietaryName,< 1K
-Predicate,http://schema.org/proprietaryName-input,< 1K
-Predicate,http://schema.org/proprietaryName-output,< 1K
-Predicate,http://schema.org/proteinContent,10K - 100K
-Predicate,http://schema.org/proteinContent-input,< 1K
-Predicate,http://schema.org/proteinContent-output,< 1K
-Predicate,http://schema.org/provider,1M - 10M
-Predicate,http://schema.org/provider-input,< 1K
-Predicate,http://schema.org/provider-output,< 1K
-Predicate,http://schema.org/providerMobility,1K - 10K
-Predicate,http://schema.org/providerMobility-input,< 1K
-Predicate,http://schema.org/providerMobility-output,< 1K
-Predicate,http://schema.org/providesBroadcastService,< 1K
-Predicate,http://schema.org/providesBroadcastService-input,< 1K
-Predicate,http://schema.org/providesBroadcastService-output,< 1K
-Predicate,http://schema.org/providesService,< 1K
-Predicate,http://schema.org/providesService-input,< 1K
-Predicate,http://schema.org/providesService-output,< 1K
-Predicate,http://schema.org/publicAccess,10K - 100K
-Predicate,http://schema.org/publicAccess-input,< 1K
-Predicate,http://schema.org/publicAccess-output,< 1K
-Predicate,http://schema.org/publicTransportClosuresInfo,< 1K
-Predicate,http://schema.org/publicTransportClosuresInfo-input,< 1K
-Predicate,http://schema.org/publicTransportClosuresInfo-output,< 1K
-Predicate,http://schema.org/publication,1K - 10K
-Predicate,http://schema.org/publication-input,< 1K
-Predicate,http://schema.org/publication-output,< 1K
-Predicate,http://schema.org/publicationType,< 1K
-Predicate,http://schema.org/publicationType-input,< 1K
-Predicate,http://schema.org/publicationType-output,< 1K
-Predicate,http://schema.org/publishedBy,< 1K
-Predicate,http://schema.org/publishedBy-input,< 1K
-Predicate,http://schema.org/publishedBy-output,< 1K
-Predicate,http://schema.org/publishedOn,< 1K
-Predicate,http://schema.org/publishedOn-input,< 1K
-Predicate,http://schema.org/publishedOn-output,< 1K
-Predicate,http://schema.org/publisher,10M+
-Predicate,http://schema.org/publisher-input,< 1K
-Predicate,http://schema.org/publisher-output,< 1K
-Predicate,http://schema.org/publisherImprint,< 1K
-Predicate,http://schema.org/publisherImprint-input,< 1K
-Predicate,http://schema.org/publisherImprint-output,< 1K
-Predicate,http://schema.org/publishingPrinciples,10K - 100K
-Predicate,http://schema.org/publishingPrinciples-input,< 1K
-Predicate,http://schema.org/publishingPrinciples-output,< 1K
-Predicate,http://schema.org/purchaseDate,1K - 10K
-Predicate,http://schema.org/purchaseDate-input,< 1K
-Predicate,http://schema.org/purchaseDate-output,< 1K
-Predicate,http://schema.org/purchasePriceLimit,< 1K
-Predicate,http://schema.org/purchasePriceLimit-input,< 1K
-Predicate,http://schema.org/purchasePriceLimit-output,< 1K
-Predicate,http://schema.org/purchaseType,< 1K
-Predicate,http://schema.org/purchaseType-input,< 1K
-Predicate,http://schema.org/purchaseType-output,< 1K
-Predicate,http://schema.org/qualifications,10K - 100K
-Predicate,http://schema.org/qualifications-input,< 1K
-Predicate,http://schema.org/qualifications-output,< 1K
-Predicate,http://schema.org/qualifiedExpense,< 1K
-Predicate,http://schema.org/qualifiedExpense-input,< 1K
-Predicate,http://schema.org/qualifiedExpense-output,< 1K
-Predicate,http://schema.org/quarantineGuidelines,< 1K
-Predicate,http://schema.org/quarantineGuidelines-input,< 1K
-Predicate,http://schema.org/quarantineGuidelines-output,< 1K
-Predicate,http://schema.org/query,10K - 100K
-Predicate,http://schema.org/query-input,10M+
-Predicate,http://schema.org/query-output,< 1K
-Predicate,http://schema.org/quest,< 1K
-Predicate,http://schema.org/quest-input,< 1K
-Predicate,http://schema.org/quest-output,< 1K
-Predicate,http://schema.org/question,1K - 10K
-Predicate,http://schema.org/question-input,< 1K
-Predicate,http://schema.org/question-output,< 1K
-Predicate,http://schema.org/rangeIncludes,< 1K
-Predicate,http://schema.org/rangeIncludes-input,< 1K
-Predicate,http://schema.org/rangeIncludes-output,< 1K
-Predicate,http://schema.org/ratingCount,1M - 10M
-Predicate,http://schema.org/ratingCount-input,< 1K
-Predicate,http://schema.org/ratingCount-output,< 1K
-Predicate,http://schema.org/ratingExplanation,1K - 10K
-Predicate,http://schema.org/ratingExplanation-input,< 1K
-Predicate,http://schema.org/ratingExplanation-output,< 1K
-Predicate,http://schema.org/ratingValue,1M - 10M
-Predicate,http://schema.org/ratingValue-input,< 1K
-Predicate,http://schema.org/ratingValue-output,< 1K
-Predicate,http://schema.org/readBy,< 1K
-Predicate,http://schema.org/readBy-input,< 1K
-Predicate,http://schema.org/readBy-output,< 1K
-Predicate,http://schema.org/readonlyValue,< 1K
-Predicate,http://schema.org/readonlyValue-input,< 1K
-Predicate,http://schema.org/readonlyValue-output,< 1K
-Predicate,http://schema.org/realEstateAgent,< 1K
-Predicate,http://schema.org/realEstateAgent-input,< 1K
-Predicate,http://schema.org/realEstateAgent-output,< 1K
-Predicate,http://schema.org/recipe,< 1K
-Predicate,http://schema.org/recipe-input,< 1K
-Predicate,http://schema.org/recipe-output,< 1K
-Predicate,http://schema.org/recipeCategory,10K - 100K
-Predicate,http://schema.org/recipeCategory-input,< 1K
-Predicate,http://schema.org/recipeCategory-output,< 1K
-Predicate,http://schema.org/recipeCuisine,10K - 100K
-Predicate,http://schema.org/recipeCuisine-input,< 1K
-Predicate,http://schema.org/recipeCuisine-output,< 1K
-Predicate,http://schema.org/recipeIngredient,10K - 100K
-Predicate,http://schema.org/recipeIngredient-input,< 1K
-Predicate,http://schema.org/recipeIngredient-output,< 1K
-Predicate,http://schema.org/recipeInstructions,10K - 100K
-Predicate,http://schema.org/recipeInstructions-input,< 1K
-Predicate,http://schema.org/recipeInstructions-output,< 1K
-Predicate,http://schema.org/recipeYield,10K - 100K
-Predicate,http://schema.org/recipeYield-input,< 1K
-Predicate,http://schema.org/recipeYield-output,< 1K
-Predicate,http://schema.org/recipient,1K - 10K
-Predicate,http://schema.org/recipient-input,< 1K
-Predicate,http://schema.org/recipient-output,< 1K
-Predicate,http://schema.org/recognizedBy,10K - 100K
-Predicate,http://schema.org/recognizedBy-input,< 1K
-Predicate,http://schema.org/recognizedBy-output,< 1K
-Predicate,http://schema.org/recognizingAuthority,1K - 10K
-Predicate,http://schema.org/recognizingAuthority-input,< 1K
-Predicate,http://schema.org/recognizingAuthority-output,< 1K
-Predicate,http://schema.org/recommendationStrength,< 1K
-Predicate,http://schema.org/recommendationStrength-input,< 1K
-Predicate,http://schema.org/recommendationStrength-output,< 1K
-Predicate,http://schema.org/recommendedIntake,< 1K
-Predicate,http://schema.org/recommendedIntake-input,< 1K
-Predicate,http://schema.org/recommendedIntake-output,< 1K
-Predicate,http://schema.org/recordLabel,1K - 10K
-Predicate,http://schema.org/recordLabel-input,< 1K
-Predicate,http://schema.org/recordLabel-output,< 1K
-Predicate,http://schema.org/recordedAs,< 1K
-Predicate,http://schema.org/recordedAs-input,< 1K
-Predicate,http://schema.org/recordedAs-output,< 1K
-Predicate,http://schema.org/recordedAt,< 1K
-Predicate,http://schema.org/recordedAt-input,< 1K
-Predicate,http://schema.org/recordedAt-output,< 1K
-Predicate,http://schema.org/recordedIn,< 1K
-Predicate,http://schema.org/recordedIn-input,< 1K
-Predicate,http://schema.org/recordedIn-output,< 1K
-Predicate,http://schema.org/recordingOf,1K - 10K
-Predicate,http://schema.org/recordingOf-input,< 1K
-Predicate,http://schema.org/recordingOf-output,< 1K
-Predicate,http://schema.org/recourseLoan,< 1K
-Predicate,http://schema.org/recourseLoan-input,< 1K
-Predicate,http://schema.org/recourseLoan-output,< 1K
-Predicate,http://schema.org/referee,< 1K
-Predicate,http://schema.org/referee-input,< 1K
-Predicate,http://schema.org/referee-output,< 1K
-Predicate,http://schema.org/referenceQuantity,1M - 10M
-Predicate,http://schema.org/referenceQuantity-input,< 1K
-Predicate,http://schema.org/referenceQuantity-output,< 1K
-Predicate,http://schema.org/referencesOrder,< 1K
-Predicate,http://schema.org/referencesOrder-input,< 1K
-Predicate,http://schema.org/referencesOrder-output,< 1K
-Predicate,http://schema.org/refundType,10K - 100K
-Predicate,http://schema.org/refundType-input,< 1K
-Predicate,http://schema.org/refundType-output,< 1K
-Predicate,http://schema.org/regionDrained,< 1K
-Predicate,http://schema.org/regionDrained-input,< 1K
-Predicate,http://schema.org/regionDrained-output,< 1K
-Predicate,http://schema.org/regionsAllowed,10K - 100K
-Predicate,http://schema.org/regionsAllowed-input,< 1K
-Predicate,http://schema.org/regionsAllowed-output,< 1K
-Predicate,http://schema.org/relatedAnatomy,< 1K
-Predicate,http://schema.org/relatedAnatomy-input,< 1K
-Predicate,http://schema.org/relatedAnatomy-output,< 1K
-Predicate,http://schema.org/relatedCondition,< 1K
-Predicate,http://schema.org/relatedCondition-input,< 1K
-Predicate,http://schema.org/relatedCondition-output,< 1K
-Predicate,http://schema.org/relatedDrug,< 1K
-Predicate,http://schema.org/relatedDrug-input,< 1K
-Predicate,http://schema.org/relatedDrug-output,< 1K
-Predicate,http://schema.org/relatedLink,10K - 100K
-Predicate,http://schema.org/relatedLink-input,< 1K
-Predicate,http://schema.org/relatedLink-output,< 1K
-Predicate,http://schema.org/relatedStructure,< 1K
-Predicate,http://schema.org/relatedStructure-input,< 1K
-Predicate,http://schema.org/relatedStructure-output,< 1K
-Predicate,http://schema.org/relatedTherapy,< 1K
-Predicate,http://schema.org/relatedTherapy-input,< 1K
-Predicate,http://schema.org/relatedTherapy-output,< 1K
-Predicate,http://schema.org/relatedTo,< 1K
-Predicate,http://schema.org/relatedTo-input,< 1K
-Predicate,http://schema.org/relatedTo-output,< 1K
-Predicate,http://schema.org/releaseDate,10K - 100K
-Predicate,http://schema.org/releaseDate-input,< 1K
-Predicate,http://schema.org/releaseDate-output,< 1K
-Predicate,http://schema.org/releaseNotes,10K - 100K
-Predicate,http://schema.org/releaseNotes-input,< 1K
-Predicate,http://schema.org/releaseNotes-output,< 1K
-Predicate,http://schema.org/releaseOf,< 1K
-Predicate,http://schema.org/releaseOf-input,< 1K
-Predicate,http://schema.org/releaseOf-output,< 1K
-Predicate,http://schema.org/releasedEvent,1K - 10K
-Predicate,http://schema.org/releasedEvent-input,< 1K
-Predicate,http://schema.org/releasedEvent-output,< 1K
-Predicate,http://schema.org/relevantOccupation,< 1K
-Predicate,http://schema.org/relevantOccupation-input,< 1K
-Predicate,http://schema.org/relevantOccupation-output,< 1K
-Predicate,http://schema.org/relevantSpecialty,10K - 100K
-Predicate,http://schema.org/relevantSpecialty-input,< 1K
-Predicate,http://schema.org/relevantSpecialty-output,< 1K
-Predicate,http://schema.org/remainingAttendeeCapacity,1K - 10K
-Predicate,http://schema.org/remainingAttendeeCapacity-input,< 1K
-Predicate,http://schema.org/remainingAttendeeCapacity-output,< 1K
-Predicate,http://schema.org/renegotiableLoan,< 1K
-Predicate,http://schema.org/renegotiableLoan-input,< 1K
-Predicate,http://schema.org/renegotiableLoan-output,< 1K
-Predicate,http://schema.org/repeatCount,1K - 10K
-Predicate,http://schema.org/repeatCount-input,< 1K
-Predicate,http://schema.org/repeatCount-output,< 1K
-Predicate,http://schema.org/repeatFrequency,10K - 100K
-Predicate,http://schema.org/repeatFrequency-input,< 1K
-Predicate,http://schema.org/repeatFrequency-output,< 1K
-Predicate,http://schema.org/repetitions,< 1K
-Predicate,http://schema.org/repetitions-input,< 1K
-Predicate,http://schema.org/repetitions-output,< 1K
-Predicate,http://schema.org/replacee,< 1K
-Predicate,http://schema.org/replacee-input,< 1K
-Predicate,http://schema.org/replacee-output,< 1K
-Predicate,http://schema.org/replacer,< 1K
-Predicate,http://schema.org/replacer-input,< 1K
-Predicate,http://schema.org/replacer-output,< 1K
-Predicate,http://schema.org/replyToUrl,1K - 10K
-Predicate,http://schema.org/replyToUrl-input,< 1K
-Predicate,http://schema.org/replyToUrl-output,< 1K
-Predicate,http://schema.org/reportNumber,< 1K
-Predicate,http://schema.org/reportNumber-input,< 1K
-Predicate,http://schema.org/reportNumber-output,< 1K
-Predicate,http://schema.org/representativeOfPage,100K - 1M
-Predicate,http://schema.org/representativeOfPage-input,< 1K
-Predicate,http://schema.org/representativeOfPage-output,< 1K
-Predicate,http://schema.org/requiredCollateral,< 1K
-Predicate,http://schema.org/requiredCollateral-input,< 1K
-Predicate,http://schema.org/requiredCollateral-output,< 1K
-Predicate,http://schema.org/requiredGender,< 1K
-Predicate,http://schema.org/requiredGender-input,< 1K
-Predicate,http://schema.org/requiredGender-output,< 1K
-Predicate,http://schema.org/requiredMaxAge,< 1K
-Predicate,http://schema.org/requiredMaxAge-input,< 1K
-Predicate,http://schema.org/requiredMaxAge-output,< 1K
-Predicate,http://schema.org/requiredMinAge,1K - 10K
-Predicate,http://schema.org/requiredMinAge-input,< 1K
-Predicate,http://schema.org/requiredMinAge-output,< 1K
-Predicate,http://schema.org/requiredQuantity,1K - 10K
-Predicate,http://schema.org/requiredQuantity-input,< 1K
-Predicate,http://schema.org/requiredQuantity-output,< 1K
-Predicate,http://schema.org/requirements,1K - 10K
-Predicate,http://schema.org/requirements-input,< 1K
-Predicate,http://schema.org/requirements-output,< 1K
-Predicate,http://schema.org/requiresSubscription,1K - 10K
-Predicate,http://schema.org/requiresSubscription-input,< 1K
-Predicate,http://schema.org/requiresSubscription-output,< 1K
-Predicate,http://schema.org/reservationFor,1K - 10K
-Predicate,http://schema.org/reservationFor-input,< 1K
-Predicate,http://schema.org/reservationFor-output,< 1K
-Predicate,http://schema.org/reservationId,< 1K
-Predicate,http://schema.org/reservationId-input,< 1K
-Predicate,http://schema.org/reservationId-output,< 1K
-Predicate,http://schema.org/reservationStatus,< 1K
-Predicate,http://schema.org/reservationStatus-input,< 1K
-Predicate,http://schema.org/reservationStatus-output,< 1K
-Predicate,http://schema.org/reservedTicket,< 1K
-Predicate,http://schema.org/reservedTicket-input,< 1K
-Predicate,http://schema.org/reservedTicket-output,< 1K
-Predicate,http://schema.org/responsibilities,10K - 100K
-Predicate,http://schema.org/responsibilities-input,< 1K
-Predicate,http://schema.org/responsibilities-output,< 1K
-Predicate,http://schema.org/restPeriods,< 1K
-Predicate,http://schema.org/restPeriods-input,< 1K
-Predicate,http://schema.org/restPeriods-output,< 1K
-Predicate,http://schema.org/restockingFee,1K - 10K
-Predicate,http://schema.org/restockingFee-input,< 1K
-Predicate,http://schema.org/restockingFee-output,< 1K
-Predicate,http://schema.org/result,10K - 100K
-Predicate,http://schema.org/result-input,< 1K
-Predicate,http://schema.org/result-output,< 1K
-Predicate,http://schema.org/resultComment,< 1K
-Predicate,http://schema.org/resultComment-input,< 1K
-Predicate,http://schema.org/resultComment-output,< 1K
-Predicate,http://schema.org/resultReview,< 1K
-Predicate,http://schema.org/resultReview-input,< 1K
-Predicate,http://schema.org/resultReview-output,< 1K
-Predicate,http://schema.org/returnFees,100K - 1M
-Predicate,http://schema.org/returnFees-input,< 1K
-Predicate,http://schema.org/returnFees-output,< 1K
-Predicate,http://schema.org/returnLabelSource,1K - 10K
-Predicate,http://schema.org/returnLabelSource-input,< 1K
-Predicate,http://schema.org/returnLabelSource-output,< 1K
-Predicate,http://schema.org/returnMethod,100K - 1M
-Predicate,http://schema.org/returnMethod-input,< 1K
-Predicate,http://schema.org/returnMethod-output,< 1K
-Predicate,http://schema.org/returnPolicyCategory,100K - 1M
-Predicate,http://schema.org/returnPolicyCategory-input,< 1K
-Predicate,http://schema.org/returnPolicyCategory-output,< 1K
-Predicate,http://schema.org/returnPolicyCountry,10K - 100K
-Predicate,http://schema.org/returnPolicyCountry-input,< 1K
-Predicate,http://schema.org/returnPolicyCountry-output,< 1K
-Predicate,http://schema.org/returnPolicySeasonalOverride,1K - 10K
-Predicate,http://schema.org/returnPolicySeasonalOverride-input,< 1K
-Predicate,http://schema.org/returnPolicySeasonalOverride-output,< 1K
-Predicate,http://schema.org/returnShippingFeesAmount,10K - 100K
-Predicate,http://schema.org/returnShippingFeesAmount-input,< 1K
-Predicate,http://schema.org/returnShippingFeesAmount-output,< 1K
-Predicate,http://schema.org/review,1M - 10M
-Predicate,http://schema.org/review-input,< 1K
-Predicate,http://schema.org/review-output,< 1K
-Predicate,http://schema.org/reviewAspect,10K - 100K
-Predicate,http://schema.org/reviewAspect-input,< 1K
-Predicate,http://schema.org/reviewAspect-output,< 1K
-Predicate,http://schema.org/reviewBody,1M - 10M
-Predicate,http://schema.org/reviewBody-input,< 1K
-Predicate,http://schema.org/reviewBody-output,< 1K
-Predicate,http://schema.org/reviewCount,1M - 10M
-Predicate,http://schema.org/reviewCount-input,< 1K
-Predicate,http://schema.org/reviewCount-output,< 1K
-Predicate,http://schema.org/reviewRating,1M - 10M
-Predicate,http://schema.org/reviewRating-input,< 1K
-Predicate,http://schema.org/reviewRating-output,< 1K
-Predicate,http://schema.org/reviewedBy,10K - 100K
-Predicate,http://schema.org/reviewedBy-input,< 1K
-Predicate,http://schema.org/reviewedBy-output,< 1K
-Predicate,http://schema.org/reviews,1K - 10K
-Predicate,http://schema.org/reviews-input,< 1K
-Predicate,http://schema.org/reviews-output,< 1K
-Predicate,http://schema.org/riskFactor,1K - 10K
-Predicate,http://schema.org/riskFactor-input,< 1K
-Predicate,http://schema.org/riskFactor-output,< 1K
-Predicate,http://schema.org/risks,< 1K
-Predicate,http://schema.org/risks-input,< 1K
-Predicate,http://schema.org/risks-output,< 1K
-Predicate,http://schema.org/roleName,1K - 10K
-Predicate,http://schema.org/roleName-input,< 1K
-Predicate,http://schema.org/roleName-output,< 1K
-Predicate,http://schema.org/roofLoad,< 1K
-Predicate,http://schema.org/roofLoad-input,< 1K
-Predicate,http://schema.org/roofLoad-output,< 1K
-Predicate,http://schema.org/rsvpResponse,< 1K
-Predicate,http://schema.org/rsvpResponse-input,< 1K
-Predicate,http://schema.org/rsvpResponse-output,< 1K
-Predicate,http://schema.org/runsTo,< 1K
-Predicate,http://schema.org/runsTo-input,< 1K
-Predicate,http://schema.org/runsTo-output,< 1K
-Predicate,http://schema.org/runtime,< 1K
-Predicate,http://schema.org/runtime-input,< 1K
-Predicate,http://schema.org/runtime-output,< 1K
-Predicate,http://schema.org/runtimePlatform,1K - 10K
-Predicate,http://schema.org/runtimePlatform-input,< 1K
-Predicate,http://schema.org/runtimePlatform-output,< 1K
-Predicate,http://schema.org/rxcui,< 1K
-Predicate,http://schema.org/rxcui-input,< 1K
-Predicate,http://schema.org/rxcui-output,< 1K
-Predicate,http://schema.org/safetyConsideration,< 1K
-Predicate,http://schema.org/safetyConsideration-input,< 1K
-Predicate,http://schema.org/safetyConsideration-output,< 1K
-Predicate,http://schema.org/salaryCurrency,1K - 10K
-Predicate,http://schema.org/salaryCurrency-input,< 1K
-Predicate,http://schema.org/salaryCurrency-output,< 1K
-Predicate,http://schema.org/salaryUponCompletion,< 1K
-Predicate,http://schema.org/salaryUponCompletion-input,< 1K
-Predicate,http://schema.org/salaryUponCompletion-output,< 1K
-Predicate,http://schema.org/sameAs,10M+
-Predicate,http://schema.org/sameAs-input,< 1K
-Predicate,http://schema.org/sameAs-output,< 1K
-Predicate,http://schema.org/sampleType,< 1K
-Predicate,http://schema.org/sampleType-input,< 1K
-Predicate,http://schema.org/sampleType-output,< 1K
-Predicate,http://schema.org/saturatedFatContent,10K - 100K
-Predicate,http://schema.org/saturatedFatContent-input,< 1K
-Predicate,http://schema.org/saturatedFatContent-output,< 1K
-Predicate,http://schema.org/scheduleTimezone,1K - 10K
-Predicate,http://schema.org/scheduleTimezone-input,< 1K
-Predicate,http://schema.org/scheduleTimezone-output,< 1K
-Predicate,http://schema.org/scheduledPaymentDate,< 1K
-Predicate,http://schema.org/scheduledPaymentDate-input,< 1K
-Predicate,http://schema.org/scheduledPaymentDate-output,< 1K
-Predicate,http://schema.org/scheduledTime,< 1K
-Predicate,http://schema.org/scheduledTime-input,< 1K
-Predicate,http://schema.org/scheduledTime-output,< 1K
-Predicate,http://schema.org/schemaVersion,< 1K
-Predicate,http://schema.org/schemaVersion-input,< 1K
-Predicate,http://schema.org/schemaVersion-output,< 1K
-Predicate,http://schema.org/schoolClosuresInfo,< 1K
-Predicate,http://schema.org/schoolClosuresInfo-input,< 1K
-Predicate,http://schema.org/schoolClosuresInfo-output,< 1K
-Predicate,http://schema.org/screenCount,< 1K
-Predicate,http://schema.org/screenCount-input,< 1K
-Predicate,http://schema.org/screenCount-output,< 1K
-Predicate,http://schema.org/screenshot,100K - 1M
-Predicate,http://schema.org/screenshot-input,< 1K
-Predicate,http://schema.org/screenshot-output,< 1K
-Predicate,http://schema.org/sdDatePublished,1K - 10K
-Predicate,http://schema.org/sdDatePublished-input,< 1K
-Predicate,http://schema.org/sdDatePublished-output,< 1K
-Predicate,http://schema.org/sdLicense,< 1K
-Predicate,http://schema.org/sdLicense-input,< 1K
-Predicate,http://schema.org/sdLicense-output,< 1K
-Predicate,http://schema.org/sdPublisher,1K - 10K
-Predicate,http://schema.org/sdPublisher-input,< 1K
-Predicate,http://schema.org/sdPublisher-output,< 1K
-Predicate,http://schema.org/season,1K - 10K
-Predicate,http://schema.org/season-input,< 1K
-Predicate,http://schema.org/season-output,< 1K
-Predicate,http://schema.org/seasonNumber,1K - 10K
-Predicate,http://schema.org/seasonNumber-input,< 1K
-Predicate,http://schema.org/seasonNumber-output,< 1K
-Predicate,http://schema.org/seasonalOverride,< 1K
-Predicate,http://schema.org/seasonalOverride-input,< 1K
-Predicate,http://schema.org/seasonalOverride-output,< 1K
-Predicate,http://schema.org/seasons,< 1K
-Predicate,http://schema.org/seasons-input,< 1K
-Predicate,http://schema.org/seasons-output,< 1K
-Predicate,http://schema.org/seatNumber,< 1K
-Predicate,http://schema.org/seatNumber-input,< 1K
-Predicate,http://schema.org/seatNumber-output,< 1K
-Predicate,http://schema.org/seatRow,< 1K
-Predicate,http://schema.org/seatRow-input,< 1K
-Predicate,http://schema.org/seatRow-output,< 1K
-Predicate,http://schema.org/seatSection,< 1K
-Predicate,http://schema.org/seatSection-input,< 1K
-Predicate,http://schema.org/seatSection-output,< 1K
-Predicate,http://schema.org/seatingCapacity,1K - 10K
-Predicate,http://schema.org/seatingCapacity-input,< 1K
-Predicate,http://schema.org/seatingCapacity-output,< 1K
-Predicate,http://schema.org/seatingType,< 1K
-Predicate,http://schema.org/seatingType-input,< 1K
-Predicate,http://schema.org/seatingType-output,< 1K
-Predicate,http://schema.org/secondaryPrevention,< 1K
-Predicate,http://schema.org/secondaryPrevention-input,< 1K
-Predicate,http://schema.org/secondaryPrevention-output,< 1K
-Predicate,http://schema.org/securityClearanceRequirement,< 1K
-Predicate,http://schema.org/securityClearanceRequirement-input,< 1K
-Predicate,http://schema.org/securityClearanceRequirement-output,< 1K
-Predicate,http://schema.org/securityScreening,< 1K
-Predicate,http://schema.org/securityScreening-input,< 1K
-Predicate,http://schema.org/securityScreening-output,< 1K
-Predicate,http://schema.org/seeks,1K - 10K
-Predicate,http://schema.org/seeks-input,< 1K
-Predicate,http://schema.org/seeks-output,< 1K
-Predicate,http://schema.org/seller,1M - 10M
-Predicate,http://schema.org/seller-input,< 1K
-Predicate,http://schema.org/seller-output,< 1K
-Predicate,http://schema.org/sender,< 1K
-Predicate,http://schema.org/sender-input,< 1K
-Predicate,http://schema.org/sender-output,< 1K
-Predicate,http://schema.org/sensoryRequirement,< 1K
-Predicate,http://schema.org/sensoryRequirement-input,< 1K
-Predicate,http://schema.org/sensoryRequirement-output,< 1K
-Predicate,http://schema.org/sensoryUnit,< 1K
-Predicate,http://schema.org/sensoryUnit-input,< 1K
-Predicate,http://schema.org/sensoryUnit-output,< 1K
-Predicate,http://schema.org/serialNumber,10K - 100K
-Predicate,http://schema.org/serialNumber-input,< 1K
-Predicate,http://schema.org/serialNumber-output,< 1K
-Predicate,http://schema.org/seriousAdverseOutcome,< 1K
-Predicate,http://schema.org/seriousAdverseOutcome-input,< 1K
-Predicate,http://schema.org/seriousAdverseOutcome-output,< 1K
-Predicate,http://schema.org/serverStatus,< 1K
-Predicate,http://schema.org/serverStatus-input,< 1K
-Predicate,http://schema.org/serverStatus-output,< 1K
-Predicate,http://schema.org/servesCuisine,100K - 1M
-Predicate,http://schema.org/servesCuisine-input,< 1K
-Predicate,http://schema.org/servesCuisine-output,< 1K
-Predicate,http://schema.org/serviceArea,10K - 100K
-Predicate,http://schema.org/serviceArea-input,< 1K
-Predicate,http://schema.org/serviceArea-output,< 1K
-Predicate,http://schema.org/serviceAudience,1K - 10K
-Predicate,http://schema.org/serviceAudience-input,< 1K
-Predicate,http://schema.org/serviceAudience-output,< 1K
-Predicate,http://schema.org/serviceLocation,10K - 100K
-Predicate,http://schema.org/serviceLocation-input,< 1K
-Predicate,http://schema.org/serviceLocation-output,< 1K
-Predicate,http://schema.org/serviceOperator,1K - 10K
-Predicate,http://schema.org/serviceOperator-input,< 1K
-Predicate,http://schema.org/serviceOperator-output,< 1K
-Predicate,http://schema.org/serviceOutput,10K - 100K
-Predicate,http://schema.org/serviceOutput-input,< 1K
-Predicate,http://schema.org/serviceOutput-output,< 1K
-Predicate,http://schema.org/servicePhone,10K - 100K
-Predicate,http://schema.org/servicePhone-input,< 1K
-Predicate,http://schema.org/servicePhone-output,< 1K
-Predicate,http://schema.org/servicePostalAddress,< 1K
-Predicate,http://schema.org/servicePostalAddress-input,< 1K
-Predicate,http://schema.org/servicePostalAddress-output,< 1K
-Predicate,http://schema.org/serviceSmsNumber,1K - 10K
-Predicate,http://schema.org/serviceSmsNumber-input,< 1K
-Predicate,http://schema.org/serviceSmsNumber-output,< 1K
-Predicate,http://schema.org/serviceType,1M - 10M
-Predicate,http://schema.org/serviceType-input,< 1K
-Predicate,http://schema.org/serviceType-output,< 1K
-Predicate,http://schema.org/serviceUrl,10K - 100K
-Predicate,http://schema.org/serviceUrl-input,< 1K
-Predicate,http://schema.org/serviceUrl-output,< 1K
-Predicate,http://schema.org/servingSize,10K - 100K
-Predicate,http://schema.org/servingSize-input,< 1K
-Predicate,http://schema.org/servingSize-output,< 1K
-Predicate,http://schema.org/sha256,< 1K
-Predicate,http://schema.org/sha256-input,< 1K
-Predicate,http://schema.org/sha256-output,< 1K
-Predicate,http://schema.org/sharedContent,1K - 10K
-Predicate,http://schema.org/sharedContent-input,< 1K
-Predicate,http://schema.org/sharedContent-output,< 1K
-Predicate,http://schema.org/shippingConditions,10K - 100K
-Predicate,http://schema.org/shippingConditions-input,< 1K
-Predicate,http://schema.org/shippingConditions-output,< 1K
-Predicate,http://schema.org/shippingDestination,100K - 1M
-Predicate,http://schema.org/shippingDestination-input,< 1K
-Predicate,http://schema.org/shippingDestination-output,< 1K
-Predicate,http://schema.org/shippingDetails,100K - 1M
-Predicate,http://schema.org/shippingDetails-input,< 1K
-Predicate,http://schema.org/shippingDetails-output,< 1K
-Predicate,http://schema.org/shippingLabel,1K - 10K
-Predicate,http://schema.org/shippingLabel-input,< 1K
-Predicate,http://schema.org/shippingLabel-output,< 1K
-Predicate,http://schema.org/shippingOrigin,10K - 100K
-Predicate,http://schema.org/shippingOrigin-input,< 1K
-Predicate,http://schema.org/shippingOrigin-output,< 1K
-Predicate,http://schema.org/shippingRate,100K - 1M
-Predicate,http://schema.org/shippingRate-input,< 1K
-Predicate,http://schema.org/shippingRate-output,< 1K
-Predicate,http://schema.org/shippingSettingsLink,1K - 10K
-Predicate,http://schema.org/shippingSettingsLink-input,< 1K
-Predicate,http://schema.org/shippingSettingsLink-output,< 1K
-Predicate,http://schema.org/sibling,< 1K
-Predicate,http://schema.org/sibling-input,< 1K
-Predicate,http://schema.org/sibling-output,< 1K
-Predicate,http://schema.org/siblings,< 1K
-Predicate,http://schema.org/siblings-input,< 1K
-Predicate,http://schema.org/siblings-output,< 1K
-Predicate,http://schema.org/signDetected,< 1K
-Predicate,http://schema.org/signDetected-input,< 1K
-Predicate,http://schema.org/signDetected-output,< 1K
-Predicate,http://schema.org/signOrSymptom,1K - 10K
-Predicate,http://schema.org/signOrSymptom-input,< 1K
-Predicate,http://schema.org/signOrSymptom-output,< 1K
-Predicate,http://schema.org/significance,< 1K
-Predicate,http://schema.org/significance-input,< 1K
-Predicate,http://schema.org/significance-output,< 1K
-Predicate,http://schema.org/significantLink,10K - 100K
-Predicate,http://schema.org/significantLink-input,< 1K
-Predicate,http://schema.org/significantLink-output,< 1K
-Predicate,http://schema.org/significantLinks,1K - 10K
-Predicate,http://schema.org/significantLinks-input,< 1K
-Predicate,http://schema.org/significantLinks-output,< 1K
-Predicate,http://schema.org/size,10K - 100K
-Predicate,http://schema.org/size-input,< 1K
-Predicate,http://schema.org/size-output,< 1K
-Predicate,http://schema.org/sizeGroup,< 1K
-Predicate,http://schema.org/sizeGroup-input,< 1K
-Predicate,http://schema.org/sizeGroup-output,< 1K
-Predicate,http://schema.org/sizeSystem,< 1K
-Predicate,http://schema.org/sizeSystem-input,< 1K
-Predicate,http://schema.org/sizeSystem-output,< 1K
-Predicate,http://schema.org/skills,10K - 100K
-Predicate,http://schema.org/skills-input,< 1K
-Predicate,http://schema.org/skills-output,< 1K
-Predicate,http://schema.org/sku,1M - 10M
-Predicate,http://schema.org/sku-input,< 1K
-Predicate,http://schema.org/sku-output,< 1K
-Predicate,http://schema.org/slogan,100K - 1M
-Predicate,http://schema.org/slogan-input,< 1K
-Predicate,http://schema.org/slogan-output,< 1K
-Predicate,http://schema.org/smiles,< 1K
-Predicate,http://schema.org/smiles-input,< 1K
-Predicate,http://schema.org/smiles-output,< 1K
-Predicate,http://schema.org/smokingAllowed,10K - 100K
-Predicate,http://schema.org/smokingAllowed-input,< 1K
-Predicate,http://schema.org/smokingAllowed-output,< 1K
-Predicate,http://schema.org/sodiumContent,10K - 100K
-Predicate,http://schema.org/sodiumContent-input,< 1K
-Predicate,http://schema.org/sodiumContent-output,< 1K
-Predicate,http://schema.org/softwareAddOn,< 1K
-Predicate,http://schema.org/softwareAddOn-input,< 1K
-Predicate,http://schema.org/softwareAddOn-output,< 1K
-Predicate,http://schema.org/softwareHelp,10K - 100K
-Predicate,http://schema.org/softwareHelp-input,< 1K
-Predicate,http://schema.org/softwareHelp-output,< 1K
-Predicate,http://schema.org/softwareRequirements,10K - 100K
-Predicate,http://schema.org/softwareRequirements-input,< 1K
-Predicate,http://schema.org/softwareRequirements-output,< 1K
-Predicate,http://schema.org/softwareVersion,100K - 1M
-Predicate,http://schema.org/softwareVersion-input,< 1K
-Predicate,http://schema.org/softwareVersion-output,< 1K
-Predicate,http://schema.org/source,1K - 10K
-Predicate,http://schema.org/source-input,< 1K
-Predicate,http://schema.org/source-output,< 1K
-Predicate,http://schema.org/sourceOrganization,10K - 100K
-Predicate,http://schema.org/sourceOrganization-input,< 1K
-Predicate,http://schema.org/sourceOrganization-output,< 1K
-Predicate,http://schema.org/sourcedFrom,< 1K
-Predicate,http://schema.org/sourcedFrom-input,< 1K
-Predicate,http://schema.org/sourcedFrom-output,< 1K
-Predicate,http://schema.org/spatial,1K - 10K
-Predicate,http://schema.org/spatial-input,< 1K
-Predicate,http://schema.org/spatial-output,< 1K
-Predicate,http://schema.org/spatialCoverage,10K - 100K
-Predicate,http://schema.org/spatialCoverage-input,< 1K
-Predicate,http://schema.org/spatialCoverage-output,< 1K
-Predicate,http://schema.org/speakable,100K - 1M
-Predicate,http://schema.org/speakable-input,< 1K
-Predicate,http://schema.org/speakable-output,< 1K
-Predicate,http://schema.org/specialCommitments,1K - 10K
-Predicate,http://schema.org/specialCommitments-input,< 1K
-Predicate,http://schema.org/specialCommitments-output,< 1K
-Predicate,http://schema.org/specialOpeningHoursSpecification,1K - 10K
-Predicate,http://schema.org/specialOpeningHoursSpecification-input,< 1K
-Predicate,http://schema.org/specialOpeningHoursSpecification-output,< 1K
-Predicate,http://schema.org/specialty,10K - 100K
-Predicate,http://schema.org/specialty-input,< 1K
-Predicate,http://schema.org/specialty-output,< 1K
-Predicate,http://schema.org/speechToTextMarkup,< 1K
-Predicate,http://schema.org/speechToTextMarkup-input,< 1K
-Predicate,http://schema.org/speechToTextMarkup-output,< 1K
-Predicate,http://schema.org/speed,1K - 10K
-Predicate,http://schema.org/speed-input,< 1K
-Predicate,http://schema.org/speed-output,< 1K
-Predicate,http://schema.org/spokenByCharacter,1K - 10K
-Predicate,http://schema.org/spokenByCharacter-input,< 1K
-Predicate,http://schema.org/spokenByCharacter-output,< 1K
-Predicate,http://schema.org/sponsor,10K - 100K
-Predicate,http://schema.org/sponsor-input,< 1K
-Predicate,http://schema.org/sponsor-output,< 1K
-Predicate,http://schema.org/sport,10K - 100K
-Predicate,http://schema.org/sport-input,< 1K
-Predicate,http://schema.org/sport-output,< 1K
-Predicate,http://schema.org/sportsActivityLocation,< 1K
-Predicate,http://schema.org/sportsActivityLocation-input,< 1K
-Predicate,http://schema.org/sportsActivityLocation-output,< 1K
-Predicate,http://schema.org/sportsEvent,< 1K
-Predicate,http://schema.org/sportsEvent-input,< 1K
-Predicate,http://schema.org/sportsEvent-output,< 1K
-Predicate,http://schema.org/sportsTeam,< 1K
-Predicate,http://schema.org/sportsTeam-input,< 1K
-Predicate,http://schema.org/sportsTeam-output,< 1K
-Predicate,http://schema.org/spouse,1K - 10K
-Predicate,http://schema.org/spouse-input,< 1K
-Predicate,http://schema.org/spouse-output,< 1K
-Predicate,http://schema.org/stage,< 1K
-Predicate,http://schema.org/stage-input,< 1K
-Predicate,http://schema.org/stage-output,< 1K
-Predicate,http://schema.org/stageAsNumber,< 1K
-Predicate,http://schema.org/stageAsNumber-input,< 1K
-Predicate,http://schema.org/stageAsNumber-output,< 1K
-Predicate,http://schema.org/starRating,10K - 100K
-Predicate,http://schema.org/starRating-input,< 1K
-Predicate,http://schema.org/starRating-output,< 1K
-Predicate,http://schema.org/startDate,100K - 1M
-Predicate,http://schema.org/startDate-input,< 1K
-Predicate,http://schema.org/startDate-output,< 1K
-Predicate,http://schema.org/startOffset,10K - 100K
-Predicate,http://schema.org/startOffset-input,10K - 100K
-Predicate,http://schema.org/startOffset-output,< 1K
-Predicate,http://schema.org/startTime,1K - 10K
-Predicate,http://schema.org/startTime-input,< 1K
-Predicate,http://schema.org/startTime-output,< 1K
-Predicate,http://schema.org/statType,< 1K
-Predicate,http://schema.org/statType-input,< 1K
-Predicate,http://schema.org/statType-output,< 1K
-Predicate,http://schema.org/status,1K - 10K
-Predicate,http://schema.org/status-input,< 1K
-Predicate,http://schema.org/status-output,< 1K
-Predicate,http://schema.org/steeringPosition,1K - 10K
-Predicate,http://schema.org/steeringPosition-input,< 1K
-Predicate,http://schema.org/steeringPosition-output,< 1K
-Predicate,http://schema.org/step,100K - 1M
-Predicate,http://schema.org/step-input,< 1K
-Predicate,http://schema.org/step-output,< 1K
-Predicate,http://schema.org/stepValue,< 1K
-Predicate,http://schema.org/stepValue-input,< 1K
-Predicate,http://schema.org/stepValue-output,< 1K
-Predicate,http://schema.org/steps,< 1K
-Predicate,http://schema.org/steps-input,< 1K
-Predicate,http://schema.org/steps-output,< 1K
-Predicate,http://schema.org/storageRequirements,10K - 100K
-Predicate,http://schema.org/storageRequirements-input,< 1K
-Predicate,http://schema.org/storageRequirements-output,< 1K
-Predicate,http://schema.org/streetAddress,1M - 10M
-Predicate,http://schema.org/streetAddress-input,< 1K
-Predicate,http://schema.org/streetAddress-output,< 1K
-Predicate,http://schema.org/strengthUnit,< 1K
-Predicate,http://schema.org/strengthUnit-input,< 1K
-Predicate,http://schema.org/strengthUnit-output,< 1K
-Predicate,http://schema.org/strengthValue,< 1K
-Predicate,http://schema.org/strengthValue-input,< 1K
-Predicate,http://schema.org/strengthValue-output,< 1K
-Predicate,http://schema.org/structuralClass,< 1K
-Predicate,http://schema.org/structuralClass-input,< 1K
-Predicate,http://schema.org/structuralClass-output,< 1K
-Predicate,http://schema.org/study,< 1K
-Predicate,http://schema.org/study-input,< 1K
-Predicate,http://schema.org/study-output,< 1K
-Predicate,http://schema.org/studyDesign,< 1K
-Predicate,http://schema.org/studyDesign-input,< 1K
-Predicate,http://schema.org/studyDesign-output,< 1K
-Predicate,http://schema.org/studyLocation,< 1K
-Predicate,http://schema.org/studyLocation-input,< 1K
-Predicate,http://schema.org/studyLocation-output,< 1K
-Predicate,http://schema.org/studySubject,< 1K
-Predicate,http://schema.org/studySubject-input,< 1K
-Predicate,http://schema.org/studySubject-output,< 1K
-Predicate,http://schema.org/stupidProperty,< 1K
-Predicate,http://schema.org/stupidProperty-input,< 1K
-Predicate,http://schema.org/stupidProperty-output,< 1K
-Predicate,http://schema.org/subEvent,1K - 10K
-Predicate,http://schema.org/subEvent-input,< 1K
-Predicate,http://schema.org/subEvent-output,< 1K
-Predicate,http://schema.org/subEvents,< 1K
-Predicate,http://schema.org/subEvents-input,< 1K
-Predicate,http://schema.org/subEvents-output,< 1K
-Predicate,http://schema.org/subOrganization,10K - 100K
-Predicate,http://schema.org/subOrganization-input,< 1K
-Predicate,http://schema.org/subOrganization-output,< 1K
-Predicate,http://schema.org/subReservation,< 1K
-Predicate,http://schema.org/subReservation-input,< 1K
-Predicate,http://schema.org/subReservation-output,< 1K
-Predicate,http://schema.org/subStageSuffix,< 1K
-Predicate,http://schema.org/subStageSuffix-input,< 1K
-Predicate,http://schema.org/subStageSuffix-output,< 1K
-Predicate,http://schema.org/subStructure,< 1K
-Predicate,http://schema.org/subStructure-input,< 1K
-Predicate,http://schema.org/subStructure-output,< 1K
-Predicate,http://schema.org/subTest,< 1K
-Predicate,http://schema.org/subTest-input,< 1K
-Predicate,http://schema.org/subTest-output,< 1K
-Predicate,http://schema.org/subTrip,< 1K
-Predicate,http://schema.org/subTrip-input,< 1K
-Predicate,http://schema.org/subTrip-output,< 1K
-Predicate,http://schema.org/subjectOf,100K - 1M
-Predicate,http://schema.org/subjectOf-input,< 1K
-Predicate,http://schema.org/subjectOf-output,< 1K
-Predicate,http://schema.org/subtitleLanguage,< 1K
-Predicate,http://schema.org/subtitleLanguage-input,< 1K
-Predicate,http://schema.org/subtitleLanguage-output,< 1K
-Predicate,http://schema.org/successorOf,< 1K
-Predicate,http://schema.org/successorOf-input,< 1K
-Predicate,http://schema.org/successorOf-output,< 1K
-Predicate,http://schema.org/sugarContent,10K - 100K
-Predicate,http://schema.org/sugarContent-input,< 1K
-Predicate,http://schema.org/sugarContent-output,< 1K
-Predicate,http://schema.org/suggestedAge,1K - 10K
-Predicate,http://schema.org/suggestedAge-input,< 1K
-Predicate,http://schema.org/suggestedAge-output,< 1K
-Predicate,http://schema.org/suggestedAnswer,10K - 100K
-Predicate,http://schema.org/suggestedAnswer-input,< 1K
-Predicate,http://schema.org/suggestedAnswer-output,< 1K
-Predicate,http://schema.org/suggestedGender,10K - 100K
-Predicate,http://schema.org/suggestedGender-input,< 1K
-Predicate,http://schema.org/suggestedGender-output,< 1K
-Predicate,http://schema.org/suggestedMaxAge,1K - 10K
-Predicate,http://schema.org/suggestedMaxAge-input,< 1K
-Predicate,http://schema.org/suggestedMaxAge-output,< 1K
-Predicate,http://schema.org/suggestedMeasurement,< 1K
-Predicate,http://schema.org/suggestedMeasurement-input,< 1K
-Predicate,http://schema.org/suggestedMeasurement-output,< 1K
-Predicate,http://schema.org/suggestedMinAge,10K - 100K
-Predicate,http://schema.org/suggestedMinAge-input,< 1K
-Predicate,http://schema.org/suggestedMinAge-output,< 1K
-Predicate,http://schema.org/suitableForDiet,10K - 100K
-Predicate,http://schema.org/suitableForDiet-input,< 1K
-Predicate,http://schema.org/suitableForDiet-output,< 1K
-Predicate,http://schema.org/superEvent,1K - 10K
-Predicate,http://schema.org/superEvent-input,< 1K
-Predicate,http://schema.org/superEvent-output,< 1K
-Predicate,http://schema.org/supersededBy,1K - 10K
-Predicate,http://schema.org/supersededBy-input,< 1K
-Predicate,http://schema.org/supersededBy-output,< 1K
-Predicate,http://schema.org/supply,10K - 100K
-Predicate,http://schema.org/supply-input,< 1K
-Predicate,http://schema.org/supply-output,< 1K
-Predicate,http://schema.org/supplyTo,< 1K
-Predicate,http://schema.org/supplyTo-input,< 1K
-Predicate,http://schema.org/supplyTo-output,< 1K
-Predicate,http://schema.org/supportingData,< 1K
-Predicate,http://schema.org/supportingData-input,< 1K
-Predicate,http://schema.org/supportingData-output,< 1K
-Predicate,http://schema.org/surface,< 1K
-Predicate,http://schema.org/surface-input,< 1K
-Predicate,http://schema.org/surface-output,< 1K
-Predicate,http://schema.org/syllabusSections,1K - 10K
-Predicate,http://schema.org/syllabusSections-input,< 1K
-Predicate,http://schema.org/syllabusSections-output,< 1K
-Predicate,http://schema.org/target,10M+
-Predicate,http://schema.org/target-input,< 1K
-Predicate,http://schema.org/target-output,< 1K
-Predicate,http://schema.org/targetCollection,< 1K
-Predicate,http://schema.org/targetCollection-input,< 1K
-Predicate,http://schema.org/targetCollection-output,< 1K
-Predicate,http://schema.org/targetDescription,< 1K
-Predicate,http://schema.org/targetDescription-input,< 1K
-Predicate,http://schema.org/targetDescription-output,< 1K
-Predicate,http://schema.org/targetName,1K - 10K
-Predicate,http://schema.org/targetName-input,< 1K
-Predicate,http://schema.org/targetName-output,< 1K
-Predicate,http://schema.org/targetPlatform,< 1K
-Predicate,http://schema.org/targetPlatform-input,< 1K
-Predicate,http://schema.org/targetPlatform-output,< 1K
-Predicate,http://schema.org/targetPopulation,< 1K
-Predicate,http://schema.org/targetPopulation-input,< 1K
-Predicate,http://schema.org/targetPopulation-output,< 1K
-Predicate,http://schema.org/targetProduct,< 1K
-Predicate,http://schema.org/targetProduct-input,< 1K
-Predicate,http://schema.org/targetProduct-output,< 1K
-Predicate,http://schema.org/targetUrl,< 1K
-Predicate,http://schema.org/targetUrl-input,< 1K
-Predicate,http://schema.org/targetUrl-output,< 1K
-Predicate,http://schema.org/taxID,100K - 1M
-Predicate,http://schema.org/taxID-input,< 1K
-Predicate,http://schema.org/taxID-output,< 1K
-Predicate,http://schema.org/taxonRank,< 1K
-Predicate,http://schema.org/taxonRank-input,< 1K
-Predicate,http://schema.org/taxonRank-output,< 1K
-Predicate,http://schema.org/taxonomicRange,< 1K
-Predicate,http://schema.org/taxonomicRange-input,< 1K
-Predicate,http://schema.org/taxonomicRange-output,< 1K
-Predicate,http://schema.org/teaches,10K - 100K
-Predicate,http://schema.org/teaches-input,< 1K
-Predicate,http://schema.org/teaches-output,< 1K
-Predicate,http://schema.org/telephone,1M - 10M
-Predicate,http://schema.org/telephone-input,< 1K
-Predicate,http://schema.org/telephone-output,< 1K
-Predicate,http://schema.org/temporal,< 1K
-Predicate,http://schema.org/temporal-input,< 1K
-Predicate,http://schema.org/temporal-output,< 1K
-Predicate,http://schema.org/temporalCoverage,10K - 100K
-Predicate,http://schema.org/temporalCoverage-input,< 1K
-Predicate,http://schema.org/temporalCoverage-output,< 1K
-Predicate,http://schema.org/termCode,1K - 10K
-Predicate,http://schema.org/termCode-input,< 1K
-Predicate,http://schema.org/termCode-output,< 1K
-Predicate,http://schema.org/termDuration,< 1K
-Predicate,http://schema.org/termDuration-input,< 1K
-Predicate,http://schema.org/termDuration-output,< 1K
-Predicate,http://schema.org/termsOfService,10K - 100K
-Predicate,http://schema.org/termsOfService-input,< 1K
-Predicate,http://schema.org/termsOfService-output,< 1K
-Predicate,http://schema.org/termsPerYear,< 1K
-Predicate,http://schema.org/termsPerYear-input,< 1K
-Predicate,http://schema.org/termsPerYear-output,< 1K
-Predicate,http://schema.org/text,1M - 10M
-Predicate,http://schema.org/text-input,< 1K
-Predicate,http://schema.org/text-output,< 1K
-Predicate,http://schema.org/textValue,< 1K
-Predicate,http://schema.org/textValue-input,< 1K
-Predicate,http://schema.org/textValue-output,< 1K
-Predicate,http://schema.org/thumbnail,100K - 1M
-Predicate,http://schema.org/thumbnail-input,< 1K
-Predicate,http://schema.org/thumbnail-output,< 1K
-Predicate,http://schema.org/thumbnailUrl,10M+
-Predicate,http://schema.org/thumbnailUrl-input,< 1K
-Predicate,http://schema.org/thumbnailUrl-output,< 1K
-Predicate,http://schema.org/tickerSymbol,1K - 10K
-Predicate,http://schema.org/tickerSymbol-input,< 1K
-Predicate,http://schema.org/tickerSymbol-output,< 1K
-Predicate,http://schema.org/ticketNumber,< 1K
-Predicate,http://schema.org/ticketNumber-input,< 1K
-Predicate,http://schema.org/ticketNumber-output,< 1K
-Predicate,http://schema.org/ticketToken,< 1K
-Predicate,http://schema.org/ticketToken-input,< 1K
-Predicate,http://schema.org/ticketToken-output,< 1K
-Predicate,http://schema.org/ticketedSeat,< 1K
-Predicate,http://schema.org/ticketedSeat-input,< 1K
-Predicate,http://schema.org/ticketedSeat-output,< 1K
-Predicate,http://schema.org/timeOfDay,< 1K
-Predicate,http://schema.org/timeOfDay-input,< 1K
-Predicate,http://schema.org/timeOfDay-output,< 1K
-Predicate,http://schema.org/timeRequired,100K - 1M
-Predicate,http://schema.org/timeRequired-input,< 1K
-Predicate,http://schema.org/timeRequired-output,< 1K
-Predicate,http://schema.org/timeToComplete,1K - 10K
-Predicate,http://schema.org/timeToComplete-input,< 1K
-Predicate,http://schema.org/timeToComplete-output,< 1K
-Predicate,http://schema.org/timestamp,1K - 10K
-Predicate,http://schema.org/timestamp-input,< 1K
-Predicate,http://schema.org/timestamp-output,< 1K
-Predicate,http://schema.org/tissueSample,< 1K
-Predicate,http://schema.org/tissueSample-input,< 1K
-Predicate,http://schema.org/tissueSample-output,< 1K
-Predicate,http://schema.org/title,100K - 1M
-Predicate,http://schema.org/title-input,< 1K
-Predicate,http://schema.org/title-output,< 1K
-Predicate,http://schema.org/titleEIDR,< 1K
-Predicate,http://schema.org/titleEIDR-input,< 1K
-Predicate,http://schema.org/titleEIDR-output,< 1K
-Predicate,http://schema.org/toLocation,1K - 10K
-Predicate,http://schema.org/toLocation-input,< 1K
-Predicate,http://schema.org/toLocation-output,< 1K
-Predicate,http://schema.org/toRecipient,< 1K
-Predicate,http://schema.org/toRecipient-input,< 1K
-Predicate,http://schema.org/toRecipient-output,< 1K
-Predicate,http://schema.org/tocContinuation,< 1K
-Predicate,http://schema.org/tocContinuation-input,< 1K
-Predicate,http://schema.org/tocContinuation-output,< 1K
-Predicate,http://schema.org/tocEntry,< 1K
-Predicate,http://schema.org/tocEntry-input,< 1K
-Predicate,http://schema.org/tocEntry-output,< 1K
-Predicate,http://schema.org/tongueWeight,< 1K
-Predicate,http://schema.org/tongueWeight-input,< 1K
-Predicate,http://schema.org/tongueWeight-output,< 1K
-Predicate,http://schema.org/tool,10K - 100K
-Predicate,http://schema.org/tool-input,< 1K
-Predicate,http://schema.org/tool-output,< 1K
-Predicate,http://schema.org/torque,1K - 10K
-Predicate,http://schema.org/torque-input,< 1K
-Predicate,http://schema.org/torque-output,< 1K
-Predicate,http://schema.org/totalHistoricalEnrollment,< 1K
-Predicate,http://schema.org/totalHistoricalEnrollment-input,< 1K
-Predicate,http://schema.org/totalHistoricalEnrollment-output,< 1K
-Predicate,http://schema.org/totalJobOpenings,1K - 10K
-Predicate,http://schema.org/totalJobOpenings-input,< 1K
-Predicate,http://schema.org/totalJobOpenings-output,< 1K
-Predicate,http://schema.org/totalPaymentDue,< 1K
-Predicate,http://schema.org/totalPaymentDue-input,< 1K
-Predicate,http://schema.org/totalPaymentDue-output,< 1K
-Predicate,http://schema.org/totalPrice,< 1K
-Predicate,http://schema.org/totalPrice-input,< 1K
-Predicate,http://schema.org/totalPrice-output,< 1K
-Predicate,http://schema.org/totalTime,100K - 1M
-Predicate,http://schema.org/totalTime-input,< 1K
-Predicate,http://schema.org/totalTime-output,< 1K
-Predicate,http://schema.org/tourBookingPage,10K - 100K
-Predicate,http://schema.org/tourBookingPage-input,< 1K
-Predicate,http://schema.org/tourBookingPage-output,< 1K
-Predicate,http://schema.org/touristType,10K - 100K
-Predicate,http://schema.org/touristType-input,< 1K
-Predicate,http://schema.org/touristType-output,< 1K
-Predicate,http://schema.org/track,10K - 100K
-Predicate,http://schema.org/track-input,< 1K
-Predicate,http://schema.org/track-output,< 1K
-Predicate,http://schema.org/trackingNumber,< 1K
-Predicate,http://schema.org/trackingNumber-input,< 1K
-Predicate,http://schema.org/trackingNumber-output,< 1K
-Predicate,http://schema.org/trackingUrl,< 1K
-Predicate,http://schema.org/trackingUrl-input,< 1K
-Predicate,http://schema.org/trackingUrl-output,< 1K
-Predicate,http://schema.org/tracks,< 1K
-Predicate,http://schema.org/tracks-input,< 1K
-Predicate,http://schema.org/tracks-output,< 1K
-Predicate,http://schema.org/trailer,1K - 10K
-Predicate,http://schema.org/trailer-input,< 1K
-Predicate,http://schema.org/trailer-output,< 1K
-Predicate,http://schema.org/trailerWeight,< 1K
-Predicate,http://schema.org/trailerWeight-input,< 1K
-Predicate,http://schema.org/trailerWeight-output,< 1K
-Predicate,http://schema.org/trainName,< 1K
-Predicate,http://schema.org/trainName-input,< 1K
-Predicate,http://schema.org/trainName-output,< 1K
-Predicate,http://schema.org/trainNumber,< 1K
-Predicate,http://schema.org/trainNumber-input,< 1K
-Predicate,http://schema.org/trainNumber-output,< 1K
-Predicate,http://schema.org/trainingSalary,< 1K
-Predicate,http://schema.org/trainingSalary-input,< 1K
-Predicate,http://schema.org/trainingSalary-output,< 1K
-Predicate,http://schema.org/transFatContent,10K - 100K
-Predicate,http://schema.org/transFatContent-input,< 1K
-Predicate,http://schema.org/transFatContent-output,< 1K
-Predicate,http://schema.org/transcript,100K - 1M
-Predicate,http://schema.org/transcript-input,< 1K
-Predicate,http://schema.org/transcript-output,< 1K
-Predicate,http://schema.org/transitTime,100K - 1M
-Predicate,http://schema.org/transitTime-input,< 1K
-Predicate,http://schema.org/transitTime-output,< 1K
-Predicate,http://schema.org/transitTimeLabel,< 1K
-Predicate,http://schema.org/transitTimeLabel-input,< 1K
-Predicate,http://schema.org/transitTimeLabel-output,< 1K
-Predicate,http://schema.org/translationOfWork,1K - 10K
-Predicate,http://schema.org/translationOfWork-input,< 1K
-Predicate,http://schema.org/translationOfWork-output,< 1K
-Predicate,http://schema.org/translator,1K - 10K
-Predicate,http://schema.org/translator-input,< 1K
-Predicate,http://schema.org/translator-output,< 1K
-Predicate,http://schema.org/transmissionMethod,< 1K
-Predicate,http://schema.org/transmissionMethod-input,< 1K
-Predicate,http://schema.org/transmissionMethod-output,< 1K
-Predicate,http://schema.org/travelBans,< 1K
-Predicate,http://schema.org/travelBans-input,< 1K
-Predicate,http://schema.org/travelBans-output,< 1K
-Predicate,http://schema.org/trialDesign,< 1K
-Predicate,http://schema.org/trialDesign-input,< 1K
-Predicate,http://schema.org/trialDesign-output,< 1K
-Predicate,http://schema.org/tributary,< 1K
-Predicate,http://schema.org/tributary-input,< 1K
-Predicate,http://schema.org/tributary-output,< 1K
-Predicate,http://schema.org/tripOrigin,< 1K
-Predicate,http://schema.org/tripOrigin-input,< 1K
-Predicate,http://schema.org/tripOrigin-output,< 1K
-Predicate,http://schema.org/typeOfBed,10K - 100K
-Predicate,http://schema.org/typeOfBed-input,< 1K
-Predicate,http://schema.org/typeOfBed-output,< 1K
-Predicate,http://schema.org/typeOfGood,< 1K
-Predicate,http://schema.org/typeOfGood-input,< 1K
-Predicate,http://schema.org/typeOfGood-output,< 1K
-Predicate,http://schema.org/typicalAgeRange,10K - 100K
-Predicate,http://schema.org/typicalAgeRange-input,< 1K
-Predicate,http://schema.org/typicalAgeRange-output,< 1K
-Predicate,http://schema.org/typicalCreditsPerTerm,< 1K
-Predicate,http://schema.org/typicalCreditsPerTerm-input,< 1K
-Predicate,http://schema.org/typicalCreditsPerTerm-output,< 1K
-Predicate,http://schema.org/typicalTest,1K - 10K
-Predicate,http://schema.org/typicalTest-input,< 1K
-Predicate,http://schema.org/typicalTest-output,< 1K
-Predicate,http://schema.org/underName,< 1K
-Predicate,http://schema.org/underName-input,< 1K
-Predicate,http://schema.org/underName-output,< 1K
-Predicate,http://schema.org/unitCode,1M - 10M
-Predicate,http://schema.org/unitCode-input,< 1K
-Predicate,http://schema.org/unitCode-output,< 1K
-Predicate,http://schema.org/unitText,100K - 1M
-Predicate,http://schema.org/unitText-input,< 1K
-Predicate,http://schema.org/unitText-output,< 1K
-Predicate,http://schema.org/unnamedSourcesPolicy,1K - 10K
-Predicate,http://schema.org/unnamedSourcesPolicy-input,< 1K
-Predicate,http://schema.org/unnamedSourcesPolicy-output,< 1K
-Predicate,http://schema.org/unsaturatedFatContent,10K - 100K
-Predicate,http://schema.org/unsaturatedFatContent-input,< 1K
-Predicate,http://schema.org/unsaturatedFatContent-output,< 1K
-Predicate,http://schema.org/uploadDate,1M - 10M
-Predicate,http://schema.org/uploadDate-input,< 1K
-Predicate,http://schema.org/uploadDate-output,< 1K
-Predicate,http://schema.org/upvoteCount,10K - 100K
-Predicate,http://schema.org/upvoteCount-input,< 1K
-Predicate,http://schema.org/upvoteCount-output,< 1K
-Predicate,http://schema.org/url,10M+
-Predicate,http://schema.org/url-input,< 1K
-Predicate,http://schema.org/url-output,< 1K
-Predicate,http://schema.org/urlTemplate,10M+
-Predicate,http://schema.org/urlTemplate-input,< 1K
-Predicate,http://schema.org/urlTemplate-output,< 1K
-Predicate,http://schema.org/usNPI,< 1K
-Predicate,http://schema.org/usNPI-input,< 1K
-Predicate,http://schema.org/usNPI-output,< 1K
-Predicate,http://schema.org/usageInfo,1K - 10K
-Predicate,http://schema.org/usageInfo-input,< 1K
-Predicate,http://schema.org/usageInfo-output,< 1K
-Predicate,http://schema.org/usedToDiagnose,1K - 10K
-Predicate,http://schema.org/usedToDiagnose-input,< 1K
-Predicate,http://schema.org/usedToDiagnose-output,< 1K
-Predicate,http://schema.org/userInteractionCount,100K - 1M
-Predicate,http://schema.org/userInteractionCount-input,< 1K
-Predicate,http://schema.org/userInteractionCount-output,< 1K
-Predicate,http://schema.org/usesDevice,< 1K
-Predicate,http://schema.org/usesDevice-input,< 1K
-Predicate,http://schema.org/usesDevice-output,< 1K
-Predicate,http://schema.org/usesHealthPlanIdStandard,< 1K
-Predicate,http://schema.org/usesHealthPlanIdStandard-input,< 1K
-Predicate,http://schema.org/usesHealthPlanIdStandard-output,< 1K
-Predicate,http://schema.org/utterances,< 1K
-Predicate,http://schema.org/utterances-input,< 1K
-Predicate,http://schema.org/utterances-output,< 1K
-Predicate,http://schema.org/validFor,< 1K
-Predicate,http://schema.org/validFor-input,< 1K
-Predicate,http://schema.org/validFor-output,< 1K
-Predicate,http://schema.org/validForMemberTier,< 1K
-Predicate,http://schema.org/validForMemberTier-input,< 1K
-Predicate,http://schema.org/validForMemberTier-output,< 1K
-Predicate,http://schema.org/validFrom,100K - 1M
-Predicate,http://schema.org/validFrom-input,< 1K
-Predicate,http://schema.org/validFrom-output,< 1K
-Predicate,http://schema.org/validIn,1K - 10K
-Predicate,http://schema.org/validIn-input,< 1K
-Predicate,http://schema.org/validIn-output,< 1K
-Predicate,http://schema.org/validThrough,1M - 10M
-Predicate,http://schema.org/validThrough-input,< 1K
-Predicate,http://schema.org/validThrough-output,< 1K
-Predicate,http://schema.org/validUntil,1K - 10K
-Predicate,http://schema.org/validUntil-input,< 1K
-Predicate,http://schema.org/validUntil-output,< 1K
-Predicate,http://schema.org/value,1M - 10M
-Predicate,http://schema.org/value-input,< 1K
-Predicate,http://schema.org/value-output,< 1K
-Predicate,http://schema.org/valueAddedTaxIncluded,1M - 10M
-Predicate,http://schema.org/valueAddedTaxIncluded-input,< 1K
-Predicate,http://schema.org/valueAddedTaxIncluded-output,< 1K
-Predicate,http://schema.org/valueMaxLength,1K - 10K
-Predicate,http://schema.org/valueMaxLength-input,< 1K
-Predicate,http://schema.org/valueMaxLength-output,< 1K
-Predicate,http://schema.org/valueMinLength,< 1K
-Predicate,http://schema.org/valueMinLength-input,< 1K
-Predicate,http://schema.org/valueMinLength-output,< 1K
-Predicate,http://schema.org/valueName,10M+
-Predicate,http://schema.org/valueName-input,< 1K
-Predicate,http://schema.org/valueName-output,< 1K
-Predicate,http://schema.org/valuePattern,< 1K
-Predicate,http://schema.org/valuePattern-input,< 1K
-Predicate,http://schema.org/valuePattern-output,< 1K
-Predicate,http://schema.org/valueReference,1K - 10K
-Predicate,http://schema.org/valueReference-input,< 1K
-Predicate,http://schema.org/valueReference-output,< 1K
-Predicate,http://schema.org/valueRequired,10M+
-Predicate,http://schema.org/valueRequired-input,< 1K
-Predicate,http://schema.org/valueRequired-output,< 1K
-Predicate,http://schema.org/variableMeasured,10K - 100K
-Predicate,http://schema.org/variableMeasured-input,< 1K
-Predicate,http://schema.org/variableMeasured-output,< 1K
-Predicate,http://schema.org/variablesMeasured,< 1K
-Predicate,http://schema.org/variablesMeasured-input,< 1K
-Predicate,http://schema.org/variablesMeasured-output,< 1K
-Predicate,http://schema.org/variantCover,< 1K
-Predicate,http://schema.org/variantCover-input,< 1K
-Predicate,http://schema.org/variantCover-output,< 1K
-Predicate,http://schema.org/variesBy,100K - 1M
-Predicate,http://schema.org/variesBy-input,< 1K
-Predicate,http://schema.org/variesBy-output,< 1K
-Predicate,http://schema.org/vatID,100K - 1M
-Predicate,http://schema.org/vatID-input,< 1K
-Predicate,http://schema.org/vatID-output,< 1K
-Predicate,http://schema.org/vehicleConfiguration,10K - 100K
-Predicate,http://schema.org/vehicleConfiguration-input,< 1K
-Predicate,http://schema.org/vehicleConfiguration-output,< 1K
-Predicate,http://schema.org/vehicleEngine,10K - 100K
-Predicate,http://schema.org/vehicleEngine-input,< 1K
-Predicate,http://schema.org/vehicleEngine-output,< 1K
-Predicate,http://schema.org/vehicleIdentificationNumber,10K - 100K
-Predicate,http://schema.org/vehicleIdentificationNumber-input,< 1K
-Predicate,http://schema.org/vehicleIdentificationNumber-output,< 1K
-Predicate,http://schema.org/vehicleInteriorColor,10K - 100K
-Predicate,http://schema.org/vehicleInteriorColor-input,< 1K
-Predicate,http://schema.org/vehicleInteriorColor-output,< 1K
-Predicate,http://schema.org/vehicleInteriorType,10K - 100K
-Predicate,http://schema.org/vehicleInteriorType-input,< 1K
-Predicate,http://schema.org/vehicleInteriorType-output,< 1K
-Predicate,http://schema.org/vehicleModelDate,10K - 100K
-Predicate,http://schema.org/vehicleModelDate-input,< 1K
-Predicate,http://schema.org/vehicleModelDate-output,< 1K
-Predicate,http://schema.org/vehicleSeatingCapacity,10K - 100K
-Predicate,http://schema.org/vehicleSeatingCapacity-input,< 1K
-Predicate,http://schema.org/vehicleSeatingCapacity-output,< 1K
-Predicate,http://schema.org/vehicleSpecialUsage,< 1K
-Predicate,http://schema.org/vehicleSpecialUsage-input,< 1K
-Predicate,http://schema.org/vehicleSpecialUsage-output,< 1K
-Predicate,http://schema.org/vehicleTransmission,10K - 100K
-Predicate,http://schema.org/vehicleTransmission-input,< 1K
-Predicate,http://schema.org/vehicleTransmission-output,< 1K
-Predicate,http://schema.org/vendor,< 1K
-Predicate,http://schema.org/vendor-input,< 1K
-Predicate,http://schema.org/vendor-output,< 1K
-Predicate,http://schema.org/verificationFactCheckingPolicy,1K - 10K
-Predicate,http://schema.org/verificationFactCheckingPolicy-input,< 1K
-Predicate,http://schema.org/verificationFactCheckingPolicy-output,< 1K
-Predicate,http://schema.org/version,10K - 100K
-Predicate,http://schema.org/version-input,< 1K
-Predicate,http://schema.org/version-output,< 1K
-Predicate,http://schema.org/video,100K - 1M
-Predicate,http://schema.org/video-input,< 1K
-Predicate,http://schema.org/video-output,< 1K
-Predicate,http://schema.org/videoFormat,1K - 10K
-Predicate,http://schema.org/videoFormat-input,< 1K
-Predicate,http://schema.org/videoFormat-output,< 1K
-Predicate,http://schema.org/videoFrameSize,< 1K
-Predicate,http://schema.org/videoFrameSize-input,< 1K
-Predicate,http://schema.org/videoFrameSize-output,< 1K
-Predicate,http://schema.org/videoQuality,10K - 100K
-Predicate,http://schema.org/videoQuality-input,< 1K
-Predicate,http://schema.org/videoQuality-output,< 1K
-Predicate,http://schema.org/volumeNumber,1K - 10K
-Predicate,http://schema.org/volumeNumber-input,< 1K
-Predicate,http://schema.org/volumeNumber-output,< 1K
-Predicate,http://schema.org/warning,1K - 10K
-Predicate,http://schema.org/warning-input,< 1K
-Predicate,http://schema.org/warning-output,< 1K
-Predicate,http://schema.org/warranty,10K - 100K
-Predicate,http://schema.org/warranty-input,< 1K
-Predicate,http://schema.org/warranty-output,< 1K
-Predicate,http://schema.org/warrantyPromise,< 1K
-Predicate,http://schema.org/warrantyPromise-input,< 1K
-Predicate,http://schema.org/warrantyPromise-output,< 1K
-Predicate,http://schema.org/warrantyScope,1K - 10K
-Predicate,http://schema.org/warrantyScope-input,< 1K
-Predicate,http://schema.org/warrantyScope-output,< 1K
-Predicate,http://schema.org/webCheckinTime,< 1K
-Predicate,http://schema.org/webCheckinTime-input,< 1K
-Predicate,http://schema.org/webCheckinTime-output,< 1K
-Predicate,http://schema.org/webFeed,10K - 100K
-Predicate,http://schema.org/webFeed-input,< 1K
-Predicate,http://schema.org/webFeed-output,< 1K
-Predicate,http://schema.org/weight,100K - 1M
-Predicate,http://schema.org/weight-input,< 1K
-Predicate,http://schema.org/weight-output,< 1K
-Predicate,http://schema.org/weightPercentage,< 1K
-Predicate,http://schema.org/weightPercentage-input,< 1K
-Predicate,http://schema.org/weightPercentage-output,< 1K
-Predicate,http://schema.org/weightTotal,1K - 10K
-Predicate,http://schema.org/weightTotal-input,< 1K
-Predicate,http://schema.org/weightTotal-output,< 1K
-Predicate,http://schema.org/wheelbase,1K - 10K
-Predicate,http://schema.org/wheelbase-input,< 1K
-Predicate,http://schema.org/wheelbase-output,< 1K
-Predicate,http://schema.org/width,10M+
-Predicate,http://schema.org/width-input,< 1K
-Predicate,http://schema.org/width-output,< 1K
-Predicate,http://schema.org/winner,< 1K
-Predicate,http://schema.org/winner-input,< 1K
-Predicate,http://schema.org/winner-output,< 1K
-Predicate,http://schema.org/wordCount,1M - 10M
-Predicate,http://schema.org/wordCount-input,< 1K
-Predicate,http://schema.org/wordCount-output,< 1K
-Predicate,http://schema.org/workExample,1K - 10K
-Predicate,http://schema.org/workExample-input,< 1K
-Predicate,http://schema.org/workExample-output,< 1K
-Predicate,http://schema.org/workFeatured,< 1K
-Predicate,http://schema.org/workFeatured-input,< 1K
-Predicate,http://schema.org/workFeatured-output,< 1K
-Predicate,http://schema.org/workHours,10K - 100K
-Predicate,http://schema.org/workHours-input,< 1K
-Predicate,http://schema.org/workHours-output,< 1K
-Predicate,http://schema.org/workLocation,10K - 100K
-Predicate,http://schema.org/workLocation-input,< 1K
-Predicate,http://schema.org/workLocation-output,< 1K
-Predicate,http://schema.org/workPerformed,1K - 10K
-Predicate,http://schema.org/workPerformed-input,< 1K
-Predicate,http://schema.org/workPerformed-output,< 1K
-Predicate,http://schema.org/workPresented,< 1K
-Predicate,http://schema.org/workPresented-input,< 1K
-Predicate,http://schema.org/workPresented-output,< 1K
-Predicate,http://schema.org/workTranslation,10K - 100K
-Predicate,http://schema.org/workTranslation-input,< 1K
-Predicate,http://schema.org/workTranslation-output,< 1K
-Predicate,http://schema.org/workload,< 1K
-Predicate,http://schema.org/workload-input,< 1K
-Predicate,http://schema.org/workload-output,< 1K
-Predicate,http://schema.org/worksFor,1M - 10M
-Predicate,http://schema.org/worksFor-input,< 1K
-Predicate,http://schema.org/worksFor-output,< 1K
-Predicate,http://schema.org/worstRating,1M - 10M
-Predicate,http://schema.org/worstRating-input,< 1K
-Predicate,http://schema.org/worstRating-output,< 1K
-Predicate,http://schema.org/xpath,10K - 100K
-Predicate,http://schema.org/xpath-input,< 1K
-Predicate,http://schema.org/xpath-output,< 1K
-Predicate,http://schema.org/yearBuilt,10K - 100K
-Predicate,http://schema.org/yearBuilt-input,< 1K
-Predicate,http://schema.org/yearBuilt-output,< 1K
-Predicate,http://schema.org/yearlyRevenue,< 1K
-Predicate,http://schema.org/yearlyRevenue-input,< 1K
-Predicate,http://schema.org/yearlyRevenue-output,< 1K
-Predicate,http://schema.org/yearsInOperation,< 1K
-Predicate,http://schema.org/yearsInOperation-input,< 1K
-Predicate,http://schema.org/yearsInOperation-output,< 1K
-Predicate,http://schema.org/yield,1K - 10K
-Predicate,http://schema.org/yield-input,< 1K
-Predicate,http://schema.org/yield-output,< 1K
+Itemtype,https://schema.org/3DModel,< 1K
+Itemtype,https://schema.org/AMRadioChannel,< 1K
+Itemtype,https://schema.org/APIReference,< 1K
+Itemtype,https://schema.org/AboutPage,100K - 1M
+Itemtype,https://schema.org/AcceptAction,< 1K
+Itemtype,https://schema.org/Accommodation,10K - 100K
+Itemtype,https://schema.org/AccountingService,10K - 100K
+Itemtype,https://schema.org/AchieveAction,< 1K
+Itemtype,https://schema.org/Action,10K - 100K
+Itemtype,https://schema.org/ActionAccessSpecification,< 1K
+Itemtype,https://schema.org/ActionStatusType,< 1K
+Itemtype,https://schema.org/ActivateAction,< 1K
+Itemtype,https://schema.org/AddAction,< 1K
+Itemtype,https://schema.org/AdministrativeArea,100K - 1M
+Itemtype,https://schema.org/AdultEntertainment,1K - 10K
+Itemtype,https://schema.org/AdultOrientedEnumeration,< 1K
+Itemtype,https://schema.org/AdvertiserContentArticle,1K - 10K
+Itemtype,https://schema.org/AggregateOffer,1M - 10M
+Itemtype,https://schema.org/AggregateRating,1M - 10M
+Itemtype,https://schema.org/AgreeAction,< 1K
+Itemtype,https://schema.org/Airline,1K - 10K
+Itemtype,https://schema.org/Airport,1K - 10K
+Itemtype,https://schema.org/AlignmentObject,1K - 10K
+Itemtype,https://schema.org/AllocateAction,< 1K
+Itemtype,https://schema.org/AmpStory,< 1K
+Itemtype,https://schema.org/AmusementPark,1K - 10K
+Itemtype,https://schema.org/AnalysisNewsArticle,1K - 10K
+Itemtype,https://schema.org/AnatomicalStructure,1K - 10K
+Itemtype,https://schema.org/AnatomicalSystem,< 1K
+Itemtype,https://schema.org/AnimalShelter,1K - 10K
+Itemtype,https://schema.org/Answer,1M - 10M
+Itemtype,https://schema.org/Apartment,10K - 100K
+Itemtype,https://schema.org/ApartmentComplex,10K - 100K
+Itemtype,https://schema.org/AppendAction,< 1K
+Itemtype,https://schema.org/ApplyAction,1K - 10K
+Itemtype,https://schema.org/ApprovedIndication,< 1K
+Itemtype,https://schema.org/Aquarium,< 1K
+Itemtype,https://schema.org/ArchiveComponent,< 1K
+Itemtype,https://schema.org/ArchiveOrganization,1K - 10K
+Itemtype,https://schema.org/ArriveAction,< 1K
+Itemtype,https://schema.org/ArtGallery,1K - 10K
+Itemtype,https://schema.org/Artery,< 1K
+Itemtype,https://schema.org/Article,10M+
+Itemtype,https://schema.org/AskAction,1K - 10K
+Itemtype,https://schema.org/AskPublicNewsArticle,< 1K
+Itemtype,https://schema.org/AssessAction,< 1K
+Itemtype,https://schema.org/AssignAction,< 1K
+Itemtype,https://schema.org/Atlas,< 1K
+Itemtype,https://schema.org/Attorney,10K - 100K
+Itemtype,https://schema.org/Audience,100K - 1M
+Itemtype,https://schema.org/AudioObject,10K - 100K
+Itemtype,https://schema.org/AudioObjectSnapshot,< 1K
+Itemtype,https://schema.org/Audiobook,< 1K
+Itemtype,https://schema.org/AuthenticateAction,< 1K
+Itemtype,https://schema.org/AuthorizeAction,< 1K
+Itemtype,https://schema.org/AutoBodyShop,1K - 10K
+Itemtype,https://schema.org/AutoDealer,10K - 100K
+Itemtype,https://schema.org/AutoPartsStore,10K - 100K
+Itemtype,https://schema.org/AutoRental,10K - 100K
+Itemtype,https://schema.org/AutoRepair,10K - 100K
+Itemtype,https://schema.org/AutoWash,1K - 10K
+Itemtype,https://schema.org/AutomatedTeller,< 1K
+Itemtype,https://schema.org/AutomotiveBusiness,10K - 100K
+Itemtype,https://schema.org/BackgroundNewsArticle,< 1K
+Itemtype,https://schema.org/Bakery,1K - 10K
+Itemtype,https://schema.org/BankAccount,< 1K
+Itemtype,https://schema.org/BankOrCreditUnion,1K - 10K
+Itemtype,https://schema.org/BarOrPub,10K - 100K
+Itemtype,https://schema.org/Barcode,< 1K
+Itemtype,https://schema.org/Beach,1K - 10K
+Itemtype,https://schema.org/BeautySalon,10K - 100K
+Itemtype,https://schema.org/BedAndBreakfast,1K - 10K
+Itemtype,https://schema.org/BedDetails,10K - 100K
+Itemtype,https://schema.org/BedType,< 1K
+Itemtype,https://schema.org/BefriendAction,< 1K
+Itemtype,https://schema.org/BikeStore,1K - 10K
+Itemtype,https://schema.org/BioChemEntity,< 1K
+Itemtype,https://schema.org/Blog,1M - 10M
+Itemtype,https://schema.org/BlogPosting,1M - 10M
+Itemtype,https://schema.org/BloodTest,< 1K
+Itemtype,https://schema.org/BoardingPolicyType,< 1K
+Itemtype,https://schema.org/BoatReservation,< 1K
+Itemtype,https://schema.org/BoatTerminal,< 1K
+Itemtype,https://schema.org/BoatTrip,< 1K
+Itemtype,https://schema.org/BodyMeasurementTypeEnumeration,< 1K
+Itemtype,https://schema.org/BodyOfWater,< 1K
+Itemtype,https://schema.org/Bone,< 1K
+Itemtype,https://schema.org/Book,10K - 100K
+Itemtype,https://schema.org/BookFormatType,< 1K
+Itemtype,https://schema.org/BookSeries,1K - 10K
+Itemtype,https://schema.org/BookStore,1K - 10K
+Itemtype,https://schema.org/BookmarkAction,< 1K
+Itemtype,https://schema.org/Boolean,< 1K
+Itemtype,https://schema.org/BorrowAction,< 1K
+Itemtype,https://schema.org/BowlingAlley,< 1K
+Itemtype,https://schema.org/BrainStructure,< 1K
+Itemtype,https://schema.org/Brand,1M - 10M
+Itemtype,https://schema.org/BreadcrumbList,10M+
+Itemtype,https://schema.org/Brewery,1K - 10K
+Itemtype,https://schema.org/Bridge,< 1K
+Itemtype,https://schema.org/BroadcastChannel,< 1K
+Itemtype,https://schema.org/BroadcastEvent,10K - 100K
+Itemtype,https://schema.org/BroadcastFrequencySpecification,< 1K
+Itemtype,https://schema.org/BroadcastService,1K - 10K
+Itemtype,https://schema.org/BrokerageAccount,< 1K
+Itemtype,https://schema.org/BuddhistTemple,< 1K
+Itemtype,https://schema.org/BusOrCoach,< 1K
+Itemtype,https://schema.org/BusReservation,< 1K
+Itemtype,https://schema.org/BusStation,< 1K
+Itemtype,https://schema.org/BusStop,< 1K
+Itemtype,https://schema.org/BusTrip,1K - 10K
+Itemtype,https://schema.org/BusinessAudience,10K - 100K
+Itemtype,https://schema.org/BusinessEntityType,< 1K
+Itemtype,https://schema.org/BusinessEvent,1K - 10K
+Itemtype,https://schema.org/BusinessFunction,< 1K
+Itemtype,https://schema.org/BuyAction,1M - 10M
+Itemtype,https://schema.org/CDCPMDRecord,< 1K
+Itemtype,https://schema.org/CableOrSatelliteService,< 1K
+Itemtype,https://schema.org/CafeOrCoffeeShop,1K - 10K
+Itemtype,https://schema.org/Campground,1K - 10K
+Itemtype,https://schema.org/CampingPitch,< 1K
+Itemtype,https://schema.org/Canal,< 1K
+Itemtype,https://schema.org/CancelAction,< 1K
+Itemtype,https://schema.org/Car,10K - 100K
+Itemtype,https://schema.org/CarUsageType,< 1K
+Itemtype,https://schema.org/Casino,100K - 1M
+Itemtype,https://schema.org/CategoryCode,1K - 10K
+Itemtype,https://schema.org/CategoryCodeSet,< 1K
+Itemtype,https://schema.org/CatholicChurch,< 1K
+Itemtype,https://schema.org/Cemetery,< 1K
+Itemtype,https://schema.org/Certification,10K - 100K
+Itemtype,https://schema.org/CertificationStatusEnumeration,< 1K
+Itemtype,https://schema.org/Chapter,1K - 10K
+Itemtype,https://schema.org/CheckAction,< 1K
+Itemtype,https://schema.org/CheckInAction,< 1K
+Itemtype,https://schema.org/CheckOutAction,< 1K
+Itemtype,https://schema.org/CheckoutPage,1K - 10K
+Itemtype,https://schema.org/ChemicalSubstance,1K - 10K
+Itemtype,https://schema.org/ChildCare,1K - 10K
+Itemtype,https://schema.org/ChildrensEvent,< 1K
+Itemtype,https://schema.org/ChooseAction,1K - 10K
+Itemtype,https://schema.org/Church,1K - 10K
+Itemtype,https://schema.org/City,100K - 1M
+Itemtype,https://schema.org/CityHall,< 1K
+Itemtype,https://schema.org/CivicStructure,1K - 10K
+Itemtype,https://schema.org/Claim,1K - 10K
+Itemtype,https://schema.org/ClaimReview,1K - 10K
+Itemtype,https://schema.org/Class,< 1K
+Itemtype,https://schema.org/Clip,10K - 100K
+Itemtype,https://schema.org/ClothingStore,10K - 100K
+Itemtype,https://schema.org/Code,< 1K
+Itemtype,https://schema.org/Collection,10K - 100K
+Itemtype,https://schema.org/CollectionPage,1M - 10M
+Itemtype,https://schema.org/CollegeOrUniversity,10K - 100K
+Itemtype,https://schema.org/ComedyClub,< 1K
+Itemtype,https://schema.org/ComedyEvent,1K - 10K
+Itemtype,https://schema.org/ComicCoverArt,< 1K
+Itemtype,https://schema.org/ComicIssue,< 1K
+Itemtype,https://schema.org/ComicSeries,1K - 10K
+Itemtype,https://schema.org/ComicStory,< 1K
+Itemtype,https://schema.org/Comment,100K - 1M
+Itemtype,https://schema.org/CommentAction,1M - 10M
+Itemtype,https://schema.org/CommunicateAction,10K - 100K
+Itemtype,https://schema.org/CommunityHealth,1K - 10K
+Itemtype,https://schema.org/CompleteDataFeed,< 1K
+Itemtype,https://schema.org/CompoundPriceSpecification,1K - 10K
+Itemtype,https://schema.org/ComputerLanguage,< 1K
+Itemtype,https://schema.org/ComputerStore,1K - 10K
+Itemtype,https://schema.org/ConferenceEvent,< 1K
+Itemtype,https://schema.org/ConfirmAction,< 1K
+Itemtype,https://schema.org/Consortium,< 1K
+Itemtype,https://schema.org/ConstraintNode,< 1K
+Itemtype,https://schema.org/ConsumeAction,< 1K
+Itemtype,https://schema.org/ContactPage,100K - 1M
+Itemtype,https://schema.org/ContactPoint,1M - 10M
+Itemtype,https://schema.org/ContactPointOption,< 1K
+Itemtype,https://schema.org/Continent,1K - 10K
+Itemtype,https://schema.org/ControlAction,< 1K
+Itemtype,https://schema.org/ConvenienceStore,< 1K
+Itemtype,https://schema.org/Conversation,< 1K
+Itemtype,https://schema.org/CookAction,< 1K
+Itemtype,https://schema.org/Cooperative,< 1K
+Itemtype,https://schema.org/Corporation,100K - 1M
+Itemtype,https://schema.org/CorrectionComment,< 1K
+Itemtype,https://schema.org/Country,1M - 10M
+Itemtype,https://schema.org/Course,100K - 1M
+Itemtype,https://schema.org/CourseInstance,10K - 100K
+Itemtype,https://schema.org/Courthouse,< 1K
+Itemtype,https://schema.org/CoverArt,< 1K
+Itemtype,https://schema.org/CovidTestingFacility,< 1K
+Itemtype,https://schema.org/CreateAction,1K - 10K
+Itemtype,https://schema.org/CreativeWork,1M - 10M
+Itemtype,https://schema.org/CreativeWorkSeason,1K - 10K
+Itemtype,https://schema.org/CreativeWorkSeries,10K - 100K
+Itemtype,https://schema.org/Credential,10K - 100K
+Itemtype,https://schema.org/CreditCard,1K - 10K
+Itemtype,https://schema.org/Crematorium,< 1K
+Itemtype,https://schema.org/CriticReview,< 1K
+Itemtype,https://schema.org/CssSelectorType,< 1K
+Itemtype,https://schema.org/CurrencyConversionService,< 1K
+Itemtype,https://schema.org/DDxElement,< 1K
+Itemtype,https://schema.org/DENonprofitType,< 1K
+Itemtype,https://schema.org/DanceEvent,< 1K
+Itemtype,https://schema.org/DanceGroup,< 1K
+Itemtype,https://schema.org/DataCatalog,1K - 10K
+Itemtype,https://schema.org/DataDownload,10K - 100K
+Itemtype,https://schema.org/DataFeed,1K - 10K
+Itemtype,https://schema.org/DataFeedItem,1K - 10K
+Itemtype,https://schema.org/DataType,< 1K
+Itemtype,https://schema.org/Dataset,10K - 100K
+Itemtype,https://schema.org/Date,< 1K
+Itemtype,https://schema.org/DateTime,< 1K
+Itemtype,https://schema.org/DatedMoneySpecification,< 1K
+Itemtype,https://schema.org/DayOfWeek,10K - 100K
+Itemtype,https://schema.org/DaySpa,1K - 10K
+Itemtype,https://schema.org/DeactivateAction,< 1K
+Itemtype,https://schema.org/DefenceEstablishment,< 1K
+Itemtype,https://schema.org/DefinedRegion,100K - 1M
+Itemtype,https://schema.org/DefinedTerm,10K - 100K
+Itemtype,https://schema.org/DefinedTermSet,10K - 100K
+Itemtype,https://schema.org/DeleteAction,< 1K
+Itemtype,https://schema.org/DeliveryChargeSpecification,10K - 100K
+Itemtype,https://schema.org/DeliveryEvent,< 1K
+Itemtype,https://schema.org/DeliveryMethod,1K - 10K
+Itemtype,https://schema.org/DeliveryTimeSettings,< 1K
+Itemtype,https://schema.org/Demand,1K - 10K
+Itemtype,https://schema.org/Dentist,10K - 100K
+Itemtype,https://schema.org/DepartAction,< 1K
+Itemtype,https://schema.org/DepartmentStore,1K - 10K
+Itemtype,https://schema.org/DepositAccount,< 1K
+Itemtype,https://schema.org/Dermatology,1K - 10K
+Itemtype,https://schema.org/DiagnosticLab,1K - 10K
+Itemtype,https://schema.org/DiagnosticProcedure,< 1K
+Itemtype,https://schema.org/Diet,< 1K
+Itemtype,https://schema.org/DietNutrition,1K - 10K
+Itemtype,https://schema.org/DietarySupplement,< 1K
+Itemtype,https://schema.org/DigitalDocument,10K - 100K
+Itemtype,https://schema.org/DigitalDocumentPermission,< 1K
+Itemtype,https://schema.org/DigitalDocumentPermissionType,< 1K
+Itemtype,https://schema.org/DigitalPlatformEnumeration,< 1K
+Itemtype,https://schema.org/DisagreeAction,< 1K
+Itemtype,https://schema.org/DiscoverAction,< 1K
+Itemtype,https://schema.org/DiscussionForumPosting,10K - 100K
+Itemtype,https://schema.org/DislikeAction,1K - 10K
+Itemtype,https://schema.org/Distance,1K - 10K
+Itemtype,https://schema.org/Distillery,< 1K
+Itemtype,https://schema.org/DonateAction,1K - 10K
+Itemtype,https://schema.org/DoseSchedule,< 1K
+Itemtype,https://schema.org/DownloadAction,1K - 10K
+Itemtype,https://schema.org/DrawAction,< 1K
+Itemtype,https://schema.org/Drawing,< 1K
+Itemtype,https://schema.org/DrinkAction,< 1K
+Itemtype,https://schema.org/DriveWheelConfigurationValue,< 1K
+Itemtype,https://schema.org/Drug,1K - 10K
+Itemtype,https://schema.org/DrugClass,1K - 10K
+Itemtype,https://schema.org/DrugCost,< 1K
+Itemtype,https://schema.org/DrugCostCategory,< 1K
+Itemtype,https://schema.org/DrugLegalStatus,< 1K
+Itemtype,https://schema.org/DrugPregnancyCategory,< 1K
+Itemtype,https://schema.org/DrugPrescriptionStatus,< 1K
+Itemtype,https://schema.org/DrugStrength,< 1K
+Itemtype,https://schema.org/DryCleaningOrLaundry,1K - 10K
+Itemtype,https://schema.org/Duration,10K - 100K
+Itemtype,https://schema.org/EUEnergyEfficiencyEnumeration,< 1K
+Itemtype,https://schema.org/EatAction,< 1K
+Itemtype,https://schema.org/EducationEvent,1K - 10K
+Itemtype,https://schema.org/EducationalAudience,10K - 100K
+Itemtype,https://schema.org/EducationalOccupationalCredential,100K - 1M
+Itemtype,https://schema.org/EducationalOccupationalProgram,1K - 10K
+Itemtype,https://schema.org/EducationalOrganization,100K - 1M
+Itemtype,https://schema.org/Electrician,10K - 100K
+Itemtype,https://schema.org/ElectronicsStore,1K - 10K
+Itemtype,https://schema.org/ElementarySchool,< 1K
+Itemtype,https://schema.org/EmailMessage,< 1K
+Itemtype,https://schema.org/Embassy,< 1K
+Itemtype,https://schema.org/Emergency,< 1K
+Itemtype,https://schema.org/EmergencyService,1K - 10K
+Itemtype,https://schema.org/EmployeeRole,< 1K
+Itemtype,https://schema.org/EmployerAggregateRating,1K - 10K
+Itemtype,https://schema.org/EmployerReview,< 1K
+Itemtype,https://schema.org/EmploymentAgency,1K - 10K
+Itemtype,https://schema.org/EndorseAction,< 1K
+Itemtype,https://schema.org/EndorsementRating,< 1K
+Itemtype,https://schema.org/Energy,< 1K
+Itemtype,https://schema.org/EnergyConsumptionDetails,1K - 10K
+Itemtype,https://schema.org/EnergyEfficiencyEnumeration,< 1K
+Itemtype,https://schema.org/EnergyStarEnergyEfficiencyEnumeration,< 1K
+Itemtype,https://schema.org/EngineSpecification,10K - 100K
+Itemtype,https://schema.org/EntertainmentBusiness,10K - 100K
+Itemtype,https://schema.org/EntryPoint,10M+
+Itemtype,https://schema.org/Enumeration,1K - 10K
+Itemtype,https://schema.org/Episode,1K - 10K
+Itemtype,https://schema.org/Error,< 1K
+Itemtype,https://schema.org/Event,100K - 1M
+Itemtype,https://schema.org/EventAttendanceModeEnumeration,< 1K
+Itemtype,https://schema.org/EventReservation,< 1K
+Itemtype,https://schema.org/EventSeries,1K - 10K
+Itemtype,https://schema.org/EventStatusType,< 1K
+Itemtype,https://schema.org/EventVenue,10K - 100K
+Itemtype,https://schema.org/ExchangeRateSpecification,< 1K
+Itemtype,https://schema.org/ExerciseAction,< 1K
+Itemtype,https://schema.org/ExerciseGym,1K - 10K
+Itemtype,https://schema.org/ExercisePlan,< 1K
+Itemtype,https://schema.org/ExhibitionEvent,1K - 10K
+Itemtype,https://schema.org/FAQPage,1M - 10M
+Itemtype,https://schema.org/FMRadioChannel,< 1K
+Itemtype,https://schema.org/FastFoodRestaurant,1K - 10K
+Itemtype,https://schema.org/Festival,1K - 10K
+Itemtype,https://schema.org/FilmAction,< 1K
+Itemtype,https://schema.org/FinancialIncentive,< 1K
+Itemtype,https://schema.org/FinancialProduct,10K - 100K
+Itemtype,https://schema.org/FinancialService,10K - 100K
+Itemtype,https://schema.org/FindAction,1K - 10K
+Itemtype,https://schema.org/FireStation,< 1K
+Itemtype,https://schema.org/Flight,1K - 10K
+Itemtype,https://schema.org/FlightReservation,< 1K
+Itemtype,https://schema.org/Float,< 1K
+Itemtype,https://schema.org/FloorPlan,10K - 100K
+Itemtype,https://schema.org/Florist,10K - 100K
+Itemtype,https://schema.org/FollowAction,10K - 100K
+Itemtype,https://schema.org/FoodEstablishment,10K - 100K
+Itemtype,https://schema.org/FoodEstablishmentReservation,1K - 10K
+Itemtype,https://schema.org/FoodEvent,1K - 10K
+Itemtype,https://schema.org/FoodService,1K - 10K
+Itemtype,https://schema.org/FulfillmentTypeEnumeration,< 1K
+Itemtype,https://schema.org/FundingAgency,< 1K
+Itemtype,https://schema.org/FundingScheme,< 1K
+Itemtype,https://schema.org/FurnitureStore,10K - 100K
+Itemtype,https://schema.org/Game,100K - 1M
+Itemtype,https://schema.org/GameAvailabilityEnumeration,< 1K
+Itemtype,https://schema.org/GamePlayMode,< 1K
+Itemtype,https://schema.org/GameServer,1K - 10K
+Itemtype,https://schema.org/GameServerStatus,< 1K
+Itemtype,https://schema.org/GardenStore,1K - 10K
+Itemtype,https://schema.org/GasStation,1K - 10K
+Itemtype,https://schema.org/GatedResidenceCommunity,< 1K
+Itemtype,https://schema.org/GenderType,< 1K
+Itemtype,https://schema.org/Gene,< 1K
+Itemtype,https://schema.org/GeneralContractor,10K - 100K
+Itemtype,https://schema.org/GeoCircle,100K - 1M
+Itemtype,https://schema.org/GeoCoordinates,1M - 10M
+Itemtype,https://schema.org/GeoShape,10K - 100K
+Itemtype,https://schema.org/GeospatialGeometry,< 1K
+Itemtype,https://schema.org/Geriatric,< 1K
+Itemtype,https://schema.org/GiveAction,< 1K
+Itemtype,https://schema.org/GolfCourse,1K - 10K
+Itemtype,https://schema.org/GovernmentBenefitsType,< 1K
+Itemtype,https://schema.org/GovernmentBuilding,< 1K
+Itemtype,https://schema.org/GovernmentOffice,1K - 10K
+Itemtype,https://schema.org/GovernmentOrganization,10K - 100K
+Itemtype,https://schema.org/GovernmentPermit,< 1K
+Itemtype,https://schema.org/GovernmentService,1K - 10K
+Itemtype,https://schema.org/Grant,1K - 10K
+Itemtype,https://schema.org/GroceryStore,1K - 10K
+Itemtype,https://schema.org/Guide,1K - 10K
+Itemtype,https://schema.org/Gynecologic,< 1K
+Itemtype,https://schema.org/HVACBusiness,10K - 100K
+Itemtype,https://schema.org/Hackathon,< 1K
+Itemtype,https://schema.org/HairSalon,10K - 100K
+Itemtype,https://schema.org/HardwareStore,1K - 10K
+Itemtype,https://schema.org/HealthAndBeautyBusiness,10K - 100K
+Itemtype,https://schema.org/HealthAspectEnumeration,< 1K
+Itemtype,https://schema.org/HealthClub,1K - 10K
+Itemtype,https://schema.org/HealthInsurancePlan,< 1K
+Itemtype,https://schema.org/HealthPlanCostSharingSpecification,< 1K
+Itemtype,https://schema.org/HealthPlanFormulary,< 1K
+Itemtype,https://schema.org/HealthPlanNetwork,< 1K
+Itemtype,https://schema.org/HealthTopicContent,< 1K
+Itemtype,https://schema.org/HighSchool,1K - 10K
+Itemtype,https://schema.org/HinduTemple,< 1K
+Itemtype,https://schema.org/HobbyShop,1K - 10K
+Itemtype,https://schema.org/HomeAndConstructionBusiness,100K - 1M
+Itemtype,https://schema.org/HomeGoodsStore,1K - 10K
+Itemtype,https://schema.org/Hospital,10K - 100K
+Itemtype,https://schema.org/Hostel,1K - 10K
+Itemtype,https://schema.org/Hotel,100K - 1M
+Itemtype,https://schema.org/HotelRoom,10K - 100K
+Itemtype,https://schema.org/House,10K - 100K
+Itemtype,https://schema.org/HousePainter,1K - 10K
+Itemtype,https://schema.org/HowTo,100K - 1M
+Itemtype,https://schema.org/HowToDirection,10K - 100K
+Itemtype,https://schema.org/HowToItem,< 1K
+Itemtype,https://schema.org/HowToSection,10K - 100K
+Itemtype,https://schema.org/HowToStep,100K - 1M
+Itemtype,https://schema.org/HowToSupply,10K - 100K
+Itemtype,https://schema.org/HowToTip,1K - 10K
+Itemtype,https://schema.org/HowToTool,10K - 100K
+Itemtype,https://schema.org/HyperToc,< 1K
+Itemtype,https://schema.org/HyperTocEntry,< 1K
+Itemtype,https://schema.org/IPTCDigitalSourceEnumeration,< 1K
+Itemtype,https://schema.org/ITNonprofitType,< 1K
+Itemtype,https://schema.org/IceCreamShop,1K - 10K
+Itemtype,https://schema.org/IgnoreAction,< 1K
+Itemtype,https://schema.org/ImageGallery,1M - 10M
+Itemtype,https://schema.org/ImageObject,10M+
+Itemtype,https://schema.org/ImageObjectSnapshot,< 1K
+Itemtype,https://schema.org/ImagingTest,< 1K
+Itemtype,https://schema.org/IncentiveQualifiedExpenseType,< 1K
+Itemtype,https://schema.org/IncentiveStatus,< 1K
+Itemtype,https://schema.org/IncentiveType,< 1K
+Itemtype,https://schema.org/IndividualPhysician,1K - 10K
+Itemtype,https://schema.org/IndividualProduct,10K - 100K
+Itemtype,https://schema.org/InfectiousAgentClass,< 1K
+Itemtype,https://schema.org/InfectiousDisease,< 1K
+Itemtype,https://schema.org/InformAction,< 1K
+Itemtype,https://schema.org/InsertAction,< 1K
+Itemtype,https://schema.org/InstallAction,< 1K
+Itemtype,https://schema.org/InstantaneousEvent,< 1K
+Itemtype,https://schema.org/InsuranceAgency,10K - 100K
+Itemtype,https://schema.org/Intangible,1K - 10K
+Itemtype,https://schema.org/Integer,< 1K
+Itemtype,https://schema.org/InteractAction,1K - 10K
+Itemtype,https://schema.org/InteractionCounter,100K - 1M
+Itemtype,https://schema.org/InternetCafe,< 1K
+Itemtype,https://schema.org/InvestmentFund,< 1K
+Itemtype,https://schema.org/InvestmentOrDeposit,< 1K
+Itemtype,https://schema.org/InviteAction,< 1K
+Itemtype,https://schema.org/Invoice,< 1K
+Itemtype,https://schema.org/ItemAvailability,1K - 10K
+Itemtype,https://schema.org/ItemList,1M - 10M
+Itemtype,https://schema.org/ItemListOrderType,< 1K
+Itemtype,https://schema.org/ItemPage,1M - 10M
+Itemtype,https://schema.org/JewelryStore,10K - 100K
+Itemtype,https://schema.org/JobPosting,100K - 1M
+Itemtype,https://schema.org/JoinAction,1K - 10K
+Itemtype,https://schema.org/Joint,< 1K
+Itemtype,https://schema.org/LakeBodyOfWater,< 1K
+Itemtype,https://schema.org/Landform,1K - 10K
+Itemtype,https://schema.org/LandmarksOrHistoricalBuildings,1K - 10K
+Itemtype,https://schema.org/Language,10K - 100K
+Itemtype,https://schema.org/LearningResource,1K - 10K
+Itemtype,https://schema.org/LeaveAction,< 1K
+Itemtype,https://schema.org/LegalForceStatus,< 1K
+Itemtype,https://schema.org/LegalService,10K - 100K
+Itemtype,https://schema.org/LegalValueLevel,< 1K
+Itemtype,https://schema.org/Legislation,1K - 10K
+Itemtype,https://schema.org/LegislationObject,1K - 10K
+Itemtype,https://schema.org/LegislativeBuilding,< 1K
+Itemtype,https://schema.org/LendAction,< 1K
+Itemtype,https://schema.org/Library,1K - 10K
+Itemtype,https://schema.org/LibrarySystem,< 1K
+Itemtype,https://schema.org/LifestyleModification,< 1K
+Itemtype,https://schema.org/Ligament,< 1K
+Itemtype,https://schema.org/LikeAction,10K - 100K
+Itemtype,https://schema.org/LinkRole,< 1K
+Itemtype,https://schema.org/LiquorStore,1K - 10K
+Itemtype,https://schema.org/ListItem,10M+
+Itemtype,https://schema.org/ListenAction,1K - 10K
+Itemtype,https://schema.org/Literal,< 1K
+Itemtype,https://schema.org/LiteraryEvent,< 1K
+Itemtype,https://schema.org/LiveBlogPosting,1K - 10K
+Itemtype,https://schema.org/LoanOrCredit,1K - 10K
+Itemtype,https://schema.org/LocalBusiness,1M - 10M
+Itemtype,https://schema.org/LocationFeatureSpecification,100K - 1M
+Itemtype,https://schema.org/Locksmith,10K - 100K
+Itemtype,https://schema.org/LodgingBusiness,10K - 100K
+Itemtype,https://schema.org/LodgingReservation,1K - 10K
+Itemtype,https://schema.org/LoginAction,1K - 10K
+Itemtype,https://schema.org/LoseAction,< 1K
+Itemtype,https://schema.org/LymphaticVessel,< 1K
+Itemtype,https://schema.org/Manuscript,< 1K
+Itemtype,https://schema.org/Map,10K - 100K
+Itemtype,https://schema.org/MapCategoryType,< 1K
+Itemtype,https://schema.org/MarryAction,< 1K
+Itemtype,https://schema.org/Mass,< 1K
+Itemtype,https://schema.org/MathSolver,< 1K
+Itemtype,https://schema.org/MaximumDoseSchedule,< 1K
+Itemtype,https://schema.org/MeasurementMethodEnum,< 1K
+Itemtype,https://schema.org/MeasurementTypeEnumeration,< 1K
+Itemtype,https://schema.org/MediaEnumeration,< 1K
+Itemtype,https://schema.org/MediaGallery,1K - 10K
+Itemtype,https://schema.org/MediaManipulationRatingEnumeration,< 1K
+Itemtype,https://schema.org/MediaObject,100K - 1M
+Itemtype,https://schema.org/MediaReview,< 1K
+Itemtype,https://schema.org/MediaReviewItem,< 1K
+Itemtype,https://schema.org/MediaSubscription,< 1K
+Itemtype,https://schema.org/MedicalAudience,10K - 100K
+Itemtype,https://schema.org/MedicalAudienceType,< 1K
+Itemtype,https://schema.org/MedicalBusiness,100K - 1M
+Itemtype,https://schema.org/MedicalCause,1K - 10K
+Itemtype,https://schema.org/MedicalClinic,10K - 100K
+Itemtype,https://schema.org/MedicalCode,1K - 10K
+Itemtype,https://schema.org/MedicalCondition,10K - 100K
+Itemtype,https://schema.org/MedicalConditionStage,< 1K
+Itemtype,https://schema.org/MedicalContraindication,< 1K
+Itemtype,https://schema.org/MedicalDevice,1K - 10K
+Itemtype,https://schema.org/MedicalDevicePurpose,< 1K
+Itemtype,https://schema.org/MedicalEntity,1K - 10K
+Itemtype,https://schema.org/MedicalEnumeration,< 1K
+Itemtype,https://schema.org/MedicalEvidenceLevel,< 1K
+Itemtype,https://schema.org/MedicalGuideline,1K - 10K
+Itemtype,https://schema.org/MedicalGuidelineContraindication,< 1K
+Itemtype,https://schema.org/MedicalGuidelineRecommendation,< 1K
+Itemtype,https://schema.org/MedicalImagingTechnique,< 1K
+Itemtype,https://schema.org/MedicalIndication,1K - 10K
+Itemtype,https://schema.org/MedicalIntangible,< 1K
+Itemtype,https://schema.org/MedicalObservationalStudy,< 1K
+Itemtype,https://schema.org/MedicalObservationalStudyDesign,< 1K
+Itemtype,https://schema.org/MedicalOrganization,10K - 100K
+Itemtype,https://schema.org/MedicalProcedure,10K - 100K
+Itemtype,https://schema.org/MedicalProcedureType,< 1K
+Itemtype,https://schema.org/MedicalRiskCalculator,< 1K
+Itemtype,https://schema.org/MedicalRiskEstimator,< 1K
+Itemtype,https://schema.org/MedicalRiskFactor,1K - 10K
+Itemtype,https://schema.org/MedicalRiskScore,< 1K
+Itemtype,https://schema.org/MedicalScholarlyArticle,1K - 10K
+Itemtype,https://schema.org/MedicalSign,< 1K
+Itemtype,https://schema.org/MedicalSignOrSymptom,1K - 10K
+Itemtype,https://schema.org/MedicalSpecialty,10K - 100K
+Itemtype,https://schema.org/MedicalStudy,1K - 10K
+Itemtype,https://schema.org/MedicalStudyStatus,< 1K
+Itemtype,https://schema.org/MedicalSymptom,1K - 10K
+Itemtype,https://schema.org/MedicalTest,1K - 10K
+Itemtype,https://schema.org/MedicalTestPanel,< 1K
+Itemtype,https://schema.org/MedicalTherapy,10K - 100K
+Itemtype,https://schema.org/MedicalTrial,< 1K
+Itemtype,https://schema.org/MedicalTrialDesign,< 1K
+Itemtype,https://schema.org/MedicalWebPage,10K - 100K
+Itemtype,https://schema.org/MedicineSystem,< 1K
+Itemtype,https://schema.org/MeetingRoom,1K - 10K
+Itemtype,https://schema.org/MemberProgram,1K - 10K
+Itemtype,https://schema.org/MemberProgramTier,1K - 10K
+Itemtype,https://schema.org/MensClothingStore,< 1K
+Itemtype,https://schema.org/Menu,100K - 1M
+Itemtype,https://schema.org/MenuItem,10K - 100K
+Itemtype,https://schema.org/MenuSection,10K - 100K
+Itemtype,https://schema.org/MerchantReturnEnumeration,< 1K
+Itemtype,https://schema.org/MerchantReturnPolicy,100K - 1M
+Itemtype,https://schema.org/MerchantReturnPolicySeasonalOverride,1K - 10K
+Itemtype,https://schema.org/Message,1K - 10K
+Itemtype,https://schema.org/MiddleSchool,< 1K
+Itemtype,https://schema.org/Midwifery,< 1K
+Itemtype,https://schema.org/MobileApplication,100K - 1M
+Itemtype,https://schema.org/MobilePhoneStore,1K - 10K
+Itemtype,https://schema.org/MolecularEntity,< 1K
+Itemtype,https://schema.org/MonetaryAmount,100K - 1M
+Itemtype,https://schema.org/MonetaryAmountDistribution,1K - 10K
+Itemtype,https://schema.org/MonetaryGrant,1K - 10K
+Itemtype,https://schema.org/MoneyTransfer,< 1K
+Itemtype,https://schema.org/MortgageLoan,< 1K
+Itemtype,https://schema.org/Mosque,< 1K
+Itemtype,https://schema.org/Motel,< 1K
+Itemtype,https://schema.org/Motorcycle,1K - 10K
+Itemtype,https://schema.org/MotorcycleDealer,1K - 10K
+Itemtype,https://schema.org/MotorcycleRepair,< 1K
+Itemtype,https://schema.org/MotorizedBicycle,< 1K
+Itemtype,https://schema.org/Mountain,< 1K
+Itemtype,https://schema.org/MoveAction,< 1K
+Itemtype,https://schema.org/Movie,10K - 100K
+Itemtype,https://schema.org/MovieClip,< 1K
+Itemtype,https://schema.org/MovieRentalStore,< 1K
+Itemtype,https://schema.org/MovieSeries,< 1K
+Itemtype,https://schema.org/MovieTheater,1K - 10K
+Itemtype,https://schema.org/MovingCompany,10K - 100K
+Itemtype,https://schema.org/Muscle,< 1K
+Itemtype,https://schema.org/Museum,1K - 10K
+Itemtype,https://schema.org/MusicAlbum,10K - 100K
+Itemtype,https://schema.org/MusicAlbumProductionType,< 1K
+Itemtype,https://schema.org/MusicAlbumReleaseType,< 1K
+Itemtype,https://schema.org/MusicComposition,1K - 10K
+Itemtype,https://schema.org/MusicEvent,10K - 100K
+Itemtype,https://schema.org/MusicGroup,10K - 100K
+Itemtype,https://schema.org/MusicPlaylist,1K - 10K
+Itemtype,https://schema.org/MusicRecording,10K - 100K
+Itemtype,https://schema.org/MusicRelease,1K - 10K
+Itemtype,https://schema.org/MusicReleaseFormatType,< 1K
+Itemtype,https://schema.org/MusicStore,1K - 10K
+Itemtype,https://schema.org/MusicVenue,1K - 10K
+Itemtype,https://schema.org/MusicVideoObject,< 1K
+Itemtype,https://schema.org/NGO,10K - 100K
+Itemtype,https://schema.org/NLNonprofitType,< 1K
+Itemtype,https://schema.org/NailSalon,1K - 10K
+Itemtype,https://schema.org/Nerve,< 1K
+Itemtype,https://schema.org/NewsArticle,100K - 1M
+Itemtype,https://schema.org/NewsMediaOrganization,10K - 100K
+Itemtype,https://schema.org/Newspaper,< 1K
+Itemtype,https://schema.org/NightClub,1K - 10K
+Itemtype,https://schema.org/NonprofitType,< 1K
+Itemtype,https://schema.org/Notary,1K - 10K
+Itemtype,https://schema.org/NoteDigitalDocument,< 1K
+Itemtype,https://schema.org/Number,< 1K
+Itemtype,https://schema.org/Nursing,< 1K
+Itemtype,https://schema.org/NutritionInformation,10K - 100K
+Itemtype,https://schema.org/Observation,< 1K
+Itemtype,https://schema.org/Obstetric,< 1K
+Itemtype,https://schema.org/Occupation,10K - 100K
+Itemtype,https://schema.org/OccupationalExperienceRequirements,1K - 10K
+Itemtype,https://schema.org/OccupationalTherapy,< 1K
+Itemtype,https://schema.org/OceanBodyOfWater,< 1K
+Itemtype,https://schema.org/Offer,10M+
+Itemtype,https://schema.org/OfferCatalog,100K - 1M
+Itemtype,https://schema.org/OfferForLease,1K - 10K
+Itemtype,https://schema.org/OfferForPurchase,1K - 10K
+Itemtype,https://schema.org/OfferItemCondition,1K - 10K
+Itemtype,https://schema.org/OfferShippingDetails,100K - 1M
+Itemtype,https://schema.org/OfficeEquipmentStore,1K - 10K
+Itemtype,https://schema.org/OnDemandEvent,< 1K
+Itemtype,https://schema.org/Oncologic,< 1K
+Itemtype,https://schema.org/OnlineBusiness,10K - 100K
+Itemtype,https://schema.org/OnlineMarketplace,< 1K
+Itemtype,https://schema.org/OnlineStore,100K - 1M
+Itemtype,https://schema.org/OpeningHoursSpecification,1M - 10M
+Itemtype,https://schema.org/OperatingSystem,< 1K
+Itemtype,https://schema.org/OpinionNewsArticle,1K - 10K
+Itemtype,https://schema.org/Optician,1K - 10K
+Itemtype,https://schema.org/Optometric,1K - 10K
+Itemtype,https://schema.org/Order,1K - 10K
+Itemtype,https://schema.org/OrderAction,10K - 100K
+Itemtype,https://schema.org/OrderItem,< 1K
+Itemtype,https://schema.org/OrderStatus,< 1K
+Itemtype,https://schema.org/Organization,10M+
+Itemtype,https://schema.org/OrganizationRole,1K - 10K
+Itemtype,https://schema.org/OrganizeAction,< 1K
+Itemtype,https://schema.org/Otolaryngologic,< 1K
+Itemtype,https://schema.org/OutletStore,< 1K
+Itemtype,https://schema.org/OwnershipInfo,< 1K
+Itemtype,https://schema.org/PaintAction,< 1K
+Itemtype,https://schema.org/Painting,< 1K
+Itemtype,https://schema.org/PalliativeProcedure,< 1K
+Itemtype,https://schema.org/ParcelDelivery,< 1K
+Itemtype,https://schema.org/ParentAudience,< 1K
+Itemtype,https://schema.org/Park,1K - 10K
+Itemtype,https://schema.org/ParkingFacility,1K - 10K
+Itemtype,https://schema.org/PathologyTest,< 1K
+Itemtype,https://schema.org/Patient,1K - 10K
+Itemtype,https://schema.org/PawnShop,< 1K
+Itemtype,https://schema.org/PayAction,< 1K
+Itemtype,https://schema.org/PaymentCard,< 1K
+Itemtype,https://schema.org/PaymentChargeSpecification,< 1K
+Itemtype,https://schema.org/PaymentMethod,10K - 100K
+Itemtype,https://schema.org/PaymentMethodType,< 1K
+Itemtype,https://schema.org/PaymentService,1K - 10K
+Itemtype,https://schema.org/PaymentStatusType,< 1K
+Itemtype,https://schema.org/Pediatric,< 1K
+Itemtype,https://schema.org/PeopleAudience,10K - 100K
+Itemtype,https://schema.org/PerformAction,< 1K
+Itemtype,https://schema.org/PerformanceRole,< 1K
+Itemtype,https://schema.org/PerformingArtsEvent,< 1K
+Itemtype,https://schema.org/PerformingArtsTheater,1K - 10K
+Itemtype,https://schema.org/PerformingGroup,10K - 100K
+Itemtype,https://schema.org/Periodical,1K - 10K
+Itemtype,https://schema.org/Permit,10K - 100K
+Itemtype,https://schema.org/Person,10M+
+Itemtype,https://schema.org/PetStore,1K - 10K
+Itemtype,https://schema.org/Pharmacy,10K - 100K
+Itemtype,https://schema.org/Photograph,10K - 100K
+Itemtype,https://schema.org/PhotographAction,< 1K
+Itemtype,https://schema.org/PhysicalActivity,< 1K
+Itemtype,https://schema.org/PhysicalActivityCategory,1K - 10K
+Itemtype,https://schema.org/PhysicalExam,< 1K
+Itemtype,https://schema.org/PhysicalTherapy,< 1K
+Itemtype,https://schema.org/Physician,10K - 100K
+Itemtype,https://schema.org/PhysiciansOffice,< 1K
+Itemtype,https://schema.org/Physiotherapy,1K - 10K
+Itemtype,https://schema.org/Place,1M - 10M
+Itemtype,https://schema.org/PlaceOfWorship,1K - 10K
+Itemtype,https://schema.org/PlanAction,< 1K
+Itemtype,https://schema.org/PlasticSurgery,< 1K
+Itemtype,https://schema.org/Play,< 1K
+Itemtype,https://schema.org/PlayAction,1K - 10K
+Itemtype,https://schema.org/PlayGameAction,< 1K
+Itemtype,https://schema.org/Playground,< 1K
+Itemtype,https://schema.org/Plumber,10K - 100K
+Itemtype,https://schema.org/PodcastEpisode,10K - 100K
+Itemtype,https://schema.org/PodcastSeason,< 1K
+Itemtype,https://schema.org/PodcastSeries,10K - 100K
+Itemtype,https://schema.org/Podiatric,< 1K
+Itemtype,https://schema.org/PoliceStation,< 1K
+Itemtype,https://schema.org/PoliticalParty,< 1K
+Itemtype,https://schema.org/Pond,< 1K
+Itemtype,https://schema.org/PostOffice,< 1K
+Itemtype,https://schema.org/PostalAddress,10M+
+Itemtype,https://schema.org/PostalCodeRangeSpecification,1K - 10K
+Itemtype,https://schema.org/Poster,< 1K
+Itemtype,https://schema.org/PreOrderAction,< 1K
+Itemtype,https://schema.org/PrependAction,< 1K
+Itemtype,https://schema.org/Preschool,1K - 10K
+Itemtype,https://schema.org/PresentationDigitalDocument,< 1K
+Itemtype,https://schema.org/PreventionIndication,< 1K
+Itemtype,https://schema.org/PriceComponentTypeEnumeration,< 1K
+Itemtype,https://schema.org/PriceSpecification,100K - 1M
+Itemtype,https://schema.org/PriceTypeEnumeration,< 1K
+Itemtype,https://schema.org/PrimaryCare,< 1K
+Itemtype,https://schema.org/Product,10M+
+Itemtype,https://schema.org/ProductCollection,1K - 10K
+Itemtype,https://schema.org/ProductGroup,100K - 1M
+Itemtype,https://schema.org/ProductModel,1K - 10K
+Itemtype,https://schema.org/ProductReturnEnumeration,< 1K
+Itemtype,https://schema.org/ProductReturnPolicy,< 1K
+Itemtype,https://schema.org/ProfessionalService,100K - 1M
+Itemtype,https://schema.org/ProfilePage,1M - 10M
+Itemtype,https://schema.org/ProgramMembership,1K - 10K
+Itemtype,https://schema.org/Project,1K - 10K
+Itemtype,https://schema.org/PronounceableText,< 1K
+Itemtype,https://schema.org/Property,< 1K
+Itemtype,https://schema.org/PropertyValue,100K - 1M
+Itemtype,https://schema.org/PropertyValueSpecification,10M+
+Itemtype,https://schema.org/Protein,< 1K
+Itemtype,https://schema.org/Psychiatric,1K - 10K
+Itemtype,https://schema.org/PsychologicalTreatment,< 1K
+Itemtype,https://schema.org/PublicHealth,< 1K
+Itemtype,https://schema.org/PublicSwimmingPool,< 1K
+Itemtype,https://schema.org/PublicToilet,< 1K
+Itemtype,https://schema.org/PublicationEvent,1K - 10K
+Itemtype,https://schema.org/PublicationIssue,1K - 10K
+Itemtype,https://schema.org/PublicationVolume,1K - 10K
+Itemtype,https://schema.org/PurchaseType,< 1K
+Itemtype,https://schema.org/QAPage,10K - 100K
+Itemtype,https://schema.org/QualitativeValue,1K - 10K
+Itemtype,https://schema.org/QuantitativeValue,1M - 10M
+Itemtype,https://schema.org/QuantitativeValueDistribution,< 1K
+Itemtype,https://schema.org/Quantity,< 1K
+Itemtype,https://schema.org/Question,1M - 10M
+Itemtype,https://schema.org/Quiz,1K - 10K
+Itemtype,https://schema.org/Quotation,1K - 10K
+Itemtype,https://schema.org/QuoteAction,1K - 10K
+Itemtype,https://schema.org/RVPark,< 1K
+Itemtype,https://schema.org/RadiationTherapy,< 1K
+Itemtype,https://schema.org/RadioBroadcastService,< 1K
+Itemtype,https://schema.org/RadioChannel,< 1K
+Itemtype,https://schema.org/RadioClip,< 1K
+Itemtype,https://schema.org/RadioEpisode,< 1K
+Itemtype,https://schema.org/RadioSeason,< 1K
+Itemtype,https://schema.org/RadioSeries,1K - 10K
+Itemtype,https://schema.org/RadioStation,1K - 10K
+Itemtype,https://schema.org/Rating,1M - 10M
+Itemtype,https://schema.org/ReactAction,< 1K
+Itemtype,https://schema.org/ReadAction,10M+
+Itemtype,https://schema.org/RealEstateAgent,100K - 1M
+Itemtype,https://schema.org/RealEstateListing,10K - 100K
+Itemtype,https://schema.org/ReceiveAction,< 1K
+Itemtype,https://schema.org/Recipe,10K - 100K
+Itemtype,https://schema.org/Recommendation,< 1K
+Itemtype,https://schema.org/RecommendedDoseSchedule,< 1K
+Itemtype,https://schema.org/RecyclingCenter,1K - 10K
+Itemtype,https://schema.org/RefundTypeEnumeration,< 1K
+Itemtype,https://schema.org/RegisterAction,10K - 100K
+Itemtype,https://schema.org/RejectAction,< 1K
+Itemtype,https://schema.org/RentAction,1K - 10K
+Itemtype,https://schema.org/RentalCarReservation,< 1K
+Itemtype,https://schema.org/RepaymentSpecification,< 1K
+Itemtype,https://schema.org/ReplaceAction,< 1K
+Itemtype,https://schema.org/ReplyAction,1K - 10K
+Itemtype,https://schema.org/Report,1K - 10K
+Itemtype,https://schema.org/ReportageNewsArticle,1K - 10K
+Itemtype,https://schema.org/ReportedDoseSchedule,< 1K
+Itemtype,https://schema.org/ResearchOrganization,1K - 10K
+Itemtype,https://schema.org/ResearchProject,1K - 10K
+Itemtype,https://schema.org/Researcher,< 1K
+Itemtype,https://schema.org/Reservation,10K - 100K
+Itemtype,https://schema.org/ReservationPackage,< 1K
+Itemtype,https://schema.org/ReservationStatusType,< 1K
+Itemtype,https://schema.org/ReserveAction,10K - 100K
+Itemtype,https://schema.org/Reservoir,< 1K
+Itemtype,https://schema.org/ResetPasswordAction,< 1K
+Itemtype,https://schema.org/Residence,10K - 100K
+Itemtype,https://schema.org/Resort,1K - 10K
+Itemtype,https://schema.org/RespiratoryTherapy,< 1K
+Itemtype,https://schema.org/Restaurant,100K - 1M
+Itemtype,https://schema.org/RestrictedDiet,1K - 10K
+Itemtype,https://schema.org/ResumeAction,< 1K
+Itemtype,https://schema.org/ReturnAction,< 1K
+Itemtype,https://schema.org/ReturnFeesEnumeration,< 1K
+Itemtype,https://schema.org/ReturnLabelSourceEnumeration,< 1K
+Itemtype,https://schema.org/ReturnMethodEnumeration,< 1K
+Itemtype,https://schema.org/Review,1M - 10M
+Itemtype,https://schema.org/ReviewAction,1K - 10K
+Itemtype,https://schema.org/ReviewNewsArticle,< 1K
+Itemtype,https://schema.org/RiverBodyOfWater,< 1K
+Itemtype,https://schema.org/Role,1K - 10K
+Itemtype,https://schema.org/RoofingContractor,10K - 100K
+Itemtype,https://schema.org/Room,1K - 10K
+Itemtype,https://schema.org/RsvpAction,< 1K
+Itemtype,https://schema.org/RsvpResponseType,< 1K
+Itemtype,https://schema.org/RuntimePlatform,< 1K
+Itemtype,https://schema.org/SaleEvent,1K - 10K
+Itemtype,https://schema.org/SatiricalArticle,< 1K
+Itemtype,https://schema.org/Schedule,10K - 100K
+Itemtype,https://schema.org/ScheduleAction,1K - 10K
+Itemtype,https://schema.org/ScholarlyArticle,10K - 100K
+Itemtype,https://schema.org/School,10K - 100K
+Itemtype,https://schema.org/SchoolDistrict,< 1K
+Itemtype,https://schema.org/ScreeningEvent,1K - 10K
+Itemtype,https://schema.org/Sculpture,< 1K
+Itemtype,https://schema.org/SeaBodyOfWater,< 1K
+Itemtype,https://schema.org/SearchAction,10M+
+Itemtype,https://schema.org/SearchRescueOrganization,< 1K
+Itemtype,https://schema.org/SearchResultsPage,10K - 100K
+Itemtype,https://schema.org/Season,< 1K
+Itemtype,https://schema.org/Seat,< 1K
+Itemtype,https://schema.org/SeekToAction,10K - 100K
+Itemtype,https://schema.org/SelfStorage,10K - 100K
+Itemtype,https://schema.org/SellAction,1K - 10K
+Itemtype,https://schema.org/SendAction,< 1K
+Itemtype,https://schema.org/SequentialArt,< 1K
+Itemtype,https://schema.org/Series,10K - 100K
+Itemtype,https://schema.org/Service,1M - 10M
+Itemtype,https://schema.org/ServiceChannel,100K - 1M
+Itemtype,https://schema.org/ServicePeriod,1K - 10K
+Itemtype,https://schema.org/ShareAction,10K - 100K
+Itemtype,https://schema.org/SheetMusic,< 1K
+Itemtype,https://schema.org/ShippingConditions,10K - 100K
+Itemtype,https://schema.org/ShippingDeliveryTime,100K - 1M
+Itemtype,https://schema.org/ShippingRateSettings,< 1K
+Itemtype,https://schema.org/ShippingService,10K - 100K
+Itemtype,https://schema.org/ShoeStore,1K - 10K
+Itemtype,https://schema.org/ShoppingCenter,1K - 10K
+Itemtype,https://schema.org/ShortStory,< 1K
+Itemtype,https://schema.org/SingleFamilyResidence,10K - 100K
+Itemtype,https://schema.org/SiteNavigationElement,1M - 10M
+Itemtype,https://schema.org/SizeGroupEnumeration,< 1K
+Itemtype,https://schema.org/SizeSpecification,1K - 10K
+Itemtype,https://schema.org/SizeSystemEnumeration,< 1K
+Itemtype,https://schema.org/SkiResort,< 1K
+Itemtype,https://schema.org/SocialEvent,1K - 10K
+Itemtype,https://schema.org/SocialMediaPosting,10K - 100K
+Itemtype,https://schema.org/SoftwareApplication,1M - 10M
+Itemtype,https://schema.org/SoftwareSourceCode,1K - 10K
+Itemtype,https://schema.org/SolveMathAction,< 1K
+Itemtype,https://schema.org/SomeProducts,10K - 100K
+Itemtype,https://schema.org/SpeakableSpecification,100K - 1M
+Itemtype,https://schema.org/SpecialAnnouncement,1K - 10K
+Itemtype,https://schema.org/Specialty,1K - 10K
+Itemtype,https://schema.org/SportingGoodsStore,1K - 10K
+Itemtype,https://schema.org/SportsActivityLocation,10K - 100K
+Itemtype,https://schema.org/SportsClub,1K - 10K
+Itemtype,https://schema.org/SportsEvent,10K - 100K
+Itemtype,https://schema.org/SportsOrganization,10K - 100K
+Itemtype,https://schema.org/SportsTeam,10K - 100K
+Itemtype,https://schema.org/SpreadsheetDigitalDocument,< 1K
+Itemtype,https://schema.org/StadiumOrArena,1K - 10K
+Itemtype,https://schema.org/State,100K - 1M
+Itemtype,https://schema.org/Statement,< 1K
+Itemtype,https://schema.org/StatisticalPopulation,< 1K
+Itemtype,https://schema.org/StatisticalVariable,< 1K
+Itemtype,https://schema.org/StatusEnumeration,< 1K
+Itemtype,https://schema.org/SteeringPositionValue,< 1K
+Itemtype,https://schema.org/Store,100K - 1M
+Itemtype,https://schema.org/StructuredValue,1K - 10K
+Itemtype,https://schema.org/StupidType,< 1K
+Itemtype,https://schema.org/SubscribeAction,10K - 100K
+Itemtype,https://schema.org/Substance,< 1K
+Itemtype,https://schema.org/SubwayStation,< 1K
+Itemtype,https://schema.org/Suite,< 1K
+Itemtype,https://schema.org/SuperficialAnatomy,< 1K
+Itemtype,https://schema.org/SurgicalProcedure,1K - 10K
+Itemtype,https://schema.org/SuspendAction,< 1K
+Itemtype,https://schema.org/Syllabus,1K - 10K
+Itemtype,https://schema.org/Synagogue,< 1K
+Itemtype,https://schema.org/TVClip,< 1K
+Itemtype,https://schema.org/TVEpisode,1K - 10K
+Itemtype,https://schema.org/TVSeason,1K - 10K
+Itemtype,https://schema.org/TVSeries,10K - 100K
+Itemtype,https://schema.org/Table,10K - 100K
+Itemtype,https://schema.org/TakeAction,< 1K
+Itemtype,https://schema.org/TattooParlor,1K - 10K
+Itemtype,https://schema.org/Taxi,< 1K
+Itemtype,https://schema.org/TaxiReservation,< 1K
+Itemtype,https://schema.org/TaxiService,10K - 100K
+Itemtype,https://schema.org/TaxiStand,< 1K
+Itemtype,https://schema.org/Taxon,< 1K
+Itemtype,https://schema.org/TechArticle,10K - 100K
+Itemtype,https://schema.org/TelevisionChannel,< 1K
+Itemtype,https://schema.org/TelevisionStation,< 1K
+Itemtype,https://schema.org/TennisComplex,< 1K
+Itemtype,https://schema.org/Text,10K - 100K
+Itemtype,https://schema.org/TextDigitalDocument,< 1K
+Itemtype,https://schema.org/TextObject,1K - 10K
+Itemtype,https://schema.org/TheaterEvent,1K - 10K
+Itemtype,https://schema.org/TheaterGroup,1K - 10K
+Itemtype,https://schema.org/TherapeuticProcedure,1K - 10K
+Itemtype,https://schema.org/Thesis,< 1K
+Itemtype,https://schema.org/Thing,10M+
+Itemtype,https://schema.org/Ticket,< 1K
+Itemtype,https://schema.org/TieAction,< 1K
+Itemtype,https://schema.org/TierBenefitEnumeration,< 1K
+Itemtype,https://schema.org/Time,< 1K
+Itemtype,https://schema.org/TipAction,< 1K
+Itemtype,https://schema.org/TireShop,1K - 10K
+Itemtype,https://schema.org/TouristAttraction,10K - 100K
+Itemtype,https://schema.org/TouristDestination,10K - 100K
+Itemtype,https://schema.org/TouristInformationCenter,1K - 10K
+Itemtype,https://schema.org/TouristTrip,10K - 100K
+Itemtype,https://schema.org/ToyStore,1K - 10K
+Itemtype,https://schema.org/TrackAction,< 1K
+Itemtype,https://schema.org/TradeAction,1K - 10K
+Itemtype,https://schema.org/TrainReservation,< 1K
+Itemtype,https://schema.org/TrainStation,1K - 10K
+Itemtype,https://schema.org/TrainTrip,< 1K
+Itemtype,https://schema.org/TransferAction,< 1K
+Itemtype,https://schema.org/TravelAction,1K - 10K
+Itemtype,https://schema.org/TravelAgency,10K - 100K
+Itemtype,https://schema.org/TreatmentIndication,< 1K
+Itemtype,https://schema.org/Trip,10K - 100K
+Itemtype,https://schema.org/TypeAndQuantityNode,1K - 10K
+Itemtype,https://schema.org/UKNonprofitType,< 1K
+Itemtype,https://schema.org/URL,1K - 10K
+Itemtype,https://schema.org/USNonprofitType,< 1K
+Itemtype,https://schema.org/UnRegisterAction,< 1K
+Itemtype,https://schema.org/UnitPriceSpecification,1M - 10M
+Itemtype,https://schema.org/UpdateAction,< 1K
+Itemtype,https://schema.org/UseAction,1K - 10K
+Itemtype,https://schema.org/UserBlocks,< 1K
+Itemtype,https://schema.org/UserCheckins,1K - 10K
+Itemtype,https://schema.org/UserComments,10K - 100K
+Itemtype,https://schema.org/UserDownloads,< 1K
+Itemtype,https://schema.org/UserInteraction,< 1K
+Itemtype,https://schema.org/UserLikes,< 1K
+Itemtype,https://schema.org/UserPageVisits,< 1K
+Itemtype,https://schema.org/UserPlays,< 1K
+Itemtype,https://schema.org/UserPlusOnes,< 1K
+Itemtype,https://schema.org/UserReview,1K - 10K
+Itemtype,https://schema.org/UserTweets,< 1K
+Itemtype,https://schema.org/VacationRental,10K - 100K
+Itemtype,https://schema.org/Vehicle,10K - 100K
+Itemtype,https://schema.org/Vein,< 1K
+Itemtype,https://schema.org/Vessel,< 1K
+Itemtype,https://schema.org/VeterinaryCare,1K - 10K
+Itemtype,https://schema.org/VideoGallery,1K - 10K
+Itemtype,https://schema.org/VideoGame,10K - 100K
+Itemtype,https://schema.org/VideoGameClip,< 1K
+Itemtype,https://schema.org/VideoGameSeries,1K - 10K
+Itemtype,https://schema.org/VideoObject,1M - 10M
+Itemtype,https://schema.org/VideoObjectSnapshot,< 1K
+Itemtype,https://schema.org/ViewAction,10K - 100K
+Itemtype,https://schema.org/VirtualLocation,10K - 100K
+Itemtype,https://schema.org/VisualArtsEvent,< 1K
+Itemtype,https://schema.org/VisualArtwork,1K - 10K
+Itemtype,https://schema.org/VitalSign,< 1K
+Itemtype,https://schema.org/Volcano,< 1K
+Itemtype,https://schema.org/VoteAction,< 1K
+Itemtype,https://schema.org/WPAdBlock,10K - 100K
+Itemtype,https://schema.org/WPFooter,1M - 10M
+Itemtype,https://schema.org/WPHeader,1M - 10M
+Itemtype,https://schema.org/WPSideBar,1M - 10M
+Itemtype,https://schema.org/WantAction,< 1K
+Itemtype,https://schema.org/WarrantyPromise,10K - 100K
+Itemtype,https://schema.org/WarrantyScope,< 1K
+Itemtype,https://schema.org/WatchAction,100K - 1M
+Itemtype,https://schema.org/Waterfall,< 1K
+Itemtype,https://schema.org/WearAction,< 1K
+Itemtype,https://schema.org/WearableMeasurementTypeEnumeration,< 1K
+Itemtype,https://schema.org/WearableSizeGroupEnumeration,< 1K
+Itemtype,https://schema.org/WearableSizeSystemEnumeration,< 1K
+Itemtype,https://schema.org/WebAPI,1K - 10K
+Itemtype,https://schema.org/WebApplication,100K - 1M
+Itemtype,https://schema.org/WebContent,1K - 10K
+Itemtype,https://schema.org/WebPage,10M+
+Itemtype,https://schema.org/WebPageElement,1M - 10M
+Itemtype,https://schema.org/WebSite,10M+
+Itemtype,https://schema.org/WholesaleStore,1K - 10K
+Itemtype,https://schema.org/WinAction,< 1K
+Itemtype,https://schema.org/Winery,1K - 10K
+Itemtype,https://schema.org/WorkBasedProgram,< 1K
+Itemtype,https://schema.org/WorkersUnion,< 1K
+Itemtype,https://schema.org/WriteAction,10K - 100K
+Itemtype,https://schema.org/XPathType,< 1K
+Itemtype,https://schema.org/Zoo,< 1K
+Predicate,https://schema.org/about,10M+
+Predicate,https://schema.org/about-input,< 1K
+Predicate,https://schema.org/about-output,< 1K
+Predicate,https://schema.org/abridged,< 1K
+Predicate,https://schema.org/abridged-input,< 1K
+Predicate,https://schema.org/abridged-output,< 1K
+Predicate,https://schema.org/abstract,10K - 100K
+Predicate,https://schema.org/abstract-input,< 1K
+Predicate,https://schema.org/abstract-output,< 1K
+Predicate,https://schema.org/accelerationTime,1K - 10K
+Predicate,https://schema.org/accelerationTime-input,< 1K
+Predicate,https://schema.org/accelerationTime-output,< 1K
+Predicate,https://schema.org/acceptedAnswer,1M - 10M
+Predicate,https://schema.org/acceptedAnswer-input,< 1K
+Predicate,https://schema.org/acceptedAnswer-output,< 1K
+Predicate,https://schema.org/acceptedOffer,< 1K
+Predicate,https://schema.org/acceptedOffer-input,< 1K
+Predicate,https://schema.org/acceptedOffer-output,< 1K
+Predicate,https://schema.org/acceptedPaymentMethod,10K - 100K
+Predicate,https://schema.org/acceptedPaymentMethod-input,< 1K
+Predicate,https://schema.org/acceptedPaymentMethod-output,< 1K
+Predicate,https://schema.org/acceptsReservations,100K - 1M
+Predicate,https://schema.org/acceptsReservations-input,< 1K
+Predicate,https://schema.org/acceptsReservations-output,< 1K
+Predicate,https://schema.org/accessCode,< 1K
+Predicate,https://schema.org/accessCode-input,< 1K
+Predicate,https://schema.org/accessCode-output,< 1K
+Predicate,https://schema.org/accessMode,1K - 10K
+Predicate,https://schema.org/accessMode-input,< 1K
+Predicate,https://schema.org/accessMode-output,< 1K
+Predicate,https://schema.org/accessModeSufficient,1K - 10K
+Predicate,https://schema.org/accessModeSufficient-input,< 1K
+Predicate,https://schema.org/accessModeSufficient-output,< 1K
+Predicate,https://schema.org/accessibilityAPI,1K - 10K
+Predicate,https://schema.org/accessibilityAPI-input,< 1K
+Predicate,https://schema.org/accessibilityAPI-output,< 1K
+Predicate,https://schema.org/accessibilityControl,1K - 10K
+Predicate,https://schema.org/accessibilityControl-input,< 1K
+Predicate,https://schema.org/accessibilityControl-output,< 1K
+Predicate,https://schema.org/accessibilityFeature,10K - 100K
+Predicate,https://schema.org/accessibilityFeature-input,< 1K
+Predicate,https://schema.org/accessibilityFeature-output,< 1K
+Predicate,https://schema.org/accessibilityHazard,1K - 10K
+Predicate,https://schema.org/accessibilityHazard-input,< 1K
+Predicate,https://schema.org/accessibilityHazard-output,< 1K
+Predicate,https://schema.org/accessibilitySummary,10K - 100K
+Predicate,https://schema.org/accessibilitySummary-input,< 1K
+Predicate,https://schema.org/accessibilitySummary-output,< 1K
+Predicate,https://schema.org/accommodationCategory,1K - 10K
+Predicate,https://schema.org/accommodationCategory-input,< 1K
+Predicate,https://schema.org/accommodationCategory-output,< 1K
+Predicate,https://schema.org/accommodationFloorPlan,10K - 100K
+Predicate,https://schema.org/accommodationFloorPlan-input,< 1K
+Predicate,https://schema.org/accommodationFloorPlan-output,< 1K
+Predicate,https://schema.org/accountId,< 1K
+Predicate,https://schema.org/accountId-input,< 1K
+Predicate,https://schema.org/accountId-output,< 1K
+Predicate,https://schema.org/accountMinimumInflow,< 1K
+Predicate,https://schema.org/accountMinimumInflow-input,< 1K
+Predicate,https://schema.org/accountMinimumInflow-output,< 1K
+Predicate,https://schema.org/accountOverdraftLimit,< 1K
+Predicate,https://schema.org/accountOverdraftLimit-input,< 1K
+Predicate,https://schema.org/accountOverdraftLimit-output,< 1K
+Predicate,https://schema.org/accountablePerson,10K - 100K
+Predicate,https://schema.org/accountablePerson-input,< 1K
+Predicate,https://schema.org/accountablePerson-output,< 1K
+Predicate,https://schema.org/acquireLicensePage,10K - 100K
+Predicate,https://schema.org/acquireLicensePage-input,< 1K
+Predicate,https://schema.org/acquireLicensePage-output,< 1K
+Predicate,https://schema.org/acquiredFrom,< 1K
+Predicate,https://schema.org/acquiredFrom-input,< 1K
+Predicate,https://schema.org/acquiredFrom-output,< 1K
+Predicate,https://schema.org/acrissCode,< 1K
+Predicate,https://schema.org/acrissCode-input,< 1K
+Predicate,https://schema.org/acrissCode-output,< 1K
+Predicate,https://schema.org/actionAccessibilityRequirement,< 1K
+Predicate,https://schema.org/actionAccessibilityRequirement-input,< 1K
+Predicate,https://schema.org/actionAccessibilityRequirement-output,< 1K
+Predicate,https://schema.org/actionApplication,1K - 10K
+Predicate,https://schema.org/actionApplication-input,< 1K
+Predicate,https://schema.org/actionApplication-output,< 1K
+Predicate,https://schema.org/actionOption,1K - 10K
+Predicate,https://schema.org/actionOption-input,< 1K
+Predicate,https://schema.org/actionOption-output,< 1K
+Predicate,https://schema.org/actionPlatform,100K - 1M
+Predicate,https://schema.org/actionPlatform-input,< 1K
+Predicate,https://schema.org/actionPlatform-output,< 1K
+Predicate,https://schema.org/actionProcess,< 1K
+Predicate,https://schema.org/actionProcess-input,< 1K
+Predicate,https://schema.org/actionProcess-output,< 1K
+Predicate,https://schema.org/actionStatus,10K - 100K
+Predicate,https://schema.org/actionStatus-input,< 1K
+Predicate,https://schema.org/actionStatus-output,< 1K
+Predicate,https://schema.org/actionableFeedbackPolicy,10K - 100K
+Predicate,https://schema.org/actionableFeedbackPolicy-input,< 1K
+Predicate,https://schema.org/actionableFeedbackPolicy-output,< 1K
+Predicate,https://schema.org/activeIngredient,1K - 10K
+Predicate,https://schema.org/activeIngredient-input,< 1K
+Predicate,https://schema.org/activeIngredient-output,< 1K
+Predicate,https://schema.org/activityDuration,< 1K
+Predicate,https://schema.org/activityDuration-input,< 1K
+Predicate,https://schema.org/activityDuration-output,< 1K
+Predicate,https://schema.org/activityFrequency,< 1K
+Predicate,https://schema.org/activityFrequency-input,< 1K
+Predicate,https://schema.org/activityFrequency-output,< 1K
+Predicate,https://schema.org/actor,10K - 100K
+Predicate,https://schema.org/actor-input,< 1K
+Predicate,https://schema.org/actor-output,< 1K
+Predicate,https://schema.org/actors,1K - 10K
+Predicate,https://schema.org/actors-input,< 1K
+Predicate,https://schema.org/actors-output,< 1K
+Predicate,https://schema.org/addOn,1K - 10K
+Predicate,https://schema.org/addOn-input,< 1K
+Predicate,https://schema.org/addOn-output,< 1K
+Predicate,https://schema.org/additionalName,10K - 100K
+Predicate,https://schema.org/additionalName-input,< 1K
+Predicate,https://schema.org/additionalName-output,< 1K
+Predicate,https://schema.org/additionalNumberOfGuests,< 1K
+Predicate,https://schema.org/additionalNumberOfGuests-input,< 1K
+Predicate,https://schema.org/additionalNumberOfGuests-output,< 1K
+Predicate,https://schema.org/additionalProperty,100K - 1M
+Predicate,https://schema.org/additionalProperty-input,< 1K
+Predicate,https://schema.org/additionalProperty-output,< 1K
+Predicate,https://schema.org/additionalType,100K - 1M
+Predicate,https://schema.org/additionalType-input,< 1K
+Predicate,https://schema.org/additionalType-output,< 1K
+Predicate,https://schema.org/additionalVariable,< 1K
+Predicate,https://schema.org/additionalVariable-input,< 1K
+Predicate,https://schema.org/additionalVariable-output,< 1K
+Predicate,https://schema.org/address,10M+
+Predicate,https://schema.org/address-input,< 1K
+Predicate,https://schema.org/address-output,< 1K
+Predicate,https://schema.org/addressCountry,1M - 10M
+Predicate,https://schema.org/addressCountry-input,< 1K
+Predicate,https://schema.org/addressCountry-output,< 1K
+Predicate,https://schema.org/addressLocality,1M - 10M
+Predicate,https://schema.org/addressLocality-input,< 1K
+Predicate,https://schema.org/addressLocality-output,< 1K
+Predicate,https://schema.org/addressRegion,1M - 10M
+Predicate,https://schema.org/addressRegion-input,< 1K
+Predicate,https://schema.org/addressRegion-output,< 1K
+Predicate,https://schema.org/administrationRoute,1K - 10K
+Predicate,https://schema.org/administrationRoute-input,< 1K
+Predicate,https://schema.org/administrationRoute-output,< 1K
+Predicate,https://schema.org/advanceBookingRequirement,< 1K
+Predicate,https://schema.org/advanceBookingRequirement-input,< 1K
+Predicate,https://schema.org/advanceBookingRequirement-output,< 1K
+Predicate,https://schema.org/adverseOutcome,< 1K
+Predicate,https://schema.org/adverseOutcome-input,< 1K
+Predicate,https://schema.org/adverseOutcome-output,< 1K
+Predicate,https://schema.org/affectedBy,< 1K
+Predicate,https://schema.org/affectedBy-input,< 1K
+Predicate,https://schema.org/affectedBy-output,< 1K
+Predicate,https://schema.org/affiliation,100K - 1M
+Predicate,https://schema.org/affiliation-input,< 1K
+Predicate,https://schema.org/affiliation-output,< 1K
+Predicate,https://schema.org/afterMedia,< 1K
+Predicate,https://schema.org/afterMedia-input,< 1K
+Predicate,https://schema.org/afterMedia-output,< 1K
+Predicate,https://schema.org/agent,10K - 100K
+Predicate,https://schema.org/agent-input,< 1K
+Predicate,https://schema.org/agent-output,< 1K
+Predicate,https://schema.org/agentInteractionStatistic,10K - 100K
+Predicate,https://schema.org/agentInteractionStatistic-input,< 1K
+Predicate,https://schema.org/agentInteractionStatistic-output,< 1K
+Predicate,https://schema.org/aggregateElement,< 1K
+Predicate,https://schema.org/aggregateElement-input,< 1K
+Predicate,https://schema.org/aggregateElement-output,< 1K
+Predicate,https://schema.org/aggregateRating,1M - 10M
+Predicate,https://schema.org/aggregateRating-input,< 1K
+Predicate,https://schema.org/aggregateRating-output,< 1K
+Predicate,https://schema.org/aircraft,< 1K
+Predicate,https://schema.org/aircraft-input,< 1K
+Predicate,https://schema.org/aircraft-output,< 1K
+Predicate,https://schema.org/album,1K - 10K
+Predicate,https://schema.org/album-input,< 1K
+Predicate,https://schema.org/album-output,< 1K
+Predicate,https://schema.org/albumProductionType,1K - 10K
+Predicate,https://schema.org/albumProductionType-input,< 1K
+Predicate,https://schema.org/albumProductionType-output,< 1K
+Predicate,https://schema.org/albumRelease,1K - 10K
+Predicate,https://schema.org/albumRelease-input,< 1K
+Predicate,https://schema.org/albumRelease-output,< 1K
+Predicate,https://schema.org/albumReleaseType,1K - 10K
+Predicate,https://schema.org/albumReleaseType-input,< 1K
+Predicate,https://schema.org/albumReleaseType-output,< 1K
+Predicate,https://schema.org/albums,< 1K
+Predicate,https://schema.org/albums-input,< 1K
+Predicate,https://schema.org/albums-output,< 1K
+Predicate,https://schema.org/alcoholWarning,< 1K
+Predicate,https://schema.org/alcoholWarning-input,< 1K
+Predicate,https://schema.org/alcoholWarning-output,< 1K
+Predicate,https://schema.org/algorithm,< 1K
+Predicate,https://schema.org/algorithm-input,< 1K
+Predicate,https://schema.org/algorithm-output,< 1K
+Predicate,https://schema.org/alignmentType,1K - 10K
+Predicate,https://schema.org/alignmentType-input,< 1K
+Predicate,https://schema.org/alignmentType-output,< 1K
+Predicate,https://schema.org/alternateName,1M - 10M
+Predicate,https://schema.org/alternateName-input,< 1K
+Predicate,https://schema.org/alternateName-output,< 1K
+Predicate,https://schema.org/alternativeHeadline,100K - 1M
+Predicate,https://schema.org/alternativeHeadline-input,< 1K
+Predicate,https://schema.org/alternativeHeadline-output,< 1K
+Predicate,https://schema.org/alternativeOf,< 1K
+Predicate,https://schema.org/alternativeOf-input,< 1K
+Predicate,https://schema.org/alternativeOf-output,< 1K
+Predicate,https://schema.org/alumni,1K - 10K
+Predicate,https://schema.org/alumni-input,< 1K
+Predicate,https://schema.org/alumni-output,< 1K
+Predicate,https://schema.org/alumniOf,100K - 1M
+Predicate,https://schema.org/alumniOf-input,< 1K
+Predicate,https://schema.org/alumniOf-output,< 1K
+Predicate,https://schema.org/amenityFeature,100K - 1M
+Predicate,https://schema.org/amenityFeature-input,< 1K
+Predicate,https://schema.org/amenityFeature-output,< 1K
+Predicate,https://schema.org/amount,1K - 10K
+Predicate,https://schema.org/amount-input,< 1K
+Predicate,https://schema.org/amount-output,< 1K
+Predicate,https://schema.org/amountOfThisGood,< 1K
+Predicate,https://schema.org/amountOfThisGood-input,< 1K
+Predicate,https://schema.org/amountOfThisGood-output,< 1K
+Predicate,https://schema.org/announcementLocation,1K - 10K
+Predicate,https://schema.org/announcementLocation-input,< 1K
+Predicate,https://schema.org/announcementLocation-output,< 1K
+Predicate,https://schema.org/annualPercentageRate,1K - 10K
+Predicate,https://schema.org/annualPercentageRate-input,< 1K
+Predicate,https://schema.org/annualPercentageRate-output,< 1K
+Predicate,https://schema.org/answerCount,100K - 1M
+Predicate,https://schema.org/answerCount-input,< 1K
+Predicate,https://schema.org/answerCount-output,< 1K
+Predicate,https://schema.org/answerExplanation,< 1K
+Predicate,https://schema.org/answerExplanation-input,< 1K
+Predicate,https://schema.org/answerExplanation-output,< 1K
+Predicate,https://schema.org/antagonist,< 1K
+Predicate,https://schema.org/antagonist-input,< 1K
+Predicate,https://schema.org/antagonist-output,< 1K
+Predicate,https://schema.org/appearance,1K - 10K
+Predicate,https://schema.org/appearance-input,< 1K
+Predicate,https://schema.org/appearance-output,< 1K
+Predicate,https://schema.org/applicableCountry,100K - 1M
+Predicate,https://schema.org/applicableCountry-input,< 1K
+Predicate,https://schema.org/applicableCountry-output,< 1K
+Predicate,https://schema.org/applicableLocation,< 1K
+Predicate,https://schema.org/applicableLocation-input,< 1K
+Predicate,https://schema.org/applicableLocation-output,< 1K
+Predicate,https://schema.org/applicantLocationRequirements,10K - 100K
+Predicate,https://schema.org/applicantLocationRequirements-input,< 1K
+Predicate,https://schema.org/applicantLocationRequirements-output,< 1K
+Predicate,https://schema.org/application,< 1K
+Predicate,https://schema.org/application-input,< 1K
+Predicate,https://schema.org/application-output,< 1K
+Predicate,https://schema.org/applicationCategory,1M - 10M
+Predicate,https://schema.org/applicationCategory-input,< 1K
+Predicate,https://schema.org/applicationCategory-output,< 1K
+Predicate,https://schema.org/applicationContact,1K - 10K
+Predicate,https://schema.org/applicationContact-input,< 1K
+Predicate,https://schema.org/applicationContact-output,< 1K
+Predicate,https://schema.org/applicationDeadline,1K - 10K
+Predicate,https://schema.org/applicationDeadline-input,< 1K
+Predicate,https://schema.org/applicationDeadline-output,< 1K
+Predicate,https://schema.org/applicationStartDate,< 1K
+Predicate,https://schema.org/applicationStartDate-input,< 1K
+Predicate,https://schema.org/applicationStartDate-output,< 1K
+Predicate,https://schema.org/applicationSubCategory,10K - 100K
+Predicate,https://schema.org/applicationSubCategory-input,< 1K
+Predicate,https://schema.org/applicationSubCategory-output,< 1K
+Predicate,https://schema.org/applicationSuite,1K - 10K
+Predicate,https://schema.org/applicationSuite-input,< 1K
+Predicate,https://schema.org/applicationSuite-output,< 1K
+Predicate,https://schema.org/appliesToDeliveryMethod,10K - 100K
+Predicate,https://schema.org/appliesToDeliveryMethod-input,< 1K
+Predicate,https://schema.org/appliesToDeliveryMethod-output,< 1K
+Predicate,https://schema.org/appliesToPaymentMethod,< 1K
+Predicate,https://schema.org/appliesToPaymentMethod-input,< 1K
+Predicate,https://schema.org/appliesToPaymentMethod-output,< 1K
+Predicate,https://schema.org/archiveHeld,< 1K
+Predicate,https://schema.org/archiveHeld-input,< 1K
+Predicate,https://schema.org/archiveHeld-output,< 1K
+Predicate,https://schema.org/archivedAt,< 1K
+Predicate,https://schema.org/archivedAt-input,< 1K
+Predicate,https://schema.org/archivedAt-output,< 1K
+Predicate,https://schema.org/area,1K - 10K
+Predicate,https://schema.org/area-input,< 1K
+Predicate,https://schema.org/area-output,< 1K
+Predicate,https://schema.org/areaServed,1M - 10M
+Predicate,https://schema.org/areaServed-input,< 1K
+Predicate,https://schema.org/areaServed-output,< 1K
+Predicate,https://schema.org/arrivalAirport,1K - 10K
+Predicate,https://schema.org/arrivalAirport-input,< 1K
+Predicate,https://schema.org/arrivalAirport-output,< 1K
+Predicate,https://schema.org/arrivalBoatTerminal,< 1K
+Predicate,https://schema.org/arrivalBoatTerminal-input,< 1K
+Predicate,https://schema.org/arrivalBoatTerminal-output,< 1K
+Predicate,https://schema.org/arrivalBusStop,< 1K
+Predicate,https://schema.org/arrivalBusStop-input,< 1K
+Predicate,https://schema.org/arrivalBusStop-output,< 1K
+Predicate,https://schema.org/arrivalGate,< 1K
+Predicate,https://schema.org/arrivalGate-input,< 1K
+Predicate,https://schema.org/arrivalGate-output,< 1K
+Predicate,https://schema.org/arrivalPlatform,< 1K
+Predicate,https://schema.org/arrivalPlatform-input,< 1K
+Predicate,https://schema.org/arrivalPlatform-output,< 1K
+Predicate,https://schema.org/arrivalStation,< 1K
+Predicate,https://schema.org/arrivalStation-input,< 1K
+Predicate,https://schema.org/arrivalStation-output,< 1K
+Predicate,https://schema.org/arrivalTerminal,< 1K
+Predicate,https://schema.org/arrivalTerminal-input,< 1K
+Predicate,https://schema.org/arrivalTerminal-output,< 1K
+Predicate,https://schema.org/arrivalTime,1K - 10K
+Predicate,https://schema.org/arrivalTime-input,< 1K
+Predicate,https://schema.org/arrivalTime-output,< 1K
+Predicate,https://schema.org/artEdition,< 1K
+Predicate,https://schema.org/artEdition-input,< 1K
+Predicate,https://schema.org/artEdition-output,< 1K
+Predicate,https://schema.org/artMedium,1K - 10K
+Predicate,https://schema.org/artMedium-input,< 1K
+Predicate,https://schema.org/artMedium-output,< 1K
+Predicate,https://schema.org/arterialBranch,< 1K
+Predicate,https://schema.org/arterialBranch-input,< 1K
+Predicate,https://schema.org/arterialBranch-output,< 1K
+Predicate,https://schema.org/artform,1K - 10K
+Predicate,https://schema.org/artform-input,< 1K
+Predicate,https://schema.org/artform-output,< 1K
+Predicate,https://schema.org/articleBody,1M - 10M
+Predicate,https://schema.org/articleBody-input,< 1K
+Predicate,https://schema.org/articleBody-output,< 1K
+Predicate,https://schema.org/articleSection,1M - 10M
+Predicate,https://schema.org/articleSection-input,< 1K
+Predicate,https://schema.org/articleSection-output,< 1K
+Predicate,https://schema.org/artist,1K - 10K
+Predicate,https://schema.org/artist-input,< 1K
+Predicate,https://schema.org/artist-output,< 1K
+Predicate,https://schema.org/artworkSurface,1K - 10K
+Predicate,https://schema.org/artworkSurface-input,< 1K
+Predicate,https://schema.org/artworkSurface-output,< 1K
+Predicate,https://schema.org/asin,< 1K
+Predicate,https://schema.org/asin-input,< 1K
+Predicate,https://schema.org/asin-output,< 1K
+Predicate,https://schema.org/aspect,< 1K
+Predicate,https://schema.org/aspect-input,< 1K
+Predicate,https://schema.org/aspect-output,< 1K
+Predicate,https://schema.org/assembly,< 1K
+Predicate,https://schema.org/assembly-input,< 1K
+Predicate,https://schema.org/assembly-output,< 1K
+Predicate,https://schema.org/assemblyVersion,< 1K
+Predicate,https://schema.org/assemblyVersion-input,< 1K
+Predicate,https://schema.org/assemblyVersion-output,< 1K
+Predicate,https://schema.org/assesses,1K - 10K
+Predicate,https://schema.org/assesses-input,< 1K
+Predicate,https://schema.org/assesses-output,< 1K
+Predicate,https://schema.org/associatedAnatomy,1K - 10K
+Predicate,https://schema.org/associatedAnatomy-input,< 1K
+Predicate,https://schema.org/associatedAnatomy-output,< 1K
+Predicate,https://schema.org/associatedArticle,1K - 10K
+Predicate,https://schema.org/associatedArticle-input,< 1K
+Predicate,https://schema.org/associatedArticle-output,< 1K
+Predicate,https://schema.org/associatedClaimReview,< 1K
+Predicate,https://schema.org/associatedClaimReview-input,< 1K
+Predicate,https://schema.org/associatedClaimReview-output,< 1K
+Predicate,https://schema.org/associatedDisease,< 1K
+Predicate,https://schema.org/associatedDisease-input,< 1K
+Predicate,https://schema.org/associatedDisease-output,< 1K
+Predicate,https://schema.org/associatedMedia,100K - 1M
+Predicate,https://schema.org/associatedMedia-input,< 1K
+Predicate,https://schema.org/associatedMedia-output,< 1K
+Predicate,https://schema.org/associatedMediaReview,< 1K
+Predicate,https://schema.org/associatedMediaReview-input,< 1K
+Predicate,https://schema.org/associatedMediaReview-output,< 1K
+Predicate,https://schema.org/associatedPathophysiology,< 1K
+Predicate,https://schema.org/associatedPathophysiology-input,< 1K
+Predicate,https://schema.org/associatedPathophysiology-output,< 1K
+Predicate,https://schema.org/associatedReview,< 1K
+Predicate,https://schema.org/associatedReview-input,< 1K
+Predicate,https://schema.org/associatedReview-output,< 1K
+Predicate,https://schema.org/athlete,1K - 10K
+Predicate,https://schema.org/athlete-input,< 1K
+Predicate,https://schema.org/athlete-output,< 1K
+Predicate,https://schema.org/attendee,1K - 10K
+Predicate,https://schema.org/attendee-input,< 1K
+Predicate,https://schema.org/attendee-output,< 1K
+Predicate,https://schema.org/attendees,< 1K
+Predicate,https://schema.org/attendees-input,< 1K
+Predicate,https://schema.org/attendees-output,< 1K
+Predicate,https://schema.org/audience,100K - 1M
+Predicate,https://schema.org/audience-input,< 1K
+Predicate,https://schema.org/audience-output,< 1K
+Predicate,https://schema.org/audienceType,100K - 1M
+Predicate,https://schema.org/audienceType-input,< 1K
+Predicate,https://schema.org/audienceType-output,< 1K
+Predicate,https://schema.org/audio,10K - 100K
+Predicate,https://schema.org/audio-input,< 1K
+Predicate,https://schema.org/audio-output,< 1K
+Predicate,https://schema.org/auditDate,< 1K
+Predicate,https://schema.org/auditDate-input,< 1K
+Predicate,https://schema.org/auditDate-output,< 1K
+Predicate,https://schema.org/authenticator,< 1K
+Predicate,https://schema.org/authenticator-input,< 1K
+Predicate,https://schema.org/authenticator-output,< 1K
+Predicate,https://schema.org/author,10M+
+Predicate,https://schema.org/author-input,< 1K
+Predicate,https://schema.org/author-output,< 1K
+Predicate,https://schema.org/availability,10M+
+Predicate,https://schema.org/availability-input,< 1K
+Predicate,https://schema.org/availability-output,< 1K
+Predicate,https://schema.org/availabilityEnds,10K - 100K
+Predicate,https://schema.org/availabilityEnds-input,< 1K
+Predicate,https://schema.org/availabilityEnds-output,< 1K
+Predicate,https://schema.org/availabilityStarts,10K - 100K
+Predicate,https://schema.org/availabilityStarts-input,< 1K
+Predicate,https://schema.org/availabilityStarts-output,< 1K
+Predicate,https://schema.org/availableAtOrFrom,10K - 100K
+Predicate,https://schema.org/availableAtOrFrom-input,< 1K
+Predicate,https://schema.org/availableAtOrFrom-output,< 1K
+Predicate,https://schema.org/availableChannel,100K - 1M
+Predicate,https://schema.org/availableChannel-input,< 1K
+Predicate,https://schema.org/availableChannel-output,< 1K
+Predicate,https://schema.org/availableDeliveryMethod,10K - 100K
+Predicate,https://schema.org/availableDeliveryMethod-input,< 1K
+Predicate,https://schema.org/availableDeliveryMethod-output,< 1K
+Predicate,https://schema.org/availableFrom,< 1K
+Predicate,https://schema.org/availableFrom-input,< 1K
+Predicate,https://schema.org/availableFrom-output,< 1K
+Predicate,https://schema.org/availableIn,< 1K
+Predicate,https://schema.org/availableIn-input,< 1K
+Predicate,https://schema.org/availableIn-output,< 1K
+Predicate,https://schema.org/availableLanguage,1M - 10M
+Predicate,https://schema.org/availableLanguage-input,< 1K
+Predicate,https://schema.org/availableLanguage-output,< 1K
+Predicate,https://schema.org/availableOnDevice,1K - 10K
+Predicate,https://schema.org/availableOnDevice-input,< 1K
+Predicate,https://schema.org/availableOnDevice-output,< 1K
+Predicate,https://schema.org/availableService,10K - 100K
+Predicate,https://schema.org/availableService-input,< 1K
+Predicate,https://schema.org/availableService-output,< 1K
+Predicate,https://schema.org/availableStrength,< 1K
+Predicate,https://schema.org/availableStrength-input,< 1K
+Predicate,https://schema.org/availableStrength-output,< 1K
+Predicate,https://schema.org/availableTest,< 1K
+Predicate,https://schema.org/availableTest-input,< 1K
+Predicate,https://schema.org/availableTest-output,< 1K
+Predicate,https://schema.org/availableThrough,< 1K
+Predicate,https://schema.org/availableThrough-input,< 1K
+Predicate,https://schema.org/availableThrough-output,< 1K
+Predicate,https://schema.org/award,100K - 1M
+Predicate,https://schema.org/award-input,< 1K
+Predicate,https://schema.org/award-output,< 1K
+Predicate,https://schema.org/awards,1K - 10K
+Predicate,https://schema.org/awards-input,< 1K
+Predicate,https://schema.org/awards-output,< 1K
+Predicate,https://schema.org/awayTeam,10K - 100K
+Predicate,https://schema.org/awayTeam-input,< 1K
+Predicate,https://schema.org/awayTeam-output,< 1K
+Predicate,https://schema.org/backstory,1K - 10K
+Predicate,https://schema.org/backstory-input,< 1K
+Predicate,https://schema.org/backstory-output,< 1K
+Predicate,https://schema.org/bankAccountType,< 1K
+Predicate,https://schema.org/bankAccountType-input,< 1K
+Predicate,https://schema.org/bankAccountType-output,< 1K
+Predicate,https://schema.org/baseSalary,10K - 100K
+Predicate,https://schema.org/baseSalary-input,< 1K
+Predicate,https://schema.org/baseSalary-output,< 1K
+Predicate,https://schema.org/bccRecipient,< 1K
+Predicate,https://schema.org/bccRecipient-input,< 1K
+Predicate,https://schema.org/bccRecipient-output,< 1K
+Predicate,https://schema.org/bed,10K - 100K
+Predicate,https://schema.org/bed-input,< 1K
+Predicate,https://schema.org/bed-output,< 1K
+Predicate,https://schema.org/beforeMedia,< 1K
+Predicate,https://schema.org/beforeMedia-input,< 1K
+Predicate,https://schema.org/beforeMedia-output,< 1K
+Predicate,https://schema.org/beneficiaryBank,< 1K
+Predicate,https://schema.org/beneficiaryBank-input,< 1K
+Predicate,https://schema.org/beneficiaryBank-output,< 1K
+Predicate,https://schema.org/benefits,1K - 10K
+Predicate,https://schema.org/benefits-input,< 1K
+Predicate,https://schema.org/benefits-output,< 1K
+Predicate,https://schema.org/benefitsSummaryUrl,< 1K
+Predicate,https://schema.org/benefitsSummaryUrl-input,< 1K
+Predicate,https://schema.org/benefitsSummaryUrl-output,< 1K
+Predicate,https://schema.org/bestRating,1M - 10M
+Predicate,https://schema.org/bestRating-input,< 1K
+Predicate,https://schema.org/bestRating-output,< 1K
+Predicate,https://schema.org/billingAddress,< 1K
+Predicate,https://schema.org/billingAddress-input,< 1K
+Predicate,https://schema.org/billingAddress-output,< 1K
+Predicate,https://schema.org/billingDuration,10K - 100K
+Predicate,https://schema.org/billingDuration-input,< 1K
+Predicate,https://schema.org/billingDuration-output,< 1K
+Predicate,https://schema.org/billingIncrement,10K - 100K
+Predicate,https://schema.org/billingIncrement-input,< 1K
+Predicate,https://schema.org/billingIncrement-output,< 1K
+Predicate,https://schema.org/billingPeriod,1K - 10K
+Predicate,https://schema.org/billingPeriod-input,< 1K
+Predicate,https://schema.org/billingPeriod-output,< 1K
+Predicate,https://schema.org/billingStart,< 1K
+Predicate,https://schema.org/billingStart-input,< 1K
+Predicate,https://schema.org/billingStart-output,< 1K
+Predicate,https://schema.org/bioChemInteraction,< 1K
+Predicate,https://schema.org/bioChemInteraction-input,< 1K
+Predicate,https://schema.org/bioChemInteraction-output,< 1K
+Predicate,https://schema.org/bioChemSimilarity,< 1K
+Predicate,https://schema.org/bioChemSimilarity-input,< 1K
+Predicate,https://schema.org/bioChemSimilarity-output,< 1K
+Predicate,https://schema.org/biologicalRole,< 1K
+Predicate,https://schema.org/biologicalRole-input,< 1K
+Predicate,https://schema.org/biologicalRole-output,< 1K
+Predicate,https://schema.org/biomechnicalClass,< 1K
+Predicate,https://schema.org/biomechnicalClass-input,< 1K
+Predicate,https://schema.org/biomechnicalClass-output,< 1K
+Predicate,https://schema.org/birthDate,10K - 100K
+Predicate,https://schema.org/birthDate-input,< 1K
+Predicate,https://schema.org/birthDate-output,< 1K
+Predicate,https://schema.org/birthPlace,10K - 100K
+Predicate,https://schema.org/birthPlace-input,< 1K
+Predicate,https://schema.org/birthPlace-output,< 1K
+Predicate,https://schema.org/bitrate,1K - 10K
+Predicate,https://schema.org/bitrate-input,< 1K
+Predicate,https://schema.org/bitrate-output,< 1K
+Predicate,https://schema.org/blogPost,100K - 1M
+Predicate,https://schema.org/blogPost-input,< 1K
+Predicate,https://schema.org/blogPost-output,< 1K
+Predicate,https://schema.org/blogPosts,10K - 100K
+Predicate,https://schema.org/blogPosts-input,< 1K
+Predicate,https://schema.org/blogPosts-output,< 1K
+Predicate,https://schema.org/bloodSupply,< 1K
+Predicate,https://schema.org/bloodSupply-input,< 1K
+Predicate,https://schema.org/bloodSupply-output,< 1K
+Predicate,https://schema.org/boardingGroup,< 1K
+Predicate,https://schema.org/boardingGroup-input,< 1K
+Predicate,https://schema.org/boardingGroup-output,< 1K
+Predicate,https://schema.org/boardingPolicy,< 1K
+Predicate,https://schema.org/boardingPolicy-input,< 1K
+Predicate,https://schema.org/boardingPolicy-output,< 1K
+Predicate,https://schema.org/bodyLocation,10K - 100K
+Predicate,https://schema.org/bodyLocation-input,< 1K
+Predicate,https://schema.org/bodyLocation-output,< 1K
+Predicate,https://schema.org/bodyType,10K - 100K
+Predicate,https://schema.org/bodyType-input,< 1K
+Predicate,https://schema.org/bodyType-output,< 1K
+Predicate,https://schema.org/bookEdition,1K - 10K
+Predicate,https://schema.org/bookEdition-input,< 1K
+Predicate,https://schema.org/bookEdition-output,< 1K
+Predicate,https://schema.org/bookFormat,10K - 100K
+Predicate,https://schema.org/bookFormat-input,< 1K
+Predicate,https://schema.org/bookFormat-output,< 1K
+Predicate,https://schema.org/bookingAgent,< 1K
+Predicate,https://schema.org/bookingAgent-input,< 1K
+Predicate,https://schema.org/bookingAgent-output,< 1K
+Predicate,https://schema.org/bookingTime,< 1K
+Predicate,https://schema.org/bookingTime-input,< 1K
+Predicate,https://schema.org/bookingTime-output,< 1K
+Predicate,https://schema.org/borrower,< 1K
+Predicate,https://schema.org/borrower-input,< 1K
+Predicate,https://schema.org/borrower-output,< 1K
+Predicate,https://schema.org/box,1K - 10K
+Predicate,https://schema.org/box-input,< 1K
+Predicate,https://schema.org/box-output,< 1K
+Predicate,https://schema.org/branch,< 1K
+Predicate,https://schema.org/branch-input,< 1K
+Predicate,https://schema.org/branch-output,< 1K
+Predicate,https://schema.org/branchCode,1K - 10K
+Predicate,https://schema.org/branchCode-input,< 1K
+Predicate,https://schema.org/branchCode-output,< 1K
+Predicate,https://schema.org/branchOf,10K - 100K
+Predicate,https://schema.org/branchOf-input,< 1K
+Predicate,https://schema.org/branchOf-output,< 1K
+Predicate,https://schema.org/brand,1M - 10M
+Predicate,https://schema.org/brand-input,< 1K
+Predicate,https://schema.org/brand-output,< 1K
+Predicate,https://schema.org/breadcrumb,10M+
+Predicate,https://schema.org/breadcrumb-input,< 1K
+Predicate,https://schema.org/breadcrumb-output,< 1K
+Predicate,https://schema.org/breastfeedingWarning,< 1K
+Predicate,https://schema.org/breastfeedingWarning-input,< 1K
+Predicate,https://schema.org/breastfeedingWarning-output,< 1K
+Predicate,https://schema.org/broadcastAffiliateOf,< 1K
+Predicate,https://schema.org/broadcastAffiliateOf-input,< 1K
+Predicate,https://schema.org/broadcastAffiliateOf-output,< 1K
+Predicate,https://schema.org/broadcastChannelId,< 1K
+Predicate,https://schema.org/broadcastChannelId-input,< 1K
+Predicate,https://schema.org/broadcastChannelId-output,< 1K
+Predicate,https://schema.org/broadcastDisplayName,1K - 10K
+Predicate,https://schema.org/broadcastDisplayName-input,< 1K
+Predicate,https://schema.org/broadcastDisplayName-output,< 1K
+Predicate,https://schema.org/broadcastFrequency,1K - 10K
+Predicate,https://schema.org/broadcastFrequency-input,< 1K
+Predicate,https://schema.org/broadcastFrequency-output,< 1K
+Predicate,https://schema.org/broadcastFrequencyValue,< 1K
+Predicate,https://schema.org/broadcastFrequencyValue-input,< 1K
+Predicate,https://schema.org/broadcastFrequencyValue-output,< 1K
+Predicate,https://schema.org/broadcastOfEvent,1K - 10K
+Predicate,https://schema.org/broadcastOfEvent-input,< 1K
+Predicate,https://schema.org/broadcastOfEvent-output,< 1K
+Predicate,https://schema.org/broadcastServiceTier,< 1K
+Predicate,https://schema.org/broadcastServiceTier-input,< 1K
+Predicate,https://schema.org/broadcastServiceTier-output,< 1K
+Predicate,https://schema.org/broadcastSignalModulation,< 1K
+Predicate,https://schema.org/broadcastSignalModulation-input,< 1K
+Predicate,https://schema.org/broadcastSignalModulation-output,< 1K
+Predicate,https://schema.org/broadcastSubChannel,< 1K
+Predicate,https://schema.org/broadcastSubChannel-input,< 1K
+Predicate,https://schema.org/broadcastSubChannel-output,< 1K
+Predicate,https://schema.org/broadcastTimezone,< 1K
+Predicate,https://schema.org/broadcastTimezone-input,< 1K
+Predicate,https://schema.org/broadcastTimezone-output,< 1K
+Predicate,https://schema.org/broadcaster,< 1K
+Predicate,https://schema.org/broadcaster-input,< 1K
+Predicate,https://schema.org/broadcaster-output,< 1K
+Predicate,https://schema.org/broker,1K - 10K
+Predicate,https://schema.org/broker-input,< 1K
+Predicate,https://schema.org/broker-output,< 1K
+Predicate,https://schema.org/browserRequirements,10K - 100K
+Predicate,https://schema.org/browserRequirements-input,< 1K
+Predicate,https://schema.org/browserRequirements-output,< 1K
+Predicate,https://schema.org/busName,< 1K
+Predicate,https://schema.org/busName-input,< 1K
+Predicate,https://schema.org/busName-output,< 1K
+Predicate,https://schema.org/busNumber,< 1K
+Predicate,https://schema.org/busNumber-input,< 1K
+Predicate,https://schema.org/busNumber-output,< 1K
+Predicate,https://schema.org/businessDays,10K - 100K
+Predicate,https://schema.org/businessDays-input,< 1K
+Predicate,https://schema.org/businessDays-output,< 1K
+Predicate,https://schema.org/businessFunction,1M - 10M
+Predicate,https://schema.org/businessFunction-input,< 1K
+Predicate,https://schema.org/businessFunction-output,< 1K
+Predicate,https://schema.org/buyer,< 1K
+Predicate,https://schema.org/buyer-input,< 1K
+Predicate,https://schema.org/buyer-output,< 1K
+Predicate,https://schema.org/byArtist,10K - 100K
+Predicate,https://schema.org/byArtist-input,< 1K
+Predicate,https://schema.org/byArtist-output,< 1K
+Predicate,https://schema.org/byDay,1K - 10K
+Predicate,https://schema.org/byDay-input,< 1K
+Predicate,https://schema.org/byDay-output,< 1K
+Predicate,https://schema.org/byMonth,< 1K
+Predicate,https://schema.org/byMonth-input,< 1K
+Predicate,https://schema.org/byMonth-output,< 1K
+Predicate,https://schema.org/byMonthDay,< 1K
+Predicate,https://schema.org/byMonthDay-input,< 1K
+Predicate,https://schema.org/byMonthDay-output,< 1K
+Predicate,https://schema.org/byMonthWeek,< 1K
+Predicate,https://schema.org/byMonthWeek-input,< 1K
+Predicate,https://schema.org/byMonthWeek-output,< 1K
+Predicate,https://schema.org/callSign,< 1K
+Predicate,https://schema.org/callSign-input,< 1K
+Predicate,https://schema.org/callSign-output,< 1K
+Predicate,https://schema.org/calories,10K - 100K
+Predicate,https://schema.org/calories-input,< 1K
+Predicate,https://schema.org/calories-output,< 1K
+Predicate,https://schema.org/candidate,< 1K
+Predicate,https://schema.org/candidate-input,< 1K
+Predicate,https://schema.org/candidate-output,< 1K
+Predicate,https://schema.org/caption,10M+
+Predicate,https://schema.org/caption-input,< 1K
+Predicate,https://schema.org/caption-output,< 1K
+Predicate,https://schema.org/carbohydrateContent,10K - 100K
+Predicate,https://schema.org/carbohydrateContent-input,< 1K
+Predicate,https://schema.org/carbohydrateContent-output,< 1K
+Predicate,https://schema.org/cargoVolume,1K - 10K
+Predicate,https://schema.org/cargoVolume-input,< 1K
+Predicate,https://schema.org/cargoVolume-output,< 1K
+Predicate,https://schema.org/carrier,< 1K
+Predicate,https://schema.org/carrier-input,< 1K
+Predicate,https://schema.org/carrier-output,< 1K
+Predicate,https://schema.org/carrierRequirements,< 1K
+Predicate,https://schema.org/carrierRequirements-input,< 1K
+Predicate,https://schema.org/carrierRequirements-output,< 1K
+Predicate,https://schema.org/cashBack,< 1K
+Predicate,https://schema.org/cashBack-input,< 1K
+Predicate,https://schema.org/cashBack-output,< 1K
+Predicate,https://schema.org/catalog,< 1K
+Predicate,https://schema.org/catalog-input,< 1K
+Predicate,https://schema.org/catalog-output,< 1K
+Predicate,https://schema.org/catalogNumber,< 1K
+Predicate,https://schema.org/catalogNumber-input,< 1K
+Predicate,https://schema.org/catalogNumber-output,< 1K
+Predicate,https://schema.org/category,1M - 10M
+Predicate,https://schema.org/category-input,< 1K
+Predicate,https://schema.org/category-output,< 1K
+Predicate,https://schema.org/cause,1K - 10K
+Predicate,https://schema.org/cause-input,< 1K
+Predicate,https://schema.org/cause-output,< 1K
+Predicate,https://schema.org/causeOf,< 1K
+Predicate,https://schema.org/causeOf-input,< 1K
+Predicate,https://schema.org/causeOf-output,< 1K
+Predicate,https://schema.org/ccRecipient,< 1K
+Predicate,https://schema.org/ccRecipient-input,< 1K
+Predicate,https://schema.org/ccRecipient-output,< 1K
+Predicate,https://schema.org/certificationIdentification,1K - 10K
+Predicate,https://schema.org/certificationIdentification-input,< 1K
+Predicate,https://schema.org/certificationIdentification-output,< 1K
+Predicate,https://schema.org/certificationRating,< 1K
+Predicate,https://schema.org/certificationRating-input,< 1K
+Predicate,https://schema.org/certificationRating-output,< 1K
+Predicate,https://schema.org/certificationStatus,1K - 10K
+Predicate,https://schema.org/certificationStatus-input,< 1K
+Predicate,https://schema.org/certificationStatus-output,< 1K
+Predicate,https://schema.org/character,1K - 10K
+Predicate,https://schema.org/character-input,< 1K
+Predicate,https://schema.org/character-output,< 1K
+Predicate,https://schema.org/characterAttribute,< 1K
+Predicate,https://schema.org/characterAttribute-input,< 1K
+Predicate,https://schema.org/characterAttribute-output,< 1K
+Predicate,https://schema.org/characterName,< 1K
+Predicate,https://schema.org/characterName-input,< 1K
+Predicate,https://schema.org/characterName-output,< 1K
+Predicate,https://schema.org/cheatCode,< 1K
+Predicate,https://schema.org/cheatCode-input,< 1K
+Predicate,https://schema.org/cheatCode-output,< 1K
+Predicate,https://schema.org/checkinTime,10K - 100K
+Predicate,https://schema.org/checkinTime-input,< 1K
+Predicate,https://schema.org/checkinTime-output,< 1K
+Predicate,https://schema.org/checkoutPageURLTemplate,10K - 100K
+Predicate,https://schema.org/checkoutPageURLTemplate-input,< 1K
+Predicate,https://schema.org/checkoutPageURLTemplate-output,< 1K
+Predicate,https://schema.org/checkoutTime,10K - 100K
+Predicate,https://schema.org/checkoutTime-input,< 1K
+Predicate,https://schema.org/checkoutTime-output,< 1K
+Predicate,https://schema.org/chemicalComposition,< 1K
+Predicate,https://schema.org/chemicalComposition-input,< 1K
+Predicate,https://schema.org/chemicalComposition-output,< 1K
+Predicate,https://schema.org/chemicalRole,< 1K
+Predicate,https://schema.org/chemicalRole-input,< 1K
+Predicate,https://schema.org/chemicalRole-output,< 1K
+Predicate,https://schema.org/childMaxAge,< 1K
+Predicate,https://schema.org/childMaxAge-input,< 1K
+Predicate,https://schema.org/childMaxAge-output,< 1K
+Predicate,https://schema.org/childMinAge,< 1K
+Predicate,https://schema.org/childMinAge-input,< 1K
+Predicate,https://schema.org/childMinAge-output,< 1K
+Predicate,https://schema.org/childTaxon,< 1K
+Predicate,https://schema.org/childTaxon-input,< 1K
+Predicate,https://schema.org/childTaxon-output,< 1K
+Predicate,https://schema.org/children,1K - 10K
+Predicate,https://schema.org/children-input,< 1K
+Predicate,https://schema.org/children-output,< 1K
+Predicate,https://schema.org/cholesterolContent,10K - 100K
+Predicate,https://schema.org/cholesterolContent-input,< 1K
+Predicate,https://schema.org/cholesterolContent-output,< 1K
+Predicate,https://schema.org/circle,1K - 10K
+Predicate,https://schema.org/circle-input,< 1K
+Predicate,https://schema.org/circle-output,< 1K
+Predicate,https://schema.org/citation,10K - 100K
+Predicate,https://schema.org/citation-input,< 1K
+Predicate,https://schema.org/citation-output,< 1K
+Predicate,https://schema.org/claimInterpreter,< 1K
+Predicate,https://schema.org/claimInterpreter-input,< 1K
+Predicate,https://schema.org/claimInterpreter-output,< 1K
+Predicate,https://schema.org/claimReviewed,1K - 10K
+Predicate,https://schema.org/claimReviewed-input,< 1K
+Predicate,https://schema.org/claimReviewed-output,< 1K
+Predicate,https://schema.org/clincalPharmacology,< 1K
+Predicate,https://schema.org/clincalPharmacology-input,< 1K
+Predicate,https://schema.org/clincalPharmacology-output,< 1K
+Predicate,https://schema.org/clinicalPharmacology,< 1K
+Predicate,https://schema.org/clinicalPharmacology-input,< 1K
+Predicate,https://schema.org/clinicalPharmacology-output,< 1K
+Predicate,https://schema.org/clipNumber,< 1K
+Predicate,https://schema.org/clipNumber-input,< 1K
+Predicate,https://schema.org/clipNumber-output,< 1K
+Predicate,https://schema.org/closes,1M - 10M
+Predicate,https://schema.org/closes-input,< 1K
+Predicate,https://schema.org/closes-output,< 1K
+Predicate,https://schema.org/coach,1K - 10K
+Predicate,https://schema.org/coach-input,< 1K
+Predicate,https://schema.org/coach-output,< 1K
+Predicate,https://schema.org/code,1K - 10K
+Predicate,https://schema.org/code-input,< 1K
+Predicate,https://schema.org/code-output,< 1K
+Predicate,https://schema.org/codeRepository,1K - 10K
+Predicate,https://schema.org/codeRepository-input,< 1K
+Predicate,https://schema.org/codeRepository-output,< 1K
+Predicate,https://schema.org/codeSampleType,< 1K
+Predicate,https://schema.org/codeSampleType-input,< 1K
+Predicate,https://schema.org/codeSampleType-output,< 1K
+Predicate,https://schema.org/codeValue,1K - 10K
+Predicate,https://schema.org/codeValue-input,< 1K
+Predicate,https://schema.org/codeValue-output,< 1K
+Predicate,https://schema.org/codingSystem,1K - 10K
+Predicate,https://schema.org/codingSystem-input,< 1K
+Predicate,https://schema.org/codingSystem-output,< 1K
+Predicate,https://schema.org/colleague,1K - 10K
+Predicate,https://schema.org/colleague-input,< 1K
+Predicate,https://schema.org/colleague-output,< 1K
+Predicate,https://schema.org/colleagues,< 1K
+Predicate,https://schema.org/colleagues-input,< 1K
+Predicate,https://schema.org/colleagues-output,< 1K
+Predicate,https://schema.org/collection,< 1K
+Predicate,https://schema.org/collection-input,< 1K
+Predicate,https://schema.org/collection-output,< 1K
+Predicate,https://schema.org/collectionSize,1K - 10K
+Predicate,https://schema.org/collectionSize-input,< 1K
+Predicate,https://schema.org/collectionSize-output,< 1K
+Predicate,https://schema.org/color,100K - 1M
+Predicate,https://schema.org/color-input,< 1K
+Predicate,https://schema.org/color-output,< 1K
+Predicate,https://schema.org/colorSwatch,< 1K
+Predicate,https://schema.org/colorSwatch-input,< 1K
+Predicate,https://schema.org/colorSwatch-output,< 1K
+Predicate,https://schema.org/colorist,< 1K
+Predicate,https://schema.org/colorist-input,< 1K
+Predicate,https://schema.org/colorist-output,< 1K
+Predicate,https://schema.org/comment,10K - 100K
+Predicate,https://schema.org/comment-input,< 1K
+Predicate,https://schema.org/comment-output,< 1K
+Predicate,https://schema.org/commentCount,1M - 10M
+Predicate,https://schema.org/commentCount-input,< 1K
+Predicate,https://schema.org/commentCount-output,< 1K
+Predicate,https://schema.org/commentText,10K - 100K
+Predicate,https://schema.org/commentText-input,< 1K
+Predicate,https://schema.org/commentText-output,< 1K
+Predicate,https://schema.org/commentTime,10K - 100K
+Predicate,https://schema.org/commentTime-input,< 1K
+Predicate,https://schema.org/commentTime-output,< 1K
+Predicate,https://schema.org/companyRegistration,< 1K
+Predicate,https://schema.org/companyRegistration-input,< 1K
+Predicate,https://schema.org/companyRegistration-output,< 1K
+Predicate,https://schema.org/competencyRequired,1K - 10K
+Predicate,https://schema.org/competencyRequired-input,< 1K
+Predicate,https://schema.org/competencyRequired-output,< 1K
+Predicate,https://schema.org/competitor,10K - 100K
+Predicate,https://schema.org/competitor-input,< 1K
+Predicate,https://schema.org/competitor-output,< 1K
+Predicate,https://schema.org/composer,1K - 10K
+Predicate,https://schema.org/composer-input,< 1K
+Predicate,https://schema.org/composer-output,< 1K
+Predicate,https://schema.org/comprisedOf,< 1K
+Predicate,https://schema.org/comprisedOf-input,< 1K
+Predicate,https://schema.org/comprisedOf-output,< 1K
+Predicate,https://schema.org/conditionsOfAccess,< 1K
+Predicate,https://schema.org/conditionsOfAccess-input,< 1K
+Predicate,https://schema.org/conditionsOfAccess-output,< 1K
+Predicate,https://schema.org/confirmationNumber,< 1K
+Predicate,https://schema.org/confirmationNumber-input,< 1K
+Predicate,https://schema.org/confirmationNumber-output,< 1K
+Predicate,https://schema.org/connectedTo,< 1K
+Predicate,https://schema.org/connectedTo-input,< 1K
+Predicate,https://schema.org/connectedTo-output,< 1K
+Predicate,https://schema.org/constraintProperty,< 1K
+Predicate,https://schema.org/constraintProperty-input,< 1K
+Predicate,https://schema.org/constraintProperty-output,< 1K
+Predicate,https://schema.org/contactOption,100K - 1M
+Predicate,https://schema.org/contactOption-input,< 1K
+Predicate,https://schema.org/contactOption-output,< 1K
+Predicate,https://schema.org/contactPoint,1M - 10M
+Predicate,https://schema.org/contactPoint-input,< 1K
+Predicate,https://schema.org/contactPoint-output,< 1K
+Predicate,https://schema.org/contactPoints,< 1K
+Predicate,https://schema.org/contactPoints-input,< 1K
+Predicate,https://schema.org/contactPoints-output,< 1K
+Predicate,https://schema.org/contactType,1M - 10M
+Predicate,https://schema.org/contactType-input,< 1K
+Predicate,https://schema.org/contactType-output,< 1K
+Predicate,https://schema.org/contactlessPayment,< 1K
+Predicate,https://schema.org/contactlessPayment-input,< 1K
+Predicate,https://schema.org/contactlessPayment-output,< 1K
+Predicate,https://schema.org/containedIn,10K - 100K
+Predicate,https://schema.org/containedIn-input,< 1K
+Predicate,https://schema.org/containedIn-output,< 1K
+Predicate,https://schema.org/containedInPlace,100K - 1M
+Predicate,https://schema.org/containedInPlace-input,< 1K
+Predicate,https://schema.org/containedInPlace-output,< 1K
+Predicate,https://schema.org/containsPlace,10K - 100K
+Predicate,https://schema.org/containsPlace-input,< 1K
+Predicate,https://schema.org/containsPlace-output,< 1K
+Predicate,https://schema.org/containsSeason,1K - 10K
+Predicate,https://schema.org/containsSeason-input,< 1K
+Predicate,https://schema.org/containsSeason-output,< 1K
+Predicate,https://schema.org/contentLocation,10K - 100K
+Predicate,https://schema.org/contentLocation-input,< 1K
+Predicate,https://schema.org/contentLocation-output,< 1K
+Predicate,https://schema.org/contentRating,10K - 100K
+Predicate,https://schema.org/contentRating-input,< 1K
+Predicate,https://schema.org/contentRating-output,< 1K
+Predicate,https://schema.org/contentReferenceTime,1K - 10K
+Predicate,https://schema.org/contentReferenceTime-input,< 1K
+Predicate,https://schema.org/contentReferenceTime-output,< 1K
+Predicate,https://schema.org/contentSize,100K - 1M
+Predicate,https://schema.org/contentSize-input,< 1K
+Predicate,https://schema.org/contentSize-output,< 1K
+Predicate,https://schema.org/contentType,10K - 100K
+Predicate,https://schema.org/contentType-input,< 1K
+Predicate,https://schema.org/contentType-output,< 1K
+Predicate,https://schema.org/contentUrl,10M+
+Predicate,https://schema.org/contentUrl-input,< 1K
+Predicate,https://schema.org/contentUrl-output,< 1K
+Predicate,https://schema.org/contraindication,1K - 10K
+Predicate,https://schema.org/contraindication-input,< 1K
+Predicate,https://schema.org/contraindication-output,< 1K
+Predicate,https://schema.org/contributor,100K - 1M
+Predicate,https://schema.org/contributor-input,< 1K
+Predicate,https://schema.org/contributor-output,< 1K
+Predicate,https://schema.org/cookTime,10K - 100K
+Predicate,https://schema.org/cookTime-input,< 1K
+Predicate,https://schema.org/cookTime-output,< 1K
+Predicate,https://schema.org/cookingMethod,1K - 10K
+Predicate,https://schema.org/cookingMethod-input,< 1K
+Predicate,https://schema.org/cookingMethod-output,< 1K
+Predicate,https://schema.org/copyrightHolder,100K - 1M
+Predicate,https://schema.org/copyrightHolder-input,< 1K
+Predicate,https://schema.org/copyrightHolder-output,< 1K
+Predicate,https://schema.org/copyrightNotice,10K - 100K
+Predicate,https://schema.org/copyrightNotice-input,< 1K
+Predicate,https://schema.org/copyrightNotice-output,< 1K
+Predicate,https://schema.org/copyrightYear,100K - 1M
+Predicate,https://schema.org/copyrightYear-input,< 1K
+Predicate,https://schema.org/copyrightYear-output,< 1K
+Predicate,https://schema.org/correction,< 1K
+Predicate,https://schema.org/correction-input,< 1K
+Predicate,https://schema.org/correction-output,< 1K
+Predicate,https://schema.org/correctionsPolicy,10K - 100K
+Predicate,https://schema.org/correctionsPolicy-input,< 1K
+Predicate,https://schema.org/correctionsPolicy-output,< 1K
+Predicate,https://schema.org/costCategory,< 1K
+Predicate,https://schema.org/costCategory-input,< 1K
+Predicate,https://schema.org/costCategory-output,< 1K
+Predicate,https://schema.org/costCurrency,< 1K
+Predicate,https://schema.org/costCurrency-input,< 1K
+Predicate,https://schema.org/costCurrency-output,< 1K
+Predicate,https://schema.org/costOrigin,< 1K
+Predicate,https://schema.org/costOrigin-input,< 1K
+Predicate,https://schema.org/costOrigin-output,< 1K
+Predicate,https://schema.org/costPerUnit,< 1K
+Predicate,https://schema.org/costPerUnit-input,< 1K
+Predicate,https://schema.org/costPerUnit-output,< 1K
+Predicate,https://schema.org/countriesNotSupported,< 1K
+Predicate,https://schema.org/countriesNotSupported-input,< 1K
+Predicate,https://schema.org/countriesNotSupported-output,< 1K
+Predicate,https://schema.org/countriesSupported,1K - 10K
+Predicate,https://schema.org/countriesSupported-input,< 1K
+Predicate,https://schema.org/countriesSupported-output,< 1K
+Predicate,https://schema.org/countryOfAssembly,1K - 10K
+Predicate,https://schema.org/countryOfAssembly-input,< 1K
+Predicate,https://schema.org/countryOfAssembly-output,< 1K
+Predicate,https://schema.org/countryOfLastProcessing,< 1K
+Predicate,https://schema.org/countryOfLastProcessing-input,< 1K
+Predicate,https://schema.org/countryOfLastProcessing-output,< 1K
+Predicate,https://schema.org/countryOfOrigin,10K - 100K
+Predicate,https://schema.org/countryOfOrigin-input,< 1K
+Predicate,https://schema.org/countryOfOrigin-output,< 1K
+Predicate,https://schema.org/course,< 1K
+Predicate,https://schema.org/course-input,< 1K
+Predicate,https://schema.org/course-output,< 1K
+Predicate,https://schema.org/courseCode,10K - 100K
+Predicate,https://schema.org/courseCode-input,< 1K
+Predicate,https://schema.org/courseCode-output,< 1K
+Predicate,https://schema.org/courseMode,10K - 100K
+Predicate,https://schema.org/courseMode-input,< 1K
+Predicate,https://schema.org/courseMode-output,< 1K
+Predicate,https://schema.org/coursePrerequisites,1K - 10K
+Predicate,https://schema.org/coursePrerequisites-input,< 1K
+Predicate,https://schema.org/coursePrerequisites-output,< 1K
+Predicate,https://schema.org/courseSchedule,1K - 10K
+Predicate,https://schema.org/courseSchedule-input,< 1K
+Predicate,https://schema.org/courseSchedule-output,< 1K
+Predicate,https://schema.org/courseWorkload,10K - 100K
+Predicate,https://schema.org/courseWorkload-input,< 1K
+Predicate,https://schema.org/courseWorkload-output,< 1K
+Predicate,https://schema.org/coverageEndTime,1K - 10K
+Predicate,https://schema.org/coverageEndTime-input,< 1K
+Predicate,https://schema.org/coverageEndTime-output,< 1K
+Predicate,https://schema.org/coverageStartTime,1K - 10K
+Predicate,https://schema.org/coverageStartTime-input,< 1K
+Predicate,https://schema.org/coverageStartTime-output,< 1K
+Predicate,https://schema.org/creativeWorkStatus,1K - 10K
+Predicate,https://schema.org/creativeWorkStatus-input,< 1K
+Predicate,https://schema.org/creativeWorkStatus-output,< 1K
+Predicate,https://schema.org/creator,1M - 10M
+Predicate,https://schema.org/creator-input,< 1K
+Predicate,https://schema.org/creator-output,< 1K
+Predicate,https://schema.org/credentialCategory,10K - 100K
+Predicate,https://schema.org/credentialCategory-input,< 1K
+Predicate,https://schema.org/credentialCategory-output,< 1K
+Predicate,https://schema.org/creditText,100K - 1M
+Predicate,https://schema.org/creditText-input,< 1K
+Predicate,https://schema.org/creditText-output,< 1K
+Predicate,https://schema.org/creditedTo,< 1K
+Predicate,https://schema.org/creditedTo-input,< 1K
+Predicate,https://schema.org/creditedTo-output,< 1K
+Predicate,https://schema.org/cssSelector,100K - 1M
+Predicate,https://schema.org/cssSelector-input,< 1K
+Predicate,https://schema.org/cssSelector-output,< 1K
+Predicate,https://schema.org/currenciesAccepted,100K - 1M
+Predicate,https://schema.org/currenciesAccepted-input,< 1K
+Predicate,https://schema.org/currenciesAccepted-output,< 1K
+Predicate,https://schema.org/currency,100K - 1M
+Predicate,https://schema.org/currency-input,< 1K
+Predicate,https://schema.org/currency-output,< 1K
+Predicate,https://schema.org/currentExchangeRate,< 1K
+Predicate,https://schema.org/currentExchangeRate-input,< 1K
+Predicate,https://schema.org/currentExchangeRate-output,< 1K
+Predicate,https://schema.org/customer,< 1K
+Predicate,https://schema.org/customer-input,< 1K
+Predicate,https://schema.org/customer-output,< 1K
+Predicate,https://schema.org/customerRemorseReturnFees,1K - 10K
+Predicate,https://schema.org/customerRemorseReturnFees-input,< 1K
+Predicate,https://schema.org/customerRemorseReturnFees-output,< 1K
+Predicate,https://schema.org/customerRemorseReturnLabelSource,< 1K
+Predicate,https://schema.org/customerRemorseReturnLabelSource-input,< 1K
+Predicate,https://schema.org/customerRemorseReturnLabelSource-output,< 1K
+Predicate,https://schema.org/customerRemorseReturnShippingFeesAmount,< 1K
+Predicate,https://schema.org/customerRemorseReturnShippingFeesAmount-input,< 1K
+Predicate,https://schema.org/customerRemorseReturnShippingFeesAmount-output,< 1K
+Predicate,https://schema.org/cutoffTime,10K - 100K
+Predicate,https://schema.org/cutoffTime-input,< 1K
+Predicate,https://schema.org/cutoffTime-output,< 1K
+Predicate,https://schema.org/cvdCollectionDate,< 1K
+Predicate,https://schema.org/cvdCollectionDate-input,< 1K
+Predicate,https://schema.org/cvdCollectionDate-output,< 1K
+Predicate,https://schema.org/cvdFacilityCounty,< 1K
+Predicate,https://schema.org/cvdFacilityCounty-input,< 1K
+Predicate,https://schema.org/cvdFacilityCounty-output,< 1K
+Predicate,https://schema.org/cvdFacilityId,< 1K
+Predicate,https://schema.org/cvdFacilityId-input,< 1K
+Predicate,https://schema.org/cvdFacilityId-output,< 1K
+Predicate,https://schema.org/cvdNumBeds,< 1K
+Predicate,https://schema.org/cvdNumBeds-input,< 1K
+Predicate,https://schema.org/cvdNumBeds-output,< 1K
+Predicate,https://schema.org/cvdNumBedsOcc,< 1K
+Predicate,https://schema.org/cvdNumBedsOcc-input,< 1K
+Predicate,https://schema.org/cvdNumBedsOcc-output,< 1K
+Predicate,https://schema.org/cvdNumC19Died,< 1K
+Predicate,https://schema.org/cvdNumC19Died-input,< 1K
+Predicate,https://schema.org/cvdNumC19Died-output,< 1K
+Predicate,https://schema.org/cvdNumC19HOPats,< 1K
+Predicate,https://schema.org/cvdNumC19HOPats-input,< 1K
+Predicate,https://schema.org/cvdNumC19HOPats-output,< 1K
+Predicate,https://schema.org/cvdNumC19HospPats,< 1K
+Predicate,https://schema.org/cvdNumC19HospPats-input,< 1K
+Predicate,https://schema.org/cvdNumC19HospPats-output,< 1K
+Predicate,https://schema.org/cvdNumC19MechVentPats,< 1K
+Predicate,https://schema.org/cvdNumC19MechVentPats-input,< 1K
+Predicate,https://schema.org/cvdNumC19MechVentPats-output,< 1K
+Predicate,https://schema.org/cvdNumC19OFMechVentPats,< 1K
+Predicate,https://schema.org/cvdNumC19OFMechVentPats-input,< 1K
+Predicate,https://schema.org/cvdNumC19OFMechVentPats-output,< 1K
+Predicate,https://schema.org/cvdNumC19OverflowPats,< 1K
+Predicate,https://schema.org/cvdNumC19OverflowPats-input,< 1K
+Predicate,https://schema.org/cvdNumC19OverflowPats-output,< 1K
+Predicate,https://schema.org/cvdNumICUBeds,< 1K
+Predicate,https://schema.org/cvdNumICUBeds-input,< 1K
+Predicate,https://schema.org/cvdNumICUBeds-output,< 1K
+Predicate,https://schema.org/cvdNumICUBedsOcc,< 1K
+Predicate,https://schema.org/cvdNumICUBedsOcc-input,< 1K
+Predicate,https://schema.org/cvdNumICUBedsOcc-output,< 1K
+Predicate,https://schema.org/cvdNumTotBeds,< 1K
+Predicate,https://schema.org/cvdNumTotBeds-input,< 1K
+Predicate,https://schema.org/cvdNumTotBeds-output,< 1K
+Predicate,https://schema.org/cvdNumVent,< 1K
+Predicate,https://schema.org/cvdNumVent-input,< 1K
+Predicate,https://schema.org/cvdNumVent-output,< 1K
+Predicate,https://schema.org/cvdNumVentUse,< 1K
+Predicate,https://schema.org/cvdNumVentUse-input,< 1K
+Predicate,https://schema.org/cvdNumVentUse-output,< 1K
+Predicate,https://schema.org/data,1K - 10K
+Predicate,https://schema.org/data-input,< 1K
+Predicate,https://schema.org/data-output,< 1K
+Predicate,https://schema.org/dataFeedElement,1K - 10K
+Predicate,https://schema.org/dataFeedElement-input,< 1K
+Predicate,https://schema.org/dataFeedElement-output,< 1K
+Predicate,https://schema.org/dataset,1K - 10K
+Predicate,https://schema.org/dataset-input,< 1K
+Predicate,https://schema.org/dataset-output,< 1K
+Predicate,https://schema.org/datasetTimeInterval,< 1K
+Predicate,https://schema.org/datasetTimeInterval-input,< 1K
+Predicate,https://schema.org/datasetTimeInterval-output,< 1K
+Predicate,https://schema.org/dateCreated,100K - 1M
+Predicate,https://schema.org/dateCreated-input,< 1K
+Predicate,https://schema.org/dateCreated-output,< 1K
+Predicate,https://schema.org/dateDeleted,< 1K
+Predicate,https://schema.org/dateDeleted-input,< 1K
+Predicate,https://schema.org/dateDeleted-output,< 1K
+Predicate,https://schema.org/dateIssued,< 1K
+Predicate,https://schema.org/dateIssued-input,< 1K
+Predicate,https://schema.org/dateIssued-output,< 1K
+Predicate,https://schema.org/dateModified,10M+
+Predicate,https://schema.org/dateModified-input,< 1K
+Predicate,https://schema.org/dateModified-output,< 1K
+Predicate,https://schema.org/datePosted,100K - 1M
+Predicate,https://schema.org/datePosted-input,< 1K
+Predicate,https://schema.org/datePosted-output,< 1K
+Predicate,https://schema.org/datePublished,10M+
+Predicate,https://schema.org/datePublished-input,< 1K
+Predicate,https://schema.org/datePublished-output,< 1K
+Predicate,https://schema.org/dateRead,< 1K
+Predicate,https://schema.org/dateRead-input,< 1K
+Predicate,https://schema.org/dateRead-output,< 1K
+Predicate,https://schema.org/dateReceived,< 1K
+Predicate,https://schema.org/dateReceived-input,< 1K
+Predicate,https://schema.org/dateReceived-output,< 1K
+Predicate,https://schema.org/dateSent,< 1K
+Predicate,https://schema.org/dateSent-input,< 1K
+Predicate,https://schema.org/dateSent-output,< 1K
+Predicate,https://schema.org/dateVehicleFirstRegistered,1K - 10K
+Predicate,https://schema.org/dateVehicleFirstRegistered-input,< 1K
+Predicate,https://schema.org/dateVehicleFirstRegistered-output,< 1K
+Predicate,https://schema.org/dateline,1K - 10K
+Predicate,https://schema.org/dateline-input,< 1K
+Predicate,https://schema.org/dateline-output,< 1K
+Predicate,https://schema.org/dayOfWeek,1M - 10M
+Predicate,https://schema.org/dayOfWeek-input,< 1K
+Predicate,https://schema.org/dayOfWeek-output,< 1K
+Predicate,https://schema.org/deathDate,10K - 100K
+Predicate,https://schema.org/deathDate-input,< 1K
+Predicate,https://schema.org/deathDate-output,< 1K
+Predicate,https://schema.org/deathPlace,1K - 10K
+Predicate,https://schema.org/deathPlace-input,< 1K
+Predicate,https://schema.org/deathPlace-output,< 1K
+Predicate,https://schema.org/defaultValue,100K - 1M
+Predicate,https://schema.org/defaultValue-input,< 1K
+Predicate,https://schema.org/defaultValue-output,< 1K
+Predicate,https://schema.org/deliveryAddress,< 1K
+Predicate,https://schema.org/deliveryAddress-input,< 1K
+Predicate,https://schema.org/deliveryAddress-output,< 1K
+Predicate,https://schema.org/deliveryLeadTime,10K - 100K
+Predicate,https://schema.org/deliveryLeadTime-input,< 1K
+Predicate,https://schema.org/deliveryLeadTime-output,< 1K
+Predicate,https://schema.org/deliveryMethod,100K - 1M
+Predicate,https://schema.org/deliveryMethod-input,< 1K
+Predicate,https://schema.org/deliveryMethod-output,< 1K
+Predicate,https://schema.org/deliveryStatus,< 1K
+Predicate,https://schema.org/deliveryStatus-input,< 1K
+Predicate,https://schema.org/deliveryStatus-output,< 1K
+Predicate,https://schema.org/deliveryTime,100K - 1M
+Predicate,https://schema.org/deliveryTime-input,< 1K
+Predicate,https://schema.org/deliveryTime-output,< 1K
+Predicate,https://schema.org/department,10K - 100K
+Predicate,https://schema.org/department-input,< 1K
+Predicate,https://schema.org/department-output,< 1K
+Predicate,https://schema.org/departureAirport,1K - 10K
+Predicate,https://schema.org/departureAirport-input,< 1K
+Predicate,https://schema.org/departureAirport-output,< 1K
+Predicate,https://schema.org/departureBoatTerminal,< 1K
+Predicate,https://schema.org/departureBoatTerminal-input,< 1K
+Predicate,https://schema.org/departureBoatTerminal-output,< 1K
+Predicate,https://schema.org/departureBusStop,< 1K
+Predicate,https://schema.org/departureBusStop-input,< 1K
+Predicate,https://schema.org/departureBusStop-output,< 1K
+Predicate,https://schema.org/departureGate,< 1K
+Predicate,https://schema.org/departureGate-input,< 1K
+Predicate,https://schema.org/departureGate-output,< 1K
+Predicate,https://schema.org/departurePlatform,< 1K
+Predicate,https://schema.org/departurePlatform-input,< 1K
+Predicate,https://schema.org/departurePlatform-output,< 1K
+Predicate,https://schema.org/departureStation,< 1K
+Predicate,https://schema.org/departureStation-input,< 1K
+Predicate,https://schema.org/departureStation-output,< 1K
+Predicate,https://schema.org/departureTerminal,< 1K
+Predicate,https://schema.org/departureTerminal-input,< 1K
+Predicate,https://schema.org/departureTerminal-output,< 1K
+Predicate,https://schema.org/departureTime,1K - 10K
+Predicate,https://schema.org/departureTime-input,< 1K
+Predicate,https://schema.org/departureTime-output,< 1K
+Predicate,https://schema.org/dependencies,10K - 100K
+Predicate,https://schema.org/dependencies-input,< 1K
+Predicate,https://schema.org/dependencies-output,< 1K
+Predicate,https://schema.org/depth,10K - 100K
+Predicate,https://schema.org/depth-input,< 1K
+Predicate,https://schema.org/depth-output,< 1K
+Predicate,https://schema.org/description,10M+
+Predicate,https://schema.org/description-input,< 1K
+Predicate,https://schema.org/description-output,< 1K
+Predicate,https://schema.org/device,< 1K
+Predicate,https://schema.org/device-input,< 1K
+Predicate,https://schema.org/device-output,< 1K
+Predicate,https://schema.org/diagnosis,< 1K
+Predicate,https://schema.org/diagnosis-input,< 1K
+Predicate,https://schema.org/diagnosis-output,< 1K
+Predicate,https://schema.org/diagram,< 1K
+Predicate,https://schema.org/diagram-input,< 1K
+Predicate,https://schema.org/diagram-output,< 1K
+Predicate,https://schema.org/diet,< 1K
+Predicate,https://schema.org/diet-input,< 1K
+Predicate,https://schema.org/diet-output,< 1K
+Predicate,https://schema.org/dietFeatures,< 1K
+Predicate,https://schema.org/dietFeatures-input,< 1K
+Predicate,https://schema.org/dietFeatures-output,< 1K
+Predicate,https://schema.org/differentialDiagnosis,< 1K
+Predicate,https://schema.org/differentialDiagnosis-input,< 1K
+Predicate,https://schema.org/differentialDiagnosis-output,< 1K
+Predicate,https://schema.org/digitalSourceType,< 1K
+Predicate,https://schema.org/digitalSourceType-input,< 1K
+Predicate,https://schema.org/digitalSourceType-output,< 1K
+Predicate,https://schema.org/directApply,10K - 100K
+Predicate,https://schema.org/directApply-input,< 1K
+Predicate,https://schema.org/directApply-output,< 1K
+Predicate,https://schema.org/director,10K - 100K
+Predicate,https://schema.org/director-input,< 1K
+Predicate,https://schema.org/director-output,< 1K
+Predicate,https://schema.org/directors,< 1K
+Predicate,https://schema.org/directors-input,< 1K
+Predicate,https://schema.org/directors-output,< 1K
+Predicate,https://schema.org/disambiguatingDescription,10K - 100K
+Predicate,https://schema.org/disambiguatingDescription-input,< 1K
+Predicate,https://schema.org/disambiguatingDescription-output,< 1K
+Predicate,https://schema.org/discount,10K - 100K
+Predicate,https://schema.org/discount-input,< 1K
+Predicate,https://schema.org/discount-output,< 1K
+Predicate,https://schema.org/discountCode,< 1K
+Predicate,https://schema.org/discountCode-input,< 1K
+Predicate,https://schema.org/discountCode-output,< 1K
+Predicate,https://schema.org/discountCurrency,< 1K
+Predicate,https://schema.org/discountCurrency-input,< 1K
+Predicate,https://schema.org/discountCurrency-output,< 1K
+Predicate,https://schema.org/discusses,1K - 10K
+Predicate,https://schema.org/discusses-input,< 1K
+Predicate,https://schema.org/discusses-output,< 1K
+Predicate,https://schema.org/discussionUrl,10K - 100K
+Predicate,https://schema.org/discussionUrl-input,< 1K
+Predicate,https://schema.org/discussionUrl-output,< 1K
+Predicate,https://schema.org/diseasePreventionInfo,< 1K
+Predicate,https://schema.org/diseasePreventionInfo-input,< 1K
+Predicate,https://schema.org/diseasePreventionInfo-output,< 1K
+Predicate,https://schema.org/diseaseSpreadStatistics,< 1K
+Predicate,https://schema.org/diseaseSpreadStatistics-input,< 1K
+Predicate,https://schema.org/diseaseSpreadStatistics-output,< 1K
+Predicate,https://schema.org/displayLocation,< 1K
+Predicate,https://schema.org/displayLocation-input,< 1K
+Predicate,https://schema.org/displayLocation-output,< 1K
+Predicate,https://schema.org/dissolutionDate,< 1K
+Predicate,https://schema.org/dissolutionDate-input,< 1K
+Predicate,https://schema.org/dissolutionDate-output,< 1K
+Predicate,https://schema.org/distance,1K - 10K
+Predicate,https://schema.org/distance-input,< 1K
+Predicate,https://schema.org/distance-output,< 1K
+Predicate,https://schema.org/distinguishingSign,< 1K
+Predicate,https://schema.org/distinguishingSign-input,< 1K
+Predicate,https://schema.org/distinguishingSign-output,< 1K
+Predicate,https://schema.org/distribution,10K - 100K
+Predicate,https://schema.org/distribution-input,< 1K
+Predicate,https://schema.org/distribution-output,< 1K
+Predicate,https://schema.org/diversityPolicy,10K - 100K
+Predicate,https://schema.org/diversityPolicy-input,< 1K
+Predicate,https://schema.org/diversityPolicy-output,< 1K
+Predicate,https://schema.org/diversityStaffingReport,1K - 10K
+Predicate,https://schema.org/diversityStaffingReport-input,< 1K
+Predicate,https://schema.org/diversityStaffingReport-output,< 1K
+Predicate,https://schema.org/documentation,1K - 10K
+Predicate,https://schema.org/documentation-input,< 1K
+Predicate,https://schema.org/documentation-output,< 1K
+Predicate,https://schema.org/doesNotShip,10K - 100K
+Predicate,https://schema.org/doesNotShip-input,< 1K
+Predicate,https://schema.org/doesNotShip-output,< 1K
+Predicate,https://schema.org/domainIncludes,< 1K
+Predicate,https://schema.org/domainIncludes-input,< 1K
+Predicate,https://schema.org/domainIncludes-output,< 1K
+Predicate,https://schema.org/domiciledMortgage,< 1K
+Predicate,https://schema.org/domiciledMortgage-input,< 1K
+Predicate,https://schema.org/domiciledMortgage-output,< 1K
+Predicate,https://schema.org/doorTime,1K - 10K
+Predicate,https://schema.org/doorTime-input,< 1K
+Predicate,https://schema.org/doorTime-output,< 1K
+Predicate,https://schema.org/dosageForm,1K - 10K
+Predicate,https://schema.org/dosageForm-input,< 1K
+Predicate,https://schema.org/dosageForm-output,< 1K
+Predicate,https://schema.org/doseSchedule,< 1K
+Predicate,https://schema.org/doseSchedule-input,< 1K
+Predicate,https://schema.org/doseSchedule-output,< 1K
+Predicate,https://schema.org/doseUnit,< 1K
+Predicate,https://schema.org/doseUnit-input,< 1K
+Predicate,https://schema.org/doseUnit-output,< 1K
+Predicate,https://schema.org/doseValue,< 1K
+Predicate,https://schema.org/doseValue-input,< 1K
+Predicate,https://schema.org/doseValue-output,< 1K
+Predicate,https://schema.org/downPayment,< 1K
+Predicate,https://schema.org/downPayment-input,< 1K
+Predicate,https://schema.org/downPayment-output,< 1K
+Predicate,https://schema.org/downloadUrl,100K - 1M
+Predicate,https://schema.org/downloadUrl-input,< 1K
+Predicate,https://schema.org/downloadUrl-output,< 1K
+Predicate,https://schema.org/downvoteCount,1K - 10K
+Predicate,https://schema.org/downvoteCount-input,< 1K
+Predicate,https://schema.org/downvoteCount-output,< 1K
+Predicate,https://schema.org/drainsTo,< 1K
+Predicate,https://schema.org/drainsTo-input,< 1K
+Predicate,https://schema.org/drainsTo-output,< 1K
+Predicate,https://schema.org/driveWheelConfiguration,10K - 100K
+Predicate,https://schema.org/driveWheelConfiguration-input,< 1K
+Predicate,https://schema.org/driveWheelConfiguration-output,< 1K
+Predicate,https://schema.org/dropoffLocation,< 1K
+Predicate,https://schema.org/dropoffLocation-input,< 1K
+Predicate,https://schema.org/dropoffLocation-output,< 1K
+Predicate,https://schema.org/dropoffTime,< 1K
+Predicate,https://schema.org/dropoffTime-input,< 1K
+Predicate,https://schema.org/dropoffTime-output,< 1K
+Predicate,https://schema.org/drug,< 1K
+Predicate,https://schema.org/drug-input,< 1K
+Predicate,https://schema.org/drug-output,< 1K
+Predicate,https://schema.org/drugClass,1K - 10K
+Predicate,https://schema.org/drugClass-input,< 1K
+Predicate,https://schema.org/drugClass-output,< 1K
+Predicate,https://schema.org/drugUnit,< 1K
+Predicate,https://schema.org/drugUnit-input,< 1K
+Predicate,https://schema.org/drugUnit-output,< 1K
+Predicate,https://schema.org/duns,1K - 10K
+Predicate,https://schema.org/duns-input,< 1K
+Predicate,https://schema.org/duns-output,< 1K
+Predicate,https://schema.org/duplicateTherapy,< 1K
+Predicate,https://schema.org/duplicateTherapy-input,< 1K
+Predicate,https://schema.org/duplicateTherapy-output,< 1K
+Predicate,https://schema.org/duration,1M - 10M
+Predicate,https://schema.org/duration-input,< 1K
+Predicate,https://schema.org/duration-output,< 1K
+Predicate,https://schema.org/durationOfWarranty,1K - 10K
+Predicate,https://schema.org/durationOfWarranty-input,< 1K
+Predicate,https://schema.org/durationOfWarranty-output,< 1K
+Predicate,https://schema.org/duringMedia,< 1K
+Predicate,https://schema.org/duringMedia-input,< 1K
+Predicate,https://schema.org/duringMedia-output,< 1K
+Predicate,https://schema.org/earlyPrepaymentPenalty,< 1K
+Predicate,https://schema.org/earlyPrepaymentPenalty-input,< 1K
+Predicate,https://schema.org/earlyPrepaymentPenalty-output,< 1K
+Predicate,https://schema.org/editEIDR,< 1K
+Predicate,https://schema.org/editEIDR-input,< 1K
+Predicate,https://schema.org/editEIDR-output,< 1K
+Predicate,https://schema.org/editor,100K - 1M
+Predicate,https://schema.org/editor-input,< 1K
+Predicate,https://schema.org/editor-output,< 1K
+Predicate,https://schema.org/eduQuestionType,1K - 10K
+Predicate,https://schema.org/eduQuestionType-input,< 1K
+Predicate,https://schema.org/eduQuestionType-output,< 1K
+Predicate,https://schema.org/educationRequirements,10K - 100K
+Predicate,https://schema.org/educationRequirements-input,< 1K
+Predicate,https://schema.org/educationRequirements-output,< 1K
+Predicate,https://schema.org/educationalAlignment,1K - 10K
+Predicate,https://schema.org/educationalAlignment-input,< 1K
+Predicate,https://schema.org/educationalAlignment-output,< 1K
+Predicate,https://schema.org/educationalCredentialAwarded,10K - 100K
+Predicate,https://schema.org/educationalCredentialAwarded-input,< 1K
+Predicate,https://schema.org/educationalCredentialAwarded-output,< 1K
+Predicate,https://schema.org/educationalFramework,< 1K
+Predicate,https://schema.org/educationalFramework-input,< 1K
+Predicate,https://schema.org/educationalFramework-output,< 1K
+Predicate,https://schema.org/educationalLevel,10K - 100K
+Predicate,https://schema.org/educationalLevel-input,< 1K
+Predicate,https://schema.org/educationalLevel-output,< 1K
+Predicate,https://schema.org/educationalProgramMode,1K - 10K
+Predicate,https://schema.org/educationalProgramMode-input,< 1K
+Predicate,https://schema.org/educationalProgramMode-output,< 1K
+Predicate,https://schema.org/educationalRole,10K - 100K
+Predicate,https://schema.org/educationalRole-input,< 1K
+Predicate,https://schema.org/educationalRole-output,< 1K
+Predicate,https://schema.org/educationalUse,1K - 10K
+Predicate,https://schema.org/educationalUse-input,< 1K
+Predicate,https://schema.org/educationalUse-output,< 1K
+Predicate,https://schema.org/elevation,1K - 10K
+Predicate,https://schema.org/elevation-input,< 1K
+Predicate,https://schema.org/elevation-output,< 1K
+Predicate,https://schema.org/eligibilityToWorkRequirement,< 1K
+Predicate,https://schema.org/eligibilityToWorkRequirement-input,< 1K
+Predicate,https://schema.org/eligibilityToWorkRequirement-output,< 1K
+Predicate,https://schema.org/eligibleCustomerType,1K - 10K
+Predicate,https://schema.org/eligibleCustomerType-input,< 1K
+Predicate,https://schema.org/eligibleCustomerType-output,< 1K
+Predicate,https://schema.org/eligibleDuration,10K - 100K
+Predicate,https://schema.org/eligibleDuration-input,< 1K
+Predicate,https://schema.org/eligibleDuration-output,< 1K
+Predicate,https://schema.org/eligibleQuantity,100K - 1M
+Predicate,https://schema.org/eligibleQuantity-input,< 1K
+Predicate,https://schema.org/eligibleQuantity-output,< 1K
+Predicate,https://schema.org/eligibleRegion,10K - 100K
+Predicate,https://schema.org/eligibleRegion-input,< 1K
+Predicate,https://schema.org/eligibleRegion-output,< 1K
+Predicate,https://schema.org/eligibleTransactionVolume,10K - 100K
+Predicate,https://schema.org/eligibleTransactionVolume-input,< 1K
+Predicate,https://schema.org/eligibleTransactionVolume-output,< 1K
+Predicate,https://schema.org/eligibleWithSupplier,< 1K
+Predicate,https://schema.org/eligibleWithSupplier-input,< 1K
+Predicate,https://schema.org/eligibleWithSupplier-output,< 1K
+Predicate,https://schema.org/email,1M - 10M
+Predicate,https://schema.org/email-input,< 1K
+Predicate,https://schema.org/email-output,< 1K
+Predicate,https://schema.org/embedUrl,1M - 10M
+Predicate,https://schema.org/embedUrl-input,< 1K
+Predicate,https://schema.org/embedUrl-output,< 1K
+Predicate,https://schema.org/embeddedTextCaption,1K - 10K
+Predicate,https://schema.org/embeddedTextCaption-input,< 1K
+Predicate,https://schema.org/embeddedTextCaption-output,< 1K
+Predicate,https://schema.org/emissionsCO2,1K - 10K
+Predicate,https://schema.org/emissionsCO2-input,< 1K
+Predicate,https://schema.org/emissionsCO2-output,< 1K
+Predicate,https://schema.org/employee,100K - 1M
+Predicate,https://schema.org/employee-input,< 1K
+Predicate,https://schema.org/employee-output,< 1K
+Predicate,https://schema.org/employees,1K - 10K
+Predicate,https://schema.org/employees-input,< 1K
+Predicate,https://schema.org/employees-output,< 1K
+Predicate,https://schema.org/employerOverview,1K - 10K
+Predicate,https://schema.org/employerOverview-input,< 1K
+Predicate,https://schema.org/employerOverview-output,< 1K
+Predicate,https://schema.org/employmentType,100K - 1M
+Predicate,https://schema.org/employmentType-input,< 1K
+Predicate,https://schema.org/employmentType-output,< 1K
+Predicate,https://schema.org/employmentUnit,1K - 10K
+Predicate,https://schema.org/employmentUnit-input,< 1K
+Predicate,https://schema.org/employmentUnit-output,< 1K
+Predicate,https://schema.org/encodesBioChemEntity,< 1K
+Predicate,https://schema.org/encodesBioChemEntity-input,< 1K
+Predicate,https://schema.org/encodesBioChemEntity-output,< 1K
+Predicate,https://schema.org/encodesCreativeWork,< 1K
+Predicate,https://schema.org/encodesCreativeWork-input,< 1K
+Predicate,https://schema.org/encodesCreativeWork-output,< 1K
+Predicate,https://schema.org/encoding,100K - 1M
+Predicate,https://schema.org/encoding-input,< 1K
+Predicate,https://schema.org/encoding-output,< 1K
+Predicate,https://schema.org/encodingFormat,10K - 100K
+Predicate,https://schema.org/encodingFormat-input,< 1K
+Predicate,https://schema.org/encodingFormat-output,< 1K
+Predicate,https://schema.org/encodingType,< 1K
+Predicate,https://schema.org/encodingType-input,< 1K
+Predicate,https://schema.org/encodingType-output,< 1K
+Predicate,https://schema.org/encodings,< 1K
+Predicate,https://schema.org/encodings-input,< 1K
+Predicate,https://schema.org/encodings-output,< 1K
+Predicate,https://schema.org/endDate,100K - 1M
+Predicate,https://schema.org/endDate-input,< 1K
+Predicate,https://schema.org/endDate-output,< 1K
+Predicate,https://schema.org/endOffset,10K - 100K
+Predicate,https://schema.org/endOffset-input,< 1K
+Predicate,https://schema.org/endOffset-output,< 1K
+Predicate,https://schema.org/endTime,1K - 10K
+Predicate,https://schema.org/endTime-input,< 1K
+Predicate,https://schema.org/endTime-output,< 1K
+Predicate,https://schema.org/endorsee,< 1K
+Predicate,https://schema.org/endorsee-input,< 1K
+Predicate,https://schema.org/endorsee-output,< 1K
+Predicate,https://schema.org/endorsers,< 1K
+Predicate,https://schema.org/endorsers-input,< 1K
+Predicate,https://schema.org/endorsers-output,< 1K
+Predicate,https://schema.org/energyEfficiencyScaleMax,1K - 10K
+Predicate,https://schema.org/energyEfficiencyScaleMax-input,< 1K
+Predicate,https://schema.org/energyEfficiencyScaleMax-output,< 1K
+Predicate,https://schema.org/energyEfficiencyScaleMin,1K - 10K
+Predicate,https://schema.org/energyEfficiencyScaleMin-input,< 1K
+Predicate,https://schema.org/energyEfficiencyScaleMin-output,< 1K
+Predicate,https://schema.org/engineDisplacement,10K - 100K
+Predicate,https://schema.org/engineDisplacement-input,< 1K
+Predicate,https://schema.org/engineDisplacement-output,< 1K
+Predicate,https://schema.org/enginePower,10K - 100K
+Predicate,https://schema.org/enginePower-input,< 1K
+Predicate,https://schema.org/enginePower-output,< 1K
+Predicate,https://schema.org/engineType,1K - 10K
+Predicate,https://schema.org/engineType-input,< 1K
+Predicate,https://schema.org/engineType-output,< 1K
+Predicate,https://schema.org/entertainmentBusiness,< 1K
+Predicate,https://schema.org/entertainmentBusiness-input,< 1K
+Predicate,https://schema.org/entertainmentBusiness-output,< 1K
+Predicate,https://schema.org/epidemiology,1K - 10K
+Predicate,https://schema.org/epidemiology-input,< 1K
+Predicate,https://schema.org/epidemiology-output,< 1K
+Predicate,https://schema.org/episode,1K - 10K
+Predicate,https://schema.org/episode-input,< 1K
+Predicate,https://schema.org/episode-output,< 1K
+Predicate,https://schema.org/episodeNumber,10K - 100K
+Predicate,https://schema.org/episodeNumber-input,< 1K
+Predicate,https://schema.org/episodeNumber-output,< 1K
+Predicate,https://schema.org/episodes,< 1K
+Predicate,https://schema.org/episodes-input,< 1K
+Predicate,https://schema.org/episodes-output,< 1K
+Predicate,https://schema.org/equal,< 1K
+Predicate,https://schema.org/equal-input,< 1K
+Predicate,https://schema.org/equal-output,< 1K
+Predicate,https://schema.org/error,1K - 10K
+Predicate,https://schema.org/error-input,< 1K
+Predicate,https://schema.org/error-output,< 1K
+Predicate,https://schema.org/errorCode,< 1K
+Predicate,https://schema.org/errorCode-input,< 1K
+Predicate,https://schema.org/errorCode-output,< 1K
+Predicate,https://schema.org/estimatedCost,10K - 100K
+Predicate,https://schema.org/estimatedCost-input,< 1K
+Predicate,https://schema.org/estimatedCost-output,< 1K
+Predicate,https://schema.org/estimatedFlightDuration,< 1K
+Predicate,https://schema.org/estimatedFlightDuration-input,< 1K
+Predicate,https://schema.org/estimatedFlightDuration-output,< 1K
+Predicate,https://schema.org/estimatedSalary,1K - 10K
+Predicate,https://schema.org/estimatedSalary-input,< 1K
+Predicate,https://schema.org/estimatedSalary-output,< 1K
+Predicate,https://schema.org/estimatesRiskOf,< 1K
+Predicate,https://schema.org/estimatesRiskOf-input,< 1K
+Predicate,https://schema.org/estimatesRiskOf-output,< 1K
+Predicate,https://schema.org/ethicsPolicy,10K - 100K
+Predicate,https://schema.org/ethicsPolicy-input,< 1K
+Predicate,https://schema.org/ethicsPolicy-output,< 1K
+Predicate,https://schema.org/event,10K - 100K
+Predicate,https://schema.org/event-input,< 1K
+Predicate,https://schema.org/event-output,< 1K
+Predicate,https://schema.org/eventAttendanceMode,100K - 1M
+Predicate,https://schema.org/eventAttendanceMode-input,< 1K
+Predicate,https://schema.org/eventAttendanceMode-output,< 1K
+Predicate,https://schema.org/eventSchedule,1K - 10K
+Predicate,https://schema.org/eventSchedule-input,< 1K
+Predicate,https://schema.org/eventSchedule-output,< 1K
+Predicate,https://schema.org/eventStatus,100K - 1M
+Predicate,https://schema.org/eventStatus-input,< 1K
+Predicate,https://schema.org/eventStatus-output,< 1K
+Predicate,https://schema.org/events,1K - 10K
+Predicate,https://schema.org/events-input,< 1K
+Predicate,https://schema.org/events-output,< 1K
+Predicate,https://schema.org/evidenceLevel,< 1K
+Predicate,https://schema.org/evidenceLevel-input,< 1K
+Predicate,https://schema.org/evidenceLevel-output,< 1K
+Predicate,https://schema.org/evidenceOrigin,< 1K
+Predicate,https://schema.org/evidenceOrigin-input,< 1K
+Predicate,https://schema.org/evidenceOrigin-output,< 1K
+Predicate,https://schema.org/exampleOfWork,1K - 10K
+Predicate,https://schema.org/exampleOfWork-input,< 1K
+Predicate,https://schema.org/exampleOfWork-output,< 1K
+Predicate,https://schema.org/exceptDate,< 1K
+Predicate,https://schema.org/exceptDate-input,< 1K
+Predicate,https://schema.org/exceptDate-output,< 1K
+Predicate,https://schema.org/exchangeRateSpread,< 1K
+Predicate,https://schema.org/exchangeRateSpread-input,< 1K
+Predicate,https://schema.org/exchangeRateSpread-output,< 1K
+Predicate,https://schema.org/executableLibraryName,< 1K
+Predicate,https://schema.org/executableLibraryName-input,< 1K
+Predicate,https://schema.org/executableLibraryName-output,< 1K
+Predicate,https://schema.org/exerciseCourse,< 1K
+Predicate,https://schema.org/exerciseCourse-input,< 1K
+Predicate,https://schema.org/exerciseCourse-output,< 1K
+Predicate,https://schema.org/exercisePlan,< 1K
+Predicate,https://schema.org/exercisePlan-input,< 1K
+Predicate,https://schema.org/exercisePlan-output,< 1K
+Predicate,https://schema.org/exerciseRelatedDiet,< 1K
+Predicate,https://schema.org/exerciseRelatedDiet-input,< 1K
+Predicate,https://schema.org/exerciseRelatedDiet-output,< 1K
+Predicate,https://schema.org/exerciseType,< 1K
+Predicate,https://schema.org/exerciseType-input,< 1K
+Predicate,https://schema.org/exerciseType-output,< 1K
+Predicate,https://schema.org/exifData,1K - 10K
+Predicate,https://schema.org/exifData-input,< 1K
+Predicate,https://schema.org/exifData-output,< 1K
+Predicate,https://schema.org/expectedArrivalFrom,< 1K
+Predicate,https://schema.org/expectedArrivalFrom-input,< 1K
+Predicate,https://schema.org/expectedArrivalFrom-output,< 1K
+Predicate,https://schema.org/expectedArrivalUntil,< 1K
+Predicate,https://schema.org/expectedArrivalUntil-input,< 1K
+Predicate,https://schema.org/expectedArrivalUntil-output,< 1K
+Predicate,https://schema.org/expectedPrognosis,< 1K
+Predicate,https://schema.org/expectedPrognosis-input,< 1K
+Predicate,https://schema.org/expectedPrognosis-output,< 1K
+Predicate,https://schema.org/expectsAcceptanceOf,1K - 10K
+Predicate,https://schema.org/expectsAcceptanceOf-input,< 1K
+Predicate,https://schema.org/expectsAcceptanceOf-output,< 1K
+Predicate,https://schema.org/experienceInPlaceOfEducation,1K - 10K
+Predicate,https://schema.org/experienceInPlaceOfEducation-input,< 1K
+Predicate,https://schema.org/experienceInPlaceOfEducation-output,< 1K
+Predicate,https://schema.org/experienceRequirements,10K - 100K
+Predicate,https://schema.org/experienceRequirements-input,< 1K
+Predicate,https://schema.org/experienceRequirements-output,< 1K
+Predicate,https://schema.org/expertConsiderations,< 1K
+Predicate,https://schema.org/expertConsiderations-input,< 1K
+Predicate,https://schema.org/expertConsiderations-output,< 1K
+Predicate,https://schema.org/expires,1K - 10K
+Predicate,https://schema.org/expires-input,< 1K
+Predicate,https://schema.org/expires-output,< 1K
+Predicate,https://schema.org/expressedIn,< 1K
+Predicate,https://schema.org/expressedIn-input,< 1K
+Predicate,https://schema.org/expressedIn-output,< 1K
+Predicate,https://schema.org/extendedAddress,< 1K
+Predicate,https://schema.org/extendedAddress-input,< 1K
+Predicate,https://schema.org/extendedAddress-output,< 1K
+Predicate,https://schema.org/familyName,100K - 1M
+Predicate,https://schema.org/familyName-input,< 1K
+Predicate,https://schema.org/familyName-output,< 1K
+Predicate,https://schema.org/fatContent,10K - 100K
+Predicate,https://schema.org/fatContent-input,< 1K
+Predicate,https://schema.org/fatContent-output,< 1K
+Predicate,https://schema.org/faxNumber,100K - 1M
+Predicate,https://schema.org/faxNumber-input,< 1K
+Predicate,https://schema.org/faxNumber-output,< 1K
+Predicate,https://schema.org/featureList,100K - 1M
+Predicate,https://schema.org/featureList-input,< 1K
+Predicate,https://schema.org/featureList-output,< 1K
+Predicate,https://schema.org/feesAndCommissionsSpecification,1K - 10K
+Predicate,https://schema.org/feesAndCommissionsSpecification-input,< 1K
+Predicate,https://schema.org/feesAndCommissionsSpecification-output,< 1K
+Predicate,https://schema.org/fiberContent,10K - 100K
+Predicate,https://schema.org/fiberContent-input,< 1K
+Predicate,https://schema.org/fiberContent-output,< 1K
+Predicate,https://schema.org/fileFormat,10K - 100K
+Predicate,https://schema.org/fileFormat-input,< 1K
+Predicate,https://schema.org/fileFormat-output,< 1K
+Predicate,https://schema.org/fileSize,100K - 1M
+Predicate,https://schema.org/fileSize-input,< 1K
+Predicate,https://schema.org/fileSize-output,< 1K
+Predicate,https://schema.org/financialAidEligible,< 1K
+Predicate,https://schema.org/financialAidEligible-input,< 1K
+Predicate,https://schema.org/financialAidEligible-output,< 1K
+Predicate,https://schema.org/firstAppearance,< 1K
+Predicate,https://schema.org/firstAppearance-input,< 1K
+Predicate,https://schema.org/firstAppearance-output,< 1K
+Predicate,https://schema.org/firstPerformance,< 1K
+Predicate,https://schema.org/firstPerformance-input,< 1K
+Predicate,https://schema.org/firstPerformance-output,< 1K
+Predicate,https://schema.org/flightDistance,< 1K
+Predicate,https://schema.org/flightDistance-input,< 1K
+Predicate,https://schema.org/flightDistance-output,< 1K
+Predicate,https://schema.org/flightNumber,< 1K
+Predicate,https://schema.org/flightNumber-input,< 1K
+Predicate,https://schema.org/flightNumber-output,< 1K
+Predicate,https://schema.org/floorLevel,1K - 10K
+Predicate,https://schema.org/floorLevel-input,< 1K
+Predicate,https://schema.org/floorLevel-output,< 1K
+Predicate,https://schema.org/floorLimit,< 1K
+Predicate,https://schema.org/floorLimit-input,< 1K
+Predicate,https://schema.org/floorLimit-output,< 1K
+Predicate,https://schema.org/floorSize,100K - 1M
+Predicate,https://schema.org/floorSize-input,< 1K
+Predicate,https://schema.org/floorSize-output,< 1K
+Predicate,https://schema.org/followee,< 1K
+Predicate,https://schema.org/followee-input,< 1K
+Predicate,https://schema.org/followee-output,< 1K
+Predicate,https://schema.org/follows,< 1K
+Predicate,https://schema.org/follows-input,< 1K
+Predicate,https://schema.org/follows-output,< 1K
+Predicate,https://schema.org/followup,1K - 10K
+Predicate,https://schema.org/followup-input,< 1K
+Predicate,https://schema.org/followup-output,< 1K
+Predicate,https://schema.org/foodEstablishment,< 1K
+Predicate,https://schema.org/foodEstablishment-input,< 1K
+Predicate,https://schema.org/foodEstablishment-output,< 1K
+Predicate,https://schema.org/foodEvent,< 1K
+Predicate,https://schema.org/foodEvent-input,< 1K
+Predicate,https://schema.org/foodEvent-output,< 1K
+Predicate,https://schema.org/foodWarning,< 1K
+Predicate,https://schema.org/foodWarning-input,< 1K
+Predicate,https://schema.org/foodWarning-output,< 1K
+Predicate,https://schema.org/founder,100K - 1M
+Predicate,https://schema.org/founder-input,< 1K
+Predicate,https://schema.org/founder-output,< 1K
+Predicate,https://schema.org/founders,10K - 100K
+Predicate,https://schema.org/founders-input,< 1K
+Predicate,https://schema.org/founders-output,< 1K
+Predicate,https://schema.org/foundingDate,1M - 10M
+Predicate,https://schema.org/foundingDate-input,< 1K
+Predicate,https://schema.org/foundingDate-output,< 1K
+Predicate,https://schema.org/foundingLocation,100K - 1M
+Predicate,https://schema.org/foundingLocation-input,< 1K
+Predicate,https://schema.org/foundingLocation-output,< 1K
+Predicate,https://schema.org/free,1K - 10K
+Predicate,https://schema.org/free-input,< 1K
+Predicate,https://schema.org/free-output,< 1K
+Predicate,https://schema.org/freeShippingThreshold,10K - 100K
+Predicate,https://schema.org/freeShippingThreshold-input,< 1K
+Predicate,https://schema.org/freeShippingThreshold-output,< 1K
+Predicate,https://schema.org/frequency,< 1K
+Predicate,https://schema.org/frequency-input,< 1K
+Predicate,https://schema.org/frequency-output,< 1K
+Predicate,https://schema.org/fromLocation,1K - 10K
+Predicate,https://schema.org/fromLocation-input,< 1K
+Predicate,https://schema.org/fromLocation-output,< 1K
+Predicate,https://schema.org/fuelCapacity,1K - 10K
+Predicate,https://schema.org/fuelCapacity-input,< 1K
+Predicate,https://schema.org/fuelCapacity-output,< 1K
+Predicate,https://schema.org/fuelConsumption,1K - 10K
+Predicate,https://schema.org/fuelConsumption-input,< 1K
+Predicate,https://schema.org/fuelConsumption-output,< 1K
+Predicate,https://schema.org/fuelEfficiency,10K - 100K
+Predicate,https://schema.org/fuelEfficiency-input,< 1K
+Predicate,https://schema.org/fuelEfficiency-output,< 1K
+Predicate,https://schema.org/fuelType,10K - 100K
+Predicate,https://schema.org/fuelType-input,< 1K
+Predicate,https://schema.org/fuelType-output,< 1K
+Predicate,https://schema.org/fulfillmentType,10K - 100K
+Predicate,https://schema.org/fulfillmentType-input,< 1K
+Predicate,https://schema.org/fulfillmentType-output,< 1K
+Predicate,https://schema.org/functionalClass,< 1K
+Predicate,https://schema.org/functionalClass-input,< 1K
+Predicate,https://schema.org/functionalClass-output,< 1K
+Predicate,https://schema.org/fundedItem,< 1K
+Predicate,https://schema.org/fundedItem-input,< 1K
+Predicate,https://schema.org/fundedItem-output,< 1K
+Predicate,https://schema.org/funder,10K - 100K
+Predicate,https://schema.org/funder-input,< 1K
+Predicate,https://schema.org/funder-output,< 1K
+Predicate,https://schema.org/funding,1K - 10K
+Predicate,https://schema.org/funding-input,< 1K
+Predicate,https://schema.org/funding-output,< 1K
+Predicate,https://schema.org/game,10K - 100K
+Predicate,https://schema.org/game-input,< 1K
+Predicate,https://schema.org/game-output,< 1K
+Predicate,https://schema.org/gameAvailabilityType,< 1K
+Predicate,https://schema.org/gameAvailabilityType-input,< 1K
+Predicate,https://schema.org/gameAvailabilityType-output,< 1K
+Predicate,https://schema.org/gameEdition,< 1K
+Predicate,https://schema.org/gameEdition-input,< 1K
+Predicate,https://schema.org/gameEdition-output,< 1K
+Predicate,https://schema.org/gameItem,10K - 100K
+Predicate,https://schema.org/gameItem-input,< 1K
+Predicate,https://schema.org/gameItem-output,< 1K
+Predicate,https://schema.org/gameLocation,10K - 100K
+Predicate,https://schema.org/gameLocation-input,< 1K
+Predicate,https://schema.org/gameLocation-output,< 1K
+Predicate,https://schema.org/gamePlatform,10K - 100K
+Predicate,https://schema.org/gamePlatform-input,< 1K
+Predicate,https://schema.org/gamePlatform-output,< 1K
+Predicate,https://schema.org/gameServer,< 1K
+Predicate,https://schema.org/gameServer-input,< 1K
+Predicate,https://schema.org/gameServer-output,< 1K
+Predicate,https://schema.org/gameTip,< 1K
+Predicate,https://schema.org/gameTip-input,< 1K
+Predicate,https://schema.org/gameTip-output,< 1K
+Predicate,https://schema.org/gender,10K - 100K
+Predicate,https://schema.org/gender-input,< 1K
+Predicate,https://schema.org/gender-output,< 1K
+Predicate,https://schema.org/genre,100K - 1M
+Predicate,https://schema.org/genre-input,< 1K
+Predicate,https://schema.org/genre-output,< 1K
+Predicate,https://schema.org/geo,1M - 10M
+Predicate,https://schema.org/geo-input,< 1K
+Predicate,https://schema.org/geo-output,< 1K
+Predicate,https://schema.org/geoContains,< 1K
+Predicate,https://schema.org/geoContains-input,< 1K
+Predicate,https://schema.org/geoContains-output,< 1K
+Predicate,https://schema.org/geoCoveredBy,< 1K
+Predicate,https://schema.org/geoCoveredBy-input,< 1K
+Predicate,https://schema.org/geoCoveredBy-output,< 1K
+Predicate,https://schema.org/geoCovers,< 1K
+Predicate,https://schema.org/geoCovers-input,< 1K
+Predicate,https://schema.org/geoCovers-output,< 1K
+Predicate,https://schema.org/geoCrosses,< 1K
+Predicate,https://schema.org/geoCrosses-input,< 1K
+Predicate,https://schema.org/geoCrosses-output,< 1K
+Predicate,https://schema.org/geoDisjoint,< 1K
+Predicate,https://schema.org/geoDisjoint-input,< 1K
+Predicate,https://schema.org/geoDisjoint-output,< 1K
+Predicate,https://schema.org/geoEquals,< 1K
+Predicate,https://schema.org/geoEquals-input,< 1K
+Predicate,https://schema.org/geoEquals-output,< 1K
+Predicate,https://schema.org/geoIntersects,< 1K
+Predicate,https://schema.org/geoIntersects-input,< 1K
+Predicate,https://schema.org/geoIntersects-output,< 1K
+Predicate,https://schema.org/geoMidpoint,100K - 1M
+Predicate,https://schema.org/geoMidpoint-input,< 1K
+Predicate,https://schema.org/geoMidpoint-output,< 1K
+Predicate,https://schema.org/geoOverlaps,< 1K
+Predicate,https://schema.org/geoOverlaps-input,< 1K
+Predicate,https://schema.org/geoOverlaps-output,< 1K
+Predicate,https://schema.org/geoRadius,100K - 1M
+Predicate,https://schema.org/geoRadius-input,< 1K
+Predicate,https://schema.org/geoRadius-output,< 1K
+Predicate,https://schema.org/geoTouches,< 1K
+Predicate,https://schema.org/geoTouches-input,< 1K
+Predicate,https://schema.org/geoTouches-output,< 1K
+Predicate,https://schema.org/geoWithin,< 1K
+Predicate,https://schema.org/geoWithin-input,< 1K
+Predicate,https://schema.org/geoWithin-output,< 1K
+Predicate,https://schema.org/geographicArea,10K - 100K
+Predicate,https://schema.org/geographicArea-input,< 1K
+Predicate,https://schema.org/geographicArea-output,< 1K
+Predicate,https://schema.org/gettingTestedInfo,< 1K
+Predicate,https://schema.org/gettingTestedInfo-input,< 1K
+Predicate,https://schema.org/gettingTestedInfo-output,< 1K
+Predicate,https://schema.org/givenName,100K - 1M
+Predicate,https://schema.org/givenName-input,< 1K
+Predicate,https://schema.org/givenName-output,< 1K
+Predicate,https://schema.org/globalLocationNumber,1K - 10K
+Predicate,https://schema.org/globalLocationNumber-input,< 1K
+Predicate,https://schema.org/globalLocationNumber-output,< 1K
+Predicate,https://schema.org/governmentBenefitsInfo,< 1K
+Predicate,https://schema.org/governmentBenefitsInfo-input,< 1K
+Predicate,https://schema.org/governmentBenefitsInfo-output,< 1K
+Predicate,https://schema.org/gracePeriod,< 1K
+Predicate,https://schema.org/gracePeriod-input,< 1K
+Predicate,https://schema.org/gracePeriod-output,< 1K
+Predicate,https://schema.org/grantee,< 1K
+Predicate,https://schema.org/grantee-input,< 1K
+Predicate,https://schema.org/grantee-output,< 1K
+Predicate,https://schema.org/greater,< 1K
+Predicate,https://schema.org/greater-input,< 1K
+Predicate,https://schema.org/greater-output,< 1K
+Predicate,https://schema.org/greaterOrEqual,< 1K
+Predicate,https://schema.org/greaterOrEqual-input,< 1K
+Predicate,https://schema.org/greaterOrEqual-output,< 1K
+Predicate,https://schema.org/gtin,100K - 1M
+Predicate,https://schema.org/gtin-input,< 1K
+Predicate,https://schema.org/gtin-output,< 1K
+Predicate,https://schema.org/gtin12,100K - 1M
+Predicate,https://schema.org/gtin12-input,< 1K
+Predicate,https://schema.org/gtin12-output,< 1K
+Predicate,https://schema.org/gtin13,100K - 1M
+Predicate,https://schema.org/gtin13-input,< 1K
+Predicate,https://schema.org/gtin13-output,< 1K
+Predicate,https://schema.org/gtin14,10K - 100K
+Predicate,https://schema.org/gtin14-input,< 1K
+Predicate,https://schema.org/gtin14-output,< 1K
+Predicate,https://schema.org/gtin8,10K - 100K
+Predicate,https://schema.org/gtin8-input,< 1K
+Predicate,https://schema.org/gtin8-output,< 1K
+Predicate,https://schema.org/guideline,< 1K
+Predicate,https://schema.org/guideline-input,< 1K
+Predicate,https://schema.org/guideline-output,< 1K
+Predicate,https://schema.org/guidelineDate,< 1K
+Predicate,https://schema.org/guidelineDate-input,< 1K
+Predicate,https://schema.org/guidelineDate-output,< 1K
+Predicate,https://schema.org/guidelineSubject,< 1K
+Predicate,https://schema.org/guidelineSubject-input,< 1K
+Predicate,https://schema.org/guidelineSubject-output,< 1K
+Predicate,https://schema.org/handlingTime,100K - 1M
+Predicate,https://schema.org/handlingTime-input,< 1K
+Predicate,https://schema.org/handlingTime-output,< 1K
+Predicate,https://schema.org/hasAdultConsideration,< 1K
+Predicate,https://schema.org/hasAdultConsideration-input,< 1K
+Predicate,https://schema.org/hasAdultConsideration-output,< 1K
+Predicate,https://schema.org/hasBioChemEntityPart,< 1K
+Predicate,https://schema.org/hasBioChemEntityPart-input,< 1K
+Predicate,https://schema.org/hasBioChemEntityPart-output,< 1K
+Predicate,https://schema.org/hasBioPolymerSequence,< 1K
+Predicate,https://schema.org/hasBioPolymerSequence-input,< 1K
+Predicate,https://schema.org/hasBioPolymerSequence-output,< 1K
+Predicate,https://schema.org/hasBroadcastChannel,< 1K
+Predicate,https://schema.org/hasBroadcastChannel-input,< 1K
+Predicate,https://schema.org/hasBroadcastChannel-output,< 1K
+Predicate,https://schema.org/hasCategoryCode,< 1K
+Predicate,https://schema.org/hasCategoryCode-input,< 1K
+Predicate,https://schema.org/hasCategoryCode-output,< 1K
+Predicate,https://schema.org/hasCertification,10K - 100K
+Predicate,https://schema.org/hasCertification-input,< 1K
+Predicate,https://schema.org/hasCertification-output,< 1K
+Predicate,https://schema.org/hasCourse,1K - 10K
+Predicate,https://schema.org/hasCourse-input,< 1K
+Predicate,https://schema.org/hasCourse-output,< 1K
+Predicate,https://schema.org/hasCourseInstance,10K - 100K
+Predicate,https://schema.org/hasCourseInstance-input,< 1K
+Predicate,https://schema.org/hasCourseInstance-output,< 1K
+Predicate,https://schema.org/hasCredential,100K - 1M
+Predicate,https://schema.org/hasCredential-input,< 1K
+Predicate,https://schema.org/hasCredential-output,< 1K
+Predicate,https://schema.org/hasDefinedTerm,10K - 100K
+Predicate,https://schema.org/hasDefinedTerm-input,< 1K
+Predicate,https://schema.org/hasDefinedTerm-output,< 1K
+Predicate,https://schema.org/hasDeliveryMethod,< 1K
+Predicate,https://schema.org/hasDeliveryMethod-input,< 1K
+Predicate,https://schema.org/hasDeliveryMethod-output,< 1K
+Predicate,https://schema.org/hasDigitalDocumentPermission,< 1K
+Predicate,https://schema.org/hasDigitalDocumentPermission-input,< 1K
+Predicate,https://schema.org/hasDigitalDocumentPermission-output,< 1K
+Predicate,https://schema.org/hasDriveThroughService,< 1K
+Predicate,https://schema.org/hasDriveThroughService-input,< 1K
+Predicate,https://schema.org/hasDriveThroughService-output,< 1K
+Predicate,https://schema.org/hasEnergyConsumptionDetails,1K - 10K
+Predicate,https://schema.org/hasEnergyConsumptionDetails-input,< 1K
+Predicate,https://schema.org/hasEnergyConsumptionDetails-output,< 1K
+Predicate,https://schema.org/hasEnergyEfficiencyCategory,1K - 10K
+Predicate,https://schema.org/hasEnergyEfficiencyCategory-input,< 1K
+Predicate,https://schema.org/hasEnergyEfficiencyCategory-output,< 1K
+Predicate,https://schema.org/hasGS1DigitalLink,< 1K
+Predicate,https://schema.org/hasGS1DigitalLink-input,< 1K
+Predicate,https://schema.org/hasGS1DigitalLink-output,< 1K
+Predicate,https://schema.org/hasHealthAspect,< 1K
+Predicate,https://schema.org/hasHealthAspect-input,< 1K
+Predicate,https://schema.org/hasHealthAspect-output,< 1K
+Predicate,https://schema.org/hasMap,100K - 1M
+Predicate,https://schema.org/hasMap-input,< 1K
+Predicate,https://schema.org/hasMap-output,< 1K
+Predicate,https://schema.org/hasMeasurement,1K - 10K
+Predicate,https://schema.org/hasMeasurement-input,< 1K
+Predicate,https://schema.org/hasMeasurement-output,< 1K
+Predicate,https://schema.org/hasMemberProgram,1K - 10K
+Predicate,https://schema.org/hasMemberProgram-input,< 1K
+Predicate,https://schema.org/hasMemberProgram-output,< 1K
+Predicate,https://schema.org/hasMenu,10K - 100K
+Predicate,https://schema.org/hasMenu-input,< 1K
+Predicate,https://schema.org/hasMenu-output,< 1K
+Predicate,https://schema.org/hasMenuItem,10K - 100K
+Predicate,https://schema.org/hasMenuItem-input,< 1K
+Predicate,https://schema.org/hasMenuItem-output,< 1K
+Predicate,https://schema.org/hasMenuSection,10K - 100K
+Predicate,https://schema.org/hasMenuSection-input,< 1K
+Predicate,https://schema.org/hasMenuSection-output,< 1K
+Predicate,https://schema.org/hasMerchantReturnPolicy,100K - 1M
+Predicate,https://schema.org/hasMerchantReturnPolicy-input,< 1K
+Predicate,https://schema.org/hasMerchantReturnPolicy-output,< 1K
+Predicate,https://schema.org/hasMolecularFunction,< 1K
+Predicate,https://schema.org/hasMolecularFunction-input,< 1K
+Predicate,https://schema.org/hasMolecularFunction-output,< 1K
+Predicate,https://schema.org/hasOccupation,10K - 100K
+Predicate,https://schema.org/hasOccupation-input,< 1K
+Predicate,https://schema.org/hasOccupation-output,< 1K
+Predicate,https://schema.org/hasOfferCatalog,100K - 1M
+Predicate,https://schema.org/hasOfferCatalog-input,< 1K
+Predicate,https://schema.org/hasOfferCatalog-output,< 1K
+Predicate,https://schema.org/hasPOS,1K - 10K
+Predicate,https://schema.org/hasPOS-input,< 1K
+Predicate,https://schema.org/hasPOS-output,< 1K
+Predicate,https://schema.org/hasPart,100K - 1M
+Predicate,https://schema.org/hasPart-input,< 1K
+Predicate,https://schema.org/hasPart-output,< 1K
+Predicate,https://schema.org/hasParticipationOffer,< 1K
+Predicate,https://schema.org/hasParticipationOffer-input,< 1K
+Predicate,https://schema.org/hasParticipationOffer-output,< 1K
+Predicate,https://schema.org/hasProductReturnPolicy,< 1K
+Predicate,https://schema.org/hasProductReturnPolicy-input,< 1K
+Predicate,https://schema.org/hasProductReturnPolicy-output,< 1K
+Predicate,https://schema.org/hasRepresentation,< 1K
+Predicate,https://schema.org/hasRepresentation-input,< 1K
+Predicate,https://schema.org/hasRepresentation-output,< 1K
+Predicate,https://schema.org/hasShippingService,10K - 100K
+Predicate,https://schema.org/hasShippingService-input,< 1K
+Predicate,https://schema.org/hasShippingService-output,< 1K
+Predicate,https://schema.org/hasSponsorshipOffer,< 1K
+Predicate,https://schema.org/hasSponsorshipOffer-input,< 1K
+Predicate,https://schema.org/hasSponsorshipOffer-output,< 1K
+Predicate,https://schema.org/hasStore,< 1K
+Predicate,https://schema.org/hasStore-input,< 1K
+Predicate,https://schema.org/hasStore-output,< 1K
+Predicate,https://schema.org/hasTierBenefit,1K - 10K
+Predicate,https://schema.org/hasTierBenefit-input,< 1K
+Predicate,https://schema.org/hasTierBenefit-output,< 1K
+Predicate,https://schema.org/hasTierRequirement,< 1K
+Predicate,https://schema.org/hasTierRequirement-input,< 1K
+Predicate,https://schema.org/hasTierRequirement-output,< 1K
+Predicate,https://schema.org/hasTiers,1K - 10K
+Predicate,https://schema.org/hasTiers-input,< 1K
+Predicate,https://schema.org/hasTiers-output,< 1K
+Predicate,https://schema.org/hasVariant,100K - 1M
+Predicate,https://schema.org/hasVariant-input,< 1K
+Predicate,https://schema.org/hasVariant-output,< 1K
+Predicate,https://schema.org/headline,10M+
+Predicate,https://schema.org/headline-input,< 1K
+Predicate,https://schema.org/headline-output,< 1K
+Predicate,https://schema.org/healthCondition,1K - 10K
+Predicate,https://schema.org/healthCondition-input,< 1K
+Predicate,https://schema.org/healthCondition-output,< 1K
+Predicate,https://schema.org/healthPlanCoinsuranceOption,< 1K
+Predicate,https://schema.org/healthPlanCoinsuranceOption-input,< 1K
+Predicate,https://schema.org/healthPlanCoinsuranceOption-output,< 1K
+Predicate,https://schema.org/healthPlanCoinsuranceRate,< 1K
+Predicate,https://schema.org/healthPlanCoinsuranceRate-input,< 1K
+Predicate,https://schema.org/healthPlanCoinsuranceRate-output,< 1K
+Predicate,https://schema.org/healthPlanCopay,< 1K
+Predicate,https://schema.org/healthPlanCopay-input,< 1K
+Predicate,https://schema.org/healthPlanCopay-output,< 1K
+Predicate,https://schema.org/healthPlanCopayOption,< 1K
+Predicate,https://schema.org/healthPlanCopayOption-input,< 1K
+Predicate,https://schema.org/healthPlanCopayOption-output,< 1K
+Predicate,https://schema.org/healthPlanCostSharing,< 1K
+Predicate,https://schema.org/healthPlanCostSharing-input,< 1K
+Predicate,https://schema.org/healthPlanCostSharing-output,< 1K
+Predicate,https://schema.org/healthPlanDrugOption,< 1K
+Predicate,https://schema.org/healthPlanDrugOption-input,< 1K
+Predicate,https://schema.org/healthPlanDrugOption-output,< 1K
+Predicate,https://schema.org/healthPlanDrugTier,< 1K
+Predicate,https://schema.org/healthPlanDrugTier-input,< 1K
+Predicate,https://schema.org/healthPlanDrugTier-output,< 1K
+Predicate,https://schema.org/healthPlanId,< 1K
+Predicate,https://schema.org/healthPlanId-input,< 1K
+Predicate,https://schema.org/healthPlanId-output,< 1K
+Predicate,https://schema.org/healthPlanMarketingUrl,< 1K
+Predicate,https://schema.org/healthPlanMarketingUrl-input,< 1K
+Predicate,https://schema.org/healthPlanMarketingUrl-output,< 1K
+Predicate,https://schema.org/healthPlanNetworkId,< 1K
+Predicate,https://schema.org/healthPlanNetworkId-input,< 1K
+Predicate,https://schema.org/healthPlanNetworkId-output,< 1K
+Predicate,https://schema.org/healthPlanNetworkTier,< 1K
+Predicate,https://schema.org/healthPlanNetworkTier-input,< 1K
+Predicate,https://schema.org/healthPlanNetworkTier-output,< 1K
+Predicate,https://schema.org/healthPlanPharmacyCategory,< 1K
+Predicate,https://schema.org/healthPlanPharmacyCategory-input,< 1K
+Predicate,https://schema.org/healthPlanPharmacyCategory-output,< 1K
+Predicate,https://schema.org/healthcareReportingData,< 1K
+Predicate,https://schema.org/healthcareReportingData-input,< 1K
+Predicate,https://schema.org/healthcareReportingData-output,< 1K
+Predicate,https://schema.org/height,10M+
+Predicate,https://schema.org/height-input,< 1K
+Predicate,https://schema.org/height-output,< 1K
+Predicate,https://schema.org/highPrice,1M - 10M
+Predicate,https://schema.org/highPrice-input,< 1K
+Predicate,https://schema.org/highPrice-output,< 1K
+Predicate,https://schema.org/hiringOrganization,100K - 1M
+Predicate,https://schema.org/hiringOrganization-input,< 1K
+Predicate,https://schema.org/hiringOrganization-output,< 1K
+Predicate,https://schema.org/holdingArchive,< 1K
+Predicate,https://schema.org/holdingArchive-input,< 1K
+Predicate,https://schema.org/holdingArchive-output,< 1K
+Predicate,https://schema.org/homeLocation,10K - 100K
+Predicate,https://schema.org/homeLocation-input,< 1K
+Predicate,https://schema.org/homeLocation-output,< 1K
+Predicate,https://schema.org/homeTeam,10K - 100K
+Predicate,https://schema.org/homeTeam-input,< 1K
+Predicate,https://schema.org/homeTeam-output,< 1K
+Predicate,https://schema.org/honorificPrefix,10K - 100K
+Predicate,https://schema.org/honorificPrefix-input,< 1K
+Predicate,https://schema.org/honorificPrefix-output,< 1K
+Predicate,https://schema.org/honorificSuffix,10K - 100K
+Predicate,https://schema.org/honorificSuffix-input,< 1K
+Predicate,https://schema.org/honorificSuffix-output,< 1K
+Predicate,https://schema.org/hospitalAffiliation,1K - 10K
+Predicate,https://schema.org/hospitalAffiliation-input,< 1K
+Predicate,https://schema.org/hospitalAffiliation-output,< 1K
+Predicate,https://schema.org/hostingOrganization,1K - 10K
+Predicate,https://schema.org/hostingOrganization-input,< 1K
+Predicate,https://schema.org/hostingOrganization-output,< 1K
+Predicate,https://schema.org/hoursAvailable,100K - 1M
+Predicate,https://schema.org/hoursAvailable-input,< 1K
+Predicate,https://schema.org/hoursAvailable-output,< 1K
+Predicate,https://schema.org/howPerformed,10K - 100K
+Predicate,https://schema.org/howPerformed-input,< 1K
+Predicate,https://schema.org/howPerformed-output,< 1K
+Predicate,https://schema.org/httpMethod,1K - 10K
+Predicate,https://schema.org/httpMethod-input,< 1K
+Predicate,https://schema.org/httpMethod-output,< 1K
+Predicate,https://schema.org/iataCode,1K - 10K
+Predicate,https://schema.org/iataCode-input,< 1K
+Predicate,https://schema.org/iataCode-output,< 1K
+Predicate,https://schema.org/icaoCode,1K - 10K
+Predicate,https://schema.org/icaoCode-input,< 1K
+Predicate,https://schema.org/icaoCode-output,< 1K
+Predicate,https://schema.org/identifier,100K - 1M
+Predicate,https://schema.org/identifier-input,< 1K
+Predicate,https://schema.org/identifier-output,< 1K
+Predicate,https://schema.org/identifyingExam,< 1K
+Predicate,https://schema.org/identifyingExam-input,< 1K
+Predicate,https://schema.org/identifyingExam-output,< 1K
+Predicate,https://schema.org/identifyingTest,< 1K
+Predicate,https://schema.org/identifyingTest-input,< 1K
+Predicate,https://schema.org/identifyingTest-output,< 1K
+Predicate,https://schema.org/illustrator,1K - 10K
+Predicate,https://schema.org/illustrator-input,< 1K
+Predicate,https://schema.org/illustrator-output,< 1K
+Predicate,https://schema.org/image,10M+
+Predicate,https://schema.org/image-input,< 1K
+Predicate,https://schema.org/image-output,< 1K
+Predicate,https://schema.org/imagingTechnique,< 1K
+Predicate,https://schema.org/imagingTechnique-input,< 1K
+Predicate,https://schema.org/imagingTechnique-output,< 1K
+Predicate,https://schema.org/inAlbum,10K - 100K
+Predicate,https://schema.org/inAlbum-input,< 1K
+Predicate,https://schema.org/inAlbum-output,< 1K
+Predicate,https://schema.org/inBroadcastLineup,< 1K
+Predicate,https://schema.org/inBroadcastLineup-input,< 1K
+Predicate,https://schema.org/inBroadcastLineup-output,< 1K
+Predicate,https://schema.org/inChI,< 1K
+Predicate,https://schema.org/inChI-input,< 1K
+Predicate,https://schema.org/inChI-output,< 1K
+Predicate,https://schema.org/inChIKey,< 1K
+Predicate,https://schema.org/inChIKey-input,< 1K
+Predicate,https://schema.org/inChIKey-output,< 1K
+Predicate,https://schema.org/inCodeSet,1K - 10K
+Predicate,https://schema.org/inCodeSet-input,< 1K
+Predicate,https://schema.org/inCodeSet-output,< 1K
+Predicate,https://schema.org/inDefinedTermSet,10K - 100K
+Predicate,https://schema.org/inDefinedTermSet-input,< 1K
+Predicate,https://schema.org/inDefinedTermSet-output,< 1K
+Predicate,https://schema.org/inLanguage,10M+
+Predicate,https://schema.org/inLanguage-input,< 1K
+Predicate,https://schema.org/inLanguage-output,< 1K
+Predicate,https://schema.org/inPlaylist,< 1K
+Predicate,https://schema.org/inPlaylist-input,< 1K
+Predicate,https://schema.org/inPlaylist-output,< 1K
+Predicate,https://schema.org/inProductGroupWithID,10K - 100K
+Predicate,https://schema.org/inProductGroupWithID-input,< 1K
+Predicate,https://schema.org/inProductGroupWithID-output,< 1K
+Predicate,https://schema.org/inStoreReturnsOffered,1K - 10K
+Predicate,https://schema.org/inStoreReturnsOffered-input,< 1K
+Predicate,https://schema.org/inStoreReturnsOffered-output,< 1K
+Predicate,https://schema.org/inSupportOf,< 1K
+Predicate,https://schema.org/inSupportOf-input,< 1K
+Predicate,https://schema.org/inSupportOf-output,< 1K
+Predicate,https://schema.org/incentiveAmount,< 1K
+Predicate,https://schema.org/incentiveAmount-input,< 1K
+Predicate,https://schema.org/incentiveAmount-output,< 1K
+Predicate,https://schema.org/incentiveCompensation,1K - 10K
+Predicate,https://schema.org/incentiveCompensation-input,< 1K
+Predicate,https://schema.org/incentiveCompensation-output,< 1K
+Predicate,https://schema.org/incentiveStatus,< 1K
+Predicate,https://schema.org/incentiveStatus-input,< 1K
+Predicate,https://schema.org/incentiveStatus-output,< 1K
+Predicate,https://schema.org/incentiveType,< 1K
+Predicate,https://schema.org/incentiveType-input,< 1K
+Predicate,https://schema.org/incentiveType-output,< 1K
+Predicate,https://schema.org/incentives,< 1K
+Predicate,https://schema.org/incentives-input,< 1K
+Predicate,https://schema.org/incentives-output,< 1K
+Predicate,https://schema.org/incentivizedItem,< 1K
+Predicate,https://schema.org/incentivizedItem-input,< 1K
+Predicate,https://schema.org/incentivizedItem-output,< 1K
+Predicate,https://schema.org/includedComposition,< 1K
+Predicate,https://schema.org/includedComposition-input,< 1K
+Predicate,https://schema.org/includedComposition-output,< 1K
+Predicate,https://schema.org/includedDataCatalog,< 1K
+Predicate,https://schema.org/includedDataCatalog-input,< 1K
+Predicate,https://schema.org/includedDataCatalog-output,< 1K
+Predicate,https://schema.org/includedInDataCatalog,1K - 10K
+Predicate,https://schema.org/includedInDataCatalog-input,< 1K
+Predicate,https://schema.org/includedInDataCatalog-output,< 1K
+Predicate,https://schema.org/includedInHealthInsurancePlan,< 1K
+Predicate,https://schema.org/includedInHealthInsurancePlan-input,< 1K
+Predicate,https://schema.org/includedInHealthInsurancePlan-output,< 1K
+Predicate,https://schema.org/includedRiskFactor,< 1K
+Predicate,https://schema.org/includedRiskFactor-input,< 1K
+Predicate,https://schema.org/includedRiskFactor-output,< 1K
+Predicate,https://schema.org/includesAttraction,1K - 10K
+Predicate,https://schema.org/includesAttraction-input,< 1K
+Predicate,https://schema.org/includesAttraction-output,< 1K
+Predicate,https://schema.org/includesHealthPlanFormulary,< 1K
+Predicate,https://schema.org/includesHealthPlanFormulary-input,< 1K
+Predicate,https://schema.org/includesHealthPlanFormulary-output,< 1K
+Predicate,https://schema.org/includesHealthPlanNetwork,< 1K
+Predicate,https://schema.org/includesHealthPlanNetwork-input,< 1K
+Predicate,https://schema.org/includesHealthPlanNetwork-output,< 1K
+Predicate,https://schema.org/includesObject,1K - 10K
+Predicate,https://schema.org/includesObject-input,< 1K
+Predicate,https://schema.org/includesObject-output,< 1K
+Predicate,https://schema.org/incomeLimit,< 1K
+Predicate,https://schema.org/incomeLimit-input,< 1K
+Predicate,https://schema.org/incomeLimit-output,< 1K
+Predicate,https://schema.org/increasesRiskOf,< 1K
+Predicate,https://schema.org/increasesRiskOf-input,< 1K
+Predicate,https://schema.org/increasesRiskOf-output,< 1K
+Predicate,https://schema.org/industry,10K - 100K
+Predicate,https://schema.org/industry-input,< 1K
+Predicate,https://schema.org/industry-output,< 1K
+Predicate,https://schema.org/ineligibleRegion,< 1K
+Predicate,https://schema.org/ineligibleRegion-input,< 1K
+Predicate,https://schema.org/ineligibleRegion-output,< 1K
+Predicate,https://schema.org/infectiousAgent,< 1K
+Predicate,https://schema.org/infectiousAgent-input,< 1K
+Predicate,https://schema.org/infectiousAgent-output,< 1K
+Predicate,https://schema.org/infectiousAgentClass,< 1K
+Predicate,https://schema.org/infectiousAgentClass-input,< 1K
+Predicate,https://schema.org/infectiousAgentClass-output,< 1K
+Predicate,https://schema.org/ingredients,1K - 10K
+Predicate,https://schema.org/ingredients-input,< 1K
+Predicate,https://schema.org/ingredients-output,< 1K
+Predicate,https://schema.org/inker,< 1K
+Predicate,https://schema.org/inker-input,< 1K
+Predicate,https://schema.org/inker-output,< 1K
+Predicate,https://schema.org/insertion,< 1K
+Predicate,https://schema.org/insertion-input,< 1K
+Predicate,https://schema.org/insertion-output,< 1K
+Predicate,https://schema.org/installUrl,100K - 1M
+Predicate,https://schema.org/installUrl-input,< 1K
+Predicate,https://schema.org/installUrl-output,< 1K
+Predicate,https://schema.org/instructor,10K - 100K
+Predicate,https://schema.org/instructor-input,< 1K
+Predicate,https://schema.org/instructor-output,< 1K
+Predicate,https://schema.org/instrument,1K - 10K
+Predicate,https://schema.org/instrument-input,< 1K
+Predicate,https://schema.org/instrument-output,< 1K
+Predicate,https://schema.org/intensity,< 1K
+Predicate,https://schema.org/intensity-input,< 1K
+Predicate,https://schema.org/intensity-output,< 1K
+Predicate,https://schema.org/interactingDrug,< 1K
+Predicate,https://schema.org/interactingDrug-input,< 1K
+Predicate,https://schema.org/interactingDrug-output,< 1K
+Predicate,https://schema.org/interactionCount,100K - 1M
+Predicate,https://schema.org/interactionCount-input,< 1K
+Predicate,https://schema.org/interactionCount-output,< 1K
+Predicate,https://schema.org/interactionService,< 1K
+Predicate,https://schema.org/interactionService-input,< 1K
+Predicate,https://schema.org/interactionService-output,< 1K
+Predicate,https://schema.org/interactionStatistic,100K - 1M
+Predicate,https://schema.org/interactionStatistic-input,< 1K
+Predicate,https://schema.org/interactionStatistic-output,< 1K
+Predicate,https://schema.org/interactionType,100K - 1M
+Predicate,https://schema.org/interactionType-input,< 1K
+Predicate,https://schema.org/interactionType-output,< 1K
+Predicate,https://schema.org/interactivityType,1K - 10K
+Predicate,https://schema.org/interactivityType-input,< 1K
+Predicate,https://schema.org/interactivityType-output,< 1K
+Predicate,https://schema.org/interestRate,1K - 10K
+Predicate,https://schema.org/interestRate-input,< 1K
+Predicate,https://schema.org/interestRate-output,< 1K
+Predicate,https://schema.org/interpretedAsClaim,< 1K
+Predicate,https://schema.org/interpretedAsClaim-input,< 1K
+Predicate,https://schema.org/interpretedAsClaim-output,< 1K
+Predicate,https://schema.org/inventoryLevel,100K - 1M
+Predicate,https://schema.org/inventoryLevel-input,< 1K
+Predicate,https://schema.org/inventoryLevel-output,< 1K
+Predicate,https://schema.org/inverseOf,< 1K
+Predicate,https://schema.org/inverseOf-input,< 1K
+Predicate,https://schema.org/inverseOf-output,< 1K
+Predicate,https://schema.org/isAcceptingNewPatients,10K - 100K
+Predicate,https://schema.org/isAcceptingNewPatients-input,< 1K
+Predicate,https://schema.org/isAcceptingNewPatients-output,< 1K
+Predicate,https://schema.org/isAccessibleForFree,100K - 1M
+Predicate,https://schema.org/isAccessibleForFree-input,< 1K
+Predicate,https://schema.org/isAccessibleForFree-output,< 1K
+Predicate,https://schema.org/isAccessoryOrSparePartFor,1K - 10K
+Predicate,https://schema.org/isAccessoryOrSparePartFor-input,< 1K
+Predicate,https://schema.org/isAccessoryOrSparePartFor-output,< 1K
+Predicate,https://schema.org/isAvailableGenerically,< 1K
+Predicate,https://schema.org/isAvailableGenerically-input,< 1K
+Predicate,https://schema.org/isAvailableGenerically-output,< 1K
+Predicate,https://schema.org/isBasedOn,10K - 100K
+Predicate,https://schema.org/isBasedOn-input,< 1K
+Predicate,https://schema.org/isBasedOn-output,< 1K
+Predicate,https://schema.org/isBasedOnUrl,< 1K
+Predicate,https://schema.org/isBasedOnUrl-input,< 1K
+Predicate,https://schema.org/isBasedOnUrl-output,< 1K
+Predicate,https://schema.org/isConsumableFor,< 1K
+Predicate,https://schema.org/isConsumableFor-input,< 1K
+Predicate,https://schema.org/isConsumableFor-output,< 1K
+Predicate,https://schema.org/isEncodedByBioChemEntity,< 1K
+Predicate,https://schema.org/isEncodedByBioChemEntity-input,< 1K
+Predicate,https://schema.org/isEncodedByBioChemEntity-output,< 1K
+Predicate,https://schema.org/isFamilyFriendly,100K - 1M
+Predicate,https://schema.org/isFamilyFriendly-input,< 1K
+Predicate,https://schema.org/isFamilyFriendly-output,< 1K
+Predicate,https://schema.org/isGift,< 1K
+Predicate,https://schema.org/isGift-input,< 1K
+Predicate,https://schema.org/isGift-output,< 1K
+Predicate,https://schema.org/isInvolvedInBiologicalProcess,< 1K
+Predicate,https://schema.org/isInvolvedInBiologicalProcess-input,< 1K
+Predicate,https://schema.org/isInvolvedInBiologicalProcess-output,< 1K
+Predicate,https://schema.org/isLiveBroadcast,10K - 100K
+Predicate,https://schema.org/isLiveBroadcast-input,< 1K
+Predicate,https://schema.org/isLiveBroadcast-output,< 1K
+Predicate,https://schema.org/isLocatedInSubcellularLocation,< 1K
+Predicate,https://schema.org/isLocatedInSubcellularLocation-input,< 1K
+Predicate,https://schema.org/isLocatedInSubcellularLocation-output,< 1K
+Predicate,https://schema.org/isPartOf,10M+
+Predicate,https://schema.org/isPartOf-input,< 1K
+Predicate,https://schema.org/isPartOf-output,< 1K
+Predicate,https://schema.org/isPartOfBioChemEntity,< 1K
+Predicate,https://schema.org/isPartOfBioChemEntity-input,< 1K
+Predicate,https://schema.org/isPartOfBioChemEntity-output,< 1K
+Predicate,https://schema.org/isPlanForApartment,< 1K
+Predicate,https://schema.org/isPlanForApartment-input,< 1K
+Predicate,https://schema.org/isPlanForApartment-output,< 1K
+Predicate,https://schema.org/isProprietary,< 1K
+Predicate,https://schema.org/isProprietary-input,< 1K
+Predicate,https://schema.org/isProprietary-output,< 1K
+Predicate,https://schema.org/isRelatedTo,100K - 1M
+Predicate,https://schema.org/isRelatedTo-input,< 1K
+Predicate,https://schema.org/isRelatedTo-output,< 1K
+Predicate,https://schema.org/isResizable,< 1K
+Predicate,https://schema.org/isResizable-input,< 1K
+Predicate,https://schema.org/isResizable-output,< 1K
+Predicate,https://schema.org/isSimilarTo,10K - 100K
+Predicate,https://schema.org/isSimilarTo-input,< 1K
+Predicate,https://schema.org/isSimilarTo-output,< 1K
+Predicate,https://schema.org/isStoreOn,< 1K
+Predicate,https://schema.org/isStoreOn-input,< 1K
+Predicate,https://schema.org/isStoreOn-output,< 1K
+Predicate,https://schema.org/isTierOf,< 1K
+Predicate,https://schema.org/isTierOf-input,< 1K
+Predicate,https://schema.org/isTierOf-output,< 1K
+Predicate,https://schema.org/isUnlabelledFallback,< 1K
+Predicate,https://schema.org/isUnlabelledFallback-input,< 1K
+Predicate,https://schema.org/isUnlabelledFallback-output,< 1K
+Predicate,https://schema.org/isVariantOf,10K - 100K
+Predicate,https://schema.org/isVariantOf-input,< 1K
+Predicate,https://schema.org/isVariantOf-output,< 1K
+Predicate,https://schema.org/isbn,10K - 100K
+Predicate,https://schema.org/isbn-input,< 1K
+Predicate,https://schema.org/isbn-output,< 1K
+Predicate,https://schema.org/isicV4,1K - 10K
+Predicate,https://schema.org/isicV4-input,< 1K
+Predicate,https://schema.org/isicV4-output,< 1K
+Predicate,https://schema.org/iso6523Code,1K - 10K
+Predicate,https://schema.org/iso6523Code-input,< 1K
+Predicate,https://schema.org/iso6523Code-output,< 1K
+Predicate,https://schema.org/isrcCode,< 1K
+Predicate,https://schema.org/isrcCode-input,< 1K
+Predicate,https://schema.org/isrcCode-output,< 1K
+Predicate,https://schema.org/issn,1K - 10K
+Predicate,https://schema.org/issn-input,< 1K
+Predicate,https://schema.org/issn-output,< 1K
+Predicate,https://schema.org/issueNumber,1K - 10K
+Predicate,https://schema.org/issueNumber-input,< 1K
+Predicate,https://schema.org/issueNumber-output,< 1K
+Predicate,https://schema.org/issuedBy,10K - 100K
+Predicate,https://schema.org/issuedBy-input,< 1K
+Predicate,https://schema.org/issuedBy-output,< 1K
+Predicate,https://schema.org/issuedThrough,< 1K
+Predicate,https://schema.org/issuedThrough-input,< 1K
+Predicate,https://schema.org/issuedThrough-output,< 1K
+Predicate,https://schema.org/iswcCode,< 1K
+Predicate,https://schema.org/iswcCode-input,< 1K
+Predicate,https://schema.org/iswcCode-output,< 1K
+Predicate,https://schema.org/item,10M+
+Predicate,https://schema.org/item-input,< 1K
+Predicate,https://schema.org/item-output,< 1K
+Predicate,https://schema.org/itemCondition,1M - 10M
+Predicate,https://schema.org/itemCondition-input,< 1K
+Predicate,https://schema.org/itemCondition-output,< 1K
+Predicate,https://schema.org/itemDefectReturnFees,1K - 10K
+Predicate,https://schema.org/itemDefectReturnFees-input,< 1K
+Predicate,https://schema.org/itemDefectReturnFees-output,< 1K
+Predicate,https://schema.org/itemDefectReturnLabelSource,< 1K
+Predicate,https://schema.org/itemDefectReturnLabelSource-input,< 1K
+Predicate,https://schema.org/itemDefectReturnLabelSource-output,< 1K
+Predicate,https://schema.org/itemDefectReturnShippingFeesAmount,< 1K
+Predicate,https://schema.org/itemDefectReturnShippingFeesAmount-input,< 1K
+Predicate,https://schema.org/itemDefectReturnShippingFeesAmount-output,< 1K
+Predicate,https://schema.org/itemListElement,10M+
+Predicate,https://schema.org/itemListElement-input,< 1K
+Predicate,https://schema.org/itemListElement-output,< 1K
+Predicate,https://schema.org/itemListOrder,100K - 1M
+Predicate,https://schema.org/itemListOrder-input,< 1K
+Predicate,https://schema.org/itemListOrder-output,< 1K
+Predicate,https://schema.org/itemLocation,< 1K
+Predicate,https://schema.org/itemLocation-input,< 1K
+Predicate,https://schema.org/itemLocation-output,< 1K
+Predicate,https://schema.org/itemOffered,100K - 1M
+Predicate,https://schema.org/itemOffered-input,< 1K
+Predicate,https://schema.org/itemOffered-output,< 1K
+Predicate,https://schema.org/itemReviewed,100K - 1M
+Predicate,https://schema.org/itemReviewed-input,< 1K
+Predicate,https://schema.org/itemReviewed-output,< 1K
+Predicate,https://schema.org/itemShipped,< 1K
+Predicate,https://schema.org/itemShipped-input,< 1K
+Predicate,https://schema.org/itemShipped-output,< 1K
+Predicate,https://schema.org/itinerary,10K - 100K
+Predicate,https://schema.org/itinerary-input,< 1K
+Predicate,https://schema.org/itinerary-output,< 1K
+Predicate,https://schema.org/iupacName,< 1K
+Predicate,https://schema.org/iupacName-input,< 1K
+Predicate,https://schema.org/iupacName-output,< 1K
+Predicate,https://schema.org/jobBenefits,10K - 100K
+Predicate,https://schema.org/jobBenefits-input,< 1K
+Predicate,https://schema.org/jobBenefits-output,< 1K
+Predicate,https://schema.org/jobDuration,< 1K
+Predicate,https://schema.org/jobDuration-input,< 1K
+Predicate,https://schema.org/jobDuration-output,< 1K
+Predicate,https://schema.org/jobImmediateStart,1K - 10K
+Predicate,https://schema.org/jobImmediateStart-input,< 1K
+Predicate,https://schema.org/jobImmediateStart-output,< 1K
+Predicate,https://schema.org/jobLocation,100K - 1M
+Predicate,https://schema.org/jobLocation-input,< 1K
+Predicate,https://schema.org/jobLocation-output,< 1K
+Predicate,https://schema.org/jobLocationType,10K - 100K
+Predicate,https://schema.org/jobLocationType-input,< 1K
+Predicate,https://schema.org/jobLocationType-output,< 1K
+Predicate,https://schema.org/jobStartDate,1K - 10K
+Predicate,https://schema.org/jobStartDate-input,< 1K
+Predicate,https://schema.org/jobStartDate-output,< 1K
+Predicate,https://schema.org/jobTitle,1M - 10M
+Predicate,https://schema.org/jobTitle-input,< 1K
+Predicate,https://schema.org/jobTitle-output,< 1K
+Predicate,https://schema.org/jurisdiction,1K - 10K
+Predicate,https://schema.org/jurisdiction-input,< 1K
+Predicate,https://schema.org/jurisdiction-output,< 1K
+Predicate,https://schema.org/keywords,1M - 10M
+Predicate,https://schema.org/keywords-input,< 1K
+Predicate,https://schema.org/keywords-output,< 1K
+Predicate,https://schema.org/knownVehicleDamages,< 1K
+Predicate,https://schema.org/knownVehicleDamages-input,< 1K
+Predicate,https://schema.org/knownVehicleDamages-output,< 1K
+Predicate,https://schema.org/knows,1K - 10K
+Predicate,https://schema.org/knows-input,< 1K
+Predicate,https://schema.org/knows-output,< 1K
+Predicate,https://schema.org/knowsAbout,100K - 1M
+Predicate,https://schema.org/knowsAbout-input,< 1K
+Predicate,https://schema.org/knowsAbout-output,< 1K
+Predicate,https://schema.org/knowsLanguage,100K - 1M
+Predicate,https://schema.org/knowsLanguage-input,< 1K
+Predicate,https://schema.org/knowsLanguage-output,< 1K
+Predicate,https://schema.org/labelDetails,< 1K
+Predicate,https://schema.org/labelDetails-input,< 1K
+Predicate,https://schema.org/labelDetails-output,< 1K
+Predicate,https://schema.org/landlord,< 1K
+Predicate,https://schema.org/landlord-input,< 1K
+Predicate,https://schema.org/landlord-output,< 1K
+Predicate,https://schema.org/language,10K - 100K
+Predicate,https://schema.org/language-input,< 1K
+Predicate,https://schema.org/language-output,< 1K
+Predicate,https://schema.org/lastReviewed,10K - 100K
+Predicate,https://schema.org/lastReviewed-input,< 1K
+Predicate,https://schema.org/lastReviewed-output,< 1K
+Predicate,https://schema.org/latitude,1M - 10M
+Predicate,https://schema.org/latitude-input,< 1K
+Predicate,https://schema.org/latitude-output,< 1K
+Predicate,https://schema.org/layoutImage,1K - 10K
+Predicate,https://schema.org/layoutImage-input,< 1K
+Predicate,https://schema.org/layoutImage-output,< 1K
+Predicate,https://schema.org/learningResourceType,10K - 100K
+Predicate,https://schema.org/learningResourceType-input,< 1K
+Predicate,https://schema.org/learningResourceType-output,< 1K
+Predicate,https://schema.org/leaseLength,1K - 10K
+Predicate,https://schema.org/leaseLength-input,< 1K
+Predicate,https://schema.org/leaseLength-output,< 1K
+Predicate,https://schema.org/legalAddress,1K - 10K
+Predicate,https://schema.org/legalAddress-input,< 1K
+Predicate,https://schema.org/legalAddress-output,< 1K
+Predicate,https://schema.org/legalName,1M - 10M
+Predicate,https://schema.org/legalName-input,< 1K
+Predicate,https://schema.org/legalName-output,< 1K
+Predicate,https://schema.org/legalRepresentative,1K - 10K
+Predicate,https://schema.org/legalRepresentative-input,< 1K
+Predicate,https://schema.org/legalRepresentative-output,< 1K
+Predicate,https://schema.org/legalStatus,1K - 10K
+Predicate,https://schema.org/legalStatus-input,< 1K
+Predicate,https://schema.org/legalStatus-output,< 1K
+Predicate,https://schema.org/legislationAmends,< 1K
+Predicate,https://schema.org/legislationAmends-input,< 1K
+Predicate,https://schema.org/legislationAmends-output,< 1K
+Predicate,https://schema.org/legislationApplies,< 1K
+Predicate,https://schema.org/legislationApplies-input,< 1K
+Predicate,https://schema.org/legislationApplies-output,< 1K
+Predicate,https://schema.org/legislationChanges,< 1K
+Predicate,https://schema.org/legislationChanges-input,< 1K
+Predicate,https://schema.org/legislationChanges-output,< 1K
+Predicate,https://schema.org/legislationCommences,< 1K
+Predicate,https://schema.org/legislationCommences-input,< 1K
+Predicate,https://schema.org/legislationCommences-output,< 1K
+Predicate,https://schema.org/legislationConsolidates,< 1K
+Predicate,https://schema.org/legislationConsolidates-input,< 1K
+Predicate,https://schema.org/legislationConsolidates-output,< 1K
+Predicate,https://schema.org/legislationCorrects,< 1K
+Predicate,https://schema.org/legislationCorrects-input,< 1K
+Predicate,https://schema.org/legislationCorrects-output,< 1K
+Predicate,https://schema.org/legislationCountersignedBy,< 1K
+Predicate,https://schema.org/legislationCountersignedBy-input,< 1K
+Predicate,https://schema.org/legislationCountersignedBy-output,< 1K
+Predicate,https://schema.org/legislationDate,< 1K
+Predicate,https://schema.org/legislationDate-input,< 1K
+Predicate,https://schema.org/legislationDate-output,< 1K
+Predicate,https://schema.org/legislationDateOfApplicability,< 1K
+Predicate,https://schema.org/legislationDateOfApplicability-input,< 1K
+Predicate,https://schema.org/legislationDateOfApplicability-output,< 1K
+Predicate,https://schema.org/legislationDateVersion,< 1K
+Predicate,https://schema.org/legislationDateVersion-input,< 1K
+Predicate,https://schema.org/legislationDateVersion-output,< 1K
+Predicate,https://schema.org/legislationEnsuresImplementationOf,< 1K
+Predicate,https://schema.org/legislationEnsuresImplementationOf-input,< 1K
+Predicate,https://schema.org/legislationEnsuresImplementationOf-output,< 1K
+Predicate,https://schema.org/legislationIdentifier,1K - 10K
+Predicate,https://schema.org/legislationIdentifier-input,< 1K
+Predicate,https://schema.org/legislationIdentifier-output,< 1K
+Predicate,https://schema.org/legislationJurisdiction,1K - 10K
+Predicate,https://schema.org/legislationJurisdiction-input,< 1K
+Predicate,https://schema.org/legislationJurisdiction-output,< 1K
+Predicate,https://schema.org/legislationLegalForce,< 1K
+Predicate,https://schema.org/legislationLegalForce-input,< 1K
+Predicate,https://schema.org/legislationLegalForce-output,< 1K
+Predicate,https://schema.org/legislationLegalValue,< 1K
+Predicate,https://schema.org/legislationLegalValue-input,< 1K
+Predicate,https://schema.org/legislationLegalValue-output,< 1K
+Predicate,https://schema.org/legislationPassedBy,< 1K
+Predicate,https://schema.org/legislationPassedBy-input,< 1K
+Predicate,https://schema.org/legislationPassedBy-output,< 1K
+Predicate,https://schema.org/legislationRepeals,< 1K
+Predicate,https://schema.org/legislationRepeals-input,< 1K
+Predicate,https://schema.org/legislationRepeals-output,< 1K
+Predicate,https://schema.org/legislationResponsible,< 1K
+Predicate,https://schema.org/legislationResponsible-input,< 1K
+Predicate,https://schema.org/legislationResponsible-output,< 1K
+Predicate,https://schema.org/legislationTransposes,< 1K
+Predicate,https://schema.org/legislationTransposes-input,< 1K
+Predicate,https://schema.org/legislationTransposes-output,< 1K
+Predicate,https://schema.org/legislationType,1K - 10K
+Predicate,https://schema.org/legislationType-input,< 1K
+Predicate,https://schema.org/legislationType-output,< 1K
+Predicate,https://schema.org/leiCode,1K - 10K
+Predicate,https://schema.org/leiCode-input,< 1K
+Predicate,https://schema.org/leiCode-output,< 1K
+Predicate,https://schema.org/lender,< 1K
+Predicate,https://schema.org/lender-input,< 1K
+Predicate,https://schema.org/lender-output,< 1K
+Predicate,https://schema.org/lesser,< 1K
+Predicate,https://schema.org/lesser-input,< 1K
+Predicate,https://schema.org/lesser-output,< 1K
+Predicate,https://schema.org/lesserOrEqual,< 1K
+Predicate,https://schema.org/lesserOrEqual-input,< 1K
+Predicate,https://schema.org/lesserOrEqual-output,< 1K
+Predicate,https://schema.org/letterer,< 1K
+Predicate,https://schema.org/letterer-input,< 1K
+Predicate,https://schema.org/letterer-output,< 1K
+Predicate,https://schema.org/license,100K - 1M
+Predicate,https://schema.org/license-input,< 1K
+Predicate,https://schema.org/license-output,< 1K
+Predicate,https://schema.org/lifeEvent,< 1K
+Predicate,https://schema.org/lifeEvent-input,< 1K
+Predicate,https://schema.org/lifeEvent-output,< 1K
+Predicate,https://schema.org/line,< 1K
+Predicate,https://schema.org/line-input,< 1K
+Predicate,https://schema.org/line-output,< 1K
+Predicate,https://schema.org/linkRelationship,< 1K
+Predicate,https://schema.org/linkRelationship-input,< 1K
+Predicate,https://schema.org/linkRelationship-output,< 1K
+Predicate,https://schema.org/liveBlogUpdate,1K - 10K
+Predicate,https://schema.org/liveBlogUpdate-input,< 1K
+Predicate,https://schema.org/liveBlogUpdate-output,< 1K
+Predicate,https://schema.org/loanMortgageMandateAmount,< 1K
+Predicate,https://schema.org/loanMortgageMandateAmount-input,< 1K
+Predicate,https://schema.org/loanMortgageMandateAmount-output,< 1K
+Predicate,https://schema.org/loanPaymentAmount,< 1K
+Predicate,https://schema.org/loanPaymentAmount-input,< 1K
+Predicate,https://schema.org/loanPaymentAmount-output,< 1K
+Predicate,https://schema.org/loanPaymentFrequency,< 1K
+Predicate,https://schema.org/loanPaymentFrequency-input,< 1K
+Predicate,https://schema.org/loanPaymentFrequency-output,< 1K
+Predicate,https://schema.org/loanRepaymentForm,< 1K
+Predicate,https://schema.org/loanRepaymentForm-input,< 1K
+Predicate,https://schema.org/loanRepaymentForm-output,< 1K
+Predicate,https://schema.org/loanTerm,1K - 10K
+Predicate,https://schema.org/loanTerm-input,< 1K
+Predicate,https://schema.org/loanTerm-output,< 1K
+Predicate,https://schema.org/loanType,1K - 10K
+Predicate,https://schema.org/loanType-input,< 1K
+Predicate,https://schema.org/loanType-output,< 1K
+Predicate,https://schema.org/location,1M - 10M
+Predicate,https://schema.org/location-input,< 1K
+Predicate,https://schema.org/location-output,< 1K
+Predicate,https://schema.org/locationCreated,10K - 100K
+Predicate,https://schema.org/locationCreated-input,< 1K
+Predicate,https://schema.org/locationCreated-output,< 1K
+Predicate,https://schema.org/lodgingUnitDescription,< 1K
+Predicate,https://schema.org/lodgingUnitDescription-input,< 1K
+Predicate,https://schema.org/lodgingUnitDescription-output,< 1K
+Predicate,https://schema.org/lodgingUnitType,< 1K
+Predicate,https://schema.org/lodgingUnitType-input,< 1K
+Predicate,https://schema.org/lodgingUnitType-output,< 1K
+Predicate,https://schema.org/logo,10M+
+Predicate,https://schema.org/logo-input,< 1K
+Predicate,https://schema.org/logo-output,< 1K
+Predicate,https://schema.org/longitude,1M - 10M
+Predicate,https://schema.org/longitude-input,< 1K
+Predicate,https://schema.org/longitude-output,< 1K
+Predicate,https://schema.org/loser,< 1K
+Predicate,https://schema.org/loser-input,< 1K
+Predicate,https://schema.org/loser-output,< 1K
+Predicate,https://schema.org/lowPrice,1M - 10M
+Predicate,https://schema.org/lowPrice-input,< 1K
+Predicate,https://schema.org/lowPrice-output,< 1K
+Predicate,https://schema.org/lyricist,< 1K
+Predicate,https://schema.org/lyricist-input,< 1K
+Predicate,https://schema.org/lyricist-output,< 1K
+Predicate,https://schema.org/lyrics,1K - 10K
+Predicate,https://schema.org/lyrics-input,< 1K
+Predicate,https://schema.org/lyrics-output,< 1K
+Predicate,https://schema.org/mainContentOfPage,1M - 10M
+Predicate,https://schema.org/mainContentOfPage-input,< 1K
+Predicate,https://schema.org/mainContentOfPage-output,< 1K
+Predicate,https://schema.org/mainEntity,1M - 10M
+Predicate,https://schema.org/mainEntity-input,< 1K
+Predicate,https://schema.org/mainEntity-output,< 1K
+Predicate,https://schema.org/mainEntityOfPage,10M+
+Predicate,https://schema.org/mainEntityOfPage-input,< 1K
+Predicate,https://schema.org/mainEntityOfPage-output,< 1K
+Predicate,https://schema.org/maintainer,1K - 10K
+Predicate,https://schema.org/maintainer-input,< 1K
+Predicate,https://schema.org/maintainer-output,< 1K
+Predicate,https://schema.org/makesOffer,100K - 1M
+Predicate,https://schema.org/makesOffer-input,< 1K
+Predicate,https://schema.org/makesOffer-output,< 1K
+Predicate,https://schema.org/manufacturer,100K - 1M
+Predicate,https://schema.org/manufacturer-input,< 1K
+Predicate,https://schema.org/manufacturer-output,< 1K
+Predicate,https://schema.org/map,1K - 10K
+Predicate,https://schema.org/map-input,< 1K
+Predicate,https://schema.org/map-output,< 1K
+Predicate,https://schema.org/mapType,1K - 10K
+Predicate,https://schema.org/mapType-input,< 1K
+Predicate,https://schema.org/mapType-output,< 1K
+Predicate,https://schema.org/maps,1K - 10K
+Predicate,https://schema.org/maps-input,< 1K
+Predicate,https://schema.org/maps-output,< 1K
+Predicate,https://schema.org/marginOfError,< 1K
+Predicate,https://schema.org/marginOfError-input,< 1K
+Predicate,https://schema.org/marginOfError-output,< 1K
+Predicate,https://schema.org/masthead,1K - 10K
+Predicate,https://schema.org/masthead-input,< 1K
+Predicate,https://schema.org/masthead-output,< 1K
+Predicate,https://schema.org/material,10K - 100K
+Predicate,https://schema.org/material-input,< 1K
+Predicate,https://schema.org/material-output,< 1K
+Predicate,https://schema.org/materialExtent,< 1K
+Predicate,https://schema.org/materialExtent-input,< 1K
+Predicate,https://schema.org/materialExtent-output,< 1K
+Predicate,https://schema.org/mathExpression,< 1K
+Predicate,https://schema.org/mathExpression-input,< 1K
+Predicate,https://schema.org/mathExpression-output,< 1K
+Predicate,https://schema.org/maxPrice,10K - 100K
+Predicate,https://schema.org/maxPrice-input,< 1K
+Predicate,https://schema.org/maxPrice-output,< 1K
+Predicate,https://schema.org/maxValue,100K - 1M
+Predicate,https://schema.org/maxValue-input,< 1K
+Predicate,https://schema.org/maxValue-output,< 1K
+Predicate,https://schema.org/maximumAttendeeCapacity,10K - 100K
+Predicate,https://schema.org/maximumAttendeeCapacity-input,< 1K
+Predicate,https://schema.org/maximumAttendeeCapacity-output,< 1K
+Predicate,https://schema.org/maximumEnrollment,< 1K
+Predicate,https://schema.org/maximumEnrollment-input,< 1K
+Predicate,https://schema.org/maximumEnrollment-output,< 1K
+Predicate,https://schema.org/maximumIntake,< 1K
+Predicate,https://schema.org/maximumIntake-input,< 1K
+Predicate,https://schema.org/maximumIntake-output,< 1K
+Predicate,https://schema.org/maximumPhysicalAttendeeCapacity,< 1K
+Predicate,https://schema.org/maximumPhysicalAttendeeCapacity-input,< 1K
+Predicate,https://schema.org/maximumPhysicalAttendeeCapacity-output,< 1K
+Predicate,https://schema.org/maximumVirtualAttendeeCapacity,< 1K
+Predicate,https://schema.org/maximumVirtualAttendeeCapacity-input,< 1K
+Predicate,https://schema.org/maximumVirtualAttendeeCapacity-output,< 1K
+Predicate,https://schema.org/mealService,< 1K
+Predicate,https://schema.org/mealService-input,< 1K
+Predicate,https://schema.org/mealService-output,< 1K
+Predicate,https://schema.org/measuredProperty,< 1K
+Predicate,https://schema.org/measuredProperty-input,< 1K
+Predicate,https://schema.org/measuredProperty-output,< 1K
+Predicate,https://schema.org/measurementDenominator,< 1K
+Predicate,https://schema.org/measurementDenominator-input,< 1K
+Predicate,https://schema.org/measurementDenominator-output,< 1K
+Predicate,https://schema.org/measurementMethod,< 1K
+Predicate,https://schema.org/measurementMethod-input,< 1K
+Predicate,https://schema.org/measurementMethod-output,< 1K
+Predicate,https://schema.org/measurementQualifier,< 1K
+Predicate,https://schema.org/measurementQualifier-input,< 1K
+Predicate,https://schema.org/measurementQualifier-output,< 1K
+Predicate,https://schema.org/measurementTechnique,1K - 10K
+Predicate,https://schema.org/measurementTechnique-input,< 1K
+Predicate,https://schema.org/measurementTechnique-output,< 1K
+Predicate,https://schema.org/mechanismOfAction,< 1K
+Predicate,https://schema.org/mechanismOfAction-input,< 1K
+Predicate,https://schema.org/mechanismOfAction-output,< 1K
+Predicate,https://schema.org/mediaAuthenticityCategory,< 1K
+Predicate,https://schema.org/mediaAuthenticityCategory-input,< 1K
+Predicate,https://schema.org/mediaAuthenticityCategory-output,< 1K
+Predicate,https://schema.org/mediaItemAppearance,< 1K
+Predicate,https://schema.org/mediaItemAppearance-input,< 1K
+Predicate,https://schema.org/mediaItemAppearance-output,< 1K
+Predicate,https://schema.org/median,1K - 10K
+Predicate,https://schema.org/median-input,< 1K
+Predicate,https://schema.org/median-output,< 1K
+Predicate,https://schema.org/medicalAudience,1K - 10K
+Predicate,https://schema.org/medicalAudience-input,< 1K
+Predicate,https://schema.org/medicalAudience-output,< 1K
+Predicate,https://schema.org/medicalSpecialty,100K - 1M
+Predicate,https://schema.org/medicalSpecialty-input,< 1K
+Predicate,https://schema.org/medicalSpecialty-output,< 1K
+Predicate,https://schema.org/medicineSystem,1K - 10K
+Predicate,https://schema.org/medicineSystem-input,< 1K
+Predicate,https://schema.org/medicineSystem-output,< 1K
+Predicate,https://schema.org/meetsEmissionStandard,< 1K
+Predicate,https://schema.org/meetsEmissionStandard-input,< 1K
+Predicate,https://schema.org/meetsEmissionStandard-output,< 1K
+Predicate,https://schema.org/member,10K - 100K
+Predicate,https://schema.org/member-input,< 1K
+Predicate,https://schema.org/member-output,< 1K
+Predicate,https://schema.org/memberOf,100K - 1M
+Predicate,https://schema.org/memberOf-input,< 1K
+Predicate,https://schema.org/memberOf-output,< 1K
+Predicate,https://schema.org/members,< 1K
+Predicate,https://schema.org/members-input,< 1K
+Predicate,https://schema.org/members-output,< 1K
+Predicate,https://schema.org/membershipNumber,< 1K
+Predicate,https://schema.org/membershipNumber-input,< 1K
+Predicate,https://schema.org/membershipNumber-output,< 1K
+Predicate,https://schema.org/membershipPointsEarned,1K - 10K
+Predicate,https://schema.org/membershipPointsEarned-input,< 1K
+Predicate,https://schema.org/membershipPointsEarned-output,< 1K
+Predicate,https://schema.org/memoryRequirements,1K - 10K
+Predicate,https://schema.org/memoryRequirements-input,< 1K
+Predicate,https://schema.org/memoryRequirements-output,< 1K
+Predicate,https://schema.org/mentions,10K - 100K
+Predicate,https://schema.org/mentions-input,< 1K
+Predicate,https://schema.org/mentions-output,< 1K
+Predicate,https://schema.org/menu,10K - 100K
+Predicate,https://schema.org/menu-input,< 1K
+Predicate,https://schema.org/menu-output,< 1K
+Predicate,https://schema.org/menuAddOn,10K - 100K
+Predicate,https://schema.org/menuAddOn-input,< 1K
+Predicate,https://schema.org/menuAddOn-output,< 1K
+Predicate,https://schema.org/merchant,< 1K
+Predicate,https://schema.org/merchant-input,< 1K
+Predicate,https://schema.org/merchant-output,< 1K
+Predicate,https://schema.org/merchantReturnDays,100K - 1M
+Predicate,https://schema.org/merchantReturnDays-input,< 1K
+Predicate,https://schema.org/merchantReturnDays-output,< 1K
+Predicate,https://schema.org/merchantReturnLink,10K - 100K
+Predicate,https://schema.org/merchantReturnLink-input,< 1K
+Predicate,https://schema.org/merchantReturnLink-output,< 1K
+Predicate,https://schema.org/messageAttachment,< 1K
+Predicate,https://schema.org/messageAttachment-input,< 1K
+Predicate,https://schema.org/messageAttachment-output,< 1K
+Predicate,https://schema.org/mileageFromOdometer,10K - 100K
+Predicate,https://schema.org/mileageFromOdometer-input,< 1K
+Predicate,https://schema.org/mileageFromOdometer-output,< 1K
+Predicate,https://schema.org/minPrice,10K - 100K
+Predicate,https://schema.org/minPrice-input,< 1K
+Predicate,https://schema.org/minPrice-output,< 1K
+Predicate,https://schema.org/minValue,100K - 1M
+Predicate,https://schema.org/minValue-input,< 1K
+Predicate,https://schema.org/minValue-output,< 1K
+Predicate,https://schema.org/minimumPaymentDue,< 1K
+Predicate,https://schema.org/minimumPaymentDue-input,< 1K
+Predicate,https://schema.org/minimumPaymentDue-output,< 1K
+Predicate,https://schema.org/missionCoveragePrioritiesPolicy,1K - 10K
+Predicate,https://schema.org/missionCoveragePrioritiesPolicy-input,< 1K
+Predicate,https://schema.org/missionCoveragePrioritiesPolicy-output,< 1K
+Predicate,https://schema.org/mobileUrl,< 1K
+Predicate,https://schema.org/mobileUrl-input,< 1K
+Predicate,https://schema.org/mobileUrl-output,< 1K
+Predicate,https://schema.org/model,100K - 1M
+Predicate,https://schema.org/model-input,< 1K
+Predicate,https://schema.org/model-output,< 1K
+Predicate,https://schema.org/modelDate,10K - 100K
+Predicate,https://schema.org/modelDate-input,< 1K
+Predicate,https://schema.org/modelDate-output,< 1K
+Predicate,https://schema.org/modifiedTime,< 1K
+Predicate,https://schema.org/modifiedTime-input,< 1K
+Predicate,https://schema.org/modifiedTime-output,< 1K
+Predicate,https://schema.org/molecularFormula,< 1K
+Predicate,https://schema.org/molecularFormula-input,< 1K
+Predicate,https://schema.org/molecularFormula-output,< 1K
+Predicate,https://schema.org/molecularWeight,< 1K
+Predicate,https://schema.org/molecularWeight-input,< 1K
+Predicate,https://schema.org/molecularWeight-output,< 1K
+Predicate,https://schema.org/monoisotopicMolecularWeight,< 1K
+Predicate,https://schema.org/monoisotopicMolecularWeight-input,< 1K
+Predicate,https://schema.org/monoisotopicMolecularWeight-output,< 1K
+Predicate,https://schema.org/monthlyMinimumRepaymentAmount,< 1K
+Predicate,https://schema.org/monthlyMinimumRepaymentAmount-input,< 1K
+Predicate,https://schema.org/monthlyMinimumRepaymentAmount-output,< 1K
+Predicate,https://schema.org/monthsOfExperience,1K - 10K
+Predicate,https://schema.org/monthsOfExperience-input,< 1K
+Predicate,https://schema.org/monthsOfExperience-output,< 1K
+Predicate,https://schema.org/mpn,100K - 1M
+Predicate,https://schema.org/mpn-input,< 1K
+Predicate,https://schema.org/mpn-output,< 1K
+Predicate,https://schema.org/multipleValues,< 1K
+Predicate,https://schema.org/multipleValues-input,< 1K
+Predicate,https://schema.org/multipleValues-output,< 1K
+Predicate,https://schema.org/muscleAction,< 1K
+Predicate,https://schema.org/muscleAction-input,< 1K
+Predicate,https://schema.org/muscleAction-output,< 1K
+Predicate,https://schema.org/musicArrangement,< 1K
+Predicate,https://schema.org/musicArrangement-input,< 1K
+Predicate,https://schema.org/musicArrangement-output,< 1K
+Predicate,https://schema.org/musicBy,1K - 10K
+Predicate,https://schema.org/musicBy-input,< 1K
+Predicate,https://schema.org/musicBy-output,< 1K
+Predicate,https://schema.org/musicCompositionForm,< 1K
+Predicate,https://schema.org/musicCompositionForm-input,< 1K
+Predicate,https://schema.org/musicCompositionForm-output,< 1K
+Predicate,https://schema.org/musicGroupMember,< 1K
+Predicate,https://schema.org/musicGroupMember-input,< 1K
+Predicate,https://schema.org/musicGroupMember-output,< 1K
+Predicate,https://schema.org/musicReleaseFormat,1K - 10K
+Predicate,https://schema.org/musicReleaseFormat-input,< 1K
+Predicate,https://schema.org/musicReleaseFormat-output,< 1K
+Predicate,https://schema.org/musicalKey,< 1K
+Predicate,https://schema.org/musicalKey-input,< 1K
+Predicate,https://schema.org/musicalKey-output,< 1K
+Predicate,https://schema.org/naics,10K - 100K
+Predicate,https://schema.org/naics-input,< 1K
+Predicate,https://schema.org/naics-output,< 1K
+Predicate,https://schema.org/name,10M+
+Predicate,https://schema.org/name-input,< 1K
+Predicate,https://schema.org/name-output,< 1K
+Predicate,https://schema.org/namedPosition,< 1K
+Predicate,https://schema.org/namedPosition-input,< 1K
+Predicate,https://schema.org/namedPosition-output,< 1K
+Predicate,https://schema.org/nationality,10K - 100K
+Predicate,https://schema.org/nationality-input,< 1K
+Predicate,https://schema.org/nationality-output,< 1K
+Predicate,https://schema.org/naturalProgression,< 1K
+Predicate,https://schema.org/naturalProgression-input,< 1K
+Predicate,https://schema.org/naturalProgression-output,< 1K
+Predicate,https://schema.org/negativeNotes,10K - 100K
+Predicate,https://schema.org/negativeNotes-input,< 1K
+Predicate,https://schema.org/negativeNotes-output,< 1K
+Predicate,https://schema.org/nerve,< 1K
+Predicate,https://schema.org/nerve-input,< 1K
+Predicate,https://schema.org/nerve-output,< 1K
+Predicate,https://schema.org/nerveMotor,< 1K
+Predicate,https://schema.org/nerveMotor-input,< 1K
+Predicate,https://schema.org/nerveMotor-output,< 1K
+Predicate,https://schema.org/netWorth,< 1K
+Predicate,https://schema.org/netWorth-input,< 1K
+Predicate,https://schema.org/netWorth-output,< 1K
+Predicate,https://schema.org/newsUpdatesAndGuidelines,< 1K
+Predicate,https://schema.org/newsUpdatesAndGuidelines-input,< 1K
+Predicate,https://schema.org/newsUpdatesAndGuidelines-output,< 1K
+Predicate,https://schema.org/nextItem,1M - 10M
+Predicate,https://schema.org/nextItem-input,< 1K
+Predicate,https://schema.org/nextItem-output,< 1K
+Predicate,https://schema.org/noBylinesPolicy,1K - 10K
+Predicate,https://schema.org/noBylinesPolicy-input,< 1K
+Predicate,https://schema.org/noBylinesPolicy-output,< 1K
+Predicate,https://schema.org/nonEqual,< 1K
+Predicate,https://schema.org/nonEqual-input,< 1K
+Predicate,https://schema.org/nonEqual-output,< 1K
+Predicate,https://schema.org/nonProprietaryName,1K - 10K
+Predicate,https://schema.org/nonProprietaryName-input,< 1K
+Predicate,https://schema.org/nonProprietaryName-output,< 1K
+Predicate,https://schema.org/nonprofitStatus,1K - 10K
+Predicate,https://schema.org/nonprofitStatus-input,< 1K
+Predicate,https://schema.org/nonprofitStatus-output,< 1K
+Predicate,https://schema.org/normalRange,< 1K
+Predicate,https://schema.org/normalRange-input,< 1K
+Predicate,https://schema.org/normalRange-output,< 1K
+Predicate,https://schema.org/nsn,< 1K
+Predicate,https://schema.org/nsn-input,< 1K
+Predicate,https://schema.org/nsn-output,< 1K
+Predicate,https://schema.org/numAdults,< 1K
+Predicate,https://schema.org/numAdults-input,< 1K
+Predicate,https://schema.org/numAdults-output,< 1K
+Predicate,https://schema.org/numChildren,< 1K
+Predicate,https://schema.org/numChildren-input,< 1K
+Predicate,https://schema.org/numChildren-output,< 1K
+Predicate,https://schema.org/numConstraints,< 1K
+Predicate,https://schema.org/numConstraints-input,< 1K
+Predicate,https://schema.org/numConstraints-output,< 1K
+Predicate,https://schema.org/numItems,< 1K
+Predicate,https://schema.org/numItems-input,< 1K
+Predicate,https://schema.org/numItems-output,< 1K
+Predicate,https://schema.org/numTracks,10K - 100K
+Predicate,https://schema.org/numTracks-input,< 1K
+Predicate,https://schema.org/numTracks-output,< 1K
+Predicate,https://schema.org/numberOfAccommodationUnits,1K - 10K
+Predicate,https://schema.org/numberOfAccommodationUnits-input,< 1K
+Predicate,https://schema.org/numberOfAccommodationUnits-output,< 1K
+Predicate,https://schema.org/numberOfAirbags,< 1K
+Predicate,https://schema.org/numberOfAirbags-input,< 1K
+Predicate,https://schema.org/numberOfAirbags-output,< 1K
+Predicate,https://schema.org/numberOfAvailableAccommodationUnits,1K - 10K
+Predicate,https://schema.org/numberOfAvailableAccommodationUnits-input,< 1K
+Predicate,https://schema.org/numberOfAvailableAccommodationUnits-output,< 1K
+Predicate,https://schema.org/numberOfAxles,1K - 10K
+Predicate,https://schema.org/numberOfAxles-input,< 1K
+Predicate,https://schema.org/numberOfAxles-output,< 1K
+Predicate,https://schema.org/numberOfBathroomsTotal,10K - 100K
+Predicate,https://schema.org/numberOfBathroomsTotal-input,< 1K
+Predicate,https://schema.org/numberOfBathroomsTotal-output,< 1K
+Predicate,https://schema.org/numberOfBedrooms,100K - 1M
+Predicate,https://schema.org/numberOfBedrooms-input,< 1K
+Predicate,https://schema.org/numberOfBedrooms-output,< 1K
+Predicate,https://schema.org/numberOfBeds,10K - 100K
+Predicate,https://schema.org/numberOfBeds-input,< 1K
+Predicate,https://schema.org/numberOfBeds-output,< 1K
+Predicate,https://schema.org/numberOfCredits,1K - 10K
+Predicate,https://schema.org/numberOfCredits-input,< 1K
+Predicate,https://schema.org/numberOfCredits-output,< 1K
+Predicate,https://schema.org/numberOfDoors,10K - 100K
+Predicate,https://schema.org/numberOfDoors-input,< 1K
+Predicate,https://schema.org/numberOfDoors-output,< 1K
+Predicate,https://schema.org/numberOfEmployees,100K - 1M
+Predicate,https://schema.org/numberOfEmployees-input,< 1K
+Predicate,https://schema.org/numberOfEmployees-output,< 1K
+Predicate,https://schema.org/numberOfEpisodes,10K - 100K
+Predicate,https://schema.org/numberOfEpisodes-input,< 1K
+Predicate,https://schema.org/numberOfEpisodes-output,< 1K
+Predicate,https://schema.org/numberOfForwardGears,1K - 10K
+Predicate,https://schema.org/numberOfForwardGears-input,< 1K
+Predicate,https://schema.org/numberOfForwardGears-output,< 1K
+Predicate,https://schema.org/numberOfFullBathrooms,10K - 100K
+Predicate,https://schema.org/numberOfFullBathrooms-input,< 1K
+Predicate,https://schema.org/numberOfFullBathrooms-output,< 1K
+Predicate,https://schema.org/numberOfItems,100K - 1M
+Predicate,https://schema.org/numberOfItems-input,< 1K
+Predicate,https://schema.org/numberOfItems-output,< 1K
+Predicate,https://schema.org/numberOfLoanPayments,< 1K
+Predicate,https://schema.org/numberOfLoanPayments-input,< 1K
+Predicate,https://schema.org/numberOfLoanPayments-output,< 1K
+Predicate,https://schema.org/numberOfPages,10K - 100K
+Predicate,https://schema.org/numberOfPages-input,< 1K
+Predicate,https://schema.org/numberOfPages-output,< 1K
+Predicate,https://schema.org/numberOfPartialBathrooms,1K - 10K
+Predicate,https://schema.org/numberOfPartialBathrooms-input,< 1K
+Predicate,https://schema.org/numberOfPartialBathrooms-output,< 1K
+Predicate,https://schema.org/numberOfPlayers,10K - 100K
+Predicate,https://schema.org/numberOfPlayers-input,< 1K
+Predicate,https://schema.org/numberOfPlayers-output,< 1K
+Predicate,https://schema.org/numberOfPreviousOwners,1K - 10K
+Predicate,https://schema.org/numberOfPreviousOwners-input,< 1K
+Predicate,https://schema.org/numberOfPreviousOwners-output,< 1K
+Predicate,https://schema.org/numberOfRooms,10K - 100K
+Predicate,https://schema.org/numberOfRooms-input,< 1K
+Predicate,https://schema.org/numberOfRooms-output,< 1K
+Predicate,https://schema.org/numberOfSeasons,1K - 10K
+Predicate,https://schema.org/numberOfSeasons-input,< 1K
+Predicate,https://schema.org/numberOfSeasons-output,< 1K
+Predicate,https://schema.org/numberedPosition,< 1K
+Predicate,https://schema.org/numberedPosition-input,< 1K
+Predicate,https://schema.org/numberedPosition-output,< 1K
+Predicate,https://schema.org/nutrition,10K - 100K
+Predicate,https://schema.org/nutrition-input,< 1K
+Predicate,https://schema.org/nutrition-output,< 1K
+Predicate,https://schema.org/object,10K - 100K
+Predicate,https://schema.org/object-input,< 1K
+Predicate,https://schema.org/object-output,< 1K
+Predicate,https://schema.org/observationAbout,< 1K
+Predicate,https://schema.org/observationAbout-input,< 1K
+Predicate,https://schema.org/observationAbout-output,< 1K
+Predicate,https://schema.org/observationDate,< 1K
+Predicate,https://schema.org/observationDate-input,< 1K
+Predicate,https://schema.org/observationDate-output,< 1K
+Predicate,https://schema.org/observationPeriod,< 1K
+Predicate,https://schema.org/observationPeriod-input,< 1K
+Predicate,https://schema.org/observationPeriod-output,< 1K
+Predicate,https://schema.org/occupancy,10K - 100K
+Predicate,https://schema.org/occupancy-input,< 1K
+Predicate,https://schema.org/occupancy-output,< 1K
+Predicate,https://schema.org/occupationLocation,10K - 100K
+Predicate,https://schema.org/occupationLocation-input,< 1K
+Predicate,https://schema.org/occupationLocation-output,< 1K
+Predicate,https://schema.org/occupationalCategory,10K - 100K
+Predicate,https://schema.org/occupationalCategory-input,< 1K
+Predicate,https://schema.org/occupationalCategory-output,< 1K
+Predicate,https://schema.org/occupationalCredentialAwarded,1K - 10K
+Predicate,https://schema.org/occupationalCredentialAwarded-input,< 1K
+Predicate,https://schema.org/occupationalCredentialAwarded-output,< 1K
+Predicate,https://schema.org/offerCount,1M - 10M
+Predicate,https://schema.org/offerCount-input,< 1K
+Predicate,https://schema.org/offerCount-output,< 1K
+Predicate,https://schema.org/offeredBy,10K - 100K
+Predicate,https://schema.org/offeredBy-input,< 1K
+Predicate,https://schema.org/offeredBy-output,< 1K
+Predicate,https://schema.org/offers,10M+
+Predicate,https://schema.org/offers-input,< 1K
+Predicate,https://schema.org/offers-output,< 1K
+Predicate,https://schema.org/offersPrescriptionByMail,< 1K
+Predicate,https://schema.org/offersPrescriptionByMail-input,< 1K
+Predicate,https://schema.org/offersPrescriptionByMail-output,< 1K
+Predicate,https://schema.org/openingHours,1M - 10M
+Predicate,https://schema.org/openingHours-input,< 1K
+Predicate,https://schema.org/openingHours-output,< 1K
+Predicate,https://schema.org/openingHoursSpecification,1M - 10M
+Predicate,https://schema.org/openingHoursSpecification-input,< 1K
+Predicate,https://schema.org/openingHoursSpecification-output,< 1K
+Predicate,https://schema.org/opens,1M - 10M
+Predicate,https://schema.org/opens-input,< 1K
+Predicate,https://schema.org/opens-output,< 1K
+Predicate,https://schema.org/operatingSystem,1M - 10M
+Predicate,https://schema.org/operatingSystem-input,< 1K
+Predicate,https://schema.org/operatingSystem-output,< 1K
+Predicate,https://schema.org/opponent,< 1K
+Predicate,https://schema.org/opponent-input,< 1K
+Predicate,https://schema.org/opponent-output,< 1K
+Predicate,https://schema.org/option,< 1K
+Predicate,https://schema.org/option-input,< 1K
+Predicate,https://schema.org/option-output,< 1K
+Predicate,https://schema.org/orderDate,< 1K
+Predicate,https://schema.org/orderDate-input,< 1K
+Predicate,https://schema.org/orderDate-output,< 1K
+Predicate,https://schema.org/orderDelivery,< 1K
+Predicate,https://schema.org/orderDelivery-input,< 1K
+Predicate,https://schema.org/orderDelivery-output,< 1K
+Predicate,https://schema.org/orderItemNumber,< 1K
+Predicate,https://schema.org/orderItemNumber-input,< 1K
+Predicate,https://schema.org/orderItemNumber-output,< 1K
+Predicate,https://schema.org/orderItemStatus,< 1K
+Predicate,https://schema.org/orderItemStatus-input,< 1K
+Predicate,https://schema.org/orderItemStatus-output,< 1K
+Predicate,https://schema.org/orderNumber,< 1K
+Predicate,https://schema.org/orderNumber-input,< 1K
+Predicate,https://schema.org/orderNumber-output,< 1K
+Predicate,https://schema.org/orderPercentage,< 1K
+Predicate,https://schema.org/orderPercentage-input,< 1K
+Predicate,https://schema.org/orderPercentage-output,< 1K
+Predicate,https://schema.org/orderQuantity,< 1K
+Predicate,https://schema.org/orderQuantity-input,< 1K
+Predicate,https://schema.org/orderQuantity-output,< 1K
+Predicate,https://schema.org/orderStatus,< 1K
+Predicate,https://schema.org/orderStatus-input,< 1K
+Predicate,https://schema.org/orderStatus-output,< 1K
+Predicate,https://schema.org/orderValue,< 1K
+Predicate,https://schema.org/orderValue-input,< 1K
+Predicate,https://schema.org/orderValue-output,< 1K
+Predicate,https://schema.org/orderedItem,< 1K
+Predicate,https://schema.org/orderedItem-input,< 1K
+Predicate,https://schema.org/orderedItem-output,< 1K
+Predicate,https://schema.org/organizer,100K - 1M
+Predicate,https://schema.org/organizer-input,< 1K
+Predicate,https://schema.org/organizer-output,< 1K
+Predicate,https://schema.org/originAddress,< 1K
+Predicate,https://schema.org/originAddress-input,< 1K
+Predicate,https://schema.org/originAddress-output,< 1K
+Predicate,https://schema.org/originalMediaContextDescription,< 1K
+Predicate,https://schema.org/originalMediaContextDescription-input,< 1K
+Predicate,https://schema.org/originalMediaContextDescription-output,< 1K
+Predicate,https://schema.org/originalMediaLink,< 1K
+Predicate,https://schema.org/originalMediaLink-input,< 1K
+Predicate,https://schema.org/originalMediaLink-output,< 1K
+Predicate,https://schema.org/originatesFrom,< 1K
+Predicate,https://schema.org/originatesFrom-input,< 1K
+Predicate,https://schema.org/originatesFrom-output,< 1K
+Predicate,https://schema.org/overdosage,< 1K
+Predicate,https://schema.org/overdosage-input,< 1K
+Predicate,https://schema.org/overdosage-output,< 1K
+Predicate,https://schema.org/ownedFrom,< 1K
+Predicate,https://schema.org/ownedFrom-input,< 1K
+Predicate,https://schema.org/ownedFrom-output,< 1K
+Predicate,https://schema.org/ownedThrough,< 1K
+Predicate,https://schema.org/ownedThrough-input,< 1K
+Predicate,https://schema.org/ownedThrough-output,< 1K
+Predicate,https://schema.org/owner,1K - 10K
+Predicate,https://schema.org/owner-input,< 1K
+Predicate,https://schema.org/owner-output,< 1K
+Predicate,https://schema.org/ownershipFundingInfo,10K - 100K
+Predicate,https://schema.org/ownershipFundingInfo-input,< 1K
+Predicate,https://schema.org/ownershipFundingInfo-output,< 1K
+Predicate,https://schema.org/owns,10K - 100K
+Predicate,https://schema.org/owns-input,< 1K
+Predicate,https://schema.org/owns-output,< 1K
+Predicate,https://schema.org/pageEnd,1K - 10K
+Predicate,https://schema.org/pageEnd-input,< 1K
+Predicate,https://schema.org/pageEnd-output,< 1K
+Predicate,https://schema.org/pageStart,1K - 10K
+Predicate,https://schema.org/pageStart-input,< 1K
+Predicate,https://schema.org/pageStart-output,< 1K
+Predicate,https://schema.org/pagination,1K - 10K
+Predicate,https://schema.org/pagination-input,< 1K
+Predicate,https://schema.org/pagination-output,< 1K
+Predicate,https://schema.org/parent,1K - 10K
+Predicate,https://schema.org/parent-input,< 1K
+Predicate,https://schema.org/parent-output,< 1K
+Predicate,https://schema.org/parentItem,1K - 10K
+Predicate,https://schema.org/parentItem-input,< 1K
+Predicate,https://schema.org/parentItem-output,< 1K
+Predicate,https://schema.org/parentOrganization,100K - 1M
+Predicate,https://schema.org/parentOrganization-input,< 1K
+Predicate,https://schema.org/parentOrganization-output,< 1K
+Predicate,https://schema.org/parentService,< 1K
+Predicate,https://schema.org/parentService-input,< 1K
+Predicate,https://schema.org/parentService-output,< 1K
+Predicate,https://schema.org/parentTaxon,< 1K
+Predicate,https://schema.org/parentTaxon-input,< 1K
+Predicate,https://schema.org/parentTaxon-output,< 1K
+Predicate,https://schema.org/parents,< 1K
+Predicate,https://schema.org/parents-input,< 1K
+Predicate,https://schema.org/parents-output,< 1K
+Predicate,https://schema.org/partOfEpisode,< 1K
+Predicate,https://schema.org/partOfEpisode-input,< 1K
+Predicate,https://schema.org/partOfEpisode-output,< 1K
+Predicate,https://schema.org/partOfInvoice,< 1K
+Predicate,https://schema.org/partOfInvoice-input,< 1K
+Predicate,https://schema.org/partOfInvoice-output,< 1K
+Predicate,https://schema.org/partOfOrder,< 1K
+Predicate,https://schema.org/partOfOrder-input,< 1K
+Predicate,https://schema.org/partOfOrder-output,< 1K
+Predicate,https://schema.org/partOfSeason,1K - 10K
+Predicate,https://schema.org/partOfSeason-input,< 1K
+Predicate,https://schema.org/partOfSeason-output,< 1K
+Predicate,https://schema.org/partOfSeries,10K - 100K
+Predicate,https://schema.org/partOfSeries-input,< 1K
+Predicate,https://schema.org/partOfSeries-output,< 1K
+Predicate,https://schema.org/partOfSystem,< 1K
+Predicate,https://schema.org/partOfSystem-input,< 1K
+Predicate,https://schema.org/partOfSystem-output,< 1K
+Predicate,https://schema.org/partOfTVSeries,< 1K
+Predicate,https://schema.org/partOfTVSeries-input,< 1K
+Predicate,https://schema.org/partOfTVSeries-output,< 1K
+Predicate,https://schema.org/partOfTrip,< 1K
+Predicate,https://schema.org/partOfTrip-input,< 1K
+Predicate,https://schema.org/partOfTrip-output,< 1K
+Predicate,https://schema.org/participant,1K - 10K
+Predicate,https://schema.org/participant-input,< 1K
+Predicate,https://schema.org/participant-output,< 1K
+Predicate,https://schema.org/partySize,< 1K
+Predicate,https://schema.org/partySize-input,< 1K
+Predicate,https://schema.org/partySize-output,< 1K
+Predicate,https://schema.org/passengerPriorityStatus,< 1K
+Predicate,https://schema.org/passengerPriorityStatus-input,< 1K
+Predicate,https://schema.org/passengerPriorityStatus-output,< 1K
+Predicate,https://schema.org/passengerSequenceNumber,< 1K
+Predicate,https://schema.org/passengerSequenceNumber-input,< 1K
+Predicate,https://schema.org/passengerSequenceNumber-output,< 1K
+Predicate,https://schema.org/pathophysiology,< 1K
+Predicate,https://schema.org/pathophysiology-input,< 1K
+Predicate,https://schema.org/pathophysiology-output,< 1K
+Predicate,https://schema.org/pattern,1K - 10K
+Predicate,https://schema.org/pattern-input,< 1K
+Predicate,https://schema.org/pattern-output,< 1K
+Predicate,https://schema.org/payload,1K - 10K
+Predicate,https://schema.org/payload-input,< 1K
+Predicate,https://schema.org/payload-output,< 1K
+Predicate,https://schema.org/paymentAccepted,100K - 1M
+Predicate,https://schema.org/paymentAccepted-input,< 1K
+Predicate,https://schema.org/paymentAccepted-output,< 1K
+Predicate,https://schema.org/paymentDue,< 1K
+Predicate,https://schema.org/paymentDue-input,< 1K
+Predicate,https://schema.org/paymentDue-output,< 1K
+Predicate,https://schema.org/paymentDueDate,< 1K
+Predicate,https://schema.org/paymentDueDate-input,< 1K
+Predicate,https://schema.org/paymentDueDate-output,< 1K
+Predicate,https://schema.org/paymentMethod,< 1K
+Predicate,https://schema.org/paymentMethod-input,< 1K
+Predicate,https://schema.org/paymentMethod-output,< 1K
+Predicate,https://schema.org/paymentMethodId,< 1K
+Predicate,https://schema.org/paymentMethodId-input,< 1K
+Predicate,https://schema.org/paymentMethodId-output,< 1K
+Predicate,https://schema.org/paymentMethodType,< 1K
+Predicate,https://schema.org/paymentMethodType-input,< 1K
+Predicate,https://schema.org/paymentMethodType-output,< 1K
+Predicate,https://schema.org/paymentStatus,< 1K
+Predicate,https://schema.org/paymentStatus-input,< 1K
+Predicate,https://schema.org/paymentStatus-output,< 1K
+Predicate,https://schema.org/paymentUrl,< 1K
+Predicate,https://schema.org/paymentUrl-input,< 1K
+Predicate,https://schema.org/paymentUrl-output,< 1K
+Predicate,https://schema.org/penciler,< 1K
+Predicate,https://schema.org/penciler-input,< 1K
+Predicate,https://schema.org/penciler-output,< 1K
+Predicate,https://schema.org/percentile10,1K - 10K
+Predicate,https://schema.org/percentile10-input,< 1K
+Predicate,https://schema.org/percentile10-output,< 1K
+Predicate,https://schema.org/percentile25,1K - 10K
+Predicate,https://schema.org/percentile25-input,< 1K
+Predicate,https://schema.org/percentile25-output,< 1K
+Predicate,https://schema.org/percentile75,1K - 10K
+Predicate,https://schema.org/percentile75-input,< 1K
+Predicate,https://schema.org/percentile75-output,< 1K
+Predicate,https://schema.org/percentile90,1K - 10K
+Predicate,https://schema.org/percentile90-input,< 1K
+Predicate,https://schema.org/percentile90-output,< 1K
+Predicate,https://schema.org/performTime,10K - 100K
+Predicate,https://schema.org/performTime-input,< 1K
+Predicate,https://schema.org/performTime-output,< 1K
+Predicate,https://schema.org/performer,100K - 1M
+Predicate,https://schema.org/performer-input,< 1K
+Predicate,https://schema.org/performer-output,< 1K
+Predicate,https://schema.org/performerIn,1K - 10K
+Predicate,https://schema.org/performerIn-input,< 1K
+Predicate,https://schema.org/performerIn-output,< 1K
+Predicate,https://schema.org/performers,10K - 100K
+Predicate,https://schema.org/performers-input,< 1K
+Predicate,https://schema.org/performers-output,< 1K
+Predicate,https://schema.org/permissionType,< 1K
+Predicate,https://schema.org/permissionType-input,< 1K
+Predicate,https://schema.org/permissionType-output,< 1K
+Predicate,https://schema.org/permissions,10K - 100K
+Predicate,https://schema.org/permissions-input,< 1K
+Predicate,https://schema.org/permissions-output,< 1K
+Predicate,https://schema.org/permitAudience,< 1K
+Predicate,https://schema.org/permitAudience-input,< 1K
+Predicate,https://schema.org/permitAudience-output,< 1K
+Predicate,https://schema.org/permittedUsage,< 1K
+Predicate,https://schema.org/permittedUsage-input,< 1K
+Predicate,https://schema.org/permittedUsage-output,< 1K
+Predicate,https://schema.org/petsAllowed,10K - 100K
+Predicate,https://schema.org/petsAllowed-input,< 1K
+Predicate,https://schema.org/petsAllowed-output,< 1K
+Predicate,https://schema.org/phoneticText,< 1K
+Predicate,https://schema.org/phoneticText-input,< 1K
+Predicate,https://schema.org/phoneticText-output,< 1K
+Predicate,https://schema.org/photo,10K - 100K
+Predicate,https://schema.org/photo-input,< 1K
+Predicate,https://schema.org/photo-output,< 1K
+Predicate,https://schema.org/photos,10K - 100K
+Predicate,https://schema.org/photos-input,< 1K
+Predicate,https://schema.org/photos-output,< 1K
+Predicate,https://schema.org/physicalRequirement,< 1K
+Predicate,https://schema.org/physicalRequirement-input,< 1K
+Predicate,https://schema.org/physicalRequirement-output,< 1K
+Predicate,https://schema.org/physiologicalBenefits,< 1K
+Predicate,https://schema.org/physiologicalBenefits-input,< 1K
+Predicate,https://schema.org/physiologicalBenefits-output,< 1K
+Predicate,https://schema.org/pickupLocation,< 1K
+Predicate,https://schema.org/pickupLocation-input,< 1K
+Predicate,https://schema.org/pickupLocation-output,< 1K
+Predicate,https://schema.org/pickupTime,< 1K
+Predicate,https://schema.org/pickupTime-input,< 1K
+Predicate,https://schema.org/pickupTime-output,< 1K
+Predicate,https://schema.org/playMode,10K - 100K
+Predicate,https://schema.org/playMode-input,< 1K
+Predicate,https://schema.org/playMode-output,< 1K
+Predicate,https://schema.org/playerType,10K - 100K
+Predicate,https://schema.org/playerType-input,< 1K
+Predicate,https://schema.org/playerType-output,< 1K
+Predicate,https://schema.org/playersOnline,1K - 10K
+Predicate,https://schema.org/playersOnline-input,< 1K
+Predicate,https://schema.org/playersOnline-output,< 1K
+Predicate,https://schema.org/polygon,1K - 10K
+Predicate,https://schema.org/polygon-input,< 1K
+Predicate,https://schema.org/polygon-output,< 1K
+Predicate,https://schema.org/populationType,< 1K
+Predicate,https://schema.org/populationType-input,< 1K
+Predicate,https://schema.org/populationType-output,< 1K
+Predicate,https://schema.org/position,10M+
+Predicate,https://schema.org/position-input,< 1K
+Predicate,https://schema.org/position-output,< 1K
+Predicate,https://schema.org/positiveNotes,10K - 100K
+Predicate,https://schema.org/positiveNotes-input,< 1K
+Predicate,https://schema.org/positiveNotes-output,< 1K
+Predicate,https://schema.org/possibleComplication,1K - 10K
+Predicate,https://schema.org/possibleComplication-input,< 1K
+Predicate,https://schema.org/possibleComplication-output,< 1K
+Predicate,https://schema.org/possibleTreatment,1K - 10K
+Predicate,https://schema.org/possibleTreatment-input,< 1K
+Predicate,https://schema.org/possibleTreatment-output,< 1K
+Predicate,https://schema.org/postOfficeBoxNumber,10K - 100K
+Predicate,https://schema.org/postOfficeBoxNumber-input,< 1K
+Predicate,https://schema.org/postOfficeBoxNumber-output,< 1K
+Predicate,https://schema.org/postOp,< 1K
+Predicate,https://schema.org/postOp-input,< 1K
+Predicate,https://schema.org/postOp-output,< 1K
+Predicate,https://schema.org/postalCode,1M - 10M
+Predicate,https://schema.org/postalCode-input,< 1K
+Predicate,https://schema.org/postalCode-output,< 1K
+Predicate,https://schema.org/postalCodeBegin,1K - 10K
+Predicate,https://schema.org/postalCodeBegin-input,< 1K
+Predicate,https://schema.org/postalCodeBegin-output,< 1K
+Predicate,https://schema.org/postalCodeEnd,1K - 10K
+Predicate,https://schema.org/postalCodeEnd-input,< 1K
+Predicate,https://schema.org/postalCodeEnd-output,< 1K
+Predicate,https://schema.org/postalCodePrefix,< 1K
+Predicate,https://schema.org/postalCodePrefix-input,< 1K
+Predicate,https://schema.org/postalCodePrefix-output,< 1K
+Predicate,https://schema.org/postalCodeRange,1K - 10K
+Predicate,https://schema.org/postalCodeRange-input,< 1K
+Predicate,https://schema.org/postalCodeRange-output,< 1K
+Predicate,https://schema.org/potentialAction,10M+
+Predicate,https://schema.org/potentialAction-input,< 1K
+Predicate,https://schema.org/potentialAction-output,< 1K
+Predicate,https://schema.org/potentialUse,< 1K
+Predicate,https://schema.org/potentialUse-input,< 1K
+Predicate,https://schema.org/potentialUse-output,< 1K
+Predicate,https://schema.org/practicesAt,1K - 10K
+Predicate,https://schema.org/practicesAt-input,< 1K
+Predicate,https://schema.org/practicesAt-output,< 1K
+Predicate,https://schema.org/preOp,< 1K
+Predicate,https://schema.org/preOp-input,< 1K
+Predicate,https://schema.org/preOp-output,< 1K
+Predicate,https://schema.org/predecessorOf,< 1K
+Predicate,https://schema.org/predecessorOf-input,< 1K
+Predicate,https://schema.org/predecessorOf-output,< 1K
+Predicate,https://schema.org/pregnancyCategory,< 1K
+Predicate,https://schema.org/pregnancyCategory-input,< 1K
+Predicate,https://schema.org/pregnancyCategory-output,< 1K
+Predicate,https://schema.org/pregnancyWarning,< 1K
+Predicate,https://schema.org/pregnancyWarning-input,< 1K
+Predicate,https://schema.org/pregnancyWarning-output,< 1K
+Predicate,https://schema.org/prepTime,10K - 100K
+Predicate,https://schema.org/prepTime-input,< 1K
+Predicate,https://schema.org/prepTime-output,< 1K
+Predicate,https://schema.org/preparation,1K - 10K
+Predicate,https://schema.org/preparation-input,< 1K
+Predicate,https://schema.org/preparation-output,< 1K
+Predicate,https://schema.org/prescribingInfo,< 1K
+Predicate,https://schema.org/prescribingInfo-input,< 1K
+Predicate,https://schema.org/prescribingInfo-output,< 1K
+Predicate,https://schema.org/prescriptionStatus,1K - 10K
+Predicate,https://schema.org/prescriptionStatus-input,< 1K
+Predicate,https://schema.org/prescriptionStatus-output,< 1K
+Predicate,https://schema.org/previousItem,1M - 10M
+Predicate,https://schema.org/previousItem-input,< 1K
+Predicate,https://schema.org/previousItem-output,< 1K
+Predicate,https://schema.org/previousStartDate,1K - 10K
+Predicate,https://schema.org/previousStartDate-input,< 1K
+Predicate,https://schema.org/previousStartDate-output,< 1K
+Predicate,https://schema.org/price,10M+
+Predicate,https://schema.org/price-input,< 1K
+Predicate,https://schema.org/price-output,< 1K
+Predicate,https://schema.org/priceComponent,1K - 10K
+Predicate,https://schema.org/priceComponent-input,< 1K
+Predicate,https://schema.org/priceComponent-output,< 1K
+Predicate,https://schema.org/priceComponentType,< 1K
+Predicate,https://schema.org/priceComponentType-input,< 1K
+Predicate,https://schema.org/priceComponentType-output,< 1K
+Predicate,https://schema.org/priceCurrency,10M+
+Predicate,https://schema.org/priceCurrency-input,< 1K
+Predicate,https://schema.org/priceCurrency-output,< 1K
+Predicate,https://schema.org/priceRange,1M - 10M
+Predicate,https://schema.org/priceRange-input,< 1K
+Predicate,https://schema.org/priceRange-output,< 1K
+Predicate,https://schema.org/priceSpecification,1M - 10M
+Predicate,https://schema.org/priceSpecification-input,< 1K
+Predicate,https://schema.org/priceSpecification-output,< 1K
+Predicate,https://schema.org/priceType,100K - 1M
+Predicate,https://schema.org/priceType-input,< 1K
+Predicate,https://schema.org/priceType-output,< 1K
+Predicate,https://schema.org/priceValidUntil,1M - 10M
+Predicate,https://schema.org/priceValidUntil-input,< 1K
+Predicate,https://schema.org/priceValidUntil-output,< 1K
+Predicate,https://schema.org/primaryImageOfPage,10M+
+Predicate,https://schema.org/primaryImageOfPage-input,< 1K
+Predicate,https://schema.org/primaryImageOfPage-output,< 1K
+Predicate,https://schema.org/primaryPrevention,< 1K
+Predicate,https://schema.org/primaryPrevention-input,< 1K
+Predicate,https://schema.org/primaryPrevention-output,< 1K
+Predicate,https://schema.org/printColumn,< 1K
+Predicate,https://schema.org/printColumn-input,< 1K
+Predicate,https://schema.org/printColumn-output,< 1K
+Predicate,https://schema.org/printEdition,< 1K
+Predicate,https://schema.org/printEdition-input,< 1K
+Predicate,https://schema.org/printEdition-output,< 1K
+Predicate,https://schema.org/printPage,< 1K
+Predicate,https://schema.org/printPage-input,< 1K
+Predicate,https://schema.org/printPage-output,< 1K
+Predicate,https://schema.org/printSection,< 1K
+Predicate,https://schema.org/printSection-input,< 1K
+Predicate,https://schema.org/printSection-output,< 1K
+Predicate,https://schema.org/procedure,< 1K
+Predicate,https://schema.org/procedure-input,< 1K
+Predicate,https://schema.org/procedure-output,< 1K
+Predicate,https://schema.org/procedureType,10K - 100K
+Predicate,https://schema.org/procedureType-input,< 1K
+Predicate,https://schema.org/procedureType-output,< 1K
+Predicate,https://schema.org/processingTime,< 1K
+Predicate,https://schema.org/processingTime-input,< 1K
+Predicate,https://schema.org/processingTime-output,< 1K
+Predicate,https://schema.org/processorRequirements,1K - 10K
+Predicate,https://schema.org/processorRequirements-input,< 1K
+Predicate,https://schema.org/processorRequirements-output,< 1K
+Predicate,https://schema.org/producer,1K - 10K
+Predicate,https://schema.org/producer-input,< 1K
+Predicate,https://schema.org/producer-output,< 1K
+Predicate,https://schema.org/produces,< 1K
+Predicate,https://schema.org/produces-input,< 1K
+Predicate,https://schema.org/produces-output,< 1K
+Predicate,https://schema.org/productGroupID,100K - 1M
+Predicate,https://schema.org/productGroupID-input,< 1K
+Predicate,https://schema.org/productGroupID-output,< 1K
+Predicate,https://schema.org/productID,100K - 1M
+Predicate,https://schema.org/productID-input,< 1K
+Predicate,https://schema.org/productID-output,< 1K
+Predicate,https://schema.org/productReturnDays,< 1K
+Predicate,https://schema.org/productReturnDays-input,< 1K
+Predicate,https://schema.org/productReturnDays-output,< 1K
+Predicate,https://schema.org/productReturnLink,< 1K
+Predicate,https://schema.org/productReturnLink-input,< 1K
+Predicate,https://schema.org/productReturnLink-output,< 1K
+Predicate,https://schema.org/productSupported,1K - 10K
+Predicate,https://schema.org/productSupported-input,< 1K
+Predicate,https://schema.org/productSupported-output,< 1K
+Predicate,https://schema.org/productionCompany,1K - 10K
+Predicate,https://schema.org/productionCompany-input,< 1K
+Predicate,https://schema.org/productionCompany-output,< 1K
+Predicate,https://schema.org/productionDate,10K - 100K
+Predicate,https://schema.org/productionDate-input,< 1K
+Predicate,https://schema.org/productionDate-output,< 1K
+Predicate,https://schema.org/proficiencyLevel,10K - 100K
+Predicate,https://schema.org/proficiencyLevel-input,< 1K
+Predicate,https://schema.org/proficiencyLevel-output,< 1K
+Predicate,https://schema.org/program,< 1K
+Predicate,https://schema.org/program-input,< 1K
+Predicate,https://schema.org/program-output,< 1K
+Predicate,https://schema.org/programMembershipUsed,< 1K
+Predicate,https://schema.org/programMembershipUsed-input,< 1K
+Predicate,https://schema.org/programMembershipUsed-output,< 1K
+Predicate,https://schema.org/programName,1K - 10K
+Predicate,https://schema.org/programName-input,< 1K
+Predicate,https://schema.org/programName-output,< 1K
+Predicate,https://schema.org/programPrerequisites,1K - 10K
+Predicate,https://schema.org/programPrerequisites-input,< 1K
+Predicate,https://schema.org/programPrerequisites-output,< 1K
+Predicate,https://schema.org/programType,1K - 10K
+Predicate,https://schema.org/programType-input,< 1K
+Predicate,https://schema.org/programType-output,< 1K
+Predicate,https://schema.org/programmingLanguage,1K - 10K
+Predicate,https://schema.org/programmingLanguage-input,< 1K
+Predicate,https://schema.org/programmingLanguage-output,< 1K
+Predicate,https://schema.org/programmingModel,< 1K
+Predicate,https://schema.org/programmingModel-input,< 1K
+Predicate,https://schema.org/programmingModel-output,< 1K
+Predicate,https://schema.org/pronouns,1K - 10K
+Predicate,https://schema.org/pronouns-input,< 1K
+Predicate,https://schema.org/pronouns-output,< 1K
+Predicate,https://schema.org/propertyID,10K - 100K
+Predicate,https://schema.org/propertyID-input,< 1K
+Predicate,https://schema.org/propertyID-output,< 1K
+Predicate,https://schema.org/proprietaryName,< 1K
+Predicate,https://schema.org/proprietaryName-input,< 1K
+Predicate,https://schema.org/proprietaryName-output,< 1K
+Predicate,https://schema.org/proteinContent,10K - 100K
+Predicate,https://schema.org/proteinContent-input,< 1K
+Predicate,https://schema.org/proteinContent-output,< 1K
+Predicate,https://schema.org/provider,1M - 10M
+Predicate,https://schema.org/provider-input,< 1K
+Predicate,https://schema.org/provider-output,< 1K
+Predicate,https://schema.org/providerMobility,1K - 10K
+Predicate,https://schema.org/providerMobility-input,< 1K
+Predicate,https://schema.org/providerMobility-output,< 1K
+Predicate,https://schema.org/providesBroadcastService,< 1K
+Predicate,https://schema.org/providesBroadcastService-input,< 1K
+Predicate,https://schema.org/providesBroadcastService-output,< 1K
+Predicate,https://schema.org/providesService,< 1K
+Predicate,https://schema.org/providesService-input,< 1K
+Predicate,https://schema.org/providesService-output,< 1K
+Predicate,https://schema.org/publicAccess,10K - 100K
+Predicate,https://schema.org/publicAccess-input,< 1K
+Predicate,https://schema.org/publicAccess-output,< 1K
+Predicate,https://schema.org/publicTransportClosuresInfo,< 1K
+Predicate,https://schema.org/publicTransportClosuresInfo-input,< 1K
+Predicate,https://schema.org/publicTransportClosuresInfo-output,< 1K
+Predicate,https://schema.org/publication,1K - 10K
+Predicate,https://schema.org/publication-input,< 1K
+Predicate,https://schema.org/publication-output,< 1K
+Predicate,https://schema.org/publicationType,< 1K
+Predicate,https://schema.org/publicationType-input,< 1K
+Predicate,https://schema.org/publicationType-output,< 1K
+Predicate,https://schema.org/publishedBy,< 1K
+Predicate,https://schema.org/publishedBy-input,< 1K
+Predicate,https://schema.org/publishedBy-output,< 1K
+Predicate,https://schema.org/publishedOn,< 1K
+Predicate,https://schema.org/publishedOn-input,< 1K
+Predicate,https://schema.org/publishedOn-output,< 1K
+Predicate,https://schema.org/publisher,10M+
+Predicate,https://schema.org/publisher-input,< 1K
+Predicate,https://schema.org/publisher-output,< 1K
+Predicate,https://schema.org/publisherImprint,< 1K
+Predicate,https://schema.org/publisherImprint-input,< 1K
+Predicate,https://schema.org/publisherImprint-output,< 1K
+Predicate,https://schema.org/publishingPrinciples,10K - 100K
+Predicate,https://schema.org/publishingPrinciples-input,< 1K
+Predicate,https://schema.org/publishingPrinciples-output,< 1K
+Predicate,https://schema.org/purchaseDate,1K - 10K
+Predicate,https://schema.org/purchaseDate-input,< 1K
+Predicate,https://schema.org/purchaseDate-output,< 1K
+Predicate,https://schema.org/purchasePriceLimit,< 1K
+Predicate,https://schema.org/purchasePriceLimit-input,< 1K
+Predicate,https://schema.org/purchasePriceLimit-output,< 1K
+Predicate,https://schema.org/purchaseType,< 1K
+Predicate,https://schema.org/purchaseType-input,< 1K
+Predicate,https://schema.org/purchaseType-output,< 1K
+Predicate,https://schema.org/qualifications,10K - 100K
+Predicate,https://schema.org/qualifications-input,< 1K
+Predicate,https://schema.org/qualifications-output,< 1K
+Predicate,https://schema.org/qualifiedExpense,< 1K
+Predicate,https://schema.org/qualifiedExpense-input,< 1K
+Predicate,https://schema.org/qualifiedExpense-output,< 1K
+Predicate,https://schema.org/quarantineGuidelines,< 1K
+Predicate,https://schema.org/quarantineGuidelines-input,< 1K
+Predicate,https://schema.org/quarantineGuidelines-output,< 1K
+Predicate,https://schema.org/query,10K - 100K
+Predicate,https://schema.org/query-input,10M+
+Predicate,https://schema.org/query-output,< 1K
+Predicate,https://schema.org/quest,< 1K
+Predicate,https://schema.org/quest-input,< 1K
+Predicate,https://schema.org/quest-output,< 1K
+Predicate,https://schema.org/question,1K - 10K
+Predicate,https://schema.org/question-input,< 1K
+Predicate,https://schema.org/question-output,< 1K
+Predicate,https://schema.org/rangeIncludes,< 1K
+Predicate,https://schema.org/rangeIncludes-input,< 1K
+Predicate,https://schema.org/rangeIncludes-output,< 1K
+Predicate,https://schema.org/ratingCount,1M - 10M
+Predicate,https://schema.org/ratingCount-input,< 1K
+Predicate,https://schema.org/ratingCount-output,< 1K
+Predicate,https://schema.org/ratingExplanation,1K - 10K
+Predicate,https://schema.org/ratingExplanation-input,< 1K
+Predicate,https://schema.org/ratingExplanation-output,< 1K
+Predicate,https://schema.org/ratingValue,1M - 10M
+Predicate,https://schema.org/ratingValue-input,< 1K
+Predicate,https://schema.org/ratingValue-output,< 1K
+Predicate,https://schema.org/readBy,< 1K
+Predicate,https://schema.org/readBy-input,< 1K
+Predicate,https://schema.org/readBy-output,< 1K
+Predicate,https://schema.org/readonlyValue,< 1K
+Predicate,https://schema.org/readonlyValue-input,< 1K
+Predicate,https://schema.org/readonlyValue-output,< 1K
+Predicate,https://schema.org/realEstateAgent,< 1K
+Predicate,https://schema.org/realEstateAgent-input,< 1K
+Predicate,https://schema.org/realEstateAgent-output,< 1K
+Predicate,https://schema.org/recipe,< 1K
+Predicate,https://schema.org/recipe-input,< 1K
+Predicate,https://schema.org/recipe-output,< 1K
+Predicate,https://schema.org/recipeCategory,10K - 100K
+Predicate,https://schema.org/recipeCategory-input,< 1K
+Predicate,https://schema.org/recipeCategory-output,< 1K
+Predicate,https://schema.org/recipeCuisine,10K - 100K
+Predicate,https://schema.org/recipeCuisine-input,< 1K
+Predicate,https://schema.org/recipeCuisine-output,< 1K
+Predicate,https://schema.org/recipeIngredient,10K - 100K
+Predicate,https://schema.org/recipeIngredient-input,< 1K
+Predicate,https://schema.org/recipeIngredient-output,< 1K
+Predicate,https://schema.org/recipeInstructions,10K - 100K
+Predicate,https://schema.org/recipeInstructions-input,< 1K
+Predicate,https://schema.org/recipeInstructions-output,< 1K
+Predicate,https://schema.org/recipeYield,10K - 100K
+Predicate,https://schema.org/recipeYield-input,< 1K
+Predicate,https://schema.org/recipeYield-output,< 1K
+Predicate,https://schema.org/recipient,1K - 10K
+Predicate,https://schema.org/recipient-input,< 1K
+Predicate,https://schema.org/recipient-output,< 1K
+Predicate,https://schema.org/recognizedBy,10K - 100K
+Predicate,https://schema.org/recognizedBy-input,< 1K
+Predicate,https://schema.org/recognizedBy-output,< 1K
+Predicate,https://schema.org/recognizingAuthority,1K - 10K
+Predicate,https://schema.org/recognizingAuthority-input,< 1K
+Predicate,https://schema.org/recognizingAuthority-output,< 1K
+Predicate,https://schema.org/recommendationStrength,< 1K
+Predicate,https://schema.org/recommendationStrength-input,< 1K
+Predicate,https://schema.org/recommendationStrength-output,< 1K
+Predicate,https://schema.org/recommendedIntake,< 1K
+Predicate,https://schema.org/recommendedIntake-input,< 1K
+Predicate,https://schema.org/recommendedIntake-output,< 1K
+Predicate,https://schema.org/recordLabel,1K - 10K
+Predicate,https://schema.org/recordLabel-input,< 1K
+Predicate,https://schema.org/recordLabel-output,< 1K
+Predicate,https://schema.org/recordedAs,< 1K
+Predicate,https://schema.org/recordedAs-input,< 1K
+Predicate,https://schema.org/recordedAs-output,< 1K
+Predicate,https://schema.org/recordedAt,< 1K
+Predicate,https://schema.org/recordedAt-input,< 1K
+Predicate,https://schema.org/recordedAt-output,< 1K
+Predicate,https://schema.org/recordedIn,< 1K
+Predicate,https://schema.org/recordedIn-input,< 1K
+Predicate,https://schema.org/recordedIn-output,< 1K
+Predicate,https://schema.org/recordingOf,1K - 10K
+Predicate,https://schema.org/recordingOf-input,< 1K
+Predicate,https://schema.org/recordingOf-output,< 1K
+Predicate,https://schema.org/recourseLoan,< 1K
+Predicate,https://schema.org/recourseLoan-input,< 1K
+Predicate,https://schema.org/recourseLoan-output,< 1K
+Predicate,https://schema.org/referee,< 1K
+Predicate,https://schema.org/referee-input,< 1K
+Predicate,https://schema.org/referee-output,< 1K
+Predicate,https://schema.org/referenceQuantity,1M - 10M
+Predicate,https://schema.org/referenceQuantity-input,< 1K
+Predicate,https://schema.org/referenceQuantity-output,< 1K
+Predicate,https://schema.org/referencesOrder,< 1K
+Predicate,https://schema.org/referencesOrder-input,< 1K
+Predicate,https://schema.org/referencesOrder-output,< 1K
+Predicate,https://schema.org/refundType,10K - 100K
+Predicate,https://schema.org/refundType-input,< 1K
+Predicate,https://schema.org/refundType-output,< 1K
+Predicate,https://schema.org/regionDrained,< 1K
+Predicate,https://schema.org/regionDrained-input,< 1K
+Predicate,https://schema.org/regionDrained-output,< 1K
+Predicate,https://schema.org/regionsAllowed,10K - 100K
+Predicate,https://schema.org/regionsAllowed-input,< 1K
+Predicate,https://schema.org/regionsAllowed-output,< 1K
+Predicate,https://schema.org/relatedAnatomy,< 1K
+Predicate,https://schema.org/relatedAnatomy-input,< 1K
+Predicate,https://schema.org/relatedAnatomy-output,< 1K
+Predicate,https://schema.org/relatedCondition,< 1K
+Predicate,https://schema.org/relatedCondition-input,< 1K
+Predicate,https://schema.org/relatedCondition-output,< 1K
+Predicate,https://schema.org/relatedDrug,< 1K
+Predicate,https://schema.org/relatedDrug-input,< 1K
+Predicate,https://schema.org/relatedDrug-output,< 1K
+Predicate,https://schema.org/relatedLink,10K - 100K
+Predicate,https://schema.org/relatedLink-input,< 1K
+Predicate,https://schema.org/relatedLink-output,< 1K
+Predicate,https://schema.org/relatedStructure,< 1K
+Predicate,https://schema.org/relatedStructure-input,< 1K
+Predicate,https://schema.org/relatedStructure-output,< 1K
+Predicate,https://schema.org/relatedTherapy,< 1K
+Predicate,https://schema.org/relatedTherapy-input,< 1K
+Predicate,https://schema.org/relatedTherapy-output,< 1K
+Predicate,https://schema.org/relatedTo,< 1K
+Predicate,https://schema.org/relatedTo-input,< 1K
+Predicate,https://schema.org/relatedTo-output,< 1K
+Predicate,https://schema.org/releaseDate,10K - 100K
+Predicate,https://schema.org/releaseDate-input,< 1K
+Predicate,https://schema.org/releaseDate-output,< 1K
+Predicate,https://schema.org/releaseNotes,10K - 100K
+Predicate,https://schema.org/releaseNotes-input,< 1K
+Predicate,https://schema.org/releaseNotes-output,< 1K
+Predicate,https://schema.org/releaseOf,< 1K
+Predicate,https://schema.org/releaseOf-input,< 1K
+Predicate,https://schema.org/releaseOf-output,< 1K
+Predicate,https://schema.org/releasedEvent,1K - 10K
+Predicate,https://schema.org/releasedEvent-input,< 1K
+Predicate,https://schema.org/releasedEvent-output,< 1K
+Predicate,https://schema.org/relevantOccupation,< 1K
+Predicate,https://schema.org/relevantOccupation-input,< 1K
+Predicate,https://schema.org/relevantOccupation-output,< 1K
+Predicate,https://schema.org/relevantSpecialty,10K - 100K
+Predicate,https://schema.org/relevantSpecialty-input,< 1K
+Predicate,https://schema.org/relevantSpecialty-output,< 1K
+Predicate,https://schema.org/remainingAttendeeCapacity,1K - 10K
+Predicate,https://schema.org/remainingAttendeeCapacity-input,< 1K
+Predicate,https://schema.org/remainingAttendeeCapacity-output,< 1K
+Predicate,https://schema.org/renegotiableLoan,< 1K
+Predicate,https://schema.org/renegotiableLoan-input,< 1K
+Predicate,https://schema.org/renegotiableLoan-output,< 1K
+Predicate,https://schema.org/repeatCount,1K - 10K
+Predicate,https://schema.org/repeatCount-input,< 1K
+Predicate,https://schema.org/repeatCount-output,< 1K
+Predicate,https://schema.org/repeatFrequency,10K - 100K
+Predicate,https://schema.org/repeatFrequency-input,< 1K
+Predicate,https://schema.org/repeatFrequency-output,< 1K
+Predicate,https://schema.org/repetitions,< 1K
+Predicate,https://schema.org/repetitions-input,< 1K
+Predicate,https://schema.org/repetitions-output,< 1K
+Predicate,https://schema.org/replacee,< 1K
+Predicate,https://schema.org/replacee-input,< 1K
+Predicate,https://schema.org/replacee-output,< 1K
+Predicate,https://schema.org/replacer,< 1K
+Predicate,https://schema.org/replacer-input,< 1K
+Predicate,https://schema.org/replacer-output,< 1K
+Predicate,https://schema.org/replyToUrl,1K - 10K
+Predicate,https://schema.org/replyToUrl-input,< 1K
+Predicate,https://schema.org/replyToUrl-output,< 1K
+Predicate,https://schema.org/reportNumber,< 1K
+Predicate,https://schema.org/reportNumber-input,< 1K
+Predicate,https://schema.org/reportNumber-output,< 1K
+Predicate,https://schema.org/representativeOfPage,100K - 1M
+Predicate,https://schema.org/representativeOfPage-input,< 1K
+Predicate,https://schema.org/representativeOfPage-output,< 1K
+Predicate,https://schema.org/requiredCollateral,< 1K
+Predicate,https://schema.org/requiredCollateral-input,< 1K
+Predicate,https://schema.org/requiredCollateral-output,< 1K
+Predicate,https://schema.org/requiredGender,< 1K
+Predicate,https://schema.org/requiredGender-input,< 1K
+Predicate,https://schema.org/requiredGender-output,< 1K
+Predicate,https://schema.org/requiredMaxAge,< 1K
+Predicate,https://schema.org/requiredMaxAge-input,< 1K
+Predicate,https://schema.org/requiredMaxAge-output,< 1K
+Predicate,https://schema.org/requiredMinAge,1K - 10K
+Predicate,https://schema.org/requiredMinAge-input,< 1K
+Predicate,https://schema.org/requiredMinAge-output,< 1K
+Predicate,https://schema.org/requiredQuantity,1K - 10K
+Predicate,https://schema.org/requiredQuantity-input,< 1K
+Predicate,https://schema.org/requiredQuantity-output,< 1K
+Predicate,https://schema.org/requirements,1K - 10K
+Predicate,https://schema.org/requirements-input,< 1K
+Predicate,https://schema.org/requirements-output,< 1K
+Predicate,https://schema.org/requiresSubscription,1K - 10K
+Predicate,https://schema.org/requiresSubscription-input,< 1K
+Predicate,https://schema.org/requiresSubscription-output,< 1K
+Predicate,https://schema.org/reservationFor,1K - 10K
+Predicate,https://schema.org/reservationFor-input,< 1K
+Predicate,https://schema.org/reservationFor-output,< 1K
+Predicate,https://schema.org/reservationId,< 1K
+Predicate,https://schema.org/reservationId-input,< 1K
+Predicate,https://schema.org/reservationId-output,< 1K
+Predicate,https://schema.org/reservationStatus,< 1K
+Predicate,https://schema.org/reservationStatus-input,< 1K
+Predicate,https://schema.org/reservationStatus-output,< 1K
+Predicate,https://schema.org/reservedTicket,< 1K
+Predicate,https://schema.org/reservedTicket-input,< 1K
+Predicate,https://schema.org/reservedTicket-output,< 1K
+Predicate,https://schema.org/responsibilities,10K - 100K
+Predicate,https://schema.org/responsibilities-input,< 1K
+Predicate,https://schema.org/responsibilities-output,< 1K
+Predicate,https://schema.org/restPeriods,< 1K
+Predicate,https://schema.org/restPeriods-input,< 1K
+Predicate,https://schema.org/restPeriods-output,< 1K
+Predicate,https://schema.org/restockingFee,1K - 10K
+Predicate,https://schema.org/restockingFee-input,< 1K
+Predicate,https://schema.org/restockingFee-output,< 1K
+Predicate,https://schema.org/result,10K - 100K
+Predicate,https://schema.org/result-input,< 1K
+Predicate,https://schema.org/result-output,< 1K
+Predicate,https://schema.org/resultComment,< 1K
+Predicate,https://schema.org/resultComment-input,< 1K
+Predicate,https://schema.org/resultComment-output,< 1K
+Predicate,https://schema.org/resultReview,< 1K
+Predicate,https://schema.org/resultReview-input,< 1K
+Predicate,https://schema.org/resultReview-output,< 1K
+Predicate,https://schema.org/returnFees,100K - 1M
+Predicate,https://schema.org/returnFees-input,< 1K
+Predicate,https://schema.org/returnFees-output,< 1K
+Predicate,https://schema.org/returnLabelSource,1K - 10K
+Predicate,https://schema.org/returnLabelSource-input,< 1K
+Predicate,https://schema.org/returnLabelSource-output,< 1K
+Predicate,https://schema.org/returnMethod,100K - 1M
+Predicate,https://schema.org/returnMethod-input,< 1K
+Predicate,https://schema.org/returnMethod-output,< 1K
+Predicate,https://schema.org/returnPolicyCategory,100K - 1M
+Predicate,https://schema.org/returnPolicyCategory-input,< 1K
+Predicate,https://schema.org/returnPolicyCategory-output,< 1K
+Predicate,https://schema.org/returnPolicyCountry,10K - 100K
+Predicate,https://schema.org/returnPolicyCountry-input,< 1K
+Predicate,https://schema.org/returnPolicyCountry-output,< 1K
+Predicate,https://schema.org/returnPolicySeasonalOverride,1K - 10K
+Predicate,https://schema.org/returnPolicySeasonalOverride-input,< 1K
+Predicate,https://schema.org/returnPolicySeasonalOverride-output,< 1K
+Predicate,https://schema.org/returnShippingFeesAmount,10K - 100K
+Predicate,https://schema.org/returnShippingFeesAmount-input,< 1K
+Predicate,https://schema.org/returnShippingFeesAmount-output,< 1K
+Predicate,https://schema.org/review,1M - 10M
+Predicate,https://schema.org/review-input,< 1K
+Predicate,https://schema.org/review-output,< 1K
+Predicate,https://schema.org/reviewAspect,10K - 100K
+Predicate,https://schema.org/reviewAspect-input,< 1K
+Predicate,https://schema.org/reviewAspect-output,< 1K
+Predicate,https://schema.org/reviewBody,1M - 10M
+Predicate,https://schema.org/reviewBody-input,< 1K
+Predicate,https://schema.org/reviewBody-output,< 1K
+Predicate,https://schema.org/reviewCount,1M - 10M
+Predicate,https://schema.org/reviewCount-input,< 1K
+Predicate,https://schema.org/reviewCount-output,< 1K
+Predicate,https://schema.org/reviewRating,1M - 10M
+Predicate,https://schema.org/reviewRating-input,< 1K
+Predicate,https://schema.org/reviewRating-output,< 1K
+Predicate,https://schema.org/reviewedBy,10K - 100K
+Predicate,https://schema.org/reviewedBy-input,< 1K
+Predicate,https://schema.org/reviewedBy-output,< 1K
+Predicate,https://schema.org/reviews,1K - 10K
+Predicate,https://schema.org/reviews-input,< 1K
+Predicate,https://schema.org/reviews-output,< 1K
+Predicate,https://schema.org/riskFactor,1K - 10K
+Predicate,https://schema.org/riskFactor-input,< 1K
+Predicate,https://schema.org/riskFactor-output,< 1K
+Predicate,https://schema.org/risks,< 1K
+Predicate,https://schema.org/risks-input,< 1K
+Predicate,https://schema.org/risks-output,< 1K
+Predicate,https://schema.org/roleName,1K - 10K
+Predicate,https://schema.org/roleName-input,< 1K
+Predicate,https://schema.org/roleName-output,< 1K
+Predicate,https://schema.org/roofLoad,< 1K
+Predicate,https://schema.org/roofLoad-input,< 1K
+Predicate,https://schema.org/roofLoad-output,< 1K
+Predicate,https://schema.org/rsvpResponse,< 1K
+Predicate,https://schema.org/rsvpResponse-input,< 1K
+Predicate,https://schema.org/rsvpResponse-output,< 1K
+Predicate,https://schema.org/runsTo,< 1K
+Predicate,https://schema.org/runsTo-input,< 1K
+Predicate,https://schema.org/runsTo-output,< 1K
+Predicate,https://schema.org/runtime,< 1K
+Predicate,https://schema.org/runtime-input,< 1K
+Predicate,https://schema.org/runtime-output,< 1K
+Predicate,https://schema.org/runtimePlatform,1K - 10K
+Predicate,https://schema.org/runtimePlatform-input,< 1K
+Predicate,https://schema.org/runtimePlatform-output,< 1K
+Predicate,https://schema.org/rxcui,< 1K
+Predicate,https://schema.org/rxcui-input,< 1K
+Predicate,https://schema.org/rxcui-output,< 1K
+Predicate,https://schema.org/safetyConsideration,< 1K
+Predicate,https://schema.org/safetyConsideration-input,< 1K
+Predicate,https://schema.org/safetyConsideration-output,< 1K
+Predicate,https://schema.org/salaryCurrency,1K - 10K
+Predicate,https://schema.org/salaryCurrency-input,< 1K
+Predicate,https://schema.org/salaryCurrency-output,< 1K
+Predicate,https://schema.org/salaryUponCompletion,< 1K
+Predicate,https://schema.org/salaryUponCompletion-input,< 1K
+Predicate,https://schema.org/salaryUponCompletion-output,< 1K
+Predicate,https://schema.org/sameAs,10M+
+Predicate,https://schema.org/sameAs-input,< 1K
+Predicate,https://schema.org/sameAs-output,< 1K
+Predicate,https://schema.org/sampleType,< 1K
+Predicate,https://schema.org/sampleType-input,< 1K
+Predicate,https://schema.org/sampleType-output,< 1K
+Predicate,https://schema.org/saturatedFatContent,10K - 100K
+Predicate,https://schema.org/saturatedFatContent-input,< 1K
+Predicate,https://schema.org/saturatedFatContent-output,< 1K
+Predicate,https://schema.org/scheduleTimezone,1K - 10K
+Predicate,https://schema.org/scheduleTimezone-input,< 1K
+Predicate,https://schema.org/scheduleTimezone-output,< 1K
+Predicate,https://schema.org/scheduledPaymentDate,< 1K
+Predicate,https://schema.org/scheduledPaymentDate-input,< 1K
+Predicate,https://schema.org/scheduledPaymentDate-output,< 1K
+Predicate,https://schema.org/scheduledTime,< 1K
+Predicate,https://schema.org/scheduledTime-input,< 1K
+Predicate,https://schema.org/scheduledTime-output,< 1K
+Predicate,https://schema.org/schemaVersion,< 1K
+Predicate,https://schema.org/schemaVersion-input,< 1K
+Predicate,https://schema.org/schemaVersion-output,< 1K
+Predicate,https://schema.org/schoolClosuresInfo,< 1K
+Predicate,https://schema.org/schoolClosuresInfo-input,< 1K
+Predicate,https://schema.org/schoolClosuresInfo-output,< 1K
+Predicate,https://schema.org/screenCount,< 1K
+Predicate,https://schema.org/screenCount-input,< 1K
+Predicate,https://schema.org/screenCount-output,< 1K
+Predicate,https://schema.org/screenshot,100K - 1M
+Predicate,https://schema.org/screenshot-input,< 1K
+Predicate,https://schema.org/screenshot-output,< 1K
+Predicate,https://schema.org/sdDatePublished,1K - 10K
+Predicate,https://schema.org/sdDatePublished-input,< 1K
+Predicate,https://schema.org/sdDatePublished-output,< 1K
+Predicate,https://schema.org/sdLicense,< 1K
+Predicate,https://schema.org/sdLicense-input,< 1K
+Predicate,https://schema.org/sdLicense-output,< 1K
+Predicate,https://schema.org/sdPublisher,1K - 10K
+Predicate,https://schema.org/sdPublisher-input,< 1K
+Predicate,https://schema.org/sdPublisher-output,< 1K
+Predicate,https://schema.org/season,1K - 10K
+Predicate,https://schema.org/season-input,< 1K
+Predicate,https://schema.org/season-output,< 1K
+Predicate,https://schema.org/seasonNumber,1K - 10K
+Predicate,https://schema.org/seasonNumber-input,< 1K
+Predicate,https://schema.org/seasonNumber-output,< 1K
+Predicate,https://schema.org/seasonalOverride,< 1K
+Predicate,https://schema.org/seasonalOverride-input,< 1K
+Predicate,https://schema.org/seasonalOverride-output,< 1K
+Predicate,https://schema.org/seasons,< 1K
+Predicate,https://schema.org/seasons-input,< 1K
+Predicate,https://schema.org/seasons-output,< 1K
+Predicate,https://schema.org/seatNumber,< 1K
+Predicate,https://schema.org/seatNumber-input,< 1K
+Predicate,https://schema.org/seatNumber-output,< 1K
+Predicate,https://schema.org/seatRow,< 1K
+Predicate,https://schema.org/seatRow-input,< 1K
+Predicate,https://schema.org/seatRow-output,< 1K
+Predicate,https://schema.org/seatSection,< 1K
+Predicate,https://schema.org/seatSection-input,< 1K
+Predicate,https://schema.org/seatSection-output,< 1K
+Predicate,https://schema.org/seatingCapacity,1K - 10K
+Predicate,https://schema.org/seatingCapacity-input,< 1K
+Predicate,https://schema.org/seatingCapacity-output,< 1K
+Predicate,https://schema.org/seatingType,< 1K
+Predicate,https://schema.org/seatingType-input,< 1K
+Predicate,https://schema.org/seatingType-output,< 1K
+Predicate,https://schema.org/secondaryPrevention,< 1K
+Predicate,https://schema.org/secondaryPrevention-input,< 1K
+Predicate,https://schema.org/secondaryPrevention-output,< 1K
+Predicate,https://schema.org/securityClearanceRequirement,< 1K
+Predicate,https://schema.org/securityClearanceRequirement-input,< 1K
+Predicate,https://schema.org/securityClearanceRequirement-output,< 1K
+Predicate,https://schema.org/securityScreening,< 1K
+Predicate,https://schema.org/securityScreening-input,< 1K
+Predicate,https://schema.org/securityScreening-output,< 1K
+Predicate,https://schema.org/seeks,1K - 10K
+Predicate,https://schema.org/seeks-input,< 1K
+Predicate,https://schema.org/seeks-output,< 1K
+Predicate,https://schema.org/seller,1M - 10M
+Predicate,https://schema.org/seller-input,< 1K
+Predicate,https://schema.org/seller-output,< 1K
+Predicate,https://schema.org/sender,< 1K
+Predicate,https://schema.org/sender-input,< 1K
+Predicate,https://schema.org/sender-output,< 1K
+Predicate,https://schema.org/sensoryRequirement,< 1K
+Predicate,https://schema.org/sensoryRequirement-input,< 1K
+Predicate,https://schema.org/sensoryRequirement-output,< 1K
+Predicate,https://schema.org/sensoryUnit,< 1K
+Predicate,https://schema.org/sensoryUnit-input,< 1K
+Predicate,https://schema.org/sensoryUnit-output,< 1K
+Predicate,https://schema.org/serialNumber,10K - 100K
+Predicate,https://schema.org/serialNumber-input,< 1K
+Predicate,https://schema.org/serialNumber-output,< 1K
+Predicate,https://schema.org/seriousAdverseOutcome,< 1K
+Predicate,https://schema.org/seriousAdverseOutcome-input,< 1K
+Predicate,https://schema.org/seriousAdverseOutcome-output,< 1K
+Predicate,https://schema.org/serverStatus,< 1K
+Predicate,https://schema.org/serverStatus-input,< 1K
+Predicate,https://schema.org/serverStatus-output,< 1K
+Predicate,https://schema.org/servesCuisine,100K - 1M
+Predicate,https://schema.org/servesCuisine-input,< 1K
+Predicate,https://schema.org/servesCuisine-output,< 1K
+Predicate,https://schema.org/serviceArea,10K - 100K
+Predicate,https://schema.org/serviceArea-input,< 1K
+Predicate,https://schema.org/serviceArea-output,< 1K
+Predicate,https://schema.org/serviceAudience,1K - 10K
+Predicate,https://schema.org/serviceAudience-input,< 1K
+Predicate,https://schema.org/serviceAudience-output,< 1K
+Predicate,https://schema.org/serviceLocation,10K - 100K
+Predicate,https://schema.org/serviceLocation-input,< 1K
+Predicate,https://schema.org/serviceLocation-output,< 1K
+Predicate,https://schema.org/serviceOperator,1K - 10K
+Predicate,https://schema.org/serviceOperator-input,< 1K
+Predicate,https://schema.org/serviceOperator-output,< 1K
+Predicate,https://schema.org/serviceOutput,10K - 100K
+Predicate,https://schema.org/serviceOutput-input,< 1K
+Predicate,https://schema.org/serviceOutput-output,< 1K
+Predicate,https://schema.org/servicePhone,10K - 100K
+Predicate,https://schema.org/servicePhone-input,< 1K
+Predicate,https://schema.org/servicePhone-output,< 1K
+Predicate,https://schema.org/servicePostalAddress,< 1K
+Predicate,https://schema.org/servicePostalAddress-input,< 1K
+Predicate,https://schema.org/servicePostalAddress-output,< 1K
+Predicate,https://schema.org/serviceSmsNumber,1K - 10K
+Predicate,https://schema.org/serviceSmsNumber-input,< 1K
+Predicate,https://schema.org/serviceSmsNumber-output,< 1K
+Predicate,https://schema.org/serviceType,1M - 10M
+Predicate,https://schema.org/serviceType-input,< 1K
+Predicate,https://schema.org/serviceType-output,< 1K
+Predicate,https://schema.org/serviceUrl,10K - 100K
+Predicate,https://schema.org/serviceUrl-input,< 1K
+Predicate,https://schema.org/serviceUrl-output,< 1K
+Predicate,https://schema.org/servingSize,10K - 100K
+Predicate,https://schema.org/servingSize-input,< 1K
+Predicate,https://schema.org/servingSize-output,< 1K
+Predicate,https://schema.org/sha256,< 1K
+Predicate,https://schema.org/sha256-input,< 1K
+Predicate,https://schema.org/sha256-output,< 1K
+Predicate,https://schema.org/sharedContent,1K - 10K
+Predicate,https://schema.org/sharedContent-input,< 1K
+Predicate,https://schema.org/sharedContent-output,< 1K
+Predicate,https://schema.org/shippingConditions,10K - 100K
+Predicate,https://schema.org/shippingConditions-input,< 1K
+Predicate,https://schema.org/shippingConditions-output,< 1K
+Predicate,https://schema.org/shippingDestination,100K - 1M
+Predicate,https://schema.org/shippingDestination-input,< 1K
+Predicate,https://schema.org/shippingDestination-output,< 1K
+Predicate,https://schema.org/shippingDetails,100K - 1M
+Predicate,https://schema.org/shippingDetails-input,< 1K
+Predicate,https://schema.org/shippingDetails-output,< 1K
+Predicate,https://schema.org/shippingLabel,1K - 10K
+Predicate,https://schema.org/shippingLabel-input,< 1K
+Predicate,https://schema.org/shippingLabel-output,< 1K
+Predicate,https://schema.org/shippingOrigin,10K - 100K
+Predicate,https://schema.org/shippingOrigin-input,< 1K
+Predicate,https://schema.org/shippingOrigin-output,< 1K
+Predicate,https://schema.org/shippingRate,100K - 1M
+Predicate,https://schema.org/shippingRate-input,< 1K
+Predicate,https://schema.org/shippingRate-output,< 1K
+Predicate,https://schema.org/shippingSettingsLink,1K - 10K
+Predicate,https://schema.org/shippingSettingsLink-input,< 1K
+Predicate,https://schema.org/shippingSettingsLink-output,< 1K
+Predicate,https://schema.org/sibling,< 1K
+Predicate,https://schema.org/sibling-input,< 1K
+Predicate,https://schema.org/sibling-output,< 1K
+Predicate,https://schema.org/siblings,< 1K
+Predicate,https://schema.org/siblings-input,< 1K
+Predicate,https://schema.org/siblings-output,< 1K
+Predicate,https://schema.org/signDetected,< 1K
+Predicate,https://schema.org/signDetected-input,< 1K
+Predicate,https://schema.org/signDetected-output,< 1K
+Predicate,https://schema.org/signOrSymptom,1K - 10K
+Predicate,https://schema.org/signOrSymptom-input,< 1K
+Predicate,https://schema.org/signOrSymptom-output,< 1K
+Predicate,https://schema.org/significance,< 1K
+Predicate,https://schema.org/significance-input,< 1K
+Predicate,https://schema.org/significance-output,< 1K
+Predicate,https://schema.org/significantLink,10K - 100K
+Predicate,https://schema.org/significantLink-input,< 1K
+Predicate,https://schema.org/significantLink-output,< 1K
+Predicate,https://schema.org/significantLinks,1K - 10K
+Predicate,https://schema.org/significantLinks-input,< 1K
+Predicate,https://schema.org/significantLinks-output,< 1K
+Predicate,https://schema.org/size,10K - 100K
+Predicate,https://schema.org/size-input,< 1K
+Predicate,https://schema.org/size-output,< 1K
+Predicate,https://schema.org/sizeGroup,< 1K
+Predicate,https://schema.org/sizeGroup-input,< 1K
+Predicate,https://schema.org/sizeGroup-output,< 1K
+Predicate,https://schema.org/sizeSystem,< 1K
+Predicate,https://schema.org/sizeSystem-input,< 1K
+Predicate,https://schema.org/sizeSystem-output,< 1K
+Predicate,https://schema.org/skills,10K - 100K
+Predicate,https://schema.org/skills-input,< 1K
+Predicate,https://schema.org/skills-output,< 1K
+Predicate,https://schema.org/sku,1M - 10M
+Predicate,https://schema.org/sku-input,< 1K
+Predicate,https://schema.org/sku-output,< 1K
+Predicate,https://schema.org/slogan,100K - 1M
+Predicate,https://schema.org/slogan-input,< 1K
+Predicate,https://schema.org/slogan-output,< 1K
+Predicate,https://schema.org/smiles,< 1K
+Predicate,https://schema.org/smiles-input,< 1K
+Predicate,https://schema.org/smiles-output,< 1K
+Predicate,https://schema.org/smokingAllowed,10K - 100K
+Predicate,https://schema.org/smokingAllowed-input,< 1K
+Predicate,https://schema.org/smokingAllowed-output,< 1K
+Predicate,https://schema.org/sodiumContent,10K - 100K
+Predicate,https://schema.org/sodiumContent-input,< 1K
+Predicate,https://schema.org/sodiumContent-output,< 1K
+Predicate,https://schema.org/softwareAddOn,< 1K
+Predicate,https://schema.org/softwareAddOn-input,< 1K
+Predicate,https://schema.org/softwareAddOn-output,< 1K
+Predicate,https://schema.org/softwareHelp,10K - 100K
+Predicate,https://schema.org/softwareHelp-input,< 1K
+Predicate,https://schema.org/softwareHelp-output,< 1K
+Predicate,https://schema.org/softwareRequirements,10K - 100K
+Predicate,https://schema.org/softwareRequirements-input,< 1K
+Predicate,https://schema.org/softwareRequirements-output,< 1K
+Predicate,https://schema.org/softwareVersion,100K - 1M
+Predicate,https://schema.org/softwareVersion-input,< 1K
+Predicate,https://schema.org/softwareVersion-output,< 1K
+Predicate,https://schema.org/source,1K - 10K
+Predicate,https://schema.org/source-input,< 1K
+Predicate,https://schema.org/source-output,< 1K
+Predicate,https://schema.org/sourceOrganization,10K - 100K
+Predicate,https://schema.org/sourceOrganization-input,< 1K
+Predicate,https://schema.org/sourceOrganization-output,< 1K
+Predicate,https://schema.org/sourcedFrom,< 1K
+Predicate,https://schema.org/sourcedFrom-input,< 1K
+Predicate,https://schema.org/sourcedFrom-output,< 1K
+Predicate,https://schema.org/spatial,1K - 10K
+Predicate,https://schema.org/spatial-input,< 1K
+Predicate,https://schema.org/spatial-output,< 1K
+Predicate,https://schema.org/spatialCoverage,10K - 100K
+Predicate,https://schema.org/spatialCoverage-input,< 1K
+Predicate,https://schema.org/spatialCoverage-output,< 1K
+Predicate,https://schema.org/speakable,100K - 1M
+Predicate,https://schema.org/speakable-input,< 1K
+Predicate,https://schema.org/speakable-output,< 1K
+Predicate,https://schema.org/specialCommitments,1K - 10K
+Predicate,https://schema.org/specialCommitments-input,< 1K
+Predicate,https://schema.org/specialCommitments-output,< 1K
+Predicate,https://schema.org/specialOpeningHoursSpecification,1K - 10K
+Predicate,https://schema.org/specialOpeningHoursSpecification-input,< 1K
+Predicate,https://schema.org/specialOpeningHoursSpecification-output,< 1K
+Predicate,https://schema.org/specialty,10K - 100K
+Predicate,https://schema.org/specialty-input,< 1K
+Predicate,https://schema.org/specialty-output,< 1K
+Predicate,https://schema.org/speechToTextMarkup,< 1K
+Predicate,https://schema.org/speechToTextMarkup-input,< 1K
+Predicate,https://schema.org/speechToTextMarkup-output,< 1K
+Predicate,https://schema.org/speed,1K - 10K
+Predicate,https://schema.org/speed-input,< 1K
+Predicate,https://schema.org/speed-output,< 1K
+Predicate,https://schema.org/spokenByCharacter,1K - 10K
+Predicate,https://schema.org/spokenByCharacter-input,< 1K
+Predicate,https://schema.org/spokenByCharacter-output,< 1K
+Predicate,https://schema.org/sponsor,10K - 100K
+Predicate,https://schema.org/sponsor-input,< 1K
+Predicate,https://schema.org/sponsor-output,< 1K
+Predicate,https://schema.org/sport,10K - 100K
+Predicate,https://schema.org/sport-input,< 1K
+Predicate,https://schema.org/sport-output,< 1K
+Predicate,https://schema.org/sportsActivityLocation,< 1K
+Predicate,https://schema.org/sportsActivityLocation-input,< 1K
+Predicate,https://schema.org/sportsActivityLocation-output,< 1K
+Predicate,https://schema.org/sportsEvent,< 1K
+Predicate,https://schema.org/sportsEvent-input,< 1K
+Predicate,https://schema.org/sportsEvent-output,< 1K
+Predicate,https://schema.org/sportsTeam,< 1K
+Predicate,https://schema.org/sportsTeam-input,< 1K
+Predicate,https://schema.org/sportsTeam-output,< 1K
+Predicate,https://schema.org/spouse,1K - 10K
+Predicate,https://schema.org/spouse-input,< 1K
+Predicate,https://schema.org/spouse-output,< 1K
+Predicate,https://schema.org/stage,< 1K
+Predicate,https://schema.org/stage-input,< 1K
+Predicate,https://schema.org/stage-output,< 1K
+Predicate,https://schema.org/stageAsNumber,< 1K
+Predicate,https://schema.org/stageAsNumber-input,< 1K
+Predicate,https://schema.org/stageAsNumber-output,< 1K
+Predicate,https://schema.org/starRating,10K - 100K
+Predicate,https://schema.org/starRating-input,< 1K
+Predicate,https://schema.org/starRating-output,< 1K
+Predicate,https://schema.org/startDate,100K - 1M
+Predicate,https://schema.org/startDate-input,< 1K
+Predicate,https://schema.org/startDate-output,< 1K
+Predicate,https://schema.org/startOffset,10K - 100K
+Predicate,https://schema.org/startOffset-input,10K - 100K
+Predicate,https://schema.org/startOffset-output,< 1K
+Predicate,https://schema.org/startTime,1K - 10K
+Predicate,https://schema.org/startTime-input,< 1K
+Predicate,https://schema.org/startTime-output,< 1K
+Predicate,https://schema.org/statType,< 1K
+Predicate,https://schema.org/statType-input,< 1K
+Predicate,https://schema.org/statType-output,< 1K
+Predicate,https://schema.org/status,1K - 10K
+Predicate,https://schema.org/status-input,< 1K
+Predicate,https://schema.org/status-output,< 1K
+Predicate,https://schema.org/steeringPosition,1K - 10K
+Predicate,https://schema.org/steeringPosition-input,< 1K
+Predicate,https://schema.org/steeringPosition-output,< 1K
+Predicate,https://schema.org/step,100K - 1M
+Predicate,https://schema.org/step-input,< 1K
+Predicate,https://schema.org/step-output,< 1K
+Predicate,https://schema.org/stepValue,< 1K
+Predicate,https://schema.org/stepValue-input,< 1K
+Predicate,https://schema.org/stepValue-output,< 1K
+Predicate,https://schema.org/steps,< 1K
+Predicate,https://schema.org/steps-input,< 1K
+Predicate,https://schema.org/steps-output,< 1K
+Predicate,https://schema.org/storageRequirements,10K - 100K
+Predicate,https://schema.org/storageRequirements-input,< 1K
+Predicate,https://schema.org/storageRequirements-output,< 1K
+Predicate,https://schema.org/streetAddress,1M - 10M
+Predicate,https://schema.org/streetAddress-input,< 1K
+Predicate,https://schema.org/streetAddress-output,< 1K
+Predicate,https://schema.org/strengthUnit,< 1K
+Predicate,https://schema.org/strengthUnit-input,< 1K
+Predicate,https://schema.org/strengthUnit-output,< 1K
+Predicate,https://schema.org/strengthValue,< 1K
+Predicate,https://schema.org/strengthValue-input,< 1K
+Predicate,https://schema.org/strengthValue-output,< 1K
+Predicate,https://schema.org/structuralClass,< 1K
+Predicate,https://schema.org/structuralClass-input,< 1K
+Predicate,https://schema.org/structuralClass-output,< 1K
+Predicate,https://schema.org/study,< 1K
+Predicate,https://schema.org/study-input,< 1K
+Predicate,https://schema.org/study-output,< 1K
+Predicate,https://schema.org/studyDesign,< 1K
+Predicate,https://schema.org/studyDesign-input,< 1K
+Predicate,https://schema.org/studyDesign-output,< 1K
+Predicate,https://schema.org/studyLocation,< 1K
+Predicate,https://schema.org/studyLocation-input,< 1K
+Predicate,https://schema.org/studyLocation-output,< 1K
+Predicate,https://schema.org/studySubject,< 1K
+Predicate,https://schema.org/studySubject-input,< 1K
+Predicate,https://schema.org/studySubject-output,< 1K
+Predicate,https://schema.org/stupidProperty,< 1K
+Predicate,https://schema.org/stupidProperty-input,< 1K
+Predicate,https://schema.org/stupidProperty-output,< 1K
+Predicate,https://schema.org/subEvent,1K - 10K
+Predicate,https://schema.org/subEvent-input,< 1K
+Predicate,https://schema.org/subEvent-output,< 1K
+Predicate,https://schema.org/subEvents,< 1K
+Predicate,https://schema.org/subEvents-input,< 1K
+Predicate,https://schema.org/subEvents-output,< 1K
+Predicate,https://schema.org/subOrganization,10K - 100K
+Predicate,https://schema.org/subOrganization-input,< 1K
+Predicate,https://schema.org/subOrganization-output,< 1K
+Predicate,https://schema.org/subReservation,< 1K
+Predicate,https://schema.org/subReservation-input,< 1K
+Predicate,https://schema.org/subReservation-output,< 1K
+Predicate,https://schema.org/subStageSuffix,< 1K
+Predicate,https://schema.org/subStageSuffix-input,< 1K
+Predicate,https://schema.org/subStageSuffix-output,< 1K
+Predicate,https://schema.org/subStructure,< 1K
+Predicate,https://schema.org/subStructure-input,< 1K
+Predicate,https://schema.org/subStructure-output,< 1K
+Predicate,https://schema.org/subTest,< 1K
+Predicate,https://schema.org/subTest-input,< 1K
+Predicate,https://schema.org/subTest-output,< 1K
+Predicate,https://schema.org/subTrip,< 1K
+Predicate,https://schema.org/subTrip-input,< 1K
+Predicate,https://schema.org/subTrip-output,< 1K
+Predicate,https://schema.org/subjectOf,100K - 1M
+Predicate,https://schema.org/subjectOf-input,< 1K
+Predicate,https://schema.org/subjectOf-output,< 1K
+Predicate,https://schema.org/subtitleLanguage,< 1K
+Predicate,https://schema.org/subtitleLanguage-input,< 1K
+Predicate,https://schema.org/subtitleLanguage-output,< 1K
+Predicate,https://schema.org/successorOf,< 1K
+Predicate,https://schema.org/successorOf-input,< 1K
+Predicate,https://schema.org/successorOf-output,< 1K
+Predicate,https://schema.org/sugarContent,10K - 100K
+Predicate,https://schema.org/sugarContent-input,< 1K
+Predicate,https://schema.org/sugarContent-output,< 1K
+Predicate,https://schema.org/suggestedAge,1K - 10K
+Predicate,https://schema.org/suggestedAge-input,< 1K
+Predicate,https://schema.org/suggestedAge-output,< 1K
+Predicate,https://schema.org/suggestedAnswer,10K - 100K
+Predicate,https://schema.org/suggestedAnswer-input,< 1K
+Predicate,https://schema.org/suggestedAnswer-output,< 1K
+Predicate,https://schema.org/suggestedGender,10K - 100K
+Predicate,https://schema.org/suggestedGender-input,< 1K
+Predicate,https://schema.org/suggestedGender-output,< 1K
+Predicate,https://schema.org/suggestedMaxAge,1K - 10K
+Predicate,https://schema.org/suggestedMaxAge-input,< 1K
+Predicate,https://schema.org/suggestedMaxAge-output,< 1K
+Predicate,https://schema.org/suggestedMeasurement,< 1K
+Predicate,https://schema.org/suggestedMeasurement-input,< 1K
+Predicate,https://schema.org/suggestedMeasurement-output,< 1K
+Predicate,https://schema.org/suggestedMinAge,10K - 100K
+Predicate,https://schema.org/suggestedMinAge-input,< 1K
+Predicate,https://schema.org/suggestedMinAge-output,< 1K
+Predicate,https://schema.org/suitableForDiet,10K - 100K
+Predicate,https://schema.org/suitableForDiet-input,< 1K
+Predicate,https://schema.org/suitableForDiet-output,< 1K
+Predicate,https://schema.org/superEvent,1K - 10K
+Predicate,https://schema.org/superEvent-input,< 1K
+Predicate,https://schema.org/superEvent-output,< 1K
+Predicate,https://schema.org/supersededBy,1K - 10K
+Predicate,https://schema.org/supersededBy-input,< 1K
+Predicate,https://schema.org/supersededBy-output,< 1K
+Predicate,https://schema.org/supply,10K - 100K
+Predicate,https://schema.org/supply-input,< 1K
+Predicate,https://schema.org/supply-output,< 1K
+Predicate,https://schema.org/supplyTo,< 1K
+Predicate,https://schema.org/supplyTo-input,< 1K
+Predicate,https://schema.org/supplyTo-output,< 1K
+Predicate,https://schema.org/supportingData,< 1K
+Predicate,https://schema.org/supportingData-input,< 1K
+Predicate,https://schema.org/supportingData-output,< 1K
+Predicate,https://schema.org/surface,< 1K
+Predicate,https://schema.org/surface-input,< 1K
+Predicate,https://schema.org/surface-output,< 1K
+Predicate,https://schema.org/syllabusSections,1K - 10K
+Predicate,https://schema.org/syllabusSections-input,< 1K
+Predicate,https://schema.org/syllabusSections-output,< 1K
+Predicate,https://schema.org/target,10M+
+Predicate,https://schema.org/target-input,< 1K
+Predicate,https://schema.org/target-output,< 1K
+Predicate,https://schema.org/targetCollection,< 1K
+Predicate,https://schema.org/targetCollection-input,< 1K
+Predicate,https://schema.org/targetCollection-output,< 1K
+Predicate,https://schema.org/targetDescription,< 1K
+Predicate,https://schema.org/targetDescription-input,< 1K
+Predicate,https://schema.org/targetDescription-output,< 1K
+Predicate,https://schema.org/targetName,1K - 10K
+Predicate,https://schema.org/targetName-input,< 1K
+Predicate,https://schema.org/targetName-output,< 1K
+Predicate,https://schema.org/targetPlatform,< 1K
+Predicate,https://schema.org/targetPlatform-input,< 1K
+Predicate,https://schema.org/targetPlatform-output,< 1K
+Predicate,https://schema.org/targetPopulation,< 1K
+Predicate,https://schema.org/targetPopulation-input,< 1K
+Predicate,https://schema.org/targetPopulation-output,< 1K
+Predicate,https://schema.org/targetProduct,< 1K
+Predicate,https://schema.org/targetProduct-input,< 1K
+Predicate,https://schema.org/targetProduct-output,< 1K
+Predicate,https://schema.org/targetUrl,< 1K
+Predicate,https://schema.org/targetUrl-input,< 1K
+Predicate,https://schema.org/targetUrl-output,< 1K
+Predicate,https://schema.org/taxID,100K - 1M
+Predicate,https://schema.org/taxID-input,< 1K
+Predicate,https://schema.org/taxID-output,< 1K
+Predicate,https://schema.org/taxonRank,< 1K
+Predicate,https://schema.org/taxonRank-input,< 1K
+Predicate,https://schema.org/taxonRank-output,< 1K
+Predicate,https://schema.org/taxonomicRange,< 1K
+Predicate,https://schema.org/taxonomicRange-input,< 1K
+Predicate,https://schema.org/taxonomicRange-output,< 1K
+Predicate,https://schema.org/teaches,10K - 100K
+Predicate,https://schema.org/teaches-input,< 1K
+Predicate,https://schema.org/teaches-output,< 1K
+Predicate,https://schema.org/telephone,1M - 10M
+Predicate,https://schema.org/telephone-input,< 1K
+Predicate,https://schema.org/telephone-output,< 1K
+Predicate,https://schema.org/temporal,< 1K
+Predicate,https://schema.org/temporal-input,< 1K
+Predicate,https://schema.org/temporal-output,< 1K
+Predicate,https://schema.org/temporalCoverage,10K - 100K
+Predicate,https://schema.org/temporalCoverage-input,< 1K
+Predicate,https://schema.org/temporalCoverage-output,< 1K
+Predicate,https://schema.org/termCode,1K - 10K
+Predicate,https://schema.org/termCode-input,< 1K
+Predicate,https://schema.org/termCode-output,< 1K
+Predicate,https://schema.org/termDuration,< 1K
+Predicate,https://schema.org/termDuration-input,< 1K
+Predicate,https://schema.org/termDuration-output,< 1K
+Predicate,https://schema.org/termsOfService,10K - 100K
+Predicate,https://schema.org/termsOfService-input,< 1K
+Predicate,https://schema.org/termsOfService-output,< 1K
+Predicate,https://schema.org/termsPerYear,< 1K
+Predicate,https://schema.org/termsPerYear-input,< 1K
+Predicate,https://schema.org/termsPerYear-output,< 1K
+Predicate,https://schema.org/text,1M - 10M
+Predicate,https://schema.org/text-input,< 1K
+Predicate,https://schema.org/text-output,< 1K
+Predicate,https://schema.org/textValue,< 1K
+Predicate,https://schema.org/textValue-input,< 1K
+Predicate,https://schema.org/textValue-output,< 1K
+Predicate,https://schema.org/thumbnail,100K - 1M
+Predicate,https://schema.org/thumbnail-input,< 1K
+Predicate,https://schema.org/thumbnail-output,< 1K
+Predicate,https://schema.org/thumbnailUrl,10M+
+Predicate,https://schema.org/thumbnailUrl-input,< 1K
+Predicate,https://schema.org/thumbnailUrl-output,< 1K
+Predicate,https://schema.org/tickerSymbol,1K - 10K
+Predicate,https://schema.org/tickerSymbol-input,< 1K
+Predicate,https://schema.org/tickerSymbol-output,< 1K
+Predicate,https://schema.org/ticketNumber,< 1K
+Predicate,https://schema.org/ticketNumber-input,< 1K
+Predicate,https://schema.org/ticketNumber-output,< 1K
+Predicate,https://schema.org/ticketToken,< 1K
+Predicate,https://schema.org/ticketToken-input,< 1K
+Predicate,https://schema.org/ticketToken-output,< 1K
+Predicate,https://schema.org/ticketedSeat,< 1K
+Predicate,https://schema.org/ticketedSeat-input,< 1K
+Predicate,https://schema.org/ticketedSeat-output,< 1K
+Predicate,https://schema.org/timeOfDay,< 1K
+Predicate,https://schema.org/timeOfDay-input,< 1K
+Predicate,https://schema.org/timeOfDay-output,< 1K
+Predicate,https://schema.org/timeRequired,100K - 1M
+Predicate,https://schema.org/timeRequired-input,< 1K
+Predicate,https://schema.org/timeRequired-output,< 1K
+Predicate,https://schema.org/timeToComplete,1K - 10K
+Predicate,https://schema.org/timeToComplete-input,< 1K
+Predicate,https://schema.org/timeToComplete-output,< 1K
+Predicate,https://schema.org/timestamp,1K - 10K
+Predicate,https://schema.org/timestamp-input,< 1K
+Predicate,https://schema.org/timestamp-output,< 1K
+Predicate,https://schema.org/tissueSample,< 1K
+Predicate,https://schema.org/tissueSample-input,< 1K
+Predicate,https://schema.org/tissueSample-output,< 1K
+Predicate,https://schema.org/title,100K - 1M
+Predicate,https://schema.org/title-input,< 1K
+Predicate,https://schema.org/title-output,< 1K
+Predicate,https://schema.org/titleEIDR,< 1K
+Predicate,https://schema.org/titleEIDR-input,< 1K
+Predicate,https://schema.org/titleEIDR-output,< 1K
+Predicate,https://schema.org/toLocation,1K - 10K
+Predicate,https://schema.org/toLocation-input,< 1K
+Predicate,https://schema.org/toLocation-output,< 1K
+Predicate,https://schema.org/toRecipient,< 1K
+Predicate,https://schema.org/toRecipient-input,< 1K
+Predicate,https://schema.org/toRecipient-output,< 1K
+Predicate,https://schema.org/tocContinuation,< 1K
+Predicate,https://schema.org/tocContinuation-input,< 1K
+Predicate,https://schema.org/tocContinuation-output,< 1K
+Predicate,https://schema.org/tocEntry,< 1K
+Predicate,https://schema.org/tocEntry-input,< 1K
+Predicate,https://schema.org/tocEntry-output,< 1K
+Predicate,https://schema.org/tongueWeight,< 1K
+Predicate,https://schema.org/tongueWeight-input,< 1K
+Predicate,https://schema.org/tongueWeight-output,< 1K
+Predicate,https://schema.org/tool,10K - 100K
+Predicate,https://schema.org/tool-input,< 1K
+Predicate,https://schema.org/tool-output,< 1K
+Predicate,https://schema.org/torque,1K - 10K
+Predicate,https://schema.org/torque-input,< 1K
+Predicate,https://schema.org/torque-output,< 1K
+Predicate,https://schema.org/totalHistoricalEnrollment,< 1K
+Predicate,https://schema.org/totalHistoricalEnrollment-input,< 1K
+Predicate,https://schema.org/totalHistoricalEnrollment-output,< 1K
+Predicate,https://schema.org/totalJobOpenings,1K - 10K
+Predicate,https://schema.org/totalJobOpenings-input,< 1K
+Predicate,https://schema.org/totalJobOpenings-output,< 1K
+Predicate,https://schema.org/totalPaymentDue,< 1K
+Predicate,https://schema.org/totalPaymentDue-input,< 1K
+Predicate,https://schema.org/totalPaymentDue-output,< 1K
+Predicate,https://schema.org/totalPrice,< 1K
+Predicate,https://schema.org/totalPrice-input,< 1K
+Predicate,https://schema.org/totalPrice-output,< 1K
+Predicate,https://schema.org/totalTime,100K - 1M
+Predicate,https://schema.org/totalTime-input,< 1K
+Predicate,https://schema.org/totalTime-output,< 1K
+Predicate,https://schema.org/tourBookingPage,10K - 100K
+Predicate,https://schema.org/tourBookingPage-input,< 1K
+Predicate,https://schema.org/tourBookingPage-output,< 1K
+Predicate,https://schema.org/touristType,10K - 100K
+Predicate,https://schema.org/touristType-input,< 1K
+Predicate,https://schema.org/touristType-output,< 1K
+Predicate,https://schema.org/track,10K - 100K
+Predicate,https://schema.org/track-input,< 1K
+Predicate,https://schema.org/track-output,< 1K
+Predicate,https://schema.org/trackingNumber,< 1K
+Predicate,https://schema.org/trackingNumber-input,< 1K
+Predicate,https://schema.org/trackingNumber-output,< 1K
+Predicate,https://schema.org/trackingUrl,< 1K
+Predicate,https://schema.org/trackingUrl-input,< 1K
+Predicate,https://schema.org/trackingUrl-output,< 1K
+Predicate,https://schema.org/tracks,< 1K
+Predicate,https://schema.org/tracks-input,< 1K
+Predicate,https://schema.org/tracks-output,< 1K
+Predicate,https://schema.org/trailer,1K - 10K
+Predicate,https://schema.org/trailer-input,< 1K
+Predicate,https://schema.org/trailer-output,< 1K
+Predicate,https://schema.org/trailerWeight,< 1K
+Predicate,https://schema.org/trailerWeight-input,< 1K
+Predicate,https://schema.org/trailerWeight-output,< 1K
+Predicate,https://schema.org/trainName,< 1K
+Predicate,https://schema.org/trainName-input,< 1K
+Predicate,https://schema.org/trainName-output,< 1K
+Predicate,https://schema.org/trainNumber,< 1K
+Predicate,https://schema.org/trainNumber-input,< 1K
+Predicate,https://schema.org/trainNumber-output,< 1K
+Predicate,https://schema.org/trainingSalary,< 1K
+Predicate,https://schema.org/trainingSalary-input,< 1K
+Predicate,https://schema.org/trainingSalary-output,< 1K
+Predicate,https://schema.org/transFatContent,10K - 100K
+Predicate,https://schema.org/transFatContent-input,< 1K
+Predicate,https://schema.org/transFatContent-output,< 1K
+Predicate,https://schema.org/transcript,100K - 1M
+Predicate,https://schema.org/transcript-input,< 1K
+Predicate,https://schema.org/transcript-output,< 1K
+Predicate,https://schema.org/transitTime,100K - 1M
+Predicate,https://schema.org/transitTime-input,< 1K
+Predicate,https://schema.org/transitTime-output,< 1K
+Predicate,https://schema.org/transitTimeLabel,< 1K
+Predicate,https://schema.org/transitTimeLabel-input,< 1K
+Predicate,https://schema.org/transitTimeLabel-output,< 1K
+Predicate,https://schema.org/translationOfWork,1K - 10K
+Predicate,https://schema.org/translationOfWork-input,< 1K
+Predicate,https://schema.org/translationOfWork-output,< 1K
+Predicate,https://schema.org/translator,1K - 10K
+Predicate,https://schema.org/translator-input,< 1K
+Predicate,https://schema.org/translator-output,< 1K
+Predicate,https://schema.org/transmissionMethod,< 1K
+Predicate,https://schema.org/transmissionMethod-input,< 1K
+Predicate,https://schema.org/transmissionMethod-output,< 1K
+Predicate,https://schema.org/travelBans,< 1K
+Predicate,https://schema.org/travelBans-input,< 1K
+Predicate,https://schema.org/travelBans-output,< 1K
+Predicate,https://schema.org/trialDesign,< 1K
+Predicate,https://schema.org/trialDesign-input,< 1K
+Predicate,https://schema.org/trialDesign-output,< 1K
+Predicate,https://schema.org/tributary,< 1K
+Predicate,https://schema.org/tributary-input,< 1K
+Predicate,https://schema.org/tributary-output,< 1K
+Predicate,https://schema.org/tripOrigin,< 1K
+Predicate,https://schema.org/tripOrigin-input,< 1K
+Predicate,https://schema.org/tripOrigin-output,< 1K
+Predicate,https://schema.org/typeOfBed,10K - 100K
+Predicate,https://schema.org/typeOfBed-input,< 1K
+Predicate,https://schema.org/typeOfBed-output,< 1K
+Predicate,https://schema.org/typeOfGood,< 1K
+Predicate,https://schema.org/typeOfGood-input,< 1K
+Predicate,https://schema.org/typeOfGood-output,< 1K
+Predicate,https://schema.org/typicalAgeRange,10K - 100K
+Predicate,https://schema.org/typicalAgeRange-input,< 1K
+Predicate,https://schema.org/typicalAgeRange-output,< 1K
+Predicate,https://schema.org/typicalCreditsPerTerm,< 1K
+Predicate,https://schema.org/typicalCreditsPerTerm-input,< 1K
+Predicate,https://schema.org/typicalCreditsPerTerm-output,< 1K
+Predicate,https://schema.org/typicalTest,1K - 10K
+Predicate,https://schema.org/typicalTest-input,< 1K
+Predicate,https://schema.org/typicalTest-output,< 1K
+Predicate,https://schema.org/underName,< 1K
+Predicate,https://schema.org/underName-input,< 1K
+Predicate,https://schema.org/underName-output,< 1K
+Predicate,https://schema.org/unitCode,1M - 10M
+Predicate,https://schema.org/unitCode-input,< 1K
+Predicate,https://schema.org/unitCode-output,< 1K
+Predicate,https://schema.org/unitText,100K - 1M
+Predicate,https://schema.org/unitText-input,< 1K
+Predicate,https://schema.org/unitText-output,< 1K
+Predicate,https://schema.org/unnamedSourcesPolicy,1K - 10K
+Predicate,https://schema.org/unnamedSourcesPolicy-input,< 1K
+Predicate,https://schema.org/unnamedSourcesPolicy-output,< 1K
+Predicate,https://schema.org/unsaturatedFatContent,10K - 100K
+Predicate,https://schema.org/unsaturatedFatContent-input,< 1K
+Predicate,https://schema.org/unsaturatedFatContent-output,< 1K
+Predicate,https://schema.org/uploadDate,1M - 10M
+Predicate,https://schema.org/uploadDate-input,< 1K
+Predicate,https://schema.org/uploadDate-output,< 1K
+Predicate,https://schema.org/upvoteCount,10K - 100K
+Predicate,https://schema.org/upvoteCount-input,< 1K
+Predicate,https://schema.org/upvoteCount-output,< 1K
+Predicate,https://schema.org/url,10M+
+Predicate,https://schema.org/url-input,< 1K
+Predicate,https://schema.org/url-output,< 1K
+Predicate,https://schema.org/urlTemplate,10M+
+Predicate,https://schema.org/urlTemplate-input,< 1K
+Predicate,https://schema.org/urlTemplate-output,< 1K
+Predicate,https://schema.org/usNPI,< 1K
+Predicate,https://schema.org/usNPI-input,< 1K
+Predicate,https://schema.org/usNPI-output,< 1K
+Predicate,https://schema.org/usageInfo,1K - 10K
+Predicate,https://schema.org/usageInfo-input,< 1K
+Predicate,https://schema.org/usageInfo-output,< 1K
+Predicate,https://schema.org/usedToDiagnose,1K - 10K
+Predicate,https://schema.org/usedToDiagnose-input,< 1K
+Predicate,https://schema.org/usedToDiagnose-output,< 1K
+Predicate,https://schema.org/userInteractionCount,100K - 1M
+Predicate,https://schema.org/userInteractionCount-input,< 1K
+Predicate,https://schema.org/userInteractionCount-output,< 1K
+Predicate,https://schema.org/usesDevice,< 1K
+Predicate,https://schema.org/usesDevice-input,< 1K
+Predicate,https://schema.org/usesDevice-output,< 1K
+Predicate,https://schema.org/usesHealthPlanIdStandard,< 1K
+Predicate,https://schema.org/usesHealthPlanIdStandard-input,< 1K
+Predicate,https://schema.org/usesHealthPlanIdStandard-output,< 1K
+Predicate,https://schema.org/utterances,< 1K
+Predicate,https://schema.org/utterances-input,< 1K
+Predicate,https://schema.org/utterances-output,< 1K
+Predicate,https://schema.org/validFor,< 1K
+Predicate,https://schema.org/validFor-input,< 1K
+Predicate,https://schema.org/validFor-output,< 1K
+Predicate,https://schema.org/validForMemberTier,< 1K
+Predicate,https://schema.org/validForMemberTier-input,< 1K
+Predicate,https://schema.org/validForMemberTier-output,< 1K
+Predicate,https://schema.org/validFrom,100K - 1M
+Predicate,https://schema.org/validFrom-input,< 1K
+Predicate,https://schema.org/validFrom-output,< 1K
+Predicate,https://schema.org/validIn,1K - 10K
+Predicate,https://schema.org/validIn-input,< 1K
+Predicate,https://schema.org/validIn-output,< 1K
+Predicate,https://schema.org/validThrough,1M - 10M
+Predicate,https://schema.org/validThrough-input,< 1K
+Predicate,https://schema.org/validThrough-output,< 1K
+Predicate,https://schema.org/validUntil,1K - 10K
+Predicate,https://schema.org/validUntil-input,< 1K
+Predicate,https://schema.org/validUntil-output,< 1K
+Predicate,https://schema.org/value,1M - 10M
+Predicate,https://schema.org/value-input,< 1K
+Predicate,https://schema.org/value-output,< 1K
+Predicate,https://schema.org/valueAddedTaxIncluded,1M - 10M
+Predicate,https://schema.org/valueAddedTaxIncluded-input,< 1K
+Predicate,https://schema.org/valueAddedTaxIncluded-output,< 1K
+Predicate,https://schema.org/valueMaxLength,1K - 10K
+Predicate,https://schema.org/valueMaxLength-input,< 1K
+Predicate,https://schema.org/valueMaxLength-output,< 1K
+Predicate,https://schema.org/valueMinLength,< 1K
+Predicate,https://schema.org/valueMinLength-input,< 1K
+Predicate,https://schema.org/valueMinLength-output,< 1K
+Predicate,https://schema.org/valueName,10M+
+Predicate,https://schema.org/valueName-input,< 1K
+Predicate,https://schema.org/valueName-output,< 1K
+Predicate,https://schema.org/valuePattern,< 1K
+Predicate,https://schema.org/valuePattern-input,< 1K
+Predicate,https://schema.org/valuePattern-output,< 1K
+Predicate,https://schema.org/valueReference,1K - 10K
+Predicate,https://schema.org/valueReference-input,< 1K
+Predicate,https://schema.org/valueReference-output,< 1K
+Predicate,https://schema.org/valueRequired,10M+
+Predicate,https://schema.org/valueRequired-input,< 1K
+Predicate,https://schema.org/valueRequired-output,< 1K
+Predicate,https://schema.org/variableMeasured,10K - 100K
+Predicate,https://schema.org/variableMeasured-input,< 1K
+Predicate,https://schema.org/variableMeasured-output,< 1K
+Predicate,https://schema.org/variablesMeasured,< 1K
+Predicate,https://schema.org/variablesMeasured-input,< 1K
+Predicate,https://schema.org/variablesMeasured-output,< 1K
+Predicate,https://schema.org/variantCover,< 1K
+Predicate,https://schema.org/variantCover-input,< 1K
+Predicate,https://schema.org/variantCover-output,< 1K
+Predicate,https://schema.org/variesBy,100K - 1M
+Predicate,https://schema.org/variesBy-input,< 1K
+Predicate,https://schema.org/variesBy-output,< 1K
+Predicate,https://schema.org/vatID,100K - 1M
+Predicate,https://schema.org/vatID-input,< 1K
+Predicate,https://schema.org/vatID-output,< 1K
+Predicate,https://schema.org/vehicleConfiguration,10K - 100K
+Predicate,https://schema.org/vehicleConfiguration-input,< 1K
+Predicate,https://schema.org/vehicleConfiguration-output,< 1K
+Predicate,https://schema.org/vehicleEngine,10K - 100K
+Predicate,https://schema.org/vehicleEngine-input,< 1K
+Predicate,https://schema.org/vehicleEngine-output,< 1K
+Predicate,https://schema.org/vehicleIdentificationNumber,10K - 100K
+Predicate,https://schema.org/vehicleIdentificationNumber-input,< 1K
+Predicate,https://schema.org/vehicleIdentificationNumber-output,< 1K
+Predicate,https://schema.org/vehicleInteriorColor,10K - 100K
+Predicate,https://schema.org/vehicleInteriorColor-input,< 1K
+Predicate,https://schema.org/vehicleInteriorColor-output,< 1K
+Predicate,https://schema.org/vehicleInteriorType,10K - 100K
+Predicate,https://schema.org/vehicleInteriorType-input,< 1K
+Predicate,https://schema.org/vehicleInteriorType-output,< 1K
+Predicate,https://schema.org/vehicleModelDate,10K - 100K
+Predicate,https://schema.org/vehicleModelDate-input,< 1K
+Predicate,https://schema.org/vehicleModelDate-output,< 1K
+Predicate,https://schema.org/vehicleSeatingCapacity,10K - 100K
+Predicate,https://schema.org/vehicleSeatingCapacity-input,< 1K
+Predicate,https://schema.org/vehicleSeatingCapacity-output,< 1K
+Predicate,https://schema.org/vehicleSpecialUsage,< 1K
+Predicate,https://schema.org/vehicleSpecialUsage-input,< 1K
+Predicate,https://schema.org/vehicleSpecialUsage-output,< 1K
+Predicate,https://schema.org/vehicleTransmission,10K - 100K
+Predicate,https://schema.org/vehicleTransmission-input,< 1K
+Predicate,https://schema.org/vehicleTransmission-output,< 1K
+Predicate,https://schema.org/vendor,< 1K
+Predicate,https://schema.org/vendor-input,< 1K
+Predicate,https://schema.org/vendor-output,< 1K
+Predicate,https://schema.org/verificationFactCheckingPolicy,1K - 10K
+Predicate,https://schema.org/verificationFactCheckingPolicy-input,< 1K
+Predicate,https://schema.org/verificationFactCheckingPolicy-output,< 1K
+Predicate,https://schema.org/version,10K - 100K
+Predicate,https://schema.org/version-input,< 1K
+Predicate,https://schema.org/version-output,< 1K
+Predicate,https://schema.org/video,100K - 1M
+Predicate,https://schema.org/video-input,< 1K
+Predicate,https://schema.org/video-output,< 1K
+Predicate,https://schema.org/videoFormat,1K - 10K
+Predicate,https://schema.org/videoFormat-input,< 1K
+Predicate,https://schema.org/videoFormat-output,< 1K
+Predicate,https://schema.org/videoFrameSize,< 1K
+Predicate,https://schema.org/videoFrameSize-input,< 1K
+Predicate,https://schema.org/videoFrameSize-output,< 1K
+Predicate,https://schema.org/videoQuality,10K - 100K
+Predicate,https://schema.org/videoQuality-input,< 1K
+Predicate,https://schema.org/videoQuality-output,< 1K
+Predicate,https://schema.org/volumeNumber,1K - 10K
+Predicate,https://schema.org/volumeNumber-input,< 1K
+Predicate,https://schema.org/volumeNumber-output,< 1K
+Predicate,https://schema.org/warning,1K - 10K
+Predicate,https://schema.org/warning-input,< 1K
+Predicate,https://schema.org/warning-output,< 1K
+Predicate,https://schema.org/warranty,10K - 100K
+Predicate,https://schema.org/warranty-input,< 1K
+Predicate,https://schema.org/warranty-output,< 1K
+Predicate,https://schema.org/warrantyPromise,< 1K
+Predicate,https://schema.org/warrantyPromise-input,< 1K
+Predicate,https://schema.org/warrantyPromise-output,< 1K
+Predicate,https://schema.org/warrantyScope,1K - 10K
+Predicate,https://schema.org/warrantyScope-input,< 1K
+Predicate,https://schema.org/warrantyScope-output,< 1K
+Predicate,https://schema.org/webCheckinTime,< 1K
+Predicate,https://schema.org/webCheckinTime-input,< 1K
+Predicate,https://schema.org/webCheckinTime-output,< 1K
+Predicate,https://schema.org/webFeed,10K - 100K
+Predicate,https://schema.org/webFeed-input,< 1K
+Predicate,https://schema.org/webFeed-output,< 1K
+Predicate,https://schema.org/weight,100K - 1M
+Predicate,https://schema.org/weight-input,< 1K
+Predicate,https://schema.org/weight-output,< 1K
+Predicate,https://schema.org/weightPercentage,< 1K
+Predicate,https://schema.org/weightPercentage-input,< 1K
+Predicate,https://schema.org/weightPercentage-output,< 1K
+Predicate,https://schema.org/weightTotal,1K - 10K
+Predicate,https://schema.org/weightTotal-input,< 1K
+Predicate,https://schema.org/weightTotal-output,< 1K
+Predicate,https://schema.org/wheelbase,1K - 10K
+Predicate,https://schema.org/wheelbase-input,< 1K
+Predicate,https://schema.org/wheelbase-output,< 1K
+Predicate,https://schema.org/width,10M+
+Predicate,https://schema.org/width-input,< 1K
+Predicate,https://schema.org/width-output,< 1K
+Predicate,https://schema.org/winner,< 1K
+Predicate,https://schema.org/winner-input,< 1K
+Predicate,https://schema.org/winner-output,< 1K
+Predicate,https://schema.org/wordCount,1M - 10M
+Predicate,https://schema.org/wordCount-input,< 1K
+Predicate,https://schema.org/wordCount-output,< 1K
+Predicate,https://schema.org/workExample,1K - 10K
+Predicate,https://schema.org/workExample-input,< 1K
+Predicate,https://schema.org/workExample-output,< 1K
+Predicate,https://schema.org/workFeatured,< 1K
+Predicate,https://schema.org/workFeatured-input,< 1K
+Predicate,https://schema.org/workFeatured-output,< 1K
+Predicate,https://schema.org/workHours,10K - 100K
+Predicate,https://schema.org/workHours-input,< 1K
+Predicate,https://schema.org/workHours-output,< 1K
+Predicate,https://schema.org/workLocation,10K - 100K
+Predicate,https://schema.org/workLocation-input,< 1K
+Predicate,https://schema.org/workLocation-output,< 1K
+Predicate,https://schema.org/workPerformed,1K - 10K
+Predicate,https://schema.org/workPerformed-input,< 1K
+Predicate,https://schema.org/workPerformed-output,< 1K
+Predicate,https://schema.org/workPresented,< 1K
+Predicate,https://schema.org/workPresented-input,< 1K
+Predicate,https://schema.org/workPresented-output,< 1K
+Predicate,https://schema.org/workTranslation,10K - 100K
+Predicate,https://schema.org/workTranslation-input,< 1K
+Predicate,https://schema.org/workTranslation-output,< 1K
+Predicate,https://schema.org/workload,< 1K
+Predicate,https://schema.org/workload-input,< 1K
+Predicate,https://schema.org/workload-output,< 1K
+Predicate,https://schema.org/worksFor,1M - 10M
+Predicate,https://schema.org/worksFor-input,< 1K
+Predicate,https://schema.org/worksFor-output,< 1K
+Predicate,https://schema.org/worstRating,1M - 10M
+Predicate,https://schema.org/worstRating-input,< 1K
+Predicate,https://schema.org/worstRating-output,< 1K
+Predicate,https://schema.org/xpath,10K - 100K
+Predicate,https://schema.org/xpath-input,< 1K
+Predicate,https://schema.org/xpath-output,< 1K
+Predicate,https://schema.org/yearBuilt,10K - 100K
+Predicate,https://schema.org/yearBuilt-input,< 1K
+Predicate,https://schema.org/yearBuilt-output,< 1K
+Predicate,https://schema.org/yearlyRevenue,< 1K
+Predicate,https://schema.org/yearlyRevenue-input,< 1K
+Predicate,https://schema.org/yearlyRevenue-output,< 1K
+Predicate,https://schema.org/yearsInOperation,< 1K
+Predicate,https://schema.org/yearsInOperation-input,< 1K
+Predicate,https://schema.org/yearsInOperation-output,< 1K
+Predicate,https://schema.org/yield,1K - 10K
+Predicate,https://schema.org/yield-input,< 1K
+Predicate,https://schema.org/yield-output,< 1K

--- a/data/public_stats/google/2026_07.json
+++ b/data/public_stats/google/2026_07.json
@@ -1,27727 +1,27727 @@
 [
   {
     "Class":"Itemtype",
-    "Name":"http:\/\/schema.org\/3DModel",
+    "Name":"https://schema.org/3DModel",
     "Domain Bucket":"< 1K"
   },
   {
     "Class":"Itemtype",
-    "Name":"http:\/\/schema.org\/AMRadioChannel",
+    "Name":"https://schema.org/AMRadioChannel",
     "Domain Bucket":"< 1K"
   },
   {
     "Class":"Itemtype",
-    "Name":"http:\/\/schema.org\/APIReference",
+    "Name":"https://schema.org/APIReference",
     "Domain Bucket":"< 1K"
   },
   {
     "Class":"Itemtype",
-    "Name":"http:\/\/schema.org\/AboutPage",
+    "Name":"https://schema.org/AboutPage",
     "Domain Bucket":"100K - 1M"
   },
   {
     "Class":"Itemtype",
-    "Name":"http:\/\/schema.org\/AcceptAction",
+    "Name":"https://schema.org/AcceptAction",
     "Domain Bucket":"< 1K"
   },
   {
     "Class":"Itemtype",
-    "Name":"http:\/\/schema.org\/Accommodation",
+    "Name":"https://schema.org/Accommodation",
     "Domain Bucket":"10K - 100K"
   },
   {
     "Class":"Itemtype",
-    "Name":"http:\/\/schema.org\/AccountingService",
+    "Name":"https://schema.org/AccountingService",
     "Domain Bucket":"10K - 100K"
   },
   {
     "Class":"Itemtype",
-    "Name":"http:\/\/schema.org\/AchieveAction",
+    "Name":"https://schema.org/AchieveAction",
     "Domain Bucket":"< 1K"
   },
   {
     "Class":"Itemtype",
-    "Name":"http:\/\/schema.org\/Action",
+    "Name":"https://schema.org/Action",
     "Domain Bucket":"10K - 100K"
   },
   {
     "Class":"Itemtype",
-    "Name":"http:\/\/schema.org\/ActionAccessSpecification",
+    "Name":"https://schema.org/ActionAccessSpecification",
     "Domain Bucket":"< 1K"
   },
   {
     "Class":"Itemtype",
-    "Name":"http:\/\/schema.org\/ActionStatusType",
+    "Name":"https://schema.org/ActionStatusType",
     "Domain Bucket":"< 1K"
   },
   {
     "Class":"Itemtype",
-    "Name":"http:\/\/schema.org\/ActivateAction",
+    "Name":"https://schema.org/ActivateAction",
     "Domain Bucket":"< 1K"
   },
   {
     "Class":"Itemtype",
-    "Name":"http:\/\/schema.org\/AddAction",
+    "Name":"https://schema.org/AddAction",
     "Domain Bucket":"< 1K"
   },
   {
     "Class":"Itemtype",
-    "Name":"http:\/\/schema.org\/AdministrativeArea",
+    "Name":"https://schema.org/AdministrativeArea",
     "Domain Bucket":"100K - 1M"
   },
   {
     "Class":"Itemtype",
-    "Name":"http:\/\/schema.org\/AdultEntertainment",
+    "Name":"https://schema.org/AdultEntertainment",
     "Domain Bucket":"1K - 10K"
   },
   {
     "Class":"Itemtype",
-    "Name":"http:\/\/schema.org\/AdultOrientedEnumeration",
+    "Name":"https://schema.org/AdultOrientedEnumeration",
     "Domain Bucket":"< 1K"
   },
   {
     "Class":"Itemtype",
-    "Name":"http:\/\/schema.org\/AdvertiserContentArticle",
+    "Name":"https://schema.org/AdvertiserContentArticle",
     "Domain Bucket":"1K - 10K"
   },
   {
     "Class":"Itemtype",
-    "Name":"http:\/\/schema.org\/AggregateOffer",
+    "Name":"https://schema.org/AggregateOffer",
     "Domain Bucket":"1M - 10M"
   },
   {
     "Class":"Itemtype",
-    "Name":"http:\/\/schema.org\/AggregateRating",
+    "Name":"https://schema.org/AggregateRating",
     "Domain Bucket":"1M - 10M"
   },
   {
     "Class":"Itemtype",
-    "Name":"http:\/\/schema.org\/AgreeAction",
+    "Name":"https://schema.org/AgreeAction",
     "Domain Bucket":"< 1K"
   },
   {
     "Class":"Itemtype",
-    "Name":"http:\/\/schema.org\/Airline",
+    "Name":"https://schema.org/Airline",
     "Domain Bucket":"1K - 10K"
   },
   {
     "Class":"Itemtype",
-    "Name":"http:\/\/schema.org\/Airport",
+    "Name":"https://schema.org/Airport",
     "Domain Bucket":"1K - 10K"
   },
   {
     "Class":"Itemtype",
-    "Name":"http:\/\/schema.org\/AlignmentObject",
+    "Name":"https://schema.org/AlignmentObject",
     "Domain Bucket":"1K - 10K"
   },
   {
     "Class":"Itemtype",
-    "Name":"http:\/\/schema.org\/AllocateAction",
+    "Name":"https://schema.org/AllocateAction",
     "Domain Bucket":"< 1K"
   },
   {
     "Class":"Itemtype",
-    "Name":"http:\/\/schema.org\/AmpStory",
+    "Name":"https://schema.org/AmpStory",
     "Domain Bucket":"< 1K"
   },
   {
     "Class":"Itemtype",
-    "Name":"http:\/\/schema.org\/AmusementPark",
+    "Name":"https://schema.org/AmusementPark",
     "Domain Bucket":"1K - 10K"
   },
   {
     "Class":"Itemtype",
-    "Name":"http:\/\/schema.org\/AnalysisNewsArticle",
+    "Name":"https://schema.org/AnalysisNewsArticle",
     "Domain Bucket":"1K - 10K"
   },
   {
     "Class":"Itemtype",
-    "Name":"http:\/\/schema.org\/AnatomicalStructure",
+    "Name":"https://schema.org/AnatomicalStructure",
     "Domain Bucket":"1K - 10K"
   },
   {
     "Class":"Itemtype",
-    "Name":"http:\/\/schema.org\/AnatomicalSystem",
+    "Name":"https://schema.org/AnatomicalSystem",
     "Domain Bucket":"< 1K"
   },
   {
     "Class":"Itemtype",
-    "Name":"http:\/\/schema.org\/AnimalShelter",
+    "Name":"https://schema.org/AnimalShelter",
     "Domain Bucket":"1K - 10K"
   },
   {
     "Class":"Itemtype",
-    "Name":"http:\/\/schema.org\/Answer",
+    "Name":"https://schema.org/Answer",
     "Domain Bucket":"1M - 10M"
   },
   {
     "Class":"Itemtype",
-    "Name":"http:\/\/schema.org\/Apartment",
+    "Name":"https://schema.org/Apartment",
     "Domain Bucket":"10K - 100K"
   },
   {
     "Class":"Itemtype",
-    "Name":"http:\/\/schema.org\/ApartmentComplex",
+    "Name":"https://schema.org/ApartmentComplex",
     "Domain Bucket":"10K - 100K"
   },
   {
     "Class":"Itemtype",
-    "Name":"http:\/\/schema.org\/AppendAction",
+    "Name":"https://schema.org/AppendAction",
     "Domain Bucket":"< 1K"
   },
   {
     "Class":"Itemtype",
-    "Name":"http:\/\/schema.org\/ApplyAction",
+    "Name":"https://schema.org/ApplyAction",
     "Domain Bucket":"1K - 10K"
   },
   {
     "Class":"Itemtype",
-    "Name":"http:\/\/schema.org\/ApprovedIndication",
+    "Name":"https://schema.org/ApprovedIndication",
     "Domain Bucket":"< 1K"
   },
   {
     "Class":"Itemtype",
-    "Name":"http:\/\/schema.org\/Aquarium",
+    "Name":"https://schema.org/Aquarium",
     "Domain Bucket":"< 1K"
   },
   {
     "Class":"Itemtype",
-    "Name":"http:\/\/schema.org\/ArchiveComponent",
+    "Name":"https://schema.org/ArchiveComponent",
     "Domain Bucket":"< 1K"
   },
   {
     "Class":"Itemtype",
-    "Name":"http:\/\/schema.org\/ArchiveOrganization",
+    "Name":"https://schema.org/ArchiveOrganization",
     "Domain Bucket":"1K - 10K"
   },
   {
     "Class":"Itemtype",
-    "Name":"http:\/\/schema.org\/ArriveAction",
+    "Name":"https://schema.org/ArriveAction",
     "Domain Bucket":"< 1K"
   },
   {
     "Class":"Itemtype",
-    "Name":"http:\/\/schema.org\/ArtGallery",
+    "Name":"https://schema.org/ArtGallery",
     "Domain Bucket":"1K - 10K"
   },
   {
     "Class":"Itemtype",
-    "Name":"http:\/\/schema.org\/Artery",
+    "Name":"https://schema.org/Artery",
     "Domain Bucket":"< 1K"
   },
   {
     "Class":"Itemtype",
-    "Name":"http:\/\/schema.org\/Article",
+    "Name":"https://schema.org/Article",
     "Domain Bucket":"10M+"
   },
   {
     "Class":"Itemtype",
-    "Name":"http:\/\/schema.org\/AskAction",
+    "Name":"https://schema.org/AskAction",
     "Domain Bucket":"1K - 10K"
   },
   {
     "Class":"Itemtype",
-    "Name":"http:\/\/schema.org\/AskPublicNewsArticle",
+    "Name":"https://schema.org/AskPublicNewsArticle",
     "Domain Bucket":"< 1K"
   },
   {
     "Class":"Itemtype",
-    "Name":"http:\/\/schema.org\/AssessAction",
+    "Name":"https://schema.org/AssessAction",
     "Domain Bucket":"< 1K"
   },
   {
     "Class":"Itemtype",
-    "Name":"http:\/\/schema.org\/AssignAction",
+    "Name":"https://schema.org/AssignAction",
     "Domain Bucket":"< 1K"
   },
   {
     "Class":"Itemtype",
-    "Name":"http:\/\/schema.org\/Atlas",
+    "Name":"https://schema.org/Atlas",
     "Domain Bucket":"< 1K"
   },
   {
     "Class":"Itemtype",
-    "Name":"http:\/\/schema.org\/Attorney",
+    "Name":"https://schema.org/Attorney",
     "Domain Bucket":"10K - 100K"
   },
   {
     "Class":"Itemtype",
-    "Name":"http:\/\/schema.org\/Audience",
+    "Name":"https://schema.org/Audience",
     "Domain Bucket":"100K - 1M"
   },
   {
     "Class":"Itemtype",
-    "Name":"http:\/\/schema.org\/AudioObject",
+    "Name":"https://schema.org/AudioObject",
     "Domain Bucket":"10K - 100K"
   },
   {
     "Class":"Itemtype",
-    "Name":"http:\/\/schema.org\/AudioObjectSnapshot",
+    "Name":"https://schema.org/AudioObjectSnapshot",
     "Domain Bucket":"< 1K"
   },
   {
     "Class":"Itemtype",
-    "Name":"http:\/\/schema.org\/Audiobook",
+    "Name":"https://schema.org/Audiobook",
     "Domain Bucket":"< 1K"
   },
   {
     "Class":"Itemtype",
-    "Name":"http:\/\/schema.org\/AuthenticateAction",
+    "Name":"https://schema.org/AuthenticateAction",
     "Domain Bucket":"< 1K"
   },
   {
     "Class":"Itemtype",
-    "Name":"http:\/\/schema.org\/AuthorizeAction",
+    "Name":"https://schema.org/AuthorizeAction",
     "Domain Bucket":"< 1K"
   },
   {
     "Class":"Itemtype",
-    "Name":"http:\/\/schema.org\/AutoBodyShop",
+    "Name":"https://schema.org/AutoBodyShop",
     "Domain Bucket":"1K - 10K"
   },
   {
     "Class":"Itemtype",
-    "Name":"http:\/\/schema.org\/AutoDealer",
+    "Name":"https://schema.org/AutoDealer",
     "Domain Bucket":"10K - 100K"
   },
   {
     "Class":"Itemtype",
-    "Name":"http:\/\/schema.org\/AutoPartsStore",
+    "Name":"https://schema.org/AutoPartsStore",
     "Domain Bucket":"10K - 100K"
   },
   {
     "Class":"Itemtype",
-    "Name":"http:\/\/schema.org\/AutoRental",
+    "Name":"https://schema.org/AutoRental",
     "Domain Bucket":"10K - 100K"
   },
   {
     "Class":"Itemtype",
-    "Name":"http:\/\/schema.org\/AutoRepair",
+    "Name":"https://schema.org/AutoRepair",
     "Domain Bucket":"10K - 100K"
   },
   {
     "Class":"Itemtype",
-    "Name":"http:\/\/schema.org\/AutoWash",
+    "Name":"https://schema.org/AutoWash",
     "Domain Bucket":"1K - 10K"
   },
   {
     "Class":"Itemtype",
-    "Name":"http:\/\/schema.org\/AutomatedTeller",
+    "Name":"https://schema.org/AutomatedTeller",
     "Domain Bucket":"< 1K"
   },
   {
     "Class":"Itemtype",
-    "Name":"http:\/\/schema.org\/AutomotiveBusiness",
+    "Name":"https://schema.org/AutomotiveBusiness",
     "Domain Bucket":"10K - 100K"
   },
   {
     "Class":"Itemtype",
-    "Name":"http:\/\/schema.org\/BackgroundNewsArticle",
+    "Name":"https://schema.org/BackgroundNewsArticle",
     "Domain Bucket":"< 1K"
   },
   {
     "Class":"Itemtype",
-    "Name":"http:\/\/schema.org\/Bakery",
+    "Name":"https://schema.org/Bakery",
     "Domain Bucket":"1K - 10K"
   },
   {
     "Class":"Itemtype",
-    "Name":"http:\/\/schema.org\/BankAccount",
+    "Name":"https://schema.org/BankAccount",
     "Domain Bucket":"< 1K"
   },
   {
     "Class":"Itemtype",
-    "Name":"http:\/\/schema.org\/BankOrCreditUnion",
+    "Name":"https://schema.org/BankOrCreditUnion",
     "Domain Bucket":"1K - 10K"
   },
   {
     "Class":"Itemtype",
-    "Name":"http:\/\/schema.org\/BarOrPub",
+    "Name":"https://schema.org/BarOrPub",
     "Domain Bucket":"10K - 100K"
   },
   {
     "Class":"Itemtype",
-    "Name":"http:\/\/schema.org\/Barcode",
+    "Name":"https://schema.org/Barcode",
     "Domain Bucket":"< 1K"
   },
   {
     "Class":"Itemtype",
-    "Name":"http:\/\/schema.org\/Beach",
+    "Name":"https://schema.org/Beach",
     "Domain Bucket":"1K - 10K"
   },
   {
     "Class":"Itemtype",
-    "Name":"http:\/\/schema.org\/BeautySalon",
+    "Name":"https://schema.org/BeautySalon",
     "Domain Bucket":"10K - 100K"
   },
   {
     "Class":"Itemtype",
-    "Name":"http:\/\/schema.org\/BedAndBreakfast",
+    "Name":"https://schema.org/BedAndBreakfast",
     "Domain Bucket":"1K - 10K"
   },
   {
     "Class":"Itemtype",
-    "Name":"http:\/\/schema.org\/BedDetails",
+    "Name":"https://schema.org/BedDetails",
     "Domain Bucket":"10K - 100K"
   },
   {
     "Class":"Itemtype",
-    "Name":"http:\/\/schema.org\/BedType",
+    "Name":"https://schema.org/BedType",
     "Domain Bucket":"< 1K"
   },
   {
     "Class":"Itemtype",
-    "Name":"http:\/\/schema.org\/BefriendAction",
+    "Name":"https://schema.org/BefriendAction",
     "Domain Bucket":"< 1K"
   },
   {
     "Class":"Itemtype",
-    "Name":"http:\/\/schema.org\/BikeStore",
+    "Name":"https://schema.org/BikeStore",
     "Domain Bucket":"1K - 10K"
   },
   {
     "Class":"Itemtype",
-    "Name":"http:\/\/schema.org\/BioChemEntity",
+    "Name":"https://schema.org/BioChemEntity",
     "Domain Bucket":"< 1K"
   },
   {
     "Class":"Itemtype",
-    "Name":"http:\/\/schema.org\/Blog",
+    "Name":"https://schema.org/Blog",
     "Domain Bucket":"1M - 10M"
   },
   {
     "Class":"Itemtype",
-    "Name":"http:\/\/schema.org\/BlogPosting",
+    "Name":"https://schema.org/BlogPosting",
     "Domain Bucket":"1M - 10M"
   },
   {
     "Class":"Itemtype",
-    "Name":"http:\/\/schema.org\/BloodTest",
+    "Name":"https://schema.org/BloodTest",
     "Domain Bucket":"< 1K"
   },
   {
     "Class":"Itemtype",
-    "Name":"http:\/\/schema.org\/BoardingPolicyType",
+    "Name":"https://schema.org/BoardingPolicyType",
     "Domain Bucket":"< 1K"
   },
   {
     "Class":"Itemtype",
-    "Name":"http:\/\/schema.org\/BoatReservation",
+    "Name":"https://schema.org/BoatReservation",
     "Domain Bucket":"< 1K"
   },
   {
     "Class":"Itemtype",
-    "Name":"http:\/\/schema.org\/BoatTerminal",
+    "Name":"https://schema.org/BoatTerminal",
     "Domain Bucket":"< 1K"
   },
   {
     "Class":"Itemtype",
-    "Name":"http:\/\/schema.org\/BoatTrip",
+    "Name":"https://schema.org/BoatTrip",
     "Domain Bucket":"< 1K"
   },
   {
     "Class":"Itemtype",
-    "Name":"http:\/\/schema.org\/BodyMeasurementTypeEnumeration",
+    "Name":"https://schema.org/BodyMeasurementTypeEnumeration",
     "Domain Bucket":"< 1K"
   },
   {
     "Class":"Itemtype",
-    "Name":"http:\/\/schema.org\/BodyOfWater",
+    "Name":"https://schema.org/BodyOfWater",
     "Domain Bucket":"< 1K"
   },
   {
     "Class":"Itemtype",
-    "Name":"http:\/\/schema.org\/Bone",
+    "Name":"https://schema.org/Bone",
     "Domain Bucket":"< 1K"
   },
   {
     "Class":"Itemtype",
-    "Name":"http:\/\/schema.org\/Book",
+    "Name":"https://schema.org/Book",
     "Domain Bucket":"10K - 100K"
   },
   {
     "Class":"Itemtype",
-    "Name":"http:\/\/schema.org\/BookFormatType",
+    "Name":"https://schema.org/BookFormatType",
     "Domain Bucket":"< 1K"
   },
   {
     "Class":"Itemtype",
-    "Name":"http:\/\/schema.org\/BookSeries",
+    "Name":"https://schema.org/BookSeries",
     "Domain Bucket":"1K - 10K"
   },
   {
     "Class":"Itemtype",
-    "Name":"http:\/\/schema.org\/BookStore",
+    "Name":"https://schema.org/BookStore",
     "Domain Bucket":"1K - 10K"
   },
   {
     "Class":"Itemtype",
-    "Name":"http:\/\/schema.org\/BookmarkAction",
+    "Name":"https://schema.org/BookmarkAction",
     "Domain Bucket":"< 1K"
   },
   {
     "Class":"Itemtype",
-    "Name":"http:\/\/schema.org\/Boolean",
+    "Name":"https://schema.org/Boolean",
     "Domain Bucket":"< 1K"
   },
   {
     "Class":"Itemtype",
-    "Name":"http:\/\/schema.org\/BorrowAction",
+    "Name":"https://schema.org/BorrowAction",
     "Domain Bucket":"< 1K"
   },
   {
     "Class":"Itemtype",
-    "Name":"http:\/\/schema.org\/BowlingAlley",
+    "Name":"https://schema.org/BowlingAlley",
     "Domain Bucket":"< 1K"
   },
   {
     "Class":"Itemtype",
-    "Name":"http:\/\/schema.org\/BrainStructure",
+    "Name":"https://schema.org/BrainStructure",
     "Domain Bucket":"< 1K"
   },
   {
     "Class":"Itemtype",
-    "Name":"http:\/\/schema.org\/Brand",
+    "Name":"https://schema.org/Brand",
     "Domain Bucket":"1M - 10M"
   },
   {
     "Class":"Itemtype",
-    "Name":"http:\/\/schema.org\/BreadcrumbList",
+    "Name":"https://schema.org/BreadcrumbList",
     "Domain Bucket":"10M+"
   },
   {
     "Class":"Itemtype",
-    "Name":"http:\/\/schema.org\/Brewery",
+    "Name":"https://schema.org/Brewery",
     "Domain Bucket":"1K - 10K"
   },
   {
     "Class":"Itemtype",
-    "Name":"http:\/\/schema.org\/Bridge",
+    "Name":"https://schema.org/Bridge",
     "Domain Bucket":"< 1K"
   },
   {
     "Class":"Itemtype",
-    "Name":"http:\/\/schema.org\/BroadcastChannel",
+    "Name":"https://schema.org/BroadcastChannel",
     "Domain Bucket":"< 1K"
   },
   {
     "Class":"Itemtype",
-    "Name":"http:\/\/schema.org\/BroadcastEvent",
+    "Name":"https://schema.org/BroadcastEvent",
     "Domain Bucket":"10K - 100K"
   },
   {
     "Class":"Itemtype",
-    "Name":"http:\/\/schema.org\/BroadcastFrequencySpecification",
+    "Name":"https://schema.org/BroadcastFrequencySpecification",
     "Domain Bucket":"< 1K"
   },
   {
     "Class":"Itemtype",
-    "Name":"http:\/\/schema.org\/BroadcastService",
+    "Name":"https://schema.org/BroadcastService",
     "Domain Bucket":"1K - 10K"
   },
   {
     "Class":"Itemtype",
-    "Name":"http:\/\/schema.org\/BrokerageAccount",
+    "Name":"https://schema.org/BrokerageAccount",
     "Domain Bucket":"< 1K"
   },
   {
     "Class":"Itemtype",
-    "Name":"http:\/\/schema.org\/BuddhistTemple",
+    "Name":"https://schema.org/BuddhistTemple",
     "Domain Bucket":"< 1K"
   },
   {
     "Class":"Itemtype",
-    "Name":"http:\/\/schema.org\/BusOrCoach",
+    "Name":"https://schema.org/BusOrCoach",
     "Domain Bucket":"< 1K"
   },
   {
     "Class":"Itemtype",
-    "Name":"http:\/\/schema.org\/BusReservation",
+    "Name":"https://schema.org/BusReservation",
     "Domain Bucket":"< 1K"
   },
   {
     "Class":"Itemtype",
-    "Name":"http:\/\/schema.org\/BusStation",
+    "Name":"https://schema.org/BusStation",
     "Domain Bucket":"< 1K"
   },
   {
     "Class":"Itemtype",
-    "Name":"http:\/\/schema.org\/BusStop",
+    "Name":"https://schema.org/BusStop",
     "Domain Bucket":"< 1K"
   },
   {
     "Class":"Itemtype",
-    "Name":"http:\/\/schema.org\/BusTrip",
+    "Name":"https://schema.org/BusTrip",
     "Domain Bucket":"1K - 10K"
   },
   {
     "Class":"Itemtype",
-    "Name":"http:\/\/schema.org\/BusinessAudience",
+    "Name":"https://schema.org/BusinessAudience",
     "Domain Bucket":"10K - 100K"
   },
   {
     "Class":"Itemtype",
-    "Name":"http:\/\/schema.org\/BusinessEntityType",
+    "Name":"https://schema.org/BusinessEntityType",
     "Domain Bucket":"< 1K"
   },
   {
     "Class":"Itemtype",
-    "Name":"http:\/\/schema.org\/BusinessEvent",
+    "Name":"https://schema.org/BusinessEvent",
     "Domain Bucket":"1K - 10K"
   },
   {
     "Class":"Itemtype",
-    "Name":"http:\/\/schema.org\/BusinessFunction",
+    "Name":"https://schema.org/BusinessFunction",
     "Domain Bucket":"< 1K"
   },
   {
     "Class":"Itemtype",
-    "Name":"http:\/\/schema.org\/BuyAction",
+    "Name":"https://schema.org/BuyAction",
     "Domain Bucket":"1M - 10M"
   },
   {
     "Class":"Itemtype",
-    "Name":"http:\/\/schema.org\/CDCPMDRecord",
+    "Name":"https://schema.org/CDCPMDRecord",
     "Domain Bucket":"< 1K"
   },
   {
     "Class":"Itemtype",
-    "Name":"http:\/\/schema.org\/CableOrSatelliteService",
+    "Name":"https://schema.org/CableOrSatelliteService",
     "Domain Bucket":"< 1K"
   },
   {
     "Class":"Itemtype",
-    "Name":"http:\/\/schema.org\/CafeOrCoffeeShop",
+    "Name":"https://schema.org/CafeOrCoffeeShop",
     "Domain Bucket":"1K - 10K"
   },
   {
     "Class":"Itemtype",
-    "Name":"http:\/\/schema.org\/Campground",
+    "Name":"https://schema.org/Campground",
     "Domain Bucket":"1K - 10K"
   },
   {
     "Class":"Itemtype",
-    "Name":"http:\/\/schema.org\/CampingPitch",
+    "Name":"https://schema.org/CampingPitch",
     "Domain Bucket":"< 1K"
   },
   {
     "Class":"Itemtype",
-    "Name":"http:\/\/schema.org\/Canal",
+    "Name":"https://schema.org/Canal",
     "Domain Bucket":"< 1K"
   },
   {
     "Class":"Itemtype",
-    "Name":"http:\/\/schema.org\/CancelAction",
+    "Name":"https://schema.org/CancelAction",
     "Domain Bucket":"< 1K"
   },
   {
     "Class":"Itemtype",
-    "Name":"http:\/\/schema.org\/Car",
+    "Name":"https://schema.org/Car",
     "Domain Bucket":"10K - 100K"
   },
   {
     "Class":"Itemtype",
-    "Name":"http:\/\/schema.org\/CarUsageType",
+    "Name":"https://schema.org/CarUsageType",
     "Domain Bucket":"< 1K"
   },
   {
     "Class":"Itemtype",
-    "Name":"http:\/\/schema.org\/Casino",
+    "Name":"https://schema.org/Casino",
     "Domain Bucket":"100K - 1M"
   },
   {
     "Class":"Itemtype",
-    "Name":"http:\/\/schema.org\/CategoryCode",
+    "Name":"https://schema.org/CategoryCode",
     "Domain Bucket":"1K - 10K"
   },
   {
     "Class":"Itemtype",
-    "Name":"http:\/\/schema.org\/CategoryCodeSet",
+    "Name":"https://schema.org/CategoryCodeSet",
     "Domain Bucket":"< 1K"
   },
   {
     "Class":"Itemtype",
-    "Name":"http:\/\/schema.org\/CatholicChurch",
+    "Name":"https://schema.org/CatholicChurch",
     "Domain Bucket":"< 1K"
   },
   {
     "Class":"Itemtype",
-    "Name":"http:\/\/schema.org\/Cemetery",
+    "Name":"https://schema.org/Cemetery",
     "Domain Bucket":"< 1K"
   },
   {
     "Class":"Itemtype",
-    "Name":"http:\/\/schema.org\/Certification",
+    "Name":"https://schema.org/Certification",
     "Domain Bucket":"10K - 100K"
   },
   {
     "Class":"Itemtype",
-    "Name":"http:\/\/schema.org\/CertificationStatusEnumeration",
+    "Name":"https://schema.org/CertificationStatusEnumeration",
     "Domain Bucket":"< 1K"
   },
   {
     "Class":"Itemtype",
-    "Name":"http:\/\/schema.org\/Chapter",
+    "Name":"https://schema.org/Chapter",
     "Domain Bucket":"1K - 10K"
   },
   {
     "Class":"Itemtype",
-    "Name":"http:\/\/schema.org\/CheckAction",
+    "Name":"https://schema.org/CheckAction",
     "Domain Bucket":"< 1K"
   },
   {
     "Class":"Itemtype",
-    "Name":"http:\/\/schema.org\/CheckInAction",
+    "Name":"https://schema.org/CheckInAction",
     "Domain Bucket":"< 1K"
   },
   {
     "Class":"Itemtype",
-    "Name":"http:\/\/schema.org\/CheckOutAction",
+    "Name":"https://schema.org/CheckOutAction",
     "Domain Bucket":"< 1K"
   },
   {
     "Class":"Itemtype",
-    "Name":"http:\/\/schema.org\/CheckoutPage",
+    "Name":"https://schema.org/CheckoutPage",
     "Domain Bucket":"1K - 10K"
   },
   {
     "Class":"Itemtype",
-    "Name":"http:\/\/schema.org\/ChemicalSubstance",
+    "Name":"https://schema.org/ChemicalSubstance",
     "Domain Bucket":"1K - 10K"
   },
   {
     "Class":"Itemtype",
-    "Name":"http:\/\/schema.org\/ChildCare",
+    "Name":"https://schema.org/ChildCare",
     "Domain Bucket":"1K - 10K"
   },
   {
     "Class":"Itemtype",
-    "Name":"http:\/\/schema.org\/ChildrensEvent",
+    "Name":"https://schema.org/ChildrensEvent",
     "Domain Bucket":"< 1K"
   },
   {
     "Class":"Itemtype",
-    "Name":"http:\/\/schema.org\/ChooseAction",
+    "Name":"https://schema.org/ChooseAction",
     "Domain Bucket":"1K - 10K"
   },
   {
     "Class":"Itemtype",
-    "Name":"http:\/\/schema.org\/Church",
+    "Name":"https://schema.org/Church",
     "Domain Bucket":"1K - 10K"
   },
   {
     "Class":"Itemtype",
-    "Name":"http:\/\/schema.org\/City",
+    "Name":"https://schema.org/City",
     "Domain Bucket":"100K - 1M"
   },
   {
     "Class":"Itemtype",
-    "Name":"http:\/\/schema.org\/CityHall",
+    "Name":"https://schema.org/CityHall",
     "Domain Bucket":"< 1K"
   },
   {
     "Class":"Itemtype",
-    "Name":"http:\/\/schema.org\/CivicStructure",
+    "Name":"https://schema.org/CivicStructure",
     "Domain Bucket":"1K - 10K"
   },
   {
     "Class":"Itemtype",
-    "Name":"http:\/\/schema.org\/Claim",
+    "Name":"https://schema.org/Claim",
     "Domain Bucket":"1K - 10K"
   },
   {
     "Class":"Itemtype",
-    "Name":"http:\/\/schema.org\/ClaimReview",
+    "Name":"https://schema.org/ClaimReview",
     "Domain Bucket":"1K - 10K"
   },
   {
     "Class":"Itemtype",
-    "Name":"http:\/\/schema.org\/Class",
+    "Name":"https://schema.org/Class",
     "Domain Bucket":"< 1K"
   },
   {
     "Class":"Itemtype",
-    "Name":"http:\/\/schema.org\/Clip",
+    "Name":"https://schema.org/Clip",
     "Domain Bucket":"10K - 100K"
   },
   {
     "Class":"Itemtype",
-    "Name":"http:\/\/schema.org\/ClothingStore",
+    "Name":"https://schema.org/ClothingStore",
     "Domain Bucket":"10K - 100K"
   },
   {
     "Class":"Itemtype",
-    "Name":"http:\/\/schema.org\/Code",
+    "Name":"https://schema.org/Code",
     "Domain Bucket":"< 1K"
   },
   {
     "Class":"Itemtype",
-    "Name":"http:\/\/schema.org\/Collection",
+    "Name":"https://schema.org/Collection",
     "Domain Bucket":"10K - 100K"
   },
   {
     "Class":"Itemtype",
-    "Name":"http:\/\/schema.org\/CollectionPage",
+    "Name":"https://schema.org/CollectionPage",
     "Domain Bucket":"1M - 10M"
   },
   {
     "Class":"Itemtype",
-    "Name":"http:\/\/schema.org\/CollegeOrUniversity",
+    "Name":"https://schema.org/CollegeOrUniversity",
     "Domain Bucket":"10K - 100K"
   },
   {
     "Class":"Itemtype",
-    "Name":"http:\/\/schema.org\/ComedyClub",
+    "Name":"https://schema.org/ComedyClub",
     "Domain Bucket":"< 1K"
   },
   {
     "Class":"Itemtype",
-    "Name":"http:\/\/schema.org\/ComedyEvent",
+    "Name":"https://schema.org/ComedyEvent",
     "Domain Bucket":"1K - 10K"
   },
   {
     "Class":"Itemtype",
-    "Name":"http:\/\/schema.org\/ComicCoverArt",
+    "Name":"https://schema.org/ComicCoverArt",
     "Domain Bucket":"< 1K"
   },
   {
     "Class":"Itemtype",
-    "Name":"http:\/\/schema.org\/ComicIssue",
+    "Name":"https://schema.org/ComicIssue",
     "Domain Bucket":"< 1K"
   },
   {
     "Class":"Itemtype",
-    "Name":"http:\/\/schema.org\/ComicSeries",
+    "Name":"https://schema.org/ComicSeries",
     "Domain Bucket":"1K - 10K"
   },
   {
     "Class":"Itemtype",
-    "Name":"http:\/\/schema.org\/ComicStory",
+    "Name":"https://schema.org/ComicStory",
     "Domain Bucket":"< 1K"
   },
   {
     "Class":"Itemtype",
-    "Name":"http:\/\/schema.org\/Comment",
+    "Name":"https://schema.org/Comment",
     "Domain Bucket":"100K - 1M"
   },
   {
     "Class":"Itemtype",
-    "Name":"http:\/\/schema.org\/CommentAction",
+    "Name":"https://schema.org/CommentAction",
     "Domain Bucket":"1M - 10M"
   },
   {
     "Class":"Itemtype",
-    "Name":"http:\/\/schema.org\/CommunicateAction",
+    "Name":"https://schema.org/CommunicateAction",
     "Domain Bucket":"10K - 100K"
   },
   {
     "Class":"Itemtype",
-    "Name":"http:\/\/schema.org\/CommunityHealth",
+    "Name":"https://schema.org/CommunityHealth",
     "Domain Bucket":"1K - 10K"
   },
   {
     "Class":"Itemtype",
-    "Name":"http:\/\/schema.org\/CompleteDataFeed",
+    "Name":"https://schema.org/CompleteDataFeed",
     "Domain Bucket":"< 1K"
   },
   {
     "Class":"Itemtype",
-    "Name":"http:\/\/schema.org\/CompoundPriceSpecification",
+    "Name":"https://schema.org/CompoundPriceSpecification",
     "Domain Bucket":"1K - 10K"
   },
   {
     "Class":"Itemtype",
-    "Name":"http:\/\/schema.org\/ComputerLanguage",
+    "Name":"https://schema.org/ComputerLanguage",
     "Domain Bucket":"< 1K"
   },
   {
     "Class":"Itemtype",
-    "Name":"http:\/\/schema.org\/ComputerStore",
+    "Name":"https://schema.org/ComputerStore",
     "Domain Bucket":"1K - 10K"
   },
   {
     "Class":"Itemtype",
-    "Name":"http:\/\/schema.org\/ConferenceEvent",
+    "Name":"https://schema.org/ConferenceEvent",
     "Domain Bucket":"< 1K"
   },
   {
     "Class":"Itemtype",
-    "Name":"http:\/\/schema.org\/ConfirmAction",
+    "Name":"https://schema.org/ConfirmAction",
     "Domain Bucket":"< 1K"
   },
   {
     "Class":"Itemtype",
-    "Name":"http:\/\/schema.org\/Consortium",
+    "Name":"https://schema.org/Consortium",
     "Domain Bucket":"< 1K"
   },
   {
     "Class":"Itemtype",
-    "Name":"http:\/\/schema.org\/ConstraintNode",
+    "Name":"https://schema.org/ConstraintNode",
     "Domain Bucket":"< 1K"
   },
   {
     "Class":"Itemtype",
-    "Name":"http:\/\/schema.org\/ConsumeAction",
+    "Name":"https://schema.org/ConsumeAction",
     "Domain Bucket":"< 1K"
   },
   {
     "Class":"Itemtype",
-    "Name":"http:\/\/schema.org\/ContactPage",
+    "Name":"https://schema.org/ContactPage",
     "Domain Bucket":"100K - 1M"
   },
   {
     "Class":"Itemtype",
-    "Name":"http:\/\/schema.org\/ContactPoint",
+    "Name":"https://schema.org/ContactPoint",
     "Domain Bucket":"1M - 10M"
   },
   {
     "Class":"Itemtype",
-    "Name":"http:\/\/schema.org\/ContactPointOption",
+    "Name":"https://schema.org/ContactPointOption",
     "Domain Bucket":"< 1K"
   },
   {
     "Class":"Itemtype",
-    "Name":"http:\/\/schema.org\/Continent",
+    "Name":"https://schema.org/Continent",
     "Domain Bucket":"1K - 10K"
   },
   {
     "Class":"Itemtype",
-    "Name":"http:\/\/schema.org\/ControlAction",
+    "Name":"https://schema.org/ControlAction",
     "Domain Bucket":"< 1K"
   },
   {
     "Class":"Itemtype",
-    "Name":"http:\/\/schema.org\/ConvenienceStore",
+    "Name":"https://schema.org/ConvenienceStore",
     "Domain Bucket":"< 1K"
   },
   {
     "Class":"Itemtype",
-    "Name":"http:\/\/schema.org\/Conversation",
+    "Name":"https://schema.org/Conversation",
     "Domain Bucket":"< 1K"
   },
   {
     "Class":"Itemtype",
-    "Name":"http:\/\/schema.org\/CookAction",
+    "Name":"https://schema.org/CookAction",
     "Domain Bucket":"< 1K"
   },
   {
     "Class":"Itemtype",
-    "Name":"http:\/\/schema.org\/Cooperative",
+    "Name":"https://schema.org/Cooperative",
     "Domain Bucket":"< 1K"
   },
   {
     "Class":"Itemtype",
-    "Name":"http:\/\/schema.org\/Corporation",
+    "Name":"https://schema.org/Corporation",
     "Domain Bucket":"100K - 1M"
   },
   {
     "Class":"Itemtype",
-    "Name":"http:\/\/schema.org\/CorrectionComment",
+    "Name":"https://schema.org/CorrectionComment",
     "Domain Bucket":"< 1K"
   },
   {
     "Class":"Itemtype",
-    "Name":"http:\/\/schema.org\/Country",
+    "Name":"https://schema.org/Country",
     "Domain Bucket":"1M - 10M"
   },
   {
     "Class":"Itemtype",
-    "Name":"http:\/\/schema.org\/Course",
+    "Name":"https://schema.org/Course",
     "Domain Bucket":"100K - 1M"
   },
   {
     "Class":"Itemtype",
-    "Name":"http:\/\/schema.org\/CourseInstance",
+    "Name":"https://schema.org/CourseInstance",
     "Domain Bucket":"10K - 100K"
   },
   {
     "Class":"Itemtype",
-    "Name":"http:\/\/schema.org\/Courthouse",
+    "Name":"https://schema.org/Courthouse",
     "Domain Bucket":"< 1K"
   },
   {
     "Class":"Itemtype",
-    "Name":"http:\/\/schema.org\/CoverArt",
+    "Name":"https://schema.org/CoverArt",
     "Domain Bucket":"< 1K"
   },
   {
     "Class":"Itemtype",
-    "Name":"http:\/\/schema.org\/CovidTestingFacility",
+    "Name":"https://schema.org/CovidTestingFacility",
     "Domain Bucket":"< 1K"
   },
   {
     "Class":"Itemtype",
-    "Name":"http:\/\/schema.org\/CreateAction",
+    "Name":"https://schema.org/CreateAction",
     "Domain Bucket":"1K - 10K"
   },
   {
     "Class":"Itemtype",
-    "Name":"http:\/\/schema.org\/CreativeWork",
+    "Name":"https://schema.org/CreativeWork",
     "Domain Bucket":"1M - 10M"
   },
   {
     "Class":"Itemtype",
-    "Name":"http:\/\/schema.org\/CreativeWorkSeason",
+    "Name":"https://schema.org/CreativeWorkSeason",
     "Domain Bucket":"1K - 10K"
   },
   {
     "Class":"Itemtype",
-    "Name":"http:\/\/schema.org\/CreativeWorkSeries",
+    "Name":"https://schema.org/CreativeWorkSeries",
     "Domain Bucket":"10K - 100K"
   },
   {
     "Class":"Itemtype",
-    "Name":"http:\/\/schema.org\/Credential",
+    "Name":"https://schema.org/Credential",
     "Domain Bucket":"10K - 100K"
   },
   {
     "Class":"Itemtype",
-    "Name":"http:\/\/schema.org\/CreditCard",
+    "Name":"https://schema.org/CreditCard",
     "Domain Bucket":"1K - 10K"
   },
   {
     "Class":"Itemtype",
-    "Name":"http:\/\/schema.org\/Crematorium",
+    "Name":"https://schema.org/Crematorium",
     "Domain Bucket":"< 1K"
   },
   {
     "Class":"Itemtype",
-    "Name":"http:\/\/schema.org\/CriticReview",
+    "Name":"https://schema.org/CriticReview",
     "Domain Bucket":"< 1K"
   },
   {
     "Class":"Itemtype",
-    "Name":"http:\/\/schema.org\/CssSelectorType",
+    "Name":"https://schema.org/CssSelectorType",
     "Domain Bucket":"< 1K"
   },
   {
     "Class":"Itemtype",
-    "Name":"http:\/\/schema.org\/CurrencyConversionService",
+    "Name":"https://schema.org/CurrencyConversionService",
     "Domain Bucket":"< 1K"
   },
   {
     "Class":"Itemtype",
-    "Name":"http:\/\/schema.org\/DDxElement",
+    "Name":"https://schema.org/DDxElement",
     "Domain Bucket":"< 1K"
   },
   {
     "Class":"Itemtype",
-    "Name":"http:\/\/schema.org\/DENonprofitType",
+    "Name":"https://schema.org/DENonprofitType",
     "Domain Bucket":"< 1K"
   },
   {
     "Class":"Itemtype",
-    "Name":"http:\/\/schema.org\/DanceEvent",
+    "Name":"https://schema.org/DanceEvent",
     "Domain Bucket":"< 1K"
   },
   {
     "Class":"Itemtype",
-    "Name":"http:\/\/schema.org\/DanceGroup",
+    "Name":"https://schema.org/DanceGroup",
     "Domain Bucket":"< 1K"
   },
   {
     "Class":"Itemtype",
-    "Name":"http:\/\/schema.org\/DataCatalog",
+    "Name":"https://schema.org/DataCatalog",
     "Domain Bucket":"1K - 10K"
   },
   {
     "Class":"Itemtype",
-    "Name":"http:\/\/schema.org\/DataDownload",
+    "Name":"https://schema.org/DataDownload",
     "Domain Bucket":"10K - 100K"
   },
   {
     "Class":"Itemtype",
-    "Name":"http:\/\/schema.org\/DataFeed",
+    "Name":"https://schema.org/DataFeed",
     "Domain Bucket":"1K - 10K"
   },
   {
     "Class":"Itemtype",
-    "Name":"http:\/\/schema.org\/DataFeedItem",
+    "Name":"https://schema.org/DataFeedItem",
     "Domain Bucket":"1K - 10K"
   },
   {
     "Class":"Itemtype",
-    "Name":"http:\/\/schema.org\/DataType",
+    "Name":"https://schema.org/DataType",
     "Domain Bucket":"< 1K"
   },
   {
     "Class":"Itemtype",
-    "Name":"http:\/\/schema.org\/Dataset",
+    "Name":"https://schema.org/Dataset",
     "Domain Bucket":"10K - 100K"
   },
   {
     "Class":"Itemtype",
-    "Name":"http:\/\/schema.org\/Date",
+    "Name":"https://schema.org/Date",
     "Domain Bucket":"< 1K"
   },
   {
     "Class":"Itemtype",
-    "Name":"http:\/\/schema.org\/DateTime",
+    "Name":"https://schema.org/DateTime",
     "Domain Bucket":"< 1K"
   },
   {
     "Class":"Itemtype",
-    "Name":"http:\/\/schema.org\/DatedMoneySpecification",
+    "Name":"https://schema.org/DatedMoneySpecification",
     "Domain Bucket":"< 1K"
   },
   {
     "Class":"Itemtype",
-    "Name":"http:\/\/schema.org\/DayOfWeek",
+    "Name":"https://schema.org/DayOfWeek",
     "Domain Bucket":"10K - 100K"
   },
   {
     "Class":"Itemtype",
-    "Name":"http:\/\/schema.org\/DaySpa",
+    "Name":"https://schema.org/DaySpa",
     "Domain Bucket":"1K - 10K"
   },
   {
     "Class":"Itemtype",
-    "Name":"http:\/\/schema.org\/DeactivateAction",
+    "Name":"https://schema.org/DeactivateAction",
     "Domain Bucket":"< 1K"
   },
   {
     "Class":"Itemtype",
-    "Name":"http:\/\/schema.org\/DefenceEstablishment",
+    "Name":"https://schema.org/DefenceEstablishment",
     "Domain Bucket":"< 1K"
   },
   {
     "Class":"Itemtype",
-    "Name":"http:\/\/schema.org\/DefinedRegion",
+    "Name":"https://schema.org/DefinedRegion",
     "Domain Bucket":"100K - 1M"
   },
   {
     "Class":"Itemtype",
-    "Name":"http:\/\/schema.org\/DefinedTerm",
+    "Name":"https://schema.org/DefinedTerm",
     "Domain Bucket":"10K - 100K"
   },
   {
     "Class":"Itemtype",
-    "Name":"http:\/\/schema.org\/DefinedTermSet",
+    "Name":"https://schema.org/DefinedTermSet",
     "Domain Bucket":"10K - 100K"
   },
   {
     "Class":"Itemtype",
-    "Name":"http:\/\/schema.org\/DeleteAction",
+    "Name":"https://schema.org/DeleteAction",
     "Domain Bucket":"< 1K"
   },
   {
     "Class":"Itemtype",
-    "Name":"http:\/\/schema.org\/DeliveryChargeSpecification",
+    "Name":"https://schema.org/DeliveryChargeSpecification",
     "Domain Bucket":"10K - 100K"
   },
   {
     "Class":"Itemtype",
-    "Name":"http:\/\/schema.org\/DeliveryEvent",
+    "Name":"https://schema.org/DeliveryEvent",
     "Domain Bucket":"< 1K"
   },
   {
     "Class":"Itemtype",
-    "Name":"http:\/\/schema.org\/DeliveryMethod",
+    "Name":"https://schema.org/DeliveryMethod",
     "Domain Bucket":"1K - 10K"
   },
   {
     "Class":"Itemtype",
-    "Name":"http:\/\/schema.org\/DeliveryTimeSettings",
+    "Name":"https://schema.org/DeliveryTimeSettings",
     "Domain Bucket":"< 1K"
   },
   {
     "Class":"Itemtype",
-    "Name":"http:\/\/schema.org\/Demand",
+    "Name":"https://schema.org/Demand",
     "Domain Bucket":"1K - 10K"
   },
   {
     "Class":"Itemtype",
-    "Name":"http:\/\/schema.org\/Dentist",
+    "Name":"https://schema.org/Dentist",
     "Domain Bucket":"10K - 100K"
   },
   {
     "Class":"Itemtype",
-    "Name":"http:\/\/schema.org\/DepartAction",
+    "Name":"https://schema.org/DepartAction",
     "Domain Bucket":"< 1K"
   },
   {
     "Class":"Itemtype",
-    "Name":"http:\/\/schema.org\/DepartmentStore",
+    "Name":"https://schema.org/DepartmentStore",
     "Domain Bucket":"1K - 10K"
   },
   {
     "Class":"Itemtype",
-    "Name":"http:\/\/schema.org\/DepositAccount",
+    "Name":"https://schema.org/DepositAccount",
     "Domain Bucket":"< 1K"
   },
   {
     "Class":"Itemtype",
-    "Name":"http:\/\/schema.org\/Dermatology",
+    "Name":"https://schema.org/Dermatology",
     "Domain Bucket":"1K - 10K"
   },
   {
     "Class":"Itemtype",
-    "Name":"http:\/\/schema.org\/DiagnosticLab",
+    "Name":"https://schema.org/DiagnosticLab",
     "Domain Bucket":"1K - 10K"
   },
   {
     "Class":"Itemtype",
-    "Name":"http:\/\/schema.org\/DiagnosticProcedure",
+    "Name":"https://schema.org/DiagnosticProcedure",
     "Domain Bucket":"< 1K"
   },
   {
     "Class":"Itemtype",
-    "Name":"http:\/\/schema.org\/Diet",
+    "Name":"https://schema.org/Diet",
     "Domain Bucket":"< 1K"
   },
   {
     "Class":"Itemtype",
-    "Name":"http:\/\/schema.org\/DietNutrition",
+    "Name":"https://schema.org/DietNutrition",
     "Domain Bucket":"1K - 10K"
   },
   {
     "Class":"Itemtype",
-    "Name":"http:\/\/schema.org\/DietarySupplement",
+    "Name":"https://schema.org/DietarySupplement",
     "Domain Bucket":"< 1K"
   },
   {
     "Class":"Itemtype",
-    "Name":"http:\/\/schema.org\/DigitalDocument",
+    "Name":"https://schema.org/DigitalDocument",
     "Domain Bucket":"10K - 100K"
   },
   {
     "Class":"Itemtype",
-    "Name":"http:\/\/schema.org\/DigitalDocumentPermission",
+    "Name":"https://schema.org/DigitalDocumentPermission",
     "Domain Bucket":"< 1K"
   },
   {
     "Class":"Itemtype",
-    "Name":"http:\/\/schema.org\/DigitalDocumentPermissionType",
+    "Name":"https://schema.org/DigitalDocumentPermissionType",
     "Domain Bucket":"< 1K"
   },
   {
     "Class":"Itemtype",
-    "Name":"http:\/\/schema.org\/DigitalPlatformEnumeration",
+    "Name":"https://schema.org/DigitalPlatformEnumeration",
     "Domain Bucket":"< 1K"
   },
   {
     "Class":"Itemtype",
-    "Name":"http:\/\/schema.org\/DisagreeAction",
+    "Name":"https://schema.org/DisagreeAction",
     "Domain Bucket":"< 1K"
   },
   {
     "Class":"Itemtype",
-    "Name":"http:\/\/schema.org\/DiscoverAction",
+    "Name":"https://schema.org/DiscoverAction",
     "Domain Bucket":"< 1K"
   },
   {
     "Class":"Itemtype",
-    "Name":"http:\/\/schema.org\/DiscussionForumPosting",
+    "Name":"https://schema.org/DiscussionForumPosting",
     "Domain Bucket":"10K - 100K"
   },
   {
     "Class":"Itemtype",
-    "Name":"http:\/\/schema.org\/DislikeAction",
+    "Name":"https://schema.org/DislikeAction",
     "Domain Bucket":"1K - 10K"
   },
   {
     "Class":"Itemtype",
-    "Name":"http:\/\/schema.org\/Distance",
+    "Name":"https://schema.org/Distance",
     "Domain Bucket":"1K - 10K"
   },
   {
     "Class":"Itemtype",
-    "Name":"http:\/\/schema.org\/Distillery",
+    "Name":"https://schema.org/Distillery",
     "Domain Bucket":"< 1K"
   },
   {
     "Class":"Itemtype",
-    "Name":"http:\/\/schema.org\/DonateAction",
+    "Name":"https://schema.org/DonateAction",
     "Domain Bucket":"1K - 10K"
   },
   {
     "Class":"Itemtype",
-    "Name":"http:\/\/schema.org\/DoseSchedule",
+    "Name":"https://schema.org/DoseSchedule",
     "Domain Bucket":"< 1K"
   },
   {
     "Class":"Itemtype",
-    "Name":"http:\/\/schema.org\/DownloadAction",
+    "Name":"https://schema.org/DownloadAction",
     "Domain Bucket":"1K - 10K"
   },
   {
     "Class":"Itemtype",
-    "Name":"http:\/\/schema.org\/DrawAction",
+    "Name":"https://schema.org/DrawAction",
     "Domain Bucket":"< 1K"
   },
   {
     "Class":"Itemtype",
-    "Name":"http:\/\/schema.org\/Drawing",
+    "Name":"https://schema.org/Drawing",
     "Domain Bucket":"< 1K"
   },
   {
     "Class":"Itemtype",
-    "Name":"http:\/\/schema.org\/DrinkAction",
+    "Name":"https://schema.org/DrinkAction",
     "Domain Bucket":"< 1K"
   },
   {
     "Class":"Itemtype",
-    "Name":"http:\/\/schema.org\/DriveWheelConfigurationValue",
+    "Name":"https://schema.org/DriveWheelConfigurationValue",
     "Domain Bucket":"< 1K"
   },
   {
     "Class":"Itemtype",
-    "Name":"http:\/\/schema.org\/Drug",
+    "Name":"https://schema.org/Drug",
     "Domain Bucket":"1K - 10K"
   },
   {
     "Class":"Itemtype",
-    "Name":"http:\/\/schema.org\/DrugClass",
+    "Name":"https://schema.org/DrugClass",
     "Domain Bucket":"1K - 10K"
   },
   {
     "Class":"Itemtype",
-    "Name":"http:\/\/schema.org\/DrugCost",
+    "Name":"https://schema.org/DrugCost",
     "Domain Bucket":"< 1K"
   },
   {
     "Class":"Itemtype",
-    "Name":"http:\/\/schema.org\/DrugCostCategory",
+    "Name":"https://schema.org/DrugCostCategory",
     "Domain Bucket":"< 1K"
   },
   {
     "Class":"Itemtype",
-    "Name":"http:\/\/schema.org\/DrugLegalStatus",
+    "Name":"https://schema.org/DrugLegalStatus",
     "Domain Bucket":"< 1K"
   },
   {
     "Class":"Itemtype",
-    "Name":"http:\/\/schema.org\/DrugPregnancyCategory",
+    "Name":"https://schema.org/DrugPregnancyCategory",
     "Domain Bucket":"< 1K"
   },
   {
     "Class":"Itemtype",
-    "Name":"http:\/\/schema.org\/DrugPrescriptionStatus",
+    "Name":"https://schema.org/DrugPrescriptionStatus",
     "Domain Bucket":"< 1K"
   },
   {
     "Class":"Itemtype",
-    "Name":"http:\/\/schema.org\/DrugStrength",
+    "Name":"https://schema.org/DrugStrength",
     "Domain Bucket":"< 1K"
   },
   {
     "Class":"Itemtype",
-    "Name":"http:\/\/schema.org\/DryCleaningOrLaundry",
+    "Name":"https://schema.org/DryCleaningOrLaundry",
     "Domain Bucket":"1K - 10K"
   },
   {
     "Class":"Itemtype",
-    "Name":"http:\/\/schema.org\/Duration",
+    "Name":"https://schema.org/Duration",
     "Domain Bucket":"10K - 100K"
   },
   {
     "Class":"Itemtype",
-    "Name":"http:\/\/schema.org\/EUEnergyEfficiencyEnumeration",
+    "Name":"https://schema.org/EUEnergyEfficiencyEnumeration",
     "Domain Bucket":"< 1K"
   },
   {
     "Class":"Itemtype",
-    "Name":"http:\/\/schema.org\/EatAction",
+    "Name":"https://schema.org/EatAction",
     "Domain Bucket":"< 1K"
   },
   {
     "Class":"Itemtype",
-    "Name":"http:\/\/schema.org\/EducationEvent",
+    "Name":"https://schema.org/EducationEvent",
     "Domain Bucket":"1K - 10K"
   },
   {
     "Class":"Itemtype",
-    "Name":"http:\/\/schema.org\/EducationalAudience",
+    "Name":"https://schema.org/EducationalAudience",
     "Domain Bucket":"10K - 100K"
   },
   {
     "Class":"Itemtype",
-    "Name":"http:\/\/schema.org\/EducationalOccupationalCredential",
+    "Name":"https://schema.org/EducationalOccupationalCredential",
     "Domain Bucket":"100K - 1M"
   },
   {
     "Class":"Itemtype",
-    "Name":"http:\/\/schema.org\/EducationalOccupationalProgram",
+    "Name":"https://schema.org/EducationalOccupationalProgram",
     "Domain Bucket":"1K - 10K"
   },
   {
     "Class":"Itemtype",
-    "Name":"http:\/\/schema.org\/EducationalOrganization",
+    "Name":"https://schema.org/EducationalOrganization",
     "Domain Bucket":"100K - 1M"
   },
   {
     "Class":"Itemtype",
-    "Name":"http:\/\/schema.org\/Electrician",
+    "Name":"https://schema.org/Electrician",
     "Domain Bucket":"10K - 100K"
   },
   {
     "Class":"Itemtype",
-    "Name":"http:\/\/schema.org\/ElectronicsStore",
+    "Name":"https://schema.org/ElectronicsStore",
     "Domain Bucket":"1K - 10K"
   },
   {
     "Class":"Itemtype",
-    "Name":"http:\/\/schema.org\/ElementarySchool",
+    "Name":"https://schema.org/ElementarySchool",
     "Domain Bucket":"< 1K"
   },
   {
     "Class":"Itemtype",
-    "Name":"http:\/\/schema.org\/EmailMessage",
+    "Name":"https://schema.org/EmailMessage",
     "Domain Bucket":"< 1K"
   },
   {
     "Class":"Itemtype",
-    "Name":"http:\/\/schema.org\/Embassy",
+    "Name":"https://schema.org/Embassy",
     "Domain Bucket":"< 1K"
   },
   {
     "Class":"Itemtype",
-    "Name":"http:\/\/schema.org\/Emergency",
+    "Name":"https://schema.org/Emergency",
     "Domain Bucket":"< 1K"
   },
   {
     "Class":"Itemtype",
-    "Name":"http:\/\/schema.org\/EmergencyService",
+    "Name":"https://schema.org/EmergencyService",
     "Domain Bucket":"1K - 10K"
   },
   {
     "Class":"Itemtype",
-    "Name":"http:\/\/schema.org\/EmployeeRole",
+    "Name":"https://schema.org/EmployeeRole",
     "Domain Bucket":"< 1K"
   },
   {
     "Class":"Itemtype",
-    "Name":"http:\/\/schema.org\/EmployerAggregateRating",
+    "Name":"https://schema.org/EmployerAggregateRating",
     "Domain Bucket":"1K - 10K"
   },
   {
     "Class":"Itemtype",
-    "Name":"http:\/\/schema.org\/EmployerReview",
+    "Name":"https://schema.org/EmployerReview",
     "Domain Bucket":"< 1K"
   },
   {
     "Class":"Itemtype",
-    "Name":"http:\/\/schema.org\/EmploymentAgency",
+    "Name":"https://schema.org/EmploymentAgency",
     "Domain Bucket":"1K - 10K"
   },
   {
     "Class":"Itemtype",
-    "Name":"http:\/\/schema.org\/EndorseAction",
+    "Name":"https://schema.org/EndorseAction",
     "Domain Bucket":"< 1K"
   },
   {
     "Class":"Itemtype",
-    "Name":"http:\/\/schema.org\/EndorsementRating",
+    "Name":"https://schema.org/EndorsementRating",
     "Domain Bucket":"< 1K"
   },
   {
     "Class":"Itemtype",
-    "Name":"http:\/\/schema.org\/Energy",
+    "Name":"https://schema.org/Energy",
     "Domain Bucket":"< 1K"
   },
   {
     "Class":"Itemtype",
-    "Name":"http:\/\/schema.org\/EnergyConsumptionDetails",
+    "Name":"https://schema.org/EnergyConsumptionDetails",
     "Domain Bucket":"1K - 10K"
   },
   {
     "Class":"Itemtype",
-    "Name":"http:\/\/schema.org\/EnergyEfficiencyEnumeration",
+    "Name":"https://schema.org/EnergyEfficiencyEnumeration",
     "Domain Bucket":"< 1K"
   },
   {
     "Class":"Itemtype",
-    "Name":"http:\/\/schema.org\/EnergyStarEnergyEfficiencyEnumeration",
+    "Name":"https://schema.org/EnergyStarEnergyEfficiencyEnumeration",
     "Domain Bucket":"< 1K"
   },
   {
     "Class":"Itemtype",
-    "Name":"http:\/\/schema.org\/EngineSpecification",
+    "Name":"https://schema.org/EngineSpecification",
     "Domain Bucket":"10K - 100K"
   },
   {
     "Class":"Itemtype",
-    "Name":"http:\/\/schema.org\/EntertainmentBusiness",
+    "Name":"https://schema.org/EntertainmentBusiness",
     "Domain Bucket":"10K - 100K"
   },
   {
     "Class":"Itemtype",
-    "Name":"http:\/\/schema.org\/EntryPoint",
+    "Name":"https://schema.org/EntryPoint",
     "Domain Bucket":"10M+"
   },
   {
     "Class":"Itemtype",
-    "Name":"http:\/\/schema.org\/Enumeration",
+    "Name":"https://schema.org/Enumeration",
     "Domain Bucket":"1K - 10K"
   },
   {
     "Class":"Itemtype",
-    "Name":"http:\/\/schema.org\/Episode",
+    "Name":"https://schema.org/Episode",
     "Domain Bucket":"1K - 10K"
   },
   {
     "Class":"Itemtype",
-    "Name":"http:\/\/schema.org\/Error",
+    "Name":"https://schema.org/Error",
     "Domain Bucket":"< 1K"
   },
   {
     "Class":"Itemtype",
-    "Name":"http:\/\/schema.org\/Event",
+    "Name":"https://schema.org/Event",
     "Domain Bucket":"100K - 1M"
   },
   {
     "Class":"Itemtype",
-    "Name":"http:\/\/schema.org\/EventAttendanceModeEnumeration",
+    "Name":"https://schema.org/EventAttendanceModeEnumeration",
     "Domain Bucket":"< 1K"
   },
   {
     "Class":"Itemtype",
-    "Name":"http:\/\/schema.org\/EventReservation",
+    "Name":"https://schema.org/EventReservation",
     "Domain Bucket":"< 1K"
   },
   {
     "Class":"Itemtype",
-    "Name":"http:\/\/schema.org\/EventSeries",
+    "Name":"https://schema.org/EventSeries",
     "Domain Bucket":"1K - 10K"
   },
   {
     "Class":"Itemtype",
-    "Name":"http:\/\/schema.org\/EventStatusType",
+    "Name":"https://schema.org/EventStatusType",
     "Domain Bucket":"< 1K"
   },
   {
     "Class":"Itemtype",
-    "Name":"http:\/\/schema.org\/EventVenue",
+    "Name":"https://schema.org/EventVenue",
     "Domain Bucket":"10K - 100K"
   },
   {
     "Class":"Itemtype",
-    "Name":"http:\/\/schema.org\/ExchangeRateSpecification",
+    "Name":"https://schema.org/ExchangeRateSpecification",
     "Domain Bucket":"< 1K"
   },
   {
     "Class":"Itemtype",
-    "Name":"http:\/\/schema.org\/ExerciseAction",
+    "Name":"https://schema.org/ExerciseAction",
     "Domain Bucket":"< 1K"
   },
   {
     "Class":"Itemtype",
-    "Name":"http:\/\/schema.org\/ExerciseGym",
+    "Name":"https://schema.org/ExerciseGym",
     "Domain Bucket":"1K - 10K"
   },
   {
     "Class":"Itemtype",
-    "Name":"http:\/\/schema.org\/ExercisePlan",
+    "Name":"https://schema.org/ExercisePlan",
     "Domain Bucket":"< 1K"
   },
   {
     "Class":"Itemtype",
-    "Name":"http:\/\/schema.org\/ExhibitionEvent",
+    "Name":"https://schema.org/ExhibitionEvent",
     "Domain Bucket":"1K - 10K"
   },
   {
     "Class":"Itemtype",
-    "Name":"http:\/\/schema.org\/FAQPage",
+    "Name":"https://schema.org/FAQPage",
     "Domain Bucket":"1M - 10M"
   },
   {
     "Class":"Itemtype",
-    "Name":"http:\/\/schema.org\/FMRadioChannel",
+    "Name":"https://schema.org/FMRadioChannel",
     "Domain Bucket":"< 1K"
   },
   {
     "Class":"Itemtype",
-    "Name":"http:\/\/schema.org\/FastFoodRestaurant",
+    "Name":"https://schema.org/FastFoodRestaurant",
     "Domain Bucket":"1K - 10K"
   },
   {
     "Class":"Itemtype",
-    "Name":"http:\/\/schema.org\/Festival",
+    "Name":"https://schema.org/Festival",
     "Domain Bucket":"1K - 10K"
   },
   {
     "Class":"Itemtype",
-    "Name":"http:\/\/schema.org\/FilmAction",
+    "Name":"https://schema.org/FilmAction",
     "Domain Bucket":"< 1K"
   },
   {
     "Class":"Itemtype",
-    "Name":"http:\/\/schema.org\/FinancialIncentive",
+    "Name":"https://schema.org/FinancialIncentive",
     "Domain Bucket":"< 1K"
   },
   {
     "Class":"Itemtype",
-    "Name":"http:\/\/schema.org\/FinancialProduct",
+    "Name":"https://schema.org/FinancialProduct",
     "Domain Bucket":"10K - 100K"
   },
   {
     "Class":"Itemtype",
-    "Name":"http:\/\/schema.org\/FinancialService",
+    "Name":"https://schema.org/FinancialService",
     "Domain Bucket":"10K - 100K"
   },
   {
     "Class":"Itemtype",
-    "Name":"http:\/\/schema.org\/FindAction",
+    "Name":"https://schema.org/FindAction",
     "Domain Bucket":"1K - 10K"
   },
   {
     "Class":"Itemtype",
-    "Name":"http:\/\/schema.org\/FireStation",
+    "Name":"https://schema.org/FireStation",
     "Domain Bucket":"< 1K"
   },
   {
     "Class":"Itemtype",
-    "Name":"http:\/\/schema.org\/Flight",
+    "Name":"https://schema.org/Flight",
     "Domain Bucket":"1K - 10K"
   },
   {
     "Class":"Itemtype",
-    "Name":"http:\/\/schema.org\/FlightReservation",
+    "Name":"https://schema.org/FlightReservation",
     "Domain Bucket":"< 1K"
   },
   {
     "Class":"Itemtype",
-    "Name":"http:\/\/schema.org\/Float",
+    "Name":"https://schema.org/Float",
     "Domain Bucket":"< 1K"
   },
   {
     "Class":"Itemtype",
-    "Name":"http:\/\/schema.org\/FloorPlan",
+    "Name":"https://schema.org/FloorPlan",
     "Domain Bucket":"10K - 100K"
   },
   {
     "Class":"Itemtype",
-    "Name":"http:\/\/schema.org\/Florist",
+    "Name":"https://schema.org/Florist",
     "Domain Bucket":"10K - 100K"
   },
   {
     "Class":"Itemtype",
-    "Name":"http:\/\/schema.org\/FollowAction",
+    "Name":"https://schema.org/FollowAction",
     "Domain Bucket":"10K - 100K"
   },
   {
     "Class":"Itemtype",
-    "Name":"http:\/\/schema.org\/FoodEstablishment",
+    "Name":"https://schema.org/FoodEstablishment",
     "Domain Bucket":"10K - 100K"
   },
   {
     "Class":"Itemtype",
-    "Name":"http:\/\/schema.org\/FoodEstablishmentReservation",
+    "Name":"https://schema.org/FoodEstablishmentReservation",
     "Domain Bucket":"1K - 10K"
   },
   {
     "Class":"Itemtype",
-    "Name":"http:\/\/schema.org\/FoodEvent",
+    "Name":"https://schema.org/FoodEvent",
     "Domain Bucket":"1K - 10K"
   },
   {
     "Class":"Itemtype",
-    "Name":"http:\/\/schema.org\/FoodService",
+    "Name":"https://schema.org/FoodService",
     "Domain Bucket":"1K - 10K"
   },
   {
     "Class":"Itemtype",
-    "Name":"http:\/\/schema.org\/FulfillmentTypeEnumeration",
+    "Name":"https://schema.org/FulfillmentTypeEnumeration",
     "Domain Bucket":"< 1K"
   },
   {
     "Class":"Itemtype",
-    "Name":"http:\/\/schema.org\/FundingAgency",
+    "Name":"https://schema.org/FundingAgency",
     "Domain Bucket":"< 1K"
   },
   {
     "Class":"Itemtype",
-    "Name":"http:\/\/schema.org\/FundingScheme",
+    "Name":"https://schema.org/FundingScheme",
     "Domain Bucket":"< 1K"
   },
   {
     "Class":"Itemtype",
-    "Name":"http:\/\/schema.org\/FurnitureStore",
+    "Name":"https://schema.org/FurnitureStore",
     "Domain Bucket":"10K - 100K"
   },
   {
     "Class":"Itemtype",
-    "Name":"http:\/\/schema.org\/Game",
+    "Name":"https://schema.org/Game",
     "Domain Bucket":"100K - 1M"
   },
   {
     "Class":"Itemtype",
-    "Name":"http:\/\/schema.org\/GameAvailabilityEnumeration",
+    "Name":"https://schema.org/GameAvailabilityEnumeration",
     "Domain Bucket":"< 1K"
   },
   {
     "Class":"Itemtype",
-    "Name":"http:\/\/schema.org\/GamePlayMode",
+    "Name":"https://schema.org/GamePlayMode",
     "Domain Bucket":"< 1K"
   },
   {
     "Class":"Itemtype",
-    "Name":"http:\/\/schema.org\/GameServer",
+    "Name":"https://schema.org/GameServer",
     "Domain Bucket":"1K - 10K"
   },
   {
     "Class":"Itemtype",
-    "Name":"http:\/\/schema.org\/GameServerStatus",
+    "Name":"https://schema.org/GameServerStatus",
     "Domain Bucket":"< 1K"
   },
   {
     "Class":"Itemtype",
-    "Name":"http:\/\/schema.org\/GardenStore",
+    "Name":"https://schema.org/GardenStore",
     "Domain Bucket":"1K - 10K"
   },
   {
     "Class":"Itemtype",
-    "Name":"http:\/\/schema.org\/GasStation",
+    "Name":"https://schema.org/GasStation",
     "Domain Bucket":"1K - 10K"
   },
   {
     "Class":"Itemtype",
-    "Name":"http:\/\/schema.org\/GatedResidenceCommunity",
+    "Name":"https://schema.org/GatedResidenceCommunity",
     "Domain Bucket":"< 1K"
   },
   {
     "Class":"Itemtype",
-    "Name":"http:\/\/schema.org\/GenderType",
+    "Name":"https://schema.org/GenderType",
     "Domain Bucket":"< 1K"
   },
   {
     "Class":"Itemtype",
-    "Name":"http:\/\/schema.org\/Gene",
+    "Name":"https://schema.org/Gene",
     "Domain Bucket":"< 1K"
   },
   {
     "Class":"Itemtype",
-    "Name":"http:\/\/schema.org\/GeneralContractor",
+    "Name":"https://schema.org/GeneralContractor",
     "Domain Bucket":"10K - 100K"
   },
   {
     "Class":"Itemtype",
-    "Name":"http:\/\/schema.org\/GeoCircle",
+    "Name":"https://schema.org/GeoCircle",
     "Domain Bucket":"100K - 1M"
   },
   {
     "Class":"Itemtype",
-    "Name":"http:\/\/schema.org\/GeoCoordinates",
+    "Name":"https://schema.org/GeoCoordinates",
     "Domain Bucket":"1M - 10M"
   },
   {
     "Class":"Itemtype",
-    "Name":"http:\/\/schema.org\/GeoShape",
+    "Name":"https://schema.org/GeoShape",
     "Domain Bucket":"10K - 100K"
   },
   {
     "Class":"Itemtype",
-    "Name":"http:\/\/schema.org\/GeospatialGeometry",
+    "Name":"https://schema.org/GeospatialGeometry",
     "Domain Bucket":"< 1K"
   },
   {
     "Class":"Itemtype",
-    "Name":"http:\/\/schema.org\/Geriatric",
+    "Name":"https://schema.org/Geriatric",
     "Domain Bucket":"< 1K"
   },
   {
     "Class":"Itemtype",
-    "Name":"http:\/\/schema.org\/GiveAction",
+    "Name":"https://schema.org/GiveAction",
     "Domain Bucket":"< 1K"
   },
   {
     "Class":"Itemtype",
-    "Name":"http:\/\/schema.org\/GolfCourse",
+    "Name":"https://schema.org/GolfCourse",
     "Domain Bucket":"1K - 10K"
   },
   {
     "Class":"Itemtype",
-    "Name":"http:\/\/schema.org\/GovernmentBenefitsType",
+    "Name":"https://schema.org/GovernmentBenefitsType",
     "Domain Bucket":"< 1K"
   },
   {
     "Class":"Itemtype",
-    "Name":"http:\/\/schema.org\/GovernmentBuilding",
+    "Name":"https://schema.org/GovernmentBuilding",
     "Domain Bucket":"< 1K"
   },
   {
     "Class":"Itemtype",
-    "Name":"http:\/\/schema.org\/GovernmentOffice",
+    "Name":"https://schema.org/GovernmentOffice",
     "Domain Bucket":"1K - 10K"
   },
   {
     "Class":"Itemtype",
-    "Name":"http:\/\/schema.org\/GovernmentOrganization",
+    "Name":"https://schema.org/GovernmentOrganization",
     "Domain Bucket":"10K - 100K"
   },
   {
     "Class":"Itemtype",
-    "Name":"http:\/\/schema.org\/GovernmentPermit",
+    "Name":"https://schema.org/GovernmentPermit",
     "Domain Bucket":"< 1K"
   },
   {
     "Class":"Itemtype",
-    "Name":"http:\/\/schema.org\/GovernmentService",
+    "Name":"https://schema.org/GovernmentService",
     "Domain Bucket":"1K - 10K"
   },
   {
     "Class":"Itemtype",
-    "Name":"http:\/\/schema.org\/Grant",
+    "Name":"https://schema.org/Grant",
     "Domain Bucket":"1K - 10K"
   },
   {
     "Class":"Itemtype",
-    "Name":"http:\/\/schema.org\/GroceryStore",
+    "Name":"https://schema.org/GroceryStore",
     "Domain Bucket":"1K - 10K"
   },
   {
     "Class":"Itemtype",
-    "Name":"http:\/\/schema.org\/Guide",
+    "Name":"https://schema.org/Guide",
     "Domain Bucket":"1K - 10K"
   },
   {
     "Class":"Itemtype",
-    "Name":"http:\/\/schema.org\/Gynecologic",
+    "Name":"https://schema.org/Gynecologic",
     "Domain Bucket":"< 1K"
   },
   {
     "Class":"Itemtype",
-    "Name":"http:\/\/schema.org\/HVACBusiness",
+    "Name":"https://schema.org/HVACBusiness",
     "Domain Bucket":"10K - 100K"
   },
   {
     "Class":"Itemtype",
-    "Name":"http:\/\/schema.org\/Hackathon",
+    "Name":"https://schema.org/Hackathon",
     "Domain Bucket":"< 1K"
   },
   {
     "Class":"Itemtype",
-    "Name":"http:\/\/schema.org\/HairSalon",
+    "Name":"https://schema.org/HairSalon",
     "Domain Bucket":"10K - 100K"
   },
   {
     "Class":"Itemtype",
-    "Name":"http:\/\/schema.org\/HardwareStore",
+    "Name":"https://schema.org/HardwareStore",
     "Domain Bucket":"1K - 10K"
   },
   {
     "Class":"Itemtype",
-    "Name":"http:\/\/schema.org\/HealthAndBeautyBusiness",
+    "Name":"https://schema.org/HealthAndBeautyBusiness",
     "Domain Bucket":"10K - 100K"
   },
   {
     "Class":"Itemtype",
-    "Name":"http:\/\/schema.org\/HealthAspectEnumeration",
+    "Name":"https://schema.org/HealthAspectEnumeration",
     "Domain Bucket":"< 1K"
   },
   {
     "Class":"Itemtype",
-    "Name":"http:\/\/schema.org\/HealthClub",
+    "Name":"https://schema.org/HealthClub",
     "Domain Bucket":"1K - 10K"
   },
   {
     "Class":"Itemtype",
-    "Name":"http:\/\/schema.org\/HealthInsurancePlan",
+    "Name":"https://schema.org/HealthInsurancePlan",
     "Domain Bucket":"< 1K"
   },
   {
     "Class":"Itemtype",
-    "Name":"http:\/\/schema.org\/HealthPlanCostSharingSpecification",
+    "Name":"https://schema.org/HealthPlanCostSharingSpecification",
     "Domain Bucket":"< 1K"
   },
   {
     "Class":"Itemtype",
-    "Name":"http:\/\/schema.org\/HealthPlanFormulary",
+    "Name":"https://schema.org/HealthPlanFormulary",
     "Domain Bucket":"< 1K"
   },
   {
     "Class":"Itemtype",
-    "Name":"http:\/\/schema.org\/HealthPlanNetwork",
+    "Name":"https://schema.org/HealthPlanNetwork",
     "Domain Bucket":"< 1K"
   },
   {
     "Class":"Itemtype",
-    "Name":"http:\/\/schema.org\/HealthTopicContent",
+    "Name":"https://schema.org/HealthTopicContent",
     "Domain Bucket":"< 1K"
   },
   {
     "Class":"Itemtype",
-    "Name":"http:\/\/schema.org\/HighSchool",
+    "Name":"https://schema.org/HighSchool",
     "Domain Bucket":"1K - 10K"
   },
   {
     "Class":"Itemtype",
-    "Name":"http:\/\/schema.org\/HinduTemple",
+    "Name":"https://schema.org/HinduTemple",
     "Domain Bucket":"< 1K"
   },
   {
     "Class":"Itemtype",
-    "Name":"http:\/\/schema.org\/HobbyShop",
+    "Name":"https://schema.org/HobbyShop",
     "Domain Bucket":"1K - 10K"
   },
   {
     "Class":"Itemtype",
-    "Name":"http:\/\/schema.org\/HomeAndConstructionBusiness",
+    "Name":"https://schema.org/HomeAndConstructionBusiness",
     "Domain Bucket":"100K - 1M"
   },
   {
     "Class":"Itemtype",
-    "Name":"http:\/\/schema.org\/HomeGoodsStore",
+    "Name":"https://schema.org/HomeGoodsStore",
     "Domain Bucket":"1K - 10K"
   },
   {
     "Class":"Itemtype",
-    "Name":"http:\/\/schema.org\/Hospital",
+    "Name":"https://schema.org/Hospital",
     "Domain Bucket":"10K - 100K"
   },
   {
     "Class":"Itemtype",
-    "Name":"http:\/\/schema.org\/Hostel",
+    "Name":"https://schema.org/Hostel",
     "Domain Bucket":"1K - 10K"
   },
   {
     "Class":"Itemtype",
-    "Name":"http:\/\/schema.org\/Hotel",
+    "Name":"https://schema.org/Hotel",
     "Domain Bucket":"100K - 1M"
   },
   {
     "Class":"Itemtype",
-    "Name":"http:\/\/schema.org\/HotelRoom",
+    "Name":"https://schema.org/HotelRoom",
     "Domain Bucket":"10K - 100K"
   },
   {
     "Class":"Itemtype",
-    "Name":"http:\/\/schema.org\/House",
+    "Name":"https://schema.org/House",
     "Domain Bucket":"10K - 100K"
   },
   {
     "Class":"Itemtype",
-    "Name":"http:\/\/schema.org\/HousePainter",
+    "Name":"https://schema.org/HousePainter",
     "Domain Bucket":"1K - 10K"
   },
   {
     "Class":"Itemtype",
-    "Name":"http:\/\/schema.org\/HowTo",
+    "Name":"https://schema.org/HowTo",
     "Domain Bucket":"100K - 1M"
   },
   {
     "Class":"Itemtype",
-    "Name":"http:\/\/schema.org\/HowToDirection",
+    "Name":"https://schema.org/HowToDirection",
     "Domain Bucket":"10K - 100K"
   },
   {
     "Class":"Itemtype",
-    "Name":"http:\/\/schema.org\/HowToItem",
+    "Name":"https://schema.org/HowToItem",
     "Domain Bucket":"< 1K"
   },
   {
     "Class":"Itemtype",
-    "Name":"http:\/\/schema.org\/HowToSection",
+    "Name":"https://schema.org/HowToSection",
     "Domain Bucket":"10K - 100K"
   },
   {
     "Class":"Itemtype",
-    "Name":"http:\/\/schema.org\/HowToStep",
+    "Name":"https://schema.org/HowToStep",
     "Domain Bucket":"100K - 1M"
   },
   {
     "Class":"Itemtype",
-    "Name":"http:\/\/schema.org\/HowToSupply",
+    "Name":"https://schema.org/HowToSupply",
     "Domain Bucket":"10K - 100K"
   },
   {
     "Class":"Itemtype",
-    "Name":"http:\/\/schema.org\/HowToTip",
+    "Name":"https://schema.org/HowToTip",
     "Domain Bucket":"1K - 10K"
   },
   {
     "Class":"Itemtype",
-    "Name":"http:\/\/schema.org\/HowToTool",
+    "Name":"https://schema.org/HowToTool",
     "Domain Bucket":"10K - 100K"
   },
   {
     "Class":"Itemtype",
-    "Name":"http:\/\/schema.org\/HyperToc",
+    "Name":"https://schema.org/HyperToc",
     "Domain Bucket":"< 1K"
   },
   {
     "Class":"Itemtype",
-    "Name":"http:\/\/schema.org\/HyperTocEntry",
+    "Name":"https://schema.org/HyperTocEntry",
     "Domain Bucket":"< 1K"
   },
   {
     "Class":"Itemtype",
-    "Name":"http:\/\/schema.org\/IPTCDigitalSourceEnumeration",
+    "Name":"https://schema.org/IPTCDigitalSourceEnumeration",
     "Domain Bucket":"< 1K"
   },
   {
     "Class":"Itemtype",
-    "Name":"http:\/\/schema.org\/ITNonprofitType",
+    "Name":"https://schema.org/ITNonprofitType",
     "Domain Bucket":"< 1K"
   },
   {
     "Class":"Itemtype",
-    "Name":"http:\/\/schema.org\/IceCreamShop",
+    "Name":"https://schema.org/IceCreamShop",
     "Domain Bucket":"1K - 10K"
   },
   {
     "Class":"Itemtype",
-    "Name":"http:\/\/schema.org\/IgnoreAction",
+    "Name":"https://schema.org/IgnoreAction",
     "Domain Bucket":"< 1K"
   },
   {
     "Class":"Itemtype",
-    "Name":"http:\/\/schema.org\/ImageGallery",
+    "Name":"https://schema.org/ImageGallery",
     "Domain Bucket":"1M - 10M"
   },
   {
     "Class":"Itemtype",
-    "Name":"http:\/\/schema.org\/ImageObject",
+    "Name":"https://schema.org/ImageObject",
     "Domain Bucket":"10M+"
   },
   {
     "Class":"Itemtype",
-    "Name":"http:\/\/schema.org\/ImageObjectSnapshot",
+    "Name":"https://schema.org/ImageObjectSnapshot",
     "Domain Bucket":"< 1K"
   },
   {
     "Class":"Itemtype",
-    "Name":"http:\/\/schema.org\/ImagingTest",
+    "Name":"https://schema.org/ImagingTest",
     "Domain Bucket":"< 1K"
   },
   {
     "Class":"Itemtype",
-    "Name":"http:\/\/schema.org\/IncentiveQualifiedExpenseType",
+    "Name":"https://schema.org/IncentiveQualifiedExpenseType",
     "Domain Bucket":"< 1K"
   },
   {
     "Class":"Itemtype",
-    "Name":"http:\/\/schema.org\/IncentiveStatus",
+    "Name":"https://schema.org/IncentiveStatus",
     "Domain Bucket":"< 1K"
   },
   {
     "Class":"Itemtype",
-    "Name":"http:\/\/schema.org\/IncentiveType",
+    "Name":"https://schema.org/IncentiveType",
     "Domain Bucket":"< 1K"
   },
   {
     "Class":"Itemtype",
-    "Name":"http:\/\/schema.org\/IndividualPhysician",
+    "Name":"https://schema.org/IndividualPhysician",
     "Domain Bucket":"1K - 10K"
   },
   {
     "Class":"Itemtype",
-    "Name":"http:\/\/schema.org\/IndividualProduct",
+    "Name":"https://schema.org/IndividualProduct",
     "Domain Bucket":"10K - 100K"
   },
   {
     "Class":"Itemtype",
-    "Name":"http:\/\/schema.org\/InfectiousAgentClass",
+    "Name":"https://schema.org/InfectiousAgentClass",
     "Domain Bucket":"< 1K"
   },
   {
     "Class":"Itemtype",
-    "Name":"http:\/\/schema.org\/InfectiousDisease",
+    "Name":"https://schema.org/InfectiousDisease",
     "Domain Bucket":"< 1K"
   },
   {
     "Class":"Itemtype",
-    "Name":"http:\/\/schema.org\/InformAction",
+    "Name":"https://schema.org/InformAction",
     "Domain Bucket":"< 1K"
   },
   {
     "Class":"Itemtype",
-    "Name":"http:\/\/schema.org\/InsertAction",
+    "Name":"https://schema.org/InsertAction",
     "Domain Bucket":"< 1K"
   },
   {
     "Class":"Itemtype",
-    "Name":"http:\/\/schema.org\/InstallAction",
+    "Name":"https://schema.org/InstallAction",
     "Domain Bucket":"< 1K"
   },
   {
     "Class":"Itemtype",
-    "Name":"http:\/\/schema.org\/InstantaneousEvent",
+    "Name":"https://schema.org/InstantaneousEvent",
     "Domain Bucket":"< 1K"
   },
   {
     "Class":"Itemtype",
-    "Name":"http:\/\/schema.org\/InsuranceAgency",
+    "Name":"https://schema.org/InsuranceAgency",
     "Domain Bucket":"10K - 100K"
   },
   {
     "Class":"Itemtype",
-    "Name":"http:\/\/schema.org\/Intangible",
+    "Name":"https://schema.org/Intangible",
     "Domain Bucket":"1K - 10K"
   },
   {
     "Class":"Itemtype",
-    "Name":"http:\/\/schema.org\/Integer",
+    "Name":"https://schema.org/Integer",
     "Domain Bucket":"< 1K"
   },
   {
     "Class":"Itemtype",
-    "Name":"http:\/\/schema.org\/InteractAction",
+    "Name":"https://schema.org/InteractAction",
     "Domain Bucket":"1K - 10K"
   },
   {
     "Class":"Itemtype",
-    "Name":"http:\/\/schema.org\/InteractionCounter",
+    "Name":"https://schema.org/InteractionCounter",
     "Domain Bucket":"100K - 1M"
   },
   {
     "Class":"Itemtype",
-    "Name":"http:\/\/schema.org\/InternetCafe",
+    "Name":"https://schema.org/InternetCafe",
     "Domain Bucket":"< 1K"
   },
   {
     "Class":"Itemtype",
-    "Name":"http:\/\/schema.org\/InvestmentFund",
+    "Name":"https://schema.org/InvestmentFund",
     "Domain Bucket":"< 1K"
   },
   {
     "Class":"Itemtype",
-    "Name":"http:\/\/schema.org\/InvestmentOrDeposit",
+    "Name":"https://schema.org/InvestmentOrDeposit",
     "Domain Bucket":"< 1K"
   },
   {
     "Class":"Itemtype",
-    "Name":"http:\/\/schema.org\/InviteAction",
+    "Name":"https://schema.org/InviteAction",
     "Domain Bucket":"< 1K"
   },
   {
     "Class":"Itemtype",
-    "Name":"http:\/\/schema.org\/Invoice",
+    "Name":"https://schema.org/Invoice",
     "Domain Bucket":"< 1K"
   },
   {
     "Class":"Itemtype",
-    "Name":"http:\/\/schema.org\/ItemAvailability",
+    "Name":"https://schema.org/ItemAvailability",
     "Domain Bucket":"1K - 10K"
   },
   {
     "Class":"Itemtype",
-    "Name":"http:\/\/schema.org\/ItemList",
+    "Name":"https://schema.org/ItemList",
     "Domain Bucket":"1M - 10M"
   },
   {
     "Class":"Itemtype",
-    "Name":"http:\/\/schema.org\/ItemListOrderType",
+    "Name":"https://schema.org/ItemListOrderType",
     "Domain Bucket":"< 1K"
   },
   {
     "Class":"Itemtype",
-    "Name":"http:\/\/schema.org\/ItemPage",
+    "Name":"https://schema.org/ItemPage",
     "Domain Bucket":"1M - 10M"
   },
   {
     "Class":"Itemtype",
-    "Name":"http:\/\/schema.org\/JewelryStore",
+    "Name":"https://schema.org/JewelryStore",
     "Domain Bucket":"10K - 100K"
   },
   {
     "Class":"Itemtype",
-    "Name":"http:\/\/schema.org\/JobPosting",
+    "Name":"https://schema.org/JobPosting",
     "Domain Bucket":"100K - 1M"
   },
   {
     "Class":"Itemtype",
-    "Name":"http:\/\/schema.org\/JoinAction",
+    "Name":"https://schema.org/JoinAction",
     "Domain Bucket":"1K - 10K"
   },
   {
     "Class":"Itemtype",
-    "Name":"http:\/\/schema.org\/Joint",
+    "Name":"https://schema.org/Joint",
     "Domain Bucket":"< 1K"
   },
   {
     "Class":"Itemtype",
-    "Name":"http:\/\/schema.org\/LakeBodyOfWater",
+    "Name":"https://schema.org/LakeBodyOfWater",
     "Domain Bucket":"< 1K"
   },
   {
     "Class":"Itemtype",
-    "Name":"http:\/\/schema.org\/Landform",
+    "Name":"https://schema.org/Landform",
     "Domain Bucket":"1K - 10K"
   },
   {
     "Class":"Itemtype",
-    "Name":"http:\/\/schema.org\/LandmarksOrHistoricalBuildings",
+    "Name":"https://schema.org/LandmarksOrHistoricalBuildings",
     "Domain Bucket":"1K - 10K"
   },
   {
     "Class":"Itemtype",
-    "Name":"http:\/\/schema.org\/Language",
+    "Name":"https://schema.org/Language",
     "Domain Bucket":"10K - 100K"
   },
   {
     "Class":"Itemtype",
-    "Name":"http:\/\/schema.org\/LearningResource",
+    "Name":"https://schema.org/LearningResource",
     "Domain Bucket":"1K - 10K"
   },
   {
     "Class":"Itemtype",
-    "Name":"http:\/\/schema.org\/LeaveAction",
+    "Name":"https://schema.org/LeaveAction",
     "Domain Bucket":"< 1K"
   },
   {
     "Class":"Itemtype",
-    "Name":"http:\/\/schema.org\/LegalForceStatus",
+    "Name":"https://schema.org/LegalForceStatus",
     "Domain Bucket":"< 1K"
   },
   {
     "Class":"Itemtype",
-    "Name":"http:\/\/schema.org\/LegalService",
+    "Name":"https://schema.org/LegalService",
     "Domain Bucket":"10K - 100K"
   },
   {
     "Class":"Itemtype",
-    "Name":"http:\/\/schema.org\/LegalValueLevel",
+    "Name":"https://schema.org/LegalValueLevel",
     "Domain Bucket":"< 1K"
   },
   {
     "Class":"Itemtype",
-    "Name":"http:\/\/schema.org\/Legislation",
+    "Name":"https://schema.org/Legislation",
     "Domain Bucket":"1K - 10K"
   },
   {
     "Class":"Itemtype",
-    "Name":"http:\/\/schema.org\/LegislationObject",
+    "Name":"https://schema.org/LegislationObject",
     "Domain Bucket":"1K - 10K"
   },
   {
     "Class":"Itemtype",
-    "Name":"http:\/\/schema.org\/LegislativeBuilding",
+    "Name":"https://schema.org/LegislativeBuilding",
     "Domain Bucket":"< 1K"
   },
   {
     "Class":"Itemtype",
-    "Name":"http:\/\/schema.org\/LendAction",
+    "Name":"https://schema.org/LendAction",
     "Domain Bucket":"< 1K"
   },
   {
     "Class":"Itemtype",
-    "Name":"http:\/\/schema.org\/Library",
+    "Name":"https://schema.org/Library",
     "Domain Bucket":"1K - 10K"
   },
   {
     "Class":"Itemtype",
-    "Name":"http:\/\/schema.org\/LibrarySystem",
+    "Name":"https://schema.org/LibrarySystem",
     "Domain Bucket":"< 1K"
   },
   {
     "Class":"Itemtype",
-    "Name":"http:\/\/schema.org\/LifestyleModification",
+    "Name":"https://schema.org/LifestyleModification",
     "Domain Bucket":"< 1K"
   },
   {
     "Class":"Itemtype",
-    "Name":"http:\/\/schema.org\/Ligament",
+    "Name":"https://schema.org/Ligament",
     "Domain Bucket":"< 1K"
   },
   {
     "Class":"Itemtype",
-    "Name":"http:\/\/schema.org\/LikeAction",
+    "Name":"https://schema.org/LikeAction",
     "Domain Bucket":"10K - 100K"
   },
   {
     "Class":"Itemtype",
-    "Name":"http:\/\/schema.org\/LinkRole",
+    "Name":"https://schema.org/LinkRole",
     "Domain Bucket":"< 1K"
   },
   {
     "Class":"Itemtype",
-    "Name":"http:\/\/schema.org\/LiquorStore",
+    "Name":"https://schema.org/LiquorStore",
     "Domain Bucket":"1K - 10K"
   },
   {
     "Class":"Itemtype",
-    "Name":"http:\/\/schema.org\/ListItem",
+    "Name":"https://schema.org/ListItem",
     "Domain Bucket":"10M+"
   },
   {
     "Class":"Itemtype",
-    "Name":"http:\/\/schema.org\/ListenAction",
+    "Name":"https://schema.org/ListenAction",
     "Domain Bucket":"1K - 10K"
   },
   {
     "Class":"Itemtype",
-    "Name":"http:\/\/schema.org\/Literal",
+    "Name":"https://schema.org/Literal",
     "Domain Bucket":"< 1K"
   },
   {
     "Class":"Itemtype",
-    "Name":"http:\/\/schema.org\/LiteraryEvent",
+    "Name":"https://schema.org/LiteraryEvent",
     "Domain Bucket":"< 1K"
   },
   {
     "Class":"Itemtype",
-    "Name":"http:\/\/schema.org\/LiveBlogPosting",
+    "Name":"https://schema.org/LiveBlogPosting",
     "Domain Bucket":"1K - 10K"
   },
   {
     "Class":"Itemtype",
-    "Name":"http:\/\/schema.org\/LoanOrCredit",
+    "Name":"https://schema.org/LoanOrCredit",
     "Domain Bucket":"1K - 10K"
   },
   {
     "Class":"Itemtype",
-    "Name":"http:\/\/schema.org\/LocalBusiness",
+    "Name":"https://schema.org/LocalBusiness",
     "Domain Bucket":"1M - 10M"
   },
   {
     "Class":"Itemtype",
-    "Name":"http:\/\/schema.org\/LocationFeatureSpecification",
+    "Name":"https://schema.org/LocationFeatureSpecification",
     "Domain Bucket":"100K - 1M"
   },
   {
     "Class":"Itemtype",
-    "Name":"http:\/\/schema.org\/Locksmith",
+    "Name":"https://schema.org/Locksmith",
     "Domain Bucket":"10K - 100K"
   },
   {
     "Class":"Itemtype",
-    "Name":"http:\/\/schema.org\/LodgingBusiness",
+    "Name":"https://schema.org/LodgingBusiness",
     "Domain Bucket":"10K - 100K"
   },
   {
     "Class":"Itemtype",
-    "Name":"http:\/\/schema.org\/LodgingReservation",
+    "Name":"https://schema.org/LodgingReservation",
     "Domain Bucket":"1K - 10K"
   },
   {
     "Class":"Itemtype",
-    "Name":"http:\/\/schema.org\/LoginAction",
+    "Name":"https://schema.org/LoginAction",
     "Domain Bucket":"1K - 10K"
   },
   {
     "Class":"Itemtype",
-    "Name":"http:\/\/schema.org\/LoseAction",
+    "Name":"https://schema.org/LoseAction",
     "Domain Bucket":"< 1K"
   },
   {
     "Class":"Itemtype",
-    "Name":"http:\/\/schema.org\/LymphaticVessel",
+    "Name":"https://schema.org/LymphaticVessel",
     "Domain Bucket":"< 1K"
   },
   {
     "Class":"Itemtype",
-    "Name":"http:\/\/schema.org\/Manuscript",
+    "Name":"https://schema.org/Manuscript",
     "Domain Bucket":"< 1K"
   },
   {
     "Class":"Itemtype",
-    "Name":"http:\/\/schema.org\/Map",
+    "Name":"https://schema.org/Map",
     "Domain Bucket":"10K - 100K"
   },
   {
     "Class":"Itemtype",
-    "Name":"http:\/\/schema.org\/MapCategoryType",
+    "Name":"https://schema.org/MapCategoryType",
     "Domain Bucket":"< 1K"
   },
   {
     "Class":"Itemtype",
-    "Name":"http:\/\/schema.org\/MarryAction",
+    "Name":"https://schema.org/MarryAction",
     "Domain Bucket":"< 1K"
   },
   {
     "Class":"Itemtype",
-    "Name":"http:\/\/schema.org\/Mass",
+    "Name":"https://schema.org/Mass",
     "Domain Bucket":"< 1K"
   },
   {
     "Class":"Itemtype",
-    "Name":"http:\/\/schema.org\/MathSolver",
+    "Name":"https://schema.org/MathSolver",
     "Domain Bucket":"< 1K"
   },
   {
     "Class":"Itemtype",
-    "Name":"http:\/\/schema.org\/MaximumDoseSchedule",
+    "Name":"https://schema.org/MaximumDoseSchedule",
     "Domain Bucket":"< 1K"
   },
   {
     "Class":"Itemtype",
-    "Name":"http:\/\/schema.org\/MeasurementMethodEnum",
+    "Name":"https://schema.org/MeasurementMethodEnum",
     "Domain Bucket":"< 1K"
   },
   {
     "Class":"Itemtype",
-    "Name":"http:\/\/schema.org\/MeasurementTypeEnumeration",
+    "Name":"https://schema.org/MeasurementTypeEnumeration",
     "Domain Bucket":"< 1K"
   },
   {
     "Class":"Itemtype",
-    "Name":"http:\/\/schema.org\/MediaEnumeration",
+    "Name":"https://schema.org/MediaEnumeration",
     "Domain Bucket":"< 1K"
   },
   {
     "Class":"Itemtype",
-    "Name":"http:\/\/schema.org\/MediaGallery",
+    "Name":"https://schema.org/MediaGallery",
     "Domain Bucket":"1K - 10K"
   },
   {
     "Class":"Itemtype",
-    "Name":"http:\/\/schema.org\/MediaManipulationRatingEnumeration",
+    "Name":"https://schema.org/MediaManipulationRatingEnumeration",
     "Domain Bucket":"< 1K"
   },
   {
     "Class":"Itemtype",
-    "Name":"http:\/\/schema.org\/MediaObject",
+    "Name":"https://schema.org/MediaObject",
     "Domain Bucket":"100K - 1M"
   },
   {
     "Class":"Itemtype",
-    "Name":"http:\/\/schema.org\/MediaReview",
+    "Name":"https://schema.org/MediaReview",
     "Domain Bucket":"< 1K"
   },
   {
     "Class":"Itemtype",
-    "Name":"http:\/\/schema.org\/MediaReviewItem",
+    "Name":"https://schema.org/MediaReviewItem",
     "Domain Bucket":"< 1K"
   },
   {
     "Class":"Itemtype",
-    "Name":"http:\/\/schema.org\/MediaSubscription",
+    "Name":"https://schema.org/MediaSubscription",
     "Domain Bucket":"< 1K"
   },
   {
     "Class":"Itemtype",
-    "Name":"http:\/\/schema.org\/MedicalAudience",
+    "Name":"https://schema.org/MedicalAudience",
     "Domain Bucket":"10K - 100K"
   },
   {
     "Class":"Itemtype",
-    "Name":"http:\/\/schema.org\/MedicalAudienceType",
+    "Name":"https://schema.org/MedicalAudienceType",
     "Domain Bucket":"< 1K"
   },
   {
     "Class":"Itemtype",
-    "Name":"http:\/\/schema.org\/MedicalBusiness",
+    "Name":"https://schema.org/MedicalBusiness",
     "Domain Bucket":"100K - 1M"
   },
   {
     "Class":"Itemtype",
-    "Name":"http:\/\/schema.org\/MedicalCause",
+    "Name":"https://schema.org/MedicalCause",
     "Domain Bucket":"1K - 10K"
   },
   {
     "Class":"Itemtype",
-    "Name":"http:\/\/schema.org\/MedicalClinic",
+    "Name":"https://schema.org/MedicalClinic",
     "Domain Bucket":"10K - 100K"
   },
   {
     "Class":"Itemtype",
-    "Name":"http:\/\/schema.org\/MedicalCode",
+    "Name":"https://schema.org/MedicalCode",
     "Domain Bucket":"1K - 10K"
   },
   {
     "Class":"Itemtype",
-    "Name":"http:\/\/schema.org\/MedicalCondition",
+    "Name":"https://schema.org/MedicalCondition",
     "Domain Bucket":"10K - 100K"
   },
   {
     "Class":"Itemtype",
-    "Name":"http:\/\/schema.org\/MedicalConditionStage",
+    "Name":"https://schema.org/MedicalConditionStage",
     "Domain Bucket":"< 1K"
   },
   {
     "Class":"Itemtype",
-    "Name":"http:\/\/schema.org\/MedicalContraindication",
+    "Name":"https://schema.org/MedicalContraindication",
     "Domain Bucket":"< 1K"
   },
   {
     "Class":"Itemtype",
-    "Name":"http:\/\/schema.org\/MedicalDevice",
+    "Name":"https://schema.org/MedicalDevice",
     "Domain Bucket":"1K - 10K"
   },
   {
     "Class":"Itemtype",
-    "Name":"http:\/\/schema.org\/MedicalDevicePurpose",
+    "Name":"https://schema.org/MedicalDevicePurpose",
     "Domain Bucket":"< 1K"
   },
   {
     "Class":"Itemtype",
-    "Name":"http:\/\/schema.org\/MedicalEntity",
+    "Name":"https://schema.org/MedicalEntity",
     "Domain Bucket":"1K - 10K"
   },
   {
     "Class":"Itemtype",
-    "Name":"http:\/\/schema.org\/MedicalEnumeration",
+    "Name":"https://schema.org/MedicalEnumeration",
     "Domain Bucket":"< 1K"
   },
   {
     "Class":"Itemtype",
-    "Name":"http:\/\/schema.org\/MedicalEvidenceLevel",
+    "Name":"https://schema.org/MedicalEvidenceLevel",
     "Domain Bucket":"< 1K"
   },
   {
     "Class":"Itemtype",
-    "Name":"http:\/\/schema.org\/MedicalGuideline",
+    "Name":"https://schema.org/MedicalGuideline",
     "Domain Bucket":"1K - 10K"
   },
   {
     "Class":"Itemtype",
-    "Name":"http:\/\/schema.org\/MedicalGuidelineContraindication",
+    "Name":"https://schema.org/MedicalGuidelineContraindication",
     "Domain Bucket":"< 1K"
   },
   {
     "Class":"Itemtype",
-    "Name":"http:\/\/schema.org\/MedicalGuidelineRecommendation",
+    "Name":"https://schema.org/MedicalGuidelineRecommendation",
     "Domain Bucket":"< 1K"
   },
   {
     "Class":"Itemtype",
-    "Name":"http:\/\/schema.org\/MedicalImagingTechnique",
+    "Name":"https://schema.org/MedicalImagingTechnique",
     "Domain Bucket":"< 1K"
   },
   {
     "Class":"Itemtype",
-    "Name":"http:\/\/schema.org\/MedicalIndication",
+    "Name":"https://schema.org/MedicalIndication",
     "Domain Bucket":"1K - 10K"
   },
   {
     "Class":"Itemtype",
-    "Name":"http:\/\/schema.org\/MedicalIntangible",
+    "Name":"https://schema.org/MedicalIntangible",
     "Domain Bucket":"< 1K"
   },
   {
     "Class":"Itemtype",
-    "Name":"http:\/\/schema.org\/MedicalObservationalStudy",
+    "Name":"https://schema.org/MedicalObservationalStudy",
     "Domain Bucket":"< 1K"
   },
   {
     "Class":"Itemtype",
-    "Name":"http:\/\/schema.org\/MedicalObservationalStudyDesign",
+    "Name":"https://schema.org/MedicalObservationalStudyDesign",
     "Domain Bucket":"< 1K"
   },
   {
     "Class":"Itemtype",
-    "Name":"http:\/\/schema.org\/MedicalOrganization",
+    "Name":"https://schema.org/MedicalOrganization",
     "Domain Bucket":"10K - 100K"
   },
   {
     "Class":"Itemtype",
-    "Name":"http:\/\/schema.org\/MedicalProcedure",
+    "Name":"https://schema.org/MedicalProcedure",
     "Domain Bucket":"10K - 100K"
   },
   {
     "Class":"Itemtype",
-    "Name":"http:\/\/schema.org\/MedicalProcedureType",
+    "Name":"https://schema.org/MedicalProcedureType",
     "Domain Bucket":"< 1K"
   },
   {
     "Class":"Itemtype",
-    "Name":"http:\/\/schema.org\/MedicalRiskCalculator",
+    "Name":"https://schema.org/MedicalRiskCalculator",
     "Domain Bucket":"< 1K"
   },
   {
     "Class":"Itemtype",
-    "Name":"http:\/\/schema.org\/MedicalRiskEstimator",
+    "Name":"https://schema.org/MedicalRiskEstimator",
     "Domain Bucket":"< 1K"
   },
   {
     "Class":"Itemtype",
-    "Name":"http:\/\/schema.org\/MedicalRiskFactor",
+    "Name":"https://schema.org/MedicalRiskFactor",
     "Domain Bucket":"1K - 10K"
   },
   {
     "Class":"Itemtype",
-    "Name":"http:\/\/schema.org\/MedicalRiskScore",
+    "Name":"https://schema.org/MedicalRiskScore",
     "Domain Bucket":"< 1K"
   },
   {
     "Class":"Itemtype",
-    "Name":"http:\/\/schema.org\/MedicalScholarlyArticle",
+    "Name":"https://schema.org/MedicalScholarlyArticle",
     "Domain Bucket":"1K - 10K"
   },
   {
     "Class":"Itemtype",
-    "Name":"http:\/\/schema.org\/MedicalSign",
+    "Name":"https://schema.org/MedicalSign",
     "Domain Bucket":"< 1K"
   },
   {
     "Class":"Itemtype",
-    "Name":"http:\/\/schema.org\/MedicalSignOrSymptom",
+    "Name":"https://schema.org/MedicalSignOrSymptom",
     "Domain Bucket":"1K - 10K"
   },
   {
     "Class":"Itemtype",
-    "Name":"http:\/\/schema.org\/MedicalSpecialty",
+    "Name":"https://schema.org/MedicalSpecialty",
     "Domain Bucket":"10K - 100K"
   },
   {
     "Class":"Itemtype",
-    "Name":"http:\/\/schema.org\/MedicalStudy",
+    "Name":"https://schema.org/MedicalStudy",
     "Domain Bucket":"1K - 10K"
   },
   {
     "Class":"Itemtype",
-    "Name":"http:\/\/schema.org\/MedicalStudyStatus",
+    "Name":"https://schema.org/MedicalStudyStatus",
     "Domain Bucket":"< 1K"
   },
   {
     "Class":"Itemtype",
-    "Name":"http:\/\/schema.org\/MedicalSymptom",
+    "Name":"https://schema.org/MedicalSymptom",
     "Domain Bucket":"1K - 10K"
   },
   {
     "Class":"Itemtype",
-    "Name":"http:\/\/schema.org\/MedicalTest",
+    "Name":"https://schema.org/MedicalTest",
     "Domain Bucket":"1K - 10K"
   },
   {
     "Class":"Itemtype",
-    "Name":"http:\/\/schema.org\/MedicalTestPanel",
+    "Name":"https://schema.org/MedicalTestPanel",
     "Domain Bucket":"< 1K"
   },
   {
     "Class":"Itemtype",
-    "Name":"http:\/\/schema.org\/MedicalTherapy",
+    "Name":"https://schema.org/MedicalTherapy",
     "Domain Bucket":"10K - 100K"
   },
   {
     "Class":"Itemtype",
-    "Name":"http:\/\/schema.org\/MedicalTrial",
+    "Name":"https://schema.org/MedicalTrial",
     "Domain Bucket":"< 1K"
   },
   {
     "Class":"Itemtype",
-    "Name":"http:\/\/schema.org\/MedicalTrialDesign",
+    "Name":"https://schema.org/MedicalTrialDesign",
     "Domain Bucket":"< 1K"
   },
   {
     "Class":"Itemtype",
-    "Name":"http:\/\/schema.org\/MedicalWebPage",
+    "Name":"https://schema.org/MedicalWebPage",
     "Domain Bucket":"10K - 100K"
   },
   {
     "Class":"Itemtype",
-    "Name":"http:\/\/schema.org\/MedicineSystem",
+    "Name":"https://schema.org/MedicineSystem",
     "Domain Bucket":"< 1K"
   },
   {
     "Class":"Itemtype",
-    "Name":"http:\/\/schema.org\/MeetingRoom",
+    "Name":"https://schema.org/MeetingRoom",
     "Domain Bucket":"1K - 10K"
   },
   {
     "Class":"Itemtype",
-    "Name":"http:\/\/schema.org\/MemberProgram",
+    "Name":"https://schema.org/MemberProgram",
     "Domain Bucket":"1K - 10K"
   },
   {
     "Class":"Itemtype",
-    "Name":"http:\/\/schema.org\/MemberProgramTier",
+    "Name":"https://schema.org/MemberProgramTier",
     "Domain Bucket":"1K - 10K"
   },
   {
     "Class":"Itemtype",
-    "Name":"http:\/\/schema.org\/MensClothingStore",
+    "Name":"https://schema.org/MensClothingStore",
     "Domain Bucket":"< 1K"
   },
   {
     "Class":"Itemtype",
-    "Name":"http:\/\/schema.org\/Menu",
+    "Name":"https://schema.org/Menu",
     "Domain Bucket":"100K - 1M"
   },
   {
     "Class":"Itemtype",
-    "Name":"http:\/\/schema.org\/MenuItem",
+    "Name":"https://schema.org/MenuItem",
     "Domain Bucket":"10K - 100K"
   },
   {
     "Class":"Itemtype",
-    "Name":"http:\/\/schema.org\/MenuSection",
+    "Name":"https://schema.org/MenuSection",
     "Domain Bucket":"10K - 100K"
   },
   {
     "Class":"Itemtype",
-    "Name":"http:\/\/schema.org\/MerchantReturnEnumeration",
+    "Name":"https://schema.org/MerchantReturnEnumeration",
     "Domain Bucket":"< 1K"
   },
   {
     "Class":"Itemtype",
-    "Name":"http:\/\/schema.org\/MerchantReturnPolicy",
+    "Name":"https://schema.org/MerchantReturnPolicy",
     "Domain Bucket":"100K - 1M"
   },
   {
     "Class":"Itemtype",
-    "Name":"http:\/\/schema.org\/MerchantReturnPolicySeasonalOverride",
+    "Name":"https://schema.org/MerchantReturnPolicySeasonalOverride",
     "Domain Bucket":"1K - 10K"
   },
   {
     "Class":"Itemtype",
-    "Name":"http:\/\/schema.org\/Message",
+    "Name":"https://schema.org/Message",
     "Domain Bucket":"1K - 10K"
   },
   {
     "Class":"Itemtype",
-    "Name":"http:\/\/schema.org\/MiddleSchool",
+    "Name":"https://schema.org/MiddleSchool",
     "Domain Bucket":"< 1K"
   },
   {
     "Class":"Itemtype",
-    "Name":"http:\/\/schema.org\/Midwifery",
+    "Name":"https://schema.org/Midwifery",
     "Domain Bucket":"< 1K"
   },
   {
     "Class":"Itemtype",
-    "Name":"http:\/\/schema.org\/MobileApplication",
+    "Name":"https://schema.org/MobileApplication",
     "Domain Bucket":"100K - 1M"
   },
   {
     "Class":"Itemtype",
-    "Name":"http:\/\/schema.org\/MobilePhoneStore",
+    "Name":"https://schema.org/MobilePhoneStore",
     "Domain Bucket":"1K - 10K"
   },
   {
     "Class":"Itemtype",
-    "Name":"http:\/\/schema.org\/MolecularEntity",
+    "Name":"https://schema.org/MolecularEntity",
     "Domain Bucket":"< 1K"
   },
   {
     "Class":"Itemtype",
-    "Name":"http:\/\/schema.org\/MonetaryAmount",
+    "Name":"https://schema.org/MonetaryAmount",
     "Domain Bucket":"100K - 1M"
   },
   {
     "Class":"Itemtype",
-    "Name":"http:\/\/schema.org\/MonetaryAmountDistribution",
+    "Name":"https://schema.org/MonetaryAmountDistribution",
     "Domain Bucket":"1K - 10K"
   },
   {
     "Class":"Itemtype",
-    "Name":"http:\/\/schema.org\/MonetaryGrant",
+    "Name":"https://schema.org/MonetaryGrant",
     "Domain Bucket":"1K - 10K"
   },
   {
     "Class":"Itemtype",
-    "Name":"http:\/\/schema.org\/MoneyTransfer",
+    "Name":"https://schema.org/MoneyTransfer",
     "Domain Bucket":"< 1K"
   },
   {
     "Class":"Itemtype",
-    "Name":"http:\/\/schema.org\/MortgageLoan",
+    "Name":"https://schema.org/MortgageLoan",
     "Domain Bucket":"< 1K"
   },
   {
     "Class":"Itemtype",
-    "Name":"http:\/\/schema.org\/Mosque",
+    "Name":"https://schema.org/Mosque",
     "Domain Bucket":"< 1K"
   },
   {
     "Class":"Itemtype",
-    "Name":"http:\/\/schema.org\/Motel",
+    "Name":"https://schema.org/Motel",
     "Domain Bucket":"< 1K"
   },
   {
     "Class":"Itemtype",
-    "Name":"http:\/\/schema.org\/Motorcycle",
+    "Name":"https://schema.org/Motorcycle",
     "Domain Bucket":"1K - 10K"
   },
   {
     "Class":"Itemtype",
-    "Name":"http:\/\/schema.org\/MotorcycleDealer",
+    "Name":"https://schema.org/MotorcycleDealer",
     "Domain Bucket":"1K - 10K"
   },
   {
     "Class":"Itemtype",
-    "Name":"http:\/\/schema.org\/MotorcycleRepair",
+    "Name":"https://schema.org/MotorcycleRepair",
     "Domain Bucket":"< 1K"
   },
   {
     "Class":"Itemtype",
-    "Name":"http:\/\/schema.org\/MotorizedBicycle",
+    "Name":"https://schema.org/MotorizedBicycle",
     "Domain Bucket":"< 1K"
   },
   {
     "Class":"Itemtype",
-    "Name":"http:\/\/schema.org\/Mountain",
+    "Name":"https://schema.org/Mountain",
     "Domain Bucket":"< 1K"
   },
   {
     "Class":"Itemtype",
-    "Name":"http:\/\/schema.org\/MoveAction",
+    "Name":"https://schema.org/MoveAction",
     "Domain Bucket":"< 1K"
   },
   {
     "Class":"Itemtype",
-    "Name":"http:\/\/schema.org\/Movie",
+    "Name":"https://schema.org/Movie",
     "Domain Bucket":"10K - 100K"
   },
   {
     "Class":"Itemtype",
-    "Name":"http:\/\/schema.org\/MovieClip",
+    "Name":"https://schema.org/MovieClip",
     "Domain Bucket":"< 1K"
   },
   {
     "Class":"Itemtype",
-    "Name":"http:\/\/schema.org\/MovieRentalStore",
+    "Name":"https://schema.org/MovieRentalStore",
     "Domain Bucket":"< 1K"
   },
   {
     "Class":"Itemtype",
-    "Name":"http:\/\/schema.org\/MovieSeries",
+    "Name":"https://schema.org/MovieSeries",
     "Domain Bucket":"< 1K"
   },
   {
     "Class":"Itemtype",
-    "Name":"http:\/\/schema.org\/MovieTheater",
+    "Name":"https://schema.org/MovieTheater",
     "Domain Bucket":"1K - 10K"
   },
   {
     "Class":"Itemtype",
-    "Name":"http:\/\/schema.org\/MovingCompany",
+    "Name":"https://schema.org/MovingCompany",
     "Domain Bucket":"10K - 100K"
   },
   {
     "Class":"Itemtype",
-    "Name":"http:\/\/schema.org\/Muscle",
+    "Name":"https://schema.org/Muscle",
     "Domain Bucket":"< 1K"
   },
   {
     "Class":"Itemtype",
-    "Name":"http:\/\/schema.org\/Museum",
+    "Name":"https://schema.org/Museum",
     "Domain Bucket":"1K - 10K"
   },
   {
     "Class":"Itemtype",
-    "Name":"http:\/\/schema.org\/MusicAlbum",
+    "Name":"https://schema.org/MusicAlbum",
     "Domain Bucket":"10K - 100K"
   },
   {
     "Class":"Itemtype",
-    "Name":"http:\/\/schema.org\/MusicAlbumProductionType",
+    "Name":"https://schema.org/MusicAlbumProductionType",
     "Domain Bucket":"< 1K"
   },
   {
     "Class":"Itemtype",
-    "Name":"http:\/\/schema.org\/MusicAlbumReleaseType",
+    "Name":"https://schema.org/MusicAlbumReleaseType",
     "Domain Bucket":"< 1K"
   },
   {
     "Class":"Itemtype",
-    "Name":"http:\/\/schema.org\/MusicComposition",
+    "Name":"https://schema.org/MusicComposition",
     "Domain Bucket":"1K - 10K"
   },
   {
     "Class":"Itemtype",
-    "Name":"http:\/\/schema.org\/MusicEvent",
+    "Name":"https://schema.org/MusicEvent",
     "Domain Bucket":"10K - 100K"
   },
   {
     "Class":"Itemtype",
-    "Name":"http:\/\/schema.org\/MusicGroup",
+    "Name":"https://schema.org/MusicGroup",
     "Domain Bucket":"10K - 100K"
   },
   {
     "Class":"Itemtype",
-    "Name":"http:\/\/schema.org\/MusicPlaylist",
+    "Name":"https://schema.org/MusicPlaylist",
     "Domain Bucket":"1K - 10K"
   },
   {
     "Class":"Itemtype",
-    "Name":"http:\/\/schema.org\/MusicRecording",
+    "Name":"https://schema.org/MusicRecording",
     "Domain Bucket":"10K - 100K"
   },
   {
     "Class":"Itemtype",
-    "Name":"http:\/\/schema.org\/MusicRelease",
+    "Name":"https://schema.org/MusicRelease",
     "Domain Bucket":"1K - 10K"
   },
   {
     "Class":"Itemtype",
-    "Name":"http:\/\/schema.org\/MusicReleaseFormatType",
+    "Name":"https://schema.org/MusicReleaseFormatType",
     "Domain Bucket":"< 1K"
   },
   {
     "Class":"Itemtype",
-    "Name":"http:\/\/schema.org\/MusicStore",
+    "Name":"https://schema.org/MusicStore",
     "Domain Bucket":"1K - 10K"
   },
   {
     "Class":"Itemtype",
-    "Name":"http:\/\/schema.org\/MusicVenue",
+    "Name":"https://schema.org/MusicVenue",
     "Domain Bucket":"1K - 10K"
   },
   {
     "Class":"Itemtype",
-    "Name":"http:\/\/schema.org\/MusicVideoObject",
+    "Name":"https://schema.org/MusicVideoObject",
     "Domain Bucket":"< 1K"
   },
   {
     "Class":"Itemtype",
-    "Name":"http:\/\/schema.org\/NGO",
+    "Name":"https://schema.org/NGO",
     "Domain Bucket":"10K - 100K"
   },
   {
     "Class":"Itemtype",
-    "Name":"http:\/\/schema.org\/NLNonprofitType",
+    "Name":"https://schema.org/NLNonprofitType",
     "Domain Bucket":"< 1K"
   },
   {
     "Class":"Itemtype",
-    "Name":"http:\/\/schema.org\/NailSalon",
+    "Name":"https://schema.org/NailSalon",
     "Domain Bucket":"1K - 10K"
   },
   {
     "Class":"Itemtype",
-    "Name":"http:\/\/schema.org\/Nerve",
+    "Name":"https://schema.org/Nerve",
     "Domain Bucket":"< 1K"
   },
   {
     "Class":"Itemtype",
-    "Name":"http:\/\/schema.org\/NewsArticle",
+    "Name":"https://schema.org/NewsArticle",
     "Domain Bucket":"100K - 1M"
   },
   {
     "Class":"Itemtype",
-    "Name":"http:\/\/schema.org\/NewsMediaOrganization",
+    "Name":"https://schema.org/NewsMediaOrganization",
     "Domain Bucket":"10K - 100K"
   },
   {
     "Class":"Itemtype",
-    "Name":"http:\/\/schema.org\/Newspaper",
+    "Name":"https://schema.org/Newspaper",
     "Domain Bucket":"< 1K"
   },
   {
     "Class":"Itemtype",
-    "Name":"http:\/\/schema.org\/NightClub",
+    "Name":"https://schema.org/NightClub",
     "Domain Bucket":"1K - 10K"
   },
   {
     "Class":"Itemtype",
-    "Name":"http:\/\/schema.org\/NonprofitType",
+    "Name":"https://schema.org/NonprofitType",
     "Domain Bucket":"< 1K"
   },
   {
     "Class":"Itemtype",
-    "Name":"http:\/\/schema.org\/Notary",
+    "Name":"https://schema.org/Notary",
     "Domain Bucket":"1K - 10K"
   },
   {
     "Class":"Itemtype",
-    "Name":"http:\/\/schema.org\/NoteDigitalDocument",
+    "Name":"https://schema.org/NoteDigitalDocument",
     "Domain Bucket":"< 1K"
   },
   {
     "Class":"Itemtype",
-    "Name":"http:\/\/schema.org\/Number",
+    "Name":"https://schema.org/Number",
     "Domain Bucket":"< 1K"
   },
   {
     "Class":"Itemtype",
-    "Name":"http:\/\/schema.org\/Nursing",
+    "Name":"https://schema.org/Nursing",
     "Domain Bucket":"< 1K"
   },
   {
     "Class":"Itemtype",
-    "Name":"http:\/\/schema.org\/NutritionInformation",
+    "Name":"https://schema.org/NutritionInformation",
     "Domain Bucket":"10K - 100K"
   },
   {
     "Class":"Itemtype",
-    "Name":"http:\/\/schema.org\/Observation",
+    "Name":"https://schema.org/Observation",
     "Domain Bucket":"< 1K"
   },
   {
     "Class":"Itemtype",
-    "Name":"http:\/\/schema.org\/Obstetric",
+    "Name":"https://schema.org/Obstetric",
     "Domain Bucket":"< 1K"
   },
   {
     "Class":"Itemtype",
-    "Name":"http:\/\/schema.org\/Occupation",
+    "Name":"https://schema.org/Occupation",
     "Domain Bucket":"10K - 100K"
   },
   {
     "Class":"Itemtype",
-    "Name":"http:\/\/schema.org\/OccupationalExperienceRequirements",
+    "Name":"https://schema.org/OccupationalExperienceRequirements",
     "Domain Bucket":"1K - 10K"
   },
   {
     "Class":"Itemtype",
-    "Name":"http:\/\/schema.org\/OccupationalTherapy",
+    "Name":"https://schema.org/OccupationalTherapy",
     "Domain Bucket":"< 1K"
   },
   {
     "Class":"Itemtype",
-    "Name":"http:\/\/schema.org\/OceanBodyOfWater",
+    "Name":"https://schema.org/OceanBodyOfWater",
     "Domain Bucket":"< 1K"
   },
   {
     "Class":"Itemtype",
-    "Name":"http:\/\/schema.org\/Offer",
+    "Name":"https://schema.org/Offer",
     "Domain Bucket":"10M+"
   },
   {
     "Class":"Itemtype",
-    "Name":"http:\/\/schema.org\/OfferCatalog",
+    "Name":"https://schema.org/OfferCatalog",
     "Domain Bucket":"100K - 1M"
   },
   {
     "Class":"Itemtype",
-    "Name":"http:\/\/schema.org\/OfferForLease",
+    "Name":"https://schema.org/OfferForLease",
     "Domain Bucket":"1K - 10K"
   },
   {
     "Class":"Itemtype",
-    "Name":"http:\/\/schema.org\/OfferForPurchase",
+    "Name":"https://schema.org/OfferForPurchase",
     "Domain Bucket":"1K - 10K"
   },
   {
     "Class":"Itemtype",
-    "Name":"http:\/\/schema.org\/OfferItemCondition",
+    "Name":"https://schema.org/OfferItemCondition",
     "Domain Bucket":"1K - 10K"
   },
   {
     "Class":"Itemtype",
-    "Name":"http:\/\/schema.org\/OfferShippingDetails",
+    "Name":"https://schema.org/OfferShippingDetails",
     "Domain Bucket":"100K - 1M"
   },
   {
     "Class":"Itemtype",
-    "Name":"http:\/\/schema.org\/OfficeEquipmentStore",
+    "Name":"https://schema.org/OfficeEquipmentStore",
     "Domain Bucket":"1K - 10K"
   },
   {
     "Class":"Itemtype",
-    "Name":"http:\/\/schema.org\/OnDemandEvent",
+    "Name":"https://schema.org/OnDemandEvent",
     "Domain Bucket":"< 1K"
   },
   {
     "Class":"Itemtype",
-    "Name":"http:\/\/schema.org\/Oncologic",
+    "Name":"https://schema.org/Oncologic",
     "Domain Bucket":"< 1K"
   },
   {
     "Class":"Itemtype",
-    "Name":"http:\/\/schema.org\/OnlineBusiness",
+    "Name":"https://schema.org/OnlineBusiness",
     "Domain Bucket":"10K - 100K"
   },
   {
     "Class":"Itemtype",
-    "Name":"http:\/\/schema.org\/OnlineMarketplace",
+    "Name":"https://schema.org/OnlineMarketplace",
     "Domain Bucket":"< 1K"
   },
   {
     "Class":"Itemtype",
-    "Name":"http:\/\/schema.org\/OnlineStore",
+    "Name":"https://schema.org/OnlineStore",
     "Domain Bucket":"100K - 1M"
   },
   {
     "Class":"Itemtype",
-    "Name":"http:\/\/schema.org\/OpeningHoursSpecification",
+    "Name":"https://schema.org/OpeningHoursSpecification",
     "Domain Bucket":"1M - 10M"
   },
   {
     "Class":"Itemtype",
-    "Name":"http:\/\/schema.org\/OperatingSystem",
+    "Name":"https://schema.org/OperatingSystem",
     "Domain Bucket":"< 1K"
   },
   {
     "Class":"Itemtype",
-    "Name":"http:\/\/schema.org\/OpinionNewsArticle",
+    "Name":"https://schema.org/OpinionNewsArticle",
     "Domain Bucket":"1K - 10K"
   },
   {
     "Class":"Itemtype",
-    "Name":"http:\/\/schema.org\/Optician",
+    "Name":"https://schema.org/Optician",
     "Domain Bucket":"1K - 10K"
   },
   {
     "Class":"Itemtype",
-    "Name":"http:\/\/schema.org\/Optometric",
+    "Name":"https://schema.org/Optometric",
     "Domain Bucket":"1K - 10K"
   },
   {
     "Class":"Itemtype",
-    "Name":"http:\/\/schema.org\/Order",
+    "Name":"https://schema.org/Order",
     "Domain Bucket":"1K - 10K"
   },
   {
     "Class":"Itemtype",
-    "Name":"http:\/\/schema.org\/OrderAction",
+    "Name":"https://schema.org/OrderAction",
     "Domain Bucket":"10K - 100K"
   },
   {
     "Class":"Itemtype",
-    "Name":"http:\/\/schema.org\/OrderItem",
+    "Name":"https://schema.org/OrderItem",
     "Domain Bucket":"< 1K"
   },
   {
     "Class":"Itemtype",
-    "Name":"http:\/\/schema.org\/OrderStatus",
+    "Name":"https://schema.org/OrderStatus",
     "Domain Bucket":"< 1K"
   },
   {
     "Class":"Itemtype",
-    "Name":"http:\/\/schema.org\/Organization",
+    "Name":"https://schema.org/Organization",
     "Domain Bucket":"10M+"
   },
   {
     "Class":"Itemtype",
-    "Name":"http:\/\/schema.org\/OrganizationRole",
+    "Name":"https://schema.org/OrganizationRole",
     "Domain Bucket":"1K - 10K"
   },
   {
     "Class":"Itemtype",
-    "Name":"http:\/\/schema.org\/OrganizeAction",
+    "Name":"https://schema.org/OrganizeAction",
     "Domain Bucket":"< 1K"
   },
   {
     "Class":"Itemtype",
-    "Name":"http:\/\/schema.org\/Otolaryngologic",
+    "Name":"https://schema.org/Otolaryngologic",
     "Domain Bucket":"< 1K"
   },
   {
     "Class":"Itemtype",
-    "Name":"http:\/\/schema.org\/OutletStore",
+    "Name":"https://schema.org/OutletStore",
     "Domain Bucket":"< 1K"
   },
   {
     "Class":"Itemtype",
-    "Name":"http:\/\/schema.org\/OwnershipInfo",
+    "Name":"https://schema.org/OwnershipInfo",
     "Domain Bucket":"< 1K"
   },
   {
     "Class":"Itemtype",
-    "Name":"http:\/\/schema.org\/PaintAction",
+    "Name":"https://schema.org/PaintAction",
     "Domain Bucket":"< 1K"
   },
   {
     "Class":"Itemtype",
-    "Name":"http:\/\/schema.org\/Painting",
+    "Name":"https://schema.org/Painting",
     "Domain Bucket":"< 1K"
   },
   {
     "Class":"Itemtype",
-    "Name":"http:\/\/schema.org\/PalliativeProcedure",
+    "Name":"https://schema.org/PalliativeProcedure",
     "Domain Bucket":"< 1K"
   },
   {
     "Class":"Itemtype",
-    "Name":"http:\/\/schema.org\/ParcelDelivery",
+    "Name":"https://schema.org/ParcelDelivery",
     "Domain Bucket":"< 1K"
   },
   {
     "Class":"Itemtype",
-    "Name":"http:\/\/schema.org\/ParentAudience",
+    "Name":"https://schema.org/ParentAudience",
     "Domain Bucket":"< 1K"
   },
   {
     "Class":"Itemtype",
-    "Name":"http:\/\/schema.org\/Park",
+    "Name":"https://schema.org/Park",
     "Domain Bucket":"1K - 10K"
   },
   {
     "Class":"Itemtype",
-    "Name":"http:\/\/schema.org\/ParkingFacility",
+    "Name":"https://schema.org/ParkingFacility",
     "Domain Bucket":"1K - 10K"
   },
   {
     "Class":"Itemtype",
-    "Name":"http:\/\/schema.org\/PathologyTest",
+    "Name":"https://schema.org/PathologyTest",
     "Domain Bucket":"< 1K"
   },
   {
     "Class":"Itemtype",
-    "Name":"http:\/\/schema.org\/Patient",
+    "Name":"https://schema.org/Patient",
     "Domain Bucket":"1K - 10K"
   },
   {
     "Class":"Itemtype",
-    "Name":"http:\/\/schema.org\/PawnShop",
+    "Name":"https://schema.org/PawnShop",
     "Domain Bucket":"< 1K"
   },
   {
     "Class":"Itemtype",
-    "Name":"http:\/\/schema.org\/PayAction",
+    "Name":"https://schema.org/PayAction",
     "Domain Bucket":"< 1K"
   },
   {
     "Class":"Itemtype",
-    "Name":"http:\/\/schema.org\/PaymentCard",
+    "Name":"https://schema.org/PaymentCard",
     "Domain Bucket":"< 1K"
   },
   {
     "Class":"Itemtype",
-    "Name":"http:\/\/schema.org\/PaymentChargeSpecification",
+    "Name":"https://schema.org/PaymentChargeSpecification",
     "Domain Bucket":"< 1K"
   },
   {
     "Class":"Itemtype",
-    "Name":"http:\/\/schema.org\/PaymentMethod",
+    "Name":"https://schema.org/PaymentMethod",
     "Domain Bucket":"10K - 100K"
   },
   {
     "Class":"Itemtype",
-    "Name":"http:\/\/schema.org\/PaymentMethodType",
+    "Name":"https://schema.org/PaymentMethodType",
     "Domain Bucket":"< 1K"
   },
   {
     "Class":"Itemtype",
-    "Name":"http:\/\/schema.org\/PaymentService",
+    "Name":"https://schema.org/PaymentService",
     "Domain Bucket":"1K - 10K"
   },
   {
     "Class":"Itemtype",
-    "Name":"http:\/\/schema.org\/PaymentStatusType",
+    "Name":"https://schema.org/PaymentStatusType",
     "Domain Bucket":"< 1K"
   },
   {
     "Class":"Itemtype",
-    "Name":"http:\/\/schema.org\/Pediatric",
+    "Name":"https://schema.org/Pediatric",
     "Domain Bucket":"< 1K"
   },
   {
     "Class":"Itemtype",
-    "Name":"http:\/\/schema.org\/PeopleAudience",
+    "Name":"https://schema.org/PeopleAudience",
     "Domain Bucket":"10K - 100K"
   },
   {
     "Class":"Itemtype",
-    "Name":"http:\/\/schema.org\/PerformAction",
+    "Name":"https://schema.org/PerformAction",
     "Domain Bucket":"< 1K"
   },
   {
     "Class":"Itemtype",
-    "Name":"http:\/\/schema.org\/PerformanceRole",
+    "Name":"https://schema.org/PerformanceRole",
     "Domain Bucket":"< 1K"
   },
   {
     "Class":"Itemtype",
-    "Name":"http:\/\/schema.org\/PerformingArtsEvent",
+    "Name":"https://schema.org/PerformingArtsEvent",
     "Domain Bucket":"< 1K"
   },
   {
     "Class":"Itemtype",
-    "Name":"http:\/\/schema.org\/PerformingArtsTheater",
+    "Name":"https://schema.org/PerformingArtsTheater",
     "Domain Bucket":"1K - 10K"
   },
   {
     "Class":"Itemtype",
-    "Name":"http:\/\/schema.org\/PerformingGroup",
+    "Name":"https://schema.org/PerformingGroup",
     "Domain Bucket":"10K - 100K"
   },
   {
     "Class":"Itemtype",
-    "Name":"http:\/\/schema.org\/Periodical",
+    "Name":"https://schema.org/Periodical",
     "Domain Bucket":"1K - 10K"
   },
   {
     "Class":"Itemtype",
-    "Name":"http:\/\/schema.org\/Permit",
+    "Name":"https://schema.org/Permit",
     "Domain Bucket":"10K - 100K"
   },
   {
     "Class":"Itemtype",
-    "Name":"http:\/\/schema.org\/Person",
+    "Name":"https://schema.org/Person",
     "Domain Bucket":"10M+"
   },
   {
     "Class":"Itemtype",
-    "Name":"http:\/\/schema.org\/PetStore",
+    "Name":"https://schema.org/PetStore",
     "Domain Bucket":"1K - 10K"
   },
   {
     "Class":"Itemtype",
-    "Name":"http:\/\/schema.org\/Pharmacy",
+    "Name":"https://schema.org/Pharmacy",
     "Domain Bucket":"10K - 100K"
   },
   {
     "Class":"Itemtype",
-    "Name":"http:\/\/schema.org\/Photograph",
+    "Name":"https://schema.org/Photograph",
     "Domain Bucket":"10K - 100K"
   },
   {
     "Class":"Itemtype",
-    "Name":"http:\/\/schema.org\/PhotographAction",
+    "Name":"https://schema.org/PhotographAction",
     "Domain Bucket":"< 1K"
   },
   {
     "Class":"Itemtype",
-    "Name":"http:\/\/schema.org\/PhysicalActivity",
+    "Name":"https://schema.org/PhysicalActivity",
     "Domain Bucket":"< 1K"
   },
   {
     "Class":"Itemtype",
-    "Name":"http:\/\/schema.org\/PhysicalActivityCategory",
+    "Name":"https://schema.org/PhysicalActivityCategory",
     "Domain Bucket":"1K - 10K"
   },
   {
     "Class":"Itemtype",
-    "Name":"http:\/\/schema.org\/PhysicalExam",
+    "Name":"https://schema.org/PhysicalExam",
     "Domain Bucket":"< 1K"
   },
   {
     "Class":"Itemtype",
-    "Name":"http:\/\/schema.org\/PhysicalTherapy",
+    "Name":"https://schema.org/PhysicalTherapy",
     "Domain Bucket":"< 1K"
   },
   {
     "Class":"Itemtype",
-    "Name":"http:\/\/schema.org\/Physician",
+    "Name":"https://schema.org/Physician",
     "Domain Bucket":"10K - 100K"
   },
   {
     "Class":"Itemtype",
-    "Name":"http:\/\/schema.org\/PhysiciansOffice",
+    "Name":"https://schema.org/PhysiciansOffice",
     "Domain Bucket":"< 1K"
   },
   {
     "Class":"Itemtype",
-    "Name":"http:\/\/schema.org\/Physiotherapy",
+    "Name":"https://schema.org/Physiotherapy",
     "Domain Bucket":"1K - 10K"
   },
   {
     "Class":"Itemtype",
-    "Name":"http:\/\/schema.org\/Place",
+    "Name":"https://schema.org/Place",
     "Domain Bucket":"1M - 10M"
   },
   {
     "Class":"Itemtype",
-    "Name":"http:\/\/schema.org\/PlaceOfWorship",
+    "Name":"https://schema.org/PlaceOfWorship",
     "Domain Bucket":"1K - 10K"
   },
   {
     "Class":"Itemtype",
-    "Name":"http:\/\/schema.org\/PlanAction",
+    "Name":"https://schema.org/PlanAction",
     "Domain Bucket":"< 1K"
   },
   {
     "Class":"Itemtype",
-    "Name":"http:\/\/schema.org\/PlasticSurgery",
+    "Name":"https://schema.org/PlasticSurgery",
     "Domain Bucket":"< 1K"
   },
   {
     "Class":"Itemtype",
-    "Name":"http:\/\/schema.org\/Play",
+    "Name":"https://schema.org/Play",
     "Domain Bucket":"< 1K"
   },
   {
     "Class":"Itemtype",
-    "Name":"http:\/\/schema.org\/PlayAction",
+    "Name":"https://schema.org/PlayAction",
     "Domain Bucket":"1K - 10K"
   },
   {
     "Class":"Itemtype",
-    "Name":"http:\/\/schema.org\/PlayGameAction",
+    "Name":"https://schema.org/PlayGameAction",
     "Domain Bucket":"< 1K"
   },
   {
     "Class":"Itemtype",
-    "Name":"http:\/\/schema.org\/Playground",
+    "Name":"https://schema.org/Playground",
     "Domain Bucket":"< 1K"
   },
   {
     "Class":"Itemtype",
-    "Name":"http:\/\/schema.org\/Plumber",
+    "Name":"https://schema.org/Plumber",
     "Domain Bucket":"10K - 100K"
   },
   {
     "Class":"Itemtype",
-    "Name":"http:\/\/schema.org\/PodcastEpisode",
+    "Name":"https://schema.org/PodcastEpisode",
     "Domain Bucket":"10K - 100K"
   },
   {
     "Class":"Itemtype",
-    "Name":"http:\/\/schema.org\/PodcastSeason",
+    "Name":"https://schema.org/PodcastSeason",
     "Domain Bucket":"< 1K"
   },
   {
     "Class":"Itemtype",
-    "Name":"http:\/\/schema.org\/PodcastSeries",
+    "Name":"https://schema.org/PodcastSeries",
     "Domain Bucket":"10K - 100K"
   },
   {
     "Class":"Itemtype",
-    "Name":"http:\/\/schema.org\/Podiatric",
+    "Name":"https://schema.org/Podiatric",
     "Domain Bucket":"< 1K"
   },
   {
     "Class":"Itemtype",
-    "Name":"http:\/\/schema.org\/PoliceStation",
+    "Name":"https://schema.org/PoliceStation",
     "Domain Bucket":"< 1K"
   },
   {
     "Class":"Itemtype",
-    "Name":"http:\/\/schema.org\/PoliticalParty",
+    "Name":"https://schema.org/PoliticalParty",
     "Domain Bucket":"< 1K"
   },
   {
     "Class":"Itemtype",
-    "Name":"http:\/\/schema.org\/Pond",
+    "Name":"https://schema.org/Pond",
     "Domain Bucket":"< 1K"
   },
   {
     "Class":"Itemtype",
-    "Name":"http:\/\/schema.org\/PostOffice",
+    "Name":"https://schema.org/PostOffice",
     "Domain Bucket":"< 1K"
   },
   {
     "Class":"Itemtype",
-    "Name":"http:\/\/schema.org\/PostalAddress",
+    "Name":"https://schema.org/PostalAddress",
     "Domain Bucket":"10M+"
   },
   {
     "Class":"Itemtype",
-    "Name":"http:\/\/schema.org\/PostalCodeRangeSpecification",
+    "Name":"https://schema.org/PostalCodeRangeSpecification",
     "Domain Bucket":"1K - 10K"
   },
   {
     "Class":"Itemtype",
-    "Name":"http:\/\/schema.org\/Poster",
+    "Name":"https://schema.org/Poster",
     "Domain Bucket":"< 1K"
   },
   {
     "Class":"Itemtype",
-    "Name":"http:\/\/schema.org\/PreOrderAction",
+    "Name":"https://schema.org/PreOrderAction",
     "Domain Bucket":"< 1K"
   },
   {
     "Class":"Itemtype",
-    "Name":"http:\/\/schema.org\/PrependAction",
+    "Name":"https://schema.org/PrependAction",
     "Domain Bucket":"< 1K"
   },
   {
     "Class":"Itemtype",
-    "Name":"http:\/\/schema.org\/Preschool",
+    "Name":"https://schema.org/Preschool",
     "Domain Bucket":"1K - 10K"
   },
   {
     "Class":"Itemtype",
-    "Name":"http:\/\/schema.org\/PresentationDigitalDocument",
+    "Name":"https://schema.org/PresentationDigitalDocument",
     "Domain Bucket":"< 1K"
   },
   {
     "Class":"Itemtype",
-    "Name":"http:\/\/schema.org\/PreventionIndication",
+    "Name":"https://schema.org/PreventionIndication",
     "Domain Bucket":"< 1K"
   },
   {
     "Class":"Itemtype",
-    "Name":"http:\/\/schema.org\/PriceComponentTypeEnumeration",
+    "Name":"https://schema.org/PriceComponentTypeEnumeration",
     "Domain Bucket":"< 1K"
   },
   {
     "Class":"Itemtype",
-    "Name":"http:\/\/schema.org\/PriceSpecification",
+    "Name":"https://schema.org/PriceSpecification",
     "Domain Bucket":"100K - 1M"
   },
   {
     "Class":"Itemtype",
-    "Name":"http:\/\/schema.org\/PriceTypeEnumeration",
+    "Name":"https://schema.org/PriceTypeEnumeration",
     "Domain Bucket":"< 1K"
   },
   {
     "Class":"Itemtype",
-    "Name":"http:\/\/schema.org\/PrimaryCare",
+    "Name":"https://schema.org/PrimaryCare",
     "Domain Bucket":"< 1K"
   },
   {
     "Class":"Itemtype",
-    "Name":"http:\/\/schema.org\/Product",
+    "Name":"https://schema.org/Product",
     "Domain Bucket":"10M+"
   },
   {
     "Class":"Itemtype",
-    "Name":"http:\/\/schema.org\/ProductCollection",
+    "Name":"https://schema.org/ProductCollection",
     "Domain Bucket":"1K - 10K"
   },
   {
     "Class":"Itemtype",
-    "Name":"http:\/\/schema.org\/ProductGroup",
+    "Name":"https://schema.org/ProductGroup",
     "Domain Bucket":"100K - 1M"
   },
   {
     "Class":"Itemtype",
-    "Name":"http:\/\/schema.org\/ProductModel",
+    "Name":"https://schema.org/ProductModel",
     "Domain Bucket":"1K - 10K"
   },
   {
     "Class":"Itemtype",
-    "Name":"http:\/\/schema.org\/ProductReturnEnumeration",
+    "Name":"https://schema.org/ProductReturnEnumeration",
     "Domain Bucket":"< 1K"
   },
   {
     "Class":"Itemtype",
-    "Name":"http:\/\/schema.org\/ProductReturnPolicy",
+    "Name":"https://schema.org/ProductReturnPolicy",
     "Domain Bucket":"< 1K"
   },
   {
     "Class":"Itemtype",
-    "Name":"http:\/\/schema.org\/ProfessionalService",
+    "Name":"https://schema.org/ProfessionalService",
     "Domain Bucket":"100K - 1M"
   },
   {
     "Class":"Itemtype",
-    "Name":"http:\/\/schema.org\/ProfilePage",
+    "Name":"https://schema.org/ProfilePage",
     "Domain Bucket":"1M - 10M"
   },
   {
     "Class":"Itemtype",
-    "Name":"http:\/\/schema.org\/ProgramMembership",
+    "Name":"https://schema.org/ProgramMembership",
     "Domain Bucket":"1K - 10K"
   },
   {
     "Class":"Itemtype",
-    "Name":"http:\/\/schema.org\/Project",
+    "Name":"https://schema.org/Project",
     "Domain Bucket":"1K - 10K"
   },
   {
     "Class":"Itemtype",
-    "Name":"http:\/\/schema.org\/PronounceableText",
+    "Name":"https://schema.org/PronounceableText",
     "Domain Bucket":"< 1K"
   },
   {
     "Class":"Itemtype",
-    "Name":"http:\/\/schema.org\/Property",
+    "Name":"https://schema.org/Property",
     "Domain Bucket":"< 1K"
   },
   {
     "Class":"Itemtype",
-    "Name":"http:\/\/schema.org\/PropertyValue",
+    "Name":"https://schema.org/PropertyValue",
     "Domain Bucket":"100K - 1M"
   },
   {
     "Class":"Itemtype",
-    "Name":"http:\/\/schema.org\/PropertyValueSpecification",
+    "Name":"https://schema.org/PropertyValueSpecification",
     "Domain Bucket":"10M+"
   },
   {
     "Class":"Itemtype",
-    "Name":"http:\/\/schema.org\/Protein",
+    "Name":"https://schema.org/Protein",
     "Domain Bucket":"< 1K"
   },
   {
     "Class":"Itemtype",
-    "Name":"http:\/\/schema.org\/Psychiatric",
+    "Name":"https://schema.org/Psychiatric",
     "Domain Bucket":"1K - 10K"
   },
   {
     "Class":"Itemtype",
-    "Name":"http:\/\/schema.org\/PsychologicalTreatment",
+    "Name":"https://schema.org/PsychologicalTreatment",
     "Domain Bucket":"< 1K"
   },
   {
     "Class":"Itemtype",
-    "Name":"http:\/\/schema.org\/PublicHealth",
+    "Name":"https://schema.org/PublicHealth",
     "Domain Bucket":"< 1K"
   },
   {
     "Class":"Itemtype",
-    "Name":"http:\/\/schema.org\/PublicSwimmingPool",
+    "Name":"https://schema.org/PublicSwimmingPool",
     "Domain Bucket":"< 1K"
   },
   {
     "Class":"Itemtype",
-    "Name":"http:\/\/schema.org\/PublicToilet",
+    "Name":"https://schema.org/PublicToilet",
     "Domain Bucket":"< 1K"
   },
   {
     "Class":"Itemtype",
-    "Name":"http:\/\/schema.org\/PublicationEvent",
+    "Name":"https://schema.org/PublicationEvent",
     "Domain Bucket":"1K - 10K"
   },
   {
     "Class":"Itemtype",
-    "Name":"http:\/\/schema.org\/PublicationIssue",
+    "Name":"https://schema.org/PublicationIssue",
     "Domain Bucket":"1K - 10K"
   },
   {
     "Class":"Itemtype",
-    "Name":"http:\/\/schema.org\/PublicationVolume",
+    "Name":"https://schema.org/PublicationVolume",
     "Domain Bucket":"1K - 10K"
   },
   {
     "Class":"Itemtype",
-    "Name":"http:\/\/schema.org\/PurchaseType",
+    "Name":"https://schema.org/PurchaseType",
     "Domain Bucket":"< 1K"
   },
   {
     "Class":"Itemtype",
-    "Name":"http:\/\/schema.org\/QAPage",
+    "Name":"https://schema.org/QAPage",
     "Domain Bucket":"10K - 100K"
   },
   {
     "Class":"Itemtype",
-    "Name":"http:\/\/schema.org\/QualitativeValue",
+    "Name":"https://schema.org/QualitativeValue",
     "Domain Bucket":"1K - 10K"
   },
   {
     "Class":"Itemtype",
-    "Name":"http:\/\/schema.org\/QuantitativeValue",
+    "Name":"https://schema.org/QuantitativeValue",
     "Domain Bucket":"1M - 10M"
   },
   {
     "Class":"Itemtype",
-    "Name":"http:\/\/schema.org\/QuantitativeValueDistribution",
+    "Name":"https://schema.org/QuantitativeValueDistribution",
     "Domain Bucket":"< 1K"
   },
   {
     "Class":"Itemtype",
-    "Name":"http:\/\/schema.org\/Quantity",
+    "Name":"https://schema.org/Quantity",
     "Domain Bucket":"< 1K"
   },
   {
     "Class":"Itemtype",
-    "Name":"http:\/\/schema.org\/Question",
+    "Name":"https://schema.org/Question",
     "Domain Bucket":"1M - 10M"
   },
   {
     "Class":"Itemtype",
-    "Name":"http:\/\/schema.org\/Quiz",
+    "Name":"https://schema.org/Quiz",
     "Domain Bucket":"1K - 10K"
   },
   {
     "Class":"Itemtype",
-    "Name":"http:\/\/schema.org\/Quotation",
+    "Name":"https://schema.org/Quotation",
     "Domain Bucket":"1K - 10K"
   },
   {
     "Class":"Itemtype",
-    "Name":"http:\/\/schema.org\/QuoteAction",
+    "Name":"https://schema.org/QuoteAction",
     "Domain Bucket":"1K - 10K"
   },
   {
     "Class":"Itemtype",
-    "Name":"http:\/\/schema.org\/RVPark",
+    "Name":"https://schema.org/RVPark",
     "Domain Bucket":"< 1K"
   },
   {
     "Class":"Itemtype",
-    "Name":"http:\/\/schema.org\/RadiationTherapy",
+    "Name":"https://schema.org/RadiationTherapy",
     "Domain Bucket":"< 1K"
   },
   {
     "Class":"Itemtype",
-    "Name":"http:\/\/schema.org\/RadioBroadcastService",
+    "Name":"https://schema.org/RadioBroadcastService",
     "Domain Bucket":"< 1K"
   },
   {
     "Class":"Itemtype",
-    "Name":"http:\/\/schema.org\/RadioChannel",
+    "Name":"https://schema.org/RadioChannel",
     "Domain Bucket":"< 1K"
   },
   {
     "Class":"Itemtype",
-    "Name":"http:\/\/schema.org\/RadioClip",
+    "Name":"https://schema.org/RadioClip",
     "Domain Bucket":"< 1K"
   },
   {
     "Class":"Itemtype",
-    "Name":"http:\/\/schema.org\/RadioEpisode",
+    "Name":"https://schema.org/RadioEpisode",
     "Domain Bucket":"< 1K"
   },
   {
     "Class":"Itemtype",
-    "Name":"http:\/\/schema.org\/RadioSeason",
+    "Name":"https://schema.org/RadioSeason",
     "Domain Bucket":"< 1K"
   },
   {
     "Class":"Itemtype",
-    "Name":"http:\/\/schema.org\/RadioSeries",
+    "Name":"https://schema.org/RadioSeries",
     "Domain Bucket":"1K - 10K"
   },
   {
     "Class":"Itemtype",
-    "Name":"http:\/\/schema.org\/RadioStation",
+    "Name":"https://schema.org/RadioStation",
     "Domain Bucket":"1K - 10K"
   },
   {
     "Class":"Itemtype",
-    "Name":"http:\/\/schema.org\/Rating",
+    "Name":"https://schema.org/Rating",
     "Domain Bucket":"1M - 10M"
   },
   {
     "Class":"Itemtype",
-    "Name":"http:\/\/schema.org\/ReactAction",
+    "Name":"https://schema.org/ReactAction",
     "Domain Bucket":"< 1K"
   },
   {
     "Class":"Itemtype",
-    "Name":"http:\/\/schema.org\/ReadAction",
+    "Name":"https://schema.org/ReadAction",
     "Domain Bucket":"10M+"
   },
   {
     "Class":"Itemtype",
-    "Name":"http:\/\/schema.org\/RealEstateAgent",
+    "Name":"https://schema.org/RealEstateAgent",
     "Domain Bucket":"100K - 1M"
   },
   {
     "Class":"Itemtype",
-    "Name":"http:\/\/schema.org\/RealEstateListing",
+    "Name":"https://schema.org/RealEstateListing",
     "Domain Bucket":"10K - 100K"
   },
   {
     "Class":"Itemtype",
-    "Name":"http:\/\/schema.org\/ReceiveAction",
+    "Name":"https://schema.org/ReceiveAction",
     "Domain Bucket":"< 1K"
   },
   {
     "Class":"Itemtype",
-    "Name":"http:\/\/schema.org\/Recipe",
+    "Name":"https://schema.org/Recipe",
     "Domain Bucket":"10K - 100K"
   },
   {
     "Class":"Itemtype",
-    "Name":"http:\/\/schema.org\/Recommendation",
+    "Name":"https://schema.org/Recommendation",
     "Domain Bucket":"< 1K"
   },
   {
     "Class":"Itemtype",
-    "Name":"http:\/\/schema.org\/RecommendedDoseSchedule",
+    "Name":"https://schema.org/RecommendedDoseSchedule",
     "Domain Bucket":"< 1K"
   },
   {
     "Class":"Itemtype",
-    "Name":"http:\/\/schema.org\/RecyclingCenter",
+    "Name":"https://schema.org/RecyclingCenter",
     "Domain Bucket":"1K - 10K"
   },
   {
     "Class":"Itemtype",
-    "Name":"http:\/\/schema.org\/RefundTypeEnumeration",
+    "Name":"https://schema.org/RefundTypeEnumeration",
     "Domain Bucket":"< 1K"
   },
   {
     "Class":"Itemtype",
-    "Name":"http:\/\/schema.org\/RegisterAction",
+    "Name":"https://schema.org/RegisterAction",
     "Domain Bucket":"10K - 100K"
   },
   {
     "Class":"Itemtype",
-    "Name":"http:\/\/schema.org\/RejectAction",
+    "Name":"https://schema.org/RejectAction",
     "Domain Bucket":"< 1K"
   },
   {
     "Class":"Itemtype",
-    "Name":"http:\/\/schema.org\/RentAction",
+    "Name":"https://schema.org/RentAction",
     "Domain Bucket":"1K - 10K"
   },
   {
     "Class":"Itemtype",
-    "Name":"http:\/\/schema.org\/RentalCarReservation",
+    "Name":"https://schema.org/RentalCarReservation",
     "Domain Bucket":"< 1K"
   },
   {
     "Class":"Itemtype",
-    "Name":"http:\/\/schema.org\/RepaymentSpecification",
+    "Name":"https://schema.org/RepaymentSpecification",
     "Domain Bucket":"< 1K"
   },
   {
     "Class":"Itemtype",
-    "Name":"http:\/\/schema.org\/ReplaceAction",
+    "Name":"https://schema.org/ReplaceAction",
     "Domain Bucket":"< 1K"
   },
   {
     "Class":"Itemtype",
-    "Name":"http:\/\/schema.org\/ReplyAction",
+    "Name":"https://schema.org/ReplyAction",
     "Domain Bucket":"1K - 10K"
   },
   {
     "Class":"Itemtype",
-    "Name":"http:\/\/schema.org\/Report",
+    "Name":"https://schema.org/Report",
     "Domain Bucket":"1K - 10K"
   },
   {
     "Class":"Itemtype",
-    "Name":"http:\/\/schema.org\/ReportageNewsArticle",
+    "Name":"https://schema.org/ReportageNewsArticle",
     "Domain Bucket":"1K - 10K"
   },
   {
     "Class":"Itemtype",
-    "Name":"http:\/\/schema.org\/ReportedDoseSchedule",
+    "Name":"https://schema.org/ReportedDoseSchedule",
     "Domain Bucket":"< 1K"
   },
   {
     "Class":"Itemtype",
-    "Name":"http:\/\/schema.org\/ResearchOrganization",
+    "Name":"https://schema.org/ResearchOrganization",
     "Domain Bucket":"1K - 10K"
   },
   {
     "Class":"Itemtype",
-    "Name":"http:\/\/schema.org\/ResearchProject",
+    "Name":"https://schema.org/ResearchProject",
     "Domain Bucket":"1K - 10K"
   },
   {
     "Class":"Itemtype",
-    "Name":"http:\/\/schema.org\/Researcher",
+    "Name":"https://schema.org/Researcher",
     "Domain Bucket":"< 1K"
   },
   {
     "Class":"Itemtype",
-    "Name":"http:\/\/schema.org\/Reservation",
+    "Name":"https://schema.org/Reservation",
     "Domain Bucket":"10K - 100K"
   },
   {
     "Class":"Itemtype",
-    "Name":"http:\/\/schema.org\/ReservationPackage",
+    "Name":"https://schema.org/ReservationPackage",
     "Domain Bucket":"< 1K"
   },
   {
     "Class":"Itemtype",
-    "Name":"http:\/\/schema.org\/ReservationStatusType",
+    "Name":"https://schema.org/ReservationStatusType",
     "Domain Bucket":"< 1K"
   },
   {
     "Class":"Itemtype",
-    "Name":"http:\/\/schema.org\/ReserveAction",
+    "Name":"https://schema.org/ReserveAction",
     "Domain Bucket":"10K - 100K"
   },
   {
     "Class":"Itemtype",
-    "Name":"http:\/\/schema.org\/Reservoir",
+    "Name":"https://schema.org/Reservoir",
     "Domain Bucket":"< 1K"
   },
   {
     "Class":"Itemtype",
-    "Name":"http:\/\/schema.org\/ResetPasswordAction",
+    "Name":"https://schema.org/ResetPasswordAction",
     "Domain Bucket":"< 1K"
   },
   {
     "Class":"Itemtype",
-    "Name":"http:\/\/schema.org\/Residence",
+    "Name":"https://schema.org/Residence",
     "Domain Bucket":"10K - 100K"
   },
   {
     "Class":"Itemtype",
-    "Name":"http:\/\/schema.org\/Resort",
+    "Name":"https://schema.org/Resort",
     "Domain Bucket":"1K - 10K"
   },
   {
     "Class":"Itemtype",
-    "Name":"http:\/\/schema.org\/RespiratoryTherapy",
+    "Name":"https://schema.org/RespiratoryTherapy",
     "Domain Bucket":"< 1K"
   },
   {
     "Class":"Itemtype",
-    "Name":"http:\/\/schema.org\/Restaurant",
+    "Name":"https://schema.org/Restaurant",
     "Domain Bucket":"100K - 1M"
   },
   {
     "Class":"Itemtype",
-    "Name":"http:\/\/schema.org\/RestrictedDiet",
+    "Name":"https://schema.org/RestrictedDiet",
     "Domain Bucket":"1K - 10K"
   },
   {
     "Class":"Itemtype",
-    "Name":"http:\/\/schema.org\/ResumeAction",
+    "Name":"https://schema.org/ResumeAction",
     "Domain Bucket":"< 1K"
   },
   {
     "Class":"Itemtype",
-    "Name":"http:\/\/schema.org\/ReturnAction",
+    "Name":"https://schema.org/ReturnAction",
     "Domain Bucket":"< 1K"
   },
   {
     "Class":"Itemtype",
-    "Name":"http:\/\/schema.org\/ReturnFeesEnumeration",
+    "Name":"https://schema.org/ReturnFeesEnumeration",
     "Domain Bucket":"< 1K"
   },
   {
     "Class":"Itemtype",
-    "Name":"http:\/\/schema.org\/ReturnLabelSourceEnumeration",
+    "Name":"https://schema.org/ReturnLabelSourceEnumeration",
     "Domain Bucket":"< 1K"
   },
   {
     "Class":"Itemtype",
-    "Name":"http:\/\/schema.org\/ReturnMethodEnumeration",
+    "Name":"https://schema.org/ReturnMethodEnumeration",
     "Domain Bucket":"< 1K"
   },
   {
     "Class":"Itemtype",
-    "Name":"http:\/\/schema.org\/Review",
+    "Name":"https://schema.org/Review",
     "Domain Bucket":"1M - 10M"
   },
   {
     "Class":"Itemtype",
-    "Name":"http:\/\/schema.org\/ReviewAction",
+    "Name":"https://schema.org/ReviewAction",
     "Domain Bucket":"1K - 10K"
   },
   {
     "Class":"Itemtype",
-    "Name":"http:\/\/schema.org\/ReviewNewsArticle",
+    "Name":"https://schema.org/ReviewNewsArticle",
     "Domain Bucket":"< 1K"
   },
   {
     "Class":"Itemtype",
-    "Name":"http:\/\/schema.org\/RiverBodyOfWater",
+    "Name":"https://schema.org/RiverBodyOfWater",
     "Domain Bucket":"< 1K"
   },
   {
     "Class":"Itemtype",
-    "Name":"http:\/\/schema.org\/Role",
+    "Name":"https://schema.org/Role",
     "Domain Bucket":"1K - 10K"
   },
   {
     "Class":"Itemtype",
-    "Name":"http:\/\/schema.org\/RoofingContractor",
+    "Name":"https://schema.org/RoofingContractor",
     "Domain Bucket":"10K - 100K"
   },
   {
     "Class":"Itemtype",
-    "Name":"http:\/\/schema.org\/Room",
+    "Name":"https://schema.org/Room",
     "Domain Bucket":"1K - 10K"
   },
   {
     "Class":"Itemtype",
-    "Name":"http:\/\/schema.org\/RsvpAction",
+    "Name":"https://schema.org/RsvpAction",
     "Domain Bucket":"< 1K"
   },
   {
     "Class":"Itemtype",
-    "Name":"http:\/\/schema.org\/RsvpResponseType",
+    "Name":"https://schema.org/RsvpResponseType",
     "Domain Bucket":"< 1K"
   },
   {
     "Class":"Itemtype",
-    "Name":"http:\/\/schema.org\/RuntimePlatform",
+    "Name":"https://schema.org/RuntimePlatform",
     "Domain Bucket":"< 1K"
   },
   {
     "Class":"Itemtype",
-    "Name":"http:\/\/schema.org\/SaleEvent",
+    "Name":"https://schema.org/SaleEvent",
     "Domain Bucket":"1K - 10K"
   },
   {
     "Class":"Itemtype",
-    "Name":"http:\/\/schema.org\/SatiricalArticle",
+    "Name":"https://schema.org/SatiricalArticle",
     "Domain Bucket":"< 1K"
   },
   {
     "Class":"Itemtype",
-    "Name":"http:\/\/schema.org\/Schedule",
+    "Name":"https://schema.org/Schedule",
     "Domain Bucket":"10K - 100K"
   },
   {
     "Class":"Itemtype",
-    "Name":"http:\/\/schema.org\/ScheduleAction",
+    "Name":"https://schema.org/ScheduleAction",
     "Domain Bucket":"1K - 10K"
   },
   {
     "Class":"Itemtype",
-    "Name":"http:\/\/schema.org\/ScholarlyArticle",
+    "Name":"https://schema.org/ScholarlyArticle",
     "Domain Bucket":"10K - 100K"
   },
   {
     "Class":"Itemtype",
-    "Name":"http:\/\/schema.org\/School",
+    "Name":"https://schema.org/School",
     "Domain Bucket":"10K - 100K"
   },
   {
     "Class":"Itemtype",
-    "Name":"http:\/\/schema.org\/SchoolDistrict",
+    "Name":"https://schema.org/SchoolDistrict",
     "Domain Bucket":"< 1K"
   },
   {
     "Class":"Itemtype",
-    "Name":"http:\/\/schema.org\/ScreeningEvent",
+    "Name":"https://schema.org/ScreeningEvent",
     "Domain Bucket":"1K - 10K"
   },
   {
     "Class":"Itemtype",
-    "Name":"http:\/\/schema.org\/Sculpture",
+    "Name":"https://schema.org/Sculpture",
     "Domain Bucket":"< 1K"
   },
   {
     "Class":"Itemtype",
-    "Name":"http:\/\/schema.org\/SeaBodyOfWater",
+    "Name":"https://schema.org/SeaBodyOfWater",
     "Domain Bucket":"< 1K"
   },
   {
     "Class":"Itemtype",
-    "Name":"http:\/\/schema.org\/SearchAction",
+    "Name":"https://schema.org/SearchAction",
     "Domain Bucket":"10M+"
   },
   {
     "Class":"Itemtype",
-    "Name":"http:\/\/schema.org\/SearchRescueOrganization",
+    "Name":"https://schema.org/SearchRescueOrganization",
     "Domain Bucket":"< 1K"
   },
   {
     "Class":"Itemtype",
-    "Name":"http:\/\/schema.org\/SearchResultsPage",
+    "Name":"https://schema.org/SearchResultsPage",
     "Domain Bucket":"10K - 100K"
   },
   {
     "Class":"Itemtype",
-    "Name":"http:\/\/schema.org\/Season",
+    "Name":"https://schema.org/Season",
     "Domain Bucket":"< 1K"
   },
   {
     "Class":"Itemtype",
-    "Name":"http:\/\/schema.org\/Seat",
+    "Name":"https://schema.org/Seat",
     "Domain Bucket":"< 1K"
   },
   {
     "Class":"Itemtype",
-    "Name":"http:\/\/schema.org\/SeekToAction",
+    "Name":"https://schema.org/SeekToAction",
     "Domain Bucket":"10K - 100K"
   },
   {
     "Class":"Itemtype",
-    "Name":"http:\/\/schema.org\/SelfStorage",
+    "Name":"https://schema.org/SelfStorage",
     "Domain Bucket":"10K - 100K"
   },
   {
     "Class":"Itemtype",
-    "Name":"http:\/\/schema.org\/SellAction",
+    "Name":"https://schema.org/SellAction",
     "Domain Bucket":"1K - 10K"
   },
   {
     "Class":"Itemtype",
-    "Name":"http:\/\/schema.org\/SendAction",
+    "Name":"https://schema.org/SendAction",
     "Domain Bucket":"< 1K"
   },
   {
     "Class":"Itemtype",
-    "Name":"http:\/\/schema.org\/SequentialArt",
+    "Name":"https://schema.org/SequentialArt",
     "Domain Bucket":"< 1K"
   },
   {
     "Class":"Itemtype",
-    "Name":"http:\/\/schema.org\/Series",
+    "Name":"https://schema.org/Series",
     "Domain Bucket":"10K - 100K"
   },
   {
     "Class":"Itemtype",
-    "Name":"http:\/\/schema.org\/Service",
+    "Name":"https://schema.org/Service",
     "Domain Bucket":"1M - 10M"
   },
   {
     "Class":"Itemtype",
-    "Name":"http:\/\/schema.org\/ServiceChannel",
+    "Name":"https://schema.org/ServiceChannel",
     "Domain Bucket":"100K - 1M"
   },
   {
     "Class":"Itemtype",
-    "Name":"http:\/\/schema.org\/ServicePeriod",
+    "Name":"https://schema.org/ServicePeriod",
     "Domain Bucket":"1K - 10K"
   },
   {
     "Class":"Itemtype",
-    "Name":"http:\/\/schema.org\/ShareAction",
+    "Name":"https://schema.org/ShareAction",
     "Domain Bucket":"10K - 100K"
   },
   {
     "Class":"Itemtype",
-    "Name":"http:\/\/schema.org\/SheetMusic",
+    "Name":"https://schema.org/SheetMusic",
     "Domain Bucket":"< 1K"
   },
   {
     "Class":"Itemtype",
-    "Name":"http:\/\/schema.org\/ShippingConditions",
+    "Name":"https://schema.org/ShippingConditions",
     "Domain Bucket":"10K - 100K"
   },
   {
     "Class":"Itemtype",
-    "Name":"http:\/\/schema.org\/ShippingDeliveryTime",
+    "Name":"https://schema.org/ShippingDeliveryTime",
     "Domain Bucket":"100K - 1M"
   },
   {
     "Class":"Itemtype",
-    "Name":"http:\/\/schema.org\/ShippingRateSettings",
+    "Name":"https://schema.org/ShippingRateSettings",
     "Domain Bucket":"< 1K"
   },
   {
     "Class":"Itemtype",
-    "Name":"http:\/\/schema.org\/ShippingService",
+    "Name":"https://schema.org/ShippingService",
     "Domain Bucket":"10K - 100K"
   },
   {
     "Class":"Itemtype",
-    "Name":"http:\/\/schema.org\/ShoeStore",
+    "Name":"https://schema.org/ShoeStore",
     "Domain Bucket":"1K - 10K"
   },
   {
     "Class":"Itemtype",
-    "Name":"http:\/\/schema.org\/ShoppingCenter",
+    "Name":"https://schema.org/ShoppingCenter",
     "Domain Bucket":"1K - 10K"
   },
   {
     "Class":"Itemtype",
-    "Name":"http:\/\/schema.org\/ShortStory",
+    "Name":"https://schema.org/ShortStory",
     "Domain Bucket":"< 1K"
   },
   {
     "Class":"Itemtype",
-    "Name":"http:\/\/schema.org\/SingleFamilyResidence",
+    "Name":"https://schema.org/SingleFamilyResidence",
     "Domain Bucket":"10K - 100K"
   },
   {
     "Class":"Itemtype",
-    "Name":"http:\/\/schema.org\/SiteNavigationElement",
+    "Name":"https://schema.org/SiteNavigationElement",
     "Domain Bucket":"1M - 10M"
   },
   {
     "Class":"Itemtype",
-    "Name":"http:\/\/schema.org\/SizeGroupEnumeration",
+    "Name":"https://schema.org/SizeGroupEnumeration",
     "Domain Bucket":"< 1K"
   },
   {
     "Class":"Itemtype",
-    "Name":"http:\/\/schema.org\/SizeSpecification",
+    "Name":"https://schema.org/SizeSpecification",
     "Domain Bucket":"1K - 10K"
   },
   {
     "Class":"Itemtype",
-    "Name":"http:\/\/schema.org\/SizeSystemEnumeration",
+    "Name":"https://schema.org/SizeSystemEnumeration",
     "Domain Bucket":"< 1K"
   },
   {
     "Class":"Itemtype",
-    "Name":"http:\/\/schema.org\/SkiResort",
+    "Name":"https://schema.org/SkiResort",
     "Domain Bucket":"< 1K"
   },
   {
     "Class":"Itemtype",
-    "Name":"http:\/\/schema.org\/SocialEvent",
+    "Name":"https://schema.org/SocialEvent",
     "Domain Bucket":"1K - 10K"
   },
   {
     "Class":"Itemtype",
-    "Name":"http:\/\/schema.org\/SocialMediaPosting",
+    "Name":"https://schema.org/SocialMediaPosting",
     "Domain Bucket":"10K - 100K"
   },
   {
     "Class":"Itemtype",
-    "Name":"http:\/\/schema.org\/SoftwareApplication",
+    "Name":"https://schema.org/SoftwareApplication",
     "Domain Bucket":"1M - 10M"
   },
   {
     "Class":"Itemtype",
-    "Name":"http:\/\/schema.org\/SoftwareSourceCode",
+    "Name":"https://schema.org/SoftwareSourceCode",
     "Domain Bucket":"1K - 10K"
   },
   {
     "Class":"Itemtype",
-    "Name":"http:\/\/schema.org\/SolveMathAction",
+    "Name":"https://schema.org/SolveMathAction",
     "Domain Bucket":"< 1K"
   },
   {
     "Class":"Itemtype",
-    "Name":"http:\/\/schema.org\/SomeProducts",
+    "Name":"https://schema.org/SomeProducts",
     "Domain Bucket":"10K - 100K"
   },
   {
     "Class":"Itemtype",
-    "Name":"http:\/\/schema.org\/SpeakableSpecification",
+    "Name":"https://schema.org/SpeakableSpecification",
     "Domain Bucket":"100K - 1M"
   },
   {
     "Class":"Itemtype",
-    "Name":"http:\/\/schema.org\/SpecialAnnouncement",
+    "Name":"https://schema.org/SpecialAnnouncement",
     "Domain Bucket":"1K - 10K"
   },
   {
     "Class":"Itemtype",
-    "Name":"http:\/\/schema.org\/Specialty",
+    "Name":"https://schema.org/Specialty",
     "Domain Bucket":"1K - 10K"
   },
   {
     "Class":"Itemtype",
-    "Name":"http:\/\/schema.org\/SportingGoodsStore",
+    "Name":"https://schema.org/SportingGoodsStore",
     "Domain Bucket":"1K - 10K"
   },
   {
     "Class":"Itemtype",
-    "Name":"http:\/\/schema.org\/SportsActivityLocation",
+    "Name":"https://schema.org/SportsActivityLocation",
     "Domain Bucket":"10K - 100K"
   },
   {
     "Class":"Itemtype",
-    "Name":"http:\/\/schema.org\/SportsClub",
+    "Name":"https://schema.org/SportsClub",
     "Domain Bucket":"1K - 10K"
   },
   {
     "Class":"Itemtype",
-    "Name":"http:\/\/schema.org\/SportsEvent",
+    "Name":"https://schema.org/SportsEvent",
     "Domain Bucket":"10K - 100K"
   },
   {
     "Class":"Itemtype",
-    "Name":"http:\/\/schema.org\/SportsOrganization",
+    "Name":"https://schema.org/SportsOrganization",
     "Domain Bucket":"10K - 100K"
   },
   {
     "Class":"Itemtype",
-    "Name":"http:\/\/schema.org\/SportsTeam",
+    "Name":"https://schema.org/SportsTeam",
     "Domain Bucket":"10K - 100K"
   },
   {
     "Class":"Itemtype",
-    "Name":"http:\/\/schema.org\/SpreadsheetDigitalDocument",
+    "Name":"https://schema.org/SpreadsheetDigitalDocument",
     "Domain Bucket":"< 1K"
   },
   {
     "Class":"Itemtype",
-    "Name":"http:\/\/schema.org\/StadiumOrArena",
+    "Name":"https://schema.org/StadiumOrArena",
     "Domain Bucket":"1K - 10K"
   },
   {
     "Class":"Itemtype",
-    "Name":"http:\/\/schema.org\/State",
+    "Name":"https://schema.org/State",
     "Domain Bucket":"100K - 1M"
   },
   {
     "Class":"Itemtype",
-    "Name":"http:\/\/schema.org\/Statement",
+    "Name":"https://schema.org/Statement",
     "Domain Bucket":"< 1K"
   },
   {
     "Class":"Itemtype",
-    "Name":"http:\/\/schema.org\/StatisticalPopulation",
+    "Name":"https://schema.org/StatisticalPopulation",
     "Domain Bucket":"< 1K"
   },
   {
     "Class":"Itemtype",
-    "Name":"http:\/\/schema.org\/StatisticalVariable",
+    "Name":"https://schema.org/StatisticalVariable",
     "Domain Bucket":"< 1K"
   },
   {
     "Class":"Itemtype",
-    "Name":"http:\/\/schema.org\/StatusEnumeration",
+    "Name":"https://schema.org/StatusEnumeration",
     "Domain Bucket":"< 1K"
   },
   {
     "Class":"Itemtype",
-    "Name":"http:\/\/schema.org\/SteeringPositionValue",
+    "Name":"https://schema.org/SteeringPositionValue",
     "Domain Bucket":"< 1K"
   },
   {
     "Class":"Itemtype",
-    "Name":"http:\/\/schema.org\/Store",
+    "Name":"https://schema.org/Store",
     "Domain Bucket":"100K - 1M"
   },
   {
     "Class":"Itemtype",
-    "Name":"http:\/\/schema.org\/StructuredValue",
+    "Name":"https://schema.org/StructuredValue",
     "Domain Bucket":"1K - 10K"
   },
   {
     "Class":"Itemtype",
-    "Name":"http:\/\/schema.org\/StupidType",
+    "Name":"https://schema.org/StupidType",
     "Domain Bucket":"< 1K"
   },
   {
     "Class":"Itemtype",
-    "Name":"http:\/\/schema.org\/SubscribeAction",
+    "Name":"https://schema.org/SubscribeAction",
     "Domain Bucket":"10K - 100K"
   },
   {
     "Class":"Itemtype",
-    "Name":"http:\/\/schema.org\/Substance",
+    "Name":"https://schema.org/Substance",
     "Domain Bucket":"< 1K"
   },
   {
     "Class":"Itemtype",
-    "Name":"http:\/\/schema.org\/SubwayStation",
+    "Name":"https://schema.org/SubwayStation",
     "Domain Bucket":"< 1K"
   },
   {
     "Class":"Itemtype",
-    "Name":"http:\/\/schema.org\/Suite",
+    "Name":"https://schema.org/Suite",
     "Domain Bucket":"< 1K"
   },
   {
     "Class":"Itemtype",
-    "Name":"http:\/\/schema.org\/SuperficialAnatomy",
+    "Name":"https://schema.org/SuperficialAnatomy",
     "Domain Bucket":"< 1K"
   },
   {
     "Class":"Itemtype",
-    "Name":"http:\/\/schema.org\/SurgicalProcedure",
+    "Name":"https://schema.org/SurgicalProcedure",
     "Domain Bucket":"1K - 10K"
   },
   {
     "Class":"Itemtype",
-    "Name":"http:\/\/schema.org\/SuspendAction",
+    "Name":"https://schema.org/SuspendAction",
     "Domain Bucket":"< 1K"
   },
   {
     "Class":"Itemtype",
-    "Name":"http:\/\/schema.org\/Syllabus",
+    "Name":"https://schema.org/Syllabus",
     "Domain Bucket":"1K - 10K"
   },
   {
     "Class":"Itemtype",
-    "Name":"http:\/\/schema.org\/Synagogue",
+    "Name":"https://schema.org/Synagogue",
     "Domain Bucket":"< 1K"
   },
   {
     "Class":"Itemtype",
-    "Name":"http:\/\/schema.org\/TVClip",
+    "Name":"https://schema.org/TVClip",
     "Domain Bucket":"< 1K"
   },
   {
     "Class":"Itemtype",
-    "Name":"http:\/\/schema.org\/TVEpisode",
+    "Name":"https://schema.org/TVEpisode",
     "Domain Bucket":"1K - 10K"
   },
   {
     "Class":"Itemtype",
-    "Name":"http:\/\/schema.org\/TVSeason",
+    "Name":"https://schema.org/TVSeason",
     "Domain Bucket":"1K - 10K"
   },
   {
     "Class":"Itemtype",
-    "Name":"http:\/\/schema.org\/TVSeries",
+    "Name":"https://schema.org/TVSeries",
     "Domain Bucket":"10K - 100K"
   },
   {
     "Class":"Itemtype",
-    "Name":"http:\/\/schema.org\/Table",
+    "Name":"https://schema.org/Table",
     "Domain Bucket":"10K - 100K"
   },
   {
     "Class":"Itemtype",
-    "Name":"http:\/\/schema.org\/TakeAction",
+    "Name":"https://schema.org/TakeAction",
     "Domain Bucket":"< 1K"
   },
   {
     "Class":"Itemtype",
-    "Name":"http:\/\/schema.org\/TattooParlor",
+    "Name":"https://schema.org/TattooParlor",
     "Domain Bucket":"1K - 10K"
   },
   {
     "Class":"Itemtype",
-    "Name":"http:\/\/schema.org\/Taxi",
+    "Name":"https://schema.org/Taxi",
     "Domain Bucket":"< 1K"
   },
   {
     "Class":"Itemtype",
-    "Name":"http:\/\/schema.org\/TaxiReservation",
+    "Name":"https://schema.org/TaxiReservation",
     "Domain Bucket":"< 1K"
   },
   {
     "Class":"Itemtype",
-    "Name":"http:\/\/schema.org\/TaxiService",
+    "Name":"https://schema.org/TaxiService",
     "Domain Bucket":"10K - 100K"
   },
   {
     "Class":"Itemtype",
-    "Name":"http:\/\/schema.org\/TaxiStand",
+    "Name":"https://schema.org/TaxiStand",
     "Domain Bucket":"< 1K"
   },
   {
     "Class":"Itemtype",
-    "Name":"http:\/\/schema.org\/Taxon",
+    "Name":"https://schema.org/Taxon",
     "Domain Bucket":"< 1K"
   },
   {
     "Class":"Itemtype",
-    "Name":"http:\/\/schema.org\/TechArticle",
+    "Name":"https://schema.org/TechArticle",
     "Domain Bucket":"10K - 100K"
   },
   {
     "Class":"Itemtype",
-    "Name":"http:\/\/schema.org\/TelevisionChannel",
+    "Name":"https://schema.org/TelevisionChannel",
     "Domain Bucket":"< 1K"
   },
   {
     "Class":"Itemtype",
-    "Name":"http:\/\/schema.org\/TelevisionStation",
+    "Name":"https://schema.org/TelevisionStation",
     "Domain Bucket":"< 1K"
   },
   {
     "Class":"Itemtype",
-    "Name":"http:\/\/schema.org\/TennisComplex",
+    "Name":"https://schema.org/TennisComplex",
     "Domain Bucket":"< 1K"
   },
   {
     "Class":"Itemtype",
-    "Name":"http:\/\/schema.org\/Text",
+    "Name":"https://schema.org/Text",
     "Domain Bucket":"10K - 100K"
   },
   {
     "Class":"Itemtype",
-    "Name":"http:\/\/schema.org\/TextDigitalDocument",
+    "Name":"https://schema.org/TextDigitalDocument",
     "Domain Bucket":"< 1K"
   },
   {
     "Class":"Itemtype",
-    "Name":"http:\/\/schema.org\/TextObject",
+    "Name":"https://schema.org/TextObject",
     "Domain Bucket":"1K - 10K"
   },
   {
     "Class":"Itemtype",
-    "Name":"http:\/\/schema.org\/TheaterEvent",
+    "Name":"https://schema.org/TheaterEvent",
     "Domain Bucket":"1K - 10K"
   },
   {
     "Class":"Itemtype",
-    "Name":"http:\/\/schema.org\/TheaterGroup",
+    "Name":"https://schema.org/TheaterGroup",
     "Domain Bucket":"1K - 10K"
   },
   {
     "Class":"Itemtype",
-    "Name":"http:\/\/schema.org\/TherapeuticProcedure",
+    "Name":"https://schema.org/TherapeuticProcedure",
     "Domain Bucket":"1K - 10K"
   },
   {
     "Class":"Itemtype",
-    "Name":"http:\/\/schema.org\/Thesis",
+    "Name":"https://schema.org/Thesis",
     "Domain Bucket":"< 1K"
   },
   {
     "Class":"Itemtype",
-    "Name":"http:\/\/schema.org\/Thing",
+    "Name":"https://schema.org/Thing",
     "Domain Bucket":"10M+"
   },
   {
     "Class":"Itemtype",
-    "Name":"http:\/\/schema.org\/Ticket",
+    "Name":"https://schema.org/Ticket",
     "Domain Bucket":"< 1K"
   },
   {
     "Class":"Itemtype",
-    "Name":"http:\/\/schema.org\/TieAction",
+    "Name":"https://schema.org/TieAction",
     "Domain Bucket":"< 1K"
   },
   {
     "Class":"Itemtype",
-    "Name":"http:\/\/schema.org\/TierBenefitEnumeration",
+    "Name":"https://schema.org/TierBenefitEnumeration",
     "Domain Bucket":"< 1K"
   },
   {
     "Class":"Itemtype",
-    "Name":"http:\/\/schema.org\/Time",
+    "Name":"https://schema.org/Time",
     "Domain Bucket":"< 1K"
   },
   {
     "Class":"Itemtype",
-    "Name":"http:\/\/schema.org\/TipAction",
+    "Name":"https://schema.org/TipAction",
     "Domain Bucket":"< 1K"
   },
   {
     "Class":"Itemtype",
-    "Name":"http:\/\/schema.org\/TireShop",
+    "Name":"https://schema.org/TireShop",
     "Domain Bucket":"1K - 10K"
   },
   {
     "Class":"Itemtype",
-    "Name":"http:\/\/schema.org\/TouristAttraction",
+    "Name":"https://schema.org/TouristAttraction",
     "Domain Bucket":"10K - 100K"
   },
   {
     "Class":"Itemtype",
-    "Name":"http:\/\/schema.org\/TouristDestination",
+    "Name":"https://schema.org/TouristDestination",
     "Domain Bucket":"10K - 100K"
   },
   {
     "Class":"Itemtype",
-    "Name":"http:\/\/schema.org\/TouristInformationCenter",
+    "Name":"https://schema.org/TouristInformationCenter",
     "Domain Bucket":"1K - 10K"
   },
   {
     "Class":"Itemtype",
-    "Name":"http:\/\/schema.org\/TouristTrip",
+    "Name":"https://schema.org/TouristTrip",
     "Domain Bucket":"10K - 100K"
   },
   {
     "Class":"Itemtype",
-    "Name":"http:\/\/schema.org\/ToyStore",
+    "Name":"https://schema.org/ToyStore",
     "Domain Bucket":"1K - 10K"
   },
   {
     "Class":"Itemtype",
-    "Name":"http:\/\/schema.org\/TrackAction",
+    "Name":"https://schema.org/TrackAction",
     "Domain Bucket":"< 1K"
   },
   {
     "Class":"Itemtype",
-    "Name":"http:\/\/schema.org\/TradeAction",
+    "Name":"https://schema.org/TradeAction",
     "Domain Bucket":"1K - 10K"
   },
   {
     "Class":"Itemtype",
-    "Name":"http:\/\/schema.org\/TrainReservation",
+    "Name":"https://schema.org/TrainReservation",
     "Domain Bucket":"< 1K"
   },
   {
     "Class":"Itemtype",
-    "Name":"http:\/\/schema.org\/TrainStation",
+    "Name":"https://schema.org/TrainStation",
     "Domain Bucket":"1K - 10K"
   },
   {
     "Class":"Itemtype",
-    "Name":"http:\/\/schema.org\/TrainTrip",
+    "Name":"https://schema.org/TrainTrip",
     "Domain Bucket":"< 1K"
   },
   {
     "Class":"Itemtype",
-    "Name":"http:\/\/schema.org\/TransferAction",
+    "Name":"https://schema.org/TransferAction",
     "Domain Bucket":"< 1K"
   },
   {
     "Class":"Itemtype",
-    "Name":"http:\/\/schema.org\/TravelAction",
+    "Name":"https://schema.org/TravelAction",
     "Domain Bucket":"1K - 10K"
   },
   {
     "Class":"Itemtype",
-    "Name":"http:\/\/schema.org\/TravelAgency",
+    "Name":"https://schema.org/TravelAgency",
     "Domain Bucket":"10K - 100K"
   },
   {
     "Class":"Itemtype",
-    "Name":"http:\/\/schema.org\/TreatmentIndication",
+    "Name":"https://schema.org/TreatmentIndication",
     "Domain Bucket":"< 1K"
   },
   {
     "Class":"Itemtype",
-    "Name":"http:\/\/schema.org\/Trip",
+    "Name":"https://schema.org/Trip",
     "Domain Bucket":"10K - 100K"
   },
   {
     "Class":"Itemtype",
-    "Name":"http:\/\/schema.org\/TypeAndQuantityNode",
+    "Name":"https://schema.org/TypeAndQuantityNode",
     "Domain Bucket":"1K - 10K"
   },
   {
     "Class":"Itemtype",
-    "Name":"http:\/\/schema.org\/UKNonprofitType",
+    "Name":"https://schema.org/UKNonprofitType",
     "Domain Bucket":"< 1K"
   },
   {
     "Class":"Itemtype",
-    "Name":"http:\/\/schema.org\/URL",
+    "Name":"https://schema.org/URL",
     "Domain Bucket":"1K - 10K"
   },
   {
     "Class":"Itemtype",
-    "Name":"http:\/\/schema.org\/USNonprofitType",
+    "Name":"https://schema.org/USNonprofitType",
     "Domain Bucket":"< 1K"
   },
   {
     "Class":"Itemtype",
-    "Name":"http:\/\/schema.org\/UnRegisterAction",
+    "Name":"https://schema.org/UnRegisterAction",
     "Domain Bucket":"< 1K"
   },
   {
     "Class":"Itemtype",
-    "Name":"http:\/\/schema.org\/UnitPriceSpecification",
+    "Name":"https://schema.org/UnitPriceSpecification",
     "Domain Bucket":"1M - 10M"
   },
   {
     "Class":"Itemtype",
-    "Name":"http:\/\/schema.org\/UpdateAction",
+    "Name":"https://schema.org/UpdateAction",
     "Domain Bucket":"< 1K"
   },
   {
     "Class":"Itemtype",
-    "Name":"http:\/\/schema.org\/UseAction",
+    "Name":"https://schema.org/UseAction",
     "Domain Bucket":"1K - 10K"
   },
   {
     "Class":"Itemtype",
-    "Name":"http:\/\/schema.org\/UserBlocks",
+    "Name":"https://schema.org/UserBlocks",
     "Domain Bucket":"< 1K"
   },
   {
     "Class":"Itemtype",
-    "Name":"http:\/\/schema.org\/UserCheckins",
+    "Name":"https://schema.org/UserCheckins",
     "Domain Bucket":"1K - 10K"
   },
   {
     "Class":"Itemtype",
-    "Name":"http:\/\/schema.org\/UserComments",
+    "Name":"https://schema.org/UserComments",
     "Domain Bucket":"10K - 100K"
   },
   {
     "Class":"Itemtype",
-    "Name":"http:\/\/schema.org\/UserDownloads",
+    "Name":"https://schema.org/UserDownloads",
     "Domain Bucket":"< 1K"
   },
   {
     "Class":"Itemtype",
-    "Name":"http:\/\/schema.org\/UserInteraction",
+    "Name":"https://schema.org/UserInteraction",
     "Domain Bucket":"< 1K"
   },
   {
     "Class":"Itemtype",
-    "Name":"http:\/\/schema.org\/UserLikes",
+    "Name":"https://schema.org/UserLikes",
     "Domain Bucket":"< 1K"
   },
   {
     "Class":"Itemtype",
-    "Name":"http:\/\/schema.org\/UserPageVisits",
+    "Name":"https://schema.org/UserPageVisits",
     "Domain Bucket":"< 1K"
   },
   {
     "Class":"Itemtype",
-    "Name":"http:\/\/schema.org\/UserPlays",
+    "Name":"https://schema.org/UserPlays",
     "Domain Bucket":"< 1K"
   },
   {
     "Class":"Itemtype",
-    "Name":"http:\/\/schema.org\/UserPlusOnes",
+    "Name":"https://schema.org/UserPlusOnes",
     "Domain Bucket":"< 1K"
   },
   {
     "Class":"Itemtype",
-    "Name":"http:\/\/schema.org\/UserReview",
+    "Name":"https://schema.org/UserReview",
     "Domain Bucket":"1K - 10K"
   },
   {
     "Class":"Itemtype",
-    "Name":"http:\/\/schema.org\/UserTweets",
+    "Name":"https://schema.org/UserTweets",
     "Domain Bucket":"< 1K"
   },
   {
     "Class":"Itemtype",
-    "Name":"http:\/\/schema.org\/VacationRental",
+    "Name":"https://schema.org/VacationRental",
     "Domain Bucket":"10K - 100K"
   },
   {
     "Class":"Itemtype",
-    "Name":"http:\/\/schema.org\/Vehicle",
+    "Name":"https://schema.org/Vehicle",
     "Domain Bucket":"10K - 100K"
   },
   {
     "Class":"Itemtype",
-    "Name":"http:\/\/schema.org\/Vein",
+    "Name":"https://schema.org/Vein",
     "Domain Bucket":"< 1K"
   },
   {
     "Class":"Itemtype",
-    "Name":"http:\/\/schema.org\/Vessel",
+    "Name":"https://schema.org/Vessel",
     "Domain Bucket":"< 1K"
   },
   {
     "Class":"Itemtype",
-    "Name":"http:\/\/schema.org\/VeterinaryCare",
+    "Name":"https://schema.org/VeterinaryCare",
     "Domain Bucket":"1K - 10K"
   },
   {
     "Class":"Itemtype",
-    "Name":"http:\/\/schema.org\/VideoGallery",
+    "Name":"https://schema.org/VideoGallery",
     "Domain Bucket":"1K - 10K"
   },
   {
     "Class":"Itemtype",
-    "Name":"http:\/\/schema.org\/VideoGame",
+    "Name":"https://schema.org/VideoGame",
     "Domain Bucket":"10K - 100K"
   },
   {
     "Class":"Itemtype",
-    "Name":"http:\/\/schema.org\/VideoGameClip",
+    "Name":"https://schema.org/VideoGameClip",
     "Domain Bucket":"< 1K"
   },
   {
     "Class":"Itemtype",
-    "Name":"http:\/\/schema.org\/VideoGameSeries",
+    "Name":"https://schema.org/VideoGameSeries",
     "Domain Bucket":"1K - 10K"
   },
   {
     "Class":"Itemtype",
-    "Name":"http:\/\/schema.org\/VideoObject",
+    "Name":"https://schema.org/VideoObject",
     "Domain Bucket":"1M - 10M"
   },
   {
     "Class":"Itemtype",
-    "Name":"http:\/\/schema.org\/VideoObjectSnapshot",
+    "Name":"https://schema.org/VideoObjectSnapshot",
     "Domain Bucket":"< 1K"
   },
   {
     "Class":"Itemtype",
-    "Name":"http:\/\/schema.org\/ViewAction",
+    "Name":"https://schema.org/ViewAction",
     "Domain Bucket":"10K - 100K"
   },
   {
     "Class":"Itemtype",
-    "Name":"http:\/\/schema.org\/VirtualLocation",
+    "Name":"https://schema.org/VirtualLocation",
     "Domain Bucket":"10K - 100K"
   },
   {
     "Class":"Itemtype",
-    "Name":"http:\/\/schema.org\/VisualArtsEvent",
+    "Name":"https://schema.org/VisualArtsEvent",
     "Domain Bucket":"< 1K"
   },
   {
     "Class":"Itemtype",
-    "Name":"http:\/\/schema.org\/VisualArtwork",
+    "Name":"https://schema.org/VisualArtwork",
     "Domain Bucket":"1K - 10K"
   },
   {
     "Class":"Itemtype",
-    "Name":"http:\/\/schema.org\/VitalSign",
+    "Name":"https://schema.org/VitalSign",
     "Domain Bucket":"< 1K"
   },
   {
     "Class":"Itemtype",
-    "Name":"http:\/\/schema.org\/Volcano",
+    "Name":"https://schema.org/Volcano",
     "Domain Bucket":"< 1K"
   },
   {
     "Class":"Itemtype",
-    "Name":"http:\/\/schema.org\/VoteAction",
+    "Name":"https://schema.org/VoteAction",
     "Domain Bucket":"< 1K"
   },
   {
     "Class":"Itemtype",
-    "Name":"http:\/\/schema.org\/WPAdBlock",
+    "Name":"https://schema.org/WPAdBlock",
     "Domain Bucket":"10K - 100K"
   },
   {
     "Class":"Itemtype",
-    "Name":"http:\/\/schema.org\/WPFooter",
+    "Name":"https://schema.org/WPFooter",
     "Domain Bucket":"1M - 10M"
   },
   {
     "Class":"Itemtype",
-    "Name":"http:\/\/schema.org\/WPHeader",
+    "Name":"https://schema.org/WPHeader",
     "Domain Bucket":"1M - 10M"
   },
   {
     "Class":"Itemtype",
-    "Name":"http:\/\/schema.org\/WPSideBar",
+    "Name":"https://schema.org/WPSideBar",
     "Domain Bucket":"1M - 10M"
   },
   {
     "Class":"Itemtype",
-    "Name":"http:\/\/schema.org\/WantAction",
+    "Name":"https://schema.org/WantAction",
     "Domain Bucket":"< 1K"
   },
   {
     "Class":"Itemtype",
-    "Name":"http:\/\/schema.org\/WarrantyPromise",
+    "Name":"https://schema.org/WarrantyPromise",
     "Domain Bucket":"10K - 100K"
   },
   {
     "Class":"Itemtype",
-    "Name":"http:\/\/schema.org\/WarrantyScope",
+    "Name":"https://schema.org/WarrantyScope",
     "Domain Bucket":"< 1K"
   },
   {
     "Class":"Itemtype",
-    "Name":"http:\/\/schema.org\/WatchAction",
+    "Name":"https://schema.org/WatchAction",
     "Domain Bucket":"100K - 1M"
   },
   {
     "Class":"Itemtype",
-    "Name":"http:\/\/schema.org\/Waterfall",
+    "Name":"https://schema.org/Waterfall",
     "Domain Bucket":"< 1K"
   },
   {
     "Class":"Itemtype",
-    "Name":"http:\/\/schema.org\/WearAction",
+    "Name":"https://schema.org/WearAction",
     "Domain Bucket":"< 1K"
   },
   {
     "Class":"Itemtype",
-    "Name":"http:\/\/schema.org\/WearableMeasurementTypeEnumeration",
+    "Name":"https://schema.org/WearableMeasurementTypeEnumeration",
     "Domain Bucket":"< 1K"
   },
   {
     "Class":"Itemtype",
-    "Name":"http:\/\/schema.org\/WearableSizeGroupEnumeration",
+    "Name":"https://schema.org/WearableSizeGroupEnumeration",
     "Domain Bucket":"< 1K"
   },
   {
     "Class":"Itemtype",
-    "Name":"http:\/\/schema.org\/WearableSizeSystemEnumeration",
+    "Name":"https://schema.org/WearableSizeSystemEnumeration",
     "Domain Bucket":"< 1K"
   },
   {
     "Class":"Itemtype",
-    "Name":"http:\/\/schema.org\/WebAPI",
+    "Name":"https://schema.org/WebAPI",
     "Domain Bucket":"1K - 10K"
   },
   {
     "Class":"Itemtype",
-    "Name":"http:\/\/schema.org\/WebApplication",
+    "Name":"https://schema.org/WebApplication",
     "Domain Bucket":"100K - 1M"
   },
   {
     "Class":"Itemtype",
-    "Name":"http:\/\/schema.org\/WebContent",
+    "Name":"https://schema.org/WebContent",
     "Domain Bucket":"1K - 10K"
   },
   {
     "Class":"Itemtype",
-    "Name":"http:\/\/schema.org\/WebPage",
+    "Name":"https://schema.org/WebPage",
     "Domain Bucket":"10M+"
   },
   {
     "Class":"Itemtype",
-    "Name":"http:\/\/schema.org\/WebPageElement",
+    "Name":"https://schema.org/WebPageElement",
     "Domain Bucket":"1M - 10M"
   },
   {
     "Class":"Itemtype",
-    "Name":"http:\/\/schema.org\/WebSite",
+    "Name":"https://schema.org/WebSite",
     "Domain Bucket":"10M+"
   },
   {
     "Class":"Itemtype",
-    "Name":"http:\/\/schema.org\/WholesaleStore",
+    "Name":"https://schema.org/WholesaleStore",
     "Domain Bucket":"1K - 10K"
   },
   {
     "Class":"Itemtype",
-    "Name":"http:\/\/schema.org\/WinAction",
+    "Name":"https://schema.org/WinAction",
     "Domain Bucket":"< 1K"
   },
   {
     "Class":"Itemtype",
-    "Name":"http:\/\/schema.org\/Winery",
+    "Name":"https://schema.org/Winery",
     "Domain Bucket":"1K - 10K"
   },
   {
     "Class":"Itemtype",
-    "Name":"http:\/\/schema.org\/WorkBasedProgram",
+    "Name":"https://schema.org/WorkBasedProgram",
     "Domain Bucket":"< 1K"
   },
   {
     "Class":"Itemtype",
-    "Name":"http:\/\/schema.org\/WorkersUnion",
+    "Name":"https://schema.org/WorkersUnion",
     "Domain Bucket":"< 1K"
   },
   {
     "Class":"Itemtype",
-    "Name":"http:\/\/schema.org\/WriteAction",
+    "Name":"https://schema.org/WriteAction",
     "Domain Bucket":"10K - 100K"
   },
   {
     "Class":"Itemtype",
-    "Name":"http:\/\/schema.org\/XPathType",
+    "Name":"https://schema.org/XPathType",
     "Domain Bucket":"< 1K"
   },
   {
     "Class":"Itemtype",
-    "Name":"http:\/\/schema.org\/Zoo",
+    "Name":"https://schema.org/Zoo",
     "Domain Bucket":"< 1K"
   },
   {
     "Class":"Predicate",
-    "Name":"http:\/\/schema.org\/about",
+    "Name":"https://schema.org/about",
     "Domain Bucket":"10M+"
   },
   {
     "Class":"Predicate",
-    "Name":"http:\/\/schema.org\/about-input",
+    "Name":"https://schema.org/about-input",
     "Domain Bucket":"< 1K"
   },
   {
     "Class":"Predicate",
-    "Name":"http:\/\/schema.org\/about-output",
+    "Name":"https://schema.org/about-output",
     "Domain Bucket":"< 1K"
   },
   {
     "Class":"Predicate",
-    "Name":"http:\/\/schema.org\/abridged",
+    "Name":"https://schema.org/abridged",
     "Domain Bucket":"< 1K"
   },
   {
     "Class":"Predicate",
-    "Name":"http:\/\/schema.org\/abridged-input",
+    "Name":"https://schema.org/abridged-input",
     "Domain Bucket":"< 1K"
   },
   {
     "Class":"Predicate",
-    "Name":"http:\/\/schema.org\/abridged-output",
+    "Name":"https://schema.org/abridged-output",
     "Domain Bucket":"< 1K"
   },
   {
     "Class":"Predicate",
-    "Name":"http:\/\/schema.org\/abstract",
+    "Name":"https://schema.org/abstract",
     "Domain Bucket":"10K - 100K"
   },
   {
     "Class":"Predicate",
-    "Name":"http:\/\/schema.org\/abstract-input",
+    "Name":"https://schema.org/abstract-input",
     "Domain Bucket":"< 1K"
   },
   {
     "Class":"Predicate",
-    "Name":"http:\/\/schema.org\/abstract-output",
+    "Name":"https://schema.org/abstract-output",
     "Domain Bucket":"< 1K"
   },
   {
     "Class":"Predicate",
-    "Name":"http:\/\/schema.org\/accelerationTime",
+    "Name":"https://schema.org/accelerationTime",
     "Domain Bucket":"1K - 10K"
   },
   {
     "Class":"Predicate",
-    "Name":"http:\/\/schema.org\/accelerationTime-input",
+    "Name":"https://schema.org/accelerationTime-input",
     "Domain Bucket":"< 1K"
   },
   {
     "Class":"Predicate",
-    "Name":"http:\/\/schema.org\/accelerationTime-output",
+    "Name":"https://schema.org/accelerationTime-output",
     "Domain Bucket":"< 1K"
   },
   {
     "Class":"Predicate",
-    "Name":"http:\/\/schema.org\/acceptedAnswer",
+    "Name":"https://schema.org/acceptedAnswer",
     "Domain Bucket":"1M - 10M"
   },
   {
     "Class":"Predicate",
-    "Name":"http:\/\/schema.org\/acceptedAnswer-input",
+    "Name":"https://schema.org/acceptedAnswer-input",
     "Domain Bucket":"< 1K"
   },
   {
     "Class":"Predicate",
-    "Name":"http:\/\/schema.org\/acceptedAnswer-output",
+    "Name":"https://schema.org/acceptedAnswer-output",
     "Domain Bucket":"< 1K"
   },
   {
     "Class":"Predicate",
-    "Name":"http:\/\/schema.org\/acceptedOffer",
+    "Name":"https://schema.org/acceptedOffer",
     "Domain Bucket":"< 1K"
   },
   {
     "Class":"Predicate",
-    "Name":"http:\/\/schema.org\/acceptedOffer-input",
+    "Name":"https://schema.org/acceptedOffer-input",
     "Domain Bucket":"< 1K"
   },
   {
     "Class":"Predicate",
-    "Name":"http:\/\/schema.org\/acceptedOffer-output",
+    "Name":"https://schema.org/acceptedOffer-output",
     "Domain Bucket":"< 1K"
   },
   {
     "Class":"Predicate",
-    "Name":"http:\/\/schema.org\/acceptedPaymentMethod",
+    "Name":"https://schema.org/acceptedPaymentMethod",
     "Domain Bucket":"10K - 100K"
   },
   {
     "Class":"Predicate",
-    "Name":"http:\/\/schema.org\/acceptedPaymentMethod-input",
+    "Name":"https://schema.org/acceptedPaymentMethod-input",
     "Domain Bucket":"< 1K"
   },
   {
     "Class":"Predicate",
-    "Name":"http:\/\/schema.org\/acceptedPaymentMethod-output",
+    "Name":"https://schema.org/acceptedPaymentMethod-output",
     "Domain Bucket":"< 1K"
   },
   {
     "Class":"Predicate",
-    "Name":"http:\/\/schema.org\/acceptsReservations",
+    "Name":"https://schema.org/acceptsReservations",
     "Domain Bucket":"100K - 1M"
   },
   {
     "Class":"Predicate",
-    "Name":"http:\/\/schema.org\/acceptsReservations-input",
+    "Name":"https://schema.org/acceptsReservations-input",
     "Domain Bucket":"< 1K"
   },
   {
     "Class":"Predicate",
-    "Name":"http:\/\/schema.org\/acceptsReservations-output",
+    "Name":"https://schema.org/acceptsReservations-output",
     "Domain Bucket":"< 1K"
   },
   {
     "Class":"Predicate",
-    "Name":"http:\/\/schema.org\/accessCode",
+    "Name":"https://schema.org/accessCode",
     "Domain Bucket":"< 1K"
   },
   {
     "Class":"Predicate",
-    "Name":"http:\/\/schema.org\/accessCode-input",
+    "Name":"https://schema.org/accessCode-input",
     "Domain Bucket":"< 1K"
   },
   {
     "Class":"Predicate",
-    "Name":"http:\/\/schema.org\/accessCode-output",
+    "Name":"https://schema.org/accessCode-output",
     "Domain Bucket":"< 1K"
   },
   {
     "Class":"Predicate",
-    "Name":"http:\/\/schema.org\/accessMode",
+    "Name":"https://schema.org/accessMode",
     "Domain Bucket":"1K - 10K"
   },
   {
     "Class":"Predicate",
-    "Name":"http:\/\/schema.org\/accessMode-input",
+    "Name":"https://schema.org/accessMode-input",
     "Domain Bucket":"< 1K"
   },
   {
     "Class":"Predicate",
-    "Name":"http:\/\/schema.org\/accessMode-output",
+    "Name":"https://schema.org/accessMode-output",
     "Domain Bucket":"< 1K"
   },
   {
     "Class":"Predicate",
-    "Name":"http:\/\/schema.org\/accessModeSufficient",
+    "Name":"https://schema.org/accessModeSufficient",
     "Domain Bucket":"1K - 10K"
   },
   {
     "Class":"Predicate",
-    "Name":"http:\/\/schema.org\/accessModeSufficient-input",
+    "Name":"https://schema.org/accessModeSufficient-input",
     "Domain Bucket":"< 1K"
   },
   {
     "Class":"Predicate",
-    "Name":"http:\/\/schema.org\/accessModeSufficient-output",
+    "Name":"https://schema.org/accessModeSufficient-output",
     "Domain Bucket":"< 1K"
   },
   {
     "Class":"Predicate",
-    "Name":"http:\/\/schema.org\/accessibilityAPI",
+    "Name":"https://schema.org/accessibilityAPI",
     "Domain Bucket":"1K - 10K"
   },
   {
     "Class":"Predicate",
-    "Name":"http:\/\/schema.org\/accessibilityAPI-input",
+    "Name":"https://schema.org/accessibilityAPI-input",
     "Domain Bucket":"< 1K"
   },
   {
     "Class":"Predicate",
-    "Name":"http:\/\/schema.org\/accessibilityAPI-output",
+    "Name":"https://schema.org/accessibilityAPI-output",
     "Domain Bucket":"< 1K"
   },
   {
     "Class":"Predicate",
-    "Name":"http:\/\/schema.org\/accessibilityControl",
+    "Name":"https://schema.org/accessibilityControl",
     "Domain Bucket":"1K - 10K"
   },
   {
     "Class":"Predicate",
-    "Name":"http:\/\/schema.org\/accessibilityControl-input",
+    "Name":"https://schema.org/accessibilityControl-input",
     "Domain Bucket":"< 1K"
   },
   {
     "Class":"Predicate",
-    "Name":"http:\/\/schema.org\/accessibilityControl-output",
+    "Name":"https://schema.org/accessibilityControl-output",
     "Domain Bucket":"< 1K"
   },
   {
     "Class":"Predicate",
-    "Name":"http:\/\/schema.org\/accessibilityFeature",
+    "Name":"https://schema.org/accessibilityFeature",
     "Domain Bucket":"10K - 100K"
   },
   {
     "Class":"Predicate",
-    "Name":"http:\/\/schema.org\/accessibilityFeature-input",
+    "Name":"https://schema.org/accessibilityFeature-input",
     "Domain Bucket":"< 1K"
   },
   {
     "Class":"Predicate",
-    "Name":"http:\/\/schema.org\/accessibilityFeature-output",
+    "Name":"https://schema.org/accessibilityFeature-output",
     "Domain Bucket":"< 1K"
   },
   {
     "Class":"Predicate",
-    "Name":"http:\/\/schema.org\/accessibilityHazard",
+    "Name":"https://schema.org/accessibilityHazard",
     "Domain Bucket":"1K - 10K"
   },
   {
     "Class":"Predicate",
-    "Name":"http:\/\/schema.org\/accessibilityHazard-input",
+    "Name":"https://schema.org/accessibilityHazard-input",
     "Domain Bucket":"< 1K"
   },
   {
     "Class":"Predicate",
-    "Name":"http:\/\/schema.org\/accessibilityHazard-output",
+    "Name":"https://schema.org/accessibilityHazard-output",
     "Domain Bucket":"< 1K"
   },
   {
     "Class":"Predicate",
-    "Name":"http:\/\/schema.org\/accessibilitySummary",
+    "Name":"https://schema.org/accessibilitySummary",
     "Domain Bucket":"10K - 100K"
   },
   {
     "Class":"Predicate",
-    "Name":"http:\/\/schema.org\/accessibilitySummary-input",
+    "Name":"https://schema.org/accessibilitySummary-input",
     "Domain Bucket":"< 1K"
   },
   {
     "Class":"Predicate",
-    "Name":"http:\/\/schema.org\/accessibilitySummary-output",
+    "Name":"https://schema.org/accessibilitySummary-output",
     "Domain Bucket":"< 1K"
   },
   {
     "Class":"Predicate",
-    "Name":"http:\/\/schema.org\/accommodationCategory",
+    "Name":"https://schema.org/accommodationCategory",
     "Domain Bucket":"1K - 10K"
   },
   {
     "Class":"Predicate",
-    "Name":"http:\/\/schema.org\/accommodationCategory-input",
+    "Name":"https://schema.org/accommodationCategory-input",
     "Domain Bucket":"< 1K"
   },
   {
     "Class":"Predicate",
-    "Name":"http:\/\/schema.org\/accommodationCategory-output",
+    "Name":"https://schema.org/accommodationCategory-output",
     "Domain Bucket":"< 1K"
   },
   {
     "Class":"Predicate",
-    "Name":"http:\/\/schema.org\/accommodationFloorPlan",
+    "Name":"https://schema.org/accommodationFloorPlan",
     "Domain Bucket":"10K - 100K"
   },
   {
     "Class":"Predicate",
-    "Name":"http:\/\/schema.org\/accommodationFloorPlan-input",
+    "Name":"https://schema.org/accommodationFloorPlan-input",
     "Domain Bucket":"< 1K"
   },
   {
     "Class":"Predicate",
-    "Name":"http:\/\/schema.org\/accommodationFloorPlan-output",
+    "Name":"https://schema.org/accommodationFloorPlan-output",
     "Domain Bucket":"< 1K"
   },
   {
     "Class":"Predicate",
-    "Name":"http:\/\/schema.org\/accountId",
+    "Name":"https://schema.org/accountId",
     "Domain Bucket":"< 1K"
   },
   {
     "Class":"Predicate",
-    "Name":"http:\/\/schema.org\/accountId-input",
+    "Name":"https://schema.org/accountId-input",
     "Domain Bucket":"< 1K"
   },
   {
     "Class":"Predicate",
-    "Name":"http:\/\/schema.org\/accountId-output",
+    "Name":"https://schema.org/accountId-output",
     "Domain Bucket":"< 1K"
   },
   {
     "Class":"Predicate",
-    "Name":"http:\/\/schema.org\/accountMinimumInflow",
+    "Name":"https://schema.org/accountMinimumInflow",
     "Domain Bucket":"< 1K"
   },
   {
     "Class":"Predicate",
-    "Name":"http:\/\/schema.org\/accountMinimumInflow-input",
+    "Name":"https://schema.org/accountMinimumInflow-input",
     "Domain Bucket":"< 1K"
   },
   {
     "Class":"Predicate",
-    "Name":"http:\/\/schema.org\/accountMinimumInflow-output",
+    "Name":"https://schema.org/accountMinimumInflow-output",
     "Domain Bucket":"< 1K"
   },
   {
     "Class":"Predicate",
-    "Name":"http:\/\/schema.org\/accountOverdraftLimit",
+    "Name":"https://schema.org/accountOverdraftLimit",
     "Domain Bucket":"< 1K"
   },
   {
     "Class":"Predicate",
-    "Name":"http:\/\/schema.org\/accountOverdraftLimit-input",
+    "Name":"https://schema.org/accountOverdraftLimit-input",
     "Domain Bucket":"< 1K"
   },
   {
     "Class":"Predicate",
-    "Name":"http:\/\/schema.org\/accountOverdraftLimit-output",
+    "Name":"https://schema.org/accountOverdraftLimit-output",
     "Domain Bucket":"< 1K"
   },
   {
     "Class":"Predicate",
-    "Name":"http:\/\/schema.org\/accountablePerson",
+    "Name":"https://schema.org/accountablePerson",
     "Domain Bucket":"10K - 100K"
   },
   {
     "Class":"Predicate",
-    "Name":"http:\/\/schema.org\/accountablePerson-input",
+    "Name":"https://schema.org/accountablePerson-input",
     "Domain Bucket":"< 1K"
   },
   {
     "Class":"Predicate",
-    "Name":"http:\/\/schema.org\/accountablePerson-output",
+    "Name":"https://schema.org/accountablePerson-output",
     "Domain Bucket":"< 1K"
   },
   {
     "Class":"Predicate",
-    "Name":"http:\/\/schema.org\/acquireLicensePage",
+    "Name":"https://schema.org/acquireLicensePage",
     "Domain Bucket":"10K - 100K"
   },
   {
     "Class":"Predicate",
-    "Name":"http:\/\/schema.org\/acquireLicensePage-input",
+    "Name":"https://schema.org/acquireLicensePage-input",
     "Domain Bucket":"< 1K"
   },
   {
     "Class":"Predicate",
-    "Name":"http:\/\/schema.org\/acquireLicensePage-output",
+    "Name":"https://schema.org/acquireLicensePage-output",
     "Domain Bucket":"< 1K"
   },
   {
     "Class":"Predicate",
-    "Name":"http:\/\/schema.org\/acquiredFrom",
+    "Name":"https://schema.org/acquiredFrom",
     "Domain Bucket":"< 1K"
   },
   {
     "Class":"Predicate",
-    "Name":"http:\/\/schema.org\/acquiredFrom-input",
+    "Name":"https://schema.org/acquiredFrom-input",
     "Domain Bucket":"< 1K"
   },
   {
     "Class":"Predicate",
-    "Name":"http:\/\/schema.org\/acquiredFrom-output",
+    "Name":"https://schema.org/acquiredFrom-output",
     "Domain Bucket":"< 1K"
   },
   {
     "Class":"Predicate",
-    "Name":"http:\/\/schema.org\/acrissCode",
+    "Name":"https://schema.org/acrissCode",
     "Domain Bucket":"< 1K"
   },
   {
     "Class":"Predicate",
-    "Name":"http:\/\/schema.org\/acrissCode-input",
+    "Name":"https://schema.org/acrissCode-input",
     "Domain Bucket":"< 1K"
   },
   {
     "Class":"Predicate",
-    "Name":"http:\/\/schema.org\/acrissCode-output",
+    "Name":"https://schema.org/acrissCode-output",
     "Domain Bucket":"< 1K"
   },
   {
     "Class":"Predicate",
-    "Name":"http:\/\/schema.org\/actionAccessibilityRequirement",
+    "Name":"https://schema.org/actionAccessibilityRequirement",
     "Domain Bucket":"< 1K"
   },
   {
     "Class":"Predicate",
-    "Name":"http:\/\/schema.org\/actionAccessibilityRequirement-input",
+    "Name":"https://schema.org/actionAccessibilityRequirement-input",
     "Domain Bucket":"< 1K"
   },
   {
     "Class":"Predicate",
-    "Name":"http:\/\/schema.org\/actionAccessibilityRequirement-output",
+    "Name":"https://schema.org/actionAccessibilityRequirement-output",
     "Domain Bucket":"< 1K"
   },
   {
     "Class":"Predicate",
-    "Name":"http:\/\/schema.org\/actionApplication",
+    "Name":"https://schema.org/actionApplication",
     "Domain Bucket":"1K - 10K"
   },
   {
     "Class":"Predicate",
-    "Name":"http:\/\/schema.org\/actionApplication-input",
+    "Name":"https://schema.org/actionApplication-input",
     "Domain Bucket":"< 1K"
   },
   {
     "Class":"Predicate",
-    "Name":"http:\/\/schema.org\/actionApplication-output",
+    "Name":"https://schema.org/actionApplication-output",
     "Domain Bucket":"< 1K"
   },
   {
     "Class":"Predicate",
-    "Name":"http:\/\/schema.org\/actionOption",
+    "Name":"https://schema.org/actionOption",
     "Domain Bucket":"1K - 10K"
   },
   {
     "Class":"Predicate",
-    "Name":"http:\/\/schema.org\/actionOption-input",
+    "Name":"https://schema.org/actionOption-input",
     "Domain Bucket":"< 1K"
   },
   {
     "Class":"Predicate",
-    "Name":"http:\/\/schema.org\/actionOption-output",
+    "Name":"https://schema.org/actionOption-output",
     "Domain Bucket":"< 1K"
   },
   {
     "Class":"Predicate",
-    "Name":"http:\/\/schema.org\/actionPlatform",
+    "Name":"https://schema.org/actionPlatform",
     "Domain Bucket":"100K - 1M"
   },
   {
     "Class":"Predicate",
-    "Name":"http:\/\/schema.org\/actionPlatform-input",
+    "Name":"https://schema.org/actionPlatform-input",
     "Domain Bucket":"< 1K"
   },
   {
     "Class":"Predicate",
-    "Name":"http:\/\/schema.org\/actionPlatform-output",
+    "Name":"https://schema.org/actionPlatform-output",
     "Domain Bucket":"< 1K"
   },
   {
     "Class":"Predicate",
-    "Name":"http:\/\/schema.org\/actionProcess",
+    "Name":"https://schema.org/actionProcess",
     "Domain Bucket":"< 1K"
   },
   {
     "Class":"Predicate",
-    "Name":"http:\/\/schema.org\/actionProcess-input",
+    "Name":"https://schema.org/actionProcess-input",
     "Domain Bucket":"< 1K"
   },
   {
     "Class":"Predicate",
-    "Name":"http:\/\/schema.org\/actionProcess-output",
+    "Name":"https://schema.org/actionProcess-output",
     "Domain Bucket":"< 1K"
   },
   {
     "Class":"Predicate",
-    "Name":"http:\/\/schema.org\/actionStatus",
+    "Name":"https://schema.org/actionStatus",
     "Domain Bucket":"10K - 100K"
   },
   {
     "Class":"Predicate",
-    "Name":"http:\/\/schema.org\/actionStatus-input",
+    "Name":"https://schema.org/actionStatus-input",
     "Domain Bucket":"< 1K"
   },
   {
     "Class":"Predicate",
-    "Name":"http:\/\/schema.org\/actionStatus-output",
+    "Name":"https://schema.org/actionStatus-output",
     "Domain Bucket":"< 1K"
   },
   {
     "Class":"Predicate",
-    "Name":"http:\/\/schema.org\/actionableFeedbackPolicy",
+    "Name":"https://schema.org/actionableFeedbackPolicy",
     "Domain Bucket":"10K - 100K"
   },
   {
     "Class":"Predicate",
-    "Name":"http:\/\/schema.org\/actionableFeedbackPolicy-input",
+    "Name":"https://schema.org/actionableFeedbackPolicy-input",
     "Domain Bucket":"< 1K"
   },
   {
     "Class":"Predicate",
-    "Name":"http:\/\/schema.org\/actionableFeedbackPolicy-output",
+    "Name":"https://schema.org/actionableFeedbackPolicy-output",
     "Domain Bucket":"< 1K"
   },
   {
     "Class":"Predicate",
-    "Name":"http:\/\/schema.org\/activeIngredient",
+    "Name":"https://schema.org/activeIngredient",
     "Domain Bucket":"1K - 10K"
   },
   {
     "Class":"Predicate",
-    "Name":"http:\/\/schema.org\/activeIngredient-input",
+    "Name":"https://schema.org/activeIngredient-input",
     "Domain Bucket":"< 1K"
   },
   {
     "Class":"Predicate",
-    "Name":"http:\/\/schema.org\/activeIngredient-output",
+    "Name":"https://schema.org/activeIngredient-output",
     "Domain Bucket":"< 1K"
   },
   {
     "Class":"Predicate",
-    "Name":"http:\/\/schema.org\/activityDuration",
+    "Name":"https://schema.org/activityDuration",
     "Domain Bucket":"< 1K"
   },
   {
     "Class":"Predicate",
-    "Name":"http:\/\/schema.org\/activityDuration-input",
+    "Name":"https://schema.org/activityDuration-input",
     "Domain Bucket":"< 1K"
   },
   {
     "Class":"Predicate",
-    "Name":"http:\/\/schema.org\/activityDuration-output",
+    "Name":"https://schema.org/activityDuration-output",
     "Domain Bucket":"< 1K"
   },
   {
     "Class":"Predicate",
-    "Name":"http:\/\/schema.org\/activityFrequency",
+    "Name":"https://schema.org/activityFrequency",
     "Domain Bucket":"< 1K"
   },
   {
     "Class":"Predicate",
-    "Name":"http:\/\/schema.org\/activityFrequency-input",
+    "Name":"https://schema.org/activityFrequency-input",
     "Domain Bucket":"< 1K"
   },
   {
     "Class":"Predicate",
-    "Name":"http:\/\/schema.org\/activityFrequency-output",
+    "Name":"https://schema.org/activityFrequency-output",
     "Domain Bucket":"< 1K"
   },
   {
     "Class":"Predicate",
-    "Name":"http:\/\/schema.org\/actor",
+    "Name":"https://schema.org/actor",
     "Domain Bucket":"10K - 100K"
   },
   {
     "Class":"Predicate",
-    "Name":"http:\/\/schema.org\/actor-input",
+    "Name":"https://schema.org/actor-input",
     "Domain Bucket":"< 1K"
   },
   {
     "Class":"Predicate",
-    "Name":"http:\/\/schema.org\/actor-output",
+    "Name":"https://schema.org/actor-output",
     "Domain Bucket":"< 1K"
   },
   {
     "Class":"Predicate",
-    "Name":"http:\/\/schema.org\/actors",
+    "Name":"https://schema.org/actors",
     "Domain Bucket":"1K - 10K"
   },
   {
     "Class":"Predicate",
-    "Name":"http:\/\/schema.org\/actors-input",
+    "Name":"https://schema.org/actors-input",
     "Domain Bucket":"< 1K"
   },
   {
     "Class":"Predicate",
-    "Name":"http:\/\/schema.org\/actors-output",
+    "Name":"https://schema.org/actors-output",
     "Domain Bucket":"< 1K"
   },
   {
     "Class":"Predicate",
-    "Name":"http:\/\/schema.org\/addOn",
+    "Name":"https://schema.org/addOn",
     "Domain Bucket":"1K - 10K"
   },
   {
     "Class":"Predicate",
-    "Name":"http:\/\/schema.org\/addOn-input",
+    "Name":"https://schema.org/addOn-input",
     "Domain Bucket":"< 1K"
   },
   {
     "Class":"Predicate",
-    "Name":"http:\/\/schema.org\/addOn-output",
+    "Name":"https://schema.org/addOn-output",
     "Domain Bucket":"< 1K"
   },
   {
     "Class":"Predicate",
-    "Name":"http:\/\/schema.org\/additionalName",
+    "Name":"https://schema.org/additionalName",
     "Domain Bucket":"10K - 100K"
   },
   {
     "Class":"Predicate",
-    "Name":"http:\/\/schema.org\/additionalName-input",
+    "Name":"https://schema.org/additionalName-input",
     "Domain Bucket":"< 1K"
   },
   {
     "Class":"Predicate",
-    "Name":"http:\/\/schema.org\/additionalName-output",
+    "Name":"https://schema.org/additionalName-output",
     "Domain Bucket":"< 1K"
   },
   {
     "Class":"Predicate",
-    "Name":"http:\/\/schema.org\/additionalNumberOfGuests",
+    "Name":"https://schema.org/additionalNumberOfGuests",
     "Domain Bucket":"< 1K"
   },
   {
     "Class":"Predicate",
-    "Name":"http:\/\/schema.org\/additionalNumberOfGuests-input",
+    "Name":"https://schema.org/additionalNumberOfGuests-input",
     "Domain Bucket":"< 1K"
   },
   {
     "Class":"Predicate",
-    "Name":"http:\/\/schema.org\/additionalNumberOfGuests-output",
+    "Name":"https://schema.org/additionalNumberOfGuests-output",
     "Domain Bucket":"< 1K"
   },
   {
     "Class":"Predicate",
-    "Name":"http:\/\/schema.org\/additionalProperty",
+    "Name":"https://schema.org/additionalProperty",
     "Domain Bucket":"100K - 1M"
   },
   {
     "Class":"Predicate",
-    "Name":"http:\/\/schema.org\/additionalProperty-input",
+    "Name":"https://schema.org/additionalProperty-input",
     "Domain Bucket":"< 1K"
   },
   {
     "Class":"Predicate",
-    "Name":"http:\/\/schema.org\/additionalProperty-output",
+    "Name":"https://schema.org/additionalProperty-output",
     "Domain Bucket":"< 1K"
   },
   {
     "Class":"Predicate",
-    "Name":"http:\/\/schema.org\/additionalType",
+    "Name":"https://schema.org/additionalType",
     "Domain Bucket":"100K - 1M"
   },
   {
     "Class":"Predicate",
-    "Name":"http:\/\/schema.org\/additionalType-input",
+    "Name":"https://schema.org/additionalType-input",
     "Domain Bucket":"< 1K"
   },
   {
     "Class":"Predicate",
-    "Name":"http:\/\/schema.org\/additionalType-output",
+    "Name":"https://schema.org/additionalType-output",
     "Domain Bucket":"< 1K"
   },
   {
     "Class":"Predicate",
-    "Name":"http:\/\/schema.org\/additionalVariable",
+    "Name":"https://schema.org/additionalVariable",
     "Domain Bucket":"< 1K"
   },
   {
     "Class":"Predicate",
-    "Name":"http:\/\/schema.org\/additionalVariable-input",
+    "Name":"https://schema.org/additionalVariable-input",
     "Domain Bucket":"< 1K"
   },
   {
     "Class":"Predicate",
-    "Name":"http:\/\/schema.org\/additionalVariable-output",
+    "Name":"https://schema.org/additionalVariable-output",
     "Domain Bucket":"< 1K"
   },
   {
     "Class":"Predicate",
-    "Name":"http:\/\/schema.org\/address",
+    "Name":"https://schema.org/address",
     "Domain Bucket":"10M+"
   },
   {
     "Class":"Predicate",
-    "Name":"http:\/\/schema.org\/address-input",
+    "Name":"https://schema.org/address-input",
     "Domain Bucket":"< 1K"
   },
   {
     "Class":"Predicate",
-    "Name":"http:\/\/schema.org\/address-output",
+    "Name":"https://schema.org/address-output",
     "Domain Bucket":"< 1K"
   },
   {
     "Class":"Predicate",
-    "Name":"http:\/\/schema.org\/addressCountry",
+    "Name":"https://schema.org/addressCountry",
     "Domain Bucket":"1M - 10M"
   },
   {
     "Class":"Predicate",
-    "Name":"http:\/\/schema.org\/addressCountry-input",
+    "Name":"https://schema.org/addressCountry-input",
     "Domain Bucket":"< 1K"
   },
   {
     "Class":"Predicate",
-    "Name":"http:\/\/schema.org\/addressCountry-output",
+    "Name":"https://schema.org/addressCountry-output",
     "Domain Bucket":"< 1K"
   },
   {
     "Class":"Predicate",
-    "Name":"http:\/\/schema.org\/addressLocality",
+    "Name":"https://schema.org/addressLocality",
     "Domain Bucket":"1M - 10M"
   },
   {
     "Class":"Predicate",
-    "Name":"http:\/\/schema.org\/addressLocality-input",
+    "Name":"https://schema.org/addressLocality-input",
     "Domain Bucket":"< 1K"
   },
   {
     "Class":"Predicate",
-    "Name":"http:\/\/schema.org\/addressLocality-output",
+    "Name":"https://schema.org/addressLocality-output",
     "Domain Bucket":"< 1K"
   },
   {
     "Class":"Predicate",
-    "Name":"http:\/\/schema.org\/addressRegion",
+    "Name":"https://schema.org/addressRegion",
     "Domain Bucket":"1M - 10M"
   },
   {
     "Class":"Predicate",
-    "Name":"http:\/\/schema.org\/addressRegion-input",
+    "Name":"https://schema.org/addressRegion-input",
     "Domain Bucket":"< 1K"
   },
   {
     "Class":"Predicate",
-    "Name":"http:\/\/schema.org\/addressRegion-output",
+    "Name":"https://schema.org/addressRegion-output",
     "Domain Bucket":"< 1K"
   },
   {
     "Class":"Predicate",
-    "Name":"http:\/\/schema.org\/administrationRoute",
+    "Name":"https://schema.org/administrationRoute",
     "Domain Bucket":"1K - 10K"
   },
   {
     "Class":"Predicate",
-    "Name":"http:\/\/schema.org\/administrationRoute-input",
+    "Name":"https://schema.org/administrationRoute-input",
     "Domain Bucket":"< 1K"
   },
   {
     "Class":"Predicate",
-    "Name":"http:\/\/schema.org\/administrationRoute-output",
+    "Name":"https://schema.org/administrationRoute-output",
     "Domain Bucket":"< 1K"
   },
   {
     "Class":"Predicate",
-    "Name":"http:\/\/schema.org\/advanceBookingRequirement",
+    "Name":"https://schema.org/advanceBookingRequirement",
     "Domain Bucket":"< 1K"
   },
   {
     "Class":"Predicate",
-    "Name":"http:\/\/schema.org\/advanceBookingRequirement-input",
+    "Name":"https://schema.org/advanceBookingRequirement-input",
     "Domain Bucket":"< 1K"
   },
   {
     "Class":"Predicate",
-    "Name":"http:\/\/schema.org\/advanceBookingRequirement-output",
+    "Name":"https://schema.org/advanceBookingRequirement-output",
     "Domain Bucket":"< 1K"
   },
   {
     "Class":"Predicate",
-    "Name":"http:\/\/schema.org\/adverseOutcome",
+    "Name":"https://schema.org/adverseOutcome",
     "Domain Bucket":"< 1K"
   },
   {
     "Class":"Predicate",
-    "Name":"http:\/\/schema.org\/adverseOutcome-input",
+    "Name":"https://schema.org/adverseOutcome-input",
     "Domain Bucket":"< 1K"
   },
   {
     "Class":"Predicate",
-    "Name":"http:\/\/schema.org\/adverseOutcome-output",
+    "Name":"https://schema.org/adverseOutcome-output",
     "Domain Bucket":"< 1K"
   },
   {
     "Class":"Predicate",
-    "Name":"http:\/\/schema.org\/affectedBy",
+    "Name":"https://schema.org/affectedBy",
     "Domain Bucket":"< 1K"
   },
   {
     "Class":"Predicate",
-    "Name":"http:\/\/schema.org\/affectedBy-input",
+    "Name":"https://schema.org/affectedBy-input",
     "Domain Bucket":"< 1K"
   },
   {
     "Class":"Predicate",
-    "Name":"http:\/\/schema.org\/affectedBy-output",
+    "Name":"https://schema.org/affectedBy-output",
     "Domain Bucket":"< 1K"
   },
   {
     "Class":"Predicate",
-    "Name":"http:\/\/schema.org\/affiliation",
+    "Name":"https://schema.org/affiliation",
     "Domain Bucket":"100K - 1M"
   },
   {
     "Class":"Predicate",
-    "Name":"http:\/\/schema.org\/affiliation-input",
+    "Name":"https://schema.org/affiliation-input",
     "Domain Bucket":"< 1K"
   },
   {
     "Class":"Predicate",
-    "Name":"http:\/\/schema.org\/affiliation-output",
+    "Name":"https://schema.org/affiliation-output",
     "Domain Bucket":"< 1K"
   },
   {
     "Class":"Predicate",
-    "Name":"http:\/\/schema.org\/afterMedia",
+    "Name":"https://schema.org/afterMedia",
     "Domain Bucket":"< 1K"
   },
   {
     "Class":"Predicate",
-    "Name":"http:\/\/schema.org\/afterMedia-input",
+    "Name":"https://schema.org/afterMedia-input",
     "Domain Bucket":"< 1K"
   },
   {
     "Class":"Predicate",
-    "Name":"http:\/\/schema.org\/afterMedia-output",
+    "Name":"https://schema.org/afterMedia-output",
     "Domain Bucket":"< 1K"
   },
   {
     "Class":"Predicate",
-    "Name":"http:\/\/schema.org\/agent",
+    "Name":"https://schema.org/agent",
     "Domain Bucket":"10K - 100K"
   },
   {
     "Class":"Predicate",
-    "Name":"http:\/\/schema.org\/agent-input",
+    "Name":"https://schema.org/agent-input",
     "Domain Bucket":"< 1K"
   },
   {
     "Class":"Predicate",
-    "Name":"http:\/\/schema.org\/agent-output",
+    "Name":"https://schema.org/agent-output",
     "Domain Bucket":"< 1K"
   },
   {
     "Class":"Predicate",
-    "Name":"http:\/\/schema.org\/agentInteractionStatistic",
+    "Name":"https://schema.org/agentInteractionStatistic",
     "Domain Bucket":"10K - 100K"
   },
   {
     "Class":"Predicate",
-    "Name":"http:\/\/schema.org\/agentInteractionStatistic-input",
+    "Name":"https://schema.org/agentInteractionStatistic-input",
     "Domain Bucket":"< 1K"
   },
   {
     "Class":"Predicate",
-    "Name":"http:\/\/schema.org\/agentInteractionStatistic-output",
+    "Name":"https://schema.org/agentInteractionStatistic-output",
     "Domain Bucket":"< 1K"
   },
   {
     "Class":"Predicate",
-    "Name":"http:\/\/schema.org\/aggregateElement",
+    "Name":"https://schema.org/aggregateElement",
     "Domain Bucket":"< 1K"
   },
   {
     "Class":"Predicate",
-    "Name":"http:\/\/schema.org\/aggregateElement-input",
+    "Name":"https://schema.org/aggregateElement-input",
     "Domain Bucket":"< 1K"
   },
   {
     "Class":"Predicate",
-    "Name":"http:\/\/schema.org\/aggregateElement-output",
+    "Name":"https://schema.org/aggregateElement-output",
     "Domain Bucket":"< 1K"
   },
   {
     "Class":"Predicate",
-    "Name":"http:\/\/schema.org\/aggregateRating",
+    "Name":"https://schema.org/aggregateRating",
     "Domain Bucket":"1M - 10M"
   },
   {
     "Class":"Predicate",
-    "Name":"http:\/\/schema.org\/aggregateRating-input",
+    "Name":"https://schema.org/aggregateRating-input",
     "Domain Bucket":"< 1K"
   },
   {
     "Class":"Predicate",
-    "Name":"http:\/\/schema.org\/aggregateRating-output",
+    "Name":"https://schema.org/aggregateRating-output",
     "Domain Bucket":"< 1K"
   },
   {
     "Class":"Predicate",
-    "Name":"http:\/\/schema.org\/aircraft",
+    "Name":"https://schema.org/aircraft",
     "Domain Bucket":"< 1K"
   },
   {
     "Class":"Predicate",
-    "Name":"http:\/\/schema.org\/aircraft-input",
+    "Name":"https://schema.org/aircraft-input",
     "Domain Bucket":"< 1K"
   },
   {
     "Class":"Predicate",
-    "Name":"http:\/\/schema.org\/aircraft-output",
+    "Name":"https://schema.org/aircraft-output",
     "Domain Bucket":"< 1K"
   },
   {
     "Class":"Predicate",
-    "Name":"http:\/\/schema.org\/album",
+    "Name":"https://schema.org/album",
     "Domain Bucket":"1K - 10K"
   },
   {
     "Class":"Predicate",
-    "Name":"http:\/\/schema.org\/album-input",
+    "Name":"https://schema.org/album-input",
     "Domain Bucket":"< 1K"
   },
   {
     "Class":"Predicate",
-    "Name":"http:\/\/schema.org\/album-output",
+    "Name":"https://schema.org/album-output",
     "Domain Bucket":"< 1K"
   },
   {
     "Class":"Predicate",
-    "Name":"http:\/\/schema.org\/albumProductionType",
+    "Name":"https://schema.org/albumProductionType",
     "Domain Bucket":"1K - 10K"
   },
   {
     "Class":"Predicate",
-    "Name":"http:\/\/schema.org\/albumProductionType-input",
+    "Name":"https://schema.org/albumProductionType-input",
     "Domain Bucket":"< 1K"
   },
   {
     "Class":"Predicate",
-    "Name":"http:\/\/schema.org\/albumProductionType-output",
+    "Name":"https://schema.org/albumProductionType-output",
     "Domain Bucket":"< 1K"
   },
   {
     "Class":"Predicate",
-    "Name":"http:\/\/schema.org\/albumRelease",
+    "Name":"https://schema.org/albumRelease",
     "Domain Bucket":"1K - 10K"
   },
   {
     "Class":"Predicate",
-    "Name":"http:\/\/schema.org\/albumRelease-input",
+    "Name":"https://schema.org/albumRelease-input",
     "Domain Bucket":"< 1K"
   },
   {
     "Class":"Predicate",
-    "Name":"http:\/\/schema.org\/albumRelease-output",
+    "Name":"https://schema.org/albumRelease-output",
     "Domain Bucket":"< 1K"
   },
   {
     "Class":"Predicate",
-    "Name":"http:\/\/schema.org\/albumReleaseType",
+    "Name":"https://schema.org/albumReleaseType",
     "Domain Bucket":"1K - 10K"
   },
   {
     "Class":"Predicate",
-    "Name":"http:\/\/schema.org\/albumReleaseType-input",
+    "Name":"https://schema.org/albumReleaseType-input",
     "Domain Bucket":"< 1K"
   },
   {
     "Class":"Predicate",
-    "Name":"http:\/\/schema.org\/albumReleaseType-output",
+    "Name":"https://schema.org/albumReleaseType-output",
     "Domain Bucket":"< 1K"
   },
   {
     "Class":"Predicate",
-    "Name":"http:\/\/schema.org\/albums",
+    "Name":"https://schema.org/albums",
     "Domain Bucket":"< 1K"
   },
   {
     "Class":"Predicate",
-    "Name":"http:\/\/schema.org\/albums-input",
+    "Name":"https://schema.org/albums-input",
     "Domain Bucket":"< 1K"
   },
   {
     "Class":"Predicate",
-    "Name":"http:\/\/schema.org\/albums-output",
+    "Name":"https://schema.org/albums-output",
     "Domain Bucket":"< 1K"
   },
   {
     "Class":"Predicate",
-    "Name":"http:\/\/schema.org\/alcoholWarning",
+    "Name":"https://schema.org/alcoholWarning",
     "Domain Bucket":"< 1K"
   },
   {
     "Class":"Predicate",
-    "Name":"http:\/\/schema.org\/alcoholWarning-input",
+    "Name":"https://schema.org/alcoholWarning-input",
     "Domain Bucket":"< 1K"
   },
   {
     "Class":"Predicate",
-    "Name":"http:\/\/schema.org\/alcoholWarning-output",
+    "Name":"https://schema.org/alcoholWarning-output",
     "Domain Bucket":"< 1K"
   },
   {
     "Class":"Predicate",
-    "Name":"http:\/\/schema.org\/algorithm",
+    "Name":"https://schema.org/algorithm",
     "Domain Bucket":"< 1K"
   },
   {
     "Class":"Predicate",
-    "Name":"http:\/\/schema.org\/algorithm-input",
+    "Name":"https://schema.org/algorithm-input",
     "Domain Bucket":"< 1K"
   },
   {
     "Class":"Predicate",
-    "Name":"http:\/\/schema.org\/algorithm-output",
+    "Name":"https://schema.org/algorithm-output",
     "Domain Bucket":"< 1K"
   },
   {
     "Class":"Predicate",
-    "Name":"http:\/\/schema.org\/alignmentType",
+    "Name":"https://schema.org/alignmentType",
     "Domain Bucket":"1K - 10K"
   },
   {
     "Class":"Predicate",
-    "Name":"http:\/\/schema.org\/alignmentType-input",
+    "Name":"https://schema.org/alignmentType-input",
     "Domain Bucket":"< 1K"
   },
   {
     "Class":"Predicate",
-    "Name":"http:\/\/schema.org\/alignmentType-output",
+    "Name":"https://schema.org/alignmentType-output",
     "Domain Bucket":"< 1K"
   },
   {
     "Class":"Predicate",
-    "Name":"http:\/\/schema.org\/alternateName",
+    "Name":"https://schema.org/alternateName",
     "Domain Bucket":"1M - 10M"
   },
   {
     "Class":"Predicate",
-    "Name":"http:\/\/schema.org\/alternateName-input",
+    "Name":"https://schema.org/alternateName-input",
     "Domain Bucket":"< 1K"
   },
   {
     "Class":"Predicate",
-    "Name":"http:\/\/schema.org\/alternateName-output",
+    "Name":"https://schema.org/alternateName-output",
     "Domain Bucket":"< 1K"
   },
   {
     "Class":"Predicate",
-    "Name":"http:\/\/schema.org\/alternativeHeadline",
+    "Name":"https://schema.org/alternativeHeadline",
     "Domain Bucket":"100K - 1M"
   },
   {
     "Class":"Predicate",
-    "Name":"http:\/\/schema.org\/alternativeHeadline-input",
+    "Name":"https://schema.org/alternativeHeadline-input",
     "Domain Bucket":"< 1K"
   },
   {
     "Class":"Predicate",
-    "Name":"http:\/\/schema.org\/alternativeHeadline-output",
+    "Name":"https://schema.org/alternativeHeadline-output",
     "Domain Bucket":"< 1K"
   },
   {
     "Class":"Predicate",
-    "Name":"http:\/\/schema.org\/alternativeOf",
+    "Name":"https://schema.org/alternativeOf",
     "Domain Bucket":"< 1K"
   },
   {
     "Class":"Predicate",
-    "Name":"http:\/\/schema.org\/alternativeOf-input",
+    "Name":"https://schema.org/alternativeOf-input",
     "Domain Bucket":"< 1K"
   },
   {
     "Class":"Predicate",
-    "Name":"http:\/\/schema.org\/alternativeOf-output",
+    "Name":"https://schema.org/alternativeOf-output",
     "Domain Bucket":"< 1K"
   },
   {
     "Class":"Predicate",
-    "Name":"http:\/\/schema.org\/alumni",
+    "Name":"https://schema.org/alumni",
     "Domain Bucket":"1K - 10K"
   },
   {
     "Class":"Predicate",
-    "Name":"http:\/\/schema.org\/alumni-input",
+    "Name":"https://schema.org/alumni-input",
     "Domain Bucket":"< 1K"
   },
   {
     "Class":"Predicate",
-    "Name":"http:\/\/schema.org\/alumni-output",
+    "Name":"https://schema.org/alumni-output",
     "Domain Bucket":"< 1K"
   },
   {
     "Class":"Predicate",
-    "Name":"http:\/\/schema.org\/alumniOf",
+    "Name":"https://schema.org/alumniOf",
     "Domain Bucket":"100K - 1M"
   },
   {
     "Class":"Predicate",
-    "Name":"http:\/\/schema.org\/alumniOf-input",
+    "Name":"https://schema.org/alumniOf-input",
     "Domain Bucket":"< 1K"
   },
   {
     "Class":"Predicate",
-    "Name":"http:\/\/schema.org\/alumniOf-output",
+    "Name":"https://schema.org/alumniOf-output",
     "Domain Bucket":"< 1K"
   },
   {
     "Class":"Predicate",
-    "Name":"http:\/\/schema.org\/amenityFeature",
+    "Name":"https://schema.org/amenityFeature",
     "Domain Bucket":"100K - 1M"
   },
   {
     "Class":"Predicate",
-    "Name":"http:\/\/schema.org\/amenityFeature-input",
+    "Name":"https://schema.org/amenityFeature-input",
     "Domain Bucket":"< 1K"
   },
   {
     "Class":"Predicate",
-    "Name":"http:\/\/schema.org\/amenityFeature-output",
+    "Name":"https://schema.org/amenityFeature-output",
     "Domain Bucket":"< 1K"
   },
   {
     "Class":"Predicate",
-    "Name":"http:\/\/schema.org\/amount",
+    "Name":"https://schema.org/amount",
     "Domain Bucket":"1K - 10K"
   },
   {
     "Class":"Predicate",
-    "Name":"http:\/\/schema.org\/amount-input",
+    "Name":"https://schema.org/amount-input",
     "Domain Bucket":"< 1K"
   },
   {
     "Class":"Predicate",
-    "Name":"http:\/\/schema.org\/amount-output",
+    "Name":"https://schema.org/amount-output",
     "Domain Bucket":"< 1K"
   },
   {
     "Class":"Predicate",
-    "Name":"http:\/\/schema.org\/amountOfThisGood",
+    "Name":"https://schema.org/amountOfThisGood",
     "Domain Bucket":"< 1K"
   },
   {
     "Class":"Predicate",
-    "Name":"http:\/\/schema.org\/amountOfThisGood-input",
+    "Name":"https://schema.org/amountOfThisGood-input",
     "Domain Bucket":"< 1K"
   },
   {
     "Class":"Predicate",
-    "Name":"http:\/\/schema.org\/amountOfThisGood-output",
+    "Name":"https://schema.org/amountOfThisGood-output",
     "Domain Bucket":"< 1K"
   },
   {
     "Class":"Predicate",
-    "Name":"http:\/\/schema.org\/announcementLocation",
+    "Name":"https://schema.org/announcementLocation",
     "Domain Bucket":"1K - 10K"
   },
   {
     "Class":"Predicate",
-    "Name":"http:\/\/schema.org\/announcementLocation-input",
+    "Name":"https://schema.org/announcementLocation-input",
     "Domain Bucket":"< 1K"
   },
   {
     "Class":"Predicate",
-    "Name":"http:\/\/schema.org\/announcementLocation-output",
+    "Name":"https://schema.org/announcementLocation-output",
     "Domain Bucket":"< 1K"
   },
   {
     "Class":"Predicate",
-    "Name":"http:\/\/schema.org\/annualPercentageRate",
+    "Name":"https://schema.org/annualPercentageRate",
     "Domain Bucket":"1K - 10K"
   },
   {
     "Class":"Predicate",
-    "Name":"http:\/\/schema.org\/annualPercentageRate-input",
+    "Name":"https://schema.org/annualPercentageRate-input",
     "Domain Bucket":"< 1K"
   },
   {
     "Class":"Predicate",
-    "Name":"http:\/\/schema.org\/annualPercentageRate-output",
+    "Name":"https://schema.org/annualPercentageRate-output",
     "Domain Bucket":"< 1K"
   },
   {
     "Class":"Predicate",
-    "Name":"http:\/\/schema.org\/answerCount",
+    "Name":"https://schema.org/answerCount",
     "Domain Bucket":"100K - 1M"
   },
   {
     "Class":"Predicate",
-    "Name":"http:\/\/schema.org\/answerCount-input",
+    "Name":"https://schema.org/answerCount-input",
     "Domain Bucket":"< 1K"
   },
   {
     "Class":"Predicate",
-    "Name":"http:\/\/schema.org\/answerCount-output",
+    "Name":"https://schema.org/answerCount-output",
     "Domain Bucket":"< 1K"
   },
   {
     "Class":"Predicate",
-    "Name":"http:\/\/schema.org\/answerExplanation",
+    "Name":"https://schema.org/answerExplanation",
     "Domain Bucket":"< 1K"
   },
   {
     "Class":"Predicate",
-    "Name":"http:\/\/schema.org\/answerExplanation-input",
+    "Name":"https://schema.org/answerExplanation-input",
     "Domain Bucket":"< 1K"
   },
   {
     "Class":"Predicate",
-    "Name":"http:\/\/schema.org\/answerExplanation-output",
+    "Name":"https://schema.org/answerExplanation-output",
     "Domain Bucket":"< 1K"
   },
   {
     "Class":"Predicate",
-    "Name":"http:\/\/schema.org\/antagonist",
+    "Name":"https://schema.org/antagonist",
     "Domain Bucket":"< 1K"
   },
   {
     "Class":"Predicate",
-    "Name":"http:\/\/schema.org\/antagonist-input",
+    "Name":"https://schema.org/antagonist-input",
     "Domain Bucket":"< 1K"
   },
   {
     "Class":"Predicate",
-    "Name":"http:\/\/schema.org\/antagonist-output",
+    "Name":"https://schema.org/antagonist-output",
     "Domain Bucket":"< 1K"
   },
   {
     "Class":"Predicate",
-    "Name":"http:\/\/schema.org\/appearance",
+    "Name":"https://schema.org/appearance",
     "Domain Bucket":"1K - 10K"
   },
   {
     "Class":"Predicate",
-    "Name":"http:\/\/schema.org\/appearance-input",
+    "Name":"https://schema.org/appearance-input",
     "Domain Bucket":"< 1K"
   },
   {
     "Class":"Predicate",
-    "Name":"http:\/\/schema.org\/appearance-output",
+    "Name":"https://schema.org/appearance-output",
     "Domain Bucket":"< 1K"
   },
   {
     "Class":"Predicate",
-    "Name":"http:\/\/schema.org\/applicableCountry",
+    "Name":"https://schema.org/applicableCountry",
     "Domain Bucket":"100K - 1M"
   },
   {
     "Class":"Predicate",
-    "Name":"http:\/\/schema.org\/applicableCountry-input",
+    "Name":"https://schema.org/applicableCountry-input",
     "Domain Bucket":"< 1K"
   },
   {
     "Class":"Predicate",
-    "Name":"http:\/\/schema.org\/applicableCountry-output",
+    "Name":"https://schema.org/applicableCountry-output",
     "Domain Bucket":"< 1K"
   },
   {
     "Class":"Predicate",
-    "Name":"http:\/\/schema.org\/applicableLocation",
+    "Name":"https://schema.org/applicableLocation",
     "Domain Bucket":"< 1K"
   },
   {
     "Class":"Predicate",
-    "Name":"http:\/\/schema.org\/applicableLocation-input",
+    "Name":"https://schema.org/applicableLocation-input",
     "Domain Bucket":"< 1K"
   },
   {
     "Class":"Predicate",
-    "Name":"http:\/\/schema.org\/applicableLocation-output",
+    "Name":"https://schema.org/applicableLocation-output",
     "Domain Bucket":"< 1K"
   },
   {
     "Class":"Predicate",
-    "Name":"http:\/\/schema.org\/applicantLocationRequirements",
+    "Name":"https://schema.org/applicantLocationRequirements",
     "Domain Bucket":"10K - 100K"
   },
   {
     "Class":"Predicate",
-    "Name":"http:\/\/schema.org\/applicantLocationRequirements-input",
+    "Name":"https://schema.org/applicantLocationRequirements-input",
     "Domain Bucket":"< 1K"
   },
   {
     "Class":"Predicate",
-    "Name":"http:\/\/schema.org\/applicantLocationRequirements-output",
+    "Name":"https://schema.org/applicantLocationRequirements-output",
     "Domain Bucket":"< 1K"
   },
   {
     "Class":"Predicate",
-    "Name":"http:\/\/schema.org\/application",
+    "Name":"https://schema.org/application",
     "Domain Bucket":"< 1K"
   },
   {
     "Class":"Predicate",
-    "Name":"http:\/\/schema.org\/application-input",
+    "Name":"https://schema.org/application-input",
     "Domain Bucket":"< 1K"
   },
   {
     "Class":"Predicate",
-    "Name":"http:\/\/schema.org\/application-output",
+    "Name":"https://schema.org/application-output",
     "Domain Bucket":"< 1K"
   },
   {
     "Class":"Predicate",
-    "Name":"http:\/\/schema.org\/applicationCategory",
+    "Name":"https://schema.org/applicationCategory",
     "Domain Bucket":"1M - 10M"
   },
   {
     "Class":"Predicate",
-    "Name":"http:\/\/schema.org\/applicationCategory-input",
+    "Name":"https://schema.org/applicationCategory-input",
     "Domain Bucket":"< 1K"
   },
   {
     "Class":"Predicate",
-    "Name":"http:\/\/schema.org\/applicationCategory-output",
+    "Name":"https://schema.org/applicationCategory-output",
     "Domain Bucket":"< 1K"
   },
   {
     "Class":"Predicate",
-    "Name":"http:\/\/schema.org\/applicationContact",
+    "Name":"https://schema.org/applicationContact",
     "Domain Bucket":"1K - 10K"
   },
   {
     "Class":"Predicate",
-    "Name":"http:\/\/schema.org\/applicationContact-input",
+    "Name":"https://schema.org/applicationContact-input",
     "Domain Bucket":"< 1K"
   },
   {
     "Class":"Predicate",
-    "Name":"http:\/\/schema.org\/applicationContact-output",
+    "Name":"https://schema.org/applicationContact-output",
     "Domain Bucket":"< 1K"
   },
   {
     "Class":"Predicate",
-    "Name":"http:\/\/schema.org\/applicationDeadline",
+    "Name":"https://schema.org/applicationDeadline",
     "Domain Bucket":"1K - 10K"
   },
   {
     "Class":"Predicate",
-    "Name":"http:\/\/schema.org\/applicationDeadline-input",
+    "Name":"https://schema.org/applicationDeadline-input",
     "Domain Bucket":"< 1K"
   },
   {
     "Class":"Predicate",
-    "Name":"http:\/\/schema.org\/applicationDeadline-output",
+    "Name":"https://schema.org/applicationDeadline-output",
     "Domain Bucket":"< 1K"
   },
   {
     "Class":"Predicate",
-    "Name":"http:\/\/schema.org\/applicationStartDate",
+    "Name":"https://schema.org/applicationStartDate",
     "Domain Bucket":"< 1K"
   },
   {
     "Class":"Predicate",
-    "Name":"http:\/\/schema.org\/applicationStartDate-input",
+    "Name":"https://schema.org/applicationStartDate-input",
     "Domain Bucket":"< 1K"
   },
   {
     "Class":"Predicate",
-    "Name":"http:\/\/schema.org\/applicationStartDate-output",
+    "Name":"https://schema.org/applicationStartDate-output",
     "Domain Bucket":"< 1K"
   },
   {
     "Class":"Predicate",
-    "Name":"http:\/\/schema.org\/applicationSubCategory",
+    "Name":"https://schema.org/applicationSubCategory",
     "Domain Bucket":"10K - 100K"
   },
   {
     "Class":"Predicate",
-    "Name":"http:\/\/schema.org\/applicationSubCategory-input",
+    "Name":"https://schema.org/applicationSubCategory-input",
     "Domain Bucket":"< 1K"
   },
   {
     "Class":"Predicate",
-    "Name":"http:\/\/schema.org\/applicationSubCategory-output",
+    "Name":"https://schema.org/applicationSubCategory-output",
     "Domain Bucket":"< 1K"
   },
   {
     "Class":"Predicate",
-    "Name":"http:\/\/schema.org\/applicationSuite",
+    "Name":"https://schema.org/applicationSuite",
     "Domain Bucket":"1K - 10K"
   },
   {
     "Class":"Predicate",
-    "Name":"http:\/\/schema.org\/applicationSuite-input",
+    "Name":"https://schema.org/applicationSuite-input",
     "Domain Bucket":"< 1K"
   },
   {
     "Class":"Predicate",
-    "Name":"http:\/\/schema.org\/applicationSuite-output",
+    "Name":"https://schema.org/applicationSuite-output",
     "Domain Bucket":"< 1K"
   },
   {
     "Class":"Predicate",
-    "Name":"http:\/\/schema.org\/appliesToDeliveryMethod",
+    "Name":"https://schema.org/appliesToDeliveryMethod",
     "Domain Bucket":"10K - 100K"
   },
   {
     "Class":"Predicate",
-    "Name":"http:\/\/schema.org\/appliesToDeliveryMethod-input",
+    "Name":"https://schema.org/appliesToDeliveryMethod-input",
     "Domain Bucket":"< 1K"
   },
   {
     "Class":"Predicate",
-    "Name":"http:\/\/schema.org\/appliesToDeliveryMethod-output",
+    "Name":"https://schema.org/appliesToDeliveryMethod-output",
     "Domain Bucket":"< 1K"
   },
   {
     "Class":"Predicate",
-    "Name":"http:\/\/schema.org\/appliesToPaymentMethod",
+    "Name":"https://schema.org/appliesToPaymentMethod",
     "Domain Bucket":"< 1K"
   },
   {
     "Class":"Predicate",
-    "Name":"http:\/\/schema.org\/appliesToPaymentMethod-input",
+    "Name":"https://schema.org/appliesToPaymentMethod-input",
     "Domain Bucket":"< 1K"
   },
   {
     "Class":"Predicate",
-    "Name":"http:\/\/schema.org\/appliesToPaymentMethod-output",
+    "Name":"https://schema.org/appliesToPaymentMethod-output",
     "Domain Bucket":"< 1K"
   },
   {
     "Class":"Predicate",
-    "Name":"http:\/\/schema.org\/archiveHeld",
+    "Name":"https://schema.org/archiveHeld",
     "Domain Bucket":"< 1K"
   },
   {
     "Class":"Predicate",
-    "Name":"http:\/\/schema.org\/archiveHeld-input",
+    "Name":"https://schema.org/archiveHeld-input",
     "Domain Bucket":"< 1K"
   },
   {
     "Class":"Predicate",
-    "Name":"http:\/\/schema.org\/archiveHeld-output",
+    "Name":"https://schema.org/archiveHeld-output",
     "Domain Bucket":"< 1K"
   },
   {
     "Class":"Predicate",
-    "Name":"http:\/\/schema.org\/archivedAt",
+    "Name":"https://schema.org/archivedAt",
     "Domain Bucket":"< 1K"
   },
   {
     "Class":"Predicate",
-    "Name":"http:\/\/schema.org\/archivedAt-input",
+    "Name":"https://schema.org/archivedAt-input",
     "Domain Bucket":"< 1K"
   },
   {
     "Class":"Predicate",
-    "Name":"http:\/\/schema.org\/archivedAt-output",
+    "Name":"https://schema.org/archivedAt-output",
     "Domain Bucket":"< 1K"
   },
   {
     "Class":"Predicate",
-    "Name":"http:\/\/schema.org\/area",
+    "Name":"https://schema.org/area",
     "Domain Bucket":"1K - 10K"
   },
   {
     "Class":"Predicate",
-    "Name":"http:\/\/schema.org\/area-input",
+    "Name":"https://schema.org/area-input",
     "Domain Bucket":"< 1K"
   },
   {
     "Class":"Predicate",
-    "Name":"http:\/\/schema.org\/area-output",
+    "Name":"https://schema.org/area-output",
     "Domain Bucket":"< 1K"
   },
   {
     "Class":"Predicate",
-    "Name":"http:\/\/schema.org\/areaServed",
+    "Name":"https://schema.org/areaServed",
     "Domain Bucket":"1M - 10M"
   },
   {
     "Class":"Predicate",
-    "Name":"http:\/\/schema.org\/areaServed-input",
+    "Name":"https://schema.org/areaServed-input",
     "Domain Bucket":"< 1K"
   },
   {
     "Class":"Predicate",
-    "Name":"http:\/\/schema.org\/areaServed-output",
+    "Name":"https://schema.org/areaServed-output",
     "Domain Bucket":"< 1K"
   },
   {
     "Class":"Predicate",
-    "Name":"http:\/\/schema.org\/arrivalAirport",
+    "Name":"https://schema.org/arrivalAirport",
     "Domain Bucket":"1K - 10K"
   },
   {
     "Class":"Predicate",
-    "Name":"http:\/\/schema.org\/arrivalAirport-input",
+    "Name":"https://schema.org/arrivalAirport-input",
     "Domain Bucket":"< 1K"
   },
   {
     "Class":"Predicate",
-    "Name":"http:\/\/schema.org\/arrivalAirport-output",
+    "Name":"https://schema.org/arrivalAirport-output",
     "Domain Bucket":"< 1K"
   },
   {
     "Class":"Predicate",
-    "Name":"http:\/\/schema.org\/arrivalBoatTerminal",
+    "Name":"https://schema.org/arrivalBoatTerminal",
     "Domain Bucket":"< 1K"
   },
   {
     "Class":"Predicate",
-    "Name":"http:\/\/schema.org\/arrivalBoatTerminal-input",
+    "Name":"https://schema.org/arrivalBoatTerminal-input",
     "Domain Bucket":"< 1K"
   },
   {
     "Class":"Predicate",
-    "Name":"http:\/\/schema.org\/arrivalBoatTerminal-output",
+    "Name":"https://schema.org/arrivalBoatTerminal-output",
     "Domain Bucket":"< 1K"
   },
   {
     "Class":"Predicate",
-    "Name":"http:\/\/schema.org\/arrivalBusStop",
+    "Name":"https://schema.org/arrivalBusStop",
     "Domain Bucket":"< 1K"
   },
   {
     "Class":"Predicate",
-    "Name":"http:\/\/schema.org\/arrivalBusStop-input",
+    "Name":"https://schema.org/arrivalBusStop-input",
     "Domain Bucket":"< 1K"
   },
   {
     "Class":"Predicate",
-    "Name":"http:\/\/schema.org\/arrivalBusStop-output",
+    "Name":"https://schema.org/arrivalBusStop-output",
     "Domain Bucket":"< 1K"
   },
   {
     "Class":"Predicate",
-    "Name":"http:\/\/schema.org\/arrivalGate",
+    "Name":"https://schema.org/arrivalGate",
     "Domain Bucket":"< 1K"
   },
   {
     "Class":"Predicate",
-    "Name":"http:\/\/schema.org\/arrivalGate-input",
+    "Name":"https://schema.org/arrivalGate-input",
     "Domain Bucket":"< 1K"
   },
   {
     "Class":"Predicate",
-    "Name":"http:\/\/schema.org\/arrivalGate-output",
+    "Name":"https://schema.org/arrivalGate-output",
     "Domain Bucket":"< 1K"
   },
   {
     "Class":"Predicate",
-    "Name":"http:\/\/schema.org\/arrivalPlatform",
+    "Name":"https://schema.org/arrivalPlatform",
     "Domain Bucket":"< 1K"
   },
   {
     "Class":"Predicate",
-    "Name":"http:\/\/schema.org\/arrivalPlatform-input",
+    "Name":"https://schema.org/arrivalPlatform-input",
     "Domain Bucket":"< 1K"
   },
   {
     "Class":"Predicate",
-    "Name":"http:\/\/schema.org\/arrivalPlatform-output",
+    "Name":"https://schema.org/arrivalPlatform-output",
     "Domain Bucket":"< 1K"
   },
   {
     "Class":"Predicate",
-    "Name":"http:\/\/schema.org\/arrivalStation",
+    "Name":"https://schema.org/arrivalStation",
     "Domain Bucket":"< 1K"
   },
   {
     "Class":"Predicate",
-    "Name":"http:\/\/schema.org\/arrivalStation-input",
+    "Name":"https://schema.org/arrivalStation-input",
     "Domain Bucket":"< 1K"
   },
   {
     "Class":"Predicate",
-    "Name":"http:\/\/schema.org\/arrivalStation-output",
+    "Name":"https://schema.org/arrivalStation-output",
     "Domain Bucket":"< 1K"
   },
   {
     "Class":"Predicate",
-    "Name":"http:\/\/schema.org\/arrivalTerminal",
+    "Name":"https://schema.org/arrivalTerminal",
     "Domain Bucket":"< 1K"
   },
   {
     "Class":"Predicate",
-    "Name":"http:\/\/schema.org\/arrivalTerminal-input",
+    "Name":"https://schema.org/arrivalTerminal-input",
     "Domain Bucket":"< 1K"
   },
   {
     "Class":"Predicate",
-    "Name":"http:\/\/schema.org\/arrivalTerminal-output",
+    "Name":"https://schema.org/arrivalTerminal-output",
     "Domain Bucket":"< 1K"
   },
   {
     "Class":"Predicate",
-    "Name":"http:\/\/schema.org\/arrivalTime",
+    "Name":"https://schema.org/arrivalTime",
     "Domain Bucket":"1K - 10K"
   },
   {
     "Class":"Predicate",
-    "Name":"http:\/\/schema.org\/arrivalTime-input",
+    "Name":"https://schema.org/arrivalTime-input",
     "Domain Bucket":"< 1K"
   },
   {
     "Class":"Predicate",
-    "Name":"http:\/\/schema.org\/arrivalTime-output",
+    "Name":"https://schema.org/arrivalTime-output",
     "Domain Bucket":"< 1K"
   },
   {
     "Class":"Predicate",
-    "Name":"http:\/\/schema.org\/artEdition",
+    "Name":"https://schema.org/artEdition",
     "Domain Bucket":"< 1K"
   },
   {
     "Class":"Predicate",
-    "Name":"http:\/\/schema.org\/artEdition-input",
+    "Name":"https://schema.org/artEdition-input",
     "Domain Bucket":"< 1K"
   },
   {
     "Class":"Predicate",
-    "Name":"http:\/\/schema.org\/artEdition-output",
+    "Name":"https://schema.org/artEdition-output",
     "Domain Bucket":"< 1K"
   },
   {
     "Class":"Predicate",
-    "Name":"http:\/\/schema.org\/artMedium",
+    "Name":"https://schema.org/artMedium",
     "Domain Bucket":"1K - 10K"
   },
   {
     "Class":"Predicate",
-    "Name":"http:\/\/schema.org\/artMedium-input",
+    "Name":"https://schema.org/artMedium-input",
     "Domain Bucket":"< 1K"
   },
   {
     "Class":"Predicate",
-    "Name":"http:\/\/schema.org\/artMedium-output",
+    "Name":"https://schema.org/artMedium-output",
     "Domain Bucket":"< 1K"
   },
   {
     "Class":"Predicate",
-    "Name":"http:\/\/schema.org\/arterialBranch",
+    "Name":"https://schema.org/arterialBranch",
     "Domain Bucket":"< 1K"
   },
   {
     "Class":"Predicate",
-    "Name":"http:\/\/schema.org\/arterialBranch-input",
+    "Name":"https://schema.org/arterialBranch-input",
     "Domain Bucket":"< 1K"
   },
   {
     "Class":"Predicate",
-    "Name":"http:\/\/schema.org\/arterialBranch-output",
+    "Name":"https://schema.org/arterialBranch-output",
     "Domain Bucket":"< 1K"
   },
   {
     "Class":"Predicate",
-    "Name":"http:\/\/schema.org\/artform",
+    "Name":"https://schema.org/artform",
     "Domain Bucket":"1K - 10K"
   },
   {
     "Class":"Predicate",
-    "Name":"http:\/\/schema.org\/artform-input",
+    "Name":"https://schema.org/artform-input",
     "Domain Bucket":"< 1K"
   },
   {
     "Class":"Predicate",
-    "Name":"http:\/\/schema.org\/artform-output",
+    "Name":"https://schema.org/artform-output",
     "Domain Bucket":"< 1K"
   },
   {
     "Class":"Predicate",
-    "Name":"http:\/\/schema.org\/articleBody",
+    "Name":"https://schema.org/articleBody",
     "Domain Bucket":"1M - 10M"
   },
   {
     "Class":"Predicate",
-    "Name":"http:\/\/schema.org\/articleBody-input",
+    "Name":"https://schema.org/articleBody-input",
     "Domain Bucket":"< 1K"
   },
   {
     "Class":"Predicate",
-    "Name":"http:\/\/schema.org\/articleBody-output",
+    "Name":"https://schema.org/articleBody-output",
     "Domain Bucket":"< 1K"
   },
   {
     "Class":"Predicate",
-    "Name":"http:\/\/schema.org\/articleSection",
+    "Name":"https://schema.org/articleSection",
     "Domain Bucket":"1M - 10M"
   },
   {
     "Class":"Predicate",
-    "Name":"http:\/\/schema.org\/articleSection-input",
+    "Name":"https://schema.org/articleSection-input",
     "Domain Bucket":"< 1K"
   },
   {
     "Class":"Predicate",
-    "Name":"http:\/\/schema.org\/articleSection-output",
+    "Name":"https://schema.org/articleSection-output",
     "Domain Bucket":"< 1K"
   },
   {
     "Class":"Predicate",
-    "Name":"http:\/\/schema.org\/artist",
+    "Name":"https://schema.org/artist",
     "Domain Bucket":"1K - 10K"
   },
   {
     "Class":"Predicate",
-    "Name":"http:\/\/schema.org\/artist-input",
+    "Name":"https://schema.org/artist-input",
     "Domain Bucket":"< 1K"
   },
   {
     "Class":"Predicate",
-    "Name":"http:\/\/schema.org\/artist-output",
+    "Name":"https://schema.org/artist-output",
     "Domain Bucket":"< 1K"
   },
   {
     "Class":"Predicate",
-    "Name":"http:\/\/schema.org\/artworkSurface",
+    "Name":"https://schema.org/artworkSurface",
     "Domain Bucket":"1K - 10K"
   },
   {
     "Class":"Predicate",
-    "Name":"http:\/\/schema.org\/artworkSurface-input",
+    "Name":"https://schema.org/artworkSurface-input",
     "Domain Bucket":"< 1K"
   },
   {
     "Class":"Predicate",
-    "Name":"http:\/\/schema.org\/artworkSurface-output",
+    "Name":"https://schema.org/artworkSurface-output",
     "Domain Bucket":"< 1K"
   },
   {
     "Class":"Predicate",
-    "Name":"http:\/\/schema.org\/asin",
+    "Name":"https://schema.org/asin",
     "Domain Bucket":"< 1K"
   },
   {
     "Class":"Predicate",
-    "Name":"http:\/\/schema.org\/asin-input",
+    "Name":"https://schema.org/asin-input",
     "Domain Bucket":"< 1K"
   },
   {
     "Class":"Predicate",
-    "Name":"http:\/\/schema.org\/asin-output",
+    "Name":"https://schema.org/asin-output",
     "Domain Bucket":"< 1K"
   },
   {
     "Class":"Predicate",
-    "Name":"http:\/\/schema.org\/aspect",
+    "Name":"https://schema.org/aspect",
     "Domain Bucket":"< 1K"
   },
   {
     "Class":"Predicate",
-    "Name":"http:\/\/schema.org\/aspect-input",
+    "Name":"https://schema.org/aspect-input",
     "Domain Bucket":"< 1K"
   },
   {
     "Class":"Predicate",
-    "Name":"http:\/\/schema.org\/aspect-output",
+    "Name":"https://schema.org/aspect-output",
     "Domain Bucket":"< 1K"
   },
   {
     "Class":"Predicate",
-    "Name":"http:\/\/schema.org\/assembly",
+    "Name":"https://schema.org/assembly",
     "Domain Bucket":"< 1K"
   },
   {
     "Class":"Predicate",
-    "Name":"http:\/\/schema.org\/assembly-input",
+    "Name":"https://schema.org/assembly-input",
     "Domain Bucket":"< 1K"
   },
   {
     "Class":"Predicate",
-    "Name":"http:\/\/schema.org\/assembly-output",
+    "Name":"https://schema.org/assembly-output",
     "Domain Bucket":"< 1K"
   },
   {
     "Class":"Predicate",
-    "Name":"http:\/\/schema.org\/assemblyVersion",
+    "Name":"https://schema.org/assemblyVersion",
     "Domain Bucket":"< 1K"
   },
   {
     "Class":"Predicate",
-    "Name":"http:\/\/schema.org\/assemblyVersion-input",
+    "Name":"https://schema.org/assemblyVersion-input",
     "Domain Bucket":"< 1K"
   },
   {
     "Class":"Predicate",
-    "Name":"http:\/\/schema.org\/assemblyVersion-output",
+    "Name":"https://schema.org/assemblyVersion-output",
     "Domain Bucket":"< 1K"
   },
   {
     "Class":"Predicate",
-    "Name":"http:\/\/schema.org\/assesses",
+    "Name":"https://schema.org/assesses",
     "Domain Bucket":"1K - 10K"
   },
   {
     "Class":"Predicate",
-    "Name":"http:\/\/schema.org\/assesses-input",
+    "Name":"https://schema.org/assesses-input",
     "Domain Bucket":"< 1K"
   },
   {
     "Class":"Predicate",
-    "Name":"http:\/\/schema.org\/assesses-output",
+    "Name":"https://schema.org/assesses-output",
     "Domain Bucket":"< 1K"
   },
   {
     "Class":"Predicate",
-    "Name":"http:\/\/schema.org\/associatedAnatomy",
+    "Name":"https://schema.org/associatedAnatomy",
     "Domain Bucket":"1K - 10K"
   },
   {
     "Class":"Predicate",
-    "Name":"http:\/\/schema.org\/associatedAnatomy-input",
+    "Name":"https://schema.org/associatedAnatomy-input",
     "Domain Bucket":"< 1K"
   },
   {
     "Class":"Predicate",
-    "Name":"http:\/\/schema.org\/associatedAnatomy-output",
+    "Name":"https://schema.org/associatedAnatomy-output",
     "Domain Bucket":"< 1K"
   },
   {
     "Class":"Predicate",
-    "Name":"http:\/\/schema.org\/associatedArticle",
+    "Name":"https://schema.org/associatedArticle",
     "Domain Bucket":"1K - 10K"
   },
   {
     "Class":"Predicate",
-    "Name":"http:\/\/schema.org\/associatedArticle-input",
+    "Name":"https://schema.org/associatedArticle-input",
     "Domain Bucket":"< 1K"
   },
   {
     "Class":"Predicate",
-    "Name":"http:\/\/schema.org\/associatedArticle-output",
+    "Name":"https://schema.org/associatedArticle-output",
     "Domain Bucket":"< 1K"
   },
   {
     "Class":"Predicate",
-    "Name":"http:\/\/schema.org\/associatedClaimReview",
+    "Name":"https://schema.org/associatedClaimReview",
     "Domain Bucket":"< 1K"
   },
   {
     "Class":"Predicate",
-    "Name":"http:\/\/schema.org\/associatedClaimReview-input",
+    "Name":"https://schema.org/associatedClaimReview-input",
     "Domain Bucket":"< 1K"
   },
   {
     "Class":"Predicate",
-    "Name":"http:\/\/schema.org\/associatedClaimReview-output",
+    "Name":"https://schema.org/associatedClaimReview-output",
     "Domain Bucket":"< 1K"
   },
   {
     "Class":"Predicate",
-    "Name":"http:\/\/schema.org\/associatedDisease",
+    "Name":"https://schema.org/associatedDisease",
     "Domain Bucket":"< 1K"
   },
   {
     "Class":"Predicate",
-    "Name":"http:\/\/schema.org\/associatedDisease-input",
+    "Name":"https://schema.org/associatedDisease-input",
     "Domain Bucket":"< 1K"
   },
   {
     "Class":"Predicate",
-    "Name":"http:\/\/schema.org\/associatedDisease-output",
+    "Name":"https://schema.org/associatedDisease-output",
     "Domain Bucket":"< 1K"
   },
   {
     "Class":"Predicate",
-    "Name":"http:\/\/schema.org\/associatedMedia",
+    "Name":"https://schema.org/associatedMedia",
     "Domain Bucket":"100K - 1M"
   },
   {
     "Class":"Predicate",
-    "Name":"http:\/\/schema.org\/associatedMedia-input",
+    "Name":"https://schema.org/associatedMedia-input",
     "Domain Bucket":"< 1K"
   },
   {
     "Class":"Predicate",
-    "Name":"http:\/\/schema.org\/associatedMedia-output",
+    "Name":"https://schema.org/associatedMedia-output",
     "Domain Bucket":"< 1K"
   },
   {
     "Class":"Predicate",
-    "Name":"http:\/\/schema.org\/associatedMediaReview",
+    "Name":"https://schema.org/associatedMediaReview",
     "Domain Bucket":"< 1K"
   },
   {
     "Class":"Predicate",
-    "Name":"http:\/\/schema.org\/associatedMediaReview-input",
+    "Name":"https://schema.org/associatedMediaReview-input",
     "Domain Bucket":"< 1K"
   },
   {
     "Class":"Predicate",
-    "Name":"http:\/\/schema.org\/associatedMediaReview-output",
+    "Name":"https://schema.org/associatedMediaReview-output",
     "Domain Bucket":"< 1K"
   },
   {
     "Class":"Predicate",
-    "Name":"http:\/\/schema.org\/associatedPathophysiology",
+    "Name":"https://schema.org/associatedPathophysiology",
     "Domain Bucket":"< 1K"
   },
   {
     "Class":"Predicate",
-    "Name":"http:\/\/schema.org\/associatedPathophysiology-input",
+    "Name":"https://schema.org/associatedPathophysiology-input",
     "Domain Bucket":"< 1K"
   },
   {
     "Class":"Predicate",
-    "Name":"http:\/\/schema.org\/associatedPathophysiology-output",
+    "Name":"https://schema.org/associatedPathophysiology-output",
     "Domain Bucket":"< 1K"
   },
   {
     "Class":"Predicate",
-    "Name":"http:\/\/schema.org\/associatedReview",
+    "Name":"https://schema.org/associatedReview",
     "Domain Bucket":"< 1K"
   },
   {
     "Class":"Predicate",
-    "Name":"http:\/\/schema.org\/associatedReview-input",
+    "Name":"https://schema.org/associatedReview-input",
     "Domain Bucket":"< 1K"
   },
   {
     "Class":"Predicate",
-    "Name":"http:\/\/schema.org\/associatedReview-output",
+    "Name":"https://schema.org/associatedReview-output",
     "Domain Bucket":"< 1K"
   },
   {
     "Class":"Predicate",
-    "Name":"http:\/\/schema.org\/athlete",
+    "Name":"https://schema.org/athlete",
     "Domain Bucket":"1K - 10K"
   },
   {
     "Class":"Predicate",
-    "Name":"http:\/\/schema.org\/athlete-input",
+    "Name":"https://schema.org/athlete-input",
     "Domain Bucket":"< 1K"
   },
   {
     "Class":"Predicate",
-    "Name":"http:\/\/schema.org\/athlete-output",
+    "Name":"https://schema.org/athlete-output",
     "Domain Bucket":"< 1K"
   },
   {
     "Class":"Predicate",
-    "Name":"http:\/\/schema.org\/attendee",
+    "Name":"https://schema.org/attendee",
     "Domain Bucket":"1K - 10K"
   },
   {
     "Class":"Predicate",
-    "Name":"http:\/\/schema.org\/attendee-input",
+    "Name":"https://schema.org/attendee-input",
     "Domain Bucket":"< 1K"
   },
   {
     "Class":"Predicate",
-    "Name":"http:\/\/schema.org\/attendee-output",
+    "Name":"https://schema.org/attendee-output",
     "Domain Bucket":"< 1K"
   },
   {
     "Class":"Predicate",
-    "Name":"http:\/\/schema.org\/attendees",
+    "Name":"https://schema.org/attendees",
     "Domain Bucket":"< 1K"
   },
   {
     "Class":"Predicate",
-    "Name":"http:\/\/schema.org\/attendees-input",
+    "Name":"https://schema.org/attendees-input",
     "Domain Bucket":"< 1K"
   },
   {
     "Class":"Predicate",
-    "Name":"http:\/\/schema.org\/attendees-output",
+    "Name":"https://schema.org/attendees-output",
     "Domain Bucket":"< 1K"
   },
   {
     "Class":"Predicate",
-    "Name":"http:\/\/schema.org\/audience",
+    "Name":"https://schema.org/audience",
     "Domain Bucket":"100K - 1M"
   },
   {
     "Class":"Predicate",
-    "Name":"http:\/\/schema.org\/audience-input",
+    "Name":"https://schema.org/audience-input",
     "Domain Bucket":"< 1K"
   },
   {
     "Class":"Predicate",
-    "Name":"http:\/\/schema.org\/audience-output",
+    "Name":"https://schema.org/audience-output",
     "Domain Bucket":"< 1K"
   },
   {
     "Class":"Predicate",
-    "Name":"http:\/\/schema.org\/audienceType",
+    "Name":"https://schema.org/audienceType",
     "Domain Bucket":"100K - 1M"
   },
   {
     "Class":"Predicate",
-    "Name":"http:\/\/schema.org\/audienceType-input",
+    "Name":"https://schema.org/audienceType-input",
     "Domain Bucket":"< 1K"
   },
   {
     "Class":"Predicate",
-    "Name":"http:\/\/schema.org\/audienceType-output",
+    "Name":"https://schema.org/audienceType-output",
     "Domain Bucket":"< 1K"
   },
   {
     "Class":"Predicate",
-    "Name":"http:\/\/schema.org\/audio",
+    "Name":"https://schema.org/audio",
     "Domain Bucket":"10K - 100K"
   },
   {
     "Class":"Predicate",
-    "Name":"http:\/\/schema.org\/audio-input",
+    "Name":"https://schema.org/audio-input",
     "Domain Bucket":"< 1K"
   },
   {
     "Class":"Predicate",
-    "Name":"http:\/\/schema.org\/audio-output",
+    "Name":"https://schema.org/audio-output",
     "Domain Bucket":"< 1K"
   },
   {
     "Class":"Predicate",
-    "Name":"http:\/\/schema.org\/auditDate",
+    "Name":"https://schema.org/auditDate",
     "Domain Bucket":"< 1K"
   },
   {
     "Class":"Predicate",
-    "Name":"http:\/\/schema.org\/auditDate-input",
+    "Name":"https://schema.org/auditDate-input",
     "Domain Bucket":"< 1K"
   },
   {
     "Class":"Predicate",
-    "Name":"http:\/\/schema.org\/auditDate-output",
+    "Name":"https://schema.org/auditDate-output",
     "Domain Bucket":"< 1K"
   },
   {
     "Class":"Predicate",
-    "Name":"http:\/\/schema.org\/authenticator",
+    "Name":"https://schema.org/authenticator",
     "Domain Bucket":"< 1K"
   },
   {
     "Class":"Predicate",
-    "Name":"http:\/\/schema.org\/authenticator-input",
+    "Name":"https://schema.org/authenticator-input",
     "Domain Bucket":"< 1K"
   },
   {
     "Class":"Predicate",
-    "Name":"http:\/\/schema.org\/authenticator-output",
+    "Name":"https://schema.org/authenticator-output",
     "Domain Bucket":"< 1K"
   },
   {
     "Class":"Predicate",
-    "Name":"http:\/\/schema.org\/author",
+    "Name":"https://schema.org/author",
     "Domain Bucket":"10M+"
   },
   {
     "Class":"Predicate",
-    "Name":"http:\/\/schema.org\/author-input",
+    "Name":"https://schema.org/author-input",
     "Domain Bucket":"< 1K"
   },
   {
     "Class":"Predicate",
-    "Name":"http:\/\/schema.org\/author-output",
+    "Name":"https://schema.org/author-output",
     "Domain Bucket":"< 1K"
   },
   {
     "Class":"Predicate",
-    "Name":"http:\/\/schema.org\/availability",
+    "Name":"https://schema.org/availability",
     "Domain Bucket":"10M+"
   },
   {
     "Class":"Predicate",
-    "Name":"http:\/\/schema.org\/availability-input",
+    "Name":"https://schema.org/availability-input",
     "Domain Bucket":"< 1K"
   },
   {
     "Class":"Predicate",
-    "Name":"http:\/\/schema.org\/availability-output",
+    "Name":"https://schema.org/availability-output",
     "Domain Bucket":"< 1K"
   },
   {
     "Class":"Predicate",
-    "Name":"http:\/\/schema.org\/availabilityEnds",
+    "Name":"https://schema.org/availabilityEnds",
     "Domain Bucket":"10K - 100K"
   },
   {
     "Class":"Predicate",
-    "Name":"http:\/\/schema.org\/availabilityEnds-input",
+    "Name":"https://schema.org/availabilityEnds-input",
     "Domain Bucket":"< 1K"
   },
   {
     "Class":"Predicate",
-    "Name":"http:\/\/schema.org\/availabilityEnds-output",
+    "Name":"https://schema.org/availabilityEnds-output",
     "Domain Bucket":"< 1K"
   },
   {
     "Class":"Predicate",
-    "Name":"http:\/\/schema.org\/availabilityStarts",
+    "Name":"https://schema.org/availabilityStarts",
     "Domain Bucket":"10K - 100K"
   },
   {
     "Class":"Predicate",
-    "Name":"http:\/\/schema.org\/availabilityStarts-input",
+    "Name":"https://schema.org/availabilityStarts-input",
     "Domain Bucket":"< 1K"
   },
   {
     "Class":"Predicate",
-    "Name":"http:\/\/schema.org\/availabilityStarts-output",
+    "Name":"https://schema.org/availabilityStarts-output",
     "Domain Bucket":"< 1K"
   },
   {
     "Class":"Predicate",
-    "Name":"http:\/\/schema.org\/availableAtOrFrom",
+    "Name":"https://schema.org/availableAtOrFrom",
     "Domain Bucket":"10K - 100K"
   },
   {
     "Class":"Predicate",
-    "Name":"http:\/\/schema.org\/availableAtOrFrom-input",
+    "Name":"https://schema.org/availableAtOrFrom-input",
     "Domain Bucket":"< 1K"
   },
   {
     "Class":"Predicate",
-    "Name":"http:\/\/schema.org\/availableAtOrFrom-output",
+    "Name":"https://schema.org/availableAtOrFrom-output",
     "Domain Bucket":"< 1K"
   },
   {
     "Class":"Predicate",
-    "Name":"http:\/\/schema.org\/availableChannel",
+    "Name":"https://schema.org/availableChannel",
     "Domain Bucket":"100K - 1M"
   },
   {
     "Class":"Predicate",
-    "Name":"http:\/\/schema.org\/availableChannel-input",
+    "Name":"https://schema.org/availableChannel-input",
     "Domain Bucket":"< 1K"
   },
   {
     "Class":"Predicate",
-    "Name":"http:\/\/schema.org\/availableChannel-output",
+    "Name":"https://schema.org/availableChannel-output",
     "Domain Bucket":"< 1K"
   },
   {
     "Class":"Predicate",
-    "Name":"http:\/\/schema.org\/availableDeliveryMethod",
+    "Name":"https://schema.org/availableDeliveryMethod",
     "Domain Bucket":"10K - 100K"
   },
   {
     "Class":"Predicate",
-    "Name":"http:\/\/schema.org\/availableDeliveryMethod-input",
+    "Name":"https://schema.org/availableDeliveryMethod-input",
     "Domain Bucket":"< 1K"
   },
   {
     "Class":"Predicate",
-    "Name":"http:\/\/schema.org\/availableDeliveryMethod-output",
+    "Name":"https://schema.org/availableDeliveryMethod-output",
     "Domain Bucket":"< 1K"
   },
   {
     "Class":"Predicate",
-    "Name":"http:\/\/schema.org\/availableFrom",
+    "Name":"https://schema.org/availableFrom",
     "Domain Bucket":"< 1K"
   },
   {
     "Class":"Predicate",
-    "Name":"http:\/\/schema.org\/availableFrom-input",
+    "Name":"https://schema.org/availableFrom-input",
     "Domain Bucket":"< 1K"
   },
   {
     "Class":"Predicate",
-    "Name":"http:\/\/schema.org\/availableFrom-output",
+    "Name":"https://schema.org/availableFrom-output",
     "Domain Bucket":"< 1K"
   },
   {
     "Class":"Predicate",
-    "Name":"http:\/\/schema.org\/availableIn",
+    "Name":"https://schema.org/availableIn",
     "Domain Bucket":"< 1K"
   },
   {
     "Class":"Predicate",
-    "Name":"http:\/\/schema.org\/availableIn-input",
+    "Name":"https://schema.org/availableIn-input",
     "Domain Bucket":"< 1K"
   },
   {
     "Class":"Predicate",
-    "Name":"http:\/\/schema.org\/availableIn-output",
+    "Name":"https://schema.org/availableIn-output",
     "Domain Bucket":"< 1K"
   },
   {
     "Class":"Predicate",
-    "Name":"http:\/\/schema.org\/availableLanguage",
+    "Name":"https://schema.org/availableLanguage",
     "Domain Bucket":"1M - 10M"
   },
   {
     "Class":"Predicate",
-    "Name":"http:\/\/schema.org\/availableLanguage-input",
+    "Name":"https://schema.org/availableLanguage-input",
     "Domain Bucket":"< 1K"
   },
   {
     "Class":"Predicate",
-    "Name":"http:\/\/schema.org\/availableLanguage-output",
+    "Name":"https://schema.org/availableLanguage-output",
     "Domain Bucket":"< 1K"
   },
   {
     "Class":"Predicate",
-    "Name":"http:\/\/schema.org\/availableOnDevice",
+    "Name":"https://schema.org/availableOnDevice",
     "Domain Bucket":"1K - 10K"
   },
   {
     "Class":"Predicate",
-    "Name":"http:\/\/schema.org\/availableOnDevice-input",
+    "Name":"https://schema.org/availableOnDevice-input",
     "Domain Bucket":"< 1K"
   },
   {
     "Class":"Predicate",
-    "Name":"http:\/\/schema.org\/availableOnDevice-output",
+    "Name":"https://schema.org/availableOnDevice-output",
     "Domain Bucket":"< 1K"
   },
   {
     "Class":"Predicate",
-    "Name":"http:\/\/schema.org\/availableService",
+    "Name":"https://schema.org/availableService",
     "Domain Bucket":"10K - 100K"
   },
   {
     "Class":"Predicate",
-    "Name":"http:\/\/schema.org\/availableService-input",
+    "Name":"https://schema.org/availableService-input",
     "Domain Bucket":"< 1K"
   },
   {
     "Class":"Predicate",
-    "Name":"http:\/\/schema.org\/availableService-output",
+    "Name":"https://schema.org/availableService-output",
     "Domain Bucket":"< 1K"
   },
   {
     "Class":"Predicate",
-    "Name":"http:\/\/schema.org\/availableStrength",
+    "Name":"https://schema.org/availableStrength",
     "Domain Bucket":"< 1K"
   },
   {
     "Class":"Predicate",
-    "Name":"http:\/\/schema.org\/availableStrength-input",
+    "Name":"https://schema.org/availableStrength-input",
     "Domain Bucket":"< 1K"
   },
   {
     "Class":"Predicate",
-    "Name":"http:\/\/schema.org\/availableStrength-output",
+    "Name":"https://schema.org/availableStrength-output",
     "Domain Bucket":"< 1K"
   },
   {
     "Class":"Predicate",
-    "Name":"http:\/\/schema.org\/availableTest",
+    "Name":"https://schema.org/availableTest",
     "Domain Bucket":"< 1K"
   },
   {
     "Class":"Predicate",
-    "Name":"http:\/\/schema.org\/availableTest-input",
+    "Name":"https://schema.org/availableTest-input",
     "Domain Bucket":"< 1K"
   },
   {
     "Class":"Predicate",
-    "Name":"http:\/\/schema.org\/availableTest-output",
+    "Name":"https://schema.org/availableTest-output",
     "Domain Bucket":"< 1K"
   },
   {
     "Class":"Predicate",
-    "Name":"http:\/\/schema.org\/availableThrough",
+    "Name":"https://schema.org/availableThrough",
     "Domain Bucket":"< 1K"
   },
   {
     "Class":"Predicate",
-    "Name":"http:\/\/schema.org\/availableThrough-input",
+    "Name":"https://schema.org/availableThrough-input",
     "Domain Bucket":"< 1K"
   },
   {
     "Class":"Predicate",
-    "Name":"http:\/\/schema.org\/availableThrough-output",
+    "Name":"https://schema.org/availableThrough-output",
     "Domain Bucket":"< 1K"
   },
   {
     "Class":"Predicate",
-    "Name":"http:\/\/schema.org\/award",
+    "Name":"https://schema.org/award",
     "Domain Bucket":"100K - 1M"
   },
   {
     "Class":"Predicate",
-    "Name":"http:\/\/schema.org\/award-input",
+    "Name":"https://schema.org/award-input",
     "Domain Bucket":"< 1K"
   },
   {
     "Class":"Predicate",
-    "Name":"http:\/\/schema.org\/award-output",
+    "Name":"https://schema.org/award-output",
     "Domain Bucket":"< 1K"
   },
   {
     "Class":"Predicate",
-    "Name":"http:\/\/schema.org\/awards",
+    "Name":"https://schema.org/awards",
     "Domain Bucket":"1K - 10K"
   },
   {
     "Class":"Predicate",
-    "Name":"http:\/\/schema.org\/awards-input",
+    "Name":"https://schema.org/awards-input",
     "Domain Bucket":"< 1K"
   },
   {
     "Class":"Predicate",
-    "Name":"http:\/\/schema.org\/awards-output",
+    "Name":"https://schema.org/awards-output",
     "Domain Bucket":"< 1K"
   },
   {
     "Class":"Predicate",
-    "Name":"http:\/\/schema.org\/awayTeam",
+    "Name":"https://schema.org/awayTeam",
     "Domain Bucket":"10K - 100K"
   },
   {
     "Class":"Predicate",
-    "Name":"http:\/\/schema.org\/awayTeam-input",
+    "Name":"https://schema.org/awayTeam-input",
     "Domain Bucket":"< 1K"
   },
   {
     "Class":"Predicate",
-    "Name":"http:\/\/schema.org\/awayTeam-output",
+    "Name":"https://schema.org/awayTeam-output",
     "Domain Bucket":"< 1K"
   },
   {
     "Class":"Predicate",
-    "Name":"http:\/\/schema.org\/backstory",
+    "Name":"https://schema.org/backstory",
     "Domain Bucket":"1K - 10K"
   },
   {
     "Class":"Predicate",
-    "Name":"http:\/\/schema.org\/backstory-input",
+    "Name":"https://schema.org/backstory-input",
     "Domain Bucket":"< 1K"
   },
   {
     "Class":"Predicate",
-    "Name":"http:\/\/schema.org\/backstory-output",
+    "Name":"https://schema.org/backstory-output",
     "Domain Bucket":"< 1K"
   },
   {
     "Class":"Predicate",
-    "Name":"http:\/\/schema.org\/bankAccountType",
+    "Name":"https://schema.org/bankAccountType",
     "Domain Bucket":"< 1K"
   },
   {
     "Class":"Predicate",
-    "Name":"http:\/\/schema.org\/bankAccountType-input",
+    "Name":"https://schema.org/bankAccountType-input",
     "Domain Bucket":"< 1K"
   },
   {
     "Class":"Predicate",
-    "Name":"http:\/\/schema.org\/bankAccountType-output",
+    "Name":"https://schema.org/bankAccountType-output",
     "Domain Bucket":"< 1K"
   },
   {
     "Class":"Predicate",
-    "Name":"http:\/\/schema.org\/baseSalary",
+    "Name":"https://schema.org/baseSalary",
     "Domain Bucket":"10K - 100K"
   },
   {
     "Class":"Predicate",
-    "Name":"http:\/\/schema.org\/baseSalary-input",
+    "Name":"https://schema.org/baseSalary-input",
     "Domain Bucket":"< 1K"
   },
   {
     "Class":"Predicate",
-    "Name":"http:\/\/schema.org\/baseSalary-output",
+    "Name":"https://schema.org/baseSalary-output",
     "Domain Bucket":"< 1K"
   },
   {
     "Class":"Predicate",
-    "Name":"http:\/\/schema.org\/bccRecipient",
+    "Name":"https://schema.org/bccRecipient",
     "Domain Bucket":"< 1K"
   },
   {
     "Class":"Predicate",
-    "Name":"http:\/\/schema.org\/bccRecipient-input",
+    "Name":"https://schema.org/bccRecipient-input",
     "Domain Bucket":"< 1K"
   },
   {
     "Class":"Predicate",
-    "Name":"http:\/\/schema.org\/bccRecipient-output",
+    "Name":"https://schema.org/bccRecipient-output",
     "Domain Bucket":"< 1K"
   },
   {
     "Class":"Predicate",
-    "Name":"http:\/\/schema.org\/bed",
+    "Name":"https://schema.org/bed",
     "Domain Bucket":"10K - 100K"
   },
   {
     "Class":"Predicate",
-    "Name":"http:\/\/schema.org\/bed-input",
+    "Name":"https://schema.org/bed-input",
     "Domain Bucket":"< 1K"
   },
   {
     "Class":"Predicate",
-    "Name":"http:\/\/schema.org\/bed-output",
+    "Name":"https://schema.org/bed-output",
     "Domain Bucket":"< 1K"
   },
   {
     "Class":"Predicate",
-    "Name":"http:\/\/schema.org\/beforeMedia",
+    "Name":"https://schema.org/beforeMedia",
     "Domain Bucket":"< 1K"
   },
   {
     "Class":"Predicate",
-    "Name":"http:\/\/schema.org\/beforeMedia-input",
+    "Name":"https://schema.org/beforeMedia-input",
     "Domain Bucket":"< 1K"
   },
   {
     "Class":"Predicate",
-    "Name":"http:\/\/schema.org\/beforeMedia-output",
+    "Name":"https://schema.org/beforeMedia-output",
     "Domain Bucket":"< 1K"
   },
   {
     "Class":"Predicate",
-    "Name":"http:\/\/schema.org\/beneficiaryBank",
+    "Name":"https://schema.org/beneficiaryBank",
     "Domain Bucket":"< 1K"
   },
   {
     "Class":"Predicate",
-    "Name":"http:\/\/schema.org\/beneficiaryBank-input",
+    "Name":"https://schema.org/beneficiaryBank-input",
     "Domain Bucket":"< 1K"
   },
   {
     "Class":"Predicate",
-    "Name":"http:\/\/schema.org\/beneficiaryBank-output",
+    "Name":"https://schema.org/beneficiaryBank-output",
     "Domain Bucket":"< 1K"
   },
   {
     "Class":"Predicate",
-    "Name":"http:\/\/schema.org\/benefits",
+    "Name":"https://schema.org/benefits",
     "Domain Bucket":"1K - 10K"
   },
   {
     "Class":"Predicate",
-    "Name":"http:\/\/schema.org\/benefits-input",
+    "Name":"https://schema.org/benefits-input",
     "Domain Bucket":"< 1K"
   },
   {
     "Class":"Predicate",
-    "Name":"http:\/\/schema.org\/benefits-output",
+    "Name":"https://schema.org/benefits-output",
     "Domain Bucket":"< 1K"
   },
   {
     "Class":"Predicate",
-    "Name":"http:\/\/schema.org\/benefitsSummaryUrl",
+    "Name":"https://schema.org/benefitsSummaryUrl",
     "Domain Bucket":"< 1K"
   },
   {
     "Class":"Predicate",
-    "Name":"http:\/\/schema.org\/benefitsSummaryUrl-input",
+    "Name":"https://schema.org/benefitsSummaryUrl-input",
     "Domain Bucket":"< 1K"
   },
   {
     "Class":"Predicate",
-    "Name":"http:\/\/schema.org\/benefitsSummaryUrl-output",
+    "Name":"https://schema.org/benefitsSummaryUrl-output",
     "Domain Bucket":"< 1K"
   },
   {
     "Class":"Predicate",
-    "Name":"http:\/\/schema.org\/bestRating",
+    "Name":"https://schema.org/bestRating",
     "Domain Bucket":"1M - 10M"
   },
   {
     "Class":"Predicate",
-    "Name":"http:\/\/schema.org\/bestRating-input",
+    "Name":"https://schema.org/bestRating-input",
     "Domain Bucket":"< 1K"
   },
   {
     "Class":"Predicate",
-    "Name":"http:\/\/schema.org\/bestRating-output",
+    "Name":"https://schema.org/bestRating-output",
     "Domain Bucket":"< 1K"
   },
   {
     "Class":"Predicate",
-    "Name":"http:\/\/schema.org\/billingAddress",
+    "Name":"https://schema.org/billingAddress",
     "Domain Bucket":"< 1K"
   },
   {
     "Class":"Predicate",
-    "Name":"http:\/\/schema.org\/billingAddress-input",
+    "Name":"https://schema.org/billingAddress-input",
     "Domain Bucket":"< 1K"
   },
   {
     "Class":"Predicate",
-    "Name":"http:\/\/schema.org\/billingAddress-output",
+    "Name":"https://schema.org/billingAddress-output",
     "Domain Bucket":"< 1K"
   },
   {
     "Class":"Predicate",
-    "Name":"http:\/\/schema.org\/billingDuration",
+    "Name":"https://schema.org/billingDuration",
     "Domain Bucket":"10K - 100K"
   },
   {
     "Class":"Predicate",
-    "Name":"http:\/\/schema.org\/billingDuration-input",
+    "Name":"https://schema.org/billingDuration-input",
     "Domain Bucket":"< 1K"
   },
   {
     "Class":"Predicate",
-    "Name":"http:\/\/schema.org\/billingDuration-output",
+    "Name":"https://schema.org/billingDuration-output",
     "Domain Bucket":"< 1K"
   },
   {
     "Class":"Predicate",
-    "Name":"http:\/\/schema.org\/billingIncrement",
+    "Name":"https://schema.org/billingIncrement",
     "Domain Bucket":"10K - 100K"
   },
   {
     "Class":"Predicate",
-    "Name":"http:\/\/schema.org\/billingIncrement-input",
+    "Name":"https://schema.org/billingIncrement-input",
     "Domain Bucket":"< 1K"
   },
   {
     "Class":"Predicate",
-    "Name":"http:\/\/schema.org\/billingIncrement-output",
+    "Name":"https://schema.org/billingIncrement-output",
     "Domain Bucket":"< 1K"
   },
   {
     "Class":"Predicate",
-    "Name":"http:\/\/schema.org\/billingPeriod",
+    "Name":"https://schema.org/billingPeriod",
     "Domain Bucket":"1K - 10K"
   },
   {
     "Class":"Predicate",
-    "Name":"http:\/\/schema.org\/billingPeriod-input",
+    "Name":"https://schema.org/billingPeriod-input",
     "Domain Bucket":"< 1K"
   },
   {
     "Class":"Predicate",
-    "Name":"http:\/\/schema.org\/billingPeriod-output",
+    "Name":"https://schema.org/billingPeriod-output",
     "Domain Bucket":"< 1K"
   },
   {
     "Class":"Predicate",
-    "Name":"http:\/\/schema.org\/billingStart",
+    "Name":"https://schema.org/billingStart",
     "Domain Bucket":"< 1K"
   },
   {
     "Class":"Predicate",
-    "Name":"http:\/\/schema.org\/billingStart-input",
+    "Name":"https://schema.org/billingStart-input",
     "Domain Bucket":"< 1K"
   },
   {
     "Class":"Predicate",
-    "Name":"http:\/\/schema.org\/billingStart-output",
+    "Name":"https://schema.org/billingStart-output",
     "Domain Bucket":"< 1K"
   },
   {
     "Class":"Predicate",
-    "Name":"http:\/\/schema.org\/bioChemInteraction",
+    "Name":"https://schema.org/bioChemInteraction",
     "Domain Bucket":"< 1K"
   },
   {
     "Class":"Predicate",
-    "Name":"http:\/\/schema.org\/bioChemInteraction-input",
+    "Name":"https://schema.org/bioChemInteraction-input",
     "Domain Bucket":"< 1K"
   },
   {
     "Class":"Predicate",
-    "Name":"http:\/\/schema.org\/bioChemInteraction-output",
+    "Name":"https://schema.org/bioChemInteraction-output",
     "Domain Bucket":"< 1K"
   },
   {
     "Class":"Predicate",
-    "Name":"http:\/\/schema.org\/bioChemSimilarity",
+    "Name":"https://schema.org/bioChemSimilarity",
     "Domain Bucket":"< 1K"
   },
   {
     "Class":"Predicate",
-    "Name":"http:\/\/schema.org\/bioChemSimilarity-input",
+    "Name":"https://schema.org/bioChemSimilarity-input",
     "Domain Bucket":"< 1K"
   },
   {
     "Class":"Predicate",
-    "Name":"http:\/\/schema.org\/bioChemSimilarity-output",
+    "Name":"https://schema.org/bioChemSimilarity-output",
     "Domain Bucket":"< 1K"
   },
   {
     "Class":"Predicate",
-    "Name":"http:\/\/schema.org\/biologicalRole",
+    "Name":"https://schema.org/biologicalRole",
     "Domain Bucket":"< 1K"
   },
   {
     "Class":"Predicate",
-    "Name":"http:\/\/schema.org\/biologicalRole-input",
+    "Name":"https://schema.org/biologicalRole-input",
     "Domain Bucket":"< 1K"
   },
   {
     "Class":"Predicate",
-    "Name":"http:\/\/schema.org\/biologicalRole-output",
+    "Name":"https://schema.org/biologicalRole-output",
     "Domain Bucket":"< 1K"
   },
   {
     "Class":"Predicate",
-    "Name":"http:\/\/schema.org\/biomechnicalClass",
+    "Name":"https://schema.org/biomechnicalClass",
     "Domain Bucket":"< 1K"
   },
   {
     "Class":"Predicate",
-    "Name":"http:\/\/schema.org\/biomechnicalClass-input",
+    "Name":"https://schema.org/biomechnicalClass-input",
     "Domain Bucket":"< 1K"
   },
   {
     "Class":"Predicate",
-    "Name":"http:\/\/schema.org\/biomechnicalClass-output",
+    "Name":"https://schema.org/biomechnicalClass-output",
     "Domain Bucket":"< 1K"
   },
   {
     "Class":"Predicate",
-    "Name":"http:\/\/schema.org\/birthDate",
+    "Name":"https://schema.org/birthDate",
     "Domain Bucket":"10K - 100K"
   },
   {
     "Class":"Predicate",
-    "Name":"http:\/\/schema.org\/birthDate-input",
+    "Name":"https://schema.org/birthDate-input",
     "Domain Bucket":"< 1K"
   },
   {
     "Class":"Predicate",
-    "Name":"http:\/\/schema.org\/birthDate-output",
+    "Name":"https://schema.org/birthDate-output",
     "Domain Bucket":"< 1K"
   },
   {
     "Class":"Predicate",
-    "Name":"http:\/\/schema.org\/birthPlace",
+    "Name":"https://schema.org/birthPlace",
     "Domain Bucket":"10K - 100K"
   },
   {
     "Class":"Predicate",
-    "Name":"http:\/\/schema.org\/birthPlace-input",
+    "Name":"https://schema.org/birthPlace-input",
     "Domain Bucket":"< 1K"
   },
   {
     "Class":"Predicate",
-    "Name":"http:\/\/schema.org\/birthPlace-output",
+    "Name":"https://schema.org/birthPlace-output",
     "Domain Bucket":"< 1K"
   },
   {
     "Class":"Predicate",
-    "Name":"http:\/\/schema.org\/bitrate",
+    "Name":"https://schema.org/bitrate",
     "Domain Bucket":"1K - 10K"
   },
   {
     "Class":"Predicate",
-    "Name":"http:\/\/schema.org\/bitrate-input",
+    "Name":"https://schema.org/bitrate-input",
     "Domain Bucket":"< 1K"
   },
   {
     "Class":"Predicate",
-    "Name":"http:\/\/schema.org\/bitrate-output",
+    "Name":"https://schema.org/bitrate-output",
     "Domain Bucket":"< 1K"
   },
   {
     "Class":"Predicate",
-    "Name":"http:\/\/schema.org\/blogPost",
+    "Name":"https://schema.org/blogPost",
     "Domain Bucket":"100K - 1M"
   },
   {
     "Class":"Predicate",
-    "Name":"http:\/\/schema.org\/blogPost-input",
+    "Name":"https://schema.org/blogPost-input",
     "Domain Bucket":"< 1K"
   },
   {
     "Class":"Predicate",
-    "Name":"http:\/\/schema.org\/blogPost-output",
+    "Name":"https://schema.org/blogPost-output",
     "Domain Bucket":"< 1K"
   },
   {
     "Class":"Predicate",
-    "Name":"http:\/\/schema.org\/blogPosts",
+    "Name":"https://schema.org/blogPosts",
     "Domain Bucket":"10K - 100K"
   },
   {
     "Class":"Predicate",
-    "Name":"http:\/\/schema.org\/blogPosts-input",
+    "Name":"https://schema.org/blogPosts-input",
     "Domain Bucket":"< 1K"
   },
   {
     "Class":"Predicate",
-    "Name":"http:\/\/schema.org\/blogPosts-output",
+    "Name":"https://schema.org/blogPosts-output",
     "Domain Bucket":"< 1K"
   },
   {
     "Class":"Predicate",
-    "Name":"http:\/\/schema.org\/bloodSupply",
+    "Name":"https://schema.org/bloodSupply",
     "Domain Bucket":"< 1K"
   },
   {
     "Class":"Predicate",
-    "Name":"http:\/\/schema.org\/bloodSupply-input",
+    "Name":"https://schema.org/bloodSupply-input",
     "Domain Bucket":"< 1K"
   },
   {
     "Class":"Predicate",
-    "Name":"http:\/\/schema.org\/bloodSupply-output",
+    "Name":"https://schema.org/bloodSupply-output",
     "Domain Bucket":"< 1K"
   },
   {
     "Class":"Predicate",
-    "Name":"http:\/\/schema.org\/boardingGroup",
+    "Name":"https://schema.org/boardingGroup",
     "Domain Bucket":"< 1K"
   },
   {
     "Class":"Predicate",
-    "Name":"http:\/\/schema.org\/boardingGroup-input",
+    "Name":"https://schema.org/boardingGroup-input",
     "Domain Bucket":"< 1K"
   },
   {
     "Class":"Predicate",
-    "Name":"http:\/\/schema.org\/boardingGroup-output",
+    "Name":"https://schema.org/boardingGroup-output",
     "Domain Bucket":"< 1K"
   },
   {
     "Class":"Predicate",
-    "Name":"http:\/\/schema.org\/boardingPolicy",
+    "Name":"https://schema.org/boardingPolicy",
     "Domain Bucket":"< 1K"
   },
   {
     "Class":"Predicate",
-    "Name":"http:\/\/schema.org\/boardingPolicy-input",
+    "Name":"https://schema.org/boardingPolicy-input",
     "Domain Bucket":"< 1K"
   },
   {
     "Class":"Predicate",
-    "Name":"http:\/\/schema.org\/boardingPolicy-output",
+    "Name":"https://schema.org/boardingPolicy-output",
     "Domain Bucket":"< 1K"
   },
   {
     "Class":"Predicate",
-    "Name":"http:\/\/schema.org\/bodyLocation",
+    "Name":"https://schema.org/bodyLocation",
     "Domain Bucket":"10K - 100K"
   },
   {
     "Class":"Predicate",
-    "Name":"http:\/\/schema.org\/bodyLocation-input",
+    "Name":"https://schema.org/bodyLocation-input",
     "Domain Bucket":"< 1K"
   },
   {
     "Class":"Predicate",
-    "Name":"http:\/\/schema.org\/bodyLocation-output",
+    "Name":"https://schema.org/bodyLocation-output",
     "Domain Bucket":"< 1K"
   },
   {
     "Class":"Predicate",
-    "Name":"http:\/\/schema.org\/bodyType",
+    "Name":"https://schema.org/bodyType",
     "Domain Bucket":"10K - 100K"
   },
   {
     "Class":"Predicate",
-    "Name":"http:\/\/schema.org\/bodyType-input",
+    "Name":"https://schema.org/bodyType-input",
     "Domain Bucket":"< 1K"
   },
   {
     "Class":"Predicate",
-    "Name":"http:\/\/schema.org\/bodyType-output",
+    "Name":"https://schema.org/bodyType-output",
     "Domain Bucket":"< 1K"
   },
   {
     "Class":"Predicate",
-    "Name":"http:\/\/schema.org\/bookEdition",
+    "Name":"https://schema.org/bookEdition",
     "Domain Bucket":"1K - 10K"
   },
   {
     "Class":"Predicate",
-    "Name":"http:\/\/schema.org\/bookEdition-input",
+    "Name":"https://schema.org/bookEdition-input",
     "Domain Bucket":"< 1K"
   },
   {
     "Class":"Predicate",
-    "Name":"http:\/\/schema.org\/bookEdition-output",
+    "Name":"https://schema.org/bookEdition-output",
     "Domain Bucket":"< 1K"
   },
   {
     "Class":"Predicate",
-    "Name":"http:\/\/schema.org\/bookFormat",
+    "Name":"https://schema.org/bookFormat",
     "Domain Bucket":"10K - 100K"
   },
   {
     "Class":"Predicate",
-    "Name":"http:\/\/schema.org\/bookFormat-input",
+    "Name":"https://schema.org/bookFormat-input",
     "Domain Bucket":"< 1K"
   },
   {
     "Class":"Predicate",
-    "Name":"http:\/\/schema.org\/bookFormat-output",
+    "Name":"https://schema.org/bookFormat-output",
     "Domain Bucket":"< 1K"
   },
   {
     "Class":"Predicate",
-    "Name":"http:\/\/schema.org\/bookingAgent",
+    "Name":"https://schema.org/bookingAgent",
     "Domain Bucket":"< 1K"
   },
   {
     "Class":"Predicate",
-    "Name":"http:\/\/schema.org\/bookingAgent-input",
+    "Name":"https://schema.org/bookingAgent-input",
     "Domain Bucket":"< 1K"
   },
   {
     "Class":"Predicate",
-    "Name":"http:\/\/schema.org\/bookingAgent-output",
+    "Name":"https://schema.org/bookingAgent-output",
     "Domain Bucket":"< 1K"
   },
   {
     "Class":"Predicate",
-    "Name":"http:\/\/schema.org\/bookingTime",
+    "Name":"https://schema.org/bookingTime",
     "Domain Bucket":"< 1K"
   },
   {
     "Class":"Predicate",
-    "Name":"http:\/\/schema.org\/bookingTime-input",
+    "Name":"https://schema.org/bookingTime-input",
     "Domain Bucket":"< 1K"
   },
   {
     "Class":"Predicate",
-    "Name":"http:\/\/schema.org\/bookingTime-output",
+    "Name":"https://schema.org/bookingTime-output",
     "Domain Bucket":"< 1K"
   },
   {
     "Class":"Predicate",
-    "Name":"http:\/\/schema.org\/borrower",
+    "Name":"https://schema.org/borrower",
     "Domain Bucket":"< 1K"
   },
   {
     "Class":"Predicate",
-    "Name":"http:\/\/schema.org\/borrower-input",
+    "Name":"https://schema.org/borrower-input",
     "Domain Bucket":"< 1K"
   },
   {
     "Class":"Predicate",
-    "Name":"http:\/\/schema.org\/borrower-output",
+    "Name":"https://schema.org/borrower-output",
     "Domain Bucket":"< 1K"
   },
   {
     "Class":"Predicate",
-    "Name":"http:\/\/schema.org\/box",
+    "Name":"https://schema.org/box",
     "Domain Bucket":"1K - 10K"
   },
   {
     "Class":"Predicate",
-    "Name":"http:\/\/schema.org\/box-input",
+    "Name":"https://schema.org/box-input",
     "Domain Bucket":"< 1K"
   },
   {
     "Class":"Predicate",
-    "Name":"http:\/\/schema.org\/box-output",
+    "Name":"https://schema.org/box-output",
     "Domain Bucket":"< 1K"
   },
   {
     "Class":"Predicate",
-    "Name":"http:\/\/schema.org\/branch",
+    "Name":"https://schema.org/branch",
     "Domain Bucket":"< 1K"
   },
   {
     "Class":"Predicate",
-    "Name":"http:\/\/schema.org\/branch-input",
+    "Name":"https://schema.org/branch-input",
     "Domain Bucket":"< 1K"
   },
   {
     "Class":"Predicate",
-    "Name":"http:\/\/schema.org\/branch-output",
+    "Name":"https://schema.org/branch-output",
     "Domain Bucket":"< 1K"
   },
   {
     "Class":"Predicate",
-    "Name":"http:\/\/schema.org\/branchCode",
+    "Name":"https://schema.org/branchCode",
     "Domain Bucket":"1K - 10K"
   },
   {
     "Class":"Predicate",
-    "Name":"http:\/\/schema.org\/branchCode-input",
+    "Name":"https://schema.org/branchCode-input",
     "Domain Bucket":"< 1K"
   },
   {
     "Class":"Predicate",
-    "Name":"http:\/\/schema.org\/branchCode-output",
+    "Name":"https://schema.org/branchCode-output",
     "Domain Bucket":"< 1K"
   },
   {
     "Class":"Predicate",
-    "Name":"http:\/\/schema.org\/branchOf",
+    "Name":"https://schema.org/branchOf",
     "Domain Bucket":"10K - 100K"
   },
   {
     "Class":"Predicate",
-    "Name":"http:\/\/schema.org\/branchOf-input",
+    "Name":"https://schema.org/branchOf-input",
     "Domain Bucket":"< 1K"
   },
   {
     "Class":"Predicate",
-    "Name":"http:\/\/schema.org\/branchOf-output",
+    "Name":"https://schema.org/branchOf-output",
     "Domain Bucket":"< 1K"
   },
   {
     "Class":"Predicate",
-    "Name":"http:\/\/schema.org\/brand",
+    "Name":"https://schema.org/brand",
     "Domain Bucket":"1M - 10M"
   },
   {
     "Class":"Predicate",
-    "Name":"http:\/\/schema.org\/brand-input",
+    "Name":"https://schema.org/brand-input",
     "Domain Bucket":"< 1K"
   },
   {
     "Class":"Predicate",
-    "Name":"http:\/\/schema.org\/brand-output",
+    "Name":"https://schema.org/brand-output",
     "Domain Bucket":"< 1K"
   },
   {
     "Class":"Predicate",
-    "Name":"http:\/\/schema.org\/breadcrumb",
+    "Name":"https://schema.org/breadcrumb",
     "Domain Bucket":"10M+"
   },
   {
     "Class":"Predicate",
-    "Name":"http:\/\/schema.org\/breadcrumb-input",
+    "Name":"https://schema.org/breadcrumb-input",
     "Domain Bucket":"< 1K"
   },
   {
     "Class":"Predicate",
-    "Name":"http:\/\/schema.org\/breadcrumb-output",
+    "Name":"https://schema.org/breadcrumb-output",
     "Domain Bucket":"< 1K"
   },
   {
     "Class":"Predicate",
-    "Name":"http:\/\/schema.org\/breastfeedingWarning",
+    "Name":"https://schema.org/breastfeedingWarning",
     "Domain Bucket":"< 1K"
   },
   {
     "Class":"Predicate",
-    "Name":"http:\/\/schema.org\/breastfeedingWarning-input",
+    "Name":"https://schema.org/breastfeedingWarning-input",
     "Domain Bucket":"< 1K"
   },
   {
     "Class":"Predicate",
-    "Name":"http:\/\/schema.org\/breastfeedingWarning-output",
+    "Name":"https://schema.org/breastfeedingWarning-output",
     "Domain Bucket":"< 1K"
   },
   {
     "Class":"Predicate",
-    "Name":"http:\/\/schema.org\/broadcastAffiliateOf",
+    "Name":"https://schema.org/broadcastAffiliateOf",
     "Domain Bucket":"< 1K"
   },
   {
     "Class":"Predicate",
-    "Name":"http:\/\/schema.org\/broadcastAffiliateOf-input",
+    "Name":"https://schema.org/broadcastAffiliateOf-input",
     "Domain Bucket":"< 1K"
   },
   {
     "Class":"Predicate",
-    "Name":"http:\/\/schema.org\/broadcastAffiliateOf-output",
+    "Name":"https://schema.org/broadcastAffiliateOf-output",
     "Domain Bucket":"< 1K"
   },
   {
     "Class":"Predicate",
-    "Name":"http:\/\/schema.org\/broadcastChannelId",
+    "Name":"https://schema.org/broadcastChannelId",
     "Domain Bucket":"< 1K"
   },
   {
     "Class":"Predicate",
-    "Name":"http:\/\/schema.org\/broadcastChannelId-input",
+    "Name":"https://schema.org/broadcastChannelId-input",
     "Domain Bucket":"< 1K"
   },
   {
     "Class":"Predicate",
-    "Name":"http:\/\/schema.org\/broadcastChannelId-output",
+    "Name":"https://schema.org/broadcastChannelId-output",
     "Domain Bucket":"< 1K"
   },
   {
     "Class":"Predicate",
-    "Name":"http:\/\/schema.org\/broadcastDisplayName",
+    "Name":"https://schema.org/broadcastDisplayName",
     "Domain Bucket":"1K - 10K"
   },
   {
     "Class":"Predicate",
-    "Name":"http:\/\/schema.org\/broadcastDisplayName-input",
+    "Name":"https://schema.org/broadcastDisplayName-input",
     "Domain Bucket":"< 1K"
   },
   {
     "Class":"Predicate",
-    "Name":"http:\/\/schema.org\/broadcastDisplayName-output",
+    "Name":"https://schema.org/broadcastDisplayName-output",
     "Domain Bucket":"< 1K"
   },
   {
     "Class":"Predicate",
-    "Name":"http:\/\/schema.org\/broadcastFrequency",
+    "Name":"https://schema.org/broadcastFrequency",
     "Domain Bucket":"1K - 10K"
   },
   {
     "Class":"Predicate",
-    "Name":"http:\/\/schema.org\/broadcastFrequency-input",
+    "Name":"https://schema.org/broadcastFrequency-input",
     "Domain Bucket":"< 1K"
   },
   {
     "Class":"Predicate",
-    "Name":"http:\/\/schema.org\/broadcastFrequency-output",
+    "Name":"https://schema.org/broadcastFrequency-output",
     "Domain Bucket":"< 1K"
   },
   {
     "Class":"Predicate",
-    "Name":"http:\/\/schema.org\/broadcastFrequencyValue",
+    "Name":"https://schema.org/broadcastFrequencyValue",
     "Domain Bucket":"< 1K"
   },
   {
     "Class":"Predicate",
-    "Name":"http:\/\/schema.org\/broadcastFrequencyValue-input",
+    "Name":"https://schema.org/broadcastFrequencyValue-input",
     "Domain Bucket":"< 1K"
   },
   {
     "Class":"Predicate",
-    "Name":"http:\/\/schema.org\/broadcastFrequencyValue-output",
+    "Name":"https://schema.org/broadcastFrequencyValue-output",
     "Domain Bucket":"< 1K"
   },
   {
     "Class":"Predicate",
-    "Name":"http:\/\/schema.org\/broadcastOfEvent",
+    "Name":"https://schema.org/broadcastOfEvent",
     "Domain Bucket":"1K - 10K"
   },
   {
     "Class":"Predicate",
-    "Name":"http:\/\/schema.org\/broadcastOfEvent-input",
+    "Name":"https://schema.org/broadcastOfEvent-input",
     "Domain Bucket":"< 1K"
   },
   {
     "Class":"Predicate",
-    "Name":"http:\/\/schema.org\/broadcastOfEvent-output",
+    "Name":"https://schema.org/broadcastOfEvent-output",
     "Domain Bucket":"< 1K"
   },
   {
     "Class":"Predicate",
-    "Name":"http:\/\/schema.org\/broadcastServiceTier",
+    "Name":"https://schema.org/broadcastServiceTier",
     "Domain Bucket":"< 1K"
   },
   {
     "Class":"Predicate",
-    "Name":"http:\/\/schema.org\/broadcastServiceTier-input",
+    "Name":"https://schema.org/broadcastServiceTier-input",
     "Domain Bucket":"< 1K"
   },
   {
     "Class":"Predicate",
-    "Name":"http:\/\/schema.org\/broadcastServiceTier-output",
+    "Name":"https://schema.org/broadcastServiceTier-output",
     "Domain Bucket":"< 1K"
   },
   {
     "Class":"Predicate",
-    "Name":"http:\/\/schema.org\/broadcastSignalModulation",
+    "Name":"https://schema.org/broadcastSignalModulation",
     "Domain Bucket":"< 1K"
   },
   {
     "Class":"Predicate",
-    "Name":"http:\/\/schema.org\/broadcastSignalModulation-input",
+    "Name":"https://schema.org/broadcastSignalModulation-input",
     "Domain Bucket":"< 1K"
   },
   {
     "Class":"Predicate",
-    "Name":"http:\/\/schema.org\/broadcastSignalModulation-output",
+    "Name":"https://schema.org/broadcastSignalModulation-output",
     "Domain Bucket":"< 1K"
   },
   {
     "Class":"Predicate",
-    "Name":"http:\/\/schema.org\/broadcastSubChannel",
+    "Name":"https://schema.org/broadcastSubChannel",
     "Domain Bucket":"< 1K"
   },
   {
     "Class":"Predicate",
-    "Name":"http:\/\/schema.org\/broadcastSubChannel-input",
+    "Name":"https://schema.org/broadcastSubChannel-input",
     "Domain Bucket":"< 1K"
   },
   {
     "Class":"Predicate",
-    "Name":"http:\/\/schema.org\/broadcastSubChannel-output",
+    "Name":"https://schema.org/broadcastSubChannel-output",
     "Domain Bucket":"< 1K"
   },
   {
     "Class":"Predicate",
-    "Name":"http:\/\/schema.org\/broadcastTimezone",
+    "Name":"https://schema.org/broadcastTimezone",
     "Domain Bucket":"< 1K"
   },
   {
     "Class":"Predicate",
-    "Name":"http:\/\/schema.org\/broadcastTimezone-input",
+    "Name":"https://schema.org/broadcastTimezone-input",
     "Domain Bucket":"< 1K"
   },
   {
     "Class":"Predicate",
-    "Name":"http:\/\/schema.org\/broadcastTimezone-output",
+    "Name":"https://schema.org/broadcastTimezone-output",
     "Domain Bucket":"< 1K"
   },
   {
     "Class":"Predicate",
-    "Name":"http:\/\/schema.org\/broadcaster",
+    "Name":"https://schema.org/broadcaster",
     "Domain Bucket":"< 1K"
   },
   {
     "Class":"Predicate",
-    "Name":"http:\/\/schema.org\/broadcaster-input",
+    "Name":"https://schema.org/broadcaster-input",
     "Domain Bucket":"< 1K"
   },
   {
     "Class":"Predicate",
-    "Name":"http:\/\/schema.org\/broadcaster-output",
+    "Name":"https://schema.org/broadcaster-output",
     "Domain Bucket":"< 1K"
   },
   {
     "Class":"Predicate",
-    "Name":"http:\/\/schema.org\/broker",
+    "Name":"https://schema.org/broker",
     "Domain Bucket":"1K - 10K"
   },
   {
     "Class":"Predicate",
-    "Name":"http:\/\/schema.org\/broker-input",
+    "Name":"https://schema.org/broker-input",
     "Domain Bucket":"< 1K"
   },
   {
     "Class":"Predicate",
-    "Name":"http:\/\/schema.org\/broker-output",
+    "Name":"https://schema.org/broker-output",
     "Domain Bucket":"< 1K"
   },
   {
     "Class":"Predicate",
-    "Name":"http:\/\/schema.org\/browserRequirements",
+    "Name":"https://schema.org/browserRequirements",
     "Domain Bucket":"10K - 100K"
   },
   {
     "Class":"Predicate",
-    "Name":"http:\/\/schema.org\/browserRequirements-input",
+    "Name":"https://schema.org/browserRequirements-input",
     "Domain Bucket":"< 1K"
   },
   {
     "Class":"Predicate",
-    "Name":"http:\/\/schema.org\/browserRequirements-output",
+    "Name":"https://schema.org/browserRequirements-output",
     "Domain Bucket":"< 1K"
   },
   {
     "Class":"Predicate",
-    "Name":"http:\/\/schema.org\/busName",
+    "Name":"https://schema.org/busName",
     "Domain Bucket":"< 1K"
   },
   {
     "Class":"Predicate",
-    "Name":"http:\/\/schema.org\/busName-input",
+    "Name":"https://schema.org/busName-input",
     "Domain Bucket":"< 1K"
   },
   {
     "Class":"Predicate",
-    "Name":"http:\/\/schema.org\/busName-output",
+    "Name":"https://schema.org/busName-output",
     "Domain Bucket":"< 1K"
   },
   {
     "Class":"Predicate",
-    "Name":"http:\/\/schema.org\/busNumber",
+    "Name":"https://schema.org/busNumber",
     "Domain Bucket":"< 1K"
   },
   {
     "Class":"Predicate",
-    "Name":"http:\/\/schema.org\/busNumber-input",
+    "Name":"https://schema.org/busNumber-input",
     "Domain Bucket":"< 1K"
   },
   {
     "Class":"Predicate",
-    "Name":"http:\/\/schema.org\/busNumber-output",
+    "Name":"https://schema.org/busNumber-output",
     "Domain Bucket":"< 1K"
   },
   {
     "Class":"Predicate",
-    "Name":"http:\/\/schema.org\/businessDays",
+    "Name":"https://schema.org/businessDays",
     "Domain Bucket":"10K - 100K"
   },
   {
     "Class":"Predicate",
-    "Name":"http:\/\/schema.org\/businessDays-input",
+    "Name":"https://schema.org/businessDays-input",
     "Domain Bucket":"< 1K"
   },
   {
     "Class":"Predicate",
-    "Name":"http:\/\/schema.org\/businessDays-output",
+    "Name":"https://schema.org/businessDays-output",
     "Domain Bucket":"< 1K"
   },
   {
     "Class":"Predicate",
-    "Name":"http:\/\/schema.org\/businessFunction",
+    "Name":"https://schema.org/businessFunction",
     "Domain Bucket":"1M - 10M"
   },
   {
     "Class":"Predicate",
-    "Name":"http:\/\/schema.org\/businessFunction-input",
+    "Name":"https://schema.org/businessFunction-input",
     "Domain Bucket":"< 1K"
   },
   {
     "Class":"Predicate",
-    "Name":"http:\/\/schema.org\/businessFunction-output",
+    "Name":"https://schema.org/businessFunction-output",
     "Domain Bucket":"< 1K"
   },
   {
     "Class":"Predicate",
-    "Name":"http:\/\/schema.org\/buyer",
+    "Name":"https://schema.org/buyer",
     "Domain Bucket":"< 1K"
   },
   {
     "Class":"Predicate",
-    "Name":"http:\/\/schema.org\/buyer-input",
+    "Name":"https://schema.org/buyer-input",
     "Domain Bucket":"< 1K"
   },
   {
     "Class":"Predicate",
-    "Name":"http:\/\/schema.org\/buyer-output",
+    "Name":"https://schema.org/buyer-output",
     "Domain Bucket":"< 1K"
   },
   {
     "Class":"Predicate",
-    "Name":"http:\/\/schema.org\/byArtist",
+    "Name":"https://schema.org/byArtist",
     "Domain Bucket":"10K - 100K"
   },
   {
     "Class":"Predicate",
-    "Name":"http:\/\/schema.org\/byArtist-input",
+    "Name":"https://schema.org/byArtist-input",
     "Domain Bucket":"< 1K"
   },
   {
     "Class":"Predicate",
-    "Name":"http:\/\/schema.org\/byArtist-output",
+    "Name":"https://schema.org/byArtist-output",
     "Domain Bucket":"< 1K"
   },
   {
     "Class":"Predicate",
-    "Name":"http:\/\/schema.org\/byDay",
+    "Name":"https://schema.org/byDay",
     "Domain Bucket":"1K - 10K"
   },
   {
     "Class":"Predicate",
-    "Name":"http:\/\/schema.org\/byDay-input",
+    "Name":"https://schema.org/byDay-input",
     "Domain Bucket":"< 1K"
   },
   {
     "Class":"Predicate",
-    "Name":"http:\/\/schema.org\/byDay-output",
+    "Name":"https://schema.org/byDay-output",
     "Domain Bucket":"< 1K"
   },
   {
     "Class":"Predicate",
-    "Name":"http:\/\/schema.org\/byMonth",
+    "Name":"https://schema.org/byMonth",
     "Domain Bucket":"< 1K"
   },
   {
     "Class":"Predicate",
-    "Name":"http:\/\/schema.org\/byMonth-input",
+    "Name":"https://schema.org/byMonth-input",
     "Domain Bucket":"< 1K"
   },
   {
     "Class":"Predicate",
-    "Name":"http:\/\/schema.org\/byMonth-output",
+    "Name":"https://schema.org/byMonth-output",
     "Domain Bucket":"< 1K"
   },
   {
     "Class":"Predicate",
-    "Name":"http:\/\/schema.org\/byMonthDay",
+    "Name":"https://schema.org/byMonthDay",
     "Domain Bucket":"< 1K"
   },
   {
     "Class":"Predicate",
-    "Name":"http:\/\/schema.org\/byMonthDay-input",
+    "Name":"https://schema.org/byMonthDay-input",
     "Domain Bucket":"< 1K"
   },
   {
     "Class":"Predicate",
-    "Name":"http:\/\/schema.org\/byMonthDay-output",
+    "Name":"https://schema.org/byMonthDay-output",
     "Domain Bucket":"< 1K"
   },
   {
     "Class":"Predicate",
-    "Name":"http:\/\/schema.org\/byMonthWeek",
+    "Name":"https://schema.org/byMonthWeek",
     "Domain Bucket":"< 1K"
   },
   {
     "Class":"Predicate",
-    "Name":"http:\/\/schema.org\/byMonthWeek-input",
+    "Name":"https://schema.org/byMonthWeek-input",
     "Domain Bucket":"< 1K"
   },
   {
     "Class":"Predicate",
-    "Name":"http:\/\/schema.org\/byMonthWeek-output",
+    "Name":"https://schema.org/byMonthWeek-output",
     "Domain Bucket":"< 1K"
   },
   {
     "Class":"Predicate",
-    "Name":"http:\/\/schema.org\/callSign",
+    "Name":"https://schema.org/callSign",
     "Domain Bucket":"< 1K"
   },
   {
     "Class":"Predicate",
-    "Name":"http:\/\/schema.org\/callSign-input",
+    "Name":"https://schema.org/callSign-input",
     "Domain Bucket":"< 1K"
   },
   {
     "Class":"Predicate",
-    "Name":"http:\/\/schema.org\/callSign-output",
+    "Name":"https://schema.org/callSign-output",
     "Domain Bucket":"< 1K"
   },
   {
     "Class":"Predicate",
-    "Name":"http:\/\/schema.org\/calories",
+    "Name":"https://schema.org/calories",
     "Domain Bucket":"10K - 100K"
   },
   {
     "Class":"Predicate",
-    "Name":"http:\/\/schema.org\/calories-input",
+    "Name":"https://schema.org/calories-input",
     "Domain Bucket":"< 1K"
   },
   {
     "Class":"Predicate",
-    "Name":"http:\/\/schema.org\/calories-output",
+    "Name":"https://schema.org/calories-output",
     "Domain Bucket":"< 1K"
   },
   {
     "Class":"Predicate",
-    "Name":"http:\/\/schema.org\/candidate",
+    "Name":"https://schema.org/candidate",
     "Domain Bucket":"< 1K"
   },
   {
     "Class":"Predicate",
-    "Name":"http:\/\/schema.org\/candidate-input",
+    "Name":"https://schema.org/candidate-input",
     "Domain Bucket":"< 1K"
   },
   {
     "Class":"Predicate",
-    "Name":"http:\/\/schema.org\/candidate-output",
+    "Name":"https://schema.org/candidate-output",
     "Domain Bucket":"< 1K"
   },
   {
     "Class":"Predicate",
-    "Name":"http:\/\/schema.org\/caption",
+    "Name":"https://schema.org/caption",
     "Domain Bucket":"10M+"
   },
   {
     "Class":"Predicate",
-    "Name":"http:\/\/schema.org\/caption-input",
+    "Name":"https://schema.org/caption-input",
     "Domain Bucket":"< 1K"
   },
   {
     "Class":"Predicate",
-    "Name":"http:\/\/schema.org\/caption-output",
+    "Name":"https://schema.org/caption-output",
     "Domain Bucket":"< 1K"
   },
   {
     "Class":"Predicate",
-    "Name":"http:\/\/schema.org\/carbohydrateContent",
+    "Name":"https://schema.org/carbohydrateContent",
     "Domain Bucket":"10K - 100K"
   },
   {
     "Class":"Predicate",
-    "Name":"http:\/\/schema.org\/carbohydrateContent-input",
+    "Name":"https://schema.org/carbohydrateContent-input",
     "Domain Bucket":"< 1K"
   },
   {
     "Class":"Predicate",
-    "Name":"http:\/\/schema.org\/carbohydrateContent-output",
+    "Name":"https://schema.org/carbohydrateContent-output",
     "Domain Bucket":"< 1K"
   },
   {
     "Class":"Predicate",
-    "Name":"http:\/\/schema.org\/cargoVolume",
+    "Name":"https://schema.org/cargoVolume",
     "Domain Bucket":"1K - 10K"
   },
   {
     "Class":"Predicate",
-    "Name":"http:\/\/schema.org\/cargoVolume-input",
+    "Name":"https://schema.org/cargoVolume-input",
     "Domain Bucket":"< 1K"
   },
   {
     "Class":"Predicate",
-    "Name":"http:\/\/schema.org\/cargoVolume-output",
+    "Name":"https://schema.org/cargoVolume-output",
     "Domain Bucket":"< 1K"
   },
   {
     "Class":"Predicate",
-    "Name":"http:\/\/schema.org\/carrier",
+    "Name":"https://schema.org/carrier",
     "Domain Bucket":"< 1K"
   },
   {
     "Class":"Predicate",
-    "Name":"http:\/\/schema.org\/carrier-input",
+    "Name":"https://schema.org/carrier-input",
     "Domain Bucket":"< 1K"
   },
   {
     "Class":"Predicate",
-    "Name":"http:\/\/schema.org\/carrier-output",
+    "Name":"https://schema.org/carrier-output",
     "Domain Bucket":"< 1K"
   },
   {
     "Class":"Predicate",
-    "Name":"http:\/\/schema.org\/carrierRequirements",
+    "Name":"https://schema.org/carrierRequirements",
     "Domain Bucket":"< 1K"
   },
   {
     "Class":"Predicate",
-    "Name":"http:\/\/schema.org\/carrierRequirements-input",
+    "Name":"https://schema.org/carrierRequirements-input",
     "Domain Bucket":"< 1K"
   },
   {
     "Class":"Predicate",
-    "Name":"http:\/\/schema.org\/carrierRequirements-output",
+    "Name":"https://schema.org/carrierRequirements-output",
     "Domain Bucket":"< 1K"
   },
   {
     "Class":"Predicate",
-    "Name":"http:\/\/schema.org\/cashBack",
+    "Name":"https://schema.org/cashBack",
     "Domain Bucket":"< 1K"
   },
   {
     "Class":"Predicate",
-    "Name":"http:\/\/schema.org\/cashBack-input",
+    "Name":"https://schema.org/cashBack-input",
     "Domain Bucket":"< 1K"
   },
   {
     "Class":"Predicate",
-    "Name":"http:\/\/schema.org\/cashBack-output",
+    "Name":"https://schema.org/cashBack-output",
     "Domain Bucket":"< 1K"
   },
   {
     "Class":"Predicate",
-    "Name":"http:\/\/schema.org\/catalog",
+    "Name":"https://schema.org/catalog",
     "Domain Bucket":"< 1K"
   },
   {
     "Class":"Predicate",
-    "Name":"http:\/\/schema.org\/catalog-input",
+    "Name":"https://schema.org/catalog-input",
     "Domain Bucket":"< 1K"
   },
   {
     "Class":"Predicate",
-    "Name":"http:\/\/schema.org\/catalog-output",
+    "Name":"https://schema.org/catalog-output",
     "Domain Bucket":"< 1K"
   },
   {
     "Class":"Predicate",
-    "Name":"http:\/\/schema.org\/catalogNumber",
+    "Name":"https://schema.org/catalogNumber",
     "Domain Bucket":"< 1K"
   },
   {
     "Class":"Predicate",
-    "Name":"http:\/\/schema.org\/catalogNumber-input",
+    "Name":"https://schema.org/catalogNumber-input",
     "Domain Bucket":"< 1K"
   },
   {
     "Class":"Predicate",
-    "Name":"http:\/\/schema.org\/catalogNumber-output",
+    "Name":"https://schema.org/catalogNumber-output",
     "Domain Bucket":"< 1K"
   },
   {
     "Class":"Predicate",
-    "Name":"http:\/\/schema.org\/category",
+    "Name":"https://schema.org/category",
     "Domain Bucket":"1M - 10M"
   },
   {
     "Class":"Predicate",
-    "Name":"http:\/\/schema.org\/category-input",
+    "Name":"https://schema.org/category-input",
     "Domain Bucket":"< 1K"
   },
   {
     "Class":"Predicate",
-    "Name":"http:\/\/schema.org\/category-output",
+    "Name":"https://schema.org/category-output",
     "Domain Bucket":"< 1K"
   },
   {
     "Class":"Predicate",
-    "Name":"http:\/\/schema.org\/cause",
+    "Name":"https://schema.org/cause",
     "Domain Bucket":"1K - 10K"
   },
   {
     "Class":"Predicate",
-    "Name":"http:\/\/schema.org\/cause-input",
+    "Name":"https://schema.org/cause-input",
     "Domain Bucket":"< 1K"
   },
   {
     "Class":"Predicate",
-    "Name":"http:\/\/schema.org\/cause-output",
+    "Name":"https://schema.org/cause-output",
     "Domain Bucket":"< 1K"
   },
   {
     "Class":"Predicate",
-    "Name":"http:\/\/schema.org\/causeOf",
+    "Name":"https://schema.org/causeOf",
     "Domain Bucket":"< 1K"
   },
   {
     "Class":"Predicate",
-    "Name":"http:\/\/schema.org\/causeOf-input",
+    "Name":"https://schema.org/causeOf-input",
     "Domain Bucket":"< 1K"
   },
   {
     "Class":"Predicate",
-    "Name":"http:\/\/schema.org\/causeOf-output",
+    "Name":"https://schema.org/causeOf-output",
     "Domain Bucket":"< 1K"
   },
   {
     "Class":"Predicate",
-    "Name":"http:\/\/schema.org\/ccRecipient",
+    "Name":"https://schema.org/ccRecipient",
     "Domain Bucket":"< 1K"
   },
   {
     "Class":"Predicate",
-    "Name":"http:\/\/schema.org\/ccRecipient-input",
+    "Name":"https://schema.org/ccRecipient-input",
     "Domain Bucket":"< 1K"
   },
   {
     "Class":"Predicate",
-    "Name":"http:\/\/schema.org\/ccRecipient-output",
+    "Name":"https://schema.org/ccRecipient-output",
     "Domain Bucket":"< 1K"
   },
   {
     "Class":"Predicate",
-    "Name":"http:\/\/schema.org\/certificationIdentification",
+    "Name":"https://schema.org/certificationIdentification",
     "Domain Bucket":"1K - 10K"
   },
   {
     "Class":"Predicate",
-    "Name":"http:\/\/schema.org\/certificationIdentification-input",
+    "Name":"https://schema.org/certificationIdentification-input",
     "Domain Bucket":"< 1K"
   },
   {
     "Class":"Predicate",
-    "Name":"http:\/\/schema.org\/certificationIdentification-output",
+    "Name":"https://schema.org/certificationIdentification-output",
     "Domain Bucket":"< 1K"
   },
   {
     "Class":"Predicate",
-    "Name":"http:\/\/schema.org\/certificationRating",
+    "Name":"https://schema.org/certificationRating",
     "Domain Bucket":"< 1K"
   },
   {
     "Class":"Predicate",
-    "Name":"http:\/\/schema.org\/certificationRating-input",
+    "Name":"https://schema.org/certificationRating-input",
     "Domain Bucket":"< 1K"
   },
   {
     "Class":"Predicate",
-    "Name":"http:\/\/schema.org\/certificationRating-output",
+    "Name":"https://schema.org/certificationRating-output",
     "Domain Bucket":"< 1K"
   },
   {
     "Class":"Predicate",
-    "Name":"http:\/\/schema.org\/certificationStatus",
+    "Name":"https://schema.org/certificationStatus",
     "Domain Bucket":"1K - 10K"
   },
   {
     "Class":"Predicate",
-    "Name":"http:\/\/schema.org\/certificationStatus-input",
+    "Name":"https://schema.org/certificationStatus-input",
     "Domain Bucket":"< 1K"
   },
   {
     "Class":"Predicate",
-    "Name":"http:\/\/schema.org\/certificationStatus-output",
+    "Name":"https://schema.org/certificationStatus-output",
     "Domain Bucket":"< 1K"
   },
   {
     "Class":"Predicate",
-    "Name":"http:\/\/schema.org\/character",
+    "Name":"https://schema.org/character",
     "Domain Bucket":"1K - 10K"
   },
   {
     "Class":"Predicate",
-    "Name":"http:\/\/schema.org\/character-input",
+    "Name":"https://schema.org/character-input",
     "Domain Bucket":"< 1K"
   },
   {
     "Class":"Predicate",
-    "Name":"http:\/\/schema.org\/character-output",
+    "Name":"https://schema.org/character-output",
     "Domain Bucket":"< 1K"
   },
   {
     "Class":"Predicate",
-    "Name":"http:\/\/schema.org\/characterAttribute",
+    "Name":"https://schema.org/characterAttribute",
     "Domain Bucket":"< 1K"
   },
   {
     "Class":"Predicate",
-    "Name":"http:\/\/schema.org\/characterAttribute-input",
+    "Name":"https://schema.org/characterAttribute-input",
     "Domain Bucket":"< 1K"
   },
   {
     "Class":"Predicate",
-    "Name":"http:\/\/schema.org\/characterAttribute-output",
+    "Name":"https://schema.org/characterAttribute-output",
     "Domain Bucket":"< 1K"
   },
   {
     "Class":"Predicate",
-    "Name":"http:\/\/schema.org\/characterName",
+    "Name":"https://schema.org/characterName",
     "Domain Bucket":"< 1K"
   },
   {
     "Class":"Predicate",
-    "Name":"http:\/\/schema.org\/characterName-input",
+    "Name":"https://schema.org/characterName-input",
     "Domain Bucket":"< 1K"
   },
   {
     "Class":"Predicate",
-    "Name":"http:\/\/schema.org\/characterName-output",
+    "Name":"https://schema.org/characterName-output",
     "Domain Bucket":"< 1K"
   },
   {
     "Class":"Predicate",
-    "Name":"http:\/\/schema.org\/cheatCode",
+    "Name":"https://schema.org/cheatCode",
     "Domain Bucket":"< 1K"
   },
   {
     "Class":"Predicate",
-    "Name":"http:\/\/schema.org\/cheatCode-input",
+    "Name":"https://schema.org/cheatCode-input",
     "Domain Bucket":"< 1K"
   },
   {
     "Class":"Predicate",
-    "Name":"http:\/\/schema.org\/cheatCode-output",
+    "Name":"https://schema.org/cheatCode-output",
     "Domain Bucket":"< 1K"
   },
   {
     "Class":"Predicate",
-    "Name":"http:\/\/schema.org\/checkinTime",
+    "Name":"https://schema.org/checkinTime",
     "Domain Bucket":"10K - 100K"
   },
   {
     "Class":"Predicate",
-    "Name":"http:\/\/schema.org\/checkinTime-input",
+    "Name":"https://schema.org/checkinTime-input",
     "Domain Bucket":"< 1K"
   },
   {
     "Class":"Predicate",
-    "Name":"http:\/\/schema.org\/checkinTime-output",
+    "Name":"https://schema.org/checkinTime-output",
     "Domain Bucket":"< 1K"
   },
   {
     "Class":"Predicate",
-    "Name":"http:\/\/schema.org\/checkoutPageURLTemplate",
+    "Name":"https://schema.org/checkoutPageURLTemplate",
     "Domain Bucket":"10K - 100K"
   },
   {
     "Class":"Predicate",
-    "Name":"http:\/\/schema.org\/checkoutPageURLTemplate-input",
+    "Name":"https://schema.org/checkoutPageURLTemplate-input",
     "Domain Bucket":"< 1K"
   },
   {
     "Class":"Predicate",
-    "Name":"http:\/\/schema.org\/checkoutPageURLTemplate-output",
+    "Name":"https://schema.org/checkoutPageURLTemplate-output",
     "Domain Bucket":"< 1K"
   },
   {
     "Class":"Predicate",
-    "Name":"http:\/\/schema.org\/checkoutTime",
+    "Name":"https://schema.org/checkoutTime",
     "Domain Bucket":"10K - 100K"
   },
   {
     "Class":"Predicate",
-    "Name":"http:\/\/schema.org\/checkoutTime-input",
+    "Name":"https://schema.org/checkoutTime-input",
     "Domain Bucket":"< 1K"
   },
   {
     "Class":"Predicate",
-    "Name":"http:\/\/schema.org\/checkoutTime-output",
+    "Name":"https://schema.org/checkoutTime-output",
     "Domain Bucket":"< 1K"
   },
   {
     "Class":"Predicate",
-    "Name":"http:\/\/schema.org\/chemicalComposition",
+    "Name":"https://schema.org/chemicalComposition",
     "Domain Bucket":"< 1K"
   },
   {
     "Class":"Predicate",
-    "Name":"http:\/\/schema.org\/chemicalComposition-input",
+    "Name":"https://schema.org/chemicalComposition-input",
     "Domain Bucket":"< 1K"
   },
   {
     "Class":"Predicate",
-    "Name":"http:\/\/schema.org\/chemicalComposition-output",
+    "Name":"https://schema.org/chemicalComposition-output",
     "Domain Bucket":"< 1K"
   },
   {
     "Class":"Predicate",
-    "Name":"http:\/\/schema.org\/chemicalRole",
+    "Name":"https://schema.org/chemicalRole",
     "Domain Bucket":"< 1K"
   },
   {
     "Class":"Predicate",
-    "Name":"http:\/\/schema.org\/chemicalRole-input",
+    "Name":"https://schema.org/chemicalRole-input",
     "Domain Bucket":"< 1K"
   },
   {
     "Class":"Predicate",
-    "Name":"http:\/\/schema.org\/chemicalRole-output",
+    "Name":"https://schema.org/chemicalRole-output",
     "Domain Bucket":"< 1K"
   },
   {
     "Class":"Predicate",
-    "Name":"http:\/\/schema.org\/childMaxAge",
+    "Name":"https://schema.org/childMaxAge",
     "Domain Bucket":"< 1K"
   },
   {
     "Class":"Predicate",
-    "Name":"http:\/\/schema.org\/childMaxAge-input",
+    "Name":"https://schema.org/childMaxAge-input",
     "Domain Bucket":"< 1K"
   },
   {
     "Class":"Predicate",
-    "Name":"http:\/\/schema.org\/childMaxAge-output",
+    "Name":"https://schema.org/childMaxAge-output",
     "Domain Bucket":"< 1K"
   },
   {
     "Class":"Predicate",
-    "Name":"http:\/\/schema.org\/childMinAge",
+    "Name":"https://schema.org/childMinAge",
     "Domain Bucket":"< 1K"
   },
   {
     "Class":"Predicate",
-    "Name":"http:\/\/schema.org\/childMinAge-input",
+    "Name":"https://schema.org/childMinAge-input",
     "Domain Bucket":"< 1K"
   },
   {
     "Class":"Predicate",
-    "Name":"http:\/\/schema.org\/childMinAge-output",
+    "Name":"https://schema.org/childMinAge-output",
     "Domain Bucket":"< 1K"
   },
   {
     "Class":"Predicate",
-    "Name":"http:\/\/schema.org\/childTaxon",
+    "Name":"https://schema.org/childTaxon",
     "Domain Bucket":"< 1K"
   },
   {
     "Class":"Predicate",
-    "Name":"http:\/\/schema.org\/childTaxon-input",
+    "Name":"https://schema.org/childTaxon-input",
     "Domain Bucket":"< 1K"
   },
   {
     "Class":"Predicate",
-    "Name":"http:\/\/schema.org\/childTaxon-output",
+    "Name":"https://schema.org/childTaxon-output",
     "Domain Bucket":"< 1K"
   },
   {
     "Class":"Predicate",
-    "Name":"http:\/\/schema.org\/children",
+    "Name":"https://schema.org/children",
     "Domain Bucket":"1K - 10K"
   },
   {
     "Class":"Predicate",
-    "Name":"http:\/\/schema.org\/children-input",
+    "Name":"https://schema.org/children-input",
     "Domain Bucket":"< 1K"
   },
   {
     "Class":"Predicate",
-    "Name":"http:\/\/schema.org\/children-output",
+    "Name":"https://schema.org/children-output",
     "Domain Bucket":"< 1K"
   },
   {
     "Class":"Predicate",
-    "Name":"http:\/\/schema.org\/cholesterolContent",
+    "Name":"https://schema.org/cholesterolContent",
     "Domain Bucket":"10K - 100K"
   },
   {
     "Class":"Predicate",
-    "Name":"http:\/\/schema.org\/cholesterolContent-input",
+    "Name":"https://schema.org/cholesterolContent-input",
     "Domain Bucket":"< 1K"
   },
   {
     "Class":"Predicate",
-    "Name":"http:\/\/schema.org\/cholesterolContent-output",
+    "Name":"https://schema.org/cholesterolContent-output",
     "Domain Bucket":"< 1K"
   },
   {
     "Class":"Predicate",
-    "Name":"http:\/\/schema.org\/circle",
+    "Name":"https://schema.org/circle",
     "Domain Bucket":"1K - 10K"
   },
   {
     "Class":"Predicate",
-    "Name":"http:\/\/schema.org\/circle-input",
+    "Name":"https://schema.org/circle-input",
     "Domain Bucket":"< 1K"
   },
   {
     "Class":"Predicate",
-    "Name":"http:\/\/schema.org\/circle-output",
+    "Name":"https://schema.org/circle-output",
     "Domain Bucket":"< 1K"
   },
   {
     "Class":"Predicate",
-    "Name":"http:\/\/schema.org\/citation",
+    "Name":"https://schema.org/citation",
     "Domain Bucket":"10K - 100K"
   },
   {
     "Class":"Predicate",
-    "Name":"http:\/\/schema.org\/citation-input",
+    "Name":"https://schema.org/citation-input",
     "Domain Bucket":"< 1K"
   },
   {
     "Class":"Predicate",
-    "Name":"http:\/\/schema.org\/citation-output",
+    "Name":"https://schema.org/citation-output",
     "Domain Bucket":"< 1K"
   },
   {
     "Class":"Predicate",
-    "Name":"http:\/\/schema.org\/claimInterpreter",
+    "Name":"https://schema.org/claimInterpreter",
     "Domain Bucket":"< 1K"
   },
   {
     "Class":"Predicate",
-    "Name":"http:\/\/schema.org\/claimInterpreter-input",
+    "Name":"https://schema.org/claimInterpreter-input",
     "Domain Bucket":"< 1K"
   },
   {
     "Class":"Predicate",
-    "Name":"http:\/\/schema.org\/claimInterpreter-output",
+    "Name":"https://schema.org/claimInterpreter-output",
     "Domain Bucket":"< 1K"
   },
   {
     "Class":"Predicate",
-    "Name":"http:\/\/schema.org\/claimReviewed",
+    "Name":"https://schema.org/claimReviewed",
     "Domain Bucket":"1K - 10K"
   },
   {
     "Class":"Predicate",
-    "Name":"http:\/\/schema.org\/claimReviewed-input",
+    "Name":"https://schema.org/claimReviewed-input",
     "Domain Bucket":"< 1K"
   },
   {
     "Class":"Predicate",
-    "Name":"http:\/\/schema.org\/claimReviewed-output",
+    "Name":"https://schema.org/claimReviewed-output",
     "Domain Bucket":"< 1K"
   },
   {
     "Class":"Predicate",
-    "Name":"http:\/\/schema.org\/clincalPharmacology",
+    "Name":"https://schema.org/clincalPharmacology",
     "Domain Bucket":"< 1K"
   },
   {
     "Class":"Predicate",
-    "Name":"http:\/\/schema.org\/clincalPharmacology-input",
+    "Name":"https://schema.org/clincalPharmacology-input",
     "Domain Bucket":"< 1K"
   },
   {
     "Class":"Predicate",
-    "Name":"http:\/\/schema.org\/clincalPharmacology-output",
+    "Name":"https://schema.org/clincalPharmacology-output",
     "Domain Bucket":"< 1K"
   },
   {
     "Class":"Predicate",
-    "Name":"http:\/\/schema.org\/clinicalPharmacology",
+    "Name":"https://schema.org/clinicalPharmacology",
     "Domain Bucket":"< 1K"
   },
   {
     "Class":"Predicate",
-    "Name":"http:\/\/schema.org\/clinicalPharmacology-input",
+    "Name":"https://schema.org/clinicalPharmacology-input",
     "Domain Bucket":"< 1K"
   },
   {
     "Class":"Predicate",
-    "Name":"http:\/\/schema.org\/clinicalPharmacology-output",
+    "Name":"https://schema.org/clinicalPharmacology-output",
     "Domain Bucket":"< 1K"
   },
   {
     "Class":"Predicate",
-    "Name":"http:\/\/schema.org\/clipNumber",
+    "Name":"https://schema.org/clipNumber",
     "Domain Bucket":"< 1K"
   },
   {
     "Class":"Predicate",
-    "Name":"http:\/\/schema.org\/clipNumber-input",
+    "Name":"https://schema.org/clipNumber-input",
     "Domain Bucket":"< 1K"
   },
   {
     "Class":"Predicate",
-    "Name":"http:\/\/schema.org\/clipNumber-output",
+    "Name":"https://schema.org/clipNumber-output",
     "Domain Bucket":"< 1K"
   },
   {
     "Class":"Predicate",
-    "Name":"http:\/\/schema.org\/closes",
+    "Name":"https://schema.org/closes",
     "Domain Bucket":"1M - 10M"
   },
   {
     "Class":"Predicate",
-    "Name":"http:\/\/schema.org\/closes-input",
+    "Name":"https://schema.org/closes-input",
     "Domain Bucket":"< 1K"
   },
   {
     "Class":"Predicate",
-    "Name":"http:\/\/schema.org\/closes-output",
+    "Name":"https://schema.org/closes-output",
     "Domain Bucket":"< 1K"
   },
   {
     "Class":"Predicate",
-    "Name":"http:\/\/schema.org\/coach",
+    "Name":"https://schema.org/coach",
     "Domain Bucket":"1K - 10K"
   },
   {
     "Class":"Predicate",
-    "Name":"http:\/\/schema.org\/coach-input",
+    "Name":"https://schema.org/coach-input",
     "Domain Bucket":"< 1K"
   },
   {
     "Class":"Predicate",
-    "Name":"http:\/\/schema.org\/coach-output",
+    "Name":"https://schema.org/coach-output",
     "Domain Bucket":"< 1K"
   },
   {
     "Class":"Predicate",
-    "Name":"http:\/\/schema.org\/code",
+    "Name":"https://schema.org/code",
     "Domain Bucket":"1K - 10K"
   },
   {
     "Class":"Predicate",
-    "Name":"http:\/\/schema.org\/code-input",
+    "Name":"https://schema.org/code-input",
     "Domain Bucket":"< 1K"
   },
   {
     "Class":"Predicate",
-    "Name":"http:\/\/schema.org\/code-output",
+    "Name":"https://schema.org/code-output",
     "Domain Bucket":"< 1K"
   },
   {
     "Class":"Predicate",
-    "Name":"http:\/\/schema.org\/codeRepository",
+    "Name":"https://schema.org/codeRepository",
     "Domain Bucket":"1K - 10K"
   },
   {
     "Class":"Predicate",
-    "Name":"http:\/\/schema.org\/codeRepository-input",
+    "Name":"https://schema.org/codeRepository-input",
     "Domain Bucket":"< 1K"
   },
   {
     "Class":"Predicate",
-    "Name":"http:\/\/schema.org\/codeRepository-output",
+    "Name":"https://schema.org/codeRepository-output",
     "Domain Bucket":"< 1K"
   },
   {
     "Class":"Predicate",
-    "Name":"http:\/\/schema.org\/codeSampleType",
+    "Name":"https://schema.org/codeSampleType",
     "Domain Bucket":"< 1K"
   },
   {
     "Class":"Predicate",
-    "Name":"http:\/\/schema.org\/codeSampleType-input",
+    "Name":"https://schema.org/codeSampleType-input",
     "Domain Bucket":"< 1K"
   },
   {
     "Class":"Predicate",
-    "Name":"http:\/\/schema.org\/codeSampleType-output",
+    "Name":"https://schema.org/codeSampleType-output",
     "Domain Bucket":"< 1K"
   },
   {
     "Class":"Predicate",
-    "Name":"http:\/\/schema.org\/codeValue",
+    "Name":"https://schema.org/codeValue",
     "Domain Bucket":"1K - 10K"
   },
   {
     "Class":"Predicate",
-    "Name":"http:\/\/schema.org\/codeValue-input",
+    "Name":"https://schema.org/codeValue-input",
     "Domain Bucket":"< 1K"
   },
   {
     "Class":"Predicate",
-    "Name":"http:\/\/schema.org\/codeValue-output",
+    "Name":"https://schema.org/codeValue-output",
     "Domain Bucket":"< 1K"
   },
   {
     "Class":"Predicate",
-    "Name":"http:\/\/schema.org\/codingSystem",
+    "Name":"https://schema.org/codingSystem",
     "Domain Bucket":"1K - 10K"
   },
   {
     "Class":"Predicate",
-    "Name":"http:\/\/schema.org\/codingSystem-input",
+    "Name":"https://schema.org/codingSystem-input",
     "Domain Bucket":"< 1K"
   },
   {
     "Class":"Predicate",
-    "Name":"http:\/\/schema.org\/codingSystem-output",
+    "Name":"https://schema.org/codingSystem-output",
     "Domain Bucket":"< 1K"
   },
   {
     "Class":"Predicate",
-    "Name":"http:\/\/schema.org\/colleague",
+    "Name":"https://schema.org/colleague",
     "Domain Bucket":"1K - 10K"
   },
   {
     "Class":"Predicate",
-    "Name":"http:\/\/schema.org\/colleague-input",
+    "Name":"https://schema.org/colleague-input",
     "Domain Bucket":"< 1K"
   },
   {
     "Class":"Predicate",
-    "Name":"http:\/\/schema.org\/colleague-output",
+    "Name":"https://schema.org/colleague-output",
     "Domain Bucket":"< 1K"
   },
   {
     "Class":"Predicate",
-    "Name":"http:\/\/schema.org\/colleagues",
+    "Name":"https://schema.org/colleagues",
     "Domain Bucket":"< 1K"
   },
   {
     "Class":"Predicate",
-    "Name":"http:\/\/schema.org\/colleagues-input",
+    "Name":"https://schema.org/colleagues-input",
     "Domain Bucket":"< 1K"
   },
   {
     "Class":"Predicate",
-    "Name":"http:\/\/schema.org\/colleagues-output",
+    "Name":"https://schema.org/colleagues-output",
     "Domain Bucket":"< 1K"
   },
   {
     "Class":"Predicate",
-    "Name":"http:\/\/schema.org\/collection",
+    "Name":"https://schema.org/collection",
     "Domain Bucket":"< 1K"
   },
   {
     "Class":"Predicate",
-    "Name":"http:\/\/schema.org\/collection-input",
+    "Name":"https://schema.org/collection-input",
     "Domain Bucket":"< 1K"
   },
   {
     "Class":"Predicate",
-    "Name":"http:\/\/schema.org\/collection-output",
+    "Name":"https://schema.org/collection-output",
     "Domain Bucket":"< 1K"
   },
   {
     "Class":"Predicate",
-    "Name":"http:\/\/schema.org\/collectionSize",
+    "Name":"https://schema.org/collectionSize",
     "Domain Bucket":"1K - 10K"
   },
   {
     "Class":"Predicate",
-    "Name":"http:\/\/schema.org\/collectionSize-input",
+    "Name":"https://schema.org/collectionSize-input",
     "Domain Bucket":"< 1K"
   },
   {
     "Class":"Predicate",
-    "Name":"http:\/\/schema.org\/collectionSize-output",
+    "Name":"https://schema.org/collectionSize-output",
     "Domain Bucket":"< 1K"
   },
   {
     "Class":"Predicate",
-    "Name":"http:\/\/schema.org\/color",
+    "Name":"https://schema.org/color",
     "Domain Bucket":"100K - 1M"
   },
   {
     "Class":"Predicate",
-    "Name":"http:\/\/schema.org\/color-input",
+    "Name":"https://schema.org/color-input",
     "Domain Bucket":"< 1K"
   },
   {
     "Class":"Predicate",
-    "Name":"http:\/\/schema.org\/color-output",
+    "Name":"https://schema.org/color-output",
     "Domain Bucket":"< 1K"
   },
   {
     "Class":"Predicate",
-    "Name":"http:\/\/schema.org\/colorSwatch",
+    "Name":"https://schema.org/colorSwatch",
     "Domain Bucket":"< 1K"
   },
   {
     "Class":"Predicate",
-    "Name":"http:\/\/schema.org\/colorSwatch-input",
+    "Name":"https://schema.org/colorSwatch-input",
     "Domain Bucket":"< 1K"
   },
   {
     "Class":"Predicate",
-    "Name":"http:\/\/schema.org\/colorSwatch-output",
+    "Name":"https://schema.org/colorSwatch-output",
     "Domain Bucket":"< 1K"
   },
   {
     "Class":"Predicate",
-    "Name":"http:\/\/schema.org\/colorist",
+    "Name":"https://schema.org/colorist",
     "Domain Bucket":"< 1K"
   },
   {
     "Class":"Predicate",
-    "Name":"http:\/\/schema.org\/colorist-input",
+    "Name":"https://schema.org/colorist-input",
     "Domain Bucket":"< 1K"
   },
   {
     "Class":"Predicate",
-    "Name":"http:\/\/schema.org\/colorist-output",
+    "Name":"https://schema.org/colorist-output",
     "Domain Bucket":"< 1K"
   },
   {
     "Class":"Predicate",
-    "Name":"http:\/\/schema.org\/comment",
+    "Name":"https://schema.org/comment",
     "Domain Bucket":"10K - 100K"
   },
   {
     "Class":"Predicate",
-    "Name":"http:\/\/schema.org\/comment-input",
+    "Name":"https://schema.org/comment-input",
     "Domain Bucket":"< 1K"
   },
   {
     "Class":"Predicate",
-    "Name":"http:\/\/schema.org\/comment-output",
+    "Name":"https://schema.org/comment-output",
     "Domain Bucket":"< 1K"
   },
   {
     "Class":"Predicate",
-    "Name":"http:\/\/schema.org\/commentCount",
+    "Name":"https://schema.org/commentCount",
     "Domain Bucket":"1M - 10M"
   },
   {
     "Class":"Predicate",
-    "Name":"http:\/\/schema.org\/commentCount-input",
+    "Name":"https://schema.org/commentCount-input",
     "Domain Bucket":"< 1K"
   },
   {
     "Class":"Predicate",
-    "Name":"http:\/\/schema.org\/commentCount-output",
+    "Name":"https://schema.org/commentCount-output",
     "Domain Bucket":"< 1K"
   },
   {
     "Class":"Predicate",
-    "Name":"http:\/\/schema.org\/commentText",
+    "Name":"https://schema.org/commentText",
     "Domain Bucket":"10K - 100K"
   },
   {
     "Class":"Predicate",
-    "Name":"http:\/\/schema.org\/commentText-input",
+    "Name":"https://schema.org/commentText-input",
     "Domain Bucket":"< 1K"
   },
   {
     "Class":"Predicate",
-    "Name":"http:\/\/schema.org\/commentText-output",
+    "Name":"https://schema.org/commentText-output",
     "Domain Bucket":"< 1K"
   },
   {
     "Class":"Predicate",
-    "Name":"http:\/\/schema.org\/commentTime",
+    "Name":"https://schema.org/commentTime",
     "Domain Bucket":"10K - 100K"
   },
   {
     "Class":"Predicate",
-    "Name":"http:\/\/schema.org\/commentTime-input",
+    "Name":"https://schema.org/commentTime-input",
     "Domain Bucket":"< 1K"
   },
   {
     "Class":"Predicate",
-    "Name":"http:\/\/schema.org\/commentTime-output",
+    "Name":"https://schema.org/commentTime-output",
     "Domain Bucket":"< 1K"
   },
   {
     "Class":"Predicate",
-    "Name":"http:\/\/schema.org\/companyRegistration",
+    "Name":"https://schema.org/companyRegistration",
     "Domain Bucket":"< 1K"
   },
   {
     "Class":"Predicate",
-    "Name":"http:\/\/schema.org\/companyRegistration-input",
+    "Name":"https://schema.org/companyRegistration-input",
     "Domain Bucket":"< 1K"
   },
   {
     "Class":"Predicate",
-    "Name":"http:\/\/schema.org\/companyRegistration-output",
+    "Name":"https://schema.org/companyRegistration-output",
     "Domain Bucket":"< 1K"
   },
   {
     "Class":"Predicate",
-    "Name":"http:\/\/schema.org\/competencyRequired",
+    "Name":"https://schema.org/competencyRequired",
     "Domain Bucket":"1K - 10K"
   },
   {
     "Class":"Predicate",
-    "Name":"http:\/\/schema.org\/competencyRequired-input",
+    "Name":"https://schema.org/competencyRequired-input",
     "Domain Bucket":"< 1K"
   },
   {
     "Class":"Predicate",
-    "Name":"http:\/\/schema.org\/competencyRequired-output",
+    "Name":"https://schema.org/competencyRequired-output",
     "Domain Bucket":"< 1K"
   },
   {
     "Class":"Predicate",
-    "Name":"http:\/\/schema.org\/competitor",
+    "Name":"https://schema.org/competitor",
     "Domain Bucket":"10K - 100K"
   },
   {
     "Class":"Predicate",
-    "Name":"http:\/\/schema.org\/competitor-input",
+    "Name":"https://schema.org/competitor-input",
     "Domain Bucket":"< 1K"
   },
   {
     "Class":"Predicate",
-    "Name":"http:\/\/schema.org\/competitor-output",
+    "Name":"https://schema.org/competitor-output",
     "Domain Bucket":"< 1K"
   },
   {
     "Class":"Predicate",
-    "Name":"http:\/\/schema.org\/composer",
+    "Name":"https://schema.org/composer",
     "Domain Bucket":"1K - 10K"
   },
   {
     "Class":"Predicate",
-    "Name":"http:\/\/schema.org\/composer-input",
+    "Name":"https://schema.org/composer-input",
     "Domain Bucket":"< 1K"
   },
   {
     "Class":"Predicate",
-    "Name":"http:\/\/schema.org\/composer-output",
+    "Name":"https://schema.org/composer-output",
     "Domain Bucket":"< 1K"
   },
   {
     "Class":"Predicate",
-    "Name":"http:\/\/schema.org\/comprisedOf",
+    "Name":"https://schema.org/comprisedOf",
     "Domain Bucket":"< 1K"
   },
   {
     "Class":"Predicate",
-    "Name":"http:\/\/schema.org\/comprisedOf-input",
+    "Name":"https://schema.org/comprisedOf-input",
     "Domain Bucket":"< 1K"
   },
   {
     "Class":"Predicate",
-    "Name":"http:\/\/schema.org\/comprisedOf-output",
+    "Name":"https://schema.org/comprisedOf-output",
     "Domain Bucket":"< 1K"
   },
   {
     "Class":"Predicate",
-    "Name":"http:\/\/schema.org\/conditionsOfAccess",
+    "Name":"https://schema.org/conditionsOfAccess",
     "Domain Bucket":"< 1K"
   },
   {
     "Class":"Predicate",
-    "Name":"http:\/\/schema.org\/conditionsOfAccess-input",
+    "Name":"https://schema.org/conditionsOfAccess-input",
     "Domain Bucket":"< 1K"
   },
   {
     "Class":"Predicate",
-    "Name":"http:\/\/schema.org\/conditionsOfAccess-output",
+    "Name":"https://schema.org/conditionsOfAccess-output",
     "Domain Bucket":"< 1K"
   },
   {
     "Class":"Predicate",
-    "Name":"http:\/\/schema.org\/confirmationNumber",
+    "Name":"https://schema.org/confirmationNumber",
     "Domain Bucket":"< 1K"
   },
   {
     "Class":"Predicate",
-    "Name":"http:\/\/schema.org\/confirmationNumber-input",
+    "Name":"https://schema.org/confirmationNumber-input",
     "Domain Bucket":"< 1K"
   },
   {
     "Class":"Predicate",
-    "Name":"http:\/\/schema.org\/confirmationNumber-output",
+    "Name":"https://schema.org/confirmationNumber-output",
     "Domain Bucket":"< 1K"
   },
   {
     "Class":"Predicate",
-    "Name":"http:\/\/schema.org\/connectedTo",
+    "Name":"https://schema.org/connectedTo",
     "Domain Bucket":"< 1K"
   },
   {
     "Class":"Predicate",
-    "Name":"http:\/\/schema.org\/connectedTo-input",
+    "Name":"https://schema.org/connectedTo-input",
     "Domain Bucket":"< 1K"
   },
   {
     "Class":"Predicate",
-    "Name":"http:\/\/schema.org\/connectedTo-output",
+    "Name":"https://schema.org/connectedTo-output",
     "Domain Bucket":"< 1K"
   },
   {
     "Class":"Predicate",
-    "Name":"http:\/\/schema.org\/constraintProperty",
+    "Name":"https://schema.org/constraintProperty",
     "Domain Bucket":"< 1K"
   },
   {
     "Class":"Predicate",
-    "Name":"http:\/\/schema.org\/constraintProperty-input",
+    "Name":"https://schema.org/constraintProperty-input",
     "Domain Bucket":"< 1K"
   },
   {
     "Class":"Predicate",
-    "Name":"http:\/\/schema.org\/constraintProperty-output",
+    "Name":"https://schema.org/constraintProperty-output",
     "Domain Bucket":"< 1K"
   },
   {
     "Class":"Predicate",
-    "Name":"http:\/\/schema.org\/contactOption",
+    "Name":"https://schema.org/contactOption",
     "Domain Bucket":"100K - 1M"
   },
   {
     "Class":"Predicate",
-    "Name":"http:\/\/schema.org\/contactOption-input",
+    "Name":"https://schema.org/contactOption-input",
     "Domain Bucket":"< 1K"
   },
   {
     "Class":"Predicate",
-    "Name":"http:\/\/schema.org\/contactOption-output",
+    "Name":"https://schema.org/contactOption-output",
     "Domain Bucket":"< 1K"
   },
   {
     "Class":"Predicate",
-    "Name":"http:\/\/schema.org\/contactPoint",
+    "Name":"https://schema.org/contactPoint",
     "Domain Bucket":"1M - 10M"
   },
   {
     "Class":"Predicate",
-    "Name":"http:\/\/schema.org\/contactPoint-input",
+    "Name":"https://schema.org/contactPoint-input",
     "Domain Bucket":"< 1K"
   },
   {
     "Class":"Predicate",
-    "Name":"http:\/\/schema.org\/contactPoint-output",
+    "Name":"https://schema.org/contactPoint-output",
     "Domain Bucket":"< 1K"
   },
   {
     "Class":"Predicate",
-    "Name":"http:\/\/schema.org\/contactPoints",
+    "Name":"https://schema.org/contactPoints",
     "Domain Bucket":"< 1K"
   },
   {
     "Class":"Predicate",
-    "Name":"http:\/\/schema.org\/contactPoints-input",
+    "Name":"https://schema.org/contactPoints-input",
     "Domain Bucket":"< 1K"
   },
   {
     "Class":"Predicate",
-    "Name":"http:\/\/schema.org\/contactPoints-output",
+    "Name":"https://schema.org/contactPoints-output",
     "Domain Bucket":"< 1K"
   },
   {
     "Class":"Predicate",
-    "Name":"http:\/\/schema.org\/contactType",
+    "Name":"https://schema.org/contactType",
     "Domain Bucket":"1M - 10M"
   },
   {
     "Class":"Predicate",
-    "Name":"http:\/\/schema.org\/contactType-input",
+    "Name":"https://schema.org/contactType-input",
     "Domain Bucket":"< 1K"
   },
   {
     "Class":"Predicate",
-    "Name":"http:\/\/schema.org\/contactType-output",
+    "Name":"https://schema.org/contactType-output",
     "Domain Bucket":"< 1K"
   },
   {
     "Class":"Predicate",
-    "Name":"http:\/\/schema.org\/contactlessPayment",
+    "Name":"https://schema.org/contactlessPayment",
     "Domain Bucket":"< 1K"
   },
   {
     "Class":"Predicate",
-    "Name":"http:\/\/schema.org\/contactlessPayment-input",
+    "Name":"https://schema.org/contactlessPayment-input",
     "Domain Bucket":"< 1K"
   },
   {
     "Class":"Predicate",
-    "Name":"http:\/\/schema.org\/contactlessPayment-output",
+    "Name":"https://schema.org/contactlessPayment-output",
     "Domain Bucket":"< 1K"
   },
   {
     "Class":"Predicate",
-    "Name":"http:\/\/schema.org\/containedIn",
+    "Name":"https://schema.org/containedIn",
     "Domain Bucket":"10K - 100K"
   },
   {
     "Class":"Predicate",
-    "Name":"http:\/\/schema.org\/containedIn-input",
+    "Name":"https://schema.org/containedIn-input",
     "Domain Bucket":"< 1K"
   },
   {
     "Class":"Predicate",
-    "Name":"http:\/\/schema.org\/containedIn-output",
+    "Name":"https://schema.org/containedIn-output",
     "Domain Bucket":"< 1K"
   },
   {
     "Class":"Predicate",
-    "Name":"http:\/\/schema.org\/containedInPlace",
+    "Name":"https://schema.org/containedInPlace",
     "Domain Bucket":"100K - 1M"
   },
   {
     "Class":"Predicate",
-    "Name":"http:\/\/schema.org\/containedInPlace-input",
+    "Name":"https://schema.org/containedInPlace-input",
     "Domain Bucket":"< 1K"
   },
   {
     "Class":"Predicate",
-    "Name":"http:\/\/schema.org\/containedInPlace-output",
+    "Name":"https://schema.org/containedInPlace-output",
     "Domain Bucket":"< 1K"
   },
   {
     "Class":"Predicate",
-    "Name":"http:\/\/schema.org\/containsPlace",
+    "Name":"https://schema.org/containsPlace",
     "Domain Bucket":"10K - 100K"
   },
   {
     "Class":"Predicate",
-    "Name":"http:\/\/schema.org\/containsPlace-input",
+    "Name":"https://schema.org/containsPlace-input",
     "Domain Bucket":"< 1K"
   },
   {
     "Class":"Predicate",
-    "Name":"http:\/\/schema.org\/containsPlace-output",
+    "Name":"https://schema.org/containsPlace-output",
     "Domain Bucket":"< 1K"
   },
   {
     "Class":"Predicate",
-    "Name":"http:\/\/schema.org\/containsSeason",
+    "Name":"https://schema.org/containsSeason",
     "Domain Bucket":"1K - 10K"
   },
   {
     "Class":"Predicate",
-    "Name":"http:\/\/schema.org\/containsSeason-input",
+    "Name":"https://schema.org/containsSeason-input",
     "Domain Bucket":"< 1K"
   },
   {
     "Class":"Predicate",
-    "Name":"http:\/\/schema.org\/containsSeason-output",
+    "Name":"https://schema.org/containsSeason-output",
     "Domain Bucket":"< 1K"
   },
   {
     "Class":"Predicate",
-    "Name":"http:\/\/schema.org\/contentLocation",
+    "Name":"https://schema.org/contentLocation",
     "Domain Bucket":"10K - 100K"
   },
   {
     "Class":"Predicate",
-    "Name":"http:\/\/schema.org\/contentLocation-input",
+    "Name":"https://schema.org/contentLocation-input",
     "Domain Bucket":"< 1K"
   },
   {
     "Class":"Predicate",
-    "Name":"http:\/\/schema.org\/contentLocation-output",
+    "Name":"https://schema.org/contentLocation-output",
     "Domain Bucket":"< 1K"
   },
   {
     "Class":"Predicate",
-    "Name":"http:\/\/schema.org\/contentRating",
+    "Name":"https://schema.org/contentRating",
     "Domain Bucket":"10K - 100K"
   },
   {
     "Class":"Predicate",
-    "Name":"http:\/\/schema.org\/contentRating-input",
+    "Name":"https://schema.org/contentRating-input",
     "Domain Bucket":"< 1K"
   },
   {
     "Class":"Predicate",
-    "Name":"http:\/\/schema.org\/contentRating-output",
+    "Name":"https://schema.org/contentRating-output",
     "Domain Bucket":"< 1K"
   },
   {
     "Class":"Predicate",
-    "Name":"http:\/\/schema.org\/contentReferenceTime",
+    "Name":"https://schema.org/contentReferenceTime",
     "Domain Bucket":"1K - 10K"
   },
   {
     "Class":"Predicate",
-    "Name":"http:\/\/schema.org\/contentReferenceTime-input",
+    "Name":"https://schema.org/contentReferenceTime-input",
     "Domain Bucket":"< 1K"
   },
   {
     "Class":"Predicate",
-    "Name":"http:\/\/schema.org\/contentReferenceTime-output",
+    "Name":"https://schema.org/contentReferenceTime-output",
     "Domain Bucket":"< 1K"
   },
   {
     "Class":"Predicate",
-    "Name":"http:\/\/schema.org\/contentSize",
+    "Name":"https://schema.org/contentSize",
     "Domain Bucket":"100K - 1M"
   },
   {
     "Class":"Predicate",
-    "Name":"http:\/\/schema.org\/contentSize-input",
+    "Name":"https://schema.org/contentSize-input",
     "Domain Bucket":"< 1K"
   },
   {
     "Class":"Predicate",
-    "Name":"http:\/\/schema.org\/contentSize-output",
+    "Name":"https://schema.org/contentSize-output",
     "Domain Bucket":"< 1K"
   },
   {
     "Class":"Predicate",
-    "Name":"http:\/\/schema.org\/contentType",
+    "Name":"https://schema.org/contentType",
     "Domain Bucket":"10K - 100K"
   },
   {
     "Class":"Predicate",
-    "Name":"http:\/\/schema.org\/contentType-input",
+    "Name":"https://schema.org/contentType-input",
     "Domain Bucket":"< 1K"
   },
   {
     "Class":"Predicate",
-    "Name":"http:\/\/schema.org\/contentType-output",
+    "Name":"https://schema.org/contentType-output",
     "Domain Bucket":"< 1K"
   },
   {
     "Class":"Predicate",
-    "Name":"http:\/\/schema.org\/contentUrl",
+    "Name":"https://schema.org/contentUrl",
     "Domain Bucket":"10M+"
   },
   {
     "Class":"Predicate",
-    "Name":"http:\/\/schema.org\/contentUrl-input",
+    "Name":"https://schema.org/contentUrl-input",
     "Domain Bucket":"< 1K"
   },
   {
     "Class":"Predicate",
-    "Name":"http:\/\/schema.org\/contentUrl-output",
+    "Name":"https://schema.org/contentUrl-output",
     "Domain Bucket":"< 1K"
   },
   {
     "Class":"Predicate",
-    "Name":"http:\/\/schema.org\/contraindication",
+    "Name":"https://schema.org/contraindication",
     "Domain Bucket":"1K - 10K"
   },
   {
     "Class":"Predicate",
-    "Name":"http:\/\/schema.org\/contraindication-input",
+    "Name":"https://schema.org/contraindication-input",
     "Domain Bucket":"< 1K"
   },
   {
     "Class":"Predicate",
-    "Name":"http:\/\/schema.org\/contraindication-output",
+    "Name":"https://schema.org/contraindication-output",
     "Domain Bucket":"< 1K"
   },
   {
     "Class":"Predicate",
-    "Name":"http:\/\/schema.org\/contributor",
+    "Name":"https://schema.org/contributor",
     "Domain Bucket":"100K - 1M"
   },
   {
     "Class":"Predicate",
-    "Name":"http:\/\/schema.org\/contributor-input",
+    "Name":"https://schema.org/contributor-input",
     "Domain Bucket":"< 1K"
   },
   {
     "Class":"Predicate",
-    "Name":"http:\/\/schema.org\/contributor-output",
+    "Name":"https://schema.org/contributor-output",
     "Domain Bucket":"< 1K"
   },
   {
     "Class":"Predicate",
-    "Name":"http:\/\/schema.org\/cookTime",
+    "Name":"https://schema.org/cookTime",
     "Domain Bucket":"10K - 100K"
   },
   {
     "Class":"Predicate",
-    "Name":"http:\/\/schema.org\/cookTime-input",
+    "Name":"https://schema.org/cookTime-input",
     "Domain Bucket":"< 1K"
   },
   {
     "Class":"Predicate",
-    "Name":"http:\/\/schema.org\/cookTime-output",
+    "Name":"https://schema.org/cookTime-output",
     "Domain Bucket":"< 1K"
   },
   {
     "Class":"Predicate",
-    "Name":"http:\/\/schema.org\/cookingMethod",
+    "Name":"https://schema.org/cookingMethod",
     "Domain Bucket":"1K - 10K"
   },
   {
     "Class":"Predicate",
-    "Name":"http:\/\/schema.org\/cookingMethod-input",
+    "Name":"https://schema.org/cookingMethod-input",
     "Domain Bucket":"< 1K"
   },
   {
     "Class":"Predicate",
-    "Name":"http:\/\/schema.org\/cookingMethod-output",
+    "Name":"https://schema.org/cookingMethod-output",
     "Domain Bucket":"< 1K"
   },
   {
     "Class":"Predicate",
-    "Name":"http:\/\/schema.org\/copyrightHolder",
+    "Name":"https://schema.org/copyrightHolder",
     "Domain Bucket":"100K - 1M"
   },
   {
     "Class":"Predicate",
-    "Name":"http:\/\/schema.org\/copyrightHolder-input",
+    "Name":"https://schema.org/copyrightHolder-input",
     "Domain Bucket":"< 1K"
   },
   {
     "Class":"Predicate",
-    "Name":"http:\/\/schema.org\/copyrightHolder-output",
+    "Name":"https://schema.org/copyrightHolder-output",
     "Domain Bucket":"< 1K"
   },
   {
     "Class":"Predicate",
-    "Name":"http:\/\/schema.org\/copyrightNotice",
+    "Name":"https://schema.org/copyrightNotice",
     "Domain Bucket":"10K - 100K"
   },
   {
     "Class":"Predicate",
-    "Name":"http:\/\/schema.org\/copyrightNotice-input",
+    "Name":"https://schema.org/copyrightNotice-input",
     "Domain Bucket":"< 1K"
   },
   {
     "Class":"Predicate",
-    "Name":"http:\/\/schema.org\/copyrightNotice-output",
+    "Name":"https://schema.org/copyrightNotice-output",
     "Domain Bucket":"< 1K"
   },
   {
     "Class":"Predicate",
-    "Name":"http:\/\/schema.org\/copyrightYear",
+    "Name":"https://schema.org/copyrightYear",
     "Domain Bucket":"100K - 1M"
   },
   {
     "Class":"Predicate",
-    "Name":"http:\/\/schema.org\/copyrightYear-input",
+    "Name":"https://schema.org/copyrightYear-input",
     "Domain Bucket":"< 1K"
   },
   {
     "Class":"Predicate",
-    "Name":"http:\/\/schema.org\/copyrightYear-output",
+    "Name":"https://schema.org/copyrightYear-output",
     "Domain Bucket":"< 1K"
   },
   {
     "Class":"Predicate",
-    "Name":"http:\/\/schema.org\/correction",
+    "Name":"https://schema.org/correction",
     "Domain Bucket":"< 1K"
   },
   {
     "Class":"Predicate",
-    "Name":"http:\/\/schema.org\/correction-input",
+    "Name":"https://schema.org/correction-input",
     "Domain Bucket":"< 1K"
   },
   {
     "Class":"Predicate",
-    "Name":"http:\/\/schema.org\/correction-output",
+    "Name":"https://schema.org/correction-output",
     "Domain Bucket":"< 1K"
   },
   {
     "Class":"Predicate",
-    "Name":"http:\/\/schema.org\/correctionsPolicy",
+    "Name":"https://schema.org/correctionsPolicy",
     "Domain Bucket":"10K - 100K"
   },
   {
     "Class":"Predicate",
-    "Name":"http:\/\/schema.org\/correctionsPolicy-input",
+    "Name":"https://schema.org/correctionsPolicy-input",
     "Domain Bucket":"< 1K"
   },
   {
     "Class":"Predicate",
-    "Name":"http:\/\/schema.org\/correctionsPolicy-output",
+    "Name":"https://schema.org/correctionsPolicy-output",
     "Domain Bucket":"< 1K"
   },
   {
     "Class":"Predicate",
-    "Name":"http:\/\/schema.org\/costCategory",
+    "Name":"https://schema.org/costCategory",
     "Domain Bucket":"< 1K"
   },
   {
     "Class":"Predicate",
-    "Name":"http:\/\/schema.org\/costCategory-input",
+    "Name":"https://schema.org/costCategory-input",
     "Domain Bucket":"< 1K"
   },
   {
     "Class":"Predicate",
-    "Name":"http:\/\/schema.org\/costCategory-output",
+    "Name":"https://schema.org/costCategory-output",
     "Domain Bucket":"< 1K"
   },
   {
     "Class":"Predicate",
-    "Name":"http:\/\/schema.org\/costCurrency",
+    "Name":"https://schema.org/costCurrency",
     "Domain Bucket":"< 1K"
   },
   {
     "Class":"Predicate",
-    "Name":"http:\/\/schema.org\/costCurrency-input",
+    "Name":"https://schema.org/costCurrency-input",
     "Domain Bucket":"< 1K"
   },
   {
     "Class":"Predicate",
-    "Name":"http:\/\/schema.org\/costCurrency-output",
+    "Name":"https://schema.org/costCurrency-output",
     "Domain Bucket":"< 1K"
   },
   {
     "Class":"Predicate",
-    "Name":"http:\/\/schema.org\/costOrigin",
+    "Name":"https://schema.org/costOrigin",
     "Domain Bucket":"< 1K"
   },
   {
     "Class":"Predicate",
-    "Name":"http:\/\/schema.org\/costOrigin-input",
+    "Name":"https://schema.org/costOrigin-input",
     "Domain Bucket":"< 1K"
   },
   {
     "Class":"Predicate",
-    "Name":"http:\/\/schema.org\/costOrigin-output",
+    "Name":"https://schema.org/costOrigin-output",
     "Domain Bucket":"< 1K"
   },
   {
     "Class":"Predicate",
-    "Name":"http:\/\/schema.org\/costPerUnit",
+    "Name":"https://schema.org/costPerUnit",
     "Domain Bucket":"< 1K"
   },
   {
     "Class":"Predicate",
-    "Name":"http:\/\/schema.org\/costPerUnit-input",
+    "Name":"https://schema.org/costPerUnit-input",
     "Domain Bucket":"< 1K"
   },
   {
     "Class":"Predicate",
-    "Name":"http:\/\/schema.org\/costPerUnit-output",
+    "Name":"https://schema.org/costPerUnit-output",
     "Domain Bucket":"< 1K"
   },
   {
     "Class":"Predicate",
-    "Name":"http:\/\/schema.org\/countriesNotSupported",
+    "Name":"https://schema.org/countriesNotSupported",
     "Domain Bucket":"< 1K"
   },
   {
     "Class":"Predicate",
-    "Name":"http:\/\/schema.org\/countriesNotSupported-input",
+    "Name":"https://schema.org/countriesNotSupported-input",
     "Domain Bucket":"< 1K"
   },
   {
     "Class":"Predicate",
-    "Name":"http:\/\/schema.org\/countriesNotSupported-output",
+    "Name":"https://schema.org/countriesNotSupported-output",
     "Domain Bucket":"< 1K"
   },
   {
     "Class":"Predicate",
-    "Name":"http:\/\/schema.org\/countriesSupported",
+    "Name":"https://schema.org/countriesSupported",
     "Domain Bucket":"1K - 10K"
   },
   {
     "Class":"Predicate",
-    "Name":"http:\/\/schema.org\/countriesSupported-input",
+    "Name":"https://schema.org/countriesSupported-input",
     "Domain Bucket":"< 1K"
   },
   {
     "Class":"Predicate",
-    "Name":"http:\/\/schema.org\/countriesSupported-output",
+    "Name":"https://schema.org/countriesSupported-output",
     "Domain Bucket":"< 1K"
   },
   {
     "Class":"Predicate",
-    "Name":"http:\/\/schema.org\/countryOfAssembly",
+    "Name":"https://schema.org/countryOfAssembly",
     "Domain Bucket":"1K - 10K"
   },
   {
     "Class":"Predicate",
-    "Name":"http:\/\/schema.org\/countryOfAssembly-input",
+    "Name":"https://schema.org/countryOfAssembly-input",
     "Domain Bucket":"< 1K"
   },
   {
     "Class":"Predicate",
-    "Name":"http:\/\/schema.org\/countryOfAssembly-output",
+    "Name":"https://schema.org/countryOfAssembly-output",
     "Domain Bucket":"< 1K"
   },
   {
     "Class":"Predicate",
-    "Name":"http:\/\/schema.org\/countryOfLastProcessing",
+    "Name":"https://schema.org/countryOfLastProcessing",
     "Domain Bucket":"< 1K"
   },
   {
     "Class":"Predicate",
-    "Name":"http:\/\/schema.org\/countryOfLastProcessing-input",
+    "Name":"https://schema.org/countryOfLastProcessing-input",
     "Domain Bucket":"< 1K"
   },
   {
     "Class":"Predicate",
-    "Name":"http:\/\/schema.org\/countryOfLastProcessing-output",
+    "Name":"https://schema.org/countryOfLastProcessing-output",
     "Domain Bucket":"< 1K"
   },
   {
     "Class":"Predicate",
-    "Name":"http:\/\/schema.org\/countryOfOrigin",
+    "Name":"https://schema.org/countryOfOrigin",
     "Domain Bucket":"10K - 100K"
   },
   {
     "Class":"Predicate",
-    "Name":"http:\/\/schema.org\/countryOfOrigin-input",
+    "Name":"https://schema.org/countryOfOrigin-input",
     "Domain Bucket":"< 1K"
   },
   {
     "Class":"Predicate",
-    "Name":"http:\/\/schema.org\/countryOfOrigin-output",
+    "Name":"https://schema.org/countryOfOrigin-output",
     "Domain Bucket":"< 1K"
   },
   {
     "Class":"Predicate",
-    "Name":"http:\/\/schema.org\/course",
+    "Name":"https://schema.org/course",
     "Domain Bucket":"< 1K"
   },
   {
     "Class":"Predicate",
-    "Name":"http:\/\/schema.org\/course-input",
+    "Name":"https://schema.org/course-input",
     "Domain Bucket":"< 1K"
   },
   {
     "Class":"Predicate",
-    "Name":"http:\/\/schema.org\/course-output",
+    "Name":"https://schema.org/course-output",
     "Domain Bucket":"< 1K"
   },
   {
     "Class":"Predicate",
-    "Name":"http:\/\/schema.org\/courseCode",
+    "Name":"https://schema.org/courseCode",
     "Domain Bucket":"10K - 100K"
   },
   {
     "Class":"Predicate",
-    "Name":"http:\/\/schema.org\/courseCode-input",
+    "Name":"https://schema.org/courseCode-input",
     "Domain Bucket":"< 1K"
   },
   {
     "Class":"Predicate",
-    "Name":"http:\/\/schema.org\/courseCode-output",
+    "Name":"https://schema.org/courseCode-output",
     "Domain Bucket":"< 1K"
   },
   {
     "Class":"Predicate",
-    "Name":"http:\/\/schema.org\/courseMode",
+    "Name":"https://schema.org/courseMode",
     "Domain Bucket":"10K - 100K"
   },
   {
     "Class":"Predicate",
-    "Name":"http:\/\/schema.org\/courseMode-input",
+    "Name":"https://schema.org/courseMode-input",
     "Domain Bucket":"< 1K"
   },
   {
     "Class":"Predicate",
-    "Name":"http:\/\/schema.org\/courseMode-output",
+    "Name":"https://schema.org/courseMode-output",
     "Domain Bucket":"< 1K"
   },
   {
     "Class":"Predicate",
-    "Name":"http:\/\/schema.org\/coursePrerequisites",
+    "Name":"https://schema.org/coursePrerequisites",
     "Domain Bucket":"1K - 10K"
   },
   {
     "Class":"Predicate",
-    "Name":"http:\/\/schema.org\/coursePrerequisites-input",
+    "Name":"https://schema.org/coursePrerequisites-input",
     "Domain Bucket":"< 1K"
   },
   {
     "Class":"Predicate",
-    "Name":"http:\/\/schema.org\/coursePrerequisites-output",
+    "Name":"https://schema.org/coursePrerequisites-output",
     "Domain Bucket":"< 1K"
   },
   {
     "Class":"Predicate",
-    "Name":"http:\/\/schema.org\/courseSchedule",
+    "Name":"https://schema.org/courseSchedule",
     "Domain Bucket":"1K - 10K"
   },
   {
     "Class":"Predicate",
-    "Name":"http:\/\/schema.org\/courseSchedule-input",
+    "Name":"https://schema.org/courseSchedule-input",
     "Domain Bucket":"< 1K"
   },
   {
     "Class":"Predicate",
-    "Name":"http:\/\/schema.org\/courseSchedule-output",
+    "Name":"https://schema.org/courseSchedule-output",
     "Domain Bucket":"< 1K"
   },
   {
     "Class":"Predicate",
-    "Name":"http:\/\/schema.org\/courseWorkload",
+    "Name":"https://schema.org/courseWorkload",
     "Domain Bucket":"10K - 100K"
   },
   {
     "Class":"Predicate",
-    "Name":"http:\/\/schema.org\/courseWorkload-input",
+    "Name":"https://schema.org/courseWorkload-input",
     "Domain Bucket":"< 1K"
   },
   {
     "Class":"Predicate",
-    "Name":"http:\/\/schema.org\/courseWorkload-output",
+    "Name":"https://schema.org/courseWorkload-output",
     "Domain Bucket":"< 1K"
   },
   {
     "Class":"Predicate",
-    "Name":"http:\/\/schema.org\/coverageEndTime",
+    "Name":"https://schema.org/coverageEndTime",
     "Domain Bucket":"1K - 10K"
   },
   {
     "Class":"Predicate",
-    "Name":"http:\/\/schema.org\/coverageEndTime-input",
+    "Name":"https://schema.org/coverageEndTime-input",
     "Domain Bucket":"< 1K"
   },
   {
     "Class":"Predicate",
-    "Name":"http:\/\/schema.org\/coverageEndTime-output",
+    "Name":"https://schema.org/coverageEndTime-output",
     "Domain Bucket":"< 1K"
   },
   {
     "Class":"Predicate",
-    "Name":"http:\/\/schema.org\/coverageStartTime",
+    "Name":"https://schema.org/coverageStartTime",
     "Domain Bucket":"1K - 10K"
   },
   {
     "Class":"Predicate",
-    "Name":"http:\/\/schema.org\/coverageStartTime-input",
+    "Name":"https://schema.org/coverageStartTime-input",
     "Domain Bucket":"< 1K"
   },
   {
     "Class":"Predicate",
-    "Name":"http:\/\/schema.org\/coverageStartTime-output",
+    "Name":"https://schema.org/coverageStartTime-output",
     "Domain Bucket":"< 1K"
   },
   {
     "Class":"Predicate",
-    "Name":"http:\/\/schema.org\/creativeWorkStatus",
+    "Name":"https://schema.org/creativeWorkStatus",
     "Domain Bucket":"1K - 10K"
   },
   {
     "Class":"Predicate",
-    "Name":"http:\/\/schema.org\/creativeWorkStatus-input",
+    "Name":"https://schema.org/creativeWorkStatus-input",
     "Domain Bucket":"< 1K"
   },
   {
     "Class":"Predicate",
-    "Name":"http:\/\/schema.org\/creativeWorkStatus-output",
+    "Name":"https://schema.org/creativeWorkStatus-output",
     "Domain Bucket":"< 1K"
   },
   {
     "Class":"Predicate",
-    "Name":"http:\/\/schema.org\/creator",
+    "Name":"https://schema.org/creator",
     "Domain Bucket":"1M - 10M"
   },
   {
     "Class":"Predicate",
-    "Name":"http:\/\/schema.org\/creator-input",
+    "Name":"https://schema.org/creator-input",
     "Domain Bucket":"< 1K"
   },
   {
     "Class":"Predicate",
-    "Name":"http:\/\/schema.org\/creator-output",
+    "Name":"https://schema.org/creator-output",
     "Domain Bucket":"< 1K"
   },
   {
     "Class":"Predicate",
-    "Name":"http:\/\/schema.org\/credentialCategory",
+    "Name":"https://schema.org/credentialCategory",
     "Domain Bucket":"10K - 100K"
   },
   {
     "Class":"Predicate",
-    "Name":"http:\/\/schema.org\/credentialCategory-input",
+    "Name":"https://schema.org/credentialCategory-input",
     "Domain Bucket":"< 1K"
   },
   {
     "Class":"Predicate",
-    "Name":"http:\/\/schema.org\/credentialCategory-output",
+    "Name":"https://schema.org/credentialCategory-output",
     "Domain Bucket":"< 1K"
   },
   {
     "Class":"Predicate",
-    "Name":"http:\/\/schema.org\/creditText",
+    "Name":"https://schema.org/creditText",
     "Domain Bucket":"100K - 1M"
   },
   {
     "Class":"Predicate",
-    "Name":"http:\/\/schema.org\/creditText-input",
+    "Name":"https://schema.org/creditText-input",
     "Domain Bucket":"< 1K"
   },
   {
     "Class":"Predicate",
-    "Name":"http:\/\/schema.org\/creditText-output",
+    "Name":"https://schema.org/creditText-output",
     "Domain Bucket":"< 1K"
   },
   {
     "Class":"Predicate",
-    "Name":"http:\/\/schema.org\/creditedTo",
+    "Name":"https://schema.org/creditedTo",
     "Domain Bucket":"< 1K"
   },
   {
     "Class":"Predicate",
-    "Name":"http:\/\/schema.org\/creditedTo-input",
+    "Name":"https://schema.org/creditedTo-input",
     "Domain Bucket":"< 1K"
   },
   {
     "Class":"Predicate",
-    "Name":"http:\/\/schema.org\/creditedTo-output",
+    "Name":"https://schema.org/creditedTo-output",
     "Domain Bucket":"< 1K"
   },
   {
     "Class":"Predicate",
-    "Name":"http:\/\/schema.org\/cssSelector",
+    "Name":"https://schema.org/cssSelector",
     "Domain Bucket":"100K - 1M"
   },
   {
     "Class":"Predicate",
-    "Name":"http:\/\/schema.org\/cssSelector-input",
+    "Name":"https://schema.org/cssSelector-input",
     "Domain Bucket":"< 1K"
   },
   {
     "Class":"Predicate",
-    "Name":"http:\/\/schema.org\/cssSelector-output",
+    "Name":"https://schema.org/cssSelector-output",
     "Domain Bucket":"< 1K"
   },
   {
     "Class":"Predicate",
-    "Name":"http:\/\/schema.org\/currenciesAccepted",
+    "Name":"https://schema.org/currenciesAccepted",
     "Domain Bucket":"100K - 1M"
   },
   {
     "Class":"Predicate",
-    "Name":"http:\/\/schema.org\/currenciesAccepted-input",
+    "Name":"https://schema.org/currenciesAccepted-input",
     "Domain Bucket":"< 1K"
   },
   {
     "Class":"Predicate",
-    "Name":"http:\/\/schema.org\/currenciesAccepted-output",
+    "Name":"https://schema.org/currenciesAccepted-output",
     "Domain Bucket":"< 1K"
   },
   {
     "Class":"Predicate",
-    "Name":"http:\/\/schema.org\/currency",
+    "Name":"https://schema.org/currency",
     "Domain Bucket":"100K - 1M"
   },
   {
     "Class":"Predicate",
-    "Name":"http:\/\/schema.org\/currency-input",
+    "Name":"https://schema.org/currency-input",
     "Domain Bucket":"< 1K"
   },
   {
     "Class":"Predicate",
-    "Name":"http:\/\/schema.org\/currency-output",
+    "Name":"https://schema.org/currency-output",
     "Domain Bucket":"< 1K"
   },
   {
     "Class":"Predicate",
-    "Name":"http:\/\/schema.org\/currentExchangeRate",
+    "Name":"https://schema.org/currentExchangeRate",
     "Domain Bucket":"< 1K"
   },
   {
     "Class":"Predicate",
-    "Name":"http:\/\/schema.org\/currentExchangeRate-input",
+    "Name":"https://schema.org/currentExchangeRate-input",
     "Domain Bucket":"< 1K"
   },
   {
     "Class":"Predicate",
-    "Name":"http:\/\/schema.org\/currentExchangeRate-output",
+    "Name":"https://schema.org/currentExchangeRate-output",
     "Domain Bucket":"< 1K"
   },
   {
     "Class":"Predicate",
-    "Name":"http:\/\/schema.org\/customer",
+    "Name":"https://schema.org/customer",
     "Domain Bucket":"< 1K"
   },
   {
     "Class":"Predicate",
-    "Name":"http:\/\/schema.org\/customer-input",
+    "Name":"https://schema.org/customer-input",
     "Domain Bucket":"< 1K"
   },
   {
     "Class":"Predicate",
-    "Name":"http:\/\/schema.org\/customer-output",
+    "Name":"https://schema.org/customer-output",
     "Domain Bucket":"< 1K"
   },
   {
     "Class":"Predicate",
-    "Name":"http:\/\/schema.org\/customerRemorseReturnFees",
+    "Name":"https://schema.org/customerRemorseReturnFees",
     "Domain Bucket":"1K - 10K"
   },
   {
     "Class":"Predicate",
-    "Name":"http:\/\/schema.org\/customerRemorseReturnFees-input",
+    "Name":"https://schema.org/customerRemorseReturnFees-input",
     "Domain Bucket":"< 1K"
   },
   {
     "Class":"Predicate",
-    "Name":"http:\/\/schema.org\/customerRemorseReturnFees-output",
+    "Name":"https://schema.org/customerRemorseReturnFees-output",
     "Domain Bucket":"< 1K"
   },
   {
     "Class":"Predicate",
-    "Name":"http:\/\/schema.org\/customerRemorseReturnLabelSource",
+    "Name":"https://schema.org/customerRemorseReturnLabelSource",
     "Domain Bucket":"< 1K"
   },
   {
     "Class":"Predicate",
-    "Name":"http:\/\/schema.org\/customerRemorseReturnLabelSource-input",
+    "Name":"https://schema.org/customerRemorseReturnLabelSource-input",
     "Domain Bucket":"< 1K"
   },
   {
     "Class":"Predicate",
-    "Name":"http:\/\/schema.org\/customerRemorseReturnLabelSource-output",
+    "Name":"https://schema.org/customerRemorseReturnLabelSource-output",
     "Domain Bucket":"< 1K"
   },
   {
     "Class":"Predicate",
-    "Name":"http:\/\/schema.org\/customerRemorseReturnShippingFeesAmount",
+    "Name":"https://schema.org/customerRemorseReturnShippingFeesAmount",
     "Domain Bucket":"< 1K"
   },
   {
     "Class":"Predicate",
-    "Name":"http:\/\/schema.org\/customerRemorseReturnShippingFeesAmount-input",
+    "Name":"https://schema.org/customerRemorseReturnShippingFeesAmount-input",
     "Domain Bucket":"< 1K"
   },
   {
     "Class":"Predicate",
-    "Name":"http:\/\/schema.org\/customerRemorseReturnShippingFeesAmount-output",
+    "Name":"https://schema.org/customerRemorseReturnShippingFeesAmount-output",
     "Domain Bucket":"< 1K"
   },
   {
     "Class":"Predicate",
-    "Name":"http:\/\/schema.org\/cutoffTime",
+    "Name":"https://schema.org/cutoffTime",
     "Domain Bucket":"10K - 100K"
   },
   {
     "Class":"Predicate",
-    "Name":"http:\/\/schema.org\/cutoffTime-input",
+    "Name":"https://schema.org/cutoffTime-input",
     "Domain Bucket":"< 1K"
   },
   {
     "Class":"Predicate",
-    "Name":"http:\/\/schema.org\/cutoffTime-output",
+    "Name":"https://schema.org/cutoffTime-output",
     "Domain Bucket":"< 1K"
   },
   {
     "Class":"Predicate",
-    "Name":"http:\/\/schema.org\/cvdCollectionDate",
+    "Name":"https://schema.org/cvdCollectionDate",
     "Domain Bucket":"< 1K"
   },
   {
     "Class":"Predicate",
-    "Name":"http:\/\/schema.org\/cvdCollectionDate-input",
+    "Name":"https://schema.org/cvdCollectionDate-input",
     "Domain Bucket":"< 1K"
   },
   {
     "Class":"Predicate",
-    "Name":"http:\/\/schema.org\/cvdCollectionDate-output",
+    "Name":"https://schema.org/cvdCollectionDate-output",
     "Domain Bucket":"< 1K"
   },
   {
     "Class":"Predicate",
-    "Name":"http:\/\/schema.org\/cvdFacilityCounty",
+    "Name":"https://schema.org/cvdFacilityCounty",
     "Domain Bucket":"< 1K"
   },
   {
     "Class":"Predicate",
-    "Name":"http:\/\/schema.org\/cvdFacilityCounty-input",
+    "Name":"https://schema.org/cvdFacilityCounty-input",
     "Domain Bucket":"< 1K"
   },
   {
     "Class":"Predicate",
-    "Name":"http:\/\/schema.org\/cvdFacilityCounty-output",
+    "Name":"https://schema.org/cvdFacilityCounty-output",
     "Domain Bucket":"< 1K"
   },
   {
     "Class":"Predicate",
-    "Name":"http:\/\/schema.org\/cvdFacilityId",
+    "Name":"https://schema.org/cvdFacilityId",
     "Domain Bucket":"< 1K"
   },
   {
     "Class":"Predicate",
-    "Name":"http:\/\/schema.org\/cvdFacilityId-input",
+    "Name":"https://schema.org/cvdFacilityId-input",
     "Domain Bucket":"< 1K"
   },
   {
     "Class":"Predicate",
-    "Name":"http:\/\/schema.org\/cvdFacilityId-output",
+    "Name":"https://schema.org/cvdFacilityId-output",
     "Domain Bucket":"< 1K"
   },
   {
     "Class":"Predicate",
-    "Name":"http:\/\/schema.org\/cvdNumBeds",
+    "Name":"https://schema.org/cvdNumBeds",
     "Domain Bucket":"< 1K"
   },
   {
     "Class":"Predicate",
-    "Name":"http:\/\/schema.org\/cvdNumBeds-input",
+    "Name":"https://schema.org/cvdNumBeds-input",
     "Domain Bucket":"< 1K"
   },
   {
     "Class":"Predicate",
-    "Name":"http:\/\/schema.org\/cvdNumBeds-output",
+    "Name":"https://schema.org/cvdNumBeds-output",
     "Domain Bucket":"< 1K"
   },
   {
     "Class":"Predicate",
-    "Name":"http:\/\/schema.org\/cvdNumBedsOcc",
+    "Name":"https://schema.org/cvdNumBedsOcc",
     "Domain Bucket":"< 1K"
   },
   {
     "Class":"Predicate",
-    "Name":"http:\/\/schema.org\/cvdNumBedsOcc-input",
+    "Name":"https://schema.org/cvdNumBedsOcc-input",
     "Domain Bucket":"< 1K"
   },
   {
     "Class":"Predicate",
-    "Name":"http:\/\/schema.org\/cvdNumBedsOcc-output",
+    "Name":"https://schema.org/cvdNumBedsOcc-output",
     "Domain Bucket":"< 1K"
   },
   {
     "Class":"Predicate",
-    "Name":"http:\/\/schema.org\/cvdNumC19Died",
+    "Name":"https://schema.org/cvdNumC19Died",
     "Domain Bucket":"< 1K"
   },
   {
     "Class":"Predicate",
-    "Name":"http:\/\/schema.org\/cvdNumC19Died-input",
+    "Name":"https://schema.org/cvdNumC19Died-input",
     "Domain Bucket":"< 1K"
   },
   {
     "Class":"Predicate",
-    "Name":"http:\/\/schema.org\/cvdNumC19Died-output",
+    "Name":"https://schema.org/cvdNumC19Died-output",
     "Domain Bucket":"< 1K"
   },
   {
     "Class":"Predicate",
-    "Name":"http:\/\/schema.org\/cvdNumC19HOPats",
+    "Name":"https://schema.org/cvdNumC19HOPats",
     "Domain Bucket":"< 1K"
   },
   {
     "Class":"Predicate",
-    "Name":"http:\/\/schema.org\/cvdNumC19HOPats-input",
+    "Name":"https://schema.org/cvdNumC19HOPats-input",
     "Domain Bucket":"< 1K"
   },
   {
     "Class":"Predicate",
-    "Name":"http:\/\/schema.org\/cvdNumC19HOPats-output",
+    "Name":"https://schema.org/cvdNumC19HOPats-output",
     "Domain Bucket":"< 1K"
   },
   {
     "Class":"Predicate",
-    "Name":"http:\/\/schema.org\/cvdNumC19HospPats",
+    "Name":"https://schema.org/cvdNumC19HospPats",
     "Domain Bucket":"< 1K"
   },
   {
     "Class":"Predicate",
-    "Name":"http:\/\/schema.org\/cvdNumC19HospPats-input",
+    "Name":"https://schema.org/cvdNumC19HospPats-input",
     "Domain Bucket":"< 1K"
   },
   {
     "Class":"Predicate",
-    "Name":"http:\/\/schema.org\/cvdNumC19HospPats-output",
+    "Name":"https://schema.org/cvdNumC19HospPats-output",
     "Domain Bucket":"< 1K"
   },
   {
     "Class":"Predicate",
-    "Name":"http:\/\/schema.org\/cvdNumC19MechVentPats",
+    "Name":"https://schema.org/cvdNumC19MechVentPats",
     "Domain Bucket":"< 1K"
   },
   {
     "Class":"Predicate",
-    "Name":"http:\/\/schema.org\/cvdNumC19MechVentPats-input",
+    "Name":"https://schema.org/cvdNumC19MechVentPats-input",
     "Domain Bucket":"< 1K"
   },
   {
     "Class":"Predicate",
-    "Name":"http:\/\/schema.org\/cvdNumC19MechVentPats-output",
+    "Name":"https://schema.org/cvdNumC19MechVentPats-output",
     "Domain Bucket":"< 1K"
   },
   {
     "Class":"Predicate",
-    "Name":"http:\/\/schema.org\/cvdNumC19OFMechVentPats",
+    "Name":"https://schema.org/cvdNumC19OFMechVentPats",
     "Domain Bucket":"< 1K"
   },
   {
     "Class":"Predicate",
-    "Name":"http:\/\/schema.org\/cvdNumC19OFMechVentPats-input",
+    "Name":"https://schema.org/cvdNumC19OFMechVentPats-input",
     "Domain Bucket":"< 1K"
   },
   {
     "Class":"Predicate",
-    "Name":"http:\/\/schema.org\/cvdNumC19OFMechVentPats-output",
+    "Name":"https://schema.org/cvdNumC19OFMechVentPats-output",
     "Domain Bucket":"< 1K"
   },
   {
     "Class":"Predicate",
-    "Name":"http:\/\/schema.org\/cvdNumC19OverflowPats",
+    "Name":"https://schema.org/cvdNumC19OverflowPats",
     "Domain Bucket":"< 1K"
   },
   {
     "Class":"Predicate",
-    "Name":"http:\/\/schema.org\/cvdNumC19OverflowPats-input",
+    "Name":"https://schema.org/cvdNumC19OverflowPats-input",
     "Domain Bucket":"< 1K"
   },
   {
     "Class":"Predicate",
-    "Name":"http:\/\/schema.org\/cvdNumC19OverflowPats-output",
+    "Name":"https://schema.org/cvdNumC19OverflowPats-output",
     "Domain Bucket":"< 1K"
   },
   {
     "Class":"Predicate",
-    "Name":"http:\/\/schema.org\/cvdNumICUBeds",
+    "Name":"https://schema.org/cvdNumICUBeds",
     "Domain Bucket":"< 1K"
   },
   {
     "Class":"Predicate",
-    "Name":"http:\/\/schema.org\/cvdNumICUBeds-input",
+    "Name":"https://schema.org/cvdNumICUBeds-input",
     "Domain Bucket":"< 1K"
   },
   {
     "Class":"Predicate",
-    "Name":"http:\/\/schema.org\/cvdNumICUBeds-output",
+    "Name":"https://schema.org/cvdNumICUBeds-output",
     "Domain Bucket":"< 1K"
   },
   {
     "Class":"Predicate",
-    "Name":"http:\/\/schema.org\/cvdNumICUBedsOcc",
+    "Name":"https://schema.org/cvdNumICUBedsOcc",
     "Domain Bucket":"< 1K"
   },
   {
     "Class":"Predicate",
-    "Name":"http:\/\/schema.org\/cvdNumICUBedsOcc-input",
+    "Name":"https://schema.org/cvdNumICUBedsOcc-input",
     "Domain Bucket":"< 1K"
   },
   {
     "Class":"Predicate",
-    "Name":"http:\/\/schema.org\/cvdNumICUBedsOcc-output",
+    "Name":"https://schema.org/cvdNumICUBedsOcc-output",
     "Domain Bucket":"< 1K"
   },
   {
     "Class":"Predicate",
-    "Name":"http:\/\/schema.org\/cvdNumTotBeds",
+    "Name":"https://schema.org/cvdNumTotBeds",
     "Domain Bucket":"< 1K"
   },
   {
     "Class":"Predicate",
-    "Name":"http:\/\/schema.org\/cvdNumTotBeds-input",
+    "Name":"https://schema.org/cvdNumTotBeds-input",
     "Domain Bucket":"< 1K"
   },
   {
     "Class":"Predicate",
-    "Name":"http:\/\/schema.org\/cvdNumTotBeds-output",
+    "Name":"https://schema.org/cvdNumTotBeds-output",
     "Domain Bucket":"< 1K"
   },
   {
     "Class":"Predicate",
-    "Name":"http:\/\/schema.org\/cvdNumVent",
+    "Name":"https://schema.org/cvdNumVent",
     "Domain Bucket":"< 1K"
   },
   {
     "Class":"Predicate",
-    "Name":"http:\/\/schema.org\/cvdNumVent-input",
+    "Name":"https://schema.org/cvdNumVent-input",
     "Domain Bucket":"< 1K"
   },
   {
     "Class":"Predicate",
-    "Name":"http:\/\/schema.org\/cvdNumVent-output",
+    "Name":"https://schema.org/cvdNumVent-output",
     "Domain Bucket":"< 1K"
   },
   {
     "Class":"Predicate",
-    "Name":"http:\/\/schema.org\/cvdNumVentUse",
+    "Name":"https://schema.org/cvdNumVentUse",
     "Domain Bucket":"< 1K"
   },
   {
     "Class":"Predicate",
-    "Name":"http:\/\/schema.org\/cvdNumVentUse-input",
+    "Name":"https://schema.org/cvdNumVentUse-input",
     "Domain Bucket":"< 1K"
   },
   {
     "Class":"Predicate",
-    "Name":"http:\/\/schema.org\/cvdNumVentUse-output",
+    "Name":"https://schema.org/cvdNumVentUse-output",
     "Domain Bucket":"< 1K"
   },
   {
     "Class":"Predicate",
-    "Name":"http:\/\/schema.org\/data",
+    "Name":"https://schema.org/data",
     "Domain Bucket":"1K - 10K"
   },
   {
     "Class":"Predicate",
-    "Name":"http:\/\/schema.org\/data-input",
+    "Name":"https://schema.org/data-input",
     "Domain Bucket":"< 1K"
   },
   {
     "Class":"Predicate",
-    "Name":"http:\/\/schema.org\/data-output",
+    "Name":"https://schema.org/data-output",
     "Domain Bucket":"< 1K"
   },
   {
     "Class":"Predicate",
-    "Name":"http:\/\/schema.org\/dataFeedElement",
+    "Name":"https://schema.org/dataFeedElement",
     "Domain Bucket":"1K - 10K"
   },
   {
     "Class":"Predicate",
-    "Name":"http:\/\/schema.org\/dataFeedElement-input",
+    "Name":"https://schema.org/dataFeedElement-input",
     "Domain Bucket":"< 1K"
   },
   {
     "Class":"Predicate",
-    "Name":"http:\/\/schema.org\/dataFeedElement-output",
+    "Name":"https://schema.org/dataFeedElement-output",
     "Domain Bucket":"< 1K"
   },
   {
     "Class":"Predicate",
-    "Name":"http:\/\/schema.org\/dataset",
+    "Name":"https://schema.org/dataset",
     "Domain Bucket":"1K - 10K"
   },
   {
     "Class":"Predicate",
-    "Name":"http:\/\/schema.org\/dataset-input",
+    "Name":"https://schema.org/dataset-input",
     "Domain Bucket":"< 1K"
   },
   {
     "Class":"Predicate",
-    "Name":"http:\/\/schema.org\/dataset-output",
+    "Name":"https://schema.org/dataset-output",
     "Domain Bucket":"< 1K"
   },
   {
     "Class":"Predicate",
-    "Name":"http:\/\/schema.org\/datasetTimeInterval",
+    "Name":"https://schema.org/datasetTimeInterval",
     "Domain Bucket":"< 1K"
   },
   {
     "Class":"Predicate",
-    "Name":"http:\/\/schema.org\/datasetTimeInterval-input",
+    "Name":"https://schema.org/datasetTimeInterval-input",
     "Domain Bucket":"< 1K"
   },
   {
     "Class":"Predicate",
-    "Name":"http:\/\/schema.org\/datasetTimeInterval-output",
+    "Name":"https://schema.org/datasetTimeInterval-output",
     "Domain Bucket":"< 1K"
   },
   {
     "Class":"Predicate",
-    "Name":"http:\/\/schema.org\/dateCreated",
+    "Name":"https://schema.org/dateCreated",
     "Domain Bucket":"100K - 1M"
   },
   {
     "Class":"Predicate",
-    "Name":"http:\/\/schema.org\/dateCreated-input",
+    "Name":"https://schema.org/dateCreated-input",
     "Domain Bucket":"< 1K"
   },
   {
     "Class":"Predicate",
-    "Name":"http:\/\/schema.org\/dateCreated-output",
+    "Name":"https://schema.org/dateCreated-output",
     "Domain Bucket":"< 1K"
   },
   {
     "Class":"Predicate",
-    "Name":"http:\/\/schema.org\/dateDeleted",
+    "Name":"https://schema.org/dateDeleted",
     "Domain Bucket":"< 1K"
   },
   {
     "Class":"Predicate",
-    "Name":"http:\/\/schema.org\/dateDeleted-input",
+    "Name":"https://schema.org/dateDeleted-input",
     "Domain Bucket":"< 1K"
   },
   {
     "Class":"Predicate",
-    "Name":"http:\/\/schema.org\/dateDeleted-output",
+    "Name":"https://schema.org/dateDeleted-output",
     "Domain Bucket":"< 1K"
   },
   {
     "Class":"Predicate",
-    "Name":"http:\/\/schema.org\/dateIssued",
+    "Name":"https://schema.org/dateIssued",
     "Domain Bucket":"< 1K"
   },
   {
     "Class":"Predicate",
-    "Name":"http:\/\/schema.org\/dateIssued-input",
+    "Name":"https://schema.org/dateIssued-input",
     "Domain Bucket":"< 1K"
   },
   {
     "Class":"Predicate",
-    "Name":"http:\/\/schema.org\/dateIssued-output",
+    "Name":"https://schema.org/dateIssued-output",
     "Domain Bucket":"< 1K"
   },
   {
     "Class":"Predicate",
-    "Name":"http:\/\/schema.org\/dateModified",
+    "Name":"https://schema.org/dateModified",
     "Domain Bucket":"10M+"
   },
   {
     "Class":"Predicate",
-    "Name":"http:\/\/schema.org\/dateModified-input",
+    "Name":"https://schema.org/dateModified-input",
     "Domain Bucket":"< 1K"
   },
   {
     "Class":"Predicate",
-    "Name":"http:\/\/schema.org\/dateModified-output",
+    "Name":"https://schema.org/dateModified-output",
     "Domain Bucket":"< 1K"
   },
   {
     "Class":"Predicate",
-    "Name":"http:\/\/schema.org\/datePosted",
+    "Name":"https://schema.org/datePosted",
     "Domain Bucket":"100K - 1M"
   },
   {
     "Class":"Predicate",
-    "Name":"http:\/\/schema.org\/datePosted-input",
+    "Name":"https://schema.org/datePosted-input",
     "Domain Bucket":"< 1K"
   },
   {
     "Class":"Predicate",
-    "Name":"http:\/\/schema.org\/datePosted-output",
+    "Name":"https://schema.org/datePosted-output",
     "Domain Bucket":"< 1K"
   },
   {
     "Class":"Predicate",
-    "Name":"http:\/\/schema.org\/datePublished",
+    "Name":"https://schema.org/datePublished",
     "Domain Bucket":"10M+"
   },
   {
     "Class":"Predicate",
-    "Name":"http:\/\/schema.org\/datePublished-input",
+    "Name":"https://schema.org/datePublished-input",
     "Domain Bucket":"< 1K"
   },
   {
     "Class":"Predicate",
-    "Name":"http:\/\/schema.org\/datePublished-output",
+    "Name":"https://schema.org/datePublished-output",
     "Domain Bucket":"< 1K"
   },
   {
     "Class":"Predicate",
-    "Name":"http:\/\/schema.org\/dateRead",
+    "Name":"https://schema.org/dateRead",
     "Domain Bucket":"< 1K"
   },
   {
     "Class":"Predicate",
-    "Name":"http:\/\/schema.org\/dateRead-input",
+    "Name":"https://schema.org/dateRead-input",
     "Domain Bucket":"< 1K"
   },
   {
     "Class":"Predicate",
-    "Name":"http:\/\/schema.org\/dateRead-output",
+    "Name":"https://schema.org/dateRead-output",
     "Domain Bucket":"< 1K"
   },
   {
     "Class":"Predicate",
-    "Name":"http:\/\/schema.org\/dateReceived",
+    "Name":"https://schema.org/dateReceived",
     "Domain Bucket":"< 1K"
   },
   {
     "Class":"Predicate",
-    "Name":"http:\/\/schema.org\/dateReceived-input",
+    "Name":"https://schema.org/dateReceived-input",
     "Domain Bucket":"< 1K"
   },
   {
     "Class":"Predicate",
-    "Name":"http:\/\/schema.org\/dateReceived-output",
+    "Name":"https://schema.org/dateReceived-output",
     "Domain Bucket":"< 1K"
   },
   {
     "Class":"Predicate",
-    "Name":"http:\/\/schema.org\/dateSent",
+    "Name":"https://schema.org/dateSent",
     "Domain Bucket":"< 1K"
   },
   {
     "Class":"Predicate",
-    "Name":"http:\/\/schema.org\/dateSent-input",
+    "Name":"https://schema.org/dateSent-input",
     "Domain Bucket":"< 1K"
   },
   {
     "Class":"Predicate",
-    "Name":"http:\/\/schema.org\/dateSent-output",
+    "Name":"https://schema.org/dateSent-output",
     "Domain Bucket":"< 1K"
   },
   {
     "Class":"Predicate",
-    "Name":"http:\/\/schema.org\/dateVehicleFirstRegistered",
+    "Name":"https://schema.org/dateVehicleFirstRegistered",
     "Domain Bucket":"1K - 10K"
   },
   {
     "Class":"Predicate",
-    "Name":"http:\/\/schema.org\/dateVehicleFirstRegistered-input",
+    "Name":"https://schema.org/dateVehicleFirstRegistered-input",
     "Domain Bucket":"< 1K"
   },
   {
     "Class":"Predicate",
-    "Name":"http:\/\/schema.org\/dateVehicleFirstRegistered-output",
+    "Name":"https://schema.org/dateVehicleFirstRegistered-output",
     "Domain Bucket":"< 1K"
   },
   {
     "Class":"Predicate",
-    "Name":"http:\/\/schema.org\/dateline",
+    "Name":"https://schema.org/dateline",
     "Domain Bucket":"1K - 10K"
   },
   {
     "Class":"Predicate",
-    "Name":"http:\/\/schema.org\/dateline-input",
+    "Name":"https://schema.org/dateline-input",
     "Domain Bucket":"< 1K"
   },
   {
     "Class":"Predicate",
-    "Name":"http:\/\/schema.org\/dateline-output",
+    "Name":"https://schema.org/dateline-output",
     "Domain Bucket":"< 1K"
   },
   {
     "Class":"Predicate",
-    "Name":"http:\/\/schema.org\/dayOfWeek",
+    "Name":"https://schema.org/dayOfWeek",
     "Domain Bucket":"1M - 10M"
   },
   {
     "Class":"Predicate",
-    "Name":"http:\/\/schema.org\/dayOfWeek-input",
+    "Name":"https://schema.org/dayOfWeek-input",
     "Domain Bucket":"< 1K"
   },
   {
     "Class":"Predicate",
-    "Name":"http:\/\/schema.org\/dayOfWeek-output",
+    "Name":"https://schema.org/dayOfWeek-output",
     "Domain Bucket":"< 1K"
   },
   {
     "Class":"Predicate",
-    "Name":"http:\/\/schema.org\/deathDate",
+    "Name":"https://schema.org/deathDate",
     "Domain Bucket":"10K - 100K"
   },
   {
     "Class":"Predicate",
-    "Name":"http:\/\/schema.org\/deathDate-input",
+    "Name":"https://schema.org/deathDate-input",
     "Domain Bucket":"< 1K"
   },
   {
     "Class":"Predicate",
-    "Name":"http:\/\/schema.org\/deathDate-output",
+    "Name":"https://schema.org/deathDate-output",
     "Domain Bucket":"< 1K"
   },
   {
     "Class":"Predicate",
-    "Name":"http:\/\/schema.org\/deathPlace",
+    "Name":"https://schema.org/deathPlace",
     "Domain Bucket":"1K - 10K"
   },
   {
     "Class":"Predicate",
-    "Name":"http:\/\/schema.org\/deathPlace-input",
+    "Name":"https://schema.org/deathPlace-input",
     "Domain Bucket":"< 1K"
   },
   {
     "Class":"Predicate",
-    "Name":"http:\/\/schema.org\/deathPlace-output",
+    "Name":"https://schema.org/deathPlace-output",
     "Domain Bucket":"< 1K"
   },
   {
     "Class":"Predicate",
-    "Name":"http:\/\/schema.org\/defaultValue",
+    "Name":"https://schema.org/defaultValue",
     "Domain Bucket":"100K - 1M"
   },
   {
     "Class":"Predicate",
-    "Name":"http:\/\/schema.org\/defaultValue-input",
+    "Name":"https://schema.org/defaultValue-input",
     "Domain Bucket":"< 1K"
   },
   {
     "Class":"Predicate",
-    "Name":"http:\/\/schema.org\/defaultValue-output",
+    "Name":"https://schema.org/defaultValue-output",
     "Domain Bucket":"< 1K"
   },
   {
     "Class":"Predicate",
-    "Name":"http:\/\/schema.org\/deliveryAddress",
+    "Name":"https://schema.org/deliveryAddress",
     "Domain Bucket":"< 1K"
   },
   {
     "Class":"Predicate",
-    "Name":"http:\/\/schema.org\/deliveryAddress-input",
+    "Name":"https://schema.org/deliveryAddress-input",
     "Domain Bucket":"< 1K"
   },
   {
     "Class":"Predicate",
-    "Name":"http:\/\/schema.org\/deliveryAddress-output",
+    "Name":"https://schema.org/deliveryAddress-output",
     "Domain Bucket":"< 1K"
   },
   {
     "Class":"Predicate",
-    "Name":"http:\/\/schema.org\/deliveryLeadTime",
+    "Name":"https://schema.org/deliveryLeadTime",
     "Domain Bucket":"10K - 100K"
   },
   {
     "Class":"Predicate",
-    "Name":"http:\/\/schema.org\/deliveryLeadTime-input",
+    "Name":"https://schema.org/deliveryLeadTime-input",
     "Domain Bucket":"< 1K"
   },
   {
     "Class":"Predicate",
-    "Name":"http:\/\/schema.org\/deliveryLeadTime-output",
+    "Name":"https://schema.org/deliveryLeadTime-output",
     "Domain Bucket":"< 1K"
   },
   {
     "Class":"Predicate",
-    "Name":"http:\/\/schema.org\/deliveryMethod",
+    "Name":"https://schema.org/deliveryMethod",
     "Domain Bucket":"100K - 1M"
   },
   {
     "Class":"Predicate",
-    "Name":"http:\/\/schema.org\/deliveryMethod-input",
+    "Name":"https://schema.org/deliveryMethod-input",
     "Domain Bucket":"< 1K"
   },
   {
     "Class":"Predicate",
-    "Name":"http:\/\/schema.org\/deliveryMethod-output",
+    "Name":"https://schema.org/deliveryMethod-output",
     "Domain Bucket":"< 1K"
   },
   {
     "Class":"Predicate",
-    "Name":"http:\/\/schema.org\/deliveryStatus",
+    "Name":"https://schema.org/deliveryStatus",
     "Domain Bucket":"< 1K"
   },
   {
     "Class":"Predicate",
-    "Name":"http:\/\/schema.org\/deliveryStatus-input",
+    "Name":"https://schema.org/deliveryStatus-input",
     "Domain Bucket":"< 1K"
   },
   {
     "Class":"Predicate",
-    "Name":"http:\/\/schema.org\/deliveryStatus-output",
+    "Name":"https://schema.org/deliveryStatus-output",
     "Domain Bucket":"< 1K"
   },
   {
     "Class":"Predicate",
-    "Name":"http:\/\/schema.org\/deliveryTime",
+    "Name":"https://schema.org/deliveryTime",
     "Domain Bucket":"100K - 1M"
   },
   {
     "Class":"Predicate",
-    "Name":"http:\/\/schema.org\/deliveryTime-input",
+    "Name":"https://schema.org/deliveryTime-input",
     "Domain Bucket":"< 1K"
   },
   {
     "Class":"Predicate",
-    "Name":"http:\/\/schema.org\/deliveryTime-output",
+    "Name":"https://schema.org/deliveryTime-output",
     "Domain Bucket":"< 1K"
   },
   {
     "Class":"Predicate",
-    "Name":"http:\/\/schema.org\/department",
+    "Name":"https://schema.org/department",
     "Domain Bucket":"10K - 100K"
   },
   {
     "Class":"Predicate",
-    "Name":"http:\/\/schema.org\/department-input",
+    "Name":"https://schema.org/department-input",
     "Domain Bucket":"< 1K"
   },
   {
     "Class":"Predicate",
-    "Name":"http:\/\/schema.org\/department-output",
+    "Name":"https://schema.org/department-output",
     "Domain Bucket":"< 1K"
   },
   {
     "Class":"Predicate",
-    "Name":"http:\/\/schema.org\/departureAirport",
+    "Name":"https://schema.org/departureAirport",
     "Domain Bucket":"1K - 10K"
   },
   {
     "Class":"Predicate",
-    "Name":"http:\/\/schema.org\/departureAirport-input",
+    "Name":"https://schema.org/departureAirport-input",
     "Domain Bucket":"< 1K"
   },
   {
     "Class":"Predicate",
-    "Name":"http:\/\/schema.org\/departureAirport-output",
+    "Name":"https://schema.org/departureAirport-output",
     "Domain Bucket":"< 1K"
   },
   {
     "Class":"Predicate",
-    "Name":"http:\/\/schema.org\/departureBoatTerminal",
+    "Name":"https://schema.org/departureBoatTerminal",
     "Domain Bucket":"< 1K"
   },
   {
     "Class":"Predicate",
-    "Name":"http:\/\/schema.org\/departureBoatTerminal-input",
+    "Name":"https://schema.org/departureBoatTerminal-input",
     "Domain Bucket":"< 1K"
   },
   {
     "Class":"Predicate",
-    "Name":"http:\/\/schema.org\/departureBoatTerminal-output",
+    "Name":"https://schema.org/departureBoatTerminal-output",
     "Domain Bucket":"< 1K"
   },
   {
     "Class":"Predicate",
-    "Name":"http:\/\/schema.org\/departureBusStop",
+    "Name":"https://schema.org/departureBusStop",
     "Domain Bucket":"< 1K"
   },
   {
     "Class":"Predicate",
-    "Name":"http:\/\/schema.org\/departureBusStop-input",
+    "Name":"https://schema.org/departureBusStop-input",
     "Domain Bucket":"< 1K"
   },
   {
     "Class":"Predicate",
-    "Name":"http:\/\/schema.org\/departureBusStop-output",
+    "Name":"https://schema.org/departureBusStop-output",
     "Domain Bucket":"< 1K"
   },
   {
     "Class":"Predicate",
-    "Name":"http:\/\/schema.org\/departureGate",
+    "Name":"https://schema.org/departureGate",
     "Domain Bucket":"< 1K"
   },
   {
     "Class":"Predicate",
-    "Name":"http:\/\/schema.org\/departureGate-input",
+    "Name":"https://schema.org/departureGate-input",
     "Domain Bucket":"< 1K"
   },
   {
     "Class":"Predicate",
-    "Name":"http:\/\/schema.org\/departureGate-output",
+    "Name":"https://schema.org/departureGate-output",
     "Domain Bucket":"< 1K"
   },
   {
     "Class":"Predicate",
-    "Name":"http:\/\/schema.org\/departurePlatform",
+    "Name":"https://schema.org/departurePlatform",
     "Domain Bucket":"< 1K"
   },
   {
     "Class":"Predicate",
-    "Name":"http:\/\/schema.org\/departurePlatform-input",
+    "Name":"https://schema.org/departurePlatform-input",
     "Domain Bucket":"< 1K"
   },
   {
     "Class":"Predicate",
-    "Name":"http:\/\/schema.org\/departurePlatform-output",
+    "Name":"https://schema.org/departurePlatform-output",
     "Domain Bucket":"< 1K"
   },
   {
     "Class":"Predicate",
-    "Name":"http:\/\/schema.org\/departureStation",
+    "Name":"https://schema.org/departureStation",
     "Domain Bucket":"< 1K"
   },
   {
     "Class":"Predicate",
-    "Name":"http:\/\/schema.org\/departureStation-input",
+    "Name":"https://schema.org/departureStation-input",
     "Domain Bucket":"< 1K"
   },
   {
     "Class":"Predicate",
-    "Name":"http:\/\/schema.org\/departureStation-output",
+    "Name":"https://schema.org/departureStation-output",
     "Domain Bucket":"< 1K"
   },
   {
     "Class":"Predicate",
-    "Name":"http:\/\/schema.org\/departureTerminal",
+    "Name":"https://schema.org/departureTerminal",
     "Domain Bucket":"< 1K"
   },
   {
     "Class":"Predicate",
-    "Name":"http:\/\/schema.org\/departureTerminal-input",
+    "Name":"https://schema.org/departureTerminal-input",
     "Domain Bucket":"< 1K"
   },
   {
     "Class":"Predicate",
-    "Name":"http:\/\/schema.org\/departureTerminal-output",
+    "Name":"https://schema.org/departureTerminal-output",
     "Domain Bucket":"< 1K"
   },
   {
     "Class":"Predicate",
-    "Name":"http:\/\/schema.org\/departureTime",
+    "Name":"https://schema.org/departureTime",
     "Domain Bucket":"1K - 10K"
   },
   {
     "Class":"Predicate",
-    "Name":"http:\/\/schema.org\/departureTime-input",
+    "Name":"https://schema.org/departureTime-input",
     "Domain Bucket":"< 1K"
   },
   {
     "Class":"Predicate",
-    "Name":"http:\/\/schema.org\/departureTime-output",
+    "Name":"https://schema.org/departureTime-output",
     "Domain Bucket":"< 1K"
   },
   {
     "Class":"Predicate",
-    "Name":"http:\/\/schema.org\/dependencies",
+    "Name":"https://schema.org/dependencies",
     "Domain Bucket":"10K - 100K"
   },
   {
     "Class":"Predicate",
-    "Name":"http:\/\/schema.org\/dependencies-input",
+    "Name":"https://schema.org/dependencies-input",
     "Domain Bucket":"< 1K"
   },
   {
     "Class":"Predicate",
-    "Name":"http:\/\/schema.org\/dependencies-output",
+    "Name":"https://schema.org/dependencies-output",
     "Domain Bucket":"< 1K"
   },
   {
     "Class":"Predicate",
-    "Name":"http:\/\/schema.org\/depth",
+    "Name":"https://schema.org/depth",
     "Domain Bucket":"10K - 100K"
   },
   {
     "Class":"Predicate",
-    "Name":"http:\/\/schema.org\/depth-input",
+    "Name":"https://schema.org/depth-input",
     "Domain Bucket":"< 1K"
   },
   {
     "Class":"Predicate",
-    "Name":"http:\/\/schema.org\/depth-output",
+    "Name":"https://schema.org/depth-output",
     "Domain Bucket":"< 1K"
   },
   {
     "Class":"Predicate",
-    "Name":"http:\/\/schema.org\/description",
+    "Name":"https://schema.org/description",
     "Domain Bucket":"10M+"
   },
   {
     "Class":"Predicate",
-    "Name":"http:\/\/schema.org\/description-input",
+    "Name":"https://schema.org/description-input",
     "Domain Bucket":"< 1K"
   },
   {
     "Class":"Predicate",
-    "Name":"http:\/\/schema.org\/description-output",
+    "Name":"https://schema.org/description-output",
     "Domain Bucket":"< 1K"
   },
   {
     "Class":"Predicate",
-    "Name":"http:\/\/schema.org\/device",
+    "Name":"https://schema.org/device",
     "Domain Bucket":"< 1K"
   },
   {
     "Class":"Predicate",
-    "Name":"http:\/\/schema.org\/device-input",
+    "Name":"https://schema.org/device-input",
     "Domain Bucket":"< 1K"
   },
   {
     "Class":"Predicate",
-    "Name":"http:\/\/schema.org\/device-output",
+    "Name":"https://schema.org/device-output",
     "Domain Bucket":"< 1K"
   },
   {
     "Class":"Predicate",
-    "Name":"http:\/\/schema.org\/diagnosis",
+    "Name":"https://schema.org/diagnosis",
     "Domain Bucket":"< 1K"
   },
   {
     "Class":"Predicate",
-    "Name":"http:\/\/schema.org\/diagnosis-input",
+    "Name":"https://schema.org/diagnosis-input",
     "Domain Bucket":"< 1K"
   },
   {
     "Class":"Predicate",
-    "Name":"http:\/\/schema.org\/diagnosis-output",
+    "Name":"https://schema.org/diagnosis-output",
     "Domain Bucket":"< 1K"
   },
   {
     "Class":"Predicate",
-    "Name":"http:\/\/schema.org\/diagram",
+    "Name":"https://schema.org/diagram",
     "Domain Bucket":"< 1K"
   },
   {
     "Class":"Predicate",
-    "Name":"http:\/\/schema.org\/diagram-input",
+    "Name":"https://schema.org/diagram-input",
     "Domain Bucket":"< 1K"
   },
   {
     "Class":"Predicate",
-    "Name":"http:\/\/schema.org\/diagram-output",
+    "Name":"https://schema.org/diagram-output",
     "Domain Bucket":"< 1K"
   },
   {
     "Class":"Predicate",
-    "Name":"http:\/\/schema.org\/diet",
+    "Name":"https://schema.org/diet",
     "Domain Bucket":"< 1K"
   },
   {
     "Class":"Predicate",
-    "Name":"http:\/\/schema.org\/diet-input",
+    "Name":"https://schema.org/diet-input",
     "Domain Bucket":"< 1K"
   },
   {
     "Class":"Predicate",
-    "Name":"http:\/\/schema.org\/diet-output",
+    "Name":"https://schema.org/diet-output",
     "Domain Bucket":"< 1K"
   },
   {
     "Class":"Predicate",
-    "Name":"http:\/\/schema.org\/dietFeatures",
+    "Name":"https://schema.org/dietFeatures",
     "Domain Bucket":"< 1K"
   },
   {
     "Class":"Predicate",
-    "Name":"http:\/\/schema.org\/dietFeatures-input",
+    "Name":"https://schema.org/dietFeatures-input",
     "Domain Bucket":"< 1K"
   },
   {
     "Class":"Predicate",
-    "Name":"http:\/\/schema.org\/dietFeatures-output",
+    "Name":"https://schema.org/dietFeatures-output",
     "Domain Bucket":"< 1K"
   },
   {
     "Class":"Predicate",
-    "Name":"http:\/\/schema.org\/differentialDiagnosis",
+    "Name":"https://schema.org/differentialDiagnosis",
     "Domain Bucket":"< 1K"
   },
   {
     "Class":"Predicate",
-    "Name":"http:\/\/schema.org\/differentialDiagnosis-input",
+    "Name":"https://schema.org/differentialDiagnosis-input",
     "Domain Bucket":"< 1K"
   },
   {
     "Class":"Predicate",
-    "Name":"http:\/\/schema.org\/differentialDiagnosis-output",
+    "Name":"https://schema.org/differentialDiagnosis-output",
     "Domain Bucket":"< 1K"
   },
   {
     "Class":"Predicate",
-    "Name":"http:\/\/schema.org\/digitalSourceType",
+    "Name":"https://schema.org/digitalSourceType",
     "Domain Bucket":"< 1K"
   },
   {
     "Class":"Predicate",
-    "Name":"http:\/\/schema.org\/digitalSourceType-input",
+    "Name":"https://schema.org/digitalSourceType-input",
     "Domain Bucket":"< 1K"
   },
   {
     "Class":"Predicate",
-    "Name":"http:\/\/schema.org\/digitalSourceType-output",
+    "Name":"https://schema.org/digitalSourceType-output",
     "Domain Bucket":"< 1K"
   },
   {
     "Class":"Predicate",
-    "Name":"http:\/\/schema.org\/directApply",
+    "Name":"https://schema.org/directApply",
     "Domain Bucket":"10K - 100K"
   },
   {
     "Class":"Predicate",
-    "Name":"http:\/\/schema.org\/directApply-input",
+    "Name":"https://schema.org/directApply-input",
     "Domain Bucket":"< 1K"
   },
   {
     "Class":"Predicate",
-    "Name":"http:\/\/schema.org\/directApply-output",
+    "Name":"https://schema.org/directApply-output",
     "Domain Bucket":"< 1K"
   },
   {
     "Class":"Predicate",
-    "Name":"http:\/\/schema.org\/director",
+    "Name":"https://schema.org/director",
     "Domain Bucket":"10K - 100K"
   },
   {
     "Class":"Predicate",
-    "Name":"http:\/\/schema.org\/director-input",
+    "Name":"https://schema.org/director-input",
     "Domain Bucket":"< 1K"
   },
   {
     "Class":"Predicate",
-    "Name":"http:\/\/schema.org\/director-output",
+    "Name":"https://schema.org/director-output",
     "Domain Bucket":"< 1K"
   },
   {
     "Class":"Predicate",
-    "Name":"http:\/\/schema.org\/directors",
+    "Name":"https://schema.org/directors",
     "Domain Bucket":"< 1K"
   },
   {
     "Class":"Predicate",
-    "Name":"http:\/\/schema.org\/directors-input",
+    "Name":"https://schema.org/directors-input",
     "Domain Bucket":"< 1K"
   },
   {
     "Class":"Predicate",
-    "Name":"http:\/\/schema.org\/directors-output",
+    "Name":"https://schema.org/directors-output",
     "Domain Bucket":"< 1K"
   },
   {
     "Class":"Predicate",
-    "Name":"http:\/\/schema.org\/disambiguatingDescription",
+    "Name":"https://schema.org/disambiguatingDescription",
     "Domain Bucket":"10K - 100K"
   },
   {
     "Class":"Predicate",
-    "Name":"http:\/\/schema.org\/disambiguatingDescription-input",
+    "Name":"https://schema.org/disambiguatingDescription-input",
     "Domain Bucket":"< 1K"
   },
   {
     "Class":"Predicate",
-    "Name":"http:\/\/schema.org\/disambiguatingDescription-output",
+    "Name":"https://schema.org/disambiguatingDescription-output",
     "Domain Bucket":"< 1K"
   },
   {
     "Class":"Predicate",
-    "Name":"http:\/\/schema.org\/discount",
+    "Name":"https://schema.org/discount",
     "Domain Bucket":"10K - 100K"
   },
   {
     "Class":"Predicate",
-    "Name":"http:\/\/schema.org\/discount-input",
+    "Name":"https://schema.org/discount-input",
     "Domain Bucket":"< 1K"
   },
   {
     "Class":"Predicate",
-    "Name":"http:\/\/schema.org\/discount-output",
+    "Name":"https://schema.org/discount-output",
     "Domain Bucket":"< 1K"
   },
   {
     "Class":"Predicate",
-    "Name":"http:\/\/schema.org\/discountCode",
+    "Name":"https://schema.org/discountCode",
     "Domain Bucket":"< 1K"
   },
   {
     "Class":"Predicate",
-    "Name":"http:\/\/schema.org\/discountCode-input",
+    "Name":"https://schema.org/discountCode-input",
     "Domain Bucket":"< 1K"
   },
   {
     "Class":"Predicate",
-    "Name":"http:\/\/schema.org\/discountCode-output",
+    "Name":"https://schema.org/discountCode-output",
     "Domain Bucket":"< 1K"
   },
   {
     "Class":"Predicate",
-    "Name":"http:\/\/schema.org\/discountCurrency",
+    "Name":"https://schema.org/discountCurrency",
     "Domain Bucket":"< 1K"
   },
   {
     "Class":"Predicate",
-    "Name":"http:\/\/schema.org\/discountCurrency-input",
+    "Name":"https://schema.org/discountCurrency-input",
     "Domain Bucket":"< 1K"
   },
   {
     "Class":"Predicate",
-    "Name":"http:\/\/schema.org\/discountCurrency-output",
+    "Name":"https://schema.org/discountCurrency-output",
     "Domain Bucket":"< 1K"
   },
   {
     "Class":"Predicate",
-    "Name":"http:\/\/schema.org\/discusses",
+    "Name":"https://schema.org/discusses",
     "Domain Bucket":"1K - 10K"
   },
   {
     "Class":"Predicate",
-    "Name":"http:\/\/schema.org\/discusses-input",
+    "Name":"https://schema.org/discusses-input",
     "Domain Bucket":"< 1K"
   },
   {
     "Class":"Predicate",
-    "Name":"http:\/\/schema.org\/discusses-output",
+    "Name":"https://schema.org/discusses-output",
     "Domain Bucket":"< 1K"
   },
   {
     "Class":"Predicate",
-    "Name":"http:\/\/schema.org\/discussionUrl",
+    "Name":"https://schema.org/discussionUrl",
     "Domain Bucket":"10K - 100K"
   },
   {
     "Class":"Predicate",
-    "Name":"http:\/\/schema.org\/discussionUrl-input",
+    "Name":"https://schema.org/discussionUrl-input",
     "Domain Bucket":"< 1K"
   },
   {
     "Class":"Predicate",
-    "Name":"http:\/\/schema.org\/discussionUrl-output",
+    "Name":"https://schema.org/discussionUrl-output",
     "Domain Bucket":"< 1K"
   },
   {
     "Class":"Predicate",
-    "Name":"http:\/\/schema.org\/diseasePreventionInfo",
+    "Name":"https://schema.org/diseasePreventionInfo",
     "Domain Bucket":"< 1K"
   },
   {
     "Class":"Predicate",
-    "Name":"http:\/\/schema.org\/diseasePreventionInfo-input",
+    "Name":"https://schema.org/diseasePreventionInfo-input",
     "Domain Bucket":"< 1K"
   },
   {
     "Class":"Predicate",
-    "Name":"http:\/\/schema.org\/diseasePreventionInfo-output",
+    "Name":"https://schema.org/diseasePreventionInfo-output",
     "Domain Bucket":"< 1K"
   },
   {
     "Class":"Predicate",
-    "Name":"http:\/\/schema.org\/diseaseSpreadStatistics",
+    "Name":"https://schema.org/diseaseSpreadStatistics",
     "Domain Bucket":"< 1K"
   },
   {
     "Class":"Predicate",
-    "Name":"http:\/\/schema.org\/diseaseSpreadStatistics-input",
+    "Name":"https://schema.org/diseaseSpreadStatistics-input",
     "Domain Bucket":"< 1K"
   },
   {
     "Class":"Predicate",
-    "Name":"http:\/\/schema.org\/diseaseSpreadStatistics-output",
+    "Name":"https://schema.org/diseaseSpreadStatistics-output",
     "Domain Bucket":"< 1K"
   },
   {
     "Class":"Predicate",
-    "Name":"http:\/\/schema.org\/displayLocation",
+    "Name":"https://schema.org/displayLocation",
     "Domain Bucket":"< 1K"
   },
   {
     "Class":"Predicate",
-    "Name":"http:\/\/schema.org\/displayLocation-input",
+    "Name":"https://schema.org/displayLocation-input",
     "Domain Bucket":"< 1K"
   },
   {
     "Class":"Predicate",
-    "Name":"http:\/\/schema.org\/displayLocation-output",
+    "Name":"https://schema.org/displayLocation-output",
     "Domain Bucket":"< 1K"
   },
   {
     "Class":"Predicate",
-    "Name":"http:\/\/schema.org\/dissolutionDate",
+    "Name":"https://schema.org/dissolutionDate",
     "Domain Bucket":"< 1K"
   },
   {
     "Class":"Predicate",
-    "Name":"http:\/\/schema.org\/dissolutionDate-input",
+    "Name":"https://schema.org/dissolutionDate-input",
     "Domain Bucket":"< 1K"
   },
   {
     "Class":"Predicate",
-    "Name":"http:\/\/schema.org\/dissolutionDate-output",
+    "Name":"https://schema.org/dissolutionDate-output",
     "Domain Bucket":"< 1K"
   },
   {
     "Class":"Predicate",
-    "Name":"http:\/\/schema.org\/distance",
+    "Name":"https://schema.org/distance",
     "Domain Bucket":"1K - 10K"
   },
   {
     "Class":"Predicate",
-    "Name":"http:\/\/schema.org\/distance-input",
+    "Name":"https://schema.org/distance-input",
     "Domain Bucket":"< 1K"
   },
   {
     "Class":"Predicate",
-    "Name":"http:\/\/schema.org\/distance-output",
+    "Name":"https://schema.org/distance-output",
     "Domain Bucket":"< 1K"
   },
   {
     "Class":"Predicate",
-    "Name":"http:\/\/schema.org\/distinguishingSign",
+    "Name":"https://schema.org/distinguishingSign",
     "Domain Bucket":"< 1K"
   },
   {
     "Class":"Predicate",
-    "Name":"http:\/\/schema.org\/distinguishingSign-input",
+    "Name":"https://schema.org/distinguishingSign-input",
     "Domain Bucket":"< 1K"
   },
   {
     "Class":"Predicate",
-    "Name":"http:\/\/schema.org\/distinguishingSign-output",
+    "Name":"https://schema.org/distinguishingSign-output",
     "Domain Bucket":"< 1K"
   },
   {
     "Class":"Predicate",
-    "Name":"http:\/\/schema.org\/distribution",
+    "Name":"https://schema.org/distribution",
     "Domain Bucket":"10K - 100K"
   },
   {
     "Class":"Predicate",
-    "Name":"http:\/\/schema.org\/distribution-input",
+    "Name":"https://schema.org/distribution-input",
     "Domain Bucket":"< 1K"
   },
   {
     "Class":"Predicate",
-    "Name":"http:\/\/schema.org\/distribution-output",
+    "Name":"https://schema.org/distribution-output",
     "Domain Bucket":"< 1K"
   },
   {
     "Class":"Predicate",
-    "Name":"http:\/\/schema.org\/diversityPolicy",
+    "Name":"https://schema.org/diversityPolicy",
     "Domain Bucket":"10K - 100K"
   },
   {
     "Class":"Predicate",
-    "Name":"http:\/\/schema.org\/diversityPolicy-input",
+    "Name":"https://schema.org/diversityPolicy-input",
     "Domain Bucket":"< 1K"
   },
   {
     "Class":"Predicate",
-    "Name":"http:\/\/schema.org\/diversityPolicy-output",
+    "Name":"https://schema.org/diversityPolicy-output",
     "Domain Bucket":"< 1K"
   },
   {
     "Class":"Predicate",
-    "Name":"http:\/\/schema.org\/diversityStaffingReport",
+    "Name":"https://schema.org/diversityStaffingReport",
     "Domain Bucket":"1K - 10K"
   },
   {
     "Class":"Predicate",
-    "Name":"http:\/\/schema.org\/diversityStaffingReport-input",
+    "Name":"https://schema.org/diversityStaffingReport-input",
     "Domain Bucket":"< 1K"
   },
   {
     "Class":"Predicate",
-    "Name":"http:\/\/schema.org\/diversityStaffingReport-output",
+    "Name":"https://schema.org/diversityStaffingReport-output",
     "Domain Bucket":"< 1K"
   },
   {
     "Class":"Predicate",
-    "Name":"http:\/\/schema.org\/documentation",
+    "Name":"https://schema.org/documentation",
     "Domain Bucket":"1K - 10K"
   },
   {
     "Class":"Predicate",
-    "Name":"http:\/\/schema.org\/documentation-input",
+    "Name":"https://schema.org/documentation-input",
     "Domain Bucket":"< 1K"
   },
   {
     "Class":"Predicate",
-    "Name":"http:\/\/schema.org\/documentation-output",
+    "Name":"https://schema.org/documentation-output",
     "Domain Bucket":"< 1K"
   },
   {
     "Class":"Predicate",
-    "Name":"http:\/\/schema.org\/doesNotShip",
+    "Name":"https://schema.org/doesNotShip",
     "Domain Bucket":"10K - 100K"
   },
   {
     "Class":"Predicate",
-    "Name":"http:\/\/schema.org\/doesNotShip-input",
+    "Name":"https://schema.org/doesNotShip-input",
     "Domain Bucket":"< 1K"
   },
   {
     "Class":"Predicate",
-    "Name":"http:\/\/schema.org\/doesNotShip-output",
+    "Name":"https://schema.org/doesNotShip-output",
     "Domain Bucket":"< 1K"
   },
   {
     "Class":"Predicate",
-    "Name":"http:\/\/schema.org\/domainIncludes",
+    "Name":"https://schema.org/domainIncludes",
     "Domain Bucket":"< 1K"
   },
   {
     "Class":"Predicate",
-    "Name":"http:\/\/schema.org\/domainIncludes-input",
+    "Name":"https://schema.org/domainIncludes-input",
     "Domain Bucket":"< 1K"
   },
   {
     "Class":"Predicate",
-    "Name":"http:\/\/schema.org\/domainIncludes-output",
+    "Name":"https://schema.org/domainIncludes-output",
     "Domain Bucket":"< 1K"
   },
   {
     "Class":"Predicate",
-    "Name":"http:\/\/schema.org\/domiciledMortgage",
+    "Name":"https://schema.org/domiciledMortgage",
     "Domain Bucket":"< 1K"
   },
   {
     "Class":"Predicate",
-    "Name":"http:\/\/schema.org\/domiciledMortgage-input",
+    "Name":"https://schema.org/domiciledMortgage-input",
     "Domain Bucket":"< 1K"
   },
   {
     "Class":"Predicate",
-    "Name":"http:\/\/schema.org\/domiciledMortgage-output",
+    "Name":"https://schema.org/domiciledMortgage-output",
     "Domain Bucket":"< 1K"
   },
   {
     "Class":"Predicate",
-    "Name":"http:\/\/schema.org\/doorTime",
+    "Name":"https://schema.org/doorTime",
     "Domain Bucket":"1K - 10K"
   },
   {
     "Class":"Predicate",
-    "Name":"http:\/\/schema.org\/doorTime-input",
+    "Name":"https://schema.org/doorTime-input",
     "Domain Bucket":"< 1K"
   },
   {
     "Class":"Predicate",
-    "Name":"http:\/\/schema.org\/doorTime-output",
+    "Name":"https://schema.org/doorTime-output",
     "Domain Bucket":"< 1K"
   },
   {
     "Class":"Predicate",
-    "Name":"http:\/\/schema.org\/dosageForm",
+    "Name":"https://schema.org/dosageForm",
     "Domain Bucket":"1K - 10K"
   },
   {
     "Class":"Predicate",
-    "Name":"http:\/\/schema.org\/dosageForm-input",
+    "Name":"https://schema.org/dosageForm-input",
     "Domain Bucket":"< 1K"
   },
   {
     "Class":"Predicate",
-    "Name":"http:\/\/schema.org\/dosageForm-output",
+    "Name":"https://schema.org/dosageForm-output",
     "Domain Bucket":"< 1K"
   },
   {
     "Class":"Predicate",
-    "Name":"http:\/\/schema.org\/doseSchedule",
+    "Name":"https://schema.org/doseSchedule",
     "Domain Bucket":"< 1K"
   },
   {
     "Class":"Predicate",
-    "Name":"http:\/\/schema.org\/doseSchedule-input",
+    "Name":"https://schema.org/doseSchedule-input",
     "Domain Bucket":"< 1K"
   },
   {
     "Class":"Predicate",
-    "Name":"http:\/\/schema.org\/doseSchedule-output",
+    "Name":"https://schema.org/doseSchedule-output",
     "Domain Bucket":"< 1K"
   },
   {
     "Class":"Predicate",
-    "Name":"http:\/\/schema.org\/doseUnit",
+    "Name":"https://schema.org/doseUnit",
     "Domain Bucket":"< 1K"
   },
   {
     "Class":"Predicate",
-    "Name":"http:\/\/schema.org\/doseUnit-input",
+    "Name":"https://schema.org/doseUnit-input",
     "Domain Bucket":"< 1K"
   },
   {
     "Class":"Predicate",
-    "Name":"http:\/\/schema.org\/doseUnit-output",
+    "Name":"https://schema.org/doseUnit-output",
     "Domain Bucket":"< 1K"
   },
   {
     "Class":"Predicate",
-    "Name":"http:\/\/schema.org\/doseValue",
+    "Name":"https://schema.org/doseValue",
     "Domain Bucket":"< 1K"
   },
   {
     "Class":"Predicate",
-    "Name":"http:\/\/schema.org\/doseValue-input",
+    "Name":"https://schema.org/doseValue-input",
     "Domain Bucket":"< 1K"
   },
   {
     "Class":"Predicate",
-    "Name":"http:\/\/schema.org\/doseValue-output",
+    "Name":"https://schema.org/doseValue-output",
     "Domain Bucket":"< 1K"
   },
   {
     "Class":"Predicate",
-    "Name":"http:\/\/schema.org\/downPayment",
+    "Name":"https://schema.org/downPayment",
     "Domain Bucket":"< 1K"
   },
   {
     "Class":"Predicate",
-    "Name":"http:\/\/schema.org\/downPayment-input",
+    "Name":"https://schema.org/downPayment-input",
     "Domain Bucket":"< 1K"
   },
   {
     "Class":"Predicate",
-    "Name":"http:\/\/schema.org\/downPayment-output",
+    "Name":"https://schema.org/downPayment-output",
     "Domain Bucket":"< 1K"
   },
   {
     "Class":"Predicate",
-    "Name":"http:\/\/schema.org\/downloadUrl",
+    "Name":"https://schema.org/downloadUrl",
     "Domain Bucket":"100K - 1M"
   },
   {
     "Class":"Predicate",
-    "Name":"http:\/\/schema.org\/downloadUrl-input",
+    "Name":"https://schema.org/downloadUrl-input",
     "Domain Bucket":"< 1K"
   },
   {
     "Class":"Predicate",
-    "Name":"http:\/\/schema.org\/downloadUrl-output",
+    "Name":"https://schema.org/downloadUrl-output",
     "Domain Bucket":"< 1K"
   },
   {
     "Class":"Predicate",
-    "Name":"http:\/\/schema.org\/downvoteCount",
+    "Name":"https://schema.org/downvoteCount",
     "Domain Bucket":"1K - 10K"
   },
   {
     "Class":"Predicate",
-    "Name":"http:\/\/schema.org\/downvoteCount-input",
+    "Name":"https://schema.org/downvoteCount-input",
     "Domain Bucket":"< 1K"
   },
   {
     "Class":"Predicate",
-    "Name":"http:\/\/schema.org\/downvoteCount-output",
+    "Name":"https://schema.org/downvoteCount-output",
     "Domain Bucket":"< 1K"
   },
   {
     "Class":"Predicate",
-    "Name":"http:\/\/schema.org\/drainsTo",
+    "Name":"https://schema.org/drainsTo",
     "Domain Bucket":"< 1K"
   },
   {
     "Class":"Predicate",
-    "Name":"http:\/\/schema.org\/drainsTo-input",
+    "Name":"https://schema.org/drainsTo-input",
     "Domain Bucket":"< 1K"
   },
   {
     "Class":"Predicate",
-    "Name":"http:\/\/schema.org\/drainsTo-output",
+    "Name":"https://schema.org/drainsTo-output",
     "Domain Bucket":"< 1K"
   },
   {
     "Class":"Predicate",
-    "Name":"http:\/\/schema.org\/driveWheelConfiguration",
+    "Name":"https://schema.org/driveWheelConfiguration",
     "Domain Bucket":"10K - 100K"
   },
   {
     "Class":"Predicate",
-    "Name":"http:\/\/schema.org\/driveWheelConfiguration-input",
+    "Name":"https://schema.org/driveWheelConfiguration-input",
     "Domain Bucket":"< 1K"
   },
   {
     "Class":"Predicate",
-    "Name":"http:\/\/schema.org\/driveWheelConfiguration-output",
+    "Name":"https://schema.org/driveWheelConfiguration-output",
     "Domain Bucket":"< 1K"
   },
   {
     "Class":"Predicate",
-    "Name":"http:\/\/schema.org\/dropoffLocation",
+    "Name":"https://schema.org/dropoffLocation",
     "Domain Bucket":"< 1K"
   },
   {
     "Class":"Predicate",
-    "Name":"http:\/\/schema.org\/dropoffLocation-input",
+    "Name":"https://schema.org/dropoffLocation-input",
     "Domain Bucket":"< 1K"
   },
   {
     "Class":"Predicate",
-    "Name":"http:\/\/schema.org\/dropoffLocation-output",
+    "Name":"https://schema.org/dropoffLocation-output",
     "Domain Bucket":"< 1K"
   },
   {
     "Class":"Predicate",
-    "Name":"http:\/\/schema.org\/dropoffTime",
+    "Name":"https://schema.org/dropoffTime",
     "Domain Bucket":"< 1K"
   },
   {
     "Class":"Predicate",
-    "Name":"http:\/\/schema.org\/dropoffTime-input",
+    "Name":"https://schema.org/dropoffTime-input",
     "Domain Bucket":"< 1K"
   },
   {
     "Class":"Predicate",
-    "Name":"http:\/\/schema.org\/dropoffTime-output",
+    "Name":"https://schema.org/dropoffTime-output",
     "Domain Bucket":"< 1K"
   },
   {
     "Class":"Predicate",
-    "Name":"http:\/\/schema.org\/drug",
+    "Name":"https://schema.org/drug",
     "Domain Bucket":"< 1K"
   },
   {
     "Class":"Predicate",
-    "Name":"http:\/\/schema.org\/drug-input",
+    "Name":"https://schema.org/drug-input",
     "Domain Bucket":"< 1K"
   },
   {
     "Class":"Predicate",
-    "Name":"http:\/\/schema.org\/drug-output",
+    "Name":"https://schema.org/drug-output",
     "Domain Bucket":"< 1K"
   },
   {
     "Class":"Predicate",
-    "Name":"http:\/\/schema.org\/drugClass",
+    "Name":"https://schema.org/drugClass",
     "Domain Bucket":"1K - 10K"
   },
   {
     "Class":"Predicate",
-    "Name":"http:\/\/schema.org\/drugClass-input",
+    "Name":"https://schema.org/drugClass-input",
     "Domain Bucket":"< 1K"
   },
   {
     "Class":"Predicate",
-    "Name":"http:\/\/schema.org\/drugClass-output",
+    "Name":"https://schema.org/drugClass-output",
     "Domain Bucket":"< 1K"
   },
   {
     "Class":"Predicate",
-    "Name":"http:\/\/schema.org\/drugUnit",
+    "Name":"https://schema.org/drugUnit",
     "Domain Bucket":"< 1K"
   },
   {
     "Class":"Predicate",
-    "Name":"http:\/\/schema.org\/drugUnit-input",
+    "Name":"https://schema.org/drugUnit-input",
     "Domain Bucket":"< 1K"
   },
   {
     "Class":"Predicate",
-    "Name":"http:\/\/schema.org\/drugUnit-output",
+    "Name":"https://schema.org/drugUnit-output",
     "Domain Bucket":"< 1K"
   },
   {
     "Class":"Predicate",
-    "Name":"http:\/\/schema.org\/duns",
+    "Name":"https://schema.org/duns",
     "Domain Bucket":"1K - 10K"
   },
   {
     "Class":"Predicate",
-    "Name":"http:\/\/schema.org\/duns-input",
+    "Name":"https://schema.org/duns-input",
     "Domain Bucket":"< 1K"
   },
   {
     "Class":"Predicate",
-    "Name":"http:\/\/schema.org\/duns-output",
+    "Name":"https://schema.org/duns-output",
     "Domain Bucket":"< 1K"
   },
   {
     "Class":"Predicate",
-    "Name":"http:\/\/schema.org\/duplicateTherapy",
+    "Name":"https://schema.org/duplicateTherapy",
     "Domain Bucket":"< 1K"
   },
   {
     "Class":"Predicate",
-    "Name":"http:\/\/schema.org\/duplicateTherapy-input",
+    "Name":"https://schema.org/duplicateTherapy-input",
     "Domain Bucket":"< 1K"
   },
   {
     "Class":"Predicate",
-    "Name":"http:\/\/schema.org\/duplicateTherapy-output",
+    "Name":"https://schema.org/duplicateTherapy-output",
     "Domain Bucket":"< 1K"
   },
   {
     "Class":"Predicate",
-    "Name":"http:\/\/schema.org\/duration",
+    "Name":"https://schema.org/duration",
     "Domain Bucket":"1M - 10M"
   },
   {
     "Class":"Predicate",
-    "Name":"http:\/\/schema.org\/duration-input",
+    "Name":"https://schema.org/duration-input",
     "Domain Bucket":"< 1K"
   },
   {
     "Class":"Predicate",
-    "Name":"http:\/\/schema.org\/duration-output",
+    "Name":"https://schema.org/duration-output",
     "Domain Bucket":"< 1K"
   },
   {
     "Class":"Predicate",
-    "Name":"http:\/\/schema.org\/durationOfWarranty",
+    "Name":"https://schema.org/durationOfWarranty",
     "Domain Bucket":"1K - 10K"
   },
   {
     "Class":"Predicate",
-    "Name":"http:\/\/schema.org\/durationOfWarranty-input",
+    "Name":"https://schema.org/durationOfWarranty-input",
     "Domain Bucket":"< 1K"
   },
   {
     "Class":"Predicate",
-    "Name":"http:\/\/schema.org\/durationOfWarranty-output",
+    "Name":"https://schema.org/durationOfWarranty-output",
     "Domain Bucket":"< 1K"
   },
   {
     "Class":"Predicate",
-    "Name":"http:\/\/schema.org\/duringMedia",
+    "Name":"https://schema.org/duringMedia",
     "Domain Bucket":"< 1K"
   },
   {
     "Class":"Predicate",
-    "Name":"http:\/\/schema.org\/duringMedia-input",
+    "Name":"https://schema.org/duringMedia-input",
     "Domain Bucket":"< 1K"
   },
   {
     "Class":"Predicate",
-    "Name":"http:\/\/schema.org\/duringMedia-output",
+    "Name":"https://schema.org/duringMedia-output",
     "Domain Bucket":"< 1K"
   },
   {
     "Class":"Predicate",
-    "Name":"http:\/\/schema.org\/earlyPrepaymentPenalty",
+    "Name":"https://schema.org/earlyPrepaymentPenalty",
     "Domain Bucket":"< 1K"
   },
   {
     "Class":"Predicate",
-    "Name":"http:\/\/schema.org\/earlyPrepaymentPenalty-input",
+    "Name":"https://schema.org/earlyPrepaymentPenalty-input",
     "Domain Bucket":"< 1K"
   },
   {
     "Class":"Predicate",
-    "Name":"http:\/\/schema.org\/earlyPrepaymentPenalty-output",
+    "Name":"https://schema.org/earlyPrepaymentPenalty-output",
     "Domain Bucket":"< 1K"
   },
   {
     "Class":"Predicate",
-    "Name":"http:\/\/schema.org\/editEIDR",
+    "Name":"https://schema.org/editEIDR",
     "Domain Bucket":"< 1K"
   },
   {
     "Class":"Predicate",
-    "Name":"http:\/\/schema.org\/editEIDR-input",
+    "Name":"https://schema.org/editEIDR-input",
     "Domain Bucket":"< 1K"
   },
   {
     "Class":"Predicate",
-    "Name":"http:\/\/schema.org\/editEIDR-output",
+    "Name":"https://schema.org/editEIDR-output",
     "Domain Bucket":"< 1K"
   },
   {
     "Class":"Predicate",
-    "Name":"http:\/\/schema.org\/editor",
+    "Name":"https://schema.org/editor",
     "Domain Bucket":"100K - 1M"
   },
   {
     "Class":"Predicate",
-    "Name":"http:\/\/schema.org\/editor-input",
+    "Name":"https://schema.org/editor-input",
     "Domain Bucket":"< 1K"
   },
   {
     "Class":"Predicate",
-    "Name":"http:\/\/schema.org\/editor-output",
+    "Name":"https://schema.org/editor-output",
     "Domain Bucket":"< 1K"
   },
   {
     "Class":"Predicate",
-    "Name":"http:\/\/schema.org\/eduQuestionType",
+    "Name":"https://schema.org/eduQuestionType",
     "Domain Bucket":"1K - 10K"
   },
   {
     "Class":"Predicate",
-    "Name":"http:\/\/schema.org\/eduQuestionType-input",
+    "Name":"https://schema.org/eduQuestionType-input",
     "Domain Bucket":"< 1K"
   },
   {
     "Class":"Predicate",
-    "Name":"http:\/\/schema.org\/eduQuestionType-output",
+    "Name":"https://schema.org/eduQuestionType-output",
     "Domain Bucket":"< 1K"
   },
   {
     "Class":"Predicate",
-    "Name":"http:\/\/schema.org\/educationRequirements",
+    "Name":"https://schema.org/educationRequirements",
     "Domain Bucket":"10K - 100K"
   },
   {
     "Class":"Predicate",
-    "Name":"http:\/\/schema.org\/educationRequirements-input",
+    "Name":"https://schema.org/educationRequirements-input",
     "Domain Bucket":"< 1K"
   },
   {
     "Class":"Predicate",
-    "Name":"http:\/\/schema.org\/educationRequirements-output",
+    "Name":"https://schema.org/educationRequirements-output",
     "Domain Bucket":"< 1K"
   },
   {
     "Class":"Predicate",
-    "Name":"http:\/\/schema.org\/educationalAlignment",
+    "Name":"https://schema.org/educationalAlignment",
     "Domain Bucket":"1K - 10K"
   },
   {
     "Class":"Predicate",
-    "Name":"http:\/\/schema.org\/educationalAlignment-input",
+    "Name":"https://schema.org/educationalAlignment-input",
     "Domain Bucket":"< 1K"
   },
   {
     "Class":"Predicate",
-    "Name":"http:\/\/schema.org\/educationalAlignment-output",
+    "Name":"https://schema.org/educationalAlignment-output",
     "Domain Bucket":"< 1K"
   },
   {
     "Class":"Predicate",
-    "Name":"http:\/\/schema.org\/educationalCredentialAwarded",
+    "Name":"https://schema.org/educationalCredentialAwarded",
     "Domain Bucket":"10K - 100K"
   },
   {
     "Class":"Predicate",
-    "Name":"http:\/\/schema.org\/educationalCredentialAwarded-input",
+    "Name":"https://schema.org/educationalCredentialAwarded-input",
     "Domain Bucket":"< 1K"
   },
   {
     "Class":"Predicate",
-    "Name":"http:\/\/schema.org\/educationalCredentialAwarded-output",
+    "Name":"https://schema.org/educationalCredentialAwarded-output",
     "Domain Bucket":"< 1K"
   },
   {
     "Class":"Predicate",
-    "Name":"http:\/\/schema.org\/educationalFramework",
+    "Name":"https://schema.org/educationalFramework",
     "Domain Bucket":"< 1K"
   },
   {
     "Class":"Predicate",
-    "Name":"http:\/\/schema.org\/educationalFramework-input",
+    "Name":"https://schema.org/educationalFramework-input",
     "Domain Bucket":"< 1K"
   },
   {
     "Class":"Predicate",
-    "Name":"http:\/\/schema.org\/educationalFramework-output",
+    "Name":"https://schema.org/educationalFramework-output",
     "Domain Bucket":"< 1K"
   },
   {
     "Class":"Predicate",
-    "Name":"http:\/\/schema.org\/educationalLevel",
+    "Name":"https://schema.org/educationalLevel",
     "Domain Bucket":"10K - 100K"
   },
   {
     "Class":"Predicate",
-    "Name":"http:\/\/schema.org\/educationalLevel-input",
+    "Name":"https://schema.org/educationalLevel-input",
     "Domain Bucket":"< 1K"
   },
   {
     "Class":"Predicate",
-    "Name":"http:\/\/schema.org\/educationalLevel-output",
+    "Name":"https://schema.org/educationalLevel-output",
     "Domain Bucket":"< 1K"
   },
   {
     "Class":"Predicate",
-    "Name":"http:\/\/schema.org\/educationalProgramMode",
+    "Name":"https://schema.org/educationalProgramMode",
     "Domain Bucket":"1K - 10K"
   },
   {
     "Class":"Predicate",
-    "Name":"http:\/\/schema.org\/educationalProgramMode-input",
+    "Name":"https://schema.org/educationalProgramMode-input",
     "Domain Bucket":"< 1K"
   },
   {
     "Class":"Predicate",
-    "Name":"http:\/\/schema.org\/educationalProgramMode-output",
+    "Name":"https://schema.org/educationalProgramMode-output",
     "Domain Bucket":"< 1K"
   },
   {
     "Class":"Predicate",
-    "Name":"http:\/\/schema.org\/educationalRole",
+    "Name":"https://schema.org/educationalRole",
     "Domain Bucket":"10K - 100K"
   },
   {
     "Class":"Predicate",
-    "Name":"http:\/\/schema.org\/educationalRole-input",
+    "Name":"https://schema.org/educationalRole-input",
     "Domain Bucket":"< 1K"
   },
   {
     "Class":"Predicate",
-    "Name":"http:\/\/schema.org\/educationalRole-output",
+    "Name":"https://schema.org/educationalRole-output",
     "Domain Bucket":"< 1K"
   },
   {
     "Class":"Predicate",
-    "Name":"http:\/\/schema.org\/educationalUse",
+    "Name":"https://schema.org/educationalUse",
     "Domain Bucket":"1K - 10K"
   },
   {
     "Class":"Predicate",
-    "Name":"http:\/\/schema.org\/educationalUse-input",
+    "Name":"https://schema.org/educationalUse-input",
     "Domain Bucket":"< 1K"
   },
   {
     "Class":"Predicate",
-    "Name":"http:\/\/schema.org\/educationalUse-output",
+    "Name":"https://schema.org/educationalUse-output",
     "Domain Bucket":"< 1K"
   },
   {
     "Class":"Predicate",
-    "Name":"http:\/\/schema.org\/elevation",
+    "Name":"https://schema.org/elevation",
     "Domain Bucket":"1K - 10K"
   },
   {
     "Class":"Predicate",
-    "Name":"http:\/\/schema.org\/elevation-input",
+    "Name":"https://schema.org/elevation-input",
     "Domain Bucket":"< 1K"
   },
   {
     "Class":"Predicate",
-    "Name":"http:\/\/schema.org\/elevation-output",
+    "Name":"https://schema.org/elevation-output",
     "Domain Bucket":"< 1K"
   },
   {
     "Class":"Predicate",
-    "Name":"http:\/\/schema.org\/eligibilityToWorkRequirement",
+    "Name":"https://schema.org/eligibilityToWorkRequirement",
     "Domain Bucket":"< 1K"
   },
   {
     "Class":"Predicate",
-    "Name":"http:\/\/schema.org\/eligibilityToWorkRequirement-input",
+    "Name":"https://schema.org/eligibilityToWorkRequirement-input",
     "Domain Bucket":"< 1K"
   },
   {
     "Class":"Predicate",
-    "Name":"http:\/\/schema.org\/eligibilityToWorkRequirement-output",
+    "Name":"https://schema.org/eligibilityToWorkRequirement-output",
     "Domain Bucket":"< 1K"
   },
   {
     "Class":"Predicate",
-    "Name":"http:\/\/schema.org\/eligibleCustomerType",
+    "Name":"https://schema.org/eligibleCustomerType",
     "Domain Bucket":"1K - 10K"
   },
   {
     "Class":"Predicate",
-    "Name":"http:\/\/schema.org\/eligibleCustomerType-input",
+    "Name":"https://schema.org/eligibleCustomerType-input",
     "Domain Bucket":"< 1K"
   },
   {
     "Class":"Predicate",
-    "Name":"http:\/\/schema.org\/eligibleCustomerType-output",
+    "Name":"https://schema.org/eligibleCustomerType-output",
     "Domain Bucket":"< 1K"
   },
   {
     "Class":"Predicate",
-    "Name":"http:\/\/schema.org\/eligibleDuration",
+    "Name":"https://schema.org/eligibleDuration",
     "Domain Bucket":"10K - 100K"
   },
   {
     "Class":"Predicate",
-    "Name":"http:\/\/schema.org\/eligibleDuration-input",
+    "Name":"https://schema.org/eligibleDuration-input",
     "Domain Bucket":"< 1K"
   },
   {
     "Class":"Predicate",
-    "Name":"http:\/\/schema.org\/eligibleDuration-output",
+    "Name":"https://schema.org/eligibleDuration-output",
     "Domain Bucket":"< 1K"
   },
   {
     "Class":"Predicate",
-    "Name":"http:\/\/schema.org\/eligibleQuantity",
+    "Name":"https://schema.org/eligibleQuantity",
     "Domain Bucket":"100K - 1M"
   },
   {
     "Class":"Predicate",
-    "Name":"http:\/\/schema.org\/eligibleQuantity-input",
+    "Name":"https://schema.org/eligibleQuantity-input",
     "Domain Bucket":"< 1K"
   },
   {
     "Class":"Predicate",
-    "Name":"http:\/\/schema.org\/eligibleQuantity-output",
+    "Name":"https://schema.org/eligibleQuantity-output",
     "Domain Bucket":"< 1K"
   },
   {
     "Class":"Predicate",
-    "Name":"http:\/\/schema.org\/eligibleRegion",
+    "Name":"https://schema.org/eligibleRegion",
     "Domain Bucket":"10K - 100K"
   },
   {
     "Class":"Predicate",
-    "Name":"http:\/\/schema.org\/eligibleRegion-input",
+    "Name":"https://schema.org/eligibleRegion-input",
     "Domain Bucket":"< 1K"
   },
   {
     "Class":"Predicate",
-    "Name":"http:\/\/schema.org\/eligibleRegion-output",
+    "Name":"https://schema.org/eligibleRegion-output",
     "Domain Bucket":"< 1K"
   },
   {
     "Class":"Predicate",
-    "Name":"http:\/\/schema.org\/eligibleTransactionVolume",
+    "Name":"https://schema.org/eligibleTransactionVolume",
     "Domain Bucket":"10K - 100K"
   },
   {
     "Class":"Predicate",
-    "Name":"http:\/\/schema.org\/eligibleTransactionVolume-input",
+    "Name":"https://schema.org/eligibleTransactionVolume-input",
     "Domain Bucket":"< 1K"
   },
   {
     "Class":"Predicate",
-    "Name":"http:\/\/schema.org\/eligibleTransactionVolume-output",
+    "Name":"https://schema.org/eligibleTransactionVolume-output",
     "Domain Bucket":"< 1K"
   },
   {
     "Class":"Predicate",
-    "Name":"http:\/\/schema.org\/eligibleWithSupplier",
+    "Name":"https://schema.org/eligibleWithSupplier",
     "Domain Bucket":"< 1K"
   },
   {
     "Class":"Predicate",
-    "Name":"http:\/\/schema.org\/eligibleWithSupplier-input",
+    "Name":"https://schema.org/eligibleWithSupplier-input",
     "Domain Bucket":"< 1K"
   },
   {
     "Class":"Predicate",
-    "Name":"http:\/\/schema.org\/eligibleWithSupplier-output",
+    "Name":"https://schema.org/eligibleWithSupplier-output",
     "Domain Bucket":"< 1K"
   },
   {
     "Class":"Predicate",
-    "Name":"http:\/\/schema.org\/email",
+    "Name":"https://schema.org/email",
     "Domain Bucket":"1M - 10M"
   },
   {
     "Class":"Predicate",
-    "Name":"http:\/\/schema.org\/email-input",
+    "Name":"https://schema.org/email-input",
     "Domain Bucket":"< 1K"
   },
   {
     "Class":"Predicate",
-    "Name":"http:\/\/schema.org\/email-output",
+    "Name":"https://schema.org/email-output",
     "Domain Bucket":"< 1K"
   },
   {
     "Class":"Predicate",
-    "Name":"http:\/\/schema.org\/embedUrl",
+    "Name":"https://schema.org/embedUrl",
     "Domain Bucket":"1M - 10M"
   },
   {
     "Class":"Predicate",
-    "Name":"http:\/\/schema.org\/embedUrl-input",
+    "Name":"https://schema.org/embedUrl-input",
     "Domain Bucket":"< 1K"
   },
   {
     "Class":"Predicate",
-    "Name":"http:\/\/schema.org\/embedUrl-output",
+    "Name":"https://schema.org/embedUrl-output",
     "Domain Bucket":"< 1K"
   },
   {
     "Class":"Predicate",
-    "Name":"http:\/\/schema.org\/embeddedTextCaption",
+    "Name":"https://schema.org/embeddedTextCaption",
     "Domain Bucket":"1K - 10K"
   },
   {
     "Class":"Predicate",
-    "Name":"http:\/\/schema.org\/embeddedTextCaption-input",
+    "Name":"https://schema.org/embeddedTextCaption-input",
     "Domain Bucket":"< 1K"
   },
   {
     "Class":"Predicate",
-    "Name":"http:\/\/schema.org\/embeddedTextCaption-output",
+    "Name":"https://schema.org/embeddedTextCaption-output",
     "Domain Bucket":"< 1K"
   },
   {
     "Class":"Predicate",
-    "Name":"http:\/\/schema.org\/emissionsCO2",
+    "Name":"https://schema.org/emissionsCO2",
     "Domain Bucket":"1K - 10K"
   },
   {
     "Class":"Predicate",
-    "Name":"http:\/\/schema.org\/emissionsCO2-input",
+    "Name":"https://schema.org/emissionsCO2-input",
     "Domain Bucket":"< 1K"
   },
   {
     "Class":"Predicate",
-    "Name":"http:\/\/schema.org\/emissionsCO2-output",
+    "Name":"https://schema.org/emissionsCO2-output",
     "Domain Bucket":"< 1K"
   },
   {
     "Class":"Predicate",
-    "Name":"http:\/\/schema.org\/employee",
+    "Name":"https://schema.org/employee",
     "Domain Bucket":"100K - 1M"
   },
   {
     "Class":"Predicate",
-    "Name":"http:\/\/schema.org\/employee-input",
+    "Name":"https://schema.org/employee-input",
     "Domain Bucket":"< 1K"
   },
   {
     "Class":"Predicate",
-    "Name":"http:\/\/schema.org\/employee-output",
+    "Name":"https://schema.org/employee-output",
     "Domain Bucket":"< 1K"
   },
   {
     "Class":"Predicate",
-    "Name":"http:\/\/schema.org\/employees",
+    "Name":"https://schema.org/employees",
     "Domain Bucket":"1K - 10K"
   },
   {
     "Class":"Predicate",
-    "Name":"http:\/\/schema.org\/employees-input",
+    "Name":"https://schema.org/employees-input",
     "Domain Bucket":"< 1K"
   },
   {
     "Class":"Predicate",
-    "Name":"http:\/\/schema.org\/employees-output",
+    "Name":"https://schema.org/employees-output",
     "Domain Bucket":"< 1K"
   },
   {
     "Class":"Predicate",
-    "Name":"http:\/\/schema.org\/employerOverview",
+    "Name":"https://schema.org/employerOverview",
     "Domain Bucket":"1K - 10K"
   },
   {
     "Class":"Predicate",
-    "Name":"http:\/\/schema.org\/employerOverview-input",
+    "Name":"https://schema.org/employerOverview-input",
     "Domain Bucket":"< 1K"
   },
   {
     "Class":"Predicate",
-    "Name":"http:\/\/schema.org\/employerOverview-output",
+    "Name":"https://schema.org/employerOverview-output",
     "Domain Bucket":"< 1K"
   },
   {
     "Class":"Predicate",
-    "Name":"http:\/\/schema.org\/employmentType",
+    "Name":"https://schema.org/employmentType",
     "Domain Bucket":"100K - 1M"
   },
   {
     "Class":"Predicate",
-    "Name":"http:\/\/schema.org\/employmentType-input",
+    "Name":"https://schema.org/employmentType-input",
     "Domain Bucket":"< 1K"
   },
   {
     "Class":"Predicate",
-    "Name":"http:\/\/schema.org\/employmentType-output",
+    "Name":"https://schema.org/employmentType-output",
     "Domain Bucket":"< 1K"
   },
   {
     "Class":"Predicate",
-    "Name":"http:\/\/schema.org\/employmentUnit",
+    "Name":"https://schema.org/employmentUnit",
     "Domain Bucket":"1K - 10K"
   },
   {
     "Class":"Predicate",
-    "Name":"http:\/\/schema.org\/employmentUnit-input",
+    "Name":"https://schema.org/employmentUnit-input",
     "Domain Bucket":"< 1K"
   },
   {
     "Class":"Predicate",
-    "Name":"http:\/\/schema.org\/employmentUnit-output",
+    "Name":"https://schema.org/employmentUnit-output",
     "Domain Bucket":"< 1K"
   },
   {
     "Class":"Predicate",
-    "Name":"http:\/\/schema.org\/encodesBioChemEntity",
+    "Name":"https://schema.org/encodesBioChemEntity",
     "Domain Bucket":"< 1K"
   },
   {
     "Class":"Predicate",
-    "Name":"http:\/\/schema.org\/encodesBioChemEntity-input",
+    "Name":"https://schema.org/encodesBioChemEntity-input",
     "Domain Bucket":"< 1K"
   },
   {
     "Class":"Predicate",
-    "Name":"http:\/\/schema.org\/encodesBioChemEntity-output",
+    "Name":"https://schema.org/encodesBioChemEntity-output",
     "Domain Bucket":"< 1K"
   },
   {
     "Class":"Predicate",
-    "Name":"http:\/\/schema.org\/encodesCreativeWork",
+    "Name":"https://schema.org/encodesCreativeWork",
     "Domain Bucket":"< 1K"
   },
   {
     "Class":"Predicate",
-    "Name":"http:\/\/schema.org\/encodesCreativeWork-input",
+    "Name":"https://schema.org/encodesCreativeWork-input",
     "Domain Bucket":"< 1K"
   },
   {
     "Class":"Predicate",
-    "Name":"http:\/\/schema.org\/encodesCreativeWork-output",
+    "Name":"https://schema.org/encodesCreativeWork-output",
     "Domain Bucket":"< 1K"
   },
   {
     "Class":"Predicate",
-    "Name":"http:\/\/schema.org\/encoding",
+    "Name":"https://schema.org/encoding",
     "Domain Bucket":"100K - 1M"
   },
   {
     "Class":"Predicate",
-    "Name":"http:\/\/schema.org\/encoding-input",
+    "Name":"https://schema.org/encoding-input",
     "Domain Bucket":"< 1K"
   },
   {
     "Class":"Predicate",
-    "Name":"http:\/\/schema.org\/encoding-output",
+    "Name":"https://schema.org/encoding-output",
     "Domain Bucket":"< 1K"
   },
   {
     "Class":"Predicate",
-    "Name":"http:\/\/schema.org\/encodingFormat",
+    "Name":"https://schema.org/encodingFormat",
     "Domain Bucket":"10K - 100K"
   },
   {
     "Class":"Predicate",
-    "Name":"http:\/\/schema.org\/encodingFormat-input",
+    "Name":"https://schema.org/encodingFormat-input",
     "Domain Bucket":"< 1K"
   },
   {
     "Class":"Predicate",
-    "Name":"http:\/\/schema.org\/encodingFormat-output",
+    "Name":"https://schema.org/encodingFormat-output",
     "Domain Bucket":"< 1K"
   },
   {
     "Class":"Predicate",
-    "Name":"http:\/\/schema.org\/encodingType",
+    "Name":"https://schema.org/encodingType",
     "Domain Bucket":"< 1K"
   },
   {
     "Class":"Predicate",
-    "Name":"http:\/\/schema.org\/encodingType-input",
+    "Name":"https://schema.org/encodingType-input",
     "Domain Bucket":"< 1K"
   },
   {
     "Class":"Predicate",
-    "Name":"http:\/\/schema.org\/encodingType-output",
+    "Name":"https://schema.org/encodingType-output",
     "Domain Bucket":"< 1K"
   },
   {
     "Class":"Predicate",
-    "Name":"http:\/\/schema.org\/encodings",
+    "Name":"https://schema.org/encodings",
     "Domain Bucket":"< 1K"
   },
   {
     "Class":"Predicate",
-    "Name":"http:\/\/schema.org\/encodings-input",
+    "Name":"https://schema.org/encodings-input",
     "Domain Bucket":"< 1K"
   },
   {
     "Class":"Predicate",
-    "Name":"http:\/\/schema.org\/encodings-output",
+    "Name":"https://schema.org/encodings-output",
     "Domain Bucket":"< 1K"
   },
   {
     "Class":"Predicate",
-    "Name":"http:\/\/schema.org\/endDate",
+    "Name":"https://schema.org/endDate",
     "Domain Bucket":"100K - 1M"
   },
   {
     "Class":"Predicate",
-    "Name":"http:\/\/schema.org\/endDate-input",
+    "Name":"https://schema.org/endDate-input",
     "Domain Bucket":"< 1K"
   },
   {
     "Class":"Predicate",
-    "Name":"http:\/\/schema.org\/endDate-output",
+    "Name":"https://schema.org/endDate-output",
     "Domain Bucket":"< 1K"
   },
   {
     "Class":"Predicate",
-    "Name":"http:\/\/schema.org\/endOffset",
+    "Name":"https://schema.org/endOffset",
     "Domain Bucket":"10K - 100K"
   },
   {
     "Class":"Predicate",
-    "Name":"http:\/\/schema.org\/endOffset-input",
+    "Name":"https://schema.org/endOffset-input",
     "Domain Bucket":"< 1K"
   },
   {
     "Class":"Predicate",
-    "Name":"http:\/\/schema.org\/endOffset-output",
+    "Name":"https://schema.org/endOffset-output",
     "Domain Bucket":"< 1K"
   },
   {
     "Class":"Predicate",
-    "Name":"http:\/\/schema.org\/endTime",
+    "Name":"https://schema.org/endTime",
     "Domain Bucket":"1K - 10K"
   },
   {
     "Class":"Predicate",
-    "Name":"http:\/\/schema.org\/endTime-input",
+    "Name":"https://schema.org/endTime-input",
     "Domain Bucket":"< 1K"
   },
   {
     "Class":"Predicate",
-    "Name":"http:\/\/schema.org\/endTime-output",
+    "Name":"https://schema.org/endTime-output",
     "Domain Bucket":"< 1K"
   },
   {
     "Class":"Predicate",
-    "Name":"http:\/\/schema.org\/endorsee",
+    "Name":"https://schema.org/endorsee",
     "Domain Bucket":"< 1K"
   },
   {
     "Class":"Predicate",
-    "Name":"http:\/\/schema.org\/endorsee-input",
+    "Name":"https://schema.org/endorsee-input",
     "Domain Bucket":"< 1K"
   },
   {
     "Class":"Predicate",
-    "Name":"http:\/\/schema.org\/endorsee-output",
+    "Name":"https://schema.org/endorsee-output",
     "Domain Bucket":"< 1K"
   },
   {
     "Class":"Predicate",
-    "Name":"http:\/\/schema.org\/endorsers",
+    "Name":"https://schema.org/endorsers",
     "Domain Bucket":"< 1K"
   },
   {
     "Class":"Predicate",
-    "Name":"http:\/\/schema.org\/endorsers-input",
+    "Name":"https://schema.org/endorsers-input",
     "Domain Bucket":"< 1K"
   },
   {
     "Class":"Predicate",
-    "Name":"http:\/\/schema.org\/endorsers-output",
+    "Name":"https://schema.org/endorsers-output",
     "Domain Bucket":"< 1K"
   },
   {
     "Class":"Predicate",
-    "Name":"http:\/\/schema.org\/energyEfficiencyScaleMax",
+    "Name":"https://schema.org/energyEfficiencyScaleMax",
     "Domain Bucket":"1K - 10K"
   },
   {
     "Class":"Predicate",
-    "Name":"http:\/\/schema.org\/energyEfficiencyScaleMax-input",
+    "Name":"https://schema.org/energyEfficiencyScaleMax-input",
     "Domain Bucket":"< 1K"
   },
   {
     "Class":"Predicate",
-    "Name":"http:\/\/schema.org\/energyEfficiencyScaleMax-output",
+    "Name":"https://schema.org/energyEfficiencyScaleMax-output",
     "Domain Bucket":"< 1K"
   },
   {
     "Class":"Predicate",
-    "Name":"http:\/\/schema.org\/energyEfficiencyScaleMin",
+    "Name":"https://schema.org/energyEfficiencyScaleMin",
     "Domain Bucket":"1K - 10K"
   },
   {
     "Class":"Predicate",
-    "Name":"http:\/\/schema.org\/energyEfficiencyScaleMin-input",
+    "Name":"https://schema.org/energyEfficiencyScaleMin-input",
     "Domain Bucket":"< 1K"
   },
   {
     "Class":"Predicate",
-    "Name":"http:\/\/schema.org\/energyEfficiencyScaleMin-output",
+    "Name":"https://schema.org/energyEfficiencyScaleMin-output",
     "Domain Bucket":"< 1K"
   },
   {
     "Class":"Predicate",
-    "Name":"http:\/\/schema.org\/engineDisplacement",
+    "Name":"https://schema.org/engineDisplacement",
     "Domain Bucket":"10K - 100K"
   },
   {
     "Class":"Predicate",
-    "Name":"http:\/\/schema.org\/engineDisplacement-input",
+    "Name":"https://schema.org/engineDisplacement-input",
     "Domain Bucket":"< 1K"
   },
   {
     "Class":"Predicate",
-    "Name":"http:\/\/schema.org\/engineDisplacement-output",
+    "Name":"https://schema.org/engineDisplacement-output",
     "Domain Bucket":"< 1K"
   },
   {
     "Class":"Predicate",
-    "Name":"http:\/\/schema.org\/enginePower",
+    "Name":"https://schema.org/enginePower",
     "Domain Bucket":"10K - 100K"
   },
   {
     "Class":"Predicate",
-    "Name":"http:\/\/schema.org\/enginePower-input",
+    "Name":"https://schema.org/enginePower-input",
     "Domain Bucket":"< 1K"
   },
   {
     "Class":"Predicate",
-    "Name":"http:\/\/schema.org\/enginePower-output",
+    "Name":"https://schema.org/enginePower-output",
     "Domain Bucket":"< 1K"
   },
   {
     "Class":"Predicate",
-    "Name":"http:\/\/schema.org\/engineType",
+    "Name":"https://schema.org/engineType",
     "Domain Bucket":"1K - 10K"
   },
   {
     "Class":"Predicate",
-    "Name":"http:\/\/schema.org\/engineType-input",
+    "Name":"https://schema.org/engineType-input",
     "Domain Bucket":"< 1K"
   },
   {
     "Class":"Predicate",
-    "Name":"http:\/\/schema.org\/engineType-output",
+    "Name":"https://schema.org/engineType-output",
     "Domain Bucket":"< 1K"
   },
   {
     "Class":"Predicate",
-    "Name":"http:\/\/schema.org\/entertainmentBusiness",
+    "Name":"https://schema.org/entertainmentBusiness",
     "Domain Bucket":"< 1K"
   },
   {
     "Class":"Predicate",
-    "Name":"http:\/\/schema.org\/entertainmentBusiness-input",
+    "Name":"https://schema.org/entertainmentBusiness-input",
     "Domain Bucket":"< 1K"
   },
   {
     "Class":"Predicate",
-    "Name":"http:\/\/schema.org\/entertainmentBusiness-output",
+    "Name":"https://schema.org/entertainmentBusiness-output",
     "Domain Bucket":"< 1K"
   },
   {
     "Class":"Predicate",
-    "Name":"http:\/\/schema.org\/epidemiology",
+    "Name":"https://schema.org/epidemiology",
     "Domain Bucket":"1K - 10K"
   },
   {
     "Class":"Predicate",
-    "Name":"http:\/\/schema.org\/epidemiology-input",
+    "Name":"https://schema.org/epidemiology-input",
     "Domain Bucket":"< 1K"
   },
   {
     "Class":"Predicate",
-    "Name":"http:\/\/schema.org\/epidemiology-output",
+    "Name":"https://schema.org/epidemiology-output",
     "Domain Bucket":"< 1K"
   },
   {
     "Class":"Predicate",
-    "Name":"http:\/\/schema.org\/episode",
+    "Name":"https://schema.org/episode",
     "Domain Bucket":"1K - 10K"
   },
   {
     "Class":"Predicate",
-    "Name":"http:\/\/schema.org\/episode-input",
+    "Name":"https://schema.org/episode-input",
     "Domain Bucket":"< 1K"
   },
   {
     "Class":"Predicate",
-    "Name":"http:\/\/schema.org\/episode-output",
+    "Name":"https://schema.org/episode-output",
     "Domain Bucket":"< 1K"
   },
   {
     "Class":"Predicate",
-    "Name":"http:\/\/schema.org\/episodeNumber",
+    "Name":"https://schema.org/episodeNumber",
     "Domain Bucket":"10K - 100K"
   },
   {
     "Class":"Predicate",
-    "Name":"http:\/\/schema.org\/episodeNumber-input",
+    "Name":"https://schema.org/episodeNumber-input",
     "Domain Bucket":"< 1K"
   },
   {
     "Class":"Predicate",
-    "Name":"http:\/\/schema.org\/episodeNumber-output",
+    "Name":"https://schema.org/episodeNumber-output",
     "Domain Bucket":"< 1K"
   },
   {
     "Class":"Predicate",
-    "Name":"http:\/\/schema.org\/episodes",
+    "Name":"https://schema.org/episodes",
     "Domain Bucket":"< 1K"
   },
   {
     "Class":"Predicate",
-    "Name":"http:\/\/schema.org\/episodes-input",
+    "Name":"https://schema.org/episodes-input",
     "Domain Bucket":"< 1K"
   },
   {
     "Class":"Predicate",
-    "Name":"http:\/\/schema.org\/episodes-output",
+    "Name":"https://schema.org/episodes-output",
     "Domain Bucket":"< 1K"
   },
   {
     "Class":"Predicate",
-    "Name":"http:\/\/schema.org\/equal",
+    "Name":"https://schema.org/equal",
     "Domain Bucket":"< 1K"
   },
   {
     "Class":"Predicate",
-    "Name":"http:\/\/schema.org\/equal-input",
+    "Name":"https://schema.org/equal-input",
     "Domain Bucket":"< 1K"
   },
   {
     "Class":"Predicate",
-    "Name":"http:\/\/schema.org\/equal-output",
+    "Name":"https://schema.org/equal-output",
     "Domain Bucket":"< 1K"
   },
   {
     "Class":"Predicate",
-    "Name":"http:\/\/schema.org\/error",
+    "Name":"https://schema.org/error",
     "Domain Bucket":"1K - 10K"
   },
   {
     "Class":"Predicate",
-    "Name":"http:\/\/schema.org\/error-input",
+    "Name":"https://schema.org/error-input",
     "Domain Bucket":"< 1K"
   },
   {
     "Class":"Predicate",
-    "Name":"http:\/\/schema.org\/error-output",
+    "Name":"https://schema.org/error-output",
     "Domain Bucket":"< 1K"
   },
   {
     "Class":"Predicate",
-    "Name":"http:\/\/schema.org\/errorCode",
+    "Name":"https://schema.org/errorCode",
     "Domain Bucket":"< 1K"
   },
   {
     "Class":"Predicate",
-    "Name":"http:\/\/schema.org\/errorCode-input",
+    "Name":"https://schema.org/errorCode-input",
     "Domain Bucket":"< 1K"
   },
   {
     "Class":"Predicate",
-    "Name":"http:\/\/schema.org\/errorCode-output",
+    "Name":"https://schema.org/errorCode-output",
     "Domain Bucket":"< 1K"
   },
   {
     "Class":"Predicate",
-    "Name":"http:\/\/schema.org\/estimatedCost",
+    "Name":"https://schema.org/estimatedCost",
     "Domain Bucket":"10K - 100K"
   },
   {
     "Class":"Predicate",
-    "Name":"http:\/\/schema.org\/estimatedCost-input",
+    "Name":"https://schema.org/estimatedCost-input",
     "Domain Bucket":"< 1K"
   },
   {
     "Class":"Predicate",
-    "Name":"http:\/\/schema.org\/estimatedCost-output",
+    "Name":"https://schema.org/estimatedCost-output",
     "Domain Bucket":"< 1K"
   },
   {
     "Class":"Predicate",
-    "Name":"http:\/\/schema.org\/estimatedFlightDuration",
+    "Name":"https://schema.org/estimatedFlightDuration",
     "Domain Bucket":"< 1K"
   },
   {
     "Class":"Predicate",
-    "Name":"http:\/\/schema.org\/estimatedFlightDuration-input",
+    "Name":"https://schema.org/estimatedFlightDuration-input",
     "Domain Bucket":"< 1K"
   },
   {
     "Class":"Predicate",
-    "Name":"http:\/\/schema.org\/estimatedFlightDuration-output",
+    "Name":"https://schema.org/estimatedFlightDuration-output",
     "Domain Bucket":"< 1K"
   },
   {
     "Class":"Predicate",
-    "Name":"http:\/\/schema.org\/estimatedSalary",
+    "Name":"https://schema.org/estimatedSalary",
     "Domain Bucket":"1K - 10K"
   },
   {
     "Class":"Predicate",
-    "Name":"http:\/\/schema.org\/estimatedSalary-input",
+    "Name":"https://schema.org/estimatedSalary-input",
     "Domain Bucket":"< 1K"
   },
   {
     "Class":"Predicate",
-    "Name":"http:\/\/schema.org\/estimatedSalary-output",
+    "Name":"https://schema.org/estimatedSalary-output",
     "Domain Bucket":"< 1K"
   },
   {
     "Class":"Predicate",
-    "Name":"http:\/\/schema.org\/estimatesRiskOf",
+    "Name":"https://schema.org/estimatesRiskOf",
     "Domain Bucket":"< 1K"
   },
   {
     "Class":"Predicate",
-    "Name":"http:\/\/schema.org\/estimatesRiskOf-input",
+    "Name":"https://schema.org/estimatesRiskOf-input",
     "Domain Bucket":"< 1K"
   },
   {
     "Class":"Predicate",
-    "Name":"http:\/\/schema.org\/estimatesRiskOf-output",
+    "Name":"https://schema.org/estimatesRiskOf-output",
     "Domain Bucket":"< 1K"
   },
   {
     "Class":"Predicate",
-    "Name":"http:\/\/schema.org\/ethicsPolicy",
+    "Name":"https://schema.org/ethicsPolicy",
     "Domain Bucket":"10K - 100K"
   },
   {
     "Class":"Predicate",
-    "Name":"http:\/\/schema.org\/ethicsPolicy-input",
+    "Name":"https://schema.org/ethicsPolicy-input",
     "Domain Bucket":"< 1K"
   },
   {
     "Class":"Predicate",
-    "Name":"http:\/\/schema.org\/ethicsPolicy-output",
+    "Name":"https://schema.org/ethicsPolicy-output",
     "Domain Bucket":"< 1K"
   },
   {
     "Class":"Predicate",
-    "Name":"http:\/\/schema.org\/event",
+    "Name":"https://schema.org/event",
     "Domain Bucket":"10K - 100K"
   },
   {
     "Class":"Predicate",
-    "Name":"http:\/\/schema.org\/event-input",
+    "Name":"https://schema.org/event-input",
     "Domain Bucket":"< 1K"
   },
   {
     "Class":"Predicate",
-    "Name":"http:\/\/schema.org\/event-output",
+    "Name":"https://schema.org/event-output",
     "Domain Bucket":"< 1K"
   },
   {
     "Class":"Predicate",
-    "Name":"http:\/\/schema.org\/eventAttendanceMode",
+    "Name":"https://schema.org/eventAttendanceMode",
     "Domain Bucket":"100K - 1M"
   },
   {
     "Class":"Predicate",
-    "Name":"http:\/\/schema.org\/eventAttendanceMode-input",
+    "Name":"https://schema.org/eventAttendanceMode-input",
     "Domain Bucket":"< 1K"
   },
   {
     "Class":"Predicate",
-    "Name":"http:\/\/schema.org\/eventAttendanceMode-output",
+    "Name":"https://schema.org/eventAttendanceMode-output",
     "Domain Bucket":"< 1K"
   },
   {
     "Class":"Predicate",
-    "Name":"http:\/\/schema.org\/eventSchedule",
+    "Name":"https://schema.org/eventSchedule",
     "Domain Bucket":"1K - 10K"
   },
   {
     "Class":"Predicate",
-    "Name":"http:\/\/schema.org\/eventSchedule-input",
+    "Name":"https://schema.org/eventSchedule-input",
     "Domain Bucket":"< 1K"
   },
   {
     "Class":"Predicate",
-    "Name":"http:\/\/schema.org\/eventSchedule-output",
+    "Name":"https://schema.org/eventSchedule-output",
     "Domain Bucket":"< 1K"
   },
   {
     "Class":"Predicate",
-    "Name":"http:\/\/schema.org\/eventStatus",
+    "Name":"https://schema.org/eventStatus",
     "Domain Bucket":"100K - 1M"
   },
   {
     "Class":"Predicate",
-    "Name":"http:\/\/schema.org\/eventStatus-input",
+    "Name":"https://schema.org/eventStatus-input",
     "Domain Bucket":"< 1K"
   },
   {
     "Class":"Predicate",
-    "Name":"http:\/\/schema.org\/eventStatus-output",
+    "Name":"https://schema.org/eventStatus-output",
     "Domain Bucket":"< 1K"
   },
   {
     "Class":"Predicate",
-    "Name":"http:\/\/schema.org\/events",
+    "Name":"https://schema.org/events",
     "Domain Bucket":"1K - 10K"
   },
   {
     "Class":"Predicate",
-    "Name":"http:\/\/schema.org\/events-input",
+    "Name":"https://schema.org/events-input",
     "Domain Bucket":"< 1K"
   },
   {
     "Class":"Predicate",
-    "Name":"http:\/\/schema.org\/events-output",
+    "Name":"https://schema.org/events-output",
     "Domain Bucket":"< 1K"
   },
   {
     "Class":"Predicate",
-    "Name":"http:\/\/schema.org\/evidenceLevel",
+    "Name":"https://schema.org/evidenceLevel",
     "Domain Bucket":"< 1K"
   },
   {
     "Class":"Predicate",
-    "Name":"http:\/\/schema.org\/evidenceLevel-input",
+    "Name":"https://schema.org/evidenceLevel-input",
     "Domain Bucket":"< 1K"
   },
   {
     "Class":"Predicate",
-    "Name":"http:\/\/schema.org\/evidenceLevel-output",
+    "Name":"https://schema.org/evidenceLevel-output",
     "Domain Bucket":"< 1K"
   },
   {
     "Class":"Predicate",
-    "Name":"http:\/\/schema.org\/evidenceOrigin",
+    "Name":"https://schema.org/evidenceOrigin",
     "Domain Bucket":"< 1K"
   },
   {
     "Class":"Predicate",
-    "Name":"http:\/\/schema.org\/evidenceOrigin-input",
+    "Name":"https://schema.org/evidenceOrigin-input",
     "Domain Bucket":"< 1K"
   },
   {
     "Class":"Predicate",
-    "Name":"http:\/\/schema.org\/evidenceOrigin-output",
+    "Name":"https://schema.org/evidenceOrigin-output",
     "Domain Bucket":"< 1K"
   },
   {
     "Class":"Predicate",
-    "Name":"http:\/\/schema.org\/exampleOfWork",
+    "Name":"https://schema.org/exampleOfWork",
     "Domain Bucket":"1K - 10K"
   },
   {
     "Class":"Predicate",
-    "Name":"http:\/\/schema.org\/exampleOfWork-input",
+    "Name":"https://schema.org/exampleOfWork-input",
     "Domain Bucket":"< 1K"
   },
   {
     "Class":"Predicate",
-    "Name":"http:\/\/schema.org\/exampleOfWork-output",
+    "Name":"https://schema.org/exampleOfWork-output",
     "Domain Bucket":"< 1K"
   },
   {
     "Class":"Predicate",
-    "Name":"http:\/\/schema.org\/exceptDate",
+    "Name":"https://schema.org/exceptDate",
     "Domain Bucket":"< 1K"
   },
   {
     "Class":"Predicate",
-    "Name":"http:\/\/schema.org\/exceptDate-input",
+    "Name":"https://schema.org/exceptDate-input",
     "Domain Bucket":"< 1K"
   },
   {
     "Class":"Predicate",
-    "Name":"http:\/\/schema.org\/exceptDate-output",
+    "Name":"https://schema.org/exceptDate-output",
     "Domain Bucket":"< 1K"
   },
   {
     "Class":"Predicate",
-    "Name":"http:\/\/schema.org\/exchangeRateSpread",
+    "Name":"https://schema.org/exchangeRateSpread",
     "Domain Bucket":"< 1K"
   },
   {
     "Class":"Predicate",
-    "Name":"http:\/\/schema.org\/exchangeRateSpread-input",
+    "Name":"https://schema.org/exchangeRateSpread-input",
     "Domain Bucket":"< 1K"
   },
   {
     "Class":"Predicate",
-    "Name":"http:\/\/schema.org\/exchangeRateSpread-output",
+    "Name":"https://schema.org/exchangeRateSpread-output",
     "Domain Bucket":"< 1K"
   },
   {
     "Class":"Predicate",
-    "Name":"http:\/\/schema.org\/executableLibraryName",
+    "Name":"https://schema.org/executableLibraryName",
     "Domain Bucket":"< 1K"
   },
   {
     "Class":"Predicate",
-    "Name":"http:\/\/schema.org\/executableLibraryName-input",
+    "Name":"https://schema.org/executableLibraryName-input",
     "Domain Bucket":"< 1K"
   },
   {
     "Class":"Predicate",
-    "Name":"http:\/\/schema.org\/executableLibraryName-output",
+    "Name":"https://schema.org/executableLibraryName-output",
     "Domain Bucket":"< 1K"
   },
   {
     "Class":"Predicate",
-    "Name":"http:\/\/schema.org\/exerciseCourse",
+    "Name":"https://schema.org/exerciseCourse",
     "Domain Bucket":"< 1K"
   },
   {
     "Class":"Predicate",
-    "Name":"http:\/\/schema.org\/exerciseCourse-input",
+    "Name":"https://schema.org/exerciseCourse-input",
     "Domain Bucket":"< 1K"
   },
   {
     "Class":"Predicate",
-    "Name":"http:\/\/schema.org\/exerciseCourse-output",
+    "Name":"https://schema.org/exerciseCourse-output",
     "Domain Bucket":"< 1K"
   },
   {
     "Class":"Predicate",
-    "Name":"http:\/\/schema.org\/exercisePlan",
+    "Name":"https://schema.org/exercisePlan",
     "Domain Bucket":"< 1K"
   },
   {
     "Class":"Predicate",
-    "Name":"http:\/\/schema.org\/exercisePlan-input",
+    "Name":"https://schema.org/exercisePlan-input",
     "Domain Bucket":"< 1K"
   },
   {
     "Class":"Predicate",
-    "Name":"http:\/\/schema.org\/exercisePlan-output",
+    "Name":"https://schema.org/exercisePlan-output",
     "Domain Bucket":"< 1K"
   },
   {
     "Class":"Predicate",
-    "Name":"http:\/\/schema.org\/exerciseRelatedDiet",
+    "Name":"https://schema.org/exerciseRelatedDiet",
     "Domain Bucket":"< 1K"
   },
   {
     "Class":"Predicate",
-    "Name":"http:\/\/schema.org\/exerciseRelatedDiet-input",
+    "Name":"https://schema.org/exerciseRelatedDiet-input",
     "Domain Bucket":"< 1K"
   },
   {
     "Class":"Predicate",
-    "Name":"http:\/\/schema.org\/exerciseRelatedDiet-output",
+    "Name":"https://schema.org/exerciseRelatedDiet-output",
     "Domain Bucket":"< 1K"
   },
   {
     "Class":"Predicate",
-    "Name":"http:\/\/schema.org\/exerciseType",
+    "Name":"https://schema.org/exerciseType",
     "Domain Bucket":"< 1K"
   },
   {
     "Class":"Predicate",
-    "Name":"http:\/\/schema.org\/exerciseType-input",
+    "Name":"https://schema.org/exerciseType-input",
     "Domain Bucket":"< 1K"
   },
   {
     "Class":"Predicate",
-    "Name":"http:\/\/schema.org\/exerciseType-output",
+    "Name":"https://schema.org/exerciseType-output",
     "Domain Bucket":"< 1K"
   },
   {
     "Class":"Predicate",
-    "Name":"http:\/\/schema.org\/exifData",
+    "Name":"https://schema.org/exifData",
     "Domain Bucket":"1K - 10K"
   },
   {
     "Class":"Predicate",
-    "Name":"http:\/\/schema.org\/exifData-input",
+    "Name":"https://schema.org/exifData-input",
     "Domain Bucket":"< 1K"
   },
   {
     "Class":"Predicate",
-    "Name":"http:\/\/schema.org\/exifData-output",
+    "Name":"https://schema.org/exifData-output",
     "Domain Bucket":"< 1K"
   },
   {
     "Class":"Predicate",
-    "Name":"http:\/\/schema.org\/expectedArrivalFrom",
+    "Name":"https://schema.org/expectedArrivalFrom",
     "Domain Bucket":"< 1K"
   },
   {
     "Class":"Predicate",
-    "Name":"http:\/\/schema.org\/expectedArrivalFrom-input",
+    "Name":"https://schema.org/expectedArrivalFrom-input",
     "Domain Bucket":"< 1K"
   },
   {
     "Class":"Predicate",
-    "Name":"http:\/\/schema.org\/expectedArrivalFrom-output",
+    "Name":"https://schema.org/expectedArrivalFrom-output",
     "Domain Bucket":"< 1K"
   },
   {
     "Class":"Predicate",
-    "Name":"http:\/\/schema.org\/expectedArrivalUntil",
+    "Name":"https://schema.org/expectedArrivalUntil",
     "Domain Bucket":"< 1K"
   },
   {
     "Class":"Predicate",
-    "Name":"http:\/\/schema.org\/expectedArrivalUntil-input",
+    "Name":"https://schema.org/expectedArrivalUntil-input",
     "Domain Bucket":"< 1K"
   },
   {
     "Class":"Predicate",
-    "Name":"http:\/\/schema.org\/expectedArrivalUntil-output",
+    "Name":"https://schema.org/expectedArrivalUntil-output",
     "Domain Bucket":"< 1K"
   },
   {
     "Class":"Predicate",
-    "Name":"http:\/\/schema.org\/expectedPrognosis",
+    "Name":"https://schema.org/expectedPrognosis",
     "Domain Bucket":"< 1K"
   },
   {
     "Class":"Predicate",
-    "Name":"http:\/\/schema.org\/expectedPrognosis-input",
+    "Name":"https://schema.org/expectedPrognosis-input",
     "Domain Bucket":"< 1K"
   },
   {
     "Class":"Predicate",
-    "Name":"http:\/\/schema.org\/expectedPrognosis-output",
+    "Name":"https://schema.org/expectedPrognosis-output",
     "Domain Bucket":"< 1K"
   },
   {
     "Class":"Predicate",
-    "Name":"http:\/\/schema.org\/expectsAcceptanceOf",
+    "Name":"https://schema.org/expectsAcceptanceOf",
     "Domain Bucket":"1K - 10K"
   },
   {
     "Class":"Predicate",
-    "Name":"http:\/\/schema.org\/expectsAcceptanceOf-input",
+    "Name":"https://schema.org/expectsAcceptanceOf-input",
     "Domain Bucket":"< 1K"
   },
   {
     "Class":"Predicate",
-    "Name":"http:\/\/schema.org\/expectsAcceptanceOf-output",
+    "Name":"https://schema.org/expectsAcceptanceOf-output",
     "Domain Bucket":"< 1K"
   },
   {
     "Class":"Predicate",
-    "Name":"http:\/\/schema.org\/experienceInPlaceOfEducation",
+    "Name":"https://schema.org/experienceInPlaceOfEducation",
     "Domain Bucket":"1K - 10K"
   },
   {
     "Class":"Predicate",
-    "Name":"http:\/\/schema.org\/experienceInPlaceOfEducation-input",
+    "Name":"https://schema.org/experienceInPlaceOfEducation-input",
     "Domain Bucket":"< 1K"
   },
   {
     "Class":"Predicate",
-    "Name":"http:\/\/schema.org\/experienceInPlaceOfEducation-output",
+    "Name":"https://schema.org/experienceInPlaceOfEducation-output",
     "Domain Bucket":"< 1K"
   },
   {
     "Class":"Predicate",
-    "Name":"http:\/\/schema.org\/experienceRequirements",
+    "Name":"https://schema.org/experienceRequirements",
     "Domain Bucket":"10K - 100K"
   },
   {
     "Class":"Predicate",
-    "Name":"http:\/\/schema.org\/experienceRequirements-input",
+    "Name":"https://schema.org/experienceRequirements-input",
     "Domain Bucket":"< 1K"
   },
   {
     "Class":"Predicate",
-    "Name":"http:\/\/schema.org\/experienceRequirements-output",
+    "Name":"https://schema.org/experienceRequirements-output",
     "Domain Bucket":"< 1K"
   },
   {
     "Class":"Predicate",
-    "Name":"http:\/\/schema.org\/expertConsiderations",
+    "Name":"https://schema.org/expertConsiderations",
     "Domain Bucket":"< 1K"
   },
   {
     "Class":"Predicate",
-    "Name":"http:\/\/schema.org\/expertConsiderations-input",
+    "Name":"https://schema.org/expertConsiderations-input",
     "Domain Bucket":"< 1K"
   },
   {
     "Class":"Predicate",
-    "Name":"http:\/\/schema.org\/expertConsiderations-output",
+    "Name":"https://schema.org/expertConsiderations-output",
     "Domain Bucket":"< 1K"
   },
   {
     "Class":"Predicate",
-    "Name":"http:\/\/schema.org\/expires",
+    "Name":"https://schema.org/expires",
     "Domain Bucket":"1K - 10K"
   },
   {
     "Class":"Predicate",
-    "Name":"http:\/\/schema.org\/expires-input",
+    "Name":"https://schema.org/expires-input",
     "Domain Bucket":"< 1K"
   },
   {
     "Class":"Predicate",
-    "Name":"http:\/\/schema.org\/expires-output",
+    "Name":"https://schema.org/expires-output",
     "Domain Bucket":"< 1K"
   },
   {
     "Class":"Predicate",
-    "Name":"http:\/\/schema.org\/expressedIn",
+    "Name":"https://schema.org/expressedIn",
     "Domain Bucket":"< 1K"
   },
   {
     "Class":"Predicate",
-    "Name":"http:\/\/schema.org\/expressedIn-input",
+    "Name":"https://schema.org/expressedIn-input",
     "Domain Bucket":"< 1K"
   },
   {
     "Class":"Predicate",
-    "Name":"http:\/\/schema.org\/expressedIn-output",
+    "Name":"https://schema.org/expressedIn-output",
     "Domain Bucket":"< 1K"
   },
   {
     "Class":"Predicate",
-    "Name":"http:\/\/schema.org\/extendedAddress",
+    "Name":"https://schema.org/extendedAddress",
     "Domain Bucket":"< 1K"
   },
   {
     "Class":"Predicate",
-    "Name":"http:\/\/schema.org\/extendedAddress-input",
+    "Name":"https://schema.org/extendedAddress-input",
     "Domain Bucket":"< 1K"
   },
   {
     "Class":"Predicate",
-    "Name":"http:\/\/schema.org\/extendedAddress-output",
+    "Name":"https://schema.org/extendedAddress-output",
     "Domain Bucket":"< 1K"
   },
   {
     "Class":"Predicate",
-    "Name":"http:\/\/schema.org\/familyName",
+    "Name":"https://schema.org/familyName",
     "Domain Bucket":"100K - 1M"
   },
   {
     "Class":"Predicate",
-    "Name":"http:\/\/schema.org\/familyName-input",
+    "Name":"https://schema.org/familyName-input",
     "Domain Bucket":"< 1K"
   },
   {
     "Class":"Predicate",
-    "Name":"http:\/\/schema.org\/familyName-output",
+    "Name":"https://schema.org/familyName-output",
     "Domain Bucket":"< 1K"
   },
   {
     "Class":"Predicate",
-    "Name":"http:\/\/schema.org\/fatContent",
+    "Name":"https://schema.org/fatContent",
     "Domain Bucket":"10K - 100K"
   },
   {
     "Class":"Predicate",
-    "Name":"http:\/\/schema.org\/fatContent-input",
+    "Name":"https://schema.org/fatContent-input",
     "Domain Bucket":"< 1K"
   },
   {
     "Class":"Predicate",
-    "Name":"http:\/\/schema.org\/fatContent-output",
+    "Name":"https://schema.org/fatContent-output",
     "Domain Bucket":"< 1K"
   },
   {
     "Class":"Predicate",
-    "Name":"http:\/\/schema.org\/faxNumber",
+    "Name":"https://schema.org/faxNumber",
     "Domain Bucket":"100K - 1M"
   },
   {
     "Class":"Predicate",
-    "Name":"http:\/\/schema.org\/faxNumber-input",
+    "Name":"https://schema.org/faxNumber-input",
     "Domain Bucket":"< 1K"
   },
   {
     "Class":"Predicate",
-    "Name":"http:\/\/schema.org\/faxNumber-output",
+    "Name":"https://schema.org/faxNumber-output",
     "Domain Bucket":"< 1K"
   },
   {
     "Class":"Predicate",
-    "Name":"http:\/\/schema.org\/featureList",
+    "Name":"https://schema.org/featureList",
     "Domain Bucket":"100K - 1M"
   },
   {
     "Class":"Predicate",
-    "Name":"http:\/\/schema.org\/featureList-input",
+    "Name":"https://schema.org/featureList-input",
     "Domain Bucket":"< 1K"
   },
   {
     "Class":"Predicate",
-    "Name":"http:\/\/schema.org\/featureList-output",
+    "Name":"https://schema.org/featureList-output",
     "Domain Bucket":"< 1K"
   },
   {
     "Class":"Predicate",
-    "Name":"http:\/\/schema.org\/feesAndCommissionsSpecification",
+    "Name":"https://schema.org/feesAndCommissionsSpecification",
     "Domain Bucket":"1K - 10K"
   },
   {
     "Class":"Predicate",
-    "Name":"http:\/\/schema.org\/feesAndCommissionsSpecification-input",
+    "Name":"https://schema.org/feesAndCommissionsSpecification-input",
     "Domain Bucket":"< 1K"
   },
   {
     "Class":"Predicate",
-    "Name":"http:\/\/schema.org\/feesAndCommissionsSpecification-output",
+    "Name":"https://schema.org/feesAndCommissionsSpecification-output",
     "Domain Bucket":"< 1K"
   },
   {
     "Class":"Predicate",
-    "Name":"http:\/\/schema.org\/fiberContent",
+    "Name":"https://schema.org/fiberContent",
     "Domain Bucket":"10K - 100K"
   },
   {
     "Class":"Predicate",
-    "Name":"http:\/\/schema.org\/fiberContent-input",
+    "Name":"https://schema.org/fiberContent-input",
     "Domain Bucket":"< 1K"
   },
   {
     "Class":"Predicate",
-    "Name":"http:\/\/schema.org\/fiberContent-output",
+    "Name":"https://schema.org/fiberContent-output",
     "Domain Bucket":"< 1K"
   },
   {
     "Class":"Predicate",
-    "Name":"http:\/\/schema.org\/fileFormat",
+    "Name":"https://schema.org/fileFormat",
     "Domain Bucket":"10K - 100K"
   },
   {
     "Class":"Predicate",
-    "Name":"http:\/\/schema.org\/fileFormat-input",
+    "Name":"https://schema.org/fileFormat-input",
     "Domain Bucket":"< 1K"
   },
   {
     "Class":"Predicate",
-    "Name":"http:\/\/schema.org\/fileFormat-output",
+    "Name":"https://schema.org/fileFormat-output",
     "Domain Bucket":"< 1K"
   },
   {
     "Class":"Predicate",
-    "Name":"http:\/\/schema.org\/fileSize",
+    "Name":"https://schema.org/fileSize",
     "Domain Bucket":"100K - 1M"
   },
   {
     "Class":"Predicate",
-    "Name":"http:\/\/schema.org\/fileSize-input",
+    "Name":"https://schema.org/fileSize-input",
     "Domain Bucket":"< 1K"
   },
   {
     "Class":"Predicate",
-    "Name":"http:\/\/schema.org\/fileSize-output",
+    "Name":"https://schema.org/fileSize-output",
     "Domain Bucket":"< 1K"
   },
   {
     "Class":"Predicate",
-    "Name":"http:\/\/schema.org\/financialAidEligible",
+    "Name":"https://schema.org/financialAidEligible",
     "Domain Bucket":"< 1K"
   },
   {
     "Class":"Predicate",
-    "Name":"http:\/\/schema.org\/financialAidEligible-input",
+    "Name":"https://schema.org/financialAidEligible-input",
     "Domain Bucket":"< 1K"
   },
   {
     "Class":"Predicate",
-    "Name":"http:\/\/schema.org\/financialAidEligible-output",
+    "Name":"https://schema.org/financialAidEligible-output",
     "Domain Bucket":"< 1K"
   },
   {
     "Class":"Predicate",
-    "Name":"http:\/\/schema.org\/firstAppearance",
+    "Name":"https://schema.org/firstAppearance",
     "Domain Bucket":"< 1K"
   },
   {
     "Class":"Predicate",
-    "Name":"http:\/\/schema.org\/firstAppearance-input",
+    "Name":"https://schema.org/firstAppearance-input",
     "Domain Bucket":"< 1K"
   },
   {
     "Class":"Predicate",
-    "Name":"http:\/\/schema.org\/firstAppearance-output",
+    "Name":"https://schema.org/firstAppearance-output",
     "Domain Bucket":"< 1K"
   },
   {
     "Class":"Predicate",
-    "Name":"http:\/\/schema.org\/firstPerformance",
+    "Name":"https://schema.org/firstPerformance",
     "Domain Bucket":"< 1K"
   },
   {
     "Class":"Predicate",
-    "Name":"http:\/\/schema.org\/firstPerformance-input",
+    "Name":"https://schema.org/firstPerformance-input",
     "Domain Bucket":"< 1K"
   },
   {
     "Class":"Predicate",
-    "Name":"http:\/\/schema.org\/firstPerformance-output",
+    "Name":"https://schema.org/firstPerformance-output",
     "Domain Bucket":"< 1K"
   },
   {
     "Class":"Predicate",
-    "Name":"http:\/\/schema.org\/flightDistance",
+    "Name":"https://schema.org/flightDistance",
     "Domain Bucket":"< 1K"
   },
   {
     "Class":"Predicate",
-    "Name":"http:\/\/schema.org\/flightDistance-input",
+    "Name":"https://schema.org/flightDistance-input",
     "Domain Bucket":"< 1K"
   },
   {
     "Class":"Predicate",
-    "Name":"http:\/\/schema.org\/flightDistance-output",
+    "Name":"https://schema.org/flightDistance-output",
     "Domain Bucket":"< 1K"
   },
   {
     "Class":"Predicate",
-    "Name":"http:\/\/schema.org\/flightNumber",
+    "Name":"https://schema.org/flightNumber",
     "Domain Bucket":"< 1K"
   },
   {
     "Class":"Predicate",
-    "Name":"http:\/\/schema.org\/flightNumber-input",
+    "Name":"https://schema.org/flightNumber-input",
     "Domain Bucket":"< 1K"
   },
   {
     "Class":"Predicate",
-    "Name":"http:\/\/schema.org\/flightNumber-output",
+    "Name":"https://schema.org/flightNumber-output",
     "Domain Bucket":"< 1K"
   },
   {
     "Class":"Predicate",
-    "Name":"http:\/\/schema.org\/floorLevel",
+    "Name":"https://schema.org/floorLevel",
     "Domain Bucket":"1K - 10K"
   },
   {
     "Class":"Predicate",
-    "Name":"http:\/\/schema.org\/floorLevel-input",
+    "Name":"https://schema.org/floorLevel-input",
     "Domain Bucket":"< 1K"
   },
   {
     "Class":"Predicate",
-    "Name":"http:\/\/schema.org\/floorLevel-output",
+    "Name":"https://schema.org/floorLevel-output",
     "Domain Bucket":"< 1K"
   },
   {
     "Class":"Predicate",
-    "Name":"http:\/\/schema.org\/floorLimit",
+    "Name":"https://schema.org/floorLimit",
     "Domain Bucket":"< 1K"
   },
   {
     "Class":"Predicate",
-    "Name":"http:\/\/schema.org\/floorLimit-input",
+    "Name":"https://schema.org/floorLimit-input",
     "Domain Bucket":"< 1K"
   },
   {
     "Class":"Predicate",
-    "Name":"http:\/\/schema.org\/floorLimit-output",
+    "Name":"https://schema.org/floorLimit-output",
     "Domain Bucket":"< 1K"
   },
   {
     "Class":"Predicate",
-    "Name":"http:\/\/schema.org\/floorSize",
+    "Name":"https://schema.org/floorSize",
     "Domain Bucket":"100K - 1M"
   },
   {
     "Class":"Predicate",
-    "Name":"http:\/\/schema.org\/floorSize-input",
+    "Name":"https://schema.org/floorSize-input",
     "Domain Bucket":"< 1K"
   },
   {
     "Class":"Predicate",
-    "Name":"http:\/\/schema.org\/floorSize-output",
+    "Name":"https://schema.org/floorSize-output",
     "Domain Bucket":"< 1K"
   },
   {
     "Class":"Predicate",
-    "Name":"http:\/\/schema.org\/followee",
+    "Name":"https://schema.org/followee",
     "Domain Bucket":"< 1K"
   },
   {
     "Class":"Predicate",
-    "Name":"http:\/\/schema.org\/followee-input",
+    "Name":"https://schema.org/followee-input",
     "Domain Bucket":"< 1K"
   },
   {
     "Class":"Predicate",
-    "Name":"http:\/\/schema.org\/followee-output",
+    "Name":"https://schema.org/followee-output",
     "Domain Bucket":"< 1K"
   },
   {
     "Class":"Predicate",
-    "Name":"http:\/\/schema.org\/follows",
+    "Name":"https://schema.org/follows",
     "Domain Bucket":"< 1K"
   },
   {
     "Class":"Predicate",
-    "Name":"http:\/\/schema.org\/follows-input",
+    "Name":"https://schema.org/follows-input",
     "Domain Bucket":"< 1K"
   },
   {
     "Class":"Predicate",
-    "Name":"http:\/\/schema.org\/follows-output",
+    "Name":"https://schema.org/follows-output",
     "Domain Bucket":"< 1K"
   },
   {
     "Class":"Predicate",
-    "Name":"http:\/\/schema.org\/followup",
+    "Name":"https://schema.org/followup",
     "Domain Bucket":"1K - 10K"
   },
   {
     "Class":"Predicate",
-    "Name":"http:\/\/schema.org\/followup-input",
+    "Name":"https://schema.org/followup-input",
     "Domain Bucket":"< 1K"
   },
   {
     "Class":"Predicate",
-    "Name":"http:\/\/schema.org\/followup-output",
+    "Name":"https://schema.org/followup-output",
     "Domain Bucket":"< 1K"
   },
   {
     "Class":"Predicate",
-    "Name":"http:\/\/schema.org\/foodEstablishment",
+    "Name":"https://schema.org/foodEstablishment",
     "Domain Bucket":"< 1K"
   },
   {
     "Class":"Predicate",
-    "Name":"http:\/\/schema.org\/foodEstablishment-input",
+    "Name":"https://schema.org/foodEstablishment-input",
     "Domain Bucket":"< 1K"
   },
   {
     "Class":"Predicate",
-    "Name":"http:\/\/schema.org\/foodEstablishment-output",
+    "Name":"https://schema.org/foodEstablishment-output",
     "Domain Bucket":"< 1K"
   },
   {
     "Class":"Predicate",
-    "Name":"http:\/\/schema.org\/foodEvent",
+    "Name":"https://schema.org/foodEvent",
     "Domain Bucket":"< 1K"
   },
   {
     "Class":"Predicate",
-    "Name":"http:\/\/schema.org\/foodEvent-input",
+    "Name":"https://schema.org/foodEvent-input",
     "Domain Bucket":"< 1K"
   },
   {
     "Class":"Predicate",
-    "Name":"http:\/\/schema.org\/foodEvent-output",
+    "Name":"https://schema.org/foodEvent-output",
     "Domain Bucket":"< 1K"
   },
   {
     "Class":"Predicate",
-    "Name":"http:\/\/schema.org\/foodWarning",
+    "Name":"https://schema.org/foodWarning",
     "Domain Bucket":"< 1K"
   },
   {
     "Class":"Predicate",
-    "Name":"http:\/\/schema.org\/foodWarning-input",
+    "Name":"https://schema.org/foodWarning-input",
     "Domain Bucket":"< 1K"
   },
   {
     "Class":"Predicate",
-    "Name":"http:\/\/schema.org\/foodWarning-output",
+    "Name":"https://schema.org/foodWarning-output",
     "Domain Bucket":"< 1K"
   },
   {
     "Class":"Predicate",
-    "Name":"http:\/\/schema.org\/founder",
+    "Name":"https://schema.org/founder",
     "Domain Bucket":"100K - 1M"
   },
   {
     "Class":"Predicate",
-    "Name":"http:\/\/schema.org\/founder-input",
+    "Name":"https://schema.org/founder-input",
     "Domain Bucket":"< 1K"
   },
   {
     "Class":"Predicate",
-    "Name":"http:\/\/schema.org\/founder-output",
+    "Name":"https://schema.org/founder-output",
     "Domain Bucket":"< 1K"
   },
   {
     "Class":"Predicate",
-    "Name":"http:\/\/schema.org\/founders",
+    "Name":"https://schema.org/founders",
     "Domain Bucket":"10K - 100K"
   },
   {
     "Class":"Predicate",
-    "Name":"http:\/\/schema.org\/founders-input",
+    "Name":"https://schema.org/founders-input",
     "Domain Bucket":"< 1K"
   },
   {
     "Class":"Predicate",
-    "Name":"http:\/\/schema.org\/founders-output",
+    "Name":"https://schema.org/founders-output",
     "Domain Bucket":"< 1K"
   },
   {
     "Class":"Predicate",
-    "Name":"http:\/\/schema.org\/foundingDate",
+    "Name":"https://schema.org/foundingDate",
     "Domain Bucket":"1M - 10M"
   },
   {
     "Class":"Predicate",
-    "Name":"http:\/\/schema.org\/foundingDate-input",
+    "Name":"https://schema.org/foundingDate-input",
     "Domain Bucket":"< 1K"
   },
   {
     "Class":"Predicate",
-    "Name":"http:\/\/schema.org\/foundingDate-output",
+    "Name":"https://schema.org/foundingDate-output",
     "Domain Bucket":"< 1K"
   },
   {
     "Class":"Predicate",
-    "Name":"http:\/\/schema.org\/foundingLocation",
+    "Name":"https://schema.org/foundingLocation",
     "Domain Bucket":"100K - 1M"
   },
   {
     "Class":"Predicate",
-    "Name":"http:\/\/schema.org\/foundingLocation-input",
+    "Name":"https://schema.org/foundingLocation-input",
     "Domain Bucket":"< 1K"
   },
   {
     "Class":"Predicate",
-    "Name":"http:\/\/schema.org\/foundingLocation-output",
+    "Name":"https://schema.org/foundingLocation-output",
     "Domain Bucket":"< 1K"
   },
   {
     "Class":"Predicate",
-    "Name":"http:\/\/schema.org\/free",
+    "Name":"https://schema.org/free",
     "Domain Bucket":"1K - 10K"
   },
   {
     "Class":"Predicate",
-    "Name":"http:\/\/schema.org\/free-input",
+    "Name":"https://schema.org/free-input",
     "Domain Bucket":"< 1K"
   },
   {
     "Class":"Predicate",
-    "Name":"http:\/\/schema.org\/free-output",
+    "Name":"https://schema.org/free-output",
     "Domain Bucket":"< 1K"
   },
   {
     "Class":"Predicate",
-    "Name":"http:\/\/schema.org\/freeShippingThreshold",
+    "Name":"https://schema.org/freeShippingThreshold",
     "Domain Bucket":"10K - 100K"
   },
   {
     "Class":"Predicate",
-    "Name":"http:\/\/schema.org\/freeShippingThreshold-input",
+    "Name":"https://schema.org/freeShippingThreshold-input",
     "Domain Bucket":"< 1K"
   },
   {
     "Class":"Predicate",
-    "Name":"http:\/\/schema.org\/freeShippingThreshold-output",
+    "Name":"https://schema.org/freeShippingThreshold-output",
     "Domain Bucket":"< 1K"
   },
   {
     "Class":"Predicate",
-    "Name":"http:\/\/schema.org\/frequency",
+    "Name":"https://schema.org/frequency",
     "Domain Bucket":"< 1K"
   },
   {
     "Class":"Predicate",
-    "Name":"http:\/\/schema.org\/frequency-input",
+    "Name":"https://schema.org/frequency-input",
     "Domain Bucket":"< 1K"
   },
   {
     "Class":"Predicate",
-    "Name":"http:\/\/schema.org\/frequency-output",
+    "Name":"https://schema.org/frequency-output",
     "Domain Bucket":"< 1K"
   },
   {
     "Class":"Predicate",
-    "Name":"http:\/\/schema.org\/fromLocation",
+    "Name":"https://schema.org/fromLocation",
     "Domain Bucket":"1K - 10K"
   },
   {
     "Class":"Predicate",
-    "Name":"http:\/\/schema.org\/fromLocation-input",
+    "Name":"https://schema.org/fromLocation-input",
     "Domain Bucket":"< 1K"
   },
   {
     "Class":"Predicate",
-    "Name":"http:\/\/schema.org\/fromLocation-output",
+    "Name":"https://schema.org/fromLocation-output",
     "Domain Bucket":"< 1K"
   },
   {
     "Class":"Predicate",
-    "Name":"http:\/\/schema.org\/fuelCapacity",
+    "Name":"https://schema.org/fuelCapacity",
     "Domain Bucket":"1K - 10K"
   },
   {
     "Class":"Predicate",
-    "Name":"http:\/\/schema.org\/fuelCapacity-input",
+    "Name":"https://schema.org/fuelCapacity-input",
     "Domain Bucket":"< 1K"
   },
   {
     "Class":"Predicate",
-    "Name":"http:\/\/schema.org\/fuelCapacity-output",
+    "Name":"https://schema.org/fuelCapacity-output",
     "Domain Bucket":"< 1K"
   },
   {
     "Class":"Predicate",
-    "Name":"http:\/\/schema.org\/fuelConsumption",
+    "Name":"https://schema.org/fuelConsumption",
     "Domain Bucket":"1K - 10K"
   },
   {
     "Class":"Predicate",
-    "Name":"http:\/\/schema.org\/fuelConsumption-input",
+    "Name":"https://schema.org/fuelConsumption-input",
     "Domain Bucket":"< 1K"
   },
   {
     "Class":"Predicate",
-    "Name":"http:\/\/schema.org\/fuelConsumption-output",
+    "Name":"https://schema.org/fuelConsumption-output",
     "Domain Bucket":"< 1K"
   },
   {
     "Class":"Predicate",
-    "Name":"http:\/\/schema.org\/fuelEfficiency",
+    "Name":"https://schema.org/fuelEfficiency",
     "Domain Bucket":"10K - 100K"
   },
   {
     "Class":"Predicate",
-    "Name":"http:\/\/schema.org\/fuelEfficiency-input",
+    "Name":"https://schema.org/fuelEfficiency-input",
     "Domain Bucket":"< 1K"
   },
   {
     "Class":"Predicate",
-    "Name":"http:\/\/schema.org\/fuelEfficiency-output",
+    "Name":"https://schema.org/fuelEfficiency-output",
     "Domain Bucket":"< 1K"
   },
   {
     "Class":"Predicate",
-    "Name":"http:\/\/schema.org\/fuelType",
+    "Name":"https://schema.org/fuelType",
     "Domain Bucket":"10K - 100K"
   },
   {
     "Class":"Predicate",
-    "Name":"http:\/\/schema.org\/fuelType-input",
+    "Name":"https://schema.org/fuelType-input",
     "Domain Bucket":"< 1K"
   },
   {
     "Class":"Predicate",
-    "Name":"http:\/\/schema.org\/fuelType-output",
+    "Name":"https://schema.org/fuelType-output",
     "Domain Bucket":"< 1K"
   },
   {
     "Class":"Predicate",
-    "Name":"http:\/\/schema.org\/fulfillmentType",
+    "Name":"https://schema.org/fulfillmentType",
     "Domain Bucket":"10K - 100K"
   },
   {
     "Class":"Predicate",
-    "Name":"http:\/\/schema.org\/fulfillmentType-input",
+    "Name":"https://schema.org/fulfillmentType-input",
     "Domain Bucket":"< 1K"
   },
   {
     "Class":"Predicate",
-    "Name":"http:\/\/schema.org\/fulfillmentType-output",
+    "Name":"https://schema.org/fulfillmentType-output",
     "Domain Bucket":"< 1K"
   },
   {
     "Class":"Predicate",
-    "Name":"http:\/\/schema.org\/functionalClass",
+    "Name":"https://schema.org/functionalClass",
     "Domain Bucket":"< 1K"
   },
   {
     "Class":"Predicate",
-    "Name":"http:\/\/schema.org\/functionalClass-input",
+    "Name":"https://schema.org/functionalClass-input",
     "Domain Bucket":"< 1K"
   },
   {
     "Class":"Predicate",
-    "Name":"http:\/\/schema.org\/functionalClass-output",
+    "Name":"https://schema.org/functionalClass-output",
     "Domain Bucket":"< 1K"
   },
   {
     "Class":"Predicate",
-    "Name":"http:\/\/schema.org\/fundedItem",
+    "Name":"https://schema.org/fundedItem",
     "Domain Bucket":"< 1K"
   },
   {
     "Class":"Predicate",
-    "Name":"http:\/\/schema.org\/fundedItem-input",
+    "Name":"https://schema.org/fundedItem-input",
     "Domain Bucket":"< 1K"
   },
   {
     "Class":"Predicate",
-    "Name":"http:\/\/schema.org\/fundedItem-output",
+    "Name":"https://schema.org/fundedItem-output",
     "Domain Bucket":"< 1K"
   },
   {
     "Class":"Predicate",
-    "Name":"http:\/\/schema.org\/funder",
+    "Name":"https://schema.org/funder",
     "Domain Bucket":"10K - 100K"
   },
   {
     "Class":"Predicate",
-    "Name":"http:\/\/schema.org\/funder-input",
+    "Name":"https://schema.org/funder-input",
     "Domain Bucket":"< 1K"
   },
   {
     "Class":"Predicate",
-    "Name":"http:\/\/schema.org\/funder-output",
+    "Name":"https://schema.org/funder-output",
     "Domain Bucket":"< 1K"
   },
   {
     "Class":"Predicate",
-    "Name":"http:\/\/schema.org\/funding",
+    "Name":"https://schema.org/funding",
     "Domain Bucket":"1K - 10K"
   },
   {
     "Class":"Predicate",
-    "Name":"http:\/\/schema.org\/funding-input",
+    "Name":"https://schema.org/funding-input",
     "Domain Bucket":"< 1K"
   },
   {
     "Class":"Predicate",
-    "Name":"http:\/\/schema.org\/funding-output",
+    "Name":"https://schema.org/funding-output",
     "Domain Bucket":"< 1K"
   },
   {
     "Class":"Predicate",
-    "Name":"http:\/\/schema.org\/game",
+    "Name":"https://schema.org/game",
     "Domain Bucket":"10K - 100K"
   },
   {
     "Class":"Predicate",
-    "Name":"http:\/\/schema.org\/game-input",
+    "Name":"https://schema.org/game-input",
     "Domain Bucket":"< 1K"
   },
   {
     "Class":"Predicate",
-    "Name":"http:\/\/schema.org\/game-output",
+    "Name":"https://schema.org/game-output",
     "Domain Bucket":"< 1K"
   },
   {
     "Class":"Predicate",
-    "Name":"http:\/\/schema.org\/gameAvailabilityType",
+    "Name":"https://schema.org/gameAvailabilityType",
     "Domain Bucket":"< 1K"
   },
   {
     "Class":"Predicate",
-    "Name":"http:\/\/schema.org\/gameAvailabilityType-input",
+    "Name":"https://schema.org/gameAvailabilityType-input",
     "Domain Bucket":"< 1K"
   },
   {
     "Class":"Predicate",
-    "Name":"http:\/\/schema.org\/gameAvailabilityType-output",
+    "Name":"https://schema.org/gameAvailabilityType-output",
     "Domain Bucket":"< 1K"
   },
   {
     "Class":"Predicate",
-    "Name":"http:\/\/schema.org\/gameEdition",
+    "Name":"https://schema.org/gameEdition",
     "Domain Bucket":"< 1K"
   },
   {
     "Class":"Predicate",
-    "Name":"http:\/\/schema.org\/gameEdition-input",
+    "Name":"https://schema.org/gameEdition-input",
     "Domain Bucket":"< 1K"
   },
   {
     "Class":"Predicate",
-    "Name":"http:\/\/schema.org\/gameEdition-output",
+    "Name":"https://schema.org/gameEdition-output",
     "Domain Bucket":"< 1K"
   },
   {
     "Class":"Predicate",
-    "Name":"http:\/\/schema.org\/gameItem",
+    "Name":"https://schema.org/gameItem",
     "Domain Bucket":"10K - 100K"
   },
   {
     "Class":"Predicate",
-    "Name":"http:\/\/schema.org\/gameItem-input",
+    "Name":"https://schema.org/gameItem-input",
     "Domain Bucket":"< 1K"
   },
   {
     "Class":"Predicate",
-    "Name":"http:\/\/schema.org\/gameItem-output",
+    "Name":"https://schema.org/gameItem-output",
     "Domain Bucket":"< 1K"
   },
   {
     "Class":"Predicate",
-    "Name":"http:\/\/schema.org\/gameLocation",
+    "Name":"https://schema.org/gameLocation",
     "Domain Bucket":"10K - 100K"
   },
   {
     "Class":"Predicate",
-    "Name":"http:\/\/schema.org\/gameLocation-input",
+    "Name":"https://schema.org/gameLocation-input",
     "Domain Bucket":"< 1K"
   },
   {
     "Class":"Predicate",
-    "Name":"http:\/\/schema.org\/gameLocation-output",
+    "Name":"https://schema.org/gameLocation-output",
     "Domain Bucket":"< 1K"
   },
   {
     "Class":"Predicate",
-    "Name":"http:\/\/schema.org\/gamePlatform",
+    "Name":"https://schema.org/gamePlatform",
     "Domain Bucket":"10K - 100K"
   },
   {
     "Class":"Predicate",
-    "Name":"http:\/\/schema.org\/gamePlatform-input",
+    "Name":"https://schema.org/gamePlatform-input",
     "Domain Bucket":"< 1K"
   },
   {
     "Class":"Predicate",
-    "Name":"http:\/\/schema.org\/gamePlatform-output",
+    "Name":"https://schema.org/gamePlatform-output",
     "Domain Bucket":"< 1K"
   },
   {
     "Class":"Predicate",
-    "Name":"http:\/\/schema.org\/gameServer",
+    "Name":"https://schema.org/gameServer",
     "Domain Bucket":"< 1K"
   },
   {
     "Class":"Predicate",
-    "Name":"http:\/\/schema.org\/gameServer-input",
+    "Name":"https://schema.org/gameServer-input",
     "Domain Bucket":"< 1K"
   },
   {
     "Class":"Predicate",
-    "Name":"http:\/\/schema.org\/gameServer-output",
+    "Name":"https://schema.org/gameServer-output",
     "Domain Bucket":"< 1K"
   },
   {
     "Class":"Predicate",
-    "Name":"http:\/\/schema.org\/gameTip",
+    "Name":"https://schema.org/gameTip",
     "Domain Bucket":"< 1K"
   },
   {
     "Class":"Predicate",
-    "Name":"http:\/\/schema.org\/gameTip-input",
+    "Name":"https://schema.org/gameTip-input",
     "Domain Bucket":"< 1K"
   },
   {
     "Class":"Predicate",
-    "Name":"http:\/\/schema.org\/gameTip-output",
+    "Name":"https://schema.org/gameTip-output",
     "Domain Bucket":"< 1K"
   },
   {
     "Class":"Predicate",
-    "Name":"http:\/\/schema.org\/gender",
+    "Name":"https://schema.org/gender",
     "Domain Bucket":"10K - 100K"
   },
   {
     "Class":"Predicate",
-    "Name":"http:\/\/schema.org\/gender-input",
+    "Name":"https://schema.org/gender-input",
     "Domain Bucket":"< 1K"
   },
   {
     "Class":"Predicate",
-    "Name":"http:\/\/schema.org\/gender-output",
+    "Name":"https://schema.org/gender-output",
     "Domain Bucket":"< 1K"
   },
   {
     "Class":"Predicate",
-    "Name":"http:\/\/schema.org\/genre",
+    "Name":"https://schema.org/genre",
     "Domain Bucket":"100K - 1M"
   },
   {
     "Class":"Predicate",
-    "Name":"http:\/\/schema.org\/genre-input",
+    "Name":"https://schema.org/genre-input",
     "Domain Bucket":"< 1K"
   },
   {
     "Class":"Predicate",
-    "Name":"http:\/\/schema.org\/genre-output",
+    "Name":"https://schema.org/genre-output",
     "Domain Bucket":"< 1K"
   },
   {
     "Class":"Predicate",
-    "Name":"http:\/\/schema.org\/geo",
+    "Name":"https://schema.org/geo",
     "Domain Bucket":"1M - 10M"
   },
   {
     "Class":"Predicate",
-    "Name":"http:\/\/schema.org\/geo-input",
+    "Name":"https://schema.org/geo-input",
     "Domain Bucket":"< 1K"
   },
   {
     "Class":"Predicate",
-    "Name":"http:\/\/schema.org\/geo-output",
+    "Name":"https://schema.org/geo-output",
     "Domain Bucket":"< 1K"
   },
   {
     "Class":"Predicate",
-    "Name":"http:\/\/schema.org\/geoContains",
+    "Name":"https://schema.org/geoContains",
     "Domain Bucket":"< 1K"
   },
   {
     "Class":"Predicate",
-    "Name":"http:\/\/schema.org\/geoContains-input",
+    "Name":"https://schema.org/geoContains-input",
     "Domain Bucket":"< 1K"
   },
   {
     "Class":"Predicate",
-    "Name":"http:\/\/schema.org\/geoContains-output",
+    "Name":"https://schema.org/geoContains-output",
     "Domain Bucket":"< 1K"
   },
   {
     "Class":"Predicate",
-    "Name":"http:\/\/schema.org\/geoCoveredBy",
+    "Name":"https://schema.org/geoCoveredBy",
     "Domain Bucket":"< 1K"
   },
   {
     "Class":"Predicate",
-    "Name":"http:\/\/schema.org\/geoCoveredBy-input",
+    "Name":"https://schema.org/geoCoveredBy-input",
     "Domain Bucket":"< 1K"
   },
   {
     "Class":"Predicate",
-    "Name":"http:\/\/schema.org\/geoCoveredBy-output",
+    "Name":"https://schema.org/geoCoveredBy-output",
     "Domain Bucket":"< 1K"
   },
   {
     "Class":"Predicate",
-    "Name":"http:\/\/schema.org\/geoCovers",
+    "Name":"https://schema.org/geoCovers",
     "Domain Bucket":"< 1K"
   },
   {
     "Class":"Predicate",
-    "Name":"http:\/\/schema.org\/geoCovers-input",
+    "Name":"https://schema.org/geoCovers-input",
     "Domain Bucket":"< 1K"
   },
   {
     "Class":"Predicate",
-    "Name":"http:\/\/schema.org\/geoCovers-output",
+    "Name":"https://schema.org/geoCovers-output",
     "Domain Bucket":"< 1K"
   },
   {
     "Class":"Predicate",
-    "Name":"http:\/\/schema.org\/geoCrosses",
+    "Name":"https://schema.org/geoCrosses",
     "Domain Bucket":"< 1K"
   },
   {
     "Class":"Predicate",
-    "Name":"http:\/\/schema.org\/geoCrosses-input",
+    "Name":"https://schema.org/geoCrosses-input",
     "Domain Bucket":"< 1K"
   },
   {
     "Class":"Predicate",
-    "Name":"http:\/\/schema.org\/geoCrosses-output",
+    "Name":"https://schema.org/geoCrosses-output",
     "Domain Bucket":"< 1K"
   },
   {
     "Class":"Predicate",
-    "Name":"http:\/\/schema.org\/geoDisjoint",
+    "Name":"https://schema.org/geoDisjoint",
     "Domain Bucket":"< 1K"
   },
   {
     "Class":"Predicate",
-    "Name":"http:\/\/schema.org\/geoDisjoint-input",
+    "Name":"https://schema.org/geoDisjoint-input",
     "Domain Bucket":"< 1K"
   },
   {
     "Class":"Predicate",
-    "Name":"http:\/\/schema.org\/geoDisjoint-output",
+    "Name":"https://schema.org/geoDisjoint-output",
     "Domain Bucket":"< 1K"
   },
   {
     "Class":"Predicate",
-    "Name":"http:\/\/schema.org\/geoEquals",
+    "Name":"https://schema.org/geoEquals",
     "Domain Bucket":"< 1K"
   },
   {
     "Class":"Predicate",
-    "Name":"http:\/\/schema.org\/geoEquals-input",
+    "Name":"https://schema.org/geoEquals-input",
     "Domain Bucket":"< 1K"
   },
   {
     "Class":"Predicate",
-    "Name":"http:\/\/schema.org\/geoEquals-output",
+    "Name":"https://schema.org/geoEquals-output",
     "Domain Bucket":"< 1K"
   },
   {
     "Class":"Predicate",
-    "Name":"http:\/\/schema.org\/geoIntersects",
+    "Name":"https://schema.org/geoIntersects",
     "Domain Bucket":"< 1K"
   },
   {
     "Class":"Predicate",
-    "Name":"http:\/\/schema.org\/geoIntersects-input",
+    "Name":"https://schema.org/geoIntersects-input",
     "Domain Bucket":"< 1K"
   },
   {
     "Class":"Predicate",
-    "Name":"http:\/\/schema.org\/geoIntersects-output",
+    "Name":"https://schema.org/geoIntersects-output",
     "Domain Bucket":"< 1K"
   },
   {
     "Class":"Predicate",
-    "Name":"http:\/\/schema.org\/geoMidpoint",
+    "Name":"https://schema.org/geoMidpoint",
     "Domain Bucket":"100K - 1M"
   },
   {
     "Class":"Predicate",
-    "Name":"http:\/\/schema.org\/geoMidpoint-input",
+    "Name":"https://schema.org/geoMidpoint-input",
     "Domain Bucket":"< 1K"
   },
   {
     "Class":"Predicate",
-    "Name":"http:\/\/schema.org\/geoMidpoint-output",
+    "Name":"https://schema.org/geoMidpoint-output",
     "Domain Bucket":"< 1K"
   },
   {
     "Class":"Predicate",
-    "Name":"http:\/\/schema.org\/geoOverlaps",
+    "Name":"https://schema.org/geoOverlaps",
     "Domain Bucket":"< 1K"
   },
   {
     "Class":"Predicate",
-    "Name":"http:\/\/schema.org\/geoOverlaps-input",
+    "Name":"https://schema.org/geoOverlaps-input",
     "Domain Bucket":"< 1K"
   },
   {
     "Class":"Predicate",
-    "Name":"http:\/\/schema.org\/geoOverlaps-output",
+    "Name":"https://schema.org/geoOverlaps-output",
     "Domain Bucket":"< 1K"
   },
   {
     "Class":"Predicate",
-    "Name":"http:\/\/schema.org\/geoRadius",
+    "Name":"https://schema.org/geoRadius",
     "Domain Bucket":"100K - 1M"
   },
   {
     "Class":"Predicate",
-    "Name":"http:\/\/schema.org\/geoRadius-input",
+    "Name":"https://schema.org/geoRadius-input",
     "Domain Bucket":"< 1K"
   },
   {
     "Class":"Predicate",
-    "Name":"http:\/\/schema.org\/geoRadius-output",
+    "Name":"https://schema.org/geoRadius-output",
     "Domain Bucket":"< 1K"
   },
   {
     "Class":"Predicate",
-    "Name":"http:\/\/schema.org\/geoTouches",
+    "Name":"https://schema.org/geoTouches",
     "Domain Bucket":"< 1K"
   },
   {
     "Class":"Predicate",
-    "Name":"http:\/\/schema.org\/geoTouches-input",
+    "Name":"https://schema.org/geoTouches-input",
     "Domain Bucket":"< 1K"
   },
   {
     "Class":"Predicate",
-    "Name":"http:\/\/schema.org\/geoTouches-output",
+    "Name":"https://schema.org/geoTouches-output",
     "Domain Bucket":"< 1K"
   },
   {
     "Class":"Predicate",
-    "Name":"http:\/\/schema.org\/geoWithin",
+    "Name":"https://schema.org/geoWithin",
     "Domain Bucket":"< 1K"
   },
   {
     "Class":"Predicate",
-    "Name":"http:\/\/schema.org\/geoWithin-input",
+    "Name":"https://schema.org/geoWithin-input",
     "Domain Bucket":"< 1K"
   },
   {
     "Class":"Predicate",
-    "Name":"http:\/\/schema.org\/geoWithin-output",
+    "Name":"https://schema.org/geoWithin-output",
     "Domain Bucket":"< 1K"
   },
   {
     "Class":"Predicate",
-    "Name":"http:\/\/schema.org\/geographicArea",
+    "Name":"https://schema.org/geographicArea",
     "Domain Bucket":"10K - 100K"
   },
   {
     "Class":"Predicate",
-    "Name":"http:\/\/schema.org\/geographicArea-input",
+    "Name":"https://schema.org/geographicArea-input",
     "Domain Bucket":"< 1K"
   },
   {
     "Class":"Predicate",
-    "Name":"http:\/\/schema.org\/geographicArea-output",
+    "Name":"https://schema.org/geographicArea-output",
     "Domain Bucket":"< 1K"
   },
   {
     "Class":"Predicate",
-    "Name":"http:\/\/schema.org\/gettingTestedInfo",
+    "Name":"https://schema.org/gettingTestedInfo",
     "Domain Bucket":"< 1K"
   },
   {
     "Class":"Predicate",
-    "Name":"http:\/\/schema.org\/gettingTestedInfo-input",
+    "Name":"https://schema.org/gettingTestedInfo-input",
     "Domain Bucket":"< 1K"
   },
   {
     "Class":"Predicate",
-    "Name":"http:\/\/schema.org\/gettingTestedInfo-output",
+    "Name":"https://schema.org/gettingTestedInfo-output",
     "Domain Bucket":"< 1K"
   },
   {
     "Class":"Predicate",
-    "Name":"http:\/\/schema.org\/givenName",
+    "Name":"https://schema.org/givenName",
     "Domain Bucket":"100K - 1M"
   },
   {
     "Class":"Predicate",
-    "Name":"http:\/\/schema.org\/givenName-input",
+    "Name":"https://schema.org/givenName-input",
     "Domain Bucket":"< 1K"
   },
   {
     "Class":"Predicate",
-    "Name":"http:\/\/schema.org\/givenName-output",
+    "Name":"https://schema.org/givenName-output",
     "Domain Bucket":"< 1K"
   },
   {
     "Class":"Predicate",
-    "Name":"http:\/\/schema.org\/globalLocationNumber",
+    "Name":"https://schema.org/globalLocationNumber",
     "Domain Bucket":"1K - 10K"
   },
   {
     "Class":"Predicate",
-    "Name":"http:\/\/schema.org\/globalLocationNumber-input",
+    "Name":"https://schema.org/globalLocationNumber-input",
     "Domain Bucket":"< 1K"
   },
   {
     "Class":"Predicate",
-    "Name":"http:\/\/schema.org\/globalLocationNumber-output",
+    "Name":"https://schema.org/globalLocationNumber-output",
     "Domain Bucket":"< 1K"
   },
   {
     "Class":"Predicate",
-    "Name":"http:\/\/schema.org\/governmentBenefitsInfo",
+    "Name":"https://schema.org/governmentBenefitsInfo",
     "Domain Bucket":"< 1K"
   },
   {
     "Class":"Predicate",
-    "Name":"http:\/\/schema.org\/governmentBenefitsInfo-input",
+    "Name":"https://schema.org/governmentBenefitsInfo-input",
     "Domain Bucket":"< 1K"
   },
   {
     "Class":"Predicate",
-    "Name":"http:\/\/schema.org\/governmentBenefitsInfo-output",
+    "Name":"https://schema.org/governmentBenefitsInfo-output",
     "Domain Bucket":"< 1K"
   },
   {
     "Class":"Predicate",
-    "Name":"http:\/\/schema.org\/gracePeriod",
+    "Name":"https://schema.org/gracePeriod",
     "Domain Bucket":"< 1K"
   },
   {
     "Class":"Predicate",
-    "Name":"http:\/\/schema.org\/gracePeriod-input",
+    "Name":"https://schema.org/gracePeriod-input",
     "Domain Bucket":"< 1K"
   },
   {
     "Class":"Predicate",
-    "Name":"http:\/\/schema.org\/gracePeriod-output",
+    "Name":"https://schema.org/gracePeriod-output",
     "Domain Bucket":"< 1K"
   },
   {
     "Class":"Predicate",
-    "Name":"http:\/\/schema.org\/grantee",
+    "Name":"https://schema.org/grantee",
     "Domain Bucket":"< 1K"
   },
   {
     "Class":"Predicate",
-    "Name":"http:\/\/schema.org\/grantee-input",
+    "Name":"https://schema.org/grantee-input",
     "Domain Bucket":"< 1K"
   },
   {
     "Class":"Predicate",
-    "Name":"http:\/\/schema.org\/grantee-output",
+    "Name":"https://schema.org/grantee-output",
     "Domain Bucket":"< 1K"
   },
   {
     "Class":"Predicate",
-    "Name":"http:\/\/schema.org\/greater",
+    "Name":"https://schema.org/greater",
     "Domain Bucket":"< 1K"
   },
   {
     "Class":"Predicate",
-    "Name":"http:\/\/schema.org\/greater-input",
+    "Name":"https://schema.org/greater-input",
     "Domain Bucket":"< 1K"
   },
   {
     "Class":"Predicate",
-    "Name":"http:\/\/schema.org\/greater-output",
+    "Name":"https://schema.org/greater-output",
     "Domain Bucket":"< 1K"
   },
   {
     "Class":"Predicate",
-    "Name":"http:\/\/schema.org\/greaterOrEqual",
+    "Name":"https://schema.org/greaterOrEqual",
     "Domain Bucket":"< 1K"
   },
   {
     "Class":"Predicate",
-    "Name":"http:\/\/schema.org\/greaterOrEqual-input",
+    "Name":"https://schema.org/greaterOrEqual-input",
     "Domain Bucket":"< 1K"
   },
   {
     "Class":"Predicate",
-    "Name":"http:\/\/schema.org\/greaterOrEqual-output",
+    "Name":"https://schema.org/greaterOrEqual-output",
     "Domain Bucket":"< 1K"
   },
   {
     "Class":"Predicate",
-    "Name":"http:\/\/schema.org\/gtin",
+    "Name":"https://schema.org/gtin",
     "Domain Bucket":"100K - 1M"
   },
   {
     "Class":"Predicate",
-    "Name":"http:\/\/schema.org\/gtin-input",
+    "Name":"https://schema.org/gtin-input",
     "Domain Bucket":"< 1K"
   },
   {
     "Class":"Predicate",
-    "Name":"http:\/\/schema.org\/gtin-output",
+    "Name":"https://schema.org/gtin-output",
     "Domain Bucket":"< 1K"
   },
   {
     "Class":"Predicate",
-    "Name":"http:\/\/schema.org\/gtin12",
+    "Name":"https://schema.org/gtin12",
     "Domain Bucket":"100K - 1M"
   },
   {
     "Class":"Predicate",
-    "Name":"http:\/\/schema.org\/gtin12-input",
+    "Name":"https://schema.org/gtin12-input",
     "Domain Bucket":"< 1K"
   },
   {
     "Class":"Predicate",
-    "Name":"http:\/\/schema.org\/gtin12-output",
+    "Name":"https://schema.org/gtin12-output",
     "Domain Bucket":"< 1K"
   },
   {
     "Class":"Predicate",
-    "Name":"http:\/\/schema.org\/gtin13",
+    "Name":"https://schema.org/gtin13",
     "Domain Bucket":"100K - 1M"
   },
   {
     "Class":"Predicate",
-    "Name":"http:\/\/schema.org\/gtin13-input",
+    "Name":"https://schema.org/gtin13-input",
     "Domain Bucket":"< 1K"
   },
   {
     "Class":"Predicate",
-    "Name":"http:\/\/schema.org\/gtin13-output",
+    "Name":"https://schema.org/gtin13-output",
     "Domain Bucket":"< 1K"
   },
   {
     "Class":"Predicate",
-    "Name":"http:\/\/schema.org\/gtin14",
+    "Name":"https://schema.org/gtin14",
     "Domain Bucket":"10K - 100K"
   },
   {
     "Class":"Predicate",
-    "Name":"http:\/\/schema.org\/gtin14-input",
+    "Name":"https://schema.org/gtin14-input",
     "Domain Bucket":"< 1K"
   },
   {
     "Class":"Predicate",
-    "Name":"http:\/\/schema.org\/gtin14-output",
+    "Name":"https://schema.org/gtin14-output",
     "Domain Bucket":"< 1K"
   },
   {
     "Class":"Predicate",
-    "Name":"http:\/\/schema.org\/gtin8",
+    "Name":"https://schema.org/gtin8",
     "Domain Bucket":"10K - 100K"
   },
   {
     "Class":"Predicate",
-    "Name":"http:\/\/schema.org\/gtin8-input",
+    "Name":"https://schema.org/gtin8-input",
     "Domain Bucket":"< 1K"
   },
   {
     "Class":"Predicate",
-    "Name":"http:\/\/schema.org\/gtin8-output",
+    "Name":"https://schema.org/gtin8-output",
     "Domain Bucket":"< 1K"
   },
   {
     "Class":"Predicate",
-    "Name":"http:\/\/schema.org\/guideline",
+    "Name":"https://schema.org/guideline",
     "Domain Bucket":"< 1K"
   },
   {
     "Class":"Predicate",
-    "Name":"http:\/\/schema.org\/guideline-input",
+    "Name":"https://schema.org/guideline-input",
     "Domain Bucket":"< 1K"
   },
   {
     "Class":"Predicate",
-    "Name":"http:\/\/schema.org\/guideline-output",
+    "Name":"https://schema.org/guideline-output",
     "Domain Bucket":"< 1K"
   },
   {
     "Class":"Predicate",
-    "Name":"http:\/\/schema.org\/guidelineDate",
+    "Name":"https://schema.org/guidelineDate",
     "Domain Bucket":"< 1K"
   },
   {
     "Class":"Predicate",
-    "Name":"http:\/\/schema.org\/guidelineDate-input",
+    "Name":"https://schema.org/guidelineDate-input",
     "Domain Bucket":"< 1K"
   },
   {
     "Class":"Predicate",
-    "Name":"http:\/\/schema.org\/guidelineDate-output",
+    "Name":"https://schema.org/guidelineDate-output",
     "Domain Bucket":"< 1K"
   },
   {
     "Class":"Predicate",
-    "Name":"http:\/\/schema.org\/guidelineSubject",
+    "Name":"https://schema.org/guidelineSubject",
     "Domain Bucket":"< 1K"
   },
   {
     "Class":"Predicate",
-    "Name":"http:\/\/schema.org\/guidelineSubject-input",
+    "Name":"https://schema.org/guidelineSubject-input",
     "Domain Bucket":"< 1K"
   },
   {
     "Class":"Predicate",
-    "Name":"http:\/\/schema.org\/guidelineSubject-output",
+    "Name":"https://schema.org/guidelineSubject-output",
     "Domain Bucket":"< 1K"
   },
   {
     "Class":"Predicate",
-    "Name":"http:\/\/schema.org\/handlingTime",
+    "Name":"https://schema.org/handlingTime",
     "Domain Bucket":"100K - 1M"
   },
   {
     "Class":"Predicate",
-    "Name":"http:\/\/schema.org\/handlingTime-input",
+    "Name":"https://schema.org/handlingTime-input",
     "Domain Bucket":"< 1K"
   },
   {
     "Class":"Predicate",
-    "Name":"http:\/\/schema.org\/handlingTime-output",
+    "Name":"https://schema.org/handlingTime-output",
     "Domain Bucket":"< 1K"
   },
   {
     "Class":"Predicate",
-    "Name":"http:\/\/schema.org\/hasAdultConsideration",
+    "Name":"https://schema.org/hasAdultConsideration",
     "Domain Bucket":"< 1K"
   },
   {
     "Class":"Predicate",
-    "Name":"http:\/\/schema.org\/hasAdultConsideration-input",
+    "Name":"https://schema.org/hasAdultConsideration-input",
     "Domain Bucket":"< 1K"
   },
   {
     "Class":"Predicate",
-    "Name":"http:\/\/schema.org\/hasAdultConsideration-output",
+    "Name":"https://schema.org/hasAdultConsideration-output",
     "Domain Bucket":"< 1K"
   },
   {
     "Class":"Predicate",
-    "Name":"http:\/\/schema.org\/hasBioChemEntityPart",
+    "Name":"https://schema.org/hasBioChemEntityPart",
     "Domain Bucket":"< 1K"
   },
   {
     "Class":"Predicate",
-    "Name":"http:\/\/schema.org\/hasBioChemEntityPart-input",
+    "Name":"https://schema.org/hasBioChemEntityPart-input",
     "Domain Bucket":"< 1K"
   },
   {
     "Class":"Predicate",
-    "Name":"http:\/\/schema.org\/hasBioChemEntityPart-output",
+    "Name":"https://schema.org/hasBioChemEntityPart-output",
     "Domain Bucket":"< 1K"
   },
   {
     "Class":"Predicate",
-    "Name":"http:\/\/schema.org\/hasBioPolymerSequence",
+    "Name":"https://schema.org/hasBioPolymerSequence",
     "Domain Bucket":"< 1K"
   },
   {
     "Class":"Predicate",
-    "Name":"http:\/\/schema.org\/hasBioPolymerSequence-input",
+    "Name":"https://schema.org/hasBioPolymerSequence-input",
     "Domain Bucket":"< 1K"
   },
   {
     "Class":"Predicate",
-    "Name":"http:\/\/schema.org\/hasBioPolymerSequence-output",
+    "Name":"https://schema.org/hasBioPolymerSequence-output",
     "Domain Bucket":"< 1K"
   },
   {
     "Class":"Predicate",
-    "Name":"http:\/\/schema.org\/hasBroadcastChannel",
+    "Name":"https://schema.org/hasBroadcastChannel",
     "Domain Bucket":"< 1K"
   },
   {
     "Class":"Predicate",
-    "Name":"http:\/\/schema.org\/hasBroadcastChannel-input",
+    "Name":"https://schema.org/hasBroadcastChannel-input",
     "Domain Bucket":"< 1K"
   },
   {
     "Class":"Predicate",
-    "Name":"http:\/\/schema.org\/hasBroadcastChannel-output",
+    "Name":"https://schema.org/hasBroadcastChannel-output",
     "Domain Bucket":"< 1K"
   },
   {
     "Class":"Predicate",
-    "Name":"http:\/\/schema.org\/hasCategoryCode",
+    "Name":"https://schema.org/hasCategoryCode",
     "Domain Bucket":"< 1K"
   },
   {
     "Class":"Predicate",
-    "Name":"http:\/\/schema.org\/hasCategoryCode-input",
+    "Name":"https://schema.org/hasCategoryCode-input",
     "Domain Bucket":"< 1K"
   },
   {
     "Class":"Predicate",
-    "Name":"http:\/\/schema.org\/hasCategoryCode-output",
+    "Name":"https://schema.org/hasCategoryCode-output",
     "Domain Bucket":"< 1K"
   },
   {
     "Class":"Predicate",
-    "Name":"http:\/\/schema.org\/hasCertification",
+    "Name":"https://schema.org/hasCertification",
     "Domain Bucket":"10K - 100K"
   },
   {
     "Class":"Predicate",
-    "Name":"http:\/\/schema.org\/hasCertification-input",
+    "Name":"https://schema.org/hasCertification-input",
     "Domain Bucket":"< 1K"
   },
   {
     "Class":"Predicate",
-    "Name":"http:\/\/schema.org\/hasCertification-output",
+    "Name":"https://schema.org/hasCertification-output",
     "Domain Bucket":"< 1K"
   },
   {
     "Class":"Predicate",
-    "Name":"http:\/\/schema.org\/hasCourse",
+    "Name":"https://schema.org/hasCourse",
     "Domain Bucket":"1K - 10K"
   },
   {
     "Class":"Predicate",
-    "Name":"http:\/\/schema.org\/hasCourse-input",
+    "Name":"https://schema.org/hasCourse-input",
     "Domain Bucket":"< 1K"
   },
   {
     "Class":"Predicate",
-    "Name":"http:\/\/schema.org\/hasCourse-output",
+    "Name":"https://schema.org/hasCourse-output",
     "Domain Bucket":"< 1K"
   },
   {
     "Class":"Predicate",
-    "Name":"http:\/\/schema.org\/hasCourseInstance",
+    "Name":"https://schema.org/hasCourseInstance",
     "Domain Bucket":"10K - 100K"
   },
   {
     "Class":"Predicate",
-    "Name":"http:\/\/schema.org\/hasCourseInstance-input",
+    "Name":"https://schema.org/hasCourseInstance-input",
     "Domain Bucket":"< 1K"
   },
   {
     "Class":"Predicate",
-    "Name":"http:\/\/schema.org\/hasCourseInstance-output",
+    "Name":"https://schema.org/hasCourseInstance-output",
     "Domain Bucket":"< 1K"
   },
   {
     "Class":"Predicate",
-    "Name":"http:\/\/schema.org\/hasCredential",
+    "Name":"https://schema.org/hasCredential",
     "Domain Bucket":"100K - 1M"
   },
   {
     "Class":"Predicate",
-    "Name":"http:\/\/schema.org\/hasCredential-input",
+    "Name":"https://schema.org/hasCredential-input",
     "Domain Bucket":"< 1K"
   },
   {
     "Class":"Predicate",
-    "Name":"http:\/\/schema.org\/hasCredential-output",
+    "Name":"https://schema.org/hasCredential-output",
     "Domain Bucket":"< 1K"
   },
   {
     "Class":"Predicate",
-    "Name":"http:\/\/schema.org\/hasDefinedTerm",
+    "Name":"https://schema.org/hasDefinedTerm",
     "Domain Bucket":"10K - 100K"
   },
   {
     "Class":"Predicate",
-    "Name":"http:\/\/schema.org\/hasDefinedTerm-input",
+    "Name":"https://schema.org/hasDefinedTerm-input",
     "Domain Bucket":"< 1K"
   },
   {
     "Class":"Predicate",
-    "Name":"http:\/\/schema.org\/hasDefinedTerm-output",
+    "Name":"https://schema.org/hasDefinedTerm-output",
     "Domain Bucket":"< 1K"
   },
   {
     "Class":"Predicate",
-    "Name":"http:\/\/schema.org\/hasDeliveryMethod",
+    "Name":"https://schema.org/hasDeliveryMethod",
     "Domain Bucket":"< 1K"
   },
   {
     "Class":"Predicate",
-    "Name":"http:\/\/schema.org\/hasDeliveryMethod-input",
+    "Name":"https://schema.org/hasDeliveryMethod-input",
     "Domain Bucket":"< 1K"
   },
   {
     "Class":"Predicate",
-    "Name":"http:\/\/schema.org\/hasDeliveryMethod-output",
+    "Name":"https://schema.org/hasDeliveryMethod-output",
     "Domain Bucket":"< 1K"
   },
   {
     "Class":"Predicate",
-    "Name":"http:\/\/schema.org\/hasDigitalDocumentPermission",
+    "Name":"https://schema.org/hasDigitalDocumentPermission",
     "Domain Bucket":"< 1K"
   },
   {
     "Class":"Predicate",
-    "Name":"http:\/\/schema.org\/hasDigitalDocumentPermission-input",
+    "Name":"https://schema.org/hasDigitalDocumentPermission-input",
     "Domain Bucket":"< 1K"
   },
   {
     "Class":"Predicate",
-    "Name":"http:\/\/schema.org\/hasDigitalDocumentPermission-output",
+    "Name":"https://schema.org/hasDigitalDocumentPermission-output",
     "Domain Bucket":"< 1K"
   },
   {
     "Class":"Predicate",
-    "Name":"http:\/\/schema.org\/hasDriveThroughService",
+    "Name":"https://schema.org/hasDriveThroughService",
     "Domain Bucket":"< 1K"
   },
   {
     "Class":"Predicate",
-    "Name":"http:\/\/schema.org\/hasDriveThroughService-input",
+    "Name":"https://schema.org/hasDriveThroughService-input",
     "Domain Bucket":"< 1K"
   },
   {
     "Class":"Predicate",
-    "Name":"http:\/\/schema.org\/hasDriveThroughService-output",
+    "Name":"https://schema.org/hasDriveThroughService-output",
     "Domain Bucket":"< 1K"
   },
   {
     "Class":"Predicate",
-    "Name":"http:\/\/schema.org\/hasEnergyConsumptionDetails",
+    "Name":"https://schema.org/hasEnergyConsumptionDetails",
     "Domain Bucket":"1K - 10K"
   },
   {
     "Class":"Predicate",
-    "Name":"http:\/\/schema.org\/hasEnergyConsumptionDetails-input",
+    "Name":"https://schema.org/hasEnergyConsumptionDetails-input",
     "Domain Bucket":"< 1K"
   },
   {
     "Class":"Predicate",
-    "Name":"http:\/\/schema.org\/hasEnergyConsumptionDetails-output",
+    "Name":"https://schema.org/hasEnergyConsumptionDetails-output",
     "Domain Bucket":"< 1K"
   },
   {
     "Class":"Predicate",
-    "Name":"http:\/\/schema.org\/hasEnergyEfficiencyCategory",
+    "Name":"https://schema.org/hasEnergyEfficiencyCategory",
     "Domain Bucket":"1K - 10K"
   },
   {
     "Class":"Predicate",
-    "Name":"http:\/\/schema.org\/hasEnergyEfficiencyCategory-input",
+    "Name":"https://schema.org/hasEnergyEfficiencyCategory-input",
     "Domain Bucket":"< 1K"
   },
   {
     "Class":"Predicate",
-    "Name":"http:\/\/schema.org\/hasEnergyEfficiencyCategory-output",
+    "Name":"https://schema.org/hasEnergyEfficiencyCategory-output",
     "Domain Bucket":"< 1K"
   },
   {
     "Class":"Predicate",
-    "Name":"http:\/\/schema.org\/hasGS1DigitalLink",
+    "Name":"https://schema.org/hasGS1DigitalLink",
     "Domain Bucket":"< 1K"
   },
   {
     "Class":"Predicate",
-    "Name":"http:\/\/schema.org\/hasGS1DigitalLink-input",
+    "Name":"https://schema.org/hasGS1DigitalLink-input",
     "Domain Bucket":"< 1K"
   },
   {
     "Class":"Predicate",
-    "Name":"http:\/\/schema.org\/hasGS1DigitalLink-output",
+    "Name":"https://schema.org/hasGS1DigitalLink-output",
     "Domain Bucket":"< 1K"
   },
   {
     "Class":"Predicate",
-    "Name":"http:\/\/schema.org\/hasHealthAspect",
+    "Name":"https://schema.org/hasHealthAspect",
     "Domain Bucket":"< 1K"
   },
   {
     "Class":"Predicate",
-    "Name":"http:\/\/schema.org\/hasHealthAspect-input",
+    "Name":"https://schema.org/hasHealthAspect-input",
     "Domain Bucket":"< 1K"
   },
   {
     "Class":"Predicate",
-    "Name":"http:\/\/schema.org\/hasHealthAspect-output",
+    "Name":"https://schema.org/hasHealthAspect-output",
     "Domain Bucket":"< 1K"
   },
   {
     "Class":"Predicate",
-    "Name":"http:\/\/schema.org\/hasMap",
+    "Name":"https://schema.org/hasMap",
     "Domain Bucket":"100K - 1M"
   },
   {
     "Class":"Predicate",
-    "Name":"http:\/\/schema.org\/hasMap-input",
+    "Name":"https://schema.org/hasMap-input",
     "Domain Bucket":"< 1K"
   },
   {
     "Class":"Predicate",
-    "Name":"http:\/\/schema.org\/hasMap-output",
+    "Name":"https://schema.org/hasMap-output",
     "Domain Bucket":"< 1K"
   },
   {
     "Class":"Predicate",
-    "Name":"http:\/\/schema.org\/hasMeasurement",
+    "Name":"https://schema.org/hasMeasurement",
     "Domain Bucket":"1K - 10K"
   },
   {
     "Class":"Predicate",
-    "Name":"http:\/\/schema.org\/hasMeasurement-input",
+    "Name":"https://schema.org/hasMeasurement-input",
     "Domain Bucket":"< 1K"
   },
   {
     "Class":"Predicate",
-    "Name":"http:\/\/schema.org\/hasMeasurement-output",
+    "Name":"https://schema.org/hasMeasurement-output",
     "Domain Bucket":"< 1K"
   },
   {
     "Class":"Predicate",
-    "Name":"http:\/\/schema.org\/hasMemberProgram",
+    "Name":"https://schema.org/hasMemberProgram",
     "Domain Bucket":"1K - 10K"
   },
   {
     "Class":"Predicate",
-    "Name":"http:\/\/schema.org\/hasMemberProgram-input",
+    "Name":"https://schema.org/hasMemberProgram-input",
     "Domain Bucket":"< 1K"
   },
   {
     "Class":"Predicate",
-    "Name":"http:\/\/schema.org\/hasMemberProgram-output",
+    "Name":"https://schema.org/hasMemberProgram-output",
     "Domain Bucket":"< 1K"
   },
   {
     "Class":"Predicate",
-    "Name":"http:\/\/schema.org\/hasMenu",
+    "Name":"https://schema.org/hasMenu",
     "Domain Bucket":"10K - 100K"
   },
   {
     "Class":"Predicate",
-    "Name":"http:\/\/schema.org\/hasMenu-input",
+    "Name":"https://schema.org/hasMenu-input",
     "Domain Bucket":"< 1K"
   },
   {
     "Class":"Predicate",
-    "Name":"http:\/\/schema.org\/hasMenu-output",
+    "Name":"https://schema.org/hasMenu-output",
     "Domain Bucket":"< 1K"
   },
   {
     "Class":"Predicate",
-    "Name":"http:\/\/schema.org\/hasMenuItem",
+    "Name":"https://schema.org/hasMenuItem",
     "Domain Bucket":"10K - 100K"
   },
   {
     "Class":"Predicate",
-    "Name":"http:\/\/schema.org\/hasMenuItem-input",
+    "Name":"https://schema.org/hasMenuItem-input",
     "Domain Bucket":"< 1K"
   },
   {
     "Class":"Predicate",
-    "Name":"http:\/\/schema.org\/hasMenuItem-output",
+    "Name":"https://schema.org/hasMenuItem-output",
     "Domain Bucket":"< 1K"
   },
   {
     "Class":"Predicate",
-    "Name":"http:\/\/schema.org\/hasMenuSection",
+    "Name":"https://schema.org/hasMenuSection",
     "Domain Bucket":"10K - 100K"
   },
   {
     "Class":"Predicate",
-    "Name":"http:\/\/schema.org\/hasMenuSection-input",
+    "Name":"https://schema.org/hasMenuSection-input",
     "Domain Bucket":"< 1K"
   },
   {
     "Class":"Predicate",
-    "Name":"http:\/\/schema.org\/hasMenuSection-output",
+    "Name":"https://schema.org/hasMenuSection-output",
     "Domain Bucket":"< 1K"
   },
   {
     "Class":"Predicate",
-    "Name":"http:\/\/schema.org\/hasMerchantReturnPolicy",
+    "Name":"https://schema.org/hasMerchantReturnPolicy",
     "Domain Bucket":"100K - 1M"
   },
   {
     "Class":"Predicate",
-    "Name":"http:\/\/schema.org\/hasMerchantReturnPolicy-input",
+    "Name":"https://schema.org/hasMerchantReturnPolicy-input",
     "Domain Bucket":"< 1K"
   },
   {
     "Class":"Predicate",
-    "Name":"http:\/\/schema.org\/hasMerchantReturnPolicy-output",
+    "Name":"https://schema.org/hasMerchantReturnPolicy-output",
     "Domain Bucket":"< 1K"
   },
   {
     "Class":"Predicate",
-    "Name":"http:\/\/schema.org\/hasMolecularFunction",
+    "Name":"https://schema.org/hasMolecularFunction",
     "Domain Bucket":"< 1K"
   },
   {
     "Class":"Predicate",
-    "Name":"http:\/\/schema.org\/hasMolecularFunction-input",
+    "Name":"https://schema.org/hasMolecularFunction-input",
     "Domain Bucket":"< 1K"
   },
   {
     "Class":"Predicate",
-    "Name":"http:\/\/schema.org\/hasMolecularFunction-output",
+    "Name":"https://schema.org/hasMolecularFunction-output",
     "Domain Bucket":"< 1K"
   },
   {
     "Class":"Predicate",
-    "Name":"http:\/\/schema.org\/hasOccupation",
+    "Name":"https://schema.org/hasOccupation",
     "Domain Bucket":"10K - 100K"
   },
   {
     "Class":"Predicate",
-    "Name":"http:\/\/schema.org\/hasOccupation-input",
+    "Name":"https://schema.org/hasOccupation-input",
     "Domain Bucket":"< 1K"
   },
   {
     "Class":"Predicate",
-    "Name":"http:\/\/schema.org\/hasOccupation-output",
+    "Name":"https://schema.org/hasOccupation-output",
     "Domain Bucket":"< 1K"
   },
   {
     "Class":"Predicate",
-    "Name":"http:\/\/schema.org\/hasOfferCatalog",
+    "Name":"https://schema.org/hasOfferCatalog",
     "Domain Bucket":"100K - 1M"
   },
   {
     "Class":"Predicate",
-    "Name":"http:\/\/schema.org\/hasOfferCatalog-input",
+    "Name":"https://schema.org/hasOfferCatalog-input",
     "Domain Bucket":"< 1K"
   },
   {
     "Class":"Predicate",
-    "Name":"http:\/\/schema.org\/hasOfferCatalog-output",
+    "Name":"https://schema.org/hasOfferCatalog-output",
     "Domain Bucket":"< 1K"
   },
   {
     "Class":"Predicate",
-    "Name":"http:\/\/schema.org\/hasPOS",
+    "Name":"https://schema.org/hasPOS",
     "Domain Bucket":"1K - 10K"
   },
   {
     "Class":"Predicate",
-    "Name":"http:\/\/schema.org\/hasPOS-input",
+    "Name":"https://schema.org/hasPOS-input",
     "Domain Bucket":"< 1K"
   },
   {
     "Class":"Predicate",
-    "Name":"http:\/\/schema.org\/hasPOS-output",
+    "Name":"https://schema.org/hasPOS-output",
     "Domain Bucket":"< 1K"
   },
   {
     "Class":"Predicate",
-    "Name":"http:\/\/schema.org\/hasPart",
+    "Name":"https://schema.org/hasPart",
     "Domain Bucket":"100K - 1M"
   },
   {
     "Class":"Predicate",
-    "Name":"http:\/\/schema.org\/hasPart-input",
+    "Name":"https://schema.org/hasPart-input",
     "Domain Bucket":"< 1K"
   },
   {
     "Class":"Predicate",
-    "Name":"http:\/\/schema.org\/hasPart-output",
+    "Name":"https://schema.org/hasPart-output",
     "Domain Bucket":"< 1K"
   },
   {
     "Class":"Predicate",
-    "Name":"http:\/\/schema.org\/hasParticipationOffer",
+    "Name":"https://schema.org/hasParticipationOffer",
     "Domain Bucket":"< 1K"
   },
   {
     "Class":"Predicate",
-    "Name":"http:\/\/schema.org\/hasParticipationOffer-input",
+    "Name":"https://schema.org/hasParticipationOffer-input",
     "Domain Bucket":"< 1K"
   },
   {
     "Class":"Predicate",
-    "Name":"http:\/\/schema.org\/hasParticipationOffer-output",
+    "Name":"https://schema.org/hasParticipationOffer-output",
     "Domain Bucket":"< 1K"
   },
   {
     "Class":"Predicate",
-    "Name":"http:\/\/schema.org\/hasProductReturnPolicy",
+    "Name":"https://schema.org/hasProductReturnPolicy",
     "Domain Bucket":"< 1K"
   },
   {
     "Class":"Predicate",
-    "Name":"http:\/\/schema.org\/hasProductReturnPolicy-input",
+    "Name":"https://schema.org/hasProductReturnPolicy-input",
     "Domain Bucket":"< 1K"
   },
   {
     "Class":"Predicate",
-    "Name":"http:\/\/schema.org\/hasProductReturnPolicy-output",
+    "Name":"https://schema.org/hasProductReturnPolicy-output",
     "Domain Bucket":"< 1K"
   },
   {
     "Class":"Predicate",
-    "Name":"http:\/\/schema.org\/hasRepresentation",
+    "Name":"https://schema.org/hasRepresentation",
     "Domain Bucket":"< 1K"
   },
   {
     "Class":"Predicate",
-    "Name":"http:\/\/schema.org\/hasRepresentation-input",
+    "Name":"https://schema.org/hasRepresentation-input",
     "Domain Bucket":"< 1K"
   },
   {
     "Class":"Predicate",
-    "Name":"http:\/\/schema.org\/hasRepresentation-output",
+    "Name":"https://schema.org/hasRepresentation-output",
     "Domain Bucket":"< 1K"
   },
   {
     "Class":"Predicate",
-    "Name":"http:\/\/schema.org\/hasShippingService",
+    "Name":"https://schema.org/hasShippingService",
     "Domain Bucket":"10K - 100K"
   },
   {
     "Class":"Predicate",
-    "Name":"http:\/\/schema.org\/hasShippingService-input",
+    "Name":"https://schema.org/hasShippingService-input",
     "Domain Bucket":"< 1K"
   },
   {
     "Class":"Predicate",
-    "Name":"http:\/\/schema.org\/hasShippingService-output",
+    "Name":"https://schema.org/hasShippingService-output",
     "Domain Bucket":"< 1K"
   },
   {
     "Class":"Predicate",
-    "Name":"http:\/\/schema.org\/hasSponsorshipOffer",
+    "Name":"https://schema.org/hasSponsorshipOffer",
     "Domain Bucket":"< 1K"
   },
   {
     "Class":"Predicate",
-    "Name":"http:\/\/schema.org\/hasSponsorshipOffer-input",
+    "Name":"https://schema.org/hasSponsorshipOffer-input",
     "Domain Bucket":"< 1K"
   },
   {
     "Class":"Predicate",
-    "Name":"http:\/\/schema.org\/hasSponsorshipOffer-output",
+    "Name":"https://schema.org/hasSponsorshipOffer-output",
     "Domain Bucket":"< 1K"
   },
   {
     "Class":"Predicate",
-    "Name":"http:\/\/schema.org\/hasStore",
+    "Name":"https://schema.org/hasStore",
     "Domain Bucket":"< 1K"
   },
   {
     "Class":"Predicate",
-    "Name":"http:\/\/schema.org\/hasStore-input",
+    "Name":"https://schema.org/hasStore-input",
     "Domain Bucket":"< 1K"
   },
   {
     "Class":"Predicate",
-    "Name":"http:\/\/schema.org\/hasStore-output",
+    "Name":"https://schema.org/hasStore-output",
     "Domain Bucket":"< 1K"
   },
   {
     "Class":"Predicate",
-    "Name":"http:\/\/schema.org\/hasTierBenefit",
+    "Name":"https://schema.org/hasTierBenefit",
     "Domain Bucket":"1K - 10K"
   },
   {
     "Class":"Predicate",
-    "Name":"http:\/\/schema.org\/hasTierBenefit-input",
+    "Name":"https://schema.org/hasTierBenefit-input",
     "Domain Bucket":"< 1K"
   },
   {
     "Class":"Predicate",
-    "Name":"http:\/\/schema.org\/hasTierBenefit-output",
+    "Name":"https://schema.org/hasTierBenefit-output",
     "Domain Bucket":"< 1K"
   },
   {
     "Class":"Predicate",
-    "Name":"http:\/\/schema.org\/hasTierRequirement",
+    "Name":"https://schema.org/hasTierRequirement",
     "Domain Bucket":"< 1K"
   },
   {
     "Class":"Predicate",
-    "Name":"http:\/\/schema.org\/hasTierRequirement-input",
+    "Name":"https://schema.org/hasTierRequirement-input",
     "Domain Bucket":"< 1K"
   },
   {
     "Class":"Predicate",
-    "Name":"http:\/\/schema.org\/hasTierRequirement-output",
+    "Name":"https://schema.org/hasTierRequirement-output",
     "Domain Bucket":"< 1K"
   },
   {
     "Class":"Predicate",
-    "Name":"http:\/\/schema.org\/hasTiers",
+    "Name":"https://schema.org/hasTiers",
     "Domain Bucket":"1K - 10K"
   },
   {
     "Class":"Predicate",
-    "Name":"http:\/\/schema.org\/hasTiers-input",
+    "Name":"https://schema.org/hasTiers-input",
     "Domain Bucket":"< 1K"
   },
   {
     "Class":"Predicate",
-    "Name":"http:\/\/schema.org\/hasTiers-output",
+    "Name":"https://schema.org/hasTiers-output",
     "Domain Bucket":"< 1K"
   },
   {
     "Class":"Predicate",
-    "Name":"http:\/\/schema.org\/hasVariant",
+    "Name":"https://schema.org/hasVariant",
     "Domain Bucket":"100K - 1M"
   },
   {
     "Class":"Predicate",
-    "Name":"http:\/\/schema.org\/hasVariant-input",
+    "Name":"https://schema.org/hasVariant-input",
     "Domain Bucket":"< 1K"
   },
   {
     "Class":"Predicate",
-    "Name":"http:\/\/schema.org\/hasVariant-output",
+    "Name":"https://schema.org/hasVariant-output",
     "Domain Bucket":"< 1K"
   },
   {
     "Class":"Predicate",
-    "Name":"http:\/\/schema.org\/headline",
+    "Name":"https://schema.org/headline",
     "Domain Bucket":"10M+"
   },
   {
     "Class":"Predicate",
-    "Name":"http:\/\/schema.org\/headline-input",
+    "Name":"https://schema.org/headline-input",
     "Domain Bucket":"< 1K"
   },
   {
     "Class":"Predicate",
-    "Name":"http:\/\/schema.org\/headline-output",
+    "Name":"https://schema.org/headline-output",
     "Domain Bucket":"< 1K"
   },
   {
     "Class":"Predicate",
-    "Name":"http:\/\/schema.org\/healthCondition",
+    "Name":"https://schema.org/healthCondition",
     "Domain Bucket":"1K - 10K"
   },
   {
     "Class":"Predicate",
-    "Name":"http:\/\/schema.org\/healthCondition-input",
+    "Name":"https://schema.org/healthCondition-input",
     "Domain Bucket":"< 1K"
   },
   {
     "Class":"Predicate",
-    "Name":"http:\/\/schema.org\/healthCondition-output",
+    "Name":"https://schema.org/healthCondition-output",
     "Domain Bucket":"< 1K"
   },
   {
     "Class":"Predicate",
-    "Name":"http:\/\/schema.org\/healthPlanCoinsuranceOption",
+    "Name":"https://schema.org/healthPlanCoinsuranceOption",
     "Domain Bucket":"< 1K"
   },
   {
     "Class":"Predicate",
-    "Name":"http:\/\/schema.org\/healthPlanCoinsuranceOption-input",
+    "Name":"https://schema.org/healthPlanCoinsuranceOption-input",
     "Domain Bucket":"< 1K"
   },
   {
     "Class":"Predicate",
-    "Name":"http:\/\/schema.org\/healthPlanCoinsuranceOption-output",
+    "Name":"https://schema.org/healthPlanCoinsuranceOption-output",
     "Domain Bucket":"< 1K"
   },
   {
     "Class":"Predicate",
-    "Name":"http:\/\/schema.org\/healthPlanCoinsuranceRate",
+    "Name":"https://schema.org/healthPlanCoinsuranceRate",
     "Domain Bucket":"< 1K"
   },
   {
     "Class":"Predicate",
-    "Name":"http:\/\/schema.org\/healthPlanCoinsuranceRate-input",
+    "Name":"https://schema.org/healthPlanCoinsuranceRate-input",
     "Domain Bucket":"< 1K"
   },
   {
     "Class":"Predicate",
-    "Name":"http:\/\/schema.org\/healthPlanCoinsuranceRate-output",
+    "Name":"https://schema.org/healthPlanCoinsuranceRate-output",
     "Domain Bucket":"< 1K"
   },
   {
     "Class":"Predicate",
-    "Name":"http:\/\/schema.org\/healthPlanCopay",
+    "Name":"https://schema.org/healthPlanCopay",
     "Domain Bucket":"< 1K"
   },
   {
     "Class":"Predicate",
-    "Name":"http:\/\/schema.org\/healthPlanCopay-input",
+    "Name":"https://schema.org/healthPlanCopay-input",
     "Domain Bucket":"< 1K"
   },
   {
     "Class":"Predicate",
-    "Name":"http:\/\/schema.org\/healthPlanCopay-output",
+    "Name":"https://schema.org/healthPlanCopay-output",
     "Domain Bucket":"< 1K"
   },
   {
     "Class":"Predicate",
-    "Name":"http:\/\/schema.org\/healthPlanCopayOption",
+    "Name":"https://schema.org/healthPlanCopayOption",
     "Domain Bucket":"< 1K"
   },
   {
     "Class":"Predicate",
-    "Name":"http:\/\/schema.org\/healthPlanCopayOption-input",
+    "Name":"https://schema.org/healthPlanCopayOption-input",
     "Domain Bucket":"< 1K"
   },
   {
     "Class":"Predicate",
-    "Name":"http:\/\/schema.org\/healthPlanCopayOption-output",
+    "Name":"https://schema.org/healthPlanCopayOption-output",
     "Domain Bucket":"< 1K"
   },
   {
     "Class":"Predicate",
-    "Name":"http:\/\/schema.org\/healthPlanCostSharing",
+    "Name":"https://schema.org/healthPlanCostSharing",
     "Domain Bucket":"< 1K"
   },
   {
     "Class":"Predicate",
-    "Name":"http:\/\/schema.org\/healthPlanCostSharing-input",
+    "Name":"https://schema.org/healthPlanCostSharing-input",
     "Domain Bucket":"< 1K"
   },
   {
     "Class":"Predicate",
-    "Name":"http:\/\/schema.org\/healthPlanCostSharing-output",
+    "Name":"https://schema.org/healthPlanCostSharing-output",
     "Domain Bucket":"< 1K"
   },
   {
     "Class":"Predicate",
-    "Name":"http:\/\/schema.org\/healthPlanDrugOption",
+    "Name":"https://schema.org/healthPlanDrugOption",
     "Domain Bucket":"< 1K"
   },
   {
     "Class":"Predicate",
-    "Name":"http:\/\/schema.org\/healthPlanDrugOption-input",
+    "Name":"https://schema.org/healthPlanDrugOption-input",
     "Domain Bucket":"< 1K"
   },
   {
     "Class":"Predicate",
-    "Name":"http:\/\/schema.org\/healthPlanDrugOption-output",
+    "Name":"https://schema.org/healthPlanDrugOption-output",
     "Domain Bucket":"< 1K"
   },
   {
     "Class":"Predicate",
-    "Name":"http:\/\/schema.org\/healthPlanDrugTier",
+    "Name":"https://schema.org/healthPlanDrugTier",
     "Domain Bucket":"< 1K"
   },
   {
     "Class":"Predicate",
-    "Name":"http:\/\/schema.org\/healthPlanDrugTier-input",
+    "Name":"https://schema.org/healthPlanDrugTier-input",
     "Domain Bucket":"< 1K"
   },
   {
     "Class":"Predicate",
-    "Name":"http:\/\/schema.org\/healthPlanDrugTier-output",
+    "Name":"https://schema.org/healthPlanDrugTier-output",
     "Domain Bucket":"< 1K"
   },
   {
     "Class":"Predicate",
-    "Name":"http:\/\/schema.org\/healthPlanId",
+    "Name":"https://schema.org/healthPlanId",
     "Domain Bucket":"< 1K"
   },
   {
     "Class":"Predicate",
-    "Name":"http:\/\/schema.org\/healthPlanId-input",
+    "Name":"https://schema.org/healthPlanId-input",
     "Domain Bucket":"< 1K"
   },
   {
     "Class":"Predicate",
-    "Name":"http:\/\/schema.org\/healthPlanId-output",
+    "Name":"https://schema.org/healthPlanId-output",
     "Domain Bucket":"< 1K"
   },
   {
     "Class":"Predicate",
-    "Name":"http:\/\/schema.org\/healthPlanMarketingUrl",
+    "Name":"https://schema.org/healthPlanMarketingUrl",
     "Domain Bucket":"< 1K"
   },
   {
     "Class":"Predicate",
-    "Name":"http:\/\/schema.org\/healthPlanMarketingUrl-input",
+    "Name":"https://schema.org/healthPlanMarketingUrl-input",
     "Domain Bucket":"< 1K"
   },
   {
     "Class":"Predicate",
-    "Name":"http:\/\/schema.org\/healthPlanMarketingUrl-output",
+    "Name":"https://schema.org/healthPlanMarketingUrl-output",
     "Domain Bucket":"< 1K"
   },
   {
     "Class":"Predicate",
-    "Name":"http:\/\/schema.org\/healthPlanNetworkId",
+    "Name":"https://schema.org/healthPlanNetworkId",
     "Domain Bucket":"< 1K"
   },
   {
     "Class":"Predicate",
-    "Name":"http:\/\/schema.org\/healthPlanNetworkId-input",
+    "Name":"https://schema.org/healthPlanNetworkId-input",
     "Domain Bucket":"< 1K"
   },
   {
     "Class":"Predicate",
-    "Name":"http:\/\/schema.org\/healthPlanNetworkId-output",
+    "Name":"https://schema.org/healthPlanNetworkId-output",
     "Domain Bucket":"< 1K"
   },
   {
     "Class":"Predicate",
-    "Name":"http:\/\/schema.org\/healthPlanNetworkTier",
+    "Name":"https://schema.org/healthPlanNetworkTier",
     "Domain Bucket":"< 1K"
   },
   {
     "Class":"Predicate",
-    "Name":"http:\/\/schema.org\/healthPlanNetworkTier-input",
+    "Name":"https://schema.org/healthPlanNetworkTier-input",
     "Domain Bucket":"< 1K"
   },
   {
     "Class":"Predicate",
-    "Name":"http:\/\/schema.org\/healthPlanNetworkTier-output",
+    "Name":"https://schema.org/healthPlanNetworkTier-output",
     "Domain Bucket":"< 1K"
   },
   {
     "Class":"Predicate",
-    "Name":"http:\/\/schema.org\/healthPlanPharmacyCategory",
+    "Name":"https://schema.org/healthPlanPharmacyCategory",
     "Domain Bucket":"< 1K"
   },
   {
     "Class":"Predicate",
-    "Name":"http:\/\/schema.org\/healthPlanPharmacyCategory-input",
+    "Name":"https://schema.org/healthPlanPharmacyCategory-input",
     "Domain Bucket":"< 1K"
   },
   {
     "Class":"Predicate",
-    "Name":"http:\/\/schema.org\/healthPlanPharmacyCategory-output",
+    "Name":"https://schema.org/healthPlanPharmacyCategory-output",
     "Domain Bucket":"< 1K"
   },
   {
     "Class":"Predicate",
-    "Name":"http:\/\/schema.org\/healthcareReportingData",
+    "Name":"https://schema.org/healthcareReportingData",
     "Domain Bucket":"< 1K"
   },
   {
     "Class":"Predicate",
-    "Name":"http:\/\/schema.org\/healthcareReportingData-input",
+    "Name":"https://schema.org/healthcareReportingData-input",
     "Domain Bucket":"< 1K"
   },
   {
     "Class":"Predicate",
-    "Name":"http:\/\/schema.org\/healthcareReportingData-output",
+    "Name":"https://schema.org/healthcareReportingData-output",
     "Domain Bucket":"< 1K"
   },
   {
     "Class":"Predicate",
-    "Name":"http:\/\/schema.org\/height",
+    "Name":"https://schema.org/height",
     "Domain Bucket":"10M+"
   },
   {
     "Class":"Predicate",
-    "Name":"http:\/\/schema.org\/height-input",
+    "Name":"https://schema.org/height-input",
     "Domain Bucket":"< 1K"
   },
   {
     "Class":"Predicate",
-    "Name":"http:\/\/schema.org\/height-output",
+    "Name":"https://schema.org/height-output",
     "Domain Bucket":"< 1K"
   },
   {
     "Class":"Predicate",
-    "Name":"http:\/\/schema.org\/highPrice",
+    "Name":"https://schema.org/highPrice",
     "Domain Bucket":"1M - 10M"
   },
   {
     "Class":"Predicate",
-    "Name":"http:\/\/schema.org\/highPrice-input",
+    "Name":"https://schema.org/highPrice-input",
     "Domain Bucket":"< 1K"
   },
   {
     "Class":"Predicate",
-    "Name":"http:\/\/schema.org\/highPrice-output",
+    "Name":"https://schema.org/highPrice-output",
     "Domain Bucket":"< 1K"
   },
   {
     "Class":"Predicate",
-    "Name":"http:\/\/schema.org\/hiringOrganization",
+    "Name":"https://schema.org/hiringOrganization",
     "Domain Bucket":"100K - 1M"
   },
   {
     "Class":"Predicate",
-    "Name":"http:\/\/schema.org\/hiringOrganization-input",
+    "Name":"https://schema.org/hiringOrganization-input",
     "Domain Bucket":"< 1K"
   },
   {
     "Class":"Predicate",
-    "Name":"http:\/\/schema.org\/hiringOrganization-output",
+    "Name":"https://schema.org/hiringOrganization-output",
     "Domain Bucket":"< 1K"
   },
   {
     "Class":"Predicate",
-    "Name":"http:\/\/schema.org\/holdingArchive",
+    "Name":"https://schema.org/holdingArchive",
     "Domain Bucket":"< 1K"
   },
   {
     "Class":"Predicate",
-    "Name":"http:\/\/schema.org\/holdingArchive-input",
+    "Name":"https://schema.org/holdingArchive-input",
     "Domain Bucket":"< 1K"
   },
   {
     "Class":"Predicate",
-    "Name":"http:\/\/schema.org\/holdingArchive-output",
+    "Name":"https://schema.org/holdingArchive-output",
     "Domain Bucket":"< 1K"
   },
   {
     "Class":"Predicate",
-    "Name":"http:\/\/schema.org\/homeLocation",
+    "Name":"https://schema.org/homeLocation",
     "Domain Bucket":"10K - 100K"
   },
   {
     "Class":"Predicate",
-    "Name":"http:\/\/schema.org\/homeLocation-input",
+    "Name":"https://schema.org/homeLocation-input",
     "Domain Bucket":"< 1K"
   },
   {
     "Class":"Predicate",
-    "Name":"http:\/\/schema.org\/homeLocation-output",
+    "Name":"https://schema.org/homeLocation-output",
     "Domain Bucket":"< 1K"
   },
   {
     "Class":"Predicate",
-    "Name":"http:\/\/schema.org\/homeTeam",
+    "Name":"https://schema.org/homeTeam",
     "Domain Bucket":"10K - 100K"
   },
   {
     "Class":"Predicate",
-    "Name":"http:\/\/schema.org\/homeTeam-input",
+    "Name":"https://schema.org/homeTeam-input",
     "Domain Bucket":"< 1K"
   },
   {
     "Class":"Predicate",
-    "Name":"http:\/\/schema.org\/homeTeam-output",
+    "Name":"https://schema.org/homeTeam-output",
     "Domain Bucket":"< 1K"
   },
   {
     "Class":"Predicate",
-    "Name":"http:\/\/schema.org\/honorificPrefix",
+    "Name":"https://schema.org/honorificPrefix",
     "Domain Bucket":"10K - 100K"
   },
   {
     "Class":"Predicate",
-    "Name":"http:\/\/schema.org\/honorificPrefix-input",
+    "Name":"https://schema.org/honorificPrefix-input",
     "Domain Bucket":"< 1K"
   },
   {
     "Class":"Predicate",
-    "Name":"http:\/\/schema.org\/honorificPrefix-output",
+    "Name":"https://schema.org/honorificPrefix-output",
     "Domain Bucket":"< 1K"
   },
   {
     "Class":"Predicate",
-    "Name":"http:\/\/schema.org\/honorificSuffix",
+    "Name":"https://schema.org/honorificSuffix",
     "Domain Bucket":"10K - 100K"
   },
   {
     "Class":"Predicate",
-    "Name":"http:\/\/schema.org\/honorificSuffix-input",
+    "Name":"https://schema.org/honorificSuffix-input",
     "Domain Bucket":"< 1K"
   },
   {
     "Class":"Predicate",
-    "Name":"http:\/\/schema.org\/honorificSuffix-output",
+    "Name":"https://schema.org/honorificSuffix-output",
     "Domain Bucket":"< 1K"
   },
   {
     "Class":"Predicate",
-    "Name":"http:\/\/schema.org\/hospitalAffiliation",
+    "Name":"https://schema.org/hospitalAffiliation",
     "Domain Bucket":"1K - 10K"
   },
   {
     "Class":"Predicate",
-    "Name":"http:\/\/schema.org\/hospitalAffiliation-input",
+    "Name":"https://schema.org/hospitalAffiliation-input",
     "Domain Bucket":"< 1K"
   },
   {
     "Class":"Predicate",
-    "Name":"http:\/\/schema.org\/hospitalAffiliation-output",
+    "Name":"https://schema.org/hospitalAffiliation-output",
     "Domain Bucket":"< 1K"
   },
   {
     "Class":"Predicate",
-    "Name":"http:\/\/schema.org\/hostingOrganization",
+    "Name":"https://schema.org/hostingOrganization",
     "Domain Bucket":"1K - 10K"
   },
   {
     "Class":"Predicate",
-    "Name":"http:\/\/schema.org\/hostingOrganization-input",
+    "Name":"https://schema.org/hostingOrganization-input",
     "Domain Bucket":"< 1K"
   },
   {
     "Class":"Predicate",
-    "Name":"http:\/\/schema.org\/hostingOrganization-output",
+    "Name":"https://schema.org/hostingOrganization-output",
     "Domain Bucket":"< 1K"
   },
   {
     "Class":"Predicate",
-    "Name":"http:\/\/schema.org\/hoursAvailable",
+    "Name":"https://schema.org/hoursAvailable",
     "Domain Bucket":"100K - 1M"
   },
   {
     "Class":"Predicate",
-    "Name":"http:\/\/schema.org\/hoursAvailable-input",
+    "Name":"https://schema.org/hoursAvailable-input",
     "Domain Bucket":"< 1K"
   },
   {
     "Class":"Predicate",
-    "Name":"http:\/\/schema.org\/hoursAvailable-output",
+    "Name":"https://schema.org/hoursAvailable-output",
     "Domain Bucket":"< 1K"
   },
   {
     "Class":"Predicate",
-    "Name":"http:\/\/schema.org\/howPerformed",
+    "Name":"https://schema.org/howPerformed",
     "Domain Bucket":"10K - 100K"
   },
   {
     "Class":"Predicate",
-    "Name":"http:\/\/schema.org\/howPerformed-input",
+    "Name":"https://schema.org/howPerformed-input",
     "Domain Bucket":"< 1K"
   },
   {
     "Class":"Predicate",
-    "Name":"http:\/\/schema.org\/howPerformed-output",
+    "Name":"https://schema.org/howPerformed-output",
     "Domain Bucket":"< 1K"
   },
   {
     "Class":"Predicate",
-    "Name":"http:\/\/schema.org\/httpMethod",
+    "Name":"https://schema.org/httpMethod",
     "Domain Bucket":"1K - 10K"
   },
   {
     "Class":"Predicate",
-    "Name":"http:\/\/schema.org\/httpMethod-input",
+    "Name":"https://schema.org/httpMethod-input",
     "Domain Bucket":"< 1K"
   },
   {
     "Class":"Predicate",
-    "Name":"http:\/\/schema.org\/httpMethod-output",
+    "Name":"https://schema.org/httpMethod-output",
     "Domain Bucket":"< 1K"
   },
   {
     "Class":"Predicate",
-    "Name":"http:\/\/schema.org\/iataCode",
+    "Name":"https://schema.org/iataCode",
     "Domain Bucket":"1K - 10K"
   },
   {
     "Class":"Predicate",
-    "Name":"http:\/\/schema.org\/iataCode-input",
+    "Name":"https://schema.org/iataCode-input",
     "Domain Bucket":"< 1K"
   },
   {
     "Class":"Predicate",
-    "Name":"http:\/\/schema.org\/iataCode-output",
+    "Name":"https://schema.org/iataCode-output",
     "Domain Bucket":"< 1K"
   },
   {
     "Class":"Predicate",
-    "Name":"http:\/\/schema.org\/icaoCode",
+    "Name":"https://schema.org/icaoCode",
     "Domain Bucket":"1K - 10K"
   },
   {
     "Class":"Predicate",
-    "Name":"http:\/\/schema.org\/icaoCode-input",
+    "Name":"https://schema.org/icaoCode-input",
     "Domain Bucket":"< 1K"
   },
   {
     "Class":"Predicate",
-    "Name":"http:\/\/schema.org\/icaoCode-output",
+    "Name":"https://schema.org/icaoCode-output",
     "Domain Bucket":"< 1K"
   },
   {
     "Class":"Predicate",
-    "Name":"http:\/\/schema.org\/identifier",
+    "Name":"https://schema.org/identifier",
     "Domain Bucket":"100K - 1M"
   },
   {
     "Class":"Predicate",
-    "Name":"http:\/\/schema.org\/identifier-input",
+    "Name":"https://schema.org/identifier-input",
     "Domain Bucket":"< 1K"
   },
   {
     "Class":"Predicate",
-    "Name":"http:\/\/schema.org\/identifier-output",
+    "Name":"https://schema.org/identifier-output",
     "Domain Bucket":"< 1K"
   },
   {
     "Class":"Predicate",
-    "Name":"http:\/\/schema.org\/identifyingExam",
+    "Name":"https://schema.org/identifyingExam",
     "Domain Bucket":"< 1K"
   },
   {
     "Class":"Predicate",
-    "Name":"http:\/\/schema.org\/identifyingExam-input",
+    "Name":"https://schema.org/identifyingExam-input",
     "Domain Bucket":"< 1K"
   },
   {
     "Class":"Predicate",
-    "Name":"http:\/\/schema.org\/identifyingExam-output",
+    "Name":"https://schema.org/identifyingExam-output",
     "Domain Bucket":"< 1K"
   },
   {
     "Class":"Predicate",
-    "Name":"http:\/\/schema.org\/identifyingTest",
+    "Name":"https://schema.org/identifyingTest",
     "Domain Bucket":"< 1K"
   },
   {
     "Class":"Predicate",
-    "Name":"http:\/\/schema.org\/identifyingTest-input",
+    "Name":"https://schema.org/identifyingTest-input",
     "Domain Bucket":"< 1K"
   },
   {
     "Class":"Predicate",
-    "Name":"http:\/\/schema.org\/identifyingTest-output",
+    "Name":"https://schema.org/identifyingTest-output",
     "Domain Bucket":"< 1K"
   },
   {
     "Class":"Predicate",
-    "Name":"http:\/\/schema.org\/illustrator",
+    "Name":"https://schema.org/illustrator",
     "Domain Bucket":"1K - 10K"
   },
   {
     "Class":"Predicate",
-    "Name":"http:\/\/schema.org\/illustrator-input",
+    "Name":"https://schema.org/illustrator-input",
     "Domain Bucket":"< 1K"
   },
   {
     "Class":"Predicate",
-    "Name":"http:\/\/schema.org\/illustrator-output",
+    "Name":"https://schema.org/illustrator-output",
     "Domain Bucket":"< 1K"
   },
   {
     "Class":"Predicate",
-    "Name":"http:\/\/schema.org\/image",
+    "Name":"https://schema.org/image",
     "Domain Bucket":"10M+"
   },
   {
     "Class":"Predicate",
-    "Name":"http:\/\/schema.org\/image-input",
+    "Name":"https://schema.org/image-input",
     "Domain Bucket":"< 1K"
   },
   {
     "Class":"Predicate",
-    "Name":"http:\/\/schema.org\/image-output",
+    "Name":"https://schema.org/image-output",
     "Domain Bucket":"< 1K"
   },
   {
     "Class":"Predicate",
-    "Name":"http:\/\/schema.org\/imagingTechnique",
+    "Name":"https://schema.org/imagingTechnique",
     "Domain Bucket":"< 1K"
   },
   {
     "Class":"Predicate",
-    "Name":"http:\/\/schema.org\/imagingTechnique-input",
+    "Name":"https://schema.org/imagingTechnique-input",
     "Domain Bucket":"< 1K"
   },
   {
     "Class":"Predicate",
-    "Name":"http:\/\/schema.org\/imagingTechnique-output",
+    "Name":"https://schema.org/imagingTechnique-output",
     "Domain Bucket":"< 1K"
   },
   {
     "Class":"Predicate",
-    "Name":"http:\/\/schema.org\/inAlbum",
+    "Name":"https://schema.org/inAlbum",
     "Domain Bucket":"10K - 100K"
   },
   {
     "Class":"Predicate",
-    "Name":"http:\/\/schema.org\/inAlbum-input",
+    "Name":"https://schema.org/inAlbum-input",
     "Domain Bucket":"< 1K"
   },
   {
     "Class":"Predicate",
-    "Name":"http:\/\/schema.org\/inAlbum-output",
+    "Name":"https://schema.org/inAlbum-output",
     "Domain Bucket":"< 1K"
   },
   {
     "Class":"Predicate",
-    "Name":"http:\/\/schema.org\/inBroadcastLineup",
+    "Name":"https://schema.org/inBroadcastLineup",
     "Domain Bucket":"< 1K"
   },
   {
     "Class":"Predicate",
-    "Name":"http:\/\/schema.org\/inBroadcastLineup-input",
+    "Name":"https://schema.org/inBroadcastLineup-input",
     "Domain Bucket":"< 1K"
   },
   {
     "Class":"Predicate",
-    "Name":"http:\/\/schema.org\/inBroadcastLineup-output",
+    "Name":"https://schema.org/inBroadcastLineup-output",
     "Domain Bucket":"< 1K"
   },
   {
     "Class":"Predicate",
-    "Name":"http:\/\/schema.org\/inChI",
+    "Name":"https://schema.org/inChI",
     "Domain Bucket":"< 1K"
   },
   {
     "Class":"Predicate",
-    "Name":"http:\/\/schema.org\/inChI-input",
+    "Name":"https://schema.org/inChI-input",
     "Domain Bucket":"< 1K"
   },
   {
     "Class":"Predicate",
-    "Name":"http:\/\/schema.org\/inChI-output",
+    "Name":"https://schema.org/inChI-output",
     "Domain Bucket":"< 1K"
   },
   {
     "Class":"Predicate",
-    "Name":"http:\/\/schema.org\/inChIKey",
+    "Name":"https://schema.org/inChIKey",
     "Domain Bucket":"< 1K"
   },
   {
     "Class":"Predicate",
-    "Name":"http:\/\/schema.org\/inChIKey-input",
+    "Name":"https://schema.org/inChIKey-input",
     "Domain Bucket":"< 1K"
   },
   {
     "Class":"Predicate",
-    "Name":"http:\/\/schema.org\/inChIKey-output",
+    "Name":"https://schema.org/inChIKey-output",
     "Domain Bucket":"< 1K"
   },
   {
     "Class":"Predicate",
-    "Name":"http:\/\/schema.org\/inCodeSet",
+    "Name":"https://schema.org/inCodeSet",
     "Domain Bucket":"1K - 10K"
   },
   {
     "Class":"Predicate",
-    "Name":"http:\/\/schema.org\/inCodeSet-input",
+    "Name":"https://schema.org/inCodeSet-input",
     "Domain Bucket":"< 1K"
   },
   {
     "Class":"Predicate",
-    "Name":"http:\/\/schema.org\/inCodeSet-output",
+    "Name":"https://schema.org/inCodeSet-output",
     "Domain Bucket":"< 1K"
   },
   {
     "Class":"Predicate",
-    "Name":"http:\/\/schema.org\/inDefinedTermSet",
+    "Name":"https://schema.org/inDefinedTermSet",
     "Domain Bucket":"10K - 100K"
   },
   {
     "Class":"Predicate",
-    "Name":"http:\/\/schema.org\/inDefinedTermSet-input",
+    "Name":"https://schema.org/inDefinedTermSet-input",
     "Domain Bucket":"< 1K"
   },
   {
     "Class":"Predicate",
-    "Name":"http:\/\/schema.org\/inDefinedTermSet-output",
+    "Name":"https://schema.org/inDefinedTermSet-output",
     "Domain Bucket":"< 1K"
   },
   {
     "Class":"Predicate",
-    "Name":"http:\/\/schema.org\/inLanguage",
+    "Name":"https://schema.org/inLanguage",
     "Domain Bucket":"10M+"
   },
   {
     "Class":"Predicate",
-    "Name":"http:\/\/schema.org\/inLanguage-input",
+    "Name":"https://schema.org/inLanguage-input",
     "Domain Bucket":"< 1K"
   },
   {
     "Class":"Predicate",
-    "Name":"http:\/\/schema.org\/inLanguage-output",
+    "Name":"https://schema.org/inLanguage-output",
     "Domain Bucket":"< 1K"
   },
   {
     "Class":"Predicate",
-    "Name":"http:\/\/schema.org\/inPlaylist",
+    "Name":"https://schema.org/inPlaylist",
     "Domain Bucket":"< 1K"
   },
   {
     "Class":"Predicate",
-    "Name":"http:\/\/schema.org\/inPlaylist-input",
+    "Name":"https://schema.org/inPlaylist-input",
     "Domain Bucket":"< 1K"
   },
   {
     "Class":"Predicate",
-    "Name":"http:\/\/schema.org\/inPlaylist-output",
+    "Name":"https://schema.org/inPlaylist-output",
     "Domain Bucket":"< 1K"
   },
   {
     "Class":"Predicate",
-    "Name":"http:\/\/schema.org\/inProductGroupWithID",
+    "Name":"https://schema.org/inProductGroupWithID",
     "Domain Bucket":"10K - 100K"
   },
   {
     "Class":"Predicate",
-    "Name":"http:\/\/schema.org\/inProductGroupWithID-input",
+    "Name":"https://schema.org/inProductGroupWithID-input",
     "Domain Bucket":"< 1K"
   },
   {
     "Class":"Predicate",
-    "Name":"http:\/\/schema.org\/inProductGroupWithID-output",
+    "Name":"https://schema.org/inProductGroupWithID-output",
     "Domain Bucket":"< 1K"
   },
   {
     "Class":"Predicate",
-    "Name":"http:\/\/schema.org\/inStoreReturnsOffered",
+    "Name":"https://schema.org/inStoreReturnsOffered",
     "Domain Bucket":"1K - 10K"
   },
   {
     "Class":"Predicate",
-    "Name":"http:\/\/schema.org\/inStoreReturnsOffered-input",
+    "Name":"https://schema.org/inStoreReturnsOffered-input",
     "Domain Bucket":"< 1K"
   },
   {
     "Class":"Predicate",
-    "Name":"http:\/\/schema.org\/inStoreReturnsOffered-output",
+    "Name":"https://schema.org/inStoreReturnsOffered-output",
     "Domain Bucket":"< 1K"
   },
   {
     "Class":"Predicate",
-    "Name":"http:\/\/schema.org\/inSupportOf",
+    "Name":"https://schema.org/inSupportOf",
     "Domain Bucket":"< 1K"
   },
   {
     "Class":"Predicate",
-    "Name":"http:\/\/schema.org\/inSupportOf-input",
+    "Name":"https://schema.org/inSupportOf-input",
     "Domain Bucket":"< 1K"
   },
   {
     "Class":"Predicate",
-    "Name":"http:\/\/schema.org\/inSupportOf-output",
+    "Name":"https://schema.org/inSupportOf-output",
     "Domain Bucket":"< 1K"
   },
   {
     "Class":"Predicate",
-    "Name":"http:\/\/schema.org\/incentiveAmount",
+    "Name":"https://schema.org/incentiveAmount",
     "Domain Bucket":"< 1K"
   },
   {
     "Class":"Predicate",
-    "Name":"http:\/\/schema.org\/incentiveAmount-input",
+    "Name":"https://schema.org/incentiveAmount-input",
     "Domain Bucket":"< 1K"
   },
   {
     "Class":"Predicate",
-    "Name":"http:\/\/schema.org\/incentiveAmount-output",
+    "Name":"https://schema.org/incentiveAmount-output",
     "Domain Bucket":"< 1K"
   },
   {
     "Class":"Predicate",
-    "Name":"http:\/\/schema.org\/incentiveCompensation",
+    "Name":"https://schema.org/incentiveCompensation",
     "Domain Bucket":"1K - 10K"
   },
   {
     "Class":"Predicate",
-    "Name":"http:\/\/schema.org\/incentiveCompensation-input",
+    "Name":"https://schema.org/incentiveCompensation-input",
     "Domain Bucket":"< 1K"
   },
   {
     "Class":"Predicate",
-    "Name":"http:\/\/schema.org\/incentiveCompensation-output",
+    "Name":"https://schema.org/incentiveCompensation-output",
     "Domain Bucket":"< 1K"
   },
   {
     "Class":"Predicate",
-    "Name":"http:\/\/schema.org\/incentiveStatus",
+    "Name":"https://schema.org/incentiveStatus",
     "Domain Bucket":"< 1K"
   },
   {
     "Class":"Predicate",
-    "Name":"http:\/\/schema.org\/incentiveStatus-input",
+    "Name":"https://schema.org/incentiveStatus-input",
     "Domain Bucket":"< 1K"
   },
   {
     "Class":"Predicate",
-    "Name":"http:\/\/schema.org\/incentiveStatus-output",
+    "Name":"https://schema.org/incentiveStatus-output",
     "Domain Bucket":"< 1K"
   },
   {
     "Class":"Predicate",
-    "Name":"http:\/\/schema.org\/incentiveType",
+    "Name":"https://schema.org/incentiveType",
     "Domain Bucket":"< 1K"
   },
   {
     "Class":"Predicate",
-    "Name":"http:\/\/schema.org\/incentiveType-input",
+    "Name":"https://schema.org/incentiveType-input",
     "Domain Bucket":"< 1K"
   },
   {
     "Class":"Predicate",
-    "Name":"http:\/\/schema.org\/incentiveType-output",
+    "Name":"https://schema.org/incentiveType-output",
     "Domain Bucket":"< 1K"
   },
   {
     "Class":"Predicate",
-    "Name":"http:\/\/schema.org\/incentives",
+    "Name":"https://schema.org/incentives",
     "Domain Bucket":"< 1K"
   },
   {
     "Class":"Predicate",
-    "Name":"http:\/\/schema.org\/incentives-input",
+    "Name":"https://schema.org/incentives-input",
     "Domain Bucket":"< 1K"
   },
   {
     "Class":"Predicate",
-    "Name":"http:\/\/schema.org\/incentives-output",
+    "Name":"https://schema.org/incentives-output",
     "Domain Bucket":"< 1K"
   },
   {
     "Class":"Predicate",
-    "Name":"http:\/\/schema.org\/incentivizedItem",
+    "Name":"https://schema.org/incentivizedItem",
     "Domain Bucket":"< 1K"
   },
   {
     "Class":"Predicate",
-    "Name":"http:\/\/schema.org\/incentivizedItem-input",
+    "Name":"https://schema.org/incentivizedItem-input",
     "Domain Bucket":"< 1K"
   },
   {
     "Class":"Predicate",
-    "Name":"http:\/\/schema.org\/incentivizedItem-output",
+    "Name":"https://schema.org/incentivizedItem-output",
     "Domain Bucket":"< 1K"
   },
   {
     "Class":"Predicate",
-    "Name":"http:\/\/schema.org\/includedComposition",
+    "Name":"https://schema.org/includedComposition",
     "Domain Bucket":"< 1K"
   },
   {
     "Class":"Predicate",
-    "Name":"http:\/\/schema.org\/includedComposition-input",
+    "Name":"https://schema.org/includedComposition-input",
     "Domain Bucket":"< 1K"
   },
   {
     "Class":"Predicate",
-    "Name":"http:\/\/schema.org\/includedComposition-output",
+    "Name":"https://schema.org/includedComposition-output",
     "Domain Bucket":"< 1K"
   },
   {
     "Class":"Predicate",
-    "Name":"http:\/\/schema.org\/includedDataCatalog",
+    "Name":"https://schema.org/includedDataCatalog",
     "Domain Bucket":"< 1K"
   },
   {
     "Class":"Predicate",
-    "Name":"http:\/\/schema.org\/includedDataCatalog-input",
+    "Name":"https://schema.org/includedDataCatalog-input",
     "Domain Bucket":"< 1K"
   },
   {
     "Class":"Predicate",
-    "Name":"http:\/\/schema.org\/includedDataCatalog-output",
+    "Name":"https://schema.org/includedDataCatalog-output",
     "Domain Bucket":"< 1K"
   },
   {
     "Class":"Predicate",
-    "Name":"http:\/\/schema.org\/includedInDataCatalog",
+    "Name":"https://schema.org/includedInDataCatalog",
     "Domain Bucket":"1K - 10K"
   },
   {
     "Class":"Predicate",
-    "Name":"http:\/\/schema.org\/includedInDataCatalog-input",
+    "Name":"https://schema.org/includedInDataCatalog-input",
     "Domain Bucket":"< 1K"
   },
   {
     "Class":"Predicate",
-    "Name":"http:\/\/schema.org\/includedInDataCatalog-output",
+    "Name":"https://schema.org/includedInDataCatalog-output",
     "Domain Bucket":"< 1K"
   },
   {
     "Class":"Predicate",
-    "Name":"http:\/\/schema.org\/includedInHealthInsurancePlan",
+    "Name":"https://schema.org/includedInHealthInsurancePlan",
     "Domain Bucket":"< 1K"
   },
   {
     "Class":"Predicate",
-    "Name":"http:\/\/schema.org\/includedInHealthInsurancePlan-input",
+    "Name":"https://schema.org/includedInHealthInsurancePlan-input",
     "Domain Bucket":"< 1K"
   },
   {
     "Class":"Predicate",
-    "Name":"http:\/\/schema.org\/includedInHealthInsurancePlan-output",
+    "Name":"https://schema.org/includedInHealthInsurancePlan-output",
     "Domain Bucket":"< 1K"
   },
   {
     "Class":"Predicate",
-    "Name":"http:\/\/schema.org\/includedRiskFactor",
+    "Name":"https://schema.org/includedRiskFactor",
     "Domain Bucket":"< 1K"
   },
   {
     "Class":"Predicate",
-    "Name":"http:\/\/schema.org\/includedRiskFactor-input",
+    "Name":"https://schema.org/includedRiskFactor-input",
     "Domain Bucket":"< 1K"
   },
   {
     "Class":"Predicate",
-    "Name":"http:\/\/schema.org\/includedRiskFactor-output",
+    "Name":"https://schema.org/includedRiskFactor-output",
     "Domain Bucket":"< 1K"
   },
   {
     "Class":"Predicate",
-    "Name":"http:\/\/schema.org\/includesAttraction",
+    "Name":"https://schema.org/includesAttraction",
     "Domain Bucket":"1K - 10K"
   },
   {
     "Class":"Predicate",
-    "Name":"http:\/\/schema.org\/includesAttraction-input",
+    "Name":"https://schema.org/includesAttraction-input",
     "Domain Bucket":"< 1K"
   },
   {
     "Class":"Predicate",
-    "Name":"http:\/\/schema.org\/includesAttraction-output",
+    "Name":"https://schema.org/includesAttraction-output",
     "Domain Bucket":"< 1K"
   },
   {
     "Class":"Predicate",
-    "Name":"http:\/\/schema.org\/includesHealthPlanFormulary",
+    "Name":"https://schema.org/includesHealthPlanFormulary",
     "Domain Bucket":"< 1K"
   },
   {
     "Class":"Predicate",
-    "Name":"http:\/\/schema.org\/includesHealthPlanFormulary-input",
+    "Name":"https://schema.org/includesHealthPlanFormulary-input",
     "Domain Bucket":"< 1K"
   },
   {
     "Class":"Predicate",
-    "Name":"http:\/\/schema.org\/includesHealthPlanFormulary-output",
+    "Name":"https://schema.org/includesHealthPlanFormulary-output",
     "Domain Bucket":"< 1K"
   },
   {
     "Class":"Predicate",
-    "Name":"http:\/\/schema.org\/includesHealthPlanNetwork",
+    "Name":"https://schema.org/includesHealthPlanNetwork",
     "Domain Bucket":"< 1K"
   },
   {
     "Class":"Predicate",
-    "Name":"http:\/\/schema.org\/includesHealthPlanNetwork-input",
+    "Name":"https://schema.org/includesHealthPlanNetwork-input",
     "Domain Bucket":"< 1K"
   },
   {
     "Class":"Predicate",
-    "Name":"http:\/\/schema.org\/includesHealthPlanNetwork-output",
+    "Name":"https://schema.org/includesHealthPlanNetwork-output",
     "Domain Bucket":"< 1K"
   },
   {
     "Class":"Predicate",
-    "Name":"http:\/\/schema.org\/includesObject",
+    "Name":"https://schema.org/includesObject",
     "Domain Bucket":"1K - 10K"
   },
   {
     "Class":"Predicate",
-    "Name":"http:\/\/schema.org\/includesObject-input",
+    "Name":"https://schema.org/includesObject-input",
     "Domain Bucket":"< 1K"
   },
   {
     "Class":"Predicate",
-    "Name":"http:\/\/schema.org\/includesObject-output",
+    "Name":"https://schema.org/includesObject-output",
     "Domain Bucket":"< 1K"
   },
   {
     "Class":"Predicate",
-    "Name":"http:\/\/schema.org\/incomeLimit",
+    "Name":"https://schema.org/incomeLimit",
     "Domain Bucket":"< 1K"
   },
   {
     "Class":"Predicate",
-    "Name":"http:\/\/schema.org\/incomeLimit-input",
+    "Name":"https://schema.org/incomeLimit-input",
     "Domain Bucket":"< 1K"
   },
   {
     "Class":"Predicate",
-    "Name":"http:\/\/schema.org\/incomeLimit-output",
+    "Name":"https://schema.org/incomeLimit-output",
     "Domain Bucket":"< 1K"
   },
   {
     "Class":"Predicate",
-    "Name":"http:\/\/schema.org\/increasesRiskOf",
+    "Name":"https://schema.org/increasesRiskOf",
     "Domain Bucket":"< 1K"
   },
   {
     "Class":"Predicate",
-    "Name":"http:\/\/schema.org\/increasesRiskOf-input",
+    "Name":"https://schema.org/increasesRiskOf-input",
     "Domain Bucket":"< 1K"
   },
   {
     "Class":"Predicate",
-    "Name":"http:\/\/schema.org\/increasesRiskOf-output",
+    "Name":"https://schema.org/increasesRiskOf-output",
     "Domain Bucket":"< 1K"
   },
   {
     "Class":"Predicate",
-    "Name":"http:\/\/schema.org\/industry",
+    "Name":"https://schema.org/industry",
     "Domain Bucket":"10K - 100K"
   },
   {
     "Class":"Predicate",
-    "Name":"http:\/\/schema.org\/industry-input",
+    "Name":"https://schema.org/industry-input",
     "Domain Bucket":"< 1K"
   },
   {
     "Class":"Predicate",
-    "Name":"http:\/\/schema.org\/industry-output",
+    "Name":"https://schema.org/industry-output",
     "Domain Bucket":"< 1K"
   },
   {
     "Class":"Predicate",
-    "Name":"http:\/\/schema.org\/ineligibleRegion",
+    "Name":"https://schema.org/ineligibleRegion",
     "Domain Bucket":"< 1K"
   },
   {
     "Class":"Predicate",
-    "Name":"http:\/\/schema.org\/ineligibleRegion-input",
+    "Name":"https://schema.org/ineligibleRegion-input",
     "Domain Bucket":"< 1K"
   },
   {
     "Class":"Predicate",
-    "Name":"http:\/\/schema.org\/ineligibleRegion-output",
+    "Name":"https://schema.org/ineligibleRegion-output",
     "Domain Bucket":"< 1K"
   },
   {
     "Class":"Predicate",
-    "Name":"http:\/\/schema.org\/infectiousAgent",
+    "Name":"https://schema.org/infectiousAgent",
     "Domain Bucket":"< 1K"
   },
   {
     "Class":"Predicate",
-    "Name":"http:\/\/schema.org\/infectiousAgent-input",
+    "Name":"https://schema.org/infectiousAgent-input",
     "Domain Bucket":"< 1K"
   },
   {
     "Class":"Predicate",
-    "Name":"http:\/\/schema.org\/infectiousAgent-output",
+    "Name":"https://schema.org/infectiousAgent-output",
     "Domain Bucket":"< 1K"
   },
   {
     "Class":"Predicate",
-    "Name":"http:\/\/schema.org\/infectiousAgentClass",
+    "Name":"https://schema.org/infectiousAgentClass",
     "Domain Bucket":"< 1K"
   },
   {
     "Class":"Predicate",
-    "Name":"http:\/\/schema.org\/infectiousAgentClass-input",
+    "Name":"https://schema.org/infectiousAgentClass-input",
     "Domain Bucket":"< 1K"
   },
   {
     "Class":"Predicate",
-    "Name":"http:\/\/schema.org\/infectiousAgentClass-output",
+    "Name":"https://schema.org/infectiousAgentClass-output",
     "Domain Bucket":"< 1K"
   },
   {
     "Class":"Predicate",
-    "Name":"http:\/\/schema.org\/ingredients",
+    "Name":"https://schema.org/ingredients",
     "Domain Bucket":"1K - 10K"
   },
   {
     "Class":"Predicate",
-    "Name":"http:\/\/schema.org\/ingredients-input",
+    "Name":"https://schema.org/ingredients-input",
     "Domain Bucket":"< 1K"
   },
   {
     "Class":"Predicate",
-    "Name":"http:\/\/schema.org\/ingredients-output",
+    "Name":"https://schema.org/ingredients-output",
     "Domain Bucket":"< 1K"
   },
   {
     "Class":"Predicate",
-    "Name":"http:\/\/schema.org\/inker",
+    "Name":"https://schema.org/inker",
     "Domain Bucket":"< 1K"
   },
   {
     "Class":"Predicate",
-    "Name":"http:\/\/schema.org\/inker-input",
+    "Name":"https://schema.org/inker-input",
     "Domain Bucket":"< 1K"
   },
   {
     "Class":"Predicate",
-    "Name":"http:\/\/schema.org\/inker-output",
+    "Name":"https://schema.org/inker-output",
     "Domain Bucket":"< 1K"
   },
   {
     "Class":"Predicate",
-    "Name":"http:\/\/schema.org\/insertion",
+    "Name":"https://schema.org/insertion",
     "Domain Bucket":"< 1K"
   },
   {
     "Class":"Predicate",
-    "Name":"http:\/\/schema.org\/insertion-input",
+    "Name":"https://schema.org/insertion-input",
     "Domain Bucket":"< 1K"
   },
   {
     "Class":"Predicate",
-    "Name":"http:\/\/schema.org\/insertion-output",
+    "Name":"https://schema.org/insertion-output",
     "Domain Bucket":"< 1K"
   },
   {
     "Class":"Predicate",
-    "Name":"http:\/\/schema.org\/installUrl",
+    "Name":"https://schema.org/installUrl",
     "Domain Bucket":"100K - 1M"
   },
   {
     "Class":"Predicate",
-    "Name":"http:\/\/schema.org\/installUrl-input",
+    "Name":"https://schema.org/installUrl-input",
     "Domain Bucket":"< 1K"
   },
   {
     "Class":"Predicate",
-    "Name":"http:\/\/schema.org\/installUrl-output",
+    "Name":"https://schema.org/installUrl-output",
     "Domain Bucket":"< 1K"
   },
   {
     "Class":"Predicate",
-    "Name":"http:\/\/schema.org\/instructor",
+    "Name":"https://schema.org/instructor",
     "Domain Bucket":"10K - 100K"
   },
   {
     "Class":"Predicate",
-    "Name":"http:\/\/schema.org\/instructor-input",
+    "Name":"https://schema.org/instructor-input",
     "Domain Bucket":"< 1K"
   },
   {
     "Class":"Predicate",
-    "Name":"http:\/\/schema.org\/instructor-output",
+    "Name":"https://schema.org/instructor-output",
     "Domain Bucket":"< 1K"
   },
   {
     "Class":"Predicate",
-    "Name":"http:\/\/schema.org\/instrument",
+    "Name":"https://schema.org/instrument",
     "Domain Bucket":"1K - 10K"
   },
   {
     "Class":"Predicate",
-    "Name":"http:\/\/schema.org\/instrument-input",
+    "Name":"https://schema.org/instrument-input",
     "Domain Bucket":"< 1K"
   },
   {
     "Class":"Predicate",
-    "Name":"http:\/\/schema.org\/instrument-output",
+    "Name":"https://schema.org/instrument-output",
     "Domain Bucket":"< 1K"
   },
   {
     "Class":"Predicate",
-    "Name":"http:\/\/schema.org\/intensity",
+    "Name":"https://schema.org/intensity",
     "Domain Bucket":"< 1K"
   },
   {
     "Class":"Predicate",
-    "Name":"http:\/\/schema.org\/intensity-input",
+    "Name":"https://schema.org/intensity-input",
     "Domain Bucket":"< 1K"
   },
   {
     "Class":"Predicate",
-    "Name":"http:\/\/schema.org\/intensity-output",
+    "Name":"https://schema.org/intensity-output",
     "Domain Bucket":"< 1K"
   },
   {
     "Class":"Predicate",
-    "Name":"http:\/\/schema.org\/interactingDrug",
+    "Name":"https://schema.org/interactingDrug",
     "Domain Bucket":"< 1K"
   },
   {
     "Class":"Predicate",
-    "Name":"http:\/\/schema.org\/interactingDrug-input",
+    "Name":"https://schema.org/interactingDrug-input",
     "Domain Bucket":"< 1K"
   },
   {
     "Class":"Predicate",
-    "Name":"http:\/\/schema.org\/interactingDrug-output",
+    "Name":"https://schema.org/interactingDrug-output",
     "Domain Bucket":"< 1K"
   },
   {
     "Class":"Predicate",
-    "Name":"http:\/\/schema.org\/interactionCount",
+    "Name":"https://schema.org/interactionCount",
     "Domain Bucket":"100K - 1M"
   },
   {
     "Class":"Predicate",
-    "Name":"http:\/\/schema.org\/interactionCount-input",
+    "Name":"https://schema.org/interactionCount-input",
     "Domain Bucket":"< 1K"
   },
   {
     "Class":"Predicate",
-    "Name":"http:\/\/schema.org\/interactionCount-output",
+    "Name":"https://schema.org/interactionCount-output",
     "Domain Bucket":"< 1K"
   },
   {
     "Class":"Predicate",
-    "Name":"http:\/\/schema.org\/interactionService",
+    "Name":"https://schema.org/interactionService",
     "Domain Bucket":"< 1K"
   },
   {
     "Class":"Predicate",
-    "Name":"http:\/\/schema.org\/interactionService-input",
+    "Name":"https://schema.org/interactionService-input",
     "Domain Bucket":"< 1K"
   },
   {
     "Class":"Predicate",
-    "Name":"http:\/\/schema.org\/interactionService-output",
+    "Name":"https://schema.org/interactionService-output",
     "Domain Bucket":"< 1K"
   },
   {
     "Class":"Predicate",
-    "Name":"http:\/\/schema.org\/interactionStatistic",
+    "Name":"https://schema.org/interactionStatistic",
     "Domain Bucket":"100K - 1M"
   },
   {
     "Class":"Predicate",
-    "Name":"http:\/\/schema.org\/interactionStatistic-input",
+    "Name":"https://schema.org/interactionStatistic-input",
     "Domain Bucket":"< 1K"
   },
   {
     "Class":"Predicate",
-    "Name":"http:\/\/schema.org\/interactionStatistic-output",
+    "Name":"https://schema.org/interactionStatistic-output",
     "Domain Bucket":"< 1K"
   },
   {
     "Class":"Predicate",
-    "Name":"http:\/\/schema.org\/interactionType",
+    "Name":"https://schema.org/interactionType",
     "Domain Bucket":"100K - 1M"
   },
   {
     "Class":"Predicate",
-    "Name":"http:\/\/schema.org\/interactionType-input",
+    "Name":"https://schema.org/interactionType-input",
     "Domain Bucket":"< 1K"
   },
   {
     "Class":"Predicate",
-    "Name":"http:\/\/schema.org\/interactionType-output",
+    "Name":"https://schema.org/interactionType-output",
     "Domain Bucket":"< 1K"
   },
   {
     "Class":"Predicate",
-    "Name":"http:\/\/schema.org\/interactivityType",
+    "Name":"https://schema.org/interactivityType",
     "Domain Bucket":"1K - 10K"
   },
   {
     "Class":"Predicate",
-    "Name":"http:\/\/schema.org\/interactivityType-input",
+    "Name":"https://schema.org/interactivityType-input",
     "Domain Bucket":"< 1K"
   },
   {
     "Class":"Predicate",
-    "Name":"http:\/\/schema.org\/interactivityType-output",
+    "Name":"https://schema.org/interactivityType-output",
     "Domain Bucket":"< 1K"
   },
   {
     "Class":"Predicate",
-    "Name":"http:\/\/schema.org\/interestRate",
+    "Name":"https://schema.org/interestRate",
     "Domain Bucket":"1K - 10K"
   },
   {
     "Class":"Predicate",
-    "Name":"http:\/\/schema.org\/interestRate-input",
+    "Name":"https://schema.org/interestRate-input",
     "Domain Bucket":"< 1K"
   },
   {
     "Class":"Predicate",
-    "Name":"http:\/\/schema.org\/interestRate-output",
+    "Name":"https://schema.org/interestRate-output",
     "Domain Bucket":"< 1K"
   },
   {
     "Class":"Predicate",
-    "Name":"http:\/\/schema.org\/interpretedAsClaim",
+    "Name":"https://schema.org/interpretedAsClaim",
     "Domain Bucket":"< 1K"
   },
   {
     "Class":"Predicate",
-    "Name":"http:\/\/schema.org\/interpretedAsClaim-input",
+    "Name":"https://schema.org/interpretedAsClaim-input",
     "Domain Bucket":"< 1K"
   },
   {
     "Class":"Predicate",
-    "Name":"http:\/\/schema.org\/interpretedAsClaim-output",
+    "Name":"https://schema.org/interpretedAsClaim-output",
     "Domain Bucket":"< 1K"
   },
   {
     "Class":"Predicate",
-    "Name":"http:\/\/schema.org\/inventoryLevel",
+    "Name":"https://schema.org/inventoryLevel",
     "Domain Bucket":"100K - 1M"
   },
   {
     "Class":"Predicate",
-    "Name":"http:\/\/schema.org\/inventoryLevel-input",
+    "Name":"https://schema.org/inventoryLevel-input",
     "Domain Bucket":"< 1K"
   },
   {
     "Class":"Predicate",
-    "Name":"http:\/\/schema.org\/inventoryLevel-output",
+    "Name":"https://schema.org/inventoryLevel-output",
     "Domain Bucket":"< 1K"
   },
   {
     "Class":"Predicate",
-    "Name":"http:\/\/schema.org\/inverseOf",
+    "Name":"https://schema.org/inverseOf",
     "Domain Bucket":"< 1K"
   },
   {
     "Class":"Predicate",
-    "Name":"http:\/\/schema.org\/inverseOf-input",
+    "Name":"https://schema.org/inverseOf-input",
     "Domain Bucket":"< 1K"
   },
   {
     "Class":"Predicate",
-    "Name":"http:\/\/schema.org\/inverseOf-output",
+    "Name":"https://schema.org/inverseOf-output",
     "Domain Bucket":"< 1K"
   },
   {
     "Class":"Predicate",
-    "Name":"http:\/\/schema.org\/isAcceptingNewPatients",
+    "Name":"https://schema.org/isAcceptingNewPatients",
     "Domain Bucket":"10K - 100K"
   },
   {
     "Class":"Predicate",
-    "Name":"http:\/\/schema.org\/isAcceptingNewPatients-input",
+    "Name":"https://schema.org/isAcceptingNewPatients-input",
     "Domain Bucket":"< 1K"
   },
   {
     "Class":"Predicate",
-    "Name":"http:\/\/schema.org\/isAcceptingNewPatients-output",
+    "Name":"https://schema.org/isAcceptingNewPatients-output",
     "Domain Bucket":"< 1K"
   },
   {
     "Class":"Predicate",
-    "Name":"http:\/\/schema.org\/isAccessibleForFree",
+    "Name":"https://schema.org/isAccessibleForFree",
     "Domain Bucket":"100K - 1M"
   },
   {
     "Class":"Predicate",
-    "Name":"http:\/\/schema.org\/isAccessibleForFree-input",
+    "Name":"https://schema.org/isAccessibleForFree-input",
     "Domain Bucket":"< 1K"
   },
   {
     "Class":"Predicate",
-    "Name":"http:\/\/schema.org\/isAccessibleForFree-output",
+    "Name":"https://schema.org/isAccessibleForFree-output",
     "Domain Bucket":"< 1K"
   },
   {
     "Class":"Predicate",
-    "Name":"http:\/\/schema.org\/isAccessoryOrSparePartFor",
+    "Name":"https://schema.org/isAccessoryOrSparePartFor",
     "Domain Bucket":"1K - 10K"
   },
   {
     "Class":"Predicate",
-    "Name":"http:\/\/schema.org\/isAccessoryOrSparePartFor-input",
+    "Name":"https://schema.org/isAccessoryOrSparePartFor-input",
     "Domain Bucket":"< 1K"
   },
   {
     "Class":"Predicate",
-    "Name":"http:\/\/schema.org\/isAccessoryOrSparePartFor-output",
+    "Name":"https://schema.org/isAccessoryOrSparePartFor-output",
     "Domain Bucket":"< 1K"
   },
   {
     "Class":"Predicate",
-    "Name":"http:\/\/schema.org\/isAvailableGenerically",
+    "Name":"https://schema.org/isAvailableGenerically",
     "Domain Bucket":"< 1K"
   },
   {
     "Class":"Predicate",
-    "Name":"http:\/\/schema.org\/isAvailableGenerically-input",
+    "Name":"https://schema.org/isAvailableGenerically-input",
     "Domain Bucket":"< 1K"
   },
   {
     "Class":"Predicate",
-    "Name":"http:\/\/schema.org\/isAvailableGenerically-output",
+    "Name":"https://schema.org/isAvailableGenerically-output",
     "Domain Bucket":"< 1K"
   },
   {
     "Class":"Predicate",
-    "Name":"http:\/\/schema.org\/isBasedOn",
+    "Name":"https://schema.org/isBasedOn",
     "Domain Bucket":"10K - 100K"
   },
   {
     "Class":"Predicate",
-    "Name":"http:\/\/schema.org\/isBasedOn-input",
+    "Name":"https://schema.org/isBasedOn-input",
     "Domain Bucket":"< 1K"
   },
   {
     "Class":"Predicate",
-    "Name":"http:\/\/schema.org\/isBasedOn-output",
+    "Name":"https://schema.org/isBasedOn-output",
     "Domain Bucket":"< 1K"
   },
   {
     "Class":"Predicate",
-    "Name":"http:\/\/schema.org\/isBasedOnUrl",
+    "Name":"https://schema.org/isBasedOnUrl",
     "Domain Bucket":"< 1K"
   },
   {
     "Class":"Predicate",
-    "Name":"http:\/\/schema.org\/isBasedOnUrl-input",
+    "Name":"https://schema.org/isBasedOnUrl-input",
     "Domain Bucket":"< 1K"
   },
   {
     "Class":"Predicate",
-    "Name":"http:\/\/schema.org\/isBasedOnUrl-output",
+    "Name":"https://schema.org/isBasedOnUrl-output",
     "Domain Bucket":"< 1K"
   },
   {
     "Class":"Predicate",
-    "Name":"http:\/\/schema.org\/isConsumableFor",
+    "Name":"https://schema.org/isConsumableFor",
     "Domain Bucket":"< 1K"
   },
   {
     "Class":"Predicate",
-    "Name":"http:\/\/schema.org\/isConsumableFor-input",
+    "Name":"https://schema.org/isConsumableFor-input",
     "Domain Bucket":"< 1K"
   },
   {
     "Class":"Predicate",
-    "Name":"http:\/\/schema.org\/isConsumableFor-output",
+    "Name":"https://schema.org/isConsumableFor-output",
     "Domain Bucket":"< 1K"
   },
   {
     "Class":"Predicate",
-    "Name":"http:\/\/schema.org\/isEncodedByBioChemEntity",
+    "Name":"https://schema.org/isEncodedByBioChemEntity",
     "Domain Bucket":"< 1K"
   },
   {
     "Class":"Predicate",
-    "Name":"http:\/\/schema.org\/isEncodedByBioChemEntity-input",
+    "Name":"https://schema.org/isEncodedByBioChemEntity-input",
     "Domain Bucket":"< 1K"
   },
   {
     "Class":"Predicate",
-    "Name":"http:\/\/schema.org\/isEncodedByBioChemEntity-output",
+    "Name":"https://schema.org/isEncodedByBioChemEntity-output",
     "Domain Bucket":"< 1K"
   },
   {
     "Class":"Predicate",
-    "Name":"http:\/\/schema.org\/isFamilyFriendly",
+    "Name":"https://schema.org/isFamilyFriendly",
     "Domain Bucket":"100K - 1M"
   },
   {
     "Class":"Predicate",
-    "Name":"http:\/\/schema.org\/isFamilyFriendly-input",
+    "Name":"https://schema.org/isFamilyFriendly-input",
     "Domain Bucket":"< 1K"
   },
   {
     "Class":"Predicate",
-    "Name":"http:\/\/schema.org\/isFamilyFriendly-output",
+    "Name":"https://schema.org/isFamilyFriendly-output",
     "Domain Bucket":"< 1K"
   },
   {
     "Class":"Predicate",
-    "Name":"http:\/\/schema.org\/isGift",
+    "Name":"https://schema.org/isGift",
     "Domain Bucket":"< 1K"
   },
   {
     "Class":"Predicate",
-    "Name":"http:\/\/schema.org\/isGift-input",
+    "Name":"https://schema.org/isGift-input",
     "Domain Bucket":"< 1K"
   },
   {
     "Class":"Predicate",
-    "Name":"http:\/\/schema.org\/isGift-output",
+    "Name":"https://schema.org/isGift-output",
     "Domain Bucket":"< 1K"
   },
   {
     "Class":"Predicate",
-    "Name":"http:\/\/schema.org\/isInvolvedInBiologicalProcess",
+    "Name":"https://schema.org/isInvolvedInBiologicalProcess",
     "Domain Bucket":"< 1K"
   },
   {
     "Class":"Predicate",
-    "Name":"http:\/\/schema.org\/isInvolvedInBiologicalProcess-input",
+    "Name":"https://schema.org/isInvolvedInBiologicalProcess-input",
     "Domain Bucket":"< 1K"
   },
   {
     "Class":"Predicate",
-    "Name":"http:\/\/schema.org\/isInvolvedInBiologicalProcess-output",
+    "Name":"https://schema.org/isInvolvedInBiologicalProcess-output",
     "Domain Bucket":"< 1K"
   },
   {
     "Class":"Predicate",
-    "Name":"http:\/\/schema.org\/isLiveBroadcast",
+    "Name":"https://schema.org/isLiveBroadcast",
     "Domain Bucket":"10K - 100K"
   },
   {
     "Class":"Predicate",
-    "Name":"http:\/\/schema.org\/isLiveBroadcast-input",
+    "Name":"https://schema.org/isLiveBroadcast-input",
     "Domain Bucket":"< 1K"
   },
   {
     "Class":"Predicate",
-    "Name":"http:\/\/schema.org\/isLiveBroadcast-output",
+    "Name":"https://schema.org/isLiveBroadcast-output",
     "Domain Bucket":"< 1K"
   },
   {
     "Class":"Predicate",
-    "Name":"http:\/\/schema.org\/isLocatedInSubcellularLocation",
+    "Name":"https://schema.org/isLocatedInSubcellularLocation",
     "Domain Bucket":"< 1K"
   },
   {
     "Class":"Predicate",
-    "Name":"http:\/\/schema.org\/isLocatedInSubcellularLocation-input",
+    "Name":"https://schema.org/isLocatedInSubcellularLocation-input",
     "Domain Bucket":"< 1K"
   },
   {
     "Class":"Predicate",
-    "Name":"http:\/\/schema.org\/isLocatedInSubcellularLocation-output",
+    "Name":"https://schema.org/isLocatedInSubcellularLocation-output",
     "Domain Bucket":"< 1K"
   },
   {
     "Class":"Predicate",
-    "Name":"http:\/\/schema.org\/isPartOf",
+    "Name":"https://schema.org/isPartOf",
     "Domain Bucket":"10M+"
   },
   {
     "Class":"Predicate",
-    "Name":"http:\/\/schema.org\/isPartOf-input",
+    "Name":"https://schema.org/isPartOf-input",
     "Domain Bucket":"< 1K"
   },
   {
     "Class":"Predicate",
-    "Name":"http:\/\/schema.org\/isPartOf-output",
+    "Name":"https://schema.org/isPartOf-output",
     "Domain Bucket":"< 1K"
   },
   {
     "Class":"Predicate",
-    "Name":"http:\/\/schema.org\/isPartOfBioChemEntity",
+    "Name":"https://schema.org/isPartOfBioChemEntity",
     "Domain Bucket":"< 1K"
   },
   {
     "Class":"Predicate",
-    "Name":"http:\/\/schema.org\/isPartOfBioChemEntity-input",
+    "Name":"https://schema.org/isPartOfBioChemEntity-input",
     "Domain Bucket":"< 1K"
   },
   {
     "Class":"Predicate",
-    "Name":"http:\/\/schema.org\/isPartOfBioChemEntity-output",
+    "Name":"https://schema.org/isPartOfBioChemEntity-output",
     "Domain Bucket":"< 1K"
   },
   {
     "Class":"Predicate",
-    "Name":"http:\/\/schema.org\/isPlanForApartment",
+    "Name":"https://schema.org/isPlanForApartment",
     "Domain Bucket":"< 1K"
   },
   {
     "Class":"Predicate",
-    "Name":"http:\/\/schema.org\/isPlanForApartment-input",
+    "Name":"https://schema.org/isPlanForApartment-input",
     "Domain Bucket":"< 1K"
   },
   {
     "Class":"Predicate",
-    "Name":"http:\/\/schema.org\/isPlanForApartment-output",
+    "Name":"https://schema.org/isPlanForApartment-output",
     "Domain Bucket":"< 1K"
   },
   {
     "Class":"Predicate",
-    "Name":"http:\/\/schema.org\/isProprietary",
+    "Name":"https://schema.org/isProprietary",
     "Domain Bucket":"< 1K"
   },
   {
     "Class":"Predicate",
-    "Name":"http:\/\/schema.org\/isProprietary-input",
+    "Name":"https://schema.org/isProprietary-input",
     "Domain Bucket":"< 1K"
   },
   {
     "Class":"Predicate",
-    "Name":"http:\/\/schema.org\/isProprietary-output",
+    "Name":"https://schema.org/isProprietary-output",
     "Domain Bucket":"< 1K"
   },
   {
     "Class":"Predicate",
-    "Name":"http:\/\/schema.org\/isRelatedTo",
+    "Name":"https://schema.org/isRelatedTo",
     "Domain Bucket":"100K - 1M"
   },
   {
     "Class":"Predicate",
-    "Name":"http:\/\/schema.org\/isRelatedTo-input",
+    "Name":"https://schema.org/isRelatedTo-input",
     "Domain Bucket":"< 1K"
   },
   {
     "Class":"Predicate",
-    "Name":"http:\/\/schema.org\/isRelatedTo-output",
+    "Name":"https://schema.org/isRelatedTo-output",
     "Domain Bucket":"< 1K"
   },
   {
     "Class":"Predicate",
-    "Name":"http:\/\/schema.org\/isResizable",
+    "Name":"https://schema.org/isResizable",
     "Domain Bucket":"< 1K"
   },
   {
     "Class":"Predicate",
-    "Name":"http:\/\/schema.org\/isResizable-input",
+    "Name":"https://schema.org/isResizable-input",
     "Domain Bucket":"< 1K"
   },
   {
     "Class":"Predicate",
-    "Name":"http:\/\/schema.org\/isResizable-output",
+    "Name":"https://schema.org/isResizable-output",
     "Domain Bucket":"< 1K"
   },
   {
     "Class":"Predicate",
-    "Name":"http:\/\/schema.org\/isSimilarTo",
+    "Name":"https://schema.org/isSimilarTo",
     "Domain Bucket":"10K - 100K"
   },
   {
     "Class":"Predicate",
-    "Name":"http:\/\/schema.org\/isSimilarTo-input",
+    "Name":"https://schema.org/isSimilarTo-input",
     "Domain Bucket":"< 1K"
   },
   {
     "Class":"Predicate",
-    "Name":"http:\/\/schema.org\/isSimilarTo-output",
+    "Name":"https://schema.org/isSimilarTo-output",
     "Domain Bucket":"< 1K"
   },
   {
     "Class":"Predicate",
-    "Name":"http:\/\/schema.org\/isStoreOn",
+    "Name":"https://schema.org/isStoreOn",
     "Domain Bucket":"< 1K"
   },
   {
     "Class":"Predicate",
-    "Name":"http:\/\/schema.org\/isStoreOn-input",
+    "Name":"https://schema.org/isStoreOn-input",
     "Domain Bucket":"< 1K"
   },
   {
     "Class":"Predicate",
-    "Name":"http:\/\/schema.org\/isStoreOn-output",
+    "Name":"https://schema.org/isStoreOn-output",
     "Domain Bucket":"< 1K"
   },
   {
     "Class":"Predicate",
-    "Name":"http:\/\/schema.org\/isTierOf",
+    "Name":"https://schema.org/isTierOf",
     "Domain Bucket":"< 1K"
   },
   {
     "Class":"Predicate",
-    "Name":"http:\/\/schema.org\/isTierOf-input",
+    "Name":"https://schema.org/isTierOf-input",
     "Domain Bucket":"< 1K"
   },
   {
     "Class":"Predicate",
-    "Name":"http:\/\/schema.org\/isTierOf-output",
+    "Name":"https://schema.org/isTierOf-output",
     "Domain Bucket":"< 1K"
   },
   {
     "Class":"Predicate",
-    "Name":"http:\/\/schema.org\/isUnlabelledFallback",
+    "Name":"https://schema.org/isUnlabelledFallback",
     "Domain Bucket":"< 1K"
   },
   {
     "Class":"Predicate",
-    "Name":"http:\/\/schema.org\/isUnlabelledFallback-input",
+    "Name":"https://schema.org/isUnlabelledFallback-input",
     "Domain Bucket":"< 1K"
   },
   {
     "Class":"Predicate",
-    "Name":"http:\/\/schema.org\/isUnlabelledFallback-output",
+    "Name":"https://schema.org/isUnlabelledFallback-output",
     "Domain Bucket":"< 1K"
   },
   {
     "Class":"Predicate",
-    "Name":"http:\/\/schema.org\/isVariantOf",
+    "Name":"https://schema.org/isVariantOf",
     "Domain Bucket":"10K - 100K"
   },
   {
     "Class":"Predicate",
-    "Name":"http:\/\/schema.org\/isVariantOf-input",
+    "Name":"https://schema.org/isVariantOf-input",
     "Domain Bucket":"< 1K"
   },
   {
     "Class":"Predicate",
-    "Name":"http:\/\/schema.org\/isVariantOf-output",
+    "Name":"https://schema.org/isVariantOf-output",
     "Domain Bucket":"< 1K"
   },
   {
     "Class":"Predicate",
-    "Name":"http:\/\/schema.org\/isbn",
+    "Name":"https://schema.org/isbn",
     "Domain Bucket":"10K - 100K"
   },
   {
     "Class":"Predicate",
-    "Name":"http:\/\/schema.org\/isbn-input",
+    "Name":"https://schema.org/isbn-input",
     "Domain Bucket":"< 1K"
   },
   {
     "Class":"Predicate",
-    "Name":"http:\/\/schema.org\/isbn-output",
+    "Name":"https://schema.org/isbn-output",
     "Domain Bucket":"< 1K"
   },
   {
     "Class":"Predicate",
-    "Name":"http:\/\/schema.org\/isicV4",
+    "Name":"https://schema.org/isicV4",
     "Domain Bucket":"1K - 10K"
   },
   {
     "Class":"Predicate",
-    "Name":"http:\/\/schema.org\/isicV4-input",
+    "Name":"https://schema.org/isicV4-input",
     "Domain Bucket":"< 1K"
   },
   {
     "Class":"Predicate",
-    "Name":"http:\/\/schema.org\/isicV4-output",
+    "Name":"https://schema.org/isicV4-output",
     "Domain Bucket":"< 1K"
   },
   {
     "Class":"Predicate",
-    "Name":"http:\/\/schema.org\/iso6523Code",
+    "Name":"https://schema.org/iso6523Code",
     "Domain Bucket":"1K - 10K"
   },
   {
     "Class":"Predicate",
-    "Name":"http:\/\/schema.org\/iso6523Code-input",
+    "Name":"https://schema.org/iso6523Code-input",
     "Domain Bucket":"< 1K"
   },
   {
     "Class":"Predicate",
-    "Name":"http:\/\/schema.org\/iso6523Code-output",
+    "Name":"https://schema.org/iso6523Code-output",
     "Domain Bucket":"< 1K"
   },
   {
     "Class":"Predicate",
-    "Name":"http:\/\/schema.org\/isrcCode",
+    "Name":"https://schema.org/isrcCode",
     "Domain Bucket":"< 1K"
   },
   {
     "Class":"Predicate",
-    "Name":"http:\/\/schema.org\/isrcCode-input",
+    "Name":"https://schema.org/isrcCode-input",
     "Domain Bucket":"< 1K"
   },
   {
     "Class":"Predicate",
-    "Name":"http:\/\/schema.org\/isrcCode-output",
+    "Name":"https://schema.org/isrcCode-output",
     "Domain Bucket":"< 1K"
   },
   {
     "Class":"Predicate",
-    "Name":"http:\/\/schema.org\/issn",
+    "Name":"https://schema.org/issn",
     "Domain Bucket":"1K - 10K"
   },
   {
     "Class":"Predicate",
-    "Name":"http:\/\/schema.org\/issn-input",
+    "Name":"https://schema.org/issn-input",
     "Domain Bucket":"< 1K"
   },
   {
     "Class":"Predicate",
-    "Name":"http:\/\/schema.org\/issn-output",
+    "Name":"https://schema.org/issn-output",
     "Domain Bucket":"< 1K"
   },
   {
     "Class":"Predicate",
-    "Name":"http:\/\/schema.org\/issueNumber",
+    "Name":"https://schema.org/issueNumber",
     "Domain Bucket":"1K - 10K"
   },
   {
     "Class":"Predicate",
-    "Name":"http:\/\/schema.org\/issueNumber-input",
+    "Name":"https://schema.org/issueNumber-input",
     "Domain Bucket":"< 1K"
   },
   {
     "Class":"Predicate",
-    "Name":"http:\/\/schema.org\/issueNumber-output",
+    "Name":"https://schema.org/issueNumber-output",
     "Domain Bucket":"< 1K"
   },
   {
     "Class":"Predicate",
-    "Name":"http:\/\/schema.org\/issuedBy",
+    "Name":"https://schema.org/issuedBy",
     "Domain Bucket":"10K - 100K"
   },
   {
     "Class":"Predicate",
-    "Name":"http:\/\/schema.org\/issuedBy-input",
+    "Name":"https://schema.org/issuedBy-input",
     "Domain Bucket":"< 1K"
   },
   {
     "Class":"Predicate",
-    "Name":"http:\/\/schema.org\/issuedBy-output",
+    "Name":"https://schema.org/issuedBy-output",
     "Domain Bucket":"< 1K"
   },
   {
     "Class":"Predicate",
-    "Name":"http:\/\/schema.org\/issuedThrough",
+    "Name":"https://schema.org/issuedThrough",
     "Domain Bucket":"< 1K"
   },
   {
     "Class":"Predicate",
-    "Name":"http:\/\/schema.org\/issuedThrough-input",
+    "Name":"https://schema.org/issuedThrough-input",
     "Domain Bucket":"< 1K"
   },
   {
     "Class":"Predicate",
-    "Name":"http:\/\/schema.org\/issuedThrough-output",
+    "Name":"https://schema.org/issuedThrough-output",
     "Domain Bucket":"< 1K"
   },
   {
     "Class":"Predicate",
-    "Name":"http:\/\/schema.org\/iswcCode",
+    "Name":"https://schema.org/iswcCode",
     "Domain Bucket":"< 1K"
   },
   {
     "Class":"Predicate",
-    "Name":"http:\/\/schema.org\/iswcCode-input",
+    "Name":"https://schema.org/iswcCode-input",
     "Domain Bucket":"< 1K"
   },
   {
     "Class":"Predicate",
-    "Name":"http:\/\/schema.org\/iswcCode-output",
+    "Name":"https://schema.org/iswcCode-output",
     "Domain Bucket":"< 1K"
   },
   {
     "Class":"Predicate",
-    "Name":"http:\/\/schema.org\/item",
+    "Name":"https://schema.org/item",
     "Domain Bucket":"10M+"
   },
   {
     "Class":"Predicate",
-    "Name":"http:\/\/schema.org\/item-input",
+    "Name":"https://schema.org/item-input",
     "Domain Bucket":"< 1K"
   },
   {
     "Class":"Predicate",
-    "Name":"http:\/\/schema.org\/item-output",
+    "Name":"https://schema.org/item-output",
     "Domain Bucket":"< 1K"
   },
   {
     "Class":"Predicate",
-    "Name":"http:\/\/schema.org\/itemCondition",
+    "Name":"https://schema.org/itemCondition",
     "Domain Bucket":"1M - 10M"
   },
   {
     "Class":"Predicate",
-    "Name":"http:\/\/schema.org\/itemCondition-input",
+    "Name":"https://schema.org/itemCondition-input",
     "Domain Bucket":"< 1K"
   },
   {
     "Class":"Predicate",
-    "Name":"http:\/\/schema.org\/itemCondition-output",
+    "Name":"https://schema.org/itemCondition-output",
     "Domain Bucket":"< 1K"
   },
   {
     "Class":"Predicate",
-    "Name":"http:\/\/schema.org\/itemDefectReturnFees",
+    "Name":"https://schema.org/itemDefectReturnFees",
     "Domain Bucket":"1K - 10K"
   },
   {
     "Class":"Predicate",
-    "Name":"http:\/\/schema.org\/itemDefectReturnFees-input",
+    "Name":"https://schema.org/itemDefectReturnFees-input",
     "Domain Bucket":"< 1K"
   },
   {
     "Class":"Predicate",
-    "Name":"http:\/\/schema.org\/itemDefectReturnFees-output",
+    "Name":"https://schema.org/itemDefectReturnFees-output",
     "Domain Bucket":"< 1K"
   },
   {
     "Class":"Predicate",
-    "Name":"http:\/\/schema.org\/itemDefectReturnLabelSource",
+    "Name":"https://schema.org/itemDefectReturnLabelSource",
     "Domain Bucket":"< 1K"
   },
   {
     "Class":"Predicate",
-    "Name":"http:\/\/schema.org\/itemDefectReturnLabelSource-input",
+    "Name":"https://schema.org/itemDefectReturnLabelSource-input",
     "Domain Bucket":"< 1K"
   },
   {
     "Class":"Predicate",
-    "Name":"http:\/\/schema.org\/itemDefectReturnLabelSource-output",
+    "Name":"https://schema.org/itemDefectReturnLabelSource-output",
     "Domain Bucket":"< 1K"
   },
   {
     "Class":"Predicate",
-    "Name":"http:\/\/schema.org\/itemDefectReturnShippingFeesAmount",
+    "Name":"https://schema.org/itemDefectReturnShippingFeesAmount",
     "Domain Bucket":"< 1K"
   },
   {
     "Class":"Predicate",
-    "Name":"http:\/\/schema.org\/itemDefectReturnShippingFeesAmount-input",
+    "Name":"https://schema.org/itemDefectReturnShippingFeesAmount-input",
     "Domain Bucket":"< 1K"
   },
   {
     "Class":"Predicate",
-    "Name":"http:\/\/schema.org\/itemDefectReturnShippingFeesAmount-output",
+    "Name":"https://schema.org/itemDefectReturnShippingFeesAmount-output",
     "Domain Bucket":"< 1K"
   },
   {
     "Class":"Predicate",
-    "Name":"http:\/\/schema.org\/itemListElement",
+    "Name":"https://schema.org/itemListElement",
     "Domain Bucket":"10M+"
   },
   {
     "Class":"Predicate",
-    "Name":"http:\/\/schema.org\/itemListElement-input",
+    "Name":"https://schema.org/itemListElement-input",
     "Domain Bucket":"< 1K"
   },
   {
     "Class":"Predicate",
-    "Name":"http:\/\/schema.org\/itemListElement-output",
+    "Name":"https://schema.org/itemListElement-output",
     "Domain Bucket":"< 1K"
   },
   {
     "Class":"Predicate",
-    "Name":"http:\/\/schema.org\/itemListOrder",
+    "Name":"https://schema.org/itemListOrder",
     "Domain Bucket":"100K - 1M"
   },
   {
     "Class":"Predicate",
-    "Name":"http:\/\/schema.org\/itemListOrder-input",
+    "Name":"https://schema.org/itemListOrder-input",
     "Domain Bucket":"< 1K"
   },
   {
     "Class":"Predicate",
-    "Name":"http:\/\/schema.org\/itemListOrder-output",
+    "Name":"https://schema.org/itemListOrder-output",
     "Domain Bucket":"< 1K"
   },
   {
     "Class":"Predicate",
-    "Name":"http:\/\/schema.org\/itemLocation",
+    "Name":"https://schema.org/itemLocation",
     "Domain Bucket":"< 1K"
   },
   {
     "Class":"Predicate",
-    "Name":"http:\/\/schema.org\/itemLocation-input",
+    "Name":"https://schema.org/itemLocation-input",
     "Domain Bucket":"< 1K"
   },
   {
     "Class":"Predicate",
-    "Name":"http:\/\/schema.org\/itemLocation-output",
+    "Name":"https://schema.org/itemLocation-output",
     "Domain Bucket":"< 1K"
   },
   {
     "Class":"Predicate",
-    "Name":"http:\/\/schema.org\/itemOffered",
+    "Name":"https://schema.org/itemOffered",
     "Domain Bucket":"100K - 1M"
   },
   {
     "Class":"Predicate",
-    "Name":"http:\/\/schema.org\/itemOffered-input",
+    "Name":"https://schema.org/itemOffered-input",
     "Domain Bucket":"< 1K"
   },
   {
     "Class":"Predicate",
-    "Name":"http:\/\/schema.org\/itemOffered-output",
+    "Name":"https://schema.org/itemOffered-output",
     "Domain Bucket":"< 1K"
   },
   {
     "Class":"Predicate",
-    "Name":"http:\/\/schema.org\/itemReviewed",
+    "Name":"https://schema.org/itemReviewed",
     "Domain Bucket":"100K - 1M"
   },
   {
     "Class":"Predicate",
-    "Name":"http:\/\/schema.org\/itemReviewed-input",
+    "Name":"https://schema.org/itemReviewed-input",
     "Domain Bucket":"< 1K"
   },
   {
     "Class":"Predicate",
-    "Name":"http:\/\/schema.org\/itemReviewed-output",
+    "Name":"https://schema.org/itemReviewed-output",
     "Domain Bucket":"< 1K"
   },
   {
     "Class":"Predicate",
-    "Name":"http:\/\/schema.org\/itemShipped",
+    "Name":"https://schema.org/itemShipped",
     "Domain Bucket":"< 1K"
   },
   {
     "Class":"Predicate",
-    "Name":"http:\/\/schema.org\/itemShipped-input",
+    "Name":"https://schema.org/itemShipped-input",
     "Domain Bucket":"< 1K"
   },
   {
     "Class":"Predicate",
-    "Name":"http:\/\/schema.org\/itemShipped-output",
+    "Name":"https://schema.org/itemShipped-output",
     "Domain Bucket":"< 1K"
   },
   {
     "Class":"Predicate",
-    "Name":"http:\/\/schema.org\/itinerary",
+    "Name":"https://schema.org/itinerary",
     "Domain Bucket":"10K - 100K"
   },
   {
     "Class":"Predicate",
-    "Name":"http:\/\/schema.org\/itinerary-input",
+    "Name":"https://schema.org/itinerary-input",
     "Domain Bucket":"< 1K"
   },
   {
     "Class":"Predicate",
-    "Name":"http:\/\/schema.org\/itinerary-output",
+    "Name":"https://schema.org/itinerary-output",
     "Domain Bucket":"< 1K"
   },
   {
     "Class":"Predicate",
-    "Name":"http:\/\/schema.org\/iupacName",
+    "Name":"https://schema.org/iupacName",
     "Domain Bucket":"< 1K"
   },
   {
     "Class":"Predicate",
-    "Name":"http:\/\/schema.org\/iupacName-input",
+    "Name":"https://schema.org/iupacName-input",
     "Domain Bucket":"< 1K"
   },
   {
     "Class":"Predicate",
-    "Name":"http:\/\/schema.org\/iupacName-output",
+    "Name":"https://schema.org/iupacName-output",
     "Domain Bucket":"< 1K"
   },
   {
     "Class":"Predicate",
-    "Name":"http:\/\/schema.org\/jobBenefits",
+    "Name":"https://schema.org/jobBenefits",
     "Domain Bucket":"10K - 100K"
   },
   {
     "Class":"Predicate",
-    "Name":"http:\/\/schema.org\/jobBenefits-input",
+    "Name":"https://schema.org/jobBenefits-input",
     "Domain Bucket":"< 1K"
   },
   {
     "Class":"Predicate",
-    "Name":"http:\/\/schema.org\/jobBenefits-output",
+    "Name":"https://schema.org/jobBenefits-output",
     "Domain Bucket":"< 1K"
   },
   {
     "Class":"Predicate",
-    "Name":"http:\/\/schema.org\/jobDuration",
+    "Name":"https://schema.org/jobDuration",
     "Domain Bucket":"< 1K"
   },
   {
     "Class":"Predicate",
-    "Name":"http:\/\/schema.org\/jobDuration-input",
+    "Name":"https://schema.org/jobDuration-input",
     "Domain Bucket":"< 1K"
   },
   {
     "Class":"Predicate",
-    "Name":"http:\/\/schema.org\/jobDuration-output",
+    "Name":"https://schema.org/jobDuration-output",
     "Domain Bucket":"< 1K"
   },
   {
     "Class":"Predicate",
-    "Name":"http:\/\/schema.org\/jobImmediateStart",
+    "Name":"https://schema.org/jobImmediateStart",
     "Domain Bucket":"1K - 10K"
   },
   {
     "Class":"Predicate",
-    "Name":"http:\/\/schema.org\/jobImmediateStart-input",
+    "Name":"https://schema.org/jobImmediateStart-input",
     "Domain Bucket":"< 1K"
   },
   {
     "Class":"Predicate",
-    "Name":"http:\/\/schema.org\/jobImmediateStart-output",
+    "Name":"https://schema.org/jobImmediateStart-output",
     "Domain Bucket":"< 1K"
   },
   {
     "Class":"Predicate",
-    "Name":"http:\/\/schema.org\/jobLocation",
+    "Name":"https://schema.org/jobLocation",
     "Domain Bucket":"100K - 1M"
   },
   {
     "Class":"Predicate",
-    "Name":"http:\/\/schema.org\/jobLocation-input",
+    "Name":"https://schema.org/jobLocation-input",
     "Domain Bucket":"< 1K"
   },
   {
     "Class":"Predicate",
-    "Name":"http:\/\/schema.org\/jobLocation-output",
+    "Name":"https://schema.org/jobLocation-output",
     "Domain Bucket":"< 1K"
   },
   {
     "Class":"Predicate",
-    "Name":"http:\/\/schema.org\/jobLocationType",
+    "Name":"https://schema.org/jobLocationType",
     "Domain Bucket":"10K - 100K"
   },
   {
     "Class":"Predicate",
-    "Name":"http:\/\/schema.org\/jobLocationType-input",
+    "Name":"https://schema.org/jobLocationType-input",
     "Domain Bucket":"< 1K"
   },
   {
     "Class":"Predicate",
-    "Name":"http:\/\/schema.org\/jobLocationType-output",
+    "Name":"https://schema.org/jobLocationType-output",
     "Domain Bucket":"< 1K"
   },
   {
     "Class":"Predicate",
-    "Name":"http:\/\/schema.org\/jobStartDate",
+    "Name":"https://schema.org/jobStartDate",
     "Domain Bucket":"1K - 10K"
   },
   {
     "Class":"Predicate",
-    "Name":"http:\/\/schema.org\/jobStartDate-input",
+    "Name":"https://schema.org/jobStartDate-input",
     "Domain Bucket":"< 1K"
   },
   {
     "Class":"Predicate",
-    "Name":"http:\/\/schema.org\/jobStartDate-output",
+    "Name":"https://schema.org/jobStartDate-output",
     "Domain Bucket":"< 1K"
   },
   {
     "Class":"Predicate",
-    "Name":"http:\/\/schema.org\/jobTitle",
+    "Name":"https://schema.org/jobTitle",
     "Domain Bucket":"1M - 10M"
   },
   {
     "Class":"Predicate",
-    "Name":"http:\/\/schema.org\/jobTitle-input",
+    "Name":"https://schema.org/jobTitle-input",
     "Domain Bucket":"< 1K"
   },
   {
     "Class":"Predicate",
-    "Name":"http:\/\/schema.org\/jobTitle-output",
+    "Name":"https://schema.org/jobTitle-output",
     "Domain Bucket":"< 1K"
   },
   {
     "Class":"Predicate",
-    "Name":"http:\/\/schema.org\/jurisdiction",
+    "Name":"https://schema.org/jurisdiction",
     "Domain Bucket":"1K - 10K"
   },
   {
     "Class":"Predicate",
-    "Name":"http:\/\/schema.org\/jurisdiction-input",
+    "Name":"https://schema.org/jurisdiction-input",
     "Domain Bucket":"< 1K"
   },
   {
     "Class":"Predicate",
-    "Name":"http:\/\/schema.org\/jurisdiction-output",
+    "Name":"https://schema.org/jurisdiction-output",
     "Domain Bucket":"< 1K"
   },
   {
     "Class":"Predicate",
-    "Name":"http:\/\/schema.org\/keywords",
+    "Name":"https://schema.org/keywords",
     "Domain Bucket":"1M - 10M"
   },
   {
     "Class":"Predicate",
-    "Name":"http:\/\/schema.org\/keywords-input",
+    "Name":"https://schema.org/keywords-input",
     "Domain Bucket":"< 1K"
   },
   {
     "Class":"Predicate",
-    "Name":"http:\/\/schema.org\/keywords-output",
+    "Name":"https://schema.org/keywords-output",
     "Domain Bucket":"< 1K"
   },
   {
     "Class":"Predicate",
-    "Name":"http:\/\/schema.org\/knownVehicleDamages",
+    "Name":"https://schema.org/knownVehicleDamages",
     "Domain Bucket":"< 1K"
   },
   {
     "Class":"Predicate",
-    "Name":"http:\/\/schema.org\/knownVehicleDamages-input",
+    "Name":"https://schema.org/knownVehicleDamages-input",
     "Domain Bucket":"< 1K"
   },
   {
     "Class":"Predicate",
-    "Name":"http:\/\/schema.org\/knownVehicleDamages-output",
+    "Name":"https://schema.org/knownVehicleDamages-output",
     "Domain Bucket":"< 1K"
   },
   {
     "Class":"Predicate",
-    "Name":"http:\/\/schema.org\/knows",
+    "Name":"https://schema.org/knows",
     "Domain Bucket":"1K - 10K"
   },
   {
     "Class":"Predicate",
-    "Name":"http:\/\/schema.org\/knows-input",
+    "Name":"https://schema.org/knows-input",
     "Domain Bucket":"< 1K"
   },
   {
     "Class":"Predicate",
-    "Name":"http:\/\/schema.org\/knows-output",
+    "Name":"https://schema.org/knows-output",
     "Domain Bucket":"< 1K"
   },
   {
     "Class":"Predicate",
-    "Name":"http:\/\/schema.org\/knowsAbout",
+    "Name":"https://schema.org/knowsAbout",
     "Domain Bucket":"100K - 1M"
   },
   {
     "Class":"Predicate",
-    "Name":"http:\/\/schema.org\/knowsAbout-input",
+    "Name":"https://schema.org/knowsAbout-input",
     "Domain Bucket":"< 1K"
   },
   {
     "Class":"Predicate",
-    "Name":"http:\/\/schema.org\/knowsAbout-output",
+    "Name":"https://schema.org/knowsAbout-output",
     "Domain Bucket":"< 1K"
   },
   {
     "Class":"Predicate",
-    "Name":"http:\/\/schema.org\/knowsLanguage",
+    "Name":"https://schema.org/knowsLanguage",
     "Domain Bucket":"100K - 1M"
   },
   {
     "Class":"Predicate",
-    "Name":"http:\/\/schema.org\/knowsLanguage-input",
+    "Name":"https://schema.org/knowsLanguage-input",
     "Domain Bucket":"< 1K"
   },
   {
     "Class":"Predicate",
-    "Name":"http:\/\/schema.org\/knowsLanguage-output",
+    "Name":"https://schema.org/knowsLanguage-output",
     "Domain Bucket":"< 1K"
   },
   {
     "Class":"Predicate",
-    "Name":"http:\/\/schema.org\/labelDetails",
+    "Name":"https://schema.org/labelDetails",
     "Domain Bucket":"< 1K"
   },
   {
     "Class":"Predicate",
-    "Name":"http:\/\/schema.org\/labelDetails-input",
+    "Name":"https://schema.org/labelDetails-input",
     "Domain Bucket":"< 1K"
   },
   {
     "Class":"Predicate",
-    "Name":"http:\/\/schema.org\/labelDetails-output",
+    "Name":"https://schema.org/labelDetails-output",
     "Domain Bucket":"< 1K"
   },
   {
     "Class":"Predicate",
-    "Name":"http:\/\/schema.org\/landlord",
+    "Name":"https://schema.org/landlord",
     "Domain Bucket":"< 1K"
   },
   {
     "Class":"Predicate",
-    "Name":"http:\/\/schema.org\/landlord-input",
+    "Name":"https://schema.org/landlord-input",
     "Domain Bucket":"< 1K"
   },
   {
     "Class":"Predicate",
-    "Name":"http:\/\/schema.org\/landlord-output",
+    "Name":"https://schema.org/landlord-output",
     "Domain Bucket":"< 1K"
   },
   {
     "Class":"Predicate",
-    "Name":"http:\/\/schema.org\/language",
+    "Name":"https://schema.org/language",
     "Domain Bucket":"10K - 100K"
   },
   {
     "Class":"Predicate",
-    "Name":"http:\/\/schema.org\/language-input",
+    "Name":"https://schema.org/language-input",
     "Domain Bucket":"< 1K"
   },
   {
     "Class":"Predicate",
-    "Name":"http:\/\/schema.org\/language-output",
+    "Name":"https://schema.org/language-output",
     "Domain Bucket":"< 1K"
   },
   {
     "Class":"Predicate",
-    "Name":"http:\/\/schema.org\/lastReviewed",
+    "Name":"https://schema.org/lastReviewed",
     "Domain Bucket":"10K - 100K"
   },
   {
     "Class":"Predicate",
-    "Name":"http:\/\/schema.org\/lastReviewed-input",
+    "Name":"https://schema.org/lastReviewed-input",
     "Domain Bucket":"< 1K"
   },
   {
     "Class":"Predicate",
-    "Name":"http:\/\/schema.org\/lastReviewed-output",
+    "Name":"https://schema.org/lastReviewed-output",
     "Domain Bucket":"< 1K"
   },
   {
     "Class":"Predicate",
-    "Name":"http:\/\/schema.org\/latitude",
+    "Name":"https://schema.org/latitude",
     "Domain Bucket":"1M - 10M"
   },
   {
     "Class":"Predicate",
-    "Name":"http:\/\/schema.org\/latitude-input",
+    "Name":"https://schema.org/latitude-input",
     "Domain Bucket":"< 1K"
   },
   {
     "Class":"Predicate",
-    "Name":"http:\/\/schema.org\/latitude-output",
+    "Name":"https://schema.org/latitude-output",
     "Domain Bucket":"< 1K"
   },
   {
     "Class":"Predicate",
-    "Name":"http:\/\/schema.org\/layoutImage",
+    "Name":"https://schema.org/layoutImage",
     "Domain Bucket":"1K - 10K"
   },
   {
     "Class":"Predicate",
-    "Name":"http:\/\/schema.org\/layoutImage-input",
+    "Name":"https://schema.org/layoutImage-input",
     "Domain Bucket":"< 1K"
   },
   {
     "Class":"Predicate",
-    "Name":"http:\/\/schema.org\/layoutImage-output",
+    "Name":"https://schema.org/layoutImage-output",
     "Domain Bucket":"< 1K"
   },
   {
     "Class":"Predicate",
-    "Name":"http:\/\/schema.org\/learningResourceType",
+    "Name":"https://schema.org/learningResourceType",
     "Domain Bucket":"10K - 100K"
   },
   {
     "Class":"Predicate",
-    "Name":"http:\/\/schema.org\/learningResourceType-input",
+    "Name":"https://schema.org/learningResourceType-input",
     "Domain Bucket":"< 1K"
   },
   {
     "Class":"Predicate",
-    "Name":"http:\/\/schema.org\/learningResourceType-output",
+    "Name":"https://schema.org/learningResourceType-output",
     "Domain Bucket":"< 1K"
   },
   {
     "Class":"Predicate",
-    "Name":"http:\/\/schema.org\/leaseLength",
+    "Name":"https://schema.org/leaseLength",
     "Domain Bucket":"1K - 10K"
   },
   {
     "Class":"Predicate",
-    "Name":"http:\/\/schema.org\/leaseLength-input",
+    "Name":"https://schema.org/leaseLength-input",
     "Domain Bucket":"< 1K"
   },
   {
     "Class":"Predicate",
-    "Name":"http:\/\/schema.org\/leaseLength-output",
+    "Name":"https://schema.org/leaseLength-output",
     "Domain Bucket":"< 1K"
   },
   {
     "Class":"Predicate",
-    "Name":"http:\/\/schema.org\/legalAddress",
+    "Name":"https://schema.org/legalAddress",
     "Domain Bucket":"1K - 10K"
   },
   {
     "Class":"Predicate",
-    "Name":"http:\/\/schema.org\/legalAddress-input",
+    "Name":"https://schema.org/legalAddress-input",
     "Domain Bucket":"< 1K"
   },
   {
     "Class":"Predicate",
-    "Name":"http:\/\/schema.org\/legalAddress-output",
+    "Name":"https://schema.org/legalAddress-output",
     "Domain Bucket":"< 1K"
   },
   {
     "Class":"Predicate",
-    "Name":"http:\/\/schema.org\/legalName",
+    "Name":"https://schema.org/legalName",
     "Domain Bucket":"1M - 10M"
   },
   {
     "Class":"Predicate",
-    "Name":"http:\/\/schema.org\/legalName-input",
+    "Name":"https://schema.org/legalName-input",
     "Domain Bucket":"< 1K"
   },
   {
     "Class":"Predicate",
-    "Name":"http:\/\/schema.org\/legalName-output",
+    "Name":"https://schema.org/legalName-output",
     "Domain Bucket":"< 1K"
   },
   {
     "Class":"Predicate",
-    "Name":"http:\/\/schema.org\/legalRepresentative",
+    "Name":"https://schema.org/legalRepresentative",
     "Domain Bucket":"1K - 10K"
   },
   {
     "Class":"Predicate",
-    "Name":"http:\/\/schema.org\/legalRepresentative-input",
+    "Name":"https://schema.org/legalRepresentative-input",
     "Domain Bucket":"< 1K"
   },
   {
     "Class":"Predicate",
-    "Name":"http:\/\/schema.org\/legalRepresentative-output",
+    "Name":"https://schema.org/legalRepresentative-output",
     "Domain Bucket":"< 1K"
   },
   {
     "Class":"Predicate",
-    "Name":"http:\/\/schema.org\/legalStatus",
+    "Name":"https://schema.org/legalStatus",
     "Domain Bucket":"1K - 10K"
   },
   {
     "Class":"Predicate",
-    "Name":"http:\/\/schema.org\/legalStatus-input",
+    "Name":"https://schema.org/legalStatus-input",
     "Domain Bucket":"< 1K"
   },
   {
     "Class":"Predicate",
-    "Name":"http:\/\/schema.org\/legalStatus-output",
+    "Name":"https://schema.org/legalStatus-output",
     "Domain Bucket":"< 1K"
   },
   {
     "Class":"Predicate",
-    "Name":"http:\/\/schema.org\/legislationAmends",
+    "Name":"https://schema.org/legislationAmends",
     "Domain Bucket":"< 1K"
   },
   {
     "Class":"Predicate",
-    "Name":"http:\/\/schema.org\/legislationAmends-input",
+    "Name":"https://schema.org/legislationAmends-input",
     "Domain Bucket":"< 1K"
   },
   {
     "Class":"Predicate",
-    "Name":"http:\/\/schema.org\/legislationAmends-output",
+    "Name":"https://schema.org/legislationAmends-output",
     "Domain Bucket":"< 1K"
   },
   {
     "Class":"Predicate",
-    "Name":"http:\/\/schema.org\/legislationApplies",
+    "Name":"https://schema.org/legislationApplies",
     "Domain Bucket":"< 1K"
   },
   {
     "Class":"Predicate",
-    "Name":"http:\/\/schema.org\/legislationApplies-input",
+    "Name":"https://schema.org/legislationApplies-input",
     "Domain Bucket":"< 1K"
   },
   {
     "Class":"Predicate",
-    "Name":"http:\/\/schema.org\/legislationApplies-output",
+    "Name":"https://schema.org/legislationApplies-output",
     "Domain Bucket":"< 1K"
   },
   {
     "Class":"Predicate",
-    "Name":"http:\/\/schema.org\/legislationChanges",
+    "Name":"https://schema.org/legislationChanges",
     "Domain Bucket":"< 1K"
   },
   {
     "Class":"Predicate",
-    "Name":"http:\/\/schema.org\/legislationChanges-input",
+    "Name":"https://schema.org/legislationChanges-input",
     "Domain Bucket":"< 1K"
   },
   {
     "Class":"Predicate",
-    "Name":"http:\/\/schema.org\/legislationChanges-output",
+    "Name":"https://schema.org/legislationChanges-output",
     "Domain Bucket":"< 1K"
   },
   {
     "Class":"Predicate",
-    "Name":"http:\/\/schema.org\/legislationCommences",
+    "Name":"https://schema.org/legislationCommences",
     "Domain Bucket":"< 1K"
   },
   {
     "Class":"Predicate",
-    "Name":"http:\/\/schema.org\/legislationCommences-input",
+    "Name":"https://schema.org/legislationCommences-input",
     "Domain Bucket":"< 1K"
   },
   {
     "Class":"Predicate",
-    "Name":"http:\/\/schema.org\/legislationCommences-output",
+    "Name":"https://schema.org/legislationCommences-output",
     "Domain Bucket":"< 1K"
   },
   {
     "Class":"Predicate",
-    "Name":"http:\/\/schema.org\/legislationConsolidates",
+    "Name":"https://schema.org/legislationConsolidates",
     "Domain Bucket":"< 1K"
   },
   {
     "Class":"Predicate",
-    "Name":"http:\/\/schema.org\/legislationConsolidates-input",
+    "Name":"https://schema.org/legislationConsolidates-input",
     "Domain Bucket":"< 1K"
   },
   {
     "Class":"Predicate",
-    "Name":"http:\/\/schema.org\/legislationConsolidates-output",
+    "Name":"https://schema.org/legislationConsolidates-output",
     "Domain Bucket":"< 1K"
   },
   {
     "Class":"Predicate",
-    "Name":"http:\/\/schema.org\/legislationCorrects",
+    "Name":"https://schema.org/legislationCorrects",
     "Domain Bucket":"< 1K"
   },
   {
     "Class":"Predicate",
-    "Name":"http:\/\/schema.org\/legislationCorrects-input",
+    "Name":"https://schema.org/legislationCorrects-input",
     "Domain Bucket":"< 1K"
   },
   {
     "Class":"Predicate",
-    "Name":"http:\/\/schema.org\/legislationCorrects-output",
+    "Name":"https://schema.org/legislationCorrects-output",
     "Domain Bucket":"< 1K"
   },
   {
     "Class":"Predicate",
-    "Name":"http:\/\/schema.org\/legislationCountersignedBy",
+    "Name":"https://schema.org/legislationCountersignedBy",
     "Domain Bucket":"< 1K"
   },
   {
     "Class":"Predicate",
-    "Name":"http:\/\/schema.org\/legislationCountersignedBy-input",
+    "Name":"https://schema.org/legislationCountersignedBy-input",
     "Domain Bucket":"< 1K"
   },
   {
     "Class":"Predicate",
-    "Name":"http:\/\/schema.org\/legislationCountersignedBy-output",
+    "Name":"https://schema.org/legislationCountersignedBy-output",
     "Domain Bucket":"< 1K"
   },
   {
     "Class":"Predicate",
-    "Name":"http:\/\/schema.org\/legislationDate",
+    "Name":"https://schema.org/legislationDate",
     "Domain Bucket":"< 1K"
   },
   {
     "Class":"Predicate",
-    "Name":"http:\/\/schema.org\/legislationDate-input",
+    "Name":"https://schema.org/legislationDate-input",
     "Domain Bucket":"< 1K"
   },
   {
     "Class":"Predicate",
-    "Name":"http:\/\/schema.org\/legislationDate-output",
+    "Name":"https://schema.org/legislationDate-output",
     "Domain Bucket":"< 1K"
   },
   {
     "Class":"Predicate",
-    "Name":"http:\/\/schema.org\/legislationDateOfApplicability",
+    "Name":"https://schema.org/legislationDateOfApplicability",
     "Domain Bucket":"< 1K"
   },
   {
     "Class":"Predicate",
-    "Name":"http:\/\/schema.org\/legislationDateOfApplicability-input",
+    "Name":"https://schema.org/legislationDateOfApplicability-input",
     "Domain Bucket":"< 1K"
   },
   {
     "Class":"Predicate",
-    "Name":"http:\/\/schema.org\/legislationDateOfApplicability-output",
+    "Name":"https://schema.org/legislationDateOfApplicability-output",
     "Domain Bucket":"< 1K"
   },
   {
     "Class":"Predicate",
-    "Name":"http:\/\/schema.org\/legislationDateVersion",
+    "Name":"https://schema.org/legislationDateVersion",
     "Domain Bucket":"< 1K"
   },
   {
     "Class":"Predicate",
-    "Name":"http:\/\/schema.org\/legislationDateVersion-input",
+    "Name":"https://schema.org/legislationDateVersion-input",
     "Domain Bucket":"< 1K"
   },
   {
     "Class":"Predicate",
-    "Name":"http:\/\/schema.org\/legislationDateVersion-output",
+    "Name":"https://schema.org/legislationDateVersion-output",
     "Domain Bucket":"< 1K"
   },
   {
     "Class":"Predicate",
-    "Name":"http:\/\/schema.org\/legislationEnsuresImplementationOf",
+    "Name":"https://schema.org/legislationEnsuresImplementationOf",
     "Domain Bucket":"< 1K"
   },
   {
     "Class":"Predicate",
-    "Name":"http:\/\/schema.org\/legislationEnsuresImplementationOf-input",
+    "Name":"https://schema.org/legislationEnsuresImplementationOf-input",
     "Domain Bucket":"< 1K"
   },
   {
     "Class":"Predicate",
-    "Name":"http:\/\/schema.org\/legislationEnsuresImplementationOf-output",
+    "Name":"https://schema.org/legislationEnsuresImplementationOf-output",
     "Domain Bucket":"< 1K"
   },
   {
     "Class":"Predicate",
-    "Name":"http:\/\/schema.org\/legislationIdentifier",
+    "Name":"https://schema.org/legislationIdentifier",
     "Domain Bucket":"1K - 10K"
   },
   {
     "Class":"Predicate",
-    "Name":"http:\/\/schema.org\/legislationIdentifier-input",
+    "Name":"https://schema.org/legislationIdentifier-input",
     "Domain Bucket":"< 1K"
   },
   {
     "Class":"Predicate",
-    "Name":"http:\/\/schema.org\/legislationIdentifier-output",
+    "Name":"https://schema.org/legislationIdentifier-output",
     "Domain Bucket":"< 1K"
   },
   {
     "Class":"Predicate",
-    "Name":"http:\/\/schema.org\/legislationJurisdiction",
+    "Name":"https://schema.org/legislationJurisdiction",
     "Domain Bucket":"1K - 10K"
   },
   {
     "Class":"Predicate",
-    "Name":"http:\/\/schema.org\/legislationJurisdiction-input",
+    "Name":"https://schema.org/legislationJurisdiction-input",
     "Domain Bucket":"< 1K"
   },
   {
     "Class":"Predicate",
-    "Name":"http:\/\/schema.org\/legislationJurisdiction-output",
+    "Name":"https://schema.org/legislationJurisdiction-output",
     "Domain Bucket":"< 1K"
   },
   {
     "Class":"Predicate",
-    "Name":"http:\/\/schema.org\/legislationLegalForce",
+    "Name":"https://schema.org/legislationLegalForce",
     "Domain Bucket":"< 1K"
   },
   {
     "Class":"Predicate",
-    "Name":"http:\/\/schema.org\/legislationLegalForce-input",
+    "Name":"https://schema.org/legislationLegalForce-input",
     "Domain Bucket":"< 1K"
   },
   {
     "Class":"Predicate",
-    "Name":"http:\/\/schema.org\/legislationLegalForce-output",
+    "Name":"https://schema.org/legislationLegalForce-output",
     "Domain Bucket":"< 1K"
   },
   {
     "Class":"Predicate",
-    "Name":"http:\/\/schema.org\/legislationLegalValue",
+    "Name":"https://schema.org/legislationLegalValue",
     "Domain Bucket":"< 1K"
   },
   {
     "Class":"Predicate",
-    "Name":"http:\/\/schema.org\/legislationLegalValue-input",
+    "Name":"https://schema.org/legislationLegalValue-input",
     "Domain Bucket":"< 1K"
   },
   {
     "Class":"Predicate",
-    "Name":"http:\/\/schema.org\/legislationLegalValue-output",
+    "Name":"https://schema.org/legislationLegalValue-output",
     "Domain Bucket":"< 1K"
   },
   {
     "Class":"Predicate",
-    "Name":"http:\/\/schema.org\/legislationPassedBy",
+    "Name":"https://schema.org/legislationPassedBy",
     "Domain Bucket":"< 1K"
   },
   {
     "Class":"Predicate",
-    "Name":"http:\/\/schema.org\/legislationPassedBy-input",
+    "Name":"https://schema.org/legislationPassedBy-input",
     "Domain Bucket":"< 1K"
   },
   {
     "Class":"Predicate",
-    "Name":"http:\/\/schema.org\/legislationPassedBy-output",
+    "Name":"https://schema.org/legislationPassedBy-output",
     "Domain Bucket":"< 1K"
   },
   {
     "Class":"Predicate",
-    "Name":"http:\/\/schema.org\/legislationRepeals",
+    "Name":"https://schema.org/legislationRepeals",
     "Domain Bucket":"< 1K"
   },
   {
     "Class":"Predicate",
-    "Name":"http:\/\/schema.org\/legislationRepeals-input",
+    "Name":"https://schema.org/legislationRepeals-input",
     "Domain Bucket":"< 1K"
   },
   {
     "Class":"Predicate",
-    "Name":"http:\/\/schema.org\/legislationRepeals-output",
+    "Name":"https://schema.org/legislationRepeals-output",
     "Domain Bucket":"< 1K"
   },
   {
     "Class":"Predicate",
-    "Name":"http:\/\/schema.org\/legislationResponsible",
+    "Name":"https://schema.org/legislationResponsible",
     "Domain Bucket":"< 1K"
   },
   {
     "Class":"Predicate",
-    "Name":"http:\/\/schema.org\/legislationResponsible-input",
+    "Name":"https://schema.org/legislationResponsible-input",
     "Domain Bucket":"< 1K"
   },
   {
     "Class":"Predicate",
-    "Name":"http:\/\/schema.org\/legislationResponsible-output",
+    "Name":"https://schema.org/legislationResponsible-output",
     "Domain Bucket":"< 1K"
   },
   {
     "Class":"Predicate",
-    "Name":"http:\/\/schema.org\/legislationTransposes",
+    "Name":"https://schema.org/legislationTransposes",
     "Domain Bucket":"< 1K"
   },
   {
     "Class":"Predicate",
-    "Name":"http:\/\/schema.org\/legislationTransposes-input",
+    "Name":"https://schema.org/legislationTransposes-input",
     "Domain Bucket":"< 1K"
   },
   {
     "Class":"Predicate",
-    "Name":"http:\/\/schema.org\/legislationTransposes-output",
+    "Name":"https://schema.org/legislationTransposes-output",
     "Domain Bucket":"< 1K"
   },
   {
     "Class":"Predicate",
-    "Name":"http:\/\/schema.org\/legislationType",
+    "Name":"https://schema.org/legislationType",
     "Domain Bucket":"1K - 10K"
   },
   {
     "Class":"Predicate",
-    "Name":"http:\/\/schema.org\/legislationType-input",
+    "Name":"https://schema.org/legislationType-input",
     "Domain Bucket":"< 1K"
   },
   {
     "Class":"Predicate",
-    "Name":"http:\/\/schema.org\/legislationType-output",
+    "Name":"https://schema.org/legislationType-output",
     "Domain Bucket":"< 1K"
   },
   {
     "Class":"Predicate",
-    "Name":"http:\/\/schema.org\/leiCode",
+    "Name":"https://schema.org/leiCode",
     "Domain Bucket":"1K - 10K"
   },
   {
     "Class":"Predicate",
-    "Name":"http:\/\/schema.org\/leiCode-input",
+    "Name":"https://schema.org/leiCode-input",
     "Domain Bucket":"< 1K"
   },
   {
     "Class":"Predicate",
-    "Name":"http:\/\/schema.org\/leiCode-output",
+    "Name":"https://schema.org/leiCode-output",
     "Domain Bucket":"< 1K"
   },
   {
     "Class":"Predicate",
-    "Name":"http:\/\/schema.org\/lender",
+    "Name":"https://schema.org/lender",
     "Domain Bucket":"< 1K"
   },
   {
     "Class":"Predicate",
-    "Name":"http:\/\/schema.org\/lender-input",
+    "Name":"https://schema.org/lender-input",
     "Domain Bucket":"< 1K"
   },
   {
     "Class":"Predicate",
-    "Name":"http:\/\/schema.org\/lender-output",
+    "Name":"https://schema.org/lender-output",
     "Domain Bucket":"< 1K"
   },
   {
     "Class":"Predicate",
-    "Name":"http:\/\/schema.org\/lesser",
+    "Name":"https://schema.org/lesser",
     "Domain Bucket":"< 1K"
   },
   {
     "Class":"Predicate",
-    "Name":"http:\/\/schema.org\/lesser-input",
+    "Name":"https://schema.org/lesser-input",
     "Domain Bucket":"< 1K"
   },
   {
     "Class":"Predicate",
-    "Name":"http:\/\/schema.org\/lesser-output",
+    "Name":"https://schema.org/lesser-output",
     "Domain Bucket":"< 1K"
   },
   {
     "Class":"Predicate",
-    "Name":"http:\/\/schema.org\/lesserOrEqual",
+    "Name":"https://schema.org/lesserOrEqual",
     "Domain Bucket":"< 1K"
   },
   {
     "Class":"Predicate",
-    "Name":"http:\/\/schema.org\/lesserOrEqual-input",
+    "Name":"https://schema.org/lesserOrEqual-input",
     "Domain Bucket":"< 1K"
   },
   {
     "Class":"Predicate",
-    "Name":"http:\/\/schema.org\/lesserOrEqual-output",
+    "Name":"https://schema.org/lesserOrEqual-output",
     "Domain Bucket":"< 1K"
   },
   {
     "Class":"Predicate",
-    "Name":"http:\/\/schema.org\/letterer",
+    "Name":"https://schema.org/letterer",
     "Domain Bucket":"< 1K"
   },
   {
     "Class":"Predicate",
-    "Name":"http:\/\/schema.org\/letterer-input",
+    "Name":"https://schema.org/letterer-input",
     "Domain Bucket":"< 1K"
   },
   {
     "Class":"Predicate",
-    "Name":"http:\/\/schema.org\/letterer-output",
+    "Name":"https://schema.org/letterer-output",
     "Domain Bucket":"< 1K"
   },
   {
     "Class":"Predicate",
-    "Name":"http:\/\/schema.org\/license",
+    "Name":"https://schema.org/license",
     "Domain Bucket":"100K - 1M"
   },
   {
     "Class":"Predicate",
-    "Name":"http:\/\/schema.org\/license-input",
+    "Name":"https://schema.org/license-input",
     "Domain Bucket":"< 1K"
   },
   {
     "Class":"Predicate",
-    "Name":"http:\/\/schema.org\/license-output",
+    "Name":"https://schema.org/license-output",
     "Domain Bucket":"< 1K"
   },
   {
     "Class":"Predicate",
-    "Name":"http:\/\/schema.org\/lifeEvent",
+    "Name":"https://schema.org/lifeEvent",
     "Domain Bucket":"< 1K"
   },
   {
     "Class":"Predicate",
-    "Name":"http:\/\/schema.org\/lifeEvent-input",
+    "Name":"https://schema.org/lifeEvent-input",
     "Domain Bucket":"< 1K"
   },
   {
     "Class":"Predicate",
-    "Name":"http:\/\/schema.org\/lifeEvent-output",
+    "Name":"https://schema.org/lifeEvent-output",
     "Domain Bucket":"< 1K"
   },
   {
     "Class":"Predicate",
-    "Name":"http:\/\/schema.org\/line",
+    "Name":"https://schema.org/line",
     "Domain Bucket":"< 1K"
   },
   {
     "Class":"Predicate",
-    "Name":"http:\/\/schema.org\/line-input",
+    "Name":"https://schema.org/line-input",
     "Domain Bucket":"< 1K"
   },
   {
     "Class":"Predicate",
-    "Name":"http:\/\/schema.org\/line-output",
+    "Name":"https://schema.org/line-output",
     "Domain Bucket":"< 1K"
   },
   {
     "Class":"Predicate",
-    "Name":"http:\/\/schema.org\/linkRelationship",
+    "Name":"https://schema.org/linkRelationship",
     "Domain Bucket":"< 1K"
   },
   {
     "Class":"Predicate",
-    "Name":"http:\/\/schema.org\/linkRelationship-input",
+    "Name":"https://schema.org/linkRelationship-input",
     "Domain Bucket":"< 1K"
   },
   {
     "Class":"Predicate",
-    "Name":"http:\/\/schema.org\/linkRelationship-output",
+    "Name":"https://schema.org/linkRelationship-output",
     "Domain Bucket":"< 1K"
   },
   {
     "Class":"Predicate",
-    "Name":"http:\/\/schema.org\/liveBlogUpdate",
+    "Name":"https://schema.org/liveBlogUpdate",
     "Domain Bucket":"1K - 10K"
   },
   {
     "Class":"Predicate",
-    "Name":"http:\/\/schema.org\/liveBlogUpdate-input",
+    "Name":"https://schema.org/liveBlogUpdate-input",
     "Domain Bucket":"< 1K"
   },
   {
     "Class":"Predicate",
-    "Name":"http:\/\/schema.org\/liveBlogUpdate-output",
+    "Name":"https://schema.org/liveBlogUpdate-output",
     "Domain Bucket":"< 1K"
   },
   {
     "Class":"Predicate",
-    "Name":"http:\/\/schema.org\/loanMortgageMandateAmount",
+    "Name":"https://schema.org/loanMortgageMandateAmount",
     "Domain Bucket":"< 1K"
   },
   {
     "Class":"Predicate",
-    "Name":"http:\/\/schema.org\/loanMortgageMandateAmount-input",
+    "Name":"https://schema.org/loanMortgageMandateAmount-input",
     "Domain Bucket":"< 1K"
   },
   {
     "Class":"Predicate",
-    "Name":"http:\/\/schema.org\/loanMortgageMandateAmount-output",
+    "Name":"https://schema.org/loanMortgageMandateAmount-output",
     "Domain Bucket":"< 1K"
   },
   {
     "Class":"Predicate",
-    "Name":"http:\/\/schema.org\/loanPaymentAmount",
+    "Name":"https://schema.org/loanPaymentAmount",
     "Domain Bucket":"< 1K"
   },
   {
     "Class":"Predicate",
-    "Name":"http:\/\/schema.org\/loanPaymentAmount-input",
+    "Name":"https://schema.org/loanPaymentAmount-input",
     "Domain Bucket":"< 1K"
   },
   {
     "Class":"Predicate",
-    "Name":"http:\/\/schema.org\/loanPaymentAmount-output",
+    "Name":"https://schema.org/loanPaymentAmount-output",
     "Domain Bucket":"< 1K"
   },
   {
     "Class":"Predicate",
-    "Name":"http:\/\/schema.org\/loanPaymentFrequency",
+    "Name":"https://schema.org/loanPaymentFrequency",
     "Domain Bucket":"< 1K"
   },
   {
     "Class":"Predicate",
-    "Name":"http:\/\/schema.org\/loanPaymentFrequency-input",
+    "Name":"https://schema.org/loanPaymentFrequency-input",
     "Domain Bucket":"< 1K"
   },
   {
     "Class":"Predicate",
-    "Name":"http:\/\/schema.org\/loanPaymentFrequency-output",
+    "Name":"https://schema.org/loanPaymentFrequency-output",
     "Domain Bucket":"< 1K"
   },
   {
     "Class":"Predicate",
-    "Name":"http:\/\/schema.org\/loanRepaymentForm",
+    "Name":"https://schema.org/loanRepaymentForm",
     "Domain Bucket":"< 1K"
   },
   {
     "Class":"Predicate",
-    "Name":"http:\/\/schema.org\/loanRepaymentForm-input",
+    "Name":"https://schema.org/loanRepaymentForm-input",
     "Domain Bucket":"< 1K"
   },
   {
     "Class":"Predicate",
-    "Name":"http:\/\/schema.org\/loanRepaymentForm-output",
+    "Name":"https://schema.org/loanRepaymentForm-output",
     "Domain Bucket":"< 1K"
   },
   {
     "Class":"Predicate",
-    "Name":"http:\/\/schema.org\/loanTerm",
+    "Name":"https://schema.org/loanTerm",
     "Domain Bucket":"1K - 10K"
   },
   {
     "Class":"Predicate",
-    "Name":"http:\/\/schema.org\/loanTerm-input",
+    "Name":"https://schema.org/loanTerm-input",
     "Domain Bucket":"< 1K"
   },
   {
     "Class":"Predicate",
-    "Name":"http:\/\/schema.org\/loanTerm-output",
+    "Name":"https://schema.org/loanTerm-output",
     "Domain Bucket":"< 1K"
   },
   {
     "Class":"Predicate",
-    "Name":"http:\/\/schema.org\/loanType",
+    "Name":"https://schema.org/loanType",
     "Domain Bucket":"1K - 10K"
   },
   {
     "Class":"Predicate",
-    "Name":"http:\/\/schema.org\/loanType-input",
+    "Name":"https://schema.org/loanType-input",
     "Domain Bucket":"< 1K"
   },
   {
     "Class":"Predicate",
-    "Name":"http:\/\/schema.org\/loanType-output",
+    "Name":"https://schema.org/loanType-output",
     "Domain Bucket":"< 1K"
   },
   {
     "Class":"Predicate",
-    "Name":"http:\/\/schema.org\/location",
+    "Name":"https://schema.org/location",
     "Domain Bucket":"1M - 10M"
   },
   {
     "Class":"Predicate",
-    "Name":"http:\/\/schema.org\/location-input",
+    "Name":"https://schema.org/location-input",
     "Domain Bucket":"< 1K"
   },
   {
     "Class":"Predicate",
-    "Name":"http:\/\/schema.org\/location-output",
+    "Name":"https://schema.org/location-output",
     "Domain Bucket":"< 1K"
   },
   {
     "Class":"Predicate",
-    "Name":"http:\/\/schema.org\/locationCreated",
+    "Name":"https://schema.org/locationCreated",
     "Domain Bucket":"10K - 100K"
   },
   {
     "Class":"Predicate",
-    "Name":"http:\/\/schema.org\/locationCreated-input",
+    "Name":"https://schema.org/locationCreated-input",
     "Domain Bucket":"< 1K"
   },
   {
     "Class":"Predicate",
-    "Name":"http:\/\/schema.org\/locationCreated-output",
+    "Name":"https://schema.org/locationCreated-output",
     "Domain Bucket":"< 1K"
   },
   {
     "Class":"Predicate",
-    "Name":"http:\/\/schema.org\/lodgingUnitDescription",
+    "Name":"https://schema.org/lodgingUnitDescription",
     "Domain Bucket":"< 1K"
   },
   {
     "Class":"Predicate",
-    "Name":"http:\/\/schema.org\/lodgingUnitDescription-input",
+    "Name":"https://schema.org/lodgingUnitDescription-input",
     "Domain Bucket":"< 1K"
   },
   {
     "Class":"Predicate",
-    "Name":"http:\/\/schema.org\/lodgingUnitDescription-output",
+    "Name":"https://schema.org/lodgingUnitDescription-output",
     "Domain Bucket":"< 1K"
   },
   {
     "Class":"Predicate",
-    "Name":"http:\/\/schema.org\/lodgingUnitType",
+    "Name":"https://schema.org/lodgingUnitType",
     "Domain Bucket":"< 1K"
   },
   {
     "Class":"Predicate",
-    "Name":"http:\/\/schema.org\/lodgingUnitType-input",
+    "Name":"https://schema.org/lodgingUnitType-input",
     "Domain Bucket":"< 1K"
   },
   {
     "Class":"Predicate",
-    "Name":"http:\/\/schema.org\/lodgingUnitType-output",
+    "Name":"https://schema.org/lodgingUnitType-output",
     "Domain Bucket":"< 1K"
   },
   {
     "Class":"Predicate",
-    "Name":"http:\/\/schema.org\/logo",
+    "Name":"https://schema.org/logo",
     "Domain Bucket":"10M+"
   },
   {
     "Class":"Predicate",
-    "Name":"http:\/\/schema.org\/logo-input",
+    "Name":"https://schema.org/logo-input",
     "Domain Bucket":"< 1K"
   },
   {
     "Class":"Predicate",
-    "Name":"http:\/\/schema.org\/logo-output",
+    "Name":"https://schema.org/logo-output",
     "Domain Bucket":"< 1K"
   },
   {
     "Class":"Predicate",
-    "Name":"http:\/\/schema.org\/longitude",
+    "Name":"https://schema.org/longitude",
     "Domain Bucket":"1M - 10M"
   },
   {
     "Class":"Predicate",
-    "Name":"http:\/\/schema.org\/longitude-input",
+    "Name":"https://schema.org/longitude-input",
     "Domain Bucket":"< 1K"
   },
   {
     "Class":"Predicate",
-    "Name":"http:\/\/schema.org\/longitude-output",
+    "Name":"https://schema.org/longitude-output",
     "Domain Bucket":"< 1K"
   },
   {
     "Class":"Predicate",
-    "Name":"http:\/\/schema.org\/loser",
+    "Name":"https://schema.org/loser",
     "Domain Bucket":"< 1K"
   },
   {
     "Class":"Predicate",
-    "Name":"http:\/\/schema.org\/loser-input",
+    "Name":"https://schema.org/loser-input",
     "Domain Bucket":"< 1K"
   },
   {
     "Class":"Predicate",
-    "Name":"http:\/\/schema.org\/loser-output",
+    "Name":"https://schema.org/loser-output",
     "Domain Bucket":"< 1K"
   },
   {
     "Class":"Predicate",
-    "Name":"http:\/\/schema.org\/lowPrice",
+    "Name":"https://schema.org/lowPrice",
     "Domain Bucket":"1M - 10M"
   },
   {
     "Class":"Predicate",
-    "Name":"http:\/\/schema.org\/lowPrice-input",
+    "Name":"https://schema.org/lowPrice-input",
     "Domain Bucket":"< 1K"
   },
   {
     "Class":"Predicate",
-    "Name":"http:\/\/schema.org\/lowPrice-output",
+    "Name":"https://schema.org/lowPrice-output",
     "Domain Bucket":"< 1K"
   },
   {
     "Class":"Predicate",
-    "Name":"http:\/\/schema.org\/lyricist",
+    "Name":"https://schema.org/lyricist",
     "Domain Bucket":"< 1K"
   },
   {
     "Class":"Predicate",
-    "Name":"http:\/\/schema.org\/lyricist-input",
+    "Name":"https://schema.org/lyricist-input",
     "Domain Bucket":"< 1K"
   },
   {
     "Class":"Predicate",
-    "Name":"http:\/\/schema.org\/lyricist-output",
+    "Name":"https://schema.org/lyricist-output",
     "Domain Bucket":"< 1K"
   },
   {
     "Class":"Predicate",
-    "Name":"http:\/\/schema.org\/lyrics",
+    "Name":"https://schema.org/lyrics",
     "Domain Bucket":"1K - 10K"
   },
   {
     "Class":"Predicate",
-    "Name":"http:\/\/schema.org\/lyrics-input",
+    "Name":"https://schema.org/lyrics-input",
     "Domain Bucket":"< 1K"
   },
   {
     "Class":"Predicate",
-    "Name":"http:\/\/schema.org\/lyrics-output",
+    "Name":"https://schema.org/lyrics-output",
     "Domain Bucket":"< 1K"
   },
   {
     "Class":"Predicate",
-    "Name":"http:\/\/schema.org\/mainContentOfPage",
+    "Name":"https://schema.org/mainContentOfPage",
     "Domain Bucket":"1M - 10M"
   },
   {
     "Class":"Predicate",
-    "Name":"http:\/\/schema.org\/mainContentOfPage-input",
+    "Name":"https://schema.org/mainContentOfPage-input",
     "Domain Bucket":"< 1K"
   },
   {
     "Class":"Predicate",
-    "Name":"http:\/\/schema.org\/mainContentOfPage-output",
+    "Name":"https://schema.org/mainContentOfPage-output",
     "Domain Bucket":"< 1K"
   },
   {
     "Class":"Predicate",
-    "Name":"http:\/\/schema.org\/mainEntity",
+    "Name":"https://schema.org/mainEntity",
     "Domain Bucket":"1M - 10M"
   },
   {
     "Class":"Predicate",
-    "Name":"http:\/\/schema.org\/mainEntity-input",
+    "Name":"https://schema.org/mainEntity-input",
     "Domain Bucket":"< 1K"
   },
   {
     "Class":"Predicate",
-    "Name":"http:\/\/schema.org\/mainEntity-output",
+    "Name":"https://schema.org/mainEntity-output",
     "Domain Bucket":"< 1K"
   },
   {
     "Class":"Predicate",
-    "Name":"http:\/\/schema.org\/mainEntityOfPage",
+    "Name":"https://schema.org/mainEntityOfPage",
     "Domain Bucket":"10M+"
   },
   {
     "Class":"Predicate",
-    "Name":"http:\/\/schema.org\/mainEntityOfPage-input",
+    "Name":"https://schema.org/mainEntityOfPage-input",
     "Domain Bucket":"< 1K"
   },
   {
     "Class":"Predicate",
-    "Name":"http:\/\/schema.org\/mainEntityOfPage-output",
+    "Name":"https://schema.org/mainEntityOfPage-output",
     "Domain Bucket":"< 1K"
   },
   {
     "Class":"Predicate",
-    "Name":"http:\/\/schema.org\/maintainer",
+    "Name":"https://schema.org/maintainer",
     "Domain Bucket":"1K - 10K"
   },
   {
     "Class":"Predicate",
-    "Name":"http:\/\/schema.org\/maintainer-input",
+    "Name":"https://schema.org/maintainer-input",
     "Domain Bucket":"< 1K"
   },
   {
     "Class":"Predicate",
-    "Name":"http:\/\/schema.org\/maintainer-output",
+    "Name":"https://schema.org/maintainer-output",
     "Domain Bucket":"< 1K"
   },
   {
     "Class":"Predicate",
-    "Name":"http:\/\/schema.org\/makesOffer",
+    "Name":"https://schema.org/makesOffer",
     "Domain Bucket":"100K - 1M"
   },
   {
     "Class":"Predicate",
-    "Name":"http:\/\/schema.org\/makesOffer-input",
+    "Name":"https://schema.org/makesOffer-input",
     "Domain Bucket":"< 1K"
   },
   {
     "Class":"Predicate",
-    "Name":"http:\/\/schema.org\/makesOffer-output",
+    "Name":"https://schema.org/makesOffer-output",
     "Domain Bucket":"< 1K"
   },
   {
     "Class":"Predicate",
-    "Name":"http:\/\/schema.org\/manufacturer",
+    "Name":"https://schema.org/manufacturer",
     "Domain Bucket":"100K - 1M"
   },
   {
     "Class":"Predicate",
-    "Name":"http:\/\/schema.org\/manufacturer-input",
+    "Name":"https://schema.org/manufacturer-input",
     "Domain Bucket":"< 1K"
   },
   {
     "Class":"Predicate",
-    "Name":"http:\/\/schema.org\/manufacturer-output",
+    "Name":"https://schema.org/manufacturer-output",
     "Domain Bucket":"< 1K"
   },
   {
     "Class":"Predicate",
-    "Name":"http:\/\/schema.org\/map",
+    "Name":"https://schema.org/map",
     "Domain Bucket":"1K - 10K"
   },
   {
     "Class":"Predicate",
-    "Name":"http:\/\/schema.org\/map-input",
+    "Name":"https://schema.org/map-input",
     "Domain Bucket":"< 1K"
   },
   {
     "Class":"Predicate",
-    "Name":"http:\/\/schema.org\/map-output",
+    "Name":"https://schema.org/map-output",
     "Domain Bucket":"< 1K"
   },
   {
     "Class":"Predicate",
-    "Name":"http:\/\/schema.org\/mapType",
+    "Name":"https://schema.org/mapType",
     "Domain Bucket":"1K - 10K"
   },
   {
     "Class":"Predicate",
-    "Name":"http:\/\/schema.org\/mapType-input",
+    "Name":"https://schema.org/mapType-input",
     "Domain Bucket":"< 1K"
   },
   {
     "Class":"Predicate",
-    "Name":"http:\/\/schema.org\/mapType-output",
+    "Name":"https://schema.org/mapType-output",
     "Domain Bucket":"< 1K"
   },
   {
     "Class":"Predicate",
-    "Name":"http:\/\/schema.org\/maps",
+    "Name":"https://schema.org/maps",
     "Domain Bucket":"1K - 10K"
   },
   {
     "Class":"Predicate",
-    "Name":"http:\/\/schema.org\/maps-input",
+    "Name":"https://schema.org/maps-input",
     "Domain Bucket":"< 1K"
   },
   {
     "Class":"Predicate",
-    "Name":"http:\/\/schema.org\/maps-output",
+    "Name":"https://schema.org/maps-output",
     "Domain Bucket":"< 1K"
   },
   {
     "Class":"Predicate",
-    "Name":"http:\/\/schema.org\/marginOfError",
+    "Name":"https://schema.org/marginOfError",
     "Domain Bucket":"< 1K"
   },
   {
     "Class":"Predicate",
-    "Name":"http:\/\/schema.org\/marginOfError-input",
+    "Name":"https://schema.org/marginOfError-input",
     "Domain Bucket":"< 1K"
   },
   {
     "Class":"Predicate",
-    "Name":"http:\/\/schema.org\/marginOfError-output",
+    "Name":"https://schema.org/marginOfError-output",
     "Domain Bucket":"< 1K"
   },
   {
     "Class":"Predicate",
-    "Name":"http:\/\/schema.org\/masthead",
+    "Name":"https://schema.org/masthead",
     "Domain Bucket":"1K - 10K"
   },
   {
     "Class":"Predicate",
-    "Name":"http:\/\/schema.org\/masthead-input",
+    "Name":"https://schema.org/masthead-input",
     "Domain Bucket":"< 1K"
   },
   {
     "Class":"Predicate",
-    "Name":"http:\/\/schema.org\/masthead-output",
+    "Name":"https://schema.org/masthead-output",
     "Domain Bucket":"< 1K"
   },
   {
     "Class":"Predicate",
-    "Name":"http:\/\/schema.org\/material",
+    "Name":"https://schema.org/material",
     "Domain Bucket":"10K - 100K"
   },
   {
     "Class":"Predicate",
-    "Name":"http:\/\/schema.org\/material-input",
+    "Name":"https://schema.org/material-input",
     "Domain Bucket":"< 1K"
   },
   {
     "Class":"Predicate",
-    "Name":"http:\/\/schema.org\/material-output",
+    "Name":"https://schema.org/material-output",
     "Domain Bucket":"< 1K"
   },
   {
     "Class":"Predicate",
-    "Name":"http:\/\/schema.org\/materialExtent",
+    "Name":"https://schema.org/materialExtent",
     "Domain Bucket":"< 1K"
   },
   {
     "Class":"Predicate",
-    "Name":"http:\/\/schema.org\/materialExtent-input",
+    "Name":"https://schema.org/materialExtent-input",
     "Domain Bucket":"< 1K"
   },
   {
     "Class":"Predicate",
-    "Name":"http:\/\/schema.org\/materialExtent-output",
+    "Name":"https://schema.org/materialExtent-output",
     "Domain Bucket":"< 1K"
   },
   {
     "Class":"Predicate",
-    "Name":"http:\/\/schema.org\/mathExpression",
+    "Name":"https://schema.org/mathExpression",
     "Domain Bucket":"< 1K"
   },
   {
     "Class":"Predicate",
-    "Name":"http:\/\/schema.org\/mathExpression-input",
+    "Name":"https://schema.org/mathExpression-input",
     "Domain Bucket":"< 1K"
   },
   {
     "Class":"Predicate",
-    "Name":"http:\/\/schema.org\/mathExpression-output",
+    "Name":"https://schema.org/mathExpression-output",
     "Domain Bucket":"< 1K"
   },
   {
     "Class":"Predicate",
-    "Name":"http:\/\/schema.org\/maxPrice",
+    "Name":"https://schema.org/maxPrice",
     "Domain Bucket":"10K - 100K"
   },
   {
     "Class":"Predicate",
-    "Name":"http:\/\/schema.org\/maxPrice-input",
+    "Name":"https://schema.org/maxPrice-input",
     "Domain Bucket":"< 1K"
   },
   {
     "Class":"Predicate",
-    "Name":"http:\/\/schema.org\/maxPrice-output",
+    "Name":"https://schema.org/maxPrice-output",
     "Domain Bucket":"< 1K"
   },
   {
     "Class":"Predicate",
-    "Name":"http:\/\/schema.org\/maxValue",
+    "Name":"https://schema.org/maxValue",
     "Domain Bucket":"100K - 1M"
   },
   {
     "Class":"Predicate",
-    "Name":"http:\/\/schema.org\/maxValue-input",
+    "Name":"https://schema.org/maxValue-input",
     "Domain Bucket":"< 1K"
   },
   {
     "Class":"Predicate",
-    "Name":"http:\/\/schema.org\/maxValue-output",
+    "Name":"https://schema.org/maxValue-output",
     "Domain Bucket":"< 1K"
   },
   {
     "Class":"Predicate",
-    "Name":"http:\/\/schema.org\/maximumAttendeeCapacity",
+    "Name":"https://schema.org/maximumAttendeeCapacity",
     "Domain Bucket":"10K - 100K"
   },
   {
     "Class":"Predicate",
-    "Name":"http:\/\/schema.org\/maximumAttendeeCapacity-input",
+    "Name":"https://schema.org/maximumAttendeeCapacity-input",
     "Domain Bucket":"< 1K"
   },
   {
     "Class":"Predicate",
-    "Name":"http:\/\/schema.org\/maximumAttendeeCapacity-output",
+    "Name":"https://schema.org/maximumAttendeeCapacity-output",
     "Domain Bucket":"< 1K"
   },
   {
     "Class":"Predicate",
-    "Name":"http:\/\/schema.org\/maximumEnrollment",
+    "Name":"https://schema.org/maximumEnrollment",
     "Domain Bucket":"< 1K"
   },
   {
     "Class":"Predicate",
-    "Name":"http:\/\/schema.org\/maximumEnrollment-input",
+    "Name":"https://schema.org/maximumEnrollment-input",
     "Domain Bucket":"< 1K"
   },
   {
     "Class":"Predicate",
-    "Name":"http:\/\/schema.org\/maximumEnrollment-output",
+    "Name":"https://schema.org/maximumEnrollment-output",
     "Domain Bucket":"< 1K"
   },
   {
     "Class":"Predicate",
-    "Name":"http:\/\/schema.org\/maximumIntake",
+    "Name":"https://schema.org/maximumIntake",
     "Domain Bucket":"< 1K"
   },
   {
     "Class":"Predicate",
-    "Name":"http:\/\/schema.org\/maximumIntake-input",
+    "Name":"https://schema.org/maximumIntake-input",
     "Domain Bucket":"< 1K"
   },
   {
     "Class":"Predicate",
-    "Name":"http:\/\/schema.org\/maximumIntake-output",
+    "Name":"https://schema.org/maximumIntake-output",
     "Domain Bucket":"< 1K"
   },
   {
     "Class":"Predicate",
-    "Name":"http:\/\/schema.org\/maximumPhysicalAttendeeCapacity",
+    "Name":"https://schema.org/maximumPhysicalAttendeeCapacity",
     "Domain Bucket":"< 1K"
   },
   {
     "Class":"Predicate",
-    "Name":"http:\/\/schema.org\/maximumPhysicalAttendeeCapacity-input",
+    "Name":"https://schema.org/maximumPhysicalAttendeeCapacity-input",
     "Domain Bucket":"< 1K"
   },
   {
     "Class":"Predicate",
-    "Name":"http:\/\/schema.org\/maximumPhysicalAttendeeCapacity-output",
+    "Name":"https://schema.org/maximumPhysicalAttendeeCapacity-output",
     "Domain Bucket":"< 1K"
   },
   {
     "Class":"Predicate",
-    "Name":"http:\/\/schema.org\/maximumVirtualAttendeeCapacity",
+    "Name":"https://schema.org/maximumVirtualAttendeeCapacity",
     "Domain Bucket":"< 1K"
   },
   {
     "Class":"Predicate",
-    "Name":"http:\/\/schema.org\/maximumVirtualAttendeeCapacity-input",
+    "Name":"https://schema.org/maximumVirtualAttendeeCapacity-input",
     "Domain Bucket":"< 1K"
   },
   {
     "Class":"Predicate",
-    "Name":"http:\/\/schema.org\/maximumVirtualAttendeeCapacity-output",
+    "Name":"https://schema.org/maximumVirtualAttendeeCapacity-output",
     "Domain Bucket":"< 1K"
   },
   {
     "Class":"Predicate",
-    "Name":"http:\/\/schema.org\/mealService",
+    "Name":"https://schema.org/mealService",
     "Domain Bucket":"< 1K"
   },
   {
     "Class":"Predicate",
-    "Name":"http:\/\/schema.org\/mealService-input",
+    "Name":"https://schema.org/mealService-input",
     "Domain Bucket":"< 1K"
   },
   {
     "Class":"Predicate",
-    "Name":"http:\/\/schema.org\/mealService-output",
+    "Name":"https://schema.org/mealService-output",
     "Domain Bucket":"< 1K"
   },
   {
     "Class":"Predicate",
-    "Name":"http:\/\/schema.org\/measuredProperty",
+    "Name":"https://schema.org/measuredProperty",
     "Domain Bucket":"< 1K"
   },
   {
     "Class":"Predicate",
-    "Name":"http:\/\/schema.org\/measuredProperty-input",
+    "Name":"https://schema.org/measuredProperty-input",
     "Domain Bucket":"< 1K"
   },
   {
     "Class":"Predicate",
-    "Name":"http:\/\/schema.org\/measuredProperty-output",
+    "Name":"https://schema.org/measuredProperty-output",
     "Domain Bucket":"< 1K"
   },
   {
     "Class":"Predicate",
-    "Name":"http:\/\/schema.org\/measurementDenominator",
+    "Name":"https://schema.org/measurementDenominator",
     "Domain Bucket":"< 1K"
   },
   {
     "Class":"Predicate",
-    "Name":"http:\/\/schema.org\/measurementDenominator-input",
+    "Name":"https://schema.org/measurementDenominator-input",
     "Domain Bucket":"< 1K"
   },
   {
     "Class":"Predicate",
-    "Name":"http:\/\/schema.org\/measurementDenominator-output",
+    "Name":"https://schema.org/measurementDenominator-output",
     "Domain Bucket":"< 1K"
   },
   {
     "Class":"Predicate",
-    "Name":"http:\/\/schema.org\/measurementMethod",
+    "Name":"https://schema.org/measurementMethod",
     "Domain Bucket":"< 1K"
   },
   {
     "Class":"Predicate",
-    "Name":"http:\/\/schema.org\/measurementMethod-input",
+    "Name":"https://schema.org/measurementMethod-input",
     "Domain Bucket":"< 1K"
   },
   {
     "Class":"Predicate",
-    "Name":"http:\/\/schema.org\/measurementMethod-output",
+    "Name":"https://schema.org/measurementMethod-output",
     "Domain Bucket":"< 1K"
   },
   {
     "Class":"Predicate",
-    "Name":"http:\/\/schema.org\/measurementQualifier",
+    "Name":"https://schema.org/measurementQualifier",
     "Domain Bucket":"< 1K"
   },
   {
     "Class":"Predicate",
-    "Name":"http:\/\/schema.org\/measurementQualifier-input",
+    "Name":"https://schema.org/measurementQualifier-input",
     "Domain Bucket":"< 1K"
   },
   {
     "Class":"Predicate",
-    "Name":"http:\/\/schema.org\/measurementQualifier-output",
+    "Name":"https://schema.org/measurementQualifier-output",
     "Domain Bucket":"< 1K"
   },
   {
     "Class":"Predicate",
-    "Name":"http:\/\/schema.org\/measurementTechnique",
+    "Name":"https://schema.org/measurementTechnique",
     "Domain Bucket":"1K - 10K"
   },
   {
     "Class":"Predicate",
-    "Name":"http:\/\/schema.org\/measurementTechnique-input",
+    "Name":"https://schema.org/measurementTechnique-input",
     "Domain Bucket":"< 1K"
   },
   {
     "Class":"Predicate",
-    "Name":"http:\/\/schema.org\/measurementTechnique-output",
+    "Name":"https://schema.org/measurementTechnique-output",
     "Domain Bucket":"< 1K"
   },
   {
     "Class":"Predicate",
-    "Name":"http:\/\/schema.org\/mechanismOfAction",
+    "Name":"https://schema.org/mechanismOfAction",
     "Domain Bucket":"< 1K"
   },
   {
     "Class":"Predicate",
-    "Name":"http:\/\/schema.org\/mechanismOfAction-input",
+    "Name":"https://schema.org/mechanismOfAction-input",
     "Domain Bucket":"< 1K"
   },
   {
     "Class":"Predicate",
-    "Name":"http:\/\/schema.org\/mechanismOfAction-output",
+    "Name":"https://schema.org/mechanismOfAction-output",
     "Domain Bucket":"< 1K"
   },
   {
     "Class":"Predicate",
-    "Name":"http:\/\/schema.org\/mediaAuthenticityCategory",
+    "Name":"https://schema.org/mediaAuthenticityCategory",
     "Domain Bucket":"< 1K"
   },
   {
     "Class":"Predicate",
-    "Name":"http:\/\/schema.org\/mediaAuthenticityCategory-input",
+    "Name":"https://schema.org/mediaAuthenticityCategory-input",
     "Domain Bucket":"< 1K"
   },
   {
     "Class":"Predicate",
-    "Name":"http:\/\/schema.org\/mediaAuthenticityCategory-output",
+    "Name":"https://schema.org/mediaAuthenticityCategory-output",
     "Domain Bucket":"< 1K"
   },
   {
     "Class":"Predicate",
-    "Name":"http:\/\/schema.org\/mediaItemAppearance",
+    "Name":"https://schema.org/mediaItemAppearance",
     "Domain Bucket":"< 1K"
   },
   {
     "Class":"Predicate",
-    "Name":"http:\/\/schema.org\/mediaItemAppearance-input",
+    "Name":"https://schema.org/mediaItemAppearance-input",
     "Domain Bucket":"< 1K"
   },
   {
     "Class":"Predicate",
-    "Name":"http:\/\/schema.org\/mediaItemAppearance-output",
+    "Name":"https://schema.org/mediaItemAppearance-output",
     "Domain Bucket":"< 1K"
   },
   {
     "Class":"Predicate",
-    "Name":"http:\/\/schema.org\/median",
+    "Name":"https://schema.org/median",
     "Domain Bucket":"1K - 10K"
   },
   {
     "Class":"Predicate",
-    "Name":"http:\/\/schema.org\/median-input",
+    "Name":"https://schema.org/median-input",
     "Domain Bucket":"< 1K"
   },
   {
     "Class":"Predicate",
-    "Name":"http:\/\/schema.org\/median-output",
+    "Name":"https://schema.org/median-output",
     "Domain Bucket":"< 1K"
   },
   {
     "Class":"Predicate",
-    "Name":"http:\/\/schema.org\/medicalAudience",
+    "Name":"https://schema.org/medicalAudience",
     "Domain Bucket":"1K - 10K"
   },
   {
     "Class":"Predicate",
-    "Name":"http:\/\/schema.org\/medicalAudience-input",
+    "Name":"https://schema.org/medicalAudience-input",
     "Domain Bucket":"< 1K"
   },
   {
     "Class":"Predicate",
-    "Name":"http:\/\/schema.org\/medicalAudience-output",
+    "Name":"https://schema.org/medicalAudience-output",
     "Domain Bucket":"< 1K"
   },
   {
     "Class":"Predicate",
-    "Name":"http:\/\/schema.org\/medicalSpecialty",
+    "Name":"https://schema.org/medicalSpecialty",
     "Domain Bucket":"100K - 1M"
   },
   {
     "Class":"Predicate",
-    "Name":"http:\/\/schema.org\/medicalSpecialty-input",
+    "Name":"https://schema.org/medicalSpecialty-input",
     "Domain Bucket":"< 1K"
   },
   {
     "Class":"Predicate",
-    "Name":"http:\/\/schema.org\/medicalSpecialty-output",
+    "Name":"https://schema.org/medicalSpecialty-output",
     "Domain Bucket":"< 1K"
   },
   {
     "Class":"Predicate",
-    "Name":"http:\/\/schema.org\/medicineSystem",
+    "Name":"https://schema.org/medicineSystem",
     "Domain Bucket":"1K - 10K"
   },
   {
     "Class":"Predicate",
-    "Name":"http:\/\/schema.org\/medicineSystem-input",
+    "Name":"https://schema.org/medicineSystem-input",
     "Domain Bucket":"< 1K"
   },
   {
     "Class":"Predicate",
-    "Name":"http:\/\/schema.org\/medicineSystem-output",
+    "Name":"https://schema.org/medicineSystem-output",
     "Domain Bucket":"< 1K"
   },
   {
     "Class":"Predicate",
-    "Name":"http:\/\/schema.org\/meetsEmissionStandard",
+    "Name":"https://schema.org/meetsEmissionStandard",
     "Domain Bucket":"< 1K"
   },
   {
     "Class":"Predicate",
-    "Name":"http:\/\/schema.org\/meetsEmissionStandard-input",
+    "Name":"https://schema.org/meetsEmissionStandard-input",
     "Domain Bucket":"< 1K"
   },
   {
     "Class":"Predicate",
-    "Name":"http:\/\/schema.org\/meetsEmissionStandard-output",
+    "Name":"https://schema.org/meetsEmissionStandard-output",
     "Domain Bucket":"< 1K"
   },
   {
     "Class":"Predicate",
-    "Name":"http:\/\/schema.org\/member",
+    "Name":"https://schema.org/member",
     "Domain Bucket":"10K - 100K"
   },
   {
     "Class":"Predicate",
-    "Name":"http:\/\/schema.org\/member-input",
+    "Name":"https://schema.org/member-input",
     "Domain Bucket":"< 1K"
   },
   {
     "Class":"Predicate",
-    "Name":"http:\/\/schema.org\/member-output",
+    "Name":"https://schema.org/member-output",
     "Domain Bucket":"< 1K"
   },
   {
     "Class":"Predicate",
-    "Name":"http:\/\/schema.org\/memberOf",
+    "Name":"https://schema.org/memberOf",
     "Domain Bucket":"100K - 1M"
   },
   {
     "Class":"Predicate",
-    "Name":"http:\/\/schema.org\/memberOf-input",
+    "Name":"https://schema.org/memberOf-input",
     "Domain Bucket":"< 1K"
   },
   {
     "Class":"Predicate",
-    "Name":"http:\/\/schema.org\/memberOf-output",
+    "Name":"https://schema.org/memberOf-output",
     "Domain Bucket":"< 1K"
   },
   {
     "Class":"Predicate",
-    "Name":"http:\/\/schema.org\/members",
+    "Name":"https://schema.org/members",
     "Domain Bucket":"< 1K"
   },
   {
     "Class":"Predicate",
-    "Name":"http:\/\/schema.org\/members-input",
+    "Name":"https://schema.org/members-input",
     "Domain Bucket":"< 1K"
   },
   {
     "Class":"Predicate",
-    "Name":"http:\/\/schema.org\/members-output",
+    "Name":"https://schema.org/members-output",
     "Domain Bucket":"< 1K"
   },
   {
     "Class":"Predicate",
-    "Name":"http:\/\/schema.org\/membershipNumber",
+    "Name":"https://schema.org/membershipNumber",
     "Domain Bucket":"< 1K"
   },
   {
     "Class":"Predicate",
-    "Name":"http:\/\/schema.org\/membershipNumber-input",
+    "Name":"https://schema.org/membershipNumber-input",
     "Domain Bucket":"< 1K"
   },
   {
     "Class":"Predicate",
-    "Name":"http:\/\/schema.org\/membershipNumber-output",
+    "Name":"https://schema.org/membershipNumber-output",
     "Domain Bucket":"< 1K"
   },
   {
     "Class":"Predicate",
-    "Name":"http:\/\/schema.org\/membershipPointsEarned",
+    "Name":"https://schema.org/membershipPointsEarned",
     "Domain Bucket":"1K - 10K"
   },
   {
     "Class":"Predicate",
-    "Name":"http:\/\/schema.org\/membershipPointsEarned-input",
+    "Name":"https://schema.org/membershipPointsEarned-input",
     "Domain Bucket":"< 1K"
   },
   {
     "Class":"Predicate",
-    "Name":"http:\/\/schema.org\/membershipPointsEarned-output",
+    "Name":"https://schema.org/membershipPointsEarned-output",
     "Domain Bucket":"< 1K"
   },
   {
     "Class":"Predicate",
-    "Name":"http:\/\/schema.org\/memoryRequirements",
+    "Name":"https://schema.org/memoryRequirements",
     "Domain Bucket":"1K - 10K"
   },
   {
     "Class":"Predicate",
-    "Name":"http:\/\/schema.org\/memoryRequirements-input",
+    "Name":"https://schema.org/memoryRequirements-input",
     "Domain Bucket":"< 1K"
   },
   {
     "Class":"Predicate",
-    "Name":"http:\/\/schema.org\/memoryRequirements-output",
+    "Name":"https://schema.org/memoryRequirements-output",
     "Domain Bucket":"< 1K"
   },
   {
     "Class":"Predicate",
-    "Name":"http:\/\/schema.org\/mentions",
+    "Name":"https://schema.org/mentions",
     "Domain Bucket":"10K - 100K"
   },
   {
     "Class":"Predicate",
-    "Name":"http:\/\/schema.org\/mentions-input",
+    "Name":"https://schema.org/mentions-input",
     "Domain Bucket":"< 1K"
   },
   {
     "Class":"Predicate",
-    "Name":"http:\/\/schema.org\/mentions-output",
+    "Name":"https://schema.org/mentions-output",
     "Domain Bucket":"< 1K"
   },
   {
     "Class":"Predicate",
-    "Name":"http:\/\/schema.org\/menu",
+    "Name":"https://schema.org/menu",
     "Domain Bucket":"10K - 100K"
   },
   {
     "Class":"Predicate",
-    "Name":"http:\/\/schema.org\/menu-input",
+    "Name":"https://schema.org/menu-input",
     "Domain Bucket":"< 1K"
   },
   {
     "Class":"Predicate",
-    "Name":"http:\/\/schema.org\/menu-output",
+    "Name":"https://schema.org/menu-output",
     "Domain Bucket":"< 1K"
   },
   {
     "Class":"Predicate",
-    "Name":"http:\/\/schema.org\/menuAddOn",
+    "Name":"https://schema.org/menuAddOn",
     "Domain Bucket":"10K - 100K"
   },
   {
     "Class":"Predicate",
-    "Name":"http:\/\/schema.org\/menuAddOn-input",
+    "Name":"https://schema.org/menuAddOn-input",
     "Domain Bucket":"< 1K"
   },
   {
     "Class":"Predicate",
-    "Name":"http:\/\/schema.org\/menuAddOn-output",
+    "Name":"https://schema.org/menuAddOn-output",
     "Domain Bucket":"< 1K"
   },
   {
     "Class":"Predicate",
-    "Name":"http:\/\/schema.org\/merchant",
+    "Name":"https://schema.org/merchant",
     "Domain Bucket":"< 1K"
   },
   {
     "Class":"Predicate",
-    "Name":"http:\/\/schema.org\/merchant-input",
+    "Name":"https://schema.org/merchant-input",
     "Domain Bucket":"< 1K"
   },
   {
     "Class":"Predicate",
-    "Name":"http:\/\/schema.org\/merchant-output",
+    "Name":"https://schema.org/merchant-output",
     "Domain Bucket":"< 1K"
   },
   {
     "Class":"Predicate",
-    "Name":"http:\/\/schema.org\/merchantReturnDays",
+    "Name":"https://schema.org/merchantReturnDays",
     "Domain Bucket":"100K - 1M"
   },
   {
     "Class":"Predicate",
-    "Name":"http:\/\/schema.org\/merchantReturnDays-input",
+    "Name":"https://schema.org/merchantReturnDays-input",
     "Domain Bucket":"< 1K"
   },
   {
     "Class":"Predicate",
-    "Name":"http:\/\/schema.org\/merchantReturnDays-output",
+    "Name":"https://schema.org/merchantReturnDays-output",
     "Domain Bucket":"< 1K"
   },
   {
     "Class":"Predicate",
-    "Name":"http:\/\/schema.org\/merchantReturnLink",
+    "Name":"https://schema.org/merchantReturnLink",
     "Domain Bucket":"10K - 100K"
   },
   {
     "Class":"Predicate",
-    "Name":"http:\/\/schema.org\/merchantReturnLink-input",
+    "Name":"https://schema.org/merchantReturnLink-input",
     "Domain Bucket":"< 1K"
   },
   {
     "Class":"Predicate",
-    "Name":"http:\/\/schema.org\/merchantReturnLink-output",
+    "Name":"https://schema.org/merchantReturnLink-output",
     "Domain Bucket":"< 1K"
   },
   {
     "Class":"Predicate",
-    "Name":"http:\/\/schema.org\/messageAttachment",
+    "Name":"https://schema.org/messageAttachment",
     "Domain Bucket":"< 1K"
   },
   {
     "Class":"Predicate",
-    "Name":"http:\/\/schema.org\/messageAttachment-input",
+    "Name":"https://schema.org/messageAttachment-input",
     "Domain Bucket":"< 1K"
   },
   {
     "Class":"Predicate",
-    "Name":"http:\/\/schema.org\/messageAttachment-output",
+    "Name":"https://schema.org/messageAttachment-output",
     "Domain Bucket":"< 1K"
   },
   {
     "Class":"Predicate",
-    "Name":"http:\/\/schema.org\/mileageFromOdometer",
+    "Name":"https://schema.org/mileageFromOdometer",
     "Domain Bucket":"10K - 100K"
   },
   {
     "Class":"Predicate",
-    "Name":"http:\/\/schema.org\/mileageFromOdometer-input",
+    "Name":"https://schema.org/mileageFromOdometer-input",
     "Domain Bucket":"< 1K"
   },
   {
     "Class":"Predicate",
-    "Name":"http:\/\/schema.org\/mileageFromOdometer-output",
+    "Name":"https://schema.org/mileageFromOdometer-output",
     "Domain Bucket":"< 1K"
   },
   {
     "Class":"Predicate",
-    "Name":"http:\/\/schema.org\/minPrice",
+    "Name":"https://schema.org/minPrice",
     "Domain Bucket":"10K - 100K"
   },
   {
     "Class":"Predicate",
-    "Name":"http:\/\/schema.org\/minPrice-input",
+    "Name":"https://schema.org/minPrice-input",
     "Domain Bucket":"< 1K"
   },
   {
     "Class":"Predicate",
-    "Name":"http:\/\/schema.org\/minPrice-output",
+    "Name":"https://schema.org/minPrice-output",
     "Domain Bucket":"< 1K"
   },
   {
     "Class":"Predicate",
-    "Name":"http:\/\/schema.org\/minValue",
+    "Name":"https://schema.org/minValue",
     "Domain Bucket":"100K - 1M"
   },
   {
     "Class":"Predicate",
-    "Name":"http:\/\/schema.org\/minValue-input",
+    "Name":"https://schema.org/minValue-input",
     "Domain Bucket":"< 1K"
   },
   {
     "Class":"Predicate",
-    "Name":"http:\/\/schema.org\/minValue-output",
+    "Name":"https://schema.org/minValue-output",
     "Domain Bucket":"< 1K"
   },
   {
     "Class":"Predicate",
-    "Name":"http:\/\/schema.org\/minimumPaymentDue",
+    "Name":"https://schema.org/minimumPaymentDue",
     "Domain Bucket":"< 1K"
   },
   {
     "Class":"Predicate",
-    "Name":"http:\/\/schema.org\/minimumPaymentDue-input",
+    "Name":"https://schema.org/minimumPaymentDue-input",
     "Domain Bucket":"< 1K"
   },
   {
     "Class":"Predicate",
-    "Name":"http:\/\/schema.org\/minimumPaymentDue-output",
+    "Name":"https://schema.org/minimumPaymentDue-output",
     "Domain Bucket":"< 1K"
   },
   {
     "Class":"Predicate",
-    "Name":"http:\/\/schema.org\/missionCoveragePrioritiesPolicy",
+    "Name":"https://schema.org/missionCoveragePrioritiesPolicy",
     "Domain Bucket":"1K - 10K"
   },
   {
     "Class":"Predicate",
-    "Name":"http:\/\/schema.org\/missionCoveragePrioritiesPolicy-input",
+    "Name":"https://schema.org/missionCoveragePrioritiesPolicy-input",
     "Domain Bucket":"< 1K"
   },
   {
     "Class":"Predicate",
-    "Name":"http:\/\/schema.org\/missionCoveragePrioritiesPolicy-output",
+    "Name":"https://schema.org/missionCoveragePrioritiesPolicy-output",
     "Domain Bucket":"< 1K"
   },
   {
     "Class":"Predicate",
-    "Name":"http:\/\/schema.org\/mobileUrl",
+    "Name":"https://schema.org/mobileUrl",
     "Domain Bucket":"< 1K"
   },
   {
     "Class":"Predicate",
-    "Name":"http:\/\/schema.org\/mobileUrl-input",
+    "Name":"https://schema.org/mobileUrl-input",
     "Domain Bucket":"< 1K"
   },
   {
     "Class":"Predicate",
-    "Name":"http:\/\/schema.org\/mobileUrl-output",
+    "Name":"https://schema.org/mobileUrl-output",
     "Domain Bucket":"< 1K"
   },
   {
     "Class":"Predicate",
-    "Name":"http:\/\/schema.org\/model",
+    "Name":"https://schema.org/model",
     "Domain Bucket":"100K - 1M"
   },
   {
     "Class":"Predicate",
-    "Name":"http:\/\/schema.org\/model-input",
+    "Name":"https://schema.org/model-input",
     "Domain Bucket":"< 1K"
   },
   {
     "Class":"Predicate",
-    "Name":"http:\/\/schema.org\/model-output",
+    "Name":"https://schema.org/model-output",
     "Domain Bucket":"< 1K"
   },
   {
     "Class":"Predicate",
-    "Name":"http:\/\/schema.org\/modelDate",
+    "Name":"https://schema.org/modelDate",
     "Domain Bucket":"10K - 100K"
   },
   {
     "Class":"Predicate",
-    "Name":"http:\/\/schema.org\/modelDate-input",
+    "Name":"https://schema.org/modelDate-input",
     "Domain Bucket":"< 1K"
   },
   {
     "Class":"Predicate",
-    "Name":"http:\/\/schema.org\/modelDate-output",
+    "Name":"https://schema.org/modelDate-output",
     "Domain Bucket":"< 1K"
   },
   {
     "Class":"Predicate",
-    "Name":"http:\/\/schema.org\/modifiedTime",
+    "Name":"https://schema.org/modifiedTime",
     "Domain Bucket":"< 1K"
   },
   {
     "Class":"Predicate",
-    "Name":"http:\/\/schema.org\/modifiedTime-input",
+    "Name":"https://schema.org/modifiedTime-input",
     "Domain Bucket":"< 1K"
   },
   {
     "Class":"Predicate",
-    "Name":"http:\/\/schema.org\/modifiedTime-output",
+    "Name":"https://schema.org/modifiedTime-output",
     "Domain Bucket":"< 1K"
   },
   {
     "Class":"Predicate",
-    "Name":"http:\/\/schema.org\/molecularFormula",
+    "Name":"https://schema.org/molecularFormula",
     "Domain Bucket":"< 1K"
   },
   {
     "Class":"Predicate",
-    "Name":"http:\/\/schema.org\/molecularFormula-input",
+    "Name":"https://schema.org/molecularFormula-input",
     "Domain Bucket":"< 1K"
   },
   {
     "Class":"Predicate",
-    "Name":"http:\/\/schema.org\/molecularFormula-output",
+    "Name":"https://schema.org/molecularFormula-output",
     "Domain Bucket":"< 1K"
   },
   {
     "Class":"Predicate",
-    "Name":"http:\/\/schema.org\/molecularWeight",
+    "Name":"https://schema.org/molecularWeight",
     "Domain Bucket":"< 1K"
   },
   {
     "Class":"Predicate",
-    "Name":"http:\/\/schema.org\/molecularWeight-input",
+    "Name":"https://schema.org/molecularWeight-input",
     "Domain Bucket":"< 1K"
   },
   {
     "Class":"Predicate",
-    "Name":"http:\/\/schema.org\/molecularWeight-output",
+    "Name":"https://schema.org/molecularWeight-output",
     "Domain Bucket":"< 1K"
   },
   {
     "Class":"Predicate",
-    "Name":"http:\/\/schema.org\/monoisotopicMolecularWeight",
+    "Name":"https://schema.org/monoisotopicMolecularWeight",
     "Domain Bucket":"< 1K"
   },
   {
     "Class":"Predicate",
-    "Name":"http:\/\/schema.org\/monoisotopicMolecularWeight-input",
+    "Name":"https://schema.org/monoisotopicMolecularWeight-input",
     "Domain Bucket":"< 1K"
   },
   {
     "Class":"Predicate",
-    "Name":"http:\/\/schema.org\/monoisotopicMolecularWeight-output",
+    "Name":"https://schema.org/monoisotopicMolecularWeight-output",
     "Domain Bucket":"< 1K"
   },
   {
     "Class":"Predicate",
-    "Name":"http:\/\/schema.org\/monthlyMinimumRepaymentAmount",
+    "Name":"https://schema.org/monthlyMinimumRepaymentAmount",
     "Domain Bucket":"< 1K"
   },
   {
     "Class":"Predicate",
-    "Name":"http:\/\/schema.org\/monthlyMinimumRepaymentAmount-input",
+    "Name":"https://schema.org/monthlyMinimumRepaymentAmount-input",
     "Domain Bucket":"< 1K"
   },
   {
     "Class":"Predicate",
-    "Name":"http:\/\/schema.org\/monthlyMinimumRepaymentAmount-output",
+    "Name":"https://schema.org/monthlyMinimumRepaymentAmount-output",
     "Domain Bucket":"< 1K"
   },
   {
     "Class":"Predicate",
-    "Name":"http:\/\/schema.org\/monthsOfExperience",
+    "Name":"https://schema.org/monthsOfExperience",
     "Domain Bucket":"1K - 10K"
   },
   {
     "Class":"Predicate",
-    "Name":"http:\/\/schema.org\/monthsOfExperience-input",
+    "Name":"https://schema.org/monthsOfExperience-input",
     "Domain Bucket":"< 1K"
   },
   {
     "Class":"Predicate",
-    "Name":"http:\/\/schema.org\/monthsOfExperience-output",
+    "Name":"https://schema.org/monthsOfExperience-output",
     "Domain Bucket":"< 1K"
   },
   {
     "Class":"Predicate",
-    "Name":"http:\/\/schema.org\/mpn",
+    "Name":"https://schema.org/mpn",
     "Domain Bucket":"100K - 1M"
   },
   {
     "Class":"Predicate",
-    "Name":"http:\/\/schema.org\/mpn-input",
+    "Name":"https://schema.org/mpn-input",
     "Domain Bucket":"< 1K"
   },
   {
     "Class":"Predicate",
-    "Name":"http:\/\/schema.org\/mpn-output",
+    "Name":"https://schema.org/mpn-output",
     "Domain Bucket":"< 1K"
   },
   {
     "Class":"Predicate",
-    "Name":"http:\/\/schema.org\/multipleValues",
+    "Name":"https://schema.org/multipleValues",
     "Domain Bucket":"< 1K"
   },
   {
     "Class":"Predicate",
-    "Name":"http:\/\/schema.org\/multipleValues-input",
+    "Name":"https://schema.org/multipleValues-input",
     "Domain Bucket":"< 1K"
   },
   {
     "Class":"Predicate",
-    "Name":"http:\/\/schema.org\/multipleValues-output",
+    "Name":"https://schema.org/multipleValues-output",
     "Domain Bucket":"< 1K"
   },
   {
     "Class":"Predicate",
-    "Name":"http:\/\/schema.org\/muscleAction",
+    "Name":"https://schema.org/muscleAction",
     "Domain Bucket":"< 1K"
   },
   {
     "Class":"Predicate",
-    "Name":"http:\/\/schema.org\/muscleAction-input",
+    "Name":"https://schema.org/muscleAction-input",
     "Domain Bucket":"< 1K"
   },
   {
     "Class":"Predicate",
-    "Name":"http:\/\/schema.org\/muscleAction-output",
+    "Name":"https://schema.org/muscleAction-output",
     "Domain Bucket":"< 1K"
   },
   {
     "Class":"Predicate",
-    "Name":"http:\/\/schema.org\/musicArrangement",
+    "Name":"https://schema.org/musicArrangement",
     "Domain Bucket":"< 1K"
   },
   {
     "Class":"Predicate",
-    "Name":"http:\/\/schema.org\/musicArrangement-input",
+    "Name":"https://schema.org/musicArrangement-input",
     "Domain Bucket":"< 1K"
   },
   {
     "Class":"Predicate",
-    "Name":"http:\/\/schema.org\/musicArrangement-output",
+    "Name":"https://schema.org/musicArrangement-output",
     "Domain Bucket":"< 1K"
   },
   {
     "Class":"Predicate",
-    "Name":"http:\/\/schema.org\/musicBy",
+    "Name":"https://schema.org/musicBy",
     "Domain Bucket":"1K - 10K"
   },
   {
     "Class":"Predicate",
-    "Name":"http:\/\/schema.org\/musicBy-input",
+    "Name":"https://schema.org/musicBy-input",
     "Domain Bucket":"< 1K"
   },
   {
     "Class":"Predicate",
-    "Name":"http:\/\/schema.org\/musicBy-output",
+    "Name":"https://schema.org/musicBy-output",
     "Domain Bucket":"< 1K"
   },
   {
     "Class":"Predicate",
-    "Name":"http:\/\/schema.org\/musicCompositionForm",
+    "Name":"https://schema.org/musicCompositionForm",
     "Domain Bucket":"< 1K"
   },
   {
     "Class":"Predicate",
-    "Name":"http:\/\/schema.org\/musicCompositionForm-input",
+    "Name":"https://schema.org/musicCompositionForm-input",
     "Domain Bucket":"< 1K"
   },
   {
     "Class":"Predicate",
-    "Name":"http:\/\/schema.org\/musicCompositionForm-output",
+    "Name":"https://schema.org/musicCompositionForm-output",
     "Domain Bucket":"< 1K"
   },
   {
     "Class":"Predicate",
-    "Name":"http:\/\/schema.org\/musicGroupMember",
+    "Name":"https://schema.org/musicGroupMember",
     "Domain Bucket":"< 1K"
   },
   {
     "Class":"Predicate",
-    "Name":"http:\/\/schema.org\/musicGroupMember-input",
+    "Name":"https://schema.org/musicGroupMember-input",
     "Domain Bucket":"< 1K"
   },
   {
     "Class":"Predicate",
-    "Name":"http:\/\/schema.org\/musicGroupMember-output",
+    "Name":"https://schema.org/musicGroupMember-output",
     "Domain Bucket":"< 1K"
   },
   {
     "Class":"Predicate",
-    "Name":"http:\/\/schema.org\/musicReleaseFormat",
+    "Name":"https://schema.org/musicReleaseFormat",
     "Domain Bucket":"1K - 10K"
   },
   {
     "Class":"Predicate",
-    "Name":"http:\/\/schema.org\/musicReleaseFormat-input",
+    "Name":"https://schema.org/musicReleaseFormat-input",
     "Domain Bucket":"< 1K"
   },
   {
     "Class":"Predicate",
-    "Name":"http:\/\/schema.org\/musicReleaseFormat-output",
+    "Name":"https://schema.org/musicReleaseFormat-output",
     "Domain Bucket":"< 1K"
   },
   {
     "Class":"Predicate",
-    "Name":"http:\/\/schema.org\/musicalKey",
+    "Name":"https://schema.org/musicalKey",
     "Domain Bucket":"< 1K"
   },
   {
     "Class":"Predicate",
-    "Name":"http:\/\/schema.org\/musicalKey-input",
+    "Name":"https://schema.org/musicalKey-input",
     "Domain Bucket":"< 1K"
   },
   {
     "Class":"Predicate",
-    "Name":"http:\/\/schema.org\/musicalKey-output",
+    "Name":"https://schema.org/musicalKey-output",
     "Domain Bucket":"< 1K"
   },
   {
     "Class":"Predicate",
-    "Name":"http:\/\/schema.org\/naics",
+    "Name":"https://schema.org/naics",
     "Domain Bucket":"10K - 100K"
   },
   {
     "Class":"Predicate",
-    "Name":"http:\/\/schema.org\/naics-input",
+    "Name":"https://schema.org/naics-input",
     "Domain Bucket":"< 1K"
   },
   {
     "Class":"Predicate",
-    "Name":"http:\/\/schema.org\/naics-output",
+    "Name":"https://schema.org/naics-output",
     "Domain Bucket":"< 1K"
   },
   {
     "Class":"Predicate",
-    "Name":"http:\/\/schema.org\/name",
+    "Name":"https://schema.org/name",
     "Domain Bucket":"10M+"
   },
   {
     "Class":"Predicate",
-    "Name":"http:\/\/schema.org\/name-input",
+    "Name":"https://schema.org/name-input",
     "Domain Bucket":"< 1K"
   },
   {
     "Class":"Predicate",
-    "Name":"http:\/\/schema.org\/name-output",
+    "Name":"https://schema.org/name-output",
     "Domain Bucket":"< 1K"
   },
   {
     "Class":"Predicate",
-    "Name":"http:\/\/schema.org\/namedPosition",
+    "Name":"https://schema.org/namedPosition",
     "Domain Bucket":"< 1K"
   },
   {
     "Class":"Predicate",
-    "Name":"http:\/\/schema.org\/namedPosition-input",
+    "Name":"https://schema.org/namedPosition-input",
     "Domain Bucket":"< 1K"
   },
   {
     "Class":"Predicate",
-    "Name":"http:\/\/schema.org\/namedPosition-output",
+    "Name":"https://schema.org/namedPosition-output",
     "Domain Bucket":"< 1K"
   },
   {
     "Class":"Predicate",
-    "Name":"http:\/\/schema.org\/nationality",
+    "Name":"https://schema.org/nationality",
     "Domain Bucket":"10K - 100K"
   },
   {
     "Class":"Predicate",
-    "Name":"http:\/\/schema.org\/nationality-input",
+    "Name":"https://schema.org/nationality-input",
     "Domain Bucket":"< 1K"
   },
   {
     "Class":"Predicate",
-    "Name":"http:\/\/schema.org\/nationality-output",
+    "Name":"https://schema.org/nationality-output",
     "Domain Bucket":"< 1K"
   },
   {
     "Class":"Predicate",
-    "Name":"http:\/\/schema.org\/naturalProgression",
+    "Name":"https://schema.org/naturalProgression",
     "Domain Bucket":"< 1K"
   },
   {
     "Class":"Predicate",
-    "Name":"http:\/\/schema.org\/naturalProgression-input",
+    "Name":"https://schema.org/naturalProgression-input",
     "Domain Bucket":"< 1K"
   },
   {
     "Class":"Predicate",
-    "Name":"http:\/\/schema.org\/naturalProgression-output",
+    "Name":"https://schema.org/naturalProgression-output",
     "Domain Bucket":"< 1K"
   },
   {
     "Class":"Predicate",
-    "Name":"http:\/\/schema.org\/negativeNotes",
+    "Name":"https://schema.org/negativeNotes",
     "Domain Bucket":"10K - 100K"
   },
   {
     "Class":"Predicate",
-    "Name":"http:\/\/schema.org\/negativeNotes-input",
+    "Name":"https://schema.org/negativeNotes-input",
     "Domain Bucket":"< 1K"
   },
   {
     "Class":"Predicate",
-    "Name":"http:\/\/schema.org\/negativeNotes-output",
+    "Name":"https://schema.org/negativeNotes-output",
     "Domain Bucket":"< 1K"
   },
   {
     "Class":"Predicate",
-    "Name":"http:\/\/schema.org\/nerve",
+    "Name":"https://schema.org/nerve",
     "Domain Bucket":"< 1K"
   },
   {
     "Class":"Predicate",
-    "Name":"http:\/\/schema.org\/nerve-input",
+    "Name":"https://schema.org/nerve-input",
     "Domain Bucket":"< 1K"
   },
   {
     "Class":"Predicate",
-    "Name":"http:\/\/schema.org\/nerve-output",
+    "Name":"https://schema.org/nerve-output",
     "Domain Bucket":"< 1K"
   },
   {
     "Class":"Predicate",
-    "Name":"http:\/\/schema.org\/nerveMotor",
+    "Name":"https://schema.org/nerveMotor",
     "Domain Bucket":"< 1K"
   },
   {
     "Class":"Predicate",
-    "Name":"http:\/\/schema.org\/nerveMotor-input",
+    "Name":"https://schema.org/nerveMotor-input",
     "Domain Bucket":"< 1K"
   },
   {
     "Class":"Predicate",
-    "Name":"http:\/\/schema.org\/nerveMotor-output",
+    "Name":"https://schema.org/nerveMotor-output",
     "Domain Bucket":"< 1K"
   },
   {
     "Class":"Predicate",
-    "Name":"http:\/\/schema.org\/netWorth",
+    "Name":"https://schema.org/netWorth",
     "Domain Bucket":"< 1K"
   },
   {
     "Class":"Predicate",
-    "Name":"http:\/\/schema.org\/netWorth-input",
+    "Name":"https://schema.org/netWorth-input",
     "Domain Bucket":"< 1K"
   },
   {
     "Class":"Predicate",
-    "Name":"http:\/\/schema.org\/netWorth-output",
+    "Name":"https://schema.org/netWorth-output",
     "Domain Bucket":"< 1K"
   },
   {
     "Class":"Predicate",
-    "Name":"http:\/\/schema.org\/newsUpdatesAndGuidelines",
+    "Name":"https://schema.org/newsUpdatesAndGuidelines",
     "Domain Bucket":"< 1K"
   },
   {
     "Class":"Predicate",
-    "Name":"http:\/\/schema.org\/newsUpdatesAndGuidelines-input",
+    "Name":"https://schema.org/newsUpdatesAndGuidelines-input",
     "Domain Bucket":"< 1K"
   },
   {
     "Class":"Predicate",
-    "Name":"http:\/\/schema.org\/newsUpdatesAndGuidelines-output",
+    "Name":"https://schema.org/newsUpdatesAndGuidelines-output",
     "Domain Bucket":"< 1K"
   },
   {
     "Class":"Predicate",
-    "Name":"http:\/\/schema.org\/nextItem",
+    "Name":"https://schema.org/nextItem",
     "Domain Bucket":"1M - 10M"
   },
   {
     "Class":"Predicate",
-    "Name":"http:\/\/schema.org\/nextItem-input",
+    "Name":"https://schema.org/nextItem-input",
     "Domain Bucket":"< 1K"
   },
   {
     "Class":"Predicate",
-    "Name":"http:\/\/schema.org\/nextItem-output",
+    "Name":"https://schema.org/nextItem-output",
     "Domain Bucket":"< 1K"
   },
   {
     "Class":"Predicate",
-    "Name":"http:\/\/schema.org\/noBylinesPolicy",
+    "Name":"https://schema.org/noBylinesPolicy",
     "Domain Bucket":"1K - 10K"
   },
   {
     "Class":"Predicate",
-    "Name":"http:\/\/schema.org\/noBylinesPolicy-input",
+    "Name":"https://schema.org/noBylinesPolicy-input",
     "Domain Bucket":"< 1K"
   },
   {
     "Class":"Predicate",
-    "Name":"http:\/\/schema.org\/noBylinesPolicy-output",
+    "Name":"https://schema.org/noBylinesPolicy-output",
     "Domain Bucket":"< 1K"
   },
   {
     "Class":"Predicate",
-    "Name":"http:\/\/schema.org\/nonEqual",
+    "Name":"https://schema.org/nonEqual",
     "Domain Bucket":"< 1K"
   },
   {
     "Class":"Predicate",
-    "Name":"http:\/\/schema.org\/nonEqual-input",
+    "Name":"https://schema.org/nonEqual-input",
     "Domain Bucket":"< 1K"
   },
   {
     "Class":"Predicate",
-    "Name":"http:\/\/schema.org\/nonEqual-output",
+    "Name":"https://schema.org/nonEqual-output",
     "Domain Bucket":"< 1K"
   },
   {
     "Class":"Predicate",
-    "Name":"http:\/\/schema.org\/nonProprietaryName",
+    "Name":"https://schema.org/nonProprietaryName",
     "Domain Bucket":"1K - 10K"
   },
   {
     "Class":"Predicate",
-    "Name":"http:\/\/schema.org\/nonProprietaryName-input",
+    "Name":"https://schema.org/nonProprietaryName-input",
     "Domain Bucket":"< 1K"
   },
   {
     "Class":"Predicate",
-    "Name":"http:\/\/schema.org\/nonProprietaryName-output",
+    "Name":"https://schema.org/nonProprietaryName-output",
     "Domain Bucket":"< 1K"
   },
   {
     "Class":"Predicate",
-    "Name":"http:\/\/schema.org\/nonprofitStatus",
+    "Name":"https://schema.org/nonprofitStatus",
     "Domain Bucket":"1K - 10K"
   },
   {
     "Class":"Predicate",
-    "Name":"http:\/\/schema.org\/nonprofitStatus-input",
+    "Name":"https://schema.org/nonprofitStatus-input",
     "Domain Bucket":"< 1K"
   },
   {
     "Class":"Predicate",
-    "Name":"http:\/\/schema.org\/nonprofitStatus-output",
+    "Name":"https://schema.org/nonprofitStatus-output",
     "Domain Bucket":"< 1K"
   },
   {
     "Class":"Predicate",
-    "Name":"http:\/\/schema.org\/normalRange",
+    "Name":"https://schema.org/normalRange",
     "Domain Bucket":"< 1K"
   },
   {
     "Class":"Predicate",
-    "Name":"http:\/\/schema.org\/normalRange-input",
+    "Name":"https://schema.org/normalRange-input",
     "Domain Bucket":"< 1K"
   },
   {
     "Class":"Predicate",
-    "Name":"http:\/\/schema.org\/normalRange-output",
+    "Name":"https://schema.org/normalRange-output",
     "Domain Bucket":"< 1K"
   },
   {
     "Class":"Predicate",
-    "Name":"http:\/\/schema.org\/nsn",
+    "Name":"https://schema.org/nsn",
     "Domain Bucket":"< 1K"
   },
   {
     "Class":"Predicate",
-    "Name":"http:\/\/schema.org\/nsn-input",
+    "Name":"https://schema.org/nsn-input",
     "Domain Bucket":"< 1K"
   },
   {
     "Class":"Predicate",
-    "Name":"http:\/\/schema.org\/nsn-output",
+    "Name":"https://schema.org/nsn-output",
     "Domain Bucket":"< 1K"
   },
   {
     "Class":"Predicate",
-    "Name":"http:\/\/schema.org\/numAdults",
+    "Name":"https://schema.org/numAdults",
     "Domain Bucket":"< 1K"
   },
   {
     "Class":"Predicate",
-    "Name":"http:\/\/schema.org\/numAdults-input",
+    "Name":"https://schema.org/numAdults-input",
     "Domain Bucket":"< 1K"
   },
   {
     "Class":"Predicate",
-    "Name":"http:\/\/schema.org\/numAdults-output",
+    "Name":"https://schema.org/numAdults-output",
     "Domain Bucket":"< 1K"
   },
   {
     "Class":"Predicate",
-    "Name":"http:\/\/schema.org\/numChildren",
+    "Name":"https://schema.org/numChildren",
     "Domain Bucket":"< 1K"
   },
   {
     "Class":"Predicate",
-    "Name":"http:\/\/schema.org\/numChildren-input",
+    "Name":"https://schema.org/numChildren-input",
     "Domain Bucket":"< 1K"
   },
   {
     "Class":"Predicate",
-    "Name":"http:\/\/schema.org\/numChildren-output",
+    "Name":"https://schema.org/numChildren-output",
     "Domain Bucket":"< 1K"
   },
   {
     "Class":"Predicate",
-    "Name":"http:\/\/schema.org\/numConstraints",
+    "Name":"https://schema.org/numConstraints",
     "Domain Bucket":"< 1K"
   },
   {
     "Class":"Predicate",
-    "Name":"http:\/\/schema.org\/numConstraints-input",
+    "Name":"https://schema.org/numConstraints-input",
     "Domain Bucket":"< 1K"
   },
   {
     "Class":"Predicate",
-    "Name":"http:\/\/schema.org\/numConstraints-output",
+    "Name":"https://schema.org/numConstraints-output",
     "Domain Bucket":"< 1K"
   },
   {
     "Class":"Predicate",
-    "Name":"http:\/\/schema.org\/numItems",
+    "Name":"https://schema.org/numItems",
     "Domain Bucket":"< 1K"
   },
   {
     "Class":"Predicate",
-    "Name":"http:\/\/schema.org\/numItems-input",
+    "Name":"https://schema.org/numItems-input",
     "Domain Bucket":"< 1K"
   },
   {
     "Class":"Predicate",
-    "Name":"http:\/\/schema.org\/numItems-output",
+    "Name":"https://schema.org/numItems-output",
     "Domain Bucket":"< 1K"
   },
   {
     "Class":"Predicate",
-    "Name":"http:\/\/schema.org\/numTracks",
+    "Name":"https://schema.org/numTracks",
     "Domain Bucket":"10K - 100K"
   },
   {
     "Class":"Predicate",
-    "Name":"http:\/\/schema.org\/numTracks-input",
+    "Name":"https://schema.org/numTracks-input",
     "Domain Bucket":"< 1K"
   },
   {
     "Class":"Predicate",
-    "Name":"http:\/\/schema.org\/numTracks-output",
+    "Name":"https://schema.org/numTracks-output",
     "Domain Bucket":"< 1K"
   },
   {
     "Class":"Predicate",
-    "Name":"http:\/\/schema.org\/numberOfAccommodationUnits",
+    "Name":"https://schema.org/numberOfAccommodationUnits",
     "Domain Bucket":"1K - 10K"
   },
   {
     "Class":"Predicate",
-    "Name":"http:\/\/schema.org\/numberOfAccommodationUnits-input",
+    "Name":"https://schema.org/numberOfAccommodationUnits-input",
     "Domain Bucket":"< 1K"
   },
   {
     "Class":"Predicate",
-    "Name":"http:\/\/schema.org\/numberOfAccommodationUnits-output",
+    "Name":"https://schema.org/numberOfAccommodationUnits-output",
     "Domain Bucket":"< 1K"
   },
   {
     "Class":"Predicate",
-    "Name":"http:\/\/schema.org\/numberOfAirbags",
+    "Name":"https://schema.org/numberOfAirbags",
     "Domain Bucket":"< 1K"
   },
   {
     "Class":"Predicate",
-    "Name":"http:\/\/schema.org\/numberOfAirbags-input",
+    "Name":"https://schema.org/numberOfAirbags-input",
     "Domain Bucket":"< 1K"
   },
   {
     "Class":"Predicate",
-    "Name":"http:\/\/schema.org\/numberOfAirbags-output",
+    "Name":"https://schema.org/numberOfAirbags-output",
     "Domain Bucket":"< 1K"
   },
   {
     "Class":"Predicate",
-    "Name":"http:\/\/schema.org\/numberOfAvailableAccommodationUnits",
+    "Name":"https://schema.org/numberOfAvailableAccommodationUnits",
     "Domain Bucket":"1K - 10K"
   },
   {
     "Class":"Predicate",
-    "Name":"http:\/\/schema.org\/numberOfAvailableAccommodationUnits-input",
+    "Name":"https://schema.org/numberOfAvailableAccommodationUnits-input",
     "Domain Bucket":"< 1K"
   },
   {
     "Class":"Predicate",
-    "Name":"http:\/\/schema.org\/numberOfAvailableAccommodationUnits-output",
+    "Name":"https://schema.org/numberOfAvailableAccommodationUnits-output",
     "Domain Bucket":"< 1K"
   },
   {
     "Class":"Predicate",
-    "Name":"http:\/\/schema.org\/numberOfAxles",
+    "Name":"https://schema.org/numberOfAxles",
     "Domain Bucket":"1K - 10K"
   },
   {
     "Class":"Predicate",
-    "Name":"http:\/\/schema.org\/numberOfAxles-input",
+    "Name":"https://schema.org/numberOfAxles-input",
     "Domain Bucket":"< 1K"
   },
   {
     "Class":"Predicate",
-    "Name":"http:\/\/schema.org\/numberOfAxles-output",
+    "Name":"https://schema.org/numberOfAxles-output",
     "Domain Bucket":"< 1K"
   },
   {
     "Class":"Predicate",
-    "Name":"http:\/\/schema.org\/numberOfBathroomsTotal",
+    "Name":"https://schema.org/numberOfBathroomsTotal",
     "Domain Bucket":"10K - 100K"
   },
   {
     "Class":"Predicate",
-    "Name":"http:\/\/schema.org\/numberOfBathroomsTotal-input",
+    "Name":"https://schema.org/numberOfBathroomsTotal-input",
     "Domain Bucket":"< 1K"
   },
   {
     "Class":"Predicate",
-    "Name":"http:\/\/schema.org\/numberOfBathroomsTotal-output",
+    "Name":"https://schema.org/numberOfBathroomsTotal-output",
     "Domain Bucket":"< 1K"
   },
   {
     "Class":"Predicate",
-    "Name":"http:\/\/schema.org\/numberOfBedrooms",
+    "Name":"https://schema.org/numberOfBedrooms",
     "Domain Bucket":"100K - 1M"
   },
   {
     "Class":"Predicate",
-    "Name":"http:\/\/schema.org\/numberOfBedrooms-input",
+    "Name":"https://schema.org/numberOfBedrooms-input",
     "Domain Bucket":"< 1K"
   },
   {
     "Class":"Predicate",
-    "Name":"http:\/\/schema.org\/numberOfBedrooms-output",
+    "Name":"https://schema.org/numberOfBedrooms-output",
     "Domain Bucket":"< 1K"
   },
   {
     "Class":"Predicate",
-    "Name":"http:\/\/schema.org\/numberOfBeds",
+    "Name":"https://schema.org/numberOfBeds",
     "Domain Bucket":"10K - 100K"
   },
   {
     "Class":"Predicate",
-    "Name":"http:\/\/schema.org\/numberOfBeds-input",
+    "Name":"https://schema.org/numberOfBeds-input",
     "Domain Bucket":"< 1K"
   },
   {
     "Class":"Predicate",
-    "Name":"http:\/\/schema.org\/numberOfBeds-output",
+    "Name":"https://schema.org/numberOfBeds-output",
     "Domain Bucket":"< 1K"
   },
   {
     "Class":"Predicate",
-    "Name":"http:\/\/schema.org\/numberOfCredits",
+    "Name":"https://schema.org/numberOfCredits",
     "Domain Bucket":"1K - 10K"
   },
   {
     "Class":"Predicate",
-    "Name":"http:\/\/schema.org\/numberOfCredits-input",
+    "Name":"https://schema.org/numberOfCredits-input",
     "Domain Bucket":"< 1K"
   },
   {
     "Class":"Predicate",
-    "Name":"http:\/\/schema.org\/numberOfCredits-output",
+    "Name":"https://schema.org/numberOfCredits-output",
     "Domain Bucket":"< 1K"
   },
   {
     "Class":"Predicate",
-    "Name":"http:\/\/schema.org\/numberOfDoors",
+    "Name":"https://schema.org/numberOfDoors",
     "Domain Bucket":"10K - 100K"
   },
   {
     "Class":"Predicate",
-    "Name":"http:\/\/schema.org\/numberOfDoors-input",
+    "Name":"https://schema.org/numberOfDoors-input",
     "Domain Bucket":"< 1K"
   },
   {
     "Class":"Predicate",
-    "Name":"http:\/\/schema.org\/numberOfDoors-output",
+    "Name":"https://schema.org/numberOfDoors-output",
     "Domain Bucket":"< 1K"
   },
   {
     "Class":"Predicate",
-    "Name":"http:\/\/schema.org\/numberOfEmployees",
+    "Name":"https://schema.org/numberOfEmployees",
     "Domain Bucket":"100K - 1M"
   },
   {
     "Class":"Predicate",
-    "Name":"http:\/\/schema.org\/numberOfEmployees-input",
+    "Name":"https://schema.org/numberOfEmployees-input",
     "Domain Bucket":"< 1K"
   },
   {
     "Class":"Predicate",
-    "Name":"http:\/\/schema.org\/numberOfEmployees-output",
+    "Name":"https://schema.org/numberOfEmployees-output",
     "Domain Bucket":"< 1K"
   },
   {
     "Class":"Predicate",
-    "Name":"http:\/\/schema.org\/numberOfEpisodes",
+    "Name":"https://schema.org/numberOfEpisodes",
     "Domain Bucket":"10K - 100K"
   },
   {
     "Class":"Predicate",
-    "Name":"http:\/\/schema.org\/numberOfEpisodes-input",
+    "Name":"https://schema.org/numberOfEpisodes-input",
     "Domain Bucket":"< 1K"
   },
   {
     "Class":"Predicate",
-    "Name":"http:\/\/schema.org\/numberOfEpisodes-output",
+    "Name":"https://schema.org/numberOfEpisodes-output",
     "Domain Bucket":"< 1K"
   },
   {
     "Class":"Predicate",
-    "Name":"http:\/\/schema.org\/numberOfForwardGears",
+    "Name":"https://schema.org/numberOfForwardGears",
     "Domain Bucket":"1K - 10K"
   },
   {
     "Class":"Predicate",
-    "Name":"http:\/\/schema.org\/numberOfForwardGears-input",
+    "Name":"https://schema.org/numberOfForwardGears-input",
     "Domain Bucket":"< 1K"
   },
   {
     "Class":"Predicate",
-    "Name":"http:\/\/schema.org\/numberOfForwardGears-output",
+    "Name":"https://schema.org/numberOfForwardGears-output",
     "Domain Bucket":"< 1K"
   },
   {
     "Class":"Predicate",
-    "Name":"http:\/\/schema.org\/numberOfFullBathrooms",
+    "Name":"https://schema.org/numberOfFullBathrooms",
     "Domain Bucket":"10K - 100K"
   },
   {
     "Class":"Predicate",
-    "Name":"http:\/\/schema.org\/numberOfFullBathrooms-input",
+    "Name":"https://schema.org/numberOfFullBathrooms-input",
     "Domain Bucket":"< 1K"
   },
   {
     "Class":"Predicate",
-    "Name":"http:\/\/schema.org\/numberOfFullBathrooms-output",
+    "Name":"https://schema.org/numberOfFullBathrooms-output",
     "Domain Bucket":"< 1K"
   },
   {
     "Class":"Predicate",
-    "Name":"http:\/\/schema.org\/numberOfItems",
+    "Name":"https://schema.org/numberOfItems",
     "Domain Bucket":"100K - 1M"
   },
   {
     "Class":"Predicate",
-    "Name":"http:\/\/schema.org\/numberOfItems-input",
+    "Name":"https://schema.org/numberOfItems-input",
     "Domain Bucket":"< 1K"
   },
   {
     "Class":"Predicate",
-    "Name":"http:\/\/schema.org\/numberOfItems-output",
+    "Name":"https://schema.org/numberOfItems-output",
     "Domain Bucket":"< 1K"
   },
   {
     "Class":"Predicate",
-    "Name":"http:\/\/schema.org\/numberOfLoanPayments",
+    "Name":"https://schema.org/numberOfLoanPayments",
     "Domain Bucket":"< 1K"
   },
   {
     "Class":"Predicate",
-    "Name":"http:\/\/schema.org\/numberOfLoanPayments-input",
+    "Name":"https://schema.org/numberOfLoanPayments-input",
     "Domain Bucket":"< 1K"
   },
   {
     "Class":"Predicate",
-    "Name":"http:\/\/schema.org\/numberOfLoanPayments-output",
+    "Name":"https://schema.org/numberOfLoanPayments-output",
     "Domain Bucket":"< 1K"
   },
   {
     "Class":"Predicate",
-    "Name":"http:\/\/schema.org\/numberOfPages",
+    "Name":"https://schema.org/numberOfPages",
     "Domain Bucket":"10K - 100K"
   },
   {
     "Class":"Predicate",
-    "Name":"http:\/\/schema.org\/numberOfPages-input",
+    "Name":"https://schema.org/numberOfPages-input",
     "Domain Bucket":"< 1K"
   },
   {
     "Class":"Predicate",
-    "Name":"http:\/\/schema.org\/numberOfPages-output",
+    "Name":"https://schema.org/numberOfPages-output",
     "Domain Bucket":"< 1K"
   },
   {
     "Class":"Predicate",
-    "Name":"http:\/\/schema.org\/numberOfPartialBathrooms",
+    "Name":"https://schema.org/numberOfPartialBathrooms",
     "Domain Bucket":"1K - 10K"
   },
   {
     "Class":"Predicate",
-    "Name":"http:\/\/schema.org\/numberOfPartialBathrooms-input",
+    "Name":"https://schema.org/numberOfPartialBathrooms-input",
     "Domain Bucket":"< 1K"
   },
   {
     "Class":"Predicate",
-    "Name":"http:\/\/schema.org\/numberOfPartialBathrooms-output",
+    "Name":"https://schema.org/numberOfPartialBathrooms-output",
     "Domain Bucket":"< 1K"
   },
   {
     "Class":"Predicate",
-    "Name":"http:\/\/schema.org\/numberOfPlayers",
+    "Name":"https://schema.org/numberOfPlayers",
     "Domain Bucket":"10K - 100K"
   },
   {
     "Class":"Predicate",
-    "Name":"http:\/\/schema.org\/numberOfPlayers-input",
+    "Name":"https://schema.org/numberOfPlayers-input",
     "Domain Bucket":"< 1K"
   },
   {
     "Class":"Predicate",
-    "Name":"http:\/\/schema.org\/numberOfPlayers-output",
+    "Name":"https://schema.org/numberOfPlayers-output",
     "Domain Bucket":"< 1K"
   },
   {
     "Class":"Predicate",
-    "Name":"http:\/\/schema.org\/numberOfPreviousOwners",
+    "Name":"https://schema.org/numberOfPreviousOwners",
     "Domain Bucket":"1K - 10K"
   },
   {
     "Class":"Predicate",
-    "Name":"http:\/\/schema.org\/numberOfPreviousOwners-input",
+    "Name":"https://schema.org/numberOfPreviousOwners-input",
     "Domain Bucket":"< 1K"
   },
   {
     "Class":"Predicate",
-    "Name":"http:\/\/schema.org\/numberOfPreviousOwners-output",
+    "Name":"https://schema.org/numberOfPreviousOwners-output",
     "Domain Bucket":"< 1K"
   },
   {
     "Class":"Predicate",
-    "Name":"http:\/\/schema.org\/numberOfRooms",
+    "Name":"https://schema.org/numberOfRooms",
     "Domain Bucket":"10K - 100K"
   },
   {
     "Class":"Predicate",
-    "Name":"http:\/\/schema.org\/numberOfRooms-input",
+    "Name":"https://schema.org/numberOfRooms-input",
     "Domain Bucket":"< 1K"
   },
   {
     "Class":"Predicate",
-    "Name":"http:\/\/schema.org\/numberOfRooms-output",
+    "Name":"https://schema.org/numberOfRooms-output",
     "Domain Bucket":"< 1K"
   },
   {
     "Class":"Predicate",
-    "Name":"http:\/\/schema.org\/numberOfSeasons",
+    "Name":"https://schema.org/numberOfSeasons",
     "Domain Bucket":"1K - 10K"
   },
   {
     "Class":"Predicate",
-    "Name":"http:\/\/schema.org\/numberOfSeasons-input",
+    "Name":"https://schema.org/numberOfSeasons-input",
     "Domain Bucket":"< 1K"
   },
   {
     "Class":"Predicate",
-    "Name":"http:\/\/schema.org\/numberOfSeasons-output",
+    "Name":"https://schema.org/numberOfSeasons-output",
     "Domain Bucket":"< 1K"
   },
   {
     "Class":"Predicate",
-    "Name":"http:\/\/schema.org\/numberedPosition",
+    "Name":"https://schema.org/numberedPosition",
     "Domain Bucket":"< 1K"
   },
   {
     "Class":"Predicate",
-    "Name":"http:\/\/schema.org\/numberedPosition-input",
+    "Name":"https://schema.org/numberedPosition-input",
     "Domain Bucket":"< 1K"
   },
   {
     "Class":"Predicate",
-    "Name":"http:\/\/schema.org\/numberedPosition-output",
+    "Name":"https://schema.org/numberedPosition-output",
     "Domain Bucket":"< 1K"
   },
   {
     "Class":"Predicate",
-    "Name":"http:\/\/schema.org\/nutrition",
+    "Name":"https://schema.org/nutrition",
     "Domain Bucket":"10K - 100K"
   },
   {
     "Class":"Predicate",
-    "Name":"http:\/\/schema.org\/nutrition-input",
+    "Name":"https://schema.org/nutrition-input",
     "Domain Bucket":"< 1K"
   },
   {
     "Class":"Predicate",
-    "Name":"http:\/\/schema.org\/nutrition-output",
+    "Name":"https://schema.org/nutrition-output",
     "Domain Bucket":"< 1K"
   },
   {
     "Class":"Predicate",
-    "Name":"http:\/\/schema.org\/object",
+    "Name":"https://schema.org/object",
     "Domain Bucket":"10K - 100K"
   },
   {
     "Class":"Predicate",
-    "Name":"http:\/\/schema.org\/object-input",
+    "Name":"https://schema.org/object-input",
     "Domain Bucket":"< 1K"
   },
   {
     "Class":"Predicate",
-    "Name":"http:\/\/schema.org\/object-output",
+    "Name":"https://schema.org/object-output",
     "Domain Bucket":"< 1K"
   },
   {
     "Class":"Predicate",
-    "Name":"http:\/\/schema.org\/observationAbout",
+    "Name":"https://schema.org/observationAbout",
     "Domain Bucket":"< 1K"
   },
   {
     "Class":"Predicate",
-    "Name":"http:\/\/schema.org\/observationAbout-input",
+    "Name":"https://schema.org/observationAbout-input",
     "Domain Bucket":"< 1K"
   },
   {
     "Class":"Predicate",
-    "Name":"http:\/\/schema.org\/observationAbout-output",
+    "Name":"https://schema.org/observationAbout-output",
     "Domain Bucket":"< 1K"
   },
   {
     "Class":"Predicate",
-    "Name":"http:\/\/schema.org\/observationDate",
+    "Name":"https://schema.org/observationDate",
     "Domain Bucket":"< 1K"
   },
   {
     "Class":"Predicate",
-    "Name":"http:\/\/schema.org\/observationDate-input",
+    "Name":"https://schema.org/observationDate-input",
     "Domain Bucket":"< 1K"
   },
   {
     "Class":"Predicate",
-    "Name":"http:\/\/schema.org\/observationDate-output",
+    "Name":"https://schema.org/observationDate-output",
     "Domain Bucket":"< 1K"
   },
   {
     "Class":"Predicate",
-    "Name":"http:\/\/schema.org\/observationPeriod",
+    "Name":"https://schema.org/observationPeriod",
     "Domain Bucket":"< 1K"
   },
   {
     "Class":"Predicate",
-    "Name":"http:\/\/schema.org\/observationPeriod-input",
+    "Name":"https://schema.org/observationPeriod-input",
     "Domain Bucket":"< 1K"
   },
   {
     "Class":"Predicate",
-    "Name":"http:\/\/schema.org\/observationPeriod-output",
+    "Name":"https://schema.org/observationPeriod-output",
     "Domain Bucket":"< 1K"
   },
   {
     "Class":"Predicate",
-    "Name":"http:\/\/schema.org\/occupancy",
+    "Name":"https://schema.org/occupancy",
     "Domain Bucket":"10K - 100K"
   },
   {
     "Class":"Predicate",
-    "Name":"http:\/\/schema.org\/occupancy-input",
+    "Name":"https://schema.org/occupancy-input",
     "Domain Bucket":"< 1K"
   },
   {
     "Class":"Predicate",
-    "Name":"http:\/\/schema.org\/occupancy-output",
+    "Name":"https://schema.org/occupancy-output",
     "Domain Bucket":"< 1K"
   },
   {
     "Class":"Predicate",
-    "Name":"http:\/\/schema.org\/occupationLocation",
+    "Name":"https://schema.org/occupationLocation",
     "Domain Bucket":"10K - 100K"
   },
   {
     "Class":"Predicate",
-    "Name":"http:\/\/schema.org\/occupationLocation-input",
+    "Name":"https://schema.org/occupationLocation-input",
     "Domain Bucket":"< 1K"
   },
   {
     "Class":"Predicate",
-    "Name":"http:\/\/schema.org\/occupationLocation-output",
+    "Name":"https://schema.org/occupationLocation-output",
     "Domain Bucket":"< 1K"
   },
   {
     "Class":"Predicate",
-    "Name":"http:\/\/schema.org\/occupationalCategory",
+    "Name":"https://schema.org/occupationalCategory",
     "Domain Bucket":"10K - 100K"
   },
   {
     "Class":"Predicate",
-    "Name":"http:\/\/schema.org\/occupationalCategory-input",
+    "Name":"https://schema.org/occupationalCategory-input",
     "Domain Bucket":"< 1K"
   },
   {
     "Class":"Predicate",
-    "Name":"http:\/\/schema.org\/occupationalCategory-output",
+    "Name":"https://schema.org/occupationalCategory-output",
     "Domain Bucket":"< 1K"
   },
   {
     "Class":"Predicate",
-    "Name":"http:\/\/schema.org\/occupationalCredentialAwarded",
+    "Name":"https://schema.org/occupationalCredentialAwarded",
     "Domain Bucket":"1K - 10K"
   },
   {
     "Class":"Predicate",
-    "Name":"http:\/\/schema.org\/occupationalCredentialAwarded-input",
+    "Name":"https://schema.org/occupationalCredentialAwarded-input",
     "Domain Bucket":"< 1K"
   },
   {
     "Class":"Predicate",
-    "Name":"http:\/\/schema.org\/occupationalCredentialAwarded-output",
+    "Name":"https://schema.org/occupationalCredentialAwarded-output",
     "Domain Bucket":"< 1K"
   },
   {
     "Class":"Predicate",
-    "Name":"http:\/\/schema.org\/offerCount",
+    "Name":"https://schema.org/offerCount",
     "Domain Bucket":"1M - 10M"
   },
   {
     "Class":"Predicate",
-    "Name":"http:\/\/schema.org\/offerCount-input",
+    "Name":"https://schema.org/offerCount-input",
     "Domain Bucket":"< 1K"
   },
   {
     "Class":"Predicate",
-    "Name":"http:\/\/schema.org\/offerCount-output",
+    "Name":"https://schema.org/offerCount-output",
     "Domain Bucket":"< 1K"
   },
   {
     "Class":"Predicate",
-    "Name":"http:\/\/schema.org\/offeredBy",
+    "Name":"https://schema.org/offeredBy",
     "Domain Bucket":"10K - 100K"
   },
   {
     "Class":"Predicate",
-    "Name":"http:\/\/schema.org\/offeredBy-input",
+    "Name":"https://schema.org/offeredBy-input",
     "Domain Bucket":"< 1K"
   },
   {
     "Class":"Predicate",
-    "Name":"http:\/\/schema.org\/offeredBy-output",
+    "Name":"https://schema.org/offeredBy-output",
     "Domain Bucket":"< 1K"
   },
   {
     "Class":"Predicate",
-    "Name":"http:\/\/schema.org\/offers",
+    "Name":"https://schema.org/offers",
     "Domain Bucket":"10M+"
   },
   {
     "Class":"Predicate",
-    "Name":"http:\/\/schema.org\/offers-input",
+    "Name":"https://schema.org/offers-input",
     "Domain Bucket":"< 1K"
   },
   {
     "Class":"Predicate",
-    "Name":"http:\/\/schema.org\/offers-output",
+    "Name":"https://schema.org/offers-output",
     "Domain Bucket":"< 1K"
   },
   {
     "Class":"Predicate",
-    "Name":"http:\/\/schema.org\/offersPrescriptionByMail",
+    "Name":"https://schema.org/offersPrescriptionByMail",
     "Domain Bucket":"< 1K"
   },
   {
     "Class":"Predicate",
-    "Name":"http:\/\/schema.org\/offersPrescriptionByMail-input",
+    "Name":"https://schema.org/offersPrescriptionByMail-input",
     "Domain Bucket":"< 1K"
   },
   {
     "Class":"Predicate",
-    "Name":"http:\/\/schema.org\/offersPrescriptionByMail-output",
+    "Name":"https://schema.org/offersPrescriptionByMail-output",
     "Domain Bucket":"< 1K"
   },
   {
     "Class":"Predicate",
-    "Name":"http:\/\/schema.org\/openingHours",
+    "Name":"https://schema.org/openingHours",
     "Domain Bucket":"1M - 10M"
   },
   {
     "Class":"Predicate",
-    "Name":"http:\/\/schema.org\/openingHours-input",
+    "Name":"https://schema.org/openingHours-input",
     "Domain Bucket":"< 1K"
   },
   {
     "Class":"Predicate",
-    "Name":"http:\/\/schema.org\/openingHours-output",
+    "Name":"https://schema.org/openingHours-output",
     "Domain Bucket":"< 1K"
   },
   {
     "Class":"Predicate",
-    "Name":"http:\/\/schema.org\/openingHoursSpecification",
+    "Name":"https://schema.org/openingHoursSpecification",
     "Domain Bucket":"1M - 10M"
   },
   {
     "Class":"Predicate",
-    "Name":"http:\/\/schema.org\/openingHoursSpecification-input",
+    "Name":"https://schema.org/openingHoursSpecification-input",
     "Domain Bucket":"< 1K"
   },
   {
     "Class":"Predicate",
-    "Name":"http:\/\/schema.org\/openingHoursSpecification-output",
+    "Name":"https://schema.org/openingHoursSpecification-output",
     "Domain Bucket":"< 1K"
   },
   {
     "Class":"Predicate",
-    "Name":"http:\/\/schema.org\/opens",
+    "Name":"https://schema.org/opens",
     "Domain Bucket":"1M - 10M"
   },
   {
     "Class":"Predicate",
-    "Name":"http:\/\/schema.org\/opens-input",
+    "Name":"https://schema.org/opens-input",
     "Domain Bucket":"< 1K"
   },
   {
     "Class":"Predicate",
-    "Name":"http:\/\/schema.org\/opens-output",
+    "Name":"https://schema.org/opens-output",
     "Domain Bucket":"< 1K"
   },
   {
     "Class":"Predicate",
-    "Name":"http:\/\/schema.org\/operatingSystem",
+    "Name":"https://schema.org/operatingSystem",
     "Domain Bucket":"1M - 10M"
   },
   {
     "Class":"Predicate",
-    "Name":"http:\/\/schema.org\/operatingSystem-input",
+    "Name":"https://schema.org/operatingSystem-input",
     "Domain Bucket":"< 1K"
   },
   {
     "Class":"Predicate",
-    "Name":"http:\/\/schema.org\/operatingSystem-output",
+    "Name":"https://schema.org/operatingSystem-output",
     "Domain Bucket":"< 1K"
   },
   {
     "Class":"Predicate",
-    "Name":"http:\/\/schema.org\/opponent",
+    "Name":"https://schema.org/opponent",
     "Domain Bucket":"< 1K"
   },
   {
     "Class":"Predicate",
-    "Name":"http:\/\/schema.org\/opponent-input",
+    "Name":"https://schema.org/opponent-input",
     "Domain Bucket":"< 1K"
   },
   {
     "Class":"Predicate",
-    "Name":"http:\/\/schema.org\/opponent-output",
+    "Name":"https://schema.org/opponent-output",
     "Domain Bucket":"< 1K"
   },
   {
     "Class":"Predicate",
-    "Name":"http:\/\/schema.org\/option",
+    "Name":"https://schema.org/option",
     "Domain Bucket":"< 1K"
   },
   {
     "Class":"Predicate",
-    "Name":"http:\/\/schema.org\/option-input",
+    "Name":"https://schema.org/option-input",
     "Domain Bucket":"< 1K"
   },
   {
     "Class":"Predicate",
-    "Name":"http:\/\/schema.org\/option-output",
+    "Name":"https://schema.org/option-output",
     "Domain Bucket":"< 1K"
   },
   {
     "Class":"Predicate",
-    "Name":"http:\/\/schema.org\/orderDate",
+    "Name":"https://schema.org/orderDate",
     "Domain Bucket":"< 1K"
   },
   {
     "Class":"Predicate",
-    "Name":"http:\/\/schema.org\/orderDate-input",
+    "Name":"https://schema.org/orderDate-input",
     "Domain Bucket":"< 1K"
   },
   {
     "Class":"Predicate",
-    "Name":"http:\/\/schema.org\/orderDate-output",
+    "Name":"https://schema.org/orderDate-output",
     "Domain Bucket":"< 1K"
   },
   {
     "Class":"Predicate",
-    "Name":"http:\/\/schema.org\/orderDelivery",
+    "Name":"https://schema.org/orderDelivery",
     "Domain Bucket":"< 1K"
   },
   {
     "Class":"Predicate",
-    "Name":"http:\/\/schema.org\/orderDelivery-input",
+    "Name":"https://schema.org/orderDelivery-input",
     "Domain Bucket":"< 1K"
   },
   {
     "Class":"Predicate",
-    "Name":"http:\/\/schema.org\/orderDelivery-output",
+    "Name":"https://schema.org/orderDelivery-output",
     "Domain Bucket":"< 1K"
   },
   {
     "Class":"Predicate",
-    "Name":"http:\/\/schema.org\/orderItemNumber",
+    "Name":"https://schema.org/orderItemNumber",
     "Domain Bucket":"< 1K"
   },
   {
     "Class":"Predicate",
-    "Name":"http:\/\/schema.org\/orderItemNumber-input",
+    "Name":"https://schema.org/orderItemNumber-input",
     "Domain Bucket":"< 1K"
   },
   {
     "Class":"Predicate",
-    "Name":"http:\/\/schema.org\/orderItemNumber-output",
+    "Name":"https://schema.org/orderItemNumber-output",
     "Domain Bucket":"< 1K"
   },
   {
     "Class":"Predicate",
-    "Name":"http:\/\/schema.org\/orderItemStatus",
+    "Name":"https://schema.org/orderItemStatus",
     "Domain Bucket":"< 1K"
   },
   {
     "Class":"Predicate",
-    "Name":"http:\/\/schema.org\/orderItemStatus-input",
+    "Name":"https://schema.org/orderItemStatus-input",
     "Domain Bucket":"< 1K"
   },
   {
     "Class":"Predicate",
-    "Name":"http:\/\/schema.org\/orderItemStatus-output",
+    "Name":"https://schema.org/orderItemStatus-output",
     "Domain Bucket":"< 1K"
   },
   {
     "Class":"Predicate",
-    "Name":"http:\/\/schema.org\/orderNumber",
+    "Name":"https://schema.org/orderNumber",
     "Domain Bucket":"< 1K"
   },
   {
     "Class":"Predicate",
-    "Name":"http:\/\/schema.org\/orderNumber-input",
+    "Name":"https://schema.org/orderNumber-input",
     "Domain Bucket":"< 1K"
   },
   {
     "Class":"Predicate",
-    "Name":"http:\/\/schema.org\/orderNumber-output",
+    "Name":"https://schema.org/orderNumber-output",
     "Domain Bucket":"< 1K"
   },
   {
     "Class":"Predicate",
-    "Name":"http:\/\/schema.org\/orderPercentage",
+    "Name":"https://schema.org/orderPercentage",
     "Domain Bucket":"< 1K"
   },
   {
     "Class":"Predicate",
-    "Name":"http:\/\/schema.org\/orderPercentage-input",
+    "Name":"https://schema.org/orderPercentage-input",
     "Domain Bucket":"< 1K"
   },
   {
     "Class":"Predicate",
-    "Name":"http:\/\/schema.org\/orderPercentage-output",
+    "Name":"https://schema.org/orderPercentage-output",
     "Domain Bucket":"< 1K"
   },
   {
     "Class":"Predicate",
-    "Name":"http:\/\/schema.org\/orderQuantity",
+    "Name":"https://schema.org/orderQuantity",
     "Domain Bucket":"< 1K"
   },
   {
     "Class":"Predicate",
-    "Name":"http:\/\/schema.org\/orderQuantity-input",
+    "Name":"https://schema.org/orderQuantity-input",
     "Domain Bucket":"< 1K"
   },
   {
     "Class":"Predicate",
-    "Name":"http:\/\/schema.org\/orderQuantity-output",
+    "Name":"https://schema.org/orderQuantity-output",
     "Domain Bucket":"< 1K"
   },
   {
     "Class":"Predicate",
-    "Name":"http:\/\/schema.org\/orderStatus",
+    "Name":"https://schema.org/orderStatus",
     "Domain Bucket":"< 1K"
   },
   {
     "Class":"Predicate",
-    "Name":"http:\/\/schema.org\/orderStatus-input",
+    "Name":"https://schema.org/orderStatus-input",
     "Domain Bucket":"< 1K"
   },
   {
     "Class":"Predicate",
-    "Name":"http:\/\/schema.org\/orderStatus-output",
+    "Name":"https://schema.org/orderStatus-output",
     "Domain Bucket":"< 1K"
   },
   {
     "Class":"Predicate",
-    "Name":"http:\/\/schema.org\/orderValue",
+    "Name":"https://schema.org/orderValue",
     "Domain Bucket":"< 1K"
   },
   {
     "Class":"Predicate",
-    "Name":"http:\/\/schema.org\/orderValue-input",
+    "Name":"https://schema.org/orderValue-input",
     "Domain Bucket":"< 1K"
   },
   {
     "Class":"Predicate",
-    "Name":"http:\/\/schema.org\/orderValue-output",
+    "Name":"https://schema.org/orderValue-output",
     "Domain Bucket":"< 1K"
   },
   {
     "Class":"Predicate",
-    "Name":"http:\/\/schema.org\/orderedItem",
+    "Name":"https://schema.org/orderedItem",
     "Domain Bucket":"< 1K"
   },
   {
     "Class":"Predicate",
-    "Name":"http:\/\/schema.org\/orderedItem-input",
+    "Name":"https://schema.org/orderedItem-input",
     "Domain Bucket":"< 1K"
   },
   {
     "Class":"Predicate",
-    "Name":"http:\/\/schema.org\/orderedItem-output",
+    "Name":"https://schema.org/orderedItem-output",
     "Domain Bucket":"< 1K"
   },
   {
     "Class":"Predicate",
-    "Name":"http:\/\/schema.org\/organizer",
+    "Name":"https://schema.org/organizer",
     "Domain Bucket":"100K - 1M"
   },
   {
     "Class":"Predicate",
-    "Name":"http:\/\/schema.org\/organizer-input",
+    "Name":"https://schema.org/organizer-input",
     "Domain Bucket":"< 1K"
   },
   {
     "Class":"Predicate",
-    "Name":"http:\/\/schema.org\/organizer-output",
+    "Name":"https://schema.org/organizer-output",
     "Domain Bucket":"< 1K"
   },
   {
     "Class":"Predicate",
-    "Name":"http:\/\/schema.org\/originAddress",
+    "Name":"https://schema.org/originAddress",
     "Domain Bucket":"< 1K"
   },
   {
     "Class":"Predicate",
-    "Name":"http:\/\/schema.org\/originAddress-input",
+    "Name":"https://schema.org/originAddress-input",
     "Domain Bucket":"< 1K"
   },
   {
     "Class":"Predicate",
-    "Name":"http:\/\/schema.org\/originAddress-output",
+    "Name":"https://schema.org/originAddress-output",
     "Domain Bucket":"< 1K"
   },
   {
     "Class":"Predicate",
-    "Name":"http:\/\/schema.org\/originalMediaContextDescription",
+    "Name":"https://schema.org/originalMediaContextDescription",
     "Domain Bucket":"< 1K"
   },
   {
     "Class":"Predicate",
-    "Name":"http:\/\/schema.org\/originalMediaContextDescription-input",
+    "Name":"https://schema.org/originalMediaContextDescription-input",
     "Domain Bucket":"< 1K"
   },
   {
     "Class":"Predicate",
-    "Name":"http:\/\/schema.org\/originalMediaContextDescription-output",
+    "Name":"https://schema.org/originalMediaContextDescription-output",
     "Domain Bucket":"< 1K"
   },
   {
     "Class":"Predicate",
-    "Name":"http:\/\/schema.org\/originalMediaLink",
+    "Name":"https://schema.org/originalMediaLink",
     "Domain Bucket":"< 1K"
   },
   {
     "Class":"Predicate",
-    "Name":"http:\/\/schema.org\/originalMediaLink-input",
+    "Name":"https://schema.org/originalMediaLink-input",
     "Domain Bucket":"< 1K"
   },
   {
     "Class":"Predicate",
-    "Name":"http:\/\/schema.org\/originalMediaLink-output",
+    "Name":"https://schema.org/originalMediaLink-output",
     "Domain Bucket":"< 1K"
   },
   {
     "Class":"Predicate",
-    "Name":"http:\/\/schema.org\/originatesFrom",
+    "Name":"https://schema.org/originatesFrom",
     "Domain Bucket":"< 1K"
   },
   {
     "Class":"Predicate",
-    "Name":"http:\/\/schema.org\/originatesFrom-input",
+    "Name":"https://schema.org/originatesFrom-input",
     "Domain Bucket":"< 1K"
   },
   {
     "Class":"Predicate",
-    "Name":"http:\/\/schema.org\/originatesFrom-output",
+    "Name":"https://schema.org/originatesFrom-output",
     "Domain Bucket":"< 1K"
   },
   {
     "Class":"Predicate",
-    "Name":"http:\/\/schema.org\/overdosage",
+    "Name":"https://schema.org/overdosage",
     "Domain Bucket":"< 1K"
   },
   {
     "Class":"Predicate",
-    "Name":"http:\/\/schema.org\/overdosage-input",
+    "Name":"https://schema.org/overdosage-input",
     "Domain Bucket":"< 1K"
   },
   {
     "Class":"Predicate",
-    "Name":"http:\/\/schema.org\/overdosage-output",
+    "Name":"https://schema.org/overdosage-output",
     "Domain Bucket":"< 1K"
   },
   {
     "Class":"Predicate",
-    "Name":"http:\/\/schema.org\/ownedFrom",
+    "Name":"https://schema.org/ownedFrom",
     "Domain Bucket":"< 1K"
   },
   {
     "Class":"Predicate",
-    "Name":"http:\/\/schema.org\/ownedFrom-input",
+    "Name":"https://schema.org/ownedFrom-input",
     "Domain Bucket":"< 1K"
   },
   {
     "Class":"Predicate",
-    "Name":"http:\/\/schema.org\/ownedFrom-output",
+    "Name":"https://schema.org/ownedFrom-output",
     "Domain Bucket":"< 1K"
   },
   {
     "Class":"Predicate",
-    "Name":"http:\/\/schema.org\/ownedThrough",
+    "Name":"https://schema.org/ownedThrough",
     "Domain Bucket":"< 1K"
   },
   {
     "Class":"Predicate",
-    "Name":"http:\/\/schema.org\/ownedThrough-input",
+    "Name":"https://schema.org/ownedThrough-input",
     "Domain Bucket":"< 1K"
   },
   {
     "Class":"Predicate",
-    "Name":"http:\/\/schema.org\/ownedThrough-output",
+    "Name":"https://schema.org/ownedThrough-output",
     "Domain Bucket":"< 1K"
   },
   {
     "Class":"Predicate",
-    "Name":"http:\/\/schema.org\/owner",
+    "Name":"https://schema.org/owner",
     "Domain Bucket":"1K - 10K"
   },
   {
     "Class":"Predicate",
-    "Name":"http:\/\/schema.org\/owner-input",
+    "Name":"https://schema.org/owner-input",
     "Domain Bucket":"< 1K"
   },
   {
     "Class":"Predicate",
-    "Name":"http:\/\/schema.org\/owner-output",
+    "Name":"https://schema.org/owner-output",
     "Domain Bucket":"< 1K"
   },
   {
     "Class":"Predicate",
-    "Name":"http:\/\/schema.org\/ownershipFundingInfo",
+    "Name":"https://schema.org/ownershipFundingInfo",
     "Domain Bucket":"10K - 100K"
   },
   {
     "Class":"Predicate",
-    "Name":"http:\/\/schema.org\/ownershipFundingInfo-input",
+    "Name":"https://schema.org/ownershipFundingInfo-input",
     "Domain Bucket":"< 1K"
   },
   {
     "Class":"Predicate",
-    "Name":"http:\/\/schema.org\/ownershipFundingInfo-output",
+    "Name":"https://schema.org/ownershipFundingInfo-output",
     "Domain Bucket":"< 1K"
   },
   {
     "Class":"Predicate",
-    "Name":"http:\/\/schema.org\/owns",
+    "Name":"https://schema.org/owns",
     "Domain Bucket":"10K - 100K"
   },
   {
     "Class":"Predicate",
-    "Name":"http:\/\/schema.org\/owns-input",
+    "Name":"https://schema.org/owns-input",
     "Domain Bucket":"< 1K"
   },
   {
     "Class":"Predicate",
-    "Name":"http:\/\/schema.org\/owns-output",
+    "Name":"https://schema.org/owns-output",
     "Domain Bucket":"< 1K"
   },
   {
     "Class":"Predicate",
-    "Name":"http:\/\/schema.org\/pageEnd",
+    "Name":"https://schema.org/pageEnd",
     "Domain Bucket":"1K - 10K"
   },
   {
     "Class":"Predicate",
-    "Name":"http:\/\/schema.org\/pageEnd-input",
+    "Name":"https://schema.org/pageEnd-input",
     "Domain Bucket":"< 1K"
   },
   {
     "Class":"Predicate",
-    "Name":"http:\/\/schema.org\/pageEnd-output",
+    "Name":"https://schema.org/pageEnd-output",
     "Domain Bucket":"< 1K"
   },
   {
     "Class":"Predicate",
-    "Name":"http:\/\/schema.org\/pageStart",
+    "Name":"https://schema.org/pageStart",
     "Domain Bucket":"1K - 10K"
   },
   {
     "Class":"Predicate",
-    "Name":"http:\/\/schema.org\/pageStart-input",
+    "Name":"https://schema.org/pageStart-input",
     "Domain Bucket":"< 1K"
   },
   {
     "Class":"Predicate",
-    "Name":"http:\/\/schema.org\/pageStart-output",
+    "Name":"https://schema.org/pageStart-output",
     "Domain Bucket":"< 1K"
   },
   {
     "Class":"Predicate",
-    "Name":"http:\/\/schema.org\/pagination",
+    "Name":"https://schema.org/pagination",
     "Domain Bucket":"1K - 10K"
   },
   {
     "Class":"Predicate",
-    "Name":"http:\/\/schema.org\/pagination-input",
+    "Name":"https://schema.org/pagination-input",
     "Domain Bucket":"< 1K"
   },
   {
     "Class":"Predicate",
-    "Name":"http:\/\/schema.org\/pagination-output",
+    "Name":"https://schema.org/pagination-output",
     "Domain Bucket":"< 1K"
   },
   {
     "Class":"Predicate",
-    "Name":"http:\/\/schema.org\/parent",
+    "Name":"https://schema.org/parent",
     "Domain Bucket":"1K - 10K"
   },
   {
     "Class":"Predicate",
-    "Name":"http:\/\/schema.org\/parent-input",
+    "Name":"https://schema.org/parent-input",
     "Domain Bucket":"< 1K"
   },
   {
     "Class":"Predicate",
-    "Name":"http:\/\/schema.org\/parent-output",
+    "Name":"https://schema.org/parent-output",
     "Domain Bucket":"< 1K"
   },
   {
     "Class":"Predicate",
-    "Name":"http:\/\/schema.org\/parentItem",
+    "Name":"https://schema.org/parentItem",
     "Domain Bucket":"1K - 10K"
   },
   {
     "Class":"Predicate",
-    "Name":"http:\/\/schema.org\/parentItem-input",
+    "Name":"https://schema.org/parentItem-input",
     "Domain Bucket":"< 1K"
   },
   {
     "Class":"Predicate",
-    "Name":"http:\/\/schema.org\/parentItem-output",
+    "Name":"https://schema.org/parentItem-output",
     "Domain Bucket":"< 1K"
   },
   {
     "Class":"Predicate",
-    "Name":"http:\/\/schema.org\/parentOrganization",
+    "Name":"https://schema.org/parentOrganization",
     "Domain Bucket":"100K - 1M"
   },
   {
     "Class":"Predicate",
-    "Name":"http:\/\/schema.org\/parentOrganization-input",
+    "Name":"https://schema.org/parentOrganization-input",
     "Domain Bucket":"< 1K"
   },
   {
     "Class":"Predicate",
-    "Name":"http:\/\/schema.org\/parentOrganization-output",
+    "Name":"https://schema.org/parentOrganization-output",
     "Domain Bucket":"< 1K"
   },
   {
     "Class":"Predicate",
-    "Name":"http:\/\/schema.org\/parentService",
+    "Name":"https://schema.org/parentService",
     "Domain Bucket":"< 1K"
   },
   {
     "Class":"Predicate",
-    "Name":"http:\/\/schema.org\/parentService-input",
+    "Name":"https://schema.org/parentService-input",
     "Domain Bucket":"< 1K"
   },
   {
     "Class":"Predicate",
-    "Name":"http:\/\/schema.org\/parentService-output",
+    "Name":"https://schema.org/parentService-output",
     "Domain Bucket":"< 1K"
   },
   {
     "Class":"Predicate",
-    "Name":"http:\/\/schema.org\/parentTaxon",
+    "Name":"https://schema.org/parentTaxon",
     "Domain Bucket":"< 1K"
   },
   {
     "Class":"Predicate",
-    "Name":"http:\/\/schema.org\/parentTaxon-input",
+    "Name":"https://schema.org/parentTaxon-input",
     "Domain Bucket":"< 1K"
   },
   {
     "Class":"Predicate",
-    "Name":"http:\/\/schema.org\/parentTaxon-output",
+    "Name":"https://schema.org/parentTaxon-output",
     "Domain Bucket":"< 1K"
   },
   {
     "Class":"Predicate",
-    "Name":"http:\/\/schema.org\/parents",
+    "Name":"https://schema.org/parents",
     "Domain Bucket":"< 1K"
   },
   {
     "Class":"Predicate",
-    "Name":"http:\/\/schema.org\/parents-input",
+    "Name":"https://schema.org/parents-input",
     "Domain Bucket":"< 1K"
   },
   {
     "Class":"Predicate",
-    "Name":"http:\/\/schema.org\/parents-output",
+    "Name":"https://schema.org/parents-output",
     "Domain Bucket":"< 1K"
   },
   {
     "Class":"Predicate",
-    "Name":"http:\/\/schema.org\/partOfEpisode",
+    "Name":"https://schema.org/partOfEpisode",
     "Domain Bucket":"< 1K"
   },
   {
     "Class":"Predicate",
-    "Name":"http:\/\/schema.org\/partOfEpisode-input",
+    "Name":"https://schema.org/partOfEpisode-input",
     "Domain Bucket":"< 1K"
   },
   {
     "Class":"Predicate",
-    "Name":"http:\/\/schema.org\/partOfEpisode-output",
+    "Name":"https://schema.org/partOfEpisode-output",
     "Domain Bucket":"< 1K"
   },
   {
     "Class":"Predicate",
-    "Name":"http:\/\/schema.org\/partOfInvoice",
+    "Name":"https://schema.org/partOfInvoice",
     "Domain Bucket":"< 1K"
   },
   {
     "Class":"Predicate",
-    "Name":"http:\/\/schema.org\/partOfInvoice-input",
+    "Name":"https://schema.org/partOfInvoice-input",
     "Domain Bucket":"< 1K"
   },
   {
     "Class":"Predicate",
-    "Name":"http:\/\/schema.org\/partOfInvoice-output",
+    "Name":"https://schema.org/partOfInvoice-output",
     "Domain Bucket":"< 1K"
   },
   {
     "Class":"Predicate",
-    "Name":"http:\/\/schema.org\/partOfOrder",
+    "Name":"https://schema.org/partOfOrder",
     "Domain Bucket":"< 1K"
   },
   {
     "Class":"Predicate",
-    "Name":"http:\/\/schema.org\/partOfOrder-input",
+    "Name":"https://schema.org/partOfOrder-input",
     "Domain Bucket":"< 1K"
   },
   {
     "Class":"Predicate",
-    "Name":"http:\/\/schema.org\/partOfOrder-output",
+    "Name":"https://schema.org/partOfOrder-output",
     "Domain Bucket":"< 1K"
   },
   {
     "Class":"Predicate",
-    "Name":"http:\/\/schema.org\/partOfSeason",
+    "Name":"https://schema.org/partOfSeason",
     "Domain Bucket":"1K - 10K"
   },
   {
     "Class":"Predicate",
-    "Name":"http:\/\/schema.org\/partOfSeason-input",
+    "Name":"https://schema.org/partOfSeason-input",
     "Domain Bucket":"< 1K"
   },
   {
     "Class":"Predicate",
-    "Name":"http:\/\/schema.org\/partOfSeason-output",
+    "Name":"https://schema.org/partOfSeason-output",
     "Domain Bucket":"< 1K"
   },
   {
     "Class":"Predicate",
-    "Name":"http:\/\/schema.org\/partOfSeries",
+    "Name":"https://schema.org/partOfSeries",
     "Domain Bucket":"10K - 100K"
   },
   {
     "Class":"Predicate",
-    "Name":"http:\/\/schema.org\/partOfSeries-input",
+    "Name":"https://schema.org/partOfSeries-input",
     "Domain Bucket":"< 1K"
   },
   {
     "Class":"Predicate",
-    "Name":"http:\/\/schema.org\/partOfSeries-output",
+    "Name":"https://schema.org/partOfSeries-output",
     "Domain Bucket":"< 1K"
   },
   {
     "Class":"Predicate",
-    "Name":"http:\/\/schema.org\/partOfSystem",
+    "Name":"https://schema.org/partOfSystem",
     "Domain Bucket":"< 1K"
   },
   {
     "Class":"Predicate",
-    "Name":"http:\/\/schema.org\/partOfSystem-input",
+    "Name":"https://schema.org/partOfSystem-input",
     "Domain Bucket":"< 1K"
   },
   {
     "Class":"Predicate",
-    "Name":"http:\/\/schema.org\/partOfSystem-output",
+    "Name":"https://schema.org/partOfSystem-output",
     "Domain Bucket":"< 1K"
   },
   {
     "Class":"Predicate",
-    "Name":"http:\/\/schema.org\/partOfTVSeries",
+    "Name":"https://schema.org/partOfTVSeries",
     "Domain Bucket":"< 1K"
   },
   {
     "Class":"Predicate",
-    "Name":"http:\/\/schema.org\/partOfTVSeries-input",
+    "Name":"https://schema.org/partOfTVSeries-input",
     "Domain Bucket":"< 1K"
   },
   {
     "Class":"Predicate",
-    "Name":"http:\/\/schema.org\/partOfTVSeries-output",
+    "Name":"https://schema.org/partOfTVSeries-output",
     "Domain Bucket":"< 1K"
   },
   {
     "Class":"Predicate",
-    "Name":"http:\/\/schema.org\/partOfTrip",
+    "Name":"https://schema.org/partOfTrip",
     "Domain Bucket":"< 1K"
   },
   {
     "Class":"Predicate",
-    "Name":"http:\/\/schema.org\/partOfTrip-input",
+    "Name":"https://schema.org/partOfTrip-input",
     "Domain Bucket":"< 1K"
   },
   {
     "Class":"Predicate",
-    "Name":"http:\/\/schema.org\/partOfTrip-output",
+    "Name":"https://schema.org/partOfTrip-output",
     "Domain Bucket":"< 1K"
   },
   {
     "Class":"Predicate",
-    "Name":"http:\/\/schema.org\/participant",
+    "Name":"https://schema.org/participant",
     "Domain Bucket":"1K - 10K"
   },
   {
     "Class":"Predicate",
-    "Name":"http:\/\/schema.org\/participant-input",
+    "Name":"https://schema.org/participant-input",
     "Domain Bucket":"< 1K"
   },
   {
     "Class":"Predicate",
-    "Name":"http:\/\/schema.org\/participant-output",
+    "Name":"https://schema.org/participant-output",
     "Domain Bucket":"< 1K"
   },
   {
     "Class":"Predicate",
-    "Name":"http:\/\/schema.org\/partySize",
+    "Name":"https://schema.org/partySize",
     "Domain Bucket":"< 1K"
   },
   {
     "Class":"Predicate",
-    "Name":"http:\/\/schema.org\/partySize-input",
+    "Name":"https://schema.org/partySize-input",
     "Domain Bucket":"< 1K"
   },
   {
     "Class":"Predicate",
-    "Name":"http:\/\/schema.org\/partySize-output",
+    "Name":"https://schema.org/partySize-output",
     "Domain Bucket":"< 1K"
   },
   {
     "Class":"Predicate",
-    "Name":"http:\/\/schema.org\/passengerPriorityStatus",
+    "Name":"https://schema.org/passengerPriorityStatus",
     "Domain Bucket":"< 1K"
   },
   {
     "Class":"Predicate",
-    "Name":"http:\/\/schema.org\/passengerPriorityStatus-input",
+    "Name":"https://schema.org/passengerPriorityStatus-input",
     "Domain Bucket":"< 1K"
   },
   {
     "Class":"Predicate",
-    "Name":"http:\/\/schema.org\/passengerPriorityStatus-output",
+    "Name":"https://schema.org/passengerPriorityStatus-output",
     "Domain Bucket":"< 1K"
   },
   {
     "Class":"Predicate",
-    "Name":"http:\/\/schema.org\/passengerSequenceNumber",
+    "Name":"https://schema.org/passengerSequenceNumber",
     "Domain Bucket":"< 1K"
   },
   {
     "Class":"Predicate",
-    "Name":"http:\/\/schema.org\/passengerSequenceNumber-input",
+    "Name":"https://schema.org/passengerSequenceNumber-input",
     "Domain Bucket":"< 1K"
   },
   {
     "Class":"Predicate",
-    "Name":"http:\/\/schema.org\/passengerSequenceNumber-output",
+    "Name":"https://schema.org/passengerSequenceNumber-output",
     "Domain Bucket":"< 1K"
   },
   {
     "Class":"Predicate",
-    "Name":"http:\/\/schema.org\/pathophysiology",
+    "Name":"https://schema.org/pathophysiology",
     "Domain Bucket":"< 1K"
   },
   {
     "Class":"Predicate",
-    "Name":"http:\/\/schema.org\/pathophysiology-input",
+    "Name":"https://schema.org/pathophysiology-input",
     "Domain Bucket":"< 1K"
   },
   {
     "Class":"Predicate",
-    "Name":"http:\/\/schema.org\/pathophysiology-output",
+    "Name":"https://schema.org/pathophysiology-output",
     "Domain Bucket":"< 1K"
   },
   {
     "Class":"Predicate",
-    "Name":"http:\/\/schema.org\/pattern",
+    "Name":"https://schema.org/pattern",
     "Domain Bucket":"1K - 10K"
   },
   {
     "Class":"Predicate",
-    "Name":"http:\/\/schema.org\/pattern-input",
+    "Name":"https://schema.org/pattern-input",
     "Domain Bucket":"< 1K"
   },
   {
     "Class":"Predicate",
-    "Name":"http:\/\/schema.org\/pattern-output",
+    "Name":"https://schema.org/pattern-output",
     "Domain Bucket":"< 1K"
   },
   {
     "Class":"Predicate",
-    "Name":"http:\/\/schema.org\/payload",
+    "Name":"https://schema.org/payload",
     "Domain Bucket":"1K - 10K"
   },
   {
     "Class":"Predicate",
-    "Name":"http:\/\/schema.org\/payload-input",
+    "Name":"https://schema.org/payload-input",
     "Domain Bucket":"< 1K"
   },
   {
     "Class":"Predicate",
-    "Name":"http:\/\/schema.org\/payload-output",
+    "Name":"https://schema.org/payload-output",
     "Domain Bucket":"< 1K"
   },
   {
     "Class":"Predicate",
-    "Name":"http:\/\/schema.org\/paymentAccepted",
+    "Name":"https://schema.org/paymentAccepted",
     "Domain Bucket":"100K - 1M"
   },
   {
     "Class":"Predicate",
-    "Name":"http:\/\/schema.org\/paymentAccepted-input",
+    "Name":"https://schema.org/paymentAccepted-input",
     "Domain Bucket":"< 1K"
   },
   {
     "Class":"Predicate",
-    "Name":"http:\/\/schema.org\/paymentAccepted-output",
+    "Name":"https://schema.org/paymentAccepted-output",
     "Domain Bucket":"< 1K"
   },
   {
     "Class":"Predicate",
-    "Name":"http:\/\/schema.org\/paymentDue",
+    "Name":"https://schema.org/paymentDue",
     "Domain Bucket":"< 1K"
   },
   {
     "Class":"Predicate",
-    "Name":"http:\/\/schema.org\/paymentDue-input",
+    "Name":"https://schema.org/paymentDue-input",
     "Domain Bucket":"< 1K"
   },
   {
     "Class":"Predicate",
-    "Name":"http:\/\/schema.org\/paymentDue-output",
+    "Name":"https://schema.org/paymentDue-output",
     "Domain Bucket":"< 1K"
   },
   {
     "Class":"Predicate",
-    "Name":"http:\/\/schema.org\/paymentDueDate",
+    "Name":"https://schema.org/paymentDueDate",
     "Domain Bucket":"< 1K"
   },
   {
     "Class":"Predicate",
-    "Name":"http:\/\/schema.org\/paymentDueDate-input",
+    "Name":"https://schema.org/paymentDueDate-input",
     "Domain Bucket":"< 1K"
   },
   {
     "Class":"Predicate",
-    "Name":"http:\/\/schema.org\/paymentDueDate-output",
+    "Name":"https://schema.org/paymentDueDate-output",
     "Domain Bucket":"< 1K"
   },
   {
     "Class":"Predicate",
-    "Name":"http:\/\/schema.org\/paymentMethod",
+    "Name":"https://schema.org/paymentMethod",
     "Domain Bucket":"< 1K"
   },
   {
     "Class":"Predicate",
-    "Name":"http:\/\/schema.org\/paymentMethod-input",
+    "Name":"https://schema.org/paymentMethod-input",
     "Domain Bucket":"< 1K"
   },
   {
     "Class":"Predicate",
-    "Name":"http:\/\/schema.org\/paymentMethod-output",
+    "Name":"https://schema.org/paymentMethod-output",
     "Domain Bucket":"< 1K"
   },
   {
     "Class":"Predicate",
-    "Name":"http:\/\/schema.org\/paymentMethodId",
+    "Name":"https://schema.org/paymentMethodId",
     "Domain Bucket":"< 1K"
   },
   {
     "Class":"Predicate",
-    "Name":"http:\/\/schema.org\/paymentMethodId-input",
+    "Name":"https://schema.org/paymentMethodId-input",
     "Domain Bucket":"< 1K"
   },
   {
     "Class":"Predicate",
-    "Name":"http:\/\/schema.org\/paymentMethodId-output",
+    "Name":"https://schema.org/paymentMethodId-output",
     "Domain Bucket":"< 1K"
   },
   {
     "Class":"Predicate",
-    "Name":"http:\/\/schema.org\/paymentMethodType",
+    "Name":"https://schema.org/paymentMethodType",
     "Domain Bucket":"< 1K"
   },
   {
     "Class":"Predicate",
-    "Name":"http:\/\/schema.org\/paymentMethodType-input",
+    "Name":"https://schema.org/paymentMethodType-input",
     "Domain Bucket":"< 1K"
   },
   {
     "Class":"Predicate",
-    "Name":"http:\/\/schema.org\/paymentMethodType-output",
+    "Name":"https://schema.org/paymentMethodType-output",
     "Domain Bucket":"< 1K"
   },
   {
     "Class":"Predicate",
-    "Name":"http:\/\/schema.org\/paymentStatus",
+    "Name":"https://schema.org/paymentStatus",
     "Domain Bucket":"< 1K"
   },
   {
     "Class":"Predicate",
-    "Name":"http:\/\/schema.org\/paymentStatus-input",
+    "Name":"https://schema.org/paymentStatus-input",
     "Domain Bucket":"< 1K"
   },
   {
     "Class":"Predicate",
-    "Name":"http:\/\/schema.org\/paymentStatus-output",
+    "Name":"https://schema.org/paymentStatus-output",
     "Domain Bucket":"< 1K"
   },
   {
     "Class":"Predicate",
-    "Name":"http:\/\/schema.org\/paymentUrl",
+    "Name":"https://schema.org/paymentUrl",
     "Domain Bucket":"< 1K"
   },
   {
     "Class":"Predicate",
-    "Name":"http:\/\/schema.org\/paymentUrl-input",
+    "Name":"https://schema.org/paymentUrl-input",
     "Domain Bucket":"< 1K"
   },
   {
     "Class":"Predicate",
-    "Name":"http:\/\/schema.org\/paymentUrl-output",
+    "Name":"https://schema.org/paymentUrl-output",
     "Domain Bucket":"< 1K"
   },
   {
     "Class":"Predicate",
-    "Name":"http:\/\/schema.org\/penciler",
+    "Name":"https://schema.org/penciler",
     "Domain Bucket":"< 1K"
   },
   {
     "Class":"Predicate",
-    "Name":"http:\/\/schema.org\/penciler-input",
+    "Name":"https://schema.org/penciler-input",
     "Domain Bucket":"< 1K"
   },
   {
     "Class":"Predicate",
-    "Name":"http:\/\/schema.org\/penciler-output",
+    "Name":"https://schema.org/penciler-output",
     "Domain Bucket":"< 1K"
   },
   {
     "Class":"Predicate",
-    "Name":"http:\/\/schema.org\/percentile10",
+    "Name":"https://schema.org/percentile10",
     "Domain Bucket":"1K - 10K"
   },
   {
     "Class":"Predicate",
-    "Name":"http:\/\/schema.org\/percentile10-input",
+    "Name":"https://schema.org/percentile10-input",
     "Domain Bucket":"< 1K"
   },
   {
     "Class":"Predicate",
-    "Name":"http:\/\/schema.org\/percentile10-output",
+    "Name":"https://schema.org/percentile10-output",
     "Domain Bucket":"< 1K"
   },
   {
     "Class":"Predicate",
-    "Name":"http:\/\/schema.org\/percentile25",
+    "Name":"https://schema.org/percentile25",
     "Domain Bucket":"1K - 10K"
   },
   {
     "Class":"Predicate",
-    "Name":"http:\/\/schema.org\/percentile25-input",
+    "Name":"https://schema.org/percentile25-input",
     "Domain Bucket":"< 1K"
   },
   {
     "Class":"Predicate",
-    "Name":"http:\/\/schema.org\/percentile25-output",
+    "Name":"https://schema.org/percentile25-output",
     "Domain Bucket":"< 1K"
   },
   {
     "Class":"Predicate",
-    "Name":"http:\/\/schema.org\/percentile75",
+    "Name":"https://schema.org/percentile75",
     "Domain Bucket":"1K - 10K"
   },
   {
     "Class":"Predicate",
-    "Name":"http:\/\/schema.org\/percentile75-input",
+    "Name":"https://schema.org/percentile75-input",
     "Domain Bucket":"< 1K"
   },
   {
     "Class":"Predicate",
-    "Name":"http:\/\/schema.org\/percentile75-output",
+    "Name":"https://schema.org/percentile75-output",
     "Domain Bucket":"< 1K"
   },
   {
     "Class":"Predicate",
-    "Name":"http:\/\/schema.org\/percentile90",
+    "Name":"https://schema.org/percentile90",
     "Domain Bucket":"1K - 10K"
   },
   {
     "Class":"Predicate",
-    "Name":"http:\/\/schema.org\/percentile90-input",
+    "Name":"https://schema.org/percentile90-input",
     "Domain Bucket":"< 1K"
   },
   {
     "Class":"Predicate",
-    "Name":"http:\/\/schema.org\/percentile90-output",
+    "Name":"https://schema.org/percentile90-output",
     "Domain Bucket":"< 1K"
   },
   {
     "Class":"Predicate",
-    "Name":"http:\/\/schema.org\/performTime",
+    "Name":"https://schema.org/performTime",
     "Domain Bucket":"10K - 100K"
   },
   {
     "Class":"Predicate",
-    "Name":"http:\/\/schema.org\/performTime-input",
+    "Name":"https://schema.org/performTime-input",
     "Domain Bucket":"< 1K"
   },
   {
     "Class":"Predicate",
-    "Name":"http:\/\/schema.org\/performTime-output",
+    "Name":"https://schema.org/performTime-output",
     "Domain Bucket":"< 1K"
   },
   {
     "Class":"Predicate",
-    "Name":"http:\/\/schema.org\/performer",
+    "Name":"https://schema.org/performer",
     "Domain Bucket":"100K - 1M"
   },
   {
     "Class":"Predicate",
-    "Name":"http:\/\/schema.org\/performer-input",
+    "Name":"https://schema.org/performer-input",
     "Domain Bucket":"< 1K"
   },
   {
     "Class":"Predicate",
-    "Name":"http:\/\/schema.org\/performer-output",
+    "Name":"https://schema.org/performer-output",
     "Domain Bucket":"< 1K"
   },
   {
     "Class":"Predicate",
-    "Name":"http:\/\/schema.org\/performerIn",
+    "Name":"https://schema.org/performerIn",
     "Domain Bucket":"1K - 10K"
   },
   {
     "Class":"Predicate",
-    "Name":"http:\/\/schema.org\/performerIn-input",
+    "Name":"https://schema.org/performerIn-input",
     "Domain Bucket":"< 1K"
   },
   {
     "Class":"Predicate",
-    "Name":"http:\/\/schema.org\/performerIn-output",
+    "Name":"https://schema.org/performerIn-output",
     "Domain Bucket":"< 1K"
   },
   {
     "Class":"Predicate",
-    "Name":"http:\/\/schema.org\/performers",
+    "Name":"https://schema.org/performers",
     "Domain Bucket":"10K - 100K"
   },
   {
     "Class":"Predicate",
-    "Name":"http:\/\/schema.org\/performers-input",
+    "Name":"https://schema.org/performers-input",
     "Domain Bucket":"< 1K"
   },
   {
     "Class":"Predicate",
-    "Name":"http:\/\/schema.org\/performers-output",
+    "Name":"https://schema.org/performers-output",
     "Domain Bucket":"< 1K"
   },
   {
     "Class":"Predicate",
-    "Name":"http:\/\/schema.org\/permissionType",
+    "Name":"https://schema.org/permissionType",
     "Domain Bucket":"< 1K"
   },
   {
     "Class":"Predicate",
-    "Name":"http:\/\/schema.org\/permissionType-input",
+    "Name":"https://schema.org/permissionType-input",
     "Domain Bucket":"< 1K"
   },
   {
     "Class":"Predicate",
-    "Name":"http:\/\/schema.org\/permissionType-output",
+    "Name":"https://schema.org/permissionType-output",
     "Domain Bucket":"< 1K"
   },
   {
     "Class":"Predicate",
-    "Name":"http:\/\/schema.org\/permissions",
+    "Name":"https://schema.org/permissions",
     "Domain Bucket":"10K - 100K"
   },
   {
     "Class":"Predicate",
-    "Name":"http:\/\/schema.org\/permissions-input",
+    "Name":"https://schema.org/permissions-input",
     "Domain Bucket":"< 1K"
   },
   {
     "Class":"Predicate",
-    "Name":"http:\/\/schema.org\/permissions-output",
+    "Name":"https://schema.org/permissions-output",
     "Domain Bucket":"< 1K"
   },
   {
     "Class":"Predicate",
-    "Name":"http:\/\/schema.org\/permitAudience",
+    "Name":"https://schema.org/permitAudience",
     "Domain Bucket":"< 1K"
   },
   {
     "Class":"Predicate",
-    "Name":"http:\/\/schema.org\/permitAudience-input",
+    "Name":"https://schema.org/permitAudience-input",
     "Domain Bucket":"< 1K"
   },
   {
     "Class":"Predicate",
-    "Name":"http:\/\/schema.org\/permitAudience-output",
+    "Name":"https://schema.org/permitAudience-output",
     "Domain Bucket":"< 1K"
   },
   {
     "Class":"Predicate",
-    "Name":"http:\/\/schema.org\/permittedUsage",
+    "Name":"https://schema.org/permittedUsage",
     "Domain Bucket":"< 1K"
   },
   {
     "Class":"Predicate",
-    "Name":"http:\/\/schema.org\/permittedUsage-input",
+    "Name":"https://schema.org/permittedUsage-input",
     "Domain Bucket":"< 1K"
   },
   {
     "Class":"Predicate",
-    "Name":"http:\/\/schema.org\/permittedUsage-output",
+    "Name":"https://schema.org/permittedUsage-output",
     "Domain Bucket":"< 1K"
   },
   {
     "Class":"Predicate",
-    "Name":"http:\/\/schema.org\/petsAllowed",
+    "Name":"https://schema.org/petsAllowed",
     "Domain Bucket":"10K - 100K"
   },
   {
     "Class":"Predicate",
-    "Name":"http:\/\/schema.org\/petsAllowed-input",
+    "Name":"https://schema.org/petsAllowed-input",
     "Domain Bucket":"< 1K"
   },
   {
     "Class":"Predicate",
-    "Name":"http:\/\/schema.org\/petsAllowed-output",
+    "Name":"https://schema.org/petsAllowed-output",
     "Domain Bucket":"< 1K"
   },
   {
     "Class":"Predicate",
-    "Name":"http:\/\/schema.org\/phoneticText",
+    "Name":"https://schema.org/phoneticText",
     "Domain Bucket":"< 1K"
   },
   {
     "Class":"Predicate",
-    "Name":"http:\/\/schema.org\/phoneticText-input",
+    "Name":"https://schema.org/phoneticText-input",
     "Domain Bucket":"< 1K"
   },
   {
     "Class":"Predicate",
-    "Name":"http:\/\/schema.org\/phoneticText-output",
+    "Name":"https://schema.org/phoneticText-output",
     "Domain Bucket":"< 1K"
   },
   {
     "Class":"Predicate",
-    "Name":"http:\/\/schema.org\/photo",
+    "Name":"https://schema.org/photo",
     "Domain Bucket":"10K - 100K"
   },
   {
     "Class":"Predicate",
-    "Name":"http:\/\/schema.org\/photo-input",
+    "Name":"https://schema.org/photo-input",
     "Domain Bucket":"< 1K"
   },
   {
     "Class":"Predicate",
-    "Name":"http:\/\/schema.org\/photo-output",
+    "Name":"https://schema.org/photo-output",
     "Domain Bucket":"< 1K"
   },
   {
     "Class":"Predicate",
-    "Name":"http:\/\/schema.org\/photos",
+    "Name":"https://schema.org/photos",
     "Domain Bucket":"10K - 100K"
   },
   {
     "Class":"Predicate",
-    "Name":"http:\/\/schema.org\/photos-input",
+    "Name":"https://schema.org/photos-input",
     "Domain Bucket":"< 1K"
   },
   {
     "Class":"Predicate",
-    "Name":"http:\/\/schema.org\/photos-output",
+    "Name":"https://schema.org/photos-output",
     "Domain Bucket":"< 1K"
   },
   {
     "Class":"Predicate",
-    "Name":"http:\/\/schema.org\/physicalRequirement",
+    "Name":"https://schema.org/physicalRequirement",
     "Domain Bucket":"< 1K"
   },
   {
     "Class":"Predicate",
-    "Name":"http:\/\/schema.org\/physicalRequirement-input",
+    "Name":"https://schema.org/physicalRequirement-input",
     "Domain Bucket":"< 1K"
   },
   {
     "Class":"Predicate",
-    "Name":"http:\/\/schema.org\/physicalRequirement-output",
+    "Name":"https://schema.org/physicalRequirement-output",
     "Domain Bucket":"< 1K"
   },
   {
     "Class":"Predicate",
-    "Name":"http:\/\/schema.org\/physiologicalBenefits",
+    "Name":"https://schema.org/physiologicalBenefits",
     "Domain Bucket":"< 1K"
   },
   {
     "Class":"Predicate",
-    "Name":"http:\/\/schema.org\/physiologicalBenefits-input",
+    "Name":"https://schema.org/physiologicalBenefits-input",
     "Domain Bucket":"< 1K"
   },
   {
     "Class":"Predicate",
-    "Name":"http:\/\/schema.org\/physiologicalBenefits-output",
+    "Name":"https://schema.org/physiologicalBenefits-output",
     "Domain Bucket":"< 1K"
   },
   {
     "Class":"Predicate",
-    "Name":"http:\/\/schema.org\/pickupLocation",
+    "Name":"https://schema.org/pickupLocation",
     "Domain Bucket":"< 1K"
   },
   {
     "Class":"Predicate",
-    "Name":"http:\/\/schema.org\/pickupLocation-input",
+    "Name":"https://schema.org/pickupLocation-input",
     "Domain Bucket":"< 1K"
   },
   {
     "Class":"Predicate",
-    "Name":"http:\/\/schema.org\/pickupLocation-output",
+    "Name":"https://schema.org/pickupLocation-output",
     "Domain Bucket":"< 1K"
   },
   {
     "Class":"Predicate",
-    "Name":"http:\/\/schema.org\/pickupTime",
+    "Name":"https://schema.org/pickupTime",
     "Domain Bucket":"< 1K"
   },
   {
     "Class":"Predicate",
-    "Name":"http:\/\/schema.org\/pickupTime-input",
+    "Name":"https://schema.org/pickupTime-input",
     "Domain Bucket":"< 1K"
   },
   {
     "Class":"Predicate",
-    "Name":"http:\/\/schema.org\/pickupTime-output",
+    "Name":"https://schema.org/pickupTime-output",
     "Domain Bucket":"< 1K"
   },
   {
     "Class":"Predicate",
-    "Name":"http:\/\/schema.org\/playMode",
+    "Name":"https://schema.org/playMode",
     "Domain Bucket":"10K - 100K"
   },
   {
     "Class":"Predicate",
-    "Name":"http:\/\/schema.org\/playMode-input",
+    "Name":"https://schema.org/playMode-input",
     "Domain Bucket":"< 1K"
   },
   {
     "Class":"Predicate",
-    "Name":"http:\/\/schema.org\/playMode-output",
+    "Name":"https://schema.org/playMode-output",
     "Domain Bucket":"< 1K"
   },
   {
     "Class":"Predicate",
-    "Name":"http:\/\/schema.org\/playerType",
+    "Name":"https://schema.org/playerType",
     "Domain Bucket":"10K - 100K"
   },
   {
     "Class":"Predicate",
-    "Name":"http:\/\/schema.org\/playerType-input",
+    "Name":"https://schema.org/playerType-input",
     "Domain Bucket":"< 1K"
   },
   {
     "Class":"Predicate",
-    "Name":"http:\/\/schema.org\/playerType-output",
+    "Name":"https://schema.org/playerType-output",
     "Domain Bucket":"< 1K"
   },
   {
     "Class":"Predicate",
-    "Name":"http:\/\/schema.org\/playersOnline",
+    "Name":"https://schema.org/playersOnline",
     "Domain Bucket":"1K - 10K"
   },
   {
     "Class":"Predicate",
-    "Name":"http:\/\/schema.org\/playersOnline-input",
+    "Name":"https://schema.org/playersOnline-input",
     "Domain Bucket":"< 1K"
   },
   {
     "Class":"Predicate",
-    "Name":"http:\/\/schema.org\/playersOnline-output",
+    "Name":"https://schema.org/playersOnline-output",
     "Domain Bucket":"< 1K"
   },
   {
     "Class":"Predicate",
-    "Name":"http:\/\/schema.org\/polygon",
+    "Name":"https://schema.org/polygon",
     "Domain Bucket":"1K - 10K"
   },
   {
     "Class":"Predicate",
-    "Name":"http:\/\/schema.org\/polygon-input",
+    "Name":"https://schema.org/polygon-input",
     "Domain Bucket":"< 1K"
   },
   {
     "Class":"Predicate",
-    "Name":"http:\/\/schema.org\/polygon-output",
+    "Name":"https://schema.org/polygon-output",
     "Domain Bucket":"< 1K"
   },
   {
     "Class":"Predicate",
-    "Name":"http:\/\/schema.org\/populationType",
+    "Name":"https://schema.org/populationType",
     "Domain Bucket":"< 1K"
   },
   {
     "Class":"Predicate",
-    "Name":"http:\/\/schema.org\/populationType-input",
+    "Name":"https://schema.org/populationType-input",
     "Domain Bucket":"< 1K"
   },
   {
     "Class":"Predicate",
-    "Name":"http:\/\/schema.org\/populationType-output",
+    "Name":"https://schema.org/populationType-output",
     "Domain Bucket":"< 1K"
   },
   {
     "Class":"Predicate",
-    "Name":"http:\/\/schema.org\/position",
+    "Name":"https://schema.org/position",
     "Domain Bucket":"10M+"
   },
   {
     "Class":"Predicate",
-    "Name":"http:\/\/schema.org\/position-input",
+    "Name":"https://schema.org/position-input",
     "Domain Bucket":"< 1K"
   },
   {
     "Class":"Predicate",
-    "Name":"http:\/\/schema.org\/position-output",
+    "Name":"https://schema.org/position-output",
     "Domain Bucket":"< 1K"
   },
   {
     "Class":"Predicate",
-    "Name":"http:\/\/schema.org\/positiveNotes",
+    "Name":"https://schema.org/positiveNotes",
     "Domain Bucket":"10K - 100K"
   },
   {
     "Class":"Predicate",
-    "Name":"http:\/\/schema.org\/positiveNotes-input",
+    "Name":"https://schema.org/positiveNotes-input",
     "Domain Bucket":"< 1K"
   },
   {
     "Class":"Predicate",
-    "Name":"http:\/\/schema.org\/positiveNotes-output",
+    "Name":"https://schema.org/positiveNotes-output",
     "Domain Bucket":"< 1K"
   },
   {
     "Class":"Predicate",
-    "Name":"http:\/\/schema.org\/possibleComplication",
+    "Name":"https://schema.org/possibleComplication",
     "Domain Bucket":"1K - 10K"
   },
   {
     "Class":"Predicate",
-    "Name":"http:\/\/schema.org\/possibleComplication-input",
+    "Name":"https://schema.org/possibleComplication-input",
     "Domain Bucket":"< 1K"
   },
   {
     "Class":"Predicate",
-    "Name":"http:\/\/schema.org\/possibleComplication-output",
+    "Name":"https://schema.org/possibleComplication-output",
     "Domain Bucket":"< 1K"
   },
   {
     "Class":"Predicate",
-    "Name":"http:\/\/schema.org\/possibleTreatment",
+    "Name":"https://schema.org/possibleTreatment",
     "Domain Bucket":"1K - 10K"
   },
   {
     "Class":"Predicate",
-    "Name":"http:\/\/schema.org\/possibleTreatment-input",
+    "Name":"https://schema.org/possibleTreatment-input",
     "Domain Bucket":"< 1K"
   },
   {
     "Class":"Predicate",
-    "Name":"http:\/\/schema.org\/possibleTreatment-output",
+    "Name":"https://schema.org/possibleTreatment-output",
     "Domain Bucket":"< 1K"
   },
   {
     "Class":"Predicate",
-    "Name":"http:\/\/schema.org\/postOfficeBoxNumber",
+    "Name":"https://schema.org/postOfficeBoxNumber",
     "Domain Bucket":"10K - 100K"
   },
   {
     "Class":"Predicate",
-    "Name":"http:\/\/schema.org\/postOfficeBoxNumber-input",
+    "Name":"https://schema.org/postOfficeBoxNumber-input",
     "Domain Bucket":"< 1K"
   },
   {
     "Class":"Predicate",
-    "Name":"http:\/\/schema.org\/postOfficeBoxNumber-output",
+    "Name":"https://schema.org/postOfficeBoxNumber-output",
     "Domain Bucket":"< 1K"
   },
   {
     "Class":"Predicate",
-    "Name":"http:\/\/schema.org\/postOp",
+    "Name":"https://schema.org/postOp",
     "Domain Bucket":"< 1K"
   },
   {
     "Class":"Predicate",
-    "Name":"http:\/\/schema.org\/postOp-input",
+    "Name":"https://schema.org/postOp-input",
     "Domain Bucket":"< 1K"
   },
   {
     "Class":"Predicate",
-    "Name":"http:\/\/schema.org\/postOp-output",
+    "Name":"https://schema.org/postOp-output",
     "Domain Bucket":"< 1K"
   },
   {
     "Class":"Predicate",
-    "Name":"http:\/\/schema.org\/postalCode",
+    "Name":"https://schema.org/postalCode",
     "Domain Bucket":"1M - 10M"
   },
   {
     "Class":"Predicate",
-    "Name":"http:\/\/schema.org\/postalCode-input",
+    "Name":"https://schema.org/postalCode-input",
     "Domain Bucket":"< 1K"
   },
   {
     "Class":"Predicate",
-    "Name":"http:\/\/schema.org\/postalCode-output",
+    "Name":"https://schema.org/postalCode-output",
     "Domain Bucket":"< 1K"
   },
   {
     "Class":"Predicate",
-    "Name":"http:\/\/schema.org\/postalCodeBegin",
+    "Name":"https://schema.org/postalCodeBegin",
     "Domain Bucket":"1K - 10K"
   },
   {
     "Class":"Predicate",
-    "Name":"http:\/\/schema.org\/postalCodeBegin-input",
+    "Name":"https://schema.org/postalCodeBegin-input",
     "Domain Bucket":"< 1K"
   },
   {
     "Class":"Predicate",
-    "Name":"http:\/\/schema.org\/postalCodeBegin-output",
+    "Name":"https://schema.org/postalCodeBegin-output",
     "Domain Bucket":"< 1K"
   },
   {
     "Class":"Predicate",
-    "Name":"http:\/\/schema.org\/postalCodeEnd",
+    "Name":"https://schema.org/postalCodeEnd",
     "Domain Bucket":"1K - 10K"
   },
   {
     "Class":"Predicate",
-    "Name":"http:\/\/schema.org\/postalCodeEnd-input",
+    "Name":"https://schema.org/postalCodeEnd-input",
     "Domain Bucket":"< 1K"
   },
   {
     "Class":"Predicate",
-    "Name":"http:\/\/schema.org\/postalCodeEnd-output",
+    "Name":"https://schema.org/postalCodeEnd-output",
     "Domain Bucket":"< 1K"
   },
   {
     "Class":"Predicate",
-    "Name":"http:\/\/schema.org\/postalCodePrefix",
+    "Name":"https://schema.org/postalCodePrefix",
     "Domain Bucket":"< 1K"
   },
   {
     "Class":"Predicate",
-    "Name":"http:\/\/schema.org\/postalCodePrefix-input",
+    "Name":"https://schema.org/postalCodePrefix-input",
     "Domain Bucket":"< 1K"
   },
   {
     "Class":"Predicate",
-    "Name":"http:\/\/schema.org\/postalCodePrefix-output",
+    "Name":"https://schema.org/postalCodePrefix-output",
     "Domain Bucket":"< 1K"
   },
   {
     "Class":"Predicate",
-    "Name":"http:\/\/schema.org\/postalCodeRange",
+    "Name":"https://schema.org/postalCodeRange",
     "Domain Bucket":"1K - 10K"
   },
   {
     "Class":"Predicate",
-    "Name":"http:\/\/schema.org\/postalCodeRange-input",
+    "Name":"https://schema.org/postalCodeRange-input",
     "Domain Bucket":"< 1K"
   },
   {
     "Class":"Predicate",
-    "Name":"http:\/\/schema.org\/postalCodeRange-output",
+    "Name":"https://schema.org/postalCodeRange-output",
     "Domain Bucket":"< 1K"
   },
   {
     "Class":"Predicate",
-    "Name":"http:\/\/schema.org\/potentialAction",
+    "Name":"https://schema.org/potentialAction",
     "Domain Bucket":"10M+"
   },
   {
     "Class":"Predicate",
-    "Name":"http:\/\/schema.org\/potentialAction-input",
+    "Name":"https://schema.org/potentialAction-input",
     "Domain Bucket":"< 1K"
   },
   {
     "Class":"Predicate",
-    "Name":"http:\/\/schema.org\/potentialAction-output",
+    "Name":"https://schema.org/potentialAction-output",
     "Domain Bucket":"< 1K"
   },
   {
     "Class":"Predicate",
-    "Name":"http:\/\/schema.org\/potentialUse",
+    "Name":"https://schema.org/potentialUse",
     "Domain Bucket":"< 1K"
   },
   {
     "Class":"Predicate",
-    "Name":"http:\/\/schema.org\/potentialUse-input",
+    "Name":"https://schema.org/potentialUse-input",
     "Domain Bucket":"< 1K"
   },
   {
     "Class":"Predicate",
-    "Name":"http:\/\/schema.org\/potentialUse-output",
+    "Name":"https://schema.org/potentialUse-output",
     "Domain Bucket":"< 1K"
   },
   {
     "Class":"Predicate",
-    "Name":"http:\/\/schema.org\/practicesAt",
+    "Name":"https://schema.org/practicesAt",
     "Domain Bucket":"1K - 10K"
   },
   {
     "Class":"Predicate",
-    "Name":"http:\/\/schema.org\/practicesAt-input",
+    "Name":"https://schema.org/practicesAt-input",
     "Domain Bucket":"< 1K"
   },
   {
     "Class":"Predicate",
-    "Name":"http:\/\/schema.org\/practicesAt-output",
+    "Name":"https://schema.org/practicesAt-output",
     "Domain Bucket":"< 1K"
   },
   {
     "Class":"Predicate",
-    "Name":"http:\/\/schema.org\/preOp",
+    "Name":"https://schema.org/preOp",
     "Domain Bucket":"< 1K"
   },
   {
     "Class":"Predicate",
-    "Name":"http:\/\/schema.org\/preOp-input",
+    "Name":"https://schema.org/preOp-input",
     "Domain Bucket":"< 1K"
   },
   {
     "Class":"Predicate",
-    "Name":"http:\/\/schema.org\/preOp-output",
+    "Name":"https://schema.org/preOp-output",
     "Domain Bucket":"< 1K"
   },
   {
     "Class":"Predicate",
-    "Name":"http:\/\/schema.org\/predecessorOf",
+    "Name":"https://schema.org/predecessorOf",
     "Domain Bucket":"< 1K"
   },
   {
     "Class":"Predicate",
-    "Name":"http:\/\/schema.org\/predecessorOf-input",
+    "Name":"https://schema.org/predecessorOf-input",
     "Domain Bucket":"< 1K"
   },
   {
     "Class":"Predicate",
-    "Name":"http:\/\/schema.org\/predecessorOf-output",
+    "Name":"https://schema.org/predecessorOf-output",
     "Domain Bucket":"< 1K"
   },
   {
     "Class":"Predicate",
-    "Name":"http:\/\/schema.org\/pregnancyCategory",
+    "Name":"https://schema.org/pregnancyCategory",
     "Domain Bucket":"< 1K"
   },
   {
     "Class":"Predicate",
-    "Name":"http:\/\/schema.org\/pregnancyCategory-input",
+    "Name":"https://schema.org/pregnancyCategory-input",
     "Domain Bucket":"< 1K"
   },
   {
     "Class":"Predicate",
-    "Name":"http:\/\/schema.org\/pregnancyCategory-output",
+    "Name":"https://schema.org/pregnancyCategory-output",
     "Domain Bucket":"< 1K"
   },
   {
     "Class":"Predicate",
-    "Name":"http:\/\/schema.org\/pregnancyWarning",
+    "Name":"https://schema.org/pregnancyWarning",
     "Domain Bucket":"< 1K"
   },
   {
     "Class":"Predicate",
-    "Name":"http:\/\/schema.org\/pregnancyWarning-input",
+    "Name":"https://schema.org/pregnancyWarning-input",
     "Domain Bucket":"< 1K"
   },
   {
     "Class":"Predicate",
-    "Name":"http:\/\/schema.org\/pregnancyWarning-output",
+    "Name":"https://schema.org/pregnancyWarning-output",
     "Domain Bucket":"< 1K"
   },
   {
     "Class":"Predicate",
-    "Name":"http:\/\/schema.org\/prepTime",
+    "Name":"https://schema.org/prepTime",
     "Domain Bucket":"10K - 100K"
   },
   {
     "Class":"Predicate",
-    "Name":"http:\/\/schema.org\/prepTime-input",
+    "Name":"https://schema.org/prepTime-input",
     "Domain Bucket":"< 1K"
   },
   {
     "Class":"Predicate",
-    "Name":"http:\/\/schema.org\/prepTime-output",
+    "Name":"https://schema.org/prepTime-output",
     "Domain Bucket":"< 1K"
   },
   {
     "Class":"Predicate",
-    "Name":"http:\/\/schema.org\/preparation",
+    "Name":"https://schema.org/preparation",
     "Domain Bucket":"1K - 10K"
   },
   {
     "Class":"Predicate",
-    "Name":"http:\/\/schema.org\/preparation-input",
+    "Name":"https://schema.org/preparation-input",
     "Domain Bucket":"< 1K"
   },
   {
     "Class":"Predicate",
-    "Name":"http:\/\/schema.org\/preparation-output",
+    "Name":"https://schema.org/preparation-output",
     "Domain Bucket":"< 1K"
   },
   {
     "Class":"Predicate",
-    "Name":"http:\/\/schema.org\/prescribingInfo",
+    "Name":"https://schema.org/prescribingInfo",
     "Domain Bucket":"< 1K"
   },
   {
     "Class":"Predicate",
-    "Name":"http:\/\/schema.org\/prescribingInfo-input",
+    "Name":"https://schema.org/prescribingInfo-input",
     "Domain Bucket":"< 1K"
   },
   {
     "Class":"Predicate",
-    "Name":"http:\/\/schema.org\/prescribingInfo-output",
+    "Name":"https://schema.org/prescribingInfo-output",
     "Domain Bucket":"< 1K"
   },
   {
     "Class":"Predicate",
-    "Name":"http:\/\/schema.org\/prescriptionStatus",
+    "Name":"https://schema.org/prescriptionStatus",
     "Domain Bucket":"1K - 10K"
   },
   {
     "Class":"Predicate",
-    "Name":"http:\/\/schema.org\/prescriptionStatus-input",
+    "Name":"https://schema.org/prescriptionStatus-input",
     "Domain Bucket":"< 1K"
   },
   {
     "Class":"Predicate",
-    "Name":"http:\/\/schema.org\/prescriptionStatus-output",
+    "Name":"https://schema.org/prescriptionStatus-output",
     "Domain Bucket":"< 1K"
   },
   {
     "Class":"Predicate",
-    "Name":"http:\/\/schema.org\/previousItem",
+    "Name":"https://schema.org/previousItem",
     "Domain Bucket":"1M - 10M"
   },
   {
     "Class":"Predicate",
-    "Name":"http:\/\/schema.org\/previousItem-input",
+    "Name":"https://schema.org/previousItem-input",
     "Domain Bucket":"< 1K"
   },
   {
     "Class":"Predicate",
-    "Name":"http:\/\/schema.org\/previousItem-output",
+    "Name":"https://schema.org/previousItem-output",
     "Domain Bucket":"< 1K"
   },
   {
     "Class":"Predicate",
-    "Name":"http:\/\/schema.org\/previousStartDate",
+    "Name":"https://schema.org/previousStartDate",
     "Domain Bucket":"1K - 10K"
   },
   {
     "Class":"Predicate",
-    "Name":"http:\/\/schema.org\/previousStartDate-input",
+    "Name":"https://schema.org/previousStartDate-input",
     "Domain Bucket":"< 1K"
   },
   {
     "Class":"Predicate",
-    "Name":"http:\/\/schema.org\/previousStartDate-output",
+    "Name":"https://schema.org/previousStartDate-output",
     "Domain Bucket":"< 1K"
   },
   {
     "Class":"Predicate",
-    "Name":"http:\/\/schema.org\/price",
+    "Name":"https://schema.org/price",
     "Domain Bucket":"10M+"
   },
   {
     "Class":"Predicate",
-    "Name":"http:\/\/schema.org\/price-input",
+    "Name":"https://schema.org/price-input",
     "Domain Bucket":"< 1K"
   },
   {
     "Class":"Predicate",
-    "Name":"http:\/\/schema.org\/price-output",
+    "Name":"https://schema.org/price-output",
     "Domain Bucket":"< 1K"
   },
   {
     "Class":"Predicate",
-    "Name":"http:\/\/schema.org\/priceComponent",
+    "Name":"https://schema.org/priceComponent",
     "Domain Bucket":"1K - 10K"
   },
   {
     "Class":"Predicate",
-    "Name":"http:\/\/schema.org\/priceComponent-input",
+    "Name":"https://schema.org/priceComponent-input",
     "Domain Bucket":"< 1K"
   },
   {
     "Class":"Predicate",
-    "Name":"http:\/\/schema.org\/priceComponent-output",
+    "Name":"https://schema.org/priceComponent-output",
     "Domain Bucket":"< 1K"
   },
   {
     "Class":"Predicate",
-    "Name":"http:\/\/schema.org\/priceComponentType",
+    "Name":"https://schema.org/priceComponentType",
     "Domain Bucket":"< 1K"
   },
   {
     "Class":"Predicate",
-    "Name":"http:\/\/schema.org\/priceComponentType-input",
+    "Name":"https://schema.org/priceComponentType-input",
     "Domain Bucket":"< 1K"
   },
   {
     "Class":"Predicate",
-    "Name":"http:\/\/schema.org\/priceComponentType-output",
+    "Name":"https://schema.org/priceComponentType-output",
     "Domain Bucket":"< 1K"
   },
   {
     "Class":"Predicate",
-    "Name":"http:\/\/schema.org\/priceCurrency",
+    "Name":"https://schema.org/priceCurrency",
     "Domain Bucket":"10M+"
   },
   {
     "Class":"Predicate",
-    "Name":"http:\/\/schema.org\/priceCurrency-input",
+    "Name":"https://schema.org/priceCurrency-input",
     "Domain Bucket":"< 1K"
   },
   {
     "Class":"Predicate",
-    "Name":"http:\/\/schema.org\/priceCurrency-output",
+    "Name":"https://schema.org/priceCurrency-output",
     "Domain Bucket":"< 1K"
   },
   {
     "Class":"Predicate",
-    "Name":"http:\/\/schema.org\/priceRange",
+    "Name":"https://schema.org/priceRange",
     "Domain Bucket":"1M - 10M"
   },
   {
     "Class":"Predicate",
-    "Name":"http:\/\/schema.org\/priceRange-input",
+    "Name":"https://schema.org/priceRange-input",
     "Domain Bucket":"< 1K"
   },
   {
     "Class":"Predicate",
-    "Name":"http:\/\/schema.org\/priceRange-output",
+    "Name":"https://schema.org/priceRange-output",
     "Domain Bucket":"< 1K"
   },
   {
     "Class":"Predicate",
-    "Name":"http:\/\/schema.org\/priceSpecification",
+    "Name":"https://schema.org/priceSpecification",
     "Domain Bucket":"1M - 10M"
   },
   {
     "Class":"Predicate",
-    "Name":"http:\/\/schema.org\/priceSpecification-input",
+    "Name":"https://schema.org/priceSpecification-input",
     "Domain Bucket":"< 1K"
   },
   {
     "Class":"Predicate",
-    "Name":"http:\/\/schema.org\/priceSpecification-output",
+    "Name":"https://schema.org/priceSpecification-output",
     "Domain Bucket":"< 1K"
   },
   {
     "Class":"Predicate",
-    "Name":"http:\/\/schema.org\/priceType",
+    "Name":"https://schema.org/priceType",
     "Domain Bucket":"100K - 1M"
   },
   {
     "Class":"Predicate",
-    "Name":"http:\/\/schema.org\/priceType-input",
+    "Name":"https://schema.org/priceType-input",
     "Domain Bucket":"< 1K"
   },
   {
     "Class":"Predicate",
-    "Name":"http:\/\/schema.org\/priceType-output",
+    "Name":"https://schema.org/priceType-output",
     "Domain Bucket":"< 1K"
   },
   {
     "Class":"Predicate",
-    "Name":"http:\/\/schema.org\/priceValidUntil",
+    "Name":"https://schema.org/priceValidUntil",
     "Domain Bucket":"1M - 10M"
   },
   {
     "Class":"Predicate",
-    "Name":"http:\/\/schema.org\/priceValidUntil-input",
+    "Name":"https://schema.org/priceValidUntil-input",
     "Domain Bucket":"< 1K"
   },
   {
     "Class":"Predicate",
-    "Name":"http:\/\/schema.org\/priceValidUntil-output",
+    "Name":"https://schema.org/priceValidUntil-output",
     "Domain Bucket":"< 1K"
   },
   {
     "Class":"Predicate",
-    "Name":"http:\/\/schema.org\/primaryImageOfPage",
+    "Name":"https://schema.org/primaryImageOfPage",
     "Domain Bucket":"10M+"
   },
   {
     "Class":"Predicate",
-    "Name":"http:\/\/schema.org\/primaryImageOfPage-input",
+    "Name":"https://schema.org/primaryImageOfPage-input",
     "Domain Bucket":"< 1K"
   },
   {
     "Class":"Predicate",
-    "Name":"http:\/\/schema.org\/primaryImageOfPage-output",
+    "Name":"https://schema.org/primaryImageOfPage-output",
     "Domain Bucket":"< 1K"
   },
   {
     "Class":"Predicate",
-    "Name":"http:\/\/schema.org\/primaryPrevention",
+    "Name":"https://schema.org/primaryPrevention",
     "Domain Bucket":"< 1K"
   },
   {
     "Class":"Predicate",
-    "Name":"http:\/\/schema.org\/primaryPrevention-input",
+    "Name":"https://schema.org/primaryPrevention-input",
     "Domain Bucket":"< 1K"
   },
   {
     "Class":"Predicate",
-    "Name":"http:\/\/schema.org\/primaryPrevention-output",
+    "Name":"https://schema.org/primaryPrevention-output",
     "Domain Bucket":"< 1K"
   },
   {
     "Class":"Predicate",
-    "Name":"http:\/\/schema.org\/printColumn",
+    "Name":"https://schema.org/printColumn",
     "Domain Bucket":"< 1K"
   },
   {
     "Class":"Predicate",
-    "Name":"http:\/\/schema.org\/printColumn-input",
+    "Name":"https://schema.org/printColumn-input",
     "Domain Bucket":"< 1K"
   },
   {
     "Class":"Predicate",
-    "Name":"http:\/\/schema.org\/printColumn-output",
+    "Name":"https://schema.org/printColumn-output",
     "Domain Bucket":"< 1K"
   },
   {
     "Class":"Predicate",
-    "Name":"http:\/\/schema.org\/printEdition",
+    "Name":"https://schema.org/printEdition",
     "Domain Bucket":"< 1K"
   },
   {
     "Class":"Predicate",
-    "Name":"http:\/\/schema.org\/printEdition-input",
+    "Name":"https://schema.org/printEdition-input",
     "Domain Bucket":"< 1K"
   },
   {
     "Class":"Predicate",
-    "Name":"http:\/\/schema.org\/printEdition-output",
+    "Name":"https://schema.org/printEdition-output",
     "Domain Bucket":"< 1K"
   },
   {
     "Class":"Predicate",
-    "Name":"http:\/\/schema.org\/printPage",
+    "Name":"https://schema.org/printPage",
     "Domain Bucket":"< 1K"
   },
   {
     "Class":"Predicate",
-    "Name":"http:\/\/schema.org\/printPage-input",
+    "Name":"https://schema.org/printPage-input",
     "Domain Bucket":"< 1K"
   },
   {
     "Class":"Predicate",
-    "Name":"http:\/\/schema.org\/printPage-output",
+    "Name":"https://schema.org/printPage-output",
     "Domain Bucket":"< 1K"
   },
   {
     "Class":"Predicate",
-    "Name":"http:\/\/schema.org\/printSection",
+    "Name":"https://schema.org/printSection",
     "Domain Bucket":"< 1K"
   },
   {
     "Class":"Predicate",
-    "Name":"http:\/\/schema.org\/printSection-input",
+    "Name":"https://schema.org/printSection-input",
     "Domain Bucket":"< 1K"
   },
   {
     "Class":"Predicate",
-    "Name":"http:\/\/schema.org\/printSection-output",
+    "Name":"https://schema.org/printSection-output",
     "Domain Bucket":"< 1K"
   },
   {
     "Class":"Predicate",
-    "Name":"http:\/\/schema.org\/procedure",
+    "Name":"https://schema.org/procedure",
     "Domain Bucket":"< 1K"
   },
   {
     "Class":"Predicate",
-    "Name":"http:\/\/schema.org\/procedure-input",
+    "Name":"https://schema.org/procedure-input",
     "Domain Bucket":"< 1K"
   },
   {
     "Class":"Predicate",
-    "Name":"http:\/\/schema.org\/procedure-output",
+    "Name":"https://schema.org/procedure-output",
     "Domain Bucket":"< 1K"
   },
   {
     "Class":"Predicate",
-    "Name":"http:\/\/schema.org\/procedureType",
+    "Name":"https://schema.org/procedureType",
     "Domain Bucket":"10K - 100K"
   },
   {
     "Class":"Predicate",
-    "Name":"http:\/\/schema.org\/procedureType-input",
+    "Name":"https://schema.org/procedureType-input",
     "Domain Bucket":"< 1K"
   },
   {
     "Class":"Predicate",
-    "Name":"http:\/\/schema.org\/procedureType-output",
+    "Name":"https://schema.org/procedureType-output",
     "Domain Bucket":"< 1K"
   },
   {
     "Class":"Predicate",
-    "Name":"http:\/\/schema.org\/processingTime",
+    "Name":"https://schema.org/processingTime",
     "Domain Bucket":"< 1K"
   },
   {
     "Class":"Predicate",
-    "Name":"http:\/\/schema.org\/processingTime-input",
+    "Name":"https://schema.org/processingTime-input",
     "Domain Bucket":"< 1K"
   },
   {
     "Class":"Predicate",
-    "Name":"http:\/\/schema.org\/processingTime-output",
+    "Name":"https://schema.org/processingTime-output",
     "Domain Bucket":"< 1K"
   },
   {
     "Class":"Predicate",
-    "Name":"http:\/\/schema.org\/processorRequirements",
+    "Name":"https://schema.org/processorRequirements",
     "Domain Bucket":"1K - 10K"
   },
   {
     "Class":"Predicate",
-    "Name":"http:\/\/schema.org\/processorRequirements-input",
+    "Name":"https://schema.org/processorRequirements-input",
     "Domain Bucket":"< 1K"
   },
   {
     "Class":"Predicate",
-    "Name":"http:\/\/schema.org\/processorRequirements-output",
+    "Name":"https://schema.org/processorRequirements-output",
     "Domain Bucket":"< 1K"
   },
   {
     "Class":"Predicate",
-    "Name":"http:\/\/schema.org\/producer",
+    "Name":"https://schema.org/producer",
     "Domain Bucket":"1K - 10K"
   },
   {
     "Class":"Predicate",
-    "Name":"http:\/\/schema.org\/producer-input",
+    "Name":"https://schema.org/producer-input",
     "Domain Bucket":"< 1K"
   },
   {
     "Class":"Predicate",
-    "Name":"http:\/\/schema.org\/producer-output",
+    "Name":"https://schema.org/producer-output",
     "Domain Bucket":"< 1K"
   },
   {
     "Class":"Predicate",
-    "Name":"http:\/\/schema.org\/produces",
+    "Name":"https://schema.org/produces",
     "Domain Bucket":"< 1K"
   },
   {
     "Class":"Predicate",
-    "Name":"http:\/\/schema.org\/produces-input",
+    "Name":"https://schema.org/produces-input",
     "Domain Bucket":"< 1K"
   },
   {
     "Class":"Predicate",
-    "Name":"http:\/\/schema.org\/produces-output",
+    "Name":"https://schema.org/produces-output",
     "Domain Bucket":"< 1K"
   },
   {
     "Class":"Predicate",
-    "Name":"http:\/\/schema.org\/productGroupID",
+    "Name":"https://schema.org/productGroupID",
     "Domain Bucket":"100K - 1M"
   },
   {
     "Class":"Predicate",
-    "Name":"http:\/\/schema.org\/productGroupID-input",
+    "Name":"https://schema.org/productGroupID-input",
     "Domain Bucket":"< 1K"
   },
   {
     "Class":"Predicate",
-    "Name":"http:\/\/schema.org\/productGroupID-output",
+    "Name":"https://schema.org/productGroupID-output",
     "Domain Bucket":"< 1K"
   },
   {
     "Class":"Predicate",
-    "Name":"http:\/\/schema.org\/productID",
+    "Name":"https://schema.org/productID",
     "Domain Bucket":"100K - 1M"
   },
   {
     "Class":"Predicate",
-    "Name":"http:\/\/schema.org\/productID-input",
+    "Name":"https://schema.org/productID-input",
     "Domain Bucket":"< 1K"
   },
   {
     "Class":"Predicate",
-    "Name":"http:\/\/schema.org\/productID-output",
+    "Name":"https://schema.org/productID-output",
     "Domain Bucket":"< 1K"
   },
   {
     "Class":"Predicate",
-    "Name":"http:\/\/schema.org\/productReturnDays",
+    "Name":"https://schema.org/productReturnDays",
     "Domain Bucket":"< 1K"
   },
   {
     "Class":"Predicate",
-    "Name":"http:\/\/schema.org\/productReturnDays-input",
+    "Name":"https://schema.org/productReturnDays-input",
     "Domain Bucket":"< 1K"
   },
   {
     "Class":"Predicate",
-    "Name":"http:\/\/schema.org\/productReturnDays-output",
+    "Name":"https://schema.org/productReturnDays-output",
     "Domain Bucket":"< 1K"
   },
   {
     "Class":"Predicate",
-    "Name":"http:\/\/schema.org\/productReturnLink",
+    "Name":"https://schema.org/productReturnLink",
     "Domain Bucket":"< 1K"
   },
   {
     "Class":"Predicate",
-    "Name":"http:\/\/schema.org\/productReturnLink-input",
+    "Name":"https://schema.org/productReturnLink-input",
     "Domain Bucket":"< 1K"
   },
   {
     "Class":"Predicate",
-    "Name":"http:\/\/schema.org\/productReturnLink-output",
+    "Name":"https://schema.org/productReturnLink-output",
     "Domain Bucket":"< 1K"
   },
   {
     "Class":"Predicate",
-    "Name":"http:\/\/schema.org\/productSupported",
+    "Name":"https://schema.org/productSupported",
     "Domain Bucket":"1K - 10K"
   },
   {
     "Class":"Predicate",
-    "Name":"http:\/\/schema.org\/productSupported-input",
+    "Name":"https://schema.org/productSupported-input",
     "Domain Bucket":"< 1K"
   },
   {
     "Class":"Predicate",
-    "Name":"http:\/\/schema.org\/productSupported-output",
+    "Name":"https://schema.org/productSupported-output",
     "Domain Bucket":"< 1K"
   },
   {
     "Class":"Predicate",
-    "Name":"http:\/\/schema.org\/productionCompany",
+    "Name":"https://schema.org/productionCompany",
     "Domain Bucket":"1K - 10K"
   },
   {
     "Class":"Predicate",
-    "Name":"http:\/\/schema.org\/productionCompany-input",
+    "Name":"https://schema.org/productionCompany-input",
     "Domain Bucket":"< 1K"
   },
   {
     "Class":"Predicate",
-    "Name":"http:\/\/schema.org\/productionCompany-output",
+    "Name":"https://schema.org/productionCompany-output",
     "Domain Bucket":"< 1K"
   },
   {
     "Class":"Predicate",
-    "Name":"http:\/\/schema.org\/productionDate",
+    "Name":"https://schema.org/productionDate",
     "Domain Bucket":"10K - 100K"
   },
   {
     "Class":"Predicate",
-    "Name":"http:\/\/schema.org\/productionDate-input",
+    "Name":"https://schema.org/productionDate-input",
     "Domain Bucket":"< 1K"
   },
   {
     "Class":"Predicate",
-    "Name":"http:\/\/schema.org\/productionDate-output",
+    "Name":"https://schema.org/productionDate-output",
     "Domain Bucket":"< 1K"
   },
   {
     "Class":"Predicate",
-    "Name":"http:\/\/schema.org\/proficiencyLevel",
+    "Name":"https://schema.org/proficiencyLevel",
     "Domain Bucket":"10K - 100K"
   },
   {
     "Class":"Predicate",
-    "Name":"http:\/\/schema.org\/proficiencyLevel-input",
+    "Name":"https://schema.org/proficiencyLevel-input",
     "Domain Bucket":"< 1K"
   },
   {
     "Class":"Predicate",
-    "Name":"http:\/\/schema.org\/proficiencyLevel-output",
+    "Name":"https://schema.org/proficiencyLevel-output",
     "Domain Bucket":"< 1K"
   },
   {
     "Class":"Predicate",
-    "Name":"http:\/\/schema.org\/program",
+    "Name":"https://schema.org/program",
     "Domain Bucket":"< 1K"
   },
   {
     "Class":"Predicate",
-    "Name":"http:\/\/schema.org\/program-input",
+    "Name":"https://schema.org/program-input",
     "Domain Bucket":"< 1K"
   },
   {
     "Class":"Predicate",
-    "Name":"http:\/\/schema.org\/program-output",
+    "Name":"https://schema.org/program-output",
     "Domain Bucket":"< 1K"
   },
   {
     "Class":"Predicate",
-    "Name":"http:\/\/schema.org\/programMembershipUsed",
+    "Name":"https://schema.org/programMembershipUsed",
     "Domain Bucket":"< 1K"
   },
   {
     "Class":"Predicate",
-    "Name":"http:\/\/schema.org\/programMembershipUsed-input",
+    "Name":"https://schema.org/programMembershipUsed-input",
     "Domain Bucket":"< 1K"
   },
   {
     "Class":"Predicate",
-    "Name":"http:\/\/schema.org\/programMembershipUsed-output",
+    "Name":"https://schema.org/programMembershipUsed-output",
     "Domain Bucket":"< 1K"
   },
   {
     "Class":"Predicate",
-    "Name":"http:\/\/schema.org\/programName",
+    "Name":"https://schema.org/programName",
     "Domain Bucket":"1K - 10K"
   },
   {
     "Class":"Predicate",
-    "Name":"http:\/\/schema.org\/programName-input",
+    "Name":"https://schema.org/programName-input",
     "Domain Bucket":"< 1K"
   },
   {
     "Class":"Predicate",
-    "Name":"http:\/\/schema.org\/programName-output",
+    "Name":"https://schema.org/programName-output",
     "Domain Bucket":"< 1K"
   },
   {
     "Class":"Predicate",
-    "Name":"http:\/\/schema.org\/programPrerequisites",
+    "Name":"https://schema.org/programPrerequisites",
     "Domain Bucket":"1K - 10K"
   },
   {
     "Class":"Predicate",
-    "Name":"http:\/\/schema.org\/programPrerequisites-input",
+    "Name":"https://schema.org/programPrerequisites-input",
     "Domain Bucket":"< 1K"
   },
   {
     "Class":"Predicate",
-    "Name":"http:\/\/schema.org\/programPrerequisites-output",
+    "Name":"https://schema.org/programPrerequisites-output",
     "Domain Bucket":"< 1K"
   },
   {
     "Class":"Predicate",
-    "Name":"http:\/\/schema.org\/programType",
+    "Name":"https://schema.org/programType",
     "Domain Bucket":"1K - 10K"
   },
   {
     "Class":"Predicate",
-    "Name":"http:\/\/schema.org\/programType-input",
+    "Name":"https://schema.org/programType-input",
     "Domain Bucket":"< 1K"
   },
   {
     "Class":"Predicate",
-    "Name":"http:\/\/schema.org\/programType-output",
+    "Name":"https://schema.org/programType-output",
     "Domain Bucket":"< 1K"
   },
   {
     "Class":"Predicate",
-    "Name":"http:\/\/schema.org\/programmingLanguage",
+    "Name":"https://schema.org/programmingLanguage",
     "Domain Bucket":"1K - 10K"
   },
   {
     "Class":"Predicate",
-    "Name":"http:\/\/schema.org\/programmingLanguage-input",
+    "Name":"https://schema.org/programmingLanguage-input",
     "Domain Bucket":"< 1K"
   },
   {
     "Class":"Predicate",
-    "Name":"http:\/\/schema.org\/programmingLanguage-output",
+    "Name":"https://schema.org/programmingLanguage-output",
     "Domain Bucket":"< 1K"
   },
   {
     "Class":"Predicate",
-    "Name":"http:\/\/schema.org\/programmingModel",
+    "Name":"https://schema.org/programmingModel",
     "Domain Bucket":"< 1K"
   },
   {
     "Class":"Predicate",
-    "Name":"http:\/\/schema.org\/programmingModel-input",
+    "Name":"https://schema.org/programmingModel-input",
     "Domain Bucket":"< 1K"
   },
   {
     "Class":"Predicate",
-    "Name":"http:\/\/schema.org\/programmingModel-output",
+    "Name":"https://schema.org/programmingModel-output",
     "Domain Bucket":"< 1K"
   },
   {
     "Class":"Predicate",
-    "Name":"http:\/\/schema.org\/pronouns",
+    "Name":"https://schema.org/pronouns",
     "Domain Bucket":"1K - 10K"
   },
   {
     "Class":"Predicate",
-    "Name":"http:\/\/schema.org\/pronouns-input",
+    "Name":"https://schema.org/pronouns-input",
     "Domain Bucket":"< 1K"
   },
   {
     "Class":"Predicate",
-    "Name":"http:\/\/schema.org\/pronouns-output",
+    "Name":"https://schema.org/pronouns-output",
     "Domain Bucket":"< 1K"
   },
   {
     "Class":"Predicate",
-    "Name":"http:\/\/schema.org\/propertyID",
+    "Name":"https://schema.org/propertyID",
     "Domain Bucket":"10K - 100K"
   },
   {
     "Class":"Predicate",
-    "Name":"http:\/\/schema.org\/propertyID-input",
+    "Name":"https://schema.org/propertyID-input",
     "Domain Bucket":"< 1K"
   },
   {
     "Class":"Predicate",
-    "Name":"http:\/\/schema.org\/propertyID-output",
+    "Name":"https://schema.org/propertyID-output",
     "Domain Bucket":"< 1K"
   },
   {
     "Class":"Predicate",
-    "Name":"http:\/\/schema.org\/proprietaryName",
+    "Name":"https://schema.org/proprietaryName",
     "Domain Bucket":"< 1K"
   },
   {
     "Class":"Predicate",
-    "Name":"http:\/\/schema.org\/proprietaryName-input",
+    "Name":"https://schema.org/proprietaryName-input",
     "Domain Bucket":"< 1K"
   },
   {
     "Class":"Predicate",
-    "Name":"http:\/\/schema.org\/proprietaryName-output",
+    "Name":"https://schema.org/proprietaryName-output",
     "Domain Bucket":"< 1K"
   },
   {
     "Class":"Predicate",
-    "Name":"http:\/\/schema.org\/proteinContent",
+    "Name":"https://schema.org/proteinContent",
     "Domain Bucket":"10K - 100K"
   },
   {
     "Class":"Predicate",
-    "Name":"http:\/\/schema.org\/proteinContent-input",
+    "Name":"https://schema.org/proteinContent-input",
     "Domain Bucket":"< 1K"
   },
   {
     "Class":"Predicate",
-    "Name":"http:\/\/schema.org\/proteinContent-output",
+    "Name":"https://schema.org/proteinContent-output",
     "Domain Bucket":"< 1K"
   },
   {
     "Class":"Predicate",
-    "Name":"http:\/\/schema.org\/provider",
+    "Name":"https://schema.org/provider",
     "Domain Bucket":"1M - 10M"
   },
   {
     "Class":"Predicate",
-    "Name":"http:\/\/schema.org\/provider-input",
+    "Name":"https://schema.org/provider-input",
     "Domain Bucket":"< 1K"
   },
   {
     "Class":"Predicate",
-    "Name":"http:\/\/schema.org\/provider-output",
+    "Name":"https://schema.org/provider-output",
     "Domain Bucket":"< 1K"
   },
   {
     "Class":"Predicate",
-    "Name":"http:\/\/schema.org\/providerMobility",
+    "Name":"https://schema.org/providerMobility",
     "Domain Bucket":"1K - 10K"
   },
   {
     "Class":"Predicate",
-    "Name":"http:\/\/schema.org\/providerMobility-input",
+    "Name":"https://schema.org/providerMobility-input",
     "Domain Bucket":"< 1K"
   },
   {
     "Class":"Predicate",
-    "Name":"http:\/\/schema.org\/providerMobility-output",
+    "Name":"https://schema.org/providerMobility-output",
     "Domain Bucket":"< 1K"
   },
   {
     "Class":"Predicate",
-    "Name":"http:\/\/schema.org\/providesBroadcastService",
+    "Name":"https://schema.org/providesBroadcastService",
     "Domain Bucket":"< 1K"
   },
   {
     "Class":"Predicate",
-    "Name":"http:\/\/schema.org\/providesBroadcastService-input",
+    "Name":"https://schema.org/providesBroadcastService-input",
     "Domain Bucket":"< 1K"
   },
   {
     "Class":"Predicate",
-    "Name":"http:\/\/schema.org\/providesBroadcastService-output",
+    "Name":"https://schema.org/providesBroadcastService-output",
     "Domain Bucket":"< 1K"
   },
   {
     "Class":"Predicate",
-    "Name":"http:\/\/schema.org\/providesService",
+    "Name":"https://schema.org/providesService",
     "Domain Bucket":"< 1K"
   },
   {
     "Class":"Predicate",
-    "Name":"http:\/\/schema.org\/providesService-input",
+    "Name":"https://schema.org/providesService-input",
     "Domain Bucket":"< 1K"
   },
   {
     "Class":"Predicate",
-    "Name":"http:\/\/schema.org\/providesService-output",
+    "Name":"https://schema.org/providesService-output",
     "Domain Bucket":"< 1K"
   },
   {
     "Class":"Predicate",
-    "Name":"http:\/\/schema.org\/publicAccess",
+    "Name":"https://schema.org/publicAccess",
     "Domain Bucket":"10K - 100K"
   },
   {
     "Class":"Predicate",
-    "Name":"http:\/\/schema.org\/publicAccess-input",
+    "Name":"https://schema.org/publicAccess-input",
     "Domain Bucket":"< 1K"
   },
   {
     "Class":"Predicate",
-    "Name":"http:\/\/schema.org\/publicAccess-output",
+    "Name":"https://schema.org/publicAccess-output",
     "Domain Bucket":"< 1K"
   },
   {
     "Class":"Predicate",
-    "Name":"http:\/\/schema.org\/publicTransportClosuresInfo",
+    "Name":"https://schema.org/publicTransportClosuresInfo",
     "Domain Bucket":"< 1K"
   },
   {
     "Class":"Predicate",
-    "Name":"http:\/\/schema.org\/publicTransportClosuresInfo-input",
+    "Name":"https://schema.org/publicTransportClosuresInfo-input",
     "Domain Bucket":"< 1K"
   },
   {
     "Class":"Predicate",
-    "Name":"http:\/\/schema.org\/publicTransportClosuresInfo-output",
+    "Name":"https://schema.org/publicTransportClosuresInfo-output",
     "Domain Bucket":"< 1K"
   },
   {
     "Class":"Predicate",
-    "Name":"http:\/\/schema.org\/publication",
+    "Name":"https://schema.org/publication",
     "Domain Bucket":"1K - 10K"
   },
   {
     "Class":"Predicate",
-    "Name":"http:\/\/schema.org\/publication-input",
+    "Name":"https://schema.org/publication-input",
     "Domain Bucket":"< 1K"
   },
   {
     "Class":"Predicate",
-    "Name":"http:\/\/schema.org\/publication-output",
+    "Name":"https://schema.org/publication-output",
     "Domain Bucket":"< 1K"
   },
   {
     "Class":"Predicate",
-    "Name":"http:\/\/schema.org\/publicationType",
+    "Name":"https://schema.org/publicationType",
     "Domain Bucket":"< 1K"
   },
   {
     "Class":"Predicate",
-    "Name":"http:\/\/schema.org\/publicationType-input",
+    "Name":"https://schema.org/publicationType-input",
     "Domain Bucket":"< 1K"
   },
   {
     "Class":"Predicate",
-    "Name":"http:\/\/schema.org\/publicationType-output",
+    "Name":"https://schema.org/publicationType-output",
     "Domain Bucket":"< 1K"
   },
   {
     "Class":"Predicate",
-    "Name":"http:\/\/schema.org\/publishedBy",
+    "Name":"https://schema.org/publishedBy",
     "Domain Bucket":"< 1K"
   },
   {
     "Class":"Predicate",
-    "Name":"http:\/\/schema.org\/publishedBy-input",
+    "Name":"https://schema.org/publishedBy-input",
     "Domain Bucket":"< 1K"
   },
   {
     "Class":"Predicate",
-    "Name":"http:\/\/schema.org\/publishedBy-output",
+    "Name":"https://schema.org/publishedBy-output",
     "Domain Bucket":"< 1K"
   },
   {
     "Class":"Predicate",
-    "Name":"http:\/\/schema.org\/publishedOn",
+    "Name":"https://schema.org/publishedOn",
     "Domain Bucket":"< 1K"
   },
   {
     "Class":"Predicate",
-    "Name":"http:\/\/schema.org\/publishedOn-input",
+    "Name":"https://schema.org/publishedOn-input",
     "Domain Bucket":"< 1K"
   },
   {
     "Class":"Predicate",
-    "Name":"http:\/\/schema.org\/publishedOn-output",
+    "Name":"https://schema.org/publishedOn-output",
     "Domain Bucket":"< 1K"
   },
   {
     "Class":"Predicate",
-    "Name":"http:\/\/schema.org\/publisher",
+    "Name":"https://schema.org/publisher",
     "Domain Bucket":"10M+"
   },
   {
     "Class":"Predicate",
-    "Name":"http:\/\/schema.org\/publisher-input",
+    "Name":"https://schema.org/publisher-input",
     "Domain Bucket":"< 1K"
   },
   {
     "Class":"Predicate",
-    "Name":"http:\/\/schema.org\/publisher-output",
+    "Name":"https://schema.org/publisher-output",
     "Domain Bucket":"< 1K"
   },
   {
     "Class":"Predicate",
-    "Name":"http:\/\/schema.org\/publisherImprint",
+    "Name":"https://schema.org/publisherImprint",
     "Domain Bucket":"< 1K"
   },
   {
     "Class":"Predicate",
-    "Name":"http:\/\/schema.org\/publisherImprint-input",
+    "Name":"https://schema.org/publisherImprint-input",
     "Domain Bucket":"< 1K"
   },
   {
     "Class":"Predicate",
-    "Name":"http:\/\/schema.org\/publisherImprint-output",
+    "Name":"https://schema.org/publisherImprint-output",
     "Domain Bucket":"< 1K"
   },
   {
     "Class":"Predicate",
-    "Name":"http:\/\/schema.org\/publishingPrinciples",
+    "Name":"https://schema.org/publishingPrinciples",
     "Domain Bucket":"10K - 100K"
   },
   {
     "Class":"Predicate",
-    "Name":"http:\/\/schema.org\/publishingPrinciples-input",
+    "Name":"https://schema.org/publishingPrinciples-input",
     "Domain Bucket":"< 1K"
   },
   {
     "Class":"Predicate",
-    "Name":"http:\/\/schema.org\/publishingPrinciples-output",
+    "Name":"https://schema.org/publishingPrinciples-output",
     "Domain Bucket":"< 1K"
   },
   {
     "Class":"Predicate",
-    "Name":"http:\/\/schema.org\/purchaseDate",
+    "Name":"https://schema.org/purchaseDate",
     "Domain Bucket":"1K - 10K"
   },
   {
     "Class":"Predicate",
-    "Name":"http:\/\/schema.org\/purchaseDate-input",
+    "Name":"https://schema.org/purchaseDate-input",
     "Domain Bucket":"< 1K"
   },
   {
     "Class":"Predicate",
-    "Name":"http:\/\/schema.org\/purchaseDate-output",
+    "Name":"https://schema.org/purchaseDate-output",
     "Domain Bucket":"< 1K"
   },
   {
     "Class":"Predicate",
-    "Name":"http:\/\/schema.org\/purchasePriceLimit",
+    "Name":"https://schema.org/purchasePriceLimit",
     "Domain Bucket":"< 1K"
   },
   {
     "Class":"Predicate",
-    "Name":"http:\/\/schema.org\/purchasePriceLimit-input",
+    "Name":"https://schema.org/purchasePriceLimit-input",
     "Domain Bucket":"< 1K"
   },
   {
     "Class":"Predicate",
-    "Name":"http:\/\/schema.org\/purchasePriceLimit-output",
+    "Name":"https://schema.org/purchasePriceLimit-output",
     "Domain Bucket":"< 1K"
   },
   {
     "Class":"Predicate",
-    "Name":"http:\/\/schema.org\/purchaseType",
+    "Name":"https://schema.org/purchaseType",
     "Domain Bucket":"< 1K"
   },
   {
     "Class":"Predicate",
-    "Name":"http:\/\/schema.org\/purchaseType-input",
+    "Name":"https://schema.org/purchaseType-input",
     "Domain Bucket":"< 1K"
   },
   {
     "Class":"Predicate",
-    "Name":"http:\/\/schema.org\/purchaseType-output",
+    "Name":"https://schema.org/purchaseType-output",
     "Domain Bucket":"< 1K"
   },
   {
     "Class":"Predicate",
-    "Name":"http:\/\/schema.org\/qualifications",
+    "Name":"https://schema.org/qualifications",
     "Domain Bucket":"10K - 100K"
   },
   {
     "Class":"Predicate",
-    "Name":"http:\/\/schema.org\/qualifications-input",
+    "Name":"https://schema.org/qualifications-input",
     "Domain Bucket":"< 1K"
   },
   {
     "Class":"Predicate",
-    "Name":"http:\/\/schema.org\/qualifications-output",
+    "Name":"https://schema.org/qualifications-output",
     "Domain Bucket":"< 1K"
   },
   {
     "Class":"Predicate",
-    "Name":"http:\/\/schema.org\/qualifiedExpense",
+    "Name":"https://schema.org/qualifiedExpense",
     "Domain Bucket":"< 1K"
   },
   {
     "Class":"Predicate",
-    "Name":"http:\/\/schema.org\/qualifiedExpense-input",
+    "Name":"https://schema.org/qualifiedExpense-input",
     "Domain Bucket":"< 1K"
   },
   {
     "Class":"Predicate",
-    "Name":"http:\/\/schema.org\/qualifiedExpense-output",
+    "Name":"https://schema.org/qualifiedExpense-output",
     "Domain Bucket":"< 1K"
   },
   {
     "Class":"Predicate",
-    "Name":"http:\/\/schema.org\/quarantineGuidelines",
+    "Name":"https://schema.org/quarantineGuidelines",
     "Domain Bucket":"< 1K"
   },
   {
     "Class":"Predicate",
-    "Name":"http:\/\/schema.org\/quarantineGuidelines-input",
+    "Name":"https://schema.org/quarantineGuidelines-input",
     "Domain Bucket":"< 1K"
   },
   {
     "Class":"Predicate",
-    "Name":"http:\/\/schema.org\/quarantineGuidelines-output",
+    "Name":"https://schema.org/quarantineGuidelines-output",
     "Domain Bucket":"< 1K"
   },
   {
     "Class":"Predicate",
-    "Name":"http:\/\/schema.org\/query",
+    "Name":"https://schema.org/query",
     "Domain Bucket":"10K - 100K"
   },
   {
     "Class":"Predicate",
-    "Name":"http:\/\/schema.org\/query-input",
+    "Name":"https://schema.org/query-input",
     "Domain Bucket":"10M+"
   },
   {
     "Class":"Predicate",
-    "Name":"http:\/\/schema.org\/query-output",
+    "Name":"https://schema.org/query-output",
     "Domain Bucket":"< 1K"
   },
   {
     "Class":"Predicate",
-    "Name":"http:\/\/schema.org\/quest",
+    "Name":"https://schema.org/quest",
     "Domain Bucket":"< 1K"
   },
   {
     "Class":"Predicate",
-    "Name":"http:\/\/schema.org\/quest-input",
+    "Name":"https://schema.org/quest-input",
     "Domain Bucket":"< 1K"
   },
   {
     "Class":"Predicate",
-    "Name":"http:\/\/schema.org\/quest-output",
+    "Name":"https://schema.org/quest-output",
     "Domain Bucket":"< 1K"
   },
   {
     "Class":"Predicate",
-    "Name":"http:\/\/schema.org\/question",
+    "Name":"https://schema.org/question",
     "Domain Bucket":"1K - 10K"
   },
   {
     "Class":"Predicate",
-    "Name":"http:\/\/schema.org\/question-input",
+    "Name":"https://schema.org/question-input",
     "Domain Bucket":"< 1K"
   },
   {
     "Class":"Predicate",
-    "Name":"http:\/\/schema.org\/question-output",
+    "Name":"https://schema.org/question-output",
     "Domain Bucket":"< 1K"
   },
   {
     "Class":"Predicate",
-    "Name":"http:\/\/schema.org\/rangeIncludes",
+    "Name":"https://schema.org/rangeIncludes",
     "Domain Bucket":"< 1K"
   },
   {
     "Class":"Predicate",
-    "Name":"http:\/\/schema.org\/rangeIncludes-input",
+    "Name":"https://schema.org/rangeIncludes-input",
     "Domain Bucket":"< 1K"
   },
   {
     "Class":"Predicate",
-    "Name":"http:\/\/schema.org\/rangeIncludes-output",
+    "Name":"https://schema.org/rangeIncludes-output",
     "Domain Bucket":"< 1K"
   },
   {
     "Class":"Predicate",
-    "Name":"http:\/\/schema.org\/ratingCount",
+    "Name":"https://schema.org/ratingCount",
     "Domain Bucket":"1M - 10M"
   },
   {
     "Class":"Predicate",
-    "Name":"http:\/\/schema.org\/ratingCount-input",
+    "Name":"https://schema.org/ratingCount-input",
     "Domain Bucket":"< 1K"
   },
   {
     "Class":"Predicate",
-    "Name":"http:\/\/schema.org\/ratingCount-output",
+    "Name":"https://schema.org/ratingCount-output",
     "Domain Bucket":"< 1K"
   },
   {
     "Class":"Predicate",
-    "Name":"http:\/\/schema.org\/ratingExplanation",
+    "Name":"https://schema.org/ratingExplanation",
     "Domain Bucket":"1K - 10K"
   },
   {
     "Class":"Predicate",
-    "Name":"http:\/\/schema.org\/ratingExplanation-input",
+    "Name":"https://schema.org/ratingExplanation-input",
     "Domain Bucket":"< 1K"
   },
   {
     "Class":"Predicate",
-    "Name":"http:\/\/schema.org\/ratingExplanation-output",
+    "Name":"https://schema.org/ratingExplanation-output",
     "Domain Bucket":"< 1K"
   },
   {
     "Class":"Predicate",
-    "Name":"http:\/\/schema.org\/ratingValue",
+    "Name":"https://schema.org/ratingValue",
     "Domain Bucket":"1M - 10M"
   },
   {
     "Class":"Predicate",
-    "Name":"http:\/\/schema.org\/ratingValue-input",
+    "Name":"https://schema.org/ratingValue-input",
     "Domain Bucket":"< 1K"
   },
   {
     "Class":"Predicate",
-    "Name":"http:\/\/schema.org\/ratingValue-output",
+    "Name":"https://schema.org/ratingValue-output",
     "Domain Bucket":"< 1K"
   },
   {
     "Class":"Predicate",
-    "Name":"http:\/\/schema.org\/readBy",
+    "Name":"https://schema.org/readBy",
     "Domain Bucket":"< 1K"
   },
   {
     "Class":"Predicate",
-    "Name":"http:\/\/schema.org\/readBy-input",
+    "Name":"https://schema.org/readBy-input",
     "Domain Bucket":"< 1K"
   },
   {
     "Class":"Predicate",
-    "Name":"http:\/\/schema.org\/readBy-output",
+    "Name":"https://schema.org/readBy-output",
     "Domain Bucket":"< 1K"
   },
   {
     "Class":"Predicate",
-    "Name":"http:\/\/schema.org\/readonlyValue",
+    "Name":"https://schema.org/readonlyValue",
     "Domain Bucket":"< 1K"
   },
   {
     "Class":"Predicate",
-    "Name":"http:\/\/schema.org\/readonlyValue-input",
+    "Name":"https://schema.org/readonlyValue-input",
     "Domain Bucket":"< 1K"
   },
   {
     "Class":"Predicate",
-    "Name":"http:\/\/schema.org\/readonlyValue-output",
+    "Name":"https://schema.org/readonlyValue-output",
     "Domain Bucket":"< 1K"
   },
   {
     "Class":"Predicate",
-    "Name":"http:\/\/schema.org\/realEstateAgent",
+    "Name":"https://schema.org/realEstateAgent",
     "Domain Bucket":"< 1K"
   },
   {
     "Class":"Predicate",
-    "Name":"http:\/\/schema.org\/realEstateAgent-input",
+    "Name":"https://schema.org/realEstateAgent-input",
     "Domain Bucket":"< 1K"
   },
   {
     "Class":"Predicate",
-    "Name":"http:\/\/schema.org\/realEstateAgent-output",
+    "Name":"https://schema.org/realEstateAgent-output",
     "Domain Bucket":"< 1K"
   },
   {
     "Class":"Predicate",
-    "Name":"http:\/\/schema.org\/recipe",
+    "Name":"https://schema.org/recipe",
     "Domain Bucket":"< 1K"
   },
   {
     "Class":"Predicate",
-    "Name":"http:\/\/schema.org\/recipe-input",
+    "Name":"https://schema.org/recipe-input",
     "Domain Bucket":"< 1K"
   },
   {
     "Class":"Predicate",
-    "Name":"http:\/\/schema.org\/recipe-output",
+    "Name":"https://schema.org/recipe-output",
     "Domain Bucket":"< 1K"
   },
   {
     "Class":"Predicate",
-    "Name":"http:\/\/schema.org\/recipeCategory",
+    "Name":"https://schema.org/recipeCategory",
     "Domain Bucket":"10K - 100K"
   },
   {
     "Class":"Predicate",
-    "Name":"http:\/\/schema.org\/recipeCategory-input",
+    "Name":"https://schema.org/recipeCategory-input",
     "Domain Bucket":"< 1K"
   },
   {
     "Class":"Predicate",
-    "Name":"http:\/\/schema.org\/recipeCategory-output",
+    "Name":"https://schema.org/recipeCategory-output",
     "Domain Bucket":"< 1K"
   },
   {
     "Class":"Predicate",
-    "Name":"http:\/\/schema.org\/recipeCuisine",
+    "Name":"https://schema.org/recipeCuisine",
     "Domain Bucket":"10K - 100K"
   },
   {
     "Class":"Predicate",
-    "Name":"http:\/\/schema.org\/recipeCuisine-input",
+    "Name":"https://schema.org/recipeCuisine-input",
     "Domain Bucket":"< 1K"
   },
   {
     "Class":"Predicate",
-    "Name":"http:\/\/schema.org\/recipeCuisine-output",
+    "Name":"https://schema.org/recipeCuisine-output",
     "Domain Bucket":"< 1K"
   },
   {
     "Class":"Predicate",
-    "Name":"http:\/\/schema.org\/recipeIngredient",
+    "Name":"https://schema.org/recipeIngredient",
     "Domain Bucket":"10K - 100K"
   },
   {
     "Class":"Predicate",
-    "Name":"http:\/\/schema.org\/recipeIngredient-input",
+    "Name":"https://schema.org/recipeIngredient-input",
     "Domain Bucket":"< 1K"
   },
   {
     "Class":"Predicate",
-    "Name":"http:\/\/schema.org\/recipeIngredient-output",
+    "Name":"https://schema.org/recipeIngredient-output",
     "Domain Bucket":"< 1K"
   },
   {
     "Class":"Predicate",
-    "Name":"http:\/\/schema.org\/recipeInstructions",
+    "Name":"https://schema.org/recipeInstructions",
     "Domain Bucket":"10K - 100K"
   },
   {
     "Class":"Predicate",
-    "Name":"http:\/\/schema.org\/recipeInstructions-input",
+    "Name":"https://schema.org/recipeInstructions-input",
     "Domain Bucket":"< 1K"
   },
   {
     "Class":"Predicate",
-    "Name":"http:\/\/schema.org\/recipeInstructions-output",
+    "Name":"https://schema.org/recipeInstructions-output",
     "Domain Bucket":"< 1K"
   },
   {
     "Class":"Predicate",
-    "Name":"http:\/\/schema.org\/recipeYield",
+    "Name":"https://schema.org/recipeYield",
     "Domain Bucket":"10K - 100K"
   },
   {
     "Class":"Predicate",
-    "Name":"http:\/\/schema.org\/recipeYield-input",
+    "Name":"https://schema.org/recipeYield-input",
     "Domain Bucket":"< 1K"
   },
   {
     "Class":"Predicate",
-    "Name":"http:\/\/schema.org\/recipeYield-output",
+    "Name":"https://schema.org/recipeYield-output",
     "Domain Bucket":"< 1K"
   },
   {
     "Class":"Predicate",
-    "Name":"http:\/\/schema.org\/recipient",
+    "Name":"https://schema.org/recipient",
     "Domain Bucket":"1K - 10K"
   },
   {
     "Class":"Predicate",
-    "Name":"http:\/\/schema.org\/recipient-input",
+    "Name":"https://schema.org/recipient-input",
     "Domain Bucket":"< 1K"
   },
   {
     "Class":"Predicate",
-    "Name":"http:\/\/schema.org\/recipient-output",
+    "Name":"https://schema.org/recipient-output",
     "Domain Bucket":"< 1K"
   },
   {
     "Class":"Predicate",
-    "Name":"http:\/\/schema.org\/recognizedBy",
+    "Name":"https://schema.org/recognizedBy",
     "Domain Bucket":"10K - 100K"
   },
   {
     "Class":"Predicate",
-    "Name":"http:\/\/schema.org\/recognizedBy-input",
+    "Name":"https://schema.org/recognizedBy-input",
     "Domain Bucket":"< 1K"
   },
   {
     "Class":"Predicate",
-    "Name":"http:\/\/schema.org\/recognizedBy-output",
+    "Name":"https://schema.org/recognizedBy-output",
     "Domain Bucket":"< 1K"
   },
   {
     "Class":"Predicate",
-    "Name":"http:\/\/schema.org\/recognizingAuthority",
+    "Name":"https://schema.org/recognizingAuthority",
     "Domain Bucket":"1K - 10K"
   },
   {
     "Class":"Predicate",
-    "Name":"http:\/\/schema.org\/recognizingAuthority-input",
+    "Name":"https://schema.org/recognizingAuthority-input",
     "Domain Bucket":"< 1K"
   },
   {
     "Class":"Predicate",
-    "Name":"http:\/\/schema.org\/recognizingAuthority-output",
+    "Name":"https://schema.org/recognizingAuthority-output",
     "Domain Bucket":"< 1K"
   },
   {
     "Class":"Predicate",
-    "Name":"http:\/\/schema.org\/recommendationStrength",
+    "Name":"https://schema.org/recommendationStrength",
     "Domain Bucket":"< 1K"
   },
   {
     "Class":"Predicate",
-    "Name":"http:\/\/schema.org\/recommendationStrength-input",
+    "Name":"https://schema.org/recommendationStrength-input",
     "Domain Bucket":"< 1K"
   },
   {
     "Class":"Predicate",
-    "Name":"http:\/\/schema.org\/recommendationStrength-output",
+    "Name":"https://schema.org/recommendationStrength-output",
     "Domain Bucket":"< 1K"
   },
   {
     "Class":"Predicate",
-    "Name":"http:\/\/schema.org\/recommendedIntake",
+    "Name":"https://schema.org/recommendedIntake",
     "Domain Bucket":"< 1K"
   },
   {
     "Class":"Predicate",
-    "Name":"http:\/\/schema.org\/recommendedIntake-input",
+    "Name":"https://schema.org/recommendedIntake-input",
     "Domain Bucket":"< 1K"
   },
   {
     "Class":"Predicate",
-    "Name":"http:\/\/schema.org\/recommendedIntake-output",
+    "Name":"https://schema.org/recommendedIntake-output",
     "Domain Bucket":"< 1K"
   },
   {
     "Class":"Predicate",
-    "Name":"http:\/\/schema.org\/recordLabel",
+    "Name":"https://schema.org/recordLabel",
     "Domain Bucket":"1K - 10K"
   },
   {
     "Class":"Predicate",
-    "Name":"http:\/\/schema.org\/recordLabel-input",
+    "Name":"https://schema.org/recordLabel-input",
     "Domain Bucket":"< 1K"
   },
   {
     "Class":"Predicate",
-    "Name":"http:\/\/schema.org\/recordLabel-output",
+    "Name":"https://schema.org/recordLabel-output",
     "Domain Bucket":"< 1K"
   },
   {
     "Class":"Predicate",
-    "Name":"http:\/\/schema.org\/recordedAs",
+    "Name":"https://schema.org/recordedAs",
     "Domain Bucket":"< 1K"
   },
   {
     "Class":"Predicate",
-    "Name":"http:\/\/schema.org\/recordedAs-input",
+    "Name":"https://schema.org/recordedAs-input",
     "Domain Bucket":"< 1K"
   },
   {
     "Class":"Predicate",
-    "Name":"http:\/\/schema.org\/recordedAs-output",
+    "Name":"https://schema.org/recordedAs-output",
     "Domain Bucket":"< 1K"
   },
   {
     "Class":"Predicate",
-    "Name":"http:\/\/schema.org\/recordedAt",
+    "Name":"https://schema.org/recordedAt",
     "Domain Bucket":"< 1K"
   },
   {
     "Class":"Predicate",
-    "Name":"http:\/\/schema.org\/recordedAt-input",
+    "Name":"https://schema.org/recordedAt-input",
     "Domain Bucket":"< 1K"
   },
   {
     "Class":"Predicate",
-    "Name":"http:\/\/schema.org\/recordedAt-output",
+    "Name":"https://schema.org/recordedAt-output",
     "Domain Bucket":"< 1K"
   },
   {
     "Class":"Predicate",
-    "Name":"http:\/\/schema.org\/recordedIn",
+    "Name":"https://schema.org/recordedIn",
     "Domain Bucket":"< 1K"
   },
   {
     "Class":"Predicate",
-    "Name":"http:\/\/schema.org\/recordedIn-input",
+    "Name":"https://schema.org/recordedIn-input",
     "Domain Bucket":"< 1K"
   },
   {
     "Class":"Predicate",
-    "Name":"http:\/\/schema.org\/recordedIn-output",
+    "Name":"https://schema.org/recordedIn-output",
     "Domain Bucket":"< 1K"
   },
   {
     "Class":"Predicate",
-    "Name":"http:\/\/schema.org\/recordingOf",
+    "Name":"https://schema.org/recordingOf",
     "Domain Bucket":"1K - 10K"
   },
   {
     "Class":"Predicate",
-    "Name":"http:\/\/schema.org\/recordingOf-input",
+    "Name":"https://schema.org/recordingOf-input",
     "Domain Bucket":"< 1K"
   },
   {
     "Class":"Predicate",
-    "Name":"http:\/\/schema.org\/recordingOf-output",
+    "Name":"https://schema.org/recordingOf-output",
     "Domain Bucket":"< 1K"
   },
   {
     "Class":"Predicate",
-    "Name":"http:\/\/schema.org\/recourseLoan",
+    "Name":"https://schema.org/recourseLoan",
     "Domain Bucket":"< 1K"
   },
   {
     "Class":"Predicate",
-    "Name":"http:\/\/schema.org\/recourseLoan-input",
+    "Name":"https://schema.org/recourseLoan-input",
     "Domain Bucket":"< 1K"
   },
   {
     "Class":"Predicate",
-    "Name":"http:\/\/schema.org\/recourseLoan-output",
+    "Name":"https://schema.org/recourseLoan-output",
     "Domain Bucket":"< 1K"
   },
   {
     "Class":"Predicate",
-    "Name":"http:\/\/schema.org\/referee",
+    "Name":"https://schema.org/referee",
     "Domain Bucket":"< 1K"
   },
   {
     "Class":"Predicate",
-    "Name":"http:\/\/schema.org\/referee-input",
+    "Name":"https://schema.org/referee-input",
     "Domain Bucket":"< 1K"
   },
   {
     "Class":"Predicate",
-    "Name":"http:\/\/schema.org\/referee-output",
+    "Name":"https://schema.org/referee-output",
     "Domain Bucket":"< 1K"
   },
   {
     "Class":"Predicate",
-    "Name":"http:\/\/schema.org\/referenceQuantity",
+    "Name":"https://schema.org/referenceQuantity",
     "Domain Bucket":"1M - 10M"
   },
   {
     "Class":"Predicate",
-    "Name":"http:\/\/schema.org\/referenceQuantity-input",
+    "Name":"https://schema.org/referenceQuantity-input",
     "Domain Bucket":"< 1K"
   },
   {
     "Class":"Predicate",
-    "Name":"http:\/\/schema.org\/referenceQuantity-output",
+    "Name":"https://schema.org/referenceQuantity-output",
     "Domain Bucket":"< 1K"
   },
   {
     "Class":"Predicate",
-    "Name":"http:\/\/schema.org\/referencesOrder",
+    "Name":"https://schema.org/referencesOrder",
     "Domain Bucket":"< 1K"
   },
   {
     "Class":"Predicate",
-    "Name":"http:\/\/schema.org\/referencesOrder-input",
+    "Name":"https://schema.org/referencesOrder-input",
     "Domain Bucket":"< 1K"
   },
   {
     "Class":"Predicate",
-    "Name":"http:\/\/schema.org\/referencesOrder-output",
+    "Name":"https://schema.org/referencesOrder-output",
     "Domain Bucket":"< 1K"
   },
   {
     "Class":"Predicate",
-    "Name":"http:\/\/schema.org\/refundType",
+    "Name":"https://schema.org/refundType",
     "Domain Bucket":"10K - 100K"
   },
   {
     "Class":"Predicate",
-    "Name":"http:\/\/schema.org\/refundType-input",
+    "Name":"https://schema.org/refundType-input",
     "Domain Bucket":"< 1K"
   },
   {
     "Class":"Predicate",
-    "Name":"http:\/\/schema.org\/refundType-output",
+    "Name":"https://schema.org/refundType-output",
     "Domain Bucket":"< 1K"
   },
   {
     "Class":"Predicate",
-    "Name":"http:\/\/schema.org\/regionDrained",
+    "Name":"https://schema.org/regionDrained",
     "Domain Bucket":"< 1K"
   },
   {
     "Class":"Predicate",
-    "Name":"http:\/\/schema.org\/regionDrained-input",
+    "Name":"https://schema.org/regionDrained-input",
     "Domain Bucket":"< 1K"
   },
   {
     "Class":"Predicate",
-    "Name":"http:\/\/schema.org\/regionDrained-output",
+    "Name":"https://schema.org/regionDrained-output",
     "Domain Bucket":"< 1K"
   },
   {
     "Class":"Predicate",
-    "Name":"http:\/\/schema.org\/regionsAllowed",
+    "Name":"https://schema.org/regionsAllowed",
     "Domain Bucket":"10K - 100K"
   },
   {
     "Class":"Predicate",
-    "Name":"http:\/\/schema.org\/regionsAllowed-input",
+    "Name":"https://schema.org/regionsAllowed-input",
     "Domain Bucket":"< 1K"
   },
   {
     "Class":"Predicate",
-    "Name":"http:\/\/schema.org\/regionsAllowed-output",
+    "Name":"https://schema.org/regionsAllowed-output",
     "Domain Bucket":"< 1K"
   },
   {
     "Class":"Predicate",
-    "Name":"http:\/\/schema.org\/relatedAnatomy",
+    "Name":"https://schema.org/relatedAnatomy",
     "Domain Bucket":"< 1K"
   },
   {
     "Class":"Predicate",
-    "Name":"http:\/\/schema.org\/relatedAnatomy-input",
+    "Name":"https://schema.org/relatedAnatomy-input",
     "Domain Bucket":"< 1K"
   },
   {
     "Class":"Predicate",
-    "Name":"http:\/\/schema.org\/relatedAnatomy-output",
+    "Name":"https://schema.org/relatedAnatomy-output",
     "Domain Bucket":"< 1K"
   },
   {
     "Class":"Predicate",
-    "Name":"http:\/\/schema.org\/relatedCondition",
+    "Name":"https://schema.org/relatedCondition",
     "Domain Bucket":"< 1K"
   },
   {
     "Class":"Predicate",
-    "Name":"http:\/\/schema.org\/relatedCondition-input",
+    "Name":"https://schema.org/relatedCondition-input",
     "Domain Bucket":"< 1K"
   },
   {
     "Class":"Predicate",
-    "Name":"http:\/\/schema.org\/relatedCondition-output",
+    "Name":"https://schema.org/relatedCondition-output",
     "Domain Bucket":"< 1K"
   },
   {
     "Class":"Predicate",
-    "Name":"http:\/\/schema.org\/relatedDrug",
+    "Name":"https://schema.org/relatedDrug",
     "Domain Bucket":"< 1K"
   },
   {
     "Class":"Predicate",
-    "Name":"http:\/\/schema.org\/relatedDrug-input",
+    "Name":"https://schema.org/relatedDrug-input",
     "Domain Bucket":"< 1K"
   },
   {
     "Class":"Predicate",
-    "Name":"http:\/\/schema.org\/relatedDrug-output",
+    "Name":"https://schema.org/relatedDrug-output",
     "Domain Bucket":"< 1K"
   },
   {
     "Class":"Predicate",
-    "Name":"http:\/\/schema.org\/relatedLink",
+    "Name":"https://schema.org/relatedLink",
     "Domain Bucket":"10K - 100K"
   },
   {
     "Class":"Predicate",
-    "Name":"http:\/\/schema.org\/relatedLink-input",
+    "Name":"https://schema.org/relatedLink-input",
     "Domain Bucket":"< 1K"
   },
   {
     "Class":"Predicate",
-    "Name":"http:\/\/schema.org\/relatedLink-output",
+    "Name":"https://schema.org/relatedLink-output",
     "Domain Bucket":"< 1K"
   },
   {
     "Class":"Predicate",
-    "Name":"http:\/\/schema.org\/relatedStructure",
+    "Name":"https://schema.org/relatedStructure",
     "Domain Bucket":"< 1K"
   },
   {
     "Class":"Predicate",
-    "Name":"http:\/\/schema.org\/relatedStructure-input",
+    "Name":"https://schema.org/relatedStructure-input",
     "Domain Bucket":"< 1K"
   },
   {
     "Class":"Predicate",
-    "Name":"http:\/\/schema.org\/relatedStructure-output",
+    "Name":"https://schema.org/relatedStructure-output",
     "Domain Bucket":"< 1K"
   },
   {
     "Class":"Predicate",
-    "Name":"http:\/\/schema.org\/relatedTherapy",
+    "Name":"https://schema.org/relatedTherapy",
     "Domain Bucket":"< 1K"
   },
   {
     "Class":"Predicate",
-    "Name":"http:\/\/schema.org\/relatedTherapy-input",
+    "Name":"https://schema.org/relatedTherapy-input",
     "Domain Bucket":"< 1K"
   },
   {
     "Class":"Predicate",
-    "Name":"http:\/\/schema.org\/relatedTherapy-output",
+    "Name":"https://schema.org/relatedTherapy-output",
     "Domain Bucket":"< 1K"
   },
   {
     "Class":"Predicate",
-    "Name":"http:\/\/schema.org\/relatedTo",
+    "Name":"https://schema.org/relatedTo",
     "Domain Bucket":"< 1K"
   },
   {
     "Class":"Predicate",
-    "Name":"http:\/\/schema.org\/relatedTo-input",
+    "Name":"https://schema.org/relatedTo-input",
     "Domain Bucket":"< 1K"
   },
   {
     "Class":"Predicate",
-    "Name":"http:\/\/schema.org\/relatedTo-output",
+    "Name":"https://schema.org/relatedTo-output",
     "Domain Bucket":"< 1K"
   },
   {
     "Class":"Predicate",
-    "Name":"http:\/\/schema.org\/releaseDate",
+    "Name":"https://schema.org/releaseDate",
     "Domain Bucket":"10K - 100K"
   },
   {
     "Class":"Predicate",
-    "Name":"http:\/\/schema.org\/releaseDate-input",
+    "Name":"https://schema.org/releaseDate-input",
     "Domain Bucket":"< 1K"
   },
   {
     "Class":"Predicate",
-    "Name":"http:\/\/schema.org\/releaseDate-output",
+    "Name":"https://schema.org/releaseDate-output",
     "Domain Bucket":"< 1K"
   },
   {
     "Class":"Predicate",
-    "Name":"http:\/\/schema.org\/releaseNotes",
+    "Name":"https://schema.org/releaseNotes",
     "Domain Bucket":"10K - 100K"
   },
   {
     "Class":"Predicate",
-    "Name":"http:\/\/schema.org\/releaseNotes-input",
+    "Name":"https://schema.org/releaseNotes-input",
     "Domain Bucket":"< 1K"
   },
   {
     "Class":"Predicate",
-    "Name":"http:\/\/schema.org\/releaseNotes-output",
+    "Name":"https://schema.org/releaseNotes-output",
     "Domain Bucket":"< 1K"
   },
   {
     "Class":"Predicate",
-    "Name":"http:\/\/schema.org\/releaseOf",
+    "Name":"https://schema.org/releaseOf",
     "Domain Bucket":"< 1K"
   },
   {
     "Class":"Predicate",
-    "Name":"http:\/\/schema.org\/releaseOf-input",
+    "Name":"https://schema.org/releaseOf-input",
     "Domain Bucket":"< 1K"
   },
   {
     "Class":"Predicate",
-    "Name":"http:\/\/schema.org\/releaseOf-output",
+    "Name":"https://schema.org/releaseOf-output",
     "Domain Bucket":"< 1K"
   },
   {
     "Class":"Predicate",
-    "Name":"http:\/\/schema.org\/releasedEvent",
+    "Name":"https://schema.org/releasedEvent",
     "Domain Bucket":"1K - 10K"
   },
   {
     "Class":"Predicate",
-    "Name":"http:\/\/schema.org\/releasedEvent-input",
+    "Name":"https://schema.org/releasedEvent-input",
     "Domain Bucket":"< 1K"
   },
   {
     "Class":"Predicate",
-    "Name":"http:\/\/schema.org\/releasedEvent-output",
+    "Name":"https://schema.org/releasedEvent-output",
     "Domain Bucket":"< 1K"
   },
   {
     "Class":"Predicate",
-    "Name":"http:\/\/schema.org\/relevantOccupation",
+    "Name":"https://schema.org/relevantOccupation",
     "Domain Bucket":"< 1K"
   },
   {
     "Class":"Predicate",
-    "Name":"http:\/\/schema.org\/relevantOccupation-input",
+    "Name":"https://schema.org/relevantOccupation-input",
     "Domain Bucket":"< 1K"
   },
   {
     "Class":"Predicate",
-    "Name":"http:\/\/schema.org\/relevantOccupation-output",
+    "Name":"https://schema.org/relevantOccupation-output",
     "Domain Bucket":"< 1K"
   },
   {
     "Class":"Predicate",
-    "Name":"http:\/\/schema.org\/relevantSpecialty",
+    "Name":"https://schema.org/relevantSpecialty",
     "Domain Bucket":"10K - 100K"
   },
   {
     "Class":"Predicate",
-    "Name":"http:\/\/schema.org\/relevantSpecialty-input",
+    "Name":"https://schema.org/relevantSpecialty-input",
     "Domain Bucket":"< 1K"
   },
   {
     "Class":"Predicate",
-    "Name":"http:\/\/schema.org\/relevantSpecialty-output",
+    "Name":"https://schema.org/relevantSpecialty-output",
     "Domain Bucket":"< 1K"
   },
   {
     "Class":"Predicate",
-    "Name":"http:\/\/schema.org\/remainingAttendeeCapacity",
+    "Name":"https://schema.org/remainingAttendeeCapacity",
     "Domain Bucket":"1K - 10K"
   },
   {
     "Class":"Predicate",
-    "Name":"http:\/\/schema.org\/remainingAttendeeCapacity-input",
+    "Name":"https://schema.org/remainingAttendeeCapacity-input",
     "Domain Bucket":"< 1K"
   },
   {
     "Class":"Predicate",
-    "Name":"http:\/\/schema.org\/remainingAttendeeCapacity-output",
+    "Name":"https://schema.org/remainingAttendeeCapacity-output",
     "Domain Bucket":"< 1K"
   },
   {
     "Class":"Predicate",
-    "Name":"http:\/\/schema.org\/renegotiableLoan",
+    "Name":"https://schema.org/renegotiableLoan",
     "Domain Bucket":"< 1K"
   },
   {
     "Class":"Predicate",
-    "Name":"http:\/\/schema.org\/renegotiableLoan-input",
+    "Name":"https://schema.org/renegotiableLoan-input",
     "Domain Bucket":"< 1K"
   },
   {
     "Class":"Predicate",
-    "Name":"http:\/\/schema.org\/renegotiableLoan-output",
+    "Name":"https://schema.org/renegotiableLoan-output",
     "Domain Bucket":"< 1K"
   },
   {
     "Class":"Predicate",
-    "Name":"http:\/\/schema.org\/repeatCount",
+    "Name":"https://schema.org/repeatCount",
     "Domain Bucket":"1K - 10K"
   },
   {
     "Class":"Predicate",
-    "Name":"http:\/\/schema.org\/repeatCount-input",
+    "Name":"https://schema.org/repeatCount-input",
     "Domain Bucket":"< 1K"
   },
   {
     "Class":"Predicate",
-    "Name":"http:\/\/schema.org\/repeatCount-output",
+    "Name":"https://schema.org/repeatCount-output",
     "Domain Bucket":"< 1K"
   },
   {
     "Class":"Predicate",
-    "Name":"http:\/\/schema.org\/repeatFrequency",
+    "Name":"https://schema.org/repeatFrequency",
     "Domain Bucket":"10K - 100K"
   },
   {
     "Class":"Predicate",
-    "Name":"http:\/\/schema.org\/repeatFrequency-input",
+    "Name":"https://schema.org/repeatFrequency-input",
     "Domain Bucket":"< 1K"
   },
   {
     "Class":"Predicate",
-    "Name":"http:\/\/schema.org\/repeatFrequency-output",
+    "Name":"https://schema.org/repeatFrequency-output",
     "Domain Bucket":"< 1K"
   },
   {
     "Class":"Predicate",
-    "Name":"http:\/\/schema.org\/repetitions",
+    "Name":"https://schema.org/repetitions",
     "Domain Bucket":"< 1K"
   },
   {
     "Class":"Predicate",
-    "Name":"http:\/\/schema.org\/repetitions-input",
+    "Name":"https://schema.org/repetitions-input",
     "Domain Bucket":"< 1K"
   },
   {
     "Class":"Predicate",
-    "Name":"http:\/\/schema.org\/repetitions-output",
+    "Name":"https://schema.org/repetitions-output",
     "Domain Bucket":"< 1K"
   },
   {
     "Class":"Predicate",
-    "Name":"http:\/\/schema.org\/replacee",
+    "Name":"https://schema.org/replacee",
     "Domain Bucket":"< 1K"
   },
   {
     "Class":"Predicate",
-    "Name":"http:\/\/schema.org\/replacee-input",
+    "Name":"https://schema.org/replacee-input",
     "Domain Bucket":"< 1K"
   },
   {
     "Class":"Predicate",
-    "Name":"http:\/\/schema.org\/replacee-output",
+    "Name":"https://schema.org/replacee-output",
     "Domain Bucket":"< 1K"
   },
   {
     "Class":"Predicate",
-    "Name":"http:\/\/schema.org\/replacer",
+    "Name":"https://schema.org/replacer",
     "Domain Bucket":"< 1K"
   },
   {
     "Class":"Predicate",
-    "Name":"http:\/\/schema.org\/replacer-input",
+    "Name":"https://schema.org/replacer-input",
     "Domain Bucket":"< 1K"
   },
   {
     "Class":"Predicate",
-    "Name":"http:\/\/schema.org\/replacer-output",
+    "Name":"https://schema.org/replacer-output",
     "Domain Bucket":"< 1K"
   },
   {
     "Class":"Predicate",
-    "Name":"http:\/\/schema.org\/replyToUrl",
+    "Name":"https://schema.org/replyToUrl",
     "Domain Bucket":"1K - 10K"
   },
   {
     "Class":"Predicate",
-    "Name":"http:\/\/schema.org\/replyToUrl-input",
+    "Name":"https://schema.org/replyToUrl-input",
     "Domain Bucket":"< 1K"
   },
   {
     "Class":"Predicate",
-    "Name":"http:\/\/schema.org\/replyToUrl-output",
+    "Name":"https://schema.org/replyToUrl-output",
     "Domain Bucket":"< 1K"
   },
   {
     "Class":"Predicate",
-    "Name":"http:\/\/schema.org\/reportNumber",
+    "Name":"https://schema.org/reportNumber",
     "Domain Bucket":"< 1K"
   },
   {
     "Class":"Predicate",
-    "Name":"http:\/\/schema.org\/reportNumber-input",
+    "Name":"https://schema.org/reportNumber-input",
     "Domain Bucket":"< 1K"
   },
   {
     "Class":"Predicate",
-    "Name":"http:\/\/schema.org\/reportNumber-output",
+    "Name":"https://schema.org/reportNumber-output",
     "Domain Bucket":"< 1K"
   },
   {
     "Class":"Predicate",
-    "Name":"http:\/\/schema.org\/representativeOfPage",
+    "Name":"https://schema.org/representativeOfPage",
     "Domain Bucket":"100K - 1M"
   },
   {
     "Class":"Predicate",
-    "Name":"http:\/\/schema.org\/representativeOfPage-input",
+    "Name":"https://schema.org/representativeOfPage-input",
     "Domain Bucket":"< 1K"
   },
   {
     "Class":"Predicate",
-    "Name":"http:\/\/schema.org\/representativeOfPage-output",
+    "Name":"https://schema.org/representativeOfPage-output",
     "Domain Bucket":"< 1K"
   },
   {
     "Class":"Predicate",
-    "Name":"http:\/\/schema.org\/requiredCollateral",
+    "Name":"https://schema.org/requiredCollateral",
     "Domain Bucket":"< 1K"
   },
   {
     "Class":"Predicate",
-    "Name":"http:\/\/schema.org\/requiredCollateral-input",
+    "Name":"https://schema.org/requiredCollateral-input",
     "Domain Bucket":"< 1K"
   },
   {
     "Class":"Predicate",
-    "Name":"http:\/\/schema.org\/requiredCollateral-output",
+    "Name":"https://schema.org/requiredCollateral-output",
     "Domain Bucket":"< 1K"
   },
   {
     "Class":"Predicate",
-    "Name":"http:\/\/schema.org\/requiredGender",
+    "Name":"https://schema.org/requiredGender",
     "Domain Bucket":"< 1K"
   },
   {
     "Class":"Predicate",
-    "Name":"http:\/\/schema.org\/requiredGender-input",
+    "Name":"https://schema.org/requiredGender-input",
     "Domain Bucket":"< 1K"
   },
   {
     "Class":"Predicate",
-    "Name":"http:\/\/schema.org\/requiredGender-output",
+    "Name":"https://schema.org/requiredGender-output",
     "Domain Bucket":"< 1K"
   },
   {
     "Class":"Predicate",
-    "Name":"http:\/\/schema.org\/requiredMaxAge",
+    "Name":"https://schema.org/requiredMaxAge",
     "Domain Bucket":"< 1K"
   },
   {
     "Class":"Predicate",
-    "Name":"http:\/\/schema.org\/requiredMaxAge-input",
+    "Name":"https://schema.org/requiredMaxAge-input",
     "Domain Bucket":"< 1K"
   },
   {
     "Class":"Predicate",
-    "Name":"http:\/\/schema.org\/requiredMaxAge-output",
+    "Name":"https://schema.org/requiredMaxAge-output",
     "Domain Bucket":"< 1K"
   },
   {
     "Class":"Predicate",
-    "Name":"http:\/\/schema.org\/requiredMinAge",
+    "Name":"https://schema.org/requiredMinAge",
     "Domain Bucket":"1K - 10K"
   },
   {
     "Class":"Predicate",
-    "Name":"http:\/\/schema.org\/requiredMinAge-input",
+    "Name":"https://schema.org/requiredMinAge-input",
     "Domain Bucket":"< 1K"
   },
   {
     "Class":"Predicate",
-    "Name":"http:\/\/schema.org\/requiredMinAge-output",
+    "Name":"https://schema.org/requiredMinAge-output",
     "Domain Bucket":"< 1K"
   },
   {
     "Class":"Predicate",
-    "Name":"http:\/\/schema.org\/requiredQuantity",
+    "Name":"https://schema.org/requiredQuantity",
     "Domain Bucket":"1K - 10K"
   },
   {
     "Class":"Predicate",
-    "Name":"http:\/\/schema.org\/requiredQuantity-input",
+    "Name":"https://schema.org/requiredQuantity-input",
     "Domain Bucket":"< 1K"
   },
   {
     "Class":"Predicate",
-    "Name":"http:\/\/schema.org\/requiredQuantity-output",
+    "Name":"https://schema.org/requiredQuantity-output",
     "Domain Bucket":"< 1K"
   },
   {
     "Class":"Predicate",
-    "Name":"http:\/\/schema.org\/requirements",
+    "Name":"https://schema.org/requirements",
     "Domain Bucket":"1K - 10K"
   },
   {
     "Class":"Predicate",
-    "Name":"http:\/\/schema.org\/requirements-input",
+    "Name":"https://schema.org/requirements-input",
     "Domain Bucket":"< 1K"
   },
   {
     "Class":"Predicate",
-    "Name":"http:\/\/schema.org\/requirements-output",
+    "Name":"https://schema.org/requirements-output",
     "Domain Bucket":"< 1K"
   },
   {
     "Class":"Predicate",
-    "Name":"http:\/\/schema.org\/requiresSubscription",
+    "Name":"https://schema.org/requiresSubscription",
     "Domain Bucket":"1K - 10K"
   },
   {
     "Class":"Predicate",
-    "Name":"http:\/\/schema.org\/requiresSubscription-input",
+    "Name":"https://schema.org/requiresSubscription-input",
     "Domain Bucket":"< 1K"
   },
   {
     "Class":"Predicate",
-    "Name":"http:\/\/schema.org\/requiresSubscription-output",
+    "Name":"https://schema.org/requiresSubscription-output",
     "Domain Bucket":"< 1K"
   },
   {
     "Class":"Predicate",
-    "Name":"http:\/\/schema.org\/reservationFor",
+    "Name":"https://schema.org/reservationFor",
     "Domain Bucket":"1K - 10K"
   },
   {
     "Class":"Predicate",
-    "Name":"http:\/\/schema.org\/reservationFor-input",
+    "Name":"https://schema.org/reservationFor-input",
     "Domain Bucket":"< 1K"
   },
   {
     "Class":"Predicate",
-    "Name":"http:\/\/schema.org\/reservationFor-output",
+    "Name":"https://schema.org/reservationFor-output",
     "Domain Bucket":"< 1K"
   },
   {
     "Class":"Predicate",
-    "Name":"http:\/\/schema.org\/reservationId",
+    "Name":"https://schema.org/reservationId",
     "Domain Bucket":"< 1K"
   },
   {
     "Class":"Predicate",
-    "Name":"http:\/\/schema.org\/reservationId-input",
+    "Name":"https://schema.org/reservationId-input",
     "Domain Bucket":"< 1K"
   },
   {
     "Class":"Predicate",
-    "Name":"http:\/\/schema.org\/reservationId-output",
+    "Name":"https://schema.org/reservationId-output",
     "Domain Bucket":"< 1K"
   },
   {
     "Class":"Predicate",
-    "Name":"http:\/\/schema.org\/reservationStatus",
+    "Name":"https://schema.org/reservationStatus",
     "Domain Bucket":"< 1K"
   },
   {
     "Class":"Predicate",
-    "Name":"http:\/\/schema.org\/reservationStatus-input",
+    "Name":"https://schema.org/reservationStatus-input",
     "Domain Bucket":"< 1K"
   },
   {
     "Class":"Predicate",
-    "Name":"http:\/\/schema.org\/reservationStatus-output",
+    "Name":"https://schema.org/reservationStatus-output",
     "Domain Bucket":"< 1K"
   },
   {
     "Class":"Predicate",
-    "Name":"http:\/\/schema.org\/reservedTicket",
+    "Name":"https://schema.org/reservedTicket",
     "Domain Bucket":"< 1K"
   },
   {
     "Class":"Predicate",
-    "Name":"http:\/\/schema.org\/reservedTicket-input",
+    "Name":"https://schema.org/reservedTicket-input",
     "Domain Bucket":"< 1K"
   },
   {
     "Class":"Predicate",
-    "Name":"http:\/\/schema.org\/reservedTicket-output",
+    "Name":"https://schema.org/reservedTicket-output",
     "Domain Bucket":"< 1K"
   },
   {
     "Class":"Predicate",
-    "Name":"http:\/\/schema.org\/responsibilities",
+    "Name":"https://schema.org/responsibilities",
     "Domain Bucket":"10K - 100K"
   },
   {
     "Class":"Predicate",
-    "Name":"http:\/\/schema.org\/responsibilities-input",
+    "Name":"https://schema.org/responsibilities-input",
     "Domain Bucket":"< 1K"
   },
   {
     "Class":"Predicate",
-    "Name":"http:\/\/schema.org\/responsibilities-output",
+    "Name":"https://schema.org/responsibilities-output",
     "Domain Bucket":"< 1K"
   },
   {
     "Class":"Predicate",
-    "Name":"http:\/\/schema.org\/restPeriods",
+    "Name":"https://schema.org/restPeriods",
     "Domain Bucket":"< 1K"
   },
   {
     "Class":"Predicate",
-    "Name":"http:\/\/schema.org\/restPeriods-input",
+    "Name":"https://schema.org/restPeriods-input",
     "Domain Bucket":"< 1K"
   },
   {
     "Class":"Predicate",
-    "Name":"http:\/\/schema.org\/restPeriods-output",
+    "Name":"https://schema.org/restPeriods-output",
     "Domain Bucket":"< 1K"
   },
   {
     "Class":"Predicate",
-    "Name":"http:\/\/schema.org\/restockingFee",
+    "Name":"https://schema.org/restockingFee",
     "Domain Bucket":"1K - 10K"
   },
   {
     "Class":"Predicate",
-    "Name":"http:\/\/schema.org\/restockingFee-input",
+    "Name":"https://schema.org/restockingFee-input",
     "Domain Bucket":"< 1K"
   },
   {
     "Class":"Predicate",
-    "Name":"http:\/\/schema.org\/restockingFee-output",
+    "Name":"https://schema.org/restockingFee-output",
     "Domain Bucket":"< 1K"
   },
   {
     "Class":"Predicate",
-    "Name":"http:\/\/schema.org\/result",
+    "Name":"https://schema.org/result",
     "Domain Bucket":"10K - 100K"
   },
   {
     "Class":"Predicate",
-    "Name":"http:\/\/schema.org\/result-input",
+    "Name":"https://schema.org/result-input",
     "Domain Bucket":"< 1K"
   },
   {
     "Class":"Predicate",
-    "Name":"http:\/\/schema.org\/result-output",
+    "Name":"https://schema.org/result-output",
     "Domain Bucket":"< 1K"
   },
   {
     "Class":"Predicate",
-    "Name":"http:\/\/schema.org\/resultComment",
+    "Name":"https://schema.org/resultComment",
     "Domain Bucket":"< 1K"
   },
   {
     "Class":"Predicate",
-    "Name":"http:\/\/schema.org\/resultComment-input",
+    "Name":"https://schema.org/resultComment-input",
     "Domain Bucket":"< 1K"
   },
   {
     "Class":"Predicate",
-    "Name":"http:\/\/schema.org\/resultComment-output",
+    "Name":"https://schema.org/resultComment-output",
     "Domain Bucket":"< 1K"
   },
   {
     "Class":"Predicate",
-    "Name":"http:\/\/schema.org\/resultReview",
+    "Name":"https://schema.org/resultReview",
     "Domain Bucket":"< 1K"
   },
   {
     "Class":"Predicate",
-    "Name":"http:\/\/schema.org\/resultReview-input",
+    "Name":"https://schema.org/resultReview-input",
     "Domain Bucket":"< 1K"
   },
   {
     "Class":"Predicate",
-    "Name":"http:\/\/schema.org\/resultReview-output",
+    "Name":"https://schema.org/resultReview-output",
     "Domain Bucket":"< 1K"
   },
   {
     "Class":"Predicate",
-    "Name":"http:\/\/schema.org\/returnFees",
+    "Name":"https://schema.org/returnFees",
     "Domain Bucket":"100K - 1M"
   },
   {
     "Class":"Predicate",
-    "Name":"http:\/\/schema.org\/returnFees-input",
+    "Name":"https://schema.org/returnFees-input",
     "Domain Bucket":"< 1K"
   },
   {
     "Class":"Predicate",
-    "Name":"http:\/\/schema.org\/returnFees-output",
+    "Name":"https://schema.org/returnFees-output",
     "Domain Bucket":"< 1K"
   },
   {
     "Class":"Predicate",
-    "Name":"http:\/\/schema.org\/returnLabelSource",
+    "Name":"https://schema.org/returnLabelSource",
     "Domain Bucket":"1K - 10K"
   },
   {
     "Class":"Predicate",
-    "Name":"http:\/\/schema.org\/returnLabelSource-input",
+    "Name":"https://schema.org/returnLabelSource-input",
     "Domain Bucket":"< 1K"
   },
   {
     "Class":"Predicate",
-    "Name":"http:\/\/schema.org\/returnLabelSource-output",
+    "Name":"https://schema.org/returnLabelSource-output",
     "Domain Bucket":"< 1K"
   },
   {
     "Class":"Predicate",
-    "Name":"http:\/\/schema.org\/returnMethod",
+    "Name":"https://schema.org/returnMethod",
     "Domain Bucket":"100K - 1M"
   },
   {
     "Class":"Predicate",
-    "Name":"http:\/\/schema.org\/returnMethod-input",
+    "Name":"https://schema.org/returnMethod-input",
     "Domain Bucket":"< 1K"
   },
   {
     "Class":"Predicate",
-    "Name":"http:\/\/schema.org\/returnMethod-output",
+    "Name":"https://schema.org/returnMethod-output",
     "Domain Bucket":"< 1K"
   },
   {
     "Class":"Predicate",
-    "Name":"http:\/\/schema.org\/returnPolicyCategory",
+    "Name":"https://schema.org/returnPolicyCategory",
     "Domain Bucket":"100K - 1M"
   },
   {
     "Class":"Predicate",
-    "Name":"http:\/\/schema.org\/returnPolicyCategory-input",
+    "Name":"https://schema.org/returnPolicyCategory-input",
     "Domain Bucket":"< 1K"
   },
   {
     "Class":"Predicate",
-    "Name":"http:\/\/schema.org\/returnPolicyCategory-output",
+    "Name":"https://schema.org/returnPolicyCategory-output",
     "Domain Bucket":"< 1K"
   },
   {
     "Class":"Predicate",
-    "Name":"http:\/\/schema.org\/returnPolicyCountry",
+    "Name":"https://schema.org/returnPolicyCountry",
     "Domain Bucket":"10K - 100K"
   },
   {
     "Class":"Predicate",
-    "Name":"http:\/\/schema.org\/returnPolicyCountry-input",
+    "Name":"https://schema.org/returnPolicyCountry-input",
     "Domain Bucket":"< 1K"
   },
   {
     "Class":"Predicate",
-    "Name":"http:\/\/schema.org\/returnPolicyCountry-output",
+    "Name":"https://schema.org/returnPolicyCountry-output",
     "Domain Bucket":"< 1K"
   },
   {
     "Class":"Predicate",
-    "Name":"http:\/\/schema.org\/returnPolicySeasonalOverride",
+    "Name":"https://schema.org/returnPolicySeasonalOverride",
     "Domain Bucket":"1K - 10K"
   },
   {
     "Class":"Predicate",
-    "Name":"http:\/\/schema.org\/returnPolicySeasonalOverride-input",
+    "Name":"https://schema.org/returnPolicySeasonalOverride-input",
     "Domain Bucket":"< 1K"
   },
   {
     "Class":"Predicate",
-    "Name":"http:\/\/schema.org\/returnPolicySeasonalOverride-output",
+    "Name":"https://schema.org/returnPolicySeasonalOverride-output",
     "Domain Bucket":"< 1K"
   },
   {
     "Class":"Predicate",
-    "Name":"http:\/\/schema.org\/returnShippingFeesAmount",
+    "Name":"https://schema.org/returnShippingFeesAmount",
     "Domain Bucket":"10K - 100K"
   },
   {
     "Class":"Predicate",
-    "Name":"http:\/\/schema.org\/returnShippingFeesAmount-input",
+    "Name":"https://schema.org/returnShippingFeesAmount-input",
     "Domain Bucket":"< 1K"
   },
   {
     "Class":"Predicate",
-    "Name":"http:\/\/schema.org\/returnShippingFeesAmount-output",
+    "Name":"https://schema.org/returnShippingFeesAmount-output",
     "Domain Bucket":"< 1K"
   },
   {
     "Class":"Predicate",
-    "Name":"http:\/\/schema.org\/review",
+    "Name":"https://schema.org/review",
     "Domain Bucket":"1M - 10M"
   },
   {
     "Class":"Predicate",
-    "Name":"http:\/\/schema.org\/review-input",
+    "Name":"https://schema.org/review-input",
     "Domain Bucket":"< 1K"
   },
   {
     "Class":"Predicate",
-    "Name":"http:\/\/schema.org\/review-output",
+    "Name":"https://schema.org/review-output",
     "Domain Bucket":"< 1K"
   },
   {
     "Class":"Predicate",
-    "Name":"http:\/\/schema.org\/reviewAspect",
+    "Name":"https://schema.org/reviewAspect",
     "Domain Bucket":"10K - 100K"
   },
   {
     "Class":"Predicate",
-    "Name":"http:\/\/schema.org\/reviewAspect-input",
+    "Name":"https://schema.org/reviewAspect-input",
     "Domain Bucket":"< 1K"
   },
   {
     "Class":"Predicate",
-    "Name":"http:\/\/schema.org\/reviewAspect-output",
+    "Name":"https://schema.org/reviewAspect-output",
     "Domain Bucket":"< 1K"
   },
   {
     "Class":"Predicate",
-    "Name":"http:\/\/schema.org\/reviewBody",
+    "Name":"https://schema.org/reviewBody",
     "Domain Bucket":"1M - 10M"
   },
   {
     "Class":"Predicate",
-    "Name":"http:\/\/schema.org\/reviewBody-input",
+    "Name":"https://schema.org/reviewBody-input",
     "Domain Bucket":"< 1K"
   },
   {
     "Class":"Predicate",
-    "Name":"http:\/\/schema.org\/reviewBody-output",
+    "Name":"https://schema.org/reviewBody-output",
     "Domain Bucket":"< 1K"
   },
   {
     "Class":"Predicate",
-    "Name":"http:\/\/schema.org\/reviewCount",
+    "Name":"https://schema.org/reviewCount",
     "Domain Bucket":"1M - 10M"
   },
   {
     "Class":"Predicate",
-    "Name":"http:\/\/schema.org\/reviewCount-input",
+    "Name":"https://schema.org/reviewCount-input",
     "Domain Bucket":"< 1K"
   },
   {
     "Class":"Predicate",
-    "Name":"http:\/\/schema.org\/reviewCount-output",
+    "Name":"https://schema.org/reviewCount-output",
     "Domain Bucket":"< 1K"
   },
   {
     "Class":"Predicate",
-    "Name":"http:\/\/schema.org\/reviewRating",
+    "Name":"https://schema.org/reviewRating",
     "Domain Bucket":"1M - 10M"
   },
   {
     "Class":"Predicate",
-    "Name":"http:\/\/schema.org\/reviewRating-input",
+    "Name":"https://schema.org/reviewRating-input",
     "Domain Bucket":"< 1K"
   },
   {
     "Class":"Predicate",
-    "Name":"http:\/\/schema.org\/reviewRating-output",
+    "Name":"https://schema.org/reviewRating-output",
     "Domain Bucket":"< 1K"
   },
   {
     "Class":"Predicate",
-    "Name":"http:\/\/schema.org\/reviewedBy",
+    "Name":"https://schema.org/reviewedBy",
     "Domain Bucket":"10K - 100K"
   },
   {
     "Class":"Predicate",
-    "Name":"http:\/\/schema.org\/reviewedBy-input",
+    "Name":"https://schema.org/reviewedBy-input",
     "Domain Bucket":"< 1K"
   },
   {
     "Class":"Predicate",
-    "Name":"http:\/\/schema.org\/reviewedBy-output",
+    "Name":"https://schema.org/reviewedBy-output",
     "Domain Bucket":"< 1K"
   },
   {
     "Class":"Predicate",
-    "Name":"http:\/\/schema.org\/reviews",
+    "Name":"https://schema.org/reviews",
     "Domain Bucket":"1K - 10K"
   },
   {
     "Class":"Predicate",
-    "Name":"http:\/\/schema.org\/reviews-input",
+    "Name":"https://schema.org/reviews-input",
     "Domain Bucket":"< 1K"
   },
   {
     "Class":"Predicate",
-    "Name":"http:\/\/schema.org\/reviews-output",
+    "Name":"https://schema.org/reviews-output",
     "Domain Bucket":"< 1K"
   },
   {
     "Class":"Predicate",
-    "Name":"http:\/\/schema.org\/riskFactor",
+    "Name":"https://schema.org/riskFactor",
     "Domain Bucket":"1K - 10K"
   },
   {
     "Class":"Predicate",
-    "Name":"http:\/\/schema.org\/riskFactor-input",
+    "Name":"https://schema.org/riskFactor-input",
     "Domain Bucket":"< 1K"
   },
   {
     "Class":"Predicate",
-    "Name":"http:\/\/schema.org\/riskFactor-output",
+    "Name":"https://schema.org/riskFactor-output",
     "Domain Bucket":"< 1K"
   },
   {
     "Class":"Predicate",
-    "Name":"http:\/\/schema.org\/risks",
+    "Name":"https://schema.org/risks",
     "Domain Bucket":"< 1K"
   },
   {
     "Class":"Predicate",
-    "Name":"http:\/\/schema.org\/risks-input",
+    "Name":"https://schema.org/risks-input",
     "Domain Bucket":"< 1K"
   },
   {
     "Class":"Predicate",
-    "Name":"http:\/\/schema.org\/risks-output",
+    "Name":"https://schema.org/risks-output",
     "Domain Bucket":"< 1K"
   },
   {
     "Class":"Predicate",
-    "Name":"http:\/\/schema.org\/roleName",
+    "Name":"https://schema.org/roleName",
     "Domain Bucket":"1K - 10K"
   },
   {
     "Class":"Predicate",
-    "Name":"http:\/\/schema.org\/roleName-input",
+    "Name":"https://schema.org/roleName-input",
     "Domain Bucket":"< 1K"
   },
   {
     "Class":"Predicate",
-    "Name":"http:\/\/schema.org\/roleName-output",
+    "Name":"https://schema.org/roleName-output",
     "Domain Bucket":"< 1K"
   },
   {
     "Class":"Predicate",
-    "Name":"http:\/\/schema.org\/roofLoad",
+    "Name":"https://schema.org/roofLoad",
     "Domain Bucket":"< 1K"
   },
   {
     "Class":"Predicate",
-    "Name":"http:\/\/schema.org\/roofLoad-input",
+    "Name":"https://schema.org/roofLoad-input",
     "Domain Bucket":"< 1K"
   },
   {
     "Class":"Predicate",
-    "Name":"http:\/\/schema.org\/roofLoad-output",
+    "Name":"https://schema.org/roofLoad-output",
     "Domain Bucket":"< 1K"
   },
   {
     "Class":"Predicate",
-    "Name":"http:\/\/schema.org\/rsvpResponse",
+    "Name":"https://schema.org/rsvpResponse",
     "Domain Bucket":"< 1K"
   },
   {
     "Class":"Predicate",
-    "Name":"http:\/\/schema.org\/rsvpResponse-input",
+    "Name":"https://schema.org/rsvpResponse-input",
     "Domain Bucket":"< 1K"
   },
   {
     "Class":"Predicate",
-    "Name":"http:\/\/schema.org\/rsvpResponse-output",
+    "Name":"https://schema.org/rsvpResponse-output",
     "Domain Bucket":"< 1K"
   },
   {
     "Class":"Predicate",
-    "Name":"http:\/\/schema.org\/runsTo",
+    "Name":"https://schema.org/runsTo",
     "Domain Bucket":"< 1K"
   },
   {
     "Class":"Predicate",
-    "Name":"http:\/\/schema.org\/runsTo-input",
+    "Name":"https://schema.org/runsTo-input",
     "Domain Bucket":"< 1K"
   },
   {
     "Class":"Predicate",
-    "Name":"http:\/\/schema.org\/runsTo-output",
+    "Name":"https://schema.org/runsTo-output",
     "Domain Bucket":"< 1K"
   },
   {
     "Class":"Predicate",
-    "Name":"http:\/\/schema.org\/runtime",
+    "Name":"https://schema.org/runtime",
     "Domain Bucket":"< 1K"
   },
   {
     "Class":"Predicate",
-    "Name":"http:\/\/schema.org\/runtime-input",
+    "Name":"https://schema.org/runtime-input",
     "Domain Bucket":"< 1K"
   },
   {
     "Class":"Predicate",
-    "Name":"http:\/\/schema.org\/runtime-output",
+    "Name":"https://schema.org/runtime-output",
     "Domain Bucket":"< 1K"
   },
   {
     "Class":"Predicate",
-    "Name":"http:\/\/schema.org\/runtimePlatform",
+    "Name":"https://schema.org/runtimePlatform",
     "Domain Bucket":"1K - 10K"
   },
   {
     "Class":"Predicate",
-    "Name":"http:\/\/schema.org\/runtimePlatform-input",
+    "Name":"https://schema.org/runtimePlatform-input",
     "Domain Bucket":"< 1K"
   },
   {
     "Class":"Predicate",
-    "Name":"http:\/\/schema.org\/runtimePlatform-output",
+    "Name":"https://schema.org/runtimePlatform-output",
     "Domain Bucket":"< 1K"
   },
   {
     "Class":"Predicate",
-    "Name":"http:\/\/schema.org\/rxcui",
+    "Name":"https://schema.org/rxcui",
     "Domain Bucket":"< 1K"
   },
   {
     "Class":"Predicate",
-    "Name":"http:\/\/schema.org\/rxcui-input",
+    "Name":"https://schema.org/rxcui-input",
     "Domain Bucket":"< 1K"
   },
   {
     "Class":"Predicate",
-    "Name":"http:\/\/schema.org\/rxcui-output",
+    "Name":"https://schema.org/rxcui-output",
     "Domain Bucket":"< 1K"
   },
   {
     "Class":"Predicate",
-    "Name":"http:\/\/schema.org\/safetyConsideration",
+    "Name":"https://schema.org/safetyConsideration",
     "Domain Bucket":"< 1K"
   },
   {
     "Class":"Predicate",
-    "Name":"http:\/\/schema.org\/safetyConsideration-input",
+    "Name":"https://schema.org/safetyConsideration-input",
     "Domain Bucket":"< 1K"
   },
   {
     "Class":"Predicate",
-    "Name":"http:\/\/schema.org\/safetyConsideration-output",
+    "Name":"https://schema.org/safetyConsideration-output",
     "Domain Bucket":"< 1K"
   },
   {
     "Class":"Predicate",
-    "Name":"http:\/\/schema.org\/salaryCurrency",
+    "Name":"https://schema.org/salaryCurrency",
     "Domain Bucket":"1K - 10K"
   },
   {
     "Class":"Predicate",
-    "Name":"http:\/\/schema.org\/salaryCurrency-input",
+    "Name":"https://schema.org/salaryCurrency-input",
     "Domain Bucket":"< 1K"
   },
   {
     "Class":"Predicate",
-    "Name":"http:\/\/schema.org\/salaryCurrency-output",
+    "Name":"https://schema.org/salaryCurrency-output",
     "Domain Bucket":"< 1K"
   },
   {
     "Class":"Predicate",
-    "Name":"http:\/\/schema.org\/salaryUponCompletion",
+    "Name":"https://schema.org/salaryUponCompletion",
     "Domain Bucket":"< 1K"
   },
   {
     "Class":"Predicate",
-    "Name":"http:\/\/schema.org\/salaryUponCompletion-input",
+    "Name":"https://schema.org/salaryUponCompletion-input",
     "Domain Bucket":"< 1K"
   },
   {
     "Class":"Predicate",
-    "Name":"http:\/\/schema.org\/salaryUponCompletion-output",
+    "Name":"https://schema.org/salaryUponCompletion-output",
     "Domain Bucket":"< 1K"
   },
   {
     "Class":"Predicate",
-    "Name":"http:\/\/schema.org\/sameAs",
+    "Name":"https://schema.org/sameAs",
     "Domain Bucket":"10M+"
   },
   {
     "Class":"Predicate",
-    "Name":"http:\/\/schema.org\/sameAs-input",
+    "Name":"https://schema.org/sameAs-input",
     "Domain Bucket":"< 1K"
   },
   {
     "Class":"Predicate",
-    "Name":"http:\/\/schema.org\/sameAs-output",
+    "Name":"https://schema.org/sameAs-output",
     "Domain Bucket":"< 1K"
   },
   {
     "Class":"Predicate",
-    "Name":"http:\/\/schema.org\/sampleType",
+    "Name":"https://schema.org/sampleType",
     "Domain Bucket":"< 1K"
   },
   {
     "Class":"Predicate",
-    "Name":"http:\/\/schema.org\/sampleType-input",
+    "Name":"https://schema.org/sampleType-input",
     "Domain Bucket":"< 1K"
   },
   {
     "Class":"Predicate",
-    "Name":"http:\/\/schema.org\/sampleType-output",
+    "Name":"https://schema.org/sampleType-output",
     "Domain Bucket":"< 1K"
   },
   {
     "Class":"Predicate",
-    "Name":"http:\/\/schema.org\/saturatedFatContent",
+    "Name":"https://schema.org/saturatedFatContent",
     "Domain Bucket":"10K - 100K"
   },
   {
     "Class":"Predicate",
-    "Name":"http:\/\/schema.org\/saturatedFatContent-input",
+    "Name":"https://schema.org/saturatedFatContent-input",
     "Domain Bucket":"< 1K"
   },
   {
     "Class":"Predicate",
-    "Name":"http:\/\/schema.org\/saturatedFatContent-output",
+    "Name":"https://schema.org/saturatedFatContent-output",
     "Domain Bucket":"< 1K"
   },
   {
     "Class":"Predicate",
-    "Name":"http:\/\/schema.org\/scheduleTimezone",
+    "Name":"https://schema.org/scheduleTimezone",
     "Domain Bucket":"1K - 10K"
   },
   {
     "Class":"Predicate",
-    "Name":"http:\/\/schema.org\/scheduleTimezone-input",
+    "Name":"https://schema.org/scheduleTimezone-input",
     "Domain Bucket":"< 1K"
   },
   {
     "Class":"Predicate",
-    "Name":"http:\/\/schema.org\/scheduleTimezone-output",
+    "Name":"https://schema.org/scheduleTimezone-output",
     "Domain Bucket":"< 1K"
   },
   {
     "Class":"Predicate",
-    "Name":"http:\/\/schema.org\/scheduledPaymentDate",
+    "Name":"https://schema.org/scheduledPaymentDate",
     "Domain Bucket":"< 1K"
   },
   {
     "Class":"Predicate",
-    "Name":"http:\/\/schema.org\/scheduledPaymentDate-input",
+    "Name":"https://schema.org/scheduledPaymentDate-input",
     "Domain Bucket":"< 1K"
   },
   {
     "Class":"Predicate",
-    "Name":"http:\/\/schema.org\/scheduledPaymentDate-output",
+    "Name":"https://schema.org/scheduledPaymentDate-output",
     "Domain Bucket":"< 1K"
   },
   {
     "Class":"Predicate",
-    "Name":"http:\/\/schema.org\/scheduledTime",
+    "Name":"https://schema.org/scheduledTime",
     "Domain Bucket":"< 1K"
   },
   {
     "Class":"Predicate",
-    "Name":"http:\/\/schema.org\/scheduledTime-input",
+    "Name":"https://schema.org/scheduledTime-input",
     "Domain Bucket":"< 1K"
   },
   {
     "Class":"Predicate",
-    "Name":"http:\/\/schema.org\/scheduledTime-output",
+    "Name":"https://schema.org/scheduledTime-output",
     "Domain Bucket":"< 1K"
   },
   {
     "Class":"Predicate",
-    "Name":"http:\/\/schema.org\/schemaVersion",
+    "Name":"https://schema.org/schemaVersion",
     "Domain Bucket":"< 1K"
   },
   {
     "Class":"Predicate",
-    "Name":"http:\/\/schema.org\/schemaVersion-input",
+    "Name":"https://schema.org/schemaVersion-input",
     "Domain Bucket":"< 1K"
   },
   {
     "Class":"Predicate",
-    "Name":"http:\/\/schema.org\/schemaVersion-output",
+    "Name":"https://schema.org/schemaVersion-output",
     "Domain Bucket":"< 1K"
   },
   {
     "Class":"Predicate",
-    "Name":"http:\/\/schema.org\/schoolClosuresInfo",
+    "Name":"https://schema.org/schoolClosuresInfo",
     "Domain Bucket":"< 1K"
   },
   {
     "Class":"Predicate",
-    "Name":"http:\/\/schema.org\/schoolClosuresInfo-input",
+    "Name":"https://schema.org/schoolClosuresInfo-input",
     "Domain Bucket":"< 1K"
   },
   {
     "Class":"Predicate",
-    "Name":"http:\/\/schema.org\/schoolClosuresInfo-output",
+    "Name":"https://schema.org/schoolClosuresInfo-output",
     "Domain Bucket":"< 1K"
   },
   {
     "Class":"Predicate",
-    "Name":"http:\/\/schema.org\/screenCount",
+    "Name":"https://schema.org/screenCount",
     "Domain Bucket":"< 1K"
   },
   {
     "Class":"Predicate",
-    "Name":"http:\/\/schema.org\/screenCount-input",
+    "Name":"https://schema.org/screenCount-input",
     "Domain Bucket":"< 1K"
   },
   {
     "Class":"Predicate",
-    "Name":"http:\/\/schema.org\/screenCount-output",
+    "Name":"https://schema.org/screenCount-output",
     "Domain Bucket":"< 1K"
   },
   {
     "Class":"Predicate",
-    "Name":"http:\/\/schema.org\/screenshot",
+    "Name":"https://schema.org/screenshot",
     "Domain Bucket":"100K - 1M"
   },
   {
     "Class":"Predicate",
-    "Name":"http:\/\/schema.org\/screenshot-input",
+    "Name":"https://schema.org/screenshot-input",
     "Domain Bucket":"< 1K"
   },
   {
     "Class":"Predicate",
-    "Name":"http:\/\/schema.org\/screenshot-output",
+    "Name":"https://schema.org/screenshot-output",
     "Domain Bucket":"< 1K"
   },
   {
     "Class":"Predicate",
-    "Name":"http:\/\/schema.org\/sdDatePublished",
+    "Name":"https://schema.org/sdDatePublished",
     "Domain Bucket":"1K - 10K"
   },
   {
     "Class":"Predicate",
-    "Name":"http:\/\/schema.org\/sdDatePublished-input",
+    "Name":"https://schema.org/sdDatePublished-input",
     "Domain Bucket":"< 1K"
   },
   {
     "Class":"Predicate",
-    "Name":"http:\/\/schema.org\/sdDatePublished-output",
+    "Name":"https://schema.org/sdDatePublished-output",
     "Domain Bucket":"< 1K"
   },
   {
     "Class":"Predicate",
-    "Name":"http:\/\/schema.org\/sdLicense",
+    "Name":"https://schema.org/sdLicense",
     "Domain Bucket":"< 1K"
   },
   {
     "Class":"Predicate",
-    "Name":"http:\/\/schema.org\/sdLicense-input",
+    "Name":"https://schema.org/sdLicense-input",
     "Domain Bucket":"< 1K"
   },
   {
     "Class":"Predicate",
-    "Name":"http:\/\/schema.org\/sdLicense-output",
+    "Name":"https://schema.org/sdLicense-output",
     "Domain Bucket":"< 1K"
   },
   {
     "Class":"Predicate",
-    "Name":"http:\/\/schema.org\/sdPublisher",
+    "Name":"https://schema.org/sdPublisher",
     "Domain Bucket":"1K - 10K"
   },
   {
     "Class":"Predicate",
-    "Name":"http:\/\/schema.org\/sdPublisher-input",
+    "Name":"https://schema.org/sdPublisher-input",
     "Domain Bucket":"< 1K"
   },
   {
     "Class":"Predicate",
-    "Name":"http:\/\/schema.org\/sdPublisher-output",
+    "Name":"https://schema.org/sdPublisher-output",
     "Domain Bucket":"< 1K"
   },
   {
     "Class":"Predicate",
-    "Name":"http:\/\/schema.org\/season",
+    "Name":"https://schema.org/season",
     "Domain Bucket":"1K - 10K"
   },
   {
     "Class":"Predicate",
-    "Name":"http:\/\/schema.org\/season-input",
+    "Name":"https://schema.org/season-input",
     "Domain Bucket":"< 1K"
   },
   {
     "Class":"Predicate",
-    "Name":"http:\/\/schema.org\/season-output",
+    "Name":"https://schema.org/season-output",
     "Domain Bucket":"< 1K"
   },
   {
     "Class":"Predicate",
-    "Name":"http:\/\/schema.org\/seasonNumber",
+    "Name":"https://schema.org/seasonNumber",
     "Domain Bucket":"1K - 10K"
   },
   {
     "Class":"Predicate",
-    "Name":"http:\/\/schema.org\/seasonNumber-input",
+    "Name":"https://schema.org/seasonNumber-input",
     "Domain Bucket":"< 1K"
   },
   {
     "Class":"Predicate",
-    "Name":"http:\/\/schema.org\/seasonNumber-output",
+    "Name":"https://schema.org/seasonNumber-output",
     "Domain Bucket":"< 1K"
   },
   {
     "Class":"Predicate",
-    "Name":"http:\/\/schema.org\/seasonalOverride",
+    "Name":"https://schema.org/seasonalOverride",
     "Domain Bucket":"< 1K"
   },
   {
     "Class":"Predicate",
-    "Name":"http:\/\/schema.org\/seasonalOverride-input",
+    "Name":"https://schema.org/seasonalOverride-input",
     "Domain Bucket":"< 1K"
   },
   {
     "Class":"Predicate",
-    "Name":"http:\/\/schema.org\/seasonalOverride-output",
+    "Name":"https://schema.org/seasonalOverride-output",
     "Domain Bucket":"< 1K"
   },
   {
     "Class":"Predicate",
-    "Name":"http:\/\/schema.org\/seasons",
+    "Name":"https://schema.org/seasons",
     "Domain Bucket":"< 1K"
   },
   {
     "Class":"Predicate",
-    "Name":"http:\/\/schema.org\/seasons-input",
+    "Name":"https://schema.org/seasons-input",
     "Domain Bucket":"< 1K"
   },
   {
     "Class":"Predicate",
-    "Name":"http:\/\/schema.org\/seasons-output",
+    "Name":"https://schema.org/seasons-output",
     "Domain Bucket":"< 1K"
   },
   {
     "Class":"Predicate",
-    "Name":"http:\/\/schema.org\/seatNumber",
+    "Name":"https://schema.org/seatNumber",
     "Domain Bucket":"< 1K"
   },
   {
     "Class":"Predicate",
-    "Name":"http:\/\/schema.org\/seatNumber-input",
+    "Name":"https://schema.org/seatNumber-input",
     "Domain Bucket":"< 1K"
   },
   {
     "Class":"Predicate",
-    "Name":"http:\/\/schema.org\/seatNumber-output",
+    "Name":"https://schema.org/seatNumber-output",
     "Domain Bucket":"< 1K"
   },
   {
     "Class":"Predicate",
-    "Name":"http:\/\/schema.org\/seatRow",
+    "Name":"https://schema.org/seatRow",
     "Domain Bucket":"< 1K"
   },
   {
     "Class":"Predicate",
-    "Name":"http:\/\/schema.org\/seatRow-input",
+    "Name":"https://schema.org/seatRow-input",
     "Domain Bucket":"< 1K"
   },
   {
     "Class":"Predicate",
-    "Name":"http:\/\/schema.org\/seatRow-output",
+    "Name":"https://schema.org/seatRow-output",
     "Domain Bucket":"< 1K"
   },
   {
     "Class":"Predicate",
-    "Name":"http:\/\/schema.org\/seatSection",
+    "Name":"https://schema.org/seatSection",
     "Domain Bucket":"< 1K"
   },
   {
     "Class":"Predicate",
-    "Name":"http:\/\/schema.org\/seatSection-input",
+    "Name":"https://schema.org/seatSection-input",
     "Domain Bucket":"< 1K"
   },
   {
     "Class":"Predicate",
-    "Name":"http:\/\/schema.org\/seatSection-output",
+    "Name":"https://schema.org/seatSection-output",
     "Domain Bucket":"< 1K"
   },
   {
     "Class":"Predicate",
-    "Name":"http:\/\/schema.org\/seatingCapacity",
+    "Name":"https://schema.org/seatingCapacity",
     "Domain Bucket":"1K - 10K"
   },
   {
     "Class":"Predicate",
-    "Name":"http:\/\/schema.org\/seatingCapacity-input",
+    "Name":"https://schema.org/seatingCapacity-input",
     "Domain Bucket":"< 1K"
   },
   {
     "Class":"Predicate",
-    "Name":"http:\/\/schema.org\/seatingCapacity-output",
+    "Name":"https://schema.org/seatingCapacity-output",
     "Domain Bucket":"< 1K"
   },
   {
     "Class":"Predicate",
-    "Name":"http:\/\/schema.org\/seatingType",
+    "Name":"https://schema.org/seatingType",
     "Domain Bucket":"< 1K"
   },
   {
     "Class":"Predicate",
-    "Name":"http:\/\/schema.org\/seatingType-input",
+    "Name":"https://schema.org/seatingType-input",
     "Domain Bucket":"< 1K"
   },
   {
     "Class":"Predicate",
-    "Name":"http:\/\/schema.org\/seatingType-output",
+    "Name":"https://schema.org/seatingType-output",
     "Domain Bucket":"< 1K"
   },
   {
     "Class":"Predicate",
-    "Name":"http:\/\/schema.org\/secondaryPrevention",
+    "Name":"https://schema.org/secondaryPrevention",
     "Domain Bucket":"< 1K"
   },
   {
     "Class":"Predicate",
-    "Name":"http:\/\/schema.org\/secondaryPrevention-input",
+    "Name":"https://schema.org/secondaryPrevention-input",
     "Domain Bucket":"< 1K"
   },
   {
     "Class":"Predicate",
-    "Name":"http:\/\/schema.org\/secondaryPrevention-output",
+    "Name":"https://schema.org/secondaryPrevention-output",
     "Domain Bucket":"< 1K"
   },
   {
     "Class":"Predicate",
-    "Name":"http:\/\/schema.org\/securityClearanceRequirement",
+    "Name":"https://schema.org/securityClearanceRequirement",
     "Domain Bucket":"< 1K"
   },
   {
     "Class":"Predicate",
-    "Name":"http:\/\/schema.org\/securityClearanceRequirement-input",
+    "Name":"https://schema.org/securityClearanceRequirement-input",
     "Domain Bucket":"< 1K"
   },
   {
     "Class":"Predicate",
-    "Name":"http:\/\/schema.org\/securityClearanceRequirement-output",
+    "Name":"https://schema.org/securityClearanceRequirement-output",
     "Domain Bucket":"< 1K"
   },
   {
     "Class":"Predicate",
-    "Name":"http:\/\/schema.org\/securityScreening",
+    "Name":"https://schema.org/securityScreening",
     "Domain Bucket":"< 1K"
   },
   {
     "Class":"Predicate",
-    "Name":"http:\/\/schema.org\/securityScreening-input",
+    "Name":"https://schema.org/securityScreening-input",
     "Domain Bucket":"< 1K"
   },
   {
     "Class":"Predicate",
-    "Name":"http:\/\/schema.org\/securityScreening-output",
+    "Name":"https://schema.org/securityScreening-output",
     "Domain Bucket":"< 1K"
   },
   {
     "Class":"Predicate",
-    "Name":"http:\/\/schema.org\/seeks",
+    "Name":"https://schema.org/seeks",
     "Domain Bucket":"1K - 10K"
   },
   {
     "Class":"Predicate",
-    "Name":"http:\/\/schema.org\/seeks-input",
+    "Name":"https://schema.org/seeks-input",
     "Domain Bucket":"< 1K"
   },
   {
     "Class":"Predicate",
-    "Name":"http:\/\/schema.org\/seeks-output",
+    "Name":"https://schema.org/seeks-output",
     "Domain Bucket":"< 1K"
   },
   {
     "Class":"Predicate",
-    "Name":"http:\/\/schema.org\/seller",
+    "Name":"https://schema.org/seller",
     "Domain Bucket":"1M - 10M"
   },
   {
     "Class":"Predicate",
-    "Name":"http:\/\/schema.org\/seller-input",
+    "Name":"https://schema.org/seller-input",
     "Domain Bucket":"< 1K"
   },
   {
     "Class":"Predicate",
-    "Name":"http:\/\/schema.org\/seller-output",
+    "Name":"https://schema.org/seller-output",
     "Domain Bucket":"< 1K"
   },
   {
     "Class":"Predicate",
-    "Name":"http:\/\/schema.org\/sender",
+    "Name":"https://schema.org/sender",
     "Domain Bucket":"< 1K"
   },
   {
     "Class":"Predicate",
-    "Name":"http:\/\/schema.org\/sender-input",
+    "Name":"https://schema.org/sender-input",
     "Domain Bucket":"< 1K"
   },
   {
     "Class":"Predicate",
-    "Name":"http:\/\/schema.org\/sender-output",
+    "Name":"https://schema.org/sender-output",
     "Domain Bucket":"< 1K"
   },
   {
     "Class":"Predicate",
-    "Name":"http:\/\/schema.org\/sensoryRequirement",
+    "Name":"https://schema.org/sensoryRequirement",
     "Domain Bucket":"< 1K"
   },
   {
     "Class":"Predicate",
-    "Name":"http:\/\/schema.org\/sensoryRequirement-input",
+    "Name":"https://schema.org/sensoryRequirement-input",
     "Domain Bucket":"< 1K"
   },
   {
     "Class":"Predicate",
-    "Name":"http:\/\/schema.org\/sensoryRequirement-output",
+    "Name":"https://schema.org/sensoryRequirement-output",
     "Domain Bucket":"< 1K"
   },
   {
     "Class":"Predicate",
-    "Name":"http:\/\/schema.org\/sensoryUnit",
+    "Name":"https://schema.org/sensoryUnit",
     "Domain Bucket":"< 1K"
   },
   {
     "Class":"Predicate",
-    "Name":"http:\/\/schema.org\/sensoryUnit-input",
+    "Name":"https://schema.org/sensoryUnit-input",
     "Domain Bucket":"< 1K"
   },
   {
     "Class":"Predicate",
-    "Name":"http:\/\/schema.org\/sensoryUnit-output",
+    "Name":"https://schema.org/sensoryUnit-output",
     "Domain Bucket":"< 1K"
   },
   {
     "Class":"Predicate",
-    "Name":"http:\/\/schema.org\/serialNumber",
+    "Name":"https://schema.org/serialNumber",
     "Domain Bucket":"10K - 100K"
   },
   {
     "Class":"Predicate",
-    "Name":"http:\/\/schema.org\/serialNumber-input",
+    "Name":"https://schema.org/serialNumber-input",
     "Domain Bucket":"< 1K"
   },
   {
     "Class":"Predicate",
-    "Name":"http:\/\/schema.org\/serialNumber-output",
+    "Name":"https://schema.org/serialNumber-output",
     "Domain Bucket":"< 1K"
   },
   {
     "Class":"Predicate",
-    "Name":"http:\/\/schema.org\/seriousAdverseOutcome",
+    "Name":"https://schema.org/seriousAdverseOutcome",
     "Domain Bucket":"< 1K"
   },
   {
     "Class":"Predicate",
-    "Name":"http:\/\/schema.org\/seriousAdverseOutcome-input",
+    "Name":"https://schema.org/seriousAdverseOutcome-input",
     "Domain Bucket":"< 1K"
   },
   {
     "Class":"Predicate",
-    "Name":"http:\/\/schema.org\/seriousAdverseOutcome-output",
+    "Name":"https://schema.org/seriousAdverseOutcome-output",
     "Domain Bucket":"< 1K"
   },
   {
     "Class":"Predicate",
-    "Name":"http:\/\/schema.org\/serverStatus",
+    "Name":"https://schema.org/serverStatus",
     "Domain Bucket":"< 1K"
   },
   {
     "Class":"Predicate",
-    "Name":"http:\/\/schema.org\/serverStatus-input",
+    "Name":"https://schema.org/serverStatus-input",
     "Domain Bucket":"< 1K"
   },
   {
     "Class":"Predicate",
-    "Name":"http:\/\/schema.org\/serverStatus-output",
+    "Name":"https://schema.org/serverStatus-output",
     "Domain Bucket":"< 1K"
   },
   {
     "Class":"Predicate",
-    "Name":"http:\/\/schema.org\/servesCuisine",
+    "Name":"https://schema.org/servesCuisine",
     "Domain Bucket":"100K - 1M"
   },
   {
     "Class":"Predicate",
-    "Name":"http:\/\/schema.org\/servesCuisine-input",
+    "Name":"https://schema.org/servesCuisine-input",
     "Domain Bucket":"< 1K"
   },
   {
     "Class":"Predicate",
-    "Name":"http:\/\/schema.org\/servesCuisine-output",
+    "Name":"https://schema.org/servesCuisine-output",
     "Domain Bucket":"< 1K"
   },
   {
     "Class":"Predicate",
-    "Name":"http:\/\/schema.org\/serviceArea",
+    "Name":"https://schema.org/serviceArea",
     "Domain Bucket":"10K - 100K"
   },
   {
     "Class":"Predicate",
-    "Name":"http:\/\/schema.org\/serviceArea-input",
+    "Name":"https://schema.org/serviceArea-input",
     "Domain Bucket":"< 1K"
   },
   {
     "Class":"Predicate",
-    "Name":"http:\/\/schema.org\/serviceArea-output",
+    "Name":"https://schema.org/serviceArea-output",
     "Domain Bucket":"< 1K"
   },
   {
     "Class":"Predicate",
-    "Name":"http:\/\/schema.org\/serviceAudience",
+    "Name":"https://schema.org/serviceAudience",
     "Domain Bucket":"1K - 10K"
   },
   {
     "Class":"Predicate",
-    "Name":"http:\/\/schema.org\/serviceAudience-input",
+    "Name":"https://schema.org/serviceAudience-input",
     "Domain Bucket":"< 1K"
   },
   {
     "Class":"Predicate",
-    "Name":"http:\/\/schema.org\/serviceAudience-output",
+    "Name":"https://schema.org/serviceAudience-output",
     "Domain Bucket":"< 1K"
   },
   {
     "Class":"Predicate",
-    "Name":"http:\/\/schema.org\/serviceLocation",
+    "Name":"https://schema.org/serviceLocation",
     "Domain Bucket":"10K - 100K"
   },
   {
     "Class":"Predicate",
-    "Name":"http:\/\/schema.org\/serviceLocation-input",
+    "Name":"https://schema.org/serviceLocation-input",
     "Domain Bucket":"< 1K"
   },
   {
     "Class":"Predicate",
-    "Name":"http:\/\/schema.org\/serviceLocation-output",
+    "Name":"https://schema.org/serviceLocation-output",
     "Domain Bucket":"< 1K"
   },
   {
     "Class":"Predicate",
-    "Name":"http:\/\/schema.org\/serviceOperator",
+    "Name":"https://schema.org/serviceOperator",
     "Domain Bucket":"1K - 10K"
   },
   {
     "Class":"Predicate",
-    "Name":"http:\/\/schema.org\/serviceOperator-input",
+    "Name":"https://schema.org/serviceOperator-input",
     "Domain Bucket":"< 1K"
   },
   {
     "Class":"Predicate",
-    "Name":"http:\/\/schema.org\/serviceOperator-output",
+    "Name":"https://schema.org/serviceOperator-output",
     "Domain Bucket":"< 1K"
   },
   {
     "Class":"Predicate",
-    "Name":"http:\/\/schema.org\/serviceOutput",
+    "Name":"https://schema.org/serviceOutput",
     "Domain Bucket":"10K - 100K"
   },
   {
     "Class":"Predicate",
-    "Name":"http:\/\/schema.org\/serviceOutput-input",
+    "Name":"https://schema.org/serviceOutput-input",
     "Domain Bucket":"< 1K"
   },
   {
     "Class":"Predicate",
-    "Name":"http:\/\/schema.org\/serviceOutput-output",
+    "Name":"https://schema.org/serviceOutput-output",
     "Domain Bucket":"< 1K"
   },
   {
     "Class":"Predicate",
-    "Name":"http:\/\/schema.org\/servicePhone",
+    "Name":"https://schema.org/servicePhone",
     "Domain Bucket":"10K - 100K"
   },
   {
     "Class":"Predicate",
-    "Name":"http:\/\/schema.org\/servicePhone-input",
+    "Name":"https://schema.org/servicePhone-input",
     "Domain Bucket":"< 1K"
   },
   {
     "Class":"Predicate",
-    "Name":"http:\/\/schema.org\/servicePhone-output",
+    "Name":"https://schema.org/servicePhone-output",
     "Domain Bucket":"< 1K"
   },
   {
     "Class":"Predicate",
-    "Name":"http:\/\/schema.org\/servicePostalAddress",
+    "Name":"https://schema.org/servicePostalAddress",
     "Domain Bucket":"< 1K"
   },
   {
     "Class":"Predicate",
-    "Name":"http:\/\/schema.org\/servicePostalAddress-input",
+    "Name":"https://schema.org/servicePostalAddress-input",
     "Domain Bucket":"< 1K"
   },
   {
     "Class":"Predicate",
-    "Name":"http:\/\/schema.org\/servicePostalAddress-output",
+    "Name":"https://schema.org/servicePostalAddress-output",
     "Domain Bucket":"< 1K"
   },
   {
     "Class":"Predicate",
-    "Name":"http:\/\/schema.org\/serviceSmsNumber",
+    "Name":"https://schema.org/serviceSmsNumber",
     "Domain Bucket":"1K - 10K"
   },
   {
     "Class":"Predicate",
-    "Name":"http:\/\/schema.org\/serviceSmsNumber-input",
+    "Name":"https://schema.org/serviceSmsNumber-input",
     "Domain Bucket":"< 1K"
   },
   {
     "Class":"Predicate",
-    "Name":"http:\/\/schema.org\/serviceSmsNumber-output",
+    "Name":"https://schema.org/serviceSmsNumber-output",
     "Domain Bucket":"< 1K"
   },
   {
     "Class":"Predicate",
-    "Name":"http:\/\/schema.org\/serviceType",
+    "Name":"https://schema.org/serviceType",
     "Domain Bucket":"1M - 10M"
   },
   {
     "Class":"Predicate",
-    "Name":"http:\/\/schema.org\/serviceType-input",
+    "Name":"https://schema.org/serviceType-input",
     "Domain Bucket":"< 1K"
   },
   {
     "Class":"Predicate",
-    "Name":"http:\/\/schema.org\/serviceType-output",
+    "Name":"https://schema.org/serviceType-output",
     "Domain Bucket":"< 1K"
   },
   {
     "Class":"Predicate",
-    "Name":"http:\/\/schema.org\/serviceUrl",
+    "Name":"https://schema.org/serviceUrl",
     "Domain Bucket":"10K - 100K"
   },
   {
     "Class":"Predicate",
-    "Name":"http:\/\/schema.org\/serviceUrl-input",
+    "Name":"https://schema.org/serviceUrl-input",
     "Domain Bucket":"< 1K"
   },
   {
     "Class":"Predicate",
-    "Name":"http:\/\/schema.org\/serviceUrl-output",
+    "Name":"https://schema.org/serviceUrl-output",
     "Domain Bucket":"< 1K"
   },
   {
     "Class":"Predicate",
-    "Name":"http:\/\/schema.org\/servingSize",
+    "Name":"https://schema.org/servingSize",
     "Domain Bucket":"10K - 100K"
   },
   {
     "Class":"Predicate",
-    "Name":"http:\/\/schema.org\/servingSize-input",
+    "Name":"https://schema.org/servingSize-input",
     "Domain Bucket":"< 1K"
   },
   {
     "Class":"Predicate",
-    "Name":"http:\/\/schema.org\/servingSize-output",
+    "Name":"https://schema.org/servingSize-output",
     "Domain Bucket":"< 1K"
   },
   {
     "Class":"Predicate",
-    "Name":"http:\/\/schema.org\/sha256",
+    "Name":"https://schema.org/sha256",
     "Domain Bucket":"< 1K"
   },
   {
     "Class":"Predicate",
-    "Name":"http:\/\/schema.org\/sha256-input",
+    "Name":"https://schema.org/sha256-input",
     "Domain Bucket":"< 1K"
   },
   {
     "Class":"Predicate",
-    "Name":"http:\/\/schema.org\/sha256-output",
+    "Name":"https://schema.org/sha256-output",
     "Domain Bucket":"< 1K"
   },
   {
     "Class":"Predicate",
-    "Name":"http:\/\/schema.org\/sharedContent",
+    "Name":"https://schema.org/sharedContent",
     "Domain Bucket":"1K - 10K"
   },
   {
     "Class":"Predicate",
-    "Name":"http:\/\/schema.org\/sharedContent-input",
+    "Name":"https://schema.org/sharedContent-input",
     "Domain Bucket":"< 1K"
   },
   {
     "Class":"Predicate",
-    "Name":"http:\/\/schema.org\/sharedContent-output",
+    "Name":"https://schema.org/sharedContent-output",
     "Domain Bucket":"< 1K"
   },
   {
     "Class":"Predicate",
-    "Name":"http:\/\/schema.org\/shippingConditions",
+    "Name":"https://schema.org/shippingConditions",
     "Domain Bucket":"10K - 100K"
   },
   {
     "Class":"Predicate",
-    "Name":"http:\/\/schema.org\/shippingConditions-input",
+    "Name":"https://schema.org/shippingConditions-input",
     "Domain Bucket":"< 1K"
   },
   {
     "Class":"Predicate",
-    "Name":"http:\/\/schema.org\/shippingConditions-output",
+    "Name":"https://schema.org/shippingConditions-output",
     "Domain Bucket":"< 1K"
   },
   {
     "Class":"Predicate",
-    "Name":"http:\/\/schema.org\/shippingDestination",
+    "Name":"https://schema.org/shippingDestination",
     "Domain Bucket":"100K - 1M"
   },
   {
     "Class":"Predicate",
-    "Name":"http:\/\/schema.org\/shippingDestination-input",
+    "Name":"https://schema.org/shippingDestination-input",
     "Domain Bucket":"< 1K"
   },
   {
     "Class":"Predicate",
-    "Name":"http:\/\/schema.org\/shippingDestination-output",
+    "Name":"https://schema.org/shippingDestination-output",
     "Domain Bucket":"< 1K"
   },
   {
     "Class":"Predicate",
-    "Name":"http:\/\/schema.org\/shippingDetails",
+    "Name":"https://schema.org/shippingDetails",
     "Domain Bucket":"100K - 1M"
   },
   {
     "Class":"Predicate",
-    "Name":"http:\/\/schema.org\/shippingDetails-input",
+    "Name":"https://schema.org/shippingDetails-input",
     "Domain Bucket":"< 1K"
   },
   {
     "Class":"Predicate",
-    "Name":"http:\/\/schema.org\/shippingDetails-output",
+    "Name":"https://schema.org/shippingDetails-output",
     "Domain Bucket":"< 1K"
   },
   {
     "Class":"Predicate",
-    "Name":"http:\/\/schema.org\/shippingLabel",
+    "Name":"https://schema.org/shippingLabel",
     "Domain Bucket":"1K - 10K"
   },
   {
     "Class":"Predicate",
-    "Name":"http:\/\/schema.org\/shippingLabel-input",
+    "Name":"https://schema.org/shippingLabel-input",
     "Domain Bucket":"< 1K"
   },
   {
     "Class":"Predicate",
-    "Name":"http:\/\/schema.org\/shippingLabel-output",
+    "Name":"https://schema.org/shippingLabel-output",
     "Domain Bucket":"< 1K"
   },
   {
     "Class":"Predicate",
-    "Name":"http:\/\/schema.org\/shippingOrigin",
+    "Name":"https://schema.org/shippingOrigin",
     "Domain Bucket":"10K - 100K"
   },
   {
     "Class":"Predicate",
-    "Name":"http:\/\/schema.org\/shippingOrigin-input",
+    "Name":"https://schema.org/shippingOrigin-input",
     "Domain Bucket":"< 1K"
   },
   {
     "Class":"Predicate",
-    "Name":"http:\/\/schema.org\/shippingOrigin-output",
+    "Name":"https://schema.org/shippingOrigin-output",
     "Domain Bucket":"< 1K"
   },
   {
     "Class":"Predicate",
-    "Name":"http:\/\/schema.org\/shippingRate",
+    "Name":"https://schema.org/shippingRate",
     "Domain Bucket":"100K - 1M"
   },
   {
     "Class":"Predicate",
-    "Name":"http:\/\/schema.org\/shippingRate-input",
+    "Name":"https://schema.org/shippingRate-input",
     "Domain Bucket":"< 1K"
   },
   {
     "Class":"Predicate",
-    "Name":"http:\/\/schema.org\/shippingRate-output",
+    "Name":"https://schema.org/shippingRate-output",
     "Domain Bucket":"< 1K"
   },
   {
     "Class":"Predicate",
-    "Name":"http:\/\/schema.org\/shippingSettingsLink",
+    "Name":"https://schema.org/shippingSettingsLink",
     "Domain Bucket":"1K - 10K"
   },
   {
     "Class":"Predicate",
-    "Name":"http:\/\/schema.org\/shippingSettingsLink-input",
+    "Name":"https://schema.org/shippingSettingsLink-input",
     "Domain Bucket":"< 1K"
   },
   {
     "Class":"Predicate",
-    "Name":"http:\/\/schema.org\/shippingSettingsLink-output",
+    "Name":"https://schema.org/shippingSettingsLink-output",
     "Domain Bucket":"< 1K"
   },
   {
     "Class":"Predicate",
-    "Name":"http:\/\/schema.org\/sibling",
+    "Name":"https://schema.org/sibling",
     "Domain Bucket":"< 1K"
   },
   {
     "Class":"Predicate",
-    "Name":"http:\/\/schema.org\/sibling-input",
+    "Name":"https://schema.org/sibling-input",
     "Domain Bucket":"< 1K"
   },
   {
     "Class":"Predicate",
-    "Name":"http:\/\/schema.org\/sibling-output",
+    "Name":"https://schema.org/sibling-output",
     "Domain Bucket":"< 1K"
   },
   {
     "Class":"Predicate",
-    "Name":"http:\/\/schema.org\/siblings",
+    "Name":"https://schema.org/siblings",
     "Domain Bucket":"< 1K"
   },
   {
     "Class":"Predicate",
-    "Name":"http:\/\/schema.org\/siblings-input",
+    "Name":"https://schema.org/siblings-input",
     "Domain Bucket":"< 1K"
   },
   {
     "Class":"Predicate",
-    "Name":"http:\/\/schema.org\/siblings-output",
+    "Name":"https://schema.org/siblings-output",
     "Domain Bucket":"< 1K"
   },
   {
     "Class":"Predicate",
-    "Name":"http:\/\/schema.org\/signDetected",
+    "Name":"https://schema.org/signDetected",
     "Domain Bucket":"< 1K"
   },
   {
     "Class":"Predicate",
-    "Name":"http:\/\/schema.org\/signDetected-input",
+    "Name":"https://schema.org/signDetected-input",
     "Domain Bucket":"< 1K"
   },
   {
     "Class":"Predicate",
-    "Name":"http:\/\/schema.org\/signDetected-output",
+    "Name":"https://schema.org/signDetected-output",
     "Domain Bucket":"< 1K"
   },
   {
     "Class":"Predicate",
-    "Name":"http:\/\/schema.org\/signOrSymptom",
+    "Name":"https://schema.org/signOrSymptom",
     "Domain Bucket":"1K - 10K"
   },
   {
     "Class":"Predicate",
-    "Name":"http:\/\/schema.org\/signOrSymptom-input",
+    "Name":"https://schema.org/signOrSymptom-input",
     "Domain Bucket":"< 1K"
   },
   {
     "Class":"Predicate",
-    "Name":"http:\/\/schema.org\/signOrSymptom-output",
+    "Name":"https://schema.org/signOrSymptom-output",
     "Domain Bucket":"< 1K"
   },
   {
     "Class":"Predicate",
-    "Name":"http:\/\/schema.org\/significance",
+    "Name":"https://schema.org/significance",
     "Domain Bucket":"< 1K"
   },
   {
     "Class":"Predicate",
-    "Name":"http:\/\/schema.org\/significance-input",
+    "Name":"https://schema.org/significance-input",
     "Domain Bucket":"< 1K"
   },
   {
     "Class":"Predicate",
-    "Name":"http:\/\/schema.org\/significance-output",
+    "Name":"https://schema.org/significance-output",
     "Domain Bucket":"< 1K"
   },
   {
     "Class":"Predicate",
-    "Name":"http:\/\/schema.org\/significantLink",
+    "Name":"https://schema.org/significantLink",
     "Domain Bucket":"10K - 100K"
   },
   {
     "Class":"Predicate",
-    "Name":"http:\/\/schema.org\/significantLink-input",
+    "Name":"https://schema.org/significantLink-input",
     "Domain Bucket":"< 1K"
   },
   {
     "Class":"Predicate",
-    "Name":"http:\/\/schema.org\/significantLink-output",
+    "Name":"https://schema.org/significantLink-output",
     "Domain Bucket":"< 1K"
   },
   {
     "Class":"Predicate",
-    "Name":"http:\/\/schema.org\/significantLinks",
+    "Name":"https://schema.org/significantLinks",
     "Domain Bucket":"1K - 10K"
   },
   {
     "Class":"Predicate",
-    "Name":"http:\/\/schema.org\/significantLinks-input",
+    "Name":"https://schema.org/significantLinks-input",
     "Domain Bucket":"< 1K"
   },
   {
     "Class":"Predicate",
-    "Name":"http:\/\/schema.org\/significantLinks-output",
+    "Name":"https://schema.org/significantLinks-output",
     "Domain Bucket":"< 1K"
   },
   {
     "Class":"Predicate",
-    "Name":"http:\/\/schema.org\/size",
+    "Name":"https://schema.org/size",
     "Domain Bucket":"10K - 100K"
   },
   {
     "Class":"Predicate",
-    "Name":"http:\/\/schema.org\/size-input",
+    "Name":"https://schema.org/size-input",
     "Domain Bucket":"< 1K"
   },
   {
     "Class":"Predicate",
-    "Name":"http:\/\/schema.org\/size-output",
+    "Name":"https://schema.org/size-output",
     "Domain Bucket":"< 1K"
   },
   {
     "Class":"Predicate",
-    "Name":"http:\/\/schema.org\/sizeGroup",
+    "Name":"https://schema.org/sizeGroup",
     "Domain Bucket":"< 1K"
   },
   {
     "Class":"Predicate",
-    "Name":"http:\/\/schema.org\/sizeGroup-input",
+    "Name":"https://schema.org/sizeGroup-input",
     "Domain Bucket":"< 1K"
   },
   {
     "Class":"Predicate",
-    "Name":"http:\/\/schema.org\/sizeGroup-output",
+    "Name":"https://schema.org/sizeGroup-output",
     "Domain Bucket":"< 1K"
   },
   {
     "Class":"Predicate",
-    "Name":"http:\/\/schema.org\/sizeSystem",
+    "Name":"https://schema.org/sizeSystem",
     "Domain Bucket":"< 1K"
   },
   {
     "Class":"Predicate",
-    "Name":"http:\/\/schema.org\/sizeSystem-input",
+    "Name":"https://schema.org/sizeSystem-input",
     "Domain Bucket":"< 1K"
   },
   {
     "Class":"Predicate",
-    "Name":"http:\/\/schema.org\/sizeSystem-output",
+    "Name":"https://schema.org/sizeSystem-output",
     "Domain Bucket":"< 1K"
   },
   {
     "Class":"Predicate",
-    "Name":"http:\/\/schema.org\/skills",
+    "Name":"https://schema.org/skills",
     "Domain Bucket":"10K - 100K"
   },
   {
     "Class":"Predicate",
-    "Name":"http:\/\/schema.org\/skills-input",
+    "Name":"https://schema.org/skills-input",
     "Domain Bucket":"< 1K"
   },
   {
     "Class":"Predicate",
-    "Name":"http:\/\/schema.org\/skills-output",
+    "Name":"https://schema.org/skills-output",
     "Domain Bucket":"< 1K"
   },
   {
     "Class":"Predicate",
-    "Name":"http:\/\/schema.org\/sku",
+    "Name":"https://schema.org/sku",
     "Domain Bucket":"1M - 10M"
   },
   {
     "Class":"Predicate",
-    "Name":"http:\/\/schema.org\/sku-input",
+    "Name":"https://schema.org/sku-input",
     "Domain Bucket":"< 1K"
   },
   {
     "Class":"Predicate",
-    "Name":"http:\/\/schema.org\/sku-output",
+    "Name":"https://schema.org/sku-output",
     "Domain Bucket":"< 1K"
   },
   {
     "Class":"Predicate",
-    "Name":"http:\/\/schema.org\/slogan",
+    "Name":"https://schema.org/slogan",
     "Domain Bucket":"100K - 1M"
   },
   {
     "Class":"Predicate",
-    "Name":"http:\/\/schema.org\/slogan-input",
+    "Name":"https://schema.org/slogan-input",
     "Domain Bucket":"< 1K"
   },
   {
     "Class":"Predicate",
-    "Name":"http:\/\/schema.org\/slogan-output",
+    "Name":"https://schema.org/slogan-output",
     "Domain Bucket":"< 1K"
   },
   {
     "Class":"Predicate",
-    "Name":"http:\/\/schema.org\/smiles",
+    "Name":"https://schema.org/smiles",
     "Domain Bucket":"< 1K"
   },
   {
     "Class":"Predicate",
-    "Name":"http:\/\/schema.org\/smiles-input",
+    "Name":"https://schema.org/smiles-input",
     "Domain Bucket":"< 1K"
   },
   {
     "Class":"Predicate",
-    "Name":"http:\/\/schema.org\/smiles-output",
+    "Name":"https://schema.org/smiles-output",
     "Domain Bucket":"< 1K"
   },
   {
     "Class":"Predicate",
-    "Name":"http:\/\/schema.org\/smokingAllowed",
+    "Name":"https://schema.org/smokingAllowed",
     "Domain Bucket":"10K - 100K"
   },
   {
     "Class":"Predicate",
-    "Name":"http:\/\/schema.org\/smokingAllowed-input",
+    "Name":"https://schema.org/smokingAllowed-input",
     "Domain Bucket":"< 1K"
   },
   {
     "Class":"Predicate",
-    "Name":"http:\/\/schema.org\/smokingAllowed-output",
+    "Name":"https://schema.org/smokingAllowed-output",
     "Domain Bucket":"< 1K"
   },
   {
     "Class":"Predicate",
-    "Name":"http:\/\/schema.org\/sodiumContent",
+    "Name":"https://schema.org/sodiumContent",
     "Domain Bucket":"10K - 100K"
   },
   {
     "Class":"Predicate",
-    "Name":"http:\/\/schema.org\/sodiumContent-input",
+    "Name":"https://schema.org/sodiumContent-input",
     "Domain Bucket":"< 1K"
   },
   {
     "Class":"Predicate",
-    "Name":"http:\/\/schema.org\/sodiumContent-output",
+    "Name":"https://schema.org/sodiumContent-output",
     "Domain Bucket":"< 1K"
   },
   {
     "Class":"Predicate",
-    "Name":"http:\/\/schema.org\/softwareAddOn",
+    "Name":"https://schema.org/softwareAddOn",
     "Domain Bucket":"< 1K"
   },
   {
     "Class":"Predicate",
-    "Name":"http:\/\/schema.org\/softwareAddOn-input",
+    "Name":"https://schema.org/softwareAddOn-input",
     "Domain Bucket":"< 1K"
   },
   {
     "Class":"Predicate",
-    "Name":"http:\/\/schema.org\/softwareAddOn-output",
+    "Name":"https://schema.org/softwareAddOn-output",
     "Domain Bucket":"< 1K"
   },
   {
     "Class":"Predicate",
-    "Name":"http:\/\/schema.org\/softwareHelp",
+    "Name":"https://schema.org/softwareHelp",
     "Domain Bucket":"10K - 100K"
   },
   {
     "Class":"Predicate",
-    "Name":"http:\/\/schema.org\/softwareHelp-input",
+    "Name":"https://schema.org/softwareHelp-input",
     "Domain Bucket":"< 1K"
   },
   {
     "Class":"Predicate",
-    "Name":"http:\/\/schema.org\/softwareHelp-output",
+    "Name":"https://schema.org/softwareHelp-output",
     "Domain Bucket":"< 1K"
   },
   {
     "Class":"Predicate",
-    "Name":"http:\/\/schema.org\/softwareRequirements",
+    "Name":"https://schema.org/softwareRequirements",
     "Domain Bucket":"10K - 100K"
   },
   {
     "Class":"Predicate",
-    "Name":"http:\/\/schema.org\/softwareRequirements-input",
+    "Name":"https://schema.org/softwareRequirements-input",
     "Domain Bucket":"< 1K"
   },
   {
     "Class":"Predicate",
-    "Name":"http:\/\/schema.org\/softwareRequirements-output",
+    "Name":"https://schema.org/softwareRequirements-output",
     "Domain Bucket":"< 1K"
   },
   {
     "Class":"Predicate",
-    "Name":"http:\/\/schema.org\/softwareVersion",
+    "Name":"https://schema.org/softwareVersion",
     "Domain Bucket":"100K - 1M"
   },
   {
     "Class":"Predicate",
-    "Name":"http:\/\/schema.org\/softwareVersion-input",
+    "Name":"https://schema.org/softwareVersion-input",
     "Domain Bucket":"< 1K"
   },
   {
     "Class":"Predicate",
-    "Name":"http:\/\/schema.org\/softwareVersion-output",
+    "Name":"https://schema.org/softwareVersion-output",
     "Domain Bucket":"< 1K"
   },
   {
     "Class":"Predicate",
-    "Name":"http:\/\/schema.org\/source",
+    "Name":"https://schema.org/source",
     "Domain Bucket":"1K - 10K"
   },
   {
     "Class":"Predicate",
-    "Name":"http:\/\/schema.org\/source-input",
+    "Name":"https://schema.org/source-input",
     "Domain Bucket":"< 1K"
   },
   {
     "Class":"Predicate",
-    "Name":"http:\/\/schema.org\/source-output",
+    "Name":"https://schema.org/source-output",
     "Domain Bucket":"< 1K"
   },
   {
     "Class":"Predicate",
-    "Name":"http:\/\/schema.org\/sourceOrganization",
+    "Name":"https://schema.org/sourceOrganization",
     "Domain Bucket":"10K - 100K"
   },
   {
     "Class":"Predicate",
-    "Name":"http:\/\/schema.org\/sourceOrganization-input",
+    "Name":"https://schema.org/sourceOrganization-input",
     "Domain Bucket":"< 1K"
   },
   {
     "Class":"Predicate",
-    "Name":"http:\/\/schema.org\/sourceOrganization-output",
+    "Name":"https://schema.org/sourceOrganization-output",
     "Domain Bucket":"< 1K"
   },
   {
     "Class":"Predicate",
-    "Name":"http:\/\/schema.org\/sourcedFrom",
+    "Name":"https://schema.org/sourcedFrom",
     "Domain Bucket":"< 1K"
   },
   {
     "Class":"Predicate",
-    "Name":"http:\/\/schema.org\/sourcedFrom-input",
+    "Name":"https://schema.org/sourcedFrom-input",
     "Domain Bucket":"< 1K"
   },
   {
     "Class":"Predicate",
-    "Name":"http:\/\/schema.org\/sourcedFrom-output",
+    "Name":"https://schema.org/sourcedFrom-output",
     "Domain Bucket":"< 1K"
   },
   {
     "Class":"Predicate",
-    "Name":"http:\/\/schema.org\/spatial",
+    "Name":"https://schema.org/spatial",
     "Domain Bucket":"1K - 10K"
   },
   {
     "Class":"Predicate",
-    "Name":"http:\/\/schema.org\/spatial-input",
+    "Name":"https://schema.org/spatial-input",
     "Domain Bucket":"< 1K"
   },
   {
     "Class":"Predicate",
-    "Name":"http:\/\/schema.org\/spatial-output",
+    "Name":"https://schema.org/spatial-output",
     "Domain Bucket":"< 1K"
   },
   {
     "Class":"Predicate",
-    "Name":"http:\/\/schema.org\/spatialCoverage",
+    "Name":"https://schema.org/spatialCoverage",
     "Domain Bucket":"10K - 100K"
   },
   {
     "Class":"Predicate",
-    "Name":"http:\/\/schema.org\/spatialCoverage-input",
+    "Name":"https://schema.org/spatialCoverage-input",
     "Domain Bucket":"< 1K"
   },
   {
     "Class":"Predicate",
-    "Name":"http:\/\/schema.org\/spatialCoverage-output",
+    "Name":"https://schema.org/spatialCoverage-output",
     "Domain Bucket":"< 1K"
   },
   {
     "Class":"Predicate",
-    "Name":"http:\/\/schema.org\/speakable",
+    "Name":"https://schema.org/speakable",
     "Domain Bucket":"100K - 1M"
   },
   {
     "Class":"Predicate",
-    "Name":"http:\/\/schema.org\/speakable-input",
+    "Name":"https://schema.org/speakable-input",
     "Domain Bucket":"< 1K"
   },
   {
     "Class":"Predicate",
-    "Name":"http:\/\/schema.org\/speakable-output",
+    "Name":"https://schema.org/speakable-output",
     "Domain Bucket":"< 1K"
   },
   {
     "Class":"Predicate",
-    "Name":"http:\/\/schema.org\/specialCommitments",
+    "Name":"https://schema.org/specialCommitments",
     "Domain Bucket":"1K - 10K"
   },
   {
     "Class":"Predicate",
-    "Name":"http:\/\/schema.org\/specialCommitments-input",
+    "Name":"https://schema.org/specialCommitments-input",
     "Domain Bucket":"< 1K"
   },
   {
     "Class":"Predicate",
-    "Name":"http:\/\/schema.org\/specialCommitments-output",
+    "Name":"https://schema.org/specialCommitments-output",
     "Domain Bucket":"< 1K"
   },
   {
     "Class":"Predicate",
-    "Name":"http:\/\/schema.org\/specialOpeningHoursSpecification",
+    "Name":"https://schema.org/specialOpeningHoursSpecification",
     "Domain Bucket":"1K - 10K"
   },
   {
     "Class":"Predicate",
-    "Name":"http:\/\/schema.org\/specialOpeningHoursSpecification-input",
+    "Name":"https://schema.org/specialOpeningHoursSpecification-input",
     "Domain Bucket":"< 1K"
   },
   {
     "Class":"Predicate",
-    "Name":"http:\/\/schema.org\/specialOpeningHoursSpecification-output",
+    "Name":"https://schema.org/specialOpeningHoursSpecification-output",
     "Domain Bucket":"< 1K"
   },
   {
     "Class":"Predicate",
-    "Name":"http:\/\/schema.org\/specialty",
+    "Name":"https://schema.org/specialty",
     "Domain Bucket":"10K - 100K"
   },
   {
     "Class":"Predicate",
-    "Name":"http:\/\/schema.org\/specialty-input",
+    "Name":"https://schema.org/specialty-input",
     "Domain Bucket":"< 1K"
   },
   {
     "Class":"Predicate",
-    "Name":"http:\/\/schema.org\/specialty-output",
+    "Name":"https://schema.org/specialty-output",
     "Domain Bucket":"< 1K"
   },
   {
     "Class":"Predicate",
-    "Name":"http:\/\/schema.org\/speechToTextMarkup",
+    "Name":"https://schema.org/speechToTextMarkup",
     "Domain Bucket":"< 1K"
   },
   {
     "Class":"Predicate",
-    "Name":"http:\/\/schema.org\/speechToTextMarkup-input",
+    "Name":"https://schema.org/speechToTextMarkup-input",
     "Domain Bucket":"< 1K"
   },
   {
     "Class":"Predicate",
-    "Name":"http:\/\/schema.org\/speechToTextMarkup-output",
+    "Name":"https://schema.org/speechToTextMarkup-output",
     "Domain Bucket":"< 1K"
   },
   {
     "Class":"Predicate",
-    "Name":"http:\/\/schema.org\/speed",
+    "Name":"https://schema.org/speed",
     "Domain Bucket":"1K - 10K"
   },
   {
     "Class":"Predicate",
-    "Name":"http:\/\/schema.org\/speed-input",
+    "Name":"https://schema.org/speed-input",
     "Domain Bucket":"< 1K"
   },
   {
     "Class":"Predicate",
-    "Name":"http:\/\/schema.org\/speed-output",
+    "Name":"https://schema.org/speed-output",
     "Domain Bucket":"< 1K"
   },
   {
     "Class":"Predicate",
-    "Name":"http:\/\/schema.org\/spokenByCharacter",
+    "Name":"https://schema.org/spokenByCharacter",
     "Domain Bucket":"1K - 10K"
   },
   {
     "Class":"Predicate",
-    "Name":"http:\/\/schema.org\/spokenByCharacter-input",
+    "Name":"https://schema.org/spokenByCharacter-input",
     "Domain Bucket":"< 1K"
   },
   {
     "Class":"Predicate",
-    "Name":"http:\/\/schema.org\/spokenByCharacter-output",
+    "Name":"https://schema.org/spokenByCharacter-output",
     "Domain Bucket":"< 1K"
   },
   {
     "Class":"Predicate",
-    "Name":"http:\/\/schema.org\/sponsor",
+    "Name":"https://schema.org/sponsor",
     "Domain Bucket":"10K - 100K"
   },
   {
     "Class":"Predicate",
-    "Name":"http:\/\/schema.org\/sponsor-input",
+    "Name":"https://schema.org/sponsor-input",
     "Domain Bucket":"< 1K"
   },
   {
     "Class":"Predicate",
-    "Name":"http:\/\/schema.org\/sponsor-output",
+    "Name":"https://schema.org/sponsor-output",
     "Domain Bucket":"< 1K"
   },
   {
     "Class":"Predicate",
-    "Name":"http:\/\/schema.org\/sport",
+    "Name":"https://schema.org/sport",
     "Domain Bucket":"10K - 100K"
   },
   {
     "Class":"Predicate",
-    "Name":"http:\/\/schema.org\/sport-input",
+    "Name":"https://schema.org/sport-input",
     "Domain Bucket":"< 1K"
   },
   {
     "Class":"Predicate",
-    "Name":"http:\/\/schema.org\/sport-output",
+    "Name":"https://schema.org/sport-output",
     "Domain Bucket":"< 1K"
   },
   {
     "Class":"Predicate",
-    "Name":"http:\/\/schema.org\/sportsActivityLocation",
+    "Name":"https://schema.org/sportsActivityLocation",
     "Domain Bucket":"< 1K"
   },
   {
     "Class":"Predicate",
-    "Name":"http:\/\/schema.org\/sportsActivityLocation-input",
+    "Name":"https://schema.org/sportsActivityLocation-input",
     "Domain Bucket":"< 1K"
   },
   {
     "Class":"Predicate",
-    "Name":"http:\/\/schema.org\/sportsActivityLocation-output",
+    "Name":"https://schema.org/sportsActivityLocation-output",
     "Domain Bucket":"< 1K"
   },
   {
     "Class":"Predicate",
-    "Name":"http:\/\/schema.org\/sportsEvent",
+    "Name":"https://schema.org/sportsEvent",
     "Domain Bucket":"< 1K"
   },
   {
     "Class":"Predicate",
-    "Name":"http:\/\/schema.org\/sportsEvent-input",
+    "Name":"https://schema.org/sportsEvent-input",
     "Domain Bucket":"< 1K"
   },
   {
     "Class":"Predicate",
-    "Name":"http:\/\/schema.org\/sportsEvent-output",
+    "Name":"https://schema.org/sportsEvent-output",
     "Domain Bucket":"< 1K"
   },
   {
     "Class":"Predicate",
-    "Name":"http:\/\/schema.org\/sportsTeam",
+    "Name":"https://schema.org/sportsTeam",
     "Domain Bucket":"< 1K"
   },
   {
     "Class":"Predicate",
-    "Name":"http:\/\/schema.org\/sportsTeam-input",
+    "Name":"https://schema.org/sportsTeam-input",
     "Domain Bucket":"< 1K"
   },
   {
     "Class":"Predicate",
-    "Name":"http:\/\/schema.org\/sportsTeam-output",
+    "Name":"https://schema.org/sportsTeam-output",
     "Domain Bucket":"< 1K"
   },
   {
     "Class":"Predicate",
-    "Name":"http:\/\/schema.org\/spouse",
+    "Name":"https://schema.org/spouse",
     "Domain Bucket":"1K - 10K"
   },
   {
     "Class":"Predicate",
-    "Name":"http:\/\/schema.org\/spouse-input",
+    "Name":"https://schema.org/spouse-input",
     "Domain Bucket":"< 1K"
   },
   {
     "Class":"Predicate",
-    "Name":"http:\/\/schema.org\/spouse-output",
+    "Name":"https://schema.org/spouse-output",
     "Domain Bucket":"< 1K"
   },
   {
     "Class":"Predicate",
-    "Name":"http:\/\/schema.org\/stage",
+    "Name":"https://schema.org/stage",
     "Domain Bucket":"< 1K"
   },
   {
     "Class":"Predicate",
-    "Name":"http:\/\/schema.org\/stage-input",
+    "Name":"https://schema.org/stage-input",
     "Domain Bucket":"< 1K"
   },
   {
     "Class":"Predicate",
-    "Name":"http:\/\/schema.org\/stage-output",
+    "Name":"https://schema.org/stage-output",
     "Domain Bucket":"< 1K"
   },
   {
     "Class":"Predicate",
-    "Name":"http:\/\/schema.org\/stageAsNumber",
+    "Name":"https://schema.org/stageAsNumber",
     "Domain Bucket":"< 1K"
   },
   {
     "Class":"Predicate",
-    "Name":"http:\/\/schema.org\/stageAsNumber-input",
+    "Name":"https://schema.org/stageAsNumber-input",
     "Domain Bucket":"< 1K"
   },
   {
     "Class":"Predicate",
-    "Name":"http:\/\/schema.org\/stageAsNumber-output",
+    "Name":"https://schema.org/stageAsNumber-output",
     "Domain Bucket":"< 1K"
   },
   {
     "Class":"Predicate",
-    "Name":"http:\/\/schema.org\/starRating",
+    "Name":"https://schema.org/starRating",
     "Domain Bucket":"10K - 100K"
   },
   {
     "Class":"Predicate",
-    "Name":"http:\/\/schema.org\/starRating-input",
+    "Name":"https://schema.org/starRating-input",
     "Domain Bucket":"< 1K"
   },
   {
     "Class":"Predicate",
-    "Name":"http:\/\/schema.org\/starRating-output",
+    "Name":"https://schema.org/starRating-output",
     "Domain Bucket":"< 1K"
   },
   {
     "Class":"Predicate",
-    "Name":"http:\/\/schema.org\/startDate",
+    "Name":"https://schema.org/startDate",
     "Domain Bucket":"100K - 1M"
   },
   {
     "Class":"Predicate",
-    "Name":"http:\/\/schema.org\/startDate-input",
+    "Name":"https://schema.org/startDate-input",
     "Domain Bucket":"< 1K"
   },
   {
     "Class":"Predicate",
-    "Name":"http:\/\/schema.org\/startDate-output",
+    "Name":"https://schema.org/startDate-output",
     "Domain Bucket":"< 1K"
   },
   {
     "Class":"Predicate",
-    "Name":"http:\/\/schema.org\/startOffset",
+    "Name":"https://schema.org/startOffset",
     "Domain Bucket":"10K - 100K"
   },
   {
     "Class":"Predicate",
-    "Name":"http:\/\/schema.org\/startOffset-input",
+    "Name":"https://schema.org/startOffset-input",
     "Domain Bucket":"10K - 100K"
   },
   {
     "Class":"Predicate",
-    "Name":"http:\/\/schema.org\/startOffset-output",
+    "Name":"https://schema.org/startOffset-output",
     "Domain Bucket":"< 1K"
   },
   {
     "Class":"Predicate",
-    "Name":"http:\/\/schema.org\/startTime",
+    "Name":"https://schema.org/startTime",
     "Domain Bucket":"1K - 10K"
   },
   {
     "Class":"Predicate",
-    "Name":"http:\/\/schema.org\/startTime-input",
+    "Name":"https://schema.org/startTime-input",
     "Domain Bucket":"< 1K"
   },
   {
     "Class":"Predicate",
-    "Name":"http:\/\/schema.org\/startTime-output",
+    "Name":"https://schema.org/startTime-output",
     "Domain Bucket":"< 1K"
   },
   {
     "Class":"Predicate",
-    "Name":"http:\/\/schema.org\/statType",
+    "Name":"https://schema.org/statType",
     "Domain Bucket":"< 1K"
   },
   {
     "Class":"Predicate",
-    "Name":"http:\/\/schema.org\/statType-input",
+    "Name":"https://schema.org/statType-input",
     "Domain Bucket":"< 1K"
   },
   {
     "Class":"Predicate",
-    "Name":"http:\/\/schema.org\/statType-output",
+    "Name":"https://schema.org/statType-output",
     "Domain Bucket":"< 1K"
   },
   {
     "Class":"Predicate",
-    "Name":"http:\/\/schema.org\/status",
+    "Name":"https://schema.org/status",
     "Domain Bucket":"1K - 10K"
   },
   {
     "Class":"Predicate",
-    "Name":"http:\/\/schema.org\/status-input",
+    "Name":"https://schema.org/status-input",
     "Domain Bucket":"< 1K"
   },
   {
     "Class":"Predicate",
-    "Name":"http:\/\/schema.org\/status-output",
+    "Name":"https://schema.org/status-output",
     "Domain Bucket":"< 1K"
   },
   {
     "Class":"Predicate",
-    "Name":"http:\/\/schema.org\/steeringPosition",
+    "Name":"https://schema.org/steeringPosition",
     "Domain Bucket":"1K - 10K"
   },
   {
     "Class":"Predicate",
-    "Name":"http:\/\/schema.org\/steeringPosition-input",
+    "Name":"https://schema.org/steeringPosition-input",
     "Domain Bucket":"< 1K"
   },
   {
     "Class":"Predicate",
-    "Name":"http:\/\/schema.org\/steeringPosition-output",
+    "Name":"https://schema.org/steeringPosition-output",
     "Domain Bucket":"< 1K"
   },
   {
     "Class":"Predicate",
-    "Name":"http:\/\/schema.org\/step",
+    "Name":"https://schema.org/step",
     "Domain Bucket":"100K - 1M"
   },
   {
     "Class":"Predicate",
-    "Name":"http:\/\/schema.org\/step-input",
+    "Name":"https://schema.org/step-input",
     "Domain Bucket":"< 1K"
   },
   {
     "Class":"Predicate",
-    "Name":"http:\/\/schema.org\/step-output",
+    "Name":"https://schema.org/step-output",
     "Domain Bucket":"< 1K"
   },
   {
     "Class":"Predicate",
-    "Name":"http:\/\/schema.org\/stepValue",
+    "Name":"https://schema.org/stepValue",
     "Domain Bucket":"< 1K"
   },
   {
     "Class":"Predicate",
-    "Name":"http:\/\/schema.org\/stepValue-input",
+    "Name":"https://schema.org/stepValue-input",
     "Domain Bucket":"< 1K"
   },
   {
     "Class":"Predicate",
-    "Name":"http:\/\/schema.org\/stepValue-output",
+    "Name":"https://schema.org/stepValue-output",
     "Domain Bucket":"< 1K"
   },
   {
     "Class":"Predicate",
-    "Name":"http:\/\/schema.org\/steps",
+    "Name":"https://schema.org/steps",
     "Domain Bucket":"< 1K"
   },
   {
     "Class":"Predicate",
-    "Name":"http:\/\/schema.org\/steps-input",
+    "Name":"https://schema.org/steps-input",
     "Domain Bucket":"< 1K"
   },
   {
     "Class":"Predicate",
-    "Name":"http:\/\/schema.org\/steps-output",
+    "Name":"https://schema.org/steps-output",
     "Domain Bucket":"< 1K"
   },
   {
     "Class":"Predicate",
-    "Name":"http:\/\/schema.org\/storageRequirements",
+    "Name":"https://schema.org/storageRequirements",
     "Domain Bucket":"10K - 100K"
   },
   {
     "Class":"Predicate",
-    "Name":"http:\/\/schema.org\/storageRequirements-input",
+    "Name":"https://schema.org/storageRequirements-input",
     "Domain Bucket":"< 1K"
   },
   {
     "Class":"Predicate",
-    "Name":"http:\/\/schema.org\/storageRequirements-output",
+    "Name":"https://schema.org/storageRequirements-output",
     "Domain Bucket":"< 1K"
   },
   {
     "Class":"Predicate",
-    "Name":"http:\/\/schema.org\/streetAddress",
+    "Name":"https://schema.org/streetAddress",
     "Domain Bucket":"1M - 10M"
   },
   {
     "Class":"Predicate",
-    "Name":"http:\/\/schema.org\/streetAddress-input",
+    "Name":"https://schema.org/streetAddress-input",
     "Domain Bucket":"< 1K"
   },
   {
     "Class":"Predicate",
-    "Name":"http:\/\/schema.org\/streetAddress-output",
+    "Name":"https://schema.org/streetAddress-output",
     "Domain Bucket":"< 1K"
   },
   {
     "Class":"Predicate",
-    "Name":"http:\/\/schema.org\/strengthUnit",
+    "Name":"https://schema.org/strengthUnit",
     "Domain Bucket":"< 1K"
   },
   {
     "Class":"Predicate",
-    "Name":"http:\/\/schema.org\/strengthUnit-input",
+    "Name":"https://schema.org/strengthUnit-input",
     "Domain Bucket":"< 1K"
   },
   {
     "Class":"Predicate",
-    "Name":"http:\/\/schema.org\/strengthUnit-output",
+    "Name":"https://schema.org/strengthUnit-output",
     "Domain Bucket":"< 1K"
   },
   {
     "Class":"Predicate",
-    "Name":"http:\/\/schema.org\/strengthValue",
+    "Name":"https://schema.org/strengthValue",
     "Domain Bucket":"< 1K"
   },
   {
     "Class":"Predicate",
-    "Name":"http:\/\/schema.org\/strengthValue-input",
+    "Name":"https://schema.org/strengthValue-input",
     "Domain Bucket":"< 1K"
   },
   {
     "Class":"Predicate",
-    "Name":"http:\/\/schema.org\/strengthValue-output",
+    "Name":"https://schema.org/strengthValue-output",
     "Domain Bucket":"< 1K"
   },
   {
     "Class":"Predicate",
-    "Name":"http:\/\/schema.org\/structuralClass",
+    "Name":"https://schema.org/structuralClass",
     "Domain Bucket":"< 1K"
   },
   {
     "Class":"Predicate",
-    "Name":"http:\/\/schema.org\/structuralClass-input",
+    "Name":"https://schema.org/structuralClass-input",
     "Domain Bucket":"< 1K"
   },
   {
     "Class":"Predicate",
-    "Name":"http:\/\/schema.org\/structuralClass-output",
+    "Name":"https://schema.org/structuralClass-output",
     "Domain Bucket":"< 1K"
   },
   {
     "Class":"Predicate",
-    "Name":"http:\/\/schema.org\/study",
+    "Name":"https://schema.org/study",
     "Domain Bucket":"< 1K"
   },
   {
     "Class":"Predicate",
-    "Name":"http:\/\/schema.org\/study-input",
+    "Name":"https://schema.org/study-input",
     "Domain Bucket":"< 1K"
   },
   {
     "Class":"Predicate",
-    "Name":"http:\/\/schema.org\/study-output",
+    "Name":"https://schema.org/study-output",
     "Domain Bucket":"< 1K"
   },
   {
     "Class":"Predicate",
-    "Name":"http:\/\/schema.org\/studyDesign",
+    "Name":"https://schema.org/studyDesign",
     "Domain Bucket":"< 1K"
   },
   {
     "Class":"Predicate",
-    "Name":"http:\/\/schema.org\/studyDesign-input",
+    "Name":"https://schema.org/studyDesign-input",
     "Domain Bucket":"< 1K"
   },
   {
     "Class":"Predicate",
-    "Name":"http:\/\/schema.org\/studyDesign-output",
+    "Name":"https://schema.org/studyDesign-output",
     "Domain Bucket":"< 1K"
   },
   {
     "Class":"Predicate",
-    "Name":"http:\/\/schema.org\/studyLocation",
+    "Name":"https://schema.org/studyLocation",
     "Domain Bucket":"< 1K"
   },
   {
     "Class":"Predicate",
-    "Name":"http:\/\/schema.org\/studyLocation-input",
+    "Name":"https://schema.org/studyLocation-input",
     "Domain Bucket":"< 1K"
   },
   {
     "Class":"Predicate",
-    "Name":"http:\/\/schema.org\/studyLocation-output",
+    "Name":"https://schema.org/studyLocation-output",
     "Domain Bucket":"< 1K"
   },
   {
     "Class":"Predicate",
-    "Name":"http:\/\/schema.org\/studySubject",
+    "Name":"https://schema.org/studySubject",
     "Domain Bucket":"< 1K"
   },
   {
     "Class":"Predicate",
-    "Name":"http:\/\/schema.org\/studySubject-input",
+    "Name":"https://schema.org/studySubject-input",
     "Domain Bucket":"< 1K"
   },
   {
     "Class":"Predicate",
-    "Name":"http:\/\/schema.org\/studySubject-output",
+    "Name":"https://schema.org/studySubject-output",
     "Domain Bucket":"< 1K"
   },
   {
     "Class":"Predicate",
-    "Name":"http:\/\/schema.org\/stupidProperty",
+    "Name":"https://schema.org/stupidProperty",
     "Domain Bucket":"< 1K"
   },
   {
     "Class":"Predicate",
-    "Name":"http:\/\/schema.org\/stupidProperty-input",
+    "Name":"https://schema.org/stupidProperty-input",
     "Domain Bucket":"< 1K"
   },
   {
     "Class":"Predicate",
-    "Name":"http:\/\/schema.org\/stupidProperty-output",
+    "Name":"https://schema.org/stupidProperty-output",
     "Domain Bucket":"< 1K"
   },
   {
     "Class":"Predicate",
-    "Name":"http:\/\/schema.org\/subEvent",
+    "Name":"https://schema.org/subEvent",
     "Domain Bucket":"1K - 10K"
   },
   {
     "Class":"Predicate",
-    "Name":"http:\/\/schema.org\/subEvent-input",
+    "Name":"https://schema.org/subEvent-input",
     "Domain Bucket":"< 1K"
   },
   {
     "Class":"Predicate",
-    "Name":"http:\/\/schema.org\/subEvent-output",
+    "Name":"https://schema.org/subEvent-output",
     "Domain Bucket":"< 1K"
   },
   {
     "Class":"Predicate",
-    "Name":"http:\/\/schema.org\/subEvents",
+    "Name":"https://schema.org/subEvents",
     "Domain Bucket":"< 1K"
   },
   {
     "Class":"Predicate",
-    "Name":"http:\/\/schema.org\/subEvents-input",
+    "Name":"https://schema.org/subEvents-input",
     "Domain Bucket":"< 1K"
   },
   {
     "Class":"Predicate",
-    "Name":"http:\/\/schema.org\/subEvents-output",
+    "Name":"https://schema.org/subEvents-output",
     "Domain Bucket":"< 1K"
   },
   {
     "Class":"Predicate",
-    "Name":"http:\/\/schema.org\/subOrganization",
+    "Name":"https://schema.org/subOrganization",
     "Domain Bucket":"10K - 100K"
   },
   {
     "Class":"Predicate",
-    "Name":"http:\/\/schema.org\/subOrganization-input",
+    "Name":"https://schema.org/subOrganization-input",
     "Domain Bucket":"< 1K"
   },
   {
     "Class":"Predicate",
-    "Name":"http:\/\/schema.org\/subOrganization-output",
+    "Name":"https://schema.org/subOrganization-output",
     "Domain Bucket":"< 1K"
   },
   {
     "Class":"Predicate",
-    "Name":"http:\/\/schema.org\/subReservation",
+    "Name":"https://schema.org/subReservation",
     "Domain Bucket":"< 1K"
   },
   {
     "Class":"Predicate",
-    "Name":"http:\/\/schema.org\/subReservation-input",
+    "Name":"https://schema.org/subReservation-input",
     "Domain Bucket":"< 1K"
   },
   {
     "Class":"Predicate",
-    "Name":"http:\/\/schema.org\/subReservation-output",
+    "Name":"https://schema.org/subReservation-output",
     "Domain Bucket":"< 1K"
   },
   {
     "Class":"Predicate",
-    "Name":"http:\/\/schema.org\/subStageSuffix",
+    "Name":"https://schema.org/subStageSuffix",
     "Domain Bucket":"< 1K"
   },
   {
     "Class":"Predicate",
-    "Name":"http:\/\/schema.org\/subStageSuffix-input",
+    "Name":"https://schema.org/subStageSuffix-input",
     "Domain Bucket":"< 1K"
   },
   {
     "Class":"Predicate",
-    "Name":"http:\/\/schema.org\/subStageSuffix-output",
+    "Name":"https://schema.org/subStageSuffix-output",
     "Domain Bucket":"< 1K"
   },
   {
     "Class":"Predicate",
-    "Name":"http:\/\/schema.org\/subStructure",
+    "Name":"https://schema.org/subStructure",
     "Domain Bucket":"< 1K"
   },
   {
     "Class":"Predicate",
-    "Name":"http:\/\/schema.org\/subStructure-input",
+    "Name":"https://schema.org/subStructure-input",
     "Domain Bucket":"< 1K"
   },
   {
     "Class":"Predicate",
-    "Name":"http:\/\/schema.org\/subStructure-output",
+    "Name":"https://schema.org/subStructure-output",
     "Domain Bucket":"< 1K"
   },
   {
     "Class":"Predicate",
-    "Name":"http:\/\/schema.org\/subTest",
+    "Name":"https://schema.org/subTest",
     "Domain Bucket":"< 1K"
   },
   {
     "Class":"Predicate",
-    "Name":"http:\/\/schema.org\/subTest-input",
+    "Name":"https://schema.org/subTest-input",
     "Domain Bucket":"< 1K"
   },
   {
     "Class":"Predicate",
-    "Name":"http:\/\/schema.org\/subTest-output",
+    "Name":"https://schema.org/subTest-output",
     "Domain Bucket":"< 1K"
   },
   {
     "Class":"Predicate",
-    "Name":"http:\/\/schema.org\/subTrip",
+    "Name":"https://schema.org/subTrip",
     "Domain Bucket":"< 1K"
   },
   {
     "Class":"Predicate",
-    "Name":"http:\/\/schema.org\/subTrip-input",
+    "Name":"https://schema.org/subTrip-input",
     "Domain Bucket":"< 1K"
   },
   {
     "Class":"Predicate",
-    "Name":"http:\/\/schema.org\/subTrip-output",
+    "Name":"https://schema.org/subTrip-output",
     "Domain Bucket":"< 1K"
   },
   {
     "Class":"Predicate",
-    "Name":"http:\/\/schema.org\/subjectOf",
+    "Name":"https://schema.org/subjectOf",
     "Domain Bucket":"100K - 1M"
   },
   {
     "Class":"Predicate",
-    "Name":"http:\/\/schema.org\/subjectOf-input",
+    "Name":"https://schema.org/subjectOf-input",
     "Domain Bucket":"< 1K"
   },
   {
     "Class":"Predicate",
-    "Name":"http:\/\/schema.org\/subjectOf-output",
+    "Name":"https://schema.org/subjectOf-output",
     "Domain Bucket":"< 1K"
   },
   {
     "Class":"Predicate",
-    "Name":"http:\/\/schema.org\/subtitleLanguage",
+    "Name":"https://schema.org/subtitleLanguage",
     "Domain Bucket":"< 1K"
   },
   {
     "Class":"Predicate",
-    "Name":"http:\/\/schema.org\/subtitleLanguage-input",
+    "Name":"https://schema.org/subtitleLanguage-input",
     "Domain Bucket":"< 1K"
   },
   {
     "Class":"Predicate",
-    "Name":"http:\/\/schema.org\/subtitleLanguage-output",
+    "Name":"https://schema.org/subtitleLanguage-output",
     "Domain Bucket":"< 1K"
   },
   {
     "Class":"Predicate",
-    "Name":"http:\/\/schema.org\/successorOf",
+    "Name":"https://schema.org/successorOf",
     "Domain Bucket":"< 1K"
   },
   {
     "Class":"Predicate",
-    "Name":"http:\/\/schema.org\/successorOf-input",
+    "Name":"https://schema.org/successorOf-input",
     "Domain Bucket":"< 1K"
   },
   {
     "Class":"Predicate",
-    "Name":"http:\/\/schema.org\/successorOf-output",
+    "Name":"https://schema.org/successorOf-output",
     "Domain Bucket":"< 1K"
   },
   {
     "Class":"Predicate",
-    "Name":"http:\/\/schema.org\/sugarContent",
+    "Name":"https://schema.org/sugarContent",
     "Domain Bucket":"10K - 100K"
   },
   {
     "Class":"Predicate",
-    "Name":"http:\/\/schema.org\/sugarContent-input",
+    "Name":"https://schema.org/sugarContent-input",
     "Domain Bucket":"< 1K"
   },
   {
     "Class":"Predicate",
-    "Name":"http:\/\/schema.org\/sugarContent-output",
+    "Name":"https://schema.org/sugarContent-output",
     "Domain Bucket":"< 1K"
   },
   {
     "Class":"Predicate",
-    "Name":"http:\/\/schema.org\/suggestedAge",
+    "Name":"https://schema.org/suggestedAge",
     "Domain Bucket":"1K - 10K"
   },
   {
     "Class":"Predicate",
-    "Name":"http:\/\/schema.org\/suggestedAge-input",
+    "Name":"https://schema.org/suggestedAge-input",
     "Domain Bucket":"< 1K"
   },
   {
     "Class":"Predicate",
-    "Name":"http:\/\/schema.org\/suggestedAge-output",
+    "Name":"https://schema.org/suggestedAge-output",
     "Domain Bucket":"< 1K"
   },
   {
     "Class":"Predicate",
-    "Name":"http:\/\/schema.org\/suggestedAnswer",
+    "Name":"https://schema.org/suggestedAnswer",
     "Domain Bucket":"10K - 100K"
   },
   {
     "Class":"Predicate",
-    "Name":"http:\/\/schema.org\/suggestedAnswer-input",
+    "Name":"https://schema.org/suggestedAnswer-input",
     "Domain Bucket":"< 1K"
   },
   {
     "Class":"Predicate",
-    "Name":"http:\/\/schema.org\/suggestedAnswer-output",
+    "Name":"https://schema.org/suggestedAnswer-output",
     "Domain Bucket":"< 1K"
   },
   {
     "Class":"Predicate",
-    "Name":"http:\/\/schema.org\/suggestedGender",
+    "Name":"https://schema.org/suggestedGender",
     "Domain Bucket":"10K - 100K"
   },
   {
     "Class":"Predicate",
-    "Name":"http:\/\/schema.org\/suggestedGender-input",
+    "Name":"https://schema.org/suggestedGender-input",
     "Domain Bucket":"< 1K"
   },
   {
     "Class":"Predicate",
-    "Name":"http:\/\/schema.org\/suggestedGender-output",
+    "Name":"https://schema.org/suggestedGender-output",
     "Domain Bucket":"< 1K"
   },
   {
     "Class":"Predicate",
-    "Name":"http:\/\/schema.org\/suggestedMaxAge",
+    "Name":"https://schema.org/suggestedMaxAge",
     "Domain Bucket":"1K - 10K"
   },
   {
     "Class":"Predicate",
-    "Name":"http:\/\/schema.org\/suggestedMaxAge-input",
+    "Name":"https://schema.org/suggestedMaxAge-input",
     "Domain Bucket":"< 1K"
   },
   {
     "Class":"Predicate",
-    "Name":"http:\/\/schema.org\/suggestedMaxAge-output",
+    "Name":"https://schema.org/suggestedMaxAge-output",
     "Domain Bucket":"< 1K"
   },
   {
     "Class":"Predicate",
-    "Name":"http:\/\/schema.org\/suggestedMeasurement",
+    "Name":"https://schema.org/suggestedMeasurement",
     "Domain Bucket":"< 1K"
   },
   {
     "Class":"Predicate",
-    "Name":"http:\/\/schema.org\/suggestedMeasurement-input",
+    "Name":"https://schema.org/suggestedMeasurement-input",
     "Domain Bucket":"< 1K"
   },
   {
     "Class":"Predicate",
-    "Name":"http:\/\/schema.org\/suggestedMeasurement-output",
+    "Name":"https://schema.org/suggestedMeasurement-output",
     "Domain Bucket":"< 1K"
   },
   {
     "Class":"Predicate",
-    "Name":"http:\/\/schema.org\/suggestedMinAge",
+    "Name":"https://schema.org/suggestedMinAge",
     "Domain Bucket":"10K - 100K"
   },
   {
     "Class":"Predicate",
-    "Name":"http:\/\/schema.org\/suggestedMinAge-input",
+    "Name":"https://schema.org/suggestedMinAge-input",
     "Domain Bucket":"< 1K"
   },
   {
     "Class":"Predicate",
-    "Name":"http:\/\/schema.org\/suggestedMinAge-output",
+    "Name":"https://schema.org/suggestedMinAge-output",
     "Domain Bucket":"< 1K"
   },
   {
     "Class":"Predicate",
-    "Name":"http:\/\/schema.org\/suitableForDiet",
+    "Name":"https://schema.org/suitableForDiet",
     "Domain Bucket":"10K - 100K"
   },
   {
     "Class":"Predicate",
-    "Name":"http:\/\/schema.org\/suitableForDiet-input",
+    "Name":"https://schema.org/suitableForDiet-input",
     "Domain Bucket":"< 1K"
   },
   {
     "Class":"Predicate",
-    "Name":"http:\/\/schema.org\/suitableForDiet-output",
+    "Name":"https://schema.org/suitableForDiet-output",
     "Domain Bucket":"< 1K"
   },
   {
     "Class":"Predicate",
-    "Name":"http:\/\/schema.org\/superEvent",
+    "Name":"https://schema.org/superEvent",
     "Domain Bucket":"1K - 10K"
   },
   {
     "Class":"Predicate",
-    "Name":"http:\/\/schema.org\/superEvent-input",
+    "Name":"https://schema.org/superEvent-input",
     "Domain Bucket":"< 1K"
   },
   {
     "Class":"Predicate",
-    "Name":"http:\/\/schema.org\/superEvent-output",
+    "Name":"https://schema.org/superEvent-output",
     "Domain Bucket":"< 1K"
   },
   {
     "Class":"Predicate",
-    "Name":"http:\/\/schema.org\/supersededBy",
+    "Name":"https://schema.org/supersededBy",
     "Domain Bucket":"1K - 10K"
   },
   {
     "Class":"Predicate",
-    "Name":"http:\/\/schema.org\/supersededBy-input",
+    "Name":"https://schema.org/supersededBy-input",
     "Domain Bucket":"< 1K"
   },
   {
     "Class":"Predicate",
-    "Name":"http:\/\/schema.org\/supersededBy-output",
+    "Name":"https://schema.org/supersededBy-output",
     "Domain Bucket":"< 1K"
   },
   {
     "Class":"Predicate",
-    "Name":"http:\/\/schema.org\/supply",
+    "Name":"https://schema.org/supply",
     "Domain Bucket":"10K - 100K"
   },
   {
     "Class":"Predicate",
-    "Name":"http:\/\/schema.org\/supply-input",
+    "Name":"https://schema.org/supply-input",
     "Domain Bucket":"< 1K"
   },
   {
     "Class":"Predicate",
-    "Name":"http:\/\/schema.org\/supply-output",
+    "Name":"https://schema.org/supply-output",
     "Domain Bucket":"< 1K"
   },
   {
     "Class":"Predicate",
-    "Name":"http:\/\/schema.org\/supplyTo",
+    "Name":"https://schema.org/supplyTo",
     "Domain Bucket":"< 1K"
   },
   {
     "Class":"Predicate",
-    "Name":"http:\/\/schema.org\/supplyTo-input",
+    "Name":"https://schema.org/supplyTo-input",
     "Domain Bucket":"< 1K"
   },
   {
     "Class":"Predicate",
-    "Name":"http:\/\/schema.org\/supplyTo-output",
+    "Name":"https://schema.org/supplyTo-output",
     "Domain Bucket":"< 1K"
   },
   {
     "Class":"Predicate",
-    "Name":"http:\/\/schema.org\/supportingData",
+    "Name":"https://schema.org/supportingData",
     "Domain Bucket":"< 1K"
   },
   {
     "Class":"Predicate",
-    "Name":"http:\/\/schema.org\/supportingData-input",
+    "Name":"https://schema.org/supportingData-input",
     "Domain Bucket":"< 1K"
   },
   {
     "Class":"Predicate",
-    "Name":"http:\/\/schema.org\/supportingData-output",
+    "Name":"https://schema.org/supportingData-output",
     "Domain Bucket":"< 1K"
   },
   {
     "Class":"Predicate",
-    "Name":"http:\/\/schema.org\/surface",
+    "Name":"https://schema.org/surface",
     "Domain Bucket":"< 1K"
   },
   {
     "Class":"Predicate",
-    "Name":"http:\/\/schema.org\/surface-input",
+    "Name":"https://schema.org/surface-input",
     "Domain Bucket":"< 1K"
   },
   {
     "Class":"Predicate",
-    "Name":"http:\/\/schema.org\/surface-output",
+    "Name":"https://schema.org/surface-output",
     "Domain Bucket":"< 1K"
   },
   {
     "Class":"Predicate",
-    "Name":"http:\/\/schema.org\/syllabusSections",
+    "Name":"https://schema.org/syllabusSections",
     "Domain Bucket":"1K - 10K"
   },
   {
     "Class":"Predicate",
-    "Name":"http:\/\/schema.org\/syllabusSections-input",
+    "Name":"https://schema.org/syllabusSections-input",
     "Domain Bucket":"< 1K"
   },
   {
     "Class":"Predicate",
-    "Name":"http:\/\/schema.org\/syllabusSections-output",
+    "Name":"https://schema.org/syllabusSections-output",
     "Domain Bucket":"< 1K"
   },
   {
     "Class":"Predicate",
-    "Name":"http:\/\/schema.org\/target",
+    "Name":"https://schema.org/target",
     "Domain Bucket":"10M+"
   },
   {
     "Class":"Predicate",
-    "Name":"http:\/\/schema.org\/target-input",
+    "Name":"https://schema.org/target-input",
     "Domain Bucket":"< 1K"
   },
   {
     "Class":"Predicate",
-    "Name":"http:\/\/schema.org\/target-output",
+    "Name":"https://schema.org/target-output",
     "Domain Bucket":"< 1K"
   },
   {
     "Class":"Predicate",
-    "Name":"http:\/\/schema.org\/targetCollection",
+    "Name":"https://schema.org/targetCollection",
     "Domain Bucket":"< 1K"
   },
   {
     "Class":"Predicate",
-    "Name":"http:\/\/schema.org\/targetCollection-input",
+    "Name":"https://schema.org/targetCollection-input",
     "Domain Bucket":"< 1K"
   },
   {
     "Class":"Predicate",
-    "Name":"http:\/\/schema.org\/targetCollection-output",
+    "Name":"https://schema.org/targetCollection-output",
     "Domain Bucket":"< 1K"
   },
   {
     "Class":"Predicate",
-    "Name":"http:\/\/schema.org\/targetDescription",
+    "Name":"https://schema.org/targetDescription",
     "Domain Bucket":"< 1K"
   },
   {
     "Class":"Predicate",
-    "Name":"http:\/\/schema.org\/targetDescription-input",
+    "Name":"https://schema.org/targetDescription-input",
     "Domain Bucket":"< 1K"
   },
   {
     "Class":"Predicate",
-    "Name":"http:\/\/schema.org\/targetDescription-output",
+    "Name":"https://schema.org/targetDescription-output",
     "Domain Bucket":"< 1K"
   },
   {
     "Class":"Predicate",
-    "Name":"http:\/\/schema.org\/targetName",
+    "Name":"https://schema.org/targetName",
     "Domain Bucket":"1K - 10K"
   },
   {
     "Class":"Predicate",
-    "Name":"http:\/\/schema.org\/targetName-input",
+    "Name":"https://schema.org/targetName-input",
     "Domain Bucket":"< 1K"
   },
   {
     "Class":"Predicate",
-    "Name":"http:\/\/schema.org\/targetName-output",
+    "Name":"https://schema.org/targetName-output",
     "Domain Bucket":"< 1K"
   },
   {
     "Class":"Predicate",
-    "Name":"http:\/\/schema.org\/targetPlatform",
+    "Name":"https://schema.org/targetPlatform",
     "Domain Bucket":"< 1K"
   },
   {
     "Class":"Predicate",
-    "Name":"http:\/\/schema.org\/targetPlatform-input",
+    "Name":"https://schema.org/targetPlatform-input",
     "Domain Bucket":"< 1K"
   },
   {
     "Class":"Predicate",
-    "Name":"http:\/\/schema.org\/targetPlatform-output",
+    "Name":"https://schema.org/targetPlatform-output",
     "Domain Bucket":"< 1K"
   },
   {
     "Class":"Predicate",
-    "Name":"http:\/\/schema.org\/targetPopulation",
+    "Name":"https://schema.org/targetPopulation",
     "Domain Bucket":"< 1K"
   },
   {
     "Class":"Predicate",
-    "Name":"http:\/\/schema.org\/targetPopulation-input",
+    "Name":"https://schema.org/targetPopulation-input",
     "Domain Bucket":"< 1K"
   },
   {
     "Class":"Predicate",
-    "Name":"http:\/\/schema.org\/targetPopulation-output",
+    "Name":"https://schema.org/targetPopulation-output",
     "Domain Bucket":"< 1K"
   },
   {
     "Class":"Predicate",
-    "Name":"http:\/\/schema.org\/targetProduct",
+    "Name":"https://schema.org/targetProduct",
     "Domain Bucket":"< 1K"
   },
   {
     "Class":"Predicate",
-    "Name":"http:\/\/schema.org\/targetProduct-input",
+    "Name":"https://schema.org/targetProduct-input",
     "Domain Bucket":"< 1K"
   },
   {
     "Class":"Predicate",
-    "Name":"http:\/\/schema.org\/targetProduct-output",
+    "Name":"https://schema.org/targetProduct-output",
     "Domain Bucket":"< 1K"
   },
   {
     "Class":"Predicate",
-    "Name":"http:\/\/schema.org\/targetUrl",
+    "Name":"https://schema.org/targetUrl",
     "Domain Bucket":"< 1K"
   },
   {
     "Class":"Predicate",
-    "Name":"http:\/\/schema.org\/targetUrl-input",
+    "Name":"https://schema.org/targetUrl-input",
     "Domain Bucket":"< 1K"
   },
   {
     "Class":"Predicate",
-    "Name":"http:\/\/schema.org\/targetUrl-output",
+    "Name":"https://schema.org/targetUrl-output",
     "Domain Bucket":"< 1K"
   },
   {
     "Class":"Predicate",
-    "Name":"http:\/\/schema.org\/taxID",
+    "Name":"https://schema.org/taxID",
     "Domain Bucket":"100K - 1M"
   },
   {
     "Class":"Predicate",
-    "Name":"http:\/\/schema.org\/taxID-input",
+    "Name":"https://schema.org/taxID-input",
     "Domain Bucket":"< 1K"
   },
   {
     "Class":"Predicate",
-    "Name":"http:\/\/schema.org\/taxID-output",
+    "Name":"https://schema.org/taxID-output",
     "Domain Bucket":"< 1K"
   },
   {
     "Class":"Predicate",
-    "Name":"http:\/\/schema.org\/taxonRank",
+    "Name":"https://schema.org/taxonRank",
     "Domain Bucket":"< 1K"
   },
   {
     "Class":"Predicate",
-    "Name":"http:\/\/schema.org\/taxonRank-input",
+    "Name":"https://schema.org/taxonRank-input",
     "Domain Bucket":"< 1K"
   },
   {
     "Class":"Predicate",
-    "Name":"http:\/\/schema.org\/taxonRank-output",
+    "Name":"https://schema.org/taxonRank-output",
     "Domain Bucket":"< 1K"
   },
   {
     "Class":"Predicate",
-    "Name":"http:\/\/schema.org\/taxonomicRange",
+    "Name":"https://schema.org/taxonomicRange",
     "Domain Bucket":"< 1K"
   },
   {
     "Class":"Predicate",
-    "Name":"http:\/\/schema.org\/taxonomicRange-input",
+    "Name":"https://schema.org/taxonomicRange-input",
     "Domain Bucket":"< 1K"
   },
   {
     "Class":"Predicate",
-    "Name":"http:\/\/schema.org\/taxonomicRange-output",
+    "Name":"https://schema.org/taxonomicRange-output",
     "Domain Bucket":"< 1K"
   },
   {
     "Class":"Predicate",
-    "Name":"http:\/\/schema.org\/teaches",
+    "Name":"https://schema.org/teaches",
     "Domain Bucket":"10K - 100K"
   },
   {
     "Class":"Predicate",
-    "Name":"http:\/\/schema.org\/teaches-input",
+    "Name":"https://schema.org/teaches-input",
     "Domain Bucket":"< 1K"
   },
   {
     "Class":"Predicate",
-    "Name":"http:\/\/schema.org\/teaches-output",
+    "Name":"https://schema.org/teaches-output",
     "Domain Bucket":"< 1K"
   },
   {
     "Class":"Predicate",
-    "Name":"http:\/\/schema.org\/telephone",
+    "Name":"https://schema.org/telephone",
     "Domain Bucket":"1M - 10M"
   },
   {
     "Class":"Predicate",
-    "Name":"http:\/\/schema.org\/telephone-input",
+    "Name":"https://schema.org/telephone-input",
     "Domain Bucket":"< 1K"
   },
   {
     "Class":"Predicate",
-    "Name":"http:\/\/schema.org\/telephone-output",
+    "Name":"https://schema.org/telephone-output",
     "Domain Bucket":"< 1K"
   },
   {
     "Class":"Predicate",
-    "Name":"http:\/\/schema.org\/temporal",
+    "Name":"https://schema.org/temporal",
     "Domain Bucket":"< 1K"
   },
   {
     "Class":"Predicate",
-    "Name":"http:\/\/schema.org\/temporal-input",
+    "Name":"https://schema.org/temporal-input",
     "Domain Bucket":"< 1K"
   },
   {
     "Class":"Predicate",
-    "Name":"http:\/\/schema.org\/temporal-output",
+    "Name":"https://schema.org/temporal-output",
     "Domain Bucket":"< 1K"
   },
   {
     "Class":"Predicate",
-    "Name":"http:\/\/schema.org\/temporalCoverage",
+    "Name":"https://schema.org/temporalCoverage",
     "Domain Bucket":"10K - 100K"
   },
   {
     "Class":"Predicate",
-    "Name":"http:\/\/schema.org\/temporalCoverage-input",
+    "Name":"https://schema.org/temporalCoverage-input",
     "Domain Bucket":"< 1K"
   },
   {
     "Class":"Predicate",
-    "Name":"http:\/\/schema.org\/temporalCoverage-output",
+    "Name":"https://schema.org/temporalCoverage-output",
     "Domain Bucket":"< 1K"
   },
   {
     "Class":"Predicate",
-    "Name":"http:\/\/schema.org\/termCode",
+    "Name":"https://schema.org/termCode",
     "Domain Bucket":"1K - 10K"
   },
   {
     "Class":"Predicate",
-    "Name":"http:\/\/schema.org\/termCode-input",
+    "Name":"https://schema.org/termCode-input",
     "Domain Bucket":"< 1K"
   },
   {
     "Class":"Predicate",
-    "Name":"http:\/\/schema.org\/termCode-output",
+    "Name":"https://schema.org/termCode-output",
     "Domain Bucket":"< 1K"
   },
   {
     "Class":"Predicate",
-    "Name":"http:\/\/schema.org\/termDuration",
+    "Name":"https://schema.org/termDuration",
     "Domain Bucket":"< 1K"
   },
   {
     "Class":"Predicate",
-    "Name":"http:\/\/schema.org\/termDuration-input",
+    "Name":"https://schema.org/termDuration-input",
     "Domain Bucket":"< 1K"
   },
   {
     "Class":"Predicate",
-    "Name":"http:\/\/schema.org\/termDuration-output",
+    "Name":"https://schema.org/termDuration-output",
     "Domain Bucket":"< 1K"
   },
   {
     "Class":"Predicate",
-    "Name":"http:\/\/schema.org\/termsOfService",
+    "Name":"https://schema.org/termsOfService",
     "Domain Bucket":"10K - 100K"
   },
   {
     "Class":"Predicate",
-    "Name":"http:\/\/schema.org\/termsOfService-input",
+    "Name":"https://schema.org/termsOfService-input",
     "Domain Bucket":"< 1K"
   },
   {
     "Class":"Predicate",
-    "Name":"http:\/\/schema.org\/termsOfService-output",
+    "Name":"https://schema.org/termsOfService-output",
     "Domain Bucket":"< 1K"
   },
   {
     "Class":"Predicate",
-    "Name":"http:\/\/schema.org\/termsPerYear",
+    "Name":"https://schema.org/termsPerYear",
     "Domain Bucket":"< 1K"
   },
   {
     "Class":"Predicate",
-    "Name":"http:\/\/schema.org\/termsPerYear-input",
+    "Name":"https://schema.org/termsPerYear-input",
     "Domain Bucket":"< 1K"
   },
   {
     "Class":"Predicate",
-    "Name":"http:\/\/schema.org\/termsPerYear-output",
+    "Name":"https://schema.org/termsPerYear-output",
     "Domain Bucket":"< 1K"
   },
   {
     "Class":"Predicate",
-    "Name":"http:\/\/schema.org\/text",
+    "Name":"https://schema.org/text",
     "Domain Bucket":"1M - 10M"
   },
   {
     "Class":"Predicate",
-    "Name":"http:\/\/schema.org\/text-input",
+    "Name":"https://schema.org/text-input",
     "Domain Bucket":"< 1K"
   },
   {
     "Class":"Predicate",
-    "Name":"http:\/\/schema.org\/text-output",
+    "Name":"https://schema.org/text-output",
     "Domain Bucket":"< 1K"
   },
   {
     "Class":"Predicate",
-    "Name":"http:\/\/schema.org\/textValue",
+    "Name":"https://schema.org/textValue",
     "Domain Bucket":"< 1K"
   },
   {
     "Class":"Predicate",
-    "Name":"http:\/\/schema.org\/textValue-input",
+    "Name":"https://schema.org/textValue-input",
     "Domain Bucket":"< 1K"
   },
   {
     "Class":"Predicate",
-    "Name":"http:\/\/schema.org\/textValue-output",
+    "Name":"https://schema.org/textValue-output",
     "Domain Bucket":"< 1K"
   },
   {
     "Class":"Predicate",
-    "Name":"http:\/\/schema.org\/thumbnail",
+    "Name":"https://schema.org/thumbnail",
     "Domain Bucket":"100K - 1M"
   },
   {
     "Class":"Predicate",
-    "Name":"http:\/\/schema.org\/thumbnail-input",
+    "Name":"https://schema.org/thumbnail-input",
     "Domain Bucket":"< 1K"
   },
   {
     "Class":"Predicate",
-    "Name":"http:\/\/schema.org\/thumbnail-output",
+    "Name":"https://schema.org/thumbnail-output",
     "Domain Bucket":"< 1K"
   },
   {
     "Class":"Predicate",
-    "Name":"http:\/\/schema.org\/thumbnailUrl",
+    "Name":"https://schema.org/thumbnailUrl",
     "Domain Bucket":"10M+"
   },
   {
     "Class":"Predicate",
-    "Name":"http:\/\/schema.org\/thumbnailUrl-input",
+    "Name":"https://schema.org/thumbnailUrl-input",
     "Domain Bucket":"< 1K"
   },
   {
     "Class":"Predicate",
-    "Name":"http:\/\/schema.org\/thumbnailUrl-output",
+    "Name":"https://schema.org/thumbnailUrl-output",
     "Domain Bucket":"< 1K"
   },
   {
     "Class":"Predicate",
-    "Name":"http:\/\/schema.org\/tickerSymbol",
+    "Name":"https://schema.org/tickerSymbol",
     "Domain Bucket":"1K - 10K"
   },
   {
     "Class":"Predicate",
-    "Name":"http:\/\/schema.org\/tickerSymbol-input",
+    "Name":"https://schema.org/tickerSymbol-input",
     "Domain Bucket":"< 1K"
   },
   {
     "Class":"Predicate",
-    "Name":"http:\/\/schema.org\/tickerSymbol-output",
+    "Name":"https://schema.org/tickerSymbol-output",
     "Domain Bucket":"< 1K"
   },
   {
     "Class":"Predicate",
-    "Name":"http:\/\/schema.org\/ticketNumber",
+    "Name":"https://schema.org/ticketNumber",
     "Domain Bucket":"< 1K"
   },
   {
     "Class":"Predicate",
-    "Name":"http:\/\/schema.org\/ticketNumber-input",
+    "Name":"https://schema.org/ticketNumber-input",
     "Domain Bucket":"< 1K"
   },
   {
     "Class":"Predicate",
-    "Name":"http:\/\/schema.org\/ticketNumber-output",
+    "Name":"https://schema.org/ticketNumber-output",
     "Domain Bucket":"< 1K"
   },
   {
     "Class":"Predicate",
-    "Name":"http:\/\/schema.org\/ticketToken",
+    "Name":"https://schema.org/ticketToken",
     "Domain Bucket":"< 1K"
   },
   {
     "Class":"Predicate",
-    "Name":"http:\/\/schema.org\/ticketToken-input",
+    "Name":"https://schema.org/ticketToken-input",
     "Domain Bucket":"< 1K"
   },
   {
     "Class":"Predicate",
-    "Name":"http:\/\/schema.org\/ticketToken-output",
+    "Name":"https://schema.org/ticketToken-output",
     "Domain Bucket":"< 1K"
   },
   {
     "Class":"Predicate",
-    "Name":"http:\/\/schema.org\/ticketedSeat",
+    "Name":"https://schema.org/ticketedSeat",
     "Domain Bucket":"< 1K"
   },
   {
     "Class":"Predicate",
-    "Name":"http:\/\/schema.org\/ticketedSeat-input",
+    "Name":"https://schema.org/ticketedSeat-input",
     "Domain Bucket":"< 1K"
   },
   {
     "Class":"Predicate",
-    "Name":"http:\/\/schema.org\/ticketedSeat-output",
+    "Name":"https://schema.org/ticketedSeat-output",
     "Domain Bucket":"< 1K"
   },
   {
     "Class":"Predicate",
-    "Name":"http:\/\/schema.org\/timeOfDay",
+    "Name":"https://schema.org/timeOfDay",
     "Domain Bucket":"< 1K"
   },
   {
     "Class":"Predicate",
-    "Name":"http:\/\/schema.org\/timeOfDay-input",
+    "Name":"https://schema.org/timeOfDay-input",
     "Domain Bucket":"< 1K"
   },
   {
     "Class":"Predicate",
-    "Name":"http:\/\/schema.org\/timeOfDay-output",
+    "Name":"https://schema.org/timeOfDay-output",
     "Domain Bucket":"< 1K"
   },
   {
     "Class":"Predicate",
-    "Name":"http:\/\/schema.org\/timeRequired",
+    "Name":"https://schema.org/timeRequired",
     "Domain Bucket":"100K - 1M"
   },
   {
     "Class":"Predicate",
-    "Name":"http:\/\/schema.org\/timeRequired-input",
+    "Name":"https://schema.org/timeRequired-input",
     "Domain Bucket":"< 1K"
   },
   {
     "Class":"Predicate",
-    "Name":"http:\/\/schema.org\/timeRequired-output",
+    "Name":"https://schema.org/timeRequired-output",
     "Domain Bucket":"< 1K"
   },
   {
     "Class":"Predicate",
-    "Name":"http:\/\/schema.org\/timeToComplete",
+    "Name":"https://schema.org/timeToComplete",
     "Domain Bucket":"1K - 10K"
   },
   {
     "Class":"Predicate",
-    "Name":"http:\/\/schema.org\/timeToComplete-input",
+    "Name":"https://schema.org/timeToComplete-input",
     "Domain Bucket":"< 1K"
   },
   {
     "Class":"Predicate",
-    "Name":"http:\/\/schema.org\/timeToComplete-output",
+    "Name":"https://schema.org/timeToComplete-output",
     "Domain Bucket":"< 1K"
   },
   {
     "Class":"Predicate",
-    "Name":"http:\/\/schema.org\/timestamp",
+    "Name":"https://schema.org/timestamp",
     "Domain Bucket":"1K - 10K"
   },
   {
     "Class":"Predicate",
-    "Name":"http:\/\/schema.org\/timestamp-input",
+    "Name":"https://schema.org/timestamp-input",
     "Domain Bucket":"< 1K"
   },
   {
     "Class":"Predicate",
-    "Name":"http:\/\/schema.org\/timestamp-output",
+    "Name":"https://schema.org/timestamp-output",
     "Domain Bucket":"< 1K"
   },
   {
     "Class":"Predicate",
-    "Name":"http:\/\/schema.org\/tissueSample",
+    "Name":"https://schema.org/tissueSample",
     "Domain Bucket":"< 1K"
   },
   {
     "Class":"Predicate",
-    "Name":"http:\/\/schema.org\/tissueSample-input",
+    "Name":"https://schema.org/tissueSample-input",
     "Domain Bucket":"< 1K"
   },
   {
     "Class":"Predicate",
-    "Name":"http:\/\/schema.org\/tissueSample-output",
+    "Name":"https://schema.org/tissueSample-output",
     "Domain Bucket":"< 1K"
   },
   {
     "Class":"Predicate",
-    "Name":"http:\/\/schema.org\/title",
+    "Name":"https://schema.org/title",
     "Domain Bucket":"100K - 1M"
   },
   {
     "Class":"Predicate",
-    "Name":"http:\/\/schema.org\/title-input",
+    "Name":"https://schema.org/title-input",
     "Domain Bucket":"< 1K"
   },
   {
     "Class":"Predicate",
-    "Name":"http:\/\/schema.org\/title-output",
+    "Name":"https://schema.org/title-output",
     "Domain Bucket":"< 1K"
   },
   {
     "Class":"Predicate",
-    "Name":"http:\/\/schema.org\/titleEIDR",
+    "Name":"https://schema.org/titleEIDR",
     "Domain Bucket":"< 1K"
   },
   {
     "Class":"Predicate",
-    "Name":"http:\/\/schema.org\/titleEIDR-input",
+    "Name":"https://schema.org/titleEIDR-input",
     "Domain Bucket":"< 1K"
   },
   {
     "Class":"Predicate",
-    "Name":"http:\/\/schema.org\/titleEIDR-output",
+    "Name":"https://schema.org/titleEIDR-output",
     "Domain Bucket":"< 1K"
   },
   {
     "Class":"Predicate",
-    "Name":"http:\/\/schema.org\/toLocation",
+    "Name":"https://schema.org/toLocation",
     "Domain Bucket":"1K - 10K"
   },
   {
     "Class":"Predicate",
-    "Name":"http:\/\/schema.org\/toLocation-input",
+    "Name":"https://schema.org/toLocation-input",
     "Domain Bucket":"< 1K"
   },
   {
     "Class":"Predicate",
-    "Name":"http:\/\/schema.org\/toLocation-output",
+    "Name":"https://schema.org/toLocation-output",
     "Domain Bucket":"< 1K"
   },
   {
     "Class":"Predicate",
-    "Name":"http:\/\/schema.org\/toRecipient",
+    "Name":"https://schema.org/toRecipient",
     "Domain Bucket":"< 1K"
   },
   {
     "Class":"Predicate",
-    "Name":"http:\/\/schema.org\/toRecipient-input",
+    "Name":"https://schema.org/toRecipient-input",
     "Domain Bucket":"< 1K"
   },
   {
     "Class":"Predicate",
-    "Name":"http:\/\/schema.org\/toRecipient-output",
+    "Name":"https://schema.org/toRecipient-output",
     "Domain Bucket":"< 1K"
   },
   {
     "Class":"Predicate",
-    "Name":"http:\/\/schema.org\/tocContinuation",
+    "Name":"https://schema.org/tocContinuation",
     "Domain Bucket":"< 1K"
   },
   {
     "Class":"Predicate",
-    "Name":"http:\/\/schema.org\/tocContinuation-input",
+    "Name":"https://schema.org/tocContinuation-input",
     "Domain Bucket":"< 1K"
   },
   {
     "Class":"Predicate",
-    "Name":"http:\/\/schema.org\/tocContinuation-output",
+    "Name":"https://schema.org/tocContinuation-output",
     "Domain Bucket":"< 1K"
   },
   {
     "Class":"Predicate",
-    "Name":"http:\/\/schema.org\/tocEntry",
+    "Name":"https://schema.org/tocEntry",
     "Domain Bucket":"< 1K"
   },
   {
     "Class":"Predicate",
-    "Name":"http:\/\/schema.org\/tocEntry-input",
+    "Name":"https://schema.org/tocEntry-input",
     "Domain Bucket":"< 1K"
   },
   {
     "Class":"Predicate",
-    "Name":"http:\/\/schema.org\/tocEntry-output",
+    "Name":"https://schema.org/tocEntry-output",
     "Domain Bucket":"< 1K"
   },
   {
     "Class":"Predicate",
-    "Name":"http:\/\/schema.org\/tongueWeight",
+    "Name":"https://schema.org/tongueWeight",
     "Domain Bucket":"< 1K"
   },
   {
     "Class":"Predicate",
-    "Name":"http:\/\/schema.org\/tongueWeight-input",
+    "Name":"https://schema.org/tongueWeight-input",
     "Domain Bucket":"< 1K"
   },
   {
     "Class":"Predicate",
-    "Name":"http:\/\/schema.org\/tongueWeight-output",
+    "Name":"https://schema.org/tongueWeight-output",
     "Domain Bucket":"< 1K"
   },
   {
     "Class":"Predicate",
-    "Name":"http:\/\/schema.org\/tool",
+    "Name":"https://schema.org/tool",
     "Domain Bucket":"10K - 100K"
   },
   {
     "Class":"Predicate",
-    "Name":"http:\/\/schema.org\/tool-input",
+    "Name":"https://schema.org/tool-input",
     "Domain Bucket":"< 1K"
   },
   {
     "Class":"Predicate",
-    "Name":"http:\/\/schema.org\/tool-output",
+    "Name":"https://schema.org/tool-output",
     "Domain Bucket":"< 1K"
   },
   {
     "Class":"Predicate",
-    "Name":"http:\/\/schema.org\/torque",
+    "Name":"https://schema.org/torque",
     "Domain Bucket":"1K - 10K"
   },
   {
     "Class":"Predicate",
-    "Name":"http:\/\/schema.org\/torque-input",
+    "Name":"https://schema.org/torque-input",
     "Domain Bucket":"< 1K"
   },
   {
     "Class":"Predicate",
-    "Name":"http:\/\/schema.org\/torque-output",
+    "Name":"https://schema.org/torque-output",
     "Domain Bucket":"< 1K"
   },
   {
     "Class":"Predicate",
-    "Name":"http:\/\/schema.org\/totalHistoricalEnrollment",
+    "Name":"https://schema.org/totalHistoricalEnrollment",
     "Domain Bucket":"< 1K"
   },
   {
     "Class":"Predicate",
-    "Name":"http:\/\/schema.org\/totalHistoricalEnrollment-input",
+    "Name":"https://schema.org/totalHistoricalEnrollment-input",
     "Domain Bucket":"< 1K"
   },
   {
     "Class":"Predicate",
-    "Name":"http:\/\/schema.org\/totalHistoricalEnrollment-output",
+    "Name":"https://schema.org/totalHistoricalEnrollment-output",
     "Domain Bucket":"< 1K"
   },
   {
     "Class":"Predicate",
-    "Name":"http:\/\/schema.org\/totalJobOpenings",
+    "Name":"https://schema.org/totalJobOpenings",
     "Domain Bucket":"1K - 10K"
   },
   {
     "Class":"Predicate",
-    "Name":"http:\/\/schema.org\/totalJobOpenings-input",
+    "Name":"https://schema.org/totalJobOpenings-input",
     "Domain Bucket":"< 1K"
   },
   {
     "Class":"Predicate",
-    "Name":"http:\/\/schema.org\/totalJobOpenings-output",
+    "Name":"https://schema.org/totalJobOpenings-output",
     "Domain Bucket":"< 1K"
   },
   {
     "Class":"Predicate",
-    "Name":"http:\/\/schema.org\/totalPaymentDue",
+    "Name":"https://schema.org/totalPaymentDue",
     "Domain Bucket":"< 1K"
   },
   {
     "Class":"Predicate",
-    "Name":"http:\/\/schema.org\/totalPaymentDue-input",
+    "Name":"https://schema.org/totalPaymentDue-input",
     "Domain Bucket":"< 1K"
   },
   {
     "Class":"Predicate",
-    "Name":"http:\/\/schema.org\/totalPaymentDue-output",
+    "Name":"https://schema.org/totalPaymentDue-output",
     "Domain Bucket":"< 1K"
   },
   {
     "Class":"Predicate",
-    "Name":"http:\/\/schema.org\/totalPrice",
+    "Name":"https://schema.org/totalPrice",
     "Domain Bucket":"< 1K"
   },
   {
     "Class":"Predicate",
-    "Name":"http:\/\/schema.org\/totalPrice-input",
+    "Name":"https://schema.org/totalPrice-input",
     "Domain Bucket":"< 1K"
   },
   {
     "Class":"Predicate",
-    "Name":"http:\/\/schema.org\/totalPrice-output",
+    "Name":"https://schema.org/totalPrice-output",
     "Domain Bucket":"< 1K"
   },
   {
     "Class":"Predicate",
-    "Name":"http:\/\/schema.org\/totalTime",
+    "Name":"https://schema.org/totalTime",
     "Domain Bucket":"100K - 1M"
   },
   {
     "Class":"Predicate",
-    "Name":"http:\/\/schema.org\/totalTime-input",
+    "Name":"https://schema.org/totalTime-input",
     "Domain Bucket":"< 1K"
   },
   {
     "Class":"Predicate",
-    "Name":"http:\/\/schema.org\/totalTime-output",
+    "Name":"https://schema.org/totalTime-output",
     "Domain Bucket":"< 1K"
   },
   {
     "Class":"Predicate",
-    "Name":"http:\/\/schema.org\/tourBookingPage",
+    "Name":"https://schema.org/tourBookingPage",
     "Domain Bucket":"10K - 100K"
   },
   {
     "Class":"Predicate",
-    "Name":"http:\/\/schema.org\/tourBookingPage-input",
+    "Name":"https://schema.org/tourBookingPage-input",
     "Domain Bucket":"< 1K"
   },
   {
     "Class":"Predicate",
-    "Name":"http:\/\/schema.org\/tourBookingPage-output",
+    "Name":"https://schema.org/tourBookingPage-output",
     "Domain Bucket":"< 1K"
   },
   {
     "Class":"Predicate",
-    "Name":"http:\/\/schema.org\/touristType",
+    "Name":"https://schema.org/touristType",
     "Domain Bucket":"10K - 100K"
   },
   {
     "Class":"Predicate",
-    "Name":"http:\/\/schema.org\/touristType-input",
+    "Name":"https://schema.org/touristType-input",
     "Domain Bucket":"< 1K"
   },
   {
     "Class":"Predicate",
-    "Name":"http:\/\/schema.org\/touristType-output",
+    "Name":"https://schema.org/touristType-output",
     "Domain Bucket":"< 1K"
   },
   {
     "Class":"Predicate",
-    "Name":"http:\/\/schema.org\/track",
+    "Name":"https://schema.org/track",
     "Domain Bucket":"10K - 100K"
   },
   {
     "Class":"Predicate",
-    "Name":"http:\/\/schema.org\/track-input",
+    "Name":"https://schema.org/track-input",
     "Domain Bucket":"< 1K"
   },
   {
     "Class":"Predicate",
-    "Name":"http:\/\/schema.org\/track-output",
+    "Name":"https://schema.org/track-output",
     "Domain Bucket":"< 1K"
   },
   {
     "Class":"Predicate",
-    "Name":"http:\/\/schema.org\/trackingNumber",
+    "Name":"https://schema.org/trackingNumber",
     "Domain Bucket":"< 1K"
   },
   {
     "Class":"Predicate",
-    "Name":"http:\/\/schema.org\/trackingNumber-input",
+    "Name":"https://schema.org/trackingNumber-input",
     "Domain Bucket":"< 1K"
   },
   {
     "Class":"Predicate",
-    "Name":"http:\/\/schema.org\/trackingNumber-output",
+    "Name":"https://schema.org/trackingNumber-output",
     "Domain Bucket":"< 1K"
   },
   {
     "Class":"Predicate",
-    "Name":"http:\/\/schema.org\/trackingUrl",
+    "Name":"https://schema.org/trackingUrl",
     "Domain Bucket":"< 1K"
   },
   {
     "Class":"Predicate",
-    "Name":"http:\/\/schema.org\/trackingUrl-input",
+    "Name":"https://schema.org/trackingUrl-input",
     "Domain Bucket":"< 1K"
   },
   {
     "Class":"Predicate",
-    "Name":"http:\/\/schema.org\/trackingUrl-output",
+    "Name":"https://schema.org/trackingUrl-output",
     "Domain Bucket":"< 1K"
   },
   {
     "Class":"Predicate",
-    "Name":"http:\/\/schema.org\/tracks",
+    "Name":"https://schema.org/tracks",
     "Domain Bucket":"< 1K"
   },
   {
     "Class":"Predicate",
-    "Name":"http:\/\/schema.org\/tracks-input",
+    "Name":"https://schema.org/tracks-input",
     "Domain Bucket":"< 1K"
   },
   {
     "Class":"Predicate",
-    "Name":"http:\/\/schema.org\/tracks-output",
+    "Name":"https://schema.org/tracks-output",
     "Domain Bucket":"< 1K"
   },
   {
     "Class":"Predicate",
-    "Name":"http:\/\/schema.org\/trailer",
+    "Name":"https://schema.org/trailer",
     "Domain Bucket":"1K - 10K"
   },
   {
     "Class":"Predicate",
-    "Name":"http:\/\/schema.org\/trailer-input",
+    "Name":"https://schema.org/trailer-input",
     "Domain Bucket":"< 1K"
   },
   {
     "Class":"Predicate",
-    "Name":"http:\/\/schema.org\/trailer-output",
+    "Name":"https://schema.org/trailer-output",
     "Domain Bucket":"< 1K"
   },
   {
     "Class":"Predicate",
-    "Name":"http:\/\/schema.org\/trailerWeight",
+    "Name":"https://schema.org/trailerWeight",
     "Domain Bucket":"< 1K"
   },
   {
     "Class":"Predicate",
-    "Name":"http:\/\/schema.org\/trailerWeight-input",
+    "Name":"https://schema.org/trailerWeight-input",
     "Domain Bucket":"< 1K"
   },
   {
     "Class":"Predicate",
-    "Name":"http:\/\/schema.org\/trailerWeight-output",
+    "Name":"https://schema.org/trailerWeight-output",
     "Domain Bucket":"< 1K"
   },
   {
     "Class":"Predicate",
-    "Name":"http:\/\/schema.org\/trainName",
+    "Name":"https://schema.org/trainName",
     "Domain Bucket":"< 1K"
   },
   {
     "Class":"Predicate",
-    "Name":"http:\/\/schema.org\/trainName-input",
+    "Name":"https://schema.org/trainName-input",
     "Domain Bucket":"< 1K"
   },
   {
     "Class":"Predicate",
-    "Name":"http:\/\/schema.org\/trainName-output",
+    "Name":"https://schema.org/trainName-output",
     "Domain Bucket":"< 1K"
   },
   {
     "Class":"Predicate",
-    "Name":"http:\/\/schema.org\/trainNumber",
+    "Name":"https://schema.org/trainNumber",
     "Domain Bucket":"< 1K"
   },
   {
     "Class":"Predicate",
-    "Name":"http:\/\/schema.org\/trainNumber-input",
+    "Name":"https://schema.org/trainNumber-input",
     "Domain Bucket":"< 1K"
   },
   {
     "Class":"Predicate",
-    "Name":"http:\/\/schema.org\/trainNumber-output",
+    "Name":"https://schema.org/trainNumber-output",
     "Domain Bucket":"< 1K"
   },
   {
     "Class":"Predicate",
-    "Name":"http:\/\/schema.org\/trainingSalary",
+    "Name":"https://schema.org/trainingSalary",
     "Domain Bucket":"< 1K"
   },
   {
     "Class":"Predicate",
-    "Name":"http:\/\/schema.org\/trainingSalary-input",
+    "Name":"https://schema.org/trainingSalary-input",
     "Domain Bucket":"< 1K"
   },
   {
     "Class":"Predicate",
-    "Name":"http:\/\/schema.org\/trainingSalary-output",
+    "Name":"https://schema.org/trainingSalary-output",
     "Domain Bucket":"< 1K"
   },
   {
     "Class":"Predicate",
-    "Name":"http:\/\/schema.org\/transFatContent",
+    "Name":"https://schema.org/transFatContent",
     "Domain Bucket":"10K - 100K"
   },
   {
     "Class":"Predicate",
-    "Name":"http:\/\/schema.org\/transFatContent-input",
+    "Name":"https://schema.org/transFatContent-input",
     "Domain Bucket":"< 1K"
   },
   {
     "Class":"Predicate",
-    "Name":"http:\/\/schema.org\/transFatContent-output",
+    "Name":"https://schema.org/transFatContent-output",
     "Domain Bucket":"< 1K"
   },
   {
     "Class":"Predicate",
-    "Name":"http:\/\/schema.org\/transcript",
+    "Name":"https://schema.org/transcript",
     "Domain Bucket":"100K - 1M"
   },
   {
     "Class":"Predicate",
-    "Name":"http:\/\/schema.org\/transcript-input",
+    "Name":"https://schema.org/transcript-input",
     "Domain Bucket":"< 1K"
   },
   {
     "Class":"Predicate",
-    "Name":"http:\/\/schema.org\/transcript-output",
+    "Name":"https://schema.org/transcript-output",
     "Domain Bucket":"< 1K"
   },
   {
     "Class":"Predicate",
-    "Name":"http:\/\/schema.org\/transitTime",
+    "Name":"https://schema.org/transitTime",
     "Domain Bucket":"100K - 1M"
   },
   {
     "Class":"Predicate",
-    "Name":"http:\/\/schema.org\/transitTime-input",
+    "Name":"https://schema.org/transitTime-input",
     "Domain Bucket":"< 1K"
   },
   {
     "Class":"Predicate",
-    "Name":"http:\/\/schema.org\/transitTime-output",
+    "Name":"https://schema.org/transitTime-output",
     "Domain Bucket":"< 1K"
   },
   {
     "Class":"Predicate",
-    "Name":"http:\/\/schema.org\/transitTimeLabel",
+    "Name":"https://schema.org/transitTimeLabel",
     "Domain Bucket":"< 1K"
   },
   {
     "Class":"Predicate",
-    "Name":"http:\/\/schema.org\/transitTimeLabel-input",
+    "Name":"https://schema.org/transitTimeLabel-input",
     "Domain Bucket":"< 1K"
   },
   {
     "Class":"Predicate",
-    "Name":"http:\/\/schema.org\/transitTimeLabel-output",
+    "Name":"https://schema.org/transitTimeLabel-output",
     "Domain Bucket":"< 1K"
   },
   {
     "Class":"Predicate",
-    "Name":"http:\/\/schema.org\/translationOfWork",
+    "Name":"https://schema.org/translationOfWork",
     "Domain Bucket":"1K - 10K"
   },
   {
     "Class":"Predicate",
-    "Name":"http:\/\/schema.org\/translationOfWork-input",
+    "Name":"https://schema.org/translationOfWork-input",
     "Domain Bucket":"< 1K"
   },
   {
     "Class":"Predicate",
-    "Name":"http:\/\/schema.org\/translationOfWork-output",
+    "Name":"https://schema.org/translationOfWork-output",
     "Domain Bucket":"< 1K"
   },
   {
     "Class":"Predicate",
-    "Name":"http:\/\/schema.org\/translator",
+    "Name":"https://schema.org/translator",
     "Domain Bucket":"1K - 10K"
   },
   {
     "Class":"Predicate",
-    "Name":"http:\/\/schema.org\/translator-input",
+    "Name":"https://schema.org/translator-input",
     "Domain Bucket":"< 1K"
   },
   {
     "Class":"Predicate",
-    "Name":"http:\/\/schema.org\/translator-output",
+    "Name":"https://schema.org/translator-output",
     "Domain Bucket":"< 1K"
   },
   {
     "Class":"Predicate",
-    "Name":"http:\/\/schema.org\/transmissionMethod",
+    "Name":"https://schema.org/transmissionMethod",
     "Domain Bucket":"< 1K"
   },
   {
     "Class":"Predicate",
-    "Name":"http:\/\/schema.org\/transmissionMethod-input",
+    "Name":"https://schema.org/transmissionMethod-input",
     "Domain Bucket":"< 1K"
   },
   {
     "Class":"Predicate",
-    "Name":"http:\/\/schema.org\/transmissionMethod-output",
+    "Name":"https://schema.org/transmissionMethod-output",
     "Domain Bucket":"< 1K"
   },
   {
     "Class":"Predicate",
-    "Name":"http:\/\/schema.org\/travelBans",
+    "Name":"https://schema.org/travelBans",
     "Domain Bucket":"< 1K"
   },
   {
     "Class":"Predicate",
-    "Name":"http:\/\/schema.org\/travelBans-input",
+    "Name":"https://schema.org/travelBans-input",
     "Domain Bucket":"< 1K"
   },
   {
     "Class":"Predicate",
-    "Name":"http:\/\/schema.org\/travelBans-output",
+    "Name":"https://schema.org/travelBans-output",
     "Domain Bucket":"< 1K"
   },
   {
     "Class":"Predicate",
-    "Name":"http:\/\/schema.org\/trialDesign",
+    "Name":"https://schema.org/trialDesign",
     "Domain Bucket":"< 1K"
   },
   {
     "Class":"Predicate",
-    "Name":"http:\/\/schema.org\/trialDesign-input",
+    "Name":"https://schema.org/trialDesign-input",
     "Domain Bucket":"< 1K"
   },
   {
     "Class":"Predicate",
-    "Name":"http:\/\/schema.org\/trialDesign-output",
+    "Name":"https://schema.org/trialDesign-output",
     "Domain Bucket":"< 1K"
   },
   {
     "Class":"Predicate",
-    "Name":"http:\/\/schema.org\/tributary",
+    "Name":"https://schema.org/tributary",
     "Domain Bucket":"< 1K"
   },
   {
     "Class":"Predicate",
-    "Name":"http:\/\/schema.org\/tributary-input",
+    "Name":"https://schema.org/tributary-input",
     "Domain Bucket":"< 1K"
   },
   {
     "Class":"Predicate",
-    "Name":"http:\/\/schema.org\/tributary-output",
+    "Name":"https://schema.org/tributary-output",
     "Domain Bucket":"< 1K"
   },
   {
     "Class":"Predicate",
-    "Name":"http:\/\/schema.org\/tripOrigin",
+    "Name":"https://schema.org/tripOrigin",
     "Domain Bucket":"< 1K"
   },
   {
     "Class":"Predicate",
-    "Name":"http:\/\/schema.org\/tripOrigin-input",
+    "Name":"https://schema.org/tripOrigin-input",
     "Domain Bucket":"< 1K"
   },
   {
     "Class":"Predicate",
-    "Name":"http:\/\/schema.org\/tripOrigin-output",
+    "Name":"https://schema.org/tripOrigin-output",
     "Domain Bucket":"< 1K"
   },
   {
     "Class":"Predicate",
-    "Name":"http:\/\/schema.org\/typeOfBed",
+    "Name":"https://schema.org/typeOfBed",
     "Domain Bucket":"10K - 100K"
   },
   {
     "Class":"Predicate",
-    "Name":"http:\/\/schema.org\/typeOfBed-input",
+    "Name":"https://schema.org/typeOfBed-input",
     "Domain Bucket":"< 1K"
   },
   {
     "Class":"Predicate",
-    "Name":"http:\/\/schema.org\/typeOfBed-output",
+    "Name":"https://schema.org/typeOfBed-output",
     "Domain Bucket":"< 1K"
   },
   {
     "Class":"Predicate",
-    "Name":"http:\/\/schema.org\/typeOfGood",
+    "Name":"https://schema.org/typeOfGood",
     "Domain Bucket":"< 1K"
   },
   {
     "Class":"Predicate",
-    "Name":"http:\/\/schema.org\/typeOfGood-input",
+    "Name":"https://schema.org/typeOfGood-input",
     "Domain Bucket":"< 1K"
   },
   {
     "Class":"Predicate",
-    "Name":"http:\/\/schema.org\/typeOfGood-output",
+    "Name":"https://schema.org/typeOfGood-output",
     "Domain Bucket":"< 1K"
   },
   {
     "Class":"Predicate",
-    "Name":"http:\/\/schema.org\/typicalAgeRange",
+    "Name":"https://schema.org/typicalAgeRange",
     "Domain Bucket":"10K - 100K"
   },
   {
     "Class":"Predicate",
-    "Name":"http:\/\/schema.org\/typicalAgeRange-input",
+    "Name":"https://schema.org/typicalAgeRange-input",
     "Domain Bucket":"< 1K"
   },
   {
     "Class":"Predicate",
-    "Name":"http:\/\/schema.org\/typicalAgeRange-output",
+    "Name":"https://schema.org/typicalAgeRange-output",
     "Domain Bucket":"< 1K"
   },
   {
     "Class":"Predicate",
-    "Name":"http:\/\/schema.org\/typicalCreditsPerTerm",
+    "Name":"https://schema.org/typicalCreditsPerTerm",
     "Domain Bucket":"< 1K"
   },
   {
     "Class":"Predicate",
-    "Name":"http:\/\/schema.org\/typicalCreditsPerTerm-input",
+    "Name":"https://schema.org/typicalCreditsPerTerm-input",
     "Domain Bucket":"< 1K"
   },
   {
     "Class":"Predicate",
-    "Name":"http:\/\/schema.org\/typicalCreditsPerTerm-output",
+    "Name":"https://schema.org/typicalCreditsPerTerm-output",
     "Domain Bucket":"< 1K"
   },
   {
     "Class":"Predicate",
-    "Name":"http:\/\/schema.org\/typicalTest",
+    "Name":"https://schema.org/typicalTest",
     "Domain Bucket":"1K - 10K"
   },
   {
     "Class":"Predicate",
-    "Name":"http:\/\/schema.org\/typicalTest-input",
+    "Name":"https://schema.org/typicalTest-input",
     "Domain Bucket":"< 1K"
   },
   {
     "Class":"Predicate",
-    "Name":"http:\/\/schema.org\/typicalTest-output",
+    "Name":"https://schema.org/typicalTest-output",
     "Domain Bucket":"< 1K"
   },
   {
     "Class":"Predicate",
-    "Name":"http:\/\/schema.org\/underName",
+    "Name":"https://schema.org/underName",
     "Domain Bucket":"< 1K"
   },
   {
     "Class":"Predicate",
-    "Name":"http:\/\/schema.org\/underName-input",
+    "Name":"https://schema.org/underName-input",
     "Domain Bucket":"< 1K"
   },
   {
     "Class":"Predicate",
-    "Name":"http:\/\/schema.org\/underName-output",
+    "Name":"https://schema.org/underName-output",
     "Domain Bucket":"< 1K"
   },
   {
     "Class":"Predicate",
-    "Name":"http:\/\/schema.org\/unitCode",
+    "Name":"https://schema.org/unitCode",
     "Domain Bucket":"1M - 10M"
   },
   {
     "Class":"Predicate",
-    "Name":"http:\/\/schema.org\/unitCode-input",
+    "Name":"https://schema.org/unitCode-input",
     "Domain Bucket":"< 1K"
   },
   {
     "Class":"Predicate",
-    "Name":"http:\/\/schema.org\/unitCode-output",
+    "Name":"https://schema.org/unitCode-output",
     "Domain Bucket":"< 1K"
   },
   {
     "Class":"Predicate",
-    "Name":"http:\/\/schema.org\/unitText",
+    "Name":"https://schema.org/unitText",
     "Domain Bucket":"100K - 1M"
   },
   {
     "Class":"Predicate",
-    "Name":"http:\/\/schema.org\/unitText-input",
+    "Name":"https://schema.org/unitText-input",
     "Domain Bucket":"< 1K"
   },
   {
     "Class":"Predicate",
-    "Name":"http:\/\/schema.org\/unitText-output",
+    "Name":"https://schema.org/unitText-output",
     "Domain Bucket":"< 1K"
   },
   {
     "Class":"Predicate",
-    "Name":"http:\/\/schema.org\/unnamedSourcesPolicy",
+    "Name":"https://schema.org/unnamedSourcesPolicy",
     "Domain Bucket":"1K - 10K"
   },
   {
     "Class":"Predicate",
-    "Name":"http:\/\/schema.org\/unnamedSourcesPolicy-input",
+    "Name":"https://schema.org/unnamedSourcesPolicy-input",
     "Domain Bucket":"< 1K"
   },
   {
     "Class":"Predicate",
-    "Name":"http:\/\/schema.org\/unnamedSourcesPolicy-output",
+    "Name":"https://schema.org/unnamedSourcesPolicy-output",
     "Domain Bucket":"< 1K"
   },
   {
     "Class":"Predicate",
-    "Name":"http:\/\/schema.org\/unsaturatedFatContent",
+    "Name":"https://schema.org/unsaturatedFatContent",
     "Domain Bucket":"10K - 100K"
   },
   {
     "Class":"Predicate",
-    "Name":"http:\/\/schema.org\/unsaturatedFatContent-input",
+    "Name":"https://schema.org/unsaturatedFatContent-input",
     "Domain Bucket":"< 1K"
   },
   {
     "Class":"Predicate",
-    "Name":"http:\/\/schema.org\/unsaturatedFatContent-output",
+    "Name":"https://schema.org/unsaturatedFatContent-output",
     "Domain Bucket":"< 1K"
   },
   {
     "Class":"Predicate",
-    "Name":"http:\/\/schema.org\/uploadDate",
+    "Name":"https://schema.org/uploadDate",
     "Domain Bucket":"1M - 10M"
   },
   {
     "Class":"Predicate",
-    "Name":"http:\/\/schema.org\/uploadDate-input",
+    "Name":"https://schema.org/uploadDate-input",
     "Domain Bucket":"< 1K"
   },
   {
     "Class":"Predicate",
-    "Name":"http:\/\/schema.org\/uploadDate-output",
+    "Name":"https://schema.org/uploadDate-output",
     "Domain Bucket":"< 1K"
   },
   {
     "Class":"Predicate",
-    "Name":"http:\/\/schema.org\/upvoteCount",
+    "Name":"https://schema.org/upvoteCount",
     "Domain Bucket":"10K - 100K"
   },
   {
     "Class":"Predicate",
-    "Name":"http:\/\/schema.org\/upvoteCount-input",
+    "Name":"https://schema.org/upvoteCount-input",
     "Domain Bucket":"< 1K"
   },
   {
     "Class":"Predicate",
-    "Name":"http:\/\/schema.org\/upvoteCount-output",
+    "Name":"https://schema.org/upvoteCount-output",
     "Domain Bucket":"< 1K"
   },
   {
     "Class":"Predicate",
-    "Name":"http:\/\/schema.org\/url",
+    "Name":"https://schema.org/url",
     "Domain Bucket":"10M+"
   },
   {
     "Class":"Predicate",
-    "Name":"http:\/\/schema.org\/url-input",
+    "Name":"https://schema.org/url-input",
     "Domain Bucket":"< 1K"
   },
   {
     "Class":"Predicate",
-    "Name":"http:\/\/schema.org\/url-output",
+    "Name":"https://schema.org/url-output",
     "Domain Bucket":"< 1K"
   },
   {
     "Class":"Predicate",
-    "Name":"http:\/\/schema.org\/urlTemplate",
+    "Name":"https://schema.org/urlTemplate",
     "Domain Bucket":"10M+"
   },
   {
     "Class":"Predicate",
-    "Name":"http:\/\/schema.org\/urlTemplate-input",
+    "Name":"https://schema.org/urlTemplate-input",
     "Domain Bucket":"< 1K"
   },
   {
     "Class":"Predicate",
-    "Name":"http:\/\/schema.org\/urlTemplate-output",
+    "Name":"https://schema.org/urlTemplate-output",
     "Domain Bucket":"< 1K"
   },
   {
     "Class":"Predicate",
-    "Name":"http:\/\/schema.org\/usNPI",
+    "Name":"https://schema.org/usNPI",
     "Domain Bucket":"< 1K"
   },
   {
     "Class":"Predicate",
-    "Name":"http:\/\/schema.org\/usNPI-input",
+    "Name":"https://schema.org/usNPI-input",
     "Domain Bucket":"< 1K"
   },
   {
     "Class":"Predicate",
-    "Name":"http:\/\/schema.org\/usNPI-output",
+    "Name":"https://schema.org/usNPI-output",
     "Domain Bucket":"< 1K"
   },
   {
     "Class":"Predicate",
-    "Name":"http:\/\/schema.org\/usageInfo",
+    "Name":"https://schema.org/usageInfo",
     "Domain Bucket":"1K - 10K"
   },
   {
     "Class":"Predicate",
-    "Name":"http:\/\/schema.org\/usageInfo-input",
+    "Name":"https://schema.org/usageInfo-input",
     "Domain Bucket":"< 1K"
   },
   {
     "Class":"Predicate",
-    "Name":"http:\/\/schema.org\/usageInfo-output",
+    "Name":"https://schema.org/usageInfo-output",
     "Domain Bucket":"< 1K"
   },
   {
     "Class":"Predicate",
-    "Name":"http:\/\/schema.org\/usedToDiagnose",
+    "Name":"https://schema.org/usedToDiagnose",
     "Domain Bucket":"1K - 10K"
   },
   {
     "Class":"Predicate",
-    "Name":"http:\/\/schema.org\/usedToDiagnose-input",
+    "Name":"https://schema.org/usedToDiagnose-input",
     "Domain Bucket":"< 1K"
   },
   {
     "Class":"Predicate",
-    "Name":"http:\/\/schema.org\/usedToDiagnose-output",
+    "Name":"https://schema.org/usedToDiagnose-output",
     "Domain Bucket":"< 1K"
   },
   {
     "Class":"Predicate",
-    "Name":"http:\/\/schema.org\/userInteractionCount",
+    "Name":"https://schema.org/userInteractionCount",
     "Domain Bucket":"100K - 1M"
   },
   {
     "Class":"Predicate",
-    "Name":"http:\/\/schema.org\/userInteractionCount-input",
+    "Name":"https://schema.org/userInteractionCount-input",
     "Domain Bucket":"< 1K"
   },
   {
     "Class":"Predicate",
-    "Name":"http:\/\/schema.org\/userInteractionCount-output",
+    "Name":"https://schema.org/userInteractionCount-output",
     "Domain Bucket":"< 1K"
   },
   {
     "Class":"Predicate",
-    "Name":"http:\/\/schema.org\/usesDevice",
+    "Name":"https://schema.org/usesDevice",
     "Domain Bucket":"< 1K"
   },
   {
     "Class":"Predicate",
-    "Name":"http:\/\/schema.org\/usesDevice-input",
+    "Name":"https://schema.org/usesDevice-input",
     "Domain Bucket":"< 1K"
   },
   {
     "Class":"Predicate",
-    "Name":"http:\/\/schema.org\/usesDevice-output",
+    "Name":"https://schema.org/usesDevice-output",
     "Domain Bucket":"< 1K"
   },
   {
     "Class":"Predicate",
-    "Name":"http:\/\/schema.org\/usesHealthPlanIdStandard",
+    "Name":"https://schema.org/usesHealthPlanIdStandard",
     "Domain Bucket":"< 1K"
   },
   {
     "Class":"Predicate",
-    "Name":"http:\/\/schema.org\/usesHealthPlanIdStandard-input",
+    "Name":"https://schema.org/usesHealthPlanIdStandard-input",
     "Domain Bucket":"< 1K"
   },
   {
     "Class":"Predicate",
-    "Name":"http:\/\/schema.org\/usesHealthPlanIdStandard-output",
+    "Name":"https://schema.org/usesHealthPlanIdStandard-output",
     "Domain Bucket":"< 1K"
   },
   {
     "Class":"Predicate",
-    "Name":"http:\/\/schema.org\/utterances",
+    "Name":"https://schema.org/utterances",
     "Domain Bucket":"< 1K"
   },
   {
     "Class":"Predicate",
-    "Name":"http:\/\/schema.org\/utterances-input",
+    "Name":"https://schema.org/utterances-input",
     "Domain Bucket":"< 1K"
   },
   {
     "Class":"Predicate",
-    "Name":"http:\/\/schema.org\/utterances-output",
+    "Name":"https://schema.org/utterances-output",
     "Domain Bucket":"< 1K"
   },
   {
     "Class":"Predicate",
-    "Name":"http:\/\/schema.org\/validFor",
+    "Name":"https://schema.org/validFor",
     "Domain Bucket":"< 1K"
   },
   {
     "Class":"Predicate",
-    "Name":"http:\/\/schema.org\/validFor-input",
+    "Name":"https://schema.org/validFor-input",
     "Domain Bucket":"< 1K"
   },
   {
     "Class":"Predicate",
-    "Name":"http:\/\/schema.org\/validFor-output",
+    "Name":"https://schema.org/validFor-output",
     "Domain Bucket":"< 1K"
   },
   {
     "Class":"Predicate",
-    "Name":"http:\/\/schema.org\/validForMemberTier",
+    "Name":"https://schema.org/validForMemberTier",
     "Domain Bucket":"< 1K"
   },
   {
     "Class":"Predicate",
-    "Name":"http:\/\/schema.org\/validForMemberTier-input",
+    "Name":"https://schema.org/validForMemberTier-input",
     "Domain Bucket":"< 1K"
   },
   {
     "Class":"Predicate",
-    "Name":"http:\/\/schema.org\/validForMemberTier-output",
+    "Name":"https://schema.org/validForMemberTier-output",
     "Domain Bucket":"< 1K"
   },
   {
     "Class":"Predicate",
-    "Name":"http:\/\/schema.org\/validFrom",
+    "Name":"https://schema.org/validFrom",
     "Domain Bucket":"100K - 1M"
   },
   {
     "Class":"Predicate",
-    "Name":"http:\/\/schema.org\/validFrom-input",
+    "Name":"https://schema.org/validFrom-input",
     "Domain Bucket":"< 1K"
   },
   {
     "Class":"Predicate",
-    "Name":"http:\/\/schema.org\/validFrom-output",
+    "Name":"https://schema.org/validFrom-output",
     "Domain Bucket":"< 1K"
   },
   {
     "Class":"Predicate",
-    "Name":"http:\/\/schema.org\/validIn",
+    "Name":"https://schema.org/validIn",
     "Domain Bucket":"1K - 10K"
   },
   {
     "Class":"Predicate",
-    "Name":"http:\/\/schema.org\/validIn-input",
+    "Name":"https://schema.org/validIn-input",
     "Domain Bucket":"< 1K"
   },
   {
     "Class":"Predicate",
-    "Name":"http:\/\/schema.org\/validIn-output",
+    "Name":"https://schema.org/validIn-output",
     "Domain Bucket":"< 1K"
   },
   {
     "Class":"Predicate",
-    "Name":"http:\/\/schema.org\/validThrough",
+    "Name":"https://schema.org/validThrough",
     "Domain Bucket":"1M - 10M"
   },
   {
     "Class":"Predicate",
-    "Name":"http:\/\/schema.org\/validThrough-input",
+    "Name":"https://schema.org/validThrough-input",
     "Domain Bucket":"< 1K"
   },
   {
     "Class":"Predicate",
-    "Name":"http:\/\/schema.org\/validThrough-output",
+    "Name":"https://schema.org/validThrough-output",
     "Domain Bucket":"< 1K"
   },
   {
     "Class":"Predicate",
-    "Name":"http:\/\/schema.org\/validUntil",
+    "Name":"https://schema.org/validUntil",
     "Domain Bucket":"1K - 10K"
   },
   {
     "Class":"Predicate",
-    "Name":"http:\/\/schema.org\/validUntil-input",
+    "Name":"https://schema.org/validUntil-input",
     "Domain Bucket":"< 1K"
   },
   {
     "Class":"Predicate",
-    "Name":"http:\/\/schema.org\/validUntil-output",
+    "Name":"https://schema.org/validUntil-output",
     "Domain Bucket":"< 1K"
   },
   {
     "Class":"Predicate",
-    "Name":"http:\/\/schema.org\/value",
+    "Name":"https://schema.org/value",
     "Domain Bucket":"1M - 10M"
   },
   {
     "Class":"Predicate",
-    "Name":"http:\/\/schema.org\/value-input",
+    "Name":"https://schema.org/value-input",
     "Domain Bucket":"< 1K"
   },
   {
     "Class":"Predicate",
-    "Name":"http:\/\/schema.org\/value-output",
+    "Name":"https://schema.org/value-output",
     "Domain Bucket":"< 1K"
   },
   {
     "Class":"Predicate",
-    "Name":"http:\/\/schema.org\/valueAddedTaxIncluded",
+    "Name":"https://schema.org/valueAddedTaxIncluded",
     "Domain Bucket":"1M - 10M"
   },
   {
     "Class":"Predicate",
-    "Name":"http:\/\/schema.org\/valueAddedTaxIncluded-input",
+    "Name":"https://schema.org/valueAddedTaxIncluded-input",
     "Domain Bucket":"< 1K"
   },
   {
     "Class":"Predicate",
-    "Name":"http:\/\/schema.org\/valueAddedTaxIncluded-output",
+    "Name":"https://schema.org/valueAddedTaxIncluded-output",
     "Domain Bucket":"< 1K"
   },
   {
     "Class":"Predicate",
-    "Name":"http:\/\/schema.org\/valueMaxLength",
+    "Name":"https://schema.org/valueMaxLength",
     "Domain Bucket":"1K - 10K"
   },
   {
     "Class":"Predicate",
-    "Name":"http:\/\/schema.org\/valueMaxLength-input",
+    "Name":"https://schema.org/valueMaxLength-input",
     "Domain Bucket":"< 1K"
   },
   {
     "Class":"Predicate",
-    "Name":"http:\/\/schema.org\/valueMaxLength-output",
+    "Name":"https://schema.org/valueMaxLength-output",
     "Domain Bucket":"< 1K"
   },
   {
     "Class":"Predicate",
-    "Name":"http:\/\/schema.org\/valueMinLength",
+    "Name":"https://schema.org/valueMinLength",
     "Domain Bucket":"< 1K"
   },
   {
     "Class":"Predicate",
-    "Name":"http:\/\/schema.org\/valueMinLength-input",
+    "Name":"https://schema.org/valueMinLength-input",
     "Domain Bucket":"< 1K"
   },
   {
     "Class":"Predicate",
-    "Name":"http:\/\/schema.org\/valueMinLength-output",
+    "Name":"https://schema.org/valueMinLength-output",
     "Domain Bucket":"< 1K"
   },
   {
     "Class":"Predicate",
-    "Name":"http:\/\/schema.org\/valueName",
+    "Name":"https://schema.org/valueName",
     "Domain Bucket":"10M+"
   },
   {
     "Class":"Predicate",
-    "Name":"http:\/\/schema.org\/valueName-input",
+    "Name":"https://schema.org/valueName-input",
     "Domain Bucket":"< 1K"
   },
   {
     "Class":"Predicate",
-    "Name":"http:\/\/schema.org\/valueName-output",
+    "Name":"https://schema.org/valueName-output",
     "Domain Bucket":"< 1K"
   },
   {
     "Class":"Predicate",
-    "Name":"http:\/\/schema.org\/valuePattern",
+    "Name":"https://schema.org/valuePattern",
     "Domain Bucket":"< 1K"
   },
   {
     "Class":"Predicate",
-    "Name":"http:\/\/schema.org\/valuePattern-input",
+    "Name":"https://schema.org/valuePattern-input",
     "Domain Bucket":"< 1K"
   },
   {
     "Class":"Predicate",
-    "Name":"http:\/\/schema.org\/valuePattern-output",
+    "Name":"https://schema.org/valuePattern-output",
     "Domain Bucket":"< 1K"
   },
   {
     "Class":"Predicate",
-    "Name":"http:\/\/schema.org\/valueReference",
+    "Name":"https://schema.org/valueReference",
     "Domain Bucket":"1K - 10K"
   },
   {
     "Class":"Predicate",
-    "Name":"http:\/\/schema.org\/valueReference-input",
+    "Name":"https://schema.org/valueReference-input",
     "Domain Bucket":"< 1K"
   },
   {
     "Class":"Predicate",
-    "Name":"http:\/\/schema.org\/valueReference-output",
+    "Name":"https://schema.org/valueReference-output",
     "Domain Bucket":"< 1K"
   },
   {
     "Class":"Predicate",
-    "Name":"http:\/\/schema.org\/valueRequired",
+    "Name":"https://schema.org/valueRequired",
     "Domain Bucket":"10M+"
   },
   {
     "Class":"Predicate",
-    "Name":"http:\/\/schema.org\/valueRequired-input",
+    "Name":"https://schema.org/valueRequired-input",
     "Domain Bucket":"< 1K"
   },
   {
     "Class":"Predicate",
-    "Name":"http:\/\/schema.org\/valueRequired-output",
+    "Name":"https://schema.org/valueRequired-output",
     "Domain Bucket":"< 1K"
   },
   {
     "Class":"Predicate",
-    "Name":"http:\/\/schema.org\/variableMeasured",
+    "Name":"https://schema.org/variableMeasured",
     "Domain Bucket":"10K - 100K"
   },
   {
     "Class":"Predicate",
-    "Name":"http:\/\/schema.org\/variableMeasured-input",
+    "Name":"https://schema.org/variableMeasured-input",
     "Domain Bucket":"< 1K"
   },
   {
     "Class":"Predicate",
-    "Name":"http:\/\/schema.org\/variableMeasured-output",
+    "Name":"https://schema.org/variableMeasured-output",
     "Domain Bucket":"< 1K"
   },
   {
     "Class":"Predicate",
-    "Name":"http:\/\/schema.org\/variablesMeasured",
+    "Name":"https://schema.org/variablesMeasured",
     "Domain Bucket":"< 1K"
   },
   {
     "Class":"Predicate",
-    "Name":"http:\/\/schema.org\/variablesMeasured-input",
+    "Name":"https://schema.org/variablesMeasured-input",
     "Domain Bucket":"< 1K"
   },
   {
     "Class":"Predicate",
-    "Name":"http:\/\/schema.org\/variablesMeasured-output",
+    "Name":"https://schema.org/variablesMeasured-output",
     "Domain Bucket":"< 1K"
   },
   {
     "Class":"Predicate",
-    "Name":"http:\/\/schema.org\/variantCover",
+    "Name":"https://schema.org/variantCover",
     "Domain Bucket":"< 1K"
   },
   {
     "Class":"Predicate",
-    "Name":"http:\/\/schema.org\/variantCover-input",
+    "Name":"https://schema.org/variantCover-input",
     "Domain Bucket":"< 1K"
   },
   {
     "Class":"Predicate",
-    "Name":"http:\/\/schema.org\/variantCover-output",
+    "Name":"https://schema.org/variantCover-output",
     "Domain Bucket":"< 1K"
   },
   {
     "Class":"Predicate",
-    "Name":"http:\/\/schema.org\/variesBy",
+    "Name":"https://schema.org/variesBy",
     "Domain Bucket":"100K - 1M"
   },
   {
     "Class":"Predicate",
-    "Name":"http:\/\/schema.org\/variesBy-input",
+    "Name":"https://schema.org/variesBy-input",
     "Domain Bucket":"< 1K"
   },
   {
     "Class":"Predicate",
-    "Name":"http:\/\/schema.org\/variesBy-output",
+    "Name":"https://schema.org/variesBy-output",
     "Domain Bucket":"< 1K"
   },
   {
     "Class":"Predicate",
-    "Name":"http:\/\/schema.org\/vatID",
+    "Name":"https://schema.org/vatID",
     "Domain Bucket":"100K - 1M"
   },
   {
     "Class":"Predicate",
-    "Name":"http:\/\/schema.org\/vatID-input",
+    "Name":"https://schema.org/vatID-input",
     "Domain Bucket":"< 1K"
   },
   {
     "Class":"Predicate",
-    "Name":"http:\/\/schema.org\/vatID-output",
+    "Name":"https://schema.org/vatID-output",
     "Domain Bucket":"< 1K"
   },
   {
     "Class":"Predicate",
-    "Name":"http:\/\/schema.org\/vehicleConfiguration",
+    "Name":"https://schema.org/vehicleConfiguration",
     "Domain Bucket":"10K - 100K"
   },
   {
     "Class":"Predicate",
-    "Name":"http:\/\/schema.org\/vehicleConfiguration-input",
+    "Name":"https://schema.org/vehicleConfiguration-input",
     "Domain Bucket":"< 1K"
   },
   {
     "Class":"Predicate",
-    "Name":"http:\/\/schema.org\/vehicleConfiguration-output",
+    "Name":"https://schema.org/vehicleConfiguration-output",
     "Domain Bucket":"< 1K"
   },
   {
     "Class":"Predicate",
-    "Name":"http:\/\/schema.org\/vehicleEngine",
+    "Name":"https://schema.org/vehicleEngine",
     "Domain Bucket":"10K - 100K"
   },
   {
     "Class":"Predicate",
-    "Name":"http:\/\/schema.org\/vehicleEngine-input",
+    "Name":"https://schema.org/vehicleEngine-input",
     "Domain Bucket":"< 1K"
   },
   {
     "Class":"Predicate",
-    "Name":"http:\/\/schema.org\/vehicleEngine-output",
+    "Name":"https://schema.org/vehicleEngine-output",
     "Domain Bucket":"< 1K"
   },
   {
     "Class":"Predicate",
-    "Name":"http:\/\/schema.org\/vehicleIdentificationNumber",
+    "Name":"https://schema.org/vehicleIdentificationNumber",
     "Domain Bucket":"10K - 100K"
   },
   {
     "Class":"Predicate",
-    "Name":"http:\/\/schema.org\/vehicleIdentificationNumber-input",
+    "Name":"https://schema.org/vehicleIdentificationNumber-input",
     "Domain Bucket":"< 1K"
   },
   {
     "Class":"Predicate",
-    "Name":"http:\/\/schema.org\/vehicleIdentificationNumber-output",
+    "Name":"https://schema.org/vehicleIdentificationNumber-output",
     "Domain Bucket":"< 1K"
   },
   {
     "Class":"Predicate",
-    "Name":"http:\/\/schema.org\/vehicleInteriorColor",
+    "Name":"https://schema.org/vehicleInteriorColor",
     "Domain Bucket":"10K - 100K"
   },
   {
     "Class":"Predicate",
-    "Name":"http:\/\/schema.org\/vehicleInteriorColor-input",
+    "Name":"https://schema.org/vehicleInteriorColor-input",
     "Domain Bucket":"< 1K"
   },
   {
     "Class":"Predicate",
-    "Name":"http:\/\/schema.org\/vehicleInteriorColor-output",
+    "Name":"https://schema.org/vehicleInteriorColor-output",
     "Domain Bucket":"< 1K"
   },
   {
     "Class":"Predicate",
-    "Name":"http:\/\/schema.org\/vehicleInteriorType",
+    "Name":"https://schema.org/vehicleInteriorType",
     "Domain Bucket":"10K - 100K"
   },
   {
     "Class":"Predicate",
-    "Name":"http:\/\/schema.org\/vehicleInteriorType-input",
+    "Name":"https://schema.org/vehicleInteriorType-input",
     "Domain Bucket":"< 1K"
   },
   {
     "Class":"Predicate",
-    "Name":"http:\/\/schema.org\/vehicleInteriorType-output",
+    "Name":"https://schema.org/vehicleInteriorType-output",
     "Domain Bucket":"< 1K"
   },
   {
     "Class":"Predicate",
-    "Name":"http:\/\/schema.org\/vehicleModelDate",
+    "Name":"https://schema.org/vehicleModelDate",
     "Domain Bucket":"10K - 100K"
   },
   {
     "Class":"Predicate",
-    "Name":"http:\/\/schema.org\/vehicleModelDate-input",
+    "Name":"https://schema.org/vehicleModelDate-input",
     "Domain Bucket":"< 1K"
   },
   {
     "Class":"Predicate",
-    "Name":"http:\/\/schema.org\/vehicleModelDate-output",
+    "Name":"https://schema.org/vehicleModelDate-output",
     "Domain Bucket":"< 1K"
   },
   {
     "Class":"Predicate",
-    "Name":"http:\/\/schema.org\/vehicleSeatingCapacity",
+    "Name":"https://schema.org/vehicleSeatingCapacity",
     "Domain Bucket":"10K - 100K"
   },
   {
     "Class":"Predicate",
-    "Name":"http:\/\/schema.org\/vehicleSeatingCapacity-input",
+    "Name":"https://schema.org/vehicleSeatingCapacity-input",
     "Domain Bucket":"< 1K"
   },
   {
     "Class":"Predicate",
-    "Name":"http:\/\/schema.org\/vehicleSeatingCapacity-output",
+    "Name":"https://schema.org/vehicleSeatingCapacity-output",
     "Domain Bucket":"< 1K"
   },
   {
     "Class":"Predicate",
-    "Name":"http:\/\/schema.org\/vehicleSpecialUsage",
+    "Name":"https://schema.org/vehicleSpecialUsage",
     "Domain Bucket":"< 1K"
   },
   {
     "Class":"Predicate",
-    "Name":"http:\/\/schema.org\/vehicleSpecialUsage-input",
+    "Name":"https://schema.org/vehicleSpecialUsage-input",
     "Domain Bucket":"< 1K"
   },
   {
     "Class":"Predicate",
-    "Name":"http:\/\/schema.org\/vehicleSpecialUsage-output",
+    "Name":"https://schema.org/vehicleSpecialUsage-output",
     "Domain Bucket":"< 1K"
   },
   {
     "Class":"Predicate",
-    "Name":"http:\/\/schema.org\/vehicleTransmission",
+    "Name":"https://schema.org/vehicleTransmission",
     "Domain Bucket":"10K - 100K"
   },
   {
     "Class":"Predicate",
-    "Name":"http:\/\/schema.org\/vehicleTransmission-input",
+    "Name":"https://schema.org/vehicleTransmission-input",
     "Domain Bucket":"< 1K"
   },
   {
     "Class":"Predicate",
-    "Name":"http:\/\/schema.org\/vehicleTransmission-output",
+    "Name":"https://schema.org/vehicleTransmission-output",
     "Domain Bucket":"< 1K"
   },
   {
     "Class":"Predicate",
-    "Name":"http:\/\/schema.org\/vendor",
+    "Name":"https://schema.org/vendor",
     "Domain Bucket":"< 1K"
   },
   {
     "Class":"Predicate",
-    "Name":"http:\/\/schema.org\/vendor-input",
+    "Name":"https://schema.org/vendor-input",
     "Domain Bucket":"< 1K"
   },
   {
     "Class":"Predicate",
-    "Name":"http:\/\/schema.org\/vendor-output",
+    "Name":"https://schema.org/vendor-output",
     "Domain Bucket":"< 1K"
   },
   {
     "Class":"Predicate",
-    "Name":"http:\/\/schema.org\/verificationFactCheckingPolicy",
+    "Name":"https://schema.org/verificationFactCheckingPolicy",
     "Domain Bucket":"1K - 10K"
   },
   {
     "Class":"Predicate",
-    "Name":"http:\/\/schema.org\/verificationFactCheckingPolicy-input",
+    "Name":"https://schema.org/verificationFactCheckingPolicy-input",
     "Domain Bucket":"< 1K"
   },
   {
     "Class":"Predicate",
-    "Name":"http:\/\/schema.org\/verificationFactCheckingPolicy-output",
+    "Name":"https://schema.org/verificationFactCheckingPolicy-output",
     "Domain Bucket":"< 1K"
   },
   {
     "Class":"Predicate",
-    "Name":"http:\/\/schema.org\/version",
+    "Name":"https://schema.org/version",
     "Domain Bucket":"10K - 100K"
   },
   {
     "Class":"Predicate",
-    "Name":"http:\/\/schema.org\/version-input",
+    "Name":"https://schema.org/version-input",
     "Domain Bucket":"< 1K"
   },
   {
     "Class":"Predicate",
-    "Name":"http:\/\/schema.org\/version-output",
+    "Name":"https://schema.org/version-output",
     "Domain Bucket":"< 1K"
   },
   {
     "Class":"Predicate",
-    "Name":"http:\/\/schema.org\/video",
+    "Name":"https://schema.org/video",
     "Domain Bucket":"100K - 1M"
   },
   {
     "Class":"Predicate",
-    "Name":"http:\/\/schema.org\/video-input",
+    "Name":"https://schema.org/video-input",
     "Domain Bucket":"< 1K"
   },
   {
     "Class":"Predicate",
-    "Name":"http:\/\/schema.org\/video-output",
+    "Name":"https://schema.org/video-output",
     "Domain Bucket":"< 1K"
   },
   {
     "Class":"Predicate",
-    "Name":"http:\/\/schema.org\/videoFormat",
+    "Name":"https://schema.org/videoFormat",
     "Domain Bucket":"1K - 10K"
   },
   {
     "Class":"Predicate",
-    "Name":"http:\/\/schema.org\/videoFormat-input",
+    "Name":"https://schema.org/videoFormat-input",
     "Domain Bucket":"< 1K"
   },
   {
     "Class":"Predicate",
-    "Name":"http:\/\/schema.org\/videoFormat-output",
+    "Name":"https://schema.org/videoFormat-output",
     "Domain Bucket":"< 1K"
   },
   {
     "Class":"Predicate",
-    "Name":"http:\/\/schema.org\/videoFrameSize",
+    "Name":"https://schema.org/videoFrameSize",
     "Domain Bucket":"< 1K"
   },
   {
     "Class":"Predicate",
-    "Name":"http:\/\/schema.org\/videoFrameSize-input",
+    "Name":"https://schema.org/videoFrameSize-input",
     "Domain Bucket":"< 1K"
   },
   {
     "Class":"Predicate",
-    "Name":"http:\/\/schema.org\/videoFrameSize-output",
+    "Name":"https://schema.org/videoFrameSize-output",
     "Domain Bucket":"< 1K"
   },
   {
     "Class":"Predicate",
-    "Name":"http:\/\/schema.org\/videoQuality",
+    "Name":"https://schema.org/videoQuality",
     "Domain Bucket":"10K - 100K"
   },
   {
     "Class":"Predicate",
-    "Name":"http:\/\/schema.org\/videoQuality-input",
+    "Name":"https://schema.org/videoQuality-input",
     "Domain Bucket":"< 1K"
   },
   {
     "Class":"Predicate",
-    "Name":"http:\/\/schema.org\/videoQuality-output",
+    "Name":"https://schema.org/videoQuality-output",
     "Domain Bucket":"< 1K"
   },
   {
     "Class":"Predicate",
-    "Name":"http:\/\/schema.org\/volumeNumber",
+    "Name":"https://schema.org/volumeNumber",
     "Domain Bucket":"1K - 10K"
   },
   {
     "Class":"Predicate",
-    "Name":"http:\/\/schema.org\/volumeNumber-input",
+    "Name":"https://schema.org/volumeNumber-input",
     "Domain Bucket":"< 1K"
   },
   {
     "Class":"Predicate",
-    "Name":"http:\/\/schema.org\/volumeNumber-output",
+    "Name":"https://schema.org/volumeNumber-output",
     "Domain Bucket":"< 1K"
   },
   {
     "Class":"Predicate",
-    "Name":"http:\/\/schema.org\/warning",
+    "Name":"https://schema.org/warning",
     "Domain Bucket":"1K - 10K"
   },
   {
     "Class":"Predicate",
-    "Name":"http:\/\/schema.org\/warning-input",
+    "Name":"https://schema.org/warning-input",
     "Domain Bucket":"< 1K"
   },
   {
     "Class":"Predicate",
-    "Name":"http:\/\/schema.org\/warning-output",
+    "Name":"https://schema.org/warning-output",
     "Domain Bucket":"< 1K"
   },
   {
     "Class":"Predicate",
-    "Name":"http:\/\/schema.org\/warranty",
+    "Name":"https://schema.org/warranty",
     "Domain Bucket":"10K - 100K"
   },
   {
     "Class":"Predicate",
-    "Name":"http:\/\/schema.org\/warranty-input",
+    "Name":"https://schema.org/warranty-input",
     "Domain Bucket":"< 1K"
   },
   {
     "Class":"Predicate",
-    "Name":"http:\/\/schema.org\/warranty-output",
+    "Name":"https://schema.org/warranty-output",
     "Domain Bucket":"< 1K"
   },
   {
     "Class":"Predicate",
-    "Name":"http:\/\/schema.org\/warrantyPromise",
+    "Name":"https://schema.org/warrantyPromise",
     "Domain Bucket":"< 1K"
   },
   {
     "Class":"Predicate",
-    "Name":"http:\/\/schema.org\/warrantyPromise-input",
+    "Name":"https://schema.org/warrantyPromise-input",
     "Domain Bucket":"< 1K"
   },
   {
     "Class":"Predicate",
-    "Name":"http:\/\/schema.org\/warrantyPromise-output",
+    "Name":"https://schema.org/warrantyPromise-output",
     "Domain Bucket":"< 1K"
   },
   {
     "Class":"Predicate",
-    "Name":"http:\/\/schema.org\/warrantyScope",
+    "Name":"https://schema.org/warrantyScope",
     "Domain Bucket":"1K - 10K"
   },
   {
     "Class":"Predicate",
-    "Name":"http:\/\/schema.org\/warrantyScope-input",
+    "Name":"https://schema.org/warrantyScope-input",
     "Domain Bucket":"< 1K"
   },
   {
     "Class":"Predicate",
-    "Name":"http:\/\/schema.org\/warrantyScope-output",
+    "Name":"https://schema.org/warrantyScope-output",
     "Domain Bucket":"< 1K"
   },
   {
     "Class":"Predicate",
-    "Name":"http:\/\/schema.org\/webCheckinTime",
+    "Name":"https://schema.org/webCheckinTime",
     "Domain Bucket":"< 1K"
   },
   {
     "Class":"Predicate",
-    "Name":"http:\/\/schema.org\/webCheckinTime-input",
+    "Name":"https://schema.org/webCheckinTime-input",
     "Domain Bucket":"< 1K"
   },
   {
     "Class":"Predicate",
-    "Name":"http:\/\/schema.org\/webCheckinTime-output",
+    "Name":"https://schema.org/webCheckinTime-output",
     "Domain Bucket":"< 1K"
   },
   {
     "Class":"Predicate",
-    "Name":"http:\/\/schema.org\/webFeed",
+    "Name":"https://schema.org/webFeed",
     "Domain Bucket":"10K - 100K"
   },
   {
     "Class":"Predicate",
-    "Name":"http:\/\/schema.org\/webFeed-input",
+    "Name":"https://schema.org/webFeed-input",
     "Domain Bucket":"< 1K"
   },
   {
     "Class":"Predicate",
-    "Name":"http:\/\/schema.org\/webFeed-output",
+    "Name":"https://schema.org/webFeed-output",
     "Domain Bucket":"< 1K"
   },
   {
     "Class":"Predicate",
-    "Name":"http:\/\/schema.org\/weight",
+    "Name":"https://schema.org/weight",
     "Domain Bucket":"100K - 1M"
   },
   {
     "Class":"Predicate",
-    "Name":"http:\/\/schema.org\/weight-input",
+    "Name":"https://schema.org/weight-input",
     "Domain Bucket":"< 1K"
   },
   {
     "Class":"Predicate",
-    "Name":"http:\/\/schema.org\/weight-output",
+    "Name":"https://schema.org/weight-output",
     "Domain Bucket":"< 1K"
   },
   {
     "Class":"Predicate",
-    "Name":"http:\/\/schema.org\/weightPercentage",
+    "Name":"https://schema.org/weightPercentage",
     "Domain Bucket":"< 1K"
   },
   {
     "Class":"Predicate",
-    "Name":"http:\/\/schema.org\/weightPercentage-input",
+    "Name":"https://schema.org/weightPercentage-input",
     "Domain Bucket":"< 1K"
   },
   {
     "Class":"Predicate",
-    "Name":"http:\/\/schema.org\/weightPercentage-output",
+    "Name":"https://schema.org/weightPercentage-output",
     "Domain Bucket":"< 1K"
   },
   {
     "Class":"Predicate",
-    "Name":"http:\/\/schema.org\/weightTotal",
+    "Name":"https://schema.org/weightTotal",
     "Domain Bucket":"1K - 10K"
   },
   {
     "Class":"Predicate",
-    "Name":"http:\/\/schema.org\/weightTotal-input",
+    "Name":"https://schema.org/weightTotal-input",
     "Domain Bucket":"< 1K"
   },
   {
     "Class":"Predicate",
-    "Name":"http:\/\/schema.org\/weightTotal-output",
+    "Name":"https://schema.org/weightTotal-output",
     "Domain Bucket":"< 1K"
   },
   {
     "Class":"Predicate",
-    "Name":"http:\/\/schema.org\/wheelbase",
+    "Name":"https://schema.org/wheelbase",
     "Domain Bucket":"1K - 10K"
   },
   {
     "Class":"Predicate",
-    "Name":"http:\/\/schema.org\/wheelbase-input",
+    "Name":"https://schema.org/wheelbase-input",
     "Domain Bucket":"< 1K"
   },
   {
     "Class":"Predicate",
-    "Name":"http:\/\/schema.org\/wheelbase-output",
+    "Name":"https://schema.org/wheelbase-output",
     "Domain Bucket":"< 1K"
   },
   {
     "Class":"Predicate",
-    "Name":"http:\/\/schema.org\/width",
+    "Name":"https://schema.org/width",
     "Domain Bucket":"10M+"
   },
   {
     "Class":"Predicate",
-    "Name":"http:\/\/schema.org\/width-input",
+    "Name":"https://schema.org/width-input",
     "Domain Bucket":"< 1K"
   },
   {
     "Class":"Predicate",
-    "Name":"http:\/\/schema.org\/width-output",
+    "Name":"https://schema.org/width-output",
     "Domain Bucket":"< 1K"
   },
   {
     "Class":"Predicate",
-    "Name":"http:\/\/schema.org\/winner",
+    "Name":"https://schema.org/winner",
     "Domain Bucket":"< 1K"
   },
   {
     "Class":"Predicate",
-    "Name":"http:\/\/schema.org\/winner-input",
+    "Name":"https://schema.org/winner-input",
     "Domain Bucket":"< 1K"
   },
   {
     "Class":"Predicate",
-    "Name":"http:\/\/schema.org\/winner-output",
+    "Name":"https://schema.org/winner-output",
     "Domain Bucket":"< 1K"
   },
   {
     "Class":"Predicate",
-    "Name":"http:\/\/schema.org\/wordCount",
+    "Name":"https://schema.org/wordCount",
     "Domain Bucket":"1M - 10M"
   },
   {
     "Class":"Predicate",
-    "Name":"http:\/\/schema.org\/wordCount-input",
+    "Name":"https://schema.org/wordCount-input",
     "Domain Bucket":"< 1K"
   },
   {
     "Class":"Predicate",
-    "Name":"http:\/\/schema.org\/wordCount-output",
+    "Name":"https://schema.org/wordCount-output",
     "Domain Bucket":"< 1K"
   },
   {
     "Class":"Predicate",
-    "Name":"http:\/\/schema.org\/workExample",
+    "Name":"https://schema.org/workExample",
     "Domain Bucket":"1K - 10K"
   },
   {
     "Class":"Predicate",
-    "Name":"http:\/\/schema.org\/workExample-input",
+    "Name":"https://schema.org/workExample-input",
     "Domain Bucket":"< 1K"
   },
   {
     "Class":"Predicate",
-    "Name":"http:\/\/schema.org\/workExample-output",
+    "Name":"https://schema.org/workExample-output",
     "Domain Bucket":"< 1K"
   },
   {
     "Class":"Predicate",
-    "Name":"http:\/\/schema.org\/workFeatured",
+    "Name":"https://schema.org/workFeatured",
     "Domain Bucket":"< 1K"
   },
   {
     "Class":"Predicate",
-    "Name":"http:\/\/schema.org\/workFeatured-input",
+    "Name":"https://schema.org/workFeatured-input",
     "Domain Bucket":"< 1K"
   },
   {
     "Class":"Predicate",
-    "Name":"http:\/\/schema.org\/workFeatured-output",
+    "Name":"https://schema.org/workFeatured-output",
     "Domain Bucket":"< 1K"
   },
   {
     "Class":"Predicate",
-    "Name":"http:\/\/schema.org\/workHours",
+    "Name":"https://schema.org/workHours",
     "Domain Bucket":"10K - 100K"
   },
   {
     "Class":"Predicate",
-    "Name":"http:\/\/schema.org\/workHours-input",
+    "Name":"https://schema.org/workHours-input",
     "Domain Bucket":"< 1K"
   },
   {
     "Class":"Predicate",
-    "Name":"http:\/\/schema.org\/workHours-output",
+    "Name":"https://schema.org/workHours-output",
     "Domain Bucket":"< 1K"
   },
   {
     "Class":"Predicate",
-    "Name":"http:\/\/schema.org\/workLocation",
+    "Name":"https://schema.org/workLocation",
     "Domain Bucket":"10K - 100K"
   },
   {
     "Class":"Predicate",
-    "Name":"http:\/\/schema.org\/workLocation-input",
+    "Name":"https://schema.org/workLocation-input",
     "Domain Bucket":"< 1K"
   },
   {
     "Class":"Predicate",
-    "Name":"http:\/\/schema.org\/workLocation-output",
+    "Name":"https://schema.org/workLocation-output",
     "Domain Bucket":"< 1K"
   },
   {
     "Class":"Predicate",
-    "Name":"http:\/\/schema.org\/workPerformed",
+    "Name":"https://schema.org/workPerformed",
     "Domain Bucket":"1K - 10K"
   },
   {
     "Class":"Predicate",
-    "Name":"http:\/\/schema.org\/workPerformed-input",
+    "Name":"https://schema.org/workPerformed-input",
     "Domain Bucket":"< 1K"
   },
   {
     "Class":"Predicate",
-    "Name":"http:\/\/schema.org\/workPerformed-output",
+    "Name":"https://schema.org/workPerformed-output",
     "Domain Bucket":"< 1K"
   },
   {
     "Class":"Predicate",
-    "Name":"http:\/\/schema.org\/workPresented",
+    "Name":"https://schema.org/workPresented",
     "Domain Bucket":"< 1K"
   },
   {
     "Class":"Predicate",
-    "Name":"http:\/\/schema.org\/workPresented-input",
+    "Name":"https://schema.org/workPresented-input",
     "Domain Bucket":"< 1K"
   },
   {
     "Class":"Predicate",
-    "Name":"http:\/\/schema.org\/workPresented-output",
+    "Name":"https://schema.org/workPresented-output",
     "Domain Bucket":"< 1K"
   },
   {
     "Class":"Predicate",
-    "Name":"http:\/\/schema.org\/workTranslation",
+    "Name":"https://schema.org/workTranslation",
     "Domain Bucket":"10K - 100K"
   },
   {
     "Class":"Predicate",
-    "Name":"http:\/\/schema.org\/workTranslation-input",
+    "Name":"https://schema.org/workTranslation-input",
     "Domain Bucket":"< 1K"
   },
   {
     "Class":"Predicate",
-    "Name":"http:\/\/schema.org\/workTranslation-output",
+    "Name":"https://schema.org/workTranslation-output",
     "Domain Bucket":"< 1K"
   },
   {
     "Class":"Predicate",
-    "Name":"http:\/\/schema.org\/workload",
+    "Name":"https://schema.org/workload",
     "Domain Bucket":"< 1K"
   },
   {
     "Class":"Predicate",
-    "Name":"http:\/\/schema.org\/workload-input",
+    "Name":"https://schema.org/workload-input",
     "Domain Bucket":"< 1K"
   },
   {
     "Class":"Predicate",
-    "Name":"http:\/\/schema.org\/workload-output",
+    "Name":"https://schema.org/workload-output",
     "Domain Bucket":"< 1K"
   },
   {
     "Class":"Predicate",
-    "Name":"http:\/\/schema.org\/worksFor",
+    "Name":"https://schema.org/worksFor",
     "Domain Bucket":"1M - 10M"
   },
   {
     "Class":"Predicate",
-    "Name":"http:\/\/schema.org\/worksFor-input",
+    "Name":"https://schema.org/worksFor-input",
     "Domain Bucket":"< 1K"
   },
   {
     "Class":"Predicate",
-    "Name":"http:\/\/schema.org\/worksFor-output",
+    "Name":"https://schema.org/worksFor-output",
     "Domain Bucket":"< 1K"
   },
   {
     "Class":"Predicate",
-    "Name":"http:\/\/schema.org\/worstRating",
+    "Name":"https://schema.org/worstRating",
     "Domain Bucket":"1M - 10M"
   },
   {
     "Class":"Predicate",
-    "Name":"http:\/\/schema.org\/worstRating-input",
+    "Name":"https://schema.org/worstRating-input",
     "Domain Bucket":"< 1K"
   },
   {
     "Class":"Predicate",
-    "Name":"http:\/\/schema.org\/worstRating-output",
+    "Name":"https://schema.org/worstRating-output",
     "Domain Bucket":"< 1K"
   },
   {
     "Class":"Predicate",
-    "Name":"http:\/\/schema.org\/xpath",
+    "Name":"https://schema.org/xpath",
     "Domain Bucket":"10K - 100K"
   },
   {
     "Class":"Predicate",
-    "Name":"http:\/\/schema.org\/xpath-input",
+    "Name":"https://schema.org/xpath-input",
     "Domain Bucket":"< 1K"
   },
   {
     "Class":"Predicate",
-    "Name":"http:\/\/schema.org\/xpath-output",
+    "Name":"https://schema.org/xpath-output",
     "Domain Bucket":"< 1K"
   },
   {
     "Class":"Predicate",
-    "Name":"http:\/\/schema.org\/yearBuilt",
+    "Name":"https://schema.org/yearBuilt",
     "Domain Bucket":"10K - 100K"
   },
   {
     "Class":"Predicate",
-    "Name":"http:\/\/schema.org\/yearBuilt-input",
+    "Name":"https://schema.org/yearBuilt-input",
     "Domain Bucket":"< 1K"
   },
   {
     "Class":"Predicate",
-    "Name":"http:\/\/schema.org\/yearBuilt-output",
+    "Name":"https://schema.org/yearBuilt-output",
     "Domain Bucket":"< 1K"
   },
   {
     "Class":"Predicate",
-    "Name":"http:\/\/schema.org\/yearlyRevenue",
+    "Name":"https://schema.org/yearlyRevenue",
     "Domain Bucket":"< 1K"
   },
   {
     "Class":"Predicate",
-    "Name":"http:\/\/schema.org\/yearlyRevenue-input",
+    "Name":"https://schema.org/yearlyRevenue-input",
     "Domain Bucket":"< 1K"
   },
   {
     "Class":"Predicate",
-    "Name":"http:\/\/schema.org\/yearlyRevenue-output",
+    "Name":"https://schema.org/yearlyRevenue-output",
     "Domain Bucket":"< 1K"
   },
   {
     "Class":"Predicate",
-    "Name":"http:\/\/schema.org\/yearsInOperation",
+    "Name":"https://schema.org/yearsInOperation",
     "Domain Bucket":"< 1K"
   },
   {
     "Class":"Predicate",
-    "Name":"http:\/\/schema.org\/yearsInOperation-input",
+    "Name":"https://schema.org/yearsInOperation-input",
     "Domain Bucket":"< 1K"
   },
   {
     "Class":"Predicate",
-    "Name":"http:\/\/schema.org\/yearsInOperation-output",
+    "Name":"https://schema.org/yearsInOperation-output",
     "Domain Bucket":"< 1K"
   },
   {
     "Class":"Predicate",
-    "Name":"http:\/\/schema.org\/yield",
+    "Name":"https://schema.org/yield",
     "Domain Bucket":"1K - 10K"
   },
   {
     "Class":"Predicate",
-    "Name":"http:\/\/schema.org\/yield-input",
+    "Name":"https://schema.org/yield-input",
     "Domain Bucket":"< 1K"
   },
   {
     "Class":"Predicate",
-    "Name":"http:\/\/schema.org\/yield-output",
+    "Name":"https://schema.org/yield-output",
     "Domain Bucket":"< 1K"
   }
 ]

--- a/software/SchemaTerms/example-code/jinjaTemplating/simpleJinjaHtml.py
+++ b/software/SchemaTerms/example-code/jinjaTemplating/simpleJinjaHtml.py
@@ -23,10 +23,7 @@ Markdown.setWikilinkPrePath("/")
 
 
 DATADIR = os.path.join(os.path.dirname(__file__), "../data")
-if SdoTermSource.vocabUri().startswith("https://"):
-    triplesfile = os.path.join(DATADIR, "schemaorg-all-https.nt")
-else:
-    triplesfile = os.path.join(DATADIR, "schemaorg-all-http.nt")
+triplesfile = os.path.join(DATADIR, "schemaorg-all-https.nt")
 
 termgraph = rdflib.Graph()
 termgraph.parse(triplesfile, format="nt")

--- a/software/SchemaTerms/example-code/protobufs/protoexpanded.py
+++ b/software/SchemaTerms/example-code/protobufs/protoexpanded.py
@@ -17,8 +17,8 @@ Markdown.setWikilinkPrePath("/")
 
 
 DATADIR = os.path.join(os.path.dirname(__file__), "../data")
-triplesfile = os.path.join(DATADIR, "schemaorg-all-http.nt")
-SdoTermSource.VOCABURI = "https://schema.org/" #Force to https as loaded https file
+triplesfile = os.path.join(DATADIR, "schemaorg-all-https.nt")
+SdoTermSource.VOCABURI = "https://schema.org/"
 SdoTermSource.loadSourceGraph(triplesfile)
 print ("loaded %s triples" % len(SdoTermSource.sourceGraph()))
 

--- a/software/SchemaTerms/example-code/protobufs/protosimple.py
+++ b/software/SchemaTerms/example-code/protobufs/protosimple.py
@@ -17,8 +17,8 @@ Markdown.setWikilinkPrePath("/")
 
 
 DATADIR = os.path.join(os.path.dirname(__file__), "../data")
-triplesfile = os.path.join(DATADIR, "schemaorg-all-http.nt")
-SdoTermSource.VOCABURI = "https://schema.org/" #Force to https as loaded https file
+triplesfile = os.path.join(DATADIR, "schemaorg-all-https.nt")
+SdoTermSource.VOCABURI = "https://schema.org/"
 SdoTermSource.loadSourceGraph(triplesfile)
 print ("loaded %s triples" % len(SdoTermSource.sourceGraph()))
 

--- a/software/SchemaTerms/example-code/simpleTermList/simpleExpandedTermList.py
+++ b/software/SchemaTerms/example-code/simpleTermList/simpleExpandedTermList.py
@@ -19,10 +19,7 @@ Markdown.setWikilinkCssClass("localLink")
 Markdown.setWikilinkPrePath("/")
 
 DATADIR = os.path.join(os.path.dirname(__file__), "../data")
-if SdoTermSource.vocabUri().startswith("https://"):
-    triplesfile = os.path.join(DATADIR, "schemaorg-all-https.nt")
-else:
-    triplesfile = os.path.join(DATADIR, "schemaorg-all-http.nt")
+triplesfile = os.path.join(DATADIR, "schemaorg-all-https.nt")
 
 
 termgraph = rdflib.Graph()

--- a/software/SchemaTerms/example-code/simpleTermList/simpleTermList.py
+++ b/software/SchemaTerms/example-code/simpleTermList/simpleTermList.py
@@ -19,10 +19,7 @@ Markdown.setWikilinkCssClass("localLink")
 Markdown.setWikilinkPrePath("/")
 
 DATADIR = os.path.join(os.path.dirname(__file__), "../data")
-if SdoTermSource.vocabUri().startswith("https://"):
-    triplesfile = os.path.join(DATADIR, "schemaorg-all-https.nt")
-else:
-    triplesfile = os.path.join(DATADIR, "schemaorg-all-http.nt")
+triplesfile = os.path.join(DATADIR, "schemaorg-all-https.nt")
 
 
 termgraph = rdflib.Graph()

--- a/software/SchemaTerms/sdotermsource.py
+++ b/software/SchemaTerms/sdotermsource.py
@@ -506,7 +506,7 @@ class SdoTermSource:
         wpre: Optional[str] = None
         assert self.termdesc is not None
         name: str = self.termdesc.id
-        if name.startswith("http:"):
+        if name.startswith("https:"):
             val: str = Path(name).name
             wpre = name[: -len(val)]
 
@@ -1219,7 +1219,7 @@ ProtoAndRoot = collections.namedtuple("ProtoAndRoot", ["proto", "root"])
 
 
 def getProtoAndRoot(uri: str) -> ProtoAndRoot:
-    m: Optional[re.Match] = re.search(r"^(http[s]?:\/\/)(.*)", uri)
+    m: Optional[re.Match] = re.search(r"^(https:\/\/)(.*)", uri)
     if m:
         return ProtoAndRoot(m.group(1), m.group(2))
     return ProtoAndRoot(None, None)

--- a/software/scripts/buildsite.py
+++ b/software/scripts/buildsite.py
@@ -260,8 +260,7 @@ def loadTerms(source: Optional[str] = None, force: bool = False) -> None:
             with pretty_logger.BlockLog(logger=log, message="Loading development triples files (default)"):
                 sdotermsource.SdoTermSource.loadSourceGraph("default", init=init_graph)
         elif source == "release":
-            protocol: str = "https" if sdotermsource.SdoTermSource.vocabUri().startswith("https") else "http"
-            release_file: Path = paths.DefaultInputLayout().release_file(protocol)
+            release_file: Path = paths.DefaultInputLayout().release_file("https")
 
             if not release_file.exists():
                 raise FileNotFoundError(

--- a/software/tests/test_graphs.py
+++ b/software/tests/test_graphs.py
@@ -486,7 +486,8 @@ class SDOGraphSetupTestCase(unittest.TestCase):
           SELECT DISTINCT ?term WHERE {
             ?term ?p ?o .
 
-            FILTER STRSTARTS(STR(?term), "http://schema.org")
+            FILTER STRSTARTS(STR(?term), "http://")
+            FILTER STRENDS(STR(?term), "schema.org")
           }
           ORDER BY ?term
         """,
@@ -504,7 +505,8 @@ class SDOGraphSetupTestCase(unittest.TestCase):
                   rdfs:subPropertyOf |
                   schema:supersededBy |
                   schema:inverseOf          ?target .
-            FILTER STRSTARTS(STR(?target), "http://schema.org")
+            FILTER STRSTARTS(STR(?target), "http://")
+            FILTER STRENDS(STR(?target), "schema.org")
           }
           ORDER BY ?term
         """,

--- a/software/tests/test_sdotermsource.py
+++ b/software/tests/test_sdotermsource.py
@@ -25,14 +25,14 @@ class TestConversionFunctions(unittest.TestCase):
     def testToFullId(self):
         self.assertEqual(sdotermsource.toFullId("fnord"), "https://schema.org/fnord")
         self.assertEqual(
-            sdotermsource.toFullId("http://schema.org/Thing"), "http://schema.org/Thing"
+            sdotermsource.toFullId("https://schema.org/Thing"), "https://schema.org/Thing"
         )
 
     def testUriWrap(self):
         self.assertEqual(sdotermsource.uriWrap("fnord"), "fnord")
         self.assertEqual(
-            sdotermsource.uriWrap("http://schema.org/Thing"),
-            "<http://schema.org/Thing>",
+            sdotermsource.uriWrap("https://schema.org/Thing"),
+            "<https://schema.org/Thing>",
         )
 
     def testLayerFromUri(self):
@@ -54,8 +54,8 @@ class TestConversionFunctions(unittest.TestCase):
             sdotermsource.getProtoAndRoot(""), sdotermsource.ProtoAndRoot(None, None)
         )
         self.assertEqual(
-            sdotermsource.getProtoAndRoot("http://schema.org/Thing"),
-            sdotermsource.ProtoAndRoot("http://", "schema.org/Thing"),
+            sdotermsource.getProtoAndRoot("https://schema.org/Thing"),
+            sdotermsource.ProtoAndRoot("https://", "schema.org/Thing"),
         )
 
     def testUri2id(self):

--- a/software/tests/test_stats_data.py
+++ b/software/tests/test_stats_data.py
@@ -1,0 +1,58 @@
+#!/usr/bin/env python3
+# -*- coding: utf-8 -*-
+
+"""Tests to verify that public statistics data files use https:// URLs."""
+
+import datetime
+import os
+from pathlib import Path
+import sys
+from typing import List, Tuple
+import unittest
+
+if os.getcwd() not in sys.path:
+    sys.path.insert(1, os.getcwd())
+import software
+
+import util.paths as paths
+import util.stats as stats
+
+
+class PublicStatsDataTests(unittest.TestCase):
+    """Tests to verify that public statistics data use https://."""
+
+    @classmethod
+    def setUpClass(cls) -> None:
+        cls.layout = stats.StatsLayout(paths.DefaultInputLayout())
+
+    def test_stats_csv_use_https(self) -> None:
+        """Verify that statistics CSV files use https:// for all terms."""
+        failures: List[str] = []
+        for provider in self.layout.providers():
+            for epoch, file_path in self.layout.epochs(provider, ext="csv").items():
+                for row in self.layout._read_csv(file_path):
+                    name = row.get("Name", "")
+                    if not name.startswith("https://"):
+                        failures.append(f" - Provider: {provider}, Epoch: {epoch.strftime("%Y_%m")}")
+                        break
+
+        if failures:
+            self.fail(f"Statistics CSV data contains non-https URLs in:\n{'\n'.join(failures)}")
+
+    def test_stats_json_use_https(self) -> None:
+        """Verify that statistics JSON files use https:// for all terms."""
+        failures: List[str] = []
+        for provider in self.layout.providers():
+            for epoch, file_path in self.layout.epochs(provider, ext="json").items():
+                for entry in self.layout._read_json(file_path):
+                    name = entry.get("Name", "")
+                    if not name.startswith("https://"):
+                        failures.append(f" - Provider: {provider}, Epoch: {epoch.strftime("%Y_%m")}")
+                        break
+
+        if failures:
+            self.fail(f"Statistics JSON data contains non-https URLs in:\n{'\n'.join(failures)}")
+
+
+if __name__ == "__main__":
+    unittest.main()

--- a/software/util/stats.py
+++ b/software/util/stats.py
@@ -3,13 +3,15 @@
 
 """Module that handles loading and parsing of dynamic public stats providers."""
 
+import csv
 from dataclasses import dataclass
 import datetime
-import json
-import unicodedata
 from functools import lru_cache
+import json
 from pathlib import Path
-from typing import Dict, List, Optional, Tuple
+import re
+from typing import Any, Dict, List, Optional, Sequence, Tuple, Union
+import unicodedata
 
 import util.paths as paths
 
@@ -21,63 +23,80 @@ class StatsProvider:
     date: str
     stats_map: Dict[str, str]
 
+class StatsLayout:
+    """Handles layout and file discovery for public statistics."""
+
+    def __init__(self, layout: paths.InputLayout) -> None:
+        self.base_dir: Path = layout.domain_dir(paths.Domain.PUBLIC_STATS)
+
+    def providers(self) -> List[str]:
+        """Lists the providers (subdirs) present in the stats dir."""
+        if not self.base_dir.is_dir(): return []
+        return sorted([subdir.name for subdir in self.base_dir.iterdir()
+                       if subdir.is_dir() and not subdir.name.startswith(".")])
+
+    def _list_files(self, provider: str, ext: Optional[str] = None) -> List[Path]:
+        """Private method to list the files in a provider's directory."""
+        provider_dir = self.base_dir / provider
+        if not provider_dir.is_dir(): return []
+        return sorted([p for p in provider_dir.iterdir()
+                       if p.is_file() and (not ext or p.suffix == f".{ext}")])
+
+    def epochs(self, provider: str, ext: Optional[str] = "json") -> Dict[str, List[Path]]:
+        """Provides the different sets of stats files found in a provider's directory."""
+        def extract_epoch(filename):
+            m = re.search(r"(\d{4}_\d{2})", filename.name)
+            return datetime.datetime.strptime(m.group(1), "%Y_%m") if m else None
+
+        return dict([(extract_epoch(f), f) for f in self._list_files(provider, ext)
+                     if "summary" not in f.name])
+
+    def _read_json(self, file_path: Union[Path, str]) -> Any:
+        """Private method to read and parse a JSON file."""
+        with open(file_path, "r", encoding="utf-8") as f:
+            return json.load(f)
+
+    def _read_csv(self, file_path: Union[Path, str]) -> Any:
+        """Private method to read and parse a CSV file."""
+        records = []
+        with open(file_path, "r", encoding="utf-8", newline="") as f:
+            for row in csv.DictReader(f):
+                record = dict([(field.strip(), row[field]) for field in row.keys()])
+                records.append(record)
+        return records
+
+    def get_stats(self, providers: Optional[Sequence[str]] = None) -> List[StatsProvider]:
+        """Returns a list of StatsProvider objects."""
+        providers = [p for p in self.providers() if not providers or p in providers]
+
+        result: List[StatsProvider] = []
+        for provider in providers:
+            epochs = self.epochs(provider)
+            latest_epoch = sorted(epochs.keys())[-1]
+            json_file = epochs[latest_epoch]
+
+            stats_map: Dict[str, str] = {}
+            for entry in self._read_json(json_file):
+                entry_name = entry.get("Name").strip()
+                bucket = entry.get("Domain Bucket").strip()
+                normalized_name = unicodedata.normalize("NFC", entry_name).replace("http://", "https://")
+                stats_map[normalized_name] = bucket
+
+            result.append(
+                StatsProvider(
+                    provider_id=provider,
+                    name=provider.capitalize(),
+                    description=f"Based on monthly aggregations from {provider}'s web index.",
+                    date=latest_epoch.strftime("%B %Y"),
+                    stats_map=stats_map,
+                )
+            )
+
+        return result
+
+
 @lru_cache(maxsize=1)
 def get_stats_providers() -> List[StatsProvider]:
     """Lazily loads and parses all public stats providers from the filesystem."""
-    providers: List[StatsProvider] = []
-    
-    try:
-        base_dir = paths.DefaultInputLayout().domain_dir(paths.Domain.PUBLIC_STATS)
-        if base_dir.is_dir():
-            for subdir in sorted(base_dir.iterdir()):
-                if not subdir.is_dir():
-                    continue
-                
-                provider_id = subdir.name
-                name = provider_id.capitalize()
-                description = f"Based on monthly aggregations from {name}'s web index."
-                
-                json_files = list(subdir.glob("????_??.json"))
-                json_files = [f for f in json_files if "summary" not in f.name]
-                
-                if json_files:
-                    latest_file = sorted(json_files)[-1]
-                    date_str = "Recent"
-                    try:
-                        date_part = latest_file.stem
-                        dt = datetime.datetime.strptime(date_part, "%Y_%m")
-                        date_str = dt.strftime("%B %Y")
-                    except Exception:
-                        pass
-                        
-                    stats_map: Dict[str, str] = {}
-                    try:
-                        with open(latest_file, "r", encoding="utf-8") as f:
-                            stats_data = json.load(f)
-                        if isinstance(stats_data, list):
-                            for entry in stats_data:
-                                if not isinstance(entry, dict):
-                                    continue
-                                entry_name = entry.get("Name")
-                                bucket = entry.get("Domain Bucket")
-                                if isinstance(entry_name, str) and isinstance(bucket, str):
-                                    entry_name = entry_name.strip()
-                                    bucket = bucket.strip()
-                                    normalized_name = unicodedata.normalize("NFC", entry_name)
-                                    stats_map[normalized_name.replace("http://", "https://")] = bucket
-                    except Exception:
-                        continue
-                        
-                    providers.append(
-                        StatsProvider(
-                            provider_id=provider_id,
-                            name=name,
-                            description=description,
-                            date=date_str,
-                            stats_map=stats_map
-                        )
-                    )
-    except Exception:
-        pass
-        
-    return providers
+    stats_layout = StatsLayout(paths.DefaultInputLayout())
+    return stats_layout.get_stats()

--- a/software/util/stats.py
+++ b/software/util/stats.py
@@ -64,7 +64,6 @@ def get_stats_providers() -> List[StatsProvider]:
                                     entry_name = entry_name.strip()
                                     bucket = bucket.strip()
                                     normalized_name = unicodedata.normalize("NFC", entry_name)
-                                    stats_map[normalized_name.replace("https://", "http://")] = bucket
                                     stats_map[normalized_name.replace("http://", "https://")] = bucket
                     except Exception:
                         continue


### PR DESCRIPTION
The TTL files are written using the https://schema.org namespace, so this makes the code assume this all along, except at file production time, where we produce both http and https.

It simplifies the code logic a bit, and is now also supported by some tests that assert this.

The public_stats files were also using the http variant, they are upgraded in this PR.