### PR TITLE
Fix 2 critical bugs

### DIFF
--- a/software/tests/test_graphs.py
+++ b/software/tests/test_graphs.py
@@ -486,9 +486,8 @@ class SDOGraphSetupTestCase(unittest.TestCase):
           SELECT DISTINCT ?term WHERE {
             ?term ?p ?o .
 
-            FILTER STRSTARTS(STR(?term), "http://")
-            FILTER STRENDS(STR(?term), "schema.org")
-          }
+            FILTER REGEX(STR(?term), "^http://([a-z0-9-]+\\\\.)?schema\\\\.org\\b")
+        }
           ORDER BY ?term
         """,
         error_message="Term defined as http instead of https")
@@ -505,8 +504,8 @@ class SDOGraphSetupTestCase(unittest.TestCase):
                   rdfs:subPropertyOf |
                   schema:supersededBy |
                   schema:inverseOf          ?target .
-            FILTER STRSTARTS(STR(?target), "http://")
-            FILTER STRENDS(STR(?target), "schema.org")
+
+            FILTER REGEX(STR(?target), "^http://([a-z0-9-]+\\\\.)?schema\\\\.org\\b")
           }
           ORDER BY ?term
         """,

--- a/software/util/stats.py
+++ b/software/util/stats.py
@@ -48,8 +48,9 @@ class StatsLayout:
             m = re.search(r"(\d{4}_\d{2})", filename.name)
             return datetime.datetime.strptime(m.group(1), "%Y_%m") if m else None
 
-        return dict([(extract_epoch(f), f) for f in self._list_files(provider, ext)
-                     if "summary" not in f.name])
+        epochs = [(extract_epoch(f), f) for f in self._list_files(provider, ext)
+                  if "summary" not in f.name]
+        return dict([e for e in epochs if not e[0] is None])
 
     def _read_json(self, file_path: Union[Path, str]) -> Any:
         """Private method to read and parse a JSON file."""
@@ -72,6 +73,7 @@ class StatsLayout:
         result: List[StatsProvider] = []
         for provider in providers:
             epochs = self.epochs(provider)
+            if not epochs: continue
             latest_epoch = sorted(epochs.keys())[-1]
             json_file = epochs[latest_epoch]
 


### PR DESCRIPTION
 1. make the protocol and domain verification work for URIs that have e.g. a Type after them and do not end in 'schema.org/'
 2. add some robustness to the reading epochs for stats data, in case the provider directory is empty or has no matching files.